### PR TITLE
ci: isolate mock runner for playwright

### DIFF
--- a/.github/scripts/runner-image-context.sh
+++ b/.github/scripts/runner-image-context.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
   cat <<'USAGE'
-Usage: runner-image-context.sh <resolve|turbo-consumer|crates-consumer|image-inputs|needed|artifact-name>
+Usage: runner-image-context.sh <resolve|turbo-consumer|playwright-consumer|crates-consumer|image-inputs|needed|artifact-name>
 
 resolve:
   Computes release skip, canonical job ref, and head SHA from GitHub event env.
@@ -18,6 +18,9 @@ needed:
 turbo-consumer:
   Computes whether Turbo runner E2E is a runner image consumer from the same
   change booleans used by turbo.yml.
+
+playwright-consumer:
+  Computes whether Playwright needs a mock runner.
 
 crates-consumer:
   Computes whether Crates runner tests are a runner image consumer from the
@@ -185,6 +188,9 @@ needed() {
     turbo_consumer="false"
   fi
 
+  local playwright_consumer
+  playwright_consumer=$(bool "${PLAYWRIGHT_RUNNER_CONSUMER_NEEDED:-false}")
+
   local crates_consumer
   crates_consumer=$(bool "${CRATES_RUNNER_CONSUMER_NEEDED:-false}")
 
@@ -201,16 +207,20 @@ needed() {
 
   if [ "$release_skip" = "true" ]; then
     turbo_consumer="false"
+    playwright_consumer="false"
     crates_consumer="false"
     image_inputs_changed="false"
     reason="release-skip"
   elif [ "$has_metal_hosts" != "true" ]; then
     turbo_consumer="false"
+    playwright_consumer="false"
     crates_consumer="false"
     image_inputs_changed="false"
     reason="no-metal-hosts"
   else
-    if [ "$turbo_consumer" = "true" ] || [ "$crates_consumer" = "true" ]; then
+    if [ "$turbo_consumer" = "true" ] ||
+      [ "$playwright_consumer" = "true" ] ||
+      [ "$crates_consumer" = "true" ]; then
       runner_consumer="true"
     fi
 
@@ -232,6 +242,7 @@ needed() {
 
   emit "has-metal-hosts" "$has_metal_hosts"
   emit "turbo-runner-consumer-needed" "$turbo_consumer"
+  emit "playwright-runner-consumer-needed" "$playwright_consumer"
   emit "crates-runner-consumer-needed" "$crates_consumer"
   emit "runner-image-consumer-needed" "$runner_consumer"
   emit "runner-image-inputs-changed" "$image_inputs_changed"
@@ -256,6 +267,21 @@ turbo_consumer() {
   fi
 
   emit "turbo-runner-consumer-needed" "$consumer"
+}
+
+playwright_consumer() {
+  local consumer="false"
+  if {
+    is_true "${API_CHANGED:-false}" ||
+    is_true "${PLATFORM_CHANGED:-false}" ||
+    is_true "${CLI_CHANGED:-false}" ||
+    is_true "${CI_CHANGED:-false}" ||
+    is_true "${E2E_CHANGED:-false}"
+  }; then
+    consumer="true"
+  fi
+
+  emit "playwright-runner-consumer-needed" "$consumer"
 }
 
 crates_consumer() {
@@ -304,6 +330,7 @@ cmd="${1:-}"
 case "$cmd" in
   resolve) resolve ;;
   turbo-consumer) turbo_consumer ;;
+  playwright-consumer) playwright_consumer ;;
   crates-consumer) crates_consumer ;;
   image-inputs) image_inputs ;;
   needed) needed ;;

--- a/.github/scripts/tests/runner-image-context-test.sh
+++ b/.github/scripts/tests/runner-image-context-test.sh
@@ -117,6 +117,16 @@ out=$(run_clean \
   "$CONTEXT" turbo-consumer)
 assert_contains "$out" "turbo-runner-consumer-needed=false"
 
