### PR TITLE
refactor(platform): remove optimistic event rollbacks

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -68,6 +68,14 @@ gh api repos/vm0-ai/vm0/contents/docs/testing.md --jq '.content' | base64 -d
 
 #### Surface-Specific Practice Documents
 
+Fetch the event-sourcing rules when the PR changes persistent or optimistic
+events, client-generated event IDs, event reconciliation, event projections, or
+frontend rollback behavior:
+
+```bash
+gh api repos/vm0-ai/vm0/contents/docs/event-sourcing.md --jq '.content' | base64 -d
+```
+
 Fetch the React and ccstate execution, cache, and lifecycle practices when the
 PR touches `turbo/apps/platform`, React, ccstate, `computed`, commands, Store,
 signals, caches, effects, refs, or resource lifecycles:
@@ -191,6 +199,14 @@ Review the diff for:
 
 - Check the changed code against every practice document selected in Step 4
 - Cite the relevant practice document and rule for each practice-based finding
+
+**Event Sourcing and Optimistic UI**
+
+- Persistent events are authoritative and reconcile optimistic events by their
+  shared event ID.
+- Do not require failure-path rollback, removal, timeout cleanup, or other
+  fallback cleanup for optimistic events. A rare transient mismatch is recovered
+  by refreshing the page and reloading persistent state.
 
 **Testing Coverage**
 
@@ -328,6 +344,7 @@ Review posted: https://github.com/vm0-ai/vm0/pull/<number>#pullrequestreview-<re
 
 - Documentation index: https://github.com/vm0-ai/vm0/blob/main/docs/docs.md
 - Production-code quality: https://github.com/vm0-ai/vm0/blob/main/docs/bad-smell.md
+- Event sourcing and optimistic events: https://github.com/vm0-ai/vm0/blob/main/docs/event-sourcing.md
 - Testing standards: https://github.com/vm0-ai/vm0/blob/main/docs/testing.md
 - React effects and ccstate commands: https://github.com/vm0-ai/vm0/blob/main/docs/effect.md
 - React and ccstate cache practices: https://github.com/vm0-ai/vm0/blob/main/docs/cache.md

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -7,6 +7,9 @@ surface; the index does not replace their detailed rules.
 ## Code Review
 
 - [Bad code smells](./bad-smell.md): production-code quality rules.
+- [Event sourcing and optimistic events](./event-sourcing.md): authoritative
+  persistent events, optimistic projections, reconciliation, and failure
+  semantics.
 - [React effects and ccstate commands](./effect.md): choosing between computed
   values, semantic commands, route setup, DOM lifecycles, and React effects.
 - [React and ccstate cache and lifecycle practices](./cache.md): render purity,

--- a/docs/event-sourcing.md
+++ b/docs/event-sourcing.md
@@ -1,0 +1,55 @@
+# Event Sourcing and Optimistic Events
+
+This guide defines how the frontend combines persistent events with optimistic
+events. It applies to event-sourced chat content, thread metadata, and other
+frontend projections that show a local event before the server round trip
+finishes.
+
+## Event Roles
+
+Persistent events are durable server facts. They have the server-owned ordering
+and are the authoritative input when the frontend rebuilds a projection from an
+event log or snapshot.
+
+Optimistic events are page-local projections created before persistence
+completes. They make an accepted user action visible immediately, but they are
+not a second source of truth and do not have server ordering.
+
+## Normal Reconciliation
+
+The frontend creates an event ID, appends an optimistic event with that ID, and
+passes the same ID to the server mutation. When the corresponding persistent
+event arrives through the normal event stream:
+
+1. The projection prefers the persistent event and filters out the optimistic
+   event with the same ID.
+2. Reconciliation removes that matching optimistic event from the page-local
+   buffer.
+
+This persistent-event match is the only in-session cleanup path for optimistic
+events. The persistent event remains authoritative even if it arrives through a
+later sync rather than the mutation response.
+
+## Failure Semantics
+
+The frontend must not remove or roll back an optimistic event merely because a
+request fails, aborts, times out, returns no persistent lifecycle event, or
+otherwise takes an exceptional path. Do not add error-handler cleanup,
+`finally` cleanup, fallback timers, or heuristics that guess whether an
+optimistic event should be deleted.
+
+These exceptional inconsistencies are rare. Maintaining a second rollback
+lifecycle for them adds defensive complexity and can remove an event that was
+persisted but has not reached the client yet. A stale optimistic projection is
+recoverable: refreshing the page discards page-local optimistic state and
+reloads the authoritative persistent state, restoring eventual consistency.
+
+## Review Checklist
+
+- The client-generated event ID is reused by the server mutation.
+- Persistent and optimistic projections deduplicate by that shared event ID.
+- Persistent events are the only normal trigger for removing matching
+  optimistic events.
+- Failure, cancellation, timeout, and missing-event paths do not imperatively
+  remove optimistic events.
+- A page refresh remains the recovery path for rare exceptional inconsistency.

