### PR TITLE
fix(api): reject redirected axiom ingestion

### DIFF
--- a/turbo/apps/api/src/signals/external/axiom.ts
+++ b/turbo/apps/api/src/signals/external/axiom.ts
@@ -157,6 +157,7 @@ export async function ingestAxiomDirect(
 
   const response = await fetch(axiomIngestUrl(dataset), {
     method: "POST",
+    redirect: "error",
     headers: {
       accept: "application/json",
       authorization: `Bearer ${token}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1213,6 +1213,31 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
     expect(context.mocks.ably.publish.mock.calls).toHaveLength(
       optionalPublishCount,
     );
+
+    const redirectTarget =
+      "https://api.axiom.co/v1/datasets/redirected-agent-run-events/ingest";
+    let redirectTargetRequests = 0;
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/agent-run-events/ingest",
+        () => {
+          return new HttpResponse(null, {
+            headers: { location: redirectTarget },
+            status: 307,
+          });
+        },
+      ),
+      http.post(redirectTarget, () => {
+        redirectTargetRequests += 1;
+        return HttpResponse.json(
+          successfulAxiomIngestStatus(body.events.length),
+        );
+      }),
+    );
+    const redirected = await api.requestAgentEvents(body, headers, [503]);
+    expectApiError(redirected.body);
+    expect(redirected.body.error.code).toBe("EVENT_DELIVERY_UNAVAILABLE");
+    expect(redirectTargetRequests).toBe(0);
   });
 
   it("rejects malformed and partial direct Axiom statuses", async () => {


### PR DESCRIPTION
## Summary

- reject redirects during request-local Axiom event ingestion
- verify a redirect is returned as `EVENT_DELIVERY_UNAVAILABLE` without issuing a second POST

## Rationale

The direct ingestion request introduced in #23971 must make exactly one transport attempt so the guest remains the sole retry owner. The default `fetch` redirect behavior could otherwise turn one API call into multiple POST requests and forward the bearer-authenticated request to the redirect target.

## Compatibility

- no schema or persisted-data changes
- no API contract, request payload, or response shape changes
- Axiom redirects now follow the existing required-delivery failure path and remain retryable by the guest

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts --maxWorkers=1 --silent=passed-only`
- pre-commit hooks, including repository type checks

Relates to #23904.

Follow-up to #23971.
