### PR TITLE
test(events): account for variable initial delivery batches

### DIFF
--- a/crates/guest-agent/tests/event_delivery_drain_timeout.rs
+++ b/crates/guest-agent/tests/event_delivery_drain_timeout.rs
@@ -115,11 +115,12 @@ async fn event_delivery_aborts_after_the_global_drain_deadline()
     assert_eq!(drain.carried_events, 0);
     assert_eq!(drain.carried_bytes, 0);
     assert_eq!(
-        usize::try_from(drain.queued_events)?
+        usize::try_from(failed_batch.event_count)?
+            + usize::try_from(drain.queued_events)?
             + usize::try_from(drain.carried_events)?
             + usize::try_from(active_batch.event_count)?,
-        EVENT_COUNT - 1,
-        "the drain snapshot must account for every event after the exhausted first batch"
+        EVENT_COUNT,
+        "the exhausted batch and drain snapshot must account for every event"
     );
     assert_eq!(drain.queued_events > 0, drain.queued_bytes > 0);
     assert_eq!(drain.carried_events > 0, drain.carried_bytes > 0);


### PR DESCRIPTION
## Summary

- account for the actual size of the first exhausted event-delivery batch
- verify that the exhausted batch and final drain snapshot cover every emitted event
- remove the timing-dependent assumption that the initial batch always contains one event

## Scope

- test-only follow-up to #23974
- no production behavior, timeout, retry policy, or configuration changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent`
