### PR TITLE
feat(platform): enable multilingual locale rollout

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -186,16 +186,13 @@ runs:
           add_env ENV "$deploy_env"
           add_env BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED "true"
           add_env JAPANESE_LOCALE_ROLLOUT_ENABLED "true"
+          add_env KOREAN_LOCALE_ROLLOUT_ENABLED "true"
+          add_env INDONESIAN_LOCALE_ROLLOUT_ENABLED "true"
+          add_env GERMAN_LOCALE_ROLLOUT_ENABLED "true"
+          add_env SPANISH_LOCALE_ROLLOUT_ENABLED "true"
+          add_env ITALIAN_LOCALE_ROLLOUT_ENABLED "true"
+          add_env FRENCH_LOCALE_ROLLOUT_ENABLED "true"
           add_env HINDI_LOCALE_ROLLOUT_ENABLED "true"
-          # Keep production writes disabled until every rollback candidate can
-          # parse persisted id-ID preferences. Preview deploys are isolated and
-          # remain enabled for end-to-end rollout coverage.
-          if [[ "$INPUT_ENVIRONMENT" == "preview" ]]; then
-            add_env INDONESIAN_LOCALE_ROLLOUT_ENABLED "true"
-            add_env GERMAN_LOCALE_ROLLOUT_ENABLED "true"
-            add_env FRENCH_LOCALE_ROLLOUT_ENABLED "true"
-          fi
-          add_env ITALIAN_LOCALE_ROLLOUT_ENABLED "$(first_non_empty "$(repo_var ITALIAN_LOCALE_ROLLOUT_ENABLED)" "false")"
           if [[ "$INPUT_ENVIRONMENT" == "production" ]]; then
             add_secret CLOUDFLARE_BROWSER_RENDERING_API_TOKEN CLOUDFLARE_BROWSER_RENDERING_API_TOKEN
             add_secret ARTIFACT_PREVIEW_WAF_SECRET ARTIFACT_PREVIEW_WAF_SECRET

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -115,18 +115,11 @@ run_action() {
   local test_dir="$2"
   local input_app="${3:-api}"
   local input_environment="${4:-preview}"
-  local italian_locale_rollout="${5:-}"
   local action_script="${test_dir}/web-api-env-action.sh"
   local github_output="${test_dir}/github-output"
   local repo_vars_json
 
   repo_vars_json='{"GH_OAUTH_CLIENT_ID":"github-gh-client-id","SLACK_OAUTH_CLIENT_ID":"github-slack-client-id","VM0_API_BACKEND_URL":"https://api.github.test","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-var","FINICITY_PARTNER_ID":"github-finicity-partner-id","POSTHOG_KEY":"github-posthog-key","POSTHOG_HOST":"https://posthog.github.test","ATOM_URL":"https://atom.github.test","STRIPE_OAUTH_CLIENT_ID":"ca_test_connect_client","MICROSOFT_TEAMS_BOT_APP_ID":"github-teams-bot-app-id","MICROSOFT_TEAMS_APP_TENANT_ID":"github-teams-app-tenant-id","ZERO_PRICE_PRO":"price_test_pro","ZERO_PRICE_TEAM":"price_test_team","ATOM_GRANT_PRICE":"price_test_atom_grant","ZERO_PRICE_CUSTOM_CREDITS":"price_test_custom_credits","ZERO_PRICE_CUSTOM_CREDIT_UNIT":"price_test_custom_credit_unit","ZERO_PRICE_CONCURRENCY":"price_test_concurrency","GMAIL_PUBSUB_TOPIC_NAME":"projects/github/topics/gmail","GMAIL_PUBSUB_PUSH_AUDIENCE":"https://api.github.test/api/webhooks/gmail","GMAIL_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL":"gmail-push@github.test","GOOGLE_WORKSPACE_EVENTS_PUBSUB_TOPIC_NAME":"projects/github/topics/google-workspace-events","GOOGLE_WORKSPACE_EVENTS_PUBSUB_PUSH_AUDIENCE":"https://api.github.test/api/webhooks/google-workspace-events","GOOGLE_WORKSPACE_EVENTS_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL":"workspace-events-push@github.test"}'
-  if [[ -n "$italian_locale_rollout" ]]; then
-    repo_vars_json="$(
-      jq -c --arg value "$italian_locale_rollout" \
-        '. + {ITALIAN_LOCALE_ROLLOUT_ENABLED: $value}' <<< "$repo_vars_json"
-    )"
-  fi
 
   extract_action_script > "$action_script"
 
