### PR TITLE
test(e2e): use explicit chat prompt

### DIFF
--- a/e2e/playwright/tests/webchat.spec.ts
+++ b/e2e/playwright/tests/webchat.spec.ts
@@ -21,7 +21,7 @@ test("send a chat message and receive an assistant response", async ({
       .getByRole("combobox", { name: "GPT 5.6 Luna", exact: true }),
   ).toBeVisible();
 
-  const prompt = `e2e-${Date.now()}`;
+  const prompt = "Reply with exactly: Hello from Zero. Do not use tools.";
   await composer.fill(prompt);
   await page.getByRole("button", { name: "Send", exact: true }).click();
 


### PR DESCRIPTION
## Summary

- replace the opaque timestamp-only webchat prompt with an explicit short conversational request
- keep the supported GPT 5.6 Luna model, plain-text send, user-message assertion, and final assistant-reply assertion unchanged
- add no retries, skips, or timeout changes

## Why

The main Playwright run after #24152 showed the real staging agent still running at the 120-second boundary. Its status text described investigating performance and deployment history, which means the opaque `e2e-<timestamp>` input was interpreted as a session or run identifier to investigate. The PR mock runner only echoed that input, so it could not reveal this behavior.

This smoke test should ask an unambiguous, bounded conversational question. Attachment and media layout coverage remains in the dedicated platform integration tests added by #24106.

Evidence: [main Turbo run 30595623462, Playwright job 91047731262](https://github.com/vm0-ai/vm0/actions/runs/30595623462/job/91047731262).

## Test plan

- `pnpm exec playwright test --config playwright/playwright.config.ts playwright/tests/webchat.spec.ts --project=features` (3 passed; webchat 7.3s)
- `pnpm exec playwright test --config playwright/playwright.config.ts` (9 passed; webchat 14.2s)
- `pnpm check-types` in `e2e`
- `pnpm exec prettier --check ../e2e/playwright/tests/webchat.spec.ts` in `turbo`