### PR TITLE
feat: enable composer skill search and slack dm routing globally

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -1158,18 +1158,6 @@ export function createBddIntegrationApi(context: TestContext) {
       );
     },
 
-    async enableSlackDmSessionRoutingSwitch(actor: ApiTestUser): Promise<void> {
-      await accept(
-        setupApp({ context })(zeroFeatureSwitchesContract).update({
-          headers: authenticate(context, routeMocks, actor),
-          body: {
-            switches: { [FeatureSwitchKey.SlackDmSessionRouting]: true },
-          },
-        }),
-        [200],
-      );
-    },
-
     async configureUnpinnedSlackModelRoute(actor: ApiTestUser): Promise<void> {
       const providers = setupApp({ context })(zeroModelProvidersMainContract);
       // openrouter-api-key is a claude-code provider whose catalog entry has

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -1899,7 +1899,6 @@ describe("INT-01: Slack app deep webhook flows", () => {
   it("forks Slack DM threads without replacing the main session", async () => {
     const actor = bdd.user();
     bdd.acceptAgentStorageWrites();
-    await integrations.enableSlackDmSessionRoutingSwitch(actor);
     runs.acceptStorageDownloads();
     runs.acceptTelemetryIngest();
     integrations.configureSlackAppMocks();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -262,9 +262,6 @@ describe("chat composer models", () => {
     detachedSetupPage({
       context,
       path: `/agents/${AGENT_ID}/chat`,
-      featureSwitches: {
-        [FeatureSwitchKey.ComposerSkillSubstringSearch]: true,
-      },
     });
 
     const editor = await findComposerEditor();

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -20,6 +20,12 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.LanguagePreference, {})).toBe(
       true,
     );
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.ComposerSkillSubstringSearch, {}),
+    ).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.SlackDmSessionRouting, {})).toBe(
+      true,
+    );
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -140,6 +146,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ComposerSkillSubstringSearch]).toBe(
       true,
     );
+    expect(staffOrgStates[FeatureSwitchKey.SlackDmSessionRouting]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.Artifacts]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.HostedArtifactVersions]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ImageStyleR2]).toBe(true);
@@ -174,8 +181,9 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.ComposerSkillSubstringSearch]).toBe(
-      false,
+      true,
     );
+    expect(otherOrgStates[FeatureSwitchKey.SlackDmSessionRouting]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.Artifacts]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ImageStyleR2]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -386,8 +386,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "yuma@vm0.ai",
     description:
       "Match chat composer slash skill suggestions by any slug substring instead of only prefixes.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ThreeColumnNav]: {
     maintainer: "ming@vm0.ai",
@@ -407,8 +406,8 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.SlackDmSessionRouting]: {
     maintainer: "yuma@vm0.ai",
     description:
-      "Reuse agent/model-scoped sessions for top-level Slack direct messages after compatible callback readers are deployed.",
-    enabled: false,
+      "Reuse agent/model-scoped sessions for top-level Slack direct messages.",
+    enabled: true,
   },
   [FeatureSwitchKey.TeamsIntegration]: {
     maintainer: "linghan@vm0.ai",


### PR DESCRIPTION
## Summary

- enable composer slash-skill substring search for every organization
- enable agent/model-scoped session routing for top-level Slack direct messages
- exercise both behaviors through their default-on integration paths and remove the obsolete Slack test override helper

## Testing

- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts --silent=passed-only`
- `pnpm -F @vm0/core lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/core`
- `pnpm knip --workspace api`
- `pnpm knip --workspace @vm0/app`