--- a/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
@@ -68,7 +68,6 @@ export interface BrowserLifecycleOptimisticEvents {
       },
     ]
   >;
-  readonly remove$: Command<void, [string]>;
 }
 
 export interface BrowserSessionCardSignalsRegistry {
@@ -212,13 +211,7 @@ function createStartBrowserSignals({
     set(startingState$, false);
     if (started.ok) {
       set(sessionOverride$, started.value.body.browser);
-      if (optimisticEvents && started.value.body.lifecycleEventId === null) {
-        set(optimisticEvents.remove$, eventId);
-      }
       return;
-    }
-    if (optimisticEvents) {
-      set(optimisticEvents.remove$, eventId);
     }
     set(reload$);
   });
@@ -282,13 +275,7 @@ function createStopBrowserSignals({
     set(stoppingState$, false);
     if (stopped.ok) {
       set(sessionOverride$, stopped.value.body.browser);
-      if (optimisticEvents && stopped.value.body.lifecycleEventId === null) {
-        set(optimisticEvents.remove$, eventId);
-      }
       return;
-    }
-    if (optimisticEvents) {
-      set(optimisticEvents.remove$, eventId);
     }
     set(reload$);
   });

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -42,7 +42,6 @@ import {
   createOptimisticChatEventEntry,
   createOptimisticChatEventsForThread,
   reconcileOptimisticChatEvents$,
-  removeOptimisticChatEvent$,
   type OptimisticChatEventEntry,
   type OptimisticChatEventInput,
 } from "./optimistic-chat-events.ts";
@@ -2704,9 +2703,6 @@ function createBrowserLifecycleOptimisticEvents(
           },
         }),
       );
-    }),
-    remove$: command(({ set }, eventId): void => {
-      set(removeOptimisticChatEvent$, { threadId, eventId });
     }),
   };
 }

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-events.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-events.ts
@@ -45,22 +45,6 @@ export const appendOptimisticChatEvent$ = command(
   },
 );
 
-export const removeOptimisticChatEvent$ = command(
-  (
-    { set },
-    {
-      threadId,
-      eventId,
-    }: { readonly threadId: string; readonly eventId: string },
-  ) => {
-    set(internalOptimisticChatEvents$, (prev) => {
-      return prev.filter((entry) => {
-        return entry.threadId !== threadId || entry.event.id !== eventId;
-      });
-    });
-  },
-);
-
 export const reconcileOptimisticChatEvents$ = command(
   (
     { set },


### PR DESCRIPTION
## Summary

- remove the imperative frontend command for deleting optimistic chat events
- stop browser start and stop mutations from rolling back optimistic lifecycle events on failure or when no lifecycle event is persisted
- keep matching persistent events as the sole reconciliation path
- document persistent and optimistic event semantics and route relevant reviews through the new event-sourcing guidance

## Verification

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/thread-sidebar.test.tsx --maxWorkers=1` (19 passed)
- `pnpm exec prettier --check ../REVIEW.md ../docs/docs.md ../docs/event-sourcing.md`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `pnpm knip`
