### PR TITLE
test(guest-agent): avoid real-time deadline wait

### DIFF
--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -7,8 +7,8 @@
 
 use super::process_group::ChildProcessGroup;
 use crate::error::AgentError;
-use guest_common::log_warn;
 use guest_common::telemetry::record_sandbox_op;
+use guest_common::{log_info, log_warn};
 use guest_contracts::diagnostics::{
     CliTerminationDiagnostic, CliTerminationReason as DiagnosticTerminationReason,
     CliTerminationSignal,
@@ -408,6 +408,10 @@ impl CliTerminationRuntime {
                 reason: TerminationReason::PostResult
             }
         ) {
+            log_info!(
+                LOG_TAG,
+                "Agent execution deadline reached during post-result SIGKILL grace; preserving accepted terminal result"
+            );
             return true;
         }
         if !matches!(

--- a/crates/guest-agent/tests/post_result_reap_execution_deadline.rs
+++ b/crates/guest-agent/tests/post_result_reap_execution_deadline.rs
@@ -22,13 +22,48 @@ async fn execution_deadline_preserves_post_result_sigkill_pending()
 
     let runtime = common::guest_runtime_from_process_env()?;
     let masker = guest_agent::masker::SecretMasker::from_raw("");
+    let execution_timeout = runtime
+        .config
+        .agent_execution_timeout
+        .expect("test config should set an execution timeout");
+    let execution_deadline_after_sigterm = execution_timeout
+        .checked_sub(runtime.config.post_result_sigterm_grace)
+        .expect("execution deadline should follow post-result SIGTERM");
+    let sigkill_deadline_after_execution = runtime
+        .config
+        .post_result_sigkill_grace
+        .checked_sub(execution_deadline_after_sigterm)
+        .expect("SIGKILL deadline should follow the execution deadline");
+    let checkpoints = [
+        common::VirtualTimeCheckpoint {
+            file: runtime.paths.agent_log_file(),
+            needle: common::MOCK_TERMINATION_READY_EVENT,
+            advance: runtime.config.post_result_sigterm_grace,
+        },
+        common::VirtualTimeCheckpoint {
+            file: runtime.paths.system_log_file(),
+            needle: "Post-result cleanup quiet_timeout reached",
+            advance: execution_deadline_after_sigterm,
+        },
+        common::VirtualTimeCheckpoint {
+            file: runtime.paths.system_log_file(),
+            needle: "Agent execution deadline reached during post-result SIGKILL grace",
+            advance: sigkill_deadline_after_execution,
+        },
+    ];
 
+    // Each checkpoint proves the preceding state transition before virtual
+    // time reaches the next deadline. Keep the outer timeout as a real
+    // subprocess/reaping regression bound.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+        common::execute_with_virtual_time_checkpoints(
+            common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+            &checkpoints,
+        ),
     )
     .await
-    .expect("post-result reaper did not finish within its bounded grace")?;
+    .expect("post-result reaper did not finish within its bounded grace")??;
 
     assert_eq!(result.exit_code, common::SIGKILL_EXIT);
     assert!(


### PR DESCRIPTION
## Summary

- emit an informational checkpoint when the execution deadline preserves an accepted result during post-result SIGKILL grace
- drive the real SIGTERM-deaf subprocess test through result, SIGTERM, execution-deadline, and SIGKILL checkpoints with virtual time
- reduce warm focused runtime from 9.01 seconds to approximately 0.01–0.02 seconds while retaining exit code 137 and all termination diagnostics

## Scope

This does not change production deadlines, cleanup state transitions, runtime configuration, process signals, telemetry, result classification, or return values. There are no API, schema, persistence, protocol, migration, or rollout changes.

## Validation

- `cargo test -p guest-agent --test post_result_reap_execution_deadline -- --nocapture`
- focused test repeated 10 additional times
- `cargo test -p guest-agent`
- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-agent --all-features --no-deps`

Closes #23928
