### PR TITLE
ci: overlap app domain validation with deployment

### DIFF
--- a/.github/scripts/manage-okou-pages-domain.sh
+++ b/.github/scripts/manage-okou-pages-domain.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if (( $# < 5 )); then
-  echo "usage: $0 <ensure|delete> <account-id> <zone-id> <project-name> <domain> [branch]" >&2
+  echo "usage: $0 <begin|finish|ensure|delete> <account-id> <zone-id> <project-name> <domain> [branch]" >&2
   exit 1
 fi
 
@@ -76,7 +76,6 @@ upsert_cname() {
       --arg target "$target" \
       '.type == "CNAME" and .content == $target and .proxied == true and .ttl == 1' \
       <<< "$record" >/dev/null; then
-      echo "Cloudflare DNS record already configured: ${domain} -> ${target}"
       return
     fi
 
@@ -92,46 +91,84 @@ upsert_cname() {
   fi
 }
 
-case "$action" in
-  ensure)
-    : "${branch:?branch is required for ensure}"
+domain_is_active() {
+  local domain_state="$1"
 
-    domain_state="$(pages_domain_state)"
-    if pages_domain_missing <<< "$domain_state"; then
-      cloudflare_request \
-        --request POST \
-        "$pages_domains_url" \
-        --data "$(jq -n --arg name "$domain" '{name: $name}')" >/dev/null
-      domain_state="$(cloudflare_request "${pages_domains_url}/${domain}")"
-    else
-      require_cloudflare_success <<< "$domain_state"
-    fi
+  [[ "$(jq -r '.result.status' <<< "$domain_state")" == "active" ||
+    "$(jq -r '.result.verification_data.status' <<< "$domain_state")" == "active" ]]
+}
 
-    domain_status="$(jq -r '.result.status' <<< "$domain_state")"
+begin_domain_validation() {
+  local domain_state
+
+  domain_state="$(pages_domain_state)"
+  if pages_domain_missing <<< "$domain_state"; then
+    cloudflare_request \
+      --request POST \
+      "$pages_domains_url" \
+      --data "$(jq -n --arg name "$domain" '{name: $name}')" >/dev/null
+    domain_state="$(cloudflare_request "${pages_domains_url}/${domain}")"
+  else
+    require_cloudflare_success <<< "$domain_state"
+  fi
+
+  if domain_is_active "$domain_state"; then
+    upsert_cname "${branch}.${project_name}.pages.dev"
+    printf 'active\n'
+    return
+  fi
+
+  upsert_cname "${project_name}.pages.dev"
+  printf 'pending\n'
+}
+
+finish_domain_validation() {
+  local domain_state
+  local verification_status
+
+  domain_state="$(cloudflare_request "${pages_domains_url}/${domain}")"
+  if ! domain_is_active "$domain_state"; then
+    upsert_cname "${project_name}.pages.dev"
     verification_status="$(jq -r '.result.verification_data.status' <<< "$domain_state")"
 
-    if [[ "$domain_status" != "active" && "$verification_status" != "active" ]]; then
-      upsert_cname "${project_name}.pages.dev"
-
-      # A newly-created Pages custom domain can take longer than a minute to
-      # publish ownership verification even after its CNAME is visible.
-      for _ in {1..90}; do
-        domain_state="$(cloudflare_request "${pages_domains_url}/${domain}")"
-        verification_status="$(jq -r '.result.verification_data.status' <<< "$domain_state")"
-        if [[ "$verification_status" == "active" ]]; then
-          break
-        fi
-        sleep 2
-      done
-
-      if [[ "$verification_status" != "active" ]]; then
-        echo "Cloudflare Pages did not verify ${domain}" >&2
-        exit 1
+    # A newly-created Pages custom domain can take longer than a minute to
+    # publish ownership verification even after its CNAME is visible.
+    for _ in {1..90}; do
+      domain_state="$(cloudflare_request "${pages_domains_url}/${domain}")"
+      verification_status="$(jq -r '.result.verification_data.status' <<< "$domain_state")"
+      if [[ "$verification_status" == "active" ]]; then
+        break
       fi
-    fi
+      sleep 2
+    done
 
-    upsert_cname "${branch}.${project_name}.pages.dev"
-    echo "Cloudflare Pages custom branch domain configured: https://${domain}"
+    if [[ "$verification_status" != "active" ]]; then
+      echo "Cloudflare Pages did not verify ${domain}" >&2
+      exit 1
+    fi
+  fi
+
+  upsert_cname "${branch}.${project_name}.pages.dev"
+  echo "Cloudflare Pages custom branch domain configured: https://${domain}"
+}
+
+case "$action" in
+  begin)
+    : "${branch:?branch is required for begin}"
+    begin_domain_validation
+    ;;
+  finish)
+    : "${branch:?branch is required for finish}"
+    finish_domain_validation
+    ;;
+  ensure)
+    : "${branch:?branch is required for ensure}"
+    validation_status="$(begin_domain_validation)"
+    if [[ "$validation_status" == "active" ]]; then
+      echo "Cloudflare Pages custom branch domain configured: https://${domain}"
+    else
+      finish_domain_validation
+    fi
     ;;
   delete)
     domain_state="$(pages_domain_state)"

