### PR TITLE
fix(runner): preserve upstream bindings across flows

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -778,7 +778,6 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
             send_response=False,
         )
         flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
-        upstream_admission.forget_server_binding(flow.server_conn)
         flow.kill()
         return None
 
@@ -791,7 +790,6 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
         )
     ):
         flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
-        upstream_admission.forget_server_binding(flow.server_conn)
         return None
 
     _prebind_requestheaders_upstream_destination(flow, classification)
@@ -820,7 +818,6 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
                 )
             request_classification.pop_cached_classification(flow)
             flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
-            upstream_admission.forget_server_binding(flow.server_conn)
             flow.kill()
             return None
 
@@ -844,7 +841,6 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
                 )
                 request_classification.pop_cached_classification(flow)
                 flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
-                upstream_admission.forget_server_binding(flow.server_conn)
                 flow.kill()
                 return None
             try:
@@ -944,7 +940,6 @@ def _admit_buffered_aws_sigv4_request(
             )
         request_classification.pop_cached_classification(flow)
         flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
-        upstream_admission.forget_server_binding(flow.server_conn)
         flow.kill()
         return
 
@@ -962,7 +957,6 @@ def _admit_buffered_aws_sigv4_request(
         )
         request_classification.pop_cached_classification(flow)
         flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
-        upstream_admission.forget_server_binding(flow.server_conn)
         flow.kill()
         return
 
@@ -1029,7 +1023,6 @@ async def _try_firewall_request_stream_from_headers(
         )
     except (asyncio.CancelledError, Exception):
         _restore_request_headers_probe_metadata(flow, metadata_snapshot)
-        upstream_admission.forget_server_binding(flow.server_conn)
         raise
     if result is not FirewallHeaderPhaseAuthResult.APPLIED:
         fall_back()
@@ -1048,8 +1041,6 @@ async def _try_firewall_request_stream_from_headers(
     )
     if flow.response is None:
         request_streaming.configure_request_stream(flow, capture_body=capture_body)
-    else:
-        upstream_admission.forget_server_binding(flow.server_conn)
 
 
 def _set_firewall_block_response(flow: http.HTTPFlow, result: matching.FirewallBlock) -> None:
@@ -1134,14 +1125,12 @@ async def request(flow: http.HTTPFlow) -> None:
     if flow.metadata.get(_REQUEST_HEADERS_TERMINATED):
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)
         aws_sigv4_body_admission.release_from_flow(flow)
-        upstream_admission.forget_server_binding(flow.server_conn)
         request_classification.pop_cached_classification(flow)
         return
 
     if flow.response is not None or flow.error is not None:
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)
         aws_sigv4_body_admission.release_from_flow(flow)
-        upstream_admission.forget_server_binding(flow.server_conn)
         request_classification.pop_cached_classification(flow)
         return
 
@@ -1277,8 +1266,6 @@ async def request(flow: http.HTTPFlow) -> None:
                     flow,
                     request_end_stream=True,
                 )
-                if flow.response is not None:
-                    upstream_admission.forget_server_binding(flow.server_conn)
             return
 
         if classification.kind == "allow":
@@ -1300,12 +1287,9 @@ async def request(flow: http.HTTPFlow) -> None:
         flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)
         aws_sigv4_body_admission.release_from_flow(flow)
-        upstream_admission.forget_server_binding(flow.server_conn)
         terminal_usage.release_tracked_flow(flow)
         raise
     finally:
-        if flow.response is not None or flow.error is not None:
-            upstream_admission.forget_server_binding(flow.server_conn)
         request_classification.pop_cached_classification(flow)
 
 
