### PR TITLE
refactor(api): contract chat queue admission lock

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -791,10 +791,7 @@ describe("workflow queue", () => {
     await expect.poll(admissionLock.directWaiterCount).toBe(1);
 
     const secondRequest = postWorkflowWebhook(automation, "second concurrent");
-    // The first admission holds the legacy key while waiting on the canonical
-    // key; the second admission must wait behind it on that same legacy key.
-    await expect.poll(admissionLock.transitiveWaiterCount).toBe(2);
-    await expect.poll(admissionLock.directWaiterCount).toBe(1);
+    await expect.poll(admissionLock.directWaiterCount).toBe(2);
     await expect(
       pendingWorkflowEvents(automation.threadId),
     ).resolves.toStrictEqual([]);

--- a/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
@@ -109,18 +109,9 @@ async function chatEventQueueAdmissionLock(
   tx: WorkflowQueueAdmissionTransaction,
   chatThreadId: string,
 ): Promise<void> {
-  // Release 1 of the two-phase namespace migration: every admission acquires
-  // the legacy key before the canonical key while API revisions overlap.
-  // Release 2 may drop the legacy key only after Release 1 is fully rolled out
-  // and its rollback target has drained.
-  const compatibilityKey = `chat_message_queue:${chatThreadId}`;
-  const canonicalKey = `chat_event_queue:${chatThreadId}`;
-  await tx.execute(
-    sql`SELECT pg_advisory_xact_lock(hashtext(${compatibilityKey}))`,
-  );
-  await tx.execute(
-    sql`SELECT pg_advisory_xact_lock(hashtext(${canonicalKey}))`,
-  );
+  // Serialize every admission and claim transaction for the same chat thread.
+  const lockKey = `chat_event_queue:${chatThreadId}`;
+  await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`);
 }
 
 /** Any active thread-bound run preserves strict per-thread serialization. */

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -392,9 +392,8 @@ export async function holdOrgAdmissionLockFixture(args: {
 }
 
 /**
- * Holds the canonical workflow queue admission key so tests can observe the
- * Release 1 lock chain: the first request holds the legacy key while waiting
- * here, and a concurrent request for the same thread waits behind it.
+ * Holds the workflow queue admission key so tests can observe concurrent
+ * requests waiting on the per-thread lock.
  */
 export async function holdChatEventQueueAdmissionLockFixture(args: {
   readonly threadId: string;
@@ -403,7 +402,6 @@ export async function holdChatEventQueueAdmissionLockFixture(args: {
   readonly release: () => void;
   readonly done: Promise<void>;
   readonly directWaiterCount: () => Promise<number>;
-  readonly transitiveWaiterCount: () => Promise<number>;
 }> {
   const started = createDeferredPromise<number>(args.signal);
   const released = createDeferredPromise<void>(args.signal);
@@ -436,9 +434,6 @@ export async function holdChatEventQueueAdmissionLockFixture(args: {
     done,
     directWaiterCount: async () => {
       return await directBlockedWaiterCount(holderPid);
-    },
-    transitiveWaiterCount: async () => {
-      return await transitiveBlockedWaiterCount(holderPid);
     },
   };
 }


### PR DESCRIPTION
## Summary

- remove the legacy `chat_message_queue:<threadId>` advisory lock from workflow chat queue admission and claim transactions
- acquire only the canonical `chat_event_queue:<threadId>` advisory lock and replace the rollout comment with the steady-state serialization contract
- keep the Release 1 concurrency regression and update it to prove both same-thread admissions wait directly on the single canonical key

## Release plan and gate

This is **Release 2 (contract)** of the two-release advisory-lock namespace migration in #23925.

Release 1 (#23941) was merged at 2026-07-30 06:03 UTC and shipped in `api-v1.348.0` at 06:22 UTC. A later API revision, `api-v1.350.0`, shipped at 09:42 UTC. Zero confirmed at 10:12 UTC that the Release 1 rollout was complete and its rollback target had drained, so every overlapping API revision now holds the canonical key.

## Compatibility

- no change to admission semantics, priority, FIFO, or schedule-tick coalescing
- no database migration
- no remaining `chat_message` string in `workflow-chat-event-queue.service.ts`

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/workflow-chat-event-queue.service.ts apps/api/src/test-fixtures/chat-events.ts apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts -t "serializes concurrent workflow admissions for the same thread" --maxWorkers=1 --silent=passed-only`

Closes #23925