### PR TITLE
refactor(platform): remove legacy oauth callback metadata fallback

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
@@ -171,7 +171,7 @@ export function parsePermissionActionUrl(
   if (!path) {
     return null;
   }
-  // TODO(#23823): Remove the legacy serialized-action query fallback.
+  // Historical permission links may use ref from before CLI 9.270.1.
   const connectorSlug =
     url.searchParams.get("connectorSlug") ?? url.searchParams.get("ref");
   const permission = url.searchParams.get("permission");

--- a/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
@@ -105,41 +105,34 @@ function addConnectorIconSearchParams(
   }
 }
 
-function connectorCallbackMetadataFromStorage(
+function connectorIconFromStorage(
   raw: string | null,
   connectorSlug: ConnectorSlug | null,
-): {
-  readonly connectorSlug: ConnectorSlug;
-  readonly icon: PublicConnectorCatalogIcon;
-} | null {
+): PublicConnectorCatalogIcon | undefined {
   if (!raw || !connectorSlug) {
-    return null;
+    return undefined;
   }
   const value = jsonParseOr<unknown>(raw, null);
-  if (typeof value !== "object" || value === null || !("icon" in value)) {
-    return null;
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("connectorSlug" in value) ||
+    !("icon" in value)
+  ) {
+    return undefined;
   }
-  // TODO(#23823): Remove the legacy callback metadata fallback.
-  const storedConnectorSlug =
-    "connectorSlug" in value
-      ? value.connectorSlug
-      : "connectorRef" in value
-        ? value.connectorRef
-        : undefined;
-  const parsedConnectorSlug =
-    connectorSlugSchema.safeParse(storedConnectorSlug);
+  const parsedConnectorSlug = connectorSlugSchema.safeParse(
+    value.connectorSlug,
+  );
   const parsedIcon = publicConnectorCatalogIconSchema.safeParse(value.icon);
   if (
     !parsedConnectorSlug.success ||
     parsedConnectorSlug.data !== connectorSlug ||
     !parsedIcon.success
   ) {
-    return null;
+    return undefined;
   }
-  return {
-    connectorSlug: parsedConnectorSlug.data,
-    icon: parsedIcon.data,
-  };
+  return parsedIcon.data;
 }
 
 function resultFromPath(
@@ -235,12 +228,12 @@ export const setupConnectorCallbackPage$ = command(
       callbackConnectorSlug === "custom" ? null : callbackConnectorSlug;
     const label = connectorLabel(callbackConnectorSlug);
     const searchParams = get(searchParams$);
-    const storedMetadata = connectorCallbackMetadataFromStorage(
+    const storedConnectorIcon = connectorIconFromStorage(
       get(connectorAppOauthCallbackMetadataRaw$),
       connectorSlug,
     );
     const connectorIcon =
-      connectorIconFromSearchParams(searchParams) ?? storedMetadata?.icon;
+      connectorIconFromSearchParams(searchParams) ?? storedConnectorIcon;
     const pathResult = resultFromPath(
       typeof params?.status === "string" ? params.status : undefined,
       searchParams,
@@ -301,7 +294,7 @@ export const setupConnectorCallbackPage$ = command(
       { connectorSlug: callbackConnectorSlug, status: result.status },
       resultSearchParams,
     );
-    if (storedMetadata) {
+    if (storedConnectorIcon) {
       set(clearConnectorAppOauthCallbackMetadata$);
     }
   },

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -37,7 +37,7 @@ export const permissionAllowAgentId$ = computed((get) => {
 
 export const permissionAllowConnectorSlug$ = computed((get) => {
   const searchParams = get(searchParams$);
-  // TODO(#23823): Remove the legacy serialized-action query fallback.
+  // Historical permission links may use ref from before CLI 9.270.1.
   return searchParams.get("connectorSlug") ?? searchParams.get("ref") ?? null;
 });
 

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -52,7 +52,7 @@ describe("permission allow page", () => {
 
     detachedSetupPage({
       context,
-      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=approve`,
+      path: `/agents/${agentId}/permissions?connectorSlug=slack&permission=admin.analytics%3Aread&action=approve`,
       user: {
         id: "test-user-123",
         fullName: "Dana Analyst",
@@ -224,7 +224,7 @@ describe("permission allow page", () => {
 
     detachedSetupPage({
       context,
-      path: `/agents/${agentId}/permissions?ref=hidden-connector&permission=hidden.permission&action=allow`,
+      path: `/agents/${agentId}/permissions?connectorSlug=hidden-connector&permission=hidden.permission&action=allow`,
       user: {
         id: "test-user-123",
         fullName: "Dana Analyst",
@@ -240,7 +240,7 @@ describe("permission allow page", () => {
     expect(screen.queryByText("Confirm")).not.toBeInTheDocument();
   });
 
-  it("lets a user deny a connector permission without an expiry choice", async () => {
+  it("lets a user deny a connector permission from a legacy ref URL", async () => {
     const agentId = "c0000000-0000-4000-a000-000000000002";
     let grants: UserPermissionGrantResponse[] = [
       {
@@ -359,7 +359,7 @@ describe("permission allow page", () => {
 
     detachedSetupPage({
       context,
-      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
+      path: `/agents/${agentId}/permissions?connectorSlug=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
       user: {
         id: "test-user-123",
         fullName: "Taylor Reviewer",
@@ -411,7 +411,7 @@ describe("permission allow page", () => {
 
     detachedSetupPage({
       context,
-      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
+      path: `/agents/${agentId}/permissions?connectorSlug=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
       user: {
         id: "test-user-123",
         fullName: "Taylor Reviewer",
@@ -461,7 +461,7 @@ describe("permission allow page", () => {
 
     detachedSetupPage({
       context,
-      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
+      path: `/agents/${agentId}/permissions?connectorSlug=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
       user: {
         id: "test-user-123",
         fullName: "Taylor Reviewer",
@@ -533,7 +533,7 @@ describe("permission allow page", () => {
 
     detachedSetupPage({
       context,
-      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
+      path: `/agents/${agentId}/permissions?connectorSlug=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
       user: {
         id: "test-user-123",
         fullName: "Taylor Reviewer",
@@ -580,7 +580,7 @@ describe("permission allow page", () => {
 
     detachedSetupPage({
       context,
-      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=deny`,
+      path: `/agents/${agentId}/permissions?connectorSlug=slack&permission=admin.analytics%3Aread&action=deny`,
       user: {
         id: "test-user-123",
         fullName: "Jordan Reviewer",
@@ -644,7 +644,7 @@ describe("permission allow page", () => {
 
     detachedSetupPage({
       context,
-      path: `/agents/${agentId}/permissions?ref=cloudflare&permission=__unknown__&action=allow&expiresIn=1h`,
+      path: `/agents/${agentId}/permissions?connectorSlug=cloudflare&permission=__unknown__&action=allow&expiresIn=1h`,
       user: {
         id: "test-user-123",
         fullName: "Casey Reviewer",
@@ -710,7 +710,7 @@ describe("permission allow page", () => {
 
     detachedSetupPage({
       context,
-      path: `/agents/${agentId}/permissions?ref=cloudflare&permission=__unknown__&action=allow&expiresIn=always`,
+      path: `/agents/${agentId}/permissions?connectorSlug=cloudflare&permission=__unknown__&action=allow&expiresIn=always`,
       user: {
         id: "test-user-123",
         fullName: "Riley Reviewer",
@@ -754,7 +754,7 @@ describe("permission allow page", () => {
 
     detachedSetupPage({
       context,
-      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
+      path: `/agents/${agentId}/permissions?connectorSlug=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
       user: {
         id: "test-user-123",
         fullName: "Avery Reviewer",
@@ -800,7 +800,7 @@ describe("permission allow page", () => {
 
     detachedSetupPage({
       context,
-      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
+      path: `/agents/${agentId}/permissions?connectorSlug=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
       user: {
         id: "test-user-123",
         fullName: "Quinn Reviewer",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -2235,8 +2235,8 @@ describe("chat event action cards", () => {
   it("renders and confirms multiple permission cards from one assistant event", async () => {
     mockNow();
     const user = userEvent.setup({ delay: null });
-    const createPermissionUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=google-sheets&permission=spreadsheets.create&action=allow&expiresIn=1h`;
-    const writePermissionUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=google-sheets&permission=values.write&action=allow&expiresIn=1h`;
+    const createPermissionUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=google-sheets&permission=spreadsheets.create&action=allow&expiresIn=1h`;
+    const writePermissionUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=google-sheets&permission=values.write&action=allow&expiresIn=1h`;
     const capturedPermissionGrantBodies: unknown[] = [];
 
     context.mocks.api(
@@ -2381,7 +2381,7 @@ describe("chat event action cards", () => {
     const user = userEvent.setup({ delay: null });
     const threadId = `${THREAD_ID}-single-permission`;
     const callbackPrompt = "Re-check Slack access, then continue";
-    const permissionUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=slack&permission=channels.read&action=allow&threadId=${threadId}&callbackPrompt=${encodeURIComponent(callbackPrompt)}`;
+    const permissionUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=slack&permission=channels.read&action=allow&threadId=${threadId}&callbackPrompt=${encodeURIComponent(callbackPrompt)}`;
     const sentPrompts: {
       prompt: string;
       threadId?: string;
@@ -2713,7 +2713,7 @@ describe("chat event action cards", () => {
   });
 
   it("fails closed when permission action metadata is hidden", async () => {
-    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=hidden-connector&permission=hidden.permission&action=allow&expiresIn=1h`;
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=hidden-connector&permission=hidden.permission&action=allow&expiresIn=1h`;
     context.mocks.api(
       zeroConnectorCatalogContract.permissions,
       ({ respond }) => {
@@ -2765,7 +2765,7 @@ describe("chat event action cards", () => {
 
   it("shows already allowed permission action cards as read-only after refresh", async () => {
     mockNow();
-    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=youtube&permission=videos.write&action=allow&expiresIn=24h`;
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=youtube&permission=videos.write&action=allow&expiresIn=24h`;
     let applyRequests = 0;
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
       return respond(200, [
@@ -2830,7 +2830,7 @@ describe("chat event action cards", () => {
 
   it("lets users re-confirm expired allow permission action cards", async () => {
     mockNow();
-    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=youtube&permission=videos.write&action=allow&expiresIn=24h`;
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=youtube&permission=videos.write&action=allow&expiresIn=24h`;
     let applyRequests = 0;
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
       return respond(200, [
@@ -2907,7 +2907,7 @@ describe("chat event action cards", () => {
   });
 
   it("shows already denied permission action cards as read-only after refresh", async () => {
-    const permissionDenyUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=slack&permission=admin.analytics%3Aread&action=deny`;
+    const permissionDenyUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=slack&permission=admin.analytics%3Aread&action=deny`;
     let applyRequests = 0;
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
       return respond(200, [
@@ -2969,7 +2969,7 @@ describe("chat event action cards", () => {
 
   it("reloads permission cards when a connectorPermissionUpdated event arrives", async () => {
     mockNow();
-    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=youtube&permission=videos.write&action=allow&expiresIn=24h`;
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=youtube&permission=videos.write&action=allow&expiresIn=24h`;
     let grantAllowed = false;
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
       return respond(
@@ -3220,7 +3220,7 @@ describe("chat event action cards", () => {
   it("automatically retries permission action loading before showing an error", async () => {
     mockNow();
     const user = userEvent.setup({ delay: null });
-    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=gmail&permission=messages.write&action=allow&expiresIn=1h`;
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=gmail&permission=messages.write&action=allow&expiresIn=1h`;
     let listRequests = 0;
     let capturedBody: unknown = null;
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
@@ -3315,7 +3315,7 @@ describe("chat event action cards", () => {
   });
 
   it("shows permission status loading outside the action button", async () => {
-    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=gmail&permission=messages.write&action=allow&expiresIn=1h`;
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=gmail&permission=messages.write&action=allow&expiresIn=1h`;
     let resolveList: () => void = () => {
       throw new Error("Permission grant list request did not start");
     };
@@ -3381,7 +3381,7 @@ describe("chat event action cards", () => {
   });
 
   it("does not retry non-transient permission action loading failures", async () => {
-    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=gmail&permission=messages.write&action=allow&expiresIn=1h`;
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=gmail&permission=messages.write&action=allow&expiresIn=1h`;
     let listRequests = 0;
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
       listRequests += 1;
@@ -3440,7 +3440,7 @@ describe("chat event action cards", () => {
 
   it("shows permission save failures outside the action button", async () => {
     const user = userEvent.setup({ delay: null });
-    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=gmail&permission=messages.write&action=allow&expiresIn=1h`;
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=gmail&permission=messages.write&action=allow&expiresIn=1h`;
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
       return respond(200, []);
     });
@@ -3502,7 +3502,7 @@ describe("chat event action cards", () => {
   it("keeps permission success visible while permission grants reload", async () => {
     mockNow();
     const user = userEvent.setup({ delay: null });
-    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=gmail&permission=messages.write&action=allow&expiresIn=1h`;
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=gmail&permission=messages.write&action=allow&expiresIn=1h`;
     let listRequests = 0;
     let storedGrants: UserPermissionGrantResponse[] = [];
     let resolveReload: () => void = () => {
@@ -3597,7 +3597,7 @@ describe("chat event action cards", () => {
   it("lets users change permission duration before confirming", async () => {
     mockNow();
     const user = userEvent.setup({ delay: null });
-    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`;
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`;
     let capturedBody: unknown = null;
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
       return respond(200, []);
@@ -3684,7 +3684,7 @@ describe("chat event action cards", () => {
   it("lets users confirm unknown endpoint permissions from assistant events", async () => {
     mockNow();
     const user = userEvent.setup({ delay: null });
-    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=cloudflare&permission=${UNKNOWN_PERMISSION_GRANT}&action=allow&expiresIn=1h`;
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=cloudflare&permission=${UNKNOWN_PERMISSION_GRANT}&action=allow&expiresIn=1h`;
     let capturedBody: unknown = null;
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
       return respond(200, []);
@@ -3767,7 +3767,7 @@ describe("chat event action cards", () => {
     });
   });
 
-  it("lets users deny a permission request from an assistant event", async () => {
+  it("lets users deny a historical ref permission action", async () => {
     const user = userEvent.setup({ delay: null });
     const permissionDenyUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=slack&permission=admin.analytics%3Aread&action=deny`;
     let grants: UserPermissionGrantResponse[] = [

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
@@ -64,77 +64,115 @@ describe("connector callback page", () => {
     });
   });
 
-  it.each([
-    {
-      metadataKind: "canonical",
-      metadata: {
+  it("forwards provider parameters with canonical callback metadata", async () => {
+    const githubIcon = createGithubIcon();
+    context.store.set(
+      setConnectorAppOauthCallbackMetadata$,
+      JSON.stringify({
         connectorSlug: "github",
-        connectorRef: "slack",
-        icon: createGithubIcon(),
+        icon: githubIcon,
+      }),
+    );
+    let observedQuery: Readonly<Record<string, string | undefined>> = {};
+    context.mocks.api(
+      connectorsSlugCallbackContract.callback,
+      ({ params, query, respond }) => {
+        expect(params.connectorSlug).toBe("github");
+        observedQuery = query;
+        return respond(200, {
+          status: "success",
+          username: "octocat",
+        });
       },
-    },
-    {
-      metadataKind: "legacy",
-      metadata: { connectorRef: "github", icon: createGithubIcon() },
-    },
-  ])(
-    "forwards provider parameters with $metadataKind callback metadata",
-    async ({ metadata }) => {
-      const githubIcon = metadata.icon;
-      context.store.set(
-        setConnectorAppOauthCallbackMetadata$,
-        JSON.stringify(metadata),
-      );
-      let observedQuery: Readonly<Record<string, string | undefined>> = {};
-      context.mocks.api(
-        connectorsSlugCallbackContract.callback,
-        ({ params, query, respond }) => {
-          expect(params.connectorSlug).toBe("github");
-          observedQuery = query;
-          return respond(200, {
-            status: "success",
-            username: "octocat",
-          });
-        },
-      );
+    );
 
-      detachedSetupPage({
-        context,
-        path: "/connectors/github/callback?code=oauth-code&state=oauth-state",
-        user: null,
-        session: null,
-      });
+    detachedSetupPage({
+      context,
+      path: "/connectors/github/callback?code=oauth-code&state=oauth-state",
+      user: null,
+      session: null,
+    });
 
-      const heading = await screen.findByRole("heading", {
-        name: "GitHub connected",
-      });
-      const connectorIcon = heading.parentElement?.querySelector("img");
-      if (!(connectorIcon instanceof HTMLImageElement)) {
-        throw new Error("GitHub connector icon not found");
-      }
-      expect(connectorIcon).toHaveAttribute("src", githubIcon.url);
-      expect(
-        screen.getByText("Connected as octocat. You can close this window."),
-      ).toBeInTheDocument();
-      expect(observedQuery).toMatchObject({
-        code: "oauth-code",
-        state: "oauth-state",
-        responseMode: "json",
-      });
-      await waitFor(() => {
-        expect(pathname()).toBe("/connectors/github/callback/success");
-      });
-      const resultSearchParams = new URLSearchParams(search());
-      expect(resultSearchParams.get("username")).toBe("octocat");
-      expect(resultSearchParams.get("iconUrl")).toBe(githubIcon.url);
-      expect(resultSearchParams.get("iconInvertInDarkMode")).toBe(
-        String(githubIcon.invertInDarkMode),
-      );
-      expect(resultSearchParams.get("iconScale")).toBe(
-        githubIcon.scale === undefined ? null : String(githubIcon.scale),
-      );
-    },
-  );
+    const heading = await screen.findByRole("heading", {
+      name: "GitHub connected",
+    });
+    const connectorIcon = heading.parentElement?.querySelector("img");
+    if (!(connectorIcon instanceof HTMLImageElement)) {
+      throw new Error("GitHub connector icon not found");
+    }
+    expect(connectorIcon).toHaveAttribute("src", githubIcon.url);
+    expect(
+      screen.getByText("Connected as octocat. You can close this window."),
+    ).toBeInTheDocument();
+    expect(observedQuery).toMatchObject({
+      code: "oauth-code",
+      state: "oauth-state",
+      responseMode: "json",
+    });
+    await waitFor(() => {
+      expect(pathname()).toBe("/connectors/github/callback/success");
+    });
+    const resultSearchParams = new URLSearchParams(search());
+    expect(resultSearchParams.get("username")).toBe("octocat");
+    expect(resultSearchParams.get("iconUrl")).toBe(githubIcon.url);
+    expect(resultSearchParams.get("iconInvertInDarkMode")).toBe(
+      String(githubIcon.invertInDarkMode),
+    );
+    expect(resultSearchParams.get("iconScale")).toBe(
+      githubIcon.scale === undefined ? null : String(githubIcon.scale),
+    );
+  });
+
+  it("ignores stale legacy callback metadata while completing the callback", async () => {
+    const legacyIcon = createGithubIcon();
+    context.store.set(
+      setConnectorAppOauthCallbackMetadata$,
+      JSON.stringify({
+        connectorRef: "github",
+        icon: legacyIcon,
+      }),
+    );
+    let observedQuery: Readonly<Record<string, string | undefined>> = {};
+    context.mocks.api(
+      connectorsSlugCallbackContract.callback,
+      ({ params, query, respond }) => {
+        expect(params.connectorSlug).toBe("github");
+        observedQuery = query;
+        return respond(200, {
+          status: "success",
+          username: "octocat",
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/connectors/github/callback?code=oauth-code&state=oauth-state",
+      user: null,
+      session: null,
+    });
+
+    const heading = await screen.findByRole("heading", {
+      name: "GitHub connected",
+    });
+    expect(heading.parentElement?.querySelector("img")).toBeNull();
+    expect(
+      screen.getByText("Connected as octocat. You can close this window."),
+    ).toBeInTheDocument();
+    expect(observedQuery).toMatchObject({
+      code: "oauth-code",
+      state: "oauth-state",
+      responseMode: "json",
+    });
+    await waitFor(() => {
+      expect(pathname()).toBe("/connectors/github/callback/success");
+    });
+    const resultSearchParams = new URLSearchParams(search());
+    expect(resultSearchParams.get("username")).toBe("octocat");
+    expect(resultSearchParams.get("iconUrl")).toBeNull();
+    expect(resultSearchParams.get("iconInvertInDarkMode")).toBeNull();
+    expect(resultSearchParams.get("iconScale")).toBeNull();
+  });
 
   it("renders the API failure result without retaining OAuth parameters", async () => {
     context.mocks.api(


### PR DESCRIPTION
## Summary

- accept only canonical `connectorSlug` callback metadata when restoring the
  connector icon
- ignore stale legacy callback metadata without affecting OAuth completion
- retain historical permission-action `ref` readers with an explicit
  compatibility rationale
- make canonical permission URLs the default Platform integration-test input
  while preserving focused legacy and precedence coverage

## Compatibility

- historical permission cards and direct links using `ref` remain supported
- stale callback metadata may no longer restore its icon, but route identity
  and callback completion are unchanged
- inert legacy browser values are not actively rewritten or deleted
- no API, CLI, database, schema, migration, backfill, runner, route, protocol,
  or feature-switch change

## Validation

- `pnpm exec prettier --check <changed files>`
- affected Platform page suites: 3 files, 59 tests passed
- full Platform suite: 122 files, 1338 tests passed
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app build`
- `pnpm knip --workspace @vm0/app`
- pre-commit full Knip and repository TypeScript checks
- `git diff --check` and exact legacy-input inventory

Closes #23823

Parent: #23814
