### PR TITLE
ci: prewarm api deployment before migrations

### DIFF
--- a/.github/actions/vercel-promote/action.yml
+++ b/.github/actions/vercel-promote/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Max duration to wait for the promotion to complete (e.g. 60s, 2m). Vercel CLI default is 3m."
     required: false
     default: "60s"
+  skip-setup:
+    description: "Skip Vercel CLI installation and project configuration when the caller already initialized them"
+    required: false
+    default: "false"
 
 outputs:
   url:
@@ -28,6 +32,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Vercel
+      if: ${{ inputs.skip-setup != 'true' }}
       uses: ./.github/actions/vercel-setup
       with:
         vercel-token: ${{ inputs.vercel-token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -967,6 +967,13 @@ jobs:
         if: ${{ needs.release-please.outputs.api_release_created == 'true' }}
         uses: ./.github/actions/toolchain-init
 
+      - name: Initialize API deployment toolchain
+        uses: ./.github/actions/vercel-setup
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_API }}
+
       - name: Notify Slack - Migration Starting
         id: migration-slack-start
         if: ${{ needs.release-please.outputs.api_release_created == 'true' && vars.SLACK_RELEASE_CHANNEL_ID != '' }}
@@ -1123,6 +1130,7 @@ jobs:
           vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_API }}
           deployment-url: ${{ needs.build-api-production.outputs.deployment_url }}
+          skip-setup: "true"
 
       - name: Resolve Vercel dashboard URL
         id: vercel-dashboard

--- a/turbo/apps/api/src/__tests__/release-please-config.test.ts
+++ b/turbo/apps/api/src/__tests__/release-please-config.test.ts
@@ -111,7 +111,7 @@ describe("release-please API deployment graph", () => {
     expect(promoteApiProductionHeader).not.toContain("api_release_created");
   });
 
-  it("runs API release migrations immediately before promotion", () => {
+  it("prepares API promotion before release migrations", () => {
     const workflow = readText(".github/workflows/release-please.yml");
     const promoteApiProductionJob = workflowJobBlock(
       workflow,
@@ -119,6 +119,9 @@ describe("release-please API deployment graph", () => {
     );
     const migrationStep = promoteApiProductionJob.indexOf(
       "- name: Run Production Migrations",
+    );
+    const deploymentToolchainStep = promoteApiProductionJob.indexOf(
+      "- name: Initialize API deployment toolchain",
     );
     const promotionStep = promoteApiProductionJob.indexOf(
       "- name: Promote API Deployment",
@@ -130,8 +133,27 @@ describe("release-please API deployment graph", () => {
     expect(
       promoteApiProductionJob.match(/\.\/\.github\/actions\/toolchain-init/g),
     ).toHaveLength(1);
+    expect(
+      promoteApiProductionJob.match(/\.\/\.github\/actions\/vercel-setup/g),
+    ).toHaveLength(1);
+    expect(deploymentToolchainStep).toBeGreaterThan(-1);
     expect(migrationStep).toBeGreaterThan(-1);
+    expect(migrationStep).toBeGreaterThan(deploymentToolchainStep);
     expect(promotionStep).toBeGreaterThan(migrationStep);
+    expect(promoteApiProductionJob).toContain('skip-setup: "true"');
+  });
+
+  it("keeps Vercel setup enabled for other promotion callers", () => {
+    const action = readText(".github/actions/vercel-promote/action.yml");
+    const skipSetupInputStart = action.indexOf("  skip-setup:\n");
+    const outputsStart = action.indexOf("\noutputs:\n");
+
+    expect(skipSetupInputStart).toBeGreaterThan(-1);
+    expect(outputsStart).toBeGreaterThan(skipSetupInputStart);
+    expect(action.slice(skipSetupInputStart, outputsStart)).toContain(
+      'default: "false"',
+    );
+    expect(action).toContain(`if: \${{ inputs.skip-setup != 'true' }}`);
   });
 
   it("promotes App after the API production lifecycle", () => {


### PR DESCRIPTION
## Summary

- initialize the Vercel CLI and API project configuration before production migration work starts
- reuse the prepared Vercel toolchain for release promotion while keeping setup enabled by default for rollback callers
- cover the prewarm, migration, and promotion ordering plus the shared action default in the release configuration test

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (all non-API packages passed)
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api run lint`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/__tests__/release-please-config.test.ts` (6 tests, PostgreSQL 16 with pgvector)
- `actionlint .github/workflows/release-please.yml`
