### PR TITLE
fix(api): prepare model usage observations for projection

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/model-stats-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/model-stats-state.ts
@@ -1,0 +1,148 @@
+import type {
+  TestModelStatsStateActionBody,
+  TestModelStatsStateActionResponse,
+} from "@vm0/api-contracts/contracts/test-model-stats-state";
+
+import { createAppWithRoutes } from "../../../../app-factory-core";
+import type { TestContext } from "../../../../__tests__/test-context";
+import { testModelStatsStateRoutes } from "../../test-model-stats-state";
+
+const MODEL_STATS_STATE_ROUTE = "/api/test/model-stats-state";
+
+interface ModelStatsObservationState {
+  readonly idempotencyKey: string;
+  readonly aggregatedAt: string | null;
+}
+
+function requestModelStatsState(
+  context: TestContext,
+  path: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const app = createAppWithRoutes({
+    signal: context.signal,
+    routes: testModelStatsStateRoutes,
+  });
+  return Promise.resolve(app.request(path, init));
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+function expectOk(response: Response, operation: string): void {
+  if (response.ok) {
+    return;
+  }
+  throw new Error(`${operation} failed with ${response.status}`);
+}
+
+async function postAction(
+  context: TestContext,
+  body: TestModelStatsStateActionBody,
+): Promise<TestModelStatsStateActionResponse> {
+  const response = await requestModelStatsState(
+    context,
+    `${MODEL_STATS_STATE_ROUTE}/action`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+  await expectOk(response, `model stats state action ${body.action}`);
+  return await readJson<TestModelStatsStateActionResponse>(response);
+}
+
+export async function holdModelStatsAggregationLock(
+  context: TestContext,
+): Promise<void> {
+  await postAction(context, { action: "hold-aggregation-lock" });
+}
+
+export async function readModelStatsAggregationLockState(
+  context: TestContext,
+): Promise<{ readonly held: boolean; readonly waiterCount: number }> {
+  const response = await postAction(context, {
+    action: "read-aggregation-lock-state",
+  });
+  if (
+    response.aggregation_lock_held === undefined ||
+    response.aggregation_lock_waiter_count === undefined
+  ) {
+    throw new Error("Model stats lock state response is incomplete");
+  }
+  return {
+    held: response.aggregation_lock_held,
+    waiterCount: response.aggregation_lock_waiter_count,
+  };
+}
+
+export async function releaseModelStatsAggregationLock(
+  context: TestContext,
+): Promise<void> {
+  await postAction(context, { action: "release-aggregation-lock" });
+}
+
+export async function readModelStatsObservations(
+  context: TestContext,
+  idempotencyKeys: readonly string[],
+): Promise<readonly ModelStatsObservationState[]> {
+  const response = await postAction(context, {
+    action: "read-observations",
+    idempotency_keys: [...idempotencyKeys],
+  });
+  if (!response.observations) {
+    throw new Error("Model stats observation response is incomplete");
+  }
+  return response.observations.map((observation) => {
+    return {
+      idempotencyKey: observation.idempotency_key,
+      aggregatedAt: observation.aggregated_at,
+    };
+  });
+}
+
+export async function insertZeroTokenModelStatsObservation(
+  context: TestContext,
+  args: {
+    readonly idempotencyKey: string;
+    readonly model: string;
+    readonly observedAt: Date;
+  },
+): Promise<void> {
+  await postAction(context, {
+    action: "insert-zero-token-observation",
+    idempotency_key: args.idempotencyKey,
+    model: args.model,
+    observed_at: args.observedAt.toISOString(),
+  });
+}
+
+export async function deleteModelStatsObservations(
+  context: TestContext,
+  idempotencyKeys: readonly string[],
+): Promise<void> {
+  await postAction(context, {
+    action: "delete-observations",
+    idempotency_keys: [...idempotencyKeys],
+  });
+}
+
+export async function deleteModelStatsFixture(
+  context: TestContext,
+  args: {
+    readonly idempotencyKeys: readonly string[];
+    readonly models: readonly string[];
+    readonly windowStart: Date;
+    readonly windowEnd: Date;
+  },
+): Promise<void> {
+  await postAction(context, {
+    action: "delete-fixture",
+    idempotency_keys: [...args.idempotencyKeys],
+    models: [...args.models],
+    window_start: args.windowStart.toISOString(),
+    window_end: args.windowEnd.toISOString(),
+  });
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -2,7 +2,7 @@ import { createHash, createHmac, randomUUID } from "node:crypto";
 import { gzipSync, zstdCompressSync } from "node:zlib";
 
 import AdmZip from "adm-zip";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished } from "vitest";
 
 import type {
   GenerationTemplateRequest,
@@ -25,6 +25,15 @@ import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createOpsLogsApi } from "./helpers/api-bdd-ops-logs";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+import {
+  deleteModelStatsFixture,
+  deleteModelStatsObservations,
+  holdModelStatsAggregationLock,
+  insertZeroTokenModelStatsObservation,
+  readModelStatsAggregationLockState,
+  readModelStatsObservations,
+  releaseModelStatsAggregationLock,
+} from "./helpers/model-stats-state";
 import { commitMemoryVersion } from "./helpers/zero-memory";
 import { createFixtureTracker } from "./helpers/zero-route-test";
 
@@ -32,12 +41,11 @@ import { createFixtureTracker } from "./helpers/zero-route-test";
  * BILL-02 model stats and OPS-01 user export.
  *
  * This file is the SOLE OWNER of GET /api/cron/aggregate-model-stats:
- * the cron is a global sweep (window-scoped DELETE+reinsert over model_stat
- * plus an unconditional compact observation retention delete), so calling
- * it from any other test file would race this file's far-past observation
- * windows on the shared database — the same single-file-ownership rule as the
- * email drain / billing reconcile / screenshot cleanup crons (see the shared
- * cron auth helper in helpers/api-bdd-runs.ts).
+ * the cron is a global projection sweep over model_stat, so calling it from
+ * any other test file would race this file's far-past observation windows on
+ * the shared database — the same single-file-ownership rule as the email
+ * drain / billing reconcile / screenshot cleanup crons (see the shared cron
+ * auth helper in helpers/api-bdd-runs.ts).
  *
  * Shared-DB time design: the model-stats chain derives a random far-past UTC
  * day (2003-2009) per run and asserts rankings as baseline+delta, so leftovers
@@ -255,15 +263,14 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     });
   });
 
