### PR TITLE
perf(api): clean up applied model usage observations

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/model-stats-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/model-stats-state.ts
@@ -149,6 +149,24 @@ export async function insertZeroTokenModelStatsObservation(
   });
 }
 
+export async function insertAppliedModelStatsObservations(
+  context: TestContext,
+  args: {
+    readonly idempotencyKeys: readonly string[];
+    readonly model: string;
+    readonly observedAt: Date;
+    readonly aggregatedAt: Date;
+  },
+): Promise<void> {
+  await postAction(context, {
+    action: "insert-applied-observations",
+    idempotency_keys: [...args.idempotencyKeys],
+    model: args.model,
+    observed_at: args.observedAt.toISOString(),
+    aggregated_at: args.aggregatedAt.toISOString(),
+  });
+}
+
 export async function deleteModelStatsObservations(
   context: TestContext,
   idempotencyKeys: readonly string[],

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -30,6 +30,7 @@ import {
   deleteModelStatsObservations,
   holdModelStatsAggregationLock,
   holdModelStatsObservationLock,
+  insertAppliedModelStatsObservations,
   insertZeroTokenModelStatsObservation,
   readModelStatsAggregationLockState,
   readModelStatsObservationLockState,
@@ -294,7 +295,7 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       2 + (Math.floor(seed / 84) % 26),
     );
     const aggregateAt = dayStart + 4 * HOUR_MS;
-    const mainObservedAt = dayStart + 2 * HOUR_MS + 10 * 60_000;
+    const mainObservedAt = dayStart + 3 * HOUR_MS + 10 * 60_000;
     const previousObservedAt = dayStart - DAY_MS + 22 * HOUR_MS + 30 * 60_000;
     const windowEndIso = new Date(aggregateAt).toISOString();
     const todayStartIso = new Date(dayStart).toISOString();
@@ -348,6 +349,9 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       0,
     );
     expect(baselineAggregate.body.updatedStats).toBeGreaterThanOrEqual(0);
+    expect(baselineAggregate.body.deletedObservations).toBeGreaterThanOrEqual(
+      0,
+    );
 
     const baseline = await api.readModelRankings("today");
     expect(baseline.headers.get("cache-control")).toBe(
@@ -508,10 +512,6 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
           aggregatedAt: windowEndIso,
         },
         {
-          idempotencyKey: previousIdempotencyKey,
-          aggregatedAt: windowEndIso,
-        },
-        {
           idempotencyKey: zeroTokenIdempotencyKey,
           aggregatedAt: windowEndIso,
         },
@@ -521,6 +521,11 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
         },
       ]),
     );
+    expect(
+      initialObservationStates.some((observation) => {
+        return observation.idempotencyKey === previousIdempotencyKey;
+      }),
+    ).toBeFalsy();
 
     // A delayed delivery in an already-processed hour remains pending and is
     // added exactly once by the next cron request.
@@ -616,12 +621,7 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     });
     await expect(
       readModelStatsObservations(context, [oldPendingIdempotencyKey]),
-    ).resolves.toStrictEqual([
-      {
-        idempotencyKey: oldPendingIdempotencyKey,
-        aggregatedAt: windowEndIso,
-      },
-    ]);
+    ).resolves.toStrictEqual([]);
     await expect(api.readModelRankings("today")).resolves.toMatchObject({
       body: reprocessed.body,
     });
@@ -820,22 +820,19 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     );
 
     const resumed = await api.requestAggregateModelStats("valid", [200]);
-    expect(resumed.body).toStrictEqual({
+    expect(resumed.body).toMatchObject({
       success: true,
       cutoff: windowEndIso,
       processedHours: 1,
       processedObservations: 1,
       updatedStats: 0,
     });
+    expect(resumed.body.deletedObservations).toBeGreaterThanOrEqual(2);
     const resumedStates = await readModelStatsObservations(context, [
       firstCancellationIdempotencyKey,
       secondCancellationIdempotencyKey,
     ]);
-    expect(
-      resumedStates.every((observation) => {
-        return observation.aggregatedAt === windowEndIso;
-      }),
-    ).toBeTruthy();
+    expect(resumedStates).toStrictEqual([]);
 
     // A failed increment must roll back every statistic mutation. 1,024 maximum
     // safe integers still fit in PostgreSQL bigint; the 1,025th overflows SUM.
@@ -906,8 +903,8 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       }),
     );
 
