### PR TITLE
refactor(test-api): use slug fields in connector auth fixtures

### DIFF
--- a/e2e/tests/03-runner/t42-firewall-placeholder.bats
+++ b/e2e/tests/03-runner/t42-firewall-placeholder.bats
@@ -68,7 +68,7 @@ create_artifact() {
 
 # Helper to set up a test connector with a known token via API
 setup_test_connector() {
-    local connector_name="$1"
+    local connector_slug="$1"
     local access_token="$2"
     local auth_method="${3:-oauth}"
 
@@ -86,7 +86,7 @@ setup_test_connector() {
     if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
         curl_args+=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
     fi
-    curl_args+=(-d "{\"connectorName\":\"${connector_name}\",\"authMethod\":\"${auth_method}\",\"accessToken\":\"${access_token}\"}")
+    curl_args+=(-d "{\"connectorSlug\":\"${connector_slug}\",\"authMethod\":\"${auth_method}\",\"accessToken\":\"${access_token}\"}")
 
     local response
     response=$(curl "${curl_args[@]}" \

--- a/e2e/tests/03-runner/t53-test-oauth-connector.bats
+++ b/e2e/tests/03-runner/t53-test-oauth-connector.bats
@@ -105,7 +105,7 @@ enable_test_oauth_for_compose() {
 
     local body
     body=$(cat <<EOF
-{"composeId":"${compose_id}","connectorTypes":["test-oauth"]}
+{"composeId":"${compose_id}","connectorSlugs":["test-oauth"]}
 EOF
 )
 
@@ -188,7 +188,7 @@ seed_test_oauth_connector() {
         --arg refreshToken "$refresh_token" \
         --argjson expiresIn "$expires_in" \
         '{
-            connectorName: "test-oauth",
+            connectorSlug: "test-oauth",
             authMethod: "oauth",
             accessToken: $accessToken,
             refreshToken: $refreshToken,

--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
@@ -586,6 +586,15 @@ describe("CLI-TEST: test-enable-connector", () => {
       });
     }
 
+    const malformedSlugs = await authDevice.requestTestEnableConnector(
+      {},
+      { composeId: ZERO_COMPOSE_ID, connectorSlugs: ["not a connector slug"] },
+      [400],
+    );
+    expect(malformedSlugs.body).toStrictEqual({
+      error: "Unknown connector slugs: not a connector slug",
+    });
+
     const unknownSlugs = await authDevice.requestTestEnableConnector(
       {},
       { composeId: ZERO_COMPOSE_ID, connectorSlugs: ["not-a-real-connector"] },

--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
@@ -422,6 +422,15 @@ describe("CLI-TEST: test-connector", () => {
       error: "connectorSlug, authMethod, and accessToken are required",
     });
 
+    const malformedSlug = await authDevice.requestTestConnector(
+      {},
+      { ...githubOauthBody, connectorSlug: "not a connector slug" },
+      [400],
+    );
+    expect(malformedSlug.body).toStrictEqual({
+      error: 'Unknown connector slug: "not a connector slug"',
+    });
+
     const unknownSlug = await authDevice.requestTestConnector(
       {},
       { ...githubOauthBody, connectorSlug: "unknown-connector" },

--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
@@ -370,7 +370,7 @@ describe("CLI-TEST: test-token provisioning", () => {
     const seeded = await authDevice.requestTestConnector(
       { email: firstActor.email },
       {
-        connectorName: "github",
+        connectorSlug: "github",
         authMethod: "oauth",
         accessToken: "cached-identity-access-token",
       },
@@ -385,7 +385,7 @@ describe("CLI-TEST: test-token provisioning", () => {
 
 describe("CLI-TEST: test-connector", () => {
   const githubOauthBody = {
-    connectorName: "github",
+    connectorSlug: "github",
     authMethod: "oauth",
     accessToken: "github-access-token",
   } as const;
@@ -400,17 +400,17 @@ describe("CLI-TEST: test-connector", () => {
     expect(response.body).toBe("Not found");
   });
 
-  it("rejects malformed and unsupported connector seeds with legacy errors", async () => {
+  it("rejects malformed and unsupported connector seeds", async () => {
     const invalidJson = await authDevice.requestTestConnectorRaw("{ not json");
     expect(invalidJson.status).toBe(400);
     expect(invalidJson.body).toStrictEqual({ error: "Invalid JSON body" });
 
     const missingFields = await authDevice.requestTestConnectorRaw(
-      JSON.stringify({ connectorName: "github" }),
+      JSON.stringify({ connectorSlug: "github" }),
     );
     expect(missingFields.status).toBe(400);
     expect(missingFields.body).toStrictEqual({
-      error: "connectorName, authMethod, and accessToken are required",
+      error: "connectorSlug, authMethod, and accessToken are required",
     });
 
     const emptyRefreshToken = await authDevice.requestTestConnector(
@@ -419,16 +419,16 @@ describe("CLI-TEST: test-connector", () => {
       [400],
     );
     expect(emptyRefreshToken.body).toStrictEqual({
-      error: "connectorName, authMethod, and accessToken are required",
+      error: "connectorSlug, authMethod, and accessToken are required",
     });
 
-    const unknownType = await authDevice.requestTestConnector(
+    const unknownSlug = await authDevice.requestTestConnector(
       {},
-      { ...githubOauthBody, connectorName: "unknown-connector" },
+      { ...githubOauthBody, connectorSlug: "unknown-connector" },
       [400],
     );
-    expect(unknownType.body).toStrictEqual({
-      error: 'Unknown connector type: "unknown-connector"',
+    expect(unknownSlug.body).toStrictEqual({
+      error: 'Unknown connector slug: "unknown-connector"',
     });
 
     const freshActor = bdd.user();
@@ -448,7 +448,7 @@ describe("CLI-TEST: test-connector", () => {
     const wrongGrantKind = await authDevice.requestTestConnector(
       { email: actor.email },
       {
-        connectorName: "cloudinary",
+        connectorSlug: "cloudinary",
         authMethod: "api-token",
         accessToken: "cloudinary-access-token",
       },
@@ -479,7 +479,7 @@ describe("CLI-TEST: test-connector", () => {
     const seeded = await authDevice.requestTestConnector(
       { email: actor.email },
       {
-        connectorName: "test-oauth",
+        connectorSlug: "test-oauth",
         authMethod: "oauth",
         accessToken: "test-oauth-access-token",
         refreshToken: "test-oauth-refresh-token",
@@ -489,7 +489,7 @@ describe("CLI-TEST: test-connector", () => {
     );
     expect(seeded.body).toStrictEqual({
       ok: true,
-      connectorType: "test-oauth",
+      connectorSlug: "test-oauth",
       orgId: actor.orgId,
     });
 
@@ -506,7 +506,7 @@ describe("CLI-TEST: test-connector", () => {
     const reSeeded = await authDevice.requestTestConnector(
       { email: actor.email },
       {
-        connectorName: "test-oauth",
+        connectorSlug: "test-oauth",
         authMethod: "api",
         accessToken: "test-oauth-api-access-token",
         refreshToken: "test-oauth-api-refresh-token",
@@ -515,7 +515,7 @@ describe("CLI-TEST: test-connector", () => {
     );
     expect(reSeeded.body).toStrictEqual({
       ok: true,
-      connectorType: "test-oauth",
+      connectorSlug: "test-oauth",
       orgId: actor.orgId,
     });
     const apiState = await support.readConnectorBySlug(actor, "test-oauth");
@@ -551,13 +551,13 @@ describe("CLI-TEST: test-enable-connector", () => {
     mockEnv("ENV", "production");
     const response = await authDevice.requestTestEnableConnector(
       {},
-      { composeId: ZERO_COMPOSE_ID, connectorTypes: ["github"] },
+      { composeId: ZERO_COMPOSE_ID, connectorSlugs: ["github"] },
       [404],
     );
     expect(response.body).toBe("Not found");
   });
 
-  it("rejects malformed enable-connector requests with legacy errors", async () => {
+  it("rejects malformed enable-connector requests", async () => {
     const invalidJson =
       await authDevice.requestTestEnableConnectorRaw("{ not json");
     expect(invalidJson.status).toBe(400);
@@ -565,32 +565,32 @@ describe("CLI-TEST: test-enable-connector", () => {
 
     for (const rawBody of [
       {},
-      { composeId: "not-a-uuid", connectorTypes: ["github"] },
-      { composeId: ZERO_COMPOSE_ID, connectorTypes: [] },
+      { composeId: "not-a-uuid", connectorSlugs: ["github"] },
+      { composeId: ZERO_COMPOSE_ID, connectorSlugs: [] },
     ]) {
       const invalidBody = await authDevice.requestTestEnableConnectorRaw(
         JSON.stringify(rawBody),
       );
       expect(invalidBody.status).toBe(400);
       expect(invalidBody.body).toStrictEqual({
-        error: "composeId and connectorTypes are required",
+        error: "composeId and connectorSlugs are required",
       });
     }
 
-    const unknownTypes = await authDevice.requestTestEnableConnector(
+    const unknownSlugs = await authDevice.requestTestEnableConnector(
       {},
-      { composeId: ZERO_COMPOSE_ID, connectorTypes: ["not-a-real-connector"] },
+      { composeId: ZERO_COMPOSE_ID, connectorSlugs: ["not-a-real-connector"] },
       [400],
     );
-    expect(unknownTypes.body).toStrictEqual({
-      error: "Unknown connector types: not-a-real-connector",
+    expect(unknownSlugs.body).toStrictEqual({
+      error: "Unknown connector slugs: not-a-real-connector",
     });
 
     const freshActor = bdd.user();
     authDevice.seedClerkDirectory(freshActor);
     const noOrg = await authDevice.requestTestEnableConnector(
       { email: freshActor.email },
-      { composeId: ZERO_COMPOSE_ID, connectorTypes: ["github"] },
+      { composeId: ZERO_COMPOSE_ID, connectorSlugs: ["github"] },
       [400],
     );
     expect(noOrg.body).toStrictEqual({
@@ -601,7 +601,7 @@ describe("CLI-TEST: test-enable-connector", () => {
     await authDevice.provisionTestOrg(actor);
     const missingCompose = await authDevice.requestTestEnableConnector(
       { email: actor.email },
-      { composeId: ZERO_COMPOSE_ID, connectorTypes: ["github"] },
+      { composeId: ZERO_COMPOSE_ID, connectorSlugs: ["github"] },
       [404],
     );
     expect(missingCompose.body).toStrictEqual({
@@ -619,13 +619,13 @@ describe("CLI-TEST: test-enable-connector", () => {
 
     const enabled = await authDevice.requestTestEnableConnector(
       { email: actor.email },
-      { composeId: compose.composeId, connectorTypes: ["github", "slack"] },
+      { composeId: compose.composeId, connectorSlugs: ["github", "slack"] },
       [200],
     );
     expect(enabled.body).toStrictEqual({
       ok: true,
       composeId: compose.composeId,
-      connectorTypes: ["github", "slack"],
+      connectorSlugs: ["github", "slack"],
     });
 
     const agent = await bdd.readAgent(actor, compose.composeId);
@@ -646,7 +646,7 @@ describe("CLI-TEST: test-enable-connector", () => {
     });
     await authDevice.requestTestEnableConnector(
       { email: actor.email },
-      { composeId: publicAgent.agentId, connectorTypes: ["github"] },
+      { composeId: publicAgent.agentId, connectorSlugs: ["github"] },
       [200],
     );
     const updatedPublicAgent = await bdd.readAgent(actor, publicAgent.agentId);
@@ -659,7 +659,7 @@ describe("CLI-TEST: test-enable-connector", () => {
     );
     await authDevice.requestTestEnableConnector(
       { email: "custom@test.com" },
-      { composeId: customEmailCompose.composeId, connectorTypes: ["github"] },
+      { composeId: customEmailCompose.composeId, connectorSlugs: ["github"] },
       [200],
     );
     expect(context.mocks.clerk.users.getUserList).toHaveBeenCalledWith({
@@ -679,7 +679,7 @@ describe("CLI-TEST: test-enable-connector", () => {
     await authDevice.provisionTestOrg(other);
     const response = await authDevice.requestTestEnableConnector(
       { email: other.email },
-      { composeId: compose.composeId, connectorTypes: ["github"] },
+      { composeId: compose.composeId, connectorSlugs: ["github"] },
       [404],
     );
     expect(response.body).toStrictEqual({
@@ -701,13 +701,13 @@ describe("CLI-TEST: test-enable-connector", () => {
 
     const enabled = await authDevice.requestTestEnableConnector(
       { email: actor.email },
-      { composeId: compose.composeId, connectorTypes: ["github"] },
+      { composeId: compose.composeId, connectorSlugs: ["github"] },
       [200],
     );
     expect(enabled.body).toStrictEqual({
       ok: true,
       composeId: compose.composeId,
-      connectorTypes: ["github"],
+      connectorSlugs: ["github"],
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -2249,7 +2249,7 @@ describe("connector catalog valid lifecycle", () => {
     await firewall.provisionRunReadyOrg(actor);
     const callsBeforeSeed = context.mocks.s3.send.mock.calls.length;
     await firewall.seedTestConnector(actor, {
-      connectorName: "test-oauth-device",
+      connectorSlug: "test-oauth-device",
       authMethod: "oauth",
       accessToken: "catalog-cli-access-token",
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -5868,7 +5868,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
     await fw.seedTestConnector(actor, {
-      connectorName: "x",
+      connectorSlug: "x",
       authMethod: "oauth",
       accessToken: "x-bdd-unallowed-access",
       refreshToken: "x-bdd-unallowed-refresh",
@@ -5908,7 +5908,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const { actor, agentId, runnerGroup } = await zeroBackedDirectRunActor();
 
     await fw.seedTestConnector(actor, {
-      connectorName: "x",
+      connectorSlug: "x",
       authMethod: "oauth",
       accessToken: "x-bdd-direct-unallowed-access",
       refreshToken: "x-bdd-direct-unallowed-refresh",
@@ -5959,7 +5959,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     }
 
     await fw.seedTestConnector(actor, {
-      connectorName: "x",
+      connectorSlug: "x",
       authMethod: "oauth",
       accessToken: "x-bdd-version-unallowed-access",
       refreshToken: "x-bdd-version-unallowed-refresh",
@@ -6019,7 +6019,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const member = bdd.user({ orgId: actor.orgId, orgRole: "org:member" });
 
     await fw.seedTestConnector(actor, {
-      connectorName: "x",
+      connectorSlug: "x",
       authMethod: "oauth",
       accessToken: "x-bdd-public-owner-access",
       refreshToken: "x-bdd-public-owner-refresh",
@@ -6052,13 +6052,13 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
     await fw.seedTestConnector(actor, {
-      connectorName: "x",
+      connectorSlug: "x",
       authMethod: "oauth",
       accessToken: "x-bdd-access",
       refreshToken: "x-bdd-refresh",
     });
     await fw.seedTestConnector(actor, {
-      connectorName: "slack",
+      connectorSlug: "slack",
       authMethod: "oauth",
       accessToken: "xoxb-bdd-unenabled-access",
     });
@@ -6175,7 +6175,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     await api.grantProEntitlement(actor);
 
     await fw.seedTestConnector(actor, {
-      connectorName: "x",
+      connectorSlug: "x",
       authMethod: "oauth",
       accessToken: "x-bdd-overridden-access",
       refreshToken: "x-bdd-overridden-refresh",
@@ -6331,7 +6331,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     await api.grantProEntitlement(actor);
 
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "test-oauth-bdd-access",
       refreshToken: "test-oauth-bdd-refresh",
@@ -6380,7 +6380,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     await api.grantProEntitlement(actor);
 
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "incompatible-access",
       refreshToken: "incompatible-refresh",
@@ -6474,13 +6474,13 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const { actor, agentId, runnerGroup } = await zeroBackedDirectRunActor();
 
     await fw.seedTestConnector(actor, {
-      connectorName: "x",
+      connectorSlug: "x",
       authMethod: "oauth",
       accessToken: "x-bdd-direct-access",
       refreshToken: "x-bdd-direct-refresh",
     });
     await fw.seedTestConnector(actor, {
-      connectorName: "slack",
+      connectorSlug: "slack",
       authMethod: "oauth",
       accessToken: "xoxb-bdd-direct-unenabled-access",
     });
@@ -6586,7 +6586,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const { actor, agentId } = await entitledRunActor();
 
     await fw.seedTestConnector(actor, {
-      connectorName: "x",
+      connectorSlug: "x",
       authMethod: "oauth",
       accessToken: "x-bdd-lazy-access",
       refreshToken: "x-bdd-lazy-refresh",
@@ -6719,7 +6719,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     );
 
     await fw.seedTestConnector(actor, {
-      connectorName: "google-ads",
+      connectorSlug: "google-ads",
       authMethod: "oauth",
       accessToken: "google-ads-bdd-access",
       refreshToken: "google-ads-bdd-refresh",
@@ -6810,7 +6810,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     mockOptionalEnv("GOOGLE_ADS_DEVELOPER_TOKEN", "platform-developer-token");
 
     await fw.seedTestConnector(actor, {
-      connectorName: "google-ads",
+      connectorSlug: "google-ads",
       authMethod: "oauth",
       accessToken: "google-ads-bdd-access",
       refreshToken: "google-ads-bdd-refresh",
@@ -8161,7 +8161,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     const agentId = agent.agentId;
     await fw.seedTestConnector(actor, {
-      connectorName: "slack",
+      connectorSlug: "slack",
       authMethod: "oauth",
       accessToken: "xoxb-bdd-baseline",
     });
@@ -8250,7 +8250,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       displayName: "BDD permission baseline fallback agent",
     });
     await fw.seedTestConnector(actor, {
-      connectorName: "slack",
+      connectorSlug: "slack",
       authMethod: "oauth",
       accessToken: "xoxb-bdd-baseline-fallback",
     });
@@ -8320,7 +8320,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     const agentId = agent.agentId;
     await fw.seedTestConnector(actor, {
-      connectorName: "slack",
+      connectorSlug: "slack",
       authMethod: "oauth",
       accessToken: "xoxb-bdd-grants",
     });
@@ -8713,7 +8713,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
     await fw.seedTestConnector(actor, {
-      connectorName: "slack",
+      connectorSlug: "slack",
       authMethod: "oauth",
       accessToken: "xoxb-bdd-claim-response-timing",
     });
@@ -8857,7 +8857,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.grantProEntitlement(actor);
     await api.ensureOrgModelProvider(actor);
     await fw.seedTestConnector(actor, {
-      connectorName: "slack",
+      connectorSlug: "slack",
       authMethod: "oauth",
       accessToken: "xoxb-bdd-shared-version",
     });
@@ -8944,7 +8944,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     const agentId = agent.agentId;
     await fw.seedTestConnector(actor, {
-      connectorName: "cloudflare",
+      connectorSlug: "cloudflare",
       authMethod: "oauth",
       accessToken: "cloudflare-bdd-token",
     });
@@ -9000,7 +9000,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.grantProEntitlement(actor);
 
     await fw.seedTestConnector(actor, {
-      connectorName: "cloudflare",
+      connectorSlug: "cloudflare",
       authMethod: "oauth",
       accessToken: "cloudflare-direct-bdd-token",
     });
@@ -9086,7 +9086,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
       visibility: "private",
     });
     await fw.seedTestConnector(actor, {
-      connectorName: "slack",
+      connectorSlug: "slack",
       authMethod: "oauth",
       accessToken: "xoxb-bdd-context",
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -430,7 +430,7 @@ describe("FW-3: billable firewall lease", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "stale-access",
       refreshToken: "refresh-1",
@@ -627,7 +627,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "stale-access",
       refreshToken: "refresh-1",
@@ -672,7 +672,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "stale-access",
       refreshToken: "refresh-1",
@@ -708,7 +708,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "current-access",
       refreshToken: "refresh-1",
@@ -746,7 +746,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "db-access",
       refreshToken: "refresh-1",
@@ -847,7 +847,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "stale-access",
       refreshToken: "refresh-1",
@@ -913,7 +913,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "stale-access",
       refreshToken: "refresh-1",
@@ -980,7 +980,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     const { actor, headers } = await firewallRun();
     const longSubtype = `invalid_rapt:${"x".repeat(200)}`;
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "stale-access",
       refreshToken: "refresh-1",
@@ -1043,7 +1043,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "stale-access",
       refreshToken: "refresh-1",
@@ -1093,7 +1093,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "stale-access",
       refreshToken: "refresh-1",
@@ -1136,7 +1136,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "stale-access",
       refreshToken: "refresh-1",
@@ -1170,7 +1170,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "stale-access",
       expiresIn: -60,
@@ -1222,7 +1222,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     });
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "stale-access",
       refreshToken: "refresh-1",
@@ -1275,7 +1275,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "stale-access",
       refreshToken: "refresh-1",
@@ -1372,7 +1372,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "api",
       accessToken: "stale-api-access",
       refreshToken: "api-refresh-1",
@@ -1457,7 +1457,7 @@ describe("FW-7: client-unconfigured and mixed-reason refresh failures", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "notion",
+      connectorSlug: "notion",
       authMethod: "oauth",
       accessToken: "stale-notion",
       refreshToken: "notion-refresh",
@@ -1489,14 +1489,14 @@ describe("FW-7: client-unconfigured and mixed-reason refresh failures", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "notion",
+      connectorSlug: "notion",
       authMethod: "oauth",
       accessToken: "stale-notion",
       refreshToken: "notion-refresh",
       expiresIn: -60,
     });
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth",
+      connectorSlug: "test-oauth",
       authMethod: "oauth",
       accessToken: "stale-access",
       refreshToken: "refresh-1",
@@ -1540,7 +1540,7 @@ describe("FW-8: static access tokens and unavailable sources", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth-device",
+      connectorSlug: "test-oauth-device",
       authMethod: "oauth",
       accessToken: "stale-device",
       expiresIn: -60,
@@ -1562,7 +1562,7 @@ describe("FW-8: static access tokens and unavailable sources", () => {
     expect(expired.body.error.connectors).toStrictEqual(["test-oauth-device"]);
 
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth-device",
+      connectorSlug: "test-oauth-device",
       authMethod: "oauth",
       accessToken: "current-device",
       expiresIn: 3600,
@@ -1579,7 +1579,7 @@ describe("FW-8: static access tokens and unavailable sources", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "test-oauth-device",
+      connectorSlug: "test-oauth-device",
       authMethod: "oauth",
       accessToken: "no-expiry-device",
     });
@@ -2053,7 +2053,7 @@ describe("FW-10: platform connector secrets", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "google-ads",
+      connectorSlug: "google-ads",
       authMethod: "oauth",
       accessToken: "google-ads-access",
       refreshToken: "google-ads-refresh",
@@ -2101,7 +2101,7 @@ describe("FW-10: platform connector secrets", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "google-ads",
+      connectorSlug: "google-ads",
       authMethod: "oauth",
       accessToken: "google-ads-access",
       refreshToken: "google-ads-refresh",
@@ -2139,7 +2139,7 @@ describe("FW-10: platform connector secrets", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "google-ads",
+      connectorSlug: "google-ads",
       authMethod: "oauth",
       accessToken: "google-ads-access",
       refreshToken: "google-ads-refresh",
@@ -2176,7 +2176,7 @@ describe("FW-10: platform connector secrets", () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
-      connectorName: "google-ads",
+      connectorSlug: "google-ads",
       authMethod: "oauth",
       accessToken: "google-ads-access",
       refreshToken: "google-ads-refresh",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -618,7 +618,7 @@ describe("GET /api/zero/connector-catalog", () => {
     await authDevice.requestTestConnector(
       { email: actor.email },
       {
-        connectorName: "github",
+        connectorSlug: "github",
         authMethod: "oauth",
         accessToken: "github-access-token",
         expiresIn: 3600,
@@ -657,7 +657,7 @@ describe("GET /api/zero/connector-catalog", () => {
     await authDevice.requestTestConnector(
       { email: actor.email },
       {
-        connectorName: "github",
+        connectorSlug: "github",
         authMethod: "oauth",
         accessToken: "expired-github-access-token",
         expiresIn: -60,

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -234,24 +234,24 @@ const createTestConnector$ = command(
       }
       return stringError(
         400,
-        "connectorName, authMethod, and accessToken are required",
+        "connectorSlug, authMethod, and accessToken are required",
       );
     }
 
     const connectorParsed = connectorSlugSchema.safeParse(
-      bodyResult.data.connectorName,
+      bodyResult.data.connectorSlug,
     );
     if (!connectorParsed.success) {
       return stringError(
         400,
-        `Unknown connector type: "${bodyResult.data.connectorName}"`,
+        `Unknown connector slug: "${bodyResult.data.connectorSlug}"`,
       );
     }
     const connectorSlug = connectorParsed.data;
     const snapshot = await loadConnectorRuntimeSnapshot(get(db$));
     signal.throwIfAborted();
     if (getConnectorRuntimeConnector(snapshot, connectorSlug) === undefined) {
-      return stringError(400, `Unknown connector type: "${connectorSlug}"`);
+      return stringError(400, `Unknown connector slug: "${connectorSlug}"`);
     }
 
     const query = get(testConnectorQuery$);
@@ -276,7 +276,7 @@ const createTestConnector$ = command(
     });
     signal.throwIfAborted();
     if (!resolvedSlug.ok) {
-      return stringError(400, `Unknown connector type: "${connectorSlug}"`);
+      return stringError(400, `Unknown connector slug: "${connectorSlug}"`);
     }
     const catalogMethod =
       resolvedSlug.runtimeConnector.catalogConnector.authMethods.find(
@@ -340,7 +340,7 @@ const createTestConnector$ = command(
 
     return {
       status: 200 as const,
-      body: { ok: true as const, connectorType: connectorSlug, orgId },
+      body: { ok: true as const, connectorSlug, orgId },
     };
   },
 );
@@ -360,16 +360,16 @@ const enableTestConnectors$ = command(
       ) {
         return stringError(400, "Invalid JSON body");
       }
-      return stringError(400, "composeId and connectorTypes are required");
+      return stringError(400, "composeId and connectorSlugs are required");
     }
 
     const { connectorSlugs, invalidConnectorSlugs } = parseConnectorSlugs(
-      bodyResult.data.connectorTypes,
+      bodyResult.data.connectorSlugs,
     );
     if (invalidConnectorSlugs.length > 0) {
       return stringError(
         400,
-        `Unknown connector types: ${invalidConnectorSlugs.join(", ")}`,
+        `Unknown connector slugs: ${invalidConnectorSlugs.join(", ")}`,
       );
     }
 
@@ -383,7 +383,7 @@ const enableTestConnectors$ = command(
     if (unknownConnectorSlug !== undefined) {
       return stringError(
         400,
-        `Unknown connector types: ${unknownConnectorSlug}`,
+        `Unknown connector slugs: ${unknownConnectorSlug}`,
       );
     }
 
@@ -410,7 +410,7 @@ const enableTestConnectors$ = command(
     if (!resolvedSlugs.ok) {
       return stringError(
         400,
-        `Unknown connector types: ${resolvedSlugs.connectorSlug}`,
+        `Unknown connector slugs: ${resolvedSlugs.connectorSlug}`,
       );
     }
 
@@ -475,7 +475,7 @@ const enableTestConnectors$ = command(
       body: {
         ok: true as const,
         composeId: bodyResult.data.composeId,
-        connectorTypes: connectorSlugs,
+        connectorSlugs,
       },
     };
   },

--- a/turbo/packages/api-contracts/src/contracts/cli-auth-test.ts
+++ b/turbo/packages/api-contracts/src/contracts/cli-auth-test.ts
@@ -42,7 +42,7 @@ export const cliAuthTestConnectorContract = c.router({
     path: "/api/cli/auth/test-connector",
     query: testEmailQuerySchema,
     body: z.object({
-      connectorName: z.string(),
+      connectorSlug: connectorSlugSchema,
       authMethod: connectorAuthMethodIdSchema,
       accessToken: z.string(),
       refreshToken: z.string().min(1).optional(),
@@ -51,8 +51,7 @@ export const cliAuthTestConnectorContract = c.router({
     responses: {
       200: z.object({
         ok: z.literal(true),
-        // TODO(#23619): Rename this test API wire field with its CLI caller.
-        connectorType: connectorSlugSchema,
+        connectorSlug: connectorSlugSchema,
         orgId: z.string(),
       }),
       400: stringErrorResponseSchema,
@@ -69,15 +68,13 @@ export const cliAuthTestEnableConnectorContract = c.router({
     query: testEmailQuerySchema,
     body: z.object({
       composeId: z.string().uuid(),
-      // TODO(#23619): Rename these test API wire fields with their CLI caller.
-      connectorTypes: z.array(z.string()).min(1),
+      connectorSlugs: z.array(z.string()).min(1),
     }),
     responses: {
       200: z.object({
         ok: z.literal(true),
         composeId: z.string(),
-        // TODO(#23619): Rename with the corresponding request field.
-        connectorTypes: z.array(z.string()),
+        connectorSlugs: z.array(z.string()),
       }),
       400: stringErrorResponseSchema,
       404: notFoundTextSchema.or(stringErrorResponseSchema),

--- a/turbo/packages/api-contracts/src/contracts/cli-auth-test.ts
+++ b/turbo/packages/api-contracts/src/contracts/cli-auth-test.ts
@@ -42,7 +42,7 @@ export const cliAuthTestConnectorContract = c.router({
     path: "/api/cli/auth/test-connector",
     query: testEmailQuerySchema,
     body: z.object({
-      connectorSlug: connectorSlugSchema,
+      connectorSlug: z.string(),
       authMethod: connectorAuthMethodIdSchema,
       accessToken: z.string(),
       refreshToken: z.string().min(1).optional(),


### PR DESCRIPTION
## Summary

- rename hidden test connector API request and response fields to canonical
  `connectorSlug` / `connectorSlugs` terminology
- update route validation messages, typed API integration callers, and direct
  runner Bats callers atomically
- preserve endpoint paths, connector values, authorization, persistence, and
  production hiding behavior without transitional aliases

## Validation

- `./scripts/prepare.sh`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts test`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api build`
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only src/signals/routes/__tests__/cli-auth.bdd.test.ts src/signals/routes/__tests__/zero-connector-catalog.test.ts src/signals/routes/__tests__/cron-connector-catalog.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm knip`
- pre-commit hooks (Prettier, Knip, repository TypeScript checks, file-size
  validation, commitlint)

The runner Bats suite could not be executed locally because the vendored Bats
test dependency and ShellCheck are unavailable in this checkout; CI must verify
the affected t42/t53 scenarios.

Closes #23822

Parent: #23814
