### PR TITLE
fix(runner): activate cooperative cancellation recovery

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -391,7 +391,7 @@ async fn claim_with_local_admission(
             return None;
         }
         RunnerMode::Stopping => {
-            admission.cancellation.cancel().await;
+            admission.cancellation.request_hard_cancellation().await;
         }
         RunnerMode::Stopped => {
             admission.rollback(ctx).await;

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -12,7 +12,6 @@ use futures_util::FutureExt;
 use sandbox::SandboxId;
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
-use tokio_util::sync::CancellationToken;
 use tracing::{error, warn};
 
 use super::active_sessions::{ActiveCliAgentSessionGuard, ActiveCliAgentSessions};
@@ -37,7 +36,9 @@ use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_logs;
 use crate::provider::{ClaimedJob, CompletionAuth, JobProvider};
 use crate::resource_budget::BudgetLease;
-use crate::run_cancellation::{RunCancellationHandle, RunCancellationRegistration};
+use crate::run_cancellation::{
+    RunCancellationHandle, RunCancellationRegistration, RunCancellationSignals,
+};
 use crate::status::StatusTracker;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::telemetry::JobTelemetry;
@@ -105,7 +106,7 @@ struct ExecutorInvocation {
     reuse_result: SandboxReuseResult,
     pre_spawn_timing: RunnerPreSpawnTiming,
     session_history_restore_plan: SessionHistoryRestorePlan,
-    cancel: CancellationToken,
+    cancellation: RunCancellationSignals,
     sandbox_token: String,
     sandbox_prepared: Option<executor::SandboxPreparedNotifier>,
     active_input_source: Option<crate::active_input::ActiveInputSource>,
@@ -131,13 +132,14 @@ impl ExecutorInvocation {
             reuse_result,
             pre_spawn_timing,
             session_history_restore_plan,
-            cancel,
+            cancellation,
             sandbox_token,
             sandbox_prepared,
             active_input_source,
         } = self;
         let exec_config_for_panic = Arc::clone(&exec_config);
-        let cancel_for_executor = cancel.clone();
+        let cancel_for_outcome = cancellation.any();
+        let cancellation_for_executor = cancellation.clone();
 
         // Inner spawn isolates panics: if execute_job panics, the outer task
         // still reports completion and releases budget.
@@ -148,7 +150,7 @@ impl ExecutorInvocation {
                     context,
                     &exec_config,
                     &params,
-                    cancel_for_executor,
+                    cancellation_for_executor,
                     executor::ExecutionHooks {
                         sandbox_prepared: None,
                         active_input_source,
@@ -167,7 +169,7 @@ impl ExecutorInvocation {
                     },
                     &exec_config,
                     &params,
-                    cancel_for_executor,
+                    cancellation_for_executor,
                     executor::ExecutionHooks {
                         sandbox_prepared,
                         active_input_source,
@@ -181,7 +183,7 @@ impl ExecutorInvocation {
 
         match inner.await {
             Ok((mut outcome, telemetry)) => {
-                if cancel.is_cancelled() {
+                if cancel_for_outcome.is_cancelled() {
                     outcome.mark_cancelled();
                 }
                 let exit_code = outcome.exit_code();
@@ -586,7 +588,7 @@ pub(super) fn spawn_job(
         reuse_result,
         pre_spawn_timing,
         session_history_restore_plan,
-        cancel: job_cancel.token(),
+        cancellation: job_cancel.signals(),
         sandbox_token: sandbox_token.clone(),
         sandbox_prepared,
         active_input_source,

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -1146,7 +1146,7 @@ mod tests {
             RunCleanupDisposition::IdlePoolOwned,
         );
 
-        assert!(cancel.cancel().await);
+        assert!(cancel.request_hard_cancellation().await);
 
         assert_eq!(
             fixture.idle_pool.lock().await.len(),
@@ -1984,7 +1984,7 @@ mod tests {
         let fixture = FinalizeTestFixture::new().await;
         let network_log_session = fixture.network_log_session().await;
         let cancel = RunCancellationHandle::new();
-        cancel.cancel().await;
+        cancel.request_hard_cancellation().await;
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
 
@@ -2069,7 +2069,7 @@ mod tests {
                 .expect("park should enter gate"),
             1
         );
-        cancel.cancel().await;
+        cancel.request_hard_cancellation().await;
         park_gate.release_one();
         assert_eq!(
             destroy_gate
@@ -2147,7 +2147,7 @@ mod tests {
         observer
             .wait_before_idle_pool_ownership_transfer(run_id, Duration::from_secs(5))
             .await;
-        cancel.cancel().await;
+        cancel.request_hard_cancellation().await;
         assert!(
             !fixture
                 .network_log_manager

--- a/crates/runner/src/cmd/start/signals.rs
+++ b/crates/runner/src/cmd/start/signals.rs
@@ -375,7 +375,7 @@ pub(super) async fn handle_stopping_signal(
     let count = handles.len();
     for (run_id, handle) in handles {
         info!(run_id = %run_id, "cancelling active job for hard shutdown");
-        handle.cancel().await;
+        handle.request_hard_cancellation().await;
     }
     info!(active_jobs = count, "dispatched per-job cancellations");
     cancel.cancel();

--- a/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
@@ -94,7 +94,7 @@ async fn cancelled_job_not_parked() {
         .await
         .expect("wait_process should enter before cancellation");
     let cancel_handle = wait_cancel_handle(&cancel_tokens, run_id, Duration::from_secs(5)).await;
-    cancel_handle.cancel().await;
+    cancel_handle.request_hard_cancellation().await;
 
     let c = env
         .handle

--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -475,7 +475,7 @@ async fn assert_workspace_cache_after_late_cancellation(
 
     match cancellation_point {
         LateCancellationPoint::DuringPark => {
-            cancel_handle.cancel().await;
+            cancel_handle.request_hard_cancellation().await;
             park_gate.release_one();
         }
         LateCancellationPoint::BeforeIdlePoolTransfer => {
@@ -484,7 +484,7 @@ async fn assert_workspace_cache_after_late_cancellation(
             env.start_observer
                 .wait_before_idle_pool_ownership_transfer(run_id, Duration::from_secs(5))
                 .await;
-            cancel_handle.cancel().await;
+            cancel_handle.request_hard_cancellation().await;
             drop(pool_guard);
         }
     }
@@ -711,7 +711,7 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
     env.start_observer
         .wait_before_idle_pool_ownership_transfer(run_id, Duration::from_secs(5))
         .await;
-    cancel_handle.cancel().await;
+    cancel_handle.request_hard_cancellation().await;
     drop(pool_guard);
 
     wait_lifecycle_gate_entered(
@@ -779,7 +779,7 @@ async fn cancellation_during_sandbox_park_destroys_instead_of_parking() {
     wait_lifecycle_gate_entered(&park_gate, "sandbox park should enter gate").await;
     assert_eq!(counter.park_call_count(), 1);
 
-    cancel_handle.cancel().await;
+    cancel_handle.request_hard_cancellation().await;
     park_gate.release_one();
 
     wait_lifecycle_gate_entered(

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::pin::Pin;
 use std::time::{Duration, Instant};
 
 use guest_contracts::diagnostics::{CliTerminationReason, FailureDiagnostic};
@@ -14,8 +15,9 @@ use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
 };
 use sandbox::{
-    EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, GuestProcessHandle, ProcessControlMode,
-    ProcessOutputMode, Sandbox, StartProcessRequest,
+    EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, GuestProcessCancelHandle,
+    GuestProcessControlHandle, GuestProcessHandle, ProcessControlMode, ProcessOutputMode, Sandbox,
+    StartProcessRequest,
 };
 use shell_quote::quote_shell_arg;
 use tokio::io::AsyncReadExt;
@@ -85,6 +87,7 @@ const SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR: &str =
 const STORAGE_CACHE_POPULATE_FAILED: &str = "storage-cache-populate-failed";
 const STORAGE_DOWNLOAD_FAILED: &str = "storage-download-failed";
 const SESSION_HISTORY_IDENTITY_VERIFY_TIMEOUT: Duration = Duration::from_secs(5);
+const USER_CANCELLATION_CONTROL_PAYLOAD: &[u8] = br#"{"type":"user-cancellation"}"#;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SessionHistoryIdentityReason {
@@ -692,9 +695,11 @@ async fn read_final_session_history_identity(
         .ok_or(SessionHistoryIdentityReason::FinalizeUnverifiableMetadata)
 }
 
+#[derive(Clone, Copy)]
 pub(super) struct ProcessCancelTimeouts {
     pub(super) write: Duration,
     pub(super) terminal_grace: Duration,
+    pub(super) cooperative_grace: Duration,
 }
 
 pub(super) struct AgentExecutionResult {
@@ -780,6 +785,285 @@ pub(super) fn cancelled_agent_process_exit(
     exit.termination = ExecTermination::Cancelled;
     exit.stream_overflowed = stream_overflowed;
     exit
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CancellationDisposition {
+    None,
+    Cooperative,
+    HardFallback,
+}
+
+impl CancellationDisposition {
+    fn observed(self) -> bool {
+        self != Self::None
+    }
+
+    fn used_hard_fallback(self) -> bool {
+        self == Self::HardFallback
+    }
+}
+
+struct ProcessWaitOutcome {
+    result: sandbox::Result<sandbox::ProcessExit>,
+    cancellation: CancellationDisposition,
+    abort_stdout_drain: bool,
+}
+
+impl ProcessWaitOutcome {
+    fn normal(result: sandbox::Result<sandbox::ProcessExit>) -> Self {
+        let abort_stdout_drain = result.is_err();
+        Self {
+            result,
+            cancellation: CancellationDisposition::None,
+            abort_stdout_drain,
+        }
+    }
+
+    fn cooperative(exit: sandbox::ProcessExit) -> Self {
+        Self {
+            result: Ok(exit),
+            cancellation: CancellationDisposition::Cooperative,
+            abort_stdout_drain: false,
+        }
+    }
+
+    fn hard_fallback(
+        guest_process_pid: u32,
+        stream_overflowed: bool,
+        abort_stdout_drain: bool,
+    ) -> Self {
+        Self {
+            result: Ok(cancelled_agent_process_exit(
+                guest_process_pid,
+                stream_overflowed,
+            )),
+            cancellation: CancellationDisposition::HardFallback,
+            abort_stdout_drain,
+        }
+    }
+}
+
+async fn request_guest_process_cancel(
+    run_id: crate::ids::RunId,
+    guest_process_pid: u32,
+    process_cancel: &mut Option<GuestProcessCancelHandle>,
+    timeout: Duration,
+) -> bool {
+    let Some(process_cancel) = process_cancel.take() else {
+        warn!(
+            run_id = %run_id,
+            pid = guest_process_pid,
+            "sandbox does not support guest process cancellation"
+        );
+        return false;
+    };
+    match process_cancel.cancel(timeout).await {
+        Ok(()) => true,
+        Err(error) => {
+            warn!(
+                run_id = %run_id,
+                pid = guest_process_pid,
+                error = %error,
+                "failed to send guest process cancellation"
+            );
+            false
+        }
+    }
+}
+
+async fn force_cancel_guest_process<F>(
+    run_id: crate::ids::RunId,
+    guest_process_pid: u32,
+    process_cancel: &mut Option<GuestProcessCancelHandle>,
+    process_cancel_timeouts: ProcessCancelTimeouts,
+    mut wait_process: Pin<&mut F>,
+) -> ProcessWaitOutcome
+where
+    F: Future<Output = sandbox::Result<sandbox::ProcessExit>>,
+{
+    if !request_guest_process_cancel(
+        run_id,
+        guest_process_pid,
+        process_cancel,
+        process_cancel_timeouts.write,
+    )
+    .await
+    {
+        return ProcessWaitOutcome::hard_fallback(guest_process_pid, false, true);
+    }
+
+    match tokio::time::timeout(
+        process_cancel_timeouts.terminal_grace,
+        wait_process.as_mut(),
+    )
+    .await
+    {
+        Ok(Ok(exit)) => {
+            info!(
+                run_id = %run_id,
+                pid = guest_process_pid,
+                "cancelled guest process reached terminal status"
+            );
+            ProcessWaitOutcome::hard_fallback(guest_process_pid, exit.stream_overflowed, false)
+        }
+        Ok(Err(error)) => {
+            warn!(
+                run_id = %run_id,
+                pid = guest_process_pid,
+                error = %error,
+                "guest process wait failed after cancellation"
+            );
+            ProcessWaitOutcome::hard_fallback(guest_process_pid, false, true)
+        }
+        Err(_) => {
+            warn!(
+                run_id = %run_id,
+                pid = guest_process_pid,
+                timeout_ms = process_cancel_timeouts.terminal_grace.as_millis(),
+                "timed out waiting for cancelled guest process"
+            );
+            ProcessWaitOutcome::hard_fallback(guest_process_pid, false, true)
+        }
+    }
+}
+
+async fn send_cooperative_user_cancellation(
+    run_id: crate::ids::RunId,
+    process_control: Option<&GuestProcessControlHandle>,
+    hard_cancel: &CancellationToken,
+    timeout: Duration,
+) -> bool {
+    let Some(process_control) = process_control else {
+        warn!(
+            run_id = %run_id,
+            "guest process does not support cooperative user cancellation"
+        );
+        return false;
+    };
+    let message_id = format!("user-cancellation:{run_id}");
+    tokio::select! {
+        biased;
+        () = hard_cancel.cancelled() => false,
+        result = process_control.control(
+            &message_id,
+            USER_CANCELLATION_CONTROL_PAYLOAD,
+            timeout,
+        ) => {
+            match result {
+                Ok(ack) if ack.message_id == message_id => true,
+                Ok(ack) => {
+                    warn!(
+                        run_id = %run_id,
+                        expected_message_id = %message_id,
+                        acknowledged_message_id = %ack.message_id,
+                        "guest acknowledged the wrong user-cancellation message"
+                    );
+                    false
+                }
+                Err(error) => {
+                    warn!(
+                        run_id = %run_id,
+                        error = %error,
+                        "failed to send cooperative user cancellation"
+                    );
+                    false
+                }
+            }
+        }
+    }
+}
+
+async fn wait_for_cooperative_user_cancellation<F>(
+    run_id: crate::ids::RunId,
+    guest_process_pid: u32,
+    process_control: Option<&GuestProcessControlHandle>,
+    process_cancel: &mut Option<GuestProcessCancelHandle>,
+    hard_cancel: &CancellationToken,
+    process_cancel_timeouts: ProcessCancelTimeouts,
+    mut wait_process: Pin<&mut F>,
+) -> ProcessWaitOutcome
+where
+    F: Future<Output = sandbox::Result<sandbox::ProcessExit>>,
+{
+    if !send_cooperative_user_cancellation(
+        run_id,
+        process_control,
+        hard_cancel,
+        process_cancel_timeouts.write,
+    )
+    .await
+    {
+        return force_cancel_guest_process(
+            run_id,
+            guest_process_pid,
+            process_cancel,
+            process_cancel_timeouts,
+            wait_process,
+        )
+        .await;
+    }
+
+    tokio::select! {
+        biased;
+        result = wait_process.as_mut() => {
+            match result {
+                Ok(exit) => {
+                    info!(
+                        run_id = %run_id,
+                        pid = guest_process_pid,
+                        "guest completed cooperative user cancellation"
+                    );
+                    ProcessWaitOutcome::cooperative(exit)
+                }
+                Err(error) => {
+                    warn!(
+                        run_id = %run_id,
+                        pid = guest_process_pid,
+                        error = %error,
+                        "guest process wait failed during cooperative cancellation"
+                    );
+                    request_guest_process_cancel(
+                        run_id,
+                        guest_process_pid,
+                        process_cancel,
+                        process_cancel_timeouts.write,
+                    )
+                    .await;
+                    ProcessWaitOutcome::hard_fallback(guest_process_pid, false, true)
+                }
+            }
+        }
+        () = hard_cancel.cancelled() => {
+            info!(
+                run_id = %run_id,
+                "hard cancellation preempted cooperative user cancellation"
+            );
+            force_cancel_guest_process(
+                run_id,
+                guest_process_pid,
+                process_cancel,
+                process_cancel_timeouts,
+                wait_process,
+            )
+            .await
+        }
+        () = tokio::time::sleep(process_cancel_timeouts.cooperative_grace) => {
+            warn!(
+                run_id = %run_id,
+                timeout_ms = process_cancel_timeouts.cooperative_grace.as_millis(),
+                "cooperative user cancellation timed out"
+            );
+            force_cancel_guest_process(
+                run_id,
+                guest_process_pid,
+                process_cancel,
+                process_cancel_timeouts,
+                wait_process,
+            )
+            .await
+        }
+    }
 }
 
 fn wait_process_timed_out(error: &sandbox::SandboxError) -> bool {
@@ -880,6 +1164,8 @@ pub(super) struct RunStart<'a> {
 
 pub(super) struct RunControls {
     pub(super) cancel: CancellationToken,
+    pub(super) cooperative_user_cancel: CancellationToken,
+    pub(super) hard_cancel: CancellationToken,
     pub(super) active_input_source: Option<ActiveInputSource>,
     pub(super) spawn_timing: Option<RunnerSpawnTiming>,
     pub(super) session_history_restore_plan: SessionHistoryRestorePlan,
@@ -953,12 +1239,25 @@ impl PreparedGuestRuntime {
 }
 
 impl RunControls {
+    #[cfg(test)]
     pub(super) fn new(
         cancel: CancellationToken,
         active_input_source: Option<ActiveInputSource>,
     ) -> Self {
+        Self::from_cancellation(
+            crate::run_cancellation::RunCancellationSignals::hard_only(cancel),
+            active_input_source,
+        )
+    }
+
+    pub(super) fn from_cancellation(
+        cancellation: crate::run_cancellation::RunCancellationSignals,
+        active_input_source: Option<ActiveInputSource>,
+    ) -> Self {
         Self {
-            cancel,
+            cancel: cancellation.any(),
+            cooperative_user_cancel: cancellation.cooperative_user(),
+            hard_cancel: cancellation.hard(),
             active_input_source,
             spawn_timing: None,
             session_history_restore_plan: SessionHistoryRestorePlan::Default,
@@ -1253,6 +1552,8 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
 ) -> RunnerResult<AgentExecutionResult> {
     let RunControls {
         cancel,
+        cooperative_user_cancel,
+        hard_cancel,
         active_input_source,
         spawn_timing,
         session_history_restore_plan,
@@ -1817,10 +2118,11 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // Claude Code process has a PID now — record end-to-end startup latency.
     record_api_latency("api_to_spawn", context, telemetry);
 
+    let process_control = handle.control_handle();
     let active_input_forwarder = super::active_input::ActiveInputForwarder::start(
         context.run_id,
         active_input_source,
-        handle.control_handle(),
+        process_control.clone(),
         cancel.clone(),
     );
 
@@ -1834,94 +2136,58 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         background_fill.start(telemetry);
     }
 
-    // 6. Wait for exit (or cancellation). On cancel, ask the guest to cancel the
-    // supervised process and briefly wait for its terminal status so the vsock
-    // operation can be removed before sandbox cleanup closes the connection.
+    // 6. Wait for exit or cancellation. A user request first asks guest-agent
+    // to checkpoint recovery state and exit; hard cancellation and bounded
+    // fallback use the existing supervised-process cancellation path.
     let guest_process_pid = handle.guest_pid;
-    let process_cancel = handle.take_cancel_handle();
+    let mut process_cancel = handle.take_cancel_handle();
     let wait_process = sandbox.wait_process(handle, job_terminal_wait_timeout());
     tokio::pin!(wait_process);
-    let (result, wait_cancelled, abort_stdout_drain) = model_catalog_prefetch
+    let wait_outcome = model_catalog_prefetch
         .race(async {
             tokio::select! {
                 biased;
-                result = &mut wait_process => {
-                    let abort_stdout_drain = result.is_err();
-                    (result, false, abort_stdout_drain)
+                result = wait_process.as_mut() => {
+                    ProcessWaitOutcome::normal(result)
                 }
-                () = cancel.cancelled() => {
-                    info!(run_id = %context.run_id, "cancel received, cancelling guest process");
-                    let cancelled_exit = || -> sandbox::Result<sandbox::ProcessExit> {
-                        Ok(cancelled_agent_process_exit(guest_process_pid, false))
-                    };
-                    match process_cancel {
-                        Some(process_cancel) => match process_cancel.cancel(process_cancel_timeouts.write).await {
-                            Ok(()) => {
-                                match tokio::time::timeout(
-                                    process_cancel_timeouts.terminal_grace,
-                                    &mut wait_process,
-                                )
-                                .await
-                                {
-                                    Ok(Ok(exit)) => {
-                                        info!(
-                                            run_id = %context.run_id,
-                                            pid = guest_process_pid,
-                                            "cancelled guest process reached terminal status"
-                                        );
-                                        (
-                                            Ok(cancelled_agent_process_exit(
-                                                guest_process_pid,
-                                                exit.stream_overflowed,
-                                            )),
-                                            true,
-                                            false,
-                                        )
-                                    }
-                                    Ok(Err(error)) => {
-                                        warn!(
-                                            run_id = %context.run_id,
-                                            pid = guest_process_pid,
-                                            error = %error,
-                                            "guest process wait failed after cancellation"
-                                        );
-                                        (cancelled_exit(), true, true)
-                                    }
-                                    Err(_) => {
-                                        warn!(
-                                            run_id = %context.run_id,
-                                            pid = guest_process_pid,
-                                            timeout_ms = process_cancel_timeouts.terminal_grace.as_millis(),
-                                            "timed out waiting for cancelled guest process"
-                                        );
-                                        (cancelled_exit(), true, true)
-                                    }
-                                }
-                            }
-                            Err(error) => {
-                                warn!(
-                                    run_id = %context.run_id,
-                                    pid = guest_process_pid,
-                                    error = %error,
-                                    "failed to send guest process cancellation"
-                                );
-                                (cancelled_exit(), true, true)
-                            }
-                        },
-                        None => {
-                            warn!(
-                                run_id = %context.run_id,
-                                pid = guest_process_pid,
-                                "sandbox does not support guest process cancellation"
-                            );
-                            (cancelled_exit(), true, true)
-                        }
-                    }
+                () = hard_cancel.cancelled() => {
+                    info!(run_id = %context.run_id, "hard cancellation received, cancelling guest process");
+                    force_cancel_guest_process(
+                        context.run_id,
+                        guest_process_pid,
+                        &mut process_cancel,
+                        process_cancel_timeouts,
+                        wait_process.as_mut(),
+                    )
+                    .await
+                }
+                () = cooperative_user_cancel.cancelled() => {
+                    info!(
+                        run_id = %context.run_id,
+                        "user cancellation received, requesting guest recovery"
+                    );
+                    wait_for_cooperative_user_cancellation(
+                        context.run_id,
+                        guest_process_pid,
+                        process_control.as_ref(),
+                        &mut process_cancel,
+                        &hard_cancel,
+                        process_cancel_timeouts,
+                        wait_process.as_mut(),
+                    )
+                    .await
                 }
             }
         })
         .await;
     model_catalog_prefetch.record_outcome(telemetry);
+    let ProcessWaitOutcome {
+        result,
+        cancellation,
+        abort_stdout_drain,
+    } = wait_outcome;
+    let cancellation_observed = cancellation.observed();
+    let used_hard_cancellation_fallback = cancellation.used_hard_fallback();
 
     if let Some(forwarder) = active_input_forwarder {
         forwarder.stop().await;
@@ -2023,10 +2289,10 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         stdout_stream_diagnostics,
     );
 
-    // Check for OOM kill when process was terminated by SIGKILL.
-    // Skip when cancelled — the SIGKILL exit code is synthetic and dmesg
-    // would run against a sandbox that hasn't been stopped yet.
-    if !wait_cancelled && process_exit_oom_candidate(&exit) {
+    // Check for OOM kill when process was terminated by SIGKILL. Skip only
+    // after hard fallback, where the SIGKILL exit code is synthetic. A
+    // cooperative guest exit remains real process evidence.
+    if !used_hard_cancellation_fallback && process_exit_oom_candidate(&exit) {
         let dmesg_req = ExecRequest {
             cmd: "dmesg | tail -20 2>/dev/null",
             timeout: Duration::from_secs(5),
@@ -2067,8 +2333,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         }
     }
 
-    let failure = if wait_cancelled {
-        // Skip guest file reads — sandbox hasn't been stopped yet.
+    let failure = if cancellation_observed {
+        // Cancellation remains authoritative over guest failure files. Hard
+        // fallback may also leave the guest process without terminal proof.
         Some(ExecutionFailure::cancelled())
     } else if process_failed(&exit) {
         let failure_exit_code = process_failure_exit_code(&exit);
@@ -2083,13 +2350,13 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             None
         };
         let should_log_bootstrap_diagnostics = should_log_agent_bootstrap_abnormal_exit_diagnostics(
-            wait_cancelled,
+            cancellation_observed,
             &exit,
             failure_diagnostic.as_ref(),
             guest_error.as_deref(),
         );
         let should_collect_resource_diagnostics = should_collect_agent_abnormal_exit_diagnostics(
-            wait_cancelled,
+            cancellation_observed,
             &exit,
             &stderr,
             failure_diagnostic.as_ref(),
@@ -2097,7 +2364,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         );
         let should_collect_sigkill_resource_diagnostics =
             should_collect_unattributed_sigkill_resource_diagnostics(
-                wait_cancelled,
+                cancellation_observed,
                 &exit,
                 failure_diagnostic.as_ref(),
             );

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use futures_util::future::BoxFuture;
 use guest_contracts::diagnostics::FailureDiagnostic;
 use sandbox::{Sandbox, SandboxFactory, SandboxId};
+#[cfg(test)]
 use tokio_util::sync::CancellationToken;
 
 mod active_input;
@@ -60,8 +61,10 @@ pub(crate) use telemetry::{RunnerPreSpawnPhase, RunnerPreSpawnTiming};
 use telemetry::{RunnerSpawnTiming, record_api_latency, record_reuse_result};
 
 use crate::ids::RunId;
-use api_contracts::generated::constants::runners::paths::{
-    CANONICAL_GUEST_HOME_DIR, CANONICAL_WORKING_DIR,
+use crate::run_cancellation::RunCancellationSignals;
+use api_contracts::generated::constants::runners::{
+    RUNNER_CANCELLATION_RECOVERY_GRACE_MS,
+    paths::{CANONICAL_GUEST_HOME_DIR, CANONICAL_WORKING_DIR},
 };
 
 /// Maximum guest-side runtime budget for a single agent process (2 hours).
@@ -80,7 +83,7 @@ const JOB_FINALIZATION_GRACE_TIMEOUT: Duration = Duration::from_secs(90);
 /// supervised-process cleanup, its 5s stdout/stderr drain deadline, and normal
 /// scheduling overhead before it sends terminal proof.
 const JOB_TERMINAL_GRACE_TIMEOUT: Duration = Duration::from_secs(10);
-/// Maximum time to spend writing the guest cancel frame after a user cancel.
+/// Maximum time to spend writing a guest control or cancellation frame.
 const PROCESS_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
 /// Grace period for the guest to report a terminal status after cancel is sent.
 /// This covers vsock-guest's bounded supervised-process cleanup (500ms TERM
@@ -90,6 +93,7 @@ const PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT: Duration = Duration::from_secs(8);
 const PROCESS_CANCEL_TIMEOUTS: ProcessCancelTimeouts = ProcessCancelTimeouts {
     write: PROCESS_CANCEL_WRITE_TIMEOUT,
     terminal_grace: PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT,
+    cooperative_grace: Duration::from_millis(RUNNER_CANCELLATION_RECOVERY_GRACE_MS),
 };
 /// Exit code when a process is killed by SIGKILL (128 + 9).
 const EXIT_SIGKILL: i32 = 137;
@@ -451,7 +455,7 @@ pub async fn execute_job(
         dispatch,
         config,
         params,
-        cancel,
+        RunCancellationSignals::hard_only(cancel),
         ExecutionHooks::none(),
     )
     .await
@@ -463,7 +467,7 @@ pub(crate) async fn execute_job_with_prepared_notifier(
     dispatch: NewSandboxDispatch,
     config: &ExecutorConfig,
     params: &JobParams,
-    cancel: CancellationToken,
+    cancellation: RunCancellationSignals,
     hooks: ExecutionHooks,
 ) -> (ExecuteOutcome, JobTelemetry) {
     let ExecutionHooks {
@@ -506,7 +510,7 @@ pub(crate) async fn execute_job_with_prepared_notifier(
             params,
             &mut telemetry,
             NewSandboxHooks {
-                controls: RunControls::new(cancel, active_input_source)
+                controls: RunControls::from_cancellation(cancellation, active_input_source)
                     .with_spawn_timing(spawn_timing)
                     .with_session_history_restore_plan(session_history_restore_plan),
                 sandbox_prepared: sandbox_prepared.as_ref(),
@@ -550,7 +554,7 @@ pub async fn execute_job_reuse(
         context,
         config,
         params,
-        cancel,
+        RunCancellationSignals::hard_only(cancel),
         ExecutionHooks::none(),
     )
     .await
@@ -561,7 +565,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
     context: ExecutionContext,
     config: &ExecutorConfig,
     params: &JobParams,
-    cancel: CancellationToken,
+    cancellation: RunCancellationSignals,
     hooks: ExecutionHooks,
 ) -> (ExecuteOutcome, JobTelemetry) {
     let ExecutionHooks {
@@ -671,7 +675,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
             config,
             &prev_storage,
             &mut telemetry,
-            RunControls::new(cancel, active_input_source)
+            RunControls::from_cancellation(cancellation, active_input_source)
                 .with_spawn_timing(spawn_timing)
                 .with_session_history_restore_plan(session_history_restore_plan),
         )

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -40,7 +40,7 @@ use super::super::diagnostics::AgentStdoutStreamDiagnostics;
 use super::super::storage::guest_download_stdin_command;
 use super::super::telemetry::RunnerSpawnTiming;
 use super::super::{
-    EXIT_SIGKILL, PROCESS_CANCEL_WRITE_TIMEOUT, RestoredSessionIdentity,
+    EXIT_SIGKILL, PROCESS_CANCEL_TIMEOUTS, PROCESS_CANCEL_WRITE_TIMEOUT, RestoredSessionIdentity,
     SessionHistoryMaterializer, SessionHistoryRestoreFallback, SessionHistoryRestorePlan,
     effective_cli_framework,
 };
@@ -48,8 +48,8 @@ use super::support::{
     CancelAtProcessBoundarySandbox, OperationGateSandbox, ProcessCancellationPoint,
     RUN_IN_SANDBOX_TEST_TIMEOUT, SandboxGatePoint, api_artifact, api_storage,
     create_overridden_sandbox, minimal_context, sandbox_exec_error, sandbox_read_file_error,
-    spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_timeouts, test_executor_config,
-    test_telemetry,
+    spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_cancellation,
+    spawn_run_in_sandbox_test_with_timeouts, test_executor_config, test_telemetry,
 };
 use crate::active_input::ActiveInputSource;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
@@ -57,6 +57,7 @@ use crate::restored_session_identity::{
     RestoredSessionHistoryHashSizeRelationship, RestoredSessionHistoryPrefixAttribution,
     RestoredSessionIdentityMismatchReason,
 };
+use crate::run_cancellation::RunCancellationHandle;
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::storage_manifest::StorageManifest;
 use crate::telemetry::SessionHistoryTelemetrySnapshot;
@@ -4217,6 +4218,281 @@ async fn run_in_sandbox_cancels_guest_process_and_waits_for_terminal_status() {
             stream_overflowed: true,
         }
     );
+    assert!(overrides.process_control_calls().is_empty());
+}
+
+#[tokio::test]
+async fn run_in_sandbox_requests_cooperative_user_cancellation() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let run_id = ctx.run_id;
+    let cancellation = RunCancellationHandle::new();
+    let run_task = spawn_run_in_sandbox_test_with_cancellation(
+        sandbox,
+        ctx,
+        config,
+        cancellation.signals(),
+        PROCESS_CANCEL_TIMEOUTS,
+    );
+    wait_gate
+        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+        .await
+        .expect("run should enter process wait before cancellation");
+
+    cancellation.request_cooperative_user_cancellation().await;
+    assert!(
+        overrides
+            .wait_for_process_control_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await
+    );
+    wait_gate.release_one();
+
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    let calls = overrides.process_control_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].message_id, format!("user-cancellation:{run_id}"));
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&calls[0].payload).unwrap(),
+        serde_json::json!({ "type": "user-cancellation" })
+    );
+    assert_eq!(calls[0].timeout, PROCESS_CANCEL_WRITE_TIMEOUT);
+    assert!(overrides.process_cancel_calls().is_empty());
+    assert_eq!(
+        result.failure.as_ref().map(|failure| failure.exit_code),
+        Some(EXIT_SIGKILL)
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_falls_back_when_cooperative_cancellation_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    overrides.push_process_control_error("guest rejected cancellation");
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let cancellation = RunCancellationHandle::new();
+    let run_task = spawn_run_in_sandbox_test_with_cancellation(
+        sandbox,
+        ctx,
+        config,
+        cancellation.signals(),
+        PROCESS_CANCEL_TIMEOUTS,
+    );
+    wait_gate
+        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+        .await
+        .expect("run should enter process wait before cancellation");
+
+    cancellation.request_cooperative_user_cancellation().await;
+    assert!(
+        overrides
+            .wait_for_process_cancel_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await
+    );
+
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(overrides.process_control_calls().len(), 1);
+    assert_eq!(overrides.process_cancel_calls().len(), 1);
+    assert_eq!(
+        result.failure.as_ref().map(|failure| failure.exit_code),
+        Some(EXIT_SIGKILL)
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_falls_back_when_process_control_is_unavailable() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    overrides.set_process_control_supported(false);
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let cancellation = RunCancellationHandle::new();
+    let run_task = spawn_run_in_sandbox_test_with_cancellation(
+        sandbox,
+        ctx,
+        config,
+        cancellation.signals(),
+        PROCESS_CANCEL_TIMEOUTS,
+    );
+    wait_gate
+        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+        .await
+        .expect("run should enter process wait before cancellation");
+
+    cancellation.request_cooperative_user_cancellation().await;
+    assert!(
+        overrides
+            .wait_for_process_cancel_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await
+    );
+
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(overrides.process_control_calls().is_empty());
+    assert_eq!(overrides.process_cancel_calls().len(), 1);
+    assert_eq!(
+        result.failure.as_ref().map(|failure| failure.exit_code),
+        Some(EXIT_SIGKILL)
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_forces_cancellation_when_cooperative_wait_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = MockLifecycleGate::new();
+    let mut overrides = sandbox_mock::MockSandboxOverrides::new();
+    overrides.set_wait_process_error("wait failed during cooperative cancellation");
+    let overrides = Arc::new(overrides);
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let cancellation = RunCancellationHandle::new();
+    let run_task = spawn_run_in_sandbox_test_with_cancellation(
+        sandbox,
+        ctx,
+        config,
+        cancellation.signals(),
+        PROCESS_CANCEL_TIMEOUTS,
+    );
+    wait_gate
+        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+        .await
+        .expect("run should enter process wait before cancellation");
+
+    cancellation.request_cooperative_user_cancellation().await;
+    assert!(
+        overrides
+            .wait_for_process_control_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await
+    );
+    wait_gate.release_one();
+
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(overrides.process_control_calls().len(), 1);
+    assert_eq!(overrides.process_cancel_calls().len(), 1);
+    assert_eq!(
+        result.failure.as_ref().map(|failure| failure.exit_code),
+        Some(EXIT_SIGKILL)
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_falls_back_when_cooperative_grace_expires() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let cancellation = RunCancellationHandle::new();
+    let run_task = spawn_run_in_sandbox_test_with_cancellation(
+        sandbox,
+        ctx,
+        config,
+        cancellation.signals(),
+        ProcessCancelTimeouts {
+            cooperative_grace: Duration::ZERO,
+            ..PROCESS_CANCEL_TIMEOUTS
+        },
+    );
+    wait_gate
+        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+        .await
+        .expect("run should enter process wait before cancellation");
+
+    cancellation.request_cooperative_user_cancellation().await;
+    assert!(
+        overrides
+            .wait_for_process_cancel_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await
+    );
+
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(overrides.process_control_calls().len(), 1);
+    assert_eq!(overrides.process_cancel_calls().len(), 1);
+    assert_eq!(
+        result.failure.as_ref().map(|failure| failure.exit_code),
+        Some(EXIT_SIGKILL)
+    );
+}
+
+#[tokio::test]
+async fn hard_cancellation_preempts_cooperative_recovery() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let cancellation = RunCancellationHandle::new();
+    let run_task = spawn_run_in_sandbox_test_with_cancellation(
+        sandbox,
+        ctx,
+        config,
+        cancellation.signals(),
+        PROCESS_CANCEL_TIMEOUTS,
+    );
+    wait_gate
+        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+        .await
+        .expect("run should enter process wait before cancellation");
+
+    cancellation.request_cooperative_user_cancellation().await;
+    assert!(
+        overrides
+            .wait_for_process_control_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await
+    );
+    cancellation.request_hard_cancellation().await;
+    assert!(
+        overrides
+            .wait_for_process_cancel_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await
+    );
+
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(overrides.process_cancel_calls().len(), 1);
+    assert_eq!(
+        result.failure.as_ref().map(|failure| failure.exit_code),
+        Some(EXIT_SIGKILL)
+    );
 }
 
 #[tokio::test]
@@ -4342,6 +4618,7 @@ async fn run_in_sandbox_returns_cancelled_when_terminal_grace_times_out() {
         ProcessCancelTimeouts {
             write: PROCESS_CANCEL_WRITE_TIMEOUT,
             terminal_grace: Duration::ZERO,
+            cooperative_grace: Duration::ZERO,
         },
     );
     wait_gate

--- a/crates/runner/src/executor/tests/support/execution.rs
+++ b/crates/runner/src/executor/tests/support/execution.rs
@@ -14,6 +14,7 @@ use super::super::super::{
 };
 use super::config::test_telemetry;
 use crate::error::RunnerResult;
+use crate::run_cancellation::RunCancellationSignals;
 use crate::types::{ExecutionContext, SandboxReuseResult};
 
 pub(in crate::executor::tests) const RUN_IN_SANDBOX_TEST_TIMEOUT: Duration = Duration::from_secs(5);
@@ -80,6 +81,32 @@ pub(in crate::executor::tests) fn spawn_run_in_sandbox_test_with_timeouts(
             },
             &mut telemetry,
             RunControls::new(cancel, None),
+            process_cancel_timeouts,
+        )
+        .await
+    })
+}
+
+pub(in crate::executor::tests) fn spawn_run_in_sandbox_test_with_cancellation(
+    sandbox: Box<dyn Sandbox>,
+    ctx: ExecutionContext,
+    config: ExecutorConfig,
+    cancellation: RunCancellationSignals,
+    process_cancel_timeouts: ProcessCancelTimeouts,
+) -> tokio::task::JoinHandle<RunnerResult<AgentExecutionResult>> {
+    tokio::spawn(async move {
+        let mut telemetry = test_telemetry(&config, &ctx);
+        run_in_sandbox_with_process_cancel_timeouts(
+            &*sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::from_cancellation(cancellation, None),
             process_cancel_timeouts,
         )
         .await

--- a/crates/runner/src/executor/tests/support/mod.rs
+++ b/crates/runner/src/executor/tests/support/mod.rs
@@ -18,7 +18,8 @@ pub(super) use self::env::{
 };
 pub(super) use self::execution::{
     RUN_IN_SANDBOX_TEST_TIMEOUT, run_new_sandbox_outcome, run_new_sandbox_status,
-    spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_timeouts,
+    spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_cancellation,
+    spawn_run_in_sandbox_test_with_timeouts,
 };
 pub(super) use self::manifest::{api_artifact, api_storage};
 pub(super) use self::sandbox::{

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -24,6 +24,7 @@ use super::support::{
 };
 use crate::http::{HttpClient, HttpClientConfig};
 use crate::ids::RunId;
+use crate::run_cancellation::RunCancellationSignals;
 use crate::telemetry::JobTelemetry;
 use crate::types::SandboxReuseResult;
 
@@ -602,7 +603,7 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
         },
         &config,
         &default_params(),
-        cancel,
+        RunCancellationSignals::hard_only(cancel),
         ExecutionHooks {
             sandbox_prepared: None,
             active_input_source: None,
@@ -900,7 +901,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
         minimal_context(),
         &config,
         &default_params(),
-        cancel,
+        RunCancellationSignals::hard_only(cancel),
         ExecutionHooks {
             sandbox_prepared: None,
             active_input_source: None,
@@ -960,7 +961,7 @@ async fn start_process_failure_records_phase_failure_without_spawn_completion() 
         },
         &config,
         &default_params(),
-        cancel,
+        RunCancellationSignals::hard_only(cancel),
         ExecutionHooks {
             sandbox_prepared: None,
             active_input_source: None,

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -10,7 +10,8 @@ use tracing::{error, info, warn};
 
 use api_contracts::generated::{
     constants::runners::{
-        NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE, RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
+        NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE, RUNNER_CANCELLATION_RECOVERY_CAPABILITY,
+        RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
     },
     routes,
 };
@@ -47,6 +48,7 @@ use sandbox::SandboxId;
 #[serde(rename_all = "camelCase")]
 struct ClaimRequestBody {
     telemetry: ClaimRequestTelemetry,
+    capabilities: [&'static str; 1],
 }
 
 #[derive(Serialize)]
@@ -1111,6 +1113,7 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
     };
 
     ClaimRequestBody {
+        capabilities: [RUNNER_CANCELLATION_RECOVERY_CAPABILITY],
         telemetry: ClaimRequestTelemetry {
             discovery_source: candidate.discovery_source().map(JobDiscoverySource::as_str),
             job_discovered_to_claim_request_ms: claim_telemetry_duration_ms(
@@ -2005,7 +2008,10 @@ mod tests {
         assert!(!body.to_string().contains("historyHash"));
         assert!(!body.to_string().contains("cacheKey"));
         assert!(!body.to_string().contains("path"));
-        assert!(body.get("capabilities").is_none());
+        assert_eq!(
+            body["capabilities"],
+            serde_json::json!([RUNNER_CANCELLATION_RECOVERY_CAPABILITY])
+        );
     }
 
     #[test]

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -640,8 +640,8 @@ async fn handle_ably_message_with_network_policy_refresh(
     if let Some(run_id) = parse_cancel_notification(msg) {
         let handle = cancel_tokens.handle(run_id).await;
         if let Some(handle) = handle {
-            info!(run_id = %run_id, "ably: cancel notification, killing job");
-            handle.cancel().await;
+            info!(run_id = %run_id, "ably: cancel notification, requesting cooperative cancellation");
+            handle.request_cooperative_user_cancellation().await;
         }
         return;
     }
@@ -1746,6 +1746,7 @@ mod tests {
         let tokens = RunCancellationRegistry::new();
         let registration = tokens.register(run_id).await.unwrap();
         let token = registration.token();
+        let signals = registration.handle().signals();
         let wakeups = PollWakeups::new(true);
         let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
@@ -1754,6 +1755,8 @@ mod tests {
         handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
         assert!(token.is_cancelled());
+        assert!(signals.cooperative_user().is_cancelled());
+        assert!(!signals.hard().is_cancelled());
         assert_no_direct_candidate(&direct_candidates).await;
     }
 

--- a/crates/runner/src/provider/local/cancel.rs
+++ b/crates/runner/src/provider/local/cancel.rs
@@ -75,7 +75,7 @@ impl LocalCancelScanner {
         for marker in cancel_markers {
             let run_id = marker.run_id;
             if let Some(handle) = tokens.get(&run_id) {
-                if handle.cancel().await {
+                if handle.request_hard_cancellation().await {
                     info!(run_id = %run_id, "local: cancel file detected, cancelling job");
                 }
                 let should_delete = owned_claims.contains(&run_id)
@@ -267,12 +267,15 @@ mod tests {
         let run_id = RunId::new_v4();
         let registration = insert_cancel_registration(&tokens, run_id).await;
         let job_token = registration.token();
+        let signals = registration.handle().signals();
         write_job(dir.path(), run_id);
         write_cancel(dir.path(), run_id);
 
         scanner(dir.path(), tokens).scan_cancel_files().await;
 
         assert!(job_token.is_cancelled(), "cancel token should be triggered");
+        assert!(signals.hard().is_cancelled());
+        assert!(!signals.cooperative_user().is_cancelled());
     }
 
     #[tokio::test]

--- a/crates/runner/src/run_cancellation.rs
+++ b/crates/runner/src/run_cancellation.rs
@@ -33,9 +33,18 @@ pub(crate) struct RunCancellationHandle {
     inner: Arc<RunCancellationInner>,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct RunCancellationSignals {
+    any: CancellationToken,
+    cooperative_user: CancellationToken,
+    hard: CancellationToken,
+}
+
 #[derive(Debug)]
 struct RunCancellationInner {
     token: CancellationToken,
+    cooperative_user_token: CancellationToken,
+    hard_token: CancellationToken,
     transfer_gate: Arc<Mutex<()>>,
 }
 
@@ -58,7 +67,7 @@ impl RunCancellationRegistry {
             state.hard_stopping
         };
         if hard_stopping {
-            handle.cancel().await;
+            handle.request_hard_cancellation().await;
         }
         Ok(RunCancellationRegistration {
             registry: self.clone(),
@@ -127,8 +136,8 @@ impl RunCancellationRegistration {
         self.handle.is_cancelled()
     }
 
-    pub(crate) async fn cancel(&self) -> bool {
-        self.handle.cancel().await
+    pub(crate) async fn request_hard_cancellation(&self) -> bool {
+        self.handle.request_hard_cancellation().await
     }
 
     pub(crate) async fn unregister(&self) -> bool {
@@ -149,6 +158,8 @@ impl RunCancellationHandle {
         Self {
             inner: Arc::new(RunCancellationInner {
                 token: CancellationToken::new(),
+                cooperative_user_token: CancellationToken::new(),
+                hard_token: CancellationToken::new(),
                 transfer_gate: Arc::new(Mutex::new(())),
             }),
         }
@@ -162,11 +173,28 @@ impl RunCancellationHandle {
         self.inner.token.is_cancelled()
     }
 
-    pub(crate) async fn cancel(&self) -> bool {
+    pub(crate) fn signals(&self) -> RunCancellationSignals {
+        RunCancellationSignals {
+            any: self.inner.token.clone(),
+            cooperative_user: self.inner.cooperative_user_token.clone(),
+            hard: self.inner.hard_token.clone(),
+        }
+    }
+
+    pub(crate) async fn request_cooperative_user_cancellation(&self) -> bool {
         let _transfer_guard = self.inner.transfer_gate.lock().await;
-        let was_cancelled = self.inner.token.is_cancelled();
+        let was_requested = self.inner.cooperative_user_token.is_cancelled();
+        self.inner.cooperative_user_token.cancel();
         self.inner.token.cancel();
-        !was_cancelled
+        !was_requested
+    }
+
+    pub(crate) async fn request_hard_cancellation(&self) -> bool {
+        let _transfer_guard = self.inner.transfer_gate.lock().await;
+        let was_requested = self.inner.hard_token.is_cancelled();
+        self.inner.hard_token.cancel();
+        self.inner.token.cancel();
+        !was_requested
     }
 
     pub(crate) async fn transfer_guard(&self) -> OwnedMutexGuard<()> {
@@ -179,6 +207,29 @@ impl RunCancellationHandle {
 
     fn same_registration(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+impl RunCancellationSignals {
+    pub(crate) fn any(&self) -> CancellationToken {
+        self.any.clone()
+    }
+
+    pub(crate) fn cooperative_user(&self) -> CancellationToken {
+        self.cooperative_user.clone()
+    }
+
+    pub(crate) fn hard(&self) -> CancellationToken {
+        self.hard.clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn hard_only(cancel: CancellationToken) -> Self {
+        Self {
+            any: cancel.clone(),
+            cooperative_user: CancellationToken::new(),
+            hard: cancel,
+        }
     }
 }
 
@@ -198,7 +249,12 @@ mod tests {
             DuplicateRunCancellationRegistration,
         );
 
-        registry.handle(run_id).await.unwrap().cancel().await;
+        registry
+            .handle(run_id)
+            .await
+            .unwrap()
+            .request_hard_cancellation()
+            .await;
         assert!(token.is_cancelled());
     }
 
@@ -208,14 +264,17 @@ mod tests {
         let run_id = RunId::new_v4();
         let registration = registry.register(run_id).await.unwrap();
         let token = registration.token();
+        let signals = registration.handle().signals();
 
         let handles = registry.begin_hard_stop().await;
 
         assert_eq!(handles.len(), 1);
         assert_eq!(handles[0].0, run_id);
         assert!(!token.is_cancelled());
-        handles[0].1.cancel().await;
+        handles[0].1.request_hard_cancellation().await;
         assert!(token.is_cancelled());
+        assert!(signals.hard().is_cancelled());
+        assert!(!signals.cooperative_user().is_cancelled());
     }
 
     #[tokio::test]
@@ -226,6 +285,30 @@ mod tests {
         let registration = registry.register(RunId::new_v4()).await.unwrap();
 
         assert!(registration.is_cancelled());
+        assert!(registration.handle().signals().hard().is_cancelled());
+        assert!(
+            !registration
+                .handle()
+                .signals()
+                .cooperative_user()
+                .is_cancelled()
+        );
+    }
+
+    #[tokio::test]
+    async fn cooperative_user_and_hard_cancellation_are_independent_monotonic_signals() {
+        let handle = RunCancellationHandle::new();
+        let signals = handle.signals();
+
+        assert!(handle.request_cooperative_user_cancellation().await);
+        assert!(!handle.request_cooperative_user_cancellation().await);
+        assert!(signals.any().is_cancelled());
+        assert!(signals.cooperative_user().is_cancelled());
+        assert!(!signals.hard().is_cancelled());
+
+        assert!(handle.request_hard_cancellation().await);
+        assert!(!handle.request_hard_cancellation().await);
+        assert!(signals.hard().is_cancelled());
     }
 
     #[tokio::test]
@@ -238,7 +321,12 @@ mod tests {
         let replacement_token = replacement.token();
 
         assert!(!stale.unregister().await);
-        registry.handle(run_id).await.unwrap().cancel().await;
+        registry
+            .handle(run_id)
+            .await
+            .unwrap()
+            .request_hard_cancellation()
+            .await;
 
         assert!(replacement_token.is_cancelled());
     }

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -103,6 +103,8 @@ pub(crate) struct ProcessOverrideState {
     pub(crate) start_process_stdout_chunks: Mutex<VecDeque<Vec<ProcessOutputChunk>>>,
     /// Whether factory-created sandboxes expose a process cancel handle.
     pub(crate) process_cancel_supported: Mutex<bool>,
+    /// Whether factory-created sandboxes expose a process-control handle.
+    pub(crate) process_control_supported: Mutex<bool>,
     /// Recorded process cancel calls across all sandboxes built from this
     /// override set.
     pub(crate) process_cancel_calls: Mutex<Vec<ProcessCancelCall>>,
@@ -135,6 +137,7 @@ impl Default for ProcessOverrideState {
             start_process_calls: Mutex::new(Vec::new()),
             start_process_stdout_chunks: Mutex::new(VecDeque::new()),
             process_cancel_supported: Mutex::new(true),
+            process_control_supported: Mutex::new(true),
             process_cancel_calls: Mutex::new(Vec::new()),
             process_cancel_notify: tokio::sync::Notify::new(),
             process_cancel_errors: Mutex::new(VecDeque::new()),
@@ -493,6 +496,14 @@ impl MockSandboxOverrides {
     /// Configure whether future `start_process` handles include a cancel handle.
     pub fn set_process_cancel_supported(&self, supported: bool) {
         *self.process.process_cancel_supported.lock_ignoring_poison() = supported;
+    }
+
+    /// Configure whether future `start_process` handles include a control handle.
+    pub fn set_process_control_supported(&self, supported: bool) {
+        *self
+            .process
+            .process_control_supported
+            .lock_ignoring_poison() = supported;
     }
 
     /// Return recorded process-cancel calls across all sandboxes built from

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -705,35 +705,42 @@ impl Sandbox for MockSandbox {
         {
             *self.stdout_tx.lock_ignoring_poison() = Some(tx);
         }
-        let control = (request.control == ProcessControlMode::Enabled).then(|| {
-            let overrides = self.overrides.clone();
-            GuestProcessControlHandle::new(move |message_id, payload, timeout| {
-                let overrides = overrides.clone();
-                Box::pin(async move {
-                    if let Some(overrides) = overrides {
-                        overrides
-                            .process
-                            .process_control_calls
-                            .lock_ignoring_poison()
-                            .push(ProcessControlCall {
-                                message_id: message_id.clone(),
-                                payload,
-                                timeout,
-                            });
-                        overrides.process.process_control_notify.notify_waiters();
-                        if let Some((kind, message)) = overrides
-                            .process
-                            .process_control_errors
-                            .lock_ignoring_poison()
-                            .pop_front()
-                        {
-                            return Err(std::io::Error::new(kind, message));
-                        }
-                    }
-                    Ok(ProcessControlAck { message_id })
-                })
-            })
+        let process_control_supported = self.overrides.as_ref().is_none_or(|overrides| {
+            *overrides
+                .process
+                .process_control_supported
+                .lock_ignoring_poison()
         });
+        let control = (request.control == ProcessControlMode::Enabled && process_control_supported)
+            .then(|| {
+                let overrides = self.overrides.clone();
+                GuestProcessControlHandle::new(move |message_id, payload, timeout| {
+                    let overrides = overrides.clone();
+                    Box::pin(async move {
+                        if let Some(overrides) = overrides {
+                            overrides
+                                .process
+                                .process_control_calls
+                                .lock_ignoring_poison()
+                                .push(ProcessControlCall {
+                                    message_id: message_id.clone(),
+                                    payload,
+                                    timeout,
+                                });
+                            overrides.process.process_control_notify.notify_waiters();
+                            if let Some((kind, message)) = overrides
+                                .process
+                                .process_control_errors
+                                .lock_ignoring_poison()
+                                .pop_front()
+                            {
+                                return Err(std::io::Error::new(kind, message));
+                            }
+                        }
+                        Ok(ProcessControlAck { message_id })
+                    })
+                })
+            });
         let process_cancel = self.overrides.as_ref().and_then(|overrides| {
             if !*overrides
                 .process


### PR DESCRIPTION
## Summary

- advertise `user-cancellation-recovery-v1` on API job claims
- separate cooperative user cancellation from runner-owned hard containment
- ask guest-agent to checkpoint recovery state and exit within the shared 90-second grace
- preempt cooperative recovery with hard shutdown and reuse the existing bounded process-cancel fallback
- keep local-provider cancellation hard-only because it has no API capability negotiation

## Compatibility

- old runners continue omitting the optional capability and retain legacy behavior
- overlapping old APIs accept the additive open-ended capability field
- the bundled runner and guest ship together, and the required API barrier is already deployed

## Scope

This does not change API or database behavior, guest recovery logic, sandbox park/destroy policy, workspace-cache promotion, or the later idempotent runner `/complete` fallback.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner -p sandbox-mock --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner -p sandbox-mock --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock` (78 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner` (2896 passed, 14 ignored; guest inventory passed)

Closes #23870

Parent delivery issue: #23867
