### PR TITLE
feat(api): force app.vm0.ai clients to upgrade to v0.662.2

### DIFF
--- a/turbo/apps/api/src/lib/web-client-compatibility.json
+++ b/turbo/apps/api/src/lib/web-client-compatibility.json
@@ -1,3 +1,3 @@
 {
-  "minimumSupportedVersion": "0.631.1"
+  "minimumSupportedVersion": "0.662.2"
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
@@ -47,7 +47,6 @@ describe("CHAT-01 chat thread lifecycle", () => {
     });
     await expect(api.readThreadDraft(actor, created.id)).resolves.toStrictEqual(
       {
-        draftContent: null,
         draftUserMessage: null,
         draftAttachments: null,
       },
@@ -329,7 +328,6 @@ describe("CHAT-02 chat messages and visible validation", () => {
 
     const threadId = sent.body.threadId;
     await expect(api.readThreadDraft(actor, threadId)).resolves.toStrictEqual({
-      draftContent: null,
       draftUserMessage: null,
       draftAttachments: null,
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agent-drafts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agent-drafts.test.ts
@@ -59,7 +59,6 @@ describe("GET/PATCH /api/zero/agents/:id/draft", () => {
     );
 
     expect(response.body).toStrictEqual({
-      draftContent: null,
       draftUserMessage: null,
       draftAttachments: null,
     });
@@ -114,7 +113,6 @@ describe("GET/PATCH /api/zero/agents/:id/draft", () => {
       [200],
     );
     expect(saved.body).toStrictEqual({
-      draftContent: null,
       draftUserMessage,
       draftAttachments: [attachment],
     });
@@ -139,7 +137,6 @@ describe("GET/PATCH /api/zero/agents/:id/draft", () => {
       [200],
     );
     expect(cleared.body).toStrictEqual({
-      draftContent: null,
       draftUserMessage: null,
       draftAttachments: null,
     });
@@ -175,7 +172,6 @@ describe("GET/PATCH /api/zero/agents/:id/draft", () => {
       [200],
     );
     expect(peerDraft.body).toStrictEqual({
-      draftContent: null,
       draftUserMessage: null,
       draftAttachments: null,
     });

--- a/turbo/apps/api/src/signals/routes/zero-agent-drafts.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agent-drafts.ts
@@ -55,7 +55,6 @@ const getAgentDraftInner$ = computed(async (get) => {
   return {
     status: 200 as const,
     body: {
-      draftContent: null,
       draftUserMessage: draft?.draftUserMessage ?? null,
       draftAttachments: draft?.draftAttachments ?? null,
     },

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -579,7 +579,6 @@ export function zeroChatThreadDraft(args: {
     }
 
     return {
-      draftContent: null,
       draftUserMessage: thread.draftUserMessage,
       draftAttachments: thread.draftAttachments
         ? [...thread.draftAttachments]

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -180,7 +180,6 @@ export const apiAgentsHandlers = [
   // GET /api/zero/agents/:id/draft
   mockApi(zeroAgentDraftContract.get, ({ respond }) => {
     return respond(200, {
-      draftContent: null,
       draftUserMessage: null,
       draftAttachments: null,
     });
@@ -252,7 +251,6 @@ export const apiAgentsHandlers = [
   // GET /api/zero/chat-threads/:id/draft
   mockApi(chatThreadDraftContract.get, ({ respond }) => {
     return respond(200, {
-      draftContent: null,
       draftUserMessage: null,
       draftAttachments: null,
     });

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
@@ -680,7 +680,6 @@ describe("chat thread event sourcing local-first list", () => {
       threadDraftRequests += 1;
       expect(params.id).toBe(OPTIMISTIC_THREAD_ID);
       return respond(200, {
-        draftContent: null,
         draftUserMessage: null,
         draftAttachments: null,
       });
@@ -713,7 +712,6 @@ describe("chat thread event sourcing local-first list", () => {
     await expect(
       context.store.get(dataSource.threadDraft$),
     ).resolves.toStrictEqual({
-      draftContent: null,
       draftUserMessage: null,
       draftAttachments: null,
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -667,7 +667,6 @@ describe("chat composer models", () => {
     ]);
     context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
       return respond(200, {
-        draftContent: null,
         draftUserMessage: {
           version: 1,
           parts: [{ type: "text", text: mention }],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -100,7 +100,6 @@ function mockThreadDetails(): void {
   });
   context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
     return respond(200, {
-      draftContent: null,
       draftUserMessage: null,
       draftAttachments: null,
     });
@@ -196,7 +195,6 @@ describe("chat drafts", () => {
     mockAgentChatPage(agentId);
     context.mocks.api(zeroAgentDraftContract.get, ({ params, respond }) => {
       return respond(200, {
-        draftContent: null,
         draftUserMessage: {
           version: 1,
           parts: [
@@ -259,7 +257,6 @@ describe("chat drafts", () => {
     mockAgentChatPage(agentId);
     context.mocks.http.get("*/api/zero/agents/:id/draft", () => {
       return HttpResponse.json({
-        draftContent: "stale legacy agent draft",
         draftUserMessage: {
           version: 1,
           parts: [
@@ -332,7 +329,6 @@ describe("chat drafts", () => {
     mockAgentChatPage(agentId);
     context.mocks.api(zeroAgentDraftContract.get, ({ respond }) => {
       return respond(200, {
-        draftContent: null,
         draftUserMessage: null,
         draftAttachments: null,
       });
@@ -466,13 +462,11 @@ describe("chat drafts", () => {
     context.mocks.api(chatThreadDraftContract.get, ({ params, respond }) => {
       if (params.id !== THREAD_ONE_ID) {
         return respond(200, {
-          draftContent: null,
           draftUserMessage: null,
           draftAttachments: null,
         });
       }
       return respond(200, {
-        draftContent: null,
         draftUserMessage: {
           version: 1,
           parts: [
@@ -527,7 +521,6 @@ describe("chat drafts", () => {
     });
     context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
       return respond(200, {
-        draftContent: null,
         draftUserMessage: {
           version: 1,
           parts: [
@@ -591,7 +584,6 @@ describe("chat drafts", () => {
     mockChatLifecycle(context, { threadId });
     context.mocks.http.get("*/api/zero/chat-threads/:id/draft", () => {
       return HttpResponse.json({
-        draftContent: "stale legacy draft",
         draftUserMessage: {
           version: 1,
           parts: [
@@ -741,7 +733,6 @@ describe("chat drafts", () => {
     });
     context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
       return respond(200, {
-        draftContent: null,
         draftUserMessage: {
           version: 1,
           parts: [

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -122,7 +122,6 @@ export function mockSubagentThread(context: TestContext, _threadId: string) {
   });
   context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
     return respond(200, {
-      draftContent: null,
       draftUserMessage: null,
       draftAttachments: null,
     });
@@ -855,7 +854,6 @@ export function mockChatLifecycle(
   });
   context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
     return respond(200, {
-      draftContent: null,
       draftUserMessage: null,
       draftAttachments: null,
     });

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
@@ -1,4 +1,3 @@
-import { z } from "zod";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -17,7 +16,6 @@ import {
   chatEventSchema,
   generationTemplateRequestSchema,
   MODEL_FIRST_SELECTION_PROVIDER_ID,
-  persistedAttachmentSchema,
   userMessageDocumentSchema,
 } from "../chat-threads";
 
@@ -30,12 +28,6 @@ const legacyProviderPinnedModelSelection = {
   modelProviderId: "11111111-1111-4111-8111-111111111111",
   selectedModel: "claude-sonnet-4-6",
 };
-
-const previousChatThreadDraftResponseSchema = z.object({
-  draftContent: z.string().nullable(),
-  draftUserMessage: userMessageDocumentSchema.nullable(),
-  draftAttachments: z.array(persistedAttachmentSchema).nullable(),
-});
 
 describe("chat message response contract", () => {
   const automationId = "11111111-1111-4111-8111-111111111111";
@@ -138,29 +130,13 @@ describe("chat message response contract", () => {
 
     expect(
       chatThreadDraftSchema.safeParse({
-        draftContent: null,
         draftStructuredPrompt: userMessage,
         draftAttachments: null,
       }).success,
     ).toBe(false);
   });
 
-  it("keeps thread draft responses readable by the previous App schema", () => {
-    const response = chatThreadDraftSchema.parse({
-      draftContent: null,
-      draftUserMessage: {
-        version: 1,
-        parts: [{ type: "text", text: "Resume the draft" }],
-      },
-      draftAttachments: null,
-    });
-
-    expect(previousChatThreadDraftResponseSchema.parse(response)).toStrictEqual(
-      response,
-    );
-  });
-
-  it("accepts thread draft responses without the legacy content projection", () => {
+  it("accepts canonical thread draft responses", () => {
     const response = {
       draftUserMessage: {
         version: 1 as const,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/zero-agents.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/zero-agents.test.ts
@@ -1,20 +1,9 @@
-import { z } from "zod";
 import { describe, expect, it } from "vitest";
 
-import {
-  persistedAttachmentSchema,
-  userMessageDocumentSchema,
-} from "../chat-threads";
 import {
   zeroAgentDraftRequestSchema,
   zeroAgentDraftResponseSchema,
 } from "../zero-agents";
-
-const previousZeroAgentDraftResponseSchema = z.object({
-  draftContent: z.string().nullable(),
-  draftUserMessage: userMessageDocumentSchema.nullable(),
-  draftAttachments: z.array(persistedAttachmentSchema).nullable(),
-});
 
 describe("zero agent draft contract", () => {
   it("rejects agent drafts that only carry the retired rich-input field", () => {
@@ -25,29 +14,13 @@ describe("zero agent draft contract", () => {
 
     expect(
       zeroAgentDraftResponseSchema.safeParse({
-        draftContent: null,
         draftStructuredPrompt: userMessage,
         draftAttachments: null,
       }).success,
     ).toBe(false);
   });
 
-  it("keeps agent draft responses readable by the previous App schema", () => {
-    const response = zeroAgentDraftResponseSchema.parse({
-      draftContent: null,
-      draftUserMessage: {
-        version: 1,
-        parts: [{ type: "text", text: "Resume agent work" }],
-      },
-      draftAttachments: null,
-    });
-
-    expect(previousZeroAgentDraftResponseSchema.parse(response)).toStrictEqual(
-      response,
-    );
-  });
-
-  it("accepts agent draft responses without the legacy content projection", () => {
+  it("accepts canonical agent draft responses", () => {
     const response = {
       draftUserMessage: {
         version: 1 as const,

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -693,12 +693,6 @@ const chatThreadMetadataSchema = z.object({
 
 const chatThreadDraftSchema = z
   .object({
-    /**
-     * Response-only compatibility projection for older App bundles. Optional
-     * so this App version tolerates its removal after becoming the minimum
-     * supported version.
-     */
-    draftContent: z.string().nullable().optional(),
     draftUserMessage: userMessageDocumentSchema.nullable(),
     draftAttachments: z.array(persistedAttachmentSchema).nullable(),
   })

--- a/turbo/packages/api-contracts/src/contracts/zero-agents.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-agents.ts
@@ -67,12 +67,6 @@ export const zeroAgentInstructionsRequestSchema = z.object({
 
 export const zeroAgentDraftResponseSchema = z
   .object({
-    /**
-     * Response-only compatibility projection for older App bundles. Optional
-     * so this App version tolerates its removal after becoming the minimum
-     * supported version.
-     */
-    draftContent: z.string().nullable().optional(),
     draftUserMessage: userMessageDocumentSchema.nullable(),
     draftAttachments: z.array(persistedAttachmentSchema).nullable(),
   })


### PR DESCRIPTION
## Summary

- raise the app.vm0.ai compatibility floor from `0.631.1` to `0.662.2`
- remove the retired response-only `draftContent` projection from thread and agent draft contracts and API responses
- update App mocks and focused contract, API, and App tests to use the canonical draft response shape

## Rollout evidence

- production App version: `0.662.2`
- production App commit: `783cb041d0e6b5a4a368c26c5483a7e16389c347`
- source: `window._vm0.getBuildVersion()` and `window._vm0.getBuildCommitSha()` on `https://app.vm0.ai`
- the production commit is contained in `main` and contains PR #24053's merge commit, `3cb135ee40a7e3bad834f92c6fe767392d4695b8`

This makes `0.662.2` the first verified production floor that can safely receive draft responses without `draftContent`.

## User impact

App clients below `0.662.2` receive the compatibility rejection on their next API request and must refresh to load a supported build. Supported clients continue using `draftUserMessage` and `draftAttachments`; the API no longer emits the retired `draftContent: null` field.

## Files changed

- compatibility floor configuration
- thread and zero-agent draft response contracts
- thread and zero-agent draft API response builders
- directly coupled API assertions, App mocks, and draft behavior tests

## Verification

- `pnpm format`
- focused oxlint, type-aware oxlint, and ESLint for all changed TypeScript files
- `pnpm knip`
- type checks for API contracts, App production/tests, and the other affected workspaces
- 151 focused tests across API contracts, API compatibility/draft routes, and App draft behavior
- JSON parse/target assertion and `git diff --check`

The local 3.9 GB container could not complete the full API ESLint/typecheck processes: both were terminated by memory pressure after producing no code diagnostics. The focused API lint passed, and the full API typecheck and complete CI suite are intentionally left to the PR pipeline.