@@ -187,11 +180,13 @@ assert_env_value "$success_env_file" FEISHU_CALLBACK_BASE_URL "https://pr-123-ap
 assert_env_value "$success_env_file" VM0_WEB_URL "https://pr-123-www.vm0.test"
 assert_env_value "$success_env_file" BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED "true"
 assert_env_value "$success_env_file" JAPANESE_LOCALE_ROLLOUT_ENABLED "true"
-assert_env_value "$success_env_file" HINDI_LOCALE_ROLLOUT_ENABLED "true"
+assert_env_value "$success_env_file" KOREAN_LOCALE_ROLLOUT_ENABLED "true"
 assert_env_value "$success_env_file" INDONESIAN_LOCALE_ROLLOUT_ENABLED "true"
 assert_env_value "$success_env_file" GERMAN_LOCALE_ROLLOUT_ENABLED "true"
-assert_env_value "$success_env_file" ITALIAN_LOCALE_ROLLOUT_ENABLED "false"
+assert_env_value "$success_env_file" SPANISH_LOCALE_ROLLOUT_ENABLED "true"
+assert_env_value "$success_env_file" ITALIAN_LOCALE_ROLLOUT_ENABLED "true"
 assert_env_value "$success_env_file" FRENCH_LOCALE_ROLLOUT_ENABLED "true"
+assert_env_value "$success_env_file" HINDI_LOCALE_ROLLOUT_ENABLED "true"
 assert_env_value "$success_env_file" GIT_COMMIT_SHA "$EXPECTED_BUILD_COMMIT_SHA"
 assert_env_absent_value "$success_env_file" "ONBOARDING_URL="
 assert_env_value "$success_env_file" ZERO_PRICE_PRO "price_test_pro"
@@ -214,12 +209,6 @@ assert_env_absent_value "$success_env_file" "github-slack-client-secret"
 assert_env_absent_value "$success_env_file" "github-posthog-key"
 assert_env_absent_value "$success_env_file" "github-cloudflare-browser-rendering-token"
 assert_env_absent_value "$success_env_file" "github-artifact-preview-waf-secret"
-
-enabled_rollout_dir="$(mktemp -d)"
-TEMP_DIRS+=("$enabled_rollout_dir")
-run_action "$(build_doppler_secrets_json)" "$enabled_rollout_dir" api preview true >/dev/null
-enabled_rollout_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${enabled_rollout_dir}/github-output")"
-assert_env_value "$enabled_rollout_env_file" ITALIAN_LOCALE_ROLLOUT_ENABLED "true"
 
 production_web_dir="$(mktemp -d)"
 TEMP_DIRS+=("$production_web_dir")
@@ -259,11 +248,13 @@ assert_env_value "$production_api_env_file" ZERO_SCRAPE_FIRECRAWL_TOKEN "github-
 assert_env_value "$production_api_env_file" ZERO_WEB_SEARCH_PERPLEXITY_TOKEN "github-perplexity-token"
 assert_env_value "$production_api_env_file" BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED "true"
 assert_env_value "$production_api_env_file" JAPANESE_LOCALE_ROLLOUT_ENABLED "true"
