### PR TITLE
test(api): isolate mocked clocks per test

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/time.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/time.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { clearMockNow, mockNow, now, nowDate } from "../time";
+import {
+  clearMockNow,
+  mockNow,
+  now,
+  nowDate,
+  withMockNowForTest,
+  withNowScopeForTest,
+} from "../time";
 
 describe("time", () => {
   it("returns a mocked timestamp", () => {
@@ -29,5 +36,40 @@ describe("time", () => {
     clearMockNow();
 
     expect(now()).not.toBe(123);
+  });
+
+  it("isolates scoped clocks across concurrent async work", async () => {
+    const [first, second] = await Promise.all([
+      withMockNowForTest(123, async () => {
+        await Promise.resolve();
+        mockNow(124);
+        await Promise.resolve();
+        return now();
+      }),
+      withMockNowForTest(456, async () => {
+        await Promise.resolve();
+        expect(now()).toBe(456);
+        await Promise.resolve();
+        return now();
+      }),
+    ]);
+
+    expect(first).toBe(124);
+    expect(second).toBe(456);
+  });
+
+  it("isolates a real-time scope from the legacy global override", async () => {
+    mockNow(123);
+
+    await withNowScopeForTest(async () => {
+      expect(now()).not.toBe(123);
+      mockNow(456);
+      await Promise.resolve();
+      expect(now()).toBe(456);
+      clearMockNow();
+      expect(now()).not.toBe(123);
+    });
+
+    expect(now()).toBe(123);
   });
 });

--- a/turbo/apps/api/src/lib/time.ts
+++ b/turbo/apps/api/src/lib/time.ts
@@ -1,4 +1,10 @@
-import { testOverride } from "./singleton";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import { singleton, testOverride } from "./singleton";
+
+interface ScopedMockNow {
+  value: number | undefined;
+}
 
 const {
   get: getMockedNow,
@@ -7,8 +13,23 @@ const {
 } = testOverride<number | undefined>(() => {
   return undefined;
 });
+const scopedMockNow = singleton(() => {
+  return new AsyncLocalStorage<ScopedMockNow>();
+});
+
+function timestamp(value: Date | number): number {
+  return value instanceof Date ? value.getTime() : value;
+}
+
+function currentScopedMockNow(): ScopedMockNow | undefined {
+  return scopedMockNow.peek()?.getStore();
+}
 
 export function now(): number {
+  const scoped = currentScopedMockNow();
+  if (scoped) {
+    return scoped.value ?? Date.now();
+  }
   return getMockedNow() ?? Date.now();
 }
 
@@ -23,9 +44,33 @@ export function timestampWithoutTimeZone(value: Date): string {
 }
 
 export function mockNow(value: Date | number): void {
-  setMockedNow(value instanceof Date ? value.getTime() : value);
+  const valueTimestamp = timestamp(value);
+  const scoped = currentScopedMockNow();
+  if (scoped) {
+    scoped.value = valueTimestamp;
+    return;
+  }
+  setMockedNow(valueTimestamp);
 }
 
 export function clearMockNow(): void {
+  const scoped = currentScopedMockNow();
+  if (scoped) {
+    scoped.value = undefined;
+    return;
+  }
   clearMockedNow();
+}
+
+export async function withMockNowForTest<T>(
+  value: Date | number,
+  work: () => Promise<T>,
+): Promise<T> {
+  return await scopedMockNow().run({ value: timestamp(value) }, work);
+}
+
+export async function withNowScopeForTest<T>(
+  work: () => Promise<T>,
+): Promise<T> {
+  return await scopedMockNow().run({ value: undefined }, work);
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -11,14 +11,14 @@ import {
   chatThreadsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { HttpResponse, http } from "msw";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, test as vitestTest } from "vitest";
 import { z } from "zod";
 
 import { createApp } from "../../../app-factory";
 import { browserUseCdpHandler } from "../../../__tests__/mocks";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockEnv } from "../../../lib/env";
-import { clearMockNow, mockNow } from "../../../lib/time";
+import { mockNow, withMockNowForTest } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
@@ -40,6 +40,16 @@ const BROWSER_USE_API_URL = "https://api.browser-use.com/api/v3";
 const CRON_SECRET = "test-browser-reconcile-secret";
 const STARTED_AT_MS = Date.parse("2026-07-24T10:00:00.000Z");
 const MINUTE_MS = 60_000;
+
+function it(name: string, test: () => Promise<void>, timeout?: number): void {
+  vitestTest(
+    name,
+    async () => {
+      await withMockNowForTest(STARTED_AT_MS, test);
+    },
+    timeout,
+  );
+}
 
 function isoAt(offsetMs: number): string {
   return new Date(STARTED_AT_MS + offsetMs).toISOString();
@@ -236,10 +246,6 @@ async function reconcileBrowsers() {
 }
 
 describe("zero browser route", () => {
-  afterEach(() => {
-    clearMockNow();
-  });
-
   it("keeps managed browser access off for a default chat thread", async () => {
     const { runs, chat, actor, agent } = await setupBrowserScenario();
     const sent = await chat.requestSendEvent(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -11,13 +11,13 @@ import {
 import { RUNNER_CANCELLATION_RECOVERY_CAPABILITY } from "@vm0/api-contracts/contracts/runners";
 import { zeroModelProvidersByTypeContract } from "@vm0/api-contracts/contracts/zero-model-providers";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
-import { onTestFinished } from "vitest";
+import { onTestFinished, test as vitestTest } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
 import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
-import { mockNow, now } from "../../../lib/time";
+import { mockNow, now, withNowScopeForTest } from "../../../lib/time";
 import {
   createActiveGoalQueueEventFixture,
   readGoalQueueStateFixture,
@@ -59,6 +59,16 @@ const CRON_CLEANUP_SANDBOXES_ROUTE = "/api/cron/cleanup-sandboxes";
 const CRON_EXECUTE_WORKFLOW_AUTOMATIONS_ROUTE =
   "/api/cron/execute-workflow-automations";
 const CRON_SECRET = "test-cron-secret";
+
+function it(name: string, test: () => Promise<void>, timeout?: number): void {
+  vitestTest(
+    name,
+    async () => {
+      await withNowScopeForTest(test);
+    },
+    timeout,
+  );
+}
 
 function authHeaders() {
   return { authorization: "Bearer clerk-session" };


### PR DESCRIPTION
## Summary

- scope mocked application clocks to each async test execution with AsyncLocalStorage
- invoke the browser and workflow queue test callbacks directly inside their clock scopes, keeping Vitest scheduler continuations outside those scopes
- cover concurrent mocked clocks and real-time scopes against the legacy global override

## Failure classification

This repairs a test-isolation flake, not a product race.

- Trigger: Turbo merge-group run https://github.com/vm0-ai/vm0/actions/runs/30592822795 at 5b9d27058245a63a5d8a88fab2ca899406ebc175
- First causal failure: test-api (5), zero-workflow-queue.test.ts, queues webhook events behind the active run and drains one per completion
- The assertion expected the workflow dequeue time 2026-07-31T00:14:34.732Z but received 2026-07-31T00:24:20.942Z. The received value is exactly the concurrently loaded browser test clock plus 11 minutes.
- Earlier failing runs 30580176086 and 30586637554 received the same browser clock plus 16 minutes.
- The same relevant test blobs passed in PR run 30592521388, confirming schedule-dependent isolation rather than deterministic behavior failure.

## Validation

- targeted time tests: 6 passed
- API TypeScript check passed
- changed files passed Oxlint, type-aware Oxlint, ESLint, and Prettier
- concurrent clock isolation probe passed

## Limitations

- Did not run the full local Vitest suite, per repository instructions; the PR pipeline will validate PostgreSQL-backed API tests.
- The full local API lint reached the final ESLint phase and exhausted the runtime Node heap; all changed files passed the same lint stages independently.