-    // Applied observations remain retained during the incremental soak. A
-    // later run processes the formerly current hour without deleting history.
+    // A later run processes the formerly current hour before cleaning every
+    // applied observation whose receipt-time retry lifetime has expired.
     const laterAggregateAt = dayStart + 33 * DAY_MS + 4 * HOUR_MS;
     mockNow(laterAggregateAt);
     const laterProcessing = await api.requestAggregateModelStats(
@@ -923,7 +920,8 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       1,
     );
     expect(laterProcessing.body.updatedStats).toBeGreaterThanOrEqual(1);
-    const retainedStates = await readModelStatsObservations(context, [
+    expect(laterProcessing.body.deletedObservations).toBeGreaterThanOrEqual(5);
+    const cleanedStates = await readModelStatsObservations(context, [
       compactIdempotencyKey,
       previousIdempotencyKey,
       zeroTokenIdempotencyKey,
@@ -934,12 +932,7 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       firstCancellationIdempotencyKey,
       secondCancellationIdempotencyKey,
     ]);
-    expect(retainedStates).toHaveLength(9);
-    expect(
-      retainedStates.every((observation) => {
-        return observation.aggregatedAt !== null;
-      }),
-    ).toBeTruthy();
+    expect(cleanedStates).toStrictEqual([]);
 
     mockNow(aggregateAt);
     const noOp = await api.requestAggregateModelStats("valid", [200]);
@@ -949,9 +942,204 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       processedHours: 0,
       processedObservations: 0,
       updatedStats: 0,
+      deletedObservations: 0,
     });
     const unchanged = await api.readModelRankings("today");
     expect(unchanged.body).toStrictEqual(afterConcurrent.body);
