### PR TITLE
test(api): own feishu callback event visibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -34,6 +34,7 @@ import { zeroFeishuOauthRoutes } from "../zero-feishu-oauth";
 import { zeroIntegrationsFeishuFileRoutes } from "../zero-integrations-feishu-files";
 import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import type { ApiTestUser } from "./helpers/api-bdd";
+import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
@@ -43,6 +44,7 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
 const authOrgApi = createAuthOrgAgentsBddApi(context);
+const chatCallbacks = createChatCallbacksApi(context);
 const runsApi = createRunsApi(context);
 const webhooksApi = createWebhookCallbackApi(context);
 const APP_ORIGIN = "https://app.vm0.test";
@@ -679,20 +681,23 @@ describe("Feishu integration", () => {
       headers,
       [200],
     );
-    await webhooksApi.requestAgentEvents(
-      {
-        runId: args.runId,
-        events: [
-          {
-            type: "assistant",
-            sequenceNumber: 0,
-            message: {
-              id: `msg_bdd_feishu_${args.runId}`,
-              content: [{ type: "text", text: args.assistantText }],
-            },
-          },
-        ],
+    const assistantEvent = {
+      type: "assistant" as const,
+      sequenceNumber: 0,
+      message: {
+        id: `msg_bdd_feishu_${args.runId}`,
+        content: [{ type: "text" as const, text: args.assistantText }],
       },
+    };
+    chatCallbacks.mockChatOutputEvents([
+      {
+        eventType: assistantEvent.type,
+        sequenceNumber: assistantEvent.sequenceNumber,
+        eventData: { message: assistantEvent.message },
+      },
+    ]);
+    await webhooksApi.requestAgentEvents(
+      { runId: args.runId, events: [assistantEvent] },
       headers,
       [200],
     );
@@ -702,6 +707,7 @@ describe("Feishu integration", () => {
       [200],
     );
     await flushWaitUntilForTest();
+    chatCallbacks.mockChatOutputEvents([]);
   }
 
   async function findRun(


### PR DESCRIPTION
## Summary

- make the Feishu completion helper provide its own Axiom event snapshot
- expose the submitted assistant event to both the terminal watermark barrier and callback output read
- clear the snapshot after waitUntil work settles so later scenarios cannot inherit it

## Failure evidence

- Trigger: Turbo `push` to `main` at `596d96d3d5972f9753c20ba3cdaff4e4506a0969`
- Run: https://github.com/vm0-ai/vm0/actions/runs/30530986242
- First substantive failure: `test-api (6)` / `zero-feishu-integration.test.ts` / `forks Feishu DM threads without replacing the main session` timed out at 5 seconds
- Classification: test isolation and external-boundary mock pollution
- First causal event: the callback waited 2001 ms for terminal Axiom sequence 0, then a second completion waited another 2000 ms for the same missing watermark

The helper submitted assistant events with `lastEventSequence: 0` while its own Axiom query mock returned no events. Adjacent main runs completed this test in about 1.2-1.5 seconds, so passing depended on another test changing the shared Axiom mock at the right time.

## Fix

Before completion, map the submitted assistant event into a test-owned Axiom snapshot. This gives the terminal watermark barrier and callback output query the same visible event, then clears the snapshot after tracked waitUntil work settles. No retries, sleeps, timeout increases, skipped assertions, or product behavior changes are involved.

## Validation

- pre-commit: Prettier, Knip, full workspace type checks, file-size check
- `pnpm --filter api check-types`
- targeted ESLint and Oxlint for the changed test file
- repeated targeted Vitest validation could not start locally because this runtime has neither PostgreSQL nor Docker; the database-backed PR pipeline is the remaining evidence limitation