### PR TITLE
test(e2e): use low-reasoning chat model

### DIFF
--- a/e2e/playwright/tests/webchat.spec.ts
+++ b/e2e/playwright/tests/webchat.spec.ts
@@ -14,11 +14,11 @@ test("send a chat message and receive an assistant response", async ({
 
   const modelPicker = page.locator(".zero-composer").getByRole("combobox");
   await modelPicker.click();
-  await page.getByRole("option", { name: /^GPT 5\.6 Luna\b/ }).click();
+  await page.getByRole("option", { name: /^GPT 5\.6 Terra\b/ }).click();
   await expect(
     page
       .locator(".zero-composer")
-      .getByRole("combobox", { name: "GPT 5.6 Luna", exact: true }),
+      .getByRole("combobox", { name: "GPT 5.6 Terra", exact: true }),
   ).toBeVisible();
 
   const prompt = "Reply with exactly: Hello from Zero. Do not use tools.";


### PR DESCRIPTION
## Summary

- select GPT 5.6 Terra for the webchat smoke test instead of GPT 5.6 Luna
- keep the explicit plain-text prompt and final non-error assistant-reply assertion unchanged
- add no retries, skips, or timeout changes

## Why

Both main runs after #24152 and #24153 showed the permanent staging runner still thinking at the 120-second boundary, even for an explicit one-line greeting. The runner maps GPT 5.6 Luna to Codex `model_reasoning_effort=max`, while GPT 5.6 Terra uses `low`. Both models use the same mock Codex path in PR and merge-group CI, so Terra preserves mock coverage while avoiding a maximum-reasoning model for a bounded chat smoke test.

Evidence:

- [main run 30595623462 / job 91047731262](https://github.com/vm0-ai/vm0/actions/runs/30595623462/job/91047731262)
- [main run 30596642393 / job 91051719280](https://github.com/vm0-ai/vm0/actions/runs/30596642393/job/91051719280)

Attachment and media layout coverage remains in the dedicated platform integration tests added by #24106.

## Test plan

- `pnpm exec playwright test --config playwright/playwright.config.ts playwright/tests/webchat.spec.ts --project=features` (3 passed; webchat 9.1s)
- `pnpm exec playwright test --config playwright/playwright.config.ts` (9 passed; webchat 14.2s)
- `pnpm check-types` in `e2e`
- `pnpm exec prettier --check ../e2e/playwright/tests/webchat.spec.ts` in `turbo`