### PR TITLE
fix(runner): stop when dnsmasq exits

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -58,7 +58,7 @@ use crate::http::{HttpClient, HttpClientConfig};
 use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkingGate};
 use crate::kmsg_log;
 use crate::lock;
-use crate::network_log_drain::NetworkLogDrainCoordinator;
+use crate::network_log_drain::{DrainableLineReaderExit, NetworkLogDrainCoordinator};
 use crate::network_log_manager::NetworkLogManager;
 use crate::paths::{HomePaths, LogPaths, RunnerPaths, touch_mtime};
 use crate::prefetch;
@@ -1188,7 +1188,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     } = proxy;
     let ShutdownHandles {
         mut kmsg_handle,
-        dns_handle,
+        mut dns_handle,
         mut memory_prefetch,
     } = shutdown;
 
@@ -1589,6 +1589,47 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     ).await;
                 }
                 kmsg_handle.kill_and_reap_child().await;
+            }
+            result = dns_handle.wait() => {
+                let mode = lifecycle.current_mode();
+                if !matches!(mode, RunnerMode::Stopping | RunnerMode::Stopped) {
+                    let message = match &result {
+                        Ok(DrainableLineReaderExit::Cancelled) => {
+                            "dns monitor exited unexpectedly: Cancelled".to_string()
+                        }
+                        Ok(DrainableLineReaderExit::DrainChannelClosed) => {
+                            "dns monitor exited unexpectedly: DrainChannelClosed".to_string()
+                        }
+                        Ok(DrainableLineReaderExit::Eof { during_drain }) => {
+                            format!(
+                                "dns monitor exited unexpectedly: Eof {{ during_drain: {during_drain} }}"
+                            )
+                        }
+                        Ok(DrainableLineReaderExit::ReadError {
+                            during_drain,
+                            error,
+                        }) => {
+                            format!(
+                                "dns monitor exited unexpectedly: ReadError {{ during_drain: {during_drain}, error: {error} }}"
+                            )
+                        }
+                        Err(error) => format!("dns monitor task failed: {error}"),
+                    };
+                    error!(
+                        component = "dns",
+                        ?mode,
+                        result = ?result,
+                        "required runner component exited"
+                    );
+                    terminal_error = Some(RunnerError::Internal(message));
+                    handle_stopping_signal(
+                        "dns-monitor",
+                        &provider_state.cancel,
+                        &provider_state.cancel_tokens,
+                        &lifecycle,
+                    ).await;
+                }
+                dns_handle.kill_and_reap_child().await;
             }
             // Reap completed jobs promptly in all live modes. Without this,
             // normal Running mode can retain completed JoinSet entries and

--- a/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
@@ -113,7 +113,7 @@ async fn kmsg_stdout_eof_stops_runner_and_reaps_child_before_teardown() {
         !run_handle.is_finished(),
         "blocked final heartbeat should hold teardown open",
     );
-    assert_kmsg_child_reaped(pid, starttime).await;
+    assert_child_reaped("kmsg", pid, starttime).await;
     assert!(env.cancel.is_cancelled(), "kmsg EOF should stop discovery");
 
     env.handle.unblock_heartbeats();
@@ -137,7 +137,7 @@ async fn kmsg_stdout_read_error_stops_runner_and_kills_child() {
             .await,
         "kmsg read error should drive runner teardown",
     );
-    assert_kmsg_child_reaped(pid, starttime).await;
+    assert_child_reaped("kmsg", pid, starttime).await;
 
     env.handle.unblock_heartbeats();
     assert_run_error_contains(run_handle, "ReadError").await;
@@ -158,7 +158,79 @@ async fn normal_shutdown_cancels_kmsg_and_reaps_child_without_error() {
         "normal hard shutdown should stop the kmsg monitor",
     )
     .await;
