### PR TITLE
refactor(api): move runner run creation to test route

### DIFF
--- a/e2e/helpers/run-fixtures.bash
+++ b/e2e/helpers/run-fixtures.bash
@@ -43,7 +43,7 @@ create_run_fixture() {
 
     local request_json="$1" response
     _validate_run_fixture_json "run fixture request" "$request_json" || return 1
-    response="$(e2e_api_curl "/api/agent/runs" -X POST --data-binary "$request_json")" || return 1
+    response="$(e2e_api_curl "/api/test/agent-runs" -X POST --data-binary "$request_json")" || return 1
     jq -e '
         (.runId | type == "string" and length > 0)
         and (.sessionId | type == "string" and length > 0)

--- a/turbo/apps/api/src/signals/e2e-routes.ts
+++ b/turbo/apps/api/src/signals/e2e-routes.ts
@@ -1,5 +1,6 @@
 import type { RouteEntry } from "./route-entry";
 import { cliAuthTestRoutes } from "./routes/cli-auth-test";
+import { testAgentRunsRoutes } from "./routes/test-agent-runs";
 import { testOAuthProviderAuthorizeRoutes } from "./routes/test-oauth-provider-authorize";
 import { testOAuthProviderDeviceAuthRoutes } from "./routes/test-oauth-provider-device-auth";
 import { testOAuthProviderEchoRoutes } from "./routes/test-oauth-provider-echo";
@@ -24,6 +25,8 @@ import { testZeroAgentStateRoutes } from "./routes/test-zero-agent-state";
  *
  * - `cli-auth-test`: E2E account/token/connector provisioning used by the
  *   deploy workflow (`Generate E2E test tokens`) and `e2e/` suites.
+ * - `test-agent-runs`: direct run creation used by the runner E2E suite after
+ *   the public agent run creation endpoint was retired.
  * - `test-oauth-provider-*`: the synthetic OAuth provider backing the
  *   `test-oauth`/`test-oauth-device` connectors in `packages/connectors`.
  * - `test-slack-mock` / `test-telegram-mock` / `test-teams-mock`: provider
@@ -43,6 +46,7 @@ import { testZeroAgentStateRoutes } from "./routes/test-zero-agent-state";
  */
 export const E2E_ROUTES: readonly RouteEntry[] = [
   ...cliAuthTestRoutes,
+  ...testAgentRunsRoutes,
   ...testOAuthProviderAuthorizeRoutes,
   ...testOAuthProviderDeviceAuthRoutes,
   ...testOAuthProviderEchoRoutes,

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -5,7 +5,6 @@ import { agentComposesByIdRoutes } from "./routes/agent-composes-id";
 import { agentComposesReadRoutes } from "./routes/agent-composes-read";
 import { agentComposesRoutes } from "./routes/agent-composes";
 import { agentRunsCancelRoutes } from "./routes/agent-runs-cancel";
-import { agentRunsCreateRoutes } from "./routes/agent-runs-create";
 import { agentRunsReadRoutes } from "./routes/agent-runs-read";
 import { agentRunTelemetryRoutes } from "./routes/agent-run-telemetry";
 import { agentSessionsRoutes } from "./routes/agent-sessions-id";
@@ -237,7 +236,6 @@ export const ROUTES: readonly RouteEntry[] = [
   ...agentComposesReadRoutes,
   ...agentComposesByIdRoutes,
   ...agentComposesRoutes,
-  ...agentRunsCreateRoutes,
   ...agentRunsCancelRoutes,
   ...agentRunsReadRoutes,
   ...agentRunTelemetryRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-run-reads.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-run-reads.ts
@@ -110,12 +110,14 @@ function authenticateTestAgentRun(
   };
 }
 
-export function createRunReadsApi(context: TestContext) {
-  const directRunApp = setupAppWithRoutes({
+function directRunApp(context: TestContext) {
+  return setupAppWithRoutes({
     context,
     routes: testAgentRunsRoutes,
   });
+}
 
+export function createRunReadsApi(context: TestContext) {
   return {
     async requestCreateDirectRun<
       TStatus extends 201 | 400 | 401 | 403 | 404 | 429,
@@ -125,7 +127,7 @@ export function createRunReadsApi(context: TestContext) {
       statuses: readonly TStatus[],
     ) {
       return await accept(
-        directRunApp(testAgentRunsContract).create({
+        directRunApp(context)(testAgentRunsContract).create({
           headers: authenticateTestAgentRun(context, actor),
           body,
         }),

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-run-reads.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-run-reads.ts
@@ -7,6 +7,7 @@ import {
   runsMainContract,
   runSystemLogContract,
 } from "@vm0/api-contracts/contracts/runs";
+import { testAgentRunsContract } from "@vm0/api-contracts/contracts/test-agent-runs";
 import { sessionsByIdContract } from "@vm0/api-contracts/contracts/sessions";
 import {
   logsByIdContract,
@@ -19,16 +20,25 @@ import {
 } from "@vm0/api-contracts/contracts/zero-runs";
 
 import { createApp } from "../../../../app-factory";
+import { createAppWithRoutes } from "../../../../app-factory-core";
 import {
   accept,
   setupApp,
   type TestContext,
 } from "../../../../__tests__/test-helpers";
+import { setupAppWithRoutes } from "../../../../__tests__/test-app";
+import { mockOptionalEnv } from "../../../../lib/env";
+import { testAgentRunsRoutes } from "../../test-agent-runs";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
 
-type AuthHeaders = { readonly authorization?: string };
-type DirectRunRequest = z.input<(typeof runsMainContract.create)["body"]>;
+const TEST_ENDPOINT_BYPASS_SECRET = "bdd-test-endpoint-bypass";
+
+type AuthHeaders = {
+  readonly authorization?: string;
+  readonly "x-vm0-test-endpoint-bypass"?: string;
+};
+type DirectRunRequest = z.input<(typeof testAgentRunsContract.create)["body"]>;
 type RunsListQuery = z.input<(typeof runsMainContract.list)["query"]>;
 type RunEventsQuery = z.input<(typeof runEventsContract.getEvents)["query"]>;
 type PagedTelemetryQuery = z.input<
@@ -86,7 +96,26 @@ function authenticate(
   return { authorization: "Bearer clerk-session" };
 }
 
+function authenticateTestAgentRun(
+  context: TestContext,
+  actor: ApiTestUser | null,
+): AuthHeaders {
+  mockOptionalEnv(
+    "VERCEL_AUTOMATION_BYPASS_SECRET",
+    TEST_ENDPOINT_BYPASS_SECRET,
+  );
+  return {
+    ...authenticate(context, actor),
+    "x-vm0-test-endpoint-bypass": TEST_ENDPOINT_BYPASS_SECRET,
+  };
+}
+
 export function createRunReadsApi(context: TestContext) {
+  const directRunApp = setupAppWithRoutes({
+    context,
+    routes: testAgentRunsRoutes,
+  });
+
   return {
     async requestCreateDirectRun<
       TStatus extends 201 | 400 | 401 | 403 | 404 | 429,
@@ -96,8 +125,8 @@ export function createRunReadsApi(context: TestContext) {
       statuses: readonly TStatus[],
     ) {
       return await accept(
-        setupApp({ context })(runsMainContract).create({
-          headers: authenticate(context, actor),
+        directRunApp(testAgentRunsContract).create({
+          headers: authenticateTestAgentRun(context, actor),
           body,
         }),
         statuses,
@@ -399,8 +428,11 @@ export function createRunReadsApi(context: TestContext) {
       body: unknown,
     ): Promise<{ readonly status: number; readonly body: unknown }> {
       const { authorization } = authenticate(context, actor);
-      const app = createApp({ signal: context.signal });
-      const response = await app.request("/api/agent/runs", {
+      const app = createAppWithRoutes({
+        signal: context.signal,
+        routes: testAgentRunsRoutes,
+      });
+      const response = await app.request("/api/test/agent-runs", {
         method: "POST",
         headers: {
           "content-type": "application/json",

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -12,6 +12,7 @@ import {
   type ZeroCapability,
 } from "@vm0/api-contracts/contracts/composes";
 import { runsMainContract } from "@vm0/api-contracts/contracts/runs";
+import { testAgentRunsContract } from "@vm0/api-contracts/contracts/test-agent-runs";
 import { webhookStripeContract } from "@vm0/api-contracts/contracts/webhooks";
 import { zeroBillingStatusContract } from "@vm0/api-contracts/contracts/zero-billing";
 import {
@@ -61,7 +62,6 @@ import {
 import { mockStripeClient } from "../../../external/stripe-client";
 import { agentComposesReadRoutes } from "../../agent-composes-read";
 import { agentComposesRoutes } from "../../agent-composes";
-import { agentRunsCreateRoutes } from "../../agent-runs-create";
 import { agentRunsReadRoutes } from "../../agent-runs-read";
 import { cliAuthRoutes } from "../../cli-auth";
 import { cronAggregateInsightsRoutes } from "../../cron-aggregate-insights";
@@ -83,12 +83,13 @@ import {
   zeroRunFixtureRoutes,
 } from "../../test-zero-run-fixture";
 import { zeroUserPermissionGrantsRoutes } from "../../zero-user-permission-grants";
+import { testAgentRunsRoutes } from "../../test-agent-runs";
 import { createBddApi, type ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
 
 type AuthHeaders = { readonly authorization?: string };
 type ZeroRunRequest = z.infer<typeof zeroRunCreateBodySchema>;
-type DirectRunRequest = z.infer<(typeof runsMainContract.create)["body"]>;
+type DirectRunRequest = z.infer<(typeof testAgentRunsContract.create)["body"]>;
 type RunsListQuery = z.input<(typeof runsMainContract.list)["query"]>;
 type RunnerJobClaimRequest = z.infer<
   (typeof runnersJobClaimContract.claim)["body"]
@@ -157,7 +158,7 @@ const runRoutes = [
   ...cronReconcileBillingEntitlementsRoutes,
   ...cronTelegramCleanupRoutes,
   ...runnersRoutes,
-  ...agentRunsCreateRoutes,
+  ...testAgentRunsRoutes,
   ...agentRunsReadRoutes,
   ...webhooksStripeRoutes,
   ...zeroBillingStatusRoutes,
@@ -663,7 +664,7 @@ export function createRunsApi(context: TestContext) {
 
     async createDirectRun(actor: ApiTestUser, body: DirectRunRequest) {
       const response = await accept(
-        runApp(context)(runsMainContract).create({
+        runApp(context)(testAgentRunsContract).create({
           headers: authenticate(context, actor),
           body,
         }),
@@ -678,7 +679,7 @@ export function createRunsApi(context: TestContext) {
       statuses: readonly (201 | 400 | 401 | 402 | 403 | 404 | 429 | 503)[],
     ) {
       return await accept(
-        runApp(context)(runsMainContract).create({
+        runApp(context)(testAgentRunsContract).create({
           headers: authenticate(context, actor),
           body,
         }),

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -9,7 +9,7 @@ import {
 import { delay } from "signal-timers";
 import { describe, expect, it } from "vitest";
 
-import { mockEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-context";
 import {
@@ -35,8 +35,8 @@ import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
  * end in those reads (session continuation, memory root policies, volume
  * pinning, concurrency caps, and the production capture gate).
  *
- * All state is constructed through public APIs: direct runs via compose
- * create + POST /api/agent/runs, runner claims, and sandbox webhooks
+ * All state is constructed through route boundaries: direct runs via compose
+ * create plus the gated E2E test route, runner claims, and sandbox webhooks
  * (events/checkpoint/complete). Axiom reads are answered by an
  * APL-dispatching mock so the run-event visibility poll is never left
  * unanswered (an unanswered poll burns its 2s timeout per read).
@@ -1583,6 +1583,7 @@ describe("RUN-01: direct run admission boundaries", () => {
     await api.requestCancelRun(actor, second.runId, [200]);
 
     mockEnv("ENV", "production");
+    mockOptionalEnv("VERCEL_ENV", "preview");
     const uncachedGate = await reads.requestCreateDirectRun(
       actor,
       {

--- a/turbo/apps/api/src/signals/routes/__tests__/test-agent-runs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-agent-runs.test.ts
@@ -1,0 +1,125 @@
+import { randomUUID } from "node:crypto";
+
+import { testAgentRunsContract } from "@vm0/api-contracts/contracts/test-agent-runs";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { generateSandboxToken } from "../../auth/tokens";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const bdd = createBddApi(context);
+const runs = createRunsApi(context);
+const mocks = createZeroRouteMocks(context);
+
+function client() {
+  return setupApp({ context })(testAgentRunsContract);
+}
+
+function authenticate(actor: ApiTestUser): {
+  readonly authorization: string;
+} {
+  mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+  return { authorization: "Bearer clerk-session" };
+}
+
+async function seedDirectRunActor(): Promise<{
+  readonly actor: ApiTestUser;
+  readonly composeId: string;
+}> {
+  const actor = bdd.user();
+  bdd.acceptAgentStorageWrites();
+  runs.acceptStorageDownloads();
+  runs.acceptTelemetryIngest();
+  runs.configureRunnerGroup();
+  await runs.grantProEntitlement(actor);
+
+  const name = `test-agent-runs-${randomUUID().slice(0, 8)}`;
+  const compose = await runs.createCompose(actor, {
+    version: "1",
+    agents: {
+      [name]: {
+        framework: "claude-code",
+        environment: { ANTHROPIC_API_KEY: "bdd-inline-key" },
+      },
+    },
+  });
+
+  return { actor, composeId: compose.composeId };
+}
+
+describe("POST /api/test/agent-runs", () => {
+  it("creates a direct run when the test endpoint is allowed", async () => {
+    mockEnv("ENV", "development");
+    const { actor, composeId } = await seedDirectRunActor();
+
+    const response = await accept(
+      client().create({
+        headers: authenticate(actor),
+        body: {
+          agentComposeId: composeId,
+          prompt: "create a runner E2E fixture",
+        },
+      }),
+      [201],
+    );
+
+    expect(response.body).toMatchObject({
+      runId: expect.any(String),
+      sessionId: expect.any(String),
+      status: expect.stringMatching(
+        /^(queued|pending|running|completed|failed|timeout|cancelled)$/,
+      ),
+    });
+
+    await expect(
+      runs.readRun(actor, response.body.runId),
+    ).resolves.toMatchObject({
+      runId: response.body.runId,
+      prompt: "create a runner E2E fixture",
+    });
+
+    await runs.requestCancelRun(actor, response.body.runId, [200]);
+  });
+
+  it("returns 404 when the test endpoint is not allowed", async () => {
+    mockEnv("ENV", "production");
+    const actor = bdd.user();
+
+    const response = await accept(
+      client().create({
+        headers: authenticate(actor),
+        body: { prompt: "production must not create a run" },
+      }),
+      [404],
+    );
+
+    expect(response.body).toBe("Not found");
+  });
+
+  it("rejects a sandbox token", async () => {
+    mockEnv("ENV", "development");
+    const actor = bdd.user();
+    if (!actor.orgId) {
+      throw new Error("Expected an organization-scoped test actor");
+    }
+    const token = generateSandboxToken(actor.userId, randomUUID(), actor.orgId);
+
+    const response = await accept(
+      client().create({
+        headers: { authorization: `Bearer ${token}` },
+        body: { prompt: "sandbox tokens cannot create runs" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "This endpoint is not available for sandbox tokens",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/test-agent-runs.ts
+++ b/turbo/apps/api/src/signals/routes/test-agent-runs.ts
@@ -1,15 +1,20 @@
 import { command } from "ccstate";
-import { runsMainContract } from "@vm0/api-contracts/contracts/runs";
+import { testAgentRunsContract } from "@vm0/api-contracts/contracts/test-agent-runs";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import { now } from "../external/time";
 import { createAgentRun$ } from "../services/agent-run-create.service";
 import { ApiDispatchTimingCollector } from "../services/api-dispatch-timing.service";
 import type { RouteEntry } from "../route-entry";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
 
-const createRunBody$ = bodyResultOf(runsMainContract.create);
+const createRunBody$ = bodyResultOf(testAgentRunsContract.create);
 
 const createRunInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const apiStartTime = now();
@@ -45,16 +50,17 @@ const createRunInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return await set(createAgentRun$, args, signal);
 });
 
-export const agentRunsCreateRoutes: readonly RouteEntry[] = [
+const createRun$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!isTestEndpointAllowed(get(request$))) {
+    return testEndpointNotFoundResponse();
+  }
+
+  return await set(createRunInner$, signal);
+});
+
+export const testAgentRunsRoutes: readonly RouteEntry[] = [
   {
-    route: runsMainContract.create,
-    handler: authRoute(
-      {
-        acceptAnySandboxCapability: true,
-        requireOrganization: true,
-        missingOrganizationStatus: 401,
-      },
-      createRunInner$,
-    ),
+    route: testAgentRunsContract.create,
+    handler: authRoute({ requireOrganization: true }, createRun$),
   },
 ];

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -156,6 +156,10 @@ export {
   type QueueResponse,
 } from "./runs";
 export {
+  testAgentRunsContract,
+  type TestAgentRunsContract,
+} from "./test-agent-runs";
+export {
   zeroModelPoliciesMainContract,
   type ZeroModelPoliciesMainContract,
 } from "./zero-model-policies";

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -266,7 +266,7 @@ const runsListResponseSchema = z.object({
 
 /**
  * Runs main route contract (/api/agent/runs)
- * Handles GET list and POST create
+ * Handles GET list
  */
 export const runsMainContract = c.router({
   /**
@@ -291,28 +291,6 @@ export const runsMainContract = c.router({
       403: apiErrorSchema,
     },
     summary: "List agent runs",
-  },
-  /**
-   * POST /api/agent/runs
-   * Create and execute a new agent run
-   */
-  create: {
-    method: "POST",
-    path: "/api/agent/runs",
-    headers: authHeadersSchema,
-    body: unifiedRunRequestSchema,
-    responses: {
-      201: createRunResponseSchema,
-      400: apiErrorSchema,
-      401: apiErrorSchema,
-      402: apiErrorSchema,
-      403: apiErrorSchema,
-      404: apiErrorSchema,
-      429: apiErrorSchema,
-      422: apiErrorSchema,
-      503: apiErrorSchema,
-    },
-    summary: "Create and execute agent run",
   },
 });
 

--- a/turbo/packages/api-contracts/src/contracts/test-agent-runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-agent-runs.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import { createRunResponseSchema, unifiedRunRequestSchema } from "./runs";
+
+const c = initContract();
+
+export const testAgentRunsContract = c.router({
+  create: {
+    method: "POST",
+    path: "/api/test/agent-runs",
+    headers: authHeadersSchema,
+    body: unifiedRunRequestSchema,
+    responses: {
+      201: createRunResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      402: apiErrorSchema,
+      403: apiErrorSchema,
+      404: z.union([apiErrorSchema, z.string()]),
+      429: apiErrorSchema,
+      422: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Create an agent run for end-to-end tests",
+  },
+});
+
+export type TestAgentRunsContract = typeof testAgentRunsContract;


### PR DESCRIPTION
## Summary

- replace the public `POST /api/agent/runs` contract and route with gated `POST /api/test/agent-runs`
- register direct run creation only through the E2E route table and reject sandbox tokens
- update the runner E2E fixture plus route-level coverage for allowed, production-hidden, and sandbox-denied behavior
- intentionally leave `triggerSource` unset so the existing `cli` fallback remains rolling-deployment compatible until Phase 2

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-agent-runs.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts -t 'lists, reads, and queues direct runs with status, agent, and window filters' --maxWorkers=1 --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts -t 'enforces direct-run concurrency, caps, and the production capture gate' --maxWorkers=1 --silent=passed-only`
- `bash -n e2e/helpers/run-fixtures.bash`

Closes #23990