### PR TITLE
feat: add short artifact keys

### DIFF
--- a/turbo/apps/api/src/lib/file-url.ts
+++ b/turbo/apps/api/src/lib/file-url.ts
@@ -1,6 +1,10 @@
+import { createHash } from "node:crypto";
+
 import { env } from "./env";
 
 const ARTIFACTS_PREFIX = "artifacts";
+const ARTIFACT_HASH_LENGTH = 10;
+const ARTIFACT_HASH_SPACE = 36n ** BigInt(ARTIFACT_HASH_LENGTH);
 
 /**
  * Sanitize a user-supplied filename for use in an artifact object key.
@@ -26,6 +30,39 @@ export function buildArtifactKey(
 
 export function buildArtifactPrefix(userId: string, id: string): string {
   return `${ARTIFACTS_PREFIX}/${encodeURIComponent(userId)}/${id}/`;
+}
+
+function artifactHash(id: string, variant?: string): string {
+  const seed = variant === undefined ? id : `${id}\0${variant}`;
+  const digestPrefix = createHash("sha256")
+    .update(seed)
+    .digest("hex")
+    .slice(0, 16);
+  return (BigInt(`0x${digestPrefix}`) % ARTIFACT_HASH_SPACE)
+    .toString(36)
+    .padStart(ARTIFACT_HASH_LENGTH, "0");
+}
+
+function artifactExtension(filename: string): string {
+  const sanitized = sanitizeArtifactFilename(filename);
+  const extension = sanitized.split(".").pop();
+  return extension && extension !== sanitized ? extension.toLowerCase() : "bin";
+}
+
+export function buildArtifactPrefixV2(id: string, variant?: string): string {
+  return `${ARTIFACTS_PREFIX}/${artifactHash(id, variant)}.`;
+}
+
+export function buildArtifactKeyV2(
+  id: string,
+  filename: string,
+  variant?: string,
+): string {
+  return `${buildArtifactPrefixV2(id, variant)}${artifactExtension(filename)}`;
+}
+
+export function isArtifactKeyV2(key: string): boolean {
+  return /^artifacts\/[0-9a-z]{10}\.[^/]+$/u.test(key);
 }
 
 /**

--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -478,6 +478,16 @@ export function generatePresignedPutUrl(
   );
 }
 
+export function s3MetadataHeaders(
+  metadata: Readonly<Record<string, string>>,
+): Readonly<Record<string, string>> {
+  return Object.fromEntries(
+    Object.entries(metadata).map(([name, value]) => {
+      return [`x-amz-meta-${name}`, value];
+    }),
+  );
+}
+
 export function createMultipartS3Upload(
   bucket: string,
   key: string,
@@ -607,6 +617,9 @@ function generatePresignedPutUrlWithClient(
 ): Computed<Promise<string>> {
   return computed((get): Promise<string> => {
     const client = get(client$);
+    const metadataHeaders = options.metadata
+      ? s3MetadataHeaders(options.metadata)
+      : undefined;
     const command = new PutObjectCommand({
       Bucket: bucket,
       Key: key,
@@ -615,13 +628,9 @@ function generatePresignedPutUrlWithClient(
     });
     return getSignedUrl(client, command, {
       expiresIn: options.expiresIn,
-      ...(options.metadata
+      ...(metadataHeaders
         ? {
-            hoistableHeaders: new Set(
-              Object.keys(options.metadata).map((name) => {
-                return `x-amz-meta-${name}`;
-              }),
-            ),
+            unhoistableHeaders: new Set(Object.keys(metadataHeaders)),
           }
         : {}),
     });

--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -457,14 +457,24 @@ export function generatePresignedPutUrl(
   key: string,
   contentType: string,
   expiresIn: number,
-  usePublicEndpoint = false,
+  options:
+    | boolean
+    | {
+        readonly usePublicEndpoint?: boolean;
+        readonly metadata?: Readonly<Record<string, string>>;
+      } = false,
 ): Computed<Promise<string>> {
+  const usePublicEndpoint =
+    typeof options === "boolean"
+      ? options
+      : (options.usePublicEndpoint ?? false);
+  const metadata = typeof options === "boolean" ? undefined : options.metadata;
   return generatePresignedPutUrlWithClient(
     s3ClientForBucket(bucket, usePublicEndpoint),
     bucket,
     key,
     contentType,
-    expiresIn,
+    { expiresIn, metadata },
   );
 }
 
@@ -472,6 +482,7 @@ export function createMultipartS3Upload(
   bucket: string,
   key: string,
   contentType: string,
+  metadata?: Readonly<Record<string, string>>,
 ): Computed<Promise<string>> {
   return computed(async (get): Promise<string> => {
     const client = get(s3ClientForBucket(bucket));
@@ -480,6 +491,7 @@ export function createMultipartS3Upload(
         Bucket: bucket,
         Key: key,
         ContentType: contentType,
+        Metadata: metadata,
       }),
     );
     if (!response.UploadId) {
@@ -511,22 +523,30 @@ export function generatePresignedUploadPartUrl(
   });
 }
 
-export function listMultipartS3Parts(
+export function tryListMultipartS3Parts(
   bucket: string,
   key: string,
   uploadId: string,
-): Computed<Promise<readonly MultipartS3Part[]>> {
-  return computed(async (get): Promise<readonly MultipartS3Part[]> => {
+): Computed<Promise<readonly MultipartS3Part[] | null>> {
+  return computed(async (get): Promise<readonly MultipartS3Part[] | null> => {
     const client = get(s3ClientForBucket(bucket));
-    const response = await client.send(
-      new ListPartsCommand({
-        Bucket: bucket,
-        Key: key,
-        UploadId: uploadId,
-        MaxParts: 1000,
-      }),
+    const result = await settle(
+      client.send(
+        new ListPartsCommand({
+          Bucket: bucket,
+          Key: key,
+          UploadId: uploadId,
+          MaxParts: 1000,
+        }),
+      ),
     );
-    return (response.Parts ?? []).map((part) => {
+    if (!result.ok) {
+      if (isS3NotFoundError(result.error)) {
+        return null;
+      }
+      throw result.error;
+    }
+    return (result.value.Parts ?? []).map((part) => {
       if (part.PartNumber === undefined || part.ETag === undefined) {
         throw new Error("R2 returned incomplete multipart part metadata");
       }
@@ -580,7 +600,10 @@ function generatePresignedPutUrlWithClient(
   bucket: string,
   key: string,
   contentType: string,
-  expiresIn: number,
+  options: {
+    readonly expiresIn: number;
+    readonly metadata?: Readonly<Record<string, string>>;
+  },
 ): Computed<Promise<string>> {
   return computed((get): Promise<string> => {
     const client = get(client$);
@@ -588,8 +611,20 @@ function generatePresignedPutUrlWithClient(
       Bucket: bucket,
       Key: key,
       ContentType: contentType,
+      Metadata: options.metadata,
     });
-    return getSignedUrl(client, command, { expiresIn });
+    return getSignedUrl(client, command, {
+      expiresIn: options.expiresIn,
+      ...(options.metadata
+        ? {
+            hoistableHeaders: new Set(
+              Object.keys(options.metadata).map((name) => {
+                return `x-amz-meta-${name}`;
+              }),
+            ),
+          }
+        : {}),
+    });
   });
 }
 
@@ -605,7 +640,7 @@ export function generateHostedSitesPresignedPutUrl(
     bucket,
     key,
     contentType,
-    expiresIn,
+    { expiresIn },
   );
 }
 
@@ -664,14 +699,21 @@ export function putS3Object(
   key: string,
   body: string | Buffer,
   contentType: string,
-  signal?: AbortSignal,
+  options?:
+    | AbortSignal
+    | {
+        readonly signal?: AbortSignal;
+        readonly metadata?: Readonly<Record<string, string>>;
+      },
 ): Computed<Promise<void>> {
+  const writeOptions = isAbortSignal(options) ? { signal: options } : options;
   return putS3ObjectWithClient(s3ClientForBucket(bucket), {
     bucket,
     key,
     body,
     contentType,
-    signal,
+    signal: writeOptions?.signal,
+    metadata: writeOptions?.metadata,
   });
 }
 
@@ -681,6 +723,16 @@ interface PutS3ObjectArgs {
   readonly body: string | Buffer;
   readonly contentType: string;
   readonly signal?: AbortSignal;
+  readonly metadata?: Readonly<Record<string, string>>;
+}
+
+function isAbortSignal(value: unknown): value is AbortSignal {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "aborted" in value &&
+    "addEventListener" in value
+  );
 }
 
 function putS3ObjectWithClient(
@@ -695,6 +747,7 @@ function putS3ObjectWithClient(
         Key: args.key,
         Body: args.body,
         ContentType: args.contentType,
+        Metadata: args.metadata,
       }),
       args.signal ? { abortSignal: args.signal } : undefined,
     );
@@ -723,9 +776,15 @@ export function putImmutableS3Object(
   key: string,
   body: string | Buffer,
   contentType: string,
-  signal?: AbortSignal,
+  options?:
+    | AbortSignal
+    | {
+        readonly signal?: AbortSignal;
+        readonly metadata?: Readonly<Record<string, string>>;
+      },
 ): Computed<Promise<void>> {
   return computed(async (get): Promise<void> => {
+    const writeOptions = isAbortSignal(options) ? { signal: options } : options;
     const client = get(s3ClientForBucket(bucket));
     const uploaded = await settle(
       client.send(
@@ -734,10 +793,11 @@ export function putImmutableS3Object(
           Key: key,
           Body: body,
           ContentType: contentType,
+          Metadata: writeOptions?.metadata,
           CacheControl: IMMUTABLE_CACHE_CONTROL,
           IfNoneMatch: "*",
         }),
-        signal ? { abortSignal: signal } : undefined,
+        writeOptions?.signal ? { abortSignal: writeOptions.signal } : undefined,
       ),
     );
     if (!uploaded.ok && !isS3PreconditionFailedError(uploaded.error)) {
@@ -790,6 +850,9 @@ export type S3ObjectHead =
   | {
       readonly kind: "found";
       readonly contentLength: number | undefined;
+      readonly contentType: string | undefined;
+      readonly lastModified: Date | undefined;
+      readonly metadata: Readonly<Record<string, string>>;
     };
 
 function isS3NotFoundError(error: unknown): boolean {
@@ -798,7 +861,9 @@ function isS3NotFoundError(error: unknown): boolean {
     readonly $metadata?: { readonly httpStatusCode?: number };
   };
   return (
-    candidate.name === "NotFound" || candidate.$metadata?.httpStatusCode === 404
+    candidate.name === "NotFound" ||
+    candidate.name === "NoSuchUpload" ||
+    candidate.$metadata?.httpStatusCode === 404
   );
 }
 
@@ -829,6 +894,9 @@ function s3ObjectHeadWithClient(
     return {
       kind: "found",
       contentLength: result.value.ContentLength,
+      contentType: result.value.ContentType,
+      lastModified: result.value.LastModified,
+      metadata: result.value.Metadata ?? {},
     };
   });
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -311,6 +311,81 @@ async function createRunUploadedFile(args: {
   };
 }
 
+describe("artifact key compatibility", () => {
+  it("keeps a legacy attachment URL when an enabled org uses an older upload client", async () => {
+    const owner = await artifactActor(
+      "Artifacts API legacy upload compatibility agent",
+    );
+    if (!owner.actor.orgId) {
+      throw new Error("Expected legacy upload test actor to have an org");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...owner.actor, orgId: owner.actor.orgId },
+      { [FeatureSwitchKey.ArtifactKeyV2]: true },
+    );
+
+    const prepared = await chat.prepareUpload(owner.actor, {
+      filename: "legacy attachment.txt",
+      contentType: "text/plain",
+      size: 24,
+    });
+    const legacyKey = new URL(prepared.url).pathname.replace(/^\/+/u, "");
+    expect(legacyKey).toBe(
+      `artifacts/${owner.actor.userId}/${prepared.id}/legacy_attachment.txt`,
+    );
+    owner.objectStore.addObject({
+      bucket: "test-user-artifacts",
+      key: legacyKey,
+      contentType: prepared.contentType,
+      size: prepared.size,
+    });
+
+    const sent = await chat.requestSendEvent(
+      owner.actor,
+      {
+        agentId: owner.agentId,
+        prompt: "Use the legacy attachment",
+        attachFiles: [
+          {
+            id: prepared.id,
+            filename: prepared.filename,
+            contentType: prepared.contentType,
+            size: prepared.size,
+          },
+        ],
+      },
+      [201],
+    );
+    if (sent.status !== 201 || sent.body.runId === null) {
+      throw new Error("Expected legacy attachment send to create a run");
+    }
+    await flushWaitUntilForTest();
+
+    const events = await chat.listThreadEvents(owner.actor, sent.body.threadId);
+    const input = events.events.find((event) => {
+      return event.eventType === "input.prompt";
+    });
+    expect(input).toMatchObject({
+      attachFiles: [
+        {
+          id: prepared.id,
+          filename: prepared.filename,
+          contentType: prepared.contentType,
+          size: prepared.size,
+          url: prepared.url,
+        },
+      ],
+    });
+
+    const { sandboxHeaders } = await claimChatRun(
+      owner.runnerGroup,
+      sent.body.runId,
+    );
+    await completeChatRunOk(sent.body.runId, sandboxHeaders);
+  }, 120_000);
+});
+
 describe("video Artifact previews", () => {
   it("leaves video preview empty when immediate posters are disabled", async () => {
     const owner = await artifactActor(

--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -343,7 +343,20 @@ describe("video Artifact previews", () => {
 
   it("generates a poster immediately for an ordinary video upload", async () => {
     const owner = await artifactActor("Artifacts API video preview agent");
+    if (!owner.actor.orgId) {
+      throw new Error("Expected video preview test actor to have an org");
+    }
     await setVideoArtifactPosters(owner.actor, true);
+    await updateFeatureSwitchesForUser(
+      context,
+      {
+        ...owner.actor,
+        orgId: owner.actor.orgId,
+      },
+      {
+        [FeatureSwitchKey.ArtifactKeyV2]: true,
+      },
+    );
     const frameRequests = mockCloudflareVideoFrame(owner.actor.userId);
 
     const videoArtifact = await createRunUploadedFile({
@@ -359,7 +372,7 @@ describe("video Artifact previews", () => {
       `https://cdn.vm7.io/cdn-cgi/media/mode=frame,time=1s,width=640,format=jpg/${videoArtifact.url}`,
     );
     const posterPuts = owner.objectStore.puts.filter((put) => {
-      return put.key.endsWith("/poster-v2.jpg");
+      return /^artifacts\/[0-9a-z]{10}\.jpg$/u.test(put.key);
     });
     expect(posterPuts).toHaveLength(1);
     expect(posterPuts[0]).toMatchObject({
@@ -373,7 +386,9 @@ describe("video Artifact previews", () => {
     const previewedArtifact = response.artifacts.find((item) => {
       return item.fileId === videoArtifact.fileId;
     });
-    expect(previewedArtifact?.previewImageUrl).toMatch(/\/poster-v2\.jpg$/);
+    expect(previewedArtifact?.previewImageUrl).toMatch(
+      /\/artifacts\/[0-9a-z]{10}\.jpg$/u,
+    );
   }, 180_000);
 
   it("reuses an existing write-once poster after a concurrent upload", async () => {
@@ -648,6 +663,16 @@ describe("GET /api/zero/artifacts", () => {
     }
     mockEnv("CLOUDFLARE_BROWSER_RENDERING_API_TOKEN", "preview-token");
     mockEnv("ARTIFACT_PREVIEW_WAF_SECRET", ARTIFACT_PREVIEW_WAF_SECRET);
+    await updateFeatureSwitchesForUser(
+      context,
+      {
+        ...owner.actor,
+        orgId: owner.actor.orgId,
+      },
+      {
+        [FeatureSwitchKey.ArtifactKeyV2]: true,
+      },
+    );
     const snapshotRequests = mockCloudflareSnapshot();
 
     const artifact = await createHostedArtifact({
@@ -662,8 +687,8 @@ describe("GET /api/zero/artifacts", () => {
     const firstArtifact = firstResponse.artifacts.find((item) => {
       return item.fileId === artifact.fileId;
     });
-    expect(firstArtifact?.previewImageUrl).toContain(
-      `/preview-v3-${artifact.deploymentId}.webp`,
+    expect(firstArtifact?.previewImageUrl).toMatch(
+      /\/artifacts\/[0-9a-z]{10}\.webp$/u,
     );
     const threadArtifacts = await chat.listThreadArtifacts(
       owner.actor,
@@ -705,7 +730,7 @@ describe("GET /api/zero/artifacts", () => {
     });
     expect(
       owner.objectStore.puts.find((put) => {
-        return put.key.endsWith(`/preview-v3-${artifact.deploymentId}.webp`);
+        return /^artifacts\/[0-9a-z]{10}\.webp$/u.test(put.key);
       }),
     ).toMatchObject({
       bucket: "test-user-artifacts",

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
@@ -33,7 +33,9 @@ type OpenRouterCompletionBody = z.infer<typeof openRouterCompletionBodySchema>;
 interface StoredS3Object {
   readonly bucket: string;
   readonly body?: Uint8Array;
+  readonly contentType?: string;
   readonly key: string;
+  readonly metadata?: Readonly<Record<string, string>>;
   readonly size: number;
 }
 
@@ -43,6 +45,7 @@ interface CapturedS3Put {
   readonly ifNoneMatch: string | null;
   readonly key: string;
   readonly contentType: string | null;
+  readonly metadata: Readonly<Record<string, string>> | null;
 }
 
 interface AuthHeaders {
@@ -72,6 +75,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return (
+    isRecord(value) &&
+    Object.values(value).every((entry) => {
+      return typeof entry === "string";
+    })
+  );
+}
+
 function commandInput(command: unknown): Record<string, unknown> {
   if (isRecord(command) && isRecord(command.input)) {
     return command.input;
@@ -97,6 +109,9 @@ function storedS3ObjectResponse(
     object?.body ?? (object ? new Uint8Array(object.size) : undefined);
   return {
     ContentLength: object?.size,
+    ContentType: object?.contentType,
+    LastModified: object ? nowDate() : undefined,
+    Metadata: object?.metadata,
     Body: body
       ? {
           async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
@@ -330,6 +345,7 @@ export function createChatCallbacksApi(context: TestContext) {
             key,
             contentType:
               typeof input.ContentType === "string" ? input.ContentType : null,
+            metadata: isStringRecord(input.Metadata) ? input.Metadata : null,
           });
           if (rejectNextImmutablePut && input.IfNoneMatch === "*") {
             rejectNextImmutablePut = false;

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -1233,6 +1233,7 @@ export function createChatFilesBddApi(context: TestContext) {
         readonly filename: string;
         readonly contentType: string;
         readonly size: number;
+        readonly supportsUploadHeaders?: true;
       },
     ): Promise<UploadPrepareResponse> {
       const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
@@ -203,6 +203,7 @@ describe("OPS-01: feature switches and report-error routes", () => {
         body: {
           switches: {
             [FeatureSwitchKey.ChatThreadUnifiedSearch]: true,
+            [FeatureSwitchKey.ArtifactKeyV2]: true,
             [FeatureSwitchKey.Dummy]: false,
           },
         },
@@ -221,6 +222,7 @@ describe("OPS-01: feature switches and report-error routes", () => {
     expect(
       peerRead.body.switches[FeatureSwitchKey.ChatThreadUnifiedSearch],
     ).toBeTruthy();
+    expect(peerRead.body.switches[FeatureSwitchKey.ArtifactKeyV2]).toBeTruthy();
     expect(peerRead.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
 
     const outsiderRead = await accept(
@@ -257,6 +259,9 @@ describe("OPS-01: feature switches and report-error routes", () => {
       ],
     ).toBeFalsy();
     expect(
+      ownerReadAfterPeerUpdate.body.switches[FeatureSwitchKey.ArtifactKeyV2],
+    ).toBeTruthy();
+    expect(
       ownerReadAfterPeerUpdate.body.switches[FeatureSwitchKey.Dummy],
     ).toBeFalsy();
 
@@ -274,6 +279,9 @@ describe("OPS-01: feature switches and report-error routes", () => {
       peerReadAfterDelete.body.switches[
         FeatureSwitchKey.ChatThreadUnifiedSearch
       ],
+    ).toBeUndefined();
+    expect(
+      peerReadAfterDelete.body.switches[FeatureSwitchKey.ArtifactKeyV2],
     ).toBeUndefined();
     expect(
       peerReadAfterDelete.body.switches[FeatureSwitchKey.Dummy],

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
@@ -454,6 +454,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
       await seedRunScoped();
     await updateFeatureSwitchesForUser(context, actorFor({ orgId, userId }), {
       [FeatureSwitchKey.Artifacts]: true,
+      [FeatureSwitchKey.ArtifactKeyV2]: true,
     });
     const objectStore = chatCallbacks.acceptChatObjectStorage();
     const operationId = randomUUID();
@@ -474,6 +475,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
         body: {
           filename: "report.csv",
           length: 42,
+          supportsUploadHeaders: true,
           canonical: {
             operationId,
             contentType: "text/csv",
@@ -492,14 +494,30 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
     }
     const canonicalAssetId = initialized.body.assetId;
     expect(initialized.body.kind).toBe("canonical");
+    expect(initialized.body).toMatchObject({
+      uploadHeaders: {
+        "x-amz-meta-artifact-id": canonicalAssetId,
+        "x-amz-meta-filename": "report.csv",
+        "x-amz-meta-user-id": encodeURIComponent(userId),
+      },
+    });
     expect(
       context.mocks.slack.files.getUploadURLExternal,
     ).not.toHaveBeenCalled();
+    const storageKey = new URL(initialized.body.url).pathname.replace(
+      /^\/+/u,
+      "",
+    );
     objectStore.addObject({
       bucket: "test-user-artifacts",
-      key: `artifacts/${userId}/${canonicalAssetId}/report.csv`,
+      key: storageKey,
       size: 42,
       body: Buffer.alloc(42, "a"),
+      metadata: {
+        "artifact-id": canonicalAssetId,
+        filename: "report.csv",
+        "user-id": encodeURIComponent(userId),
+      },
     });
 
     const materializeClient = setupApp({ context })(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-complete.test.ts
@@ -179,6 +179,7 @@ describe("POST /api/zero/uploads/complete", () => {
       filename: "财务 报告.pdf",
       contentType: "application/pdf",
       size: 17,
+      supportsUploadHeaders: true,
     });
     const key = new URL(prepared.url).pathname.replace(/^\/+/u, "");
     fixture.objectStore.addObject({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-complete.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { describe, expect, it } from "vitest";
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { testContext } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
@@ -16,6 +17,10 @@ import { mockClerkMembership } from "./helpers/api-bdd-clerk";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
+import {
+  deleteFeatureSwitchesForUser,
+  updateFeatureSwitchesForUser,
+} from "./helpers/zero-feature-switches";
 
 const context = testContext();
 const bdd = createBddApi(context);
@@ -162,6 +167,45 @@ describe("POST /api/zero/uploads/complete", () => {
       id: fileId,
       filename: "plain.txt",
       size: 5,
+    });
+  });
+
+  it("recovers a v2 original filename after the org switch is disabled", async () => {
+    const fixture = await createRunUploadFixture();
+    await updateFeatureSwitchesForUser(context, fixture.actor, {
+      [FeatureSwitchKey.ArtifactKeyV2]: true,
+    });
+    const prepared = await chat.prepareUpload(fixture.actor, {
+      filename: "财务 报告.pdf",
+      contentType: "application/pdf",
+      size: 17,
+    });
+    const key = new URL(prepared.url).pathname.replace(/^\/+/u, "");
+    fixture.objectStore.addObject({
+      bucket: "test-user-artifacts",
+      key,
+      size: 17,
+      contentType: "application/pdf",
+      metadata: {
+        "artifact-id": prepared.id,
+        filename: encodeURIComponent("财务 报告.pdf"),
+        "user-id": encodeURIComponent(fixture.actor.userId),
+      },
+    });
+    await deleteFeatureSwitchesForUser(context, fixture.actor);
+
+    const response = await chat.completeUploadWithBearer(
+      fixture.bearer,
+      { id: prepared.id },
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id: prepared.id,
+      filename: "财务 报告.pdf",
+      contentType: "application/pdf",
+      size: 17,
+      url: prepared.url,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-prepare.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-prepare.test.ts
@@ -3,10 +3,11 @@ import { createStore } from "ccstate";
 import { describe, expect, it, onTestFinished } from "vitest";
 
 import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockEnv } from "../../../lib/env";
-import { now } from "../../../lib/time";
+import { now, nowDate } from "../../../lib/time";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import {
   deleteOrgPlanEntitlementFixture,
@@ -15,6 +16,7 @@ import {
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { createBddApi } from "./helpers/api-bdd";
+import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { seedOrgMembership$ } from "./helpers/zero-org-membership";
 
 const context = testContext();
@@ -155,6 +157,101 @@ describe("POST /api/zero/uploads/prepare", () => {
       `https://cdn.vm7.io/artifacts/${userId}/${response.body.id}/hello.txt`,
     );
     expect(response.body.id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("uses flat 10-character keys and signed filename metadata for an enabled org", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const owner = { userId: `user_${randomUUID()}`, orgId };
+    const peer = { userId: `user_${randomUUID()}`, orgId };
+    await updateFeatureSwitchesForUser(context, owner, {
+      [FeatureSwitchKey.ArtifactKeyV2]: true,
+    });
+    mocks.clerk.session(peer.userId, peer.orgId);
+
+    const client = setupApp({ context })(zeroUploadsContract);
+    const response = await client.prepare({
+      body: {
+        filename: "财务 报告.PDF",
+        contentType: "application/pdf",
+        size: 13,
+      },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      return;
+    }
+
+    expect(response.body.url).toMatch(
+      /^https:\/\/cdn\.vm7\.io\/artifacts\/[0-9a-z]{10}\.pdf$/,
+    );
+    expect(response.body.url).not.toContain(peer.userId);
+    const signedCommand = context.mocks.s3.getSignedUrl.mock.calls[0]?.[1] as {
+      input: {
+        Key: string;
+        Metadata: Readonly<Record<string, string>>;
+      };
+    };
+    expect(signedCommand.input).toMatchObject({
+      Key: expect.stringMatching(/^artifacts\/[0-9a-z]{10}\.pdf$/),
+      Metadata: {
+        "artifact-id": response.body.id,
+        filename: encodeURIComponent("财务 报告.PDF"),
+        "user-id": encodeURIComponent(peer.userId),
+      },
+    });
+    expect(context.mocks.s3.getSignedUrl.mock.calls[0]?.[2]).toMatchObject({
+      hoistableHeaders: new Set([
+        "x-amz-meta-artifact-id",
+        "x-amz-meta-filename",
+        "x-amz-meta-user-id",
+      ]),
+    });
+  });
+
+  it("retries with a new artifact id when a flat hash is occupied", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const actor = { userId: `user_${randomUUID()}`, orgId };
+    await updateFeatureSwitchesForUser(context, actor, {
+      [FeatureSwitchKey.ArtifactKeyV2]: true,
+    });
+    mocks.clerk.session(actor.userId, actor.orgId);
+    const prefixes: string[] = [];
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (command?.constructor.name !== "ListObjectsV2Command") {
+        return Promise.resolve({});
+      }
+      const input = (command as { input: { Prefix?: string } }).input;
+      const prefix = input.Prefix ?? "";
+      prefixes.push(prefix);
+      if (prefixes.length === 1) {
+        return Promise.resolve({
+          Contents: [
+            {
+              Key: `${prefix}txt`,
+              Size: 1,
+              LastModified: nowDate(),
+            },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const response = await setupApp({ context })(zeroUploadsContract).prepare({
+      body: validBody(),
+      headers: { authorization: "Bearer clerk-session" },
+    });
+
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      throw new Error("Expected flat artifact upload preparation to succeed");
+    }
+    expect(prefixes).toHaveLength(2);
+    expect(prefixes[1]).not.toBe(prefixes[0]);
+    expect(response.body.url).toMatch(
+      /^https:\/\/cdn\.vm7\.io\/artifacts\/[0-9a-z]{10}\.txt$/,
+    );
   });
 
   it("rejects suspended orgs with insufficient credits", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-prepare.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-prepare.test.ts
@@ -167,6 +167,7 @@ describe("POST /api/zero/uploads/prepare", () => {
       [FeatureSwitchKey.ArtifactKeyV2]: true,
     });
     mocks.clerk.session(peer.userId, peer.orgId);
+    mocks.s3.listObjects([]);
 
     const client = setupApp({ context })(zeroUploadsContract);
     const response = await client.prepare({
@@ -174,6 +175,7 @@ describe("POST /api/zero/uploads/prepare", () => {
         filename: "财务 报告.PDF",
         contentType: "application/pdf",
         size: 13,
+        supportsUploadHeaders: true,
       },
       headers: { authorization: "Bearer clerk-session" },
     });
@@ -186,6 +188,13 @@ describe("POST /api/zero/uploads/prepare", () => {
       /^https:\/\/cdn\.vm7\.io\/artifacts\/[0-9a-z]{10}\.pdf$/,
     );
     expect(response.body.url).not.toContain(peer.userId);
+    expect(response.body).toMatchObject({
+      uploadHeaders: {
+        "x-amz-meta-artifact-id": response.body.id,
+        "x-amz-meta-filename": encodeURIComponent("财务 报告.PDF"),
+        "x-amz-meta-user-id": encodeURIComponent(peer.userId),
+      },
+    });
     const signedCommand = context.mocks.s3.getSignedUrl.mock.calls[0]?.[1] as {
       input: {
         Key: string;
@@ -201,12 +210,35 @@ describe("POST /api/zero/uploads/prepare", () => {
       },
     });
     expect(context.mocks.s3.getSignedUrl.mock.calls[0]?.[2]).toMatchObject({
-      hoistableHeaders: new Set([
+      unhoistableHeaders: new Set([
         "x-amz-meta-artifact-id",
         "x-amz-meta-filename",
         "x-amz-meta-user-id",
       ]),
     });
+  });
+
+  it("keeps legacy keys for enabled orgs when clients cannot send upload headers", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const actor = { userId: `user_${randomUUID()}`, orgId };
+    await updateFeatureSwitchesForUser(context, actor, {
+      [FeatureSwitchKey.ArtifactKeyV2]: true,
+    });
+    mocks.clerk.session(actor.userId, actor.orgId);
+
+    const response = await setupApp({ context })(zeroUploadsContract).prepare({
+      body: validBody(),
+      headers: { authorization: "Bearer clerk-session" },
+    });
+
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      throw new Error("Expected legacy upload preparation to succeed");
+    }
+    expect(response.body.url).toBe(
+      `https://cdn.vm7.io/artifacts/${actor.userId}/${response.body.id}/hello.txt`,
+    );
+    expect("uploadHeaders" in response.body).toBeFalsy();
   });
 
   it("retries with a new artifact id when a flat hash is occupied", async () => {
@@ -239,7 +271,7 @@ describe("POST /api/zero/uploads/prepare", () => {
     });
 
     const response = await setupApp({ context })(zeroUploadsContract).prepare({
-      body: validBody(),
+      body: { ...validBody(), supportsUploadHeaders: true },
       headers: { authorization: "Bearer clerk-session" },
     });
 

--- a/turbo/apps/api/src/signals/routes/zero-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-events.ts
@@ -59,7 +59,11 @@ import {
   notFound,
 } from "../../lib/error";
 import { env } from "../../lib/env";
-import { buildArtifactKey, sanitizeArtifactFilename } from "../../lib/file-url";
+import {
+  buildArtifactKey,
+  buildArtifactKeyV2,
+  sanitizeArtifactFilename,
+} from "../../lib/file-url";
 import { logger } from "../../lib/log";
 import type { AuthContext } from "../../types/auth";
 import {
@@ -251,6 +255,7 @@ interface PreparedNormalSend {
   readonly computerUseHostGrant: ResolvedComputerUseHostGrant | null;
   readonly persistedExplicitSelection: boolean;
   readonly initialThinkingEnabled: boolean;
+  readonly artifactKeyV2Enabled: boolean;
   readonly runConfiguration: ResolvedRunConfiguration;
   readonly clientEventPrechecked: boolean;
   readonly preflightClientEventConflict:
@@ -270,6 +275,7 @@ function shouldTouchThreadSortFromNormalSend(
 }
 
 interface NormalSendFeatureSwitches {
+  readonly artifactKeyV2Enabled: boolean;
   readonly codexFastModeEnabled: boolean;
   readonly userMessageInlineTemplatesEnabled: boolean;
   readonly imageStyleR2Enabled: boolean;
@@ -656,6 +662,7 @@ function attachFileIds(
 function attachFileMetadata(
   userId: string,
   attachFiles: readonly AttachFile[] | undefined,
+  artifactKeyV2Enabled: boolean,
 ): ChatEventAttachFileMetadata[] | null {
   const metadata = attachFiles?.map((file) => {
     const sanitized = sanitizeArtifactFilename(file.filename);
@@ -664,7 +671,9 @@ function attachFileMetadata(
       filename: file.filename,
       contentType: file.contentType,
       size: file.size,
-      objectKey: buildArtifactKey(userId, file.id, sanitized),
+      objectKey: artifactKeyV2Enabled
+        ? buildArtifactKeyV2(file.id, file.filename)
+        : buildArtifactKey(userId, file.id, sanitized),
     };
   });
   return metadata && metadata.length > 0 ? metadata : null;
@@ -1013,6 +1022,10 @@ async function resolveNormalSendFeatureSwitches(
 ): Promise<NormalSendFeatureSwitches> {
   const context = await loadUserFeatureSwitchContext(db, orgId, userId);
   return {
+    artifactKeyV2Enabled: isFeatureEnabled(
+      FeatureSwitchKey.ArtifactKeyV2,
+      context,
+    ),
     codexFastModeEnabled: isFeatureEnabled(
       FeatureSwitchKey.CodexFastMode,
       context,
@@ -1559,6 +1572,7 @@ function appendUnassociatedUserMessage(params: {
   readonly orgId: string;
   readonly prompt: string;
   readonly attachFiles: readonly AttachFile[] | undefined;
+  readonly artifactKeyV2Enabled: boolean;
   readonly clientEventId: string | undefined;
   readonly chatThreadSortEventId: string | undefined;
   readonly touchThreadSort: boolean;
@@ -1583,7 +1597,11 @@ function appendUnassociatedUserMessage(params: {
 
     const explicitId = params.clientEventId ?? undefined;
     const fileIds = attachFileIds(params.attachFiles);
-    const fileMetadata = attachFileMetadata(params.userId, params.attachFiles);
+    const fileMetadata = attachFileMetadata(
+      params.userId,
+      params.attachFiles,
+      params.artifactKeyV2Enabled,
+    );
     const event: NewChatEvent = {
       ...(explicitId ? { id: explicitId } : {}),
       chatThreadId: params.threadId,
@@ -1689,6 +1707,7 @@ async function appendAssociatedUserMessage(params: {
   readonly prompt: string;
   readonly runId: string;
   readonly attachFiles: readonly AttachFile[] | undefined;
+  readonly artifactKeyV2Enabled: boolean;
   readonly clientEventId: string | undefined;
   readonly chatThreadSortEventId: string | undefined;
   readonly touchThreadSort: boolean;
@@ -1706,7 +1725,11 @@ async function appendAssociatedUserMessage(params: {
     }
     const explicitId = params.clientEventId ?? undefined;
     const fileIds = attachFileIds(params.attachFiles);
-    const fileMetadata = attachFileMetadata(params.userId, params.attachFiles);
+    const fileMetadata = attachFileMetadata(
+      params.userId,
+      params.attachFiles,
+      params.artifactKeyV2Enabled,
+    );
     const event: NewChatEvent = {
       ...(explicitId ? { id: explicitId } : {}),
       chatThreadId: params.threadId,
@@ -2452,6 +2475,7 @@ const prepareNormalSend$ = command(
       computerUseHostGrant: computerAccess.computerUseHostGrant,
       persistedExplicitSelection,
       initialThinkingEnabled: args.zeroPreCreateSource === undefined,
+      artifactKeyV2Enabled: featureSwitches.artifactKeyV2Enabled,
       runConfiguration,
       clientEventPrechecked,
       preflightClientEventConflict: preflightClientEventResponse,
@@ -2490,6 +2514,7 @@ async function queueUnassociatedNormalEvent(params: {
     orgId: params.orgId,
     prompt: params.body.prompt,
     attachFiles: params.body.attachFiles,
+    artifactKeyV2Enabled: params.prepared.artifactKeyV2Enabled,
     clientEventId: params.body.clientEventId,
     chatThreadSortEventId: params.body.chatThreadSortEventId,
     touchThreadSort: params.touchThreadSort,
@@ -2557,6 +2582,7 @@ function scheduleAssociatedUserMessage(params: {
   readonly appendQueueMarker: boolean;
   readonly appendInitialThinking: boolean;
   readonly touchThreadSort: boolean;
+  readonly artifactKeyV2Enabled: boolean;
 }): void {
   waitUntil(
     (async () => {
@@ -2568,6 +2594,7 @@ function scheduleAssociatedUserMessage(params: {
         prompt: params.body.prompt,
         runId: params.runId,
         attachFiles: params.body.attachFiles,
+        artifactKeyV2Enabled: params.artifactKeyV2Enabled,
         clientEventId: params.body.clientEventId,
         chatThreadSortEventId: params.body.chatThreadSortEventId,
         touchThreadSort: params.touchThreadSort,
@@ -2614,6 +2641,7 @@ function scheduleCreatedChatRunSideEffects(params: {
   readonly runId: string;
   readonly runStatus: string;
   readonly initialThinkingEnabled: boolean;
+  readonly artifactKeyV2Enabled: boolean;
   readonly touchThreadSort: boolean;
   readonly queueFirstClaim:
     | {
@@ -2656,6 +2684,7 @@ function scheduleCreatedChatRunSideEffects(params: {
     appendQueueMarker: params.runStatus === "queued",
     appendInitialThinking,
     touchThreadSort: params.touchThreadSort,
+    artifactKeyV2Enabled: params.artifactKeyV2Enabled,
   });
 }
 
@@ -2862,6 +2891,7 @@ async function appendInsufficientCreditsEvents(params: {
     const fileMetadata = attachFileMetadata(
       params.userId,
       params.body.attachFiles,
+      params.prepared.artifactKeyV2Enabled,
     );
     const userValues: NewChatEvent = {
       ...(explicitId ? { id: explicitId } : {}),
@@ -3101,6 +3131,7 @@ function scheduleNormalChatRunSideEffects(params: {
     runId: params.runId,
     runStatus: params.runStatus,
     initialThinkingEnabled: params.prepared.initialThinkingEnabled,
+    artifactKeyV2Enabled: params.prepared.artifactKeyV2Enabled,
     touchThreadSort: shouldTouchThreadSortFromNormalSend(
       params.args.zeroPreCreateSource,
       params.prepared.thread.isNewThread,

--- a/turbo/apps/api/src/signals/routes/zero-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-events.ts
@@ -129,6 +129,7 @@ import {
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import { resolveChatThreadSession } from "../services/chat-session-continuity.service";
 import { attachCanonicalWebInputAssetsToEvent } from "../services/canonical-asset.service";
+import { resolveArtifactObject$ } from "../services/artifact-storage.service";
 import { loadOrgPlanCapabilities } from "../services/org-plan-entitlement-read.service";
 import { chatEventTypeIn } from "../services/zero-chat-event-type.service";
 import { bestEffort, tapError } from "../utils";
@@ -255,7 +256,7 @@ interface PreparedNormalSend {
   readonly computerUseHostGrant: ResolvedComputerUseHostGrant | null;
   readonly persistedExplicitSelection: boolean;
   readonly initialThinkingEnabled: boolean;
-  readonly artifactKeyV2Enabled: boolean;
+  readonly attachFileMetadata: ChatEventAttachFileMetadata[] | null;
   readonly runConfiguration: ResolvedRunConfiguration;
   readonly clientEventPrechecked: boolean;
   readonly preflightClientEventConflict:
@@ -659,25 +660,45 @@ function attachFileIds(
   return ids && ids.length > 0 ? ids : null;
 }
 
-function attachFileMetadata(
-  userId: string,
-  attachFiles: readonly AttachFile[] | undefined,
-  artifactKeyV2Enabled: boolean,
-): ChatEventAttachFileMetadata[] | null {
-  const metadata = attachFiles?.map((file) => {
-    const sanitized = sanitizeArtifactFilename(file.filename);
-    return {
-      id: file.id,
-      filename: file.filename,
-      contentType: file.contentType,
-      size: file.size,
-      objectKey: artifactKeyV2Enabled
-        ? buildArtifactKeyV2(file.id, file.filename)
-        : buildArtifactKey(userId, file.id, sanitized),
-    };
-  });
-  return metadata && metadata.length > 0 ? metadata : null;
-}
+const resolveAttachFileMetadata$ = command(
+  async (
+    { set },
+    args: {
+      readonly userId: string;
+      readonly attachFiles: readonly AttachFile[] | undefined;
+      readonly artifactKeyV2Enabled: boolean;
+    },
+    signal: AbortSignal,
+  ): Promise<ChatEventAttachFileMetadata[] | null> => {
+    if (!args.attachFiles || args.attachFiles.length === 0) {
+      return null;
+    }
+    const metadata: ChatEventAttachFileMetadata[] = [];
+    for (const file of args.attachFiles) {
+      const object = args.artifactKeyV2Enabled
+        ? await set(
+            resolveArtifactObject$,
+            { userId: args.userId, id: file.id },
+            signal,
+          )
+        : null;
+      signal.throwIfAborted();
+      const sanitized = sanitizeArtifactFilename(file.filename);
+      metadata.push({
+        id: file.id,
+        filename: file.filename,
+        contentType: file.contentType,
+        size: file.size,
+        objectKey:
+          object?.key ??
+          (args.artifactKeyV2Enabled
+            ? buildArtifactKeyV2(file.id, file.filename)
+            : buildArtifactKey(args.userId, file.id, sanitized)),
+      });
+    }
+    return metadata;
+  },
+);
 
 function truncatePrior(value: string): string {
   if (value.length <= WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP) {
@@ -1572,7 +1593,7 @@ function appendUnassociatedUserMessage(params: {
   readonly orgId: string;
   readonly prompt: string;
   readonly attachFiles: readonly AttachFile[] | undefined;
-  readonly artifactKeyV2Enabled: boolean;
+  readonly attachFileMetadata: ChatEventAttachFileMetadata[] | null;
   readonly clientEventId: string | undefined;
   readonly chatThreadSortEventId: string | undefined;
   readonly touchThreadSort: boolean;
@@ -1597,11 +1618,7 @@ function appendUnassociatedUserMessage(params: {
 
     const explicitId = params.clientEventId ?? undefined;
     const fileIds = attachFileIds(params.attachFiles);
-    const fileMetadata = attachFileMetadata(
-      params.userId,
-      params.attachFiles,
-      params.artifactKeyV2Enabled,
-    );
+    const fileMetadata = params.attachFileMetadata;
     const event: NewChatEvent = {
       ...(explicitId ? { id: explicitId } : {}),
       chatThreadId: params.threadId,
@@ -1707,7 +1724,7 @@ async function appendAssociatedUserMessage(params: {
   readonly prompt: string;
   readonly runId: string;
   readonly attachFiles: readonly AttachFile[] | undefined;
-  readonly artifactKeyV2Enabled: boolean;
+  readonly attachFileMetadata: ChatEventAttachFileMetadata[] | null;
   readonly clientEventId: string | undefined;
   readonly chatThreadSortEventId: string | undefined;
   readonly touchThreadSort: boolean;
@@ -1725,11 +1742,7 @@ async function appendAssociatedUserMessage(params: {
     }
     const explicitId = params.clientEventId ?? undefined;
     const fileIds = attachFileIds(params.attachFiles);
-    const fileMetadata = attachFileMetadata(
-      params.userId,
-      params.attachFiles,
-      params.artifactKeyV2Enabled,
-    );
+    const fileMetadata = params.attachFileMetadata;
     const event: NewChatEvent = {
       ...(explicitId ? { id: explicitId } : {}),
       chatThreadId: params.threadId,
@@ -2351,6 +2364,33 @@ function resolveTimedComputerAccess(
   );
 }
 
+async function resolveTimedPreflightClientEvent(
+  args: NormalSendArgs,
+  db: Db,
+): Promise<{
+  readonly prechecked: boolean;
+  readonly response: ClientSendResolution | undefined;
+}> {
+  const threadId = args.body.threadId ?? args.body.clientThreadId;
+  const prechecked = Boolean(threadId && args.body.clientEventId);
+  const response = threadId
+    ? await measureApiDispatchTiming(
+        args.timing,
+        "api_dispatch_pre_create_zero_web_chat_resolve_client_message",
+        "nested",
+        () => {
+          return resolveClientEventSend({
+            db,
+            userId: args.userId,
+            threadId,
+            clientEventId: args.body.clientEventId,
+          });
+        },
+      )
+    : undefined;
+  return { prechecked, response };
+}
+
 const prepareNormalSend$ = command(
   async (
     { set },
@@ -2365,25 +2405,10 @@ const prepareNormalSend$ = command(
       return agent;
     }
 
-    const preflightThreadId = args.body.threadId ?? args.body.clientThreadId;
-    const clientEventPrechecked = Boolean(
-      preflightThreadId && args.body.clientEventId,
-    );
-    const preflightClientEventResponse = preflightThreadId
-      ? await measureApiDispatchTiming(
-          args.timing,
-          "api_dispatch_pre_create_zero_web_chat_resolve_client_message",
-          "nested",
-          () => {
-            return resolveClientEventSend({
-              db,
-              userId: args.userId,
-              threadId: preflightThreadId,
-              clientEventId: args.body.clientEventId,
-            });
-          },
-        )
-      : undefined;
+    const {
+      prechecked: clientEventPrechecked,
+      response: preflightClientEventResponse,
+    } = await resolveTimedPreflightClientEvent(args, db);
     signal.throwIfAborted();
     if (preflightClientEventResponse?.status === 201) {
       return preflightClientEventResponse;
@@ -2464,6 +2489,15 @@ const prepareNormalSend$ = command(
     if ("status" in computerAccess) {
       return computerAccess;
     }
+    const attachFileMetadata = await set(
+      resolveAttachFileMetadata$,
+      {
+        userId: args.userId,
+        attachFiles: runtimeBody.attachFiles,
+        artifactKeyV2Enabled: featureSwitches.artifactKeyV2Enabled,
+      },
+      signal,
+    );
 
     return {
       db,
@@ -2475,7 +2509,7 @@ const prepareNormalSend$ = command(
       computerUseHostGrant: computerAccess.computerUseHostGrant,
       persistedExplicitSelection,
       initialThinkingEnabled: args.zeroPreCreateSource === undefined,
-      artifactKeyV2Enabled: featureSwitches.artifactKeyV2Enabled,
+      attachFileMetadata,
       runConfiguration,
       clientEventPrechecked,
       preflightClientEventConflict: preflightClientEventResponse,
@@ -2514,7 +2548,7 @@ async function queueUnassociatedNormalEvent(params: {
     orgId: params.orgId,
     prompt: params.body.prompt,
     attachFiles: params.body.attachFiles,
-    artifactKeyV2Enabled: params.prepared.artifactKeyV2Enabled,
+    attachFileMetadata: params.prepared.attachFileMetadata,
     clientEventId: params.body.clientEventId,
     chatThreadSortEventId: params.body.chatThreadSortEventId,
     touchThreadSort: params.touchThreadSort,
@@ -2582,7 +2616,7 @@ function scheduleAssociatedUserMessage(params: {
   readonly appendQueueMarker: boolean;
   readonly appendInitialThinking: boolean;
   readonly touchThreadSort: boolean;
-  readonly artifactKeyV2Enabled: boolean;
+  readonly attachFileMetadata: ChatEventAttachFileMetadata[] | null;
 }): void {
   waitUntil(
     (async () => {
@@ -2594,7 +2628,7 @@ function scheduleAssociatedUserMessage(params: {
         prompt: params.body.prompt,
         runId: params.runId,
         attachFiles: params.body.attachFiles,
-        artifactKeyV2Enabled: params.artifactKeyV2Enabled,
+        attachFileMetadata: params.attachFileMetadata,
         clientEventId: params.body.clientEventId,
         chatThreadSortEventId: params.body.chatThreadSortEventId,
         touchThreadSort: params.touchThreadSort,
@@ -2641,7 +2675,7 @@ function scheduleCreatedChatRunSideEffects(params: {
   readonly runId: string;
   readonly runStatus: string;
   readonly initialThinkingEnabled: boolean;
-  readonly artifactKeyV2Enabled: boolean;
+  readonly attachFileMetadata: ChatEventAttachFileMetadata[] | null;
   readonly touchThreadSort: boolean;
   readonly queueFirstClaim:
     | {
@@ -2684,7 +2718,7 @@ function scheduleCreatedChatRunSideEffects(params: {
     appendQueueMarker: params.runStatus === "queued",
     appendInitialThinking,
     touchThreadSort: params.touchThreadSort,
-    artifactKeyV2Enabled: params.artifactKeyV2Enabled,
+    attachFileMetadata: params.attachFileMetadata,
   });
 }
 
@@ -2888,11 +2922,7 @@ async function appendInsufficientCreditsEvents(params: {
 
     const explicitId = params.body.clientEventId ?? undefined;
     const fileIds = attachFileIds(params.body.attachFiles);
-    const fileMetadata = attachFileMetadata(
-      params.userId,
-      params.body.attachFiles,
-      params.prepared.artifactKeyV2Enabled,
-    );
+    const fileMetadata = params.prepared.attachFileMetadata;
     const userValues: NewChatEvent = {
       ...(explicitId ? { id: explicitId } : {}),
       chatThreadId: params.prepared.thread.threadId,
@@ -3131,7 +3161,7 @@ function scheduleNormalChatRunSideEffects(params: {
     runId: params.runId,
     runStatus: params.runStatus,
     initialThinkingEnabled: params.prepared.initialThinkingEnabled,
-    artifactKeyV2Enabled: params.prepared.artifactKeyV2Enabled,
+    attachFileMetadata: params.prepared.attachFileMetadata,
     touchThreadSort: shouldTouchThreadSortFromNormalSend(
       params.args.zeroPreCreateSource,
       params.prepared.thread.isNewThread,

--- a/turbo/apps/api/src/signals/routes/zero-integrations-feishu-files.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-feishu-files.ts
@@ -13,12 +13,7 @@ import { feishuOrgConnections } from "@vm0/db/schema/feishu-org-connection";
 import { feishuOrgInstallations } from "@vm0/db/schema/feishu-org-installation";
 
 import { env } from "../../lib/env";
-import {
-  buildArtifactKey,
-  buildArtifactPrefix,
-  buildFileUrl,
-  sanitizeArtifactFilename,
-} from "../../lib/file-url";
+import { sanitizeArtifactFilename } from "../../lib/file-url";
 import { inferMimetype } from "../../lib/mimetype";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -32,11 +27,11 @@ import {
   type FeishuOutboundMessage,
 } from "../external/feishu-client";
 import { writeDb$, type Db } from "../external/db";
+import { downloadS3Buffer, generatePresignedPutUrl } from "../external/s3";
 import {
-  downloadS3Buffer,
-  generatePresignedPutUrl,
-  listS3Objects,
-} from "../external/s3";
+  allocateArtifactObject$,
+  resolveArtifactObject$,
+} from "../services/artifact-storage.service";
 import { feishuOrgCallbackPayloadSchema } from "../services/feishu-org-callback-payload";
 import { recordFeishuUploadedFile$ } from "../services/run-uploaded-files.service";
 import type { RouteEntry } from "../route-entry";
@@ -72,6 +67,16 @@ function apiError(
     status,
     body: { error: { code, message } },
   } as const;
+}
+
+function feishuUploadSizeError(size: number) {
+  return size > FEISHU_FILE_UPLOAD_MAX_BYTES
+    ? apiError(
+        413,
+        "PAYLOAD_TOO_LARGE",
+        `File exceeds maximum size of ${FEISHU_FILE_UPLOAD_MAX_BYTES} bytes`,
+      )
+    : undefined;
 }
 
 async function resolveInstallation(args: {
@@ -367,7 +372,7 @@ const download$ = command(async ({ get, set }, signal: AbortSignal) => {
   return new Response(downloaded.value.body, { status: 200, headers });
 });
 
-const initUpload$ = command(async ({ get }, signal: AbortSignal) => {
+const initUpload$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const bodyResult = await get(
     bodyResultOf(integrationsFeishuUploadInitContract.init),
@@ -377,26 +382,33 @@ const initUpload$ = command(async ({ get }, signal: AbortSignal) => {
     return bodyResult.response;
   }
 
-  const uploadId = crypto.randomUUID();
   const filename = sanitizeArtifactFilename(bodyResult.data.filename);
+  const artifact = await set(
+    allocateArtifactObject$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      filename: bodyResult.data.filename,
+    },
+    signal,
+  );
   const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
-  const key = buildArtifactKey(auth.userId, uploadId, filename);
   const uploadUrl = await get(
     generatePresignedPutUrl(
       bucket,
-      key,
+      artifact.key,
       bodyResult.data.contentType,
       PUT_URL_TTL_SECONDS,
-      true,
+      { usePublicEndpoint: true, metadata: artifact.metadata },
     ),
   );
   signal.throwIfAborted();
   return {
     status: 200 as const,
     body: {
-      uploadId,
+      uploadId: artifact.id,
       uploadUrl,
-      fileUrl: buildFileUrl(auth.userId, uploadId, filename),
+      fileUrl: artifact.url,
       filename,
       contentType: bodyResult.data.contentType,
       size: bodyResult.data.length,
@@ -442,25 +454,23 @@ const completeUpload$ = command(async ({ get, set }, signal: AbortSignal) => {
     );
   }
 
-  const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
-  const prefix = buildArtifactPrefix(auth.userId, body.uploadId);
-  const objects = await get(listS3Objects(bucket, prefix));
-  signal.throwIfAborted();
-  const object = objects[0];
+  const object = await set(
+    resolveArtifactObject$,
+    { userId: auth.userId, id: body.uploadId },
+    signal,
+  );
   if (!object) {
     return apiError(404, "NOT_FOUND", "Uploaded file not found");
   }
-  if (object.size > FEISHU_FILE_UPLOAD_MAX_BYTES) {
-    return apiError(
-      413,
-      "PAYLOAD_TOO_LARGE",
-      `File exceeds maximum size of ${FEISHU_FILE_UPLOAD_MAX_BYTES} bytes`,
-    );
+  const sizeError = feishuUploadSizeError(object.size);
+  if (sizeError) {
+    return sizeError;
   }
 
-  const filename = object.key.split("/").pop() ?? body.uploadId;
-  const contentType = body.contentType ?? inferMimetype(filename);
-  const fileUrl = buildFileUrl(auth.userId, body.uploadId, filename);
+  const filename = object.filename;
+  const contentType = body.contentType ?? object.contentType;
+  const fileUrl = object.url;
+  const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
   const content = await get(downloadS3Buffer(bucket, object.key));
   signal.throwIfAborted();
   const uploaded = await settle(

--- a/turbo/apps/api/src/signals/routes/zero-integrations-feishu-files.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-feishu-files.ts
@@ -27,7 +27,11 @@ import {
   type FeishuOutboundMessage,
 } from "../external/feishu-client";
 import { writeDb$, type Db } from "../external/db";
-import { downloadS3Buffer, generatePresignedPutUrl } from "../external/s3";
+import {
+  downloadS3Buffer,
+  generatePresignedPutUrl,
+  s3MetadataHeaders,
+} from "../external/s3";
 import {
   allocateArtifactObject$,
   resolveArtifactObject$,
@@ -389,9 +393,13 @@ const initUpload$ = command(async ({ get, set }, signal: AbortSignal) => {
       userId: auth.userId,
       orgId: auth.orgId,
       filename: bodyResult.data.filename,
+      allowV2: bodyResult.data.supportsUploadHeaders === true,
     },
     signal,
   );
+  const uploadHeaders = artifact.metadata
+    ? s3MetadataHeaders(artifact.metadata)
+    : undefined;
   const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
   const uploadUrl = await get(
     generatePresignedPutUrl(
@@ -412,6 +420,7 @@ const initUpload$ = command(async ({ get, set }, signal: AbortSignal) => {
       filename,
       contentType: bodyResult.data.contentType,
       size: bodyResult.data.length,
+      ...(uploadHeaders ? { uploadHeaders } : {}),
     },
   };
 });

--- a/turbo/apps/api/src/signals/routes/zero-integrations-github-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-github-upload-complete.ts
@@ -4,14 +4,11 @@ import {
   type GithubUploadCompleteBody,
 } from "@vm0/api-contracts/contracts/integrations";
 
-import { env } from "../../lib/env";
-import { buildArtifactPrefix, buildFileUrl } from "../../lib/file-url";
-import { inferMimetype } from "../../lib/mimetype";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { db$ } from "../external/db";
-import { listS3Objects } from "../external/s3";
+import { resolveArtifactObject$ } from "../services/artifact-storage.service";
 import { postGithubIssueComment } from "../services/github-issues-api.service";
 import {
   getGithubIntegrationAccessToken,
@@ -96,18 +93,18 @@ const complete$ = command(async ({ get, set }, signal: AbortSignal) => {
     return routeError(404, "No GitHub installation found", "NOT_FOUND");
   }
 
-  const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
-  const prefix = buildArtifactPrefix(auth.userId, body.uploadId);
-  const objects = await get(listS3Objects(bucket, prefix));
-  signal.throwIfAborted();
-  const object = objects[0];
+  const object = await set(
+    resolveArtifactObject$,
+    { userId: auth.userId, id: body.uploadId },
+    signal,
+  );
   if (!object) {
     return routeError(404, "Uploaded file not found", "NOT_FOUND");
   }
 
-  const filename = object.key.split("/").pop() ?? body.uploadId;
-  const fileUrl = buildFileUrl(auth.userId, body.uploadId, filename);
-  const mimetype = body.contentType ?? inferMimetype(filename);
+  const filename = object.filename;
+  const fileUrl = object.url;
+  const mimetype = body.contentType ?? object.contentType;
   const commentBody = buildCommentBody({
     filename,
     fileUrl,

--- a/turbo/apps/api/src/signals/routes/zero-integrations-github-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-github-upload-init.ts
@@ -2,20 +2,17 @@ import { command } from "ccstate";
 import { integrationsGithubUploadInitContract } from "@vm0/api-contracts/contracts/integrations";
 
 import { env } from "../../lib/env";
-import {
-  buildArtifactKey,
-  buildFileUrl,
-  sanitizeArtifactFilename,
-} from "../../lib/file-url";
+import { sanitizeArtifactFilename } from "../../lib/file-url";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { generatePresignedPutUrl } from "../external/s3";
+import { allocateArtifactObject$ } from "../services/artifact-storage.service";
 import type { RouteEntry } from "../route-entry";
 
 const PUT_URL_TTL_SECONDS = 3600;
 
-const init$ = command(async ({ get }, signal: AbortSignal) => {
+const init$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const bodyResult = await get(
     bodyResultOf(integrationsGithubUploadInitContract.init),
@@ -26,17 +23,20 @@ const init$ = command(async ({ get }, signal: AbortSignal) => {
   }
 
   const body = bodyResult.data;
-  const uploadId = crypto.randomUUID();
   const filename = sanitizeArtifactFilename(body.filename);
-  const s3Key = buildArtifactKey(auth.userId, uploadId, filename);
+  const artifact = await set(
+    allocateArtifactObject$,
+    { userId: auth.userId, orgId: auth.orgId, filename: body.filename },
+    signal,
+  );
   const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
   const uploadUrl = await get(
     generatePresignedPutUrl(
       bucket,
-      s3Key,
+      artifact.key,
       body.contentType,
       PUT_URL_TTL_SECONDS,
-      true,
+      { usePublicEndpoint: true, metadata: artifact.metadata },
     ),
   );
   signal.throwIfAborted();
@@ -44,9 +44,9 @@ const init$ = command(async ({ get }, signal: AbortSignal) => {
   return {
     status: 200 as const,
     body: {
-      uploadId,
+      uploadId: artifact.id,
       uploadUrl,
-      fileUrl: buildFileUrl(auth.userId, uploadId, filename),
+      fileUrl: artifact.url,
       filename,
       contentType: body.contentType,
       size: body.length,

--- a/turbo/apps/api/src/signals/routes/zero-integrations-github-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-github-upload-init.ts
@@ -6,7 +6,7 @@ import { sanitizeArtifactFilename } from "../../lib/file-url";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
-import { generatePresignedPutUrl } from "../external/s3";
+import { generatePresignedPutUrl, s3MetadataHeaders } from "../external/s3";
 import { allocateArtifactObject$ } from "../services/artifact-storage.service";
 import type { RouteEntry } from "../route-entry";
 
@@ -26,9 +26,17 @@ const init$ = command(async ({ get, set }, signal: AbortSignal) => {
   const filename = sanitizeArtifactFilename(body.filename);
   const artifact = await set(
     allocateArtifactObject$,
-    { userId: auth.userId, orgId: auth.orgId, filename: body.filename },
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      filename: body.filename,
+      allowV2: body.supportsUploadHeaders === true,
+    },
     signal,
   );
+  const uploadHeaders = artifact.metadata
+    ? s3MetadataHeaders(artifact.metadata)
+    : undefined;
   const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
   const uploadUrl = await get(
     generatePresignedPutUrl(
@@ -50,6 +58,7 @@ const init$ = command(async ({ get, set }, signal: AbortSignal) => {
       filename,
       contentType: body.contentType,
       size: body.length,
+      ...(uploadHeaders ? { uploadHeaders } : {}),
     },
   };
 });

--- a/turbo/apps/api/src/signals/routes/zero-integrations-phone-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-phone-upload-complete.ts
@@ -4,18 +4,15 @@ import {
   type PhoneUploadCompleteBody,
 } from "@vm0/api-contracts/contracts/integrations";
 
-import { env } from "../../lib/env";
-import { buildArtifactPrefix, buildFileUrl } from "../../lib/file-url";
-import { inferMimetype } from "../../lib/mimetype";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { writeDb$ } from "../external/db";
-import { listS3Objects } from "../external/s3";
 import {
   isAgentPhoneApiError,
   sendAgentPhoneMessage,
 } from "../external/agentphone-client";
+import { resolveArtifactObject$ } from "../services/artifact-storage.service";
 import { recordAgentPhoneUploadedFile$ } from "../services/run-uploaded-files.service";
 import {
   normalizeAgentPhoneHandle,
@@ -87,21 +84,20 @@ const complete$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
   const body = bodyResult.data;
 
-  const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
-  const prefix = buildArtifactPrefix(auth.userId, body.uploadId);
-  const objects = await get(listS3Objects(bucket, prefix));
-  signal.throwIfAborted();
-  const object = objects[0];
+  const object = await set(
+    resolveArtifactObject$,
+    { userId: auth.userId, id: body.uploadId },
+    signal,
+  );
   if (!object) {
     return uploadedFileNotFound();
   }
 
-  const filename = object.key.split("/").pop() ?? body.uploadId;
   const uploadedFile: UploadedFileInfo = {
     key: object.key,
     size: object.size,
-    filename,
-    fileUrl: buildFileUrl(auth.userId, body.uploadId, filename),
+    filename: object.filename,
+    fileUrl: object.url,
   };
 
   const userChannel: AgentPhoneChannel = "sms";
@@ -129,7 +125,7 @@ const complete$ = command(async ({ get, set }, signal: AbortSignal) => {
     return routeError(404, "AgentPhone agent not found", "NOT_FOUND");
   }
 
-  const mimetype = body.contentType ?? inferMimetype(uploadedFile.filename);
+  const mimetype = body.contentType ?? object.contentType;
   const sendResult = await settle(
     sendAgentPhoneMessage(
       {

--- a/turbo/apps/api/src/signals/routes/zero-integrations-phone-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-phone-upload-init.ts
@@ -2,20 +2,17 @@ import { command } from "ccstate";
 import { integrationsPhoneUploadInitContract } from "@vm0/api-contracts/contracts/integrations";
 
 import { env } from "../../lib/env";
-import {
-  buildArtifactKey,
-  buildFileUrl,
-  sanitizeArtifactFilename,
-} from "../../lib/file-url";
+import { sanitizeArtifactFilename } from "../../lib/file-url";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { generatePresignedPutUrl } from "../external/s3";
+import { allocateArtifactObject$ } from "../services/artifact-storage.service";
 import type { RouteEntry } from "../route-entry";
 
 const PUT_URL_TTL_SECONDS = 3600;
 
-const init$ = command(async ({ get }, signal: AbortSignal) => {
+const init$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(authContext$);
   const bodyResult = await get(
     bodyResultOf(integrationsPhoneUploadInitContract.init),
@@ -26,17 +23,20 @@ const init$ = command(async ({ get }, signal: AbortSignal) => {
   }
 
   const body = bodyResult.data;
-  const uploadId = crypto.randomUUID();
   const filename = sanitizeArtifactFilename(body.filename);
-  const s3Key = buildArtifactKey(auth.userId, uploadId, filename);
+  const artifact = await set(
+    allocateArtifactObject$,
+    { userId: auth.userId, orgId: auth.orgId, filename: body.filename },
+    signal,
+  );
   const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
   const uploadUrl = await get(
     generatePresignedPutUrl(
       bucket,
-      s3Key,
+      artifact.key,
       body.contentType,
       PUT_URL_TTL_SECONDS,
-      true,
+      { usePublicEndpoint: true, metadata: artifact.metadata },
     ),
   );
   signal.throwIfAborted();
@@ -44,9 +44,9 @@ const init$ = command(async ({ get }, signal: AbortSignal) => {
   return {
     status: 200 as const,
     body: {
-      uploadId,
+      uploadId: artifact.id,
       uploadUrl,
-      fileUrl: buildFileUrl(auth.userId, uploadId, filename),
+      fileUrl: artifact.url,
       filename,
       contentType: body.contentType,
       size: body.length,

--- a/turbo/apps/api/src/signals/routes/zero-integrations-phone-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-phone-upload-init.ts
@@ -6,7 +6,7 @@ import { sanitizeArtifactFilename } from "../../lib/file-url";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
-import { generatePresignedPutUrl } from "../external/s3";
+import { generatePresignedPutUrl, s3MetadataHeaders } from "../external/s3";
 import { allocateArtifactObject$ } from "../services/artifact-storage.service";
 import type { RouteEntry } from "../route-entry";
 
@@ -26,9 +26,17 @@ const init$ = command(async ({ get, set }, signal: AbortSignal) => {
   const filename = sanitizeArtifactFilename(body.filename);
   const artifact = await set(
     allocateArtifactObject$,
-    { userId: auth.userId, orgId: auth.orgId, filename: body.filename },
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      filename: body.filename,
+      allowV2: body.supportsUploadHeaders === true,
+    },
     signal,
   );
+  const uploadHeaders = artifact.metadata
+    ? s3MetadataHeaders(artifact.metadata)
+    : undefined;
   const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
   const uploadUrl = await get(
     generatePresignedPutUrl(
@@ -50,6 +58,7 @@ const init$ = command(async ({ get, set }, signal: AbortSignal) => {
       filename,
       contentType: body.contentType,
       size: body.length,
+      ...(uploadHeaders ? { uploadHeaders } : {}),
     },
   };
 });

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack-upload-init.ts
@@ -67,6 +67,7 @@ const initInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         contentType,
         size: body.length,
         checksumSha256: body.canonical.checksumSha256,
+        allowV2: body.supportsUploadHeaders === true,
         destination: {
           channelId: body.canonical.channel,
           ...(body.canonical.threadTs
@@ -87,6 +88,9 @@ const initInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         assetId: prepared.assetId,
         operationId: prepared.operationId,
         ...(prepared.uploadUrl ? { uploadUrl: prepared.uploadUrl } : {}),
+        ...(prepared.uploadHeaders
+          ? { uploadHeaders: prepared.uploadHeaders }
+          : {}),
         url: prepared.url,
       },
     };

--- a/turbo/apps/api/src/signals/routes/zero-integrations-teams-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-teams-upload-complete.ts
@@ -6,15 +6,12 @@ import {
 import { teamsOrgInstallations } from "@vm0/db/schema/teams-org-installation";
 import { eq } from "drizzle-orm";
 
-import { env } from "../../lib/env";
-import { buildArtifactPrefix, buildFileUrl } from "../../lib/file-url";
-import { inferMimetype } from "../../lib/mimetype";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { writeDb$, type Db } from "../external/db";
-import { listS3Objects } from "../external/s3";
 import { sendTeamsMessage } from "../external/teams-bot-client";
+import { resolveArtifactObject$ } from "../services/artifact-storage.service";
 import { recordTeamsUploadedFile$ } from "../services/run-uploaded-files.service";
 import type { RouteEntry } from "../route-entry";
 
@@ -128,23 +125,22 @@ const complete$ = command(async ({ get, set }, signal: AbortSignal) => {
     );
   }
 
-  const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
-  const prefix = buildArtifactPrefix(auth.userId, body.uploadId);
-  const objects = await get(listS3Objects(bucket, prefix));
-  signal.throwIfAborted();
-  const object = objects[0];
+  const object = await set(
+    resolveArtifactObject$,
+    { userId: auth.userId, id: body.uploadId },
+    signal,
+  );
   if (!object) {
     return routeError(404, "Uploaded file not found", "NOT_FOUND");
   }
 
-  const filename = object.key.split("/").pop() ?? body.uploadId;
   const file: UploadedFileInfo = {
     key: object.key,
     size: object.size,
-    filename,
-    fileUrl: buildFileUrl(auth.userId, body.uploadId, filename),
+    filename: object.filename,
+    fileUrl: object.url,
   };
-  const mimetype = body.contentType ?? inferMimetype(file.filename);
+  const mimetype = body.contentType ?? object.contentType;
 
   const result = await sendTeamsMessage({
     serviceUrl: installation.serviceUrl,

--- a/turbo/apps/api/src/signals/routes/zero-integrations-teams-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-teams-upload-init.ts
@@ -2,20 +2,17 @@ import { command } from "ccstate";
 import { integrationsTeamsUploadInitContract } from "@vm0/api-contracts/contracts/integrations";
 
 import { env } from "../../lib/env";
-import {
-  buildArtifactKey,
-  buildFileUrl,
-  sanitizeArtifactFilename,
-} from "../../lib/file-url";
+import { sanitizeArtifactFilename } from "../../lib/file-url";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { generatePresignedPutUrl } from "../external/s3";
+import { allocateArtifactObject$ } from "../services/artifact-storage.service";
 import type { RouteEntry } from "../route-entry";
 
 const PUT_URL_TTL_SECONDS = 3600;
 
-const init$ = command(async ({ get }, signal: AbortSignal) => {
+const init$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(authContext$);
   const bodyResult = await get(
     bodyResultOf(integrationsTeamsUploadInitContract.init),
@@ -26,17 +23,20 @@ const init$ = command(async ({ get }, signal: AbortSignal) => {
   }
 
   const body = bodyResult.data;
-  const uploadId = crypto.randomUUID();
   const filename = sanitizeArtifactFilename(body.filename);
-  const s3Key = buildArtifactKey(auth.userId, uploadId, filename);
+  const artifact = await set(
+    allocateArtifactObject$,
+    { userId: auth.userId, orgId: auth.orgId, filename: body.filename },
+    signal,
+  );
   const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
   const uploadUrl = await get(
     generatePresignedPutUrl(
       bucket,
-      s3Key,
+      artifact.key,
       body.contentType,
       PUT_URL_TTL_SECONDS,
-      true,
+      { usePublicEndpoint: true, metadata: artifact.metadata },
     ),
   );
   signal.throwIfAborted();
@@ -44,9 +44,9 @@ const init$ = command(async ({ get }, signal: AbortSignal) => {
   return {
     status: 200 as const,
     body: {
-      uploadId,
+      uploadId: artifact.id,
       uploadUrl,
-      fileUrl: buildFileUrl(auth.userId, uploadId, filename),
+      fileUrl: artifact.url,
       filename,
       contentType: body.contentType,
       size: body.length,

--- a/turbo/apps/api/src/signals/routes/zero-integrations-teams-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-teams-upload-init.ts
@@ -6,7 +6,7 @@ import { sanitizeArtifactFilename } from "../../lib/file-url";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
-import { generatePresignedPutUrl } from "../external/s3";
+import { generatePresignedPutUrl, s3MetadataHeaders } from "../external/s3";
 import { allocateArtifactObject$ } from "../services/artifact-storage.service";
 import type { RouteEntry } from "../route-entry";
 
@@ -26,9 +26,17 @@ const init$ = command(async ({ get, set }, signal: AbortSignal) => {
   const filename = sanitizeArtifactFilename(body.filename);
   const artifact = await set(
     allocateArtifactObject$,
-    { userId: auth.userId, orgId: auth.orgId, filename: body.filename },
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      filename: body.filename,
+      allowV2: body.supportsUploadHeaders === true,
+    },
     signal,
   );
+  const uploadHeaders = artifact.metadata
+    ? s3MetadataHeaders(artifact.metadata)
+    : undefined;
   const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
   const uploadUrl = await get(
     generatePresignedPutUrl(
@@ -50,6 +58,7 @@ const init$ = command(async ({ get, set }, signal: AbortSignal) => {
       filename,
       contentType: body.contentType,
       size: body.length,
+      ...(uploadHeaders ? { uploadHeaders } : {}),
     },
   };
 });

--- a/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-complete.ts
@@ -4,13 +4,9 @@ import {
   type TelegramUploadCompleteBody,
 } from "@vm0/api-contracts/contracts/integrations";
 
-import { env } from "../../lib/env";
-import { buildArtifactPrefix, buildFileUrl } from "../../lib/file-url";
-import { inferMimetype } from "../../lib/mimetype";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
-import { listS3Objects } from "../external/s3";
 import {
   sendDocument,
   type SendTelegramDocumentResult,
@@ -19,6 +15,7 @@ import {
   getOfficialTelegramBotConfig,
   isOfficialTelegramBotId,
 } from "../external/telegram-official";
+import { resolveArtifactObject$ } from "../services/artifact-storage.service";
 import { recordTelegramUploadedFile$ } from "../services/run-uploaded-files.service";
 import { zeroTelegramInstallation } from "../services/zero-telegram-data.service";
 import type { RouteEntry } from "../route-entry";
@@ -127,16 +124,16 @@ const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return botNotFound;
   }
 
-  const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
-  const prefix = buildArtifactPrefix(userId, body.uploadId);
-  const objects = await get(listS3Objects(bucket, prefix));
-  signal.throwIfAborted();
-  const s3Object = objects[0];
+  const s3Object = await set(
+    resolveArtifactObject$,
+    { userId, id: body.uploadId },
+    signal,
+  );
   if (!s3Object) {
     return uploadedFileNotFound;
   }
-  const filename = s3Object.key.split("/").pop() ?? body.uploadId;
-  const fileUrl = buildFileUrl(userId, body.uploadId, filename);
+  const filename = s3Object.filename;
+  const fileUrl = s3Object.url;
 
   const result = await sendDocument(botToken, body.chatId, fileUrl, {
     caption: body.caption,
@@ -149,7 +146,7 @@ const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   const document = result.document;
   const mimetype =
-    document?.mime_type ?? body.contentType ?? inferMimetype(filename);
+    document?.mime_type ?? body.contentType ?? s3Object.contentType;
   const size = document?.file_size ?? s3Object.size;
   const fileId = document?.file_id;
   const responseFilename = document?.file_name ?? filename;

--- a/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-init.ts
@@ -6,7 +6,7 @@ import { sanitizeArtifactFilename } from "../../lib/file-url";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
-import { generatePresignedPutUrl } from "../external/s3";
+import { generatePresignedPutUrl, s3MetadataHeaders } from "../external/s3";
 import { allocateArtifactObject$ } from "../services/artifact-storage.service";
 import type { RouteEntry } from "../route-entry";
 
@@ -27,9 +27,17 @@ const initInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const sanitized = sanitizeArtifactFilename(filename);
   const artifact = await set(
     allocateArtifactObject$,
-    { userId: auth.userId, orgId: auth.orgId, filename },
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      filename,
+      allowV2: bodyResult.data.supportsUploadHeaders === true,
+    },
     signal,
   );
+  const uploadHeaders = artifact.metadata
+    ? s3MetadataHeaders(artifact.metadata)
+    : undefined;
   const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
   const uploadUrl = await get(
     generatePresignedPutUrl(
@@ -51,6 +59,7 @@ const initInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       filename: sanitized,
       contentType,
       size: length,
+      ...(uploadHeaders ? { uploadHeaders } : {}),
     },
   };
 });

--- a/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-telegram-upload-init.ts
@@ -2,20 +2,17 @@ import { command } from "ccstate";
 import { integrationsTelegramUploadInitContract } from "@vm0/api-contracts/contracts/integrations";
 
 import { env } from "../../lib/env";
-import {
-  buildArtifactKey,
-  buildFileUrl,
-  sanitizeArtifactFilename,
-} from "../../lib/file-url";
+import { sanitizeArtifactFilename } from "../../lib/file-url";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { generatePresignedPutUrl } from "../external/s3";
+import { allocateArtifactObject$ } from "../services/artifact-storage.service";
 import type { RouteEntry } from "../route-entry";
 
 const PUT_URL_TTL_SECONDS = 3600;
 
-const initInner$ = command(async ({ get }, signal: AbortSignal) => {
+const initInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(authContext$);
 
   const bodyResult = await get(
@@ -27,17 +24,20 @@ const initInner$ = command(async ({ get }, signal: AbortSignal) => {
   }
 
   const { filename, contentType, length } = bodyResult.data;
-  const uploadId = crypto.randomUUID();
   const sanitized = sanitizeArtifactFilename(filename);
-  const s3Key = buildArtifactKey(auth.userId, uploadId, sanitized);
+  const artifact = await set(
+    allocateArtifactObject$,
+    { userId: auth.userId, orgId: auth.orgId, filename },
+    signal,
+  );
   const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
   const uploadUrl = await get(
     generatePresignedPutUrl(
       bucket,
-      s3Key,
+      artifact.key,
       contentType,
       PUT_URL_TTL_SECONDS,
-      true,
+      { usePublicEndpoint: true, metadata: artifact.metadata },
     ),
   );
   signal.throwIfAborted();
@@ -45,9 +45,9 @@ const initInner$ = command(async ({ get }, signal: AbortSignal) => {
   return {
     status: 200 as const,
     body: {
-      uploadId,
+      uploadId: artifact.id,
       uploadUrl,
-      fileUrl: buildFileUrl(auth.userId, uploadId, sanitized),
+      fileUrl: artifact.url,
       filename: sanitized,
       contentType,
       size: length,

--- a/turbo/apps/api/src/signals/routes/zero-uploads-complete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-uploads-complete.ts
@@ -4,11 +4,8 @@ import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
-import { listS3Objects } from "../external/s3";
-import { env } from "../../lib/env";
-import { buildArtifactPrefix, buildFileUrl } from "../../lib/file-url";
-import { inferMimetype } from "../../lib/mimetype";
 import { isAllowedUploadType } from "../../lib/uploads-constants";
+import { resolveArtifactObject$ } from "../services/artifact-storage.service";
 import { recordWebUploadedFile$ } from "../services/run-uploaded-files.service";
 import { rejectSuspendedOrg$ } from "../services/zero-org-suspension.service";
 import type { RouteEntry } from "../route-entry";
@@ -49,11 +46,12 @@ const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     }
   }
 
-  const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
-  const prefix = buildArtifactPrefix(auth.userId, id);
-  const objects = await get(listS3Objects(bucket, prefix));
-  signal.throwIfAborted();
-  if (objects.length === 0) {
+  const s3Object = await set(
+    resolveArtifactObject$,
+    { userId: auth.userId, id },
+    signal,
+  );
+  if (!s3Object) {
     return {
       status: 404 as const,
       body: {
@@ -62,15 +60,11 @@ const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     };
   }
 
-  const s3Object = objects[0]!;
-  const filename = s3Object.key.split("/").pop() ?? id;
-  const contentType = requestedContentType ?? inferMimetype(filename);
+  const filename = s3Object.filename;
+  const contentType = requestedContentType ?? s3Object.contentType;
   const size = s3Object.size;
-  const url = buildFileUrl(auth.userId, id, filename);
-  const lastModified =
-    s3Object.lastModified instanceof Date
-      ? s3Object.lastModified.toISOString()
-      : undefined;
+  const url = s3Object.url;
+  const lastModified = s3Object.lastModified?.toISOString();
 
   const runId = "runId" in auth ? auth.runId : undefined;
 

--- a/turbo/apps/api/src/signals/routes/zero-uploads-import-image.ts
+++ b/turbo/apps/api/src/signals/routes/zero-uploads-import-image.ts
@@ -13,16 +13,13 @@ import {
 } from "../../lib/blocked-fetch-host";
 import { env } from "../../lib/env";
 import { badRequestMessage } from "../../lib/error";
-import {
-  buildArtifactKey,
-  buildFileUrl,
-  sanitizeArtifactFilename,
-} from "../../lib/file-url";
+import { sanitizeArtifactFilename } from "../../lib/file-url";
 import { inferMimetype } from "../../lib/mimetype";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { putS3Object } from "../external/s3";
+import { allocateArtifactObject$ } from "../services/artifact-storage.service";
 import { recordWebUploadedFile$ } from "../services/run-uploaded-files.service";
 import { rejectSuspendedOrg$ } from "../services/zero-org-suspension.service";
 import type { RouteEntry } from "../route-entry";
@@ -264,13 +261,22 @@ const importImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return bytes;
   }
 
-  const id = crypto.randomUUID();
   const filename = importImageFilename(fetched.url, contentType);
-  const s3Key = buildArtifactKey(auth.userId, id, filename);
+  const orgId = "orgId" in auth ? auth.orgId : null;
+  const artifact = await set(
+    allocateArtifactObject$,
+    { userId: auth.userId, orgId, filename },
+    signal,
+  );
+  const { id, key: s3Key, url, metadata } = artifact;
   const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
-  const url = buildFileUrl(auth.userId, id, filename);
 
-  await get(putS3Object(bucket, s3Key, Buffer.from(bytes), contentType));
+  await get(
+    putS3Object(bucket, s3Key, Buffer.from(bytes), contentType, {
+      signal,
+      metadata,
+    }),
+  );
   signal.throwIfAborted();
 
   await set(
@@ -279,7 +285,7 @@ const importImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       runId: "runId" in auth ? auth.runId : undefined,
       externalId: id,
       userId: auth.userId,
-      orgId: "orgId" in auth ? auth.orgId : null,
+      orgId,
       filename,
       contentType,
       sizeBytes: bytes.byteLength,

--- a/turbo/apps/api/src/signals/routes/zero-uploads-multipart.ts
+++ b/turbo/apps/api/src/signals/routes/zero-uploads-multipart.ts
@@ -3,19 +3,14 @@ import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
 
 import { env } from "../../lib/env";
 import { badRequestMessage } from "../../lib/error";
-import {
-  buildArtifactKey,
-  buildFileUrl,
-  sanitizeArtifactFilename,
-} from "../../lib/file-url";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import {
   abortMultipartS3Upload,
   completeMultipartS3Upload,
-  listMultipartS3Parts,
 } from "../external/s3";
+import { resolveArtifactMultipartUpload$ } from "../services/artifact-storage.service";
 import { rejectSuspendedOrg$ } from "../services/zero-org-suspension.service";
 import type { RouteEntry } from "../route-entry";
 
@@ -38,11 +33,22 @@ const completeMultipartInner$ = command(
     }
 
     const { id, filename, uploadId, partCount } = bodyResult.data;
-    const sanitizedName = sanitizeArtifactFilename(filename);
-    const key = buildArtifactKey(auth.userId, id, sanitizedName);
     const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
-    const parts = await get(listMultipartS3Parts(bucket, key, uploadId));
-    signal.throwIfAborted();
+    const upload = await set(
+      resolveArtifactMultipartUpload$,
+      {
+        userId: auth.userId,
+        orgId: auth.orgId,
+        id,
+        filename,
+        uploadId,
+      },
+      signal,
+    );
+    if (!upload) {
+      throw new Error("R2 multipart upload was not found");
+    }
+    const { key, parts } = upload;
     const completePartSet =
       parts.length === partCount &&
       parts.every((part, index) => {
@@ -59,38 +65,53 @@ const completeMultipartInner$ = command(
       status: 200 as const,
       body: {
         id,
-        url: buildFileUrl(auth.userId, id, sanitizedName),
+        url: upload.url,
       },
     };
   },
 );
 
-const abortMultipartInner$ = command(async ({ get }, signal: AbortSignal) => {
-  const auth = get(authContext$);
-  const bodyResult = await get(
-    bodyResultOf(zeroUploadsContract.abortMultipart),
-  );
-  signal.throwIfAborted();
-  if (!bodyResult.ok) {
-    return bodyResult.response;
-  }
+const abortMultipartInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(authContext$);
+    const bodyResult = await get(
+      bodyResultOf(zeroUploadsContract.abortMultipart),
+    );
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
 
-  const { id, filename, uploadId } = bodyResult.data;
-  const key = buildArtifactKey(
-    auth.userId,
-    id,
-    sanitizeArtifactFilename(filename),
-  );
-  await get(
-    abortMultipartS3Upload(env("R2_USER_ARTIFACTS_BUCKET_NAME"), key, uploadId),
-  );
-  signal.throwIfAborted();
+    const { id, filename, uploadId } = bodyResult.data;
+    const upload = await set(
+      resolveArtifactMultipartUpload$,
+      {
+        userId: auth.userId,
+        orgId: auth.orgId,
+        id,
+        filename,
+        uploadId,
+      },
+      signal,
+    );
+    if (!upload) {
+      throw new Error("R2 multipart upload was not found");
+    }
+    await get(
+      abortMultipartS3Upload(
+        env("R2_USER_ARTIFACTS_BUCKET_NAME"),
+        upload.key,
+        uploadId,
+      ),
+    );
+    signal.throwIfAborted();
 
-  return {
-    status: 200 as const,
-    body: { id },
-  };
-});
+    return {
+      status: 200 as const,
+      body: { id },
+    };
+  },
+);
 
 export const zeroUploadsMultipartRoutes: readonly RouteEntry[] = [
   {

--- a/turbo/apps/api/src/signals/routes/zero-uploads-prepare.ts
+++ b/turbo/apps/api/src/signals/routes/zero-uploads-prepare.ts
@@ -16,6 +16,7 @@ import {
   createMultipartS3Upload,
   generatePresignedPutUrl,
   generatePresignedUploadPartUrl,
+  s3MetadataHeaders,
 } from "../external/s3";
 import { allocateArtifactObject$ } from "../services/artifact-storage.service";
 import { rejectSuspendedOrg$ } from "../services/zero-org-suspension.service";
@@ -60,10 +61,14 @@ const prepareUploadInner$ = command(
         userId: auth.userId,
         orgId: auth.orgId,
         filename,
+        allowV2:
+          bodyResult.data.multipart === true ||
+          bodyResult.data.supportsUploadHeaders === true,
       },
       signal,
     );
     const { id, key: s3Key, url, metadata } = artifact;
+    const uploadHeaders = metadata ? s3MetadataHeaders(metadata) : undefined;
 
     if (
       bodyResult.data.multipart === true &&
@@ -130,7 +135,15 @@ const prepareUploadInner$ = command(
 
     return {
       status: 200 as const,
-      body: { id, filename, contentType, size, uploadUrl, url },
+      body: {
+        id,
+        filename,
+        contentType,
+        size,
+        uploadUrl,
+        url,
+        ...(uploadHeaders ? { uploadHeaders } : {}),
+      },
     };
   },
 );

--- a/turbo/apps/api/src/signals/routes/zero-uploads-prepare.ts
+++ b/turbo/apps/api/src/signals/routes/zero-uploads-prepare.ts
@@ -4,11 +4,6 @@ import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
 import { env } from "../../lib/env";
 import { badRequestMessage } from "../../lib/error";
 import {
-  buildArtifactKey,
-  buildFileUrl,
-  sanitizeArtifactFilename,
-} from "../../lib/file-url";
-import {
   isAllowedUploadType,
   MAX_UPLOAD_SIZE_BYTES,
   MAX_UPLOAD_SIZE_LABEL,
@@ -22,6 +17,7 @@ import {
   generatePresignedPutUrl,
   generatePresignedUploadPartUrl,
 } from "../external/s3";
+import { allocateArtifactObject$ } from "../services/artifact-storage.service";
 import { rejectSuspendedOrg$ } from "../services/zero-org-suspension.service";
 import type { RouteEntry } from "../route-entry";
 import { onRejection, tapError } from "../utils";
@@ -57,11 +53,17 @@ const prepareUploadInner$ = command(
       }
     }
 
-    const id = crypto.randomUUID();
-    const sanitizedName = sanitizeArtifactFilename(filename);
-    const s3Key = buildArtifactKey(auth.userId, id, sanitizedName);
     const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
-    const url = buildFileUrl(auth.userId, id, sanitizedName);
+    const artifact = await set(
+      allocateArtifactObject$,
+      {
+        userId: auth.userId,
+        orgId: auth.orgId,
+        filename,
+      },
+      signal,
+    );
+    const { id, key: s3Key, url, metadata } = artifact;
 
     if (
       bodyResult.data.multipart === true &&
@@ -71,7 +73,7 @@ const prepareUploadInner$ = command(
       return await onRejection(
         (async () => {
           uploadId = await get(
-            createMultipartS3Upload(bucket, s3Key, contentType),
+            createMultipartS3Upload(bucket, s3Key, contentType, metadata),
           );
           signal.throwIfAborted();
           const partCount = Math.ceil(size / MULTIPART_PART_SIZE_BYTES);
@@ -119,13 +121,10 @@ const prepareUploadInner$ = command(
     }
 
     const uploadUrl = await get(
-      generatePresignedPutUrl(
-        bucket,
-        s3Key,
-        contentType,
-        PUT_URL_TTL_SECONDS,
-        true,
-      ),
+      generatePresignedPutUrl(bucket, s3Key, contentType, PUT_URL_TTL_SECONDS, {
+        usePublicEndpoint: true,
+        metadata,
+      }),
     );
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/artifact-preview.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-preview.service.ts
@@ -6,13 +6,13 @@ import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { z } from "zod";
 
 import { env } from "../../lib/env";
-import { buildArtifactKey, buildFileUrl } from "../../lib/file-url";
 import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import { waitUntil } from "../context/wait-until";
 import { writeDb$ } from "../external/db";
 import { putImmutableS3Object } from "../external/s3";
 import { tapError } from "../utils";
+import { allocateArtifactObject$ } from "./artifact-storage.service";
 import { syncArtifactCatalogForFile$ } from "./artifact-catalog.service";
 import { publishArtifactsChangedForRun } from "./artifact-realtime.service";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
@@ -55,6 +55,7 @@ export interface RenderArtifactPreviewArgs {
   readonly id: string;
   readonly runId: string;
   readonly userId: string;
+  readonly orgId: string;
   readonly url: string;
   // Discriminates the renderer: `video/*` extracts a poster frame, otherwise a
   // Browser Rendering page screenshot.
@@ -223,14 +224,24 @@ const renderAndStoreArtifactPreview$ = command(
     }
     signal.throwIfAborted();
 
-    const key = buildArtifactKey(args.userId, args.id, filename);
+    const artifact = await set(
+      allocateArtifactObject$,
+      {
+        userId: args.userId,
+        orgId: args.orgId,
+        id: args.id,
+        filename,
+        variant: filename,
+      },
+      signal,
+    );
     await get(
       putImmutableS3Object(
         env("R2_USER_ARTIFACTS_BUCKET_NAME"),
-        key,
+        artifact.key,
         image,
         contentType,
-        signal,
+        { signal, metadata: artifact.metadata },
       ),
     );
     signal.throwIfAborted();
@@ -239,7 +250,7 @@ const renderAndStoreArtifactPreview$ = command(
     await db
       .update(runUploadedFiles)
       .set({
-        previewImageUrl: buildFileUrl(args.userId, args.id, filename),
+        previewImageUrl: artifact.url,
         updatedAt: nowDate(),
       })
       .where(eq(runUploadedFiles.id, args.id));
@@ -276,9 +287,7 @@ export const scheduleArtifactPreviewRender$ = command(
   },
 );
 
-export interface VideoArtifactPreviewRenderArgs extends RenderArtifactPreviewArgs {
-  readonly orgId: string;
-}
+export type VideoArtifactPreviewRenderArgs = RenderArtifactPreviewArgs;
 
 const renderVideoArtifactPreviewIfEnabled$ = command(
   async (

--- a/turbo/apps/api/src/signals/services/artifact-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-storage.service.ts
@@ -1,0 +1,345 @@
+import { randomUUID } from "node:crypto";
+
+import { command, computed, type Computed } from "ccstate";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+
+import { env } from "../../lib/env";
+import {
+  buildArtifactKey,
+  buildArtifactKeyV2,
+  buildArtifactPrefix,
+  buildArtifactPrefixV2,
+  buildFileUrlFromKey,
+  sanitizeArtifactFilename,
+} from "../../lib/file-url";
+import { inferMimetype } from "../../lib/mimetype";
+import {
+  listS3Objects,
+  putS3Object,
+  s3ObjectHead,
+  tryListMultipartS3Parts,
+} from "../external/s3";
+import { safeUriComponentDecode } from "../utils";
+import { userFeatureSwitchContext } from "./feature-switches.service";
+
+const MAX_ARTIFACT_KEY_ATTEMPTS = 5;
+const ARTIFACT_ID_METADATA_KEY = "artifact-id";
+const ARTIFACT_FILENAME_METADATA_KEY = "filename";
+const ARTIFACT_USER_ID_METADATA_KEY = "user-id";
+
+export interface ArtifactObjectLocation {
+  readonly id: string;
+  readonly key: string;
+  readonly url: string;
+  readonly metadata: Readonly<Record<string, string>> | undefined;
+}
+
+type StoredGeneratedArtifactObject = Omit<
+  ArtifactObjectLocation,
+  "metadata"
+> & {
+  readonly filename: string;
+  readonly metadata: Readonly<Record<string, string>>;
+};
+
+interface ResolvedArtifactObject {
+  readonly key: string;
+  readonly url: string;
+  readonly filename: string;
+  readonly contentType: string;
+  readonly size: number;
+  readonly lastModified: Date | undefined;
+}
+
+interface ResolvedArtifactMultipartUpload {
+  readonly key: string;
+  readonly url: string;
+  readonly parts: readonly {
+    readonly partNumber: number;
+    readonly etag: string;
+  }[];
+}
+
+export function artifactObjectMetadata(
+  userId: string,
+  id: string,
+  filename: string,
+): Readonly<Record<string, string>> {
+  return {
+    [ARTIFACT_ID_METADATA_KEY]: id,
+    [ARTIFACT_FILENAME_METADATA_KEY]: encodeURIComponent(filename),
+    [ARTIFACT_USER_ID_METADATA_KEY]: encodeURIComponent(userId),
+  };
+}
+
+function filenameFromMetadata(
+  metadata: Readonly<Record<string, string>>,
+): string | undefined {
+  const encoded = metadata[ARTIFACT_FILENAME_METADATA_KEY];
+  if (encoded === undefined) {
+    return undefined;
+  }
+  return safeUriComponentDecode(encoded) ?? undefined;
+}
+
+function filenameFromLegacyKey(key: string): string {
+  return decodeURIComponent(key.split("/").pop() ?? key);
+}
+
+const artifactKeyV2Enabled$ = command(
+  async (
+    { get },
+    orgId: string | null | undefined,
+    userId: string,
+  ): Promise<boolean> => {
+    if (!orgId) {
+      return false;
+    }
+    const context = await get(userFeatureSwitchContext(orgId, userId));
+    return isFeatureEnabled(FeatureSwitchKey.ArtifactKeyV2, context);
+  },
+);
+
+function collisionVariant(variant: string, attempt: number): string {
+  return attempt === 0 ? variant : `${variant}\0${String(attempt)}`;
+}
+
+export const allocateArtifactObject$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly userId: string;
+      readonly orgId: string | null | undefined;
+      readonly filename: string;
+      readonly id?: string;
+      readonly variant?: string;
+    },
+    signal: AbortSignal,
+  ): Promise<ArtifactObjectLocation> => {
+    const useV2 = await set(artifactKeyV2Enabled$, args.orgId, args.userId);
+    signal.throwIfAborted();
+
+    if (!useV2) {
+      const id = args.id ?? randomUUID();
+      const key = buildArtifactKey(
+        args.userId,
+        id,
+        sanitizeArtifactFilename(args.filename),
+      );
+      return { id, key, url: buildFileUrlFromKey(key), metadata: undefined };
+    }
+
+    const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
+    for (let attempt = 0; attempt < MAX_ARTIFACT_KEY_ATTEMPTS; attempt += 1) {
+      const id =
+        args.id !== undefined && (args.variant !== undefined || attempt === 0)
+          ? args.id
+          : randomUUID();
+      const variant =
+        args.variant === undefined
+          ? undefined
+          : collisionVariant(args.variant, attempt);
+      const prefix = buildArtifactPrefixV2(id, variant);
+      const key = buildArtifactKeyV2(id, args.filename, variant);
+      const existing = await get(listS3Objects(bucket, prefix));
+      signal.throwIfAborted();
+      if (existing.length === 0) {
+        return {
+          id,
+          key,
+          url: buildFileUrlFromKey(key),
+          metadata: artifactObjectMetadata(args.userId, id, args.filename),
+        };
+      }
+
+      if (args.id !== undefined && args.variant !== undefined) {
+        const sameKey = existing.find((object) => {
+          return object.key === key;
+        });
+        if (sameKey) {
+          const head = await get(s3ObjectHead(bucket, key));
+          signal.throwIfAborted();
+          if (
+            head.kind === "found" &&
+            head.metadata[ARTIFACT_ID_METADATA_KEY] === id &&
+            head.metadata[ARTIFACT_USER_ID_METADATA_KEY] ===
+              encodeURIComponent(args.userId) &&
+            filenameFromMetadata(head.metadata) === args.filename
+          ) {
+            return {
+              id,
+              key,
+              url: buildFileUrlFromKey(key),
+              metadata: artifactObjectMetadata(args.userId, id, args.filename),
+            };
+          }
+        }
+      }
+    }
+
+    throw new Error("Unable to allocate a unique artifact key");
+  },
+);
+
+export const storeGeneratedArtifactObject$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly userId: string;
+      readonly orgId: string;
+      readonly filenamePrefix: string;
+      readonly extension: string;
+      readonly body: Buffer;
+      readonly contentType: string;
+    },
+    signal: AbortSignal,
+  ): Promise<StoredGeneratedArtifactObject> => {
+    const proposedId = randomUUID();
+    const extension = args.extension.replace(/^\./u, "");
+    const filenameFor = (id: string) => {
+      return `${args.filenamePrefix}-${id.slice(0, 8)}.${extension}`;
+    };
+    const artifact = await set(
+      allocateArtifactObject$,
+      {
+        userId: args.userId,
+        orgId: args.orgId,
+        id: proposedId,
+        filename: filenameFor(proposedId),
+      },
+      signal,
+    );
+    const filename = filenameFor(artifact.id);
+    const metadata = artifactObjectMetadata(args.userId, artifact.id, filename);
+    await get(
+      putS3Object(
+        env("R2_USER_ARTIFACTS_BUCKET_NAME"),
+        artifact.key,
+        args.body,
+        args.contentType,
+        { signal, metadata },
+      ),
+    );
+    signal.throwIfAborted();
+    return { ...artifact, filename, metadata };
+  },
+);
+
+function resolveV2ArtifactObject(
+  bucket: string,
+  userId: string,
+  id: string,
+): Computed<Promise<ResolvedArtifactObject | null>> {
+  return computed(async (get): Promise<ResolvedArtifactObject | null> => {
+    const objects = await get(listS3Objects(bucket, buildArtifactPrefixV2(id)));
+    for (const object of objects) {
+      const head = await get(s3ObjectHead(bucket, object.key));
+      if (
+        head.kind === "missing" ||
+        head.metadata[ARTIFACT_ID_METADATA_KEY] !== id ||
+        head.metadata[ARTIFACT_USER_ID_METADATA_KEY] !==
+          encodeURIComponent(userId)
+      ) {
+        continue;
+      }
+      const filename =
+        filenameFromMetadata(head.metadata) ??
+        filenameFromLegacyKey(object.key);
+      return {
+        key: object.key,
+        url: buildFileUrlFromKey(object.key),
+        filename,
+        contentType: head.contentType ?? inferMimetype(filename),
+        size: head.contentLength ?? object.size,
+        lastModified: head.lastModified ?? object.lastModified,
+      };
+    }
+    return null;
+  });
+}
+
+function resolveV1ArtifactObject(
+  bucket: string,
+  userId: string,
+  id: string,
+): Computed<Promise<ResolvedArtifactObject | null>> {
+  return computed(async (get): Promise<ResolvedArtifactObject | null> => {
+    const objects = await get(
+      listS3Objects(bucket, buildArtifactPrefix(userId, id)),
+    );
+    const object = objects[0];
+    if (!object) {
+      return null;
+    }
+    const filename = filenameFromLegacyKey(object.key);
+    return {
+      key: object.key,
+      url: buildFileUrlFromKey(object.key),
+      filename,
+      contentType: inferMimetype(filename),
+      size: object.size,
+      lastModified: object.lastModified,
+    };
+  });
+}
+
+export function resolvedArtifactObject(
+  userId: string,
+  id: string,
+): Computed<Promise<ResolvedArtifactObject | null>> {
+  return computed(async (get): Promise<ResolvedArtifactObject | null> => {
+    const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
+    return (
+      (await get(resolveV2ArtifactObject(bucket, userId, id))) ??
+      (await get(resolveV1ArtifactObject(bucket, userId, id)))
+    );
+  });
+}
+
+export const resolveArtifactObject$ = command(
+  async (
+    { get },
+    args: {
+      readonly userId: string;
+      readonly id: string;
+    },
+    signal: AbortSignal,
+  ): Promise<ResolvedArtifactObject | null> => {
+    const resolved = await get(resolvedArtifactObject(args.userId, args.id));
+    signal.throwIfAborted();
+    return resolved;
+  },
+);
+
+export const resolveArtifactMultipartUpload$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly userId: string;
+      readonly orgId: string | null | undefined;
+      readonly id: string;
+      readonly filename: string;
+      readonly uploadId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<ResolvedArtifactMultipartUpload | null> => {
+    const sanitizedFilename = sanitizeArtifactFilename(args.filename);
+    const v1Key = buildArtifactKey(args.userId, args.id, sanitizedFilename);
+    const v2Key = buildArtifactKeyV2(args.id, args.filename);
+    const preferV2 = await set(artifactKeyV2Enabled$, args.orgId, args.userId);
+    signal.throwIfAborted();
+    const keys = preferV2 ? [v2Key, v1Key] : [v1Key, v2Key];
+    const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
+    for (const key of keys) {
+      const parts = await get(
+        tryListMultipartS3Parts(bucket, key, args.uploadId),
+      );
+      signal.throwIfAborted();
+      if (parts !== null) {
+        return { key, url: buildFileUrlFromKey(key), parts };
+      }
+    }
+    return null;
+  },
+);

--- a/turbo/apps/api/src/signals/services/artifact-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-storage.service.ts
@@ -114,10 +114,13 @@ export const allocateArtifactObject$ = command(
       readonly filename: string;
       readonly id?: string;
       readonly variant?: string;
+      readonly allowV2?: boolean;
     },
     signal: AbortSignal,
   ): Promise<ArtifactObjectLocation> => {
-    const useV2 = await set(artifactKeyV2Enabled$, args.orgId, args.userId);
+    const useV2 =
+      args.allowV2 !== false &&
+      (await set(artifactKeyV2Enabled$, args.orgId, args.userId));
     signal.throwIfAborted();
 
     if (!useV2) {

--- a/turbo/apps/api/src/signals/services/canonical-asset.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-asset.service.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
 import { command } from "ccstate";
 import {
   CANONICAL_ASSET_VERSION,
@@ -14,12 +14,7 @@ import { and, eq, isNull, sql } from "drizzle-orm";
 
 import type { SlackFile } from "../../lib/slack-webhook-context";
 import { env } from "../../lib/env";
-import {
-  buildArtifactKey,
-  buildFileUrl,
-  buildFileUrlFromKey,
-  sanitizeArtifactFilename,
-} from "../../lib/file-url";
+import { buildFileUrlFromKey } from "../../lib/file-url";
 import { inferMimetype } from "../../lib/mimetype";
 import { isAllowedUploadType } from "../../lib/uploads-constants";
 import { type Db, writeDb$ } from "../external/db";
@@ -35,6 +30,11 @@ import {
   s3ObjectHead,
 } from "../external/s3";
 import { settleIncludingAbort } from "../utils";
+import {
+  allocateArtifactObject$,
+  artifactObjectMetadata,
+  type ArtifactObjectLocation,
+} from "./artifact-storage.service";
 import { syncArtifactCatalogForFile$ } from "./artifact-catalog.service";
 import { publishArtifactsChangedForRun } from "./artifact-realtime.service";
 import { sourceForRun } from "./run-uploaded-files.service";
@@ -245,19 +245,14 @@ async function ensureSlackInputAsset(
     readonly fileId: string;
     readonly filename: string;
     readonly contentType: string;
+    readonly artifact: ArtifactObjectLocation;
   },
 ): Promise<CanonicalAssetRow> {
-  const assetId = randomUUID();
-  const storageKey = buildArtifactKey(
-    args.userId,
-    assetId,
-    sanitizeArtifactFilename(args.filename),
-  );
   const scope = "slack-input";
   const [inserted] = await db
     .insert(runUploadedFiles)
     .values({
-      id: assetId,
+      id: args.artifact.id,
       runId: null,
       chatThreadId: args.chatThreadId,
       source: "slack",
@@ -274,7 +269,7 @@ async function ensureSlackInputAsset(
       accessLevel: "private",
       materializationStatus: "pending",
       checksumSha256: null,
-      storageKey,
+      storageKey: args.artifact.key,
       provenance: {
         provider: "slack",
         workspaceId: args.workspaceId,
@@ -507,7 +502,14 @@ const importCanonicalSlackInputFile$ = command(
             args.asset.storageKey,
             buffer,
             args.contentType,
-            importSignal,
+            {
+              signal: importSignal,
+              metadata: artifactObjectMetadata(
+                args.userId,
+                args.asset.id,
+                args.asset.filename ?? args.asset.id,
+              ),
+            },
           ),
         );
         return { buffer, checksumSha256 };
@@ -550,12 +552,22 @@ const materializeCanonicalSlackInputFile$ = command(
     }
     const filename = slackFileFilename(args.file);
     const contentType = slackFileContentType(args.file, filename);
+    const artifact = await set(
+      allocateArtifactObject$,
+      {
+        userId: args.userId,
+        orgId: args.orgId,
+        filename,
+      },
+      signal,
+    );
     const db = set(writeDb$);
     let asset = await ensureSlackInputAsset(db, {
       ...args,
       fileId,
       filename,
       contentType,
+      artifact,
     });
     signal.throwIfAborted();
     if (asset.materializationStatus === "ready") {
@@ -755,22 +767,17 @@ interface PreparedCanonicalPublishedAsset {
 async function ensureCanonicalPublishedAsset(
   db: Db,
   args: PrepareCanonicalPublishedAssetArgs,
+  artifact: ArtifactObjectLocation,
   context: {
     readonly scope: string;
     readonly source: RunUploadedFileSource;
     readonly chatThreadId: string | null;
   },
 ): Promise<CanonicalAssetRow> {
-  const proposedAssetId = randomUUID();
-  const proposedStorageKey = buildArtifactKey(
-    args.userId,
-    proposedAssetId,
-    sanitizeArtifactFilename(args.filename),
-  );
   const [inserted] = await db
     .insert(runUploadedFiles)
     .values({
-      id: proposedAssetId,
+      id: artifact.id,
       runId: args.runId,
       chatThreadId: context.chatThreadId,
       source: context.source,
@@ -787,7 +794,7 @@ async function ensureCanonicalPublishedAsset(
       accessLevel: "published",
       materializationStatus: "pending",
       checksumSha256: args.checksumSha256,
-      storageKey: proposedStorageKey,
+      storageKey: artifact.key,
       provenance: { provider: "agent" },
       materializationError: null,
       idempotencyScope: context.scope,
@@ -892,7 +899,16 @@ export const prepareCanonicalPublishedAsset$ = command(
       throw new Error("Canonical publication run does not exist");
     }
 
-    const asset = await ensureCanonicalPublishedAsset(db, args, {
+    const artifact = await set(
+      allocateArtifactObject$,
+      {
+        userId: args.userId,
+        orgId: args.orgId,
+        filename: args.filename,
+      },
+      signal,
+    );
+    const asset = await ensureCanonicalPublishedAsset(db, args, artifact, {
       scope,
       source,
       chatThreadId: run.chatThreadId,
@@ -905,11 +921,7 @@ export const prepareCanonicalPublishedAsset$ = command(
       throw new Error("Canonical publication storage key is missing");
     }
 
-    const url = buildFileUrl(
-      args.userId,
-      asset.id,
-      sanitizeArtifactFilename(args.filename),
-    );
+    const url = buildFileUrlFromKey(storageKey);
     if (asset.materializationStatus === "ready") {
       return {
         assetId: asset.id,
@@ -933,7 +945,14 @@ export const prepareCanonicalPublishedAsset$ = command(
         storageKey,
         args.contentType,
         CANONICAL_UPLOAD_URL_TTL_SECONDS,
-        true,
+        {
+          usePublicEndpoint: true,
+          metadata: artifactObjectMetadata(
+            args.userId,
+            asset.id,
+            args.filename,
+          ),
+        },
       ),
     );
     signal.throwIfAborted();
@@ -992,11 +1011,7 @@ export const materializeCanonicalPublishedAsset$ = command(
         message: "Canonical publication asset was not found",
       };
     }
-    const url = buildFileUrl(
-      args.userId,
-      asset.id,
-      sanitizeArtifactFilename(asset.filename),
-    );
+    const url = buildFileUrlFromKey(asset.storageKey);
     if (asset.materializationStatus === "ready") {
       await set(syncArtifactCatalogForFile$, asset.id, signal);
       return { ok: true, assetId: asset.id, url };

--- a/turbo/apps/api/src/signals/services/canonical-asset.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-asset.service.ts
@@ -14,7 +14,7 @@ import { and, eq, isNull, sql } from "drizzle-orm";
 
 import type { SlackFile } from "../../lib/slack-webhook-context";
 import { env } from "../../lib/env";
-import { buildFileUrlFromKey } from "../../lib/file-url";
+import { buildFileUrlFromKey, isArtifactKeyV2 } from "../../lib/file-url";
 import { inferMimetype } from "../../lib/mimetype";
 import { isAllowedUploadType } from "../../lib/uploads-constants";
 import { type Db, writeDb$ } from "../external/db";
@@ -27,6 +27,7 @@ import {
 import {
   generatePresignedPutUrl,
   putS3Object,
+  s3MetadataHeaders,
   s3ObjectHead,
 } from "../external/s3";
 import { settleIncludingAbort } from "../utils";
@@ -749,6 +750,7 @@ interface PrepareCanonicalPublishedAssetArgs {
   readonly contentType: string;
   readonly size: number;
   readonly checksumSha256: string;
+  readonly allowV2: boolean;
   readonly destination: {
     readonly channelId: string;
     readonly threadTs?: string;
@@ -761,6 +763,7 @@ interface PreparedCanonicalPublishedAsset {
   readonly assetId: string;
   readonly operationId: string;
   readonly uploadUrl?: string;
+  readonly uploadHeaders?: Readonly<Record<string, string>>;
   readonly url: string;
 }
 
@@ -905,6 +908,7 @@ export const prepareCanonicalPublishedAsset$ = command(
         userId: args.userId,
         orgId: args.orgId,
         filename: args.filename,
+        allowV2: args.allowV2,
       },
       signal,
     );
@@ -920,6 +924,10 @@ export const prepareCanonicalPublishedAsset$ = command(
     if (!storageKey) {
       throw new Error("Canonical publication storage key is missing");
     }
+    const metadata = isArtifactKeyV2(storageKey)
+      ? artifactObjectMetadata(args.userId, asset.id, args.filename)
+      : undefined;
+    const uploadHeaders = metadata ? s3MetadataHeaders(metadata) : undefined;
 
     const url = buildFileUrlFromKey(storageKey);
     if (asset.materializationStatus === "ready") {
@@ -947,11 +955,7 @@ export const prepareCanonicalPublishedAsset$ = command(
         CANONICAL_UPLOAD_URL_TTL_SECONDS,
         {
           usePublicEndpoint: true,
-          metadata: artifactObjectMetadata(
-            args.userId,
-            asset.id,
-            args.filename,
-          ),
+          metadata,
         },
       ),
     );
@@ -960,6 +964,7 @@ export const prepareCanonicalPublishedAsset$ = command(
       assetId: asset.id,
       operationId: args.operationId,
       uploadUrl,
+      ...(uploadHeaders ? { uploadHeaders } : {}),
       url,
     };
   },

--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -14,6 +14,7 @@ export const ORG_SENTINEL_USER_ID = "__org__";
 
 const ORG_SCOPED_FEATURE_SWITCH_KEYS: readonly string[] = [
   FeatureSwitchKey.ChatThreadUnifiedSearch,
+  FeatureSwitchKey.ArtifactKeyV2,
 ];
 
 function isOrgScopedFeatureSwitchKey(key: string): boolean {

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -21,6 +21,7 @@ import { ZipArchive } from "archiver";
 
 import { env, optionalEnv } from "../../lib/env";
 import { badRequestMessage, notFound } from "../../lib/error";
+import { isArtifactKeyV2 } from "../../lib/file-url";
 import { db$, type ReadonlyDb } from "../external/db";
 import { downloadHostedSitesS3Buffer, downloadS3Buffer } from "../external/s3";
 import {
@@ -616,7 +617,10 @@ function resolveArtifactS3ObjectFromKey(
   value: string,
   userId: string,
 ): ArtifactS3Object | null {
-  if (value.startsWith(`artifacts/${encodeURIComponent(userId)}/`)) {
+  if (
+    value.startsWith(`artifacts/${encodeURIComponent(userId)}/`) ||
+    isArtifactKeyV2(value)
+  ) {
     return {
       bucketName: env("R2_USER_ARTIFACTS_BUCKET_NAME"),
       key: value,

--- a/turbo/apps/api/src/signals/services/zero-chat-event-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event-shared.service.ts
@@ -16,15 +16,13 @@ import {
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
-import { env } from "../../lib/env";
-import { buildArtifactPrefix, buildFileUrl } from "../../lib/file-url";
 import { writeDb$, type Db } from "../external/db";
 import {
   publishChatThreadMessageCreatedSafely,
   publishThreadListChangedSafely,
 } from "../external/realtime";
-import { listS3Objects } from "../external/s3";
 import { nowDate } from "../external/time";
+import { resolvedArtifactObject } from "./artifact-storage.service";
 import { assistantEventIdForRunEvent } from "./assistant-event-id";
 import { insertChatEvents } from "./zero-chat-event.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
@@ -151,23 +149,19 @@ export function resolveAttachFileUrls(
   fileIds: readonly string[],
 ): Computed<Promise<readonly ResolvedAttachFile[]>> {
   return computed(async (get): Promise<readonly ResolvedAttachFile[]> => {
-    const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
     const resolved = await Promise.all(
       fileIds.map(async (fileId): Promise<ResolvedAttachFile | null> => {
-        const prefix = buildArtifactPrefix(userId, fileId);
-        const objects = await get(listS3Objects(bucket, prefix));
-        const object = objects[0];
+        const object = await get(resolvedArtifactObject(userId, fileId));
         if (!object) {
           return null;
         }
 
-        const filename = object.key.split("/").pop() ?? fileId;
         return {
           id: fileId,
-          filename,
-          contentType: inferMimetype(filename),
+          filename: object.filename,
+          contentType: object.contentType,
           size: object.size,
-          url: buildFileUrl(userId, fileId, filename),
+          url: object.url,
         };
       }),
     );

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -596,6 +596,7 @@ function artifactPreviewArgs(
     id: artifactRow.id,
     runId: deployment.runId,
     userId: deployment.userId,
+    orgId: deployment.orgId,
     url: deployment.artifactUrl ?? deployment.url,
     contentType: "text/html",
     deploymentId: deployment.id,

--- a/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
@@ -1,17 +1,15 @@
 import { Buffer } from "node:buffer";
-import { randomUUID } from "node:crypto";
 
 import { command, computed, type Computed } from "ccstate";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { usagePricing } from "@vm0/db/schema/usage-pricing";
 import { and, eq, inArray } from "drizzle-orm";
 
-import { buildArtifactKey, buildFileUrl } from "../../lib/file-url";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { db$, writeDb$ } from "../external/db";
 import { checkBillableOperationCredits$ } from "./billable-operation-admission.service";
-import { putS3Object } from "../external/s3";
+import { storeGeneratedArtifactObject$ } from "./artifact-storage.service";
 import { recordWebUploadedFile$ } from "./run-uploaded-files.service";
 import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
 import {
@@ -1608,7 +1606,7 @@ export async function downloadFalImage(
 
 export const recordGeneratedImage$ = command(
   async (
-    { get, set },
+    { set },
     params: {
       readonly orgId: string;
       readonly userId: string;
@@ -1621,23 +1619,21 @@ export const recordGeneratedImage$ = command(
     signal: AbortSignal,
   ): Promise<RecordedImage> => {
     const writeDb = set(writeDb$);
-    const fileId = randomUUID();
-    const filename = `image-${fileId.slice(0, 8)}.${extensionForFormat(
-      params.generation.outputFormat,
-    )}`;
-    const s3Key = buildArtifactKey(params.userId, fileId, filename);
-    const contentType = contentTypeForFormat(params.generation.outputFormat);
-    await get(
-      putS3Object(
-        env("R2_USER_ARTIFACTS_BUCKET_NAME"),
-        s3Key,
-        params.generation.imageBytes,
-        contentType,
-      ),
+    const artifact = await set(
+      storeGeneratedArtifactObject$,
+      {
+        userId: params.userId,
+        orgId: params.orgId,
+        filenamePrefix: "image",
+        extension: extensionForFormat(params.generation.outputFormat),
+        body: params.generation.imageBytes,
+        contentType: contentTypeForFormat(params.generation.outputFormat),
+      },
+      signal,
     );
-    signal.throwIfAborted();
+    const { id: fileId, filename, key: s3Key, url } = artifact;
+    const contentType = contentTypeForFormat(params.generation.outputFormat);
 
-    const url = buildFileUrl(params.userId, fileId, filename);
     if (params.recordArtifact !== false) {
       await set(
         recordWebUploadedFile$,

--- a/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
@@ -1,17 +1,14 @@
 import { Buffer } from "node:buffer";
-import { randomUUID } from "node:crypto";
 
 import { command, computed, type Computed } from "ccstate";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { usagePricing } from "@vm0/db/schema/usage-pricing";
 import { and, eq, inArray } from "drizzle-orm";
 
-import { buildArtifactKey, buildFileUrl } from "../../lib/file-url";
-import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { db$, writeDb$ } from "../external/db";
 import { checkBillableOperationCredits$ } from "./billable-operation-admission.service";
-import { putS3Object } from "../external/s3";
+import { storeGeneratedArtifactObject$ } from "./artifact-storage.service";
 import { safeJsonParse, safeSync, tapError } from "../utils";
 import { recordWebUploadedFile$ } from "./run-uploaded-files.service";
 import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
@@ -1642,7 +1639,7 @@ function estimateVideoCredits(
 
 export const recordGeneratedVideo$ = command(
   async (
-    { get, set },
+    { set },
     params: {
       readonly orgId: string;
       readonly userId: string;
@@ -1654,22 +1651,19 @@ export const recordGeneratedVideo$ = command(
     signal: AbortSignal,
   ): Promise<RecordedVideo> => {
     const writeDb = set(writeDb$);
-    const fileId = randomUUID();
-    const filename = `video-${fileId.slice(0, 8)}.${extensionForContentType(
-      params.generation.contentType,
-    )}`;
-    const s3Key = buildArtifactKey(params.userId, fileId, filename);
-    await get(
-      putS3Object(
-        env("R2_USER_ARTIFACTS_BUCKET_NAME"),
-        s3Key,
-        params.generation.videoBytes,
-        params.generation.contentType,
-      ),
+    const artifact = await set(
+      storeGeneratedArtifactObject$,
+      {
+        userId: params.userId,
+        orgId: params.orgId,
+        filenamePrefix: "video",
+        extension: extensionForContentType(params.generation.contentType),
+        body: params.generation.videoBytes,
+        contentType: params.generation.contentType,
+      },
+      signal,
     );
-    signal.throwIfAborted();
-
-    const url = buildFileUrl(params.userId, fileId, filename);
+    const { id: fileId, filename, key: s3Key, url } = artifact;
     await set(
       recordWebUploadedFile$,
       {

--- a/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
@@ -7,14 +7,13 @@ import { userBehaviorCount } from "@vm0/db/schema/user-behavior-count";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { parseBuffer } from "music-metadata";
 
-import { buildArtifactKey, buildFileUrl } from "../../lib/file-url";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { db$, writeDb$ } from "../external/db";
 import { checkBillableOperationCredits$ } from "./billable-operation-admission.service";
 import { nowDate } from "../external/time";
-import { putS3Object } from "../external/s3";
 import { tapError } from "../utils";
+import { storeGeneratedArtifactObject$ } from "./artifact-storage.service";
 import { recordWebUploadedFile$ } from "./run-uploaded-files.service";
 import {
   AUDIO_INPUT_BEHAVIOR_KEY,
@@ -959,7 +958,7 @@ export const recordSttUsage$ = command(
 
 export const recordGeneratedSpeech$ = command(
   async (
-    { get, set },
+    { set },
     params: {
       readonly orgId: string;
       readonly userId: string;
@@ -972,21 +971,19 @@ export const recordGeneratedSpeech$ = command(
     signal: AbortSignal,
   ): Promise<RecordedSpeech> => {
     const writeDb = set(writeDb$);
-    const fileId = randomUUID();
-    const filename = `voice-${fileId.slice(0, 8)}.wav`;
-    const s3Key = buildArtifactKey(params.userId, fileId, filename);
-    const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
-    await get(
-      putS3Object(
-        bucket,
-        s3Key,
-        Buffer.from(params.audioBytes),
-        SPEECH_CONTENT_TYPE,
-      ),
+    const artifact = await set(
+      storeGeneratedArtifactObject$,
+      {
+        userId: params.userId,
+        orgId: params.orgId,
+        filenamePrefix: "voice",
+        extension: "wav",
+        body: Buffer.from(params.audioBytes),
+        contentType: SPEECH_CONTENT_TYPE,
+      },
+      signal,
     );
-    signal.throwIfAborted();
-
-    const url = buildFileUrl(params.userId, fileId, filename);
+    const { id: fileId, filename, key: s3Key, url } = artifact;
     await set(
       recordWebUploadedFile$,
       {

--- a/turbo/apps/api/src/signals/services/zero-web-download.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-web-download.service.ts
@@ -1,9 +1,8 @@
 import { computed, type Computed } from "ccstate";
 
 import { env } from "../../lib/env";
-import { buildArtifactPrefix } from "../../lib/file-url";
-import { inferMimetype } from "../../lib/mimetype";
-import { downloadS3Buffer, listS3Objects } from "../external/s3";
+import { downloadS3Buffer } from "../external/s3";
+import { resolvedArtifactObject } from "./artifact-storage.service";
 
 interface DownloadFileResult {
   readonly buffer: Buffer;
@@ -24,18 +23,17 @@ export function zeroWebDownloadFile(
     if (!bucket) {
       return null;
     }
-    const prefix = buildArtifactPrefix(userId, fileId);
-    const objects = await get(listS3Objects(bucket, prefix));
-
-    if (objects.length === 0) {
+    const object = await get(resolvedArtifactObject(userId, fileId));
+    if (!object) {
       return null;
     }
 
-    const s3Object = objects[0]!;
-    const filename = s3Object.key.split("/").pop() ?? fileId;
-    const contentType = inferMimetype(filename);
-    const buffer = await get(downloadS3Buffer(bucket, s3Object.key));
+    const buffer = await get(downloadS3Buffer(bucket, object.key));
 
-    return { buffer, contentType, filename };
+    return {
+      buffer,
+      contentType: object.contentType,
+      filename: object.filename,
+    };
   });
 }

--- a/turbo/apps/cli/src/commands/zero/feishu/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/feishu/__tests__/upload-file.test.ts
@@ -50,6 +50,7 @@ describe("zero feishu upload-file command", () => {
           filename: "report.pdf",
           contentType: "application/pdf",
           length: Buffer.byteLength(FILE_CONTENT),
+          supportsUploadHeaders: true,
         });
         return HttpResponse.json({
           uploadId: "00000000-0000-4000-8000-000000000001",
@@ -59,10 +60,16 @@ describe("zero feishu upload-file command", () => {
           filename: "report.pdf",
           contentType: "application/pdf",
           size: Buffer.byteLength(FILE_CONTENT),
+          uploadHeaders: {
+            "x-amz-meta-artifact-id": "00000000-0000-4000-8000-000000000001",
+          },
         });
       }),
       http.put(STORAGE_UPLOAD_URL, async ({ request }) => {
         expect(request.headers.get("content-type")).toBe("application/pdf");
+        expect(request.headers.get("x-amz-meta-artifact-id")).toBe(
+          "00000000-0000-4000-8000-000000000001",
+        );
         await expect(request.text()).resolves.toBe(FILE_CONTENT);
         return new HttpResponse(null, { status: 200 });
       }),

--- a/turbo/apps/cli/src/commands/zero/feishu/upload-file.ts
+++ b/turbo/apps/cli/src/commands/zero/feishu/upload-file.ts
@@ -114,10 +114,14 @@ Notes:
         filename,
         contentType,
         length: fileSize,
+        supportsUploadHeaders: true,
       });
       const uploadResponse = await fetch(prepared.uploadUrl, {
         method: "PUT",
-        headers: { "Content-Type": prepared.contentType },
+        headers: {
+          "Content-Type": prepared.contentType,
+          ...prepared.uploadHeaders,
+        },
         body: new Uint8Array(readFileSync(options.file)),
       });
       if (!uploadResponse.ok) {

--- a/turbo/apps/cli/src/commands/zero/github/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/github/__tests__/upload-file.test.ts
@@ -54,6 +54,7 @@ describe("zero github upload-file command", () => {
           filename: "report.pdf",
           contentType: "application/pdf",
           length: 18,
+          supportsUploadHeaders: true,
         });
         return HttpResponse.json({
           uploadId: "00000000-0000-4000-8000-000000000101",
@@ -63,10 +64,16 @@ describe("zero github upload-file command", () => {
           filename: "report.pdf",
           contentType: "application/pdf",
           size: 18,
+          uploadHeaders: {
+            "x-amz-meta-artifact-id": "00000000-0000-4000-8000-000000000101",
+          },
         });
       }),
       http.put(R2_UPLOAD_URL, async ({ request }) => {
         putReceivedContentType = request.headers.get("content-type");
+        expect(request.headers.get("x-amz-meta-artifact-id")).toBe(
+          "00000000-0000-4000-8000-000000000101",
+        );
         const bytes = Buffer.from(await request.arrayBuffer());
         expect(bytes.toString()).toBe("github pdf content");
         return new HttpResponse(null, { status: 200 });

--- a/turbo/apps/cli/src/commands/zero/github/upload-file.ts
+++ b/turbo/apps/cli/src/commands/zero/github/upload-file.ts
@@ -99,12 +99,16 @@ Notes:
           filename,
           contentType,
           length: fileSize,
+          supportsUploadHeaders: true,
         });
 
         const fileContent = readFileSync(options.file);
         const uploadResponse = await fetch(prepared.uploadUrl, {
           method: "PUT",
-          headers: { "Content-Type": prepared.contentType },
+          headers: {
+            "Content-Type": prepared.contentType,
+            ...prepared.uploadHeaders,
+          },
           body: new Uint8Array(fileContent),
         });
 

--- a/turbo/apps/cli/src/commands/zero/phone/__tests__/commands.test.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/__tests__/commands.test.ts
@@ -132,6 +132,7 @@ describe("zero phone commands", () => {
           filename: "report.pdf",
           contentType: "application/pdf",
           length: 17,
+          supportsUploadHeaders: true,
         });
         return HttpResponse.json({
           uploadId: "00000000-0000-4000-8000-000000000001",
@@ -141,9 +142,15 @@ describe("zero phone commands", () => {
           filename: "report.pdf",
           contentType: "application/pdf",
           size: 17,
+          uploadHeaders: {
+            "x-amz-meta-artifact-id": "00000000-0000-4000-8000-000000000001",
+          },
         });
       }),
       http.put(R2_UPLOAD_URL, async ({ request }) => {
+        expect(request.headers.get("x-amz-meta-artifact-id")).toBe(
+          "00000000-0000-4000-8000-000000000001",
+        );
         const bytes = Buffer.from(await request.arrayBuffer());
         expect(bytes.toString()).toBe("phone pdf content");
         return new HttpResponse(null, { status: 200 });

--- a/turbo/apps/cli/src/commands/zero/phone/upload-file.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/upload-file.ts
@@ -80,12 +80,16 @@ Output:
           filename,
           contentType,
           length: fileSize,
+          supportsUploadHeaders: true,
         });
 
         const fileContent = readFileSync(options.file);
         const uploadResponse = await fetch(prepared.uploadUrl, {
           method: "PUT",
-          headers: { "Content-Type": prepared.contentType },
+          headers: {
+            "Content-Type": prepared.contentType,
+            ...prepared.uploadHeaders,
+          },
           body: new Uint8Array(fileContent),
         });
 

--- a/turbo/apps/cli/src/commands/zero/slack/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/__tests__/upload-file.test.ts
@@ -205,12 +205,16 @@ describe("zero slack upload-file command", () => {
               assetId,
               operationId,
               uploadUrl: CANONICAL_PRESIGNED_URL,
+              uploadHeaders: {
+                "x-amz-meta-artifact-id": assetId,
+              },
               url: "https://cdn.vm7.io/artifacts/user/asset/test-report.pdf",
             },
             { status: 200 },
           );
         }),
-        http.put(CANONICAL_PRESIGNED_URL, () => {
+        http.put(CANONICAL_PRESIGNED_URL, ({ request }) => {
+          expect(request.headers.get("x-amz-meta-artifact-id")).toBe(assetId);
           sequence.push("canonical-upload");
           return new HttpResponse(null, { status: 200 });
         }),
@@ -270,6 +274,7 @@ describe("zero slack upload-file command", () => {
       ]);
       expect(capturedInitBody).toMatchObject({
         filename: "test-report.pdf",
+        supportsUploadHeaders: true,
         canonical: {
           operationId,
           contentType: "application/pdf",

--- a/turbo/apps/cli/src/commands/zero/slack/upload-file.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/upload-file.ts
@@ -93,7 +93,10 @@ async function uploadCanonicalBody(
   }
   const uploadResponse = await fetch(initialized.uploadUrl, {
     method: "PUT",
-    headers: { "Content-Type": contentType },
+    headers: {
+      "Content-Type": contentType,
+      ...initialized.uploadHeaders,
+    },
     body: fileContent,
   });
   if (!uploadResponse.ok) {
@@ -221,6 +224,7 @@ async function uploadFile(options: UploadFileOptions): Promise<void> {
   const initialized = await initSlackFileUpload({
     filename,
     length: file.size,
+    supportsUploadHeaders: true,
     canonical: {
       operationId,
       contentType,

--- a/turbo/apps/cli/src/commands/zero/teams/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/teams/__tests__/upload-file.test.ts
@@ -56,6 +56,7 @@ describe("zero teams upload-file command", () => {
           filename: "report.pdf",
           contentType: "application/pdf",
           length: 17,
+          supportsUploadHeaders: true,
         });
         return HttpResponse.json({
           uploadId: "00000000-0000-4000-8000-000000000001",
@@ -65,10 +66,16 @@ describe("zero teams upload-file command", () => {
           filename: "report.pdf",
           contentType: "application/pdf",
           size: 17,
+          uploadHeaders: {
+            "x-amz-meta-artifact-id": "00000000-0000-4000-8000-000000000001",
+          },
         });
       }),
       http.put(R2_UPLOAD_URL, async ({ request }) => {
         putReceivedContentType = request.headers.get("content-type");
+        expect(request.headers.get("x-amz-meta-artifact-id")).toBe(
+          "00000000-0000-4000-8000-000000000001",
+        );
         const bytes = Buffer.from(await request.arrayBuffer());
         expect(bytes.toString()).toBe("teams pdf content");
         return new HttpResponse(null, { status: 200 });

--- a/turbo/apps/cli/src/commands/zero/teams/upload-file.ts
+++ b/turbo/apps/cli/src/commands/zero/teams/upload-file.ts
@@ -86,12 +86,16 @@ Notes:
           filename,
           contentType,
           length: fileSize,
+          supportsUploadHeaders: true,
         });
 
         const fileContent = readFileSync(options.file);
         const uploadResponse = await fetch(prepared.uploadUrl, {
           method: "PUT",
-          headers: { "Content-Type": prepared.contentType },
+          headers: {
+            "Content-Type": prepared.contentType,
+            ...prepared.uploadHeaders,
+          },
           body: new Uint8Array(fileContent),
         });
 

--- a/turbo/apps/cli/src/commands/zero/telegram/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/telegram/__tests__/upload-file.test.ts
@@ -58,6 +58,7 @@ describe("zero telegram upload-file command", () => {
           filename: "report.pdf",
           contentType: "application/pdf",
           length: 20,
+          supportsUploadHeaders: true,
         });
         return HttpResponse.json({
           uploadId: "00000000-0000-4000-8000-000000000001",
@@ -67,10 +68,16 @@ describe("zero telegram upload-file command", () => {
           filename: "report.pdf",
           contentType: "application/pdf",
           size: 20,
+          uploadHeaders: {
+            "x-amz-meta-artifact-id": "00000000-0000-4000-8000-000000000001",
+          },
         });
       }),
       http.put(R2_UPLOAD_URL, async ({ request }) => {
         putReceivedContentType = request.headers.get("content-type");
+        expect(request.headers.get("x-amz-meta-artifact-id")).toBe(
+          "00000000-0000-4000-8000-000000000001",
+        );
         const bytes = Buffer.from(await request.arrayBuffer());
         expect(bytes.toString()).toBe("telegram pdf content");
         return new HttpResponse(null, { status: 200 });

--- a/turbo/apps/cli/src/commands/zero/telegram/upload-file.ts
+++ b/turbo/apps/cli/src/commands/zero/telegram/upload-file.ts
@@ -100,12 +100,16 @@ Notes:
           filename,
           contentType,
           length: fileSize,
+          supportsUploadHeaders: true,
         });
 
         const fileContent = readFileSync(options.file);
         const uploadResponse = await fetch(prepared.uploadUrl, {
           method: "PUT",
-          headers: { "Content-Type": prepared.contentType },
+          headers: {
+            "Content-Type": prepared.contentType,
+            ...prepared.uploadHeaders,
+          },
           body: new Uint8Array(fileContent),
         });
 

--- a/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
@@ -74,6 +74,11 @@ describe("zero web upload-file command", () => {
         contentType: "application/pdf",
         size: 13,
         uploadUrl: PUT_URL,
+        uploadHeaders: {
+          "x-amz-meta-artifact-id": "file-uuid-1",
+          "x-amz-meta-filename": "report.pdf",
+          "x-amz-meta-user-id": "user-test",
+        },
         url: "https://presigned.example.com/file-uuid-1/report.pdf?sig=abc",
       };
 
@@ -103,15 +108,22 @@ describe("zero web upload-file command", () => {
             filename: string;
             contentType: string;
             size: number;
+            supportsUploadHeaders: true;
           };
           expect(body.filename).toBe("report.pdf");
           expect(body.contentType).toBe("application/pdf");
           expect(body.size).toBe(13);
+          expect(body.supportsUploadHeaders).toBe(true);
 
           return HttpResponse.json(prepared, { status: 200 });
         }),
         http.put(PUT_URL, ({ request }) => {
           putReceivedContentType = request.headers.get("content-type");
+          expect(request.headers.get("x-amz-meta-artifact-id")).toBe(
+            "file-uuid-1",
+          );
+          expect(request.headers.get("x-amz-meta-filename")).toBe("report.pdf");
+          expect(request.headers.get("x-amz-meta-user-id")).toBe("user-test");
           expect(request.headers.get(CLIENT_TYPE_HEADER)).toBeNull();
           expect(request.headers.get(CLIENT_VERSION_HEADER)).toBeNull();
           expect(request.headers.get(CLIENT_SESSION_ID_HEADER)).toBeNull();

--- a/turbo/apps/cli/src/lib/api/domains/web.ts
+++ b/turbo/apps/cli/src/lib/api/domains/web.ts
@@ -349,6 +349,7 @@ interface PrepareUploadResponse {
   contentType: string;
   size: number;
   uploadUrl: string;
+  uploadHeaders?: Record<string, string>;
   url: string;
 }
 
@@ -723,7 +724,12 @@ export async function uploadWebFile(
   const prepareRes = await fetch(prepareUrl, {
     method: "POST",
     headers: headersWithCliClientHeaders(prepareHeaders),
-    body: JSON.stringify({ filename, contentType, size: stats.size }),
+    body: JSON.stringify({
+      filename,
+      contentType,
+      size: stats.size,
+      supportsUploadHeaders: true,
+    }),
   });
 
   if (!prepareRes.ok) {
@@ -739,7 +745,10 @@ export async function uploadWebFile(
   const bytes = readFileSync(localPath);
   const putRes = await fetch(prepared.uploadUrl, {
     method: "PUT",
-    headers: { "Content-Type": prepared.contentType },
+    headers: {
+      "Content-Type": prepared.contentType,
+      ...prepared.uploadHeaders,
+    },
     body: new Uint8Array(bytes),
   });
 

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -237,6 +237,7 @@ function createChatAttachment(file: File): ZeroChatAttachment {
             filename: file.name,
             contentType,
             size: file.size,
+            supportsUploadHeaders: true,
             ...(file.size >= MULTIPART_UPLOAD_THRESHOLD_BYTES
               ? { multipart: true as const }
               : {}),
@@ -298,7 +299,10 @@ function createChatAttachment(file: File): ZeroChatAttachment {
       const putRes = await fetch(prepared.body.uploadUrl, {
         method: "PUT",
         body: file,
-        headers: { "content-type": prepared.body.contentType },
+        headers: {
+          "content-type": prepared.body.contentType,
+          ...prepared.body.uploadHeaders,
+        },
         signal,
       });
       signal.throwIfAborted();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -863,26 +863,39 @@ describe("chat drafts", () => {
       updatedAt: "2026-03-10T00:00:00Z",
     });
     mockThreadDetails();
-    context.mocks.http.post("*/api/zero/uploads/prepare", () => {
-      return HttpResponse.json({
-        id: "upload-photo",
-        filename: "photo.png",
-        contentType: "image/png",
-        size: 1024,
-        uploadUrl: "https://mock-upload.example.com/photo.png",
-        url: "https://example.com/photo.png",
-      });
-    });
+    context.mocks.http.post(
+      "*/api/zero/uploads/prepare",
+      async ({ request }) => {
+        await expect(request.json()).resolves.toMatchObject({
+          filename: "photo.png",
+          supportsUploadHeaders: true,
+        });
+        return HttpResponse.json({
+          id: "upload-photo",
+          filename: "photo.png",
+          contentType: "image/png",
+          size: 1024,
+          uploadUrl: "https://mock-upload.example.com/photo.png",
+          uploadHeaders: {
+            "x-amz-meta-artifact-id": "upload-photo",
+          },
+          url: "https://example.com/photo.png",
+        });
+      },
+    );
     context.mocks.http.put(
       "https://mock-upload.example.com/photo.png",
-      ({ deferred }) => {
+      ({ deferred, request }) => {
+        expect(request.headers.get("x-amz-meta-artifact-id")).toBe(
+          "upload-photo",
+        );
         uploadStarted.resolve();
-        const request = deferred<Response>();
+        const pendingResponse = deferred<Response>();
         uploadRequest = {
-          promise: request.promise,
-          resolve: request.resolve,
+          promise: pendingResponse.promise,
+          resolve: pendingResponse.resolve,
         };
-        return request.promise;
+        return pendingResponse.promise;
       },
     );
 
@@ -1072,6 +1085,7 @@ describe("chat drafts", () => {
           contentType: "video/mp4",
           size: 5 * 1024 * 1024 + 1,
           multipart: true,
+          supportsUploadHeaders: true,
         },
       ]);
       expect(firstPartAttempts).toBe(2);

