### PR TITLE
perf(runner): prevent concurrent systemd daemon-reload storms

### DIFF
--- a/.github/scripts/runner-behavior-systemd-reload.sh
+++ b/.github/scripts/runner-behavior-systemd-reload.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REMOTE="${METAL_USER}@${HOST}"
+GROUP="vm0/systemd-reload-${JOB_REF}"
+
+echo "=== Generating systemd reload test configs ==="
+for SUFFIX in systemd-reload-a systemd-reload-b; do
+  # shellcheck disable=SC2029
+  ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
+    --profile vm0/default \
+    --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
+    --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
+    --name ${JOB_REF}-${SUFFIX} \
+    --group ${GROUP} \
+    --runner-dirname ${JOB_REF}-${SUFFIX} \
+    --max-concurrent 1 \
+    --api-url https://not-a-real-server.test \
+    --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
+done
+
+echo "=== Running systemd reload coordination test ==="
+ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${JOB_REF}" "${GROUP}" <<'REMOTE_SCRIPT'
+set -euo pipefail
+
+BIN_DIR=$1
+JOB_REF=$2
+GROUP=$3
+SVC_A="${JOB_REF}-systemd-reload-a"
+SVC_B="${JOB_REF}-systemd-reload-b"
+UNIT_A="vm0-runner-${SVC_A}.service"
+UNIT_B="vm0-runner-${SVC_B}.service"
+RUNNER_DIR_A="/var/lib/vm0-runner/runners/${SVC_A}"
+RUNNER_DIR_B="/var/lib/vm0-runner/runners/${SVC_B}"
+GROUP_DIR="/var/lib/vm0-runner/groups/${GROUP}"
+INSTALL_A_PID=""
+INSTALL_B_PID=""
+UNINSTALL_A_PID=""
+UNINSTALL_B_PID=""
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+wait_for_command() {
+  local pid=$1 label=$2
+  if ! wait "$pid"; then
+    fail "$label failed"
+  fi
+}
+
+cleanup_pid() {
+  local pid=$1
+  [ -n "$pid" ] || return 0
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+cleanup() {
+  local status=$?
+  cleanup_pid "$UNINSTALL_B_PID"
+  cleanup_pid "$UNINSTALL_A_PID"
+  cleanup_pid "$INSTALL_B_PID"
+  cleanup_pid "$INSTALL_A_PID"
+  sudo "$BIN_DIR/runner" service uninstall --name "$SVC_A" --force >/dev/null 2>&1 || true
+  sudo "$BIN_DIR/runner" service uninstall --name "$SVC_B" --force >/dev/null 2>&1 || true
+  sudo rm -rf -- "$RUNNER_DIR_A" "$RUNNER_DIR_B" "$GROUP_DIR"
+  if [ "$status" -ne 0 ]; then
+    echo "--- systemd reload test journal ---"
+    sudo journalctl -b --unit "$UNIT_A" --unit "$UNIT_B" --lines 100 --no-pager || true
+    sudo journalctl -b _PID=1 --lines 100 --no-pager || true
+  fi
+}
+trap cleanup EXIT
+
+# Remove state from an interrupted attempt before opening the measurement
+# window. The cleanup operations themselves are intentionally not counted.
+sudo "$BIN_DIR/runner" service uninstall --name "$SVC_A" --force >/dev/null 2>&1 || true
+sudo "$BIN_DIR/runner" service uninstall --name "$SVC_B" --force >/dev/null 2>&1 || true
+
+[ -n "${XDG_SESSION_ID:-}" ] || fail "XDG_SESSION_ID is unavailable"
+JOURNAL_CURSOR=$(sudo journalctl -b --no-pager -n 0 --show-cursor \
+  | sed -n 's/^-- cursor: //p')
+[ -n "$JOURNAL_CURSOR" ] || fail "could not capture journal cursor"
+
+echo "--- Installing two different services concurrently ---"
+sudo "$BIN_DIR/runner" service install --name "$SVC_A" \
+  --config "$RUNNER_DIR_A/runner.yaml" --local \
+  --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true &
+INSTALL_A_PID=$!
+sudo "$BIN_DIR/runner" service install --name "$SVC_B" \
+  --config "$RUNNER_DIR_B/runner.yaml" --local \
+  --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true &
+INSTALL_B_PID=$!
+wait_for_command "$INSTALL_A_PID" "install A"
+INSTALL_A_PID=""
+wait_for_command "$INSTALL_B_PID" "install B"
+INSTALL_B_PID=""
+
+for UNIT in "$UNIT_A" "$UNIT_B"; do
+  [ "$(sudo systemctl show "$UNIT" --property=LoadState --value)" = "loaded" ] \
+    || fail "$UNIT is not loaded after install"
+  sudo systemctl is-enabled --quiet "$UNIT" \
+    || fail "$UNIT is not enabled after install"
+  sudo systemctl is-active --quiet "$UNIT" \
+    || fail "$UNIT is not active after install"
+done
+
+echo "--- Uninstalling two different services concurrently ---"
+sudo "$BIN_DIR/runner" service uninstall --name "$SVC_A" --force &
+UNINSTALL_A_PID=$!
+sudo "$BIN_DIR/runner" service uninstall --name "$SVC_B" --force &
+UNINSTALL_B_PID=$!
+wait_for_command "$UNINSTALL_A_PID" "uninstall A"
+UNINSTALL_A_PID=""
+wait_for_command "$UNINSTALL_B_PID" "uninstall B"
+UNINSTALL_B_PID=""
+
+for UNIT in "$UNIT_A" "$UNIT_B"; do
+  if sudo systemctl is-active --quiet "$UNIT"; then
+    fail "$UNIT remained active after uninstall"
+  fi
+  if sudo systemctl is-enabled --quiet "$UNIT"; then
+    fail "$UNIT remained enabled after uninstall"
+  fi
+  [ ! -e "/etc/systemd/system/${UNIT}" ] \
+    || fail "$UNIT file remained after uninstall"
+  [ ! -e "/run/systemd/system/${UNIT}.d/50-vm0-drain.conf" ] \
+    || fail "$UNIT drain override remained after uninstall"
+  [ "$(sudo systemctl show "$UNIT" --property=NeedDaemonReload --value)" = "no" ] \
+    || fail "systemd remained dirty after uninstalling $UNIT"
+done
+
+SESSION_SCOPE="unit session-${XDG_SESSION_ID}.scope"
+RELOAD_COUNT=$(sudo journalctl -b _PID=1 --after-cursor="$JOURNAL_CURSOR" \
+  --no-pager -o cat \
+  | awk -v scope="$SESSION_SCOPE" \
+    'index($0, "Reloading requested") && index($0, scope) { count++ } END { print count + 0 }')
+
+echo "Session ${XDG_SESSION_ID} requested ${RELOAD_COUNT} systemd manager reload(s)"
+[ "$RELOAD_COUNT" -ge 2 ] \
+  || fail "expected at least one install and one uninstall reload, got $RELOAD_COUNT"
+[ "$RELOAD_COUNT" -le 4 ] \
+  || fail "expected at most one reload per successful lifecycle operation, got $RELOAD_COUNT"
+
+trap - EXIT
+cleanup
+echo "=== Systemd reload coordination test passed ==="
+REMOTE_SCRIPT

--- a/.github/scripts/runner-behavior-upgrade-local.sh
+++ b/.github/scripts/runner-behavior-upgrade-local.sh
@@ -116,7 +116,7 @@ SUBMIT2_PID=""
 # an inactive-but-enabled installed unit.
 wait_for_exit "$SVC_A"
 echo "--- Re-enable inactive runner A, then drain again ---"
-sudo systemctl enable "vm0-runner-${SVC_A}.service"
+sudo systemctl enable --no-reload "vm0-runner-${SVC_A}.service"
 sudo systemctl is-enabled --quiet "vm0-runner-${SVC_A}.service" \
   || fail "runner A should be enabled before inactive drain"
 sudo "$BIN_DIR/runner" service drain --name "$SVC_A" \

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -785,6 +785,12 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
         run: .github/scripts/runner-behavior-cancel.sh
 
+      - name: Test systemd reload coordination
+        timeout-minutes: 5
+        env:
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+        run: .github/scripts/runner-behavior-systemd-reload.sh
+
       - name: Run upgrade test
         timeout-minutes: 5
         env:

--- a/ansible/playbooks/cleanup-crates-runner.yml
+++ b/ansible/playbooks/cleanup-crates-runner.yml
@@ -18,6 +18,7 @@
   vars:
     base_dir: /var/lib/vm0-runner
     bin_dir: "{{ base_dir }}/bin/{{ job_ref }}"
+    reload_lock: "{{ base_dir }}/locks/systemd-daemon-reload.lock"
 
   tasks:
     - name: Check required variables
@@ -26,12 +27,30 @@
           - job_ref is defined
         fail_msg: "Required variable: job_ref"
 
+    - name: Ensure runner lock directory exists
+      file:
+        path: "{{ base_dir }}/locks"
+        state: directory
+        owner: root
+        group: root
+        mode: "0700"
+
+    - name: Ensure systemd reload lock exists
+      file:
+        path: "{{ reload_lock }}"
+        state: touch
+        owner: root
+        group: root
+        mode: "0600"
+        access_time: preserve
+        modification_time: preserve
+
     - name: Stop persistent service upgrade-a
       command: systemctl stop vm0-runner-{{ job_ref }}-upgrade-a.service
       ignore_errors: true
 
     - name: Disable persistent service upgrade-a
-      command: systemctl disable vm0-runner-{{ job_ref }}-upgrade-a.service
+      command: systemctl disable --no-reload vm0-runner-{{ job_ref }}-upgrade-a.service
       ignore_errors: true
 
     - name: Remove unit file upgrade-a
@@ -44,7 +63,7 @@
       ignore_errors: true
 
     - name: Disable persistent service upgrade-b
-      command: systemctl disable vm0-runner-{{ job_ref }}-upgrade-b.service
+      command: systemctl disable --no-reload vm0-runner-{{ job_ref }}-upgrade-b.service
       ignore_errors: true
 
     - name: Remove unit file upgrade-b
@@ -73,7 +92,7 @@
       ignore_errors: true
 
     - name: Reload systemd daemon
-      command: systemctl daemon-reload
+      command: flock --exclusive {{ reload_lock }} systemctl daemon-reload
       ignore_errors: true
 
     - name: Remove directories

--- a/crates/runner/src/cmd/gc/orphaned_locks.rs
+++ b/crates/runner/src/cmd/gc/orphaned_locks.rs
@@ -12,8 +12,10 @@ use super::workspaces::is_base_dir_lock_name;
 /// `open_lock_file` will recreate them on next use, and the inode recheck in
 /// `lock.rs` prevents stale-fd races. Service locks are intentionally retained
 /// because this GC pass runs before version GC, which relies on those lock paths
-/// to coordinate with concurrent service install/uninstall commands. Stale
-/// version service locks are cleaned by a post-version-GC pass.
+/// to coordinate with concurrent service install/uninstall commands. The
+/// systemd reload lock is also retained because non-runner lifecycle owners use
+/// the same stable path with plain `flock`. Stale version service locks are
+/// cleaned by a post-version-GC pass.
 pub(super) async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> RunnerResult<GcReport> {
     let locks_dir = home.locks_dir();
     let Some(mut entries) = read_dir_or_missing(&locks_dir).await? else {
@@ -34,7 +36,10 @@ pub(super) async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> Runner
         // deleting a version that another process is installing or uninstalling.
         // Workspace GC owns base-dir lock lifecycle because those locks carry
         // the base_dir metadata needed to rediscover dead-runner workspaces.
-        if name.starts_with("service-") || is_base_dir_lock_name(name) {
+        if name.starts_with("service-")
+            || entry.path() == home.systemd_daemon_reload_lock()
+            || is_base_dir_lock_name(name)
+        {
             continue;
         }
 
@@ -75,6 +80,31 @@ mod tests {
         assert!(
             service_lock.exists(),
             "service locks must survive orphaned lock cleanup"
+        );
+        assert!(
+            !stale_lock.exists(),
+            "ordinary free locks should still be cleaned"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_orphaned_locks_preserves_systemd_reload_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+        let reload_lock = home.systemd_daemon_reload_lock();
+        let stale_lock = locks_dir.join("workspace-image-cache-test.lock");
+        std::fs::write(&reload_lock, "").unwrap();
+        std::fs::write(&stale_lock, "").unwrap();
+
+        let report = gc_orphaned_locks(&home, false).await.unwrap();
+
+        assert_eq!(report.activity_count, 1);
+        assert_eq!(report.freed_bytes, 0);
+        assert!(
+            reload_lock.exists(),
+            "the shared systemd reload lock must keep a stable inode"
         );
         assert!(
             !stale_lock.exists(),

--- a/crates/runner/src/cmd/service/drain_override.rs
+++ b/crates/runner/src/cmd/service/drain_override.rs
@@ -21,6 +21,10 @@ pub(super) fn remove_drain_restart_override(unit: &RunnerServiceUnit) -> RunnerR
     remove_drain_restart_override_at(Path::new(RUNTIME_SYSTEMD_SYSTEM_DIR), unit)
 }
 
+pub(super) fn drain_restart_override_path(unit: &RunnerServiceUnit) -> PathBuf {
+    drain_restart_override_path_at(Path::new(RUNTIME_SYSTEMD_SYSTEM_DIR), unit)
+}
+
 fn drain_restart_override_dir_at(root: &Path, unit: &RunnerServiceUnit) -> PathBuf {
     root.join(format!("{}.d", unit.service_name()))
 }

--- a/crates/runner/src/cmd/service/drain_resume.rs
+++ b/crates/runner/src/cmd/service/drain_resume.rs
@@ -9,7 +9,8 @@ use super::gate::{read_runner_status, runner_base_dir};
 use super::reload::{SystemdReloadRequirement, coordinate_systemd_reload};
 use super::signal::{ServiceSignalOutcome, signal_service_main};
 use super::systemctl::{
-    get_service_restart_policy, is_unit_active, is_unit_enabled, run_systemctl,
+    SystemdUnitEnablement, get_service_restart_policy, is_unit_active, read_unit_enablement,
+    restore_unit_enablement, run_systemctl,
 };
 use super::{RunnerServiceUnit, ServiceFuture, acquire_service_lock};
 
@@ -42,7 +43,10 @@ fn ensure_drain_restart_policy_applied(
 
 trait ServiceDrainOps {
     fn is_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool>;
-    fn is_enabled<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool>;
+    fn enablement<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, SystemdUnitEnablement>;
     fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()>;
     fn remove_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<bool>;
     fn daemon_reload<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
@@ -52,11 +56,18 @@ trait ServiceDrainOps {
         unit: &'a RunnerServiceUnit,
     ) -> ServiceFuture<'a, ServiceSignalOutcome>;
     fn disable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
-    fn enable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
+    fn restore_enablement<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        enablement: SystemdUnitEnablement,
+    ) -> ServiceFuture<'a, ()>;
 }
 
 trait ServiceResumeOps {
-    fn is_enabled<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool>;
+    fn enablement<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, SystemdUnitEnablement>;
     fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()>;
     fn remove_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<bool>;
     fn daemon_reload<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
@@ -65,7 +76,11 @@ trait ServiceResumeOps {
         unit: &'a RunnerServiceUnit,
     ) -> ServiceFuture<'a, ServiceSignalOutcome>;
     fn enable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
-    fn disable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
+    fn restore_enablement<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        enablement: SystemdUnitEnablement,
+    ) -> ServiceFuture<'a, ()>;
 }
 
 struct RealServiceDrainOps;
@@ -76,8 +91,11 @@ impl ServiceDrainOps for RealServiceDrainOps {
         Box::pin(async move { is_unit_active(unit).await })
     }
 
-    fn is_enabled<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
-        Box::pin(async move { is_unit_enabled(unit).await })
+    fn enablement<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, SystemdUnitEnablement> {
+        Box::pin(async move { read_unit_enablement(unit).await })
     }
 
     fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()> {
@@ -113,16 +131,21 @@ impl ServiceDrainOps for RealServiceDrainOps {
         )
     }
 
-    fn enable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
-        Box::pin(
-            async move { run_systemctl(&["enable", "--no-reload", unit.service_name()]).await },
-        )
+    fn restore_enablement<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        enablement: SystemdUnitEnablement,
+    ) -> ServiceFuture<'a, ()> {
+        Box::pin(async move { restore_unit_enablement(unit, enablement).await })
     }
 }
 
 impl ServiceResumeOps for RealServiceResumeOps {
-    fn is_enabled<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
-        Box::pin(async move { is_unit_enabled(unit).await })
+    fn enablement<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, SystemdUnitEnablement> {
+        Box::pin(async move { read_unit_enablement(unit).await })
     }
 
     fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()> {
@@ -154,10 +177,12 @@ impl ServiceResumeOps for RealServiceResumeOps {
         )
     }
 
-    fn disable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
-        Box::pin(
-            async move { run_systemctl(&["disable", "--no-reload", unit.service_name()]).await },
-        )
+    fn restore_enablement<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        enablement: SystemdUnitEnablement,
+    ) -> ServiceFuture<'a, ()> {
+        Box::pin(async move { restore_unit_enablement(unit, enablement).await })
     }
 }
 
