### PR TITLE
refactor(db): cut runtime over to canonical chat event columns

### DIFF
--- a/turbo/packages/db/scripts/compare-schemas-normalized.ts
+++ b/turbo/packages/db/scripts/compare-schemas-normalized.ts
@@ -55,21 +55,20 @@ const TRANSITIONAL_BROWSER_BILLING_CONSTRAINTS = new Set([
   "browser_session_instances.browser_session_instances_usage_event_id_usage_event_id_fk",
 ]);
 
-// ChatEvent property columns are in release 1 of a three-release expansion.
-// The physical columns and canonical index/FK exist, but this release must not
-// declare them in Drizzle: an ORM-generated SELECT or RETURNING list would then
-// reference them if API promotion raced the migration. Remove these allowlists
-// in the property-cutover release, when the columns enter the runtime schema.
+// ChatEvent property columns are in release 2 of a three-release cutover.
+// Drizzle now declares the canonical columns and index/FK, while the legacy
+// objects must remain for the draining predecessor and rollback target. Remove
+// these allowlists with the physical objects in the release-3 contraction.
 const TRANSITIONAL_CHAT_EVENT_PROPERTY_COLUMNS = new Set([
-  "chat_events.revokes_event_id",
-  "chat_threads.last_chat_event_seq_id",
-  "zero_runs.first_assistant_event_acknowledged_at",
+  "chat_events.revokes_message_id",
+  "chat_threads.last_chat_message_seq_id",
+  "zero_runs.first_assistant_message_acknowledged_at",
 ]);
 const TRANSITIONAL_CHAT_EVENT_PROPERTY_INDEXES = new Set([
-  "chat_events_revokes_event_id_unique",
+  "chat_events_revokes_message_id_unique",
 ]);
 const TRANSITIONAL_CHAT_EVENT_PROPERTY_CONSTRAINTS = new Set([
-  "chat_events.chat_events_revokes_event_id_chat_events_id_fk",
+  "chat_events.chat_events_revokes_message_id_chat_events_id_fk",
 ]);
 
 // Get database URLs from command line args

