### PR TITLE
refactor: reduce fallback slop in slack commands

### DIFF
--- a/e2e/helpers/slack.bash
+++ b/e2e/helpers/slack.bash
@@ -64,15 +64,16 @@ slack_sign_body() {
 }
 
 # POST a /vm0 slash command to the Slack commands endpoint.
-# Usage: slack_post_command <command> <text> <team_id> <user_id> [channel_id]
+# Usage: slack_post_command <command> <text> <team_id> <user_id> [channel_id] [trigger_id]
 # Output: HTTP status code on stderr, response body on stdout
 slack_post_command() {
     local command="$1" text="$2" team_id="$3" user_id="$4"
     local channel_id="${5:-$SLACK_FIXTURE_CHANNEL_ID}"
+    local trigger_id="${6:-trigger-e2e}"
     local body
     body=$(
-        printf 'token=xoxb-test&team_id=%s&team_domain=e2e&channel_id=%s&channel_name=e2e&user_id=%s&user_name=e2e-user&command=%s&text=%s&api_app_id=%s' \
-            "$team_id" "$channel_id" "$user_id" "$command" "$text" "$SLACK_FIXTURE_APP_ID"
+        printf 'token=xoxb-test&team_id=%s&team_domain=e2e&channel_id=%s&channel_name=e2e&user_id=%s&user_name=e2e-user&command=%s&text=%s&trigger_id=%s&api_app_id=%s' \
+            "$team_id" "$channel_id" "$user_id" "$command" "$text" "$trigger_id" "$SLACK_FIXTURE_APP_ID"
     )
     slack_sign_body "$body"
     local -a bypass=()

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -718,6 +718,25 @@ describe("INT-01: Slack integration and Slack app routes", () => {
     expectSlackEphemeral(unknown.body);
     expect(unknown.body.blocks.length).toBeGreaterThan(0);
 
+    for (const requiredField of [
+      "team_id",
+      "channel_id",
+      "user_id",
+      "trigger_id",
+    ]) {
+      const missingFieldParams = new URLSearchParams(commandBody("help"));
+      missingFieldParams.delete(requiredField);
+      const missingFieldBody = missingFieldParams.toString();
+      const missingField = await integrations.requestSlackCommand(
+        missingFieldBody,
+        integrations.signedSlackIngressHeaders(missingFieldBody),
+        [400],
+      );
+      expect(missingField.body).toStrictEqual({
+        error: "Missing required Slack command fields",
+      });
+    }
+
     const emptyActionPayload = new URLSearchParams({
       payload: JSON.stringify({
         type: "block_actions",

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -293,14 +293,21 @@ function ephemeral(blocks: unknown[]): Response {
   return jsonResponse({ response_type: "ephemeral", blocks });
 }
 
-function parseCommandPayload(body: string): SlackCommandPayload {
+function parseCommandPayload(body: string): SlackCommandPayload | null {
   const params = new URLSearchParams(body);
+  const teamId = params.get("team_id");
+  const channelId = params.get("channel_id");
+  const userId = params.get("user_id");
+  const triggerId = params.get("trigger_id");
+  if (!teamId || !channelId || !userId || !triggerId) {
+    return null;
+  }
   return {
-    team_id: params.get("team_id") ?? "",
-    channel_id: params.get("channel_id") ?? "",
-    user_id: params.get("user_id") ?? "",
+    team_id: teamId,
+    channel_id: channelId,
+    user_id: userId,
     text: params.get("text") ?? "",
-    trigger_id: params.get("trigger_id") ?? "",
+    trigger_id: triggerId,
   };
 }
 
@@ -1279,6 +1286,12 @@ export const handleZeroSlackCommands$ = command(
     }
 
     const payload = parseCommandPayload(verified.body);
+    if (!payload) {
+      return jsonResponse(
+        { error: "Missing required Slack command fields" },
+        400,
+      );
+    }
     const db = set(writeDb$);
     const args = payload.text.trim().split(/\s+/);
     const subCommand = args[0]?.toLowerCase() ?? "";

--- a/turbo/packages/api-contracts/src/contracts/zero-slack-commands.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-slack-commands.ts
@@ -11,6 +11,7 @@ export const zeroSlackCommandsContract = c.router({
     body: c.type<string>(),
     responses: {
       200: z.unknown(),
+      400: z.object({ error: z.string() }),
       401: z.object({ error: z.string() }),
       503: z.object({ error: z.string() }),
     },


### PR DESCRIPTION
## Scan

- Scanned at: `2026-07-30T20:01:36.554Z`
- Base commit: `8030d565109ec3bb36741f3f8871302d313853d5`
- Files scanned: 3,879
- High-confidence production actionable total: 229
- Suggested 5% edit budget: 12
- Changed candidates: 4

### Totals by category

| Category | Count |
| --- | ---: |
| nullish | 6,171 |
| nullish-chain | 132 |
| field-fallback-chain | 103 |
| optional-prop | 6,018 |
| zod-optional | 2,633 |
| zod-loose-optional | 5 |
| loose-record | 1,084 |
| loose-index-signature | 3 |
| as-any | 0 |
| as-unknown-as | 30 |
| empty-fallback | 619 |
| string-fallback | 658 |
| null-undefined-fallback | 1,684 |
| empty-catch | 3 |
| promise-catch-swallow | 16 |
| rust-unwrap-or | 667 |
| rust-ok-discard | 154 |

## Changes

- `zero-slack-webhooks.service.ts`: reject signed Slack slash-command payloads when `team_id`, `channel_id`, `user_id`, or `trigger_id` is absent, instead of constructing empty identifiers. Empty command text remains valid.
- `zero-slack-commands.ts`: declare the 400 response at the API contract boundary.
- `integrations.bdd.test.ts`: cover each omitted required field.

The remaining scanner matches were left untouched because they need broader contract analysis or are legitimate compatibility, presentation, or optional-data fallbacks.

## Verification

- `git diff --check`
- Prettier check for all changed files
- Package-scoped Oxlint for all changed files
- `pnpm --filter @vm0/api-contracts check-types`
- `pnpm --filter api check-types`
- Scanner rerun: `string-fallback` decreased from 658 to 654

Full test coverage is delegated to the PR pipeline.