@@ -1512,8 +1496,6 @@ def _release_terminal_flow_state(
     auth_base_forwarder.release_forward_request_admission_from_flow(flow)
     if release_aws_sigv4_body_admission:
         aws_sigv4_body_admission.release_from_flow(flow)
-    if flow.error is not None:
-        upstream_admission.forget_server_binding(flow.server_conn)
     if release_tracking:
         terminal_usage.release_tracked_flow(flow)
 

--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -8,9 +8,9 @@ reuse can fall back to earlier bindings from the same client.
 Direct server bindings take precedence over client-associated fallback
 bindings. Connected flows must be proven by authoritative endpoint evidence
 from the live connection; fresh DNS is not proof that a connected upstream is
-still the trusted destination. Callers must discard bindings when mitmproxy
-reports disconnects, connect errors, local responses, request errors, or
-header-phase termination.
+still the trusted destination. Bindings live for the server connection and are
+discarded when mitmproxy reports a server disconnect, connect error, or
+associated client disconnect.
 """
 
 import ipaddress

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -4,6 +4,7 @@ import json
 import time
 import uuid
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from mitmproxy.flow import Error
@@ -36,7 +37,7 @@ from tests.upstream_connection_helpers import seed_server_binding
 
 
 class TestErrorHandler:
-    def test_error_clears_upstream_binding(self, real_flow, mitm_ctx):
+    def test_error_preserves_upstream_binding_until_server_disconnect(self, real_flow, mitm_ctx):
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -55,6 +56,10 @@ class TestErrorHandler:
         with mitm_ctx():
             flow.error = Error("connection reset by peer")
             mitm_addon.error(flow)
+
+        assert flow.server_conn.id in upstream_destination_binding.binding_snapshot_for_tests()
+
+        mitm_addon.server_disconnected(SimpleNamespace(server=flow.server_conn))
 
         assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_auth_base_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_auth_base_body.py
@@ -151,7 +151,7 @@ async def test_auth_base_requestheaders_rejects_oversized_content_length_before_
     assert flow.error.msg == Error.KILLED_MESSAGE
     assert flow.live is False
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_base_request_body_too_large"
-    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    assert flow.server_conn.id in upstream_destination_binding.binding_snapshot_for_tests()
 
     network_log_text = read_jsonl_text_after_flush(tmp_path / "net.jsonl")
     network_log_entry = json.loads(network_log_text)
@@ -471,7 +471,7 @@ async def test_auth_base_requestheaders_admission_released_after_success(
     assert flow.response is not None
     assert flow.response.status_code == 202
     assert flow.response.content == b"accepted"
-    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    assert flow.server_conn.id in upstream_destination_binding.binding_snapshot_for_tests()
     assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
 
 
@@ -643,5 +643,5 @@ async def test_auth_base_requestheaders_admission_released_when_request_already_
     assert flow.response is not None
     assert flow.response.status_code == 204
     assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION not in flow.metadata
-    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    assert flow.server_conn.id in upstream_destination_binding.binding_snapshot_for_tests()
     assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -72,7 +72,9 @@ async def test_rejects_spoofed_host_before_firewall_auth(
     }
     auth_fetch.assert_not_called()
     assert "Authorization" not in flow.request.headers
-    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    binding = upstream_destination_binding.binding_snapshot_for_tests()[flow.server_conn.id]
+    assert binding.host == "api.github.com"
+    assert binding.kinds == frozenset(("connector_auth",))
 
 
 async def test_authority_validation_deny_response_logs_network_target(

--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_admission.py
@@ -691,7 +691,9 @@ async def test_test_connector_without_bypass_does_not_extend_existing_api_allow_
     assert flow.response.status_code == 403
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "upstream_destination_unbound"
     assert "Authorization" not in flow.request.headers
-    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    binding = upstream_destination_binding.binding_snapshot_for_tests()[flow.server_conn.id]
+    assert binding.host == "api.vm0.ai"
+    assert binding.kinds == frozenset(("api_allow",))
 
 
 async def test_test_connector_unconnected_without_bypass_blocks_before_binding(
@@ -763,7 +765,10 @@ async def test_test_connector_without_bypass_does_not_reuse_connector_auth_bindi
     assert flow.response.status_code == 403
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "upstream_destination_unbound"
     assert "Authorization" not in flow.request.headers
-    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    binding = upstream_destination_binding.binding_snapshot_for_tests()[flow.server_conn.id]
+    assert binding.host == "api.vm0.ai"
+    assert binding.kinds == frozenset(("api_allow", "connector_auth"))
+    assert binding.original_address == ("203.0.113.10", 443)
 
 
 async def test_test_connector_rejects_stale_unconnected_api_allow_binding(
@@ -803,7 +808,10 @@ async def test_test_connector_rejects_stale_unconnected_api_allow_binding(
     assert flow.response.status_code == 403
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "upstream_destination_unbound"
     assert "Authorization" not in flow.request.headers
-    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    binding = upstream_destination_binding.binding_snapshot_for_tests()[flow.server_conn.id]
+    assert binding.host == "api.vm0.ai"
+    assert binding.kinds == frozenset(("api_allow",))
+    assert binding.original_address == ("203.0.113.10", 443)
 
 
 async def test_test_connector_rejects_mismatched_existing_binding(
@@ -843,7 +851,9 @@ async def test_test_connector_rejects_mismatched_existing_binding(
     assert flow.response.status_code == 403
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "upstream_destination_unbound"
     assert "Authorization" not in flow.request.headers
-    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    binding = upstream_destination_binding.binding_snapshot_for_tests()[flow.server_conn.id]
+    assert binding.host == "api.github.com"
+    assert binding.kinds == frozenset(("api_allow",))
 
 
 async def test_matching_sni_and_host_blocks_test_connector_api_edge_without_bypass(

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -16,6 +16,7 @@ import mitm_addon
 import upstream_destination_binding
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
+from tests.firewall_helpers import cancel_pending_task
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import (
     _shared_route_vm,
@@ -24,7 +25,7 @@ from tests.request_handler_helpers import (
     _write_registry,
 )
 from tests.requestheaders_helpers import await_requestheaders_result
-from tests.upstream_connection_helpers import seed_server_binding
+from tests.upstream_connection_helpers import mark_connected_tls_upstream, seed_server_binding
 
 
 def _resolved_firewall_auth() -> auth_client.FirewallAuthSuccess:
@@ -420,7 +421,103 @@ async def test_firewall_permission_blocks_unmatched(tmp_path, real_flow, mitm_ct
     assert proxy_log_entry["type"] == "firewall_block"
     assert proxy_log_entry["name"] == "github"
     assert proxy_log_entry["reason"] == "unknown_endpoint"
-    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    assert flow.server_conn.id in upstream_destination_binding.binding_snapshot_for_tests()
+
+
+async def test_local_response_preserves_shared_binding_for_concurrent_auth(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                "permissions": [
+                    {
+                        "name": "read-repos",
+                        "rules": ["GET /repos/{owner}/{repo}"],
+                    },
+                ],
+            },
+            network_policy={
+                "allow": ["read-repos"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+        ),
+    )
+    allowed_flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path="/repos/octocat/hello",
+        request_headers=headers(("Host", "api.github.com")),
+    )
+    mark_connected_tls_upstream(
+        allowed_flow,
+        sni="api.github.com",
+        server_address=("203.0.113.10", 443),
+        peername=("203.0.113.10", 443),
+    )
+    denied_flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path="/orgs",
+        request_headers=headers(("Host", "api.github.com")),
+    )
+    denied_flow.client_conn = allowed_flow.client_conn
+    denied_flow.server_conn = allowed_flow.server_conn
+
+    auth_resolution_entered = asyncio.Event()
+    release_auth_resolution = asyncio.Event()
+
+    async def resolve_auth(*_args, **_kwargs):
+        auth_resolution_entered.set()
+        await release_auth_resolution.wait()
+        return {
+            "headers": {"Authorization": "Bearer resolved"},
+            "resolved_secrets": [],
+            "refreshed_connectors": [],
+            "refreshed_secrets": [],
+            "cache_hit": False,
+        }
+
+    auth_fetch = AsyncMock(side_effect=resolve_auth)
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", auth_fetch),
+    ):
+        allowed_task = asyncio.create_task(mitm_addon.request(allowed_flow))
+        try:
+            await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
+            assert (
+                allowed_flow.server_conn.id
+                in upstream_destination_binding.binding_snapshot_for_tests()
+            )
+
+            await mitm_addon.request(denied_flow)
+
+            assert denied_flow.response is not None
+            assert denied_flow.response.status_code == 403
+            assert (
+                allowed_flow.server_conn.id
+                in upstream_destination_binding.binding_snapshot_for_tests()
+            )
+
+            release_auth_resolution.set()
+            await allowed_task
+        finally:
+            release_auth_resolution.set()
+            await cancel_pending_task(allowed_task)
+
+    auth_fetch.assert_awaited_once()
+    assert allowed_flow.response is None
+    assert allowed_flow.request.headers["Authorization"] == "Bearer resolved"
+    assert allowed_flow.metadata.get(metadata_keys.FIREWALL_ERROR) is None
 
 
 @pytest.mark.parametrize(
@@ -1397,7 +1494,7 @@ async def test_https_firewall_with_ordinary_credentials_blocks_when_upstream_is_
     assert "Authorization" not in flow.request.headers
 
 
-async def test_firewall_auth_cancellation_clears_upstream_binding(
+async def test_firewall_auth_cancellation_preserves_upstream_binding(
     tmp_path, real_flow, mitm_ctx, headers
 ):
     reg_path = _write_registry(
@@ -1433,10 +1530,12 @@ async def test_firewall_auth_cancellation_clears_upstream_binding(
     ):
         await mitm_addon.request(flow)
 
-    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    assert flow.server_conn.id in upstream_destination_binding.binding_snapshot_for_tests()
 
 
-async def test_request_stream_metadata_error_clears_upstream_binding(tmp_path, real_flow, mitm_ctx):
+async def test_request_stream_metadata_error_preserves_upstream_binding(
+    tmp_path, real_flow, mitm_ctx
+):
     reg_path = _write_github_firewall_registry(tmp_path)
     flow = real_flow(
         with_response=False,
@@ -1460,7 +1559,7 @@ async def test_request_stream_metadata_error_clears_upstream_binding(tmp_path, r
     ):
         await mitm_addon.request(flow)
 
-    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    assert flow.server_conn.id in upstream_destination_binding.binding_snapshot_for_tests()
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -509,7 +509,7 @@ async def test_local_response_preserves_shared_binding_for_concurrent_auth(
             )
 
             release_auth_resolution.set()
-            await allowed_task
+            _ = await allowed_task
         finally:
             release_auth_resolution.set()
             await cancel_pending_task(allowed_task)

--- a/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
@@ -317,7 +317,11 @@ async def test_public_destination_upstream_change_during_auth_prevents_credentia
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "upstream_destination_unbound"
     assert flow.request.headers.fields == original_headers
     assert flow.request.path == original_path
-    assert flow.server_conn.id not in upstream_destination_binding.binding_snapshot_for_tests()
+    binding_snapshot = upstream_destination_binding.binding_snapshot_for_tests()
+    if upstream_change == "completed":
+        assert flow.server_conn.id not in binding_snapshot
+    else:
+        assert flow.server_conn.id in binding_snapshot
 
 
 async def test_public_destination_policy_allow_classifies_public_runtime_destination_once(

--- a/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
@@ -82,7 +82,7 @@ async def test_firewall_allow_current_server_binding_address_mismatch_blocks(
     assert diagnostics["direct_binding_present"] is True
     assert diagnostics["server_connected"] is False
     assert diagnostics["server_address"] == "203.0.113.99:443"
-    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    assert flow.server_conn.id in upstream_destination_binding.binding_snapshot_for_tests()
 
 
 async def test_test_connector_bounded_requestheaders_uses_connector_binding(

--- a/crates/runner/mitm-addon/tests/test_request_headers_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_firewall_auth.py
@@ -340,7 +340,7 @@ async def test_firewall_allow_header_auth_failure_falls_back_to_request_hook(
         else "auth_failed"
     )
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == expected_error
-    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    assert flow.server_conn.id in upstream_destination_binding.binding_snapshot_for_tests()
 
 
 async def test_firewall_allow_header_auth_cancellation_restores_probe_state(
@@ -381,7 +381,7 @@ async def test_firewall_allow_header_auth_cancellation_restores_probe_state(
     assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
     assert metadata_keys.FIREWALL_BASE not in flow.metadata
     assert metadata_keys.FIREWALL_API_ID not in flow.metadata
-    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    assert flow.server_conn.id in upstream_destination_binding.binding_snapshot_for_tests()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- make upstream destination bindings live for the mitmproxy server/client connection instead of an individual HTTP flow
- preserve shared binding evidence across local responses, cancellations, request exceptions, and HTTP stream errors
- add a deterministic concurrent-flow regression and retain fail-closed destination revalidation coverage

## Problem

Upstream bindings are keyed by server connection ID, but flow-local terminal paths deleted the entire connection binding. A denied HTTP/2 stream could therefore revoke the binding while a sibling stream was waiting for firewall auth, causing the valid sibling to fail with `upstream_destination_unbound`.

## Solution

Binding deletion is now owned exclusively by the existing `server_disconnected`, `server_connect_error`, and `client_disconnected` lifecycle paths. Flow-local hooks continue to release their own admission, streaming, classification, diagnostic, and usage state.

The existing post-auth guard is unchanged and still requires the same server object, connected state, trusted authority and port, binding kind, verified TLS endpoint, public destination, and built-in host policy.

No database, schema, persisted-state, API, queue, or runner protocol changes are included.

## Validation

- `uv lock --check`
- `uv sync --locked`
- focused affected integration tests: `278 passed`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/`: `4482 passed`
- `git diff --check`

Closes #24045