-  it("aggregates sandbox model observations into public rankings and applies retention", async () => {
+  it("prepares model observations atomically for public rankings", async () => {
     const api = createOpsLogsApi(context);
     const runs = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const model = "claude-sonnet-4-6";
 
-    // Random far-past UTC day (2003-2009): immune to the soon-deleted legacy
-    // model-stats cron (its retention windows live in 2001) and far enough in
-    // the past that the retention sweep below cannot touch real-now rows.
+    // Random far-past UTC day (2003-2009): isolated from real-now ranking
+    // windows and unlikely to collide with another interrupted test fixture.
     const seed = Number.parseInt(randomUUID().slice(0, 8), 16);
     const dayYear = 2003 + (seed % 7);
     const dayMonth = Math.floor(seed / 7) % 12;
@@ -278,6 +285,23 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     const windowStartIso = new Date(aggregateAt - DAY_MS).toISOString();
     const windowEndIso = new Date(aggregateAt).toISOString();
     const todayStartIso = new Date(dayStart).toISOString();
+    const fixtureObservationKeys: string[] = [];
+    let aggregationLockRequest: Promise<void> | null = null;
+
+    onTestFinished(async () => {
+      await releaseModelStatsAggregationLock(context);
+      if (aggregationLockRequest) {
+        await aggregationLockRequest;
+      }
+      if (fixtureObservationKeys.length > 0) {
+        await deleteModelStatsFixture(context, {
+          idempotencyKeys: fixtureObservationKeys,
+          models: [model],
+          windowStart: new Date(dayStart - 40 * DAY_MS),
+          windowEnd: new Date(dayStart + DAY_MS),
+        });
+      }
+    });
 
     // Given: the run and its sandbox token are created at the real wall
     // clock, then terminal-ized before any mocked-time ingestion.
@@ -300,9 +324,11 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     );
     expect(baselineAggregate.body).toMatchObject({
       success: true,
-      windowStart: windowStartIso,
       windowEnd: windowEndIso,
     });
+    expect(
+      new Date(baselineAggregate.body.windowStart).getTime(),
+    ).toBeLessThanOrEqual(new Date(windowStartIso).getTime());
 
     const baseline = await api.readModelRankings("today");
     expect(baseline.headers.get("cache-control")).toBe(
@@ -324,6 +350,7 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
 
     mockNow(mainObservedAt);
     const compactIdempotencyKey = randomUUID();
+    fixtureObservationKeys.push(compactIdempotencyKey);
     const compactBody = {
       runId: created.runId,
       events: [
@@ -375,14 +402,46 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     ]);
 
     mockNow(previousObservedAt);
+    const previousIdempotencyKey = randomUUID();
+    fixtureObservationKeys.push(previousIdempotencyKey);
     await webhooks.requestAgentModelUsageObservationV2(
       {
         runId: created.runId,
         events: [
           {
-            idempotencyKey: randomUUID(),
+            idempotencyKey: previousIdempotencyKey,
             model,
             inputTokens: 80,
+            outputTokens: 0,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+          },
+        ],
+      },
+      sandboxHeaders,
+      [200],
+    );
+
+    mockNow(mainObservedAt);
+    const zeroTokenIdempotencyKey = randomUUID();
+    fixtureObservationKeys.push(zeroTokenIdempotencyKey);
+    await insertZeroTokenModelStatsObservation(context, {
+      idempotencyKey: zeroTokenIdempotencyKey,
+      model,
+      observedAt: new Date(mainObservedAt),
+    });
+
+    mockNow(aggregateAt + 10 * 60_000);
+    const currentHourIdempotencyKey = randomUUID();
+    fixtureObservationKeys.push(currentHourIdempotencyKey);
+    await webhooks.requestAgentModelUsageObservationV2(
+      {
+        runId: created.runId,
+        events: [
+          {
+            idempotencyKey: currentHourIdempotencyKey,
+            model,
+            inputTokens: 7,
             outputTokens: 0,
             cacheReadInputTokens: 0,
             cacheCreationInputTokens: 0,
@@ -414,15 +473,44 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     });
     expect(afterIngest.body.totalTokens).toBe(baseTotal + 550);
 
-    // Re-ingest into the already-aggregated hour: the window DELETE+reinsert
-    // must surface the additional output tokens on the next aggregation.
+    const initialObservationStates = await readModelStatsObservations(context, [
+      compactIdempotencyKey,
+      previousIdempotencyKey,
+      zeroTokenIdempotencyKey,
+      currentHourIdempotencyKey,
+    ]);
+    expect(initialObservationStates).toStrictEqual(
+      expect.arrayContaining([
+        {
+          idempotencyKey: compactIdempotencyKey,
+          aggregatedAt: windowEndIso,
+        },
+        {
+          idempotencyKey: previousIdempotencyKey,
+          aggregatedAt: windowEndIso,
+        },
+        {
+          idempotencyKey: zeroTokenIdempotencyKey,
+          aggregatedAt: windowEndIso,
+        },
+        {
+          idempotencyKey: currentHourIdempotencyKey,
+          aggregatedAt: null,
+        },
+      ]),
+    );
+
+    // Re-ingest into the already-aggregated hour: exact replacement must
+    // surface the additional output tokens on the next aggregation.
     mockNow(mainObservedAt);
+    const lateIdempotencyKey = randomUUID();
+    fixtureObservationKeys.push(lateIdempotencyKey);
     await webhooks.requestAgentModelUsageObservationV2(
       {
         runId: created.runId,
         events: [
           {
-            idempotencyKey: randomUUID(),
+            idempotencyKey: lateIdempotencyKey,
             model,
             inputTokens: 0,
             outputTokens: 50,
@@ -466,8 +554,132 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     const fallback = await api.readModelRankings("unsupported");
     expect(fallback.body.period).toBe("week");
 
-    // A failed rebuild must roll back the window DELETE. 1,024 maximum safe
-    // integers still fit in PostgreSQL bigint; the 1,025th overflows SUM.
+    // Pending complete-hour observations extend the internal rebuild window
+    // even when they are older than the public route's maximum hours value.
+    const oldPendingAt = aggregateAt - 769 * HOUR_MS + 10 * 60_000;
+    const oldPendingHourIso = new Date(
+      aggregateAt - 769 * HOUR_MS,
+    ).toISOString();
+    mockNow(oldPendingAt);
+    const oldPendingIdempotencyKey = randomUUID();
+    fixtureObservationKeys.push(oldPendingIdempotencyKey);
+    await webhooks.requestAgentModelUsageObservationV2(
+      {
+        runId: created.runId,
+        events: [
+          {
+            idempotencyKey: oldPendingIdempotencyKey,
+            model,
+            inputTokens: 17,
+            outputTokens: 0,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+          },
+        ],
+      },
+      sandboxHeaders,
+      [200],
+    );
+    mockNow(aggregateAt);
+    const extended = await api.requestAggregateModelStats("valid", 24, [200]);
+    expect(extended.body).toMatchObject({
+      success: true,
+      windowStart: oldPendingHourIso,
+      windowEnd: windowEndIso,
+    });
+    await expect(
+      readModelStatsObservations(context, [oldPendingIdempotencyKey]),
+    ).resolves.toStrictEqual([
+      {
+        idempotencyKey: oldPendingIdempotencyKey,
+        aggregatedAt: windowEndIso,
+      },
+    ]);
+    await expect(api.readModelRankings("today")).resolves.toMatchObject({
+      body: reprocessed.body,
+    });
+
+    // Both cron requests begin before this observation is committed. The
+    // transaction lock must serialize them without freezing a pre-lock
+    // REPEATABLE READ snapshot that would miss the newly committed row.
+    aggregationLockRequest = holdModelStatsAggregationLock(context);
+    await expect
+      .poll(
+        async () => {
+          return await readModelStatsAggregationLockState(context);
+        },
+        { timeout: 5000, interval: 20 },
+      )
+      .toMatchObject({ held: true });
+    const concurrentAggregations = [
+      api.requestAggregateModelStats("valid", 24, [200]),
+      api.requestAggregateModelStats("valid", 24, [200]),
+    ];
+    await expect
+      .poll(
+        async () => {
+          return (await readModelStatsAggregationLockState(context))
+            .waiterCount;
+        },
+        { timeout: 5000, interval: 20 },
+      )
+      .toBe(2);
+
+    mockNow(mainObservedAt);
+    const concurrentIdempotencyKey = randomUUID();
+    fixtureObservationKeys.push(concurrentIdempotencyKey);
+    await webhooks.requestAgentModelUsageObservationV2(
+      {
+        runId: created.runId,
+        events: [
+          {
+            idempotencyKey: concurrentIdempotencyKey,
+            model,
+            inputTokens: 0,
+            outputTokens: 25,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+          },
+        ],
+      },
+      sandboxHeaders,
+      [200],
+    );
+
+    mockNow(aggregateAt);
+    await releaseModelStatsAggregationLock(context);
+    await aggregationLockRequest;
+    aggregationLockRequest = null;
+    const concurrentResults = await Promise.all(concurrentAggregations);
+    for (const result of concurrentResults) {
+      expect(result.body.success).toBeTruthy();
+    }
+
+    const afterConcurrent = await api.readModelRankings("today");
+    expect(
+      afterConcurrent.body.rows.find((row) => {
+        return row.model === model;
+      }),
+    ).toStrictEqual({
+      model,
+      inputTokens: baseRow.inputTokens + 350,
+      outputTokens: baseRow.outputTokens + 275,
+      totalTokens: baseRow.totalTokens + 625,
+      previousTotalTokens: baseRow.previousTotalTokens + 80,
+    });
+    expect(afterConcurrent.body.totalTokens).toBe(baseTotal + 625);
+    await expect(
+      readModelStatsObservations(context, [concurrentIdempotencyKey]),
+    ).resolves.toStrictEqual([
+      {
+        idempotencyKey: concurrentIdempotencyKey,
+        aggregatedAt: windowEndIso,
+      },
+    ]);
+
+    // A failed rebuild must roll back every statistic mutation. 1,024 maximum
+    // safe integers still fit in PostgreSQL bigint; the 1,025th overflows SUM.
+    // The observation markers must roll back with the stats replacement.
     mockNow(mainObservedAt);
     const overflowEvents = Array.from({ length: 1025 }, () => {
       return {
@@ -479,6 +691,11 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
         cacheCreationInputTokens: 0,
       };
     });
+    fixtureObservationKeys.push(
+      ...overflowEvents.map((event) => {
+        return event.idempotencyKey;
+      }),
+    );
     for (let offset = 0; offset < overflowEvents.length; offset += 100) {
       await webhooks.requestAgentModelUsageObservationV2(
         {
@@ -506,29 +723,63 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       error: "Internal server error",
     });
     const afterFailedRebuild = await api.readModelRankings("today");
-    expect(afterFailedRebuild.body).toStrictEqual(reprocessed.body);
+    expect(afterFailedRebuild.body).toStrictEqual(afterConcurrent.body);
+    const firstOverflowEvent = overflowEvents[0];
+    const lastOverflowEvent = overflowEvents.at(-1);
+    if (!firstOverflowEvent || !lastOverflowEvent) {
+      throw new Error("Expected overflow observation fixtures");
+    }
+    const overflowStates = await readModelStatsObservations(context, [
+      firstOverflowEvent.idempotencyKey,
+      lastOverflowEvent.idempotencyKey,
+    ]);
+    expect(overflowStates).toHaveLength(2);
+    expect(
+      overflowStates.every((observation) => {
+        return observation.aggregatedAt === null;
+      }),
+    ).toBeTruthy();
+    await deleteModelStatsObservations(
+      context,
+      overflowEvents.map((event) => {
+        return event.idempotencyKey;
+      }),
+    );
 
-    // Retention: 33 days later the cron deletes every observation at or
-    // before our day; the re-aggregation then empties the window's stats, so
-    // the strict empty read is safe even against colliding leftovers.
-    mockNow(dayStart + 33 * DAY_MS + 4 * HOUR_MS);
-    const retention = await api.requestAggregateModelStats(
+    // The projection lifecycle marker replaces observation retention. A
+    // later run still retains old source rows and can rebuild their stats.
+    const laterAggregateAt = dayStart + 33 * DAY_MS + 4 * HOUR_MS;
+    mockNow(laterAggregateAt);
+    const laterPreparation = await api.requestAggregateModelStats(
       "valid",
       undefined,
       [200],
     );
-    expect(retention.body.success).toBeTruthy();
+    expect(laterPreparation.body).toMatchObject({
+      success: true,
+      windowStart: windowEndIso,
+      windowEnd: new Date(laterAggregateAt).toISOString(),
+    });
+    const retainedStates = await readModelStatsObservations(context, [
+      compactIdempotencyKey,
+      previousIdempotencyKey,
+      zeroTokenIdempotencyKey,
+      currentHourIdempotencyKey,
+      lateIdempotencyKey,
+      oldPendingIdempotencyKey,
+      concurrentIdempotencyKey,
+    ]);
+    expect(retainedStates).toHaveLength(7);
+    expect(
+      retainedStates.every((observation) => {
+        return observation.aggregatedAt !== null;
+      }),
+    ).toBeTruthy();
 
     mockNow(aggregateAt);
     await api.requestAggregateModelStats("valid", 24, [200]);
-    const emptied = await api.readModelRankings("today");
-    expect(emptied.body).toStrictEqual({
-      period: "today",
-      totalTokens: 0,
-      windowStart: todayStartIso,
-      windowEnd: windowEndIso,
-      rows: [],
-    });
+    const rebuilt = await api.readModelRankings("today");
+    expect(rebuilt.body).toStrictEqual(afterConcurrent.body);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/test-model-stats-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-model-stats-state.ts
@@ -1,0 +1,290 @@
+import { command } from "ccstate";
+import {
+  testModelStatsStateContract,
+  type TestModelStatsStateActionBody,
+} from "@vm0/api-contracts/contracts/test-model-stats-state";
+import { modelStat } from "@vm0/db/schema/model-stat";
+import { modelUsageObservation } from "@vm0/db/schema/model-usage-observation";
+import { and, asc, gte, inArray, lt, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { executeRawRows } from "../../lib/db-raw-rows";
+import { testOverride } from "../../lib/singleton";
+import { bodyResultOf } from "../context/request";
+import { request$ } from "../context/hono";
+import { writeDb$, type Db } from "../external/db";
+import type { RouteEntry } from "../route-entry";
+import { lockModelStatsAggregation } from "../services/model-stats-aggregation-lock.service";
+import { createDeferredPromise, onRejection } from "../utils";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+const actionBody$ = bodyResultOf(testModelStatsStateContract.action);
+
+interface ModelStatsAggregationLockGate {
+  holderPid: number | null;
+  readonly released: ReturnType<typeof createDeferredPromise<void>>;
+  readonly release: () => void;
+}
+
+const aggregationLockGate = testOverride<ModelStatsAggregationLockGate | null>(
+  () => {
+    return null;
+  },
+);
+
+const lockHolderRowSchema = z.object({ holderPid: z.int() });
+const lockStateRowSchema = z.object({
+  held: z.boolean(),
+  waiterCount: z.int().nonnegative(),
+});
+
+function createAggregationLockGate(
+  signal: AbortSignal,
+): ModelStatsAggregationLockGate {
+  const released = createDeferredPromise<void>(signal);
+  return {
+    holderPid: null,
+    released,
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+  };
+}
+
+function clearAggregationLockGate(gate: ModelStatsAggregationLockGate): void {
+  if (aggregationLockGate.get() === gate) {
+    aggregationLockGate.clear();
+  }
+}
+
+async function holdAggregationLock(db: Db, signal: AbortSignal): Promise<void> {
+  if (aggregationLockGate.get()) {
+    throw new Error("A model stats aggregation lock gate is already active");
+  }
+  const gate = createAggregationLockGate(signal);
+  aggregationLockGate.set(gate);
+  await onRejection(
+    db.transaction(async (tx) => {
+      await lockModelStatsAggregation(tx);
+      signal.throwIfAborted();
+      const rows = await executeRawRows(
+        tx,
+        sql`SELECT pg_backend_pid() AS "holderPid"`,
+        lockHolderRowSchema,
+      );
+      signal.throwIfAborted();
+      const holder = rows[0];
+      if (!holder) {
+        throw new Error("Failed to read model stats lock holder");
+      }
+      gate.holderPid = holder.holderPid;
+      await gate.released.promise;
+    }),
+    () => {
+      clearAggregationLockGate(gate);
+    },
+  );
+  clearAggregationLockGate(gate);
+}
+
+async function readAggregationLockState(
+  db: Db,
+  signal: AbortSignal,
+): Promise<{ readonly held: boolean; readonly waiterCount: number }> {
+  const holderPid = aggregationLockGate.get()?.holderPid;
+  if (holderPid === null || holderPid === undefined) {
+    return { held: false, waiterCount: 0 };
+  }
+  const rows = await executeRawRows(
+    db,
+    sql`
+      SELECT
+        EXISTS (
+          SELECT 1
+          FROM pg_locks held
+          WHERE
+            held.pid = ${holderPid}
+            AND held.locktype = 'advisory'
+            AND held.granted
+        ) AS "held",
+        (
+          SELECT COUNT(*)::int
+          FROM pg_locks held
+          INNER JOIN pg_locks waiting
+            ON waiting.locktype = held.locktype
+            AND waiting.database IS NOT DISTINCT FROM held.database
+            AND waiting.classid IS NOT DISTINCT FROM held.classid
+            AND waiting.objid IS NOT DISTINCT FROM held.objid
+            AND waiting.objsubid IS NOT DISTINCT FROM held.objsubid
+          WHERE
+            held.pid = ${holderPid}
+            AND held.locktype = 'advisory'
+            AND held.granted
+            AND NOT waiting.granted
+        ) AS "waiterCount"
+    `,
+    lockStateRowSchema,
+  );
+  signal.throwIfAborted();
+  const state = rows[0];
+  if (!state) {
+    throw new Error("Failed to read model stats aggregation lock state");
+  }
+  return state;
+}
+
+async function readObservations(
+  db: Db,
+  idempotencyKeys: readonly string[],
+  signal: AbortSignal,
+) {
+  const rows = await db
+    .select({
+      idempotencyKey: modelUsageObservation.idempotencyKey,
+      aggregatedAt: modelUsageObservation.aggregatedAt,
+    })
+    .from(modelUsageObservation)
+    .where(inArray(modelUsageObservation.idempotencyKey, idempotencyKeys))
+    .orderBy(asc(modelUsageObservation.idempotencyKey));
+  signal.throwIfAborted();
+  return rows;
+}
+
+async function deleteObservations(
+  db: Db,
+  idempotencyKeys: readonly string[],
+  signal: AbortSignal,
+): Promise<void> {
+  await db
+    .delete(modelUsageObservation)
+    .where(inArray(modelUsageObservation.idempotencyKey, idempotencyKeys));
+  signal.throwIfAborted();
+}
+
+async function insertZeroTokenObservation(
+  db: Db,
+  body: Extract<
+    TestModelStatsStateActionBody,
+    { action: "insert-zero-token-observation" }
+  >,
+  signal: AbortSignal,
+): Promise<void> {
+  await db.insert(modelUsageObservation).values({
+    idempotencyKey: body.idempotency_key,
+    model: body.model,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadInputTokens: 0,
+    cacheCreationInputTokens: 0,
+    observedAt: new Date(body.observed_at),
+  });
+  signal.throwIfAborted();
+}
+
+async function deleteFixture(
+  db: Db,
+  body: Extract<TestModelStatsStateActionBody, { action: "delete-fixture" }>,
+  signal: AbortSignal,
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(modelUsageObservation)
+      .where(
+        inArray(modelUsageObservation.idempotencyKey, body.idempotency_keys),
+      );
+    signal.throwIfAborted();
+    await tx
+      .delete(modelStat)
+      .where(
+        and(
+          gte(modelStat.hourStart, new Date(body.window_start)),
+          lt(modelStat.hourStart, new Date(body.window_end)),
+          inArray(modelStat.model, body.models),
+        ),
+      );
+    signal.throwIfAborted();
+  });
+}
+
+async function mutateModelStatsState(
+  db: Db,
+  body: TestModelStatsStateActionBody,
+  signal: AbortSignal,
+) {
+  switch (body.action) {
+    case "hold-aggregation-lock": {
+      await holdAggregationLock(db, signal);
+      return { status: 200 as const, body: { ok: true as const } };
+    }
+    case "read-aggregation-lock-state": {
+      const state = await readAggregationLockState(db, signal);
+      return {
+        status: 200 as const,
+        body: {
+          ok: true as const,
+          aggregation_lock_held: state.held,
+          aggregation_lock_waiter_count: state.waiterCount,
+        },
+      };
+    }
+    case "release-aggregation-lock": {
+      aggregationLockGate.get()?.release();
+      return { status: 200 as const, body: { ok: true as const } };
+    }
+    case "read-observations": {
+      const rows = await readObservations(db, body.idempotency_keys, signal);
+      return {
+        status: 200 as const,
+        body: {
+          ok: true as const,
+          observations: rows.map((row) => {
+            return {
+              idempotency_key: row.idempotencyKey,
+              aggregated_at: row.aggregatedAt?.toISOString() ?? null,
+            };
+          }),
+        },
+      };
+    }
+    case "insert-zero-token-observation": {
+      await insertZeroTokenObservation(db, body, signal);
+      return { status: 200 as const, body: { ok: true as const } };
+    }
+    case "delete-observations": {
+      await deleteObservations(db, body.idempotency_keys, signal);
+      return { status: 200 as const, body: { ok: true as const } };
+    }
+    case "delete-fixture": {
+      await deleteFixture(db, body, signal);
+      return { status: 200 as const, body: { ok: true as const } };
+    }
+  }
+}
+
+const mutateModelStatsState$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+
+    const bodyResult = await get(actionBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    return await mutateModelStatsState(set(writeDb$), bodyResult.data, signal);
+  },
+);
+
+export const testModelStatsStateRoutes: readonly RouteEntry[] = [
+  {
+    route: testModelStatsStateContract.action,
+    handler: mutateModelStatsState$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/test-model-stats-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-model-stats-state.ts
@@ -5,7 +5,7 @@ import {
 } from "@vm0/api-contracts/contracts/test-model-stats-state";
 import { modelStat } from "@vm0/db/schema/model-stat";
 import { modelUsageObservation } from "@vm0/db/schema/model-usage-observation";
-import { and, asc, gte, inArray, lt, sql } from "drizzle-orm";
+import { and, asc, count, gte, inArray, lt, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { executeRawRows } from "../../lib/db-raw-rows";
@@ -113,7 +113,7 @@ async function readAggregationLockState(
             AND held.granted
         ) AS "held",
         (
-          SELECT COUNT(*)::int
+          SELECT ${count()}::int
           FROM pg_locks held
           INNER JOIN pg_locks waiting
             ON waiting.locktype = held.locktype

--- a/turbo/apps/api/src/signals/services/model-stats-aggregation-lock.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats-aggregation-lock.service.ts
@@ -1,0 +1,16 @@
+import { sql } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+
+type ModelStatsAggregationLockDb = Pick<Db, "execute">;
+
+export async function lockModelStatsAggregation(
+  db: ModelStatsAggregationLockDb,
+): Promise<void> {
+  await db.execute(
+    sql`SELECT pg_advisory_xact_lock(
+      hashtext('vm0'),
+      hashtext('model_stats_aggregation')
+    )`,
+  );
+}

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -1,35 +1,43 @@
 import { command } from "ccstate";
 import {
   and,
+  count,
   desc,
   eq,
   gt,
   gte,
   inArray,
+  isNull,
   lt,
+  min,
   or,
   sql,
   sum,
+  type SQL,
   type SQLWrapper,
 } from "drizzle-orm";
-import { CRON_AGGREGATE_MODEL_STATS_MAX_HOURS } from "@vm0/api-contracts/contracts/cron";
 import { modelStat } from "@vm0/db/schema/model-stat";
 import { modelUsageObservation } from "@vm0/db/schema/model-usage-observation";
 import {
   VM0_MODEL_ALIAS_TO_MODEL,
   VM0_MODEL_TO_PROVIDER,
 } from "@vm0/api-contracts/contracts/model-providers";
+import { z } from "zod";
 
+import {
+  executeRawRows,
+  pgTimestampWithoutTimezoneToDateSchema,
+} from "../../lib/db-raw-rows";
 import {
   pgInt8ToSafeIntegerDecoder,
   pgTextDecoder,
 } from "../../lib/db-structured-result";
 import { type Db, writeDb$ } from "../external/db";
 import { nowDate } from "../external/time";
+import { lockModelStatsAggregation } from "./model-stats-aggregation-lock.service";
 
 const HOUR_MS = 60 * 60_000;
 export const DEFAULT_MODEL_STATS_REPROCESS_HOURS = 24;
-const MAX_MODEL_STATS_REPROCESS_HOURS = CRON_AGGREGATE_MODEL_STATS_MAX_HOURS;
 export const MODEL_RANKING_PERIODS = ["today", "week", "month"] as const;
 
 type ModelRankingPeriod = (typeof MODEL_RANKING_PERIODS)[number];
@@ -66,6 +74,14 @@ interface ModelStatsAggregationResult {
   readonly windowEnd: Date;
   readonly aggregated: number;
 }
+
+const modelStatsAggregationRowSchema = z.object({
+  windowStart: pgTimestampWithoutTimezoneToDateSchema,
+  windowEnd: pgTimestampWithoutTimezoneToDateSchema,
+  aggregated: z.int().nonnegative(),
+  markedObservations: z.int().nonnegative(),
+  deleted: z.int().nonnegative(),
+});
 
 function utcHourStart(date: Date): Date {
   return new Date(
@@ -159,47 +175,54 @@ function modelStatWindowSum(
   )::bigint`.mapWith(pgInt8ToSafeIntegerDecoder);
 }
 
-async function replaceModelStats(
-  db: Db,
-  windowStart: Date,
-  windowEnd: Date,
-): Promise<number> {
-  const observationModelExpr = modelUsageObservationModelExpression();
-  const modelStatsModelIds = getModelStatsModelIds();
-  const windowStartParam = utcTimestampParam(windowStart);
-  const windowEndParam = utcTimestampParam(windowEnd);
+interface ModelStatsAggregationSqlArgs {
+  readonly modelStatsModelIds: string[];
+  readonly observationModelExpr: SQLWrapper;
+  readonly preparedAt: string;
+  readonly requestedWindowStart: string;
+  readonly windowEnd: string;
+}
 
-  const insertedCount = await db.transaction(async (tx) => {
-    await tx
-      .delete(modelStat)
-      .where(
-        and(
-          gte(modelStat.hourStart, sql`${windowStartParam}::timestamp`),
-          lt(modelStat.hourStart, sql`${windowEndParam}::timestamp`),
-          inArray(modelStat.model, modelStatsModelIds),
-        ),
-      );
-
-    const { rowCount } = await tx.execute(sql`
-      WITH usage_rows AS (
+function modelStatsSourceCtes(args: ModelStatsAggregationSqlArgs): SQL {
+  return sql`
+    oldest_pending AS MATERIALIZED (
+        SELECT
+          ${min(modelUsageObservation.observedAt)} AS oldest_observed_at
+        FROM ${modelUsageObservation}
+        WHERE ${and(
+          isNull(modelUsageObservation.aggregatedAt),
+          lt(
+            modelUsageObservation.observedAt,
+            sql`${args.windowEnd}::timestamp`,
+          ),
+        )}
+      ),
+      bounds AS MATERIALIZED (
+        SELECT
+          LEAST(
+            ${args.requestedWindowStart}::timestamp,
+            COALESCE(
+              date_trunc('hour', oldest_pending.oldest_observed_at)::timestamp,
+              ${args.requestedWindowStart}::timestamp
+            )
+          )::timestamp AS window_start,
+          ${args.windowEnd}::timestamp AS window_end
+        FROM oldest_pending
+      ),
+      usage_rows AS MATERIALIZED (
         SELECT
           date_trunc('hour', ${modelUsageObservation.observedAt})::timestamp AS hour_start,
-          ${observationModelExpr} AS model,
+          ${args.observationModelExpr} AS model,
           ${modelUsageObservation.inputTokens}::bigint AS input_tokens,
           ${modelUsageObservation.outputTokens}::bigint AS output_tokens,
           ${modelUsageObservation.cacheReadInputTokens}::bigint AS cache_read_input_tokens,
           ${modelUsageObservation.cacheCreationInputTokens}::bigint AS cache_creation_input_tokens
         FROM ${modelUsageObservation}
+        CROSS JOIN bounds
         WHERE ${and(
-          gte(
-            modelUsageObservation.observedAt,
-            sql`${windowStartParam}::timestamp`,
-          ),
-          lt(
-            modelUsageObservation.observedAt,
-            sql`${windowEndParam}::timestamp`,
-          ),
-          inArray(modelUsageObservation.model, modelStatsModelIds),
+          gte(modelUsageObservation.observedAt, sql`bounds.window_start`),
+          lt(modelUsageObservation.observedAt, sql`bounds.window_end`),
+          inArray(modelUsageObservation.model, args.modelStatsModelIds),
           or(
             gt(modelUsageObservation.inputTokens, sql`0`),
             gt(modelUsageObservation.outputTokens, sql`0`),
@@ -226,46 +249,120 @@ async function replaceModelStats(
         WHERE model <> ''
         GROUP BY hour_start, model
       )
-      INSERT INTO ${modelStat} (
-        "hour_start",
-        "model",
-        "input_tokens",
-        "output_tokens",
-        "cache_read_input_tokens",
-        "cache_creation_input_tokens",
-        "total_tokens"
-      )
-      SELECT
-        hour_start,
-        model,
-        input_tokens,
-        output_tokens,
-        cache_read_input_tokens,
-        cache_creation_input_tokens,
-        total_tokens
-      FROM aggregated
-      ON CONFLICT (hour_start, model) DO UPDATE SET
-        input_tokens = EXCLUDED.input_tokens,
-        output_tokens = EXCLUDED.output_tokens,
-        cache_read_input_tokens = EXCLUDED.cache_read_input_tokens,
-        cache_creation_input_tokens = EXCLUDED.cache_creation_input_tokens,
-        total_tokens = EXCLUDED.total_tokens,
-        updated_at = NOW()
-      RETURNING id
-    `);
-    return rowCount ?? 0;
-  });
-
-  return insertedCount;
+  `;
 }
 
-async function deleteExpiredModelUsageObservations(
+function modelStatsMutationCtes(args: ModelStatsAggregationSqlArgs): SQL {
+  return sql`
+    upserted_stats AS (
+        INSERT INTO ${modelStat} (
+          "hour_start",
+          "model",
+          "input_tokens",
+          "output_tokens",
+          "cache_read_input_tokens",
+          "cache_creation_input_tokens",
+          "total_tokens"
+        )
+        SELECT
+          hour_start,
+          model,
+          input_tokens,
+          output_tokens,
+          cache_read_input_tokens,
+          cache_creation_input_tokens,
+          total_tokens
+        FROM aggregated
+        ON CONFLICT (hour_start, model) DO UPDATE SET
+          input_tokens = EXCLUDED.input_tokens,
+          output_tokens = EXCLUDED.output_tokens,
+          cache_read_input_tokens = EXCLUDED.cache_read_input_tokens,
+          cache_creation_input_tokens = EXCLUDED.cache_creation_input_tokens,
+          total_tokens = EXCLUDED.total_tokens,
+          updated_at = NOW()
+        RETURNING id
+      ),
+      deleted_stats AS (
+        DELETE FROM ${modelStat}
+        USING bounds
+        WHERE
+          ${and(
+            gte(modelStat.hourStart, sql`bounds.window_start`),
+            lt(modelStat.hourStart, sql`bounds.window_end`),
+            inArray(modelStat.model, args.modelStatsModelIds),
+          )}
+          AND NOT EXISTS (
+            SELECT 1
+            FROM aggregated
+            WHERE
+              aggregated.hour_start = ${modelStat.hourStart}
+              AND aggregated.model = ${modelStat.model}
+          )
+        RETURNING ${modelStat.id}
+      ),
+      marked_observations AS (
+        UPDATE ${modelUsageObservation}
+        SET aggregated_at = ${args.preparedAt}::timestamp
+        FROM bounds
+        WHERE ${and(
+          isNull(modelUsageObservation.aggregatedAt),
+          gte(modelUsageObservation.observedAt, sql`bounds.window_start`),
+          lt(modelUsageObservation.observedAt, sql`bounds.window_end`),
+        )}
+        RETURNING ${modelUsageObservation.idempotencyKey}
+      )
+  `;
+}
+
+function modelStatsAggregationSql(args: ModelStatsAggregationSqlArgs): SQL {
+  return sql`
+    WITH
+    ${modelStatsSourceCtes(args)},
+    ${modelStatsMutationCtes(args)}
+    SELECT
+      bounds.window_start AS "windowStart",
+      bounds.window_end AS "windowEnd",
+      (SELECT ${count()}::int FROM upserted_stats) AS "aggregated",
+      (SELECT ${count()}::int FROM marked_observations)
+        AS "markedObservations",
+      (SELECT ${count()}::int FROM deleted_stats) AS "deleted"
+    FROM bounds
+  `;
+}
+
+async function prepareModelStats(
   db: Db,
-  retentionStart: Date,
-): Promise<void> {
-  await db
-    .delete(modelUsageObservation)
-    .where(lt(modelUsageObservation.observedAt, retentionStart));
+  requestedWindowStart: Date,
+  windowEnd: Date,
+  preparedAt: Date,
+  signal: AbortSignal,
+): Promise<ModelStatsAggregationResult> {
+  const query = modelStatsAggregationSql({
+    modelStatsModelIds: getModelStatsModelIds(),
+    observationModelExpr: modelUsageObservationModelExpression(),
+    preparedAt: utcTimestampParam(preparedAt),
+    requestedWindowStart: utcTimestampParam(requestedWindowStart),
+    windowEnd: utcTimestampParam(windowEnd),
+  });
+
+  return await db.transaction(async (tx) => {
+    await lockModelStatsAggregation(tx);
+    signal.throwIfAborted();
+    const rows = await executeRawRows(
+      tx,
+      query,
+      modelStatsAggregationRowSchema,
+    );
+    signal.throwIfAborted();
+
+    const [result] = rows;
+    if (rows.length !== 1 || !result) {
+      throw new Error(
+        "Model stats aggregation returned an unexpected summary row count",
+      );
+    }
+    return result;
+  });
 }
 
 async function selectModelRankings(
@@ -368,23 +465,21 @@ export const aggregateModelStats$ = command(
     signal: AbortSignal,
   ): Promise<ModelStatsAggregationResult> => {
     const db = set(writeDb$);
-    const windowEnd = utcHourStart(nowDate());
+    const preparedAt = nowDate();
+    const windowEnd = utcHourStart(preparedAt);
     const windowStart = new Date(windowEnd.getTime() - hours * HOUR_MS);
-    const retentionStart = new Date(
-      windowEnd.getTime() - MAX_MODEL_STATS_REPROCESS_HOURS * HOUR_MS,
-    );
 
     signal.throwIfAborted();
-    const aggregated = await replaceModelStats(db, windowStart, windowEnd);
-    signal.throwIfAborted();
-    await deleteExpiredModelUsageObservations(db, retentionStart);
-    signal.throwIfAborted();
-
-    return {
+    const result = await prepareModelStats(
+      db,
       windowStart,
       windowEnd,
-      aggregated,
-    };
+      preparedAt,
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return result;
   },
 );
 

--- a/turbo/packages/api-contracts/src/contracts/test-model-stats-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-model-stats-state.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+const idempotencyKeysSchema = z.array(z.uuid()).min(1);
+
+export const testModelStatsStateActionBodySchema = z.discriminatedUnion(
+  "action",
+  [
+    z.object({
+      action: z.literal("hold-aggregation-lock"),
+    }),
+    z.object({
+      action: z.literal("read-aggregation-lock-state"),
+    }),
+    z.object({
+      action: z.literal("release-aggregation-lock"),
+    }),
+    z.object({
+      action: z.literal("read-observations"),
+      idempotency_keys: idempotencyKeysSchema,
+    }),
+    z.object({
+      action: z.literal("insert-zero-token-observation"),
+      idempotency_key: z.uuid(),
+      model: z.string(),
+      observed_at: z.iso.datetime(),
+    }),
+    z.object({
+      action: z.literal("delete-observations"),
+      idempotency_keys: idempotencyKeysSchema,
+    }),
+    z.object({
+      action: z.literal("delete-fixture"),
+      idempotency_keys: idempotencyKeysSchema,
+      models: z.array(z.string()).min(1),
+      window_start: z.iso.datetime(),
+      window_end: z.iso.datetime(),
+    }),
+  ],
+);
+
+const testModelStatsObservationSchema = z.object({
+  idempotency_key: z.uuid(),
+  aggregated_at: z.iso.datetime().nullable(),
+});
+
+export const testModelStatsStateActionResponseSchema = z.object({
+  ok: z.literal(true),
+  aggregation_lock_held: z.boolean().optional(),
+  aggregation_lock_waiter_count: z.number().int().nonnegative().optional(),
+  observations: z.array(testModelStatsObservationSchema).optional(),
+});
+
+export const testModelStatsStateContract = c.router({
+  action: {
+    method: "POST",
+    path: "/api/test/model-stats-state/action",
+    body: testModelStatsStateActionBodySchema,
+    responses: {
+      200: testModelStatsStateActionResponseSchema,
+      400: z.object({ error: z.string() }),
+      404: z.string(),
+    },
+    summary: "Manage model stats API test support state",
+  },
+});
+
+export type TestModelStatsStateActionBody = z.infer<
+  typeof testModelStatsStateActionBodySchema
+>;
+export type TestModelStatsStateActionResponse = z.infer<
+  typeof testModelStatsStateActionResponseSchema
+>;


### PR DESCRIPTION
## Summary

- serialize model-stat preparation with a dedicated transaction advisory lock
  acquired before the source snapshot
- keep exact replacement while extending the effective window to the oldest
  pending complete-hour observation
- mark represented observations atomically, including ignored zero-token rows,
  and stop deleting retained observations
- cover post-lock snapshot visibility, exact reprocessing, marker lifecycle,
  overflow rollback, and retained historical source data through API entry
  points

## Compatibility and scope

- keeps the existing `hours` query, cron response, and public ranking contract
- includes no schema or index change; `aggregated_at` was deployed by #24074
- deliberately defers additive projection to #24078 and the final contract and
  cleanup changes to #24079
- old and new API versions remain exact-replacement writers during deployment;
  after old versions drain, run Prepare and reconcile retained observations
  against `model_stat` before starting #24078

## Validation

- `pnpm exec prettier --check <changed files>`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/ops-logs.bdd.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm -F api build`
- `pnpm knip --workspace api`
- `pnpm knip --workspace @vm0/api-contracts`
- pre-commit full Turbo type check and Knip

Closes #24076

Parent delivery issue: #23962
