### PR TITLE
refactor(connectors): write canonical authorization state

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/connector-authorization-provider-state.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-authorization-provider-state.test.ts
@@ -97,7 +97,7 @@ describe("connector OAuth device provider state", () => {
     }).toThrow("OAuth device provider state connector type mismatch");
   });
 
-  it("serializes the exact legacy-only state with poll state", () => {
+  it("serializes and parses the exact canonical-only state with poll state", () => {
     const serializedState = serializeConnectorOauthDeviceProviderState({
       connectorSlug,
       deviceCode: "device-code",
@@ -105,19 +105,42 @@ describe("connector OAuth device provider state", () => {
     });
 
     expect(serializedState).toBe(
-      '{"connectorType":"slack","deviceCode":"device-code","pollState":"poll-state"}',
+      '{"connectorSlug":"slack","deviceCode":"device-code","pollState":"poll-state"}',
     );
-    expect(serializedState).not.toContain("connectorSlug");
+    expect(serializedState).not.toContain("connectorType");
+    expect(
+      parseConnectorOauthDeviceProviderState({
+        serializedState,
+        connectorSlug,
+      }),
+    ).toStrictEqual({
+      connectorSlug,
+      deviceCode: "device-code",
+      pollState: "poll-state",
+    });
   });
 
-  it("omits absent poll state from the legacy-only state", () => {
+  it("omits absent poll state from the canonical-only state", () => {
+    const serializedState = serializeConnectorOauthDeviceProviderState({
+      connectorSlug,
+      deviceCode: "device-code",
+      pollState: undefined,
+    });
+
+    expect(serializedState).toBe(
+      '{"connectorSlug":"slack","deviceCode":"device-code"}',
+    );
+    expect(serializedState).not.toContain("connectorType");
     expect(
-      serializeConnectorOauthDeviceProviderState({
+      parseConnectorOauthDeviceProviderState({
+        serializedState,
         connectorSlug,
-        deviceCode: "device-code",
-        pollState: undefined,
       }),
-    ).toBe('{"connectorType":"slack","deviceCode":"device-code"}');
+    ).toStrictEqual({
+      connectorSlug,
+      deviceCode: "device-code",
+      pollState: undefined,
+    });
   });
 });
 
@@ -212,7 +235,7 @@ describe("connector external-code provider state", () => {
     }).toThrow("External-code provider state connector method mismatch");
   });
 
-  it("serializes the exact legacy-only state", () => {
+  it("serializes and parses the exact canonical-only state", () => {
     const serializedState = serializeConnectorExternalCodeProviderState({
       connectorSlug,
       authMethod,
@@ -220,8 +243,19 @@ describe("connector external-code provider state", () => {
     });
 
     expect(serializedState).toBe(
-      '{"connectorType":"slack","authMethod":"oauth","providerState":"provider-state"}',
+      '{"connectorSlug":"slack","authMethod":"oauth","providerState":"provider-state"}',
     );
-    expect(serializedState).not.toContain("connectorSlug");
+    expect(serializedState).not.toContain("connectorType");
+    expect(
+      parseConnectorExternalCodeProviderState({
+        serializedState,
+        connectorSlug,
+        authMethod,
+      }),
+    ).toStrictEqual({
+      connectorSlug,
+      authMethod,
+      providerState: "provider-state",
+    });
   });
 });

--- a/turbo/apps/api/src/signals/services/connector-authorization-provider-state.ts
+++ b/turbo/apps/api/src/signals/services/connector-authorization-provider-state.ts
@@ -96,9 +96,8 @@ export function serializeConnectorOauthDeviceProviderState(args: {
   readonly deviceCode: string;
   readonly pollState: string | undefined;
 }): string {
-  // #24075 switches this legacy-only writer after the prepared reader deploys.
   return JSON.stringify({
-    connectorType: args.connectorSlug,
+    connectorSlug: args.connectorSlug,
     deviceCode: args.deviceCode,
     ...(args.pollState === undefined ? {} : { pollState: args.pollState }),
   });
@@ -126,9 +125,8 @@ export function serializeConnectorExternalCodeProviderState(args: {
   readonly authMethod: ConnectorAuthMethodId;
   readonly providerState: string;
 }): string {
-  // #24075 switches this legacy-only writer after the prepared reader deploys.
   return JSON.stringify({
-    connectorType: args.connectorSlug,
+    connectorSlug: args.connectorSlug,
     authMethod: args.authMethod,
     providerState: args.providerState,
   });


### PR DESCRIPTION
## Summary

- switch connector OAuth device-auth persisted state to canonical-only
  `connectorSlug`
- switch connector external-code persisted state to canonical-only
  `connectorSlug`
- pin exact canonical output and round-trip it through the deployed transition
  reader
- retain legacy-only reader coverage for active pre-cutover sessions

## Compatibility

- #24073 / #24088 is the deployed reader floor and accepts both legacy-only and
  canonical-only state
- dual-identity documents remain rejected and are never emitted
- after canonical writes begin, rollback must not go earlier than #24073
- #24075 remains open until Gate 2 completes; #24077 remains blocked until then

## Exclusions

- no database schema or data migration
- no public API or contract change
- no feature switch
- no service call-site, encryption, transaction, lifecycle, or provider change
- no legacy-reader cleanup; that remains in #24077

## Validation

- `pnpm -F api exec vitest run src/signals/services/__tests__/connector-authorization-provider-state.test.ts` — 15 passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts` — 43 passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-external-code.bdd.test.ts` — 9 passed
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- pre-commit formatter, Knip, repository type checks, file-size check, and commitlint

Refs #24075

Parent: #23770
