### PR TITLE
fix(cli): emit connector slug in permission action urls

### DIFF
--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -28,9 +28,9 @@ state creation inside React render.
 The body parser accepts platform links in common message forms:
 
 ```markdown
-https://app.vm0.ai/agents/agent-123/permissions?ref=slack&permission=messages.write
+https://app.vm0.ai/agents/agent-123/permissions?connectorSlug=slack&permission=messages.write
 
-[Review permission](https://app.vm0.ai/agents/agent-123/permissions?ref=slack&permission=messages.write)
+[Review permission](https://app.vm0.ai/agents/agent-123/permissions?connectorSlug=slack&permission=messages.write)
 
 /computer-use/authorize/request-token
 ```
@@ -42,8 +42,8 @@ link remains ordinary Markdown.
 
 Current link-backed card patterns include:
 
-- `/connectors/:connectorRef/connect` and
-  `/connectors/:connectorRef/authorize`
+- `/connectors/:connectorSlug/connect` and
+  `/connectors/:connectorSlug/authorize`
 - `/connectors/custom/proposal?p=...`
 - `/agents/:agentId/permissions?...`
 - `/computer-use/authorize/:requestToken`

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/permission-request.test.ts
@@ -83,7 +83,8 @@ describe("zero connector permission-request command", () => {
     );
     expect(logCalls).toContain("[Manage Slack permissions]");
     expect(logCalls).toContain("/agents/agent-abc-123/permissions?");
-    expect(logCalls).toContain("ref=slack");
+    expect(logCalls).toContain("connectorSlug=slack");
+    expect(logCalls).not.toContain("ref=");
     expect(logCalls).toContain(
       `permission=${encodeURIComponent(SLACK_READ_PERMISSION)}`,
     );
@@ -109,7 +110,7 @@ describe("zero connector permission-request command", () => {
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("/agents/agent-abc-123/permissions?");
     expect(logCalls).not.toContain("/workflows/wf-789/permissions?");
-    expect(logCalls).toContain("ref=slack");
+    expect(logCalls).toContain("connectorSlug=slack");
     expect(logCalls).toContain(
       `permission=${encodeURIComponent(SLACK_READ_PERMISSION)}`,
     );
@@ -134,6 +135,8 @@ describe("zero connector permission-request command", () => {
     ]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("connectorSlug=slack");
+    expect(logCalls).not.toContain("ref=");
     expect(logCalls).toContain("action=allow");
     expect(logCalls).toContain("threadId=thread-abc-123");
     expect(logCalls).toContain(
@@ -209,7 +212,7 @@ describe("zero connector permission-request command", () => {
       "You can allow unknown endpoints for your connector access",
     );
     expect(logCalls).toContain("[Manage Cloudflare permissions]");
-    expect(logCalls).toContain("ref=cloudflare");
+    expect(logCalls).toContain("connectorSlug=cloudflare");
     expect(logCalls).toContain("permission=__unknown__");
     expect(logCalls).toContain("action=allow");
     expect(logCalls).not.toContain("expiresIn=");
@@ -248,7 +251,7 @@ describe("zero connector permission-request command", () => {
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("/agents/target-agent-123/permissions?");
-    expect(logCalls).toContain("ref=slack");
+    expect(logCalls).toContain("connectorSlug=slack");
     expect(logCalls).toContain("action=allow");
   });
 
@@ -351,7 +354,7 @@ describe("zero connector permission-request command", () => {
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("[Manage Server Only permissions]");
-    expect(logCalls).toContain("ref=server-only");
+    expect(logCalls).toContain("connectorSlug=server-only");
     expect(logCalls).toContain("permission=records.read");
   });
 

--- a/turbo/apps/cli/src/commands/zero/connector/permission-request.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/permission-request.ts
@@ -167,7 +167,7 @@ async function outputPermissionRequestMessage(
   const platformOrigin = await getPlatformOrigin();
 
   const urlParams = new URLSearchParams({
-    ref: connectorSlug,
+    connectorSlug,
     permission,
     action: "allow",
   });


### PR DESCRIPTION
## Summary

- emit the canonical `connectorSlug` query key from
  `zero connector permission-request`
- preserve the Platform origin, permission path, connector value, agent,
  permission, action, callback fields, guidance, and command syntax
- verify ordinary and callback URLs contain `connectorSlug` and omit the legacy
  connector identity key
- update chat-card examples and connector route placeholders to canonical slug
  terminology

## Compatibility

- #23776 / PR #23981 is deployed from `app-v0.661.1`, and the current Platform
  permission page and chat action parser accept `connectorSlug ?? ref`
- historical `ref` links remain readable until #23823
- no API schema, Platform source, database, persisted-row, feature-switch, or
  runner change is included
- after release, record the first canonical CLI version and timestamp on
  #23823 before removing the historical reader

## Validation

- `pnpm exec prettier --write apps/cli/src/commands/zero/connector/permission-request.ts apps/cli/src/commands/zero/connector/__tests__/permission-request.test.ts`
- `pnpm exec prettier --write ../docs/chat-cards.md`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/connector/__tests__/permission-request.test.ts --maxWorkers=4 --silent=passed-only` — 28 passed
- `pnpm -F @vm0/cli exec vitest run --maxWorkers=4 --silent=passed-only` — 979 passed, 1 skipped
- `pnpm -F @vm0/cli build`
- `pnpm knip --workspace @vm0/cli`
- `lefthook run pre-commit`

Closes #23957

Parent: #23814
