### PR TITLE
fix(platform): clear model provider secrets on settings close

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/model-provider-connections.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/model-provider-connections.ts
@@ -17,7 +17,7 @@ import {
   updateModelProviderConnection$,
 } from "../../external/model-provider-connections.ts";
 import { featureSwitch$ } from "../../external/feature-switch.ts";
-import { jsonParseOr } from "../../utils.ts";
+import { jsonParseOr, resetSignal } from "../../utils.ts";
 
 export type ModelProviderConnectionTemplate =
   | "custom"
@@ -149,10 +149,18 @@ function templateDraft(
   };
 }
 
-const internalConnectionDraft$ = state<ConnectionDraft>({
-  ...templateDraft("custom"),
-  open: false,
-});
+function closedDraft(): ConnectionDraft {
+  return {
+    ...templateDraft("custom"),
+    open: false,
+  };
+}
+
+const internalConnectionDraft$ = state<ConnectionDraft>(closedDraft());
+const internalConnectionDialogSignal$ = state<AbortSignal | null>(null);
+const resetConnectionDialogSignal$ = resetSignal();
+
+export { internalConnectionDialogSignal$ as modelProviderConnectionDialogSignal$ };
 
 const internalPendingDeleteConnection$ =
   state<ModelProviderConnectionResponse | null>(null);
@@ -165,14 +173,43 @@ export const pendingDeleteModelProviderConnection$ = computed((get) => {
   return get(internalPendingDeleteConnection$);
 });
 