--- a/turbo/packages/db/scripts/test-migration-consistency-schema.ts
+++ b/turbo/packages/db/scripts/test-migration-consistency-schema.ts
@@ -35,15 +35,18 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
-import { eq, isNotNull } from "drizzle-orm";
+import { eq, isNotNull, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
 import { connectorExternalCodeSessions } from "../src/schema/connector-external-code-session";
 import { connectorOauthDeviceAuthorizationSessions } from "../src/schema/connector-oauth-device-authorization-session";
 import { connectorOauthStates } from "../src/schema/connector-oauth-state";
 import { connectors } from "../src/schema/connector";
+import { chatEvents } from "../src/schema/chat-event";
+import { chatThreads } from "../src/schema/chat-thread";
 import { userConnectors } from "../src/schema/user-connector";
 import { userPermissionGrants } from "../src/schema/user-permission-grant";
+import { zeroRuns } from "../src/schema/zero-run";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const PACKAGE_DIR = path.join(dirname, "..");
@@ -610,7 +613,7 @@ async function validateCanonicalChatMessageStorage(
 
   const sequenceState = await client.query<{ lastSeqId: string }>(
     `
-      SELECT "last_chat_message_seq_id" AS "lastSeqId"
+      SELECT "last_chat_event_seq_id" AS "lastSeqId"
       FROM "chat_threads"
       WHERE "id" = $1
     `,
@@ -5457,6 +5460,12 @@ const chatEventPropertyColumnFixture = {
   postSequenceExpansionEventId: "99000000-0000-4000-8000-000000000013",
   previousApiThreadId: "99000000-0000-4000-8000-000000000014",
   nextApiThreadId: "99000000-0000-4000-8000-000000000015",
+  releaseTwoPreviousApiRunId: "99000000-0000-4000-8000-000000000016",
+  releaseTwoCurrentApiRunId: "99000000-0000-4000-8000-000000000017",
+  releaseTwoPreviousApiTargetEventId: "99000000-0000-4000-8000-000000000018",
+  releaseTwoPreviousApiRevokerEventId: "99000000-0000-4000-8000-000000000019",
+  releaseTwoCurrentApiTargetEventId: "99000000-0000-4000-8000-000000000020",
+  releaseTwoCurrentApiRevokerEventId: "99000000-0000-4000-8000-000000000021",
 } as const;
 
 async function assertChatEventsAppendOnlyProtection(
@@ -5552,6 +5561,22 @@ async function seedChatEventPropertyColumnFixture(
           'running',
           'next API acknowledgement',
           'chat-event-property-column-org'
+        ),
+        (
+          $5,
+          'chat-event-property-column-user',
+          $4,
+          'running',
+          'release 2 previous API acknowledgement',
+          'chat-event-property-column-org'
+        ),
+        (
+          $6,
+          'chat-event-property-column-user',
+          $4,
+          'running',
+          'release 2 current API acknowledgement',
+          'chat-event-property-column-org'
         )
     `,
     [
@@ -5559,6 +5584,8 @@ async function seedChatEventPropertyColumnFixture(
       fixture.previousApiRunId,
       fixture.nextApiRunId,
       fixture.sessionId,
+      fixture.releaseTwoPreviousApiRunId,
+      fixture.releaseTwoCurrentApiRunId,
     ],
   );
   await client.query(
@@ -5592,13 +5619,17 @@ async function seedChatEventPropertyColumnFixture(
       VALUES
         ($1, 'web', $4, '2026-07-30 01:00:00', '2026-07-30 01:00:01'),
         ($2, 'web', $4, '2026-07-30 02:00:00', NULL),
-        ($3, 'web', $4, '2026-07-30 03:00:00', NULL)
+        ($3, 'web', $4, '2026-07-30 03:00:00', NULL),
+        ($5, 'web', $4, '2026-07-30 04:00:00', NULL),
+        ($6, 'web', $4, '2026-07-30 05:00:00', NULL)
     `,
     [
       fixture.historicalRunId,
       fixture.previousApiRunId,
       fixture.nextApiRunId,
       fixture.threadId,
+      fixture.releaseTwoPreviousApiRunId,
+      fixture.releaseTwoCurrentApiRunId,
     ],
   );
   await client.query(
@@ -6047,9 +6078,257 @@ async function validateFirstAssistantEventAckExpansion(
   );
 }
 
+async function validateChatEventPropertyColumnRuntimeCutover(
+  client: Client,
+): Promise<void> {
+  const fixture = chatEventPropertyColumnFixture;
+  const database = drizzle(client);
+
+  await assertChatEventsAppendOnlyProtection(
+    client,
+    fixture.historicalRevokerEventId,
+  );
+
+  const previousReservation = await client.query<{ lastSeqId: string }>(
+    `
+      UPDATE "chat_threads"
+      SET "last_chat_message_seq_id" = "last_chat_message_seq_id" + 2
+      WHERE "id" = $1
+      RETURNING "last_chat_message_seq_id" AS "lastSeqId"
+    `,
+    [fixture.threadId],
+  );
+  const previousLastSeqId = Number(previousReservation.rows[0]?.lastSeqId);
+  assert.ok(Number.isSafeInteger(previousLastSeqId));
+  const previousApiInsert = await client.query<{
+    id: string;
+    revokesMessageId: string | null;
+  }>(
+    `
+      INSERT INTO "chat_events" (
+        "id",
+        "chat_thread_id",
+        "revokes_message_id",
+        "event_type",
+        "content",
+        "seq_id"
+      )
+      VALUES
+        ($1, $3, NULL, 'output.message', 'release 2 previous API target', $4),
+        ($2, $3, $1, 'control.revoke', NULL, $5)
+      ON CONFLICT ("revokes_message_id") DO NOTHING
+      RETURNING
+        "id",
+        "revokes_message_id" AS "revokesMessageId"
+    `,
+    [
+      fixture.releaseTwoPreviousApiTargetEventId,
+      fixture.releaseTwoPreviousApiRevokerEventId,
+      fixture.threadId,
+      previousLastSeqId - 1,
+      previousLastSeqId,
+    ],
+  );
+  assert.deepEqual(previousApiInsert.rows, [
+    {
+      id: fixture.releaseTwoPreviousApiTargetEventId,
+      revokesMessageId: null,
+    },
+    {
+      id: fixture.releaseTwoPreviousApiRevokerEventId,
+      revokesMessageId: fixture.releaseTwoPreviousApiTargetEventId,
+    },
+  ]);
+  const previousApiAcknowledgement = await client.query<{ id: string }>(
+    `
+      UPDATE "zero_runs"
+      SET "first_assistant_message_acknowledged_at" =
+        '2026-07-30 04:00:01'
+      WHERE "id" = $1
+        AND "first_assistant_message_acknowledged_at" IS NULL
+      RETURNING "id"
+    `,
+    [fixture.releaseTwoPreviousApiRunId],
+  );
+  assert.deepEqual(previousApiAcknowledgement.rows, [
+    { id: fixture.releaseTwoPreviousApiRunId },
+  ]);
+
+  const [currentReservation] = await database
+    .update(chatThreads)
+    .set({
+      lastChatEventSeqId: sql`${chatThreads.lastChatEventSeqId} + 2`,
+    })
+    .where(eq(chatThreads.id, fixture.threadId))
+    .returning({ lastSeqId: chatThreads.lastChatEventSeqId });
+  assert.ok(currentReservation);
+  const currentApiInsert = await database
+    .insert(chatEvents)
+    .values([
+      {
+        id: fixture.releaseTwoCurrentApiTargetEventId,
+        chatThreadId: fixture.threadId,
+        eventType: "output.message",
+        content: "release 2 current API target",
+        seqId: currentReservation.lastSeqId - 1,
+      },
+      {
+        id: fixture.releaseTwoCurrentApiRevokerEventId,
+        chatThreadId: fixture.threadId,
+        revokesEventId: fixture.releaseTwoCurrentApiTargetEventId,
+        eventType: "control.revoke",
+        seqId: currentReservation.lastSeqId,
+      },
+    ])
+    .onConflictDoNothing({ target: chatEvents.revokesEventId })
+    .returning({
+      id: chatEvents.id,
+      revokesEventId: chatEvents.revokesEventId,
+    });
+  assert.deepEqual(currentApiInsert, [
+    {
+      id: fixture.releaseTwoCurrentApiTargetEventId,
+      revokesEventId: null,
+    },
+    {
+      id: fixture.releaseTwoCurrentApiRevokerEventId,
+      revokesEventId: fixture.releaseTwoCurrentApiTargetEventId,
+    },
+  ]);
+  const currentApiAcknowledgement = await database
+    .update(zeroRuns)
+    .set({
+      firstAssistantEventAcknowledgedAt: new Date("2026-07-30T05:00:01.000Z"),
+    })
+    .where(eq(zeroRuns.id, fixture.releaseTwoCurrentApiRunId))
+    .returning({ id: zeroRuns.id });
+  assert.deepEqual(currentApiAcknowledgement, [
+    { id: fixture.releaseTwoCurrentApiRunId },
+  ]);
+
+  assert.deepEqual(
+    await database
+      .select({
+        id: chatEvents.id,
+        revokesEventId: chatEvents.revokesEventId,
+      })
+      .from(chatEvents)
+      .where(eq(chatEvents.id, fixture.releaseTwoPreviousApiRevokerEventId)),
+    [
+      {
+        id: fixture.releaseTwoPreviousApiRevokerEventId,
+        revokesEventId: fixture.releaseTwoPreviousApiTargetEventId,
+      },
+    ],
+  );
+  assert.deepEqual(
+    await database
+      .select({
+        id: chatEvents.id,
+        revokesEventId: chatEvents.revokesEventId,
+      })
+      .from(chatEvents)
+      .where(eq(chatEvents.id, fixture.releaseTwoCurrentApiRevokerEventId)),
+    [
+      {
+        id: fixture.releaseTwoCurrentApiRevokerEventId,
+        revokesEventId: fixture.releaseTwoCurrentApiTargetEventId,
+      },
+    ],
+  );
+
+  const mirroredRevokers = await client.query<{
+    id: string;
+    legacyRevokesEventId: string;
+    revokesEventId: string;
+  }>(
+    `
+      SELECT
+        "id",
+        "revokes_event_id" AS "revokesEventId",
+        "revokes_message_id" AS "legacyRevokesEventId"
+      FROM "chat_events"
+      WHERE "id" IN ($1, $2)
+      ORDER BY "id"
+    `,
+    [
+      fixture.releaseTwoPreviousApiRevokerEventId,
+      fixture.releaseTwoCurrentApiRevokerEventId,
+    ],
+  );
+  assert.deepEqual(mirroredRevokers.rows, [
+    {
+      id: fixture.releaseTwoPreviousApiRevokerEventId,
+      legacyRevokesEventId: fixture.releaseTwoPreviousApiTargetEventId,
+      revokesEventId: fixture.releaseTwoPreviousApiTargetEventId,
+    },
+    {
+      id: fixture.releaseTwoCurrentApiRevokerEventId,
+      legacyRevokesEventId: fixture.releaseTwoCurrentApiTargetEventId,
+      revokesEventId: fixture.releaseTwoCurrentApiTargetEventId,
+    },
+  ]);
+
+  const mirroredSequence = await client.query<{
+    lastChatEventSeqId: string;
+    lastChatMessageSeqId: string;
+  }>(
+    `
+      SELECT
+        "last_chat_event_seq_id" AS "lastChatEventSeqId",
+        "last_chat_message_seq_id" AS "lastChatMessageSeqId"
+      FROM "chat_threads"
+      WHERE "id" = $1
+    `,
+    [fixture.threadId],
+  );
+  assert.deepEqual(mirroredSequence.rows, [
+    {
+      lastChatEventSeqId: String(currentReservation.lastSeqId),
+      lastChatMessageSeqId: String(currentReservation.lastSeqId),
+    },
+  ]);
+
+  const mirroredAcknowledgements = await client.query<{
+    canonicalAcknowledgedAt: string | null;
+    id: string;
+    legacyAcknowledgedAt: string | null;
+  }>(
+    `
+      SELECT
+        "id",
+        to_char(
+          "first_assistant_event_acknowledged_at",
+          'YYYY-MM-DD HH24:MI:SS'
+        ) AS "canonicalAcknowledgedAt",
+        to_char(
+          "first_assistant_message_acknowledged_at",
+          'YYYY-MM-DD HH24:MI:SS'
+        ) AS "legacyAcknowledgedAt"
+      FROM "zero_runs"
+      WHERE "id" IN ($1, $2)
+      ORDER BY "id"
+    `,
+    [fixture.releaseTwoPreviousApiRunId, fixture.releaseTwoCurrentApiRunId],
+  );
+  assert.equal(mirroredAcknowledgements.rows.length, 2);
+  for (const acknowledgement of mirroredAcknowledgements.rows) {
+    assert.notEqual(acknowledgement.canonicalAcknowledgedAt, null);
+    assert.equal(
+      acknowledgement.canonicalAcknowledgedAt,
+      acknowledgement.legacyAcknowledgedAt,
+    );
+  }
+
+  await assertChatEventsAppendOnlyProtection(
+    client,
+    fixture.releaseTwoCurrentApiRevokerEventId,
+  );
+}
+
 async function validateChatEventPropertyColumnRollout(): Promise<void> {
   console.log(
-    "=== Validate populated ChatEvent property column expansion ===\n",
+    "=== Validate populated ChatEvent property column runtime cutover ===\n",
   );
   const testDb = "migration_chat_event_property_columns_test";
   const testDbUrl = createTestDbUrl(testDb);
@@ -6071,6 +6350,7 @@ async function validateChatEventPropertyColumnRollout(): Promise<void> {
       await validateRevokesEventIdExpansion(client);
       await validateLastChatEventSeqIdExpansion(client);
       await validateFirstAssistantEventAckExpansion(client);
+      await validateChatEventPropertyColumnRuntimeCutover(client);
     } finally {
       await client.end();
     }
@@ -6079,7 +6359,7 @@ async function validateChatEventPropertyColumnRollout(): Promise<void> {
   }
 
   console.log(
-    "   ✅ Previous and next API statements remain valid for all three columns, revoke conflict targets stay indexed, persisted sequence allocation mirrors both names, and append-only protection remains enabled after every migration\n",
+    "   ✅ Draining legacy and current canonical Drizzle statements coexist for all three columns, both revoke conflict targets stay indexed, persisted legacy sequence allocation remains bridged, and append-only protection remains enabled throughout\n",
   );
 }
 

--- a/turbo/packages/db/src/__tests__/chat-event.test.ts
+++ b/turbo/packages/db/src/__tests__/chat-event.test.ts
@@ -36,8 +36,8 @@ describe("chatEvents schema", () => {
         onDelete: "cascade",
       },
       {
-        columns: ["revokes_message_id"],
-        name: "chat_events_revokes_message_id_chat_events_id_fk",
+        columns: ["revokes_event_id"],
+        name: "chat_events_revokes_event_id_chat_events_id_fk",
         onDelete: "no action",
       },
     ]);

--- a/turbo/packages/db/src/schema/chat-event.ts
+++ b/turbo/packages/db/src/schema/chat-event.ts
@@ -86,7 +86,7 @@ export const chatEvents = pgTable(
     // A null value on an unrevoked input.prompt/input.automation/input.goal is pending.
     runId: uuid("run_id"),
     usagePayload: jsonb("usage_payload").$type<ChatEventUsagePayload>(),
-    revokesEventId: uuid("revokes_message_id").references(
+    revokesEventId: uuid("revokes_event_id").references(
       (): AnyPgColumn => {
         return chatEvents.id;
       },
@@ -150,7 +150,7 @@ export const chatEvents = pgTable(
       index("chat_events_usage_run_id_idx")
         .on(table.runId)
         .where(sql`${table.usagePayload} IS NOT NULL`),
-      uniqueIndex("chat_events_revokes_message_id_unique").on(
+      uniqueIndex("chat_events_revokes_event_id_unique").on(
         table.revokesEventId,
       ),
       uniqueIndex("chat_events_interrupts_run_id_unique").on(

--- a/turbo/packages/db/src/schema/chat-thread.ts
+++ b/turbo/packages/db/src/schema/chat-thread.ts
@@ -143,7 +143,7 @@ export const chatThreads = pgTable(
      */
     lastMessageAt: timestamp("last_message_at").defaultNow().notNull(),
     /** Last seq_id allocated to an event in this thread. */
-    lastChatEventSeqId: bigint("last_chat_message_seq_id", {
+    lastChatEventSeqId: bigint("last_chat_event_seq_id", {
       mode: "number",
     })
       .default(0)

--- a/turbo/packages/db/src/schema/zero-run.ts
+++ b/turbo/packages/db/src/schema/zero-run.ts
@@ -73,7 +73,7 @@ export const zeroRuns = pgTable(
     // until promotion supplies the same start used by runner telemetry.
     apiStartedAt: timestamp("api_started_at"),
     firstAssistantEventAcknowledgedAt: timestamp(
-      "first_assistant_message_acknowledged_at",
+      "first_assistant_event_acknowledged_at",
     ),
     // Brief AI-generated summary of what the run did (≤50 words)
     summary: text("summary"),


### PR DESCRIPTION
## Summary

- point the three existing Drizzle properties at their canonical physical columns:
  - `chatEvents.revokesEventId` -> `revokes_event_id`
  - `chatThreads.lastChatEventSeqId` -> `last_chat_event_seq_id`
  - `zeroRuns.firstAssistantEventAcknowledgedAt` -> `first_assistant_event_acknowledged_at`
- move the Drizzle revoke unique index to `chat_events_revokes_event_id_unique`, so targeted canonical `ON CONFLICT` statements resolve against the canonical index
- flip normalized-schema transition allowances to the legacy columns, revoke index, and FK that intentionally remain in the expanded database
- extend the populated-upgrade scenario to execute the draining predecessor's legacy SQL and this release's real canonical Drizzle statements against the same expanded database

## Rollout step and compatibility

This is **release 2 of the three-release dual-column expand/contract plan** from #23920. Release 1 (#23977) added and backfilled the canonical columns in migrations 0755/0756/0757, installed bidirectional bridge triggers, and deliberately kept the runtime Drizzle schema on the legacy columns. Those migrations shipped in `db-v1.156.4` before this cutover.

This release changes only runtime schema mappings and validation. It does not add a migration and does not remove or modify any bridge trigger, legacy column, legacy revoke index, or legacy FK. The draining predecessor and rollback target can therefore continue reading and writing the legacy names while this release reads and writes the canonical names. No application behavior or TypeScript property changes are introduced.

The active-code audit found no additional raw application SQL, result mapping, or index-name reference using these legacy names. Remaining references are limited to immutable migration history, explicit predecessor statement shapes in populated-upgrade coverage, and release-2 normalized-schema allowances for physical legacy objects.

## Populated-upgrade evidence

The existing release-1 scenario still seeds populated state at migration 0754 and applies 0755, 0756, and 0757 in order, checking backfills, both physical indexes, bidirectional mirroring, the persisted sequence allocator, and append-only enforcement after every migration.

The release-2 extension then runs both versions on the fully expanded database:

- predecessor SQL reserves sequence IDs through `last_chat_message_seq_id`, inserts and queries a revoke through `revokes_message_id` with targeted `ON CONFLICT`, and acknowledges a run through `first_assistant_message_acknowledged_at`
- current Drizzle code reserves through `last_chat_event_seq_id`, inserts and queries a revoke through `revokes_event_id` with a canonical conflict target, and acknowledges through `first_assistant_event_acknowledged_at`
- raw verification proves both physical values remain equal for both writers
- `chat_events_reject_update` remains enabled and rejects an ordinary update after the mixed-version writes

## Release 3 gate

Release 3 must wait until this release is fully deployed and its rollback predecessor has drained. Before contracting any legacy object, run the production catalog preflight required by `docs/deployment-compatibility.md` across functions/procedures, triggers, defaults, generated expressions, views/materialized views/rules, indexes/constraints, and policies.

In particular, the persisted PostgreSQL sequence-allocation function called out by migration 0756 still writes `last_chat_message_seq_id` in this release and is intentionally covered by the bridge. Release 3 must retarget that persisted function before dropping the legacy sequence column or bridge.

Only after the drain and clean catalog preflight may Release 3 remove the bridge triggers, legacy columns, legacy revoke index, and legacy FK.

## Post-release verification

- no `42703` errors for either legacy or canonical column names
- no revoke unique-constraint or conflict-target errors
- ChatEvent sequence allocation remains monotonic, with no sequence divergence
- revoke insertion and revoke-chain reads remain healthy

## Verification

- release gate: `gh release list --repo vm0-ai/vm0` confirmed `db-v1.156.4` at 2026-07-30 11:16 UTC
- focused Prettier check for all changed files
- `pnpm -F @vm0/db lint`
- `pnpm -F @vm0/db check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/db exec vitest run src/__tests__/chat-event.test.ts --silent=passed-only` (1 file, 2 tests)
- `pnpm -F @vm0/db test:migration-consistency` against the CI PostgreSQL 17.10 image (763 migrations, populated runtime cutover, latest snapshot 762, reset, fresh regeneration, and normalized schema comparison)
- `pnpm knip --workspace @vm0/db` reports only the two pre-existing unused `JsonStringArray` and `JsonReadonlyStringArray` exports; no new finding

The full repository test pipeline is left to PR CI as requested.

Refs #23920