### PR TITLE
docs(python): correct mathematical final sigma test label

### DIFF
--- a/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority.py
@@ -331,7 +331,7 @@ class TestTrustedAuthoritySuccess:
                 "xn--4xa.example",
                 "xn--4xa.example",
                 "https://xn--4xa.example/repos",
-                id="math-bold-small-beta",
+                id="math-bold-small-final-sigma",
             ),
             pytest.param(
                 "a\u0754.example",


### PR DESCRIPTION
## Summary

- rename the U+1D6D3 trusted-authority pytest case to `math-bold-small-final-sigma`
- preserve the Unicode input, expected A-label, normalized URL, and runtime behavior

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest --collect-only -q 'tests/test_url_utils_trusted_authority.py::TestTrustedAuthoritySuccess::test_accepts_authority_host_normalization_equivalence[math-bold-small-final-sigma]'`
- `uv run --no-sync python -m pytest -q 'tests/test_url_utils_trusted_authority.py::TestTrustedAuthoritySuccess::test_accepts_authority_host_normalization_equivalence[math-bold-small-final-sigma]'`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4454 passed)

Closes #23955