+const resetConnectionDialogState$ = command(({ set }) => {
+  set(internalConnectionDialogSignal$, null);
+  set(internalConnectionDraft$, closedDraft());
+});
+
+const openConnectionDialog$ = command(
+  ({ set }, draft: ConnectionDraft, settingsDialogSignal: AbortSignal) => {
+    settingsDialogSignal.throwIfAborted();
+    const signal = set(resetConnectionDialogSignal$, settingsDialogSignal);
+    signal.addEventListener(
+      "abort",
+      () => {
+        set(resetConnectionDialogState$);
+      },
+      { once: true },
+    );
+    set(internalConnectionDialogSignal$, signal);
+    set(internalConnectionDraft$, draft);
+  },
+);
+
 export const openCreateModelProviderConnection$ = command(
-  ({ set }, template: ModelProviderConnectionTemplate) => {
-    set(internalConnectionDraft$, templateDraft(template));
+  (
+    { set },
+    template: ModelProviderConnectionTemplate,
+    settingsDialogSignal: AbortSignal,
+  ) => {
+    set(openConnectionDialog$, templateDraft(template), settingsDialogSignal);
   },
 );
 
 export const openEditModelProviderConnection$ = command(
-  ({ set }, connection: ModelProviderConnectionResponse) => {
+  (
+    { set },
+    connection: ModelProviderConnectionResponse,
+    settingsDialogSignal: AbortSignal,
+  ) => {
     const surface = (protocol: ModelProviderSurfaceProtocol): SurfaceDraft => {
       const current = connection.surfaces.find((candidate) => {
         return candidate.protocol === protocol;
@@ -187,23 +224,24 @@ export const openEditModelProviderConnection$ = command(
           }
         : emptySurface();
     };
-    set(internalConnectionDraft$, {
-      open: true,
-      editingId: connection.id,
-      displayName: connection.displayName,
-      secret: "",
-      messages: surface("anthropic-messages"),
-      responses: surface("openai-responses"),
-      error: null,
-    });
+    set(
+      openConnectionDialog$,
+      {
+        open: true,
+        editingId: connection.id,
+        displayName: connection.displayName,
+        secret: "",
+        messages: surface("anthropic-messages"),
+        responses: surface("openai-responses"),
+        error: null,
+      },
+      settingsDialogSignal,
+    );
   },
 );
 
 export const closeModelProviderConnection$ = command(({ set }) => {
-  set(internalConnectionDraft$, {
-    ...templateDraft("custom"),
-    open: false,
-  });
+  set(resetConnectionDialogSignal$);
 });
 
 export const openDeleteModelProviderConnection$ = command(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-providers-tab.test.tsx
@@ -343,6 +343,18 @@ async function openModelSettings(): Promise<void> {
   });
 }
 
+async function openSettingsFromAccountMenu(): Promise<HTMLElement> {
+  const accountName = await screen.findByText("Test User");
+  const accountButton = accountName.closest("button");
+  if (!accountButton) {
+    throw new Error("Account menu trigger not found");
+  }
+  click(accountButton);
+  const menu = await screen.findByRole("menu");
+  click(within(menu).getByText("Settings"));
+  return screen.findByRole("dialog", { name: "Settings" });
+}
+
 async function openAddApiKeyModelDialog(): Promise<void> {
   mockAdminOrg();
   context.mocks.data.orgModelProviders([]);
@@ -456,6 +468,69 @@ describe("organization model providers settings", () => {
     expect(
       screen.queryByRole("heading", { name: "Provider connections" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("clears a gateway draft when settings closes", async () => {
+    mockAdminOrg();
+    context.mocks.data.orgModelProviders([]);
+    context.mocks.data.orgModelPolicies([]);
+    mockGatewayConnectionLifecycle();
+
+    await openProvidersTab(true);
+
+    const connectionsHeading = await screen.findByRole("heading", {
+      name: "Provider connections",
+    });
+    const connectionsSection = connectionsHeading.closest("section");
+    if (!(connectionsSection instanceof HTMLElement)) {
+      throw new Error("Provider connections section not found");
+    }
+    const settingsDialog = screen.getByRole("dialog", { name: "Settings" });
+
+    click(within(connectionsSection).getByText("Add provider"));
+    click(menuItemByText("Vercel AI Gateway"));
+    const addDialog = await screen.findByRole("dialog", {
+      name: "Add model provider",
+    });
+    await fill(
+      within(addDialog).getByLabelText("API key"),
+      "vck-sensitive-draft",
+    );
+
+    click(within(settingsDialog).getByLabelText("Close"));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Settings" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("dialog", { name: "Add model provider" }),
+      ).not.toBeInTheDocument();
+    });
+
+    const reopenedSettingsDialog = await openSettingsFromAccountMenu();
+    click(buttonByText("Models", reopenedSettingsDialog));
+    await expect(
+      screen.findByRole("heading", { name: "Models" }),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: "Add model provider" }),
+    ).not.toBeInTheDocument();
+
+    const reopenedConnectionsHeading = await screen.findByRole("heading", {
+      name: "Provider connections",
+    });
+    const reopenedConnectionsSection =
+      reopenedConnectionsHeading.closest("section");
+    if (!(reopenedConnectionsSection instanceof HTMLElement)) {
+      throw new Error("Provider connections section not found");
+    }
+    click(within(reopenedConnectionsSection).getByText("Add provider"));
+    click(menuItemByText("Vercel AI Gateway"));
+
+    const reopenedAddDialog = await screen.findByRole("dialog", {
+      name: "Add model provider",
+    });
+    expect(within(reopenedAddDialog).getByLabelText("API key")).toHaveValue("");
   });
 
   it("manages a gateway lifecycle and assigns it to a model route", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/model-provider-connections-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/model-provider-connections-section.tsx
@@ -34,6 +34,7 @@ import {
 import {
   closeDeleteModelProviderConnection$,
   closeModelProviderConnection$,
+  modelProviderConnectionDialogSignal$,
   modelProviderConnectionDraft$,
   openCreateModelProviderConnection$,
   openDeleteModelProviderConnection$,
@@ -45,6 +46,7 @@ import {
   updateModelProviderSurfaceField$,
   type ModelProviderConnectionTemplate,
 } from "../../../../signals/zero-page/settings/model-provider-connections.ts";
+import { settingsDialogSignal$ } from "../../../../signals/zero-page/settings/settings-dialog.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { SettingsSectionHeading } from "../settings/settings-section-heading.tsx";
@@ -53,7 +55,11 @@ const ZERO_BORDER = {
   border: "0.7px solid hsl(var(--gray-400))",
 } as const;
 
-function AddConnectionMenu() {
+function AddConnectionMenu({
+  settingsDialogSignal,
+}: {
+  settingsDialogSignal: AbortSignal;
+}) {
   const { t } = useTranslation();
   const openCreate = useSet(openCreateModelProviderConnection$);
   const templateLabels: Record<ModelProviderConnectionTemplate, string> = {
@@ -97,7 +103,7 @@ function AddConnectionMenu() {
             <DropdownMenuItem
               key={template}
               onSelect={() => {
-                openCreate(template);
+                openCreate(template, settingsDialogSignal);
               }}
             >
               {templateLabels[template]}
@@ -111,8 +117,10 @@ function AddConnectionMenu() {
 
 function ConnectionCard({
   connection,
+  settingsDialogSignal,
 }: {
   connection: ModelProviderConnectionResponse;
+  settingsDialogSignal: AbortSignal;
 }) {
   const { t } = useTranslation();
   const openEdit = useSet(openEditModelProviderConnection$);
@@ -158,7 +166,7 @@ function ConnectionCard({
         <DropdownMenuContent align="end">
           <DropdownMenuItem
             onSelect={() => {
-              openEdit(connection);
+              openEdit(connection, settingsDialogSignal);
             }}
           >
             <IconPencil size={14} />
@@ -420,8 +428,8 @@ function ConnectionDialogFields({ error }: { error: string | null }) {
 function ConnectionDialog() {
   const { t } = useTranslation();
   const draft = useGet(modelProviderConnectionDraft$);
+  const dialogSignal = useGet(modelProviderConnectionDialogSignal$);
   const close = useSet(closeModelProviderConnection$);
-  const pageSignal = useGet(pageSignal$);
   const [saveLoadable, save] = useLoadableSet(saveModelProviderConnection$);
   const saving = saveLoadable.state === "loading";
   const errorKey = draft.error;
@@ -473,9 +481,11 @@ function ConnectionDialog() {
             })}
           </Button>
           <Button
-            disabled={saving}
+            disabled={saving || !dialogSignal}
             onClick={() => {
-              detach(save(pageSignal), Reason.DomCallback);
+              if (dialogSignal) {
+                detach(save(dialogSignal), Reason.DomCallback);
+              }
             }}
           >
             {t(($) => {
@@ -490,10 +500,14 @@ function ConnectionDialog() {
 
 export function ModelProviderConnectionsSection() {
   const { t } = useTranslation();
+  const settingsDialogSignal = useGet(settingsDialogSignal$);
   const loadable = useLoadable(modelProviderConnections$);
   const last = useLastResolved(modelProviderConnections$);
   const connections =
     loadable.state === "hasData" ? loadable.data : (last ?? []);
+  if (!settingsDialogSignal) {
+    return null;
+  }
   return (
     <section className="flex flex-col gap-4">
       <SettingsSectionHeading
@@ -503,7 +517,9 @@ export function ModelProviderConnectionsSection() {
         description={t(($) => {
           return $.settings.models.gateways.description;
         })}
-        action={<AddConnectionMenu />}
+        action={
+          <AddConnectionMenu settingsDialogSignal={settingsDialogSignal} />
+        }
       />
       {connections.length === 0 ? (
         <p className="rounded-xl bg-muted/20 px-4 py-5 text-sm text-muted-foreground">
@@ -515,7 +531,11 @@ export function ModelProviderConnectionsSection() {
         <div className="grid gap-2">
           {connections.map((connection) => {
             return (
-              <ConnectionCard key={connection.id} connection={connection} />
+              <ConnectionCard
+                key={connection.id}
+                connection={connection}
+                settingsDialogSignal={settingsDialogSignal}
+              />
             );
           })}
         </div>


### PR DESCRIPTION
## Summary

- scope model provider connection drafts to a resettable dialog signal derived from the Settings lifecycle
- clear the full draft, including plaintext API keys, when either the connection dialog or Settings closes
- use the dialog signal for save requests and cover the Settings close/reopen behavior

## Verification

- `pnpm --filter @vm0/app check-types`
- targeted Oxlint, type-aware Oxlint, and ESLint on the three changed files
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/org-providers-tab.test.tsx`
