### PR TITLE
fix(platform): enforce localized ui copy

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run",
     "i18n:extract": "i18next-cli extract",
     "i18n:check": "i18next-cli extract --ci --quiet && i18next-cli status",
-    "lint:localized-ui": "node scripts/check-localized-ui.mjs",
+    "lint:localized-ui": "node --test scripts/check-localized-ui.node.mjs && node scripts/check-localized-ui.mjs",
     "lint:static-assets": "node scripts/check-static-assets.mjs",
     "lint": "pnpm lint:static-assets && pnpm lint:localized-ui && pnpm i18n:check && oxlint && oxlint --type-aware -c ../../.oxlintrc.typeaware.json && eslint . --max-warnings 0",
     "check-types": "tsc -p tsconfig.production.json --noEmit && tsc -p tsconfig.tests.json --noEmit"

--- a/turbo/apps/platform/scripts/check-localized-ui.mjs
+++ b/turbo/apps/platform/scripts/check-localized-ui.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -8,27 +8,32 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const appRoot = path.resolve(__dirname, "..");
 
 function getCheckedFiles() {
-  return [
-    "src/signals/connectors-page/connector-callback-page-setup.ts",
-    "src/signals/external/org-model-policies.ts",
-    "src/signals/zero-page/settings/connectors.ts",
-    "src/signals/zero-page/strapi-settings-page.ts",
-    "src/signals/zero-page/zero-strapi.ts",
-    "src/views/zero-page/components/model-provider-picker.tsx",
-    "src/views/zero-page/components/org-manage/org-model-policies-section.tsx",
-    "src/views/zero-page/components/preferences/codex-reset-usage-dialog.tsx",
-    "src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx",
-    "src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx",
-    "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx",
-    "src/views/zero-page/components/settings/custom-connector-update-confirm.tsx",
-    "src/views/zero-page/components/settings/custom-connectors-panel.tsx",
-    "src/views/zero-page/components/settings/provider-ui-config.ts",
-    "src/views/zero-page/feishu-card.tsx",
-    "src/views/zero-page/strapi-settings-page.tsx",
-    "src/views/zero-page/zero-chat-thread-page.tsx",
-    "src/views/zero-page/zero-sidebar-account.tsx",
-    "src/views/zero-page/zero-sidebar-subscriptions.tsx",
-  ];
+  const excludedDirectories = new Set(["__tests__", "i18n", "mocks", "test"]);
+  const checkedFiles = [];
+
+  function collectFiles(relativeDirectory) {
+    for (const entry of readdirSync(path.join(appRoot, relativeDirectory), {
+      withFileTypes: true,
+    })) {
+      const relativePath = path.posix.join(relativeDirectory, entry.name);
+      if (entry.isDirectory()) {
+        if (!excludedDirectories.has(entry.name)) {
+          collectFiles(relativePath);
+        }
+        continue;
+      }
+      if (
+        (relativePath.endsWith(".ts") || relativePath.endsWith(".tsx")) &&
+        !relativePath.endsWith(".test.ts") &&
+        !relativePath.endsWith(".test.tsx")
+      ) {
+        checkedFiles.push(relativePath);
+      }
+    }
+  }
+
+  collectFiles("src");
+  return checkedFiles.sort();
 }
 
 function isUserVisibleAttribute(value) {
@@ -36,6 +41,7 @@ function isUserVisibleAttribute(value) {
     "alt",
     "aria-description",
     "aria-label",
+    "aria-placeholder",
     "description",
     "label",
     "placeholder",
@@ -45,13 +51,28 @@ function isUserVisibleAttribute(value) {
 
 function isUserVisibleProperty(value) {
   return [
+    "actionLabel",
     "ariaLabel",
+    "buttonLabel",
+    "caption",
+    "content",
     "description",
+    "emptyLabel",
+    "emptyMessage",
     "errorMessage",
+    "heading",
+    "help",
+    "helperText",
+    "hint",
     "label",
     "message",
+    "name",
     "placeholder",
+    "subtitle",
+    "summary",
     "title",
+    "tooltip",
+    "tooltipLabel",
   ].includes(value);
 }
 
@@ -59,26 +80,53 @@ function isToastMethod(value) {
   return ["error", "info", "success", "warning"].includes(value);
 }
 
+function isUserVisibleFunctionName(value) {
+  return /(caption|copy|description|heading|help|hint|label|message|summary|title|tooltip)$/iu.test(
+    value,
+  );
+}
+
 // These literals are intentionally shown as protocol identifiers, provider or
 // product names, or example input values. Keep exclusions exact and explain why
 // each value must remain untranslated.
-function getAllowedLiterals() {
-  return new Map([
+function getInternalAllowedLiterals() {
+  return [
+    [
+      "src/signals/zero-page/chat-feedback.ts\u0000a sent email (mail ID: {…}{…})",
+      "locale-neutral serialized agent prompt metadata",
+    ],
+    [
+      "src/signals/zero-page/chat-feedback.ts\u0000an email draft (mail draft ID: {…})",
+      "locale-neutral serialized agent prompt metadata",
+    ],
+    [
+      "src/signals/chat-page/create-chat-thread.ts\u0000Run cancelled",
+      "internal run event payload; the rendered cancellation message uses typed i18n",
+    ],
+    [
+      "src/signals/zero-page/tiptap-workflow-composer.ts\u0000paragraph+",
+      "Tiptap document schema expression",
+    ],
+    [
+      "src/signals/zero-page/tiptap-workflow-composer.ts\u0000workflowHighlight",
+      "Tiptap extension identifier",
+    ],
+    [
+      "src/views/zero-page/tiptap-instructions-editor.tsx\u0000baselineMarkdown",
+      "Tiptap storage plugin identifier",
+    ],
+    [
+      "src/views/zero-page/tiptap-instructions-editor.tsx\u0000lowlightHighlight",
+      "Tiptap extension identifier",
+    ],
+  ];
+}
+
+function getConnectorAllowedLiterals() {
+  return [
     [
       "src/views/zero-page/components/model-provider-picker.tsx\u0000BYOK",
       "bring-your-own-key product acronym",
-    ],
-    [
-      "src/views/zero-page/components/settings/provider-ui-config.ts\u0000Azure foundry portal",
-      "provider product name",
-    ],
-    [
-      "src/views/zero-page/components/settings/provider-ui-config.ts\u0000Claude Code (OAuth token)",
-      "provider product name with OAuth credential type",
-    ],
-    [
-      "src/views/zero-page/components/settings/provider-ui-config.ts\u0000Deepseek",
-      "provider brand name",
     ],
     [
       "src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx\u0000OAuth 2.0",
@@ -121,10 +169,6 @@ function getAllowedLiterals() {
       "locale-neutral persisted field metadata",
     ],
     [
-      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000cli_...",
-      "example provider application identifier",
-    ],
-    [
       "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000consent",
       "example OAuth prompt value",
     ],
@@ -135,14 +179,6 @@ function getAllowedLiterals() {
     [
       "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000https://api.provider.example",
       "example OAuth audience",
-    ],
-    [
-      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000https://api.provider.example/authorize",
-      "example OAuth authorization URL",
-    ],
-    [
-      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000https://api.provider.example/token",
-      "example OAuth token URL",
     ],
     [
       "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000https://provider.example.com/oauth/authorize",
@@ -164,7 +200,6 @@ function getAllowedLiterals() {
       "src/views/zero-page/feishu-card.tsx\u0000cli_...",
       "example Feishu application identifier",
     ],
-    ["src/views/zero-page/feishu-card.tsx\u0000Feishu", "provider name"],
     [
       "src/views/zero-page/feishu-card.tsx\u0000im.message.receive_v1",
       "Feishu event identifier",
@@ -173,20 +208,73 @@ function getAllowedLiterals() {
       "src/views/zero-page/strapi-settings-page.tsx\u0000https://cms.example.com",
       "example Strapi URL",
     ],
+  ];
+}
+
+function getFileAllowedLiterals() {
+  return [
     [
-      "src/views/zero-page/zero-chat-thread-page.tsx\u0000Feishu",
-      "provider name",
+      "src/views/zero-page/zero-file-preview-icon.tsx\u0000DB",
+      "database file format abbreviation",
     ],
     [
-      "src/views/zero-page/zero-chat-thread-page.tsx\u0000Slack",
-      "provider name",
+      "src/views/zero-page/zero-file-preview-icon.tsx\u0000DOC",
+      "document file format abbreviation",
     ],
+    [
+      "src/views/zero-page/zero-file-preview-icon.tsx\u0000HTML",
+      "HTML file format abbreviation",
+    ],
+    [
+      "src/views/zero-page/zero-file-preview-icon.tsx\u0000JSON",
+      "JSON file format abbreviation",
+    ],
+    [
+      "src/views/zero-page/zero-file-preview-icon.tsx\u0000MD",
+      "Markdown file extension",
+    ],
+    [
+      "src/views/zero-page/zero-file-preview-icon.tsx\u0000PDF",
+      "PDF file format abbreviation",
+    ],
+    [
+      "src/views/zero-page/zero-file-preview-icon.tsx\u0000PPT",
+      "presentation file format abbreviation",
+    ],
+    [
+      "src/views/zero-page/zero-file-preview-icon.tsx\u0000TXT",
+      "plain-text file extension",
+    ],
+    [
+      "src/views/zero-page/zero-file-preview-icon.tsx\u0000XLS",
+      "spreadsheet file format abbreviation",
+    ],
+    [
+      "src/views/zero-page/zero-file-preview-icon.tsx\u0000ZIP",
+      "archive file format abbreviation",
+    ],
+  ];
+}
+
+function getAllowedLiterals() {
+  return new Map([
+    ...getInternalAllowedLiterals(),
+    ...getConnectorAllowedLiterals(),
+    ...getFileAllowedLiterals(),
   ]);
 }
 
 function getLiteralValue(node) {
   if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
     return node.text;
+  }
+  if (ts.isTemplateExpression(node)) {
+    return [
+      node.head.text,
+      ...node.templateSpans.flatMap((span) => {
+        return ["{…}", span.literal.text];
+      }),
+    ].join("");
   }
   return null;
 }
@@ -199,11 +287,82 @@ function getPropertyName(node) {
 }
 
 function hasHumanText(value) {
-  return /\p{L}/u.test(value);
+  const withoutEntities = value.replace(
+    /&(?:[a-z][a-z0-9]+|#\d+|#x[0-9a-f]+);/giu,
+    "",
+  );
+  return /\p{L}/u.test(withoutEntities);
+}
+
+function isTranslationCall(node) {
+  if (!ts.isCallExpression(node)) {
+    return false;
+  }
+  if (ts.isIdentifier(node.expression)) {
+    return node.expression.text === "t";
+  }
+  return (
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === "t"
+  );
+}
+
+function checkVisibleExpression(node, record, kind) {
+  if (isTranslationCall(node)) {
+    return;
+  }
+  const value = getLiteralValue(node);
+  if (value !== null) {
+    record(node, value, kind);
+    return;
+  }
+  if (ts.isConditionalExpression(node)) {
+    checkVisibleExpression(node.whenTrue, record, kind);
+    checkVisibleExpression(node.whenFalse, record, kind);
+    return;
+  }
+  if (ts.isBinaryExpression(node)) {
+    if (
+      node.operatorToken.kind === ts.SyntaxKind.PlusToken ||
+      node.operatorToken.kind === ts.SyntaxKind.BarBarToken ||
+      node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
+    ) {
+      checkVisibleExpression(node.left, record, kind);
+      checkVisibleExpression(node.right, record, kind);
+      return;
+    }
+    if (node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) {
+      checkVisibleExpression(node.right, record, kind);
+    }
+    return;
+  }
+  if (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isNonNullExpression(node) ||
+    ts.isSatisfiesExpression(node)
+  ) {
+    checkVisibleExpression(node.expression, record, kind);
+    return;
+  }
+  if (ts.isArrayLiteralExpression(node)) {
+    for (const element of node.elements) {
+      checkVisibleExpression(element, record, kind);
+    }
+  }
+}
+
+function isStyleElement(node) {
+  if (!ts.isJsxElement(node)) {
+    return false;
+  }
+  const tagName = node.openingElement.tagName;
+  return ts.isIdentifier(tagName) && tagName.text === "style";
 }
 
 function checkJsxText(node, record) {
-  if (ts.isJsxText(node)) {
+  if (ts.isJsxText(node) && !isStyleElement(node.parent)) {
     record(node, node.text, "JSX text");
   }
 }
@@ -225,10 +384,7 @@ function checkJsxAttribute(node, record) {
     return;
   }
   if (ts.isJsxExpression(node.initializer) && node.initializer.expression) {
-    const value = getLiteralValue(node.initializer.expression);
-    if (value !== null) {
-      record(node.initializer.expression, value, attributeName);
-    }
+    checkVisibleExpression(node.initializer.expression, record, attributeName);
   }
 }
 
@@ -236,12 +392,10 @@ function checkJsxExpression(node, record) {
   if (
     ts.isJsxExpression(node) &&
     node.expression &&
-    (ts.isJsxElement(node.parent) || ts.isJsxFragment(node.parent))
+    (ts.isJsxElement(node.parent) || ts.isJsxFragment(node.parent)) &&
+    !isStyleElement(node.parent)
   ) {
-    const value = getLiteralValue(node.expression);
-    if (value !== null) {
-      record(node.expression, value, "JSX expression");
-    }
+    checkVisibleExpression(node.expression, record, "JSX expression");
   }
 }
 
@@ -253,10 +407,7 @@ function checkPropertyAssignment(node, record) {
   if (!propertyName || !isUserVisibleProperty(propertyName)) {
     return;
   }
-  const value = getLiteralValue(node.initializer);
-  if (value !== null) {
-    record(node.initializer, value, propertyName);
-  }
+  checkVisibleExpression(node.initializer, record, propertyName);
 }
 
 function checkDocumentTitle(node, record) {
@@ -268,10 +419,7 @@ function checkDocumentTitle(node, record) {
   ) {
     return;
   }
-  const value = getLiteralValue(node.arguments[1]);
-  if (value !== null) {
-    record(node.arguments[1], value, "document title");
-  }
+  checkVisibleExpression(node.arguments[1], record, "document title");
 }
 
 function checkToastCall(node, record) {
@@ -285,13 +433,107 @@ function checkToastCall(node, record) {
   ) {
     return;
   }
-  const value = getLiteralValue(node.arguments[0]);
-  if (value !== null) {
-    record(node.arguments[0], value, "toast");
+  checkVisibleExpression(node.arguments[0], record, "toast");
+}
+
+function checkBrowserDialogCall(node, record) {
+  if (!ts.isCallExpression(node) || node.arguments.length === 0) {
+    return;
+  }
+  const expression = node.expression;
+  const methodName = ts.isIdentifier(expression)
+    ? expression.text
+    : ts.isPropertyAccessExpression(expression)
+      ? expression.name.text
+      : null;
+  if (!methodName || !["alert", "confirm", "prompt"].includes(methodName)) {
+    return;
+  }
+  checkVisibleExpression(node.arguments[0], record, `browser ${methodName}`);
+}
+
+function functionLikeName(node) {
+  if (
+    (ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isMethodDeclaration(node)) &&
+    node.name &&
+    (ts.isIdentifier(node.name) || ts.isStringLiteral(node.name))
+  ) {
+    return node.name.text;
+  }
+  if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
+    const parent = node.parent;
+    if (ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) {
+      return parent.name.text;
+    }
+    if (
+      ts.isPropertyAssignment(parent) &&
+      (ts.isIdentifier(parent.name) || ts.isStringLiteral(parent.name))
+    ) {
+      return parent.name.text;
+    }
+  }
+  return null;
+}
+
+function checkUserVisibleFunctionReturn(node, record) {
+  if (!ts.isReturnStatement(node) || !node.expression) {
+    return;
+  }
+  let parent = node.parent;
+  while (parent && !ts.isSourceFile(parent)) {
+    if (ts.isFunctionLike(parent)) {
+      const name = functionLikeName(parent);
+      if (name && isUserVisibleFunctionName(name)) {
+        checkVisibleExpression(node.expression, record, `${name} return`);
+      }
+      return;
+    }
+    parent = parent.parent;
   }
 }
 
-function checkFile(relativePath, allowedLiterals) {
+function checkSetAttributeCall(node, record) {
+  if (
+    !ts.isCallExpression(node) ||
+    node.arguments.length < 2 ||
+    !ts.isPropertyAccessExpression(node.expression) ||
+    node.expression.name.text !== "setAttribute"
+  ) {
+    return;
+  }
+  const attribute = getLiteralValue(node.arguments[0]);
+  if (!attribute || !isUserVisibleAttribute(attribute)) {
+    return;
+  }
+  checkVisibleExpression(
+    node.arguments[1],
+    record,
+    `setAttribute(${attribute})`,
+  );
+}
+
+function checkUserVisibleAssignment(node, record) {
+  if (
+    !ts.isBinaryExpression(node) ||
+    node.operatorToken.kind !== ts.SyntaxKind.EqualsToken ||
+    !ts.isPropertyAccessExpression(node.left)
+  ) {
+    return;
+  }
+  const propertyName = node.left.name.text;
+  if (
+    !["alt", "ariaLabel", "innerText", "placeholder", "title"].includes(
+      propertyName,
+    )
+  ) {
+    return;
+  }
+  checkVisibleExpression(node.right, record, `${propertyName} assignment`);
+}
+
+function checkFile(relativePath, allowedLiterals, usedAllowedLiterals) {
   const absolutePath = path.join(appRoot, relativePath);
   const sourceText = readFileSync(absolutePath, "utf8");
   const sourceFile = ts.createSourceFile(
@@ -310,6 +552,7 @@ function checkFile(relativePath, allowedLiterals) {
     }
     const exclusionKey = `${relativePath}\u0000${normalizedValue}`;
     if (allowedLiterals.has(exclusionKey)) {
+      usedAllowedLiterals.add(exclusionKey);
       return;
     }
     const position = sourceFile.getLineAndCharacterOfPosition(node.getStart());
@@ -328,6 +571,10 @@ function checkFile(relativePath, allowedLiterals) {
     checkPropertyAssignment(node, record);
     checkDocumentTitle(node, record);
     checkToastCall(node, record);
+    checkBrowserDialogCall(node, record);
+    checkUserVisibleFunctionReturn(node, record);
+    checkSetAttributeCall(node, record);
+    checkUserVisibleAssignment(node, record);
     ts.forEachChild(node, visit);
   }
 
@@ -337,25 +584,47 @@ function checkFile(relativePath, allowedLiterals) {
 
 function main() {
   const allowedLiterals = getAllowedLiterals();
+  const usedAllowedLiterals = new Set();
   const checkedFiles = getCheckedFiles();
   const violations = checkedFiles.flatMap((relativePath) => {
-    return checkFile(relativePath, allowedLiterals).map((violation) => {
-      return { relativePath, ...violation };
-    });
+    return checkFile(relativePath, allowedLiterals, usedAllowedLiterals).map(
+      (violation) => {
+        return { relativePath, ...violation };
+      },
+    );
   });
+  const unusedAllowedLiterals = Array.from(allowedLiterals.entries()).filter(
+    ([key]) => {
+      return !usedAllowedLiterals.has(key);
+    },
+  );
 
-  if (violations.length > 0) {
+  if (violations.length > 0 || unusedAllowedLiterals.length > 0) {
     process.stderr.write(`Platform localized UI lint failed.
 
 Move these user-visible literals into the typed i18n resources. If a literal is
 an intentional protocol identifier, provider/product name, or example value,
 add a narrow file-and-value exclusion with a reason.
 
-${violations
-  .map((violation) => {
-    return `  - ${violation.relativePath}:${violation.line}:${violation.column} (${violation.kind}) ${JSON.stringify(violation.value)}`;
-  })
-  .join("\n")}
+${
+  violations.length > 0
+    ? `Hardcoded UI copy:\n${violations
+        .map((violation) => {
+          return `  - ${violation.relativePath}:${violation.line}:${violation.column} (${violation.kind}) ${JSON.stringify(violation.value)}`;
+        })
+        .join("\n")}\n`
+    : ""
+}
+${
+  unusedAllowedLiterals.length > 0
+    ? `Unused exclusions (remove stale entries):\n${unusedAllowedLiterals
+        .map(([key, reason]) => {
+          const [relativePath, value] = key.split("\u0000");
+          return `  - ${relativePath} ${JSON.stringify(value)} (${reason})`;
+        })
+        .join("\n")}\n`
+    : ""
+}
 `);
     process.exit(1);
   }

--- a/turbo/apps/platform/scripts/check-localized-ui.mjs
+++ b/turbo/apps/platform/scripts/check-localized-ui.mjs
@@ -4,10 +4,11 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const appRoot = path.resolve(__dirname, "..");
+const scriptPath = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(scriptPath);
+const defaultAppRoot = path.resolve(__dirname, "..");
 
-function getCheckedFiles() {
+function getCheckedFiles(appRoot) {
   const excludedDirectories = new Set(["__tests__", "i18n", "mocks", "test"]);
   const checkedFiles = [];
 
@@ -68,6 +69,7 @@ function isUserVisibleProperty(value) {
     "message",
     "name",
     "placeholder",
+    "result",
     "subtitle",
     "summary",
     "title",
@@ -81,8 +83,17 @@ function isToastMethod(value) {
 }
 
 function isUserVisibleFunctionName(value) {
-  return /(caption|copy|description|heading|help|hint|label|message|summary|title|tooltip)$/iu.test(
-    value,
+  return (
+    /(caption|copy|description|displayName|displayText|heading|help|hint|label|message|plainText|summary|title|tooltip)$/iu.test(
+      value,
+    ) ||
+    /^format.*(?:Codex|Plan)/u.test(value) ||
+    [
+      "formatMessageHtml",
+      "normalizeCodexRunEvent",
+      "stringifyArrayJsonValue",
+      "stringifyObjectJsonValue",
+    ].includes(value)
   );
 }
 
@@ -98,6 +109,10 @@ function getInternalAllowedLiterals() {
     [
       "src/signals/zero-page/chat-feedback.ts\u0000an email draft (mail draft ID: {…})",
       "locale-neutral serialized agent prompt metadata",
+    ],
+    [
+      "src/signals/activity-page/log-detail-utils.ts\u0000null",
+      "JSON null literal in user-visible diagnostic serialization",
     ],
     [
       "src/signals/chat-page/create-chat-thread.ts\u0000Run cancelled",
@@ -294,21 +309,202 @@ function hasHumanText(value) {
   return /\p{L}/u.test(withoutEntities);
 }
 
-function isTranslationCall(node) {
+function bindingNames(node) {
+  if (ts.isIdentifier(node)) {
+    return [node.text];
+  }
+  if (ts.isObjectBindingPattern(node) || ts.isArrayBindingPattern(node)) {
+    return node.elements.flatMap((element) => {
+      return ts.isBindingElement(element) ? bindingNames(element.name) : [];
+    });
+  }
+  return [];
+}
+
+function variableBindingScope(node) {
+  if (ts.isCatchClause(node.parent)) {
+    return node.parent;
+  }
+  let parent = node.parent;
+  while (parent) {
+    if (ts.isBlock(parent) || ts.isSourceFile(parent)) {
+      return parent;
+    }
+    parent = parent.parent;
+  }
+  return null;
+}
+
+function declarationBindingScope(node) {
+  let parent = node.parent;
+  while (parent) {
+    if (ts.isBlock(parent) || ts.isSourceFile(parent)) {
+      return parent;
+    }
+    parent = parent.parent;
+  }
+  return null;
+}
+
+function addBinding(scopeBindings, scope, name, kind) {
+  if (!scope) {
+    return;
+  }
+  let bindings = scopeBindings.get(scope);
+  if (!bindings) {
+    bindings = new Map();
+    scopeBindings.set(scope, bindings);
+  }
+  const existing = bindings.get(name);
+  bindings.set(name, existing && existing !== kind ? "other" : kind);
+}
+
+function resolveBindingKind(node, name, scopeBindings) {
+  let parent = node;
+  while (parent) {
+    const kind = scopeBindings.get(parent)?.get(name);
+    if (kind) {
+      return kind;
+    }
+    parent = parent.parent;
+  }
+  return null;
+}
+
+function getTranslationBindings(sourceFile) {
+  const scopeBindings = new Map();
+  const translationCandidates = [];
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      continue;
+    }
+    const moduleName = statement.moduleSpecifier.text;
+    const importClause = statement.importClause;
+    if (!importClause) {
+      continue;
+    }
+    if (importClause.name) {
+      addBinding(scopeBindings, sourceFile, importClause.name.text, "other");
+    }
+    const namedBindings = importClause.namedBindings;
+    if (namedBindings && ts.isNamespaceImport(namedBindings)) {
+      addBinding(scopeBindings, sourceFile, namedBindings.name.text, "other");
+      continue;
+    }
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) {
+      continue;
+    }
+    for (const element of namedBindings.elements) {
+      const imported = element.propertyName?.text ?? element.name.text;
+      const kind =
+        moduleName === "react-i18next" && imported === "useTranslation"
+          ? "useTranslation"
+          : /(?:^|\/)i18n\/index(?:\.ts)?$/u.test(moduleName) &&
+              imported === "i18n"
+            ? "i18n"
+            : "other";
+      addBinding(scopeBindings, sourceFile, element.name.text, kind);
+    }
+  }
+
+  function visit(node) {
+    if (ts.isVariableDeclaration(node)) {
+      const scope = variableBindingScope(node);
+      const isTranslationCandidate =
+        ts.isObjectBindingPattern(node.name) &&
+        node.initializer &&
+        ts.isCallExpression(node.initializer) &&
+        ts.isIdentifier(node.initializer.expression);
+      for (const name of bindingNames(node.name)) {
+        const element = ts.isObjectBindingPattern(node.name)
+          ? node.name.elements.find((candidate) => {
+              return (
+                ts.isIdentifier(candidate.name) && candidate.name.text === name
+              );
+            })
+          : undefined;
+        const imported = element?.propertyName?.getText(sourceFile) ?? name;
+        if (isTranslationCandidate && imported === "t") {
+          translationCandidates.push({
+            hookCall: node.initializer,
+            localName: name,
+            scope,
+          });
+        } else {
+          addBinding(scopeBindings, scope, name, "other");
+        }
+      }
+    } else if (ts.isParameter(node)) {
+      const scope = ts.isFunctionLike(node.parent) ? node.parent : null;
+      for (const name of bindingNames(node.name)) {
+        addBinding(scopeBindings, scope, name, "other");
+      }
+    } else if (
+      (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) &&
+      node.name
+    ) {
+      addBinding(
+        scopeBindings,
+        declarationBindingScope(node),
+        node.name.text,
+        "other",
+      );
+    } else if (ts.isFunctionExpression(node) && node.name) {
+      addBinding(scopeBindings, node, node.name.text, "other");
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  for (const candidate of translationCandidates) {
+    const hookName = candidate.hookCall.expression.text;
+    const kind =
+      resolveBindingKind(candidate.hookCall, hookName, scopeBindings) ===
+      "useTranslation"
+        ? "translation"
+        : "other";
+    addBinding(scopeBindings, candidate.scope, candidate.localName, kind);
+  }
+  return scopeBindings;
+}
+
+function isTranslationCall(node, translationBindings) {
   if (!ts.isCallExpression(node)) {
     return false;
   }
   if (ts.isIdentifier(node.expression)) {
-    return node.expression.text === "t";
+    return (
+      resolveBindingKind(node, node.expression.text, translationBindings) ===
+      "translation"
+    );
   }
   return (
     ts.isPropertyAccessExpression(node.expression) &&
-    node.expression.name.text === "t"
+    node.expression.name.text === "t" &&
+    ts.isIdentifier(node.expression.expression) &&
+    resolveBindingKind(
+      node,
+      node.expression.expression.text,
+      translationBindings,
+    ) === "i18n"
   );
 }
 
-function checkVisibleExpression(node, record, kind) {
-  if (isTranslationCall(node)) {
+function isPotentialTranslationCall(node) {
+  return (
+    ts.isCallExpression(node) &&
+    ((ts.isIdentifier(node.expression) && node.expression.text === "t") ||
+      (ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === "t"))
+  );
+}
+
+function checkVisibleExpression(node, record, kind, translationBindings) {
+  if (isTranslationCall(node, translationBindings)) {
     return;
   }
   const value = getLiteralValue(node);
@@ -317,8 +513,8 @@ function checkVisibleExpression(node, record, kind) {
     return;
   }
   if (ts.isConditionalExpression(node)) {
-    checkVisibleExpression(node.whenTrue, record, kind);
-    checkVisibleExpression(node.whenFalse, record, kind);
+    checkVisibleExpression(node.whenTrue, record, kind, translationBindings);
+    checkVisibleExpression(node.whenFalse, record, kind, translationBindings);
     return;
   }
   if (ts.isBinaryExpression(node)) {
@@ -327,12 +523,12 @@ function checkVisibleExpression(node, record, kind) {
       node.operatorToken.kind === ts.SyntaxKind.BarBarToken ||
       node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
     ) {
-      checkVisibleExpression(node.left, record, kind);
-      checkVisibleExpression(node.right, record, kind);
+      checkVisibleExpression(node.left, record, kind, translationBindings);
+      checkVisibleExpression(node.right, record, kind, translationBindings);
       return;
     }
     if (node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) {
-      checkVisibleExpression(node.right, record, kind);
+      checkVisibleExpression(node.right, record, kind, translationBindings);
     }
     return;
   }
@@ -343,12 +539,131 @@ function checkVisibleExpression(node, record, kind) {
     ts.isNonNullExpression(node) ||
     ts.isSatisfiesExpression(node)
   ) {
-    checkVisibleExpression(node.expression, record, kind);
+    checkVisibleExpression(node.expression, record, kind, translationBindings);
     return;
   }
   if (ts.isArrayLiteralExpression(node)) {
     for (const element of node.elements) {
-      checkVisibleExpression(element, record, kind);
+      checkVisibleExpression(element, record, kind, translationBindings);
+    }
+    return;
+  }
+  if (isPotentialTranslationCall(node)) {
+    for (const argument of node.arguments) {
+      checkVisibleExpression(argument, record, kind, translationBindings);
+    }
+  }
+}
+
+function checkVisibleCallChain(node, record, kind, translationBindings) {
+  if (isTranslationCall(node, translationBindings)) {
+    return;
+  }
+  if (ts.isCallExpression(node)) {
+    if (ts.isPropertyAccessExpression(node.expression)) {
+      checkVisibleCallChain(
+        node.expression.expression,
+        record,
+        kind,
+        translationBindings,
+      );
+    }
+    for (const argument of node.arguments) {
+      checkVisibleCallChain(argument, record, kind, translationBindings);
+    }
+    return;
+  }
+  checkVisibleExpression(node, record, kind, translationBindings);
+}
+
+function checkVisibleStructure(node, record, kind, translationBindings) {
+  if (ts.isObjectLiteralExpression(node)) {
+    for (const property of node.properties) {
+      if (ts.isPropertyAssignment(property)) {
+        checkVisibleStructure(
+          property.initializer,
+          record,
+          kind,
+          translationBindings,
+        );
+      }
+    }
+    return;
+  }
+  if (ts.isArrayLiteralExpression(node)) {
+    for (const element of node.elements) {
+      checkVisibleStructure(element, record, kind, translationBindings);
+    }
+    return;
+  }
+  if (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isNonNullExpression(node) ||
+    ts.isSatisfiesExpression(node)
+  ) {
+    checkVisibleStructure(node.expression, record, kind, translationBindings);
+    return;
+  }
+  checkVisibleExpression(node, record, kind, translationBindings);
+}
+
+function checkHtmlExpression(node, record, kind, translationBindings) {
+  if (isTranslationCall(node, translationBindings)) {
+    return;
+  }
+  const value = getLiteralValue(node);
+  if (value !== null) {
+    const visibleText = value
+      .replace(/<[^>]*>/gu, " ")
+      .replaceAll("{…}", " ")
+      .trim();
+    record(node, visibleText, kind);
+    if (ts.isTemplateExpression(node)) {
+      for (const span of node.templateSpans) {
+        checkHtmlExpression(span.expression, record, kind, translationBindings);
+      }
+    }
+    return;
+  }
+  if (ts.isConditionalExpression(node)) {
+    checkHtmlExpression(node.whenTrue, record, kind, translationBindings);
+    checkHtmlExpression(node.whenFalse, record, kind, translationBindings);
+    return;
+  }
+  if (ts.isBinaryExpression(node)) {
+    checkHtmlExpression(node.left, record, kind, translationBindings);
+    checkHtmlExpression(node.right, record, kind, translationBindings);
+    return;
+  }
+  if (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isNonNullExpression(node) ||
+    ts.isSatisfiesExpression(node)
+  ) {
+    checkHtmlExpression(node.expression, record, kind, translationBindings);
+    return;
+  }
+  if (ts.isArrayLiteralExpression(node)) {
+    for (const element of node.elements) {
+      checkHtmlExpression(element, record, kind, translationBindings);
+    }
+    return;
+  }
+  if (ts.isCallExpression(node)) {
+    if (ts.isPropertyAccessExpression(node.expression)) {
+      checkHtmlExpression(
+        node.expression.expression,
+        record,
+        kind,
+        translationBindings,
+      );
+    }
+    for (const argument of node.arguments) {
+      checkHtmlExpression(argument, record, kind, translationBindings);
     }
   }
 }
@@ -367,7 +682,7 @@ function checkJsxText(node, record) {
   }
 }
 
-function checkJsxAttribute(node, record) {
+function checkJsxAttribute(node, record, translationBindings) {
   if (!ts.isJsxAttribute(node)) {
     return;
   }
@@ -384,22 +699,32 @@ function checkJsxAttribute(node, record) {
     return;
   }
   if (ts.isJsxExpression(node.initializer) && node.initializer.expression) {
-    checkVisibleExpression(node.initializer.expression, record, attributeName);
+    checkVisibleExpression(
+      node.initializer.expression,
+      record,
+      attributeName,
+      translationBindings,
+    );
   }
 }
 
-function checkJsxExpression(node, record) {
+function checkJsxExpression(node, record, translationBindings) {
   if (
     ts.isJsxExpression(node) &&
     node.expression &&
     (ts.isJsxElement(node.parent) || ts.isJsxFragment(node.parent)) &&
     !isStyleElement(node.parent)
   ) {
-    checkVisibleExpression(node.expression, record, "JSX expression");
+    checkVisibleExpression(
+      node.expression,
+      record,
+      "JSX expression",
+      translationBindings,
+    );
   }
 }
 
-function checkPropertyAssignment(node, record) {
+function checkPropertyAssignment(node, record, translationBindings) {
   if (!ts.isPropertyAssignment(node)) {
     return;
   }
@@ -407,10 +732,15 @@ function checkPropertyAssignment(node, record) {
   if (!propertyName || !isUserVisibleProperty(propertyName)) {
     return;
   }
-  checkVisibleExpression(node.initializer, record, propertyName);
+  checkVisibleExpression(
+    node.initializer,
+    record,
+    propertyName,
+    translationBindings,
+  );
 }
 
-function checkDocumentTitle(node, record) {
+function checkDocumentTitle(node, record, translationBindings) {
   if (
     !ts.isCallExpression(node) ||
     node.arguments.length < 2 ||
@@ -419,10 +749,15 @@ function checkDocumentTitle(node, record) {
   ) {
     return;
   }
-  checkVisibleExpression(node.arguments[1], record, "document title");
+  checkVisibleExpression(
+    node.arguments[1],
+    record,
+    "document title",
+    translationBindings,
+  );
 }
 
-function checkToastCall(node, record) {
+function checkToastCall(node, record, translationBindings) {
   if (
     !ts.isCallExpression(node) ||
     node.arguments.length === 0 ||
@@ -433,10 +768,15 @@ function checkToastCall(node, record) {
   ) {
     return;
   }
-  checkVisibleExpression(node.arguments[0], record, "toast");
+  checkVisibleExpression(
+    node.arguments[0],
+    record,
+    "toast",
+    translationBindings,
+  );
 }
 
-function checkBrowserDialogCall(node, record) {
+function checkBrowserDialogCall(node, record, translationBindings) {
   if (!ts.isCallExpression(node) || node.arguments.length === 0) {
     return;
   }
@@ -449,7 +789,12 @@ function checkBrowserDialogCall(node, record) {
   if (!methodName || !["alert", "confirm", "prompt"].includes(methodName)) {
     return;
   }
-  checkVisibleExpression(node.arguments[0], record, `browser ${methodName}`);
+  checkVisibleExpression(
+    node.arguments[0],
+    record,
+    `browser ${methodName}`,
+    translationBindings,
+  );
 }
 
 function functionLikeName(node) {
@@ -477,24 +822,125 @@ function functionLikeName(node) {
   return null;
 }
 
-function checkUserVisibleFunctionReturn(node, record) {
-  if (!ts.isReturnStatement(node) || !node.expression) {
-    return;
-  }
+function enclosingUserVisibleFunctionName(node) {
   let parent = node.parent;
   while (parent && !ts.isSourceFile(parent)) {
     if (ts.isFunctionLike(parent)) {
       const name = functionLikeName(parent);
-      if (name && isUserVisibleFunctionName(name)) {
-        checkVisibleExpression(node.expression, record, `${name} return`);
-      }
-      return;
+      return name && isUserVisibleFunctionName(name) ? name : null;
     }
     parent = parent.parent;
   }
+  return null;
 }
 
-function checkSetAttributeCall(node, record) {
+function checkUserVisibleFunctionReturn(node, record, translationBindings) {
+  if (!ts.isReturnStatement(node) || !node.expression) {
+    return;
+  }
+  const name = enclosingUserVisibleFunctionName(node);
+  if (name) {
+    const checkExpression =
+      name === "formatMessageHtml"
+        ? checkHtmlExpression
+        : /(?:Codex|Plan|plainText)/iu.test(name)
+          ? checkVisibleCallChain
+          : checkVisibleExpression;
+    checkExpression(
+      node.expression,
+      record,
+      `${name} return`,
+      translationBindings,
+    );
+  }
+}
+
+function checkUserVisibleFunctionMutation(node, record, translationBindings) {
+  const name = enclosingUserVisibleFunctionName(node);
+  if (!name) {
+    return;
+  }
+  if (
+    ts.isBinaryExpression(node) &&
+    node.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken
+  ) {
+    checkVisibleExpression(
+      node.right,
+      record,
+      `${name} output`,
+      translationBindings,
+    );
+    return;
+  }
+  if (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    ["push", "unshift"].includes(node.expression.name.text)
+  ) {
+    const checkExpression = [
+      "stringifyArrayJsonValue",
+      "stringifyObjectJsonValue",
+    ].includes(name)
+      ? checkVisibleCallChain
+      : checkVisibleExpression;
+    for (const argument of node.arguments) {
+      checkExpression(argument, record, `${name} output`, translationBindings);
+    }
+    return;
+  }
+  if (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === "makeCodexAssistantTextEvent"
+  ) {
+    for (const argument of node.arguments.slice(1)) {
+      checkVisibleCallChain(
+        argument,
+        record,
+        `${name} output`,
+        translationBindings,
+      );
+    }
+  }
+}
+
+function checkUserVisibleFunctionInitializer(
+  node,
+  record,
+  translationBindings,
+) {
+  if (!ts.isVariableDeclaration(node) || !node.initializer) {
+    return;
+  }
+  const name = enclosingUserVisibleFunctionName(node);
+  if (name === "formatMessageHtml") {
+    checkHtmlExpression(
+      node.initializer,
+      record,
+      `${name} output`,
+      translationBindings,
+    );
+  }
+}
+
+function checkUserVisibleNamedInitializer(node, record, translationBindings) {
+  if (
+    !ts.isVariableDeclaration(node) ||
+    !ts.isIdentifier(node.name) ||
+    !node.name.text.endsWith("_DISPLAY_NAMES") ||
+    !node.initializer
+  ) {
+    return;
+  }
+  checkVisibleStructure(
+    node.initializer,
+    record,
+    `${node.name.text} initializer`,
+    translationBindings,
+  );
+}
+
+function checkSetAttributeCall(node, record, translationBindings) {
   if (
     !ts.isCallExpression(node) ||
     node.arguments.length < 2 ||
@@ -511,10 +957,11 @@ function checkSetAttributeCall(node, record) {
     node.arguments[1],
     record,
     `setAttribute(${attribute})`,
+    translationBindings,
   );
 }
 
-function checkUserVisibleAssignment(node, record) {
+function checkUserVisibleAssignment(node, record, translationBindings) {
   if (
     !ts.isBinaryExpression(node) ||
     node.operatorToken.kind !== ts.SyntaxKind.EqualsToken ||
@@ -530,12 +977,20 @@ function checkUserVisibleAssignment(node, record) {
   ) {
     return;
   }
-  checkVisibleExpression(node.right, record, `${propertyName} assignment`);
+  checkVisibleExpression(
+    node.right,
+    record,
+    `${propertyName} assignment`,
+    translationBindings,
+  );
 }
 
-function checkFile(relativePath, allowedLiterals, usedAllowedLiterals) {
-  const absolutePath = path.join(appRoot, relativePath);
-  const sourceText = readFileSync(absolutePath, "utf8");
+export function checkSource(
+  relativePath,
+  sourceText,
+  allowedLiterals = new Map(),
+  usedAllowedLiterals = new Set(),
+) {
   const sourceFile = ts.createSourceFile(
     relativePath,
     sourceText,
@@ -543,6 +998,7 @@ function checkFile(relativePath, allowedLiterals, usedAllowedLiterals) {
     true,
     relativePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
   );
+  const translationBindings = getTranslationBindings(sourceFile);
   const violations = [];
 
   function record(node, value, kind) {
@@ -566,15 +1022,18 @@ function checkFile(relativePath, allowedLiterals, usedAllowedLiterals) {
 
   function visit(node) {
     checkJsxText(node, record);
-    checkJsxAttribute(node, record);
-    checkJsxExpression(node, record);
-    checkPropertyAssignment(node, record);
-    checkDocumentTitle(node, record);
-    checkToastCall(node, record);
-    checkBrowserDialogCall(node, record);
-    checkUserVisibleFunctionReturn(node, record);
-    checkSetAttributeCall(node, record);
-    checkUserVisibleAssignment(node, record);
+    checkJsxAttribute(node, record, translationBindings);
+    checkJsxExpression(node, record, translationBindings);
+    checkPropertyAssignment(node, record, translationBindings);
+    checkDocumentTitle(node, record, translationBindings);
+    checkToastCall(node, record, translationBindings);
+    checkBrowserDialogCall(node, record, translationBindings);
+    checkUserVisibleFunctionReturn(node, record, translationBindings);
+    checkUserVisibleFunctionMutation(node, record, translationBindings);
+    checkUserVisibleFunctionInitializer(node, record, translationBindings);
+    checkUserVisibleNamedInitializer(node, record, translationBindings);
+    checkSetAttributeCall(node, record, translationBindings);
+    checkUserVisibleAssignment(node, record, translationBindings);
     ts.forEachChild(node, visit);
   }
 
@@ -582,16 +1041,36 @@ function checkFile(relativePath, allowedLiterals, usedAllowedLiterals) {
   return violations;
 }
 
+function checkFile(
+  appRoot,
+  relativePath,
+  allowedLiterals,
+  usedAllowedLiterals,
+) {
+  const absolutePath = path.join(appRoot, relativePath);
+  const sourceText = readFileSync(absolutePath, "utf8");
+  return checkSource(
+    relativePath,
+    sourceText,
+    allowedLiterals,
+    usedAllowedLiterals,
+  );
+}
+
 function main() {
+  const appRoot = defaultAppRoot;
   const allowedLiterals = getAllowedLiterals();
   const usedAllowedLiterals = new Set();
-  const checkedFiles = getCheckedFiles();
+  const checkedFiles = getCheckedFiles(appRoot);
   const violations = checkedFiles.flatMap((relativePath) => {
-    return checkFile(relativePath, allowedLiterals, usedAllowedLiterals).map(
-      (violation) => {
-        return { relativePath, ...violation };
-      },
-    );
+    return checkFile(
+      appRoot,
+      relativePath,
+      allowedLiterals,
+      usedAllowedLiterals,
+    ).map((violation) => {
+      return { relativePath, ...violation };
+    });
   });
   const unusedAllowedLiterals = Array.from(allowedLiterals.entries()).filter(
     ([key]) => {
@@ -630,4 +1109,6 @@ ${
   }
 }
 
-main();
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  main();
+}

--- a/turbo/apps/platform/scripts/check-localized-ui.node.mjs
+++ b/turbo/apps/platform/scripts/check-localized-ui.node.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { checkSource } from "./check-localized-ui.mjs";
+
+function violationValues(sourceText, relativePath = "src/example.tsx") {
+  return checkSource(relativePath, sourceText).map((violation) => {
+    return violation.value;
+  });
+}
+
+await test("rejects direct user-visible literals", () => {
+  const values = violationValues(`
+    const card = { title: "Hardcoded title" };
+    function View() {
+      return <button aria-label="Save item">Delete item</button>;
+    }
+    toast.error("Save failed");
+    set(updateDocumentTitle$, "Thread details");
+  `);
+
+  assert.deepEqual(
+    new Set(values),
+    new Set([
+      "Hardcoded title",
+      "Save item",
+      "Delete item",
+      "Save failed",
+      "Thread details",
+    ]),
+  );
+});
+
+await test("rejects indirect display maps and formatter output", () => {
+  const values = violationValues(`
+    const TOOL_DISPLAY_NAMES = {
+      fetch: "Web Fetch",
+    };
+    function formatGenericCodexItem() {
+      const lines = [];
+      lines.push("Status: ready");
+      return ["Files changed", ...lines].join("\\n");
+    }
+    function messageDocumentToDisplayText() {
+      let text = "";
+      text += "Attached file";
+      return text;
+    }
+    function formatMessageHtml() {
+      const attachments = "<div>Attachments:</div>";
+      return attachments;
+    }
+    function stringifyArrayJsonValue() {
+      const items = [];
+      items.push(quoteJsonString("... 5 more items"));
+      return items.join(",");
+    }
+  `);
+
+  assert.deepEqual(
+    new Set(values),
+    new Set([
+      "Web Fetch",
+      "Status: ready",
+      "Files changed",
+      "Attached file",
+      "Attachments:",
+      "... 5 more items",
+    ]),
+  );
+});
+
+await test("accepts project translation bindings", () => {
+  const values = violationValues(`
+    import { useTranslation as useAppTranslation } from "react-i18next";
+    import { i18n as appI18n } from "../i18n/index.ts";
+
+    function View() {
+      const { t: translate } = useAppTranslation();
+      return (
+        <div title={translate(($) => $.card.title)}>
+          {appI18n.t(($) => $.card.message)}
+        </div>
+      );
+    }
+  `);
+
+  assert.deepEqual(values, []);
+});
+
+await test("rejects unrelated functions and methods named t", () => {
+  const values = violationValues(`
+    const t = (value: string) => value;
+    const tracker = { t: (value: string) => value };
+    function View() {
+      return (
+        <>
+          <span>{t("Local hardcode")}</span>
+          <span>{tracker.t("Method hardcode")}</span>
+        </>
+      );
+    }
+  `);
+
+  assert.deepEqual(
+    new Set(values),
+    new Set(["Local hardcode", "Method hardcode"]),
+  );
+});
+
+await test("rejects shadowed translation bindings", () => {
+  const values = violationValues(`
+    import { useTranslation } from "react-i18next";
+    import { i18n as appI18n } from "../i18n/index.ts";
+
+    function View() {
+      const { t } = useTranslation();
+      function Nested(t: (value: string) => string) {
+        return <span>{t("Shadowed hook hardcode")}</span>;
+      }
+      function Other() {
+        const appI18n = { t: (value: string) => value };
+        return <span>{appI18n.t("Shadowed i18n hardcode")}</span>;
+      }
+      return (
+        <>
+          <span>{t(($) => $.card.title)}</span>
+          <Nested t={(value) => value} />
+          <Other />
+        </>
+      );
+    }
+  `);
+
+  assert.deepEqual(
+    new Set(values),
+    new Set(["Shadowed hook hardcode", "Shadowed i18n hardcode"]),
+  );
+});

--- a/turbo/apps/platform/src/i18n/locales/en-US/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/agents.json
@@ -99,23 +99,23 @@
     "catalog": {
       "creative": {
         "cases": {
-          "Cloudinary media optimizer": {
+          "cloudinary-media-optimizer": {
             "description": "Optimize and transform images in bulk",
             "title": "Cloudinary media optimizer"
           },
-          "ElevenLabs audio content": {
+          "elevenlabs-audio-content": {
             "description": "Voice narration from Notion articles saved to Drive",
             "title": "ElevenLabs audio content"
           },
-          "Fal AI image generation": {
+          "fal-ai-image-generation": {
             "description": "Generate product images from descriptions in Notion",
             "title": "Fal AI image generation"
           },
-          "HeyGen video from script": {
+          "heygen-video-from-script": {
             "description": "Notion script becomes a HeyGen video with a team ping",
             "title": "HeyGen video from script"
           },
-          "Runway video from brief": {
+          "runway-video-from-brief": {
             "description": "Generate short videos from a creative brief",
             "title": "Runway video from brief"
           }
@@ -124,63 +124,63 @@
       },
       "engineering": {
         "cases": {
-          "Batch-create issues": {
+          "batch-create-issues": {
             "description": "Paste a list and Zero opens the issues for you",
             "title": "Batch-create issues"
           },
-          "Browserbase web testing": {
+          "browserbase-web-testing": {
             "description": "Automated browser tests for your web app",
             "title": "Browserbase web testing"
           },
-          "Cloudflare traffic & security report": {
+          "cloudflare-traffic-security-report": {
             "description": "Weekly Slack recap of traffic and security events",
             "title": "Cloudflare traffic & security report"
           },
-          "Codebase investigation": {
+          "codebase-investigation": {
             "description": "Give a URL and Zero traces the bug through the repo",
             "title": "Codebase investigation"
           },
-          "Daily standup report": {
+          "daily-standup-report": {
             "description": "Morning metrics become a slide deck posted to Slack",
             "title": "Daily standup report"
           },
-          "Deep-research code analysis": {
+          "deep-research-code-analysis": {
             "description": "Explains how a subsystem works in your codebase",
             "title": "Deep-research code analysis"
           },
-          "GitHub PR summarizer": {
+          "github-pr-summarizer": {
             "description": "Merged pull request summaries in Notion with optional Slack posts",
             "title": "GitHub PR summarizer"
           },
-          "GitHub progress weekly": {
+          "github-progress-weekly": {
             "description": "Weekly repo activity summarized by feature",
             "title": "GitHub progress weekly"
           },
-          "GitLab to GitHub migration helper": {
+          "gitlab-to-github-migration-helper": {
             "description": "Mirrors GitLab issues and merge requests into GitHub",
             "title": "GitLab to GitHub migration helper"
           },
-          "Jira ↔ GitHub issue sync": {
+          "jira-github-issue-sync": {
             "description": "Keeps Jira tickets and GitHub issues in sync",
             "title": "Jira ↔ GitHub issue sync"
           },
-          "Make scenario builder": {
+          "make-scenario-builder": {
             "description": "Design multi-step Make scenarios from a description",
             "title": "Make scenario builder"
           },
-          "Security & dependency alert digest": {
+          "security-dependency-alert-digest": {
             "description": "Weekly security and dependency alerts from GitHub",
             "title": "Security & dependency alert digest"
           },
-          "Sentry issue digest": {
+          "sentry-issue-digest": {
             "description": "Morning digest of issues grouped by severity",
             "title": "Sentry issue digest"
           },
-          "Vercel deploy digest": {
+          "vercel-deploy-digest": {
             "description": "It links each deployment to its commit and alerts Slack when a deploy fails",
             "title": "Vercel deploy digest"
           },
-          "Zapier → VM0 migration": {
+          "zapier-vm0-migration": {
             "description": "Recreate your Zapier workflows as VM0 agents",
             "title": "Zapier → VM0 migration"
           }
@@ -189,67 +189,67 @@
       },
       "everyone": {
         "cases": {
-          "Browser screenshots": {
+          "browser-screenshots": {
             "description": "Opens a page in the browser and returns a screenshot",
             "title": "Browser screenshots"
           },
-          "Calendar optimizer": {
+          "calendar-optimizer": {
             "description": "Helps with conflicts, overload, and focus time",
             "title": "Calendar optimizer"
           },
-          "Calendly booking sync": {
+          "calendly-booking-sync": {
             "description": "New bookings on your calendar with a Slack ping",
             "title": "Calendly booking sync"
           },
-          "Email assistant": {
+          "email-assistant": {
             "description": "Morning inbox summary with suggested next steps",
             "title": "Email assistant"
           },
-          "Granola notes to Notion": {
+          "granola-notes-to-notion": {
             "description": "Granola meeting notes synced to a Notion database",
             "title": "Granola notes to Notion"
           },
-          "Lark ↔ Slack message relay": {
+          "lark-slack-message-relay": {
             "description": "Forwards messages between Lark and Slack both ways",
             "title": "Lark ↔ Slack message relay"
           },
-          "LINE message relay": {
+          "line-message-relay": {
             "description": "Forward LINE messages to Slack and vice versa",
             "title": "LINE message relay"
           },
-          "Meeting notes pipeline": {
+          "meeting-notes-pipeline": {
             "description": "Fireflies notes to Notion with follow ups in Slack",
             "title": "Meeting notes pipeline"
           },
-          "Morning brief": {
+          "morning-brief": {
             "description": "Email, calendar, and notes turned into a short daily plan",
             "title": "Morning brief"
           },
-          "Perplexity deep research": {
+          "perplexity-deep-research": {
             "description": "AI-powered research summaries saved to Notion",
             "title": "Perplexity deep research"
           },
-          "Personal weekly digest": {
+          "personal-weekly-digest": {
             "description": "Pull requests, email, and calendar in one Slack update",
             "title": "Personal weekly digest"
           },
-          "Self-update instructions": {
+          "self-update-instructions": {
             "description": "Update the agent instructions right in chat",
             "title": "Self-update instructions"
           },
-          "Send messages on your behalf": {
+          "send-messages-on-your-behalf": {
             "description": "Posts team announcements to Slack for you",
             "title": "Send messages on your behalf"
           },
-          "Strava team fitness digest": {
+          "strava-team-fitness-digest": {
             "description": "Weekly team activity summary posted to Slack",
             "title": "Strava team fitness digest"
           },
-          "Tavily web research pipeline": {
+          "tavily-web-research-pipeline": {
             "description": "Search the web and compile findings in Notion",
             "title": "Tavily web research pipeline"
           },
-          "tl;dv meeting recap": {
+          "tl-dv-meeting-recap": {
             "description": "Meeting recordings summarized in Notion with action items",
             "title": "tl;dv meeting recap"
           }
@@ -258,71 +258,71 @@
       },
       "marketing": {
         "cases": {
-          "Apify web scraper to Sheets": {
+          "apify-web-scraper-to-sheets": {
             "description": "Apify scrapes sites into structured Google Sheets rows",
             "title": "Apify web scraper to Sheets"
           },
-          "Brevo email nurture sequence": {
+          "brevo-email-nurture-sequence": {
             "description": "Automated email sequences from CRM events",
             "title": "Brevo email nurture sequence"
           },
-          "Competitive intel scraper": {
+          "competitive-intel-scraper": {
             "description": "Firecrawl watches competitor sites and logs changes in Notion",
             "title": "Competitive intel scraper"
           },
-          "Competitor research to Notion": {
+          "competitor-research-to-notion": {
             "description": "Research on X saved as structured notes in Notion",
             "title": "Competitor research to Notion"
           },
-          "Content planner": {
+          "content-planner": {
             "description": "Brainstorm topics and outline an editorial calendar",
             "title": "Content planner"
           },
-          "Dev.to auto-publisher": {
+          "dev-to-auto-publisher": {
             "description": "Publishes Notion posts to Dev.to and links them on X",
             "title": "Dev.to auto-publisher"
           },
-          "Discord community insights": {
+          "discord-community-insights": {
             "description": "Discord feedback in Notion with a weekly Slack digest",
             "title": "Discord community insights"
           },
-          "Instagram engagement tracker": {
+          "instagram-engagement-tracker": {
             "description": "Engagement in Sheets with weekly Slack summaries",
             "title": "Instagram engagement tracker"
           },
-          "Loops email campaign": {
+          "loops-email-campaign": {
             "description": "Draft and send transactional emails via Loops",
             "title": "Loops email campaign"
           },
-          "Marketing automation system": {
+          "marketing-automation-system": {
             "description": "Three agents for research, weekly monitoring, and ad hoc work",
             "title": "Marketing automation system"
           },
-          "Marketing content planning": {
+          "marketing-content-planning": {
             "description": "Plans launch stories from Slack, interviews, and competitors",
             "title": "Marketing content planning"
           },
-          "Onboarding email use cases": {
+          "onboarding-email-use-cases": {
             "description": "Finds onboarding angles from Slack and interviews",
             "title": "Onboarding email use cases"
           },
-          "SerpAPI keyword tracker": {
+          "serpapi-keyword-tracker": {
             "description": "Track keyword rankings weekly and log to Sheets",
             "title": "SerpAPI keyword tracker"
           },
-          "SimilarWeb traffic comparison": {
+          "similarweb-traffic-comparison": {
             "description": "Traffic benchmarks versus competitors saved in Notion",
             "title": "SimilarWeb traffic comparison"
           },
-          "Social media content calendar": {
+          "social-media-content-calendar": {
             "description": "Turns a Sheets calendar into posts for each network",
             "title": "Social media content calendar"
           },
-          "X brand monitor": {
+          "x-brand-monitor": {
             "description": "Brand mentions on X saved in Notion with team alerts",
             "title": "X brand monitor"
           },
-          "YouTube to X thread repurposer": {
+          "youtube-to-x-thread-repurposer": {
             "description": "When a new YouTube video is published, generate a Notion summary and an X thread to promote it",
             "title": "YouTube to X thread repurposer"
           }
@@ -331,47 +331,47 @@
       },
       "ops": {
         "cases": {
-          "AgentMail inbox": {
+          "agentmail-inbox": {
             "description": "Create and manage inboxes with the AgentMail API",
             "title": "AgentMail inbox"
           },
-          "ClickUp → Slack standups": {
+          "clickup-slack-standups": {
             "description": "Daily ClickUp tasks posted as a standup in Slack",
             "title": "ClickUp → Slack standups"
           },
-          "Google Docs → Notion migrator": {
+          "google-docs-notion-migrator": {
             "description": "Google Docs batches into Notion with layout preserved",
             "title": "Google Docs → Notion migrator"
           },
-          "Google Drive file organizer": {
+          "google-drive-file-organizer": {
             "description": "New files sorted into folders automatically",
             "title": "Google Drive file organizer"
           },
-          "Jotform intake to Notion": {
+          "jotform-intake-to-notion": {
             "description": "Form answers land in Notion with Slack notifications",
             "title": "Jotform intake to Notion"
           },
-          "Monday.com weekly digest": {
+          "monday-com-weekly-digest": {
             "description": "Weekly board progress from Monday.com in Slack",
             "title": "Monday.com weekly digest"
           },
-          "PDF contract processor": {
+          "pdf-contract-processor": {
             "description": "Contract fields in Notion with reminders before expiry",
             "title": "PDF contract processor"
           },
-          "RevenueCat subscription digest": {
+          "revenuecat-subscription-digest": {
             "description": "Subscription metrics in Sheets with churn alerts in Slack",
             "title": "RevenueCat subscription digest"
           },
-          "Todoist → Notion task sync": {
+          "todoist-notion-task-sync": {
             "description": "Todoist tasks mirrored in Notion for the team",
             "title": "Todoist → Notion task sync"
           },
-          "Wrike project reporter": {
+          "wrike-project-reporter": {
             "description": "Weekly Wrike progress summaries in Slack",
             "title": "Wrike project reporter"
           },
-          "Xero financial summary": {
+          "xero-financial-summary": {
             "description": "Weekly profit and cash flow from Xero in Slack",
             "title": "Xero financial summary"
           }
@@ -380,27 +380,27 @@
       },
       "product": {
         "cases": {
-          "Asana → Notion project sync": {
+          "asana-notion-project-sync": {
             "description": "Asana milestones and tasks mirrored in Notion",
             "title": "Asana → Notion project sync"
           },
-          "Feedback router": {
+          "feedback-router": {
             "description": "Slack feedback routed by your rules to the right place",
             "title": "Feedback router"
           },
-          "Linear PRD implementer": {
+          "linear-prd-implementer": {
             "description": "Notion specs become Linear projects and issues",
             "title": "Linear PRD implementer"
           },
-          "Metabase dashboard digest": {
+          "metabase-dashboard-digest": {
             "description": "Dashboard snapshots posted to Slack automatically",
             "title": "Metabase dashboard digest"
           },
-          "Pricing analysis": {
+          "pricing-analysis": {
             "description": "Analyze competitor pricing strategies and compare with similar products",
             "title": "Pricing analysis"
           },
-          "Product copy & naming": {
+          "product-copy-naming": {
             "description": "Friendlier names for technical terms in the product",
             "title": "Product copy & naming"
           }
@@ -409,31 +409,31 @@
       },
       "sales": {
         "cases": {
-          "Airtable deal tracker": {
+          "airtable-deal-tracker": {
             "description": "Deals sync to Sheets and Slack when they close",
             "title": "Airtable deal tracker"
           },
-          "Bitrix24 lead nurture": {
+          "bitrix24-lead-nurture": {
             "description": "New Bitrix leads get follow-up tasks and Slack pings",
             "title": "Bitrix24 lead nurture"
           },
-          "HubSpot sales reporter": {
+          "hubspot-sales-reporter": {
             "description": "Weekly HubSpot summaries saved as structured reports",
             "title": "HubSpot sales reporter"
           },
-          "Lead follow-up pipeline": {
+          "lead-follow-up-pipeline": {
             "description": "New leads become HubSpot tasks with Slack alerts",
             "title": "Lead follow-up pipeline"
           },
-          "Salesforce pipeline digest": {
+          "salesforce-pipeline-digest": {
             "description": "Weekly Salesforce opportunity updates in Slack",
             "title": "Salesforce pipeline digest"
           },
-          "Streak pipeline report": {
+          "streak-pipeline-report": {
             "description": "Weekly CRM pipeline stats from Gmail in Slack",
             "title": "Streak pipeline report"
           },
-          "Win/loss reporter": {
+          "win-loss-reporter": {
             "description": "Win and loss trends from the pipeline in Slack",
             "title": "Win/loss reporter"
           }
@@ -442,23 +442,23 @@
       },
       "support": {
         "cases": {
-          "Chatwoot → Notion support log": {
+          "chatwoot-notion-support-log": {
             "description": "Customer conversations logged and categorized in Notion",
             "title": "Chatwoot → Notion support log"
           },
-          "Customer support bot": {
+          "customer-support-bot": {
             "description": "Answers from the knowledge base and tasks for gaps",
             "title": "Customer support bot"
           },
-          "Intercom conversation triager": {
+          "intercom-conversation-triager": {
             "description": "Intercom chats become prioritized Notion tasks",
             "title": "Intercom conversation triager"
           },
-          "Support ticket router": {
+          "support-ticket-router": {
             "description": "Tickets go to Notion and urgent ones ping Slack",
             "title": "Support ticket router"
           },
-          "Zendesk → Notion knowledge base": {
+          "zendesk-notion-knowledge-base": {
             "description": "Extract frequently asked Zendesk questions and auto-add them to a Notion FAQ",
             "title": "Zendesk → Notion knowledge base"
           }

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1,11 +1,36 @@
 {
   "activity": {
     "codex": {
+      "codexError": "Codex error",
       "commandStatus": "Command {{status}}",
+      "error": "Error: {{error}}",
+      "fileChangeKind": "change",
       "fileOperationCompleted": "File operation completed",
       "fileOperationStatus": "File operation {{status}}",
       "fileReadCompleted": "File read completed",
-      "fileReadStatus": "File read {{status}}"
+      "fileReadStatus": "File read {{status}}",
+      "filesChanged": "[files] Files changed:",
+      "genericEvent": "Codex {{eventType}}",
+      "genericItem": "Codex {{label}} ({{details}}){{suffix}}",
+      "idDetail": "id: {{id}}",
+      "item": "item",
+      "moreChanges_one": "- ... +{{count}} more change",
+      "moreChanges_other": "- ... +{{count}} more changes",
+      "moreSteps_one": "- ... +{{count}} more step",
+      "moreSteps_other": "- ... +{{count}} more steps",
+      "planPrefix": "[plan]",
+      "planStatus": {
+        "completed": "completed",
+        "inProgress": "in progress",
+        "pending": "pending",
+        "step": "step"
+      },
+      "status": "Status: {{status}}",
+      "statusDetail": "status: {{status}}",
+      "turnFailed": "Turn failed",
+      "turnStatus": "Turn {{status}}",
+      "warning": "[warning] {{message}}",
+      "warningFallback": "Codex warning"
     },
     "context": {
       "artifact": "Artifact",
@@ -134,6 +159,8 @@
       "inputTokens": "in: {{formattedCount}}",
       "models_one": "{{formattedCount}} model",
       "models_other": "{{formattedCount}} models",
+      "moreItems_one": "... {{count}} more item",
+      "moreItems_other": "... {{count}} more items",
       "nameLabel": "name:",
       "outputTokens": "out: {{formattedCount}}",
       "remainingLines_one": "+{{formattedCount}} line",
@@ -149,8 +176,10 @@
       "toolFailed": "{{toolName}} failed",
       "tools_one": "tool",
       "tools_other": "tools",
+      "truncated": "truncated",
       "turns_one": "{{formattedCount}} turn",
-      "turns_other": "{{formattedCount}} turns"
+      "turns_other": "{{formattedCount}} turns",
+      "unknownTool": "Unknown"
     },
     "inspect": {
       "contextUnavailable": {
@@ -1314,6 +1343,11 @@
       },
       "toRecipients": "To: {{recipients}}",
       "unavailable": "This email is no longer available."
+    },
+    "messageDocument": {
+      "chatThread": "[Chat thread: {{title}}]",
+      "file": "[File: {{filename}}]",
+      "template": "[Template: {{title}}]"
     },
     "newChat": "New chat",
     "origins": {
@@ -4473,6 +4507,16 @@
       "summary_other": "{{chats}} used {{credits}}",
       "title": "Chats",
       "untitled": "(untitled)"
+    },
+    "displayNames": {
+      "auto": "Auto",
+      "finance": "Finance",
+      "maps": "Maps",
+      "peopleSearch": "People Search",
+      "usage": "Usage",
+      "weather": "Weather",
+      "webFetch": "Web Fetch",
+      "webSearch": "Web Search"
     },
     "kinds": {
       "connector": "Connectors",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1345,6 +1345,7 @@
       "unavailable": "This email is no longer available."
     },
     "messageDocument": {
+      "agent": "[Agent: {{name}}]",
       "chatThread": "[Chat thread: {{title}}]",
       "file": "[File: {{filename}}]",
       "template": "[Template: {{title}}]"

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1,5 +1,12 @@
 {
   "activity": {
+    "codex": {
+      "commandStatus": "Command {{status}}",
+      "fileOperationCompleted": "File operation completed",
+      "fileOperationStatus": "File operation {{status}}",
+      "fileReadCompleted": "File read completed",
+      "fileReadStatus": "File read {{status}}"
+    },
     "context": {
       "artifact": "Artifact",
       "environmentMapping": "Environment Mapping",
@@ -185,6 +192,9 @@
       "title": "Activity"
     },
     "network": {
+      "actions": {
+        "block": "BLOCK"
+      },
       "browser": "browser",
       "capture": {
         "binaryData": "[Binary data, {{size}} base64-encoded]",
@@ -384,6 +394,7 @@
         "warmingNeurons": "Warming up the neurons..."
       }
     },
+    "logoAlt": "VM0",
     "metadata": {
       "description": "Zero is your AI coworker from vm0. Text Zero or chat on the web — research, email, docs, Slack, GitHub, Notion, and 100+ tools.",
       "title": "Zero — Your AI coworker from vm0"
@@ -512,6 +523,12 @@
       "kindIcon": "{{kind}} artifact",
       "loading": "Loading artifacts"
     },
+    "fileBadges": {
+      "artwork": "ART",
+      "audio": "AUD",
+      "file": "FILE",
+      "video": "VID"
+    },
     "googleDrive": {
       "agentLoading": "Agent is still loading",
       "connect": "Connect Google Drive",
@@ -567,6 +584,7 @@
         "video": "video"
       },
       "siteLabel": "Site preview for {{title}}",
+      "slideTitle": "Slide {{number}}",
       "unavailable": "{{kind}} preview unavailable.",
       "videoLabel": "Video preview for {{filename}}"
     },
@@ -608,6 +626,27 @@
       "slideThumbnail": "{{title}} slide {{slideNumber}} preview",
       "template": "Template",
       "theme": "Theme",
+      "themeNames": {
+        "bauhausPrimary": "Toy bricks",
+        "berryPop": "Raspberry soda",
+        "carnival": "Funfair",
+        "citrusFresh": "Orange juice",
+        "coralStudio": "Peach studio",
+        "forestEditorial": "Moss library",
+        "goldLuxe": "Award night",
+        "mauveDusk": "Lavender dusk",
+        "midnightMono": "Night run",
+        "mintTech": "Mint lab",
+        "monoInk": "Newsprint red",
+        "nordicFrost": "Ice lake",
+        "oceanDeep": "Deep dive",
+        "popArt": "Neon arcade",
+        "prism": "Candy party",
+        "slateCorporate": "Boardroom blue",
+        "sunsetMaroon": "Sunset glow",
+        "terracottaClay": "Clay pot",
+        "warmSand": "Morning paper"
+      },
       "tryDifferentSearch": "Try a different search.",
       "use": "Use",
       "useThisTemplate": "Use this template",
@@ -1025,6 +1064,7 @@
       "imageUnavailable": "[Image unavailable: {{filename}}]",
       "importing": "Importing attachment",
       "invalidLink": "Enter a valid link",
+      "linkPlaceholder": "https://example.com/image.png",
       "loadingFile": "Loading {{filename}}",
       "previewFile": "Preview {{filename}}",
       "supportedTypes": "Images, docs, audio, video, and archives",
@@ -1234,6 +1274,8 @@
       "sourcePartsHeading_other": "Feedback on {{count}} parts of {{description}}:"
     },
     "mail": {
+      "bcc": "bcc",
+      "cc": "cc",
       "closeDetails": "Close email details",
       "deleted": "This draft was deleted.",
       "deletedEmail": "Deleted email: {{subject}}",
@@ -1275,10 +1317,12 @@
     },
     "newChat": "New chat",
     "origins": {
+      "feishu": "Feishu",
       "openChat": "Open chat",
       "openFeishuChat": "Open original chat in Feishu",
       "openMessage": "Open message",
-      "openSlackMessage": "Open original message in Slack"
+      "openSlackMessage": "Open original message in Slack",
+      "slack": "Slack"
     },
     "permissions": {
       "actionDescription": "{{action}} {{permissionName}}",
@@ -1301,6 +1345,7 @@
       "updated": "Permissions updated",
       "updateFailed": "Couldn't update permissions"
     },
+    "promptDocumentTitle": "Prompt",
     "queue": {
       "aboutAutomationEvent": "About this automation event",
       "aboutGoal": "About this goal",
@@ -1537,6 +1582,7 @@
       "failedTitle": "Couldn’t connect {{connector}}",
       "finishing": "Finishing the secure connection",
       "genericLabel": "Connector",
+      "githubLabel": "GitHub",
       "invalidUrl": "Invalid connector callback URL.",
       "success": "Connected"
     },
@@ -1773,7 +1819,8 @@
         "created": "Created \"{{connector}}\"",
         "deleted": "Custom connector deleted",
         "disconnected": "Disconnected",
-        "renamed": "Renamed to \"{{connector}}\""
+        "renamed": "Renamed to \"{{connector}}\"",
+        "updated": "Updated \"{{connector}}\""
       },
       "updateConfirm": {
         "action": "Save and disconnect",
@@ -1785,6 +1832,7 @@
       "configure": "Configure {{connector}}",
       "descriptionAgent": "Saving will connect your values and authorize {{agent}}.",
       "descriptionUser": "Saving will connect this custom connector for your account.",
+      "documentTitle": "Configure custom connector",
       "invalid": "This custom connector proposal link is invalid or expired.",
       "requestScope": "Request scope",
       "returnToChat": "Return to the chat and reply ACK so the agent can verify the connector.",
@@ -1796,6 +1844,8 @@
     "directed": {
       "authorizeAgent": "Authorize {{agent}}",
       "authorized": "{{connector}} authorized",
+      "authorizeDocumentTitle": "Authorize {{connector}}",
+      "connectDocumentTitle": "Connect {{connector}}",
       "connected": "{{connector}} connected",
       "needsConnector": "{{agent}} needs {{connector}} to proceed",
       "reconnecting": "Reconnecting..."
@@ -1853,6 +1903,7 @@
         "back": "Back to {{brandName}}",
         "connectDescription": "Link this phone number to your {{brandName}} account so you can interact with Zero from text messages.",
         "connectTitle": "Connect phone number",
+        "documentTitle": "Connect Messages",
         "errorFallback": "We couldn't connect this phone number. Try again from your text messages.",
         "incompleteDescription": "Open a fresh /connect link from your text messages.",
         "incompleteTitle": "Connect link is incomplete",
@@ -1928,6 +1979,7 @@
         "connectTitle": "Connect Microsoft Teams",
         "invalidDescription": "This page is meant to be opened from a Microsoft Teams connect link.",
         "open": "Open Teams",
+        "providerName": "Microsoft Teams",
         "successDescription": "You are connected to {{team}}. Mention @Zero in Teams to start chatting.",
         "successTitle": "Connected to Microsoft Teams"
       },
@@ -1937,6 +1989,7 @@
         "alreadyTitle": "Already connected to Telegram",
         "back": "Back to Telegram settings",
         "botFallback": "this bot",
+        "botFatherHandle": "@BotFather",
         "checkingConnectionDescription": "Please wait while we check your Telegram connection.",
         "checkingConnectionTitle": "Checking connection...",
         "checkingDomain": "Checking domain status...",
@@ -1961,6 +2014,7 @@
         "open": "Open Telegram",
         "openBotFather": "Open BotFather",
         "refresh": "Refresh this page and try again.",
+        "setDomainCommand": "/setdomain",
         "signInButton": "Sign in to {{brandName}}",
         "signInCheckFailed": "Couldn't check sign-in",
         "signInDescription": "Use your {{brandName}} account before connecting this Telegram user.",
@@ -2090,6 +2144,7 @@
         "defaultAgentAria": "Default agent for {{appId}}",
         "developerConsole": "Feishu developer console",
         "dialogAdminRequired": "An organization admin must configure the app. You can connect your own account from the Feishu bot list after setup is complete.",
+        "documentTitle": "Feishu",
         "emptyAdmin": "Add a custom app to route Feishu messages to an agent.",
         "emptyMember": "Ask an organization admin to add a Feishu bot.",
         "emptyTitle": "No Feishu bots yet",
@@ -2220,6 +2275,7 @@
         "botFallback": "Telegram bot",
         "bots": "Telegram bots",
         "botToken": "Bot token",
+        "botTokenPlaceholder": "123456:ABC-DEF",
         "checking": "Checking...",
         "copied": "copied!",
         "copyAria": "Copy {{value}}",
@@ -2231,6 +2287,7 @@
         },
         "defaultAgent": "Default agent",
         "disconnectAria": "Disconnect {{bot}}",
+        "documentTitle": "Telegram",
         "domain": {
           "detected": "Domain detected",
           "instructionAfter": ", choose this bot, and set the domain to ",
@@ -2331,6 +2388,7 @@
   },
   "global": {
     "errors": {
+      "httpStatus": "HTTP {{status}}",
       "requestFailed": "Request failed"
     },
     "realtime": {
@@ -3854,10 +3912,18 @@
       "settings": "Settings",
       "signOut": "Sign out",
       "subscriptions": {
+        "providers": {
+          "claudeCode": "Claude Code",
+          "codex": "Codex"
+        },
         "reset": "Reset",
         "resetTimeUnavailable": "Reset time unavailable",
         "usage": "{{provider}} usage",
-        "usageRemaining": "{{provider}} {{window}} remaining"
+        "usageRemaining": "{{provider}} {{window}} remaining",
+        "windows": {
+          "fiveHour": "5h",
+          "week": "week"
+        }
       },
       "switchAccount": "Switch account",
       "userFallback": "User"
@@ -4042,6 +4108,7 @@
         "status": {
           "connected": "Connected",
           "connectedWithDetail": "Connected ({{detail}})",
+          "fiveHour": "5h",
           "left": "{{percent}} left",
           "stale": "Attention",
           "week": "Week"
@@ -4066,6 +4133,11 @@
         },
         "prioritizeSpeed": "Prioritize speed",
         "pro": "Pro",
+        "providerLabels": {
+          "azureFoundryPortal": "Azure foundry portal",
+          "claudeCodeOauth": "Claude Code (OAuth token)",
+          "deepseek": "Deepseek"
+        },
         "runSpeed": "Run speed",
         "standard": "Standard"
       },
@@ -4168,6 +4240,10 @@
       "language": {
         "description": "Choose your preferred language for the {{brandName}} interface",
         "label": "Language",
+        "options": {
+          "english": "English",
+          "portugueseBrazil": "Português (Brasil)"
+        },
         "title": "Language"
       },
       "morningBrief": {
@@ -4466,6 +4542,7 @@
         "addDescriptionUpdated": "Run this workflow when a Google Calendar event is updated.",
         "addTitle": "Add Google Calendar automation",
         "calendarId": "Calendar ID",
+        "calendarIdPlaceholder": "primary",
         "cancelledDescription": "Run when a calendar event is cancelled.",
         "cancelledRule": "When calendar {{calendar}} event is cancelled",
         "cancelledTitle": "Google Calendar event cancelled",
@@ -4486,6 +4563,7 @@
         "anyStatus": "Any finish status",
         "patternHint": "Optional * wildcard matched against the run's final reply. Leave empty to match any output.",
         "patternLabel": "Output pattern",
+        "patternPlaceholder": "*deploy failed*",
         "runFinishedDescription": "Run when a run in one of your chat threads finishes.",
         "runFinishedTitle": "Chat run finished",
         "statusCancelled": "Cancelled",
@@ -4534,6 +4612,7 @@
         "actorAnyone": "Anyone",
         "actorMe": "Me",
         "actors": "Actors",
+        "actorsPlaceholder": "octocat, dependabot[bot]",
         "addLabelAction": "Add label automation",
         "addLabelAria": "Add GitHub label automation",
         "addLabelDescription": "Run this workflow when a GitHub label is applied.",
@@ -4559,14 +4638,19 @@
         "anyReviewState": "Any review state",
         "anyWorkflow": "Any workflow",
         "apps": "GitHub Apps",
+        "appsPlaceholder": "vercel, 12345",
+        "authorsPlaceholder": "octocat, e7h4n",
         "authorsSummary": "Authors {{values}}",
         "aWorkflow": "a GitHub workflow",
         "baseBranches": "Base branches",
         "branches": "Branches",
+        "branchesPlaceholder": "main, release",
         "commentPrefixes": "Comment prefixes",
+        "commentPrefixesPlaceholder": "/zero, /verify, /deploy",
         "conclusions": "Conclusions",
         "conclusionsSummary": "Conclusions {{values}}",
         "creators": "Creators",
+        "creatorsPlaceholder": "octocat, 12345",
         "deploymentStates": "Deployment states",
         "deploymentStatesSummary": "Deployment states {{values}}",
         "deploymentStatusDescription": "Run when a matching deployment status is created.",
@@ -4576,10 +4660,13 @@
         "editWebhookFilters": "Edit {{title}} filters",
         "editWorkflowFilters": "Edit GitHub workflow filters",
         "environments": "Environments",
+        "environmentsPlaceholder": "Preview, Production",
         "environmentsSummary": "Environments {{values}}",
         "events": "Triggering events",
+        "eventsPlaceholder": "push, pull_request, workflow_dispatch",
         "filterHelp": "Leave a filter empty to match any value. Separate multiple values with commas.",
         "headBranches": "Head branches",
+        "headBranchesPlaceholder": "feature/, dependabot/",
         "installAdminRequired": "Ask an organization admin to install it.",
         "installApp": "Install GitHub App",
         "installedRequired": "GitHub is not installed for this workspace.",
@@ -4589,12 +4676,14 @@
         "issuesAndPullRequests": "Issues and pull requests",
         "issuesOnly": "Issues only",
         "jobs": "Jobs",
+        "jobsPlaceholder": "test, build",
         "jobsSummary": "Jobs {{values}}",
         "labelAppliedDescription": "Run when an issue or pull request gets a label.",
         "labelAppliedRule": "When GitHub label {{label}} is applied",
         "labelAppliedTitle": "GitHub label applied",
         "labelName": "Label name",
         "labelOnlySummary": "Label {{label}}",
+        "labelPlaceholder": "triage",
         "labelSummary": "Label {{label}} · {{subject}} · Actor {{actor}}",
         "loadError": "GitHub settings could not be loaded.",
         "nonProductionOnly": "Non-production only",
@@ -4622,14 +4711,18 @@
         "productionOnly": "Production only",
         "pullRequestsOnly": "Pull requests only",
         "refs": "Refs",
+        "refsPlaceholder": "main, v1.0.0",
         "repositories": "Repositories",
+        "repositoriesPlaceholder": "vm0-ai/vm0, owner/another-repo",
         "repositoriesSummary": "Repositories {{values}}",
         "reviewDescription": "Run when a matching review is submitted.",
         "reviewRule": "When a matching GitHub pull request review is submitted",
         "reviewStates": "Review states",
         "reviewTitle": "GitHub pull request review submitted",
         "runnerGroups": "Runner groups",
+        "runnerGroupsPlaceholder": "Default, production",
         "runnerLabels": "Runner labels",
+        "runnerLabelsPlaceholder": "self-hosted, linux",
         "saveFilters": "Save filters",
         "selectNoneAny": "Select none to match any value.",
         "selectNoneConclusion": "Select none to match any completed conclusion.",
@@ -4647,6 +4740,8 @@
         "workflowRunRule": "When {{workflows}} completes{{conclusions}}",
         "workflowRunTitle": "GitHub workflow completed",
         "workflows": "GitHub workflows",
+        "workflowsPlaceholder": "Turbo, .github/workflows/release.yml",
+        "workflowsShortPlaceholder": "Turbo, release",
         "workflowsSummary": "Workflows {{values}}"
       },
       "gmail": {
@@ -4677,6 +4772,7 @@
         "labelAppliedRule": "When Gmail label {{label}} is applied",
         "labelAppliedTitle": "Gmail label applied",
         "labelName": "Label name",
+        "labelPlaceholder": "Support",
         "labelSummary": "Label {{label}}",
         "messageMatchesRule": "When Gmail message matches {{summary}}",
         "newMessageDescription": "Run this workflow from matching email.",
@@ -4737,11 +4833,13 @@
         "databaseUpdatedRule": "When Notion database {{title}} item content is updated",
         "databaseUpdatedRuleGeneric": "When Notion database item content is updated",
         "databaseUrl": "Database URL",
+        "databaseUrlPlaceholder": "https://www.notion.so/...",
         "page": "Page",
         "pageSummary": "Page {{title}}",
         "pageUpdatedRule": "When Notion page {{title}} content is updated",
         "pageUpdatedRuleGeneric": "When a Notion page content is updated",
         "pageUrl": "Page URL",
+        "pageUrlPlaceholder": "https://www.notion.so/workspace/Page-title-...",
         "parentPageSummary": "Parent page {{title}}",
         "parentPageUrl": "Parent page URL",
         "scope": "Scope"
@@ -4814,14 +4912,26 @@
         "connectFirst": "Connect a Strapi instance before creating this automation.",
         "contentType": "Content type UID (optional)",
         "contentTypeAny": "Any content type",
+        "contentTypePlaceholder": "api::article.article",
         "entryPublishedDescription": "Run after a matching Strapi entry is published.",
         "entryPublishedTitle": "Strapi entry published",
         "instance": "Strapi instance",
         "locale": "Locale (optional)",
         "localeAny": "Any locale",
         "localeHint": "Leave locale blank to combine all localized publish events for the same document into one workflow run.",
+        "localePlaceholder": "en",
         "localeSummary": "Locale {{locale}}",
         "rule": "When a matching Strapi entry is published"
+      },
+      "types": {
+        "chat": "Chat",
+        "github": "GitHub",
+        "gmail": "Gmail",
+        "googleCalendar": "Google Calendar",
+        "googleMeet": "Google Meet",
+        "notion": "Notion",
+        "strapi": "Strapi",
+        "webhook": "Webhook"
       },
       "webhook": {
         "addDescription": "Create a signed endpoint for this workflow.",
@@ -4950,6 +5060,7 @@
         "instructionPlaceholder": "Write workflow instructions...",
         "instructions": "instructions",
         "noContent": "No content available for this file.",
+        "sizeBytes": "{{size}} B",
         "upload": "Upload text files",
         "uploadAria": "Upload workflow files"
       },
@@ -4969,6 +5080,7 @@
         "saved": "Workflow saved",
         "slug": "Slug",
         "slugHelp": "Lowercase letters, numbers, and - only. Use {{command}} in chat to use this workflow.",
+        "slugPlaceholder": "workflow-slug",
         "slugTitle": "Use lowercase letters, numbers, and hyphens only",
         "visibility": "Visibility",
         "visibilityHelp": "Choose how this workflow is shared inside your workspace."
@@ -5068,11 +5180,13 @@
       "description": "Team communication and collaboration",
       "install": "Install to Slack",
       "permissionsUpdated": "Slack permissions have been updated",
+      "title": "Slack",
       "uninstallDescription": "This will remove the Slack integration for your entire workspace. All connected users will be disconnected and {{displayName}} will no longer respond to messages or mentions in Slack. This action cannot be undone.",
       "uninstallTitle": "Uninstall Slack integration?"
     },
     "strapi": {
-      "description": "Automate work when entries are published"
+      "description": "Automate work when entries are published",
+      "title": "Strapi"
     },
     "teams": {
       "adminInstall": "Ask your admin to install the Microsoft Teams integration",
@@ -5083,13 +5197,15 @@
       "install": "Install in Teams",
       "moreOptions": "More Microsoft Teams options",
       "permissionsUpdated": "Microsoft Teams permissions have been updated",
+      "title": "Microsoft Teams",
       "uninstall": "Uninstall Microsoft Teams",
       "uninstallDescription": "This removes the Microsoft Teams integration from {{brandName}} for your workspace. All connected users will be disconnected and {{displayName}} will no longer respond to Teams messages for this workspace until an admin reconnects it.",
       "uninstallTitle": "Uninstall Microsoft Teams integration?"
     },
     "telegram": {
       "description": "Route Telegram messages to agents",
-      "openSettings": "Open Telegram settings"
+      "openSettings": "Open Telegram settings",
+      "title": "Telegram"
     }
   }
 }

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/agents.json
@@ -99,23 +99,23 @@
     "catalog": {
       "creative": {
         "cases": {
-          "Cloudinary media optimizer": {
+          "cloudinary-media-optimizer": {
             "description": "Otimize e transforme imagens em lote",
             "title": "Otimizador de mídia do Cloudinary"
           },
-          "ElevenLabs audio content": {
+          "elevenlabs-audio-content": {
             "description": "Narrações de artigos do Notion salvas no Drive",
             "title": "Conteúdo de áudio com ElevenLabs"
           },
-          "Fal AI image generation": {
+          "fal-ai-image-generation": {
             "description": "Gere imagens de produtos a partir de descrições no Notion",
             "title": "Geração de imagens com Fal AI"
           },
-          "HeyGen video from script": {
+          "heygen-video-from-script": {
             "description": "Um roteiro do Notion vira vídeo no HeyGen com aviso para a equipe",
             "title": "Vídeo do HeyGen a partir de roteiro"
           },
-          "Runway video from brief": {
+          "runway-video-from-brief": {
             "description": "Gere vídeos curtos a partir de um briefing criativo",
             "title": "Vídeo do Runway a partir de briefing"
           }
@@ -124,63 +124,63 @@
       },
       "engineering": {
         "cases": {
-          "Batch-create issues": {
+          "batch-create-issues": {
             "description": "Cole uma lista e o Zero abre as issues para você",
             "title": "Criar issues em lote"
           },
-          "Browserbase web testing": {
+          "browserbase-web-testing": {
             "description": "Testes automatizados de navegador para seu aplicativo web",
             "title": "Testes web com Browserbase"
           },
-          "Cloudflare traffic & security report": {
+          "cloudflare-traffic-security-report": {
             "description": "Resumo semanal de tráfego e eventos de segurança no Slack",
             "title": "Relatório de tráfego e segurança do Cloudflare"
           },
-          "Codebase investigation": {
+          "codebase-investigation": {
             "description": "Forneça uma URL e o Zero rastreia o bug pelo repositório",
             "title": "Investigação da base de código"
           },
-          "Daily standup report": {
+          "daily-standup-report": {
             "description": "Métricas da manhã viram uma apresentação publicada no Slack",
             "title": "Relatório diário de standup"
           },
-          "Deep-research code analysis": {
+          "deep-research-code-analysis": {
             "description": "Explica como um subsistema funciona na sua base de código",
             "title": "Análise aprofundada de código"
           },
-          "GitHub PR summarizer": {
+          "github-pr-summarizer": {
             "description": "Resumos de pull requests mesclados no Notion, com publicações opcionais no Slack",
             "title": "Resumidor de PRs do GitHub"
           },
-          "GitHub progress weekly": {
+          "github-progress-weekly": {
             "description": "Atividade semanal do repositório resumida por funcionalidade",
             "title": "Progresso semanal do GitHub"
           },
-          "GitLab to GitHub migration helper": {
+          "gitlab-to-github-migration-helper": {
             "description": "Espelha issues e merge requests do GitLab no GitHub",
             "title": "Assistente de migração do GitLab para o GitHub"
           },
-          "Jira ↔ GitHub issue sync": {
+          "jira-github-issue-sync": {
             "description": "Mantém tickets do Jira e issues do GitHub sincronizados",
             "title": "Sincronização de issues entre Jira e GitHub"
           },
-          "Make scenario builder": {
+          "make-scenario-builder": {
             "description": "Crie cenários de várias etapas no Make a partir de uma descrição",
             "title": "Criador de cenários do Make"
           },
-          "Security & dependency alert digest": {
+          "security-dependency-alert-digest": {
             "description": "Alertas semanais de segurança e dependências do GitHub",
             "title": "Resumo de alertas de segurança e dependências"
           },
-          "Sentry issue digest": {
+          "sentry-issue-digest": {
             "description": "Resumo matinal de issues agrupadas por gravidade",
             "title": "Resumo de issues do Sentry"
           },
-          "Vercel deploy digest": {
+          "vercel-deploy-digest": {
             "description": "Vincula cada deploy ao commit e alerta no Slack quando há falha",
             "title": "Resumo de deploys da Vercel"
           },
-          "Zapier → VM0 migration": {
+          "zapier-vm0-migration": {
             "description": "Recrie seus workflows do Zapier como agentes do VM0",
             "title": "Migração do Zapier para o VM0"
           }
@@ -189,67 +189,67 @@
       },
       "everyone": {
         "cases": {
-          "Browser screenshots": {
+          "browser-screenshots": {
             "description": "Abre uma página no navegador e retorna uma captura de tela",
             "title": "Capturas de tela do navegador"
           },
-          "Calendar optimizer": {
+          "calendar-optimizer": {
             "description": "Ajuda com conflitos, excesso de reuniões e tempo de foco",
             "title": "Otimizador de calendário"
           },
-          "Calendly booking sync": {
+          "calendly-booking-sync": {
             "description": "Novos agendamentos no calendário com aviso no Slack",
             "title": "Sincronização de agendamentos do Calendly"
           },
-          "Email assistant": {
+          "email-assistant": {
             "description": "Resumo matinal da caixa de entrada com próximos passos sugeridos",
             "title": "Assistente de e-mail"
           },
-          "Granola notes to Notion": {
+          "granola-notes-to-notion": {
             "description": "Notas de reuniões do Granola sincronizadas com um banco de dados do Notion",
             "title": "Notas do Granola no Notion"
           },
-          "Lark ↔ Slack message relay": {
+          "lark-slack-message-relay": {
             "description": "Encaminha mensagens entre Lark e Slack nos dois sentidos",
             "title": "Retransmissão de mensagens entre Lark e Slack"
           },
-          "LINE message relay": {
+          "line-message-relay": {
             "description": "Encaminha mensagens do LINE para o Slack e vice-versa",
             "title": "Retransmissão de mensagens do LINE"
           },
-          "Meeting notes pipeline": {
+          "meeting-notes-pipeline": {
             "description": "Notas do Fireflies no Notion com acompanhamentos no Slack",
             "title": "Pipeline de notas de reuniões"
           },
-          "Morning brief": {
+          "morning-brief": {
             "description": "E-mail, calendário e notas transformados em um plano diário curto",
             "title": "Resumo matinal"
           },
-          "Perplexity deep research": {
+          "perplexity-deep-research": {
             "description": "Resumos de pesquisa com IA salvos no Notion",
             "title": "Pesquisa aprofundada com Perplexity"
           },
-          "Personal weekly digest": {
+          "personal-weekly-digest": {
             "description": "Pull requests, e-mail e calendário em uma única atualização no Slack",
             "title": "Resumo semanal pessoal"
           },
-          "Self-update instructions": {
+          "self-update-instructions": {
             "description": "Atualize as instruções do agente diretamente na conversa",
             "title": "Atualizar as próprias instruções"
           },
-          "Send messages on your behalf": {
+          "send-messages-on-your-behalf": {
             "description": "Publica comunicados para a equipe no Slack por você",
             "title": "Enviar mensagens em seu nome"
           },
-          "Strava team fitness digest": {
+          "strava-team-fitness-digest": {
             "description": "Resumo semanal das atividades da equipe publicado no Slack",
             "title": "Resumo de atividades da equipe no Strava"
           },
-          "Tavily web research pipeline": {
+          "tavily-web-research-pipeline": {
             "description": "Pesquise na web e compile os resultados no Notion",
             "title": "Pipeline de pesquisa web com Tavily"
           },
-          "tl;dv meeting recap": {
+          "tl-dv-meeting-recap": {
             "description": "Gravações de reuniões resumidas no Notion com itens de ação",
             "title": "Resumo de reuniões do tl;dv"
           }
@@ -258,71 +258,71 @@
       },
       "marketing": {
         "cases": {
-          "Apify web scraper to Sheets": {
+          "apify-web-scraper-to-sheets": {
             "description": "O Apify extrai sites para linhas estruturadas no Google Sheets",
             "title": "Extração web do Apify para o Sheets"
           },
-          "Brevo email nurture sequence": {
+          "brevo-email-nurture-sequence": {
             "description": "Sequências automáticas de e-mail a partir de eventos do CRM",
             "title": "Sequência de nutrição por e-mail no Brevo"
           },
-          "Competitive intel scraper": {
+          "competitive-intel-scraper": {
             "description": "O Firecrawl monitora sites de concorrentes e registra mudanças no Notion",
             "title": "Coletor de inteligência competitiva"
           },
-          "Competitor research to Notion": {
+          "competitor-research-to-notion": {
             "description": "Pesquisas no X salvas como notas estruturadas no Notion",
             "title": "Pesquisa de concorrentes no Notion"
           },
-          "Content planner": {
+          "content-planner": {
             "description": "Explore temas e estruture um calendário editorial",
             "title": "Planejador de conteúdo"
           },
-          "Dev.to auto-publisher": {
+          "dev-to-auto-publisher": {
             "description": "Publica posts do Notion no Dev.to e divulga os links no X",
             "title": "Publicação automática no Dev.to"
           },
-          "Discord community insights": {
+          "discord-community-insights": {
             "description": "Feedback do Discord no Notion com resumo semanal no Slack",
             "title": "Insights da comunidade do Discord"
           },
-          "Instagram engagement tracker": {
+          "instagram-engagement-tracker": {
             "description": "Engajamento no Sheets com resumos semanais no Slack",
             "title": "Monitor de engajamento do Instagram"
           },
-          "Loops email campaign": {
+          "loops-email-campaign": {
             "description": "Crie e envie e-mails transacionais pelo Loops",
             "title": "Campanha de e-mail no Loops"
           },
-          "Marketing automation system": {
+          "marketing-automation-system": {
             "description": "Três agentes para pesquisa, monitoramento semanal e trabalho sob demanda",
             "title": "Sistema de automação de marketing"
           },
-          "Marketing content planning": {
+          "marketing-content-planning": {
             "description": "Planeja histórias de lançamento com base no Slack, entrevistas e concorrentes",
             "title": "Planejamento de conteúdo de marketing"
           },
-          "Onboarding email use cases": {
+          "onboarding-email-use-cases": {
             "description": "Encontra abordagens de onboarding no Slack e em entrevistas",
             "title": "Casos de uso para e-mails de onboarding"
           },
-          "SerpAPI keyword tracker": {
+          "serpapi-keyword-tracker": {
             "description": "Monitore semanalmente o ranking de palavras-chave e registre no Sheets",
             "title": "Monitor de palavras-chave com SerpAPI"
           },
-          "SimilarWeb traffic comparison": {
+          "similarweb-traffic-comparison": {
             "description": "Comparativos de tráfego com concorrentes salvos no Notion",
             "title": "Comparação de tráfego com SimilarWeb"
           },
-          "Social media content calendar": {
+          "social-media-content-calendar": {
             "description": "Transforma um calendário do Sheets em posts para cada rede",
             "title": "Calendário de conteúdo para redes sociais"
           },
-          "X brand monitor": {
+          "x-brand-monitor": {
             "description": "Menções à marca no X salvas no Notion com alertas para a equipe",
             "title": "Monitor de marca no X"
           },
-          "YouTube to X thread repurposer": {
+          "youtube-to-x-thread-repurposer": {
             "description": "Quando um novo vídeo é publicado no YouTube, gera um resumo no Notion e uma thread no X",
             "title": "Reaproveitamento de vídeos do YouTube em threads no X"
           }
@@ -331,47 +331,47 @@
       },
       "ops": {
         "cases": {
-          "AgentMail inbox": {
+          "agentmail-inbox": {
             "description": "Crie e gerencie caixas de entrada com a API do AgentMail",
             "title": "Caixa de entrada do AgentMail"
           },
-          "ClickUp → Slack standups": {
+          "clickup-slack-standups": {
             "description": "Tarefas diárias do ClickUp publicadas como standup no Slack",
             "title": "Standups do ClickUp no Slack"
           },
-          "Google Docs → Notion migrator": {
+          "google-docs-notion-migrator": {
             "description": "Lotes de Google Docs no Notion com o layout preservado",
             "title": "Migrador do Google Docs para o Notion"
           },
-          "Google Drive file organizer": {
+          "google-drive-file-organizer": {
             "description": "Novos arquivos organizados automaticamente em pastas",
             "title": "Organizador de arquivos do Google Drive"
           },
-          "Jotform intake to Notion": {
+          "jotform-intake-to-notion": {
             "description": "Respostas de formulários no Notion com notificações no Slack",
             "title": "Formulários do Jotform no Notion"
           },
-          "Monday.com weekly digest": {
+          "monday-com-weekly-digest": {
             "description": "Progresso semanal dos quadros do Monday.com no Slack",
             "title": "Resumo semanal do Monday.com"
           },
-          "PDF contract processor": {
+          "pdf-contract-processor": {
             "description": "Campos de contratos no Notion com lembretes antes do vencimento",
             "title": "Processador de contratos em PDF"
           },
-          "RevenueCat subscription digest": {
+          "revenuecat-subscription-digest": {
             "description": "Métricas de assinaturas no Sheets com alertas de churn no Slack",
             "title": "Resumo de assinaturas do RevenueCat"
           },
-          "Todoist → Notion task sync": {
+          "todoist-notion-task-sync": {
             "description": "Tarefas do Todoist espelhadas no Notion para a equipe",
             "title": "Sincronização de tarefas do Todoist com o Notion"
           },
-          "Wrike project reporter": {
+          "wrike-project-reporter": {
             "description": "Resumos semanais do progresso no Wrike publicados no Slack",
             "title": "Relatório de projetos do Wrike"
           },
-          "Xero financial summary": {
+          "xero-financial-summary": {
             "description": "Lucro e fluxo de caixa semanais do Xero no Slack",
             "title": "Resumo financeiro do Xero"
           }
@@ -380,27 +380,27 @@
       },
       "product": {
         "cases": {
-          "Asana → Notion project sync": {
+          "asana-notion-project-sync": {
             "description": "Marcos e tarefas do Asana espelhados no Notion",
             "title": "Sincronização de projetos do Asana com o Notion"
           },
-          "Feedback router": {
+          "feedback-router": {
             "description": "Feedback do Slack encaminhado ao lugar certo pelas suas regras",
             "title": "Roteador de feedback"
           },
-          "Linear PRD implementer": {
+          "linear-prd-implementer": {
             "description": "Especificações do Notion viram projetos e issues no Linear",
             "title": "Implementador de PRDs no Linear"
           },
-          "Metabase dashboard digest": {
+          "metabase-dashboard-digest": {
             "description": "Capturas de dashboards publicadas automaticamente no Slack",
             "title": "Resumo de dashboards do Metabase"
           },
-          "Pricing analysis": {
+          "pricing-analysis": {
             "description": "Analise estratégias de preços dos concorrentes e compare com produtos semelhantes",
             "title": "Análise de preços"
           },
-          "Product copy & naming": {
+          "product-copy-naming": {
             "description": "Nomes mais amigáveis para termos técnicos do produto",
             "title": "Textos e nomenclatura do produto"
           }
@@ -409,31 +409,31 @@
       },
       "sales": {
         "cases": {
-          "Airtable deal tracker": {
+          "airtable-deal-tracker": {
             "description": "Negócios sincronizados com o Sheets e avisos no Slack quando são fechados",
             "title": "Monitor de negócios do Airtable"
           },
-          "Bitrix24 lead nurture": {
+          "bitrix24-lead-nurture": {
             "description": "Novos leads do Bitrix recebem tarefas de acompanhamento e avisos no Slack",
             "title": "Nutrição de leads no Bitrix24"
           },
-          "HubSpot sales reporter": {
+          "hubspot-sales-reporter": {
             "description": "Resumos semanais do HubSpot salvos como relatórios estruturados",
             "title": "Relatório de vendas do HubSpot"
           },
-          "Lead follow-up pipeline": {
+          "lead-follow-up-pipeline": {
             "description": "Novos leads viram tarefas no HubSpot com alertas no Slack",
             "title": "Pipeline de acompanhamento de leads"
           },
-          "Salesforce pipeline digest": {
+          "salesforce-pipeline-digest": {
             "description": "Atualizações semanais de oportunidades do Salesforce no Slack",
             "title": "Resumo do pipeline do Salesforce"
           },
-          "Streak pipeline report": {
+          "streak-pipeline-report": {
             "description": "Estatísticas semanais do pipeline de CRM do Gmail no Slack",
             "title": "Relatório de pipeline do Streak"
           },
-          "Win/loss reporter": {
+          "win-loss-reporter": {
             "description": "Tendências de ganhos e perdas do pipeline no Slack",
             "title": "Relatório de ganhos e perdas"
           }
@@ -442,23 +442,23 @@
       },
       "support": {
         "cases": {
-          "Chatwoot → Notion support log": {
+          "chatwoot-notion-support-log": {
             "description": "Conversas com clientes registradas e categorizadas no Notion",
             "title": "Registro de suporte do Chatwoot no Notion"
           },
-          "Customer support bot": {
+          "customer-support-bot": {
             "description": "Responde com base na central de conhecimento e cria tarefas para lacunas",
             "title": "Bot de suporte ao cliente"
           },
-          "Intercom conversation triager": {
+          "intercom-conversation-triager": {
             "description": "Conversas do Intercom viram tarefas priorizadas no Notion",
             "title": "Triagem de conversas do Intercom"
           },
-          "Support ticket router": {
+          "support-ticket-router": {
             "description": "Tickets vão para o Notion e os urgentes geram avisos no Slack",
             "title": "Roteador de tickets de suporte"
           },
-          "Zendesk → Notion knowledge base": {
+          "zendesk-notion-knowledge-base": {
             "description": "Extraia perguntas frequentes do Zendesk e adicione-as automaticamente a uma FAQ no Notion",
             "title": "Base de conhecimento do Zendesk no Notion"
           }

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1,5 +1,12 @@
 {
   "activity": {
+    "codex": {
+      "commandStatus": "Comando {{status}}",
+      "fileOperationCompleted": "Operação de arquivo concluída",
+      "fileOperationStatus": "Operação de arquivo {{status}}",
+      "fileReadCompleted": "Leitura de arquivo concluída",
+      "fileReadStatus": "Leitura de arquivo {{status}}"
+    },
     "context": {
       "artifact": "Artefato",
       "environmentMapping": "Mapeamento de ambiente",
@@ -195,6 +202,9 @@
       "title": "Atividade"
     },
     "network": {
+      "actions": {
+        "block": "BLOCK"
+      },
       "browser": "navegador",
       "capture": {
         "binaryData": "[Dados binários, {{size}} codificados em base64]",
@@ -395,6 +405,7 @@
         "warmingNeurons": "Aquecendo os neurônios..."
       }
     },
+    "logoAlt": "VM0",
     "metadata": {
       "description": "Zero é seu colega de IA da vm0. Envie uma mensagem para o Zero ou converse pela web — pesquise, envie e-mails, crie documentos e use Slack, GitHub, Notion e mais de 100 ferramentas.",
       "title": "Zero — Seu colega de IA da vm0"
@@ -523,6 +534,12 @@
       "kindIcon": "Artefato do tipo {{kind}}",
       "loading": "Carregando artefatos"
     },
+    "fileBadges": {
+      "artwork": "ART",
+      "audio": "ÁUD",
+      "file": "ARQ",
+      "video": "VÍD"
+    },
     "googleDrive": {
       "agentLoading": "O agente ainda está carregando",
       "connect": "Conectar o Google Drive",
@@ -581,6 +598,7 @@
         "video": "vídeo"
       },
       "siteLabel": "Visualização do site {{title}}",
+      "slideTitle": "Slide {{number}}",
       "unavailable": "Visualização de {{kind}} indisponível.",
       "videoLabel": "Visualização de vídeo de {{filename}}"
     },
@@ -622,6 +640,27 @@
       "slideThumbnail": "Visualização do slide {{slideNumber}} de {{title}}",
       "template": "Modelo",
       "theme": "Tema",
+      "themeNames": {
+        "bauhausPrimary": "Blocos de montar",
+        "berryPop": "Refrigerante de framboesa",
+        "carnival": "Parque de diversões",
+        "citrusFresh": "Suco de laranja",
+        "coralStudio": "Estúdio pêssego",
+        "forestEditorial": "Biblioteca de musgo",
+        "goldLuxe": "Noite de premiação",
+        "mauveDusk": "Crepúsculo lavanda",
+        "midnightMono": "Corrida noturna",
+        "mintTech": "Laboratório menta",
+        "monoInk": "Vermelho jornal",
+        "nordicFrost": "Lago de gelo",
+        "oceanDeep": "Mergulho profundo",
+        "popArt": "Fliperama neon",
+        "prism": "Festa de doces",
+        "slateCorporate": "Azul corporativo",
+        "sunsetMaroon": "Brilho do pôr do sol",
+        "terracottaClay": "Vaso de barro",
+        "warmSand": "Jornal da manhã"
+      },
       "tryDifferentSearch": "Tente outra busca.",
       "use": "Usar",
       "useThisTemplate": "Usar este modelo",
@@ -1045,6 +1084,7 @@
       "imageUnavailable": "[Imagem indisponível: {{filename}}]",
       "importing": "Importando anexo",
       "invalidLink": "Insira um link válido",
+      "linkPlaceholder": "https://example.com/image.png",
       "loadingFile": "Carregando {{filename}}",
       "previewFile": "Visualizar {{filename}}",
       "supportedTypes": "Imagens, documentos, áudio, vídeo e arquivos compactados",
@@ -1260,6 +1300,8 @@
       "sourcePartsHeading_other": "Feedback sobre {{count}} partes de {{description}}:"
     },
     "mail": {
+      "bcc": "cco",
+      "cc": "cc",
       "closeDetails": "Fechar detalhes do e-mail",
       "deleted": "Este rascunho foi excluído.",
       "deletedEmail": "E-mail excluído: {{subject}}",
@@ -1301,10 +1343,12 @@
     },
     "newChat": "Nova conversa",
     "origins": {
+      "feishu": "Feishu",
       "openChat": "Abrir conversa",
       "openFeishuChat": "Abrir conversa original no Feishu",
       "openMessage": "Abrir mensagem",
-      "openSlackMessage": "Abrir mensagem original no Slack"
+      "openSlackMessage": "Abrir mensagem original no Slack",
+      "slack": "Slack"
     },
     "permissions": {
       "actionDescription": "{{action}} {{permissionName}}",
@@ -1329,6 +1373,7 @@
       "updated": "Permissões atualizadas",
       "updateFailed": "Não foi possível atualizar as permissões"
     },
+    "promptDocumentTitle": "Prompt",
     "queue": {
       "aboutAutomationEvent": "Sobre este evento de automação",
       "aboutGoal": "Sobre este objetivo",
@@ -1573,6 +1618,7 @@
       "failedTitle": "Não foi possível conectar {{connector}}",
       "finishing": "Finalizando a conexão segura",
       "genericLabel": "Conector",
+      "githubLabel": "GitHub",
       "invalidUrl": "A URL de callback do conector é inválida.",
       "success": "Conectado"
     },
@@ -1810,7 +1856,8 @@
         "created": "\"{{connector}}\" criado",
         "deleted": "Conector personalizado excluído",
         "disconnected": "Desconectado",
-        "renamed": "Renomeado para \"{{connector}}\""
+        "renamed": "Renomeado para \"{{connector}}\"",
+        "updated": "\"{{connector}}\" atualizado"
       },
       "updateConfirm": {
         "action": "Salvar e desconectar",
@@ -1822,6 +1869,7 @@
       "configure": "Configurar {{connector}}",
       "descriptionAgent": "Ao salvar, seus valores serão conectados e {{agent}} será autorizado.",
       "descriptionUser": "Ao salvar, este conector personalizado será conectado à sua conta.",
+      "documentTitle": "Configurar conector personalizado",
       "invalid": "Este link de proposta de conector personalizado é inválido ou expirou.",
       "requestScope": "Escopo da solicitação",
       "returnToChat": "Volte ao chat e responda ACK para que o agente possa verificar o conector.",
@@ -1833,6 +1881,8 @@
     "directed": {
       "authorizeAgent": "Autorizar {{agent}}",
       "authorized": "{{connector}} autorizado",
+      "authorizeDocumentTitle": "Autorizar {{connector}}",
+      "connectDocumentTitle": "Conectar {{connector}}",
       "connected": "{{connector}} conectado",
       "needsConnector": "{{agent}} precisa de {{connector}} para continuar",
       "reconnecting": "Reconectando..."
@@ -1893,6 +1943,7 @@
         "back": "Voltar para {{brandName}}",
         "connectDescription": "Vincule este número de telefone à sua conta do {{brandName}} para interagir com o Zero por mensagens de texto.",
         "connectTitle": "Conectar número de telefone",
+        "documentTitle": "Conectar mensagens",
         "errorFallback": "Não foi possível conectar este número de telefone. Tente novamente pelas suas mensagens de texto.",
         "incompleteDescription": "Abra um novo link /connect nas suas mensagens de texto.",
         "incompleteTitle": "O link de conexão está incompleto",
@@ -1968,6 +2019,7 @@
         "connectTitle": "Conectar o Microsoft Teams",
         "invalidDescription": "Esta página deve ser aberta por um link de conexão do Microsoft Teams.",
         "open": "Abrir Teams",
+        "providerName": "Microsoft Teams",
         "successDescription": "Você está conectado a {{team}}. Mencione @Zero no Teams para começar a conversar.",
         "successTitle": "Conectado ao Microsoft Teams"
       },
@@ -1977,6 +2029,7 @@
         "alreadyTitle": "Já conectado ao Telegram",
         "back": "Voltar para as configurações do Telegram",
         "botFallback": "este bot",
+        "botFatherHandle": "@BotFather",
         "checkingConnectionDescription": "Aguarde enquanto verificamos sua conexão com o Telegram.",
         "checkingConnectionTitle": "Verificando a conexão...",
         "checkingDomain": "Verificando o status do domínio...",
@@ -2001,6 +2054,7 @@
         "open": "Abrir Telegram",
         "openBotFather": "Abrir BotFather",
         "refresh": "Atualize esta página e tente novamente.",
+        "setDomainCommand": "/setdomain",
         "signInButton": "Entrar no {{brandName}}",
         "signInCheckFailed": "Não foi possível verificar o login",
         "signInDescription": "Entre com sua conta do {{brandName}} antes de conectar este usuário do Telegram.",
@@ -2130,6 +2184,7 @@
         "defaultAgentAria": "Agente padrão para {{appId}}",
         "developerConsole": "console de desenvolvedor do Feishu",
         "dialogAdminRequired": "Um administrador da organização deve configurar o app. Você poderá conectar sua própria conta pela lista de bots do Feishu após a conclusão da configuração.",
+        "documentTitle": "Feishu",
         "emptyAdmin": "Adicione um app personalizado para encaminhar mensagens do Feishu a um agente.",
         "emptyMember": "Peça a um administrador da organização para adicionar um bot do Feishu.",
         "emptyTitle": "Ainda não há bots do Feishu",
@@ -2260,6 +2315,7 @@
         "botFallback": "Bot do Telegram",
         "bots": "Bots do Telegram",
         "botToken": "Token do bot",
+        "botTokenPlaceholder": "123456:ABC-DEF",
         "checking": "Verificando...",
         "copied": "copiado!",
         "copyAria": "Copiar {{value}}",
@@ -2271,6 +2327,7 @@
         },
         "defaultAgent": "Agente padrão",
         "disconnectAria": "Desconectar {{bot}}",
+        "documentTitle": "Telegram",
         "domain": {
           "detected": "Domínio detectado",
           "instructionAfter": ", escolha este bot e defina o domínio como ",
@@ -2371,6 +2428,7 @@
   },
   "global": {
     "errors": {
+      "httpStatus": "HTTP {{status}}",
       "requestFailed": "Falha na solicitação"
     },
     "realtime": {
@@ -3918,10 +3976,18 @@
       "settings": "Configurações",
       "signOut": "Sair",
       "subscriptions": {
+        "providers": {
+          "claudeCode": "Claude Code",
+          "codex": "Codex"
+        },
         "reset": "Redefinir",
         "resetTimeUnavailable": "Horário de redefinição indisponível",
         "usage": "Uso de {{provider}}",
-        "usageRemaining": "{{provider}}: {{window}} restante"
+        "usageRemaining": "{{provider}}: {{window}} restante",
+        "windows": {
+          "fiveHour": "5h",
+          "week": "Semana"
+        }
       },
       "switchAccount": "Trocar de conta",
       "userFallback": "Usuário"
@@ -4106,6 +4172,7 @@
         "status": {
           "connected": "Conectado",
           "connectedWithDetail": "Conectado ({{detail}})",
+          "fiveHour": "5h",
           "left": "{{percent}} restante",
           "stale": "Atenção",
           "week": "Semana"
@@ -4130,6 +4197,11 @@
         },
         "prioritizeSpeed": "Prioriza a velocidade",
         "pro": "Pro",
+        "providerLabels": {
+          "azureFoundryPortal": "Portal do Azure Foundry",
+          "claudeCodeOauth": "Claude Code (token OAuth)",
+          "deepseek": "Deepseek"
+        },
         "runSpeed": "Velocidade de execução",
         "standard": "Padrão"
       },
@@ -4234,6 +4306,10 @@
       "language": {
         "description": "Escolha seu idioma preferido para a interface do {{brandName}}",
         "label": "Idioma",
+        "options": {
+          "english": "English",
+          "portugueseBrazil": "Português (Brasil)"
+        },
         "title": "Idioma"
       },
       "morningBrief": {
@@ -4539,6 +4615,7 @@
         "addDescriptionUpdated": "Execute este fluxo de trabalho quando um evento do Google Calendar for atualizado.",
         "addTitle": "Adicionar automação do Google Calendar",
         "calendarId": "ID do calendário",
+        "calendarIdPlaceholder": "primary",
         "cancelledDescription": "Execute quando um evento do calendário for cancelado.",
         "cancelledRule": "Quando um evento do calendário {{calendar}} for cancelado",
         "cancelledTitle": "Evento do Google Calendar cancelado",
@@ -4559,6 +4636,7 @@
         "anyStatus": "Qualquer status de término",
         "patternHint": "Curinga * opcional comparado com a resposta final da execução. Deixe vazio para corresponder a qualquer saída.",
         "patternLabel": "Padrão de saída",
+        "patternPlaceholder": "*falha no deploy*",
         "runFinishedDescription": "Executar quando uma execução em uma de suas threads de chat terminar.",
         "runFinishedTitle": "Execução de chat concluída",
         "statusCancelled": "Cancelada",
@@ -4610,6 +4688,7 @@
         "actorAnyone": "Qualquer pessoa",
         "actorMe": "Eu",
         "actors": "Atores",
+        "actorsPlaceholder": "octocat, dependabot[bot]",
         "addLabelAction": "Adicionar automação de rótulo",
         "addLabelAria": "Adicionar automação de rótulo do GitHub",
         "addLabelDescription": "Execute este fluxo de trabalho quando um rótulo do GitHub for aplicado.",
@@ -4635,14 +4714,19 @@
         "anyReviewState": "Qualquer status de revisão",
         "anyWorkflow": "Qualquer fluxo de trabalho",
         "apps": "GitHub Apps",
+        "appsPlaceholder": "vercel, 12345",
+        "authorsPlaceholder": "octocat, e7h4n",
         "authorsSummary": "Autores {{values}}",
         "aWorkflow": "um fluxo de trabalho do GitHub",
         "baseBranches": "Branches base",
         "branches": "Branches",
+        "branchesPlaceholder": "main, release",
         "commentPrefixes": "Prefixos de comentário",
+        "commentPrefixesPlaceholder": "/zero, /verify, /deploy",
         "conclusions": "Conclusões",
         "conclusionsSummary": "Conclusões {{values}}",
         "creators": "Criadores",
+        "creatorsPlaceholder": "octocat, 12345",
         "deploymentStates": "Status de implantação",
         "deploymentStatesSummary": "Status de implantação {{values}}",
         "deploymentStatusDescription": "Execute quando um status de implantação correspondente for criado.",
@@ -4652,10 +4736,13 @@
         "editWebhookFilters": "Editar filtros de {{title}}",
         "editWorkflowFilters": "Editar filtros do fluxo de trabalho do GitHub",
         "environments": "Ambientes",
+        "environmentsPlaceholder": "Preview, Production",
         "environmentsSummary": "Ambientes {{values}}",
         "events": "Eventos de acionamento",
+        "eventsPlaceholder": "push, pull_request, workflow_dispatch",
         "filterHelp": "Deixe um filtro vazio para corresponder a qualquer valor. Separe vários valores com vírgulas.",
         "headBranches": "Branches de origem",
+        "headBranchesPlaceholder": "feature/, dependabot/",
         "installAdminRequired": "Peça a um administrador da organização para instalá-lo.",
         "installApp": "Instalar o GitHub App",
         "installedRequired": "O GitHub não está instalado neste espaço de trabalho.",
@@ -4665,12 +4752,14 @@
         "issuesAndPullRequests": "Issues e pull requests",
         "issuesOnly": "Somente issues",
         "jobs": "Jobs",
+        "jobsPlaceholder": "test, build",
         "jobsSummary": "Jobs {{values}}",
         "labelAppliedDescription": "Execute quando uma issue ou pull request receber um rótulo.",
         "labelAppliedRule": "Quando o rótulo do GitHub {{label}} for aplicado",
         "labelAppliedTitle": "Rótulo do GitHub aplicado",
         "labelName": "Nome do rótulo",
         "labelOnlySummary": "Rótulo {{label}}",
+        "labelPlaceholder": "triagem",
         "labelSummary": "Rótulo {{label}} · {{subject}} · Ator {{actor}}",
         "loadError": "Não foi possível carregar as configurações do GitHub.",
         "nonProductionOnly": "Somente não produção",
@@ -4698,14 +4787,18 @@
         "productionOnly": "Somente produção",
         "pullRequestsOnly": "Somente pull requests",
         "refs": "Refs",
+        "refsPlaceholder": "main, v1.0.0",
         "repositories": "Repositórios",
+        "repositoriesPlaceholder": "vm0-ai/vm0, owner/another-repo",
         "repositoriesSummary": "Repositórios {{values}}",
         "reviewDescription": "Execute quando uma revisão correspondente for enviada.",
         "reviewRule": "Quando uma revisão correspondente de pull request for enviada no GitHub",
         "reviewStates": "Status de revisão",
         "reviewTitle": "Revisão de pull request do GitHub enviada",
         "runnerGroups": "Grupos de runners",
+        "runnerGroupsPlaceholder": "Default, production",
         "runnerLabels": "Rótulos de runners",
+        "runnerLabelsPlaceholder": "self-hosted, linux",
         "saveFilters": "Salvar filtros",
         "selectNoneAny": "Não selecione nada para corresponder a qualquer valor.",
         "selectNoneConclusion": "Não selecione nada para corresponder a qualquer conclusão.",
@@ -4723,6 +4816,8 @@
         "workflowRunRule": "Quando {{workflows}} for concluído{{conclusions}}",
         "workflowRunTitle": "Fluxo de trabalho do GitHub concluído",
         "workflows": "Fluxos de trabalho do GitHub",
+        "workflowsPlaceholder": "Turbo, .github/workflows/release.yml",
+        "workflowsShortPlaceholder": "Turbo, release",
         "workflowsSummary": "Fluxos de trabalho {{values}}"
       },
       "gmail": {
@@ -4753,6 +4848,7 @@
         "labelAppliedRule": "Quando o rótulo do Gmail {{label}} for aplicado",
         "labelAppliedTitle": "Rótulo do Gmail aplicado",
         "labelName": "Nome do rótulo",
+        "labelPlaceholder": "Suporte",
         "labelSummary": "Rótulo {{label}}",
         "messageMatchesRule": "Quando uma mensagem do Gmail corresponder a {{summary}}",
         "newMessageDescription": "Execute este fluxo de trabalho a partir de um e-mail correspondente.",
@@ -4813,11 +4909,13 @@
         "databaseUpdatedRule": "Quando o conteúdo de um item do banco de dados do Notion {{title}} for atualizado",
         "databaseUpdatedRuleGeneric": "Quando o conteúdo de um item de banco de dados do Notion for atualizado",
         "databaseUrl": "URL do banco de dados",
+        "databaseUrlPlaceholder": "https://www.notion.so/...",
         "page": "Página",
         "pageSummary": "Página {{title}}",
         "pageUpdatedRule": "Quando o conteúdo da página do Notion {{title}} for atualizado",
         "pageUpdatedRuleGeneric": "Quando o conteúdo de uma página do Notion for atualizado",
         "pageUrl": "URL da página",
+        "pageUrlPlaceholder": "https://www.notion.so/workspace/Page-title-...",
         "parentPageSummary": "Página principal {{title}}",
         "parentPageUrl": "URL da página principal",
         "scope": "Escopo"
@@ -4890,14 +4988,26 @@
         "connectFirst": "Conecte uma instância do Strapi antes de criar esta automação.",
         "contentType": "UID do tipo de conteúdo (opcional)",
         "contentTypeAny": "Qualquer tipo de conteúdo",
+        "contentTypePlaceholder": "api::article.article",
         "entryPublishedDescription": "Execute depois que uma entrada correspondente do Strapi for publicada.",
         "entryPublishedTitle": "Entrada do Strapi publicada",
         "instance": "Instância do Strapi",
         "locale": "Localidade (opcional)",
         "localeAny": "Qualquer localidade",
         "localeHint": "Deixe a localidade em branco para combinar todos os eventos de publicação localizados do mesmo documento em uma única execução do fluxo de trabalho.",
+        "localePlaceholder": "en",
         "localeSummary": "Localidade {{locale}}",
         "rule": "Quando uma entrada correspondente for publicada no Strapi"
+      },
+      "types": {
+        "chat": "Chat",
+        "github": "GitHub",
+        "gmail": "Gmail",
+        "googleCalendar": "Google Calendar",
+        "googleMeet": "Google Meet",
+        "notion": "Notion",
+        "strapi": "Strapi",
+        "webhook": "Webhook"
       },
       "webhook": {
         "addDescription": "Crie um endpoint assinado para este fluxo de trabalho.",
@@ -5027,6 +5137,7 @@
         "instructionPlaceholder": "Escreva as instruções do fluxo de trabalho...",
         "instructions": "instruções",
         "noContent": "Nenhum conteúdo disponível para este arquivo.",
+        "sizeBytes": "{{size}} B",
         "upload": "Enviar arquivos de texto",
         "uploadAria": "Enviar arquivos do fluxo de trabalho"
       },
@@ -5046,6 +5157,7 @@
         "saved": "Fluxo de trabalho salvo",
         "slug": "Slug",
         "slugHelp": "Use apenas letras minúsculas, números e -. Use {{command}} no chat para usar este fluxo de trabalho.",
+        "slugPlaceholder": "workflow-slug",
         "slugTitle": "Use apenas letras minúsculas, números e hifens",
         "visibility": "Visibilidade",
         "visibilityHelp": "Escolha como este fluxo de trabalho é compartilhado no seu espaço de trabalho."
@@ -5145,11 +5257,13 @@
       "description": "Comunicação e colaboração em equipe",
       "install": "Instalar no Slack",
       "permissionsUpdated": "As permissões do Slack foram atualizadas",
+      "title": "Slack",
       "uninstallDescription": "Isso removerá a integração com o Slack de todo o espaço de trabalho. Todos os usuários conectados serão desconectados, e {{displayName}} deixará de responder a mensagens ou menções no Slack. Essa ação não pode ser desfeita.",
       "uninstallTitle": "Desinstalar a integração com o Slack?"
     },
     "strapi": {
-      "description": "Automatize o trabalho quando entradas forem publicadas"
+      "description": "Automatize o trabalho quando entradas forem publicadas",
+      "title": "Strapi"
     },
     "teams": {
       "adminInstall": "Peça ao administrador para instalar a integração com o Microsoft Teams",
@@ -5160,13 +5274,15 @@
       "install": "Instalar no Teams",
       "moreOptions": "Mais opções do Microsoft Teams",
       "permissionsUpdated": "As permissões do Microsoft Teams foram atualizadas",
+      "title": "Microsoft Teams",
       "uninstall": "Desinstalar Microsoft Teams",
       "uninstallDescription": "Isso removerá a integração com o Microsoft Teams do {{brandName}} neste espaço de trabalho. Todos os usuários conectados serão desconectados, e {{displayName}} deixará de responder a mensagens do Teams neste espaço até que um administrador reconecte a integração.",
       "uninstallTitle": "Desinstalar a integração com o Microsoft Teams?"
     },
     "telegram": {
       "description": "Encaminhe mensagens do Telegram para agentes",
-      "openSettings": "Abrir configurações do Telegram"
+      "openSettings": "Abrir configurações do Telegram",
+      "title": "Telegram"
     }
   }
 }

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1,11 +1,38 @@
 {
   "activity": {
     "codex": {
+      "codexError": "Erro do Codex",
       "commandStatus": "Comando {{status}}",
+      "error": "Erro: {{error}}",
+      "fileChangeKind": "alteração",
       "fileOperationCompleted": "Operação de arquivo concluída",
       "fileOperationStatus": "Operação de arquivo {{status}}",
       "fileReadCompleted": "Leitura de arquivo concluída",
-      "fileReadStatus": "Leitura de arquivo {{status}}"
+      "fileReadStatus": "Leitura de arquivo {{status}}",
+      "filesChanged": "[arquivos] Arquivos alterados:",
+      "genericEvent": "Codex {{eventType}}",
+      "genericItem": "Codex {{label}} ({{details}}){{suffix}}",
+      "idDetail": "ID: {{id}}",
+      "item": "item",
+      "moreChanges_one": "- ... +mais {{count}} alteração",
+      "moreChanges_many": "- ... +mais {{count}} alterações",
+      "moreChanges_other": "- ... +mais {{count}} alterações",
+      "moreSteps_one": "- ... +mais {{count}} etapa",
+      "moreSteps_many": "- ... +mais {{count}} etapas",
+      "moreSteps_other": "- ... +mais {{count}} etapas",
+      "planPrefix": "[plano]",
+      "planStatus": {
+        "completed": "concluída",
+        "inProgress": "em andamento",
+        "pending": "pendente",
+        "step": "etapa"
+      },
+      "status": "Status: {{status}}",
+      "statusDetail": "status: {{status}}",
+      "turnFailed": "A interação falhou",
+      "turnStatus": "Interação {{status}}",
+      "warning": "[aviso] {{message}}",
+      "warningFallback": "Aviso do Codex"
     },
     "context": {
       "artifact": "Artefato",
@@ -139,6 +166,9 @@
       "models_one": "{{formattedCount}} modelo",
       "models_many": "{{formattedCount}} modelos",
       "models_other": "{{formattedCount}} modelos",
+      "moreItems_one": "... mais {{count}} item",
+      "moreItems_many": "... mais {{count}} itens",
+      "moreItems_other": "... mais {{count}} itens",
       "nameLabel": "nome:",
       "outputTokens": "saída: {{formattedCount}}",
       "remainingLines_one": "+{{formattedCount}} linha",
@@ -158,9 +188,11 @@
       "tools_one": "ferramenta",
       "tools_many": "ferramentas",
       "tools_other": "ferramentas",
+      "truncated": "truncado",
       "turns_one": "{{formattedCount}} turno",
       "turns_many": "{{formattedCount}} turnos",
-      "turns_other": "{{formattedCount}} turnos"
+      "turns_other": "{{formattedCount}} turnos",
+      "unknownTool": "Desconhecida"
     },
     "inspect": {
       "contextUnavailable": {
@@ -1340,6 +1372,11 @@
       },
       "toRecipients": "Para: {{recipients}}",
       "unavailable": "Este e-mail não está mais disponível."
+    },
+    "messageDocument": {
+      "chatThread": "[Conversa: {{title}}]",
+      "file": "[Arquivo: {{filename}}]",
+      "template": "[Modelo: {{title}}]"
     },
     "newChat": "Nova conversa",
     "origins": {
@@ -4543,6 +4580,16 @@
       "summary_other": "{{chats}} usaram {{credits}}",
       "title": "Conversas",
       "untitled": "(sem título)"
+    },
+    "displayNames": {
+      "auto": "Automático",
+      "finance": "Finanças",
+      "maps": "Mapas",
+      "peopleSearch": "Pesquisa de pessoas",
+      "usage": "Uso",
+      "weather": "Clima",
+      "webFetch": "Coleta da web",
+      "webSearch": "Pesquisa na web"
     },
     "kinds": {
       "connector": "Conectores",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1374,6 +1374,7 @@
       "unavailable": "Este e-mail não está mais disponível."
     },
     "messageDocument": {
+      "agent": "[Agente: {{name}}]",
       "chatThread": "[Conversa: {{title}}]",
       "file": "[Arquivo: {{filename}}]",
       "template": "[Modelo: {{title}}]"

--- a/turbo/apps/platform/src/lib/accept.ts
+++ b/turbo/apps/platform/src/lib/accept.ts
@@ -34,7 +34,15 @@ function extractError(
         : "UNKNOWN";
     return { message: body.error.message, code };
   }
-  return { message: `HTTP ${status}`, code: "UNKNOWN" };
+  return {
+    message: i18n.t(
+      ($) => {
+        return $.global.errors.httpStatus;
+      },
+      { status },
+    ),
+    code: "UNKNOWN",
+  };
 }
 
 function requestErrorMessage(error: unknown): string {

--- a/turbo/apps/platform/src/lib/credit-usage-display.ts
+++ b/turbo/apps/platform/src/lib/credit-usage-display.ts
@@ -1,29 +1,71 @@
 import { getModelDisplayName } from "@vm0/core/model-display-name";
+import { i18n } from "../i18n/index.ts";
 
-const MANAGED_USAGE_KIND_DISPLAY_NAMES: Readonly<Record<string, string>> = {
-  scrape: "Web Fetch",
-  maps: "Maps",
-  "web-search": "Web Search",
-  "people-search": "People Search",
-  finance: "Finance",
-  weather: "Weather",
-};
+const USAGE_DISPLAY_NAMES = {
+  auto(): string {
+    return i18n.t(($) => {
+      return $.usage.displayNames.auto;
+    });
+  },
+  finance(): string {
+    return i18n.t(($) => {
+      return $.usage.displayNames.finance;
+    });
+  },
+  maps(): string {
+    return i18n.t(($) => {
+      return $.usage.displayNames.maps;
+    });
+  },
+  peopleSearch(): string {
+    return i18n.t(($) => {
+      return $.usage.displayNames.peopleSearch;
+    });
+  },
+  weather(): string {
+    return i18n.t(($) => {
+      return $.usage.displayNames.weather;
+    });
+  },
+  webFetch(): string {
+    return i18n.t(($) => {
+      return $.usage.displayNames.webFetch;
+    });
+  },
+  webSearch(): string {
+    return i18n.t(($) => {
+      return $.usage.displayNames.webSearch;
+    });
+  },
+} as const;
+
+const MANAGED_USAGE_KIND_DISPLAY_NAMES: Readonly<Record<string, () => string>> =
+  {
+    scrape: USAGE_DISPLAY_NAMES.webFetch,
+    maps: USAGE_DISPLAY_NAMES.maps,
+    "web-search": USAGE_DISPLAY_NAMES.webSearch,
+    "people-search": USAGE_DISPLAY_NAMES.peopleSearch,
+    finance: USAGE_DISPLAY_NAMES.finance,
+    weather: USAGE_DISPLAY_NAMES.weather,
+  };
 
 // Current Settings responses retain raw usage kinds inside each provider.
 // Keep provider aliases for older APIs that only return the provider so app
 // and API promotions can serve different versions safely.
-const MANAGED_USAGE_PROVIDER_DISPLAY_NAMES: Readonly<Record<string, string>> = {
-  firecrawl: "Web Fetch",
-  "google-maps": "Maps",
-  openstreetmap: "Maps",
-  perplexity: "Web Search",
-  apidojo: "Finance",
-  "google-weather": "Weather",
-  "google-air-quality": "Weather",
+const MANAGED_USAGE_PROVIDER_DISPLAY_NAMES: Readonly<
+  Record<string, () => string>
+> = {
+  firecrawl: USAGE_DISPLAY_NAMES.webFetch,
+  "google-maps": USAGE_DISPLAY_NAMES.maps,
+  openstreetmap: USAGE_DISPLAY_NAMES.maps,
+  perplexity: USAGE_DISPLAY_NAMES.webSearch,
+  apidojo: USAGE_DISPLAY_NAMES.finance,
+  "google-weather": USAGE_DISPLAY_NAMES.weather,
+  "google-air-quality": USAGE_DISPLAY_NAMES.weather,
 };
 
-const MODEL_DISPLAY_NAMES: Readonly<Record<string, string>> = {
-  "vm0-model": "Auto",
+const MODEL_DISPLAY_NAMES: Readonly<Record<string, () => string>> = {
+  "vm0-model": USAGE_DISPLAY_NAMES.auto,
 };
 
 function titleCaseUsageToken(token: string): string {
@@ -35,10 +77,12 @@ function titleCaseUsageToken(token: string): string {
   return token.charAt(0).toUpperCase() + token.slice(1);
 }
 
-function formatUsageIdentifier(value: string): string {
+function formatUsageDisplayName(value: string): string {
   const normalized = value.trim();
   if (!normalized) {
-    return "Usage";
+    return i18n.t(($) => {
+      return $.usage.displayNames.usage;
+    });
   }
 
   return normalized
@@ -67,7 +111,7 @@ function stripUsageProviderPrefix(value: string): string {
 function usageModelDisplayName(model: string): string {
   const usageDisplayName = MODEL_DISPLAY_NAMES[model];
   if (usageDisplayName) {
-    return usageDisplayName;
+    return usageDisplayName();
   }
 
   const directDisplayName = getModelDisplayName(model);
@@ -81,7 +125,7 @@ function usageModelDisplayName(model: string): string {
     return strippedDisplayName;
   }
 
-  return formatUsageIdentifier(strippedModel);
+  return formatUsageDisplayName(strippedModel);
 }
 
 function usageKindBase(kind: string): string {
@@ -95,11 +139,11 @@ export function getCreditUsageDisplayName(
   const baseKind = usageKindBase(kind);
   const managedKindDisplayName = MANAGED_USAGE_KIND_DISPLAY_NAMES[baseKind];
   if (managedKindDisplayName) {
-    return managedKindDisplayName;
+    return managedKindDisplayName();
   }
 
   if (!provider || provider === "unknown") {
-    return formatUsageIdentifier(kind);
+    return formatUsageDisplayName(kind);
   }
 
   const normalizedProvider = provider.trim();
@@ -110,8 +154,8 @@ export function getCreditUsageDisplayName(
   const managedProviderDisplayName =
     MANAGED_USAGE_PROVIDER_DISPLAY_NAMES[normalizedProvider];
   if (managedProviderDisplayName) {
-    return managedProviderDisplayName;
+    return managedProviderDisplayName();
   }
 
-  return formatUsageIdentifier(normalizedProvider);
+  return formatUsageDisplayName(normalizedProvider);
 }

--- a/turbo/apps/platform/src/signals/__tests__/user-message-document-codec.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/user-message-document-codec.test.ts
@@ -4,8 +4,10 @@ import type {
   PersistedAttachment,
   UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
+import { initializeI18n } from "../../i18n/index.ts";
+import { DEFAULT_LOCALE } from "../../i18n/resources.ts";
 import { testContext } from "./test-helpers.ts";
 import { createDraftSignals } from "../zero-page/chat-draft.ts";
 import { createWorkflowComposerSignals } from "../zero-page/tiptap-workflow-composer.ts";
@@ -19,6 +21,10 @@ import {
 const context = testContext();
 const THREAD_ID = "1fe7f3cc-40b9-49f2-8f86-5f07d8d8dfd8";
 const MENTIONED_AGENT_ID = "a1000000-0000-4000-a000-000000000001";
+
+beforeAll(async () => {
+  await initializeI18n(DEFAULT_LOCALE);
+});
 
 function presentationTemplate(): GenerationTemplateRequest {
   return {

--- a/turbo/apps/platform/src/signals/__tests__/user-message-document-codec.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/user-message-document-codec.test.ts
@@ -148,6 +148,7 @@ describe("user message document codec", () => {
       `  Review [Project Alpha](/chats/${THREAD_ID}) with ` +
         `[Ada](/agents/${MENTIONED_AGENT_ID}/chat) then\ncontinue  \nlast`,
     );
+    expect(messageDocumentToDisplayText(structured)).toContain("[Agent: Ada]");
 
     const restored = messageDocumentToEditorDoc(structured);
     expect(restored).toStrictEqual({

--- a/turbo/apps/platform/src/signals/activity-page/codex-activity-normalizer.ts
+++ b/turbo/apps/platform/src/signals/activity-page/codex-activity-normalizer.ts
@@ -1,4 +1,5 @@
 import type { AgentEvent } from "../zero-page/log-types.ts";
+import { i18n } from "../../i18n/index.ts";
 
 interface NormalizeCodexEventsOptions {
   framework?: string | null;
@@ -1039,7 +1040,14 @@ function normalizeCodexCommandEvent(
       itemId,
       content:
         combineContentWithError(output, errorMessage) ??
-        (isFailedStatus(status) ? `Command ${status}` : ""),
+        (isFailedStatus(status)
+          ? i18n.t(
+              ($) => {
+                return $.activity.codex.commandStatus;
+              },
+              { status },
+            )
+          : ""),
       isError,
       durationMs: getFirstNumber(item, ["duration_ms", "durationMs"]),
     });
@@ -1082,8 +1090,15 @@ function normalizeCodexFileMutationEvent(
           errorMessage,
         ) ??
         (isFailedStatus(status)
-          ? `File operation ${status}`
-          : "File operation completed"),
+          ? i18n.t(
+              ($) => {
+                return $.activity.codex.fileOperationStatus;
+              },
+              { status },
+            )
+          : i18n.t(($) => {
+              return $.activity.codex.fileOperationCompleted;
+            })),
       isError: isFailedStatus(status) || errorMessage !== undefined,
       durationMs: getFirstNumber(item, ["duration_ms", "durationMs"]),
     });
@@ -1124,8 +1139,15 @@ function normalizeCodexFileReadEvent(
           errorMessage,
         ) ??
         (isFailedStatus(status)
-          ? `File read ${status}`
-          : "File read completed"),
+          ? i18n.t(
+              ($) => {
+                return $.activity.codex.fileReadStatus;
+              },
+              { status },
+            )
+          : i18n.t(($) => {
+              return $.activity.codex.fileReadCompleted;
+            })),
       isError: isFailedStatus(status) || errorMessage !== undefined,
       durationMs: getFirstNumber(item, ["duration_ms", "durationMs"]),
     });

--- a/turbo/apps/platform/src/signals/activity-page/codex-activity-normalizer.ts
+++ b/turbo/apps/platform/src/signals/activity-page/codex-activity-normalizer.ts
@@ -738,17 +738,35 @@ function formatCodexFileChanges(
 ): string | undefined {
   const lines: string[] = [];
   if (status && isFailedStatus(status)) {
-    lines.push(`Status: ${status}`);
+    lines.push(
+      i18n.t(
+        ($) => {
+          return $.activity.codex.status;
+        },
+        { status },
+      ),
+    );
   }
   if (errorMessage) {
-    lines.push(`Error: ${errorMessage}`);
+    lines.push(
+      i18n.t(
+        ($) => {
+          return $.activity.codex.error;
+        },
+        { error: errorMessage },
+      ),
+    );
   }
   if (changes.length === 0 && lines.length === 0) {
     return undefined;
   }
 
   for (const change of changes) {
-    const kind = change.kind ?? "change";
+    const kind =
+      change.kind ??
+      i18n.t(($) => {
+        return $.activity.codex.fileChangeKind;
+      });
     const description = change.path ? `${kind} ${change.path}` : kind;
     lines.push(`- ${description}`);
     if (change.diff) {
@@ -760,23 +778,46 @@ function formatCodexFileChanges(
     originalChangeCount - MAX_FORMATTED_FILE_CHANGES,
   );
   if (remaining > 0) {
-    lines.push(`- ... +${remaining} more changes`);
+    lines.push(
+      i18n.t(
+        ($) => {
+          return $.activity.codex.moreChanges;
+        },
+        { count: remaining },
+      ),
+    );
   }
 
-  return ["[files] Files changed:", ...lines].join("\n");
+  return [
+    i18n.t(($) => {
+      return $.activity.codex.filesChanged;
+    }),
+    ...lines,
+  ].join("\n");
 }
 
 function formatPlanStatus(status: string | undefined): string {
   if (status === "completed") {
-    return "completed";
+    return i18n.t(($) => {
+      return $.activity.codex.planStatus.completed;
+    });
   }
   if (status === "in_progress") {
-    return "in progress";
+    return i18n.t(($) => {
+      return $.activity.codex.planStatus.inProgress;
+    });
   }
   if (status === "pending") {
-    return "pending";
+    return i18n.t(($) => {
+      return $.activity.codex.planStatus.pending;
+    });
   }
-  return status ?? "step";
+  return (
+    status ??
+    i18n.t(($) => {
+      return $.activity.codex.planStatus.step;
+    })
+  );
 }
 
 function formatPlanLines(plan: unknown): string[] {
@@ -801,7 +842,14 @@ function formatPlanLines(plan: unknown): string[] {
   }
   const remaining = totalLineCount - MAX_FORMATTED_PLAN_STEPS;
   if (remaining > 0) {
-    lines.push(`- ... +${remaining} more steps`);
+    lines.push(
+      i18n.t(
+        ($) => {
+          return $.activity.codex.moreSteps;
+        },
+        { count: remaining },
+      ),
+    );
   }
   return lines;
 }
@@ -811,18 +859,41 @@ function formatGenericCodexItem(
   item: Record<string, unknown> | null,
 ): string {
   if (!item) {
-    return `Codex ${eventType}`;
+    return i18n.t(
+      ($) => {
+        return $.activity.codex.genericEvent;
+      },
+      { eventType },
+    );
   }
 
-  const label = getItemType(item) ?? "item";
+  const label =
+    getItemType(item) ??
+    i18n.t(($) => {
+      return $.activity.codex.item;
+    });
   const details: string[] = [];
   const status = getItemStatus(item);
   const id = getItemId(item);
   if (status) {
-    details.push(`status: ${status}`);
+    details.push(
+      i18n.t(
+        ($) => {
+          return $.activity.codex.statusDetail;
+        },
+        { status },
+      ),
+    );
   }
   if (id) {
-    details.push(`id: ${id}`);
+    details.push(
+      i18n.t(
+        ($) => {
+          return $.activity.codex.idDetail;
+        },
+        { id },
+      ),
+    );
   }
 
   const rawReadable =
@@ -887,7 +958,76 @@ function formatGenericCodexItem(
   details.push(...extraFields);
 
   const suffix = readable ? `\n${readable}` : "";
-  return `Codex ${label} (${eventType}${details.length > 0 ? `, ${details.join(", ")}` : ""})${suffix}`;
+  const formattedDetails = [eventType, ...details].join(", ");
+  return i18n.t(
+    ($) => {
+      return $.activity.codex.genericItem;
+    },
+    { label, details: formattedDetails, suffix },
+  );
+}
+
+function codexTurnFailureMessage(
+  eventData: Record<string, unknown>,
+  status?: string,
+): string {
+  const errorMessage = getTurnErrorMessage(eventData);
+  if (errorMessage) {
+    return errorMessage;
+  }
+  if (status && !isSuccessfulTurnCompletionStatus(status)) {
+    return i18n.t(
+      ($) => {
+        return $.activity.codex.turnStatus;
+      },
+      { status },
+    );
+  }
+  return i18n.t(($) => {
+    return $.activity.codex.turnFailed;
+  });
+}
+
+function codexErrorMessage(eventData: Record<string, unknown>): string {
+  return (
+    getTurnErrorMessage(eventData) ??
+    i18n.t(($) => {
+      return $.activity.codex.codexError;
+    })
+  );
+}
+
+function formatCodexWarning(eventData: Record<string, unknown>): string {
+  const message =
+    extractEventErrorMessage(eventData) ??
+    i18n.t(($) => {
+      return $.activity.codex.warningFallback;
+    });
+  return i18n.t(
+    ($) => {
+      return $.activity.codex.warning;
+    },
+    { message },
+  );
+}
+
+function formatCodexPlan(eventData: Record<string, unknown>): string | null {
+  const lines = formatPlanLines(eventData.plan);
+  const explanation = trimmedStringValue(eventData.explanation);
+  const contentLines = [explanation, ...lines].filter(
+    (line): line is string => {
+      return line !== undefined && line.length > 0;
+    },
+  );
+  if (contentLines.length === 0) {
+    return null;
+  }
+  return [
+    i18n.t(($) => {
+      return $.activity.codex.planPrefix;
+    }),
+    ...contentLines,
+  ].join("\n");
 }
 
 function normalizeCodexRunEvent(
@@ -915,12 +1055,7 @@ function normalizeCodexRunEvent(
         getTurnSuccess(eventData) === false ||
         isUnsuccessfulTurnCompletionStatus(status) ||
         hasTurnCompletionError(eventData);
-      const result = failed
-        ? (getTurnErrorMessage(eventData) ??
-          (status && !isSuccessfulTurnCompletionStatus(status)
-            ? `Turn ${status}`
-            : "Turn failed"))
-        : "";
+      const result = failed ? codexTurnFailureMessage(eventData, status) : "";
       return {
         event: makeCodexResultEvent({
           event,
@@ -941,7 +1076,7 @@ function normalizeCodexRunEvent(
         event: makeCodexResultEvent({
           event,
           success: false,
-          result: getTurnErrorMessage(eventData) ?? "Turn failed",
+          result: codexTurnFailureMessage(eventData),
           usage,
           durationMs,
           turnId,
@@ -957,7 +1092,7 @@ function normalizeCodexRunEvent(
         event: makeCodexResultEvent({
           event,
           success: false,
-          result: getTurnErrorMessage(eventData) ?? "Codex error",
+          result: codexErrorMessage(eventData),
           usage,
           durationMs,
           turnId,
@@ -971,28 +1106,16 @@ function normalizeCodexRunEvent(
       return {
         event: makeCodexAssistantTextEvent(
           event,
-          `[warning] ${extractEventErrorMessage(eventData) ?? "Codex warning"}`,
+          formatCodexWarning(eventData),
         ),
         codexType,
         turnId,
       };
     }
     case "turn.plan.updated": {
-      const lines = formatPlanLines(eventData.plan);
-      const explanation = trimmedStringValue(eventData.explanation);
-      const contentLines = [explanation, ...lines].filter(
-        (line): line is string => {
-          return line !== undefined && line.length > 0;
-        },
-      );
+      const content = formatCodexPlan(eventData);
       return {
-        event:
-          contentLines.length > 0
-            ? makeCodexAssistantTextEvent(
-                event,
-                ["[plan]", ...contentLines].join("\n"),
-              )
-            : null,
+        event: content ? makeCodexAssistantTextEvent(event, content) : null,
         codexType,
         turnId,
       };

--- a/turbo/apps/platform/src/signals/activity-page/log-detail-utils.ts
+++ b/turbo/apps/platform/src/signals/activity-page/log-detail-utils.ts
@@ -1,4 +1,5 @@
 import type { AgentEvent } from "../zero-page/log-types.ts";
+import { i18n } from "../../i18n/index.ts";
 import { normalizeCodexEventsForGrouping } from "./codex-activity-normalizer.ts";
 
 interface ToolResultContent {
@@ -71,7 +72,12 @@ function stringifyArrayJsonValue(
   if (value.length > MAX_STRINGIFY_ARRAY_ITEMS) {
     items.push(
       quoteJsonString(
-        `... ${value.length - MAX_STRINGIFY_ARRAY_ITEMS} more items`,
+        i18n.t(
+          ($) => {
+            return $.activity.events.moreItems;
+          },
+          { count: value.length - MAX_STRINGIFY_ARRAY_ITEMS },
+        ),
       ),
     );
   }
@@ -90,7 +96,13 @@ function stringifyObjectJsonValue(
       continue;
     }
     if (inspectedFields >= MAX_STRINGIFY_OBJECT_FIELDS) {
-      entries.push(`${quoteJsonString("...")}:${quoteJsonString("truncated")}`);
+      entries.push(
+        `${quoteJsonString("...")}:${quoteJsonString(
+          i18n.t(($) => {
+            return $.activity.events.truncated;
+          }),
+        )}`,
+      );
       break;
     }
     inspectedFields += 1;
@@ -782,7 +794,9 @@ function processToolResult(params: {
     toolOperations: [
       {
         toolUseId: toolUseId ?? fallbackToolUseIdValue,
-        toolName: "Unknown",
+        toolName: i18n.t(($) => {
+          return $.activity.events.unknownTool;
+        }),
         keyParam: "",
         input: {},
         result: {

--- a/turbo/apps/platform/src/signals/browser-authorization/browser-authorization-page-setup.ts
+++ b/turbo/apps/platform/src/signals/browser-authorization/browser-authorization-page-setup.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
 import { createElement } from "react";
 
+import { i18n } from "../../i18n/index.ts";
 import { BrowserAuthorizationPage } from "../../views/browser-authorization/browser-authorization-page.tsx";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
@@ -10,7 +11,12 @@ import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 export const setupBrowserAuthorizationPage$ = command(
   async ({ set }, signal: AbortSignal) => {
     set(updatePage$, createElement(BrowserAuthorizationPage), "minimal");
-    set(updateDocumentTitle$, "Enable cloud browser");
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.authorization.browser.title;
+      }),
+    );
     await set(hideAppSkeleton$, signal);
     if (await set(onboardGuard$, signal)) {
       return;

--- a/turbo/apps/platform/src/signals/chat-page/header-automation-menu.ts
+++ b/turbo/apps/platform/src/signals/chat-page/header-automation-menu.ts
@@ -71,7 +71,9 @@ function workflowAutomationSummary(
 ): string {
   if (automation.kind === "event") {
     if (automation.eventType === "chat-run-finished") {
-      return "Chat run finished";
+      return i18n.t(($) => {
+        return $.workflows.automations.chat.runFinishedTitle;
+      });
     }
     if (automation.eventType === "gmail-new-message") {
       return i18n.t(($) => {

--- a/turbo/apps/platform/src/signals/computer-use-authorization/computer-use-authorization-page-setup.ts
+++ b/turbo/apps/platform/src/signals/computer-use-authorization/computer-use-authorization-page-setup.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { i18n } from "../../i18n/index.ts";
 import { ComputerUseAuthorizationPage } from "../../views/computer-use-authorization/computer-use-authorization-page.tsx";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
@@ -9,7 +10,12 @@ import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 export const setupComputerUseAuthorizationPage$ = command(
   async ({ set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ComputerUseAuthorizationPage), "minimal");
-    set(updateDocumentTitle$, "Authorize computer use");
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.authorization.computerUse.title;
+      }),
+    );
     await set(hideAppSkeleton$, signal);
 
     if (await set(onboardGuard$, signal)) {

--- a/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
@@ -58,7 +58,11 @@ function connectorLabel(connectorSlug: ConnectorCallbackSlug | null): string {
       return $.connectors.callback.customConnectorLabel;
     });
   }
-  return connectorSlug === "github" ? "GitHub" : connectorSlug.toUpperCase();
+  return connectorSlug === "github"
+    ? i18n.t(($) => {
+        return $.connectors.callback.githubLabel;
+      })
+    : connectorSlug.toUpperCase();
 }
 
 function connectorCallbackDocumentTitle(label: string): string {

--- a/turbo/apps/platform/src/signals/connectors-page/connector-redirecting-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-redirecting-page-setup.ts
@@ -8,6 +8,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { command } from "ccstate";
 import { createElement } from "react";
+import { i18n } from "../../i18n/index.ts";
 import { ZeroConnectorRedirectingPage } from "../../views/zero-page/zero-connector-redirecting-page.tsx";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
@@ -67,7 +68,15 @@ export const setupConnectorRedirectingPage$ = command(
         status,
       }),
     );
-    set(updateDocumentTitle$, `Connect ${connectorLabel}`);
+    set(
+      updateDocumentTitle$,
+      i18n.t(
+        ($) => {
+          return $.connectors.callback.documentTitle;
+        },
+        { connector: connectorLabel },
+      ),
+    );
     await set(hideAppSkeleton$, signal);
     if (status === "redirecting") {
       await set(showConnectorRedirectingMobileWarningAfterDelay$, signal);

--- a/turbo/apps/platform/src/signals/connectors-page/connectors-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connectors-page-setup.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { i18n } from "../../i18n/index.ts";
 import { ZeroConnectorsPage } from "../../views/zero-page/zero-connectors-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
@@ -10,7 +11,12 @@ export const setupConnectorsPage$ = command(
   async ({ set }, signal: AbortSignal) => {
     set(migrateHiddenConnectorSlugsStorage$);
     set(updatePage$, createElement(ZeroConnectorsPage), "sidebar");
-    set(updateDocumentTitle$, "Connectors");
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.connectors.catalog.title;
+      }),
+    );
     await set(hideAppSkeleton$, signal);
 
     await set(onboardGuard$, signal);

--- a/turbo/apps/platform/src/signals/connectors-page/custom-connector-proposal-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/custom-connector-proposal-page-setup.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { i18n } from "../../i18n/index.ts";
 import { ZeroCustomConnectorProposalPage } from "../../views/zero-page/zero-custom-connector-proposal-page.tsx";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { resetCustomConnectorProposalForm$ } from "./custom-connector-proposal.ts";
@@ -15,7 +16,12 @@ export const setupCustomConnectorProposalPage$ = command(
 
     set(resetCustomConnectorProposalForm$);
     set(updatePage$, createElement(ZeroCustomConnectorProposalPage), "minimal");
-    set(updateDocumentTitle$, "Configure custom connector");
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.connectors.customProposal.documentTitle;
+      }),
+    );
     await set(hideAppSkeleton$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-page-setup.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { i18n } from "../../i18n/index.ts";
 import { ZeroDirectedAuthorizePage } from "../../views/zero-page/zero-directed-authorize-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
@@ -18,7 +19,15 @@ export const setupDirectedAuthorizePage$ = command(
       typeof params?.connectorSlug === "string" ? params.connectorSlug : "";
 
     set(updatePage$, createElement(ZeroDirectedAuthorizePage), "minimal");
-    set(updateDocumentTitle$, `Authorize ${connectorSlug}`);
+    set(
+      updateDocumentTitle$,
+      i18n.t(
+        ($) => {
+          return $.connectors.directed.authorizeDocumentTitle;
+        },
+        { connector: connectorSlug },
+      ),
+    );
     await set(hideAppSkeleton$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/connectors-page/directed-connect-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-connect-page-setup.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { i18n } from "../../i18n/index.ts";
 import { ZeroDirectedConnectPage } from "../../views/zero-page/zero-directed-connect-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
@@ -18,7 +19,15 @@ export const setupDirectedConnectPage$ = command(
       typeof params?.connectorSlug === "string" ? params.connectorSlug : "";
 
     set(updatePage$, createElement(ZeroDirectedConnectPage), "minimal");
-    set(updateDocumentTitle$, `Connect ${connectorSlug}`);
+    set(
+      updateDocumentTitle$,
+      i18n.t(
+        ($) => {
+          return $.connectors.directed.connectDocumentTitle;
+        },
+        { connector: connectorSlug },
+      ),
+    );
     await set(hideAppSkeleton$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-page-setup.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-page-setup.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { i18n } from "../../i18n/index.ts";
 import { PermissionAllowPage } from "../../views/permission-allow/permission-allow-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
@@ -10,7 +11,12 @@ import { hideAppSkeleton$ } from "../app-skeleton.ts";
 export const setupPermissionAllowPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(updatePage$, createElement(PermissionAllowPage), "minimal");
-    set(updateDocumentTitle$, "Permissions");
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.connectors.permissions.permissions;
+      }),
+    );
 
     const agentId = get(currentAgentId$);
     if (agentId) {

--- a/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
+++ b/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
@@ -7,6 +7,7 @@ import {
   findWebsiteTemplateItem,
   findVideoTemplateItem,
 } from "@vm0/core";
+import { i18n } from "../../i18n/index.ts";
 import { sendNewThread$ } from "../chat-page/optimistic-chat-thread-page.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { defaultAgentId$ } from "../agent.ts";
@@ -161,7 +162,12 @@ function generationTemplateFromSearchParam(
  */
 export const setupPromptPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    set(updateDocumentTitle$, "Prompt");
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.chat.promptDocumentTitle;
+      }),
+    );
     set(showAppSkeleton$);
 
     const params = get(searchParams$);

--- a/turbo/apps/platform/src/signals/zero-page/account-menu-subscriptions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/account-menu-subscriptions.ts
@@ -15,7 +15,6 @@ export type AccountMenuSubscriptionUsageWindow = NonNullable<
 
 export interface AccountMenuSubscriptionUsageRow {
   readonly type: ModelProviderType;
-  readonly label: string;
   readonly usage: AccountMenuSubscriptionUsage;
   readonly resetCredits?: number | null;
 }
@@ -23,11 +22,10 @@ export interface AccountMenuSubscriptionUsageRow {
 export type AccountMenuSubscriptionUsageRowsCacheKey = string | null;
 
 export const ACCOUNT_MENU_SUBSCRIPTION_PROVIDERS = [
-  { type: "codex-oauth-token", label: "Codex" },
-  { type: "claude-code-oauth-token", label: "Claude Code" },
+  { type: "codex-oauth-token" },
+  { type: "claude-code-oauth-token" },
 ] as const satisfies readonly {
   readonly type: ModelProviderType;
-  readonly label: string;
 }[];
 
 interface AccountMenuSubscriptionUsageRowsCache {
@@ -100,7 +98,7 @@ function accountMenuSubscriptionUsageRows(
     }
     return [
       {
-        ...definition,
+        type: definition.type,
         usage,
         resetCredits:
           provider.type === "codex-oauth-token"
@@ -114,17 +112,17 @@ function accountMenuSubscriptionUsageRows(
 export function accountMenuSubscriptionUsageWindows(
   usage: AccountMenuSubscriptionUsage | null | undefined,
 ): readonly {
-  readonly label: string;
+  readonly kind: "fiveHour" | "week";
   readonly window: AccountMenuSubscriptionUsageWindow;
 }[] {
   return [
-    { label: "5h", window: usage?.fiveHour ?? null },
-    { label: "week", window: usage?.weekly ?? null },
+    { kind: "fiveHour" as const, window: usage?.fiveHour ?? null },
+    { kind: "week" as const, window: usage?.weekly ?? null },
   ].filter(
     (
       item,
     ): item is {
-      label: string;
+      kind: "fiveHour" | "week";
       window: AccountMenuSubscriptionUsageWindow;
     } => {
       return hasUsageWindow(item.window);

--- a/turbo/apps/platform/src/signals/zero-page/agent-list-dialog-chat-threads.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-list-dialog-chat-threads.ts
@@ -1,6 +1,7 @@
 import { computed } from "ccstate";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import type { EventDrivenChatThread } from "@vm0/core/chat-thread-event-replay";
+import { i18n } from "../../i18n/index.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import {
   eventDrivenChatThreads$,
@@ -42,7 +43,11 @@ export const agentListDialogChatThreads$ = computed(
       readonly title: string;
     }[] = [];
     for (const thread of threads) {
-      const title = thread.title ?? "New chat";
+      const title =
+        thread.title ??
+        i18n.t(($) => {
+          return $.chat.newChat;
+        });
       if (query && !title.toLowerCase().includes(query)) {
         continue;
       }

--- a/turbo/apps/platform/src/signals/zero-page/agentphone-connect-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agentphone-connect-page.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { i18n } from "../../i18n/index.ts";
 import { capturePlausibleEvent } from "../../lib/plausible.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
@@ -21,7 +22,12 @@ export const setupAgentPhoneConnectPage$ = command(
     });
 
     set(updatePage$, createElement(ZeroAgentPhoneConnectPage));
-    set(updateDocumentTitle$, "Connect Messages");
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.connectors.providerConnect.agentphone.documentTitle;
+      }),
+    );
     await set(hideAppSkeleton$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/agentphone-connect-params.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agentphone-connect-params.ts
@@ -1,3 +1,5 @@
+import { i18n } from "../../i18n/index.ts";
+
 interface AgentPhoneConnectParams {
   phoneHandle: string;
   agentphoneAgentId: string;
@@ -68,7 +70,9 @@ function invalidParams(
     returnPath: "/agentphone/connect",
     error: {
       code,
-      title: "Connect link is invalid",
+      title: i18n.t(($) => {
+        return $.connectors.providerConnect.agentphone.invalidTitle;
+      }),
       message,
     },
   };
@@ -89,8 +93,12 @@ export function parseAgentPhoneConnectParams(
       returnPath: "/agentphone/connect",
       error: {
         code: "incomplete",
-        title: "Connect link is incomplete",
-        message: "Open a fresh /connect link from your text messages.",
+        title: i18n.t(($) => {
+          return $.connectors.providerConnect.agentphone.incompleteTitle;
+        }),
+        message: i18n.t(($) => {
+          return $.connectors.providerConnect.agentphone.incompleteDescription;
+        }),
       },
     };
   }
@@ -98,7 +106,9 @@ export function parseAgentPhoneConnectParams(
   if (!/^\d+$/.test(tsRaw)) {
     return invalidParams(
       "invalid_timestamp",
-      "The timestamp on this link is not valid.",
+      i18n.t(($) => {
+        return $.connectors.providerConnect.agentphone.invalidTimestamp;
+      }),
     );
   }
 
@@ -106,14 +116,18 @@ export function parseAgentPhoneConnectParams(
   if (!Number.isSafeInteger(timestamp) || timestamp <= 0) {
     return invalidParams(
       "invalid_timestamp",
-      "The timestamp on this link is not valid.",
+      i18n.t(($) => {
+        return $.connectors.providerConnect.agentphone.invalidTimestamp;
+      }),
     );
   }
 
   if (!/^[0-9a-f]{64}$/i.test(signature)) {
     return invalidParams(
       "invalid_signature",
-      "The signature on this link is not valid.",
+      i18n.t(($) => {
+        return $.connectors.providerConnect.agentphone.invalidSignature;
+      }),
     );
   }
 

--- a/turbo/apps/platform/src/signals/zero-page/clipboard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/clipboard.ts
@@ -2,6 +2,8 @@ import {
   userMessageDocumentSchema,
   type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { i18n } from "../../i18n/index.ts";
+import { SUPPORTED_LOCALES } from "../../i18n/resources.ts";
 import { jsonParseOr, settle, throwIfAbort, withCleanup } from "../utils.ts";
 
 const CHAT_MESSAGE_CLIPBOARD_ATTR = "data-vm0-chat-message";
@@ -85,6 +87,27 @@ function escapeHtml(value: string): string {
     .replace(/"/g, "&quot;");
 }
 
+function attachmentHeading(): string {
+  return i18n.t(($) => {
+    return $.chat.attachments.title;
+  });
+}
+
+function supportedAttachmentHeadings(): readonly string[] {
+  return Array.from(
+    new Set(
+      SUPPORTED_LOCALES.map((lng) => {
+        return i18n.t(
+          ($) => {
+            return $.chat.attachments.title;
+          },
+          { lng },
+        );
+      }),
+    ),
+  );
+}
+
 function formatPlainText(payload: ChatClipboardPayload): string {
   if (payload.attachments.length === 0) {
     return payload.text;
@@ -94,19 +117,22 @@ function formatPlainText(payload: ChatClipboardPayload): string {
       return `- ${attachment.filename}: ${attachment.url}`;
     })
     .join("\n");
-  return [payload.text.trim(), `Attachments:\n${attachments}`]
+  return [payload.text.trim(), `${attachmentHeading()}:\n${attachments}`]
     .filter(Boolean)
     .join("\n\n");
 }
 
 function textFromPlainClipboardFallback(plainText: string): string {
-  const attachmentsMarker = "\n\nAttachments:\n";
-  const markerIndex = plainText.indexOf(attachmentsMarker);
-  if (markerIndex !== -1) {
-    return plainText.slice(0, markerIndex).trim();
-  }
-  if (plainText.startsWith("Attachments:\n")) {
-    return "";
+  for (const heading of supportedAttachmentHeadings()) {
+    const standaloneMarker = `${heading}:\n`;
+    const attachmentsMarker = `\n\n${standaloneMarker}`;
+    const markerIndex = plainText.indexOf(attachmentsMarker);
+    if (markerIndex !== -1) {
+      return plainText.slice(0, markerIndex).trim();
+    }
+    if (plainText.startsWith(standaloneMarker)) {
+      return "";
+    }
   }
   return plainText.trim();
 }
@@ -124,7 +150,7 @@ function formatMessageHtml(payload: ChatClipboardPayload): string {
     })
     .join("");
   const attachmentsHtml = attachmentLinksHtml
-    ? `<div>Attachments:</div>${attachmentLinksHtml}`
+    ? `<div>${escapeHtml(attachmentHeading())}:</div>${attachmentLinksHtml}`
     : "";
   return `<div ${CHAT_MESSAGE_CLIPBOARD_ATTR}="${encoded}">${textHtml}${attachmentsHtml}</div>`;
 }

--- a/turbo/apps/platform/src/signals/zero-page/feishu-oauth-callback-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/feishu-oauth-callback-page.ts
@@ -3,6 +3,7 @@ import { createElement } from "react";
 import { zeroFeishuOauthContract } from "@vm0/api-contracts/contracts/zero-feishu-oauth";
 
 import { accept } from "../../lib/accept.ts";
+import { i18n } from "../../i18n/index.ts";
 import { FeishuOAuthCallbackPage } from "../../views/zero-page/feishu-oauth-callback-page.tsx";
 import { zeroClient$ } from "../api-client.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
@@ -21,7 +22,12 @@ export const setupFeishuOAuthCallbackPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const searchParams = get(searchParams$);
     set(updatePage$, createElement(FeishuOAuthCallbackPage));
-    set(updateDocumentTitle$, "Connect Feishu");
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.connectors.providerConnect.feishu.connectTitle;
+      }),
+    );
     await set(hideAppSkeleton$, signal);
 
     const client = get(zeroClient$)(zeroFeishuOauthContract, {

--- a/turbo/apps/platform/src/signals/zero-page/feishu-settings-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/feishu-settings-page.ts
@@ -2,6 +2,7 @@ import { command } from "ccstate";
 import { createElement } from "react";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
+import { i18n } from "../../i18n/index.ts";
 import { ZeroFeishuSettingsPage } from "../../views/zero-page/feishu-card.tsx";
 import { ZeroFeishuConnectPage } from "../../views/zero-page/zero-feishu-connect-page.tsx";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
@@ -36,7 +37,12 @@ export const setupFeishuSettingsPage$ = command(
 
     if (isAccountConnect) {
       set(updatePage$, createElement(ZeroFeishuConnectPage));
-      set(updateDocumentTitle$, "Connect Feishu");
+      set(
+        updateDocumentTitle$,
+        i18n.t(($) => {
+          return $.connectors.providerConnect.feishu.connectTitle;
+        }),
+      );
       await set(hideAppSkeleton$, signal);
       return;
     }
@@ -45,7 +51,12 @@ export const setupFeishuSettingsPage$ = command(
     set(reloadFeishuInstallations$);
     set(showFeishuSettingsResult$);
     set(updatePage$, createElement(ZeroFeishuSettingsPage), "sidebar");
-    set(updateDocumentTitle$, "Feishu");
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.connectors.providerSettings.feishu.documentTitle;
+      }),
+    );
 
     await Promise.all([
       set(hideAppSkeleton$, signal),

--- a/turbo/apps/platform/src/signals/zero-page/github-connect-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/github-connect-page.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { i18n } from "../../i18n/index.ts";
 import { capturePlausibleEvent } from "../../lib/plausible.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
@@ -23,7 +24,12 @@ export const setupGithubConnectPage$ = command(
     });
 
     set(updatePage$, createElement(ZeroGithubConnectPage));
-    set(updateDocumentTitle$, "Connect GitHub");
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.connectors.providerConnect.github.connectTitle;
+      }),
+    );
     await set(hideAppSkeleton$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/github-connect-params.ts
+++ b/turbo/apps/platform/src/signals/zero-page/github-connect-params.ts
@@ -1,3 +1,5 @@
+import { i18n } from "../../i18n/index.ts";
+
 export interface GithubConnectParams {
   installationId: string;
   githubUserId: string;
@@ -6,14 +8,16 @@ export interface GithubConnectParams {
   signature: string;
 }
 
+type GithubConnectParamErrorCode =
+  | "incomplete"
+  | "invalid_installation"
+  | "invalid_signature"
+  | "invalid_timestamp"
+  | "invalid_user"
+  | "invalid_username";
+
 interface GithubConnectParamError {
-  code:
-    | "incomplete"
-    | "invalid_installation"
-    | "invalid_signature"
-    | "invalid_timestamp"
-    | "invalid_user"
-    | "invalid_username";
+  code: GithubConnectParamErrorCode;
   title: string;
   message: string;
 }
@@ -56,6 +60,58 @@ function encodeReturnPath(params: GithubConnectParams): string {
   return `/github/connect?${search.toString()}`;
 }
 
+function githubConnectParamError(
+  code: GithubConnectParamErrorCode,
+): ParsedGithubConnectParams {
+  const title =
+    code === "incomplete"
+      ? i18n.t(($) => {
+          return $.connectors.providerConnect.github.linkIncompleteTitle;
+        })
+      : i18n.t(($) => {
+          return $.connectors.providerConnect.github.invalidTitle;
+        });
+  const message = (() => {
+    switch (code) {
+      case "incomplete": {
+        return i18n.t(($) => {
+          return $.connectors.providerConnect.github.linkIncomplete;
+        });
+      }
+      case "invalid_installation": {
+        return i18n.t(($) => {
+          return $.connectors.providerConnect.github.invalidInstallation;
+        });
+      }
+      case "invalid_signature": {
+        return i18n.t(($) => {
+          return $.connectors.providerConnect.github.invalidSignature;
+        });
+      }
+      case "invalid_timestamp": {
+        return i18n.t(($) => {
+          return $.connectors.providerConnect.github.invalidTimestamp;
+        });
+      }
+      case "invalid_user": {
+        return i18n.t(($) => {
+          return $.connectors.providerConnect.github.invalidUser;
+        });
+      }
+      case "invalid_username": {
+        return i18n.t(($) => {
+          return $.connectors.providerConnect.github.invalidUsername;
+        });
+      }
+    }
+  })();
+  return {
+    ok: false,
+    returnPath: "/github/connect",
+    error: { code, title, message },
+  };
+}
+
 export function parseGithubConnectParams(
   searchParams: SearchParams,
 ): ParsedGithubConnectParams {
@@ -68,88 +124,32 @@ export function parseGithubConnectParams(
   const signature = firstParam(searchParams, "sig")?.trim();
 
   if (!installationId || !githubUserId || !tsRaw || !signature) {
-    return {
-      ok: false,
-      returnPath: "/github/connect",
-      error: {
-        code: "incomplete",
-        title: "Connect link is incomplete",
-        message: "Open a fresh GitHub connect link and try again.",
-      },
-    };
+    return githubConnectParamError("incomplete");
   }
 
   if (!/^\d+$/.test(installationId)) {
-    return {
-      ok: false,
-      returnPath: "/github/connect",
-      error: {
-        code: "invalid_installation",
-        title: "Connect link is invalid",
-        message: "The GitHub installation on this link is not valid.",
-      },
-    };
+    return githubConnectParamError("invalid_installation");
   }
 
   if (!/^\d+$/.test(githubUserId)) {
-    return {
-      ok: false,
-      returnPath: "/github/connect",
-      error: {
-        code: "invalid_user",
-        title: "Connect link is invalid",
-        message: "The GitHub user on this link is not valid.",
-      },
-    };
+    return githubConnectParamError("invalid_user");
   }
 
   if (!/^\d+$/.test(tsRaw)) {
-    return {
-      ok: false,
-      returnPath: "/github/connect",
-      error: {
-        code: "invalid_timestamp",
-        title: "Connect link is invalid",
-        message: "The timestamp on this link is not valid.",
-      },
-    };
+    return githubConnectParamError("invalid_timestamp");
   }
 
   const timestamp = Number(tsRaw);
   if (!Number.isSafeInteger(timestamp) || timestamp <= 0) {
-    return {
-      ok: false,
-      returnPath: "/github/connect",
-      error: {
-        code: "invalid_timestamp",
-        title: "Connect link is invalid",
-        message: "The timestamp on this link is not valid.",
-      },
-    };
+    return githubConnectParamError("invalid_timestamp");
   }
 
   if (!/^[0-9a-f]{64}$/i.test(signature)) {
-    return {
-      ok: false,
-      returnPath: "/github/connect",
-      error: {
-        code: "invalid_signature",
-        title: "Connect link is invalid",
-        message: "The signature on this link is not valid.",
-      },
-    };
+    return githubConnectParamError("invalid_signature");
   }
 
   if (githubUsername && githubUsername.length > 255) {
-    return {
-      ok: false,
-      returnPath: "/github/connect",
-      error: {
-        code: "invalid_username",
-        title: "Connect link is invalid",
-        message: "The GitHub username on this link is not valid.",
-      },
-    };
+    return githubConnectParamError("invalid_username");
   }
 
   const params = {

--- a/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
@@ -210,7 +210,14 @@ export const updateCustomConnector$ = command(
     );
     signal.throwIfAborted();
     set(bumpReload$);
-    toast.success(`Updated "${result.body.displayName}"`);
+    toast.success(
+      i18n.t(
+        ($) => {
+          return $.connectors.custom.toasts.updated;
+        },
+        { connector: result.body.displayName },
+      ),
+    );
     return result.body;
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/slack-connect-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/slack-connect-page.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { i18n } from "../../i18n/index.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { ZeroSlackConnectPage } from "../../views/zero-page/zero-slack-connect-page.tsx";
@@ -14,7 +15,12 @@ export const setupSlackConnectPage$ = command(
     }
 
     set(updatePage$, createElement(ZeroSlackConnectPage));
-    set(updateDocumentTitle$, "Connect Slack");
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.connectors.providerConnect.slack.connectTitle;
+      }),
+    );
     await Promise.all([
       set(hideAppSkeleton$, signal),
       set(initSlackConnectPage$, signal),

--- a/turbo/apps/platform/src/signals/zero-page/teams-connect-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/teams-connect-page.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
 import { createElement } from "react";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { i18n } from "../../i18n/index.ts";
 import { ZeroTeamsConnectPage } from "../../views/zero-page/zero-teams-connect-page.tsx";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
@@ -24,7 +25,12 @@ export const setupTeamsConnectPage$ = command(
     }
 
     set(updatePage$, createElement(ZeroTeamsConnectPage));
-    set(updateDocumentTitle$, "Connect Microsoft Teams");
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.connectors.providerConnect.teams.connectTitle;
+      }),
+    );
 
     await Promise.all([
       set(hideAppSkeleton$, signal),

--- a/turbo/apps/platform/src/signals/zero-page/telegram-connect-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/telegram-connect-page.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { i18n } from "../../i18n/index.ts";
 import { capturePlausibleEvent } from "../../lib/plausible.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
@@ -27,7 +28,12 @@ export const setupTelegramConnectPage$ = command(
     });
 
     set(updatePage$, createElement(ZeroTelegramConnectPage));
-    set(updateDocumentTitle$, "Connect Telegram");
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.connectors.providerConnect.telegram.connectTitle;
+      }),
+    );
     await set(hideAppSkeleton$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/telegram-connect-params.ts
+++ b/turbo/apps/platform/src/signals/zero-page/telegram-connect-params.ts
@@ -1,3 +1,5 @@
+import { i18n } from "../../i18n/index.ts";
+
 export interface TelegramConnectParams {
   telegramBotId: string;
   connectSignature: {
@@ -9,13 +11,15 @@ export interface TelegramConnectParams {
   } | null;
 }
 
+type TelegramConnectParamErrorCode =
+  | "incomplete"
+  | "invalid_signature"
+  | "invalid_timestamp"
+  | "invalid_user"
+  | "invalid_username";
+
 interface TelegramConnectParamError {
-  code:
-    | "incomplete"
-    | "invalid_signature"
-    | "invalid_timestamp"
-    | "invalid_user"
-    | "invalid_username";
+  code: TelegramConnectParamErrorCode;
   title: string;
   message: string;
 }
@@ -88,6 +92,53 @@ function buildConnectSignature(params: {
   };
 }
 
+function telegramConnectParamError(
+  code: TelegramConnectParamErrorCode,
+): ParsedTelegramConnectParams {
+  const title =
+    code === "incomplete"
+      ? i18n.t(($) => {
+          return $.connectors.providerConnect.telegram.linkIncompleteTitle;
+        })
+      : i18n.t(($) => {
+          return $.connectors.providerConnect.telegram.invalidTitle;
+        });
+  const message = (() => {
+    switch (code) {
+      case "incomplete": {
+        return i18n.t(($) => {
+          return $.connectors.providerConnect.telegram.linkIncomplete;
+        });
+      }
+      case "invalid_signature": {
+        return i18n.t(($) => {
+          return $.connectors.providerConnect.telegram.invalidSignature;
+        });
+      }
+      case "invalid_timestamp": {
+        return i18n.t(($) => {
+          return $.connectors.providerConnect.telegram.invalidTimestamp;
+        });
+      }
+      case "invalid_user": {
+        return i18n.t(($) => {
+          return $.connectors.providerConnect.telegram.invalidUser;
+        });
+      }
+      case "invalid_username": {
+        return i18n.t(($) => {
+          return $.connectors.providerConnect.telegram.invalidUsername;
+        });
+      }
+    }
+  })();
+  return {
+    ok: false,
+    returnPath: "/telegram/connect",
+    error: { code, title, message },
+  };
+}
+
 export function parseTelegramConnectParams(
   searchParams: SearchParams,
 ): ParsedTelegramConnectParams {
@@ -103,15 +154,7 @@ export function parseTelegramConnectParams(
   const sig = firstParam(searchParams, "sig")?.trim();
 
   if (!bot) {
-    return {
-      ok: false,
-      returnPath: "/telegram/connect",
-      error: {
-        code: "incomplete",
-        title: "Connect link is incomplete",
-        message: "Open a fresh /connect link from Telegram and try again.",
-      },
-    };
+    return telegramConnectParamError("incomplete");
   }
 
   if (!tgUser && !tsRaw && !sig) {
@@ -124,76 +167,28 @@ export function parseTelegramConnectParams(
   }
 
   if (!tgUser || !tsRaw || !sig) {
-    return {
-      ok: false,
-      returnPath: "/telegram/connect",
-      error: {
-        code: "incomplete",
-        title: "Connect link is incomplete",
-        message: "Open a fresh /connect link from Telegram and try again.",
-      },
-    };
+    return telegramConnectParamError("incomplete");
   }
 
   if (!/^\d+$/.test(tgUser)) {
-    return {
-      ok: false,
-      returnPath: "/telegram/connect",
-      error: {
-        code: "invalid_user",
-        title: "Connect link is invalid",
-        message: "The Telegram user on this link is not valid.",
-      },
-    };
+    return telegramConnectParamError("invalid_user");
   }
 
   if (!/^\d+$/.test(tsRaw)) {
-    return {
-      ok: false,
-      returnPath: "/telegram/connect",
-      error: {
-        code: "invalid_timestamp",
-        title: "Connect link is invalid",
-        message: "The timestamp on this link is not valid.",
-      },
-    };
+    return telegramConnectParamError("invalid_timestamp");
   }
 
   const timestamp = Number(tsRaw);
   if (!Number.isSafeInteger(timestamp) || timestamp <= 0) {
-    return {
-      ok: false,
-      returnPath: "/telegram/connect",
-      error: {
-        code: "invalid_timestamp",
-        title: "Connect link is invalid",
-        message: "The timestamp on this link is not valid.",
-      },
-    };
+    return telegramConnectParamError("invalid_timestamp");
   }
 
   if (!/^[0-9a-f]{64}$/i.test(sig)) {
-    return {
-      ok: false,
-      returnPath: "/telegram/connect",
-      error: {
-        code: "invalid_signature",
-        title: "Connect link is invalid",
-        message: "The signature on this link is not valid.",
-      },
-    };
+    return telegramConnectParamError("invalid_signature");
   }
 
   if (telegramUsername && telegramUsername.length > 255) {
-    return {
-      ok: false,
-      returnPath: "/telegram/connect",
-      error: {
-        code: "invalid_username",
-        title: "Connect link is invalid",
-        message: "The Telegram username on this link is not valid.",
-      },
-    };
+    return telegramConnectParamError("invalid_username");
   }
 
   const params = {

--- a/turbo/apps/platform/src/signals/zero-page/telegram-settings-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/telegram-settings-page.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { i18n } from "../../i18n/index.ts";
 import {
   reloadTelegramBots$,
   resetTelegramSettingsUi$,
@@ -17,7 +18,12 @@ export const setupTelegramSettingsPage$ = command(
     set(resetTelegramSettingsUi$);
     set(reloadTelegramBots$);
     set(updatePage$, createElement(ZeroTelegramSettingsPage), "sidebar");
-    set(updateDocumentTitle$, "Telegram");
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.connectors.providerSettings.telegram.documentTitle;
+      }),
+    );
 
     await Promise.all([
       set(hideAppSkeleton$, signal),

--- a/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
+++ b/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
@@ -780,7 +780,12 @@ export function messageDocumentToDisplayText(
       continue;
     }
     if (part.type === "agent") {
-      inlineText += `[Agent: ${part.nameSnapshot}]`;
+      inlineText += i18n.t(
+        ($) => {
+          return $.chat.messageDocument.agent;
+        },
+        { name: part.nameSnapshot },
+      );
       continue;
     }
     if (part.type === "template") {

--- a/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
+++ b/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
@@ -11,6 +11,7 @@ import {
   type UserMessagePart,
 } from "@vm0/api-contracts/contracts/chat-threads";
 
+import { i18n } from "../../i18n/index.ts";
 import { formatFeedbackPrompt, type FeedbackSource } from "./chat-feedback.ts";
 import { serializeChatThreadMention } from "./chat-thread-suggestion-domain.ts";
 import {
@@ -770,7 +771,12 @@ export function messageDocumentToDisplayText(
       continue;
     }
     if (part.type === "chat_thread") {
-      inlineText += `[Chat thread: ${part.titleSnapshot}]`;
+      inlineText += i18n.t(
+        ($) => {
+          return $.chat.messageDocument.chatThread;
+        },
+        { title: part.titleSnapshot },
+      );
       continue;
     }
     if (part.type === "agent") {
@@ -778,17 +784,30 @@ export function messageDocumentToDisplayText(
       continue;
     }
     if (part.type === "template") {
+      const templateLabel = i18n.t(
+        ($) => {
+          return $.chat.messageDocument.template;
+        },
+        { title: part.titleSnapshot },
+      );
       if (options.inlineTemplates === true) {
-        inlineText += `[Template: ${part.titleSnapshot}]`;
+        inlineText += templateLabel;
       } else {
         flushInlineText();
-        blocks.push(`[Template: ${part.titleSnapshot}]`);
+        blocks.push(templateLabel);
       }
       continue;
     }
 
     flushInlineText();
-    blocks.push(`[File: ${part.filenameSnapshot}]`);
+    blocks.push(
+      i18n.t(
+        ($) => {
+          return $.chat.messageDocument.file;
+        },
+        { filename: part.filenameSnapshot },
+      ),
+    );
   }
   flushFeedback();
   flushInlineText();

--- a/turbo/apps/platform/src/views/auth/auth-layout.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-layout.tsx
@@ -399,7 +399,9 @@ export function AuthLayout({ children }: AuthLayoutProps) {
         <a href="/" className="absolute left-6 top-6 flex items-center gap-2">
           <img
             src={theme === "dark" ? platformVm0LogoImg : platformVm0LogoDarkImg}
-            alt="VM0"
+            alt={t(($) => {
+              return $.appShell.logoAlt;
+            })}
             width={82}
             height={20}
           />

--- a/turbo/apps/platform/src/views/export-page/export-page.tsx
+++ b/turbo/apps/platform/src/views/export-page/export-page.tsx
@@ -449,12 +449,16 @@ export function ExportPage() {
             </Link>
             <img
               src={platformVm0LogoDarkImg}
-              alt="VM0"
+              alt={t(($) => {
+                return $.appShell.logoAlt;
+              })}
               className="h-4 w-auto dark:hidden"
             />
             <img
               src={platformVm0LogoImg}
-              alt="VM0"
+              alt={t(($) => {
+                return $.appShell.logoAlt;
+              })}
               className="hidden h-4 w-auto dark:block"
             />
           </div>

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -1865,7 +1865,9 @@ function WorkflowMetadataFields({
             onPatch({ name: event.currentTarget.value });
           }}
           disabled={disabled}
-          placeholder="workflow-slug"
+          placeholder={i18n.t(($) => {
+            return $.workflows.detail.metadata.slugPlaceholder;
+          })}
           maxLength={64}
           required
           minLength={2}
@@ -2711,7 +2713,12 @@ function WorkflowFileNavigationItems({
           >
             <span className="min-w-0 truncate">{file.path}</span>
             <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-              {file.size} B
+              {i18n.t(
+                ($) => {
+                  return $.workflows.detail.files.sizeBytes;
+                },
+                { size: file.size },
+              )}
             </span>
           </DropdownMenuItem>
         );
@@ -5082,7 +5089,9 @@ function ChatRunFinishedAutomationFields({
         <Input
           name="outputPattern"
           disabled={creating}
-          placeholder="*deploy failed*"
+          placeholder={i18n.t(($) => {
+            return $.workflows.automations.chat.patternPlaceholder;
+          })}
         />
       </label>
       <p className="text-xs text-muted-foreground">
@@ -5439,14 +5448,22 @@ function StrapiAutomationForm({
         <Input
           name="contentTypeUid"
           disabled={creating}
-          placeholder="api::article.article"
+          placeholder={i18n.t(($) => {
+            return $.workflows.automations.strapi.contentTypePlaceholder;
+          })}
         />
       </label>
       <label className="flex flex-col gap-1 text-xs text-muted-foreground">
         {i18n.t(($) => {
           return $.workflows.automations.strapi.locale;
         })}
-        <Input name="locale" disabled={creating} placeholder="en" />
+        <Input
+          name="locale"
+          disabled={creating}
+          placeholder={i18n.t(($) => {
+            return $.workflows.automations.strapi.localePlaceholder;
+          })}
+        />
       </label>
       <p className="text-xs text-muted-foreground">
         {i18n.t(($) => {
@@ -5753,7 +5770,9 @@ function CreateNotionDatabaseItemAutomationDialog({
               })}
               required
               disabled={creating}
-              placeholder="https://www.notion.so/..."
+              placeholder={i18n.t(($) => {
+                return $.workflows.automations.notion.databaseUrlPlaceholder;
+              })}
             />
           </label>
           <DialogFooter>
@@ -5865,7 +5884,9 @@ function NotionPageContentUpdatedScopeFields({
             })}
             required
             disabled={creating}
-            placeholder="https://www.notion.so/workspace/Page-title-..."
+            placeholder={i18n.t(($) => {
+              return $.workflows.automations.notion.pageUrlPlaceholder;
+            })}
           />
         </label>
       ) : (
@@ -5880,7 +5901,9 @@ function NotionPageContentUpdatedScopeFields({
             })}
             required
             disabled={creating}
-            placeholder="https://www.notion.so/..."
+            placeholder={i18n.t(($) => {
+              return $.workflows.automations.notion.databaseUrlPlaceholder;
+            })}
           />
         </label>
       )}
@@ -6058,7 +6081,9 @@ function CreateNotionChildPageAutomationDialog({
               })}
               required
               disabled={creating}
-              placeholder="https://www.notion.so/workspace/Page-title-..."
+              placeholder={i18n.t(($) => {
+                return $.workflows.automations.notion.pageUrlPlaceholder;
+              })}
             />
           </label>
           <DialogFooter>
@@ -7225,7 +7250,9 @@ function CreateGmailLabelAppliedAutomationDialog({
               })}
               required
               disabled={creating}
-              placeholder="Support"
+              placeholder={i18n.t(($) => {
+                return $.workflows.automations.gmail.labelPlaceholder;
+              })}
             />
           </label>
           <DialogFooter>
@@ -7281,7 +7308,9 @@ function GithubLabelAutomationFields({
           required
           disabled={disabled}
           defaultValue={defaultConfig?.labelName ?? ""}
-          placeholder="triage"
+          placeholder={i18n.t(($) => {
+            return $.workflows.automations.github.labelPlaceholder;
+          })}
         />
       </label>
       <label className="flex flex-col gap-1 text-xs text-muted-foreground">
@@ -7356,49 +7385,59 @@ function GithubWorkflowRunAutomationFields({
 }) {
   const filters = defaultConfig?.filters;
   const fields: readonly {
-    readonly name: string;
+    readonly fieldName: string;
     readonly label: string;
     readonly placeholder: string;
     readonly defaultValues: readonly string[] | undefined;
   }[] = [
     {
-      name: "repositories",
+      fieldName: "repositories",
       label: i18n.t(($) => {
         return $.workflows.automations.github.repositories;
       }),
-      placeholder: "vm0-ai/vm0, owner/another-repo",
+      placeholder: i18n.t(($) => {
+        return $.workflows.automations.github.repositoriesPlaceholder;
+      }),
       defaultValues: filters?.repositories,
     },
     {
-      name: "workflows",
+      fieldName: "workflows",
       label: i18n.t(($) => {
         return $.workflows.automations.github.workflows;
       }),
-      placeholder: "Turbo, .github/workflows/release.yml",
+      placeholder: i18n.t(($) => {
+        return $.workflows.automations.github.workflowsPlaceholder;
+      }),
       defaultValues: filters?.workflows,
     },
     {
-      name: "branches",
+      fieldName: "branches",
       label: i18n.t(($) => {
         return $.workflows.automations.github.branches;
       }),
-      placeholder: "main, release",
+      placeholder: i18n.t(($) => {
+        return $.workflows.automations.github.branchesPlaceholder;
+      }),
       defaultValues: filters?.branches,
     },
     {
-      name: "events",
+      fieldName: "events",
       label: i18n.t(($) => {
         return $.workflows.automations.github.events;
       }),
-      placeholder: "push, pull_request, workflow_dispatch",
+      placeholder: i18n.t(($) => {
+        return $.workflows.automations.github.eventsPlaceholder;
+      }),
       defaultValues: filters?.events,
     },
     {
-      name: "actors",
+      fieldName: "actors",
       label: i18n.t(($) => {
         return $.workflows.automations.github.actors;
       }),
-      placeholder: "octocat, dependabot[bot]",
+      placeholder: i18n.t(($) => {
+        return $.workflows.automations.github.actorsPlaceholder;
+      }),
       defaultValues: filters?.actors,
     },
   ];
@@ -7412,12 +7451,12 @@ function GithubWorkflowRunAutomationFields({
       {fields.map((field) => {
         return (
           <label
-            key={field.name}
+            key={field.fieldName}
             className="flex flex-col gap-1 text-xs text-muted-foreground"
           >
             {field.label}
             <Input
-              name={field.name}
+              name={field.fieldName}
               aria-label={field.label}
               disabled={disabled}
               defaultValue={field.defaultValues?.join(", ") ?? ""}
@@ -7548,7 +7587,9 @@ function GithubWorkflowJobAutomationFields({
         label={i18n.t(($) => {
           return $.workflows.automations.github.workflows;
         })}
-        placeholder="Turbo, release"
+        placeholder={i18n.t(($) => {
+          return $.workflows.automations.github.workflowsShortPlaceholder;
+        })}
         defaultValues={config?.filters.workflows}
         disabled={disabled}
       />
@@ -7557,7 +7598,9 @@ function GithubWorkflowJobAutomationFields({
         label={i18n.t(($) => {
           return $.workflows.automations.github.jobs;
         })}
-        placeholder="test, build"
+        placeholder={i18n.t(($) => {
+          return $.workflows.automations.github.jobsPlaceholder;
+        })}
         defaultValues={config?.filters.jobs}
         disabled={disabled}
       />
@@ -7566,7 +7609,9 @@ function GithubWorkflowJobAutomationFields({
         label={i18n.t(($) => {
           return $.workflows.automations.github.branches;
         })}
-        placeholder="main, release"
+        placeholder={i18n.t(($) => {
+          return $.workflows.automations.github.branchesPlaceholder;
+        })}
         defaultValues={config?.filters.branches}
         disabled={disabled}
       />
@@ -7575,7 +7620,9 @@ function GithubWorkflowJobAutomationFields({
         label={i18n.t(($) => {
           return $.workflows.automations.github.runnerLabels;
         })}
-        placeholder="self-hosted, linux"
+        placeholder={i18n.t(($) => {
+          return $.workflows.automations.github.runnerLabelsPlaceholder;
+        })}
         defaultValues={config?.filters.runnerLabels}
         disabled={disabled}
       />
@@ -7584,7 +7631,9 @@ function GithubWorkflowJobAutomationFields({
         label={i18n.t(($) => {
           return $.workflows.automations.github.runnerGroups;
         })}
-        placeholder="Default, production"
+        placeholder={i18n.t(($) => {
+          return $.workflows.automations.github.runnerGroupsPlaceholder;
+        })}
         defaultValues={config?.filters.runnerGroups}
         disabled={disabled}
       />
@@ -7615,7 +7664,9 @@ function GithubReviewAutomationFields({
         label={i18n.t(($) => {
           return $.workflows.automations.github.baseBranches;
         })}
-        placeholder="main, release"
+        placeholder={i18n.t(($) => {
+          return $.workflows.automations.github.branchesPlaceholder;
+        })}
         defaultValues={config?.filters.baseBranches}
         disabled={disabled}
       />
@@ -7624,7 +7675,9 @@ function GithubReviewAutomationFields({
         label={i18n.t(($) => {
           return $.workflows.automations.github.headBranches;
         })}
-        placeholder="feature/, dependabot/"
+        placeholder={i18n.t(($) => {
+          return $.workflows.automations.github.headBranchesPlaceholder;
+        })}
         defaultValues={config?.filters.headBranches}
         disabled={disabled}
       />
@@ -7633,7 +7686,9 @@ function GithubReviewAutomationFields({
         label={i18n.t(($) => {
           return $.workflows.automations.github.trustedAuthors;
         })}
-        placeholder="octocat, e7h4n"
+        placeholder={i18n.t(($) => {
+          return $.workflows.automations.github.authorsPlaceholder;
+        })}
         defaultValues={config?.filters.trustedAuthors}
         disabled={disabled}
       />
@@ -7665,7 +7720,9 @@ function GithubDeploymentAutomationFields({
         label={i18n.t(($) => {
           return $.workflows.automations.github.environments;
         })}
-        placeholder="Preview, Production"
+        placeholder={i18n.t(($) => {
+          return $.workflows.automations.github.environmentsPlaceholder;
+        })}
         defaultValues={config?.filters.environments}
         disabled={disabled}
       />
@@ -7674,7 +7731,9 @@ function GithubDeploymentAutomationFields({
         label={i18n.t(($) => {
           return $.workflows.automations.github.refs;
         })}
-        placeholder="main, v1.0.0"
+        placeholder={i18n.t(($) => {
+          return $.workflows.automations.github.refsPlaceholder;
+        })}
         defaultValues={config?.filters.refs}
         disabled={disabled}
       />
@@ -7723,7 +7782,9 @@ function GithubDeploymentAutomationFields({
         label={i18n.t(($) => {
           return $.workflows.automations.github.creators;
         })}
-        placeholder="octocat, 12345"
+        placeholder={i18n.t(($) => {
+          return $.workflows.automations.github.creatorsPlaceholder;
+        })}
         defaultValues={config?.filters.creators}
         disabled={disabled}
       />
@@ -7732,7 +7793,9 @@ function GithubDeploymentAutomationFields({
         label={i18n.t(($) => {
           return $.workflows.automations.github.apps;
         })}
-        placeholder="vercel, 12345"
+        placeholder={i18n.t(($) => {
+          return $.workflows.automations.github.appsPlaceholder;
+        })}
         defaultValues={config?.filters.apps}
         disabled={disabled}
       />
@@ -7791,7 +7854,9 @@ function GithubCommentAutomationFields({
         label={i18n.t(($) => {
           return $.workflows.automations.github.trustedAuthors;
         })}
-        placeholder="octocat, e7h4n"
+        placeholder={i18n.t(($) => {
+          return $.workflows.automations.github.authorsPlaceholder;
+        })}
         defaultValues={config?.filters.trustedAuthors}
         disabled={disabled}
       />
@@ -7800,7 +7865,9 @@ function GithubCommentAutomationFields({
         label={i18n.t(($) => {
           return $.workflows.automations.github.commentPrefixes;
         })}
-        placeholder="/zero, /verify, /deploy"
+        placeholder={i18n.t(($) => {
+          return $.workflows.automations.github.commentPrefixesPlaceholder;
+        })}
         defaultValues={config?.filters.commentPrefixes}
         disabled={disabled}
       />
@@ -7877,7 +7944,9 @@ function GithubWebhookAutomationFields({
         label={i18n.t(($) => {
           return $.workflows.automations.github.repositories;
         })}
-        placeholder="vm0-ai/vm0, owner/another-repo"
+        placeholder={i18n.t(($) => {
+          return $.workflows.automations.github.repositoriesPlaceholder;
+        })}
         defaultValues={defaultConfig?.filters.repositories}
         disabled={disabled}
       />
@@ -8512,7 +8581,9 @@ function CreateGoogleCalendarEventAutomationDialog({
               aria-label={copy.calendarId}
               disabled={creating}
               defaultValue="primary"
-              placeholder="primary"
+              placeholder={i18n.t(($) => {
+                return $.workflows.automations.calendar.calendarIdPlaceholder;
+              })}
             />
           </label>
           <DialogFooter>
@@ -9765,7 +9836,9 @@ function UpdateGmailLabelAppliedAutomationForm({
           required
           defaultValue={automation.eventConfig.labelName}
           disabled={saving}
-          placeholder="Support"
+          placeholder={i18n.t(($) => {
+            return $.workflows.automations.gmail.labelPlaceholder;
+          })}
           className={AUTOMATION_FIELD_CLASS}
         />
       </label>

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -285,7 +285,9 @@ describe("chat lifecycle", () => {
     expect(screen.queryByLabelText("Credit usage 12")).not.toBeInTheDocument();
   });
 
-  it("keeps managed API usage visible when completed work is folded", async () => {
+  it("localizes managed API usage when completed work is folded", async () => {
+    document.documentElement.lang = "pt-BR";
+    await initializeI18n("pt-BR");
     mockChatLifecycle(context, {
       threadId: "thread-usage-chip-folded-managed-api",
       chatEvents: [
@@ -377,16 +379,18 @@ describe("chat lifecycle", () => {
       screen.queryByText("Inspecting managed API results."),
     ).not.toBeInTheDocument();
 
-    const managedApiCredit = await screen.findByLabelText("Credit usage 216");
+    const managedApiCredit = await screen.findByLabelText(
+      "Uso de créditos 216",
+    );
     click(managedApiCredit);
 
     await waitFor(() => {
-      expect(screen.getByText("Web Fetch")).toBeInTheDocument();
-      expect(screen.getByText("Maps")).toBeInTheDocument();
-      expect(screen.getByText("Web Search")).toBeInTheDocument();
-      expect(screen.getByText("People Search")).toBeInTheDocument();
-      expect(screen.getByText("Finance")).toBeInTheDocument();
-      expect(screen.getByText("Weather")).toBeInTheDocument();
+      expect(screen.getByText("Coleta da web")).toBeInTheDocument();
+      expect(screen.getByText("Mapas")).toBeInTheDocument();
+      expect(screen.getByText("Pesquisa na web")).toBeInTheDocument();
+      expect(screen.getByText("Pesquisa de pessoas")).toBeInTheDocument();
+      expect(screen.getByText("Finanças")).toBeInTheDocument();
+      expect(screen.getByText("Clima")).toBeInTheDocument();
       expect(screen.getAllByText("36")).toHaveLength(6);
       expect(screen.queryByText("Firecrawl")).not.toBeInTheDocument();
       expect(screen.queryByText("Google Maps")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
+import { initializeI18n } from "../../../../i18n/index.ts";
+import { DEFAULT_LOCALE } from "../../../../i18n/resources.ts";
 import type { AgentEvent } from "../../../../signals/zero-page/log-types.ts";
 import {
   groupEventsIntoGroups,
@@ -10,6 +12,10 @@ import {
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+
+beforeAll(async () => {
+  await initializeI18n(DEFAULT_LOCALE);
+});
 
 describe("groupEventsIntoGroups progress events", () => {
   it("filters Claude Code thinking token progress events", () => {

--- a/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
@@ -141,7 +141,13 @@ function TypeBadge({
   action?: NetworkLogEntry["action"];
 }) {
   if (action === "BLOCK") {
-    return <InlineBadge color="warning">BLOCK</InlineBadge>;
+    return (
+      <InlineBadge color="warning">
+        {i18n.t(($) => {
+          return $.activity.network.actions.block;
+        })}
+      </InlineBadge>
+    );
   }
 
   const denied = action === "DENY";
@@ -381,318 +387,319 @@ function hasValue(value: unknown): boolean {
   return true;
 }
 
-const NETWORK_DETAIL_LABELS: Readonly<Record<string, () => string>> =
-  Object.freeze({
-    Action: () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.action;
-      });
-    },
-    "Cache Hit": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.authCacheHit;
-      });
-    },
-    "Refreshed Connectors": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.authRefreshedConnectors;
-      });
-    },
-    "Refreshed Secrets": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.authRefreshedSecrets;
-      });
-    },
-    "Resolved Secrets": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.authResolvedSecrets;
-      });
-    },
-    "URL Rewrite": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.authUrlRewrite;
-      });
-    },
-    "Base URL": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.baseUrl;
-      });
-    },
-    Billable: () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.billable;
-      });
-    },
-    "Browser User-Agent": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.browserUserAgent;
-      });
-    },
-    "Connector Base URL": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.connectorBaseUrl;
-      });
-    },
-    "Connector Diagnostic": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.connectorDiagnostic;
-      });
-    },
-    "Connector Env Names": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.connectorEnvNames;
-      });
-    },
-    "Connector Reason": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.connectorReason;
-      });
-    },
-    "Connector Route Candidates": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.connectorRouteCandidates;
-      });
-    },
-    "Connector Route Reason": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.connectorRouteReason;
-      });
-    },
-    "DNS Event": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.dnsEvent;
-      });
-    },
-    "DNS Query Type": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.dnsQueryType;
-      });
-    },
-    "DNS Result": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.dnsResult;
-      });
-    },
-    "DNS Serial": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.dnsSerial;
-      });
-    },
-    Error: () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.error;
-      });
-    },
-    Firewall: () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.firewall;
-      });
-    },
-    Host: () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.host;
-      });
-    },
-    Latency: () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.latency;
-      });
-    },
-    Method: () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.method;
-      });
-    },
-    "Model Catalog Cache Bypass Reason": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.modelCatalogCacheBypassReason;
-      });
-    },
-    "Model Catalog Cache Entry Age": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.modelCatalogCacheEntryAge;
-      });
-    },
-    "Model Catalog Cache Eviction Count": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.modelCatalogCacheEvictionCount;
-      });
-    },
-    "Model Catalog Cache Status": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.modelCatalogCacheStatus;
-      });
-    },
-    "Model Catalog Cache Validation Latency": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.modelCatalogCacheValidationLatency;
-      });
-    },
-    "Model Catalog Prefetch Role": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.modelCatalogPrefetchRole;
-      });
-    },
-    "Model Catalog Upstream Encoding": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.modelCatalogUpstreamEncoding;
-      });
-    },
-    Params: () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.params;
-      });
-    },
-    Permission: () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.permission;
-      });
-    },
-    "Permission Error": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.permissionError;
-      });
-    },
-    Port: () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.port;
-      });
-    },
-    "Request Size": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.requestSize;
-      });
-    },
-    "Response Size": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.responseSize;
-      });
-    },
-    "Rule Match": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.ruleMatch;
-      });
-    },
-    Status: () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.status;
-      });
-    },
-    Timestamp: () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.timestamp;
-      });
-    },
-    Type: () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.type;
-      });
-    },
-    "Upstream Client Binding Count": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingClientBindingCount;
-      });
-    },
-    "Upstream Client Binding Endpoint Match": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details
-          .upstreamBindingClientBindingEndpointMatch;
-      });
-    },
-    "Upstream Client Binding Hosts": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingClientBindingHosts;
-      });
-    },
-    "Upstream Client Binding Match": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingClientBindingMatch;
-      });
-    },
-    "Upstream Binding Client ID": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingClientId;
-      });
-    },
-    "Upstream Binding Client Sockname": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingClientSockname;
-      });
-    },
-    "Upstream Direct Binding Host": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingDirectBindingHost;
-      });
-    },
-    "Upstream Direct Binding Kinds": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingDirectBindingKinds;
-      });
-    },
-    "Upstream Direct Binding Port": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingDirectBindingPort;
-      });
-    },
-    "Upstream Direct Binding Present": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingDirectBindingPresent;
-      });
-    },
-    "Upstream Binding Reason": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingReason;
-      });
-    },
-    "Upstream Binding Request Host": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingRequestHost;
-      });
-    },
-    "Upstream Binding Request Port": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingRequestPort;
-      });
-    },
-    "Upstream Binding Server Address": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingServerAddress;
-      });
-    },
-    "Upstream Binding Server Connected": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingServerConnected;
-      });
-    },
-    "Upstream Binding Server ID": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingServerId;
-      });
-    },
-    "Upstream Binding Server Peername": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingServerPeername;
-      });
-    },
-    "Upstream Binding Server Sockname": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingServerSockname;
-      });
-    },
-    "Upstream Binding Trusted Host": () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.upstreamBindingTrustedHost;
-      });
-    },
-    URL: () => {
-      return i18n.t(($) => {
-        return $.activity.network.details.url;
-      });
-    },
-  });
+const NETWORK_DETAIL_LABELS = Object.freeze({
+  action: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.action;
+    });
+  },
+  authCacheHit: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.authCacheHit;
+    });
+  },
+  authRefreshedConnectors: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.authRefreshedConnectors;
+    });
+  },
+  authRefreshedSecrets: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.authRefreshedSecrets;
+    });
+  },
+  authResolvedSecrets: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.authResolvedSecrets;
+    });
+  },
+  authUrlRewrite: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.authUrlRewrite;
+    });
+  },
+  baseUrl: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.baseUrl;
+    });
+  },
+  billable: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.billable;
+    });
+  },
+  browserUserAgent: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.browserUserAgent;
+    });
+  },
+  connectorBaseUrl: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.connectorBaseUrl;
+    });
+  },
+  connectorDiagnostic: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.connectorDiagnostic;
+    });
+  },
+  connectorEnvNames: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.connectorEnvNames;
+    });
+  },
+  connectorReason: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.connectorReason;
+    });
+  },
+  connectorRouteCandidates: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.connectorRouteCandidates;
+    });
+  },
+  connectorRouteReason: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.connectorRouteReason;
+    });
+  },
+  dnsEvent: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.dnsEvent;
+    });
+  },
+  dnsQueryType: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.dnsQueryType;
+    });
+  },
+  dnsResult: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.dnsResult;
+    });
+  },
+  dnsSerial: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.dnsSerial;
+    });
+  },
+  error: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.error;
+    });
+  },
+  firewall: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.firewall;
+    });
+  },
+  host: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.host;
+    });
+  },
+  latency: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.latency;
+    });
+  },
+  method: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.method;
+    });
+  },
+  modelCatalogCacheBypassReason: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.modelCatalogCacheBypassReason;
+    });
+  },
+  modelCatalogCacheEntryAge: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.modelCatalogCacheEntryAge;
+    });
+  },
+  modelCatalogCacheEvictionCount: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.modelCatalogCacheEvictionCount;
+    });
+  },
+  modelCatalogCacheStatus: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.modelCatalogCacheStatus;
+    });
+  },
+  modelCatalogCacheValidationLatency: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.modelCatalogCacheValidationLatency;
+    });
+  },
+  modelCatalogPrefetchRole: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.modelCatalogPrefetchRole;
+    });
+  },
+  modelCatalogUpstreamEncoding: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.modelCatalogUpstreamEncoding;
+    });
+  },
+  params: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.params;
+    });
+  },
+  permission: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.permission;
+    });
+  },
+  permissionError: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.permissionError;
+    });
+  },
+  port: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.port;
+    });
+  },
+  requestSize: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.requestSize;
+    });
+  },
+  responseSize: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.responseSize;
+    });
+  },
+  ruleMatch: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.ruleMatch;
+    });
+  },
+  status: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.status;
+    });
+  },
+  timestamp: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.timestamp;
+    });
+  },
+  type: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.type;
+    });
+  },
+  upstreamBindingClientBindingCount: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingClientBindingCount;
+    });
+  },
+  upstreamBindingClientBindingEndpointMatch: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details
+        .upstreamBindingClientBindingEndpointMatch;
+    });
+  },
+  upstreamBindingClientBindingHosts: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingClientBindingHosts;
+    });
+  },
+  upstreamBindingClientBindingMatch: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingClientBindingMatch;
+    });
+  },
+  upstreamBindingClientId: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingClientId;
+    });
+  },
+  upstreamBindingClientSockname: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingClientSockname;
+    });
+  },
+  upstreamBindingDirectBindingHost: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingDirectBindingHost;
+    });
+  },
+  upstreamBindingDirectBindingKinds: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingDirectBindingKinds;
+    });
+  },
+  upstreamBindingDirectBindingPort: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingDirectBindingPort;
+    });
+  },
+  upstreamBindingDirectBindingPresent: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingDirectBindingPresent;
+    });
+  },
+  upstreamBindingReason: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingReason;
+    });
+  },
+  upstreamBindingRequestHost: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingRequestHost;
+    });
+  },
+  upstreamBindingRequestPort: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingRequestPort;
+    });
+  },
+  upstreamBindingServerAddress: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingServerAddress;
+    });
+  },
+  upstreamBindingServerConnected: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingServerConnected;
+    });
+  },
+  upstreamBindingServerId: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingServerId;
+    });
+  },
+  upstreamBindingServerPeername: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingServerPeername;
+    });
+  },
+  upstreamBindingServerSockname: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingServerSockname;
+    });
+  },
+  upstreamBindingTrustedHost: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.upstreamBindingTrustedHost;
+    });
+  },
+  url: () => {
+    return i18n.t(($) => {
+      return $.activity.network.details.url;
+    });
+  },
+});
 