-    assert_kmsg_child_reaped(pid, starttime).await;
+    assert_child_reaped("kmsg", pid, starttime).await;
+}
+
+#[tokio::test]
+async fn dns_stderr_eof_stops_runner_and_reaps_child_before_teardown() {
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let (stdin, pid, starttime) = install_controllable_dns(&mut config).await;
+    env.handle.block_heartbeats();
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    drop(stdin);
+
+    assert!(
+        env.handle
+            .wait_heartbeat_in_flight(1, Duration::from_secs(2))
+            .await,
+        "dns EOF should drive runner teardown",
+    );
+    assert!(
+        !run_handle.is_finished(),
+        "blocked final heartbeat should hold teardown open",
+    );
+    assert_child_reaped("dns", pid, starttime).await;
+    assert!(env.cancel.is_cancelled(), "dns EOF should stop discovery");
+
+    env.handle.unblock_heartbeats();
+    assert_run_error_contains(run_handle, "dns monitor exited unexpectedly: Eof").await;
+}
+
+#[tokio::test]
+async fn dns_stderr_read_error_stops_runner_and_kills_child() {
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let (mut stdin, pid, starttime) = install_controllable_dns(&mut config).await;
+    env.handle.block_heartbeats();
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    stdin.write_all(&[0xff, b'\n']).await.unwrap();
+    stdin.flush().await.unwrap();
+
+    assert!(
+        env.handle
+            .wait_heartbeat_in_flight(1, Duration::from_secs(2))
+            .await,
+        "dns read error should drive runner teardown",
+    );
+    assert_child_reaped("dns", pid, starttime).await;
+    assert!(
+        env.cancel.is_cancelled(),
+        "dns read error should stop discovery",
+    );
+
+    env.handle.unblock_heartbeats();
+    assert_run_error_contains(run_handle, "ReadError").await;
+}
+
+#[tokio::test]
+async fn normal_shutdown_cancels_dns_and_reaps_child_without_error() {
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let (_stdin, pid, starttime) = install_controllable_dns(&mut config).await;
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    env.trigger_stopping().await;
+
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(3),
+        "normal hard shutdown should stop the dns monitor",
+    )
+    .await;
+    assert_child_reaped("dns", pid, starttime).await;
 }
 
 /// SIGTERM while a job is in flight: per-job cancellation fires, the
@@ -365,14 +437,37 @@ async fn install_controllable_kmsg(
     (stdin, pid, starttime)
 }
 
