### PR TITLE
refactor(observability): remove legacy connector debug dimensions

### DIFF
--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -193,11 +193,6 @@ def add_firewall_metadata(flow: http.HTTPFlow, log_entry: dict) -> None:
             connector_diagnostic_slug,
         ),
         (
-            # TODO(#23838): Remove this legacy projection after the rollout gate.
-            "connector_diagnostic_type",
-            connector_diagnostic_slug,
-        ),
-        (
             "connector_diagnostic_reason",
             _metadata_optional_str(meta, metadata_keys.CONNECTOR_DIAGNOSTIC_REASON),
         ),

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -142,7 +142,6 @@ class TestErrorHandler:
         assert entry["error"] == "connection reset by peer"
         assert entry["firewall_error"] == "connector_not_configured_for_run"
         assert entry["connector_diagnostic_slug"] == "fal"
-        assert entry["connector_diagnostic_type"] == "fal"
         assert entry["connector_diagnostic_env_names"] == ["FAL_TOKEN"]
         assert entry["connector_diagnostic_base"] == "https://fal.run"
 
@@ -182,7 +181,6 @@ class TestErrorHandler:
         assert entry["error"] == "connection reset by peer"
         assert entry["firewall_error"] == "connector_not_configured_for_run"
         assert entry["connector_diagnostic_slug"] == "fal"
-        assert entry["connector_diagnostic_type"] == "fal"
         assert entry["connector_diagnostic_env_names"] == ["FAL_TOKEN"]
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
@@ -225,7 +223,6 @@ class TestErrorHandler:
         assert entry["error"] == "connection reset by peer"
         assert entry["firewall_error"] == "connector_not_configured_for_run"
         assert entry["connector_diagnostic_slug"] == "fal"
