### PR TITLE
fix(runner): reconcile terminal network policy refreshes

### DIFF
--- a/crates/api-contracts/src/generated/constants.rs
+++ b/crates/api-contracts/src/generated/constants.rs
@@ -104,6 +104,10 @@ pub mod runners {
     /// Rust runners use this shared contract value to split refresh requests before calling the API.
     pub const NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX: u64 = 256;
 
+    /// API error code returned when network policy refresh targets a terminal run.
+    /// Rust runners use this shared contract value to distinguish terminal reconciliation from ambiguous refresh failures.
+    pub const NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE: &str = "RUN_TERMINAL";
+
     /// Maximum resume session history blob size accepted by the API, runner, and guest verifier.
     /// Rust and TypeScript components use this shared contract value when validating resume history refs, downloads, and idle-reuse verification.
     pub const RESUME_SESSION_HISTORY_MAX_BYTES: u64 = 134217728;

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -8,9 +8,14 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
-use api_contracts::generated::{constants::runners::RUNNER_POLL_EXCLUDED_RUN_IDS_MAX, routes};
+use api_contracts::generated::{
+    constants::runners::{
+        NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE, RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
+    },
+    routes,
+};
 use reqwest::{Response, StatusCode};
-use serde::{Serialize, de::DeserializeOwned};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use super::api_ably_supervisor::{
     AblySupervisor, AblySupervisorConfig, PollDue, PollOutcome, PollReason, PollWakeups,
@@ -77,6 +82,23 @@ struct PollRequestBody<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     excluded_run_ids: Option<&'a [RunId]>,
     telemetry: PollRequestTelemetry,
+}
+
+pub(super) enum NetworkPolicyRefreshOutcome {
+    Refreshed(NetworkPolicyRefreshBatchResponse),
+    RunTerminal,
+}
+
+#[derive(Deserialize)]
+struct ApiErrorEnvelope {
+    error: ApiErrorDetails,
+}
+
+#[derive(Deserialize)]
+struct ApiErrorDetails {
+    code: String,
+    #[serde(rename = "message")]
+    _message: String,
 }
 
 #[derive(Serialize)]
@@ -995,7 +1017,7 @@ impl ApiClient {
         &self,
         run_id: RunId,
         connector_slugs: &[String],
-    ) -> RunnerResult<NetworkPolicyRefreshBatchResponse> {
+    ) -> RunnerResult<NetworkPolicyRefreshOutcome> {
         let run_id = run_id.to_string();
         let resp = send_api(
             self.network_policy_refresh_request(&run_id, connector_slugs),
@@ -1003,8 +1025,20 @@ impl ApiClient {
         )
         .await?;
 
+        if resp.status() == StatusCode::CONFLICT {
+            let (status, body) = read_api_error(resp).await;
+            if serde_json::from_str::<ApiErrorEnvelope>(&body).is_ok_and(|response| {
+                response.error.code == NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE
+            }) {
+                return Ok(NetworkPolicyRefreshOutcome::RunTerminal);
+            }
+            return Err(api_status_error("network policy refresh", status, &body));
+        }
+
         let resp = check_api_status(resp, "network policy refresh").await?;
-        decode_api_json(resp, "network policy refresh").await
+        decode_api_json(resp, "network policy refresh")
+            .await
+            .map(NetworkPolicyRefreshOutcome::Refreshed)
     }
 
     fn network_policy_refresh_request(

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -884,16 +884,20 @@ mod tests {
     use crate::proxy::{ProxyRegistryHandle, VmRegistration};
     use crate::types::FirewallEntry;
 
-    fn api_client_for_server(server: &MockServer) -> ApiClient {
+    fn api_client_for_url(api_url: String) -> ApiClient {
         ApiClient::new(
             HttpClient::new(HttpClientConfig {
-                api_url: server.base_url(),
+                api_url,
                 vercel_bypass: None,
                 client_session_id: "runner-session-test".to_string(),
             })
             .expect("test API URL should be valid"),
             "runner-token".to_string(),
         )
+    }
+
+    fn api_client_for_server(server: &MockServer) -> ApiClient {
+        api_client_for_url(server.base_url())
     }
 
     fn core_without_worker(
@@ -966,6 +970,10 @@ mod tests {
             run_id: RunId,
             connector_slugs: &[&str],
         ) -> Self {
+            Self::new_with_api(api_client_for_server(server), run_id, connector_slugs).await
+        }
+
+        async fn new_with_api(api: ApiClient, run_id: RunId, connector_slugs: &[&str]) -> Self {
             let dir = tempfile::tempdir().expect("tempdir should be created");
             let registry_path = dir.path().join("proxy-registry.json");
             tokio::fs::write(&registry_path, br#"{"vms":{},"updatedAt":0}"#)
@@ -1026,7 +1034,7 @@ mod tests {
                 .await
                 .expect("vm should be registered");
 
-            let handle = NetworkPolicyRefreshHandle::new(api_client_for_server(server));
+            let handle = NetworkPolicyRefreshHandle::new(api);
             handle
                 .core
                 .register_run(NetworkPolicyRefreshRegistration {
@@ -1930,6 +1938,33 @@ mod tests {
             );
             harness.shutdown().await;
         }
+    }
+
+    #[tokio::test]
+    async fn transport_network_policy_refresh_error_remains_failure() {
+        let run_id = RunId::nil();
+        let harness = NetworkPolicyRefreshHarness::new_with_api(
+            api_client_for_url("http://127.0.0.1:0".to_string()),
+            run_id,
+            &["slack"],
+        )
+        .await;
+
+        let (_, events) = capture_network_policy_events(harness.refresh_slack()).await;
+
+        assert_fail_closed_policy(&harness.slack_policy().await);
+        captured_event(&events, "network policy refresh failed");
+        assert!(
+            harness
+                .handle
+                .core
+                .inner
+                .active_runs
+                .lock()
+                .await
+                .contains_key(&run_id)
+        );
+        harness.shutdown().await;
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -54,7 +54,7 @@ use tokio::sync::{
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use super::api::ApiClient;
+use super::api::{ApiClient, NetworkPolicyRefreshOutcome};
 use crate::ids::RunId;
 use crate::proxy::ProxyRegistryHandle;
 use crate::types::{NetworkPolicy, NetworkPolicyRefresh};
@@ -271,11 +271,18 @@ impl NetworkPolicyRefreshCore {
     }
 
     async fn unregister_run(&self, run_id: RunId) {
-        let old = self.inner.active_runs.lock().await.remove(&run_id);
-        if let Some(old) = old {
-            old.cancel.cancel();
-            abort_tasks(old.refresh_tasks.into_values().map(|task| task.handle));
-        }
+        let _ = self.take_active_run(run_id).await;
+    }
+
+    async fn take_active_run(&self, run_id: RunId) -> Option<ActiveRunNetworkPolicyState> {
+        let mut old = self.inner.active_runs.lock().await.remove(&run_id)?;
+        old.cancel.cancel();
+        abort_tasks(
+            std::mem::take(&mut old.refresh_tasks)
+                .into_values()
+                .map(|task| task.handle),
+        );
+        Some(old)
     }
 
     async fn notify_network_policy_refresh(&self, run_id: RunId, connector_slug: String) {
@@ -419,7 +426,11 @@ impl NetworkPolicyRefreshCore {
             .refresh_network_policies(run_id, active_connector_slugs)
             .await
         {
-            Ok(response) => response,
+            Ok(NetworkPolicyRefreshOutcome::Refreshed(response)) => response,
+            Ok(NetworkPolicyRefreshOutcome::RunTerminal) => {
+                self.reconcile_terminal_run(run_id).await;
+                return false;
+            }
             Err(error) => {
                 warn!(
                     run_id = %run_id,
@@ -532,6 +543,41 @@ impl NetworkPolicyRefreshCore {
             }
         }
         true
+    }
+
+    async fn reconcile_terminal_run(&self, run_id: RunId) {
+        let Some(active) = self.take_active_run(run_id).await else {
+            return;
+        };
+        let connector_count = active.connector_slugs.len();
+        let snapshot = ActiveRunNetworkPolicySnapshot {
+            source_ip: active.source_ip,
+            registry: active.registry,
+        };
+        for connector_slug in active.connector_slugs {
+            if let Err(error) = snapshot
+                .registry
+                .fail_closed_network_policy_if_run_matches(
+                    &snapshot.source_ip,
+                    &run_id.to_string(),
+                    &connector_slug,
+                )
+                .await
+            {
+                warn!(
+                    run_id = %run_id,
+                    connector_slug = connector_slug,
+                    connector_ref = connector_slug,
+                    error = %error,
+                    "failed to close terminal run network policy"
+                );
+            }
+        }
+        info!(
+            run_id = %run_id,
+            connector_count,
+            "reconciled terminal run network policies"
+        );
     }
 
     async fn active_connector_slugs(
@@ -908,6 +954,14 @@ mod tests {
 
     impl NetworkPolicyRefreshHarness {
         async fn new(server: &MockServer, run_id: RunId) -> Self {
+            Self::new_with_connectors(server, run_id, &["slack"]).await
+        }
+
+        async fn new_with_connectors(
+            server: &MockServer,
+            run_id: RunId,
+            connector_slugs: &[&str],
+        ) -> Self {
             let dir = tempfile::tempdir().expect("tempdir should be created");
             let registry_path = dir.path().join("proxy-registry.json");
             tokio::fs::write(&registry_path, br#"{"vms":{},"updatedAt":0}"#)
@@ -916,20 +970,31 @@ mod tests {
             let registry =
                 ProxyRegistryHandle::new(registry_path.clone(), dir.path().join("registry.lock"));
             let source_ip = "10.200.0.2";
-            let firewalls = vec![FirewallEntry::Builtin {
-                name: "slack".to_string(),
-                base_url_vars: None,
-            }];
-            let mut network_policies = HashMap::new();
-            network_policies.insert(
-                "slack".to_string(),
-                NetworkPolicy {
-                    allow: vec!["chat:write".to_string()],
-                    deny: vec!["files:write".to_string()],
-                    ask: vec!["channels:read".to_string()],
-                    unknown_policy: "allow".to_string(),
-                },
-            );
+            let connector_slugs = connector_slugs
+                .iter()
+                .map(|connector_slug| (*connector_slug).to_string())
+                .collect::<HashSet<_>>();
+            let firewalls = connector_slugs
+                .iter()
+                .map(|connector_slug| FirewallEntry::Builtin {
+                    name: connector_slug.clone(),
+                    base_url_vars: None,
+                })
+                .collect::<Vec<_>>();
+            let network_policies = connector_slugs
+                .iter()
+                .map(|connector_slug| {
+                    (
+                        connector_slug.clone(),
+                        NetworkPolicy {
+                            allow: vec!["chat:write".to_string()],
+                            deny: vec!["files:write".to_string()],
+                            ask: vec!["channels:read".to_string()],
+                            unknown_policy: "allow".to_string(),
+                        },
+                    )
+                })
+                .collect::<HashMap<_, _>>();
             let billable_firewalls = Vec::new();
             let run_id_string = run_id.to_string();
             let network_log_path = dir.path().join("network.jsonl");
@@ -964,7 +1029,7 @@ mod tests {
                     run_id,
                     source_ip,
                     registry: registry.clone(),
-                    connector_slugs: HashSet::from(["slack".to_string()]),
+                    connector_slugs,
                     refreshes: None,
                 })
                 .await;
@@ -986,13 +1051,17 @@ mod tests {
         }
 
         async fn slack_policy(&self) -> serde_json::Value {
+            self.policy("slack").await
+        }
+
+        async fn policy(&self, connector_slug: &str) -> serde_json::Value {
             let registry_json: serde_json::Value = serde_json::from_str(
                 &tokio::fs::read_to_string(&self.registry_path)
                     .await
                     .expect("registry should be readable"),
             )
             .expect("registry should be valid JSON");
-            registry_json["vms"][&self.source_ip]["networkPolicies"]["slack"].clone()
+            registry_json["vms"][&self.source_ip]["networkPolicies"][connector_slug].clone()
         }
 
         async fn shutdown(self) {
@@ -1721,6 +1790,142 @@ mod tests {
             "connector_ref",
             "slack",
         );
+    }
+
+    #[tokio::test]
+    async fn terminal_network_policy_refresh_reconciles_entire_run() {
+        let server = MockServer::start();
+        let run_id = RunId::nil();
+        let refresh_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path(format!("/api/runners/runs/{run_id}/network-policy-refresh"))
+                .json_body(json!({ "connectorSlugs": ["slack"] }));
+            then.status(409)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "error": {
+                        "code": "RUN_TERMINAL",
+                        "message": "Run is terminal",
+                    },
+                }));
+        });
+        let harness =
+            NetworkPolicyRefreshHarness::new_with_connectors(&server, run_id, &["slack", "github"])
+                .await;
+        harness
+            .handle
+            .core
+            .replace_schedule(
+                run_id,
+                "github",
+                Some("2999-01-01T00:00:00.000Z".to_string()),
+            )
+            .await
+            .expect("valid refresh deadline should schedule");
+
+        let (_, events) = capture_network_policy_events(harness.refresh_slack()).await;
+
+        refresh_mock.assert_calls(1);
+        assert_fail_closed_policy(&harness.policy("slack").await);
+        assert_fail_closed_policy(&harness.policy("github").await);
+        assert!(
+            harness
+                .handle
+                .core
+                .inner
+                .active_runs
+                .lock()
+                .await
+                .get(&run_id)
+                .is_none()
+        );
+        assert!(
+            events.iter().all(|event| {
+                event
+                    .fields
+                    .get("message")
+                    .is_none_or(|message| message != "network policy refresh failed")
+            }),
+            "terminal reconciliation should not emit the generic failure warning"
+        );
+        captured_event(&events, "reconciled terminal run network policies");
+
+        harness
+            .handle
+            .notify_network_policy_refresh(run_id, "slack".to_string())
+            .await;
+        tokio::task::yield_now().await;
+        refresh_mock.assert_calls(1);
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn ambiguous_network_policy_refresh_errors_remain_failures() {
+        for (status, body) in [
+            (
+                404_u16,
+                json!({
+                    "error": {
+                        "code": "RUN_TERMINAL",
+                        "message": "Run is terminal",
+                    },
+                }),
+            ),
+            (
+                403_u16,
+                json!({
+                    "error": {
+                        "code": "FORBIDDEN",
+                        "message": "Run does not belong to user",
+                    },
+                }),
+            ),
+            (
+                409_u16,
+                json!({
+                    "error": {
+                        "code": "CONFLICT",
+                        "message": "unrelated conflict",
+                    },
+                }),
+            ),
+            (
+                409_u16,
+                json!({
+                    "error": {
+                        "code": "RUN_TERMINAL",
+                    },
+                }),
+            ),
+        ] {
+            let server = MockServer::start();
+            let run_id = RunId::nil();
+            let refresh_mock = server.mock(|when, then| {
+                when.method(POST)
+                    .path(format!("/api/runners/runs/{run_id}/network-policy-refresh"));
+                then.status(status)
+                    .header("content-type", "application/json")
+                    .json_body(body);
+            });
+            let harness = NetworkPolicyRefreshHarness::new(&server, run_id).await;
+
+            let (_, events) = capture_network_policy_events(harness.refresh_slack()).await;
+
+            refresh_mock.assert_calls(1);
+            assert_fail_closed_policy(&harness.slack_policy().await);
+            captured_event(&events, "network policy refresh failed");
+            assert!(
+                harness
+                    .handle
+                    .core
+                    .inner
+                    .active_runs
+                    .lock()
+                    .await
+                    .contains_key(&run_id)
+            );
+            harness.shutdown().await;
+        }
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -16,6 +16,10 @@
 //! against the requested active connector set, patches the proxy registry, and
 //! replaces the next schedule from the returned `nextRefreshAt`.
 //!
+//! A typed terminal-run response removes the entire run from refresh tracking,
+//! cancels its scheduled work, and fail-closes every still-matching connector
+//! policy. Ambiguous API failures retain the connector-scoped fail-closed path.
+//!
 //! The safety contract is to trigger fail-closed patching when freshness cannot
 //! be established for an active connector. Queue overflow, API refresh failure,
 //! omitted requested connectors, duplicate requested connectors, malformed

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "node:crypto";
 
 import { cronCleanupSandboxesContract } from "@vm0/api-contracts/contracts/cron";
+import {
+  NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
+  runnersNetworkPolicyRefreshContract,
+} from "@vm0/api-contracts/contracts/runners";
 import type {
   TestCronCleanupSandboxesStateActionBody,
   TestCronCleanupSandboxesStateActionResponse,
@@ -21,6 +25,8 @@ const BUCKET = "test-user-storage-bucket";
 const FIXED_NOW_MS = Date.parse("2000-01-01T00:10:00.000Z");
 const CRON_CLEANUP_STATE_ROUTE =
   "/api/test/cron-cleanup-sandboxes-state/action";
+const OFFICIAL_RUNNER_AUTHORIZATION =
+  "Bearer vm0_official_abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
 
 interface RunFixture {
   readonly runId: string;
@@ -413,7 +419,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     });
   });
 
-  it("cleans up pending runs after the pending timeout", async () => {
+  it("exposes a pending-run timeout as terminal to policy refresh", async () => {
     const fixture = await trackRun(
       insertRunFixture({ status: "pending", createdAt: minutesAgo(6) }),
     );
@@ -437,6 +443,19 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       error: "Run timed out while pending (never started)",
     });
     await expect(findRunnerJob(fixture.runId)).resolves.toBeNull();
+
+    const refresh = await accept(
+      setupApp({ context })(runnersNetworkPolicyRefreshContract).refresh({
+        headers: { authorization: OFFICIAL_RUNNER_AUTHORIZATION },
+        params: { runId: fixture.runId },
+        body: { connectorSlugs: ["slack"] },
+      }),
+      [409],
+    );
+    expect(refresh.body.error).toStrictEqual({
+      code: NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
+      message: "Run is terminal",
+    });
   });
 
   it("cleans up pending runs without runner jobs after the pending timeout", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -96,6 +96,7 @@ type RunnerJobClaimRequest = z.infer<
 type RunnerNetworkPolicyRefreshRequest = z.input<
   (typeof runnersNetworkPolicyRefreshContract.refresh)["body"]
 >;
+type RunnerNetworkPolicyRefreshStatus = 200 | 400 | 401 | 403 | 404 | 409 | 500;
 type ComposeContent = z.infer<
   (typeof composesMainContract.create)["body"]
 >["content"];
@@ -487,11 +488,30 @@ export function createRunsApi(context: TestContext) {
       return refresh;
     },
 
-    async requestRefreshRunnerNetworkPolicyAs(
+    async requestRefreshRunnerNetworkPolicy<
+      TStatus extends RunnerNetworkPolicyRefreshStatus,
+    >(
+      runId: string,
+      body: RunnerNetworkPolicyRefreshRequest,
+      statuses: readonly TStatus[],
+    ) {
+      return await accept(
+        runApp(context)(runnersNetworkPolicyRefreshContract).refresh({
+          headers: runnerHeaders(true),
+          params: { runId },
+          body,
+        }),
+        statuses,
+      );
+    },
+
+    async requestRefreshRunnerNetworkPolicyAs<
+      TStatus extends RunnerNetworkPolicyRefreshStatus,
+    >(
       authorization: string | undefined,
       runId: string,
       body: RunnerNetworkPolicyRefreshRequest,
-      statuses: readonly (200 | 400 | 401 | 403 | 404 | 500)[],
+      statuses: readonly TStatus[],
     ) {
       return await accept(
         runApp(context)(runnersNetworkPolicyRefreshContract).refresh({

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -12,7 +12,10 @@ import {
   getVm0ConcreteProviderType,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
-import type { Job as RunnerJob } from "@vm0/api-contracts/contracts/runners";
+import {
+  NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
+  type Job as RunnerJob,
+} from "@vm0/api-contracts/contracts/runners";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { getCustomSkillStorageName } from "@vm0/core/storage-names";
 import {
@@ -8480,8 +8483,138 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(failedRefreshNotification.status).toBe(500);
 
     await api.requestCancelRun(actor, snapshotRun.runId, [200]);
+    const cancelledRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
+      `Bearer ${actorRunnerKey.token}`,
+      snapshotRun.runId,
+      { connectorSlugs: ["slack"] },
+      [409],
+    );
+    expect(cancelledRefresh.body.error.code).toBe(
+      NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
+    );
     const drained = await api.readRunQueue(actor);
     expect(drained.body.concurrency.active).toBe(0);
+  });
+
+  it("distinguishes a terminal policy refresh from missing runs", async () => {
+    const api = createRunsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const member = createBddApi(context).user({
+      orgId: actor.orgId,
+      orgRole: "org:member",
+    });
+    await api.heartbeatRunner(runnerGroup);
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "complete before runner policy cleanup",
+      modelProvider: "anthropic-api-key",
+    });
+    const claim = await api.claimRunnerJob(run.runId);
+    const history = `terminal refresh history ${run.runId}`;
+    const historyHash = createHash("sha256").update(history).digest("hex");
+    mockSessionHistoryBlob(historyHash, history);
+    const sandboxHeaders = {
+      authorization: `Bearer ${claim.sandboxToken}`,
+    };
+    await webhooks.requestAgentCheckpoint(
+      {
+        runId: run.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `terminal-refresh-${run.runId}`,
+        cliAgentSessionHistoryHash: historyHash,
+      },
+      sandboxHeaders,
+      [200],
+    );
+    await webhooks.requestAgentComplete(
+      { runId: run.runId, exitCode: 0, lastEventSequence: 0 },
+      sandboxHeaders,
+      [200],
+    );
+    expect((await api.readRun(actor, run.runId)).status).toBe("completed");
+
+    const actorRunnerKey = await api.createCliToken(actor);
+    const memberRunnerKey = await api.createCliToken(member);
+    const body = { connectorSlugs: ["slack"] };
+    const sameUserRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
+      `Bearer ${actorRunnerKey.token}`,
+      run.runId,
+      body,
+      [409],
+    );
+    expect(sameUserRefresh.body.error).toStrictEqual({
+      code: NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
+      message: "Run is terminal",
+    });
+    const officialRefresh = await api.requestRefreshRunnerNetworkPolicy(
+      run.runId,
+      body,
+      [409],
+    );
+    expect(officialRefresh.body.error.code).toBe(
+      NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
+    );
+
+    const foreignRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
+      `Bearer ${memberRunnerKey.token}`,
+      run.runId,
+      body,
+      [404],
+    );
+    expect(foreignRefresh.body.error.code).toBe("NOT_FOUND");
+    const missingRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
+      `Bearer ${actorRunnerKey.token}`,
+      randomUUID(),
+      body,
+      [404],
+    );
+    expect(missingRefresh.body.error.code).toBe("NOT_FOUND");
+
+    const failedRun = await api.createRun(actor, {
+      agentId,
+      prompt: "fail before runner policy cleanup",
+      modelProvider: "anthropic-api-key",
+    });
+    const failedClaim = await api.claimRunnerJob(failedRun.runId);
+    await webhooks.requestAgentComplete(
+      {
+        runId: failedRun.runId,
+        exitCode: 1,
+        error: "terminal refresh failure fixture",
+        lastEventSequence: 0,
+      },
+      { authorization: `Bearer ${failedClaim.sandboxToken}` },
+      [200],
+    );
+    expect((await api.readRun(actor, failedRun.runId)).status).toBe("failed");
+    const failedRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
+      `Bearer ${actorRunnerKey.token}`,
+      failedRun.runId,
+      body,
+      [409],
+    );
+    expect(failedRefresh.body.error.code).toBe(
+      NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
+    );
+
+    const nonTerminalRun = await api.createRun(actor, {
+      agentId,
+      prompt: "do not classify as terminal before claim",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(["queued", "pending"]).toContain(
+      (await api.readRun(actor, nonTerminalRun.runId)).status,
+    );
+    const nonTerminalRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
+      `Bearer ${actorRunnerKey.token}`,
+      nonTerminalRun.runId,
+      body,
+      [404],
+    );
+    expect(nonTerminalRefresh.body.error.code).toBe("NOT_FOUND");
+    await api.requestCancelRun(actor, nonTerminalRun.runId, [200]);
   });
 
   it("records co-occurring resume and policy response timing", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8598,23 +8598,40 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(failedRefresh.body.error.code).toBe(
       NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
     );
+  });
 
-    const nonTerminalRun = await api.createRun(actor, {
-      agentId,
-      prompt: "do not classify as terminal before claim",
-      modelProvider: "anthropic-api-key",
-    });
-    expect(["queued", "pending"]).toContain(
-      (await api.readRun(actor, nonTerminalRun.runId)).status,
-    );
-    const nonTerminalRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
-      `Bearer ${actorRunnerKey.token}`,
-      nonTerminalRun.runId,
-      body,
-      [404],
-    );
-    expect(nonTerminalRefresh.body.error.code).toBe("NOT_FOUND");
-    await api.requestCancelRun(actor, nonTerminalRun.runId, [200]);
+  it("does not classify queued or pending runs as terminal", async () => {
+    const api = createRunsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    const runnerKey = await api.createCliToken(actor);
+    const createNonTerminalRun = async (prompt: string) => {
+      return await api.createRun(actor, {
+        agentId,
+        prompt,
+        modelProvider: "anthropic-api-key",
+      });
+    };
+
+    const firstPending = await createNonTerminalRun("pending refresh one");
+    const secondPending = await createNonTerminalRun("pending refresh two");
+    const queued = await createNonTerminalRun("queued refresh");
+    expect(firstPending.status).toBe("pending");
+    expect(secondPending.status).toBe("pending");
+    expect(queued.status).toBe("queued");
+
+    for (const run of [firstPending, secondPending, queued]) {
+      const refresh = await api.requestRefreshRunnerNetworkPolicyAs(
+        `Bearer ${runnerKey.token}`,
+        run.runId,
+        { connectorSlugs: ["slack"] },
+        [404],
+      );
+      expect(refresh.body.error.code).toBe("NOT_FOUND");
+    }
+
+    await api.requestCancelRun(actor, queued.runId, [200]);
+    await api.requestCancelRun(actor, secondPending.runId, [200]);
+    await api.requestCancelRun(actor, firstPending.runId, [200]);
   });
 
   it("records co-occurring resume and policy response timing", async () => {

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -3,6 +3,7 @@ import { connectorSlugSchema } from "@vm0/api-contracts/contracts/connector-iden
 import {
   compatibleStoredExecutionContextSchema,
   elapsedSinceApiStartMs,
+  NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
   RESUME_SESSION_HISTORY_MAX_BYTES,
   runnersNetworkPolicyRefreshContract,
   runnersBuiltinFirewallsResolveContract,
@@ -17,6 +18,10 @@ import {
   type StoredConnectorPermissionBaseline,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
+import {
+  runStatusSchema,
+  type RunStatus,
+} from "@vm0/api-contracts/contracts/runs";
 import { runnerRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
@@ -735,11 +740,12 @@ interface ClaimedRun {
   readonly vars: unknown;
 }
 
-interface ActiveRunNetworkPolicyScope {
+interface RunNetworkPolicyScope {
   readonly runId: string;
   readonly userId: string;
   readonly orgId: string;
   readonly agentId: string;
+  readonly status: RunStatus;
 }
 
 type ClaimLookupResult = ClaimableJob | ReturnType<typeof notFound>;
@@ -748,29 +754,35 @@ function isClaimableJob(value: ClaimLookupResult): value is ClaimableJob {
   return "job" in value;
 }
 
-async function getActiveRunNetworkPolicyScope(
+async function getRunNetworkPolicyScope(
   db: Db,
   runId: string,
   signal: AbortSignal,
-): Promise<ActiveRunNetworkPolicyScope | undefined> {
+): Promise<RunNetworkPolicyScope | undefined> {
   const [row] = await db
     .select({
       runId: agentRuns.id,
       userId: agentRuns.userId,
       orgId: agentRuns.orgId,
       agentId: agentSessions.agentComposeId,
+      status: agentRuns.status,
     })
     .from(agentRuns)
     .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
-    .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "running")))
+    .where(eq(agentRuns.id, runId))
     .limit(1);
   signal.throwIfAborted();
-  return row;
+  return row
+    ? {
+        ...row,
+        status: runStatusSchema.parse(row.status),
+      }
+    : undefined;
 }
 
 function runnerRunAuthorizationError(
   auth: RunnerAuthContext,
-  run: Pick<ActiveRunNetworkPolicyScope, "userId">,
+  run: Pick<RunNetworkPolicyScope, "userId">,
 ) {
   if (auth.type === "official-runner") {
     return null;
@@ -778,6 +790,15 @@ function runnerRunAuthorizationError(
   return run.userId === auth.userId
     ? null
     : forbidden("Run does not belong to user");
+}
+
+function isTerminalRunStatus(status: RunStatus): boolean {
+  return (
+    status === "completed" ||
+    status === "failed" ||
+    status === "timeout" ||
+    status === "cancelled"
+  );
 }
 
 async function getClaimableJob(
@@ -2322,12 +2343,26 @@ const networkPolicyRefreshInner$ = command(
       pathParamsOf(runnersNetworkPolicyRefreshContract.refresh),
     ).runId;
     const db = set(writeDb$);
-    const run = await getActiveRunNetworkPolicyScope(db, runId, signal);
+    const run = await getRunNetworkPolicyScope(db, runId, signal);
     if (!run) {
       return notFound("Run not found");
     }
 
     const authError = runnerRunAuthorizationError(auth, run);
+    if (run.status !== "running") {
+      if (authError || !isTerminalRunStatus(run.status)) {
+        return notFound("Run not found");
+      }
+      return {
+        status: 409 as const,
+        body: {
+          error: {
+            code: NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
+            message: "Run is terminal",
+          },
+        },
+      };
+    }
     if (authError) {
       return authError;
     }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -11,6 +11,7 @@ import {
   heldSessionStateSchema,
   jobSchema,
   NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX,
+  NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
   RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX,
   RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
   SESSION_HISTORY_DOWNLOAD_SOURCE_CONFIGURED_PUBLIC_ENDPOINT,
@@ -887,6 +888,8 @@ describe("runner poll request contract", () => {
 
 describe("runner network policy refresh contract", () => {
   const bodySchema = runnersNetworkPolicyRefreshContract.refresh.body;
+  const terminalResponseSchema =
+    runnersNetworkPolicyRefreshContract.refresh.responses[409];
 
   it("normalizes canonical connector slugs and ignores additional fields", () => {
     expect(
@@ -914,6 +917,30 @@ describe("runner network policy refresh contract", () => {
     ],
   ])("rejects %s", (_, body) => {
     expect(bodySchema.safeParse(body).success).toBe(false);
+  });
+
+  it("requires the terminal error code for conflict responses", () => {
+    expect(
+      terminalResponseSchema.parse({
+        error: {
+          code: NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
+          message: "Run is terminal",
+        },
+      }),
+    ).toEqual({
+      error: {
+        code: "RUN_TERMINAL",
+        message: "Run is terminal",
+      },
+    });
+    expect(
+      terminalResponseSchema.safeParse({
+        error: {
+          code: "CONFLICT",
+          message: "Run is not refreshable",
+        },
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -36,6 +36,7 @@ export const SESSION_HISTORY_DOWNLOAD_SOURCE_DEFAULT_R2_ENDPOINT =
   "default_r2_endpoint";
 export const SESSION_HISTORY_GZIP_MIN_BYTES = 64 * 1024;
 export const NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX = 256;
+export const NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE = "RUN_TERMINAL";
 export const RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX = 512;
 export const sessionHistoryEncodingSchema = z.enum([
   SESSION_HISTORY_ENCODING_IDENTITY,
@@ -738,6 +739,11 @@ export const runnersNetworkPolicyRefreshContract = c.router({
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
+      409: apiErrorSchema.extend({
+        error: apiErrorSchema.shape.error.extend({
+          code: z.literal(NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE),
+        }),
+      }),
       500: apiErrorSchema,
     },
     summary: "Refresh active run network policies",

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
@@ -29,6 +29,7 @@ import {
   CANONICAL_GUEST_HOME_DIR,
   CANONICAL_WORKING_DIR,
   NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX,
+  NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
   RESUME_SESSION_HISTORY_MAX_BYTES,
   RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
   SESSION_HISTORY_DOWNLOAD_SOURCE_CONFIGURED_PUBLIC_ENDPOINT,
@@ -59,6 +60,10 @@ const resumeSessionHistoryMaxBytesDoc = [
 const networkPolicyRefreshConnectorSlugsMaxDoc = [
   "Maximum connector slugs accepted by the runner network policy refresh endpoint.",
   "Rust runners use this shared contract value to split refresh requests before calling the API.",
+] as const;
+const networkPolicyRefreshRunTerminalErrorCodeDoc = [
+  "API error code returned when network policy refresh targets a terminal run.",
+  "Rust runners use this shared contract value to distinguish terminal reconciliation from ambiguous refresh failures.",
 ] as const;
 const runnerPollExcludedRunIdsMaxDoc = [
   "Maximum runner-local claim cooldown exclusions accepted by the poll endpoint.",
@@ -182,6 +187,12 @@ const expectedBindings = [
     rustConstName: "NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX",
     value: rustU64(NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX),
     rustDoc: networkPolicyRefreshConnectorSlugsMaxDoc,
+  },
+  {
+    rustModulePath: ["runners"],
+    rustConstName: "NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE",
+    value: rustString(NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE),
+    rustDoc: networkPolicyRefreshRunTerminalErrorCodeDoc,
   },
   {
     rustModulePath: ["runners"],
@@ -412,6 +423,9 @@ describe("Rust constant bindings", () => {
     );
     expect(firstRender).toContain(
       `pub const NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX: u64 = ${NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX};`,
+    );
+    expect(firstRender).toContain(
+      `pub const NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE: &str = "${NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE}";`,
     );
     expect(firstRender).toContain(
       `pub const SESSION_HISTORY_ENCODING_GZIP: &str = "${SESSION_HISTORY_ENCODING_GZIP}";`,

--- a/turbo/packages/api-contracts/src/rust-bindings/constants.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/constants.ts
@@ -18,6 +18,7 @@ import {
   CANONICAL_GUEST_HOME_DIR,
   CANONICAL_WORKING_DIR,
   NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX,
+  NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
   RESUME_SESSION_HISTORY_MAX_BYTES,
   RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
   SESSION_HISTORY_DOWNLOAD_SOURCE_CONFIGURED_PUBLIC_ENDPOINT,
@@ -259,6 +260,15 @@ export const rustConstantBindings = [
     rustDoc: [
       "Maximum connector slugs accepted by the runner network policy refresh endpoint.",
       "Rust runners use this shared contract value to split refresh requests before calling the API.",
+    ],
+  },
+  {
+    rustModulePath: ["runners"],
+    rustConstName: "NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE",
+    value: rustString(NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE),
+    rustDoc: [
+      "API error code returned when network policy refresh targets a terminal run.",
+      "Rust runners use this shared contract value to distinguish terminal reconciliation from ambiguous refresh failures.",
     ],
   },
   {


### PR DESCRIPTION
## Summary

- return a typed `409 RUN_TERMINAL` response when an authorized network policy refresh targets a completed, failed, timed-out, or cancelled run
- make the runner recognize only that exact response, remove the terminal run from active refresh state, cancel its schedules, and fail-close every connector registered for the run
- preserve existing authorization and non-disclosure behavior for foreign, missing, queued, and pending runs, while keeping ambiguous refresh failures fail-closed

## Compatibility and scope

- mixed API/runner versions remain fail-closed
- no guest protocol, database migration, feature switch, or historical cleanup is introduced

## Validation

- `pnpm -F @vm0/api-contracts generate:rust`
- `pnpm format`
- `pnpm -F @vm0/api-contracts test -- --run`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts --silent=passed-only`
- `pnpm knip`
- `cargo fmt --all -- --check`
- `cargo clippy -p api-contracts -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p api-contracts -p runner --all-features --no-deps`
- `cargo test -p api-contracts`
- `cargo test -p runner --all-features provider::network_policy_refresh::tests`
- `cargo test -p runner --all-targets --all-features`
- pre-commit hooks

Closes #23891
