### PR TITLE
feat(platform): enable locale rollout and browser detection

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -184,10 +184,7 @@ runs:
           add_env FEISHU_CALLBACK_BASE_URL "$api_backend_url"
           add_env VM0_WEB_URL "$web_url"
           add_env ENV "$deploy_env"
-          # pt-BR has not shipped; enable it only in preview for validation.
-          if [[ "$INPUT_ENVIRONMENT" == "preview" ]]; then
-            add_env BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED "true"
-          fi
+          add_env BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED "true"
           if [[ "$INPUT_ENVIRONMENT" == "production" ]]; then
             add_secret CLOUDFLARE_BROWSER_RENDERING_API_TOKEN CLOUDFLARE_BROWSER_RENDERING_API_TOKEN
             add_secret ARTIFACT_PREVIEW_WAF_SECRET ARTIFACT_PREVIEW_WAF_SECRET

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -235,7 +235,7 @@ assert_env_value "$production_api_env_file" ZERO_FINANCE_APIDOJO_TOKEN "github-a
 assert_env_value "$production_api_env_file" ZERO_BROWSER_USE_API_KEY "github-browser-use-api-key"
 assert_env_value "$production_api_env_file" ZERO_SCRAPE_FIRECRAWL_TOKEN "github-firecrawl-token"
 assert_env_value "$production_api_env_file" ZERO_WEB_SEARCH_PERPLEXITY_TOKEN "github-perplexity-token"
-assert_env_absent_value "$production_api_env_file" "BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED="
+assert_env_value "$production_api_env_file" BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED "true"
 assert_env_absent_value "$production_api_env_file" "ONBOARDING_URL="
 assert_env_value "$production_api_env_file" CLOUDFLARE_BROWSER_RENDERING_API_TOKEN "github-cloudflare-browser-rendering-token"
 assert_env_value "$production_api_env_file" ARTIFACT_PREVIEW_WAF_SECRET "github-artifact-preview-waf-secret"