--- a/turbo/packages/api-contracts/src/contracts/integrations.ts
+++ b/turbo/packages/api-contracts/src/contracts/integrations.ts
@@ -4,6 +4,14 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
+const directUploadCapabilityShape = {
+  supportsUploadHeaders: z.literal(true).optional(),
+};
+
+const directUploadResponseShape = {
+  uploadHeaders: z.record(z.string(), z.string()).optional(),
+};
+
 /**
  * Integration Slack message contract
  * POST /api/zero/integrations/slack/message
@@ -199,6 +207,7 @@ const feishuUploadInitBodySchema = z.object({
       FEISHU_FILE_UPLOAD_MAX_BYTES,
       `File must not exceed ${FEISHU_FILE_UPLOAD_MAX_BYTES} bytes`,
     ),
+  ...directUploadCapabilityShape,
 });
 
 export type FeishuUploadInitBody = z.infer<typeof feishuUploadInitBodySchema>;
@@ -210,6 +219,7 @@ const feishuUploadInitResponseSchema = z.object({
   filename: z.string(),
   contentType: z.string(),
   size: z.number().int().nonnegative(),
+  ...directUploadResponseShape,
 });
 
 export type FeishuUploadInitResponse = z.infer<
@@ -588,6 +598,7 @@ export type IntegrationsTelegramBotListContract =
 const slackUploadInitBodySchema = z.object({
   filename: z.string().min(1, "Filename is required"),
   length: z.number().int().positive("File length must be a positive integer"),
+  ...directUploadCapabilityShape,
   canonical: z
     .object({
       operationId: z.string().uuid(),
@@ -614,6 +625,7 @@ const canonicalSlackUploadInitResponseSchema = z.object({
   operationId: z.string().uuid(),
   uploadUrl: z.string().url().optional(),
   url: z.string().url(),
+  ...directUploadResponseShape,
 });
 
 const slackUploadInitResponseSchema = z.union([
@@ -706,6 +718,7 @@ const telegramUploadInitBodySchema = z.object({
   filename: z.string().min(1, "Filename is required").max(255),
   contentType: z.string().min(1, "Content type is required").max(200),
   length: z.number().int().positive("File length must be a positive integer"),
+  ...directUploadCapabilityShape,
 });
 
 export type TelegramUploadInitBody = z.infer<
@@ -719,6 +732,7 @@ const telegramUploadInitResponseSchema = z.object({
   filename: z.string(),
   contentType: z.string(),
   size: z.number().int().nonnegative(),
+  ...directUploadResponseShape,
 });
 
 export type TelegramUploadInitResponse = z.infer<
@@ -754,6 +768,7 @@ const teamsUploadInitBodySchema = z.object({
   filename: z.string().min(1, "Filename is required").max(255),
   contentType: z.string().min(1, "Content type is required").max(200),
   length: z.number().int().positive("File length must be a positive integer"),
+  ...directUploadCapabilityShape,
 });
 
 export type TeamsUploadInitBody = z.infer<typeof teamsUploadInitBodySchema>;
@@ -765,6 +780,7 @@ const teamsUploadInitResponseSchema = z.object({
   filename: z.string(),
   contentType: z.string(),
   size: z.number().int().nonnegative(),
+  ...directUploadResponseShape,
 });
 
 export type TeamsUploadInitResponse = z.infer<
@@ -905,6 +921,7 @@ const githubUploadInitBodySchema = z.object({
   filename: z.string().min(1, "Filename is required").max(255),
   contentType: z.string().min(1, "Content type is required").max(200),
   length: z.number().int().positive("File length must be a positive integer"),
+  ...directUploadCapabilityShape,
 });
 
 export type GithubUploadInitBody = z.infer<typeof githubUploadInitBodySchema>;
@@ -916,6 +933,7 @@ const githubUploadInitResponseSchema = z.object({
   filename: z.string(),
   contentType: z.string(),
   size: z.number().int().nonnegative(),
+  ...directUploadResponseShape,
 });
 
 export type GithubUploadInitResponse = z.infer<
@@ -1013,6 +1031,7 @@ const phoneUploadInitBodySchema = z.object({
   filename: z.string().min(1, "Filename is required").max(255),
   contentType: z.string().min(1, "Content type is required").max(200),
   length: z.number().int().positive("File length must be a positive integer"),
+  ...directUploadCapabilityShape,
 });
 
 export type PhoneUploadInitBody = z.infer<typeof phoneUploadInitBodySchema>;
@@ -1024,6 +1043,7 @@ const phoneUploadInitResponseSchema = z.object({
   filename: z.string(),
   contentType: z.string(),
   size: z.number().int().nonnegative(),
+  ...directUploadResponseShape,
 });
 
 export type PhoneUploadInitResponse = z.infer<

--- a/turbo/packages/api-contracts/src/contracts/zero-uploads.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-uploads.ts
@@ -13,6 +13,12 @@ const prepareRequestSchema = z.object({
   contentType: z.string().min(1).max(200),
   size: z.number().int().nonnegative(),
   /**
+   * New clients opt in to applying headers returned with a presigned upload.
+   * Older API deployments ignore this field, while newer APIs keep returning
+   * legacy object keys to clients that omit it.
+   */
+  supportsUploadHeaders: z.literal(true).optional(),
+  /**
    * New clients request multipart uploads for large files. Older API
    * deployments ignore this unknown field and return the legacy single PUT
    * response, which keeps frontend/backend rolling deploys compatible.
@@ -36,6 +42,8 @@ const uploadMetadataSchema = z.object({
 const prepareResponseSchema = uploadMetadataSchema.extend({
   /** Presigned PUT URL — browser uploads the file body here directly. */
   uploadUrl: z.string().url(),