--- a/.github/scripts/tests/manage-okou-pages-domain-test.sh
+++ b/.github/scripts/tests/manage-okou-pages-domain-test.sh
@@ -94,17 +94,24 @@ export CLOUDFLARE_API_TOKEN="test-token"
 export MOCK_CURL_LOG="$request_log"
 
 export MOCK_DNS_CONTENT="pr-22239-app.okou-app.pages.dev"
-PATH="${tmp_dir}/bin:${PATH}" bash "$script" \
-  ensure account-id zone-id okou-app pr-22239-app.omby.ai pr-22239-app
+status="$(PATH="${tmp_dir}/bin:${PATH}" bash "$script" \
+  begin account-id zone-id okou-app pr-22239-app.omby.ai pr-22239-app)"
+test "$status" = "active"
 if grep -q -- '--request PUT' "$request_log"; then
   echo "expected an already-correct DNS record to skip PUT" >&2
   exit 1
 fi
 
 : > "$request_log"
+output="$(PATH="${tmp_dir}/bin:${PATH}" bash "$script" \
+  ensure account-id zone-id okou-app pr-22239-app.omby.ai pr-22239-app)"
+grep -q 'Cloudflare Pages custom branch domain configured' <<< "$output"
+
+: > "$request_log"
 export MOCK_DNS_CONTENT="okou-app.pages.dev"
-PATH="${tmp_dir}/bin:${PATH}" bash "$script" \
-  ensure account-id zone-id okou-app pr-22239-app.omby.ai pr-22239-app
+status="$(PATH="${tmp_dir}/bin:${PATH}" bash "$script" \
+  begin account-id zone-id okou-app pr-22239-app.omby.ai pr-22239-app)"
+test "$status" = "active"
 grep -q -- '--request PUT' "$request_log"
 
 : > "$request_log"
@@ -113,8 +120,18 @@ printf '0\n' > "$pages_state_file"
 export MOCK_PAGES_PENDING_RESPONSES="31"
 export MOCK_PAGES_STATE_FILE="$pages_state_file"
 export MOCK_DNS_CONTENT="okou-app.pages.dev"
+status="$(PATH="${tmp_dir}/bin:${PATH}" bash "$script" \
+  begin account-id zone-id okou-app pr-22239-app.omby.ai pr-22239-app)"
+test "$status" = "pending"
+test "$(<"$pages_state_file")" = "1"
+if grep -q 'pr-22239-app.okou-app.pages.dev' "$request_log"; then
+  echo "expected pending validation to keep the project Pages target" >&2
+  exit 1
+fi
+
+: > "$request_log"
 PATH="${tmp_dir}/bin:${PATH}" bash "$script" \