--- a/turbo/apps/api/src/lib/brazilian-portuguese-locale-rollout.ts
+++ b/turbo/apps/api/src/lib/brazilian-portuguese-locale-rollout.ts
@@ -1,9 +1,8 @@
 import { optionalEnv } from "./env";
 
 /**
- * Keep the writer disabled until old API readers have drained. Remove this
- * gate only after every rollback-eligible API version accepts stored pt-BR
- * locale preferences.
+ * Keep a deploy-time compatibility gate so emergency rollbacks can disable
+ * pt-BR preference reads and writes without rebuilding the API.
  */
 export function isBrazilianPortugueseLocaleRolloutEnabled(): boolean {
   return optionalEnv("BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED") === "true";

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -156,10 +156,13 @@
         var orgId = sessionStorage.getItem("clerk-active-org-id");
         var cacheKey = orgId ? "vm0:locale:" + orgId : null;
         var cached = cacheKey ? localStorage.getItem(cacheKey) : null;
-        // Browser-language auto-selection stays disabled during rollout.
-        // Locale changes come from the workspace cache or gated preference UI.
+        // Prefer the workspace cache. Signed-out and first-time visitors use a
+        // supported browser language, with English as the fallback.
+        var browserLocale = /^pt(?:-|$)/i.test(navigator.language)
+          ? "pt-BR"
+          : "en-US";
         var locale =
-          cached === "en-US" || cached === "pt-BR" ? cached : "en-US";
+          cached === "en-US" || cached === "pt-BR" ? cached : browserLocale;
         var copyByLocale = {
           "en-US": {
             browserUpgrade: {

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
@@ -95,21 +95,19 @@ afterEach(() => {
 });
 
 describe("bootstrap locale", () => {
-  it("ignores the browser language and supports changing to a bundled locale", async () => {
+  it("uses a supported browser language before a workspace is active", async () => {
     context.mocks.browser.language("pt-BR");
-    sessionStorage.setItem(ACTIVE_ORG_STORAGE_KEY, TEST_ORG_ID);
-    context.store.set(testLocaleStorage.clear$);
     executeLocaleEntrypoint();
 
-    expect(document.documentElement.lang).toBe(DEFAULT_LOCALE);
-    expect(context.store.get(testLocaleStorage.get$)).toBe(DEFAULT_LOCALE);
+    expect(document.documentElement.lang).toBe("pt-BR");
+    expect(context.store.get(testLocaleStorage.get$)).toBeNull();
     expect(window.__vm0PreBundleCopy).toMatchObject({
       loading: {
-        ariaLabel: "Loading your workspace",
-        messages: expect.arrayContaining(["Warming up the neurons..."]),
+        ariaLabel: "Carregando seu espaço de trabalho",
+        messages: expect.arrayContaining(["Aquecendo os neurônios..."]),
       },
       metadata: {
-        title: "Zero — Your AI coworker from vm0",
+        title: "Zero — Seu colega de IA da vm0",
       },
     });
 
@@ -120,9 +118,9 @@ describe("bootstrap locale", () => {
       withoutRender: true,
     });
 
-    expect(context.store.get(locale$)).toBe(DEFAULT_LOCALE);
-    expect(i18n.language).toBe(DEFAULT_LOCALE);
-    expect(document.documentElement.lang).toBe(DEFAULT_LOCALE);
+    expect(context.store.get(locale$)).toBe("pt-BR");
+    expect(i18n.language).toBe("pt-BR");
+    expect(document.documentElement.lang).toBe("pt-BR");
     expect(i18n.hasResourceBundle("en-US", "common")).toBeTruthy();
     expect(i18n.hasResourceBundle("pt-BR", "common")).toBeTruthy();
 
@@ -148,25 +146,24 @@ describe("bootstrap locale", () => {
       { once: true },
     );
 
-    await context.store.set(setLocale$, "pt-BR", context.signal);
+    await context.store.set(setLocale$, DEFAULT_LOCALE, context.signal);
 
-    expect(context.store.get(locale$)).toBe("pt-BR");
-    expect(i18n.language).toBe("pt-BR");
-    expect(document.documentElement.lang).toBe("pt-BR");
+    expect(context.store.get(locale$)).toBe(DEFAULT_LOCALE);
+    expect(i18n.language).toBe(DEFAULT_LOCALE);
+    expect(document.documentElement.lang).toBe(DEFAULT_LOCALE);
     expect(metadata).toHaveAttribute(
       "content",
-      expect.stringContaining("Zero é seu colega de IA da vm0"),
+      expect.stringContaining("Zero is your AI coworker from vm0"),
     );
-    expect(upgradeTitle).toHaveTextContent("Atualize o Chrome para continuar");
+    expect(upgradeTitle).toHaveTextContent("Update Chrome to continue");
     expect(upgradeDescription).toHaveTextContent(
-      "O Zero não oferece suporte à versão atual do seu navegador.",
+      "Zero does not support your current browser version.",
     );
-    expect(upgradeAction).toHaveTextContent("Atualizar Chrome");
-
-    await context.store.set(setLocale$, DEFAULT_LOCALE, context.signal);
+    expect(upgradeAction).toHaveTextContent("Update Chrome");
   });
 
   it("uses the cached locale across pre-bundle UI and i18next", async () => {
+    context.mocks.browser.language("en-US");
     sessionStorage.setItem(ACTIVE_ORG_STORAGE_KEY, TEST_ORG_ID);
     context.store.set(testLocaleStorage.set$, "pt-BR");
     executeLocaleEntrypoint();
@@ -224,7 +221,8 @@ describe("bootstrap locale", () => {
     await context.store.set(setLocale$, DEFAULT_LOCALE, context.signal);
   });
 
-  it("normalizes a legacy cached locale to English before bundle render", () => {
+  it("falls back to English for unsupported browser and legacy cached locales", () => {
+    context.mocks.browser.language("fr-FR");
     sessionStorage.setItem(ACTIVE_ORG_STORAGE_KEY, TEST_ORG_ID);
     context.store.set(testLocaleStorage.set$, "zh-CN");
 

--- a/turbo/apps/platform/src/signals/locale.ts
+++ b/turbo/apps/platform/src/signals/locale.ts
@@ -57,12 +57,14 @@ export const setLocale$ = command(
 
 const applyLocalePreference$ = command(
   async (
-    { set },
+    { get, set },
     orgId: string,
     locale: SupportedLocale,
     signal: AbortSignal,
   ) => {
-    await set(setLocale$, locale, signal);
+    if (get(internalLocale$) !== locale) {
+      await set(setLocale$, locale, signal);
+    }
     set(writeCachedLocale$, orgId, locale);
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
@@ -200,7 +200,9 @@ describe("settings dialog", () => {
   it("hides the language entry when the feature switch is off", async () => {
     context.mocks.data.userPreferences(createPreferences("en-US"));
 
-    await openDialog("admin", "preference");
+    await openDialog("admin", "preference", {
+      [FeatureSwitchKey.LanguagePreference]: false,
+    });
 
     await waitFor(() => {
       expect(screen.getByText("Theme")).toBeInTheDocument();

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -16,6 +16,9 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.VideoArtifactPosters, {})).toBe(
       true,
     );
+    expect(isFeatureEnabled(FeatureSwitchKey.LanguagePreference, {})).toBe(
+      true,
+    );
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -41,9 +44,6 @@ describe("isFeatureEnabled", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.StructuredPromptInlineTemplates, {}),
     ).toBe(false);
-    expect(isFeatureEnabled(FeatureSwitchKey.LanguagePreference, {})).toBe(
-      false,
-    );
     expect(
       isFeatureEnabled(FeatureSwitchKey.ChatThreadSidebarAutoOpen, {}),
     ).toBe(false);
@@ -126,7 +126,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroBrowser]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroChatMessaging]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.LanguagePreference]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.LanguagePreference]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.BrazilianPortugueseLocale]).toBe(
       false,
     );
@@ -159,7 +159,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroBrowser]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroChatMessaging]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.LanguagePreference]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.LanguagePreference]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.BrazilianPortugueseLocale]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -232,7 +232,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "yuma@vm0.ai",
     description:
       "Enable workspace language bootstrap, persistence, and the Settings preference entry.",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.BrazilianPortugueseLocale]: {
     maintainer: "yuma@vm0.ai",


### PR DESCRIPTION
## Summary

- enable the LanguagePreference switch by default and set BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED=true for production API deployments
- bootstrap signed-out and first-time visitors from a supported browser language, mapping Portuguese variants to pt-BR and falling back to en-US while preserving workspace cache precedence
- avoid reapplying an unchanged locale so the all-user rollout does not rebuild active chat editors
- cover browser locale selection, unsupported-language fallback, feature-switch defaults, and production environment wiring

This allows the app-hosted Clerk sign-in and sign-up pages to inherit pt-BR before the application bundle renders.

## Testing

- bash .github/scripts/tests/web-api-env-action-test.sh
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts --silent=passed-only
- pnpm -F api exec vitest run src/signals/routes/__tests__/misc-routes.bdd.test.ts --maxWorkers=4 --silent=passed-only
- pnpm -F @vm0/app exec vitest run --maxWorkers=4 --silent=passed-only
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm knip