### PR TITLE
perf(api): incrementally project model statistics

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-ops-logs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-ops-logs.ts
@@ -63,7 +63,6 @@ export function createOpsLogsApi(context: TestContext) {
   return {
     async requestAggregateModelStats<TStatus extends 200 | 401>(
       auth: "valid" | "invalid",
-      hours: number | undefined,
       statuses: readonly TStatus[],
     ) {
       return await accept(
@@ -72,7 +71,7 @@ export function createOpsLogsApi(context: TestContext) {
             authorization:
               auth === "valid" ? CRON_AUTHORIZATION : "Bearer wrong-secret",
           },
-          query: { hours },
+          query: {},
         }),
         statuses,
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/model-stats-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/model-stats-state.ts
@@ -84,6 +84,36 @@ export async function releaseModelStatsAggregationLock(
   await postAction(context, { action: "release-aggregation-lock" });
 }
 
+export async function holdModelStatsObservationLock(
+  context: TestContext,
+  idempotencyKey: string,
+): Promise<void> {
+  await postAction(context, {
+    action: "hold-observation-lock",
+    idempotency_key: idempotencyKey,
+  });
+}
+
+export async function readModelStatsObservationLockState(
+  context: TestContext,
+): Promise<{ readonly held: boolean }> {
+  const response = await postAction(context, {
+    action: "read-observation-lock-state",
+  });
+  if (response.observation_lock_held === undefined) {
+    throw new Error(
+      "Model stats observation lock state response is incomplete",
+    );
+  }
+  return { held: response.observation_lock_held };
+}
+
+export async function releaseModelStatsObservationLock(
+  context: TestContext,
+): Promise<void> {
+  await postAction(context, { action: "release-observation-lock" });
+}
+
 export async function readModelStatsObservations(
   context: TestContext,
   idempotencyKeys: readonly string[],

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -29,10 +29,13 @@ import {
   deleteModelStatsFixture,
   deleteModelStatsObservations,
   holdModelStatsAggregationLock,
+  holdModelStatsObservationLock,
   insertZeroTokenModelStatsObservation,
   readModelStatsAggregationLockState,
+  readModelStatsObservationLockState,
   readModelStatsObservations,
   releaseModelStatsAggregationLock,
+  releaseModelStatsObservationLock,
 } from "./helpers/model-stats-state";
 import { commitMemoryVersion } from "./helpers/zero-memory";
 import { createFixtureTracker } from "./helpers/zero-route-test";
@@ -253,17 +256,28 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
   it("rejects the model-stats aggregation cron without the cron secret", async () => {
     const api = createOpsLogsApi(context);
 
-    const rejected = await api.requestAggregateModelStats(
-      "invalid",
-      undefined,
-      [401],
-    );
+    const rejected = await api.requestAggregateModelStats("invalid", [401]);
     expect(rejected.body).toStrictEqual({
       error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
     });
   });
 
-  it("prepares model observations atomically for public rankings", async () => {
+  it("rejects the obsolete model-stats rebuild window", async () => {
+    const aggregateApp = createAppWithRoutes({
+      signal: context.signal,
+      routes: modelStatsRoutes,
+    });
+    const rejected = await aggregateApp.request(
+      `${cronAggregateModelStatsContract.aggregate.path}?hours=24`,
+      {
+        headers: { authorization: "Bearer test-cron-secret" },
+      },
+    );
+
+    expect(rejected.status).toBe(400);
+  });
+
+  it("incrementally projects model observations into public rankings", async () => {
     const api = createOpsLogsApi(context);
     const runs = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);
@@ -282,16 +296,20 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     const aggregateAt = dayStart + 4 * HOUR_MS;
     const mainObservedAt = dayStart + 2 * HOUR_MS + 10 * 60_000;
     const previousObservedAt = dayStart - DAY_MS + 22 * HOUR_MS + 30 * 60_000;
-    const windowStartIso = new Date(aggregateAt - DAY_MS).toISOString();
     const windowEndIso = new Date(aggregateAt).toISOString();
     const todayStartIso = new Date(dayStart).toISOString();
     const fixtureObservationKeys: string[] = [];
     let aggregationLockRequest: Promise<void> | null = null;
+    let observationLockRequest: Promise<void> | null = null;
 
     onTestFinished(async () => {
       await releaseModelStatsAggregationLock(context);
+      await releaseModelStatsObservationLock(context);
       if (aggregationLockRequest) {
         await aggregationLockRequest;
+      }
+      if (observationLockRequest) {
+        await observationLockRequest;
       }
       if (fixtureObservationKeys.length > 0) {
         await deleteModelStatsFixture(context, {
@@ -319,16 +337,17 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     mockNow(aggregateAt);
     const baselineAggregate = await api.requestAggregateModelStats(
       "valid",
-      undefined,
       [200],
     );
     expect(baselineAggregate.body).toMatchObject({
       success: true,
-      windowEnd: windowEndIso,
+      cutoff: windowEndIso,
     });
-    expect(
-      new Date(baselineAggregate.body.windowStart).getTime(),
-    ).toBeLessThanOrEqual(new Date(windowStartIso).getTime());
+    expect(baselineAggregate.body.processedHours).toBeGreaterThanOrEqual(0);
+    expect(baselineAggregate.body.processedObservations).toBeGreaterThanOrEqual(
+      0,
+    );
+    expect(baselineAggregate.body.updatedStats).toBeGreaterThanOrEqual(0);
 
     const baseline = await api.readModelRankings("today");
     expect(baseline.headers.get("cache-control")).toBe(
@@ -453,11 +472,14 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     );
 
     mockNow(aggregateAt);
-    const aggregated = await api.requestAggregateModelStats("valid", 24, [200]);
-    expect(aggregated.body.success).toBeTruthy();
-    expect(aggregated.body.windowStart).toBe(windowStartIso);
-    expect(aggregated.body.windowEnd).toBe(windowEndIso);
-    expect(aggregated.body.aggregated).toBeGreaterThanOrEqual(2);
+    const aggregated = await api.requestAggregateModelStats("valid", [200]);
+    expect(aggregated.body).toMatchObject({
+      success: true,
+      cutoff: windowEndIso,
+    });
+    expect(aggregated.body.processedHours).toBeGreaterThanOrEqual(2);
+    expect(aggregated.body.processedObservations).toBeGreaterThanOrEqual(3);
+    expect(aggregated.body.updatedStats).toBeGreaterThanOrEqual(2);
 
     const afterIngest = await api.readModelRankings("today");
     expect(
@@ -500,8 +522,8 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       ]),
     );
 
-    // Re-ingest into the already-aggregated hour: exact replacement must
-    // surface the additional output tokens on the next aggregation.
+    // A delayed delivery in an already-processed hour remains pending and is
+    // added exactly once by the next cron request.
     mockNow(mainObservedAt);
     const lateIdempotencyKey = randomUUID();
     fixtureObservationKeys.push(lateIdempotencyKey);
@@ -523,7 +545,14 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       [200],
     );
     mockNow(aggregateAt);
-    await api.requestAggregateModelStats("valid", 24, [200]);
+    const lateProcessing = await api.requestAggregateModelStats("valid", [200]);
+    expect(lateProcessing.body).toMatchObject({
+      success: true,
+      cutoff: windowEndIso,
+      processedHours: 1,
+      processedObservations: 1,
+      updatedStats: 1,
+    });
     const reprocessed = await api.readModelRankings("today");
     expect(
       reprocessed.body.rows.find((row) => {
@@ -554,12 +583,8 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     const fallback = await api.readModelRankings("unsupported");
     expect(fallback.body.period).toBe("week");
 
-    // Pending complete-hour observations extend the internal rebuild window
-    // even when they are older than the public route's maximum hours value.
+    // Pending work is recovered by lifecycle state regardless of age.
     const oldPendingAt = aggregateAt - 769 * HOUR_MS + 10 * 60_000;
-    const oldPendingHourIso = new Date(
-      aggregateAt - 769 * HOUR_MS,
-    ).toISOString();
     mockNow(oldPendingAt);
     const oldPendingIdempotencyKey = randomUUID();
     fixtureObservationKeys.push(oldPendingIdempotencyKey);
@@ -581,11 +606,13 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       [200],
     );
     mockNow(aggregateAt);
-    const extended = await api.requestAggregateModelStats("valid", 24, [200]);
+    const extended = await api.requestAggregateModelStats("valid", [200]);
     expect(extended.body).toMatchObject({
       success: true,
-      windowStart: oldPendingHourIso,
-      windowEnd: windowEndIso,
+      cutoff: windowEndIso,
+      processedHours: 1,
+      processedObservations: 1,
+      updatedStats: 1,
     });
     await expect(
       readModelStatsObservations(context, [oldPendingIdempotencyKey]),
@@ -600,8 +627,8 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     });
 
     // Both cron requests begin before this observation is committed. The
-    // transaction lock must serialize them without freezing a pre-lock
-    // REPEATABLE READ snapshot that would miss the newly committed row.
+    // transaction lock gives each processing statement a post-lock snapshot,
+    // and the two callers must claim the delivery only once.
     aggregationLockRequest = holdModelStatsAggregationLock(context);
     await expect
       .poll(
@@ -612,8 +639,8 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       )
       .toMatchObject({ held: true });
     const concurrentAggregations = [
-      api.requestAggregateModelStats("valid", 24, [200]),
-      api.requestAggregateModelStats("valid", 24, [200]),
+      api.requestAggregateModelStats("valid", [200]),
+      api.requestAggregateModelStats("valid", [200]),
     ];
     await expect
       .poll(
@@ -652,8 +679,26 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     aggregationLockRequest = null;
     const concurrentResults = await Promise.all(concurrentAggregations);
     for (const result of concurrentResults) {
-      expect(result.body.success).toBeTruthy();
+      expect(result.body).toMatchObject({
+        success: true,
+        cutoff: windowEndIso,
+      });
     }
+    expect(
+      concurrentResults.reduce((total, result) => {
+        return total + result.body.processedHours;
+      }, 0),
+    ).toBe(1);
+    expect(
+      concurrentResults.reduce((total, result) => {
+        return total + result.body.processedObservations;
+      }, 0),
+    ).toBe(1);
+    expect(
+      concurrentResults.reduce((total, result) => {
+        return total + result.body.updatedStats;
+      }, 0),
+    ).toBe(1);
 
     const afterConcurrent = await api.readModelRankings("today");
     expect(
@@ -677,9 +722,124 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       },
     ]);
 
-    // A failed rebuild must roll back every statistic mutation. 1,024 maximum
+    // Cancellation after one committed hour must preserve that progress and
+    // roll the later in-flight hour back for the next request.
+    const firstCancellationIdempotencyKey = randomUUID();
+    const secondCancellationIdempotencyKey = randomUUID();
+    fixtureObservationKeys.push(
+      firstCancellationIdempotencyKey,
+      secondCancellationIdempotencyKey,
+    );
+    await insertZeroTokenModelStatsObservation(context, {
+      idempotencyKey: firstCancellationIdempotencyKey,
+      model,
+      observedAt: new Date(dayStart - 5 * HOUR_MS + 10 * 60_000),
+    });
+    await insertZeroTokenModelStatsObservation(context, {
+      idempotencyKey: secondCancellationIdempotencyKey,
+      model,
+      observedAt: new Date(dayStart - 4 * HOUR_MS + 10 * 60_000),
+    });
+
+    observationLockRequest = holdModelStatsObservationLock(
+      context,
+      secondCancellationIdempotencyKey,
+    );
+    await expect
+      .poll(
+        async () => {
+          return await readModelStatsObservationLockState(context);
+        },
+        { timeout: 5000, interval: 20 },
+      )
+      .toStrictEqual({ held: true });
+
+    const cancellationController = new AbortController();
+    const cancelledAggregateApp = createAppWithRoutes({
+      signal: cancellationController.signal,
+      routes: modelStatsRoutes,
+    });
+    const cancelledAggregation = cancelledAggregateApp.request(
+      cronAggregateModelStatsContract.aggregate.path,
+      {
+        headers: { authorization: "Bearer test-cron-secret" },
+      },
+    );
+    await expect
+      .poll(
+        async () => {
+          return await readModelStatsObservations(context, [
+            firstCancellationIdempotencyKey,
+            secondCancellationIdempotencyKey,
+          ]);
+        },
+        { timeout: 5000, interval: 20 },
+      )
+      .toStrictEqual(
+        expect.arrayContaining([
+          {
+            idempotencyKey: firstCancellationIdempotencyKey,
+            aggregatedAt: windowEndIso,
+          },
+          {
+            idempotencyKey: secondCancellationIdempotencyKey,
+            aggregatedAt: null,
+          },
+        ]),
+      );
+
+    const cancellationError = new Error(
+      "abort model stats after one committed hour",
+    );
+    cancellationError.name = "AbortError";
+    cancellationController.abort(cancellationError);
+    await releaseModelStatsObservationLock(context);
+    await observationLockRequest;
+    observationLockRequest = null;
+    const cancelledResponse = await cancelledAggregation;
+    expect(cancelledResponse.status).toBe(500);
+    await expect(cancelledResponse.json()).resolves.toStrictEqual({
+      error: "Internal server error",
+    });
+    await expect(
+      readModelStatsObservations(context, [
+        firstCancellationIdempotencyKey,
+        secondCancellationIdempotencyKey,
+      ]),
+    ).resolves.toStrictEqual(
+      expect.arrayContaining([
+        {
+          idempotencyKey: firstCancellationIdempotencyKey,
+          aggregatedAt: windowEndIso,
+        },
+        {
+          idempotencyKey: secondCancellationIdempotencyKey,
+          aggregatedAt: null,
+        },
+      ]),
+    );
+
+    const resumed = await api.requestAggregateModelStats("valid", [200]);
+    expect(resumed.body).toStrictEqual({
+      success: true,
+      cutoff: windowEndIso,
+      processedHours: 1,
+      processedObservations: 1,
+      updatedStats: 0,
+    });
+    const resumedStates = await readModelStatsObservations(context, [
+      firstCancellationIdempotencyKey,
+      secondCancellationIdempotencyKey,
+    ]);
+    expect(
+      resumedStates.every((observation) => {
+        return observation.aggregatedAt === windowEndIso;
+      }),
+    ).toBeTruthy();
+
+    // A failed increment must roll back every statistic mutation. 1,024 maximum
     // safe integers still fit in PostgreSQL bigint; the 1,025th overflows SUM.
-    // The observation markers must roll back with the stats replacement.
+    // The observation markers must roll back with the additive upsert.
     mockNow(mainObservedAt);
     const overflowEvents = Array.from({ length: 1025 }, () => {
       return {
@@ -713,7 +873,7 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       routes: modelStatsRoutes,
     });
     const failedAggregate = await aggregateApp.request(
-      `${cronAggregateModelStatsContract.aggregate.path}?hours=24`,
+      cronAggregateModelStatsContract.aggregate.path,
       {
         headers: { authorization: "Bearer test-cron-secret" },
       },
@@ -722,8 +882,8 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     await expect(failedAggregate.json()).resolves.toStrictEqual({
       error: "Internal server error",
     });
-    const afterFailedRebuild = await api.readModelRankings("today");
-    expect(afterFailedRebuild.body).toStrictEqual(afterConcurrent.body);
+    const afterFailedIncrement = await api.readModelRankings("today");
+    expect(afterFailedIncrement.body).toStrictEqual(afterConcurrent.body);
     const firstOverflowEvent = overflowEvents[0];
     const lastOverflowEvent = overflowEvents.at(-1);
     if (!firstOverflowEvent || !lastOverflowEvent) {
@@ -746,20 +906,23 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       }),
     );
 
-    // The projection lifecycle marker replaces observation retention. A
-    // later run still retains old source rows and can rebuild their stats.
+    // Applied observations remain retained during the incremental soak. A
+    // later run processes the formerly current hour without deleting history.
     const laterAggregateAt = dayStart + 33 * DAY_MS + 4 * HOUR_MS;
     mockNow(laterAggregateAt);
-    const laterPreparation = await api.requestAggregateModelStats(
+    const laterProcessing = await api.requestAggregateModelStats(
       "valid",
-      undefined,
       [200],
     );
-    expect(laterPreparation.body).toMatchObject({
+    expect(laterProcessing.body).toMatchObject({
       success: true,
-      windowStart: windowEndIso,
-      windowEnd: new Date(laterAggregateAt).toISOString(),
+      cutoff: new Date(laterAggregateAt).toISOString(),
     });
+    expect(laterProcessing.body.processedHours).toBeGreaterThanOrEqual(1);
+    expect(laterProcessing.body.processedObservations).toBeGreaterThanOrEqual(
+      1,
+    );
+    expect(laterProcessing.body.updatedStats).toBeGreaterThanOrEqual(1);
     const retainedStates = await readModelStatsObservations(context, [
       compactIdempotencyKey,
       previousIdempotencyKey,
@@ -768,8 +931,10 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       lateIdempotencyKey,
       oldPendingIdempotencyKey,
       concurrentIdempotencyKey,
+      firstCancellationIdempotencyKey,
+      secondCancellationIdempotencyKey,
     ]);
-    expect(retainedStates).toHaveLength(7);
+    expect(retainedStates).toHaveLength(9);
     expect(
       retainedStates.every((observation) => {
         return observation.aggregatedAt !== null;
@@ -777,9 +942,16 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     ).toBeTruthy();
 
     mockNow(aggregateAt);
-    await api.requestAggregateModelStats("valid", 24, [200]);
-    const rebuilt = await api.readModelRankings("today");
-    expect(rebuilt.body).toStrictEqual(afterConcurrent.body);
+    const noOp = await api.requestAggregateModelStats("valid", [200]);
+    expect(noOp.body).toStrictEqual({
+      success: true,
+      cutoff: windowEndIso,
+      processedHours: 0,
+      processedObservations: 0,
+      updatedStats: 0,
+    });
+    const unchanged = await api.readModelRankings("today");
+    expect(unchanged.body).toStrictEqual(afterConcurrent.body);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/model-stats.ts
+++ b/turbo/apps/api/src/signals/routes/model-stats.ts
@@ -9,7 +9,6 @@ import { queryOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
 import {
   aggregateModelStats$,
-  DEFAULT_MODEL_STATS_REPROCESS_HOURS,
   MODEL_RANKING_PERIODS,
   readPublicModelRankings$,
 } from "../services/model-stats.service";
@@ -46,7 +45,6 @@ export const modelStatsContract = c.router({
   },
 });
 
-const aggregateQuery$ = queryOf(cronAggregateModelStatsContract.aggregate);
 const rankingsQuery$ = queryOf(modelStatsContract.rankings);
 
 function unauthorized() {
@@ -68,19 +66,15 @@ const aggregateModelStatsRoute$ = command(
       return unauthorized();
     }
 
-    const query = get(aggregateQuery$);
-    const result = await set(
-      aggregateModelStats$,
-      query.hours ?? DEFAULT_MODEL_STATS_REPROCESS_HOURS,
-      signal,
-    );
+    const result = await set(aggregateModelStats$, signal);
     return {
       status: 200 as const,
       body: {
         success: true as const,
-        windowStart: result.windowStart.toISOString(),
-        windowEnd: result.windowEnd.toISOString(),
-        aggregated: result.aggregated,
+        cutoff: result.cutoff.toISOString(),
+        processedHours: result.processedHours,
+        processedObservations: result.processedObservations,
+        updatedStats: result.updatedStats,
       },
     };
   },

--- a/turbo/apps/api/src/signals/routes/test-model-stats-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-model-stats-state.ts
@@ -5,7 +5,7 @@ import {
 } from "@vm0/api-contracts/contracts/test-model-stats-state";
 import { modelStat } from "@vm0/db/schema/model-stat";
 import { modelUsageObservation } from "@vm0/db/schema/model-usage-observation";
-import { and, asc, count, gte, inArray, lt, sql } from "drizzle-orm";
+import { and, asc, count, eq, gte, inArray, lt, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { executeRawRows } from "../../lib/db-raw-rows";
@@ -35,6 +35,18 @@ const aggregationLockGate = testOverride<ModelStatsAggregationLockGate | null>(
   },
 );
 
+interface ModelStatsObservationLockGate {
+  held: boolean;
+  readonly released: ReturnType<typeof createDeferredPromise<void>>;
+  readonly release: () => void;
+}
+
+const observationLockGate = testOverride<ModelStatsObservationLockGate | null>(
+  () => {
+    return null;
+  },
+);
+
 const lockHolderRowSchema = z.object({ holderPid: z.int() });
 const lockStateRowSchema = z.object({
   held: z.boolean(),
@@ -59,6 +71,27 @@ function createAggregationLockGate(
 function clearAggregationLockGate(gate: ModelStatsAggregationLockGate): void {
   if (aggregationLockGate.get() === gate) {
     aggregationLockGate.clear();
+  }
+}
+
+function createObservationLockGate(
+  signal: AbortSignal,
+): ModelStatsObservationLockGate {
+  const released = createDeferredPromise<void>(signal);
+  return {
+    held: false,
+    released,
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+  };
+}
+
+function clearObservationLockGate(gate: ModelStatsObservationLockGate): void {
+  if (observationLockGate.get() === gate) {
+    observationLockGate.clear();
   }
 }
 
@@ -136,6 +169,37 @@ async function readAggregationLockState(
     throw new Error("Failed to read model stats aggregation lock state");
   }
   return state;
+}
+
+async function holdObservationLock(
+  db: Db,
+  idempotencyKey: string,
+  signal: AbortSignal,
+): Promise<void> {
+  if (observationLockGate.get()) {
+    throw new Error("A model stats observation lock gate is already active");
+  }
+  const gate = createObservationLockGate(signal);
+  observationLockGate.set(gate);
+  await onRejection(
+    db.transaction(async (tx) => {
+      const rows = await tx
+        .select({ idempotencyKey: modelUsageObservation.idempotencyKey })
+        .from(modelUsageObservation)
+        .where(eq(modelUsageObservation.idempotencyKey, idempotencyKey))
+        .for("update");
+      signal.throwIfAborted();
+      if (rows.length !== 1) {
+        throw new Error("Failed to lock model stats observation");
+      }
+      gate.held = true;
+      await gate.released.promise;
+    }),
+    () => {
+      clearObservationLockGate(gate);
+    },
+  );
+  clearObservationLockGate(gate);
 }
 
 async function readObservations(
@@ -234,6 +298,23 @@ async function mutateModelStatsState(
     }
     case "release-aggregation-lock": {
       aggregationLockGate.get()?.release();
+      return { status: 200 as const, body: { ok: true as const } };
+    }
+    case "hold-observation-lock": {
+      await holdObservationLock(db, body.idempotency_key, signal);
+      return { status: 200 as const, body: { ok: true as const } };
+    }
+    case "read-observation-lock-state": {
+      return {
+        status: 200 as const,
+        body: {
+          ok: true as const,
+          observation_lock_held: observationLockGate.get()?.held ?? false,
+        },
+      };
+    }
+    case "release-observation-lock": {
+      observationLockGate.get()?.release();
       return { status: 200 as const, body: { ok: true as const } };
     }
     case "read-observations": {

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -9,7 +9,6 @@ import {
   inArray,
   isNull,
   lt,
-  min,
   or,
   sql,
   sum,
@@ -32,13 +31,14 @@ import {
   pgInt8ToSafeIntegerDecoder,
   pgTextDecoder,
 } from "../../lib/db-structured-result";
+import { logger } from "../../lib/log";
 import { type Db, writeDb$ } from "../external/db";
 import { nowDate } from "../external/time";
 import { lockModelStatsAggregation } from "./model-stats-aggregation-lock.service";
 
 const HOUR_MS = 60 * 60_000;
-export const DEFAULT_MODEL_STATS_REPROCESS_HOURS = 24;
 export const MODEL_RANKING_PERIODS = ["today", "week", "month"] as const;
+const L = logger("CronAggregateModelStats");
 
 type ModelRankingPeriod = (typeof MODEL_RANKING_PERIODS)[number];
 
@@ -69,18 +69,23 @@ function getModelStatsModelIds(): string[] {
   ];
 }
 
-interface ModelStatsAggregationResult {
-  readonly windowStart: Date;
-  readonly windowEnd: Date;
-  readonly aggregated: number;
+interface ModelStatsProcessingResult {
+  readonly cutoff: Date;
+  readonly processedHours: number;
+  readonly processedObservations: number;
+  readonly updatedStats: number;
 }
 
-const modelStatsAggregationRowSchema = z.object({
-  windowStart: pgTimestampWithoutTimezoneToDateSchema,
-  windowEnd: pgTimestampWithoutTimezoneToDateSchema,
-  aggregated: z.int().nonnegative(),
-  markedObservations: z.int().nonnegative(),
-  deleted: z.int().nonnegative(),
+interface ModelStatsHourProcessingResult {
+  readonly hourStart: Date | null;
+  readonly processedObservations: number;
+  readonly updatedStats: number;
+}
+
+const modelStatsHourProcessingRowSchema = z.object({
+  hourStart: pgTimestampWithoutTimezoneToDateSchema.nullable(),
+  processedObservations: z.int().nonnegative(),
+  updatedStats: z.int().nonnegative(),
 });
 
 function utcHourStart(date: Date): Date {
@@ -175,86 +180,104 @@ function modelStatWindowSum(
   )::bigint`.mapWith(pgInt8ToSafeIntegerDecoder);
 }
 
-interface ModelStatsAggregationSqlArgs {
+interface ModelStatsHourProcessingSqlArgs {
   readonly modelStatsModelIds: string[];
   readonly observationModelExpr: SQLWrapper;
-  readonly preparedAt: string;
-  readonly requestedWindowStart: string;
-  readonly windowEnd: string;
+  readonly processedAt: string;
+  readonly cutoff: string;
 }
 
-function modelStatsSourceCtes(args: ModelStatsAggregationSqlArgs): SQL {
+function modelStatsHourClaimCtes(args: ModelStatsHourProcessingSqlArgs): SQL {
   return sql`
-    oldest_pending AS MATERIALIZED (
+    oldest_pending_hour AS MATERIALIZED (
         SELECT
-          ${min(modelUsageObservation.observedAt)} AS oldest_observed_at
+          date_trunc(
+            'hour',
+            ${modelUsageObservation.observedAt}
+          )::timestamp AS hour_start
         FROM ${modelUsageObservation}
         WHERE ${and(
           isNull(modelUsageObservation.aggregatedAt),
+          lt(modelUsageObservation.observedAt, sql`${args.cutoff}::timestamp`),
+        )}
+        ORDER BY ${modelUsageObservation.observedAt}
+        LIMIT 1
+      ),
+      claimed_observations AS (
+        UPDATE ${modelUsageObservation}
+        SET aggregated_at = ${args.processedAt}::timestamp
+        FROM oldest_pending_hour
+        WHERE ${and(
+          isNull(modelUsageObservation.aggregatedAt),
+          gte(
+            modelUsageObservation.observedAt,
+            sql`oldest_pending_hour.hour_start`,
+          ),
           lt(
             modelUsageObservation.observedAt,
-            sql`${args.windowEnd}::timestamp`,
+            sql`oldest_pending_hour.hour_start + INTERVAL '1 hour'`,
           ),
         )}
-      ),
-      bounds AS MATERIALIZED (
-        SELECT
-          LEAST(
-            ${args.requestedWindowStart}::timestamp,
-            COALESCE(
-              date_trunc('hour', oldest_pending.oldest_observed_at)::timestamp,
-              ${args.requestedWindowStart}::timestamp
-            )
-          )::timestamp AS window_start,
-          ${args.windowEnd}::timestamp AS window_end
-        FROM oldest_pending
-      ),
-      usage_rows AS MATERIALIZED (
-        SELECT
-          date_trunc('hour', ${modelUsageObservation.observedAt})::timestamp AS hour_start,
+        RETURNING
           ${args.observationModelExpr} AS model,
           ${modelUsageObservation.inputTokens}::bigint AS input_tokens,
           ${modelUsageObservation.outputTokens}::bigint AS output_tokens,
-          ${modelUsageObservation.cacheReadInputTokens}::bigint AS cache_read_input_tokens,
-          ${modelUsageObservation.cacheCreationInputTokens}::bigint AS cache_creation_input_tokens
-        FROM ${modelUsageObservation}
-        CROSS JOIN bounds
-        WHERE ${and(
-          gte(modelUsageObservation.observedAt, sql`bounds.window_start`),
-          lt(modelUsageObservation.observedAt, sql`bounds.window_end`),
-          inArray(modelUsageObservation.model, args.modelStatsModelIds),
-          or(
-            gt(modelUsageObservation.inputTokens, sql`0`),
-            gt(modelUsageObservation.outputTokens, sql`0`),
-            gt(modelUsageObservation.cacheReadInputTokens, sql`0`),
-            gt(modelUsageObservation.cacheCreationInputTokens, sql`0`),
-          ),
-        )}
-      ),
-      aggregated AS (
-        SELECT
-          hour_start,
-          model,
-          COALESCE(SUM(input_tokens), 0)::bigint AS input_tokens,
-          COALESCE(SUM(output_tokens), 0)::bigint AS output_tokens,
-          COALESCE(SUM(cache_read_input_tokens), 0)::bigint AS cache_read_input_tokens,
-          COALESCE(SUM(cache_creation_input_tokens), 0)::bigint AS cache_creation_input_tokens,
-          (
-            COALESCE(SUM(input_tokens), 0)
-            + COALESCE(SUM(output_tokens), 0)
-            + COALESCE(SUM(cache_read_input_tokens), 0)
-            + COALESCE(SUM(cache_creation_input_tokens), 0)
-          )::bigint AS total_tokens
-        FROM usage_rows
-        WHERE model <> ''
-        GROUP BY hour_start, model
+          ${modelUsageObservation.cacheReadInputTokens}::bigint
+            AS cache_read_input_tokens,
+          ${modelUsageObservation.cacheCreationInputTokens}::bigint
+            AS cache_creation_input_tokens
       )
   `;
 }
 
-function modelStatsMutationCtes(args: ModelStatsAggregationSqlArgs): SQL {
+function modelStatsHourProjectionCtes(
+  args: ModelStatsHourProcessingSqlArgs,
+): SQL {
   return sql`
-    upserted_stats AS (
+    aggregated AS MATERIALIZED (
+        SELECT
+          oldest_pending_hour.hour_start,
+          claimed_observations.model,
+          COALESCE(SUM(claimed_observations.input_tokens), 0)::bigint
+            AS input_tokens,
+          COALESCE(SUM(claimed_observations.output_tokens), 0)::bigint
+            AS output_tokens,
+          COALESCE(
+            SUM(claimed_observations.cache_read_input_tokens),
+            0
+          )::bigint AS cache_read_input_tokens,
+          COALESCE(
+            SUM(claimed_observations.cache_creation_input_tokens),
+            0
+          )::bigint AS cache_creation_input_tokens,
+          (
+            COALESCE(SUM(claimed_observations.input_tokens), 0)
+            + COALESCE(SUM(claimed_observations.output_tokens), 0)
+            + COALESCE(
+              SUM(claimed_observations.cache_read_input_tokens),
+              0
+            )
+            + COALESCE(
+              SUM(claimed_observations.cache_creation_input_tokens),
+              0
+            )
+          )::bigint AS total_tokens
+        FROM claimed_observations
+        CROSS JOIN oldest_pending_hour
+        WHERE ${and(
+          inArray(sql`claimed_observations.model`, args.modelStatsModelIds),
+          or(
+            gt(sql`claimed_observations.input_tokens`, sql`0`),
+            gt(sql`claimed_observations.output_tokens`, sql`0`),
+            gt(sql`claimed_observations.cache_read_input_tokens`, sql`0`),
+            gt(sql`claimed_observations.cache_creation_input_tokens`, sql`0`),
+          ),
+        )}
+        GROUP BY
+          oldest_pending_hour.hour_start,
+          claimed_observations.model
+      ),
+      upserted_stats AS (
         INSERT INTO ${modelStat} (
           "hour_start",
           "model",
@@ -274,95 +297,80 @@ function modelStatsMutationCtes(args: ModelStatsAggregationSqlArgs): SQL {
           total_tokens
         FROM aggregated
         ON CONFLICT (hour_start, model) DO UPDATE SET
-          input_tokens = EXCLUDED.input_tokens,
-          output_tokens = EXCLUDED.output_tokens,
-          cache_read_input_tokens = EXCLUDED.cache_read_input_tokens,
-          cache_creation_input_tokens = EXCLUDED.cache_creation_input_tokens,
-          total_tokens = EXCLUDED.total_tokens,
+          input_tokens =
+            ${modelStat.inputTokens} + EXCLUDED.input_tokens,
+          output_tokens =
+            ${modelStat.outputTokens} + EXCLUDED.output_tokens,
+          cache_read_input_tokens =
+            ${modelStat.cacheReadInputTokens}
+            + EXCLUDED.cache_read_input_tokens,
+          cache_creation_input_tokens =
+            ${modelStat.cacheCreationInputTokens}
+            + EXCLUDED.cache_creation_input_tokens,
+          total_tokens =
+            ${modelStat.totalTokens} + EXCLUDED.total_tokens,
           updated_at = NOW()
         RETURNING id
-      ),
-      deleted_stats AS (
-        DELETE FROM ${modelStat}
-        USING bounds
-        WHERE
-          ${and(
-            gte(modelStat.hourStart, sql`bounds.window_start`),
-            lt(modelStat.hourStart, sql`bounds.window_end`),
-            inArray(modelStat.model, args.modelStatsModelIds),
-          )}
-          AND NOT EXISTS (
-            SELECT 1
-            FROM aggregated
-            WHERE
-              aggregated.hour_start = ${modelStat.hourStart}
-              AND aggregated.model = ${modelStat.model}
-          )
-        RETURNING ${modelStat.id}
-      ),
-      marked_observations AS (
-        UPDATE ${modelUsageObservation}
-        SET aggregated_at = ${args.preparedAt}::timestamp
-        FROM bounds
-        WHERE ${and(
-          isNull(modelUsageObservation.aggregatedAt),
-          gte(modelUsageObservation.observedAt, sql`bounds.window_start`),
-          lt(modelUsageObservation.observedAt, sql`bounds.window_end`),
-        )}
-        RETURNING ${modelUsageObservation.idempotencyKey}
       )
   `;
 }
 
-function modelStatsAggregationSql(args: ModelStatsAggregationSqlArgs): SQL {
+function modelStatsHourProcessingSql(
+  args: ModelStatsHourProcessingSqlArgs,
+): SQL {
   return sql`
     WITH
-    ${modelStatsSourceCtes(args)},
-    ${modelStatsMutationCtes(args)}
+      ${modelStatsHourClaimCtes(args)},
+      ${modelStatsHourProjectionCtes(args)}
     SELECT
-      bounds.window_start AS "windowStart",
-      bounds.window_end AS "windowEnd",
-      (SELECT ${count()}::int FROM upserted_stats) AS "aggregated",
-      (SELECT ${count()}::int FROM marked_observations)
-        AS "markedObservations",
-      (SELECT ${count()}::int FROM deleted_stats) AS "deleted"
-    FROM bounds
+      (
+        SELECT oldest_pending_hour.hour_start
+        FROM oldest_pending_hour
+      ) AS "hourStart",
+      (
+        SELECT ${count()}::int
+        FROM claimed_observations
+      ) AS "processedObservations",
+      (
+        SELECT ${count()}::int
+        FROM upserted_stats
+      ) AS "updatedStats"
   `;
 }
 
-async function prepareModelStats(
+async function processOldestPendingModelStatsHour(
   db: Db,
-  requestedWindowStart: Date,
-  windowEnd: Date,
-  preparedAt: Date,
+  cutoff: Date,
+  processedAt: Date,
   signal: AbortSignal,
-): Promise<ModelStatsAggregationResult> {
-  const query = modelStatsAggregationSql({
+): Promise<ModelStatsHourProcessingResult> {
+  const query = modelStatsHourProcessingSql({
     modelStatsModelIds: getModelStatsModelIds(),
     observationModelExpr: modelUsageObservationModelExpression(),
-    preparedAt: utcTimestampParam(preparedAt),
-    requestedWindowStart: utcTimestampParam(requestedWindowStart),
-    windowEnd: utcTimestampParam(windowEnd),
+    processedAt: utcTimestampParam(processedAt),
+    cutoff: utcTimestampParam(cutoff),
   });
 
-  return await db.transaction(async (tx) => {
+  const result = await db.transaction(async (tx) => {
     await lockModelStatsAggregation(tx);
     signal.throwIfAborted();
     const rows = await executeRawRows(
       tx,
       query,
-      modelStatsAggregationRowSchema,
+      modelStatsHourProcessingRowSchema,
     );
     signal.throwIfAborted();
 
-    const [result] = rows;
-    if (rows.length !== 1 || !result) {
+    const [row] = rows;
+    if (rows.length !== 1 || !row) {
       throw new Error(
-        "Model stats aggregation returned an unexpected summary row count",
+        "Model stats processing returned an unexpected summary row count",
       );
     }
-    return result;
+    return row;
   });
+  signal.throwIfAborted();
+  return result;
 }
 
 async function selectModelRankings(
@@ -459,27 +467,59 @@ async function selectModelRankings(
 }
 
 export const aggregateModelStats$ = command(
-  async (
-    { set },
-    hours: number,
-    signal: AbortSignal,
-  ): Promise<ModelStatsAggregationResult> => {
+  async ({ set }, signal: AbortSignal): Promise<ModelStatsProcessingResult> => {
     const db = set(writeDb$);
-    const preparedAt = nowDate();
-    const windowEnd = utcHourStart(preparedAt);
-    const windowStart = new Date(windowEnd.getTime() - hours * HOUR_MS);
+    const startedAt = performance.now();
+    const processedAt = nowDate();
+    const cutoff = utcHourStart(processedAt);
+    let processedHours = 0;
+    let processedObservations = 0;
+    let updatedStats = 0;
+    let firstProcessedHour: Date | null = null;
+    let lastProcessedHour: Date | null = null;
 
-    signal.throwIfAborted();
-    const result = await prepareModelStats(
-      db,
-      windowStart,
-      windowEnd,
-      preparedAt,
-      signal,
-    );
-    signal.throwIfAborted();
+    while (true) {
+      signal.throwIfAborted();
+      const result = await processOldestPendingModelStatsHour(
+        db,
+        cutoff,
+        processedAt,
+        signal,
+      );
+      signal.throwIfAborted();
+      if (!result.hourStart) {
+        break;
+      }
 
-    return result;
+      firstProcessedHour ??= result.hourStart;
+      lastProcessedHour = result.hourStart;
+      processedHours++;
+      processedObservations += result.processedObservations;
+      updatedStats += result.updatedStats;
+    }
+
+    const durationMs = Math.round(performance.now() - startedAt);
+    L.debug("model stats processing completed", {
+      cutoff: cutoff.toISOString(),
+      firstProcessedHour: firstProcessedHour?.toISOString() ?? null,
+      lastProcessedHour: lastProcessedHour?.toISOString() ?? null,
+      oldestCompleteBacklogAgeHours:
+        firstProcessedHour === null
+          ? 0
+          : (cutoff.getTime() - firstProcessedHour.getTime()) / HOUR_MS,
+      processedHours,
+      processedObservations,
+      updatedStats,
+      remainingCompletePendingObservations: 0,
+      durationMs,
+    });
+
+    return {
+      cutoff,
+      processedHours,
+      processedObservations,
+      updatedStats,
+    };
   },
 );
 

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -203,13 +203,12 @@ const cronRefreshStoragePresignedUrlsResponseSchema = z.object({
   workflowSkill: storagePresignedUrlRefreshResultSchema,
 });
 
-export const CRON_AGGREGATE_MODEL_STATS_MAX_HOURS = 24 * 32;
-
 const cronAggregateModelStatsResponseSchema = z.object({
   success: z.literal(true),
-  windowStart: z.string(),
-  windowEnd: z.string(),
-  aggregated: z.number(),
+  cutoff: z.iso.datetime(),
+  processedHours: z.number().int().nonnegative(),
+  processedObservations: z.number().int().nonnegative(),
+  updatedStats: z.number().int().nonnegative(),
 });
 
 export const cronAggregateUsageContract = c.router({
@@ -465,14 +464,7 @@ export const cronAggregateModelStatsContract = c.router({
     method: "GET",
     path: "/api/cron/aggregate-model-stats",
     headers: authHeadersSchema,
-    query: z.object({
-      hours: z.coerce
-        .number()
-        .int()
-        .min(1)
-        .max(CRON_AGGREGATE_MODEL_STATS_MAX_HOURS)
-        .optional(),
-    }),
+    query: z.object({}).strict(),
     responses: {
       200: cronAggregateModelStatsResponseSchema,
       401: apiErrorSchema,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -445,7 +445,6 @@ export {
   cronAggregateModelStatsResponseSchema,
   cronAggregateUsageContract,
   cronAggregateUsageResponseSchema,
-  CRON_AGGREGATE_MODEL_STATS_MAX_HOURS,
   cronCompactChatThreadSnapshotsContract,
   cronCompactChatThreadSnapshotsResponseSchema,
   cronCleanupSandboxesContract,

--- a/turbo/packages/api-contracts/src/contracts/test-model-stats-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-model-stats-state.ts
@@ -19,6 +19,16 @@ export const testModelStatsStateActionBodySchema = z.discriminatedUnion(
       action: z.literal("release-aggregation-lock"),
     }),
     z.object({
+      action: z.literal("hold-observation-lock"),
+      idempotency_key: z.uuid(),
+    }),
+    z.object({
+      action: z.literal("read-observation-lock-state"),
+    }),
+    z.object({
+      action: z.literal("release-observation-lock"),
+    }),
+    z.object({
       action: z.literal("read-observations"),
       idempotency_keys: idempotencyKeysSchema,
     }),
@@ -51,6 +61,7 @@ export const testModelStatsStateActionResponseSchema = z.object({
   ok: z.literal(true),
   aggregation_lock_held: z.boolean().optional(),
   aggregation_lock_waiter_count: z.number().int().nonnegative().optional(),
+  observation_lock_held: z.boolean().optional(),
   observations: z.array(testModelStatsObservationSchema).optional(),
 });
 

--- a/turbo/packages/db/src/schema/model-stat.ts
+++ b/turbo/packages/db/src/schema/model-stat.ts
@@ -11,8 +11,9 @@ import {
 /**
  * Hourly model usage rollup used by the public model rankings page.
  *
- * `hourStart` is the UTC hour bucket of usage activity time. Rows are
- * re-aggregated idempotently by the internal cron endpoint.
+ * `hourStart` is the UTC hour bucket of usage activity time. The internal cron
+ * incrementally projects each accepted model usage observation into these
+ * durable rows.
  */
 export const modelStat = pgTable(
   "model_stat",


### PR DESCRIPTION
## Summary

- replace bounded exact model-stat rebuilds with oldest-hour incremental projection
- claim observations and add their counters to `model_stat` atomically under the existing advisory lock
- make the cron endpoint parameterless and report processing progress
- cover retries, overlapping cron requests, late observations, cancellation resume, and overflow rollback

## Behavior

Each transaction selects the oldest complete pending UTC hour, marks exactly those observations through `UPDATE ... RETURNING`, aggregates the returned rows, and applies additive upserts. The transaction rolls back both the claim and projection if processing fails. The request repeats until no complete pending observations remain, while current-hour observations stay pending for a later run.

Observations remain retained for the follow-up cleanup slice. This PR does not add or alter database schema.

## Deployment notes

- [x] The prepare/reconciliation release from #24076 is deployed.
- [ ] Confirm that pre-lock API versions have drained before merging.
- [ ] Verify production callers do not send the removed `hours` query or consume the former response fields.
- [ ] Record the retained-source reconciliation state on parent issue #23962.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/db lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F api build`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/ops-logs.bdd.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm vitest run --project=api --shard=4/8 --silent=passed-only` (332 passed)
- `pnpm -F @vm0/api-contracts exec vitest run --maxWorkers=1 --silent=passed-only` (515 passed)
- `pnpm -F @vm0/api-contracts generate:rust`
- runtime API schema compatibility lint
- `pnpm -F @vm0/db test:migration-consistency`

Closes #24078

Parent: #23962
