### PR TITLE
fix(chat): expand mobile composer for two-line placeholder

### DIFF
--- a/e2e/playwright/tests/webchat.spec.ts
+++ b/e2e/playwright/tests/webchat.spec.ts
@@ -47,7 +47,7 @@ test("send a chat message, cap long drafts, and preserve template height", async
   });
 
   // The completed run leaves us on a chat-thread composer, whose responsive
-  // minimum height is compact on mobile and three lines on desktop.
+  // minimum height is two lines on mobile and three lines on desktop.
   await expect.poll(() => elementHeight(composer)).toBe(96);
 
   const longDraft = Array.from(
@@ -87,8 +87,8 @@ test("send a chat message, cap long drafts, and preserve template height", async
   await expect.poll(() => elementHeight(composer)).toBe(134);
 
   await page.setViewportSize({ width: 390, height: 844 });
-  await expect.poll(() => elementHeight(composer)).toBe(82);
+  await expect.poll(() => elementHeight(composer)).toBe(106);
 
   await page.getByRole("button", { name: /^Remove template / }).click();
-  await expect.poll(() => elementHeight(composer)).toBe(44);
+  await expect.poll(() => elementHeight(composer)).toBe(68);
 });

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -150,7 +150,7 @@ const EDITOR_CONTENT_CLASS =
 
 function editorContentClass(singleLineOnMobile: boolean): string {
   return singleLineOnMobile
-    ? `${EDITOR_CONTENT_CLASS} min-h-[44px] md:min-h-[96px]`
+    ? `${EDITOR_CONTENT_CLASS} min-h-[68px] md:min-h-[96px]`
     : `${EDITOR_CONTENT_CLASS} min-h-[96px]`;
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -89,10 +89,10 @@ describe("chat composer models", () => {
 
     const editor = await findComposerEditor();
     expect(editor).toHaveClass("min-h-[96px]");
-    expect(editor).not.toHaveClass("min-h-[44px]");
+    expect(editor).not.toHaveClass("min-h-[68px]");
   });
 
-  it("uses the mobile single-line height in chat thread composers", async () => {
+  it("uses the mobile two-line height in chat thread composers", async () => {
     mockOrgModelRoutes("kimi-k2.7-code");
     mockAgent();
     mockThread();
@@ -103,7 +103,7 @@ describe("chat composer models", () => {
     });
 
     const editor = await findComposerEditor();
-    expect(editor).toHaveClass("min-h-[44px]", "md:min-h-[96px]");
+    expect(editor).toHaveClass("min-h-[68px]", "md:min-h-[96px]");
   });
 
   it("keeps the agent chat slash composer at three-line height", async () => {
@@ -120,10 +120,10 @@ describe("chat composer models", () => {
 
     const editor = await findComposerEditor();
     expect(editor).toHaveClass("min-h-[96px]");
-    expect(editor).not.toHaveClass("min-h-[44px]");
+    expect(editor).not.toHaveClass("min-h-[68px]");
   });
 
-  it("uses the mobile single-line height in chat thread slash composers", async () => {
+  it("uses the mobile two-line height in chat thread slash composers", async () => {
     mockOrgModelRoutes("kimi-k2.7-code");
     mockAgent();
     mockThread();
@@ -137,7 +137,7 @@ describe("chat composer models", () => {
     });
 
     const editor = await findComposerEditor();
-    expect(editor).toHaveClass("min-h-[44px]", "md:min-h-[96px]");
+    expect(editor).toHaveClass("min-h-[68px]", "md:min-h-[96px]");
   });
 
   it("positions the slash workflow menu from the caret inside the viewport safe area", async () => {

--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -478,10 +478,10 @@ export function TiptapWorkflowComposer({
           className={
             hasTemplateAttachment
               ? singleLineOnMobile
-                ? "min-h-[82px] md:min-h-[134px] [&_.ProseMirror]:min-h-[82px] md:[&_.ProseMirror]:min-h-[134px]"
+                ? "min-h-[106px] md:min-h-[134px] [&_.ProseMirror]:min-h-[106px] md:[&_.ProseMirror]:min-h-[134px]"
                 : "min-h-[134px] [&_.ProseMirror]:min-h-[134px]"
               : singleLineOnMobile
-                ? "min-h-[44px] md:min-h-[96px]"
+                ? "min-h-[68px] md:min-h-[96px]"
                 : "min-h-[96px]"
           }
           ref={setContainerRef}


### PR DESCRIPTION
## Summary

- increase the compact mobile chat composer minimum height from 44px to 68px so the existing 24px placeholder line height can render two lines without overlapping the toolbar
- preserve the existing desktop heights and add the same extra line of space when a template attachment is present
- update the page-level and Playwright height assertions for the responsive behavior

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm knip`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx` (23 tests passed)

Browser verification was not run because the repository instructions prohibit starting the local dev server unless explicitly requested. The updated Playwright assertions will verify the exact mobile heights in CI.


Fixes #23366