### PR TITLE
refactor(cli): retire connector slug capability

### DIFF
--- a/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
@@ -13,7 +13,6 @@ import { basename, join } from "path";
 import { tmpdir } from "os";
 import { http, HttpResponse } from "msw";
 import {
-  CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
   CLIENT_REQUEST_ID_HEADER,
   CLIENT_SESSION_ID_HEADER,
   CLIENT_TYPE_CLI,
@@ -27,7 +26,7 @@ import chalk from "chalk";
 const PREPARE_URL = "http://localhost:3000/api/zero/uploads/prepare";
 const COMPLETE_URL = "http://localhost:3000/api/zero/uploads/complete";
 const PUT_URL = "https://mock-r2.test/upload-target";
-const CLI_VERSION = `0.0.0-test+${CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES}`;
+const CLI_VERSION = "0.0.0-test";
 
 function requiredHeader(headers: Headers, name: string): string {
   const value = headers.get(name);

--- a/turbo/apps/cli/src/lib/api/__tests__/client-headers.test.ts
+++ b/turbo/apps/cli/src/lib/api/__tests__/client-headers.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import {
-  CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
   CLIENT_REQUEST_ID_HEADER,
   CLIENT_SESSION_ID_HEADER,
   CLIENT_TYPE_CLI,
@@ -122,13 +121,9 @@ describe("CLI client headers", () => {
     expect(secondHeaders.get("x-vercel-protection-bypass")).toBe(
       "preview-bypass",
     );
-    expect(firstHeaders.get(CLIENT_VERSION_HEADER)).toBe(
-      `0.0.0-test+${CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES}`,
-    );
+    expect(firstHeaders.get(CLIENT_VERSION_HEADER)).toBe("0.0.0-test");
     expect(firstHeaders.get(CLIENT_TYPE_HEADER)).toBe(CLIENT_TYPE_CLI);
-    expect(secondHeaders.get(CLIENT_VERSION_HEADER)).toBe(
-      `0.0.0-test+${CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES}`,
-    );
+    expect(secondHeaders.get(CLIENT_VERSION_HEADER)).toBe("0.0.0-test");
     expect(secondHeaders.get(CLIENT_TYPE_HEADER)).toBe(CLIENT_TYPE_CLI);
 
     const sessionId = requiredHeader(firstHeaders, CLIENT_SESSION_ID_HEADER);

--- a/turbo/apps/cli/src/lib/api/client-headers.ts
+++ b/turbo/apps/cli/src/lib/api/client-headers.ts
@@ -1,7 +1,5 @@
 import { randomUUID } from "node:crypto";
 import {
-  addClientCapabilityToVersion,
-  CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
   CLIENT_REQUEST_ID_HEADER,
   CLIENT_SESSION_ID_HEADER,
   CLIENT_TYPE_CLI,
@@ -35,10 +33,7 @@ export function createCliClientHeaderInjector(options: {
 }
 
 const addDefaultCliClientHeaders = createCliClientHeaderInjector({
-  clientVersion: addClientCapabilityToVersion(
-    __CLI_VERSION__,
-    CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
-  ),
+  clientVersion: __CLI_VERSION__,
 });
 
 function addCliClientHeaders(headers: Headers): void {

--- a/turbo/packages/api-contracts/src/contracts/client-headers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/client-headers.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   addClientCapabilityToVersion,
   clientVersionSupportsCapability,
-  CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
   CLIENT_CAPABILITY_ES_ES_LOCALE,
   CLIENT_CAPABILITY_FR_FR_LOCALE,
   CLIENT_CAPABILITY_IT_IT_LOCALE,
@@ -76,28 +75,25 @@ describe("client header contract", () => {
               addClientCapabilityToVersion(
                 addClientCapabilityToVersion(
                   addClientCapabilityToVersion(
-                    addClientCapabilityToVersion(
-                      "0.636.1",
-                      CLIENT_CAPABILITY_PT_BR_LOCALE,
-                    ),
-                    CLIENT_CAPABILITY_JA_JP_LOCALE,
+                    "0.636.1",
+                    CLIENT_CAPABILITY_PT_BR_LOCALE,
                   ),
-                  CLIENT_CAPABILITY_KO_KR_LOCALE,
+                  CLIENT_CAPABILITY_JA_JP_LOCALE,
                 ),
-                CLIENT_CAPABILITY_ID_ID_LOCALE,
+                CLIENT_CAPABILITY_KO_KR_LOCALE,
               ),
-              CLIENT_CAPABILITY_DE_DE_LOCALE,
+              CLIENT_CAPABILITY_ID_ID_LOCALE,
             ),
-            CLIENT_CAPABILITY_ES_ES_LOCALE,
+            CLIENT_CAPABILITY_DE_DE_LOCALE,
           ),
-          CLIENT_CAPABILITY_IT_IT_LOCALE,
+          CLIENT_CAPABILITY_ES_ES_LOCALE,
         ),
-        CLIENT_CAPABILITY_FR_FR_LOCALE,
+        CLIENT_CAPABILITY_IT_IT_LOCALE,
       ),
-      CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
+      CLIENT_CAPABILITY_FR_FR_LOCALE,
     );
     expect(version).toBe(
-      "0.636.1+pt-br-locale-v1.ja-jp-locale-v1.ko-kr-locale-v1.id-id-locale-v1.de-de-locale-v1.es-es-locale-v1.it-it-locale-v1.fr-fr-locale-v1.connector-slug-identities-v1",
+      "0.636.1+pt-br-locale-v1.ja-jp-locale-v1.ko-kr-locale-v1.id-id-locale-v1.de-de-locale-v1.es-es-locale-v1.it-it-locale-v1.fr-fr-locale-v1",
     );
     expect(
       clientVersionSupportsCapability(version, CLIENT_CAPABILITY_PT_BR_LOCALE),
@@ -122,12 +118,6 @@ describe("client header contract", () => {
     ).toBe(true);
     expect(
       clientVersionSupportsCapability(version, CLIENT_CAPABILITY_FR_FR_LOCALE),
-    ).toBe(true);
-    expect(
-      clientVersionSupportsCapability(
-        version,
-        CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
-      ),
     ).toBe(true);
     expect(
       clientVersionSupportsCapability(

--- a/turbo/packages/api-contracts/src/contracts/client-headers.ts
+++ b/turbo/packages/api-contracts/src/contracts/client-headers.ts
@@ -10,8 +10,6 @@ export const CLIENT_CAPABILITY_DE_DE_LOCALE = "de-de-locale-v1";
 export const CLIENT_CAPABILITY_ES_ES_LOCALE = "es-es-locale-v1";
 export const CLIENT_CAPABILITY_IT_IT_LOCALE = "it-it-locale-v1";
 export const CLIENT_CAPABILITY_FR_FR_LOCALE = "fr-fr-locale-v1";
-export const CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES =
-  "connector-slug-identities-v1";
 export const ZERO_MAIL_CLIENT_VERSION_HEADER = "X-Zero-Mail-Client-Version";
 export const ZERO_MAIL_CLIENT_VERSION = "3";
 export const CLIENT_FORCE_UPGRADE_STATUS = 426;


### PR DESCRIPTION
## Summary

- stop appending the retired `connector-slug-identities-v1` capability to CLI
  `X-Client-Version` headers
- remove the connector-specific shared contract constant and update affected
  header expectations
- preserve the generic capability helpers and all active locale capability
  advertisements, including the concurrently added French locale

## Compatibility

API `1.355.0` no longer reads this marker and is already deployed in
production, so current API behavior is unchanged.

After the cleanup CLI is published, it cannot use connector-check against API
versions older than #23821. Rolling production API behind that boundary must
restore the compatibility projection first or recover by rolling forward.

## Out of scope

- connector request or response schemas
- API or Platform runtime behavior
- persisted browser state tracked by #23823
- database migrations, runner protocols, feature switches, and release workflow

## Validation

- affected-file Prettier check passed
- `pnpm -F @vm0/api-contracts test` — 515 passed
- `pnpm -F @vm0/cli test` — 977 passed, 1 skipped
- `pnpm -F @vm0/cli exec vitest run src/lib/api/__tests__/client-headers.test.ts src/commands/zero/web/__tests__/upload-file.test.ts` — 15 passed
- `pnpm turbo run lint --filter=@vm0/api-contracts --filter=@vm0/cli`
- `pnpm turbo run check-types --filter=@vm0/api-contracts --filter=@vm0/cli`
- `pnpm turbo run build --filter=@vm0/cli`
- `pnpm knip --workspace @vm0/api-contracts --workspace @vm0/cli`
- `pnpm knip`
- repository search confirms the retired symbol and literal are absent

Closes #24105

Parent: #23814
