### PR TITLE
refactor(api): replace scalar existence probes with builders

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-artifacts.ts
+++ b/turbo/apps/api/src/signals/routes/zero-artifacts.ts
@@ -1,11 +1,9 @@
 import { command } from "ccstate";
-import { and, eq, exists, sql, type SQL } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { artifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { imageArtifactEditSnapshots } from "@vm0/db/schema/image-artifact-edit-snapshot";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
-import { z } from "zod";
 
-import { executeRawRows } from "../../lib/db-raw-rows";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, queryOf } from "../context/request";
@@ -14,8 +12,6 @@ import { zeroArtifacts$ } from "../services/zero-chat-thread.service";
 import { nowDate } from "../../lib/time";
 import { notFound } from "../../lib/error";
 import type { RouteEntry } from "../route-entry";
-
-const artifactAccessRowSchema = z.object({ canAccess: z.boolean() });
 
 interface UserArtifactUrlAccessArgs {
   readonly artifactUrl: string;
@@ -27,37 +23,23 @@ function artifactNotFound() {
   return notFound("Artifact not found");
 }
 
-function uploadedArtifactAccessCondition(
+async function userCanAccessArtifactUrl(
   db: Pick<Db, "select">,
   args: UserArtifactUrlAccessArgs,
-): SQL {
-  return exists(
-    db
-      .select({ id: runUploadedFiles.id })
-      .from(runUploadedFiles)
-      .where(
-        and(
-          eq(runUploadedFiles.userId, args.userId),
-          eq(runUploadedFiles.orgId, args.orgId),
-          eq(runUploadedFiles.url, args.artifactUrl),
-        ),
-      ),
-  );
-}
-
-async function userCanAccessArtifactUrl(
-  db: Db,
-  args: UserArtifactUrlAccessArgs,
 ): Promise<boolean> {
-  const rows = await executeRawRows(
-    db,
-    sql`
-      SELECT ${uploadedArtifactAccessCondition(db, args)} AS "canAccess"
-    `,
-    artifactAccessRowSchema,
-  );
+  const [artifact] = await db
+    .select({ id: runUploadedFiles.id })
+    .from(runUploadedFiles)
+    .where(
+      and(
+        eq(runUploadedFiles.userId, args.userId),
+        eq(runUploadedFiles.orgId, args.orgId),
+        eq(runUploadedFiles.url, args.artifactUrl),
+      ),
+    )
+    .limit(1);
 
-  return rows[0]?.canAccess === true;
+  return artifact !== undefined;
 }
 
 async function deleteImageEditSnapshotRow(

--- a/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
@@ -8,6 +8,7 @@ import {
   gt,
   isNull,
   lt,
+  notExists,
   or,
   sql,
   type SQL,
@@ -31,7 +32,7 @@ interface SnapshotCompactionStats {
   readonly eventsPruned: number;
 }
 
-type SnapshotRootDb = Pick<Db, "execute" | "transaction">;
+type SnapshotRootDb = Pick<Db, "execute" | "select" | "transaction">;
 const CHAT_THREAD_EVENT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_CHAT_THREAD_SNAPSHOT_BATCH_SIZE = 500;
 const CHAT_THREAD_SNAPSHOT_STALE_MS = 24 * 60 * 60 * 1000;
@@ -122,7 +123,7 @@ function candidateScopesCte(staleCutoff: Date, batchSize: number): SQL {
   `;
 }
 
-function rebuiltCte(): SQL {
+function rebuiltCte(db: Pick<Db, "select">): SQL {
   return sql`
     rebuilt AS (
       SELECT
@@ -198,14 +199,17 @@ function rebuiltCte(): SQL {
         FROM jsonb_array_elements(
           COALESCE(${snapshot.chatThreads}, '[]'::jsonb)
         ) AS old_thread(thread)
-        WHERE NOT EXISTS (
-          SELECT 1
-          FROM ${agentComposes} ${agent}
-          WHERE ${and(
-            eq(agent.id, sql`(old_thread.thread ->> 'agentId')::uuid`),
-            eq(agent.orgId, sql`scope.org_id`),
-          )}
-          )
+        WHERE ${notExists(
+          db
+            .select({ id: agent.id })
+            .from(agent)
+            .where(
+              and(
+                eq(agent.id, sql`(old_thread.thread ->> 'agentId')::uuid`),
+                eq(agent.orgId, sql`scope.org_id`),
+              ),
+            ),
+        )}
         ) deleted_agent_threads ON true
     )
   `;
@@ -243,15 +247,18 @@ function upsertedCte(updatedAt: Date): SQL {
   `;
 }
 
-function compactChatThreadSnapshotBatchSql(args: {
-  readonly updatedAt: Date;
-  readonly staleCutoff: Date;
-  readonly batchSize: number;
-}): SQL {
+function compactChatThreadSnapshotBatchSql(
+  db: Pick<Db, "select">,
+  args: {
+    readonly updatedAt: Date;
+    readonly staleCutoff: Date;
+    readonly batchSize: number;
+  },
+): SQL {
   return sql`
     WITH ${allScopesCte(args.staleCutoff)},
     ${candidateScopesCte(args.staleCutoff, args.batchSize)},
-    ${rebuiltCte()},
+    ${rebuiltCte(db)},
     ${upsertedCte(args.updatedAt)}
     SELECT
       ${count()}::int AS "scopes",
@@ -273,7 +280,7 @@ async function compactChatThreadSnapshotBatch(
   );
   const rows = await executeRawRows(
     db,
-    compactChatThreadSnapshotBatchSql({
+    compactChatThreadSnapshotBatchSql(db, {
       updatedAt,
       staleCutoff,
       batchSize: chatThreadSnapshotBatchSize(),

--- a/turbo/apps/api/src/signals/services/cron-compact-usage-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-compact-usage-events.service.ts
@@ -80,10 +80,6 @@ const compactionRowSchema = z.object({
   reconciled: z.boolean(),
 });
 
-const remainingRawRowSchema = z.object({
-  hasMoreRaw: z.boolean(),
-});
-
 // The explicit null order matches a reverse scan of the deployed
 // idx_usage_event_processed_org_user index. Eligible rows are always non-null.
 const oldestProcessedEventOrder = sql`${asc(event.processedAt)} NULLS FIRST`;
@@ -557,28 +553,15 @@ async function loadHoldProbe(
 }
 
 async function hasRemainingRawUsage(
-  db: Pick<Db, "execute">,
+  db: Pick<Db, "select">,
   cutoff: string,
 ): Promise<boolean> {
-  const rows = await executeRawRows(
-    db,
-    sql`
-      SELECT EXISTS (
-        SELECT 1
-        FROM ${usageEvent} ${event}
-        WHERE ${eligibleRawPredicate(cutoff)}
-        LIMIT 1
-      ) AS "hasMoreRaw"
-    `,
-    remainingRawRowSchema,
-  );
-  const remaining = rows[0];
-  if (!remaining) {
-    throw new Error(
-      "Usage event compaction remaining probe returned no summary row",
-    );
-  }
-  return remaining.hasMoreRaw;
+  const [remaining] = await db
+    .select({ id: event.id })
+    .from(event)
+    .where(eligibleRawPredicate(cutoff))
+    .limit(1);
+  return remaining !== undefined;
 }
 
 async function compactUsageEventBatch(

--- a/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
@@ -1467,6 +1467,182 @@ const queryBuilderCases = {
   ],
   readValid: [
     {
+      name: "typed existence wrappers keep non-row-select builders opaque",
+      code: `${rawRowsImport}${structuredSelectionPreamble}
+        import { count, eq, exists, sql } from "drizzle-orm";
+        declare const rowSchema: never;
+        const joined = db
+          .select({ id: users.id })
+          .from(users)
+          .innerJoin(messages, eq(messages.userId, users.id));
+        const extraTargets = db
+          .select({ id: users.id, name: users.name })
+          .from(users);
+        const computed = db
+          .select({ id: sql\`\${users.id}\` })
+          .from(users);
+        const aggregate = db
+          .select({ id: count(users.id) })
+          .from(users);
+        const grouped = db
+          .select({ id: users.id })
+          .from(users)
+          .groupBy(users.id);
+        const ordered = db
+          .select({ id: users.id })
+          .from(users)
+          .orderBy(users.id);
+        const limited = db
+          .select({ id: users.id })
+          .from(users)
+          .limit(1);
+        const rawSource = db
+          .select({ id: users.id })
+          .from(sql\`users\`);
+        const locked = db
+          .select({ id: users.id })
+          .from(users)
+          .for("update");
+        const unioned = db
+          .select({ id: users.id })
+          .from(users)
+          .union(db.select({ id: users.id }).from(users));
+        const sq = db.$with("sq").as(
+          db.select({ id: users.id }).from(users),
+        );
+        const withCte = db
+          .with(sq)
+          .select({ id: sq.id })
+          .from(sq);
+        await executeRawRows(
+          db,
+          sql\`SELECT \${exists(joined)} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${exists(extraTargets)} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${exists(computed)} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${exists(aggregate)} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${exists(grouped)} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${exists(ordered)} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${exists(limited)} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${exists(rawSource)} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${exists(locked)} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${exists(unioned)} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${exists(withCte)} AS visible\`,
+          rowSchema,
+        );
+        const [directRow] = await db
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.id, 1))
+          .limit(1);
+        void directRow;
+      `,
+    },
+    {
+      name: "typed existence wrappers keep uncertain provenance and outer shapes opaque",
+      code: `${rawRowsImport}${structuredSelectionPreamble}
+        import {
+          eq,
+          exists as drizzleExists,
+          sql,
+          type SQL,
+        } from "drizzle-orm";
+        declare const rowSchema: never;
+        declare const choose: boolean;
+        const selected = db
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.id, 1));
+        let mutable = drizzleExists(selected);
+        const conditional = choose
+          ? drizzleExists(selected)
+          : drizzleExists(selected);
+        declare function opaque(): SQL;
+        function multiStatement() {
+          const condition = drizzleExists(selected);
+          return condition;
+        }
+        function exists(value: unknown): SQL {
+          return sql\`\${value}\`;
+        }
+        await executeRawRows(
+          db,
+          sql\`SELECT \${mutable} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${conditional} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${opaque()} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${multiStatement()} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${exists(selected)} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${drizzleExists(selected)} AS visible ORDER BY 1\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${drizzleExists(selected)} AS visible, 1 AS extra\`,
+          rowSchema,
+        );
+        void mutable;
+      `,
+    },
+    {
       code: `${rawRowsImport}${schemaPreamble}
         import { sql } from "drizzle-orm";
         await executeRawRows(
@@ -2278,6 +2454,76 @@ const queryBuilderCases = {
     },
   ],
   readInvalid: [
+    {
+      name: "single-table scalar existence uses a row-presence builder",
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT EXISTS (
+              SELECT 1
+              FROM \${runs}
+              WHERE \${eq(runs.threadId, threadId)}
+              LIMIT 1
+            ) AS visible
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [
+        { messageId: "existsQueryBuilder" },
+        {
+          messageId: "existencePredicate",
+          data: { helper: "exists" },
+        },
+      ],
+    },
+    {
+      name: "typed scalar existence resolves conventional local provenance",
+      code: `${rawRowsImport}${structuredSelectionPreamble}
+        import { eq, exists, sql } from "drizzle-orm";
+        declare const rowSchema: never;
+        const selected = db
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.id, 1));
+        const visible = exists(selected);
+        function userExists(database: typeof db, userId: number) {
+          return exists(
+            database
+              .select({ id: users.id })
+              .from(users)
+              .where(eq(users.id, userId)),
+          );
+        }
+        await executeRawRows(
+          db,
+          sql\`SELECT \${exists(
+            db
+              .select({ id: users.id })
+              .from(users)
+              .where(eq(users.id, 1)),
+          )} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${visible} AS visible\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${userExists(db, 1)} AS visible\`,
+          rowSchema,
+        );
+      `,
+      errors: [
+        { messageId: "existsQueryBuilder" },
+        { messageId: "existsQueryBuilder" },
+        { messageId: "existsQueryBuilder" },
+      ],
+    },
     {
       code: `${rawRowsImport}${schemaPreamble}
         import { eq, gt, sql, sum } from "drizzle-orm";

--- a/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
@@ -1467,6 +1467,39 @@ const queryBuilderCases = {
   ],
   readValid: [
     {
+      name: "scalar existence keeps uncertain aliases and optional boolean trees opaque",
+      code: `${rawRowsImport}${schemaPreamble}
+        import { and, eq, sql, type SQL } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const mismatchedAlias = alias(runStates, "event");
+        declare const optionalPredicate: SQL | undefined;
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT EXISTS (
+              SELECT 1
+              FROM \${runs} \${mismatchedAlias}
+              WHERE \${eq(mismatchedAlias.id, threadId)}
+              LIMIT 1
+            ) AS visible
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT EXISTS (
+              SELECT 1
+              FROM \${runs}
+              WHERE \${and(optionalPredicate)}
+              LIMIT 1
+            ) AS visible
+          \`,
+          rowSchema,
+        );
+      `,
+    },
+    {
       name: "typed existence wrappers keep non-row-select builders opaque",
       code: `${rawRowsImport}${structuredSelectionPreamble}
         import { count, eq, exists, sql } from "drizzle-orm";
@@ -2454,6 +2487,73 @@ const queryBuilderCases = {
     },
   ],
   readInvalid: [
+    {
+      name: "aliased compound scalar existence uses a row-presence builder",
+      code: `${rawRowsImport}${schemaPreamble}
+        import {
+          and,
+          eq,
+          isNotNull,
+          sql,
+          type SQL,
+        } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const event = alias(runs, "event");
+        function eligibleRunPredicate(value: number): SQL {
+          return sql\`\${and(
+            eq(event.threadId, value),
+            isNotNull(event.id),
+          )}\`;
+        }
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT EXISTS (
+              SELECT 1
+              FROM \${runs} \${event}
+              WHERE \${eligibleRunPredicate(threadId)}
+              LIMIT 1
+            ) AS visible
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [
+        {
+          messageId: "existencePredicate",
+          data: { helper: "exists" },
+        },
+        { messageId: "existsQueryBuilder" },
+      ],
+    },
+    {
+      name: "fixed compound scalar existence uses a row-presence builder",
+      code: `${rawRowsImport}${schemaPreamble}
+        import { and, eq, isNotNull, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT EXISTS (
+              SELECT 1
+              FROM \${runs}
+              WHERE \${and(
+                eq(runs.threadId, threadId),
+                isNotNull(runs.id),
+              )}
+              LIMIT 1
+            ) AS visible
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [
+        { messageId: "existsQueryBuilder" },
+        {
+          messageId: "existencePredicate",
+          data: { helper: "exists" },
+        },
+      ],
+    },
     {
       name: "single-table scalar existence uses a row-presence builder",
       code: `${rawRowsImport}${schemaPreamble}

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -391,7 +391,6 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           LEFT JOIN \${otherUsers} ON \${condition}
           WHERE \${condition}
         )\`;
-        sql\`EXISTS (SELECT 1 FROM \${users} WHERE \${or(condition, condition)})\`;
         sql\`EXISTS (SELECT 1 FROM \${users} WHERE \${condition} FOR UPDATE)\`;
         sql\`EXISTS (SELECT 1 FROM \${users} WHERE \${condition}); SELECT 1\`;
       `,
@@ -2167,6 +2166,27 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
               FROM \${users}
               WHERE \${eq(users.id, 1)}
                 AND \${isNotNull(users.name)}
+            )\`,
+          );
+      `,
+      errors: [
+        {
+          messageId: "existencePredicate",
+          data: { helper: "exists" },
+        },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, or, sql } from "drizzle-orm";
+        const condition = eq(users.id, 1);
+        db.select()
+          .from(users)
+          .where(
+            sql\`EXISTS (
+              SELECT 1
+              FROM \${users}
+              WHERE \${or(condition, condition)}
             )\`,
           );
       `,

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -33,11 +33,14 @@ import {
   drizzleCallName,
   getDrizzleColumnDataType,
   getDrizzleColumnMetadata,
+  getDrizzleTableMetadataForWrite,
   isDrizzleDeclaration,
   isDrizzlePgCoreDeclaration,
+  isDrizzleSelectType,
   isDrizzleSqlTag,
   isDrizzleSqlType,
   isDrizzleSymbol,
+  isDrizzleTableType,
   isNamedDrizzleSignature,
   resolvedSymbol,
 } from "../drizzle.ts";
@@ -224,6 +227,7 @@ export const preferDrizzleApis = createRule({
       hasDirectResultMapping: hasDirectMapWith,
       hasParameterListOrigin,
       isInlineParameterList: isInlineParameterListSqlJoin,
+      isSelectExistence,
     };
 
     function allowsWriteQueryBuilder(
@@ -835,6 +839,200 @@ export const preferDrizzleApis = createRule({
         statement.expression !== undefined
         ? services.tsNodeToESTreeNodeMap.get(statement.expression)
         : undefined;
+    }
+
+    function isConventionalReferenceExpression(
+      node: TSESTree.Expression,
+    ): boolean {
+      const transparent = transparentNode(node);
+      if (transparent !== undefined) {
+        return isConventionalReferenceExpression(transparent);
+      }
+      if (
+        node.type === AST_NODE_TYPES.Identifier ||
+        node.type === AST_NODE_TYPES.Literal
+      ) {
+        return true;
+      }
+      return (
+        node.type === AST_NODE_TYPES.MemberExpression &&
+        !node.computed &&
+        !node.optional &&
+        node.object.type !== AST_NODE_TYPES.Super &&
+        node.property.type === AST_NODE_TYPES.Identifier &&
+        isConventionalReferenceExpression(node.object)
+      );
+    }
+
+    function localSelectExistenceReturn(
+      node: TSESTree.CallExpression,
+    ): TSESTree.Node | undefined {
+      if (
+        node.callee.type !== AST_NODE_TYPES.Identifier ||
+        node.arguments.some((argument) => {
+          return (
+            argument.type === AST_NODE_TYPES.SpreadElement ||
+            !isConventionalReferenceExpression(argument)
+          );
+        })
+      ) {
+        return undefined;
+      }
+      const tsCallee = services.esTreeNodeToTSNodeMap.get(node.callee);
+      const declaration = resolvedSymbol(
+        checker,
+        checker.getSymbolAtLocation(tsCallee),
+      )?.valueDeclaration;
+      if (
+        declaration === undefined ||
+        !isFunctionDeclaration(declaration) ||
+        declaration.getSourceFile() !== tsCallee.getSourceFile() ||
+        declaration.parameters.length !== node.arguments.length ||
+        declaration.parameters.some((parameter) => {
+          return (
+            parameter.dotDotDotToken !== undefined ||
+            parameter.initializer !== undefined ||
+            !isIdentifier(parameter.name)
+          );
+        }) ||
+        declaration.body === undefined ||
+        declaration.body.statements.length !== 1
+      ) {
+        return undefined;
+      }
+      const statement = declaration.body.statements[0];
+      return statement !== undefined &&
+        isReturnStatement(statement) &&
+        statement.expression !== undefined
+        ? services.tsNodeToESTreeNodeMap.get(statement.expression)
+        : undefined;
+    }
+
+    function isDirectSchemaRowSelect(
+      node: TSESTree.Node,
+      visited: Set<TSESTree.Node>,
+    ): boolean {
+      if (visited.has(node)) {
+        return false;
+      }
+      visited.add(node);
+      const transparent = transparentNode(node);
+      if (transparent !== undefined) {
+        return isDirectSchemaRowSelect(transparent, visited);
+      }
+      const initializer = localSelectionInitializer(node);
+      if (initializer !== undefined) {
+        return isDirectSchemaRowSelect(initializer, visited);
+      }
+      if (node.type !== AST_NODE_TYPES.CallExpression) {
+        return false;
+      }
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      if (
+        !isDrizzleSelectType(checker, checker.getTypeAtLocation(tsNode), tsNode)
+      ) {
+        return false;
+      }
+
+      let current: TSESTree.Expression = node;
+      const where = directDrizzleCall(current, "where");
+      if (where !== undefined) {
+        const beforeWhere = callReceiver(where);
+        if (
+          where.optional ||
+          singleCallArgument(where) === undefined ||
+          beforeWhere === undefined
+        ) {
+          return false;
+        }
+        current = beforeWhere;
+      }
+
+      const from = directDrizzleCall(current, "from");
+      const source = from === undefined ? undefined : singleCallArgument(from);
+      const beforeFrom = from === undefined ? undefined : callReceiver(from);
+      if (
+        from?.optional === true ||
+        source === undefined ||
+        beforeFrom === undefined
+      ) {
+        return false;
+      }
+      const tsSource = services.esTreeNodeToTSNodeMap.get(source);
+      const sourceType = checker.getTypeAtLocation(tsSource);
+      const sourceMetadata = getDrizzleTableMetadataForWrite(checker, tsSource);
+      if (
+        !isDrizzleTableType(checker, sourceType, tsSource) ||
+        sourceMetadata === undefined
+      ) {
+        return false;
+      }
+
+      const select = directDrizzleCall(beforeFrom, "select");
+      const selection =
+        select === undefined ? undefined : singleCallArgument(select);
+      if (
+        select?.optional === true ||
+        selection?.type !== AST_NODE_TYPES.ObjectExpression ||
+        selection.properties.length !== 1
+      ) {
+        return false;
+      }
+      const property = selection.properties[0];
+      if (
+        property?.type !== AST_NODE_TYPES.Property ||
+        property.kind !== "init" ||
+        property.computed ||
+        property.method ||
+        (property.value.type !== AST_NODE_TYPES.Identifier &&
+          property.value.type !== AST_NODE_TYPES.MemberExpression) ||
+        !isConventionalColumnExpression(property.value)
+      ) {
+        return false;
+      }
+      const selectedColumn = columnMetadata(property.value);
+      return (
+        selectedColumn !== undefined &&
+        selectedColumn.tableName === sourceMetadata.name &&
+        sourceMetadata.columns.has(selectedColumn.databaseName)
+      );
+    }
+
+    function isSelectExistenceNode(
+      node: TSESTree.Node,
+      visited: Set<TSESTree.Node>,
+    ): boolean {
+      if (visited.has(node)) {
+        return false;
+      }
+      visited.add(node);
+      const transparent = transparentNode(node);
+      if (transparent !== undefined) {
+        return isSelectExistenceNode(transparent, visited);
+      }
+      const initializer = localSelectionInitializer(node);
+      if (initializer !== undefined) {
+        return isSelectExistenceNode(initializer, visited);
+      }
+      if (node.type !== AST_NODE_TYPES.CallExpression) {
+        return false;
+      }
+      const returned = localSelectExistenceReturn(node);
+      if (returned !== undefined) {
+        return isSelectExistenceNode(returned, visited);
+      }
+      const select = node.arguments[0];
+      return (
+        node.arguments.length === 1 &&
+        select !== undefined &&
+        select.type !== AST_NODE_TYPES.SpreadElement &&
+        isNamedDrizzleCall(node, "exists") &&
+        isDirectSchemaRowSelect(select, new Set())
+      );
+    }
+
+    function isSelectExistence(node: TSESTree.Expression): boolean {
+      return isSelectExistenceNode(node, new Set());
     }
 
     function isDrizzleResultWrapper(node: TSESTree.CallExpression): boolean {

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -114,6 +114,7 @@ export interface SqlCapabilityChecks {
   hasDirectResultMapping(node: TSESTree.Expression): boolean;
   hasParameterListOrigin(node: TSESTree.Expression): boolean;
   isInlineParameterList(node: TSESTree.Expression): boolean;
+  isSelectExistence(node: TSESTree.Expression): boolean;
 }
 
 const NO_CAPABILITY_CHECKS: SqlCapabilityChecks = {
@@ -130,6 +131,9 @@ const NO_CAPABILITY_CHECKS: SqlCapabilityChecks = {
     return false;
   },
   isInlineParameterList(): boolean {
+    return false;
+  },
+  isSelectExistence(): boolean {
     return false;
   },
 };
@@ -207,6 +211,7 @@ interface SqlMarker {
   readonly isNumber: boolean;
   readonly isPatternOperand: boolean;
   readonly isSelect: boolean;
+  readonly isSelectExistence: boolean;
   readonly isStringOrWrapper: boolean;
   readonly isAnalyzableWriteInterpolation: boolean;
   readonly isTable: boolean;
@@ -1135,6 +1140,7 @@ function parseSqlVariant(
   checker: TypeChecker,
   services: ParserServicesWithTypeInformation,
   schemaTarget: SqlSchemaTarget | undefined,
+  capabilities: SqlCapabilityChecks = NO_CAPABILITY_CHECKS,
 ): ParsedSql | null {
   const literals = variant.chunks.flatMap((chunk) => {
     return chunk.kind === "literal" ? [chunk.text] : [];
@@ -1185,6 +1191,7 @@ function parseSqlVariant(
     let cachedNumber: boolean | undefined;
     let cachedPatternOperand: boolean | undefined;
     let cachedSelect: boolean | undefined;
+    let cachedSelectExistence: boolean | undefined;
     let cachedAnalyzableWriteInterpolation: boolean | undefined;
     let cachedStringOrWrapper: boolean | undefined;
     let cachedTable: boolean | undefined;
@@ -1251,6 +1258,10 @@ function parseSqlVariant(
       get isSelect(): boolean {
         cachedSelect ??= markerIsSelect(expression, checker, services);
         return cachedSelect;
+      },
+      get isSelectExistence(): boolean {
+        cachedSelectExistence ??= capabilities.isSelectExistence(expression);
+        return cachedSelectExistence;
       },
       get isAnalyzableWriteInterpolation(): boolean {
         cachedAnalyzableWriteInterpolation ??=
@@ -3632,7 +3643,7 @@ const PAGINATED_SELECT_KEYS = new Set([
   "whereClause",
 ]);
 
-function isPaginatedJoinedSelect(
+function isPaginatedSchemaSelect(
   select: Record<string, unknown>,
   markers: ReadonlyMap<string, SqlMarker>,
 ): boolean {
@@ -3661,7 +3672,6 @@ function isPaginatedJoinedSelect(
   const relation = schemaJoinGraph(select.fromClause[0], markers);
   if (
     relation === undefined ||
-    relation.joinCount === 0 ||
     !relation.conditions.every((condition) => {
       return markersMatch(condition, markers, (marker) => {
         return marker.isWrapper;
@@ -3708,15 +3718,22 @@ function isPaginatedExistsSelect(
     return false;
   }
   const target = recordProperty(select.targetList[0], "ResTarget");
+  if (
+    target === undefined ||
+    typeof target.name !== "string" ||
+    !hasOnlyKeys(target, new Set(["location", "name", "val"]))
+  ) {
+    return false;
+  }
+  if (columnMarker(target.val, markers)?.isSelectExistence === true) {
+    return true;
+  }
   const subLink = exactSubLink(target?.val);
   const inner = recordProperty(subLink?.subselect, "SelectStmt");
   return (
-    target !== undefined &&
-    typeof target.name === "string" &&
-    hasOnlyKeys(target, new Set(["location", "name", "val"])) &&
     subLink?.subLinkType === "EXISTS_SUBLINK" &&
     inner !== undefined &&
-    isPaginatedJoinedSelect(inner, markers)
+    isPaginatedSchemaSelect(inner, markers)
   );
 }
 
@@ -5803,6 +5820,7 @@ function replacementBoundaryForFinding(
         checker,
         services,
         schemaTarget,
+        capabilities,
       );
       if (
         parsed === null ||
@@ -6388,6 +6406,7 @@ export function analyzeSql(
           checker,
           services,
           schemaTarget,
+          capabilities,
         );
         if (parsed === null) {
           variants.length = 0;

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -32,6 +32,7 @@ import {
   drizzleCallName,
   getDrizzleColumnMetadata,
   getDrizzleTableMetadataForWrite,
+  isDefinitelyPresentDrizzleBooleanHelper,
   isDrizzleArrayParameter,
   isDrizzleColumnType,
   isDrizzleArrayOperandType,
@@ -208,6 +209,7 @@ interface SqlMarker {
   readonly isArrayOperand: boolean;
   readonly isBoundScalar: boolean;
   readonly isColumn: boolean;
+  readonly isDefinitelyPresentWrapper: boolean;
   readonly isNumber: boolean;
   readonly isPatternOperand: boolean;
   readonly isSelect: boolean;
@@ -803,6 +805,17 @@ function markerIsWrapper(
   return isDrizzleWrapperType(checker, checker.getTypeAtLocation(tsNode));
 }
 
+function markerIsDefinitelyPresentWrapper(
+  node: TSESTree.Expression,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): boolean {
+  return (
+    markerIsWrapper(node, checker, services) ||
+    isDefinitelyPresentDrizzleBooleanHelper(checker, services, node)
+  );
+}
+
 function isOptionalDrizzleWrapperType(
   type: Type,
   checker: TypeChecker,
@@ -1187,6 +1200,7 @@ function parseSqlVariant(
     let cachedBoundScalar: boolean | undefined;
     let cachedColumn: boolean | undefined;
     let cachedColumnMetadata: SqlMarker["columnMetadata"] | null | undefined;
+    let cachedDefinitelyPresentWrapper: boolean | undefined;
     let cachedExpressionSymbol: TypeScriptSymbol | null | undefined;
     let cachedNumber: boolean | undefined;
     let cachedPatternOperand: boolean | undefined;
@@ -1242,6 +1256,14 @@ function parseSqlVariant(
       get isColumn(): boolean {
         cachedColumn ??= markerIsColumn(expression, checker, services);
         return cachedColumn;
+      },
+      get isDefinitelyPresentWrapper(): boolean {
+        cachedDefinitelyPresentWrapper ??= markerIsDefinitelyPresentWrapper(
+          expression,
+          checker,
+          services,
+        );
+        return cachedDefinitelyPresentWrapper;
       },
       get isNumber(): boolean {
         cachedNumber ??= markerIsNumber(expression, checker, services);
@@ -3259,7 +3281,7 @@ function relationMatch(
   value: unknown,
   markers: ReadonlyMap<string, SqlMarker>,
 ): RelationMatch | undefined {
-  const direct = relationMarker(value, markers);
+  const direct = schemaRelationMarker(value, markers);
   if (direct !== undefined) {
     return {
       joinedConditions: [],
@@ -3281,7 +3303,7 @@ function relationMatch(
     return undefined;
   }
   const left = relationMatch(join.larg, markers);
-  const right = relationMarker(join.rarg, markers);
+  const right = schemaRelationMarker(join.rarg, markers);
   const condition = columnMarker(join.quals, markers);
   if (left === undefined || right === undefined || condition === undefined) {
     return undefined;
@@ -3410,10 +3432,10 @@ function isHandBuiltExistenceSelect(
       return marker.isTable;
     }) &&
     relation.joinedConditions.every((marker) => {
-      return marker.isWrapper;
+      return marker.isDefinitelyPresentWrapper;
     }) &&
     predicates?.every((marker) => {
-      return marker.isWrapper;
+      return marker.isDefinitelyPresentWrapper;
     }) === true
   );
 }
@@ -3606,7 +3628,7 @@ function schemaJoinGraph(
   value: unknown,
   markers: ReadonlyMap<string, SqlMarker>,
 ): SchemaJoinGraph | undefined {
-  const table = relationMarker(value, markers);
+  const table = schemaRelationMarker(value, markers);
   if (table !== undefined) {
     return table.isTable ? { conditions: [], joinCount: 0 } : undefined;
   }
@@ -3623,7 +3645,7 @@ function schemaJoinGraph(
     return undefined;
   }
   const left = schemaJoinGraph(join.larg, markers);
-  const right = relationMarker(join.rarg, markers);
+  const right = schemaRelationMarker(join.rarg, markers);
   if (left === undefined || right?.isTable !== true) {
     return undefined;
   }
@@ -3631,6 +3653,30 @@ function schemaJoinGraph(
     conditions: [...left.conditions, join.quals],
     joinCount: left.joinCount + 1,
   };
+}
+
+function schemaRelationMarker(
+  value: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+): SqlMarker | undefined {
+  const direct = relationMarker(value, markers);
+  if (direct !== undefined) {
+    return direct;
+  }
+  const range = rangeVarPayload(value);
+  const aliasName =
+    range === undefined ? undefined : directRelationAliasName(range.alias);
+  if (range === undefined || aliasName === undefined) {
+    return undefined;
+  }
+  const relation = markers.get(range.relname);
+  const alias = markers.get(aliasName);
+  const tableAlias = alias?.tableAlias;
+  return relation?.isTable === true &&
+    alias?.isTable === true &&
+    tableAlias?.sourceSymbol === relation.expressionSymbol
+    ? alias
+    : undefined;
 }
 
 const PAGINATED_SELECT_KEYS = new Set([
@@ -3674,11 +3720,11 @@ function isPaginatedSchemaSelect(
     relation === undefined ||
     !relation.conditions.every((condition) => {
       return markersMatch(condition, markers, (marker) => {
-        return marker.isWrapper;
+        return marker.isDefinitelyPresentWrapper;
       });
     }) ||
     !markersMatch(select.whereClause, markers, (marker) => {
-      return marker.isWrapper;
+      return marker.isDefinitelyPresentWrapper;
     })
   ) {
     return false;


### PR DESCRIPTION
## Summary

- replace artifact-access and remaining-usage scalar `SELECT EXISTS` probes
  with typed one-row Drizzle selects and application row-presence checks
- extend `api/prefer-drizzle-apis` to report supported single-table raw
  existence statements, including source-matched schema aliases and
  statically nonempty `and(...)` / `or(...)` predicates
- keep the proof conservative for mismatched aliases, optional all-empty
  boolean trees, richer statements, and uncertain builders
- replace the equivalent snapshot-compaction `NOT EXISTS` leaf exposed by the
  expanded lint coverage with `notExists(selectBuilder)`

## SQL and performance

- all runtime rewrites preserve one statement, one round trip, predicates, and
  transaction placement
- the two scalar row-presence rewrites preserve existing predicate parameter
  order; Drizzle adds only the trailing parameterized `LIMIT 1`
- the snapshot-compaction rewrite preserves its correlated predicates; changing
  the ignored `NOT EXISTS` target from `1` to `agent.id` is semantically
  equivalent
- representative PostgreSQL plans retain the artifact sequential scan and the
  usage `idx_usage_event_processed_org_user` index scan
- five alternating final API ESLint pairs passed the inherited gates: median
  wall time changed by `-15.04%` and median aggregate process-tree peak RSS by
  `+1.15%`

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F @vm0/eslint-rules test` (47 files, 1023 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-artifacts-image-edit-snapshot.test.ts src/signals/routes/__tests__/cron-compact-usage-events.test.ts`
  (2 files, 17 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts --maxWorkers=1 --silent=passed-only`
  (1 file, 28 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm format`
- `pnpm knip`
- staged pre-commit checks, including full Turbo `check-types` (12/12)
- generated SQL/parameter comparison and
  `EXPLAIN (ANALYZE, BUFFERS, TIMING OFF, COSTS OFF)` for both scalar probes
- `git diff --check`

## Scope

No schema migration, persisted-data rewrite, public API or protocol change,
feature switch, compatibility bridge, extra round trip, or checked-in audit
registry is introduced.

Closes #24128

Parent context: #23047