+  /** Headers the client must include with the presigned PUT request. */
+  uploadHeaders: z.record(z.string(), z.string()).optional(),
 });
 
 const multipartUploadPartSchema = z.object({

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -141,6 +141,7 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.Artifacts]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ArtifactKeyV2]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.HostedArtifactVersions]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ImageStyleR2]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
@@ -177,6 +178,7 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.Artifacts]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.ArtifactKeyV2]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ImageStyleR2]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -141,7 +141,7 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.Artifacts]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ArtifactKeyV2]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ArtifactKeyV2]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.HostedArtifactVersions]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ImageStyleR2]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -74,6 +74,7 @@ export enum FeatureSwitchKey {
   FeishuIntegration = "feishuIntegration",
   StrapiIntegration = "strapiIntegration",
   Artifacts = "artifacts",
+  ArtifactKeyV2 = "artifactKeyV2",
   HostedArtifactVersions = "hostedArtifactVersions",
   VideoArtifactPosters = "videoArtifactPosters",
   ImageStyleR2 = "imageStyleR2",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -443,7 +443,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Store new user artifacts under flat, ten-character hashed public keys.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.HostedArtifactVersions]: {
     maintainer: "yuma@vm0.ai",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -443,6 +443,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Store new user artifacts under flat, ten-character hashed public keys.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.HostedArtifactVersions]: {
     maintainer: "yuma@vm0.ai",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -438,6 +438,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Show the Artifacts manage page for generated artifacts in the current organization.",
     enabled: true,
   },