-function localizeNetworkDetailLabel(label: string): string {
-  return NETWORK_DETAIL_LABELS[label]?.() ?? label;
+type NetworkDetailLabelKey = keyof typeof NETWORK_DETAIL_LABELS;
+
+function localizeNetworkDetailLabel(labelKey: NetworkDetailLabelKey): string {
+  return NETWORK_DETAIL_LABELS[labelKey]();
 }
 
 function addField(
@@ -710,18 +717,18 @@ function addField(
 // The exhaustive Record makes a new contract field fail type checking until
 // the UI either adds a detail formatter or explicitly delegates it.
 interface NetworkLogDetailDescriptor {
-  readonly label: string;
+  readonly labelKey: NetworkDetailLabelKey;
   readonly value: (entry: NetworkLogEntry) => unknown;
   readonly format: (entry: NetworkLogEntry) => string;
 }
 
 function detailField<K extends keyof NetworkLogEntry>(
-  label: string,
+  labelKey: NetworkDetailLabelKey,
   key: K,
   formatter: (value: NetworkLogEntry[K]) => string = formatValue,
 ): NetworkLogDetailDescriptor {
   return {
-    label,
+    labelKey,
     value: (entry) => {
       return entry[key];
     },
@@ -732,137 +739,137 @@ function detailField<K extends keyof NetworkLogEntry>(
 }
 
 const networkLogDetailFields = {
-  timestamp: detailField("Timestamp", "timestamp"),
-  type: detailField("Type", "type"),
-  action: detailField("Action", "action"),
-  method: detailField("Method", "method"),
-  url: detailField("URL", "url"),
-  host: detailField("Host", "host"),
-  port: detailField("Port", "port"),
-  status: detailField("Status", "status"),
-  latency_ms: detailField("Latency", "latency_ms", formatLatency),
-  request_size: detailField("Request Size", "request_size", formatSize),
-  response_size: detailField("Response Size", "response_size", formatSize),
-  browser_user_agent: detailField("Browser User-Agent", "browser_user_agent"),
+  timestamp: detailField("timestamp", "timestamp"),
+  type: detailField("type", "type"),
+  action: detailField("action", "action"),
+  method: detailField("method", "method"),
+  url: detailField("url", "url"),
+  host: detailField("host", "host"),
+  port: detailField("port", "port"),
+  status: detailField("status", "status"),
+  latency_ms: detailField("latency", "latency_ms", formatLatency),
+  request_size: detailField("requestSize", "request_size", formatSize),
+  response_size: detailField("responseSize", "response_size", formatSize),
+  browser_user_agent: detailField("browserUserAgent", "browser_user_agent"),
   model_catalog_cache_status: detailField(
-    "Model Catalog Cache Status",
+    "modelCatalogCacheStatus",
     "model_catalog_cache_status",
   ),
   model_catalog_cache_upstream_encoding: detailField(
-    "Model Catalog Upstream Encoding",
+    "modelCatalogUpstreamEncoding",
     "model_catalog_cache_upstream_encoding",
   ),
   model_catalog_cache_bypass_reason: detailField(
-    "Model Catalog Cache Bypass Reason",
+    "modelCatalogCacheBypassReason",
     "model_catalog_cache_bypass_reason",
   ),
   model_catalog_cache_entry_age_ms: detailField(
-    "Model Catalog Cache Entry Age",
+    "modelCatalogCacheEntryAge",
     "model_catalog_cache_entry_age_ms",
     formatLatency,
   ),
   model_catalog_cache_validation_latency_ms: detailField(
-    "Model Catalog Cache Validation Latency",
+    "modelCatalogCacheValidationLatency",
     "model_catalog_cache_validation_latency_ms",
     formatLatency,
   ),
   model_catalog_cache_eviction_count: detailField(
-    "Model Catalog Cache Eviction Count",
+    "modelCatalogCacheEvictionCount",
     "model_catalog_cache_eviction_count",
   ),
   model_catalog_prefetch_role: detailField(
-    "Model Catalog Prefetch Role",
+    "modelCatalogPrefetchRole",
     "model_catalog_prefetch_role",
   ),
-  dns_event: detailField("DNS Event", "dns_event"),
-  dns_query_type: detailField("DNS Query Type", "dns_query_type"),
-  dns_result: detailField("DNS Result", "dns_result"),
-  dns_serial: detailField("DNS Serial", "dns_serial"),
-  firewall_name: detailField("Firewall", "firewall_name"),
-  firewall_permission: detailField("Permission", "firewall_permission"),
-  firewall_rule_match: detailField("Rule Match", "firewall_rule_match"),
-  firewall_base: detailField("Base URL", "firewall_base"),
-  firewall_params: detailField("Params", "firewall_params", formatParams),
-  firewall_billable: detailField("Billable", "firewall_billable"),
-  firewall_error: detailField("Permission Error", "firewall_error"),
+  dns_event: detailField("dnsEvent", "dns_event"),
+  dns_query_type: detailField("dnsQueryType", "dns_query_type"),
+  dns_result: detailField("dnsResult", "dns_result"),
+  dns_serial: detailField("dnsSerial", "dns_serial"),
+  firewall_name: detailField("firewall", "firewall_name"),
+  firewall_permission: detailField("permission", "firewall_permission"),
+  firewall_rule_match: detailField("ruleMatch", "firewall_rule_match"),
+  firewall_base: detailField("baseUrl", "firewall_base"),
+  firewall_params: detailField("params", "firewall_params", formatParams),
+  firewall_billable: detailField("billable", "firewall_billable"),
+  firewall_error: detailField("permissionError", "firewall_error"),
   upstream_binding_reason: detailField(
-    "Upstream Binding Reason",
+    "upstreamBindingReason",
     "upstream_binding_reason",
   ),
   upstream_binding_trusted_host: detailField(
-    "Upstream Binding Trusted Host",
+    "upstreamBindingTrustedHost",
     "upstream_binding_trusted_host",
   ),
   upstream_binding_request_host: detailField(
-    "Upstream Binding Request Host",
+    "upstreamBindingRequestHost",
     "upstream_binding_request_host",
   ),
   upstream_binding_request_port: detailField(
-    "Upstream Binding Request Port",
+    "upstreamBindingRequestPort",
     "upstream_binding_request_port",
   ),
   upstream_binding_server_connected: detailField(
-    "Upstream Binding Server Connected",
+    "upstreamBindingServerConnected",
     "upstream_binding_server_connected",
   ),
   upstream_binding_server_address: detailField(
-    "Upstream Binding Server Address",
+    "upstreamBindingServerAddress",
     "upstream_binding_server_address",
   ),
   upstream_binding_server_peername: detailField(
-    "Upstream Binding Server Peername",
+    "upstreamBindingServerPeername",
     "upstream_binding_server_peername",
   ),
   upstream_binding_server_sockname: detailField(
-    "Upstream Binding Server Sockname",
+    "upstreamBindingServerSockname",
     "upstream_binding_server_sockname",
   ),
   upstream_binding_client_sockname: detailField(
-    "Upstream Binding Client Sockname",
+    "upstreamBindingClientSockname",
     "upstream_binding_client_sockname",
   ),
   upstream_binding_server_id: detailField(
-    "Upstream Binding Server ID",
+    "upstreamBindingServerId",
     "upstream_binding_server_id",
   ),
   upstream_binding_client_id: detailField(
-    "Upstream Binding Client ID",
+    "upstreamBindingClientId",
     "upstream_binding_client_id",
   ),
   upstream_binding_direct_binding_present: detailField(
-    "Upstream Direct Binding Present",
+    "upstreamBindingDirectBindingPresent",
     "upstream_binding_direct_binding_present",
   ),
   upstream_binding_direct_binding_host: detailField(
-    "Upstream Direct Binding Host",
+    "upstreamBindingDirectBindingHost",
     "upstream_binding_direct_binding_host",
   ),
   upstream_binding_direct_binding_port: detailField(
-    "Upstream Direct Binding Port",
+    "upstreamBindingDirectBindingPort",
     "upstream_binding_direct_binding_port",
   ),
   upstream_binding_direct_binding_kinds: detailField(
-    "Upstream Direct Binding Kinds",
+    "upstreamBindingDirectBindingKinds",
     "upstream_binding_direct_binding_kinds",
   ),
   upstream_binding_client_binding_count: detailField(
-    "Upstream Client Binding Count",
+    "upstreamBindingClientBindingCount",
     "upstream_binding_client_binding_count",
   ),
   upstream_binding_client_binding_match: detailField(
-    "Upstream Client Binding Match",
+    "upstreamBindingClientBindingMatch",
     "upstream_binding_client_binding_match",
   ),
   upstream_binding_client_binding_endpoint_match: detailField(
-    "Upstream Client Binding Endpoint Match",
+    "upstreamBindingClientBindingEndpointMatch",
     "upstream_binding_client_binding_endpoint_match",
   ),
   upstream_binding_client_binding_hosts: detailField(
-    "Upstream Client Binding Hosts",
+    "upstreamBindingClientBindingHosts",
     "upstream_binding_client_binding_hosts",
   ),
   connector_diagnostic_slug: {
-    label: "Connector Diagnostic",
+    labelKey: "connectorDiagnostic",
     value: (entry) => {
       return entry.connector_diagnostic_slug ?? entry.connector_diagnostic_type;
     },
@@ -875,40 +882,40 @@ const networkLogDetailFields = {
   // TODO(#23838): Remove after the diagnostic compatibility window.
   connector_diagnostic_type: null,
   connector_diagnostic_reason: detailField(
-    "Connector Reason",
+    "connectorReason",
     "connector_diagnostic_reason",
   ),
   connector_diagnostic_env_names: detailField(
-    "Connector Env Names",
+    "connectorEnvNames",
     "connector_diagnostic_env_names",
   ),
   connector_diagnostic_base: detailField(
-    "Connector Base URL",
+    "connectorBaseUrl",
     "connector_diagnostic_base",
   ),
   connector_route_reason: detailField(
-    "Connector Route Reason",
+    "connectorRouteReason",
     "connector_route_reason",
   ),
   connector_route_candidates: detailField(
-    "Connector Route Candidates",
+    "connectorRouteCandidates",
     "connector_route_candidates",
   ),
   auth_resolved_secrets: detailField(
-    "Resolved Secrets",
+    "authResolvedSecrets",
     "auth_resolved_secrets",
   ),
   auth_refreshed_connectors: detailField(
-    "Refreshed Connectors",
+    "authRefreshedConnectors",
     "auth_refreshed_connectors",
   ),
   auth_refreshed_secrets: detailField(
-    "Refreshed Secrets",
+    "authRefreshedSecrets",
     "auth_refreshed_secrets",
   ),
-  auth_cache_hit: detailField("Cache Hit", "auth_cache_hit"),
-  auth_url_rewrite: detailField("URL Rewrite", "auth_url_rewrite"),
-  error: detailField("Error", "error"),
+  auth_cache_hit: detailField("authCacheHit", "auth_cache_hit"),
+  auth_url_rewrite: detailField("authUrlRewrite", "auth_url_rewrite"),
+  error: detailField("error", "error"),
   // CapturedBodySections renders these fields below the detail grid.
   request_headers: null,
   request_body: null,
@@ -926,7 +933,7 @@ function collectDetails(entry: NetworkLogEntry): [string, string][] {
     if (descriptor) {
       addField(
         out,
-        localizeNetworkDetailLabel(descriptor.label),
+        localizeNetworkDetailLabel(descriptor.labelKey),
         descriptor.value(entry),
         descriptor.format(entry),
       );

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -298,7 +298,6 @@ function CodexOAuthCredentialRow({
               },
               {
                 kind: "separator",
-                label: "codex-reset-separator",
               },
               {
                 label: t(($) => {
@@ -419,14 +418,19 @@ function fallbackSubscriptionUsage(
 }
 
 function usageWindows(usage: SubscriptionUsage | null | undefined): readonly {
-  readonly label: string;
+  readonly kind: "fiveHour" | "week";
   readonly window: SubscriptionUsageWindow;
 }[] {
   return [
-    { label: "5h", window: usage?.fiveHour ?? null },
-    { label: "Week", window: usage?.weekly ?? null },
+    { kind: "fiveHour" as const, window: usage?.fiveHour ?? null },
+    { kind: "week" as const, window: usage?.weekly ?? null },
   ].filter(
-    (item): item is { label: string; window: SubscriptionUsageWindow } => {
+    (
+      item,
+    ): item is {
+      kind: "fiveHour" | "week";
+      window: SubscriptionUsageWindow;
+    } => {
       return hasUsageWindow(item.window);
     },
   );
@@ -473,13 +477,15 @@ function SubscriptionUsageMeter({
   return (
     <div className="w-full rounded-lg bg-muted/30 px-3 py-2.5">
       <div className="space-y-2">
-        {windows.map(({ label, window }) => {
+        {windows.map(({ kind, window }) => {
           const windowLabel =
-            label === "Week"
+            kind === "week"
               ? t(($) => {
                   return $.settings.models.personal.status.week;
                 })
-              : label;
+              : t(($) => {
+                  return $.settings.models.personal.status.fiveHour;
+                });
           const remainingPercent =
             window.remainingPercent ??
             (window.usedPercent === null ? null : 100 - window.usedPercent);
@@ -487,7 +493,7 @@ function SubscriptionUsageMeter({
           const reset = formatSubscriptionUsageReset(window.resetAt);
           const tone = usageTone(remainingPercent);
           return (
-            <div key={label} className="space-y-1">
+            <div key={kind} className="space-y-1">
               <div className="flex min-w-0 items-center justify-between gap-2 text-[11px] leading-none">
                 <span className="font-medium text-foreground">
                   {windowLabel}
@@ -542,13 +548,21 @@ function SubscriptionUsageMeter({
   );
 }
 
-interface OAuthMenuItem {
-  label: string;
-  kind?: "item" | "status" | "separator";
-  disabled?: boolean;
-  onSelect?: () => void;
-  opensModal?: boolean;
-}
+type OAuthMenuItem =
+  | {
+      readonly kind: "separator";
+    }
+  | {
+      readonly kind: "status";
+      readonly label: string;
+    }
+  | {
+      readonly kind?: "item";
+      readonly label: string;
+      readonly disabled?: boolean;
+      readonly onSelect?: () => void;
+      readonly opensModal?: boolean;
+    };
 
 function OAuthMenuEntry({ item }: { item: OAuthMenuItem }) {
   if (item.kind === "separator") {
@@ -679,7 +693,9 @@ function OAuthCredentialRow({
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-44">
                   {menuItems.map((item) => {
-                    return <OAuthMenuEntry key={item.label} item={item} />;
+                    const key =
+                      item.kind === "separator" ? "separator" : item.label;
+                    return <OAuthMenuEntry key={key} item={item} />;
                   })}
                 </DropdownMenuContent>
               </DropdownMenu>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-card.tsx
@@ -494,7 +494,6 @@ function permissionDescription(description: string): string {
   return description
     .replace(/^Connect your \w+ account to /iu, "")
     .replace(/^access /iu, "")
-    .replace(/^create /iu, "Create ")
     .replace(/^./u, (character) => {
       return character.toUpperCase();
     });

--- a/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
@@ -80,8 +80,17 @@ export function LanguageSettings() {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="en-US">English</SelectItem>
-              <SelectItem value="pt-BR">Português (Brasil)</SelectItem>
+              <SelectItem value="en-US">
+                {t(($) => {
+                  return $.settings.preferences.language.options.english;
+                })}
+              </SelectItem>
+              <SelectItem value="pt-BR">
+                {t(($) => {
+                  return $.settings.preferences.language.options
+                    .portugueseBrazil;
+                })}
+              </SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -8,44 +8,34 @@ import {
 import { i18n } from "../../../../i18n/index.ts";
 
 /**
- * UI-only display overrides for provider labels. These do not modify the core
- * contracts, only how the platform UI renders them.
- */
-
-interface ProviderUIOverrides {
-  label?: string;
-}
-
-const PROVIDER_UI_OVERRIDES = Object.freeze<
-  Partial<Record<ModelProviderType, ProviderUIOverrides>>
->({
-  "claude-code-oauth-token": {
-    label: "Claude Code (OAuth token)",
-  },
-  "deepseek-api-key": {
-    label: "Deepseek",
-  },
-  "azure-foundry": {
-    label: "Azure foundry portal",
-  },
-});
-
-function getOverrides(
-  type: ModelProviderType,
-): ProviderUIOverrides | undefined {
-  return PROVIDER_UI_OVERRIDES[type];
-}
-
-/**
  * Get the display label for a provider type (UI override or core fallback)
  */
 export function getUILabel(type: ModelProviderType): string {
-  if (type === "vm0") {
-    return i18n.t(($) => {
-      return $.settings.models.picker.builtInModel;
-    });
+  switch (type) {
+    case "vm0": {
+      return i18n.t(($) => {
+        return $.settings.models.picker.builtInModel;
+      });
+    }
+    case "claude-code-oauth-token": {
+      return i18n.t(($) => {
+        return $.settings.models.picker.providerLabels.claudeCodeOauth;
+      });
+    }
+    case "deepseek-api-key": {
+      return i18n.t(($) => {
+        return $.settings.models.picker.providerLabels.deepseek;
+      });
+    }
+    case "azure-foundry": {
+      return i18n.t(($) => {
+        return $.settings.models.picker.providerLabels.azureFoundryPortal;
+      });
+    }
+    default: {
+      return MODEL_PROVIDER_TYPES[type].label;
+    }
   }
-  return getOverrides(type)?.label ?? MODEL_PROVIDER_TYPES[type].label;
 }
 
 export function getVm0ModelPriceTierLabel(tier: Vm0ModelPriceTier): string {

--- a/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
@@ -1279,7 +1279,11 @@ export function FeishuCard() {
           <img src={feishuIconImg} alt="" className="h-7 w-7" />
         </div>
         <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <div className="text-sm font-medium text-foreground">Feishu</div>
+          <div className="text-sm font-medium text-foreground">
+            {t(($) => {
+              return $.connectors.providerSettings.feishu.documentTitle;
+            })}
+          </div>
           <div className="truncate text-sm text-muted-foreground">
             {t(($) => {
               return $.connectors.providerSettings.feishu.routeDescription;
@@ -2085,7 +2089,9 @@ export function ZeroFeishuSettingsPage() {
             </span>
             <div className="min-w-0">
               <h1 className="truncate text-lg font-semibold tracking-tight text-foreground">
-                Feishu
+                {t(($) => {
+                  return $.connectors.providerSettings.feishu.documentTitle;
+                })}
               </h1>
               <p className="mt-0.5 text-sm text-muted-foreground">
                 {t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -250,13 +250,23 @@ function MailMessageHeader({
             {draft.cc.length > 0 ? (
               <>
                 <span aria-hidden="true"> · </span>
-                <span>cc {draft.cc.join(", ")}</span>
+                <span>
+                  {t(($) => {
+                    return $.chat.mail.cc;
+                  })}{" "}
+                  {draft.cc.join(", ")}
+                </span>
               </>
             ) : null}
             {draft.bcc.length > 0 ? (
               <>
                 <span aria-hidden="true"> · </span>
-                <span>bcc {draft.bcc.join(", ")}</span>
+                <span>
+                  {t(($) => {
+                    return $.chat.mail.bcc;
+                  })}{" "}
+                  {draft.bcc.join(", ")}
+                </span>
               </>
             ) : null}
           </div>

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-preview.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-preview.ts
@@ -1,3 +1,5 @@
+import { i18n } from "../../i18n/index.ts";
+
 const EDITABLE_SELECTOR = '[data-vm0-editable="text"]';
 const METADATA_SCRIPT_ID = "vm0-deck-metadata";
 const SLIDE_SELECTORS = [
@@ -283,7 +285,15 @@ export function parsePresentationPreviewDraft(
     return {
       id,
       notes: metadata.slides?.[id]?.speakerNotes ?? "",
-      title: slideTitle(slide, `Slide ${index + 1}`),
+      title: slideTitle(
+        slide,
+        i18n.t(
+          ($) => {
+            return $.artifacts.preview.slideTitle;
+          },
+          { number: index + 1 },
+        ),
+      ),
     };
   });
   const blocks = slideElements.flatMap(

--- a/turbo/apps/platform/src/views/zero-page/workflow-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-automations-page.tsx
@@ -492,7 +492,9 @@ export function automationTypeLabel(
     automation.eventType === "gmail-new-message" ||
     automation.eventType === "gmail-label-applied"
   ) {
-    return "Gmail";
+    return i18n.t(($) => {
+      return $.workflows.automations.types.gmail;
+    });
   }
   if (
     automation.eventType === "github-label-applied" ||
@@ -502,33 +504,47 @@ export function automationTypeLabel(
     automation.eventType === "github-workflow-job-completed" ||
     automation.eventType === "github-workflow-run-completed"
   ) {
-    return "GitHub";
+    return i18n.t(($) => {
+      return $.workflows.automations.types.github;
+    });
   }
   if (
     automation.eventType === "google-calendar-event-created" ||
     automation.eventType === "google-calendar-event-updated" ||
     automation.eventType === "google-calendar-event-cancelled"
   ) {
-    return "Google Calendar";
+    return i18n.t(($) => {
+      return $.workflows.automations.types.googleCalendar;
+    });
   }
   if (automation.eventType === "google-meet-transcript-generated") {
-    return "Google Meet";
+    return i18n.t(($) => {
+      return $.workflows.automations.types.googleMeet;
+    });
   }
   if (
     automation.eventType === "notion-child-page-created" ||
     automation.eventType === "notion-database-item-created" ||
     automation.eventType === "notion-page-content-updated"
   ) {
-    return "Notion";
+    return i18n.t(($) => {
+      return $.workflows.automations.types.notion;
+    });
   }
   if (automation.eventType === "webhook-received") {
-    return "Webhook";
+    return i18n.t(($) => {
+      return $.workflows.automations.types.webhook;
+    });
   }
   if (automation.eventType === "strapi-entry-published") {
-    return "Strapi";
+    return i18n.t(($) => {
+      return $.workflows.automations.types.strapi;
+    });
   }
   if (automation.eventType === "chat-run-finished") {
-    return "Chat";
+    return i18n.t(($) => {
+      return $.workflows.automations.types.chat;
+    });
   }
   return i18n.t(($) => {
     return $.workflows.automations.common.automation;

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -139,7 +139,7 @@ function runWhenGoogleDriveReady(params: {
   pageSignal: AbortSignal;
   run: GoogleDriveReadyRun;
   waitForGoogleDriveAuthorization: WaitForGoogleDriveAuthorizationFn;
-  description: string;
+  operation: string;
 }): void {
   if (!params.agentId) {
     toast.error(
@@ -159,7 +159,7 @@ function runWhenGoogleDriveReady(params: {
       await params.run();
     })(),
     Reason.DomCallback,
-    params.description,
+    params.operation,
   );
 }
 
@@ -171,7 +171,7 @@ function startGoogleDriveConnectAndRun(params: {
   pageSignal: AbortSignal;
   run: GoogleDriveReadyRun;
   waitForGoogleDriveAuthorization: WaitForGoogleDriveAuthorizationFn;
-  description: string;
+  operation: string;
 }): void {
   if (!params.agentId) {
     toast.error(
@@ -246,7 +246,7 @@ function startGoogleDriveConnectAndRun(params: {
     pageSignal: params.pageSignal,
     run: params.run,
     waitForGoogleDriveAuthorization: params.waitForGoogleDriveAuthorization,
-    description: params.description,
+    operation: params.operation,
   });
 }
 
@@ -255,7 +255,7 @@ function authorizeGoogleDriveAndRun(params: {
   pageSignal: AbortSignal;
   run: GoogleDriveReadyRun;
   waitForGoogleDriveAuthorization: WaitForGoogleDriveAuthorizationFn;
-  description: string;
+  operation: string;
 }): void {
   runWhenGoogleDriveReady({ ...params, authorizeConnected: true });
 }
@@ -406,19 +406,19 @@ function useGoogleDriveAvailability(
 }
 
 function GoogleDriveDisabledMenuItem({
-  label,
+  kind,
   muted = false,
 }: {
-  label: "connect" | "synced" | "upload";
+  kind: "connect" | "synced" | "upload";
   muted?: boolean;
 }) {
   const { t } = useTranslation();
   const text =
-    label === "connect"
+    kind === "connect"
       ? t(($) => {
           return $.artifacts.googleDrive.connect;
         })
-      : label === "synced"
+      : kind === "synced"
         ? t(($) => {
             return $.artifacts.googleDrive.synced;
           })
@@ -458,17 +458,17 @@ function GoogleDriveMenuItem({
   );
 
   if (!syncTarget) {
-    return <GoogleDriveDisabledMenuItem label="upload" />;
+    return <GoogleDriveDisabledMenuItem kind="upload" />;
   }
 
   if (syncTarget.synced) {
-    return <GoogleDriveDisabledMenuItem label="synced" />;
+    return <GoogleDriveDisabledMenuItem kind="synced" />;
   }
 
   if (!connectorListLoaded) {
     return (
       <GoogleDriveDisabledMenuItem
-        label={syncTarget.disconnected ? "connect" : "upload"}
+        kind={syncTarget.disconnected ? "connect" : "upload"}
         muted={syncTarget.disconnected}
       />
     );
@@ -499,7 +499,7 @@ function GoogleDriveMenuItem({
         pageSignal,
         run,
         waitForGoogleDriveAuthorization,
-        description: "artifact google drive authorize sync",
+        operation: "artifact google drive authorize sync",
       });
       return;
     }
@@ -514,7 +514,7 @@ function GoogleDriveMenuItem({
       pageSignal,
       run,
       waitForGoogleDriveAuthorization,
-      description: "artifact google drive connect sync",
+      operation: "artifact google drive connect sync",
     });
   };
 
@@ -621,7 +621,7 @@ function setArtifactDownloadMenuOpen(params: {
 
 function startArtifactDownloadWithCleanup(params: {
   readonly closeMenu: () => void;
-  readonly description: string;
+  readonly operation: string;
   readonly download: Promise<void>;
   readonly downloadKey: string;
   readonly finish: (key: string) => void;
@@ -634,7 +634,7 @@ function startArtifactDownloadWithCleanup(params: {
       params.finish(params.downloadKey);
     }),
     Reason.DomCallback,
-    params.description,
+    params.operation,
   );
 }
 
@@ -719,7 +719,7 @@ export function ArtifactDownloadMenu({
           onClick={() => {
             startArtifactDownloadWithCleanup({
               closeMenu,
-              description: "artifact download",
+              operation: "artifact download",
               download: downloadAttachmentUrl(url, pageSignal, downloadName),
               downloadKey: artifactDownloadKey,
               finish: finishArtifactDownload,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1964,9 +1964,7 @@ function prewarmIllustrationPreviewImagesNearScroll({
 
 interface PresentationTemplateThemeOption {
   readonly id: string;
-  readonly name: string;
   readonly group: "multi-accent" | "single-accent";
-  readonly paletteName: string;
   readonly colors: readonly [
     bg: string,
     surface: string,
@@ -1980,332 +1978,400 @@ interface PresentationTemplateThemeOption {
   ];
 }
 
-const PRESENTATION_TEMPLATE_THEME_OPTIONS: readonly PresentationTemplateThemeOption[] =
-  [
-    {
-      id: "prism",
-      name: "Candy party",
-      group: "multi-accent",
-      paletteName: "Candy party",
-      colors: [
-        "#FFFFFF",
-        "#F7F7FA",
-        "#1A1726",
-        "#5C5870",
-        "#7257E6",
-        "#FF6B4A",
-        "#AEE63E",
-        "#3FA9F5",
-        "#ECECF2",
-      ],
-    },
-    {
-      id: "carnival",
-      name: "Funfair",
-      group: "multi-accent",
-      paletteName: "Funfair",
-      colors: [
-        "#FFFDF7",
-        "#FFFFFF",
-        "#221C14",
-        "#5E564A",
-        "#FF7A1A",
-        "#E5388E",
-        "#F5B73E",
-        "#1FB6A6",
-        "#EFEADF",
-      ],
-    },
-    {
-      id: "pop-art",
-      name: "Neon arcade",
-      group: "multi-accent",
-      paletteName: "Neon arcade",
-      colors: [
-        "#111016",
-        "#1B1A22",
-        "#F4F2FA",
-        "#A09CB0",
-        "#3D7BFF",
-        "#FF3D9A",
-        "#C6FF4A",
-        "#FF7A1A",
-        "#26242E",
-      ],
-    },
-    {
-      id: "warm-sand",
-      name: "Morning paper",
-      group: "single-accent",
-      paletteName: "Morning paper",
-      colors: [
-        "#FFFDF8",
-        "#FFFFFF",
-        "#262626",
-        "#5A5A5A",
-        "#F19B3A",
-        "#8DACE5",
-        "#DDB8D9",
-        "#516049",
-        "#ECECEC",
-      ],
-    },
-    {
-      id: "bauhaus-primary",
-      name: "Toy bricks",
-      group: "single-accent",
-      paletteName: "Toy bricks",
-      colors: [
-        "#F5F1E6",
-        "#FFFFFF",
-        "#1A1A1A",
-        "#4A4A4A",
-        "#E63327",
-        "#2C5BD6",
-        "#F2B705",
-        "#1A1A1A",
-        "#E2DDD0",
-      ],
-    },
-    {
-      id: "nordic-frost",
-      name: "Ice lake",
-      group: "single-accent",
-      paletteName: "Ice lake",
-      colors: [
-        "#FBFCFD",
-        "#FFFFFF",
-        "#1F2933",
-        "#5B6B7B",
-        "#3E8EDE",
-        "#7BC6C9",
-        "#B8C4D0",
-        "#1F2933",
-        "#E8EDF1",
-      ],
-    },
-    {
-      id: "forest-editorial",
-      name: "Moss library",
-      group: "single-accent",
-      paletteName: "Moss library",
-      colors: [
-        "#F7F6F1",
-        "#FFFFFF",
-        "#1E2B22",
-        "#4F5C52",
-        "#5B7553",
-        "#C97B4A",
-        "#E4DFD0",
-        "#1E2B22",
-        "#E6E8E1",
-      ],
-    },
-    {
-      id: "coral-studio",
-      name: "Peach studio",
-      group: "single-accent",
-      paletteName: "Peach studio",
-      colors: [
-        "#FFF9F6",
-        "#FFFFFF",
-        "#3A2A26",
-        "#6E5B55",
-        "#FF6F5E",
-        "#FFB199",
-        "#2BB3A3",
-        "#3A2A26",
-        "#F0E7E2",
-      ],
-    },
-    {
-      id: "slate-corporate",
-      name: "Boardroom blue",
-      group: "single-accent",
-      paletteName: "Boardroom blue",
-      colors: [
-        "#FFFFFF",
-        "#F6F8FB",
-        "#16243B",
-        "#5A6678",
-        "#2F5BD0",
-        "#6E8BB8",
-        "#F0A03A",
-        "#16243B",
-        "#E9EDF3",
-      ],
-    },
-    {
-      id: "terracotta-clay",
-      name: "Clay pot",
-      group: "single-accent",
-      paletteName: "Clay pot",
-      colors: [
-        "#FBF4EC",
-        "#FFFFFF",
-        "#3B2A20",
-        "#6B5546",
-        "#C36A3F",
-        "#D9A441",
-        "#7A7A52",
-        "#EAD9C6",
-        "#ECE0D2",
-      ],
-    },
-    {
-      id: "berry-pop",
-      name: "Raspberry soda",
-      group: "single-accent",
-      paletteName: "Raspberry soda",
-      colors: [
-        "#FFFAFC",
-        "#FFFFFF",
-        "#2E1A2C",
-        "#6A5566",
-        "#D63A8E",
-        "#8E5BD0",
-        "#F4B8D4",
-        "#2E1A2C",
-        "#F0E6EC",
-      ],
-    },
-    {
-      id: "citrus-fresh",
-      name: "Orange juice",
-      group: "single-accent",
-      paletteName: "Orange juice",
-      colors: [
-        "#FFFFFB",
-        "#FFFFFF",
-        "#232318",
-        "#5C5C4E",
-        "#FF8A1E",
-        "#FFD23E",
-        "#8FB339",
-        "#4FA3A3",
-        "#EDEDE3",
-      ],
-    },
-    {
-      id: "mauve-dusk",
-      name: "Lavender dusk",
-      group: "single-accent",
-      paletteName: "Lavender dusk",
-      colors: [
-        "#FAF7FB",
-        "#FFFFFF",
-        "#2B2533",
-        "#635B70",
-        "#9C7BB8",
-        "#8AA0C9",
-        "#E0B6C9",
-        "#2B2533",
-        "#ECE7F0",
-      ],
-    },
-    {
-      id: "mono-ink",
-      name: "Newsprint red",
-      group: "single-accent",
-      paletteName: "Newsprint red",
-      colors: [
-        "#FFFFFF",
-        "#FAFAFA",
-        "#0A0A0A",
-        "#6B6B6B",
-        "#E5392E",
-        "#0A0A0A",
-        "#BFBFBF",
-        "#0A0A0A",
-        "#EEEEEE",
-      ],
-    },
-    {
-      id: "sunset-maroon",
-      name: "Sunset glow",
-      group: "single-accent",
-      paletteName: "Sunset glow",
-      colors: [
-        "#FFF7F2",
-        "#FFFFFF",
-        "#3A1F22",
-        "#6E4A4C",
-        "#F26B3A",
-        "#E0457B",
-        "#F2A93B",
-        "#3A1F22",
-        "#F0E2DA",
-      ],
-    },
-    {
-      id: "mint-tech",
-      name: "Mint lab",
-      group: "single-accent",
-      paletteName: "Mint lab",
-      colors: [
-        "#FBFFFD",
-        "#FFFFFF",
-        "#1B2A26",
-        "#56655F",
-        "#16B981",
-        "#4FA3E0",
-        "#9AE6C8",
-        "#3A4A45",
-        "#E6F0EB",
-      ],
-    },
-    {
-      id: "midnight-mono",
-      name: "Night run",
-      group: "single-accent",
-      paletteName: "Night run",
-      colors: [
-        "#121316",
-        "#1C1E22",
-        "#F2F2F0",
-        "#A0A3A8",
-        "#C6FF4A",
-        "#6B7280",
-        "#3A3D44",
-        "#C6FF4A",
-        "#2A2C31",
-      ],
-    },
-    {
-      id: "ocean-deep",
-      name: "Deep dive",
-      group: "single-accent",
-      paletteName: "Deep dive",
-      colors: [
-        "#0E2A33",
-        "#143840",
-        "#EAF6F4",
-        "#9DB8B8",
-        "#38C7B4",
-        "#5A93A8",
-        "#1F4A52",
-        "#38C7B4",
-        "#1B454E",
-      ],
-    },
-    {
-      id: "gold-luxe",
-      name: "Award night",
-      group: "single-accent",
-      paletteName: "Award night",
-      colors: [
-        "#16140F",
-        "#211E16",
-        "#F3EEE2",
-        "#ADA48E",
-        "#C9A24B",
-        "#8A6E3A",
-        "#3A352A",
-        "#C9A24B",
-        "#2A271E",
-      ],
-    },
-  ];
+const PRESENTATION_TEMPLATE_THEME_OPTIONS = [
+  {
+    id: "prism",
+    group: "multi-accent",
+    colors: [
+      "#FFFFFF",
+      "#F7F7FA",
+      "#1A1726",
+      "#5C5870",
+      "#7257E6",
+      "#FF6B4A",
+      "#AEE63E",
+      "#3FA9F5",
+      "#ECECF2",
+    ],
+  },
+  {
+    id: "carnival",
+    group: "multi-accent",
+    colors: [
+      "#FFFDF7",
+      "#FFFFFF",
+      "#221C14",
+      "#5E564A",
+      "#FF7A1A",
+      "#E5388E",
+      "#F5B73E",
+      "#1FB6A6",
+      "#EFEADF",
+    ],
+  },
+  {
+    id: "pop-art",
+    group: "multi-accent",
+    colors: [
+      "#111016",
+      "#1B1A22",
+      "#F4F2FA",
+      "#A09CB0",
+      "#3D7BFF",
+      "#FF3D9A",
+      "#C6FF4A",
+      "#FF7A1A",
+      "#26242E",
+    ],
+  },
+  {
+    id: "warm-sand",
+    group: "single-accent",
+    colors: [
+      "#FFFDF8",
+      "#FFFFFF",
+      "#262626",
+      "#5A5A5A",
+      "#F19B3A",
+      "#8DACE5",
+      "#DDB8D9",
+      "#516049",
+      "#ECECEC",
+    ],
+  },
+  {
+    id: "bauhaus-primary",
+    group: "single-accent",
+    colors: [
+      "#F5F1E6",
+      "#FFFFFF",
+      "#1A1A1A",
+      "#4A4A4A",
+      "#E63327",
+      "#2C5BD6",
+      "#F2B705",
+      "#1A1A1A",
+      "#E2DDD0",
+    ],
+  },
+  {
+    id: "nordic-frost",
+    group: "single-accent",
+    colors: [
+      "#FBFCFD",
+      "#FFFFFF",
+      "#1F2933",
+      "#5B6B7B",
+      "#3E8EDE",
+      "#7BC6C9",
+      "#B8C4D0",
+      "#1F2933",
+      "#E8EDF1",
+    ],
+  },
+  {
+    id: "forest-editorial",
+    group: "single-accent",
+    colors: [
+      "#F7F6F1",
+      "#FFFFFF",
+      "#1E2B22",
+      "#4F5C52",
+      "#5B7553",
+      "#C97B4A",
+      "#E4DFD0",
+      "#1E2B22",
+      "#E6E8E1",
+    ],
+  },
+  {
+    id: "coral-studio",
+    group: "single-accent",
+    colors: [
+      "#FFF9F6",
+      "#FFFFFF",
+      "#3A2A26",
+      "#6E5B55",
+      "#FF6F5E",
+      "#FFB199",
+      "#2BB3A3",
+      "#3A2A26",
+      "#F0E7E2",
+    ],
+  },
+  {
+    id: "slate-corporate",
+    group: "single-accent",
+    colors: [
+      "#FFFFFF",
+      "#F6F8FB",
+      "#16243B",
+      "#5A6678",
+      "#2F5BD0",
+      "#6E8BB8",
+      "#F0A03A",
+      "#16243B",
+      "#E9EDF3",
+    ],
+  },
+  {
+    id: "terracotta-clay",
+    group: "single-accent",
+    colors: [
+      "#FBF4EC",
+      "#FFFFFF",
+      "#3B2A20",
+      "#6B5546",
+      "#C36A3F",
+      "#D9A441",
+      "#7A7A52",
+      "#EAD9C6",
+      "#ECE0D2",
+    ],
+  },
+  {
+    id: "berry-pop",
+    group: "single-accent",
+    colors: [
+      "#FFFAFC",
+      "#FFFFFF",
+      "#2E1A2C",
+      "#6A5566",
+      "#D63A8E",
+      "#8E5BD0",
+      "#F4B8D4",
+      "#2E1A2C",
+      "#F0E6EC",
+    ],
+  },
+  {
+    id: "citrus-fresh",
+    group: "single-accent",
+    colors: [
+      "#FFFFFB",
+      "#FFFFFF",
+      "#232318",
+      "#5C5C4E",
+      "#FF8A1E",
+      "#FFD23E",
+      "#8FB339",
+      "#4FA3A3",
+      "#EDEDE3",
+    ],
+  },
+  {
+    id: "mauve-dusk",
+    group: "single-accent",
+    colors: [
+      "#FAF7FB",
+      "#FFFFFF",
+      "#2B2533",
+      "#635B70",
+      "#9C7BB8",
+      "#8AA0C9",
+      "#E0B6C9",
+      "#2B2533",
+      "#ECE7F0",
+    ],
+  },
+  {
+    id: "mono-ink",
+    group: "single-accent",
+    colors: [
+      "#FFFFFF",
+      "#FAFAFA",
+      "#0A0A0A",
+      "#6B6B6B",
+      "#E5392E",
+      "#0A0A0A",
+      "#BFBFBF",
+      "#0A0A0A",
+      "#EEEEEE",
+    ],
+  },
+  {
+    id: "sunset-maroon",
+    group: "single-accent",
+    colors: [
+      "#FFF7F2",
+      "#FFFFFF",
+      "#3A1F22",
+      "#6E4A4C",
+      "#F26B3A",
+      "#E0457B",
+      "#F2A93B",
+      "#3A1F22",
+      "#F0E2DA",
+    ],
+  },
+  {
+    id: "mint-tech",
+    group: "single-accent",
+    colors: [
+      "#FBFFFD",
+      "#FFFFFF",
+      "#1B2A26",
+      "#56655F",
+      "#16B981",
+      "#4FA3E0",
+      "#9AE6C8",
+      "#3A4A45",
+      "#E6F0EB",
+    ],
+  },
+  {
+    id: "midnight-mono",
+    group: "single-accent",
+    colors: [
+      "#121316",
+      "#1C1E22",
+      "#F2F2F0",
+      "#A0A3A8",
+      "#C6FF4A",
+      "#6B7280",
+      "#3A3D44",
+      "#C6FF4A",
+      "#2A2C31",
+    ],
+  },
+  {
+    id: "ocean-deep",
+    group: "single-accent",
+    colors: [
+      "#0E2A33",
+      "#143840",
+      "#EAF6F4",
+      "#9DB8B8",
+      "#38C7B4",
+      "#5A93A8",
+      "#1F4A52",
+      "#38C7B4",
+      "#1B454E",
+    ],
+  },
+  {
+    id: "gold-luxe",
+    group: "single-accent",
+    colors: [
+      "#16140F",
+      "#211E16",
+      "#F3EEE2",
+      "#ADA48E",
+      "#C9A24B",
+      "#8A6E3A",
+      "#3A352A",
+      "#C9A24B",
+      "#2A271E",
+    ],
+  },
+] as const satisfies readonly PresentationTemplateThemeOption[];
+
+type PresentationTemplateTheme =
+  (typeof PRESENTATION_TEMPLATE_THEME_OPTIONS)[number];
+
+const PRESENTATION_TEMPLATE_THEME_NAMES = {
+  "bauhaus-primary": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.bauhausPrimary;
+    });
+  },
+  "berry-pop": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.berryPop;
+    });
+  },
+  carnival: () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.carnival;
+    });
+  },
+  "citrus-fresh": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.citrusFresh;
+    });
+  },
+  "coral-studio": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.coralStudio;
+    });
+  },
+  "forest-editorial": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.forestEditorial;
+    });
+  },
+  "gold-luxe": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.goldLuxe;
+    });
+  },
+  "mauve-dusk": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.mauveDusk;
+    });
+  },
+  "midnight-mono": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.midnightMono;
+    });
+  },
+  "mint-tech": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.mintTech;
+    });
+  },
+  "mono-ink": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.monoInk;
+    });
+  },
+  "nordic-frost": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.nordicFrost;
+    });
+  },
+  "ocean-deep": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.oceanDeep;
+    });
+  },
+  "pop-art": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.popArt;
+    });
+  },
+  prism: () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.prism;
+    });
+  },
+  "slate-corporate": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.slateCorporate;
+    });
+  },
+  "sunset-maroon": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.sunsetMaroon;
+    });
+  },
+  "terracotta-clay": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.terracottaClay;
+    });
+  },
+  "warm-sand": () => {
+    return i18n.t(($) => {
+      return $.artifacts.templates.themeNames.warmSand;
+    });
+  },
+} satisfies Record<PresentationTemplateTheme["id"], () => string>;
+
+function presentationTemplateThemeName(
+  theme: PresentationTemplateTheme,
+): string {
+  return PRESENTATION_TEMPLATE_THEME_NAMES[theme.id]();
+}
 
 function defaultPresentationTemplateThemeId(
   item: PresentationTemplateItem,
@@ -2319,7 +2385,7 @@ function presentationTemplateColorSystemId(themeId: string): string {
 
 function findPresentationTemplateTheme(
   themeId: string,
-): PresentationTemplateThemeOption {
+): PresentationTemplateTheme {
   return (
     PRESENTATION_TEMPLATE_THEME_OPTIONS.find((theme) => {
       return theme.id === themeId;
@@ -3724,7 +3790,7 @@ function TemplatePreviewPage({
                           ($) => {
                             return $.artifacts.templates.selectStyle;
                           },
-                          { style: theme.name },
+                          { style: presentationTemplateThemeName(theme) },
                         )}
                         aria-pressed={active}
                         onClick={() => {
@@ -3776,7 +3842,7 @@ function TemplatePreviewPage({
                           ($) => {
                             return $.artifacts.templates.selectStyle;
                           },
-                          { style: theme.name },
+                          { style: presentationTemplateThemeName(theme) },
                         )}
                         aria-pressed={active}
                         onClick={() => {
@@ -5823,10 +5889,16 @@ function CustomConnectorCatalogCard({
   connector: CustomConnectorResponse;
   onConnect: () => void;
 }) {
+  const { t } = useTranslation();
   return (
     <button
       type="button"
-      aria-label={`Connect ${connector.displayName}`}
+      aria-label={t(
+        ($) => {
+          return $.connectors.card.connectAria;
+        },
+        { connector: connector.displayName },
+      )}
       className="zero-card cursor-pointer overflow-hidden text-left"
       onClick={onConnect}
     >
@@ -6945,7 +7017,9 @@ function ComposerUploadMenu({
             <Input
               className="mt-2 h-9 text-sm"
               name="uploadLink"
-              placeholder="https://example.com/image.png"
+              placeholder={t(($) => {
+                return $.chat.attachments.linkPlaceholder;
+              })}
               type="url"
               data-testid="composer-upload-link-input"
             />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -6717,7 +6717,11 @@ function SlackUserMessageOrigin({
       className="mb-1.5 inline-flex h-7 max-w-[85%] items-center gap-1.5 self-end rounded-md px-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-gray-50 hover:text-foreground"
     >
       <IconBrandSlack size={15} stroke={1.8} className="shrink-0" />
-      <span className="shrink-0">Slack</span>
+      <span className="shrink-0">
+        {t(($) => {
+          return $.chat.origins.slack;
+        })}
+      </span>
       <span className="shrink-0">·</span>
       <span className="min-w-0 truncate">
         {t(($) => {
@@ -6755,7 +6759,11 @@ function FeishuUserMessageOrigin({
         alt=""
         className="size-[15px] shrink-0 object-contain"
       />
-      <span className="shrink-0">Feishu</span>
+      <span className="shrink-0">
+        {t(($) => {
+          return $.chat.origins.feishu;
+        })}
+      </span>
       <span className="shrink-0">·</span>
       <span className="min-w-0 truncate">
         {t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { useGet, useSet } from "ccstate-react";
+import { useTranslation } from "react-i18next";
 import { handleZeroAccountAction$ } from "../../signals/zero-page/zero-nav.ts";
 import {
   closeSettingsModal$,
@@ -41,6 +42,7 @@ export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
 }
 
 export function Vm0LogoLink() {
+  const { t } = useTranslation();
   return (
     <Link pathname="/connectors" className="no-underline text-foreground">
       <svg
@@ -49,7 +51,9 @@ export function Vm0LogoLink() {
         viewBox="0 0 100 30"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
-        aria-label="VM0"
+        aria-label={t(($) => {
+          return $.appShell.logoAlt;
+        })}
       >
         <path
           d="M13.3915 0.0627979C13.2455 -0.0209506 13.0657 -0.020839 12.9198 0.0630906L1.0053 6.91543C0.692394 7.09539 0.690093 7.54442 1.00114 7.72755L12.9156 14.7423C13.0636 14.8295 13.2475 14.8296 13.3957 14.7426L25.3445 7.72785C25.6562 7.54485 25.6539 7.09497 25.3404 6.91514L13.3915 0.0627979Z"

--- a/turbo/apps/platform/src/views/zero-page/zero-file-preview-icon.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-file-preview-icon.tsx
@@ -1,3 +1,5 @@
+import { i18n } from "../../i18n/index.ts";
+
 const SPREADSHEET_FILE_RE =
   /\.(csv|tsv|xls|xlsx|xlsm|xlsb|xltx|xltm|ods|numbers|parquet)$/i;
 const DATABASE_FILE_RE = /\.(sqlite|sqlite3|db)$/i;
@@ -184,11 +186,25 @@ function getTextDocumentPreviewIconMeta(
   }
 
   if (AUDIO_FILE_RE.test(lower) || type.startsWith("audio/")) {
-    return { label: ext || "AUD", bandClassName: "bg-[#7C3AED]" };
+    return {
+      label:
+        ext ||
+        i18n.t(($) => {
+          return $.artifacts.fileBadges.audio;
+        }),
+      bandClassName: "bg-[#7C3AED]",
+    };
   }
 
   if (VIDEO_FILE_RE.test(lower) || type.startsWith("video/")) {
-    return { label: ext || "VID", bandClassName: "bg-[#E11D48]" };
+    return {
+      label:
+        ext ||
+        i18n.t(($) => {
+          return $.artifacts.fileBadges.video;
+        }),
+      bandClassName: "bg-[#E11D48]",
+    };
   }
 
   return null;
@@ -234,7 +250,14 @@ function getStructuredFilePreviewIconMeta(
     ARTWORK_EXTENSION_RE.test(ext) ||
     matchesFilePreviewType(lower, type, ARTWORK_FILE_RE, ["illustrator"])
   ) {
-    return { label: ext || "ART", bandClassName: "bg-[#D84E1F]" };
+    return {
+      label:
+        ext ||
+        i18n.t(($) => {
+          return $.artifacts.fileBadges.artwork;
+        }),
+      bandClassName: "bg-[#D84E1F]",
+    };
   }
 
   if (DOCUMENT_EXTENSION_RE.test(ext) || DOCUMENT_FILE_RE.test(lower)) {
@@ -263,7 +286,11 @@ function getFilePreviewIconMeta(
   }
 
   return {
-    label: ext ? ext.slice(0, 4) : "FILE",
+    label: ext
+      ? ext.slice(0, 4)
+      : i18n.t(($) => {
+          return $.artifacts.fileBadges.file;
+        }),
     bandClassName: "bg-[#64748B]",
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -3,8 +3,7 @@ import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 type IdeationConnectorSlug = string;
 
 interface UseCase {
-  readonly title: string;
-  readonly description: string;
+  readonly id: string;
   readonly prompt: string;
   readonly connectors?: readonly IdeationConnectorSlug[];
   readonly featureFlag?: FeatureSwitchKey;
@@ -12,7 +11,6 @@ interface UseCase {
 
 interface Category {
   readonly id: string;
-  readonly title: string;
   readonly cases: readonly UseCase[];
 }
 
@@ -24,112 +22,94 @@ interface IdeationFilterOptions {
 const categories: readonly Category[] = [
   {
     id: "engineering",
-    title: "Engineering",
     cases: [
       {
-        title: "Daily standup report",
-        description: "Morning metrics become a slide deck posted to Slack",
+        id: "daily-standup-report",
         prompt:
           "Set up a daily standup report that pulls data from GitHub, Sentry, Axiom, and Plausible every morning, generates a pptx, and posts it to #all-vm0",
         connectors: ["github", "sentry", "axiom", "plausible", "slack"],
       },
       {
-        title: "GitHub progress weekly",
-        description: "Weekly repo activity summarized by feature",
+        id: "github-progress-weekly",
         prompt:
           "Generate a weekly GitHub progress report summarized by feature modules",
         connectors: ["github"],
       },
       {
-        title: "GitHub PR summarizer",
-        description:
-          "Merged pull request summaries in Notion with optional Slack posts",
+        id: "github-pr-summarizer",
         prompt:
           "Summarize all merged GitHub PRs from the past week and save a daily report in Notion with an optional Slack post",
         connectors: ["github", "notion", "slack"],
       },
       {
-        title: "Sentry issue digest",
-        description: "Morning digest of issues grouped by severity",
+        id: "sentry-issue-digest",
         prompt:
           "Set up a daily Sentry issue digest that summarizes critical and high severity issues every morning and posts to Slack",
         connectors: ["sentry", "slack"],
       },
       {
-        title: "Vercel deploy digest",
-        description:
-          "It links each deployment to its commit and alerts Slack when a deploy fails",
+        id: "vercel-deploy-digest",
         prompt:
           "Set up a Vercel deploy digest that monitors deployments, links each to its GitHub commit, and sends Slack alerts on failures",
         connectors: ["vercel", "github", "slack"],
       },
       {
-        title: "Cloudflare traffic & security report",
-        description: "Weekly Slack recap of traffic and security events",
+        id: "cloudflare-traffic-security-report",
         prompt:
           "Set up a weekly Cloudflare report that summarizes traffic analytics, WAF events, and bot activity, then posts to Slack",
         connectors: ["cloudflare", "slack"],
       },
       {
-        title: "Batch-create issues",
-        description: "Paste a list and Zero opens the issues for you",
+        id: "batch-create-issues",
         prompt:
           "Create the following GitHub issues and assign them to the right people: 1) ... 2) ... 3) ...",
         connectors: ["github"],
       },
       {
-        title: "Codebase investigation",
-        description: "Give a URL and Zero traces the bug through the repo",
+        id: "codebase-investigation",
         prompt:
           "Look at this page and search the codebase to find the root cause of the bug: [paste URL]",
         connectors: ["github"],
       },
       {
-        title: "Deep-research code analysis",
-        description: "Explains how a subsystem works in your codebase",
+        id: "deep-research-code-analysis",
         prompt:
           "Do a deep research on how the agent run queue locking mechanism works in our codebase",
         connectors: ["github"],
       },
       {
-        title: "Security & dependency alert digest",
-        description: "Weekly security and dependency alerts from GitHub",
+        id: "security-dependency-alert-digest",
         prompt:
           "Generate a weekly GitHub security and dependency alert digest and post it to Slack",
         connectors: ["github", "slack"],
       },
       {
-        title: "Jira ↔ GitHub issue sync",
-        description: "Keeps Jira tickets and GitHub issues in sync",
+        id: "jira-github-issue-sync",
         prompt:
           "Set up a bidirectional sync between Jira and GitHub so that issue status, labels, and comments stay in sync across both platforms",
         connectors: ["jira", "github", "slack"],
       },
       {
-        title: "GitLab to GitHub migration helper",
-        description: "Mirrors GitLab issues and merge requests into GitHub",
+        id: "gitlab-to-github-migration-helper",
         prompt:
           "Set up a workflow that mirrors GitLab issues to GitHub issues and notifies on Slack when new items are synced",
         connectors: ["gitlab", "github", "slack"],
       },
       {
-        title: "Browserbase web testing",
-        description: "Automated browser tests for your web app",
+        id: "browserbase-web-testing",
         prompt:
           "Set up automated browser tests using Browserbase that check our landing page, login flow, and dashboard every day and report failures to Slack",
         connectors: ["browserbase", "slack"],
       },
       {
-        title: "Zapier → VM0 migration",
-        description: "Recreate your Zapier workflows as VM0 agents",
+        id: "zapier-vm0-migration",
         prompt:
           "Help me migrate my Zapier workflows to VM0. I have zaps for: new Slack message → Notion, Gmail → Google Sheets, and GitHub PR → Slack",
         connectors: ["zapier", "slack", "notion"],
         featureFlag: FeatureSwitchKey.ZapierConnector,
       },
       {
-        title: "Make scenario builder",
-        description: "Design multi-step Make scenarios from a description",
+        id: "make-scenario-builder",
         prompt:
           "Design a Make scenario that watches a Gmail inbox for invoices, extracts amounts and dates, logs them to Google Sheets, and alerts on Slack",
         connectors: ["make", "gmail", "google-sheets", "slack"],
@@ -138,45 +118,37 @@ const categories: readonly Category[] = [
   },
   {
     id: "product",
-    title: "Product",
     cases: [
       {
-        title: "Product copy & naming",
-        description: "Friendlier names for technical terms in the product",
+        id: "product-copy-naming",
         prompt:
           'Suggest user-friendly alternative names for "logs" in our product UI',
       },
       {
-        title: "Pricing analysis",
-        description:
-          "Analyze competitor pricing strategies and compare with similar products",
+        id: "pricing-analysis",
         prompt:
           "Analyze the pricing strategy of Claude Code and compare it with similar products",
       },
       {
-        title: "Linear PRD implementer",
-        description: "Notion specs become Linear projects and issues",
+        id: "linear-prd-implementer",
         prompt:
           "Take the product spec from Notion and create a structured Linear project with epics and issues",
         connectors: ["notion", "linear"],
       },
       {
-        title: "Feedback router",
-        description: "Slack feedback routed by your rules to the right place",
+        id: "feedback-router",
         prompt:
           "Set up a feedback router that watches a Slack channel and routes messages to the right team based on keywords and labels",
         connectors: ["slack", "notion"],
       },
       {
-        title: "Metabase dashboard digest",
-        description: "Dashboard snapshots posted to Slack automatically",
+        id: "metabase-dashboard-digest",
         prompt:
           "Set up a weekly Metabase digest that snapshots key dashboards, captures charts, and posts them to Slack every Monday morning",
         connectors: ["metabase", "slack"],
       },
       {
-        title: "Asana → Notion project sync",
-        description: "Asana milestones and tasks mirrored in Notion",
+        id: "asana-notion-project-sync",
         prompt:
           "Set up a sync between Asana and Notion that mirrors project milestones, task progress, and due dates into a Notion dashboard",
         connectors: ["asana", "notion", "slack"],
@@ -185,127 +157,105 @@ const categories: readonly Category[] = [
   },
   {
     id: "marketing",
-    title: "Marketing",
     cases: [
       {
-        title: "Content planner",
-        description: "Brainstorm topics and outline an editorial calendar",
+        id: "content-planner",
         prompt:
           "Help me brainstorm content ideas and plan an editorial calendar for the next month in Notion",
         connectors: ["notion"],
       },
       {
-        title: "Marketing content planning",
-        description:
-          "Plans launch stories from Slack, interviews, and competitors",
+        id: "marketing-content-planning",
         prompt:
           "Help me plan GTM use case content. Reference our team's Slack usage patterns, user interviews, and competitor analysis",
         connectors: ["slack"],
       },
       {
-        title: "Onboarding email use cases",
-        description: "Finds onboarding angles from Slack and interviews",
+        id: "onboarding-email-use-cases",
         prompt:
           "Analyze our Slack usage records and user interviews to extract key onboarding use cases for email campaigns",
         connectors: ["slack"],
       },
       {
-        title: "Competitor research to Notion",
-        description: "Research on X saved as structured notes in Notion",
+        id: "competitor-research-to-notion",
         prompt:
           "Research competitor [name] on X/Twitter and save the findings into our Notion research database",
         connectors: ["x", "notion"],
       },
       {
-        title: "Social media content calendar",
-        description: "Turns a Sheets calendar into posts for each network",
+        id: "social-media-content-calendar",
         prompt:
           "Generate social media content for Twitter and LinkedIn from my Google Sheets content calendar and schedule the posts",
         connectors: ["google-sheets", "x"],
       },
       {
-        title: "YouTube to X thread repurposer",
-        description:
-          "When a new YouTube video is published, generate a Notion summary and an X thread to promote it",
+        id: "youtube-to-x-thread-repurposer",
         prompt:
           "Set up a workflow that monitors my YouTube channel for new videos, creates a summary page in Notion, and generates a promotional X thread",
         connectors: ["youtube", "notion", "x"],
       },
       {
-        title: "Competitive intel scraper",
-        description:
-          "Firecrawl watches competitor sites and logs changes in Notion",
+        id: "competitive-intel-scraper",
         prompt:
           "Set up a weekly competitor scraper using Firecrawl that monitors competitor websites for pricing and feature changes, saves findings to Notion, and alerts on Slack",
         connectors: ["firecrawl", "notion", "slack"],
       },
       {
-        title: "Dev.to auto-publisher",
-        description: "Publishes Notion posts to Dev.to and links them on X",
+        id: "dev-to-auto-publisher",
         prompt:
           "Set up a workflow that publishes Notion pages tagged as 'ready' to Dev.to and posts a link on X",
         connectors: ["devto", "notion", "x"],
       },
       {
-        title: "Instagram engagement tracker",
-        description: "Engagement in Sheets with weekly Slack summaries",
+        id: "instagram-engagement-tracker",
         prompt:
           "Set up an Instagram tracker that logs post engagement metrics to Google Sheets and posts a weekly summary to Slack",
         connectors: ["instagram", "google-sheets", "slack"],
       },
       {
-        title: "SimilarWeb traffic comparison",
-        description: "Traffic benchmarks versus competitors saved in Notion",
+        id: "similarweb-traffic-comparison",
         prompt:
           "Run a monthly SimilarWeb traffic comparison between our site and top 5 competitors, save the report to Notion",
         connectors: ["similarweb", "notion"],
       },
       {
-        title: "SerpAPI keyword tracker",
-        description: "Track keyword rankings weekly and log to Sheets",
+        id: "serpapi-keyword-tracker",
         prompt:
           "Set up a weekly keyword ranking tracker using SerpAPI that monitors our target keywords and logs position changes to Google Sheets with a Slack summary",
         connectors: ["serpapi", "google-sheets", "slack"],
       },
       {
-        title: "Apify web scraper to Sheets",
-        description: "Apify scrapes sites into structured Google Sheets rows",
+        id: "apify-web-scraper-to-sheets",
         prompt:
           "Set up an Apify scraper that extracts product listings from a competitor website and saves them to Google Sheets daily",
         connectors: ["apify", "google-sheets", "slack"],
       },
       {
-        title: "Marketing automation system",
-        description:
-          "Three agents for research, weekly monitoring, and ad hoc work",
+        id: "marketing-automation-system",
         prompt:
           "Set up a marketing automation system with three agents: a daily researcher for information collection, a weekly monitor for tracking, and an on-demand agent for ad-hoc tasks",
         connectors: ["slack"],
       },
       {
-        title: "Discord community insights",
-        description: "Discord feedback in Notion with a weekly Slack digest",
+        id: "discord-community-insights",
         prompt:
           "Set up a Discord community monitor that watches for feature requests and bug reports, categorizes them in Notion, and posts a weekly digest to Slack",
         connectors: ["discord", "notion", "slack"],
       },
       {
-        title: "X brand monitor",
-        description: "Brand mentions on X saved in Notion with team alerts",
+        id: "x-brand-monitor",
         prompt:
           "Set up an X brand monitor that watches for mentions of our product, saves relevant posts to Notion, and sends Slack alerts for high-engagement posts",
         connectors: ["x", "notion", "slack"],
       },
       {
-        title: "Loops email campaign",
-        description: "Draft and send transactional emails via Loops",
+        id: "loops-email-campaign",
         prompt:
           "Set up a workflow that drafts email campaigns from Notion content and sends them through Loops",
         connectors: ["loops", "notion"],
       },
       {
-        title: "Brevo email nurture sequence",
-        description: "Automated email sequences from CRM events",
+        id: "brevo-email-nurture-sequence",
         prompt:
           "Set up a Brevo nurture sequence that sends onboarding emails when new contacts are added to a Notion database",
         connectors: ["brevo", "notion", "slack"],
@@ -314,39 +264,33 @@ const categories: readonly Category[] = [
   },
   {
     id: "creative",
-    title: "Creative",
     cases: [
       {
-        title: "ElevenLabs audio content",
-        description: "Voice narration from Notion articles saved to Drive",
+        id: "elevenlabs-audio-content",
         prompt:
           "Set up a workflow that takes blog posts from Notion, generates voice narration with ElevenLabs, and saves the audio to Google Drive",
         connectors: ["elevenlabs", "notion", "google-drive"],
       },
       {
-        title: "HeyGen video from script",
-        description: "Notion script becomes a HeyGen video with a team ping",
+        id: "heygen-video-from-script",
         prompt:
           "Set up a workflow that takes a script from Notion, generates a video with HeyGen, and sends a Slack notification when it's ready",
         connectors: ["heygen", "notion", "slack"],
       },
       {
-        title: "Runway video from brief",
-        description: "Generate short videos from a creative brief",
+        id: "runway-video-from-brief",
         prompt:
           "Take a creative brief from Notion and generate a short promotional video using Runway, then notify the team on Slack when ready",
         connectors: ["runway", "notion", "slack"],
       },
       {
-        title: "Fal AI image generation",
-        description: "Generate product images from descriptions in Notion",
+        id: "fal-ai-image-generation",
         prompt:
           "Set up a workflow that takes product descriptions from Notion, generates marketing images using Fal, and saves them to Google Drive",
         connectors: ["fal", "notion", "google-drive"],
       },
       {
-        title: "Cloudinary media optimizer",
-        description: "Optimize and transform images in bulk",
+        id: "cloudinary-media-optimizer",
         prompt:
           "Set up a workflow that takes images from Google Drive, optimizes them with Cloudinary for web use, and logs the results in Notion",
         connectors: ["cloudinary", "google-drive", "notion"],
@@ -355,53 +299,45 @@ const categories: readonly Category[] = [
   },
   {
     id: "sales",
-    title: "Sales",
     cases: [
       {
-        title: "Streak pipeline report",
-        description: "Weekly CRM pipeline stats from Gmail in Slack",
+        id: "streak-pipeline-report",
         prompt:
           "Set up a weekly Streak pipeline report that summarizes deal stages, win rates, and upcoming follow-ups, then posts to Slack",
         connectors: ["streak", "slack"],
       },
       {
-        title: "Lead follow-up pipeline",
-        description: "New leads become HubSpot tasks with Slack alerts",
+        id: "lead-follow-up-pipeline",
         prompt:
           "Set up a lead follow-up pipeline that monitors Gmail for new leads, analyzes them with AI, creates HubSpot tasks, and notifies the sales team on Slack",
         connectors: ["gmail", "hubspot", "slack"],
       },
       {
-        title: "Win/loss reporter",
-        description: "Win and loss trends from the pipeline in Slack",
+        id: "win-loss-reporter",
         prompt:
           "Set up a weekly win/loss report that analyzes our HubSpot pipeline, tracks deal outcomes, and posts trends to Slack",
         connectors: ["hubspot", "slack"],
       },
       {
-        title: "Salesforce pipeline digest",
-        description: "Weekly Salesforce opportunity updates in Slack",
+        id: "salesforce-pipeline-digest",
         prompt:
           "Set up a weekly Salesforce pipeline digest that summarizes new opportunities, stage changes, and close dates, then posts to Slack",
         connectors: ["salesforce", "slack"],
       },
       {
-        title: "Airtable deal tracker",
-        description: "Deals sync to Sheets and Slack when they close",
+        id: "airtable-deal-tracker",
         prompt:
           "Set up an Airtable deal tracker that syncs deal records to Google Sheets and sends a Slack notification when a deal is marked as closed-won",
         connectors: ["airtable", "google-sheets", "slack"],
       },
       {
-        title: "HubSpot sales reporter",
-        description: "Weekly HubSpot summaries saved as structured reports",
+        id: "hubspot-sales-reporter",
         prompt:
           "Generate a weekly HubSpot sales summary and save it as a structured report in Notion",
         connectors: ["hubspot", "notion"],
       },
       {
-        title: "Bitrix24 lead nurture",
-        description: "New Bitrix leads get follow-up tasks and Slack pings",
+        id: "bitrix24-lead-nurture",
         prompt:
           "Set up a lead nurture workflow that monitors Bitrix24 for new leads, creates follow-up tasks, and notifies sales on Slack",
         connectors: ["bitrix", "slack"],
@@ -410,40 +346,33 @@ const categories: readonly Category[] = [
   },
   {
     id: "support",
-    title: "Support",
     cases: [
       {
-        title: "Support ticket router",
-        description: "Tickets go to Notion and urgent ones ping Slack",
+        id: "support-ticket-router",
         prompt:
           "Set up a support ticket router that monitors Gmail for support emails, classifies them by category and priority, creates Notion entries, and sends Slack alerts for critical tickets",
         connectors: ["gmail", "notion", "slack"],
       },
       {
-        title: "Intercom conversation triager",
-        description: "Intercom chats become prioritized Notion tasks",
+        id: "intercom-conversation-triager",
         prompt:
           "Set up a workflow that takes Intercom conversations, classifies them, and creates structured tasks in Notion",
         connectors: ["intercom", "notion"],
       },
       {
-        title: "Zendesk → Notion knowledge base",
-        description:
-          "Extract frequently asked Zendesk questions and auto-add them to a Notion FAQ",
+        id: "zendesk-notion-knowledge-base",
         prompt:
           "Set up a workflow that identifies recurring Zendesk questions, drafts FAQ entries, and adds them to our Notion knowledge base",
         connectors: ["zendesk", "notion", "slack"],
       },
       {
-        title: "Customer support bot",
-        description: "Answers from the knowledge base and tasks for gaps",
+        id: "customer-support-bot",
         prompt:
           "Set up a customer support bot that answers questions from our Notion knowledge base and creates tasks for unanswered questions",
         connectors: ["slack", "notion"],
       },
       {
-        title: "Chatwoot → Notion support log",
-        description: "Customer conversations logged and categorized in Notion",
+        id: "chatwoot-notion-support-log",
         prompt:
           "Set up a workflow that takes Chatwoot customer conversations, categorizes them by topic, and creates structured entries in Notion",
         connectors: ["chatwoot", "notion", "slack"],
@@ -452,82 +381,69 @@ const categories: readonly Category[] = [
   },
   {
     id: "ops",
-    title: "Ops",
     cases: [
       {
-        title: "RevenueCat subscription digest",
-        description:
-          "Subscription metrics in Sheets with churn alerts in Slack",
+        id: "revenuecat-subscription-digest",
         prompt:
           "Set up a daily RevenueCat digest that tracks new subscriptions, renewals, and cancellations in Google Sheets and alerts on Slack for churn spikes",
         connectors: ["revenuecat", "google-sheets", "slack"],
       },
       {
-        title: "Xero financial summary",
-        description: "Weekly profit and cash flow from Xero in Slack",
+        id: "xero-financial-summary",
         prompt:
           "Set up a weekly Xero financial summary that pulls profit & loss and cash flow data and posts a formatted report to Slack",
         connectors: ["xero", "slack"],
       },
       {
-        title: "PDF contract processor",
-        description: "Contract fields in Notion with reminders before expiry",
+        id: "pdf-contract-processor",
         prompt:
           "Set up a workflow that processes PDF contracts, extracts key dates and terms into Notion, and sends Slack reminders before expiration dates",
         connectors: ["pdfco", "notion", "slack"],
       },
       {
-        title: "Jotform intake to Notion",
-        description: "Form answers land in Notion with Slack notifications",
+        id: "jotform-intake-to-notion",
         prompt:
           "Set up a Jotform intake that routes new form submissions to the right Notion database and sends a Slack notification",
         connectors: ["jotform", "notion", "slack"],
       },
       {
-        title: "Google Drive file organizer",
-        description: "New files sorted into folders automatically",
+        id: "google-drive-file-organizer",
         prompt:
           "Set up a workflow that watches Google Drive for new files, classifies them by content, and moves them into the right folders",
         connectors: ["google-drive"],
       },
       {
-        title: "Google Docs → Notion migrator",
-        description: "Google Docs batches into Notion with layout preserved",
+        id: "google-docs-notion-migrator",
         prompt:
           "Set up a workflow that converts a folder of Google Docs into Notion pages, preserving headings, tables, and images",
         connectors: ["google-docs", "notion"],
       },
       {
-        title: "Monday.com weekly digest",
-        description: "Weekly board progress from Monday.com in Slack",
+        id: "monday-com-weekly-digest",
         prompt:
           "Set up a weekly Monday.com digest that summarizes board activity, completed items, and blockers, then posts to Slack",
         connectors: ["monday", "slack"],
       },
       {
-        title: "Wrike project reporter",
-        description: "Weekly Wrike progress summaries in Slack",
+        id: "wrike-project-reporter",
         prompt:
           "Set up a weekly Wrike report that summarizes task completion, overdue items, and blockers across all projects, then posts to Slack",
         connectors: ["wrike", "slack"],
       },
       {
-        title: "Todoist → Notion task sync",
-        description: "Todoist tasks mirrored in Notion for the team",
+        id: "todoist-notion-task-sync",
         prompt:
           "Set up a sync that mirrors my Todoist tasks into a Notion database so the team can see what I'm working on",
         connectors: ["todoist", "notion"],
       },
       {
-        title: "ClickUp → Slack standups",
-        description: "Daily ClickUp tasks posted as a standup in Slack",
+        id: "clickup-slack-standups",
         prompt:
           "Set up a daily standup that pulls each team member's tasks from ClickUp and posts a formatted summary to Slack every morning",
         connectors: ["clickup", "slack"],
       },
       {
-        title: "AgentMail inbox",
-        description: "Create and manage inboxes with the AgentMail API",
+        id: "agentmail-inbox",
         prompt:
           "Create a new AgentMail inbox and set up email forwarding rules",
         connectors: ["agentmail"],
@@ -536,115 +452,96 @@ const categories: readonly Category[] = [
   },
   {
     id: "everyone",
-    title: "Everyone",
     cases: [
       {
-        title: "Personal weekly digest",
-        description: "Pull requests, email, and calendar in one Slack update",
+        id: "personal-weekly-digest",
         prompt:
           "Create a personal weekly report workflow that merges GitHub PRs, Gmail, and Calendar data into a summary and sends it to Slack",
         connectors: ["github", "gmail", "google-calendar", "slack"],
       },
       {
-        title: "Morning brief",
-        description:
-          "Email, calendar, and notes turned into a short daily plan",
+        id: "morning-brief",
         prompt:
           "Set up a morning brief that pulls updates from Gmail, Calendar, and Notion every morning and posts a daily plan to Slack",
         connectors: ["gmail", "google-calendar", "notion", "slack"],
       },
       {
-        title: "Strava team fitness digest",
-        description: "Weekly team activity summary posted to Slack",
+        id: "strava-team-fitness-digest",
         prompt:
           "Set up a weekly Strava digest that summarizes team members' running and cycling activities and posts a leaderboard to Slack",
         connectors: ["strava", "slack"],
       },
       {
-        title: "Email assistant",
-        description: "Morning inbox summary with suggested next steps",
+        id: "email-assistant",
         prompt:
           "Set up a daily email assistant that summarizes my inbox every morning and suggests actions for each thread",
         connectors: ["gmail"],
       },
       {
-        title: "Calendar optimizer",
-        description: "Helps with conflicts, overload, and focus time",
+        id: "calendar-optimizer",
         prompt:
           "Analyze my calendar for today and recommend how to manage conflicts, prevent overload, and schedule focus time",
         connectors: ["google-calendar"],
       },
       {
-        title: "Send messages on your behalf",
-        description: "Posts team announcements to Slack for you",
+        id: "send-messages-on-your-behalf",
         prompt:
           "Send a message to the team on my behalf: I'll be taking a day off tomorrow. Please reach out to [name] for urgent matters.",
         connectors: ["slack"],
       },
       {
-        title: "Browser screenshots",
-        description: "Opens a page in the browser and returns a screenshot",
+        id: "browser-screenshots",
         prompt:
           "Open this URL in the browser and take a screenshot: [paste URL]",
       },
       {
-        title: "Self-update instructions",
-        description: "Update the agent instructions right in chat",
+        id: "self-update-instructions",
         prompt: "Update yourself: add the following instructions — ...",
       },
       {
-        title: "Meeting notes pipeline",
-        description: "Fireflies notes to Notion with follow ups in Slack",
+        id: "meeting-notes-pipeline",
         prompt:
           "Set up a meeting notes pipeline that takes Fireflies transcripts, generates a summary in Notion, and posts action items to Slack after each meeting",
         connectors: ["fireflies", "notion", "slack"],
       },
       {
-        title: "Calendly booking sync",
-        description: "New bookings on your calendar with a Slack ping",
+        id: "calendly-booking-sync",
         prompt:
           "Set up a Calendly sync that adds new bookings to Google Calendar and sends a Slack notification with meeting details",
         connectors: ["calendly", "google-calendar", "slack"],
       },
       {
-        title: "Lark ↔ Slack message relay",
-        description: "Forwards messages between Lark and Slack both ways",
+        id: "lark-slack-message-relay",
         prompt:
           "Set up a message relay between a Lark group and a Slack channel so that messages are forwarded both ways",
         connectors: ["lark", "slack"],
       },
       {
-        title: "LINE message relay",
-        description: "Forward LINE messages to Slack and vice versa",
+        id: "line-message-relay",
         prompt:
           "Set up a message relay between a LINE group and a Slack channel so messages flow both ways",
         connectors: ["line", "slack"],
       },
       {
-        title: "tl;dv meeting recap",
-        description:
-          "Meeting recordings summarized in Notion with action items",
+        id: "tl-dv-meeting-recap",
         prompt:
           "Set up a workflow that takes tl;dv meeting recordings, generates a summary with action items in Notion, and posts highlights to Slack",
         connectors: ["tldv", "notion", "slack"],
       },
       {
-        title: "Granola notes to Notion",
-        description: "Granola meeting notes synced to a Notion database",
+        id: "granola-notes-to-notion",
         prompt:
           "Set up a sync that takes meeting notes from Granola and organizes them in a Notion database grouped by project",
         connectors: ["granola", "notion"],
       },
       {
-        title: "Perplexity deep research",
-        description: "AI-powered research summaries saved to Notion",
+        id: "perplexity-deep-research",
         prompt:
           "Use Perplexity to research a topic in depth, compile findings into a structured Notion page with sources and key insights",
         connectors: ["perplexity", "notion"],
       },
       {
-        title: "Tavily web research pipeline",
-        description: "Search the web and compile findings in Notion",
+        id: "tavily-web-research-pipeline",
         prompt:
           "Use Tavily to research the latest trends in AI agents, compile a structured report in Notion with sources and key takeaways",
         connectors: ["tavily", "notion"],

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-localization.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-localization.ts
@@ -15,22 +15,23 @@ export type IdeationCatalogCopy = Readonly<
 >;
 
 function resolveUseCaseCopy(
-  title: string,
+  id: string,
   catalogCopy: IdeationCatalogCopy,
 ): IdeationUseCaseCopy {
   for (const categoryCopy of Object.values(catalogCopy)) {
-    const copy = categoryCopy.cases[title];
+    const copy = categoryCopy.cases[id];
     if (copy) {
       return copy;
     }
   }
-  throw new Error(`Missing ideation use case copy: ${title}`);
+  throw new Error(`Missing ideation use case copy: ${id}`);
 }
 
-export function localizeIdeationUseCase<
-  T extends { readonly title: string; readonly description: string },
->(useCase: T, catalogCopy: IdeationCatalogCopy): T {
-  const copy = resolveUseCaseCopy(useCase.title, catalogCopy);
+export function localizeIdeationUseCase<T extends { readonly id: string }>(
+  useCase: T,
+  catalogCopy: IdeationCatalogCopy,
+): T & IdeationUseCaseCopy {
+  const copy = resolveUseCaseCopy(useCase.id, catalogCopy);
   return {
     ...useCase,
     title: copy.title,
@@ -51,9 +52,9 @@ export function localizeIdeationCategories(
       ...category,
       title: categoryCopy.title,
       cases: category.cases.map((useCase) => {
-        const copy = categoryCopy.cases[useCase.title];
+        const copy = categoryCopy.cases[useCase.id];
         if (!copy) {
-          throw new Error(`Missing ideation use case copy: ${useCase.title}`);
+          throw new Error(`Missing ideation use case copy: ${useCase.id}`);
         }
         return {
           ...useCase,

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-subscriptions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-subscriptions.tsx
@@ -54,6 +54,7 @@ export function AccountMenuSubscriptionsPanel({
   readonly onResetCodexUsage?: (resetCredits: number | null) => void;
   readonly resetPending?: boolean;
 }) {
+  const { t } = useTranslation();
   return (
     <div data-testid="account-menu-subscriptions" className="px-3 py-2.5">
       {loading && rows.length === 0 ? (
@@ -62,12 +63,22 @@ export function AccountMenuSubscriptionsPanel({
         <TooltipProvider delayDuration={100}>
           <div className="flex flex-col gap-2.5">
             {rows.map((row, index) => {
+              const label =
+                row.type === "codex-oauth-token"
+                  ? t(($) => {
+                      return $.settings.accountMenu.subscriptions.providers
+                        .codex;
+                    })
+                  : t(($) => {
+                      return $.settings.accountMenu.subscriptions.providers
+                        .claudeCode;
+                    });
               return (
                 <AccountMenuSubscriptionProviderSection
                   key={row.type}
                   divided={index > 0}
                   type={row.type}
-                  label={row.label}
+                  label={label}
                   usage={row.usage}
                   resetCredits={row.resetCredits}
                   resetPending={resetPending}
@@ -90,10 +101,10 @@ function AccountMenuSubscriptionsSkeleton() {
           <div key={provider.type} className="flex flex-col gap-1.5">
             {index > 0 && <div className="-mx-3 h-px bg-border" />}
             <div className="h-3 w-20 animate-pulse rounded bg-muted/60" />
-            {["5h", "week"].map((label) => {
+            {["fiveHour", "week"].map((kind) => {
               return (
                 <div
-                  key={label}
+                  key={kind}
                   className="grid grid-cols-[34px_minmax(0,1fr)_34px] items-center gap-1.5"
                 >
                   <div className="h-2.5 animate-pulse rounded bg-muted/60" />
@@ -150,10 +161,18 @@ function AccountMenuSubscriptionProviderSection({
         {label}
       </h3>
       <div className="flex flex-col gap-1">
-        {windows.map(({ label: windowLabel, window }) => {
+        {windows.map(({ kind, window }) => {
+          const windowLabel =
+            kind === "fiveHour"
+              ? t(($) => {
+                  return $.settings.accountMenu.subscriptions.windows.fiveHour;
+                })
+              : t(($) => {
+                  return $.settings.accountMenu.subscriptions.windows.week;
+                });
           return (
             <AccountMenuSubscriptionUsageBar
-              key={windowLabel}
+              key={kind}
               providerLabel={label}
               windowLabel={windowLabel}
               window={window}

--- a/turbo/apps/platform/src/views/zero-page/zero-teams-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-teams-connect-page.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tabler/icons-react";
 import { Button } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
+import { i18n } from "../../i18n/index.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { searchParams$ } from "../../signals/route.ts";
 import {
@@ -53,7 +54,11 @@ export function ZeroTeamsConnectPage() {
 
 function connectedLabel(params: URLSearchParams): string {
   return (
-    params.get("teamName") ?? params.get("tenantName") ?? "Microsoft Teams"
+    params.get("teamName") ??
+    params.get("tenantName") ??
+    i18n.t(($) => {
+      return $.connectors.providerConnect.teams.providerName;
+    })
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
@@ -291,13 +291,17 @@ function DomainSetupState({
             rel="noreferrer"
             className="font-medium text-foreground underline-offset-4 hover:underline"
           >
-            @BotFather
+            {t(($) => {
+              return $.connectors.providerConnect.telegram.botFatherHandle;
+            })}
           </a>
           {t(($) => {
             return $.connectors.providerConnect.telegram.domainSend;
           })}
           <code className="rounded border border-amber-500/30 bg-background/80 px-1 py-0.5 font-mono text-xs">
-            /setdomain
+            {t(($) => {
+              return $.connectors.providerConnect.telegram.setDomainCommand;
+            })}
           </code>
           {t(($) => {
             return $.connectors.providerConnect.telegram

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
@@ -500,7 +500,9 @@ function AddTelegramBotTokenField({
           value={botToken}
           disabled={disabled}
           autoComplete="off"
-          placeholder="123456:ABC-DEF"
+          placeholder={t(($) => {
+            return $.connectors.providerSettings.telegram.botTokenPlaceholder;
+          })}
           className="pl-9"
           onChange={(event) => {
             onBotTokenChange(event.target.value);
@@ -1900,7 +1902,10 @@ function TelegramReinstallDialog({ bot }: { bot: TelegramBot | null }) {
                 value={token}
                 disabled={reinstalling}
                 autoComplete="off"
-                placeholder="123456:ABC-DEF"
+                placeholder={t(($) => {
+                  return $.connectors.providerSettings.telegram
+                    .botTokenPlaceholder;
+                })}
                 className="pl-9"
                 onChange={(event) => {
                   setToken(event.target.value);
@@ -2202,7 +2207,10 @@ export function ZeroTelegramSettingsPage() {
               <div className="min-w-0">
                 <div className="flex min-w-0 items-center gap-2">
                   <h1 className="truncate text-lg font-semibold tracking-tight text-foreground">
-                    Telegram
+                    {t(($) => {
+                      return $.connectors.providerSettings.telegram
+                        .documentTitle;
+                    })}
                   </h1>
                 </div>
                 <p className="mt-0.5 text-sm text-muted-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -280,7 +280,11 @@ function SlackCard({ displayName }: { displayName: string }) {
             <img src={slackIconImg} alt="" className="h-7 w-7 scale-[2.2]" />
           </div>
           <div className="flex flex-1 flex-col gap-1 min-w-0">
-            <div className="text-sm font-medium text-foreground">Slack</div>
+            <div className="text-sm font-medium text-foreground">
+              {t(($) => {
+                return $.works.slack.title;
+              })}
+            </div>
             <div className="text-sm text-muted-foreground">
               {!isInstalled && !isAdmin
                 ? t(($) => {
@@ -622,7 +626,9 @@ function TeamsCard({ displayName }: { displayName: string }) {
           </div>
           <div className="flex flex-1 flex-col gap-1 min-w-0">
             <div className="text-sm font-medium text-foreground">
-              Microsoft Teams
+              {t(($) => {
+                return $.works.teams.title;
+              })}
             </div>
             <div className="text-sm text-muted-foreground">{description}</div>
           </div>
@@ -727,7 +733,9 @@ function TelegramCard() {
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <div className="flex min-w-0 items-center gap-2">
             <div className="truncate text-sm font-medium text-foreground">
-              Telegram
+              {t(($) => {
+                return $.works.telegram.title;
+              })}
             </div>
           </div>
           <div className="truncate text-sm text-muted-foreground">
@@ -760,7 +768,9 @@ function StrapiCard() {
         </div>
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <div className="truncate text-sm font-medium text-foreground">
-            Strapi
+            {t(($) => {
+              return $.works.strapi.title;
+            })}
           </div>
           <div className="truncate text-sm text-muted-foreground">
             {t(($) => {


### PR DESCRIPTION
## Summary

- migrate remaining user-visible Platform copy to typed i18n translations
- replace English-derived UI lookup keys with stable identifiers
- expand the localized UI lint to recursively cover production TypeScript and TSX files
- validate narrow technical exceptions and reject stale exclusions

## Testing

- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm knip --workspace @vm0/app
- pnpm -F @vm0/app exec vitest run --maxWorkers=4 --silent=passed-only (121 files, 1238 tests)