### PR TITLE
fix(ci): shorten cloudflare ssh recovery socket path

### DIFF
--- a/.github/scripts/cloudflare-ssh-command.sh
+++ b/.github/scripts/cloudflare-ssh-command.sh
@@ -504,8 +504,10 @@ if [ "$probe_status" -ne 0 ]; then
   emit_probe_failure \
     1 "$probe_status" "$first_probe_stderr" warning \
     "${current_control_path:+${current_control_path}.stderr}"
-  recovery_dir=$(mktemp -d "${STATE_DIR}/${target_key}.recovery.XXXXXX")
-  recovery_control_path="${recovery_dir}/master.sock"
+  # Keep this path compact: OpenSSH appends a 17-byte temporary suffix before
+  # binding it against Linux's 108-byte Unix socket path limit.
+  recovery_dir=$(mktemp -d "${STATE_DIR}/r.XXXXXX")
+  recovery_control_path="${recovery_dir}/m"
   recovery_status=0
   CLOUDFLARE_SSH_BIN="$REAL_SSH" \
     "${SCRIPTS_DIR}/cloudflare-ssh-preconnect.sh" \

--- a/.github/scripts/tests/cloudflare-ssh-command-test.sh
+++ b/.github/scripts/tests/cloudflare-ssh-command-test.sh
@@ -6,6 +6,9 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 WRAPPER="${REPO_ROOT}/.github/scripts/cloudflare-ssh-command.sh"
 SSH_ACTION="${REPO_ROOT}/.github/actions/setup-ssh-tunnel/action.yml"
 SECURITY_WORKFLOW="${REPO_ROOT}/.github/workflows/security.yml"
+LINUX_UNIX_SOCKET_PATH_BYTES=108
+OPENSSH_TEMPORARY_CONTROL_PATH_SUFFIX_BYTES=17
+OBSERVED_GITHUB_STATE_DIR_BYTES=43
 
 fail() {
   echo "$1" >&2
@@ -55,6 +58,20 @@ assert_match_count() {
     echo "expected ${file} to contain ${expected} matching line(s): ${pattern}; got ${actual}" >&2
     cat "$file" >&2
     exit 1
+  fi
+}
+
+assert_control_path_fits() {
+  local control_path=$1
+  local control_path_bytes
+  local openssh_temporary_path_bytes
+  control_path_bytes=$(printf '%s' "$control_path" | wc -c)
+  openssh_temporary_path_bytes=$((
+    control_path_bytes
+      + OPENSSH_TEMPORARY_CONTROL_PATH_SUFFIX_BYTES
+  ))
+  if [ "$openssh_temporary_path_bytes" -ge "$LINUX_UNIX_SOCKET_PATH_BYTES" ]; then
+    fail "recovery ControlPath exceeds the OpenSSH/Linux socket budget: ${openssh_temporary_path_bytes} bytes"
   fi
 }
 
@@ -311,7 +328,11 @@ assert_line_count "$actual_failure/actual-ssh.log" 1 \
 assert_line_count "$actual_failure/stdout" 1 "actual stdout"
 assert_line_count "$actual_failure/stderr" 1 "actual stderr"
 
-recovery="${tmp}/recovery"
+recovery="${tmp}/github-runner-work-temp-cf-ssh"
+recovery_state_dir_bytes=$(printf '%s' "${recovery}/state" | wc -c)
+if [ "$recovery_state_dir_bytes" -lt "$OBSERVED_GITHUB_STATE_DIR_BYTES" ]; then
+  fail "recovery test state path is shorter than the observed GitHub runner path"
+fi
 run_wrapper "$recovery" stale-success ssh \
   metal@dev-11.gcp.vm3.ai touch /tmp/recovered-operation
 assert_contains "$recovery/status" "0"
@@ -331,6 +352,7 @@ state_file=$(find "$recovery/state" -name '*.control-path' -print -quit)
 [ -n "$state_file" ] || fail "expected recovery control-path state"
 selected_control_path=$(< "$state_file")
 [ -n "$selected_control_path" ] || fail "expected selected recovery socket"
+assert_control_path_fits "$selected_control_path"
 assert_line_count "$recovery/ssh.log" 1 \
   "-S ${selected_control_path} -n -M -N -f metal@dev-11.gcp.vm3.ai"
 assert_line_count "$recovery/ssh.log" 1 \
@@ -417,6 +439,7 @@ new_control_path=$(< "$state_file")
 if [ "$new_control_path" = "$old_control_path" ]; then
   fail "stale selected transport must be replaced with a unique socket"
 fi
+assert_control_path_fits "$new_control_path"
 assert_match_count "$recovery/ssh.log" 2 "-M -N -f"
 assert_line_count "$recovery/actual-ssh.log" 1 \
   "-o ControlPath=${new_control_path} metal@dev-11.gcp.vm3.ai touch /tmp/second-recovery"


### PR DESCRIPTION
## Summary

- create each Cloudflare SSH recovery master at a compact, atomically unique
  path inside the existing job-scoped state root
- reserve the 17 bytes OpenSSH appends while binding its temporary
  multiplexing socket below Linux's 108-byte Unix socket path size
- exercise first and repeated recovery from a GitHub-runner-shaped long state
  path and enforce the pathname budget in the wrapper integration test

## Safety boundary

- per-user/host locking and atomic selected-path publication are unchanged
- every replacement still receives a distinct directory, so an older master
  cannot unlink or collide with its successor
- only the detached no-op probe and no-command master establishment can retry;
  the real SSH, SCP, SFTP, or Ansible operation remains single-shot
- no API, database, runner protocol, migration, deployment-order, or persisted
  production state changes

## Validation

- `bash .github/scripts/tests/cloudflare-ssh-command-test.sh`
- `bash .github/scripts/tests/cloudflare-ssh-preconnect-test.sh`
- Bash syntax for `.github/scripts/*.sh` and
  `.github/scripts/tests/*.sh`
- the Security workflow's complete ShellCheck command
- `.github/scripts/check-workflow-shell-compatibility.sh`
- `for test_script in .github/scripts/tests/*.sh; do bash "$test_script"; done`
- `actionlint 1.7.12`
- `./scripts/check-file-size.sh` for both changed files
- `git diff --check`

Closes #24028