-        assert entry["connector_diagnostic_type"] == "fal"
 
         [proxy_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
         assert proxy_entry["type"] == "connection_error"
@@ -262,7 +259,6 @@ class TestErrorHandler:
         assert entry["status"] == 0
         assert entry["request_size"] == len(b"partial request")
         assert entry["error"] == "connection reset by peer"
-        assert "connector_diagnostic_type" not in entry
         assert "firewall_error" not in entry
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
@@ -297,7 +293,6 @@ class TestErrorHandler:
         assert entry["status"] == 0
         assert entry["browser_user_agent"] is True
         assert entry["error"] == "connection reset by peer"
-        assert "connector_diagnostic_type" not in entry
         assert "firewall_error" not in entry
 
     async def test_authenticated_connector_candidate_error_keeps_original_error(
@@ -325,7 +320,6 @@ class TestErrorHandler:
         [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert entry["status"] == 0
         assert entry["error"] == "connection reset by peer"
-        assert "connector_diagnostic_type" not in entry
         assert "firewall_error" not in entry
 
     def test_cleans_up_start_time(self, tmp_path, real_flow, mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -423,7 +423,6 @@ class TestAddFirewallMetadata:
             "firewall_rule_match": "",
             "firewall_billable": False,
             "connector_diagnostic_slug": "fal",
-            "connector_diagnostic_type": "fal",
             "connector_diagnostic_reason": "not_configured_for_run",
             "connector_diagnostic_env_names": ["FAL_TOKEN"],
             "connector_diagnostic_base": "https://fal.run",

--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
@@ -442,7 +442,6 @@ async def test_inactive_builtin_connector_url_without_auth_gets_local_diagnostic
     assert entry["status"] == 424
     assert entry["firewall_error"] == "connector_not_configured_for_run"
     assert entry["connector_diagnostic_slug"] == "fal"
-    assert entry["connector_diagnostic_type"] == "fal"
     [proxy_entry, http_error_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
     assert proxy_entry["type"] == "connector_diagnostic"
     assert proxy_entry["connector"] == "fal"

--- a/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
@@ -71,7 +71,6 @@ async def test_replaces_unauthenticated_connector_401_body(tmp_path, real_flow, 
     assert entry["status"] == 401
     assert entry["firewall_error"] == "connector_not_configured_for_run"
     assert entry["connector_diagnostic_slug"] == "fal"
-    assert entry["connector_diagnostic_type"] == "fal"
     assert entry["connector_diagnostic_reason"] == "not_configured_for_run"
     assert entry["connector_diagnostic_env_names"] == ["FAL_TOKEN"]
     assert entry["connector_diagnostic_base"] == "https://fal.run"
@@ -247,7 +246,6 @@ async def test_streamed_connector_401_with_user_auth_keeps_upstream_response(
     [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
     assert entry["status"] == 401
     assert entry["request_size"] == len(b"partial request")
-    assert "connector_diagnostic_type" not in entry
     assert "firewall_error" not in entry
 
 
@@ -285,7 +283,6 @@ async def test_streamed_connector_401_with_query_auth_keeps_upstream_response(
     [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
     assert entry["status"] == 401
     assert entry["request_size"] == len(b"partial request")
-    assert "connector_diagnostic_type" not in entry
     assert "firewall_error" not in entry
 
 
@@ -328,7 +325,6 @@ def test_streamed_connector_401_before_request_gets_diagnostic(tmp_path, real_fl
     assert entry["request_size"] == len(b"partial request")
     assert entry["firewall_error"] == "connector_not_configured_for_run"
     assert entry["connector_diagnostic_slug"] == "fal"
-    assert entry["connector_diagnostic_type"] == "fal"
     assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
     assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
 
@@ -370,7 +366,6 @@ def test_streamed_authenticated_connector_401_before_request_keeps_upstream_resp
     [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
     assert entry["status"] == 401
     assert entry["request_size"] == len(b"partial request")
-    assert "connector_diagnostic_type" not in entry
     assert "firewall_error" not in entry
     assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
     assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
@@ -409,7 +404,6 @@ def test_streamed_query_authenticated_connector_401_before_request_keeps_upstrea
     [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
     assert entry["status"] == 401
     assert entry["request_size"] == len(b"partial request")
-    assert "connector_diagnostic_type" not in entry
     assert "firewall_error" not in entry
     assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
     assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
@@ -456,7 +450,6 @@ def test_streamed_browser_connector_403_before_request_keeps_upstream_response(
     assert entry["status"] == 403
     assert entry["request_size"] == len(b"partial request")
     assert entry["browser_user_agent"] is True
-    assert "connector_diagnostic_type" not in entry
     assert "firewall_error" not in entry
     assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
     assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
@@ -498,7 +491,6 @@ def test_streamed_api_allow_response_before_request_logs_without_firewall_contex
     assert entry["request_size"] == len(b"partial request")
     assert entry["response_size"] == len(b"api auth error")
     assert "firewall_base" not in entry
-    assert "connector_diagnostic_type" not in entry
     assert "firewall_error" not in entry
     assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
     assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
@@ -677,7 +669,6 @@ async def test_preserves_connector_401_body_when_user_auth_is_present(
     assert flow.response.status_code == 401
     assert flow.response.content == b"upstream auth error"
     [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
-    assert "connector_diagnostic_type" not in entry
     assert "firewall_error" not in entry
 
 
@@ -707,7 +698,6 @@ async def test_preserves_model_provider_401_body_without_connector_diagnostic(
     assert flow.response.content == b'{"error":"provider auth error"}'
     [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
     assert entry["status"] == 401
-    assert "connector_diagnostic_type" not in entry
     assert "firewall_error" not in entry
 
 
@@ -735,7 +725,6 @@ async def test_preserves_connector_401_body_when_query_auth_is_present(
     assert flow.response.status_code == 401
     assert flow.response.content == b"upstream query auth error"
     [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
-    assert "connector_diagnostic_type" not in entry
     assert "firewall_error" not in entry
 
 
@@ -798,7 +787,6 @@ async def test_preserves_successful_connector_response_body(tmp_path, real_flow,
     assert flow.response.content == b'{"ok":true}'
     [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
     assert entry["status"] == 200
-    assert "connector_diagnostic_type" not in entry
 
 
 async def test_preserves_browser_403_body_for_connector_candidate(
@@ -832,4 +820,3 @@ async def test_preserves_browser_403_body_for_connector_candidate(
     assert flow.response.content == b"browser upstream body"
     [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
     assert entry["browser_user_agent"] is True
-    assert "connector_diagnostic_type" not in entry

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -42,9 +42,6 @@
 //! and aborts the worker task, preventing orphaned scheduled tasks from
 //! enqueueing stale registry refreshes.
 //!
-//! TODO(#23837): Remove the retained `connector_ref` / `connector_refs` tracing
-//! fields after the seven-day operational log compatibility window.
-
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
@@ -352,7 +349,6 @@ impl NetworkPolicyRefreshCore {
                     run_id = %request.run_id,
                     connector_count = request.connector_slugs.len(),
                     connector_slugs = ?request.connector_slugs,
-                    connector_refs = ?request.connector_slugs,
                     "network policy refresh queue full; failing closed after network policy refresh notification"
                 );
                 if let Some(cancel) = cancel {
@@ -372,7 +368,6 @@ impl NetworkPolicyRefreshCore {
                     run_id = %error.run_id,
                     connector_count = error.connector_slugs.len(),
                     connector_slugs = ?error.connector_slugs,
-                    connector_refs = ?error.connector_slugs,
                     "network policy refresh queue closed"
                 );
             }
@@ -396,7 +391,6 @@ impl NetworkPolicyRefreshCore {
                     run_id = %request.run_id,
                     connector_count = request.connector_slugs.len(),
                     connector_slugs = ?request.connector_slugs,
-                    connector_refs = ?request.connector_slugs,
                     "network policy refresh queue full; failing closed after scheduled refresh deadline"
                 );
                 self.fail_closed_active_connectors(request.run_id, &request.connector_slugs)
@@ -407,7 +401,6 @@ impl NetworkPolicyRefreshCore {
                     run_id = %error.run_id,
                     connector_count = error.connector_slugs.len(),
                     connector_slugs = ?error.connector_slugs,
-                    connector_refs = ?error.connector_slugs,
                     "network policy refresh queue closed"
                 );
             }
@@ -453,7 +446,6 @@ impl NetworkPolicyRefreshCore {
                     run_id = %run_id,
                     connector_count = active_connector_slugs.len(),
                     connector_slugs = ?active_connector_slugs,
-                    connector_refs = ?active_connector_slugs,
                     error = %error,
                     "network policy refresh failed"
                 );
@@ -473,9 +465,7 @@ impl NetworkPolicyRefreshCore {
                 warn!(
                     run_id = %run_id,
                     response_connector_slug = response_connector_slug,
-                    response_connector_ref = response_connector_slug,
                     requested_connector_slugs = ?active_connector_slugs,
-                    requested_connector_refs = ?active_connector_slugs,
                     "network policy refresh returned unexpected connector"
                 );
                 continue;
@@ -487,7 +477,6 @@ impl NetworkPolicyRefreshCore {
                 warn!(
                     run_id = %run_id,
                     connector_slug = response_connector_slug,
-                    connector_ref = response_connector_slug,
                     "network policy refresh returned duplicate connector"
                 );
                 duplicate_connector_slugs.insert(response_connector_slug);
@@ -506,7 +495,6 @@ impl NetworkPolicyRefreshCore {
                 warn!(
                     run_id = %run_id,
                     connector_slug = connector_slug,
-                    connector_ref = connector_slug,
                     "network policy refresh response omitted requested connector"
                 );
                 if let Some(snapshot) = self.active_snapshot(run_id, connector_slug).await {
@@ -535,7 +523,6 @@ impl NetworkPolicyRefreshCore {
                     info!(
                         run_id = %run_id,
                         connector_slug = connector_slug,
-                        connector_ref = connector_slug,
                         "refreshed network policy"
                     );
                     self.replace_schedule_deadline(run_id, connector_slug, deadline)
@@ -549,7 +536,6 @@ impl NetworkPolicyRefreshCore {
                     warn!(
                         run_id = %run_id,
                         connector_slug = connector_slug,
-                        connector_ref = connector_slug,
                         error = %error,
                         "failed to patch refreshed network policy"
                     );
@@ -584,7 +570,6 @@ impl NetworkPolicyRefreshCore {
                 warn!(
                     run_id = %run_id,
                     connector_slug = connector_slug,
-                    connector_ref = connector_slug,
                     error = %error,
                     "failed to close terminal run network policy"
                 );
@@ -865,7 +850,6 @@ fn log_fail_closed_network_policy_result(
             warn!(
                 run_id = %run_id,
                 connector_slug = connector_slug,
-                connector_ref = connector_slug,
                 "failed closed network policy after network policy refresh failure"
             );
         }
@@ -874,7 +858,6 @@ fn log_fail_closed_network_policy_result(
             warn!(
                 run_id = %run_id,
                 connector_slug = connector_slug,
-                connector_ref = connector_slug,
                 error = %error,
                 "failed to fail close network policy"
             );
@@ -1184,27 +1167,12 @@ mod tests {
             .unwrap_or_else(|| panic!("missing event {message}; events={events:#?}"))
     }
 
-    fn assert_matching_connector_fields(
-        event: &CapturedEvent,
-        canonical_field: &str,
-        legacy_field: &str,
-        expected: &str,
-    ) {
-        let canonical = event
+    fn assert_connector_field(event: &CapturedEvent, field: &str, expected: &str) {
+        let actual = event
             .fields
-            .get(canonical_field)
-            .unwrap_or_else(|| panic!("missing field {canonical_field}; event={event:#?}"));
-        let legacy = event
-            .fields
-            .get(legacy_field)
-            .unwrap_or_else(|| panic!("missing field {legacy_field}; event={event:#?}"));
-        assert_eq!(canonical, expected, "event={event:#?}");
-        assert_eq!(legacy, canonical, "event={event:#?}");
-        assert_eq!(
-            event.field_kinds.get(canonical_field),
-            event.field_kinds.get(legacy_field),
-            "field kinds differ; event={event:#?}"
-        );
+            .get(field)
+            .unwrap_or_else(|| panic!("missing field {field}; event={event:#?}"));
+        assert_eq!(actual, expected, "event={event:#?}");
     }
 
     fn active_run_network_policy_state(
@@ -1852,25 +1820,14 @@ mod tests {
             &events,
             "network policy refresh returned unexpected connector",
         );
-        assert_matching_connector_fields(
-            unexpected,
-            "response_connector_slug",
-            "response_connector_ref",
-            "github",
-        );
-        assert_matching_connector_fields(
-            unexpected,
-            "requested_connector_slugs",
-            "requested_connector_refs",
-            "[\"slack\"]",
-        );
-        assert_matching_connector_fields(
+        assert_connector_field(unexpected, "response_connector_slug", "github");
+        assert_connector_field(unexpected, "requested_connector_slugs", "[\"slack\"]");
+        assert_connector_field(
             captured_event(
                 &events,
                 "network policy refresh response omitted requested connector",
             ),
             "connector_slug",
-            "connector_ref",
             "slack",
         );
     }
@@ -1880,28 +1837,25 @@ mod tests {
         let (_, events) =
             capture_network_policy_events(assert_failed_network_policy_refresh_fail_closed()).await;
 
-        assert_matching_connector_fields(
+        assert_connector_field(
             captured_event(&events, "network policy refresh failed"),
             "connector_slugs",
-            "connector_refs",
             "[\"slack\"]",
         );
-        assert_matching_connector_fields(
+        assert_connector_field(
             captured_event(
                 &events,
                 "failed closed connector network policy in proxy registry",
             ),
             "connector_slug",
-            "connector_ref",
             "slack",
         );
-        assert_matching_connector_fields(
+        assert_connector_field(
             captured_event(
                 &events,
                 "failed closed network policy after network policy refresh failure",
             ),
             "connector_slug",
-            "connector_ref",
             "slack",
         );
     }
@@ -2113,19 +2067,17 @@ mod tests {
         let (_, events) = capture_network_policy_events(harness.refresh_slack()).await;
 
         refresh_mock.assert_calls(1);
-        assert_matching_connector_fields(
+        assert_connector_field(
             captured_event(
                 &events,
                 "patched connector network policy in proxy registry",
             ),
             "connector_slug",
-            "connector_ref",
             "slack",
         );
-        assert_matching_connector_fields(
+        assert_connector_field(
             captured_event(&events, "refreshed network policy"),
             "connector_slug",
-            "connector_ref",
             "slack",
         );
         harness.shutdown().await;

--- a/crates/runner/src/proxy/registry.rs
+++ b/crates/runner/src/proxy/registry.rs
@@ -1,8 +1,5 @@
 //! Proxy registry schema and file persistence.
 //!
-//! TODO(#23837): Remove retained `connector_ref` tracing fields after the
-//! seven-day operational log compatibility window.
-
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -294,7 +291,6 @@ impl ProxyRegistryHandle {
             source_ip,
             run_id,
             connector_slug = connector_slug,
-            connector_ref = connector_slug,
             "failed closed connector network policy in proxy registry"
         );
         Ok(true)
@@ -326,7 +322,6 @@ impl ProxyRegistryHandle {
             source_ip,
             run_id,
             connector_slug = connector_slug,
-            connector_ref = connector_slug,
             "patched connector network policy in proxy registry"
         );
         Ok(true)

--- a/e2e/helpers/setup.bash
+++ b/e2e/helpers/setup.bash
@@ -215,8 +215,8 @@ _NETWORK_LOG_JQ='.networkLogs[] |
     (.error // empty),
     (.firewall_error // empty),
     (if .dns_result then "-> \(.dns_result)" else empty end),
-    (if (.connector_diagnostic_slug or .connector_diagnostic_type or .connector_diagnostic_reason) then
-      "[connector diagnostic: \([(.connector_diagnostic_slug // .connector_diagnostic_type // empty), (.connector_diagnostic_reason // empty),
+    (if (.connector_diagnostic_slug or .connector_diagnostic_reason) then
+      "[connector diagnostic: \([(.connector_diagnostic_slug // empty), (.connector_diagnostic_reason // empty),
         (if ((.connector_diagnostic_env_names // []) | length) > 0 then "env: \(.connector_diagnostic_env_names | join(", "))" else empty end),
         (if .connector_diagnostic_base then "base: \(.connector_diagnostic_base)" else empty end)] | join("; "))]"
       else empty end),

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-aggregate-insights.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-aggregate-insights.test.ts
@@ -845,14 +845,7 @@ describe("GET /api/cron/aggregate-insights", () => {
         }),
       ]),
     );
-    for (const permission of storedPermissions) {
-      expect(permission).not.toHaveProperty("connectorType");
-    }
-
     const data = await findInsights(seeded.actor);
-    for (const permission of data?.permissions ?? []) {
-      expect(permission).not.toHaveProperty("connectorType");
-    }
     const githubDeny = data?.permissions.find((permission) => {
       return permission.label === "github" && permission.denied > 0;
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -11707,7 +11707,7 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
             model_catalog_cache_status: "model_catalog_cold_stored",
             model_catalog_cache_upstream_encoding: "br",
             model_catalog_cache_entry_age_ms: 4000,
-            connector_diagnostic_type: "github",
+            connector_diagnostic_slug: "github",
           },
           {
             timestamp: nowDate().toISOString(),
@@ -11724,7 +11724,6 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
             firewall_name: "blocked-service",
             firewall_error: "connector_not_configured",
             connector_diagnostic_slug: "slack",
-            connector_diagnostic_type: "slack",
           },
         ],
         sandboxOperations: [
@@ -11765,7 +11764,6 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
         model_catalog_cache_upstream_encoding: "br",
         model_catalog_cache_entry_age_ms: 4000,
         connector_diagnostic_slug: "github",
-        connector_diagnostic_type: "github",
       }),
       expect.objectContaining({
         runId: created.runId,
@@ -11773,32 +11771,8 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
         host: "blocked.example.test",
         firewall_error: "connector_not_configured",
         connector_diagnostic_slug: "slack",
-        connector_diagnostic_type: "slack",
       }),
     ]);
-    const networkIngestCallCount = telemetryIngests.filter((call) => {
-      return call.dataset === "sandbox-telemetry-network";
-    }).length;
-    const conflictingTelemetry = await webhooks.requestAgentTelemetryUnchecked(
-      {
-        runId: created.runId,
-        networkLogs: [
-          {
-            timestamp: nowDate().toISOString(),
-            connector_diagnostic_slug: "github",
-            connector_diagnostic_type: "gitlab",
-          },
-        ],
-      },
-      sandboxHeaders,
-      [400],
-    );
-    expectApiError(conflictingTelemetry.body);
-    expect(
-      telemetryIngests.filter((call) => {
-        return call.dataset === "sandbox-telemetry-network";
-      }),
-    ).toHaveLength(networkIngestCallCount);
 
     let failedTelemetryRequests = 0;
     server.use(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1897,7 +1897,7 @@ describe("RUN-04: agent run telemetry families", () => {
             firewall_params: { owner: "vm0-ai", empty: null },
             firewall_billable: true,
             firewall_error: "none",
-            connector_diagnostic_type: "fal",
+            connector_diagnostic_slug: "fal",
             connector_diagnostic_reason: "not_configured_for_run",
             connector_diagnostic_env_names: ["FAL_TOKEN"],
             connector_diagnostic_base: "https://fal.run",
@@ -2177,82 +2177,6 @@ describe("RUN-04: agent run telemetry families", () => {
       networkLogs: expectedNetworkLogs,
       hasMore: true,
       nextCursor: expectedNextCursor,
-    });
-  });
-
-  it("normalizes connector diagnostic identity from axiom", async () => {
-    const actor = await entitledActor();
-    const compose = await createClaudeCompose(
-      actor,
-      "bdd-network-diagnostic-identity",
-    );
-    const run = await api.createDirectRun(actor, {
-      agentComposeId: compose.composeId,
-      prompt: "read connector diagnostic identity",
-    });
-
-    dispatchAxiomQueries({
-      [run.runId]: {
-        network: [
-          {
-            _time: "2026-07-30T04:00:00Z",
-            runId: run.runId,
-            userId: actor.userId,
-            connector_diagnostic_type: "legacy",
-          },
-          {
-            _time: "2026-07-30T04:01:00Z",
-            runId: run.runId,
-            userId: actor.userId,
-            connector_diagnostic_slug: "canonical",
-          },
-          {
-            _time: "2026-07-30T04:02:00Z",
-            runId: run.runId,
-            userId: actor.userId,
-            connector_diagnostic_slug: "dual",
-            connector_diagnostic_type: "dual",
-          },
-          {
-            _time: "2026-07-30T04:03:00Z",
-            runId: run.runId,
-            userId: actor.userId,
-            connector_diagnostic_slug: "github",
-            connector_diagnostic_type: "gitlab",
-          },
-        ],
-      },
-    });
-
-    const network = await reads.requestZeroRunNetworkLogs(
-      actor,
-      run.runId,
-      { limit: 10, order: "asc" },
-      [200],
-    );
-    if (network.status !== 200) {
-      throw new Error("Expected the zero network log read to succeed");
-    }
-
-    expect(network.body).toStrictEqual({
-      networkLogs: [
-        {
-          timestamp: "2026-07-30T04:00:00Z",
-          connector_diagnostic_slug: "legacy",
-          connector_diagnostic_type: "legacy",
-        },
-        {
-          timestamp: "2026-07-30T04:01:00Z",
-          connector_diagnostic_slug: "canonical",
-          connector_diagnostic_type: "canonical",
-        },
-        {
-          timestamp: "2026-07-30T04:02:00Z",
-          connector_diagnostic_slug: "dual",
-          connector_diagnostic_type: "dual",
-        },
-      ],
-      hasMore: false,
     });
   });
 
@@ -2774,7 +2698,7 @@ describe("RUN-04: agent run telemetry families", () => {
             request_size: 100,
             response_size: 2048,
             firewall_params: { owner: "vm0-ai", broken: 5 },
-            connector_diagnostic_type: "fal",
+            connector_diagnostic_slug: "fal",
             connector_diagnostic_reason: "not_configured_for_run",
             connector_diagnostic_env_names: ["FAL_TOKEN"],
             connector_diagnostic_base: "https://fal.run",
@@ -2980,7 +2904,7 @@ describe("RUN-04: agent run telemetry families", () => {
             request_size: 100,
             response_size: 2048,
             firewall_params: { owner: "vm0-ai", broken: 5 },
-            connector_diagnostic_type: "fal",
+            connector_diagnostic_slug: "fal",
             connector_diagnostic_reason: "not_configured_for_run",
             connector_diagnostic_env_names: ["FAL_TOKEN"],
             connector_diagnostic_base: "https://fal.run",
@@ -3056,7 +2980,6 @@ describe("RUN-04: agent run telemetry families", () => {
       response_size: 2048,
       firewall_params: { owner: "vm0-ai" },
       connector_diagnostic_slug: "fal",
-      connector_diagnostic_type: "fal",
       connector_diagnostic_reason: "not_configured_for_run",
       connector_diagnostic_env_names: ["FAL_TOKEN"],
       connector_diagnostic_base: "https://fal.run",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
@@ -631,7 +631,7 @@ describe("POST /api/zero/mail/drafts/link", () => {
     expect(refreshCalls).toBe(0);
   });
 
-  it("logs canonical and legacy connector dimensions on refresh failure", async () => {
+  it("logs the canonical connector dimension on refresh failure", async () => {
     const fixture = await seedGmailMailCardFixture();
     await setConnectorCredentialStorageState(context, {
       orgId: fixture.actor.orgId ?? "",
@@ -666,7 +666,6 @@ describe("POST /api/zero/mail/drafts/link", () => {
       "Connector credential refresh failed",
       expect.objectContaining({
         connectorSlug: "gmail",
-        connectorRef: "gmail",
       }),
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-report-error.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-report-error.test.ts
@@ -529,7 +529,7 @@ describe("POST /api/zero/report-error", () => {
       upstream_binding_reason: "connector_auth",
       upstream_binding_server_connected: false,
       upstream_binding_client_binding_count: 0,
-      connector_diagnostic_type: "github",
+      connector_diagnostic_slug: "github",
       connector_route_reason: "connector_intent_required",
       connector_route_candidates: ["auditor", "primary"],
       auth_resolved_secrets: ["GITHUB_TOKEN"],
@@ -553,21 +553,13 @@ describe("POST /api/zero/report-error", () => {
       host: "api.slack.com",
       url: "https://api.slack.com/methods/auth.test",
       connector_diagnostic_slug: "slack",
-      connector_diagnostic_type: undefined,
-    } satisfies AxiomNetworkEvent;
-    const conflictingNetworkEntry = {
-      ...networkEntry,
-      _time: "2026-04-28T07:00:02.123Z",
-      host: "conflict.example.com",
-      connector_diagnostic_slug: "github",
-      connector_diagnostic_type: "gitlab",
     } satisfies AxiomNetworkEvent;
     const identityFreeNetworkEntry = {
       ...networkEntry,
       _time: "2026-04-28T07:00:03.123Z",
       host: "example.com",
       url: "https://example.com/health",
-      connector_diagnostic_type: undefined,
+      connector_diagnostic_slug: undefined,
     } satisfies AxiomNetworkEvent;
 
     context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
@@ -593,7 +585,6 @@ describe("POST /api/zero/report-error", () => {
         return Promise.resolve([
           networkEntry,
           canonicalNetworkEntry,
-          conflictingNetworkEntry,
           identityFreeNetworkEntry,
         ]);
       }
@@ -615,13 +606,11 @@ describe("POST /api/zero/report-error", () => {
         _time: "2026-04-28T07:00:00.123Z",
         method: "POST",
         connector_diagnostic_slug: "github",
-        connector_diagnostic_type: "github",
       }),
       expect.objectContaining({
         _time: "2026-04-28T07:00:01.123Z",
         host: "api.slack.com",
         connector_diagnostic_slug: "slack",
-        connector_diagnostic_type: "slack",
       }),
       expect.objectContaining({
         _time: "2026-04-28T07:00:03.123Z",
@@ -629,7 +618,6 @@ describe("POST /api/zero/report-error", () => {
       }),
     ]);
     expect(networkLogs[2]).not.toHaveProperty("connector_diagnostic_slug");
-    expect(networkLogs[2]).not.toHaveProperty("connector_diagnostic_type");
 
     const activityLogEntry = zip.getEntries().find((entry) => {
       return entry.entryName.startsWith("activity-log-");
@@ -675,7 +663,6 @@ describe("POST /api/zero/report-error", () => {
       upstream_binding_server_connected: false,
       upstream_binding_client_binding_count: 0,
       connector_diagnostic_slug: "github",
-      connector_diagnostic_type: "github",
       connector_route_reason: "connector_intent_required",
       connector_route_candidates: ["auditor", "primary"],
       auth_resolved_secrets: ["GITHUB_TOKEN"],
@@ -698,7 +685,6 @@ describe("POST /api/zero/report-error", () => {
       timestamp: "2026-04-28T07:00:01.123Z",
       host: "api.slack.com",
       connector_diagnostic_slug: "slack",
-      connector_diagnostic_type: "slack",
     });
     expect(activityLog.networkLogs?.[2]).toMatchObject({
       timestamp: "2026-04-28T07:00:03.123Z",
@@ -706,9 +692,6 @@ describe("POST /api/zero/report-error", () => {
     });
     expect(activityLog.networkLogs?.[2]).not.toHaveProperty(
       "connector_diagnostic_slug",
-    );
-    expect(activityLog.networkLogs?.[2]).not.toHaveProperty(
-      "connector_diagnostic_type",
     );
   });
 

--- a/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
@@ -579,9 +579,7 @@ export async function refreshConnectorCredentialAccess(
   args.signal.throwIfAborted();
   if (!refreshed.ok) {
     log.warn("Connector credential refresh failed", {
-      // TODO(#23837): Remove the legacy field after the seven-day Axiom window.
       connectorSlug: args.connection.connectorSlug,
-      connectorRef: args.connection.connectorSlug,
       authMethodId: args.connection.runtimeMethod.authMethodId,
       error: refreshed.error,
     });

--- a/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
+++ b/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
@@ -616,33 +616,7 @@ function collectNetworkLog(
         },
       )) ?? [];
 
-    return networkLogs.flatMap((event) => {
-      const canonical = event.connector_diagnostic_slug;
-      const legacy = event.connector_diagnostic_type;
-      if (
-        typeof canonical === "string" &&
-        typeof legacy === "string" &&
-        canonical !== legacy
-      ) {
-        return [];
-      }
-
-      const connectorDiagnosticSlug =
-        typeof canonical === "string"
-          ? canonical
-          : typeof legacy === "string"
-            ? legacy
-            : undefined;
-      return connectorDiagnosticSlug === undefined
-        ? [event]
-        : [
-            {
-              ...event,
-              connector_diagnostic_slug: connectorDiagnosticSlug,
-              connector_diagnostic_type: connectorDiagnosticSlug,
-            },
-          ];
-    });
+    return networkLogs;
   });
 }
 

--- a/turbo/apps/api/src/signals/services/network-log-sanitizer.ts
+++ b/turbo/apps/api/src/signals/services/network-log-sanitizer.ts
@@ -245,7 +245,6 @@ function sanitizeAxiomNetworkEvent(event: unknown): NetworkLogEntry | null {
     firewall_error: stringValue(event.firewall_error),
     ...sanitizeUpstreamBindingFields(event),
     connector_diagnostic_slug: stringValue(event.connector_diagnostic_slug),
-    connector_diagnostic_type: stringValue(event.connector_diagnostic_type),
     connector_diagnostic_reason: stringValue(event.connector_diagnostic_reason),
     connector_diagnostic_env_names: stringArrayValue(
       event.connector_diagnostic_env_names,

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-inspect-page.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-inspect-page.test.tsx
@@ -140,7 +140,7 @@ function inspectFile(
       latency_ms: 87,
       request_size: 24,
       response_size: 512,
-      connector_diagnostic_type: "slack-connector",
+      connector_diagnostic_slug: "slack-connector",
     },
   ];
 
@@ -514,11 +514,11 @@ describe("activity inspect page", () => {
       expect(screen.queryByText("github-connector")).not.toBeInTheDocument();
     });
 
-    const legacyNetworkRow = networkRows[2];
-    if (!legacyNetworkRow) {
-      throw new Error("Expected a legacy network log row");
+    const secondNetworkRow = networkRows[2];
+    if (!secondNetworkRow) {
+      throw new Error("Expected a second network log row");
     }
-    await user.click(legacyNetworkRow);
+    await user.click(secondNetworkRow);
     await waitFor(() => {
       expect(screen.getByText("slack-connector")).toBeInTheDocument();
     });

--- a/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
@@ -868,19 +868,10 @@ const networkLogDetailFields = {
     "upstreamBindingClientBindingHosts",
     "upstream_binding_client_binding_hosts",
   ),
-  connector_diagnostic_slug: {
-    labelKey: "connectorDiagnostic",
-    value: (entry) => {
-      return entry.connector_diagnostic_slug ?? entry.connector_diagnostic_type;
-    },
-    format: (entry) => {
-      return formatValue(
-        entry.connector_diagnostic_slug ?? entry.connector_diagnostic_type,
-      );
-    },
-  },
-  // TODO(#23838): Remove after the diagnostic compatibility window.
-  connector_diagnostic_type: null,
+  connector_diagnostic_slug: detailField(
+    "connectorDiagnostic",
+    "connector_diagnostic_slug",
+  ),
   connector_diagnostic_reason: detailField(
     "connectorReason",
     "connector_diagnostic_reason",

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runs.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runs.test.ts
@@ -100,14 +100,3 @@ describe("network log model catalog cache telemetry", () => {
     }
   });
 });
-
-describe("network log connector diagnostic identity", () => {
-  it("preserves the canonical connector slug", () => {
-    expect(
-      networkLogEntrySchema.parse({
-        timestamp: "2026-07-30T03:00:00.000Z",
-        connector_diagnostic_slug: "github",
-      }).connector_diagnostic_slug,
-    ).toBe("github");
-  });
-});

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runs.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runs.test.ts
@@ -102,60 +102,12 @@ describe("network log model catalog cache telemetry", () => {
 });
 
 describe("network log connector diagnostic identity", () => {
-  const timestamp = "2026-07-30T03:00:00.000Z";
-
-  it.each([
-    {
-      name: "absent",
-      identity: {},
-      expected: {
-        connector_diagnostic_slug: undefined,
-        connector_diagnostic_type: undefined,
-      },
-    },
-    {
-      name: "legacy-only",
-      identity: { connector_diagnostic_type: "github" },
-      expected: {
-        connector_diagnostic_slug: "github",
-        connector_diagnostic_type: "github",
-      },
-    },
-    {
-      name: "canonical-only",
-      identity: { connector_diagnostic_slug: "github" },
-      expected: {
-        connector_diagnostic_slug: "github",
-        connector_diagnostic_type: "github",
-      },
-    },
-    {
-      name: "equal dual",
-      identity: {
-        connector_diagnostic_slug: "github",
-        connector_diagnostic_type: "github",
-      },
-      expected: {
-        connector_diagnostic_slug: "github",
-        connector_diagnostic_type: "github",
-      },
-    },
-  ])("normalizes $name input", ({ identity, expected }) => {
-    const parsed = networkLogEntrySchema.parse({ timestamp, ...identity });
-
-    expect({
-      connector_diagnostic_slug: parsed.connector_diagnostic_slug,
-      connector_diagnostic_type: parsed.connector_diagnostic_type,
-    }).toStrictEqual(expected);
-  });
-
-  it("rejects conflicting dual identity", () => {
+  it("preserves the canonical connector slug", () => {
     expect(
-      networkLogEntrySchema.safeParse({
-        timestamp,
+      networkLogEntrySchema.parse({
+        timestamp: "2026-07-30T03:00:00.000Z",
         connector_diagnostic_slug: "github",
-        connector_diagnostic_type: "gitlab",
-      }).success,
-    ).toBe(false);
+      }).connector_diagnostic_slug,
+    ).toBe("github");
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -609,7 +609,7 @@ const modelCatalogCacheEvictionCountSchema = z.number().int().min(0).max(32);
  * Network log entry schema.
  * [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
  */
-const networkLogEntryInputSchema = z.object({
+const networkLogEntrySchema = z.object({
   timestamp: z.string(),
   type: z.string().optional(),
   action: networkLogActionSchema.optional(),
@@ -665,8 +665,6 @@ const networkLogEntryInputSchema = z.object({
   upstream_binding_client_binding_endpoint_match: z.boolean().optional(),
   upstream_binding_client_binding_hosts: z.string().optional(),
   connector_diagnostic_slug: z.string().optional(),
-  // TODO(#23838): Remove after the diagnostic compatibility window.
-  connector_diagnostic_type: z.string().optional(),
   connector_diagnostic_reason: z.string().optional(),
   connector_diagnostic_env_names: z.array(z.string()).optional(),
   connector_diagnostic_base: z.string().optional(),
@@ -688,34 +686,6 @@ const networkLogEntryInputSchema = z.object({
   response_body_encoding: z.enum(["utf-8", "base64", "binary"]).optional(),
   response_body_truncated: z.boolean().optional(),
 });
-
-const networkLogEntrySchema = networkLogEntryInputSchema
-  .superRefine((entry, context) => {
-    if (
-      entry.connector_diagnostic_slug !== undefined &&
-      entry.connector_diagnostic_type !== undefined &&
-      entry.connector_diagnostic_slug !== entry.connector_diagnostic_type
-    ) {
-      context.addIssue({
-        code: "custom",
-        path: ["connector_diagnostic_slug"],
-        message:
-          "connector_diagnostic_slug and connector_diagnostic_type must match",
-      });
-    }
-  })
-  .overwrite((entry) => {
-    const connectorDiagnosticSlug =
-      entry.connector_diagnostic_slug ?? entry.connector_diagnostic_type;
-    if (connectorDiagnosticSlug === undefined) {
-      return entry;
-    }
-    return {
-      ...entry,
-      connector_diagnostic_slug: connectorDiagnosticSlug,
-      connector_diagnostic_type: connectorDiagnosticSlug,
-    };
-  });
 
 /**
  * Network logs response schema


### PR DESCRIPTION
## Summary

- remove legacy connector reference dimensions from API and runner operational logs
- make connector identity in network diagnostics and Insights canonical-only across producers, contracts, API services, Platform, diagnostic bundles, and E2E helpers
- remove transition-only normalization, fallback logic, and positive or negative legacy-name tests

## Compatibility

- accepts that retained legacy-only Axiom rows and mixed-version deployments may temporarily omit the optional connector diagnostic label
- leaves firewall behavior, authentication, credentials, billing, protocols, persisted state, and `firewall_name` unchanged
- does not rewrite existing Axiom records; no database migration is required

## Validation

- Python: uv lock/sync checks, Ruff format/lint, BasedPyright, and 4,486 pytest cases
- Rust: fmt, Clippy, rustdoc, and 2,889 runner tests
- TypeScript: affected API and Platform lint/type checks and 214 focused integration tests; API contracts lint/type checks and all 510 tests
- repository: Knip, Bash syntax validation, runtime API schema generation, and the full pre-commit hook

Closes #23837
Closes #23838

Parent: #23774