@@ -176,7 +201,7 @@ fn transition_error_with_rollback_failure(
 async fn rollback_drain_transition(
     unit: &RunnerServiceUnit,
     restart_override_written: bool,
-    was_enabled: Option<bool>,
+    prior_enablement: Option<SystemdUnitEnablement>,
     ops: &mut impl ServiceDrainOps,
     context: &str,
 ) -> RunnerResult<()> {
@@ -189,14 +214,9 @@ async fn rollback_drain_transition(
         }
     }
 
-    match was_enabled {
-        Some(was_enabled) => {
-            let result = if was_enabled {
-                ops.enable(unit).await
-            } else {
-                ops.disable(unit).await
-            };
-            if let Err(error) = result {
+    match prior_enablement {
+        Some(enablement) => {
+            if let Err(error) = ops.restore_enablement(unit, enablement).await {
                 failures.push(format!("restore boot enablement: {error}"));
             }
         }
@@ -221,7 +241,7 @@ async fn rollback_drain_transition(
 async fn rollback_resume_transition(
     unit: &RunnerServiceUnit,
     drain_override_removed: bool,
-    was_enabled: Option<bool>,
+    prior_enablement: Option<SystemdUnitEnablement>,
     ops: &mut impl ServiceResumeOps,
     context: &str,
 ) -> RunnerResult<()> {
@@ -231,14 +251,9 @@ async fn rollback_resume_transition(
         failures.push(format!("restore drain restart override: {error}"));
     }
 
-    match was_enabled {
-        Some(was_enabled) => {
-            let result = if was_enabled {
-                ops.enable(unit).await
-            } else {
-                ops.disable(unit).await
-            };
-            if let Err(error) = result {
+    match prior_enablement {
+        Some(enablement) => {
+            if let Err(error) = ops.restore_enablement(unit, enablement).await {
                 failures.push(format!("restore boot enablement: {error}"));
             }
         }
@@ -263,12 +278,19 @@ async fn rollback_resume_transition(
 async fn drain_error_after_rollback(
     unit: &RunnerServiceUnit,
     restart_override_written: bool,
-    was_enabled: Option<bool>,
+    prior_enablement: Option<SystemdUnitEnablement>,
     ops: &mut impl ServiceDrainOps,
     context: &str,
     error: RunnerError,
 ) -> RunnerError {
-    match rollback_drain_transition(unit, restart_override_written, was_enabled, ops, context).await
+    match rollback_drain_transition(
+        unit,
+        restart_override_written,
+        prior_enablement,
+        ops,
+        context,
+    )
+    .await
     {
         Ok(()) => error,
         Err(rollback_error) => {
@@ -280,12 +302,13 @@ async fn drain_error_after_rollback(
 async fn resume_error_after_rollback(
     unit: &RunnerServiceUnit,
     drain_override_removed: bool,
-    was_enabled: Option<bool>,
+    prior_enablement: Option<SystemdUnitEnablement>,
     ops: &mut impl ServiceResumeOps,
     context: &str,
     error: RunnerError,
 ) -> RunnerError {
-    match rollback_resume_transition(unit, drain_override_removed, was_enabled, ops, context).await
+    match rollback_resume_transition(unit, drain_override_removed, prior_enablement, ops, context)
+        .await
     {
         Ok(()) => error,
         Err(rollback_error) => {
@@ -319,9 +342,9 @@ fn ensure_resume_mode_is_draining(unit: &RunnerServiceUnit, mode: &str) -> Runne
 async fn drain_enablement_before_transition(
     unit: &RunnerServiceUnit,
     ops: &mut impl ServiceDrainOps,
-) -> Option<bool> {
-    match ops.is_enabled(unit).await {
-        Ok(enabled) => Some(enabled),
+) -> Option<SystemdUnitEnablement> {
+    match ops.enablement(unit).await {
+        Ok(enablement) => Some(enablement),
         Err(error) => {
             warn!(
                 unit = %unit.unit_name(),
@@ -336,9 +359,9 @@ async fn drain_enablement_before_transition(
 async fn resume_enablement_before_transition(
     unit: &RunnerServiceUnit,
     ops: &mut impl ServiceResumeOps,
-) -> Option<bool> {
-    match ops.is_enabled(unit).await {
-        Ok(enabled) => Some(enabled),
+) -> Option<SystemdUnitEnablement> {
+    match ops.enablement(unit).await {
+        Ok(enablement) => Some(enablement),
         Err(error) => {
             warn!(
                 unit = %unit.unit_name(),
@@ -355,7 +378,7 @@ async fn drain_with_ops(
     ops: &mut impl ServiceDrainOps,
 ) -> RunnerResult<()> {
     let mut should_signal = ops.is_active(unit).await?;
-    let was_enabled = drain_enablement_before_transition(unit, ops).await;
+    let prior_enablement = drain_enablement_before_transition(unit, ops).await;
     if !should_signal {
         info!(unit = %unit.unit_name(), "no active service found; drain signal not needed");
     }
@@ -380,7 +403,7 @@ async fn drain_with_ops(
         return Err(drain_error_after_rollback(
             unit,
             restart_override_written,
-            was_enabled,
+            prior_enablement,
             ops,
             "daemon_reload",
             error,
@@ -395,7 +418,7 @@ async fn drain_with_ops(
                     return Err(drain_error_after_rollback(
                         unit,
                         restart_override_written,
-                        was_enabled,
+                        prior_enablement,
                         ops,
                         "restart_policy",
                         error,
@@ -409,7 +432,7 @@ async fn drain_with_ops(
                         return Err(drain_error_after_rollback(
                             unit,
                             restart_override_written,
-                            was_enabled,
+                            prior_enablement,
                             ops,
                             "restart_policy",
                             error,
@@ -421,7 +444,7 @@ async fn drain_with_ops(
                         return Err(drain_error_after_rollback(
                             unit,
                             restart_override_written,
-                            was_enabled,
+                            prior_enablement,
                             ops,
                             "restart_policy_active_check",
                             active_err,
@@ -447,7 +470,7 @@ async fn drain_with_ops(
                 return Err(drain_error_after_rollback(
                     unit,
                     restart_override_written,
-                    was_enabled,
+                    prior_enablement,
                     ops,
                     "signal_drain",
                     error,
@@ -470,7 +493,7 @@ async fn resume_after_preflight_with_ops(
     unit: &RunnerServiceUnit,
     ops: &mut impl ServiceResumeOps,
 ) -> RunnerResult<()> {
-    let was_enabled = resume_enablement_before_transition(unit, ops).await;
+    let prior_enablement = resume_enablement_before_transition(unit, ops).await;
     let drain_override_removed = ops.remove_restart_override(unit)?;
 
     if let Err(error) = ops.enable(unit).await {
@@ -488,7 +511,7 @@ async fn resume_after_preflight_with_ops(
         return Err(resume_error_after_rollback(
             unit,
             drain_override_removed,
-            was_enabled,
+            prior_enablement,
             ops,
             "daemon_reload",
             error,
@@ -517,7 +540,7 @@ async fn resume_after_preflight_with_ops(
     Err(resume_error_after_rollback(
         unit,
         drain_override_removed,
-        was_enabled,
+        prior_enablement,
         ops,
         "signal_resume",
         signal_result,
@@ -588,7 +611,7 @@ mod tests {
     struct FakeDrainOps {
         events: Vec<&'static str>,
         active_results: VecDeque<RunnerResult<bool>>,
-        enabled_results: VecDeque<RunnerResult<bool>>,
+        enablement_results: VecDeque<RunnerResult<SystemdUnitEnablement>>,
         write_error: bool,
         remove_error: bool,
         reload_errors: VecDeque<bool>,
@@ -597,12 +620,12 @@ mod tests {
         signal_error: bool,
         signal_outcome: ServiceSignalOutcome,
         disable_error: bool,
-        enable_error: bool,
+        restore_enablement_error: bool,
     }
 
     struct FakeResumeOps {
         events: Vec<&'static str>,
-        enabled_results: VecDeque<RunnerResult<bool>>,
+        enablement_results: VecDeque<RunnerResult<SystemdUnitEnablement>>,
         write_error: bool,
         remove_error: bool,
         removed_restart_override: bool,
@@ -610,7 +633,7 @@ mod tests {
         signal_error: bool,
         signal_outcome: ServiceSignalOutcome,
         enable_error: bool,
-        disable_error: bool,
+        restore_enablement_error: bool,
     }
 
     impl Default for FakeDrainOps {
@@ -618,7 +641,7 @@ mod tests {
             Self {
                 events: Vec::new(),
                 active_results: VecDeque::from([Ok(true)]),
-                enabled_results: VecDeque::from([Ok(true)]),
+                enablement_results: VecDeque::from([Ok(SystemdUnitEnablement::Enabled)]),
                 write_error: false,
                 remove_error: false,
                 reload_errors: VecDeque::new(),
@@ -627,7 +650,7 @@ mod tests {
                 signal_error: false,
                 signal_outcome: ServiceSignalOutcome::Sent,
                 disable_error: false,
-                enable_error: false,
+                restore_enablement_error: false,
             }
         }
     }
@@ -636,7 +659,7 @@ mod tests {
         fn default() -> Self {
             Self {
                 events: Vec::new(),
-                enabled_results: VecDeque::from([Ok(false)]),
+                enablement_results: VecDeque::from([Ok(SystemdUnitEnablement::NotEnabled)]),
                 write_error: false,
                 remove_error: false,
                 removed_restart_override: true,
@@ -644,7 +667,7 @@ mod tests {
                 signal_error: false,
                 signal_outcome: ServiceSignalOutcome::Sent,
                 enable_error: false,
-                disable_error: false,
+                restore_enablement_error: false,
             }
         }
     }
@@ -661,10 +684,15 @@ mod tests {
             ))
         }
 
-        fn is_enabled<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
+        fn enablement<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+        ) -> ServiceFuture<'a, SystemdUnitEnablement> {
             self.events.push("is_enabled");
             Box::pin(std::future::ready(
-                self.enabled_results.pop_front().unwrap_or(Ok(false)),
+                self.enablement_results
+                    .pop_front()
+                    .unwrap_or(Ok(SystemdUnitEnablement::NotEnabled)),
             ))
         }
 
@@ -729,10 +757,18 @@ mod tests {
             }))
         }
 
-        fn enable<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
-            self.events.push("enable");
-            Box::pin(std::future::ready(if self.enable_error {
-                Err(fake_error("enable failed"))
+        fn restore_enablement<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+            enablement: SystemdUnitEnablement,
+        ) -> ServiceFuture<'a, ()> {
+            self.events.push(match enablement {
+                SystemdUnitEnablement::Enabled => "restore_enabled",
+                SystemdUnitEnablement::EnabledRuntime => "restore_enabled_runtime",
+                SystemdUnitEnablement::NotEnabled => "restore_not_enabled",
+            });
+            Box::pin(std::future::ready(if self.restore_enablement_error {
+                Err(fake_error("restore enablement failed"))
             } else {
                 Ok(())
             }))
@@ -740,10 +776,15 @@ mod tests {
     }
 
     impl ServiceResumeOps for FakeResumeOps {
-        fn is_enabled<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
+        fn enablement<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+        ) -> ServiceFuture<'a, SystemdUnitEnablement> {
             self.events.push("is_enabled");
             Box::pin(std::future::ready(
-                self.enabled_results.pop_front().unwrap_or(Ok(false)),
+                self.enablement_results
+                    .pop_front()
+                    .unwrap_or(Ok(SystemdUnitEnablement::NotEnabled)),
             ))
         }
 
@@ -796,10 +837,18 @@ mod tests {
             }))
         }
 
-        fn disable<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
-            self.events.push("disable");
-            Box::pin(std::future::ready(if self.disable_error {
-                Err(fake_error("disable failed"))
+        fn restore_enablement<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+            enablement: SystemdUnitEnablement,
+        ) -> ServiceFuture<'a, ()> {
+            self.events.push(match enablement {
+                SystemdUnitEnablement::Enabled => "restore_enabled",
+                SystemdUnitEnablement::EnabledRuntime => "restore_enabled_runtime",
+                SystemdUnitEnablement::NotEnabled => "restore_not_enabled",
+            });
+            Box::pin(std::future::ready(if self.restore_enablement_error {
+                Err(fake_error("restore enablement failed"))
             } else {
                 Ok(())
             }))
@@ -904,10 +953,26 @@ mod tests {
                 "disable",
                 "daemon_reload",
                 "remove_restart_override",
-                "enable",
+                "restore_enabled",
                 "daemon_reload",
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn drain_failure_restores_runtime_only_enablement() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            enablement_results: VecDeque::from([Ok(SystemdUnitEnablement::EnabledRuntime)]),
+            reload_errors: VecDeque::from([true, false]),
+            ..FakeDrainOps::default()
+        };
+
+        let error = drain_with_ops(&unit, &mut ops).await.unwrap_err();
+
+        assert!(error.to_string().contains("reload failed"));
+        assert!(ops.events.contains(&"restore_enabled_runtime"));
+        assert!(!ops.events.contains(&"restore_enabled"));
     }
 
     #[tokio::test]
@@ -931,7 +996,7 @@ mod tests {
                 "daemon_reload",
                 "restart_policy",
                 "remove_restart_override",
-                "enable",
+                "restore_enabled",
                 "daemon_reload",
             ]
         );
@@ -960,7 +1025,7 @@ mod tests {
                 "restart_policy",
                 "is_active",
                 "remove_restart_override",
-                "enable",
+                "restore_enabled",
                 "daemon_reload",
             ]
         );
@@ -989,7 +1054,7 @@ mod tests {
                 "restart_policy",
                 "is_active",
                 "remove_restart_override",
-                "enable",
+                "restore_enabled",
                 "daemon_reload",
             ]
         );
@@ -1042,7 +1107,7 @@ mod tests {
                 "restart_policy",
                 "signal_drain",
                 "remove_restart_override",
-                "enable",
+                "restore_enabled",
                 "daemon_reload",
             ]
         );
@@ -1138,7 +1203,7 @@ mod tests {
                 "enable",
                 "daemon_reload",
                 "write_restart_override",
-                "disable",
+                "restore_not_enabled",
                 "daemon_reload",
             ]
         );
@@ -1166,7 +1231,7 @@ mod tests {
                 "daemon_reload",
                 "signal_resume",
                 "write_restart_override",
-                "disable",
+                "restore_not_enabled",
                 "daemon_reload",
             ]
         );
@@ -1177,7 +1242,7 @@ mod tests {
         let unit = service_unit();
         let mut ops = FakeResumeOps {
             write_error: true,
-            disable_error: true,
+            restore_enablement_error: true,
             reload_errors: VecDeque::from([false, true]),
             signal_error: true,
             ..FakeResumeOps::default()
@@ -1191,7 +1256,7 @@ mod tests {
         assert!(message.contains("signal failed"));
         assert!(message.contains("additionally rollback failed"));
         assert!(message.contains("write failed"));
-        assert!(message.contains("disable failed"));
+        assert!(message.contains("restore enablement failed"));
         assert!(message.contains("reload failed"));
     }
 
@@ -1221,7 +1286,7 @@ mod tests {
                 "daemon_reload",
                 "signal_resume",
                 "write_restart_override",
-                "disable",
+                "restore_not_enabled",
                 "daemon_reload",
             ]
         );
@@ -1249,7 +1314,7 @@ mod tests {
                 "enable",
                 "daemon_reload",
                 "signal_resume",
-                "disable",
+                "restore_not_enabled",
                 "daemon_reload",
             ]
         );

--- a/crates/runner/src/cmd/service/drain_resume.rs
+++ b/crates/runner/src/cmd/service/drain_resume.rs
@@ -6,8 +6,11 @@ use crate::paths::HomePaths;
 
 use super::drain_override::{remove_drain_restart_override, write_drain_restart_override};
 use super::gate::{read_runner_status, runner_base_dir};
+use super::reload::{SystemdReloadRequirement, coordinate_systemd_reload};
 use super::signal::{ServiceSignalOutcome, signal_service_main};
-use super::systemctl::{get_service_restart_policy, is_unit_active, run_systemctl};
+use super::systemctl::{
+    get_service_restart_policy, is_unit_active, is_unit_enabled, run_systemctl,
+};
 use super::{RunnerServiceUnit, ServiceFuture, acquire_service_lock};
 
 #[derive(Args)]
@@ -39,26 +42,30 @@ fn ensure_drain_restart_policy_applied(
 
 trait ServiceDrainOps {
     fn is_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool>;
+    fn is_enabled<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool>;
     fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()>;
     fn remove_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<bool>;
-    fn daemon_reload(&mut self) -> ServiceFuture<'_, ()>;
+    fn daemon_reload<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
     fn restart_policy<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, String>;
     fn signal_drain<'a>(
         &'a mut self,
         unit: &'a RunnerServiceUnit,
     ) -> ServiceFuture<'a, ServiceSignalOutcome>;
     fn disable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
+    fn enable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
 }
 
 trait ServiceResumeOps {
+    fn is_enabled<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool>;
     fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()>;
     fn remove_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<bool>;
-    fn daemon_reload(&mut self) -> ServiceFuture<'_, ()>;
+    fn daemon_reload<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
     fn signal_resume<'a>(
         &'a mut self,
         unit: &'a RunnerServiceUnit,
     ) -> ServiceFuture<'a, ServiceSignalOutcome>;
     fn enable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
+    fn disable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
 }
 
 struct RealServiceDrainOps;
@@ -69,6 +76,10 @@ impl ServiceDrainOps for RealServiceDrainOps {
         Box::pin(async move { is_unit_active(unit).await })
     }
 
+    fn is_enabled<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
+        Box::pin(async move { is_unit_enabled(unit).await })
+    }
+
     fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()> {
         write_drain_restart_override(unit)
     }
@@ -77,8 +88,12 @@ impl ServiceDrainOps for RealServiceDrainOps {
         remove_drain_restart_override(unit)
     }
 
-    fn daemon_reload(&mut self) -> ServiceFuture<'_, ()> {
-        Box::pin(async { run_systemctl(&["daemon-reload"]).await })
+    fn daemon_reload<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
+        Box::pin(async move {
+            coordinate_systemd_reload(unit, SystemdReloadRequirement::Dirty)
+                .await
+                .map(|_| ())
+        })
     }
 
     fn restart_policy<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, String> {
@@ -93,11 +108,23 @@ impl ServiceDrainOps for RealServiceDrainOps {
     }
 
     fn disable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
-        Box::pin(async move { run_systemctl(&["disable", unit.service_name()]).await })
+        Box::pin(
+            async move { run_systemctl(&["disable", "--no-reload", unit.service_name()]).await },
+        )
+    }
+
+    fn enable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
+        Box::pin(
+            async move { run_systemctl(&["enable", "--no-reload", unit.service_name()]).await },
+        )
     }
 }
 
 impl ServiceResumeOps for RealServiceResumeOps {
+    fn is_enabled<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
+        Box::pin(async move { is_unit_enabled(unit).await })
+    }
+
     fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()> {
         write_drain_restart_override(unit)
     }
@@ -106,8 +133,12 @@ impl ServiceResumeOps for RealServiceResumeOps {
         remove_drain_restart_override(unit)
     }
 
-    fn daemon_reload(&mut self) -> ServiceFuture<'_, ()> {
-        Box::pin(async { run_systemctl(&["daemon-reload"]).await })
+    fn daemon_reload<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
+        Box::pin(async move {
+            coordinate_systemd_reload(unit, SystemdReloadRequirement::Dirty)
+                .await
+                .map(|_| ())
+        })
     }
 
     fn signal_resume<'a>(
@@ -118,78 +149,149 @@ impl ServiceResumeOps for RealServiceResumeOps {
     }
 
     fn enable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
-        Box::pin(async move { run_systemctl(&["enable", unit.service_name()]).await })
+        Box::pin(
+            async move { run_systemctl(&["enable", "--no-reload", unit.service_name()]).await },
+        )
+    }
+
+    fn disable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
+        Box::pin(
+            async move { run_systemctl(&["disable", "--no-reload", unit.service_name()]).await },
+        )
     }
 }
 
-async fn rollback_drain_restart_override(
+fn transition_error_with_rollback_failure(
     unit: &RunnerServiceUnit,
+    transition: &str,
+    error: RunnerError,
+    rollback_error: RunnerError,
+) -> RunnerError {
+    RunnerError::Internal(format!(
+        "{transition} failed for {}: {error}; additionally rollback failed: {rollback_error}",
+        unit.unit_name()
+    ))
+}
+
+async fn rollback_drain_transition(
+    unit: &RunnerServiceUnit,
+    restart_override_written: bool,
+    was_enabled: Option<bool>,
     ops: &mut impl ServiceDrainOps,
     context: &str,
-) {
-    match ops.remove_restart_override(unit) {
-        Ok(true) => {
-            if let Err(e) = ops.daemon_reload().await {
-                warn!(
-                    unit = %unit.unit_name(),
-                    context,
-                    error = %e,
-                    "failed to reload systemd after removing drain restart override"
-                );
+) -> RunnerResult<()> {
+    let mut failures = Vec::new();
+
+    if restart_override_written {
+        match ops.remove_restart_override(unit) {
+            Ok(_) => {}
+            Err(error) => failures.push(format!("remove drain restart override: {error}")),
+        }
+    }
+
+    match was_enabled {
+        Some(was_enabled) => {
+            let result = if was_enabled {
+                ops.enable(unit).await
+            } else {
+                ops.disable(unit).await
+            };
+            if let Err(error) = result {
+                failures.push(format!("restore boot enablement: {error}"));
             }
         }
-        Ok(false) => {}
-        Err(e) => {
-            warn!(
-                unit = %unit.unit_name(),
-                context,
-                error = %e,
-                "failed to remove drain restart override after drain failure"
-            );
-        }
+        None => failures.push("prior boot enablement is unavailable".to_string()),
+    }
+
+    if let Err(error) = ops.daemon_reload(unit).await {
+        failures.push(format!("reload restored systemd state: {error}"));
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(RunnerError::Internal(format!(
+            "failed to roll back drain transition for {} ({context}): {}",
+            unit.unit_name(),
+            failures.join("; ")
+        )))
     }
 }
 
-async fn restore_drain_restart_override_after_failed_resume(
+async fn rollback_resume_transition(
     unit: &RunnerServiceUnit,
+    drain_override_removed: bool,
+    was_enabled: Option<bool>,
     ops: &mut impl ServiceResumeOps,
     context: &str,
 ) -> RunnerResult<()> {
-    if let Err(e) = ops.write_restart_override(unit) {
-        return Err(RunnerError::Internal(format!(
-            "failed to restore drain restart override for {} after resume failure ({context}): {e}",
-            unit.unit_name()
-        )));
+    let mut failures = Vec::new();
+
+    if drain_override_removed && let Err(error) = ops.write_restart_override(unit) {
+        failures.push(format!("restore drain restart override: {error}"));
     }
-    if let Err(e) = ops.daemon_reload().await {
-        return Err(RunnerError::Internal(format!(
-            "failed to reload systemd after restoring drain restart override for {} ({context}): {e}",
-            unit.unit_name()
-        )));
+
+    match was_enabled {
+        Some(was_enabled) => {
+            let result = if was_enabled {
+                ops.enable(unit).await
+            } else {
+                ops.disable(unit).await
+            };
+            if let Err(error) = result {
+                failures.push(format!("restore boot enablement: {error}"));
+            }
+        }
+        None => failures.push("prior boot enablement is unavailable".to_string()),
     }
-    Ok(())
+
+    if let Err(error) = ops.daemon_reload(unit).await {
+        failures.push(format!("reload restored systemd state: {error}"));
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(RunnerError::Internal(format!(
+            "failed to roll back resume transition for {} ({context}): {}",
+            unit.unit_name(),
+            failures.join("; ")
+        )))
+    }
 }
 
-fn resume_error_with_restore_failure(
+async fn drain_error_after_rollback(
     unit: &RunnerServiceUnit,
-    resume_error: RunnerError,
-    restore_error: RunnerError,
+    restart_override_written: bool,
+    was_enabled: Option<bool>,
+    ops: &mut impl ServiceDrainOps,
+    context: &str,
+    error: RunnerError,
 ) -> RunnerError {
-    RunnerError::Internal(format!(
-        "resume failed for {}: {resume_error}; additionally failed to restore drain restart override: {restore_error}",
-        unit.unit_name()
-    ))
+    match rollback_drain_transition(unit, restart_override_written, was_enabled, ops, context).await
+    {
+        Ok(()) => error,
+        Err(rollback_error) => {
+            transition_error_with_rollback_failure(unit, "drain", error, rollback_error)
+        }
+    }
 }
 
-fn removed_drain_override_reload_error(
+async fn resume_error_after_rollback(
     unit: &RunnerServiceUnit,
-    reload_error: RunnerError,
-    restore_error: RunnerError,
+    drain_override_removed: bool,
+    was_enabled: Option<bool>,
+    ops: &mut impl ServiceResumeOps,
+    context: &str,
+    error: RunnerError,
 ) -> RunnerError {
-    RunnerError::Internal(format!(
-        "failed to reload systemd after removing drain restart override for {} before resume: {reload_error}; additionally failed to restore drain restart override: {restore_error}",
-        unit.unit_name()
-    ))
+    match rollback_resume_transition(unit, drain_override_removed, was_enabled, ops, context).await
+    {
+        Ok(()) => error,
+        Err(rollback_error) => {
+            transition_error_with_rollback_failure(unit, "resume", error, rollback_error)
+        }
+    }
 }
 
 fn ensure_resume_mode_is_draining(unit: &RunnerServiceUnit, mode: &str) -> RunnerResult<()> {
@@ -214,78 +316,36 @@ fn ensure_resume_mode_is_draining(unit: &RunnerServiceUnit, mode: &str) -> Runne
     }
 }
 
-async fn remove_drain_restart_override_before_resume(
+async fn drain_enablement_before_transition(
     unit: &RunnerServiceUnit,
-    ops: &mut impl ServiceResumeOps,
-) -> RunnerResult<bool> {
-    let removed = ops.remove_restart_override(unit)?;
-    if !removed {
-        return Ok(false);
-    }
-
-    if let Err(reload_error) = ops.daemon_reload().await {
-        if let Err(restore_error) =
-            restore_drain_restart_override_after_failed_resume(unit, ops, "remove_reload").await
-        {
-            return Err(removed_drain_override_reload_error(
-                unit,
-                reload_error,
-                restore_error,
-            ));
+    ops: &mut impl ServiceDrainOps,
+) -> Option<bool> {
+    match ops.is_enabled(unit).await {
+        Ok(enabled) => Some(enabled),
+        Err(error) => {
+            warn!(
+                unit = %unit.unit_name(),
+                error = %error,
+                "failed to read boot enablement before drain; rollback may be partial"
+            );
+            None
         }
-        return Err(reload_error);
     }
-
-    Ok(true)
 }
 
-async fn signal_resume_after_restart_policy_restored(
+async fn resume_enablement_before_transition(
     unit: &RunnerServiceUnit,
-    removed_drain_restart_override: bool,
     ops: &mut impl ServiceResumeOps,
-) -> RunnerResult<()> {
-    match ops.signal_resume(unit).await {
-        Ok(ServiceSignalOutcome::Sent) => {
-            info!(unit = %unit.unit_name(), "sent SIGUSR2 (resume)");
-            Ok(())
-        }
-        Ok(ServiceSignalOutcome::AlreadyGone) => {
-            let resume_error = RunnerError::Internal(format!(
-                "{} is not active — cannot resume an inactive runner",
-                unit.unit_name()
-            ));
-            if removed_drain_restart_override
-                && let Err(restore_error) = restore_drain_restart_override_after_failed_resume(
-                    unit,
-                    ops,
-                    "signal_resume_gone",
-                )
-                .await
-            {
-                return Err(resume_error_with_restore_failure(
-                    unit,
-                    resume_error,
-                    restore_error,
-                ));
-            }
-            info!(
+) -> Option<bool> {
+    match ops.is_enabled(unit).await {
+        Ok(enabled) => Some(enabled),
+        Err(error) => {
+            warn!(
                 unit = %unit.unit_name(),
-                "runner exited between preflight and signal; refusing resume",
+                error = %error,
+                "failed to read boot enablement before resume; rollback may be partial"
             );
-            Err(resume_error)
-        }
-        Err(e) => {
-            if removed_drain_restart_override
-                && let Err(restore_error) = restore_drain_restart_override_after_failed_resume(
-                    unit,
-                    ops,
-                    "signal_resume_error",
-                )
-                .await
-            {
-                return Err(resume_error_with_restore_failure(unit, e, restore_error));
-            }
-            Err(e)
+            None
         }
     }
 }
@@ -295,34 +355,78 @@ async fn drain_with_ops(
     ops: &mut impl ServiceDrainOps,
 ) -> RunnerResult<()> {
     let mut should_signal = ops.is_active(unit).await?;
+    let was_enabled = drain_enablement_before_transition(unit, ops).await;
     if !should_signal {
         info!(unit = %unit.unit_name(), "no active service found; drain signal not needed");
     }
 
+    let restart_override_written = should_signal;
     if should_signal {
         ops.write_restart_override(unit)?;
-        if let Err(e) = ops.daemon_reload().await {
-            rollback_drain_restart_override(unit, ops, "daemon_reload").await;
-            return Err(e);
-        }
+    }
+
+    if let Err(error) = ops.disable(unit).await {
+        warn!(unit = %unit.unit_name(), error = %error, "failed to disable unit");
+        eprintln!(
+            "WARNING: drain could not disable {}: {error}. \
+             Run it manually to prevent the unit from restarting on reboot.",
+            unit.service_name()
+        );
+    } else {
+        info!(unit = %unit.unit_name(), "disabled (won't restart on reboot)");
+    }
+
+    if let Err(error) = ops.daemon_reload(unit).await {
+        return Err(drain_error_after_rollback(
+            unit,
+            restart_override_written,
+            was_enabled,
+            ops,
+            "daemon_reload",
+            error,
+        )
+        .await);
+    }
+
+    if should_signal {
         match ops.restart_policy(unit).await {
             Ok(restart_policy) => {
-                if let Err(e) = ensure_drain_restart_policy_applied(unit, &restart_policy) {
-                    rollback_drain_restart_override(unit, ops, "restart_policy").await;
-                    return Err(e);
+                if let Err(error) = ensure_drain_restart_policy_applied(unit, &restart_policy) {
+                    return Err(drain_error_after_rollback(
+                        unit,
+                        restart_override_written,
+                        was_enabled,
+                        ops,
+                        "restart_policy",
+                        error,
+                    )
+                    .await);
                 }
             }
-            Err(e) => {
+            Err(error) => {
                 match ops.is_active(unit).await {
                     Ok(true) => {
-                        rollback_drain_restart_override(unit, ops, "restart_policy").await;
-                        return Err(e);
+                        return Err(drain_error_after_rollback(
+                            unit,
+                            restart_override_written,
+                            was_enabled,
+                            ops,
+                            "restart_policy",
+                            error,
+                        )
+                        .await);
                     }
                     Ok(false) => {}
                     Err(active_err) => {
-                        rollback_drain_restart_override(unit, ops, "restart_policy_active_check")
-                            .await;
-                        return Err(active_err);
+                        return Err(drain_error_after_rollback(
+                            unit,
+                            restart_override_written,
+                            was_enabled,
+                            ops,
+                            "restart_policy_active_check",
+                            active_err,
+                        )
+                        .await);
                     }
                 }
                 info!(
@@ -336,13 +440,19 @@ async fn drain_with_ops(
 
     if should_signal {
         // `is_unit_active` above can race against the runner exiting on its own.
-        // Both outcomes ("live, signal delivered" and "already gone") must still
-        // run `systemctl disable` below so the unit does not auto-start at the
-        // next boot.
+        // Both outcomes ("live, signal delivered" and "already gone") retain
+        // the already-applied disabled boot state.
         match ops.signal_drain(unit).await {
-            Err(e) => {
-                rollback_drain_restart_override(unit, ops, "signal_drain").await;
-                return Err(e);
+            Err(error) => {
+                return Err(drain_error_after_rollback(
+                    unit,
+                    restart_override_written,
+                    was_enabled,
+                    ops,
+                    "signal_drain",
+                    error,
+                )
+                .await);
             }
             Ok(ServiceSignalOutcome::Sent) => {
                 info!(unit = %unit.unit_name(), "sent SIGUSR1 (drain)");
@@ -353,20 +463,6 @@ async fn drain_with_ops(
         }
     }
 
-    // Disable so it won't restart on reboot. Disabling is boot enablement
-    // cleanup only; active-unit restart prevention is handled by the runtime
-    // Restart=no override above.
-    if let Err(e) = ops.disable(unit).await {
-        warn!(unit = %unit.unit_name(), error = %e, "failed to disable unit");
-        eprintln!(
-            "WARNING: drain could not disable {}: {e}. \
-             Run it manually to prevent the unit from restarting on reboot.",
-            unit.service_name()
-        );
-    } else {
-        info!(unit = %unit.unit_name(), "disabled (won't restart on reboot)");
-    }
-
     Ok(())
 }
 
@@ -374,24 +470,13 @@ async fn resume_after_preflight_with_ops(
     unit: &RunnerServiceUnit,
     ops: &mut impl ServiceResumeOps,
 ) -> RunnerResult<()> {
-    let removed_drain_restart_override =
-        remove_drain_restart_override_before_resume(unit, ops).await?;
+    let was_enabled = resume_enablement_before_transition(unit, ops).await;
+    let drain_override_removed = ops.remove_restart_override(unit)?;
 
-    // Same race as in `drain`: the runner can exit after the preflight
-    // `is_unit_active` check but before we deliver SIGUSR2. If resume does not
-    // deliver SIGUSR2 after restoring Restart=on-failure, put the drain override
-    // back so a still-draining old runner does not regain restart behavior.
-    signal_resume_after_restart_policy_restored(unit, removed_drain_restart_override, ops).await?;
-
-    // Re-enable so the unit restarts on reboot (undoes the disable from drain).
-    // Use `enable` (not `--now`) — the service is already running. SIGUSR2
-    // has already been delivered so the runner IS resumed; a re-enable
-    // failure is partial success. Surface the hint on stderr so CLI users
-    // don't miss it.
-    if let Err(e) = ops.enable(unit).await {
-        warn!(unit = %unit.unit_name(), error = %e, "failed to re-enable unit");
+    if let Err(error) = ops.enable(unit).await {
+        warn!(unit = %unit.unit_name(), error = %error, "failed to re-enable unit");
         eprintln!(
-            "WARNING: runner resumed but `systemctl enable {}` failed: {e}. \
+            "WARNING: resume could not `systemctl enable {}`: {error}. \
              Run it manually to restore the restart-on-reboot behavior.",
             unit.service_name()
         );
@@ -399,7 +484,45 @@ async fn resume_after_preflight_with_ops(
         info!(unit = %unit.unit_name(), "re-enabled (will restart on reboot)");
     }
 
-    Ok(())
+    if let Err(error) = ops.daemon_reload(unit).await {
+        return Err(resume_error_after_rollback(
+            unit,
+            drain_override_removed,
+            was_enabled,
+            ops,
+            "daemon_reload",
+            error,
+        )
+        .await);
+    }
+
+    let signal_result = match ops.signal_resume(unit).await {
+        Ok(ServiceSignalOutcome::Sent) => {
+            info!(unit = %unit.unit_name(), "sent SIGUSR2 (resume)");
+            return Ok(());
+        }
+        Ok(ServiceSignalOutcome::AlreadyGone) => {
+            info!(
+                unit = %unit.unit_name(),
+                "runner exited between preflight and signal; refusing resume",
+            );
+            RunnerError::Internal(format!(
+                "{} is not active — cannot resume an inactive runner",
+                unit.unit_name()
+            ))
+        }
+        Err(error) => error,
+    };
+
+    Err(resume_error_after_rollback(
+        unit,
+        drain_override_removed,
+        was_enabled,
+        ops,
+        "signal_resume",
+        signal_result,
+    )
+    .await)
 }
 
 /// `service drain` — send SIGUSR1, disable unit, return immediately.
@@ -465,18 +588,21 @@ mod tests {
     struct FakeDrainOps {
         events: Vec<&'static str>,
         active_results: VecDeque<RunnerResult<bool>>,
+        enabled_results: VecDeque<RunnerResult<bool>>,
         write_error: bool,
         remove_error: bool,
-        reload_error: bool,
+        reload_errors: VecDeque<bool>,
         restart_policy_error: bool,
         restart_policy: String,
         signal_error: bool,
         signal_outcome: ServiceSignalOutcome,
         disable_error: bool,
+        enable_error: bool,
     }
 
     struct FakeResumeOps {
         events: Vec<&'static str>,
+        enabled_results: VecDeque<RunnerResult<bool>>,
         write_error: bool,
         remove_error: bool,
         removed_restart_override: bool,
@@ -484,6 +610,7 @@ mod tests {
         signal_error: bool,
         signal_outcome: ServiceSignalOutcome,
         enable_error: bool,
+        disable_error: bool,
     }
 
     impl Default for FakeDrainOps {
@@ -491,14 +618,16 @@ mod tests {
             Self {
                 events: Vec::new(),
                 active_results: VecDeque::from([Ok(true)]),
+                enabled_results: VecDeque::from([Ok(true)]),
                 write_error: false,
                 remove_error: false,
-                reload_error: false,
+                reload_errors: VecDeque::new(),
                 restart_policy_error: false,
                 restart_policy: "no".to_string(),
                 signal_error: false,
                 signal_outcome: ServiceSignalOutcome::Sent,
                 disable_error: false,
+                enable_error: false,
             }
         }
     }
@@ -507,6 +636,7 @@ mod tests {
         fn default() -> Self {
             Self {
                 events: Vec::new(),
+                enabled_results: VecDeque::from([Ok(false)]),
                 write_error: false,
                 remove_error: false,
                 removed_restart_override: true,
@@ -514,6 +644,7 @@ mod tests {
                 signal_error: false,
                 signal_outcome: ServiceSignalOutcome::Sent,
                 enable_error: false,
+                disable_error: false,
             }
         }
     }
@@ -527,6 +658,13 @@ mod tests {
             self.events.push("is_active");
             Box::pin(std::future::ready(
                 self.active_results.pop_front().unwrap_or(Ok(false)),
+            ))
+        }
+
+        fn is_enabled<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
+            self.events.push("is_enabled");
+            Box::pin(std::future::ready(
+                self.enabled_results.pop_front().unwrap_or(Ok(false)),
             ))
         }
 
@@ -548,9 +686,10 @@ mod tests {
             }
         }
 
-        fn daemon_reload(&mut self) -> ServiceFuture<'_, ()> {
+        fn daemon_reload<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
             self.events.push("daemon_reload");
-            Box::pin(std::future::ready(if self.reload_error {
+            let reload_error = self.reload_errors.pop_front().unwrap_or(false);
+            Box::pin(std::future::ready(if reload_error {
                 Err(fake_error("reload failed"))
             } else {
                 Ok(())
@@ -589,9 +728,25 @@ mod tests {
                 Ok(())
             }))
         }
+
+        fn enable<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
+            self.events.push("enable");
+            Box::pin(std::future::ready(if self.enable_error {
+                Err(fake_error("enable failed"))
+            } else {
+                Ok(())
+            }))
+        }
     }
 
     impl ServiceResumeOps for FakeResumeOps {
+        fn is_enabled<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
+            self.events.push("is_enabled");
+            Box::pin(std::future::ready(
+                self.enabled_results.pop_front().unwrap_or(Ok(false)),
+            ))
+        }
+
         fn write_restart_override(&mut self, _unit: &RunnerServiceUnit) -> RunnerResult<()> {
             self.events.push("write_restart_override");
             if self.write_error {
@@ -610,7 +765,7 @@ mod tests {
             }
         }
 
-        fn daemon_reload(&mut self) -> ServiceFuture<'_, ()> {
+        fn daemon_reload<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
             self.events.push("daemon_reload");
             let reload_error = self.reload_errors.pop_front().unwrap_or(false);
             Box::pin(std::future::ready(if reload_error {
@@ -640,6 +795,15 @@ mod tests {
                 Ok(())
             }))
         }
+
+        fn disable<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
+            self.events.push("disable");
+            Box::pin(std::future::ready(if self.disable_error {
+                Err(fake_error("disable failed"))
+            } else {
+                Ok(())
+            }))
+        }
     }
 
     #[tokio::test]
@@ -653,11 +817,12 @@ mod tests {
             ops.events,
             [
                 "is_active",
+                "is_enabled",
                 "write_restart_override",
+                "disable",
                 "daemon_reload",
                 "restart_policy",
                 "signal_drain",
-                "disable",
             ]
         );
     }
@@ -676,11 +841,12 @@ mod tests {
             ops.events,
             [
                 "is_active",
+                "is_enabled",
                 "write_restart_override",
+                "disable",
                 "daemon_reload",
                 "restart_policy",
                 "signal_drain",
-                "disable",
             ]
         );
     }
@@ -695,7 +861,10 @@ mod tests {
 
         drain_with_ops(&unit, &mut ops).await.unwrap();
 
-        assert_eq!(ops.events, ["is_active", "disable"]);
+        assert_eq!(
+            ops.events,
+            ["is_active", "is_enabled", "disable", "daemon_reload"]
+        );
     }
 
     #[tokio::test]
@@ -709,14 +878,17 @@ mod tests {
         let err = drain_with_ops(&unit, &mut ops).await.unwrap_err();
 
         assert!(err.to_string().contains("write failed"));
-        assert_eq!(ops.events, ["is_active", "write_restart_override"]);
+        assert_eq!(
+            ops.events,
+            ["is_active", "is_enabled", "write_restart_override"]
+        );
     }
 
     #[tokio::test]
     async fn drain_daemon_reload_failure_rolls_back_before_signal() {
         let unit = service_unit();
         let mut ops = FakeDrainOps {
-            reload_error: true,
+            reload_errors: VecDeque::from([true, false]),
             ..FakeDrainOps::default()
         };
 
@@ -727,9 +899,12 @@ mod tests {
             ops.events,
             [
                 "is_active",
+                "is_enabled",
                 "write_restart_override",
+                "disable",
                 "daemon_reload",
                 "remove_restart_override",
+                "enable",
                 "daemon_reload",
             ]
         );
@@ -750,10 +925,13 @@ mod tests {
             ops.events,
             [
                 "is_active",
+                "is_enabled",
                 "write_restart_override",
+                "disable",
                 "daemon_reload",
                 "restart_policy",
                 "remove_restart_override",
+                "enable",
                 "daemon_reload",
             ]
         );
@@ -775,11 +953,14 @@ mod tests {
             ops.events,
             [
                 "is_active",
+                "is_enabled",
                 "write_restart_override",
+                "disable",
                 "daemon_reload",
                 "restart_policy",
                 "is_active",
                 "remove_restart_override",
+                "enable",
                 "daemon_reload",
             ]
         );
@@ -801,11 +982,14 @@ mod tests {
             ops.events,
             [
                 "is_active",
+                "is_enabled",
                 "write_restart_override",
+                "disable",
                 "daemon_reload",
                 "restart_policy",
                 "is_active",
                 "remove_restart_override",
+                "enable",
                 "daemon_reload",
             ]
         );
@@ -826,11 +1010,12 @@ mod tests {
             ops.events,
             [
                 "is_active",
+                "is_enabled",
                 "write_restart_override",
+                "disable",
                 "daemon_reload",
                 "restart_policy",
                 "is_active",
-                "disable",
             ]
         );
     }
@@ -850,11 +1035,14 @@ mod tests {
             ops.events,
             [
                 "is_active",
+                "is_enabled",
                 "write_restart_override",
+                "disable",
                 "daemon_reload",
                 "restart_policy",
                 "signal_drain",
                 "remove_restart_override",
+                "enable",
                 "daemon_reload",
             ]
         );
@@ -874,29 +1062,39 @@ mod tests {
             ops.events,
             [
                 "is_active",
+                "is_enabled",
                 "write_restart_override",
+                "disable",
                 "daemon_reload",
                 "restart_policy",
                 "signal_drain",
-                "disable",
             ]
         );
     }
 
     #[tokio::test]
-    async fn resume_signal_sent_keeps_restored_restart_policy() {
+    async fn resume_enables_and_reloads_before_signal() {
         let unit = service_unit();
         let mut ops = FakeResumeOps::default();
 
-        signal_resume_after_restart_policy_restored(&unit, true, &mut ops)
+        resume_after_preflight_with_ops(&unit, &mut ops)
             .await
             .unwrap();
 
-        assert_eq!(ops.events, ["signal_resume"]);
+        assert_eq!(
+            ops.events,
+            [
+                "is_enabled",
+                "remove_restart_override",
+                "enable",
+                "daemon_reload",
+                "signal_resume",
+            ]
+        );
     }
 
     #[tokio::test]
-    async fn resume_enable_failure_remains_successful_after_signal() {
+    async fn resume_enable_failure_remains_successful_after_reload_and_signal() {
         let unit = service_unit();
         let mut ops = FakeResumeOps {
             enable_error: true,
@@ -910,10 +1108,149 @@ mod tests {
         assert_eq!(
             ops.events,
             [
+                "is_enabled",
                 "remove_restart_override",
+                "enable",
                 "daemon_reload",
                 "signal_resume",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_reload_failure_restores_override_and_enablement() {
+        let unit = service_unit();
+        let mut ops = FakeResumeOps {
+            reload_errors: VecDeque::from([true, false]),
+            ..FakeResumeOps::default()
+        };
+
+        let error = resume_after_preflight_with_ops(&unit, &mut ops)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("reload failed"));
+        assert_eq!(
+            ops.events,
+            [
+                "is_enabled",
+                "remove_restart_override",
                 "enable",
+                "daemon_reload",
+                "write_restart_override",
+                "disable",
+                "daemon_reload",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_signal_failure_restores_override_and_enablement() {
+        let unit = service_unit();
+        let mut ops = FakeResumeOps {
+            signal_error: true,
+            ..FakeResumeOps::default()
+        };
+
+        let error = resume_after_preflight_with_ops(&unit, &mut ops)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("signal failed"));
+        assert_eq!(
+            ops.events,
+            [
+                "is_enabled",
+                "remove_restart_override",
+                "enable",
+                "daemon_reload",
+                "signal_resume",
+                "write_restart_override",
+                "disable",
+                "daemon_reload",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_signal_failure_reports_rollback_failures() {
+        let unit = service_unit();
+        let mut ops = FakeResumeOps {
+            write_error: true,
+            disable_error: true,
+            reload_errors: VecDeque::from([false, true]),
+            signal_error: true,
+            ..FakeResumeOps::default()
+        };
+
+        let error = resume_after_preflight_with_ops(&unit, &mut ops)
+            .await
+            .unwrap_err();
+        let message = error.to_string();
+
+        assert!(message.contains("signal failed"));
+        assert!(message.contains("additionally rollback failed"));
+        assert!(message.contains("write failed"));
+        assert!(message.contains("disable failed"));
+        assert!(message.contains("reload failed"));
+    }
+
+    #[tokio::test]
+    async fn resume_already_gone_restores_transition() {
+        let unit = service_unit();
+        let mut ops = FakeResumeOps {
+            signal_outcome: ServiceSignalOutcome::AlreadyGone,
+            ..FakeResumeOps::default()
+        };
+
+        let error = resume_after_preflight_with_ops(&unit, &mut ops)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("cannot resume an inactive runner")
+        );
+        assert_eq!(
+            ops.events,
+            [
+                "is_enabled",
+                "remove_restart_override",
+                "enable",
+                "daemon_reload",
+                "signal_resume",
+                "write_restart_override",
+                "disable",
+                "daemon_reload",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_failure_without_override_restores_only_enablement() {
+        let unit = service_unit();
+        let mut ops = FakeResumeOps {
+            removed_restart_override: false,
+            signal_error: true,
+            ..FakeResumeOps::default()
+        };
+
+        let error = resume_after_preflight_with_ops(&unit, &mut ops)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("signal failed"));
+        assert_eq!(
+            ops.events,
+            [
+                "is_enabled",
+                "remove_restart_override",
+                "enable",
+                "daemon_reload",
+                "signal_resume",
+                "disable",
+                "daemon_reload",
             ]
         );
     }
@@ -935,196 +1272,5 @@ mod tests {
 
         let unknown = ensure_resume_mode_is_draining(&unit, "paused").unwrap_err();
         assert!(unknown.to_string().contains("unknown mode"));
-    }
-
-    #[tokio::test]
-    async fn resume_remove_missing_override_skips_reload() {
-        let unit = service_unit();
-        let mut ops = FakeResumeOps {
-            removed_restart_override: false,
-            ..FakeResumeOps::default()
-        };
-
-        let removed = remove_drain_restart_override_before_resume(&unit, &mut ops)
-            .await
-            .unwrap();
-
-        assert!(!removed);
-        assert_eq!(ops.events, ["remove_restart_override"]);
-    }
-
-    #[tokio::test]
-    async fn resume_remove_reload_failure_restores_removed_drain_override() {
-        let unit = service_unit();
-        let mut ops = FakeResumeOps {
-            reload_errors: VecDeque::from([true, false]),
-            ..FakeResumeOps::default()
-        };
-
-        let err = remove_drain_restart_override_before_resume(&unit, &mut ops)
-            .await
-            .unwrap_err();
-
-        assert!(err.to_string().contains("reload failed"));
-        assert_eq!(
-            ops.events,
-            [
-                "remove_restart_override",
-                "daemon_reload",
-                "write_restart_override",
-                "daemon_reload",
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn resume_remove_reload_failure_reports_restore_write_failure() {
-        let unit = service_unit();
-        let mut ops = FakeResumeOps {
-            write_error: true,
-            reload_errors: VecDeque::from([true]),
-            ..FakeResumeOps::default()
-        };
-
-        let err = remove_drain_restart_override_before_resume(&unit, &mut ops)
-            .await
-            .unwrap_err();
-        let message = err.to_string();
-
-        assert!(message.contains("failed to reload systemd after removing drain restart override"));
-        assert!(message.contains("additionally failed to restore drain restart override"));
-        assert!(message.contains("write failed"));
-        assert_eq!(
-            ops.events,
-            [
-                "remove_restart_override",
-                "daemon_reload",
-                "write_restart_override",
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn resume_remove_reload_failure_reports_restore_reload_failure() {
-        let unit = service_unit();
-        let mut ops = FakeResumeOps {
-            reload_errors: VecDeque::from([true, true]),
-            ..FakeResumeOps::default()
-        };
-
-        let err = remove_drain_restart_override_before_resume(&unit, &mut ops)
-            .await
-            .unwrap_err();
-        let message = err.to_string();
-
-        assert!(message.contains("failed to reload systemd after removing drain restart override"));
-        assert!(message.contains("additionally failed to restore drain restart override"));
-        assert!(message.contains("reload failed"));
-        assert_eq!(
-            ops.events,
-            [
-                "remove_restart_override",
-                "daemon_reload",
-                "write_restart_override",
-                "daemon_reload",
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn resume_signal_failure_restores_removed_drain_override() {
-        let unit = service_unit();
-        let mut ops = FakeResumeOps {
-            signal_error: true,
-            ..FakeResumeOps::default()
-        };
-
-        let err = signal_resume_after_restart_policy_restored(&unit, true, &mut ops)
-            .await
-            .unwrap_err();
-
-        assert!(err.to_string().contains("signal failed"));
-        assert_eq!(
-            ops.events,
-            ["signal_resume", "write_restart_override", "daemon_reload"]
-        );
-    }
-
-    #[tokio::test]
-    async fn resume_signal_failure_reports_restore_write_failure() {
-        let unit = service_unit();
-        let mut ops = FakeResumeOps {
-            write_error: true,
-            signal_error: true,
-            ..FakeResumeOps::default()
-        };
-
-        let err = signal_resume_after_restart_policy_restored(&unit, true, &mut ops)
-            .await
-            .unwrap_err();
-        let message = err.to_string();
-
-        assert!(message.contains("signal failed"));
-        assert!(message.contains("additionally failed to restore drain restart override"));
-        assert!(message.contains("write failed"));
-        assert_eq!(ops.events, ["signal_resume", "write_restart_override"]);
-    }
-
-    #[tokio::test]
-    async fn resume_signal_failure_reports_restore_reload_failure() {
-        let unit = service_unit();
-        let mut ops = FakeResumeOps {
-            reload_errors: VecDeque::from([true]),
-            signal_error: true,
-            ..FakeResumeOps::default()
-        };
-
-        let err = signal_resume_after_restart_policy_restored(&unit, true, &mut ops)
-            .await
-            .unwrap_err();
-        let message = err.to_string();
-
-        assert!(message.contains("signal failed"));
-        assert!(message.contains("additionally failed to restore drain restart override"));
-        assert!(message.contains("reload failed"));
-        assert_eq!(
-            ops.events,
-            ["signal_resume", "write_restart_override", "daemon_reload"]
-        );
-    }
-
-    #[tokio::test]
-    async fn resume_already_gone_restores_removed_drain_override() {
-        let unit = service_unit();
-        let mut ops = FakeResumeOps {
-            signal_outcome: ServiceSignalOutcome::AlreadyGone,
-            ..FakeResumeOps::default()
-        };
-
-        let err = signal_resume_after_restart_policy_restored(&unit, true, &mut ops)
-            .await
-            .unwrap_err();
-
-        assert!(err.to_string().contains("cannot resume an inactive runner"));
-        assert_eq!(
-            ops.events,
-            ["signal_resume", "write_restart_override", "daemon_reload"]
-        );
-    }
-
-    #[tokio::test]
-    async fn resume_signal_failure_without_removed_override_does_not_write_override() {
-        let unit = service_unit();
-        let mut ops = FakeResumeOps {
-            signal_error: true,
-            ..FakeResumeOps::default()
-        };
-
-        let err = signal_resume_after_restart_policy_restored(&unit, false, &mut ops)
-            .await
-            .unwrap_err();
-
-        assert!(err.to_string().contains("signal failed"));
-        assert_eq!(ops.events, ["signal_resume"]);
     }
 }

--- a/crates/runner/src/cmd/service/drain_resume.rs
+++ b/crates/runner/src/cmd/service/drain_resume.rs
@@ -239,13 +239,12 @@ async fn rollback_drain_transition(
         None => failures.push("prior boot enablement is unavailable".to_string()),
     }
 
-    if let Err(error) = ops
-        .daemon_reload(
-            unit,
-            SystemdReloadRequirement::dirty().with_drain_override(false),
-        )
-        .await
-    {
+    let reload_requirement = if restart_override_written {
+        SystemdReloadRequirement::dirty().with_drain_override(false)
+    } else {
+        SystemdReloadRequirement::dirty()
+    };
+    if let Err(error) = ops.daemon_reload(unit, reload_requirement).await {
         failures.push(format!("reload restored systemd state: {error}"));
     }
 
@@ -282,13 +281,12 @@ async fn rollback_resume_transition(
         None => failures.push("prior boot enablement is unavailable".to_string()),
     }
 
-    if let Err(error) = ops
-        .daemon_reload(
-            unit,
-            SystemdReloadRequirement::dirty().with_drain_override(true),
-        )
-        .await
-    {
+    let reload_requirement = if drain_override_removed {
+        SystemdReloadRequirement::dirty().with_drain_override(true)
+    } else {
+        SystemdReloadRequirement::dirty()
+    };
+    if let Err(error) = ops.daemon_reload(unit, reload_requirement).await {
         failures.push(format!("reload restored systemd state: {error}"));
     }
 
@@ -427,13 +425,12 @@ async fn drain_with_ops(
         info!(unit = %unit.unit_name(), "disabled (won't restart on reboot)");
     }
 
-    if let Err(error) = ops
-        .daemon_reload(
-            unit,
-            SystemdReloadRequirement::dirty().with_drain_override(true),
-        )
-        .await
-    {
+    let reload_requirement = if restart_override_written {
+        SystemdReloadRequirement::dirty().with_drain_override(true)
+    } else {
+        SystemdReloadRequirement::dirty()
+    };
+    if let Err(error) = ops.daemon_reload(unit, reload_requirement).await {
         return Err(drain_error_after_rollback(
             unit,
             restart_override_written,
@@ -655,6 +652,7 @@ mod tests {
         write_error: bool,
         remove_error: bool,
         reload_errors: VecDeque<bool>,
+        reload_requirements: Vec<SystemdReloadRequirement>,
         restart_policy_error: bool,
         restart_policy: String,
         signal_error: bool,
@@ -670,6 +668,7 @@ mod tests {
         remove_error: bool,
         removed_restart_override: bool,
         reload_errors: VecDeque<bool>,
+        reload_requirements: Vec<SystemdReloadRequirement>,
         signal_error: bool,
         signal_outcome: ServiceSignalOutcome,
         enable_error: bool,
@@ -685,6 +684,7 @@ mod tests {
                 write_error: false,
                 remove_error: false,
                 reload_errors: VecDeque::new(),
+                reload_requirements: Vec::new(),
                 restart_policy_error: false,
                 restart_policy: "no".to_string(),
                 signal_error: false,
@@ -704,6 +704,7 @@ mod tests {
                 remove_error: false,
                 removed_restart_override: true,
                 reload_errors: VecDeque::new(),
+                reload_requirements: Vec::new(),
                 signal_error: false,
                 signal_outcome: ServiceSignalOutcome::Sent,
                 enable_error: false,
@@ -757,9 +758,10 @@ mod tests {
         fn daemon_reload<'a>(
             &'a mut self,
             _unit: &'a RunnerServiceUnit,
-            _requirement: SystemdReloadRequirement,
+            requirement: SystemdReloadRequirement,
         ) -> ServiceFuture<'a, ()> {
             self.events.push("daemon_reload");
+            self.reload_requirements.push(requirement);
             let reload_error = self.reload_errors.pop_front().unwrap_or(false);
             Box::pin(std::future::ready(if reload_error {
                 Err(fake_error("reload failed"))
@@ -853,9 +855,10 @@ mod tests {
         fn daemon_reload<'a>(
             &'a mut self,
             _unit: &'a RunnerServiceUnit,
-            _requirement: SystemdReloadRequirement,
+            requirement: SystemdReloadRequirement,
         ) -> ServiceFuture<'a, ()> {
             self.events.push("daemon_reload");
+            self.reload_requirements.push(requirement);
             let reload_error = self.reload_errors.pop_front().unwrap_or(false);
             Box::pin(std::future::ready(if reload_error {
                 Err(fake_error("reload failed"))
@@ -922,6 +925,10 @@ mod tests {
                 "signal_drain",
             ]
         );
+        assert_eq!(
+            ops.reload_requirements,
+            [SystemdReloadRequirement::dirty().with_drain_override(true),]
+        );
     }
 
     #[tokio::test]
@@ -962,6 +969,7 @@ mod tests {
             ops.events,
             ["is_active", "is_enabled", "disable", "daemon_reload"]
         );
+        assert_eq!(ops.reload_requirements, [SystemdReloadRequirement::dirty()]);
     }
 
     #[tokio::test]
@@ -1003,6 +1011,13 @@ mod tests {
                 "remove_restart_override",
                 "restore_enabled",
                 "daemon_reload",
+            ]
+        );
+        assert_eq!(
+            ops.reload_requirements,
+            [
+                SystemdReloadRequirement::dirty().with_drain_override(true),
+                SystemdReloadRequirement::dirty().with_drain_override(false),
             ]
         );
     }
@@ -1364,6 +1379,13 @@ mod tests {
                 "signal_resume",
                 "restore_not_enabled",
                 "daemon_reload",
+            ]
+        );
+        assert_eq!(
+            ops.reload_requirements,
+            [
+                SystemdReloadRequirement::dirty().with_drain_override(false),
+                SystemdReloadRequirement::dirty(),
             ]
         );
     }

--- a/crates/runner/src/cmd/service/drain_resume.rs
+++ b/crates/runner/src/cmd/service/drain_resume.rs
@@ -49,7 +49,11 @@ trait ServiceDrainOps {
     ) -> ServiceFuture<'a, SystemdUnitEnablement>;
     fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()>;
     fn remove_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<bool>;
-    fn daemon_reload<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
+    fn daemon_reload<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        requirement: SystemdReloadRequirement,
+    ) -> ServiceFuture<'a, ()>;
     fn restart_policy<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, String>;
     fn signal_drain<'a>(
         &'a mut self,
@@ -70,7 +74,11 @@ trait ServiceResumeOps {
     ) -> ServiceFuture<'a, SystemdUnitEnablement>;
     fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()>;
     fn remove_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<bool>;
-    fn daemon_reload<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
+    fn daemon_reload<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        requirement: SystemdReloadRequirement,
+    ) -> ServiceFuture<'a, ()>;
     fn signal_resume<'a>(
         &'a mut self,
         unit: &'a RunnerServiceUnit,
@@ -106,9 +114,13 @@ impl ServiceDrainOps for RealServiceDrainOps {
         remove_drain_restart_override(unit)
     }
 
-    fn daemon_reload<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
+    fn daemon_reload<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        requirement: SystemdReloadRequirement,
+    ) -> ServiceFuture<'a, ()> {
         Box::pin(async move {
-            coordinate_systemd_reload(unit, SystemdReloadRequirement::Dirty)
+            coordinate_systemd_reload(unit, requirement)
                 .await
                 .map(|_| ())
         })
@@ -156,9 +168,13 @@ impl ServiceResumeOps for RealServiceResumeOps {
         remove_drain_restart_override(unit)
     }
 
-    fn daemon_reload<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
+    fn daemon_reload<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        requirement: SystemdReloadRequirement,
+    ) -> ServiceFuture<'a, ()> {
         Box::pin(async move {
-            coordinate_systemd_reload(unit, SystemdReloadRequirement::Dirty)
+            coordinate_systemd_reload(unit, requirement)
                 .await
                 .map(|_| ())
         })
@@ -223,7 +239,13 @@ async fn rollback_drain_transition(
         None => failures.push("prior boot enablement is unavailable".to_string()),
     }
 
-    if let Err(error) = ops.daemon_reload(unit).await {
+    if let Err(error) = ops
+        .daemon_reload(
+            unit,
+            SystemdReloadRequirement::dirty().with_drain_override(false),
+        )
+        .await
+    {
         failures.push(format!("reload restored systemd state: {error}"));
     }
 
@@ -260,7 +282,13 @@ async fn rollback_resume_transition(
         None => failures.push("prior boot enablement is unavailable".to_string()),
     }
 
-    if let Err(error) = ops.daemon_reload(unit).await {
+    if let Err(error) = ops
+        .daemon_reload(
+            unit,
+            SystemdReloadRequirement::dirty().with_drain_override(true),
+        )
+        .await
+    {
         failures.push(format!("reload restored systemd state: {error}"));
     }
 
@@ -399,7 +427,13 @@ async fn drain_with_ops(
         info!(unit = %unit.unit_name(), "disabled (won't restart on reboot)");
     }
 
-    if let Err(error) = ops.daemon_reload(unit).await {
+    if let Err(error) = ops
+        .daemon_reload(
+            unit,
+            SystemdReloadRequirement::dirty().with_drain_override(true),
+        )
+        .await
+    {
         return Err(drain_error_after_rollback(
             unit,
             restart_override_written,
@@ -507,7 +541,13 @@ async fn resume_after_preflight_with_ops(
         info!(unit = %unit.unit_name(), "re-enabled (will restart on reboot)");
     }
 
-    if let Err(error) = ops.daemon_reload(unit).await {
+    if let Err(error) = ops
+        .daemon_reload(
+            unit,
+            SystemdReloadRequirement::dirty().with_drain_override(false),
+        )
+        .await
+    {
         return Err(resume_error_after_rollback(
             unit,
             drain_override_removed,
@@ -714,7 +754,11 @@ mod tests {
             }
         }
 
-        fn daemon_reload<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
+        fn daemon_reload<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+            _requirement: SystemdReloadRequirement,
+        ) -> ServiceFuture<'a, ()> {
             self.events.push("daemon_reload");
             let reload_error = self.reload_errors.pop_front().unwrap_or(false);
             Box::pin(std::future::ready(if reload_error {
@@ -806,7 +850,11 @@ mod tests {
             }
         }
 
-        fn daemon_reload<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
+        fn daemon_reload<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+            _requirement: SystemdReloadRequirement,
+        ) -> ServiceFuture<'a, ()> {
             self.events.push("daemon_reload");
             let reload_error = self.reload_errors.pop_front().unwrap_or(false);
             Box::pin(std::future::ready(if reload_error {

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -15,6 +15,7 @@ mod diagnostic;
 mod drain_override;
 mod drain_resume;
 mod gate;
+mod reload;
 mod signal;
 mod state;
 mod stop;
@@ -29,6 +30,7 @@ pub(crate) use unit_config::read_unit_config_path;
 
 use drain_override::{remove_drain_restart_override, write_drain_restart_override};
 use gate::check_active_jobs_gate;
+use reload::{SystemdReloadRequirement, coordinate_systemd_reload};
 use systemctl::{journalctl_logs_status, run_systemctl};
 use unit_file::{
     RUNNER_SERVICE_NOFILE_LIMIT_DIRECTIVE, cleanup_unit_staging_files, generate_unit_file,
@@ -202,7 +204,7 @@ async fn restore_drain_restart_override_after_failed_cleanup(
             unit.unit_name()
         )));
     }
-    if let Err(e) = run_systemctl(&["daemon-reload"]).await {
+    if let Err(e) = coordinate_systemd_reload(unit, SystemdReloadRequirement::Dirty).await {
         return Err(RunnerError::Internal(format!(
             "failed to reload systemd after restoring drain restart override for {} ({context}): {e}",
             unit.unit_name()
@@ -218,7 +220,9 @@ async fn reload_systemd_if_drain_restart_override_removed(
         return Ok(false);
     }
 
-    if let Err(reload_error) = run_systemctl(&["daemon-reload"]).await {
+    if let Err(reload_error) =
+        coordinate_systemd_reload(unit, SystemdReloadRequirement::Dirty).await
+    {
         if let Err(restore_error) =
             restore_drain_restart_override_after_failed_cleanup(unit, "remove_reload").await
         {
@@ -232,6 +236,39 @@ async fn reload_systemd_if_drain_restart_override_removed(
     }
 
     Ok(true)
+}
+
+async fn restore_service_state_after_reload_failure(
+    unit: &RunnerServiceUnit,
+    was_enabled: bool,
+    restore_drain_override: bool,
+) -> RunnerResult<()> {
+    let mut failures = Vec::new();
+
+    if restore_drain_override && let Err(error) = write_drain_restart_override(unit) {
+        failures.push(format!("restore drain restart override: {error}"));
+    }
+
+    let command = if was_enabled { "enable" } else { "disable" };
+    if let Err(error) = run_systemctl(&[command, "--no-reload", unit.service_name()]).await {
+        failures.push(format!("restore boot enablement: {error}"));
+    }
+
+    if let Err(error) =
+        coordinate_systemd_reload(unit, SystemdReloadRequirement::DirtyOrNotFound).await
+    {
+        failures.push(format!("reload restored systemd state: {error}"));
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(RunnerError::Internal(format!(
+            "failed to restore service state for {}: {}",
+            unit.unit_name(),
+            failures.join("; ")
+        )))
+    }
 }
 
 async fn prepare_service_activation_config(
@@ -387,6 +424,7 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
 
     let unit_for_activation = unit.clone();
     let upath = unit.unit_file_path().to_path_buf();
+    let was_enabled = is_unit_enabled(&unit).await?;
 
     with_service_activation_image_artifacts(
         &unit,
@@ -400,19 +438,54 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
                 &args.env,
                 args.local,
             );
-            if is_unit_active(&unit_for_activation).await? {
+            let drain_override_removed = if is_unit_active(&unit_for_activation).await? {
                 warn!(
                     unit = %unit_for_activation.unit_name(),
                     "skipping drain restart override cleanup while service is active"
                 );
+                false
             } else {
-                reload_systemd_if_drain_restart_override_removed(&unit_for_activation).await?;
-            }
+                remove_drain_restart_override(&unit_for_activation)?
+            };
             cleanup_unit_staging_files(&upath)?;
             write_unit_file(&upath, &unit_content)?;
 
-            run_systemctl(&["daemon-reload"]).await?;
-            run_systemctl(&["enable", "--now", unit_for_activation.service_name()]).await?;
+            let enable_result = run_systemctl(&[
+                "enable",
+                "--no-reload",
+                unit_for_activation.service_name(),
+            ])
+            .await;
+            let reload_result = coordinate_systemd_reload(
+                &unit_for_activation,
+                SystemdReloadRequirement::DirtyOrNotFound,
+            )
+            .await;
+
+            if let Err(reload_error) = reload_result {
+                let primary_error = match enable_result {
+                    Ok(()) => reload_error,
+                    Err(enable_error) => RunnerError::Internal(format!(
+                        "failed to enable {}: {enable_error}; additionally failed to reload systemd: {reload_error}",
+                        unit_for_activation.unit_name()
+                    )),
+                };
+                return match restore_service_state_after_reload_failure(
+                    &unit_for_activation,
+                    was_enabled,
+                    drain_override_removed,
+                )
+                .await
+                {
+                    Ok(()) => Err(primary_error),
+                    Err(rollback_error) => Err(RunnerError::Internal(format!(
+                        "install failed for {}: {primary_error}; additionally failed to restore service state: {rollback_error}",
+                        unit_for_activation.unit_name()
+                    ))),
+                };
+            }
+            enable_result?;
+            run_systemctl(&["start", unit_for_activation.service_name()]).await?;
             Ok(())
         },
     )
@@ -453,7 +526,7 @@ pub(crate) async fn uninstall_service_unit(unit: &RunnerServiceUnit) -> RunnerRe
         },
     };
 
-    let _ = run_systemctl(&["disable", unit.service_name()]).await;
+    let _ = run_systemctl(&["disable", "--no-reload", unit.service_name()]).await;
 
     // Remove the unit file if it exists.
     let upath = unit.unit_file_path();
@@ -463,26 +536,14 @@ pub(crate) async fn uninstall_service_unit(unit: &RunnerServiceUnit) -> RunnerRe
     if let Err(e) = remove_unit_file_if_exists(upath) {
         warn!(unit = %unit.unit_name(), error = %e, "failed to remove unit file");
     }
-    let drain_override_cleanup_reloaded = match reload_systemd_if_drain_restart_override_removed(
-        unit,
-    )
-    .await
-    {
-        Ok(removed) => removed,
+    match remove_drain_restart_override(unit) {
+        Ok(_) => {}
         Err(e) => {
             warn!(unit = %unit.unit_name(), error = %e, "failed to remove drain restart override");
-            false
         }
-    };
-
-    if drain_override_cleanup_reloaded {
-        info!(unit = %unit.unit_name(), "service uninstalled");
-        return Ok(());
     }
 
-    if let Err(e) = run_systemctl(&["daemon-reload"]).await {
-        warn!(unit = %unit.unit_name(), error = %e, "failed to reload systemd daemon");
-    }
+    coordinate_systemd_reload(unit, SystemdReloadRequirement::Dirty).await?;
 
     info!(unit = %unit.unit_name(), "service uninstalled");
     Ok(())

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -207,7 +207,12 @@ async fn restore_drain_restart_override_after_failed_cleanup(
             unit.unit_name()
         )));
     }
-    if let Err(e) = coordinate_systemd_reload(unit, SystemdReloadRequirement::Dirty).await {
+    if let Err(e) = coordinate_systemd_reload(
+        unit,
+        SystemdReloadRequirement::dirty().with_drain_override(true),
+    )
+    .await
+    {
         return Err(RunnerError::Internal(format!(
             "failed to reload systemd after restoring drain restart override for {} ({context}): {e}",
             unit.unit_name()
@@ -223,8 +228,11 @@ async fn reload_systemd_if_drain_restart_override_removed(
         return Ok(false);
     }
 
-    if let Err(reload_error) =
-        coordinate_systemd_reload(unit, SystemdReloadRequirement::Dirty).await
+    if let Err(reload_error) = coordinate_systemd_reload(
+        unit,
+        SystemdReloadRequirement::dirty().with_drain_override(false),
+    )
+    .await
     {
         if let Err(restore_error) =
             restore_drain_restart_override_after_failed_cleanup(unit, "remove_reload").await
@@ -256,9 +264,12 @@ async fn restore_service_state_after_reload_failure(
         failures.push(format!("restore boot enablement: {error}"));
     }
 
-    if let Err(error) =
-        coordinate_systemd_reload(unit, SystemdReloadRequirement::DirtyOrNotFound).await
-    {
+    let requirement = if restore_drain_override {
+        SystemdReloadRequirement::dirty_or_not_found().with_drain_override(true)
+    } else {
+        SystemdReloadRequirement::dirty_or_not_found()
+    };
+    if let Err(error) = coordinate_systemd_reload(unit, requirement).await {
         failures.push(format!("reload restored systemd state: {error}"));
     }
 
@@ -458,11 +469,13 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
                 unit_for_activation.service_name(),
             ])
             .await;
-            let reload_result = coordinate_systemd_reload(
-                &unit_for_activation,
-                SystemdReloadRequirement::DirtyOrNotFound,
-            )
-            .await;
+            let requirement = if drain_override_removed {
+                SystemdReloadRequirement::dirty_or_not_found().with_drain_override(false)
+            } else {
+                SystemdReloadRequirement::dirty_or_not_found()
+            };
+            let reload_result =
+                coordinate_systemd_reload(&unit_for_activation, requirement).await;
 
             if let Err(reload_error) = reload_result {
                 let primary_error = match enable_result {
@@ -545,7 +558,11 @@ pub(crate) async fn uninstall_service_unit(unit: &RunnerServiceUnit) -> RunnerRe
         }
     }
 
-    coordinate_systemd_reload(unit, SystemdReloadRequirement::Dirty).await?;
+    coordinate_systemd_reload(
+        unit,
+        SystemdReloadRequirement::dirty().with_drain_override(false),
+    )
+    .await?;
 
     info!(unit = %unit.unit_name(), "service uninstalled");
     Ok(())

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -31,7 +31,10 @@ pub(crate) use unit_config::read_unit_config_path;
 use drain_override::{remove_drain_restart_override, write_drain_restart_override};
 use gate::check_active_jobs_gate;
 use reload::{SystemdReloadRequirement, coordinate_systemd_reload};
-use systemctl::{journalctl_logs_status, run_systemctl};
+use systemctl::{
+    SystemdUnitEnablement, journalctl_logs_status, read_unit_enablement, restore_unit_enablement,
+    run_systemctl,
+};
 use unit_file::{
     RUNNER_SERVICE_NOFILE_LIMIT_DIRECTIVE, cleanup_unit_staging_files, generate_unit_file,
     remove_unit_file_if_exists, resolve_config_path, validate_current_exe_path, validate_env_vars,
@@ -240,7 +243,7 @@ async fn reload_systemd_if_drain_restart_override_removed(
 
 async fn restore_service_state_after_reload_failure(
     unit: &RunnerServiceUnit,
-    was_enabled: bool,
+    prior_enablement: SystemdUnitEnablement,
     restore_drain_override: bool,
 ) -> RunnerResult<()> {
     let mut failures = Vec::new();
@@ -249,8 +252,7 @@ async fn restore_service_state_after_reload_failure(
         failures.push(format!("restore drain restart override: {error}"));
     }
 
-    let command = if was_enabled { "enable" } else { "disable" };
-    if let Err(error) = run_systemctl(&[command, "--no-reload", unit.service_name()]).await {
+    if let Err(error) = restore_unit_enablement(unit, prior_enablement).await {
         failures.push(format!("restore boot enablement: {error}"));
     }
 
@@ -424,7 +426,7 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
 
     let unit_for_activation = unit.clone();
     let upath = unit.unit_file_path().to_path_buf();
-    let was_enabled = is_unit_enabled(&unit).await?;
+    let prior_enablement = read_unit_enablement(&unit).await?;
 
     with_service_activation_image_artifacts(
         &unit,
@@ -472,7 +474,7 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
                 };
                 return match restore_service_state_after_reload_failure(
                     &unit_for_activation,
-                    was_enabled,
+                    prior_enablement,
                     drain_override_removed,
                 )
                 .await

--- a/crates/runner/src/cmd/service/reload.rs
+++ b/crates/runner/src/cmd/service/reload.rs
@@ -1,0 +1,297 @@
+use std::time::Duration;
+
+use tracing::{debug, info, warn};
+
+use crate::error::{RunnerError, RunnerResult};
+use crate::paths::HomePaths;
+
+use super::systemctl::{
+    BoundedSystemctlOutcome, SystemdReloadState, read_systemd_reload_state,
+    read_systemd_reload_state_bounded, run_systemctl, run_systemctl_bounded,
+};
+use super::{RunnerServiceUnit, ServiceFuture};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SystemdReloadRequirement {
+    Dirty,
+    DirtyOrNotFound,
+}
+
+impl SystemdReloadRequirement {
+    fn requires_reload(self, state: SystemdReloadState) -> bool {
+        state.need_daemon_reload() || matches!(self, Self::DirtyOrNotFound) && state.is_not_found()
+    }
+}
+
+trait SystemdReloadOps {
+    fn read_state<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, SystemdReloadState>;
+    fn daemon_reload(&mut self) -> ServiceFuture<'_, ()>;
+}
+
+struct RealSystemdReloadOps {
+    command_timeout: Option<Duration>,
+}
+
+impl SystemdReloadOps for RealSystemdReloadOps {
+    fn read_state<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, SystemdReloadState> {
+        Box::pin(async move {
+            match self.command_timeout {
+                Some(duration) => read_systemd_reload_state_bounded(unit, duration).await,
+                None => read_systemd_reload_state(unit).await,
+            }
+        })
+    }
+
+    fn daemon_reload(&mut self) -> ServiceFuture<'_, ()> {
+        Box::pin(async move {
+            match self.command_timeout {
+                Some(duration) => {
+                    match run_systemctl_bounded(&["daemon-reload"], duration).await? {
+                        BoundedSystemctlOutcome::Success => Ok(()),
+                        BoundedSystemctlOutcome::Failed(status) => Err(RunnerError::Internal(
+                            format!("systemctl daemon-reload exited with {status} during cleanup"),
+                        )),
+                        BoundedSystemctlOutcome::TimedOut => Err(RunnerError::Internal(format!(
+                            "systemctl daemon-reload timed out after {}s during cleanup",
+                            duration.as_secs()
+                        ))),
+                    }
+                }
+                None => run_systemctl(&["daemon-reload"]).await,
+            }
+        })
+    }
+}
+
+async fn acquire_systemd_reload_lock(
+    home: &HomePaths,
+    unit: &RunnerServiceUnit,
+    lock_timeout: Option<Duration>,
+) -> RunnerResult<nix::fcntl::Flock<std::fs::File>> {
+    let path = home.systemd_daemon_reload_lock();
+    match lock_timeout {
+        Some(duration) => tokio::time::timeout(duration, crate::lock::acquire(path))
+            .await
+            .map_err(|_| {
+                RunnerError::Internal(format!(
+                    "timed out waiting {}s for systemd daemon-reload lock while updating {}",
+                    duration.as_secs(),
+                    unit.unit_name()
+                ))
+            })?,
+        None => crate::lock::acquire(path).await,
+    }
+}
+
+async fn coordinate_systemd_reload_with_ops(
+    unit: &RunnerServiceUnit,
+    home: &HomePaths,
+    requirement: SystemdReloadRequirement,
+    lock_timeout: Option<Duration>,
+    ops: &mut impl SystemdReloadOps,
+) -> RunnerResult<bool> {
+    let _reload_lock = acquire_systemd_reload_lock(home, unit, lock_timeout).await?;
+
+    let should_reload = match ops.read_state(unit).await {
+        Ok(state) => requirement.requires_reload(state),
+        Err(error) => {
+            warn!(
+                unit = %unit.unit_name(),
+                error = %error,
+                "failed to read systemd reload state; falling back to daemon-reload"
+            );
+            true
+        }
+    };
+
+    if !should_reload {
+        debug!(
+            unit = %unit.unit_name(),
+            "systemd reload skipped because the unit mutation is already effective"
+        );
+        return Ok(false);
+    }
+
+    ops.daemon_reload().await?;
+    info!(unit = %unit.unit_name(), "systemd daemon reloaded");
+    Ok(true)
+}
+
+pub(super) async fn coordinate_systemd_reload(
+    unit: &RunnerServiceUnit,
+    requirement: SystemdReloadRequirement,
+) -> RunnerResult<bool> {
+    let home = HomePaths::new()?;
+    coordinate_systemd_reload_with_ops(
+        unit,
+        &home,
+        requirement,
+        None,
+        &mut RealSystemdReloadOps {
+            command_timeout: None,
+        },
+    )
+    .await
+}
+
+pub(super) async fn coordinate_systemd_reload_bounded(
+    unit: &RunnerServiceUnit,
+    requirement: SystemdReloadRequirement,
+    lock_timeout: Duration,
+    command_timeout: Duration,
+) -> RunnerResult<bool> {
+    let home = HomePaths::new()?;
+    coordinate_systemd_reload_with_ops(
+        unit,
+        &home,
+        requirement,
+        Some(lock_timeout),
+        &mut RealSystemdReloadOps {
+            command_timeout: Some(command_timeout),
+        },
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct FakeSystemdReloadOps {
+        dirty: Arc<AtomicBool>,
+        query_error: bool,
+        reload_count: Arc<AtomicUsize>,
+    }
+
+    impl SystemdReloadOps for FakeSystemdReloadOps {
+        fn read_state<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+        ) -> ServiceFuture<'a, SystemdReloadState> {
+            Box::pin(std::future::ready(if self.query_error {
+                Err(RunnerError::Internal("query failed".to_string()))
+            } else {
+                Ok(SystemdReloadState::for_test(
+                    false,
+                    self.dirty.load(Ordering::SeqCst),
+                ))
+            }))
+        }
+
+        fn daemon_reload(&mut self) -> ServiceFuture<'_, ()> {
+            self.reload_count.fetch_add(1, Ordering::SeqCst);
+            self.dirty.store(false, Ordering::SeqCst);
+            Box::pin(std::future::ready(Ok(())))
+        }
+    }
+
+    fn fake_ops(dirty: bool) -> FakeSystemdReloadOps {
+        FakeSystemdReloadOps {
+            dirty: Arc::new(AtomicBool::new(dirty)),
+            query_error: false,
+            reload_count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    #[test]
+    fn install_requires_reload_for_not_found_unit() {
+        let state = SystemdReloadState::for_test(true, false);
+
+        assert!(
+            SystemdReloadRequirement::DirtyOrNotFound.requires_reload(state),
+            "a newly written unit must be loaded before start"
+        );
+        assert!(!SystemdReloadRequirement::Dirty.requires_reload(state));
+    }
+
+    #[tokio::test]
+    async fn query_failure_falls_back_to_daemon_reload() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        let unit = RunnerServiceUnit::from_suffix("test").unwrap();
+        let mut ops = fake_ops(false);
+        ops.query_error = true;
+
+        assert!(
+            coordinate_systemd_reload_with_ops(
+                &unit,
+                &home,
+                SystemdReloadRequirement::Dirty,
+                None,
+                &mut ops,
+            )
+            .await
+            .unwrap()
+        );
+        assert_eq!(ops.reload_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn different_units_coalesce_one_dirty_generation_under_real_flock() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        let unit_a = RunnerServiceUnit::from_suffix("reload-a").unwrap();
+        let unit_b = RunnerServiceUnit::from_suffix("reload-b").unwrap();
+        let ops = fake_ops(true);
+        let mut ops_a = ops.clone();
+        let mut ops_b = ops.clone();
+
+        let (result_a, result_b) = tokio::join!(
+            coordinate_systemd_reload_with_ops(
+                &unit_a,
+                &home,
+                SystemdReloadRequirement::Dirty,
+                None,
+                &mut ops_a,
+            ),
+            coordinate_systemd_reload_with_ops(
+                &unit_b,
+                &home,
+                SystemdReloadRequirement::Dirty,
+                None,
+                &mut ops_b,
+            ),
+        );
+
+        let performed = [result_a.unwrap(), result_b.unwrap()]
+            .into_iter()
+            .filter(|performed| *performed)
+            .count();
+        assert_eq!(performed, 1);
+        assert_eq!(ops.reload_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn bounded_coordinator_times_out_waiting_for_global_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        let unit = RunnerServiceUnit::from_suffix("test").unwrap();
+        let _holder = crate::lock::acquire(home.systemd_daemon_reload_lock())
+            .await
+            .unwrap();
+        let mut ops = fake_ops(true);
+
+        let error = coordinate_systemd_reload_with_ops(
+            &unit,
+            &home,
+            SystemdReloadRequirement::Dirty,
+            Some(Duration::from_secs(1)),
+            &mut ops,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("systemd daemon-reload lock"));
+        assert_eq!(ops.reload_count.load(Ordering::SeqCst), 0);
+    }
+}

--- a/crates/runner/src/cmd/service/reload.rs
+++ b/crates/runner/src/cmd/service/reload.rs
@@ -5,6 +5,7 @@ use tracing::{debug, info, warn};
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
 
+use super::drain_override::drain_restart_override_path;
 use super::systemctl::{
     BoundedSystemctlOutcome, SystemdReloadState, read_systemd_reload_state,
     read_systemd_reload_state_bounded, run_systemctl, run_systemctl_bounded,
@@ -12,14 +13,37 @@ use super::systemctl::{
 use super::{RunnerServiceUnit, ServiceFuture};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum SystemdReloadRequirement {
-    Dirty,
-    DirtyOrNotFound,
+pub(super) struct SystemdReloadRequirement {
+    reload_if_not_found: bool,
+    expected_drain_override: Option<bool>,
 }
 
 impl SystemdReloadRequirement {
-    fn requires_reload(self, state: SystemdReloadState) -> bool {
-        state.need_daemon_reload() || matches!(self, Self::DirtyOrNotFound) && state.is_not_found()
+    pub(super) const fn dirty() -> Self {
+        Self {
+            reload_if_not_found: false,
+            expected_drain_override: None,
+        }
+    }
+
+    pub(super) const fn dirty_or_not_found() -> Self {
+        Self {
+            reload_if_not_found: true,
+            expected_drain_override: None,
+        }
+    }
+
+    pub(super) const fn with_drain_override(mut self, expected_present: bool) -> Self {
+        self.expected_drain_override = Some(expected_present);
+        self
+    }
+
+    fn requires_reload(self, unit: &RunnerServiceUnit, state: &SystemdReloadState) -> bool {
+        state.need_daemon_reload()
+            || self.reload_if_not_found && state.is_not_found()
+            || self.expected_drain_override.is_some_and(|expected| {
+                state.has_drop_in_path(&drain_restart_override_path(unit)) != expected
+            })
     }
 }
 
@@ -99,7 +123,7 @@ async fn coordinate_systemd_reload_with_ops(
     let _reload_lock = acquire_systemd_reload_lock(home, unit, lock_timeout).await?;
 
     let should_reload = match ops.read_state(unit).await {
-        Ok(state) => requirement.requires_reload(state),
+        Ok(state) => requirement.requires_reload(unit, &state),
         Err(error) => {
             warn!(
                 unit = %unit.unit_name(),
@@ -169,6 +193,7 @@ mod tests {
     #[derive(Clone)]
     struct FakeSystemdReloadOps {
         dirty: Arc<AtomicBool>,
+        drain_override_loaded: bool,
         query_error: bool,
         reload_count: Arc<AtomicUsize>,
     }
@@ -176,7 +201,7 @@ mod tests {
     impl SystemdReloadOps for FakeSystemdReloadOps {
         fn read_state<'a>(
             &'a mut self,
-            _unit: &'a RunnerServiceUnit,
+            unit: &'a RunnerServiceUnit,
         ) -> ServiceFuture<'a, SystemdReloadState> {
             Box::pin(std::future::ready(if self.query_error {
                 Err(RunnerError::Internal("query failed".to_string()))
@@ -184,6 +209,15 @@ mod tests {
                 Ok(SystemdReloadState::for_test(
                     false,
                     self.dirty.load(Ordering::SeqCst),
+                    if self.drain_override_loaded {
+                        vec![
+                            drain_restart_override_path(unit)
+                                .to_string_lossy()
+                                .into_owned(),
+                        ]
+                    } else {
+                        Vec::new()
+                    },
                 ))
             }))
         }
@@ -198,6 +232,7 @@ mod tests {
     fn fake_ops(dirty: bool) -> FakeSystemdReloadOps {
         FakeSystemdReloadOps {
             dirty: Arc::new(AtomicBool::new(dirty)),
+            drain_override_loaded: false,
             query_error: false,
             reload_count: Arc::new(AtomicUsize::new(0)),
         }
@@ -205,13 +240,50 @@ mod tests {
 
     #[test]
     fn install_requires_reload_for_not_found_unit() {
-        let state = SystemdReloadState::for_test(true, false);
+        let unit = RunnerServiceUnit::from_suffix("test").unwrap();
+        let state = SystemdReloadState::for_test(true, false, Vec::new());
 
         assert!(
-            SystemdReloadRequirement::DirtyOrNotFound.requires_reload(state),
+            SystemdReloadRequirement::dirty_or_not_found().requires_reload(&unit, &state),
             "a newly written unit must be loaded before start"
         );
-        assert!(!SystemdReloadRequirement::Dirty.requires_reload(state));
+        assert!(!SystemdReloadRequirement::dirty().requires_reload(&unit, &state));
+    }
+
+    #[test]
+    fn drain_override_state_requires_reload_when_systemd_dirty_flag_misses_change() {
+        let unit = RunnerServiceUnit::from_suffix("test").unwrap();
+        let absent = SystemdReloadState::for_test(false, false, Vec::new());
+        let present = SystemdReloadState::for_test(
+            false,
+            false,
+            vec![
+                drain_restart_override_path(&unit)
+                    .to_string_lossy()
+                    .into_owned(),
+            ],
+        );
+
+        assert!(
+            SystemdReloadRequirement::dirty()
+                .with_drain_override(true)
+                .requires_reload(&unit, &absent)
+        );
+        assert!(
+            !SystemdReloadRequirement::dirty()
+                .with_drain_override(true)
+                .requires_reload(&unit, &present)
+        );
+        assert!(
+            SystemdReloadRequirement::dirty()
+                .with_drain_override(false)
+                .requires_reload(&unit, &present)
+        );
+        assert!(
+            !SystemdReloadRequirement::dirty()
+                .with_drain_override(false)
+                .requires_reload(&unit, &absent)
+        );
     }
 
     #[tokio::test]
@@ -226,7 +298,7 @@ mod tests {
             coordinate_systemd_reload_with_ops(
                 &unit,
                 &home,
-                SystemdReloadRequirement::Dirty,
+                SystemdReloadRequirement::dirty(),
                 None,
                 &mut ops,
             )
@@ -250,14 +322,14 @@ mod tests {
             coordinate_systemd_reload_with_ops(
                 &unit_a,
                 &home,
-                SystemdReloadRequirement::Dirty,
+                SystemdReloadRequirement::dirty(),
                 None,
                 &mut ops_a,
             ),
             coordinate_systemd_reload_with_ops(
                 &unit_b,
                 &home,
-                SystemdReloadRequirement::Dirty,
+                SystemdReloadRequirement::dirty(),
                 None,
                 &mut ops_b,
             ),
@@ -284,7 +356,7 @@ mod tests {
         let error = coordinate_systemd_reload_with_ops(
             &unit,
             &home,
-            SystemdReloadRequirement::Dirty,
+            SystemdReloadRequirement::dirty(),
             Some(Duration::from_secs(1)),
             &mut ops,
         )

--- a/crates/runner/src/cmd/service/stop.rs
+++ b/crates/runner/src/cmd/service/stop.rs
@@ -7,6 +7,7 @@ use crate::paths::HomePaths;
 
 use super::drain_override::{remove_drain_restart_override, write_drain_restart_override};
 use super::gate::check_active_jobs_gate;
+use super::reload::{SystemdReloadRequirement, coordinate_systemd_reload_bounded};
 use super::systemctl::{
     BoundedSystemctlOutcome, CleanupUnitActiveState, cleanup_unit_active_state_bounded,
     is_unit_active, is_unit_enabled_bounded, run_systemctl, run_systemctl_bounded,
@@ -147,26 +148,40 @@ async fn run_cleanup_systemctl(args: &[&str], duration: TokioDuration) -> Runner
 async fn reload_systemd_if_drain_restart_override_removed_bounded(
     unit: &RunnerServiceUnit,
 ) -> RunnerResult<bool> {
-    if !remove_drain_restart_override(unit)? {
-        return Ok(false);
+    let remove_result = remove_drain_restart_override(unit);
+    let removed = matches!(&remove_result, Ok(true));
+
+    let reload_result = coordinate_systemd_reload_bounded(
+        unit,
+        SystemdReloadRequirement::Dirty,
+        CLEANUP_LOCK_TIMEOUT,
+        CLEANUP_ACTION_TIMEOUT,
+    )
+    .await;
+
+    if let Err(reload_error) = reload_result {
+        let reload_error = if removed {
+            match restore_drain_restart_override_after_failed_cleanup_bounded(unit, "remove_reload")
+                .await
+            {
+                Ok(()) => reload_error,
+                Err(restore_error) => {
+                    drain_override_cleanup_reload_error(unit, reload_error, restore_error)
+                }
+            }
+        } else {
+            reload_error
+        };
+        return match remove_result {
+            Ok(_) => Err(reload_error),
+            Err(remove_error) => Err(RunnerError::Internal(format!(
+                "failed to remove drain restart override for {} during cleanup: {remove_error}; additionally failed to reload systemd: {reload_error}",
+                unit.unit_name()
+            ))),
+        };
     }
 
-    if let Err(reload_error) =
-        run_cleanup_systemctl(&["daemon-reload"], CLEANUP_ACTION_TIMEOUT).await
-    {
-        if let Err(restore_error) =
-            restore_drain_restart_override_after_failed_cleanup_bounded(unit, "remove_reload").await
-        {
-            return Err(drain_override_cleanup_reload_error(
-                unit,
-                reload_error,
-                restore_error,
-            ));
-        }
-        return Err(reload_error);
-    }
-
-    Ok(true)
+    remove_result.map(|_| removed)
 }
 
 async fn restore_drain_restart_override_after_failed_cleanup_bounded(
@@ -179,7 +194,14 @@ async fn restore_drain_restart_override_after_failed_cleanup_bounded(
             unit.unit_name()
         )));
     }
-    if let Err(e) = run_cleanup_systemctl(&["daemon-reload"], CLEANUP_ACTION_TIMEOUT).await {
+    if let Err(e) = coordinate_systemd_reload_bounded(
+        unit,
+        SystemdReloadRequirement::Dirty,
+        CLEANUP_LOCK_TIMEOUT,
+        CLEANUP_ACTION_TIMEOUT,
+    )
+    .await
+    {
         return Err(RunnerError::Internal(format!(
             "failed to reload systemd after restoring drain restart override for {} ({context}): {e}",
             unit.unit_name()
@@ -288,7 +310,11 @@ impl ServiceStopOps for RealServiceStopOps {
 
     fn disable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
         Box::pin(async move {
-            run_cleanup_systemctl(&["disable", unit.service_name()], CLEANUP_ACTION_TIMEOUT).await
+            run_cleanup_systemctl(
+                &["disable", "--no-reload", unit.service_name()],
+                CLEANUP_ACTION_TIMEOUT,
+            )
+            .await
         })
     }
 
@@ -371,13 +397,13 @@ async fn stop_default_with_ops(
 
     // Clear "failed" latch so systemd fully unloads the transient unit.
     let _ = ops.reset_failed(unit).await;
-    if let Err(e) = ops.cleanup_drain_restart_override(unit).await {
-        warn!(unit = %unit.unit_name(), error = %e, "failed to remove drain restart override after stop");
-        eprintln!(
-            "WARNING: stop could not remove the drain restart override for {}: {e}.",
-            svc
-        );
-    }
+    ops.cleanup_drain_restart_override(unit)
+        .await
+        .map_err(|error| {
+            RunnerError::Internal(format!(
+                "stopped {svc}, but failed to make drain restart override cleanup effective: {error}"
+            ))
+        })?;
     Ok(())
 }
 
@@ -442,8 +468,9 @@ async fn stop_cleanup_with_ops(
     if let Err(e) = ops.reset_failed_bounded(unit).await {
         warn!(unit = %unit.unit_name(), error = %e, "failed to reset failed service state during cleanup");
     }
-    if let Err(e) = ops.cleanup_drain_restart_override_bounded(unit).await {
-        warn!(unit = %unit.unit_name(), error = %e, "failed to remove drain restart override during cleanup");
+    let drain_cleanup_result = ops.cleanup_drain_restart_override_bounded(unit).await;
+    if let Err(error) = &drain_cleanup_result {
+        warn!(unit = %unit.unit_name(), error = %error, "failed to remove drain restart override during cleanup");
     }
 
     let inactive_result = verify_cleanup_inactive(unit, ops, cleanup_escalated).await;
@@ -453,7 +480,9 @@ async fn stop_cleanup_with_ops(
         Ok(())
     };
 
-    combine_cleanup_postcondition_results(unit, inactive_result, disabled_result)
+    let postcondition_result =
+        combine_cleanup_postcondition_results(unit, inactive_result, disabled_result);
+    combine_cleanup_transition_results(unit, drain_cleanup_result, postcondition_result)
 }
 
 async fn verify_cleanup_not_enabled(
@@ -500,6 +529,23 @@ fn combine_cleanup_postcondition_results(
             "cleanup postconditions failed for {}: {inactive_error}; additionally: {disabled_error}",
             unit.service_name()
         ))),
+    }
+}
+
+fn combine_cleanup_transition_results(
+    unit: &RunnerServiceUnit,
+    drain_cleanup_result: RunnerResult<()>,
+    postcondition_result: RunnerResult<()>,
+) -> RunnerResult<()> {
+    match (drain_cleanup_result, postcondition_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(drain_cleanup_error), Err(postcondition_error)) => {
+            Err(RunnerError::Internal(format!(
+                "cleanup failed for {}: {drain_cleanup_error}; additionally: {postcondition_error}",
+                unit.service_name()
+            )))
+        }
     }
 }
 
@@ -834,6 +880,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stop_default_reports_drain_cleanup_failure() {
+        let unit = service_unit();
+        let home = fake_home();
+        let mut ops = FakeStopOps {
+            cleanup_drain_error: true,
+            ..FakeStopOps::default()
+        };
+
+        let error = stop_with_ops(&unit, &home, false, None, &mut ops)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed to make drain restart override cleanup effective")
+        );
+    }
+
+    #[tokio::test]
     async fn stop_force_without_cleanup_does_not_escalate_or_disable() {
         let unit = service_unit();
         let home = fake_home();
@@ -896,6 +962,28 @@ mod tests {
                 "cleanup_active_state",
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn stop_cleanup_reports_coordinated_reload_failure() {
+        let unit = service_unit();
+        let home = fake_home();
+        let mut ops = FakeStopOps {
+            cleanup_drain_error: true,
+            ..FakeStopOps::default()
+        };
+
+        let error = stop_with_ops(
+            &unit,
+            &home,
+            true,
+            Some(CleanupPolicy::PartialStart),
+            &mut ops,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("cleanup drain failed"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/service/stop.rs
+++ b/crates/runner/src/cmd/service/stop.rs
@@ -153,7 +153,7 @@ async fn reload_systemd_if_drain_restart_override_removed_bounded(
 
     let reload_result = coordinate_systemd_reload_bounded(
         unit,
-        SystemdReloadRequirement::Dirty,
+        SystemdReloadRequirement::dirty().with_drain_override(false),
         CLEANUP_LOCK_TIMEOUT,
         CLEANUP_ACTION_TIMEOUT,
     )
@@ -196,7 +196,7 @@ async fn restore_drain_restart_override_after_failed_cleanup_bounded(
     }
     if let Err(e) = coordinate_systemd_reload_bounded(
         unit,
-        SystemdReloadRequirement::Dirty,
+        SystemdReloadRequirement::dirty().with_drain_override(true),
         CLEANUP_LOCK_TIMEOUT,
         CLEANUP_ACTION_TIMEOUT,
     )

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -488,13 +488,52 @@ fn cleanup_unit_active_state_from_output(
     )
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SystemdUnitEnablement {
+    Enabled,
+    EnabledRuntime,
+    NotEnabled,
+}
+
+impl SystemdUnitEnablement {
+    fn is_enabled(self) -> bool {
+        matches!(self, Self::Enabled | Self::EnabledRuntime)
+    }
+}
+
+/// Read the unit-file enablement state needed for exact lifecycle rollback.
+pub(super) async fn read_unit_enablement(
+    unit: &RunnerServiceUnit,
+) -> RunnerResult<SystemdUnitEnablement> {
+    read_unit_enablement_bounded(unit, SYSTEMCTL_QUERY_TIMEOUT).await
+}
+
+pub(super) async fn restore_unit_enablement(
+    unit: &RunnerServiceUnit,
+    enablement: SystemdUnitEnablement,
+) -> RunnerResult<()> {
+    match enablement {
+        SystemdUnitEnablement::Enabled => {
+            run_systemctl(&["enable", "--no-reload", unit.service_name()]).await
+        }
+        SystemdUnitEnablement::EnabledRuntime => {
+            run_systemctl(&["enable", "--runtime", "--no-reload", unit.service_name()]).await
+        }
+        SystemdUnitEnablement::NotEnabled => {
+            run_systemctl(&["disable", "--no-reload", unit.service_name()]).await
+        }
+    }
+}
+
 /// Check whether systemd reports a unit file as enabled.
 ///
 /// Returns `true` for both the persistent `enabled` state and the transient
 /// `enabled-runtime` state. This does not indicate whether the unit is active
 /// or whether it will remain enabled after a reboot.
 pub(crate) async fn is_unit_enabled(unit: &RunnerServiceUnit) -> RunnerResult<bool> {
-    is_unit_enabled_bounded(unit, SYSTEMCTL_QUERY_TIMEOUT).await
+    read_unit_enablement(unit)
+        .await
+        .map(SystemdUnitEnablement::is_enabled)
 }
 
 /// Check whether systemd reports a unit file as enabled.
@@ -506,9 +545,18 @@ pub(super) async fn is_unit_enabled_bounded(
     unit: &RunnerServiceUnit,
     duration: Duration,
 ) -> RunnerResult<bool> {
+    read_unit_enablement_bounded(unit, duration)
+        .await
+        .map(SystemdUnitEnablement::is_enabled)
+}
+
+async fn read_unit_enablement_bounded(
+    unit: &RunnerServiceUnit,
+    duration: Duration,
+) -> RunnerResult<SystemdUnitEnablement> {
     let svc = unit.service_name();
     let output = run_command_output_bounded("systemctl", &["is-enabled", svc], duration).await?;
-    unit_enabled_from_systemctl_is_enabled(svc, &output.status, &output.stdout, &output.stderr)
+    unit_enablement_from_systemctl_is_enabled(svc, &output.status, &output.stdout, &output.stderr)
 }
 
 /// Check whether systemd currently reports a main process for a unit.
@@ -869,12 +917,12 @@ fn systemctl_cat_status_error(svc: &str, status: &ExitStatus, stderr: &str) -> R
     }
 }
 
-fn unit_enabled_from_systemctl_is_enabled(
+fn unit_enablement_from_systemctl_is_enabled(
     svc: &str,
     status: &ExitStatus,
     stdout: &[u8],
     stderr: &[u8],
-) -> RunnerResult<bool> {
+) -> RunnerResult<SystemdUnitEnablement> {
     let state = std::str::from_utf8(stdout).map_err(|e| {
         RunnerError::Internal(format!(
             "systemctl is-enabled {svc} returned non-UTF-8 output: {e}"
@@ -882,9 +930,12 @@ fn unit_enabled_from_systemctl_is_enabled(
     })?;
     let state = state.trim();
     match state {
-        "enabled" | "enabled-runtime" => Ok(true),
+        "enabled" => Ok(SystemdUnitEnablement::Enabled),
+        "enabled-runtime" => Ok(SystemdUnitEnablement::EnabledRuntime),
         "alias" | "disabled" | "generated" | "indirect" | "linked" | "linked-runtime"
-        | "masked" | "masked-runtime" | "not-found" | "static" | "transient" => Ok(false),
+        | "masked" | "masked-runtime" | "not-found" | "static" | "transient" => {
+            Ok(SystemdUnitEnablement::NotEnabled)
+        }
         "" if !status.success() => Err(systemctl_is_enabled_status_error(svc, status, stderr)),
         other if !status.success() => Err(RunnerError::Internal(format!(
             "unknown UnitFileState for {svc}: {other:?}; {}",
@@ -894,6 +945,17 @@ fn unit_enabled_from_systemctl_is_enabled(
             "unknown UnitFileState for {svc}: {other:?}"
         ))),
     }
+}
+
+#[cfg(test)]
+fn unit_enabled_from_systemctl_is_enabled(
+    svc: &str,
+    status: &ExitStatus,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> RunnerResult<bool> {
+    unit_enablement_from_systemctl_is_enabled(svc, status, stdout, stderr)
+        .map(SystemdUnitEnablement::is_enabled)
 }
 
 fn systemctl_is_enabled_status_error(svc: &str, status: &ExitStatus, stderr: &[u8]) -> RunnerError {
@@ -1667,6 +1729,22 @@ mod tests {
                 .unwrap()
             );
         }
+    }
+
+    #[test]
+    fn unit_enablement_preserves_runtime_only_state() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let status = ExitStatus::from_raw(0);
+        let enablement = unit_enablement_from_systemctl_is_enabled(
+            "vm0-runner-test.service",
+            &status,
+            b"enabled-runtime\n",
+            b"",
+        )
+        .unwrap();
+
+        assert_eq!(enablement, SystemdUnitEnablement::EnabledRuntime);
     }
 
     #[test]

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -252,6 +252,81 @@ pub(crate) async fn is_unit_active(unit: &RunnerServiceUnit) -> RunnerResult<boo
     unit_active_from_systemctl_show(svc, &properties, &output.status, &values, &output.stderr)
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SystemdUnitLoadState {
+    Stub,
+    Loaded,
+    NotFound,
+    BadSetting,
+    Error,
+    Merged,
+    Masked,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct SystemdReloadState {
+    load_state: SystemdUnitLoadState,
+    need_daemon_reload: bool,
+}
+
+impl SystemdReloadState {
+    pub(super) fn is_not_found(self) -> bool {
+        self.load_state == SystemdUnitLoadState::NotFound
+    }
+
+    pub(super) fn need_daemon_reload(self) -> bool {
+        self.need_daemon_reload
+    }
+
+    #[cfg(test)]
+    pub(super) fn for_test(is_not_found: bool, need_daemon_reload: bool) -> Self {
+        Self {
+            load_state: if is_not_found {
+                SystemdUnitLoadState::NotFound
+            } else {
+                SystemdUnitLoadState::Loaded
+            },
+            need_daemon_reload,
+        }
+    }
+}
+
+/// Read systemd's authoritative dirty state for reload coalescing.
+pub(super) async fn read_systemd_reload_state(
+    unit: &RunnerServiceUnit,
+) -> RunnerResult<SystemdReloadState> {
+    let svc = unit.service_name();
+    let properties = ["LoadState", "NeedDaemonReload"];
+    let output = run_systemctl_show(svc, &properties).await?;
+    systemd_reload_state_from_output(svc, &properties, &output)
+}
+
+/// Read systemd's authoritative dirty state with cleanup timeout semantics.
+pub(super) async fn read_systemd_reload_state_bounded(
+    unit: &RunnerServiceUnit,
+    duration: Duration,
+) -> RunnerResult<SystemdReloadState> {
+    let svc = unit.service_name();
+    let properties = ["LoadState", "NeedDaemonReload"];
+    let output = run_systemctl_show_bounded(svc, &properties, duration).await?;
+    systemd_reload_state_from_output(svc, &properties, &output)
+}
+
+fn systemd_reload_state_from_output(
+    svc: &str,
+    properties: &[&str],
+    output: &Output,
+) -> RunnerResult<SystemdReloadState> {
+    let values = parse_systemctl_show_output(svc, properties, output)?;
+    systemd_reload_state_from_systemctl_show(
+        svc,
+        properties,
+        &output.status,
+        &values,
+        &output.stderr,
+    )
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct CleanupUnitActiveState {
     active_state: String,
@@ -584,6 +659,58 @@ fn systemctl_property<'a>(
 fn classify_unit_active(svc: &str, load_state: &str, active_state: &str) -> RunnerResult<bool> {
     let normalized_state = normalize_unit_state(svc, load_state, active_state)?;
     Ok(normalized_state.is_active_like() && active_state != "deactivating")
+}
+
+fn parse_systemd_unit_load_state(svc: &str, value: &str) -> RunnerResult<SystemdUnitLoadState> {
+    match value {
+        "stub" => Ok(SystemdUnitLoadState::Stub),
+        "loaded" => Ok(SystemdUnitLoadState::Loaded),
+        "not-found" => Ok(SystemdUnitLoadState::NotFound),
+        "bad-setting" => Ok(SystemdUnitLoadState::BadSetting),
+        "error" => Ok(SystemdUnitLoadState::Error),
+        "merged" => Ok(SystemdUnitLoadState::Merged),
+        "masked" => Ok(SystemdUnitLoadState::Masked),
+        other => Err(RunnerError::Internal(format!(
+            "unknown LoadState for {svc}: {other:?}"
+        ))),
+    }
+}
+
+fn parse_systemd_boolean(svc: &str, property: &str, value: &str) -> RunnerResult<bool> {
+    match value {
+        "yes" => Ok(true),
+        "no" => Ok(false),
+        other => Err(RunnerError::Internal(format!(
+            "unknown {property} for {svc}: {other:?}"
+        ))),
+    }
+}
+
+fn systemd_reload_state_from_systemctl_show(
+    svc: &str,
+    properties: &[&str],
+    status: &ExitStatus,
+    values: &BTreeMap<String, String>,
+    stderr: &[u8],
+) -> RunnerResult<SystemdReloadState> {
+    let load_state =
+        parse_systemd_unit_load_state(svc, required_systemctl_property(svc, values, "LoadState")?)?;
+    let need_daemon_reload = parse_systemd_boolean(
+        svc,
+        "NeedDaemonReload",
+        required_systemctl_property(svc, values, "NeedDaemonReload")?,
+    )?;
+    ensure_systemctl_show_status(
+        svc,
+        properties,
+        status,
+        stderr,
+        load_state == SystemdUnitLoadState::NotFound,
+    )?;
+    Ok(SystemdReloadState {
+        load_state,
+        need_daemon_reload,
+    })
 }
 
 fn normalize_unit_state(
@@ -1081,6 +1208,80 @@ mod tests {
         let message = err.to_string();
 
         assert!(message.contains("empty systemctl show property"));
+    }
+
+    #[test]
+    fn systemd_reload_state_parses_loaded_dirty_unit() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "NeedDaemonReload"];
+        let output = systemctl_show_output(
+            ExitStatus::from_raw(0),
+            b"LoadState=loaded\nNeedDaemonReload=yes\n",
+            b"",
+        );
+
+        let state =
+            systemd_reload_state_from_output("vm0-runner-test.service", &properties, &output)
+                .unwrap();
+
+        assert!(!state.is_not_found());
+        assert!(state.need_daemon_reload());
+    }
+
+    #[test]
+    fn systemd_reload_state_accepts_not_found_with_failed_status() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "NeedDaemonReload"];
+        let output = systemctl_show_output(
+            ExitStatus::from_raw(0x100),
+            b"LoadState=not-found\nNeedDaemonReload=no\n",
+            b"Unit not found\n",
+        );
+
+        let state =
+            systemd_reload_state_from_output("vm0-runner-test.service", &properties, &output)
+                .unwrap();
+
+        assert!(state.is_not_found());
+        assert!(!state.need_daemon_reload());
+    }
+
+    #[test]
+    fn systemd_reload_state_rejects_unknown_boolean() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "NeedDaemonReload"];
+        let output = systemctl_show_output(
+            ExitStatus::from_raw(0),
+            b"LoadState=loaded\nNeedDaemonReload=maybe\n",
+            b"",
+        );
+
+        let error =
+            systemd_reload_state_from_output("vm0-runner-test.service", &properties, &output)
+                .unwrap_err();
+
+        assert!(error.to_string().contains("unknown NeedDaemonReload"));
+    }
+
+    #[test]
+    fn systemd_reload_state_rejects_unknown_load_state() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "NeedDaemonReload"];
+        let output = systemctl_show_output(
+            ExitStatus::from_raw(0),
+            b"LoadState=half-loaded\nNeedDaemonReload=yes\n",
+            b"",
+        );
+
+        let error =
+            systemd_reload_state_from_output("vm0-runner-test.service", &properties, &output)
+                .unwrap_err();
+
+        assert!(error.to_string().contains("unknown LoadState"));
     }
 
     #[test]

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -495,9 +495,26 @@ pub(super) enum SystemdUnitEnablement {
     NotEnabled,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SystemdEnablementRestoreAction {
+    Disable,
+    Enable,
+    EnableRuntime,
+}
+
 impl SystemdUnitEnablement {
     fn is_enabled(self) -> bool {
         matches!(self, Self::Enabled | Self::EnabledRuntime)
+    }
+
+    fn restore_actions(self) -> &'static [SystemdEnablementRestoreAction] {
+        use SystemdEnablementRestoreAction::{Disable, Enable, EnableRuntime};
+
+        match self {
+            Self::Enabled => &[Enable],
+            Self::EnabledRuntime => &[Disable, EnableRuntime],
+            Self::NotEnabled => &[Disable],
+        }
     }
 }
 
@@ -512,17 +529,20 @@ pub(super) async fn restore_unit_enablement(
     unit: &RunnerServiceUnit,
     enablement: SystemdUnitEnablement,
 ) -> RunnerResult<()> {
-    match enablement {
-        SystemdUnitEnablement::Enabled => {
-            run_systemctl(&["enable", "--no-reload", unit.service_name()]).await
-        }
-        SystemdUnitEnablement::EnabledRuntime => {
-            run_systemctl(&["enable", "--runtime", "--no-reload", unit.service_name()]).await
-        }
-        SystemdUnitEnablement::NotEnabled => {
-            run_systemctl(&["disable", "--no-reload", unit.service_name()]).await
+    for action in enablement.restore_actions() {
+        match action {
+            SystemdEnablementRestoreAction::Disable => {
+                run_systemctl(&["disable", "--no-reload", unit.service_name()]).await?;
+            }
+            SystemdEnablementRestoreAction::Enable => {
+                run_systemctl(&["enable", "--no-reload", unit.service_name()]).await?;
+            }
+            SystemdEnablementRestoreAction::EnableRuntime => {
+                run_systemctl(&["enable", "--runtime", "--no-reload", unit.service_name()]).await?;
+            }
         }
     }
+    Ok(())
 }
 
 /// Check whether systemd reports a unit file as enabled.
@@ -1745,6 +1765,13 @@ mod tests {
         .unwrap();
 
         assert_eq!(enablement, SystemdUnitEnablement::EnabledRuntime);
+        assert_eq!(
+            enablement.restore_actions(),
+            [
+                SystemdEnablementRestoreAction::Disable,
+                SystemdEnablementRestoreAction::EnableRuntime,
+            ]
+        );
     }
 
     #[test]

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -263,23 +263,35 @@ enum SystemdUnitLoadState {
     Masked,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct SystemdReloadState {
     load_state: SystemdUnitLoadState,
     need_daemon_reload: bool,
+    drop_in_paths: Vec<String>,
 }
 
 impl SystemdReloadState {
-    pub(super) fn is_not_found(self) -> bool {
+    pub(super) fn is_not_found(&self) -> bool {
         self.load_state == SystemdUnitLoadState::NotFound
     }
 
-    pub(super) fn need_daemon_reload(self) -> bool {
+    pub(super) fn need_daemon_reload(&self) -> bool {
         self.need_daemon_reload
     }
 
+    pub(super) fn has_drop_in_path(&self, path: &std::path::Path) -> bool {
+        let path = path.to_string_lossy();
+        self.drop_in_paths
+            .iter()
+            .any(|loaded| loaded == path.as_ref())
+    }
+
     #[cfg(test)]
-    pub(super) fn for_test(is_not_found: bool, need_daemon_reload: bool) -> Self {
+    pub(super) fn for_test(
+        is_not_found: bool,
+        need_daemon_reload: bool,
+        drop_in_paths: Vec<String>,
+    ) -> Self {
         Self {
             load_state: if is_not_found {
                 SystemdUnitLoadState::NotFound
@@ -287,6 +299,7 @@ impl SystemdReloadState {
                 SystemdUnitLoadState::Loaded
             },
             need_daemon_reload,
+            drop_in_paths,
         }
     }
 }
@@ -296,7 +309,7 @@ pub(super) async fn read_systemd_reload_state(
     unit: &RunnerServiceUnit,
 ) -> RunnerResult<SystemdReloadState> {
     let svc = unit.service_name();
-    let properties = ["LoadState", "NeedDaemonReload"];
+    let properties = ["LoadState", "NeedDaemonReload", "DropInPaths"];
     let output = run_systemctl_show(svc, &properties).await?;
     systemd_reload_state_from_output(svc, &properties, &output)
 }
@@ -307,7 +320,7 @@ pub(super) async fn read_systemd_reload_state_bounded(
     duration: Duration,
 ) -> RunnerResult<SystemdReloadState> {
     let svc = unit.service_name();
-    let properties = ["LoadState", "NeedDaemonReload"];
+    let properties = ["LoadState", "NeedDaemonReload", "DropInPaths"];
     let output = run_systemctl_show_bounded(svc, &properties, duration).await?;
     systemd_reload_state_from_output(svc, &properties, &output)
 }
@@ -768,6 +781,10 @@ fn systemd_reload_state_from_systemctl_show(
         "NeedDaemonReload",
         required_systemctl_property(svc, values, "NeedDaemonReload")?,
     )?;
+    let drop_in_paths = systemctl_property(svc, values, "DropInPaths")?
+        .split_ascii_whitespace()
+        .map(str::to_owned)
+        .collect();
     ensure_systemctl_show_status(
         svc,
         properties,
@@ -778,6 +795,7 @@ fn systemd_reload_state_from_systemctl_show(
     Ok(SystemdReloadState {
         load_state,
         need_daemon_reload,
+        drop_in_paths,
     })
 }
 
@@ -1296,10 +1314,10 @@ mod tests {
     fn systemd_reload_state_parses_loaded_dirty_unit() {
         use std::os::unix::process::ExitStatusExt;
 
-        let properties = ["LoadState", "NeedDaemonReload"];
+        let properties = ["LoadState", "NeedDaemonReload", "DropInPaths"];
         let output = systemctl_show_output(
             ExitStatus::from_raw(0),
-            b"LoadState=loaded\nNeedDaemonReload=yes\n",
+            b"LoadState=loaded\nNeedDaemonReload=yes\nDropInPaths=/run/systemd/system/vm0-runner-test.service.d/50-vm0-drain.conf\n",
             b"",
         );
 
@@ -1309,16 +1327,19 @@ mod tests {
 
         assert!(!state.is_not_found());
         assert!(state.need_daemon_reload());
+        assert!(state.has_drop_in_path(std::path::Path::new(
+            "/run/systemd/system/vm0-runner-test.service.d/50-vm0-drain.conf"
+        )));
     }
 
     #[test]
     fn systemd_reload_state_accepts_not_found_with_failed_status() {
         use std::os::unix::process::ExitStatusExt;
 
-        let properties = ["LoadState", "NeedDaemonReload"];
+        let properties = ["LoadState", "NeedDaemonReload", "DropInPaths"];
         let output = systemctl_show_output(
             ExitStatus::from_raw(0x100),
-            b"LoadState=not-found\nNeedDaemonReload=no\n",
+            b"LoadState=not-found\nNeedDaemonReload=no\nDropInPaths=\n",
             b"Unit not found\n",
         );
 
@@ -1334,10 +1355,10 @@ mod tests {
     fn systemd_reload_state_rejects_unknown_boolean() {
         use std::os::unix::process::ExitStatusExt;
 
-        let properties = ["LoadState", "NeedDaemonReload"];
+        let properties = ["LoadState", "NeedDaemonReload", "DropInPaths"];
         let output = systemctl_show_output(
             ExitStatus::from_raw(0),
-            b"LoadState=loaded\nNeedDaemonReload=maybe\n",
+            b"LoadState=loaded\nNeedDaemonReload=maybe\nDropInPaths=\n",
             b"",
         );
 
@@ -1352,10 +1373,10 @@ mod tests {
     fn systemd_reload_state_rejects_unknown_load_state() {
         use std::os::unix::process::ExitStatusExt;
 
-        let properties = ["LoadState", "NeedDaemonReload"];
+        let properties = ["LoadState", "NeedDaemonReload", "DropInPaths"];
         let output = systemctl_show_output(
             ExitStatus::from_raw(0),
-            b"LoadState=half-loaded\nNeedDaemonReload=yes\n",
+            b"LoadState=half-loaded\nNeedDaemonReload=yes\nDropInPaths=\n",
             b"",
         );
 

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -289,6 +289,11 @@ impl HomePaths {
         self.locks_dir().join(format!("service-{unit}.lock"))
     }
 
+    /// Host-global lock for systemd manager reload coordination.
+    pub fn systemd_daemon_reload_lock(&self) -> PathBuf {
+        self.locks_dir().join("systemd-daemon-reload.lock")
+    }
+
     pub fn base_dir_lock(&self, base_dir: &Path) -> PathBuf {
         self.locks_dir().join(base_dir_lock_name(base_dir))
     }
@@ -643,6 +648,16 @@ mod tests {
             PathBuf::from("/test/locks/service-vm0-runner-v1.2.3.lock")
         );
         assert_eq!(service_lock.parent(), Some(home.locks_dir().as_path()));
+    }
+
+    #[test]
+    fn systemd_daemon_reload_lock_path() {
+        let home = HomePaths::with_root(PathBuf::from("/test"));
+
+        assert_eq!(
+            home.systemd_daemon_reload_lock(),
+            PathBuf::from("/test/locks/systemd-daemon-reload.lock")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a stable host-global systemd reload coordinator that rechecks
  `LoadState`, `NeedDaemonReload`, and expected VM0 drain drop-in state under
  an exclusive flock
- batch runner service enablement changes with `--no-reload`, preserving
  install, uninstall, drain, resume, stop, cleanup, and rollback ordering
- preserve the shared lock across runner GC, align stale-runner Ansible
  cleanup, and add a real-metal concurrent reload-budget scenario

## Behavior

The existing per-unit service lock remains the outer lifecycle boundary. A
caller mutates its unit or drop-in, then briefly acquires the host-global lock
to query systemd and perform a reload only when the mutation is still dirty or
its expected effective state is not loaded. Concurrent different-name
operations can therefore share a completed manager reload instead of merely
queueing equivalent reload requests.

Install additionally reloads while a new unit remains `not-found`. Drain
drop-in additions and removals compare the exact VM0 path against systemd's
loaded `DropInPaths`; this covers transient units for which systemd 255 can
report `NeedDaemonReload=no` before the new drop-in is effective. Query failure
falls back to an unconditional reload. Bounded failed-start cleanup uses
bounded waits for the global lock and systemd commands. Failure paths restore
VM0-owned drain state and prior boot enablement, including preserving
runtime-only enablement, or return combined primary and rollback context.

## Compatibility

This changes no API, queue payload, database schema, persisted runner state,
guest contract, or runner/backend protocol. Old runner binaries remain
state-safe during rollout but can still issue redundant reloads until all
participating lifecycle processes contain the coordinator.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --bin runner cmd::service`
- `cargo test -p runner --bin runner cmd::gc::orphaned_locks`
- `cargo test -p runner --bin runner` (2,889 passed, 14 ignored child fixtures)
- `bash -n` for the changed runner behavior scripts
- `shellcheck` for the changed runner behavior scripts
- `.github/scripts/check-workflow-shell-compatibility.sh .github/workflows/crates.yml`
- `actionlint .github/workflows/crates.yml`
- `ansible-playbook -i localhost, ansible/playbooks/cleanup-crates-runner.yml --syntax-check`
- `git diff --check`
- read-only dev-1/dev-11 verification of the systemd 255 journal and
  `DropInPaths` output used by the metal assertions

Closes #24080
