### PR TITLE
test(runner): assert terminal refresh task cleanup

### DIFF
--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -1936,6 +1936,12 @@ mod tests {
             )
             .await
             .expect("valid refresh deadline should schedule");
+        let scheduled_task = {
+            let active_runs = harness.handle.core.inner.active_runs.lock().await;
+            active_runs[&run_id].refresh_tasks["github"]
+                .handle
+                .abort_handle()
+        };
 
         let (_, events) = capture_network_policy_events(harness.refresh_slack()).await;
 
@@ -1962,7 +1968,17 @@ mod tests {
             }),
             "terminal reconciliation should not emit the generic failure warning"
         );
-        captured_event(&events, "reconciled terminal run network policies");
+        assert_eq!(
+            captured_event(&events, "reconciled terminal run network policies").level,
+            tracing::Level::INFO
+        );
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !scheduled_task.is_finished() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("terminal reconciliation should stop scheduled refresh tasks");
 
         harness
             .handle


### PR DESCRIPTION
## Summary

- assert that terminal network-policy reconciliation actually stops an existing scheduled refresh task
- assert that expected terminal reconciliation remains an info-level event

## Scope

- test coverage only
- no production behavior or API contract changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-features provider::network_policy_refresh::tests`

Relates to #23891