+assert_env_value "$production_api_env_file" KOREAN_LOCALE_ROLLOUT_ENABLED "true"
+assert_env_value "$production_api_env_file" INDONESIAN_LOCALE_ROLLOUT_ENABLED "true"
+assert_env_value "$production_api_env_file" GERMAN_LOCALE_ROLLOUT_ENABLED "true"
+assert_env_value "$production_api_env_file" SPANISH_LOCALE_ROLLOUT_ENABLED "true"
+assert_env_value "$production_api_env_file" ITALIAN_LOCALE_ROLLOUT_ENABLED "true"
+assert_env_value "$production_api_env_file" FRENCH_LOCALE_ROLLOUT_ENABLED "true"
 assert_env_value "$production_api_env_file" HINDI_LOCALE_ROLLOUT_ENABLED "true"
-assert_env_absent_value "$production_api_env_file" "INDONESIAN_LOCALE_ROLLOUT_ENABLED="
-assert_env_absent_value "$production_api_env_file" "GERMAN_LOCALE_ROLLOUT_ENABLED="
-assert_env_value "$production_api_env_file" ITALIAN_LOCALE_ROLLOUT_ENABLED "false"
-assert_env_absent_value "$production_api_env_file" "FRENCH_LOCALE_ROLLOUT_ENABLED="
 assert_env_absent_value "$production_api_env_file" "ONBOARDING_URL="
 assert_env_value "$production_api_env_file" CLOUDFLARE_BROWSER_RENDERING_API_TOKEN "github-cloudflare-browser-rendering-token"
 assert_env_value "$production_api_env_file" ARTIFACT_PREVIEW_WAF_SECRET "github-artifact-preview-waf-secret"

--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -133,33 +133,15 @@ GMAIL_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL=op://Development/gmail/GMAIL_PUBSUB_PUSH
 # new-message event configurations with threadId.
 ZERO_MAIL_REPLY_FOLLOW_UP_ROLLOUT_ENABLED=false
 
-# Brazilian Portuguese has not shipped yet. Enable it in development so the
-# capable Platform client can exercise the rollout path.
+# Enable locale rollout gates in development.
 BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED=true
-ITALIAN_LOCALE_ROLLOUT_ENABLED=true
-
-# Keep disabled until every rollback-eligible API version accepts stored
-# Korean locale preferences.
-KOREAN_LOCALE_ROLLOUT_ENABLED=false
-
-# Enable Indonesian in development so the capable Platform client can exercise
-# the rollout path.
-INDONESIAN_LOCALE_ROLLOUT_ENABLED=true
-
-# German has not shipped yet. Enable it in development so the capable Platform
-# client can exercise the rollout path.
-GERMAN_LOCALE_ROLLOUT_ENABLED=true
-
-# French has not shipped yet. Enable it in development so the capable Platform
-# client can exercise the rollout path.
-FRENCH_LOCALE_ROLLOUT_ENABLED=true
-
-# Japanese has not shipped yet. Enable the deployment gate in development so
-# users can opt into the locale through the feature switch.
 JAPANESE_LOCALE_ROLLOUT_ENABLED=true
-
-# Enable Hindi in development so the capable Platform client can exercise the
-# rollout path.
+KOREAN_LOCALE_ROLLOUT_ENABLED=true
+INDONESIAN_LOCALE_ROLLOUT_ENABLED=true
+GERMAN_LOCALE_ROLLOUT_ENABLED=true
+SPANISH_LOCALE_ROLLOUT_ENABLED=true
+ITALIAN_LOCALE_ROLLOUT_ENABLED=true
+FRENCH_LOCALE_ROLLOUT_ENABLED=true
 HINDI_LOCALE_ROLLOUT_ENABLED=true
 
 # Optional: Google Ads API (developer token + login customer ID for MCC)