+  });
+
+  it("cleans expired applied observations in bounded batches", async () => {
+    const api = createOpsLogsApi(context);
+    const runs = createRunsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const model = "claude-sonnet-4-6";
+    const seed = Number.parseInt(randomUUID().slice(0, 8), 16);
+    const dayStart = Date.UTC(
+      1970 + (seed % 7),
+      Math.floor(seed / 7) % 12,
+      2 + (Math.floor(seed / 84) % 26),
+    );
+    const exactBoundaryObservedAt = dayStart + 3 * HOUR_MS + 15 * 60_000;
+    const overBoundaryObservedAt = exactBoundaryObservedAt - 1;
+    const underBoundaryObservedAt = exactBoundaryObservedAt + 1;
+    const projectionAt = dayStart + 4 * HOUR_MS;
+    const cleanupAt = exactBoundaryObservedAt + HOUR_MS;
+    const oldPendingAt = cleanupAt - 769 * HOUR_MS;
+    const fixtureObservationKeys: string[] = [];
+
+    onTestFinished(async () => {
+      if (fixtureObservationKeys.length > 0) {
+        await deleteModelStatsFixture(context, {
+          idempotencyKeys: fixtureObservationKeys,
+          models: [model],
+          windowStart: new Date(oldPendingAt - HOUR_MS),
+          windowEnd: new Date(dayStart + DAY_MS),
+        });
+      }
+    });
+
+    const { actor, agentId } = await entitledRunActor();
+    const created = await runs.createRun(actor, {
+      agentId,
+      prompt: "clean model usage observations",
+      modelProvider: "anthropic-api-key",
+    });
+    const sandboxHeaders = {
+      authorization: `Bearer ${runs.sandboxTokenForRun(actor, created.runId)}`,
+    };
+    await runs.requestCancelRun(actor, created.runId, [200]);
+
+    async function sendObservation(
+      idempotencyKey: string,
+      inputTokens: number,
+    ): Promise<void> {
+      await webhooks.requestAgentModelUsageObservationV2(
+        {
+          runId: created.runId,
+          events: [
+            {
+              idempotencyKey,
+              model,
+              inputTokens,
+              outputTokens: 0,
+              cacheReadInputTokens: 0,
+              cacheCreationInputTokens: 0,
+            },
+          ],
+        },
+        sandboxHeaders,
+        [200],
+      );
+    }
+
+    mockNow(projectionAt);
+    await api.requestAggregateModelStats("valid", [200]);
+
+    const overBoundaryIdempotencyKey = randomUUID();
+    const exactBoundaryIdempotencyKey = randomUUID();
+    const underBoundaryIdempotencyKey = randomUUID();
+    fixtureObservationKeys.push(
+      overBoundaryIdempotencyKey,
+      exactBoundaryIdempotencyKey,
+      underBoundaryIdempotencyKey,
+    );
+
+    mockNow(overBoundaryObservedAt);
+    await sendObservation(overBoundaryIdempotencyKey, 11);
+    mockNow(exactBoundaryObservedAt);
+    await sendObservation(exactBoundaryIdempotencyKey, 13);
+    mockNow(underBoundaryObservedAt);
+    await sendObservation(underBoundaryIdempotencyKey, 17);
+
+    mockNow(projectionAt);
+    const projected = await api.requestAggregateModelStats("valid", [200]);
+    expect(projected.body).toMatchObject({
+      success: true,
+      cutoff: new Date(projectionAt).toISOString(),
+      processedHours: 1,
+      processedObservations: 3,
+      updatedStats: 1,
+      deletedObservations: 0,
+    });
+    const rankingBeforeCleanup = await api.readModelRankings("today");
+
+    // A retry after projection but within one hour still finds the original
+    // UUID ledger row and cannot create new pending work.
+    await sendObservation(exactBoundaryIdempotencyKey, 13);
+    await expect(
+      readModelStatsObservations(context, [exactBoundaryIdempotencyKey]),
+    ).resolves.toStrictEqual([
+      {
+        idempotencyKey: exactBoundaryIdempotencyKey,
+        aggregatedAt: new Date(projectionAt).toISOString(),
+      },
+    ]);
+
+    const oldPendingIdempotencyKey = randomUUID();
+    fixtureObservationKeys.push(oldPendingIdempotencyKey);
+    mockNow(oldPendingAt);
+    await sendObservation(oldPendingIdempotencyKey, 19);
+
+    mockNow(cleanupAt);
+    const cleaned = await api.requestAggregateModelStats("valid", [200]);
+    expect(cleaned.body).toStrictEqual({
+      success: true,
+      cutoff: new Date(dayStart + 4 * HOUR_MS).toISOString(),
+      processedHours: 1,
+      processedObservations: 1,
+      updatedStats: 1,
+      deletedObservations: 2,
+    });
+    const boundaryStates = await readModelStatsObservations(context, [
+      overBoundaryIdempotencyKey,
+      exactBoundaryIdempotencyKey,
+      underBoundaryIdempotencyKey,
+      oldPendingIdempotencyKey,
+    ]);
+    expect(boundaryStates).toHaveLength(2);
+    expect(boundaryStates).toStrictEqual(
+      expect.arrayContaining([
+        {
+          idempotencyKey: exactBoundaryIdempotencyKey,
+          aggregatedAt: new Date(projectionAt).toISOString(),
+        },
+        {
+          idempotencyKey: underBoundaryIdempotencyKey,
+          aggregatedAt: new Date(projectionAt).toISOString(),
+        },
+      ]),
+    );
+    const rankingAfterCleanup = await api.readModelRankings("today");
+    expect(rankingAfterCleanup.body).toStrictEqual(rankingBeforeCleanup.body);
+
+    // Once the one-hour guarantee has expired and cleanup removed the ledger
+    // row, the same UUID is accepted as a new current-hour observation.
+    await sendObservation(overBoundaryIdempotencyKey, 11);
+    await expect(
+      readModelStatsObservations(context, [overBoundaryIdempotencyKey]),
+    ).resolves.toStrictEqual([
+      {
+        idempotencyKey: overBoundaryIdempotencyKey,
+        aggregatedAt: null,
+      },
+    ]);
+
+    const cleanupBatchIdempotencyKeys = Array.from({ length: 10_001 }, () => {
+      return randomUUID();
+    });
+    fixtureObservationKeys.push(...cleanupBatchIdempotencyKeys);
+    await insertAppliedModelStatsObservations(context, {
+      idempotencyKeys: cleanupBatchIdempotencyKeys,
+      model,
+      observedAt: new Date(dayStart + 2 * HOUR_MS),
+      aggregatedAt: new Date(projectionAt),
+    });
+
+    const firstBatch = await api.requestAggregateModelStats("valid", [200]);
+    expect(firstBatch.body).toStrictEqual({
+      success: true,
+      cutoff: new Date(dayStart + 4 * HOUR_MS).toISOString(),
+      processedHours: 0,
+      processedObservations: 0,
+      updatedStats: 0,
+      deletedObservations: 10_000,
+    });
+    await expect(
+      readModelStatsObservations(context, cleanupBatchIdempotencyKeys),
+    ).resolves.toHaveLength(1);
+
+    const finalBatch = await api.requestAggregateModelStats("valid", [200]);
+    expect(finalBatch.body).toStrictEqual({
+      success: true,
+      cutoff: new Date(dayStart + 4 * HOUR_MS).toISOString(),
+      processedHours: 0,
+      processedObservations: 0,
+      updatedStats: 0,
+      deletedObservations: 1,
+    });
+    await expect(
+      readModelStatsObservations(context, cleanupBatchIdempotencyKeys),
+    ).resolves.toStrictEqual([]);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/model-stats.ts
+++ b/turbo/apps/api/src/signals/routes/model-stats.ts
@@ -75,6 +75,7 @@ const aggregateModelStatsRoute$ = command(
         processedHours: result.processedHours,
         processedObservations: result.processedObservations,
         updatedStats: result.updatedStats,
+        deletedObservations: result.deletedObservations,
       },
     };
   },

