### PR TITLE
refactor(contracts): add the test trigger source to the read side only

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -339,6 +339,7 @@
       "slack": "Slack",
       "teams": "Teams",
       "telegram": "Telegram",
+      "test": "Test",
       "web": "Web",
       "webhook": "Webhook",
       "workflowEvent": "Workflow event",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -339,6 +339,7 @@
       "slack": "Slack",
       "teams": "チーム",
       "telegram": "Telegram",
+      "test": "テスト",
       "web": "ウェブ",
       "webhook": "Webhook",
       "workflowEvent": "ワークフローイベント",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -353,6 +353,7 @@
       "slack": "Slack",
       "teams": "Teams",
       "telegram": "Telegram",
+      "test": "Teste",
       "web": "Web",
       "webhook": "Webhook",
       "workflowEvent": "Evento de fluxo de trabalho",

--- a/turbo/apps/platform/src/signals/zero-page/log-types.ts
+++ b/turbo/apps/platform/src/signals/zero-page/log-types.ts
@@ -70,6 +70,11 @@ export function getTriggerSourceLabel(
         return $.activity.sources.cli;
       });
     }
+    case "test": {
+      return i18n.t(($) => {
+        return $.activity.sources.test;
+      });
+    }
     case "agent": {
       return i18n.t(($) => {
         return $.activity.sources.agent;

--- a/turbo/packages/api-contracts/src/contracts/logs.ts
+++ b/turbo/packages/api-contracts/src/contracts/logs.ts
@@ -53,6 +53,7 @@ export const triggerSourceSchema = z.enum([
   "agentphone",
   "github",
   "cli",
+  "test",
   "agent",
   "webhook",
   "workflow-schedule",


### PR DESCRIPTION
## Summary

- add `"test"` to the shared `triggerSourceSchema` so log and run readers accept the staged value
- add the exhaustive platform label case and translations for en-US, ja-JP, and pt-BR
- audit the API and platform read paths named in #24090, plus other `TriggerSource` switches and records

## Deployment sequencing

This is a **read-side-only** release. No code path in this PR writes `triggerSource: "test"`: `routes/test-agent-runs.ts` continues to omit `triggerSource`, and the `args.body.triggerSource ?? "cli"` fallback in `agent-run-create.service.ts` remains unchanged.

Phase 2-b must not start writing `"test"` until this PR has been fully deployed. During a rolling deployment, an older API instance would otherwise fail when `zero-runs.service.ts` parses a row containing the unknown value.

Closes #24090

## Validation

- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- runtime smoke check: `triggerSourceSchema.parse("test")`

Per issue scope, no local full Vitest suite or dev server was run; PR CI provides the test coverage.