+  [FeatureSwitchKey.ArtifactKeyV2]: {
+    maintainer: "yuma@vm0.ai",
+    description:
+      "Store new user artifacts under flat, ten-character hashed public keys.",
+    enabled: false,
+  },
   [FeatureSwitchKey.HostedArtifactVersions]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add the org-scoped `artifactKeyV2` switch and generate flat artifact URLs with 10-character lowercase base36 hashes
- retry key allocation up to five times on collisions and preserve the original filename, artifact ID, and owner in R2 object metadata
- migrate artifact uploads, generated media, canonical assets, previews, and posters while keeping all ID-based readers compatible with both v1 and v2 keys

## Rollout and compatibility

- the switch defaults to on for staff organizations and off elsewhere, and can be overridden per organization
- new writes follow the current switch value; reads always resolve both v2 flat keys and legacy nested keys
- preview and poster variants include their versioned filename in the hash seed so immutable-cache behavior remains intact
- no database migration or CLI/API contract change is required

## Validation

- `pnpm -F api check-types`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/core lint`
- changed-file Prettier, Oxlint, type-aware Oxlint, and ESLint checks
- `pnpm knip --workspace api`
- `pnpm knip --workspace @vm0/core`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (24 passed)
- targeted API integration suites were discovered locally, but suite setup skipped all 39 tests because PostgreSQL is unavailable; the PR pipeline will run them with services