### PR TITLE
feat(platform): support japanese locale

### DIFF
--- a/turbo/apps/api/src/lib/japanese-locale-rollout.ts
+++ b/turbo/apps/api/src/lib/japanese-locale-rollout.ts
@@ -1,0 +1,9 @@
+import { optionalEnv } from "./env";
+
+/**
+ * Keep a deploy-time compatibility gate so emergency rollbacks can disable
+ * ja-JP preference reads and writes without rebuilding the API.
+ */
+export function isJapaneseLocaleRolloutEnabled(): boolean {
+  return optionalEnv("JAPANESE_LOCALE_ROLLOUT_ENABLED") === "true";
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
@@ -28,6 +28,7 @@ import {
 import { zeroOrgLogoContract } from "@vm0/api-contracts/contracts/zero-org-logo";
 import {
   addClientCapabilityToVersion,
+  CLIENT_CAPABILITY_JA_JP_LOCALE,
   CLIENT_CAPABILITY_PT_BR_LOCALE,
   CLIENT_VERSION_HEADER,
 } from "@vm0/api-contracts/contracts/client-headers";
@@ -58,6 +59,10 @@ type UpdateUserPreferencesInput = z.input<
 export const BRAZILIAN_PORTUGUESE_CLIENT_VERSION = addClientCapabilityToVersion(
   "0.648.0",
   CLIENT_CAPABILITY_PT_BR_LOCALE,
+);
+export const JAPANESE_CLIENT_VERSION = addClientCapabilityToVersion(
+  BRAZILIAN_PORTUGUESE_CLIENT_VERSION,
+  CLIENT_CAPABILITY_JA_JP_LOCALE,
 );
 
 type ZeroLogsSearchQuery = z.input<

--- a/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
@@ -9,6 +9,7 @@ import { createBddApi, expectApiError } from "./helpers/api-bdd";
 import {
   BRAZILIAN_PORTUGUESE_CLIENT_VERSION,
   createMiscRoutesApi,
+  JAPANESE_CLIENT_VERSION,
 } from "./helpers/api-bdd-misc";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 
@@ -318,6 +319,142 @@ describe("MISC-02: preferences, push subscription, user export, and empty logs",
       BRAZILIAN_PORTUGUESE_CLIENT_VERSION,
     );
     expect(capableReread.body.locale).toBe("pt-BR");
+  });
+
+  it("negotiates Japanese across rollout and legacy clients", async () => {
+    const { api, admin } = testActors();
+    mockOptionalEnv("BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED", undefined);
+    mockOptionalEnv("JAPANESE_LOCALE_ROLLOUT_ENABLED", undefined);
+
+    const guarded = await api.readPreferences(admin, JAPANESE_CLIENT_VERSION);
+    expect(guarded.body).toMatchObject({
+      locale: null,
+      supportedLocales: ["en-US"],
+    });
+
+    const rejected = await api.updatePreferences(
+      admin,
+      { locale: "ja-JP" },
+      [400],
+      JAPANESE_CLIENT_VERSION,
+    );
+    expectApiError(rejected.body);
+
+    const orgId = admin.orgId;
+    if (orgId === null) {
+      throw new Error("Expected an organization-scoped test actor");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      {
+        userId: admin.userId,
+        orgId,
+        ...(admin.orgRole && { orgRole: admin.orgRole }),
+      },
+      {
+        [FeatureSwitchKey.JapaneseLocale]: true,
+      },
+    );
+
+    const publicOverrideRejected = await api.updatePreferences(
+      admin,
+      { locale: "ja-JP" },
+      [400],
+      JAPANESE_CLIENT_VERSION,
+    );
+    expectApiError(publicOverrideRejected.body);
+
+    mockOptionalEnv("JAPANESE_LOCALE_ROLLOUT_ENABLED", "true");
+
+    const legacyClientRejected = await api.updatePreferences(
+      admin,
+      { locale: "ja-JP" },
+      [400],
+    );
+    expectApiError(legacyClientRejected.body);
+
+    const portugueseClientRejected = await api.updatePreferences(
+      admin,
+      { locale: "ja-JP" },
+      [400],
+      BRAZILIAN_PORTUGUESE_CLIENT_VERSION,
+    );
+    expectApiError(portugueseClientRejected.body);
+
+    const english = await api.updatePreferences(
+      admin,
+      { locale: "en-US" },
+      [200],
+      JAPANESE_CLIENT_VERSION,
+    );
+    expect(english.body).toMatchObject({
+      locale: "en-US",
+      supportedLocales: ["en-US", "ja-JP"],
+    });
+
+    const japanese = await api.updatePreferences(
+      admin,
+      { locale: "ja-JP" },
+      [200],
+      JAPANESE_CLIENT_VERSION,
+    );
+    expect(japanese.body).toMatchObject({
+      locale: "ja-JP",
+      supportedLocales: ["en-US", "ja-JP"],
+    });
+
+    const legacyRead = await api.readPreferences(admin);
+    expect(legacyRead.body.locale).toBe("en-US");
+    expect(legacyRead.body.supportedLocales).toBeUndefined();
+
+    const portugueseClientRead = await api.readPreferences(
+      admin,
+      BRAZILIAN_PORTUGUESE_CLIENT_VERSION,
+    );
+    expect(portugueseClientRead.body).toMatchObject({
+      locale: "en-US",
+      supportedLocales: ["en-US"],
+    });
+
+    await api.updatePreferences(admin, { timezone: "UTC" }, [200]);
+    const capableReread = await api.readPreferences(
+      admin,
+      JAPANESE_CLIENT_VERSION,
+    );
+    expect(capableReread.body.locale).toBe("ja-JP");
+
+    mockOptionalEnv("JAPANESE_LOCALE_ROLLOUT_ENABLED", undefined);
+    const rollbackRead = await api.readPreferences(
+      admin,
+      JAPANESE_CLIENT_VERSION,
+    );
+    expect(rollbackRead.body).toMatchObject({
+      locale: "en-US",
+      supportedLocales: ["en-US"],
+    });
+    await api.updatePreferences(
+      admin,
+      { timezone: "Asia/Tokyo" },
+      [200],
+      JAPANESE_CLIENT_VERSION,
+    );
+
+    mockOptionalEnv("JAPANESE_LOCALE_ROLLOUT_ENABLED", "true");
+    const postRollbackRead = await api.readPreferences(
+      admin,
+      JAPANESE_CLIENT_VERSION,
+    );
+    expect(postRollbackRead.body.locale).toBe("ja-JP");
+
+    mockOptionalEnv("BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED", "true");
+    const allLocales = await api.readPreferences(
+      admin,
+      JAPANESE_CLIENT_VERSION,
+    );
+    expect(allLocales.body).toMatchObject({
+      locale: "ja-JP",
+      supportedLocales: ["en-US", "pt-BR", "ja-JP"],
+    });
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -3,6 +3,7 @@ import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -12,6 +13,27 @@ function client() {
 }
 
 describe("/api/zero/feature-switches", () => {
+  it("projects the Japanese locale deployment switch", async () => {
+    createZeroRouteMocks(context).clerk.session(
+      "user_japanese_locale_switch_test",
+      "org_japanese_locale_switch_test",
+      "org:member",
+    );
+    const headers = { authorization: "Bearer clerk-session" };
+
+    mockOptionalEnv("JAPANESE_LOCALE_ROLLOUT_ENABLED", undefined);
+    const disabled = await accept(client().get({ headers }), [200]);
+    expect(
+      disabled.body.effectiveSwitches[FeatureSwitchKey.JapaneseLocale],
+    ).toBeFalsy();
+
+    mockOptionalEnv("JAPANESE_LOCALE_ROLLOUT_ENABLED", "true");
+    const enabled = await accept(client().get({ headers }), [200]);
+    expect(
+      enabled.body.effectiveSwitches[FeatureSwitchKey.JapaneseLocale],
+    ).toBeTruthy();
+  });
+
   it("persists and activates inline templates for a non-staff org", async () => {
     createZeroRouteMocks(context).clerk.session(
       "user_nonstaff_feature_switch_test",

--- a/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
@@ -4,6 +4,7 @@ import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { isBrazilianPortugueseLocaleRolloutEnabled } from "../../lib/brazilian-portuguese-locale-rollout";
+import { isJapaneseLocaleRolloutEnabled } from "../../lib/japanese-locale-rollout";
 import { isZeroMailReplyFollowUpRolloutEnabled } from "../../lib/zero-mail-reply-follow-up-rollout";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -36,6 +37,8 @@ function featureSwitchResponseBody(params: {
     isZeroMailReplyFollowUpRolloutEnabled();
   effectiveSwitches[FeatureSwitchKey.BrazilianPortugueseLocale] =
     isBrazilianPortugueseLocaleRolloutEnabled();
+  effectiveSwitches[FeatureSwitchKey.JapaneseLocale] =
+    isJapaneseLocaleRolloutEnabled();
 
   return {
     switches: params.switches,

--- a/turbo/apps/api/src/signals/routes/zero-user-preferences.ts
+++ b/turbo/apps/api/src/signals/routes/zero-user-preferences.ts
@@ -1,17 +1,19 @@
 import { command, computed } from "ccstate";
 import {
   clientVersionSupportsCapability,
+  CLIENT_CAPABILITY_JA_JP_LOCALE,
   CLIENT_CAPABILITY_PT_BR_LOCALE,
   CLIENT_VERSION_HEADER,
 } from "@vm0/api-contracts/contracts/client-headers";
 import {
-  SUPPORTED_USER_LOCALES,
+  type UserLocale,
   type UserPreferencesResponse,
   zeroUserPreferencesContract,
 } from "@vm0/api-contracts/contracts/zero-user-preferences";
 
 import { isBrazilianPortugueseLocaleRolloutEnabled } from "../../lib/brazilian-portuguese-locale-rollout";
 import { badRequestMessage } from "../../lib/error";
+import { isJapaneseLocaleRolloutEnabled } from "../../lib/japanese-locale-rollout";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { request$ } from "../context/hono";
@@ -28,44 +30,62 @@ const updateUserPreferencesBody$ = bodyResultOf(
 
 interface LocaleRollout {
   readonly clientSupportsBrazilianPortuguese: boolean;
+  readonly clientSupportsJapanese: boolean;
   readonly brazilianPortugueseEnabled: boolean;
+  readonly japaneseEnabled: boolean;
 }
 
 const localeRollout$ = computed((get): LocaleRollout => {
+  const clientVersion = get(request$).raw.headers.get(CLIENT_VERSION_HEADER);
   const clientSupportsBrazilianPortuguese = clientVersionSupportsCapability(
-    get(request$).raw.headers.get(CLIENT_VERSION_HEADER),
+    clientVersion,
     CLIENT_CAPABILITY_PT_BR_LOCALE,
   );
-  if (!clientSupportsBrazilianPortuguese) {
-    return {
-      clientSupportsBrazilianPortuguese: false,
-      brazilianPortugueseEnabled: false,
-    };
-  }
+  const clientSupportsJapanese = clientVersionSupportsCapability(
+    clientVersion,
+    CLIENT_CAPABILITY_JA_JP_LOCALE,
+  );
 
   return {
-    clientSupportsBrazilianPortuguese: true,
-    brazilianPortugueseEnabled: isBrazilianPortugueseLocaleRolloutEnabled(),
+    clientSupportsBrazilianPortuguese,
+    clientSupportsJapanese,
+    brazilianPortugueseEnabled:
+      clientSupportsBrazilianPortuguese &&
+      isBrazilianPortugueseLocaleRolloutEnabled(),
+    japaneseEnabled: clientSupportsJapanese && isJapaneseLocaleRolloutEnabled(),
   };
 });
+
+function supportedLocalesForRollout(rollout: LocaleRollout): UserLocale[] {
+  const supportedLocales: UserLocale[] = ["en-US"];
+  if (rollout.brazilianPortugueseEnabled) {
+    supportedLocales.push("pt-BR");
+  }
+  if (rollout.japaneseEnabled) {
+    supportedLocales.push("ja-JP");
+  }
+  return supportedLocales;
+}
 
 function projectUserPreferences(
   preferences: UserPreferencesResponse,
   rollout: LocaleRollout,
 ): UserPreferencesResponse {
   // TODO(#23508): remove projection after legacy browser clients expire.
+  const supportedLocales = supportedLocalesForRollout(rollout);
   const locale =
-    rollout.brazilianPortugueseEnabled || preferences.locale !== "pt-BR"
+    preferences.locale === undefined ||
+    preferences.locale === null ||
+    supportedLocales.includes(preferences.locale)
       ? preferences.locale
       : "en-US";
 
   return {
     ...preferences,
     locale,
-    ...(rollout.clientSupportsBrazilianPortuguese && {
-      supportedLocales: rollout.brazilianPortugueseEnabled
-        ? [...SUPPORTED_USER_LOCALES]
-        : ["en-US"],
+    ...((rollout.clientSupportsBrazilianPortuguese ||
+      rollout.clientSupportsJapanese) && {
+      supportedLocales,
     }),
   };
 }
@@ -100,6 +120,7 @@ const updateUserPreferencesInner$ = command(
         userId: auth.userId,
         preferences: body.data,
         allowBrazilianPortuguese: rollout.brazilianPortugueseEnabled,
+        allowJapanese: rollout.japaneseEnabled,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/zero-user-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-data.service.ts
@@ -60,7 +60,12 @@ function parseSendMode(value: unknown): SendMode {
 }
 
 function parseUserLocale(value: unknown): UserLocale | null {
-  if (value === null || value === "en-US" || value === "pt-BR") {
+  if (
+    value === null ||
+    value === "en-US" ||
+    value === "pt-BR" ||
+    value === "ja-JP"
+  ) {
     return value;
   }
   // TODO(#23508): remove after persisted legacy values are migrated.
@@ -179,11 +184,23 @@ export function userModelPreference({
 interface UpdateUserPreferencesArgs extends UserScopedQuery {
   readonly preferences: UpdateUserPreferencesRequest;
   readonly allowBrazilianPortuguese?: boolean;
+  readonly allowJapanese?: boolean;
 }
 
 type UpdateUserPreferencesResult =
   | { readonly ok: true; readonly data: UserPreferencesResponse }
   | { readonly ok: false; readonly message: string };
+
+function isUserPreferencesUpdateAllowed(
+  args: UpdateUserPreferencesArgs,
+): boolean {
+  const { locale, timezone } = args.preferences;
+  return (
+    (locale !== "pt-BR" || args.allowBrazilianPortuguese === true) &&
+    (locale !== "ja-JP" || args.allowJapanese === true) &&
+    (timezone === undefined || isValidTimeZone(timezone))
+  );
+}
 
 export const updateUserPreferences$ = command(
   async (
@@ -192,19 +209,7 @@ export const updateUserPreferences$ = command(
     signal: AbortSignal,
   ): Promise<UpdateUserPreferencesResult> => {
     const preferences = args.preferences;
-    if (
-      preferences.locale === "pt-BR" &&
-      args.allowBrazilianPortuguese !== true
-    ) {
-      return {
-        ok: false,
-        message: "Invalid request",
-      };
-    }
-    if (
-      preferences.timezone !== undefined &&
-      !isValidTimeZone(preferences.timezone)
-    ) {
+    if (!isUserPreferencesUpdateAllowed(args)) {
       return {
         ok: false,
         message: "Invalid request",

--- a/turbo/apps/platform/i18next.config.ts
+++ b/turbo/apps/platform/i18next.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "i18next-cli";
 
 export default defineConfig({
-  locales: ["en-US", "pt-BR"],
+  locales: ["en-US", "pt-BR", "ja-JP"],
   extract: {
     input: ["src/**/*.{ts,tsx}"],
     ignore: [

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -158,11 +158,15 @@
         var cached = cacheKey ? localStorage.getItem(cacheKey) : null;
         // Prefer the workspace cache. Signed-out and first-time visitors use a
         // supported browser language, with English as the fallback.
-        var browserLocale = /^pt(?:-|$)/i.test(navigator.language)
-          ? "pt-BR"
-          : "en-US";
+        var browserLocale = /^ja(?:-|$)/i.test(navigator.language)
+          ? "ja-JP"
+          : /^pt(?:-|$)/i.test(navigator.language)
+            ? "pt-BR"
+            : "en-US";
         var locale =
-          cached === "en-US" || cached === "pt-BR" ? cached : browserLocale;
+          cached === "en-US" || cached === "pt-BR" || cached === "ja-JP"
+            ? cached
+            : browserLocale;
         var copyByLocale = {
           "en-US": {
             browserUpgrade: {
@@ -266,6 +270,58 @@
               description:
                 "Zero é seu colega de IA da vm0. Envie uma mensagem para o Zero ou converse pela web — pesquise, envie e-mails, crie documentos e use Slack, GitHub, Notion e mais de 100 ferramentas.",
               title: "Zero — Seu colega de IA da vm0",
+            },
+          },
+          "ja-JP": {
+            browserUpgrade: {
+              browser: {
+                actionLabel: "ブラウザを更新",
+                description:
+                  "現在のブラウザのバージョンはZeroでサポートされていません。続行するにはブラウザを更新してください。",
+                title: "続行するにはブラウザを更新してください",
+              },
+              chrome: {
+                actionLabel: "Chromeを更新",
+                description:
+                  "現在のブラウザのバージョンはZeroでサポートされていません。続行するにはChromeを更新してください。",
+                title: "続行するにはChromeを更新してください",
+              },
+              chromium: {
+                actionLabel: "Chromiumを更新",
+                description:
+                  "現在のブラウザのバージョンはZeroでサポートされていません。続行するにはChromiumを更新してください。",
+                title: "続行するにはChromiumを更新してください",
+              },
+              ios: {
+                actionLabel: "iOSを更新",
+                description:
+                  "現在のブラウザのバージョンはZeroでサポートされていません。続行するにはiOSを更新してください。",
+                title: "続行するにはiOSを更新してください",
+              },
+              safari: {
+                actionLabel: "Safariを更新",
+                description:
+                  "現在のブラウザのバージョンはZeroでサポートされていません。続行するにはSafariを更新してください。",
+                title: "続行するにはSafariを更新してください",
+              },
+            },
+            loading: {
+              ariaLabel: "ワークスペースを読み込み中",
+              messages: [
+                "ニューラルネットワークを準備しています...",
+                "アイデアを練っています...",
+                "準備しています...",
+                "もうすぐです...",
+                "ワークスペースを読み込んでいます...",
+                "楽器を調整しています...",
+                "点と点をつないでいます...",
+                "チームを立ち上げています...",
+              ],
+            },
+            metadata: {
+              description:
+                "Zeroはvm0のAIコワーカーです。Zeroにメッセージを送るか、Webでチャットできます。リサーチ、メール、ドキュメント、Slack、GitHub、Notionなど、100以上のツールを利用できます。",
+              title: "Zero — vm0のAIコワーカー",
             },
           },
         };

--- a/turbo/apps/platform/src/i18n/locale-storage.ts
+++ b/turbo/apps/platform/src/i18n/locale-storage.ts
@@ -9,7 +9,9 @@ export function localeStorageKey(orgId: string): string {
 function parseSupportedLocale(
   value: string | null | undefined,
 ): SupportedLocale | null {
-  return value === "en-US" || value === "pt-BR" ? value : null;
+  return value === "en-US" || value === "pt-BR" || value === "ja-JP"
+    ? value
+    : null;
 }
 
 export function resolveDocumentLocale(): SupportedLocale {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4277,6 +4277,7 @@
         "label": "Language",
         "options": {
           "english": "English",
+          "japanese": "日本語",
           "portugueseBrazil": "Português (Brasil)"
         },
         "title": "Language"

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/agents.json
@@ -1,0 +1,639 @@
+{
+  "actions": {
+    "cancel": "キャンセル",
+    "close": "閉じる",
+    "copying": "コピー中…",
+    "create": "作成",
+    "delete": "エージェントの削除",
+    "deleting": "削除中…",
+    "discard": "破棄",
+    "retry": "再試行",
+    "save": "保存",
+    "saving": "保存中…"
+  },
+  "authorization": {
+    "closeSearch": "検索を閉じる",
+    "connectorsLink": "コネクター",
+    "connectorsSaved": "コネクターを保存しました",
+    "customConnectors": {
+      "authorize": "このエージェントに{{connectorName}}を許可",
+      "description": "組織が登録したカスタムコネクターです。シークレットを設定したコネクターのみ有効にできます。",
+      "noSecret": "シークレットは設定されていません",
+      "noSecretSuffix": " — シークレットが設定されていません",
+      "saved": "カスタムコネクターを保存しました"
+    },
+    "description": "実行中、エージェントは接続済みサービスを安全に利用できます。アクセスはいつでも管理または無効化できます。",
+    "findConnectors": "コネクターを検索",
+    "noConnectorsAfterLink": "ページで最初のサービスを接続してください。",
+    "noConnectorsAlt": "コネクターなし",
+    "noConnectorsBeforeLink": "接続済みのサービスはまだありません。",
+    "noResults": "「{{search}}」の結果はありません",
+    "permissionLoadError": "権限の読み込みに失敗しました",
+    "permissionsUpdated": "権限が更新されました",
+    "searchPlaceholder": "コネクターを検索..."
+  },
+  "avatar": {
+    "accessibilityDescription": "エージェントのアバターのスタイル、色、顔の詳細をカスタマイズします。",
+    "actions": {
+      "customize": "アバターのカスタマイズ"
+    },
+    "create": "カスタムアバターを作成する",
+    "description": "スタイルを選ぶか、シャッフルしてランダムな見た目を試せます。",
+    "intensity": {
+      "chill": "チル",
+      "hyped": "ハイテンション",
+      "normal": "ノーマル"
+    },
+    "nextStep": "次のステップ",
+    "previousStep": "前のステップ",
+    "randomize": "アバターをランダム化する",
+    "shuffleHint": "シャッフル — ランダムに見てみましょう!",
+    "steps": {
+      "angle": "角度",
+      "color": "色",
+      "face": "顔",
+      "hair": "髪",
+      "mood": "気分",
+      "skin": "肌"
+    },
+    "title": "エージェントの顔を作成",
+    "use": "このアバターを使用"
+  },
+  "delete": {
+    "dangerZone": "危険な操作",
+    "dangerZoneDescription": "このエージェントとそのすべてのデータを完全に削除します。この操作は元に戻すことができません。",
+    "description": "エージェント、そのワークフロー、オートメーション、および全員のチャット履歴を削除します。",
+    "irreversible": "これを元に戻すことはできません。",
+    "success": "エージェントが削除されました",
+    "title": "{{agentName}} を削除しますか?",
+    "workflows": {
+      "copyTo": "{{agentName}} にコピーします",
+      "deleteWithAgent": "エージェントと一緒に削除",
+      "description": "ワークフローを別のエージェントにコピーして保持します。残ったものはすべて削除されます。",
+      "handle": "ワークフロー「{{workflowTitle}}」を処理",
+      "title": "ワークフローを残しますか？"
+    }
+  },
+  "detail": {
+    "chatWith": "{{agentName}} とチャットする",
+    "defaultDescription": "あなた向けに調整されたAIチームメイト",
+    "noSelection": "エージェントが選択されていません",
+    "notFound": {
+      "back": "チームに戻る",
+      "description": "エージェント「{{agentId}}」が存在しないか、アクセス権がありません。",
+      "title": "エージェントが見つかりません"
+    },
+    "tabs": {
+      "authorization": "アクセス権限",
+      "instructions": "指示",
+      "profile": "プロフィール"
+    },
+    "viewProfile": "エージェントのプロフィールを表示する"
+  },
+  "errors": {
+    "unknown": "不明なエラー"
+  },
+  "fallbackName": "エージェント",
+  "ideation": {
+    "all": "すべて",
+    "catalog": {
+      "creative": {
+        "cases": {
+          "cloudinary-media-optimizer": {
+            "description": "画像を一括で最適化および変換する",
+            "title": "Cloudinary メディア オプティマイザー"
+          },
+          "elevenlabs-audio-content": {
+            "description": "ドライブに保存された Notion 記事の音声ナレーション",
+            "title": "ElevenLabs オーディオ コンテンツ"
+          },
+          "fal-ai-image-generation": {
+            "description": "Notion の説明から製品画像を生成します",
+            "title": "Fal AI イメージの生成"
+          },
+          "heygen-video-from-script": {
+            "description": "Notion スクリプトはチーム ping を使用して HeyGen ビデオになります",
+            "title": "スクリプトからの HeyGen ビデオ"
+          },
+          "runway-video-from-brief": {
+            "description": "クリエイティブなブリーフから短いビデオを生成する",
+            "title": "Runwayでブリーフから動画を生成"
+          }
+        },
+        "title": "クリエイティブ"
+      },
+      "engineering": {
+        "cases": {
+          "batch-create-issues": {
+            "description": "リストを貼り付けると、ZeroがIssueを一括作成します",
+            "title": "Issueを一括作成"
+          },
+          "browserbase-web-testing": {
+            "description": "Web アプリの自動ブラウザ テスト",
+            "title": "Browserbase Web テスト"
+          },
+          "cloudflare-traffic-security-report": {
+            "description": "毎週の Slack によるトラフィックとセキュリティ イベントの要約",
+            "title": "Cloudflare トラフィックとセキュリティ レポート"
+          },
+          "codebase-investigation": {
+            "description": "URL を指定すると、Zero がリポジトリを通じてバグを追跡します。",
+            "title": "コードベースの調査"
+          },
+          "daily-standup-report": {
+            "description": "朝の指標は、Slack に投稿されるスライドデッキになります",
+            "title": "日次スタンドアップレポート"
+          },
+          "deep-research-code-analysis": {
+            "description": "コードベース内でサブシステムがどのように動作するかを説明します",
+            "title": "徹底的なコード分析"
+          },
+          "github-pr-summarizer": {
+            "description": "Notion のプル リクエストの概要とオプションの Slack の投稿を統合しました",
+            "title": "GitHub PR サマライザー"
+          },
+          "github-progress-weekly": {
+            "description": "機能別にまとめられた週次リポジトリ アクティビティ",
+            "title": "GitHub 毎週の進捗状況"
+          },
+          "gitlab-to-github-migration-helper": {
+            "description": "GitLabのIssueとマージリクエストをGitHubにミラーリング",
+            "title": "GitLab から GitHub への移行ヘルパー"
+          },
+          "jira-github-issue-sync": {
+            "description": "JiraチケットとGitHub Issueを同期します",
+            "title": "Jira ↔ GitHub Issue同期"
+          },
+          "make-scenario-builder": {
+            "description": "説明から複数ステップの Make シナリオを設計する",
+            "title": "Make シナリオ ビルダー"
+          },
+          "security-dependency-alert-digest": {
+            "description": "GitHub からの毎週のセキュリティと依存関係のアラート",
+            "title": "セキュリティと依存関係のアラート ダイジェスト"
+          },
+          "sentry-issue-digest": {
+            "description": "重大度ごとにグループ化された問題の朝のダイジェスト",
+            "title": "Sentry 問題のダイジェスト"
+          },
+          "vercel-deploy-digest": {
+            "description": "各デプロイメントをそのコミットにリンクし、デプロイメントが失敗した場合に Slack を警告します。",
+            "title": "Vercel デプロイ ダイジェスト"
+          },
+          "zapier-vm0-migration": {
+            "description": "Zapier ワークフローを VM0 エージェントとして再作成します",
+            "title": "Zapier → VM0 の移行"
+          }
+        },
+        "title": "エンジニアリング"
+      },
+      "everyone": {
+        "cases": {
+          "browser-screenshots": {
+            "description": "ブラウザでページを開き、スクリーンショットを返します",
+            "title": "ブラウザのスクリーンショット"
+          },
+          "calendar-optimizer": {
+            "description": "競合、過負荷、集中時間を軽減します",
+            "title": "カレンダーオプティマイザー"
+          },
+          "calendly-booking-sync": {
+            "description": "Slack ping によるカレンダーの新しい予約",
+            "title": "Calendly 予約同期"
+          },
+          "email-assistant": {
+            "description": "朝の受信トレイの概要と推奨される次のステップ",
+            "title": "メールアシスタント"
+          },
+          "granola-notes-to-notion": {
+            "description": "Granola の会議メモが Notion データベースに同期されました",
+            "title": "GranolaのメモをNotionへ"
+          },
+          "lark-slack-message-relay": {
+            "description": "Lark と Slack の間で双方向にメッセージを転送します",
+            "title": "Lark ↔ Slack メッセージリレー"
+          },
+          "line-message-relay": {
+            "description": "LINE メッセージを Slack に転送、またはその逆",
+            "title": "LINE メッセージ リレー"
+          },
+          "meeting-notes-pipeline": {
+            "description": "Fireflies は Notion にメモし、Slack でフォローアップします",
+            "title": "会議メモのパイプライン"
+          },
+          "morning-brief": {
+            "description": "メール、カレンダー、メモを短い日次計画に変える",
+            "title": "モーニングブリーフ"
+          },
+          "perplexity-deep-research": {
+            "description": "AI を利用した調査概要は Notion に保存されます",
+            "title": "Perplexityディープリサーチ"
+          },
+          "personal-weekly-digest": {
+            "description": "プルリクエスト、メール、カレンダーを1件のSlack更新にまとめます",
+            "title": "個人的な毎週のダイジェスト"
+          },
+          "self-update-instructions": {
+            "description": "エージェントの指示をチャット内で直接更新する",
+            "title": "自己更新の手順"
+          },
+          "send-messages-on-your-behalf": {
+            "description": "チームのお知らせを Slack に投稿します",
+            "title": "あなたに代わってメッセージを送信する"
+          },
+          "strava-team-fitness-digest": {
+            "description": "毎週のチーム活動の概要が Slack に投稿される",
+            "title": "Strava チーム フィットネス ダイジェスト"
+          },
+          "tavily-web-research-pipeline": {
+            "description": "Web を検索し、結果を Notion にまとめます",
+            "title": "Tavily ウェブリサーチパイプライン"
+          },
+          "tl-dv-meeting-recap": {
+            "description": "Notion に要約された会議の記録とアクションアイテム",
+            "title": "TL;DV 会議の要約"
+          }
+        },
+        "title": "すべて"
+      },
+      "marketing": {
+        "cases": {
+          "apify-web-scraper-to-sheets": {
+            "description": "Apify はサイトを構造化された Google Sheets 行にスクレイピングします",
+            "title": "Web スクレイパーをスプレッドシートに適用"
+          },
+          "brevo-email-nurture-sequence": {
+            "description": "CRMイベントからの自動メールシーケンス",
+            "title": "Brevo メールナーチャリングシーケンス"
+          },
+          "competitive-intel-scraper": {
+            "description": "Firecrawl は競合サイトを監視し、Notion の変更をログに記録します。",
+            "title": "競争力のあるインテル スクレーパー"
+          },
+          "competitor-research-to-notion": {
+            "description": "X に関する研究が構造化メモとして Notion に保存されました",
+            "title": "Notion に対する競合他社の調査"
+          },
+          "content-planner": {
+            "description": "トピックをブレインストーミングし、編集カレンダーの概要を作成する",
+            "title": "コンテンツプランナー"
+          },
+          "dev-to-auto-publisher": {
+            "description": "Notion の投稿を Dev.to に公開し、X にリンクします",
+            "title": "Dev.to自動公開"
+          },
+          "discord-community-insights": {
+            "description": "Notion の Discord フィードバックと毎週の Slack ダイジェスト",
+            "title": "Discord コミュニティのインサイト"
+          },
+          "instagram-engagement-tracker": {
+            "description": "毎週の Slack 概要をスプレッドシートで利用する",
+            "title": "Instagram エンゲージメント トラッカー"
+          },
+          "loops-email-campaign": {
+            "description": "Loops 経由でトランザクションメールを作成して送信する",
+            "title": "ループメールキャンペーン"
+          },
+          "marketing-automation-system": {
+            "description": "研究、毎週の監視、臨時作業のための 3 つのエージェント",
+            "title": "マーケティングオートメーションシステム"
+          },
+          "marketing-content-planning": {
+            "description": "Slack の記事、インタビュー、競合他社の記事を公開する予定です",
+            "title": "マーケティングコンテンツの企画"
+          },
+          "onboarding-email-use-cases": {
+            "description": "Slack とインタビューからオンボーディングの視点を見つける",
+            "title": "オンボーディングメールの使用例"
+          },
+          "serpapi-keyword-tracker": {
+            "description": "キーワードランキングを毎週追跡し、スプレッドシートに記録します",
+            "title": "SerpAPI キーワード トラッカー"
+          },
+          "similarweb-traffic-comparison": {
+            "description": "Notion に保存されたトラフィック ベンチマークと競合他社",
+            "title": "類似ウェブのトラフィック比較"
+          },
+          "social-media-content-calendar": {
+            "description": "スプレッドシートのカレンダーを各ネットワークの投稿に変える",
+            "title": "ソーシャルメディアコンテンツカレンダー"
+          },
+          "x-brand-monitor": {
+            "description": "Notion に保存された X に関するブランドのメンションとチーム アラート",
+            "title": "Xブランドモニター"
+          },
+          "youtube-to-x-thread-repurposer": {
+            "description": "新しい YouTube ビデオが公開されると、Notion 概要とそれを宣伝する X スレッドを生成します",
+            "title": "YouTube から X スレッドへのリパーパス化"
+          }
+        },
+        "title": "マーケティング"
+      },
+      "ops": {
+        "cases": {
+          "agentmail-inbox": {
+            "description": "AgentMail API を使用して受信トレイを作成および管理する",
+            "title": "AgentMail 受信箱"
+          },
+          "clickup-slack-standups": {
+            "description": "毎日の ClickUp タスクが Slack にスタンドアップとして投稿されました",
+            "title": "ClickUp → Slack スタンドアップ"
+          },
+          "google-docs-notion-migrator": {
+            "description": "Google ドキュメントはレイアウトを保持したまま Notion にバッチ化されます",
+            "title": "Google ドキュメント → Notion 移行者"
+          },
+          "google-drive-file-organizer": {
+            "description": "新しいファイルは自動的にフォルダーに分類されます",
+            "title": "Google Drive ファイル オーガナイザー"
+          },
+          "jotform-intake-to-notion": {
+            "description": "フォームの回答は Notion に到達し、Slack 通知が送信されます",
+            "title": "Notion への Jotform インテーク"
+          },
+          "monday-com-weekly-digest": {
+            "description": "Slack の Monday.com からの毎週のボードの進捗状況",
+            "title": "Monday.com の毎週のダイジェスト"
+          },
+          "pdf-contract-processor": {
+            "description": "Notion の契約フィールドと有効期限切れ前のリマインダー",
+            "title": "PDF契約処理者"
+          },
+          "revenuecat-subscription-digest": {
+            "description": "Slack の解約アラートを含むスプレッドシートの定期購入指標",
+            "title": "RevenueCat サブスクリプションのダイジェスト"
+          },
+          "todoist-notion-task-sync": {
+            "description": "チームの Notion にミラーリングされた Todoist タスク",
+            "title": "Todoist → Notion タスクの同期"
+          },
+          "wrike-project-reporter": {
+            "description": "Slack の毎週の Wrike 進捗状況サマリー",
+            "title": "Wrikeプロジェクトレポーター"
+          },
+          "xero-financial-summary": {
+            "description": "Slack における Xero からの週間利益とキャッシュ フロー",
+            "title": "Xeroの財務概要"
+          }
+        },
+        "title": "オペレーション"
+      },
+      "product": {
+        "cases": {
+          "asana-notion-project-sync": {
+            "description": "Asana のマイルストーンとタスクが Notion にミラーリングされました",
+            "title": "Asana → Notion プロジェクトの同期"
+          },
+          "feedback-router": {
+            "description": "Slack フィードバックはルールによって適切な場所にルーティングされます",
+            "title": "フィードバックルーター"
+          },
+          "linear-prd-implementer": {
+            "description": "Notion 仕様は Linear プロジェクトと問題になります",
+            "title": "Linear PRD 実装者"
+          },
+          "metabase-dashboard-digest": {
+            "description": "ダッシュボードのスナップショットが Slack に自動的に投稿される",
+            "title": "メタベース ダッシュボードのダイジェスト"
+          },
+          "pricing-analysis": {
+            "description": "競合他社の価格戦略を分析し、類似製品と比較します",
+            "title": "価格分析"
+          },
+          "product-copy-naming": {
+            "description": "製品内の専門用語のわかりやすい名前",
+            "title": "商品コピー＆ネーミング"
+          }
+        },
+        "title": "プロダクト"
+      },
+      "sales": {
+        "cases": {
+          "airtable-deal-tracker": {
+            "description": "取引が終了するとスプレッドシートと Slack に同期されます",
+            "title": "Airtable 取引トラッカー"
+          },
+          "bitrix24-lead-nurture": {
+            "description": "新しい Bitrix リードはフォローアップ タスクと Slack ping を取得します",
+            "title": "Bitrix24 リードナーチャリング"
+          },
+          "hubspot-sales-reporter": {
+            "description": "週次 HubSpot の概要を構造化レポートとして保存",
+            "title": "HubSpot 営業レポーター"
+          },
+          "lead-follow-up-pipeline": {
+            "description": "新しいリードは、Slack アラートを伴う HubSpot タスクになります",
+            "title": "リードフォローアップパイプライン"
+          },
+          "salesforce-pipeline-digest": {
+            "description": "Slack での毎週の Salesforce 案件の更新",
+            "title": "Salesforce パイプライン ダイジェスト"
+          },
+          "streak-pipeline-report": {
+            "description": "Slack の Gmail からの毎週の CRM パイプライン統計",
+            "title": "連続パイプラインレポート"
+          },
+          "win-loss-reporter": {
+            "description": "Slack のパイプラインからの勝敗の傾向",
+            "title": "勝敗記者"
+          }
+        },
+        "title": "セールス"
+      },
+      "support": {
+        "cases": {
+          "chatwoot-notion-support-log": {
+            "description": "Notion に記録され、分類された顧客の会話",
+            "title": "Chatwoot → Notion サポート ログ"
+          },
+          "customer-support-bot": {
+            "description": "ナレッジベースからの回答とギャップに対するタスク",
+            "title": "カスタマーサポートボット"
+          },
+          "intercom-conversation-triager": {
+            "description": "Intercom チャットが Notion タスクに優先される",
+            "title": "Intercom 会話トリアージャー"
+          },
+          "support-ticket-router": {
+            "description": "チケットは Notion に送られ、緊急のチケットは Slack に ping されます。",
+            "title": "サポートチケットルーター"
+          },
+          "zendesk-notion-knowledge-base": {
+            "description": "よくある Zendesk の質問を抽出し、Notion FAQ に自動追加します",
+            "title": "Zendesk → Notion ナレッジ ベース"
+          }
+        },
+        "title": "サポート"
+      }
+    },
+    "chat": "チャット",
+    "description": "任意のカードをクリックして会話を開始します。これは、オンデマンド タスク、定期的なワークフロー、またはサブエージェントになる可能性があります。",
+    "entry": {
+      "description": "すべてのコネクタにわたるユースケースを参照する",
+      "title": "アイデアと使用例",
+      "viewAll": "すべて見る"
+    },
+    "search": {
+      "accessibilityLabel": "ユースケースの検索",
+      "empty": "検索に一致するユースケースはありません。",
+      "placeholder": "検索"
+    },
+    "title": "アイデアと使用例"
+  },
+  "instructions": {
+    "editor": {
+      "accessibilityLabel": "指示エディター",
+      "footerHint": "指示を直接編集して、エージェントの動作をカスタマイズします。",
+      "placeholder": "エージェントへの指示を書きます...",
+      "toolbar": {
+        "blockquote": "ブロッククォート",
+        "bold": "太字",
+        "bulletList": "箇条書きリスト",
+        "heading1": "見出し1",
+        "heading2": "見出し2",
+        "heading3": "見出し 3",
+        "inlineCode": "インラインコード",
+        "italic": "イタリック体",
+        "orderedList": "順序付きリスト",
+        "strikethrough": "取り消し線"
+      }
+    },
+    "saved": "指示を保存しました"
+  },
+  "list": {
+    "actions": {
+      "new": "新しいエージェント"
+    },
+    "cards": {
+      "coreDescription": "あなたのコアエージェント",
+      "createdBy": "{{creator}} によって作成されました",
+      "subagentDescription": "サブエージェント",
+      "unknownCreator": "不明"
+    },
+    "create": {
+      "accessibilityDescription": "新しいエージェントに名前を付け、その可視性を選択し、そのアバターをカスタマイズします。",
+      "creating": "作成中…",
+      "description": "エージェントに名前を付け、それを使用できる人を設定します。",
+      "namePlaceholder": "例: リサーチアシスタント",
+      "newAgentAlt": "新しいエージェント",
+      "success": "{{agentName}} が正常に作成されました",
+      "title": "新しいエージェントを作成する",
+      "visibility": {
+        "private": {
+          "description": "（あなただけが閲覧・使用できます）",
+          "label": "非公開"
+        },
+        "public": {
+          "description": "(このワークスペース内の誰でも使用できます)",
+          "label": "公開"
+        }
+      },
+      "visibilityLabel": "公開範囲"
+    },
+    "description": "{{agentName}} とサブエージェントが連携して、あなたとあなたのチームに合わせたワークフローを実行します。",
+    "documentTitle": "エージェント",
+    "privateEmpty": {
+      "description": "自分だけが表示および使用できるエージェントを作成します。プライベートエージェントは無制限です。",
+      "title": "非公開のエージェントはまだありません"
+    },
+    "tabs": {
+      "private": "非公開",
+      "public": "公開"
+    },
+    "title": "エージェント"
+  },
+  "profile": {
+    "fields": {
+      "avatar": {
+        "description": "独自のアバターを作成します。",
+        "label": "アバター"
+      },
+      "description": {
+        "description": "このエージェントが何を支援するか - チームメイトに表示されます。",
+        "label": "説明",
+        "placeholder": "このエージェントは何をするのですか?"
+      },
+      "name": {
+        "description": "チームリストとこのエージェントが話すときに表示されます。",
+        "label": "名前",
+        "placeholder": "名前を入力"
+      },
+      "tone": {
+        "accessibilityLabel": "{{agentName}}の話し方",
+        "description": "返信の話し方を設定します。トーンを変更するとプレビューも更新されます。",
+        "groupLabel": "トーン",
+        "label": "話し方"
+      },
+      "visibility": {
+        "description": "このワークスペース内の全員に表示されます。",
+        "label": "公開する"
+      }
+    },
+    "makePrivate": {
+      "confirm": "非公開にする",
+      "description": "このエージェントが非公開である間、他のメンバーはそのエージェントの下にあるチャット履歴にアクセスできなくなります。再度公開すると、アクセスが回復されます。",
+      "title": "{{agentName}}を非公開にしますか？",
+      "warningDescription": "他のメンバーには {{agentName}} またはその下のチャットが表示されなくなります。",
+      "warningTitle": "メンバーはアクセスできなくなります"
+    },
+    "saved": "プロフィールを保存しました",
+    "tones": {
+      "direct": {
+        "agentSample": "金曜日。木曜日に草案を送ります。",
+        "hint": "要点を簡潔に",
+        "label": "簡潔",
+        "userSample": "金曜日までに第 3 四半期のレポートが必要です。"
+      },
+      "friendly": {
+        "agentSample": "確かに！第 3 四半期のレポートは金曜日までにお送りします。木曜日に草稿をお送りしますので、ご覧ください。",
+        "hint": "温かくて親しみやすい",
+        "label": "フレンドリー",
+        "userSample": "金曜日までに第 3 四半期のレポートが必要です。"
+      },
+      "professional": {
+        "agentSample": "第 3 四半期のレポートは金曜日までに準備する予定です。あなたのレビューのために木曜日までに草稿を送ります。",
+        "hint": "クリアで洗練された",
+        "label": "プロフェッショナル",
+        "userSample": "金曜日までに第 3 四半期のレポートが必要です。"
+      },
+      "supportive": {
+        "agentSample": "第 3 四半期のレポートは金曜日までに必ず提出します。木曜日に下書きをお送りしますので、ご検討いただく時間を設けてください。他にご要望があればお知らせください。",
+        "hint": "いつでも味方に",
+        "label": "サポート重視",
+        "userSample": "金曜日までに第 3 四半期のレポートが必要です。"
+      }
+    }
+  },
+  "sidebar": {
+    "clearSearch": "検索をクリア",
+    "description": "エージェントを選択して会話を開始します。",
+    "descriptionWithChats": "エージェントを選択するか、チャットにジャンプします。",
+    "leadDescription": "あなたの主任アシスタントがいつでもあなたのためにここにいます",
+    "markAllRead": "すべて既読としてマークする",
+    "more": "もっと見る",
+    "new": "新しい",
+    "noAgents": "エージェントが見つかりませんでした",
+    "noResults": "結果が見つかりませんでした",
+    "noSubagents": "まだ利用可能なサブエージェントはありません。",
+    "openConversation": "会話を開く",
+    "openMenu": "エージェントメニューを開く",
+    "pin": "サイドバーにピン留めする",
+    "pinned": "ピン留め済み",
+    "pinnedAgents": "ピン留めしたエージェント",
+    "searchAgents": "エージェントを検索...",
+    "searchAgentsAndChats": "エージェントとチャットを検索...",
+    "sections": {
+      "chats": "チャット",
+      "lead": "リード",
+      "others": "その他"
+    },
+    "talkTo": "話しかける",
+    "unpin": "固定を解除する"
+  },
+  "status": {
+    "unread": "未読"
+  },
+  "unsaved": {
+    "message": "未保存の変更があります"
+  }
+}

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1,0 +1,5257 @@
+{
+  "activity": {
+    "codex": {
+      "codexError": "Codex エラー",
+      "commandStatus": "コマンド {{status}}",
+      "error": "エラー: {{error}}",
+      "fileChangeKind": "変更",
+      "fileOperationCompleted": "ファイル操作が完了しました",
+      "fileOperationStatus": "ファイル操作 {{status}}",
+      "fileReadCompleted": "ファイルの読み込みが完了しました",
+      "fileReadStatus": "ファイル読み取り {{status}}",
+      "filesChanged": "[ファイル] 変更されたファイル:",
+      "genericEvent": "Codex {{eventType}}",
+      "genericItem": "Codex {{label}} ({{details}}){{suffix}}",
+      "idDetail": "id: {{id}}",
+      "item": "アイテム",
+      "moreChanges_one": "- ... +{{count}} その他の変更点",
+      "moreChanges_other": "- ... +{{count}} その他の変更点",
+      "moreSteps_one": "- ... +{{count}} の追加手順",
+      "moreSteps_other": "- ... +{{count}} の追加手順",
+      "planPrefix": "【予定】",
+      "planStatus": {
+        "completed": "完了",
+        "inProgress": "進行中",
+        "pending": "保留",
+        "step": "ステップ"
+      },
+      "status": "ステータス: {{status}}",
+      "statusDetail": "ステータス: {{status}}",
+      "turnFailed": "ターンに失敗しました",
+      "turnStatus": "ターン: {{status}}",
+      "warning": "[警告] {{message}}",
+      "warningFallback": "Codex 警告"
+    },
+    "context": {
+      "artifact": "アーティファクト",
+      "environmentMapping": "環境マッピング",
+      "featureFlags": "機能フラグ",
+      "firewalls": "ファイアウォール",
+      "mountPath": "マウントパス",
+      "name": "名前",
+      "networkPolicies": "ネットワークポリシー",
+      "none": "なし",
+      "prompt": "プロンプト",
+      "runId": "実行ID",
+      "secrets": "シークレット",
+      "session": "セッション",
+      "storageName": "ストレージ名",
+      "systemPrompt": "システムプロンプト",
+      "value": "値",
+      "variables": "変数",
+      "version": "バージョン",
+      "volumes": "ボリューム"
+    },
+    "detail": {
+      "activity": "アクティビティ",
+      "contextUnavailable": {
+        "description": "この実行では実行コンテキストを使用できません。コンテキスト スナップショットが有効になる前に作成された古い実行である可能性があります。",
+        "title": "コンテキストが利用できません"
+      },
+      "downloadRawData": "生データをダウンロード",
+      "errorGuidance": {
+        "computerUseAuthorizationRequired": {
+          "guidance": "委任されたコンピューターの使用認証リンクを要求し、ユーザーにこのチャットの Zero Desktop ホストまたは Slack スレッドを選択してから、新しい実行を開始するように依頼します。既存の実行トークンをそのままアップグレードすることはできません。",
+          "title": "コンピュータの使用許可が必要です"
+        },
+        "concurrentRunLimitReached": {
+          "guidance": "現在の実行が完了するまで待ってから、新しい実行を開始してください。",
+          "title": "同時実行制限に達しました"
+        },
+        "creditsDepleted": {
+          "guidance": "まずクレジット診断を実行してください。現在のプランで購入できる場合にのみクレジットを購入し、それ以外の場合はプランのアップグレードリンクを返してください。",
+          "title": "クレジットが枯渇しました"
+        },
+        "modelProviderUnavailable": {
+          "guidance": "このスレッドで使用されているモデルプロバイダーは削除されました。続行するには、新しいチャット スレッドを開始してください。",
+          "title": "モデルプロバイダーが利用できません"
+        },
+        "noModelProvider": {
+          "guidance": "エージェントを実行するには、モデルプロバイダーを設定してください。",
+          "title": "モデルプロバイダーが設定されていません"
+        },
+        "paidPlanRequired": {
+          "guidance": "組み込みのビデオ生成は、現在のプランでは利用できません。",
+          "title": "有料プランが必要です"
+        },
+        "providerIncompatible": {
+          "guidance": "このセッションは別のプロバイダー タイプで作成されました。",
+          "title": "プロバイダーに互換性がありません"
+        },
+        "providerTemporarilyUnavailable": {
+          "guidance": "モデルプロバイダーは一時的に利用できません。後でもう一度試してください。",
+          "title": "モデルプロバイダーが一時的に利用できません"
+        }
+      },
+      "fallbackAgent": "エージェント",
+      "fields": {
+        "duration": "期間",
+        "model": "モデル",
+        "source": "ソース",
+        "status": "ステータス",
+        "time": "時間"
+      },
+      "log": "ログ",
+      "modelProvidedBy": "{{model}} は {{provider}} によって提供されます",
+      "networkEmpty": {
+        "description": "この実行ではネットワーク トラフィックは記録されませんでした。",
+        "title": "ネットワークログがありません"
+      },
+      "notFound": {
+        "back": "アクティビティに戻る",
+        "description": "このログは存在しないか、現在のワークスペースで表示する権限がありません。",
+        "title": "ログが見つかりません"
+      },
+      "runner": {
+        "deviceLimitMismatch": "アイドル プール エントリは存在しますが、そのデバイス レート リミッタの状態が一致しません。",
+        "featureDisabled": "この実行ではサンドボックスの再利用が無効になっています。",
+        "noSessionId": "アイドル状態のプールと照合できるセッション ID がありません。",
+        "notReused": "再利用されない",
+        "poolMiss": "アイドル状態のプールに一致するサンドボックスが見つかりません。",
+        "profileMismatch": "アイドル プール エントリは存在しますが、そのプロファイルが一致しません。",
+        "reused": "再利用",
+        "reusedDescription": "サンドボックスがアイドル状態のプールからパーク解除されました。",
+        "sandbox": "サンドボックス",
+        "unknown": "不明 (古い実行、サンドボックス再利用追跡が追加される前に記録されました)。",
+        "unparkFailed": "パーク解除の試行は失敗しました。新しいサンドボックスがプロビジョニングされました。"
+      },
+      "steps": {
+        "matched": "({{matched}}/{{total}} が一致しました)",
+        "noEvents": "利用可能なイベントはありません",
+        "search": "ステップを検索",
+        "systemPrompt": "システムプロンプト",
+        "title": "ステップ",
+        "total": "合計{{total}}",
+        "userPrompt": "プロンプト"
+      },
+      "tabs": {
+        "context": "コンテキスト",
+        "network": "ネットワーク",
+        "runner": "ランナー",
+        "steps": "ステップ"
+      }
+    },
+    "documentTitle": "アクティビティ",
+    "events": {
+      "agents_one": "エージェント",
+      "agents_other": "エージェント",
+      "allTasksCompleted": "すべてのタスクが完了しました",
+      "argsLabel": "引数:",
+      "calls_one": "{{formattedCount}} 呼び出し",
+      "calls_other": "{{formattedCount}} 呼び出し",
+      "commands_one": "コマンド",
+      "commands_other": "コマンド",
+      "duration": "期間: {{duration}}",
+      "emptyOutput": "(空の出力)",
+      "files_one": "{{formattedCount}} ファイル",
+      "files_other": "{{formattedCount}} ファイル",
+      "initialize": "初期化する",
+      "inputTokens": "入力: {{formattedCount}}",
+      "models_one": "{{formattedCount}} モデル",
+      "models_other": "{{formattedCount}} モデル",
+      "moreItems_one": "... {{count}} その他の項目",
+      "moreItems_other": "... {{count}} その他のアイテム",
+      "nameLabel": "名前:",
+      "outputTokens": "出力: {{formattedCount}}",
+      "remainingLines_one": "+{{formattedCount}} 行",
+      "remainingLines_other": "+{{formattedCount}} 行",
+      "searches_one": "{{formattedCount}} 検索",
+      "searches_other": "{{formattedCount}} 検索",
+      "steps_one": "{{formattedCount}} ステップ",
+      "steps_other": "{{formattedCount}} ステップ",
+      "summary": "概要",
+      "task": "タスク",
+      "thinking": "思考",
+      "todo": "TODO",
+      "toolFailed": "{{toolName}} が失敗しました",
+      "tools_one": "ツール",
+      "tools_other": "ツール",
+      "truncated": "省略",
+      "turns_one": "{{formattedCount}} ターン",
+      "turns_other": "{{formattedCount}} ターン",
+      "unknownTool": "不明"
+    },
+    "inspect": {
+      "contextUnavailable": {
+        "description": "このインポートされたログでは実行コンテキストは使用できません。",
+        "title": "コンテキストが利用できません"
+      },
+      "documentTitle": "ログを検査",
+      "errors": {
+        "invalid": "無効な JSON ファイルです。エクスポートされたアクティビティ ログ JSON ファイルをアップロードします。",
+        "load": "JSONファイルを読み込めませんでした。エクスポートされたアクティビティ ログ JSON ファイルをアップロードします。",
+        "oversized": "JSON ファイルが大きすぎます。エクスポートされた 25 MB 未満のアクティビティ ログ JSON ファイルをアップロードします。"
+      },
+      "fallbackName": "インポートされたログ",
+      "inspect": "検査",
+      "networkUnavailable": {
+        "description": "このインポートされたログではネットワーク ログは利用できません。",
+        "title": "ネットワークログは利用できません"
+      },
+      "noLog": {
+        "description": "エクスポートしたアクティビティログのJSONファイルをアップロードして内容を確認できます。",
+        "title": "ログがロードされていません",
+        "upload": "JSONをアップロード"
+      }
+    },
+    "list": {
+      "description": "エージェントのログと実行履歴。",
+      "errors": {
+        "description": "何か問題が発生しました。後でもう一度試してください。",
+        "title": "アクティビティデータのロードに失敗しました"
+      },
+      "filters": {
+        "agent": "エージェントフィルター",
+        "allAgents": "すべてのエージェント",
+        "allSources": "すべてのソース",
+        "allStatuses": "すべてのステータス",
+        "source": "ソースフィルター",
+        "status": "ステータスフィルター"
+      },
+      "title": "アクティビティ"
+    },
+    "network": {
+      "actions": {
+        "block": "ブロック"
+      },
+      "browser": "ブラウザ",
+      "capture": {
+        "binaryData": "[バイナリ データ、{{size}} Base64 エンコード]",
+        "complete": "完了",
+        "headersWithCount": "{{title}} ({{formattedCount}})",
+        "requestBody": "リクエストボディ",
+        "requestHeaders": "リクエストヘッダー",
+        "responseBody": "応答本文",
+        "responseHeaders": "応答ヘッダー",
+        "truncated": "省略"
+      },
+      "details": {
+        "action": "アクション",
+        "authCacheHit": "キャッシュヒット",
+        "authRefreshedConnectors": "リフレッシュされたコネクタ",
+        "authRefreshedSecrets": "更新されたシークレット",
+        "authResolvedSecrets": "解決されたシークレット",
+        "authUrlRewrite": "URL書き換え",
+        "baseUrl": "ベースURL",
+        "billable": "請求可能",
+        "browserUserAgent": "ブラウザユーザーエージェント",
+        "connectorBaseUrl": "コネクタのベース URL",
+        "connectorDiagnostic": "コネクタ診断",
+        "connectorEnvNames": "コネクタ環境名",
+        "connectorReason": "コネクタの理由",
+        "connectorRouteCandidates": "コネクタルート候補",
+        "connectorRouteReason": "コネクタルートの理由",
+        "dnsEvent": "DNSイベント",
+        "dnsQueryType": "DNS クエリの種類",
+        "dnsResult": "DNS結果",
+        "dnsSerial": "DNSシリアル",
+        "error": "エラー",
+        "firewall": "ファイアウォール",
+        "host": "ホスト",
+        "latency": "レイテンシ",
+        "method": "方法",
+        "modelCatalogCacheBypassReason": "モデル カタログ キャッシュ バイパスの理由",
+        "modelCatalogCacheEntryAge": "モデル カタログ キャッシュ エントリの経過時間",
+        "modelCatalogCacheEvictionCount": "モデルカタログキャッシュエビクション数",
+        "modelCatalogCacheStatus": "モデルカタログキャッシュステータス",
+        "modelCatalogCacheValidationLatency": "モデル カタログ キャッシュ検証のレイテンシ",
+        "modelCatalogPrefetchRole": "モデルカタログのプリフェッチの役割",
+        "modelCatalogUpstreamEncoding": "モデルカタログのアップストリームエンコーディング",
+        "params": "パラメータ",
+        "permission": "許可",
+        "permissionError": "許可エラー",
+        "port": "港",
+        "requestSize": "リクエストサイズ",
+        "responseSize": "応答サイズ",
+        "ruleMatch": "ルールマッチ",
+        "status": "ステータス",
+        "timestamp": "タイムスタンプ",
+        "type": "種類",
+        "upstreamBindingClientBindingCount": "アップストリームクライアントバインディング数",
+        "upstreamBindingClientBindingEndpointMatch": "アップストリーム クライアント バインディング エンドポイントの一致",
+        "upstreamBindingClientBindingHosts": "アップストリームクライアントバインディングホスト",
+        "upstreamBindingClientBindingMatch": "アップストリームクライアントバインディングの一致",
+        "upstreamBindingClientId": "アップストリーム バインディング クライアント ID",
+        "upstreamBindingClientSockname": "アップストリーム バインディング クライアントのソケット名",
+        "upstreamBindingDirectBindingHost": "アップストリーム ダイレクト バインディング ホスト",
+        "upstreamBindingDirectBindingKinds": "上流の直接バインディングの種類",
+        "upstreamBindingDirectBindingPort": "アップストリーム直接バインディングポート",
+        "upstreamBindingDirectBindingPresent": "上流の直接結合の存在",
+        "upstreamBindingReason": "上流のバインド理由",
+        "upstreamBindingRequestHost": "アップストリーム バインディング リクエスト ホスト",
+        "upstreamBindingRequestPort": "アップストリームバインディングリクエストポート",
+        "upstreamBindingServerAddress": "アップストリームバインディングサーバーアドレス",
+        "upstreamBindingServerConnected": "アップストリーム バインディング サーバーが接続されました",
+        "upstreamBindingServerId": "アップストリームバインディングサーバーID",
+        "upstreamBindingServerPeername": "アップストリーム バインディング サーバーのピア名",
+        "upstreamBindingServerSockname": "アップストリーム バインディング サーバーのソケット名",
+        "upstreamBindingTrustedHost": "アップストリームバインディングトラステッドホスト",
+        "url": "URL"
+      },
+      "filter": {
+        "allTypes": "全種類",
+        "selectedTypes_one": "{{formattedCount}} タイプ",
+        "selectedTypes_other": "{{formattedCount}} タイプ",
+        "type": "タイプフィルター"
+      },
+      "headers": {
+        "latency": "レイテンシ",
+        "method": "方法",
+        "permission": "許可",
+        "status": "ステータス",
+        "time": "時間",
+        "type": "種類",
+        "urlHost": "URL / ホスト"
+      },
+      "loadMore": "さらにロードする",
+      "no": "いいえ",
+      "noMatchingLogs": "ロードされた結果に一致するログがありません",
+      "unknown": "不明",
+      "yes": "はい"
+    },
+    "pagination": {
+      "backTwo": "2ページ戻る",
+      "forwardTwo": "2ページ進む",
+      "next": "次のページ",
+      "page": "ページ {{current}}",
+      "pageOf": "ページ {{current}} / {{total}}",
+      "previous": "前のページへ",
+      "rowsPerPage": "ページあたりの行数"
+    },
+    "sources": {
+      "agent": "エージェント",
+      "agentphone": "エージェントフォン",
+      "agentWithName": "エージェント ({{name}})",
+      "cli": "CLI",
+      "email": "メール",
+      "feishu": "Feishu",
+      "github": "GitHub",
+      "slack": "Slack",
+      "teams": "チーム",
+      "telegram": "Telegram",
+      "web": "ウェブ",
+      "webhook": "Webhook",
+      "workflowEvent": "ワークフローイベント",
+      "workflowSchedule": "ワークフロースケジュール"
+    },
+    "statuses": {
+      "cancelled": "キャンセルされました",
+      "completed": "完了",
+      "failed": "失敗しました",
+      "pending": "保留中",
+      "queued": "キューに入れられました",
+      "running": "ランニング",
+      "timeout": "タイムアウト"
+    },
+    "statusFilters": {
+      "cancelled": "キャンセルされました",
+      "completed": "完了しました",
+      "failed": "失敗しました",
+      "pending": "保留中",
+      "queued": "キューに入れられました",
+      "running": "ランニング",
+      "timeout": "タイムアウト"
+    },
+    "table": {
+      "empty": {
+        "description": "エージェントが作業を開始すると、そのアクティビティがここに表示されます。",
+        "title": "今はみんな静かに"
+      },
+      "filteredEmpty": {
+        "description": "さまざまなフィルターを試して、探しているものを見つけてください。",
+        "title": "これらのフィルターに一致するものはありません"
+      },
+      "headers": {
+        "agent": "エージェント",
+        "description": "説明",
+        "duration": "期間",
+        "session": "セッション",
+        "source": "ソース",
+        "startTime": "開始時間",
+        "status": "ステータス"
+      }
+    }
+  },
+  "appShell": {
+    "browserUpgrade": {
+      "browser": {
+        "action": "ブラウザを更新する",
+        "description": "Zero は、現在のブラウザのバージョンをサポートしていません。続行するにはブラウザを更新してください。",
+        "title": "続行するにはブラウザを更新してください"
+      },
+      "chrome": {
+        "action": "Chrome を更新します",
+        "description": "Zero は、現在のブラウザのバージョンをサポートしていません。続行するには、Chrome を更新してください。",
+        "title": "続行するには Chrome を更新してください"
+      },
+      "chromium": {
+        "action": "Chromium を更新します",
+        "description": "Zero は、現在のブラウザのバージョンをサポートしていません。続行するには、Chromium を更新してください。",
+        "title": "続行するには Chromium を更新してください"
+      },
+      "ios": {
+        "action": "iOS を更新します",
+        "description": "Zero は、現在のブラウザのバージョンをサポートしていません。続行するには、iOS を更新してください。",
+        "title": "続行するには iOS を更新してください"
+      },
+      "safari": {
+        "action": "Safari を更新します",
+        "description": "Zero は、現在のブラウザのバージョンをサポートしていません。続行するには、Safari を更新してください。",
+        "title": "続行するには Safari を更新してください"
+      }
+    },
+    "loading": {
+      "ariaLabel": "ワークスペースを読み込み中",
+      "messages": {
+        "almostThere": "もうすぐです...",
+        "brewingIdeas": "アイデアを練っています...",
+        "connectingDots": "点と点をつないでいます...",
+        "gettingReady": "準備しています...",
+        "loadingWorkspace": "ワークスペースを読み込んでいます...",
+        "spinningTeam": "チームを立ち上げています...",
+        "tuningInstruments": "楽器を調整しています...",
+        "warmingNeurons": "ニューラルネットワークを準備しています..."
+      }
+    },
+    "logoAlt": "VM0",
+    "metadata": {
+      "description": "Zeroはvm0のAIコワーカーです。Zeroにメッセージを送るか、Webでチャットできます。リサーチ、メール、ドキュメント、Slack、GitHub、Notionなど、100以上のツールを利用できます。",
+      "title": "Zero — vm0のAIコワーカー"
+    },
+    "shortcutHelp": {
+      "close": "キーボードショートカットを閉じる",
+      "description": "このページで利用可能なショートカット",
+      "sections": {
+        "composer": "コンポーザー",
+        "global": "グローバル",
+        "messages": "メッセージ"
+      },
+      "shortcuts": {
+        "blurComposer": "コンポーザーからフォーカスを外す",
+        "changeIcon": "アイコンの変更",
+        "clearIcon": "クリアアイコン",
+        "newChat": "新しいチャット",
+        "nextAgent": "次のエージェント",
+        "nextThread": "次のスレッド",
+        "openAgentList": "エージェントリストを開く",
+        "openFirstThread": "最初のスレッドを開く",
+        "previousAgent": "前のエージェント",
+        "previousThread": "前のスレッド",
+        "renameChat": "チャットの名前を変更する",
+        "scrollBottom": "一番下までスクロール",
+        "scrollTop": "一番上までスクロール",
+        "sendMessage": "メッセージを送信する",
+        "setIcon": "アイコンの設定 (Ctrl+Shift+1-9)",
+        "showShortcuts": "ショートカットを表示する",
+        "toggleSidebar": "サイドバーの切り替え"
+      },
+      "title": "キーボードショートカット"
+    },
+    "sidebar": {
+      "ariaLabel": "サイドバー",
+      "chat": "チャット",
+      "collapse": "サイドバーを折りたたむ",
+      "expand": "サイドバーを展開する",
+      "manage": "管理",
+      "mobile": {
+        "invite": "招待する",
+        "openArtifacts": "モバイルでアーティファクトを開く",
+        "openAutomations": "モバイルでオートメーションを開く",
+        "openMenu": "メニューを開く",
+        "overlay": "サイドバーのオーバーレイ"
+      },
+      "navigation": {
+        "activity": "アクティビティログ",
+        "agents": "エージェント",
+        "artifacts": "アーティファクト",
+        "connectors": "コネクター",
+        "insights": "インサイト",
+        "insightsAndUsage": "インサイトと使用量",
+        "newChat": "新しいチャット",
+        "settings": "設定",
+        "workflows": "ワークフロー",
+        "works": "{{agentName}}の連携先"
+      },
+      "rail": {
+        "activity": "アクティビティ",
+        "new": "新しい",
+        "workflows": "ワークフロー",
+        "works": "連携先"
+      },
+      "searchConversations": "会話を検索する",
+      "workspaceSwitcher": {
+        "create": "ワークスペースの作成",
+        "creating": "作成中…",
+        "join": "参加する",
+        "joining": "参加中…",
+        "organizationFallback": "組織",
+        "switch": "ワークスペースを切り替える"
+      }
+    }
+  },
+  "artifacts": {
+    "actions": {
+      "backToAll": "すべてのアーティファクトに戻る",
+      "backToArtifacts": "アーティファクトに戻る",
+      "close": "閉じる",
+      "closeArtifact": "アーティファクトを閉じる",
+      "closeDownloadMenu": "ダウンロードメニューを閉じる",
+      "closeNamed": "{{title}} を閉じる",
+      "closePreviewMenu": "プレビューメニューを閉じる",
+      "download": "ダウンロード",
+      "downloadArtifact": "アーティファクトをダウンロードする",
+      "downloadOptions": "ダウンロードオプション",
+      "enterFullscreen": "全画面表示に入る",
+      "exitFullscreen": "全画面表示を終了する",
+      "more": "その他のアーティファクトアクション",
+      "nextImage": "次の画像アーティファクト",
+      "openNewTab": "新しいタブで開く",
+      "openSplitView": "分割ビューで開く",
+      "previousImage": "前の画像アーティファクト",
+      "resetZoom": "ズームをリセットする",
+      "share": "シェアする",
+      "shareArtifact": "アーティファクトを共有する",
+      "zoomIn": "Zoom 内",
+      "zoomOut": "Zoom アウト"
+    },
+    "attachments": {
+      "cancelUpload": "アップロードをキャンセル {{filename}}",
+      "download": "{{filename}} をダウンロード",
+      "openImagePreview": "{{filename}} の画像プレビューを開く",
+      "remove": "{{filename}} を削除します"
+    },
+    "catalog": {
+      "cardPreview": "{{title}} のプレビュー",
+      "description": "ここで作成したものをすべて参照してください。",
+      "emptyDescription": "アーティファクトが利用可能になると、ここに表示されます。",
+      "emptyTitle": "アーティファクトは見つかりませんでした",
+      "error": "アーティファクトをロードできませんでした。後でもう一度試してください。",
+      "filters": {
+        "file": "ファイル",
+        "fileAria": "ファイルアーティファクトを表示する",
+        "image": "画像",
+        "imageAria": "画像アーティファクトを表示する",
+        "label": "アーティファクトの種類のフィルター",
+        "presentation": "プレゼンテーション",
+        "presentationAria": "プレゼンテーションのアーティファクトを表示する",
+        "video": "動画",
+        "videoAria": "ビデオアーティファクトを表示する",
+        "website": "ウェブサイト",
+        "websiteAria": "Web サイトのアーティファクトを表示する"
+      },
+      "kindIcon": "{{kind}} アーティファクト",
+      "loading": "アーティファクトをロードしています"
+    },
+    "fileBadges": {
+      "artwork": "アート",
+      "audio": "オーストラリアドル",
+      "file": "ファイル",
+      "video": "ビデオ"
+    },
+    "googleDrive": {
+      "agentLoading": "エージェントを読み込み中",
+      "connect": "Google Drive を接続します",
+      "connectTooltip": "Google Drive を接続してアーティファクトをアップロードする",
+      "failedToOpenConnect": "Google Drive 接続ページを開けませんでした",
+      "noArtifacts": "同期するアーティファクトがありません",
+      "partial_one": "{{count}} ファイルの {{synced}} を Google Drive に同期しました",
+      "partial_other": "{{count}} ファイルの {{synced}} を Google Drive に同期しました",
+      "synced": "Google Drive に同期されました",
+      "syncedFiles_one": "Google Drive に同期されました",
+      "syncedFiles_other": "{{count}} ファイルを Google Drive に同期しました",
+      "syncFailed": "Google Drive との同期に失敗しました",
+      "syncingArtifact": "アーティファクトを同期中...",
+      "syncingFiles_one": "{{count}} ファイルを同期しています...",
+      "syncingFiles_other": "{{count}} ファイルを同期しています...",
+      "syncingNamed": "{{filename}} を同期しています...",
+      "upload": "Google Drive にアップロード"
+    },
+    "kinds": {
+      "audio": "オーディオ",
+      "code": "コード",
+      "csv": "CSV",
+      "data": "データ",
+      "document": "文書",
+      "file": "ファイル",
+      "hostedSite": "ホストされているサイト",
+      "image": "画像",
+      "json": "JSON",
+      "markdown": "マークダウン",
+      "presentation": "プレゼンテーション",
+      "text": "テキスト",
+      "video": "ビデオ"
+    },
+    "metadata": {
+      "generated": "{{date}} が生成されました"
+    },
+    "preview": {
+      "audioLabel": "{{filename}} のオーディオ プレビュー",
+      "badge": "プレビュー",
+      "dialogLabel": "{{filename}} プレビュー",
+      "emptyCsv": "空のCSV。",
+      "genericUnavailable": "プレビューは利用できません。",
+      "noInline": "このファイルではインライン プレビューを使用できません。",
+      "openKind": "{{filename}} の {{kind}} プレビューを開く",
+      "openKinds": {
+        "audio": "オーディオ",
+        "csv": "csv",
+        "html": "html",
+        "json": "json",
+        "markdown": "値下げ",
+        "pdf": "pdf",
+        "text": "テキスト",
+        "video": "ビデオ"
+      },
+      "siteLabel": "{{title}} のサイト プレビュー",
+      "slideTitle": "スライド {{number}}",
+      "unavailable": "{{kind}} プレビューは利用できません。",
+      "videoLabel": "{{filename}} のビデオ プレビュー"
+    },
+    "sidebar": {
+      "panelTitle": "アーティファクト",
+      "singularTitle": "アーティファクト",
+      "unavailable": "このアーティファクトはもう入手できません。"
+    },
+    "templates": {
+      "activeHtmlPreview": "{{title}} アクティブな HTML プレビュー",
+      "all": "すべて",
+      "categories": "テンプレートのカテゴリ",
+      "category": "テンプレートカテゴリ",
+      "fullPreview": "{{title}} Web サイトの完全なプレビュー",
+      "htmlPreview": "{{title}} HTML プレビュー",
+      "illustration": "イラストレーション",
+      "illustrationPreview": "{{title}} イラストのプレビュー",
+      "multiAccent": "マルチアクセント",
+      "nextSlide": "次のスライドをプレビューする",
+      "noMatches": "一致しません",
+      "placeholder": "{{title}} Web サイトのプレビュー プレースホルダー",
+      "playVideo": "ビデオ テンプレートのプレビューを再生 {{title}}",
+      "previewCurrentSlide": "現在のスライドで {{title}} をプレビューする",
+      "previewSlide": "スライドのプレビュー {{slideNumber}}",
+      "previewWebsite": "Web サイト テンプレートのプレビュー {{title}}",
+      "previousHtmlPreview": "{{title}} 前の HTML プレビュー",
+      "previousSlide": "前のスライドをプレビューする",
+      "searchConnector": "検索コネクタ...",
+      "searchConnectors": "検索コネクタ",
+      "selected": "テンプレート: {{title}}",
+      "selectStyle": "スタイル {{style}} を選択してください",
+      "selectTemplate": "テンプレート {{title}} を選択します",
+      "selectVideo": "ビデオ テンプレート {{title}} を選択してください",
+      "selectWebsite": "Web サイト テンプレート {{title}} を選択してください",
+      "selectWorkflow": "ワークフロー テンプレート {{title}} を選択します",
+      "showVariant": "バリアント {{variantNumber}} を表示",
+      "singleAccent": "シングルアクセント",
+      "slidePreview": "{{title}} スライド プレビュー",
+      "slideThumbnail": "{{title}} スライド {{slideNumber}} プレビュー",
+      "template": "テンプレート",
+      "theme": "テーマ",
+      "themeNames": {
+        "bauhausPrimary": "おもちゃのレンガ",
+        "berryPop": "ラズベリーソーダ",
+        "carnival": "遊園地",
+        "citrusFresh": "オレンジジュース",
+        "coralStudio": "ピーチスタジオ",
+        "forestEditorial": "苔の図書館",
+        "goldLuxe": "アワードナイト",
+        "mauveDusk": "ラベンダーの夕暮れ",
+        "midnightMono": "ナイトラン",
+        "mintTech": "ミントラボ",
+        "monoInk": "新聞紙赤",
+        "nordicFrost": "氷の湖",
+        "oceanDeep": "詳細な説明",
+        "popArt": "ネオンアーケード",
+        "prism": "キャンディパーティー",
+        "slateCorporate": "役員室ブルー",
+        "sunsetMaroon": "夕焼け",
+        "terracottaClay": "土鍋",
+        "warmSand": "朝刊"
+      },
+      "tryDifferentSearch": "別の検索を試してください。",
+      "use": "使用する",
+      "useThisTemplate": "このテンプレートを使用してください",
+      "website": "ウェブサイト",
+      "websitePreview": "{{title}} Web サイト テンプレートのプレビュー",
+      "workflow": "ワークフロー"
+    },
+    "title": "アーティファクト",
+    "toasts": {
+      "copyLinkFailed": "リンクのコピーに失敗しました",
+      "downloadFailed": "ダウンロードに失敗しました",
+      "linkCopied": "リンクがコピーされました"
+    }
+  },
+  "auth": {
+    "clerk": {
+      "accessNotAllowed": "アクセスは許可されていません。",
+      "userBanned": "このアカウントでのアクティビティが {{brandName}} 利用規約に違反したため、アカウントへのアクセスが停止されました。ご質問がある場合は、support@vm0.ai までお問い合わせください。"
+    },
+    "documentTitles": {
+      "signIn": "サインイン",
+      "signUp": "サインアップ"
+    },
+    "loading": "認証を読み込み中",
+    "toggleTheme": "テーマの切り替え"
+  },
+  "authorization": {
+    "browser": {
+      "description": "Zero は、このチャット スレッドに分離されたクラウド ブラウザ プロファイルを使用します。これを有効にすると、スレッドのコンピューターの使用が切断されます。",
+      "enable": "このスレッドに対して有効にする",
+      "enabled": "クラウドブラウザが有効になっている",
+      "linkExpires": "リンクの有効期限が切れます {{date}}。",
+      "title": "クラウドブラウザを有効にする",
+      "unavailableDescription": "このクラウド ブラウザ認証リンクは無効であるか、期限切れであるか、このワークスペースでは使用できません。",
+      "unavailableTitle": "認証リンクは使用できません"
+    },
+    "computerUse": {
+      "authorize": "承認する",
+      "authorized": "認可された",
+      "checkingCompatibility": "互換性の確認",
+      "description": "{{source}} で使用する Zero のオンライン コンピューターを選択します。",
+      "downloadMac": "macOS をダウンロード",
+      "lastSeen": "最後に表示されたのは {{date}}",
+      "linkExpires": "リンクの有効期限が切れます {{date}}。",
+      "macRequirement": "macOS 14 以降を搭載した Apple Silicon Mac が必要です。 Intel Mac はサポートされていません。",
+      "noHostsDescription": "Mac で Zero Computer Use を開き、オンラインになったらこのページを更新します。",
+      "noHostsTitle": "オンラインコンピュータはありません",
+      "sources": {
+        "chat": "このチャットスレッド",
+        "slack": "この Slack スレッド",
+        "teams": "この Teams スレッド"
+      },
+      "title": "コンピュータの使用を許可する",
+      "unavailableDescription": "このコンピュータ使用認証リンクは無効であるか、有効期限が切れているか、このワークスペースでは使用できません。",
+      "unavailableTitle": "認証リンクは使用できません",
+      "unsupportedIntelMac": "AppleシリコンMacが必要です"
+    },
+    "permission": {
+      "confirm": "確認する",
+      "duration": "期間",
+      "durationLabel": "許可期間",
+      "durationOptions": {
+        "always": "いつも",
+        "oneHour": "1時間",
+        "sevenDays": "7日間",
+        "twentyFourHours": "24時間"
+      },
+      "errors": {
+        "agentNotFound": "エージェントが見つかりません",
+        "loadAgent": "エージェントの読み込みに失敗しました",
+        "loadGrants": "権限付与のロードに失敗しました",
+        "loadMetadata": "権限メタデータのロードに失敗しました",
+        "missingAgentId": "URLパラメータにエージェントIDがありません",
+        "missingPermission": "URLパラメータに権限がありません",
+        "unknownAction": "不明な権限アクション: {{action}}",
+        "unknownConnector": "不明なコネクタ: {{connector}}",
+        "unknownPermission": "不明な権限: {{permission}}",
+        "updateFailed": "権限を更新できませんでした"
+      },
+      "expiration": {
+        "expired": "期限切れ",
+        "inDays_one": "{{count}} 日で期限切れになります",
+        "inDays_other": "{{count}} 日で期限切れになります",
+        "inHours_one": "{{count}} 時間後に期限切れになります",
+        "inHours_other": "{{count}} 時間で期限切れになります",
+        "lessThanHour": "1 時間以内に期限切れになります",
+        "lessThanHourShort": "1時間未満",
+        "prefix": "有効期限が切れる "
+      },
+      "greeting": "{{userName}} さん、{{targetName}} の権限を更新しています。",
+      "result": {
+        "alreadyAllowedDescription": "コネクタの権限付与はすでに許可されています",
+        "alreadyAllowedTitle": "すでに許可されています",
+        "alreadyDeniedDescription": "コネクタ権限の付与はすでに拒否されています",
+        "alreadyDeniedTitle": "すでに拒否されています",
+        "deniedDescription": "コネクタ権限の付与が拒否されました",
+        "deniedTitle": "権限が拒否されました",
+        "updatedDescription": "コネクタの権限付与が更新されました",
+        "updatedTitle": "権限が更新されました"
+      },
+      "saving": "保存中...",
+      "unknownEndpoints": "不明なエンドポイント",
+      "userFallback": "そこに",
+      "wouldLike": "したいです"
+    }
+  },
+  "billing": {
+    "autoRecharge": {
+      "amountAria": "自動リチャージクレジット金額（クレジット単位）",
+      "amountTitle": "チャージ金額",
+      "automaticTopUps": "自動補充",
+      "description": "残高がしきい値を下回ったときにクレジットを購入します。",
+      "enableAria": "自動リチャージを有効にする",
+      "thresholdAria": "オートリチャージのクレジットしきい値",
+      "thresholdDescription": "クレジット残高がこの数値を下回ったときに購入をトリガーします。",
+      "thresholdPlaceholder": "例: 2000年",
+      "thresholdTitle": "クレジットが以下になったとき",
+      "title": "オートリチャージ"
+    },
+    "common": {
+      "back": "戻る",
+      "cancel": "キャンセル",
+      "credits": "クレジット",
+      "manage": "管理",
+      "redirecting": "リダイレクト中...",
+      "restore": "復元",
+      "retry": "再試行",
+      "unavailable": "利用不可",
+      "updating": "更新中..."
+    },
+    "concurrency": {
+      "activeUntil": "{{date}} までアクティブ",
+      "billedMonthly": "毎月請求される",
+      "buyAmount": "{{amount}} を購入する",
+      "buyButton": "同時購入",
+      "buyDescription": "同時実行を増やすには、月次サブスクリプションを追加してください。",
+      "buyTitle": "同時実行性を購入する",
+      "cancelDescription": "これにより、現在の請求期間の終了時に更新が停止されます。それまで既存のスロットはアクティブのままです。",
+      "cancellationScheduled": "キャンセル予定",
+      "cancelTitle": "同時実行サブスクリプションをキャンセルしますか?",
+      "concurrentRun_one": "{{value}} 同時実行",
+      "concurrentRun_other": "{{value}} 同時実行数",
+      "decreaseAria": "追加の同時実行数を減らす",
+      "emptyDescription": "このワークスペースに対して追加の同時実行を購入します。",
+      "emptyTitle": "同時実行サブスクリプションなし",
+      "increaseAria": "追加の同時実行数を増やす",
+      "restoreDescription": "これにより、この同時実行サブスクリプションの更新が再開されます。",
+      "restoreSubscription": "サブスクリプションを復元する",
+      "restoreTitle": "同時実行サブスクリプションを復元しますか?",
+      "slot_one": "{{value}} スロット",
+      "slot_other": "{{value}} スロット",
+      "slots": "スロット",
+      "title": "同時実行性"
+    },
+    "credits": {
+      "amount": "金額",
+      "amountRangeError": "{{minimum}} と {{maximum}} の間を入力してください",
+      "anyAmount": "いくらでも",
+      "custom": "カスタム",
+      "customAmountAria": "カスタムドル額",
+      "exchangeRate": "クレジットに有効期限はありません。 1 USD = {{credits}} クレジット。",
+      "quickBuy": "すぐに購入",
+      "quickBuyAmount": "クイック購入 {{amount}}",
+      "title": "クレジットを購入する"
+    },
+    "downgrade": {
+      "cancelSubscription": "サブスクリプションをキャンセルする",
+      "chooseTarget": "どのプランにダウングレードするかを選択します。",
+      "confirmProCancellation": "Pro プランをキャンセルしてもよろしいですか?",
+      "confirmTarget": "{{plan}} にダウングレードしますか?",
+      "inProgress": "ダウングレード中...",
+      "proWarning": "Pro アクセスは、現在の請求期間が終了するまで有効のままです。その後、このワークスペースは [プランなし] に移行し、再度アップグレードするまでエージェントは実行できません。",
+      "teamWarning": "チームのアクセスは、現在の請求期間が終了するまで有効のままです。その後、このワークスペースは {{plan}} に移動します。",
+      "title": "ダウングレード計画"
+    },
+    "invoices": {
+      "amount": "金額",
+      "date": "日付",
+      "downloadDescription": "連続する月を最大 3 か月まで選択します。その範囲の領収書 PDF は 1 つの ZIP ファイルにまとめられます。",
+      "downloadInvoice": "{{month}} 請求書をダウンロード",
+      "downloadReceipts": "領収書のダウンロード",
+      "downloadZip": "ZIPをダウンロード",
+      "empty": "まだ請求書はありません。",
+      "from": "から",
+      "invoice": "請求書",
+      "loading": "請求書の読み込み",
+      "monthAria": "{{label}} 月",
+      "preparingReceipts": "領収書を準備しています...",
+      "rangeError": "連続 3 か月以内の範囲を選択します。",
+      "selectMonth": "月を選択してください",
+      "to": "に"
+    },
+    "manage": {
+      "description": "Stripe のサブスクリプション、支払い方法、請求書。",
+      "title": "請求の管理"
+    },
+    "plans": {
+      "cancellationNotice": "{{plan}} プランはキャンセルされ、{{date}} に終了します。",
+      "changeAnytime": "いつでもアップグレードまたはダウングレードできます。",
+      "compare": "プランを比較する",
+      "compareAll": "すべてのプランを比較する",
+      "currentPlan": "現在の計画",
+      "custom": {
+        "name": "カスタム"
+      },
+      "customAccess": "{{value}} 同時実行によるカスタム アクセス",
+      "customCancellationNotice": "カスタム プランは {{date}} に終了します。",
+      "customCheckoutUnavailable": "カスタム ワークスペースは、Pro または Team チェックアウトに切り替えることができません。",
+      "downgrade": "ダウングレード",
+      "downgradeNotice": "{{currentPlan}} プランは、{{date}} の {{targetPlan}} にダウングレードされます。",
+      "downgradesOn": "{{date}} の {{plan}} にダウングレード",
+      "downgradeTo": "{{plan}} にダウングレード",
+      "endsOn": "{{date}} に終了",
+      "features": {
+        "byok": "独自の LLM キーを持参する",
+        "communitySupport": "コミュニティサポート",
+        "emailSupport": "メールサポート",
+        "existingCredits": "既存の無料クレジットのみ",
+        "monthlyCredits": "{{value}} クレジット / 月",
+        "oneConcurrentRun": "1つの同時実行",
+        "payAsYouGo": "その後は従量料金を支払う",
+        "prioritySupport": "優先サポート",
+        "tenConcurrentRuns": "10 個の同時実行",
+        "twoConcurrentRuns": "2つの同時実行",
+        "unlimitedAgents": "無制限の合計エージェント",
+        "voiceInput": "音声入力",
+        "voiceInputLifetime": "音声入力 (メンバーごとに生涯 10 回まで使用可能)"
+      },
+      "free": {
+        "description": "既存のワークスペースへの従来の無料アクセス。",
+        "name": "無料"
+      },
+      "limitedFree": {
+        "name": "限定無料"
+      },
+      "loadError": "請求ステータスを読み込めませんでした。",
+      "manageSubscription": "サブスクリプションの管理",
+      "namedPlan": "{{plan}} プラン",
+      "noActivePlan": "有効なプランはありません",
+      "noActiveSubscription": "有効なサブスクリプションがありません",
+      "noPlan": {
+        "name": "計画なし"
+      },
+      "perMonth": "/月",
+      "popular": "人気のある",
+      "pricePerMonth": "{{price}}/月",
+      "pro": {
+        "description": "チームのさらなるパワーとシームレスなコラボレーション。",
+        "name": "プロ"
+      },
+      "renews": "{{date}} を更新します",
+      "restorePlan": "復元計画",
+      "sectionTitle": "計画",
+      "selectedPlan": "選択したプラン",
+      "team": {
+        "description": "摩擦がなく、完全な柔軟性を備えているため、迅速に拡張できます。",
+        "name": "チーム"
+      },
+      "upgrade": "アップグレード",
+      "upgradeTo": "{{plan}} にアップグレードする"
+    },
+    "restore": {
+      "cancellationDescription": "これにより、{{plan}} プランの予定されたキャンセルが取り消されます。",
+      "cancellationDescriptionDate": "これにより、{{plan}} プランの予定されたキャンセルが取り消されます。 {{date}} に更新されます。",
+      "downgradeDescription": "これにより、{{target}} へのスケジュールされたダウングレードがキャンセルされます。 {{plan}} プランは引き続き更新されます。",
+      "inProgress": "復元中...",
+      "title": "{{plan}} プランを復元しますか?"
+    },
+    "sidebar": {
+      "description": "より多くのクレジットと同時実行",
+      "getPlan": "{{plan}} を取得"
+    },
+    "toasts": {
+      "autoRechargeUpdated": "オートリチャージが更新されました",
+      "cancellationScheduledDate": "キャンセル予定。現在のプランは {{date}} まで有効です。",
+      "cancellationScheduledPeriod": "キャンセル予定。現在のプランは、請求期間が終了するまで有効のままです。",
+      "checkoutCompleted": "{{plan}} チェックアウトが完了しました。クレジットは請求書の支払い後に追加されます。",
+      "concurrencyAdded": "同時実行性が追加されました。新しいスロットは、Stripe がサブスクリプションを確認した後に利用可能になります。",
+      "concurrencyCanceled": "同時実行サブスクリプションがキャンセルされました。",
+      "concurrencyCanceledDate": "同時実行サブスクリプションがキャンセルされました。スロットは {{date}} までアクティブのままです。",
+      "concurrencyRestored": "同時実行サブスクリプションが復元されました。",
+      "creditsAdded": "クレジットが追加されました。 Zero とのチャットを続けることができます。",
+      "downgradeScheduledDate": "ダウングレードが予定されています。現在のプランは {{date}} まで有効です。",
+      "downgradeScheduledPeriod": "ダウングレードが予定されています。現在のプランは、請求期間が終了するまで有効のままです。",
+      "planRestored": "計画が復元されました。サブスクリプションは通常どおり更新されます。",
+      "preparingReceiptDownload": "領収書のダウンロードを準備しています...",
+      "receiptDownloadFailed": "領収書のダウンロードに失敗しました",
+      "receiptsDownloaded": "領収書をダウンロードしました"
+    },
+    "usage": {
+      "added": "{{date}} を追加しました",
+      "allowance": {
+        "day": "{{value}}日",
+        "hour": "{{value}}時間",
+        "minute": "{{value}}分",
+        "remaining": "{{remaining}} / {{total}} クレジット",
+        "remainingAria": "使用許容量 {{label}} が残っています",
+        "resets": "{{date}}にリセット",
+        "resetsRaw": "リセット: {{value}}",
+        "title": "使用枠",
+        "week": "{{value}}週間"
+      },
+      "breakdown": {
+        "currentPlanDescription": "請求サイクルごとにリセットされる月間プランクレジット",
+        "freeDescription": "残高がなくなるまで利用できるスタータークレジット",
+        "freePlan": "Freeプラン",
+        "payAsYouGo": "従量課金",
+        "payAsYouGoDescription": "有効期限のない自動チャージクレジット",
+        "previousPlanDescription": "以前のプランから繰り越されたクレジット",
+        "promotional": "プロモーション用",
+        "promotionalDescription": "一定期間後に期限切れになるキャンペーンクレジット",
+        "proPlan": "Proプラン",
+        "teamPlan": "Teamプラン"
+      },
+      "creditAdditions": "クレジットの追加",
+      "creditsRemaining_one": "{{value}} クレジットが残っています",
+      "creditsRemaining_other": "{{value}} クレジットが残っています",
+      "expires": "{{date}}に期限切れ",
+      "left": "{{value}} 残り",
+      "member": "メンバー",
+      "neverExpires": "有効期限はありません",
+      "unavailable": "クレジット残高が利用できません。",
+      "upgradeDescription": "Pro には毎月のクレジットが含まれており、追加のクレジット オプションのロックが解除されます。",
+      "upgradeTitle": "Pro にアップグレードしてより多くのクレジットを獲得",
+      "used": "使用済み"
+    }
+  },
+  "browserSession": {
+    "cardTitle": "クラウドブラウザ",
+    "close": "ライブブラウザを閉じる",
+    "documentTitle": "ライブブラウザ",
+    "fitWindow": "ブラウザをウィンドウに合わせる",
+    "iframeTitle": "ライブブラウザ: {{name}}",
+    "invalidLink": "無効なブラウザリンク",
+    "open": "{{name}} ブラウザを開きます",
+    "openAction": "開く",
+    "openNewPage": "このブラウザを新しいページで開く",
+    "panel": {
+      "notLive": "ブラウザが稼働していない",
+      "resume": "ブラウザを再開する",
+      "resumeDescription": "再開すると、保存されているログイン プロファイルとストレージが復元されます。前のページやタブは戻りません。",
+      "resuming": "再開中…",
+      "suspended": "ブラウザが一時停止されました"
+    },
+    "reclaimHint_one": "Zero は、このパネルが開いている間はこのブラウザを保持し、{{formattedCount}} 分間アイドル状態が経過するとブラウザを再利用します。",
+    "reclaimHint_other": "Zero は、このパネルが開いている間はこのブラウザを保持し、{{formattedCount}} 分間アイドル状態が経過するとブラウザを再利用します。",
+    "status": {
+      "live": "ライブ",
+      "starting": "開始",
+      "stopped": "停止しました"
+    },
+    "title": "ライブブラウザ",
+    "unavailable": {
+      "description": "このブラウザはこのチャットに属していないか、削除されています。",
+      "title": "ブラウザが使用できません"
+    }
+  },
+  "chat": {
+    "actions": {
+      "authorize": "承認する",
+      "cancel": "キャンセル",
+      "configure": "設定する",
+      "confirm": "確認する",
+      "continue": "続ける",
+      "copied": "コピーしました！",
+      "copy": "コピー",
+      "copyMessage": "メッセージをコピーする",
+      "delete": "削除",
+      "edit": "編集",
+      "more": "さらなるアクション",
+      "remove": "削除",
+      "rename": "名前の変更",
+      "saving": "保存中...",
+      "send": "送信",
+      "stop": "停止",
+      "view": "見る"
+    },
+    "agentPage": {
+      "invitePeople": "人を招待する",
+      "taglines": {
+        "anonymous": {
+          "buildSomething": "何かを構築する準備はできていますか?",
+          "goodToSeeYou": "会えてうれしいです。",
+          "readyToRoll": "準備はできていますか?",
+          "welcomeBack": "おかえりなさい。",
+          "whatAreWeWorkingOn": "私たちは何に取り組んでいますか?",
+          "whatsOnYourMind": "何を考えていますか?",
+          "whatsTheMove": "どういう動きですか？"
+        },
+        "anotherWin": "今日も勝利しました、{{userName}}?",
+        "coffeeReady": "コーヒーの準備ができました、{{userName}}。",
+        "enteredChat": "{{userName}} がチャットに参加しました。",
+        "goodToSeeYou": "初めまして、{{userName}} さん。",
+        "knewYouWouldCome": "必ず戻ってくると思っていました、{{userName}}。",
+        "letsRoll": "{{agentName}} は準備ができています、{{userName}}。転がりましょう。",
+        "makeTodayCount": "今日を有意義に過ごしましょう、{{userName}}。",
+        "newIdeas": "{{userName}} さん、今日は新しいアイデアがありますか?",
+        "readyToBuild": "ビルドする準備はできましたか? {{userName}}?",
+        "rightOnTime": "時間通りです、{{userName}}。",
+        "savedYourSeat": "席を確保しました、{{userName}}。",
+        "theUsual": "いつもの、{{userName}}?",
+        "welcomeBack": "おかえりなさい、{{userName}}。",
+        "whatAreWeWorkingOn": "{{userName}} さん、私たちは何を取り組んでいますか?",
+        "whatsCooking": "{{userName}}、料理は何ですか?",
+        "whatsOnYourMind": "{{userName}} さん、何を考えていますか?",
+        "whatsTheMove": "{{userName}} さん、どうしますか?"
+      },
+      "viewAgentProfile": "エージェントのプロフィールを表示する"
+    },
+    "attachments": {
+      "addLink": "リンクを追加",
+      "attach": "添付する",
+      "file": "ファイル {{filename}}",
+      "fileTooLarge": "{{filename}} が 1 GB の制限を超えています",
+      "imageUnavailable": "[画像は利用できません: {{filename}}]",
+      "importing": "添付ファイルをインポートしています",
+      "invalidLink": "有効なリンクを入力してください",
+      "linkPlaceholder": "https://example.com/image.png",
+      "loadingFile": "{{filename}} をロードしています",
+      "previewFile": "{{filename}} のプレビュー",
+      "supportedTypes": "画像、ドキュメント、オーディオ、ビデオ、アーカイブ",
+      "title": "添付ファイル",
+      "unavailable": "添付ファイルが利用できません",
+      "upload": "アップロード",
+      "uploadFailed": "{{filename}} のアップロードに失敗しました",
+      "uploadFailedRetry": "{{filename}} のアップロードに失敗しました。もう一度やり直してください。",
+      "uploadFromComputer": "パソコンからアップロードする",
+      "uploadFromLink": "リンクからアップロード",
+      "uploadsFailed": "一部の添付ファイルのアップロードに失敗しました。もう一度やり直してください。"
+    },
+    "automations": {
+      "active": "アクティブ",
+      "automation": "オートメーション",
+      "close": "オートメーションを閉じる",
+      "cronExpression": "クロン式",
+      "cronWithTimezone": "{{expression}} ({{timezone}})",
+      "dailyAt": "毎日 {{time}} で",
+      "disabled": "障害者",
+      "displaysIn": "{{timezone}} に表示されます",
+      "edit": "オートメーションの編集",
+      "editDescription": "このワークフローオートメーションを更新します。",
+      "empty": "オートメーションはまだありません。",
+      "event": "イベント",
+      "events": {
+        "githubDeploymentStatus": "GitHub デプロイメントステータスが作成されました",
+        "githubIssueComment": "GitHub Issueのコメントが作成されました",
+        "githubLabelApplied": "GitHub ラベルが適用されました",
+        "githubReviewSubmitted": "GitHub プル リクエストのレビューが送信されました",
+        "githubWorkflowCompleted": "GitHub ワークフローが完了しました",
+        "githubWorkflowJobCompleted": "GitHub ワークフロー ジョブが完了しました",
+        "gmailLabelApplied": "Gmail ラベルが適用されました",
+        "gmailNewMessage": "Gmail 新しいメッセージ",
+        "googleCalendarCancelled": "Google Calendar イベントがキャンセルされました",
+        "googleCalendarCreated": "Google Calendar イベントが作成されました",
+        "googleCalendarUpdated": "Google Calendar イベントが更新されました",
+        "googleMeetTranscript": "Google 会議記録の準備が完了しました",
+        "notionChildPage": "新しい Notion 子ページ",
+        "notionDatabaseItem": "新しい Notion データベース項目",
+        "notionPageUpdated": "Notion ページのコンテンツが更新されました",
+        "webhook": "Webhook のオートメーション"
+      },
+      "every": "毎",
+      "everyHour_one": "{{count}} 時間ごと",
+      "everyHour_other": "{{count}} 時間ごと",
+      "everyMinute_one": "{{count}} 分ごと",
+      "everyMinute_other": "{{count}} 分ごと",
+      "everySecond_one": "{{count}} 秒ごと",
+      "everySecond_other": "{{count}} 秒ごと",
+      "gmail": {
+        "body": "本体",
+        "cc": "Cc",
+        "contains": "{{field}} には以下が含まれます",
+        "containsAny": "{{field}} には、",
+        "doesNotContain": "{{field}} には次の内容が含まれません",
+        "from": "から",
+        "is": "です",
+        "labelName": "レーベル名",
+        "labelPlaceholder": "サポート",
+        "subject": "件名",
+        "threadId": "スレッドID",
+        "threadIdField": "スレッドIDフィールド",
+        "threadIdOperator": "スレッド ID 演算子",
+        "threadIdValue": "スレッド ID 値",
+        "to": "に"
+      },
+      "lastRun": "最後の実行",
+      "match": "一致",
+      "matchSummary": {
+        "allInboundMessages": "すべての受信メッセージ",
+        "anyComment": "任意のコメント",
+        "anyDeploymentState": "あらゆる展開状態",
+        "anyResult": "いかなる結果も",
+        "anyReview": "あらゆるレビュー",
+        "calendar": "カレンダー {{value}}",
+        "configuredDatabase": "構成されたデータベース",
+        "configuredPage": "設定されたページ",
+        "configuredParentPage": "設定された親ページ",
+        "contains": "{{field}} には {{value}} が含まれます",
+        "containsAny": "{{field}} には {{values}} のいずれかが含まれます",
+        "database": "データベース {{value}}",
+        "doesNotContain": "{{field}} には {{value}} が含まれません",
+        "doesNotContainAny": "{{field}} には {{values}} が含まれていません",
+        "label": "ラベル {{value}}",
+        "meetingsYouOrganize": "あなたが主催する会議",
+        "page": "ページ {{value}}",
+        "parentPage": "親ページ {{value}}",
+        "threadIdIs": "スレッド ID は {{value}} です"
+      },
+      "monthlyAt": "毎月 {{day}} 日、{{time}}",
+      "nextRun": "次の実行",
+      "noRuns": "まだ実行はありません",
+      "noUpcomingRun": "今後の実行はありません",
+      "onceAt": "{{date}} の {{time}} で 1 回",
+      "open": "オープンオートメーション",
+      "runAt": "実行時刻",
+      "runNow": "今すぐ実行",
+      "runsIn": "{{timezone}} で実行",
+      "save": "オートメーションの保存",
+      "schedule": "スケジュール",
+      "starting": "開始中...",
+      "status": "ステータス",
+      "title": "オートメーション",
+      "weekdayAt": "毎週平日 {{time}}",
+      "weeklyAt": "毎週 {{time}} で",
+      "weeklyOnAt": "毎週 {{days}} の {{time}}"
+    },
+    "billing": {
+      "addCreditsToContinue": "クレジットを追加すると、Zero とのチャットを続けることができます。",
+      "askAdminCredits": "Zero とチャットを続けることができるように、ワークスペース管理者にクレジットを追加するように依頼してください。",
+      "askAdminUpgrade": "Zero とのチャットを継続できるように、ワークスペース管理者に Pro にアップグレードするよう依頼してください。",
+      "buy": "購入する",
+      "checkingPermissions": "課金権限を確認しています...",
+      "comparePlans": "プランを比較する",
+      "comparePlansDescription": "プランを比較して、有料ワークスペース機能と追加クレジットのロックを解除します。",
+      "creditsAdded": "クレジットが追加されました。 Zero とのチャットを続けることができます。",
+      "creditsAvailable": "利用可能なクレジット",
+      "custom": "カスタム",
+      "customAmountError": "1 ドルから 10,000 ドルの間で入力してください",
+      "customDollarAmount": "カスタムドル額",
+      "outOfCredits": "クレジットが不足しています",
+      "redirecting": "リダイレクト中...",
+      "upgradeToContinue": "Zero とチャットを続けるには、Pro にアップグレードしてください。",
+      "upgradeToPro": "プロにアップグレード",
+      "upgradeToRun": "Zero を実行するには Pro にアップグレードしてください",
+      "upgradeWorkspace": "ワークスペースをアップグレードする"
+    },
+    "composer": {
+      "agentSuggestions": "エージェント",
+      "configureModel": "モデルの構成",
+      "createWorkflow": "ワークフローの作成",
+      "message": "メッセージ",
+      "modelConfigureAction": "モデル構成",
+      "placeholder": "ワークフローの自動化、タスクの管理を依頼してください...",
+      "selectedModelUnavailable": "選択されたモデルは使用できません。送信する前に設定してください。",
+      "selectedModelUnavailableToast": "選択したモデルは利用できません",
+      "selectModel": "モデルを選択してください",
+      "threadSuggestions": "チャットスレッド",
+      "visualAttachmentsUnsupported": "{{modelName}} は画像またはビデオを認識できません。ビジョン対応モデルに切り替えて取り付けてください。",
+      "workflows": {
+        "empty": "一致するワークフローがありません",
+        "loading": "ワークフローを読み込んでいます...",
+        "title": "ワークフロー",
+        "viewAll": "すべてのワークフローを表示"
+      }
+    },
+    "computerUse": {
+      "authorization": "コンピュータの使用許可",
+      "authorizationDescription": "このスレッドで今後実行するデスクトップ ホストを選択してください。",
+      "checkingCompatibility": "互換性の確認",
+      "cloudBrowser": "クラウドブラウザ",
+      "connectHost": "{{hostName}} を接続します",
+      "connectMyComputer": "コンピューターを接続する",
+      "dialogDescription": "そのため、Zero は、LinkedIn や Reddit のようなコネクタを持たないブラウザやアプリでも動作します。",
+      "dialogTitle": "Zero にコンピュータを使用させます",
+      "disableCloudBrowser": "クラウドブラウザを無効にする",
+      "disconnectHost": "{{hostName}} を切断します",
+      "downloadMacos": "macOS をダウンロード",
+      "enableCloudBrowser": "クラウドブラウザを有効にする",
+      "hosts": "コンピュータ使用ホスト",
+      "macosRequirement": "macOS 14 以降を搭載した Apple Silicon Mac が必要です。 Intel Mac はサポートされていません。",
+      "noOnlineComputers": "オンラインコンピュータはありません",
+      "offline": "オフライン",
+      "unsupportedIntelMac": "AppleシリコンMacが必要です",
+      "yourComputer": "あなたのコンピュータ"
+    },
+    "connectors": {
+      "add": "{{connectorName}} を追加",
+      "addConnectors": "コネクタの追加",
+      "authorizationFailed": "{{connectorName}} は接続されましたが、{{agentName}} に対して認証できませんでした",
+      "authorized": "{{connectorName}} が接続され、{{agentName}} に対して承認されました",
+      "available_one": "接続可能なコネクタ ({{count}})",
+      "available_other": "接続可能なコネクタ ({{count}})",
+      "configurePermissions": "{{connectorName}} 権限を構成する",
+      "customAuthorizeDescription": "エージェント用のこのカスタム コネクタを確認、接続、承認します。",
+      "customConnectDescription": "このカスタム コネクタを確認して接続します。",
+      "find": "コネクタを検索...",
+      "remove": "{{connectorName}} を削除します",
+      "title": "コネクター"
+    },
+    "documentTitle": "チャット",
+    "errors": {
+      "loadMessages": "メッセージの読み込みに失敗しました",
+      "noModelProviderAction": "ワークスペース設定で設定します",
+      "noModelProviderPrefix": "モデルプロバイダーがまだ構成されていません。",
+      "noModelProviderSuffix": "始めるために。",
+      "providerDeletedAction": "新しいチャット スレッドを開始する",
+      "providerDeletedPrefix": "このスレッドで使用されているモデルプロバイダーは削除されました。",
+      "providerDeletedSuffix": "続けます。",
+      "providerIncompatibleAction": "新しいセッションを開始する",
+      "providerIncompatiblePrefix": "このセッションは別のモデル プロバイダーで開始されたため、現在のモデル プロバイダーでは続行できません。",
+      "runCancelled": "考えの途中で一時停止しました。いつでも元に戻してください。"
+    },
+    "feedback": {
+      "emailDraftDescription": "メールの下書き (メールの下書き ID: {{id}})",
+      "partHeading": "返信のこの部分に関するフィードバック:",
+      "partsHeading_one": "返信の {{count}} 部分に関するフィードバック:",
+      "partsHeading_other": "返信の {{count}} 部分に関するフィードバック:",
+      "placeholder": "これについて何を変える必要がありますか?",
+      "provide": "フィードバックを提供する",
+      "remove": "フィードバックを削除する",
+      "sentEmailDescription": "送信されたメール (メール ID: {{id}}{{sentIdSuffix}})",
+      "sentIdSuffix": "、送信された ID: {{sentId}}",
+      "sourcePartHeading": "{{description}} のこの部分に関するフィードバック:",
+      "sourcePartsHeading_one": "{{description}} の {{count}} 部分に関するフィードバック:",
+      "sourcePartsHeading_other": "{{description}} の {{count}} 部分に関するフィードバック:"
+    },
+    "mail": {
+      "bcc": "BCC",
+      "cc": "cc",
+      "closeDetails": "メールの詳細を閉じる",
+      "deleted": "この下書きは削除されました。",
+      "deletedEmail": "削除されたメール: {{subject}}",
+      "details": "メールの詳細",
+      "email": "メール",
+      "followUp": {
+        "action": "フォローアップ",
+        "active": "返信の追跡",
+        "activeDescription": "返信は追跡され、このチャットで報告されます。",
+        "idleDescription": "返信を追跡し、このチャットで通知を受け取ります。",
+        "paused": "追跡が一時停止されました",
+        "pausedDescription": "返信追跡は現在一時停止されています。",
+        "settingUp": "セットアップ中…",
+        "submitting": "セットアップ中…",
+        "submittingDescription": "返信追跡を設定しています…",
+        "tracking": "返信の追跡"
+      },
+      "loadingDetails": "メールの詳細を読み込んでいます",
+      "needReconnect": "再接続が必要です",
+      "noMessage": "(メッセージなし)",
+      "noRecipient": "受信者がいません",
+      "noSubject": "(件名なし)",
+      "noSubjectPlain": "件名なし",
+      "openEmail": "{{status}} メールを開きます: {{subject}}",
+      "openInGmail": "Gmail で開く",
+      "recipientsLine": "{{recipients}} へ",
+      "reconnectDescription": "このメールにアクセスする権限がありません。続行するには、Gmail を再接続します。",
+      "reconnectGmail": "Gmail を再接続します",
+      "reconnecting": "再接続中…",
+      "reconnectToAccess": "Gmail を再接続してメールにアクセスします: {{subject}}",
+      "sentToast": "メールを送信しました",
+      "status": {
+        "deleted": "削除されました",
+        "draft": "草案",
+        "sent": "送信済み"
+      },
+      "toRecipients": "宛先: {{recipients}}",
+      "unavailable": "このメールはもう利用できません。"
+    },
+    "messageDocument": {
+      "agent": "[エージェント: {{name}}]",
+      "chatThread": "[チャット スレッド: {{title}}]",
+      "file": "[ファイル: {{filename}}]",
+      "template": "[テンプレート: {{title}}]"
+    },
+    "newChat": "新しいチャット",
+    "origins": {
+      "feishu": "Feishu",
+      "openChat": "オープンチャット",
+      "openFeishuChat": "Feishu で元のチャットを開く",
+      "openMessage": "メッセージを開く",
+      "openSlackMessage": "Slack で元のメッセージを開く",
+      "slack": "Slack"
+    },
+    "permissions": {
+      "actionDescription": "{{action}} {{permissionName}}",
+      "agentNotFound": "エージェントが見つかりません",
+      "allow": "許可する",
+      "alreadyAllowed": "すでに許可されています",
+      "alreadyDenied": "すでに拒否されています",
+      "checking": "許可ステータスを確認しています...",
+      "connectorTitle": "{{connectorName}} 権限",
+      "denied": "許可が拒否されました",
+      "deny": "拒否する",
+      "duration": "許可期間",
+      "expired": "期限切れ",
+      "expiresInDays_one": "{{count}} 日で期限切れになります",
+      "expiresInDays_other": "{{count}} 日で期限切れになります",
+      "expiresInHours_one": "{{count}} 時間後に期限切れになります",
+      "expiresInHours_other": "{{count}} 時間で期限切れになります",
+      "loadFailed": "権限ステータスを読み込めませんでした",
+      "unknown": "不明な権限",
+      "updated": "権限が更新されました",
+      "updateFailed": "権限を更新できませんでした"
+    },
+    "promptDocumentTitle": "プロンプト",
+    "queue": {
+      "aboutAutomationEvent": "このオートメーションイベントについて",
+      "aboutGoal": "この目標について",
+      "aboutQueuedMessage": "このキューに入れられたメッセージについて",
+      "activeGoal": "アクティブな目標",
+      "automationEvent": "オートメーションイベント",
+      "automationEventDescription": "キューに入れられたメッセージの後ろで待機し、現在の実行が終了すると実行されます。",
+      "cancelGoal": "ゴールをキャンセルする",
+      "event_one": "{{count}} イベント",
+      "event_other": "{{count}} イベント",
+      "goal": "目標",
+      "goalDescription": "キューが空になった後に実行され、キャンセルされるまで実行され続けます。",
+      "goalLoadFailed": "この目標を読み込めませんでした",
+      "goalRetry": "ダイアログを閉じて、もう一度開いて再試行してください。",
+      "goalUnavailable": "この目標はもう利用できません。",
+      "itemsWaiting": "{{items}} 待機中",
+      "itemsWaitingTogether": "{{messages}} と {{events}} が待機中です",
+      "loadingGoal": "目標を読み込んでいます...",
+      "message_one": "{{count}} メッセージ",
+      "message_other": "{{count}} メッセージ",
+      "openGoalDetails": "目標の詳細を開く",
+      "pendingAutomationEvent": "保留中のオートメーションイベント",
+      "queuedMessage": "キューに入れられたメッセージ",
+      "queuedMessageDescription": "列に並んで待機し、現在の実行が終了したら送信します。",
+      "removeQueuedMessage": "キューに入れられたメッセージを削除する",
+      "skipAutomationEvent": "オートメーションイベントをスキップする"
+    },
+    "replaceDraft": {
+      "description": "続行すると、現在のコンポーザーの下書きが消去され、ワークフローのプロンプトが開始されます。",
+      "title": "コンポーザーの下書きを置き換えますか？"
+    },
+    "run": {
+      "automatedRun": "自動実行",
+      "collapseGroupedHistory": "グループ化された実行履歴を折りたたむ",
+      "collapseWorkHistory": "作業履歴を折りたたむ",
+      "creditUsage": "クレジット使用量",
+      "done": {
+        "allDone": "すべて完了 — {{time}}",
+        "default": "完了",
+        "delivered": "{{time}} に配信",
+        "doneAndDusted": "完了し、埃を払いました — {{time}}",
+        "finished": "{{time}} に終了しました。ご対応ください",
+        "missionComplete": "ミッション完了、{{time}}",
+        "signedOff": "{{time}} でサインオフされました",
+        "wrap": "これで終わりです — {{time}}",
+        "wrappedUp": "{{time}} で終了"
+      },
+      "duration": {
+        "hour_one": "{{count}} 時間",
+        "hour_other": "{{count}} 時間",
+        "hoursShort_one": "{{count}}h",
+        "hoursShort_other": "{{count}}h",
+        "minute_one": "{{count}} 分",
+        "minute_other": "{{count}} 分",
+        "minutesShort_one": "{{count}}m",
+        "minutesShort_other": "{{count}}m",
+        "secondsShort_one": "{{count}}s",
+        "secondsShort_other": "{{count}}s"
+      },
+      "durationFor": "{{label}} の場合は {{duration}}",
+      "expandGroupedHistory": "グループ化された実行履歴を展開する",
+      "expandWorkHistory": "作業履歴を展開",
+      "goalFor": "{{label}} の目標",
+      "groupedRunsFor_one": "{{count}} は {{source}} に対して実行されます",
+      "groupedRunsFor_other": "{{count}} は {{source}} に対して実行されます",
+      "justNow": "たった今",
+      "keepGoing": "続ける",
+      "keepGoingAt": "続ける · {{timestamp}}",
+      "queueEllipsis": "行列...",
+      "thinking": {
+        "assembling": "部品を組み立て中...",
+        "brewing": "返答を作成中...",
+        "mapping": "それをマッピングする...",
+        "onIt": "その上で...",
+        "piecingTogether": "物事をつなぎ合わせる...",
+        "shaping": "応答を形成中...",
+        "sketching": "詳細をスケッチ中...",
+        "spinningUp": "スピンアップ中...",
+        "tuningIn": "チューニング中...",
+        "wiring": "配線を合わせてみると・・・"
+      },
+      "viewActivityLogs": "アクティビティログを表示する",
+      "viewLogs": "実行ログを表示する",
+      "waitingIn": "待機中",
+      "worked": "働いた",
+      "workedFor": "{{duration}} で働いていました"
+    },
+    "shortcuts": {
+      "number": "番号"
+    },
+    "sidebar": {
+      "allChats": "すべてのチャット",
+      "chatsWith": "{{agentName}} とのチャット",
+      "chatThreads": "チャットスレッド",
+      "delete": "チャットを削除する",
+      "deleteDescription": "これにより、このチャットは完全に削除されます。このチャットで現在実行中のタスクはすぐに停止されます。この操作は元に戻すことができません。",
+      "deleteTitle": "チャットを削除しますか?",
+      "draft": "草案",
+      "empty": "会話を開始するとここに表示されます",
+      "newChatWith": "{{agentName}} との新しいチャット",
+      "noUnread": "未読のチャットはありません",
+      "openChatMenu": "チャットメニューを開く",
+      "openListMenu": "チャットリストメニューを開く",
+      "pin": "チャットをピン留めする",
+      "pinned": "ピン留め済み",
+      "rename": "チャットの名前を変更する",
+      "renameDescription": "このチャット スレッドの新しい名前を入力します。",
+      "titlePlaceholder": "チャットのタイトル",
+      "unpin": "チャットの固定を解除する",
+      "unread": "未読",
+      "unreadOnly": "未読のみ"
+    },
+    "templates": {
+      "categories": {
+        "illustration": "イラストレーション",
+        "presentation": "プレゼンテーション",
+        "video": "ビデオ",
+        "website": "ウェブサイト",
+        "workflow": "ワークフロー"
+      },
+      "messageTemplate": "メッセージ テンプレート {{title}}",
+      "previewTemplate": "プレビュー テンプレート {{title}}",
+      "previewVideo": "プレビュービデオテンプレート {{title}}",
+      "previewWebsite": "Web サイト テンプレートのプレビュー {{title}}",
+      "previewWorkflow": "ワークフロー テンプレートのプレビュー {{title}}",
+      "removeTemplate": "テンプレート {{title}} を削除します",
+      "removeVideo": "ビデオ テンプレート {{title}} を削除します",
+      "removeWebsite": "Web サイト テンプレート {{title}} を削除します",
+      "removeWorkflow": "ワークフロー テンプレート {{title}} を削除します"
+    },
+    "thread": {
+      "ariaLabel": "チャットスレッド",
+      "changeIcon": "アイコンの変更",
+      "emoji": {
+        "done": "完了",
+        "idea": "アイデア",
+        "no": "いいえ",
+        "question": "質問",
+        "risk": "リスク",
+        "shipped": "出荷済み",
+        "urgent": "緊急",
+        "waiting": "待っています",
+        "watching": "見てる"
+      },
+      "empty": "メッセージを送信して会話を始めましょう",
+      "frequentlyUsed": "頻繁に使用される",
+      "icon": "チャットスレッドアイコン",
+      "loadingEarlier": "以前のメッセージを読み込んでいます",
+      "noEmojiFound": "絵文字が見つかりませんでした",
+      "openArtifacts": "オープンアーティファクト",
+      "openBrowser": "ブラウザを開く",
+      "openNamedAgent": "エージェント {{name}} を開く",
+      "openNamedChat": "チャットを開く {{title}}",
+      "scrollToBottom": "一番下までスクロール",
+      "searchEmoji": "絵文字を検索"
+    },
+    "threadSidebar": {
+      "resize": "サイドバーのサイズを変更する"
+    },
+    "toasts": {
+      "copied": "コピーされました",
+      "deleted": "チャットが削除されました"
+    },
+    "voice": {
+      "checkingLimit": "音声入力制限を確認する",
+      "input": "音声入力",
+      "inputLimitReached": "音声入力の制限に達しました。より高い制限を得るには、Pro または Team にアップグレードしてください。",
+      "microphoneAccessDenied": "マイクへのアクセスが拒否されました。マイクへのアクセスを許可して、再試行してください。",
+      "openingMicrophone": "マイクを開いて...",
+      "starting": "音声入力を開始する",
+      "stopRecording": "録音を停止する",
+      "transcribing": "文字起こし",
+      "transcribingProgress": "転記中...",
+      "transcriptionFailed": "音声の転写に失敗しました。もう一度やり直してください。"
+    },
+    "workflows": {
+      "named": "ワークフロー {{title}}",
+      "open": "ワークフロー {{title}} を開く"
+    }
+  },
+  "connectors": {
+    "access": {
+      "accessFor": "{{action}} {{connector}} {{agent}} へのアクセス",
+      "accessUpdated": "{{connector}} アクセスが更新されました",
+      "clearSearch": "エージェント検索をクリアする",
+      "description": "このコネクタを使用できるエージェントを選択します。",
+      "loading": "エージェントをロード中...",
+      "managePermissions": "権限の管理",
+      "managePermissionsFor": "{{agent}} の {{connector}} 権限を管理する",
+      "noAgents": "エージェントが見つかりませんでした",
+      "noMatchingAgents": "「{{search}}」に一致するエージェントはありません",
+      "permissionsUpdated": "権限が更新されました",
+      "search": "エージェントを探す",
+      "title": "{{connector}} アクセスを管理する",
+      "unnamedAgent": "無名"
+    },
+    "actions": {
+      "apply": "申し込む",
+      "authorize": "承認する",
+      "cancel": "キャンセル",
+      "close": "閉じる",
+      "closeWindow": "ウィンドウを閉じる",
+      "connect": "接続する",
+      "connecting": "接続中...",
+      "create": "作成",
+      "creating": "作成中…",
+      "delete": "削除",
+      "deleting": "削除中…",
+      "disconnect": "切断する",
+      "disconnecting": "切断中...",
+      "edit": "編集",
+      "grant": "グラント",
+      "reconnect": "再接続",
+      "rename": "名前の変更",
+      "revoke": "取り消し",
+      "save": "保存",
+      "saving": "保存中...",
+      "savingEllipsis": "保存中…",
+      "tryAgain": "もう一度試してください",
+      "uninstall": "アンインストール",
+      "uninstalling": "アンインストール中..."
+    },
+    "callback": {
+      "connected": "{{connector}} が接続されました",
+      "connectedAs": "{{username}} として接続されています。このウィンドウは閉じても構いません。",
+      "connectedDescription": "あなたのアカウントは接続されました。このウィンドウは閉じても構いません。",
+      "connecting": "{{connector}} を接続中…",
+      "connectingDescription": "アカウントの接続が完了するまでお待ちください。",
+      "customConnectorLabel": "カスタムコネクタ",
+      "documentTitle": "{{connector}} を接続します",
+      "errorDescription": "{{error}} このウィンドウを閉じて、再試行してください。",
+      "errorFallback": "接続中にエラーが発生しました。",
+      "failed": "接続に失敗しました",
+      "failedTitle": "{{connector}} に接続できませんでした",
+      "finishing": "安全な接続を完了する",
+      "genericLabel": "コネクタ",
+      "githubLabel": "GitHub",
+      "invalidUrl": "コネクタのコールバック URL が無効です。",
+      "success": "接続済み"
+    },
+    "card": {
+      "accessFor": "{{action}} {{connector}} アクセス",
+      "authorized": "認可された",
+      "connectAria": "{{connector}} を接続します",
+      "connected": "接続済み",
+      "connecting": "接続中…",
+      "connectionExpired": "接続が期限切れになりました",
+      "connectToContinue": "続行するにはこのアカウントを接続してください",
+      "managePermissions": "権限の管理",
+      "managePermissionsFor": "{{connector}} 権限を管理する",
+      "optional": "オプション",
+      "required": "必須",
+      "reviewPermissions": "権限の確認",
+      "updatePermissions": "権限の更新"
+    },
+    "catalog": {
+      "access": {
+        "add": "アクセス権の追加",
+        "manage": "{{connector}} アクセスを管理する",
+        "usedBy": "使用者 "
+      },
+      "categories": {
+        "ai": {
+          "label": "AI",
+          "menu": "AI"
+        },
+        "aiAgentApps": {
+          "label": "エージェント プラットフォームと AI アプリ",
+          "menu": "エージェントプラットフォーム"
+        },
+        "aiGeneralModels": {
+          "label": "一般的なモデルと推論",
+          "menu": "一般モデル"
+        },
+        "aiImageVideo": {
+          "label": "画像/ビデオの生成",
+          "menu": "画像・動画"
+        },
+        "aiMemoryTracingEval": {
+          "label": "メモリ/トレース/評価",
+          "menu": "メモリ/トレース"
+        },
+        "aiVoiceAudio": {
+          "label": "音声・オーディオ",
+          "menu": "音声・オーディオ"
+        },
+        "communicationCollaboration": {
+          "label": "コミュニケーションとコラボレーション",
+          "menu": "コミュニケーション"
+        },
+        "dataAutomationInfrastructure": {
+          "label": "データ、オートメーション、インフラストラクチャ",
+          "menu": "データとオートメーション"
+        },
+        "docsFilesKnowledge": {
+          "label": "ドキュメント、ファイル、ナレッジ",
+          "menu": "書類"
+        },
+        "engineeringTeamExecution": {
+          "label": "エンジニアリングとチームの実行",
+          "menu": "エンジニアリング"
+        },
+        "marketingContentGrowth": {
+          "label": "マーケティング、コンテンツ、成長",
+          "menu": "マーケティング"
+        },
+        "meetingsScheduling": {
+          "label": "会議とスケジュール設定",
+          "menu": "会議"
+        },
+        "salesCrmBusinessOperations": {
+          "label": "営業、CRM、事業運営",
+          "menu": "販売と事業"
+        }
+      },
+      "categoriesAria": "コネクタのカテゴリ",
+      "description": "エージェントが使用できるようにサードパーティのサービスを接続します。",
+      "empty": {
+        "agent": "このエージェントにはコネクタがありません",
+        "connected": "コネクタが接続されていません",
+        "matching": "{{message}} が「{{search}}」に一致",
+        "notConnected": "接続するコネクタが残っていない",
+        "search": "「{{search}}」に一致するコネクタはありません"
+      },
+      "filters": {
+        "agents": "エージェント",
+        "all": "すべて",
+        "aria": "フィルターコネクター",
+        "connected": "接続済み",
+        "notConnected": "接続されていません",
+        "status": "ステータス"
+      },
+      "iconUnavailable": "コネクタアイコンが使用不可",
+      "newConnector": "新しいコネクタ",
+      "noConnectorsAlt": "コネクターなし",
+      "otherCategory": "その他",
+      "search": "コネクターを検索",
+      "tabs": {
+        "builtin": "内蔵",
+        "custom": "カスタム"
+      },
+      "title": "コネクター",
+      "unnamedAgent": "無名"
+    },
+    "connectDialog": {
+      "connectedAs": "{{username}} として接続されています",
+      "device": {
+        "checking": "承認を確認しています...",
+        "connect": "{{connector}} を接続します",
+        "copyThenOpen": "このコードをコピーし、確認ページを開いてアクセスを承認します。",
+        "description": "プロバイダーの確認ページを開き、この確認コードを入力してアクセスを承認します。",
+        "intro": "接続して確認コードを取得し、プロバイダーの確認ページでそれを使用してアクセスを承認します。",
+        "openPage": "認証ページを開く",
+        "selectOption": "{{option}} を選択します",
+        "starting": "開始中...",
+        "startingConnection": "接続を開始しています...",
+        "verificationCode": "認証コード",
+        "waiting": "承認を待っています。このダイアログは開いたままにしておきます。"
+      },
+      "errors": {
+        "authorizationWindow": "認証ウィンドウを開けませんでした",
+        "codeRequired": "{{connector}} のコードを入力します。",
+        "denied": "接続が拒否されました。もう一度やり直してください。",
+        "expired": "接続セッションの有効期限が切れました。もう一度やり直してください。",
+        "failed": "接続に失敗しました。もう一度やり直してください。",
+        "verificationOpen": "確認ページを開けませんでした。もう一度やり直してください。"
+      },
+      "external": {
+        "code": "コード",
+        "complete": "接続完了",
+        "description": "{{connector}} サインインを開き、{{connector}} によって表示されたコードを貼り付けます。",
+        "open": "{{connector}} サインインを開きます",
+        "start": "{{connector}} サインインを開始します"
+      },
+      "noAuth": {
+        "enable": "{{connector}} を有効にする",
+        "enabling": "有効化中..."
+      },
+      "noMethod": "利用できる接続方法はありません。",
+      "or": "または",
+      "progress": {
+        "connecting": "接続中...",
+        "savingPermissions": "権限を保存しています..."
+      },
+      "unavailable": {
+        "description": "このコネクタには利用可能な接続方法がありますが、このダイアログからはまだ設定できません。",
+        "title": "利用できない接続方法"
+      }
+    },
+    "custom": {
+      "agentUsage": {
+        "none": "どのエージェントも使用していません",
+        "usedBy": "{{agents}} によって使用されます",
+        "usedByOverflow_one": "{{agents}} +{{value}} によって使用されます",
+        "usedByOverflow_other": "{{agents}} +{{value}} によって使用されます"
+      },
+      "connect": {
+        "apiAuthentication": "API認証",
+        "apiDescription": "プロバイダーが発行したAPIシークレットを入力します。",
+        "back": "戻る",
+        "connecting": "接続中…",
+        "continue": "続ける",
+        "continueToProvider": "プロバイダーに進み、アクセスを承認します。",
+        "description": "シークレットは保存時に暗号化され、ファイアウォールによって送信リクエストに挿入されます。環境変数としてエージェントに公開されることはありません。",
+        "oauthDescription": "コネクタの OAuth アプリを使用してアクセスを承認します。",
+        "save": "保存",
+        "saving": "保存中…",
+        "secret": "シークレット",
+        "title": "{{connector}} を接続します"
+      },
+      "create": {
+        "addAuthentication": "認証の追加",
+        "advancedApiPreserved": "高度な API フィールドとインジェクションは、保存時に保持されます。",
+        "advancedSettings": "詳細設定",
+        "apiAuthentication": "API認証",
+        "apiAuthenticationDescription": "ユーザーが提供したシークレットを、一致するすべてのリクエストに挿入します。",
+        "authorizationParameters": "認可パラメータ",
+        "authorizationParametersDescription": "プロバイダーが必要とするパラメータのみを追加してください。",
+        "authorizationUrl": "認可URL",
+        "clientId": "クライアントID",
+        "clientSecret": "クライアントシークレット",
+        "displayName": "表示名",
+        "headerName": "ヘッダー名",
+        "headerTemplate": "ヘッダーテンプレート",
+        "headerTemplateHint": "({{placeholder}} を含める必要があります)",
+        "httpBasicAuthentication": "HTTP基本認証",
+        "keepClientSecret": "保存された値を保持するには、クライアント シークレットを空白のままにしておきます。",
+        "keepClientSecretPlaceholder": "最新の状態を保つには空白のままにしてください",
+        "newClientSecret": "新しいクライアントシークレット",
+        "none": "なし",
+        "oauthChangesDisconnect": "OAuth 設定またはクライアント認証情報を変更すると、既存の OAuth 接続が切断されます。",
+        "oauthDescription": "メンバーが承認できるように 1 つの OAuth アプリを構成します。",
+        "optional": "(オプション)",
+        "parameters": {
+          "accessType": "アクセスタイプ",
+          "audience": "観客",
+          "prompt": "プロンプト",
+          "resource": "リソース"
+        },
+        "prefixes": "プレフィックス",
+        "prefixesHint": "(1 行に 1 つ、https のみ)",
+        "redirectCopy": "リダイレクト URL をコピーする",
+        "redirectHint": "(この URL をプロバイダーの OAuth アプリケーションに登録します。)",
+        "redirectUrl": "リダイレクトURL",
+        "removeApiAuthentication": "API認証を削除する",
+        "removeOauth": "OAuth 2.0 を削除する",
+        "scopes": "スコープ",
+        "scopesHint": "(1 行に 1 つ)",
+        "secretInRequestBody": "リクエスト本文のクライアント シークレット",
+        "title": "新しいカスタムコネクタ",
+        "tokenEndpointAuthentication": "トークンエンドポイント認証",
+        "tokenUrl": "トークンURL"
+      },
+      "delete": {
+        "description": "これにより、コネクタと、そのコネクタに対してすべてのメンバーが保存したシークレットが削除されます。このコネクタに対して認可されたエージェントは、すぐにアクセスできなくなります。これを元に戻すことはできません。",
+        "title": "{{connector}} を削除しますか?"
+      },
+      "edit": {
+        "title": "カスタムコネクタの編集"
+      },
+      "emptyAdmin": "カスタム コネクタはまだありません。すべてのメンバーが使用する API を登録するために作成します。",
+      "emptyMember": "組織はまだカスタム コネクタを登録していません。",
+      "moreOptions": "その他のオプション",
+      "rename": {
+        "displayName": "表示名",
+        "title": "カスタムコネクタの名前を変更する"
+      },
+      "statusConnected": "接続済み",
+      "toasts": {
+        "connected": "接続済み",
+        "created": "「{{connector}}」を作成しました",
+        "deleted": "カスタムコネクタが削除されました",
+        "disconnected": "切断されました",
+        "renamed": "名前を「{{connector}}」に変更しました",
+        "updated": "「{{connector}}」を更新しました"
+      },
+      "updateConfirm": {
+        "action": "保存して切断する",
+        "description": "これらの OAuth の変更により、現在 OAuth に接続しているすべてのメンバーが切断されます。このカスタム コネクタを再度接続する必要があります。",
+        "title": "既存の OAuth 接続を切断しますか?"
+      }
+    },
+    "customProposal": {
+      "configure": "{{connector}} を構成する",
+      "descriptionAgent": "保存すると、値が接続され、{{agent}} が承認されます。",
+      "descriptionUser": "保存すると、アカウントのこのカスタム コネクタが接続されます。",
+      "documentTitle": "カスタムコネクタの構成",
+      "invalid": "このカスタム コネクタ プロポーザル リンクは無効であるか、期限切れです。",
+      "requestScope": "リクエストの範囲",
+      "returnToChat": "チャットに戻り、エージェントがコネクタを確認できるように ACK を返信します。",
+      "saved": "保存されました",
+      "savedToast": "{{connector}} が保存されました",
+      "targetFallback": "このエージェント",
+      "update": "{{connector}} を更新します"
+    },
+    "directed": {
+      "authorizeAgent": "{{agent}} を承認する",
+      "authorized": "{{connector}} が承認されました",
+      "authorizeDocumentTitle": "{{connector}} を承認する",
+      "connectDocumentTitle": "{{connector}} を接続します",
+      "connected": "{{connector}} が接続されました",
+      "needsConnector": "{{agent}} を続行するには {{connector}} が必要です",
+      "reconnecting": "再接続中..."
+    },
+    "expiration": {
+      "inDays_one": "{{count}} 日で期限切れになります",
+      "inDays_other": "{{count}} 日で期限切れになります",
+      "inHours_one": "{{count}} 時間後に期限切れになります",
+      "inHours_other": "{{count}} 時間で期限切れになります",
+      "lessThanHour": "1 時間以内に期限切れになります"
+    },
+    "permissions": {
+      "actions": {
+        "allow": "許可する",
+        "deny": "拒否する",
+        "mixed": "混合"
+      },
+      "allowDuration": {
+        "always": "常に許可する",
+        "oneHour": "1時間お待ちください",
+        "sevenDays": "7日ほどお待ちください",
+        "twentyFourHours": "24時間待つ"
+      },
+      "allowOptions": "{{permission}} 許可オプション",
+      "always": "いつも",
+      "clearSearch": "権限検索のクリア",
+      "descriptionAgent": "このエージェントがこのコネクタ経由で実行できるアクションを構成します。",
+      "descriptionWorkflow": "このワークフローがこのコネクタ経由で実行できるアクションを構成します。",
+      "find": "権限の検索",
+      "findPlaceholder": "権限を検索...",
+      "forTarget": "{{target}} の場合",
+      "loadError": "権限メタデータのロードに失敗しました",
+      "loading": "権限を読み込んでいます...",
+      "metadataMissing": "{{connector}} の権限メタデータが見つかりません",
+      "noResults": "「{{search}}」の結果はありません",
+      "otherEndpoints": "その他のエンドポイント",
+      "otherEndpointsDescription": "API エンドポイントが上記のどの権限にも一致しません",
+      "permissions": "権限",
+      "restore": "復元",
+      "scopeReview": {
+        "added": "新しい権限",
+        "description": "このコネクタに必要な権限が変更されました。確認して再接続し、アップデートを適用してください。",
+        "failed": "スコープの変更をロードできませんでした。",
+        "loading": "スコープの変更を読み込んでいます...",
+        "removed": "削除された権限",
+        "title": "{{connector}} 権限の更新"
+      },
+      "selectAll": "すべて選択",
+      "showMore_one": "もっと見る ({{count}})",
+      "showMore_other": "もっと見る ({{count}})",
+      "title": "{{connector}} 権限"
+    },
+    "providerConnect": {
+      "agentphone": {
+        "back": "{{brandName}} に戻る",
+        "connectDescription": "この電話番号を {{brandName}} アカウントにリンクすると、テキスト メッセージから Zero とやり取りできるようになります。",
+        "connectTitle": "電話番号を接続する",
+        "documentTitle": "メッセージを接続する",
+        "errorFallback": "この電話番号には接続できませんでした。テキスト メッセージからもう一度お試しください。",
+        "incompleteDescription": "テキスト メッセージから新しい /connect リンクを開きます。",
+        "incompleteTitle": "接続リンクが不完全です",
+        "invalidSignature": "このリンクの署名は無効です。",
+        "invalidTimestamp": "このリンクのタイムスタンプは無効です。",
+        "invalidTitle": "接続リンクが無効です",
+        "risk": "SMS および MMS の返信は確実に配信されない可能性があります。最も信頼性の高いエクスペリエンスを得るには、この AgentPhone 番号で iMessage を使用してください。",
+        "successDescription": "{{phone}} が接続されています。テキスト メッセージを送信して、Zero とのチャットを開始します。",
+        "successTitle": "接続された電話番号"
+      },
+      "common": {
+        "backToSettings": "設定に戻る",
+        "checkingTitle": "アカウントのステータスを確認しています...",
+        "connectionFailed": "接続に失敗しました",
+        "invalidLink": "無効なリンク",
+        "verifying": "接続を確認するまでお待ちください。"
+      },
+      "feishu": {
+        "back": "Feishu 設定に戻る",
+        "checkingTitle": "アカウントのステータスを確認しています…",
+        "connectDescription": "{{brandName}} アカウントをこの Feishu ボットにリンクすると、Feishu から直接エージェントと連携できるようになります。",
+        "connectTitle": "Feishu に接続します",
+        "errorFallback": "Feishu に接続できませんでした。新しい接続リンクを開いて、再試行してください。",
+        "invalidDescription": "Feishu から新しい接続リンクを開いて、再試行してください。",
+        "open": "Feishu を開く",
+        "successDescription": "つながっていますね。 Feishu でメッセージを送信してチャットを開始してください。",
+        "successDescriptionNamed": "{{bot}} に接続しています。 Feishu でメッセージを送信してチャットを開始してください。",
+        "successTitle": "Feishu に接続しました!"
+      },
+      "github": {
+        "accountFallback": "この GitHub アカウント",
+        "alreadyDescription": "すでに {{account}} として接続されています。チャットを開始するには、GitHub のIssueまたはプル リクエストでエージェントに言及してください。",
+        "alreadyTitle": "すでに GitHub に接続されています",
+        "back": "ワークフローに戻る",
+        "checkingConnectionDescription": "GitHub 接続を確認するまでお待ちください。",
+        "checkingConnectionTitle": "接続を確認しています...",
+        "checkingSession": "{{brandName}} セッションを確認するまでお待ちください。",
+        "connectDescription": "{{brandName}} アカウントを {{account}} にリンクすると、GitHub メンションで問題やプル リクエストからエージェントを実行できるようになります。",
+        "connectTitle": "GitHub に接続します",
+        "errorFallback": "GitHub に接続できませんでした。 GitHub から再試行してください。",
+        "invalidInstallation": "このリンク上の GitHub インストールは無効です。",
+        "invalidSignature": "このリンクの署名は無効です。",
+        "invalidTimestamp": "このリンクのタイムスタンプは無効です。",
+        "invalidTitle": "接続リンクが無効です",
+        "invalidUser": "このリンクの GitHub ユーザーは無効です。",
+        "invalidUsername": "このリンクの GitHub ユーザー名は無効です。",
+        "linkIncomplete": "新しい GitHub 接続リンクを開いて、再試行してください。",
+        "linkIncompleteTitle": "接続リンクが不完全です",
+        "notInstalledDescription": "アカウントを接続する前に、組織管理者に GitHub をインストールするよう依頼してください。",
+        "notInstalledTitle": "GitHub がインストールされていません",
+        "refresh": "このページを更新して、もう一度お試しください。",
+        "signInButton": "{{brandName}} にサインインします",
+        "signInCheckFailed": "サインインを確認できませんでした",
+        "signInDescription": "この GitHub ユーザーに接続する前に、{{brandName}} アカウントを使用してください。",
+        "signInTitle": "続行するにはサインインしてください",
+        "successDescription": "{{account}} として接続されています。チャットを開始するには、GitHub のIssueまたはプル リクエストでエージェントに言及してください。",
+        "successTitle": "GitHub に接続しました!",
+        "wrongOrganizationDescription": "アクティブな組織は、この GitHub インストールと一致しません。正しい組織に切り替えて、リンクを再度開きます。",
+        "wrongOrganizationTitle": "組織を切り替える"
+      },
+      "slack": {
+        "connectDescription": "アカウントをこの Slack ワークスペースにリンクすると、Slack からエージェントと直接対話できるようになります。",
+        "connectTitle": "Slack に接続します",
+        "invalidDescription": "このページは、Slack 接続リンクから開かれるように設計されています。",
+        "open": "Slack を開く",
+        "successDescription": "チャットを開始するには、任意のチャンネルで @Zero にメンションするか、DM を送信してください。",
+        "successDescriptionWorkspace": "{{workspace}} に接続しています。チャットを開始するには、任意のチャンネルで @Zero にメンションするか、DM を送信してください。",
+        "successTitle": "Slack に接続しました!"
+      },
+      "teams": {
+        "connectDescription": "Teams アカウントをリンクすると、Microsoft Teams からエージェントと直接対話できるようになります。",
+        "connectDescriptionNamed": "{{displayName}} の場合は、Teams アカウントをリンクして、Microsoft Teams からエージェントと直接やり取りできるようにします。",
+        "connectTitle": "Microsoft Teams を接続します",
+        "invalidDescription": "このページは、Microsoft Teams 接続リンクから開かれるように設計されています。",
+        "open": "オープンチーム",
+        "providerName": "Microsoft Teams",
+        "successDescription": "{{team}} に接続されています。チャットを開始するには、Teams で @Zero にメンションします。",
+        "successTitle": "Microsoft Teams に接続されました"
+      },
+      "telegram": {
+        "alreadyDescription": "すでに接続されています。 Telegram でメッセージを送信してチャットを開始してください。",
+        "alreadyDescriptionNamed": "すでに {{bot}} に接続されています。 Telegram でメッセージを送信してチャットを開始してください。",
+        "alreadyTitle": "すでに Telegram に接続されています",
+        "back": "Telegram 設定に戻る",
+        "botFallback": "このボット",
+        "botFatherHandle": "@BotFather",
+        "checkingConnectionDescription": "Telegram 接続を確認するまでお待ちください。",
+        "checkingConnectionTitle": "接続を確認しています...",
+        "checkingDomain": "ドメインのステータスを確認しています...",
+        "checkingSession": "{{brandName}} セッションを確認するまでお待ちください。",
+        "connectDescription": "アカウントをこの Telegram ボットにリンクすると、Telegram からエージェントと直接対話できるようになります。",
+        "connectTitle": "Telegram に接続します",
+        "continue": "Telegram に進みます",
+        "domainDescription": "Telegram Web ログインは {{bot}} に対して有効になっていません。",
+        "domainIn": "で ",
+        "domainInstructionsAfter": "、ボットを選択し、ドメインを次のように設定します。",
+        "domainKeepOpen": "ドメインを保存した後、このページを開いたままにしてください。 /connect を使用して Telegram から接続することもできます。",
+        "domainSend": "、送信します ",
+        "domainTitle": "Telegram ログイン ドメインを設定する",
+        "errorFallback": "Telegram に接続できませんでした。 Telegram から再試行してください。",
+        "invalidSignature": "このリンクの署名は無効です。",
+        "invalidTimestamp": "このリンクのタイムスタンプは無効です。",
+        "invalidTitle": "接続リンクが無効です",
+        "invalidUser": "このリンクの Telegram ユーザーは無効です。",
+        "invalidUsername": "このリンクの Telegram ユーザー名は無効です。",
+        "linkIncomplete": "Telegram から新しい /connect リンクを開いて、再試行してください。",
+        "linkIncompleteTitle": "接続リンクが不完全です",
+        "open": "Telegram を開く",
+        "openBotFather": "BotFatherを開く",
+        "refresh": "このページを更新して、もう一度お試しください。",
+        "setDomainCommand": "/setdomain",
+        "signInButton": "{{brandName}} にサインインします",
+        "signInCheckFailed": "サインインを確認できませんでした",
+        "signInDescription": "この Telegram ユーザーに接続する前に、{{brandName}} アカウントを使用してください。",
+        "signInTitle": "続行するにはサインインしてください",
+        "successDescription": "{{bot}} に接続しています。 Telegram でメッセージを送信してチャットを開始してください。",
+        "successTitle": "Telegram に接続しました!"
+      }
+    },
+    "providerSettings": {
+      "agentphone": {
+        "authorizedSender": "承認された送信者",
+        "connectAria": "電話を接続する",
+        "connectDescription": "電話番号を入力してください。このワークスペースに接続する確認リンクをテキストで送信します。",
+        "connectTitle": "電話を接続する",
+        "copyAria": "{{phone}} をコピーします",
+        "copyError": "電話番号のコピーに失敗しました",
+        "copySuccess": "電話番号をコピーしました",
+        "description": "Zero へのテキスト メッセージ アクセス",
+        "destination": "iMessage または SMS で",
+        "normalized": "{{phone}} にテキスト メッセージを送信します。",
+        "options": "電話オプション",
+        "phoneLabel": "電話",
+        "phoneNumber": "電話番号",
+        "risk": "SMS および MMS の返信は確実に配信されない可能性があります。最も信頼性の高いエクスペリエンスを得るには、この AgentPhone 番号で iMessage を使用してください。",
+        "sending": "送信中...",
+        "sendVerification": "確認の送信",
+        "verificationSent": "検証テキストが {{phone}} に送信されました。接続を完了するには、そのテキスト内のリンクを開いてください。"
+      },
+      "catalogDiagnostics": {
+        "fields": {
+          "activated": "アクティブ化された",
+          "activeCatalogDigest": "アクティブなカタログダイジェスト",
+          "activeVersion": "アクティブなバージョン",
+          "evaluated": "評価済み",
+          "evaluation": "評価",
+          "executableCapabilityDigest": "実行可能機能のダイジェスト",
+          "failureCode": "障害コード",
+          "filteredAuthMethods": "フィルタリングされた認証方法",
+          "lastAttempt": "最後の試み",
+          "lastAttemptAt": "最後の試み",
+          "lastSuccess": "最後の成功",
+          "missingVersions": "欠落しているバージョン",
+          "rejectedCatalogDigest": "拒否されたカタログダイジェスト",
+          "rejectedVersion": "拒否されたバージョン",
+          "rejectingBackend": "バックエンドを拒否しています",
+          "rejectionCache": "拒否キャッシュ",
+          "rejectionFailure": "拒否失敗",
+          "syncState": "同期状態",
+          "unownedSecrets": "所有されていないシークレット",
+          "unownedVariables": "所有されていない変数",
+          "unresolvedBridgeCredentials": "未解決のブリッジ認証情報"
+        },
+        "loading": "読み込み中",
+        "none": "なし",
+        "notReused": "再利用されない",
+        "reused": "再利用",
+        "sections": {
+          "compatibility": "互換性",
+          "credentialStorage": "認証情報のストレージ",
+          "rejectedCandidate": "拒否された候補者"
+        },
+        "title": "コネクタカタログ",
+        "unavailable": "利用不可",
+        "values": {
+          "accepted": "承認されました",
+          "current": "現在",
+          "digestMismatch": "ダイジェストの不一致",
+          "invalidArtifact": "無効なアーティファクト",
+          "invalidCompression": "無効な圧縮",
+          "invalidJson": "無効な JSON",
+          "invalidPointer": "無効なポインタ",
+          "invalidReference": "無効な参照",
+          "missingAccessProvider": "アクセスプロバイダーがありません",
+          "missingGrantProvider": "助成金提供者が不足している",
+          "missingPlatformConfiguration": "プラットフォーム構成がありません",
+          "missingRevokeProvider": "取り消しプロバイダーがありません",
+          "neverSynced": "決して同期しない",
+          "objectTooLarge": "オブジェクトが大きすぎます",
+          "providerContractMismatch": "プロバイダ契約の不一致",
+          "publicLeakage": "公然漏洩",
+          "rejected": "拒否されました",
+          "relationshipMismatch": "関係の不一致",
+          "sourceUnavailable": "ソースが利用できません",
+          "stale": "古い",
+          "unchanged": "変わらない",
+          "unsupportedSchema": "サポートされていないスキーマ"
+        }
+      },
+      "errors": {
+        "agentphonePhone": "+1 555 555 1212 のように、国コードを含む電話番号を入力します。",
+        "githubAuthorizationWindow": "認証ウィンドウを開けませんでした",
+        "telegramDomain": "ドメインはまだ Telegram に表示されていません。 BotFather を確認して再試行してください。",
+        "telegramPrivacy": "プライバシーモードはまだオンになっているようです。 BotFather でこれをオフにして、もう一度試してください。"
+      },
+      "feishu": {
+        "addBot": "ボットの追加",
+        "addDialogDescription": "エンタープライズ カスタム アプリを作成し、そのボットを有効にして、Feishu 開発者コンソールでこれらの手順を完了します。",
+        "addDialogTitle": "Feishu ボットを追加する",
+        "agentDescription": "このボットに送信されたメッセージを処理するエージェントを選択します。",
+        "backToIntegrations": "統合に戻る",
+        "botFallback": "Feishu ボット",
+        "botIconAlt": "{{bot}} ボット アイコン",
+        "bots": "Feishu ボット",
+        "callbackStatusVerified": "コールバックが検証されました",
+        "callbackStatusWaiting": "コールバックを待っています",
+        "configured": "設定済み",
+        "copied": "{{label}} がコピーされました",
+        "copy": "コピー",
+        "create": {
+          "descriptionAfter": "、{{brandName}} という名前のエンタープライズ カスタム アプリを作成し、{{brandName}} アイコンをアップロードしてから、ボット機能を追加します。",
+          "descriptionBefore": "で ",
+          "downloadIcon": "{{brandName}} アイコンをダウンロードします",
+          "iconAlt": "{{brandName}} アプリ アイコン",
+          "iconHint": "、またはお好みのアイコンを使用してください。",
+          "iconTitle": "{{brandName}} アプリ アイコン",
+          "imageAlt": "Feishu アプリ名、アイコン、および [作成] ボタンが強調表示されたアプリ作成フォーム",
+          "title": "エンタープライズカスタムアプリを作成する"
+        },
+        "credentials": {
+          "appId": "アプリID",
+          "appSecret": "アプリのシークレット",
+          "description": "「資格情報と基本情報」からアプリ ID とアプリ シークレットをコピーします。",
+          "imageAlt": "Feishu アプリ ID とアプリ シークレットの場所を示すアプリ作成結果",
+          "title": "アプリの認証情報を追加する"
+        },
+        "defaultAgent": "デフォルトエージェント",
+        "defaultAgentAria": "{{appId}} のデフォルト エージェント",
+        "developerConsole": "Feishu 開発者コンソール",
+        "dialogAdminRequired": "組織管理者はアプリを構成する必要があります。セットアップが完了したら、Feishu ボット リストから自分のアカウントに接続できます。",
+        "documentTitle": "Feishu",
+        "emptyAdmin": "Feishu メッセージをエージェントにルーティングするカスタム アプリを追加します。",
+        "emptyMember": "Feishu ボットを追加するように組織管理者に依頼します。",
+        "emptyTitle": "Feishu ボットはまだありません",
+        "events": {
+          "callbackLabel": "コールバック URL",
+          "continue": "Feishu がコールバック URL を検証し、メッセージ イベントがサブスクライブされた後に続行します。",
+          "description": "イベント設定を開きます。サブスクリプション モードで、[開発者のサーバーに通知を送信する] を選択します。次に、「コールバック構成」を開き、コールバック URL を貼り付けます。 Feishu がそれを検証した後、「受信メッセージ v1」イベントを追加します。",
+          "requestAlt": "Feishu 「リクエスト URL」フィールドが強調表示された「イベント構成」画面",
+          "requestLabel": "コールバックリクエストURLを追加します。",
+          "subscriptionAlt": "Feishu サブスクリプション モード編集コントロールが強調表示されたイベント構成画面",
+          "subscriptionLabel": "イベントサブスクリプションモードを選択します",
+          "title": "イベント配信を構成する"
+        },
+        "faq": {
+          "approvalAnswer": "可用性が [すべてのメンバー] に設定されている場合、Feishu 管理者はリリースを承認する必要があります。 Feishu は承認リクエストをダイレクト メッセージで管理者に送信し、アプリは管理者がレビューを完了するまで保留状態になります。",
+          "approvalQuestion": "アプリの公開が承認を待っているのはなぜですか?",
+          "challengeAnswer": "これは通常、トークンのステップ中に保存された暗号化キーまたは検証トークンが正しくないことを意味します。 「トークン」ステップに戻り、「イベント構成」→「暗号化戦略」から両方の値を再度入力し、保存して、リクエスト URL を再試行します。",
+          "challengeQuestion": "Feishu に「チャレンジ コードは応答がありませんでした」と表示されるのはなぜですか?",
+          "title": "セットアップに関するよくある質問"
+        },
+        "guide": {
+          "next": "次の Feishu ガイド画像を表示",
+          "previous": "以前の Feishu ガイド画像を表示",
+          "show": "Feishu ガイド画像 {{number}} を表示"
+        },
+        "loadError": "Feishu 設定を読み込めませんでした。",
+        "manage": "管理",
+        "manageDialogTitle": "Feishu ボットを管理する",
+        "moreOptions": "{{bot}} のその他のオプション",
+        "pageDescription": "このワークスペースのボット ルーティングを管理する",
+        "publish": {
+          "allMembersAlt": "すべてのメンバーが選択された場合の Feishu 可用性設定",
+          "allMembersLabel": "すべてのメンバーが利用できるようにする",
+          "createVersionAlt": "Feishu [バージョンの作成] ボタンが強調表示された [バージョン管理] ページ",
+          "createVersionLabel": "アプリのバージョンを作成する",
+          "description": "アプリのバージョンを作成して公開し、その可用性設定を編集して [すべてのメンバー] を選択します。このアプリは、組織内の他のメンバーにアクセスを許可した後でのみ使用できます。",
+          "editAvailabilityAlt": "可用性設定の編集アクションが強調表示された Feishu バージョンの詳細ページ",
+          "editAvailabilityLabel": "可用性設定を編集する",
+          "title": "アプリを公開する"
+        },
+        "redirect": {
+          "descriptionAfter": "、「開発構成」→「セキュリティ設定」を開きます。 [リダイレクト URL] に以下の URL を追加して、ワークスペース メンバーが Feishu アカウントを {{brandName}} に接続できるようにします。",
+          "descriptionBefore": "で ",
+          "imageAlt": "Feishu OAuth リダイレクト URL を追加する場所を示す [セキュリティ設定] ページ",
+          "label": "OAuth リダイレクト URL",
+          "title": "OAuth リダイレクト URL を構成する"
+        },
+        "reviewGuide": "レビューガイド",
+        "reviewGuideDescription": "この Feishu ボットの完了したセットアップ手順を確認してください。",
+        "reviewGuideTitle": "Feishu レビュー ガイド",
+        "routeDescription": "Feishu メッセージをエージェントにルーティングする",
+        "selectAgent": "エージェントを選択してください",
+        "setupIncomplete": "セットアップが不完全",
+        "steps": {
+          "back": "戻る",
+          "checking": "確認中…",
+          "close": "閉じる",
+          "create": "作成",
+          "credentials": "資格情報",
+          "done": "完了",
+          "events": "イベント",
+          "next": "次へ",
+          "publish": "発行する",
+          "redirect": "リダイレクト",
+          "tokens": "トークン",
+          "verify": "確認して続行",
+          "verifying": "確認中…",
+          "waiting": "コールバックを待っています"
+        },
+        "tokens": {
+          "descriptionAfter": "、作成したばかりのアプリを選択し、その構成ページに入ります。 「イベント構成」→「暗号化戦略」を開き、暗号化キーと検証トークンをコピーします。",
+          "descriptionBefore": "を開きます ",
+          "encryptKey": "暗号化キー",
+          "imageAlt": "Feishu 暗号化キーと検証トークンを示す暗号化戦略画面",
+          "title": "イベント検証トークンを追加する",
+          "verificationToken": "検証トークン"
+        },
+        "uninstallDescription": "これにより、ワークスペースから {{bot}} がアンインストールされ、それを使用しているすべての {{brandName}} アカウントが切断されます。この操作は元に戻すことができません。",
+        "uninstallTargetFallback": "このボット",
+        "uninstallTitle": "Feishu ボットをアンインストールしますか?"
+      },
+      "strapi": {
+        "actions": {
+          "cancel": "キャンセル",
+          "checkTest": "チェックテスト",
+          "copy": "コピー",
+          "create": "統合の作成",
+          "remove": "削除",
+          "revealAuthorization": "認可ヘッダーを明らかにする"
+        },
+        "addDescription": "1 つの統合で複数のワークフローオートメーションに対応できます。",
+        "addTitle": "Strapi インスタンスを追加します",
+        "adminRequired": "Strapi 統合を追加または更新するように組織管理者に依頼します。",
+        "authorizationHeader": "認可ヘッダー",
+        "copied": "{{label}} がコピーされました",
+        "description": "Zero が公開された Strapi エントリに反応し、ダウンストリーム作業を自動化できるようにします。",
+        "documentTitle": "Strapi",
+        "empty": "Strapi インスタンスはまだ接続されていません。",
+        "form": {
+          "name": "名前",
+          "namePlaceholder": "企業CMS",
+          "url": "Strapi URL"
+        },
+        "instructions": "Strapi で、[設定] → [Webhook] を開き、この URL と認証ヘッダーを追加し、entry.publish を選択して、[トリガー] をクリックして Strapi テスト Webhook を送信します。",
+        "lastPublish": "最終公開日: {{date}}",
+        "lastTest": "最後のテスト: {{date}}",
+        "notReceived": "未受信",
+        "removeDescription": "まずワークフローのオートメーションを削除します。 Strapi この URL への Webhook リクエストは機能しなくなります。",
+        "removeTitle": "Strapi 統合を削除しますか?",
+        "tested": "Webhook テスト済み",
+        "title": "Strapi",
+        "toasts": {
+          "created": "Strapi 統合が作成されました",
+          "noTestReceived": "Strapi テスト Webhook をまだ受信していません",
+          "removed": "Strapi 統合が削除されました",
+          "testReceived": "Strapi テスト Webhook を受信しました"
+        },
+        "webhookUrl": "Webhook URL",
+        "whereZeroWorks": "Zero が機能する場所"
+      },
+      "telegram": {
+        "addBot": "ボットの追加",
+        "addDescription": "BotFather の各手順を完了してから、ワークスペース ボットを作成します。",
+        "adding": "追加中...",
+        "addTitle": "Telegram ボットを追加",
+        "agentAria": "{{bot}} のデフォルト エージェント",
+        "backToIntegrations": "統合に戻る",
+        "botFallback": "Telegram ボット",
+        "bots": "Telegram ボット",
+        "botToken": "ボットトークン",
+        "botTokenPlaceholder": "123456:ABC-DEF",
+        "checking": "確認中...",
+        "copied": "コピーしました！",
+        "copyAria": "{{value}} をコピーします",
+        "copyTitle": "クリックしてコピー",
+        "create": {
+          "description": "{{brandName}} は、このボットを登録し、その Webhook を構成します。セットアップ後、グループ内でボットにメンションするか、DM を送信して、選択したエージェントと会話します。",
+          "descriptionNamed": "{{brandName}} は {{bot}} を登録し、その Webhook を構成します。セットアップ後、グループ内でボットにメンションするか、DM を送信して、選択したエージェントと会話します。",
+          "title": "統合を作成する準備ができました"
+        },
+        "defaultAgent": "デフォルトエージェント",
+        "disconnectAria": "{{bot}} を切断します",
+        "documentTitle": "Telegram",
+        "domain": {
+          "detected": "ドメインが検出されました",
+          "instructionAfter": "、このボットを選択し、ドメインを次のように設定します。 ",
+          "instructionEnd": "。 Telegram は、このドメインを使用して、このボットの接続フローを許可します。",
+          "instructionStart": "{{botFather}} で、送信します ",
+          "title": "Telegram ログイン ドメインを設定する"
+        },
+        "emptyDescription": "ボット トークンを追加して、Telegram メッセージのエージェントへのルーティングを開始します。",
+        "emptyTitle": "Telegram ボットはまだありません",
+        "invalidTokenDescription": "BotFather からの新しいトークンを使用してボットを再インストールします。",
+        "loadError": "Telegram 設定を読み込めませんでした。",
+        "moreOptions": "{{bot}} のその他のオプション",
+        "newBotToken": "新しいボットトークン",
+        "notConnected": "接続されていません",
+        "officialBot": "Zero 公式ボット",
+        "officialDescription": "{{brandName}} が提供する公式 bot。",
+        "officialMissing": "公式ボット設定がありません。",
+        "pageDescription": "このワークスペースのボット ルーティングを管理する",
+        "privacy": {
+          "instructionAfter": "、このボットを選択し、プライバシー モードを無効にします。これにより、エージェントはメンションや返信に関するグループのコンテキストを読み取ることができます。",
+          "instructionStart": "{{botFather}} で、送信します ",
+          "off": "プライバシーモードがオフになっています",
+          "title": "オプション: プライバシー モードをオフにする"
+        },
+        "registerAria": "Telegram ボットを登録する",
+        "reinstall": "再インストール",
+        "reinstallDescription": "{{bot}} の新しい BotFather トークンを貼り付けます。トークンはこの同じボットに属している必要があります。",
+        "reinstalling": "再インストール中...",
+        "reinstallTargetFallback": "このボット",
+        "reinstallTitle": "Telegram ボットを再インストールします",
+        "selectAgent": "エージェントの選択",
+        "steps": {
+          "back": "戻る",
+          "create": "作成",
+          "domain": "ドメイン",
+          "next": "次へ",
+          "privacy": "プライバシー",
+          "token": "トークン"
+        },
+        "token": {
+          "instructionAfter": "、名前とユーザー名を選択し、以下のトークンを貼り付けます。",
+          "open": "開く ",
+          "send": "、送信します ",
+          "title": "BotFather でボット トークンを作成する",
+          "verified": "トークンが検証されました"
+        },
+        "tokenInvalid": "トークンが無効です",
+        "uninstallAria": "{{bot}} をアンインストールします",
+        "uninstallDescription": "これにより、ワークスペースから {{bot}} が削除され、それを使用するユーザーの Telegram アクセスが切断されます。この操作は元に戻すことができません。",
+        "uninstallTargetFallback": "このボット",
+        "uninstallTitle": "Telegram ボットをアンインストールしますか?"
+      },
+      "toasts": {
+        "agentphoneConnected": "エージェントフォンが接続されました",
+        "agentphoneDisconnected": "AgentPhone が切断されました",
+        "agentphoneVerificationSent": "確認テキストが送信されました",
+        "feishuBotInstalled": "Feishu ボットは正常にインストールされました",
+        "feishuBotUninstalled": "Feishu ボットがアンインストールされました",
+        "feishuConnected": "Feishu は正常に接続されました",
+        "feishuDisconnected": "Feishu から切断されました",
+        "slackConnected": "Slack は正常に接続されました",
+        "slackDisconnected": "Slack から切断されました",
+        "slackInstalled": "Slack は正常にインストールされました",
+        "slackPermissionsUpdated": "権限が更新されました",
+        "slackUninstalled": "Slack ワークスペースがアンインストールされました",
+        "slackUpdated": "Slack が更新されました",
+        "teamsConnected": "Microsoft Teams は正常に接続されました",
+        "teamsDisconnected": "Microsoft Teams から切断されました",
+        "teamsInstalled": "Microsoft Teams は正常にインストールされました",
+        "teamsUninstalled": "Microsoft Teams 統合がアンインストールされました",
+        "teamsUpdated": "Microsoft Teams が更新されました",
+        "telegramAgentUpdated": "デフォルトエージェントが更新されました",
+        "telegramBotAdded": "Telegram ボットが追加されました",
+        "telegramBotReinstalled": "Telegram ボットが再インストールされました",
+        "telegramBotUninstalled": "Telegram ボットがアンインストールされました",
+        "telegramDisconnected": "Telegram アカウントが切断されました",
+        "telegramUpdatingAgent": "デフォルトのエージェントを更新しています..."
+      },
+      "works": {
+        "connected": "接続済み",
+        "connectedDetail": "接続されました ({{detail}})"
+      }
+    },
+    "redirect": {
+      "back": "{{brandName}} に戻る",
+      "errorDescription": "{{brandName}} に戻り、再度接続を試みます。",
+      "errorStatus": "接続を開始できません",
+      "errorTitle": "{{connector}} を開けませんでした",
+      "mobileWarning": "{{connector}} アプリは、この OAuth リンクをサポートしていない可能性があります。コンピューター上の {{brandName}} Web アプリでこの接続を完了してください。",
+      "preparing": "安全な接続の準備",
+      "redirectDescription": "{{connector}} に進み、{{brandName}} を承認します。",
+      "redirectTitle": "{{connector}} にリダイレクトしています…"
+    },
+    "toasts": {
+      "connected": "{{connector}} が接続されました",
+      "disconnected": "{{connector}} が切断されました"
+    }
+  },
+  "global": {
+    "errors": {
+      "httpStatus": "HTTP {{status}}",
+      "requestFailed": "リクエストが失敗しました"
+    },
+    "realtime": {
+      "degraded": "ライブアップデートで問題が発生しました。ページを更新してください。"
+    }
+  },
+  "insights": {
+    "calendar": {
+      "nextMonth": "来月",
+      "previousMonth": "前月"
+    },
+    "cards": {
+      "agents": "エージェント",
+      "agentsRan_one": "{{agents}} は {{runs}} を実行しました",
+      "agentsRan_other": "{{agents}} は {{runs}} を実行しました",
+      "allowed": "許可される",
+      "allowedSummary_one": "{{permissions}} 内で作成された {{calls}} には権限が付与されました",
+      "allowedSummary_other": "{{permissions}} 内で作成された {{calls}} に権限が付与されました",
+      "automations": "オートメーション",
+      "automationsUsed_one": "{{automations}} は {{credits}} を使用しました",
+      "automationsUsed_other": "{{automations}} は {{credits}} を使用しました",
+      "balance": "バランス",
+      "byAgent": "{{agent}} 著",
+      "chats": "チャット",
+      "chatsUsed_one": "{{chats}} は {{credits}} を使用しました",
+      "chatsUsed_other": "{{chats}} は {{credits}} を使用しました",
+      "clickToOpen": "クリックして開きます",
+      "consumedToday": "今日消費された",
+      "moreAutomations_one": "+{{value}} のさらなるオートメーション",
+      "moreAutomations_other": "+{{value}} 個以上のオートメーション",
+      "moreChats_one": "+{{value}} その他のチャット",
+      "moreChats_other": "+{{value}} 件以上のチャット",
+      "protected": "保護されています",
+      "protectedSummary_one": "{{calls}} は {{permissions}} 権限全体で保護されています",
+      "protectedSummary_other": "{{calls}} は {{permissions}} 権限全体で保護されています",
+      "rejected_one": "{{value}} が拒否されました",
+      "rejected_other": "{{value}} が拒否されました",
+      "rejectedOf": "{{total}} の {{denied}} が拒否されました",
+      "services": "サービス",
+      "servicesReceived_one": "{{services}} が {{calls}} を受け取りました",
+      "servicesReceived_other": "{{services}} が {{calls}} を受け取りました",
+      "team": "チーム",
+      "teamCreditUsage": "チームクレジットの使用状況",
+      "untitled": "(無題)",
+      "yourCreditUsage": "クレジットの使用状況"
+    },
+    "common": {
+      "loadMore": "さらにロードする",
+      "showLess": "表示を少なくする"
+    },
+    "page": {
+      "description": "エージェントが何にアクセスするか、クレジットがどのように消費されるか、エージェントが使用する権限を監視し、異常な点を見つけます。",
+      "documentTitle": "インサイトと使用量",
+      "empty": "ここでエージェントを実行してインサイトを確認します。",
+      "emptyRange": "この時間範囲にはアクティビティはありません。",
+      "lastUpdated": "最終更新日 — {{date}}",
+      "loadError": "ネットワークアクティビティを読み込めませんでした。",
+      "title": "インサイト"
+    },
+    "range": {
+      "custom": "カスタム範囲",
+      "last28Days": "過去 28 日間",
+      "last30Days": "過去 30 日間",
+      "last7Days": "過去 7 日間",
+      "today": "今日",
+      "yesterday": "昨日"
+    },
+    "summary": {
+      "activityCaption": "{{first}} · {{second}}",
+      "blocked_one": "{{blocked}} リクエストは権限ルールによってブロックされました。重要なことが妨げられていないことを確認するためにレビューしてください。",
+      "blocked_other": "{{blocked}} リクエストは権限ルールによってブロックされました。それらを見直して、重要なことが妨げられていないことを確認してください。",
+      "blockedCaption": "{{calls}} · {{blocked}} がブロックされました",
+      "busy_one": "忙しい 1 日 — {{agentCount}} エージェントが {{runs}} を完了しました。ネットワークは懸命に動作しています。",
+      "busy_other": "忙しい 1 日 — {{agentCount}} エージェントが {{runs}} を完了しました。ネットワークは懸命に動作しています。",
+      "distributed_one": "{{agents}} がアクティブで、合計 {{credits}} を使用しています。適切に分散されたワークロード。",
+      "distributed_other": "{{agents}} がアクティブで、合計 {{credits}} を使用しています。適切に分散されたワークロード。",
+      "highTraffic_one": "{{callCount}} サービスは {{services}} 経由で呼び出します。交通量の多い日。",
+      "highTraffic_other": "{{callCount}} サービスは {{services}} 経由で呼び出します。交通量の多い日。",
+      "light_one": "軽いアクティビティ — {{runs}} および {{calls}} のみ。静かな一日。",
+      "light_other": "軽いアクティビティ — {{runs}} および {{calls}} のみ。静かな一日。",
+      "quietCaption": "{{runs}} · 静かな一日",
+      "smooth": "本日、{{runs}} および {{callCount}} サービス コールが行われます。すべてがスムーズに進んでいます。"
+    },
+    "units": {
+      "agent_one": "{{value}} エージェント",
+      "agent_other": "{{value}} エージェント",
+      "call_one": "{{value}} 呼び出し",
+      "call_other": "{{value}} 呼び出し",
+      "run_one": "{{value}} の実行",
+      "run_other": "{{value}} が実行されます",
+      "service_one": "{{value}} サービス",
+      "service_other": "{{value}} サービス"
+    }
+  },
+  "lifecycle": {
+    "emailUnsubscribe": {
+      "action": "購読を解除する",
+      "body": "{{brandName}} からシステムによって開始されるメール通知は受信されなくなります。",
+      "confirmTitle": "メール通知の購読を解除しますか?",
+      "documentTitle": "購読を解除する",
+      "doneTitle": "購読解除済み",
+      "errorBody": "この購読解除リンクは無効であるか、期限切れです。メール通知は設定で管理できます。",
+      "errorTitle": "何か問題が発生しました"
+    },
+    "morningBriefUnsubscribe": {
+      "documentTitle": "モーニングブリーフ",
+      "doneBody": "毎日の Morning Brief メールは受信されなくなります。設定でいつでもオンに戻すことができます。",
+      "doneTitle": "モーニングブリーフがオフになりました",
+      "errorBody": "購読解除リンクが無効か不完全です。最新の Morning Brief メールを開いて購読解除リンクを使用するか、設定で設定を管理します。",
+      "errorTitle": "このリンクは無効です",
+      "loadingLabel": "購読解除ステータスを読み込んでいます",
+      "managePreferences": "設定の管理"
+    },
+    "pwaInstall": {
+      "banner": "Zero をインストールするとエクスペリエンスが向上します",
+      "description": "Zero をホーム画面に追加すると、すぐにアクセスできるようになります。",
+      "dismiss": "インストールバナーを閉じる",
+      "gotIt": "わかりました",
+      "install": "インストール",
+      "installApp": "アプリをインストールする",
+      "stepOne": "Safari で、[共有] ボタンをタップします。",
+      "stepThree": "名前が Zero であることを確認し、[追加] をタップします。",
+      "stepTwo": "「ホーム画面に追加」を選択します。",
+      "title": "Zero をインストールする"
+    },
+    "redeemCampaign": {
+      "actions": {
+        "back": "{{brandName}} に戻る",
+        "redeem": "クレジットを引き換える"
+      },
+      "documentTitle": "クレジットを請求する",
+      "organizationFallback": "あなたの組織",
+      "states": {
+        "adminRequired": {
+          "body": "組織管理者のみが {{orgName}} のキャンペーン クレジットを引き換えることができます。代わりにリンクを開くように組織の管理者に依頼してください。",
+          "title": "管理者アクセスが必要です"
+        },
+        "alreadyGranted": {
+          "body": "あなたのクレジットはすでに {{orgName}} のアカウントにあります。アプリに戻って使用を開始してください。",
+          "title": "あなたはすでにこの特典を利用しています"
+        },
+        "billingUnavailable": {
+          "body": "現在、弊社の支払いシステムはご利用いただけません。数分後にもう一度試してください。",
+          "title": "課金は一時的に利用できません"
+        },
+        "broken": {
+          "body": "あなたの償還を完了できませんでした。もう一度試すか、サポートにお問い合わせください。",
+          "title": "何か問題が発生しました"
+        },
+        "campaignUnavailable": {
+          "body": "プロモーション コードの有効期限が切れたか、引き換え制限に達したか、削除された可能性があります。これが間違いであると思われる場合は、サポートにお問い合わせください。",
+          "title": "このオファーは利用できません"
+        },
+        "paymentSuccessful": {
+          "body": "あなたのクレジットは {{orgName}} に向かっています。ダッシュボードを開いて新しい残高を確認します。",
+          "title": "支払いが成功しました"
+        },
+        "processing": {
+          "body": "現在、あなたのクレジットを {{orgName}} に適用しています。通常、これには数秒かかります。すぐに更新すると、更新された残高が表示されます。",
+          "title": "支払いを受け取りました"
+        },
+        "ready": {
+          "body": "チェックアウトを完了して、これらのクレジットを {{orgName}} の残高に追加してください。",
+          "title": "クレジットを請求する"
+        }
+      }
+    }
+  },
+  "onboarding": {
+    "categories": {
+      "ceo": {
+        "description": "説明会と全体像",
+        "title": "代表取締役社長"
+      },
+      "data": {
+        "description": "ダッシュボード、メトリクス、クエリ",
+        "title": "データ"
+      },
+      "engineering": {
+        "description": "コードの出荷、デバッグ、自動化",
+        "title": "エンジニア"
+      },
+      "everyone": {
+        "description": "メール、カレンダー、会議",
+        "title": "すべて"
+      },
+      "marketing": {
+        "description": "コンテンツ、SEO、キャンペーン",
+        "title": "マーケティング"
+      },
+      "operations": {
+        "description": "プロジェクト、スケジュール設定、同期",
+        "title": "運営"
+      },
+      "product": {
+        "description": "仕様、リリース、フィードバック",
+        "title": "プロダクト"
+      },
+      "sales": {
+        "description": "パイプラインとアウトリーチ",
+        "title": "セールス"
+      },
+      "support": {
+        "description": "チケットとカスタマーサポート",
+        "title": "サポート"
+      }
+    },
+    "common": {
+      "back": "戻る",
+      "continue": "続ける",
+      "dialogPreview": "{{title}} プレビュー",
+      "gotIt": "わかりました",
+      "next": "次へ",
+      "noConnectorRequired": "コネクタは不要です",
+      "previewWorkflowDetails": "ワークフローの詳細をプレビューする",
+      "selectTemplate": "このテンプレートを選択してください",
+      "selectThisTemplate": "このテンプレートを選択してください",
+      "stepProgress": "ステップ {{current}}/{{total}}"
+    },
+    "documentTitles": {
+      "chooseImage": "画像スタイルを選択してください",
+      "choosePresentation": "プレゼンテーションテンプレートを選択してください",
+      "chooseVideo": "ビデオスタイルを選択してください",
+      "chooseWorkflow": "ワークフローを選択する",
+      "make": "{{brandName}} へようこそ",
+      "runImage": "最初のイメージを作成する",
+      "runPresentation": "最初のプレゼンテーションを作成する",
+      "runVideo": "初めてのビデオを作成する",
+      "runWorkflow": "最初のワークフローを実行する"
+    },
+    "make": {
+      "description": "開始点を選択すれば、他のことは後で行うことができます。",
+      "options": {
+        "explore": {
+          "description": "私のツールに接続するだけです",
+          "title": "自分で調べてみます"
+        },
+        "images": {
+          "description": "高品質のビジュアルを作成する",
+          "title": "画像の生成"
+        },
+        "presentation": {
+          "description": "スライドとスピーカーを生成する",
+          "title": "プレゼンテーションを生成する"
+        },
+        "video": {
+          "description": "あなたのアイデアをビデオに変換しましょう",
+          "title": "映像制作"
+        },
+        "workflow": {
+          "description": "プリセットテンプレートから探索する",
+          "title": "ワークフローのオートメーション"
+        }
+      },
+      "projectTypeLabel": "最初のプロジェクトの種類",
+      "promptDescription": "以下で調整するか、そのまま実行します。 Zero はここから取得します。ツールはサンドボックスに保たれ、ワークスペースから何も出なくなります。",
+      "promptLabel": "オンボーディングプロンプト",
+      "promptTitle": "このプロンプトを試してください",
+      "title": "最初に何を作りたいですか"
+    },
+    "runAction": {
+      "checkingPlan": "計画の確認",
+      "runNow": "今すぐ実行",
+      "upgradePro": "実行するには Pro をアップグレードしてください"
+    },
+    "templatePicker": {
+      "image": {
+        "description": "作りたいイメージの参考にしてください。",
+        "selectTemplate": "{{title}} イラスト テンプレートを選択します",
+        "showVariant": "{{title}} バリアント {{variant}} を表示",
+        "title": "開始するイラストのテンプレートを選択してください"
+      },
+      "presentation": {
+        "description": "作成したいデッキの参考にしてください。",
+        "nextSlide": "次のスライドを表示",
+        "previousSlide": "前のスライドを表示",
+        "selectTemplate": "{{title}} プレゼンテーション テンプレートを選択します",
+        "showSlide": "スライドを表示 {{slide}}",
+        "slideAlt": "{{title}} スライド {{slide}}",
+        "title": "開始するプレゼンテーション テンプレートを選択してください",
+        "viewTemplate": "{{title}} プレゼンテーションを表示する"
+      },
+      "video": {
+        "description": "作成したい動画の参考にしてください。",
+        "selectTemplate": "{{title}} ビデオ テンプレートを選択します",
+        "title": "開始するビデオテンプレートを選択してください"
+      }
+    },
+    "templateRun": {
+      "image": {
+        "noteLabel": "カスタムイラストシーン",
+        "notePlaceholder": "カスタムシーンを追加して、独自のイラストとリミックスします",
+        "previewLabel": "イラストテンプレートのプレビュー",
+        "title": "試してみたいオートメーションを 1 つ選択してください"
+      },
+      "presentation": {
+        "noteLabel": "プレゼンテーションの内容と指示",
+        "notePlaceholder": "プレゼンテーションの内容と説明を追加します",
+        "previewLabel": "プレゼンテーションテンプレートのプレビュー",
+        "title": "プレゼンテーションを充実させる"
+      },
+      "video": {
+        "noteLabel": "カスタムビデオプロンプト",
+        "notePlaceholder": "カスタム プロンプトを追加して、独自のビデオとリミックスします",
+        "previewLabel": "ビデオテンプレートのプレビュー",
+        "title": "ビデオをカスタマイズする"
+      }
+    },
+    "templates": {
+      "illustration": {
+        "cozy-parlor": "コージーパーラー",
+        "crowd-ink": "クラウドインク",
+        "editorial-flatfolk": "社説フラットフォーク",
+        "endpaper": "見返し",
+        "flat-poster": "フラットポスター",
+        "folk-muse": "フォークミューズ",
+        "folk-storybook": "民話の本",
+        "grain-poster": "穀物ポスター",
+        "grainy-duotone": "粒子の粗いデュオトーン",
+        "iberian-vignette": "イベリコのビネット",
+        "ink-mascot": "インクマスコット",
+        "ink-storefront": "インクの店頭",
+        "inkdab": "インクダブ",
+        "inkstomp": "インクストンプ",
+        "iso-scene": "イソシーン",
+        "jade-blockprint": "翡翠のブロックプリント",
+        "light-pop-portrait": "ライトポップポートレート",
+        "loose-contour": "緩やかな輪郭",
+        "mellow-pop": "メロウポップ",
+        "mosaic-still-life": "モザイク静物画",
+        "notion-illustration": "Notionの図",
+        "op-ed-cover": "論説表紙",
+        "painterly-botanical": "絵画的な植物",
+        "papernook": "ペーパーヌック",
+        "postcard-illustration": "ポストカードイラスト",
+        "riso-relic": "リソレリック",
+        "shadow-pop": "シャドウポップ",
+        "soft-vector": "ソフトベクトル",
+        "sticker-sheet": "ステッカーシート",
+        "sunlit-gouache": "サンライトガッシュ",
+        "tiny-wanderer": "小さな放浪者"
+      },
+      "presentation": {
+        "botane-organic-deck": "モーブガーデン",
+        "business-data-presentation": "ベリーダッシュボード",
+        "crayon-learning-deck": "クレヨンの落書き",
+        "creative-agency-presentation": "紅葉ギャラリー",
+        "data-report-presentation": "キャンディチャート",
+        "editorial-magazine-deck": "紙の雑誌",
+        "landing-consulting-deck": "ネオンブラウザ",
+        "lumina-creative-studio": "ブラシステッカー",
+        "mosaic-geometric-pitch": "バウハウスタイル",
+        "playful-launch-presentation": "サンバーストプレイルーム",
+        "playful-pop-deck": "ネオンキャンディー"
+      },
+      "video": {
+        "chinese-ink-art": "中国の水墨画",
+        "cyberpunk-anime": "サイバーパンクアニメ",
+        "epic-grandeur": "壮大な壮大さ",
+        "fashion-editorial": "ファッション社説",
+        "gourmet-documentary": "グルメドキュメンタリー",
+        "hand-drawn-fantasy-anime": "手描きファンタジーアニメ",
+        "japanese-wabi-sabi": "日本のわびさび",
+        "luxury-product": "高級品マクロ",
+        "shortform-viral": "短編バイラル",
+        "sports-performance-ad": "スポーツパフォーマンス広告"
+      }
+    },
+    "workflowDiagram": {
+      "preparedDescription": "Zero は、ツールから次のステップを準備します。",
+      "preparedTitle": "ワークフローが準備されました",
+      "reviewDescription": "Zero はワークフローを完了し、結果を返します。",
+      "reviewTitle": "レビューの準備ができました",
+      "source": "ソース"
+    },
+    "workflowPicker": {
+      "categoryDescription": "すぐに実行できるセットアップなので、ツールや目標に合わせて調整できます。",
+      "categoryTitle": "{{category}} ワークフロー",
+      "customDescription": "必要なものを説明すると、Zero が一緒にそれを構築します。",
+      "customTitle": "Zero と話し、自分のものを作成してください",
+      "description": "役割を選択すると、適切なワークフローが表示されます。いつでも切り替えることができます。",
+      "title": "何に取り組んでいますか?",
+      "workflowCardLabel": "{{title}} {{description}}"
+    },
+    "workflowPreview": {
+      "howItWorks": "仕組み",
+      "whatItDoes": "何をするのか"
+    },
+    "workflowRun": {
+      "continueWithZero": "Zero に進みます",
+      "createDraft": "ドラフトの作成",
+      "customNoteLabel": "ワークフローを説明する",
+      "customNotePlaceholder": "Zero で構築したいものを説明してください",
+      "customTitle": "ワークフローを説明する",
+      "noteLabel": "他に何か追加したいことはありますか?",
+      "notePlaceholder": "他に何か追加したいことはありますか?",
+      "reviewTitle": "ワークフローの下書きを確認する"
+    },
+    "workflows": {
+      "alert-metric-moves-slack": {
+        "description": "主要なメトリクスを監視し、急激に変化した場合は Slack に警告します。",
+        "scenario": "週次レビューでメトリクスの問題が判明するまでに、それは数日経過しています。 Zero は、主要なメトリックを 1 時間ごとに監視し、通常の範囲を超えた瞬間に Slack に ping を送信します。",
+        "steps": {
+          "one": {
+            "description": "Zero は 1 時間ごとにメトリックを読み取ります。",
+            "title": "Zero はメトリックをチェックします"
+          },
+          "three": {
+            "description": "Zero は逸脱を含むアラートを投稿します。",
+            "title": "Slack にアラートが投稿されました"
+          },
+          "two": {
+            "description": "Zero は、予想される帯域外の値にフラグを立てます。",
+            "title": "通常の範囲と比較して"
+          }
+        },
+        "title": "メトリクスが移動したときにアラートを送信する"
+      },
+      "auto-merge-github-prs": {
+        "description": "「マージ準備完了」というラベルが付いた PR を確認し、CI を待ってからマージして Slack にポストします。",
+        "scenario": "PR をマージするということは、CI の世話をし、差分を再チェックし、それが出荷されたことを忘れずに投稿することを意味します。 Zero は、マージ準備完了のラベルを監視し、変更を確認し、チェックが緑色になるのを待ってマージし、チャネルに通知します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、マージ ラベルが付けられるとすぐにプル リクエストを取得します。",
+            "title": "PR には「マージ準備完了」というラベルが付けられます"
+          },
+          "three": {
+            "description": "Zero は PR をマージし、結果をチャンネルに投稿します。",
+            "title": "マージされ、Slack に投稿されました"
+          },
+          "two": {
+            "description": "Zero は差分を読み取り、必要なすべてのチェックに合格するまで保持します。",
+            "title": "Zero は CI をレビューして待機します"
+          }
+        },
+        "title": "GitHub PR の自動マージ"
+      },
+      "blog-posts-to-x": {
+        "description": "毎日、Zero は新しく公開されたブログ投稿をソーシャル バリアントに変換し、バッファーを通じて X のキューに入れます。",
+        "scenario": "1 つのブログ投稿が 10 個のソーシャル投稿に相当する場合もありますが、それらを切り取る時間は誰にもありません。 Zero は、新しく公開された投稿を特定し、一連の X バリアントを作成し、承認のためにバッファーのキューに入れます。",
+        "steps": {
+          "one": {
+            "description": "Zero は、Strapi で新しく公開された投稿を検出します。",
+            "title": "Zero が新しい投稿を見つけます"
+          },
+          "three": {
+            "description": "Zero は、バリアントのレビューをスケジュールします。",
+            "title": "バッファにキューに入れられました"
+          },
+          "two": {
+            "description": "Zero は、各記事から複数の X 投稿の下書きを作成します。",
+            "title": "社会のバリアントに切り込む"
+          }
+        },
+        "title": "ブログ投稿をソーシャル投稿に変える"
+      },
+      "build-weekly-deck-gamma": {
+        "description": "Gamma で、その週の指標をすぐに提示できるデッキに変換します。",
+        "scenario": "週次指標デッキは、毎回新しい数値が記載された同じスライドです。 Zero はデータを取得し、Gamma でデッキを構築し、Slack に投稿することで、会議の前にレビューの準備が整います。",
+        "steps": {
+          "one": {
+            "description": "Zero は、スプレッドシートとアナリティクスから指標を読み取ります。",
+            "title": "Zero は数値を収集します"
+          },
+          "three": {
+            "description": "Zero は完成したデッキを共有します。",
+            "title": "Slack に投稿されました"
+          },
+          "two": {
+            "description": "Zero は、定期的なメトリクス デックを組み立てます。",
+            "title": "ガンマで構築されたデッキ"
+          }
+        },
+        "title": "Gamma で毎週のデッキを作成する"
+      },
+      "business-review-gamma": {
+        "description": "Gamma で月の指標をビジネス レビュー資料に変換します。",
+        "scenario": "毎週のビジネスレビューは、誰かが手作業で再構築する繰り返しのデッキです。 Zero は収益と成長を引き出し、Gamma でデッキを構築し、会議の前に準備します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、Stripe および Clerk から MRR、バーン、および成長を読み取ります。",
+            "title": "Zero が数値を取得します"
+          },
+          "three": {
+            "description": "Zero は完成したデッキを共有します。",
+            "title": "プレゼンテーションの準備ができました"
+          },
+          "two": {
+            "description": "Zero は、定期的なビジネス レビューを組み立てます。",
+            "title": "ガンマで構築されたデッキ"
+          }
+        },
+        "title": "Gamma でビジネス レビューを作成する"
+      },
+      "catch-calendar-conflicts": {
+        "description": "カレンダーをスキャンしてダブルブッキングがないか確認し、早めに通知します。",
+        "scenario": "ダブルブッキングは、2 つの会議が同時に開始された場合にのみ発見されます。 Zero は、新しいイベントをカレンダーと Cal.com の空き状況と照合してチェックし、競合が発生する前に警告します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、新しいイベントがカレンダーに登録されるとトリガーされます。",
+            "title": "イベントが作成されました"
+          },
+          "three": {
+            "description": "Zero は、干渉とオプションについて警告します。",
+            "title": "Slack で競合のフラグが立てられました"
+          },
+          "two": {
+            "description": "Zero は、既存のイベントおよび可用性と比較します。",
+            "title": "競合がないかチェックされました"
+          }
+        },
+        "title": "Google Calendar の競合を捕捉する"
+      },
+      "catch-leads-gmail": {
+        "description": "新しいメール内の購入シグナルを特定し、見込み客を記録します。",
+        "scenario": "温かいリードは忙しい受信トレイに隠れて冷めてしまいます。 Zero は、購入シグナルの受信メールを読み取り、Apollo で送信者を強化し、リードをシートに記録し、Slack で次の動きを提案します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、買いシグナルの受信 Gmail を読み取ります。",
+            "title": "Zero は新しいメールをスキャンします"
+          },
+          "three": {
+            "description": "Zero は、リードと推奨される次のステップを Slack に投稿します。",
+            "title": "次のステップが提案されました"
+          },
+          "two": {
+            "description": "Zero は Apollo で強化され、シートに行を追加します。",
+            "title": "鉛の濃縮と記録"
+          }
+        },
+        "title": "Gmail からのリードを獲得する"
+      },
+      "chase-overdue-asana-tasks": {
+        "description": "期限を過ぎた Asana タスクを見つけて、その所有者に Slack を指示します。",
+        "scenario": "期限を過ぎたタスクには誰かが追いかける必要があり、その誰かは常に忙しいです。 Zero は、Asana を毎日スキャンして期限を過ぎたものがないか確認し、各所有者を Slack に誘導します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、期日を過ぎたタスクを読み取ります。",
+            "title": "Zero は Asana をスキャンします"
+          },
+          "three": {
+            "description": "Zero 各所有者に期限を過ぎたリストを DM で送信します。",
+            "title": "Slack で送信されたナッジ"
+          },
+          "two": {
+            "description": "Zero は、期限を過ぎた作業を担当者ごとにグループ化します。",
+            "title": "所有者が特定されました"
+          }
+        },
+        "title": "期限を過ぎた Asana タスクを追跡する"
+      },
+      "check-posthog-signup-funnel": {
+        "description": "サインアップ ファネルを追跡し、最大の減少を Slack にポストします。",
+        "scenario": "ファネルは誰かが実行した場合にのみ役に立ちます。 Zero はサインアップ ファネルを毎週実行し、最も多くの人が失われているステップを見つけて Slack に投稿することで、チームはどこに集中すべきかを認識します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、PostHog でその週のサインアップ ファネルを実行します。",
+            "title": "Zero はファネルを実行します"
+          },
+          "three": {
+            "description": "Zero はリークとトレンドを投稿します。",
+            "title": "Slack に投稿されました"
+          },
+          "two": {
+            "description": "Zero は、減衰が最大のステップを見つけます。",
+            "title": "確認された最大のドロップオフ"
+          }
+        },
+        "title": "PostHog サインアップ ファネルを確認する"
+      },
+      "compare-google-ads-last-month": {
+        "description": "毎日、Zero は、Google 広告とメタ広告の費用、CPA、ROAS を前の期間と比較し、Slack で異常を報告します。",
+        "scenario": "広告のペース調整の問題は、気づかれないうちに毎日コストがかかります。 Zero は、費用、CPA、ROAS を前の期間と毎日比較し、Slack で変動しているものにフラグを立てます。",
+        "steps": {
+          "one": {
+            "description": "Zero は、Google とメタ広告から支出、CPA、コンバージョンを取得します。",
+            "title": "Zero は広告のパフォーマンスを読み取ります"
+          },
+          "three": {
+            "description": "Zero は比較を投稿し、ドリフトを強調表示します。",
+            "title": "Slack で異常のフラグが立てられた"
+          },
+          "two": {
+            "description": "Zero はデルタとペーシングを計算します。",
+            "title": "前期との比較"
+          }
+        },
+        "title": "Google 広告と先月の比較"
+      },
+      "daily-company-brief-slack": {
+        "description": "製品、成長、収益を Slack の日次概要にまとめます。",
+        "scenario": "全体像は、誰も一緒にチェックしていない 5 つのツールにあります。 Zero は毎朝、成長、収益、製品の健全性、エンジニアリングを取得し、成功、リスク、注意が必要なものなどの 1 つの企業パルスを Slack に投稿します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、スタック全体の成長、収益、エラー、出荷を読み取ります。",
+            "title": "Zero は信号を収集します"
+          },
+          "three": {
+            "description": "Zero は、毎日の会社概要を投稿します。",
+            "title": "Slack に投稿されました"
+          },
+          "two": {
+            "description": "Zero は、成功、リスク、注意が必要なものを書き込みます。",
+            "title": "パルスに組み立てられる"
+          }
+        },
+        "title": "毎日の会社概要を Slack に投稿します"
+      },
+      "daily-industry-news-slack": {
+        "description": "その日の関連業界ニュースを Slack 概要にまとめます。",
+        "scenario": "最新の状態を保つということは、決して開かないタブが 12 個もあるということです。 Zero は、毎日過去 24 時間の AI および競合他社のニュースをスキャンし、短い概要を Slack に投稿するので、代わりに 1 つの概要をざっと読むことができます。",
+        "steps": {
+          "one": {
+            "description": "Zero は、Exa を使用して、前日の AI と競合他社のカバレッジを検索します。",
+            "title": "Zero がニュースをスキャンします"
+          },
+          "three": {
+            "description": "Zero は毎日のニュース概要を投稿します。",
+            "title": "Slack に投稿されました"
+          },
+          "two": {
+            "description": "Zero は、実際に重要なことを要約しています。",
+            "title": "簡潔にまとめたもの"
+          }
+        },
+        "title": "毎日の業界ニュースを Slack に投稿します"
+      },
+      "draft-github-release-notes-notion": {
+        "description": "前回のリリース以降にマージされた PR を Notion のクリーン ノートに変換します。",
+        "scenario": "リリースノートを書くということは、PR 履歴をスクロールし、コミットを平易な言葉に翻訳することを意味します。 Zero は、出荷された PR にラベルを付けるときにそれを行います。最後のタグ以降にマージされたすべてのものを収集し、Notion に読みやすいメモを下書きします。",
+        "steps": {
+          "one": {
+            "description": "Zero はリリース ラベルでトリガーされます。",
+            "title": "PR には出荷済みのラベルが付いています"
+          },
+          "three": {
+            "description": "Zero は、Notion ページにクリーンでグループ化されたリリース ノートの下書きを作成します。",
+            "title": "リリース ノートは Notion に保存されました"
+          },
+          "two": {
+            "description": "Zero は、最後のリリース タグ以降にマージされたすべてのものを収集します。",
+            "title": "Zero はマージされた PR を収集します"
+          }
+        },
+        "title": "Notion で GitHub リリース ノートの草案を作成する"
+      },
+      "draft-newsletter-mailchimp": {
+        "description": "毎月、Zero は出荷された機能からニュースレターを作成し、Mailchimp でドラフトを作成します。",
+        "scenario": "月刊ニュースレターは常に白紙のページから始まります。 Zero は、GitHub から出荷されたものを収集し、問題の下書きを作成して、Mailchimp にステージングするため、作成者ではなく編集することができます。",
+        "steps": {
+          "one": {
+            "description": "Zero は、マージされた機能を読み取り、GitHub からハイライトします。",
+            "title": "Zero は出荷されたものを収集します"
+          },
+          "three": {
+            "description": "Zero は、すぐに編集できるドラフト キャンペーンを作成します。",
+            "title": "Mailchimp でステージングされています"
+          },
+          "two": {
+            "description": "Zero があなたの声で問題を書きます。",
+            "title": "ニュースレターの下書き"
+          }
+        },
+        "title": "Mailchimp でニュースレターの下書きを作成します"
+      },
+      "draft-replies-notion-faq": {
+        "description": "Notion FAQ に基づいたドラフト チケットの返信。",
+        "scenario": "ほとんどの質問はドキュメントですでに回答されています。 Zero は、受信した質問を読み、Notion で FAQ を検索し、エージェントが承認できるように独自のドキュメントに基づいた回答の下書きを作成します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、Intercom または Gmail の新しい会話を読み取ります。",
+            "title": "質問が届く"
+          },
+          "three": {
+            "description": "Zero はブランドに基づいた対応を行います。",
+            "title": "返信の下書きがレビュー用に作成されました"
+          },
+          "two": {
+            "description": "Zero は、ドキュメント内で関連する回答を見つけます。",
+            "title": "Zero は Notion FAQ を確認します"
+          }
+        },
+        "title": "Notion FAQ からの返信の下書き"
+      },
+      "file-gmail-invoices-drive": {
+        "description": "請求書メールをドライブにファイルし、それぞれをシートに記録します。",
+        "scenario": "請求書が受信箱に山積みになり、調整は大忙しです。 Zero は、ラベル付きの各請求書を適切なドライブ フォルダーにファイルし、到着時に経費シートに金額と期日を記録します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、Gmail の請求書ラベルでトリガーされます。",
+            "title": "請求書にはラベルが付いています"
+          },
+          "three": {
+            "description": "Zero は、経費シートに金額と期日を記録します。",
+            "title": "シートにログインしました"
+          },
+          "two": {
+            "description": "Zero は、添付ファイルを正しいフォルダーに保存します。",
+            "title": "Google Drive にファイルされました"
+          }
+        },
+        "title": "Gmail 請求書を Google Drive にファイルします"
+      },
+      "file-sentry-crashes-github": {
+        "description": "新しい Sentry エラーをユーザーへの影響別にランク付けし、最悪のものを GitHub Issueとして記録します。",
+        "scenario": "新しいクラッシュは、誰かが探しに行くまで Sentry に隠れます。 Zero は 1 時間ごとにチェックし、ヒットしたユーザーの数によってエラーをランク付けし、重要なものについては GitHub Issueを開き、そのコードの所有者に ping を送信します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、過去 1 時間の未解決のエラーとそのイベント数を読み取ります。",
+            "title": "Zero は新しい Sentry エラーを取得します"
+          },
+          "three": {
+            "description": "Zero は、スタック トレースに関する GitHub Issueを開き、Slack で所有者に通知します。",
+            "title": "問題が提起され、所有者に ping が送信されました"
+          },
+          "two": {
+            "description": "Zero は、影響を受けるユーザーごとに並べ替え、影響の少ないノイズをフィルターで除去します。",
+            "title": "ユーザーへの影響によるランキング"
+          }
+        },
+        "title": "GitHub のIssueにより、ファイル Sentry がクラッシュする"
+      },
+      "fixes-to-notion-help-docs": {
+        "description": "チケットが解決済みとしてマークされると、Zero は修正を Notion の再利用可能なヘルプ記事に変換します。",
+        "scenario": "修正が文書化されていないため、同じ質問が戻ってきます。 Zero は、解決された各チケットを Notion のクリーンで再利用可能なヘルプ記事に変換するため、次回は答えが存在します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、チケットが閉じられたときにトリガーされます。",
+            "title": "チケットが解決されました"
+          },
+          "three": {
+            "description": "Zero は、ヘルプセンターに記事を追加します。",
+            "title": "Notion に保存されました"
+          },
+          "two": {
+            "description": "Zero は、解決策から明確なハウツーを草案します。",
+            "title": "書き込まれた修正"
+          }
+        },
+        "title": "修正を Notion ヘルプ ドキュメントに変換する"
+      },
+      "flag-figma-designs-no-task": {
+        "description": "Linear タスクがまだリンクされていない Figma デザインにフラグを立てます。",
+        "scenario": "デザインはビルド チケットになることなく静かに終了します。 Zero は、リンクされた Linear タスクのない、準備完了とマークされたフレームの Figma を毎日スキャンし、スリップする前に Slack のギャップにフラグを立てます。",
+        "steps": {
+          "one": {
+            "description": "Zero は、フレームとそのリンクされたタスクを読み取ります。",
+            "title": "Zero は Figma フレームをスキャンします"
+          },
+          "three": {
+            "description": "Zero には、チャネル内のリンクされていないデザインがリストされます。",
+            "title": "Slack に投稿されたギャップ"
+          },
+          "two": {
+            "description": "Zero は、ビルド チケットが不足している準備完了デザインにフラグを立てます。",
+            "title": "タスクのないフレームを検索します"
+          }
+        },
+        "title": "タスクのない Figma デザインにフラグを立てる"
+      },
+      "flagged-gmail-todoist-tasks": {
+        "description": "フラグを付けたメールは自動的に Todoist タスクに変換されます。",
+        "scenario": "メールにフラグを付けると、決定が後回しになるだけです。 Zero はフラグを選択し、トピックと前のスレッドを調査し、すでにアタッチされているコンテキストを使用して Todoist タスクをファイルします。",
+        "steps": {
+          "one": {
+            "description": "Zero は、Gmail の To Do ラベルでトリガーされます。",
+            "title": "メールにフラグを立てた場合"
+          },
+          "three": {
+            "description": "Zero は、リンクを含むすぐに実行できるタスクを作成します。",
+            "title": "Todoist に提出されたタスク"
+          },
+          "two": {
+            "description": "Zero は、Exa を使用して以前のスレッドのコンテキストと Web 情報を収集します。",
+            "title": "Zero が調査します"
+          }
+        },
+        "title": "フラグが設定された Gmail を Todoist タスクに変換する"
+      },
+      "github-idea-to-notion-spec": {
+        "description": "ラベル付き GitHub のIssueを Notion の構造化された製品仕様に展開します。",
+        "scenario": "問題の 1 行のアイデアは仕様ではありません。 Zero は、ニーズ仕様ラベルを選択し、問題、ユーザー、要件、受け入れ基準を調整する準備ができた状態で、問題を Notion の構造化 PRD に拡張します。",
+        "steps": {
+          "one": {
+            "description": "Zero はラベルでトリガーされ、問題を読み取ります。",
+            "title": "問題には「ニーズ仕様」というラベルが付けられています"
+          },
+          "three": {
+            "description": "Zero は、構造化 PRD ページを Notion に作成します。",
+            "title": "Notion に保存されました"
+          },
+          "two": {
+            "description": "Zero は、問題、ユーザー、要件、および受け入れ基準の草案を作成します。",
+            "title": "Zero は PRD に展開します"
+          }
+        },
+        "title": "GitHub のアイデアを Notion 仕様に変える"
+      },
+      "gmail-followups-auto": {
+        "description": "返信しなかった連絡先を見つけて、次のフォローアップの下書きを作成します。",
+        "scenario": "フォローアップは、取引を獲得する場所と忘れ去られる場所です。 Zero は毎日シーケンスを進め、返信されないすべてに対して次のタッチの下書きを作成するため、何も失効することはありません。",
+        "steps": {
+          "one": {
+            "description": "Zero は、Instantly と Apollo で返信しなかった人を読み取ります。",
+            "title": "Zero はシーケンスのステータスをチェックします"
+          },
+          "three": {
+            "description": "Zero は、承認を得るためにドラフトを段階的に作成します。",
+            "title": "Gmail で準備完了"
+          },
+          "two": {
+            "description": "Zero は、各連絡先のフォローアップを書き込みます。",
+            "title": "次のタッチのドラフト"
+          }
+        },
+        "title": "Gmail のフォローアップを自動的に送信する"
+      },
+      "gmail-reconnect-reminders": {
+        "description": "しばらくメールを送っていない重要な連絡先を表示します。",
+        "scenario": "頭を下げていると、人間関係は薄れます。 Zero は、受信トレイとカレンダーを毎週確認し、沈黙を保っていた重要な連絡先を明らかにし、再接続のための自然なきっかけを提案します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、最近のメールとカレンダーの履歴を読み取ります。",
+            "title": "Zero が連絡先を確認します"
+          },
+          "three": {
+            "description": "Zero は、提案されたオープナーを使用して各連絡先を投稿します。",
+            "title": "提案されたオープナー"
+          },
+          "two": {
+            "description": "Zero は、最近触れていない重要な連絡先を見つけます。",
+            "title": "静かな関係が表面化"
+          }
+        },
+        "title": "Gmail 再接続リマインダーを取得する"
+      },
+      "highlight-key-emails-gmail": {
+        "description": "実際に注意が必要なメールをいくつか洗い出します。",
+        "scenario": "受信箱があふれて、重要な 3 通のメールが埋もれてしまいます。 Zero は毎朝メールを読み、本当に必要なメールだけを表示し、Slack に投稿します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、Gmail で夜間メールをスキャンします。",
+            "title": "Zero は受信トレイを読み取ります"
+          },
+          "three": {
+            "description": "Zero は、それぞれが重要である理由を含む候補リストを投稿します。",
+            "title": "Slack に投稿されました"
+          },
+          "two": {
+            "description": "Zero は、注意が必要な少数のものにフィルターをかけます。",
+            "title": "特定された優先事項"
+          }
+        },
+        "title": "Gmail で重要なメールを強調表示する"
+      },
+      "investor-update-google-docs": {
+        "description": "指標とハイライトをドキュメント内の投資家向け最新情報にまとめます。",
+        "scenario": "毎月の投資家向けアップデートはいつも遅れて最初から始まります。 Zero は KPI を収集し、更新内容を強調表示して Google ドキュメントに草稿するため、組み立てるのではなく調整することができます。",
+        "steps": {
+          "one": {
+            "description": "Zero は、Stripe とスプレッドシートから収益と成長を引き出します。",
+            "title": "Zero は KPI を収集します"
+          },
+          "three": {
+            "description": "Zero は、すぐに編集できるドラフトを残します。",
+            "title": "Google ドキュメントで編集可能"
+          },
+          "two": {
+            "description": "Zero は、ナラティブとメトリクスを書き込みます。",
+            "title": "アップデートの下書き"
+          }
+        },
+        "title": "Google ドキュメントで投資家向け最新情報の草案を作成する"
+      },
+      "log-gong-calls-hubspot": {
+        "description": "HubSpot 取引への Gong コールからメモと次のステップを引き出します。",
+        "scenario": "通話メモが新しいうちは CRM に組み込まれることはありません。 Zero は、各通話後に Gong トランスクリプトを読み取り、概要と次のステップを HubSpot 取引に自動的に書き込みます。",
+        "steps": {
+          "one": {
+            "description": "通話後、Zero は Gong から録音メモを取得します。",
+            "title": "Zero はトランスクリプトを読み取ります"
+          },
+          "three": {
+            "description": "Zero はメモを取引レコードに書き込みます。",
+            "title": "HubSpot に記録されました"
+          },
+          "two": {
+            "description": "Zero は決定事項とフォローアップを抽出します。",
+            "title": "概要と次のステップの草案"
+          }
+        },
+        "title": "Gong 呼び出しを HubSpot に記録します"
+      },
+      "meeting-notes-asana-tasks": {
+        "description": "Asana では、会議メモを期限付きの割り当てられたタスクに変換します。",
+        "scenario": "アクションアイテムは会議メモでは無効になります。 Zero は、各会議の後にトランスクリプトを読み取り、ToDo を取り出し、割り当てられた Asana タスクを作成するため、決定が実際に仕事になります。",
+        "steps": {
+          "one": {
+            "description": "会議の後、Zero は Fireflies からメモを取得します。",
+            "title": "Zero はトランスクリプトを読み取ります"
+          },
+          "three": {
+            "description": "Zero ファイルには、期限付きのタスクが割り当てられています。",
+            "title": "Asana で作成されたタスク"
+          },
+          "two": {
+            "description": "Zero は、To-Do と所有者を識別します。",
+            "title": "抽出されたアクションアイテム"
+          }
+        },
+        "title": "会議メモを Asana タスクに変える"
+      },
+      "meeting-recaps-slack": {
+        "description": "各会議の後に、決定事項と実行項目の要約を共有します。",
+        "scenario": "会議の詳細は次の会議までに薄れてしまいます。 Zero はその後トランスクリプトを読み取り、決定事項とアクション項目の完全な要約を送信するため、何も失われることはありません。",
+        "steps": {
+          "one": {
+            "description": "会議の後、Zero は Fireflies からメモを取得します。",
+            "title": "Zero はトランスクリプトを読み取ります"
+          },
+          "three": {
+            "description": "Zero は、要約を Gmail または Slack に提供します。",
+            "title": "あなたに送信されました"
+          },
+          "two": {
+            "description": "Zero には、決定事項とアクション項目が要約されています。",
+            "title": "要約を書きました"
+          }
+        },
+        "title": "Slack で会議の概要を取得します"
+      },
+      "morning-brief-slack": {
+        "description": "Zero は毎朝、スケジュールと必要なメールを記載した概要を送信し、Slack に投稿します。",
+        "scenario": "一日の最初の10分間は、その日が何なのかを理解するために費やされます。 Zero は、スケジュールと必要なメールをまとめ、座る前に朝の概要を Slack に投稿します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、今日のカレンダーと優先メールを取得します。",
+            "title": "Zero があなたの一日を読み取ります"
+          },
+          "three": {
+            "description": "Zero は朝の概要を送信します。",
+            "title": "Slack に投稿されました"
+          },
+          "two": {
+            "description": "Zero には、スケジュールと注意が必要なものが書き込まれます。",
+            "title": "簡単に組み立てたもの"
+          }
+        },
+        "title": "Slack で朝の概要を入手"
+      },
+      "new-gmail-contacts-hubspot": {
+        "description": "不明なメール送信者を HubSpot 連絡先として追加して強化します。",
+        "scenario": "連絡先は誰も記録しないとすり抜けてしまいます。 Zero は、HubSpot にまだ存在していないユーザーからのメールを認識し、レコードを作成し、Apollo でそれを強化するため、CRM は手動入力なしで完全な状態を維持できます。",
+        "steps": {
+          "one": {
+            "description": "Zero は、受信メールを CRM と照合してチェックします。",
+            "title": "Zero は不明な送信者を特定します"
+          },
+          "three": {
+            "description": "Zero は、連絡先とソースをタイムラインに記録します。",
+            "title": "フォローアップのために記録されました"
+          },
+          "two": {
+            "description": "Zero は、その人を HubSpot に追加し、Apollo で強化します。",
+            "title": "連絡先が作成され、充実しました"
+          }
+        },
+        "title": "新しい Gmail 連絡先を HubSpot に追加します"
+      },
+      "onboard-new-hires-asana": {
+        "description": "Asana で各新入社員のオンボーディング タスク チェックリストを作成します。",
+        "scenario": "オンボーディングは毎回同じチェックリストであり、毎回手動で行われます。 Zero は新規採用者を検出し、Asana でオンボーディング プロジェクトを立ち上げ、ドライブにスターター ドキュメントを設定します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、Deel の新しいレコードを検出します。",
+            "title": "新規採用者が追加されました"
+          },
+          "three": {
+            "description": "Zero は、Google Drive にスターター ドキュメントを設定します。",
+            "title": "プロビジョニングされたドキュメント"
+          },
+          "two": {
+            "description": "Zero は、タスクが割り当てられたオンボーディング プロジェクトを起動します。",
+            "title": "Asana で作成されたチェックリスト"
+          }
+        },
+        "title": "Asana での新入社員のオンボーディング"
+      },
+      "post-daily-metrics-slack": {
+        "description": "毎日の訪問者、サインアップ、アクティベーション番号を Slack に投稿します。",
+        "scenario": "コーヒーを飲む前に 3 つのダッシュボードをチェックするのは、誰もが好む習慣です。 Zero は毎朝訪問者、サインアップ、アクティベーションを取得し、その数値を Slack にポストするため、チャネルにすでに存在する KPI から 1 日が始まるようになります。",
+        "steps": {
+          "one": {
+            "description": "Zero は、分析ツールからトラフィック、サインアップ、アクティベーションを読み取ります。",
+            "title": "Zero はメトリクスを取得します"
+          },
+          "three": {
+            "description": "Zero は朝の KPI 更新を投稿します。",
+            "title": "Slack に投稿されました"
+          },
+          "two": {
+            "description": "Zero は、日々のコンテキストを使用してキー数値をフォーマットします。",
+            "title": "KPI スナップショットに組み立てられる"
+          }
+        },
+        "title": "毎日のメトリクスを Slack に投稿します"
+      },
+      "post-github-updates-slack": {
+        "description": "平日の毎朝 Zero は、GitHub と Linear からのマージされた進行中の作業を Slack の進行状況更新にコンパイルします。",
+        "scenario": "スタンドアップは時間を食いますが、半分は自分がやったことを思い出すだけです。 Zero は、マージされた PR と進行中の Linear チケットを毎朝コンパイルし、きちんとした進行状況の更新を投稿するため、非同期スタンドアップはそれ自体を書き込みます。",
+        "steps": {
+          "one": {
+            "description": "Zero は、マージされて開いている作業を GitHub および Linear から読み取ります。",
+            "title": "Zero はアクティビティを収集します"
+          },
+          "three": {
+            "description": "Zero は、平日毎日スタンドアップ チャンネルに更新情報を投稿します。",
+            "title": "Slack に投稿されました"
+          },
+          "two": {
+            "description": "Zero は、短くて読みやすい進行状況の概要を書き込みます。",
+            "title": "アップデートにまとめました"
+          }
+        },
+        "title": "GitHub の更新を Slack に投稿します"
+      },
+      "post-release-notes-slack": {
+        "description": "最近出荷された作業から変更ログを作成し、Slack に投稿します。",
+        "scenario": "ユーザーに表示される変更ログはコミット ログとは異なります。 Zero は、リリース ラベルでトリガーされ、出荷されたもののユーザー向けのわかりやすい概要を作成し、それを Slack および Notion に投稿します。",
+        "steps": {
+          "one": {
+            "description": "Zero はリリース ラベルでトリガーされます。",
+            "title": "PR にはリリースというラベルが付けられます"
+          },
+          "three": {
+            "description": "Zero は両方の場所で発表を共有します。",
+            "title": "Slack および Notion に投稿されました"
+          },
+          "two": {
+            "description": "Zero は、変更内容のユーザー向けの概要を書き込みます。",
+            "title": "Zero が変更ログの下書きを作成します"
+          }
+        },
+        "title": "リリース ノートを Slack に投稿します"
+      },
+      "prep-google-calendar-meetings": {
+        "description": "外部出席者を調査し、会議の前に準備概要を送信します。",
+        "scenario": "コールドコールに応じるということは、それを終わらせることを意味します。 Zero は、新しい外部会議を通知し、出席者と Apollo の会社を調査し、Gong から以前の通話コンテキストを取得し、開始前に 1 ページの概要を DM で送信します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、外部出席者がカレンダーに参加するとトリガーされます。",
+            "title": "会議が追加されました"
+          },
+          "three": {
+            "description": "Zero は、電話の前に 1 ページの資料を DM で送信します。",
+            "title": "準備概要を Slack に送信しました"
+          },
+          "two": {
+            "description": "Zero は、Apollo と Gong で個人と会社を豊かにします。",
+            "title": "出席者が調査しました"
+          }
+        },
+        "title": "Google Calendar 会議の準備をする"
+      },
+      "publish-scheduled-posts-buffer": {
+        "description": "毎日、Zero は、今日スケジュールされたコンテンツを Notion カレンダーから Strapi に公開し、ソーシャル投稿をバッファーのキューに入れます。",
+        "scenario": "コンテンツ カレンダーは、誰かが公開をクリックした場合にのみ機能します。 Zero は、今日のスケジュールされたアイテムを Notion から読み取り、それらを Strapi に公開し、一致するソーシャル投稿をバッファーのキューに入れます。",
+        "steps": {
+          "one": {
+            "description": "Zero は、今日予定されているアイテムを Notion から取得します。",
+            "title": "Zero は今日のカレンダーを読み取ります"
+          },
+          "three": {
+            "description": "Zero は、バッファー内のプロモーション投稿をスケジュールします。",
+            "title": "ソーシャルがバッファにキューに入れられました"
+          },
+          "two": {
+            "description": "Zero は、コンテンツを Strapi にプッシュします。",
+            "title": "CMSに公開"
+          }
+        },
+        "title": "スケジュールされた投稿をバッファに公開する"
+      },
+      "report-ai-model-costs-slack": {
+        "description": "毎日、Zero は、Langfuse から Slack へのモデルおよびルートごとの LLM トークンの使用量と p95 レイテンシーを報告します。",
+        "scenario": "モデルの支出はルートやモデル全体で静かに増加しています。 Zero は、Langfuse を毎日読み取り、モデルおよびルートごとのトークン支出と p95 レイテンシーの内訳を投稿するため、請求書が届くまでコストが驚くことがありません。",
+        "steps": {
+          "one": {
+            "description": "Zero は、その日のトークンの使用量と遅延のトレースを取得します。",
+            "title": "Zero は Langfuse を読み取ります"
+          },
+          "three": {
+            "description": "Zero は、日次コストと遅延レポートを投稿します。",
+            "title": "Slack に投稿されました"
+          },
+          "two": {
+            "description": "Zero は、モデルごとおよびルートごとに支出と p95 を集計します。",
+            "title": "車種別・路線別"
+          }
+        },
+        "title": "AI モデルのコストを Slack に報告します"
+      },
+      "research-calendar-meetings": {
+        "description": "カレンダーの各イベントの前に、会う人について調べてください。",
+        "scenario": "準備を整えて参加するということは、時間がほとんどない研究を意味します。 Zero は、新しい会議を通知し、出席者とその会社を検索し、開始前に 1 ページの関係書類を送信します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、新しいカレンダー イベントでトリガーされます。",
+            "title": "会議が追加されました"
+          },
+          "three": {
+            "description": "Zero は、呼び出しの前に Slack に 1 ページの概要を送信します。",
+            "title": "提出された書類"
+          },
+          "two": {
+            "description": "Zero は、Exa を使用して人物と会社を検索します。",
+            "title": "参加者が調査しました"
+          }
+        },
+        "title": "カレンダー上の会議を調査する"
+      },
+      "research-new-signups-apollo": {
+        "description": "新しいサインアップをそれぞれ調査し、簡単なスナップショットを投稿します。",
+        "scenario": "新しいサインアップは、誰かが時間内に気づいた場合にのみチャンスとなります。 Zero は、Clerk を時間ごとにチェックし、Apollo を使用して各新規ユーザーとその会社を調査し、バックグラウンド スナップショットを Slack に投稿します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、1 時間ごとに Clerk から新しいユーザーをプルします。",
+            "title": "Zero は新しいサインアップを読み取ります"
+          },
+          "three": {
+            "description": "Zero は、各サインアップのプロファイルをチャネルに投稿します。",
+            "title": "スナップショットが Slack に投稿されました"
+          },
+          "two": {
+            "description": "Zero は、背景と会社のコンテキストを強化します。",
+            "title": "アポロとともに研究"
+          }
+        },
+        "title": "新しいサインアップを調査する"
+      },
+      "run-daily-query-sheets": {
+        "description": "保存した SQL をスケジュールに従って実行し、結果をシートに追加します。",
+        "scenario": "毎朝再構築するレポートは、同じクエリであり、同じシートに貼り付けられたものです。 Zero は毎日クエリを実行し、フォーマットされた結果を Google Sheets に直接書き込みます。",
+        "steps": {
+          "one": {
+            "description": "Zero は、保存された読み取り専用クエリをウェアハウスに対して実行します。",
+            "title": "Zero はクエリを実行します"
+          },
+          "three": {
+            "description": "Zero は結果を追跡シートに追加します。",
+            "title": "Google Sheets に書き込まれます"
+          },
+          "two": {
+            "description": "Zero は、出力をきれいな列に整形します。",
+            "title": "結果がフォーマットされました"
+          }
+        },
+        "title": "Google Sheets に対して毎日クエリを実行します。"
+      },
+      "send-bugs-github-slack": {
+        "description": "バグタグを付けたレポートを GitHub Issueとしてファイルし、Slack でチームに警告します。",
+        "scenario": "バグレポートは、完全なものである場合にのみエンジニアにとって役立ちます。 Zero はバグ ラベルを取得し、再現手順と顧客への影響をまとめて、きれいにファイルして、エンジニアリング チャネルに投稿します。",
+        "steps": {
+          "one": {
+            "description": "Zero はバグ ラベルでトリガーされます。",
+            "title": "問題にはバグというラベルが付けられます"
+          },
+          "three": {
+            "description": "Zero は、構造化レポートを Slack に投稿します。",
+            "title": "エンジニアリング部門に送られる"
+          },
+          "two": {
+            "description": "Zero は、ステップ、影響、およびコンテキストを組み立てます。",
+            "title": "リプロとインパクトのパッケージ化"
+          }
+        },
+        "title": "バグを GitHub および Slack に送信します。"
+      },
+      "sort-gmail-draft-replies": {
+        "description": "受信トレイを分類し、必要なメールへの返信の下書きを作成します。",
+        "scenario": "受信トレイがいっぱいになるのはフルタイムの仕事です。 Zero は、受信メールを緊急度によって分類し、音声で返信の下書きを作成するので、最初から入力するのではなく、ざっと読んで承認することができます。",
+        "steps": {
+          "one": {
+            "description": "Zero は、受信した Gmail メッセージをスキャンします。",
+            "title": "Zero は新しいメールを読み取ります"
+          },
+          "three": {
+            "description": "Zero は、承認を得るために応答を段階的に処理します。",
+            "title": "返信草案"
+          },
+          "two": {
+            "description": "Zero は、現在必要なものと後で必要なものをラベル付けします。",
+            "title": "緊急度順に並べ替え"
+          }
+        },
+        "title": "Gmail と返信の下書きを並べ替える"
+      },
+      "sort-route-zendesk-tickets": {
+        "description": "サポート チケットが到着すると、Zero はその重大度を設定し、適切なチームにルーティングして、最初の返信の草案を作成します。",
+        "scenario": "すべてのチケットには、回答する前にトリアージが必要です。 Zero は、新しいチケットをそれぞれ読み取り、重大度を割り当て、適切なキューにルーティングして、最初の応答を下書きするため、エージェントは空のボックスではなく下書きから開始します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、新しい Zendesk チケットを読み取ります。",
+            "title": "チケットが届く"
+          },
+          "three": {
+            "description": "Zero は、ブランドに関する最初の対応を段階的に行います。",
+            "title": "最初の返信の下書き"
+          },
+          "two": {
+            "description": "Zero は緊急度を分類し、適切なチームに送信します。",
+            "title": "重大度の設定とルーティング"
+          }
+        },
+        "title": "Zendesk チケットの並べ替えとルーティング"
+      },
+      "spot-churn-risk-stripe-zendesk": {
+        "description": "解約のリスクがあるアカウントにフラグを立てて、回復メールの下書きを作成します。",
+        "scenario": "チャーンは、チャーンが起こって初めて明らかになります。 Zero は、請求に関するトラブルやチケットの急増がないか Stripe と Zendesk を毎日チェックし、リスクのあるアカウントにフラグを立てて、誰かが早期に介入できるように回復メールの下書きを作成します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、Stripe から請求ステータスを読み取り、Zendesk からチケット量を読み取ります。",
+            "title": "Zero がアカウントをスキャンします"
+          },
+          "three": {
+            "description": "Zero は、レビュー用にアウトリーチ メールの下書きを作成します。",
+            "title": "回復メールの下書き"
+          },
+          "two": {
+            "description": "Zero は、チャーンシグナルを示すアカウントを表示します。",
+            "title": "リスクのあるアカウントにフラグが設定される"
+          }
+        },
+        "title": "Stripe および Zendesk のスポット チャーン リスク"
+      },
+      "summarize-gmail-newsletters": {
+        "description": "受信トレイ内のニュースレターを 1 つの短い要約に要約します。",
+        "scenario": "あなたは 20 のニュースレターを購読していますが、何も読んでいません。 Zero は、ニュースレターとしてラベル付けしたすべてのものを収集し、毎週 1 つのきちんとしたダイジェストを投稿するので、山積みせずにシグナルを受け取ることができます。",
+        "steps": {
+          "one": {
+            "description": "Zero は、ニュースレター ラベルの下にあるメッセージを読み取ります。",
+            "title": "Zero はニュースレターを収集します"
+          },
+          "three": {
+            "description": "Zero は毎週のダイジェストを送信します。",
+            "title": "Slack に投稿されました"
+          },
+          "two": {
+            "description": "Zero は、それぞれから重要なポイントを抽出します。",
+            "title": "1 つの要約にまとめた"
+          }
+        },
+        "title": "Gmail ニュースレターの要約"
+      },
+      "summarize-user-feedback-notion": {
+        "description": "Zero は毎週、Productlane、Typeform、Intercom、GitHub からフィードバックを収集し、それをテーマに分類して、Notion にランク付けします。",
+        "scenario": "フィードバックは 4 つのツールに分散されており、すべてを読む時間は誰もありません。 Zero は毎週各ソースから取得し、コメントをテーマにまとめて、ランク付けされた概要を Notion に書き込むため、上位の質問が明確になります。",
+        "steps": {
+          "one": {
+            "description": "Zero は、Productlane、Typeform、Intercom、および GitHub からの新しいフィードバックを読み取ります。",
+            "title": "Zero はフィードバックを取得します"
+          },
+          "three": {
+            "description": "Zero は、ランク付けされたダイジェストを Notion ページに書き込みます。",
+            "title": "概要が Notion に保存されました"
+          },
+          "two": {
+            "description": "Zero は、関連するフィードバックをグループ化し、頻度によってテーマをランク付けします。",
+            "title": "テーマごとに分類"
+          }
+        },
+        "title": "ユーザーのフィードバックを Notion に要約します"
+      },
+      "summarize-zendesk-tickets-daily": {
+        "description": "Zendesk チケットの最終日を要約し、Slack に投稿します。",
+        "scenario": "サポートのバックログは、火事になるまではわかりません。 Zero は毎朝、チケットの最終日を重大度および経過時間別に要約して Slack に投稿するため、目に見えないまま腐ることはありません。",
+        "steps": {
+          "one": {
+            "description": "Zero は、過去 24 時間の Zendesk チケットを取得します。",
+            "title": "Zero はキューを読み取ります"
+          },
+          "three": {
+            "description": "Zero は毎日のサポート ダイジェストを投稿します。",
+            "title": "Slack に投稿されました"
+          },
+          "two": {
+            "description": "Zero は、開いているチケットを整理し、古いチケットにフラグを立てます。",
+            "title": "重症度と年齢ごとにグループ化"
+          }
+        },
+        "title": "Zendesk チケットを毎日要約する"
+      },
+      "sync-asana-projects-notion": {
+        "description": "Asana プロジェクトのステータスを Notion の単一ボードにロールアップします。",
+        "scenario": "ステータスは Asana にありますが、リーダーシップは Notion となります。 Zero は、タスクのステータスを毎日 1 つの Notion ボードにまとめてダイジェストを投稿するため、ステータス会議を行わずに全員が同じ画像を見ることができます。",
+        "steps": {
+          "one": {
+            "description": "Zero は、チーム全体のタスクとプロジェクトのステータスを取得します。",
+            "title": "Zero は Asana を読み取ります"
+          },
+          "three": {
+            "description": "Zero は、概要を Slack に投稿します。",
+            "title": "ダイジェスト掲載"
+          },
+          "two": {
+            "description": "Zero は、単一の Notion ステータス ボードを更新します。",
+            "title": "一枚の板に丸めたもの"
+          }
+        },
+        "title": "Asana プロジェクトを Notion に同期します"
+      },
+      "sync-linear-roadmap-notion": {
+        "description": "Notion ロードマップと Linear の問題ステータスの同期を維持します。",
+        "scenario": "チケットが移動した瞬間にロードマップは古くなります。 Zero は、Linear ステータスを Notion の Now / Next / Later ボードに毎日同期するため、関係者が読むロードマップは常に現実と一致します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、現在のチケットの状態とマイルストーンを取得します。",
+            "title": "Zero は Linear ステータスを読み取ります"
+          },
+          "three": {
+            "description": "Zero は、Notion ロードマップ ボードを更新します。",
+            "title": "Notion でボードが更新されました"
+          },
+          "two": {
+            "description": "Zero バケットはロードマップ列に組み込まれます。",
+            "title": "現在 / 次 / 後でマッピング"
+          }
+        },
+        "title": "Linear ロードマップを Notion に同期します"
+      },
+      "track-feature-usage-posthog": {
+        "description": "PostHog からの機能使用量の週ごとの最大の変化を明らかにします。",
+        "scenario": "問題が発生するまで、機能がひっそりと使用できなくなっていることに誰も気づきません。 Zero は毎週 PostHog をチェックし、どの機能が上昇または下降しているかを投稿するため、チームは導入の変化を早期に確認できます。",
+        "steps": {
+          "one": {
+            "description": "Zero は、その週の機能の使用状況を取得します。",
+            "title": "Zero は PostHog を読み取ります"
+          },
+          "three": {
+            "description": "Zero は、採用の変更をチャンネルに投稿します。",
+            "title": "Slack に投稿されたシフト"
+          },
+          "two": {
+            "description": "Zero は、最大の上昇値と下降値を見つけます。",
+            "title": "週ごとの比較"
+          }
+        },
+        "title": "PostHog を使用して機能の使用状況を追跡する"
+      },
+      "track-keyword-ranks-ahrefs": {
+        "description": "毎週 Zero は、Ahrefs でターゲット キーワードのランキングを追跡し、Notion で上位キーワードをレポートします。",
+        "scenario": "ランクの追跡は、手動でエクスポートして比較する作業です。 Zero は毎週ターゲットのキーワードを取得し、順位を比較し、最も大きな要因を Notion に書き込むため、SEO の勝敗が明らかになります。",
+        "steps": {
+          "one": {
+            "description": "Zero は、Ahrefs から現在のランキングを取得します。",
+            "title": "Zero はキーワードの位置を読み取ります"
+          },
+          "three": {
+            "description": "Zero は、ムーバーとトレンドを Notion に書き込みます。",
+            "title": "Notion で報告されました"
+          },
+          "two": {
+            "description": "Zero は先週と比較し、最も大きな変化が見られます。",
+            "title": "引っ越し業者が特定されました"
+          }
+        },
+        "title": "Ahrefs でキーワード ランクを追跡する"
+      },
+      "track-signup-sources-sheets": {
+        "description": "追跡シート内の各新規サインアップをそのソースに帰属させます。",
+        "scenario": "サインアップがどこから来たのかを知るということは、Clerk を手動で分析に結び付けることを意味します。 Zero は、新しいサインアップを毎日そのチャネルとキャンペーンに関連付け、ピボットできる Google シートに記録します。",
+        "steps": {
+          "one": {
+            "description": "Zero は、Clerk から新しいユーザーを取得します。",
+            "title": "Zero は新しいサインアップを読み取ります"
+          },
+          "three": {
+            "description": "Zero は、属性付きの行をシートに追加します。",
+            "title": "Google Sheets に記録されました"
+          },
+          "two": {
+            "description": "Zero は、Plausible を介して各サインアップをそのソースおよびキャンペーンと照合します。",
+            "title": "チャンネルに起因する"
+          }
+        },
+        "title": "Google Sheets でサインアップ ソースを追跡する"
+      },
+      "watch-brand-mentions": {
+        "description": "Zero は 1 時間ごとに Web、Hacker News、X で製品に関する言及を検索し、Slack に投稿します。",
+        "scenario": "あなたの製品に関するスレッドを見つける頃には、会話はさらに進んでいます。 Zero は、Web、Reddit、および X を 1 時間ごとに検索し、新しいメンションを Slack に投稿するので、ライブ中に参加できます。",
+        "steps": {
+          "one": {
+            "description": "Zero は Web、Reddit、および X を Exa でスキャンします。",
+            "title": "Zero はメンションを検索します"
+          },
+          "three": {
+            "description": "Zero は、各メンションをリンクとコンテキストとともに投稿します。",
+            "title": "Slack に投稿されました"
+          },
+          "two": {
+            "description": "Zero は、新鮮で関連性のあるヒットのみを保持します。",
+            "title": "新しいメンションがフィルタリングされました"
+          }
+        },
+        "title": "HN と X でブランドの言及を確認する"
+      },
+      "watch-sentry-after-release": {
+        "description": "各リリース後に、Zero は新しいバージョンのクラッシュフリー率をベースラインと比較し、ロールバックの提案で回帰のフラグを立てます。",
+        "scenario": "最もリスクが高いのは、デプロイ直後です。 Zero は、新しいリリースのクラッシュフリー率とエラー率を以前のベースラインと比較して監視し、状況が悪化した場合は回帰を警告し、ロールバックを提案します。",
+        "steps": {
+          "one": {
+            "description": "デプロイ後、Zero はリリースのクラッシュフリー率とエラー率を Sentry で追跡します。",
+            "title": "Zero は新しいリリースを監視します"
+          },
+          "three": {
+            "description": "リリースが後退すると、Zero は Slack に警告し、ロールバックを提案します。",
+            "title": "ロールバック ヒントでリグレッションのフラグが立てられる"
+          },
+          "two": {
+            "description": "Zero は、ライブ数値を以前のリリースのベースラインと比較します。",
+            "title": "ベースラインとの比較"
+          }
+        },
+        "title": "リリース後に Sentry を監視する"
+      }
+    }
+  },
+  "queue": {
+    "concurrentRuns_one": "{{count}} 同時実行",
+    "concurrentRuns_other": "{{count}} 同時実行数",
+    "description": "キュー内の自分の位置を確認し、アップグレードして待ち時間をスキップします。",
+    "perMonth": "/月",
+    "pricePerMonth": "{{price}}/月",
+    "purchase": {
+      "addOn": "アドオン",
+      "addsToLimit": "現在の制限に追加されます",
+      "appliedAfterCheckout": "チェックアウト完了後に適用されます",
+      "buy": "{{price}}/月を購入する",
+      "decreaseQuantity": "同時実行数を減らす",
+      "description": "このワークスペースに専用の同時実行を追加すると、月ごとに請求されます。",
+      "increaseQuantity": "同時実行数を増やす",
+      "quantity": "数量",
+      "subscription_one": "{{count}} スロットの月額サブスクリプション",
+      "subscription_other": "{{count}} スロットの月次サブスクリプション",
+      "title": "追加の同時実行性"
+    },
+    "redirecting": "リダイレクト中...",
+    "status": {
+      "atLimit_one": "一度に実行できるのは {{limit}} タスクのみです。新しい実行は、終了するまでキューで待機します。",
+      "atLimit_other": "一度に実行できるタスクは {{limit}} のみです。新しい実行は、終了するまでキューで待機します。",
+      "available_one": "{{count}} スロットが使用可能です",
+      "available_other": "{{count}} スロットが利用可能",
+      "inUse_one": "{{limit}} スロットの {{active}} が使用中です",
+      "inUse_other": "{{limit}} スロット中 {{active}} が使用中です"
+    },
+    "tiers": {
+      "custom": "カスタム",
+      "free": "無料",
+      "limitedFree": "限定無料",
+      "noPlan": "計画なし",
+      "pro": "プロ",
+      "team": "チーム"
+    },
+    "title": "あなたのエージェントが列に並んで待っています",
+    "upgrade": {
+      "action": "{{plan}} にアップグレードする",
+      "features": {
+        "creditsPerMonth": "{{credits}} クレジット / 月",
+        "emailSupport": "メールサポート",
+        "ownKeys": "独自の LLM キーを持参する",
+        "payAsYouGo": "その後は従量料金を支払う",
+        "prioritySupport": "優先サポート",
+        "unlimitedAgents": "無制限の合計エージェント"
+      },
+      "proDescription": "複数のタスクを並行して実行し、キューをスキップします。",
+      "recommended": "おすすめ",
+      "teamDescription": "10 回の並列実行とより多くのクレジットでチームを拡張します。"
+    }
+  },
+  "reportError": {
+    "description": "この失敗した実行に関する診断情報を開発者チームに送信します。すぐに調査してフォローアップいたします。",
+    "disclosure": {
+      "agentConfiguration": "エージェントの構成",
+      "agentTelemetry": "エージェントのテレメトリと実行ログ",
+      "chatHistory": "チャット履歴とエージェント イベント",
+      "connectedServices": "接続されたサービス (認証情報なし)",
+      "networkLogs": "ネットワークリクエストログ",
+      "runContext": "実行コンテキストと環境",
+      "title": "何が送られるのか"
+    },
+    "documentTitle": "エラーを報告する",
+    "error": {
+      "loadFailed": "実行の詳細をロードできませんでした",
+      "notFailed": "この実行は失敗していないため、報告できません",
+      "title": "エラー",
+      "tryAgain": "もう一度試してください"
+    },
+    "fields": {
+      "description": "説明",
+      "descriptionPlaceholder": "何が起こったのでしょうか？何を期待していましたか？",
+      "title": "タイトル",
+      "titlePlaceholder": "問題の簡単な概要"
+    },
+    "loading": "実行の詳細をロードしています",
+    "send": "レポートの送信",
+    "sending": "送信中...",
+    "success": {
+      "description": "エラーレポートは開発者チームに送信されました。彼らは調査して追跡調査します。",
+      "reference": "参照: {{reference}}",
+      "title": "レポートを送信しました"
+    },
+    "title": "開発者にエラーを報告する"
+  },
+  "settings": {
+    "accountMenu": {
+      "addAccount": "アカウントを追加",
+      "creditBalance_one": "{{value}} クレジット",
+      "creditBalance_other": "{{value}} クレジット",
+      "exportData": "データのエクスポート",
+      "lab": "研究室",
+      "settings": "設定",
+      "signOut": "サインアウト",
+      "subscriptions": {
+        "providers": {
+          "claudeCode": "Claude コード",
+          "codex": "Codex"
+        },
+        "reset": "リセット",
+        "resetTimeUnavailable": "リセット時間は利用不可",
+        "usage": "{{provider}} の使用法",
+        "usageRemaining": "{{provider}} {{window}} 残り",
+        "windows": {
+          "fiveHour": "5時間",
+          "week": "週"
+        }
+      },
+      "switchAccount": "アカウントを切り替える",
+      "userFallback": "ユーザー"
+    },
+    "buildInfo": {
+      "backend": "バックエンド",
+      "commitSha": "SHAをコミットする",
+      "frontend": "フロントエンド",
+      "loading": "読み込み中",
+      "title": "ビルド情報",
+      "unavailable": "利用不可"
+    },
+    "dialog": {
+      "description": "アカウント、設定、ワークスペース、および請求設定を管理します。",
+      "groups": {
+        "billing": "請求と価格設定",
+        "models": "モデル",
+        "personal": "個人的な",
+        "workspace": "ワークスペース"
+      },
+      "sections": {
+        "billing": {
+          "description": "プランと支払い方法を管理します。",
+          "title": "請求"
+        },
+        "debug": {
+          "description": "診断と開発者ツール。",
+          "title": "デバッグ"
+        },
+        "general": {
+          "description": "ワークスペースのプロファイルと設定を管理します。",
+          "title": "一般"
+        },
+        "invoices": {
+          "description": "過去の請求書を表示してダウンロードします。",
+          "title": "請求書"
+        },
+        "model": {
+          "description": "ワークスペースと実行で使用する AI モデルを選択します。",
+          "title": "モデル"
+        },
+        "people": {
+          "description": "このワークスペースにアクセスできるユーザーを管理します。",
+          "title": "人々"
+        },
+        "preference": {
+          "description": "アプリの外観と動作をカスタマイズします。",
+          "title": "好み"
+        },
+        "usage": {
+          "balanceDescription": "チームのクレジット残高と使用量。",
+          "balanceTitle": "クレジット残高",
+          "usageDescription": "チャット、オートメーション、チャネル全体でのクレジットの使用状況。",
+          "usageTitle": "クレジット使用量"
+        }
+      },
+      "title": "設定"
+    },
+    "export": {
+      "actions": {
+        "again": "再度エクスポートする",
+        "download": "ダウンロードエクスポート",
+        "start": "データをエクスポートする",
+        "starting": "エクスポートの開始"
+      },
+      "backToZero": "Zero に戻る",
+      "description": "Zero で作成したファイルとテキスト レコードをダウンロードします。",
+      "documentTitle": "データのエクスポート",
+      "duration": {
+        "soon": "すぐに"
+      },
+      "errors": {
+        "loadFailed": "エクスポートのロードに失敗しました",
+        "rateLimited": "24 時間ごとに 1 回エクスポートできます。",
+        "startFailed": "エクスポートの開始に失敗しました"
+      },
+      "scope": {
+        "agentInstructions": "エージェントの指示文書",
+        "artifactsExcluded": "このエクスポートにはアーティファクトは含まれません。",
+        "chatMessages": "ユーザーとアシスタントのテキスト チャット メッセージ",
+        "memoryFiles": "メモリファイル",
+        "workflowInstructions": "ワークフロー SKILL.md の手順とファイル"
+      },
+      "status": {
+        "checkingDescription": "最新のエクスポート状態がここに表示されます。",
+        "checkingTitle": "エクスポートステータスの確認",
+        "downloadExpires": "ダウンロード リンクの有効期限は {{duration}} です。",
+        "downloadNoExpiry": "リンクの有効期限が切れる前にダウンロードしてください。",
+        "downloadTitle": "エクスポートの準備が完了しました",
+        "expiredDescription": "新しいエクスポートを開始して、新しいダウンロード リンクを取得します。",
+        "expiredTitle": "前回のエクスポートの有効期限が切れました",
+        "failedDescription": "もう一度試すか、これが続く場合はサポートにお問い合わせください。",
+        "failedTitle": "エクスポートが完了しませんでした",
+        "preparingDescription": "これには数分かかる場合があります。このページは開いたままにしておいても構いません。",
+        "preparingTitle": "エクスポートの準備",
+        "rateLimitedFallback": "クールダウンが終了したら、別のエクスポートを開始できます。",
+        "rateLimitedTitle": "最近リクエストされたエクスポート",
+        "rateLimitedUntil": "{{duration}} で別のエクスポートを開始できます。",
+        "readyDescription": "ワークスペース データを含む ZIP ファイルを作成します。",
+        "readyTitle": "エクスポートの準備ができました"
+      },
+      "title": "データのエクスポート"
+    },
+    "lab": {
+      "actions": {
+        "resetAll": "すべてリセット",
+        "resetting": "リセット中…"
+      },
+      "description": "実験的機能のオンとオフを切り替えます。",
+      "documentTitle": "研究室",
+      "empty": {
+        "description": "このメンテナには機能スイッチがありません。",
+        "title": "機能スイッチなし"
+      },
+      "filters": {
+        "all": "すべて"
+      },
+      "groups": {
+        "connectors": "コネクター",
+        "other": "その他"
+      },
+      "maintainer": "メンテナ: {{maintainer}}",
+      "title": "研究室"
+    },
+    "models": {
+      "actions": {
+        "addModel": "モデルの追加",
+        "deleteModel": "モデルの削除",
+        "editModel": "モデルの編集",
+        "resetUsage": "使用量をリセットする",
+        "upgradePro": "Pro をアップグレードして使用する",
+        "upgradeToPro": "プロにアップグレード"
+      },
+      "deviceAuth": {
+        "claude": {
+          "approvalOpenError": "承認ページを開けませんでした。リンクを手動で使用し、ここにコードを貼り付けます。",
+          "authorizationCode": "認証コード",
+          "codePlaceholder": "Claude からコードを貼り付けます",
+          "codeRequired": "Claude コード認証コードを貼り付けて続行します。",
+          "connectedToast": "Claude コードが接続されました",
+          "connectTitle": "Claude コードを接続する",
+          "error": "Claude コード接続に失敗しました。もう一度やり直してください。",
+          "expired": "Claude コード接続セッションの有効期限が切れました。もう一度やり直してください。",
+          "instructions": "まず、[Claude 承認ページを開く] をクリックします。次に、Claude の {{brandName}} を承認し、承認後に表示される認証コードをコピーします。最後にそのコードをここに貼り付けて、「接続」をクリックします。",
+          "openApproval": "Claude 承認ページを開く",
+          "preparing": "準備中...",
+          "reconnectAction": "Claude コードを再接続します",
+          "reconnectTitle": "Claude コードを再接続します",
+          "signIn": "Claude でサインインします",
+          "submit": "接続する"
+        },
+        "codex": {
+          "approvalOpened": "承認ページが開きました。承認する前にデバイスコードをコピーしてください。",
+          "codeCopied": "デバイスコードがコピーされました。承認を待っています...",
+          "codeCopiedRetry": "デバイスコードがコピーされました。もう一度承認ページを開いてみてください。",
+          "connectedToast": "ChatGPT が接続されました",
+          "connectTitle": "Codex を接続します",
+          "copyAndOpen": "コードをコピーして承認ページを開く",
+          "copyAndOpenError": "デバイスコードをコピーできなかったか、承認ページを開けませんでした。コードを手動でコピーして、再試行してください。",
+          "copyError": "承認ページが開きましたが、デバイス コードがコピーされませんでした。承認する前に手動でコピーしてください。",
+          "deviceCode": "デバイスコード",
+          "error": "ChatGPT 接続に失敗しました。もう一度やり直してください。",
+          "expired": "Codex 接続セッションの有効期限が切れました。もう一度やり直してください。",
+          "freePlanRejected": "無料の ChatGPT プランでは、{{brandName}} 経由で Codex を使用できません。 Plus または Pro にアップグレードして、もう一度試してください。",
+          "instructions": "まず、「コードをコピーして承認ページを開く」をクリックします。次に、プロンプトが表示されたら、デバイス コードを OpenAI に貼り付けます。最後にアクセスを承認し、{{brandName}} が接続を完了するまでこのダイアログを開いたままにします。",
+          "invalidTokenFormat": "Codex は、{{brandName}} が認識できない形式のログイン トークンを生成しました。 Codex を更新して、再試行してください。",
+          "openError": "デバイスコードはコピーされましたが、承認ページを開けませんでした。もう一度やり直してください。",
+          "preparing": "準備中...",
+          "reconnectAction": "ChatGPT を再接続する",
+          "reconnectTitle": "Codex を再接続します",
+          "signIn": "ChatGPT でサインインする"
+        }
+      },
+      "personal": {
+        "actionForProvider": "{{action}} {{provider}}",
+        "claudeDescription": "Claude をサポートするモデル ルートの Claude コード ログインに接続します。",
+        "claudeTitle": "Claude コード OAuth",
+        "codexDescription": "Codex をサポートするモデル ルートの Codex デバイス ログインを使用して接続します。",
+        "codexTitle": "ChatGPT (Codex)",
+        "description": "自分の実行でのみ、自分の資格情報を使用して使用されます。",
+        "sectionTitle": "個人的な",
+        "status": {
+          "connected": "接続済み",
+          "connectedWithDetail": "接続されました ({{detail}})",
+          "fiveHour": "5時間",
+          "left": "{{percent}} 残り",
+          "stale": "注意",
+          "week": "週"
+        }
+      },
+      "picker": {
+        "balancedUse": "バランスよく使う",
+        "builtInModel": "内蔵モデル",
+        "byokHelp": "設定されたプロバイダーを使用します",
+        "fast": "速い",
+        "inheritDefault": "組織のデフォルトから継承",
+        "loadError": "モデルをロードできません。",
+        "loading": "モデルをロード中...",
+        "models": "モデル",
+        "moreCodexCredits": "Codex クレジットをさらに使用します。",
+        "noConfiguredModels": "設定されたモデルはありません",
+        "priceTiers": {
+          "balanced": "バランスの取れたコストとパフォーマンス",
+          "economy": "日常の単純なタスク向けのエコノミー層",
+          "frontier": "フロンティアフラッグシップモデル",
+          "premium": "最も困難なタスクに対応するプレミアムフロンティアモデル"
+        },
+        "prioritizeSpeed": "スピードを優先",
+        "pro": "プロ",
+        "providerLabels": {
+          "azureFoundryPortal": "Azure ファウンドリ ポータル",
+          "claudeCodeOauth": "Claude コード (OAuth トークン)",
+          "deepseek": "ディープシーク"
+        },
+        "runSpeed": "走行速度",
+        "standard": "標準"
+      },
+      "policies": {
+        "actionsFor": "{{model}} のアクション",
+        "apiKey": "APIキー",
+        "apiKeyDescription": "共有ワークスペースキー。チームが 1 つのアカウントを通じて請求する場合に最適です。",
+        "apiKeyPlaceholder": "API キーを入力してください",
+        "apiKeyRequired": "APIキーが必要です",
+        "builtIn": "内蔵",
+        "builtInDescription": "ワークスペース クレジットで使用量がカバーされます。",
+        "claudeSubscription": "Claude サブスクリプション",
+        "claudeSubscriptionDescription": "各メンバーは、独自の Pro、Max、または Team プランを接続します。",
+        "codexSubscription": "Codex サブスクリプション",
+        "codexSubscriptionDescription": "各メンバーは独自のプロまたはチーム プランを接続します。",
+        "defaultModel": "デフォルトモデル",
+        "defaultModelDescription": "タスクが独自のモデルを選択しない場合に使用されます。",
+        "dialogDescription": "メンバーがこのモデルにアクセスする方法を決定します。",
+        "getKey": "鍵を入手する",
+        "invalidRoute": "無効なルート",
+        "missingProvider": "プロバイダーがありません",
+        "model": "モデル",
+        "noAvailableModels": "利用可能なモデルはありません",
+        "providedBy": "提供元",
+        "provider": "プロバイダー",
+        "providerApiKey": "{{provider}} API キー",
+        "secretStored": "ワークスペースのシークレットに保存されます。",
+        "selectDefaultModel": "デフォルトのモデルを選択してください",
+        "selectModel": "モデルを選択してください",
+        "selectProvider": "プロバイダーを選択してください",
+        "workspaceDescription": "このワークスペース内の全員が利用できます。",
+        "workspaceTitle": "ワークスペース"
+      },
+      "reset": {
+        "confirmDescription": "Codex リセットを 1 回使用して、現在の使用状況ウィンドウをリセットします。 {{remaining}} があります。",
+        "progress": "リセット中...",
+        "remaining_one": "{{value}} 左にリセット",
+        "remaining_other": "{{value}} が左にリセットされます",
+        "remainingUnavailable": "リセットが利用できないままになる",
+        "title": "Codex の使用状況をリセットしますか?"
+      },
+      "stale": {
+        "claudeExpired": "Claude コード セッションの有効期限が切れました。続行するには再接続してください。",
+        "claudeFailed": "Claude コードの更新に失敗しました。再接続して再試行してください。",
+        "claudeTitle": "Claude コード セッションは再接続が必要です",
+        "codexExpired": "ChatGPT セッションの有効期限が切れました。続行するには再接続してください。",
+        "codexFailed": "ChatGPT の更新に失敗しました。再接続して再試行してください。",
+        "codexInvalidated": "ChatGPT セッションが取り消されました。再接続します。",
+        "codexReused": "ChatGPT セッションが他の場所で使用されました。再接続します。",
+        "codexTitle": "ChatGPTセッションは再接続が必要です"
+      },
+      "toasts": {
+        "disconnected": "{{provider}} が切断されました",
+        "policiesUpdated": "モデルプロバイダーの設定が更新されました",
+        "reset": "Codex 使用量のリセット",
+        "resetUnavailable": "Codex 使用状況のリセットは利用できません",
+        "resetUnneeded": "Codex の使用状況は現時点ではリセットする必要はありません"
+      },
+      "usage": {
+        "inDays": "{{days}}日後",
+        "inDaysHours": "{{days}}日{{hours}}時間後",
+        "inHours": "{{hours}}時間後",
+        "inHoursMinutes": "{{hours}}時間{{minutes}}分後",
+        "inLessThanMinute": "1分未満",
+        "inMinutes": "{{minutes}}分後",
+        "resetsAt": "{{date}}にリセット",
+        "resetsRaw": "リセット: {{value}}",
+        "resetsRelative": "{{relative}}にリセット",
+        "resetTimePassed": "リセット時刻を過ぎています",
+        "resetTimePassedTitle": "リセット時刻を過ぎています"
+      }
+    },
+    "preferences": {
+      "account": {
+        "manage": "管理",
+        "sectionTitle": "アカウントとセキュリティ"
+      },
+      "appearance": {
+        "description": "インターフェイスの外観を選択します。",
+        "sectionTitle": "外観",
+        "theme": {
+          "dark": "暗い",
+          "description": "お好みの配色",
+          "light": "ライト",
+          "system": "システム",
+          "title": "テーマ"
+        }
+      },
+      "debug": {
+        "capture": {
+          "description": "デバッグのために、HTTP ヘッダー名、選択された安全なヘッダー値、および本文をネットワーク ログにキャプチャします。",
+          "disabled": "障害者",
+          "enabled_one": "次回の {{count}} の実行で有効になります",
+          "enabled_other": "次回の {{count}} の実行に対して有効になります",
+          "title": "ネットワーク本体をキャプチャする"
+        },
+        "tab": "デバッグ"
+      },
+      "documentTitle": "設定",
+      "language": {
+        "description": "{{brandName}}のインターフェースで使用する言語を選択します",
+        "label": "言語",
+        "options": {
+          "english": "English",
+          "japanese": "日本語",
+          "portugueseBrazil": "Português (Brasil)"
+        },
+        "title": "言語"
+      },
+      "morningBrief": {
+        "description": "接続されている GitHub、Gmail、Google Calendar からのスケジュール、アクション アイテム、更新情報を含む毎日午前 7 時のメール",
+        "nextEmail": "次のメール: {{date}}",
+        "nextEmailInTimezone": "次のメール: {{date}} ({{timezone}})",
+        "notScheduled": "次のメール: まだスケジュールされていません — スイッチをオフにしてからオンにし、スケジュールを変更してください",
+        "sending": "送信中...",
+        "sendNow": "今すぐ送信",
+        "title": "モーニングブリーフ",
+        "triggeredToast": "モーニング ブリーフがトリガーされ、すぐにメールが届きます"
+      },
+      "pageDescription": "外観とエージェントの実行時の設定を管理する",
+      "pageTitle": "設定",
+      "send": {
+        "cmdEnter": "⌘ 入力してください",
+        "cmdEnterDescription": "⌘/Ctrl+Enter を押して送信し、Enter を押して改行します",
+        "description": "チャットでメッセージを送信する方法を選択します。",
+        "enter": "入力してください",
+        "enterDescription": "Enter を押して送信し、Shift+Enter を押して改行します",
+        "sectionTitle": "入力してください",
+        "title": "メッセージを送信する"
+      },
+      "tabs": {
+        "appearance": "外観",
+        "models": "パーソナルモデル",
+        "timezone": "タイムゾーン"
+      },
+      "timezone": {
+        "description": "表示され、オートメーションの実行に使用される時間。",
+        "rowDescription": "エージェントは実行中にこのタイムゾーンを使用します",
+        "rowTitle": "タイムゾーン",
+        "sectionTitle": "タイムゾーン",
+        "zones": {
+          "alaska": "アラスカ時間 (AKT)",
+          "auckland": "ニュージーランド時間 (NZST)",
+          "berlin": "中央ヨーロッパ時間 (CET)",
+          "brasilia": "ブラジリア時間 (BRT)",
+          "central": "中部標準時 (CT)",
+          "dubai": "湾岸標準時 (GST)",
+          "eastern": "東部時間 (ET)",
+          "hawaii": "ハワイ時間 (HST)",
+          "india": "インド標準時 (IST)",
+          "london": "ロンドン (GMT/BST)",
+          "losAngeles": "太平洋時間 (PT)",
+          "moscow": "モスクワ時間 (MSK)",
+          "mountain": "山岳時間 (MT)",
+          "paris": "パリ (中央ヨーロッパ時間)",
+          "seoul": "韓国標準時 (KST)",
+          "shanghai": "中国標準時 (CST)",
+          "singapore": "シンガポール時間 (SGT)",
+          "sydney": "オーストラリア東部時間 (AET)",
+          "tokyo": "日本標準時 (JST)",
+          "toronto": "トロント（ET）",
+          "utc": "UTC",
+          "vancouver": "バンクーバー（PT）"
+        }
+      }
+    },
+    "shared": {
+      "cancel": "キャンセル",
+      "close": "閉じる",
+      "connect": "接続する",
+      "connecting": "接続中...",
+      "delete": "削除",
+      "discard": "破棄",
+      "disconnect": "切断する",
+      "loading": "読み込み中",
+      "moreOptions": "その他のオプション",
+      "reconnect": "再接続",
+      "remove": "削除",
+      "replace": "交換する",
+      "save": "保存",
+      "saveChanges": "変更を保存する",
+      "saving": "保存中..."
+    },
+    "workspace": {
+      "danger": {
+        "delete": {
+          "button": "ワークスペースの削除",
+          "confirmDescription": "これにより、{{workspace}} とそのすべてのデータが完全に削除されます。この操作は元に戻すことができません。確認のためにワークスペース名を入力します。",
+          "description": "このワークスペースとそのすべてのデータを完全に削除します。この操作は元に戻すことができません。",
+          "progress": "削除中...",
+          "title": "ワークスペースの削除",
+          "titleQuestion": "ワークスペースを削除しますか?"
+        },
+        "leave": {
+          "confirmDescription": "このワークスペースにはアクセスできなくなります。管理者から再度招待された場合にのみ、再参加できます。",
+          "description": "このワークスペースとそのリソースにアクセスできなくなります。",
+          "progress": "出発中...",
+          "title": "ワークスペースを離れる",
+          "titleQuestion": "ワークスペースを離れますか?"
+        },
+        "sectionTitle": "危険な操作"
+      },
+      "members": {
+        "actionsFor": "{{email}} のアクション",
+        "addMember": "メンバーを追加",
+        "admin": "管理者",
+        "empty": "メンバーがいません",
+        "emptySearch": "メンバーが見つかりませんでした",
+        "invite": {
+          "description": "このワークスペースに参加するための招待状を送信します。",
+          "emailPlaceholder": "email@example.com",
+          "invalidEmail": "有効なメールアドレスを入力してください",
+          "progress": "送信中...",
+          "roleLabel": "役割",
+          "send": "招待状を送信する",
+          "title": "メンバーを招待する"
+        },
+        "joined": "参加しました",
+        "joinRequests": "参加リクエスト",
+        "member": "メンバー",
+        "membershipRequest": {
+          "acceptTitle": "リクエストを受け入れる",
+          "rejectTitle": "リクエストを拒否する",
+          "role": "リクエスト"
+        },
+        "pending": "保留中",
+        "remove": {
+          "action": "ワークスペースから削除",
+          "confirmDescription": "{{email}} はこのワークスペースから削除され、すべてのリソースにアクセスできなくなります。",
+          "progress": "削除中...",
+          "title": "メンバーを削除しますか?"
+        },
+        "revoke": {
+          "action": "招待を取り消す",
+          "button": "取り消し",
+          "confirmDescription": "{{email}} への招待はキャンセルされます。この招待状を使用して参加することはできなくなります。",
+          "progress": "取り消し中...",
+          "title": "招待を取り消しますか?"
+        },
+        "role": "役割",
+        "roleActions": {
+          "makeAdmin": "管理者にする",
+          "makeMember": "メンバーにする"
+        },
+        "search": "検索",
+        "selfDemote": {
+          "action": "メンバーに切り替える",
+          "confirm": "確認する",
+          "description": "通常会員となり、管理者権限が失われます。別の管理者があなたを再度昇格させる必要があります。",
+          "progress": "切り替え中...",
+          "title": "メンバーに切り替えますか？"
+        },
+        "user": "ユーザー",
+        "you": "あなた"
+      },
+      "profile": {
+        "logo": {
+          "description": "アプリ全体に表示されるワークスペース アバター",
+          "fallbackAlt": "ワークスペース",
+          "title": "ロゴ",
+          "upload": "ロゴをアップロードする"
+        },
+        "name": {
+          "description": "このワークスペースを識別するために使用されます",
+          "placeholder": "ワークスペース名",
+          "title": "名前"
+        },
+        "sectionTitle": "プロフィール"
+      },
+      "toasts": {
+        "deleted": "ワークスペースが削除されました",
+        "invitationRevoked": "招待が取り消されました",
+        "invitationSent": "招待状が {{email}} に送信されました",
+        "left": "ワークスペースを離れました",
+        "memberRemoved": "{{email}} を削除しました",
+        "membershipRequestAccepted": "メンバーシップリクエストを受け付けました",
+        "membershipRequestRejected": "メンバーシップリクエストが拒否されました",
+        "roleUpdated": "{{email}} のロールを更新しました",
+        "updated": "ワークスペースが更新されました"
+      },
+      "unsaved": {
+        "message": "未保存の変更があります"
+      },
+      "validation": {
+        "imageUnreadable": "画像ファイルを読み取れませんでした",
+        "logoTooLarge": "ロゴが大きすぎます ({{width}}×{{height}}px)。最大サイズは {{maximum}}×{{maximum}}px です。",
+        "logoTooSmall": "ロゴが小さすぎます ({{width}}×{{height}}px)。最小サイズは {{minimum}}×{{minimum}}px です。"
+      }
+    }
+  },
+  "shared": {
+    "breadcrumb": "ブレッドクラム",
+    "errorBoundary": {
+      "contactSupport": "サポート",
+      "description": "もう一度試すか、お問い合わせください",
+      "help": "私たちはお手伝いします",
+      "title": "おっと！何かが横に逸れた"
+    },
+    "forceUpgrade": {
+      "action": "リフレッシュ",
+      "description": "このバージョンの {{brandName}} はサポートされなくなりました。更新して最新バージョンをロードします。",
+      "title": "アップデートが必要です"
+    },
+    "notFound": {
+      "description": "お探しのページは存在しません。",
+      "title": "ページが見つかりません"
+    }
+  },
+  "usage": {
+    "automations": {
+      "empty": "この期間にオートメーションの利用はありません",
+      "more_one": "ほか{{value}}件のオートメーション",
+      "more_other": "ほか{{value}}件のオートメーション",
+      "summary_one": "{{automations}}で{{credits}}を使用",
+      "summary_other": "{{automations}}で{{credits}}を使用",
+      "title": "オートメーション"
+    },
+    "chart": {
+      "ariaLabel": "クレジットの合計",
+      "credits": "クレジット",
+      "groupBy": {
+        "agent": "エージェント",
+        "source": "ソース"
+      },
+      "noUsage": "利用なし",
+      "showDetails": "{{date}} の使用状況の詳細を表示する"
+    },
+    "chats": {
+      "clickToOpen": "クリックして開きます",
+      "empty": "この期間にチャットの利用はありません",
+      "more_one": "ほか{{value}}件の会話",
+      "more_other": "ほか{{value}}件の会話",
+      "summary_one": "{{chats}}で{{credits}}を使用",
+      "summary_other": "{{chats}}で{{credits}}を使用",
+      "title": "チャット",
+      "untitled": "(無題)"
+    },
+    "displayNames": {
+      "auto": "自動",
+      "finance": "金融",
+      "maps": "地図",
+      "peopleSearch": "人物検索",
+      "usage": "使用量",
+      "weather": "天気",
+      "webFetch": "ウェブフェッチ",
+      "webSearch": "ウェブ検索"
+    },
+    "kinds": {
+      "connector": "コネクター",
+      "image": "画像",
+      "model": "モデル",
+      "other": "その他",
+      "video": "動画"
+    },
+    "page": {
+      "description": "チャット、オートメーション、チャンネル別のクレジット使用量。",
+      "loadError": "使用量のインサイトを読み込めませんでした。しばらくしてからもう一度お試しください。",
+      "title": "使用量"
+    },
+    "range": {
+      "ariaLabel": "日付範囲",
+      "billingPeriod": "請求期間",
+      "last24Hours": "過去 24 時間",
+      "last28Days": "過去 28 日間",
+      "last30Days": "過去 30 日間",
+      "last7Days": "過去7日間",
+      "selectedDay": "選択した日",
+      "today": "今日",
+      "yesterday": "昨日"
+    },
+    "records": {
+      "emptyBillingPeriod": "この請求期間の利用はありません。",
+      "emptyRange": "この期間の利用はありません。",
+      "loadError": "使用量を読み込めませんでした。",
+      "loadMore": "さらに読み込む",
+      "myUsage": "自分の使用量",
+      "noActiveBillingPeriod": "有効な請求期間はありません。",
+      "teamLoadError": "チームの使用量を読み込めませんでした。",
+      "teamUsage": "チームの使用量",
+      "untitled": "(無題)"
+    },
+    "sources": {
+      "agent": "エージェント",
+      "automation": "オートメーション",
+      "chat": "チャット",
+      "cli": "CLI",
+      "email": "メール",
+      "github": "GitHub",
+      "other": "その他",
+      "others": "その他",
+      "phone": "電話",
+      "slack": "Slack",
+      "teams": "Microsoft Teams",
+      "telegram": "Telegram",
+      "unknown": "不明"
+    },
+    "units": {
+      "automation_one": "{{value}}件のオートメーション",
+      "automation_other": "{{value}}件のオートメーション",
+      "chat_one": "{{value}}件の会話",
+      "chat_other": "{{value}}件の会話",
+      "credit_one": "{{value}}クレジット",
+      "credit_other": "{{value}}クレジット"
+    }
+  },
+  "workflows": {
+    "automations": {
+      "calendar": {
+        "addAction": "カレンダーのオートメーションを追加する",
+        "addAria": "Google Calendar オートメーションを追加",
+        "addDescriptionCancelled": "Google Calendar イベントがキャンセルされたときに、このワークフローを実行します。",
+        "addDescriptionCreated": "新しい Google Calendar イベントが作成されたときに、このワークフローを実行します。",
+        "addDescriptionUpdated": "Google Calendar イベントが更新されたときにこのワークフローを実行します。",
+        "addTitle": "Google Calendar オートメーションを追加",
+        "calendarId": "カレンダーID",
+        "calendarIdPlaceholder": "プライマリー",
+        "cancelledDescription": "カレンダーイベントがキャンセルされたときに実行されます。",
+        "cancelledRule": "カレンダー {{calendar}} イベントがキャンセルされた場合",
+        "cancelledTitle": "Google Calendar イベントがキャンセルされました",
+        "createdDescription": "カレンダーイベントの作成時に実行します。",
+        "createdRule": "カレンダー {{calendar}} が新しいイベントを取得したとき",
+        "createdTitle": "Google Calendar イベントが作成されました",
+        "summary": "カレンダー {{calendar}}",
+        "updatedDescription": "カレンダーイベントが更新されたときに実行します。",
+        "updatedRule": "カレンダー {{calendar}} イベントが更新されたとき",
+        "updatedTitle": "Google Calendar イベントが更新されました"
+      },
+      "chat": {
+        "addAction": "チャットオートメーションを追加する",
+        "addAria": "チャット実行完了オートメーションを追加",
+        "addDescription": "監視されているチャット スレッドの実行が終了したら、このワークフローを実行します。",
+        "addTitle": "チャットオートメーションを追加する",
+        "anyOutput": "任意の出力",
+        "anyStatus": "任意の終了ステータス",
+        "patternHint": "オプションの * 実行の最終応答と照合されるワイルドカード。任意の出力に一致させるには、空のままにしておきます。",
+        "patternLabel": "出力パターン",
+        "patternPlaceholder": "*デプロイに失敗しました*",
+        "runFinishedDescription": "チャット スレッドの 1 つでの実行が終了したときに実行します。",
+        "runFinishedTitle": "チャット実行が終了しました",
+        "statusCancelled": "キャンセルされました",
+        "statusCompleted": "完了しました",
+        "statusesHint": "失敗した実行やキャンセルされた実行には応答テキストがないため、出力パターンがそれらと一致することはありません。",
+        "statusesLabel": "終了ステータス",
+        "statusFailed": "失敗しました",
+        "threadIdHint": "チャットを開き、URL からスレッド ID をコピーします。スレッドはあなた自身のチャットの 1 つである必要があります。",
+        "threadIdLabel": "チャットスレッドID",
+        "viewDescription": "このオートメーションのフィルターは作成後に修正されます。",
+        "viewTitle": "チャット実行のオートメーションが完了しました",
+        "watchedThreadLabel": "チャットスレッドを見ました"
+      },
+      "common": {
+        "addAutomation": "オートメーションを追加する",
+        "automation": "オートメーション",
+        "cancel": "キャンセル",
+        "chooseAutomation": "このワークフローを開始するにはオートメーションを選択してください。",
+        "deleteAutomation": "オートメーションの削除",
+        "disable": "{{title}} を無効にする",
+        "disabledPaidPlan": "無効 — 有料プランが必要です",
+        "done": "完了",
+        "editAutomation": "オートメーションの編集",
+        "enable": "{{title}} を有効にする",
+        "eventAutomation": "イベントのオートメーション",
+        "moreActions": "さらなるアクション",
+        "noAutomations": "オートメーションなし",
+        "noAutomationsDescription": "オートメーションを追加して、オートメーションが起動するたびにこのワークフローを実行します。",
+        "runNow": "今すぐ実行",
+        "schedule": "スケジュール",
+        "scheduleAutomation": "スケジュールのオートメーション",
+        "updateDescription": "このオートメーションを更新します。",
+        "webhookAutomation": "Webhook のオートメーション"
+      },
+      "duration": {
+        "hour_one": "{{count}} 時間",
+        "hour_other": "{{count}} 時間",
+        "minute_one": "{{count}} 分",
+        "minute_other": "{{count}} 分",
+        "second_one": "{{count}} 秒",
+        "second_other": "{{count}} 秒"
+      },
+      "github": {
+        "accountConnect": "GitHub を接続します",
+        "accountRequired": "Me を使用するには、GitHub アカウントを接続します。",
+        "actorAnyone": "誰でも",
+        "actorMe": "私",
+        "actors": "俳優",
+        "actorsPlaceholder": "オクトキャット、ディペンダボット[ボット]",
+        "addLabelAction": "ラベルのオートメーションを追加する",
+        "addLabelAria": "GitHub ラベルのオートメーションを追加",
+        "addLabelDescription": "GitHub ラベルが適用されている場合は、このワークフローを実行します。",
+        "addLabelTitle": "GitHub ラベルのオートメーションを追加",
+        "addWebhookAction": "オートメーションを追加する",
+        "addWebhookAria": "{{title}} オートメーションを追加",
+        "addWebhookDescription": "一致する GitHub Webhook イベントが到着したときに、このワークフローを実行します。",
+        "addWorkflowAction": "ワークフローのオートメーションを追加する",
+        "addWorkflowAria": "GitHub ワークフローオートメーションを追加",
+        "addWorkflowDescription": "一致する GitHub アクション ワークフローの実行が完了したら、このワークフローを実行します。",
+        "addWorkflowTitle": "GitHub ワークフローオートメーションを追加",
+        "aJob": "GitHub ワークフロー ジョブ",
+        "any": "どれでも",
+        "anyAuthor": "どの作者でも",
+        "anyComment": "任意のコメント",
+        "anyConclusion": "結論は何でもいい",
+        "anyDeploymentState": "あらゆる展開状態",
+        "anyEnvironment": "あらゆる環境",
+        "anyJob": "どんな仕事でも",
+        "anyRepository": "任意のリポジトリ",
+        "anyResult": "いかなる結果も",
+        "anyReview": "あらゆるレビュー",
+        "anyReviewState": "任意のレビュー状態",
+        "anyWorkflow": "あらゆるワークフロー",
+        "apps": "GitHub アプリ",
+        "appsPlaceholder": "ヴェルセル、12345",
+        "authorsPlaceholder": "オクトキャット、e7h4n",
+        "authorsSummary": "著者 {{values}}",
+        "aWorkflow": "GitHub ワークフロー",
+        "baseBranches": "ベースブランチ",
+        "branches": "支店",
+        "branchesPlaceholder": "メイン、リリース",
+        "commentPrefixes": "コメント接頭辞",
+        "commentPrefixesPlaceholder": "/zero、/verify、/deploy",
+        "conclusions": "結論",
+        "conclusionsSummary": "結論 {{values}}",
+        "creators": "クリエイター",
+        "creatorsPlaceholder": "オクトキャット、12345",
+        "deploymentStates": "展開状態",
+        "deploymentStatesSummary": "デプロイメント状態 {{values}}",
+        "deploymentStatusDescription": "一致する展開ステータスが作成されたときに実行します。",
+        "deploymentStatusRule": "一致する GitHub デプロイメント ステータスが作成されたとき",
+        "deploymentStatusTitle": "GitHub デプロイメントステータスが作成されました",
+        "editLabel": "ラベルを編集する",
+        "editWebhookFilters": "{{title}} フィルターを編集する",
+        "editWorkflowFilters": "GitHub ワークフロー フィルターを編集する",
+        "environments": "環境",
+        "environmentsPlaceholder": "プレビュー、制作",
+        "environmentsSummary": "環境 {{values}}",
+        "events": "イベントのトリガー",
+        "eventsPlaceholder": "プッシュ、プルリクエスト、ワークフローディスパッチ",
+        "filterHelp": "任意の値に一致させるには、フィルターを空のままにしておきます。複数の値はカンマで区切ります。",
+        "headBranches": "頭枝",
+        "headBranchesPlaceholder": "機能/、依存ボット/",
+        "installAdminRequired": "組織管理者にインストールを依頼してください。",
+        "installApp": "GitHub アプリをインストールする",
+        "installedRequired": "GitHub はこのワークスペースにはインストールされていません。",
+        "issueCommentDescription": "一致する問題または PR コメントが作成されたときに実行します。",
+        "issueCommentRule": "一致する GitHub Issueまたはプル リクエストのコメントが作成されたとき",
+        "issueCommentTitle": "GitHub Issueのコメントが作成されました",
+        "issuesAndPullRequests": "問題とプルリクエスト",
+        "issuesOnly": "問題のみ",
+        "jobs": "求人",
+        "jobsPlaceholder": "テスト、ビルド",
+        "jobsSummary": "ジョブ {{values}}",
+        "labelAppliedDescription": "Issue または Pull Request がラベルを取得したときに実行します。",
+        "labelAppliedRule": "GitHub ラベル {{label}} が適用される場合",
+        "labelAppliedTitle": "GitHub ラベルが適用されました",
+        "labelName": "レーベル名",
+        "labelOnlySummary": "ラベル {{label}}",
+        "labelPlaceholder": "トリアージ",
+        "labelSummary": "ラベル {{label}} · {{subject}} · アクター {{actor}}",
+        "loadError": "GitHub 設定をロードできませんでした。",
+        "nonProductionOnly": "非実稼働のみ",
+        "option": {
+          "actionRequired": "アクションが必要です",
+          "approved": "承認済み",
+          "cancelled": "キャンセルされました",
+          "changesRequested": "変更要求",
+          "commented": "コメント付き",
+          "error": "エラー",
+          "failure": "失敗",
+          "inactive": "非アクティブ",
+          "inProgress": "進行中",
+          "neutral": "ニュートラル",
+          "pending": "保留中",
+          "queued": "キューに入れられました",
+          "skipped": "スキップされました",
+          "stale": "古い",
+          "startupFailure": "起動失敗",
+          "success": "成功",
+          "timedOut": "タイムアウトしました",
+          "waiting": "待っています"
+        },
+        "productionEnvironment": "生産環境",
+        "productionOnly": "本番のみ",
+        "pullRequestsOnly": "プルリクエストのみ",
+        "refs": "参照",
+        "refsPlaceholder": "メイン、v1.0.0",
+        "repositories": "リポジトリ",
+        "repositoriesPlaceholder": "vm0-ai/vm0、所有者/別のリポジトリ",
+        "repositoriesSummary": "リポジトリ {{values}}",
+        "reviewDescription": "一致するレビューが送信されたときに実行されます。",
+        "reviewRule": "一致する GitHub プル リクエストのレビューが送信されたとき",
+        "reviewStates": "レビュー状態",
+        "reviewTitle": "GitHub プル リクエストのレビューが送信されました",
+        "runnerGroups": "ランナーグループ",
+        "runnerGroupsPlaceholder": "デフォルト、本番環境",
+        "runnerLabels": "ランナーラベル",
+        "runnerLabelsPlaceholder": "セルフホスト型、Linux",
+        "saveFilters": "フィルターを保存する",
+        "selectNoneAny": "任意の値と一致させるには、[なし] を選択します。",
+        "selectNoneConclusion": "完了した結論に一致する場合は、[なし] を選択します。",
+        "startedBy": "によって開始されました",
+        "subject": "件名",
+        "trustedAuthors": "信頼できる著者",
+        "updateLabelAria": "GitHub ラベルのオートメーションを更新する",
+        "updateWebhookAria": "{{title}} オートメーションの更新",
+        "updateWorkflowAria": "GitHub ワークフローオートメーションを更新します",
+        "withConclusions": " {{values}} を使用",
+        "workflowJobDescription": "一致するアクション ジョブが完了すると実行されます。",
+        "workflowJobRule": "{{jobs}} が完了したとき",
+        "workflowJobTitle": "GitHub ワークフロー ジョブが完了しました",
+        "workflowRunDescription": "一致するアクション ワークフローの実行が完了すると実行されます。",
+        "workflowRunRule": "{{workflows}} が完了すると{{conclusions}}",
+        "workflowRunTitle": "GitHub ワークフローが完了しました",
+        "workflows": "GitHub ワークフロー",
+        "workflowsPlaceholder": "ターボ、.github/workflows/release.yml",
+        "workflowsShortPlaceholder": "ターボ、リリース",
+        "workflowsSummary": "ワークフロー {{values}}"
+      },
+      "gmail": {
+        "addCondition": "条件の追加",
+        "addLabelAction": "ラベルのオートメーションを追加する",
+        "addLabelAria": "Gmail ラベルのオートメーションを追加",
+        "addLabelDescription": "名前付き Gmail ラベルが適用されるときに、このワークフローを実行します。",
+        "addLabelTitle": "Gmail ラベルのオートメーションを追加",
+        "addMessageAction": "Gmail オートメーションを追加",
+        "addMessageAria": "Gmail オートメーションを追加",
+        "addMessageDescription": "一致するメッセージが到着したら、このワークフローを実行します。",
+        "addMessageTitle": "Gmail オートメーションを追加",
+        "allInboundMessages": "すべての受信メッセージ",
+        "anyMessageRule": "Gmail メッセージが到着したとき",
+        "conditionField": "条件 {{number}} フィールド",
+        "conditionOperator": "条件 {{number}} 演算子",
+        "editLabel": "ラベルを編集する",
+        "editMatch": "マッチを編集",
+        "enterValue": "値を入力してください",
+        "field": {
+          "body": "本体",
+          "cc": "Cc",
+          "from": "から",
+          "subject": "件名",
+          "threadId": "スレッドID",
+          "to": "に"
+        },
+        "labelAppliedRule": "Gmail ラベル {{label}} が適用される場合",
+        "labelAppliedTitle": "Gmail ラベルが適用されました",
+        "labelName": "レーベル名",
+        "labelPlaceholder": "サポート",
+        "labelSummary": "ラベル {{label}}",
+        "messageMatchesRule": "Gmail メッセージが {{summary}} と一致する場合",
+        "newMessageDescription": "一致するメールからこのワークフローを実行します。",
+        "newMessageTitle": "Gmail 新しいメッセージ",
+        "operator": {
+          "contains": "含まれています",
+          "containsAny": "どれも含まれます",
+          "doesNotContain": "含まれていない",
+          "is": "です"
+        },
+        "removeCondition": "条件 {{number}} を削除します",
+        "saveLabel": "ラベルを保存",
+        "saveMatch": "試合を保存する",
+        "summary": {
+          "contains": "{{field}} には {{value}} が含まれます",
+          "containsAny": "{{field}} には {{value}} のいずれかが含まれます",
+          "doesNotContain": "{{field}} には {{value}} が含まれません",
+          "doesNotContainAny": "{{field}} には {{value}} が含まれていません",
+          "threadId": "スレッド ID は {{value}} です"
+        },
+        "updateLabelAria": "Gmail ラベルのオートメーションを更新する",
+        "updateMessageAria": "Gmail の新しいメッセージオートメーションを更新します"
+      },
+      "meet": {
+        "addAction": "Meet のオートメーションを追加する",
+        "addAria": "Google トランスクリプトのオートメーションを追加",
+        "addDescription": "Google Meet が、接続されている Google Meet アカウントによって開催された会議のトランスクリプトの生成を完了したときに、このワークフローを実行します。",
+        "addTitle": "Google Meet オートメーションを追加",
+        "rule": "Google Meet がトランスクリプトの生成を完了したとき",
+        "summary": "あなたが主催する会議",
+        "transcriptHint": "会議の文字起こしを有効にする必要があります。 Meet がトランスクリプトを作成しない場合、このオートメーションは実行されません。",
+        "transcriptReadyDescription": "Meet がトランスクリプトの生成を完了したときに実行します。",
+        "transcriptReadyTitle": "Google 会議記録の準備が完了しました"
+      },
+      "notion": {
+        "addAction": "Notion オートメーションを追加",
+        "childPageAddAria": "Notion 子ページオートメーションを追加",
+        "childPageDescription": "直接の子ページが作成されるときに実行します。",
+        "childPageDialogDescription": "直接の子ページが Notion ページの下に作成されるときに、このワークフローを実行します。",
+        "childPageRule": "{{title}} の下に Notion 子ページが作成された場合",
+        "childPageRuleGeneric": "Notion 子ページが作成されるとき",
+        "childPageTitle": "新しい Notion 子ページ",
+        "configuredDatabase": "構成されたデータベース",
+        "configuredPage": "設定されたページ",
+        "configuredParentPage": "設定された親ページ",
+        "contentUpdatedAddAria": "Notion ページのコンテンツ更新のオートメーションを追加",
+        "contentUpdatedDescription": "ページまたはデータベース項目のコンテンツが変更されたときに実行します。",
+        "contentUpdatedDialogDescription": "Notion ページ コンテンツの更新が完了したら、このワークフローを実行します。",
+        "contentUpdatedTitle": "Notion ページのコンテンツが更新されました",
+        "database": "データベース",
+        "databaseItemAddAria": "Notion データベース項目のオートメーションを追加",
+        "databaseItemDescription": "ページが Notion データベースに追加されるときに実行されます。",
+        "databaseItemDialogDescription": "ページが Notion データベースに追加されるときに、このワークフローを実行します。",
+        "databaseItemRule": "Notion データベース {{title}} が新しいアイテムを取得したとき",
+        "databaseItemRuleGeneric": "Notion データベースが新しいアイテムを取得したとき",
+        "databaseItemTitle": "新しい Notion データベース項目",
+        "databaseSummary": "データベース {{title}}",
+        "databaseUpdatedRule": "Notion データベース {{title}} アイテムのコンテンツが更新されたとき",
+        "databaseUpdatedRuleGeneric": "Notion データベース項目の内容が更新されたとき",
+        "databaseUrl": "データベースのURL",
+        "databaseUrlPlaceholder": "https://www.notion.so/...",
+        "page": "ページ",
+        "pageSummary": "ページ {{title}}",
+        "pageUpdatedRule": "Notion ページ {{title}} のコンテンツが更新されたとき",
+        "pageUpdatedRuleGeneric": "Notion ページのコンテンツが更新されたとき",
+        "pageUrl": "ページURL",
+        "pageUrlPlaceholder": "https://www.notion.so/workspace/Page-title-...",
+        "parentPageSummary": "親ページ {{title}}",
+        "parentPageUrl": "親ページのURL",
+        "scope": "範囲"
+      },
+      "picker": {
+        "calendar": "カレンダー",
+        "email": "メール",
+        "integrations": "統合",
+        "notion": "Notion",
+        "schedule": "スケジュール"
+      },
+      "rules": {
+        "inboundWebhook": "インバウンド Webhook を受信したとき"
+      },
+      "schedule": {
+        "addIntervalAction": "間隔を追加",
+        "addIntervalAria": "間隔のオートメーションを追加する",
+        "addIntervalDescription": "このワークフローを実行する頻度を選択します。",
+        "addIntervalTitle": "間隔のオートメーションを追加する",
+        "addOnceAction": "1 回限りの実行を追加する",
+        "addOnceAria": "ワンタイムオートメーションを追加する",
+        "addOnceDescription": "このワークフローを 1 回実行する日時を選択します。",
+        "addOnceTitle": "ワンタイムオートメーションを追加する",
+        "addScheduleAction": "スケジュールを追加",
+        "addScheduleAria": "スケジュールのオートメーションを追加する",
+        "addScheduleDescription": "このワークフローをいつ実行するかを選択します。",
+        "addScheduleTitle": "スケジュールのオートメーションを追加する",
+        "cronExpression": "クロン式",
+        "customCron": "カスタム cron",
+        "dayOfMonth": "月の日",
+        "dayOfWeek": "曜日",
+        "displaysIn": "{{timezone}} に表示されます",
+        "editSchedule": "スケジュールを編集する",
+        "every": "毎",
+        "everyDay": "毎日",
+        "everyDayAt": "毎日 {{time}} で",
+        "everyMonth": "毎月",
+        "everyMonthAt": "毎月 {{day}} 日、{{time}}",
+        "everyWeek": "毎週",
+        "everyWeekAt": "毎週 {{time}} で",
+        "everyWeekday": "平日毎日",
+        "everyWeekdayAt": "毎週平日 {{time}}",
+        "everyWeekOn": "毎週 {{days}} の {{time}}",
+        "frequencyIntervalDescription": "このワークフローは一定の間隔で実行します。",
+        "frequencyIntervalTitle": "間隔",
+        "frequencyOnceDescription": "このワークフローは、指定した日時に 1 回実行します。",
+        "frequencyOnceTitle": "1 回限りの実行",
+        "frequencyScheduleDescription": "このワークフローを時間ルールから実行します。",
+        "frequencyScheduleTitle": "予定時刻",
+        "hour": "時間",
+        "last": "最後",
+        "minute": "分",
+        "next": "次へ",
+        "noRunsYet": "まだ実行はありません",
+        "noUpcomingRun": "今後の実行はありません",
+        "onceOn": "{{date}} の {{time}} で 1 回",
+        "repeatEvery": "{{interval}} ごと",
+        "repeats": "繰り返し",
+        "runAt": "実行時刻",
+        "saveSchedule": "スケジュールの保存",
+        "time": "時間 ({{timezone}})",
+        "updateScheduleAria": "更新スケジュールのオートメーション"
+      },
+      "strapi": {
+        "addAction": "Strapi オートメーションを追加",
+        "addAria": "Strapi エントリ公開オートメーションを追加",
+        "addDescription": "ローカライズされたパブリッシュ イベントの一致が解決したら、このワークフローを実行します。",
+        "addTitle": "Strapi オートメーションを追加",
+        "configure": "Strapi を構成する",
+        "connectFirst": "このオートメーションを作成する前に、Strapi インスタンスを接続してください。",
+        "contentType": "コンテンツタイプ UID (オプション)",
+        "contentTypeAny": "あらゆるコンテンツタイプ",
+        "contentTypePlaceholder": "api::article.article",
+        "entryPublishedDescription": "一致する Strapi エントリが公開された後に実行します。",
+        "entryPublishedTitle": "Strapi エントリが公開されました",
+        "instance": "Strapi インスタンス",
+        "locale": "ロケール (オプション)",
+        "localeAny": "任意のロケール",
+        "localeHint": "同じドキュメントのすべてのローカライズされたパブリッシュ イベントを 1 つのワークフロー実行に結合するには、ロケールを空白のままにします。",
+        "localePlaceholder": "jp",
+        "localeSummary": "ロケール {{locale}}",
+        "rule": "一致する Strapi エントリが公開されたとき"
+      },
+      "types": {
+        "chat": "チャット",
+        "github": "GitHub",
+        "gmail": "Gmail",
+        "googleCalendar": "Google Calendar",
+        "googleMeet": "Google 会う",
+        "notion": "Notion",
+        "strapi": "Strapi",
+        "webhook": "Webhook"
+      },
+      "webhook": {
+        "addDescription": "このワークフローの署名付きエンドポイントを作成します。",
+        "addTitle": "Webhook オートメーションを追加する",
+        "copy": "コピー",
+        "create": "Webhook の作成",
+        "createDescription": "このワークフローは署名付き POST から実行します。",
+        "createTitle": "Webhook",
+        "hidden": "Webhook URL 非表示",
+        "paidBadge": "チーム",
+        "reveal": "シークレットを明らかにする",
+        "revealDescription": "{{suffix}} で終わる署名付きエンドポイントとシークレットを明らかにします",
+        "revealTitle": "Webhook シークレットを表示する",
+        "secret": "署名のシークレット",
+        "secretHiddenHint": "シークレット値はオートメーションリストから非表示になります。この Webhook を構成またはテストする必要がある場合にのみ、それらを公開してください。",
+        "secretOneTimeHint": "署名シークレットは作成後にのみ表示されます。",
+        "signedCurl": "サイン付きカール",
+        "upgrade": {
+          "adminHint": "ワークスペース管理者にアップグレードを依頼してください。",
+          "benefitDescription": "外部システムからワークフローを開始する署名付きエンドポイントを作成します。",
+          "benefitTitle": "安全な受信ワークフローのオートメーション",
+          "description": "Webhook のオートメーションには、チーム ワークスペースまたはカスタム ワークスペースが必要です。",
+          "title": "Webhook オートメーションのためのアップグレード",
+          "upgradeAction": "チームにアップグレード"
+        },
+        "url": "Webhook URL"
+      }
+    },
+    "common": {
+      "agents": "エージェント",
+      "cancel": "キャンセル",
+      "close": "閉じる",
+      "copyWorkflow": "ワークフローをコピー",
+      "delete": "削除",
+      "deleteWorkflow": "ワークフローの削除",
+      "instructions": "指示",
+      "manual": "マニュアル",
+      "others": "その他",
+      "pinned": "ピン留め済み",
+      "private": "非公開",
+      "public": "公開",
+      "settings": "設定",
+      "view": "見る",
+      "workflow": "ワークフロー",
+      "workflows": "ワークフロー"
+    },
+    "composer": {
+      "nextMessage": "次のメッセージを入力してください…",
+      "placeholder": "ワークフローの自動化、タスクの管理を依頼してください..."
+    },
+    "createDialog": {
+      "addAutomation": "オートメーションを追加する",
+      "chooseAgentAutomation": "このオートメーションのエージェントを選択してください",
+      "chooseAgentWorkflow": "このワークフローのエージェントを選択します。",
+      "chooseWorkflow": "自動化するワークフローを選択するか、チャットでワークフローを作成します。",
+      "createAutomation": "オートメーションの作成",
+      "createInChat": "チャットで作成",
+      "createInChatDescription": "ワークフローがまだ適合していない場合は、会話から始めます。",
+      "createWorkflow": "ワークフローの作成",
+      "noAgents": "まだエージェントがいません",
+      "noAgentsFound": "エージェントが見つかりませんでした",
+      "noWorkflows": "ワークフローはまだありません。続行するには、チャットで作成してください。"
+    },
+    "detail": {
+      "connectors": {
+        "action": {
+          "connect": "接続する",
+          "enable": "エージェントに対して有効にする",
+          "reconnect": "再接続",
+          "reviewPermissions": "権限の確認"
+        },
+        "aria": "コネクタの準備状況",
+        "check": "コネクタを確認してください",
+        "checkAgain": "もう一度確認してください",
+        "checking": "確認中...",
+        "description": "このワークフローに必要な組み込みコネクタとその準備が整っているかどうかを確認します。",
+        "empty": "必要なコネクタが検出されませんでした",
+        "error": {
+          "inputTooLong": "このワークフローは長すぎるため確認できません。名前、説明、指示を100,000文字以内にしてください。",
+          "retry": "コネクターを確認できませんでした。もう一度やり直してください。",
+          "timeout": "コネクタのチェックがタイムアウトしました。もう一度やり直してください。"
+        },
+        "saveFirst": "コネクタをチェックする前に変更を保存してください。",
+        "status": {
+          "connected": "接続済み",
+          "notConnected": "接続されていません",
+          "notEnabled": "このエージェントに対して有効ではありません",
+          "reconnect": "再接続が必要です",
+          "scopeMismatch": "権限の更新",
+          "unavailable": "現在利用不可"
+        },
+        "title": "コネクタの準備状況"
+      },
+      "copy": {
+        "agentFallback": "エージェント",
+        "copied": "{{agent}} にコピーされました",
+        "copyAndRemove": "コピーして削除する",
+        "description": "このワークフローを新しいプライベート ワークフローとして別のエージェントにコピーします。",
+        "moved": "{{agent}} に移動",
+        "moveDescription": "オリジナルは {{agent}} から削除されました。",
+        "noAgents": "他にエージェントはまだいません",
+        "privateReady": "プライベートコピーが完成しました。",
+        "removalAlert": "これにより、オリジナルが削除されます",
+        "removalNoAutomations": "このワークフローは {{agent}} から削除されます。",
+        "removalWithAutomations_one": "{{count}} オートメーションは {{agent}} で一時停止され、このワークフローは削除されます。",
+        "removalWithAutomations_other": "{{count}} オートメーションは {{agent}} で一時停止され、このワークフローは削除されます。",
+        "removeOriginal": "コピー後、{{agent}} から元のファイルを削除します",
+        "selectAgent": "エージェントを選択してください",
+        "title": "ワークフローをコピー",
+        "to": "コピー先"
+      },
+      "delete": {
+        "confirm": "{{title}} とバインドされたすべてのオートメーションが削除されます。",
+        "dangerDescription": "このワークフローとそのオートメーションを削除します。この操作は元に戻すことができません。",
+        "dangerTitle": "危険な操作",
+        "description": "これは危険な操作です。このワークフローを削除すると、他のユーザーが作成したオートメーションを含む、ワークフローにバインドされているすべてのオートメーションも削除されます。",
+        "title": "ワークフローの削除"
+      },
+      "files": {
+        "aria": "ワークフローファイル",
+        "deleteAria": "{{path}} を削除します",
+        "deleteSelected": "選択したファイルを削除します",
+        "fileContent": "ワークフローファイルの内容",
+        "filePlaceholder": "このマークダウン ファイルを編集...",
+        "instruction": "ワークフローの指示",
+        "instructionPlaceholder": "ワークフローの指示を書きます...",
+        "instructions": "指示",
+        "noContent": "このファイルには利用可能なコンテンツがありません。",
+        "sizeBytes": "{{size}} B",
+        "upload": "テキストファイルをアップロードする",
+        "uploadAria": "ワークフローファイルをアップロードする"
+      },
+      "info": {
+        "copyDescription": "このワークフローを別のエージェントにコピーします。",
+        "copyTitle": "ワークフローをコピー"
+      },
+      "metadata": {
+        "agent": "エージェント",
+        "agentDescription": "このワークフローはこのエージェントに属します。",
+        "aria": "ワークフローメタデータ",
+        "description": "説明",
+        "descriptionHelp": "このワークフローをいつ使用するかをエージェントに伝えます。",
+        "name": "名前",
+        "nameHelp": "ワークフロー リストおよびワークフローの選択時に表示されます。",
+        "namePlaceholder": "ワークフロー名",
+        "saved": "ワークフローが保存されました",
+        "slug": "ナメクジ",
+        "slugHelp": "小文字、数字、および - のみ。このワークフローを使用するには、チャットで {{command}} を使用します。",
+        "slugPlaceholder": "ワークフロースラッグ",
+        "slugTitle": "小文字、数字、ハイフンのみを使用してください",
+        "visibility": "公開範囲",
+        "visibilityHelp": "このワークフローをワークスペース内で共有する方法を選択します。"
+      },
+      "notFound": "ワークフローが見つかりません。",
+      "refineWith": "{{agent}} で絞り込む",
+      "shadow": {
+        "end": "あなたのために。このワークフローは、同じスラッグの優先順位ルールによってシャドウされます。",
+        "resolvesTo": "現在は次のように解決されます"
+      },
+      "visibility": {
+        "adminRequired": "所有していないエージェントの下でワークフローを公開するには、組織管理者権限が必要です。",
+        "automationWarning": "オートメーションは停止します",
+        "confirmDescription": "これは危険な操作です。このワークフローは非公開ですが、その上に構築された他のメンバーのオートメーションは実行を停止します。",
+        "confirmTitle": "このワークフローを非公開にしますか？",
+        "makePrivate": "非公開にする",
+        "publishAria": "ワークフローを公開",
+        "workflowHidden": "{{title}} は他のメンバーから非表示になり、オートメーションは停止します。"
+      }
+    },
+    "editor": {
+      "aria": "指示エディター",
+      "footer": "指示を直接編集して、エージェントの動作をカスタマイズします。",
+      "placeholder": "エージェントへの指示を書きます...",
+      "toolbar": {
+        "blockquote": "ブロッククォート",
+        "bold": "太字",
+        "bulletList": "箇条書きリスト",
+        "heading1": "見出し1",
+        "heading2": "見出し2",
+        "heading3": "見出し 3",
+        "inlineCode": "インラインコード",
+        "italic": "イタリック体",
+        "orderedList": "順序付きリスト",
+        "strikethrough": "取り消し線"
+      }
+    },
+    "list": {
+      "agentEmpty": "このエージェントとして実行されるワークフローはまだありません。",
+      "all": "すべて",
+      "allAgents": "すべてのエージェント",
+      "automated": "自動化",
+      "automations": "オートメーション",
+      "createdBy": "作成者",
+      "createInChat": "チャットで作成",
+      "description": "タスク用の再利用可能なSOP。ゼロから作成するか、日常業務から抽出して実行、編集、自動化します。",
+      "empty": {
+        "all": "チャットからワークフローを作成するか、有用な実行からワークフローを保存します。",
+        "automated": "ワークフローにオートメーションを追加すると、ここに表示されます。",
+        "private": "プライベート ワークフローはまだありません。",
+        "public": "公開ワークフローはまだありません。",
+        "without": "ここでのすべてのワークフローは、スケジュールまたはイベントに基づいて実行されます。"
+      },
+      "noWorkflows": "ワークフローなし",
+      "open": "{{title}} を開く",
+      "runsAs": "として実行",
+      "runsAsAria": "{{agent}} として実行",
+      "section": {
+        "event": "オートメーションについて",
+        "later": "後で",
+        "manual": "マニュアル",
+        "today": "今日も運行",
+        "week": "今週"
+      },
+      "sort": {
+        "alphabetical": "アルファベット順",
+        "created": "作成時間",
+        "label": "次の実行",
+        "nextRun": "次の実行"
+      },
+      "title": "ワークフロー",
+      "viewAutomations": "オートメーションを表示する"
+    }
+  },
+  "works": {
+    "actions": {
+      "cancel": "キャンセル",
+      "connect": "接続する",
+      "disconnect": "切断する",
+      "disconnecting": "切断中…",
+      "manage": "管理",
+      "moreOptions": "その他のオプション",
+      "uninstall": "アンインストール",
+      "uninstalling": "アンインストール中…",
+      "updatePermissions": "権限の更新"
+    },
+    "connected": "接続済み",
+    "connectedWithDetail": "接続されました ({{detail}})",
+    "documentTitle": "連携先",
+    "feishuConnected": "Feishu は正常に接続されました",
+    "header": {
+      "description": "これらのチャネルを通じて {{displayName}} に接続します",
+      "title": "{{displayName}}の連携先"
+    },
+    "slack": {
+      "adminInstall": "Slack 統合をインストールするように管理者に依頼してください",
+      "description": "チームのコミュニケーションとコラボレーション",
+      "install": "Slack にインストールします",
+      "permissionsUpdated": "Slack 権限が更新されました",
+      "title": "Slack",
+      "uninstallDescription": "これにより、ワークスペース全体の Slack 統合が削除されます。接続されているすべてのユーザーは切断され、{{displayName}} は Slack のメッセージやメンションに応答しなくなります。この操作は元に戻すことができません。",
+      "uninstallTitle": "Slack 統合をアンインストールしますか?"
+    },
+    "strapi": {
+      "description": "エントリー公開時の作業を自動化する",
+      "title": "Strapi"
+    },
+    "teams": {
+      "adminInstall": "Microsoft Teams 統合をインストールするように管理者に依頼してください",
+      "connectAccount": "Microsoft アカウントに接続してセットアップを完了してください",
+      "connectThenInstall": "Microsoft アカウントに接続し、Teams アプリをインストールします",
+      "description": "チームのコミュニケーションとコラボレーション",
+      "disconnect": "Microsoft Teams を切断します",
+      "install": "Teams にインストールする",
+      "moreOptions": "その他の Microsoft Teams オプション",
+      "permissionsUpdated": "Microsoft Teams 権限が更新されました",
+      "title": "Microsoft Teams",
+      "uninstall": "Microsoft Teams をアンインストールします",
+      "uninstallDescription": "これにより、ワークスペースの {{brandName}} から Microsoft Teams 統合が削除されます。接続されているすべてのユーザーは切断され、管理者が再接続するまで、{{displayName}} はこのワークスペースの Teams メッセージに応答しなくなります。",
+      "uninstallTitle": "Microsoft Teams 統合をアンインストールしますか?"
+    },
+    "telegram": {
+      "description": "Telegram メッセージをエージェントにルーティングする",
+      "openSettings": "Telegram 設定を開く",
+      "title": "Telegram"
+    }
+  }
+}

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -3144,7 +3144,7 @@
             "title": "ユーザーへの影響によるランキング"
           }
         },
-        "title": "GitHub のIssueにより、ファイル Sentry がクラッシュする"
+        "title": "SentryのクラッシュをGitHub Issueとして登録"
       },
       "fixes-to-notion-help-docs": {
         "description": "チケットが解決済みとしてマークされると、Zero は修正を Notion の再利用可能なヘルプ記事に変換します。",
@@ -3948,12 +3948,12 @@
       "signOut": "サインアウト",
       "subscriptions": {
         "providers": {
-          "claudeCode": "Claude コード",
+          "claudeCode": "Claude Code",
           "codex": "Codex"
         },
         "reset": "リセット",
         "resetTimeUnavailable": "リセット時間は利用不可",
-        "usage": "{{provider}} の使用法",
+        "usage": "{{provider}}の使用量",
         "usageRemaining": "{{provider}} {{window}} 残り",
         "windows": {
           "fiveHour": "5時間",
@@ -4097,16 +4097,16 @@
           "approvalOpenError": "承認ページを開けませんでした。リンクを手動で使用し、ここにコードを貼り付けます。",
           "authorizationCode": "認証コード",
           "codePlaceholder": "Claude からコードを貼り付けます",
-          "codeRequired": "Claude コード認証コードを貼り付けて続行します。",
-          "connectedToast": "Claude コードが接続されました",
-          "connectTitle": "Claude コードを接続する",
-          "error": "Claude コード接続に失敗しました。もう一度やり直してください。",
-          "expired": "Claude コード接続セッションの有効期限が切れました。もう一度やり直してください。",
+          "codeRequired": "Claude Codeの認証コードを貼り付けて続行します。",
+          "connectedToast": "Claude Codeが接続されました",
+          "connectTitle": "Claude Codeを接続する",
+          "error": "Claude Codeの接続に失敗しました。もう一度やり直してください。",
+          "expired": "Claude Codeの接続セッションの有効期限が切れました。もう一度やり直してください。",
           "instructions": "まず、[Claude 承認ページを開く] をクリックします。次に、Claude の {{brandName}} を承認し、承認後に表示される認証コードをコピーします。最後にそのコードをここに貼り付けて、「接続」をクリックします。",
           "openApproval": "Claude 承認ページを開く",
           "preparing": "準備中...",
-          "reconnectAction": "Claude コードを再接続します",
-          "reconnectTitle": "Claude コードを再接続します",
+          "reconnectAction": "Claude Codeを再接続する",
+          "reconnectTitle": "Claude Codeを再接続",
           "signIn": "Claude でサインインします",
           "submit": "接続する"
         },
@@ -4134,8 +4134,8 @@
       },
       "personal": {
         "actionForProvider": "{{action}} {{provider}}",
-        "claudeDescription": "Claude をサポートするモデル ルートの Claude コード ログインに接続します。",
-        "claudeTitle": "Claude コード OAuth",
+        "claudeDescription": "Claudeベースのモデルルートで使用するClaude Codeログインを接続します。",
+        "claudeTitle": "Claude Code OAuth",
         "codexDescription": "Codex をサポートするモデル ルートの Codex デバイス ログインを使用して接続します。",
         "codexTitle": "ChatGPT (Codex)",
         "description": "自分の実行でのみ、自分の資格情報を使用して使用されます。",
@@ -4170,7 +4170,7 @@
         "pro": "プロ",
         "providerLabels": {
           "azureFoundryPortal": "Azure ファウンドリ ポータル",
-          "claudeCodeOauth": "Claude コード (OAuth トークン)",
+          "claudeCodeOauth": "Claude Code（OAuthトークン）",
           "deepseek": "ディープシーク"
         },
         "runSpeed": "走行速度",
@@ -4207,17 +4207,17 @@
         "workspaceTitle": "ワークスペース"
       },
       "reset": {
-        "confirmDescription": "Codex リセットを 1 回使用して、現在の使用状況ウィンドウをリセットします。 {{remaining}} があります。",
+        "confirmDescription": "Codexリセットを1回使用して、現在の使用枠をリセットします。{{remaining}}。",
         "progress": "リセット中...",
-        "remaining_one": "{{value}} 左にリセット",
-        "remaining_other": "{{value}} が左にリセットされます",
-        "remainingUnavailable": "リセットが利用できないままになる",
-        "title": "Codex の使用状況をリセットしますか?"
+        "remaining_one": "リセット残り{{value}}回",
+        "remaining_other": "リセット残り{{value}}回",
+        "remainingUnavailable": "残りのリセット回数を取得できません",
+        "title": "Codexの使用量をリセットしますか？"
       },
       "stale": {
-        "claudeExpired": "Claude コード セッションの有効期限が切れました。続行するには再接続してください。",
-        "claudeFailed": "Claude コードの更新に失敗しました。再接続して再試行してください。",
-        "claudeTitle": "Claude コード セッションは再接続が必要です",
+        "claudeExpired": "Claude Codeセッションの有効期限が切れました。続行するには再接続してください。",
+        "claudeFailed": "Claude Codeの更新に失敗しました。再接続してもう一度お試しください。",
+        "claudeTitle": "Claude Codeセッションの再接続が必要です",
         "codexExpired": "ChatGPT セッションの有効期限が切れました。続行するには再接続してください。",
         "codexFailed": "ChatGPT の更新に失敗しました。再接続して再試行してください。",
         "codexInvalidated": "ChatGPT セッションが取り消されました。再接続します。",
@@ -4469,7 +4469,7 @@
       "contactSupport": "サポート",
       "description": "もう一度試すか、お問い合わせください",
       "help": "私たちはお手伝いします",
-      "title": "おっと！何かが横に逸れた"
+      "title": "問題が発生しました"
     },
     "forceUpgrade": {
       "action": "リフレッシュ",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -4346,6 +4346,7 @@
         "label": "Idioma",
         "options": {
           "english": "English",
+          "japanese": "日本語",
           "portugueseBrazil": "Português (Brasil)"
         },
         "title": "Idioma"

--- a/turbo/apps/platform/src/i18n/resources.ts
+++ b/turbo/apps/platform/src/i18n/resources.ts
@@ -6,6 +6,8 @@ import enUSCommon from "./locales/en-US/common.json";
 import enUSAgents from "./locales/en-US/agents.json";
 import ptBRCommon from "./locales/pt-BR/common.json";
 import ptBRAgents from "./locales/pt-BR/agents.json";
+import jaJPCommon from "./locales/ja-JP/common.json";
+import jaJPAgents from "./locales/ja-JP/agents.json";
 
 export const DEFAULT_LOCALE = "en-US";
 export const DEFAULT_NAMESPACE = "common";
@@ -21,5 +23,9 @@ export const resources = {
   "pt-BR": {
     agents: ptBRAgents,
     common: ptBRCommon,
+  },
+  "ja-JP": {
+    agents: jaJPAgents,
+    common: jaJPCommon,
   },
 } as const;

--- a/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { HttpResponse } from "msw";
 import {
   addClientCapabilityToVersion,
+  CLIENT_CAPABILITY_JA_JP_LOCALE,
   CLIENT_CAPABILITY_PT_BR_LOCALE,
   CLIENT_FORCE_UPGRADE_STATUS,
 } from "@vm0/api-contracts/contracts/client-headers";
@@ -27,8 +28,8 @@ const context = testContext();
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const EXPECTED_CLIENT_VERSION = addClientCapabilityToVersion(
-  "0.540.0",
-  CLIENT_CAPABILITY_PT_BR_LOCALE,
+  addClientCapabilityToVersion("0.540.0", CLIENT_CAPABILITY_PT_BR_LOCALE),
+  CLIENT_CAPABILITY_JA_JP_LOCALE,
 );
 
 interface ObservedClientHeaders {

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
@@ -3,7 +3,7 @@ import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import indexHtml from "../../../index.html?raw";
 import { setupPage } from "../../__tests__/page-helper.ts";
-import { DEFAULT_LOCALE } from "../../i18n/resources.ts";
+import { DEFAULT_LOCALE, resources } from "../../i18n/resources.ts";
 import { i18n } from "../../i18n/index.ts";
 import { localStorageSignals } from "../external/local-storage.ts";
 import { locale$, setLocale$ } from "../locale.ts";
@@ -95,6 +95,23 @@ afterEach(() => {
 });
 
 describe("bootstrap locale", () => {
+  it("normalizes a Japanese browser language before bundle render", () => {
+    context.mocks.browser.language("ja");
+
+    executeLocaleEntrypoint();
+
+    expect(document.documentElement.lang).toBe("ja-JP");
+    expect(context.store.get(testLocaleStorage.get$)).toBeNull();
+    expect(window.__vm0PreBundleCopy).toMatchObject({
+      loading: {
+        ariaLabel: "ワークスペースを読み込み中",
+      },
+      metadata: {
+        title: "Zero — vm0のAIコワーカー",
+      },
+    });
+  });
+
   it("uses a supported browser language before a workspace is active", async () => {
     context.mocks.browser.language("pt-BR");
     executeLocaleEntrypoint();
@@ -123,6 +140,7 @@ describe("bootstrap locale", () => {
     expect(document.documentElement.lang).toBe("pt-BR");
     expect(i18n.hasResourceBundle("en-US", "common")).toBeTruthy();
     expect(i18n.hasResourceBundle("pt-BR", "common")).toBeTruthy();
+    expect(i18n.hasResourceBundle("ja-JP", "common")).toBeTruthy();
 
     const metadata = document.createElement("meta");
     metadata.name = "description";
@@ -165,7 +183,7 @@ describe("bootstrap locale", () => {
   it("uses the cached locale across pre-bundle UI and i18next", async () => {
     context.mocks.browser.language("en-US");
     sessionStorage.setItem(ACTIVE_ORG_STORAGE_KEY, TEST_ORG_ID);
-    context.store.set(testLocaleStorage.set$, "pt-BR");
+    context.store.set(testLocaleStorage.set$, "ja-JP");
     executeLocaleEntrypoint();
     executeBrowserCompatibilityEntrypoint(
       "Mozilla/5.0 Chrome/100.0.0.0 Safari/537.36",
@@ -190,33 +208,53 @@ describe("bootstrap locale", () => {
       withoutRender: true,
     });
 
-    expect(context.store.get(locale$)).toBe("pt-BR");
-    expect(i18n.language).toBe("pt-BR");
+    expect(context.store.get(locale$)).toBe("ja-JP");
+    expect(i18n.language).toBe("ja-JP");
     expect(window.__vm0BrowserSupported).toBeFalsy();
     expect(window.__vm0BrowserUpgrade).toMatchObject({
-      actionLabel: "Atualizar Chrome",
+      actionLabel: "Chromeを更新",
       actionUrl: "https://www.google.com/chrome/",
-      title: "Atualize o Chrome para continuar",
+      title: "続行するにはChromeを更新してください",
     });
     expect(metadata).toHaveAttribute(
       "content",
-      expect.stringContaining("Zero é seu colega de IA da vm0"),
+      expect.stringContaining("Zeroはvm0のAIコワーカーです"),
     );
     expect(window.__vm0PreBundleCopy).toMatchObject({
       browserUpgrade: {
         safari: {
-          actionLabel: "Atualizar Safari",
-          title: "Atualize o Safari para continuar",
+          actionLabel: "Safariを更新",
+          title: "続行するにはSafariを更新してください",
         },
       },
       loading: {
-        ariaLabel: "Carregando seu espaço de trabalho",
-        messages: expect.arrayContaining(["Aquecendo os neurônios..."]),
+        ariaLabel: "ワークスペースを読み込み中",
+        messages: expect.arrayContaining([
+          "ニューラルネットワークを準備しています...",
+        ]),
       },
       metadata: {
-        title: "Zero — Seu colega de IA da vm0",
+        title: "Zero — vm0のAIコワーカー",
       },
     });
+
+    const japaneseAgentResources = resources["ja-JP"].agents;
+    i18n.removeResourceBundle("ja-JP", "agents");
+    expect(
+      i18n.t(
+        ($) => {
+          return $.actions.save;
+        },
+        { ns: "agents" },
+      ),
+    ).toBe("Save");
+    i18n.addResourceBundle(
+      "ja-JP",
+      "agents",
+      japaneseAgentResources,
+      true,
+      true,
+    );
 
     await context.store.set(setLocale$, DEFAULT_LOCALE, context.signal);
   });

--- a/turbo/apps/platform/src/signals/client-headers.ts
+++ b/turbo/apps/platform/src/signals/client-headers.ts
@@ -1,5 +1,6 @@
 import {
   addClientCapabilityToVersion,
+  CLIENT_CAPABILITY_JA_JP_LOCALE,
   CLIENT_CAPABILITY_PT_BR_LOCALE,
   CLIENT_REQUEST_ID_HEADER,
   CLIENT_SESSION_ID_HEADER,
@@ -26,8 +27,11 @@ const clientSessionId = crypto.randomUUID();
 function createClientHeaders(): Record<string, string> {
   return {
     [CLIENT_VERSION_HEADER]: addClientCapabilityToVersion(
-      clientVersion,
-      CLIENT_CAPABILITY_PT_BR_LOCALE,
+      addClientCapabilityToVersion(
+        clientVersion,
+        CLIENT_CAPABILITY_PT_BR_LOCALE,
+      ),
+      CLIENT_CAPABILITY_JA_JP_LOCALE,
     ),
     [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
     [CLIENT_SESSION_ID_HEADER]: clientSessionId,

--- a/turbo/apps/platform/src/signals/locale.ts
+++ b/turbo/apps/platform/src/signals/locale.ts
@@ -28,12 +28,11 @@ export const locale$ = computed((get) => {
   return get(internalLocale$);
 });
 
-export const localePreferenceSupported$ = computed(async (get) => {
+export const availableLocalePreferences$ = computed(async (get) => {
   const preferences = await get(userPreferences$);
-  return (
-    preferences.locale !== undefined &&
-    preferences.supportedLocales?.includes("pt-BR") === true
-  );
+  return preferences.locale === undefined
+    ? []
+    : (preferences.supportedLocales ?? []);
 });
 
 export const initLocale$ = command(async ({ set }, signal: AbortSignal) => {
@@ -79,14 +78,22 @@ export const syncLocalePreference$ = command(
 
     const preferences = await get(userPreferences$);
     signal.throwIfAborted();
+    const supportedLocales = preferences.supportedLocales;
     if (
       preferences.locale === undefined ||
-      preferences.supportedLocales?.includes("pt-BR") !== true
+      supportedLocales === undefined ||
+      (!supportedLocales.includes("pt-BR") &&
+        !supportedLocales.includes("ja-JP"))
     ) {
       return;
     }
 
-    const locale = preferences.locale ?? resolveDocumentLocale();
+    const documentLocale = resolveDocumentLocale();
+    const locale =
+      preferences.locale ??
+      (supportedLocales.includes(documentLocale)
+        ? documentLocale
+        : DEFAULT_LOCALE);
     await set(applyLocalePreference$, clerk.organization.id, locale, signal);
 
     if (preferences.locale === null) {

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -27,6 +27,21 @@ function usePortugueseLocale(): void {
   );
 }
 
+function useJapaneseLocale(): void {
+  document.documentElement.lang = "ja-JP";
+  context.mocks.data.userPreferences({
+    locale: "ja-JP",
+    supportedLocales: ["en-US", "ja-JP"],
+  });
+  context.signal.addEventListener(
+    "abort",
+    () => {
+      document.documentElement.lang = "en-US";
+    },
+    { once: true },
+  );
+}
+
 describe("app auth pages", () => {
   it("localizes the app auth shell and Clerk resources in Brazilian Portuguese", async () => {
     usePortugueseLocale();
@@ -45,6 +60,30 @@ describe("app auth pages", () => {
     expect(localization.signIn?.start?.actionLink).toBe("Registre-se");
     expect(localization.unstable__errors?.not_allowed_access).toBe(
       "Acesso não permitido.",
+    );
+
+    act(() => {
+      authComponent.mount();
+    });
+  });
+
+  it("localizes the app auth shell and Clerk resources in Japanese", async () => {
+    useJapaneseLocale();
+    setBrowserUrl("https://app.vm0.ai/sign-up");
+
+    const authComponent = context.mocks.clerk.deferAuthComponentMount();
+    detachedSetupPage({ context, path: "/sign-up" });
+
+    await expect(
+      screen.findByText("認証を読み込み中"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByLabelText("テーマの切り替え")).toBeInTheDocument();
+    expect(document.title).toBe("サインアップ | VM0");
+
+    const localization = getClerkLocalization("VM0", "ja-JP", i18n.t);
+    expect(localization.signIn?.start?.actionLink).toBe("サインアップ");
+    expect(localization.unstable__errors?.not_allowed_access).toBe(
+      "アクセスは許可されていません。",
     );
 
     act(() => {

--- a/turbo/apps/platform/src/views/auth/clerk-localization.ts
+++ b/turbo/apps/platform/src/views/auth/clerk-localization.ts
@@ -1,4 +1,4 @@
-import { enUS, ptBR } from "@clerk/localizations";
+import { enUS, jaJP, ptBR } from "@clerk/localizations";
 import type { TFunction } from "i18next";
 import type { SupportedLocale } from "../../i18n/resources.ts";
 import type { BrandName } from "../../signals/branding.ts";
@@ -8,7 +8,8 @@ export function getClerkLocalization(
   locale: SupportedLocale,
   t: TFunction<"common">,
 ) {
-  const localization = locale === "pt-BR" ? ptBR : enUS;
+  const localization =
+    locale === "pt-BR" ? ptBR : locale === "ja-JP" ? jaJP : enUS;
   return {
     ...localization,
     unstable__errors: {

--- a/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
+++ b/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
@@ -236,4 +236,41 @@ describe("/usage page", () => {
       screen.getByRole("option", { name: "Últimos 7 dias" }),
     ).toBeInTheDocument();
   });
+
+  it("localizes usage copy, counts, and numeric totals in Japanese", async () => {
+    context.mocks.data.userPreferences({ locale: "ja-JP" });
+    context.mocks.api(zeroUsageInsightContract.get, ({ respond }) => {
+      return respond(200, usageInsightTodayFixture);
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/usage",
+      featureSwitches: {
+        [FeatureSwitchKey.LanguagePreference]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(document.documentElement.lang).toBe("ja-JP");
+      expect(
+        screen.getByRole("heading", { level: 1, name: "使用量" }),
+      ).toBeInTheDocument();
+      expect(
+        within(
+          screen.getByRole("region", { name: "クレジットの合計" }),
+        ).getByText("1300"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("1件のオートメーションで300クレジットを使用"),
+      ).toBeVisible();
+      expect(screen.getByText("1件の会話で200クレジットを使用")).toBeVisible();
+      expect(screen.getAllByText("チャット")).not.toHaveLength(0);
+    });
+
+    click(screen.getByLabelText("日付範囲"));
+    expect(
+      screen.getByRole("option", { name: "過去7日間" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -971,6 +971,67 @@ describe("chat lifecycle", () => {
     expect(document.documentElement.lang).toBe("pt-BR");
   });
 
+  it("formats completed-run timestamps with the selected Japanese locale", async () => {
+    const completedAt = "2026-06-09T10:00:21Z";
+    const completedAtLabel = new Date(completedAt).toLocaleString("ja-JP", {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    context.mocks.data.userPreferences({ locale: "ja-JP" });
+    mockChatLifecycle(context, {
+      threadId: "thread-japanese-completed-run",
+      chatEvents: [
+        {
+          role: "user",
+          content: "リリース計画を準備してください",
+          runId: "run-japanese-completed-run",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          role: "assistant",
+          content: "リリース計画が完了しました。",
+          runId: "run-japanese-completed-run",
+          createdAt: "2026-06-09T10:00:20Z",
+        },
+        {
+          role: "assistant",
+          content: null,
+          runId: "run-japanese-completed-run",
+          runLifecycleEvent: "completed",
+          createdAt: completedAt,
+        },
+        {
+          role: "assistant",
+          content: null,
+          runId: "run-japanese-completed-run",
+          recommendedFollowups: [
+            {
+              prompt: "プレゼンテーションに変換する",
+              kind: "generate",
+              generationType: "presentation",
+            },
+          ],
+          createdAt: "2026-06-09T10:00:30Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-japanese-completed-run",
+      featureSwitches: {
+        [FeatureSwitchKey.LanguagePreference]: true,
+      },
+    });
+
+    await expect(
+      screen.findByText(`続ける · ${completedAtLabel}`),
+    ).resolves.toBeInTheDocument();
+    expect(document.documentElement.lang).toBe("ja-JP");
+  });
+
   it("does not let an attached lifecycle marker hide the final answer", async () => {
     mockChatLifecycle(context, {
       threadId: "thread-work-folding-completion-marker",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
@@ -547,6 +547,52 @@ describe("personal model providers settings", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("localizes subscription reset dates and relative times in Japanese", async () => {
+    const timeZone = "Asia/Tokyo";
+    mockBrowserTimeZone(timeZone);
+    mockNow(new Date("2030-01-01T00:48:00.000Z"));
+    context.mocks.data.org({
+      id: "org_1",
+      slug: "test-org",
+      name: "Test Org",
+      role: "member",
+    });
+    context.mocks.data.personalModelProviders([
+      connectedPersonalClaudeCodeProvider(),
+    ]);
+    context.mocks.data.userPreferences({
+      locale: "ja-JP",
+      supportedLocales: ["en-US", "ja-JP"],
+    });
+
+    await openModelSettings("モデル", true);
+
+    const claudeCodeRow = await screen.findByTestId(
+      "oauth-card-claude-code-oauth-token",
+    );
+    expect(document.documentElement.lang).toBe("ja-JP");
+    expect(within(claudeCodeRow).getByText("5時間")).toBeInTheDocument();
+    expect(within(claudeCodeRow).getByText("88% 残り")).toBeInTheDocument();
+    expect(within(claudeCodeRow).getByText("4時間12分後")).toBeInTheDocument();
+    expect(within(claudeCodeRow).getByText("週")).toBeInTheDocument();
+    expect(within(claudeCodeRow).getByText("76% 残り")).toBeInTheDocument();
+    expect(within(claudeCodeRow).getByText("5日23時間後")).toBeInTheDocument();
+
+    const resetAt = "2030-01-01T05:00:00.000Z";
+    const absoluteReset = new Intl.DateTimeFormat("ja-JP", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone,
+      timeZoneName: "short",
+    }).format(new Date(resetAt));
+    expect(
+      within(claudeCodeRow).getByText(`${absoluteReset}にリセット`),
+    ).toBeInTheDocument();
+  });
+
   it("resets connected personal Codex usage from the row menu", async () => {
     context.mocks.data.org({
       id: "org_1",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
@@ -59,11 +59,14 @@ async function openDialog(
   });
 }
 
-function createPreferences(locale: UserLocale | null): UserPreferencesResponse {
+function createPreferences(
+  locale: UserLocale | null,
+  supportedLocales: UserLocale[] = ["en-US", "pt-BR"],
+): UserPreferencesResponse {
   return {
     timezone: null,
     locale,
-    supportedLocales: ["en-US", "pt-BR"],
+    supportedLocales,
     pinnedAgentIds: [],
     sendMode: "enter",
     morningBriefEnabled: false,
@@ -194,6 +197,113 @@ describe("settings dialog", () => {
     click(screen.getByRole("option", { name: "English" }));
     await waitFor(() => {
       expect(document.documentElement.lang).toBe("en-US");
+    });
+  });
+
+  it("selects and persists Japanese when the API advertises it", async () => {
+    const submittedLocales: UserLocale[] = [];
+    let serverLocale: UserLocale | null = "en-US";
+    const supportedLocales: UserLocale[] = ["en-US", "pt-BR", "ja-JP"];
+    context.mocks.api(zeroUserPreferencesContract.get, ({ respond }) => {
+      return respond(200, createPreferences(serverLocale, supportedLocales));
+    });
+    context.mocks.api(
+      zeroUserPreferencesContract.update,
+      ({ body, respond }) => {
+        if (body.locale !== undefined) {
+          serverLocale = body.locale;
+          submittedLocales.push(body.locale);
+        }
+        return respond(200, createPreferences(serverLocale, supportedLocales));
+      },
+    );
+
+    await openDialog("admin", "preference", {
+      [FeatureSwitchKey.LanguagePreference]: true,
+    });
+
+    click(
+      await screen.findByRole("combobox", {
+        name: "Language",
+      }),
+    );
+    click(screen.getByRole("option", { name: "日本語" }));
+
+    await waitFor(() => {
+      expect(submittedLocales).toContain("ja-JP");
+      expect(screen.getByRole("combobox", { name: "言語" })).toHaveTextContent(
+        "日本語",
+      );
+      expect(document.documentElement.lang).toBe("ja-JP");
+      expect(cachedLocale()).toBe("ja-JP");
+    });
+
+    click(screen.getByRole("combobox", { name: "言語" }));
+    click(screen.getByRole("option", { name: "English" }));
+    await waitFor(() => {
+      expect(document.documentElement.lang).toBe("en-US");
+    });
+  });
+
+  it("restores Japanese from the workspace preference on reload", async () => {
+    document.documentElement.lang = "en-US";
+    context.store.set(setCachedLocale$, "en-US");
+    context.mocks.data.userPreferences(
+      createPreferences("ja-JP", ["en-US", "ja-JP"]),
+    );
+
+    await openDialog("admin", "preference", {
+      [FeatureSwitchKey.LanguagePreference]: true,
+    });
+
+    const languageSelect = await screen.findByRole("combobox", {
+      name: "言語",
+    });
+    await waitFor(() => {
+      expect(languageSelect).toHaveTextContent("日本語");
+      expect(document.documentElement.lang).toBe("ja-JP");
+      expect(cachedLocale()).toBe("ja-JP");
+    });
+
+    click(languageSelect);
+    expect(
+      screen.queryByRole("option", { name: "Português (Brasil)" }),
+    ).not.toBeInTheDocument();
+    click(screen.getByRole("option", { name: "English" }));
+    await waitFor(() => {
+      expect(document.documentElement.lang).toBe("en-US");
+    });
+  });
+
+  it("does not submit Japanese to an API that advertises only Portuguese", async () => {
+    const submittedLocales: UserLocale[] = [];
+    document.documentElement.lang = "ja-JP";
+    context.store.set(setCachedLocale$, "ja-JP");
+    context.mocks.api(zeroUserPreferencesContract.get, ({ respond }) => {
+      return respond(200, createPreferences(null, ["en-US", "pt-BR"]));
+    });
+    context.mocks.api(
+      zeroUserPreferencesContract.update,
+      ({ body, respond }) => {
+        if (body.locale !== undefined) {
+          submittedLocales.push(body.locale);
+        }
+        return respond(
+          200,
+          createPreferences(body.locale ?? null, ["en-US", "pt-BR"]),
+        );
+      },
+    );
+
+    await openDialog("admin", "preference", {
+      [FeatureSwitchKey.LanguagePreference]: true,
+    });
+
+    await waitFor(() => {
+      expect(submittedLocales).toContain("en-US");
+      expect(submittedLocales).not.toContain("ja-JP");
+      expect(document.documentElement.lang).toBe("en-US");
+      expect(cachedLocale()).toBe("en-US");
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -2524,6 +2524,67 @@ describe("zero sidebar", () => {
     ).toBeInTheDocument();
   });
 
+  it("localizes desktop and mobile shell navigation in Japanese", async () => {
+    prepareDefaultAgent();
+    mockSidebarThreadStory([
+      createThread(EXISTING_THREAD_ID, "Localized conversation"),
+    ]);
+    setMockWorkflowAutomations([
+      createMockWorkflowAutomation({
+        chatThreadId: EXISTING_THREAD_ID,
+      }),
+    ]);
+    context.mocks.data.userPreferences({
+      locale: "ja-JP",
+      supportedLocales: ["en-US", "ja-JP"],
+    });
+
+    setupSidebarPage({
+      context,
+      path: `/chats/${EXISTING_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.Artifacts]: true,
+        [FeatureSwitchKey.LanguagePreference]: true,
+        [FeatureSwitchKey.ThreeColumnNav]: true,
+        [FeatureSwitchKey.ZeroDebug]: true,
+      },
+    });
+
+    const rail = await screen.findByTestId("labeled-nav-rail");
+    expect(
+      within(rail).getByRole("navigation", { name: "サイドバー" }),
+    ).toBeInTheDocument();
+    expect(within(rail).getByText("エージェント")).toBeInTheDocument();
+    expect(within(rail).getByText("ワークフロー")).toBeInTheDocument();
+    expect(within(rail).getByText("コネクター")).toBeInTheDocument();
+    expect(within(rail).getByText("アーティファクト")).toBeInTheDocument();
+    expect(within(rail).getByText("アクティビティ")).toBeInTheDocument();
+    expect(within(rail).getByLabelText("Zeroの連携先")).toBeInTheDocument();
+    expect(screen.getByLabelText("メニューを開く")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("モバイルでアーティファクトを開く"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("モバイルでオートメーションを開く"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("サイドバーを折りたたむ")).toBeInTheDocument();
+
+    fireEvent.keyDown(document.body, { key: "?", shiftKey: true });
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "キーボードショートカット",
+    });
+    expect(
+      within(dialog).getByText("このページで利用可能なショートカット"),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByText("ショートカットを表示する"),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByLabelText("キーボードショートカットを閉じる"),
+    ).toBeInTheDocument();
+  });
+
   it("keeps localized navigation accessible while collapsing and expanding", async () => {
     prepareDefaultAgent();
     context.mocks.data.userPreferences({

--- a/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
@@ -13,15 +13,15 @@ import {
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { brandName$ } from "../../../../signals/branding.ts";
 import {
+  availableLocalePreferences$,
   locale$,
-  localePreferenceSupported$,
   updateLocalePreference$,
 } from "../../../../signals/locale.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 
 export function LanguageSettings() {
   const { t } = useTranslation();
-  const supportLoadable = useLoadable(localePreferenceSupported$);
+  const availableLocalesLoadable = useLoadable(availableLocalePreferences$);
   const brandName = useGet(brandName$);
   const locale = useGet(locale$);
   const pageSignal = useGet(pageSignal$);
@@ -29,14 +29,19 @@ export function LanguageSettings() {
     updateLocalePreference$,
   );
 
-  if (supportLoadable.state !== "hasData" || supportLoadable.data !== true) {
+  if (
+    availableLocalesLoadable.state !== "hasData" ||
+    (!availableLocalesLoadable.data.includes("pt-BR") &&
+      !availableLocalesLoadable.data.includes("ja-JP"))
+  ) {
     return null;
   }
 
+  const availableLocales = availableLocalesLoadable.data;
   const saving = updateLoadable.state === "loading";
 
   const handleChange = (value: string) => {
-    if (value !== "en-US" && value !== "pt-BR") {
+    if (value !== "en-US" && value !== "pt-BR" && value !== "ja-JP") {
       throw new Error(`Unsupported locale: ${value}`);
     }
     detach(updateLocale(value, pageSignal), Reason.DomCallback);
@@ -85,12 +90,21 @@ export function LanguageSettings() {
                   return $.settings.preferences.language.options.english;
                 })}
               </SelectItem>
-              <SelectItem value="pt-BR">
-                {t(($) => {
-                  return $.settings.preferences.language.options
-                    .portugueseBrazil;
-                })}
-              </SelectItem>
+              {availableLocales.includes("pt-BR") && (
+                <SelectItem value="pt-BR">
+                  {t(($) => {
+                    return $.settings.preferences.language.options
+                      .portugueseBrazil;
+                  })}
+                </SelectItem>
+              )}
+              {availableLocales.includes("ja-JP") && (
+                <SelectItem value="ja-JP">
+                  {t(($) => {
+                    return $.settings.preferences.language.options.japanese;
+                  })}
+                </SelectItem>
+              )}
             </SelectContent>
           </Select>
         </div>

--- a/turbo/packages/api-contracts/src/contracts/client-headers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/client-headers.test.ts
@@ -3,6 +3,7 @@ import {
   addClientCapabilityToVersion,
   clientVersionSupportsCapability,
   CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
+  CLIENT_CAPABILITY_JA_JP_LOCALE,
   CLIENT_CAPABILITY_PT_BR_LOCALE,
   CLIENT_FORCE_UPGRADE_STATUS,
   CLIENT_HEADER_NAMES,
@@ -62,14 +63,20 @@ describe("client header contract", () => {
 
   it("advertises capabilities through backward-compatible version metadata", () => {
     const version = addClientCapabilityToVersion(
-      addClientCapabilityToVersion("0.636.1", CLIENT_CAPABILITY_PT_BR_LOCALE),
+      addClientCapabilityToVersion(
+        addClientCapabilityToVersion("0.636.1", CLIENT_CAPABILITY_PT_BR_LOCALE),
+        CLIENT_CAPABILITY_JA_JP_LOCALE,
+      ),
       CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
     );
     expect(version).toBe(
-      "0.636.1+pt-br-locale-v1.connector-slug-identities-v1",
+      "0.636.1+pt-br-locale-v1.ja-jp-locale-v1.connector-slug-identities-v1",
     );
     expect(
       clientVersionSupportsCapability(version, CLIENT_CAPABILITY_PT_BR_LOCALE),
+    ).toBe(true);
+    expect(
+      clientVersionSupportsCapability(version, CLIENT_CAPABILITY_JA_JP_LOCALE),
     ).toBe(true);
     expect(
       clientVersionSupportsCapability(

--- a/turbo/packages/api-contracts/src/contracts/client-headers.ts
+++ b/turbo/packages/api-contracts/src/contracts/client-headers.ts
@@ -3,6 +3,7 @@ export const CLIENT_TYPE_HEADER = "X-Client-Type";
 export const CLIENT_SESSION_ID_HEADER = "X-Client-Session-Id";
 export const CLIENT_REQUEST_ID_HEADER = "X-Client-Request-Id";
 export const CLIENT_CAPABILITY_PT_BR_LOCALE = "pt-br-locale-v1";
+export const CLIENT_CAPABILITY_JA_JP_LOCALE = "ja-jp-locale-v1";
 export const CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES =
   "connector-slug-identities-v1";
 export const ZERO_MAIL_CLIENT_VERSION_HEADER = "X-Zero-Mail-Client-Version";

--- a/turbo/packages/api-contracts/src/contracts/zero-user-preferences.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-preferences.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { userPreferencesResponseSchema } from "./zero-user-preferences";
+import {
+  userLocaleSchema,
+  userPreferencesResponseSchema,
+} from "./zero-user-preferences";
 
 describe("user preferences contract", () => {
   it("normalizes the previous locale in an API response", () => {
@@ -15,5 +18,24 @@ describe("user preferences contract", () => {
     });
 
     expect(preferences.locale).toBe("en-US");
+  });
+
+  it("accepts the canonical Japanese locale", () => {
+    expect(userLocaleSchema.parse("ja-JP")).toBe("ja-JP");
+    expect(
+      userPreferencesResponseSchema.parse({
+        timezone: null,
+        locale: "ja-JP",
+        supportedLocales: ["en-US", "pt-BR", "ja-JP"],
+        pinnedAgentIds: [],
+        sendMode: "enter",
+        morningBriefEnabled: false,
+        morningBriefNextRunAt: null,
+        captureNetworkBodiesRemaining: 0,
+      }),
+    ).toMatchObject({
+      locale: "ja-JP",
+      supportedLocales: ["en-US", "pt-BR", "ja-JP"],
+    });
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/zero-user-preferences.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-preferences.ts
@@ -10,7 +10,7 @@ const c = initContract();
 export const sendModeSchema = z.enum(["enter", "cmd-enter"]);
 export type SendMode = z.infer<typeof sendModeSchema>;
 
-export const SUPPORTED_USER_LOCALES = ["en-US", "pt-BR"] as const;
+export const SUPPORTED_USER_LOCALES = ["en-US", "pt-BR", "ja-JP"] as const;
 export const userLocaleSchema = z.enum(SUPPORTED_USER_LOCALES);
 export type UserLocale = z.infer<typeof userLocaleSchema>;
 

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -50,6 +50,7 @@ describe("isFeatureEnabled", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.BrazilianPortugueseLocale, {}),
     ).toBe(false);
+    expect(isFeatureEnabled(FeatureSwitchKey.JapaneseLocale, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.ZeroChatMessaging, {})).toBe(
       false,
     );
@@ -130,6 +131,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.BrazilianPortugueseLocale]).toBe(
       false,
     );
+    expect(staffOrgStates[FeatureSwitchKey.JapaneseLocale]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ClaudeSessionPruning]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadSidebarAutoOpen]).toBe(
@@ -163,6 +165,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.BrazilianPortugueseLocale]).toBe(
       false,
     );
+    expect(otherOrgStates[FeatureSwitchKey.JapaneseLocale]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ClaudeSessionPruning]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(
       false,
@@ -234,6 +237,9 @@ describe("user-overridable switches", () => {
     expect(getUserOverridableFeatureSwitchKeys()).not.toContain(
       FeatureSwitchKey.BrazilianPortugueseLocale,
     );
+    expect(getUserOverridableFeatureSwitchKeys()).not.toContain(
+      FeatureSwitchKey.JapaneseLocale,
+    );
     expect(getUserOverridableFeatureSwitchKeys()).toContain(
       FeatureSwitchKey.ZeroBrowser,
     );
@@ -260,6 +266,7 @@ describe("user-overridable switches", () => {
         [FeatureSwitchKey.StructuredPromptInlineTemplates]: true,
         [FeatureSwitchKey.ZeroMailReplyFollowUp]: true,
         [FeatureSwitchKey.BrazilianPortugueseLocale]: true,
+        [FeatureSwitchKey.JapaneseLocale]: true,
         [FeatureSwitchKey.ZeroBrowser]: true,
         [FeatureSwitchKey.ComposerConnectorPermissions]: true,
         [FeatureSwitchKey.Dummy]: false,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -43,6 +43,7 @@ export enum FeatureSwitchKey {
   ZeroDebug = "zeroDebug",
   LanguagePreference = "languagePreference",
   BrazilianPortugueseLocale = "brazilianPortugueseLocale",
+  JapaneseLocale = "japaneseLocale",
   ZeroBrowser = "zeroBrowser",
   ZeroChatMessaging = "zeroChatMessaging",
   ZeroMailReplyFollowUp = "zeroMailReplyFollowUp",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -241,6 +241,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     userOverridable: false,
   },
+  [FeatureSwitchKey.JapaneseLocale]: {
+    maintainer: "yuma@vm0.ai",
+    description:
+      "Allow ja-JP preference writes after incompatible API readers and rollback candidates have drained.",
+    enabled: false,
+    userOverridable: false,
+  },
   [FeatureSwitchKey.Banking]: {
     maintainer: "linghan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add complete `ja-JP` resources for the platform, pre-bundle loading and browser-upgrade UI, Clerk auth, language settings, and locale-aware formatting
- advertise a Japanese-locale client capability and negotiate `supportedLocales` independently from Brazilian Portuguese
- gate Japanese preference reads and writes with a dedicated deploy-time rollout switch, including legacy-client projection and rollback-safe persistence
- cover locale selection, resource fallback, numbers, dates, relative time, mixed-version clients, and rollout rollback behavior

## Testing

- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/core lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- direct type checks for all four affected workspaces
- scoped Knip for all four affected workspaces
- 506 API contract tests
- 213 core tests
- 9 API locale rollout integration tests
- 79 platform localization integration tests
- platform and API production builds

Closes #23994