+out=$(run_clean "$CONTEXT" playwright-consumer)
+assert_contains "$out" "playwright-runner-consumer-needed=false"
+
+for flag in API_CHANGED PLATFORM_CHANGED CLI_CHANGED CI_CHANGED E2E_CHANGED; do
+  out=$(run_clean \
+    "${flag}=true" \
+    "$CONTEXT" playwright-consumer)
+  assert_contains "$out" "playwright-runner-consumer-needed=true"
+done
+
 for flag in CI_CHANGED RUNNER_CHANGED; do
   out=$(run_clean \
     "${flag}=true" \
@@ -297,6 +307,21 @@ assert_contains "$out" "runner-image-inputs-changed=true"
 assert_contains "$out" "stable-runner-image-allowed=false"
 assert_contains "$out" "current-runner-image-needed=true"
 assert_contains "$out" "image-selection-reason=runner-image-inputs-changed"
+
+out=$(assert_needed_case "main Playwright runner consumer" \
+  EVENT_NAME=push \
+  RELEASE_SKIP=false \
+  METAL_HOSTS=dev-1 \
+  PLAYWRIGHT_RUNNER_CONSUMER_NEEDED=true \
+  RUNNER_IMAGE_INPUTS_CHANGED=false)
+assert_contains "$out" "turbo-runner-consumer-needed=false"
+assert_contains "$out" "playwright-runner-consumer-needed=true"
+assert_contains "$out" "crates-runner-consumer-needed=false"
+assert_contains "$out" "runner-image-consumer-needed=true"
+assert_contains "$out" "runner-image-inputs-changed=false"
+assert_contains "$out" "stable-runner-image-allowed=true"
+assert_contains "$out" "current-runner-image-needed=true"
+assert_contains "$out" "image-selection-reason=runner-image-consumer-without-stable-reuse"
 
 out=$(assert_needed_case "guest input" \
   EVENT_NAME=pull_request \

--- a/.github/scripts/tests/runner-image-workflow-test.sh
+++ b/.github/scripts/tests/runner-image-workflow-test.sh
@@ -14,6 +14,20 @@ command -v yq >/dev/null || fail "yq is required"
 workflow_json=$(yq -o=json '.' "$WORKFLOW")
 
 jq -e '
+  .jobs.prepare.outputs["playwright-runner-consumer-needed"] ==
+    "${{ steps.needed.outputs.playwright-runner-consumer-needed }}" and
+  any(.jobs.prepare.steps[];
+    .id == "turbo" and
+    (.run | contains(".github/scripts/runner-image-context.sh playwright-consumer"))
+  ) and
+  any(.jobs.prepare.steps[];
+    .id == "needed" and
+    .env.PLAYWRIGHT_RUNNER_CONSUMER_NEEDED ==
+      "${{ steps.turbo.outputs.playwright-runner-consumer-needed }}"
+  )
+' <<<"$workflow_json" >/dev/null || fail "Playwright mock-runner demand must reach runner image selection"
+
+jq -e '
   .jobs["cancel-superseded"].name == "Cancel superseded merge-group CI" and
   .jobs["cancel-superseded"].if == "github.event_name == '\''merge_group'\''" and
   .jobs["cancel-superseded"].permissions.actions == "write" and

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -58,6 +58,7 @@ jobs:
       pr-number: ${{ steps.identity.outputs.pr-number }}
       pr-head-ref: ${{ steps.identity.outputs.pr-head-ref }}
       turbo-runner-consumer-needed: ${{ steps.needed.outputs.turbo-runner-consumer-needed }}
+      playwright-runner-consumer-needed: ${{ steps.needed.outputs.playwright-runner-consumer-needed }}
       crates-runner-consumer-needed: ${{ steps.needed.outputs.crates-runner-consumer-needed }}
       runner-image-consumer-needed: ${{ steps.needed.outputs.runner-image-consumer-needed }}
       runner-image-inputs-changed: ${{ steps.needed.outputs.runner-image-inputs-changed }}
@@ -102,7 +103,7 @@ jobs:
           echo "base-ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
           echo "Base ref: ${BASE_REF}"
 
-      - name: Detect Turbo runner image consumers
+      - name: Detect Turbo and Playwright runner image consumers
         id: turbo
         if: steps.identity.outputs.release-skip != 'true'
         env:
@@ -111,6 +112,7 @@ jobs:
           set -euo pipefail
           CHANGES_JSON=$(./scripts/changed.sh "$BASE_REF")
           web_changed=$(echo "$CHANGES_JSON" | jq -r '."web" // false')
+          platform_changed=$(echo "$CHANGES_JSON" | jq -r '."@vm0/app" // false')
           api_changed=$(echo "$CHANGES_JSON" | jq -r '."api" // false')
           cli_changed=$(echo "$CHANGES_JSON" | jq -r '."@vm0/cli" // false')
 
@@ -140,6 +142,14 @@ jobs:
           CI_CHANGED="$ci_changed" \
           E2E_CHANGED="$e2e_changed" \
           .github/scripts/runner-image-context.sh turbo-consumer
+
+          EVENT_NAME="${{ github.event_name }}" \
+          API_CHANGED="$api_changed" \
+          PLATFORM_CHANGED="$platform_changed" \
+          CLI_CHANGED="$cli_changed" \
+          CI_CHANGED="$ci_changed" \
+          E2E_CHANGED="$e2e_changed" \
+          .github/scripts/runner-image-context.sh playwright-consumer
 
       - name: Detect Crates runner image consumers
         id: crates
@@ -223,6 +233,7 @@ jobs:
           RELEASE_SKIP: ${{ steps.identity.outputs.release-skip }}
           RUNNER_HOST_GROUPS_CONFIGURED: ${{ steps.host-group-presence.outputs.configured }}
           TURBO_RUNNER_CONSUMER_NEEDED: ${{ steps.turbo.outputs.turbo-runner-consumer-needed }}
+          PLAYWRIGHT_RUNNER_CONSUMER_NEEDED: ${{ steps.turbo.outputs.playwright-runner-consumer-needed }}
           CRATES_RUNNER_CONSUMER_NEEDED: ${{ steps.crates.outputs.crates-runner-consumer-needed }}
           RUNNER_IMAGE_INPUTS_CHANGED: ${{ steps.image-inputs.outputs.runner-image-inputs-changed }}
         run: .github/scripts/runner-image-context.sh needed

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -161,6 +161,7 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     outputs:
       job-ref: ${{ steps.set-job-ref.outputs.job-ref }}
+      runner-image-job-ref: ${{ steps.set-job-ref.outputs.runner-image-job-ref }}
       app-preview-url: ${{ steps.preview-urls.outputs.app-url }}
       api-preview-url: ${{ steps.preview-urls.outputs.api-url }}
       api-changed: ${{ steps.detect.outputs.api-changed }}
@@ -172,6 +173,7 @@ jobs:
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
       e2e-changed: ${{ steps.detect.outputs.e2e-changed }}
       turbo-runner-consumer-needed: ${{ steps.runner-e2e.outputs.turbo-runner-consumer-needed }}
+      playwright-runner-consumer-needed: ${{ steps.playwright-runner.outputs.playwright-runner-consumer-needed }}
       base-ref: ${{ steps.detect.outputs.base-ref }}
     steps:
       - uses: actions/checkout@v7.0.1
@@ -272,6 +274,17 @@ jobs:
           E2E_CHANGED: ${{ steps.detect.outputs.e2e-changed }}
         run: .github/scripts/runner-image-context.sh turbo-consumer
 
+      - name: Select Playwright runner consumer
+        id: playwright-runner
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          API_CHANGED: ${{ steps.detect.outputs.api-changed }}
+          PLATFORM_CHANGED: ${{ steps.detect.outputs.platform-changed }}
+          CLI_CHANGED: ${{ steps.detect.outputs.cli-changed }}
+          CI_CHANGED: ${{ steps.detect.outputs.ci-changed }}
+          E2E_CHANGED: ${{ steps.detect.outputs.e2e-changed }}
+        run: .github/scripts/runner-image-context.sh playwright-consumer
+
       - name: Set job-ref
         id: set-job-ref
         env:
@@ -301,19 +314,23 @@ jobs:
               exit 0
             fi
             echo "job-ref=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "runner-image-job-ref=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
             echo "Job ref set to: pr-${{ github.event.pull_request.number }}"
           elif [ "${{ github.event_name }}" = "merge_group" ]; then
             MQ_REF="${{ github.event.merge_group.head_ref }}"
             PR_NUM=$(echo "$MQ_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//')
             if [ -n "$PR_NUM" ]; then
               echo "job-ref=pr-${PR_NUM}" >> "$GITHUB_OUTPUT"
+              echo "runner-image-job-ref=pr-${PR_NUM}" >> "$GITHUB_OUTPUT"
               echo "Job ref set to: pr-${PR_NUM}"
             else
               echo "::error::Failed to extract PR number from merge_group head_ref: $MQ_REF"
               exit 1
             fi
           else
+            SHORT_SHA=$(printf '%s' "$GITHUB_SHA" | cut -c1-12)
             echo "job-ref=staging" >> "$GITHUB_OUTPUT"
+            echo "runner-image-job-ref=staging-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
             echo "Job ref set to: staging"
           fi
 
@@ -1822,6 +1839,7 @@ jobs:
       - deploy-api
       - deploy-app
       - deploy-stripe-listener
+      - deploy-runner-start
     if: |
       always() &&
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -1834,7 +1852,14 @@ jobs:
       ) &&
       needs.deploy-api.result == 'success' &&
       needs.deploy-app.result == 'success' &&
-      (github.event_name == 'push' || needs.deploy-stripe-listener.result == 'success')
+      (github.event_name == 'push' || needs.deploy-stripe-listener.result == 'success') &&
+      (
+        (
+          needs.prepare.outputs.turbo-runner-consumer-needed != 'true' &&
+          needs.prepare.outputs.playwright-runner-consumer-needed != 'true'
+        ) ||
+        needs.deploy-runner-start.result == 'success'
+      )
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -1906,6 +1931,7 @@ jobs:
           CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+          E2E_RUNNER_GROUP: ${{ github.event_name == 'push' && 'vm0/playwright-staging' || format('vm0/development-{0}', needs.prepare.outputs.job-ref) }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       - name: Print Stripe webhook forwarding log
         if: always() && github.event_name == 'push' && needs.prepare.outputs.job-ref != 'staging'
@@ -2136,7 +2162,6 @@ jobs:
 
   # Deploy runner prepare: wait for the shared runner-image workflow manifest.
   # The runner-image workflow owns cross-compilation and all-host image build.
-  # Skip on push to main - runner deployment is only needed for PRs
   deploy-runner-prepare:
     runs-on: ubuntu-latest
     permissions:
@@ -2150,7 +2175,10 @@ jobs:
     if: |
       needs.prepare.outputs.job-ref != '' &&
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      needs.prepare.outputs.turbo-runner-consumer-needed == 'true'
+      (
+        needs.prepare.outputs.turbo-runner-consumer-needed == 'true' ||
+        needs.prepare.outputs.playwright-runner-consumer-needed == 'true'
+      )
     outputs:
       bin-dir: ${{ steps.manifest.outputs.bin-dir }}
       runner-dir: ${{ steps.manifest.outputs.runner-dir }}
@@ -2224,7 +2252,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.sha }}
           LOOKUP_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+          JOB_REF: ${{ needs.prepare.outputs.runner-image-job-ref }}
           # The helper resolves per-architecture host subsets locally and emits
           # merged hash maps for deploy-runner-start.
           AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
@@ -2248,7 +2276,10 @@ jobs:
     if: |
       needs.prepare.outputs.job-ref != '' &&
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      needs.prepare.outputs.turbo-runner-consumer-needed == 'true'
+      (
+        needs.prepare.outputs.turbo-runner-consumer-needed == 'true' ||
+        needs.prepare.outputs.playwright-runner-consumer-needed == 'true'
+      )
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -2268,7 +2299,8 @@ jobs:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
-          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+          RUNNER_SERVICE_REF: ${{ github.event_name == 'push' && 'playwright-staging' || needs.prepare.outputs.job-ref }}
+          RUNNER_GROUP: ${{ github.event_name == 'push' && 'vm0/playwright-staging' || format('vm0/development-{0}', needs.prepare.outputs.job-ref) }}
           BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
           RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
           ROOTFS_HASH_MAP: ${{ needs.deploy-runner-prepare.outputs.rootfs-hash-map }}
@@ -2291,7 +2323,7 @@ jobs:
 
             local HOST=$1
             local HOST_INDEX=$2
-            local RUNNER_NAME="${JOB_REF}-${HOST_INDEX}"
+            local RUNNER_NAME="${RUNNER_SERVICE_REF}-${HOST_INDEX}"
             local REMOTE="${METAL_USER}@${HOST}"
             local MC
             echo "=== Starting runner ${RUNNER_NAME} on ${HOST} ==="
@@ -2320,8 +2352,8 @@ jobs:
               --rootfs-hash ${ROOTFS_HASH} \
               --snapshot-hash ${SNAPSHOT_HASH} \
               --name ${RUNNER_NAME} \
-              --group vm0/development-${JOB_REF} \
-              --runner-dirname ${JOB_REF} \
+              --group ${RUNNER_GROUP} \
+              --runner-dirname ${RUNNER_SERVICE_REF} \
               --concurrency-factor 1.5 \
               --api-url ${RUNNER_API_URL} \
               --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
@@ -2430,7 +2462,7 @@ jobs:
             local HOST_INDEX=0
             for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
               HOST_INDEX=$((HOST_INDEX + 1))
-              local RUNNER_NAME="${JOB_REF}-${HOST_INDEX}"
+              local RUNNER_NAME="${RUNNER_SERVICE_REF}-${HOST_INDEX}"
               local REMOTE="${METAL_USER}@${HOST}"
               echo "::warning::Requesting stop for partially started runner ${RUNNER_NAME} on ${HOST}"
               (
@@ -2496,7 +2528,7 @@ jobs:
           HOST_INDEX=0
           for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
             HOST_INDEX=$((HOST_INDEX + 1))
-            RUNNER_NAME="${JOB_REF}-${HOST_INDEX}"
+            RUNNER_NAME="${RUNNER_SERVICE_REF}-${HOST_INDEX}"
             if ! MC=$(read_host_capacity "$HOST" "$RUNNER_NAME"); then
               check_runner_start_exit
               FAILED=1
@@ -2859,6 +2891,11 @@ jobs:
           if [ "${{ needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed }}" = "false" ]; then
             TS_CHECK_SKIP_ALLOWED="skipped"
           fi
+          RUNNER_DEPLOY_SKIP_ALLOWED="true"
+          if [ "${{ needs.prepare.outputs.turbo-runner-consumer-needed }}" = "true" ] ||
+            [ "${{ needs.prepare.outputs.playwright-runner-consumer-needed }}" = "true" ]; then
+            RUNNER_DEPLOY_SKIP_ALLOWED=""
+          fi
           RUNNER_E2E_SKIP_ALLOWED="true"
           if [ "${{ needs.prepare.outputs.turbo-runner-consumer-needed }}" = "true" ]; then
             RUNNER_E2E_SKIP_ALLOWED=""
@@ -2867,6 +2904,7 @@ jobs:
           if [ "${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}" = "true" ]; then
             # External fork PRs cannot access runner infra secrets, so their
             # runner deployment and runner E2E jobs are expected to skip.
+            RUNNER_DEPLOY_SKIP_ALLOWED="true"
             RUNNER_E2E_SKIP_ALLOWED="true"
             CF_APP_SKIP_ALLOWED="true"
           fi
@@ -2921,8 +2959,8 @@ jobs:
           check_result "cli-e2e-02-browser" "${{ needs.cli-e2e-02-browser.result }}" "${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}"
           check_result "cli-e2e-02-playwright" "${{ needs.cli-e2e-02-playwright.result }}" "${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}"
           check_result "cli-e2e-01-serial" "${{ needs.cli-e2e-01-serial.result }}" "true"
-          check_result "deploy-runner-prepare" "${{ needs.deploy-runner-prepare.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
-          check_result "deploy-runner-start" "${{ needs.deploy-runner-start.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
+          check_result "deploy-runner-prepare" "${{ needs.deploy-runner-prepare.result }}" "$RUNNER_DEPLOY_SKIP_ALLOWED"
+          check_result "deploy-runner-start" "${{ needs.deploy-runner-start.result }}" "$RUNNER_DEPLOY_SKIP_ALLOWED"
           check_result "e2e-runner-bootstrap" "${{ needs.e2e-runner-bootstrap.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
           check_result "cli-e2e-03-runner" "${{ needs.cli-e2e-03-runner.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
 

--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -4,7 +4,10 @@ import {
   refreshClerkSessionToken,
   signInWithClerkTestingHelper,
 } from "../lib/auth";
-import { completeExploreOnboarding } from "../lib/onboarding";
+import {
+  authHeadersForToken,
+  completeExploreOnboarding,
+} from "../lib/onboarding";
 import { deriveAppUrl, STORAGE_STATE } from "../playwright.config";
 
 test("complete app onboarding to chat page", async ({ browser, page }) => {
@@ -31,6 +34,41 @@ test("complete app onboarding to chat page", async ({ browser, page }) => {
   expect(page.url()).toMatch(/\/agents\/.*\/chat/);
 
   await refreshClerkSessionToken(page, { activeOrganizationId: orgId });
+
+  const runnerGroup = process.env.E2E_RUNNER_GROUP;
+  if (runnerGroup) {
+    const token = await page.evaluate(async () => {
+      return (
+        (await window.Clerk?.session?.getToken({ skipCache: true })) ?? null
+      );
+    });
+    if (!token) {
+      throw new Error("Clerk session token unavailable for runner setup");
+    }
+    const response = await page.request.post(
+      new URL("/api/test/agent-composes", apiUrl).toString(),
+      {
+        headers: authHeadersForToken(token),
+        data: {
+          content: {
+            version: "1",
+            agents: {
+              "default-agent": {
+                framework: "claude-code",
+                instructions: "CLAUDE.md",
+                environment: {
+                  ZERO_AGENT_ID: "${{ vars.ZERO_AGENT_ID }}",
+                  ZERO_TOKEN: "${{ secrets.ZERO_TOKEN }}",
+                },
+                experimental_runner: { group: runnerGroup },
+              },
+            },
+          },
+        },
+      },
+    );
+    expect(response.status()).toBe(200);
+  }
 
   // Save storageState for feature tests (use absolute path to match playwright.config.ts)
   await page.context().storageState({ path: STORAGE_STATE });

--- a/e2e/playwright/tests/webchat.spec.ts
+++ b/e2e/playwright/tests/webchat.spec.ts
@@ -35,6 +35,6 @@ test("send a chat message and receive an assistant response", async ({
     .locator(".zero-chat-bubble-assistant")
     .filter({ hasText: /\S/ })
     .last();
-  await expect(assistantReply).toBeVisible({ timeout: 120_000 });
+  await expect(assistantReply).toBeVisible({ timeout: 30_000 });
   await expect(assistantReply).not.toContainText("Oops, something went wrong");
 });


### PR DESCRIPTION
## Summary

- deploy a dedicated mock runner for Playwright whenever the browser suite runs, including main pushes
- pin the Playwright test agent compose to the isolated runner group without enabling the full runner E2E matrix on main
- keep the webchat scenario text-only and reduce the assistant reply bound from 120 seconds to 30 seconds

## Testing

- `bash .github/scripts/tests/runner-image-context-test.sh`
- `bash .github/scripts/tests/runner-image-workflow-test.sh`
- `bash .github/scripts/tests/check-workflow-shell-compatibility-test.sh`
- workflow shell compatibility checks for `runner-image.yml` and `turbo.yml`
- `shellcheck -x` for the changed shell scripts
- `actionlint` for the changed workflows
- `pnpm exec prettier --check` for the changed TypeScript and workflows
- `cd e2e && pnpm check-types && pnpm test`
- local Playwright: setup + text-only webchat, 3 passed