### PR TITLE
test(e2e): assert normal assistant replies

### DIFF
--- a/e2e/playwright/tests/webchat.spec.ts
+++ b/e2e/playwright/tests/webchat.spec.ts
@@ -30,10 +30,11 @@ test("send a chat message and receive an assistant response", async ({
     timeout: 10_000,
   });
 
-  const assistantMessage = page.locator('[data-role="assistant"]').last();
-  await expect(assistantMessage.getByText(prompt, { exact: true })).toBeVisible(
-    {
-      timeout: 120_000,
-    },
-  );
+  const assistantReply = page
+    .locator('[data-role="assistant"]:not([data-thinking-indicator])')
+    .locator(".zero-chat-bubble-assistant")
+    .filter({ hasText: /\S/ })
+    .last();
+  await expect(assistantReply).toBeVisible({ timeout: 120_000 });
+  await expect(assistantReply).not.toContainText("Oops, something went wrong");
 });


### PR DESCRIPTION
## Summary

- assert that webchat renders a visible, non-empty assistant reply instead of requiring an exact prompt echo
- exclude the transient thinking indicator and reject the known assistant error state
- preserve the narrowed browser-test boundary from #24106: supported model selection, plain text send, user message, and assistant reply only

## Why

#24106 passed against the PR and merge-group mock runner, where Codex echoes the prompt. The subsequent main run [30593512786](https://github.com/vm0-ai/vm0/actions/runs/30593512786) used the permanent staging runner and rendered a normal streaming assistant response, but the exact-echo assertion timed out. This assertion now checks the product contract shared by both environments without retries or timeout changes.

Attachment and media layout coverage remains in the dedicated platform integration tests added by #24106.

## Test plan

- `pnpm exec playwright test --config playwright/playwright.config.ts playwright/tests/webchat.spec.ts --project=features` (3 passed)
- `pnpm exec playwright test --config playwright/playwright.config.ts` (9 passed)
- `pnpm check-types` in `e2e`
- `pnpm exec prettier --check ../e2e/playwright/tests/webchat.spec.ts` in `turbo`