### PR TITLE
test(e2e): stabilize default browser profile check

### DIFF
--- a/e2e/tests/03-runner/t45-vm0-profile.bats
+++ b/e2e/tests/03-runner/t45-vm0-profile.bats
@@ -64,9 +64,9 @@ EOF
     assert_success
 
     run run_compose_fixture "$AGENT_NAME" \
-        "agent-browser open https://github.com && agent-browser get title | grep -Fq GitHub && agent-browser close" \
+        "agent-browser open 'data:text/html,%3Ctitle%3EVM0%20Browser%20E2E%3C%2Ftitle%3E' && agent-browser get title && agent-browser close" \
         "$(jq -nc --arg name "$ARTIFACT_NAME" \
             '{artifacts: [{name: $name, mountPath: "/home/user/workspace"}]}')"
     assert_success
-    assert_output --partial "https://github.com/"
+    assert_output --partial "VM0 Browser E2E"
 }


### PR DESCRIPTION
## Trigger

- Exact Turbo run: [30526426352 attempt 1](https://github.com/vm0-ai/vm0/actions/runs/30526426352)
- Event: `merge_group` at `a7b9243aefba16e99e076244fc506a8bba19991f`
- First failing job: [cli-e2e-03-runner shard 6](https://github.com/vm0-ai/vm0/actions/runs/30526426352/job/90819624291)
- Failing test: `direct run with default profile has agent-browser and chromium` in `e2e/tests/03-runner/t45-vm0-profile.bats`

## Root cause

The first causal failure was `agent-browser open https://github.com` timing out. The test used a public GitHub page to verify the default browser profile, so transient external network or page-load latency could fail an otherwise healthy runner. The aggregate `ci-gate-turbo` failure was downstream only.

This is an E2E test dependency flake, not a deterministic regression from queued PR #23984. That PR changed only `crates/guest-agent/tests/event_delivery_drain_timeout.rs`, which is unrelated to the browser-profile fixture.

Intermittency evidence:

- The same test passed in the pull-request run in 10.322 seconds.
- Three adjacent merge-group executions passed in 9.417, 10.068, and 13.680 seconds.
- The requeued merge group for the same PR passed in 9.505 seconds.
- The exact triggering run has no second attempt.

## Fix

Use an inline `data:text/html` page with a deterministic title instead of loading `https://github.com`. The test still exercises the real `agent-browser` binary end to end: it launches Chromium, navigates, reads the title, and closes the browser, while removing the unrelated external dependency.

## Validation

- Exact local `agent-browser` open/get-title/close sequence: 5/5 passes
- BATS discovery: `2` tests parsed from `t45-vm0-profile.bats`
- `pnpm format`: passed
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm turbo run lint --concurrency=1 --log-order grouped`: passed
- `pnpm knip`: passed with existing configuration hints only
- Non-API/platform package type checks: passed, 10/10 tasks
- Platform type checks: passed
- API type checks: passed

The deployed `run_compose_fixture` BATS case was not run locally because `E2E_API_TOKEN` and `E2E_API_URL` are unavailable in this environment. The PR pipeline will execute that coverage.