### PR TITLE
docs(python): document public destination denial response modes

### DIFF
--- a/crates/runner/mitm-addon/src/http_local_responses.py
+++ b/crates/runner/mitm-addon/src/http_local_responses.py
@@ -316,6 +316,15 @@ def block_public_destination_denied(
     reason: str,
     send_response: bool = True,
 ) -> None:
+    """Record a public-destination denial and optionally install its local response.
+
+    Both modes disable request streaming, record the DENY decision with the
+    ``unsafe_public_destination`` error and firewall base/name, and emit the redacted
+    public-destination proxy warning. When ``send_response`` is ``True``, this also installs
+    the JSON HTTP 403 response. When it is ``False``, the function leaves ``flow.response``
+    unchanged and does not terminate the flow; the caller must terminate it and prevent
+    later request dispatch.
+    """
     proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
     flow.request.stream = False
     flow_metadata.set_firewall_decision(


### PR DESCRIPTION
## Summary

- document the side effects shared by both public-destination denial response modes
- explain when the helper installs a JSON HTTP 403 and when it leaves the response unchanged
- make the no-response caller's termination and later-dispatch obligations explicit

## Scope

This changes documentation only. Runtime code, tests, APIs, persisted data, queue payloads, runner protocols, and deployment behavior are unchanged.

## Tests

- `cd crates/runner/mitm-addon && uv lock --check`
- `cd crates/runner/mitm-addon && uv sync --locked`
- `cd crates/runner/mitm-addon && uv run --no-sync ruff format --check .`
- `cd crates/runner/mitm-addon && uv run --no-sync ruff check .`
- `cd crates/runner/mitm-addon && uv run --no-sync basedpyright -p .`
- `cd crates/runner/mitm-addon && uv run --no-sync python -m pytest tests/` (4486 passed)

Closes #24167