--- a/turbo/apps/api/src/signals/routes/test-model-stats-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-model-stats-state.ts
@@ -22,6 +22,7 @@ import {
 } from "./test-oauth-provider-helpers";
 
 const actionBody$ = bodyResultOf(testModelStatsStateContract.action);
+const OBSERVATION_FIXTURE_INSERT_BATCH_SIZE = 5000;
 
 interface ModelStatsAggregationLockGate {
   holderPid: number | null;
@@ -250,6 +251,44 @@ async function insertZeroTokenObservation(
   signal.throwIfAborted();
 }
 
+async function insertAppliedObservations(
+  db: Db,
+  body: Extract<
+    TestModelStatsStateActionBody,
+    { action: "insert-applied-observations" }
+  >,
+  signal: AbortSignal,
+): Promise<void> {
+  const observedAt = new Date(body.observed_at);
+  const aggregatedAt = new Date(body.aggregated_at);
+
+  for (
+    let offset = 0;
+    offset < body.idempotency_keys.length;
+    offset += OBSERVATION_FIXTURE_INSERT_BATCH_SIZE
+  ) {
+    const idempotencyKeys = body.idempotency_keys.slice(
+      offset,
+      offset + OBSERVATION_FIXTURE_INSERT_BATCH_SIZE,
+    );
+    await db.insert(modelUsageObservation).values(
+      idempotencyKeys.map((idempotencyKey) => {
+        return {
+          idempotencyKey,
+          model: body.model,
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadInputTokens: 0,
+          cacheCreationInputTokens: 0,
+          observedAt,
+          aggregatedAt,
+        };
+      }),
+    );
+    signal.throwIfAborted();
+  }
+}
+
 async function deleteFixture(
   db: Db,
   body: Extract<TestModelStatsStateActionBody, { action: "delete-fixture" }>,
@@ -334,6 +373,10 @@ async function mutateModelStatsState(
     }
     case "insert-zero-token-observation": {
       await insertZeroTokenObservation(db, body, signal);
+      return { status: 200 as const, body: { ok: true as const } };
+    }
+    case "insert-applied-observations": {
+      await insertAppliedObservations(db, body, signal);
       return { status: 200 as const, body: { ok: true as const } };
     }
     case "delete-observations": {

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -1,12 +1,14 @@
 import { command } from "ccstate";
 import {
   and,
+  asc,
   count,
   desc,
   eq,
   gt,
   gte,
   inArray,
+  isNotNull,
   isNull,
   lt,
   or,
@@ -37,6 +39,8 @@ import { nowDate } from "../external/time";
 import { lockModelStatsAggregation } from "./model-stats-aggregation-lock.service";
 
 const HOUR_MS = 60 * 60_000;
+const MODEL_USAGE_OBSERVATION_CLEANUP_BATCH_SIZE = 1000;
+const MODEL_USAGE_OBSERVATION_CLEANUP_MAX_BATCHES = 10;
 export const MODEL_RANKING_PERIODS = ["today", "week", "month"] as const;
 const L = logger("CronAggregateModelStats");
 
@@ -74,6 +78,7 @@ interface ModelStatsProcessingResult {
   readonly processedHours: number;
   readonly processedObservations: number;
   readonly updatedStats: number;
+  readonly deletedObservations: number;
 }
 
 interface ModelStatsHourProcessingResult {
@@ -373,6 +378,51 @@ async function processOldestPendingModelStatsHour(
   return result;
 }
 
+async function cleanupAppliedModelUsageObservations(
+  db: Db,
+  cutoff: Date,
+  signal: AbortSignal,
+): Promise<number> {
+  let deletedObservations = 0;
+
+  for (
+    let batch = 0;
+    batch < MODEL_USAGE_OBSERVATION_CLEANUP_MAX_BATCHES;
+    batch += 1
+  ) {
+    signal.throwIfAborted();
+    const candidates = db
+      .select({
+        idempotencyKey: modelUsageObservation.idempotencyKey,
+      })
+      .from(modelUsageObservation)
+      .where(
+        and(
+          isNotNull(modelUsageObservation.aggregatedAt),
+          lt(modelUsageObservation.observedAt, cutoff),
+        ),
+      )
+      .orderBy(
+        asc(modelUsageObservation.observedAt),
+        asc(modelUsageObservation.idempotencyKey),
+      )
+      .limit(MODEL_USAGE_OBSERVATION_CLEANUP_BATCH_SIZE)
+      .for("update", { skipLocked: true });
+    const { rowCount } = await db
+      .delete(modelUsageObservation)
+      .where(inArray(modelUsageObservation.idempotencyKey, candidates));
+    signal.throwIfAborted();
+
+    const batchDeleted = rowCount ?? 0;
+    deletedObservations += batchDeleted;
+    if (batchDeleted < MODEL_USAGE_OBSERVATION_CLEANUP_BATCH_SIZE) {
+      break;
+    }
+  }
+
+  return deletedObservations;
+}
+
 async function selectModelRankings(
   db: Db,
   period: ModelRankingPeriod,
@@ -472,6 +522,7 @@ export const aggregateModelStats$ = command(
     const startedAt = performance.now();
     const processedAt = nowDate();
     const cutoff = utcHourStart(processedAt);
+    const cleanupCutoff = new Date(processedAt.getTime() - HOUR_MS);
     let processedHours = 0;
     let processedObservations = 0;
     let updatedStats = 0;
@@ -498,9 +549,17 @@ export const aggregateModelStats$ = command(
       updatedStats += result.updatedStats;
     }
 
+    const deletedObservations = await cleanupAppliedModelUsageObservations(
+      db,
+      cleanupCutoff,
+      signal,
+    );
+    signal.throwIfAborted();
+
     const durationMs = Math.round(performance.now() - startedAt);
     L.debug("model stats processing completed", {
       cutoff: cutoff.toISOString(),
+      cleanupCutoff: cleanupCutoff.toISOString(),
       firstProcessedHour: firstProcessedHour?.toISOString() ?? null,
       lastProcessedHour: lastProcessedHour?.toISOString() ?? null,
       oldestCompleteBacklogAgeHours:
@@ -510,6 +569,7 @@ export const aggregateModelStats$ = command(
       processedHours,
       processedObservations,
       updatedStats,
+      deletedObservations,
       remainingCompletePendingObservations: 0,
       durationMs,
     });
@@ -519,6 +579,7 @@ export const aggregateModelStats$ = command(
       processedHours,
       processedObservations,
       updatedStats,
+      deletedObservations,
     };
   },
 );

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -209,6 +209,7 @@ const cronAggregateModelStatsResponseSchema = z.object({
   processedHours: z.number().int().nonnegative(),
   processedObservations: z.number().int().nonnegative(),
   updatedStats: z.number().int().nonnegative(),
+  deletedObservations: z.number().int().nonnegative(),
 });
 
 export const cronAggregateUsageContract = c.router({

--- a/turbo/packages/api-contracts/src/contracts/test-model-stats-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-model-stats-state.ts
@@ -39,6 +39,13 @@ export const testModelStatsStateActionBodySchema = z.discriminatedUnion(
       observed_at: z.iso.datetime(),
     }),
     z.object({
+      action: z.literal("insert-applied-observations"),
+      idempotency_keys: idempotencyKeysSchema,
+      model: z.string(),
+      observed_at: z.iso.datetime(),
+      aggregated_at: z.iso.datetime(),
+    }),
+    z.object({
       action: z.literal("delete-observations"),
       idempotency_keys: idempotencyKeysSchema,
     }),


### PR DESCRIPTION
## Summary

- run applied-observation cleanup after incremental projection completes
- delete oldest eligible rows in 1,000-row `SKIP LOCKED` batches, capped at
  10,000 rows per cron invocation
- expose committed cleanup progress as `deletedObservations`
- cover the strict one-hour boundary, pending-first projection, UUID expiry,
  unchanged rankings, and bounded progress through the real API and PostgreSQL

## Scope

- no database schema or index change
- no runner, billing, ranking-window, cache, or model-selection change
- no cleanup retry wrapper, feature switch, environment setting, or separate
  endpoint

## Rollout gate

Do not merge until #23962 records:

- all replacement-style API versions drained
- repeated incremental cron runs with no growing complete-hour pending backlog
- retained-source reconciliation matching `model_stat`
- production peak hourly ingestion below the 10,000-row invocation capacity
  (or revised constants and tests)
- the before-cleanup database baseline and #24078 as the rollback target

## Validation

- `pnpm format`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/ops-logs.bdd.test.ts --silent=passed-only`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts test -- --silent=passed-only`
- `pnpm knip --workspace api --workspace @vm0/api-contracts`
- pre-commit full Knip and Turbo type checks

Closes #24079

Parent: #23962
