### PR TITLE
refactor(connectors): remove legacy authorization state reader

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -4,14 +4,6 @@
  * Feature-switched connectors are enabled per test actor through
  * POST /api/zero/feature-switches. External provider endpoints are mocked with
  * MSW at the HTTP boundary.
- *
- * Not rebuilt here:
- * - The legacy corrupted-provider-state trigger (direct ciphertext UPDATE) is
- *   not API-constructible; the same markClaimError/terminal-error statements
- *   are reached through an STS identity-lookup failure instead.
- * - The legacy abort-after-provider-success commit race drove the service
- *   command directly with a custom aborting KMS client; its persistence path
- *   is statement-identical to the happy-path completion covered here.
  */
 
 import { Buffer } from "node:buffer";

--- a/turbo/apps/api/src/signals/services/__tests__/connector-authorization-provider-state.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-authorization-provider-state.test.ts
@@ -46,23 +46,10 @@ describe("connector OAuth device provider state", () => {
     });
   });
 
-  it.each([
-    {
-      identity: "zero",
-      serializedState: JSON.stringify({ deviceCode: "device-code" }),
-    },
-    {
-      identity: "dual",
-      serializedState: JSON.stringify({
-        connectorType: connectorSlug,
-        connectorSlug,
-        deviceCode: "device-code",
-      }),
-    },
-  ])("rejects $identity identity state", ({ serializedState }) => {
+  it("rejects state without a connector slug", () => {
     expect(() => {
       parseConnectorOauthDeviceProviderState({
-        serializedState,
+        serializedState: JSON.stringify({ deviceCode: "device-code" }),
         connectorSlug,
       });
     }).toThrow(ZodError);
@@ -145,27 +132,13 @@ describe("connector external-code provider state", () => {
     });
   });
 
-  it.each([
-    {
-      identity: "zero",
-      serializedState: JSON.stringify({
-        authMethod,
-        providerState: "provider-state",
-      }),
-    },
-    {
-      identity: "dual",
-      serializedState: JSON.stringify({
-        connectorType: connectorSlug,
-        connectorSlug,
-        authMethod,
-        providerState: "provider-state",
-      }),
-    },
-  ])("rejects $identity identity state", ({ serializedState }) => {
+  it("rejects state without a connector slug", () => {
     expect(() => {
       parseConnectorExternalCodeProviderState({
-        serializedState,
+        serializedState: JSON.stringify({
+          authMethod,
+          providerState: "provider-state",
+        }),
         connectorSlug,
         authMethod,
       });

--- a/turbo/apps/api/src/signals/services/__tests__/connector-authorization-provider-state.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-authorization-provider-state.test.ts
@@ -12,46 +12,29 @@ const connectorSlug = "slack";
 const authMethod = "oauth";
 
 describe("connector OAuth device provider state", () => {
-  it.each([
-    {
-      format: "legacy",
-      serializedState: JSON.stringify({
-        connectorType: connectorSlug,
-        deviceCode: "device-code",
-        pollState: "poll-state",
-        unrelatedProperty: "ignored",
-      }),
-    },
-    {
-      format: "canonical",
-      serializedState: JSON.stringify({
-        connectorSlug,
-        deviceCode: "device-code",
-        pollState: "poll-state",
-        unrelatedProperty: "ignored",
-      }),
-    },
-  ])(
-    "normalizes $format state and preserves poll state",
-    ({ serializedState }) => {
-      expect(
-        parseConnectorOauthDeviceProviderState({
-          serializedState,
+  it("parses canonical state and preserves poll state", () => {
+    expect(
+      parseConnectorOauthDeviceProviderState({
+        serializedState: JSON.stringify({
           connectorSlug,
+          deviceCode: "device-code",
+          pollState: "poll-state",
+          unrelatedProperty: "ignored",
         }),
-      ).toStrictEqual({
         connectorSlug,
-        deviceCode: "device-code",
-        pollState: "poll-state",
-      });
-    },
-  );
+      }),
+    ).toStrictEqual({
+      connectorSlug,
+      deviceCode: "device-code",
+      pollState: "poll-state",
+    });
+  });
 
   it("preserves an absent poll state", () => {
     expect(
       parseConnectorOauthDeviceProviderState({
         serializedState: JSON.stringify({
-          connectorType: connectorSlug,
+          connectorSlug,
           deviceCode: "device-code",
         }),
         connectorSlug,
@@ -94,7 +77,7 @@ describe("connector OAuth device provider state", () => {
         }),
         connectorSlug,
       });
-    }).toThrow("OAuth device provider state connector type mismatch");
+    }).toThrow("OAuth device provider state connector slug mismatch");
   });
 
   it("serializes and parses the exact canonical-only state with poll state", () => {
@@ -107,7 +90,6 @@ describe("connector OAuth device provider state", () => {
     expect(serializedState).toBe(
       '{"connectorSlug":"slack","deviceCode":"device-code","pollState":"poll-state"}',
     );
-    expect(serializedState).not.toContain("connectorType");
     expect(
       parseConnectorOauthDeviceProviderState({
         serializedState,
@@ -130,7 +112,6 @@ describe("connector OAuth device provider state", () => {
     expect(serializedState).toBe(
       '{"connectorSlug":"slack","deviceCode":"device-code"}',
     );
-    expect(serializedState).not.toContain("connectorType");
     expect(
       parseConnectorOauthDeviceProviderState({
         serializedState,
@@ -145,41 +126,24 @@ describe("connector OAuth device provider state", () => {
 });
 
 describe("connector external-code provider state", () => {
-  it.each([
-    {
-      format: "legacy",
-      serializedState: JSON.stringify({
-        connectorType: connectorSlug,
-        authMethod,
-        providerState: "provider-state",
-        unrelatedProperty: "ignored",
-      }),
-    },
-    {
-      format: "canonical",
-      serializedState: JSON.stringify({
-        connectorSlug,
-        authMethod,
-        providerState: "provider-state",
-        unrelatedProperty: "ignored",
-      }),
-    },
-  ])(
-    "normalizes $format state and preserves provider state",
-    ({ serializedState }) => {
-      expect(
-        parseConnectorExternalCodeProviderState({
-          serializedState,
+  it("parses canonical state and preserves provider state", () => {
+    expect(
+      parseConnectorExternalCodeProviderState({
+        serializedState: JSON.stringify({
           connectorSlug,
           authMethod,
+          providerState: "provider-state",
+          unrelatedProperty: "ignored",
         }),
-      ).toStrictEqual({
         connectorSlug,
         authMethod,
-        providerState: "provider-state",
-      });
-    },
-  );
+      }),
+    ).toStrictEqual({
+      connectorSlug,
+      authMethod,
+      providerState: "provider-state",
+    });
+  });
 
   it.each([
     {
@@ -245,7 +209,6 @@ describe("connector external-code provider state", () => {
     expect(serializedState).toBe(
       '{"connectorSlug":"slack","authMethod":"oauth","providerState":"provider-state"}',
     );
-    expect(serializedState).not.toContain("connectorType");
     expect(
       parseConnectorExternalCodeProviderState({
         serializedState,

--- a/turbo/apps/api/src/signals/services/connector-authorization-provider-state.ts
+++ b/turbo/apps/api/src/signals/services/connector-authorization-provider-state.ts
@@ -8,7 +8,6 @@ import { z } from "zod";
 
 const deviceProviderStateSchema = z
   .object({
-    connectorType: z.never().optional(),
     connectorSlug: connectorSlugSchema,
     deviceCode: z.string(),
     pollState: z.string().optional(),
@@ -23,7 +22,6 @@ const deviceProviderStateSchema = z
 
 const externalCodeProviderStateSchema = z
   .object({
-    connectorType: z.never().optional(),
     connectorSlug: connectorSlugSchema,
     authMethod: connectorAuthMethodIdSchema,
     providerState: z.string(),

--- a/turbo/apps/api/src/signals/services/connector-authorization-provider-state.ts
+++ b/turbo/apps/api/src/signals/services/connector-authorization-provider-state.ts
@@ -6,24 +6,7 @@ import {
 } from "@vm0/api-contracts/contracts/connector-identity";
 import { z } from "zod";
 
-// #23770 accepts either single identity property until #24077 removes the
-// legacy reader after the staged writer rollout.
-const deviceLegacyProviderStateSchema = z
-  .object({
-    connectorType: connectorSlugSchema,
-    connectorSlug: z.never().optional(),
-    deviceCode: z.string(),
-    pollState: z.string().optional(),
-  })
-  .transform((state) => {
-    return {
-      connectorSlug: state.connectorType,
-      deviceCode: state.deviceCode,
-      pollState: state.pollState,
-    };
-  });
-
-const deviceCanonicalProviderStateSchema = z
+const deviceProviderStateSchema = z
   .object({
     connectorType: z.never().optional(),
     connectorSlug: connectorSlugSchema,
@@ -38,27 +21,7 @@ const deviceCanonicalProviderStateSchema = z
     };
   });
 
-const deviceProviderStateSchema = z.union([
-  deviceLegacyProviderStateSchema,
-  deviceCanonicalProviderStateSchema,
-]);
-
-const externalCodeLegacyProviderStateSchema = z
-  .object({
-    connectorType: connectorSlugSchema,
-    connectorSlug: z.never().optional(),
-    authMethod: connectorAuthMethodIdSchema,
-    providerState: z.string(),
-  })
-  .transform((state) => {
-    return {
-      connectorSlug: state.connectorType,
-      authMethod: state.authMethod,
-      providerState: state.providerState,
-    };
-  });
-
-const externalCodeCanonicalProviderStateSchema = z
+const externalCodeProviderStateSchema = z
   .object({
     connectorType: z.never().optional(),
     connectorSlug: connectorSlugSchema,
@@ -72,11 +35,6 @@ const externalCodeCanonicalProviderStateSchema = z
       providerState: state.providerState,
     };
   });
-
-const externalCodeProviderStateSchema = z.union([
-  externalCodeLegacyProviderStateSchema,
-  externalCodeCanonicalProviderStateSchema,
-]);
 
 export function parseConnectorOauthDeviceProviderState(args: {
   readonly serializedState: string;
@@ -86,7 +44,7 @@ export function parseConnectorOauthDeviceProviderState(args: {
     JSON.parse(args.serializedState) as unknown,
   );
   if (providerState.connectorSlug !== args.connectorSlug) {
-    throw new Error("OAuth device provider state connector type mismatch");
+    throw new Error("OAuth device provider state connector slug mismatch");
   }
   return providerState;
 }

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -67,7 +67,7 @@ const externalCodeSessionSelection = Object.freeze({
   userId: connectorExternalCodeSessions.userId,
   agentId: connectorExternalCodeSessions.agentId,
   authorizeAgent: connectorExternalCodeSessions.authorizeAgent,
-  connectorType: connectorExternalCodeSessions.connectorSlug,
+  connectorSlug: connectorExternalCodeSessions.connectorSlug,
   authMethod: connectorExternalCodeSessions.authMethod,
   status: connectorExternalCodeSessions.status,
   sessionTokenHash: connectorExternalCodeSessions.sessionTokenHash,
@@ -81,12 +81,7 @@ const externalCodeSessionSelection = Object.freeze({
   completedAt: connectorExternalCodeSessions.completedAt,
 });
 
-type ExternalCodeSessionRow = Omit<
-  typeof connectorExternalCodeSessions.$inferSelect,
-  "connectorSlug"
-> & {
-  readonly connectorType: typeof connectorExternalCodeSessions.$inferSelect.connectorSlug;
-};
+type ExternalCodeSessionRow = typeof connectorExternalCodeSessions.$inferSelect;
 
 type ExternalCodeSessionOwner = {
   readonly connectorSlug: ConnectorSlug;

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -74,7 +74,7 @@ const deviceAuthSessionSelection = Object.freeze({
   userId: connectorOauthDeviceAuthorizationSessions.userId,
   agentId: connectorOauthDeviceAuthorizationSessions.agentId,
   authorizeAgent: connectorOauthDeviceAuthorizationSessions.authorizeAgent,
-  connectorType: connectorOauthDeviceAuthorizationSessions.connectorSlug,
+  connectorSlug: connectorOauthDeviceAuthorizationSessions.connectorSlug,
   authMethod: connectorOauthDeviceAuthorizationSessions.authMethod,
   status: connectorOauthDeviceAuthorizationSessions.status,
   sessionTokenHash: connectorOauthDeviceAuthorizationSessions.sessionTokenHash,
@@ -93,12 +93,8 @@ const deviceAuthSessionSelection = Object.freeze({
   completedAt: connectorOauthDeviceAuthorizationSessions.completedAt,
 });
 
-type DeviceAuthSessionRow = Omit<
-  typeof connectorOauthDeviceAuthorizationSessions.$inferSelect,
-  "connectorSlug"
-> & {
-  readonly connectorType: typeof connectorOauthDeviceAuthorizationSessions.$inferSelect.connectorSlug;
-};
+type DeviceAuthSessionRow =
+  typeof connectorOauthDeviceAuthorizationSessions.$inferSelect;
 
 type PendingPollBody = Extract<
   ConnectorOauthDeviceAuthSessionPollResponse,


### PR DESCRIPTION
## Summary

- collapse the device-auth and external-code persisted-state readers to
  canonical-only `connectorSlug` schemas containing only canonical fields
- remove transition-era database row aliases and use canonical inferred row
  types
- remove legacy acceptance fixtures, negative legacy-field cases, redundant
  compatibility assertions, and a stale external-code BDD coverage note

## Compatibility

- canonical serializer output remains byte-for-byte unchanged
- canonical parser result shape, including explicit `pollState: undefined`, is
  preserved
- removed identity properties are not represented in production schemas or
  focused tests; canonical documents retain the existing unknown-property
  handling
- no database migration, ciphertext mutation, public API, feature switch,
  provider protocol, transaction, or lifecycle behavior changes
- any surviving legacy active state lacks canonical identity and fails at the
  existing parser boundary, as explicitly accepted by the #24075 Gate 2
  decision

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api exec vitest run src/signals/services/__tests__/connector-authorization-provider-state.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts -t "CONN-02: OAuth device authorization"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-external-code.bdd.test.ts`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`

## Tracking

Relates to #24077.

Parent delivery issue: #23770.

#24077 intentionally remains open after merge until the cleanup is current in
production and its final production/source audit is recorded.
