### PR TITLE
refactor: remove legacy chat message capability aliases

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -102,26 +102,6 @@ describe("auth tokens", () => {
     });
   });
 
-  it("normalizes legacy chat message capabilities to chat event capabilities", () => {
-    const nowSeconds = currentSecond();
-    const token = signSandboxJwtForTests({
-      scope: "zero",
-      userId: "user_zero",
-      orgId: "org_zero",
-      runId: "run_zero",
-      capabilities: ["chat-message:read", "chat-message:write"],
-      iat: nowSeconds,
-      exp: nowSeconds + 60,
-    });
-
-    expect(verifyZeroToken(token)).toStrictEqual({
-      userId: "user_zero",
-      orgId: "org_zero",
-      runId: "run_zero",
-      capabilities: ["chat-event:read", "chat-event:write"],
-    });
-  });
-
   it("rejects expired tokens and mismatched scopes", () => {
     const nowSeconds = currentSecond();
     const expiredToken = signPatJwtForTests({
@@ -177,12 +157,6 @@ describe("auth tokens", () => {
         "chat-event:read",
         "chat-event:write",
       ]),
-    });
-    expect(decodeZeroTokenPayloadForTest(token)).not.toMatchObject({
-      capabilities: expect.arrayContaining(["chat-message:read"]),
-    });
-    expect(decodeZeroTokenPayloadForTest(token)).not.toMatchObject({
-      capabilities: expect.arrayContaining(["chat-message:write"]),
     });
     expect(verifyZeroToken(token)?.capabilities).toContain("chat-event:read");
     expect(verifyZeroToken(token)?.capabilities).toContain("chat-event:write");

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -58,30 +58,13 @@ function isZeroCapability(value: string): value is ZeroCapability {
   });
 }
 
-function normalizeZeroCapability(capability: string): string {
-  switch (capability) {
-    case "chat-message:read": {
-      return "chat-event:read";
-    }
-    case "chat-message:write": {
-      return "chat-event:write";
-    }
-    default: {
-      return capability;
-    }
-  }
-}
-
 // Capability names are open-ended at the token boundary so tokens issued by a
 // newer API remain valid on an older API. The validated output remains closed
 // to known capabilities so unknown names cannot grant permissions.
 const zeroCapabilitiesSchema = z
   .array(z.string().min(1))
   .transform((capabilities) => {
-    return capabilities.flatMap((capability) => {
-      const normalized = normalizeZeroCapability(capability);
-      return isZeroCapability(normalized) ? [normalized] : [];
-    });
+    return capabilities.filter(isZeroCapability);
   })
   .readonly();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-get.test.ts
@@ -158,31 +158,6 @@ describe("GET /api/zero/chat-threads/:threadId/events", () => {
     });
   });
 
