### PR TITLE
test(python): cover corrupt trailing zlib members after decoded usage

### DIFF
--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -134,6 +134,24 @@ class TestStreamDecodeSession:
         assert session.finish_error() == "incomplete compressed body"
 
     @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_zlib_session_reports_corrupt_member_after_decoded_payload(self, headers, encoding):
+        plaintext = b'{"model":"claude-sonnet-4-6","usage":{"input_tokens":42}}'
+        trailing_member = bytearray(_compress_one_shot_body(encoding, b""))
+        checksum_offset = -8 if encoding == "gzip" else -1
+        trailing_member[checksum_offset] ^= 0xFF
+        compressed = _compress_one_shot_body(encoding, plaintext) + bytes(trailing_member)
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(
+            headers(("Content-Encoding", encoding)), chunks.append
+        )
+        assert session is not None
+
+        session.feed(compressed)
+
+        assert b"".join(chunks) == plaintext
+        assert session.finish_error() == "invalid compressed body"
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
     def test_concatenated_zlib_members_same_callback(self, headers, encoding):
         plaintext = b'{"model":"claude-sonnet-4-6","usage":{"input_tokens":42}}'
         if encoding == "gzip":

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
@@ -337,6 +337,46 @@ class TestModelProviderJsonStreaming:
         assert usage_warnings[0]["error"] == "incomplete compressed body"
 
     @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
+    def test_full_pipeline_corrupt_trailing_zlib_member_does_not_report_decoded_usage(
+        self, tmp_path, real_flow, encoding_case
+    ):
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow = model_provider_flow(
+            real_flow,
+            tmp_path,
+            ANTHROPIC_JSON_CASE,
+            proxy_log_path=proxy_log_path,
+        )
+        payload = standard_success_payload(ANTHROPIC_JSON_CASE)
+        compress = gzip.compress if encoding_case == "gzip" else zlib.compress
+        trailing_member = bytearray(compress(b""))
+        checksum_offset = -8 if encoding_case == "gzip" else -1
+        trailing_member[checksum_offset] ^= 0xFF
+        compressed = compress(payload) + bytes(trailing_member)
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map(
+                {"content-type": "application/json", "content-encoding": encoding_case}
+            ),
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(compressed)
+
+        webhook = run_response(flow, self._usage_webhook_api)
+
+        assert webhook.request_count == 0
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
+        entries = read_jsonl_entries_after_flush(proxy_log_path)
+        usage_warnings = [
+            entry
+            for entry in entries
+            if entry.get("message") == "Model provider JSON usage extraction failed"
+        ]
+        assert len(usage_warnings) == 1
+        assert usage_warnings[0]["error"] == "invalid compressed body"
+
+    @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
     def test_full_pipeline_concatenated_zlib_model_json_reports_usage(
         self, tmp_path, real_flow, encoding_case
     ):


### PR DESCRIPTION
## Summary

- cover gzip and deflate streams that emit a complete payload before a corrupt trailing member fails checksum validation
- verify the real model-provider JSON pipeline suppresses usage, clears usage metadata, and logs `invalid compressed body`
- keep production decoding and reporting behavior unchanged

## Scope

This is a test-only change. It does not change APIs, persisted data, runner protocols, dependencies, deployment ordering, or runtime behavior.

## Testing

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_body_decoding.py tests/test_model_provider_json_streaming.py` (123 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4485 passed)

Closes #24047
