### PR TITLE
refactor(connectors): prepare authorization state readers

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -261,11 +261,12 @@ export default [
     },
   },
   {
-    // Keep the finite SemVer/build-identity policy matrix as a narrow
-    // state-machine exception. Route tests cover the constructible sync
-    // behavior, while arbitrary build versions are not a production API input.
+    // Keep finite persisted/state-machine contract matrices as narrow
+    // exceptions. Route tests cover constructible behavior, while these exact
+    // transition inputs are not available through production APIs.
     files: [
       "src/signals/services/__tests__/connector-catalog-rejection-authority.test.ts",
+      "src/signals/services/__tests__/connector-authorization-provider-state.test.ts",
     ],
     rules: {
       "no-restricted-syntax": ["error", ...restrictedSyntax],

--- a/turbo/apps/api/src/signals/services/__tests__/connector-authorization-provider-state.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-authorization-provider-state.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseConnectorExternalCodeProviderState,
+  parseConnectorOauthDeviceProviderState,
+  serializeConnectorExternalCodeProviderState,
+  serializeConnectorOauthDeviceProviderState,
+} from "../connector-authorization-provider-state";
+
+const connectorSlug = "slack";
+const authMethod = "oauth";
+
+describe("connector OAuth device provider state", () => {
+  it.each([
+    {
+      format: "legacy",
+      serializedState: JSON.stringify({
+        connectorType: connectorSlug,
+        deviceCode: "device-code",
+        pollState: "poll-state",
+      }),
+    },
+    {
+      format: "canonical",
+      serializedState: JSON.stringify({
+        connectorSlug,
+        deviceCode: "device-code",
+        pollState: "poll-state",
+      }),
+    },
+  ])(
+    "normalizes $format state and preserves poll state",
+    ({ serializedState }) => {
+      expect(
+        parseConnectorOauthDeviceProviderState({
+          serializedState,
+          connectorSlug,
+        }),
+      ).toStrictEqual({
+        connectorSlug,
+        deviceCode: "device-code",
+        pollState: "poll-state",
+      });
+    },
+  );
+
+  it("preserves an absent poll state", () => {
+    expect(
+      parseConnectorOauthDeviceProviderState({
+        serializedState: JSON.stringify({
+          connectorType: connectorSlug,
+          deviceCode: "device-code",
+        }),
+        connectorSlug,
+      }),
+    ).toStrictEqual({
+      connectorSlug,
+      deviceCode: "device-code",
+      pollState: undefined,
+    });
+  });
+
+  it.each([
+    {
+      identity: "zero",
+      serializedState: JSON.stringify({ deviceCode: "device-code" }),
+    },
+    {
+      identity: "dual",
+      serializedState: JSON.stringify({
+        connectorType: connectorSlug,
+        connectorSlug,
+        deviceCode: "device-code",
+      }),
+    },
+  ])("rejects $identity identity state", ({ serializedState }) => {
+    expect(() => {
+      parseConnectorOauthDeviceProviderState({
+        serializedState,
+        connectorSlug,
+      });
+    }).toThrow("Invalid input");
+  });
+
+  it("rejects a connector mismatch", () => {
+    expect(() => {
+      parseConnectorOauthDeviceProviderState({
+        serializedState: JSON.stringify({
+          connectorSlug: "github",
+          deviceCode: "device-code",
+        }),
+        connectorSlug,
+      });
+    }).toThrow("OAuth device provider state connector type mismatch");
+  });
+
+  it("serializes the exact legacy-only state with poll state", () => {
+    const serializedState = serializeConnectorOauthDeviceProviderState({
+      connectorSlug,
+      deviceCode: "device-code",
+      pollState: "poll-state",
+    });
+
+    expect(serializedState).toBe(
+      '{"connectorType":"slack","deviceCode":"device-code","pollState":"poll-state"}',
+    );
+    expect(serializedState).not.toContain("connectorSlug");
+  });
+
+  it("omits absent poll state from the legacy-only state", () => {
+    expect(
+      serializeConnectorOauthDeviceProviderState({
+        connectorSlug,
+        deviceCode: "device-code",
+        pollState: undefined,
+      }),
+    ).toBe('{"connectorType":"slack","deviceCode":"device-code"}');
+  });
+});
+
+describe("connector external-code provider state", () => {
+  it.each([
+    {
+      format: "legacy",
+      serializedState: JSON.stringify({
+        connectorType: connectorSlug,
+        authMethod,
+        providerState: "provider-state",
+      }),
+    },
+    {
+      format: "canonical",
+      serializedState: JSON.stringify({
+        connectorSlug,
+        authMethod,
+        providerState: "provider-state",
+      }),
+    },
+  ])(
+    "normalizes $format state and preserves provider state",
+    ({ serializedState }) => {
+      expect(
+        parseConnectorExternalCodeProviderState({
+          serializedState,
+          connectorSlug,
+          authMethod,
+        }),
+      ).toStrictEqual({
+        connectorSlug,
+        authMethod,
+        providerState: "provider-state",
+      });
+    },
+  );
+
+  it.each([
+    {
+      identity: "zero",
+      serializedState: JSON.stringify({
+        authMethod,
+        providerState: "provider-state",
+      }),
+    },
+    {
+      identity: "dual",
+      serializedState: JSON.stringify({
+        connectorType: connectorSlug,
+        connectorSlug,
+        authMethod,
+        providerState: "provider-state",
+      }),
+    },
+  ])("rejects $identity identity state", ({ serializedState }) => {
+    expect(() => {
+      parseConnectorExternalCodeProviderState({
+        serializedState,
+        connectorSlug,
+        authMethod,
+      });
+    }).toThrow("Invalid input");
+  });
+
+  it.each([
+    {
+      mismatch: "connector",
+      serializedState: JSON.stringify({
+        connectorSlug: "github",
+        authMethod,
+        providerState: "provider-state",
+      }),
+    },
+    {
+      mismatch: "auth method",
+      serializedState: JSON.stringify({
+        connectorSlug,
+        authMethod: "api-key",
+        providerState: "provider-state",
+      }),
+    },
+  ])("rejects an external-code $mismatch mismatch", ({ serializedState }) => {
+    expect(() => {
+      parseConnectorExternalCodeProviderState({
+        serializedState,
+        connectorSlug,
+        authMethod,
+      });
+    }).toThrow("External-code provider state connector method mismatch");
+  });
+
+  it("serializes the exact legacy-only state", () => {
+    const serializedState = serializeConnectorExternalCodeProviderState({
+      connectorSlug,
+      authMethod,
+      providerState: "provider-state",
+    });
+
+    expect(serializedState).toBe(
+      '{"connectorType":"slack","authMethod":"oauth","providerState":"provider-state"}',
+    );
+    expect(serializedState).not.toContain("connectorSlug");
+  });
+});

--- a/turbo/apps/api/src/signals/services/__tests__/connector-authorization-provider-state.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-authorization-provider-state.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { ZodError } from "zod";
 
 import {
   parseConnectorExternalCodeProviderState,
@@ -18,6 +19,7 @@ describe("connector OAuth device provider state", () => {
         connectorType: connectorSlug,
         deviceCode: "device-code",
         pollState: "poll-state",
+        unrelatedProperty: "ignored",
       }),
     },
     {
@@ -26,6 +28,7 @@ describe("connector OAuth device provider state", () => {
         connectorSlug,
         deviceCode: "device-code",
         pollState: "poll-state",
+        unrelatedProperty: "ignored",
       }),
     },
   ])(
@@ -79,7 +82,7 @@ describe("connector OAuth device provider state", () => {
         serializedState,
         connectorSlug,
       });
-    }).toThrow("Invalid input");
+    }).toThrow(ZodError);
   });
 
   it("rejects a connector mismatch", () => {
@@ -126,6 +129,7 @@ describe("connector external-code provider state", () => {
         connectorType: connectorSlug,
         authMethod,
         providerState: "provider-state",
+        unrelatedProperty: "ignored",
       }),
     },
     {
@@ -134,6 +138,7 @@ describe("connector external-code provider state", () => {
         connectorSlug,
         authMethod,
         providerState: "provider-state",
+        unrelatedProperty: "ignored",
       }),
     },
   ])(
@@ -177,7 +182,7 @@ describe("connector external-code provider state", () => {
         connectorSlug,
         authMethod,
       });
-    }).toThrow("Invalid input");
+    }).toThrow(ZodError);
   });
 
   it.each([

--- a/turbo/apps/api/src/signals/services/connector-authorization-provider-state.ts
+++ b/turbo/apps/api/src/signals/services/connector-authorization-provider-state.ts
@@ -1,0 +1,135 @@
+import {
+  connectorAuthMethodIdSchema,
+  connectorSlugSchema,
+  type ConnectorAuthMethodId,
+  type ConnectorSlug,
+} from "@vm0/api-contracts/contracts/connector-identity";
+import { z } from "zod";
+
+// #23770 accepts either single identity property until #24077 removes the
+// legacy reader after the staged writer rollout.
+const deviceLegacyProviderStateSchema = z
+  .object({
+    connectorType: connectorSlugSchema,
+    connectorSlug: z.never().optional(),
+    deviceCode: z.string(),
+    pollState: z.string().optional(),
+  })
+  .transform((state) => {
+    return {
+      connectorSlug: state.connectorType,
+      deviceCode: state.deviceCode,
+      pollState: state.pollState,
+    };
+  });
+
+const deviceCanonicalProviderStateSchema = z
+  .object({
+    connectorType: z.never().optional(),
+    connectorSlug: connectorSlugSchema,
+    deviceCode: z.string(),
+    pollState: z.string().optional(),
+  })
+  .transform((state) => {
+    return {
+      connectorSlug: state.connectorSlug,
+      deviceCode: state.deviceCode,
+      pollState: state.pollState,
+    };
+  });
+
+const deviceProviderStateSchema = z.union([
+  deviceLegacyProviderStateSchema,
+  deviceCanonicalProviderStateSchema,
+]);
+
+const externalCodeLegacyProviderStateSchema = z
+  .object({
+    connectorType: connectorSlugSchema,
+    connectorSlug: z.never().optional(),
+    authMethod: connectorAuthMethodIdSchema,
+    providerState: z.string(),
+  })
+  .transform((state) => {
+    return {
+      connectorSlug: state.connectorType,
+      authMethod: state.authMethod,
+      providerState: state.providerState,
+    };
+  });
+
+const externalCodeCanonicalProviderStateSchema = z
+  .object({
+    connectorType: z.never().optional(),
+    connectorSlug: connectorSlugSchema,
+    authMethod: connectorAuthMethodIdSchema,
+    providerState: z.string(),
+  })
+  .transform((state) => {
+    return {
+      connectorSlug: state.connectorSlug,
+      authMethod: state.authMethod,
+      providerState: state.providerState,
+    };
+  });
+
+const externalCodeProviderStateSchema = z.union([
+  externalCodeLegacyProviderStateSchema,
+  externalCodeCanonicalProviderStateSchema,
+]);
+
+export function parseConnectorOauthDeviceProviderState(args: {
+  readonly serializedState: string;
+  readonly connectorSlug: ConnectorSlug;
+}) {
+  const providerState = deviceProviderStateSchema.parse(
+    JSON.parse(args.serializedState) as unknown,
+  );
+  if (providerState.connectorSlug !== args.connectorSlug) {
+    throw new Error("OAuth device provider state connector type mismatch");
+  }
+  return providerState;
+}
+
+export function serializeConnectorOauthDeviceProviderState(args: {
+  readonly connectorSlug: ConnectorSlug;
+  readonly deviceCode: string;
+  readonly pollState: string | undefined;
+}): string {
+  // #24075 switches this legacy-only writer after the prepared reader deploys.
+  return JSON.stringify({
+    connectorType: args.connectorSlug,
+    deviceCode: args.deviceCode,
+    ...(args.pollState === undefined ? {} : { pollState: args.pollState }),
+  });
+}
+
+export function parseConnectorExternalCodeProviderState(args: {
+  readonly serializedState: string;
+  readonly connectorSlug: ConnectorSlug;
+  readonly authMethod: ConnectorAuthMethodId;
+}) {
+  const providerState = externalCodeProviderStateSchema.parse(
+    JSON.parse(args.serializedState) as unknown,
+  );
+  if (
+    providerState.connectorSlug !== args.connectorSlug ||
+    providerState.authMethod !== args.authMethod
+  ) {
+    throw new Error("External-code provider state connector method mismatch");
+  }
+  return providerState;
+}
+
+export function serializeConnectorExternalCodeProviderState(args: {
+  readonly connectorSlug: ConnectorSlug;
+  readonly authMethod: ConnectorAuthMethodId;
+  readonly providerState: string;
+}): string {
+  // #24075 switches this legacy-only writer after the prepared reader deploys.
+  return JSON.stringify({
+    connectorType: args.connectorSlug,
+    authMethod: args.authMethod,
+    providerState: args.providerState,
+  });
+}

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -8,7 +8,6 @@ import type {
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
   connectorAuthMethodIdSchema,
-  connectorSlugSchema,
   type ConnectorAuthMethodId,
   type ConnectorSlug,
 } from "@vm0/api-contracts/contracts/connector-identity";
@@ -25,7 +24,6 @@ import { isOAuthProviderHttpError } from "@vm0/connectors/auth-providers/oauth/e
 import { connectorExternalCodeSessions } from "@vm0/db/schema/connector-external-code-session";
 import { command } from "ccstate";
 import { and, eq, inArray, or, sql } from "drizzle-orm";
-import { z } from "zod";
 
 import { badRequestMessage, notFound } from "../../lib/error";
 import { optionalEnv } from "../../lib/env";
@@ -36,6 +34,10 @@ import {
   decryptPersistentSecretValue,
   encryptPersistentSecretValue,
 } from "./crypto.utils";
+import {
+  parseConnectorExternalCodeProviderState,
+  serializeConnectorExternalCodeProviderState,
+} from "./connector-authorization-provider-state";
 import {
   connectorActionResolver,
   type ConnectorActionMethodResolution,
@@ -102,13 +104,6 @@ type CompleteSuccess = {
   readonly status: 200;
   readonly body: ConnectorExternalCodeSessionCompleteResponse;
 };
-
-const encryptedProviderStateSchema = z.object({
-  // TODO(#23619): Rename with the persisted encrypted provider-state format.
-  connectorType: connectorSlugSchema,
-  authMethod: connectorAuthMethodIdSchema,
-  providerState: z.string(),
-});
 
 const connectorExternalCodeDisabled = Object.freeze({
   status: 403 as const,
@@ -306,16 +301,11 @@ async function parseEncryptedProviderState(args: {
       userId: args.session.userId,
     },
   );
-  const providerState = encryptedProviderStateSchema.parse(
-    JSON.parse(decrypted) as unknown,
-  );
-  if (
-    providerState.connectorType !== args.method.connectorSlug ||
-    providerState.authMethod !== args.method.authMethodId
-  ) {
-    throw new Error("External-code provider state connector method mismatch");
-  }
-  return providerState.providerState;
+  return parseConnectorExternalCodeProviderState({
+    serializedState: decrypted,
+    connectorSlug: args.method.connectorSlug,
+    authMethod: args.method.authMethodId,
+  }).providerState;
 }
 
 async function expireSession(args: {
@@ -809,8 +799,8 @@ export const startConnectorExternalCodeSession$ = command(
     const now = nowDate();
     const expiresAt = new Date(now.getTime() + startResult.expiresIn * 1000);
     const encryptedProviderState = await encryptPersistentSecretValue(
-      JSON.stringify({
-        connectorType: resolved.connectorSlug,
+      serializeConnectorExternalCodeProviderState({
+        connectorSlug: resolved.connectorSlug,
         authMethod: resolved.authMethodId,
         providerState: providerStateWithinLimit(startResult.providerState),
       }),

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -8,7 +8,6 @@ import type {
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
   connectorAuthMethodIdSchema,
-  connectorSlugSchema,
   type ConnectorAuthMethodId,
   type ConnectorSlug,
 } from "@vm0/api-contracts/contracts/connector-identity";
@@ -27,7 +26,6 @@ import type {
 import { connectorOauthDeviceAuthorizationSessions } from "@vm0/db/schema/connector-oauth-device-authorization-session";
 import { command } from "ccstate";
 import { and, eq, inArray, lt, or, sql } from "drizzle-orm";
-import { z } from "zod";
 
 import { badRequestMessage, notFound } from "../../lib/error";
 import { optionalEnv } from "../../lib/env";
@@ -38,6 +36,10 @@ import {
   decryptPersistentSecretValue,
   encryptPersistentSecretValue,
 } from "./crypto.utils";
+import {
+  parseConnectorOauthDeviceProviderState,
+  serializeConnectorOauthDeviceProviderState,
+} from "./connector-authorization-provider-state";
 import {
   connectorActionResolver,
   type ConnectorActionMethodResolution,
@@ -137,15 +139,6 @@ function deviceAuthStartResponse(args: {
 }
 
 const DEVICE_AUTH_POLL_STATE_MAX_BYTES = 4096;
-
-const encryptedProviderStateSchema = z.object({
-  // TODO(#23619): Rename with the persisted encrypted provider-state format.
-  connectorType: connectorSlugSchema,
-  deviceCode: z.string(),
-  pollState: z.string().optional(),
-});
-
-type EncryptedProviderState = z.infer<typeof encryptedProviderStateSchema>;
 
 function validatedDeviceAuthPollState(
   pollState: string | undefined,
@@ -558,7 +551,7 @@ async function claimSession(args: {
 async function parseEncryptedProviderState(args: {
   readonly session: DeviceAuthSessionRow;
   readonly connectorSlug: ConnectorSlug;
-}): Promise<EncryptedProviderState> {
+}) {
   const decrypted = await decryptPersistentSecretValue(
     args.session.encryptedProviderState,
     {
@@ -566,13 +559,10 @@ async function parseEncryptedProviderState(args: {
       userId: args.session.userId,
     },
   );
-  const providerState = encryptedProviderStateSchema.parse(
-    JSON.parse(decrypted) as unknown,
-  );
-  if (providerState.connectorType !== args.connectorSlug) {
-    throw new Error("OAuth device provider state connector type mismatch");
-  }
-  return providerState;
+  return parseConnectorOauthDeviceProviderState({
+    serializedState: decrypted,
+    connectorSlug: args.connectorSlug,
+  });
 }
 
 async function claimStillCurrent(args: {
@@ -980,10 +970,10 @@ export const startConnectorOauthDeviceAuthSession$ = command(
     const expiresAt = new Date(now.getTime() + startResult.expiresIn * 1000);
     const pollState = validatedDeviceAuthPollState(startResult.pollState);
     const encryptedProviderState = await encryptPersistentSecretValue(
-      JSON.stringify({
-        connectorType: resolvedMethod.connectorSlug,
+      serializeConnectorOauthDeviceProviderState({
+        connectorSlug: resolvedMethod.connectorSlug,
         deviceCode: startResult.deviceCode,
-        ...(pollState === undefined ? {} : { pollState }),
+        pollState,
       }),
       {
         orgId: args.orgId,


### PR DESCRIPTION
## Summary

- add a shared plaintext codec for device-auth and external-code provider state
- accept legacy-only `connectorType` or canonical-only `connectorSlug`, reject
  zero/dual identity, and normalize reads to `connectorSlug`
- keep both production serializers exactly legacy-only for deployment
  compatibility
- cover the otherwise-unconstructible persisted format matrix with one
  documented direct contract test while retaining route-level lifecycle tests

## Deployment compatibility

This is the reader-first slice of the staged migration. Newly created sessions
still contain only `connectorType`, so previous API releases and this release
can both read them. The canonical writer remains deferred to #24075 after this
reader has deployed and prior API invocations have drained.

#24073 intentionally remains open after merge until Production Gate 1 evidence
is recorded. This PR does not unblock #24075 by itself.

## Exclusions

- no database or public API changes
- no feature switch or schema-version changes
- no test-only route or direct database fixture
- no physical connector identity column cleanup from #23978
- no canonical writer cutover or legacy reader cleanup

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/services/__tests__/connector-authorization-provider-state.test.ts src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/connectors-external-code.bdd.test.ts --maxWorkers=4 --silent=passed-only` (67 tests)
- pre-commit full-repository Knip and Turbo type checks

Refs #24073

Parent: #23770
