### PR TITLE
refactor(platform): remove obsolete hidden connector storage

### DIFF
--- a/turbo/apps/platform/src/signals/connectors-page/connectors-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connectors-page-setup.ts
@@ -6,10 +6,9 @@ import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
-import { migrateHiddenConnectorSlugsStorage$ } from "../zero-page/settings/connectors.ts";
+
 export const setupConnectorsPage$ = command(
   async ({ set }, signal: AbortSignal) => {
-    set(migrateHiddenConnectorSlugsStorage$);
     set(updatePage$, createElement(ZeroConnectorsPage), "sidebar");
     set(
       updateDocumentTitle$,

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -48,13 +48,7 @@ import {
   zeroClient$,
   type ZeroClientFactory,
 } from "../../api-client.ts";
-import {
-  jsonParseOr,
-  resetSignal,
-  setLoop,
-  tapError,
-  withCleanup,
-} from "../../utils.ts";
+import { resetSignal, setLoop, tapError, withCleanup } from "../../utils.ts";
 import { setAblyPayloadLoop$ } from "../../realtime.ts";
 import { localStorageSignals } from "../../external/local-storage.ts";
 import { subagents$ } from "../../agent.ts";
@@ -69,16 +63,6 @@ import type {
   PlatformConnectorCatalogStatusItem,
 } from "../../connector-domain.ts";
 
-const HIDDEN_CONNECTOR_SLUGS_STORAGE_KEY =
-  "vm0.connections.hiddenConnectorSlugs";
-const LEGACY_HIDDEN_CONNECTOR_SLUGS_STORAGE_KEY = "vm0.connections.hiddenTypes";
-
-const { get$: hiddenConnectorSlugsRaw$, set$: setHiddenConnectorSlugsRaw$ } =
-  localStorageSignals(HIDDEN_CONNECTOR_SLUGS_STORAGE_KEY);
-const {
-  get$: legacyHiddenConnectorSlugsRaw$,
-  clear$: clearLegacyHiddenConnectorSlugs$,
-} = localStorageSignals(LEGACY_HIDDEN_CONNECTOR_SLUGS_STORAGE_KEY);
 const { set$: setConnectorAppOauthCallbackMetadata$ } = localStorageSignals(
   CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY,
 );
@@ -419,38 +403,6 @@ export const allConnectorCatalogItems$ = computed(async (get) => {
 
   return items;
 });
-
-// ---------------------------------------------------------------------------
-// Hidden connector slugs (removed from list by user; persisted in localStorage)
-// ---------------------------------------------------------------------------
-
-export const migrateHiddenConnectorSlugsStorage$ = command(({ get, set }) => {
-  const legacy = get(legacyHiddenConnectorSlugsRaw$);
-  if (legacy === null) {
-    return;
-  }
-  if (get(hiddenConnectorSlugsRaw$) === null) {
-    set(setHiddenConnectorSlugsRaw$, legacy);
-  }
-  set(clearLegacyHiddenConnectorSlugs$);
-});
-
-const hiddenConnectorSlugs$ = computed((get): Set<ConnectorSlug> => {
-  // TODO(#23823): Remove the legacy hidden-connector storage fallback.
-  const raw =
-    get(hiddenConnectorSlugsRaw$) ?? get(legacyHiddenConnectorSlugsRaw$);
-  if (!raw) {
-    return new Set();
-  }
-  return new Set(jsonParseOr<ConnectorSlug[]>(raw, []));
-});
-
-const setHiddenConnectorSlugs$ = command(
-  ({ set }, connectorSlugs: readonly ConnectorSlug[]) => {
-    set(setHiddenConnectorSlugsRaw$, JSON.stringify(connectorSlugs));
-    set(clearLegacyHiddenConnectorSlugs$);
-  },
-);
 
 // ---------------------------------------------------------------------------
 // Search filter
@@ -880,7 +832,7 @@ const authorizeConnectorForVisibleAgents$ = command(
 
 const finishConnectorConnection$ = command(
   async (
-    { get, set },
+    { set },
     connectorSlug: ConnectorSlug,
     options: FinishConnectorConnectionOptions,
     signal: AbortSignal,
@@ -897,10 +849,6 @@ const finishConnectorConnection$ = command(
     if (options.agentId) {
       set(reloadAgentConnectorAuthorizations$);
     }
-
-    const hidden = new Set(get(hiddenConnectorSlugs$));
-    hidden.delete(connectorSlug);
-    set(setHiddenConnectorSlugs$, [...hidden]);
 
     if (options.toastMessage !== null) {
       toast.success(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -57,13 +57,6 @@ import { customConnectorCreateForm$ } from "../../../signals/zero-page/settings/
 
 const context = testContext();
 const resetAfterManualGrantConnectSignal$ = resetSignal();
-const { get$: hiddenConnectorSlugs$ } = localStorageSignals(
-  "vm0.connections.hiddenConnectorSlugs",
-);
-const {
-  get$: legacyHiddenConnectorSlugs$,
-  set$: setLegacyHiddenConnectorSlugs$,
-} = localStorageSignals("vm0.connections.hiddenTypes");
 const { get$: connectorAppOauthCallbackMetadata$ } = localStorageSignals(
   CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY,
 );
@@ -528,21 +521,6 @@ async function expectConnectorCardsVisible(expected: {
 }
 
 describe("connectors page", () => {
-  it("migrates legacy hidden connector storage to the canonical key", async () => {
-    const hiddenConnectorSlugs = JSON.stringify(["github"]);
-    context.store.set(setLegacyHiddenConnectorSlugs$, hiddenConnectorSlugs);
-
-    detachedSetupPage({ context, path: "/connectors" });
-
-    await screen.findByPlaceholderText("Find connectors");
-    await waitFor(() => {
-      expect(context.store.get(hiddenConnectorSlugs$)).toBe(
-        hiddenConnectorSlugs,
-      );
-      expect(context.store.get(legacyHiddenConnectorSlugs$)).toBeNull();
-    });
-  });
-
   it("syncs the active connector tab with the URL query", async () => {
     mockCustomConnectorStory();
 


### PR DESCRIPTION
## Summary

- remove the obsolete `hiddenTypes` and `hiddenConnectorSlugs` browser-storage
  signals and migration
- stop no-effect hidden-connector bookkeeping after successful connections
- remove the Connectors-page migration invocation and migration-only
  integration coverage

## Compatibility

The hidden-list producer and visibility consumer were removed by #5095, so
neither key affects current UI behavior. Existing browser values remain inert;
this PR does not add a cleanup migration to erase them. Because values are not
erased, an ordinary Platform rollback can still read them.

This PR does not change API or CLI contracts, database state, runner protocols,
OAuth callback metadata, or historical permission-action compatibility owned
by #23823.

## Validation

- `pnpm exec prettier --check apps/platform/src/signals/zero-page/settings/connectors.ts apps/platform/src/signals/connectors-page/connectors-page-setup.ts apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx` — 78 passed
- `pnpm -F @vm0/app test` — 122 files and 1,331 tests passed
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app build`
- `pnpm knip --workspace @vm0/app`
- pre-commit full Knip and repository TypeScript checks

Closes #24157

Parent: #23814
