### PR TITLE
fix(cli): distinguish git and r2 html resources

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
@@ -71,9 +71,18 @@ describe("zero generate source-backed artifact commands", () => {
 
       const stdout = output();
       expect(stdout).toContain(`# Zero generate ${command}`);
-      expect(stdout).toContain("federated generation source-selection packet");
+      expect(stdout).toContain("generation source-selection packet");
+      expect(stdout).not.toContain("federated");
       expect(stdout).toContain(prompt);
       expect(stdout).toContain(template);
+      expect(stdout).toContain(
+        "Source: `nexu-io/open-design@3fb620af423534643677c7c6fae76be088fa770a`",
+      );
+      expect(stdout).not.toContain("Sources:");
+      expect(stdout).not.toContain("vm0-ai/vm0-skills");
+      expect(stdout).toContain(
+        "For a candidate without `source.archive`, resolve `source.path` only from the pinned Git Source above. Do not run `zero resource pull` for it.",
+      );
       expect(stdout).toContain(`Artifact kind: ${command}`);
       expect(stdout).toContain("## Artifact Output Model");
       expect(stdout).toContain(

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
@@ -76,7 +76,7 @@ describe("zero generate source-backed artifact commands", () => {
       expect(stdout).toContain(prompt);
       expect(stdout).toContain(template);
       expect(stdout).toContain(
-        "Source: `nexu-io/open-design@3fb620af423534643677c7c6fae76be088fa770a`",
+        "Default Git Source: `nexu-io/open-design@3fb620af423534643677c7c6fae76be088fa770a`",
       );
       expect(stdout).not.toContain("Sources:");
       expect(stdout).not.toContain("vm0-ai/vm0-skills");

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
@@ -45,9 +45,7 @@ describe("zero generate presentation command", () => {
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     expect(stdout).toContain("# Zero generate presentation");
     expect(stdout).toContain("direct HTML presentation authoring packet");
-    expect(stdout).not.toContain(
-      "federated generation source-selection packet",
-    );
+    expect(stdout).not.toContain("generation source-selection packet");
     expect(stdout).not.toContain("## Stage 1: Resource Selection");
     expect(stdout).not.toContain("## Candidate Registry Slice");
     expect(stdout).toContain("API migration plan");

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
@@ -48,9 +48,21 @@ describe("zero generate website command", () => {
 
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     expect(stdout).toContain("# Zero generate website");
-    expect(stdout).toContain("federated generation source-selection packet");
+    expect(stdout).toContain("generation source-selection packet");
+    expect(stdout).not.toContain("federated");
     expect(stdout).toContain("## Stage 1: Resource Selection");
     expect(stdout).toContain("## Candidate Registry Slice");
+    expect(stdout).toContain(
+      "Source: `nexu-io/open-design@3fb620af423534643677c7c6fae76be088fa770a`",
+    );
+    expect(stdout).not.toContain("Sources:");
+    expect(stdout).not.toContain("vm0-ai/vm0-skills");
+    expect(stdout).toContain(
+      "For a candidate without `source.archive`, resolve `source.path` only from the pinned Git Source above. Do not run `zero resource pull` for it.",
+    );
+    expect(stdout).toContain(
+      "For a candidate with `source.archive`, run `zero resource pull <candidate-id> --dir ./generated/resources` with that candidate's `id`, then resolve it at `./generated/resources/<source.path>`. Do not look for it in the Git Source.",
+    );
     expect(stdout).toContain("observability launch site");
     expect(stdout).toContain("template:black-slabs");
     expect(stdout).toContain("template:web-prototype-taste-editorial");

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
@@ -53,7 +53,7 @@ describe("zero generate website command", () => {
     expect(stdout).toContain("## Stage 1: Resource Selection");
     expect(stdout).toContain("## Candidate Registry Slice");
     expect(stdout).toContain(
-      "Source: `nexu-io/open-design@3fb620af423534643677c7c6fae76be088fa770a`",
+      "Default Git Source: `nexu-io/open-design@3fb620af423534643677c7c6fae76be088fa770a`",
     );
     expect(stdout).not.toContain("Sources:");
     expect(stdout).not.toContain("vm0-ai/vm0-skills");

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -158,7 +158,7 @@ export function createHtmlArtifactAuthoringPacket(
     "",
     "## Candidate Registry Slice",
     `Registry: \`${candidateSlice.registryVersion}\``,
-    `Source: \`${candidateSlice.source.repo}@${candidateSlice.source.ref}\``,
+    `Default Git Source: \`${candidateSlice.source.repo}@${candidateSlice.source.ref}\``,
     "",
     "```json",
     JSON.stringify(candidateSlice.candidates, null, 2),

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -85,15 +85,6 @@ function outputDirForSite(site: string): string {
   return `./generated/mockups/${site}`;
 }
 
-function formatCandidateSource(
-  source: ResourceCandidateSlice["sources"][number],
-): string {
-  if ("repo" in source) {
-    return `- \`${source.repo}@${source.ref}\``;
-  }
-  return `- ${source.description}`;
-}
-
 export function createHtmlArtifactAuthoringPacket(
   options: HtmlArtifactAuthoringOptions,
 ): HtmlArtifactAuthoringPacket {
@@ -147,14 +138,14 @@ export function createHtmlArtifactAuthoringPacket(
   const instructions = [
     `# Zero generate ${options.kind}`,
     "",
-    "This is a federated generation source-selection packet for the current agent.",
+    "This is a generation source-selection packet for the current agent.",
     `Zero is not generating this ${title} on the server. You select resources, resolve them, and author the artifact.`,
     "",
     "## User Prompt",
     options.prompt,
     "",
     "## Stage 1: Resource Selection",
-    "- Choose generation resources from the bundled federated registry slice below.",
+    "- Choose generation resources from the bundled registry slice below.",
     "- Select one template, one or more skills, and zero or one design system.",
     "- Choose only IDs present in this packet; do not invent registry IDs.",
     "- Prefer compatible resources, but the user prompt is the highest-priority signal.",
@@ -167,8 +158,7 @@ export function createHtmlArtifactAuthoringPacket(
     "",
     "## Candidate Registry Slice",
     `Registry: \`${candidateSlice.registryVersion}\``,
-    "Sources:",
-    ...candidateSlice.sources.map(formatCandidateSource),
+    `Source: \`${candidateSlice.source.repo}@${candidateSlice.source.ref}\``,
     "",
     "```json",
     JSON.stringify(candidateSlice.candidates, null, 2),
@@ -176,8 +166,8 @@ export function createHtmlArtifactAuthoringPacket(
     "",
     "## Stage 2: Resolve Selected Resources",
     "- First resolve every required resource listed above, then resolve every selected resource before authoring.",
-    "- Each candidate carries a `source` object with `path` and optional `repo`/`ref`; when `repo`/`ref` are omitted, fall back to the registry-level source above.",
-    "- If `source.archive` is present, pull the private R2 archive with `zero resource pull <resource-id> --dir ./generated/resources`; the CLI requests an authenticated short-lived download URL, verifies the digest, and then extracts `source.path`.",
+    "- For a candidate without `source.archive`, resolve `source.path` only from the pinned Git Source above. Do not run `zero resource pull` for it.",
+    "- For a candidate with `source.archive`, run `zero resource pull <candidate-id> --dir ./generated/resources` with that candidate's `id`, then resolve it at `./generated/resources/<source.path>`. Do not look for it in the Git Source.",
     "- For directory refs, inspect the most relevant files such as `SKILL.md`, `DESIGN.md`, `README.md`, tokens, examples, and templates.",
     "- If a source file cannot be fetched, state that limitation and fall back to the registry metadata for that resource.",
     "",

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -78,21 +78,11 @@ export interface VideoTemplateRegistryEntry extends Omit<
 
 export interface ResourceCandidateSlice {
   readonly registryVersion: string;
+  /** Pinned Git source for every candidate without `source.archive`. */
   readonly source: {
     readonly repo: string;
     readonly ref: string;
   };
-  readonly sources: readonly (
-    | {
-        readonly type?: "git";
-        readonly repo: string;
-        readonly ref: string;
-      }
-    | {
-        readonly type: "r2-archive";
-        readonly description: string;
-      }
-  )[];
   readonly candidates: {
     readonly skills: readonly RegistryEntry[];
     readonly templates: readonly RegistryEntry[];
@@ -4059,21 +4049,6 @@ export function selectResourceCandidates(
       repo: RESOURCE_REGISTRY_REPO,
       ref: RESOURCE_REGISTRY_COMMIT,
     },
-    sources: [
-      {
-        repo: RESOURCE_REGISTRY_REPO,
-        ref: RESOURCE_REGISTRY_COMMIT,
-      },
-      {
-        repo: VM0_SKILLS_REPO,
-        ref: VM0_SKILLS_REF,
-      },
-      {
-        type: "r2-archive",
-        description:
-          "Private R2-backed resource archives resolved through authenticated `zero resource pull` requests",
-      },
-    ],
     candidates: {
       skills: listSkills(target),
       templates: listTemplates(target),


### PR DESCRIPTION
## Summary

- remove the ambiguous multi-source list from HTML resource candidate slices
- keep one pinned Open Design Git source for candidates without archives
- route archive-backed candidates through `zero resource pull` and Git-backed candidates through `source.path`
- cover the source contract through CLI integration tests

## Problem

HTML authoring packets listed Open Design, `vm0-skills`, and R2 as global sources without mapping candidates to them. This allowed Git-backed skills, templates, and design systems to be passed to `zero resource pull`, producing unknown-resource or missing-archive errors even though their Open Design paths existed.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (API ESLint rerun with a 4 GB Node heap after the default heap was exhausted)
- `pnpm knip`
- staged Turbo, Platform, and API type checks
- `pnpm --filter @vm0/cli exec vitest run src/commands/zero/generate/__tests__/artifacts.test.ts`
- `pnpm --filter @vm0/cli exec vitest run src/commands/zero/generate/__tests__/website.test.ts`
- `pnpm --filter @vm0/cli exec vitest run src/commands/zero/generate/__tests__/presentation.test.ts`
