### PR TITLE
feat(events): report structured guest event delivery failures

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -148,11 +148,7 @@ pub(super) async fn execute_codex_app_server_for_runtime(
     log_info!(LOG_TAG, "Starting codex app-server execution...");
 
     let should_send_events = http.has_api();
-    let event_delivery = EventDeliveryRuntime::start(
-        http.clone(),
-        runtime.event_error_flag.to_string(),
-        &runtime.run_id,
-    )?;
+    let event_delivery = EventDeliveryRuntime::start(http.clone(), &runtime.run_id)?;
 
     let run_result = run_codex_app_server(
         masker,
@@ -166,12 +162,16 @@ pub(super) async fn execute_codex_app_server_for_runtime(
     .await;
 
     match run_result {
-        Ok(result) if result.control_error.is_some() => {
-            event_delivery.abort().await;
+        Ok(mut result) if result.control_error.is_some() => {
+            let delivery_report = event_delivery.abort().await;
+            result.last_event_sequence = delivery_report.last_acknowledged_sequence;
+            result.event_delivery = delivery_report.diagnostic;
             Ok(result)
         }
         Ok(mut result) => {
-            result.last_event_sequence = event_delivery.finish().await?;
+            let delivery_report = event_delivery.finish().await?;
+            result.last_event_sequence = delivery_report.last_acknowledged_sequence;
+            result.event_delivery = delivery_report.diagnostic;
             Ok(result)
         }
         Err(error) => {
@@ -365,6 +365,7 @@ async fn run_codex_app_server(
             cli_observed_exit: None,
             stderr_lines: Vec::new(),
             last_event_sequence: None,
+            event_delivery: None,
             claude_result: None,
             post_result_cleanup_result: None,
             failure_diagnostic: ingestor.failure_diagnostic(),
@@ -421,6 +422,7 @@ async fn run_codex_app_server(
                 cli_observed_exit: None,
                 stderr_lines,
                 last_event_sequence: None,
+                event_delivery: None,
                 claude_result: None,
                 post_result_cleanup_result: None,
                 failure_diagnostic: ingestor.failure_diagnostic(),
@@ -445,6 +447,7 @@ async fn run_codex_app_server(
                 cli_observed_exit: None,
                 stderr_lines,
                 last_event_sequence: None,
+                event_delivery: None,
                 claude_result: None,
                 post_result_cleanup_result: None,
                 failure_diagnostic: ingestor.failure_diagnostic(),

--- a/crates/guest-agent/src/cli/event_delivery.rs
+++ b/crates/guest-agent/src/cli/event_delivery.rs
@@ -1,17 +1,27 @@
 //! Shared CLI event delivery worker and acknowledgement state.
 //!
-//! Event schema transformation and HTTP retry details stay in `events` and
-//! `http`; this module owns bounded non-blocking admission and serial FIFO
-//! backlog batching shared by CLI backends. A batch is one retry/failure unit,
-//! and acknowledgement remains the highest contiguous successful sequence.
+//! Event schema transformation stays in `events`, while HTTP retry policy stays
+//! in `http`. This module owns bounded non-blocking admission, serial FIFO
+//! batching, and the bounded progress snapshot shared by CLI backends. A batch
+//! is one retry/failure unit, and acknowledgement remains the highest
+//! contiguous successful sequence.
 
 use crate::error::AgentError;
 use crate::events;
-use crate::http::HttpClient;
+use crate::http::{
+    HttpAttemptFailureKind, HttpAttemptFinished, HttpAttemptObserver, HttpAttemptOutcome,
+    HttpAttemptStarted, HttpClient,
+};
 use bytes::Bytes;
 use guest_common::{log_info, log_warn};
-use std::sync::Arc;
+use guest_contracts::diagnostics::{
+    EventDeliveryAcceptanceOutcome, EventDeliveryActiveAttemptDiagnostic,
+    EventDeliveryActiveBatchDiagnostic, EventDeliveryAttemptFailureKind,
+    EventDeliveryCompletedAttemptDiagnostic, EventDeliveryDiagnostic,
+    EventDeliveryDrainTimeoutDiagnostic, EventDeliveryFailedBatchDiagnostic,
+};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc};
 use tokio::task::JoinHandle;
@@ -93,20 +103,24 @@ impl EventDeliverySender {
     }
 }
 
+#[derive(Debug)]
+pub(super) struct EventDeliveryReport {
+    pub(super) last_acknowledged_sequence: Option<u32>,
+    pub(super) diagnostic: Option<EventDeliveryDiagnostic>,
+}
+
 pub(super) struct EventDeliveryRuntime {
     sender: EventDeliverySender,
-    worker: JoinHandle<Option<u32>>,
+    worker: JoinHandle<Result<(), AgentError>>,
     pressure: Arc<DeliveryPressure>,
+    progress: Arc<Mutex<DeliveryProgress>>,
 }
 
 impl EventDeliveryRuntime {
-    pub(super) fn start(
-        http: HttpClient,
-        event_error_flag: String,
-        run_id: &str,
-    ) -> Result<Self, AgentError> {
+    pub(super) fn start(http: HttpClient, run_id: &str) -> Result<Self, AgentError> {
         let (tx, event_rx) = mpsc::channel(EVENT_DELIVERY_QUEUE_CAPACITY);
         let pressure = Arc::new(DeliveryPressure::default());
+        let progress = Arc::new(Mutex::new(DeliveryProgress::default()));
         let payload_envelope = Arc::new(events::EventPayloadEnvelope::new(run_id)?);
         let sender = EventDeliverySender {
             tx,
@@ -117,14 +131,15 @@ impl EventDeliveryRuntime {
         let worker = tokio::spawn(run_event_sender(
             event_rx,
             http,
-            event_error_flag,
             payload_envelope,
             Arc::clone(&pressure),
+            Arc::clone(&progress),
         ));
         Ok(Self {
             sender,
             worker,
             pressure,
+            progress,
         })
     }
 
@@ -132,49 +147,63 @@ impl EventDeliveryRuntime {
         &self.sender
     }
 
-    pub(super) async fn finish(self) -> Result<Option<u32>, AgentError> {
+    pub(super) async fn finish(self) -> Result<EventDeliveryReport, AgentError> {
         let Self {
             sender,
             mut worker,
             pressure,
+            progress,
         } = self;
         drop(sender);
         let drain_start = pressure.snapshot();
         log_info!(
             LOG_TAG,
-            "Event delivery drain started: pending_events={} buffered_bytes={}",
+            "Event delivery drain started: pending_events={} queued_bytes={} buffered_bytes={}",
             drain_start.pending_events,
+            drain_start.queued_bytes,
             drain_start.buffered_bytes
         );
 
         match tokio::time::timeout(EVENT_DELIVERY_DRAIN_TIMEOUT, &mut worker).await {
-            Ok(Ok(sequence)) => Ok(sequence),
+            Ok(Ok(Ok(()))) => Ok(progress_report(&progress, None)),
+            Ok(Ok(Err(error))) => Err(AgentError::Execution(format!(
+                "CLI event delivery worker failed: {error}"
+            ))),
             Ok(Err(error)) => Err(AgentError::Execution(format!(
                 "CLI event delivery worker failed: {error}"
             ))),
             Err(_) => {
+                // Freeze both independently updated state holders before
+                // composing one deadline snapshot. The active request context
+                // lives in shared progress and survives cancellation.
                 worker.abort();
                 let _ = worker.await;
-                let snapshot = pressure.snapshot();
-                Err(AgentError::Execution(format!(
-                    "CLI event delivery did not drain within {} seconds: {} events pending, {} bytes buffered",
+                let pressure_snapshot = pressure.snapshot();
+                let report = progress_report(&progress, Some(pressure_snapshot));
+                log_warn!(
+                    LOG_TAG,
+                    "CLI event delivery did not drain within {} seconds: {} events queued, {} queued bytes, {} bytes buffered",
                     EVENT_DELIVERY_DRAIN_TIMEOUT.as_secs(),
-                    snapshot.pending_events,
-                    snapshot.buffered_bytes
-                )))
+                    pressure_snapshot.pending_events,
+                    pressure_snapshot.queued_bytes,
+                    pressure_snapshot.buffered_bytes
+                );
+                Ok(report)
             }
         }
     }
 
-    pub(super) async fn abort(self) {
+    pub(super) async fn abort(self) -> EventDeliveryReport {
         let Self {
             sender,
             worker,
             pressure: _,
+            progress,
         } = self;
         drop(sender);
         worker.abort();
         let _ = worker.await;
+        progress_report(&progress, None)
     }
 }
 
@@ -187,6 +216,7 @@ struct AdmissionPressure {
 #[derive(Clone, Copy)]
 struct DeliveryPressureSnapshot {
     pending_events: usize,
+    queued_bytes: usize,
     buffered_bytes: usize,
     max_pending_events: usize,
     max_buffered_bytes: usize,
@@ -195,6 +225,7 @@ struct DeliveryPressureSnapshot {
 #[derive(Default)]
 struct DeliveryPressure {
     pending_events: AtomicUsize,
+    queued_bytes: AtomicUsize,
     buffered_bytes: AtomicUsize,
     max_pending_events: AtomicUsize,
     max_buffered_bytes: AtomicUsize,
@@ -202,6 +233,7 @@ struct DeliveryPressure {
 
 impl DeliveryPressure {
     fn begin_admission(&self, bytes: usize) -> AdmissionPressure {
+        self.queued_bytes.fetch_add(bytes, Ordering::Relaxed);
         AdmissionPressure {
             pending_events: self.pending_events.fetch_add(1, Ordering::Relaxed) + 1,
             buffered_bytes: self.buffered_bytes.fetch_add(bytes, Ordering::Relaxed) + bytes,
@@ -217,11 +249,13 @@ impl DeliveryPressure {
 
     fn reject_admission(&self, bytes: usize) {
         self.pending_events.fetch_sub(1, Ordering::Relaxed);
+        self.queued_bytes.fetch_sub(bytes, Ordering::Relaxed);
         self.buffered_bytes.fetch_sub(bytes, Ordering::Relaxed);
     }
 
-    fn mark_dequeued(&self) {
+    fn mark_dequeued(&self, bytes: usize) {
         self.pending_events.fetch_sub(1, Ordering::Relaxed);
+        self.queued_bytes.fetch_sub(bytes, Ordering::Relaxed);
     }
 
     fn release_bytes(&self, bytes: usize) {
@@ -239,6 +273,7 @@ impl DeliveryPressure {
     fn snapshot(&self) -> DeliveryPressureSnapshot {
         DeliveryPressureSnapshot {
             pending_events: self.pending_events(),
+            queued_bytes: self.queued_bytes.load(Ordering::Relaxed),
             buffered_bytes: self.buffered_bytes(),
             max_pending_events: self.max_pending_events.load(Ordering::Relaxed),
             max_buffered_bytes: self.max_buffered_bytes.load(Ordering::Relaxed),
@@ -278,16 +313,137 @@ impl AckedEventPrefix {
     }
 }
 
+#[derive(Default)]
+struct DeliveryProgress {
+    acked_prefix: AckedEventPrefix,
+    total_events: u64,
+    total_batches: u64,
+    failed_batches: u64,
+    max_batch_events: usize,
+    max_batch_bytes: usize,
+    first_failed_batch: Option<EventDeliveryFailedBatchDiagnostic>,
+    active_batch: Option<ActiveBatchProgress>,
+    carried_event_bytes: Option<usize>,
+}
+
+impl DeliveryProgress {
+    fn begin_batch(
+        &mut self,
+        sequences: Vec<u32>,
+        first_sequence: u32,
+        last_sequence: u32,
+        conservative_bytes: usize,
+        carried_event_bytes: Option<usize>,
+    ) {
+        let event_count = sequences.len();
+        self.total_events = self.total_events.saturating_add(usize_to_u64(event_count));
+        self.total_batches = self.total_batches.saturating_add(1);
+        self.max_batch_events = self.max_batch_events.max(event_count);
+        self.max_batch_bytes = self.max_batch_bytes.max(conservative_bytes);
+        self.active_batch = Some(ActiveBatchProgress {
+            sequences,
+            first_sequence,
+            last_sequence,
+            conservative_bytes,
+            completed_attempts: Vec::new(),
+            active_attempt: None,
+        });
+        self.carried_event_bytes = carried_event_bytes;
+    }
+
+    fn finish_batch(&mut self, succeeded: bool) -> Result<(), AgentError> {
+        let active_batch = self.active_batch.take().ok_or_else(|| {
+            AgentError::Execution(
+                "event delivery batch state disappeared before completion".to_string(),
+            )
+        })?;
+        if succeeded {
+            for sequence in active_batch.sequences {
+                self.acked_prefix.record_success(sequence);
+            }
+            return Ok(());
+        }
+
+        self.acked_prefix
+            .record_failure(active_batch.first_sequence);
+        self.failed_batches = self.failed_batches.saturating_add(1);
+        if self.first_failed_batch.is_none() {
+            let event_count = usize_to_u32(active_batch.sequences.len());
+            let conservative_bytes = usize_to_u64(active_batch.conservative_bytes);
+            let attempts = active_batch.completed_attempts;
+            let outcome = acceptance_outcome(&attempts);
+            self.first_failed_batch = Some(EventDeliveryFailedBatchDiagnostic {
+                first_sequence: active_batch.first_sequence,
+                last_sequence: active_batch.last_sequence,
+                event_count,
+                conservative_bytes,
+                outcome,
+                attempts,
+            });
+        }
+        Ok(())
+    }
+}
+
+struct ActiveBatchProgress {
+    sequences: Vec<u32>,
+    first_sequence: u32,
+    last_sequence: u32,
+    conservative_bytes: usize,
+    completed_attempts: Vec<EventDeliveryCompletedAttemptDiagnostic>,
+    active_attempt: Option<HttpAttemptStarted>,
+}
+
+struct DeliveryAttemptObserver {
+    progress: Arc<Mutex<DeliveryProgress>>,
+}
+
+impl HttpAttemptObserver for DeliveryAttemptObserver {
+    fn attempt_started(&self, attempt: HttpAttemptStarted) -> Result<(), AgentError> {
+        let mut progress = progress_guard(&self.progress);
+        let active_batch = progress.active_batch.as_mut().ok_or_else(|| {
+            AgentError::Execution(
+                "event delivery batch state missing before HTTP attempt".to_string(),
+            )
+        })?;
+        active_batch.active_attempt = Some(attempt);
+        Ok(())
+    }
+
+    fn attempt_finished(&self, attempt: HttpAttemptFinished) -> Result<(), AgentError> {
+        let mut progress = progress_guard(&self.progress);
+        let active_batch = progress.active_batch.as_mut().ok_or_else(|| {
+            AgentError::Execution(
+                "event delivery batch state missing after HTTP attempt".to_string(),
+            )
+        })?;
+        active_batch.active_attempt = None;
+        if let HttpAttemptOutcome::Failure { kind, http_status } = attempt.outcome {
+            active_batch
+                .completed_attempts
+                .push(EventDeliveryCompletedAttemptDiagnostic {
+                    attempt: attempt.attempt,
+                    client_request_id: attempt.client_request_id,
+                    elapsed_ms: attempt.elapsed_ms,
+                    failure_kind: event_attempt_failure_kind(kind),
+                    http_status,
+                });
+        }
+        Ok(())
+    }
+}
+
 async fn run_event_sender(
     mut event_rx: mpsc::Receiver<PreparedEvent>,
     http: HttpClient,
-    event_error_flag: String,
     payload_envelope: Arc<events::EventPayloadEnvelope>,
     pressure: Arc<DeliveryPressure>,
-) -> Option<u32> {
-    let mut acked_prefix = AckedEventPrefix::default();
+    progress: Arc<Mutex<DeliveryProgress>>,
+) -> Result<(), AgentError> {
+    let observer = DeliveryAttemptObserver {
+        progress: Arc::clone(&progress),
+    };
     let mut carried_event = None;
-    let mut stats = DeliveryStats::default();
 
     loop {
         let first_event = match carried_event.take() {
@@ -296,7 +452,7 @@ async fn run_event_sender(
                 let Some(event) = event_rx.recv().await else {
                     break;
                 };
-                pressure.mark_dequeued();
+                pressure.mark_dequeued(event.conservative_bytes);
                 event
             }
         };
@@ -311,13 +467,20 @@ async fn run_event_sender(
             byte_budgets,
         } = EventBatch::new(batch, &payload_envelope);
         let event_count = sequences.len();
-        let send_result =
-            events::post_serialized_event_with_error_flag(&http, payload, &event_error_flag).await;
+        progress_guard(&progress).begin_batch(
+            sequences.clone(),
+            first_sequence,
+            last_sequence,
+            conservative_bytes,
+            carried_event.as_ref().map(|event| event.conservative_bytes),
+        );
+
+        let send_result = events::post_serialized_event(&http, payload, &observer).await;
         drop(byte_budgets);
         pressure.release_bytes(conservative_bytes);
+        progress_guard(&progress).finish_batch(send_result.is_ok())?;
 
         let succeeded = send_result.is_ok();
-        stats.record_request(event_count, conservative_bytes, succeeded);
         log_info!(
             LOG_TAG,
             "Event delivery request: first_sequence={first_sequence} last_sequence={last_sequence} events={event_count} conservative_bytes={conservative_bytes} result={} queued_events_remaining={}",
@@ -325,36 +488,29 @@ async fn run_event_sender(
             pressure.pending_events() + usize::from(carried_event.is_some())
         );
 
-        match send_result {
-            Ok(()) => {
-                for sequence in sequences {
-                    acked_prefix.record_success(sequence);
-                }
-            }
-            Err(e) => {
-                acked_prefix.record_failure(first_sequence);
-                log_warn!(
-                    LOG_TAG,
-                    "Event send failed for sequences {first_sequence}-{last_sequence}: {e}"
-                );
-            }
+        if let Err(error) = send_result {
+            log_warn!(
+                LOG_TAG,
+                "Event send failed for sequences {first_sequence}-{last_sequence}: {error}"
+            );
         }
     }
 
-    let last_contiguous = acked_prefix.last_contiguous();
     let pressure = pressure.snapshot();
+    let progress = progress_guard(&progress);
     log_info!(
         LOG_TAG,
-        "Event delivery complete: events={} requests={} failed_requests={} max_batch_events={} max_batch_bytes={} max_pending_events={} max_buffered_bytes={} last_contiguous_sequence={last_contiguous:?}",
-        stats.total_events,
-        stats.total_requests,
-        stats.failed_requests,
-        stats.max_batch_events,
-        stats.max_batch_bytes,
+        "Event delivery complete: events={} requests={} failed_requests={} max_batch_events={} max_batch_bytes={} max_pending_events={} max_buffered_bytes={} last_contiguous_sequence={:?}",
+        progress.total_events,
+        progress.total_batches,
+        progress.failed_batches,
+        progress.max_batch_events,
+        progress.max_batch_bytes,
         pressure.max_pending_events,
-        pressure.max_buffered_bytes
+        pressure.max_buffered_bytes,
+        progress.acked_prefix.last_contiguous()
     );
-    last_contiguous
+    Ok(())
 }
 
 fn collect_batch(
@@ -369,7 +525,7 @@ fn collect_batch(
     while batch.len() < EVENT_DELIVERY_MAX_REQUEST_EVENTS {
         let next_event = match event_rx.try_recv() {
             Ok(event) => {
-                pressure.mark_dequeued();
+                pressure.mark_dequeued(event.conservative_bytes);
                 event
             }
             Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected) => {
@@ -416,23 +572,90 @@ impl EventBatch {
     }
 }
 
-#[derive(Default)]
-struct DeliveryStats {
-    total_events: usize,
-    total_requests: usize,
-    failed_requests: usize,
-    max_batch_events: usize,
-    max_batch_bytes: usize,
+fn progress_report(
+    progress: &Arc<Mutex<DeliveryProgress>>,
+    drain_pressure: Option<DeliveryPressureSnapshot>,
+) -> EventDeliveryReport {
+    let progress = progress_guard(progress);
+    let last_acknowledged_sequence = progress.acked_prefix.last_contiguous();
+    let drain_timeout = drain_pressure.map(|pressure| EventDeliveryDrainTimeoutDiagnostic {
+        queued_events: usize_to_u32(pressure.pending_events),
+        queued_bytes: usize_to_u64(pressure.queued_bytes),
+        carried_events: u32::from(progress.carried_event_bytes.is_some()),
+        carried_bytes: progress.carried_event_bytes.map_or(0, usize_to_u64),
+        active_batch: progress.active_batch.as_ref().map(active_batch_diagnostic),
+    });
+    let has_failure = progress.first_failed_batch.is_some() || drain_timeout.is_some();
+    let diagnostic = has_failure.then(|| EventDeliveryDiagnostic {
+        total_events: progress.total_events,
+        total_batches: progress.total_batches,
+        failed_batches: progress.failed_batches,
+        last_acknowledged_sequence,
+        first_failed_batch: progress.first_failed_batch.clone(),
+        drain_timeout,
+    });
+    EventDeliveryReport {
+        last_acknowledged_sequence,
+        diagnostic,
+    }
 }
 
-impl DeliveryStats {
-    fn record_request(&mut self, events: usize, bytes: usize, succeeded: bool) {
-        self.total_events += events;
-        self.total_requests += 1;
-        self.failed_requests += usize::from(!succeeded);
-        self.max_batch_events = self.max_batch_events.max(events);
-        self.max_batch_bytes = self.max_batch_bytes.max(bytes);
+fn active_batch_diagnostic(active: &ActiveBatchProgress) -> EventDeliveryActiveBatchDiagnostic {
+    EventDeliveryActiveBatchDiagnostic {
+        first_sequence: active.first_sequence,
+        last_sequence: active.last_sequence,
+        event_count: usize_to_u32(active.sequences.len()),
+        conservative_bytes: usize_to_u64(active.conservative_bytes),
+        completed_attempts: active.completed_attempts.clone(),
+        active_attempt: active.active_attempt.as_ref().map(|attempt| {
+            EventDeliveryActiveAttemptDiagnostic {
+                attempt: attempt.attempt,
+                client_request_id: attempt.client_request_id.clone(),
+                elapsed_ms: u64::try_from(attempt.started_at.elapsed().as_millis())
+                    .unwrap_or(u64::MAX),
+            }
+        }),
+        outcome: EventDeliveryAcceptanceOutcome::OutcomeUnknown,
     }
+}
+
+fn acceptance_outcome(
+    attempts: &[EventDeliveryCompletedAttemptDiagnostic],
+) -> EventDeliveryAcceptanceOutcome {
+    if !attempts.is_empty()
+        && attempts
+            .iter()
+            .all(|attempt| attempt.failure_kind == EventDeliveryAttemptFailureKind::HttpStatus)
+    {
+        EventDeliveryAcceptanceOutcome::ConfirmedRejection
+    } else {
+        EventDeliveryAcceptanceOutcome::OutcomeUnknown
+    }
+}
+
+fn event_attempt_failure_kind(kind: HttpAttemptFailureKind) -> EventDeliveryAttemptFailureKind {
+    match kind {
+        HttpAttemptFailureKind::Timeout => EventDeliveryAttemptFailureKind::Timeout,
+        HttpAttemptFailureKind::Connect => EventDeliveryAttemptFailureKind::Connect,
+        HttpAttemptFailureKind::HttpStatus => EventDeliveryAttemptFailureKind::HttpStatus,
+        HttpAttemptFailureKind::Transport => EventDeliveryAttemptFailureKind::Transport,
+    }
+}
+
+fn progress_guard(
+    progress: &Arc<Mutex<DeliveryProgress>>,
+) -> std::sync::MutexGuard<'_, DeliveryProgress> {
+    progress
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn usize_to_u32(value: usize) -> u32 {
+    u32::try_from(value).unwrap_or(u32::MAX)
+}
+
+fn usize_to_u64(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -51,7 +51,8 @@ use framework::CliFrameworkBehavior;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
 use guest_contracts::diagnostics::{
-    CliObservedExitDiagnostic, CliTerminationDiagnostic, FailureDetailSource, FailureReason,
+    CliObservedExitDiagnostic, CliTerminationDiagnostic, EventDeliveryDiagnostic,
+    FailureDetailSource, FailureReason,
 };
 use process_group::ChildProcessGroup;
 use std::borrow::Cow;
@@ -248,6 +249,9 @@ pub struct CliExecutionResult {
     /// was successfully posted.
     pub last_event_sequence: Option<u32>,
 
+    /// Bounded event-delivery failure details, when delivery was terminally incomplete.
+    pub event_delivery: Option<EventDeliveryDiagnostic>,
+
     /// Claude Code's final result metadata, when a terminal result event was
     /// observed. Codex uses its own event schema and leaves this unset.
     pub claude_result: Option<ClaudeResultSummary>,
@@ -344,7 +348,6 @@ pub(super) struct CliRuntimeConfig<'a> {
     agent_log_file: Cow<'a, str>,
     session_id_file: Cow<'a, str>,
     session_history_path_file: Cow<'a, str>,
-    event_error_flag: Cow<'a, str>,
     user_env: &'a HashMap<String, String>,
 }
 
@@ -419,7 +422,6 @@ impl<'a> CliRuntimeConfig<'a> {
             agent_log_file: Cow::Borrowed(paths.agent_log_file()),
             session_id_file: Cow::Borrowed(paths.session_id_file()),
             session_history_path_file: Cow::Borrowed(paths.session_history_path_file()),
-            event_error_flag: Cow::Borrowed(paths.event_error_flag()),
             user_env: &config.user_env,
         })
     }
@@ -930,11 +932,7 @@ async fn execute_cli_inner(
     // no collection delay or concurrent POST path. Overload enters controlled
     // CLI termination rather than blocking stdout.
     let mut should_send_events = http.has_api();
-    let event_delivery = EventDeliveryRuntime::start(
-        http.clone(),
-        runtime.event_error_flag.to_string(),
-        &runtime.run_id,
-    )?;
+    let event_delivery = EventDeliveryRuntime::start(http.clone(), &runtime.run_id)?;
 
     let mut heartbeat_done = false;
     let mut user_cancellation_handled = false;
@@ -1515,12 +1513,11 @@ async fn execute_cli_inner(
 
     // On success, boundedly drain accepted events. On any execution or
     // control error, abort unsent delivery rather than stalling on retries.
-    let delivery_result = if event_error.is_none() && !has_control_error {
+    let delivery_report = if event_error.is_none() && !has_control_error {
         event_delivery.finish().await
     } else {
-        event_delivery.abort().await;
-        Ok(None)
-    };
+        Ok(event_delivery.abort().await)
+    }?;
     let status = match cli_status {
         Some(s) => s,
         None => {
@@ -1573,13 +1570,13 @@ async fn execute_cli_inner(
     if let Some(err) = event_error {
         return Err(err);
     }
-    let last_event_sequence = delivery_result?;
 
     Ok(CliExecutionResult {
         exit_code,
         cli_observed_exit,
         stderr_lines: masked_stderr_lines,
-        last_event_sequence,
+        last_event_sequence: delivery_report.last_acknowledged_sequence,
+        event_delivery: delivery_report.diagnostic,
         claude_result,
         post_result_cleanup_result,
         failure_diagnostic: event_ingestor.failure_diagnostic(),
@@ -1796,7 +1793,6 @@ mod tests {
             agent_log_file: Cow::Borrowed("/tmp/agent.log"),
             session_id_file: Cow::Borrowed("/tmp/session-id"),
             session_history_path_file: Cow::Borrowed("/tmp/session-history-path"),
-            event_error_flag: Cow::Borrowed("/tmp/event-error"),
             user_env,
         }
     }

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -10,7 +10,7 @@ use crate::failure_patterns::{
     has_exact_codex_oauth_connector, is_codex_context_window_exceeded_message,
     is_codex_model_capacity_message, is_generic_codex_failure_diagnostic,
 };
-use crate::http::HttpClient;
+use crate::http::{HttpAttemptObserver, HttpClient};
 use crate::masker::SecretMasker;
 use crate::paths;
 use crate::session_metadata;
@@ -64,7 +64,7 @@ pub async fn send_event_for_config(
     }
 
     let payload = prepare_event_payload_for_run_id(event, seq, masker, &config.run_id);
-    post_event_with_error_flag(http, &payload, paths.event_error_flag()).await
+    post_event(http, &payload).await
 }
 
 pub fn prepare_event_payload_for_run_id(
@@ -432,42 +432,21 @@ fn truncate_diagnostic_message(message: &str) -> String {
     format!("{}{}", &message[..end], FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX)
 }
 
-pub async fn post_event_with_error_flag(
-    http: &HttpClient,
-    payload: &Value,
-    event_error_flag: &str,
-) -> Result<(), AgentError> {
+pub async fn post_event(http: &HttpClient, payload: &Value) -> Result<(), AgentError> {
     let url = http.events_url()?;
-    let result = http
-        .post_json(url, payload, constants::HTTP_MAX_ATTEMPTS)
-        .await;
-    handle_event_post_result(result, event_error_flag)
+    let payload = Bytes::from(serde_json::to_vec(payload)?);
+    http.post_event_bytes(url, payload, constants::HTTP_MAX_ATTEMPTS, None)
+        .await
 }
 
-pub(crate) async fn post_serialized_event_with_error_flag(
+pub(crate) async fn post_serialized_event(
     http: &HttpClient,
     payload: Bytes,
-    event_error_flag: &str,
+    observer: &dyn HttpAttemptObserver,
 ) -> Result<(), AgentError> {
     let url = http.events_url()?;
-    let result = http
-        .post_json_bytes(url, payload, constants::HTTP_MAX_ATTEMPTS)
-        .await;
-    handle_event_post_result(result, event_error_flag)
-}
-
-fn handle_event_post_result(
-    result: Result<Option<Value>, AgentError>,
-    event_error_flag: &str,
-) -> Result<(), AgentError> {
-    match result {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            log_error!(LOG_TAG, "Failed to send event after retries");
-            let _ = paths::write_private(event_error_flag, "1");
-            Err(e)
-        }
-    }
+    http.post_event_bytes(url, payload, constants::HTTP_MAX_ATTEMPTS, Some(observer))
+        .await
 }
 
 /// Tool event extracted from a Claude Code JSONL line.

--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -12,8 +12,9 @@ use crate::paths;
 use crate::session_metadata;
 use guest_common::{log_info, log_warn};
 use guest_contracts::diagnostics::{
-    AgentFramework, CliObservedExitDiagnostic, CliTerminationDiagnostic, FailureClass,
-    FailureDetailSource, FailureDiagnostic, FailureReason, PromptMetadata, SessionHistoryStatus,
+    AgentFramework, CliObservedExitDiagnostic, CliTerminationDiagnostic, EventDeliveryDiagnostic,
+    FailureClass, FailureDetailSource, FailureDiagnostic, FailureReason, PromptMetadata,
+    SessionHistoryStatus,
 };
 use serde_json::Value;
 use std::io::ErrorKind;
@@ -67,6 +68,26 @@ pub fn cli_control_failure_for_config(
         cli_result.exit_code,
         cli_result.claude_result,
     );
+    let diagnostic =
+        with_cli_observed_exit(diagnostic, cli_result.cli_observed_exit.as_ref().cloned());
+    with_cli_termination(diagnostic, cli_result.cli_termination)
+}
+
+/// Build the primary diagnostic for terminal event delivery after a CLI result.
+pub fn event_delivery_failure_for_config(
+    config: &env::GuestConfig,
+    runtime_paths: &paths::GuestPaths,
+    cli_result: &cli::CliExecutionResult,
+    event_delivery: EventDeliveryDiagnostic,
+) -> FailureDiagnostic {
+    let diagnostic = cli_result_failure_diagnostic_for_config(
+        config,
+        runtime_paths,
+        FailureClass::EventUploadFailed,
+        cli_result.exit_code,
+        cli_result.claude_result,
+    )
+    .with_event_delivery(event_delivery);
     let diagnostic =
         with_cli_observed_exit(diagnostic, cli_result.cli_observed_exit.as_ref().cloned());
     with_cli_termination(diagnostic, cli_result.cli_termination)

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -23,12 +23,55 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncSeekExt, ReadBuf};
+use tokio::time::Instant;
 use uuid::Uuid;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const HTTP_TOO_MANY_REQUESTS: u16 = 429;
 const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(1);
 const GUEST_AGENT_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Content-safe facts published before one event request is awaited.
+#[derive(Debug, Clone)]
+pub(crate) struct HttpAttemptStarted {
+    pub attempt: u32,
+    pub client_request_id: String,
+    pub started_at: Instant,
+}
+
+/// Content-safe facts published after one event request completes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HttpAttemptFinished {
+    pub attempt: u32,
+    pub client_request_id: String,
+    pub elapsed_ms: u64,
+    pub outcome: HttpAttemptOutcome,
+}
+
+/// Transport outcome for an observed event request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HttpAttemptOutcome {
+    Success,
+    Failure {
+        kind: HttpAttemptFailureKind,
+        http_status: Option<u16>,
+    },
+}
+
+/// Content-safe failure classification for an observed request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HttpAttemptFailureKind {
+    Timeout,
+    Connect,
+    HttpStatus,
+    Transport,
+}
+
+/// Synchronous observer for the event delivery request path.
+pub(crate) trait HttpAttemptObserver: Send + Sync {
+    fn attempt_started(&self, attempt: HttpAttemptStarted) -> Result<(), AgentError>;
+    fn attempt_finished(&self, attempt: HttpAttemptFinished) -> Result<(), AgentError>;
+}
 
 fn format_reqwest_error(error: reqwest::Error) -> String {
     error.without_url().to_string()
@@ -261,6 +304,27 @@ impl ApiUrls {
     }
 }
 
+struct RetryRequest {
+    builder: RequestBuilder,
+    client_request_id: Option<String>,
+}
+
+impl RetryRequest {
+    fn unobserved(builder: RequestBuilder) -> Self {
+        Self {
+            builder,
+            client_request_id: None,
+        }
+    }
+
+    fn observed(builder: RequestBuilder, client_request_id: String) -> Self {
+        Self {
+            builder,
+            client_request_id: Some(client_request_id),
+        }
+    }
+}
+
 async fn send_with_retry<BuildRequest, BuildRequestFuture, BuildClientError, ClientErrorFuture>(
     label: &str,
     max_attempts: u32,
@@ -268,18 +332,47 @@ async fn send_with_retry<BuildRequest, BuildRequestFuture, BuildClientError, Cli
     final_error: String,
     mut build_request: BuildRequest,
     mut build_client_error: BuildClientError,
+    observer: Option<&dyn HttpAttemptObserver>,
 ) -> Result<Response, AgentError>
 where
     BuildRequest: FnMut() -> BuildRequestFuture,
-    BuildRequestFuture: Future<Output = Result<RequestBuilder, AgentError>>,
+    BuildRequestFuture: Future<Output = Result<RetryRequest, AgentError>>,
     BuildClientError: FnMut(Response, u32, u32) -> ClientErrorFuture,
     ClientErrorFuture: Future<Output = AgentError>,
 {
     for attempt in 1..=max_attempts {
-        match build_request().await?.send().await {
-            Ok(resp) if resp.status().is_success() => return Ok(resp),
+        let request = build_request().await?;
+        let active_attempt =
+            request
+                .client_request_id
+                .map(|client_request_id| HttpAttemptStarted {
+                    attempt,
+                    client_request_id,
+                    started_at: Instant::now(),
+                });
+        if let Some(observer) = observer {
+            let started = active_attempt.as_ref().ok_or_else(|| {
+                AgentError::Execution(
+                    "observed HTTP request omitted its client request ID".to_string(),
+                )
+            })?;
+            observer.attempt_started(started.clone())?;
+        }
+        match request.builder.send().await {
+            Ok(resp) if resp.status().is_success() => {
+                observe_attempt_finished(observer, active_attempt, HttpAttemptOutcome::Success)?;
+                return Ok(resp);
+            }
             Ok(resp) => {
                 let status = resp.status();
+                observe_attempt_finished(
+                    observer,
+                    active_attempt,
+                    HttpAttemptOutcome::Failure {
+                        kind: HttpAttemptFailureKind::HttpStatus,
+                        http_status: Some(status.as_u16()),
+                    },
+                )?;
                 // 4xx errors are deterministic except for rate limits.
                 if status.is_client_error() && status.as_u16() != HTTP_TOO_MANY_REQUESTS {
                     return Err(build_client_error(resp, attempt, max_attempts).await);
@@ -290,6 +383,21 @@ where
                 );
             }
             Err(error) => {
+                let failure_kind = if error.is_timeout() {
+                    HttpAttemptFailureKind::Timeout
+                } else if error.is_connect() {
+                    HttpAttemptFailureKind::Connect
+                } else {
+                    HttpAttemptFailureKind::Transport
+                };
+                observe_attempt_finished(
+                    observer,
+                    active_attempt,
+                    HttpAttemptOutcome::Failure {
+                        kind: failure_kind,
+                        http_status: None,
+                    },
+                )?;
                 let error = format_reqwest_error(error);
                 log_warn!(
                     LOG_TAG,
@@ -304,6 +412,25 @@ where
     }
 
     Err(AgentError::Http(final_error))
+}
+
+fn observe_attempt_finished(
+    observer: Option<&dyn HttpAttemptObserver>,
+    started: Option<HttpAttemptStarted>,
+    outcome: HttpAttemptOutcome,
+) -> Result<(), AgentError> {
+    let Some(observer) = observer else {
+        return Ok(());
+    };
+    let started = started.ok_or_else(|| {
+        AgentError::Execution("observed HTTP attempt lost its request context".to_string())
+    })?;
+    observer.attempt_finished(HttpAttemptFinished {
+        attempt: started.attempt,
+        client_request_id: started.client_request_id,
+        elapsed_ms: u64::try_from(started.started_at.elapsed().as_millis()).unwrap_or(u64::MAX),
+        outcome,
+    })
 }
 
 impl HttpClient {
@@ -329,9 +456,44 @@ impl HttpClient {
         body: Bytes,
         max_attempts: u32,
     ) -> Result<Option<Value>, AgentError> {
+        let resp = self
+            .post_json_response(url, body, max_attempts, None)
+            .await?;
+
+        let text = resp
+            .text()
+            .await
+            .map_err(|error| AgentError::Http(format_reqwest_error(error)))?;
+        if text.is_empty() {
+            return Ok(None);
+        }
+        let val: Value =
+            serde_json::from_str(&text).map_err(|e| AgentError::Http(e.to_string()))?;
+        Ok(Some(val))
+    }
+
+    pub(crate) async fn post_event_bytes(
+        &self,
+        url: &str,
+        body: Bytes,
+        max_attempts: u32,
+        observer: Option<&dyn HttpAttemptObserver>,
+    ) -> Result<(), AgentError> {
+        self.post_json_response(url, body, max_attempts, observer)
+            .await?;
+        Ok(())
+    }
+
+    async fn post_json_response(
+        &self,
+        url: &str,
+        body: Bytes,
+        max_attempts: u32,
+        observer: Option<&dyn HttpAttemptObserver>,
+    ) -> Result<Response, AgentError> {
         let client = self.inner()?;
         let api = self.api_config()?;
-        let resp = send_with_retry(
+        send_with_retry(
             "POST",
             max_attempts,
             self.retry_delay,
@@ -352,9 +514,9 @@ impl HttpClient {
                     .header(CLIENT_VERSION_HEADER, GUEST_AGENT_CLIENT_VERSION)
                     .header(CLIENT_TYPE_HEADER, CLIENT_TYPE_GUEST_AGENT)
                     .header(CLIENT_SESSION_ID_HEADER, api.client_session_id.as_str())
-                    .header(CLIENT_REQUEST_ID_HEADER, request_id);
+                    .header(CLIENT_REQUEST_ID_HEADER, &request_id);
 
-                std::future::ready(Ok(req))
+                std::future::ready(Ok(RetryRequest::observed(req, request_id)))
             },
             |resp, attempt, max_attempts| {
                 let url = url.to_owned();
@@ -388,19 +550,9 @@ impl HttpClient {
                     }
                 }
             },
+            observer,
         )
-        .await?;
-
-        let text = resp
-            .text()
-            .await
-            .map_err(|error| AgentError::Http(format_reqwest_error(error)))?;
-        if text.is_empty() {
-            return Ok(None);
-        }
-        let val: Value =
-            serde_json::from_str(&text).map_err(|e| AgentError::Http(e.to_string()))?;
-        Ok(Some(val))
+        .await
     }
 
     /// PUT raw bytes to a presigned S3 URL with retry.
@@ -424,11 +576,13 @@ impl HttpClient {
             format!("PUT presigned failed after {max_attempts} attempts"),
             move || {
                 let data = data.clone();
-                std::future::ready(Ok(client
-                    .put(url)
-                    .timeout(Duration::from_secs(constants::HTTP_UPLOAD_TIMEOUT_SECS))
-                    .header("Content-Type", content_type)
-                    .body(data)))
+                std::future::ready(Ok(RetryRequest::unobserved(
+                    client
+                        .put(url)
+                        .timeout(Duration::from_secs(constants::HTTP_UPLOAD_TIMEOUT_SECS))
+                        .header("Content-Type", content_type)
+                        .body(data),
+                )))
             },
             |resp, attempt, max_attempts| async move {
                 let status = resp.status();
@@ -438,6 +592,7 @@ impl HttpClient {
                 );
                 AgentError::Http(format!("PUT presigned: HTTP {status}"))
             },
+            None,
         )
         .await?;
 
@@ -574,11 +729,13 @@ impl HttpClient {
                     file.seek(std::io::SeekFrom::Start(0)).await?;
                     let body = reqwest::Body::wrap(SizedBody::new(file, file_len));
 
-                    Ok(client
-                        .put(url)
-                        .timeout(Duration::from_secs(constants::HTTP_UPLOAD_TIMEOUT_SECS))
-                        .header("Content-Type", content_type)
-                        .body(body))
+                    Ok(RetryRequest::unobserved(
+                        client
+                            .put(url)
+                            .timeout(Duration::from_secs(constants::HTTP_UPLOAD_TIMEOUT_SECS))
+                            .header("Content-Type", content_type)
+                            .body(body),
+                    ))
                 }
             },
             |resp, attempt, max_attempts| async move {
@@ -589,6 +746,7 @@ impl HttpClient {
                 );
                 AgentError::Http(format!("PUT presigned: HTTP {status}"))
             },
+            None,
         )
         .await?;
 

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -21,8 +21,8 @@ use guest_agent::telemetry::{Telemetry, UploadMode};
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
 use guest_contracts::diagnostics::{
-    AGENT_EXECUTION_TIMEOUT_EXIT_CODE, CliTerminationReason, FailureClass, FailureDiagnostic,
-    FailureReason,
+    AGENT_EXECUTION_TIMEOUT_EXIT_CODE, CliTerminationReason, EventDeliveryDiagnostic, FailureClass,
+    FailureDiagnostic, FailureReason,
 };
 use guest_contracts::session_history_identity::{
     FinalSessionHistoryIdentityExpectation, SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
@@ -394,12 +394,13 @@ async fn execute(
     log_info!(LOG_TAG, "▷ Execution");
     let cli_start = Instant::now();
     let mut last_event_sequence = None;
+    let mut event_delivery_failure = None;
     let (
         cli_exit_code,
-        exit_code,
-        error_message,
+        mut exit_code,
+        mut error_message,
         skip_recovery_checkpoint_for_no_history,
-        failure_diagnostic,
+        mut failure_diagnostic,
         cli_execution_succeeded,
     ) = match cli::execute_cli_with_controls_for_config_started_at(
         masker,
@@ -414,6 +415,15 @@ async fn execute(
     {
         Ok(cli_result) => {
             last_event_sequence = cli_result.last_event_sequence;
+            if let Some(event_delivery) = cli_result.event_delivery.clone() {
+                let diagnostic = failure_diagnostics::event_delivery_failure_for_config(
+                    config,
+                    runtime_paths,
+                    &cli_result,
+                    event_delivery.clone(),
+                );
+                event_delivery_failure = Some((event_delivery, diagnostic));
+            }
             let cli_exit_code = cli_result.exit_code;
             if let Some(control_error) = cli_result.control_error.as_ref() {
                 let msg = control_error.to_string();
@@ -520,6 +530,20 @@ async fn execute(
         },
     );
 
+    if let Some((event_delivery, event_failure_diagnostic)) = event_delivery_failure {
+        match failure_diagnostic.take() {
+            Some(diagnostic) => {
+                failure_diagnostic = Some(diagnostic.with_event_delivery(event_delivery));
+            }
+            None => {
+                error_message = event_delivery_failure_message(&event_delivery);
+                log_error!(LOG_TAG, "{error_message}");
+                exit_code = 1;
+                failure_diagnostic = Some(event_failure_diagnostic);
+            }
+        }
+    }
+
     complete_execution(
         cli_exit_code,
         exit_code,
@@ -534,6 +558,38 @@ async fn execute(
         runtime,
     )
     .await
+}
+
+fn event_delivery_failure_message(diagnostic: &EventDeliveryDiagnostic) -> String {
+    let last_acknowledged = diagnostic
+        .last_acknowledged_sequence
+        .map_or_else(|| "none".to_string(), |sequence| sequence.to_string());
+    let first_failed = diagnostic.first_failed_batch.as_ref();
+    let drain_active = diagnostic
+        .drain_timeout
+        .as_ref()
+        .and_then(|drain| drain.active_batch.as_ref());
+
+    match (first_failed, drain_active) {
+        (Some(failed), Some(active)) => format!(
+            "Event delivery failed after acknowledged sequence {last_acknowledged}: batch {}-{} exhausted retries and the global drain deadline interrupted batch {}-{}",
+            failed.first_sequence,
+            failed.last_sequence,
+            active.first_sequence,
+            active.last_sequence
+        ),
+        (Some(failed), None) => format!(
+            "Event delivery failed after acknowledged sequence {last_acknowledged}: batch {}-{} exhausted retries",
+            failed.first_sequence, failed.last_sequence
+        ),
+        (None, Some(active)) => format!(
+            "Event delivery failed after acknowledged sequence {last_acknowledged}: the global drain deadline interrupted batch {}-{}",
+            active.first_sequence, active.last_sequence
+        ),
+        (None, None) => format!(
+            "Event delivery did not complete before the global drain deadline after acknowledged sequence {last_acknowledged}"
+        ),
+    }
 }
 
 fn is_claude_zero_turn_result(
@@ -584,9 +640,6 @@ async fn complete_execution(
     let config = &runtime.config;
     let runtime_paths = &runtime.paths;
     let http = &runtime.http;
-    let has_failure_message = state
-        .failure_message
-        .is_some_and(|message| !message.trim().is_empty());
     if let Some(message) = state.failure_message {
         failure_diagnostics::write_guest_error_file(runtime_paths.checkpoint_error_file(), message);
     }
@@ -597,34 +650,6 @@ async fn complete_execution(
             diagnostic,
         );
         wrote_failure_diagnostic = true;
-    }
-
-    // Check if any events failed to send (before logging execution result)
-    if std::path::Path::new(runtime_paths.event_error_flag()).exists() {
-        let msg = "Some events failed to send, marking run as failed";
-        log_error!(LOG_TAG, "{msg}");
-        if !has_failure_message {
-            failure_diagnostics::write_guest_error_file(runtime_paths.checkpoint_error_file(), msg);
-        }
-        if !wrote_failure_diagnostic {
-            let diagnostic = failure_diagnostics::base_failure_diagnostic_for_config(
-                config,
-                FailureClass::EventUploadFailed,
-            )
-            .with_cli_exit_code(cli_exit_code)
-            .with_session_history_status(
-                failure_diagnostics::diagnostic_session_history_status_for_config(
-                    config,
-                    runtime_paths,
-                ),
-            );
-            failure_diagnostics::write_guest_failure_diagnostic(
-                runtime_paths.failure_diagnostic_file(),
-                &diagnostic,
-            );
-            wrote_failure_diagnostic = true;
-        }
-        exit_code = 1;
     }
 
     if exit_code == 0 {
@@ -972,40 +997,12 @@ mod tests {
         cleanup_paths.extend([
             paths.checkpoint_error_file().to_string(),
             paths.failure_diagnostic_file().to_string(),
-            paths.event_error_flag().to_string(),
             paths.sandbox_ops_file().to_string(),
             paths.telemetry_system_log_pos_file().to_string(),
             paths.telemetry_metrics_pos_file().to_string(),
             paths.telemetry_sandbox_ops_pos_file().to_string(),
         ]);
         cleanup_paths
-    }
-
-    struct EnvVarRestoreGuard {
-        saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
-    }
-
-    impl EnvVarRestoreGuard {
-        fn capture(keys: impl IntoIterator<Item = &'static str>) -> Self {
-            let saved = keys
-                .into_iter()
-                .map(|key| (key, std::env::var_os(key)))
-                .collect();
-            Self { saved }
-        }
-    }
-
-    impl Drop for EnvVarRestoreGuard {
-        fn drop(&mut self) {
-            for (key, value) in &self.saved {
-                unsafe {
-                    match value {
-                        Some(value) => std::env::set_var(key, value),
-                        None => std::env::remove_var(key),
-                    }
-                }
-            }
-        }
     }
 
     #[test]
@@ -1130,6 +1127,7 @@ mod tests {
             cli_observed_exit: Some(CliObservedExitDiagnostic::from_exit_code(0)),
             stderr_lines: Vec::new(),
             last_event_sequence: None,
+            event_delivery: None,
             claude_result: Some(cli::ClaudeResultSummary {
                 num_turns: Some(0),
                 status: cli::ClaudeResultStatus::Success,
@@ -1144,6 +1142,7 @@ mod tests {
             cli_observed_exit: Some(CliObservedExitDiagnostic::from_exit_code(0)),
             stderr_lines: Vec::new(),
             last_event_sequence: None,
+            event_delivery: None,
             claude_result: Some(cli::ClaudeResultSummary {
                 num_turns: Some(1),
                 status: cli::ClaudeResultStatus::Success,
@@ -1158,6 +1157,7 @@ mod tests {
             cli_observed_exit: Some(CliObservedExitDiagnostic::from_exit_code(1)),
             stderr_lines: Vec::new(),
             last_event_sequence: None,
+            event_delivery: None,
             claude_result: Some(cli::ClaudeResultSummary {
                 num_turns: Some(0),
                 status: cli::ClaudeResultStatus::Success,
@@ -1172,6 +1172,7 @@ mod tests {
             cli_observed_exit: Some(CliObservedExitDiagnostic::from_exit_code(0)),
             stderr_lines: Vec::new(),
             last_event_sequence: None,
+            event_delivery: None,
             claude_result: Some(cli::ClaudeResultSummary {
                 num_turns: Some(0),
                 status: cli::ClaudeResultStatus::Unknown,
@@ -1221,6 +1222,7 @@ mod tests {
                 cli_observed_exit: Some(CliObservedExitDiagnostic::from_signal(libc::SIGTERM)),
                 stderr_lines: Vec::new(),
                 last_event_sequence: None,
+                event_delivery: None,
                 claude_result: Some(claude_result),
                 post_result_cleanup_result: Some(cleanup_result),
                 failure_diagnostic: None,
@@ -1474,16 +1476,6 @@ mod tests {
     }
 
     #[test]
-    fn complete_execution_writes_event_upload_failure_diagnostic() {
-        let _test_state_guard = lock_test_state();
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(complete_execution_writes_event_upload_failure_diagnostic_inner());
-    }
-
-    #[test]
     fn complete_execution_writes_checkpoint_failure_diagnostic() {
         let _test_state_guard = lock_test_state();
         tokio::runtime::Builder::new_current_thread()
@@ -1491,183 +1483,6 @@ mod tests {
             .build()
             .unwrap()
             .block_on(complete_execution_writes_checkpoint_failure_diagnostic_inner());
-    }
-
-    #[test]
-    fn complete_execution_preserves_existing_failure_diagnostic_when_events_fail() {
-        let _test_state_guard = lock_test_state();
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(
-                complete_execution_preserves_existing_failure_diagnostic_when_events_fail_inner(),
-            );
-    }
-
-    #[test]
-    fn complete_execution_uses_explicit_paths_after_process_env_changes() {
-        let _test_state_guard = lock_test_state();
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(complete_execution_uses_explicit_paths_after_process_env_changes_inner());
-    }
-
-    async fn complete_execution_uses_explicit_paths_after_process_env_changes_inner() {
-        let tmp = tempfile::tempdir().unwrap();
-        let explicit_paths = paths::GuestPaths::from_runtime_dir(tmp.path().join("captured-run"));
-        let stale_paths = paths::GuestPaths::from_runtime_dir(tmp.path().join("stale-run"));
-        let run_payload_dir = explicit_paths
-            .runtime_dir()
-            .join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
-        std::fs::create_dir_all(&run_payload_dir).unwrap();
-        let run_payload_file = run_payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
-        std::fs::write(
-            &run_payload_file,
-            serde_json::to_vec(&guest_contracts::env::RunPayload {
-                prompt: "captured prompt".to_string(),
-                ..guest_contracts::env::RunPayload::default()
-            })
-            .unwrap(),
-        )
-        .unwrap();
-        let config = env::GuestConfig::from_raw(env::GuestConfigRaw {
-            run_id: "captured-run".to_string(),
-            home: Some(
-                tmp.path()
-                    .join("captured-home")
-                    .to_string_lossy()
-                    .into_owned(),
-            ),
-            run_payload_file: run_payload_file.to_string_lossy().into_owned(),
-            guest_runtime_dir: Some(explicit_paths.runtime_dir().to_path_buf()),
-            ..env::GuestConfigRaw::default()
-        })
-        .unwrap();
-        let http = HttpClient::for_config(&config).unwrap();
-        let masker = Arc::new(masker::SecretMasker::from_config(&config));
-        let runtime = GuestRuntime {
-            config,
-            paths: explicit_paths,
-            http,
-        };
-
-        let _env_guard = EnvVarRestoreGuard::capture([
-            "VM0_RUN_ID",
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-        ]);
-        unsafe {
-            std::env::set_var("VM0_RUN_ID", "stale-run");
-            std::env::set_var(
-                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-                stale_paths.runtime_dir(),
-            );
-        }
-        paths::write_private(runtime.paths.event_error_flag(), "").unwrap();
-
-        let telemetry = Telemetry::spawn_for_paths(
-            runtime.config.run_id.clone(),
-            &runtime.paths,
-            masker,
-            runtime.http.clone(),
-        );
-        let exit_code = complete_execution(
-            0,
-            0,
-            Duration::ZERO,
-            CompletionState {
-                last_event_sequence: None,
-                failure_message: None,
-                failure_diagnostic: None,
-                skip_recovery_checkpoint_for_no_history: false,
-            },
-            &telemetry,
-            &runtime,
-        )
-        .await;
-        telemetry.shutdown().await;
-
-        assert_eq!(exit_code, 1);
-        assert_eq!(
-            std::fs::read_to_string(runtime.paths.checkpoint_error_file()).unwrap(),
-            "Some events failed to send, marking run as failed"
-        );
-        let diagnostic: FailureDiagnostic = serde_json::from_slice(
-            &std::fs::read(runtime.paths.failure_diagnostic_file()).unwrap(),
-        )
-        .unwrap();
-        assert_eq!(diagnostic.failure_class, FailureClass::EventUploadFailed);
-        assert_eq!(diagnostic.cli_exit_code, Some(0));
-        assert!(
-            !std::path::Path::new(stale_paths.checkpoint_error_file()).exists(),
-            "completion should not write checkpoint errors through stale process env paths"
-        );
-        assert!(
-            !std::path::Path::new(stale_paths.failure_diagnostic_file()).exists(),
-            "completion should not write failure diagnostics through stale process env paths"
-        );
-    }
-
-    async fn complete_execution_writes_event_upload_failure_diagnostic_inner() {
-        let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
-        server.reset_async().await;
-        let _env_guard = unsafe { set_test_env(server, Some("/event-upload-failure")) };
-        let guest_paths = test_guest_paths();
-
-        let cleanup_paths = run_scoped_cleanup_paths(&guest_paths, true);
-        for path in &cleanup_paths {
-            let _ = std::fs::remove_file(path);
-        }
-        paths::write_private(guest_paths.event_error_flag(), "").unwrap();
-
-        let _telemetry_mock = server.mock(|when, then| {
-            when.method(POST).path("/api/webhooks/agent/telemetry");
-            then.status(200)
-                .header("Content-Type", "application/json")
-                .json_body(json!({}));
-        });
-
-        let config = test_guest_config(server, Some("/event-upload-failure"));
-        let masker = Arc::new(masker::SecretMasker::from_config(&config));
-        let http = test_http_client(server);
-        let telemetry =
-            Telemetry::spawn_for_paths(config.run_id.clone(), &guest_paths, masker, http.clone());
-        let runtime = test_guest_runtime(config, http.clone());
-        let exit_code = complete_execution(
-            0,
-            0,
-            Duration::ZERO,
-            CompletionState {
-                last_event_sequence: None,
-                failure_message: None,
-                failure_diagnostic: None,
-                skip_recovery_checkpoint_for_no_history: false,
-            },
-            &telemetry,
-            &runtime,
-        )
-        .await;
-        telemetry.shutdown().await;
-
-        assert_eq!(exit_code, 1);
-        assert_eq!(
-            std::fs::read_to_string(guest_paths.checkpoint_error_file()).unwrap(),
-            "Some events failed to send, marking run as failed"
-        );
-        let diagnostic: FailureDiagnostic =
-            serde_json::from_slice(&std::fs::read(guest_paths.failure_diagnostic_file()).unwrap())
-                .unwrap();
-        assert_eq!(diagnostic.failure_class, FailureClass::EventUploadFailed);
-        assert_eq!(diagnostic.cli_exit_code, Some(0));
-        assert_eq!(
-            diagnostic.session_history_status,
-            SessionHistoryStatus::Missing
-        );
-        for path in cleanup_paths {
-            let _ = std::fs::remove_file(path);
-        }
     }
 
     async fn complete_execution_writes_checkpoint_failure_diagnostic_inner() {
@@ -1722,69 +1537,6 @@ mod tests {
             diagnostic.session_history_status,
             SessionHistoryStatus::Missing
         );
-        for path in cleanup_paths {
-            let _ = std::fs::remove_file(path);
-        }
-    }
-
-    async fn complete_execution_preserves_existing_failure_diagnostic_when_events_fail_inner() {
-        let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
-        server.reset_async().await;
-        let _env_guard = unsafe { set_test_env(server, Some("plain prompt")) };
-        let guest_paths = test_guest_paths();
-
-        let cleanup_paths = run_scoped_cleanup_paths(&guest_paths, true);
-        for path in &cleanup_paths {
-            let _ = std::fs::remove_file(path);
-        }
-        paths::write_private(guest_paths.event_error_flag(), "").unwrap();
-
-        let _telemetry_mock = server.mock(|when, then| {
-            when.method(POST).path("/api/webhooks/agent/telemetry");
-            then.status(200)
-                .header("Content-Type", "application/json")
-                .json_body(json!({}));
-        });
-
-        let config = test_guest_config(server, Some("plain prompt"));
-        let masker = Arc::new(masker::SecretMasker::from_config(&config));
-        let http = test_http_client(server);
-        let telemetry =
-            Telemetry::spawn_for_paths(config.run_id.clone(), &guest_paths, masker, http.clone());
-        let runtime = test_guest_runtime(config, http.clone());
-        let failure_message = "CLI failed before all events uploaded";
-        let failure_diagnostic = FailureDiagnostic::new(
-            FailureClass::CliNonzero,
-            AgentFramework::ClaudeCode,
-            PromptMetadata::from_prompt("plain prompt"),
-        )
-        .with_cli_exit_code(1)
-        .with_session_history_status(SessionHistoryStatus::Missing);
-        let exit_code = complete_execution(
-            1,
-            1,
-            Duration::ZERO,
-            CompletionState {
-                last_event_sequence: None,
-                failure_message: Some(failure_message),
-                failure_diagnostic: Some(failure_diagnostic.clone()),
-                skip_recovery_checkpoint_for_no_history: false,
-            },
-            &telemetry,
-            &runtime,
-        )
-        .await;
-        telemetry.shutdown().await;
-
-        assert_eq!(exit_code, 1);
-        assert_eq!(
-            std::fs::read_to_string(guest_paths.checkpoint_error_file()).unwrap(),
-            failure_message
-        );
-        let diagnostic: FailureDiagnostic =
-            serde_json::from_slice(&std::fs::read(guest_paths.failure_diagnostic_file()).unwrap())
-                .unwrap();
-        assert_eq!(diagnostic, failure_diagnostic);
         for path in cleanup_paths {
             let _ = std::fs::remove_file(path);
         }

--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -25,7 +25,6 @@ pub struct GuestPaths {
     runtime_dir: PathBuf,
     session_id_file: String,
     session_history_path_file: String,
-    event_error_flag: String,
     checkpoint_error_file: String,
     final_session_history_identity_file: String,
     failure_diagnostic_file: String,
@@ -49,9 +48,6 @@ impl GuestPaths {
             session_history_path_file: path_to_string(
                 guest_contracts::runtime_paths::session_history_marker_file(&runtime_dir),
             ),
-            event_error_flag: path_to_string(guest_contracts::runtime_paths::event_error_file(
-                &runtime_dir,
-            )),
             checkpoint_error_file: path_to_string(
                 guest_contracts::runtime_paths::checkpoint_error_file(&runtime_dir),
             ),
@@ -126,10 +122,6 @@ impl GuestPaths {
 
     pub fn session_history_path_file(&self) -> &str {
         &self.session_history_path_file
-    }
-
-    pub fn event_error_flag(&self) -> &str {
-        &self.event_error_flag
     }
 
     pub fn checkpoint_error_file(&self) -> &str {
@@ -213,10 +205,6 @@ mod tests {
             paths.session_history_path_file(),
             guest_contracts::runtime_paths::session_history_marker_file(&runtime_dir)
                 .to_string_lossy()
-        );
-        assert_eq!(
-            paths.event_error_flag(),
-            guest_contracts::runtime_paths::event_error_file(&runtime_dir).to_string_lossy()
         );
         assert_eq!(
             paths.checkpoint_error_file(),

--- a/crates/guest-agent/tests/codex_app_server_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_event_delivery.rs
@@ -6,6 +6,9 @@
 mod common;
 
 use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::{
+    EventDeliveryAcceptanceOutcome, EventDeliveryAttemptFailureKind,
+};
 use std::time::Duration;
 
 const RUN_ID: &str = "codex-app-server-event-delivery-test";
@@ -40,7 +43,6 @@ async fn codex_app_server_event_delivery_stops_watermark_at_failed_sequence()
         RUN_ID,
         Duration::ZERO,
     )?;
-    let event_error_flag = runtime.paths.event_error_flag().to_string();
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let execution = tokio::spawn(async move {
@@ -55,6 +57,7 @@ async fn codex_app_server_event_delivery_stops_watermark_at_failed_sequence()
     let mut logical_sequences = Vec::new();
     let mut failed_sequences = None;
     let mut failed_attempts = 0usize;
+    let mut failed_request_ids = Vec::new();
     while logical_sequences.len() < TOTAL_EVENTS || failed_attempts < 3 {
         let request = server.next_request(Duration::from_secs(5)).await?;
         let sequences = common::event_request_sequences(&request.request)?;
@@ -69,6 +72,13 @@ async fn codex_app_server_event_delivery_stops_watermark_at_failed_sequence()
                 failed_sequences = Some(sequences.clone());
             }
             failed_attempts += 1;
+            failed_request_ids.push(
+                request
+                    .request
+                    .client_request_id
+                    .clone()
+                    .ok_or("failed request omitted x-client-request-id")?,
+            );
             request.respond(500)?;
         } else {
             logical_sequences.extend(sequences);
@@ -87,13 +97,38 @@ async fn codex_app_server_event_delivery_stops_watermark_at_failed_sequence()
 
     assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
     assert_eq!(cli_result.last_event_sequence, expected_watermark);
+    let delivery = cli_result
+        .event_delivery
+        .ok_or("failed delivery omitted structured diagnostic")?;
+    assert_eq!(delivery.total_events, TOTAL_EVENTS as u64);
+    assert_eq!(delivery.failed_batches, 1);
+    assert_eq!(delivery.last_acknowledged_sequence, expected_watermark);
+    let failed_batch = delivery
+        .first_failed_batch
+        .ok_or("failed delivery omitted first failed batch")?;
+    assert_eq!(
+        failed_batch.outcome,
+        EventDeliveryAcceptanceOutcome::ConfirmedRejection
+    );
+    assert_eq!(failed_batch.attempts.len(), 3);
+    assert_eq!(
+        failed_batch
+            .attempts
+            .iter()
+            .map(|attempt| attempt.client_request_id.clone())
+            .collect::<Vec<_>>(),
+        failed_request_ids
+    );
+    assert!(failed_batch.attempts.iter().all(|attempt| {
+        attempt.failure_kind == EventDeliveryAttemptFailureKind::HttpStatus
+            && attempt.http_status == Some(500)
+    }));
     assert_eq!(failed_attempts, 3);
     assert_eq!(
         logical_sequences,
         (0..TOTAL_EVENTS as u32).collect::<Vec<_>>(),
         "logical batches should cover the translated Codex events in FIFO order"
     );
-    assert_eq!(std::fs::read_to_string(event_error_flag)?, "1");
 
     Ok(())
 }

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -85,6 +85,7 @@ pub struct RecordedRequest {
     pub path: String,
     pub authorization: Option<String>,
     pub content_type: Option<String>,
+    pub client_request_id: Option<String>,
     pub body: String,
 }
 
@@ -235,6 +236,8 @@ impl ControlledRequest {
 pub struct ControlledHttpServer {
     pub base_url: String,
     requests: Arc<AtomicUsize>,
+    completed_responses: Arc<AtomicUsize>,
+    recorded_requests: Arc<Mutex<Vec<RecordedRequest>>>,
     request_rx: mpsc::UnboundedReceiver<ControlledRequest>,
     handle: tokio::task::JoinHandle<()>,
 }
@@ -249,17 +252,26 @@ impl ControlledHttpServer {
             .map_err(|error| format!("controlled HTTP server local_addr: {error}"))?;
         let requests = Arc::new(AtomicUsize::new(0));
         let task_requests = Arc::clone(&requests);
+        let completed_responses = Arc::new(AtomicUsize::new(0));
+        let task_completed_responses = Arc::clone(&completed_responses);
+        let recorded_requests = Arc::new(Mutex::new(Vec::new()));
+        let task_recorded_requests = Arc::clone(&recorded_requests);
         let (request_tx, request_rx) = mpsc::unbounded_channel();
         let handle = tokio::spawn(async move {
             while let Ok((mut socket, _peer)) = listener.accept().await {
                 let connection_tx = request_tx.clone();
                 let connection_requests = Arc::clone(&task_requests);
+                let connection_completed_responses = Arc::clone(&task_completed_responses);
+                let connection_recorded_requests = Arc::clone(&task_recorded_requests);
                 tokio::spawn(async move {
                     let Ok(request) = read_http_request(&mut socket).await else {
                         let _ = write_http_response(&mut socket, 400).await;
                         return;
                     };
                     connection_requests.fetch_add(1, Ordering::SeqCst);
+                    if let Ok(mut requests) = connection_recorded_requests.lock() {
+                        requests.push(request.clone());
+                    }
                     let (response, response_rx) = oneshot::channel();
                     if connection_tx
                         .send(ControlledRequest { request, response })
@@ -271,6 +283,7 @@ impl ControlledHttpServer {
                         return;
                     };
                     let _ = write_http_response(&mut socket, status).await;
+                    connection_completed_responses.fetch_add(1, Ordering::SeqCst);
                 });
             }
         });
@@ -278,6 +291,8 @@ impl ControlledHttpServer {
         Ok(Self {
             base_url: format!("http://{addr}"),
             requests,
+            completed_responses,
+            recorded_requests,
             request_rx,
             handle,
         })
@@ -292,6 +307,17 @@ impl ControlledHttpServer {
 
     pub fn request_count(&self) -> usize {
         self.requests.load(Ordering::SeqCst)
+    }
+
+    pub fn completed_response_count(&self) -> usize {
+        self.completed_responses.load(Ordering::SeqCst)
+    }
+
+    pub fn requests(&self) -> Result<Vec<RecordedRequest>, String> {
+        self.recorded_requests
+            .lock()
+            .map(|requests| requests.clone())
+            .map_err(|_| "controlled HTTP request mutex poisoned".to_string())
     }
 }
 
@@ -327,7 +353,6 @@ impl Drop for RunFilesGuard {
 
 fn cleanup_run_files_for_paths(paths: &guest_agent::paths::GuestPaths) {
     let _ = std::fs::remove_file(paths.agent_log_file());
-    let _ = std::fs::remove_file(paths.event_error_flag());
     let _ = std::fs::remove_file(paths.session_id_file());
     let _ = std::fs::remove_file(paths.session_history_path_file());
     let _ = std::fs::remove_file(paths.sandbox_ops_file());
@@ -370,6 +395,7 @@ async fn read_http_request(socket: &mut tokio::net::TcpStream) -> Result<Recorde
 
     let mut authorization = None;
     let mut content_type = None;
+    let mut client_request_id = None;
     let mut content_length = 0usize;
     for line in header_lines.lines() {
         let Some((name, value)) = line.split_once(':') else {
@@ -382,6 +408,9 @@ async fn read_http_request(socket: &mut tokio::net::TcpStream) -> Result<Recorde
         }
         if trimmed_name.eq_ignore_ascii_case("content-type") {
             content_type = Some(trimmed_value.to_string());
+        }
+        if trimmed_name.eq_ignore_ascii_case("x-client-request-id") {
+            client_request_id = Some(trimmed_value.to_string());
         }
         if trimmed_name.eq_ignore_ascii_case("content-length") {
             content_length = trimmed_value
@@ -421,6 +450,7 @@ async fn read_http_request(socket: &mut tokio::net::TcpStream) -> Result<Recorde
         path,
         authorization,
         content_type,
+        client_request_id,
         body,
     })
 }

--- a/crates/guest-agent/tests/event_delivery_batch_failure.rs
+++ b/crates/guest-agent/tests/event_delivery_batch_failure.rs
@@ -4,6 +4,9 @@
 mod common;
 
 use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::{
+    EventDeliveryAcceptanceOutcome, EventDeliveryAttemptFailureKind,
+};
 use serde_json::json;
 use std::io;
 use std::time::Duration;
@@ -39,7 +42,6 @@ async fn failed_batch_retries_three_times_and_later_batches_continue()
         Duration::ZERO,
     )?;
     let agent_log_file = runtime.paths.agent_log_file().to_string();
-    let event_error_flag = runtime.paths.event_error_flag().to_string();
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let execution = tokio::spawn(async move {
@@ -68,6 +70,13 @@ async fn failed_batch_retries_three_times_and_later_batches_continue()
     let failed_request = server.next_request(Duration::from_secs(5)).await?;
     let failed_sequences = common::event_request_sequences(&failed_request.request)?;
     let failed_body = failed_request.request.body.clone();
+    let mut failed_request_ids = vec![
+        failed_request
+            .request
+            .client_request_id
+            .clone()
+            .ok_or_else(|| io::Error::other("failed request omitted x-client-request-id"))?,
+    ];
     assert_eq!(failed_sequences.len(), 32);
     failed_request.respond(500)?;
     for _ in 1..3 {
@@ -77,11 +86,31 @@ async fn failed_batch_retries_three_times_and_later_batches_continue()
             common::event_request_sequences(&retry.request)?,
             failed_sequences
         );
+        failed_request_ids.push(
+            retry
+                .request
+                .client_request_id
+                .clone()
+                .ok_or_else(|| io::Error::other("retry omitted x-client-request-id"))?,
+        );
         retry.respond(500)?;
     }
 
     let mut logical_sequences = first_sequences;
-    logical_sequences.extend(failed_sequences);
+    logical_sequences.extend(failed_sequences.iter().copied());
+    let eventually_successful_request = server.next_request(Duration::from_secs(5)).await?;
+    let eventually_successful_sequences =
+        common::event_request_sequences(&eventually_successful_request.request)?;
+    let eventually_successful_body = eventually_successful_request.request.body.clone();
+    eventually_successful_request.respond(500)?;
+    let successful_retry = server.next_request(Duration::from_secs(5)).await?;
+    assert_eq!(successful_retry.request.body, eventually_successful_body);
+    assert_eq!(
+        common::event_request_sequences(&successful_retry.request)?,
+        eventually_successful_sequences
+    );
+    successful_retry.respond(200)?;
+    logical_sequences.extend(eventually_successful_sequences);
     while logical_sequences.len() < TOTAL_EVENTS {
         let request = server.next_request(Duration::from_secs(5)).await?;
         logical_sequences.extend(common::event_request_sequences(&request.request)?);
@@ -93,12 +122,58 @@ async fn failed_batch_retries_three_times_and_later_batches_continue()
         .expect("CLI should finish after later batches are acknowledged")??;
     assert_eq!(result.exit_code, common::CLEAN_EXIT);
     assert_eq!(result.last_event_sequence, Some(expected_watermark));
+    let delivery = result
+        .event_delivery
+        .ok_or_else(|| io::Error::other("failed delivery omitted structured diagnostic"))?;
+    assert_eq!(delivery.total_events, TOTAL_EVENTS as u64);
+    assert_eq!(delivery.failed_batches, 1);
+    assert_eq!(
+        delivery.last_acknowledged_sequence,
+        Some(expected_watermark)
+    );
+    assert!(delivery.drain_timeout.is_none());
+    let failed_batch = delivery
+        .first_failed_batch
+        .ok_or_else(|| io::Error::other("failed delivery omitted first failed batch"))?;
+    assert_eq!(
+        (failed_batch.first_sequence, failed_batch.last_sequence),
+        (
+            *failed_sequences
+                .first()
+                .ok_or_else(|| io::Error::other("failed batch was empty"))?,
+            *failed_sequences
+                .last()
+                .ok_or_else(|| io::Error::other("failed batch was empty"))?,
+        )
+    );
+    assert_eq!(failed_batch.event_count, failed_sequences.len() as u32);
+    assert!(failed_batch.conservative_bytes > 0);
+    assert_eq!(
+        failed_batch.outcome,
+        EventDeliveryAcceptanceOutcome::ConfirmedRejection
+    );
+    assert_eq!(failed_batch.attempts.len(), 3);
+    assert_eq!(
+        failed_batch
+            .attempts
+            .iter()
+            .map(|attempt| attempt.client_request_id.clone())
+            .collect::<Vec<_>>(),
+        failed_request_ids
+    );
+    assert!(failed_batch.attempts.iter().all(|attempt| {
+        attempt.failure_kind == EventDeliveryAttemptFailureKind::HttpStatus
+            && attempt.http_status == Some(500)
+    }));
+    let mut unique_request_ids = failed_request_ids.clone();
+    unique_request_ids.sort();
+    unique_request_ids.dedup();
+    assert_eq!(unique_request_ids.len(), 3);
     assert_eq!(
         logical_sequences,
         (0..TOTAL_EVENTS as u32).collect::<Vec<_>>(),
         "logical batches should remain FIFO even though one batch was retried"
     );
-    assert_eq!(std::fs::read_to_string(event_error_flag)?, "1");
 
     Ok(())
 }

--- a/crates/guest-agent/tests/event_delivery_drain_timeout.rs
+++ b/crates/guest-agent/tests/event_delivery_drain_timeout.rs
@@ -4,10 +4,14 @@
 mod common;
 
 use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::{
+    EventDeliveryAcceptanceOutcome, EventDeliveryAttemptFailureKind,
+};
 use serde_json::json;
+use std::io;
 use std::time::Duration;
 
-const EVENT_COUNT: usize = 40;
+const EVENT_COUNT: usize = 33;
 
 #[tokio::test]
 async fn event_delivery_aborts_after_the_global_drain_deadline()
@@ -50,7 +54,7 @@ async fn event_delivery_aborts_after_the_global_drain_deadline()
         )
         .await
     });
-    let _stalled_request = server.next_request(Duration::from_secs(5)).await?;
+    let stalled_request = server.next_request(Duration::from_secs(5)).await?;
     common::wait_for_file_contains(
         std::path::Path::new(&agent_log_file),
         "drain-timeout-sentinel",
@@ -76,15 +80,59 @@ async fn event_delivery_aborts_after_the_global_drain_deadline()
         execution.is_finished(),
         "event delivery should stop at the unchanged 120-second global deadline"
     );
-    let error = execution
-        .await?
-        .expect_err("the drain deadline should fail the CLI run");
-    assert!(
-        error
-            .to_string()
-            .contains("CLI event delivery did not drain within 120 seconds"),
-        "unexpected drain error: {error}"
+    let result = execution.await??;
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    let delivery = result
+        .event_delivery
+        .ok_or_else(|| io::Error::other("drain timeout omitted structured diagnostic"))?;
+    assert_eq!(
+        result.last_event_sequence,
+        delivery.last_acknowledged_sequence
     );
+    let failed_batch = delivery
+        .first_failed_batch
+        .as_ref()
+        .ok_or_else(|| io::Error::other("drain scenario omitted first exhausted batch"))?;
+    assert_eq!(failed_batch.attempts.len(), 3);
+    assert_eq!(
+        failed_batch.outcome,
+        EventDeliveryAcceptanceOutcome::OutcomeUnknown
+    );
+    assert!(failed_batch.attempts.iter().all(|attempt| {
+        attempt.failure_kind == EventDeliveryAttemptFailureKind::Timeout
+            && attempt.http_status.is_none()
+    }));
+    let drain = delivery
+        .drain_timeout
+        .as_ref()
+        .ok_or_else(|| io::Error::other("drain scenario omitted deadline snapshot"))?;
+    let active_batch = drain
+        .active_batch
+        .as_ref()
+        .ok_or_else(|| io::Error::other("drain scenario omitted active batch"))?;
+    assert_eq!(drain.queued_events, 0);
+    assert_eq!(drain.queued_bytes, 0);
+    assert_eq!(drain.carried_events, 0);
+    assert_eq!(drain.carried_bytes, 0);
+    assert_eq!(
+        usize::try_from(drain.queued_events)?
+            + usize::try_from(drain.carried_events)?
+            + usize::try_from(active_batch.event_count)?,
+        EVENT_COUNT - 1,
+        "the drain snapshot must account for every event after the exhausted first batch"
+    );
+    assert_eq!(drain.queued_events > 0, drain.queued_bytes > 0);
+    assert_eq!(drain.carried_events > 0, drain.carried_bytes > 0);
+    assert!(active_batch.conservative_bytes > 0);
+    assert_eq!(
+        active_batch.outcome,
+        EventDeliveryAcceptanceOutcome::OutcomeUnknown
+    );
+    let active_attempt = active_batch
+        .active_attempt
+        .as_ref()
+        .ok_or_else(|| io::Error::other("drain scenario omitted active attempt"))?;
+    assert!(active_attempt.elapsed_ms > 0);
 
     tokio::task::yield_now().await;
     let requests_after_abort = server.request_count();
@@ -99,6 +147,42 @@ async fn event_delivery_aborts_after_the_global_drain_deadline()
         requests_after_abort,
         "aborting the delivery worker should prevent later requests"
     );
+    let recorded_requests = server.requests()?;
+    let recorded_active = recorded_requests
+        .last()
+        .ok_or_else(|| io::Error::other("controlled server recorded no requests"))?;
+    assert_eq!(
+        recorded_active.client_request_id.as_deref(),
+        Some(active_attempt.client_request_id.as_str())
+    );
+    assert_eq!(
+        common::event_request_sequences(recorded_active)?,
+        (active_batch.first_sequence..=active_batch.last_sequence).collect::<Vec<_>>()
+    );
+
+    tokio::time::resume();
+    let mut pending_requests = Vec::new();
+    for _ in 1..requests_after_abort {
+        pending_requests.push(server.next_request(Duration::from_secs(1)).await?);
+    }
+    let active_request = pending_requests
+        .pop()
+        .ok_or_else(|| io::Error::other("active controlled request was not retained"))?;
+    assert_eq!(
+        active_request.request.client_request_id.as_deref(),
+        Some(active_attempt.client_request_id.as_str())
+    );
+    let completed_before = server.completed_response_count();
+    active_request.respond(200)?;
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while server.completed_response_count() == completed_before {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("server should finish the response after the guest abandons it");
+    drop(pending_requests);
+    drop(stalled_request);
 
     Ok(())
 }

--- a/crates/guest-agent/tests/event_delivery_failure_recovery.rs
+++ b/crates/guest-agent/tests/event_delivery_failure_recovery.rs
@@ -1,0 +1,242 @@
+//! Terminal event delivery must select recovery without replacing a primary
+//! CLI result.
+
+mod common;
+
+use guest_contracts::diagnostics::{
+    EventDeliveryAcceptanceOutcome, FailureClass, FailureDiagnostic,
+};
+use httpmock::prelude::*;
+use serde_json::json;
+use std::io;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::time::Duration;
+use tokio::process::Command;
+
+const THREAD_ID: &str = "019fac13-2355-74d3-8414-b467fbb80c70";
+
+struct EventFailureRun {
+    process_exit_code: Option<i32>,
+    stderr: String,
+    diagnostic: FailureDiagnostic,
+}
+
+#[tokio::test]
+async fn successful_cli_with_exhausted_event_delivery_uses_recovery_checkpoint()
+-> Result<(), Box<dyn std::error::Error>> {
+    let run = run_event_failure_case("event-delivery-failure-recovery", 0).await?;
+
+    assert_eq!(
+        run.process_exit_code,
+        Some(1),
+        "guest-agent stderr:\n{}",
+        run.stderr
+    );
+    assert!(
+        run.stderr
+            .contains("Attempting best-effort recovery checkpoint")
+    );
+    assert!(run.stderr.contains("Recovery checkpoint created"));
+    assert!(!run.stderr.contains("▷ Checkpoint"));
+    assert_eq!(
+        run.diagnostic.failure_class,
+        FailureClass::EventUploadFailed
+    );
+    assert_eq!(run.diagnostic.cli_exit_code, Some(0));
+    assert_confirmed_event_delivery(&run.diagnostic)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn nonzero_cli_remains_primary_when_event_delivery_also_fails()
+-> Result<(), Box<dyn std::error::Error>> {
+    let run = run_event_failure_case("event-delivery-secondary-failure", 7).await?;
+
+    assert_eq!(
+        run.process_exit_code,
+        Some(7),
+        "guest-agent stderr:\n{}",
+        run.stderr
+    );
+    assert!(run.stderr.contains("mock codex primary failure"));
+    assert_eq!(run.diagnostic.failure_class, FailureClass::CliNonzero);
+    assert_eq!(run.diagnostic.cli_exit_code, Some(7));
+    assert_confirmed_event_delivery(&run.diagnostic)?;
+
+    Ok(())
+}
+
+async fn run_event_failure_case(
+    run_id: &str,
+    cli_exit_code: i32,
+) -> Result<EventFailureRun, Box<dyn std::error::Error>> {
+    common::ensure_canonical_workspace_for_test()?;
+    let server = MockServer::start();
+    let tmp = tempfile::tempdir()?;
+    let home = tmp.path().join("home");
+    let runtime_dir = tmp.path().join("runtime");
+    std::fs::create_dir_all(&home)?;
+    let history = format!(
+        "{{\"type\":\"thread.started\",\"thread_id\":\"{THREAD_ID}\"}}\n\
+         {{\"type\":\"turn.started\"}}\n"
+    );
+    let mock_codex = write_codex(tmp.path(), &history, cli_exit_code)?;
+    let run_payload_file = common::write_run_payload_file_for_test(
+        &runtime_dir,
+        &guest_contracts::env::RunPayload {
+            prompt: "finish CLI execution while event delivery fails".to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )?;
+
+    let _heartbeat = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/heartbeat");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({}));
+    });
+    let events = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/events");
+        then.status(500);
+    });
+    let _telemetry = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/telemetry");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({}));
+    });
+    let prepare = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(format!(r#"{{"runId":"{run_id}"}}"#));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url("/test/event-delivery-recovery-history"),
+                "existing": false
+            }));
+    });
+    let upload = server.mock(|when, then| {
+        when.method(PUT)
+            .path("/test/event-delivery-recovery-history")
+            .header("Content-Type", "application/octet-stream")
+            .body(history.as_str());
+        then.status(200);
+    });
+    let checkpoint = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(format!(r#"{{"cliAgentSessionId":"{THREAD_ID}"}}"#));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "event-delivery-recovery-checkpoint"}));
+    });
+
+    let output = tokio::time::timeout(
+        Duration::from_secs(20),
+        Command::new(env!("CARGO_BIN_EXE_guest-agent"))
+            .env_clear()
+            .env(
+                "PATH",
+                std::env::var("PATH")
+                    .unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin".to_string()),
+            )
+            .env("SHELL", "/bin/sh")
+            .env("HOME", &home)
+            .env(guest_contracts::env::API_URL_ENV, server.base_url())
+            .env(guest_contracts::env::API_TOKEN_ENV, "test-token")
+            .env(guest_contracts::env::RUN_ID_ENV, run_id)
+            .env(
+                guest_contracts::env::SANDBOX_ID_ENV,
+                "00000000-0000-4000-8000-000000000abc",
+            )
+            .env(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused")
+            .env(guest_contracts::env::CLI_AGENT_TYPE_ENV, "codex")
+            .env(guest_contracts::env::USE_MOCK_CODEX_ENV, "true")
+            .env(guest_contracts::env::MOCK_CODEX_PATH_ENV, &mock_codex)
+            .env(
+                guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
+                &run_payload_file,
+            )
+            .env(
+                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                &runtime_dir,
+            )
+            .output(),
+    )
+    .await
+    .map_err(|_| io::Error::other("guest-agent exceeded its finalization budget"))??;
+
+    assert!(events.calls_async().await >= 3);
+    prepare.assert_calls_async(1).await;
+    upload.assert_calls_async(1).await;
+    checkpoint.assert_calls_async(1).await;
+
+    let paths = guest_agent::paths::GuestPaths::from_runtime_dir(runtime_dir.clone());
+    let diagnostic: FailureDiagnostic =
+        serde_json::from_slice(&std::fs::read(paths.failure_diagnostic_file())?)?;
+    assert!(
+        !runtime_dir.join("event-error").exists(),
+        "structured failure propagation must not recreate the boolean event flag"
+    );
+
+    Ok(EventFailureRun {
+        process_exit_code: output.status.code(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        diagnostic,
+    })
+}
+
+fn assert_confirmed_event_delivery(
+    diagnostic: &FailureDiagnostic,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let event_delivery = diagnostic
+        .event_delivery
+        .as_ref()
+        .ok_or_else(|| io::Error::other("failure omitted event delivery details"))?;
+    assert!(event_delivery.failed_batches > 0);
+    assert_eq!(
+        event_delivery.failed_batches, event_delivery.total_batches,
+        "the mock rejects every event delivery batch"
+    );
+    assert_eq!(
+        event_delivery
+            .first_failed_batch
+            .as_ref()
+            .ok_or_else(|| io::Error::other("failure omitted first failed batch"))?
+            .outcome,
+        EventDeliveryAcceptanceOutcome::ConfirmedRejection
+    );
+    Ok(())
+}
+
+fn write_codex(
+    root: &Path,
+    history: &str,
+    cli_exit_code: i32,
+) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    let path = root.join("mock-codex");
+    let exit_script = if cli_exit_code == 0 {
+        String::new()
+    } else {
+        format!("printf '%s\\n' 'mock codex primary failure' >&2\nexit {cli_exit_code}\n")
+    };
+    let script = format!(
+        "#!/bin/sh\n\
+         set -eu\n\
+         history_dir=\"$HOME/.codex/sessions/2026/07/30\"\n\
+         mkdir -p \"$history_dir\"\n\
+         printf '%s' '{}' > \"$history_dir/{THREAD_ID}.jsonl\"\n\
+         printf '%s\\n' '{{\"type\":\"thread.started\",\"thread_id\":\"{THREAD_ID}\"}}'\n\
+         printf '%s\\n' '{{\"type\":\"turn.completed\"}}'\n\
+         {exit_script}",
+        history.replace('\'', "'\\''"),
+    );
+    std::fs::write(&path, script)?;
+    let mut permissions = std::fs::metadata(&path)?.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&path, permissions)?;
+    Ok(path)
+}

--- a/crates/guest-agent/tests/event_delivery_nonretryable_failure.rs
+++ b/crates/guest-agent/tests/event_delivery_nonretryable_failure.rs
@@ -1,0 +1,130 @@
+//! A non-retryable event rejection records exactly its single on-wire attempt
+//! while later logical batches continue.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::{
+    EventDeliveryAcceptanceOutcome, EventDeliveryAttemptFailureKind,
+};
+use serde_json::json;
+use std::io;
+use std::time::Duration;
+
+const TOTAL_EVENTS: usize = 34;
+
+#[tokio::test]
+async fn nonretryable_client_rejection_records_one_attempt()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock_cli = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let mut server = common::ControlledHttpServer::start().await?;
+    let mut prompt_lines = vec!["@ECHO@".to_string()];
+    prompt_lines.extend(
+        (0..TOTAL_EVENTS - 1)
+            .map(|index| json!({ "type": "assistant", "index": index }).to_string()),
+    );
+    prompt_lines
+        .push(json!({ "type": "result", "marker": "nonretryable-rejection-sentinel" }).to_string());
+    let prompt = prompt_lines.join("\n");
+
+    unsafe {
+        common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
+        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let mut runtime = common::guest_runtime_from_process_env()?;
+    let run_id = runtime.config.run_id.clone();
+    runtime.http = guest_agent::http::HttpClient::with_api_config(
+        &server.base_url,
+        "test-token",
+        "",
+        run_id,
+        Duration::ZERO,
+    )?;
+    let agent_log_file = runtime.paths.agent_log_file().to_string();
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+
+    let execution = tokio::spawn(async move {
+        common::execute_cli_for_runtime(
+            &runtime,
+            &SecretMasker::from_raw(""),
+            common::spawn_dummy_heartbeat(),
+        )
+        .await
+    });
+
+    let first_request = server.next_request(Duration::from_secs(5)).await?;
+    common::wait_for_file_contains(
+        std::path::Path::new(&agent_log_file),
+        "nonretryable-rejection-sentinel",
+        Duration::from_secs(5),
+    )
+    .await?;
+    let first_sequences = common::event_request_sequences(&first_request.request)?;
+    let expected_watermark = first_sequences
+        .last()
+        .copied()
+        .ok_or_else(|| io::Error::other("first request contained no events"))?;
+    first_request.respond(200)?;
+
+    let rejected_request = server.next_request(Duration::from_secs(5)).await?;
+    let rejected_sequences = common::event_request_sequences(&rejected_request.request)?;
+    let rejected_request_id = rejected_request
+        .request
+        .client_request_id
+        .clone()
+        .ok_or_else(|| io::Error::other("rejected request omitted x-client-request-id"))?;
+    rejected_request.respond(400)?;
+
+    let mut logical_sequences = first_sequences;
+    logical_sequences.extend(rejected_sequences.iter().copied());
+    while logical_sequences.len() < TOTAL_EVENTS {
+        let request = server.next_request(Duration::from_secs(5)).await?;
+        let sequences = common::event_request_sequences(&request.request)?;
+        assert_ne!(
+            sequences, rejected_sequences,
+            "a non-retryable 4xx response must not retry the rejected batch"
+        );
+        logical_sequences.extend(sequences);
+        request.respond(200)?;
+    }
+
+    let result = tokio::time::timeout(Duration::from_secs(5), execution)
+        .await
+        .expect("CLI should finish after later batches are acknowledged")??;
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    assert_eq!(result.last_event_sequence, Some(expected_watermark));
+    let delivery = result
+        .event_delivery
+        .ok_or_else(|| io::Error::other("rejected delivery omitted structured diagnostic"))?;
+    assert_eq!(delivery.failed_batches, 1);
+    assert_eq!(
+        delivery.last_acknowledged_sequence,
+        Some(expected_watermark)
+    );
+    let failed_batch = delivery
+        .first_failed_batch
+        .ok_or_else(|| io::Error::other("rejected delivery omitted first failed batch"))?;
+    assert_eq!(failed_batch.attempts.len(), 1);
+    assert_eq!(
+        failed_batch.attempts[0].client_request_id,
+        rejected_request_id
+    );
+    assert_eq!(
+        failed_batch.attempts[0].failure_kind,
+        EventDeliveryAttemptFailureKind::HttpStatus
+    );
+    assert_eq!(failed_batch.attempts[0].http_status, Some(400));
+    assert_eq!(
+        failed_batch.outcome,
+        EventDeliveryAcceptanceOutcome::ConfirmedRejection
+    );
+    assert_eq!(
+        logical_sequences,
+        (0..TOTAL_EVENTS as u32).collect::<Vec<_>>(),
+        "logical batches should remain FIFO after the rejected batch"
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/event_delivery_transport_classification.rs
+++ b/crates/guest-agent/tests/event_delivery_transport_classification.rs
@@ -1,0 +1,169 @@
+//! Event delivery distinguishes connection establishment failures from other
+//! response-less transport failures without retaining raw error text.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::{
+    EventDeliveryAcceptanceOutcome, EventDeliveryAttemptFailureKind, EventDeliveryDiagnostic,
+};
+use serde_json::json;
+use std::io;
+use std::time::Duration;
+
+#[tokio::test]
+async fn response_less_failures_have_stable_classifications()
+-> Result<(), Box<dyn std::error::Error>> {
+    let connect_delivery = run_connect_failure().await?;
+    assert_failed_attempts(&connect_delivery, EventDeliveryAttemptFailureKind::Connect)?;
+
+    let (transport_delivery, on_wire_request_ids) = run_transport_failure().await?;
+    let transport_attempts = assert_failed_attempts(
+        &transport_delivery,
+        EventDeliveryAttemptFailureKind::Transport,
+    )?;
+    assert_eq!(
+        transport_attempts
+            .iter()
+            .map(|attempt| attempt.client_request_id.as_str())
+            .collect::<Vec<_>>(),
+        on_wire_request_ids
+    );
+
+    Ok(())
+}
+
+async fn run_connect_failure() -> Result<EventDeliveryDiagnostic, Box<dyn std::error::Error>> {
+    let mock_cli = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let prompt = format!(
+        "@ECHO@\n{}",
+        json!({ "type": "result", "marker": "connect-failure" })
+    );
+
+    unsafe {
+        common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
+        std::env::set_var("VM0_API_BACKEND_URL", "http://127.0.0.1:1");
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let mut runtime = common::guest_runtime_from_process_env()?;
+    let run_id = runtime.config.run_id.clone();
+    runtime.http = guest_agent::http::HttpClient::with_api_config(
+        "http://127.0.0.1:1",
+        "test-token",
+        "",
+        run_id,
+        Duration::ZERO,
+    )?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        common::execute_cli_for_runtime(
+            &runtime,
+            &SecretMasker::from_raw(""),
+            common::spawn_dummy_heartbeat(),
+        ),
+    )
+    .await
+    .map_err(|_| io::Error::other("connect-failure delivery exceeded its retry budget"))??;
+
+    result
+        .event_delivery
+        .ok_or_else(|| io::Error::other("connect failure omitted delivery diagnostic").into())
+}
+
+async fn run_transport_failure()
+-> Result<(EventDeliveryDiagnostic, Vec<String>), Box<dyn std::error::Error>> {
+    let mock_cli = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let mut server = common::ControlledHttpServer::start().await?;
+    let prompt = format!(
+        "@ECHO@\n{}",
+        json!({ "type": "result", "marker": "transport-failure" })
+    );
+
+    unsafe {
+        common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
+        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let mut runtime = common::guest_runtime_from_process_env()?;
+    let run_id = runtime.config.run_id.clone();
+    runtime.http = guest_agent::http::HttpClient::with_api_config(
+        &server.base_url,
+        "test-token",
+        "",
+        run_id,
+        Duration::ZERO,
+    )?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let execution = tokio::spawn(async move {
+        common::execute_cli_for_runtime(
+            &runtime,
+            &SecretMasker::from_raw(""),
+            common::spawn_dummy_heartbeat(),
+        )
+        .await
+    });
+
+    let mut request_ids = Vec::new();
+    let mut request_body = None;
+    for _ in 0..3 {
+        let request = server.next_request(Duration::from_secs(5)).await?;
+        if let Some(request_body) = &request_body {
+            assert_eq!(&request.request.body, request_body);
+        } else {
+            request_body = Some(request.request.body.clone());
+        }
+        request_ids.push(
+            request
+                .request
+                .client_request_id
+                .clone()
+                .ok_or_else(|| io::Error::other("transport request omitted request ID"))?,
+        );
+        drop(request);
+    }
+
+    let joined = tokio::time::timeout(Duration::from_secs(5), execution)
+        .await
+        .map_err(|_| io::Error::other("transport-failure delivery exceeded its retry budget"))?;
+    let result = joined??;
+    let delivery = result
+        .event_delivery
+        .ok_or_else(|| io::Error::other("transport failure omitted delivery diagnostic"))?;
+    Ok((delivery, request_ids))
+}
+
+fn assert_failed_attempts(
+    delivery: &EventDeliveryDiagnostic,
+    expected_kind: EventDeliveryAttemptFailureKind,
+) -> Result<
+    &[guest_contracts::diagnostics::EventDeliveryCompletedAttemptDiagnostic],
+    Box<dyn std::error::Error>,
+> {
+    let failed_batch = delivery
+        .first_failed_batch
+        .as_ref()
+        .ok_or_else(|| io::Error::other("delivery diagnostic omitted first failed batch"))?;
+    assert_eq!(failed_batch.attempts.len(), 3);
+    assert!(
+        failed_batch.attempts.iter().all(|attempt| {
+            attempt.failure_kind == expected_kind && attempt.http_status.is_none()
+        })
+    );
+    assert_eq!(
+        failed_batch.outcome,
+        EventDeliveryAcceptanceOutcome::OutcomeUnknown
+    );
+    let mut unique_request_ids = failed_batch
+        .attempts
+        .iter()
+        .map(|attempt| attempt.client_request_id.as_str())
+        .collect::<Vec<_>>();
+    unique_request_ids.sort_unstable();
+    unique_request_ids.dedup();
+    assert_eq!(unique_request_ids.len(), 3);
+    Ok(&failed_batch.attempts)
+}

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -460,12 +460,9 @@ async fn send_event_skips_session_id_for_non_init() {
 // =========================================================================
 
 #[tokio::test]
-async fn send_event_failure_writes_error_flag() {
+async fn send_event_failure_returns_error() {
     let api = SharedApiMock::new().await;
     let server = api.server();
-    let tmp = tempfile::tempdir().unwrap();
-    let paths = guest_agent::paths::GuestPaths::from_runtime_dir(tmp.path().join("runtime"));
-    let flag_path = paths.event_error_flag();
 
     let _mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/events");
@@ -476,12 +473,27 @@ async fn send_event_failure_writes_error_flag() {
         "runId": "test-run-001",
         "events": [{"type": "test", "sequenceNumber": 1}]
     });
-    let result =
-        guest_agent::events::post_event_with_error_flag(&http_client!(), &payload, flag_path).await;
+    let result = guest_agent::events::post_event(&http_client!(), &payload).await;
 
     assert!(result.is_err());
-    assert!(
-        std::path::Path::new(flag_path).exists(),
-        "event error flag should be written on failure"
-    );
+}
+
+#[tokio::test]
+async fn send_event_accepts_success_without_parsing_response_body() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/events");
+        then.status(204).body("not valid JSON");
+    });
+
+    let payload = json!({
+        "runId": "test-run-001",
+        "events": [{"type": "test", "sequenceNumber": 1}]
+    });
+    let result = guest_agent::events::post_event(&http_client!(), &payload).await;
+
+    assert!(result.is_ok());
+    mock.assert_calls_async(1).await;
 }

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -280,7 +280,6 @@ fn cleanup_session_checkpoint_files() {
     let _ = std::fs::remove_file(paths.final_session_history_identity_file());
     let _ = std::fs::remove_file(paths.checkpoint_error_file());
     let _ = std::fs::remove_file(paths.failure_diagnostic_file());
-    let _ = std::fs::remove_file(paths.event_error_flag());
 }
 
 pub(crate) struct SessionCheckpointFilesGuard;

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -120,10 +120,7 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
         cli_result.last_event_sequence, None,
         "no-API execute_cli must not enqueue webhook events"
     );
-    assert!(
-        !std::path::Path::new(runtime.paths.event_error_flag()).exists(),
-        "no-API execute_cli must not write event error flag"
-    );
+    assert!(cli_result.event_delivery.is_none());
     let cli_session_id = std::fs::read_to_string(runtime.paths.session_id_file())?;
     assert!(
         cli_session_id.starts_with("mock-"),

--- a/crates/guest-agent/tests/runtime_api_surface.rs
+++ b/crates/guest-agent/tests/runtime_api_surface.rs
@@ -29,7 +29,6 @@ const RUN_SCOPED_PATH_READER_NAMES: &[&str] = &[
     "runtime_dir",
     "session_id_file",
     "session_history_path_file",
-    "event_error_flag",
     "checkpoint_error_file",
     "final_session_history_identity_file",
     "failure_diagnostic_file",

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -47,6 +47,9 @@ pub struct FailureDiagnostic {
     pub prompt_bytes: u64,
     /// First prompt line length in bytes after stripping a trailing carriage return.
     pub first_line_bytes: u64,
+    /// Bounded event-delivery failure details, when delivery was terminally incomplete.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_delivery: Option<EventDeliveryDiagnostic>,
 }
 
 impl FailureDiagnostic {
@@ -71,6 +74,7 @@ impl FailureDiagnostic {
             prompt_shape: prompt.prompt_shape,
             prompt_bytes: prompt.prompt_bytes,
             first_line_bytes: prompt.first_line_bytes,
+            event_delivery: None,
         }
     }
 
@@ -127,6 +131,167 @@ impl FailureDiagnostic {
     ) -> Self {
         self.session_history_status = session_history_status;
         self
+    }
+
+    /// Attach bounded event-delivery failure details.
+    #[must_use]
+    pub fn with_event_delivery(mut self, event_delivery: EventDeliveryDiagnostic) -> Self {
+        self.event_delivery = Some(event_delivery);
+        self
+    }
+}
+
+/// Bounded structured details for terminal guest event-delivery failure.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventDeliveryDiagnostic {
+    /// Logical events included in delivery batches.
+    pub total_events: u64,
+    /// Logical delivery batches started.
+    pub total_batches: u64,
+    /// Logical batches whose HTTP retry budget was exhausted.
+    pub failed_batches: u64,
+    /// Highest contiguous event sequence acknowledged by the API.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_acknowledged_sequence: Option<u32>,
+    /// First logical batch whose retry budget was exhausted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_failed_batch: Option<EventDeliveryFailedBatchDiagnostic>,
+    /// Final delivery state captured at the global drain deadline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub drain_timeout: Option<EventDeliveryDrainTimeoutDiagnostic>,
+}
+
+/// First logical event batch whose HTTP retry budget was exhausted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventDeliveryFailedBatchDiagnostic {
+    /// First event sequence in the batch.
+    pub first_sequence: u32,
+    /// Last event sequence in the batch.
+    pub last_sequence: u32,
+    /// Number of events in the batch.
+    pub event_count: u32,
+    /// Conservative batch byte accounting used by guest admission control.
+    pub conservative_bytes: u64,
+    /// Whether the API explicitly rejected every terminal attempt.
+    pub outcome: EventDeliveryAcceptanceOutcome,
+    /// Completed failed attempts, bounded by the delivery retry budget.
+    pub attempts: Vec<EventDeliveryCompletedAttemptDiagnostic>,
+}
+
+/// One completed failed HTTP attempt for an exhausted event batch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventDeliveryCompletedAttemptDiagnostic {
+    /// One-based attempt number.
+    pub attempt: u32,
+    /// Exact `x-client-request-id` value sent on the request.
+    pub client_request_id: String,
+    /// Monotonic elapsed request time in milliseconds.
+    pub elapsed_ms: u64,
+    /// Stable content-safe failure classification.
+    pub failure_kind: EventDeliveryAttemptFailureKind,
+    /// HTTP response status, when a response was received.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_status: Option<u16>,
+}
+
+/// Delivery state captured when the global drain deadline expires.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventDeliveryDrainTimeoutDiagnostic {
+    /// Events still waiting in the bounded channel.
+    pub queued_events: u32,
+    /// Conservative bytes still waiting in the bounded channel.
+    pub queued_bytes: u64,
+    /// Events held outside the channel for the next batch.
+    pub carried_events: u32,
+    /// Conservative bytes held outside the channel for the next batch.
+    pub carried_bytes: u64,
+    /// Logical batch active at the deadline, when one was active.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_batch: Option<EventDeliveryActiveBatchDiagnostic>,
+}
+
+/// Logical event batch active at the global drain deadline.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventDeliveryActiveBatchDiagnostic {
+    /// First event sequence in the batch.
+    pub first_sequence: u32,
+    /// Last event sequence in the batch.
+    pub last_sequence: u32,
+    /// Number of events in the batch.
+    pub event_count: u32,
+    /// Conservative batch byte accounting used by guest admission control.
+    pub conservative_bytes: u64,
+    /// Completed failed attempts before the drain deadline.
+    pub completed_attempts: Vec<EventDeliveryCompletedAttemptDiagnostic>,
+    /// Request attempt still in flight at the deadline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_attempt: Option<EventDeliveryActiveAttemptDiagnostic>,
+    /// Acceptance remains unknown because delivery did not reach a terminal response.
+    pub outcome: EventDeliveryAcceptanceOutcome,
+}
+
+/// Request attempt active when the global drain deadline expires.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventDeliveryActiveAttemptDiagnostic {
+    /// One-based attempt number.
+    pub attempt: u32,
+    /// Exact `x-client-request-id` value sent on the request.
+    pub client_request_id: String,
+    /// Monotonic elapsed request time in milliseconds at the deadline.
+    pub elapsed_ms: u64,
+}
+
+/// Observed API acceptance outcome for terminal event delivery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventDeliveryAcceptanceOutcome {
+    /// Every failed attempt received an explicit non-success HTTP response.
+    ConfirmedRejection,
+    /// At least one request received no response, so acceptance is unknown.
+    OutcomeUnknown,
+}
+
+impl EventDeliveryAcceptanceOutcome {
+    /// Return the stable snake_case string representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ConfirmedRejection => "confirmed_rejection",
+            Self::OutcomeUnknown => "outcome_unknown",
+        }
+    }
+}
+
+/// Content-safe failure classification for a completed event HTTP attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventDeliveryAttemptFailureKind {
+    /// The request exceeded its transport timeout.
+    Timeout,
+    /// A connection could not be established.
+    Connect,
+    /// The API returned a non-success HTTP response.
+    HttpStatus,
+    /// Another transport failure occurred without an HTTP response.
+    Transport,
+}
+
+impl EventDeliveryAttemptFailureKind {
+    /// Return the stable snake_case string representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Timeout => "timeout",
+            Self::Connect => "connect",
+            Self::HttpStatus => "http_status",
+            Self::Transport => "transport",
+        }
     }
 }
 
@@ -1155,6 +1320,94 @@ mod tests {
     }
 
     #[test]
+    fn failure_diagnostic_round_trips_bounded_event_delivery_details() {
+        let first_attempt = EventDeliveryCompletedAttemptDiagnostic {
+            attempt: 1,
+            client_request_id: "11111111-1111-4111-8111-111111111111".to_string(),
+            elapsed_ms: 30_000,
+            failure_kind: EventDeliveryAttemptFailureKind::HttpStatus,
+            http_status: Some(500),
+        };
+        let active_attempt = EventDeliveryActiveAttemptDiagnostic {
+            attempt: 2,
+            client_request_id: "22222222-2222-4222-8222-222222222222".to_string(),
+            elapsed_ms: 4_000,
+        };
+        let event_delivery = EventDeliveryDiagnostic {
+            total_events: 40,
+            total_batches: 2,
+            failed_batches: 1,
+            last_acknowledged_sequence: Some(7),
+            first_failed_batch: Some(EventDeliveryFailedBatchDiagnostic {
+                first_sequence: 8,
+                last_sequence: 15,
+                event_count: 8,
+                conservative_bytes: 2_048,
+                outcome: EventDeliveryAcceptanceOutcome::ConfirmedRejection,
+                attempts: vec![first_attempt.clone()],
+            }),
+            drain_timeout: Some(EventDeliveryDrainTimeoutDiagnostic {
+                queued_events: 0,
+                queued_bytes: 0,
+                carried_events: 0,
+                carried_bytes: 0,
+                active_batch: Some(EventDeliveryActiveBatchDiagnostic {
+                    first_sequence: 16,
+                    last_sequence: 39,
+                    event_count: 24,
+                    conservative_bytes: 8_192,
+                    completed_attempts: vec![first_attempt],
+                    active_attempt: Some(active_attempt),
+                    outcome: EventDeliveryAcceptanceOutcome::OutcomeUnknown,
+                }),
+            }),
+        };
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::EventUploadFailed,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("continue"),
+        )
+        .with_cli_exit_code(0)
+        .with_event_delivery(event_delivery);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(
+            json["eventDelivery"]["firstFailedBatch"]["outcome"],
+            "confirmed_rejection"
+        );
+        assert_eq!(
+            json["eventDelivery"]["firstFailedBatch"]["attempts"][0]["failureKind"],
+            "http_status"
+        );
+        assert_eq!(
+            json["eventDelivery"]["drainTimeout"]["activeBatch"]["outcome"],
+            "outcome_unknown"
+        );
+        assert_eq!(
+            EventDeliveryAcceptanceOutcome::ConfirmedRejection.as_str(),
+            "confirmed_rejection"
+        );
+        assert_eq!(
+            EventDeliveryAttemptFailureKind::Transport.as_str(),
+            "transport"
+        );
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(round_trip, diagnostic);
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct OldFailureDiagnostic {
+            schema_version: u8,
+            failure_class: FailureClass,
+        }
+
+        let old_shape: OldFailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(old_shape.schema_version, FAILURE_DIAGNOSTIC_SCHEMA_VERSION);
+        assert_eq!(old_shape.failure_class, FailureClass::EventUploadFailed);
+    }
+
+    #[test]
     fn failure_diagnostic_deserializes_without_optional_fields() {
         let json = serde_json::json!({
             "schemaVersion": 1,
@@ -1173,5 +1426,6 @@ mod tests {
         assert_eq!(diagnostic.failure_detail_source, None);
         assert_eq!(diagnostic.failure_reason, None);
         assert_eq!(diagnostic.cli_termination, None);
+        assert_eq!(diagnostic.event_delivery, None);
     }
 }

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -146,11 +146,6 @@ pub fn session_history_marker_file(run_dir: impl AsRef<Path>) -> PathBuf {
     file(run_dir, "session-history-marker")
 }
 
-/// Return the run-root `event-error` file.
-pub fn event_error_file(run_dir: impl AsRef<Path>) -> PathBuf {
-    file(run_dir, "event-error")
-}
-
 /// Return the run-root `checkpoint-error` file.
 pub fn checkpoint_error_file(run_dir: impl AsRef<Path>) -> PathBuf {
     file(run_dir, "checkpoint-error")
@@ -899,7 +894,6 @@ mod tests {
         let files = [
             session_id_file(&run_dir),
             session_history_marker_file(&run_dir),
-            event_error_file(&run_dir),
             checkpoint_error_file(&run_dir),
             final_session_history_identity_file(&run_dir),
             failure_diagnostic_file(&run_dir),

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -10,8 +10,8 @@ use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
 use guest_contracts::diagnostics::{
-    CliObservedExitDiagnostic, CliObservedExitKind, CliTerminationDiagnostic, FailureClass,
-    FailureDiagnostic, FailureReason,
+    CliObservedExitDiagnostic, CliObservedExitKind, CliTerminationDiagnostic,
+    EventDeliveryDiagnostic, FailureClass, FailureDiagnostic, FailureReason,
 };
 use sandbox::SandboxId;
 use tokio::sync::mpsc;
@@ -737,6 +737,9 @@ fn log_job_execution_failed(
     let cli_observed_exit_fields = JobCliObservedExitLogFields::from(
         diagnostic.and_then(|diagnostic| diagnostic.cli_observed_exit.as_ref()),
     );
+    let event_delivery_fields = JobEventDeliveryLogFields::from(
+        diagnostic.and_then(|diagnostic| diagnostic.event_delivery.as_ref()),
+    );
     let resource_fields = JobResourceLogFields::from(failure.resource_diagnostics);
     let (timeout_ms, elapsed_ms, guest_duration_ms) = match failure.kind {
         ExecutionFailureKind::Generic => (None, None, None),
@@ -787,6 +790,59 @@ fn log_job_execution_failed(
                 prompt_shape = diagnostic.map(|diagnostic| diagnostic.prompt_shape.as_str()),
                 prompt_bytes = diagnostic.map(|diagnostic| diagnostic.prompt_bytes),
                 first_line_bytes = diagnostic.map(|diagnostic| diagnostic.first_line_bytes),
+                event_delivery_total_events = event_delivery_fields.total_events,
+                event_delivery_total_batches = event_delivery_fields.total_batches,
+                event_delivery_failed_batches = event_delivery_fields.failed_batches,
+                event_delivery_last_acknowledged_sequence =
+                    event_delivery_fields.last_acknowledged_sequence,
+                event_delivery_first_failure_first_sequence =
+                    event_delivery_fields.first_failure_first_sequence,
+                event_delivery_first_failure_last_sequence =
+                    event_delivery_fields.first_failure_last_sequence,
+                event_delivery_first_failure_event_count =
+                    event_delivery_fields.first_failure_event_count,
+                event_delivery_first_failure_conservative_bytes =
+                    event_delivery_fields.first_failure_conservative_bytes,
+                event_delivery_first_failure_outcome =
+                    event_delivery_fields.first_failure_outcome,
+                event_delivery_first_failure_attempt_count =
+                    event_delivery_fields.first_failure_attempt_count,
+                event_delivery_first_failure_final_attempt_number =
+                    event_delivery_fields.first_failure_final_attempt_number,
+                event_delivery_first_failure_final_attempt_kind =
+                    event_delivery_fields.first_failure_final_attempt_kind,
+                event_delivery_first_failure_final_attempt_http_status =
+                    event_delivery_fields.first_failure_final_attempt_http_status,
+                event_delivery_first_failure_final_attempt_request_id =
+                    event_delivery_fields.first_failure_final_attempt_request_id,
+                event_delivery_first_failure_final_attempt_elapsed_ms =
+                    event_delivery_fields.first_failure_final_attempt_elapsed_ms,
+                event_delivery_drain_timeout = event_delivery_fields.drain_timeout,
+                event_delivery_drain_queued_events =
+                    event_delivery_fields.drain_queued_events,
+                event_delivery_drain_queued_bytes = event_delivery_fields.drain_queued_bytes,
+                event_delivery_drain_carried_events =
+                    event_delivery_fields.drain_carried_events,
+                event_delivery_drain_carried_bytes =
+                    event_delivery_fields.drain_carried_bytes,
+                event_delivery_drain_active_first_sequence =
+                    event_delivery_fields.drain_active_first_sequence,
+                event_delivery_drain_active_last_sequence =
+                    event_delivery_fields.drain_active_last_sequence,
+                event_delivery_drain_active_event_count =
+                    event_delivery_fields.drain_active_event_count,
+                event_delivery_drain_active_conservative_bytes =
+                    event_delivery_fields.drain_active_conservative_bytes,
+                event_delivery_drain_active_completed_attempt_count =
+                    event_delivery_fields.drain_active_completed_attempt_count,
+                event_delivery_drain_active_attempt_number =
+                    event_delivery_fields.drain_active_attempt_number,
+                event_delivery_drain_active_attempt_request_id =
+                    event_delivery_fields.drain_active_attempt_request_id,
+                event_delivery_drain_active_attempt_elapsed_ms =
+                    event_delivery_fields.drain_active_attempt_elapsed_ms,
+                event_delivery_drain_active_outcome =
+                    event_delivery_fields.drain_active_outcome,
                 resource_failure_kind = resource_fields.resource_failure_kind,
                 guest_root_fs_used_percent = resource_fields.guest_root_fs_used_percent,
                 guest_root_fs_available_kb = resource_fields.guest_root_fs_available_kb,
@@ -841,6 +897,38 @@ struct JobCliObservedExitLogFields {
     mapped_exit_code: Option<i32>,
 }
 
+struct JobEventDeliveryLogFields<'a> {
+    total_events: Option<u64>,
+    total_batches: Option<u64>,
+    failed_batches: Option<u64>,
+    last_acknowledged_sequence: Option<u32>,
+    first_failure_first_sequence: Option<u32>,
+    first_failure_last_sequence: Option<u32>,
+    first_failure_event_count: Option<u32>,
+    first_failure_conservative_bytes: Option<u64>,
+    first_failure_outcome: Option<&'static str>,
+    first_failure_attempt_count: Option<u64>,
+    first_failure_final_attempt_number: Option<u32>,
+    first_failure_final_attempt_kind: Option<&'static str>,
+    first_failure_final_attempt_http_status: Option<u16>,
+    first_failure_final_attempt_request_id: Option<&'a str>,
+    first_failure_final_attempt_elapsed_ms: Option<u64>,
+    drain_timeout: Option<bool>,
+    drain_queued_events: Option<u32>,
+    drain_queued_bytes: Option<u64>,
+    drain_carried_events: Option<u32>,
+    drain_carried_bytes: Option<u64>,
+    drain_active_first_sequence: Option<u32>,
+    drain_active_last_sequence: Option<u32>,
+    drain_active_event_count: Option<u32>,
+    drain_active_conservative_bytes: Option<u64>,
+    drain_active_completed_attempt_count: Option<u64>,
+    drain_active_attempt_number: Option<u32>,
+    drain_active_attempt_request_id: Option<&'a str>,
+    drain_active_attempt_elapsed_ms: Option<u64>,
+    drain_active_outcome: Option<&'static str>,
+}
+
 impl From<Option<&CliTerminationDiagnostic>> for JobCliTerminationLogFields {
     fn from(diagnostic: Option<&CliTerminationDiagnostic>) -> Self {
         Self {
@@ -874,6 +962,59 @@ impl From<Option<&CliObservedExitDiagnostic>> for JobCliObservedExitLogFields {
                 .then(|| diagnostic.and_then(CliObservedExitDiagnostic::known_signal_name))
                 .flatten(),
             mapped_exit_code: diagnostic.map(|diagnostic| diagnostic.mapped_exit_code),
+        }
+    }
+}
+
+impl<'a> From<Option<&'a EventDeliveryDiagnostic>> for JobEventDeliveryLogFields<'a> {
+    fn from(diagnostic: Option<&'a EventDeliveryDiagnostic>) -> Self {
+        let first_failure =
+            diagnostic.and_then(|diagnostic| diagnostic.first_failed_batch.as_ref());
+        let first_failure_final_attempt = first_failure.and_then(|failure| failure.attempts.last());
+        let drain = diagnostic.and_then(|diagnostic| diagnostic.drain_timeout.as_ref());
+        let drain_active = drain.and_then(|drain| drain.active_batch.as_ref());
+        let drain_active_attempt = drain_active.and_then(|active| active.active_attempt.as_ref());
+
+        Self {
+            total_events: diagnostic.map(|diagnostic| diagnostic.total_events),
+            total_batches: diagnostic.map(|diagnostic| diagnostic.total_batches),
+            failed_batches: diagnostic.map(|diagnostic| diagnostic.failed_batches),
+            last_acknowledged_sequence: diagnostic
+                .and_then(|diagnostic| diagnostic.last_acknowledged_sequence),
+            first_failure_first_sequence: first_failure.map(|failure| failure.first_sequence),
+            first_failure_last_sequence: first_failure.map(|failure| failure.last_sequence),
+            first_failure_event_count: first_failure.map(|failure| failure.event_count),
+            first_failure_conservative_bytes: first_failure
+                .map(|failure| failure.conservative_bytes),
+            first_failure_outcome: first_failure.map(|failure| failure.outcome.as_str()),
+            first_failure_attempt_count: first_failure
+                .map(|failure| u64::try_from(failure.attempts.len()).unwrap_or(u64::MAX)),
+            first_failure_final_attempt_number: first_failure_final_attempt
+                .map(|attempt| attempt.attempt),
+            first_failure_final_attempt_kind: first_failure_final_attempt
+                .map(|attempt| attempt.failure_kind.as_str()),
+            first_failure_final_attempt_http_status: first_failure_final_attempt
+                .and_then(|attempt| attempt.http_status),
+            first_failure_final_attempt_request_id: first_failure_final_attempt
+                .map(|attempt| attempt.client_request_id.as_str()),
+            first_failure_final_attempt_elapsed_ms: first_failure_final_attempt
+                .map(|attempt| attempt.elapsed_ms),
+            drain_timeout: drain.map(|_| true),
+            drain_queued_events: drain.map(|drain| drain.queued_events),
+            drain_queued_bytes: drain.map(|drain| drain.queued_bytes),
+            drain_carried_events: drain.map(|drain| drain.carried_events),
+            drain_carried_bytes: drain.map(|drain| drain.carried_bytes),
+            drain_active_first_sequence: drain_active.map(|active| active.first_sequence),
+            drain_active_last_sequence: drain_active.map(|active| active.last_sequence),
+            drain_active_event_count: drain_active.map(|active| active.event_count),
+            drain_active_conservative_bytes: drain_active.map(|active| active.conservative_bytes),
+            drain_active_completed_attempt_count: drain_active
+                .map(|active| u64::try_from(active.completed_attempts.len()).unwrap_or(u64::MAX)),
+            drain_active_attempt_number: drain_active_attempt.map(|attempt| attempt.attempt),
+            drain_active_attempt_request_id: drain_active_attempt
+                .map(|attempt| attempt.client_request_id.as_str()),
+            drain_active_attempt_elapsed_ms: drain_active_attempt.map(|attempt| attempt.elapsed_ms),
+            drain_active_outcome: drain_active.map(|active| active.outcome.as_str()),
         }
     }
 }
@@ -982,8 +1123,11 @@ mod tests {
 
     use guest_contracts::diagnostics::{
         AgentFramework, CliObservedExitKind, CliTerminationDiagnostic, CliTerminationReason,
-        CliTerminationSignal, FailureClass, FailureDetailSource, PromptMetadata,
-        SessionHistoryStatus,
+        CliTerminationSignal, EventDeliveryAcceptanceOutcome, EventDeliveryActiveAttemptDiagnostic,
+        EventDeliveryActiveBatchDiagnostic, EventDeliveryAttemptFailureKind,
+        EventDeliveryCompletedAttemptDiagnostic, EventDeliveryDiagnostic,
+        EventDeliveryDrainTimeoutDiagnostic, EventDeliveryFailedBatchDiagnostic, FailureClass,
+        FailureDetailSource, PromptMetadata, SessionHistoryStatus,
     };
     use sandbox::SandboxId;
     use tracing::Level;
@@ -1582,6 +1726,7 @@ mod tests {
         assert!(!event.fields.contains_key("timeout_ms"));
         assert!(!event.fields.contains_key("cli_termination_reason"));
         assert!(!event.fields.contains_key("cli_observed_exit_kind"));
+        assert!(!event.fields.contains_key("event_delivery_total_batches"));
     }
 
     #[test]
@@ -1645,6 +1790,112 @@ mod tests {
         assert!(!event.fields.contains_key("cli_observed_signal_number"));
         assert!(!event.fields.contains_key("cli_observed_signal_name"));
         assert_field_eq(&event, "cli_observed_mapped_exit_code", "2");
+    }
+
+    #[test]
+    fn diagnostic_failure_logs_bounded_event_delivery_fields() {
+        let failed_attempt = EventDeliveryCompletedAttemptDiagnostic {
+            attempt: 3,
+            client_request_id: "11111111-1111-4111-8111-111111111111".to_string(),
+            elapsed_ms: 30_000,
+            failure_kind: EventDeliveryAttemptFailureKind::HttpStatus,
+            http_status: Some(500),
+        };
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::EventUploadFailed,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("continue"),
+        )
+        .with_cli_exit_code(0)
+        .with_event_delivery(EventDeliveryDiagnostic {
+            total_events: 40,
+            total_batches: 2,
+            failed_batches: 1,
+            last_acknowledged_sequence: Some(7),
+            first_failed_batch: Some(EventDeliveryFailedBatchDiagnostic {
+                first_sequence: 8,
+                last_sequence: 15,
+                event_count: 8,
+                conservative_bytes: 2_048,
+                outcome: EventDeliveryAcceptanceOutcome::ConfirmedRejection,
+                attempts: vec![failed_attempt.clone()],
+            }),
+            drain_timeout: Some(EventDeliveryDrainTimeoutDiagnostic {
+                queued_events: 0,
+                queued_bytes: 0,
+                carried_events: 1,
+                carried_bytes: 128,
+                active_batch: Some(EventDeliveryActiveBatchDiagnostic {
+                    first_sequence: 16,
+                    last_sequence: 39,
+                    event_count: 24,
+                    conservative_bytes: 8_192,
+                    completed_attempts: vec![failed_attempt],
+                    active_attempt: Some(EventDeliveryActiveAttemptDiagnostic {
+                        attempt: 2,
+                        client_request_id: "22222222-2222-4222-8222-222222222222".to_string(),
+                        elapsed_ms: 4_000,
+                    }),
+                    outcome: EventDeliveryAcceptanceOutcome::OutcomeUnknown,
+                }),
+            }),
+        });
+        let failure = executor::ExecutionFailure::new(1, "event delivery failed", Some(diagnostic));
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_field_eq(&event, "event_delivery_total_events", "40");
+        assert_field_eq(&event, "event_delivery_total_batches", "2");
+        assert_field_eq(&event, "event_delivery_failed_batches", "1");
+        assert_field_eq(&event, "event_delivery_last_acknowledged_sequence", "7");
+        assert_field_eq(&event, "event_delivery_first_failure_first_sequence", "8");
+        assert_field_eq(&event, "event_delivery_first_failure_last_sequence", "15");
+        assert_field_eq(
+            &event,
+            "event_delivery_first_failure_conservative_bytes",
+            "2048",
+        );
+        assert_field_eq(
+            &event,
+            "event_delivery_first_failure_outcome",
+            "confirmed_rejection",
+        );
+        assert_field_eq(
+            &event,
+            "event_delivery_first_failure_final_attempt_kind",
+            "http_status",
+        );
+        assert_field_eq(
+            &event,
+            "event_delivery_first_failure_final_attempt_http_status",
+            "500",
+        );
+        assert_field_eq(
+            &event,
+            "event_delivery_first_failure_final_attempt_request_id",
+            "11111111-1111-4111-8111-111111111111",
+        );
+        assert_field_eq(&event, "event_delivery_drain_timeout", "true");
+        assert_field_eq(&event, "event_delivery_drain_queued_events", "0");
+        assert_field_eq(&event, "event_delivery_drain_carried_events", "1");
+        assert_field_eq(&event, "event_delivery_drain_active_first_sequence", "16");
+        assert_field_eq(
+            &event,
+            "event_delivery_drain_active_attempt_request_id",
+            "22222222-2222-4222-8222-222222222222",
+        );
+        assert_field_eq(
+            &event,
+            "event_delivery_drain_active_attempt_elapsed_ms",
+            "4000",
+        );
+        assert_field_eq(
+            &event,
+            "event_delivery_drain_active_outcome",
+            "outcome_unknown",
+        );
+        assert!(!event.fields.contains_key("event_delivery_attempts"));
+        assert!(!event.fields.contains_key("event_delivery_body"));
     }
 
     #[test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -1,4 +1,9 @@
 use super::*;
+use guest_contracts::diagnostics::{
+    EventDeliveryAcceptanceOutcome, EventDeliveryAttemptFailureKind,
+    EventDeliveryCompletedAttemptDiagnostic, EventDeliveryDiagnostic,
+    EventDeliveryFailedBatchDiagnostic,
+};
 
 #[tokio::test]
 async fn execute_inner_appends_stream_overflow_marker() {
@@ -911,18 +916,40 @@ async fn execute_inner_nonzero_with_failure_diagnostic_skips_abnormal_exit_diagn
         FailureClass::CliNonzero,
         AgentFramework::ClaudeCode,
         PromptMetadata::from_prompt("/help"),
-    );
+    )
+    .with_event_delivery(EventDeliveryDiagnostic {
+        total_events: 1,
+        total_batches: 1,
+        failed_batches: 1,
+        last_acknowledged_sequence: None,
+        first_failed_batch: Some(EventDeliveryFailedBatchDiagnostic {
+            first_sequence: 0,
+            last_sequence: 0,
+            event_count: 1,
+            conservative_bytes: 128,
+            outcome: EventDeliveryAcceptanceOutcome::OutcomeUnknown,
+            attempts: vec![EventDeliveryCompletedAttemptDiagnostic {
+                attempt: 1,
+                client_request_id: "11111111-1111-4111-8111-111111111111".to_string(),
+                elapsed_ms: 10_000,
+                failure_kind: EventDeliveryAttemptFailureKind::Timeout,
+                http_status: None,
+            }],
+        }),
+        drain_timeout: None,
+    });
     overrides.push_read_file_result(Ok(Some(serde_json::to_vec(&diagnostic).unwrap())));
     overrides.push_read_file_result(Ok(None));
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
 
-    let (exit_code, error) =
-        run_new_sandbox_status(&factory, &minimal_context(), &config, &default_params())
-            .await
-            .unwrap();
+    let outcome = run_new_sandbox_outcome(&factory, &minimal_context(), &config, &default_params())
+        .await
+        .unwrap();
 
-    assert_eq!(exit_code, 126);
-    assert_eq!(error.as_deref(), Some("Agent exited with code 126"));
+    let failure = outcome.failure.expect("expected execution failure");
+    assert_eq!(failure.exit_code, 126);
+    assert_eq!(failure.error, "Agent exited with code 126");
+    assert_eq!(failure.diagnostic, Some(diagnostic));
     assert!(
         overrides
             .exec_calls()


### PR DESCRIPTION
## Summary

- replace the guest `event-error` flag with bounded structured delivery diagnostics
- record the first terminally failed batch, exact per-attempt request IDs and outcomes, and a separate drain-timeout snapshot
- preserve CLI and control failure precedence while routing delivery-only failures through recovery checkpointing
- expose a bounded scalar projection in runner failure logs and accept successful event responses without parsing their bodies
- cover retry exhaustion, non-retryable rejection, transport classification, drain cancellation, precedence, and guest/runner compatibility

## Compatibility and exclusions

- adds only an optional `eventDelivery` member to the existing schema-v1 guest diagnostic contract, so old and new guests and runners remain wire-compatible
- does not change API routes, database schemas, migrations, event replay, or metrics
- #23904 should preferably deploy first so event acknowledgements complete within the existing guest retry and drain budgets; there is no code-level dependency

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-contracts -p guest-agent -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-contracts -p guest-agent -p runner --all-features --no-deps`
- `cargo test -p guest-contracts`
- `cargo test -p guest-agent`
- `cargo test -p runner`

Closes #23905
