### PR TITLE
fix(api): refresh API release marker comment

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createApp } from "./app-factory";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed again on 2026-07-28)
+// (no-op API release marker refreshed after the 2026-07-30 workflow update)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Summary

- refresh the existing no-op API release marker comment
- intentionally trigger a release-please API release after the prior release workflow was not scheduled

## Behavior

Comment-only change; no runtime behavior changes.

## Validation

- `git diff --check`