### PR TITLE
docs(sandbox-fc): document cow producer invariants

### DIFF
--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -1,8 +1,52 @@
-//! COW slot producer for Firecracker VMs.
+//! Bounded producer for connected, one-shot COW slots used by Firecracker VMs.
 //!
-//! Pre-creates one-shot COW slots in bounded background workers to reduce
-//! sandbox creation latency. A slot is consumed by one sandbox and is never
-//! returned to this producer.
+//! Pre-creating the COW file and its NBD device removes that work from the
+//! sandbox creation path. Every [`CowPoolHandle`] clone communicates with one
+//! background actor, which exclusively owns [`state::CowPool`] and serializes
+//! its state transitions.
+//!
+//! # Ownership
+//!
+//! The actor distinguishes these ownership states:
+//!
+//! - the ready queue owns completed [`PreparedCowSlot`] values available for
+//!   acquisition;
+//! - pending tasks own in-flight slot creations;
+//! - teardown tasks own completed slots that no longer belong in the ready
+//!   pipeline;
+//! - the waiter queue owns FIFO acquisition requests, not slots.
+//!
+//! A successful response transfers its slot out of producer ownership and
+//! accounting. The caller consumes it through [`PreparedCowSlot::checkout_to`];
+//! the slot is never returned to this producer. A receiver that closes before
+//! the transfer is skipped without losing the slot.
+//!
+//! # Scheduling and bounds
+//!
+//! Pipeline inventory is the ready queue plus pending creations. Its target is
+//! the warm buffer plus live acquisition waiters, capped by the global slot
+//! limit. Creation and steady-state teardown tasks share bounded task capacity.
+//! Ready slots and waiters are matched FIFO.
+//!
+//! A scheduled warm retry delays background-only replenishment, but live demand
+//! may still start creation. One creation failure is delivered to one live
+//! waiter; any remaining demand is repumped subject to the normal bounds. A
+//! completed slot that is no longer needed enters explicit teardown instead of
+//! increasing ready inventory.
+//!
+//! # Shutdown
+//!
+//! The actor's biased polling order considers cleanup, creation completions,
+//! teardown completions, and due warm retries before ordinary queued commands
+//! when multiple branches are ready. Cleanup deactivates the producer, rejects
+//! acquisition waiters, completes warmup waiters, and drains ready slots,
+//! in-flight creations, and existing teardowns. Successful late creations
+//! remain pool-owned and enter the cleanup teardown queue.
+//!
+//! Shutdown is acknowledged only after every pool-owned slot's explicit
+//! [`destroy_prepared_slot_async`] task has finished. Finalization can preserve
+//! backing files when the NBD device lifecycle cannot prove that deletion is
+//! safe.
 
 mod actor;
 mod create;

--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -43,10 +43,10 @@
 //! in-flight creations, and existing teardowns. Successful late creations
 //! remain pool-owned and enter the cleanup teardown queue.
 //!
-//! Shutdown is acknowledged only after every pool-owned slot's explicit
-//! [`destroy_prepared_slot_async`] task has finished. Finalization can preserve
-//! backing files when the NBD device lifecycle cannot prove that deletion is
-//! safe.
+//! Cleanup acknowledges shutdown only after pending creations have drained and
+//! all ready, late, and already-running [`destroy_prepared_slot_async`] teardown
+//! work has finished. Finalization can preserve backing files when the NBD
+//! device lifecycle cannot prove that deletion is safe.
 
 mod actor;
 mod create;


### PR DESCRIPTION
## Summary

- expand the Firecracker COW producer module rustdoc into the central architecture overview
- document actor ownership, pipeline and task bounds, FIFO cancellation handling, retry behavior, and shutdown drain semantics
- cross-link the state owner, checked-out slot lifecycle, and explicit finalizer while keeping runtime behavior unchanged

## Compatibility

This is a source-rustdoc-only change. It does not change scheduling, capacity, retry, cleanup,
NBD behavior, APIs, protocols, schemas, persisted data, configuration, telemetry, or rollout.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features`
- `cargo clippy --all-targets --all-features`
- `cargo doc -p sandbox-fc --all-features --no-deps`
- `cargo doc -p sandbox-fc --all-features --no-deps --document-private-items`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p sandbox-fc --all-targets --all-features` (793 passed)

Closes #24173
