### PR TITLE
refactor(api): rename github chat event identifiers

### DIFF
--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-A chat card turns a specially recognized link inside a `ChatMessage` into a
+A chat card turns a specially recognized link inside a `ChatEvent` into a
 rich, interactive React surface. The message remains the transport: an agent or
 another producer can emit a normal URL, Markdown link, or relative platform
 path, and the platform upgrades that link into a typed card when its path
@@ -11,7 +11,7 @@ matches a supported pattern.
 The core pipeline is:
 
 ```text
-ChatMessage content
+ChatEvent content
   -> recognize a trusted link and parse a typed descriptor
   -> derive a stable resource key
   -> register signals at the message write/command boundary
@@ -65,7 +65,7 @@ that card type exists.
 
 ### 1. Parse content into pure descriptors
 
-`parseMessageBodyBlocks` extracts renderable content from a `ChatMessage`
+`parseChatEventBodyBlocks` extracts renderable content from a `ChatEvent`
 and passes it to `parseBodyBlocks`. The parser separates normal Markdown from
 recognized cards.
 
@@ -350,7 +350,7 @@ registry.
 
 ## Relevant Implementation Files
 
-- `turbo/apps/platform/src/signals/chat-page/chat-message-body-blocks.ts`
+- `turbo/apps/platform/src/signals/chat-page/chat-event-body-blocks.ts`
 - `turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts`
 - `turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts`
 - `turbo/apps/platform/src/signals/chat-page/artifact-card-signals.ts`

--- a/turbo/apps/api/src/signals/services/github-chat-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/github-chat-callback-payload.ts
@@ -13,7 +13,20 @@ export const githubDeliveryTargetSchema = z.object({
 
 export type GitHubDeliveryTarget = z.infer<typeof githubDeliveryTargetSchema>;
 
-export const githubChatCallbackPayloadSchema =
+export const githubChatCallbackPayloadSchema = z.preprocess(
+  (payload) => {
+    if (
+      typeof payload !== "object" ||
+      payload === null ||
+      "chatEventId" in payload ||
+      !("chatMessageId" in payload)
+    ) {
+      return payload;
+    }
+    const { chatMessageId, ...target } = payload;
+    return { ...target, chatEventId: chatMessageId };
+  },
   githubDeliveryTargetSchema.extend({
-    chatMessageId: z.string().uuid(),
-  });
+    chatEventId: z.string().uuid(),
+  }),
+);

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -537,7 +537,7 @@ interface ChatCallbackDependencies {
       readonly orgId: string;
       readonly agentId: string;
       readonly target: GitHubDeliveryTarget;
-      readonly chatMessageId: string;
+      readonly chatEventId: string;
     },
     signal: AbortSignal,
   ) => Promise<void>;
@@ -1252,7 +1252,7 @@ async function insertGitHubChatDeliveryCallback(args: {
   readonly runId: string;
   readonly sourceCallbackId?: string;
   readonly target: GitHubDeliveryTarget;
-  readonly chatMessageId: string;
+  readonly chatEventId: string;
 }): Promise<string> {
   const callbackCondition = args.sourceCallbackId
     ? and(
@@ -1281,7 +1281,7 @@ async function insertGitHubChatDeliveryCallback(args: {
       encryptedSecret: sourceCallback.encryptedSecret,
       payload: {
         ...args.target,
-        chatMessageId: args.chatMessageId,
+        chatEventId: args.chatEventId,
       },
     })
     .returning({ id: agentRunCallbacks.id });
@@ -1376,7 +1376,7 @@ async function insertAssistantErrorEvent(args: {
           runId: args.runId,
           sourceCallbackId: args.sourceCallbackId,
           target: args.githubDelivery,
-          chatMessageId: event.id,
+          chatEventId: event.id,
         })
       : undefined;
     await touchChatThreadLastMessageAt(tx, args.threadId, event.createdAt);
@@ -1644,7 +1644,7 @@ async function insertRunLifecycleMarkerTransaction(args: {
           runId: input.runId,
           sourceCallbackId: input.sourceCallbackId,
           target: input.githubDelivery,
-          chatMessageId: deliveryEvent.id,
+          chatEventId: deliveryEvent.id,
         })
       : undefined;
   await touchChatThreadLastMessageAt(
@@ -3312,7 +3312,7 @@ async function handleGitHubQueuedMessageAdmissionFailure(args: {
         orgId: args.failure.orgId,
         agentId: args.failure.agentId,
         target: args.failure.githubDelivery,
-        chatMessageId: failed.assistantEventId,
+        chatEventId: failed.assistantEventId,
       },
       args.signal,
     ),

--- a/turbo/apps/api/src/signals/services/internal-github-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-github-chat-run-callback.service.ts
@@ -140,7 +140,7 @@ async function loadGitHubChatDeliveryContext(args: {
     .from(chatEvents)
     .where(
       and(
-        eq(chatEvents.id, payload.chatMessageId),
+        eq(chatEvents.id, payload.chatEventId),
         eq(chatEvents.runId, args.callback.runId),
         eq(chatEvents.chatThreadId, runContext.chatThreadId),
         chatEventTypeIn([
@@ -377,7 +377,7 @@ export async function deliverGitHubChatAdmissionFailure(args: {
   readonly orgId: string;
   readonly agentId: string;
   readonly target: GitHubDeliveryTarget;
-  readonly chatMessageId: string;
+  readonly chatEventId: string;
   readonly signal: AbortSignal;
 }): Promise<void> {
   const [event] = await args.db
@@ -385,7 +385,7 @@ export async function deliverGitHubChatAdmissionFailure(args: {
     .from(chatEvents)
     .where(
       and(
-        eq(chatEvents.id, args.chatMessageId),
+        eq(chatEvents.id, args.chatEventId),
         eq(chatEvents.chatThreadId, args.chatThreadId),
         chatEventTypeIn(["output.error"]),
         isNotNull(chatEvents.content),

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -1246,7 +1246,7 @@ async function insertGitHubChatInput(args: {
   readonly promptParts: ReturnType<typeof buildPromptParts>;
   readonly reactionId: string | undefined;
   readonly currentTime: Date;
-}): Promise<{ readonly chatMessageId: string; readonly inserted: boolean }> {
+}): Promise<{ readonly chatEventId: string; readonly inserted: boolean }> {
   const issueNumber = args.params.issue.number;
   const encryptedParams = await encryptQueuedUserMessageRunParams(
     {
@@ -1268,7 +1268,7 @@ async function insertGitHubChatInput(args: {
     { orgId: args.target.orgId, userId: args.params.vm0UserId },
   );
 
-  const chatMessageId = uuidv5(
+  const chatEventId = uuidv5(
     [
       args.route.installationId,
       args.params.repo,
@@ -1282,7 +1282,7 @@ async function insertGitHubChatInput(args: {
     const event = await insertChatEvent(
       tx,
       {
-        id: chatMessageId,
+        id: chatEventId,
         chatThreadId: args.route.chatThreadId,
         eventType: "input.prompt",
         userMessage: createUserMessageDocument({ text: args.prompt }),
@@ -1307,11 +1307,11 @@ async function insertGitHubChatInput(args: {
       tx,
       args.route.chatThreadId,
       args.currentTime,
-      chatMessageId,
+      chatEventId,
     );
     return true;
   });
-  return { chatMessageId, inserted };
+  return { chatEventId, inserted };
 }
 
 const dispatchGithubAgentRun$ = command(
@@ -1385,7 +1385,7 @@ const dispatchGithubAgentRun$ = command(
     });
     signal.throwIfAborted();
 
-    const { chatMessageId, inserted } = await insertGitHubChatInput({
+    const { chatEventId, inserted } = await insertGitHubChatInput({
       db,
       route,
       params,
@@ -1429,7 +1429,7 @@ const dispatchGithubAgentRun$ = command(
 
     L.debug("GitHub comment queued on canonical chat thread", {
       chatThreadId: route.chatThreadId,
-      chatMessageId,
+      chatEventId,
       repo: params.repo,
       issueNumber,
       subjectKind: params.subjectKind,


### PR DESCRIPTION
## Summary

- rename GitHub chat internals that carry `chat_events.id` values from `chatMessageId` to `chatEventId`
- ship Release 1 of the persisted GitHub callback payload transition: readers accept and normalize both field names, while writers emit only `chatEventId`
- update the chat-card documentation to use the current `ChatEvent` type, parser export, and implementation path

## Rename map

| Scope | Previous | Current | Notes |
| --- | --- | --- | --- |
| `webhooks-github.service.ts` (7 occurrences) | `chatMessageId` | `chatEventId` | Internal `chat_events.id` value only |
| `internal-github-chat-run-callback.service.ts` (3 occurrences) | `chatMessageId` | `chatEventId` | Internal `chat_events.id` value only |
| `internal-chat-run-callback.service.ts` (7 occurrences) | `chatMessageId` | `chatEventId` | Includes the persisted GitHub callback writer |
| `github-chat-callback-payload.ts` | payload `chatMessageId` | payload `chatEventId` | Release 1 reader compatibility retained for legacy rows |
| `docs/chat-cards.md` | `ChatMessage` | `ChatEvent` | Domain type documentation |
| `docs/chat-cards.md` | `parseMessageBodyBlocks` | `parseChatEventBodyBlocks` | Current exported parser name |
| `docs/chat-cards.md` | `chat-message-body-blocks.ts` | `chat-event-body-blocks.ts` | Current implementation path |

## Persisted payload compatibility

Release 1 behavior in this PR:

- reads accept either `chatMessageId` or `chatEventId`
- legacy `chatMessageId` input is normalized to `chatEventId`
- new `agent_run_callbacks.payload` writes contain only `chatEventId`

Release 2 must be a separate PR. Remove the legacy reader only after both gates are satisfied:

1. this Release 1 change has completed rollout across the API fleet
2. no unclaimed pre-Release-1 GitHub chat callback rows remain

The issue intentionally remains open until Release 2 is complete.

## Validation

- targeted Prettier formatting for all changed files
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace apps/api`
- legacy/new callback payload normalization smoke check
- migrations on the CI-pinned PostgreSQL 17.10 image
- `DATABASE_URL=postgresql://postgres@localhost:55432/postgres pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-github-chat.test.ts --maxWorkers=1 --silent=passed-only` (2 tests passed)
- stale documentation term/path scan and relevant-path existence check

Refs #24158