--- a/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
@@ -240,6 +240,7 @@ describe("MISC-02: preferences, push subscription, user export, and empty logs",
   it("negotiates gated locales across old and new clients", async () => {
     const { api, admin } = testActors();
     mockOptionalEnv("BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED", undefined);
+    mockOptionalEnv("JAPANESE_LOCALE_ROLLOUT_ENABLED", undefined);
     mockOptionalEnv("INDONESIAN_LOCALE_ROLLOUT_ENABLED", undefined);
     mockOptionalEnv("FRENCH_LOCALE_ROLLOUT_ENABLED", undefined);
 
@@ -414,6 +415,7 @@ describe("MISC-02: preferences, push subscription, user export, and empty logs",
   it("negotiates French across rollout and legacy clients", async () => {
     const { api, admin } = testActors();
     mockOptionalEnv("BRAZILIAN_PORTUGUESE_LOCALE_ROLLOUT_ENABLED", undefined);
+    mockOptionalEnv("JAPANESE_LOCALE_ROLLOUT_ENABLED", undefined);
     mockOptionalEnv("INDONESIAN_LOCALE_ROLLOUT_ENABLED", undefined);
     mockOptionalEnv("FRENCH_LOCALE_ROLLOUT_ENABLED", undefined);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -23,10 +23,10 @@ describe("/api/zero/feature-switches", () => {
 
     await accept(client().delete({ headers }), [200]);
     mockOptionalEnv("JAPANESE_LOCALE_ROLLOUT_ENABLED", "true");
-    const defaultDisabled = await accept(client().get({ headers }), [200]);
+    const defaultEnabled = await accept(client().get({ headers }), [200]);
     expect(
-      defaultDisabled.body.effectiveSwitches[FeatureSwitchKey.JapaneseLocale],
-    ).toBeFalsy();
+      defaultEnabled.body.effectiveSwitches[FeatureSwitchKey.JapaneseLocale],
+    ).toBeTruthy();
 
     const enabled = await accept(
       client().update({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
@@ -86,7 +86,7 @@ function createPreferences(
 }
 
 describe("settings dialog", () => {
-  it("caps the language menu height when all locales are available", async () => {
+  it("keeps every available locale in the language menu", async () => {
     context.mocks.data.userPreferences(
       createPreferences("en-US", [
         "en-US",
@@ -109,9 +109,9 @@ describe("settings dialog", () => {
 
     click(await screen.findByRole("combobox", { name: "Language" }));
 
-    const languageMenu = screen.getByRole("listbox");
-    expect(languageMenu).toHaveClass("max-h-64");
-    expect(within(languageMenu).getAllByRole("option")).toHaveLength(10);
+    expect(
+      within(screen.getByRole("listbox")).getAllByRole("option"),
+    ).toHaveLength(10);
   });
 
   it("defaults to English instead of the browser language before user selection", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
@@ -86,6 +86,34 @@ function createPreferences(
 }
 
 describe("settings dialog", () => {
+  it("caps the language menu height when all locales are available", async () => {
+    context.mocks.data.userPreferences(
+      createPreferences("en-US", [
+        "en-US",
+        "pt-BR",
+        "ja-JP",
+        "ko-KR",
+        "id-ID",
+        "de-DE",
+        "es-ES",
+        "it-IT",
+        "fr-FR",
+        "hi-IN",
+      ]),
+    );
+
+    await openDialog("admin", "preference", {
+      [FeatureSwitchKey.LanguagePreference]: true,
+      [FeatureSwitchKey.JapaneseLocale]: true,
+    });
+
+    click(await screen.findByRole("combobox", { name: "Language" }));
+
+    const languageMenu = screen.getByRole("listbox");
+    expect(languageMenu).toHaveClass("max-h-64");
+    expect(within(languageMenu).getAllByRole("option")).toHaveLength(10);
+  });
+
   it("defaults to English instead of the browser language before user selection", async () => {
     const submittedLocales: UserLocale[] = [];
     let serverLocale: UserLocale | null = null;
@@ -614,6 +642,7 @@ describe("settings dialog", () => {
 
     await openDialog("admin", "preference", {
       [FeatureSwitchKey.LanguagePreference]: true,
+      [FeatureSwitchKey.JapaneseLocale]: false,
     });
 
     const languageSelect = await screen.findByRole("combobox", {
@@ -644,6 +673,7 @@ describe("settings dialog", () => {
 
     await openDialog("admin", "preference", {
       [FeatureSwitchKey.LanguagePreference]: true,
+      [FeatureSwitchKey.JapaneseLocale]: false,
     });
 
     const languageSelect = await screen.findByRole("combobox", {
@@ -860,6 +890,7 @@ describe("settings dialog", () => {
 
     await openDialog("admin", "preference", {
       [FeatureSwitchKey.LanguagePreference]: true,
+      [FeatureSwitchKey.JapaneseLocale]: false,
     });
 
     await waitFor(() => {
@@ -877,6 +908,7 @@ describe("settings dialog", () => {
 
     await openDialog("admin", "preference", {
       [FeatureSwitchKey.LanguagePreference]: true,
+      [FeatureSwitchKey.JapaneseLocale]: false,
     });
 
     await waitFor(() => {
@@ -894,6 +926,7 @@ describe("settings dialog", () => {
 
     await openDialog("admin", "preference", {
       [FeatureSwitchKey.LanguagePreference]: true,
+      [FeatureSwitchKey.JapaneseLocale]: false,
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
@@ -43,7 +43,7 @@ function LanguageSelectContent({
   };
 
   return (
-    <SelectContent>
+    <SelectContent className="max-h-64">
       {supports("en-US") && (
         <SelectItem value="en-US">
           {t(($) => {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -20,6 +20,17 @@ describe("isFeatureEnabled", () => {
       true,
     );
     expect(
+      isFeatureEnabled(FeatureSwitchKey.BrazilianPortugueseLocale, {}),
+    ).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.JapaneseLocale, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.KoreanLocale, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.IndonesianLocale, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.GermanLocale, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.SpanishLocale, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.ItalianLocale, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.FrenchLocale, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.HindiLocale, {})).toBe(true);
+    expect(
       isFeatureEnabled(FeatureSwitchKey.ComposerSkillSubstringSearch, {}),
     ).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.SlackDmSessionRouting, {})).toBe(
@@ -52,17 +63,6 @@ describe("isFeatureEnabled", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.ChatThreadSidebarAutoOpen, {}),
     ).toBe(false);
-    expect(
-      isFeatureEnabled(FeatureSwitchKey.BrazilianPortugueseLocale, {}),
-    ).toBe(false);
-    expect(isFeatureEnabled(FeatureSwitchKey.JapaneseLocale, {})).toBe(false);
-    expect(isFeatureEnabled(FeatureSwitchKey.KoreanLocale, {})).toBe(false);
-    expect(isFeatureEnabled(FeatureSwitchKey.IndonesianLocale, {})).toBe(false);
-    expect(isFeatureEnabled(FeatureSwitchKey.GermanLocale, {})).toBe(false);
-    expect(isFeatureEnabled(FeatureSwitchKey.SpanishLocale, {})).toBe(false);
-    expect(isFeatureEnabled(FeatureSwitchKey.ItalianLocale, {})).toBe(false);
-    expect(isFeatureEnabled(FeatureSwitchKey.FrenchLocale, {})).toBe(false);
-    expect(isFeatureEnabled(FeatureSwitchKey.HindiLocale, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.ZeroChatMessaging, {})).toBe(
       false,
     );
@@ -141,16 +141,16 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ZeroChatMessaging]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.LanguagePreference]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.BrazilianPortugueseLocale]).toBe(
-      false,
+      true,
     );
-    expect(staffOrgStates[FeatureSwitchKey.JapaneseLocale]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.KoreanLocale]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.IndonesianLocale]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.GermanLocale]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.SpanishLocale]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.ItalianLocale]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.FrenchLocale]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.HindiLocale]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.JapaneseLocale]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.KoreanLocale]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.IndonesianLocale]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.GermanLocale]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.SpanishLocale]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ItalianLocale]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.FrenchLocale]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.HindiLocale]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ClaudeSessionPruning]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(true);
@@ -185,16 +185,16 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ZeroChatMessaging]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.LanguagePreference]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.BrazilianPortugueseLocale]).toBe(
-      false,
+      true,
     );
-    expect(otherOrgStates[FeatureSwitchKey.JapaneseLocale]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.KoreanLocale]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.IndonesianLocale]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.GermanLocale]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.SpanishLocale]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ItalianLocale]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.FrenchLocale]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.HindiLocale]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.JapaneseLocale]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.KoreanLocale]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.IndonesianLocale]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.GermanLocale]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.SpanishLocale]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.ItalianLocale]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.FrenchLocale]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.HindiLocale]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ClaudeSessionPruning]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -243,62 +243,62 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "yuma@vm0.ai",
     description:
       "Allow pt-BR preference writes after incompatible API readers and rollback candidates have drained.",
-    enabled: false,
+    enabled: true,
     userOverridable: false,
   },
   [FeatureSwitchKey.JapaneseLocale]: {
     maintainer: "yuma@vm0.ai",
     description:
       "Allow ja-JP preference writes after incompatible API readers and rollback candidates have drained.",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.KoreanLocale]: {
     maintainer: "yuma@vm0.ai",
     description:
       "Allow ko-KR preference writes after incompatible API readers and rollback candidates have drained.",
-    enabled: false,
+    enabled: true,
     userOverridable: false,
   },
   [FeatureSwitchKey.IndonesianLocale]: {
     maintainer: "yuma@vm0.ai",
     description:
       "Allow id-ID preference writes after incompatible API readers and rollback candidates have drained.",
-    enabled: false,
+    enabled: true,
     userOverridable: false,
   },
   [FeatureSwitchKey.GermanLocale]: {
     maintainer: "yuma@vm0.ai",
     description:
       "Allow de-DE preference writes after incompatible API readers and rollback candidates have drained.",
-    enabled: false,
+    enabled: true,
     userOverridable: false,
   },
   [FeatureSwitchKey.SpanishLocale]: {
     maintainer: "linghan@vm0.ai",
     description:
       "Allow es-ES preference writes after incompatible API readers and rollback candidates have drained.",
-    enabled: false,
+    enabled: true,
     userOverridable: false,
   },
   [FeatureSwitchKey.ItalianLocale]: {
     maintainer: "linghan@vm0.ai",
     description:
       "Allow it-IT preference writes after incompatible API readers and rollback candidates have drained.",
-    enabled: false,
+    enabled: true,
     userOverridable: false,
   },
   [FeatureSwitchKey.FrenchLocale]: {
     maintainer: "yuma@vm0.ai",
     description:
       "Allow fr-FR preference writes after incompatible API readers and rollback candidates have drained.",
-    enabled: false,
+    enabled: true,
     userOverridable: false,
   },
   [FeatureSwitchKey.HindiLocale]: {
     maintainer: "yuma@vm0.ai",
     description:
       "Allow hi-IN preference writes after incompatible API readers and rollback candidates have drained.",
-    enabled: false,
+    enabled: true,
     userOverridable: false,
   },
   [FeatureSwitchKey.Banking]: {


### PR DESCRIPTION
## Summary

- enable all supported locale feature switches and API deployment rollout gates
- enable all locale gates in the local API environment template
- cap the language selector height and use the existing scroll behavior for long locale lists
- update locale rollout and settings integration coverage

## Testing

- bash .github/scripts/tests/web-api-env-action-test.sh
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feature-switches.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/misc-routes.bdd.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/settings-dialog.test.tsx
- lint and type checks for @vm0/core, api, and @vm0/app
- scoped Knip for @vm0/core, api, and @vm0/app
- full pre-commit Knip and TypeScript type checks