-async fn assert_kmsg_child_reaped(pid: u32, starttime: u64) {
+async fn install_controllable_dns(
+    config: &mut RunConfig,
+) -> (tokio::process::ChildStdin, u32, u64) {
+    let mut child = tokio::process::Command::new("sh")
+        .args(["-c", "exec cat >&2"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn controllable dns child");
+    let stdin = child.stdin.take().expect("capture test child stdin");
+    let pid = child.id().expect("test child pid");
+    let starttime = crate::process::read_process_stat(pid)
+        .await
+        .expect("test child should be visible in procfs")
+        .starttime;
+    config.shutdown.dns_handle =
+        crate::dns::DnsProxy::from_test_child(child, NetworkLogManager::new())
+            .await
+            .expect("create test dns handle");
+    (stdin, pid, starttime)
+}
+
+async fn assert_child_reaped(component: &str, pid: u32, starttime: u64) {
     let observed_starttime = crate::process::read_process_stat(pid)
         .await
         .map(|stat| stat.starttime);
     assert_ne!(
         observed_starttime,
         Some(starttime),
-        "kmsg child pid {pid} with start time {starttime} was not reaped",
+        "{component} child pid {pid} with start time {starttime} was not reaped",
     );
 }
 
@@ -385,10 +480,10 @@ async fn assert_run_error_contains(
         Err(_) => {
             run_handle.abort();
             let _ = run_handle.await;
-            panic!("runner did not finish after kmsg failure");
+            panic!("runner did not finish after required component failure");
         }
     };
-    let error = result.expect_err("kmsg failure should return a runner error");
+    let error = result.expect_err("required component failure should return a runner error");
     assert!(
         error.to_string().contains(expected),
         "expected error containing {expected:?}, got {error}",

--- a/crates/runner/src/dns/log.rs
+++ b/crates/runner/src/dns/log.rs
@@ -8,7 +8,6 @@ use sandbox_fc::DNS_READINESS_HOSTNAME;
 use tokio::io::{AsyncBufRead, AsyncReadExt, AsyncSeekExt};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
 
 use crate::network_log_drain::{
     DrainableLineReaderExit, NetworkLogDrainRequest, run_drainable_line_reader,
@@ -72,7 +71,7 @@ pub(super) async fn tail_stderr(
     network_log_manager: NetworkLogManager,
     cancel: CancellationToken,
     drain_rx: mpsc::Receiver<NetworkLogDrainRequest>,
-) -> std::io::Result<()> {
+) -> DrainableLineReaderExit {
     tail_reader(
         tokio::io::BufReader::new(stderr),
         network_log_manager,
@@ -87,38 +86,17 @@ async fn tail_reader<R>(
     network_log_manager: NetworkLogManager,
     cancel: CancellationToken,
     drain_rx: mpsc::Receiver<NetworkLogDrainRequest>,
-) -> std::io::Result<()>
+) -> DrainableLineReaderExit
 where
     R: AsyncBufRead + Unpin,
 {
-    let exit = run_drainable_line_reader(reader, cancel.clone(), drain_rx, move |line| {
+    run_drainable_line_reader(reader, cancel, drain_rx, move |line| {
         let network_log_manager = network_log_manager.clone();
         async move {
             handle_dns_line(&network_log_manager, &line).await;
         }
     })
-    .await;
-
-    match exit {
-        DrainableLineReaderExit::Cancelled | DrainableLineReaderExit::DrainChannelClosed => Ok(()),
-        DrainableLineReaderExit::Eof { during_drain } => {
-            if !during_drain && !cancel.is_cancelled() {
-                warn!("dnsmasq exited unexpectedly (stderr EOF)");
-            }
-            Ok(())
-        }
-        DrainableLineReaderExit::ReadError {
-            during_drain,
-            error,
-        } => {
-            if during_drain {
-                Err(error)
-            } else {
-                warn!(error = %error, "dnsmasq stderr read error");
-                Ok(())
-            }
-        }
-    }
+    .await
 }
 
 async fn handle_dns_line(network_log_manager: &NetworkLogManager, line: &str) {
@@ -421,13 +399,10 @@ fn network_log_row(entry: &DnsLogEntry<'_>, timestamp: DateTime<Utc>) -> serde_j
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
 
     use crate::ids::RunId;
     use crate::network_log_drain::{NetworkLogDrainContext, NetworkLogDrainProducer};
-    use tokio::io::{AsyncBufRead, AsyncRead, AsyncWriteExt, ReadBuf};
+    use tokio::io::AsyncWriteExt;
 
     fn assert_query_event(entry: &DnsLogEntry<'_>, expected_query_type: &str) {
         assert_eq!(entry.event.name(), "query");
@@ -931,59 +906,10 @@ mod tests {
         assert_eq!(parsed["dns_event"], "query");
 
         cancel.cancel();
+        assert!(matches!(
+            task.await.unwrap(),
+            DrainableLineReaderExit::Cancelled
+        ));
         drop(writer);
-        task.await.unwrap().unwrap();
-    }
-
-    #[tokio::test]
-    async fn tail_reader_returns_ok_on_normal_eof() {
-        let cancel = CancellationToken::new();
-        let (_producer, drain_rx) = NetworkLogDrainProducer::channel("dns-test");
-
-        let result = tail_reader(
-            tokio::io::BufReader::new(tokio::io::empty()),
-            NetworkLogManager::new(),
-            cancel,
-            drain_rx,
-        )
-        .await;
-
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn tail_reader_returns_ok_on_normal_read_error() {
-        let cancel = CancellationToken::new();
-        let (_producer, drain_rx) = NetworkLogDrainProducer::channel("dns-test");
-
-        let result = tail_reader(FailingReader, NetworkLogManager::new(), cancel, drain_rx).await;
-
-        assert!(result.is_ok());
-    }
-
-    struct FailingReader;
-
-    impl AsyncRead for FailingReader {
-        fn poll_read(
-            self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-            _buf: &mut ReadBuf<'_>,
-        ) -> Poll<io::Result<()>> {
-            Poll::Ready(Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "test read error",
-            )))
-        }
-    }
-
-    impl AsyncBufRead for FailingReader {
-        fn poll_fill_buf(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
-            Poll::Ready(Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "test read error",
-            )))
-        }
-
-        fn consume(self: Pin<&mut Self>, _amt: usize) {}
     }
 }

--- a/crates/runner/src/dns/proxy.rs
+++ b/crates/runner/src/dns/proxy.rs
@@ -2,29 +2,39 @@ use std::process::Stdio;
 
 use tokio::io::AsyncReadExt;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::info;
 
 use sandbox_fc::{DNS_DIAGNOSTIC_HOSTNAME, DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4};
 
 use super::log::tail_stderr;
 use super::port::DnsPortReservation;
 use crate::child_cleanup::kill_and_reap_child_on_drop;
-use crate::network_log_drain::NetworkLogDrainProducer;
+use crate::network_log_drain::{DrainableLineReaderExit, NetworkLogDrainProducer};
 use crate::network_log_manager::NetworkLogManager;
 
 /// Handle to the dnsmasq process and its log monitor.
 pub struct DnsProxy {
     cancel: CancellationToken,
-    task: tokio::task::JoinHandle<()>,
+    task: Option<tokio::task::JoinHandle<DrainableLineReaderExit>>,
     child: Option<tokio::process::Child>,
     drain: NetworkLogDrainProducer,
     port: u16,
 }
 
 impl DnsProxy {
-    /// Stop the DNS proxy and wait for cleanup.
-    pub async fn stop(mut self) {
-        self.cancel.cancel();
+    /// Await the log monitor task, or pend forever after its completion has
+    /// already been consumed.
+    pub(crate) async fn wait(&mut self) -> Result<DrainableLineReaderExit, tokio::task::JoinError> {
+        let result = match self.task.as_mut() {
+            Some(task) => task.await,
+            None => std::future::pending().await,
+        };
+        self.task = None;
+        result
+    }
+
+    /// Kill dnsmasq when necessary and wait for it to be reaped.
+    pub(crate) async fn kill_and_reap_child(&mut self) {
         let child_reaped = if let Some(ref mut child) = self.child {
             let _ = child.start_kill();
             child.wait().await.is_ok()
@@ -34,7 +44,15 @@ impl DnsProxy {
         if child_reaped {
             self.child = None;
         }
-        let _ = (&mut self.task).await;
+    }
+
+    /// Stop the DNS proxy and wait for cleanup.
+    pub async fn stop(mut self) {
+        self.cancel.cancel();
+        self.kill_and_reap_child().await;
+        if let Some(task) = self.task.take() {
+            let _ = task.await;
+        }
         info!("dns proxy stopped");
     }
 
@@ -59,23 +77,58 @@ impl DnsProxy {
         let (drain, mut drain_rx) = NetworkLogDrainProducer::channel("dns");
         Self {
             cancel,
-            task: tokio::spawn(async move {
+            task: Some(tokio::spawn(async move {
                 loop {
                     tokio::select! {
-                        _ = token.cancelled() => break,
+                        _ = token.cancelled() => {
+                            return DrainableLineReaderExit::Cancelled;
+                        }
                         request = drain_rx.recv() => {
                             let Some(request) = request else {
-                                break;
+                                return DrainableLineReaderExit::DrainChannelClosed;
                             };
                             request.ack();
                         }
                     }
                 }
-            }),
+            })),
             child: None,
             drain,
             port: 0,
         }
+    }
+
+    async fn from_started_child(
+        mut child: tokio::process::Child,
+        port: u16,
+        network_log_manager: NetworkLogManager,
+    ) -> std::io::Result<Self> {
+        let Some(stderr) = child.stderr.take() else {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            return Err(std::io::Error::other("failed to capture dnsmasq stderr"));
+        };
+
+        let cancel = CancellationToken::new();
+        let token = cancel.clone();
+        let (drain, drain_rx) = NetworkLogDrainProducer::channel("dns");
+        let task = tokio::spawn(tail_stderr(stderr, network_log_manager, token, drain_rx));
+
+        Ok(Self {
+            cancel,
+            task: Some(task),
+            child: Some(child),
+            drain,
+            port,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn from_test_child(
+        child: tokio::process::Child,
+        network_log_manager: NetworkLogManager,
+    ) -> std::io::Result<Self> {
+        Self::from_started_child(child, 0, network_log_manager).await
     }
 }
 
@@ -88,7 +141,9 @@ impl Drop for DnsProxy {
     fn drop(&mut self) {
         kill_and_reap_child_on_drop("dnsmasq", &mut self.child);
         self.cancel.cancel();
-        self.task.abort();
+        if let Some(task) = &self.task {
+            task.abort();
+        }
     }
 }
 
@@ -156,28 +211,9 @@ async fn try_start(
         Ok(None) => {} // still running — good
     }
 
-    let Some(stderr) = child.stderr.take() else {
-        let _ = child.kill().await;
-        return Err(std::io::Error::other("failed to capture dnsmasq stderr"));
-    };
-
-    let cancel = CancellationToken::new();
-    let token = cancel.clone();
-    let (drain, drain_rx) = NetworkLogDrainProducer::channel("dns");
-    let task = tokio::spawn(async move {
-        if let Err(e) = tail_stderr(stderr, network_log_manager, token, drain_rx).await {
-            warn!(error = %e, "dns log monitor exited");
-        }
-    });
-
+    let proxy = DnsProxy::from_started_child(child, port, network_log_manager).await?;
     info!(port, "dns proxy started");
-    Ok(DnsProxy {
-        cancel,
-        task,
-        child: Some(child),
-        drain,
-        port,
-    })
+    Ok(proxy)
 }
 
 fn dnsmasq_immediate_exit_error(status: std::process::ExitStatus, stderr: &str) -> std::io::Error {


### PR DESCRIPTION
## Summary

- propagate typed DNS stderr-monitor completion into the runner reactor
- fail closed when dnsmasq exits after startup by stopping work admission, recording a terminal runner error, and promptly killing and reaping the child
- cover DNS stderr EOF, read failure, and normal shutdown through the real runner main loop

## Behavior and compatibility

The startup path is unchanged. After startup, losing the required DNS process now drives the existing controlled runner shutdown path so the service manager can restart the runner instead of leaving it live without DNS.

This does not change APIs, runner protocols, configuration, schemas, migrations, or persisted data.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo check --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::main_loop::shutdown`
- each new DNS lifecycle test repeated 10 times

Closes #24168