-  ensure account-id zone-id okou-app pr-22239-app.omby.ai pr-22239-app
+  finish account-id zone-id okou-app pr-22239-app.omby.ai pr-22239-app
 test "$(<"$pages_state_file")" = "32"
 grep -q -- '--request PUT' "$request_log"
 unset MOCK_PAGES_PENDING_RESPONSES MOCK_PAGES_STATE_FILE
@@ -122,8 +139,9 @@ unset MOCK_PAGES_PENDING_RESPONSES MOCK_PAGES_STATE_FILE
 : > "$request_log"
 export MOCK_PAGES_DOMAIN_EXISTS="false"
 export MOCK_DNS_CONTENT="pr-22239-app.okou-app.pages.dev"
-PATH="${tmp_dir}/bin:${PATH}" bash "$script" \
-  ensure account-id zone-id okou-app pr-22239-app.omby.ai pr-22239-app
+status="$(PATH="${tmp_dir}/bin:${PATH}" bash "$script" \
+  begin account-id zone-id okou-app pr-22239-app.omby.ai pr-22239-app)"
+test "$status" = "active"
 grep -q -- '--request POST' "$request_log"
 
 echo "manage-okou-pages-domain tests passed"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1233,6 +1233,57 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
+      - name: Resolve Cloudflare Pages preview branch
+        id: pages-branch
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref || '' }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || '' }}
+        run: |
+          branch="$(bash .github/scripts/resolve-okou-pages-branch.sh \
+            "$EVENT_NAME" \
+            "$PULL_REQUEST_NUMBER" \
+            "$MERGE_GROUP_HEAD_REF")"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve Cloudflare Pages custom preview domain
+        id: pages-custom-domain
+        if: needs.detect-release.outputs.skip != 'true' || github.event_name == 'push'
+        env:
+          PAGES_BRANCH: ${{ steps.pages-branch.outputs.branch }}
+        run: |
+          : "${CF_PAGES_PREVIEW_DOMAIN:?CF_PAGES_PREVIEW_DOMAIN variable is required}"
+          echo "domain=${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}" >> "$GITHUB_OUTPUT"
+          echo "url=https://${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}" >> "$GITHUB_OUTPUT"
+
+      - name: Begin Cloudflare Pages custom preview domain validation
+        id: pages-domain-validation
+        if: steps.pages-custom-domain.outputs.domain != ''
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
+          PAGES_BRANCH: ${{ steps.pages-branch.outputs.branch }}
+          PAGES_CUSTOM_DOMAIN: ${{ steps.pages-custom-domain.outputs.domain }}
+        run: |
+          : "${CF_PAGES_PROJECT_NAME:?CF_PAGES_PROJECT_NAME variable is required}"
+          : "${CF_PAGES_PREVIEW_ZONE_ID:?CF_PAGES_PREVIEW_ZONE_ID variable is required}"
+          : "${CLOUDFLARE_ACCOUNT_ID:?CF_ACCOUNT_ID variable is required}"
+          status="$(bash .github/scripts/manage-okou-pages-domain.sh \
+            begin \
+            "$CLOUDFLARE_ACCOUNT_ID" \
+            "$CF_PAGES_PREVIEW_ZONE_ID" \
+            "$CF_PAGES_PROJECT_NAME" \
+            "$PAGES_CUSTOM_DOMAIN" \
+            "$PAGES_BRANCH")"
+          case "$status" in
+            active|pending) ;;
+            *)
+              echo "Unexpected Pages domain status: ${status}" >&2
+              exit 1
+              ;;
+          esac
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "Cloudflare Pages domain validation status: ${status}"
+
       - uses: ./.github/actions/toolchain-init
 
       - name: Install AWS CLI
