### PR TITLE
refactor(insights): stop writing legacy connector type

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-aggregate-insights.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-aggregate-insights.test.ts
@@ -22,6 +22,7 @@ import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import {
   insertUsageEvent$,
   materializeHourlyUsage$,
+  readInsightsDailyPermissions$,
 } from "./helpers/zero-usage-insight";
 
 /**
@@ -818,6 +819,35 @@ describe("GET /api/cron/aggregate-insights", () => {
     defaultClerkMocksFor(seeded);
 
     await runAggregation();
+
+    if (!seeded.actor.orgId) {
+      throw new Error("Expected an org-scoped actor");
+    }
+    const storedPermissions = await store.set(
+      readInsightsDailyPermissions$,
+      {
+        orgId: seeded.actor.orgId,
+        userId: seeded.actor.userId,
+        date: TODAY,
+      },
+      context.signal,
+    );
+    expect(storedPermissions).toHaveLength(2);
+    expect(storedPermissions).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          connectorSlug: "github",
+          denied: 2,
+        }),
+        expect.objectContaining({
+          connectorSlug: "github",
+          allowed: 1,
+        }),
+      ]),
+    );
+    for (const permission of storedPermissions) {
+      expect(permission).not.toHaveProperty("connectorType");
+    }
 
     const data = await findInsights(seeded.actor);
     const githubDeny = data?.permissions.find((permission) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
@@ -492,6 +492,31 @@ export const readUsageCompactionStorageCounts$ = command(
   },
 );
 
+export const readInsightsDailyPermissions$ = command(
+  async (
+    _,
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly date: string;
+    },
+    signal: AbortSignal,
+  ): Promise<readonly Record<string, unknown>[]> => {
+    const response = await postAction(signal, {
+      action: "read-insights-daily-permissions",
+      org_id: args.orgId,
+      user_id: args.userId,
+      date: args.date,
+    });
+    if (response.insights_daily_permissions === undefined) {
+      throw new Error(
+        "readInsightsDailyPermissions$: response missing permissions",
+      );
+    }
+    return response.insights_daily_permissions;
+  },
+);
+
 export const deleteUsageData$ = command(
   async (
     _,

--- a/turbo/apps/api/src/signals/routes/test-usage-insight-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-usage-insight-state.ts
@@ -13,6 +13,7 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { connectors } from "@vm0/db/schema/connector";
+import { insightsDaily } from "@vm0/db/schema/insights-daily";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import {
   orgUsageAllowanceEntitlements,
@@ -118,6 +119,7 @@ type UsageInsightEventMaterializationAction = UsageInsightAction<
   | "set-usage-event-created-at"
   | "materialize-hourly-usage"
   | "read-usage-storage-counts"
+  | "read-insights-daily-permissions"
 >;
 
 type UsageInsightCleanupAction = UsageInsightAction<"delete-usage-data">;
@@ -930,6 +932,41 @@ async function readUsageStorageCounts(
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readInsightsDailyPermissions(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly date: string;
+  },
+): Promise<readonly Record<string, unknown>[]> {
+  const [row] = await db
+    .select({ data: insightsDaily.data })
+    .from(insightsDaily)
+    .where(
+      and(
+        eq(insightsDaily.orgId, args.orgId),
+        eq(insightsDaily.userId, args.userId),
+        eq(insightsDaily.date, args.date),
+      ),
+    )
+    .limit(1);
+  if (!row || !isRecord(row.data)) {
+    throw new Error("readInsightsDailyPermissions: insight data not found");
+  }
+  const { permissions } = row.data;
+  if (!Array.isArray(permissions) || !permissions.every(isRecord)) {
+    throw new Error(
+      "readInsightsDailyPermissions: insight permissions not found",
+    );
+  }
+  return permissions;
+}
+
 async function readUsageEventState(
   db: Db,
   idempotencyKey: string,
@@ -1222,6 +1259,21 @@ async function mutateUsageInsightEventMaterializationState(
         },
       };
     }
+    case "read-insights-daily-permissions": {
+      const permissions = await readInsightsDailyPermissions(db, {
+        orgId: body.org_id,
+        userId: body.user_id,
+        date: body.date,
+      });
+      signal.throwIfAborted();
+      return {
+        status: 200 as const,
+        body: {
+          ok: true as const,
+          insights_daily_permissions: permissions,
+        },
+      };
+    }
   }
 }
 
@@ -1265,7 +1317,8 @@ async function mutateUsageInsightState(
     case "seed-usage-overflow-grain":
     case "set-usage-event-created-at":
     case "materialize-hourly-usage":
-    case "read-usage-storage-counts": {
+    case "read-usage-storage-counts":
+    case "read-insights-daily-permissions": {
       return await mutateUsageInsightEventMaterializationState(
         db,
         body,

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -120,8 +120,6 @@ interface InsightData {
   readonly permissions: {
     readonly label: string;
     readonly connectorSlug: string;
-    // TODO(#23839): Stop writing after pre-expand API writers have drained.
-    readonly connectorType: string;
     readonly allowed: number;
     readonly denied: number;
     readonly agentNames: string[];
@@ -568,7 +566,6 @@ function buildUserInsight(args: BuildUserInsightArgs): InsightData {
           return {
             label: permission.label,
             connectorSlug: permission.connectorSlug,
-            connectorType: permission.connectorSlug,
             allowed: permission.allowed,
             denied: permission.denied,
             agentNames: [...permission.agentNames],

--- a/turbo/packages/api-contracts/src/contracts/test-usage-insight-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-usage-insight-state.ts
@@ -135,6 +135,12 @@ export const testUsageInsightStateActionBodySchema = z.discriminatedUnion(
       id: z.string(),
     }),
     z.object({
+      action: z.literal("read-insights-daily-permissions"),
+      org_id: z.string(),
+      user_id: z.string(),
+      date: z.string(),
+    }),
+    z.object({
       action: z.literal("delete-usage-data"),
       scope: z.enum(["organization", "user"]),
       id: z.string(),
@@ -162,6 +168,9 @@ export const testUsageInsightStateActionResponseSchema = z.object({
   raw_allowance_units: z.string().optional(),
   hourly_allowance_units: z.string().optional(),
   allocation_count: z.number().optional(),
+  insights_daily_permissions: z
+    .array(z.record(z.string(), z.unknown()))
+    .optional(),
 });
 
 export const testUsageInsightStateContract = c.router({


### PR DESCRIPTION
## Summary

- stop the hourly insights aggregator from persisting the legacy
  `connectorType` permission field
- keep `connectorSlug` as the canonical stored connector identity
- verify canonical-only JSONB through the existing gated test-state API while
  preserving the dual-field compatibility response from
  `GET /api/zero/insights`

## Compatibility and scope

- existing legacy and dual stored rows remain readable
- old Platform clients continue receiving the `connectorType` response alias
- no database migration, historical data rewrite, Axiom query change, or
  Platform cleanup is included
- final stored/API/Platform compatibility removal remains #23840

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-aggregate-insights.test.ts src/signals/routes/__tests__/zero-insights.test.ts src/signals/routes/__tests__/test-usage-insight-state.test.ts --maxWorkers=4 --silent=passed-only`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/zero-insights.test.ts --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/network-insights/__tests__/network-insights-page.test.tsx --silent=passed-only`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm knip --workspace api`
- `pnpm knip --workspace @vm0/api-contracts`
- `lefthook run pre-commit`

Closes #23839

Part of #23834
