### PR TITLE
refactor(api): remove legacy github callback field

### DIFF
--- a/turbo/apps/api/src/signals/services/github-chat-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/github-chat-callback-payload.ts
@@ -13,20 +13,7 @@ export const githubDeliveryTargetSchema = z.object({
 
 export type GitHubDeliveryTarget = z.infer<typeof githubDeliveryTargetSchema>;
 
-export const githubChatCallbackPayloadSchema = z.preprocess(
-  (payload) => {
-    if (
-      typeof payload !== "object" ||
-      payload === null ||
-      "chatEventId" in payload ||
-      !("chatMessageId" in payload)
-    ) {
-      return payload;
-    }
-    const { chatMessageId, ...target } = payload;
-    return { ...target, chatEventId: chatMessageId };
-  },
+export const githubChatCallbackPayloadSchema =
   githubDeliveryTargetSchema.extend({
     chatEventId: z.string().uuid(),
-  }),
-);
+  });


### PR DESCRIPTION
## Summary

- remove the GitHub chat callback payload compatibility reader for the legacy `chatMessageId` field
- make `githubChatCallbackPayloadSchema` directly extend `githubDeliveryTargetSchema` with the canonical `chatEventId` UUID field, matching the Slack and Teams payload schemas
- keep callback delivery, claim behavior, and every other platform payload schema unchanged

## Release 2 gate

Both rollout gates are satisfied:

1. Release 1 shipped in `api-v1.358.0`, published at `2026-07-31 02:49:54 UTC`. Zero confirmed at `2026-07-31 03:05 UTC` that the API rollout was complete, old instances had drained, and no pre-Release-1 unclaimed-row blocker remained.
2. The rollback-elimination wave shipped in `api-v1.358.1`, published at `2026-07-31 03:32:04 UTC` after release PR #24192 merged. A rollback now remains on the canonical `chatEventId` writer.

## Scope

- no delivery or claim semantic changes
- no changes to Slack, Teams, or other platform payload schemas
- no migration
- repository scan leaves `chatMessageId` only in migration-consistency history

## Validation

- targeted Prettier formatting for `github-chat-callback-payload.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace apps/api`
- schema smoke check: canonical `chatEventId` accepted and legacy `chatMessageId` rejected
- `DATABASE_URL=postgresql://postgres@localhost:55432/postgres pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-github-chat.test.ts --maxWorkers=1 --silent=passed-only` (2 tests passed on the CI-pinned PostgreSQL 17.10 image)

Closes #24158