### PR TITLE
test(python): cover catalog fstat descriptor cleanup

### DIFF
--- a/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_validation.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_validation.py
@@ -85,6 +85,24 @@ class TestRegistryBuiltinCatalogValidation:
         assert snapshot.catalog.firewalls["fallback"]["name"] == "fallback"
         assert snapshot.unavailable_reason is None
 
+    def test_runner_catalog_cache_fstat_failure_closes_opened_descriptor(self):
+        cache_path = Path("builtin-firewall-catalog-cache.json")
+        opened_fd = 42
+        error = OSError("fstat failed")
+
+        with (
+            patch.object(builtin_firewall_cache.os, "open", return_value=opened_fd),
+            patch.object(builtin_firewall_cache.os, "fstat", side_effect=error),
+            patch.object(builtin_firewall_cache.os, "close") as close,
+        ):
+            snapshot = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+
+        assert snapshot.dependency_file_key is None
+        assert snapshot.catalog is None
+        assert snapshot.cache_path == str(cache_path.absolute())
+        assert snapshot.unavailable_reason == "cache_unavailable"
+        close.assert_called_once_with(opened_fd)
+
     def test_runner_catalog_cache_rejects_initial_oversize_before_parsing(self, tmp_path, mitm_ctx):
         cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
         write_catalog_cache(


### PR DESCRIPTION
## Summary

- add fault-injection coverage for built-in catalog metadata lookup failure
- assert the public loader returns `cache_unavailable` without a catalog dependency
- verify the descriptor opened before `fstat` failure is closed exactly once

## Scope

- test-only change in the Python mitmproxy addon
- no production code, dependency, schema, persisted data, API, protocol, or deployment changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_registry_builtin_catalog_validation.py` (26 passed)
- mutation check: temporarily removed the cleanup call and confirmed the new focused test failed on zero close calls
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4455 passed)
- Lefthook pre-commit checks and commitlint

Closes #23959
