### PR TITLE
refactor(api): write test trigger source explicitly

### DIFF
--- a/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
@@ -513,7 +513,7 @@ async function seedBackgroundLoad(): Promise<void> {
       });
       zRunRows.push({
         id: runId,
-        triggerSource: "cli",
+        triggerSource: "test",
         chatThreadId: threadIds[t]!,
       });
     }
@@ -629,7 +629,7 @@ async function seedTargetThreadRuns(
     });
     zRunRows.push({
       id: runId,
-      triggerSource: "cli",
+      triggerSource: "test",
       chatThreadId: fixture.threadId,
     });
     for (let m = 0; m < TARGET_MESSAGES_PER_RUN; m++) {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -3292,7 +3292,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       description: "Member isolation.",
       visibility: "private",
     });
-    const cliCompose = await createClaudeCompose(actor, "bdd-cli-logs");
+    const testCompose = await createClaudeCompose(actor, "bdd-test-logs");
     const authOrg = createAuthOrgAgentsBddApi(context);
     const agentOneName = (
       await authOrg.readComposeById(actor, agentOne.agentId)
@@ -3310,11 +3310,11 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       modelProvider: "anthropic-api-key",
     });
     await api.requestCancelRun(actor, secondAgentRun.runId, [200]);
-    const cliRun = await api.createDirectRun(actor, {
-      agentComposeId: cliCompose.composeId,
-      prompt: "direct cli run",
+    const testRun = await api.createDirectRun(actor, {
+      agentComposeId: testCompose.composeId,
+      prompt: "direct test run",
     });
-    await api.requestCancelRun(actor, cliRun.runId, [200]);
+    await api.requestCancelRun(actor, testRun.runId, [200]);
 
     const memberRun = await api.createRun(member, {
       agentId: memberAgent.agentId,
@@ -3329,7 +3329,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       return entry.id;
     });
     expect([...listedIds].sort()).toStrictEqual(
-      [webRun.runId, secondAgentRun.runId, cliRun.runId].sort(),
+      [webRun.runId, secondAgentRun.runId, testRun.runId].sort(),
     );
 
     const invalidListSince = await reads.requestListLogs(
@@ -3350,13 +3350,13 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       status: "cancelled",
       prompt: "web run on agent one",
     });
-    const cliEntry = listed.body.data.find((entry) => {
-      return entry.id === cliRun.runId;
+    const testEntry = listed.body.data.find((entry) => {
+      return entry.id === testRun.runId;
     });
-    expect(cliEntry).toMatchObject({
+    expect(testEntry).toMatchObject({
       agentId: null,
       displayName: null,
-      triggerSource: "cli",
+      triggerSource: "test",
     });
     const pageOne = await reads.requestListLogs(actor, { limit: 1 }, [200]);
     mustOk(pageOne, "the first log page");
@@ -3472,7 +3472,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
 
     expect(listed.body.filters.statuses).toContain("cancelled");
     expect([...listed.body.filters.sources].sort()).toStrictEqual([
-      "cli",
+      "test",
       "web",
     ]);
     expect(listed.body.filters.agents).toContain(agentOne.agentId);

--- a/turbo/apps/api/src/signals/routes/__tests__/test-agent-runs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-agent-runs.test.ts
@@ -7,11 +7,13 @@ import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockEnv } from "../../../lib/env";
 import { generateSandboxToken } from "../../auth/tokens";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { createRunReadsApi } from "./helpers/api-bdd-run-reads";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
 const bdd = createBddApi(context);
+const reads = createRunReadsApi(context);
 const runs = createRunsApi(context);
 const mocks = createZeroRouteMocks(context);
 
@@ -100,6 +102,14 @@ describe("POST /api/test/agent-runs", () => {
       runId: response.body.runId,
       prompt: "create a runner E2E fixture",
     });
+
+    const logs = await reads.requestListLogs(actor, {}, [200]);
+    expect(logs.body.data).toContainEqual(
+      expect.objectContaining({
+        id: response.body.runId,
+        triggerSource: "test",
+      }),
+    );
 
     await runs.requestCancelRun(actor, response.body.runId, [200]);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -956,7 +956,7 @@ describe("GET /api/zero/usage/record", () => {
     expect(response.body.pagination.total).toBe(1);
     expect(response.body.totalCredits).toBe(6);
     expect(response.body.rows[0]).toMatchObject({
-      source: "test",
+      source: "other",
       runId: run.runId,
       credits: 6,
       tokens: 0,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -835,7 +835,7 @@ describe("GET /api/zero/usage/record", () => {
 
     const run = await createUnthreadedRun(fixture.actor, {
       prompt: "Mixed media run",
-      triggerSource: "cli",
+      triggerSource: "test",
       createdAt: createdAt(5),
     });
     await recordModelUsage(fixture.actor, run.runId, model, {
@@ -922,7 +922,7 @@ describe("GET /api/zero/usage/record", () => {
 
     const run = await createUnthreadedRun(fixture.actor, {
       prompt: "Settlement boundary usage",
-      triggerSource: "cli",
+      triggerSource: "test",
     });
     const settledAt = new Date(nowDate().getTime() + 8 * DAY_MS);
     mockNow(settledAt);
@@ -956,7 +956,7 @@ describe("GET /api/zero/usage/record", () => {
     expect(response.body.pagination.total).toBe(1);
     expect(response.body.totalCredits).toBe(6);
     expect(response.body.rows[0]).toMatchObject({
-      source: "cli",
+      source: "test",
       runId: run.runId,
       credits: 6,
       tokens: 0,

--- a/turbo/apps/api/src/signals/routes/test-agent-runs.ts
+++ b/turbo/apps/api/src/signals/routes/test-agent-runs.ts
@@ -39,7 +39,7 @@ const createRunInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       return {
         userId: auth.userId,
         orgId: auth.orgId,
-        body: body.data,
+        body: { ...body.data, triggerSource: "test" as const },
         apiStartTime,
         modelProviderType: body.data.modelProviderType,
         timing,

--- a/turbo/apps/api/src/signals/routes/test-usage-insight-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-usage-insight-state.ts
@@ -409,7 +409,7 @@ async function seedRun(
   }
   await db.insert(zeroRuns).values({
     id: run.id,
-    triggerSource: args.triggerSource ?? "cli",
+    triggerSource: args.triggerSource ?? "test",
     chatThreadId: args.chatThreadId ?? null,
     selectedModel: args.selectedModel ?? null,
   });

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -9,6 +9,7 @@ import {
   type StoredConnectorPermissionBaseline,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
+import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
 import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import type {
@@ -285,7 +286,12 @@ const COUNT_BUCKET_DIMENSIONS = [
   "17_plus",
 ] as const;
 
-type CreateRunBody = z.infer<typeof unifiedRunRequestSchema>;
+type CreateRunBody = Omit<
+  z.infer<typeof unifiedRunRequestSchema>,
+  "triggerSource"
+> & {
+  readonly triggerSource: TriggerSource;
+};
 type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
 const CODEX_WEB_IMAGE_GENERATION_UPLOAD_PROMPT =
@@ -5015,7 +5021,7 @@ async function insertZeroRunRecord(
   const metadata: ZeroRunMetadata = args.zeroRunMetadata ?? {};
   await tx.insert(zeroRuns).values({
     id: args.runId,
-    triggerSource: args.body.triggerSource ?? "cli",
+    triggerSource: args.body.triggerSource,
     workflowAutomationId: metadata.workflowAutomationId ?? null,
     triggerBrief: metadata.triggerBrief ?? null,
     runGroupId: metadata.runGroupId ?? null,

--- a/turbo/apps/api/src/test-fixtures/agent-runs.ts
+++ b/turbo/apps/api/src/test-fixtures/agent-runs.ts
@@ -7,6 +7,7 @@
  * product behavior through the remaining production routes.
  */
 import { createStore } from "ccstate";
+import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 
 import { now } from "../lib/time";
 import {
@@ -17,7 +18,12 @@ import { agentRunList } from "../signals/services/zero-runs.service";
 
 const store = createStore();
 
-export type DirectRunFixtureRequest = CreateAgentRunArgs["body"];
+export type DirectRunFixtureRequest = Omit<
+  CreateAgentRunArgs["body"],
+  "triggerSource"
+> & {
+  readonly triggerSource?: TriggerSource;
+};
 
 export async function createDirectRunFixture(args: {
   readonly userId: string;
@@ -32,7 +38,10 @@ export async function createDirectRunFixture(args: {
       orgId: args.orgId,
       apiStartTime: now(),
       modelProviderType: args.body.modelProviderType,
-      body: args.body,
+      body: {
+        ...args.body,
+        triggerSource: args.body.triggerSource ?? "test",
+      },
     },
     args.signal,
   );

--- a/turbo/apps/api/src/test-fixtures/thread-bound-run-admission.ts
+++ b/turbo/apps/api/src/test-fixtures/thread-bound-run-admission.ts
@@ -50,6 +50,7 @@ export async function createUnassociatedThreadBoundAgentRunFixture(
       orgId: ORG_ID,
       body: {
         prompt: "must be rejected before agent run preparation",
+        triggerSource: "test",
       },
       apiStartTime: now(),
       chatThreadId,


### PR DESCRIPTION
## Summary

- write `triggerSource: "test"` from the test-only direct-run route
- make the agent-run service boundary require every caller to provide `triggerSource`, removing the `"cli"` write fallback
- default direct-run test fixtures and test-only seed state to `"test"`, and update dependent test and benchmark expectations
- keep `"cli"` readable for historical rows and leave the historical null read fallbacks unchanged

## Deployment sequencing

This is the Phase 2-b **write-side** release for #23985. The prerequisite read-side change in #24094 shipped as `api-v1.352.0` and has completed deployment. Before starting this change, production telemetry confirmed the serving API commit is the `api-v1.353.0` release commit, so all serving instances can parse `triggerSource: "test"`.

## Validation

- `pnpm exec prettier --write --ignore-unknown . --log-level warn`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`

Per issue scope, no local full Vitest suite or dev server was run. A focused Vitest attempt was blocked by the existing local database migration contraction gate for legacy connector identity constraints; the gate was not bypassed or weakened. PR CI provides the API integration and runner E2E coverage.

Closes #24107