@@ -1258,19 +1309,6 @@ jobs:
           sha="$(bash .github/scripts/resolve-build-commit-sha.sh)"
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "prefix=okou-app/$sha" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve Cloudflare Pages preview branch
-        id: pages-branch
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref || '' }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || '' }}
-        run: |
-          branch="$(bash .github/scripts/resolve-okou-pages-branch.sh \
-            "$EVENT_NAME" \
-            "$PULL_REQUEST_NUMBER" \
-            "$MERGE_GROUP_HEAD_REF")"
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
       - name: Check for existing artifact
         id: existing
@@ -1445,16 +1483,6 @@ jobs:
             echo "url=https://${PAGES_BRANCH}.${CF_PAGES_PROJECT_NAME}.pages.dev"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Resolve Cloudflare Pages custom preview domain
-        id: pages-custom-domain
-        if: needs.detect-release.outputs.skip != 'true' || github.event_name == 'push'
-        env:
-          PAGES_BRANCH: ${{ steps.pages-branch.outputs.branch }}
-        run: |
-          : "${CF_PAGES_PREVIEW_DOMAIN:?CF_PAGES_PREVIEW_DOMAIN variable is required}"
-          echo "domain=${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}" >> "$GITHUB_OUTPUT"
-          echo "url=https://${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}" >> "$GITHUB_OUTPUT"
-
       - name: Deploy Cloudflare Pages preview
         id: pages-deploy
         env:
@@ -1503,16 +1531,21 @@ jobs:
 
           echo "url=$deployment_url" >> "$GITHUB_OUTPUT"
 
-      - name: Configure Cloudflare Pages custom preview domain
+      - name: Finalize Cloudflare Pages custom preview domain
         if: steps.pages-custom-domain.outputs.domain != ''
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
           PAGES_BRANCH: ${{ steps.pages-branch.outputs.branch }}
           PAGES_CUSTOM_DOMAIN: ${{ steps.pages-custom-domain.outputs.domain }}
+          PAGES_DOMAIN_STATUS: ${{ steps.pages-domain-validation.outputs.status }}
         run: |
           : "${CF_PAGES_PREVIEW_ZONE_ID:?CF_PAGES_PREVIEW_ZONE_ID variable is required}"
+          if [[ "$PAGES_DOMAIN_STATUS" == "active" ]]; then
+            echo "Cloudflare Pages custom branch domain already active: https://${PAGES_CUSTOM_DOMAIN}"
+            exit 0
+          fi
           bash .github/scripts/manage-okou-pages-domain.sh \
-            ensure \
+            finish \
             "$CLOUDFLARE_ACCOUNT_ID" \
             "$CF_PAGES_PREVIEW_ZONE_ID" \
             "$CF_PAGES_PROJECT_NAME" \


### PR DESCRIPTION
## Summary

- start Cloudflare Pages custom-domain validation before toolchain initialization and AWS CLI installation
- overlap ownership verification with the app build, R2 upload, and Pages deployment
- finalize the branch CNAME only after the immutable Pages deployment, while preserving `ensure` and `delete` compatibility

## Why

The first custom-domain setup waited on Cloudflare only after deployment (21 seconds in PR #23991). This adopts vm0-marketing's proven begin/finish lifecycle so most or all of that wait can run in parallel with existing deployment work. vm0 does not need the marketing anchor deployment because the real Pages app deployment creates the branch alias.

## Verification

- `bash .github/scripts/tests/manage-okou-pages-domain-test.sh`
- `bash -n .github/scripts/manage-okou-pages-domain.sh .github/scripts/tests/manage-okou-pages-domain-test.sh`
- ShellCheck 0.11.0 on the changed shell scripts
- actionlint 1.7.12 on `.github/workflows/turbo.yml`
- workflow shell compatibility check on `.github/workflows/turbo.yml`
- `pnpm format` and Prettier 3.8.1 on the workflow
- workspace lint (API rerun with a larger Node heap after the default 2 GB heap OOM)
- `pnpm knip`
- workspace, app, and API type checks