### PR TITLE
fix(api): enforce column encoding for typed comparison values

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1012,8 +1012,11 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     ).toContain(deletedAgentThread.id);
 
     mockNow(incrementalSnapshotAt + DAY_MS + 1);
-    await compactChatThreadSnapshots();
+    const staleCompact = await compactChatThreadSnapshots();
+    expect(staleCompact.removedDeletedAgentThreads).toBeGreaterThanOrEqual(1);
     const compactedSnapshot = await chat.getThreadSnapshot(actor);
+    expect(compactedSnapshot.latestEventId).not.toBeNull();
+    expect(compactedSnapshot.latestSeqId).not.toBeNull();
     expect(compactedSnapshot.chatThreads).toStrictEqual([
       expect.objectContaining({
         id: liveThread.id,
@@ -1036,7 +1039,8 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     expect(retainedBoundaryCursor.status).toBe(200);
 
     mockNow(retentionBoundary + 1);
-    await compactChatThreadSnapshots();
+    const retentionCompact = await compactChatThreadSnapshots();
+    expect(retentionCompact.eventsPruned).toBeGreaterThanOrEqual(1);
     const prunedCursor = await chat.requestThreadEvents(
       actor,
       { sinceSeqId: liveCreateEvent.seqId },

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -13,6 +13,7 @@ import { zeroGoalsContract } from "@vm0/api-contracts/contracts/zero-goals";
 import { describe, expect, it, onTestFinished } from "vitest";
 
 import { createApp } from "../../../app-factory";
+import { stubTestTimezone } from "../../../__tests__/env-stub";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -91,6 +92,7 @@ const connectorsApi = createConnectorBddApi(context);
 const authOrg = createAuthOrgAgentsBddApi(context);
 const store = createStore();
 const CHAT_THREAD_SNAPSHOT_CRON_SECRET = "chat-thread-snapshot-cron-secret";
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 type UserMessage = Extract<
   ChatEventResponse,
@@ -918,7 +920,12 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     expect(sortTouches).toHaveLength(2);
   }, 90_000);
 
-  it("compacts chat thread snapshots from event markers and prunes deleted agent threads", async () => {
+  it("preserves UTC snapshot and event cutoff boundaries outside UTC", async () => {
+    stubTestTimezone("Asia/Shanghai");
+    onTestFinished(() => {
+      clearMockNow();
+      stubTestTimezone("UTC");
+    });
     mockEnv("CRON_SECRET", CHAT_THREAD_SNAPSHOT_CRON_SECRET);
     const actor = bdd.user();
     await api.ensureOrgModelProvider(actor);
@@ -942,15 +949,24 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       eventId: deletedCreateEventId,
     });
 
-    const initialCompact = await compactChatThreadSnapshots();
-    expect(initialCompact.eventsApplied).toBeGreaterThanOrEqual(2);
-
-    const liveCreateEvent = (await allThreadEvents(actor)).find((event) => {
+    const initialEvents = await allThreadEvents(actor);
+    const liveCreateEvent = initialEvents.find((event) => {
       return event.id === liveCreateEventId;
     });
-    if (!liveCreateEvent) {
-      throw new Error("Expected live thread creation event");
+    const deletedCreateEvent = initialEvents.find((event) => {
+      return event.id === deletedCreateEventId;
+    });
+    if (!liveCreateEvent || !deletedCreateEvent) {
+      throw new Error("Expected both thread creation events");
     }
+    const initialSnapshotAt =
+      Math.max(
+        Date.parse(liveCreateEvent.createdAt),
+        Date.parse(deletedCreateEvent.createdAt),
+      ) + 1000;
+    mockNow(initialSnapshotAt);
+    const initialCompact = await compactChatThreadSnapshots();
+    expect(initialCompact.eventsApplied).toBeGreaterThanOrEqual(2);
 
     const baselineSnapshot = await chat.getThreadSnapshot(actor);
     expect(baselineSnapshot.latestEventId).not.toBeNull();
@@ -977,23 +993,27 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       "claude-sonnet-4-6",
       { eventId: modelSelectionEventId },
     );
+
+    const incrementalSnapshotAt = initialSnapshotAt + 1000;
+    mockNow(incrementalSnapshotAt);
+    const incrementalCompact = await compactChatThreadSnapshots();
+    expect(incrementalCompact.eventsApplied).toBeGreaterThanOrEqual(1);
+
     chat.mockObjectStorageObjectsExist();
     await authOrg.deleteAgent(actor, deletedAgent.agentId);
 
-    onTestFinished(() => {
-      clearMockNow();
-    });
-    mockNow(now() + 8 * 24 * 60 * 60 * 1000);
-    const incrementalCompact = await compactChatThreadSnapshots();
-    expect(incrementalCompact.eventsApplied).toBeGreaterThanOrEqual(1);
+    mockNow(incrementalSnapshotAt + DAY_MS);
+    await compactChatThreadSnapshots();
+    const boundarySnapshot = await chat.getThreadSnapshot(actor);
     expect(
-      incrementalCompact.removedDeletedAgentThreads,
-    ).toBeGreaterThanOrEqual(1);
-    expect(incrementalCompact.eventsPruned).toBeGreaterThanOrEqual(1);
+      boundarySnapshot.chatThreads.map((thread) => {
+        return thread.id;
+      }),
+    ).toContain(deletedAgentThread.id);
 
+    mockNow(incrementalSnapshotAt + DAY_MS + 1);
+    await compactChatThreadSnapshots();
     const compactedSnapshot = await chat.getThreadSnapshot(actor);
-    expect(compactedSnapshot.latestEventId).not.toBeNull();
-    expect(compactedSnapshot.latestSeqId).not.toBeNull();
     expect(compactedSnapshot.chatThreads).toStrictEqual([
       expect.objectContaining({
         id: liveThread.id,
@@ -1004,6 +1024,19 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       }),
     ]);
 
+    const retentionBoundary =
+      Date.parse(liveCreateEvent.createdAt) + 7 * DAY_MS;
+    mockNow(retentionBoundary);
+    await compactChatThreadSnapshots();
+    const retainedBoundaryCursor = await chat.requestThreadEvents(
+      actor,
+      { sinceSeqId: liveCreateEvent.seqId },
+      [200],
+    );
+    expect(retainedBoundaryCursor.status).toBe(200);
+
+    mockNow(retentionBoundary + 1);
+    await compactChatThreadSnapshots();
     const prunedCursor = await chat.requestThreadEvents(
       actor,
       { sinceSeqId: liveCreateEvent.seqId },

--- a/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
@@ -229,7 +229,7 @@ function upsertedCte(updatedAt: Date): SQL {
         rebuilt.latest_event_id,
         rebuilt.latest_event_seq_id,
         rebuilt.chat_threads,
-        ${sql.param(updatedAt, chatThreadSnapshots.updatedAt)},
+        ${sql.param(updatedAt, chatThreadSnapshots.createdAt)},
         ${sql.param(updatedAt, chatThreadSnapshots.updatedAt)}
       FROM rebuilt
       ON CONFLICT (user_id, org_id)

--- a/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
@@ -110,7 +110,7 @@ function candidateScopesCte(staleCutoff: Date, batchSize: number): SQL {
       WHERE ${or(
         isNull(snapshot.userId),
         sql`${snapshot.latestEventSeqId} IS DISTINCT FROM latest_event.seq_id`,
-        lt(snapshot.updatedAt, sql`${staleCutoff}`),
+        lt(snapshot.updatedAt, staleCutoff),
       )}
       ORDER BY
         ${asc(snapshot.updatedAt)} NULLS FIRST,
@@ -229,8 +229,8 @@ function upsertedCte(updatedAt: Date): SQL {
         rebuilt.latest_event_id,
         rebuilt.latest_event_seq_id,
         rebuilt.chat_threads,
-        ${updatedAt},
-        ${updatedAt}
+        ${sql.param(updatedAt, chatThreadSnapshots.updatedAt)},
+        ${sql.param(updatedAt, chatThreadSnapshots.updatedAt)}
       FROM rebuilt
       ON CONFLICT (user_id, org_id)
       DO UPDATE SET
@@ -317,7 +317,7 @@ async function compactChatThreadSnapshotsForAllScopes(
         WHERE ${and(
           eq(event.userId, snapshot.userId),
           eq(event.orgId, snapshot.orgId),
-          lt(event.createdAt, sql`${cutoff}`),
+          lt(event.createdAt, cutoff),
           lt(event.seqId, marker.seqId),
         )}
         RETURNING 1

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -2907,6 +2907,170 @@ ruleTester.run("prefer-drizzle-apis retained operands", preferDrizzleApis, {
   ],
 });
 
+ruleTester.run(
+  "prefer-drizzle-apis column-encoded comparison values",
+  preferDrizzleApis,
+  {
+    valid: [
+      {
+        name: "direct values already use the column encoder",
+        code: `${drizzlePreamble}
+          import { eq, gt, gte, lt, lte, ne } from "drizzle-orm";
+          const cutoff = new Date();
+          eq(users.deletedAt, cutoff);
+          ne(users.deletedAt, cutoff);
+          gt(users.deletedAt, cutoff);
+          gte(users.deletedAt, cutoff);
+          lt(users.deletedAt, cutoff);
+          lte(users.deletedAt, cutoff);
+        `,
+      },
+      {
+        name: "sql operands and schema columns remain wrappers",
+        code: `${drizzlePreamble}
+          import { lt, sql, type SQL } from "drizzle-orm";
+          const cutoff = new Date();
+          class SqlDate extends Date {
+            getSQL(): SQL {
+              return sql\`now()\`;
+            }
+          }
+          lt(sql\`COALESCE(\${users.deletedAt}, now())\`, sql\`\${cutoff}\`);
+          lt(users.deletedAt, sql\`\${users.deletedAt}\`);
+          lt(users.deletedAt, sql\`\${sql\`now()\`}\`);
+          lt(
+            users.deletedAt,
+            sql\`\${sql.param(cutoff, users.deletedAt)}\`,
+          );
+          lt(users.deletedAt, sql\`\${sql.placeholder("cutoff")}\`);
+          lt(users.deletedAt, sql\`\${new SqlDate()}\`);
+        `,
+      },
+      {
+        name: "templates containing sql syntax remain opaque",
+        code: `${drizzlePreamble}
+          import { lt, sql } from "drizzle-orm";
+          const cutoff = new Date();
+          lt(users.deletedAt, sql\`\${cutoff}::timestamp\`);
+          lt(users.deletedAt, sql\`DATE_TRUNC('day', \${cutoff})\`);
+          lt(users.deletedAt, sql\`\${cutoff} + interval '1 day'\`);
+          lt(users.deletedAt, sql\`\${cutoff} + \${cutoff}\`);
+          lt(
+            users.deletedAt,
+            sql\`\${cutoff}\`.mapWith(users.deletedAt),
+          );
+          lt(users.deletedAt, sql\`\${cutoff}\`.as("cutoff"));
+        `,
+      },
+      {
+        name: "unproven value types remain opaque",
+        code: `${drizzlePreamble}
+          import { eq, lt, sql, type SQL } from "drizzle-orm";
+          declare const unknownCutoff: unknown;
+          declare const optionalCutoff: Date | undefined;
+          declare const dates: Date[];
+          declare const args: [typeof users.deletedAt, SQL];
+          const stringCutoff = "2026-07-30";
+          function compare<T>(cutoff: T): void {
+            lt(users.deletedAt, sql\`\${cutoff}\`);
+          }
+          lt(users.deletedAt, sql\`\${unknownCutoff}\`);
+          lt(users.deletedAt, sql\`\${optionalCutoff}\`);
+          lt(users.deletedAt, sql\`\${unknownCutoff as Date}\`);
+          lt(users.deletedAt, sql\`\${optionalCutoff!}\`);
+          lt(users.deletedAt, sql\`\${stringCutoff}\`);
+          eq(users.tags, sql\`\${dates}\`);
+          lt(...args);
+          void compare;
+        `,
+      },
+      {
+        name: "fake helper tag and column symbols remain opaque",
+        code: `${drizzlePreamble}
+          import {
+            lt as drizzleLt,
+            sql,
+            type SQL,
+          } from "drizzle-orm";
+          const cutoff = new Date();
+          function lt(left: unknown, right: unknown): unknown {
+            return { left, right };
+          }
+          function tag(
+            strings: TemplateStringsArray,
+            ...values: unknown[]
+          ): SQL {
+            return sql(strings, ...values);
+          }
+          declare const fakeColumn: {
+            readonly _: { readonly data: Date };
+            getSQL(): SQL;
+          };
+          lt(users.deletedAt, sql\`\${cutoff}\`);
+          drizzleLt(users.deletedAt, tag\`\${cutoff}\`);
+          drizzleLt(fakeColumn, sql\`\${cutoff}\`);
+        `,
+      },
+    ],
+    invalid: [
+      {
+        name: "all drizzle binary helpers restore the column encoder",
+        code: `${drizzlePreamble}
+          import { eq, gt, gte, lt, lte, ne, sql } from "drizzle-orm";
+          const cutoff = new Date();
+          eq(users.deletedAt, sql\`\${cutoff}\`);
+          ne(users.deletedAt, sql\`\${cutoff}\`);
+          gt(users.deletedAt, sql\`\${cutoff}\`);
+          gte(users.deletedAt, sql\`\${cutoff}\`);
+          lt(users.deletedAt, sql\`\${cutoff}\`);
+          lte(users.deletedAt, sql\`\${cutoff}\`);
+        `,
+        errors: [
+          { messageId: "columnEncodedValue", data: { helper: "eq" } },
+          { messageId: "columnEncodedValue", data: { helper: "ne" } },
+          { messageId: "columnEncodedValue", data: { helper: "gt" } },
+          { messageId: "columnEncodedValue", data: { helper: "gte" } },
+          { messageId: "columnEncodedValue", data: { helper: "lt" } },
+          { messageId: "columnEncodedValue", data: { helper: "lte" } },
+        ],
+      },
+      {
+        name: "real helper tag and column aliases remain supported",
+        code: `${drizzlePreamble}
+          import { lt as before, sql as query } from "drizzle-orm";
+          const deletedAt = users.deletedAt;
+          const cutoff = new Date();
+          before(deletedAt, query\`\${cutoff}\`);
+        `,
+        errors: [{ messageId: "columnEncodedValue", data: { helper: "lt" } }],
+      },
+      {
+        name: "primitive column values restore their column encoders",
+        code: `${drizzlePreamble}
+          import { eq, ne, sql } from "drizzle-orm";
+          const id = 1;
+          const name = "name";
+          eq(users.id, sql\`\${id}\`);
+          ne(users.name, sql\`\${name}\`);
+        `,
+        errors: [
+          { messageId: "columnEncodedValue", data: { helper: "eq" } },
+          { messageId: "columnEncodedValue", data: { helper: "ne" } },
+        ],
+      },
+      {
+        name: "namespace imports remain supported",
+        code: `${drizzlePreamble}
+          import * as drizzle from "drizzle-orm";
+          const cutoff = new Date();
+          drizzle.lt(users.deletedAt, drizzle.sql\`\${cutoff}\`);
+        `,
+        errors: [{ messageId: "columnEncodedValue", data: { helper: "lt" } }],
+      },
+    ],
+  },
+);
+
 ruleTester.run("prefer-drizzle-apis source-local analysis", preferDrizzleApis, {
   valid: [
     {

--- a/turbo/packages/eslint-rules/src/api/drizzle.ts
+++ b/turbo/packages/eslint-rules/src/api/drizzle.ts
@@ -752,6 +752,24 @@ export function getDrizzleColumnMetadata(
   return drizzleColumnMetadata(checker, type, location);
 }
 
+export function getDrizzleColumnDataType(
+  checker: TypeChecker,
+  type: Type,
+  location: Node,
+): Type | undefined {
+  if (
+    type.isUnion() ||
+    (type.flags & TypeFlags.TypeParameter) !== 0 ||
+    concreteDrizzleColumnMetadata(checker, type, location) === undefined
+  ) {
+    return undefined;
+  }
+  const metadataType = propertyType(checker, type, "_", location);
+  return metadataType === undefined
+    ? undefined
+    : propertyType(checker, metadataType, "data", location);
+}
+
 export function isDrizzleArrayParameter(
   checker: TypeChecker,
   services: ParserServicesWithTypeInformation,

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -30,6 +30,8 @@ import {
 } from "typescript";
 
 import {
+  drizzleCallName,
+  getDrizzleColumnDataType,
   getDrizzleColumnMetadata,
   isDrizzleDeclaration,
   isDrizzlePgCoreDeclaration,
@@ -80,6 +82,15 @@ const PREDICATE_HELPERS = new Set([
   "notInArray",
   "notLike",
   "or",
+]);
+
+const BINARY_COMPARISON_HELPERS = new Set([
+  "eq",
+  "ne",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
 ]);
 
 const SELECTION_HELPERS = new Set([
@@ -135,6 +146,8 @@ export const preferDrizzleApis = createRule({
         "Use Drizzle crossJoin(...) for this equivalent inner join on true.",
       crossJoinLateral:
         "Use Drizzle crossJoinLateral(...) for this equivalent lateral join.",
+      columnEncodedValue:
+        "This empty SQL wrapper bypasses the schema column encoder; pass the value directly to {{helper}}(...).",
       directColumn:
         "Select the Drizzle column directly instead of using an identity SQL wrapper.",
       composedCteQueryBuilder:
@@ -1007,6 +1020,97 @@ export const preferDrizzleApis = createRule({
         leftMetadata.tableName === rightMetadata.tableName &&
         context.sourceCode.getText(left) === context.sourceCode.getText(right)
       );
+    }
+
+    function hasConcreteBoundValueType(type: Type, location: Node): boolean {
+      if (
+        (type.flags &
+          (TypeFlags.Any |
+            TypeFlags.Never |
+            TypeFlags.Null |
+            TypeFlags.TypeParameter |
+            TypeFlags.Undefined |
+            TypeFlags.Unknown |
+            TypeFlags.Void)) !==
+        0
+      ) {
+        return false;
+      }
+      if (type.isUnionOrIntersection()) {
+        return type.types.every((member) => {
+          return hasConcreteBoundValueType(member, location);
+        });
+      }
+      if (checker.isArrayType(type) || checker.isTupleType(type)) {
+        return false;
+      }
+      const getSql = checker.getPropertyOfType(type, "getSQL");
+      return (
+        getSql === undefined ||
+        checker.getTypeOfSymbolAtLocation(getSql, location).getCallSignatures()
+          .length === 0
+      );
+    }
+
+    function inspectColumnEncodedComparisonValue(
+      node: TSESTree.CallExpression,
+    ): void {
+      if (node.arguments.length !== 2) {
+        return;
+      }
+      const [left, right] = node.arguments;
+      if (
+        left === undefined ||
+        right === undefined ||
+        left.type === AST_NODE_TYPES.SpreadElement ||
+        right.type !== AST_NODE_TYPES.TaggedTemplateExpression ||
+        right.quasi.expressions.length !== 1 ||
+        right.quasi.quasis.length !== 2 ||
+        right.quasi.quasis.some((quasi) => {
+          return (quasi.value.cooked ?? quasi.value.raw) !== "";
+        }) ||
+        !isDrizzleSqlTag(checker, services, right.tag) ||
+        !isConventionalColumnExpression(left)
+      ) {
+        return;
+      }
+      const value = right.quasi.expressions[0];
+      const helper = drizzleCallName(
+        checker,
+        services.esTreeNodeToTSNodeMap.get(node),
+      );
+      if (
+        helper === undefined ||
+        !BINARY_COMPARISON_HELPERS.has(helper) ||
+        value === undefined ||
+        value.type === AST_NODE_TYPES.TSAsExpression ||
+        value.type === AST_NODE_TYPES.TSNonNullExpression ||
+        value.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+        value.type === AST_NODE_TYPES.TSTypeAssertion
+      ) {
+        return;
+      }
+      const tsLeft = services.esTreeNodeToTSNodeMap.get(left);
+      const tsValue = services.esTreeNodeToTSNodeMap.get(value);
+      const columnDataType = getDrizzleColumnDataType(
+        checker,
+        checker.getTypeAtLocation(tsLeft),
+        tsLeft,
+      );
+      const valueType = checker.getTypeAtLocation(tsValue);
+      if (
+        columnDataType === undefined ||
+        !hasConcreteBoundValueType(columnDataType, tsLeft) ||
+        !hasConcreteBoundValueType(valueType, tsValue) ||
+        !checker.isTypeAssignableTo(valueType, columnDataType)
+      ) {
+        return;
+      }
+      context.report({
+        node: right,
+        messageId: "columnEncodedValue",
+        data: { helper },
+      });
     }
 
     function callReceiver(
@@ -2285,6 +2389,7 @@ export const preferDrizzleApis = createRule({
       CallExpression(node: TSESTree.CallExpression): void {
         inspectRawQueryCall(node);
         inspectPredicateCall(node);
+        inspectColumnEncodedComparisonValue(node);
         inspectSqlJoinCall(node);
         inspectUnstableGroupingCall(node);
         inspectAdditionalContextCall(node);


### PR DESCRIPTION
## Summary

- preserve the timestamp column encoder for snapshot staleness and event
  retention comparisons
- encode raw snapshot UPSERT timestamps with the schema column before binding
- extend `api/prefer-drizzle-apis` to detect conventional empty SQL wrappers
  around assignable values for Drizzle's six binary comparison helpers
- verify strict 24-hour and seven-day UTC boundaries against real PostgreSQL
  while the API process runs in `Asia/Shanghai`

The generated SQL text, placeholder order, CTE and transaction topology, and
query plan shape remain unchanged. Only the four affected driver parameters
change from raw JavaScript `Date` values to the timestamp column's ISO UTC
representation.

## Exclusions

- no schema migration, persisted-data rewrite, API or protocol change, feature
  switch, or compatibility bridge
- no autofix, blanket `sql` ban, PostgreSQL-parser fallback for empty templates,
  or generalization to array/range helpers and arbitrary raw writes

## Validation

- `pnpm exec prettier --write <changed files>`
- `pnpm -F @vm0/eslint-rules test` (47 files, 1,015 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts --maxWorkers=1 --silent=passed-only`
  (28 tests)
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api check-types`
- `pnpm knip`
- `git diff --check`
- real PostgreSQL parameter probe under `TZ=Asia/Shanghai`
- five alternating warm API ESLint pairs: median wall time `+2.00%`
  (limit `+5%`), median aggregate process-tree peak RSS `-0.80%`
  (limit `+10%`)

Closes #24067

Parent context: #23047
