### PR TITLE
fix: make chat run finished automations claimable

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
@@ -261,7 +261,7 @@ describe("chat-run-finished workflow automations", () => {
   });
 
   it(
-    "fires matching automations when a watched run completes",
+    "fires claimable matching automations when a watched run completes",
     { timeout: 30_000 },
     async () => {
       const fixture = await setupChatAutomationFixture();
@@ -304,6 +304,17 @@ describe("chat-run-finished workflow automations", () => {
       await expectAutomationFired(patternMatch);
       await expect(automationLastRunAt(failedOnly)).resolves.toBeNull();
       await expect(automationLastRunAt(patternMiss)).resolves.toBeNull();
+
+      const automationRuns = await api.listAgentRuns(fixture.actor, {
+        status: "pending",
+        limit: 20,
+      });
+      expect(automationRuns.runs).toHaveLength(2);
+      const automationRunId = automationRuns.runs[0]?.id;
+      if (!automationRunId) {
+        throw new Error("Expected a triggered automation run");
+      }
+      await claimChatRun(fixture.runnerGroup, automationRunId);
     },
   );
 

--- a/turbo/apps/api/src/signals/services/chat-run-finished-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-run-finished-workflow-event.service.ts
@@ -12,7 +12,7 @@ import {
 import { and, eq, sql } from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
-import { nowDate } from "../../lib/time";
+import { now, nowDate } from "../../lib/time";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import {
   buildChatOnlyWorkflowAutomationCallbacks,
@@ -201,7 +201,7 @@ export const dispatchChatRunFinishedWorkflowEvents$ = command(
             workflowName: row.workflowName,
             chatThreadId,
           },
-          apiStartTime: performance.now(),
+          apiStartTime: now(),
           triggerSource: "workflow-event",
           prompt: workflowAutomationPrompt(context),
           appendSystemPrompt: workflowAutomationAppendSystemPrompt(context),


### PR DESCRIPTION
## Summary

- use the canonical epoch-millisecond clock when dispatching `chat-run-finished` workflow automations
- extend the existing API BDD to claim a triggered automation run and cover the runner execution-context contract

## Verification

- `corepack pnpm exec prettier --check apps/api/src/signals/services/chat-run-finished-workflow-event.service.ts apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 corepack pnpm --filter api run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 corepack pnpm knip --workspace api`
- `corepack pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test corepack pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts`