-  it("lists events with the legacy chat-message:read capability", async () => {
-    const fixture = await seedChatThread("Launch plan");
-    const seconds = currentSecond();
-    const token = signSandboxJwtForTests({
-      scope: "zero",
-      userId: fixture.userId,
-      orgId: fixture.orgId,
-      runId: `run_${randomUUID()}`,
-      capabilities: ["chat-message:read"],
-      iat: seconds,
-      exp: seconds + 600,
-    });
-
-    const response = await accept(
-      eventsClient().list({
-        headers: { authorization: `Bearer ${token}` },
-        params: { threadId: fixture.threadId },
-        query: {},
-      }),
-      [200],
-    );
-
-    expect(response.body).toStrictEqual({ events: [] });
-  });
-
   it("rejects ZERO_TOKEN without chat-event:read capability", async () => {
     const fixture = await seedChatThread("Launch plan");
     const token = zeroToken({

--- a/turbo/apps/cli/CHANGELOG.md
+++ b/turbo/apps/cli/CHANGELOG.md
@@ -8219,7 +8219,7 @@
 
 * add zero web upload-file and file:read/file:write caps ([#10256](https://github.com/vm0-ai/vm0/issues/10256)) ([497dc17](https://github.com/vm0-ai/vm0/commit/497dc17f454d584e1427b10a6ae3e28a63c7c726))
 * **cli:** implement zero search --source slack static recipe ([#10270](https://github.com/vm0-ai/vm0/issues/10270)) ([dbb30e7](https://github.com/vm0-ai/vm0/commit/dbb30e79d1ea64cc6c7466e6b1eb897b489664b7))
-* **cli:** scaffold zero search command and chat-message:read capability ([#10251](https://github.com/vm0-ai/vm0/issues/10251)) ([bc6cb51](https://github.com/vm0-ai/vm0/commit/bc6cb51312022317278d86896e360cca6ef777f4))
+* **cli:** scaffold zero search command and chat message read capability ([#10251](https://github.com/vm0-ai/vm0/issues/10251)) ([bc6cb51](https://github.com/vm0-ai/vm0/commit/bc6cb51312022317278d86896e360cca6ef777f4))
 
 
 ### Bug Fixes
@@ -8540,7 +8540,7 @@
 
 ### Features
 
-* add zero chat message send command with chat-message:write capability ([#9580](https://github.com/vm0-ai/vm0/issues/9580)) ([93692d7](https://github.com/vm0-ai/vm0/commit/93692d7cff357a7d9d015e194dd134f475dd9ccb))
+* add zero chat message send command with chat message write capability ([#9580](https://github.com/vm0-ai/vm0/issues/9580)) ([93692d7](https://github.com/vm0-ai/vm0/commit/93692d7cff357a7d9d015e194dd134f475dd9ccb))
 
 
 ### Dependencies

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -115,23 +115,6 @@ describe("decodeZeroTokenPayload", () => {
     });
   });
 
-  it("should normalize legacy chat message capabilities", () => {
-    const token = buildZeroToken({
-      userId: "user-1",
-      runId: "run-1",
-      orgId: "org-1",
-      scope: "zero",
-      capabilities: ["chat-message:read", "chat-message:write"],
-      iat: 1000,
-      exp: 2000,
-    });
-
-    expect(decodeZeroTokenPayload(token)?.capabilities).toStrictEqual([
-      "chat-event:read",
-      "chat-event:write",
-    ]);
-  });
-
   it("should return undefined for token without vm0_sandbox_ prefix", () => {
     expect(decodeZeroTokenPayload("some-other-token")).toBeUndefined();
   });

--- a/turbo/apps/cli/src/lib/api/zero-token.ts
+++ b/turbo/apps/cli/src/lib/api/zero-token.ts
@@ -11,20 +11,6 @@ export interface ZeroTokenPayload {
   exp: number;
 }
 
-function normalizeZeroCapability(capability: string): string {
-  switch (capability) {
-    case "chat-message:read": {
-      return "chat-event:read";
-    }
-    case "chat-message:write": {
-      return "chat-event:write";
-    }
-    default: {
-      return capability;
-    }
-  }
-}
-
 /**
  * Decode a ZERO_TOKEN JWT payload.
  * Only decodes — does NOT verify signature (server does that).
@@ -49,10 +35,7 @@ export function decodeZeroTokenPayload(
       Buffer.from(parts[1]!, "base64url").toString(),
     ) as ZeroTokenPayload;
     if (payload.scope === "zero" && Array.isArray(payload.capabilities)) {
-      return {
-        ...payload,
-        capabilities: payload.capabilities.map(normalizeZeroCapability),
-      };
+      return payload;
     }
   } catch {
     // Malformed token — fall through

--- a/turbo/packages/api-contracts/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/composes.test.ts
@@ -147,8 +147,6 @@ describe("ZERO_CAPABILITIES", () => {
   it("should include chat event read and write capabilities", () => {
     expect(ZERO_CAPABILITIES).toContain("chat-event:read");
     expect(ZERO_CAPABILITIES).toContain("chat-event:write");
-    expect(ZERO_CAPABILITIES).not.toContain("chat-message:read");
-    expect(ZERO_CAPABILITIES).not.toContain("chat-message:write");
   });
 });
 

--- a/turbo/packages/core/CHANGELOG.md
+++ b/turbo/packages/core/CHANGELOG.md
@@ -8052,7 +8052,7 @@
 ### Features
 
 * add zero web upload-file and file:read/file:write caps ([#10256](https://github.com/vm0-ai/vm0/issues/10256)) ([497dc17](https://github.com/vm0-ai/vm0/commit/497dc17f454d584e1427b10a6ae3e28a63c7c726))
-* **cli:** scaffold zero search command and chat-message:read capability ([#10251](https://github.com/vm0-ai/vm0/issues/10251)) ([bc6cb51](https://github.com/vm0-ai/vm0/commit/bc6cb51312022317278d86896e360cca6ef777f4))
+* **cli:** scaffold zero search command and chat message read capability ([#10251](https://github.com/vm0-ai/vm0/issues/10251)) ([bc6cb51](https://github.com/vm0-ai/vm0/commit/bc6cb51312022317278d86896e360cca6ef777f4))
 * **voice-io:** gate audio input by org tier with free-tier quota ([#10258](https://github.com/vm0-ai/vm0/issues/10258)) ([2df8bb8](https://github.com/vm0-ai/vm0/commit/2df8bb8bf4baf7fbc744e20a621bd9a1107ba552))
 
 
@@ -8318,7 +8318,7 @@
 
 * add auth.query support to firewall schema for query-parameter authentication ([#9583](https://github.com/vm0-ai/vm0/issues/9583)) ([c39727a](https://github.com/vm0-ai/vm0/commit/c39727abd12ddd86271294324cf352fe86f96658))
 * add GET /api/zero/chat-threads/:id/messages with sinceId cursor pagination ([#9561](https://github.com/vm0-ai/vm0/issues/9561)) ([dcc04b4](https://github.com/vm0-ai/vm0/commit/dcc04b4feb23d25c75220b4ad983b91c0dd56fee))
-* add zero chat message send command with chat-message:write capability ([#9580](https://github.com/vm0-ai/vm0/issues/9580)) ([93692d7](https://github.com/vm0-ai/vm0/commit/93692d7cff357a7d9d015e194dd134f475dd9ccb))
+* add zero chat message send command with chat message write capability ([#9580](https://github.com/vm0-ai/vm0/issues/9580)) ([93692d7](https://github.com/vm0-ai/vm0/commit/93692d7cff357a7d9d015e194dd134f475dd9ccb))
 
 ## [8.189.1](https://github.com/vm0-ai/vm0/compare/core-v8.189.0...core-v8.189.1) (2026-04-16)
 


### PR DESCRIPTION
## Summary

- remove the Release 1 legacy capability normalizers from the API Zero token verifier and CLI Zero token decoder
- validate API token capabilities directly against the closed `ZERO_CAPABILITIES` set without changing unknown-capability filtering or any authorization semantics
- remove only compatibility-window tests while retaining canonical `chat-event:read` / `chat-event:write` authorization and CLI command-visibility coverage
- remove the retired claim spellings from historical changelog text so the repository has zero exact legacy-string matches

## Release 2 gate

Release 1 from #23946 is included in `api-v1.348.0`, published at **2026-07-30 06:22:45 UTC**. `generateZeroToken()` sets `exp = iat + 2 hours`, matching the maximum run duration, so tokens issued before that deployment could no longer be valid after **08:22:45 UTC**.

The gate was rechecked at **2026-07-30 10:16:11 UTC** (3h 53m after Release 1). A read-only production query found zero `agent_runs` created before the Release 1 publication time with status `queued`, `pending`, or `running`. The later `api-v1.350.0` release was also published at **09:42:36 UTC**. Therefore no pre-Release-1 active run or valid legacy-claim token remains.

## Scope

- no capability semantic or authorization-policy changes
- no changes to other capability namespaces
- no migration

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- API contracts focused test: 39 passed
- CLI capability and command-visibility focused test: 79 passed
- API token focused test: 17 passed
- API chat-thread authorization focused test: 4 passed
- repository search: zero matches for the retired claim spellings and `normalizeZeroCapability`
- full test matrix and `lint-knip` remain required PR pipeline gates before merge

Closes #23921