### PR TITLE
fix(cli): limit candidates for selected templates

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
@@ -317,6 +317,9 @@ describe("zero generate source-backed artifact commands", () => {
     expect(stdout).toContain(
       "Selected template: template:finance-report (Finance Report)",
     );
+    expect(stdout).toContain('"id": "template:finance-report"');
+    expect(stdout.match(/"kind": "template"/gu)).toHaveLength(1);
+    expect(stdout).not.toContain('"id": "template:weekly-update"');
   });
 
   it("rejects an unknown template id on dashboard-design", async () => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
@@ -72,6 +72,8 @@ describe("zero generate source-backed artifact commands", () => {
       const stdout = output();
       expect(stdout).toContain(`# Zero generate ${command}`);
       expect(stdout).toContain("federated generation source-selection packet");
+      expect(stdout).toContain("## Stage 1: Resource Selection");
+      expect(stdout).toContain("## Candidate Registry Slice");
       expect(stdout).toContain(prompt);
       expect(stdout).toContain(template);
       expect(stdout).toContain(`Artifact kind: ${command}`);
@@ -311,15 +313,40 @@ describe("zero generate source-backed artifact commands", () => {
     ]);
 
     const stdout = output();
-    expect(stdout).toContain(
-      "Selected design system: design-system:apple (Apple)",
-    );
-    expect(stdout).toContain(
-      "Selected template: template:finance-report (Finance Report)",
-    );
+    expect(stdout).toContain("## Selected Resources");
     expect(stdout).toContain('"id": "template:finance-report"');
+    expect(stdout).toContain('"id": "design-system:apple"');
     expect(stdout.match(/"kind": "template"/gu)).toHaveLength(1);
+    expect(stdout.match(/"kind": "design-system"/gu)).toHaveLength(1);
+    expect(stdout.match(/"kind":/gu)).toHaveLength(2);
+    expect(stdout).not.toContain("## Stage 1: Resource Selection");
+    expect(stdout).not.toContain("## Selection Output Schema");
+    expect(stdout).not.toContain("## Candidate Registry Slice");
+    expect(stdout).not.toContain('"id": "skill:article-magazine"');
     expect(stdout).not.toContain('"id": "template:weekly-update"');
+    expect(stdout).not.toContain('"id": "design-system:shopify"');
+    expect(stdout).not.toContain("agent decides");
+  });
+
+  it("prints only an explicitly selected design system", async () => {
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "report",
+      "--prompt",
+      "Q2 finance report",
+      "--design-system",
+      "apple",
+    ]);
+
+    const stdout = output();
+    expect(stdout).toContain("## Selected Resources");
+    expect(stdout).toContain('"id": "design-system:apple"');
+    expect(stdout.match(/"kind":/gu)).toHaveLength(1);
+    expect(stdout).not.toContain('"kind": "template"');
+    expect(stdout).not.toContain('"kind": "skill"');
+    expect(stdout).not.toContain("## Stage 1: Resource Selection");
+    expect(stdout).not.toContain("## Candidate Registry Slice");
   });
 
   it("rejects an unknown template id on dashboard-design", async () => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
@@ -101,10 +101,14 @@ describe("zero generate website command", () => {
     ]);
 
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(stdout).toContain(
-      "Selected template: template:web-prototype (Web Prototype)",
-    );
-    expect(stdout).toContain("Use the explicitly selected template.");
+    expect(stdout).toContain("## Selected Resources");
+    expect(stdout).toContain('"id": "template:web-prototype"');
+    expect(stdout.match(/"kind":/gu)).toHaveLength(1);
+    expect(stdout).not.toContain("## Stage 1: Resource Selection");
+    expect(stdout).not.toContain("## Candidate Registry Slice");
+    expect(stdout).not.toContain('"id": "template:black-slabs"');
+    expect(stdout).not.toContain('"id": "skill:article-magazine"');
+    expect(stdout).not.toContain('"id": "design-system:apple"');
     expect(stdout).not.toContain(
       "For landing, marketing, official brand or product, and launch pages, select a vm0 built-in website template.",
     );
@@ -129,23 +133,23 @@ describe("zero generate website command", () => {
     ]);
 
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(stdout).toContain(
-      "Selected template: template:dot-matrix (Dot Matrix)",
-    );
-    expect(stdout).toContain(
-      "Selected design system: design-system:stripe (Stripe)",
-    );
-    expect(stdout).toContain(
-      "Selected template package: zero resource pull template:dot-matrix --dir ./generated/resources",
-    );
+    expect(stdout).toContain("## Selected Resources");
     expect(stdout).toContain('"id": "template:dot-matrix"');
+    expect(stdout).toContain('"id": "design-system:stripe"');
     expect(stdout).toContain('"type": "tar.gz"');
     expect(stdout).toContain(
       '"sha256": "f489a51fb99d8fadff8712d0406df06ac1a530116ebe612ab3f8605daa2bcce2"',
     );
     expect(stdout.match(/"kind": "template"/gu)).toHaveLength(1);
+    expect(stdout.match(/"kind": "design-system"/gu)).toHaveLength(1);
+    expect(stdout.match(/"kind":/gu)).toHaveLength(2);
+    expect(stdout).not.toContain("## Stage 1: Resource Selection");
+    expect(stdout).not.toContain("## Selection Output Schema");
+    expect(stdout).not.toContain("## Candidate Registry Slice");
     expect(stdout).not.toContain('"id": "template:black-slabs"');
     expect(stdout).not.toContain('"id": "template:web-prototype"');
+    expect(stdout).not.toContain('"id": "skill:article-magazine"');
+    expect(stdout).not.toContain('"id": "design-system:apple"');
   });
 
   it("should accept the built-in website picker id for --template", async () => {
@@ -160,9 +164,9 @@ describe("zero generate website command", () => {
     ]);
 
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(stdout).toContain(
-      "Selected template: template:black-slabs (Black Slabs)",
-    );
+    expect(stdout).toContain('"id": "template:black-slabs"');
+    expect(stdout.match(/"kind":/gu)).toHaveLength(1);
+    expect(stdout).not.toContain("## Candidate Registry Slice");
   });
 
   it("should reject a template that does not target website", async () => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
@@ -143,6 +143,9 @@ describe("zero generate website command", () => {
     expect(stdout).toContain(
       '"sha256": "f489a51fb99d8fadff8712d0406df06ac1a530116ebe612ab3f8605daa2bcce2"',
     );
+    expect(stdout.match(/"kind": "template"/gu)).toHaveLength(1);
+    expect(stdout).not.toContain('"id": "template:black-slabs"');
+    expect(stdout).not.toContain('"id": "template:web-prototype"');
   });
 
   it("should accept the built-in website picker id for --template", async () => {

--- a/turbo/apps/cli/src/commands/zero/generate/website.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/website.ts
@@ -7,6 +7,7 @@ import {
   findTemplate,
   listDesignSystems,
   listTemplates,
+  type RegistryEntry,
 } from "../shared/resource-registry";
 import {
   canonicalizeRegistryId,
@@ -23,21 +24,6 @@ interface WebsiteOptions {
   readonly designSystem?: string;
   readonly siteSlug?: string;
   readonly title?: string;
-}
-
-function selectedTemplateDetails(
-  template: ReturnType<typeof findTemplate> | undefined,
-): readonly string[] {
-  if (!template) {
-    return ["Selected template: agent decides"];
-  }
-  const details = [`Selected template: ${template.id} (${template.name})`];
-  if (template.source.archive) {
-    details.push(
-      `Selected template package: zero resource pull ${template.id} --dir ./generated/resources`,
-    );
-  }
-  return details;
 }
 
 function unknownDesignSystemError(id: string): Error {
@@ -146,28 +132,38 @@ ${formatRegistryListing(templates, "website templates")}`;
         resolvedTemplate = entry;
       }
 
-      const templateSelectionRules = resolvedTemplate
-        ? ["Use the explicitly selected template."]
-        : [
-            "For landing, marketing, official brand or product, and launch pages, select a vm0 built-in website template.",
-            "For other HTML or website requests, select an Open Design template based on intent; when ambiguous, prefer Open Design.",
-            "Built-in website candidates have `source.archive`; candidates without it are Open Design templates.",
-          ];
+      const selectedResources: RegistryEntry[] = [];
+      if (resolvedTemplate) {
+        selectedResources.push(resolvedTemplate);
+      }
+      if (resolvedDesignSystem) {
+        selectedResources.push(resolvedDesignSystem);
+      }
+      const templateSelectionRules =
+        selectedResources.length === 0
+          ? [
+              "For landing, marketing, official brand or product, and launch pages, select a vm0 built-in website template.",
+              "For other HTML or website requests, select an Open Design template based on intent; when ambiguous, prefer Open Design.",
+              "Built-in website candidates have `source.archive`; candidates without it are Open Design templates.",
+            ]
+          : [];
+      const resourceDetails =
+        selectedResources.length === 0
+          ? [
+              "Selected design system: agent decides",
+              "Selected template: agent decides",
+            ]
+          : [];
 
       const packet = createHtmlArtifactAuthoringPacket({
         kind: "website",
         prompt,
         slugSource: options.title,
         siteSlug: options.siteSlug,
-        selectedTemplate: resolvedTemplate,
+        selectedResources,
         details: [
           `Requested title/site name: ${options.title ?? "not specified"}`,
-          `Selected design system: ${
-            resolvedDesignSystem
-              ? `${resolvedDesignSystem.id} (${resolvedDesignSystem.name})`
-              : "agent decides"
-          }`,
-          ...selectedTemplateDetails(resolvedTemplate),
+          ...resourceDetails,
         ],
         artifactRules: [
           "Build the usable website as the first screen; do not output a landing-page plan.",

--- a/turbo/apps/cli/src/commands/zero/generate/website.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/website.ts
@@ -159,6 +159,7 @@ ${formatRegistryListing(templates, "website templates")}`;
         prompt,
         slugSource: options.title,
         siteSlug: options.siteSlug,
+        selectedTemplate: resolvedTemplate,
         details: [
           `Requested title/site name: ${options.title ?? "not specified"}`,
           `Selected design system: ${

--- a/turbo/apps/cli/src/commands/zero/shared/artifact-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/artifact-generate.ts
@@ -6,6 +6,7 @@ import {
   listDesignSystems,
   listTemplates,
   type GenerationTarget,
+  type RegistryEntry,
   toGenerationTarget,
 } from "./resource-registry";
 import {
@@ -151,25 +152,27 @@ ${formatRegistryListing(templates, `${config.target} templates`)}`;
           resolvedTemplate = entry;
         }
 
-        const extraDetails = [
-          `Selected design system: ${
-            resolvedDesignSystem
-              ? `${resolvedDesignSystem.id} (${resolvedDesignSystem.name})`
-              : "agent decides"
-          }`,
-          `Selected template: ${
-            resolvedTemplate
-              ? `${resolvedTemplate.id} (${resolvedTemplate.name})`
-              : "agent decides"
-          }`,
-        ];
+        const selectedResources: RegistryEntry[] = [];
+        if (resolvedTemplate) {
+          selectedResources.push(resolvedTemplate);
+        }
+        if (resolvedDesignSystem) {
+          selectedResources.push(resolvedDesignSystem);
+        }
+        const extraDetails =
+          selectedResources.length === 0
+            ? [
+                "Selected design system: agent decides",
+                "Selected template: agent decides",
+              ]
+            : [];
 
         const packet = createHtmlArtifactAuthoringPacket({
           kind: toGenerationTarget(config.target),
           prompt,
           slugSource: options.title,
           siteSlug: options.siteSlug,
-          selectedTemplate: resolvedTemplate,
+          selectedResources,
           details: [...config.details(options), ...extraDetails],
           artifactRules: config.artifactRules,
         });

--- a/turbo/apps/cli/src/commands/zero/shared/artifact-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/artifact-generate.ts
@@ -169,6 +169,7 @@ ${formatRegistryListing(templates, `${config.target} templates`)}`;
           prompt,
           slugSource: options.title,
           siteSlug: options.siteSlug,
+          selectedTemplate: resolvedTemplate,
           details: [...config.details(options), ...extraDetails],
           artifactRules: config.artifactRules,
         });

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -13,10 +13,26 @@ interface HtmlArtifactAuthoringOptions {
   readonly prompt: string;
   readonly slugSource?: string;
   readonly siteSlug?: string;
-  readonly selectedTemplate?: RegistryEntry;
+  readonly selectedResources?: readonly RegistryEntry[];
   readonly details: readonly string[];
   readonly artifactRules: readonly string[];
 }
+
+type HtmlArtifactResourceSelection =
+  | {
+      readonly mode: "selected";
+      readonly resources: readonly RegistryEntry[];
+    }
+  | {
+      readonly mode: "candidate";
+      readonly candidates: ResourceCandidateSlice["candidates"];
+      readonly outputSchema: {
+        readonly skills: "string[]";
+        readonly template: "string";
+        readonly designSystem: "string | null";
+        readonly rationale: "string";
+      };
+    };
 
 interface HtmlArtifactAuthoringPacket {
   readonly type: "generation-source-selection";
@@ -37,15 +53,7 @@ interface HtmlArtifactAuthoringPacket {
     readonly previewKind: "hosted-url";
     readonly outputDir: string;
   };
-  readonly selection: {
-    readonly candidates: ResourceCandidateSlice["candidates"];
-    readonly outputSchema: {
-      readonly skills: "string[]";
-      readonly template: "string";
-      readonly designSystem: "string | null";
-      readonly rationale: "string";
-    };
-  };
+  readonly selection: HtmlArtifactResourceSelection;
   readonly authoring: {
     readonly details: readonly string[];
     readonly artifactRules: readonly string[];
@@ -109,19 +117,88 @@ export function createHtmlArtifactAuthoringPacket(
   }`;
   const title = titleForKind(options.kind);
   const candidateSlice = selectResourceCandidates(options.kind);
-  const candidates: ResourceCandidateSlice["candidates"] = {
-    ...candidateSlice.candidates,
-    templates:
-      options.selectedTemplate === undefined
-        ? candidateSlice.candidates.templates
-        : [options.selectedTemplate],
-  };
+  const selectedResources = options.selectedResources ?? [];
+  const hasSelectedResources = selectedResources.length > 0;
   const selectionSchema = {
     skills: "string[]",
     template: "string",
     designSystem: "string | null",
     rationale: "string",
   } as const;
+  const selection: HtmlArtifactResourceSelection = hasSelectedResources
+    ? {
+        mode: "selected",
+        resources: selectedResources,
+      }
+    : {
+        mode: "candidate",
+        candidates: candidateSlice.candidates,
+        outputSchema: selectionSchema,
+      };
+  const packetIntroduction = hasSelectedResources
+    ? [
+        "This is a generation authoring packet for the current agent.",
+        `Zero is not generating this ${title} on the server. The registry resources are already selected; resolve them and author the artifact.`,
+      ]
+    : [
+        "This is a federated generation source-selection packet for the current agent.",
+        `Zero is not generating this ${title} on the server. You select resources, resolve them, and author the artifact.`,
+      ];
+  const resourceSelectionInstructions = hasSelectedResources
+    ? [
+        "## Selected Resources",
+        "- Use every resource listed below. Do not select or add other registry resources.",
+        "",
+        `Registry: \`${candidateSlice.registryVersion}\``,
+        `Source: \`${candidateSlice.source.repo}@${candidateSlice.source.ref}\``,
+        "",
+        "```json",
+        JSON.stringify(selectedResources, null, 2),
+        "```",
+        "",
+      ]
+    : [
+        "## Stage 1: Resource Selection",
+        "- Choose generation resources from the bundled federated registry slice below.",
+        "- Select one template, one or more skills, and zero or one design system.",
+        "- Choose only IDs present in this packet; do not invent registry IDs.",
+        "- Prefer compatible resources, but the user prompt is the highest-priority signal.",
+        "- Treat the selection JSON as internal working state, then continue to authoring.",
+        "",
+        "## Selection Output Schema",
+        "```json",
+        JSON.stringify(selectionSchema, null, 2),
+        "```",
+        "",
+        "## Candidate Registry Slice",
+        `Registry: \`${candidateSlice.registryVersion}\``,
+        "Sources:",
+        ...candidateSlice.sources.map(formatCandidateSource),
+        "",
+        "```json",
+        JSON.stringify(candidateSlice.candidates, null, 2),
+        "```",
+        "",
+      ];
+  const resourceResolutionInstructions = hasSelectedResources
+    ? [
+        "## Resolve Selected Resources",
+        "- Resolve every selected resource listed above before authoring.",
+        "- Each selected resource carries a `source` object with `path` and optional `repo`/`ref`; when `repo`/`ref` are omitted, fall back to the registry-level source above.",
+        "- If `source.archive` is present, pull the private R2 archive with `zero resource pull <resource-id> --dir ./generated/resources`; the CLI requests an authenticated short-lived download URL, verifies the digest, and then extracts `source.path`.",
+        "- For directory refs, inspect the most relevant files such as `SKILL.md`, `DESIGN.md`, `README.md`, tokens, examples, and templates.",
+        "- If a source file cannot be fetched, state that limitation and fall back to the registry metadata for that resource.",
+        "",
+      ]
+    : [
+        "## Stage 2: Resolve Selected Resources",
+        "- First resolve every required resource listed above, then resolve every selected resource before authoring.",
+        "- Each candidate carries a `source` object with `path` and optional `repo`/`ref`; when `repo`/`ref` are omitted, fall back to the registry-level source above.",
+        "- If `source.archive` is present, pull the private R2 archive with `zero resource pull <resource-id> --dir ./generated/resources`; the CLI requests an authenticated short-lived download URL, verifies the digest, and then extracts `source.path`.",
+        "- For directory refs, inspect the most relevant files such as `SKILL.md`, `DESIGN.md`, `README.md`, tokens, examples, and templates.",
+        "- If a source file cannot be fetched, state that limitation and fall back to the registry metadata for that resource.",
+        "",
+      ];
   const artifact = {
     outputMode: "primary-artifact-with-supporting-assets",
     primaryArtifact: {
@@ -156,41 +233,14 @@ export function createHtmlArtifactAuthoringPacket(
   const instructions = [
     `# Zero generate ${options.kind}`,
     "",
-    "This is a federated generation source-selection packet for the current agent.",
-    `Zero is not generating this ${title} on the server. You select resources, resolve them, and author the artifact.`,
+    ...packetIntroduction,
     "",
     "## User Prompt",
     options.prompt,
     "",
-    "## Stage 1: Resource Selection",
-    "- Choose generation resources from the bundled federated registry slice below.",
-    "- Select one template, one or more skills, and zero or one design system.",
-    "- Choose only IDs present in this packet; do not invent registry IDs.",
-    "- Prefer compatible resources, but the user prompt is the highest-priority signal.",
-    "- Treat the selection JSON as internal working state, then continue to authoring.",
-    "",
-    "## Selection Output Schema",
-    "```json",
-    JSON.stringify(selectionSchema, null, 2),
-    "```",
-    "",
-    "## Candidate Registry Slice",
-    `Registry: \`${candidateSlice.registryVersion}\``,
-    "Sources:",
-    ...candidateSlice.sources.map(formatCandidateSource),
-    "",
-    "```json",
-    JSON.stringify(candidates, null, 2),
-    "```",
-    "",
-    "## Stage 2: Resolve Selected Resources",
-    "- First resolve every required resource listed above, then resolve every selected resource before authoring.",
-    "- Each candidate carries a `source` object with `path` and optional `repo`/`ref`; when `repo`/`ref` are omitted, fall back to the registry-level source above.",
-    "- If `source.archive` is present, pull the private R2 archive with `zero resource pull <resource-id> --dir ./generated/resources`; the CLI requests an authenticated short-lived download URL, verifies the digest, and then extracts `source.path`.",
-    "- For directory refs, inspect the most relevant files such as `SKILL.md`, `DESIGN.md`, `README.md`, tokens, examples, and templates.",
-    "- If a source file cannot be fetched, state that limitation and fall back to the registry metadata for that resource.",
-    "",
-    "## Stage 3: Author Artifact",
+    ...resourceSelectionInstructions,
+    ...resourceResolutionInstructions,
+    hasSelectedResources ? "## Author Artifact" : "## Stage 3: Author Artifact",
     `Author a production-quality ${title} as a static HTML artifact using the selected generation resources.`,
     "",
     "## Artifact Output Model",
@@ -213,7 +263,9 @@ export function createHtmlArtifactAuthoringPacket(
     }),
     "",
     "## Authoring Rules",
-    "- Let the selected template define structure, the selected design system define visual language, and the selected skills define process.",
+    hasSelectedResources
+      ? "- Use each selected resource according to its role: templates define structure, design systems define visual language, and skills define process."
+      : "- Let the selected template define structure, the selected design system define visual language, and the selected skills define process.",
     "- Read the local codebase, brand assets, and existing design systems when the prompt depends on this repository.",
     "- Avoid generic AI design defaults: no stock SaaS gradients, no emoji-as-icons, no filler stats, no decorative chrome that does not help the artifact.",
     "- Build the actual artifact first, not a marketing explanation of the artifact.",
@@ -249,10 +301,7 @@ export function createHtmlArtifactAuthoringPacket(
     prompt: options.prompt,
     registryVersion: candidateSlice.registryVersion,
     artifact,
-    selection: {
-      candidates,
-      outputSchema: selectionSchema,
-    },
+    selection,
     authoring: {
       details: options.details,
       artifactRules: options.artifactRules,

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -1,5 +1,6 @@
 import {
   type GenerationOutputKind,
+  type RegistryEntry,
   type ResourceCandidateSlice,
   type GenerationTarget,
   selectResourceCandidates,
@@ -12,6 +13,7 @@ interface HtmlArtifactAuthoringOptions {
   readonly prompt: string;
   readonly slugSource?: string;
   readonly siteSlug?: string;
+  readonly selectedTemplate?: RegistryEntry;
   readonly details: readonly string[];
   readonly artifactRules: readonly string[];
 }
@@ -107,6 +109,13 @@ export function createHtmlArtifactAuthoringPacket(
   }`;
   const title = titleForKind(options.kind);
   const candidateSlice = selectResourceCandidates(options.kind);
+  const candidates: ResourceCandidateSlice["candidates"] = {
+    ...candidateSlice.candidates,
+    templates:
+      options.selectedTemplate === undefined
+        ? candidateSlice.candidates.templates
+        : [options.selectedTemplate],
+  };
   const selectionSchema = {
     skills: "string[]",
     template: "string",
@@ -171,7 +180,7 @@ export function createHtmlArtifactAuthoringPacket(
     ...candidateSlice.sources.map(formatCandidateSource),
     "",
     "```json",
-    JSON.stringify(candidateSlice.candidates, null, 2),
+    JSON.stringify(candidates, null, 2),
     "```",
     "",
     "## Stage 2: Resolve Selected Resources",
@@ -241,7 +250,7 @@ export function createHtmlArtifactAuthoringPacket(
     registryVersion: candidateSlice.registryVersion,
     artifact,
     selection: {
-      candidates: candidateSlice.candidates,
+      candidates,
       outputSchema: selectionSchema,
     },
     authoring: {


### PR DESCRIPTION
## Summary

- pass an explicitly selected template into the HTML artifact authoring packet
- serialize only that template in the candidate registry slice while preserving the full template list when the agent must choose
- cover shared HTML artifact commands and website templates, including R2-backed packages

## Verification

- `pnpm format`
- `NODE_OPTIONS='--max-old-space-size=4096' pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/cli exec vitest run src/commands/zero/generate/__tests__/artifacts.test.ts`
- `pnpm --filter @vm0/cli exec vitest run src/commands/zero/generate/__tests__/website.test.ts`
