### PR TITLE
chore(api): analyze schema aliases in drizzle sql lint

### DIFF
--- a/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
@@ -1,5 +1,18 @@
 import { command } from "ccstate";
-import { count, eq, lt, sql, type SQL } from "drizzle-orm";
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  gt,
+  isNull,
+  lt,
+  or,
+  sql,
+  type SQL,
+} from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import { chatThreadEvents } from "@vm0/db/schema/chat-thread-event";
 import { chatThreadSnapshots } from "@vm0/db/schema/chat-thread-snapshot";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
@@ -22,6 +35,11 @@ type SnapshotRootDb = Pick<Db, "execute" | "transaction">;
 const CHAT_THREAD_EVENT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_CHAT_THREAD_SNAPSHOT_BATCH_SIZE = 500;
 const CHAT_THREAD_SNAPSHOT_STALE_MS = 24 * 60 * 60 * 1000;
+const snapshot = alias(chatThreadSnapshots, "snapshot");
+const event = alias(chatThreadEvents, "event");
+const marker = alias(chatThreadEvents, "marker");
+const thread = alias(chatThreads, "thread");
+const agent = alias(agentComposes, "agent");
 
 function chatThreadSnapshotBatchSize(): number {
   const raw = optionalEnv("CHAT_THREAD_SNAPSHOT_COMPACTION_BATCH_SIZE");
@@ -74,22 +92,28 @@ function candidateScopesCte(staleCutoff: Date, batchSize: number): SQL {
         scope.user_id,
         scope.org_id
       FROM all_scopes scope
-      LEFT JOIN ${chatThreadSnapshots} snapshot
-        ON snapshot.user_id = scope.user_id
-       AND snapshot.org_id = scope.org_id
+      LEFT JOIN ${chatThreadSnapshots} ${snapshot}
+        ON ${and(
+          eq(snapshot.userId, sql`scope.user_id`),
+          eq(snapshot.orgId, sql`scope.org_id`),
+        )}
       LEFT JOIN LATERAL (
         SELECT event.id, event.seq_id
-        FROM ${chatThreadEvents} event
-        WHERE event.user_id = scope.user_id
-          AND event.org_id = scope.org_id
-        ORDER BY event.seq_id DESC
+        FROM ${chatThreadEvents} ${event}
+        WHERE ${and(
+          eq(event.userId, sql`scope.user_id`),
+          eq(event.orgId, sql`scope.org_id`),
+        )}
+        ORDER BY ${desc(event.seqId)}
         LIMIT 1
       ) latest_event ON true
-      WHERE snapshot.user_id IS NULL
-         OR snapshot.latest_event_seq_id IS DISTINCT FROM latest_event.seq_id
-         OR snapshot.updated_at < ${staleCutoff}
+      WHERE ${or(
+        isNull(snapshot.userId),
+        sql`${snapshot.latestEventSeqId} IS DISTINCT FROM latest_event.seq_id`,
+        lt(snapshot.updatedAt, sql`${staleCutoff}`),
+      )}
       ORDER BY
-        snapshot.updated_at ASC NULLS FIRST,
+        ${asc(snapshot.updatedAt)} NULLS FIRST,
         latest_event.seq_id ASC NULLS FIRST,
         scope.user_id ASC,
         scope.org_id ASC
@@ -110,9 +134,11 @@ function rebuiltCte(): SQL {
         events_after_marker.count AS events_applied,
         deleted_agent_threads.count AS removed_deleted_agent_threads
       FROM candidate_scopes scope
-      LEFT JOIN ${chatThreadSnapshots} snapshot
-        ON snapshot.user_id = scope.user_id
-       AND snapshot.org_id = scope.org_id
+      LEFT JOIN ${chatThreadSnapshots} ${snapshot}
+        ON ${and(
+          eq(snapshot.userId, sql`scope.user_id`),
+          eq(snapshot.orgId, sql`scope.org_id`),
+        )}
       LEFT JOIN LATERAL (
         SELECT jsonb_agg(
           jsonb_build_object(
@@ -126,51 +152,59 @@ function rebuiltCte(): SQL {
             'renamedAt', thread.renamed_at,
             'selectedModel', thread.selected_model,
             'serviceTier', CASE
-              WHEN thread.codex_service_tier = 'fast' THEN 'priority'
+              WHEN ${eq(thread.codexServiceTier, sql`'fast'`)} THEN 'priority'
               ELSE NULL
             END,
             'computerUseHostId', thread.computer_use_host_id,
             'cloudBrowserEnabled', thread.cloud_browser_enabled
           )
           ORDER BY
-            (thread.pinned_at IS NULL) ASC,
-            thread.last_message_at DESC,
-            thread.id DESC
+            ${asc(isNull(thread.pinnedAt))},
+            ${desc(thread.lastMessageAt)},
+            ${desc(thread.id)}
         ) AS chat_threads
-        FROM ${chatThreads} thread
-        INNER JOIN ${agentComposes} agent
-          ON agent.id = thread.agent_compose_id
-        WHERE thread.user_id = scope.user_id
-          AND agent.org_id = scope.org_id
+        FROM ${chatThreads} ${thread}
+        INNER JOIN ${agentComposes} ${agent}
+          ON ${eq(agent.id, thread.agentComposeId)}
+        WHERE ${and(
+          eq(thread.userId, sql`scope.user_id`),
+          eq(agent.orgId, sql`scope.org_id`),
+        )}
       ) thread_projection ON true
       LEFT JOIN LATERAL (
         SELECT event.id, event.seq_id
-        FROM ${chatThreadEvents} event
-        WHERE event.user_id = scope.user_id
-          AND event.org_id = scope.org_id
-        ORDER BY event.seq_id DESC
+        FROM ${chatThreadEvents} ${event}
+        WHERE ${and(
+          eq(event.userId, sql`scope.user_id`),
+          eq(event.orgId, sql`scope.org_id`),
+        )}
+        ORDER BY ${desc(event.seqId)}
         LIMIT 1
       ) latest_event ON true
       LEFT JOIN LATERAL (
         SELECT ${count()}::int AS count
-        FROM ${chatThreadEvents} event
-        WHERE event.user_id = scope.user_id
-          AND event.org_id = scope.org_id
-          AND (
-            snapshot.latest_event_seq_id IS NULL
-            OR event.seq_id > snapshot.latest_event_seq_id
-          )
+        FROM ${chatThreadEvents} ${event}
+        WHERE ${and(
+          eq(event.userId, sql`scope.user_id`),
+          eq(event.orgId, sql`scope.org_id`),
+          or(
+            isNull(snapshot.latestEventSeqId),
+            gt(event.seqId, snapshot.latestEventSeqId),
+          ),
+        )}
       ) events_after_marker ON true
       LEFT JOIN LATERAL (
         SELECT ${count()}::int AS count
         FROM jsonb_array_elements(
-          COALESCE(snapshot.chat_threads, '[]'::jsonb)
+          COALESCE(${snapshot.chatThreads}, '[]'::jsonb)
         ) AS old_thread(thread)
         WHERE NOT EXISTS (
           SELECT 1
-          FROM ${agentComposes} agent
-          WHERE agent.id = (old_thread.thread ->> 'agentId')::uuid
-            AND agent.org_id = scope.org_id
+          FROM ${agentComposes} ${agent}
+          WHERE ${and(
+            eq(agent.id, sql`(old_thread.thread ->> 'agentId')::uuid`),
+            eq(agent.orgId, sql`scope.org_id`),
+          )}
           )
         ) deleted_agent_threads ON true
     )
@@ -271,17 +305,21 @@ async function compactChatThreadSnapshotsForAllScopes(
     db,
     sql`
       WITH pruned AS (
-        DELETE FROM ${chatThreadEvents} event
-        USING ${chatThreadSnapshots} snapshot
-        INNER JOIN ${chatThreadEvents} marker
-          ON marker.id = snapshot.latest_event_id
-         AND marker.seq_id = snapshot.latest_event_seq_id
-         AND marker.user_id = snapshot.user_id
-         AND marker.org_id = snapshot.org_id
-        WHERE event.user_id = snapshot.user_id
-          AND event.org_id = snapshot.org_id
-          AND event.created_at < ${cutoff}
-          AND event.seq_id < marker.seq_id
+        DELETE FROM ${chatThreadEvents} ${event}
+        USING ${chatThreadSnapshots} ${snapshot}
+        INNER JOIN ${chatThreadEvents} ${marker}
+          ON ${and(
+            eq(marker.id, snapshot.latestEventId),
+            eq(marker.seqId, snapshot.latestEventSeqId),
+            eq(marker.userId, snapshot.userId),
+            eq(marker.orgId, snapshot.orgId),
+          )}
+        WHERE ${and(
+          eq(event.userId, snapshot.userId),
+          eq(event.orgId, snapshot.orgId),
+          lt(event.createdAt, sql`${cutoff}`),
+          lt(event.seqId, marker.seqId),
+        )}
         RETURNING 1
       )
       SELECT ${count()}::int AS "count"

--- a/turbo/apps/api/src/signals/services/cron-compact-usage-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-compact-usage-events.service.ts
@@ -2,7 +2,19 @@ import { usageAllowanceAllocations } from "@vm0/db/schema/org-usage-allowance";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { usageEventHourlyRollup } from "@vm0/db/schema/usage-event-hourly-rollup";
 import { command } from "ccstate";
-import { count, sql, type SQL } from "drizzle-orm";
+import {
+  and,
+  asc,
+  count,
+  eq,
+  gte,
+  isNotNull,
+  isNull,
+  lt,
+  sql,
+  type SQL,
+} from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
 
 import {
@@ -16,6 +28,9 @@ import { lockUsageEventCompaction } from "./usage-event-compaction-lock.service"
 
 const L = logger("CronCompactUsageEvents");
 const USAGE_EVENT_COMPACTION_RAW_SEED_LIMIT = 500;
+const event = alias(usageEvent, "event");
+const allocation = alias(usageAllowanceAllocations, "allocation");
+const hourly = alias(usageEventHourlyRollup, "hourly");
 
 type UsageEventCompactionDb = Pick<Db, "execute" | "transaction">;
 
@@ -71,31 +86,15 @@ const remainingRawRowSchema = z.object({
 
 // The explicit null order matches a reverse scan of the deployed
 // idx_usage_event_processed_org_user index. Eligible rows are always non-null.
-const oldestProcessedEventOrder = sql`event.processed_at ASC NULLS FIRST`;
+const oldestProcessedEventOrder = sql`${asc(event.processedAt)} NULLS FIRST`;
 
 function eligibleRawPredicate(cutoff: string): SQL {
-  return sql`
-    event.status = 'processed'
-    AND event.processed_at IS NOT NULL
-    AND event.processed_at < ${cutoff}::timestamp
-    AND event.billing_error IS NULL
-  `;
-}
-
-function physicalGrainMatch(leftAlias: string, rightAlias: string): SQL {
-  const left = sql.identifier(leftAlias);
-  const right = sql.identifier(rightAlias);
-  return sql`
-    ${left}.processed_hour = ${right}.processed_hour
-    AND ${left}.org_id = ${right}.org_id
-    AND ${left}.user_id = ${right}.user_id
-    AND ${left}.run_id IS NOT DISTINCT FROM ${right}.run_id
-    AND ${left}.kind = ${right}.kind
-    AND ${left}.provider = ${right}.provider
-    AND ${left}.category = ${right}.category
-    AND ${left}.short_window_id IS NOT DISTINCT FROM ${right}.short_window_id
-    AND ${left}.weekly_window_id IS NOT DISTINCT FROM ${right}.weekly_window_id
-  `;
+  return sql`${and(
+    eq(event.status, sql`'processed'`),
+    isNotNull(event.processedAt),
+    lt(event.processedAt, sql`${cutoff}::timestamp`),
+    isNull(event.billingError),
+  )}`;
 }
 
 function physicalGrainColumns(alias: string): SQL {
@@ -145,9 +144,9 @@ function candidateCtes(args: {
         event.category,
         allocation.short_window_id,
         allocation.weekly_window_id
-      FROM ${usageEvent} event
-      LEFT JOIN ${usageAllowanceAllocations} allocation
-        ON allocation.usage_event_id = event.id
+      FROM ${usageEvent} ${event}
+      LEFT JOIN ${usageAllowanceAllocations} ${allocation}
+        ON ${eq(allocation.usageEventId, event.id)}
       WHERE ${eligibleRawPredicate(args.cutoff)}
       ORDER BY ${oldestProcessedEventOrder}
       LIMIT ${args.rawSeedLimit}
@@ -182,20 +181,24 @@ function lockedSourceCtes(cutoff: string): SQL {
         event.quantity,
         COALESCE(event.credits_charged, 0)::bigint AS credits_charged
       FROM selected_grains grain
-      INNER JOIN ${usageEvent} event
-        ON event.processed_at >= grain.processed_hour
-       AND event.processed_at < grain.processed_hour + interval '1 hour'
-       AND event.org_id = grain.org_id
-       AND event.user_id = grain.user_id
-       AND event.run_id IS NOT DISTINCT FROM grain.run_id
-       AND event.kind = grain.kind
-       AND event.provider = grain.provider
-       AND event.category = grain.category
-      LEFT JOIN ${usageAllowanceAllocations} allocation
-        ON allocation.usage_event_id = event.id
-      WHERE ${eligibleRawPredicate(cutoff)}
-        AND allocation.short_window_id IS NOT DISTINCT FROM grain.short_window_id
-        AND allocation.weekly_window_id IS NOT DISTINCT FROM grain.weekly_window_id
+      INNER JOIN ${usageEvent} ${event}
+        ON ${and(
+          gte(event.processedAt, sql`grain.processed_hour`),
+          lt(event.processedAt, sql`grain.processed_hour + interval '1 hour'`),
+          eq(event.orgId, sql`grain.org_id`),
+          eq(event.userId, sql`grain.user_id`),
+          sql`${event.runId} IS NOT DISTINCT FROM grain.run_id`,
+          eq(event.kind, sql`grain.kind`),
+          eq(event.provider, sql`grain.provider`),
+          eq(event.category, sql`grain.category`),
+        )}
+      LEFT JOIN ${usageAllowanceAllocations} ${allocation}
+        ON ${eq(allocation.usageEventId, event.id)}
+      WHERE ${and(
+        eligibleRawPredicate(cutoff),
+        sql`${allocation.shortWindowId} IS NOT DISTINCT FROM grain.short_window_id`,
+        sql`${allocation.weeklyWindowId} IS NOT DISTINCT FROM grain.weekly_window_id`,
+      )}
       FOR UPDATE OF event
     ),
     locked_raw_allocations AS MATERIALIZED (
@@ -203,8 +206,8 @@ function lockedSourceCtes(cutoff: string): SQL {
         allocation.usage_event_id,
         allocation.units_applied
       FROM locked_raw_events event
-      INNER JOIN ${usageAllowanceAllocations} allocation
-        ON allocation.usage_event_id = event.id
+      INNER JOIN ${usageAllowanceAllocations} ${allocation}
+        ON ${eq(allocation.usageEventId, sql`event.id`)}
       FOR UPDATE OF allocation
     ),
     locked_raw AS MATERIALIZED (
@@ -242,8 +245,18 @@ function lockedSourceCtes(cutoff: string): SQL {
         hourly.credits_charged,
         hourly.allowance_units
       FROM selected_grains grain
-      INNER JOIN ${usageEventHourlyRollup} hourly
-        ON ${physicalGrainMatch("hourly", "grain")}
+      INNER JOIN ${usageEventHourlyRollup} ${hourly}
+        ON ${and(
+          eq(hourly.processedHour, sql`grain.processed_hour`),
+          eq(hourly.orgId, sql`grain.org_id`),
+          eq(hourly.userId, sql`grain.user_id`),
+          sql`${hourly.runId} IS NOT DISTINCT FROM grain.run_id`,
+          eq(hourly.kind, sql`grain.kind`),
+          eq(hourly.provider, sql`grain.provider`),
+          eq(hourly.category, sql`grain.category`),
+          sql`${hourly.shortWindowId} IS NOT DISTINCT FROM grain.short_window_id`,
+          sql`${hourly.weeklyWindowId} IS NOT DISTINCT FROM grain.weekly_window_id`,
+        )}
       FOR UPDATE OF hourly
     ),
     source_facts AS MATERIALIZED (
@@ -278,9 +291,9 @@ function lockedSourceCtes(cutoff: string): SQL {
 function mutationCtes(): SQL {
   return sql`
     deleted_hourly AS (
-      DELETE FROM ${usageEventHourlyRollup} hourly
+      DELETE FROM ${usageEventHourlyRollup} ${hourly}
       USING locked_hourly
-      WHERE hourly.id = locked_hourly.id
+      WHERE ${eq(hourly.id, sql`locked_hourly.id`)}
       RETURNING hourly.id
     ),
     inserted_hourly AS (
@@ -319,11 +332,13 @@ function mutationCtes(): SQL {
         allowance_units
     ),
     compacted_raw AS (
-      UPDATE ${usageEvent} event
+      UPDATE ${usageEvent} ${event}
       SET status = 'compacted'
       FROM locked_raw
-      WHERE event.id = locked_raw.id
-        AND event.status = 'processed'
+      WHERE ${and(
+        eq(event.id, sql`locked_raw.id`),
+        eq(event.status, sql`'processed'`),
+      )}
       RETURNING event.id
     )
   `;
@@ -515,10 +530,12 @@ async function loadHoldProbe(
     sql`
       WITH probed AS MATERIALIZED (
         SELECT event.billing_error
-        FROM ${usageEvent} event
-        WHERE event.status = 'processed'
-          AND event.processed_at IS NOT NULL
-          AND event.processed_at < ${cutoff}::timestamp
+        FROM ${usageEvent} ${event}
+        WHERE ${and(
+          eq(event.status, sql`'processed'`),
+          isNotNull(event.processedAt),
+          lt(event.processedAt, sql`${cutoff}::timestamp`),
+        )}
         ORDER BY ${oldestProcessedEventOrder}
         LIMIT ${rawSeedLimit}
       )
@@ -548,7 +565,7 @@ async function hasRemainingRawUsage(
     sql`
       SELECT EXISTS (
         SELECT 1
-        FROM ${usageEvent} event
+        FROM ${usageEvent} ${event}
         WHERE ${eligibleRawPredicate(cutoff)}
         LIMIT 1
       ) AS "hasMoreRaw"

--- a/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
@@ -780,12 +780,14 @@ const queryBuilderCases = {
     },
     {
       code: `${unnestUpdatePreamble}
-        import { sql } from "drizzle-orm";
+        import { eq, sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const target = alias(allowanceWindows, "target");
         await db.execute(sql\`
-          UPDATE \${allowanceWindows} AS target
+          UPDATE \${allowanceWindows} AS \${target}
           SET consumed_units = consumption.units_applied
           FROM unnest(\${sql.param(unitDeltas)}::bigint[]) AS consumption(units_applied)
-          WHERE target.id = consumption.window_id
+          WHERE \${eq(target.id, sql\`consumption.window_id\`)}
         \`);
         await db.execute(sql\`
           UPDATE \${allowanceWindows}

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -2924,6 +2924,110 @@ ruleTester.run("prefer-drizzle-apis source-local analysis", preferDrizzleApis, {
         db.select().from(users).where(and(...fragments));
       `,
     },
+    {
+      name: "non-schema relation aliases remain opaque",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          WITH event AS (
+            SELECT 1 AS id
+          )
+          SELECT event.id
+          FROM event
+          WHERE event.id = 1
+        \`;
+        sql\`
+          SELECT event.id
+          FROM (SELECT 1 AS id) event
+          WHERE event.id IS NOT NULL
+        \`;
+        sql\`
+          SELECT event.id
+          FROM jsonb_array_elements(\${users.tags}) event
+          WHERE event.id > 0
+        \`;
+      `,
+    },
+    {
+      name: "local opaque alias shadows a schema alias",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          SELECT event.id
+          FROM \${users} event
+          WHERE EXISTS (
+            SELECT 1
+            FROM (SELECT 1 AS id) event
+            WHERE event.id = 1
+          )
+        \`;
+      `,
+    },
+    {
+      name: "ambiguous and renamed schema aliases remain opaque",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          SELECT event.id
+          FROM \${users} event, \${users} event
+          WHERE event.id = 1
+        \`;
+        sql\`
+          SELECT event.event_id
+          FROM \${users} event(event_id, event_name, deleted_at, tags)
+          WHERE event.event_id = 1
+        \`;
+      `,
+    },
+    {
+      name: "raw relations and aliased join results remain opaque",
+      code: `${drizzlePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        declare const relation: SQL;
+        sql\`
+          SELECT event.id
+          FROM \${relation} event
+          WHERE event.id = 1
+        \`;
+        sql\`
+          SELECT pair.id
+          FROM (
+            \${users} event
+            JOIN (SELECT 1 AS other_id) other ON TRUE
+          ) pair
+          WHERE pair.id = 1
+        \`;
+      `,
+    },
+    {
+      name: "a Drizzle alias for a different source table remains opaque",
+      code: `${structuredReadPreamble}
+        import { sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const event = alias(messages, "event");
+        sql\`
+          SELECT event.id
+          FROM \${users} \${event}
+          WHERE event.id = 1
+        \`;
+      `,
+    },
+    {
+      name: "unknown schema columns and unsupported operators remain raw",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          SELECT event.id
+          FROM \${users} event
+          WHERE event.unknown_column = 1
+        \`;
+        sql\`
+          SELECT event.id
+          FROM \${users} event
+          WHERE event.id IS DISTINCT FROM 1
+        \`;
+      `,
+    },
   ],
   invalid: [
     {
@@ -3268,6 +3372,314 @@ ruleTester.run("prefer-drizzle-apis source-local analysis", preferDrizzleApis, {
         { messageId: "typedApi", data: { helper: "eq" } },
         { messageId: "typedApi", data: { helper: "eq" } },
       ],
+    },
+    {
+      name: "direct schema alias comparison",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          SELECT event.id
+          FROM \${users} event
+          WHERE event.id = \${1}
+        \`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      name: "matching interpolated Drizzle alias comparison",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const event = alias(users, "event");
+        sql\`
+          SELECT event.id
+          FROM \${users} \${event}
+          WHERE event.id = \${1}
+        \`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      name: "schema alias analysis survives an interpolated aggregate filter",
+      code: `${drizzlePreamble}
+        import { count, isNotNull, sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const event = alias(users, "event");
+        sql\`
+          SELECT \${count()} FILTER (
+            WHERE \${isNotNull(event.deletedAt)}
+          )
+          FROM \${users} \${event}
+          WHERE event.id = 1
+        \`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      name: "matching interpolated alias of an imported schema comparison",
+      code: `
+        import { usageEvent } from "./src/schema/usage-event";
+        import { sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const event = alias(usageEvent, "event");
+        sql\`
+          SELECT event.id
+          FROM \${usageEvent} \${event}
+          WHERE event.status = 'processed'
+        \`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      name: "matching interpolated schema alias inside a select cte",
+      code: `
+        import { usageEvent } from "./src/schema/usage-event";
+        import { asc, count, sql, type SQL } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        import { executeRawRows } from "./lib/db-raw-rows";
+        const event = alias(usageEvent, "event");
+        const oldest = sql\`\${asc(event.processedAt)} NULLS FIRST\`;
+        declare const db: never;
+        declare const rowSchema: never;
+        declare const cutoff: string;
+        function probeQuery(args: { readonly cutoff: string }): SQL {
+          return sql\`
+            WITH probed AS MATERIALIZED (
+              SELECT event.billing_error
+              FROM \${usageEvent} \${event}
+              WHERE event.status = 'processed'
+                AND event.processed_at IS NOT NULL
+                AND event.processed_at < \${args.cutoff}::timestamp
+              ORDER BY \${oldest}
+            )
+            SELECT \${count()}
+            FROM probed
+          \`;
+        }
+        await executeRawRows(
+          db,
+          probeQuery({ cutoff }),
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "and" } }],
+    },
+    {
+      name: "direct schema alias null predicates",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          SELECT event.id
+          FROM \${users} event
+          WHERE event.deleted_at IS NOT NULL
+        \`;
+        sql\`
+          SELECT event.id
+          FROM \${users} event
+          WHERE event.deleted_at IS NULL
+        \`;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "isNotNull" } },
+        { messageId: "typedApi", data: { helper: "isNull" } },
+      ],
+    },
+    {
+      name: "direct schema alias ordering with retained null order",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          SELECT event.id
+          FROM \${users} event
+          ORDER BY event.name ASC NULLS FIRST
+        \`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "asc" } }],
+    },
+    {
+      name: "direct schema alias mapped aggregate",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          SELECT MAX(event.id)
+          FROM \${users} event
+        \`.mapWith(users.id);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "max" } }],
+    },
+    {
+      name: "direct schema alias comparison capabilities",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          SELECT event.id
+          FROM \${users} event
+          WHERE CASE
+            WHEN event.id = 1 THEN event.id
+            WHEN event.id <> 2 THEN event.id
+            WHEN event.id > 3 THEN event.id
+            WHEN event.id >= 4 THEN event.id
+            WHEN event.id < 5 THEN event.id
+            WHEN event.id <= 6 THEN event.id
+          END IS NOT NULL
+        \`;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "ne" } },
+        { messageId: "typedApi", data: { helper: "gt" } },
+        { messageId: "typedApi", data: { helper: "gte" } },
+        { messageId: "typedApi", data: { helper: "lt" } },
+        { messageId: "typedApi", data: { helper: "lte" } },
+      ],
+    },
+    {
+      name: "direct schema alias membership",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          SELECT event.id
+          FROM \${users} event
+          WHERE event.id IN (1, 2)
+        \`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "inArray" } }],
+    },
+    {
+      name: "direct schema alias boolean capabilities",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          SELECT event.id
+          FROM \${users} event
+          WHERE event.id = 1 AND event.name = 'one'
+        \`;
+        sql\`
+          SELECT event.id
+          FROM \${users} event
+          WHERE event.id = 1 OR event.name = 'one'
+        \`;
+        sql\`
+          SELECT event.id
+          FROM \${users} event
+          WHERE NOT event.id = 1
+        \`;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "and" } },
+        { messageId: "typedApi", data: { helper: "or" } },
+        { messageId: "typedApi", data: { helper: "not" } },
+      ],
+    },
+    {
+      name: "two direct schema aliases in a join",
+      code: `${structuredReadPreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          SELECT event.id
+          FROM \${users} event
+          INNER JOIN \${messages} message
+            ON event.id = message.user_id
+        \`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      name: "direct schema aliases in update and delete statements",
+      code: `${structuredReadPreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          UPDATE \${users} event
+          SET name = 'updated'
+          FROM \${messages} message
+          WHERE event.id = message.user_id
+        \`;
+        sql\`
+          DELETE FROM \${users} event
+          USING \${messages} message
+          WHERE event.id = message.user_id
+        \`;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
+    },
+    {
+      name: "direct schema alias in a data-modifying cte",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          WITH changed AS (
+            UPDATE \${users} event
+            SET name = 'updated'
+            WHERE event.id = \${1}
+            RETURNING event.id
+          )
+          SELECT changed.id
+          FROM changed
+        \`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      name: "correlated and lateral schema aliases use the nearest scope",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          SELECT (
+            SELECT nested.id
+            FROM \${users} nested
+            WHERE nested.id = event.id
+            GROUP BY nested.id
+          )
+          FROM \${users} event
+        \`;
+        sql\`
+          SELECT selected.id
+          FROM \${users} event
+          CROSS JOIN LATERAL (
+            SELECT event.id
+            WHERE event.id = 1
+          ) selected
+        \`;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
+    },
+    {
+      name: "an inner schema alias shadows an outer schema alias",
+      code: `${structuredReadPreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          SELECT event.id
+          FROM \${users} event
+          WHERE EXISTS (
+            SELECT 1
+            FROM \${messages} event
+            WHERE event.user_id = 1
+          )
+        \`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      name: "local opaque aliases stop correlated outer lookup",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          SELECT (
+            SELECT event.id
+            FROM (SELECT 1 AS id) event
+            WHERE event.id = 1
+          )
+          FROM \${users} event
+          WHERE event.id = 2
+        \`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
     },
   ],
 });

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -12,8 +12,10 @@ import {
   isIdentifier,
   isNonNullExpression,
   isParenthesizedExpression,
+  isPropertyAccessExpression,
   isSatisfiesExpression,
   isSpreadElement,
+  isStringLiteral,
   isVariableDeclaration,
   isVariableDeclarationList,
   IndexKind,
@@ -187,6 +189,7 @@ type SqlHelper =
   | "sumDistinct";
 
 interface SqlMarker {
+  readonly aggregateHelper: AggregateHelper | undefined;
   readonly chunk: SqlSourceChunk;
   readonly columnMetadata:
     | Readonly<
@@ -210,10 +213,12 @@ interface SqlMarker {
   readonly isWrapper: boolean;
   readonly node: TSESTree.Expression;
   readonly tableMetadata: DrizzleTableMetadata | undefined;
+  readonly tableAlias: SqlTableAlias | undefined;
 }
 
 interface ParsedSql {
   readonly markers: ReadonlyMap<string, SqlMarker>;
+  readonly schemaColumns: ReadonlyMap<Record<string, unknown>, SqlSchemaColumn>;
   readonly sourceRanges: readonly SqlSourceRange[];
   readonly statement: unknown;
 }
@@ -229,6 +234,18 @@ interface SqlSourceRange {
   readonly start: number;
 }
 
+interface SqlSchemaColumn {
+  readonly alias: string;
+  readonly column: DrizzleTableColumnMetadata;
+  readonly relationMarker: SqlMarker;
+  readonly tableMarker: SqlMarker;
+}
+
+interface SqlTableAlias {
+  readonly name: string;
+  readonly sourceSymbol: TypeScriptSymbol;
+}
+
 type StructuralExpression = (
   | {
       readonly children: readonly StructuralExpression[];
@@ -241,6 +258,10 @@ type StructuralExpression = (
   | {
       readonly kind: "marker";
       readonly marker: SqlMarker;
+    }
+  | {
+      readonly kind: "schema-column";
+      readonly schemaColumn: SqlSchemaColumn;
     }
   | {
       readonly kind: "comparison";
@@ -538,6 +559,78 @@ function markerTableMetadata(
 ): DrizzleTableMetadata | undefined {
   const tsNode = services.esTreeNodeToTSNodeMap.get(node);
   return getDrizzleTableMetadataForWrite(checker, tsNode);
+}
+
+function markerTableAlias(
+  node: TSESTree.Expression,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): SqlTableAlias | undefined {
+  const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+  const local = localConstInitializer(
+    checker,
+    tsNode,
+    tsNode.getSourceFile(),
+    new Set(),
+  );
+  if (local === undefined) {
+    return undefined;
+  }
+  const initializer = unwrapWriteInterpolationExpression(local.initializer);
+  if (
+    !isCallExpression(initializer) ||
+    drizzleCallName(checker, initializer) !== "alias" ||
+    initializer.arguments.length !== 2
+  ) {
+    return undefined;
+  }
+  const source = initializer.arguments[0];
+  const name = initializer.arguments[1];
+  if (
+    source === undefined ||
+    name === undefined ||
+    isSpreadElement(source) ||
+    isSpreadElement(name) ||
+    !isStringLiteral(name)
+  ) {
+    return undefined;
+  }
+  const sourceExpression = unwrapWriteInterpolationExpression(source);
+  const symbolNode = isPropertyAccessExpression(sourceExpression)
+    ? sourceExpression.name
+    : sourceExpression;
+  const sourceSymbol = resolvedSymbol(
+    checker,
+    checker.getSymbolAtLocation(symbolNode),
+  );
+  const metadata = getDrizzleTableMetadataForWrite(checker, tsNode);
+  return sourceSymbol === undefined || metadata?.name !== name.text
+    ? undefined
+    : { name: name.text, sourceSymbol };
+}
+
+function markerAggregateHelper(
+  node: TSESTree.Expression,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): AggregateHelper | undefined {
+  const tsNode = unwrapWriteInterpolationExpression(
+    services.esTreeNodeToTSNodeMap.get(node),
+  );
+  if (!isCallExpression(tsNode)) {
+    return undefined;
+  }
+  const helper = drizzleCallName(checker, tsNode);
+  return helper === "avg" ||
+    helper === "avgDistinct" ||
+    helper === "count" ||
+    helper === "countDistinct" ||
+    helper === "max" ||
+    helper === "min" ||
+    helper === "sum" ||
+    helper === "sumDistinct"
+    ? helper
+    : undefined;
 }
 
 function markerIsColumn(
@@ -1060,6 +1153,7 @@ function parseSqlVariant(
       selectCandidateNames.add(name);
     }
     precedingLiteral = "";
+    let cachedAggregateHelper: AggregateHelper | null | undefined;
     let cachedArrayParameter: boolean | undefined;
     let cachedArrayOperand: boolean | undefined;
     let cachedBoundScalar: boolean | undefined;
@@ -1072,9 +1166,15 @@ function parseSqlVariant(
     let cachedAnalyzableWriteInterpolation: boolean | undefined;
     let cachedStringOrWrapper: boolean | undefined;
     let cachedTable: boolean | undefined;
+    let cachedTableAlias: SqlTableAlias | null | undefined;
     let cachedTableMetadata: DrizzleTableMetadata | null | undefined;
     let cachedWrapper: boolean | undefined;
     const marker: SqlMarker = {
+      get aggregateHelper(): AggregateHelper | undefined {
+        cachedAggregateHelper ??=
+          markerAggregateHelper(expression, checker, services) ?? null;
+        return cachedAggregateHelper ?? undefined;
+      },
       chunk,
       get columnMetadata(): SqlMarker["columnMetadata"] {
         cachedColumnMetadata ??=
@@ -1157,6 +1257,11 @@ function parseSqlVariant(
           markerTableMetadata(expression, checker, services) ?? null;
         return cachedTableMetadata ?? undefined;
       },
+      get tableAlias(): SqlTableAlias | undefined {
+        cachedTableAlias ??=
+          markerTableAlias(expression, checker, services) ?? null;
+        return cachedTableAlias ?? undefined;
+      },
     };
     markers.set(name, marker);
   }
@@ -1181,13 +1286,16 @@ function parseSqlVariant(
         if (name === undefined) {
           return { source: "", sourceRanges: [] };
         }
+        const marker = markers.get(name);
         const markerIdentifier = `"${name}"`;
         chunkSource =
-          useSelectMarkers &&
-          selectCandidateNames.has(name) &&
-          markers.get(name)?.isSelect === true
-            ? `(SELECT ${markerIdentifier})`
-            : markerIdentifier;
+          marker?.aggregateHelper !== undefined
+            ? `${markerIdentifier}()`
+            : useSelectMarkers &&
+                selectCandidateNames.has(name) &&
+                marker?.isSelect === true
+              ? `(SELECT ${markerIdentifier})`
+              : markerIdentifier;
       }
       source += chunkSource;
       if (trackSourceRanges) {
@@ -1208,9 +1316,15 @@ function parseSqlVariant(
     return null;
   }
   const statement = parseResult.statements[0];
-  return statement === undefined
-    ? null
-    : { markers, sourceRanges: rendered.sourceRanges, statement };
+  if (statement === undefined) {
+    return null;
+  }
+  return {
+    markers,
+    schemaColumns: resolveSchemaColumns(statement, markers),
+    sourceRanges: rendered.sourceRanges,
+    statement,
+  };
 }
 
 function stringNodeValue(value: unknown): string | undefined {
@@ -1238,6 +1352,24 @@ function columnMarker(
   return name === undefined ? undefined : markers.get(name);
 }
 
+function aggregateMarkerCall(
+  value: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+):
+  | {
+      readonly call: Record<string, unknown>;
+      readonly marker: SqlMarker;
+    }
+  | undefined {
+  const call = recordProperty(value, "FuncCall");
+  const names = functionName(value);
+  if (call === undefined || names?.length !== 1 || Array.isArray(call.args)) {
+    return undefined;
+  }
+  const marker = markers.get(names[0] ?? "");
+  return marker?.aggregateHelper === undefined ? undefined : { call, marker };
+}
+
 function relationMarker(
   value: unknown,
   markers: ReadonlyMap<string, SqlMarker>,
@@ -1253,6 +1385,403 @@ function relationMarker(
     return undefined;
   }
   return markers.get(rangeVar.relname);
+}
+
+type RelationBinding =
+  | {
+      readonly kind: "opaque";
+    }
+  | {
+      readonly kind: "schema";
+      readonly relationMarker: SqlMarker;
+      readonly tableMarker: SqlMarker;
+      readonly metadata: DrizzleTableMetadata;
+    };
+
+interface RelationScope {
+  readonly bindings: ReadonlyMap<string, RelationBinding>;
+  readonly parent: RelationScope | undefined;
+}
+
+const OPAQUE_RELATION_BINDING: RelationBinding = { kind: "opaque" };
+
+function scopeRangeVarPayload(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  const wrapped = recordProperty(value, "RangeVar");
+  if (wrapped !== undefined) {
+    return wrapped;
+  }
+  return isRecord(value) && typeof value.relname === "string"
+    ? value
+    : undefined;
+}
+
+function relationAliasName(value: unknown): string | undefined {
+  return isRecord(value) && typeof value.aliasname === "string"
+    ? value.aliasname
+    : undefined;
+}
+
+function directRelationAliasName(value: unknown): string | undefined {
+  return isRecord(value) &&
+    typeof value.aliasname === "string" &&
+    hasOnlyKeys(value, new Set(["aliasname"]))
+    ? value.aliasname
+    : undefined;
+}
+
+function addRelationBinding(
+  bindings: Map<string, RelationBinding>,
+  name: string,
+  binding: RelationBinding,
+): void {
+  bindings.set(name, bindings.has(name) ? OPAQUE_RELATION_BINDING : binding);
+}
+
+function mergeRelationBindings(
+  target: Map<string, RelationBinding>,
+  source: ReadonlyMap<string, RelationBinding>,
+): void {
+  for (const [name, binding] of source) {
+    addRelationBinding(target, name, binding);
+  }
+}
+
+function rangeVarBinding(
+  rangeVar: Record<string, unknown>,
+  markers: ReadonlyMap<string, SqlMarker>,
+): readonly [string, RelationBinding] | undefined {
+  if (typeof rangeVar.relname !== "string") {
+    return undefined;
+  }
+  const parsedAlias = directRelationAliasName(rangeVar.alias);
+  if (parsedAlias === undefined) {
+    const exposedName = relationAliasName(rangeVar.alias) ?? rangeVar.relname;
+    return [exposedName, OPAQUE_RELATION_BINDING];
+  }
+  const relationMarker = markers.get(rangeVar.relname);
+  if (relationMarker?.isTable !== true) {
+    return [parsedAlias, OPAQUE_RELATION_BINDING];
+  }
+  const aliasMarker = markers.get(parsedAlias);
+  const tableAlias = aliasMarker?.tableAlias;
+  const isMatchingAliasMarker =
+    tableAlias !== undefined &&
+    tableAlias.sourceSymbol === relationMarker.expressionSymbol;
+  const exposedName = isMatchingAliasMarker ? tableAlias.name : parsedAlias;
+  const tableMarker =
+    isMatchingAliasMarker && aliasMarker !== undefined
+      ? aliasMarker
+      : relationMarker;
+  const metadata = tableMarker.tableMetadata;
+  return metadata === undefined
+    ? [exposedName, OPAQUE_RELATION_BINDING]
+    : [
+        exposedName,
+        {
+          kind: "schema",
+          metadata,
+          relationMarker,
+          tableMarker,
+        },
+      ];
+}
+
+function relationBindings(
+  value: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+): ReadonlyMap<string, RelationBinding> {
+  const bindings = new Map<string, RelationBinding>();
+  const rangeVar = scopeRangeVarPayload(value);
+  if (rangeVar !== undefined) {
+    const entry = rangeVarBinding(rangeVar, markers);
+    if (entry !== undefined) {
+      addRelationBinding(bindings, entry[0], entry[1]);
+    }
+    return bindings;
+  }
+
+  const join = recordProperty(value, "JoinExpr");
+  if (join !== undefined) {
+    const alias = relationAliasName(join.alias);
+    if (alias !== undefined) {
+      addRelationBinding(bindings, alias, OPAQUE_RELATION_BINDING);
+      return bindings;
+    }
+    mergeRelationBindings(bindings, relationBindings(join.larg, markers));
+    mergeRelationBindings(bindings, relationBindings(join.rarg, markers));
+    return bindings;
+  }
+
+  const subselect = recordProperty(value, "RangeSubselect");
+  if (subselect !== undefined) {
+    const alias = relationAliasName(subselect.alias);
+    if (alias !== undefined) {
+      addRelationBinding(bindings, alias, OPAQUE_RELATION_BINDING);
+    }
+    return bindings;
+  }
+
+  const rangeFunction = recordProperty(value, "RangeFunction");
+  if (rangeFunction !== undefined) {
+    const alias = relationAliasName(rangeFunction.alias);
+    if (alias !== undefined) {
+      addRelationBinding(bindings, alias, OPAQUE_RELATION_BINDING);
+    }
+  }
+  return bindings;
+}
+
+function hasPotentialSchemaAlias(
+  value: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+): boolean {
+  if (Array.isArray(value)) {
+    return value.some((item) => {
+      return hasPotentialSchemaAlias(item, markers);
+    });
+  }
+  if (!isRecord(value)) {
+    return false;
+  }
+  const rangeVar = scopeRangeVarPayload(value);
+  if (
+    rangeVar !== undefined &&
+    typeof rangeVar.relname === "string" &&
+    directRelationAliasName(rangeVar.alias) !== undefined &&
+    markers.has(rangeVar.relname)
+  ) {
+    return true;
+  }
+  return Object.values(value).some((item) => {
+    return hasPotentialSchemaAlias(item, markers);
+  });
+}
+
+function resolveSchemaColumns(
+  statement: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+): ReadonlyMap<Record<string, unknown>, SqlSchemaColumn> {
+  const columns = new Map<Record<string, unknown>, SqlSchemaColumn>();
+  if (!hasPotentialSchemaAlias(statement, markers)) {
+    return columns;
+  }
+
+  function scopeForRelations(
+    relations: readonly unknown[],
+    parent: RelationScope | undefined,
+  ): RelationScope {
+    const bindings = new Map<string, RelationBinding>();
+    for (const relation of relations) {
+      mergeRelationBindings(bindings, relationBindings(relation, markers));
+    }
+    return { bindings, parent };
+  }
+
+  function resolveColumn(
+    columnRef: Record<string, unknown>,
+    scope: RelationScope | undefined,
+  ): void {
+    if (
+      !Array.isArray(columnRef.fields) ||
+      columnRef.fields.length !== 2 ||
+      !hasOnlyKeys(columnRef, new Set(["fields", "location"]))
+    ) {
+      return;
+    }
+    const alias = stringNodeValue(columnRef.fields[0]);
+    const databaseName = stringNodeValue(columnRef.fields[1]);
+    if (alias === undefined || databaseName === undefined) {
+      return;
+    }
+    let current = scope;
+    while (current !== undefined) {
+      const binding = current.bindings.get(alias);
+      if (binding !== undefined) {
+        if (binding.kind === "schema") {
+          const column = binding.metadata.columns.get(databaseName);
+          if (column !== undefined) {
+            columns.set(columnRef, {
+              alias,
+              column,
+              relationMarker: binding.relationMarker,
+              tableMarker: binding.tableMarker,
+            });
+          }
+        }
+        return;
+      }
+      current = current.parent;
+    }
+  }
+
+  function visitWithClause(
+    value: unknown,
+    parent: RelationScope | undefined,
+  ): void {
+    if (!isRecord(value) || !Array.isArray(value.ctes)) {
+      return;
+    }
+    for (const item of value.ctes) {
+      const expression = recordProperty(item, "CommonTableExpr");
+      if (expression?.ctequery !== undefined) {
+        visit(expression.ctequery, parent);
+      }
+    }
+  }
+
+  function visitFromItem(value: unknown, scope: RelationScope): void {
+    const join = recordProperty(value, "JoinExpr");
+    if (join !== undefined) {
+      const alias = relationAliasName(join.alias);
+      if (alias === undefined) {
+        visit(join.quals, scope);
+      } else {
+        const inputBindings = new Map<string, RelationBinding>();
+        mergeRelationBindings(
+          inputBindings,
+          relationBindings(join.larg, markers),
+        );
+        mergeRelationBindings(
+          inputBindings,
+          relationBindings(join.rarg, markers),
+        );
+        visit(join.quals, { bindings: inputBindings, parent: scope.parent });
+      }
+      visitFromItem(join.larg, scope);
+      visitFromItem(join.rarg, scope);
+      return;
+    }
+
+    const subselect = recordProperty(value, "RangeSubselect");
+    if (subselect?.subquery !== undefined) {
+      visit(
+        subselect.subquery,
+        subselect.lateral === true ? scope : scope.parent,
+      );
+      return;
+    }
+
+    const rangeFunction = recordProperty(value, "RangeFunction");
+    if (rangeFunction !== undefined) {
+      for (const [key, child] of Object.entries(rangeFunction)) {
+        if (key !== "alias") {
+          visit(child, scope);
+        }
+      }
+    }
+  }
+
+  function visitSelect(
+    select: Record<string, unknown>,
+    parent: RelationScope | undefined,
+  ): void {
+    const fromClause = Array.isArray(select.fromClause)
+      ? select.fromClause
+      : [];
+    const scope = scopeForRelations(fromClause, parent);
+    visitWithClause(select.withClause, parent);
+    for (const relation of fromClause) {
+      visitFromItem(relation, scope);
+    }
+    for (const [key, child] of Object.entries(select)) {
+      if (key === "fromClause" || key === "withClause") {
+        continue;
+      }
+      visit(child, key === "larg" || key === "rarg" ? parent : scope);
+    }
+  }
+
+  function visitUpdate(
+    update: Record<string, unknown>,
+    parent: RelationScope | undefined,
+  ): void {
+    const relations = [
+      update.relation,
+      ...(Array.isArray(update.fromClause) ? update.fromClause : []),
+    ].filter((item) => {
+      return item !== undefined;
+    });
+    const scope = scopeForRelations(relations, parent);
+    visitWithClause(update.withClause, parent);
+    for (const relation of relations.slice(1)) {
+      visitFromItem(relation, scope);
+    }
+    for (const [key, child] of Object.entries(update)) {
+      if (key !== "relation" && key !== "fromClause" && key !== "withClause") {
+        visit(child, scope);
+      }
+    }
+  }
+
+  function visitDelete(
+    deletion: Record<string, unknown>,
+    parent: RelationScope | undefined,
+  ): void {
+    const relations = [
+      deletion.relation,
+      ...(Array.isArray(deletion.usingClause) ? deletion.usingClause : []),
+    ].filter((item) => {
+      return item !== undefined;
+    });
+    const scope = scopeForRelations(relations, parent);
+    visitWithClause(deletion.withClause, parent);
+    for (const relation of relations.slice(1)) {
+      visitFromItem(relation, scope);
+    }
+    for (const [key, child] of Object.entries(deletion)) {
+      if (key !== "relation" && key !== "usingClause" && key !== "withClause") {
+        visit(child, scope);
+      }
+    }
+  }
+
+  function visit(value: unknown, scope: RelationScope | undefined): void {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        visit(item, scope);
+      }
+      return;
+    }
+    if (!isRecord(value)) {
+      return;
+    }
+    const columnRef = recordProperty(value, "ColumnRef");
+    if (columnRef !== undefined) {
+      resolveColumn(columnRef, scope);
+      return;
+    }
+    const select = recordProperty(value, "SelectStmt");
+    if (select !== undefined) {
+      visitSelect(select, scope);
+      return;
+    }
+    const update = recordProperty(value, "UpdateStmt");
+    if (update !== undefined) {
+      visitUpdate(update, scope);
+      return;
+    }
+    const deletion = recordProperty(value, "DeleteStmt");
+    if (deletion !== undefined) {
+      visitDelete(deletion, scope);
+      return;
+    }
+    const subselect = recordProperty(value, "RangeSubselect");
+    if (subselect?.subquery !== undefined) {
+      visit(
+        subselect.subquery,
+        subselect.lateral === true ? scope : scope?.parent,
+      );
+      return;
+    }
+    for (const child of Object.values(value)) {
+      visit(child, scope);
+    }
+  }
+
+  visit(statement, undefined);
+  return columns;
 }
 
 function operatorName(value: unknown): string | undefined {
@@ -1312,6 +1841,7 @@ function mergeSourceChunks(
 function collectStructuralExpressions(
   value: unknown,
   markers: ReadonlyMap<string, SqlMarker>,
+  schemaColumns: ReadonlyMap<Record<string, unknown>, SqlSchemaColumn>,
   sourceRanges: readonly SqlSourceRange[],
 ): StructuralExpression[] {
   const expressions: StructuralExpression[] = [];
@@ -1327,7 +1857,9 @@ function collectStructuralExpressions(
       return;
     }
     if (isExpressionNode(current)) {
-      expressions.push(structuralExpression(current, markers, sourceRanges));
+      expressions.push(
+        structuralExpression(current, markers, schemaColumns, sourceRanges),
+      );
       return;
     }
     for (const child of Object.values(current)) {
@@ -1399,6 +1931,7 @@ function opaqueNodeKey(value: unknown): string {
 function structuralExpression(
   value: unknown,
   markers: ReadonlyMap<string, SqlMarker>,
+  schemaColumns: ReadonlyMap<Record<string, unknown>, SqlSchemaColumn>,
   sourceRanges: readonly SqlSourceRange[],
 ): StructuralExpression {
   const marker = columnMarker(value, markers);
@@ -1409,10 +1942,60 @@ function structuralExpression(
       sourceChunks: new Set([marker.chunk]),
     };
   }
+  const columnRef = recordProperty(value, "ColumnRef");
+  const schemaColumn =
+    columnRef === undefined ? undefined : schemaColumns.get(columnRef);
+  if (schemaColumn !== undefined) {
+    return {
+      kind: "schema-column",
+      schemaColumn,
+      sourceChunks: new Set([
+        ...ownSourceChunks(value, sourceRanges),
+        schemaColumn.relationMarker.chunk,
+        schemaColumn.tableMarker.chunk,
+      ]),
+    };
+  }
   if (recordProperty(value, "A_Const") !== undefined) {
     return {
       kind: "constant",
       sourceChunks: ownSourceChunks(value, sourceRanges),
+    };
+  }
+  const aggregateMarker = aggregateMarkerCall(value, markers);
+  if (aggregateMarker !== undefined) {
+    const children = collectStructuralExpressions(
+      [
+        aggregateMarker.call.agg_filter,
+        aggregateMarker.call.agg_order,
+        aggregateMarker.call.over,
+      ],
+      markers,
+      schemaColumns,
+      sourceRanges,
+    );
+    if (children.length === 0) {
+      return {
+        kind: "marker",
+        marker: aggregateMarker.marker,
+        sourceChunks: new Set([aggregateMarker.marker.chunk]),
+      };
+    }
+    return {
+      children: [
+        {
+          kind: "marker",
+          marker: aggregateMarker.marker,
+          sourceChunks: new Set([aggregateMarker.marker.chunk]),
+        },
+        ...children,
+      ],
+      kind: "opaque",
+      nodeKey: opaqueNodeKey(value),
+      sourceChunks: mergeSourceChunks(
+        ownSourceChunks(value, sourceRanges),
+        children,
+      ),
     };
   }
 
@@ -1424,8 +2007,18 @@ function structuralExpression(
     binary.lexpr !== undefined &&
     binary.rexpr !== undefined
   ) {
-    const left = structuralExpression(binary.lexpr, markers, sourceRanges);
-    const right = structuralExpression(binary.rexpr, markers, sourceRanges);
+    const left = structuralExpression(
+      binary.lexpr,
+      markers,
+      schemaColumns,
+      sourceRanges,
+    );
+    const right = structuralExpression(
+      binary.rexpr,
+      markers,
+      schemaColumns,
+      sourceRanges,
+    );
     const own = ownSourceChunks(value, sourceRanges);
     if (binary.kind === "AEXPR_LIKE" || binary.kind === "AEXPR_ILIKE") {
       const helper = PATTERN_HELPERS.get(binaryOperator);
@@ -1441,10 +2034,20 @@ function structuralExpression(
           rightNames[1] === "like_escape" &&
           rightArguments?.length === 2;
         const pattern = hasEscape
-          ? structuralExpression(rightArguments?.[0], markers, sourceRanges)
+          ? structuralExpression(
+              rightArguments?.[0],
+              markers,
+              schemaColumns,
+              sourceRanges,
+            )
           : right;
         const escape = hasEscape
-          ? structuralExpression(rightArguments?.[1], markers, sourceRanges)
+          ? structuralExpression(
+              rightArguments?.[1],
+              markers,
+              schemaColumns,
+              sourceRanges,
+            )
           : undefined;
         return {
           escape,
@@ -1485,7 +2088,7 @@ function structuralExpression(
       (binaryOperator === "=" || binaryOperator === "<>")
     ) {
       const values = items.map((item) => {
-        return structuralExpression(item, markers, sourceRanges);
+        return structuralExpression(item, markers, schemaColumns, sourceRanges);
       });
       return {
         helper: binaryOperator === "=" ? "inArray" : "notInArray",
@@ -1500,8 +2103,18 @@ function structuralExpression(
         binary.kind === "AEXPR_NOT_BETWEEN") &&
       items?.length === 2
     ) {
-      const minimum = structuralExpression(items[0], markers, sourceRanges);
-      const maximum = structuralExpression(items[1], markers, sourceRanges);
+      const minimum = structuralExpression(
+        items[0],
+        markers,
+        schemaColumns,
+        sourceRanges,
+      );
+      const maximum = structuralExpression(
+        items[1],
+        markers,
+        schemaColumns,
+        sourceRanges,
+      );
       return {
         helper: binary.kind === "AEXPR_BETWEEN" ? "between" : "notBetween",
         kind: "range",
@@ -1519,7 +2132,12 @@ function structuralExpression(
     (nullTest.nulltesttype === "IS_NULL" ||
       nullTest.nulltesttype === "IS_NOT_NULL")
   ) {
-    const operand = structuralExpression(nullTest.arg, markers, sourceRanges);
+    const operand = structuralExpression(
+      nullTest.arg,
+      markers,
+      schemaColumns,
+      sourceRanges,
+    );
     return {
       helper: nullTest.nulltesttype === "IS_NULL" ? "isNull" : "isNotNull",
       kind: "null",
@@ -1540,7 +2158,7 @@ function structuralExpression(
       (boolean.boolop !== "NOT_EXPR" && boolean.args.length >= 2))
   ) {
     const items = boolean.args.map((item) => {
-      return structuralExpression(item, markers, sourceRanges);
+      return structuralExpression(item, markers, schemaColumns, sourceRanges);
     });
     return {
       items,
@@ -1570,17 +2188,27 @@ function structuralExpression(
     if (helper !== undefined && validArity) {
       const orderings = Array.isArray(call.agg_order)
         ? call.agg_order.flatMap((item) => {
-            return structuralOrdering(item, markers, sourceRanges);
+            return structuralOrdering(
+              item,
+              markers,
+              schemaColumns,
+              sourceRanges,
+            );
           })
         : [];
       const argument =
         args[0] === undefined
           ? undefined
-          : structuralExpression(args[0], markers, sourceRanges);
+          : structuralExpression(args[0], markers, schemaColumns, sourceRanges);
       const filter =
         call.agg_filter === undefined
           ? undefined
-          : structuralExpression(call.agg_filter, markers, sourceRanges);
+          : structuralExpression(
+              call.agg_filter,
+              markers,
+              schemaColumns,
+              sourceRanges,
+            );
       return {
         argument,
         filter,
@@ -1619,14 +2247,25 @@ function structuralExpression(
     const selection =
       selectionValue === undefined
         ? undefined
-        : structuralExpression(selectionValue, markers, sourceRanges);
+        : structuralExpression(
+            selectionValue,
+            markers,
+            schemaColumns,
+            sourceRanges,
+          );
     const predicate =
       select?.whereClause === undefined
         ? undefined
-        : structuralExpression(select.whereClause, markers, sourceRanges);
+        : structuralExpression(
+            select.whereClause,
+            markers,
+            schemaColumns,
+            sourceRanges,
+          );
     const children = collectStructuralExpressions(
       sublink.subselect,
       markers,
+      schemaColumns,
       sourceRanges,
     );
     const from = select?.fromClause;
@@ -1671,6 +2310,7 @@ function structuralExpression(
     const children = collectStructuralExpressions(
       sublink.subselect,
       markers,
+      schemaColumns,
       sourceRanges,
     );
     return {
@@ -1687,7 +2327,12 @@ function structuralExpression(
   }
 
   const payload = isRecord(value) ? Object.values(value)[0] : undefined;
-  const children = collectStructuralExpressions(payload, markers, sourceRanges);
+  const children = collectStructuralExpressions(
+    payload,
+    markers,
+    schemaColumns,
+    sourceRanges,
+  );
   return {
     children,
     kind: "opaque",
@@ -1797,10 +2442,36 @@ function nodeMatchesRole(
   return isDrizzleWrapperType(checker, type);
 }
 
+function schemaColumnMatchesRole(
+  schemaColumn: SqlSchemaColumn,
+  role: DrizzleOperandRole,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): boolean {
+  const tableNode = services.esTreeNodeToTSNodeMap.get(
+    schemaColumn.tableMarker.node,
+  );
+  const type = checker.getTypeOfSymbolAtLocation(
+    schemaColumn.column.propertySymbol,
+    tableNode,
+  );
+  if (role === "array") {
+    return isDrizzleArrayOperandType(checker, type, tableNode);
+  }
+  if (role === "pattern") {
+    return isDrizzlePatternOperandType(checker, type, tableNode);
+  }
+  return isDrizzleColumnType(checker, type, tableNode);
+}
+
 function directStructuralChildren(
   expression: StructuralExpression,
 ): readonly StructuralExpression[] {
-  if (expression.kind === "marker" || expression.kind === "constant") {
+  if (
+    expression.kind === "marker" ||
+    expression.kind === "schema-column" ||
+    expression.kind === "constant"
+  ) {
     return [];
   }
   if (expression.kind === "comparison" || expression.kind === "array") {
@@ -1843,6 +2514,9 @@ function retainableInlineMarkers(
   expression: StructuralExpression,
   context: ClassificationContext,
 ): readonly SqlMarker[] | undefined {
+  if (expression.kind === "schema-column") {
+    return [];
+  }
   if (expression.kind === "marker") {
     const marker = expression.marker;
     return !marker.isTable &&
@@ -1878,6 +2552,9 @@ function isSafeHelperValueOperand(
   context: ClassificationContext,
 ): boolean {
   if (expression.kind === "constant") {
+    return true;
+  }
+  if (expression.kind === "schema-column") {
     return true;
   }
   if (expression.kind === "marker") {
@@ -1929,6 +2606,16 @@ function operandAnchor(
   classificationContext: ClassificationContext,
   retainedRequirement: RetainedOperandRequirement = "schema-column",
 ): TSESTree.Expression | undefined {
+  if (expression.kind === "schema-column") {
+    return schemaColumnMatchesRole(
+      expression.schemaColumn,
+      role,
+      classificationContext.checker,
+      classificationContext.services,
+    )
+      ? literalBoundaryNode(expression.sourceChunks, classificationContext.root)
+      : undefined;
+  }
   if (expression.kind === "marker") {
     return directMarkerMatchesRole(expression.marker, role)
       ? expression.marker.node
@@ -2130,6 +2817,13 @@ function classifyExpression(
   expression: StructuralExpression,
   context: ClassificationContext,
 ): ExpressionClassification {
+  if (expression.kind === "schema-column") {
+    return {
+      anchor: literalBoundaryNode(expression.sourceChunks, context.root),
+      findings: [],
+      isWholeReplacement: false,
+    };
+  }
   if (expression.kind === "marker") {
     return {
       anchor:
@@ -4369,6 +5063,7 @@ function contextOwnsWholeExpression(
 function orderingExpressions(
   statement: unknown,
   markers: ReadonlyMap<string, SqlMarker>,
+  schemaColumns: ReadonlyMap<Record<string, unknown>, SqlSchemaColumn>,
   sourceRanges: readonly SqlSourceRange[],
 ): readonly StructuralOrdering[] {
   const select = selectStatement(statement);
@@ -4376,20 +5071,26 @@ function orderingExpressions(
     return [];
   }
   return select.sortClause.flatMap((item) => {
-    return structuralOrdering(item, markers, sourceRanges);
+    return structuralOrdering(item, markers, schemaColumns, sourceRanges);
   });
 }
 
 function structuralOrdering(
   value: unknown,
   markers: ReadonlyMap<string, SqlMarker>,
+  schemaColumns: ReadonlyMap<Record<string, unknown>, SqlSchemaColumn>,
   sourceRanges: readonly SqlSourceRange[],
 ): readonly StructuralOrdering[] {
   const sort = recordProperty(value, "SortBy");
   if (sort?.node === undefined) {
     return [];
   }
-  const expression = structuralExpression(sort.node, markers, sourceRanges);
+  const expression = structuralExpression(
+    sort.node,
+    markers,
+    schemaColumns,
+    sourceRanges,
+  );
   const direction =
     sort.sortby_dir === "SORTBY_ASC"
       ? "asc"
@@ -4411,6 +5112,7 @@ function structuralOrdering(
 function collectStructuralOrderings(
   value: unknown,
   markers: ReadonlyMap<string, SqlMarker>,
+  schemaColumns: ReadonlyMap<Record<string, unknown>, SqlSchemaColumn>,
   sourceRanges: readonly SqlSourceRange[],
 ): readonly StructuralOrdering[] {
   const orderings: StructuralOrdering[] = [];
@@ -4425,7 +5127,12 @@ function collectStructuralOrderings(
     if (!isRecord(current)) {
       return;
     }
-    const ordering = structuralOrdering(current, markers, sourceRanges);
+    const ordering = structuralOrdering(
+      current,
+      markers,
+      schemaColumns,
+      sourceRanges,
+    );
     if (ordering.length > 0) {
       orderings.push(...ordering);
       return;
@@ -4452,7 +5159,14 @@ function structuralExpressionsForContext(
     const predicate = predicateExpression(parsed.statement);
     return predicate === undefined
       ? []
-      : [structuralExpression(predicate, parsed.markers, parsed.sourceRanges)];
+      : [
+          structuralExpression(
+            predicate,
+            parsed.markers,
+            parsed.schemaColumns,
+            parsed.sourceRanges,
+          ),
+        ];
   }
   if (
     context === "selection" ||
@@ -4464,6 +5178,7 @@ function structuralExpressionsForContext(
       return structuralExpression(
         expression,
         parsed.markers,
+        parsed.schemaColumns,
         parsed.sourceRanges,
       );
     });
@@ -4473,6 +5188,7 @@ function structuralExpressionsForContext(
     return collectStructuralExpressions(
       from,
       parsed.markers,
+      parsed.schemaColumns,
       parsed.sourceRanges,
     );
   }
@@ -4480,6 +5196,7 @@ function structuralExpressionsForContext(
     return orderingExpressions(
       parsed.statement,
       parsed.markers,
+      parsed.schemaColumns,
       parsed.sourceRanges,
     ).map((ordering) => {
       return ordering.expression;
@@ -4488,6 +5205,7 @@ function structuralExpressionsForContext(
   return collectStructuralExpressions(
     parsed.statement,
     parsed.markers,
+    parsed.schemaColumns,
     parsed.sourceRanges,
   );
 }
@@ -4541,6 +5259,17 @@ function sameStructuralExpression(
   }
   if (left.kind === "marker" && right.kind === "marker") {
     return left.marker.chunk === right.marker.chunk;
+  }
+  if (left.kind === "schema-column" && right.kind === "schema-column") {
+    return (
+      left.schemaColumn.relationMarker.chunk ===
+        right.schemaColumn.relationMarker.chunk &&
+      left.schemaColumn.tableMarker.chunk ===
+        right.schemaColumn.tableMarker.chunk &&
+      left.schemaColumn.alias === right.schemaColumn.alias &&
+      left.schemaColumn.column.databaseName ===
+        right.schemaColumn.column.databaseName
+    );
   }
   if (left.kind === "constant" && right.kind === "constant") {
     return true;
@@ -4772,6 +5501,7 @@ function exactExpressionBoundary(
     const candidateExpression = structuralExpression(
       selected[0],
       parsed.markers,
+      parsed.schemaColumns,
       parsed.sourceRanges,
     );
     if (sameStructuralExpression(expression, candidateExpression)) {
@@ -4970,77 +5700,126 @@ function replacementBoundaryForFinding(
         return chunk.origins.includes(candidate);
       }),
     };
-    const parsed = parseSqlVariant(
-      candidateVariant,
-      finding.isolationContext,
-      true,
-      checker,
-      services,
-    );
-    if (parsed === null) {
-      continue;
-    }
+    const attempts: Array<{
+      readonly context: SqlAnalysisContext;
+      readonly requiresWholeOwnership: boolean;
+    }> = [
+      {
+        context: finding.isolationContext,
+        requiresWholeOwnership: true,
+      },
+    ];
+    const firstChunk = candidateVariant.chunks[0];
     if (
-      !contextOwnsWholeExpression(finding.isolationContext, parsed.statement)
+      firstChunk?.kind === "literal" &&
+      sourceLocalContextForLeadingLiteral(firstChunk.text) ===
+        "source-statement"
     ) {
-      continue;
-    }
-    const classificationContext: ClassificationContext = {
-      allowsOptionalSql: true,
-      allowsRetainedSqlWrapper,
-      allowsScalarQuery,
-      capabilities,
-      checker,
-      ownsResultMapping: false,
-      root: candidate,
-      services,
-      variant: candidateVariant,
-    };
-    const classifications =
-      finding.isolationContext === "ordering"
-        ? orderingExpressions(
-            parsed.statement,
-            parsed.markers,
-            parsed.sourceRanges,
-          ).map((ordering) => {
-            return classifyOrdering(ordering, classificationContext);
-          })
-        : structuralExpressionsForContext(finding.isolationContext, parsed).map(
-            (expression) => {
-              return classifyExpression(expression, classificationContext);
-            },
-          );
-    const matchingFinding = classifications
-      .flatMap((classification) => {
-        return classification.findings;
-      })
-      .find((candidateFinding) => {
-        return (
-          candidateFinding.kind === finding.kind &&
-          (candidateFinding.kind === "query-builder" &&
-          finding.kind === "query-builder"
-            ? candidateFinding.capability === finding.capability
-            : candidateFinding.kind !== "query-builder" &&
-              finding.kind !== "query-builder" &&
-              candidateFinding.helper === finding.helper) &&
-          candidateFinding.isolationContext === finding.isolationContext &&
-          candidateFinding.isPartial === finding.isPartial &&
-          sameSourceChunks(candidateFinding.sourceChunks, finding.sourceChunks)
-        );
+      attempts.push({
+        context: "source-statement",
+        requiresWholeOwnership: false,
       });
-    if (matchingFinding === undefined) {
-      continue;
     }
-    const classification = classifications[0];
-    if (
-      classifications.length === 1 &&
-      classification?.isWholeReplacement === true &&
-      classification.findings.length === 1 &&
-      classification.findings[0] === matchingFinding
-    ) {
-      return candidate;
+    for (const attempt of attempts) {
+      const parsed = parseSqlVariant(
+        candidateVariant,
+        attempt.context,
+        true,
+        checker,
+        services,
+      );
+      if (
+        parsed === null ||
+        (attempt.requiresWholeOwnership &&
+          !contextOwnsWholeExpression(
+            finding.isolationContext,
+            parsed.statement,
+          ))
+      ) {
+        continue;
+      }
+      const classificationContext: ClassificationContext = {
+        allowsOptionalSql: true,
+        allowsRetainedSqlWrapper,
+        allowsScalarQuery,
+        capabilities,
+        checker,
+        ownsResultMapping: false,
+        root: candidate,
+        services,
+        variant: candidateVariant,
+      };
+      const classifications =
+        attempt.context === "source-statement"
+          ? [
+              ...structuralExpressionsForContext(attempt.context, parsed).map(
+                (expression) => {
+                  return classifyExpression(expression, classificationContext);
+                },
+              ),
+              ...collectStructuralOrderings(
+                parsed.statement,
+                parsed.markers,
+                parsed.schemaColumns,
+                parsed.sourceRanges,
+              ).map((ordering) => {
+                return classifyOrdering(ordering, classificationContext);
+              }),
+            ]
+          : finding.isolationContext === "ordering"
+            ? orderingExpressions(
+                parsed.statement,
+                parsed.markers,
+                parsed.schemaColumns,
+                parsed.sourceRanges,
+              ).map((ordering) => {
+                return classifyOrdering(ordering, classificationContext);
+              })
+            : structuralExpressionsForContext(
+                finding.isolationContext,
+                parsed,
+              ).map((expression) => {
+                return classifyExpression(expression, classificationContext);
+              });
+      const matchingFinding = classifications
+        .flatMap((classification) => {
+          return classification.findings;
+        })
+        .find((candidateFinding) => {
+          return (
+            candidateFinding.kind === finding.kind &&
+            (candidateFinding.kind === "query-builder" &&
+            finding.kind === "query-builder"
+              ? candidateFinding.capability === finding.capability
+              : candidateFinding.kind !== "query-builder" &&
+                finding.kind !== "query-builder" &&
+                candidateFinding.helper === finding.helper) &&
+            candidateFinding.isolationContext === finding.isolationContext &&
+            candidateFinding.isPartial === finding.isPartial &&
+            sameSourceChunks(
+              candidateFinding.sourceChunks,
+              finding.sourceChunks,
+            )
+          );
+        });
+      if (matchingFinding === undefined) {
+        continue;
+      }
+      const classification = classifications[0];
+      if (
+        attempt.requiresWholeOwnership &&
+        classifications.length === 1 &&
+        classification?.isWholeReplacement === true &&
+        classification.findings.length === 1 &&
+        classification.findings[0] === matchingFinding
+      ) {
+        return candidate;
+      }
+      descendantBoundary ??=
+        attempt.context === "source-statement"
+          ? (candidates[0] ?? candidate)
+          : candidate;
     }
-    descendantBoundary ??= candidate;
   }
   return descendantBoundary;
 }
@@ -5090,12 +5869,14 @@ function analyzeParsed(
       ? orderingExpressions(
           parsed.statement,
           parsed.markers,
+          parsed.schemaColumns,
           parsed.sourceRanges,
         )
       : context === "statement" || context === "source-statement"
         ? collectStructuralOrderings(
             parsed.statement,
             parsed.markers,
+            parsed.schemaColumns,
             parsed.sourceRanges,
           )
         : context === "selection" ||
@@ -5106,6 +5887,7 @@ function analyzeParsed(
               return collectStructuralOrderings(
                 expression,
                 parsed.markers,
+                parsed.schemaColumns,
                 parsed.sourceRanges,
               );
             })
@@ -5518,11 +6300,9 @@ export function analyzeSql(
   return analysis;
 }
 
-function sourceLocalContext(
-  node: TSESTree.TaggedTemplateExpression,
+function sourceLocalContextForLeadingLiteral(
+  leadingLiteral: string,
 ): SqlAnalysisContext {
-  const leadingLiteral =
-    node.quasi.quasis[0]?.value.cooked ?? node.quasi.quasis[0]?.value.raw ?? "";
   if (/^\s*(?:DELETE|INSERT|SELECT|UPDATE|WITH)\b/iu.test(leadingLiteral)) {
     return "source-statement";
   }
@@ -5533,6 +6313,14 @@ function sourceLocalContext(
     return "source-predicate-prefix";
   }
   return "source-selection";
+}
+
+function sourceLocalContext(
+  node: TSESTree.TaggedTemplateExpression,
+): SqlAnalysisContext {
+  return sourceLocalContextForLeadingLiteral(
+    node.quasi.quasis[0]?.value.cooked ?? node.quasi.quasis[0]?.value.raw ?? "",
+  );
 }
 
 export function analyzeSqlSource(

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-source.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-source.ts
@@ -14,6 +14,7 @@ import {
   isIdentifier,
   isNonNullExpression,
   isParenthesizedExpression,
+  isPropertyAccessExpression,
   isReturnStatement,
   isSatisfiesExpression,
   isTemplateSpan,
@@ -35,6 +36,7 @@ import {
   isDrizzleSqlType,
   isDrizzleSqlTag,
   isDrizzleSymbol,
+  isDrizzleWrapperType,
   resolvedSymbol,
 } from "../drizzle.ts";
 
@@ -413,6 +415,20 @@ export function createSqlSourceComposer(
         current.parent.expression === current
       ) {
         current = current.parent;
+      }
+      let hasPropertyAccess = false;
+      while (
+        isPropertyAccessExpression(current.parent) &&
+        current.parent.expression === current
+      ) {
+        hasPropertyAccess = true;
+        current = current.parent;
+      }
+      if (
+        hasPropertyAccess &&
+        isDrizzleWrapperType(checker, checker.getTypeAtLocation(current))
+      ) {
+        return false;
       }
       const parent = current.parent;
       return (


### PR DESCRIPTION
## Summary

- resolve literal `alias.column` references only when PostgreSQL scope and real
  Drizzle table metadata prove an unambiguous schema alias
- reuse the existing helper-equivalence gates for comparisons, Boolean
  expressions, null checks, membership, ordering, and aggregates while keeping
  CTE, derived, raw, shadowed, and ambiguous relations opaque
- convert the resulting findings in usage-event and chat-thread snapshot
  compaction without changing statement structure, locking, parameters, or
  transaction behavior

## Scope

- no schema migration or persisted-data rewrite
- no API, queue, runner, browser, or protocol change
- no feature switch, compatibility bridge, extra SQL statement, or extra
  database round trip
- unsupported PostgreSQL constructs such as CTE fields, null-safe comparisons,
  casts, intervals, JSONB, explicit null ordering, and locks remain raw

## Validation

- `pnpm format`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F @vm0/eslint-rules test` (996 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-compact-usage-events.test.ts src/signals/routes/__tests__/chat-threads.bdd.test.ts --maxWorkers=4 --silent=passed-only` (39 tests)
- `pnpm exec knip --workspace @vm0/eslint-rules --workspace api`
- `lefthook run pre-commit`
- `git diff --check`

Complete before/after query probes preserved PostgreSQL 17 parse trees,
parameter values/order/typings, and statement counts for both compaction
statements, the hold probe, and event pruning. Representative local
`EXPLAIN (ANALYZE, BUFFERS, TIMING OFF, FORMAT JSON)` runs retained the expected
indexes, locking, and mutation nodes.

Five alternating full-API ESLint samples measured candidate median wall time at
+4.86%, median process-tree RSS at +1.32%, and maximum process-tree RSS at
+0.34% versus the exact base.

Closes #23972

Parent context: #23047
