### PR TITLE
feat(platform): support spanish locale

### DIFF
--- a/turbo/apps/api/src/lib/spanish-locale-rollout.ts
+++ b/turbo/apps/api/src/lib/spanish-locale-rollout.ts
@@ -1,0 +1,10 @@
+import { optionalEnv } from "./env";
+
+/**
+ * Keep the writer disabled until old API readers have drained. Remove this
+ * gate only after every rollback-eligible API version accepts stored es-ES
+ * locale preferences.
+ */
+export function isSpanishLocaleRolloutEnabled(): boolean {
+  return optionalEnv("SPANISH_LOCALE_ROLLOUT_ENABLED") === "true";
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
@@ -28,6 +28,7 @@ import {
 import { zeroOrgLogoContract } from "@vm0/api-contracts/contracts/zero-org-logo";
 import {
   addClientCapabilityToVersion,
+  CLIENT_CAPABILITY_ES_ES_LOCALE,
   CLIENT_CAPABILITY_JA_JP_LOCALE,
   CLIENT_CAPABILITY_KO_KR_LOCALE,
   CLIENT_CAPABILITY_ID_ID_LOCALE,
@@ -87,9 +88,17 @@ export const GERMAN_CLIENT_VERSION = addClientCapabilityToVersion(
   "0.648.0",
   CLIENT_CAPABILITY_DE_DE_LOCALE,
 );
-export const ALL_LOCALES_CLIENT_VERSION = addClientCapabilityToVersion(
+const ALL_LOCALES_WITH_GERMAN_CLIENT_VERSION = addClientCapabilityToVersion(
   ALL_LOCALES_WITH_INDONESIAN_CLIENT_VERSION,
   CLIENT_CAPABILITY_DE_DE_LOCALE,
+);
+export const SPANISH_CLIENT_VERSION = addClientCapabilityToVersion(
+  "0.648.0",
+  CLIENT_CAPABILITY_ES_ES_LOCALE,
+);
+export const ALL_LOCALES_CLIENT_VERSION = addClientCapabilityToVersion(
+  ALL_LOCALES_WITH_GERMAN_CLIENT_VERSION,
+  CLIENT_CAPABILITY_ES_ES_LOCALE,
 );
 
 type ZeroLogsSearchQuery = z.input<

--- a/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
@@ -14,6 +14,7 @@ import {
   JAPANESE_CLIENT_VERSION,
   KOREAN_CLIENT_VERSION,
   INDONESIAN_CLIENT_VERSION,
+  SPANISH_CLIENT_VERSION,
 } from "./helpers/api-bdd-misc";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 
@@ -621,7 +622,6 @@ describe("MISC-02: preferences, push subscription, user export, and empty logs",
       locale: "ko-KR",
       supportedLocales: ["en-US", "ko-KR"],
     });
-
     const japaneseClientRead = await api.readPreferences(
       admin,
       JAPANESE_CLIENT_VERSION,
@@ -786,6 +786,147 @@ describe("MISC-02: preferences, push subscription, user export, and empty logs",
     expect(rolledBack.body).toMatchObject({
       locale: "en-US",
       supportedLocales: ["en-US"],
+    });
+  });
+
+  it("negotiates Spanish across rollout and legacy clients", async () => {
+    const { api, admin } = testActors();
+    mockOptionalEnv("BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED", undefined);
+    mockOptionalEnv("JAPANESE_LOCALE_ROLLOUT_ENABLED", undefined);
+    mockOptionalEnv("KOREAN_LOCALE_ROLLOUT_ENABLED", undefined);
+    mockOptionalEnv("INDONESIAN_LOCALE_ROLLOUT_ENABLED", undefined);
+    mockOptionalEnv("GERMAN_LOCALE_ROLLOUT_ENABLED", undefined);
+    mockOptionalEnv("SPANISH_LOCALE_ROLLOUT_ENABLED", undefined);
+
+    const guarded = await api.readPreferences(admin, SPANISH_CLIENT_VERSION);
+    expect(guarded.body).toMatchObject({
+      locale: null,
+      supportedLocales: ["en-US"],
+    });
+
+    const rejected = await api.updatePreferences(
+      admin,
+      { locale: "es-ES" },
+      [400],
+      SPANISH_CLIENT_VERSION,
+    );
+    expectApiError(rejected.body);
+
+    const orgId = admin.orgId;
+    if (orgId === null) {
+      throw new Error("Expected an organization-scoped test actor");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      {
+        userId: admin.userId,
+        orgId,
+        ...(admin.orgRole && { orgRole: admin.orgRole }),
+      },
+      {
+        [FeatureSwitchKey.SpanishLocale]: true,
+      },
+    );
+
+    const publicOverrideRejected = await api.updatePreferences(
+      admin,
+      { locale: "es-ES" },
+      [400],
+      SPANISH_CLIENT_VERSION,
+    );
+    expectApiError(publicOverrideRejected.body);
+
+    mockOptionalEnv("SPANISH_LOCALE_ROLLOUT_ENABLED", "true");
+
+    const legacyClientRejected = await api.updatePreferences(
+      admin,
+      { locale: "es-ES" },
+      [400],
+    );
+    expectApiError(legacyClientRejected.body);
+
+    const japaneseClientRejected = await api.updatePreferences(
+      admin,
+      { locale: "es-ES" },
+      [400],
+      JAPANESE_CLIENT_VERSION,
+    );
+    expectApiError(japaneseClientRejected.body);
+
+    const english = await api.updatePreferences(
+      admin,
+      { locale: "en-US" },
+      [200],
+      SPANISH_CLIENT_VERSION,
+    );
+    expect(english.body).toMatchObject({
+      locale: "en-US",
+      supportedLocales: ["en-US", "es-ES"],
+    });
+
+    const spanish = await api.updatePreferences(
+      admin,
+      { locale: "es-ES" },
+      [200],
+      SPANISH_CLIENT_VERSION,
+    );
+    expect(spanish.body).toMatchObject({
+      locale: "es-ES",
+      supportedLocales: ["en-US", "es-ES"],
+    });
+
+    const legacyRead = await api.readPreferences(admin);
+    expect(legacyRead.body.locale).toBe("en-US");
+    expect(legacyRead.body.supportedLocales).toBeUndefined();
+
+    const japaneseClientRead = await api.readPreferences(
+      admin,
+      JAPANESE_CLIENT_VERSION,
+    );
+    expect(japaneseClientRead.body).toMatchObject({
+      locale: "en-US",
+      supportedLocales: ["en-US"],
+    });
+
+    await api.updatePreferences(admin, { timezone: "UTC" }, [200]);
+    const capableReread = await api.readPreferences(
+      admin,
+      SPANISH_CLIENT_VERSION,
+    );
+    expect(capableReread.body.locale).toBe("es-ES");
+
+    mockOptionalEnv("SPANISH_LOCALE_ROLLOUT_ENABLED", undefined);
+    const rollbackRead = await api.readPreferences(
+      admin,
+      SPANISH_CLIENT_VERSION,
+    );
+    expect(rollbackRead.body).toMatchObject({
+      locale: "en-US",
+      supportedLocales: ["en-US"],
+    });
+    await api.updatePreferences(
+      admin,
+      { timezone: "Europe/Madrid" },
+      [200],
+      SPANISH_CLIENT_VERSION,
+    );
+
+    mockOptionalEnv("SPANISH_LOCALE_ROLLOUT_ENABLED", "true");
+    const postRollbackRead = await api.readPreferences(
+      admin,
+      SPANISH_CLIENT_VERSION,
+    );
+    expect(postRollbackRead.body.locale).toBe("es-ES");
+
+    mockOptionalEnv("BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED", "true");
+    mockOptionalEnv("JAPANESE_LOCALE_ROLLOUT_ENABLED", "true");
+    const allLocales = await api.readPreferences(
+      admin,
+      ALL_LOCALES_CLIENT_VERSION,
+    );
+    expect(allLocales.body).toMatchObject({
+      locale: "es-ES",
+      supportedLocales: ["en-US", "pt-BR", "ja-JP", "es-ES"],
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -55,6 +55,27 @@ describe("/api/zero/feature-switches", () => {
     ).toBeTruthy();
   });
 
+  it("projects the Spanish locale deployment switch", async () => {
+    createZeroRouteMocks(context).clerk.session(
+      "user_spanish_locale_switch_test",
+      "org_spanish_locale_switch_test",
+      "org:member",
+    );
+    const headers = { authorization: "Bearer clerk-session" };
+
+    mockOptionalEnv("SPANISH_LOCALE_ROLLOUT_ENABLED", undefined);
+    const disabled = await accept(client().get({ headers }), [200]);
+    expect(
+      disabled.body.effectiveSwitches[FeatureSwitchKey.SpanishLocale],
+    ).toBeFalsy();
+
+    mockOptionalEnv("SPANISH_LOCALE_ROLLOUT_ENABLED", "true");
+    const enabled = await accept(client().get({ headers }), [200]);
+    expect(
+      enabled.body.effectiveSwitches[FeatureSwitchKey.SpanishLocale],
+    ).toBeTruthy();
+  });
+
   it("persists and activates inline templates for a non-staff org", async () => {
     createZeroRouteMocks(context).clerk.session(
       "user_nonstaff_feature_switch_test",

--- a/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
@@ -4,9 +4,11 @@ import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { isBrazilianPortugueseLocaleRolloutEnabled } from "../../lib/brazilian-portuguese-locale-rollout";
+import { isGermanLocaleRolloutEnabled } from "../../lib/german-locale-rollout";
 import { isIndonesianLocaleRolloutEnabled } from "../../lib/indonesian-locale-rollout";
 import { isJapaneseLocaleRolloutEnabled } from "../../lib/japanese-locale-rollout";
 import { isKoreanLocaleRolloutEnabled } from "../../lib/korean-locale-rollout";
+import { isSpanishLocaleRolloutEnabled } from "../../lib/spanish-locale-rollout";
 import { isZeroMailReplyFollowUpRolloutEnabled } from "../../lib/zero-mail-reply-follow-up-rollout";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -19,7 +21,6 @@ import {
   userFeatureSwitchOverrides,
 } from "../services/feature-switches.service";
 import { modelProviderGatewaySchemaAvailable } from "../services/model-provider-gateway-schema.service";
-import { isGermanLocaleRolloutEnabled } from "../../lib/german-locale-rollout";
 
 const featureSwitchesAuthOptions = {
   requireOrganization: true,
@@ -51,6 +52,8 @@ function featureSwitchResponseBody(params: {
     isIndonesianLocaleRolloutEnabled();
   effectiveSwitches[FeatureSwitchKey.GermanLocale] =
     isGermanLocaleRolloutEnabled();
+  effectiveSwitches[FeatureSwitchKey.SpanishLocale] =
+    isSpanishLocaleRolloutEnabled();
 
   return {
     switches: params.switches,

--- a/turbo/apps/api/src/signals/routes/zero-user-preferences.ts
+++ b/turbo/apps/api/src/signals/routes/zero-user-preferences.ts
@@ -1,6 +1,7 @@
 import { command, computed } from "ccstate";
 import {
   clientVersionSupportsCapability,
+  CLIENT_CAPABILITY_ES_ES_LOCALE,
   CLIENT_CAPABILITY_JA_JP_LOCALE,
   CLIENT_CAPABILITY_KO_KR_LOCALE,
   CLIENT_CAPABILITY_ID_ID_LOCALE,
@@ -20,6 +21,7 @@ import { isIndonesianLocaleRolloutEnabled } from "../../lib/indonesian-locale-ro
 import { badRequestMessage } from "../../lib/error";
 import { isJapaneseLocaleRolloutEnabled } from "../../lib/japanese-locale-rollout";
 import { isKoreanLocaleRolloutEnabled } from "../../lib/korean-locale-rollout";
+import { isSpanishLocaleRolloutEnabled } from "../../lib/spanish-locale-rollout";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { request$ } from "../context/hono";
@@ -40,11 +42,13 @@ interface LocaleRollout {
   readonly clientSupportsKorean: boolean;
   readonly clientSupportsIndonesian: boolean;
   readonly clientSupportsGerman: boolean;
+  readonly clientSupportsSpanish: boolean;
   readonly brazilianPortugueseEnabled: boolean;
   readonly japaneseEnabled: boolean;
   readonly koreanEnabled: boolean;
   readonly indonesianEnabled: boolean;
   readonly germanEnabled: boolean;
+  readonly spanishEnabled: boolean;
 }
 
 const localeRollout$ = computed((get): LocaleRollout => {
@@ -69,6 +73,10 @@ const localeRollout$ = computed((get): LocaleRollout => {
     clientVersion,
     CLIENT_CAPABILITY_DE_DE_LOCALE,
   );
+  const clientSupportsSpanish = clientVersionSupportsCapability(
+    clientVersion,
+    CLIENT_CAPABILITY_ES_ES_LOCALE,
+  );
 
   return {
     clientSupportsBrazilianPortuguese,
@@ -76,6 +84,7 @@ const localeRollout$ = computed((get): LocaleRollout => {
     clientSupportsKorean,
     clientSupportsIndonesian,
     clientSupportsGerman,
+    clientSupportsSpanish,
     brazilianPortugueseEnabled:
       clientSupportsBrazilianPortuguese &&
       isBrazilianPortugueseLocaleRolloutEnabled(),
@@ -84,6 +93,7 @@ const localeRollout$ = computed((get): LocaleRollout => {
     indonesianEnabled:
       clientSupportsIndonesian && isIndonesianLocaleRolloutEnabled(),
     germanEnabled: clientSupportsGerman && isGermanLocaleRolloutEnabled(),
+    spanishEnabled: clientSupportsSpanish && isSpanishLocaleRolloutEnabled(),
   };
 });
 
@@ -103,6 +113,9 @@ function supportedLocalesForRollout(rollout: LocaleRollout): UserLocale[] {
   }
   if (rollout.germanEnabled) {
     supportedLocales.push("de-DE");
+  }
+  if (rollout.spanishEnabled) {
+    supportedLocales.push("es-ES");
   }
   return supportedLocales;
 }
@@ -128,7 +141,8 @@ function projectUserPreferences(
       rollout.clientSupportsJapanese ||
       rollout.clientSupportsKorean ||
       rollout.clientSupportsIndonesian ||
-      rollout.clientSupportsGerman) && {
+      rollout.clientSupportsGerman ||
+      rollout.clientSupportsSpanish) && {
       supportedLocales,
     }),
   };
@@ -168,6 +182,7 @@ const updateUserPreferencesInner$ = command(
         allowKorean: rollout.koreanEnabled,
         allowIndonesian: rollout.indonesianEnabled,
         allowGerman: rollout.germanEnabled,
+        allowSpanish: rollout.spanishEnabled,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/zero-user-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-data.service.ts
@@ -67,7 +67,8 @@ function parseUserLocale(value: unknown): UserLocale | null {
     value === "ja-JP" ||
     value === "ko-KR" ||
     value === "id-ID" ||
-    value === "de-DE"
+    value === "de-DE" ||
+    value === "es-ES"
   ) {
     return value;
   }
@@ -191,6 +192,7 @@ interface UpdateUserPreferencesArgs extends UserScopedQuery {
   readonly allowKorean?: boolean;
   readonly allowIndonesian?: boolean;
   readonly allowGerman?: boolean;
+  readonly allowSpanish?: boolean;
 }
 
 type UpdateUserPreferencesResult =
@@ -207,6 +209,7 @@ function isUserPreferencesUpdateAllowed(
     (locale !== "ko-KR" || args.allowKorean === true) &&
     (locale !== "id-ID" || args.allowIndonesian === true) &&
     (locale !== "de-DE" || args.allowGerman === true) &&
+    (locale !== "es-ES" || args.allowSpanish === true) &&
     (timezone === undefined || isValidTimeZone(timezone))
   );
 }

--- a/turbo/apps/platform/i18next.config.ts
+++ b/turbo/apps/platform/i18next.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "i18next-cli";
 
 export default defineConfig({
-  locales: ["en-US", "pt-BR", "ja-JP", "ko-KR", "id-ID", "de-DE"],
+  locales: ["en-US", "pt-BR", "ja-JP", "ko-KR", "id-ID", "de-DE", "es-ES"],
   extract: {
     input: ["src/**/*.{ts,tsx}"],
     ignore: [

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -166,16 +166,19 @@
               ? "id-ID"
               : /^de(?:-|$)/i.test(navigator.language)
                 ? "de-DE"
-                : /^pt(?:-|$)/i.test(navigator.language)
-                  ? "pt-BR"
-                  : "en-US";
+                : /^es(?:-|$)/i.test(navigator.language)
+                  ? "es-ES"
+                  : /^pt(?:-|$)/i.test(navigator.language)
+                    ? "pt-BR"
+                    : "en-US";
         var locale =
           cached === "en-US" ||
           cached === "pt-BR" ||
           cached === "ja-JP" ||
           cached === "ko-KR" ||
           cached === "id-ID" ||
-          cached === "de-DE"
+          cached === "de-DE" ||
+          cached === "es-ES"
             ? cached
             : browserLocale;
         var copyByLocale = {
@@ -489,6 +492,58 @@
               description:
                 "Zero ist Ihr KI-Kollege von vm0. Schreiben Sie Zero oder chatten Sie im Web — für Recherche, E-Mails, Dokumente, Slack, GitHub, Notion und über 100 weitere Tools.",
               title: "Zero — Ihr KI-Kollege von vm0",
+            },
+          },
+          "es-ES": {
+            browserUpgrade: {
+              browser: {
+                actionLabel: "Actualizar navegador",
+                description:
+                  "Zero no es compatible con la versión actual de tu navegador. Actualiza el navegador para continuar.",
+                title: "Actualiza tu navegador para continuar",
+              },
+              chrome: {
+                actionLabel: "Actualizar Chrome",
+                description:
+                  "Zero no es compatible con la versión actual de tu navegador. Actualiza Chrome para continuar.",
+                title: "Actualiza Chrome para continuar",
+              },
+              chromium: {
+                actionLabel: "Actualizar Chromium",
+                description:
+                  "Zero no es compatible con la versión actual de tu navegador. Actualiza Chromium para continuar.",
+                title: "Actualiza Chromium para continuar",
+              },
+              ios: {
+                actionLabel: "Actualizar iOS",
+                description:
+                  "Zero no es compatible con la versión actual de tu navegador. Actualiza iOS para continuar.",
+                title: "Actualiza iOS para continuar",
+              },
+              safari: {
+                actionLabel: "Actualizar Safari",
+                description:
+                  "Zero no es compatible con la versión actual de tu navegador. Actualiza Safari para continuar.",
+                title: "Actualiza Safari para continuar",
+              },
+            },
+            loading: {
+              ariaLabel: "Cargando tu espacio de trabajo",
+              messages: [
+                "Activando las neuronas...",
+                "Preparando algunas ideas...",
+                "Dejándolo todo listo...",
+                "Ya casi está...",
+                "Cargando tu espacio de trabajo...",
+                "Afinando los instrumentos...",
+                "Conectando los puntos...",
+                "Reuniendo al equipo...",
+              ],
+            },
+            metadata: {
+              description:
+                "Zero es tu compañero de IA de vm0. Escríbele a Zero o chatea en la web: investiga, envía correos, crea documentos y usa Slack, GitHub, Notion y más de 100 herramientas.",
+              title: "Zero — Tu compañero de IA de vm0",
             },
           },
         };

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -4341,7 +4341,8 @@
           "indonesian": "Bahasa Indonesia",
           "japanese": "日本語",
           "korean": "한국어",
-          "portugueseBrazil": "Português (Brasil)"
+          "portugueseBrazil": "Português (Brasil)",
+          "spanish": "Español"
         },
         "title": "Sprache"
       },

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4341,7 +4341,8 @@
           "indonesian": "Bahasa Indonesia",
           "japanese": "日本語",
           "korean": "한국어",
-          "portugueseBrazil": "Português (Brasil)"
+          "portugueseBrazil": "Português (Brasil)",
+          "spanish": "Español"
         },
         "title": "Language"
       },

--- a/turbo/apps/platform/src/i18n/locales/es-ES/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/agents.json
@@ -1,0 +1,639 @@
+{
+  "actions": {
+    "cancel": "Cancelar",
+    "close": "Cerrar",
+    "copying": "Copiando…",
+    "create": "Crear",
+    "delete": "Eliminar agente",
+    "deleting": "Eliminando…",
+    "discard": "Descartar",
+    "retry": "Reintentar",
+    "save": "Guardar",
+    "saving": "Guardando…"
+  },
+  "authorization": {
+    "closeSearch": "Cerrar búsqueda",
+    "connectorsLink": "Conectores",
+    "connectorsSaved": "Conectores guardados",
+    "customConnectors": {
+      "authorize": "Autoriza {{connectorName}} para este agente",
+      "description": "Conectores personalizados registrados por tu organización. Solo los conectores para los que hayas proporcionado un secreto pueden activarse.",
+      "noSecret": "Ningún secreto configurado",
+      "noSecretSuffix": " — ningún secreto configurado",
+      "saved": "Conectores personalizados guardados"
+    },
+    "description": "Cuando se ejecuta, el agente puede usar tus servicios conectados de forma segura. Puedes gestionar o desactivar el acceso en cualquier momento.",
+    "findConnectors": "Buscar conectores",
+    "noConnectorsAfterLink": " para conectar tu primer servicio.",
+    "noConnectorsAlt": "Sin conectores",
+    "noConnectorsBeforeLink": "Aún no hay servicios conectados. Ve a la ",
+    "noResults": "No hay resultados para \"{{search}}\"",
+    "permissionLoadError": "No se pudieron cargar los permisos",
+    "permissionsUpdated": "Permisos actualizados",
+    "searchPlaceholder": "Buscar conectores..."
+  },
+  "avatar": {
+    "accessibilityDescription": "Personaliza el estilo del avatar del agente, el color y los detalles faciales.",
+    "actions": {
+      "customize": "Personalizar avatar"
+    },
+    "create": "Crear avatar personalizado",
+    "description": "Elige un estilo o pulsa Mezclar para llevarte una sorpresa.",
+    "intensity": {
+      "chill": "Tranquilo",
+      "hyped": "Muy emocionado",
+      "normal": "Normal"
+    },
+    "nextStep": "Siguiente paso",
+    "previousStep": "Paso anterior",
+    "randomize": "Cambiar avatar al azar",
+    "shuffleHint": "Mezcla los rasgos y prueba un aspecto aleatorio.",
+    "steps": {
+      "angle": "Ángulo",
+      "color": "Color",
+      "face": "Rostro",
+      "hair": "Cabello",
+      "mood": "Estado de ánimo",
+      "skin": "Piel"
+    },
+    "title": "Dale un rostro a tu agente",
+    "use": "Usa este avatar"
+  },
+  "delete": {
+    "dangerZone": "Zona de peligro",
+    "dangerZoneDescription": "Elimina permanentemente este agente y todos sus datos. Esta acción no puede deshacerse.",
+    "description": "Elimina el agente, sus flujos de trabajo, automatizaciones y el historial de chats de todos.",
+    "irreversible": "Esto no se puede deshacer.",
+    "success": "Agente eliminado",
+    "title": "¿Eliminar {{agentName}}?",
+    "workflows": {
+      "copyTo": "Copiar a {{agentName}}",
+      "deleteWithAgent": "Eliminar con el agente",
+      "description": "Copia un flujo de trabajo a otro agente para conservarlo. Todo lo que quede se eliminará.",
+      "handle": "Gestiona el flujo de trabajo {{workflowTitle}}",
+      "title": "¿Mantener algún flujo de trabajo?"
+    }
+  },
+  "detail": {
+    "chatWith": "Chatear con {{agentName}}",
+    "defaultDescription": "Tu compañero de equipo con IA, adaptado a ti",
+    "noSelection": "Ningún agente seleccionado",
+    "notFound": {
+      "back": "Volver al equipo",
+      "description": "El agente \"{{agentId}}\" no existe o no tienes acceso a él.",
+      "title": "Agente no encontrado"
+    },
+    "tabs": {
+      "authorization": "Autorización",
+      "instructions": "Instrucciones",
+      "profile": "Perfil"
+    },
+    "viewProfile": "Ver perfil del agente"
+  },
+  "errors": {
+    "unknown": "Error desconocido"
+  },
+  "fallbackName": "Agente",
+  "ideation": {
+    "all": "Todos",
+    "catalog": {
+      "creative": {
+        "cases": {
+          "cloudinary-media-optimizer": {
+            "description": "Optimizar y transformar imágenes en masa",
+            "title": "Optimizador de medios de Cloudinary"
+          },
+          "elevenlabs-audio-content": {
+            "description": "Narraciones de voz a partir de artículos de Notion, guardadas en Drive",
+            "title": "Contenido de audio con ElevenLabs"
+          },
+          "fal-ai-image-generation": {
+            "description": "Genera imágenes de productos a partir de descripciones en Notion",
+            "title": "Generación de imágenes con Fal AI"
+          },
+          "heygen-video-from-script": {
+            "description": "Un guion de Notion se convierte en un vídeo de HeyGen y se avisa al equipo",
+            "title": "Vídeo de HeyGen a partir de un guion"
+          },
+          "runway-video-from-brief": {
+            "description": "Genera vídeos cortos a partir de un brief creativo",
+            "title": "Vídeo de Runway a partir de un briefing"
+          }
+        },
+        "title": "Creativo"
+      },
+      "engineering": {
+        "cases": {
+          "batch-create-issues": {
+            "description": "Pega una lista y Zero creará las incidencias por ti",
+            "title": "Creación de incidencias por lotes"
+          },
+          "browserbase-web-testing": {
+            "description": "Pruebas automatizadas de navegador para tu aplicación web",
+            "title": "Pruebas web con Browserbase"
+          },
+          "cloudflare-traffic-security-report": {
+            "description": "Resumen semanal de Slack de eventos de tráfico y seguridad",
+            "title": "Informe de tráfico y seguridad de Cloudflare"
+          },
+          "codebase-investigation": {
+            "description": "Proporciona una URL y Zero rastreará el error por todo el repositorio",
+            "title": "Investigación del código fuente"
+          },
+          "daily-standup-report": {
+            "description": "Las métricas matutinas se convierten en una presentación de diapositivas publicada en Slack",
+            "title": "Informe de la reunión diaria"
+          },
+          "deep-research-code-analysis": {
+            "description": "Explica cómo funciona un subsistema en tu base de código",
+            "title": "Análisis de código en profundidad"
+          },
+          "github-pr-summarizer": {
+            "description": "Resúmenes de pull requests fusionados en Notion con publicaciones opcionales de Slack",
+            "title": "Resumen de pull requests de GitHub"
+          },
+          "github-progress-weekly": {
+            "description": "Actividad semanal de repositorios resumida por característica",
+            "title": "Progreso semanal en GitHub"
+          },
+          "gitlab-to-github-migration-helper": {
+            "description": "Replica las incidencias y solicitudes de fusión de GitLab en GitHub",
+            "title": "Asistente de migración de GitLab a GitHub"
+          },
+          "jira-github-issue-sync": {
+            "description": "Mantiene sincronizados los tickets de Jira y las incidencias de GitHub",
+            "title": "Sincronización de incidencias entre Jira y GitHub"
+          },
+          "make-scenario-builder": {
+            "description": "Diseña escenarios de Make de varios pasos a partir de una descripción",
+            "title": "Creador de escenarios de Make"
+          },
+          "security-dependency-alert-digest": {
+            "description": "Alertas semanales de seguridad y dependencias de GitHub",
+            "title": "Resumen de alertas de seguridad y dependencias"
+          },
+          "sentry-issue-digest": {
+            "description": "Resumen matutino de incidencias agrupadas por gravedad",
+            "title": "Resumen de incidencias de Sentry"
+          },
+          "vercel-deploy-digest": {
+            "description": "Vincula cada despliegue con su commit y avisa en Slack cuando falla",
+            "title": "Resumen de despliegues de Vercel"
+          },
+          "zapier-vm0-migration": {
+            "description": "Recrea tus flujos de trabajo de Zapier como agentes VM0",
+            "title": "Migración de Zapier a VM0"
+          }
+        },
+        "title": "Ingeniería"
+      },
+      "everyone": {
+        "cases": {
+          "browser-screenshots": {
+            "description": "Abre una página en el navegador y devuelve una captura de pantalla",
+            "title": "Capturas de pantalla del navegador"
+          },
+          "calendar-optimizer": {
+            "description": "Ayuda con conflictos, sobrecarga y tiempo de concentración",
+            "title": "Optimizador de calendario"
+          },
+          "calendly-booking-sync": {
+            "description": "Añade las nuevas reservas al calendario y avisa en Slack",
+            "title": "Sincronización de reservas de Calendly"
+          },
+          "email-assistant": {
+            "description": "Resumen de la bandeja de entrada matutina con los siguientes pasos sugeridos",
+            "title": "Asistente de correo electrónico"
+          },
+          "granola-notes-to-notion": {
+            "description": "Notas de reuniones de Granola sincronizadas con una base de datos de Notion",
+            "title": "Notas de Granola en Notion"
+          },
+          "lark-slack-message-relay": {
+            "description": "Reenvía mensajes entre Lark y Slack en ambos sentidos",
+            "title": "Reenvío de mensajes entre Lark y Slack"
+          },
+          "line-message-relay": {
+            "description": "Reenvía mensajes de LINE a Slack y viceversa",
+            "title": "Reenvío de mensajes de LINE"
+          },
+          "meeting-notes-pipeline": {
+            "description": "Notas de Fireflies para Notion con seguimientos en Slack",
+            "title": "Flujo de notas de reuniones"
+          },
+          "morning-brief": {
+            "description": "Convierte el correo, el calendario y las notas en un breve plan diario",
+            "title": "Resumen matutino"
+          },
+          "perplexity-deep-research": {
+            "description": "Resúmenes de investigaciones impulsados por IA guardados en Notion",
+            "title": "Investigación en profundidad con Perplexity"
+          },
+          "personal-weekly-digest": {
+            "description": "Pull requests, correo y calendario reunidos en una actualización de Slack",
+            "title": "Resumen semanal personal"
+          },
+          "self-update-instructions": {
+            "description": "Actualiza las instrucciones del agente directamente en el chat",
+            "title": "Instrucciones de actualización automática"
+          },
+          "send-messages-on-your-behalf": {
+            "description": "Publica anuncios de equipo para Slack por ti",
+            "title": "Envío de mensajes en tu nombre"
+          },
+          "strava-team-fitness-digest": {
+            "description": "Resumen semanal de actividades del equipo publicado en Slack",
+            "title": "Resumen de actividad del equipo en Strava"
+          },
+          "tavily-web-research-pipeline": {
+            "description": "Busca en internet y recopila hallazgos en Notion",
+            "title": "Flujo de investigación web con Tavily"
+          },
+          "tl-dv-meeting-recap": {
+            "description": "Grabaciones de reuniones resumidas en Notion con elementos de acción",
+            "title": "Resumen de reuniones de tl;dv"
+          }
+        },
+        "title": "Todos"
+      },
+      "marketing": {
+        "cases": {
+          "apify-web-scraper-to-sheets": {
+            "description": "Apify extrae sitios web y organiza los datos en filas de Google Sheets",
+            "title": "Extracción web de Apify a Sheets"
+          },
+          "brevo-email-nurture-sequence": {
+            "description": "Secuencias de correo automatizadas a partir de eventos del CRM",
+            "title": "Secuencia de nutrición de leads con Brevo"
+          },
+          "competitive-intel-scraper": {
+            "description": "Firecrawl observa los sitios de la competencia y registra los cambios en Notion",
+            "title": "Extractor de inteligencia competitiva"
+          },
+          "competitor-research-to-notion": {
+            "description": "Investigación sobre X guardada como notas estructuradas en Notion",
+            "title": "Investigación de competidores en Notion"
+          },
+          "content-planner": {
+            "description": "Haz una lluvia de ideas sobre temas y haz un esquema de calendario editorial",
+            "title": "Planificador de contenidos"
+          },
+          "dev-to-auto-publisher": {
+            "description": "Publica entradas de Notion en Dev.to y las enlaza desde X",
+            "title": "Publicación automática en Dev.to"
+          },
+          "discord-community-insights": {
+            "description": "Guarda los comentarios de Discord en Notion y publica un resumen semanal en Slack",
+            "title": "Análisis de la comunidad de Discord"
+          },
+          "instagram-engagement-tracker": {
+            "description": "Registra la interacción en Sheets y publica resúmenes semanales en Slack",
+            "title": "Seguimiento de interacción en Instagram"
+          },
+          "loops-email-campaign": {
+            "description": "Redactar y enviar correos transaccionales mediante Loops",
+            "title": "Campaña de correo con Loops"
+          },
+          "marketing-automation-system": {
+            "description": "Tres agentes para investigación, seguimiento semanal y trabajo puntual",
+            "title": "Sistema de automatización de marketing"
+          },
+          "marketing-content-planning": {
+            "description": "Planifica historias de lanzamiento a partir de Slack, entrevistas y competidores",
+            "title": "Planificación de contenidos de marketing"
+          },
+          "onboarding-email-use-cases": {
+            "description": "Encuentra ángulos de incorporación de Slack y entrevistas",
+            "title": "Casos de uso del correo de incorporación"
+          },
+          "serpapi-keyword-tracker": {
+            "description": "Sigue cada semana las posiciones por palabra clave y regístralas en Sheets",
+            "title": "Seguimiento de palabras clave con SerpAPI"
+          },
+          "similarweb-traffic-comparison": {
+            "description": "Comparativas de tráfico con la competencia guardadas en Notion",
+            "title": "Comparación de tráfico con SimilarWeb"
+          },
+          "social-media-content-calendar": {
+            "description": "Convierte un calendario de Sheets en publicaciones para cada red",
+            "title": "Calendario de contenidos en redes sociales"
+          },
+          "x-brand-monitor": {
+            "description": "Las menciones de marca en X se guardan en Notion con alertas de equipo",
+            "title": "Monitor de marca en X"
+          },
+          "youtube-to-x-thread-repurposer": {
+            "description": "Cuando se publique un nuevo vídeo de YouTube, crea un resumen en Notion y un hilo en X para promocionarlo",
+            "title": "Conversión de vídeos de YouTube en hilos de X"
+          }
+        },
+        "title": "Marketing"
+      },
+      "ops": {
+        "cases": {
+          "agentmail-inbox": {
+            "description": "Crea y gestiona bandejas de entrada con la API de AgentMail",
+            "title": "Bandeja de entrada de AgentMail"
+          },
+          "clickup-slack-standups": {
+            "description": "Tareas diarias de ClickUp publicadas como stand-up en Slack",
+            "title": "Reuniones diarias de ClickUp en Slack"
+          },
+          "google-docs-notion-migrator": {
+            "description": "Migra lotes de Google Docs a Notion y conserva el diseño",
+            "title": "Migrador de Google Docs a Notion"
+          },
+          "google-drive-file-organizer": {
+            "description": "Nuevos archivos ordenados automáticamente en carpetas",
+            "title": "Organizador de archivos de Google Drive"
+          },
+          "jotform-intake-to-notion": {
+            "description": "Las respuestas de los formularios llegan a Notion con notificaciones de Slack",
+            "title": "Respuestas de Jotform en Notion"
+          },
+          "monday-com-weekly-digest": {
+            "description": "Progreso semanal de los tableros de Monday.com publicado en Slack",
+            "title": "Resumen semanal de Monday.com"
+          },
+          "pdf-contract-processor": {
+            "description": "Campos de contratos en Notion con recordatorios antes de su vencimiento",
+            "title": "Procesador de contratos PDF"
+          },
+          "revenuecat-subscription-digest": {
+            "description": "Métricas de suscripción en Sheets con alertas de abandono en Slack",
+            "title": "Resumen de suscripciones de RevenueCat"
+          },
+          "todoist-notion-task-sync": {
+            "description": "Replica las tareas de Todoist en Notion para el equipo",
+            "title": "Sincronización de tareas de Todoist con Notion"
+          },
+          "wrike-project-reporter": {
+            "description": "Resúmenes semanales de progreso de Wrike en Slack",
+            "title": "Informe de proyectos de Wrike"
+          },
+          "xero-financial-summary": {
+            "description": "Beneficios semanales y flujo de caja de Xero en Slack",
+            "title": "Resumen financiero de Xero"
+          }
+        },
+        "title": "Operaciones"
+      },
+      "product": {
+        "cases": {
+          "asana-notion-project-sync": {
+            "description": "Replica los hitos y las tareas de Asana en Notion",
+            "title": "Sincronización de proyectos de Asana con Notion"
+          },
+          "feedback-router": {
+            "description": "Envía los comentarios de Slack al lugar correcto según tus reglas",
+            "title": "Enrutador de comentarios"
+          },
+          "linear-prd-implementer": {
+            "description": "Convierte las especificaciones de Notion en proyectos e incidencias de Linear",
+            "title": "Implementador de PRD en Linear"
+          },
+          "metabase-dashboard-digest": {
+            "description": "Las instantáneas del panel de control se publican automáticamente en Slack",
+            "title": "Resumen de paneles de Metabase"
+          },
+          "pricing-analysis": {
+            "description": "Analiza las estrategias de precios de la competencia y compáralas con productos similares",
+            "title": "Análisis de precios"
+          },
+          "product-copy-naming": {
+            "description": "Nombres más amigables para términos técnicos en el producto",
+            "title": "Redacción y nomenclatura del producto"
+          }
+        },
+        "title": "Producto"
+      },
+      "sales": {
+        "cases": {
+          "airtable-deal-tracker": {
+            "description": "Las ofertas se sincronizan con las hojas y Slack cuando se cierran",
+            "title": "Seguimiento de oportunidades en Airtable"
+          },
+          "bitrix24-lead-nurture": {
+            "description": "Los nuevos leads de Bitrix reciben tareas de seguimiento y avisos en Slack",
+            "title": "Nutrición de leads con Bitrix24"
+          },
+          "hubspot-sales-reporter": {
+            "description": "Resúmenes semanales de HubSpot guardados como informes estructurados",
+            "title": "Informe de ventas de HubSpot"
+          },
+          "lead-follow-up-pipeline": {
+            "description": "Los nuevos leads se convierten en tareas HubSpot con alertas de Slack",
+            "title": "Flujo de seguimiento de leads"
+          },
+          "salesforce-pipeline-digest": {
+            "description": "Actualizaciones semanales de oportunidades de Salesforce en Slack",
+            "title": "Resumen del pipeline de Salesforce"
+          },
+          "streak-pipeline-report": {
+            "description": "Estadísticas semanales del pipeline del CRM de Gmail publicadas en Slack",
+            "title": "Informe del pipeline de Streak"
+          },
+          "win-loss-reporter": {
+            "description": "Tendencias de ganancias y pérdidas del pipeline publicadas en Slack",
+            "title": "Informe de ganancias y pérdidas"
+          }
+        },
+        "title": "Ventas"
+      },
+      "support": {
+        "cases": {
+          "chatwoot-notion-support-log": {
+            "description": "Conversaciones con clientes registradas y categorizadas en Notion",
+            "title": "Registro de soporte de Chatwoot en Notion"
+          },
+          "customer-support-bot": {
+            "description": "Respuestas de la base de conocimientos y tareas para cubrir sus lagunas",
+            "title": "Bot de atención al cliente"
+          },
+          "intercom-conversation-triager": {
+            "description": "Convierte las conversaciones de Intercom en tareas priorizadas de Notion",
+            "title": "Clasificación de conversaciones de Intercom"
+          },
+          "support-ticket-router": {
+            "description": "Envía los tickets a Notion y avisa en Slack cuando son urgentes",
+            "title": "Enrutador de tickets de soporte"
+          },
+          "zendesk-notion-knowledge-base": {
+            "description": "Extrae las preguntas frecuentes de Zendesk y las añade automáticamente a una página de preguntas frecuentes en Notion",
+            "title": "Base de conocimientos de Zendesk en Notion"
+          }
+        },
+        "title": "Soporte"
+      }
+    },
+    "chat": "Chat",
+    "description": "Haz clic en cualquier tarjeta para iniciar una conversación. Podría convertirse en una tarea bajo demanda, un flujo de trabajo recurrente o un subagente.",
+    "entry": {
+      "description": "Explora los casos de uso de todos los conectores",
+      "title": "Ideas y casos de uso",
+      "viewAll": "Ver todo"
+    },
+    "search": {
+      "accessibilityLabel": "Buscar casos de uso",
+      "empty": "Ningún caso de uso coincide con tu búsqueda.",
+      "placeholder": "Buscar"
+    },
+    "title": "Ideas y casos de uso"
+  },
+  "instructions": {
+    "editor": {
+      "accessibilityLabel": "Editor de instrucciones",
+      "footerHint": "Edita las instrucciones directamente para personalizar el comportamiento de tu agente.",
+      "placeholder": "Escribe instrucciones para tu agente...",
+      "toolbar": {
+        "blockquote": "Cita en bloque",
+        "bold": "Negrita",
+        "bulletList": "Lista con viñetas",
+        "heading1": "Título 1",
+        "heading2": "Título 2",
+        "heading3": "Título 3",
+        "inlineCode": "Código en línea",
+        "italic": "Cursiva",
+        "orderedList": "Lista numerada",
+        "strikethrough": "Tachado"
+      }
+    },
+    "saved": "Instrucciones guardadas"
+  },
+  "list": {
+    "actions": {
+      "new": "Nuevo agente"
+    },
+    "cards": {
+      "coreDescription": "Tu agente principal",
+      "createdBy": "Creado por {{creator}}",
+      "subagentDescription": "Subagente",
+      "unknownCreator": "Desconocido"
+    },
+    "create": {
+      "accessibilityDescription": "Nombra al nuevo agente, elige su visibilidad y personaliza su avatar.",
+      "creating": "Creando…",
+      "description": "Ponle nombre a tu agente y decide quién puede usarlo.",
+      "namePlaceholder": "por ejemplo, Asistente de Investigación",
+      "newAgentAlt": "Nuevo agente",
+      "success": "{{agentName}} creado con éxito",
+      "title": "Crea un nuevo agente",
+      "visibility": {
+        "private": {
+          "description": "(solo tú puedes verlo y usarlo)",
+          "label": "Privado"
+        },
+        "public": {
+          "description": "(cualquiera en este espacio puede usarlo)",
+          "label": "Público"
+        }
+      },
+      "visibilityLabel": "Visibilidad"
+    },
+    "description": "{{agentName}} y subagentes trabajando juntos para ejecutar flujos de trabajo personalizados para ti y tu equipo.",
+    "documentTitle": "Agentes",
+    "privateEmpty": {
+      "description": "Crea un agente que solo tú puedas ver y usar. Los agentes privados son ilimitados.",
+      "title": "Todavía no hay agentes privados"
+    },
+    "tabs": {
+      "private": "Privado",
+      "public": "Público"
+    },
+    "title": "Agentes"
+  },
+  "profile": {
+    "fields": {
+      "avatar": {
+        "description": "Crea tu propio avatar.",
+        "label": "Avatar"
+      },
+      "description": {
+        "description": "Indica para qué sirve este agente; tus compañeros de equipo podrán verlo.",
+        "label": "Descripción",
+        "placeholder": "¿Qué hace este agente?"
+      },
+      "name": {
+        "description": "Se muestra en la lista del equipo y cuando este agente habla.",
+        "label": "Nombre",
+        "placeholder": "¿Cómo quieres llamarlo?"
+      },
+      "tone": {
+        "accessibilityLabel": "Cómo suena {{agentName}}",
+        "description": "Estilo de voz para las respuestas. Previsualiza las actualizaciones cuando cambias el tono.",
+        "groupLabel": "Tono",
+        "label": "Cómo suena"
+      },
+      "visibility": {
+        "description": "Visible para todos en este espacio de trabajo.",
+        "label": "Hacer público"
+      }
+    },
+    "makePrivate": {
+      "confirm": "Hacer privado",
+      "description": "Mientras este agente sea privado, los demás miembros perderán el acceso a su historial de chat. Lo recuperarán si vuelves a hacerlo público.",
+      "title": "¿Hacer privado a {{agentName}}?",
+      "warningDescription": "Los demás miembros dejarán de ver a {{agentName}} y sus conversaciones.",
+      "warningTitle": "Los miembros pierden el acceso"
+    },
+    "saved": "Perfil guardado",
+    "tones": {
+      "direct": {
+        "agentSample": "Viernes. Enviaré un borrador el jueves.",
+        "hint": "Al grano",
+        "label": "Directo",
+        "userSample": "Necesito el informe del tercer trimestre para el viernes."
+      },
+      "friendly": {
+        "agentSample": "¡Por supuesto! Te enviaré ese informe del tercer trimestre para el viernes—enviaré un borrador el jueves para que puedas echarle un vistazo.",
+        "hint": "Cálido y accesible",
+        "label": "Amistoso",
+        "userSample": "Necesito el informe del tercer trimestre para el viernes."
+      },
+      "professional": {
+        "agentSample": "Tendré listo el informe del tercer trimestre para el viernes. Te enviaré un borrador el jueves para que lo revises.",
+        "hint": "Claro y cuidado",
+        "label": "Profesional",
+        "userSample": "Necesito el informe del tercer trimestre para el viernes."
+      },
+      "supportive": {
+        "agentSample": "Me aseguraré de que tengas el informe del tercer trimestre para el viernes. Enviaré un borrador el jueves para que tengas tiempo de revisar—avísame si quieres algo más.",
+        "hint": "Siempre de tu lado",
+        "label": "Servicial",
+        "userSample": "Necesito el informe del tercer trimestre para el viernes."
+      }
+    }
+  },
+  "sidebar": {
+    "clearSearch": "Borrar búsqueda",
+    "description": "Elige un agente para iniciar una conversación.",
+    "descriptionWithChats": "Elige un agente o salta a un chat.",
+    "leadDescription": "Tu asistente principal, siempre aquí para ti",
+    "markAllRead": "Marcar todo como leído",
+    "more": "Más",
+    "new": "Nuevo",
+    "noAgents": "No se encontraron agentes",
+    "noResults": "No se encontraron resultados",
+    "noSubagents": "Aún no hay subagentes disponibles.",
+    "openConversation": "Abrir una conversación",
+    "openMenu": "Abrir menú de agentes",
+    "pin": "Fijar en la barra lateral",
+    "pinned": "Fijados",
+    "pinnedAgents": "Agentes fijados",
+    "searchAgents": "Buscar agentes...",
+    "searchAgentsAndChats": "Buscar agentes y conversaciones...",
+    "sections": {
+      "chats": "Conversaciones",
+      "lead": "Principal",
+      "others": "Otros"
+    },
+    "talkTo": "Hablar con",
+    "unpin": "Desfijar"
+  },
+  "status": {
+    "unread": "No leído"
+  },
+  "unsaved": {
+    "message": "Tienes cambios sin guardar"
+  }
+}

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -353,6 +353,7 @@
       "slack": "Slack",
       "teams": "Teams",
       "telegram": "Telegram",
+      "test": "Prueba",
       "web": "Web",
       "webhook": "Webhook",
       "workflowEvent": "Evento de flujo de trabajo",
@@ -1313,6 +1314,18 @@
       "providerDeletedSuffix": "para continuar.",
       "providerIncompatibleAction": "Empieza una nueva sesión",
       "providerIncompatiblePrefix": "Esta sesión se inició con un modelo diferente y no se puede continuar con el actual.",
+      "recovery": {
+        "capacityDescription": "Este modelo está temporalmente al límite de capacidad. Inténtalo de nuevo en unos minutos o cambia de modelo ahora.",
+        "capacityTitle": "El modelo de {{framework}} está ocupado",
+        "claudeCode": "Claude Code",
+        "codex": "Codex",
+        "resetAndTryAgain": "Restablecer e intentar de nuevo",
+        "resetsAt": "Se restablece {{time}}",
+        "selectModel": "Cambiar de modelo",
+        "tryAgain": "Intentar de nuevo",
+        "usageDescription": "Puedes continuar cuando se restablezca tu límite de uso o cambiar de modelo ahora.",
+        "usageTitle": "Se alcanzó el límite de {{framework}}"
+      },
       "runCancelled": "Se detuvo a mitad de la respuesta; puedes retomarla cuando quieras."
     },
     "feedback": {
@@ -2253,6 +2266,12 @@
         "manageDialogTitle": "Gestionar bot de Feishu",
         "moreOptions": "Más opciones para {{bot}}",
         "pageDescription": "Gestiona el enrutamiento de bots para este espacio de trabajo",
+        "permissions": {
+          "description": "Abre Permisos y ámbitos en la consola de desarrolladores de Feishu y añade todos los ámbitos que se indican a continuación para la identidad de usuario. Estos ámbitos de colaboración permiten al conector trabajar con mensajes, archivos, documentos, hojas de cálculo, Base, Wiki, Slides, pizarras, búsquedas, calendarios, tareas y contactos básicos.",
+          "hint": "Después de cambiar los permisos, crea y publica una nueva versión de la aplicación para que la pantalla de consentimiento de OAuth pueda concederlos.",
+          "label": "Ámbitos de OAuth",
+          "title": "Habilitar permisos del conector"
+        },
         "publish": {
           "allMembersAlt": "Ajustes de disponibilidad de Feishu con la opción Todos los miembros seleccionada",
           "allMembersLabel": "Permitir que todos los miembros usen la aplicación",
@@ -2285,6 +2304,7 @@
           "done": "Completado",
           "events": "Eventos",
           "next": "Siguiente",
+          "permissions": "Permisos",
           "publish": "Publicar",
           "redirect": "Redirección",
           "tokens": "Tokens",
@@ -4199,6 +4219,41 @@
           "signIn": "Iniciar sesión con ChatGPT"
         }
       },
+      "gateways": {
+        "actions": "Acciones del gateway",
+        "add": "Añadir proveedor",
+        "addTitle": "Añadir proveedor de modelos",
+        "apiBaseUrl": "URL base de la API",
+        "apiBaseUrlPlaceholder": "https://gateway.example.com",
+        "apiKey": "Clave API",
+        "deleteConfirm": "¿Eliminar esta conexión con el proveedor de modelos? Las rutas de modelos que la usen dejarán de estar disponibles.",
+        "description": "Conecta un gateway gestionado por un administrador mediante Anthropic Messages, OpenAI Responses o ambos.",
+        "dialogDescription": "Configura cada protocolo con la URL base de la API que usa Claude Code o Codex.",
+        "editTitle": "Editar proveedor de modelos",
+        "empty": "No hay proveedores de modelos personalizados configurados.",
+        "errors": {
+          "invalidMappings": "Las asignaciones de modelos deben ser un objeto JSON cuyos valores sean nombres de modelos ascendentes.",
+          "missingProtocol": "Habilita al menos un protocolo.",
+          "missingSecret": "Introduce una clave API."
+        },
+        "headerName": "Cabecera de autenticación",
+        "headerValue": "Plantilla del valor de la cabecera",
+        "keepKey": "Déjalo en blanco para conservar la clave actual",
+        "modelMappings": "Asignaciones de modelos (JSON)",
+        "name": "Nombre",
+        "presets": {
+          "custom": "Personalizado",
+          "fireworks": "Fireworks AI",
+          "openrouter": "OpenRouter",
+          "vercel": "Vercel AI Gateway"
+        },
+        "protocols": {
+          "anthropicMessages": "Anthropic Messages",
+          "openaiResponses": "OpenAI Responses"
+        },
+        "requestPreview": "Solicitudes",
+        "title": "Conexiones de proveedores"
+      },
       "personal": {
         "actionForProvider": "{{action}} {{provider}}",
         "claudeDescription": "Conecta tu cuenta de Claude Code para usar rutas de modelos basadas en Claude.",
@@ -4258,16 +4313,21 @@
         "defaultModel": "Modelo por defecto",
         "defaultModelDescription": "Se usa cuando una tarea no elige su propio modelo.",
         "dialogDescription": "Decide cómo acceden los miembros a este modelo.",
+        "gateway": "Gateway personalizado",
+        "gatewayDescription": "Enrutar mediante una conexión de proveedor definida por un administrador.",
+        "gatewayProvider": "Conexión de proveedor",
         "getKey": "Obtener una clave",
         "invalidRoute": "Ruta inválida",
         "missingProvider": "Falta el proveedor",
         "model": "Modelo",
         "noAvailableModels": "No hay modelos disponibles",
+        "noMappedGateway": "Ninguna conexión de proveedor asigna este modelo.",
         "providedBy": "Proporcionado por",
         "provider": "Proveedor",
         "providerApiKey": "Clave API de {{provider}}",
         "secretStored": "Almacenado en secretos del espacio de trabajo.",
         "selectDefaultModel": "Seleccionar un modelo por defecto",
+        "selectGateway": "Seleccionar una conexión de proveedor",
         "selectModel": "Seleccionar un modelo",
         "selectProvider": "Seleccionar un proveedor",
         "workspaceDescription": "Disponible para todos en este espacio de trabajo.",
@@ -4346,7 +4406,10 @@
         "label": "Idioma",
         "options": {
           "english": "English",
+          "german": "Deutsch",
+          "indonesian": "Bahasa Indonesia",
           "japanese": "日本語",
+          "korean": "한국어",
           "portugueseBrazil": "Português (Brasil)",
           "spanish": "Español"
         },
@@ -4417,6 +4480,7 @@
       "delete": "Eliminar",
       "discard": "Descartar",
       "disconnect": "Desconectar",
+      "edit": "Editar",
       "loading": "Cargando",
       "moreOptions": "Más opciones",
       "reconnect": "Volver a conectar",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -525,7 +525,7 @@
       "download": "Descargar",
       "downloadArtifact": "Descargar artefacto",
       "downloadOptions": "Opciones de descarga",
-      "enterFullscreen": "Paso a pantalla completa",
+      "enterFullscreen": "Entrar en pantalla completa",
       "exitFullscreen": "Salir de pantalla completa",
       "more": "Más acciones de artefacto",
       "nextImage": "Siguiente artefacto de imagen",
@@ -535,8 +535,8 @@
       "resetZoom": "Reiniciar el zoom",
       "share": "Compartir",
       "shareArtifact": "Compartir artefacto",
-      "zoomIn": "Zoom en",
-      "zoomOut": "Zoom fuera"
+      "zoomIn": "Acercar",
+      "zoomOut": "Alejar"
     },
     "attachments": {
       "cancelUpload": "Cancelar la subida {{filename}}",
@@ -557,11 +557,11 @@
         "imageAria": "Mostrar artefactos de imagen",
         "label": "Filtros de tipo de artefacto",
         "presentation": "Presentaciones",
-        "presentationAria": "Artefactos de presentación del espectáculo",
+        "presentationAria": "Mostrar artefactos de presentación",
         "video": "Vídeos",
         "videoAria": "Mostrar artefactos de vídeo",
         "website": "Sitios web",
-        "websiteAria": "Artefactos de la web de la exposición"
+        "websiteAria": "Mostrar artefactos de sitios web"
       },
       "kindIcon": "{{kind}} artefacto",
       "loading": "Cargando artefactos"
@@ -603,18 +603,18 @@
       "hostedSite": "Sitio alojado",
       "image": "Imagen",
       "json": "JSON",
-      "markdown": "Descuento",
+      "markdown": "Markdown",
       "presentation": "Presentación",
       "text": "Texto",
       "video": "Vídeo"
     },
     "metadata": {
-      "generated": "Generados {{date}}"
+      "generated": "Generado el {{date}}"
     },
     "preview": {
       "audioLabel": "Vista previa de audio para {{filename}}",
-      "badge": "Avance",
-      "dialogLabel": "{{filename}} vista previa",
+      "badge": "Vista previa",
+      "dialogLabel": "Vista previa de {{filename}}",
       "emptyCsv": "CSV vacío.",
       "genericUnavailable": "Vista previa no disponible.",
       "noInline": "No hay una vista previa en línea disponible para este archivo.",
@@ -624,15 +624,15 @@
         "csv": "CSV",
         "html": "HTML",
         "json": "JSON",
-        "markdown": "Descuento",
-        "pdf": "pdf",
+        "markdown": "Markdown",
+        "pdf": "PDF",
         "text": "Texto",
         "video": "Vídeo"
       },
       "siteLabel": "Vista previa del sitio para {{title}}",
       "slideTitle": "Diapositiva {{number}}",
-      "unavailable": "{{kind}} vista previa no disponible.",
-      "videoLabel": "Vista previa en vídeo para {{filename}}"
+      "unavailable": "Vista previa de {{kind}} no disponible.",
+      "videoLabel": "Vista previa de vídeo para {{filename}}"
     },
     "sidebar": {
       "panelTitle": "Artefactos",
@@ -640,23 +640,23 @@
       "unavailable": "Este artefacto ya no está disponible."
     },
     "templates": {
-      "activeHtmlPreview": "{{title}} vista previa activa de HTML",
+      "activeHtmlPreview": "Vista previa HTML activa de {{title}}",
       "all": "Todos",
       "categories": "Categorías de plantilla",
       "category": "Categoría de plantilla",
-      "fullPreview": "{{title}} vista previa completa de la web",
-      "htmlPreview": "{{title}} Vista previa HTML",
+      "fullPreview": "Vista previa completa del sitio web {{title}}",
+      "htmlPreview": "Vista previa HTML de {{title}}",
       "illustration": "Ilustración",
-      "illustrationPreview": "{{title}} vista previa de ilustraciones",
+      "illustrationPreview": "Vista previa de la ilustración {{title}}",
       "multiAccent": "Multiacentos",
-      "nextSlide": "Avance siguiente diapositiva",
-      "noMatches": "Sin partidos",
-      "placeholder": "{{title}} previsualización del sitio web",
+      "nextSlide": "Vista previa de la diapositiva siguiente",
+      "noMatches": "Sin coincidencias",
+      "placeholder": "Vista previa del sitio web {{title}}",
       "playVideo": "Reproduce la vista previa de la plantilla de vídeo {{title}}",
-      "previewCurrentSlide": "{{title}} de vista previa en la diapositiva actual",
-      "previewSlide": "Vista previa {{slideNumber}}",
-      "previewWebsite": "Plantilla de página web de vista previa {{title}}",
-      "previousHtmlPreview": "{{title}} vista previa de HTML",
+      "previewCurrentSlide": "Vista previa de {{title}} en la diapositiva actual",
+      "previewSlide": "Vista previa de la diapositiva {{slideNumber}}",
+      "previewWebsite": "Vista previa de la plantilla de sitio web {{title}}",
+      "previousHtmlPreview": "Vista previa HTML anterior de {{title}}",
       "previousSlide": "Vista previa de la diapositiva anterior",
       "searchConnector": "Buscar conector...",
       "searchConnectors": "Buscar conectores",
@@ -666,10 +666,10 @@
       "selectVideo": "Seleccionar plantilla de vídeo {{title}}",
       "selectWebsite": "Seleccionar plantilla web {{title}}",
       "selectWorkflow": "Seleccionar plantilla de flujo de trabajo {{title}}",
-      "showVariant": "Variante de mostrar {{variantNumber}}",
+      "showVariant": "Mostrar variante {{variantNumber}}",
       "singleAccent": "Acento único",
-      "slidePreview": "{{title}} vista previa de diapositivas",
-      "slideThumbnail": "{{title}} diapositiva {{slideNumber}} vista previa",
+      "slidePreview": "Vista previa de las diapositivas de {{title}}",
+      "slideThumbnail": "Vista previa de la diapositiva {{slideNumber}} de {{title}}",
       "template": "Plantilla",
       "theme": "Tema",
       "themeNames": {
@@ -694,10 +694,10 @@
         "warmSand": "Periódico matutino"
       },
       "tryDifferentSearch": "Prueba con otra búsqueda.",
-      "use": "Uso",
+      "use": "Usar",
       "useThisTemplate": "Usa esta plantilla",
       "website": "Sitio web",
-      "websitePreview": "{{title}} vista previa de plantilla de sitio web",
+      "websitePreview": "Vista previa de la plantilla de sitio web {{title}}",
       "workflow": "Flujo de trabajo"
     },
     "title": "Artefactos",
@@ -710,7 +710,7 @@
   "auth": {
     "clerk": {
       "accessNotAllowed": "Acceso no permitido.",
-      "userBanned": "El acceso a la cuenta se suspendió porque la actividad en esta cuenta violó los {{brandName}} Términos de Uso. Si tienes preguntas, contacta con support@vm0.ai."
+      "userBanned": "El acceso a la cuenta se suspendió porque su actividad infringió los Términos de uso de {{brandName}}. Si tienes alguna pregunta, escribe a support@vm0.ai."
     },
     "documentTitles": {
       "signIn": "Iniciar sesión",
@@ -733,7 +733,7 @@
       "authorize": "Autorizar",
       "authorized": "Autorizado",
       "checkingCompatibility": "Comprobación de compatibilidad",
-      "description": "Elige un ordenador online para que Zero lo uses en {{source}}.",
+      "description": "Elige un ordenador en línea para que Zero lo use en {{source}}.",
       "downloadMac": "Descargar para macOS",
       "lastSeen": "Última vez que se vio {{date}}",
       "linkExpires": "El enlace caduca {{date}}.",
@@ -742,8 +742,8 @@
       "noHostsTitle": "No hay ordenadores en línea",
       "sources": {
         "chat": "Este hilo de chat",
-        "slack": "Este Slack hilo",
-        "teams": "Este Teams hilo"
+        "slack": "Este hilo de Slack",
+        "teams": "Este hilo de Teams"
       },
       "title": "Autorizar el uso de ordenadores",
       "unavailableDescription": "Este enlace de autorización para el uso del ordenador es inválido, caducado o no está disponible para este espacio de trabajo.",
@@ -796,7 +796,7 @@
         "updatedTitle": "Permisos actualizados"
       },
       "saving": "Guardando...",
-      "unknownEndpoints": "Puntos finales desconocidos",
+      "unknownEndpoints": "Endpoints desconocidos",
       "userFallback": "Ahí",
       "wouldLike": "Me gustaría"
     }
@@ -820,7 +820,7 @@
       "credits": "Créditos",
       "manage": "Gestionar",
       "redirecting": "Redirigiendo...",
-      "restore": "Restauración",
+      "restore": "Restaurar",
       "retry": "Reintentar",
       "unavailable": "No disponible",
       "updating": "Actualizando..."
@@ -853,7 +853,7 @@
     },
     "credits": {
       "amount": "Cantidad",
-      "amountRangeError": "Entra entre {{minimum}} y {{maximum}}",
+      "amountRangeError": "Introduce un valor entre {{minimum}} y {{maximum}}",
       "anyAmount": "Cualquier cantidad",
       "custom": "Personalizado",
       "customAmountAria": "Cantidad personalizada en dólares",
@@ -864,13 +864,13 @@
     },
     "downgrade": {
       "cancelSubscription": "Cancelar suscripción",
-      "chooseTarget": "Elige a qué plan hacer downgrade.",
+      "chooseTarget": "Elige a qué plan inferior quieres cambiar.",
       "confirmProCancellation": "¿Estás seguro de que quieres cancelar tu plan Pro?",
-      "confirmTarget": "¿Degradar a {{plan}}?",
-      "inProgress": "Degradando...",
+      "confirmTarget": "¿Cambiar al plan {{plan}}?",
+      "inProgress": "Cambiando de plan...",
       "proWarning": "Tu acceso Pro permanece activo hasta que termine el periodo de facturación actual. Después de eso, este espacio de trabajo pasa a Sin plan y los agentes no pueden funcionar hasta que actualices.",
       "teamWarning": "El acceso de tu equipo permanece activo hasta que termine el periodo de facturación actual. Después de eso, este espacio de trabajo se traslada a {{plan}}.",
-      "title": "Plan de degradación"
+      "title": "Cambiar a un plan inferior"
     },
     "invoices": {
       "amount": "Cantidad",
@@ -905,10 +905,10 @@
       "customAccess": "Acceso personalizado con ejecuciones concurrentes {{value}}",
       "customCancellationNotice": "Tu plan personalizado terminará en {{date}}.",
       "customCheckoutUnavailable": "Los espacios de trabajo con un plan personalizado no pueden cambiar a Pro ni Team.",
-      "downgrade": "Degradación",
-      "downgradeNotice": "Tu plan de {{currentPlan}} se rebajará a {{targetPlan}} en {{date}}.",
-      "downgradesOn": "Degradaciones a {{plan}} en {{date}}",
-      "downgradeTo": "Retroceso a {{plan}}",
+      "downgrade": "Cambiar a un plan inferior",
+      "downgradeNotice": "Tu plan cambiará de {{currentPlan}} a {{targetPlan}} el {{date}}.",
+      "downgradesOn": "Cambio a {{plan}} el {{date}}",
+      "downgradeTo": "Cambiar a {{plan}}",
       "endsOn": "Termina en {{date}}",
       "features": {
         "byok": "Lleva tus propias llaves de LLM",
@@ -917,10 +917,10 @@
         "existingCredits": "Solo créditos gratuitos existentes",
         "monthlyCredits": "{{value}} créditos / mes",
         "oneConcurrentRun": "1 ejecución simultánea",
-        "payAsYouGo": "Paga según la compra después",
+        "payAsYouGo": "Créditos de pago por uso",
         "prioritySupport": "Soporte prioritario",
         "tenConcurrentRuns": "10 ejecuciones simultáneas",
-        "twoConcurrentRuns": "2 recorridos simultáneos",
+        "twoConcurrentRuns": "2 ejecuciones simultáneas",
         "unlimitedAgents": "Agentes totales ilimitados",
         "voiceInput": "Entrada de voz",
         "voiceInputLifetime": "Entrada de voz (10 usos de por vida por miembro)"
@@ -941,14 +941,14 @@
         "name": "Sin plan"
       },
       "perMonth": "/mes",
-      "popular": "Populares",
+      "popular": "Popular",
       "pricePerMonth": "{{price}}/mes",
       "pro": {
         "description": "Más potencia y colaboración fluida para tu equipo.",
         "name": "Pro"
       },
       "renews": "Renueva {{date}}",
-      "restorePlan": "Plan de restauración",
+      "restorePlan": "Restaurar plan",
       "sectionTitle": "Plan",
       "selectedPlan": "El plan seleccionado",
       "team": {
@@ -961,9 +961,9 @@
     "restore": {
       "cancellationDescription": "Esto anulará la cancelación programada de tu plan {{plan}}.",
       "cancellationDescriptionDate": "Esto anulará la cancelación programada de tu plan {{plan}}. Se renovará el {{date}}.",
-      "downgradeDescription": "Esto cancelará la degradación programada a {{target}}. Tu plan {{plan}} seguirá renovándose.",
+      "downgradeDescription": "Esto cancelará el cambio programado a {{target}}. Tu plan {{plan}} seguirá renovándose.",
       "inProgress": "Restaurando...",
-      "title": "¿Restaurar {{plan}} plan?"
+      "title": "¿Restaurar el plan {{plan}}?"
     },
     "sidebar": {
       "description": "Más créditos y ejecuciones simultáneas",
@@ -973,14 +973,14 @@
       "autoRechargeUpdated": "Recarga automática actualizada",
       "cancellationScheduledDate": "Cancelación programada. Tu plan actual permanece activo hasta {{date}}.",
       "cancellationScheduledPeriod": "Cancelación programada. Tu plan actual permanece activo hasta que termine el periodo de facturación.",
-      "checkoutCompleted": "{{plan}} finalizada la compra. Se añadirán créditos después de pagar la factura.",
+      "checkoutCompleted": "Compra de {{plan}} completada. Los créditos se añadirán después de pagar la factura.",
       "concurrencyAdded": "Se añadió la concurrencia. Tus nuevos cupos estarán disponibles cuando Stripe confirme la suscripción.",
       "concurrencyCanceled": "Suscripción de concurrencia cancelada.",
       "concurrencyCanceledDate": "Se canceló la suscripción de concurrencia. Los cupos seguirán activos hasta {{date}}.",
       "concurrencyRestored": "Se ha restaurado la suscripción de concurrencia.",
       "creditsAdded": "Créditos añadidos. Puedes seguir chateando con Zero.",
-      "downgradeScheduledDate": "Degradación programada. Tu plan actual permanece activo hasta {{date}}.",
-      "downgradeScheduledPeriod": "Degradación programada. Tu plan actual permanece activo hasta que termine el periodo de facturación.",
+      "downgradeScheduledDate": "Cambio de plan programado. Tu plan actual permanecerá activo hasta {{date}}.",
+      "downgradeScheduledPeriod": "Cambio de plan programado. Tu plan actual permanecerá activo hasta que termine el periodo de facturación.",
       "planRestored": "Plan restaurado. Tu suscripción se renovará normalmente.",
       "preparingReceiptDownload": "Preparando la descarga del recibo...",
       "receiptDownloadFailed": "No se han conseguido descargar los recibos",
@@ -994,16 +994,16 @@
         "minute": "{{value}}m",
         "remaining": "{{remaining}} / {{total}} créditos",
         "remainingAria": "Límite de uso {{label}} restante",
-        "resets": "Reinicios {{date}}",
-        "resetsRaw": "Reinicios {{value}}",
+        "resets": "Se restablece el {{date}}",
+        "resetsRaw": "Se restablece {{value}}",
         "title": "Asignación de uso",
-        "week": "{{value}}w"
+        "week": "{{value}} sem"
       },
       "breakdown": {
-        "currentPlanDescription": "Los créditos mensuales del plan reinician cada ciclo de facturación",
-        "freeDescription": "Créditos iniciales, úsalo hasta agotarse",
+        "currentPlanDescription": "Los créditos mensuales del plan se restablecen en cada ciclo de facturación",
+        "freeDescription": "Créditos iniciales disponibles hasta que se agoten",
         "freePlan": "Plan gratuito",
-        "payAsYouGo": "Paga según la acción",
+        "payAsYouGo": "Pago por uso",
         "payAsYouGoDescription": "Créditos de recarga automática, nunca caducan",
         "previousPlanDescription": "Créditos sobrantes del plan anterior",
         "promotional": "Promoción",
@@ -1011,7 +1011,7 @@
         "proPlan": "Plan Pro",
         "teamPlan": "Plan del equipo"
       },
-      "creditAdditions": "Adiciones de créditos",
+      "creditAdditions": "Créditos añadidos",
       "creditsRemaining_one": "{{value}} crédito restante",
       "creditsRemaining_many": "{{value}} créditos restantes",
       "creditsRemaining_other": "{{value}} créditos restantes",
@@ -1037,9 +1037,9 @@
     "openNewPage": "Abre este navegador en una página nueva",
     "panel": {
       "notLive": "El navegador no está activo",
-      "resume": "Navegador de currículums",
+      "resume": "Reanudar navegador",
       "resumeDescription": "Reanudar restaura el perfil de inicio de sesión y el almacenamiento guardados. Las páginas y pestañas anteriores no regresan.",
-      "resuming": "Reanuda...",
+      "resuming": "Reanudando...",
       "suspended": "Navegador suspendido"
     },
     "reclaimHint_one": "Zero mantiene este navegador mientras este panel está abierto y lo recupera tras {{formattedCount}} minuto de reposo.",
@@ -1047,7 +1047,7 @@
     "reclaimHint_other": "Zero mantiene este navegador mientras este panel está abierto y lo recupera tras {{formattedCount}} minutos de reposo.",
     "status": {
       "live": "En directo",
-      "starting": "Inicio",
+      "starting": "Iniciando",
       "stopped": "Detenido"
     },
     "title": "Navegador en vivo",
@@ -1072,12 +1072,12 @@
       "remove": "Eliminar",
       "rename": "Renombrar",
       "saving": "Guardando...",
-      "send": "Envía",
+      "send": "Enviar",
       "stop": "Detener",
       "view": "Ver"
     },
     "agentPage": {
-      "invitePeople": "Invita a la gente",
+      "invitePeople": "Invitar a personas",
       "taglines": {
         "anonymous": {
           "buildSomething": "¿Listo para construir algo?",
@@ -1099,7 +1099,7 @@
         "readyToBuild": "¿Listo para construir, {{userName}}?",
         "rightOnTime": "Justo a tiempo, {{userName}}.",
         "savedYourSeat": "Te guardé un sitio, {{userName}}.",
-        "theUsual": "Lo de siempre, {{userName}}?",
+        "theUsual": "¿Lo de siempre, {{userName}}?",
         "welcomeBack": "Qué bueno verte de nuevo, {{userName}}.",
         "whatAreWeWorkingOn": "¿En qué estamos trabajando, {{userName}}?",
         "whatsCooking": "¿Qué se está cocinando, {{userName}}?",
@@ -1136,7 +1136,7 @@
       "cronExpression": "Expresión cron",
       "cronWithTimezone": "{{expression}} ({{timezone}})",
       "dailyAt": "Cada día a {{time}}",
-      "disabled": "Deshabilitado",
+      "disabled": "Desactivado",
       "displaysIn": "Se muestra en {{timezone}}",
       "edit": "Editar automatización",
       "editDescription": "Actualiza esta automatización del flujo de trabajo.",
@@ -1174,7 +1174,7 @@
         "body": "Cuerpo",
         "cc": "CC",
         "contains": "{{field}} contiene",
-        "containsAny": "{{field}} contiene alguna",
+        "containsAny": "{{field}} contiene alguno de",
         "doesNotContain": "{{field}} no contiene",
         "from": "De",
         "is": "Es",
@@ -1218,7 +1218,7 @@
       "open": "Abrir automatizaciones",
       "runAt": "Ejecutar a las",
       "runNow": "Ejecutar ahora",
-      "runsIn": "Ejecuciones en {{timezone}}",
+      "runsIn": "Se ejecuta en {{timezone}}",
       "save": "Guardar automatización",
       "schedule": "Programación",
       "starting": "Iniciando...",
@@ -1232,7 +1232,7 @@
       "addCreditsToContinue": "Añade créditos para seguir charlando con Zero.",
       "askAdminCredits": "Pide a un administrador de espacio de trabajo que añada créditos para que puedas seguir hablando con Zero.",
       "askAdminUpgrade": "Pide a un administrador de espacio de trabajo que actualice a Pro para poder seguir hablando con Zero.",
-      "buy": "Compra",
+      "buy": "Comprar",
       "checkingPermissions": "Comprobando permisos de facturación...",
       "comparePlans": "Comparar planes",
       "comparePlansDescription": "Compara planes para desbloquear funciones de espacio de trabajo de pago y créditos adicionales.",
@@ -1245,8 +1245,8 @@
       "redirecting": "Redirigiendo...",
       "upgradeToContinue": "Actualiza a Pro para seguir charlando con Zero.",
       "upgradeToPro": "Actualizar a Pro",
-      "upgradeToRun": "Mejorar a Pro para ejecutar Zero",
-      "upgradeWorkspace": "Mejora tu espacio de trabajo"
+      "upgradeToRun": "Actualizar a Pro para ejecutar Zero",
+      "upgradeWorkspace": "Actualizar el espacio de trabajo"
     },
     "composer": {
       "agentSuggestions": "Agentes",
@@ -1299,7 +1299,7 @@
       "customAuthorizeDescription": "Revisa, conecta y autoriza este conector personalizado para el agente.",
       "customConnectDescription": "Revisa y conecta este conector personalizado.",
       "find": "Buscar conectores...",
-      "remove": "Elimina {{connectorName}}",
+      "remove": "Eliminar {{connectorName}}",
       "title": "Conectores"
     },
     "documentTitle": "Chat",
@@ -1316,7 +1316,7 @@
       "runCancelled": "Se detuvo a mitad de la respuesta; puedes retomarla cuando quieras."
     },
     "feedback": {
-      "emailDraftDescription": "un borrador por correo electrónico (ID del borrador por correo: {{id}})",
+      "emailDraftDescription": "un borrador de correo electrónico (ID del borrador: {{id}})",
       "partHeading": "Comentarios sobre esta parte de tu respuesta:",
       "partsHeading_one": "Comentarios sobre {{count}} parte de tu respuesta:",
       "partsHeading_many": "Comentarios sobre {{count}} partes de tu respuesta:",
@@ -1352,7 +1352,7 @@
         "tracking": "Seguimiento de respuestas"
       },
       "loadingDetails": "Cargando detalles del correo electrónico",
-      "needReconnect": "Necesito reconectar",
+      "needReconnect": "Debes volver a conectar",
       "noMessage": "(Sin mensaje)",
       "noRecipient": "Sin destinatario",
       "noSubject": "(Sin asunto)",
@@ -1499,13 +1499,13 @@
         "sketching": "Esbozando los detalles...",
         "spinningUp": "Arrancando...",
         "tuningIn": "Sintonizando...",
-        "wiring": "Conectándolos juntos..."
+        "wiring": "Conectándolo todo..."
       },
       "viewActivityLogs": "Ver registros de actividad",
       "viewLogs": "Ver registros de ejecución",
       "waitingIn": "Esperando",
-      "worked": "Trabajó",
-      "workedFor": "Trabajó durante {{duration}}"
+      "worked": "Trabajo realizado",
+      "workedFor": "Trabajo realizado durante {{duration}}"
     },
     "shortcuts": {
       "number": "Número"
@@ -1542,9 +1542,9 @@
       },
       "messageTemplate": "Plantilla de mensaje {{title}}",
       "previewTemplate": "Plantilla de vista previa {{title}}",
-      "previewVideo": "Plantilla de vídeo de vista previa {{title}}",
-      "previewWebsite": "Plantilla de página web de vista previa {{title}}",
-      "previewWorkflow": "Plantilla de flujo de trabajo de vista previa {{title}}",
+      "previewVideo": "Vista previa de la plantilla de vídeo {{title}}",
+      "previewWebsite": "Vista previa de la plantilla de sitio web {{title}}",
+      "previewWorkflow": "Vista previa de la plantilla de flujo de trabajo {{title}}",
       "removeTemplate": "Eliminar la plantilla {{title}}",
       "removeVideo": "Eliminar la plantilla de vídeo {{title}}",
       "removeWebsite": "Eliminar la plantilla de sitio web {{title}}",
@@ -1923,7 +1923,7 @@
       "connectDocumentTitle": "Conectar {{connector}}",
       "connected": "{{connector}} conectado",
       "needsConnector": "{{agent}} necesita {{connector}} para seguir adelante",
-      "reconnecting": "Reconectar..."
+      "reconnecting": "Reconectando..."
     },
     "expiration": {
       "inDays_one": "Caduca en {{count}} día",
@@ -1942,13 +1942,13 @@
       },
       "allowDuration": {
         "always": "Permitir siempre",
-        "oneHour": "Permite 1 hora",
-        "sevenDays": "Permitir 7d",
-        "twentyFourHours": "Permite 24 horas"
+        "oneHour": "Permitir durante 1 hora",
+        "sevenDays": "Permitir durante 7 días",
+        "twentyFourHours": "Permitir durante 24 horas"
       },
       "allowOptions": "{{permission}} opciones de permiso",
       "always": "Siempre",
-      "clearSearch": "Búsqueda de permisos clara",
+      "clearSearch": "Borrar búsqueda de permisos",
       "descriptionAgent": "Configura qué acciones puede realizar este agente a través de este conector.",
       "descriptionWorkflow": "Configura qué acciones puede realizar este flujo de trabajo a través de este conector.",
       "find": "Buscar permisos",
@@ -1958,10 +1958,10 @@
       "loading": "Cargando permisos...",
       "metadataMissing": "No se han encontrado metadatos de permisos para {{connector}}",
       "noResults": "No hay resultados para \"{{search}}\"",
-      "otherEndpoints": "Otros puntos finales",
+      "otherEndpoints": "Otros endpoints",
       "otherEndpointsDescription": "Los endpoints de la API no coinciden con ningún permiso anterior",
       "permissions": "Permisos",
-      "restore": "Restauración",
+      "restore": "Restaurar",
       "scopeReview": {
         "added": "Nuevos permisos",
         "description": "Los permisos requeridos para este conector han cambiado. Por favor, revisa y vuelve a conectar para aplicar la actualización.",
@@ -1974,13 +1974,13 @@
       "showMore_one": "Mostrar más ({{count}})",
       "showMore_many": "Mostrar más ({{count}})",
       "showMore_other": "Mostrar más ({{count}})",
-      "title": "{{connector}} permisos"
+      "title": "Permisos de {{connector}}"
     },
     "providerConnect": {
       "agentphone": {
         "back": "Volviendo a {{brandName}}",
         "connectDescription": "Vincula este número de teléfono a tu cuenta de {{brandName}} para poder interactuar con Zero a través de mensajes de texto.",
-        "connectTitle": "Número de teléfono de conexión",
+        "connectTitle": "Conectar número de teléfono",
         "documentTitle": "Conectar mensajes",
         "errorFallback": "No pudimos conectar este número de teléfono. Inténtalo de nuevo desde tus mensajes de texto.",
         "incompleteDescription": "Abre un enlace nuevo /connect desde tus mensajes de texto.",
@@ -1994,7 +1994,7 @@
       },
       "common": {
         "backToSettings": "Volver a los ajustes",
-        "checkingTitle": "Estado de la cuenta corriente...",
+        "checkingTitle": "Comprobando el estado de la cuenta...",
         "connectionFailed": "Fallo de conexión",
         "invalidLink": "Enlace inválido",
         "verifying": "Espera mientras verificamos tu conexión."
@@ -2003,7 +2003,7 @@
         "back": "Volver a los ajustes de Feishu",
         "checkingTitle": "Comprobando el estado de la cuenta...",
         "connectDescription": "Vincula tu cuenta de {{brandName}} a este bot de Feishu para que puedas trabajar directamente con tu agente desde Feishu.",
-        "connectTitle": "Conéctate con Feishu",
+        "connectTitle": "Conectar con Feishu",
         "errorFallback": "No pudimos conectar Feishu. Abre un enlace de conexión nuevo e inténtalo de nuevo.",
         "invalidDescription": "Abre un enlace de conexión nuevo desde Feishu e inténtalo de nuevo.",
         "open": "Abrir Feishu",
@@ -2020,7 +2020,7 @@
         "checkingConnectionTitle": "Comprobando conexión...",
         "checkingSession": "Espera mientras verificamos tu sesión de {{brandName}}.",
         "connectDescription": "Vincula tu cuenta de {{brandName}} con {{account}} para ejecutar tus agentes desde menciones en incidencias y pull requests de GitHub.",
-        "connectTitle": "Conéctate con GitHub",
+        "connectTitle": "Conectar con GitHub",
         "errorFallback": "No pudimos conectar GitHub. Inténtalo de nuevo desde GitHub.",
         "invalidInstallation": "La instalación de GitHub de este enlace no es válida.",
         "invalidSignature": "La firma en este enlace no es válida.",
@@ -2044,7 +2044,7 @@
       },
       "slack": {
         "connectDescription": "Vincula tu cuenta a este espacio de trabajo de Slack para interactuar directamente con tu agente desde Slack.",
-        "connectTitle": "Conéctate con Slack",
+        "connectTitle": "Conectar con Slack",
         "invalidDescription": "Esta página debe abrirse desde un enlace de conexión de Slack.",
         "open": "Abrir Slack",
         "successDescription": "Menciona a @Zero en cualquier canal o envía un mensaje directo para empezar a chatear.",
@@ -2054,7 +2054,7 @@
       "teams": {
         "connectDescription": "Vincula tu cuenta de Teams para interactuar directamente con tu agente desde Microsoft Teams.",
         "connectDescriptionNamed": "{{displayName}}, vincula tu cuenta de Teams para interactuar directamente con tu agente desde Microsoft Teams.",
-        "connectTitle": "Conecta Microsoft Teams",
+        "connectTitle": "Conectar Microsoft Teams",
         "invalidDescription": "Esta página debe abrirse desde un enlace de conexión de Microsoft Teams.",
         "open": "Abrir Teams",
         "providerName": "Microsoft Teams",
@@ -2073,11 +2073,11 @@
         "checkingDomain": "Comprobando el estado del dominio...",
         "checkingSession": "Espera mientras verificamos tu sesión de {{brandName}}.",
         "connectDescription": "Vincula tu cuenta a este bot de Telegram para que puedas interactuar directamente con tu agente desde Telegram.",
-        "connectTitle": "Conéctate con Telegram",
-        "continue": "Continúa con Telegram",
+        "connectTitle": "Conectar con Telegram",
+        "continue": "Continuar con Telegram",
         "domainDescription": "El inicio de sesión web de Telegram no está habilitado para {{bot}}.",
         "domainIn": "En",
-        "domainInstructionsAfter": ", elige el bot, luego establece el dominio a:",
+        "domainInstructionsAfter": ", elige el bot y establece el dominio en:",
         "domainKeepOpen": "Mantén esta página abierta después de guardar el dominio. También puedes conectarte desde Telegram con /connect.",
         "domainSend": ", enviar",
         "domainTitle": "Configurar el dominio de inicio de sesión de Telegram",
@@ -2104,15 +2104,15 @@
     "providerSettings": {
       "agentphone": {
         "authorizedSender": "Remitente autorizado",
-        "connectAria": "Conecta teléfono",
+        "connectAria": "Conectar teléfono",
         "connectDescription": "Introduce tu número de teléfono. Enviaremos un enlace de verificación por mensaje que conecte este espacio de trabajo.",
-        "connectTitle": "Conecta teléfono",
+        "connectTitle": "Conectar teléfono",
         "copyAria": "Copiar {{phone}}",
         "copyError": "No se pudo copiar el número de teléfono",
         "copySuccess": "Número de teléfono copiado",
         "description": "Acceso por mensajes de texto a Zero",
         "destination": "iMessage o SMS a",
-        "normalized": "Enviaremos mensajes {{phone}}.",
+        "normalized": "Enviaremos un mensaje a {{phone}}.",
         "options": "Opciones de teléfono",
         "phoneLabel": "Teléfono",
         "phoneNumber": "Número de teléfono",
@@ -2134,7 +2134,7 @@
           "lastAttempt": "Último intento",
           "lastAttemptAt": "Último intento",
           "lastSuccess": "Último éxito",
-          "missingVersions": "Versiones perdidas",
+          "missingVersions": "Versiones ausentes",
           "rejectedCatalogDigest": "Resumen de catálogo rechazado",
           "rejectedVersion": "Versión rechazada",
           "rejectingBackend": "Rechazando el backend",
@@ -2142,7 +2142,7 @@
           "rejectionFailure": "Fallo de rechazo",
           "syncState": "Estado de sincronización",
           "unownedSecrets": "Secretos sin dueño",
-          "unownedVariables": "Variables no propiedad",
+          "unownedVariables": "Variables sin propietario",
           "unresolvedBridgeCredentials": "Credenciales de puente sin resolver"
         },
         "loading": "Cargando",
@@ -2585,7 +2585,7 @@
       "body": "Ya no recibirás notificaciones de correo electrónico iniciadas por el sistema desde {{brandName}}.",
       "confirmTitle": "¿Cancelar las notificaciones por correo electrónico?",
       "documentTitle": "Cancelar suscripción",
-      "doneTitle": "No suscrito",
+      "doneTitle": "Suscripción cancelada",
       "errorBody": "Este enlace de baja es inválido o caducado. Puedes gestionar las notificaciones por correo electrónico en Configuración.",
       "errorTitle": "Algo salió mal"
     },
@@ -2603,7 +2603,7 @@
       "description": "Añade Zero en tu pantalla de inicio para acceder rápidamente.",
       "dismiss": "Cancelar banner de instalación",
       "gotIt": "Entendido",
-      "install": "Instalación",
+      "install": "Instalar",
       "installApp": "Instalar la aplicación",
       "stepOne": "En Safari, pulsa el botón de compartir.",
       "stepThree": "Confirma que el nombre es Zero y pulsa Añadir.",
@@ -2612,7 +2612,7 @@
     },
     "redeemCampaign": {
       "actions": {
-        "back": "Volviendo a {{brandName}}",
+        "back": "Volver a {{brandName}}",
         "redeem": "Canjear créditos"
       },
       "documentTitle": "Reclama tus créditos",
@@ -2631,7 +2631,7 @@
           "title": "La facturación está temporalmente indisponible"
         },
         "broken": {
-          "body": "No pudimos completar tu redención. Por favor, inténtalo de nuevo o contacta con el soporte.",
+          "body": "No pudimos completar el canje. Inténtalo de nuevo o contacta con el servicio de asistencia.",
           "title": "Algo salió mal"
         },
         "campaignUnavailable": {
@@ -2664,7 +2664,7 @@
         "title": "Datos"
       },
       "engineering": {
-        "description": "Enviar, depurar, automatizar código",
+        "description": "Publicar, depurar y automatizar código",
         "title": "Ingeniero"
       },
       "everyone": {
@@ -2688,18 +2688,18 @@
         "title": "Ventas"
       },
       "support": {
-        "description": "Entradas y ayuda al cliente",
+        "description": "Tickets y atención al cliente",
         "title": "Soporte"
       }
     },
     "common": {
       "back": "Volver",
       "continue": "Continuar",
-      "dialogPreview": "{{title}} vista previa",
+      "dialogPreview": "Vista previa de {{title}}",
       "gotIt": "Entendido",
       "next": "Siguiente",
       "noConnectorRequired": "No se requiere conector",
-      "previewWorkflowDetails": "Detalles del flujo de trabajo de vista previa",
+      "previewWorkflowDetails": "Vista previa de los detalles del flujo de trabajo",
       "selectTemplate": "Selecciona esta plantilla",
       "selectThisTemplate": "Selecciona esta plantilla",
       "stepProgress": "Paso {{current}} de {{total}}"
@@ -2709,7 +2709,7 @@
       "choosePresentation": "Elige una plantilla de presentación",
       "chooseVideo": "Elige un estilo de vídeo",
       "chooseWorkflow": "Elige un flujo de trabajo",
-      "make": "Bienvenidos a {{brandName}}",
+      "make": "Te damos la bienvenida a {{brandName}}",
       "runImage": "Crea tu primera imagen",
       "runPresentation": "Crea tu primera presentación",
       "runVideo": "Crea tu primer vídeo",
@@ -2727,7 +2727,7 @@
           "title": "Generar imágenes"
         },
         "presentation": {
-          "description": "Generar diapositivas y altavoz",
+          "description": "Genera diapositivas y contenido para presentarlas",
           "title": "Generar una presentación"
         },
         "video": {
@@ -2740,21 +2740,21 @@
         }
       },
       "projectTypeLabel": "Primer tipo de proyecto",
-      "promptDescription": "Ajusta la herramienta abajo o ejecuta tal cual. Zero se encarga a partir de aquí. Tus herramientas permanecen en el sandbox y nada sale de tu espacio de trabajo.",
+      "promptDescription": "Ajústalo a continuación o ejecútalo tal cual. Zero se encarga del resto. Tus herramientas permanecen aisladas y nada sale de tu espacio de trabajo.",
       "promptLabel": "Prompt de incorporación",
       "promptTitle": "Prueba este prompt",
-      "title": "¿Qué quieres preparar primero?"
+      "title": "¿Qué quieres crear primero?"
     },
     "runAction": {
-      "checkingPlan": "Plan de control",
+      "checkingPlan": "Comprobando el plan",
       "runNow": "Ejecutar ahora",
-      "upgradePro": "Actualizar Pro para que funcione"
+      "upgradePro": "Actualizar a Pro para ejecutar"
     },
     "templatePicker": {
       "image": {
         "description": "Úsalo como referencia para la imagen que quieres crear.",
         "selectTemplate": "Seleccionar la plantilla de ilustración {{title}}",
-        "showVariant": "Mostrar {{title}} variante {{variant}}",
+        "showVariant": "Mostrar la variante {{variant}} de {{title}}",
         "title": "Elige una plantilla de ilustración desde la cual empezar"
       },
       "presentation": {
@@ -2762,10 +2762,10 @@
         "nextSlide": "Mostrar la siguiente diapositiva",
         "previousSlide": "Mostrar diapositiva anterior",
         "selectTemplate": "Seleccionar la plantilla de presentación {{title}}",
-        "showSlide": "Mostrar la {{slide}} diapositivas",
-        "slideAlt": "{{title}} diapositiva {{slide}}",
+        "showSlide": "Mostrar la diapositiva {{slide}}",
+        "slideAlt": "Diapositiva {{slide}} de {{title}}",
         "title": "Elige una plantilla de presentación desde la cual empezar",
-        "viewTemplate": "Ver {{title}} presentación"
+        "viewTemplate": "Ver la presentación {{title}}"
       },
       "video": {
         "description": "Úsalo como referencia para el vídeo que quieres crear.",
@@ -2781,10 +2781,10 @@
         "title": "Selecciona una automatización que quieras probar"
       },
       "presentation": {
-        "noteLabel": "Contenido de la presentación e instrucción",
+        "noteLabel": "Contenido e instrucciones de la presentación",
         "notePlaceholder": "Añade el contenido y las instrucciones de tu presentación",
         "previewLabel": "Vista previa de la plantilla de presentación",
-        "title": "Cumple tu presentación"
+        "title": "Completa tu presentación"
       },
       "video": {
         "noteLabel": "Prompt de vídeo personalizado",
@@ -2862,10 +2862,10 @@
     },
     "workflowPicker": {
       "categoryDescription": "Configuraciones listas para usar que puedes adaptar a tus herramientas y objetivos.",
-      "categoryTitle": "{{category}} flujos de trabajo",
+      "categoryTitle": "Flujos de trabajo de {{category}}",
       "customDescription": "Describe lo que quieres y Zero lo construye contigo.",
-      "customTitle": "Habla con Zero y haz la mía propia",
-      "description": "Elige un puesto para ver los flujos de trabajo que encajan. Puedes cambiar en cualquier momento.",
+      "customTitle": "Habla con Zero y crea el tuyo",
+      "description": "Elige un rol para ver los flujos de trabajo que mejor encajan. Puedes cambiarlo en cualquier momento.",
       "title": "¿En qué trabajas?",
       "workflowCardLabel": "{{title}} {{description}}"
     },
@@ -2874,7 +2874,7 @@
       "whatItDoes": "Qué hace"
     },
     "workflowRun": {
-      "continueWithZero": "Continúa con Zero",
+      "continueWithZero": "Continuar con Zero",
       "createDraft": "Crear borrador",
       "customNoteLabel": "Describe tu flujo de trabajo",
       "customNotePlaceholder": "Describe lo que quieres que Zero cree",
@@ -3220,7 +3220,7 @@
             "title": "Guardado en Notion"
           },
           "two": {
-            "description": "Zero redacta un claro tutorial a partir de la resolución.",
+            "description": "Zero redacta un tutorial claro a partir de la resolución.",
             "title": "Corrección redactada"
           }
         },
@@ -3923,7 +3923,7 @@
       "addOn": "Complemento",
       "addsToLimit": "Añade a tu límite actual",
       "appliedAfterCheckout": "Se aplica al finalizar el pago",
-      "buy": "Compra {{price}} al mes",
+      "buy": "Comprar por {{price}} al mes",
       "decreaseQuantity": "Reducir la cantidad de concurrencia",
       "description": "Añade ejecuciones simultáneas dedicadas a este espacio de trabajo, facturadas mensualmente.",
       "increaseQuantity": "Aumentar la cantidad de concurrencia",
@@ -3960,7 +3960,7 @@
         "creditsPerMonth": "{{credits}} créditos / mes",
         "emailSupport": "Soporte por correo electrónico",
         "ownKeys": "Lleva tus propias llaves de LLM",
-        "payAsYouGo": "Paga según la compra después",
+        "payAsYouGo": "Créditos de pago por uso",
         "prioritySupport": "Soporte prioritario",
         "unlimitedAgents": "Agentes totales ilimitados"
       },
@@ -3980,7 +3980,7 @@
       "runContext": "Contexto de ejecución y entorno",
       "title": "¿Qué se enviará?"
     },
-    "documentTitle": "Error de reporte",
+    "documentTitle": "Informar de un error",
     "error": {
       "loadFailed": "No se han cargado los detalles de la ejecución",
       "notFailed": "Esta ejecución no falló y no se puede informar de ella",
@@ -3994,14 +3994,14 @@
       "titlePlaceholder": "Breve resumen del asunto"
     },
     "loading": "Cargando los detalles de la ejecución",
-    "send": "Enviar Informe",
+    "send": "Enviar informe",
     "sending": "Enviando...",
     "success": {
       "description": "Tu informe de error ha sido enviado al equipo de desarrolladores. Ellos investigarán y harán seguimiento.",
       "reference": "Referencia: {{reference}}",
       "title": "Informe enviado"
     },
-    "title": "Reportar error al desarrollador"
+    "title": "Informar del error al equipo de desarrollo"
   },
   "settings": {
     "accountMenu": {
@@ -4093,7 +4093,7 @@
       },
       "backToZero": "Volver a Zero",
       "description": "Descarga los archivos y registros de texto que creaste en Zero.",
-      "documentTitle": "Datos de exportación",
+      "documentTitle": "Exportar datos",
       "duration": {
         "soon": "Pronto"
       },
@@ -4111,7 +4111,7 @@
       },
       "status": {
         "checkingDescription": "Tu último estado de exportación aparecerá aquí.",
-        "checkingTitle": "Comprobación del estado de exportación",
+        "checkingTitle": "Comprobando el estado de la exportación",
         "downloadExpires": "El enlace de descarga expira en {{duration}}.",
         "downloadNoExpiry": "Descárgalo antes de que el enlace expire.",
         "downloadTitle": "Tu exportación está lista",
@@ -4121,18 +4121,18 @@
         "failedTitle": "La exportación no terminó",
         "preparingDescription": "Esto puede tardar unos minutos. Puedes dejar esta página abierta.",
         "preparingTitle": "Preparando tu exportación",
-        "rateLimitedFallback": "Puedes empezar otra exportación cuando termine el tiempo de reutilización.",
+        "rateLimitedFallback": "Puedes iniciar otra exportación cuando termine el periodo de espera.",
         "rateLimitedTitle": "Exportación solicitada recientemente",
         "rateLimitedUntil": "Puedes empezar otra exportación en {{duration}}.",
-        "readyDescription": "Crea un archivo ZIP con los datos de tu espacio de trabajo.",
+        "readyDescription": "La exportación contiene un archivo ZIP con los datos de tu espacio de trabajo.",
         "readyTitle": "Listo para exportar"
       },
       "title": "Datos de exportación"
     },
     "lab": {
       "actions": {
-        "resetAll": "Reiniciar todo",
-        "resetting": "Reiniciando..."
+        "resetAll": "Restablecer todo",
+        "resetting": "Restableciendo..."
       },
       "description": "Activa o desactiva funciones experimentales.",
       "documentTitle": "Laboratorio",
@@ -4156,8 +4156,8 @@
         "deleteModel": "Eliminar modelo",
         "editModel": "Editar modelo",
         "resetUsage": "Restablecer uso",
-        "upgradePro": "Mejorar a Pro para usarlo",
-        "upgradeToPro": "Mejorar a Pro"
+        "upgradePro": "Actualizar a Pro para usarlo",
+        "upgradeToPro": "Actualizar a Pro"
       },
       "deviceAuth": {
         "claude": {
@@ -4182,7 +4182,7 @@
           "codeCopied": "Código del dispositivo copiado. Esperando aprobación...",
           "codeCopiedRetry": "Código del dispositivo copiado. Intenta abrir la página de aprobación de nuevo.",
           "connectedToast": "ChatGPT conectado",
-          "connectTitle": "Conecta Codex",
+          "connectTitle": "Conectar Codex",
           "copyAndOpen": "Copiar código y abrir la página de aprobación",
           "copyAndOpenError": "No se pudo copiar el código del dispositivo ni abrir la página de aprobación. Copia el código manualmente e inténtalo de nuevo.",
           "copyError": "Se abrió la página de aprobación, pero el código del dispositivo no se copió. Cópialo manualmente antes de aprobar.",
@@ -4196,7 +4196,7 @@
           "preparing": "Preparando...",
           "reconnectAction": "Volver a conectar ChatGPT",
           "reconnectTitle": "Volver a conectar Codex",
-          "signIn": "Inicia sesión con ChatGPT"
+          "signIn": "Iniciar sesión con ChatGPT"
         }
       },
       "personal": {
@@ -4268,14 +4268,14 @@
         "providerApiKey": "Clave API de {{provider}}",
         "secretStored": "Almacenado en secretos del espacio de trabajo.",
         "selectDefaultModel": "Seleccionar un modelo por defecto",
-        "selectModel": "Selecciona un modelo",
-        "selectProvider": "Selecciona un proveedor",
+        "selectModel": "Seleccionar un modelo",
+        "selectProvider": "Seleccionar un proveedor",
         "workspaceDescription": "Disponible para todos en este espacio de trabajo.",
         "workspaceTitle": "Espacio de trabajo"
       },
       "reset": {
         "confirmDescription": "Usa un restablecimiento de Codex para reiniciar tus periodos de consumo actuales. Te quedan {{remaining}}.",
-        "progress": "Reiniciando...",
+        "progress": "Restableciendo...",
         "remaining_one": "Queda {{value}} restablecimiento",
         "remaining_many": "Quedan {{value}} restablecimientos",
         "remaining_other": "Quedan {{value}} restablecimientos",
@@ -4287,7 +4287,7 @@
         "claudeFailed": "No se pudo actualizar Claude Code. Vuelve a conectarlo para reintentarlo.",
         "claudeTitle": "La sesión de Claude Code debe volver a conectarse",
         "codexExpired": "Tu sesión de ChatGPT ha expirado. Reconecta para continuar.",
-        "codexFailed": "Falló el refresco de ChatGPT. Reconecta para intentarlo de nuevo.",
+        "codexFailed": "No se pudo actualizar la sesión de ChatGPT. Vuelve a conectarla para intentarlo de nuevo.",
         "codexInvalidated": "Tu sesión de ChatGPT ha sido revocada. Reconecta.",
         "codexReused": "Tu sesión de ChatGPT se usó en otro sitio. Reconéctate.",
         "codexTitle": "La sesión de ChatGPT necesita reconexión"
@@ -4319,7 +4319,7 @@
         "sectionTitle": "Cuenta y seguridad"
       },
       "appearance": {
-        "description": "Elige cómo queda la interfaz.",
+        "description": "Elige el aspecto de la interfaz.",
         "sectionTitle": "Apariencia",
         "theme": {
           "dark": "Oscuro",
@@ -4332,7 +4332,7 @@
       "debug": {
         "capture": {
           "description": "Captura los nombres de cabeceras HTTP, los valores de cabecera seguros seleccionados y los cuerpos en los registros de red para la depuración.",
-          "disabled": "Deshabilitado",
+          "disabled": "Desactivado",
           "enabled_one": "Activado para la próxima {{count}} ejecución",
           "enabled_many": "Activado para las próximas {{count}} ejecuciones",
           "enabled_other": "Activado para las próximas {{count}} ejecuciones",
@@ -4379,7 +4379,7 @@
         "timezone": "Zona horaria"
       },
       "timezone": {
-        "description": "Tiempos que se te muestran y se usan para las ejecuciones de automatización.",
+        "description": "Las horas que se muestran y se usan en las ejecuciones de automatización.",
         "rowDescription": "Tus agentes usarán esta zona horaria durante las ejecuciones",
         "rowTitle": "Zona horaria",
         "sectionTitle": "Zona horaria",
@@ -4439,7 +4439,7 @@
         "leave": {
           "confirmDescription": "Ya no tendrás acceso a este espacio de trabajo. Solo podrás volver a unirte si un administrador te invita de nuevo.",
           "description": "Perderás el acceso a este espacio de trabajo y a sus recursos.",
-          "progress": "Irse...",
+          "progress": "Saliendo...",
           "title": "Salir del espacio de trabajo",
           "titleQuestion": "¿Salir del espacio de trabajo?"
         },
@@ -4452,7 +4452,7 @@
         "empty": "Sin miembros",
         "emptySearch": "No se encuentran miembros",
         "invite": {
-          "description": "Envía una invitación para unirte a este espacio de trabajo.",
+          "description": "Envía una invitación para que alguien se una a este espacio de trabajo.",
           "emailPlaceholder": "email@example.com",
           "invalidEmail": "Introduce una dirección de correo electrónico válida",
           "progress": "Enviando...",
@@ -4473,7 +4473,7 @@
           "action": "Quitar del espacio de trabajo",
           "confirmDescription": "{{email}} será eliminado de este espacio de trabajo y perderá el acceso a todos los recursos.",
           "progress": "Eliminando...",
-          "title": "¿Eliminar a un miembro?"
+          "title": "¿Eliminar al miembro?"
         },
         "revoke": {
           "action": "Revocar invitación",
@@ -4590,7 +4590,7 @@
       "maps": "Mapas",
       "peopleSearch": "Búsqueda de personas",
       "usage": "Uso",
-      "weather": "Clima",
+      "weather": "Tiempo",
       "webFetch": "Búsqueda web",
       "webSearch": "Búsqueda web"
     },
@@ -4625,7 +4625,7 @@
       "myUsage": "Mi uso",
       "noActiveBillingPeriod": "No hay periodo de facturación activo.",
       "teamLoadError": "No se pudo cargar el uso del equipo.",
-      "teamUsage": "Uso en equipo",
+      "teamUsage": "Uso del equipo",
       "untitled": "(sin título)"
     },
     "sources": {
@@ -4706,8 +4706,8 @@
         "cancel": "Cancelar",
         "chooseAutomation": "Elige una automatización para iniciar este flujo de trabajo.",
         "deleteAutomation": "Eliminar automatización",
-        "disable": "Desactiva {{title}}",
-        "disabledPaidPlan": "Deshabilitado — se requiere un plan de pago",
+        "disable": "Desactivar {{title}}",
+        "disabledPaidPlan": "Desactivado — se requiere un plan de pago",
         "done": "Completado",
         "editAutomation": "Editar automatización",
         "enable": "Habilitar {{title}}",
@@ -4733,7 +4733,7 @@
         "second_other": "{{count}} segundos"
       },
       "github": {
-        "accountConnect": "Conecta GitHub",
+        "accountConnect": "Conectar GitHub",
         "accountRequired": "Conecta tu cuenta de GitHub para usar la opción «Yo».",
         "actorAnyone": "Cualquiera",
         "actorMe": "Yo",
@@ -4820,9 +4820,9 @@
           "changesRequested": "Cambios solicitados",
           "commented": "Comentado",
           "error": "Error",
-          "failure": "Fracaso",
+          "failure": "Fallido",
           "inactive": "Inactivo",
-          "inProgress": "En progreso",
+          "inProgress": "En curso",
           "neutral": "Neutro",
           "pending": "Pendiente",
           "queued": "En cola",
@@ -4830,7 +4830,7 @@
           "stale": "Obsoleto",
           "startupFailure": "Fallo de arranque",
           "success": "Éxito",
-          "timedOut": "Tiempo agotado",
+          "timedOut": "Tiempo de espera agotado",
           "waiting": "Esperando"
         },
         "productionEnvironment": "Entorno de producción",
@@ -4852,7 +4852,7 @@
         "saveFilters": "Guardar filtros",
         "selectNoneAny": "No selecciones ninguno para que coincida con cualquier valor.",
         "selectNoneConclusion": "No selecciones ninguno para que coincida con cualquier conclusión completada.",
-        "startedBy": "Empezado por",
+        "startedBy": "Iniciado por",
         "subject": "Asunto",
         "trustedAuthors": "Autores de confianza",
         "updateLabelAria": "Actualizar automatización de etiquetas de GitHub",
@@ -4863,7 +4863,7 @@
         "workflowJobRule": "Cuando {{jobs}} termine",
         "workflowJobTitle": "Tarea de flujo de trabajo de GitHub completada",
         "workflowRunDescription": "Ejecutar cuando termine una ejecución coincidente de GitHub Actions.",
-        "workflowRunRule": "Cuando {{workflows}} completa{{conclusions}}",
+        "workflowRunRule": "Cuando finalice {{workflows}}{{conclusions}}",
         "workflowRunTitle": "Flujo de trabajo de GitHub completado",
         "workflows": "Flujos de trabajo de GitHub",
         "workflowsPlaceholder": "Turbo, .github/workflows/release.yml",
@@ -4905,7 +4905,7 @@
         "newMessageTitle": "Nuevo mensaje de Gmail",
         "operator": {
           "contains": "Contiene",
-          "containsAny": "Contiene cualquiera",
+          "containsAny": "Contiene alguno de",
           "doesNotContain": "No contiene",
           "is": "Es"
         },
@@ -4925,7 +4925,7 @@
       "meet": {
         "addAction": "Añadir automatización de Meet",
         "addAria": "Añadir automatización de transcripciones de Google Meet",
-        "addDescription": "Ejecuta este flujo de trabajo cuando Google Meet termine de generar una transcripción para una reunión organizada por la cuenta conectada Google Meet.",
+        "addDescription": "Ejecuta este flujo de trabajo cuando Google Meet termine de generar la transcripción de una reunión organizada por la cuenta de Google Meet conectada.",
         "addTitle": "Añadir automatización de Google Meet",
         "rule": "Cuando Google Meet termine de generar una transcripción",
         "summary": "Reuniones que organizas",
@@ -4975,7 +4975,7 @@
         "email": "Correo electrónico",
         "integrations": "Integraciones",
         "notion": "Notion",
-        "schedule": "Calendario"
+        "schedule": "Programación"
       },
       "rules": {
         "inboundWebhook": "Cuando se recibe un webhook entrante"
@@ -4990,9 +4990,9 @@
         "addOnceDescription": "Elige la fecha y hora para que este flujo de trabajo se ejecute una vez.",
         "addOnceTitle": "Añadir automatización única",
         "addScheduleAction": "Añadir horario",
-        "addScheduleAria": "Añadir automatización de calendarios",
+        "addScheduleAria": "Añadir automatización programada",
         "addScheduleDescription": "Elige cuándo debe ejecutarse este flujo de trabajo.",
-        "addScheduleTitle": "Añadir automatización de calendarios",
+        "addScheduleTitle": "Añadir automatización programada",
         "cronExpression": "Expresión cron",
         "customCron": "Cron personalizado",
         "dayOfMonth": "Día del mes",
@@ -5003,12 +5003,12 @@
         "everyDay": "Cada día",
         "everyDayAt": "Cada día a {{time}}",
         "everyMonth": "Cada mes",
-        "everyMonthAt": "Cada mes en el día {{day}} a las {{time}}",
+        "everyMonthAt": "Cada mes, el día {{day}} a las {{time}}",
         "everyWeek": "Cada semana",
         "everyWeekAt": "Cada semana a {{time}}",
         "everyWeekday": "Todos los días laborables",
         "everyWeekdayAt": "Todos los días laborables a {{time}}",
-        "everyWeekOn": "Cada semana en {{days}} a {{time}}",
+        "everyWeekOn": "Cada semana, los {{days}} a las {{time}}",
         "frequencyIntervalDescription": "Ejecuta este flujo de trabajo en un intervalo fijo.",
         "frequencyIntervalTitle": "Intervalo",
         "frequencyOnceDescription": "Ejecuta este flujo de trabajo una vez en una fecha y hora.",
@@ -5021,7 +5021,7 @@
         "next": "Siguiente",
         "noRunsYet": "Aún no hay ejecuciones",
         "noUpcomingRun": "No hay próximas ejecuciones",
-        "onceOn": "Una vez en {{date}} a {{time}}",
+        "onceOn": "Una vez, el {{date}} a las {{time}}",
         "repeatEvery": "Cada {{interval}}",
         "repeats": "Repeticiones",
         "runAt": "Ejecutar a las",
@@ -5060,28 +5060,28 @@
         "webhook": "Webhook"
       },
       "webhook": {
-        "addDescription": "Crea un punto final firmado para este flujo de trabajo.",
+        "addDescription": "Crea un endpoint firmado para este flujo de trabajo.",
         "addTitle": "Añadir automatización de webhooks",
         "copy": "Copiar",
         "create": "Crear webhook",
         "createDescription": "Ejecuta este flujo de trabajo desde un POST firmado.",
         "createTitle": "Webhook",
-        "hidden": "URL de Webhook oculta",
+        "hidden": "URL del webhook oculta",
         "paidBadge": "Equipo",
         "reveal": "Mostrar secreto",
-        "revealDescription": "Revela el punto final con signos y el final secreto en {{suffix}}",
+        "revealDescription": "Muestra el endpoint firmado y el secreto que termina en {{suffix}}",
         "revealTitle": "Ver secreto del webhook",
         "secret": "Secreto de firma",
         "secretHiddenHint": "Los valores secretos están ocultos en la lista de automatización. Revélalos solo cuando necesites configurar o probar este webhook.",
         "secretOneTimeHint": "El secreto de firma solo se muestra después de la creación.",
-        "signedCurl": "Rotación con signo",
+        "signedCurl": "cURL firmado",
         "upgrade": {
           "adminHint": "Pide a un administrador de espacio de trabajo que actualice.",
           "benefitDescription": "Crea endpoints firmados que inicien flujos de trabajo desde sistemas externos.",
           "benefitTitle": "Automatización segura de flujos de trabajo entrantes",
           "description": "Las automatizaciones de Webhook requieren un espacio de trabajo en equipo o personalizado.",
-          "title": "Actualización para automatizaciones de webhooks",
-          "upgradeAction": "Ascenso a equipo"
+          "title": "Actualizar para usar automatizaciones de webhooks",
+          "upgradeAction": "Actualizar a Team"
         },
         "url": "URL del webhook"
       }
@@ -5130,8 +5130,8 @@
           "reviewPermissions": "Revisar permisos"
         },
         "aria": "Preparación de los conectores",
-        "check": "Revisa los conectores",
-        "checkAgain": "Revisa de nuevo",
+        "check": "Revisar conectores",
+        "checkAgain": "Revisar de nuevo",
         "checking": "Comprobando...",
         "description": "Consulta qué conectores integrados puede necesitar este flujo de trabajo y si están listos.",
         "empty": "No se detectaron conectores necesarios",
@@ -5165,7 +5165,7 @@
         "removalWithAutomations_one": "{{count}} automatización se pausa en {{agent}} y este flujo de trabajo se elimina.",
         "removalWithAutomations_many": "{{count}} automatizaciones se pausan en {{agent}} y este flujo de trabajo se elimina.",
         "removalWithAutomations_other": "{{count}} automatizaciones se pausan en {{agent}} y este flujo de trabajo se elimina.",
-        "removeOriginal": "Elimina el original de {{agent}} después de copiar",
+        "removeOriginal": "Eliminar el original de {{agent}} después de copiar",
         "selectAgent": "Elige un agente",
         "title": "Copiar flujo de trabajo",
         "to": "Copiar a"
@@ -5179,7 +5179,7 @@
       },
       "files": {
         "aria": "Archivos de flujo de trabajo",
-        "deleteAria": "Elimina {{path}}",
+        "deleteAria": "Eliminar {{path}}",
         "deleteSelected": "Eliminar archivo seleccionado",
         "fileContent": "Contenido de archivos de flujo de trabajo",
         "filePlaceholder": "Edita este archivo markdown...",
@@ -5219,13 +5219,13 @@
         "resolvesTo": "actualmente se resuelve como"
       },
       "visibility": {
-        "adminRequired": "Publicar un flujo de trabajo bajo un agente que no eres propietario requiere permisos de administrador de la organización.",
+        "adminRequired": "Publicar un flujo de trabajo para un agente que no es de tu propiedad requiere permisos de administrador de la organización.",
         "automationWarning": "Las automatizaciones se detendrán",
         "confirmDescription": "Esta es una operación peligrosa. Aunque este flujo de trabajo es privado, las automatizaciones que otros miembros construyeron sobre él dejan de funcionar.",
         "confirmTitle": "¿Hacer privado este flujo de trabajo?",
         "makePrivate": "Hacer privado",
         "publishAria": "Hacer público el flujo de trabajo",
-        "workflowHidden": "{{title}} quedarán ocultos para otros miembros y sus automatizaciones cesarán."
+        "workflowHidden": "{{title}} quedará oculto para otros miembros y sus automatizaciones se detendrán."
       }
     },
     "editor": {
@@ -5312,7 +5312,7 @@
       "uninstallTitle": "¿Desinstalar la integración de Slack?"
     },
     "strapi": {
-      "description": "Automatizar el trabajo cuando se publican las entradas",
+      "description": "Automatiza el trabajo cuando se publican entradas",
       "title": "Strapi"
     },
     "teams": {
@@ -5321,8 +5321,8 @@
       "connectThenInstall": "Conecta tu cuenta de Microsoft y luego instala la app Teams",
       "description": "Comunicación y colaboración en equipo",
       "disconnect": "Desconectar Microsoft Teams",
-      "install": "Instala en Teams",
-      "moreOptions": "Más opciones Microsoft Teams",
+      "install": "Instalar en Teams",
+      "moreOptions": "Más opciones de Microsoft Teams",
       "permissionsUpdated": "Los permisos de Microsoft Teams se han actualizado",
       "title": "Microsoft Teams",
       "uninstall": "Desinstalar Microsoft Teams",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1,0 +1,5338 @@
+{
+  "activity": {
+    "codex": {
+      "codexError": "Error de Codex",
+      "commandStatus": "Comando {{status}}",
+      "error": "Error: {{error}}",
+      "fileChangeKind": "Cambio",
+      "fileOperationCompleted": "Operación de archivo completada",
+      "fileOperationStatus": "Operación de archivo: {{status}}",
+      "fileReadCompleted": "Lectura del archivo completada",
+      "fileReadStatus": "Lectura de archivo: {{status}}",
+      "filesChanged": "[archivos] Archivos modificados:",
+      "genericEvent": "Codex {{eventType}}",
+      "genericItem": "Codex {{label}} ({{details}}){{suffix}}",
+      "idDetail": "id: {{id}}",
+      "item": "Ítem",
+      "moreChanges_one": "-... +{{count}} más cambio",
+      "moreChanges_many": "-... +{{count}} más cambios",
+      "moreChanges_other": "-... +{{count}} más cambios",
+      "moreSteps_one": "-... +{{count}} paso más",
+      "moreSteps_many": "-... +{{count}} más pasos",
+      "moreSteps_other": "-... +{{count}} más pasos",
+      "planPrefix": "[plan]",
+      "planStatus": {
+        "completed": "Completado",
+        "inProgress": "En curso",
+        "pending": "Pendiente",
+        "step": "Paso"
+      },
+      "status": "Estado: {{status}}",
+      "statusDetail": "Estado: {{status}}",
+      "turnFailed": "Turno fallido",
+      "turnStatus": "Turno {{status}}",
+      "warning": "[advertencia] {{message}}",
+      "warningFallback": "Advertencia de Codex"
+    },
+    "context": {
+      "artifact": "Artefacto",
+      "environmentMapping": "Asignación del entorno",
+      "featureFlags": "Indicadores de funciones",
+      "firewalls": "Cortafuegos",
+      "mountPath": "Ruta de montaje",
+      "name": "Nombre",
+      "networkPolicies": "Políticas de Red",
+      "none": "Ninguno",
+      "prompt": "Prompt",
+      "runId": "ID de ejecución",
+      "secrets": "Secretos",
+      "session": "Sesión",
+      "storageName": "Nombre de almacenamiento",
+      "systemPrompt": "Prompt del sistema",
+      "value": "Valor",
+      "variables": "Variables",
+      "version": "Versión",
+      "volumes": "Volúmenes"
+    },
+    "detail": {
+      "activity": "Actividad",
+      "contextUnavailable": {
+        "description": "El contexto de ejecución no está disponible para esta ejecución. Puede ser una ejecución anterior creada antes de que se habilitaran las instantáneas de contexto.",
+        "title": "Contexto no disponible"
+      },
+      "downloadRawData": "Descargar datos en bruto",
+      "errorGuidance": {
+        "computerUseAuthorizationRequired": {
+          "guidance": "Solicita un enlace de autorización delegado para Uso del Ordenador, pide al usuario que seleccione un host de escritorio Zero para este chat o hilo Slack, y luego inicia una nueva ejecución. Los tokens de ejecución existentes no pueden actualizarse en su lugar.",
+          "title": "Se requiere autorización para el uso de ordenadores"
+        },
+        "concurrentRunLimitReached": {
+          "guidance": "Espera a que termine la ejecución actual antes de iniciar otra.",
+          "title": "Se alcanzó el límite de ejecuciones simultáneas"
+        },
+        "creditsDepleted": {
+          "guidance": "Haz primero el diagnóstico de créditos. Compra créditos solo cuando el plan actual lo permita; de lo contrario, devuelve el enlace de actualización del plan.",
+          "title": "Créditos agotados"
+        },
+        "modelProviderUnavailable": {
+          "guidance": "El proveedor de modelos utilizado en este hilo ha sido eliminado. Inicia un nuevo hilo de chat para continuar.",
+          "title": "Proveedor de modelo no disponible"
+        },
+        "noModelProvider": {
+          "guidance": "Configura un proveedor de modelos para que empiece a ejecutar agentes.",
+          "title": "No configurado ningún proveedor de modelos"
+        },
+        "paidPlanRequired": {
+          "guidance": "La generación de vídeo integrada no está disponible en el plan actual.",
+          "title": "Se requiere un plan de pago"
+        },
+        "providerIncompatible": {
+          "guidance": "Esta sesión se creó con un tipo de proveedor diferente.",
+          "title": "Proveedor no compatible"
+        },
+        "providerTemporarilyUnavailable": {
+          "guidance": "El proveedor del modelo está temporalmente indisponible. Por favor, inténtalo de nuevo más tarde.",
+          "title": "Proveedor temporalmente no disponible"
+        }
+      },
+      "fallbackAgent": "Agente",
+      "fields": {
+        "duration": "Duración",
+        "model": "Modelo",
+        "source": "Fuente",
+        "status": "Estado",
+        "time": "Tiempo"
+      },
+      "log": "Registro",
+      "modelProvidedBy": "{{model}} proporcionado por {{provider}}",
+      "networkEmpty": {
+        "description": "No se registró tráfico de red durante esta ejecución.",
+        "title": "No hay registros de red"
+      },
+      "notFound": {
+        "back": "Volver a la actividad",
+        "description": "Este registro no existe o no tienes permiso para verlo en el espacio de trabajo actual.",
+        "title": "Registro no encontrado"
+      },
+      "runner": {
+        "deviceLimitMismatch": "Existe una entrada en el pool inactivo, pero no coincide con el estado del límite de dispositivos.",
+        "featureDisabled": "La reutilización del sandbox está desactivada para esta ejecución.",
+        "noSessionId": "No hay un ID de sesión disponible para compararlo con el pool inactivo.",
+        "notReused": "No reutilizado",
+        "poolMiss": "No se encontró un sandbox coincidente en el pool inactivo.",
+        "profileMismatch": "Existe una entrada en el pool inactivo, pero su perfil no coincide.",
+        "reused": "Reutilizado",
+        "reusedDescription": "El sandbox se reactivó desde el pool inactivo.",
+        "sandbox": "Sandbox",
+        "unknown": "Desconocido (ejecución antigua, registrada antes de añadir el seguimiento de reutilización del sandbox).",
+        "unparkFailed": "No se pudo reactivar el sandbox; se aprovisionó uno nuevo."
+      },
+      "steps": {
+        "matched": "({{matched}}/{{total}} coincididos)",
+        "noEvents": "No hay eventos disponibles",
+        "search": "Buscar pasos",
+        "systemPrompt": "Prompt del sistema",
+        "title": "Pasos",
+        "total": "{{total}} en total",
+        "userPrompt": "Prompt"
+      },
+      "tabs": {
+        "context": "Contexto",
+        "network": "Red",
+        "runner": "Runner",
+        "steps": "Pasos"
+      }
+    },
+    "documentTitle": "Actividad",
+    "events": {
+      "agents_one": "agente",
+      "agents_many": "agentes",
+      "agents_other": "agentes",
+      "allTasksCompleted": "Todas las tareas completadas",
+      "argsLabel": "args:",
+      "calls_one": "{{formattedCount}} llamada",
+      "calls_many": "{{formattedCount}} llamadas",
+      "calls_other": "{{formattedCount}} llamadas",
+      "commands_one": "comando",
+      "commands_many": "comandos",
+      "commands_other": "comandos",
+      "duration": "Duración: {{duration}}",
+      "emptyOutput": "(salida vacía)",
+      "files_one": "{{formattedCount}} archivo",
+      "files_many": "{{formattedCount}} archivos",
+      "files_other": "{{formattedCount}} archivos",
+      "initialize": "Inicializar",
+      "inputTokens": "Entrada: {{formattedCount}}",
+      "models_one": "{{formattedCount}} modelo",
+      "models_many": "{{formattedCount}} modelos",
+      "models_other": "{{formattedCount}} modelos",
+      "moreItems_one": "... {{count}} elemento más",
+      "moreItems_many": "... {{count}} elementos más",
+      "moreItems_other": "... {{count}} elementos más",
+      "nameLabel": "Nombre:",
+      "outputTokens": "Salida: {{formattedCount}}",
+      "remainingLines_one": "+{{formattedCount}} línea",
+      "remainingLines_many": "+{{formattedCount}} líneas",
+      "remainingLines_other": "+{{formattedCount}} líneas",
+      "searches_one": "{{formattedCount}} búsqueda",
+      "searches_many": "{{formattedCount}} búsquedas",
+      "searches_other": "{{formattedCount}} búsquedas",
+      "steps_one": "{{formattedCount}} paso",
+      "steps_many": "{{formattedCount}} pasos",
+      "steps_other": "{{formattedCount}} pasos",
+      "summary": "Resumen",
+      "task": "Tarea",
+      "thinking": "Pensamiento",
+      "todo": "Tareas pendientes",
+      "toolFailed": "{{toolName}} falló",
+      "tools_one": "Herramienta",
+      "tools_many": "Herramientas",
+      "tools_other": "Herramientas",
+      "truncated": "truncada",
+      "turns_one": "{{formattedCount}} turno",
+      "turns_many": "{{formattedCount}} turnos",
+      "turns_other": "{{formattedCount}} turnos",
+      "unknownTool": "Desconocido"
+    },
+    "inspect": {
+      "contextUnavailable": {
+        "description": "El contexto de ejecución no está disponible en este registro importado.",
+        "title": "Contexto no disponible"
+      },
+      "documentTitle": "Registro de inspección",
+      "errors": {
+        "invalid": "Archivo JSON inválido. Sube un archivo JSON exportado del registro de actividad.",
+        "load": "No se pudo cargar el archivo JSON. Sube un archivo JSON del registro de actividad exportado.",
+        "oversized": "El archivo JSON es demasiado grande. Sube un archivo JSON de registro de actividad exportado por debajo de 25 MB."
+      },
+      "fallbackName": "Registro importado",
+      "inspect": "Inspeccionar",
+      "networkUnavailable": {
+        "description": "Los registros de red no están disponibles en este registro importado.",
+        "title": "Registros de red no disponibles"
+      },
+      "noLog": {
+        "description": "Sube un archivo JSON del registro de actividad para inspeccionarlo.",
+        "title": "No se cargó log",
+        "upload": "Sube JSON"
+      }
+    },
+    "list": {
+      "description": "Registros y ejecuciones de tus agentes.",
+      "errors": {
+        "description": "Algo salió mal. Por favor, inténtalo de nuevo más tarde.",
+        "title": "No se han cargado los datos de actividad"
+      },
+      "filters": {
+        "agent": "Filtro de agentes",
+        "allAgents": "Todos los agentes",
+        "allSources": "Todas las fuentes",
+        "allStatuses": "Todos los estados",
+        "source": "Filtro de fuente",
+        "status": "Filtro de estado"
+      },
+      "title": "Actividad"
+    },
+    "network": {
+      "actions": {
+        "block": "BLOQUEAR"
+      },
+      "browser": "Navegador",
+      "capture": {
+        "binaryData": "[Datos binarios, {{size}} codificados en base64]",
+        "complete": "completo",
+        "headersWithCount": "{{title}} ({{formattedCount}})",
+        "requestBody": "Cuerpo de la solicitud",
+        "requestHeaders": "Cabeceras de peticiones",
+        "responseBody": "Cuerpo de la respuesta",
+        "responseHeaders": "Cabeceras de respuesta",
+        "truncated": "truncada"
+      },
+      "details": {
+        "action": "Acción",
+        "authCacheHit": "Impacto en caché",
+        "authRefreshedConnectors": "Conectores renovados",
+        "authRefreshedSecrets": "Secretos renovados",
+        "authResolvedSecrets": "Secretos resueltos",
+        "authUrlRewrite": "Reescritura de URL",
+        "baseUrl": "URL base",
+        "billable": "Facturable",
+        "browserUserAgent": "Agente de usuario del navegador",
+        "connectorBaseUrl": "URL base del conector",
+        "connectorDiagnostic": "Diagnóstico de conectores",
+        "connectorEnvNames": "Nombres de variables de entorno del conector",
+        "connectorReason": "Razón del conector",
+        "connectorRouteCandidates": "Candidatos a la ruta de conexión",
+        "connectorRouteReason": "Razón de la ruta del conector",
+        "dnsEvent": "Evento DNS",
+        "dnsQueryType": "Tipo de consulta DNS",
+        "dnsResult": "Resultado DNS",
+        "dnsSerial": "Serie DNS",
+        "error": "Error",
+        "firewall": "Cortafuegos",
+        "host": "Host",
+        "latency": "Latencia",
+        "method": "Método",
+        "modelCatalogCacheBypassReason": "Razón del bypass de caché en el catálogo de modelos",
+        "modelCatalogCacheEntryAge": "Edad de entrada de la caché en catálogos de modelos",
+        "modelCatalogCacheEvictionCount": "Número de expulsiones de la caché del catálogo de modelos",
+        "modelCatalogCacheStatus": "Estado de la caché del catálogo de modelos",
+        "modelCatalogCacheValidationLatency": "Latencia de validación de caché de catálogos de modelos",
+        "modelCatalogPrefetchRole": "Rol de Prefetch en el Catálogo de Modelos",
+        "modelCatalogUpstreamEncoding": "Codificación upstream del catálogo de modelos",
+        "params": "Parámetros",
+        "permission": "Permiso",
+        "permissionError": "Error de permiso",
+        "port": "Puerto",
+        "requestSize": "Tamaño de la solicitud",
+        "responseSize": "Tamaño de la respuesta",
+        "ruleMatch": "Coincidencia de regla",
+        "status": "Estado",
+        "timestamp": "Marca temporal",
+        "type": "Tipo",
+        "upstreamBindingClientBindingCount": "Recuento de vinculación de cliente aguas arriba",
+        "upstreamBindingClientBindingEndpointMatch": "Coincidencia de enlace de cliente ascendente",
+        "upstreamBindingClientBindingHosts": "Hosts de enlace de cliente aguas arriba",
+        "upstreamBindingClientBindingMatch": "Coincidencia de enlace de cliente aguas arriba",
+        "upstreamBindingClientId": "ID de cliente de vinculación ascendente",
+        "upstreamBindingClientSockname": "Nombre Sockname del Cliente de Enlace Upstream",
+        "upstreamBindingDirectBindingHost": "Host de enlace directo aguas arriba",
+        "upstreamBindingDirectBindingKinds": "Tipos de unión directa aguas arriba",
+        "upstreamBindingDirectBindingPort": "Puerto de enlace directo aguas arriba",
+        "upstreamBindingDirectBindingPresent": "Enlace directo aguas arriba presente",
+        "upstreamBindingReason": "Razón de Vinculación Aguas arriba",
+        "upstreamBindingRequestHost": "Host de Solicitud de Vinculación Upstream",
+        "upstreamBindingRequestPort": "Puerto de Solicitud de Enlace Ascendente",
+        "upstreamBindingServerAddress": "Dirección del servidor de enlace aguas arriba",
+        "upstreamBindingServerConnected": "Servidor de enlace ascendente conectado",
+        "upstreamBindingServerId": "ID de servidor de enlace ascendente",
+        "upstreamBindingServerPeername": "Nombre de par del servidor de enlace ascendente",
+        "upstreamBindingServerSockname": "Nombre Sockname del servidor de enlace ascendente",
+        "upstreamBindingTrustedHost": "Vinculación ascendente del host confiable",
+        "url": "URL"
+      },
+      "filter": {
+        "allTypes": "Todos los tipos",
+        "selectedTypes_one": "{{formattedCount}} tipo",
+        "selectedTypes_many": "{{formattedCount}} tipos",
+        "selectedTypes_other": "{{formattedCount}} tipos",
+        "type": "Filtro de tipo"
+      },
+      "headers": {
+        "latency": "Latencia",
+        "method": "Método",
+        "permission": "Permiso",
+        "status": "Estado",
+        "time": "Tiempo",
+        "type": "Tipo",
+        "urlHost": "URL / Host"
+      },
+      "loadMore": "Cargar más",
+      "no": "No",
+      "noMatchingLogs": "No hay registros coincidentes en los resultados cargados",
+      "unknown": "Desconocido",
+      "yes": "Sí"
+    },
+    "pagination": {
+      "backTwo": "Retroceder 2 páginas",
+      "forwardTwo": "Avanzar 2 páginas",
+      "next": "Página siguiente",
+      "page": "Página {{current}}",
+      "pageOf": "Página {{current}} de {{total}}",
+      "previous": "Página anterior",
+      "rowsPerPage": "Filas por página"
+    },
+    "sources": {
+      "agent": "Agente",
+      "agentphone": "AgentPhone",
+      "agentWithName": "Agente ({{name}})",
+      "cli": "CLI",
+      "email": "Correo electrónico",
+      "feishu": "Feishu",
+      "github": "GitHub",
+      "slack": "Slack",
+      "teams": "Teams",
+      "telegram": "Telegram",
+      "web": "Web",
+      "webhook": "Webhook",
+      "workflowEvent": "Evento de flujo de trabajo",
+      "workflowSchedule": "Calendario de flujo de trabajo"
+    },
+    "statuses": {
+      "cancelled": "Cancelado",
+      "completed": "Completado",
+      "failed": "Fallido",
+      "pending": "Pendiente",
+      "queued": "En cola",
+      "running": "En ejecución",
+      "timeout": "Tiempo de espera agotado"
+    },
+    "statusFilters": {
+      "cancelled": "Cancelado",
+      "completed": "Completado",
+      "failed": "Fallido",
+      "pending": "Pendiente",
+      "queued": "En cola",
+      "running": "En ejecución",
+      "timeout": "Tiempo de espera agotado"
+    },
+    "table": {
+      "empty": {
+        "description": "Cuando tus agentes empiecen a trabajar, su actividad aparecerá aquí.",
+        "title": "Todo en silencio por ahora"
+      },
+      "filteredEmpty": {
+        "description": "Prueba diferentes filtros para encontrar lo que buscas.",
+        "title": "Nada coincide con esos filtros"
+      },
+      "headers": {
+        "agent": "Agente",
+        "description": "Descripción",
+        "duration": "Duración",
+        "session": "Sesión",
+        "source": "Fuente",
+        "startTime": "Hora de inicio",
+        "status": "Estado"
+      }
+    }
+  },
+  "appShell": {
+    "browserUpgrade": {
+      "browser": {
+        "action": "Actualizar navegador",
+        "description": "Zero no es compatible con la versión actual de tu navegador. Actualiza el navegador para continuar.",
+        "title": "Actualiza tu navegador para continuar"
+      },
+      "chrome": {
+        "action": "Actualizar Chrome",
+        "description": "Zero no es compatible con la versión actual de tu navegador. Actualiza Chrome para continuar.",
+        "title": "Actualiza Chrome para continuar"
+      },
+      "chromium": {
+        "action": "Actualizar Chromium",
+        "description": "Zero no es compatible con la versión actual de tu navegador. Actualiza Chromium para continuar.",
+        "title": "Actualiza Chromium para continuar"
+      },
+      "ios": {
+        "action": "Actualizar iOS",
+        "description": "Zero no es compatible con la versión actual de tu navegador. Actualiza iOS para continuar.",
+        "title": "Actualiza iOS para continuar"
+      },
+      "safari": {
+        "action": "Actualizar Safari",
+        "description": "Zero no es compatible con la versión actual de tu navegador. Actualiza Safari para continuar.",
+        "title": "Actualiza Safari para continuar"
+      }
+    },
+    "loading": {
+      "ariaLabel": "Cargando tu espacio de trabajo",
+      "messages": {
+        "almostThere": "Ya casi está...",
+        "brewingIdeas": "Preparando algunas ideas...",
+        "connectingDots": "Conectando los puntos...",
+        "gettingReady": "Dejándolo todo listo...",
+        "loadingWorkspace": "Cargando tu espacio de trabajo...",
+        "spinningTeam": "Reuniendo al equipo...",
+        "tuningInstruments": "Afinando los instrumentos...",
+        "warmingNeurons": "Activando las neuronas..."
+      }
+    },
+    "logoAlt": "VM0",
+    "metadata": {
+      "description": "Zero es tu compañero de IA de vm0. Escríbele a Zero o chatea en la web: investiga, envía correos, crea documentos y usa Slack, GitHub, Notion y más de 100 herramientas.",
+      "title": "Zero — Tu compañero de IA de vm0"
+    },
+    "shortcutHelp": {
+      "close": "Cerrar atajos de teclado",
+      "description": "Atajos disponibles en esta página",
+      "sections": {
+        "composer": "Editor",
+        "global": "Global",
+        "messages": "Mensajes"
+      },
+      "shortcuts": {
+        "blurComposer": "Quitar el foco del editor",
+        "changeIcon": "Cambiar icono",
+        "clearIcon": "Quitar icono",
+        "newChat": "Nuevo chat",
+        "nextAgent": "Siguiente agente",
+        "nextThread": "Siguiente hilo",
+        "openAgentList": "Abrir la lista de agentes",
+        "openFirstThread": "Abrir primer hilo",
+        "previousAgent": "Agente anterior",
+        "previousThread": "Hilo anterior",
+        "renameChat": "Renombrar chat",
+        "scrollBottom": "Desplázate hasta abajo",
+        "scrollTop": "Desplázate hasta arriba",
+        "sendMessage": "Enviar mensaje",
+        "setIcon": "Asignar icono (Ctrl+Mayús+1-9)",
+        "showShortcuts": "Mostrar atajos de teclado",
+        "toggleSidebar": "Mostrar u ocultar la barra lateral"
+      },
+      "title": "Atajos de teclado"
+    },
+    "sidebar": {
+      "ariaLabel": "Barra lateral",
+      "chat": "Chat",
+      "collapse": "Contraer barra lateral",
+      "expand": "Expandir la barra lateral",
+      "manage": "Gestionar",
+      "mobile": {
+        "invite": "Invitar",
+        "openArtifacts": "Abrir artefactos en móvil",
+        "openAutomations": "Abrir automatizaciones en móvil",
+        "openMenu": "Abrir menú",
+        "overlay": "Superposición de barra lateral"
+      },
+      "navigation": {
+        "activity": "Registros de actividad",
+        "agents": "Agentes",
+        "artifacts": "Artefactos",
+        "connectors": "Conectores",
+        "insights": "Estadísticas",
+        "insightsAndUsage": "Estadísticas y uso",
+        "newChat": "Nuevo chat",
+        "settings": "Configuración",
+        "workflows": "Flujos de trabajo",
+        "works": "Dónde trabaja {{agentName}}"
+      },
+      "rail": {
+        "activity": "Actividad",
+        "new": "Nuevo",
+        "workflows": "Flujos de trabajo",
+        "works": "Integraciones"
+      },
+      "searchConversations": "Buscar conversaciones",
+      "workspaceSwitcher": {
+        "create": "Crear espacio de trabajo",
+        "creating": "Creando…",
+        "join": "Unirse",
+        "joining": "Uniéndose...",
+        "organizationFallback": "Organización",
+        "switch": "Cambiar de espacio de trabajo"
+      }
+    }
+  },
+  "artifacts": {
+    "actions": {
+      "backToAll": "Volver a todos los artefactos",
+      "backToArtifacts": "Volver a los artefactos",
+      "close": "Cerrar",
+      "closeArtifact": "Cerrar artefacto",
+      "closeDownloadMenu": "Cerrar menú de descarga",
+      "closeNamed": "Cerrar {{title}}",
+      "closePreviewMenu": "Cerrar menú de vista previa",
+      "download": "Descargar",
+      "downloadArtifact": "Descargar artefacto",
+      "downloadOptions": "Opciones de descarga",
+      "enterFullscreen": "Paso a pantalla completa",
+      "exitFullscreen": "Salir de pantalla completa",
+      "more": "Más acciones de artefacto",
+      "nextImage": "Siguiente artefacto de imagen",
+      "openNewTab": "Abrir en una pestaña nueva",
+      "openSplitView": "Abrir en vista dividida",
+      "previousImage": "Artefacto de imagen anterior",
+      "resetZoom": "Reiniciar el zoom",
+      "share": "Compartir",
+      "shareArtifact": "Compartir artefacto",
+      "zoomIn": "Zoom en",
+      "zoomOut": "Zoom fuera"
+    },
+    "attachments": {
+      "cancelUpload": "Cancelar la subida {{filename}}",
+      "download": "Descargar {{filename}}",
+      "openImagePreview": "Abrir la vista previa de {{filename}}",
+      "remove": "Elimina {{filename}}"
+    },
+    "catalog": {
+      "cardPreview": "Vista previa {{title}}",
+      "description": "Explora todo lo que hayas creado aquí.",
+      "emptyDescription": "Los artefactos aparecerán aquí cuando estén disponibles.",
+      "emptyTitle": "No se han encontrado artefactos",
+      "error": "No se pudo cargar artefactos. Inténtalo de nuevo más tarde.",
+      "filters": {
+        "file": "Archivos",
+        "fileAria": "Mostrar artefactos de archivo",
+        "image": "Imágenes",
+        "imageAria": "Mostrar artefactos de imagen",
+        "label": "Filtros de tipo de artefacto",
+        "presentation": "Presentaciones",
+        "presentationAria": "Artefactos de presentación del espectáculo",
+        "video": "Vídeos",
+        "videoAria": "Mostrar artefactos de vídeo",
+        "website": "Sitios web",
+        "websiteAria": "Artefactos de la web de la exposición"
+      },
+      "kindIcon": "{{kind}} artefacto",
+      "loading": "Cargando artefactos"
+    },
+    "fileBadges": {
+      "artwork": "ARTE",
+      "audio": "AUD",
+      "file": "ARCHIVO",
+      "video": "VID"
+    },
+    "googleDrive": {
+      "agentLoading": "El agente sigue cargando",
+      "connect": "Conectar Google Drive",
+      "connectTooltip": "Conecta Google Drive para subir artefactos",
+      "failedToOpenConnect": "No se pudo abrir la página de conexión de Google Drive",
+      "noArtifacts": "No hay artefactos que sincronizar",
+      "partial_one": "Se sincronizó {{synced}} de {{count}} archivo con Google Drive",
+      "partial_many": "Se sincronizaron {{synced}} de {{count}} archivos con Google Drive",
+      "partial_other": "Se sincronizaron {{synced}} de {{count}} archivos con Google Drive",
+      "synced": "Sincronizado con Google Drive",
+      "syncedFiles_one": "Sincronizado con Google Drive",
+      "syncedFiles_many": "Se sincronizaron {{count}} archivos con Google Drive",
+      "syncedFiles_other": "Se sincronizaron {{count}} archivos con Google Drive",
+      "syncFailed": "No se pudo sincronizar con Google Drive",
+      "syncingArtifact": "Sincronizando artefacto...",
+      "syncingFiles_one": "Sincronizando {{count}} archivo...",
+      "syncingFiles_many": "Sincronizando {{count}} archivos...",
+      "syncingFiles_other": "Sincronizando {{count}} archivos...",
+      "syncingNamed": "Sincronizando {{filename}}...",
+      "upload": "Subir a Google Drive"
+    },
+    "kinds": {
+      "audio": "Audio",
+      "code": "Código",
+      "csv": "CSV",
+      "data": "Datos",
+      "document": "Documento",
+      "file": "Archivo",
+      "hostedSite": "Sitio alojado",
+      "image": "Imagen",
+      "json": "JSON",
+      "markdown": "Descuento",
+      "presentation": "Presentación",
+      "text": "Texto",
+      "video": "Vídeo"
+    },
+    "metadata": {
+      "generated": "Generados {{date}}"
+    },
+    "preview": {
+      "audioLabel": "Vista previa de audio para {{filename}}",
+      "badge": "Avance",
+      "dialogLabel": "{{filename}} vista previa",
+      "emptyCsv": "CSV vacío.",
+      "genericUnavailable": "Vista previa no disponible.",
+      "noInline": "No hay una vista previa en línea disponible para este archivo.",
+      "openKind": "Abrir vista previa de {{kind}} para {{filename}}",
+      "openKinds": {
+        "audio": "Audio",
+        "csv": "CSV",
+        "html": "HTML",
+        "json": "JSON",
+        "markdown": "Descuento",
+        "pdf": "pdf",
+        "text": "Texto",
+        "video": "Vídeo"
+      },
+      "siteLabel": "Vista previa del sitio para {{title}}",
+      "slideTitle": "Diapositiva {{number}}",
+      "unavailable": "{{kind}} vista previa no disponible.",
+      "videoLabel": "Vista previa en vídeo para {{filename}}"
+    },
+    "sidebar": {
+      "panelTitle": "Artefactos",
+      "singularTitle": "Artefacto",
+      "unavailable": "Este artefacto ya no está disponible."
+    },
+    "templates": {
+      "activeHtmlPreview": "{{title}} vista previa activa de HTML",
+      "all": "Todos",
+      "categories": "Categorías de plantilla",
+      "category": "Categoría de plantilla",
+      "fullPreview": "{{title}} vista previa completa de la web",
+      "htmlPreview": "{{title}} Vista previa HTML",
+      "illustration": "Ilustración",
+      "illustrationPreview": "{{title}} vista previa de ilustraciones",
+      "multiAccent": "Multiacentos",
+      "nextSlide": "Avance siguiente diapositiva",
+      "noMatches": "Sin partidos",
+      "placeholder": "{{title}} previsualización del sitio web",
+      "playVideo": "Reproduce la vista previa de la plantilla de vídeo {{title}}",
+      "previewCurrentSlide": "{{title}} de vista previa en la diapositiva actual",
+      "previewSlide": "Vista previa {{slideNumber}}",
+      "previewWebsite": "Plantilla de página web de vista previa {{title}}",
+      "previousHtmlPreview": "{{title}} vista previa de HTML",
+      "previousSlide": "Vista previa de la diapositiva anterior",
+      "searchConnector": "Buscar conector...",
+      "searchConnectors": "Buscar conectores",
+      "selected": "Plantilla: {{title}}",
+      "selectStyle": "Selecciona el estilo {{style}}",
+      "selectTemplate": "Seleccionar plantilla {{title}}",
+      "selectVideo": "Seleccionar plantilla de vídeo {{title}}",
+      "selectWebsite": "Seleccionar plantilla web {{title}}",
+      "selectWorkflow": "Seleccionar plantilla de flujo de trabajo {{title}}",
+      "showVariant": "Variante de mostrar {{variantNumber}}",
+      "singleAccent": "Acento único",
+      "slidePreview": "{{title}} vista previa de diapositivas",
+      "slideThumbnail": "{{title}} diapositiva {{slideNumber}} vista previa",
+      "template": "Plantilla",
+      "theme": "Tema",
+      "themeNames": {
+        "bauhausPrimary": "Ladrillos de juguete",
+        "berryPop": "Refresco de frambuesa",
+        "carnival": "Feria de atracciones",
+        "citrusFresh": "Zumo de naranja",
+        "coralStudio": "Peach Studio",
+        "forestEditorial": "Biblioteca Moss",
+        "goldLuxe": "Noche de entrega de premios",
+        "mauveDusk": "Crepúsculo lavanda",
+        "midnightMono": "Ejecución nocturna",
+        "mintTech": "Laboratorio de la Casa de la Moneda",
+        "monoInk": "Papel de periódico rojo",
+        "nordicFrost": "Lago de hielo",
+        "oceanDeep": "Inmersión profunda",
+        "popArt": "Sala de neón",
+        "prism": "Fiesta de caramelos",
+        "slateCorporate": "Azul de la sala de juntas",
+        "sunsetMaroon": "Resplandor del atardecer",
+        "terracottaClay": "Vasija de barro",
+        "warmSand": "Periódico matutino"
+      },
+      "tryDifferentSearch": "Prueba con otra búsqueda.",
+      "use": "Uso",
+      "useThisTemplate": "Usa esta plantilla",
+      "website": "Sitio web",
+      "websitePreview": "{{title}} vista previa de plantilla de sitio web",
+      "workflow": "Flujo de trabajo"
+    },
+    "title": "Artefactos",
+    "toasts": {
+      "copyLinkFailed": "No se pudo copiar el enlace",
+      "downloadFailed": "Descarga fallida",
+      "linkCopied": "Enlace copiado"
+    }
+  },
+  "auth": {
+    "clerk": {
+      "accessNotAllowed": "Acceso no permitido.",
+      "userBanned": "El acceso a la cuenta se suspendió porque la actividad en esta cuenta violó los {{brandName}} Términos de Uso. Si tienes preguntas, contacta con support@vm0.ai."
+    },
+    "documentTitles": {
+      "signIn": "Iniciar sesión",
+      "signUp": "Crear una cuenta"
+    },
+    "loading": "Cargando autenticación",
+    "toggleTheme": "Cambiar tema"
+  },
+  "authorization": {
+    "browser": {
+      "description": "Zero usará un perfil aislado de navegador en la nube para este hilo de chat. Activarlo desconecta el uso del ordenador para el hilo.",
+      "enable": "Habilitar este hilo",
+      "enabled": "Navegador en la nube habilitado",
+      "linkExpires": "El enlace caduca {{date}}.",
+      "title": "Activar el navegador en la nube",
+      "unavailableDescription": "Este enlace de autorización para navegador en la nube es inválido, caducado o no está disponible para este espacio de trabajo.",
+      "unavailableTitle": "Enlace de autorización no disponible"
+    },
+    "computerUse": {
+      "authorize": "Autorizar",
+      "authorized": "Autorizado",
+      "checkingCompatibility": "Comprobación de compatibilidad",
+      "description": "Elige un ordenador online para que Zero lo uses en {{source}}.",
+      "downloadMac": "Descargar para macOS",
+      "lastSeen": "Última vez que se vio {{date}}",
+      "linkExpires": "El enlace caduca {{date}}.",
+      "macRequirement": "Requiere un Mac Apple Silicon con macOS 14 o más reciente. No se soportan Macs Intel.",
+      "noHostsDescription": "Abre Zero Uso del ordenador en tu Mac y actualiza esta página cuando esté en línea.",
+      "noHostsTitle": "No hay ordenadores en línea",
+      "sources": {
+        "chat": "Este hilo de chat",
+        "slack": "Este Slack hilo",
+        "teams": "Este Teams hilo"
+      },
+      "title": "Autorizar el uso de ordenadores",
+      "unavailableDescription": "Este enlace de autorización para el uso del ordenador es inválido, caducado o no está disponible para este espacio de trabajo.",
+      "unavailableTitle": "Enlace de autorización no disponible",
+      "unsupportedIntelMac": "Requiere un Mac Apple Silicon"
+    },
+    "permission": {
+      "confirm": "Confirmar",
+      "duration": "Duración",
+      "durationLabel": "Duración del permiso",
+      "durationOptions": {
+        "always": "Siempre",
+        "oneHour": "1 hora",
+        "sevenDays": "7 días",
+        "twentyFourHours": "24 horas"
+      },
+      "errors": {
+        "agentNotFound": "Agente no encontrado",
+        "loadAgent": "No se ha conseguido cargar el agente",
+        "loadGrants": "No se han cargado las concesiones de permiso",
+        "loadMetadata": "No se han cargado los metadatos de permisos",
+        "missingAgentId": "Falta el ID del agente en los parámetros de URL",
+        "missingPermission": "Permiso faltante en los parámetros de URL",
+        "unknownAction": "Acción de permiso desconocida: {{action}}",
+        "unknownConnector": "Conector desconocido: {{connector}}",
+        "unknownPermission": "Permiso desconocido: {{permission}}",
+        "updateFailed": "No se pudo actualizar los permisos"
+      },
+      "expiration": {
+        "expired": "Caducado",
+        "inDays_one": "Caduca en {{count}} día",
+        "inDays_many": "Caduca en {{count}} días",
+        "inDays_other": "Caduca en {{count}} días",
+        "inHours_one": "Caduca en {{count}} hora",
+        "inHours_many": "Caduca en {{count}} horas",
+        "inHours_other": "Caduca en {{count}} horas",
+        "lessThanHour": "Caduca en menos de 1 hora",
+        "lessThanHourShort": "< 1 hora",
+        "prefix": "Caduca en"
+      },
+      "greeting": "Hola {{userName}}, estás actualizando tus permisos para {{targetName}}.",
+      "result": {
+        "alreadyAllowedDescription": "Tu permiso de conexión ya está concedido",
+        "alreadyAllowedTitle": "Ya está permitido",
+        "alreadyDeniedDescription": "Tu permiso de conexión ya está denegado",
+        "alreadyDeniedTitle": "Ya denegado",
+        "deniedDescription": "Tu permiso de conexión ha sido denegado",
+        "deniedTitle": "Permisos denegados",
+        "updatedDescription": "Tu permiso de conexión ha sido actualizado",
+        "updatedTitle": "Permisos actualizados"
+      },
+      "saving": "Guardando...",
+      "unknownEndpoints": "Puntos finales desconocidos",
+      "userFallback": "Ahí",
+      "wouldLike": "Me gustaría"
+    }
+  },
+  "billing": {
+    "autoRecharge": {
+      "amountAria": "Recarga automática del crédito en créditos",
+      "amountTitle": "Cantidad de recarga",
+      "automaticTopUps": "Recargas automáticas",
+      "description": "Compra créditos cuando tu saldo esté por debajo de un umbral.",
+      "enableAria": "Activar la recarga automática",
+      "thresholdAria": "Umbral de crédito para la recarga automática",
+      "thresholdDescription": "Activa una compra cuando tu saldo crediticio baje de este número.",
+      "thresholdPlaceholder": "por ejemplo, 2000",
+      "thresholdTitle": "Cuando los créditos bajan",
+      "title": "Recarga automática"
+    },
+    "common": {
+      "back": "Volver",
+      "cancel": "Cancelar",
+      "credits": "Créditos",
+      "manage": "Gestionar",
+      "redirecting": "Redirigiendo...",
+      "restore": "Restauración",
+      "retry": "Reintentar",
+      "unavailable": "No disponible",
+      "updating": "Actualizando..."
+    },
+    "concurrency": {
+      "activeUntil": "Activo hasta {{date}}",
+      "billedMonthly": "Facturado mensualmente",
+      "buyAmount": "Compra {{amount}}",
+      "buyButton": "Comprar concurrencia",
+      "buyDescription": "Añade una suscripción mensual para disponer de más ejecuciones simultáneas.",
+      "buyTitle": "Comprar concurrencia",
+      "cancelDescription": "La renovación se detendrá al final del periodo de facturación actual. Los cupos existentes seguirán activos hasta entonces.",
+      "cancellationScheduled": "Cancelación programada",
+      "cancelTitle": "¿Cancelar la suscripción de concurrencia?",
+      "concurrentRun_one": "{{value}} ejecución simultánea",
+      "concurrentRun_many": "{{value}} ejecuciones simultáneas",
+      "concurrentRun_other": "{{value}} ejecuciones simultáneas",
+      "decreaseAria": "Reducir la cantidad adicional de concurrencia",
+      "emptyDescription": "Compra ejecuciones concurrentes adicionales para este espacio de trabajo.",
+      "emptyTitle": "No hay suscripciones de concurrencia",
+      "increaseAria": "Aumentar la cantidad adicional de concurrencia",
+      "restoreDescription": "Esto reanuda la renovación de esta suscripción de concurrencia.",
+      "restoreSubscription": "Restaurar suscripción",
+      "restoreTitle": "¿Restaurar la suscripción de concurrencia?",
+      "slot_one": "{{value}} cupo",
+      "slot_many": "{{value}} cupos",
+      "slot_other": "{{value}} cupos",
+      "slots": "Cupos",
+      "title": "Concurrencia"
+    },
+    "credits": {
+      "amount": "Cantidad",
+      "amountRangeError": "Entra entre {{minimum}} y {{maximum}}",
+      "anyAmount": "Cualquier cantidad",
+      "custom": "Personalizado",
+      "customAmountAria": "Cantidad personalizada en dólares",
+      "exchangeRate": "Los créditos nunca caducan. 1 USD = {{credits}} créditos.",
+      "quickBuy": "Compra rápida",
+      "quickBuyAmount": "Compra rápida {{amount}}",
+      "title": "Comprar créditos"
+    },
+    "downgrade": {
+      "cancelSubscription": "Cancelar suscripción",
+      "chooseTarget": "Elige a qué plan hacer downgrade.",
+      "confirmProCancellation": "¿Estás seguro de que quieres cancelar tu plan Pro?",
+      "confirmTarget": "¿Degradar a {{plan}}?",
+      "inProgress": "Degradando...",
+      "proWarning": "Tu acceso Pro permanece activo hasta que termine el periodo de facturación actual. Después de eso, este espacio de trabajo pasa a Sin plan y los agentes no pueden funcionar hasta que actualices.",
+      "teamWarning": "El acceso de tu equipo permanece activo hasta que termine el periodo de facturación actual. Después de eso, este espacio de trabajo se traslada a {{plan}}.",
+      "title": "Plan de degradación"
+    },
+    "invoices": {
+      "amount": "Cantidad",
+      "date": "Fecha",
+      "downloadDescription": "Elige hasta 3 meses consecutivos. Los PDFs de recibo en ese rango se agruparán en un solo archivo ZIP.",
+      "downloadInvoice": "Descargar factura de {{month}}",
+      "downloadReceipts": "Descargar recibos",
+      "downloadZip": "Descargar ZIP",
+      "empty": "Todavía no hay facturas.",
+      "from": "De",
+      "invoice": "Factura",
+      "loading": "Cargando facturas",
+      "monthAria": "{{label}} mes",
+      "preparingReceipts": "Preparando recibos...",
+      "rangeError": "Selecciona un rango de no más de 3 meses consecutivos.",
+      "selectMonth": "Seleccionar mes",
+      "to": "Para"
+    },
+    "manage": {
+      "description": "Suscripciones, método de pago y facturas en Stripe.",
+      "title": "Gestionar la facturación"
+    },
+    "plans": {
+      "cancellationNotice": "Tu plan {{plan}} ha sido cancelado y terminará el {{date}}.",
+      "changeAnytime": "Actualiza o baja cuando quieras.",
+      "compare": "Comparar planes",
+      "compareAll": "Compara todos los planes",
+      "currentPlan": "Plan actual",
+      "custom": {
+        "name": "Personalizado"
+      },
+      "customAccess": "Acceso personalizado con ejecuciones concurrentes {{value}}",
+      "customCancellationNotice": "Tu plan personalizado terminará en {{date}}.",
+      "customCheckoutUnavailable": "Los espacios de trabajo con un plan personalizado no pueden cambiar a Pro ni Team.",
+      "downgrade": "Degradación",
+      "downgradeNotice": "Tu plan de {{currentPlan}} se rebajará a {{targetPlan}} en {{date}}.",
+      "downgradesOn": "Degradaciones a {{plan}} en {{date}}",
+      "downgradeTo": "Retroceso a {{plan}}",
+      "endsOn": "Termina en {{date}}",
+      "features": {
+        "byok": "Lleva tus propias llaves de LLM",
+        "communitySupport": "Soporte de la comunidad",
+        "emailSupport": "Soporte por correo electrónico",
+        "existingCredits": "Solo créditos gratuitos existentes",
+        "monthlyCredits": "{{value}} créditos / mes",
+        "oneConcurrentRun": "1 ejecución simultánea",
+        "payAsYouGo": "Paga según la compra después",
+        "prioritySupport": "Soporte prioritario",
+        "tenConcurrentRuns": "10 ejecuciones simultáneas",
+        "twoConcurrentRuns": "2 recorridos simultáneos",
+        "unlimitedAgents": "Agentes totales ilimitados",
+        "voiceInput": "Entrada de voz",
+        "voiceInputLifetime": "Entrada de voz (10 usos de por vida por miembro)"
+      },
+      "free": {
+        "description": "Acceso gratuito heredado para los espacios de trabajo existentes.",
+        "name": "Gratis"
+      },
+      "limitedFree": {
+        "name": "Gratis limitado"
+      },
+      "loadError": "No se pudo cargar el estado de facturación.",
+      "manageSubscription": "Gestionar la suscripción",
+      "namedPlan": "Plan {{plan}}",
+      "noActivePlan": "No hay plan activo",
+      "noActiveSubscription": "Sin suscripción activa",
+      "noPlan": {
+        "name": "Sin plan"
+      },
+      "perMonth": "/mes",
+      "popular": "Populares",
+      "pricePerMonth": "{{price}}/mes",
+      "pro": {
+        "description": "Más potencia y colaboración fluida para tu equipo.",
+        "name": "Pro"
+      },
+      "renews": "Renueva {{date}}",
+      "restorePlan": "Plan de restauración",
+      "sectionTitle": "Plan",
+      "selectedPlan": "El plan seleccionado",
+      "team": {
+        "description": "Escala rápido, sin fricción y con total flexibilidad.",
+        "name": "Equipo"
+      },
+      "upgrade": "Actualización",
+      "upgradeTo": "Actualizar a {{plan}}"
+    },
+    "restore": {
+      "cancellationDescription": "Esto anulará la cancelación programada de tu plan {{plan}}.",
+      "cancellationDescriptionDate": "Esto anulará la cancelación programada de tu plan {{plan}}. Se renovará el {{date}}.",
+      "downgradeDescription": "Esto cancelará la degradación programada a {{target}}. Tu plan {{plan}} seguirá renovándose.",
+      "inProgress": "Restaurando...",
+      "title": "¿Restaurar {{plan}} plan?"
+    },
+    "sidebar": {
+      "description": "Más créditos y ejecuciones simultáneas",
+      "getPlan": "Obtener {{plan}}"
+    },
+    "toasts": {
+      "autoRechargeUpdated": "Recarga automática actualizada",
+      "cancellationScheduledDate": "Cancelación programada. Tu plan actual permanece activo hasta {{date}}.",
+      "cancellationScheduledPeriod": "Cancelación programada. Tu plan actual permanece activo hasta que termine el periodo de facturación.",
+      "checkoutCompleted": "{{plan}} finalizada la compra. Se añadirán créditos después de pagar la factura.",
+      "concurrencyAdded": "Se añadió la concurrencia. Tus nuevos cupos estarán disponibles cuando Stripe confirme la suscripción.",
+      "concurrencyCanceled": "Suscripción de concurrencia cancelada.",
+      "concurrencyCanceledDate": "Se canceló la suscripción de concurrencia. Los cupos seguirán activos hasta {{date}}.",
+      "concurrencyRestored": "Se ha restaurado la suscripción de concurrencia.",
+      "creditsAdded": "Créditos añadidos. Puedes seguir chateando con Zero.",
+      "downgradeScheduledDate": "Degradación programada. Tu plan actual permanece activo hasta {{date}}.",
+      "downgradeScheduledPeriod": "Degradación programada. Tu plan actual permanece activo hasta que termine el periodo de facturación.",
+      "planRestored": "Plan restaurado. Tu suscripción se renovará normalmente.",
+      "preparingReceiptDownload": "Preparando la descarga del recibo...",
+      "receiptDownloadFailed": "No se han conseguido descargar los recibos",
+      "receiptsDownloaded": "Recibos descargados"
+    },
+    "usage": {
+      "added": "Añadido {{date}}",
+      "allowance": {
+        "day": "{{value}}d",
+        "hour": "{{value}}h",
+        "minute": "{{value}}m",
+        "remaining": "{{remaining}} / {{total}} créditos",
+        "remainingAria": "Límite de uso {{label}} restante",
+        "resets": "Reinicios {{date}}",
+        "resetsRaw": "Reinicios {{value}}",
+        "title": "Asignación de uso",
+        "week": "{{value}}w"
+      },
+      "breakdown": {
+        "currentPlanDescription": "Los créditos mensuales del plan reinician cada ciclo de facturación",
+        "freeDescription": "Créditos iniciales, úsalo hasta agotarse",
+        "freePlan": "Plan gratuito",
+        "payAsYouGo": "Paga según la acción",
+        "payAsYouGoDescription": "Créditos de recarga automática, nunca caducan",
+        "previousPlanDescription": "Créditos sobrantes del plan anterior",
+        "promotional": "Promoción",
+        "promotionalDescription": "Los créditos de campaña expiran tras un periodo determinado",
+        "proPlan": "Plan Pro",
+        "teamPlan": "Plan del equipo"
+      },
+      "creditAdditions": "Adiciones de créditos",
+      "creditsRemaining_one": "{{value}} crédito restante",
+      "creditsRemaining_many": "{{value}} créditos restantes",
+      "creditsRemaining_other": "{{value}} créditos restantes",
+      "expires": "Caduca {{date}}",
+      "left": "{{value}} restante",
+      "member": "Miembro",
+      "neverExpires": "Nunca caduca",
+      "unavailable": "Saldo de crédito no disponible.",
+      "upgradeDescription": "Pro incluye créditos mensuales y desbloquea opciones adicionales de crédito.",
+      "upgradeTitle": "Actualiza a Pro para conseguir más créditos",
+      "used": "Usados"
+    }
+  },
+  "browserSession": {
+    "cardTitle": "Navegador en la nube",
+    "close": "Cerrar el navegador en vivo",
+    "documentTitle": "Navegador en vivo",
+    "fitWindow": "Ajustar el navegador a la ventana",
+    "iframeTitle": "Navegador en vivo: {{name}}",
+    "invalidLink": "Enlace del navegador inválido",
+    "open": "Abrir navegador de {{name}}",
+    "openAction": "Abrir",
+    "openNewPage": "Abre este navegador en una página nueva",
+    "panel": {
+      "notLive": "El navegador no está activo",
+      "resume": "Navegador de currículums",
+      "resumeDescription": "Reanudar restaura el perfil de inicio de sesión y el almacenamiento guardados. Las páginas y pestañas anteriores no regresan.",
+      "resuming": "Reanuda...",
+      "suspended": "Navegador suspendido"
+    },
+    "reclaimHint_one": "Zero mantiene este navegador mientras este panel está abierto y lo recupera tras {{formattedCount}} minuto de reposo.",
+    "reclaimHint_many": "Zero mantiene este navegador mientras este panel está abierto y lo recupera tras {{formattedCount}} minutos de reposo.",
+    "reclaimHint_other": "Zero mantiene este navegador mientras este panel está abierto y lo recupera tras {{formattedCount}} minutos de reposo.",
+    "status": {
+      "live": "En directo",
+      "starting": "Inicio",
+      "stopped": "Detenido"
+    },
+    "title": "Navegador en vivo",
+    "unavailable": {
+      "description": "Este navegador no pertenece a este chat ni ha sido eliminado.",
+      "title": "Navegador no disponible"
+    }
+  },
+  "chat": {
+    "actions": {
+      "authorize": "Autorizar",
+      "cancel": "Cancelar",
+      "configure": "Configurar",
+      "confirm": "Confirmar",
+      "continue": "Continuar",
+      "copied": "¡Copiado!",
+      "copy": "Copiar",
+      "copyMessage": "Copiar mensaje",
+      "delete": "Eliminar",
+      "edit": "Editar",
+      "more": "Más acciones",
+      "remove": "Eliminar",
+      "rename": "Renombrar",
+      "saving": "Guardando...",
+      "send": "Envía",
+      "stop": "Detener",
+      "view": "Ver"
+    },
+    "agentPage": {
+      "invitePeople": "Invita a la gente",
+      "taglines": {
+        "anonymous": {
+          "buildSomething": "¿Listo para construir algo?",
+          "goodToSeeYou": "Me alegro de verte.",
+          "readyToRoll": "¿Listo para salir?",
+          "welcomeBack": "Bienvenido de nuevo.",
+          "whatAreWeWorkingOn": "¿En qué estamos trabajando?",
+          "whatsOnYourMind": "¿Qué tienes en mente?",
+          "whatsTheMove": "¿Cuál es el plan?"
+        },
+        "anotherWin": "¿Otra victoria hoy, {{userName}}?",
+        "coffeeReady": "El café está listo, {{userName}}.",
+        "enteredChat": "{{userName}} ha entrado en el chat.",
+        "goodToSeeYou": "Me alegro de verte, {{userName}}.",
+        "knewYouWouldCome": "Sabía que volverías, {{userName}}.",
+        "letsRoll": "{{agentName}} está listo, {{userName}}. Vamos.",
+        "makeTodayCount": "Aprovechemos el día de hoy, {{userName}}.",
+        "newIdeas": "¿Nuevas ideas hoy, {{userName}}?",
+        "readyToBuild": "¿Listo para construir, {{userName}}?",
+        "rightOnTime": "Justo a tiempo, {{userName}}.",
+        "savedYourSeat": "Te guardé un sitio, {{userName}}.",
+        "theUsual": "Lo de siempre, {{userName}}?",
+        "welcomeBack": "Qué bueno verte de nuevo, {{userName}}.",
+        "whatAreWeWorkingOn": "¿En qué estamos trabajando, {{userName}}?",
+        "whatsCooking": "¿Qué se está cocinando, {{userName}}?",
+        "whatsOnYourMind": "¿Qué tienes en mente, {{userName}}?",
+        "whatsTheMove": "¿Cuál es el plan, {{userName}}?"
+      },
+      "viewAgentProfile": "Ver perfil del agente"
+    },
+    "attachments": {
+      "addLink": "Añadir enlace",
+      "attach": "Adjuntar",
+      "file": "Archivo {{filename}}",
+      "fileTooLarge": "{{filename}} supera el límite de 1 GB",
+      "imageUnavailable": "[Imagen no disponible: {{filename}}]",
+      "importing": "Importando archivos adjuntos",
+      "invalidLink": "Introduce un enlace válido",
+      "linkPlaceholder": "https://example.com/image.png",
+      "loadingFile": "Cargando {{filename}}",
+      "previewFile": "Vista previa de {{filename}}",
+      "supportedTypes": "Imágenes, documentos, audio, vídeo y archivos",
+      "title": "Archivos adjuntos",
+      "unavailable": "Adjunto no disponible",
+      "upload": "Subir",
+      "uploadFailed": "No se pudo subir {{filename}}",
+      "uploadFailedRetry": "No se pudo subir {{filename}}. Inténtalo de nuevo.",
+      "uploadFromComputer": "Subir desde el ordenador",
+      "uploadFromLink": "Subir desde el enlace",
+      "uploadsFailed": "Algunos archivos adjuntos no se han subido. Inténtalo de nuevo."
+    },
+    "automations": {
+      "active": "Activo",
+      "automation": "Automatización",
+      "close": "Cerrar automatizaciones",
+      "cronExpression": "Expresión cron",
+      "cronWithTimezone": "{{expression}} ({{timezone}})",
+      "dailyAt": "Cada día a {{time}}",
+      "disabled": "Deshabilitado",
+      "displaysIn": "Se muestra en {{timezone}}",
+      "edit": "Editar automatización",
+      "editDescription": "Actualiza esta automatización del flujo de trabajo.",
+      "empty": "Todavía no hay automatizaciones.",
+      "event": "Evento",
+      "events": {
+        "githubDeploymentStatus": "Estado de despliegue de GitHub creado",
+        "githubIssueComment": "Comentario de una incidencia de GitHub creado",
+        "githubLabelApplied": "Etiqueta de GitHub aplicada",
+        "githubReviewSubmitted": "Revisión de pull request de GitHub enviada",
+        "githubWorkflowCompleted": "Flujo de trabajo de GitHub completado",
+        "githubWorkflowJobCompleted": "Tarea de un flujo de trabajo de GitHub completada",
+        "gmailLabelApplied": "Etiqueta de Gmail aplicada",
+        "gmailNewMessage": "Nuevo mensaje de Gmail",
+        "googleCalendarCancelled": "Evento de Google Calendar cancelado",
+        "googleCalendarCreated": "Evento de Google Calendar creado",
+        "googleCalendarUpdated": "Evento de Google Calendar actualizado",
+        "googleMeetTranscript": "Transcripción de Google Meet disponible",
+        "notionChildPage": "Nueva página secundaria de Notion",
+        "notionDatabaseItem": "Nuevo elemento de base de datos de Notion",
+        "notionPageUpdated": "Contenido de página de Notion actualizado",
+        "webhook": "Automatización de webhooks"
+      },
+      "every": "Cada",
+      "everyHour_one": "Cada {{count}} hora",
+      "everyHour_many": "Cada {{count}} horas",
+      "everyHour_other": "Cada {{count}} horas",
+      "everyMinute_one": "Cada {{count}} minutos",
+      "everyMinute_many": "Cada {{count}} minutos",
+      "everyMinute_other": "Cada {{count}} minutos",
+      "everySecond_one": "Cada {{count}} segundo",
+      "everySecond_many": "Cada {{count}} segundos",
+      "everySecond_other": "Cada {{count}} segundos",
+      "gmail": {
+        "body": "Cuerpo",
+        "cc": "CC",
+        "contains": "{{field}} contiene",
+        "containsAny": "{{field}} contiene alguna",
+        "doesNotContain": "{{field}} no contiene",
+        "from": "De",
+        "is": "Es",
+        "labelName": "Nombre de etiqueta",
+        "labelPlaceholder": "Soporte",
+        "subject": "Asunto",
+        "threadId": "ID de hilo",
+        "threadIdField": "Campo ID de hilo",
+        "threadIdOperator": "Operador de ID de hilo",
+        "threadIdValue": "Valor del ID de hilo",
+        "to": "Para"
+      },
+      "lastRun": "Última ejecución",
+      "match": "Coincidencia",
+      "matchSummary": {
+        "allInboundMessages": "Todos los mensajes entrantes",
+        "anyComment": "Cualquier comentario",
+        "anyDeploymentState": "Cualquier estado de despliegue",
+        "anyResult": "Cualquier resultado",
+        "anyReview": "Cualquier revisión",
+        "calendar": "Calendario {{value}}",
+        "configuredDatabase": "Base de datos configurada",
+        "configuredPage": "Página configurada",
+        "configuredParentPage": "Página principal configurada",
+        "contains": "{{field}} contiene {{value}}",
+        "containsAny": "{{field}} contiene alguno de {{values}}",
+        "database": "{{value}} de base de datos",
+        "doesNotContain": "{{field}} no contiene {{value}}",
+        "doesNotContainAny": "{{field}} no contiene ninguna de {{values}}",
+        "label": "Etiqueta {{value}}",
+        "meetingsYouOrganize": "Reuniones que organizas",
+        "page": "Página {{value}}",
+        "parentPage": "Página principal {{value}}",
+        "threadIdIs": "El ID del hilo es {{value}}"
+      },
+      "monthlyAt": "Cada mes, el día {{day}} a las {{time}}",
+      "nextRun": "Próxima ejecución",
+      "noRuns": "Aún no hay ejecuciones",
+      "noUpcomingRun": "No hay una próxima ejecución",
+      "onceAt": "Una vez, el {{date}} a las {{time}}",
+      "open": "Abrir automatizaciones",
+      "runAt": "Ejecutar a las",
+      "runNow": "Ejecutar ahora",
+      "runsIn": "Ejecuciones en {{timezone}}",
+      "save": "Guardar automatización",
+      "schedule": "Programación",
+      "starting": "Iniciando...",
+      "status": "Estado",
+      "title": "Automatizaciones",
+      "weekdayAt": "Todos los días laborables a {{time}}",
+      "weeklyAt": "Cada semana a {{time}}",
+      "weeklyOnAt": "Cada semana, el {{days}} a las {{time}}"
+    },
+    "billing": {
+      "addCreditsToContinue": "Añade créditos para seguir charlando con Zero.",
+      "askAdminCredits": "Pide a un administrador de espacio de trabajo que añada créditos para que puedas seguir hablando con Zero.",
+      "askAdminUpgrade": "Pide a un administrador de espacio de trabajo que actualice a Pro para poder seguir hablando con Zero.",
+      "buy": "Compra",
+      "checkingPermissions": "Comprobando permisos de facturación...",
+      "comparePlans": "Comparar planes",
+      "comparePlansDescription": "Compara planes para desbloquear funciones de espacio de trabajo de pago y créditos adicionales.",
+      "creditsAdded": "Tus créditos han sido añadidos. Puedes seguir chateando con Zero.",
+      "creditsAvailable": "Créditos disponibles",
+      "custom": "Personalizado",
+      "customAmountError": "Introduce entre $1 y $10,000",
+      "customDollarAmount": "Cantidad personalizada en dólares",
+      "outOfCredits": "Se te han acabado los créditos",
+      "redirecting": "Redirigiendo...",
+      "upgradeToContinue": "Actualiza a Pro para seguir charlando con Zero.",
+      "upgradeToPro": "Actualizar a Pro",
+      "upgradeToRun": "Mejorar a Pro para ejecutar Zero",
+      "upgradeWorkspace": "Mejora tu espacio de trabajo"
+    },
+    "composer": {
+      "agentSuggestions": "Agentes",
+      "configureModel": "Configurar modelo",
+      "createWorkflow": "Crear flujo de trabajo",
+      "message": "Mensaje",
+      "modelConfigureAction": "Configurar modelos",
+      "placeholder": "Pídeme que automatice flujos de trabajo, gestione tareas...",
+      "selectedModelUnavailable": "El modelo seleccionado no está disponible. Configúralo antes de enviar.",
+      "selectedModelUnavailableToast": "El modelo seleccionado no está disponible",
+      "selectModel": "Seleccionar modelo",
+      "threadSuggestions": "Conversaciones",
+      "visualAttachmentsUnsupported": "{{modelName}} no reconoce imágenes ni vídeos. Cambia a un modelo con capacidad visual para adjuntarlos.",
+      "workflows": {
+        "empty": "No hay flujos de trabajo coincidentes",
+        "loading": "Cargando flujos de trabajo...",
+        "title": "Flujos de trabajo",
+        "viewAll": "Ver todos los flujos de trabajo"
+      }
+    },
+    "computerUse": {
+      "authorization": "Autorización para el uso de ordenadores",
+      "authorizationDescription": "Selecciona un host de escritorio para las próximas ejecuciones de esta conversación.",
+      "checkingCompatibility": "Comprobación de compatibilidad",
+      "cloudBrowser": "Navegador en la nube",
+      "connectHost": "Conectar {{hostName}}",
+      "connectMyComputer": "Conectar mi ordenador",
+      "dialogDescription": "Así Zero puede funcionar en tu navegador y en aplicaciones, incluso en aquellos sin conector como LinkedIn o Reddit.",
+      "dialogTitle": "Permite que Zero use tu ordenador",
+      "disableCloudBrowser": "Desactivar el navegador de la nube",
+      "disconnectHost": "Desconectar {{hostName}}",
+      "downloadMacos": "Descargar para macOS",
+      "enableCloudBrowser": "Activar el navegador en la nube",
+      "hosts": "Hosts para el uso de ordenadores",
+      "macosRequirement": "Requiere un Mac Apple Silicon con macOS 14 o más reciente. No se soportan Macs Intel.",
+      "noOnlineComputers": "No hay ordenadores en línea",
+      "offline": "Sin conexión",
+      "unsupportedIntelMac": "Requiere un Mac Apple Silicon",
+      "yourComputer": "Tu ordenador"
+    },
+    "connectors": {
+      "add": "Añadir {{connectorName}}",
+      "addConnectors": "Añadir conectores",
+      "authorizationFailed": "{{connectorName}} está conectado, pero no se pudo autorizar para {{agentName}}",
+      "authorized": "{{connectorName}} está conectado y autorizado para {{agentName}}",
+      "available_one": "Conectores disponibles para conectar ({{count}})",
+      "available_many": "Conectores disponibles para conectar ({{count}})",
+      "available_other": "Conectores disponibles para conectar ({{count}})",
+      "configurePermissions": "Configurar permisos de {{connectorName}}",
+      "customAuthorizeDescription": "Revisa, conecta y autoriza este conector personalizado para el agente.",
+      "customConnectDescription": "Revisa y conecta este conector personalizado.",
+      "find": "Buscar conectores...",
+      "remove": "Elimina {{connectorName}}",
+      "title": "Conectores"
+    },
+    "documentTitle": "Chat",
+    "errors": {
+      "loadMessages": "No se pudieron cargar los mensajes",
+      "noModelProviderAction": "Configura uno en la configuración del espacio de trabajo",
+      "noModelProviderPrefix": "Aún no hay un proveedor de modelo configurado.",
+      "noModelProviderSuffix": "para empezar.",
+      "providerDeletedAction": "Inicia un nuevo hilo de chat",
+      "providerDeletedPrefix": "El proveedor de modelos utilizado en este hilo ha sido eliminado.",
+      "providerDeletedSuffix": "para continuar.",
+      "providerIncompatibleAction": "Empieza una nueva sesión",
+      "providerIncompatiblePrefix": "Esta sesión se inició con un modelo diferente y no se puede continuar con el actual.",
+      "runCancelled": "Se detuvo a mitad de la respuesta; puedes retomarla cuando quieras."
+    },
+    "feedback": {
+      "emailDraftDescription": "un borrador por correo electrónico (ID del borrador por correo: {{id}})",
+      "partHeading": "Comentarios sobre esta parte de tu respuesta:",
+      "partsHeading_one": "Comentarios sobre {{count}} parte de tu respuesta:",
+      "partsHeading_many": "Comentarios sobre {{count}} partes de tu respuesta:",
+      "partsHeading_other": "Comentarios sobre {{count}} partes de tu respuesta:",
+      "placeholder": "¿Qué debería cambiar en esto?",
+      "provide": "Enviar comentarios",
+      "remove": "Eliminar comentarios",
+      "sentEmailDescription": "un correo enviado (ID de correo: {{id}}{{sentIdSuffix}})",
+      "sentIdSuffix": ", ID enviado: {{sentId}}",
+      "sourcePartHeading": "Comentarios sobre esta parte de {{description}}:",
+      "sourcePartsHeading_one": "Comentarios sobre {{count}} parte de {{description}}:",
+      "sourcePartsHeading_many": "Comentarios sobre {{count}} partes de {{description}}:",
+      "sourcePartsHeading_other": "Comentarios sobre {{count}} partes de {{description}}:"
+    },
+    "mail": {
+      "bcc": "BCC",
+      "cc": "cc",
+      "closeDetails": "Cerrar detalles del correo",
+      "deleted": "Este borrador fue eliminado.",
+      "deletedEmail": "Correo electrónico eliminado: {{subject}}",
+      "details": "Detalles del correo electrónico",
+      "email": "Correo electrónico",
+      "followUp": {
+        "action": "Seguimiento",
+        "active": "Seguimiento de respuestas",
+        "activeDescription": "Las respuestas se rastrean y se reportarán en este chat.",
+        "idleDescription": "Rastrea las respuestas y recibe notificaciones en este chat.",
+        "paused": "Seguimiento pausado",
+        "pausedDescription": "El seguimiento de respuestas está actualmente pausado.",
+        "settingUp": "Configurando…",
+        "submitting": "Configurando…",
+        "submittingDescription": "Configurando el seguimiento de respuestas...",
+        "tracking": "Seguimiento de respuestas"
+      },
+      "loadingDetails": "Cargando detalles del correo electrónico",
+      "needReconnect": "Necesito reconectar",
+      "noMessage": "(Sin mensaje)",
+      "noRecipient": "Sin destinatario",
+      "noSubject": "(Sin asunto)",
+      "noSubjectPlain": "Sin asunto",
+      "openEmail": "Abrir correo {{status}}: {{subject}}",
+      "openInGmail": "Abrir en Gmail",
+      "recipientsLine": "para {{recipients}}",
+      "reconnectDescription": "Ya no tienes permiso para acceder a este correo. Vuelve a conectar Gmail para continuar.",
+      "reconnectGmail": "Reconectar Gmail",
+      "reconnecting": "Volviendo a conectar...",
+      "reconnectToAccess": "Reconectar Gmail para acceder al correo electrónico: {{subject}}",
+      "sentToast": "Correo electrónico enviado",
+      "status": {
+        "deleted": "Eliminado",
+        "draft": "Borrador",
+        "sent": "Enviado"
+      },
+      "toRecipients": "Para: {{recipients}}",
+      "unavailable": "Este correo electrónico ya no está disponible."
+    },
+    "messageDocument": {
+      "agent": "[Agente: {{name}}]",
+      "chatThread": "[Hilo de chat: {{title}}]",
+      "file": "[Archivo: {{filename}}]",
+      "template": "[Plantilla: {{title}}]"
+    },
+    "newChat": "Nuevo chat",
+    "origins": {
+      "feishu": "Feishu",
+      "openChat": "Abrir chat",
+      "openFeishuChat": "Abrir el chat original en Feishu",
+      "openMessage": "Abrir mensaje",
+      "openSlackMessage": "Abrir el mensaje original en Slack",
+      "slack": "Slack"
+    },
+    "permissions": {
+      "actionDescription": "{{action}} {{permissionName}}",
+      "agentNotFound": "Agente no encontrado",
+      "allow": "Permitir",
+      "alreadyAllowed": "Ya está permitido",
+      "alreadyDenied": "Ya denegado",
+      "checking": "Comprobando el estado de los permisos...",
+      "connectorTitle": "Permisos de {{connectorName}}",
+      "denied": "Permiso denegado",
+      "deny": "Denegar",
+      "duration": "Duración del permiso",
+      "expired": "Caducado",
+      "expiresInDays_one": "Caduca en {{count}} día",
+      "expiresInDays_many": "Caduca en {{count}} días",
+      "expiresInDays_other": "Caduca en {{count}} días",
+      "expiresInHours_one": "Caduca en {{count}} hora",
+      "expiresInHours_many": "Caduca en {{count}} horas",
+      "expiresInHours_other": "Caduca en {{count}} horas",
+      "loadFailed": "No se pudo cargar el estado de los permisos",
+      "unknown": "Permiso desconocido",
+      "updated": "Permisos actualizados",
+      "updateFailed": "No se pudieron actualizar los permisos"
+    },
+    "promptDocumentTitle": "Prompt",
+    "queue": {
+      "aboutAutomationEvent": "Acerca de este evento de automatización",
+      "aboutGoal": "Sobre este objetivo",
+      "aboutQueuedMessage": "Acerca de este mensaje en cola",
+      "activeGoal": "Objetivo activo",
+      "automationEvent": "Evento de automatización",
+      "automationEventDescription": "Espera detrás de los mensajes en cola y se ejecuta cuando termina la ejecución actual.",
+      "cancelGoal": "Cancelar objetivo",
+      "event_one": "{{count}} evento",
+      "event_many": "{{count}} eventos",
+      "event_other": "{{count}} eventos",
+      "goal": "Objetivo",
+      "goalDescription": "Se ejecuta después de que la cola se vacía y sigue funcionando hasta que la cancelas.",
+      "goalLoadFailed": "No se pudo cargar este objetivo",
+      "goalRetry": "Cierra el diálogo y ábrelo de nuevo para intentarlo de nuevo.",
+      "goalUnavailable": "Este objetivo ya no está disponible.",
+      "itemsWaiting": "{{items}} esperando",
+      "itemsWaitingTogether": "{{messages}} y {{events}} esperando",
+      "loadingGoal": "Cargando objetivo...",
+      "message_one": "{{count}} mensaje",
+      "message_many": "{{count}} mensajes",
+      "message_other": "{{count}} mensajes",
+      "openGoalDetails": "Abrir detalles del objetivo",
+      "pendingAutomationEvent": "Evento de automatización pendiente",
+      "queuedMessage": "Mensaje en cola",
+      "queuedMessageDescription": "Espera en la cola y se envía cuando termina la ejecución actual.",
+      "removeQueuedMessage": "Eliminar mensaje en cola",
+      "skipAutomationEvent": "Omitir evento de automatización"
+    },
+    "replaceDraft": {
+      "description": "Si continúas, se borrará el borrador actual del editor y se abrirá un prompt de flujo de trabajo.",
+      "title": "¿Reemplazar el borrador del editor?"
+    },
+    "run": {
+      "automatedRun": "Ejecución automatizada",
+      "collapseGroupedHistory": "Contraer el historial de ejecuciones agrupadas",
+      "collapseWorkHistory": "Contraer el historial de trabajo",
+      "creditUsage": "Consumo de créditos",
+      "done": {
+        "allDone": "Todo hecho — {{time}}",
+        "default": "Completado",
+        "delivered": "Entregado a {{time}}",
+        "doneAndDusted": "Hecho y listo — {{time}}",
+        "finished": "Terminado a {{time}}, a tu servicio",
+        "missionComplete": "Misión cumplida, {{time}}",
+        "signedOff": "Firmado a {{time}}",
+        "wrap": "Eso fue todo — {{time}}",
+        "wrappedUp": "Terminado en {{time}}"
+      },
+      "duration": {
+        "hour_one": "{{count}} hora",
+        "hour_many": "{{count}} horas",
+        "hour_other": "{{count}} horas",
+        "hoursShort_one": "{{count}}h",
+        "hoursShort_many": "{{count}}h",
+        "hoursShort_other": "{{count}}h",
+        "minute_one": "{{count}} min",
+        "minute_many": "{{count}} minutos",
+        "minute_other": "{{count}} minutos",
+        "minutesShort_one": "{{count}}m",
+        "minutesShort_many": "{{count}}m",
+        "minutesShort_other": "{{count}}m",
+        "secondsShort_one": "{{count}}s",
+        "secondsShort_many": "{{count}}s",
+        "secondsShort_other": "{{count}}s"
+      },
+      "durationFor": "{{duration}} para {{label}}",
+      "expandGroupedHistory": "Expandir el historial de ejecuciones agrupadas",
+      "expandWorkHistory": "Expandir el historial de trabajo",
+      "goalFor": "Objetivo para {{label}}",
+      "groupedRunsFor_one": "{{count}} ejecución desde {{source}}",
+      "groupedRunsFor_many": "{{count}} ejecuciones desde {{source}}",
+      "groupedRunsFor_other": "{{count}} ejecuciones desde {{source}}",
+      "justNow": "Justo ahora",
+      "keepGoing": "Sigue",
+      "keepGoingAt": "Sigue adelante · {{timestamp}}",
+      "queueEllipsis": "cola...",
+      "thinking": {
+        "assembling": "Ensamblando las piezas...",
+        "brewing": "Preparando una respuesta...",
+        "mapping": "Trazándolo...",
+        "onIt": "En ello...",
+        "piecingTogether": "Juntando las cosas...",
+        "shaping": "Moldeando la respuesta...",
+        "sketching": "Esbozando los detalles...",
+        "spinningUp": "Arrancando...",
+        "tuningIn": "Sintonizando...",
+        "wiring": "Conectándolos juntos..."
+      },
+      "viewActivityLogs": "Ver registros de actividad",
+      "viewLogs": "Ver registros de ejecución",
+      "waitingIn": "Esperando",
+      "worked": "Trabajó",
+      "workedFor": "Trabajó durante {{duration}}"
+    },
+    "shortcuts": {
+      "number": "Número"
+    },
+    "sidebar": {
+      "allChats": "Todas las conversaciones",
+      "chatsWith": "Conversaciones con {{agentName}}",
+      "chatThreads": "Conversaciones",
+      "delete": "Eliminar chat",
+      "deleteDescription": "Esto eliminará permanentemente este chat. Cualquier tarea que se esté ejecutando en este chat se detendrá inmediatamente. Esta acción no puede deshacerse.",
+      "deleteTitle": "¿Eliminar el chat?",
+      "draft": "Borrador",
+      "empty": "Empieza una conversación y aparecerá aquí",
+      "newChatWith": "Nuevo chat con {{agentName}}",
+      "noUnread": "No hay conversaciones sin leer",
+      "openChatMenu": "Abrir menú de chat",
+      "openListMenu": "Abrir menú de conversaciones",
+      "pin": "Fijar chat",
+      "pinned": "Fijado",
+      "rename": "Renombrar chat",
+      "renameDescription": "Introduce un nuevo nombre para este hilo de chat.",
+      "titlePlaceholder": "Título del chat",
+      "unpin": "Desfijar chat",
+      "unread": "No leído",
+      "unreadOnly": "Solo sin leer"
+    },
+    "templates": {
+      "categories": {
+        "illustration": "Ilustración",
+        "presentation": "Presentación",
+        "video": "Vídeo",
+        "website": "Sitio web",
+        "workflow": "Flujo de trabajo"
+      },
+      "messageTemplate": "Plantilla de mensaje {{title}}",
+      "previewTemplate": "Plantilla de vista previa {{title}}",
+      "previewVideo": "Plantilla de vídeo de vista previa {{title}}",
+      "previewWebsite": "Plantilla de página web de vista previa {{title}}",
+      "previewWorkflow": "Plantilla de flujo de trabajo de vista previa {{title}}",
+      "removeTemplate": "Eliminar la plantilla {{title}}",
+      "removeVideo": "Eliminar la plantilla de vídeo {{title}}",
+      "removeWebsite": "Eliminar la plantilla de sitio web {{title}}",
+      "removeWorkflow": "Eliminar la plantilla de flujo de trabajo {{title}}"
+    },
+    "thread": {
+      "ariaLabel": "Hilo de chat",
+      "changeIcon": "Cambiar icono",
+      "emoji": {
+        "done": "Completado",
+        "idea": "Idea",
+        "no": "No",
+        "question": "Pregunta",
+        "risk": "Riesgo",
+        "shipped": "Publicado",
+        "urgent": "Urgente",
+        "waiting": "Esperando",
+        "watching": "Observando"
+      },
+      "empty": "Envía un mensaje para iniciar la conversación",
+      "frequentlyUsed": "Usados con frecuencia",
+      "icon": "Icono del hilo de chat",
+      "loadingEarlier": "Cargando mensajes anteriores",
+      "noEmojiFound": "No se ha encontrado ningún emoji",
+      "openArtifacts": "Abrir artefactos",
+      "openBrowser": "Abrir navegador",
+      "openNamedAgent": "Abrir agente {{name}}",
+      "openNamedChat": "Abrir chat {{title}}",
+      "scrollToBottom": "Desplázate hasta abajo",
+      "searchEmoji": "Buscar emoji"
+    },
+    "threadSidebar": {
+      "resize": "Cambiar el tamaño de la barra lateral"
+    },
+    "toasts": {
+      "copied": "Copiado",
+      "deleted": "Chat eliminado"
+    },
+    "voice": {
+      "checkingLimit": "Comprobando el límite de entrada de voz",
+      "input": "Entrada de voz",
+      "inputLimitReached": "Límite de entrada de voz alcanzado. Actualiza a Pro o Team para límites más altos.",
+      "microphoneAccessDenied": "Se ha denegado el acceso al micrófono. Permite el acceso al micrófono e inténtalo de nuevo.",
+      "openingMicrophone": "Abriendo el micrófono...",
+      "starting": "Iniciando entrada de voz",
+      "stopRecording": "Detener la grabación",
+      "transcribing": "Transcribiendo",
+      "transcribingProgress": "Transcribiendo...",
+      "transcriptionFailed": "Falló la transcripción de voz. Inténtalo de nuevo."
+    },
+    "workflows": {
+      "named": "Flujo de trabajo {{title}}",
+      "open": "Abrir flujo de trabajo {{title}}"
+    }
+  },
+  "connectors": {
+    "access": {
+      "accessFor": "{{action}} el acceso de {{connector}} para {{agent}}",
+      "accessUpdated": "Acceso a {{connector}} actualizado",
+      "clearSearch": "Borrar búsqueda de agentes",
+      "description": "Elige qué agentes pueden usar este conector.",
+      "loading": "Cargando agentes...",
+      "managePermissions": "Gestionar permisos",
+      "managePermissionsFor": "Gestionar los permisos de {{connector}} para {{agent}}",
+      "noAgents": "No se encontraron agentes",
+      "noMatchingAgents": "No hay agentes que coincidan con \"{{search}}\"",
+      "permissionsUpdated": "Permisos actualizados",
+      "search": "Buscar agentes",
+      "title": "Gestionar el acceso a {{connector}}",
+      "unnamedAgent": "Sin nombre"
+    },
+    "actions": {
+      "apply": "Aplicar",
+      "authorize": "Autorizar",
+      "cancel": "Cancelar",
+      "close": "Cerrar",
+      "closeWindow": "Cerrar ventana",
+      "connect": "Conectar",
+      "connecting": "Conectando...",
+      "create": "Crear",
+      "creating": "Creando…",
+      "delete": "Eliminar",
+      "deleting": "Eliminando…",
+      "disconnect": "Desconectar",
+      "disconnecting": "Desconectando...",
+      "edit": "Editar",
+      "grant": "Conceder",
+      "reconnect": "Volver a conectar",
+      "rename": "Renombrar",
+      "revoke": "Revocar",
+      "save": "Guardar",
+      "saving": "Guardando...",
+      "savingEllipsis": "Guardando…",
+      "tryAgain": "Inténtalo de nuevo",
+      "uninstall": "Desinstalar",
+      "uninstalling": "Desinstalando..."
+    },
+    "callback": {
+      "connected": "{{connector}} conectado",
+      "connectedAs": "Conectado como {{username}}. Puedes cerrar esta ventana.",
+      "connectedDescription": "Tu cuenta ha sido conectada. Puedes cerrar esta ventana.",
+      "connecting": "Conectando {{connector}}...",
+      "connectingDescription": "Espera mientras terminamos de conectar tu cuenta.",
+      "customConnectorLabel": "Conector personalizado",
+      "documentTitle": "Conectar {{connector}}",
+      "errorDescription": "{{error}} Cierra esta ventana e inténtalo de nuevo.",
+      "errorFallback": "Ocurrió un error durante la conexión.",
+      "failed": "Fallo de conexión",
+      "failedTitle": "No se pudo conectar {{connector}}",
+      "finishing": "Finalizando la conexión segura",
+      "genericLabel": "Conector",
+      "githubLabel": "GitHub",
+      "invalidUrl": "URL de devolución de llamada de conector inválida.",
+      "success": "Conectado"
+    },
+    "card": {
+      "accessFor": "{{action}} el acceso a {{connector}}",
+      "authorized": "Autorizado",
+      "connectAria": "Conectar {{connector}}",
+      "connected": "Conectado",
+      "connecting": "Conectando…",
+      "connectionExpired": "Conexión expirada",
+      "connectToContinue": "Conecta esta cuenta para continuar",
+      "managePermissions": "Gestionar permisos",
+      "managePermissionsFor": "Gestionar los permisos de {{connector}}",
+      "optional": "Opcional",
+      "required": "Obligatorio",
+      "reviewPermissions": "Revisar permisos",
+      "updatePermissions": "Actualizar permisos"
+    },
+    "catalog": {
+      "access": {
+        "add": "Añadir acceso",
+        "manage": "Gestionar el acceso a {{connector}}",
+        "usedBy": "Utilizado por"
+      },
+      "categories": {
+        "ai": {
+          "label": "IA",
+          "menu": "IA"
+        },
+        "aiAgentApps": {
+          "label": "Plataformas de agentes y aplicaciones de IA",
+          "menu": "Plataformas de Agentes"
+        },
+        "aiGeneralModels": {
+          "label": "Modelos generales y razonamiento",
+          "menu": "Modelos generales"
+        },
+        "aiImageVideo": {
+          "label": "Generación de imágenes / vídeo",
+          "menu": "Imagen / Vídeo"
+        },
+        "aiMemoryTracingEval": {
+          "label": "Memoria / Rastreo / Evaluación",
+          "menu": "Memoria / Trazado"
+        },
+        "aiVoiceAudio": {
+          "label": "Voz / Audio",
+          "menu": "Voz / Audio"
+        },
+        "communicationCollaboration": {
+          "label": "Comunicación y colaboración",
+          "menu": "Comunicación"
+        },
+        "dataAutomationInfrastructure": {
+          "label": "Datos, automatización e infraestructura",
+          "menu": "Datos y automatización"
+        },
+        "docsFilesKnowledge": {
+          "label": "Documentos, archivos y conocimientos",
+          "menu": "Documentos"
+        },
+        "engineeringTeamExecution": {
+          "label": "Ingeniería y ejecución del equipo",
+          "menu": "Ingeniería"
+        },
+        "marketingContentGrowth": {
+          "label": "Marketing, Contenido y Crecimiento",
+          "menu": "Marketing"
+        },
+        "meetingsScheduling": {
+          "label": "Reuniones y programación",
+          "menu": "Reuniones"
+        },
+        "salesCrmBusinessOperations": {
+          "label": "Ventas, CRM y Operaciones Comerciales",
+          "menu": "Ventas y Negocios"
+        }
+      },
+      "categoriesAria": "Categorías de conectores",
+      "description": "Conecta servicios de terceros para que tus agentes los utilicen.",
+      "empty": {
+        "agent": "No hay conectores para este agente",
+        "connected": "Sin conectores conectados",
+        "matching": "{{message}} \"{{search}}\" que coincida",
+        "notConnected": "No quedan conectores para conectar",
+        "search": "No hay conectores que coincidan con \"{{search}}\""
+      },
+      "filters": {
+        "agents": "Agentes",
+        "all": "Todos",
+        "aria": "Conectores de filtro",
+        "connected": "Conectados",
+        "notConnected": "No conectado",
+        "status": "Estado"
+      },
+      "iconUnavailable": "Icono del conector no disponible",
+      "newConnector": "Nuevo conector",
+      "noConnectorsAlt": "Sin conectores",
+      "otherCategory": "Otro",
+      "search": "Buscar conectores",
+      "tabs": {
+        "builtin": "Integrados",
+        "custom": "Personalizado"
+      },
+      "title": "Conectores",
+      "unnamedAgent": "Sin nombre"
+    },
+    "connectDialog": {
+      "connectedAs": "Conectado como {{username}}",
+      "device": {
+        "checking": "Comprobando la aprobación...",
+        "connect": "Conectar {{connector}}",
+        "copyThenOpen": "Copia este código y luego abre la página de verificación para aprobar el acceso.",
+        "description": "Abre la página de verificación del proveedor y luego introduce este código de verificación para aprobar el acceso.",
+        "intro": "Conéctate para obtener un código de verificación y luego úsalo en la página de verificación del proveedor para aprobar el acceso.",
+        "openPage": "Abrir página de verificación",
+        "selectOption": "Seleccionar {{option}}",
+        "starting": "Iniciando...",
+        "startingConnection": "Iniciando conexión...",
+        "verificationCode": "Código de verificación",
+        "waiting": "Esperando aprobación. Mantén este diálogo abierto."
+      },
+      "errors": {
+        "authorizationWindow": "No se abrió la ventana de autorización",
+        "codeRequired": "Introduce el código desde {{connector}}.",
+        "denied": "Conexión denegada. Empieza de nuevo para intentarlo de nuevo.",
+        "expired": "Sesión de conexión expirada. Empieza de nuevo para intentarlo de nuevo.",
+        "failed": "Conexión fallida. Empieza de nuevo para intentarlo de nuevo.",
+        "verificationOpen": "No se pudo abrir la página de verificación. Inténtalo de nuevo."
+      },
+      "external": {
+        "code": "Código",
+        "complete": "Conexión completa",
+        "description": "Abre el inicio de sesión de {{connector}} y pega el código que muestra {{connector}}.",
+        "open": "Abrir inicio de sesión de {{connector}}",
+        "start": "Iniciar sesión en {{connector}}"
+      },
+      "noAuth": {
+        "enable": "Habilitar {{connector}}",
+        "enabling": "Habilitando..."
+      },
+      "noMethod": "No hay método de conexión disponible.",
+      "or": "o",
+      "progress": {
+        "connecting": "Conectando...",
+        "savingPermissions": "Guardando permisos..."
+      },
+      "unavailable": {
+        "description": "Este conector tiene métodos de conexión disponibles, pero ninguno de ellos puede configurarse aún desde este diálogo.",
+        "title": "Métodos de conexión no disponibles"
+      }
+    },
+    "custom": {
+      "agentUsage": {
+        "none": "No utilizado por ningún agente",
+        "usedBy": "Utilizado por {{agents}}",
+        "usedByOverflow_one": "Usado por {{agents}} +{{value}}",
+        "usedByOverflow_many": "Usado por {{agents}} +{{value}}",
+        "usedByOverflow_other": "Usado por {{agents}} +{{value}}"
+      },
+      "connect": {
+        "apiAuthentication": "Autenticación por API",
+        "apiDescription": "Introduce el secreto de la API emitido por el proveedor.",
+        "back": "Volver",
+        "connecting": "Conectando…",
+        "continue": "Continuar",
+        "continueToProvider": "Continúa con el proveedor para autorizar el acceso.",
+        "description": "Tu secreto se cifra en reposo y se inyecta en las solicitudes salientes por el cortafuegos. Nunca se expone al agente como una variable de entorno.",
+        "oauthDescription": "Autoriza el acceso con la app OAuth del conector.",
+        "save": "Guardar",
+        "saving": "Guardando…",
+        "secret": "Secreto",
+        "title": "Conectar {{connector}}"
+      },
+      "create": {
+        "addAuthentication": "Añadir autenticación",
+        "advancedApiPreserved": "Los campos avanzados de API e inyecciones se conservan cuando guardas.",
+        "advancedSettings": "Ajustes avanzados",
+        "apiAuthentication": "Autenticación por API",
+        "apiAuthenticationDescription": "Inyecta un secreto proporcionado por el usuario en cada solicitud correspondiente.",
+        "authorizationParameters": "Parámetros de autorización",
+        "authorizationParametersDescription": "Añade solo los parámetros que requiera tu proveedor.",
+        "authorizationUrl": "URL de autorización",
+        "clientId": "ID de cliente",
+        "clientSecret": "Secreto del cliente",
+        "displayName": "Nombre de visualización",
+        "headerName": "Nombre de la cabecera",
+        "headerTemplate": "Plantilla de cabecera",
+        "headerTemplateHint": "(debe contener {{placeholder}})",
+        "httpBasicAuthentication": "Autenticación básica HTTP",
+        "keepClientSecret": "Deja el secreto del cliente en blanco para conservar el valor almacenado.",
+        "keepClientSecretPlaceholder": "Deja en blanco para conservar el valor actual",
+        "newClientSecret": "Nuevo secreto de cliente",
+        "none": "Ninguno",
+        "oauthChangesDisconnect": "Cambiar la configuración de OAuth o las credenciales del cliente desconecta las conexiones OAuth existentes.",
+        "oauthDescription": "Configura una app OAuth para que los miembros la autoricen.",
+        "optional": "(opcional)",
+        "parameters": {
+          "accessType": "Tipo de acceso",
+          "audience": "Audiencia",
+          "prompt": "Prompt",
+          "resource": "Recurso"
+        },
+        "prefixes": "Prefijos",
+        "prefixesHint": "(uno por línea, solo HTTPS)",
+        "redirectCopy": "Copiar URL de redirección",
+        "redirectHint": "(Registra esta URL en la aplicación OAuth del proveedor.)",
+        "redirectUrl": "URL de redirección",
+        "removeApiAuthentication": "Eliminar la autenticación por API",
+        "removeOauth": "Eliminar OAuth 2.0",
+        "scopes": "Alcances",
+        "scopesHint": "(uno por línea)",
+        "secretInRequestBody": "Secreto del cliente en el cuerpo de la solicitud",
+        "title": "Nuevo conector personalizado",
+        "tokenEndpointAuthentication": "Autenticación de endpoint de token",
+        "tokenUrl": "Token URL"
+      },
+      "delete": {
+        "description": "Esto elimina el conector y el secreto almacenado de cada miembro para él. Los agentes autorizados para este conector perderán el acceso inmediatamente. Esto no se puede deshacer.",
+        "title": "¿Borrar {{connector}}?"
+      },
+      "edit": {
+        "title": "Editar conector personalizado"
+      },
+      "emptyAdmin": "Todavía no hay conectores personalizados. Crea uno para registrar una API para que cada miembro la use.",
+      "emptyMember": "Tu organización aún no ha registrado ningún conector personalizado.",
+      "moreOptions": "Más opciones",
+      "rename": {
+        "displayName": "Nombre de visualización",
+        "title": "Renombrar conector personalizado"
+      },
+      "statusConnected": "Conectado",
+      "toasts": {
+        "connected": "Conectado",
+        "created": "Se ha creado \"{{connector}}\"",
+        "deleted": "Conector personalizado eliminado",
+        "disconnected": "Desconectado",
+        "renamed": "Se ha cambiado el nombre a \"{{connector}}\"",
+        "updated": "Se ha actualizado \"{{connector}}\""
+      },
+      "updateConfirm": {
+        "action": "Guardar y desconectar",
+        "description": "Estos cambios en OAuth desconectarán a todos los miembros que estén conectados con OAuth. Tendrán que volver a conectar este conector personalizado.",
+        "title": "¿Desconectar conexiones OAuth existentes?"
+      }
+    },
+    "customProposal": {
+      "configure": "Configurar {{connector}}",
+      "descriptionAgent": "Al guardar, se conectarán tus valores y se autorizará a {{agent}}.",
+      "descriptionUser": "Al guardar, se conectará este conector personalizado a tu cuenta.",
+      "documentTitle": "Configurar conector personalizado",
+      "invalid": "Este enlace de propuesta de conector personalizado es inválido o está caducado.",
+      "requestScope": "Alcance de la solicitud",
+      "returnToChat": "Vuelve al chat y responde ACK para que el agente pueda verificar el conector.",
+      "saved": "Guardado",
+      "savedToast": "{{connector}} guardado",
+      "targetFallback": "este agente",
+      "update": "Actualizar {{connector}}"
+    },
+    "directed": {
+      "authorizeAgent": "Autoriza {{agent}}",
+      "authorized": "{{connector}} autorizado",
+      "authorizeDocumentTitle": "Autoriza {{connector}}",
+      "connectDocumentTitle": "Conectar {{connector}}",
+      "connected": "{{connector}} conectado",
+      "needsConnector": "{{agent}} necesita {{connector}} para seguir adelante",
+      "reconnecting": "Reconectar..."
+    },
+    "expiration": {
+      "inDays_one": "Caduca en {{count}} día",
+      "inDays_many": "Caduca en {{count}} días",
+      "inDays_other": "Caduca en {{count}} días",
+      "inHours_one": "Caduca en {{count}} hora",
+      "inHours_many": "Caduca en {{count}} horas",
+      "inHours_other": "Caduca en {{count}} horas",
+      "lessThanHour": "Caduca en menos de 1 hora"
+    },
+    "permissions": {
+      "actions": {
+        "allow": "Permitir",
+        "deny": "Denegar",
+        "mixed": "Mixta"
+      },
+      "allowDuration": {
+        "always": "Permitir siempre",
+        "oneHour": "Permite 1 hora",
+        "sevenDays": "Permitir 7d",
+        "twentyFourHours": "Permite 24 horas"
+      },
+      "allowOptions": "{{permission}} opciones de permiso",
+      "always": "Siempre",
+      "clearSearch": "Búsqueda de permisos clara",
+      "descriptionAgent": "Configura qué acciones puede realizar este agente a través de este conector.",
+      "descriptionWorkflow": "Configura qué acciones puede realizar este flujo de trabajo a través de este conector.",
+      "find": "Buscar permisos",
+      "findPlaceholder": "Busca permisos...",
+      "forTarget": "por {{target}}",
+      "loadError": "No se han cargado los metadatos de permisos",
+      "loading": "Cargando permisos...",
+      "metadataMissing": "No se han encontrado metadatos de permisos para {{connector}}",
+      "noResults": "No hay resultados para \"{{search}}\"",
+      "otherEndpoints": "Otros puntos finales",
+      "otherEndpointsDescription": "Los endpoints de la API no coinciden con ningún permiso anterior",
+      "permissions": "Permisos",
+      "restore": "Restauración",
+      "scopeReview": {
+        "added": "Nuevos permisos",
+        "description": "Los permisos requeridos para este conector han cambiado. Por favor, revisa y vuelve a conectar para aplicar la actualización.",
+        "failed": "No se han cargado los cambios de ámbito.",
+        "loading": "Cargando cambios de permisos...",
+        "removed": "Permisos eliminados",
+        "title": "Actualización de permisos de {{connector}}"
+      },
+      "selectAll": "Seleccionar todo",
+      "showMore_one": "Mostrar más ({{count}})",
+      "showMore_many": "Mostrar más ({{count}})",
+      "showMore_other": "Mostrar más ({{count}})",
+      "title": "{{connector}} permisos"
+    },
+    "providerConnect": {
+      "agentphone": {
+        "back": "Volviendo a {{brandName}}",
+        "connectDescription": "Vincula este número de teléfono a tu cuenta de {{brandName}} para poder interactuar con Zero a través de mensajes de texto.",
+        "connectTitle": "Número de teléfono de conexión",
+        "documentTitle": "Conectar mensajes",
+        "errorFallback": "No pudimos conectar este número de teléfono. Inténtalo de nuevo desde tus mensajes de texto.",
+        "incompleteDescription": "Abre un enlace nuevo /connect desde tus mensajes de texto.",
+        "incompleteTitle": "El enlace de conexión está incompleto",
+        "invalidSignature": "La firma en este enlace no es válida.",
+        "invalidTimestamp": "La marca de tiempo de este enlace no es válida.",
+        "invalidTitle": "El enlace de conexión es inválido",
+        "risk": "Las respuestas SMS y MMS pueden no entregarse de forma fiable. Para una experiencia fiable, utiliza iMessage con este número de AgentPhone.",
+        "successDescription": "{{phone}} está conectado. Envía un mensaje de texto para empezar a chatear con Zero.",
+        "successTitle": "Número de teléfono conectado"
+      },
+      "common": {
+        "backToSettings": "Volver a los ajustes",
+        "checkingTitle": "Estado de la cuenta corriente...",
+        "connectionFailed": "Fallo de conexión",
+        "invalidLink": "Enlace inválido",
+        "verifying": "Espera mientras verificamos tu conexión."
+      },
+      "feishu": {
+        "back": "Volver a los ajustes de Feishu",
+        "checkingTitle": "Comprobando el estado de la cuenta...",
+        "connectDescription": "Vincula tu cuenta de {{brandName}} a este bot de Feishu para que puedas trabajar directamente con tu agente desde Feishu.",
+        "connectTitle": "Conéctate con Feishu",
+        "errorFallback": "No pudimos conectar Feishu. Abre un enlace de conexión nuevo e inténtalo de nuevo.",
+        "invalidDescription": "Abre un enlace de conexión nuevo desde Feishu e inténtalo de nuevo.",
+        "open": "Abrir Feishu",
+        "successDescription": "Estás conectado. Envía un mensaje en Feishu para empezar a chatear.",
+        "successDescriptionNamed": "Estás conectado con {{bot}}. Envía un mensaje en Feishu para empezar a chatear.",
+        "successTitle": "¡Conectado a Feishu!"
+      },
+      "github": {
+        "accountFallback": "esta cuenta de GitHub",
+        "alreadyDescription": "Ya tienes conexión como {{account}}. Menciona a tu agente en incidencias o pull requests de GitHub para empezar a chatear.",
+        "alreadyTitle": "Ya está conectado a GitHub",
+        "back": "Volver a los flujos de trabajo",
+        "checkingConnectionDescription": "Espera mientras comprobamos tu conexión con GitHub.",
+        "checkingConnectionTitle": "Comprobando conexión...",
+        "checkingSession": "Espera mientras verificamos tu sesión de {{brandName}}.",
+        "connectDescription": "Vincula tu cuenta de {{brandName}} con {{account}} para ejecutar tus agentes desde menciones en incidencias y pull requests de GitHub.",
+        "connectTitle": "Conéctate con GitHub",
+        "errorFallback": "No pudimos conectar GitHub. Inténtalo de nuevo desde GitHub.",
+        "invalidInstallation": "La instalación de GitHub de este enlace no es válida.",
+        "invalidSignature": "La firma en este enlace no es válida.",
+        "invalidTimestamp": "La marca de tiempo de este enlace no es válida.",
+        "invalidTitle": "El enlace de conexión es inválido",
+        "invalidUser": "El usuario de GitHub de este enlace no es válido.",
+        "invalidUsername": "El nombre de usuario de GitHub de este enlace no es válido.",
+        "linkIncomplete": "Abre un enlace nuevo de GitHub y vuelve a intentarlo.",
+        "linkIncompleteTitle": "El enlace de conexión está incompleto",
+        "notInstalledDescription": "Pide a un administrador de la organización que instale GitHub antes de conectar tu cuenta.",
+        "notInstalledTitle": "GitHub no está instalado",
+        "refresh": "Actualiza esta página e inténtalo de nuevo.",
+        "signInButton": "Inicia sesión en {{brandName}}",
+        "signInCheckFailed": "No se pudo comprobar el inicio de sesión",
+        "signInDescription": "Usa tu cuenta de {{brandName}} antes de conectar este usuario de GitHub.",
+        "signInTitle": "Iniciar sesión para continuar",
+        "successDescription": "Tienes conexión como {{account}}. Menciona a tu agente en incidencias o pull requests de GitHub para empezar a chatear.",
+        "successTitle": "¡Conectado a GitHub!",
+        "wrongOrganizationDescription": "Tu organización activa no coincide con esta instalación de GitHub. Cambia a la organización correcta y vuelve a abrir el enlace.",
+        "wrongOrganizationTitle": "Cambiar de organización"
+      },
+      "slack": {
+        "connectDescription": "Vincula tu cuenta a este espacio de trabajo de Slack para interactuar directamente con tu agente desde Slack.",
+        "connectTitle": "Conéctate con Slack",
+        "invalidDescription": "Esta página debe abrirse desde un enlace de conexión de Slack.",
+        "open": "Abrir Slack",
+        "successDescription": "Menciona a @Zero en cualquier canal o envía un mensaje directo para empezar a chatear.",
+        "successDescriptionWorkspace": "Tienes conexión con {{workspace}}. Menciona a @Zero en cualquier canal o envía un mensaje directo para empezar a chatear.",
+        "successTitle": "¡Conectado a Slack!"
+      },
+      "teams": {
+        "connectDescription": "Vincula tu cuenta de Teams para interactuar directamente con tu agente desde Microsoft Teams.",
+        "connectDescriptionNamed": "{{displayName}}, vincula tu cuenta de Teams para interactuar directamente con tu agente desde Microsoft Teams.",
+        "connectTitle": "Conecta Microsoft Teams",
+        "invalidDescription": "Esta página debe abrirse desde un enlace de conexión de Microsoft Teams.",
+        "open": "Abrir Teams",
+        "providerName": "Microsoft Teams",
+        "successDescription": "Tienes conexión con {{team}}. Menciona a @Zero en Teams para empezar a chatear.",
+        "successTitle": "Conectado a Microsoft Teams"
+      },
+      "telegram": {
+        "alreadyDescription": "Ya estás conectado. Envía un mensaje en Telegram para empezar a chatear.",
+        "alreadyDescriptionNamed": "Ya estás conectado con {{bot}}. Envía un mensaje en Telegram para empezar a hablar.",
+        "alreadyTitle": "Ya está conectado a Telegram",
+        "back": "Volver a los ajustes de Telegram",
+        "botFallback": "Este bot",
+        "botFatherHandle": "@BotFather",
+        "checkingConnectionDescription": "Espera mientras comprobamos tu conexión con Telegram.",
+        "checkingConnectionTitle": "Comprobando conexión...",
+        "checkingDomain": "Comprobando el estado del dominio...",
+        "checkingSession": "Espera mientras verificamos tu sesión de {{brandName}}.",
+        "connectDescription": "Vincula tu cuenta a este bot de Telegram para que puedas interactuar directamente con tu agente desde Telegram.",
+        "connectTitle": "Conéctate con Telegram",
+        "continue": "Continúa con Telegram",
+        "domainDescription": "El inicio de sesión web de Telegram no está habilitado para {{bot}}.",
+        "domainIn": "En",
+        "domainInstructionsAfter": ", elige el bot, luego establece el dominio a:",
+        "domainKeepOpen": "Mantén esta página abierta después de guardar el dominio. También puedes conectarte desde Telegram con /connect.",
+        "domainSend": ", enviar",
+        "domainTitle": "Configurar el dominio de inicio de sesión de Telegram",
+        "errorFallback": "No pudimos conectar Telegram. Inténtalo de nuevo desde Telegram.",
+        "invalidSignature": "La firma en este enlace no es válida.",
+        "invalidTimestamp": "La marca de tiempo de este enlace no es válida.",
+        "invalidTitle": "El enlace de conexión es inválido",
+        "invalidUser": "El usuario de Telegram de este enlace no es válido.",
+        "invalidUsername": "El nombre de usuario de Telegram de este enlace no es válido.",
+        "linkIncomplete": "Abre un enlace /connect nuevo desde Telegram e inténtalo de nuevo.",
+        "linkIncompleteTitle": "El enlace de conexión está incompleto",
+        "open": "Abrir Telegram",
+        "openBotFather": "Abrir BotFather",
+        "refresh": "Actualiza esta página e inténtalo de nuevo.",
+        "setDomainCommand": "/setdomain",
+        "signInButton": "Inicia sesión en {{brandName}}",
+        "signInCheckFailed": "No se pudo comprobar el inicio de sesión",
+        "signInDescription": "Usa tu cuenta de {{brandName}} antes de conectar este usuario de Telegram.",
+        "signInTitle": "Iniciar sesión para continuar",
+        "successDescription": "Estás conectado con {{bot}}. Envía un mensaje en Telegram para empezar a chatear.",
+        "successTitle": "¡Conectado a Telegram!"
+      }
+    },
+    "providerSettings": {
+      "agentphone": {
+        "authorizedSender": "Remitente autorizado",
+        "connectAria": "Conecta teléfono",
+        "connectDescription": "Introduce tu número de teléfono. Enviaremos un enlace de verificación por mensaje que conecte este espacio de trabajo.",
+        "connectTitle": "Conecta teléfono",
+        "copyAria": "Copiar {{phone}}",
+        "copyError": "No se pudo copiar el número de teléfono",
+        "copySuccess": "Número de teléfono copiado",
+        "description": "Acceso por mensajes de texto a Zero",
+        "destination": "iMessage o SMS a",
+        "normalized": "Enviaremos mensajes {{phone}}.",
+        "options": "Opciones de teléfono",
+        "phoneLabel": "Teléfono",
+        "phoneNumber": "Número de teléfono",
+        "risk": "Las respuestas SMS y MMS pueden no entregarse de forma fiable. Para una experiencia fiable, utiliza iMessage con este número de AgentPhone.",
+        "sending": "Enviando...",
+        "sendVerification": "Enviar verificación",
+        "verificationSent": "Mensaje de verificación enviado a {{phone}}. Abre el enlace en ese mensaje para terminar de conectar."
+      },
+      "catalogDiagnostics": {
+        "fields": {
+          "activated": "Activado",
+          "activeCatalogDigest": "Resumen activo del catálogo",
+          "activeVersion": "Versión activa",
+          "evaluated": "Evaluado",
+          "evaluation": "Evaluación",
+          "executableCapabilityDigest": "Resumen de capacidades ejecutables",
+          "failureCode": "Código de fallo",
+          "filteredAuthMethods": "Métodos de autenticación filtrados",
+          "lastAttempt": "Último intento",
+          "lastAttemptAt": "Último intento",
+          "lastSuccess": "Último éxito",
+          "missingVersions": "Versiones perdidas",
+          "rejectedCatalogDigest": "Resumen de catálogo rechazado",
+          "rejectedVersion": "Versión rechazada",
+          "rejectingBackend": "Rechazando el backend",
+          "rejectionCache": "Caché de rechazo",
+          "rejectionFailure": "Fallo de rechazo",
+          "syncState": "Estado de sincronización",
+          "unownedSecrets": "Secretos sin dueño",
+          "unownedVariables": "Variables no propiedad",
+          "unresolvedBridgeCredentials": "Credenciales de puente sin resolver"
+        },
+        "loading": "Cargando",
+        "none": "Ninguno",
+        "notReused": "No reutilizado",
+        "reused": "Reutilizado",
+        "sections": {
+          "compatibility": "Compatibilidad",
+          "credentialStorage": "Almacenamiento de credenciales",
+          "rejectedCandidate": "Candidato rechazado"
+        },
+        "title": "Catálogo de conectores",
+        "unavailable": "No disponible",
+        "values": {
+          "accepted": "Aceptado",
+          "current": "Actual",
+          "digestMismatch": "Desajuste de digest",
+          "invalidArtifact": "Artefacto inválido",
+          "invalidCompression": "Compresión inválida",
+          "invalidJson": "JSON inválido",
+          "invalidPointer": "Puntero inválido",
+          "invalidReference": "Referencia inválida",
+          "missingAccessProvider": "Proveedor de acceso ausente",
+          "missingGrantProvider": "Proveedor de concesión ausente",
+          "missingPlatformConfiguration": "Configuración de plataforma ausente",
+          "missingRevokeProvider": "Proveedor de revocación faltante",
+          "neverSynced": "Nunca sincronizado",
+          "objectTooLarge": "Objeto demasiado grande",
+          "providerContractMismatch": "Desajuste contractual con el proveedor",
+          "publicLeakage": "Filtraciones públicas",
+          "rejected": "Rechazado",
+          "relationshipMismatch": "Desajuste en la relación",
+          "sourceUnavailable": "Fuente no disponible",
+          "stale": "Obsoleto",
+          "unchanged": "Sin cambios",
+          "unsupportedSchema": "Esquema no soportado"
+        }
+      },
+      "errors": {
+        "agentphonePhone": "Introduce un número de teléfono con código de país, como +1 555 555 1212.",
+        "githubAuthorizationWindow": "No se abrió la ventana de autorización",
+        "telegramDomain": "El dominio aún no es visible para Telegram. Comprueba BotFather y vuelve a intentarlo.",
+        "telegramPrivacy": "El modo de privacidad sigue activado. Desactívalo en BotFather y vuelve a intentarlo."
+      },
+      "feishu": {
+        "addBot": "Añadir bot",
+        "addDialogDescription": "Crea una aplicación personalizada para empresas, activa su bot y completa estos pasos en la consola de desarrolladores Feishu.",
+        "addDialogTitle": "Añadir un bot de Feishu",
+        "agentDescription": "Elige el agente que debe gestionar los mensajes enviados a este bot.",
+        "backToIntegrations": "Volver a las integraciones",
+        "botFallback": "Bot de Feishu",
+        "botIconAlt": "Icono del bot {{bot}}",
+        "bots": "Bots de Feishu",
+        "callbackStatusVerified": "Verificación de la llamada",
+        "callbackStatusWaiting": "Esperando la llamada de vuelta",
+        "configured": "Configurado",
+        "copied": "{{label}} copiado",
+        "copy": "Copiar",
+        "create": {
+          "descriptionAfter": ", crea una aplicación personalizada empresarial llamada {{brandName}}, sube el icono de {{brandName}} y luego añade la capacidad de Bot.",
+          "descriptionBefore": "En el",
+          "downloadIcon": "Descarga el icono de {{brandName}}",
+          "iconAlt": "Icono de la aplicación {{brandName}}",
+          "iconHint": ", o usa cualquier icono que prefieras.",
+          "iconTitle": "Icono de la aplicación {{brandName}}",
+          "imageAlt": "Formulario de creación de aplicaciones de Feishu con el nombre, el icono y el botón Crear resaltados",
+          "title": "Crea una aplicación personalizada para empresas"
+        },
+        "credentials": {
+          "appId": "ID de la aplicación",
+          "appSecret": "App Secret",
+          "description": "Copia el ID de la app y el secreto de la app de Credenciales e Información Básica.",
+          "imageAlt": "Feishu resultado de creación de la app que muestra dónde encontrar el ID de la aplicación y el Secreto de la App",
+          "title": "Añadir las credenciales de la app"
+        },
+        "defaultAgent": "Agente por defecto",
+        "defaultAgentAria": "Agente predeterminado para {{appId}}",
+        "developerConsole": "Consola para desarrolladores de Feishu",
+        "dialogAdminRequired": "Un administrador de la organización debe configurar la aplicación. Puedes conectar tu propia cuenta desde la lista de bots de Feishu una vez que la configuración esté completa.",
+        "documentTitle": "Feishu",
+        "emptyAdmin": "Añade una app personalizada para dirigir los mensajes de Feishu a un agente.",
+        "emptyMember": "Pide a un administrador de la organización que añada un bot de Feishu.",
+        "emptyTitle": "Todavía no hay bots de Feishu",
+        "events": {
+          "callbackLabel": "URL de devolución de llamada",
+          "continue": "Continúa después de que Feishu verifique la URL de devolución de llamada y te suscribas al evento de mensajes.",
+          "description": "Abre Configuración de eventos. En Modo de suscripción, selecciona \"Enviar notificaciones al servidor del desarrollador\". Después abre Configuración de devolución de llamada y pega la URL. Cuando Feishu la verifique, añade el evento \"Recibir mensaje v1\".",
+          "requestAlt": "Pantalla de configuración de eventos de Feishu con el campo URL de solicitud resaltado",
+          "requestLabel": "Añadir la URL de solicitud de devolución de llamada",
+          "subscriptionAlt": "Pantalla de configuración de eventos de Feishu con el control del modo de suscripción resaltado",
+          "subscriptionLabel": "Selecciona el modo de suscripción al evento",
+          "title": "Configurar la entrega de eventos"
+        },
+        "faq": {
+          "approvalAnswer": "Si la disponibilidad está configurada como Todos los miembros, un administrador Feishu debe aprobar la liberación. Feishu envía la solicitud de aprobación a un administrador en un mensaje directo, y la aplicación permanece pendiente hasta que un administrador complete la revisión.",
+          "approvalQuestion": "¿Por qué está la publicación de la app esperando aprobación?",
+          "challengeAnswer": "Esto suele significar que la clave de cifrado o el token de verificación guardados durante el paso Tokens son incorrectos. Vuelve a ese paso, introduce ambos valores de Configuración de eventos → Estrategia de cifrado, guárdalos y vuelve a probar la URL de solicitud.",
+          "challengeQuestion": "¿Por qué Feishu muestra \"El código de desafío no recibió respuesta\"?",
+          "title": "Preguntas frecuentes sobre la configuración"
+        },
+        "guide": {
+          "next": "Mostrar la siguiente imagen de la guía de Feishu",
+          "previous": "Mostrar imagen de la guía de Feishu anterior",
+          "show": "Mostrar la imagen {{number}} de la guía de Feishu"
+        },
+        "loadError": "No se pudo cargar la configuración de Feishu.",
+        "manage": "Gestionar",
+        "manageDialogTitle": "Gestionar bot de Feishu",
+        "moreOptions": "Más opciones para {{bot}}",
+        "pageDescription": "Gestiona el enrutamiento de bots para este espacio de trabajo",
+        "publish": {
+          "allMembersAlt": "Ajustes de disponibilidad de Feishu con la opción Todos los miembros seleccionada",
+          "allMembersLabel": "Permitir que todos los miembros usen la aplicación",
+          "createVersionAlt": "Página de gestión de versiones de Feishu con el botón Crear una versión resaltado",
+          "createVersionLabel": "Crear una versión para la app",
+          "description": "Crea y publica una versión de la app, luego edita la configuración de disponibilidad y selecciona Todos los miembros. La app solo puede ser utilizada por otros miembros de tu organización después de que les concedas acceso.",
+          "editAvailabilityAlt": "Página de detalles de la versión de Feishu con la opción de disponibilidad resaltada",
+          "editAvailabilityLabel": "Editar la configuración de disponibilidad",
+          "title": "Publica la app"
+        },
+        "redirect": {
+          "descriptionAfter": ", abre Configuración de Desarrollo → Configuración de Seguridad. Añade la URL de abajo bajo URLs de Redirección para que los miembros del espacio de trabajo puedan conectar su cuenta de Feishu a {{brandName}}.",
+          "descriptionBefore": "En el",
+          "imageAlt": "Página de configuración de seguridad de Feishu que muestra dónde añadir una URL de redirección OAuth",
+          "label": "URL de redirección OAuth",
+          "title": "Configurar la URL de redirección OAuth"
+        },
+        "reviewGuide": "Guía para la revisión",
+        "reviewGuideDescription": "Revisa los pasos de configuración completados para este bot de Feishu.",
+        "reviewGuideTitle": "Guía de revisión de Feishu",
+        "routeDescription": "Dirige los mensajes de Feishu a los agentes",
+        "selectAgent": "Selecciona un agente",
+        "setupIncomplete": "Configuración incompleta",
+        "steps": {
+          "back": "Volver",
+          "checking": "Comprobando...",
+          "close": "Cerrar",
+          "create": "Crear",
+          "credentials": "Credenciales",
+          "done": "Completado",
+          "events": "Eventos",
+          "next": "Siguiente",
+          "publish": "Publicar",
+          "redirect": "Redirección",
+          "tokens": "Tokens",
+          "verify": "Verificar y continuar",
+          "verifying": "Verificando...",
+          "waiting": "Esperando la llamada de vuelta"
+        },
+        "tokens": {
+          "descriptionAfter": ", selecciona la aplicación que acabas de crear y abre su página de configuración. Ve a Estrategia de configuración → Cifrado de eventos y copia la clave de cifrado y el token de verificación.",
+          "descriptionBefore": "Abre el",
+          "encryptKey": "Clave de cifrado",
+          "imageAlt": "Pantalla de estrategia de cifrado de Feishu que muestra la clave de cifrado y el token de verificación",
+          "title": "Añadir los tokens de verificación de eventos",
+          "verificationToken": "Token de verificación"
+        },
+        "uninstallDescription": "Esto desinstala {{bot}} del espacio de trabajo y desconecta todas las cuentas {{brandName}} que lo usan. Esta acción no puede deshacerse.",
+        "uninstallTargetFallback": "Este bot",
+        "uninstallTitle": "¿Desinstalar el bot de Feishu?"
+      },
+      "strapi": {
+        "actions": {
+          "cancel": "Cancelar",
+          "checkTest": "Prueba de comprobación",
+          "copy": "Copiar",
+          "create": "Crear integración",
+          "remove": "Eliminar",
+          "revealAuthorization": "Mostrar cabecera de autorización"
+        },
+        "addDescription": "Una integración puede servir para múltiples automatizaciones de flujo de trabajo.",
+        "addTitle": "Añadir instancia de Strapi",
+        "adminRequired": "Pide a un administrador de la organización que añada o actualice integraciones con Strapi.",
+        "authorizationHeader": "Cabecera de autorización",
+        "copied": "{{label}} copiado",
+        "description": "Deja Zero reaccionar a las entradas publicadas de Strapi y automatizar el trabajo posterior.",
+        "documentTitle": "Strapi",
+        "empty": "Todavía no hay instancias de Strapi conectadas.",
+        "form": {
+          "name": "Nombre",
+          "namePlaceholder": "CMS de la empresa",
+          "url": "URL de Strapi"
+        },
+        "instructions": "En Strapi, abre Configuración → Webhooks, añade esta URL y el encabezado de Autorización, selecciona entry.publish y luego haz clic en Trigger para enviar un webhook de prueba de Strapi.",
+        "lastPublish": "Última publicación: {{date}}",
+        "lastTest": "Última prueba: {{date}}",
+        "notReceived": "No recibido",
+        "removeDescription": "Elimina primero sus automatizaciones de flujo de trabajo. Las peticiones de webhook de Strapi a esta URL dejarán de funcionar.",
+        "removeTitle": "¿Eliminar la integración con Strapi?",
+        "tested": "Webhook probado",
+        "title": "Strapi",
+        "toasts": {
+          "created": "Integración de Strapi creada",
+          "noTestReceived": "Aún no se ha recibido ningún webhook de prueba de Strapi",
+          "removed": "Integración de Strapi eliminada",
+          "testReceived": "Webhook de prueba de Strapi recibido"
+        },
+        "webhookUrl": "URL del webhook",
+        "whereZeroWorks": "Dónde trabaja Zero"
+      },
+      "telegram": {
+        "addBot": "Añadir bot",
+        "addDescription": "Completa cada paso de BotFather y luego crea el bot de espacio de trabajo.",
+        "adding": "Añadiendo...",
+        "addTitle": "Añadir bot de Telegram",
+        "agentAria": "Agente predeterminado para {{bot}}",
+        "backToIntegrations": "Volver a las integraciones",
+        "botFallback": "Bot de Telegram",
+        "bots": "Bots de Telegram",
+        "botToken": "Token de bot",
+        "botTokenPlaceholder": "123456:ABC-DEF",
+        "checking": "Comprobando...",
+        "copied": "¡Copiado!",
+        "copyAria": "Copiar {{value}}",
+        "copyTitle": "Haz clic para copiar",
+        "create": {
+          "description": "{{brandName}} registrará este bot y configurará su webhook. Después de configurarlo, menciona al bot en un grupo o mándale un mensaje privado para que hable con el agente seleccionado.",
+          "descriptionNamed": "{{brandName}} registrará {{bot}} y configurará su webhook. Después de configurarlo, menciona al bot en un grupo o mándale un mensaje privado para que hable con el agente seleccionado.",
+          "title": "Listo para crear la integración"
+        },
+        "defaultAgent": "Agente por defecto",
+        "disconnectAria": "Desconectar {{bot}}",
+        "documentTitle": "Telegram",
+        "domain": {
+          "detected": "Dominio detectado",
+          "instructionAfter": ", elige este bot y establece el dominio como",
+          "instructionEnd": ". Telegram utiliza este dominio para permitir el flujo de conexión de este bot.",
+          "instructionStart": "En {{botFather}}, envía",
+          "title": "Configurar el dominio de inicio de sesión de Telegram"
+        },
+        "emptyDescription": "Añade un token de bot para empezar a dirigir los mensajes de Telegram a un agente.",
+        "emptyTitle": "Todavía no hay bots de Telegram",
+        "invalidTokenDescription": "Reinstala el bot con un token nuevo de BotFather.",
+        "loadError": "No se pudo cargar la configuración de Telegram.",
+        "moreOptions": "Más opciones para {{bot}}",
+        "newBotToken": "Nuevo token de bot",
+        "notConnected": "No conectado",
+        "officialBot": "Zero bot oficial",
+        "officialDescription": "Bot oficial proporcionado por {{brandName}}.",
+        "officialMissing": "Falta la configuración oficial del bot.",
+        "pageDescription": "Gestiona el enrutamiento de bots para este espacio de trabajo",
+        "privacy": {
+          "instructionAfter": ", elige este bot y luego desactiva el modo de privacidad. Esto permite al agente leer el contexto del grupo alrededor de las menciones y respuestas.",
+          "instructionStart": "En {{botFather}}, envía",
+          "off": "El modo privacidad está desactivado",
+          "title": "Opcional: desactiva el modo privacidad"
+        },
+        "registerAria": "Registrar Telegram bot",
+        "reinstall": "Reinstalación",
+        "reinstallDescription": "Pega un token nuevo de BotFather para {{bot}}. El token debe pertenecer a este mismo bot.",
+        "reinstalling": "Reinstalando...",
+        "reinstallTargetFallback": "Este bot",
+        "reinstallTitle": "Reinstalar Telegram bot",
+        "selectAgent": "Seleccionar agente",
+        "steps": {
+          "back": "Volver",
+          "create": "Crear",
+          "domain": "Dominio",
+          "next": "Siguiente",
+          "privacy": "Privacidad",
+          "token": "Token"
+        },
+        "token": {
+          "instructionAfter": ", elige un nombre y un nombre de usuario, luego pega el token a continuación.",
+          "open": "Abrir",
+          "send": ", enviar",
+          "title": "Crear un token de bot en BotFather",
+          "verified": "Token verificado"
+        },
+        "tokenInvalid": "Token inválido",
+        "uninstallAria": "Desinstalar {{bot}}",
+        "uninstallDescription": "Esto elimina {{bot}} del espacio de trabajo y desconecta el acceso a Telegram de los usuarios que lo utilizan. Esta acción no puede deshacerse.",
+        "uninstallTargetFallback": "Este bot",
+        "uninstallTitle": "¿Desinstalar el bot de Telegram?"
+      },
+      "toasts": {
+        "agentphoneConnected": "AgentPhone conectado",
+        "agentphoneDisconnected": "AgentPhone desconectado",
+        "agentphoneVerificationSent": "Mensaje de verificación enviado",
+        "feishuBotInstalled": "Feishu bot instalado correctamente",
+        "feishuBotUninstalled": "Feishu bot desinstalado",
+        "feishuConnected": "Feishu conectado con éxito",
+        "feishuDisconnected": "Desconectado de Feishu",
+        "slackConnected": "Slack conectado con éxito",
+        "slackDisconnected": "Desconectado de Slack",
+        "slackInstalled": "Slack instalado con éxito",
+        "slackPermissionsUpdated": "Permisos actualizados",
+        "slackUninstalled": "Espacio de trabajo de Slack desinstalado",
+        "slackUpdated": "Slack actualizado",
+        "teamsConnected": "Microsoft Teams conectado con éxito",
+        "teamsDisconnected": "Desconectado de Microsoft Teams",
+        "teamsInstalled": "Microsoft Teams instalado con éxito",
+        "teamsUninstalled": "Integración de Microsoft Teams desinstalada",
+        "teamsUpdated": "Microsoft Teams actualizado",
+        "telegramAgentUpdated": "Agente predeterminado actualizado",
+        "telegramBotAdded": "Bot de Telegram añadido",
+        "telegramBotReinstalled": "Bot de Telegram reinstalado",
+        "telegramBotUninstalled": "Bot de Telegram desinstalado",
+        "telegramDisconnected": "Cuenta de Telegram desconectada",
+        "telegramUpdatingAgent": "Actualizando agente por defecto..."
+      },
+      "works": {
+        "connected": "Conectado",
+        "connectedDetail": "Conectado ({{detail}})"
+      }
+    },
+    "redirect": {
+      "back": "Volviendo a {{brandName}}",
+      "errorDescription": "Vuelve a {{brandName}} e intenta conectar de nuevo.",
+      "errorStatus": "No se puede iniciar la conexión",
+      "errorTitle": "No se pudo abrir {{connector}}",
+      "mobileWarning": "Es posible que la aplicación {{connector}} no admita este enlace OAuth. Completa la conexión desde la aplicación web de {{brandName}} en un ordenador.",
+      "preparing": "Preparando una conexión segura",
+      "redirectDescription": "Continuarás en {{connector}} para autorizar a {{brandName}}.",
+      "redirectTitle": "Redirigiendo a {{connector}}..."
+    },
+    "toasts": {
+      "connected": "{{connector}} conectado",
+      "disconnected": "{{connector}} desconectado"
+    }
+  },
+  "global": {
+    "errors": {
+      "httpStatus": "HTTP {{status}}",
+      "requestFailed": "Solicitud fallida"
+    },
+    "realtime": {
+      "degraded": "Se produjo un problema con las actualizaciones en directo. Actualiza la página."
+    }
+  },
+  "insights": {
+    "calendar": {
+      "nextMonth": "Mes siguiente",
+      "previousMonth": "Mes anterior"
+    },
+    "cards": {
+      "agents": "Agentes",
+      "agentsRan_one": "{{agents}} completó {{runs}}",
+      "agentsRan_many": "{{agents}} completaron {{runs}}",
+      "agentsRan_other": "{{agents}} completaron {{runs}}",
+      "allowed": "Permitido",
+      "allowedSummary_one": "{{calls}} realizada con {{permissions}} permiso concedido",
+      "allowedSummary_many": "{{calls}} realizadas con {{permissions}} permisos concedidos",
+      "allowedSummary_other": "{{calls}} realizadas con {{permissions}} permisos concedidos",
+      "automations": "Automatizaciones",
+      "automationsUsed_one": "{{automations}} usó {{credits}}",
+      "automationsUsed_many": "{{automations}} usaron {{credits}}",
+      "automationsUsed_other": "{{automations}} usaron {{credits}}",
+      "balance": "Saldo",
+      "byAgent": "por {{agent}}",
+      "chats": "Conversaciones",
+      "chatsUsed_one": "{{chats}} usó {{credits}}",
+      "chatsUsed_many": "{{chats}} usaron {{credits}}",
+      "chatsUsed_other": "{{chats}} usaron {{credits}}",
+      "clickToOpen": "Haz clic para abrir",
+      "consumedToday": "consumido hoy",
+      "moreAutomations_one": "+{{value}} más automatización",
+      "moreAutomations_many": "+{{value}} más automatizaciones",
+      "moreAutomations_other": "+{{value}} más automatizaciones",
+      "moreChats_one": "+{{value}} conversación más",
+      "moreChats_many": "+{{value}} conversaciones más",
+      "moreChats_other": "+{{value}} conversaciones más",
+      "protected": "Protegido",
+      "protectedSummary_one": "{{calls}} protegida con {{permissions}} permiso",
+      "protectedSummary_many": "{{calls}} protegidas con {{permissions}} permisos",
+      "protectedSummary_other": "{{calls}} protegidas con {{permissions}} permisos",
+      "rejected_one": "{{value}} rechazada",
+      "rejected_many": "{{value}} rechazadas",
+      "rejected_other": "{{value}} rechazadas",
+      "rejectedOf": "{{denied}} de {{total}} rechazadas",
+      "services": "Servicios",
+      "servicesReceived_one": "{{services}} recibió {{calls}}",
+      "servicesReceived_many": "{{services}} recibieron {{calls}}",
+      "servicesReceived_other": "{{services}} recibieron {{calls}}",
+      "team": "Equipo",
+      "teamCreditUsage": "Uso de créditos del equipo",
+      "untitled": "(sin título)",
+      "yourCreditUsage": "Tu consumo de créditos"
+    },
+    "common": {
+      "loadMore": "Cargar más",
+      "showLess": "Mostrar menos"
+    },
+    "page": {
+      "description": "Controla a qué acceden tus agentes, cómo se gastan los créditos, qué permisos usan y detecta cualquier cosa inusual.",
+      "documentTitle": "Estadísticas y uso",
+      "empty": "Ejecuta un agente para ver estadísticas aquí.",
+      "emptyRange": "No hay actividad en este periodo de tiempo.",
+      "lastUpdated": "Última actualización — {{date}}",
+      "loadError": "No se pudo cargar la actividad de red.",
+      "title": "Estadísticas"
+    },
+    "range": {
+      "custom": "Intervalo personalizado",
+      "last28Days": "Últimos 28 días",
+      "last30Days": "Últimos 30 días",
+      "last7Days": "Últimos 7 días",
+      "today": "Hoy",
+      "yesterday": "Ayer"
+    },
+    "summary": {
+      "activityCaption": "{{first}} · {{second}}",
+      "blocked_one": "Tus reglas de permisos bloquearon {{blocked}} solicitud. Revísala para comprobar que no se haya retenido nada importante.",
+      "blocked_many": "Tus reglas de permisos bloquearon {{blocked}} solicitudes. Revísalas para comprobar que no se haya retenido nada importante.",
+      "blocked_other": "Tus reglas de permisos bloquearon {{blocked}} solicitudes. Revísalas para comprobar que no se haya retenido nada importante.",
+      "blockedCaption": "{{calls}} · {{blocked}} bloqueadas",
+      "busy_one": "Un día ajetreado: {{agentCount}} agente completó {{runs}}. Tu red está trabajando duro.",
+      "busy_many": "Un día ajetreado: {{agentCount}} agentes completaron {{runs}}. Tu red está trabajando duro.",
+      "busy_other": "Un día ajetreado: {{agentCount}} agentes completaron {{runs}}. Tu red está trabajando duro.",
+      "distributed_one": "{{agents}} activo con un consumo total de {{credits}}. Una carga de trabajo bien distribuida.",
+      "distributed_many": "{{agents}} activos con un consumo total de {{credits}}. Una carga de trabajo bien distribuida.",
+      "distributed_other": "{{agents}} activos con un consumo total de {{credits}}. Una carga de trabajo bien distribuida.",
+      "highTraffic_one": "{{callCount}} llamada de servicio entre {{services}}. Un día de mucho tráfico.",
+      "highTraffic_many": "{{callCount}} llamadas de servicio entre {{services}}. Un día de mucho tráfico.",
+      "highTraffic_other": "{{callCount}} llamadas de servicio entre {{services}}. Un día de mucho tráfico.",
+      "light_one": "Actividad ligera: solo {{runs}} y {{calls}}. Un día tranquilo.",
+      "light_many": "Actividad ligera: solo {{runs}} y {{calls}}. Un día tranquilo.",
+      "light_other": "Actividad ligera: solo {{runs}} y {{calls}}. Un día tranquilo.",
+      "quietCaption": "{{runs}} · un día tranquilo",
+      "smooth": "{{runs}} y {{callCount}} llamadas de servicio hoy. Todo funciona sin problemas."
+    },
+    "units": {
+      "agent_one": "{{value}} agente",
+      "agent_many": "{{value}} agentes",
+      "agent_other": "{{value}} agentes",
+      "call_one": "{{value}} llamada",
+      "call_many": "{{value}} llamadas",
+      "call_other": "{{value}} llamadas",
+      "run_one": "{{value}} ejecución",
+      "run_many": "{{value}} ejecuciones",
+      "run_other": "{{value}} ejecuciones",
+      "service_one": "{{value}} servicio",
+      "service_many": "{{value}} servicios",
+      "service_other": "{{value}} servicios"
+    }
+  },
+  "lifecycle": {
+    "emailUnsubscribe": {
+      "action": "Cancelar suscripción",
+      "body": "Ya no recibirás notificaciones de correo electrónico iniciadas por el sistema desde {{brandName}}.",
+      "confirmTitle": "¿Cancelar las notificaciones por correo electrónico?",
+      "documentTitle": "Cancelar suscripción",
+      "doneTitle": "No suscrito",
+      "errorBody": "Este enlace de baja es inválido o caducado. Puedes gestionar las notificaciones por correo electrónico en Configuración.",
+      "errorTitle": "Algo salió mal"
+    },
+    "morningBriefUnsubscribe": {
+      "documentTitle": "Resumen matutino",
+      "doneBody": "Ya no recibirás el correo electrónico diario de Morning Brief. Puedes volver a activarlo en cualquier momento en Configuración.",
+      "doneTitle": "Morning Brief desactivado",
+      "errorBody": "El enlace de baja es inválido o incompleto. Abre el último correo de Morning Brief y utiliza su enlace de baja o gestiona la preferencia en Configuración.",
+      "errorTitle": "Este enlace no es válido",
+      "loadingLabel": "Cargando estado de cancelación de suscripción",
+      "managePreferences": "Gestionar preferencias"
+    },
+    "pwaInstall": {
+      "banner": "Instala Zero para una mejor experiencia",
+      "description": "Añade Zero en tu pantalla de inicio para acceder rápidamente.",
+      "dismiss": "Cancelar banner de instalación",
+      "gotIt": "Entendido",
+      "install": "Instalación",
+      "installApp": "Instalar la aplicación",
+      "stepOne": "En Safari, pulsa el botón de compartir.",
+      "stepThree": "Confirma que el nombre es Zero y pulsa Añadir.",
+      "stepTwo": "Elige Añadir a la pantalla de inicio.",
+      "title": "Instalar Zero"
+    },
+    "redeemCampaign": {
+      "actions": {
+        "back": "Volviendo a {{brandName}}",
+        "redeem": "Canjear créditos"
+      },
+      "documentTitle": "Reclama tus créditos",
+      "organizationFallback": "Tu organización",
+      "states": {
+        "adminRequired": {
+          "body": "Solo los administradores de la organización pueden canjear créditos de campaña por {{orgName}}. Pide a un administrador de tu organización que abra el enlace en su lugar.",
+          "title": "Se requiere acceso de administrador"
+        },
+        "alreadyGranted": {
+          "body": "Tus créditos ya están en la cuenta de {{orgName}}. Vuelve a la app para empezar a usarlos.",
+          "title": "Ya has canjeado esta oferta"
+        },
+        "billingUnavailable": {
+          "body": "Nuestro sistema de pagos no está disponible ahora mismo. Por favor, inténtalo de nuevo en unos minutos.",
+          "title": "La facturación está temporalmente indisponible"
+        },
+        "broken": {
+          "body": "No pudimos completar tu redención. Por favor, inténtalo de nuevo o contacta con el soporte.",
+          "title": "Algo salió mal"
+        },
+        "campaignUnavailable": {
+          "body": "El código promocional puede haber caducado, haber alcanzado su límite de canje o haber sido eliminado. Si crees que esto es un error, contacta con el soporte técnico.",
+          "title": "Esta oferta no está disponible"
+        },
+        "paymentSuccessful": {
+          "body": "Tus créditos están en camino a {{orgName}}. Abre el panel para ver tu nuevo saldo.",
+          "title": "Pago exitoso"
+        },
+        "processing": {
+          "body": "Estamos aplicando tus créditos a {{orgName}} ahora. Esto suele tardar unos segundos — actualiza en un momento para ver el saldo actualizado.",
+          "title": "Pago recibido"
+        },
+        "ready": {
+          "body": "Completa el pago para añadir estos créditos al saldo de {{orgName}}.",
+          "title": "Reclama tus créditos"
+        }
+      }
+    }
+  },
+  "onboarding": {
+    "categories": {
+      "ceo": {
+        "description": "Informes y el panorama general",
+        "title": "CEO"
+      },
+      "data": {
+        "description": "Paneles, métricas, consultas",
+        "title": "Datos"
+      },
+      "engineering": {
+        "description": "Enviar, depurar, automatizar código",
+        "title": "Ingeniero"
+      },
+      "everyone": {
+        "description": "Correo electrónico, calendario, reuniones",
+        "title": "Todos"
+      },
+      "marketing": {
+        "description": "Contenido, SEO, campañas",
+        "title": "Marketing"
+      },
+      "operations": {
+        "description": "Proyectos, planificación, sincronización",
+        "title": "Operaciones"
+      },
+      "product": {
+        "description": "Especificaciones, releases, feedback",
+        "title": "Producto"
+      },
+      "sales": {
+        "description": "Pipeline y divulgación",
+        "title": "Ventas"
+      },
+      "support": {
+        "description": "Entradas y ayuda al cliente",
+        "title": "Soporte"
+      }
+    },
+    "common": {
+      "back": "Volver",
+      "continue": "Continuar",
+      "dialogPreview": "{{title}} vista previa",
+      "gotIt": "Entendido",
+      "next": "Siguiente",
+      "noConnectorRequired": "No se requiere conector",
+      "previewWorkflowDetails": "Detalles del flujo de trabajo de vista previa",
+      "selectTemplate": "Selecciona esta plantilla",
+      "selectThisTemplate": "Selecciona esta plantilla",
+      "stepProgress": "Paso {{current}} de {{total}}"
+    },
+    "documentTitles": {
+      "chooseImage": "Elige un estilo de imagen",
+      "choosePresentation": "Elige una plantilla de presentación",
+      "chooseVideo": "Elige un estilo de vídeo",
+      "chooseWorkflow": "Elige un flujo de trabajo",
+      "make": "Bienvenidos a {{brandName}}",
+      "runImage": "Crea tu primera imagen",
+      "runPresentation": "Crea tu primera presentación",
+      "runVideo": "Crea tu primer vídeo",
+      "runWorkflow": "Ejecuta tu primer flujo de trabajo"
+    },
+    "make": {
+      "description": "Elige un punto de partida, puedes hacer todo lo demás después.",
+      "options": {
+        "explore": {
+          "description": "Solo conecta con mis herramientas",
+          "title": "Lo exploraré por mi cuenta"
+        },
+        "images": {
+          "description": "Crea imágenes de alta calidad",
+          "title": "Generar imágenes"
+        },
+        "presentation": {
+          "description": "Generar diapositivas y altavoz",
+          "title": "Generar una presentación"
+        },
+        "video": {
+          "description": "Convierte tus ideas en vídeo",
+          "title": "Producción de vídeo"
+        },
+        "workflow": {
+          "description": "Explorar desde plantillas preestablecidas",
+          "title": "Automatización de flujos de trabajo"
+        }
+      },
+      "projectTypeLabel": "Primer tipo de proyecto",
+      "promptDescription": "Ajusta la herramienta abajo o ejecuta tal cual. Zero se encarga a partir de aquí. Tus herramientas permanecen en el sandbox y nada sale de tu espacio de trabajo.",
+      "promptLabel": "Prompt de incorporación",
+      "promptTitle": "Prueba este prompt",
+      "title": "¿Qué quieres preparar primero?"
+    },
+    "runAction": {
+      "checkingPlan": "Plan de control",
+      "runNow": "Ejecutar ahora",
+      "upgradePro": "Actualizar Pro para que funcione"
+    },
+    "templatePicker": {
+      "image": {
+        "description": "Úsalo como referencia para la imagen que quieres crear.",
+        "selectTemplate": "Seleccionar la plantilla de ilustración {{title}}",
+        "showVariant": "Mostrar {{title}} variante {{variant}}",
+        "title": "Elige una plantilla de ilustración desde la cual empezar"
+      },
+      "presentation": {
+        "description": "Úsala como referencia para la presentación que quieres crear.",
+        "nextSlide": "Mostrar la siguiente diapositiva",
+        "previousSlide": "Mostrar diapositiva anterior",
+        "selectTemplate": "Seleccionar la plantilla de presentación {{title}}",
+        "showSlide": "Mostrar la {{slide}} diapositivas",
+        "slideAlt": "{{title}} diapositiva {{slide}}",
+        "title": "Elige una plantilla de presentación desde la cual empezar",
+        "viewTemplate": "Ver {{title}} presentación"
+      },
+      "video": {
+        "description": "Úsalo como referencia para el vídeo que quieres crear.",
+        "selectTemplate": "Seleccionar la plantilla de vídeo {{title}}",
+        "title": "Elige una plantilla de vídeo para empezar"
+      }
+    },
+    "templateRun": {
+      "image": {
+        "noteLabel": "Escena de ilustración personalizada",
+        "notePlaceholder": "Añade tu escena personalizada para remezclar con tu propia ilustración",
+        "previewLabel": "Vista previa de plantilla de ilustración",
+        "title": "Selecciona una automatización que quieras probar"
+      },
+      "presentation": {
+        "noteLabel": "Contenido de la presentación e instrucción",
+        "notePlaceholder": "Añade el contenido y las instrucciones de tu presentación",
+        "previewLabel": "Vista previa de la plantilla de presentación",
+        "title": "Cumple tu presentación"
+      },
+      "video": {
+        "noteLabel": "Prompt de vídeo personalizado",
+        "notePlaceholder": "Añade tu prompt personalizado para remezclar con tu propio vídeo",
+        "previewLabel": "Vista previa de plantilla de vídeo",
+        "title": "Personaliza tu vídeo"
+      }
+    },
+    "templates": {
+      "illustration": {
+        "cozy-parlor": "Acogedor Salón",
+        "crowd-ink": "Tinta del público",
+        "editorial-flatfolk": "Editorial Flatfolk",
+        "endpaper": "Guardada",
+        "flat-poster": "Cartel plano",
+        "folk-muse": "Musa Popular",
+        "folk-storybook": "Libro de cuentos populares",
+        "grain-poster": "Cartel de grano",
+        "grainy-duotone": "Duótono granulado",
+        "iberian-vignette": "Viñeta ibérica",
+        "ink-mascot": "Mascota Ink",
+        "ink-storefront": "Tienda de tinta",
+        "inkdab": "Inkdab",
+        "inkstomp": "Pisotón de tinta",
+        "iso-scene": "Escena Iso",
+        "jade-blockprint": "Estampado de jade",
+        "light-pop-portrait": "Retrato Light Pop",
+        "loose-contour": "Contorno suelto",
+        "mellow-pop": "Pop Suave",
+        "mosaic-still-life": "Naturaleza muerta en mosaico",
+        "notion-illustration": "Notion Ilustración",
+        "op-ed-cover": "Portada de opinión",
+        "painterly-botanical": "Botánico pictórico",
+        "papernook": "Papernook",
+        "postcard-illustration": "Ilustración de postales",
+        "riso-relic": "Reliquia de Riso",
+        "shadow-pop": "Shadow Pop",
+        "soft-vector": "Vector blando",
+        "sticker-sheet": "Hoja de pegatinas",
+        "sunlit-gouache": "Gouache iluminado por el sol",
+        "tiny-wanderer": "Pequeño Errante"
+      },
+      "presentation": {
+        "botane-organic-deck": "Jardín malva",
+        "business-data-presentation": "Salpicadero Berry",
+        "crayon-learning-deck": "Garabato con ceras",
+        "creative-agency-presentation": "Galería de follaje",
+        "data-report-presentation": "Gráficos llamativos",
+        "editorial-magazine-deck": "Revista en papel",
+        "landing-consulting-deck": "Navegador neón",
+        "lumina-creative-studio": "Pegatinas de cepillo",
+        "mosaic-geometric-pitch": "Azulejos Bauhaus",
+        "playful-launch-presentation": "Sala de juegos Sunburst",
+        "playful-pop-deck": "Caramelo de neón"
+      },
+      "video": {
+        "chinese-ink-art": "Pintura china a tinta",
+        "cyberpunk-anime": "Cyberpunk Anime",
+        "epic-grandeur": "Grandeza épica",
+        "fashion-editorial": "Editorial de moda",
+        "gourmet-documentary": "Documental Gourmet",
+        "hand-drawn-fantasy-anime": "Anime de fantasía dibujado a mano",
+        "japanese-wabi-sabi": "Wabi-Sabi japonés",
+        "luxury-product": "Macro de productos de lujo",
+        "shortform-viral": "Viral de forma corta",
+        "sports-performance-ad": "Anuncio de rendimiento deportivo"
+      }
+    },
+    "workflowDiagram": {
+      "preparedDescription": "Zero prepara el siguiente paso con tus herramientas.",
+      "preparedTitle": "Flujo de trabajo preparado",
+      "reviewDescription": "Zero completa el flujo de trabajo y devuelve el resultado.",
+      "reviewTitle": "Listo para la revisión",
+      "source": "Fuente"
+    },
+    "workflowPicker": {
+      "categoryDescription": "Configuraciones listas para usar que puedes adaptar a tus herramientas y objetivos.",
+      "categoryTitle": "{{category}} flujos de trabajo",
+      "customDescription": "Describe lo que quieres y Zero lo construye contigo.",
+      "customTitle": "Habla con Zero y haz la mía propia",
+      "description": "Elige un puesto para ver los flujos de trabajo que encajan. Puedes cambiar en cualquier momento.",
+      "title": "¿En qué trabajas?",
+      "workflowCardLabel": "{{title}} {{description}}"
+    },
+    "workflowPreview": {
+      "howItWorks": "Cómo funciona",
+      "whatItDoes": "Qué hace"
+    },
+    "workflowRun": {
+      "continueWithZero": "Continúa con Zero",
+      "createDraft": "Crear borrador",
+      "customNoteLabel": "Describe tu flujo de trabajo",
+      "customNotePlaceholder": "Describe lo que quieres que Zero cree",
+      "customTitle": "Describe tu flujo de trabajo",
+      "noteLabel": "¿Algo más que te gustaría añadir?",
+      "notePlaceholder": "¿Algo más que te gustaría añadir?",
+      "reviewTitle": "Revisa tu borrador de flujo de trabajo"
+    },
+    "workflows": {
+      "alert-metric-moves-slack": {
+        "description": "Supervisa tus métricas clave y avisa en Slack cuando una cambie bruscamente.",
+        "scenario": "Cuando un problema aparece en la revisión semanal, ya lleva días activo. Zero comprueba una métrica clave cada hora y avisa en Slack en cuanto sale de su intervalo habitual.",
+        "steps": {
+          "one": {
+            "description": "Zero lee la métrica cada hora.",
+            "title": "Zero comprueba la métrica"
+          },
+          "three": {
+            "description": "Zero publica una alerta con la desviación.",
+            "title": "Alerta publicada en Slack"
+          },
+          "two": {
+            "description": "Zero marca valores fuera de la banda esperada.",
+            "title": "Comparado con el rango normal"
+          }
+        },
+        "title": "Alerta cuando se mueve una métrica"
+      },
+      "auto-merge-github-prs": {
+        "description": "Revisa los PR etiquetados como listos para fusionar, espera a que pase CI, fusiónalos y publica el resultado en Slack.",
+        "scenario": "Fusionar un PR exige vigilar CI, revisar de nuevo el diff y avisar cuando se publica. Zero detecta la etiqueta de listo para fusionar, revisa el cambio, espera a que todas las comprobaciones pasen, fusiona el PR e informa al canal.",
+        "steps": {
+          "one": {
+            "description": "Zero recoge pull requests en cuanto llevan tu etiqueta de fusión.",
+            "title": "Una PR se etiqueta como lista para fusionarse"
+          },
+          "three": {
+            "description": "Zero fusiona el PR y publica el resultado en tu canal.",
+            "title": "Fusionado y publicado en Slack"
+          },
+          "two": {
+            "description": "Zero lee el diff y espera hasta que pasen todas las comprobaciones obligatorias.",
+            "title": "Zero revisa el PR y espera a CI"
+          }
+        },
+        "title": "Fusionar automáticamente PR de GitHub"
+      },
+      "blog-posts-to-x": {
+        "description": "Cada día, Zero convierte las nuevas entradas del blog en variantes para redes sociales y las programa en X mediante Buffer.",
+        "scenario": "Una entrada del blog puede convertirse en diez publicaciones sociales, pero nadie tiene tiempo de adaptarla. Zero detecta las entradas nuevas, redacta varias versiones para X y las deja en Buffer para su aprobación.",
+        "steps": {
+          "one": {
+            "description": "Zero detecta publicaciones recientes en Strapi.",
+            "title": "Zero encuentra nuevas publicaciones"
+          },
+          "three": {
+            "description": "Zero programa las variantes para su revisión.",
+            "title": "En cola en Buffer"
+          },
+          "two": {
+            "description": "Zero redacta varias publicaciones para X a partir de cada artículo.",
+            "title": "Convertido en variantes sociales"
+          }
+        },
+        "title": "Convierte entradas de blog en publicaciones sociales"
+      },
+      "build-weekly-deck-gamma": {
+        "description": "Convierte las métricas de la semana en una presentación de Gamma lista para exponer.",
+        "scenario": "La presentación semanal repite las mismas diapositivas con cifras nuevas. Zero obtiene los datos, crea la presentación en Gamma y la publica en Slack para que esté lista antes de la reunión.",
+        "steps": {
+          "one": {
+            "description": "Zero lee métricas de Sheets y analíticas.",
+            "title": "Zero recopila los números"
+          },
+          "three": {
+            "description": "Zero comparte la presentación terminada.",
+            "title": "Publicado en Slack"
+          },
+          "two": {
+            "description": "Zero prepara la presentación periódica de métricas.",
+            "title": "Presentación creada en Gamma"
+          }
+        },
+        "title": "Crear la presentación semanal en Gamma"
+      },
+      "business-review-gamma": {
+        "description": "Convierte las métricas del mes en una presentación de análisis empresarial en Gamma.",
+        "scenario": "La revisión semanal del negocio es una presentación recurrente que alguien reconstruye a mano. Zero obtiene los datos de ingresos y crecimiento, crea la presentación en Gamma y la deja lista antes de la reunión.",
+        "steps": {
+          "one": {
+            "description": "Zero obtiene de Stripe y Clerk el MRR, el consumo de caja y el crecimiento.",
+            "title": "Zero recopila las cifras"
+          },
+          "three": {
+            "description": "Zero comparte la presentación terminada.",
+            "title": "Listo para presentar"
+          },
+          "two": {
+            "description": "Zero elabora la revisión recurrente de negocios.",
+            "title": "Presentación creada en Gamma"
+          }
+        },
+        "title": "Crear el análisis empresarial en Gamma"
+      },
+      "catch-calendar-conflicts": {
+        "description": "Busca reservas duplicadas en tu calendario y avísate con antelación.",
+        "scenario": "Las reservas duplicadas suelen descubrirse cuando empiezan dos reuniones a la vez. Zero compara cada evento nuevo con tu calendario y tu disponibilidad en Cal.com, y te avisa antes de que se produzca el conflicto.",
+        "steps": {
+          "one": {
+            "description": "Zero se activa cuando aparece un nuevo evento en tu calendario.",
+            "title": "Se crea un evento"
+          },
+          "three": {
+            "description": "Zero te avisa del conflicto y te ofrece varias opciones.",
+            "title": "Conflicto marcado en Slack"
+          },
+          "two": {
+            "description": "Zero compara con eventos y disponibilidad existentes.",
+            "title": "Comprobado por si hay conflictos"
+          }
+        },
+        "title": "Detectar conflictos en Google Calendar"
+      },
+      "catch-leads-gmail": {
+        "description": "Detecta las señales de compra en el correo nuevo y registra los leads calificados.",
+        "scenario": "Los leads interesados se pierden en una bandeja de entrada llena y acaban enfriándose. Zero busca señales de compra en el correo entrante, enriquece los datos del remitente con Apollo, registra el lead en una hoja y sugiere el siguiente paso en Slack.",
+        "steps": {
+          "one": {
+            "description": "Zero busca señales de compra en los mensajes entrantes de Gmail.",
+            "title": "Zero escanea el correo nuevo"
+          },
+          "three": {
+            "description": "Zero publica el lead y un siguiente paso recomendado para Slack.",
+            "title": "Se sugiere el siguiente paso"
+          },
+          "two": {
+            "description": "Zero enriquece con Apollo y añade una fila a tu hoja.",
+            "title": "Lead enriquecido y registrado"
+          }
+        },
+        "title": "Detectar leads en Gmail"
+      },
+      "chase-overdue-asana-tasks": {
+        "description": "Encuentra tareas vencidas de Asana y recuerda a sus responsables que deben completarlas mediante Slack.",
+        "scenario": "Las tareas vencidas necesitan seguimiento, pero quien debe hacerlo siempre está ocupado. Zero revisa Asana cada día, encuentra lo que ha superado su fecha límite y avisa a cada responsable en Slack.",
+        "steps": {
+          "one": {
+            "description": "Zero lee tareas que ya están fuera de plazo.",
+            "title": "Zero escanea Asana"
+          },
+          "three": {
+            "description": "Zero envía por mensaje directo a cada responsable su lista de tareas vencidas.",
+            "title": "Recordatorios enviados por Slack"
+          },
+          "two": {
+            "description": "Zero agrupa el trabajo vencido por responsable.",
+            "title": "Propietarios identificados"
+          }
+        },
+        "title": "Dar seguimiento a tareas vencidas de Asana"
+      },
+      "check-posthog-signup-funnel": {
+        "description": "Sigue el embudo de inscripción y publica la mayor caída en Slack.",
+        "scenario": "Los embudos solo sirven si alguien los ejecuta. Zero analiza cada semana el embudo de registro, identifica el paso en el que se pierde más gente y lo publica en Slack para que el equipo sepa dónde centrarse.",
+        "steps": {
+          "one": {
+            "description": "Zero ejecuta el embudo de inscripción en PostHog de la semana.",
+            "title": "Zero ejecuta el embudo"
+          },
+          "three": {
+            "description": "Zero publica el punto de fuga y su tendencia.",
+            "title": "Publicado en Slack"
+          },
+          "two": {
+            "description": "Zero encuentra el escalón con la mayor caída.",
+            "title": "Mayor caída identificada"
+          }
+        },
+        "title": "Comprobar el embudo de registro de PostHog"
+      },
+      "compare-google-ads-last-month": {
+        "description": "Cada día, Zero compara el gasto, el CPA y el ROAS de Google Ads y Meta Ads con el periodo anterior, y señala las anomalías en Slack.",
+        "scenario": "Los problemas de ritmo publicitario cuestan dinero cada día que pasan desapercibidos. Zero compara a diario el gasto, el CPA y el ROAS con el periodo anterior y avisa en Slack de cualquier desviación.",
+        "steps": {
+          "one": {
+            "description": "Zero extrae gastos, CPA y conversiones de Google y Meta Ads.",
+            "title": "Zero lee el rendimiento de los anuncios"
+          },
+          "three": {
+            "description": "Zero publica la comparación y destaca las desviaciones.",
+            "title": "Anomalías señaladas en Slack"
+          },
+          "two": {
+            "description": "Zero calcula los deltas y el ritmo.",
+            "title": "Comparado con el periodo anterior"
+          }
+        },
+        "title": "Comparar Google Ads con el mes anterior"
+      },
+      "daily-company-brief-slack": {
+        "description": "Reúne producto, crecimiento e ingresos en un informe diario para Slack.",
+        "scenario": "La visión completa está repartida entre cinco herramientas que nadie consulta juntas. Cada mañana, Zero recopila crecimiento, ingresos, estado del producto e ingeniería, y publica en Slack un único pulso de la empresa con logros, riesgos y puntos que requieren atención.",
+        "steps": {
+          "one": {
+            "description": "Zero recopila crecimiento, ingresos, errores y despliegues de toda tu infraestructura.",
+            "title": "Zero recoge las señales"
+          },
+          "three": {
+            "description": "Zero publica el informe diario de la empresa.",
+            "title": "Publicado en Slack"
+          },
+          "two": {
+            "description": "Zero escribe sobre las victorias, los riesgos y lo que necesita atención.",
+            "title": "Reunido en un único pulso"
+          }
+        },
+        "title": "Publica un informe diario de la empresa para Slack"
+      },
+      "daily-industry-news-slack": {
+        "description": "Reúne las noticias relevantes del sector en un breve resumen diario para Slack.",
+        "scenario": "Mantenerse al día suele implicar una docena de pestañas que nunca abres. Zero revisa cada día las noticias de IA y de la competencia de las últimas 24 horas, y publica un breve resumen en Slack.",
+        "steps": {
+          "one": {
+            "description": "Zero busca la cobertura de IA y de la competencia del último día con Exa.",
+            "title": "Zero escanea las noticias"
+          },
+          "three": {
+            "description": "Zero publica el boletín informativo diario.",
+            "title": "Publicado en Slack"
+          },
+          "two": {
+            "description": "Zero resume lo que realmente importa.",
+            "title": "Destilado en un resumen"
+          }
+        },
+        "title": "Publica noticias diarias del sector en Slack"
+      },
+      "draft-github-release-notes-notion": {
+        "description": "Convierte los PR fusionados desde la última versión en notas claras dentro de Notion.",
+        "scenario": "Escribir notas de la versión exige revisar el historial de PR y explicar los commits con lenguaje sencillo. Cuando etiquetas un PR como publicado, Zero reúne todo lo fusionado desde la última etiqueta y redacta notas legibles en Notion.",
+        "steps": {
+          "one": {
+            "description": "Zero se activa con tu etiqueta de publicación.",
+            "title": "Una PR está etiquetada como enviada"
+          },
+          "three": {
+            "description": "Zero redacta notas de la versión claras y agrupadas en una página de Notion.",
+            "title": "Notas de lanzamiento guardadas en Notion"
+          },
+          "two": {
+            "description": "Zero recopila todo lo que se ha fusionado desde la última etiqueta de liberación.",
+            "title": "Zero reúne los PR fusionados"
+          }
+        },
+        "title": "Redactar notas de GitHub en Notion"
+      },
+      "draft-newsletter-mailchimp": {
+        "description": "Cada mes, Zero reúne las funciones publicadas en un boletín y prepara un borrador en Mailchimp.",
+        "scenario": "El boletín mensual siempre empieza con una página en blanco. Zero reúne lo publicado en GitHub, redacta la edición y la prepara en Mailchimp para que solo tengas que revisarla.",
+        "steps": {
+          "one": {
+            "description": "Zero lee en GitHub las funciones fusionadas y sus aspectos destacados.",
+            "title": "Zero recopila lo que se envió"
+          },
+          "three": {
+            "description": "Zero crea una campaña en borrador lista para editar.",
+            "title": "Preparado en Mailchimp"
+          },
+          "two": {
+            "description": "Zero redacta la edición con tu estilo.",
+            "title": "Boletín redactado"
+          }
+        },
+        "title": "Redacta el boletín en Mailchimp"
+      },
+      "draft-replies-notion-faq": {
+        "description": "Redacta respuestas a tickets basadas en tus preguntas frecuentes de Notion.",
+        "scenario": "La mayoría de las preguntas ya están respondidas en la documentación. Zero lee la pregunta entrante, consulta las preguntas frecuentes en Notion y redacta una respuesta basada en tus propios documentos para que un agente la apruebe.",
+        "steps": {
+          "one": {
+            "description": "Zero lee la nueva conversación en Intercom o Gmail.",
+            "title": "Llega una pregunta"
+          },
+          "three": {
+            "description": "Zero prepara una respuesta coherente con tu marca.",
+            "title": "Respuesta redactada para revisión"
+          },
+          "two": {
+            "description": "Zero encuentra la respuesta relevante en tus documentos.",
+            "title": "Zero consulta las preguntas frecuentes de Notion"
+          }
+        },
+        "title": "Redactar respuestas desde las preguntas frecuentes de Notion"
+      },
+      "file-gmail-invoices-drive": {
+        "description": "Archiva en Drive los correos con facturas y registra cada una en una hoja.",
+        "scenario": "Las facturas se acumulan en la bandeja de entrada y la conciliación es un caos. Zero archiva cada factura etiquetada en la carpeta correcta de Drive y registra el importe y la fecha de vencimiento en tu hoja de gastos a medida que llega.",
+        "steps": {
+          "one": {
+            "description": "Zero se activa con la etiqueta Facturas de Gmail.",
+            "title": "Una factura está etiquetada"
+          },
+          "three": {
+            "description": "Zero registra el importe y la fecha de vencimiento en la hoja de gastos.",
+            "title": "Registrado en una hoja"
+          },
+          "two": {
+            "description": "Zero guarda el archivo adjunto en la carpeta correcta.",
+            "title": "Archivado en Google Drive"
+          }
+        },
+        "title": "Archivar facturas de Gmail en Google Drive"
+      },
+      "file-sentry-crashes-github": {
+        "description": "Ordena los nuevos errores de Sentry por su impacto y registra los más graves como incidencias de GitHub.",
+        "scenario": "Los fallos nuevos permanecen ocultos en Sentry hasta que alguien los busca. Zero revisa Sentry cada hora, ordena los errores por el número de usuarios afectados, abre incidencias de GitHub para los importantes y avisa al responsable del código.",
+        "steps": {
+          "one": {
+            "description": "Zero lee los errores sin resolver y su número de eventos durante la última hora.",
+            "title": "Zero obtiene los nuevos errores de Sentry"
+          },
+          "three": {
+            "description": "Zero abre una incidencia de GitHub con la traza y avisa al responsable en Slack.",
+            "title": "Incidencias creadas y responsable avisado"
+          },
+          "two": {
+            "description": "Zero clasifica por usuarios afectados y filtra el ruido de bajo impacto.",
+            "title": "Clasificado por impacto en el usuario"
+          }
+        },
+        "title": "Registrar fallos de Sentry como incidencias de GitHub"
+      },
+      "fixes-to-notion-help-docs": {
+        "description": "Cuando un ticket se marca como resuelto, Zero convierte la solución en un artículo de ayuda reutilizable en Notion.",
+        "scenario": "La misma pregunta vuelve porque la solución nunca se documentó. Zero convierte cada ticket resuelto en un artículo de ayuda limpio y reutilizable en Notion para que la respuesta exista la próxima vez.",
+        "steps": {
+          "one": {
+            "description": "Zero se activa cuando se cierra un ticket.",
+            "title": "Se resuelve un ticket"
+          },
+          "three": {
+            "description": "Zero añade el artículo a tu centro de ayuda.",
+            "title": "Guardado en Notion"
+          },
+          "two": {
+            "description": "Zero redacta un claro tutorial a partir de la resolución.",
+            "title": "Corrección redactada"
+          }
+        },
+        "title": "Convertir soluciones en artículos de ayuda de Notion"
+      },
+      "flag-figma-designs-no-task": {
+        "description": "Marca los diseños de Figma que todavía no tienen una tarea de Linear vinculada.",
+        "scenario": "Algunos diseños se terminan sin convertirse nunca en tareas de desarrollo. Zero revisa cada día los frames de Figma marcados como listos, detecta los que no tienen una tarea de Linear vinculada y avisa en Slack.",
+        "steps": {
+          "one": {
+            "description": "Zero lee frames y sus tareas vinculadas.",
+            "title": "Zero revisa los frames de Figma"
+          },
+          "three": {
+            "description": "Zero lista los diseños no vinculados en tu canal.",
+            "title": "Diseños sin vincular publicados en Slack"
+          },
+          "two": {
+            "description": "Zero marca diseños listos que no tienen un ticket de construcción.",
+            "title": "Encuentra frames sin tarea"
+          }
+        },
+        "title": "Marcar diseños de Figma sin tarea"
+      },
+      "flagged-gmail-todoist-tasks": {
+        "description": "Convierte automáticamente los correos que marcas en tareas Todoist.",
+        "scenario": "Marcar un correo solo cambia la decisión más adelante. Zero recoge la señal, investiga el tema y el hilo anterior, y archiva una tarea Todoist con el contexto ya adjunto.",
+        "steps": {
+          "one": {
+            "description": "Zero se activa con tu etiqueta de tareas pendientes en Gmail.",
+            "title": "Marcas un correo electrónico"
+          },
+          "three": {
+            "description": "Zero crea una tarea lista para hacer con enlaces.",
+            "title": "Tarea archivada en Todoist"
+          },
+          "two": {
+            "description": "Zero recopila contexto de hilos anteriores e información web con Exa.",
+            "title": "Zero investiga"
+          }
+        },
+        "title": "Convertir correos marcados de Gmail en tareas de Todoist"
+      },
+      "github-idea-to-notion-spec": {
+        "description": "Amplía una incidencia etiquetada de GitHub y conviértela en una especificación de producto estructurada en Notion.",
+        "scenario": "Una idea de una línea en una incidencia no es una especificación. Zero detecta la etiqueta needs-spec y amplía la incidencia en un PRD estructurado en Notion con el problema, los usuarios, los requisitos y los criterios de aceptación.",
+        "steps": {
+          "one": {
+            "description": "Zero se activa con la etiqueta y lee la incidencia.",
+            "title": "Una incidencia recibe la etiqueta needs-spec"
+          },
+          "three": {
+            "description": "Zero crea la página estructurada de PRD en Notion.",
+            "title": "Guardado en Notion"
+          },
+          "two": {
+            "description": "Zero redacta el problema, los usuarios, los requisitos y los criterios de aceptación.",
+            "title": "Zero lo amplía a un PRD"
+          }
+        },
+        "title": "Convertir una idea de GitHub en una especificación de Notion"
+      },
+      "gmail-followups-auto": {
+        "description": "Busca contactos que no respondieron y redacta el siguiente seguimiento.",
+        "scenario": "El seguimiento es donde se ganan los acuerdos y también donde se olvidan. Zero avanza tus secuencias cada día y redacta el siguiente mensaje para cada contacto que no ha respondido.",
+        "steps": {
+          "one": {
+            "description": "Zero lee quién no ha respondido en Instant y Apollo.",
+            "title": "Zero comprueba el estado de la secuencia"
+          },
+          "three": {
+            "description": "Zero prepara los borradores para tu aprobación.",
+            "title": "Listo en Gmail"
+          },
+          "two": {
+            "description": "Zero escribe el seguimiento de cada contacto.",
+            "title": "Siguiente mensaje redactado"
+          }
+        },
+        "title": "Enviar seguimientos de Gmail automáticamente"
+      },
+      "gmail-reconnect-reminders": {
+        "description": "Destaca los contactos importantes a los que no has escrito últimamente.",
+        "scenario": "Las relaciones se enfrían cuando estás concentrado en otras tareas. Cada semana, Zero revisa tu correo y tu calendario, identifica contactos importantes con los que no has hablado y sugiere una forma natural de retomar el contacto.",
+        "steps": {
+          "one": {
+            "description": "Zero lee el historial reciente de correos y calendarios.",
+            "title": "Zero revisa tus contactos"
+          },
+          "three": {
+            "description": "Zero publica cada contacto con una frase sugerida para iniciar la conversación.",
+            "title": "Inicios de conversación sugeridos"
+          },
+          "two": {
+            "description": "Zero encuentra contactos importantes con los que no has hablado últimamente.",
+            "title": "Contactos inactivos identificados"
+          }
+        },
+        "title": "Recibir recordatorios para retomar contactos de Gmail"
+      },
+      "highlight-key-emails-gmail": {
+        "description": "Saca a la luz los pocos correos que realmente requieren tu atención.",
+        "scenario": "Una bandeja de entrada desbordada entierra los tres correos que importan. Zero lee tu correo cada mañana y solo muestra los que realmente te necesitan, enviados a Slack.",
+        "steps": {
+          "one": {
+            "description": "Zero escanea el correo nocturno en Gmail.",
+            "title": "Zero lee la bandeja de entrada"
+          },
+          "three": {
+            "description": "Zero publica una lista breve y explica por qué importa cada mensaje.",
+            "title": "Publicado en Slack"
+          },
+          "two": {
+            "description": "Zero filtra los pocos mensajes que requieren tu atención.",
+            "title": "Prioridades identificadas"
+          }
+        },
+        "title": "Resalta los correos clave en Gmail"
+      },
+      "investor-update-google-docs": {
+        "description": "Reúne métricas y destacados en una actualización para inversores en Docs.",
+        "scenario": "La actualización mensual para inversores siempre empieza tarde y desde cero. Zero reúne los KPI y los aspectos destacados, y redacta la actualización en Google Docs para que solo tengas que perfeccionarla.",
+        "steps": {
+          "one": {
+            "description": "Zero obtiene los datos de ingresos y crecimiento de Stripe y Sheets.",
+            "title": "Zero recopila KPIs"
+          },
+          "three": {
+            "description": "Zero deja un borrador listo para editar.",
+            "title": "Editable en Google Docs"
+          },
+          "two": {
+            "description": "Zero escribe la narrativa y las métricas.",
+            "title": "Actualización redactada"
+          }
+        },
+        "title": "Redacta la actualización para inversores en Google Docs"
+      },
+      "log-gong-calls-hubspot": {
+        "description": "Añade al acuerdo de HubSpot las notas y los siguientes pasos de una llamada de Gong.",
+        "scenario": "Las notas de las llamadas rara vez llegan al CRM mientras todavía están frescas. Después de cada llamada, Zero lee la transcripción de Gong y añade automáticamente al acuerdo de HubSpot el resumen y los siguientes pasos.",
+        "steps": {
+          "one": {
+            "description": "Después de la llamada, Zero extrae las notas de grabación de Gong.",
+            "title": "Zero lee la transcripción"
+          },
+          "three": {
+            "description": "Zero escribe las notas en el registro del acuerdo.",
+            "title": "Registrado en HubSpot"
+          },
+          "two": {
+            "description": "Zero extrae decisiones y seguimientos.",
+            "title": "Resumen y próximos pasos redactados"
+          }
+        },
+        "title": "Registrar llamadas de Gong en HubSpot"
+      },
+      "meeting-notes-asana-tasks": {
+        "description": "Convierte las notas de las reuniones en tareas asignadas y con fecha de vencimiento en Asana.",
+        "scenario": "Los elementos de acción suelen perderse en las notas de las reuniones. Después de cada reunión, Zero lee la transcripción, extrae las tareas pendientes y crea tareas asignadas en Asana para convertir las decisiones en trabajo.",
+        "steps": {
+          "one": {
+            "description": "Después de la reunión, Zero obtiene las notas de Fireflies.",
+            "title": "Zero lee la transcripción"
+          },
+          "three": {
+            "description": "Zero crea tareas asignadas con sus fechas límite.",
+            "title": "Tareas creadas en Asana"
+          },
+          "two": {
+            "description": "Zero identifica las tareas pendientes y los propietarios.",
+            "title": "Elementos de acción extraídos"
+          }
+        },
+        "title": "Convierte las notas de reuniones en tareas Asana"
+      },
+      "meeting-recaps-slack": {
+        "description": "Comparte un resumen con las decisiones y acciones después de cada reunión.",
+        "scenario": "Los detalles de una reunión se desvanecen para la siguiente. Zero lee la transcripción después y envía un resumen limpio de las decisiones y acciones para que no se pierda nada.",
+        "steps": {
+          "one": {
+            "description": "Después de la reunión, Zero obtiene las notas de Fireflies.",
+            "title": "Zero lee la transcripción"
+          },
+          "three": {
+            "description": "Zero entrega el resumen a Gmail o Slack.",
+            "title": "Enviado"
+          },
+          "two": {
+            "description": "Zero resume decisiones y acciones concretas.",
+            "title": "Resumen escrito"
+          }
+        },
+        "title": "Recibir resúmenes de reuniones en Slack"
+      },
+      "morning-brief-slack": {
+        "description": "Cada mañana, Zero reúne tu agenda y los correos que requieren atención en un resumen para Slack.",
+        "scenario": "Los primeros minutos del día suelen dedicarse a averiguar qué tienes por delante. Zero reúne tu agenda y los correos que requieren atención, y publica un resumen matutino en Slack antes de que empieces.",
+        "steps": {
+          "one": {
+            "description": "Zero obtiene el calendario de hoy y los correos prioritarios.",
+            "title": "Zero lee tu día"
+          },
+          "three": {
+            "description": "Zero envía el informe matutino.",
+            "title": "Publicado en Slack"
+          },
+          "two": {
+            "description": "Zero escribe tu horario y lo que necesita atención.",
+            "title": "Resumen"
+          }
+        },
+        "title": "Recibe un informe matutino en Slack"
+      },
+      "new-gmail-contacts-hubspot": {
+        "description": "Añade como contactos de HubSpot a remitentes desconocidos y completa sus datos.",
+        "scenario": "Los contactos se escapan cuando nadie los registra. Zero detecta un correo de alguien que aún no está en HubSpot, crea el registro y lo enriquece con Apollo para que el CRM se mantenga completo sin necesidad de entrada manual.",
+        "steps": {
+          "one": {
+            "description": "Zero comprueba el correo entrante con el CRM.",
+            "title": "Zero detecta a un remitente desconocido"
+          },
+          "three": {
+            "description": "Zero registra el contacto y la fuente en la línea temporal.",
+            "title": "Registrado para seguimiento"
+          },
+          "two": {
+            "description": "Zero añade a la persona a HubSpot y enriquece con Apollo.",
+            "title": "Contacto creado y enriquecido"
+          }
+        },
+        "title": "Añadir nuevos contactos de Gmail a HubSpot"
+      },
+      "onboard-new-hires-asana": {
+        "description": "Crea la lista de tareas de incorporación para cada nuevo empleado en Asana.",
+        "scenario": "La incorporación es la misma lista de comprobación cada vez, hecha manualmente cada vez. Zero detecta a una nueva contratación, inicia el proyecto de incorporación en Asana y configura sus documentos iniciales en Drive.",
+        "steps": {
+          "one": {
+            "description": "Zero detecta el nuevo registro en Deel.",
+            "title": "Se añade una nueva contratación"
+          },
+          "three": {
+            "description": "Zero configura los documentos iniciales en Google Drive.",
+            "title": "Documentos preparados"
+          },
+          "two": {
+            "description": "Zero inicia el proyecto de incorporación con tareas asignadas.",
+            "title": "Lista de verificación creada en Asana"
+          }
+        },
+        "title": "Incorporar a nuevos empleados en Asana"
+      },
+      "post-daily-metrics-slack": {
+        "description": "Publica cada día en Slack las cifras de visitantes, registros y activación.",
+        "scenario": "Revisar tres paneles antes del café no es el ritual favorito de nadie. Cada mañana, Zero obtiene las cifras de visitantes, registros y activación, y las publica en Slack para que el día empiece con los KPI en el canal.",
+        "steps": {
+          "one": {
+            "description": "Zero lee el tráfico, las inscripciones y la activación de tus herramientas de analítica.",
+            "title": "Zero extrae las métricas"
+          },
+          "three": {
+            "description": "Zero publica la actualización matutina del KPI.",
+            "title": "Publicado en Slack"
+          },
+          "two": {
+            "description": "Zero da formato a las cifras clave y las compara con el día anterior.",
+            "title": "Ensamblado en una instantánea de KPI"
+          }
+        },
+        "title": "Publicar métricas diarias en Slack"
+      },
+      "post-github-updates-slack": {
+        "description": "Cada mañana laborable, Zero reúne el trabajo fusionado y en curso de GitHub y Linear en una actualización de progreso para Slack.",
+        "scenario": "Los standups consumen tiempo y la mitad es solo recordar lo que hiciste. Zero compila tus PRs fusionados y tickets de Linear en curso cada mañana y publica una actualización ordenada para que el standup asíncrono se escriba solo.",
+        "steps": {
+          "one": {
+            "description": "Zero lee tu trabajo fusionado y abierto en GitHub y Linear.",
+            "title": "Zero recopila tu actividad"
+          },
+          "three": {
+            "description": "Zero publica la actualización en tu canal de stand-up todos los días laborables.",
+            "title": "Publicado en Slack"
+          },
+          "two": {
+            "description": "Zero escribe un resumen breve y legible del progreso.",
+            "title": "Resumido en una actualización"
+          }
+        },
+        "title": "Publicar actualizaciones de GitHub en Slack"
+      },
+      "post-release-notes-slack": {
+        "description": "Redacta un registro de cambios a partir del trabajo publicado recientemente y compártelo en Slack.",
+        "scenario": "El registro de cambios que ven los usuarios es diferente al registro de commit. Zero se activa en la etiqueta de liberación, redacta un resumen amigable y orientado al usuario de lo que se envió y lo publica en Slack y Notion.",
+        "steps": {
+          "one": {
+            "description": "Zero se activa en la etiqueta de lanzamiento.",
+            "title": "Un PR recibe la etiqueta de versión"
+          },
+          "three": {
+            "description": "Zero comparte el anuncio en ambos lugares.",
+            "title": "Publicado en Slack y Notion"
+          },
+          "two": {
+            "description": "Zero escribe un resumen orientado al usuario sobre lo que ha cambiado.",
+            "title": "Zero redacta el registro de cambios"
+          }
+        },
+        "title": "Publicar notas de la versión en Slack"
+      },
+      "prep-google-calendar-meetings": {
+        "description": "Investiga a los asistentes externos y envía un resumen previo antes de las reuniones.",
+        "scenario": "Entrar en una llamada en frío significa improvisar. Zero observa nuevas reuniones externas, investiga al asistente y a la empresa con Apollo, extrae el contexto de la llamada previa de Gong y te envía un mensaje privado con un resumen de una página antes de que empiece.",
+        "steps": {
+          "one": {
+            "description": "Zero se activa cuando un asistente externo se une a tu calendario.",
+            "title": "Se añade una reunión"
+          },
+          "three": {
+            "description": "Zero te manda un expediente de una página antes de la llamada.",
+            "title": "Informe de preparación enviado a Slack"
+          },
+          "two": {
+            "description": "Zero enriquece a la persona y a la empresa con Apollo y Gong.",
+            "title": "Investigación del asistente"
+          }
+        },
+        "title": "Prepara las reuniones de Google Calendar"
+      },
+      "publish-scheduled-posts-buffer": {
+        "description": "Cada día, Zero publica en Strapi el contenido programado para hoy en el calendario de Notion y deja las publicaciones sociales en Buffer.",
+        "scenario": "Un calendario de contenido solo funciona si alguien pulsa publicar. Zero lee los elementos programados de hoy de Notion, los publica en Strapi y pone en cola las publicaciones sociales correspondientes en Buffer.",
+        "steps": {
+          "one": {
+            "description": "Zero obtiene de Notion los elementos programados para hoy.",
+            "title": "Zero lee el calendario de hoy"
+          },
+          "three": {
+            "description": "Zero programa las publicaciones promocionales en Buffer.",
+            "title": "Publicaciones sociales en cola en Buffer"
+          },
+          "two": {
+            "description": "Zero publica el contenido en Strapi.",
+            "title": "Publicado en el CMS"
+          }
+        },
+        "title": "Publicar las publicaciones programadas en Buffer"
+      },
+      "report-ai-model-costs-slack": {
+        "description": "Cada día Zero informa del gasto de tokens LLM y la latencia de p95 por modelo y ruta de Langfuse a Slack.",
+        "scenario": "El gasto de los modelos aumenta silenciosamente entre rutas y modelos. Cada día, Zero lee Langfuse y publica el gasto de tokens y la latencia p95 por modelo y ruta para evitar sorpresas en la factura.",
+        "steps": {
+          "one": {
+            "description": "Zero extrae los rastreos de gasto y latencia de tokens para el día.",
+            "title": "Zero lee Langfuse"
+          },
+          "three": {
+            "description": "Zero publica el informe diario de costes y latencia.",
+            "title": "Publicado en Slack"
+          },
+          "two": {
+            "description": "Zero agrega el gasto y la latencia p95 por modelo y por ruta.",
+            "title": "Desglosado por modelo y ruta"
+          }
+        },
+        "title": "Informa los costes de los modelos de IA a Slack"
+      },
+      "research-calendar-meetings": {
+        "description": "Investiga a las personas que vas a conocer antes de cada evento del calendario.",
+        "scenario": "Llegar preparado significa investigar para lo que rara vez tienes tiempo. Zero observa nuevas reuniones, busca a los asistentes y a sus empresas, y te envía un dossier de una página antes de que empiece.",
+        "steps": {
+          "one": {
+            "description": "Zero se activa en nuevos eventos del calendario.",
+            "title": "Se añade una reunión"
+          },
+          "three": {
+            "description": "Zero envía un informe de una página a Slack antes de la llamada.",
+            "title": "Expediente entregado"
+          },
+          "two": {
+            "description": "Zero busca información sobre las personas y la empresa mediante Exa.",
+            "title": "Asistentes investigados"
+          }
+        },
+        "title": "Investiga tus reuniones en el calendario"
+      },
+      "research-new-signups-apollo": {
+        "description": "Investiga cada nuevo registro y publica un breve perfil.",
+        "scenario": "Un nuevo registro solo es una oportunidad si alguien lo detecta a tiempo. Zero consulta Clerk cada hora, investiga al nuevo usuario y su empresa mediante Apollo, y publica un breve perfil en Slack.",
+        "steps": {
+          "one": {
+            "description": "Zero obtiene cada hora los nuevos usuarios de Clerk.",
+            "title": "Zero lee los nuevos registros"
+          },
+          "three": {
+            "description": "Zero publica el perfil de cada registro en el canal.",
+            "title": "Instantánea publicada en Slack"
+          },
+          "two": {
+            "description": "Zero completa el contexto de la persona y de su empresa.",
+            "title": "Investigado con Apollo"
+          }
+        },
+        "title": "Investiga nuevas inscripciones"
+      },
+      "run-daily-query-sheets": {
+        "description": "Ejecuta tu SQL guardado según una programación y añade los resultados a una hoja.",
+        "scenario": "El informe que reconstruyes cada mañana repite la misma consulta y el mismo pegado en una hoja. Zero ejecuta la consulta cada día y escribe los resultados con el formato adecuado directamente en Google Sheets.",
+        "steps": {
+          "one": {
+            "description": "Zero ejecuta tu consulta guardada de solo lectura contra el almacén.",
+            "title": "Zero ejecuta la consulta"
+          },
+          "three": {
+            "description": "Zero añade los resultados a tu hoja de seguimiento.",
+            "title": "Escrito en Google Sheets"
+          },
+          "two": {
+            "description": "Zero da forma a la salida en columnas limpias.",
+            "title": "Resultados formateados"
+          }
+        },
+        "title": "Ejecutar una consulta diaria en Google Sheets"
+      },
+      "send-bugs-github-slack": {
+        "description": "Registra los informes etiquetados como errores en incidencias de GitHub y avisa al equipo en Slack.",
+        "scenario": "Un informe de error solo es útil para los ingenieros si está completo. Zero recoge la etiqueta de error, recopila los pasos de reproducción y el impacto en el cliente, lo archiva limpiamente y lo publica en el canal de ingeniería.",
+        "steps": {
+          "one": {
+            "description": "Zero se activa con la etiqueta de error.",
+            "title": "Una incidencia recibe la etiqueta de error"
+          },
+          "three": {
+            "description": "Zero publica el informe estructurado en Slack.",
+            "title": "Enviado a ingeniería"
+          },
+          "two": {
+            "description": "Zero ensambla pasos, impacto y contexto.",
+            "title": "Reproducción e impacto preparados"
+          }
+        },
+        "title": "Enviar errores a GitHub y Slack"
+      },
+      "sort-gmail-draft-replies": {
+        "description": "Ordena tu bandeja de entrada y redacta las respuestas a los correos que las necesiten.",
+        "scenario": "Una bandeja de entrada llena es un trabajo a tiempo completo. Zero clasifica el correo entrante por urgencia y redacta las respuestas con tu voz para que las leas por encima y apruebes en lugar de escribir desde cero.",
+        "steps": {
+          "one": {
+            "description": "Zero escanea los mensajes de Gmail que llegan.",
+            "title": "Zero lee correo nuevo"
+          },
+          "three": {
+            "description": "Zero prepara las respuestas para que las apruebes.",
+            "title": "Respuestas redactadas"
+          },
+          "two": {
+            "description": "Zero etiqueta lo que te necesita ahora frente a lo que te necesita después.",
+            "title": "Ordenados por urgencia"
+          }
+        },
+        "title": "Ordena Gmail y redacta las respuestas"
+      },
+      "sort-route-zendesk-tickets": {
+        "description": "Cuando llega un ticket de soporte, Zero establece su gravedad, lo redirige al equipo adecuado y redacta una primera respuesta.",
+        "scenario": "Cada ticket necesita un triaje antes de poder responder. Zero lee cada nuevo ticket, asigna la gravedad, lo dirige a la cola correcta y redacta una primera respuesta para que los agentes empiecen desde un borrador, no con una casilla en blanco.",
+        "steps": {
+          "one": {
+            "description": "Zero lee el nuevo ticket de Zendesk.",
+            "title": "Llega un ticket"
+          },
+          "three": {
+            "description": "Zero prepara una primera respuesta coherente con tu marca.",
+            "title": "Primera respuesta redactada"
+          },
+          "two": {
+            "description": "Zero clasifica la urgencia y la envía al equipo adecuado.",
+            "title": "Severidad establecida y enrutada"
+          }
+        },
+        "title": "Clasificar y enrutar tickets de Zendesk"
+      },
+      "spot-churn-risk-stripe-zendesk": {
+        "description": "Marca cuentas en riesgo de abandono y redacta un correo de recuperación.",
+        "scenario": "El abandono solo resulta evidente después de producirse. Zero revisa cada día Stripe y Zendesk para detectar problemas de facturación o aumentos de tickets, señala las cuentas en riesgo y redacta un correo de recuperación.",
+        "steps": {
+          "one": {
+            "description": "Zero lee el estado de facturación de Stripe y el volumen de tickets de Zendesk.",
+            "title": "Zero escanea cuentas"
+          },
+          "three": {
+            "description": "Zero redacta un correo de contacto para su revisión.",
+            "title": "Correo de recuperación redactado"
+          },
+          "two": {
+            "description": "Zero muestra cuentas que muestran señales de abandono.",
+            "title": "Cuentas en riesgo señaladas"
+          }
+        },
+        "title": "Detectar riesgo de abandono en Stripe y Zendesk"
+      },
+      "summarize-gmail-newsletters": {
+        "description": "Resume los boletines que tienes en tu bandeja de entrada en un breve resumen.",
+        "scenario": "Te suscribes a veinte boletines y no lees ninguno. Zero recopila todo lo que has etiquetado como boletín y publica un resumen semanal ordenado para que recibas la señal sin la pila.",
+        "steps": {
+          "one": {
+            "description": "Zero lee los mensajes bajo la etiqueta de Boletines.",
+            "title": "Zero recopila boletines informativos"
+          },
+          "three": {
+            "description": "Zero envía el resumen semanal.",
+            "title": "Publicado en Slack"
+          },
+          "two": {
+            "description": "Zero extrae los puntos clave de cada uno.",
+            "title": "Resumido en un solo resumen"
+          }
+        },
+        "title": "Resumir boletines de Gmail"
+      },
+      "summarize-user-feedback-notion": {
+        "description": "Cada semana, Zero reúne comentarios de Productlane, Typeform, Intercom y GitHub, los agrupa por temas y los ordena en Notion.",
+        "scenario": "Los comentarios están repartidos entre cuatro herramientas y nadie tiene tiempo de leerlos todos. Cada semana, Zero reúne cada fuente, agrupa los comentarios por temas y escribe un resumen priorizado en Notion para destacar las solicitudes principales.",
+        "steps": {
+          "one": {
+            "description": "Zero lee nuevos comentarios de Productlane, Typeform, Intercom y GitHub.",
+            "title": "Zero recopila comentarios"
+          },
+          "three": {
+            "description": "Zero escribe el resumen priorizado en una página de Notion.",
+            "title": "Resumen guardado en Notion"
+          },
+          "two": {
+            "description": "Zero agrupa los comentarios relacionados y ordena los temas por frecuencia.",
+            "title": "Agrupados en temas"
+          }
+        },
+        "title": "Resume las opiniones de los usuarios en Notion"
+      },
+      "summarize-zendesk-tickets-daily": {
+        "description": "Resume los tickets de Zendesk del último día y publica el resultado en Slack.",
+        "scenario": "La acumulación de tickets de soporte pasa desapercibida hasta convertirse en un problema. Cada mañana, Zero resume los tickets del último día por gravedad y antigüedad, y publica el resultado en Slack.",
+        "steps": {
+          "one": {
+            "description": "Zero obtiene los tickets de Zendesk de las últimas 24 horas.",
+            "title": "Zero lee la cola"
+          },
+          "three": {
+            "description": "Zero publica el resumen diario de soporte.",
+            "title": "Publicado en Slack"
+          },
+          "two": {
+            "description": "Zero organiza los tickets abiertos y señala los obsoletos.",
+            "title": "Agrupados por gravedad y edad"
+          }
+        },
+        "title": "Resumir diariamente los tickets de Zendesk"
+      },
+      "sync-asana-projects-notion": {
+        "description": "Reúne el estado de los proyectos de Asana en un único tablero de Notion.",
+        "scenario": "El estado está en Asana pero la dirección lee Notion. Zero agrupa el estado de la tarea diariamente en un solo tablero de Notion y publica un resumen para que todos vean la misma imagen sin una reunión de estado.",
+        "steps": {
+          "one": {
+            "description": "Zero recopila el estado de tareas y proyectos entre equipos.",
+            "title": "Zero lee Asana"
+          },
+          "three": {
+            "description": "Zero publica un resumen en Slack.",
+            "title": "Resumen publicado"
+          },
+          "two": {
+            "description": "Zero actualiza un único tablero de estado en Notion.",
+            "title": "Agrupados en un solo tablero"
+          }
+        },
+        "title": "Sincronizar proyectos de Asana con Notion"
+      },
+      "sync-linear-roadmap-notion": {
+        "description": "Mantén una hoja de ruta de Notion sincronizada con el estado de las incidencias de Linear.",
+        "scenario": "Las hojas de ruta quedan obsoletas en cuanto cambia un ticket. Cada día, Zero sincroniza el estado de Linear con un tablero Ahora / Próximo / Más adelante de Notion para que la hoja de ruta siempre refleje la realidad.",
+        "steps": {
+          "one": {
+            "description": "Zero recopila los estados actuales de los tickets y los hitos.",
+            "title": "Zero lee el estado de Linear"
+          },
+          "three": {
+            "description": "Zero actualiza el tablero de la hoja de ruta en Notion.",
+            "title": "Tablero actualizado en Notion"
+          },
+          "two": {
+            "description": "Zero distribuye el trabajo entre las columnas de la hoja de ruta.",
+            "title": "Asignado a Ahora / Próximo / Más adelante"
+          }
+        },
+        "title": "Sincronizar la hoja de ruta de Linear con Notion"
+      },
+      "track-feature-usage-posthog": {
+        "description": "Destaca los mayores cambios semanales en el uso de funciones según PostHog.",
+        "scenario": "Nadie nota que una función pierde uso silenciosamente hasta que se convierte en un problema. Zero revisa PostHog semanalmente y publica qué funciones están subiendo o bajando para que el equipo vea cambios en la adopción temprano.",
+        "steps": {
+          "one": {
+            "description": "Zero extrae el uso de funciones de la semana.",
+            "title": "Zero lee PostHog"
+          },
+          "three": {
+            "description": "Zero publica los cambios de adopción en tu canal.",
+            "title": "Cambios publicados en Slack"
+          },
+          "two": {
+            "description": "Zero encuentra las funciones que más suben y bajan.",
+            "title": "Comparado semana tras semana"
+          }
+        },
+        "title": "Seguir el uso de funciones con PostHog"
+      },
+      "track-keyword-ranks-ahrefs": {
+        "description": "Cada semana, Zero sigue la posición de las palabras clave objetivo en Ahrefs e informa de los mayores cambios en Notion.",
+        "scenario": "El seguimiento de posiciones exige exportar y comparar datos manualmente. Cada semana, Zero obtiene tus palabras clave objetivo, compara sus posiciones y escribe los mayores cambios en Notion para mostrar claramente los avances y retrocesos de SEO.",
+        "steps": {
+          "one": {
+            "description": "Zero extrae los rankings actuales de Ahrefs.",
+            "title": "Zero lee posiciones por palabras clave"
+          },
+          "three": {
+            "description": "Zero escribe en Notion los mayores cambios y su tendencia.",
+            "title": "Reportado en Notion"
+          },
+          "two": {
+            "description": "Zero compara con la semana pasada y encuentra los mayores cambios.",
+            "title": "Mayores cambios identificados"
+          }
+        },
+        "title": "Seguir posiciones de palabras clave con Ahrefs"
+      },
+      "track-signup-sources-sheets": {
+        "description": "Atribuye cada nuevo registro a su fuente en una hoja de seguimiento.",
+        "scenario": "Saber de dónde proceden los registros suele exigir conectar Clerk con las analíticas a mano. Cada día, Zero atribuye cada registro a su canal y campaña, y lo guarda en una hoja de Google Sheets que puedes analizar.",
+        "steps": {
+          "one": {
+            "description": "Zero obtiene los nuevos usuarios de Clerk.",
+            "title": "Zero lee los nuevos registros"
+          },
+          "three": {
+            "description": "Zero añade las filas atribuidas a tu hoja.",
+            "title": "Registrado en Google Sheets"
+          },
+          "two": {
+            "description": "Zero empareja cada registro con su fuente y campaña a través de Plausible.",
+            "title": "Atribuido a un canal"
+          }
+        },
+        "title": "Seguir las fuentes de registro en Google Sheets"
+      },
+      "watch-brand-mentions": {
+        "description": "Cada hora Zero busca en internet, Hacker News y X menciones de tu producto y las publica en Slack.",
+        "scenario": "Cuando encuentras un hilo sobre tu producto, la conversación ya ha avanzado. Zero busca cada hora en la web, Reddit y X, y publica las menciones nuevas en Slack para que puedas participar a tiempo.",
+        "steps": {
+          "one": {
+            "description": "Zero escanea la web, Reddit y X con Exa.",
+            "title": "Zero busca menciones"
+          },
+          "three": {
+            "description": "Zero publica cada mención con un enlace y contexto.",
+            "title": "Publicado en Slack"
+          },
+          "two": {
+            "description": "Zero conserva solo los resultados nuevos y relevantes.",
+            "title": "Nuevas menciones filtradas"
+          }
+        },
+        "title": "Vigilar menciones de marca en HN y X"
+      },
+      "watch-sentry-after-release": {
+        "description": "Después de cada versión, Zero compara la tasa sin fallos con la referencia y avisa de cualquier regresión con una sugerencia de reversión.",
+        "scenario": "La ventana más arriesgada es justo después de un despliegue. Zero observa las tasas de fallo y errores de la nueva versión respecto a la línea base anterior, y si la cosa empeora marca la regresión y sugiere revertir.",
+        "steps": {
+          "one": {
+            "description": "Después de un despliegue, Zero sigue en Sentry la tasa sin fallos y la tasa de errores de la versión.",
+            "title": "Zero vigila la nueva versión"
+          },
+          "three": {
+            "description": "Si la versión empeora, Zero avisa en Slack y sugiere revertirla.",
+            "title": "Regresión detectada con una sugerencia de reversión"
+          },
+          "two": {
+            "description": "Zero compara los números en directo con la línea base del lanzamiento anterior.",
+            "title": "Comparado con la línea base"
+          }
+        },
+        "title": "Vigilar Sentry después de una versión"
+      }
+    }
+  },
+  "queue": {
+    "concurrentRuns_one": "{{count}} ejecución simultánea",
+    "concurrentRuns_many": "{{count}} ejecuciones simultáneas",
+    "concurrentRuns_other": "{{count}} ejecuciones simultáneas",
+    "description": "Consulta tu posición en la cola y mejora para evitar la espera.",
+    "perMonth": "/mes",
+    "pricePerMonth": "{{price}}/mes",
+    "purchase": {
+      "addOn": "Complemento",
+      "addsToLimit": "Añade a tu límite actual",
+      "appliedAfterCheckout": "Se aplica al finalizar el pago",
+      "buy": "Compra {{price}} al mes",
+      "decreaseQuantity": "Reducir la cantidad de concurrencia",
+      "description": "Añade ejecuciones simultáneas dedicadas a este espacio de trabajo, facturadas mensualmente.",
+      "increaseQuantity": "Aumentar la cantidad de concurrencia",
+      "quantity": "Cantidad",
+      "subscription_one": "{{count}} cupo con suscripción mensual",
+      "subscription_many": "{{count}} cupos con suscripción mensual",
+      "subscription_other": "{{count}} cupos con suscripción mensual",
+      "title": "Concurrencia adicional"
+    },
+    "redirecting": "Redirigiendo...",
+    "status": {
+      "atLimit_one": "Solo puedes ejecutar {{limit}} tarea a la vez. Las nuevas ejecuciones esperarán en la cola hasta que termine una.",
+      "atLimit_many": "Solo puedes ejecutar {{limit}} tareas a la vez. Las nuevas ejecuciones esperarán en la cola hasta que termine una.",
+      "atLimit_other": "Solo puedes ejecutar {{limit}} tareas a la vez. Las nuevas ejecuciones esperarán en la cola hasta que termine una.",
+      "available_one": "{{count}} cupo disponible",
+      "available_many": "{{count}} cupos disponibles",
+      "available_other": "{{count}} cupos disponibles",
+      "inUse_one": "{{active}} de {{limit}} cupo en uso",
+      "inUse_many": "{{active}} de {{limit}} cupos en uso",
+      "inUse_other": "{{active}} de {{limit}} cupos en uso"
+    },
+    "tiers": {
+      "custom": "Personalizado",
+      "free": "Gratis",
+      "limitedFree": "Gratis limitado",
+      "noPlan": "Sin plan",
+      "pro": "Pro",
+      "team": "Equipo"
+    },
+    "title": "Tu agente está esperando en la fila",
+    "upgrade": {
+      "action": "Actualizar a {{plan}}",
+      "features": {
+        "creditsPerMonth": "{{credits}} créditos / mes",
+        "emailSupport": "Soporte por correo electrónico",
+        "ownKeys": "Lleva tus propias llaves de LLM",
+        "payAsYouGo": "Paga según la compra después",
+        "prioritySupport": "Soporte prioritario",
+        "unlimitedAgents": "Agentes totales ilimitados"
+      },
+      "proDescription": "Ejecuta varias tareas en paralelo y salta la cola.",
+      "recommended": "Recomendado",
+      "teamDescription": "Amplía tu equipo con 10 ejecuciones paralelas y más créditos."
+    }
+  },
+  "reportError": {
+    "description": "Envía la información diagnóstica de esta ejecución fallida al equipo de desarrollo. Investigaremos y haremos seguimiento en breve.",
+    "disclosure": {
+      "agentConfiguration": "Configuración del agente",
+      "agentTelemetry": "Telemetría de agentes y registros de ejecución",
+      "chatHistory": "Historial de chat y eventos de agentes",
+      "connectedServices": "Servicios conectados (sin credenciales)",
+      "networkLogs": "Registros de solicitudes de red",
+      "runContext": "Contexto de ejecución y entorno",
+      "title": "¿Qué se enviará?"
+    },
+    "documentTitle": "Error de reporte",
+    "error": {
+      "loadFailed": "No se han cargado los detalles de la ejecución",
+      "notFailed": "Esta ejecución no falló y no se puede informar de ella",
+      "title": "Error",
+      "tryAgain": "Inténtalo de nuevo"
+    },
+    "fields": {
+      "description": "Descripción",
+      "descriptionPlaceholder": "¿Qué ha pasado? ¿Qué esperabas?",
+      "title": "Título",
+      "titlePlaceholder": "Breve resumen del asunto"
+    },
+    "loading": "Cargando los detalles de la ejecución",
+    "send": "Enviar Informe",
+    "sending": "Enviando...",
+    "success": {
+      "description": "Tu informe de error ha sido enviado al equipo de desarrolladores. Ellos investigarán y harán seguimiento.",
+      "reference": "Referencia: {{reference}}",
+      "title": "Informe enviado"
+    },
+    "title": "Reportar error al desarrollador"
+  },
+  "settings": {
+    "accountMenu": {
+      "addAccount": "Añadir cuenta",
+      "creditBalance_one": "{{value}} crédito",
+      "creditBalance_many": "{{value}} créditos",
+      "creditBalance_other": "{{value}} créditos",
+      "exportData": "Exportar datos",
+      "lab": "Laboratorio",
+      "settings": "Configuración",
+      "signOut": "Cerrar sesión",
+      "subscriptions": {
+        "providers": {
+          "claudeCode": "Claude Code",
+          "codex": "Codex"
+        },
+        "reset": "Restablecer",
+        "resetTimeUnavailable": "Hora de reinicio no disponible",
+        "usage": "Uso de {{provider}}",
+        "usageRemaining": "{{window}} restante de {{provider}}",
+        "windows": {
+          "fiveHour": "5h",
+          "week": "semana"
+        }
+      },
+      "switchAccount": "Cambiar de cuenta",
+      "userFallback": "Usuario"
+    },
+    "buildInfo": {
+      "backend": "Backend",
+      "commitSha": "SHA del commit",
+      "frontend": "Frontend",
+      "loading": "Cargando",
+      "title": "Información de compilación",
+      "unavailable": "No disponible"
+    },
+    "dialog": {
+      "description": "Gestiona tu cuenta, preferencias, espacio de trabajo y configuración de facturación.",
+      "groups": {
+        "billing": "Facturación y precios",
+        "models": "Modelos",
+        "personal": "Personal",
+        "workspace": "Espacio de trabajo"
+      },
+      "sections": {
+        "billing": {
+          "description": "Gestiona tu plan y método de pago.",
+          "title": "Facturación"
+        },
+        "debug": {
+          "description": "Diagnósticos y herramientas para desarrolladores.",
+          "title": "Depuración"
+        },
+        "general": {
+          "description": "Gestiona tu perfil y ajustes de espacio de trabajo.",
+          "title": "General"
+        },
+        "invoices": {
+          "description": "Consulta y descarga facturas anteriores.",
+          "title": "Facturas"
+        },
+        "model": {
+          "description": "Elige qué modelos de IA utilizarán tu espacio de trabajo y tus ejecuciones.",
+          "title": "Modelos"
+        },
+        "people": {
+          "description": "Gestiona quién tiene acceso a este espacio de trabajo.",
+          "title": "Personas"
+        },
+        "preference": {
+          "description": "Personaliza cómo se ve y se comporta la app.",
+          "title": "Preferencias"
+        },
+        "usage": {
+          "balanceDescription": "El saldo y el consumo de créditos de tu equipo.",
+          "balanceTitle": "Saldo de créditos",
+          "usageDescription": "Tu consumo de créditos en conversaciones, automatizaciones y canales.",
+          "usageTitle": "Consumo de créditos"
+        }
+      },
+      "title": "Configuración"
+    },
+    "export": {
+      "actions": {
+        "again": "Exportar de nuevo",
+        "download": "Descargar exportación",
+        "start": "Exportar mis datos",
+        "starting": "Iniciando la exportación"
+      },
+      "backToZero": "Volver a Zero",
+      "description": "Descarga los archivos y registros de texto que creaste en Zero.",
+      "documentTitle": "Datos de exportación",
+      "duration": {
+        "soon": "Pronto"
+      },
+      "errors": {
+        "loadFailed": "No se pudo cargar la exportación",
+        "rateLimited": "Puedes exportar una vez cada 24 horas.",
+        "startFailed": "No se inició la exportación"
+      },
+      "scope": {
+        "agentInstructions": "Documentos de instrucción del agente",
+        "artifactsExcluded": "Los artefactos no están incluidos en esta exportación.",
+        "chatMessages": "Mensajes de chat de texto de usuarios y asistentes",
+        "memoryFiles": "Archivos de memoria",
+        "workflowInstructions": "Instrucciones y archivos SKILL.md de los flujos de trabajo"
+      },
+      "status": {
+        "checkingDescription": "Tu último estado de exportación aparecerá aquí.",
+        "checkingTitle": "Comprobación del estado de exportación",
+        "downloadExpires": "El enlace de descarga expira en {{duration}}.",
+        "downloadNoExpiry": "Descárgalo antes de que el enlace expire.",
+        "downloadTitle": "Tu exportación está lista",
+        "expiredDescription": "Inicia una nueva exportación para obtener otro enlace de descarga.",
+        "expiredTitle": "La exportación anterior expiró",
+        "failedDescription": "Inténtalo de nuevo, o contacta con soporte si esto sigue pasando.",
+        "failedTitle": "La exportación no terminó",
+        "preparingDescription": "Esto puede tardar unos minutos. Puedes dejar esta página abierta.",
+        "preparingTitle": "Preparando tu exportación",
+        "rateLimitedFallback": "Puedes empezar otra exportación cuando termine el tiempo de reutilización.",
+        "rateLimitedTitle": "Exportación solicitada recientemente",
+        "rateLimitedUntil": "Puedes empezar otra exportación en {{duration}}.",
+        "readyDescription": "Crea un archivo ZIP con los datos de tu espacio de trabajo.",
+        "readyTitle": "Listo para exportar"
+      },
+      "title": "Datos de exportación"
+    },
+    "lab": {
+      "actions": {
+        "resetAll": "Reiniciar todo",
+        "resetting": "Reiniciando..."
+      },
+      "description": "Activa o desactiva funciones experimentales.",
+      "documentTitle": "Laboratorio",
+      "empty": {
+        "description": "No hay funciones experimentales para este responsable.",
+        "title": "Sin funciones experimentales"
+      },
+      "filters": {
+        "all": "Todos"
+      },
+      "groups": {
+        "connectors": "Conectores",
+        "other": "Otro"
+      },
+      "maintainer": "Responsable: {{maintainer}}",
+      "title": "Laboratorio"
+    },
+    "models": {
+      "actions": {
+        "addModel": "Añadir modelo",
+        "deleteModel": "Eliminar modelo",
+        "editModel": "Editar modelo",
+        "resetUsage": "Restablecer uso",
+        "upgradePro": "Mejorar a Pro para usarlo",
+        "upgradeToPro": "Mejorar a Pro"
+      },
+      "deviceAuth": {
+        "claude": {
+          "approvalOpenError": "La página de aprobación no se pudo abrir. Usa el enlace manualmente y pega el código aquí.",
+          "authorizationCode": "Código de autorización",
+          "codePlaceholder": "Pega el código de Claude",
+          "codeRequired": "Pega el código de autorización de Claude Code para continuar.",
+          "connectedToast": "Claude Code conectado",
+          "connectTitle": "Conectar Claude Code",
+          "error": "Falló la conexión con Claude Code. Empieza de nuevo para reintentarlo.",
+          "expired": "La sesión de conexión con Claude Code ha caducado. Empieza de nuevo para reintentarlo.",
+          "instructions": "Primero, haz clic en Abrir la página de aprobación de Claude. Después, aprueba {{brandName}} en Claude y copia el código de autorización que aparecerá. Por último, pega el código aquí y haz clic en Conectar.",
+          "openApproval": "Abrir la página de aprobación de Claude",
+          "preparing": "Preparando...",
+          "reconnectAction": "Volver a conectar Claude Code",
+          "reconnectTitle": "Volver a conectar Claude Code",
+          "signIn": "Inicia sesión con Claude",
+          "submit": "Conectar"
+        },
+        "codex": {
+          "approvalOpened": "Página de aprobación abierta. Copia el código del dispositivo antes de aprobar.",
+          "codeCopied": "Código del dispositivo copiado. Esperando aprobación...",
+          "codeCopiedRetry": "Código del dispositivo copiado. Intenta abrir la página de aprobación de nuevo.",
+          "connectedToast": "ChatGPT conectado",
+          "connectTitle": "Conecta Codex",
+          "copyAndOpen": "Copiar código y abrir la página de aprobación",
+          "copyAndOpenError": "No se pudo copiar el código del dispositivo ni abrir la página de aprobación. Copia el código manualmente e inténtalo de nuevo.",
+          "copyError": "Se abrió la página de aprobación, pero el código del dispositivo no se copió. Cópialo manualmente antes de aprobar.",
+          "deviceCode": "Código del dispositivo",
+          "error": "Falló la conexión con ChatGPT. Empieza de nuevo para reintentarlo.",
+          "expired": "La sesión de conexión con Codex ha caducado. Empieza de nuevo para reintentarlo.",
+          "freePlanRejected": "Los planes gratuitos de ChatGPT no permiten usar Codex mediante {{brandName}}. Mejora a Plus o Pro e inténtalo de nuevo.",
+          "instructions": "Primero haz clic en Copiar código y abre la página de aprobación. Luego pega el código del dispositivo en OpenAI cuando te lo pidan. Finalmente, aprueba el acceso y mantén este diálogo abierto mientras {{brandName}} termina la conexión.",
+          "invalidTokenFormat": "Codex generó un formato de token de inicio de sesión que {{brandName}} no reconoce. Actualiza Codex e inténtalo de nuevo.",
+          "openError": "Código del dispositivo copiado, pero la página de aprobación no pudo abrirse. Inténtalo de nuevo.",
+          "preparing": "Preparando...",
+          "reconnectAction": "Volver a conectar ChatGPT",
+          "reconnectTitle": "Volver a conectar Codex",
+          "signIn": "Inicia sesión con ChatGPT"
+        }
+      },
+      "personal": {
+        "actionForProvider": "{{action}} {{provider}}",
+        "claudeDescription": "Conecta tu cuenta de Claude Code para usar rutas de modelos basadas en Claude.",
+        "claudeTitle": "OAuth de Claude Code",
+        "codexDescription": "Conecta tu cuenta mediante el inicio de sesión de dispositivo de Codex para usar rutas de modelos basadas en Codex.",
+        "codexTitle": "ChatGPT (Codex)",
+        "description": "Solo se usa en tus ejecuciones y con tus propias credenciales.",
+        "sectionTitle": "Personal",
+        "status": {
+          "connected": "Conectado",
+          "connectedWithDetail": "Conectado ({{detail}})",
+          "fiveHour": "5h",
+          "left": "{{percent}} restante",
+          "stale": "Atención",
+          "week": "Semana"
+        }
+      },
+      "picker": {
+        "balancedUse": "Uso equilibrado",
+        "builtInModel": "Modelo integrado",
+        "byokHelp": "Usa el proveedor que has configurado",
+        "fast": "Rápido",
+        "inheritDefault": "Heredar el valor predeterminado de la organización",
+        "loadError": "No se pudieron cargar los modelos.",
+        "loading": "Cargando modelos...",
+        "models": "Modelos",
+        "moreCodexCredits": "Consume más créditos de Codex.",
+        "noConfiguredModels": "Sin modelos configurados",
+        "priceTiers": {
+          "balanced": "Coste y rendimiento equilibrados",
+          "economy": "Nivel económico para tareas cotidianas y sencillas",
+          "frontier": "Modelo insignia de última generación",
+          "premium": "Modelo prémium de última generación para las tareas más difíciles"
+        },
+        "prioritizeSpeed": "Priorizar la velocidad",
+        "pro": "Pro",
+        "providerLabels": {
+          "azureFoundryPortal": "Portal de Azure AI Foundry",
+          "claudeCodeOauth": "Claude Code (token OAuth)",
+          "deepseek": "Deepseek"
+        },
+        "runSpeed": "Velocidad de ejecución",
+        "standard": "Estándar"
+      },
+      "policies": {
+        "actionsFor": "Acciones para {{model}}",
+        "apiKey": "Clave API",
+        "apiKeyDescription": "Una clave compartida por el espacio de trabajo, ideal cuando el equipo factura mediante una sola cuenta.",
+        "apiKeyPlaceholder": "Introduce tu clave API",
+        "apiKeyRequired": "Se requiere clave API",
+        "builtIn": "Integrado",
+        "builtInDescription": "Los créditos de espacio de trabajo cubren el uso.",
+        "claudeSubscription": "Suscripción de Claude",
+        "claudeSubscriptionDescription": "Cada miembro conecta su propio plan Pro, Max o Equipo.",
+        "codexSubscription": "Suscripción de Codex",
+        "codexSubscriptionDescription": "Cada miembro conecta su propio plan Pro o Equipo.",
+        "defaultModel": "Modelo por defecto",
+        "defaultModelDescription": "Se usa cuando una tarea no elige su propio modelo.",
+        "dialogDescription": "Decide cómo acceden los miembros a este modelo.",
+        "getKey": "Obtener una clave",
+        "invalidRoute": "Ruta inválida",
+        "missingProvider": "Falta el proveedor",
+        "model": "Modelo",
+        "noAvailableModels": "No hay modelos disponibles",
+        "providedBy": "Proporcionado por",
+        "provider": "Proveedor",
+        "providerApiKey": "Clave API de {{provider}}",
+        "secretStored": "Almacenado en secretos del espacio de trabajo.",
+        "selectDefaultModel": "Seleccionar un modelo por defecto",
+        "selectModel": "Selecciona un modelo",
+        "selectProvider": "Selecciona un proveedor",
+        "workspaceDescription": "Disponible para todos en este espacio de trabajo.",
+        "workspaceTitle": "Espacio de trabajo"
+      },
+      "reset": {
+        "confirmDescription": "Usa un restablecimiento de Codex para reiniciar tus periodos de consumo actuales. Te quedan {{remaining}}.",
+        "progress": "Reiniciando...",
+        "remaining_one": "Queda {{value}} restablecimiento",
+        "remaining_many": "Quedan {{value}} restablecimientos",
+        "remaining_other": "Quedan {{value}} restablecimientos",
+        "remainingUnavailable": "Reinicios no disponibles",
+        "title": "¿Restablecer el uso de Codex?"
+      },
+      "stale": {
+        "claudeExpired": "Tu sesión de Claude Code ha caducado. Vuelve a conectarla para continuar.",
+        "claudeFailed": "No se pudo actualizar Claude Code. Vuelve a conectarlo para reintentarlo.",
+        "claudeTitle": "La sesión de Claude Code debe volver a conectarse",
+        "codexExpired": "Tu sesión de ChatGPT ha expirado. Reconecta para continuar.",
+        "codexFailed": "Falló el refresco de ChatGPT. Reconecta para intentarlo de nuevo.",
+        "codexInvalidated": "Tu sesión de ChatGPT ha sido revocada. Reconecta.",
+        "codexReused": "Tu sesión de ChatGPT se usó en otro sitio. Reconéctate.",
+        "codexTitle": "La sesión de ChatGPT necesita reconexión"
+      },
+      "toasts": {
+        "disconnected": "{{provider}} desconectado",
+        "policiesUpdated": "Configuración del proveedor de modelos actualizada",
+        "reset": "Uso de Codex restablecido",
+        "resetUnavailable": "No hay reinicios de uso de Codex disponibles",
+        "resetUnneeded": "No es necesario restablecer el uso de Codex ahora"
+      },
+      "usage": {
+        "inDays": "en {{days}}d",
+        "inDaysHours": "en {{days}}d {{hours}}h",
+        "inHours": "en {{hours}}h",
+        "inHoursMinutes": "en {{hours}}h {{minutes}}m",
+        "inLessThanMinute": "en <1 min",
+        "inMinutes": "en {{minutes}}m",
+        "resetsAt": "se restablece el {{date}}",
+        "resetsRaw": "se restablece {{value}}",
+        "resetsRelative": "Se restablece {{relative}}",
+        "resetTimePassed": "Ya pasó la hora de restablecimiento",
+        "resetTimePassedTitle": "Ya pasó la hora de restablecimiento"
+      }
+    },
+    "preferences": {
+      "account": {
+        "manage": "Gestionar",
+        "sectionTitle": "Cuenta y seguridad"
+      },
+      "appearance": {
+        "description": "Elige cómo queda la interfaz.",
+        "sectionTitle": "Apariencia",
+        "theme": {
+          "dark": "Oscuro",
+          "description": "Tu esquema de colores preferido",
+          "light": "Claro",
+          "system": "Sistema",
+          "title": "Tema"
+        }
+      },
+      "debug": {
+        "capture": {
+          "description": "Captura los nombres de cabeceras HTTP, los valores de cabecera seguros seleccionados y los cuerpos en los registros de red para la depuración.",
+          "disabled": "Deshabilitado",
+          "enabled_one": "Activado para la próxima {{count}} ejecución",
+          "enabled_many": "Activado para las próximas {{count}} ejecuciones",
+          "enabled_other": "Activado para las próximas {{count}} ejecuciones",
+          "title": "Capturar cuerpos de red"
+        },
+        "tab": "Depuración"
+      },
+      "documentTitle": "Preferencias",
+      "language": {
+        "description": "Elige tu idioma preferido para la interfaz de {{brandName}}",
+        "label": "Idioma",
+        "options": {
+          "english": "English",
+          "japanese": "日本語",
+          "portugueseBrazil": "Português (Brasil)",
+          "spanish": "Español"
+        },
+        "title": "Idioma"
+      },
+      "morningBrief": {
+        "description": "Un correo diario a las 7:00 de la mañana con tu agenda, acciones y actualizaciones de GitHub, Gmail y Google Calendar",
+        "nextEmail": "Siguiente correo: {{date}}",
+        "nextEmailInTimezone": "Siguiente correo: {{date}} ({{timezone}})",
+        "notScheduled": "Siguiente correo: aún no está programado — apaga y enciende el interruptor para reprogramar",
+        "sending": "Enviando...",
+        "sendNow": "Enviar ahora",
+        "title": "Resumen matutino",
+        "triggeredToast": "Se inició el resumen matutino; el correo llegará en breve"
+      },
+      "pageDescription": "Gestiona la apariencia y las preferencias de ejecución de tus agentes",
+      "pageTitle": "Preferencias",
+      "send": {
+        "cmdEnter": "⌘ Enter",
+        "cmdEnterDescription": "Pulsa ⌘/Ctrl+Enter para enviar, Enter para nueva línea",
+        "description": "Elige cómo enviar mensajes en el chat.",
+        "enter": "Enter",
+        "enterDescription": "Pulsa Enter para enviar, Shift+Enter para nueva línea",
+        "sectionTitle": "Tecla Enter",
+        "title": "Enviar mensaje con"
+      },
+      "tabs": {
+        "appearance": "Apariencia",
+        "models": "Modelos personales",
+        "timezone": "Zona horaria"
+      },
+      "timezone": {
+        "description": "Tiempos que se te muestran y se usan para las ejecuciones de automatización.",
+        "rowDescription": "Tus agentes usarán esta zona horaria durante las ejecuciones",
+        "rowTitle": "Zona horaria",
+        "sectionTitle": "Zona horaria",
+        "zones": {
+          "alaska": "Hora de Alaska (AKT)",
+          "auckland": "Hora de Nueva Zelanda (NZST)",
+          "berlin": "Hora de Europa Central (CET)",
+          "brasilia": "Hora de Brasília (BRT)",
+          "central": "Hora Central (CT)",
+          "dubai": "Hora estándar del Golfo (GST)",
+          "eastern": "Hora del Este (ET)",
+          "hawaii": "Hora de Hawái (HST)",
+          "india": "Hora Estándar de India (IST)",
+          "london": "Londres (GMT/BST)",
+          "losAngeles": "Hora del Pacífico (PT)",
+          "moscow": "Hora de Moscú (MSK)",
+          "mountain": "Hora de la Montaña (MT)",
+          "paris": "París (CET)",
+          "seoul": "Hora Estándar de Corea (KST)",
+          "shanghai": "Hora Estándar de China (CST)",
+          "singapore": "Hora de Singapur (SGT)",
+          "sydney": "Hora del Este de Australia (AET)",
+          "tokyo": "Hora Estándar de Japón (JST)",
+          "toronto": "Toronto (ET)",
+          "utc": "UTC",
+          "vancouver": "Vancouver (PT)"
+        }
+      }
+    },
+    "shared": {
+      "cancel": "Cancelar",
+      "close": "Cerrar",
+      "connect": "Conectar",
+      "connecting": "Conectando...",
+      "delete": "Eliminar",
+      "discard": "Descartar",
+      "disconnect": "Desconectar",
+      "loading": "Cargando",
+      "moreOptions": "Más opciones",
+      "reconnect": "Volver a conectar",
+      "remove": "Eliminar",
+      "replace": "Reemplazar",
+      "save": "Guardar",
+      "saveChanges": "Guardar cambios",
+      "saving": "Guardando..."
+    },
+    "workspace": {
+      "danger": {
+        "delete": {
+          "button": "Eliminar espacio de trabajo",
+          "confirmDescription": "Esto eliminará permanentemente {{workspace}} y todos sus datos. Esta acción no puede deshacerse. Escribe el nombre del espacio de trabajo para confirmarlo.",
+          "description": "Elimina permanentemente este espacio de trabajo y todos sus datos. Esta acción no puede deshacerse.",
+          "progress": "Eliminando...",
+          "title": "Eliminar espacio de trabajo",
+          "titleQuestion": "¿Eliminar el espacio de trabajo?"
+        },
+        "leave": {
+          "confirmDescription": "Ya no tendrás acceso a este espacio de trabajo. Solo podrás volver a unirte si un administrador te invita de nuevo.",
+          "description": "Perderás el acceso a este espacio de trabajo y a sus recursos.",
+          "progress": "Irse...",
+          "title": "Salir del espacio de trabajo",
+          "titleQuestion": "¿Salir del espacio de trabajo?"
+        },
+        "sectionTitle": "Zona de peligro"
+      },
+      "members": {
+        "actionsFor": "Acciones para {{email}}",
+        "addMember": "Añadir miembro",
+        "admin": "Administrador",
+        "empty": "Sin miembros",
+        "emptySearch": "No se encuentran miembros",
+        "invite": {
+          "description": "Envía una invitación para unirte a este espacio de trabajo.",
+          "emailPlaceholder": "email@example.com",
+          "invalidEmail": "Introduce una dirección de correo electrónico válida",
+          "progress": "Enviando...",
+          "roleLabel": "Rol",
+          "send": "Enviar invitación",
+          "title": "Invitar a un miembro"
+        },
+        "joined": "Se unió",
+        "joinRequests": "Solicitudes de acceso",
+        "member": "Miembro",
+        "membershipRequest": {
+          "acceptTitle": "Aceptar solicitud",
+          "rejectTitle": "Rechazar solicitud",
+          "role": "Solicitud"
+        },
+        "pending": "Pendiente",
+        "remove": {
+          "action": "Quitar del espacio de trabajo",
+          "confirmDescription": "{{email}} será eliminado de este espacio de trabajo y perderá el acceso a todos los recursos.",
+          "progress": "Eliminando...",
+          "title": "¿Eliminar a un miembro?"
+        },
+        "revoke": {
+          "action": "Revocar invitación",
+          "button": "Revocar",
+          "confirmDescription": "La invitación a {{email}} será cancelada. Ya no podrán unirse usando esta invitación.",
+          "progress": "Revocando...",
+          "title": "¿Revocar la invitación?"
+        },
+        "role": "Rol",
+        "roleActions": {
+          "makeAdmin": "Convertir en administrador",
+          "makeMember": "Convertir en miembro"
+        },
+        "search": "Buscar",
+        "selfDemote": {
+          "action": "Cambiar a miembro",
+          "confirm": "Confirmar",
+          "description": "Te convertirás en miembro regular y perderás los privilegios de administrador. Otro administrador tendrá que ascenderte de nuevo.",
+          "progress": "Cambiar...",
+          "title": "¿Cambiar a miembro?"
+        },
+        "user": "Usuario",
+        "you": "Tú"
+      },
+      "profile": {
+        "logo": {
+          "description": "Avatar del espacio de trabajo mostrado en toda la app",
+          "fallbackAlt": "Espacio de trabajo",
+          "title": "Logotipo",
+          "upload": "Subir logotipo"
+        },
+        "name": {
+          "description": "Se usa para identificar este espacio de trabajo",
+          "placeholder": "Nombre del espacio de trabajo",
+          "title": "Nombre"
+        },
+        "sectionTitle": "Perfil"
+      },
+      "toasts": {
+        "deleted": "Espacio de trabajo eliminado",
+        "invitationRevoked": "Invitación revocada",
+        "invitationSent": "Invitación enviada a {{email}}",
+        "left": "Has salido del espacio de trabajo",
+        "memberRemoved": "Eliminado {{email}}",
+        "membershipRequestAccepted": "Solicitud de membresía aceptada",
+        "membershipRequestRejected": "Solicitud de membresía rechazada",
+        "roleUpdated": "Rol actualizado para {{email}}",
+        "updated": "Espacio de trabajo actualizado"
+      },
+      "unsaved": {
+        "message": "Tienes cambios sin guardar"
+      },
+      "validation": {
+        "imageUnreadable": "No se pudo leer el archivo de imagen",
+        "logoTooLarge": "El logotipo es demasiado grande ({{width}}×{{height}}px). El tamaño máximo es {{maximum}}×{{maximum}}px.",
+        "logoTooSmall": "El logo es demasiado pequeño ({{width}}×{{height}}px). El tamaño mínimo es {{minimum}}×{{minimum}}px."
+      }
+    }
+  },
+  "shared": {
+    "breadcrumb": "Ruta de navegación",
+    "errorBoundary": {
+      "contactSupport": "soporte",
+      "description": "Inténtalo de nuevo o contacta",
+      "help": "Estamos aquí para ayudarte",
+      "title": "¡Ups! Algo salió mal"
+    },
+    "forceUpgrade": {
+      "action": "Actualizar",
+      "description": "Esta versión de {{brandName}} ya no es compatible. Actualiza para cargar la última versión.",
+      "title": "Se requiere actualización"
+    },
+    "notFound": {
+      "description": "La página que buscas no existe.",
+      "title": "Página no encontrada"
+    }
+  },
+  "usage": {
+    "automations": {
+      "empty": "No se usaron automatizaciones en este periodo",
+      "more_one": "+{{value}} más automatización",
+      "more_many": "+{{value}} más automatizaciones",
+      "more_other": "+{{value}} más automatizaciones",
+      "summary_one": "{{automations}} usó {{credits}}",
+      "summary_many": "{{automations}} usaron {{credits}}",
+      "summary_other": "{{automations}} usaron {{credits}}",
+      "title": "Automatizaciones"
+    },
+    "chart": {
+      "ariaLabel": "Total de créditos",
+      "credits": "Créditos",
+      "groupBy": {
+        "agent": "Agente",
+        "source": "Fuente"
+      },
+      "noUsage": "No hay uso",
+      "showDetails": "Mostrar detalles de uso para {{date}}"
+    },
+    "chats": {
+      "clickToOpen": "Haz clic para abrir",
+      "empty": "No hubo conversaciones en este periodo",
+      "more_one": "+{{value}} conversación más",
+      "more_many": "+{{value}} conversaciones más",
+      "more_other": "+{{value}} conversaciones más",
+      "summary_one": "{{chats}} usó {{credits}}",
+      "summary_many": "{{chats}} usaron {{credits}}",
+      "summary_other": "{{chats}} usaron {{credits}}",
+      "title": "Conversaciones",
+      "untitled": "(sin título)"
+    },
+    "displayNames": {
+      "auto": "Automático",
+      "finance": "Finanzas",
+      "maps": "Mapas",
+      "peopleSearch": "Búsqueda de personas",
+      "usage": "Uso",
+      "weather": "Clima",
+      "webFetch": "Búsqueda web",
+      "webSearch": "Búsqueda web"
+    },
+    "kinds": {
+      "connector": "Conectores",
+      "image": "Imágenes",
+      "model": "Modelos",
+      "other": "Otro",
+      "video": "Vídeos"
+    },
+    "page": {
+      "description": "Tu consumo de créditos en conversaciones, automatizaciones y canales.",
+      "loadError": "No se pudieron cargar las estadísticas de uso. Inténtalo de nuevo más tarde.",
+      "title": "Uso"
+    },
+    "range": {
+      "ariaLabel": "Rango de fechas",
+      "billingPeriod": "Periodo de facturación",
+      "last24Hours": "Últimas 24 horas",
+      "last28Days": "Últimos 28 días",
+      "last30Days": "Últimos 30 días",
+      "last7Days": "Últimos 7 días",
+      "selectedDay": "Día seleccionado",
+      "today": "Hoy",
+      "yesterday": "Ayer"
+    },
+    "records": {
+      "emptyBillingPeriod": "No hubo consumo en este periodo de facturación.",
+      "emptyRange": "No hubo consumo en este intervalo.",
+      "loadError": "No se pudo cargar tu consumo.",
+      "loadMore": "Cargar más",
+      "myUsage": "Mi uso",
+      "noActiveBillingPeriod": "No hay periodo de facturación activo.",
+      "teamLoadError": "No se pudo cargar el uso del equipo.",
+      "teamUsage": "Uso en equipo",
+      "untitled": "(sin título)"
+    },
+    "sources": {
+      "agent": "Agente",
+      "automation": "Automatización",
+      "chat": "Chat",
+      "cli": "CLI",
+      "email": "Correo electrónico",
+      "github": "GitHub",
+      "other": "Otro",
+      "others": "Otros",
+      "phone": "Teléfono",
+      "slack": "Slack",
+      "teams": "Microsoft Teams",
+      "telegram": "Telegram",
+      "unknown": "Desconocido"
+    },
+    "units": {
+      "automation_one": "{{value}} automatización",
+      "automation_many": "{{value}} automatizaciones",
+      "automation_other": "{{value}} automatizaciones",
+      "chat_one": "{{value}} conversación",
+      "chat_many": "{{value}} conversaciones",
+      "chat_other": "{{value}} conversaciones",
+      "credit_one": "{{value}} crédito",
+      "credit_many": "{{value}} créditos",
+      "credit_other": "{{value}} créditos"
+    }
+  },
+  "workflows": {
+    "automations": {
+      "calendar": {
+        "addAction": "Añadir automatización de calendario",
+        "addAria": "Añadir automatización de Google Calendar",
+        "addDescriptionCancelled": "Ejecuta este flujo de trabajo cuando se cancele un evento de Google Calendar.",
+        "addDescriptionCreated": "Ejecuta este flujo de trabajo cuando se cree un evento de Google Calendar.",
+        "addDescriptionUpdated": "Ejecuta este flujo de trabajo cuando se actualice un evento de Google Calendar.",
+        "addTitle": "Añadir automatización de Google Calendar",
+        "calendarId": "ID de calendario",
+        "calendarIdPlaceholder": "primary",
+        "cancelledDescription": "Ejecutar cuando se cancele un evento del calendario.",
+        "cancelledRule": "Cuando se cancela el evento {{calendar}} del calendario",
+        "cancelledTitle": "Evento de Google Calendar cancelado",
+        "createdDescription": "Ejecuta cuando se crea un evento en el calendario.",
+        "createdRule": "Cuando el calendario {{calendar}} recibe un nuevo evento",
+        "createdTitle": "Evento de Google Calendar creado",
+        "summary": "Calendario {{calendar}}",
+        "updatedDescription": "Ejecuta cuando se actualice un evento del calendario.",
+        "updatedRule": "Cuando se actualiza el evento {{calendar}} del calendario",
+        "updatedTitle": "Evento de Google Calendar actualizado"
+      },
+      "chat": {
+        "addAction": "Añadir automatización de chat",
+        "addAria": "Añadir automatización al finalizar una ejecución de chat",
+        "addDescription": "Ejecuta este flujo de trabajo cuando termine una ejecución en el hilo de chat supervisado.",
+        "addTitle": "Añadir automatización de chat",
+        "anyOutput": "Cualquier salida",
+        "anyStatus": "Cualquier estado final",
+        "patternHint": "Comodín * opcional que se compara con la respuesta final de la ejecución. Déjalo vacío para aceptar cualquier resultado.",
+        "patternLabel": "Patrón de salida",
+        "patternPlaceholder": "*deploy failed*",
+        "runFinishedDescription": "Ejecutar cuando termine una ejecución de una de tus conversaciones.",
+        "runFinishedTitle": "Ejecución de chat finalizada",
+        "statusCancelled": "Cancelado",
+        "statusCompleted": "Completado",
+        "statusesHint": "Las ejecuciones fallidas y canceladas no tienen texto de respuesta, por lo que un patrón de salida nunca coincide con ellas.",
+        "statusesLabel": "Estados finales",
+        "statusFailed": "Fallido",
+        "threadIdHint": "Abre la conversación y copia el ID del hilo de su URL. El hilo debe pertenecer a una de tus conversaciones.",
+        "threadIdLabel": "ID del hilo de chat",
+        "viewDescription": "Los filtros de esta automatización quedan fijados tras crearla.",
+        "viewTitle": "Automatización al finalizar una ejecución de chat",
+        "watchedThreadLabel": "Hilo de chat supervisado"
+      },
+      "common": {
+        "addAutomation": "Añadir automatización",
+        "automation": "Automatización",
+        "cancel": "Cancelar",
+        "chooseAutomation": "Elige una automatización para iniciar este flujo de trabajo.",
+        "deleteAutomation": "Eliminar automatización",
+        "disable": "Desactiva {{title}}",
+        "disabledPaidPlan": "Deshabilitado — se requiere un plan de pago",
+        "done": "Completado",
+        "editAutomation": "Editar automatización",
+        "enable": "Habilitar {{title}}",
+        "eventAutomation": "Automatización de eventos",
+        "moreActions": "Más acciones",
+        "noAutomations": "Sin automatizaciones",
+        "noAutomationsDescription": "Añade una automatización para ejecutar este flujo de trabajo según una programación o un evento.",
+        "runNow": "Ejecutar ahora",
+        "schedule": "Programación",
+        "scheduleAutomation": "Automatización programada",
+        "updateDescription": "Actualiza esta automatización.",
+        "webhookAutomation": "Automatización de webhooks"
+      },
+      "duration": {
+        "hour_one": "{{count}} hora",
+        "hour_many": "{{count}} horas",
+        "hour_other": "{{count}} horas",
+        "minute_one": "{{count}} minuto",
+        "minute_many": "{{count}} minutos",
+        "minute_other": "{{count}} minutos",
+        "second_one": "{{count}} segundo",
+        "second_many": "{{count}} segundos",
+        "second_other": "{{count}} segundos"
+      },
+      "github": {
+        "accountConnect": "Conecta GitHub",
+        "accountRequired": "Conecta tu cuenta de GitHub para usar la opción «Yo».",
+        "actorAnyone": "Cualquiera",
+        "actorMe": "Yo",
+        "actors": "Actores",
+        "actorsPlaceholder": "octocat, dependabot[bot]",
+        "addLabelAction": "Añadir automatización de etiquetas",
+        "addLabelAria": "Añadir automatización de etiquetas de GitHub",
+        "addLabelDescription": "Ejecuta este flujo de trabajo cuando se aplique una etiqueta de GitHub.",
+        "addLabelTitle": "Añadir automatización de etiquetas de GitHub",
+        "addWebhookAction": "Añadir automatización",
+        "addWebhookAria": "Añadir automatización de {{title}}",
+        "addWebhookDescription": "Ejecuta este flujo de trabajo cuando llegue un evento de webhook de GitHub que coincida.",
+        "addWorkflowAction": "Añadir automatización de flujo de trabajo",
+        "addWorkflowAria": "Añadir automatización de flujos de trabajo de GitHub",
+        "addWorkflowDescription": "Ejecutar este flujo de trabajo cuando termine una ejecución coincidente de GitHub Actions.",
+        "addWorkflowTitle": "Añadir automatización de flujos de trabajo de GitHub",
+        "aJob": "Una tarea de GitHub Actions",
+        "any": "Cualquiera",
+        "anyAuthor": "Cualquier autor",
+        "anyComment": "Cualquier comentario",
+        "anyConclusion": "Cualquier conclusión",
+        "anyDeploymentState": "Cualquier estado de despliegue",
+        "anyEnvironment": "Cualquier entorno",
+        "anyJob": "Cualquier tarea",
+        "anyRepository": "Cualquier repositorio",
+        "anyResult": "Cualquier resultado",
+        "anyReview": "Cualquier revisión",
+        "anyReviewState": "Cualquier estado de revisión",
+        "anyWorkflow": "Cualquier flujo de trabajo",
+        "apps": "GitHub Apps",
+        "appsPlaceholder": "vercel, 12345",
+        "authorsPlaceholder": "octocat, e7h4n",
+        "authorsSummary": "Autores {{values}}",
+        "aWorkflow": "Un flujo de trabajo de GitHub",
+        "baseBranches": "Ramas base",
+        "branches": "Ramas",
+        "branchesPlaceholder": "main, release",
+        "commentPrefixes": "Prefijos de comentarios",
+        "commentPrefixesPlaceholder": "/zero, /verify, /deploy",
+        "conclusions": "Conclusiones",
+        "conclusionsSummary": "Conclusiones {{values}}",
+        "creators": "Creadores",
+        "creatorsPlaceholder": "octocat, 12345",
+        "deploymentStates": "Estados de despliegue",
+        "deploymentStatesSummary": "Estados de despliegue {{values}}",
+        "deploymentStatusDescription": "Ejecuta cuando se crea un estado de despliegue coincidente.",
+        "deploymentStatusRule": "Cuando se crea un estado de despliegue de GitHub que coincide",
+        "deploymentStatusTitle": "Estado de despliegue de GitHub creado",
+        "editLabel": "Editar etiqueta",
+        "editWebhookFilters": "Editar filtros de {{title}}",
+        "editWorkflowFilters": "Editar filtros de flujos de trabajo de GitHub",
+        "environments": "Entornos",
+        "environmentsPlaceholder": "Preview, Production",
+        "environmentsSummary": "Entornos {{values}}",
+        "events": "Eventos activadores",
+        "eventsPlaceholder": "push, pull_request, workflow_dispatch",
+        "filterHelp": "Deja un filtro vacío para que coincida con cualquier valor. Separa varios valores con comas.",
+        "headBranches": "Ramas principales",
+        "headBranchesPlaceholder": "feature/, dependabot/",
+        "installAdminRequired": "Pide a un administrador de la organización que lo instale.",
+        "installApp": "Instalar la aplicación de GitHub",
+        "installedRequired": "GitHub no está instalado para este espacio de trabajo.",
+        "issueCommentDescription": "Ejecutar cuando se cree un comentario coincidente en una incidencia o pull request.",
+        "issueCommentRule": "Cuando se crea un comentario de GitHub que coincide en una incidencia o pull request",
+        "issueCommentTitle": "Comentario de GitHub creado",
+        "issuesAndPullRequests": "Incidencias y pull requests",
+        "issuesOnly": "Solo incidencias",
+        "jobs": "Tareas",
+        "jobsPlaceholder": "test, build",
+        "jobsSummary": "Tareas: {{values}}",
+        "labelAppliedDescription": "Ejecutar cuando una incidencia o un pull request reciba una etiqueta.",
+        "labelAppliedRule": "Cuando se aplica la etiqueta de GitHub {{label}}",
+        "labelAppliedTitle": "Etiqueta de GitHub aplicada",
+        "labelName": "Nombre de la etiqueta",
+        "labelOnlySummary": "Etiqueta {{label}}",
+        "labelPlaceholder": "triage",
+        "labelSummary": "Etiqueta {{label}} · {{subject}} · Actor {{actor}}",
+        "loadError": "No se pudieron cargar los ajustes de GitHub.",
+        "nonProductionOnly": "Solo entornos no productivos",
+        "option": {
+          "actionRequired": "Se requiere acción",
+          "approved": "Aprobado",
+          "cancelled": "Cancelado",
+          "changesRequested": "Cambios solicitados",
+          "commented": "Comentado",
+          "error": "Error",
+          "failure": "Fracaso",
+          "inactive": "Inactivo",
+          "inProgress": "En progreso",
+          "neutral": "Neutro",
+          "pending": "Pendiente",
+          "queued": "En cola",
+          "skipped": "Omitido",
+          "stale": "Obsoleto",
+          "startupFailure": "Fallo de arranque",
+          "success": "Éxito",
+          "timedOut": "Tiempo agotado",
+          "waiting": "Esperando"
+        },
+        "productionEnvironment": "Entorno de producción",
+        "productionOnly": "Solo producción",
+        "pullRequestsOnly": "Solo pull requests",
+        "refs": "Referencias",
+        "refsPlaceholder": "main, v1.0.0",
+        "repositories": "Repositorios",
+        "repositoriesPlaceholder": "vm0-ai/vm0, owner/another-repo",
+        "repositoriesSummary": "Repositorios {{values}}",
+        "reviewDescription": "Ejecutar cuando se envíe una revisión coincidente.",
+        "reviewRule": "Cuando se envía una revisión de pull request de GitHub que coincide",
+        "reviewStates": "Estados de revisión",
+        "reviewTitle": "Revisión de pull request de GitHub enviada",
+        "runnerGroups": "Grupos de runners",
+        "runnerGroupsPlaceholder": "Default, production",
+        "runnerLabels": "Etiquetas de runners",
+        "runnerLabelsPlaceholder": "self-hosted, linux",
+        "saveFilters": "Guardar filtros",
+        "selectNoneAny": "No selecciones ninguno para que coincida con cualquier valor.",
+        "selectNoneConclusion": "No selecciones ninguno para que coincida con cualquier conclusión completada.",
+        "startedBy": "Empezado por",
+        "subject": "Asunto",
+        "trustedAuthors": "Autores de confianza",
+        "updateLabelAria": "Actualizar automatización de etiquetas de GitHub",
+        "updateWebhookAria": "Actualizar automatización de {{title}}",
+        "updateWorkflowAria": "Actualizar automatización de flujos de trabajo de GitHub",
+        "withConclusions": "con {{values}}",
+        "workflowJobDescription": "Ejecutar cuando termine una tarea coincidente de GitHub Actions.",
+        "workflowJobRule": "Cuando {{jobs}} termine",
+        "workflowJobTitle": "Tarea de flujo de trabajo de GitHub completada",
+        "workflowRunDescription": "Ejecutar cuando termine una ejecución coincidente de GitHub Actions.",
+        "workflowRunRule": "Cuando {{workflows}} completa{{conclusions}}",
+        "workflowRunTitle": "Flujo de trabajo de GitHub completado",
+        "workflows": "Flujos de trabajo de GitHub",
+        "workflowsPlaceholder": "Turbo, .github/workflows/release.yml",
+        "workflowsShortPlaceholder": "Turbo, release",
+        "workflowsSummary": "Flujos de trabajo: {{values}}"
+      },
+      "gmail": {
+        "addCondition": "Añadir condición",
+        "addLabelAction": "Añadir automatización de etiquetas",
+        "addLabelAria": "Añadir automatización de etiquetas de Gmail",
+        "addLabelDescription": "Ejecuta este flujo de trabajo cuando se aplique una etiqueta de Gmail con nombre.",
+        "addLabelTitle": "Añadir automatización de etiquetas de Gmail",
+        "addMessageAction": "Añadir automatización de Gmail",
+        "addMessageAria": "Añadir automatización de Gmail",
+        "addMessageDescription": "Ejecuta este flujo de trabajo cuando llegue un mensaje coincidente.",
+        "addMessageTitle": "Añadir automatización de Gmail",
+        "allInboundMessages": "todos los mensajes entrantes",
+        "anyMessageRule": "Cuando llega cualquier mensaje de Gmail",
+        "conditionField": "Campo de la condición {{number}}",
+        "conditionOperator": "Operador de la condición {{number}}",
+        "editLabel": "Editar etiqueta",
+        "editMatch": "Editar coincidencia",
+        "enterValue": "Introduce un valor",
+        "field": {
+          "body": "Cuerpo",
+          "cc": "CC",
+          "from": "De",
+          "subject": "Asunto",
+          "threadId": "ID de hilo",
+          "to": "Para"
+        },
+        "labelAppliedRule": "Cuando se aplica la etiqueta de Gmail {{label}}",
+        "labelAppliedTitle": "Etiqueta de Gmail aplicada",
+        "labelName": "Nombre de la etiqueta",
+        "labelPlaceholder": "Soporte",
+        "labelSummary": "Etiqueta {{label}}",
+        "messageMatchesRule": "Cuando un mensaje de Gmail coincide con {{summary}}",
+        "newMessageDescription": "Ejecuta este flujo de trabajo cuando llegue un correo que coincida.",
+        "newMessageTitle": "Nuevo mensaje de Gmail",
+        "operator": {
+          "contains": "Contiene",
+          "containsAny": "Contiene cualquiera",
+          "doesNotContain": "No contiene",
+          "is": "Es"
+        },
+        "removeCondition": "Eliminar la condición {{number}}",
+        "saveLabel": "Guardar etiqueta",
+        "saveMatch": "Guardar coincidencia",
+        "summary": {
+          "contains": "{{field}} contiene {{value}}",
+          "containsAny": "{{field}} contiene alguno de {{value}}",
+          "doesNotContain": "{{field}} no contiene {{value}}",
+          "doesNotContainAny": "{{field}} no contiene ninguna de {{value}}",
+          "threadId": "El ID del hilo es {{value}}"
+        },
+        "updateLabelAria": "Actualizar automatización de etiquetas de Gmail",
+        "updateMessageAria": "Actualizar automatización de mensajes nuevos de Gmail"
+      },
+      "meet": {
+        "addAction": "Añadir automatización de Meet",
+        "addAria": "Añadir automatización de transcripciones de Google Meet",
+        "addDescription": "Ejecuta este flujo de trabajo cuando Google Meet termine de generar una transcripción para una reunión organizada por la cuenta conectada Google Meet.",
+        "addTitle": "Añadir automatización de Google Meet",
+        "rule": "Cuando Google Meet termine de generar una transcripción",
+        "summary": "Reuniones que organizas",
+        "transcriptHint": "La transcripción debe estar habilitada para la reunión. Si Meet no crea una transcripción, esta automatización no se ejecutará.",
+        "transcriptReadyDescription": "Ejecuta cuando Meet termine de generar una transcripción.",
+        "transcriptReadyTitle": "Transcripción de Google Meet lista"
+      },
+      "notion": {
+        "addAction": "Añadir automatización de Notion",
+        "childPageAddAria": "Añadir automatización de páginas hijas de Notion",
+        "childPageDescription": "Ejecuta cuando se cree una página hija directa.",
+        "childPageDialogDescription": "Ejecuta este flujo de trabajo cuando se cree una página hija directa bajo una página de Notion.",
+        "childPageRule": "Cuando se crea una página hija de Notion bajo {{title}}",
+        "childPageRuleGeneric": "Cuando se crea una página hija de Notion",
+        "childPageTitle": "Nueva página hija de Notion",
+        "configuredDatabase": "Base de datos configurada",
+        "configuredPage": "Página configurada",
+        "configuredParentPage": "Página principal configurada",
+        "contentUpdatedAddAria": "Añadir automatización de actualización de contenido de Notion",
+        "contentUpdatedDescription": "Ejecuta cuando el contenido de una página o de un elemento de base de datos cambie.",
+        "contentUpdatedDialogDescription": "Ejecuta este flujo de trabajo cuando se actualice el contenido de una página de Notion.",
+        "contentUpdatedTitle": "Página de Notion actualizada",
+        "database": "Base de datos",
+        "databaseItemAddAria": "Añadir automatización de elementos de base de datos de Notion",
+        "databaseItemDescription": "Ejecuta cuando se añade una página a una base de datos de Notion.",
+        "databaseItemDialogDescription": "Ejecuta este flujo de trabajo cuando se añade una página a una base de datos de Notion.",
+        "databaseItemRule": "Cuando la base de datos de Notion {{title}} recibe un elemento nuevo",
+        "databaseItemRuleGeneric": "Cuando una base de datos de Notion recibe un nuevo elemento",
+        "databaseItemTitle": "Nuevo elemento de base de datos de Notion",
+        "databaseSummary": "Base de datos {{title}}",
+        "databaseUpdatedRule": "Cuando se actualiza el contenido de un elemento de la base de datos de Notion {{title}}",
+        "databaseUpdatedRuleGeneric": "Cuando se actualiza el contenido de un elemento de una base de datos de Notion",
+        "databaseUrl": "URL de la base de datos",
+        "databaseUrlPlaceholder": "https://www.notion.so/...",
+        "page": "Página",
+        "pageSummary": "Página {{title}}",
+        "pageUpdatedRule": "Cuando se actualiza el contenido de la página de Notion {{title}}",
+        "pageUpdatedRuleGeneric": "Cuando se actualiza el contenido de una página de Notion",
+        "pageUrl": "URL de la página",
+        "pageUrlPlaceholder": "https://www.notion.so/workspace/Page-title-...",
+        "parentPageSummary": "Página principal {{title}}",
+        "parentPageUrl": "URL de la página principal",
+        "scope": "Alcance"
+      },
+      "picker": {
+        "calendar": "Calendario",
+        "email": "Correo electrónico",
+        "integrations": "Integraciones",
+        "notion": "Notion",
+        "schedule": "Calendario"
+      },
+      "rules": {
+        "inboundWebhook": "Cuando se recibe un webhook entrante"
+      },
+      "schedule": {
+        "addIntervalAction": "Añadir intervalo",
+        "addIntervalAria": "Añadir automatización por intervalos",
+        "addIntervalDescription": "Elige con qué frecuencia debe ejecutarse este flujo de trabajo.",
+        "addIntervalTitle": "Añadir automatización por intervalos",
+        "addOnceAction": "Añadir una ejecución única",
+        "addOnceAria": "Añadir automatización única",
+        "addOnceDescription": "Elige la fecha y hora para que este flujo de trabajo se ejecute una vez.",
+        "addOnceTitle": "Añadir automatización única",
+        "addScheduleAction": "Añadir horario",
+        "addScheduleAria": "Añadir automatización de calendarios",
+        "addScheduleDescription": "Elige cuándo debe ejecutarse este flujo de trabajo.",
+        "addScheduleTitle": "Añadir automatización de calendarios",
+        "cronExpression": "Expresión cron",
+        "customCron": "Cron personalizado",
+        "dayOfMonth": "Día del mes",
+        "dayOfWeek": "Día de la semana",
+        "displaysIn": "Se muestra en {{timezone}}",
+        "editSchedule": "Editar programación",
+        "every": "Cada",
+        "everyDay": "Cada día",
+        "everyDayAt": "Cada día a {{time}}",
+        "everyMonth": "Cada mes",
+        "everyMonthAt": "Cada mes en el día {{day}} a las {{time}}",
+        "everyWeek": "Cada semana",
+        "everyWeekAt": "Cada semana a {{time}}",
+        "everyWeekday": "Todos los días laborables",
+        "everyWeekdayAt": "Todos los días laborables a {{time}}",
+        "everyWeekOn": "Cada semana en {{days}} a {{time}}",
+        "frequencyIntervalDescription": "Ejecuta este flujo de trabajo en un intervalo fijo.",
+        "frequencyIntervalTitle": "Intervalo",
+        "frequencyOnceDescription": "Ejecuta este flujo de trabajo una vez en una fecha y hora.",
+        "frequencyOnceTitle": "Ejecución única",
+        "frequencyScheduleDescription": "Ejecuta este flujo de trabajo según una regla horaria.",
+        "frequencyScheduleTitle": "Hora programada",
+        "hour": "Hora",
+        "last": "Última",
+        "minute": "Minuto",
+        "next": "Siguiente",
+        "noRunsYet": "Aún no hay ejecuciones",
+        "noUpcomingRun": "No hay próximas ejecuciones",
+        "onceOn": "Una vez en {{date}} a {{time}}",
+        "repeatEvery": "Cada {{interval}}",
+        "repeats": "Repeticiones",
+        "runAt": "Ejecutar a las",
+        "saveSchedule": "Guardar programación",
+        "time": "Hora ({{timezone}})",
+        "updateScheduleAria": "Actualizar automatización programada"
+      },
+      "strapi": {
+        "addAction": "Añadir automatización de Strapi",
+        "addAria": "Añadir automatización de publicación de entradas de Strapi",
+        "addDescription": "Ejecuta este flujo de trabajo después de que los eventos de publicación localizados coincidan.",
+        "addTitle": "Añadir automatización de Strapi",
+        "configure": "Configurar Strapi",
+        "connectFirst": "Conecta una instancia de Strapi antes de crear esta automatización.",
+        "contentType": "Tipo de contenido UID (opcional)",
+        "contentTypeAny": "Cualquier tipo de contenido",
+        "contentTypePlaceholder": "api::article.article",
+        "entryPublishedDescription": "Ejecutar después de que se publique una entrada coincidente de Strapi.",
+        "entryPublishedTitle": "Entrada de Strapi publicada",
+        "instance": "Instancia de Strapi",
+        "locale": "Configuración regional (opcional)",
+        "localeAny": "Cualquier configuración regional",
+        "localeHint": "Deja la configuración regional en blanco para combinar todos los eventos de publicación localizados del mismo documento en una única ejecución del flujo de trabajo.",
+        "localePlaceholder": "en",
+        "localeSummary": "Configuración regional {{locale}}",
+        "rule": "Cuando se publica una entrada coincidente de Strapi"
+      },
+      "types": {
+        "chat": "Chat",
+        "github": "GitHub",
+        "gmail": "Gmail",
+        "googleCalendar": "Google Calendar",
+        "googleMeet": "Google Meet",
+        "notion": "Notion",
+        "strapi": "Strapi",
+        "webhook": "Webhook"
+      },
+      "webhook": {
+        "addDescription": "Crea un punto final firmado para este flujo de trabajo.",
+        "addTitle": "Añadir automatización de webhooks",
+        "copy": "Copiar",
+        "create": "Crear webhook",
+        "createDescription": "Ejecuta este flujo de trabajo desde un POST firmado.",
+        "createTitle": "Webhook",
+        "hidden": "URL de Webhook oculta",
+        "paidBadge": "Equipo",
+        "reveal": "Mostrar secreto",
+        "revealDescription": "Revela el punto final con signos y el final secreto en {{suffix}}",
+        "revealTitle": "Ver secreto del webhook",
+        "secret": "Secreto de firma",
+        "secretHiddenHint": "Los valores secretos están ocultos en la lista de automatización. Revélalos solo cuando necesites configurar o probar este webhook.",
+        "secretOneTimeHint": "El secreto de firma solo se muestra después de la creación.",
+        "signedCurl": "Rotación con signo",
+        "upgrade": {
+          "adminHint": "Pide a un administrador de espacio de trabajo que actualice.",
+          "benefitDescription": "Crea endpoints firmados que inicien flujos de trabajo desde sistemas externos.",
+          "benefitTitle": "Automatización segura de flujos de trabajo entrantes",
+          "description": "Las automatizaciones de Webhook requieren un espacio de trabajo en equipo o personalizado.",
+          "title": "Actualización para automatizaciones de webhooks",
+          "upgradeAction": "Ascenso a equipo"
+        },
+        "url": "URL del webhook"
+      }
+    },
+    "common": {
+      "agents": "Agentes",
+      "cancel": "Cancelar",
+      "close": "Cerrar",
+      "copyWorkflow": "Copiar flujo de trabajo",
+      "delete": "Eliminar",
+      "deleteWorkflow": "Eliminar flujo de trabajo",
+      "instructions": "Instrucciones",
+      "manual": "Manual",
+      "others": "Otros",
+      "pinned": "Fijado",
+      "private": "Privado",
+      "public": "Público",
+      "settings": "Configuración",
+      "view": "Ver",
+      "workflow": "Flujo de trabajo",
+      "workflows": "Flujos de trabajo"
+    },
+    "composer": {
+      "nextMessage": "Escribe tu siguiente mensaje...",
+      "placeholder": "Pídeme que automatice flujos de trabajo, gestione tareas..."
+    },
+    "createDialog": {
+      "addAutomation": "Añadir automatización",
+      "chooseAgentAutomation": "Elige el agente para esta automatización",
+      "chooseAgentWorkflow": "Elige el agente para este flujo de trabajo.",
+      "chooseWorkflow": "Elige un flujo de trabajo para automatizar o crea uno en el chat.",
+      "createAutomation": "Crear automatización",
+      "createInChat": "Crear en el chat",
+      "createInChatDescription": "Empieza con una conversación cuando aún no encaja ningún flujo de trabajo.",
+      "createWorkflow": "Crear flujo de trabajo",
+      "noAgents": "Todavía no hay agentes",
+      "noAgentsFound": "No se encontraron agentes",
+      "noWorkflows": "Todavía no hay flujos de trabajo. Crea uno en el chat para continuar."
+    },
+    "detail": {
+      "connectors": {
+        "action": {
+          "connect": "Conectar",
+          "enable": "Habilitar para el agente",
+          "reconnect": "Volver a conectar",
+          "reviewPermissions": "Revisar permisos"
+        },
+        "aria": "Preparación de los conectores",
+        "check": "Revisa los conectores",
+        "checkAgain": "Revisa de nuevo",
+        "checking": "Comprobando...",
+        "description": "Consulta qué conectores integrados puede necesitar este flujo de trabajo y si están listos.",
+        "empty": "No se detectaron conectores necesarios",
+        "error": {
+          "inputTooLong": "Este flujo de trabajo es demasiado largo para comprobarlo. Mantén el nombre, la descripción y las instrucciones dentro de 100.000 caracteres.",
+          "retry": "No pudimos comprobar los conectores. Inténtalo de nuevo.",
+          "timeout": "La comprobación del conector se agotó. Inténtalo de nuevo."
+        },
+        "saveFirst": "Guarda tus cambios antes de revisar los conectores.",
+        "status": {
+          "connected": "Conectado",
+          "notConnected": "No conectado",
+          "notEnabled": "No activado para este agente",
+          "reconnect": "Se requiere reconexión",
+          "scopeMismatch": "Actualizar permisos",
+          "unavailable": "Actualmente no disponible"
+        },
+        "title": "Preparación de los conectores"
+      },
+      "copy": {
+        "agentFallback": "El agente",
+        "copied": "Copiado a {{agent}}",
+        "copyAndRemove": "Copiar y eliminar",
+        "description": "Copia este flujo de trabajo a otro agente como un nuevo flujo de trabajo privado.",
+        "moved": "Movido a {{agent}}",
+        "moveDescription": "Original eliminado de {{agent}}.",
+        "noAgents": "Aún no hay otros agentes",
+        "privateReady": "Una copia privada está lista.",
+        "removalAlert": "Esto elimina el original",
+        "removalNoAutomations": "Este flujo de trabajo se elimina de {{agent}}.",
+        "removalWithAutomations_one": "{{count}} automatización se pausa en {{agent}} y este flujo de trabajo se elimina.",
+        "removalWithAutomations_many": "{{count}} automatizaciones se pausan en {{agent}} y este flujo de trabajo se elimina.",
+        "removalWithAutomations_other": "{{count}} automatizaciones se pausan en {{agent}} y este flujo de trabajo se elimina.",
+        "removeOriginal": "Elimina el original de {{agent}} después de copiar",
+        "selectAgent": "Elige un agente",
+        "title": "Copiar flujo de trabajo",
+        "to": "Copiar a"
+      },
+      "delete": {
+        "confirm": "{{title}} y todas las automatizaciones vinculadas serán eliminadas.",
+        "dangerDescription": "Elimina este flujo de trabajo y sus automatizaciones. Esta acción no puede deshacerse.",
+        "dangerTitle": "Zona de peligro",
+        "description": "Esta es una operación peligrosa. Eliminar este flujo de trabajo también elimina todas las automatizaciones vinculadas a él, incluidas las automatizaciones creadas por otros usuarios.",
+        "title": "Eliminar flujo de trabajo"
+      },
+      "files": {
+        "aria": "Archivos de flujo de trabajo",
+        "deleteAria": "Elimina {{path}}",
+        "deleteSelected": "Eliminar archivo seleccionado",
+        "fileContent": "Contenido de archivos de flujo de trabajo",
+        "filePlaceholder": "Edita este archivo markdown...",
+        "instruction": "Instrucción de flujo de trabajo",
+        "instructionPlaceholder": "Escribe instrucciones para el flujo de trabajo...",
+        "instructions": "Instrucciones",
+        "noContent": "No hay contenido disponible para este archivo.",
+        "sizeBytes": "{{size}} B",
+        "upload": "Subir archivos de texto",
+        "uploadAria": "Subir archivos de flujo de trabajo"
+      },
+      "info": {
+        "copyDescription": "Copia este flujo de trabajo a otro agente.",
+        "copyTitle": "Copiar flujo de trabajo"
+      },
+      "metadata": {
+        "agent": "Agente",
+        "agentDescription": "Este flujo de trabajo pertenece a este agente.",
+        "aria": "Metadatos del flujo de trabajo",
+        "description": "Descripción",
+        "descriptionHelp": "Dile al agente cuándo debe usar este flujo de trabajo.",
+        "name": "Nombre",
+        "nameHelp": "Se muestra en las listas de flujo de trabajo y al elegir un flujo de trabajo.",
+        "namePlaceholder": "Nombre del flujo de trabajo",
+        "saved": "Flujo de trabajo guardado",
+        "slug": "Slug",
+        "slugHelp": "Solo letras minúsculas, números y guiones. Usa {{command}} en el chat para ejecutar este flujo de trabajo.",
+        "slugPlaceholder": "workflow-slug",
+        "slugTitle": "Usa solo letras minúsculas, números y guiones",
+        "visibility": "Visibilidad",
+        "visibilityHelp": "Elige cómo se comparte este flujo de trabajo dentro de tu espacio de trabajo."
+      },
+      "notFound": "Flujo de trabajo no encontrado.",
+      "refineWith": "Refinar con {{agent}}",
+      "shadow": {
+        "end": "Este flujo de trabajo queda reemplazado por la regla de prioridad de otro con el mismo slug.",
+        "resolvesTo": "actualmente se resuelve como"
+      },
+      "visibility": {
+        "adminRequired": "Publicar un flujo de trabajo bajo un agente que no eres propietario requiere permisos de administrador de la organización.",
+        "automationWarning": "Las automatizaciones se detendrán",
+        "confirmDescription": "Esta es una operación peligrosa. Aunque este flujo de trabajo es privado, las automatizaciones que otros miembros construyeron sobre él dejan de funcionar.",
+        "confirmTitle": "¿Hacer privado este flujo de trabajo?",
+        "makePrivate": "Hacer privado",
+        "publishAria": "Hacer público el flujo de trabajo",
+        "workflowHidden": "{{title}} quedarán ocultos para otros miembros y sus automatizaciones cesarán."
+      }
+    },
+    "editor": {
+      "aria": "Editor de instrucciones",
+      "footer": "Edita las instrucciones directamente para personalizar el comportamiento de tu agente.",
+      "placeholder": "Escribe instrucciones para tu agente...",
+      "toolbar": {
+        "blockquote": "Cita en bloque",
+        "bold": "Negrita",
+        "bulletList": "Lista con viñetas",
+        "heading1": "Título 1",
+        "heading2": "Título 2",
+        "heading3": "Título 3",
+        "inlineCode": "Código en línea",
+        "italic": "Cursiva",
+        "orderedList": "Lista numerada",
+        "strikethrough": "Tachado"
+      }
+    },
+    "list": {
+      "agentEmpty": "Todavía no se ha ejecutado ningún flujo de trabajo con este agente.",
+      "all": "Todos",
+      "allAgents": "Todos los agentes",
+      "automated": "Automatizado",
+      "automations": "Automatizaciones",
+      "createdBy": "Creado por",
+      "createInChat": "Crear en el chat",
+      "description": "Un procedimiento operativo reutilizable para una tarea. Escríbelo desde cero o extráelo de tu trabajo diario; después ejecútalo, edítalo o automatízalo.",
+      "empty": {
+        "all": "Crea un flujo de trabajo desde el chat o guarda uno a partir de una ejecución útil.",
+        "automated": "Si añades una automatización a un flujo de trabajo, aparece aquí.",
+        "private": "Todavía no hay flujos de trabajo privados.",
+        "public": "Todavía no hay flujos de trabajo públicos.",
+        "without": "Cada flujo de trabajo aquí funciona según un calendario o evento."
+      },
+      "noWorkflows": "Sin flujos de trabajo",
+      "open": "Abrir {{title}}",
+      "runsAs": "Se ejecuta como",
+      "runsAsAria": "Se ejecuta como {{agent}}",
+      "section": {
+        "event": "Por automatización",
+        "later": "Más tarde",
+        "manual": "Manual",
+        "today": "Ejecuciones de hoy",
+        "week": "Esta semana"
+      },
+      "sort": {
+        "alphabetical": "Alfabético",
+        "created": "Fecha de creación",
+        "label": "Ordenar",
+        "nextRun": "Próxima ejecución"
+      },
+      "title": "Flujos de trabajo",
+      "viewAutomations": "Ver automatizaciones"
+    }
+  },
+  "works": {
+    "actions": {
+      "cancel": "Cancelar",
+      "connect": "Conectar",
+      "disconnect": "Desconectar",
+      "disconnecting": "Desconectando…",
+      "manage": "Gestionar",
+      "moreOptions": "Más opciones",
+      "uninstall": "Desinstalar",
+      "uninstalling": "Desinstalando...",
+      "updatePermissions": "Actualizar permisos"
+    },
+    "connected": "Conectado",
+    "connectedWithDetail": "Conectado ({{detail}})",
+    "documentTitle": "Integraciones",
+    "feishuConnected": "Feishu conectado con éxito",
+    "header": {
+      "description": "Conecta con {{displayName}} a través de estos canales",
+      "title": "Dónde trabaja {{displayName}}"
+    },
+    "slack": {
+      "adminInstall": "Pide a tu administrador que instale la integración de Slack",
+      "description": "Comunicación y colaboración en equipo",
+      "install": "Instalar en Slack",
+      "permissionsUpdated": "Los permisos de Slack se han actualizado",
+      "title": "Slack",
+      "uninstallDescription": "Esto eliminará la integración de Slack de todo tu espacio de trabajo. Todos los usuarios conectados quedarán desconectados y {{displayName}} ya no responderá a mensajes ni menciones en Slack. Esta acción no puede deshacerse.",
+      "uninstallTitle": "¿Desinstalar la integración de Slack?"
+    },
+    "strapi": {
+      "description": "Automatizar el trabajo cuando se publican las entradas",
+      "title": "Strapi"
+    },
+    "teams": {
+      "adminInstall": "Pide a tu administrador que instale la integración de Microsoft Teams",
+      "connectAccount": "Conecta tu cuenta de Microsoft para terminar la configuración",
+      "connectThenInstall": "Conecta tu cuenta de Microsoft y luego instala la app Teams",
+      "description": "Comunicación y colaboración en equipo",
+      "disconnect": "Desconectar Microsoft Teams",
+      "install": "Instala en Teams",
+      "moreOptions": "Más opciones Microsoft Teams",
+      "permissionsUpdated": "Los permisos de Microsoft Teams se han actualizado",
+      "title": "Microsoft Teams",
+      "uninstall": "Desinstalar Microsoft Teams",
+      "uninstallDescription": "Esto elimina la integración de Microsoft Teams de {{brandName}} para tu espacio de trabajo. Todos los usuarios conectados quedarán desconectados y {{displayName}} ya no responderá a mensajes de Teams en este espacio hasta que un administrador vuelva a conectarla.",
+      "uninstallTitle": "¿Desinstalar la integración de Microsoft Teams?"
+    },
+    "telegram": {
+      "description": "Dirige los mensajes de Telegram a los agentes",
+      "openSettings": "Abrir los ajustes de Telegram",
+      "title": "Telegram"
+    }
+  }
+}

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -4341,7 +4341,8 @@
           "indonesian": "Bahasa Indonesia",
           "japanese": "日本語",
           "korean": "한국어",
-          "portugueseBrazil": "Português (Brasil)"
+          "portugueseBrazil": "Português (Brasil)",
+          "spanish": "Español"
         },
         "title": "Bahasa"
       },

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -4341,7 +4341,8 @@
           "indonesian": "Bahasa Indonesia",
           "japanese": "日本語",
           "korean": "한국어",
-          "portugueseBrazil": "Português (Brasil)"
+          "portugueseBrazil": "Português (Brasil)",
+          "spanish": "Español"
         },
         "title": "言語"
       },

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -4341,7 +4341,8 @@
           "indonesian": "Bahasa Indonesia",
           "japanese": "日本語",
           "korean": "한국어",
-          "portugueseBrazil": "Português (Brasil)"
+          "portugueseBrazil": "Português (Brasil)",
+          "spanish": "Español"
         },
         "title": "언어"
       },

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -4410,7 +4410,8 @@
           "indonesian": "Bahasa Indonesia",
           "japanese": "日本語",
           "korean": "한국어",
-          "portugueseBrazil": "Português (Brasil)"
+          "portugueseBrazil": "Português (Brasil)",
+          "spanish": "Español"
         },
         "title": "Idioma"
       },

--- a/turbo/apps/platform/src/i18n/resources.ts
+++ b/turbo/apps/platform/src/i18n/resources.ts
@@ -14,6 +14,8 @@ import idIDCommon from "./locales/id-ID/common.json";
 import idIDAgents from "./locales/id-ID/agents.json";
 import deDECommon from "./locales/de-DE/common.json";
 import deDEAgents from "./locales/de-DE/agents.json";
+import esESCommon from "./locales/es-ES/common.json";
+import esESAgents from "./locales/es-ES/agents.json";
 
 export const DEFAULT_LOCALE = "en-US";
 export const DEFAULT_NAMESPACE = "common";
@@ -51,5 +53,9 @@ export const resources = {
   "de-DE": {
     agents: deDEAgents,
     common: deDECommon,
+  },
+  "es-ES": {
+    agents: esESAgents,
+    common: esESCommon,
   },
 } as const;

--- a/turbo/apps/platform/src/mocks/handlers/api-user-preferences.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-user-preferences.ts
@@ -7,7 +7,15 @@ import { mockApi } from "../msw-contract.ts";
 let mockPreferences: UserPreferencesResponse = {
   timezone: null,
   locale: null,
-  supportedLocales: ["en-US", "pt-BR", "ja-JP", "ko-KR", "id-ID", "de-DE"],
+  supportedLocales: [
+    "en-US",
+    "pt-BR",
+    "ja-JP",
+    "ko-KR",
+    "id-ID",
+    "de-DE",
+    "es-ES",
+  ],
   pinnedAgentIds: [],
   sendMode: "enter",
   morningBriefEnabled: false,
@@ -23,7 +31,15 @@ export function resetMockUserPreferences(): void {
   mockPreferences = {
     timezone: null,
     locale: null,
-    supportedLocales: ["en-US", "pt-BR", "ja-JP", "ko-KR", "id-ID", "de-DE"],
+    supportedLocales: [
+      "en-US",
+      "pt-BR",
+      "ja-JP",
+      "ko-KR",
+      "id-ID",
+      "de-DE",
+      "es-ES",
+    ],
     pinnedAgentIds: [],
     sendMode: "enter",
     morningBriefEnabled: false,

--- a/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { HttpResponse } from "msw";
 import {
   addClientCapabilityToVersion,
+  CLIENT_CAPABILITY_ES_ES_LOCALE,
   CLIENT_CAPABILITY_JA_JP_LOCALE,
   CLIENT_CAPABILITY_KO_KR_LOCALE,
   CLIENT_CAPABILITY_ID_ID_LOCALE,
@@ -34,14 +35,20 @@ const EXPECTED_CLIENT_VERSION = addClientCapabilityToVersion(
   addClientCapabilityToVersion(
     addClientCapabilityToVersion(
       addClientCapabilityToVersion(
-        addClientCapabilityToVersion("0.540.0", CLIENT_CAPABILITY_PT_BR_LOCALE),
-        CLIENT_CAPABILITY_JA_JP_LOCALE,
+        addClientCapabilityToVersion(
+          addClientCapabilityToVersion(
+            "0.540.0",
+            CLIENT_CAPABILITY_PT_BR_LOCALE,
+          ),
+          CLIENT_CAPABILITY_JA_JP_LOCALE,
+        ),
+        CLIENT_CAPABILITY_KO_KR_LOCALE,
       ),
-      CLIENT_CAPABILITY_KO_KR_LOCALE,
+      CLIENT_CAPABILITY_ID_ID_LOCALE,
     ),
-    CLIENT_CAPABILITY_ID_ID_LOCALE,
+    CLIENT_CAPABILITY_DE_DE_LOCALE,
   ),
-  CLIENT_CAPABILITY_DE_DE_LOCALE,
+  CLIENT_CAPABILITY_ES_ES_LOCALE,
 );
 
 interface ObservedClientHeaders {

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
@@ -112,6 +112,23 @@ describe("bootstrap locale", () => {
     });
   });
 
+  it("normalizes a Spanish browser language before bundle render", () => {
+    context.mocks.browser.language("es");
+
+    executeLocaleEntrypoint();
+
+    expect(document.documentElement.lang).toBe("es-ES");
+    expect(context.store.get(testLocaleStorage.get$)).toBeNull();
+    expect(window.__vm0PreBundleCopy).toMatchObject({
+      loading: {
+        ariaLabel: "Cargando tu espacio de trabajo",
+      },
+      metadata: {
+        title: "Zero — Tu compañero de IA de vm0",
+      },
+    });
+  });
+
   it("loads Korean pre-bundle copy and typed resources from the browser locale", async () => {
     context.mocks.browser.language("ko-KR");
     executeLocaleEntrypoint();
@@ -180,6 +197,7 @@ describe("bootstrap locale", () => {
     expect(i18n.hasResourceBundle("ja-JP", "common")).toBeTruthy();
     expect(i18n.hasResourceBundle("ko-KR", "common")).toBeTruthy();
     expect(i18n.hasResourceBundle("id-ID", "common")).toBeTruthy();
+    expect(i18n.hasResourceBundle("es-ES", "common")).toBeTruthy();
     expect(new Intl.NumberFormat(i18n.language).format(1234.5)).toBe("1.234,5");
     expect(
       new Intl.DateTimeFormat(i18n.language, {
@@ -462,6 +480,64 @@ describe("bootstrap locale", () => {
         return $.onboarding.workflows["auto-merge-github-prs"].steps.two.title;
       }),
     ).toBe("Zero prüft und wartet auf CI");
+
+    await context.store.set(setLocale$, DEFAULT_LOCALE, context.signal);
+  });
+
+  it("uses cached Spanish across pre-bundle UI and i18next", async () => {
+    sessionStorage.setItem(ACTIVE_ORG_STORAGE_KEY, TEST_ORG_ID);
+    context.store.set(testLocaleStorage.set$, "es-ES");
+    executeLocaleEntrypoint();
+    executeBrowserCompatibilityEntrypoint(
+      "Mozilla/5.0 Chrome/100.0.0.0 Safari/537.36",
+    );
+
+    const metadata = document.createElement("meta");
+    metadata.name = "description";
+    document.head.append(metadata);
+    context.signal.addEventListener(
+      "abort",
+      () => {
+        metadata.remove();
+      },
+      { once: true },
+    );
+    executeMetadataEntrypoint();
+
+    await setupPage({
+      context,
+      path: "/error",
+      featureSwitches: { [FeatureSwitchKey.LanguagePreference]: false },
+      withoutRender: true,
+    });
+
+    expect(context.store.get(locale$)).toBe("es-ES");
+    expect(i18n.language).toBe("es-ES");
+    expect(window.__vm0BrowserSupported).toBeFalsy();
+    expect(window.__vm0BrowserUpgrade).toMatchObject({
+      actionLabel: "Actualizar Chrome",
+      actionUrl: "https://www.google.com/chrome/",
+      title: "Actualiza Chrome para continuar",
+    });
+    expect(metadata).toHaveAttribute(
+      "content",
+      expect.stringContaining("Zero es tu compañero de IA de vm0"),
+    );
+    expect(window.__vm0PreBundleCopy).toMatchObject({
+      browserUpgrade: {
+        safari: {
+          actionLabel: "Actualizar Safari",
+          title: "Actualiza Safari para continuar",
+        },
+      },
+      loading: {
+        ariaLabel: "Cargando tu espacio de trabajo",
+        messages: expect.arrayContaining(["Activando las neuronas..."]),
+      },
+      metadata: {
+        title: "Zero — Tu compañero de IA de vm0",
+      },
+    });
 
     await context.store.set(setLocale$, DEFAULT_LOCALE, context.signal);
   });

--- a/turbo/apps/platform/src/signals/client-headers.ts
+++ b/turbo/apps/platform/src/signals/client-headers.ts
@@ -1,5 +1,6 @@
 import {
   addClientCapabilityToVersion,
+  CLIENT_CAPABILITY_ES_ES_LOCALE,
   CLIENT_CAPABILITY_JA_JP_LOCALE,
   CLIENT_CAPABILITY_KO_KR_LOCALE,
   CLIENT_CAPABILITY_ID_ID_LOCALE,
@@ -34,16 +35,19 @@ function createClientHeaders(): Record<string, string> {
         addClientCapabilityToVersion(
           addClientCapabilityToVersion(
             addClientCapabilityToVersion(
-              clientVersion,
-              CLIENT_CAPABILITY_PT_BR_LOCALE,
+              addClientCapabilityToVersion(
+                clientVersion,
+                CLIENT_CAPABILITY_PT_BR_LOCALE,
+              ),
+              CLIENT_CAPABILITY_JA_JP_LOCALE,
             ),
-            CLIENT_CAPABILITY_JA_JP_LOCALE,
+            CLIENT_CAPABILITY_KO_KR_LOCALE,
           ),
-          CLIENT_CAPABILITY_KO_KR_LOCALE,
+          CLIENT_CAPABILITY_ID_ID_LOCALE,
         ),
-        CLIENT_CAPABILITY_ID_ID_LOCALE,
+        CLIENT_CAPABILITY_DE_DE_LOCALE,
       ),
-      CLIENT_CAPABILITY_DE_DE_LOCALE,
+      CLIENT_CAPABILITY_ES_ES_LOCALE,
     ),
     [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
     [CLIENT_SESSION_ID_HEADER]: clientSessionId,

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -72,6 +72,21 @@ function useGermanLocale(): void {
   );
 }
 
+function useSpanishLocale(): void {
+  document.documentElement.lang = "es-ES";
+  context.mocks.data.userPreferences({
+    locale: "es-ES",
+    supportedLocales: ["en-US", "es-ES"],
+  });
+  context.signal.addEventListener(
+    "abort",
+    () => {
+      document.documentElement.lang = "en-US";
+    },
+    { once: true },
+  );
+}
+
 describe("app auth pages", () => {
   it("localizes the app auth shell and Clerk resources in Brazilian Portuguese", async () => {
     usePortugueseLocale();
@@ -160,6 +175,30 @@ describe("app auth pages", () => {
     expect(localization.signIn?.start?.actionLink).toBe("Registrieren");
     expect(localization.unstable__errors?.not_allowed_access).toBe(
       "Zugriff nicht gestattet.",
+    );
+
+    act(() => {
+      authComponent.mount();
+    });
+  });
+
+  it("localizes the app auth shell and Clerk resources in Spanish", async () => {
+    useSpanishLocale();
+    setBrowserUrl("https://app.vm0.ai/sign-up");
+
+    const authComponent = context.mocks.clerk.deferAuthComponentMount();
+    detachedSetupPage({ context, path: "/sign-up" });
+
+    await expect(
+      screen.findByText("Cargando autenticación"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByLabelText("Cambiar tema")).toBeInTheDocument();
+    expect(document.title).toBe("Crear una cuenta | VM0");
+
+    const localization = getClerkLocalization("VM0", "es-ES", i18n.t);
+    expect(localization.signIn?.start?.actionLink).toBe("Regístrese");
+    expect(localization.unstable__errors?.not_allowed_access).toBe(
+      "Acceso no permitido.",
     );
 
     act(() => {

--- a/turbo/apps/platform/src/views/auth/clerk-localization.ts
+++ b/turbo/apps/platform/src/views/auth/clerk-localization.ts
@@ -1,4 +1,4 @@
-import { deDE, enUS, idID, jaJP, koKR, ptBR } from "@clerk/localizations";
+import { deDE, enUS, esES, idID, jaJP, koKR, ptBR } from "@clerk/localizations";
 import type { TFunction } from "i18next";
 import type { SupportedLocale } from "../../i18n/resources.ts";
 import type { BrandName } from "../../signals/branding.ts";
@@ -19,7 +19,9 @@ export function getClerkLocalization(
             ? idID
             : locale === "de-DE"
               ? deDE
-              : enUS;
+              : locale === "es-ES"
+                ? esES
+                : enUS;
   return {
     ...localization,
     unstable__errors: {

--- a/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
+++ b/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
@@ -324,4 +324,41 @@ describe("/usage page", () => {
       expect(screen.getByText("+1 weiterer Chat")).toBeVisible();
     });
   });
+
+  it("localizes usage copy, plurals, and numeric totals in Spanish", async () => {
+    context.mocks.data.userPreferences({ locale: "es-ES" });
+    context.mocks.api(zeroUsageInsightContract.get, ({ respond }) => {
+      return respond(200, usageInsightTodayFixture);
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/usage",
+      featureSwitches: {
+        [FeatureSwitchKey.LanguagePreference]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(document.documentElement.lang).toBe("es-ES");
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Uso" }),
+      ).toBeInTheDocument();
+      expect(
+        within(
+          screen.getByRole("region", { name: "Total de créditos" }),
+        ).getByText(/1,3\s+mil/u),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("1 automatización usó 300 créditos"),
+      ).toBeVisible();
+      expect(screen.getByText("1 conversación usó 200 créditos")).toBeVisible();
+      expect(screen.getAllByText("Chat")).not.toHaveLength(0);
+    });
+
+    click(screen.getByLabelText("Rango de fechas"));
+    expect(
+      screen.getByRole("option", { name: "Últimos 7 días" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -1054,6 +1054,67 @@ describe("chat lifecycle", () => {
     expect(document.documentElement.lang).toBe("ja-JP");
   });
 
+  it("formats completed-run timestamps with the selected Spanish locale", async () => {
+    const completedAt = "2026-06-09T10:00:21Z";
+    const completedAtLabel = new Date(completedAt).toLocaleString("es-ES", {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    context.mocks.data.userPreferences({ locale: "es-ES" });
+    mockChatLifecycle(context, {
+      threadId: "thread-spanish-completed-run",
+      chatEvents: [
+        {
+          role: "user",
+          content: "Prepara el plan de lanzamiento",
+          runId: "run-spanish-completed-run",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          role: "assistant",
+          content: "El plan de lanzamiento está listo.",
+          runId: "run-spanish-completed-run",
+          createdAt: "2026-06-09T10:00:20Z",
+        },
+        {
+          role: "assistant",
+          content: null,
+          runId: "run-spanish-completed-run",
+          runLifecycleEvent: "completed",
+          createdAt: completedAt,
+        },
+        {
+          role: "assistant",
+          content: null,
+          runId: "run-spanish-completed-run",
+          recommendedFollowups: [
+            {
+              prompt: "Convertir en una presentación",
+              kind: "generate",
+              generationType: "presentation",
+            },
+          ],
+          createdAt: "2026-06-09T10:00:30Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-spanish-completed-run",
+      featureSwitches: {
+        [FeatureSwitchKey.LanguagePreference]: true,
+      },
+    });
+
+    await expect(
+      screen.findByText(`Sigue adelante · ${completedAtLabel}`),
+    ).resolves.toBeInTheDocument();
+    expect(document.documentElement.lang).toBe("es-ES");
+  });
+
   it("does not let an attached lifecycle marker hide the final answer", async () => {
     mockChatLifecycle(context, {
       threadId: "thread-work-folding-completion-marker",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
@@ -597,6 +597,52 @@ describe("personal model providers settings", () => {
     ).toBeInTheDocument();
   });
 
+  it("localizes subscription reset dates and relative times in Spanish", async () => {
+    const timeZone = "Europe/Madrid";
+    mockBrowserTimeZone(timeZone);
+    mockNow(new Date("2030-01-01T00:48:00.000Z"));
+    context.mocks.data.org({
+      id: "org_1",
+      slug: "test-org",
+      name: "Test Org",
+      role: "member",
+    });
+    context.mocks.data.personalModelProviders([
+      connectedPersonalClaudeCodeProvider(),
+    ]);
+    context.mocks.data.userPreferences({
+      locale: "es-ES",
+      supportedLocales: ["en-US", "es-ES"],
+    });
+
+    await openModelSettings("Modelos", true);
+
+    const claudeCodeRow = await screen.findByTestId(
+      "oauth-card-claude-code-oauth-token",
+    );
+    expect(document.documentElement.lang).toBe("es-ES");
+    expect(within(claudeCodeRow).getByText("5h")).toBeInTheDocument();
+    expect(within(claudeCodeRow).getByText("88% restante")).toBeInTheDocument();
+    expect(within(claudeCodeRow).getByText("en 4h 12m")).toBeInTheDocument();
+    expect(within(claudeCodeRow).getByText("Semana")).toBeInTheDocument();
+    expect(within(claudeCodeRow).getByText("76% restante")).toBeInTheDocument();
+    expect(within(claudeCodeRow).getByText("en 5d 23h")).toBeInTheDocument();
+
+    const resetAt = "2030-01-01T05:00:00.000Z";
+    const absoluteReset = new Intl.DateTimeFormat("es-ES", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone,
+      timeZoneName: "short",
+    }).format(new Date(resetAt));
+    expect(
+      within(claudeCodeRow).getByText(`se restablece el ${absoluteReset}`),
+    ).toBeInTheDocument();
+  });
+
   it("resets connected personal Codex usage from the row menu", async () => {
     context.mocks.data.org({
       id: "org_1",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
@@ -391,6 +391,51 @@ describe("settings dialog", () => {
     });
   });
 
+  it("selects and persists Spanish when the API advertises it", async () => {
+    const submittedLocales: UserLocale[] = [];
+    let serverLocale: UserLocale | null = "en-US";
+    const supportedLocales: UserLocale[] = ["en-US", "pt-BR", "ja-JP", "es-ES"];
+    context.mocks.api(zeroUserPreferencesContract.get, ({ respond }) => {
+      return respond(200, createPreferences(serverLocale, supportedLocales));
+    });
+    context.mocks.api(
+      zeroUserPreferencesContract.update,
+      ({ body, respond }) => {
+        if (body.locale !== undefined) {
+          serverLocale = body.locale;
+          submittedLocales.push(body.locale);
+        }
+        return respond(200, createPreferences(serverLocale, supportedLocales));
+      },
+    );
+
+    await openDialog("admin", "preference", {
+      [FeatureSwitchKey.LanguagePreference]: true,
+    });
+
+    click(
+      await screen.findByRole("combobox", {
+        name: "Language",
+      }),
+    );
+    click(screen.getByRole("option", { name: "Español" }));
+
+    await waitFor(() => {
+      expect(submittedLocales).toContain("es-ES");
+      expect(
+        screen.getByRole("combobox", { name: "Idioma" }),
+      ).toHaveTextContent("Español");
+      expect(document.documentElement.lang).toBe("es-ES");
+      expect(cachedLocale()).toBe("es-ES");
+    });
+
+    click(screen.getByRole("combobox", { name: "Idioma" }));
+    click(screen.getByRole("option", { name: "English" }));
+    await waitFor(() => {
+      expect(document.documentElement.lang).toBe("en-US");
+    });
+  });
+
   it("restores Japanese from the workspace preference on reload", async () => {
     document.documentElement.lang = "en-US";
     context.store.set(setCachedLocale$, "en-US");
@@ -442,6 +487,39 @@ describe("settings dialog", () => {
     });
 
     click(languageSelect);
+    expect(
+      screen.queryByRole("option", { name: "日本語" }),
+    ).not.toBeInTheDocument();
+    click(screen.getByRole("option", { name: "English" }));
+    await waitFor(() => {
+      expect(document.documentElement.lang).toBe("en-US");
+    });
+  });
+
+  it("restores Spanish from the workspace preference on reload", async () => {
+    document.documentElement.lang = "en-US";
+    context.store.set(setCachedLocale$, "en-US");
+    context.mocks.data.userPreferences(
+      createPreferences("es-ES", ["en-US", "es-ES"]),
+    );
+
+    await openDialog("admin", "preference", {
+      [FeatureSwitchKey.LanguagePreference]: true,
+    });
+
+    const languageSelect = await screen.findByRole("combobox", {
+      name: "Idioma",
+    });
+    await waitFor(() => {
+      expect(languageSelect).toHaveTextContent("Español");
+      expect(document.documentElement.lang).toBe("es-ES");
+      expect(cachedLocale()).toBe("es-ES");
+    });
+
+    click(languageSelect);
+    expect(
+      screen.queryByRole("option", { name: "Português (Brasil)" }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("option", { name: "日本語" }),
     ).not.toBeInTheDocument();
@@ -520,6 +598,39 @@ describe("settings dialog", () => {
       screen.queryByRole("option", { name: "한국어" }),
     ).not.toBeInTheDocument();
     expect(screen.getByRole("option", { name: "日本語" })).toBeInTheDocument();
+  });
+
+  it("does not submit Spanish to an API that advertises only Portuguese", async () => {
+    const submittedLocales: UserLocale[] = [];
+    document.documentElement.lang = "es-ES";
+    context.store.set(setCachedLocale$, "es-ES");
+    const supportedLocales: UserLocale[] = ["en-US", "pt-BR"];
+    context.mocks.api(zeroUserPreferencesContract.get, ({ respond }) => {
+      return respond(200, createPreferences(null, supportedLocales));
+    });
+    context.mocks.api(
+      zeroUserPreferencesContract.update,
+      ({ body, respond }) => {
+        if (body.locale !== undefined) {
+          submittedLocales.push(body.locale);
+        }
+        return respond(
+          200,
+          createPreferences(body.locale ?? null, supportedLocales),
+        );
+      },
+    );
+
+    await openDialog("admin", "preference", {
+      [FeatureSwitchKey.LanguagePreference]: true,
+    });
+
+    await waitFor(() => {
+      expect(submittedLocales).toContain("en-US");
+      expect(submittedLocales).not.toContain("es-ES");
+      expect(document.documentElement.lang).toBe("en-US");
+      expect(cachedLocale()).toBe("en-US");
+    });
   });
 
   it("hides the language entry when the feature switch is off", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -2601,7 +2601,6 @@ describe("zero sidebar", () => {
       context,
       path: `/chats/${EXISTING_THREAD_ID}`,
       featureSwitches: {
-        [FeatureSwitchKey.Artifacts]: true,
         [FeatureSwitchKey.LanguagePreference]: true,
         [FeatureSwitchKey.ThreeColumnNav]: true,
         [FeatureSwitchKey.ZeroDebug]: true,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -2582,6 +2582,69 @@ describe("zero sidebar", () => {
     ).toBeInTheDocument();
   });
 
+  it("localizes desktop and mobile shell navigation in Spanish", async () => {
+    prepareDefaultAgent();
+    mockSidebarThreadStory([
+      createThread(EXISTING_THREAD_ID, "Localized conversation"),
+    ]);
+    setMockWorkflowAutomations([
+      createMockWorkflowAutomation({
+        chatThreadId: EXISTING_THREAD_ID,
+      }),
+    ]);
+    context.mocks.data.userPreferences({
+      locale: "es-ES",
+      supportedLocales: ["en-US", "es-ES"],
+    });
+
+    setupSidebarPage({
+      context,
+      path: `/chats/${EXISTING_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.Artifacts]: true,
+        [FeatureSwitchKey.LanguagePreference]: true,
+        [FeatureSwitchKey.ThreeColumnNav]: true,
+        [FeatureSwitchKey.ZeroDebug]: true,
+      },
+    });
+
+    const rail = await screen.findByTestId("labeled-nav-rail");
+    expect(
+      within(rail).getByRole("navigation", { name: "Barra lateral" }),
+    ).toBeInTheDocument();
+    expect(within(rail).getByText("Agentes")).toBeInTheDocument();
+    expect(within(rail).getByText("Flujos de trabajo")).toBeInTheDocument();
+    expect(within(rail).getByText("Conectores")).toBeInTheDocument();
+    expect(within(rail).getByText("Artefactos")).toBeInTheDocument();
+    expect(within(rail).getByText("Actividad")).toBeInTheDocument();
+    expect(
+      within(rail).getByLabelText("Dónde trabaja Zero"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Abrir menú")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Abrir artefactos en móvil"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Abrir automatizaciones en móvil"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Contraer barra lateral")).toBeInTheDocument();
+
+    fireEvent.keyDown(document.body, { key: "?", shiftKey: true });
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Atajos de teclado",
+    });
+    expect(
+      within(dialog).getByText("Atajos disponibles en esta página"),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByText("Mostrar atajos de teclado"),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByLabelText("Cerrar atajos de teclado"),
+    ).toBeInTheDocument();
+  });
+
   it("keeps localized navigation accessible while collapsing and expanding", async () => {
     prepareDefaultAgent();
     context.mocks.data.userPreferences({

--- a/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
@@ -128,6 +128,13 @@ export function LanguageSettings() {
                   })}
                 </SelectItem>
               )}
+              {availableLocales.includes("es-ES") && (
+                <SelectItem value="es-ES">
+                  {t(($) => {
+                    return $.settings.preferences.language.options.spanish;
+                  })}
+                </SelectItem>
+              )}
             </SelectContent>
           </Select>
         </div>

--- a/turbo/packages/api-contracts/src/contracts/client-headers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/client-headers.test.ts
@@ -3,6 +3,7 @@ import {
   addClientCapabilityToVersion,
   clientVersionSupportsCapability,
   CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
+  CLIENT_CAPABILITY_ES_ES_LOCALE,
   CLIENT_CAPABILITY_JA_JP_LOCALE,
   CLIENT_CAPABILITY_KO_KR_LOCALE,
   CLIENT_CAPABILITY_ID_ID_LOCALE,
@@ -71,21 +72,24 @@ describe("client header contract", () => {
           addClientCapabilityToVersion(
             addClientCapabilityToVersion(
               addClientCapabilityToVersion(
-                "0.636.1",
-                CLIENT_CAPABILITY_PT_BR_LOCALE,
+                addClientCapabilityToVersion(
+                  "0.636.1",
+                  CLIENT_CAPABILITY_PT_BR_LOCALE,
+                ),
+                CLIENT_CAPABILITY_JA_JP_LOCALE,
               ),
-              CLIENT_CAPABILITY_JA_JP_LOCALE,
+              CLIENT_CAPABILITY_KO_KR_LOCALE,
             ),
-            CLIENT_CAPABILITY_KO_KR_LOCALE,
+            CLIENT_CAPABILITY_ID_ID_LOCALE,
           ),
-          CLIENT_CAPABILITY_ID_ID_LOCALE,
+          CLIENT_CAPABILITY_DE_DE_LOCALE,
         ),
-        CLIENT_CAPABILITY_DE_DE_LOCALE,
+        CLIENT_CAPABILITY_ES_ES_LOCALE,
       ),
       CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
     );
     expect(version).toBe(
-      "0.636.1+pt-br-locale-v1.ja-jp-locale-v1.ko-kr-locale-v1.id-id-locale-v1.de-de-locale-v1.connector-slug-identities-v1",
+      "0.636.1+pt-br-locale-v1.ja-jp-locale-v1.ko-kr-locale-v1.id-id-locale-v1.de-de-locale-v1.es-es-locale-v1.connector-slug-identities-v1",
     );
     expect(
       clientVersionSupportsCapability(version, CLIENT_CAPABILITY_PT_BR_LOCALE),
@@ -101,6 +105,9 @@ describe("client header contract", () => {
     ).toBe(true);
     expect(
       clientVersionSupportsCapability(version, CLIENT_CAPABILITY_DE_DE_LOCALE),
+    ).toBe(true);
+    expect(
+      clientVersionSupportsCapability(version, CLIENT_CAPABILITY_ES_ES_LOCALE),
     ).toBe(true);
     expect(
       clientVersionSupportsCapability(

--- a/turbo/packages/api-contracts/src/contracts/client-headers.ts
+++ b/turbo/packages/api-contracts/src/contracts/client-headers.ts
@@ -7,6 +7,7 @@ export const CLIENT_CAPABILITY_JA_JP_LOCALE = "ja-jp-locale-v1";
 export const CLIENT_CAPABILITY_KO_KR_LOCALE = "ko-kr-locale-v1";
 export const CLIENT_CAPABILITY_ID_ID_LOCALE = "id-id-locale-v1";
 export const CLIENT_CAPABILITY_DE_DE_LOCALE = "de-de-locale-v1";
+export const CLIENT_CAPABILITY_ES_ES_LOCALE = "es-es-locale-v1";
 export const CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES =
   "connector-slug-identities-v1";
 export const ZERO_MAIL_CLIENT_VERSION_HEADER = "X-Zero-Mail-Client-Version";

--- a/turbo/packages/api-contracts/src/contracts/zero-user-preferences.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-preferences.test.ts
@@ -72,4 +72,23 @@ describe("user preferences contract", () => {
       supportedLocales: ["en-US", "pt-BR", "ja-JP", "ko-KR"],
     });
   });
+
+  it("accepts the canonical Spanish locale", () => {
+    expect(userLocaleSchema.parse("es-ES")).toBe("es-ES");
+    expect(
+      userPreferencesResponseSchema.parse({
+        timezone: null,
+        locale: "es-ES",
+        supportedLocales: ["en-US", "pt-BR", "ja-JP", "es-ES"],
+        pinnedAgentIds: [],
+        sendMode: "enter",
+        morningBriefEnabled: false,
+        morningBriefNextRunAt: null,
+        captureNetworkBodiesRemaining: 0,
+      }),
+    ).toMatchObject({
+      locale: "es-ES",
+      supportedLocales: ["en-US", "pt-BR", "ja-JP", "es-ES"],
+    });
+  });
 });

--- a/turbo/packages/api-contracts/src/contracts/zero-user-preferences.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-preferences.ts
@@ -17,6 +17,7 @@ export const SUPPORTED_USER_LOCALES = [
   "ko-KR",
   "id-ID",
   "de-DE",
+  "es-ES",
 ] as const;
 export const userLocaleSchema = z.enum(SUPPORTED_USER_LOCALES);
 export type UserLocale = z.infer<typeof userLocaleSchema>;

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -59,6 +59,7 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.KoreanLocale, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.IndonesianLocale, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.GermanLocale, {})).toBe(false);
+    expect(isFeatureEnabled(FeatureSwitchKey.SpanishLocale, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.ZeroChatMessaging, {})).toBe(
       false,
     );
@@ -143,6 +144,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.KoreanLocale]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.IndonesianLocale]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.GermanLocale]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.SpanishLocale]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ClaudeSessionPruning]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(true);
@@ -183,6 +185,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.KoreanLocale]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.IndonesianLocale]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.GermanLocale]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.SpanishLocale]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ClaudeSessionPruning]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(
@@ -274,6 +277,9 @@ describe("user-overridable switches", () => {
     expect(getUserOverridableFeatureSwitchKeys()).not.toContain(
       FeatureSwitchKey.GermanLocale,
     );
+    expect(getUserOverridableFeatureSwitchKeys()).not.toContain(
+      FeatureSwitchKey.SpanishLocale,
+    );
     expect(getUserOverridableFeatureSwitchKeys()).toContain(
       FeatureSwitchKey.ZeroBrowser,
     );
@@ -305,6 +311,7 @@ describe("user-overridable switches", () => {
         [FeatureSwitchKey.KoreanLocale]: true,
         [FeatureSwitchKey.IndonesianLocale]: true,
         [FeatureSwitchKey.GermanLocale]: true,
+        [FeatureSwitchKey.SpanishLocale]: true,
         [FeatureSwitchKey.ZeroBrowser]: true,
         [FeatureSwitchKey.ComposerConnectorPermissions]: true,
         [FeatureSwitchKey.Dummy]: false,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -47,6 +47,7 @@ export enum FeatureSwitchKey {
   KoreanLocale = "koreanLocale",
   IndonesianLocale = "indonesianLocale",
   GermanLocale = "germanLocale",
+  SpanishLocale = "spanishLocale",
   ZeroBrowser = "zeroBrowser",
   ZeroChatMessaging = "zeroChatMessaging",
   ZeroMailReplyFollowUp = "zeroMailReplyFollowUp",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -274,6 +274,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     userOverridable: false,
   },
+  [FeatureSwitchKey.SpanishLocale]: {
+    maintainer: "linghan@vm0.ai",
+    description:
+      "Allow es-ES preference writes after incompatible API readers and rollback candidates have drained.",
+    enabled: false,
+    userOverridable: false,
+  },
   [FeatureSwitchKey.Banking]: {
     maintainer: "linghan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add complete `es-ES` Platform translations, locale resources, Clerk localization, and pre-bundle copy
- negotiate Spanish support through a client capability and the `SPANISH_LOCALE_ROLLOUT_ENABLED` server gate while preserving legacy-client reads
- render and persist only locales advertised by the deployed API, including mixed-version fallback behavior

## Testing

- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/core lint`
- affected-workspace type checks and Knip checks
- API contracts: 5 tests passed
- core feature switches: 24 tests passed
- API preference negotiation: 7 tests passed
- Platform locale, settings, and auth: 39 tests passed

Closes #23995
