### PR TITLE
perf(vsock-guest): avoid production drain wait in orphan test

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -24,6 +24,7 @@ use crate::handlers::{
 use crate::log::log;
 use crate::process_containment::{ProcessContainmentMode, verify_exec_process_containment_empty};
 use crate::quiesce::{AcquireOperationError, OperationGuard, OperationState, QuiesceResult};
+use crate::wait::DRAIN_DEADLINE;
 use crate::writer::GuestWriter;
 
 // Vsock constants (only used on Linux)
@@ -258,6 +259,7 @@ struct ConnectionDispatcher {
     exec_control_registry: ExecControlRegistry,
     operation_state: OperationState,
     process_containment_mode: ProcessContainmentMode,
+    exec_drain_deadline: Duration,
 }
 
 impl ConnectionDispatcher {
@@ -265,6 +267,7 @@ impl ConnectionDispatcher {
         writer: GuestWriter,
         connection_cancel: Arc<AtomicBool>,
         process_containment_mode: ProcessContainmentMode,
+        exec_drain_deadline: Duration,
     ) -> io::Result<Self> {
         let file_write_worker =
             FileWriteWorker::start(writer.clone(), Arc::clone(&connection_cancel))?;
@@ -276,6 +279,7 @@ impl ConnectionDispatcher {
             exec_control_registry: ExecControlRegistry::default(),
             operation_state: OperationState::default(),
             process_containment_mode,
+            exec_drain_deadline,
         })
     }
 
@@ -312,6 +316,7 @@ impl ConnectionDispatcher {
             msg.seq,
             decoded,
             self.process_containment_mode,
+            self.exec_drain_deadline,
         ) {
             Ok(request) => request,
             Err(error) => {
@@ -568,11 +573,39 @@ pub fn handle_connection_with_test_process_containment(stream: UnixStream) -> io
     handle_connection_with_mode(stream, ProcessContainmentMode::TestNoop)
 }
 
+/// Handles a host-side test connection with an explicit exec output drain deadline.
+///
+/// This integration-test hook retains test process containment while allowing a real exec request
+/// to exercise timeout-driven output cancellation without waiting for the production deadline.
+#[doc(hidden)]
+pub fn handle_connection_with_test_process_containment_and_exec_drain_deadline(
+    stream: UnixStream,
+    exec_drain_deadline: Duration,
+) -> io::Result<()> {
+    handle_connection_with_mode_and_exec_drain_deadline(
+        stream,
+        ProcessContainmentMode::TestNoop,
+        exec_drain_deadline,
+    )
+}
+
 fn handle_connection_with_mode(
     stream: UnixStream,
     process_containment_mode: ProcessContainmentMode,
 ) -> io::Result<()> {
-    match handle_connection_with_outcome(stream, process_containment_mode) {
+    handle_connection_with_mode_and_exec_drain_deadline(
+        stream,
+        process_containment_mode,
+        DRAIN_DEADLINE,
+    )
+}
+
+fn handle_connection_with_mode_and_exec_drain_deadline(
+    stream: UnixStream,
+    process_containment_mode: ProcessContainmentMode,
+    exec_drain_deadline: Duration,
+) -> io::Result<()> {
+    match handle_connection_with_outcome(stream, process_containment_mode, exec_drain_deadline) {
         Ok(_) => Ok(()),
         Err(failure) => Err(failure.error),
     }
@@ -581,6 +614,7 @@ fn handle_connection_with_mode(
 fn handle_connection_with_outcome(
     stream: UnixStream,
     process_containment_mode: ProcessContainmentMode,
+    exec_drain_deadline: Duration,
 ) -> Result<ConnectionEnd, ConnectionFailure> {
     // Clone the stream to get separate reader and writer
     // This avoids deadlock: reader can block while worker threads write results.
@@ -603,9 +637,13 @@ fn handle_connection_with_outcome(
     log("INFO", "Sent ready signal");
 
     let mut session = ConnectionSession::new();
-    let dispatcher =
-        ConnectionDispatcher::new(writer, connection_cancel.clone(), process_containment_mode)
-            .map_err(|error| session.failure(error))?;
+    let dispatcher = ConnectionDispatcher::new(
+        writer,
+        connection_cancel.clone(),
+        process_containment_mode,
+        exec_drain_deadline,
+    )
+    .map_err(|error| session.failure(error))?;
     let mut buf = [0u8; READ_BUFFER_SIZE];
     loop {
         // Read from stream (reader is separate, no lock needed)
@@ -747,7 +785,7 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                 .map_err(unstable_connection_failure)
                 .and_then(|stream| {
                     log("INFO", "Connected");
-                    handle_connection_with_outcome(stream, process_containment_mode)
+                    handle_connection_with_outcome(stream, process_containment_mode, DRAIN_DEADLINE)
                 })
         } else {
             log("INFO", "Connecting to host (CID=2)...");
@@ -755,7 +793,7 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                 .map_err(unstable_connection_failure)
                 .and_then(|stream| {
                     log("INFO", "Connected");
-                    handle_connection_with_outcome(stream, process_containment_mode)
+                    handle_connection_with_outcome(stream, process_containment_mode, DRAIN_DEADLINE)
                 })
         };
 

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -70,10 +70,7 @@ use crate::shell_command::{
     truncate_command_preview,
 };
 use crate::threading::{SystemThreadSpawner, ThreadSpawner};
-use crate::wait::{
-    DRAIN_DEADLINE_SECS, WaitOutcome, await_drain_deadline,
-    wait_with_kill_timeout_or_cancelled_either,
-};
+use crate::wait::{WaitOutcome, await_drain_deadline, wait_with_kill_timeout_or_cancelled_either};
 use crate::writer::GuestWriter;
 
 const THREAD_EXEC_OPERATION_WORKER: &str = "vsock-exec-operation-worker";
@@ -220,6 +217,7 @@ pub(crate) struct ExecOperationWorkerRequest {
     exec_control_guard: Option<ExecControlGuard>,
     exec_control_bootstrap_endpoint: Option<String>,
     process_containment_mode: ProcessContainmentMode,
+    drain_deadline: Duration,
 }
 
 impl ExecOperationWorkerRequest {
@@ -227,6 +225,7 @@ impl ExecOperationWorkerRequest {
         seq: u32,
         decoded: vsock_proto::DecodedExecStart<'_>,
         process_containment_mode: ProcessContainmentMode,
+        drain_deadline: Duration,
     ) -> io::Result<Self> {
         let lifecycle = match decoded.lifecycle {
             ExecLifecyclePolicy::OneShot => ExecOperationLifecycle::OneShot,
@@ -281,6 +280,7 @@ impl ExecOperationWorkerRequest {
             exec_control_guard: None,
             exec_control_bootstrap_endpoint: None,
             process_containment_mode,
+            drain_deadline,
         })
     }
 
@@ -717,14 +717,16 @@ impl RunningExec {
             drain_cancel.store(true, Ordering::Release);
         }
 
-        let completed = await_drain_deadline(&drain_done_rx, 2, &drain_cancel);
+        let completed =
+            await_drain_deadline(&drain_done_rx, 2, &drain_cancel, request.drain_deadline);
         if completed < 2 {
             log(
                 "WARN",
                 &format!(
-                    "exec operation: drain deadline reached seq={} label={} after {DRAIN_DEADLINE_SECS}s",
+                    "exec operation: drain deadline reached seq={} label={} after {:?}",
                     request.seq,
-                    truncate_command_preview(&request.label)
+                    truncate_command_preview(&request.label),
+                    request.drain_deadline,
                 ),
             );
         }
@@ -1713,6 +1715,7 @@ mod tests {
             exec_control_guard: None,
             exec_control_bootstrap_endpoint: None,
             process_containment_mode: ProcessContainmentMode::BuildConfigured,
+            drain_deadline: crate::wait::DRAIN_DEADLINE,
         }
     }
 

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -19,7 +19,8 @@ use crate::shutdown::handle_shutdown;
 use crate::threading::{SystemThreadSpawner, ThreadSpawner, spawn_scoped_named};
 use crate::user::apply_write_file_identity;
 use crate::wait::{
-    WaitOutcome, await_drain_deadline, wait_with_kill_timeout_or_connection_cancelled,
+    DRAIN_DEADLINE, WaitOutcome, await_drain_deadline,
+    wait_with_kill_timeout_or_connection_cancelled,
 };
 
 const THREAD_WRITE_STDERR: &str = "vsock-write-stderr";
@@ -175,7 +176,7 @@ where
             Err(e) => {
                 cancel.store(true, std::sync::atomic::Ordering::Release);
                 kill_and_reap_child(child);
-                let _ = await_drain_deadline(&done_rx, 1, &cancel);
+                let _ = await_drain_deadline(&done_rx, 1, &cancel, DRAIN_DEADLINE);
                 let _ = stderr_handle.join();
                 return (false, format!("Failed to spawn stdin writer thread: {e}"));
             }
@@ -197,7 +198,7 @@ where
             Err(panic) => std::panic::resume_unwind(panic),
         };
 
-        let _ = await_drain_deadline(&done_rx, 1, &cancel);
+        let _ = await_drain_deadline(&done_rx, 1, &cancel, DRAIN_DEADLINE);
         let stderr = stderr_handle.join().unwrap_or_default();
 
         match outcome {

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -28,7 +28,8 @@ mod writer;
 
 pub use connection::{
     connect_unix, connect_vsock, handle_connection,
-    handle_connection_with_test_process_containment, run,
+    handle_connection_with_test_process_containment,
+    handle_connection_with_test_process_containment_and_exec_drain_deadline, run,
 };
 pub use log::log;
 

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -12,7 +12,7 @@ use crate::threading::spawn_scoped_named;
 /// many seconds. If EOF is not received within this deadline, proceed to
 /// the terminal exec result anyway to prevent indefinite hangs when orphaned
 /// child processes hold pipe fds open.
-pub(crate) const DRAIN_DEADLINE_SECS: u64 = 5;
+pub(crate) const DRAIN_DEADLINE: Duration = Duration::from_secs(5);
 const WAIT_CANCEL_POLL_INTERVAL_MS: u64 = 50;
 const THREAD_WAIT_OBSERVER: &str = "vsock-wait-observer";
 
@@ -44,8 +44,9 @@ pub(crate) fn await_drain_deadline(
     done_rx: &mpsc::Receiver<()>,
     expected: usize,
     cancel: &AtomicBool,
+    drain_deadline: Duration,
 ) -> usize {
-    let deadline = Instant::now() + Duration::from_secs(DRAIN_DEADLINE_SECS);
+    let deadline = Instant::now() + drain_deadline;
     let mut completed = 0usize;
     while completed < expected {
         let remaining = deadline.saturating_duration_since(Instant::now());

--- a/crates/vsock-guest/tests/connection/exec_cancel_cleanup.rs
+++ b/crates/vsock-guest/tests/connection/exec_cancel_cleanup.rs
@@ -269,9 +269,10 @@ fn exec_operation_different_sequences_run_concurrently_and_cancel_independently(
 fn exec_operation_returns_when_orphaned_grandchild_holds_stdout() {
     use std::time::Instant;
 
-    let (handle, mut host_stream) = start_guest_connection();
+    let (handle, mut host_stream) =
+        start_guest_connection_with_exec_drain_deadline(Duration::from_millis(500));
     host_stream
-        .set_read_timeout(Some(Duration::from_secs(15)))
+        .set_read_timeout(Some(Duration::from_secs(DRAIN_DEADLINE_SECS + 5)))
         .unwrap();
     let orphan = OrphanProcessGuard::new("orphan-exec-operation-sleep");
     let command = orphan_sleep_command("orphan-exec-operation", orphan.pid_path());
@@ -295,8 +296,8 @@ fn exec_operation_returns_when_orphaned_grandchild_holds_stdout() {
         String::from_utf8_lossy(&stdout),
     );
     assert!(
-        elapsed < Duration::from_secs(DRAIN_DEADLINE_SECS + 5),
-        "exec result should arrive within drain deadline, took {elapsed:?}",
+        elapsed < Duration::from_secs(DRAIN_DEADLINE_SECS),
+        "test exec result should arrive before the production drain deadline, took {elapsed:?}",
     );
 
     finish_guest_connection(handle, host_stream);

--- a/crates/vsock-guest/tests/connection/support/connection.rs
+++ b/crates/vsock-guest/tests/connection/support/connection.rs
@@ -2,16 +2,35 @@ use std::os::unix::net::UnixStream;
 use std::thread;
 use std::time::Duration;
 
-use vsock_guest::handle_connection_with_test_process_containment;
+use vsock_guest::{
+    handle_connection_with_test_process_containment,
+    handle_connection_with_test_process_containment_and_exec_drain_deadline,
+};
 
 use super::protocol::read_and_discard_message;
 
 pub(crate) type GuestConnectionHandle = thread::JoinHandle<std::io::Result<()>>;
 
 pub(crate) fn start_guest_connection() -> (GuestConnectionHandle, UnixStream) {
+    start_guest_connection_with_handler(handle_connection_with_test_process_containment)
+}
+
+pub(crate) fn start_guest_connection_with_exec_drain_deadline(
+    exec_drain_deadline: Duration,
+) -> (GuestConnectionHandle, UnixStream) {
+    start_guest_connection_with_handler(move |stream| {
+        handle_connection_with_test_process_containment_and_exec_drain_deadline(
+            stream,
+            exec_drain_deadline,
+        )
+    })
+}
+
+fn start_guest_connection_with_handler(
+    handler: impl FnOnce(UnixStream) -> std::io::Result<()> + Send + 'static,
+) -> (GuestConnectionHandle, UnixStream) {
     let (guest_stream, mut host_stream) = UnixStream::pair().unwrap();
-    let handle =
-        thread::spawn(move || handle_connection_with_test_process_containment(guest_stream));
+    let handle = thread::spawn(move || handler(guest_stream));
     read_and_discard_message(&mut host_stream);
     host_stream
         .set_read_timeout(Some(Duration::from_secs(5)))

--- a/crates/vsock-guest/tests/connection/support/mod.rs
+++ b/crates/vsock-guest/tests/connection/support/mod.rs
@@ -6,6 +6,7 @@ mod temp_paths;
 
 pub(crate) use connection::{
     finish_guest_connection, join_guest_connection, start_guest_connection,
+    start_guest_connection_with_exec_drain_deadline,
 };
 pub(crate) use exec::{
     DRAIN_DEADLINE_SECS, LARGE_ENV_COMMAND, LONG_RUNNING_EXEC_TIMEOUT_MS, assert_large_env_stdout,


### PR DESCRIPTION
## Summary

- make the shared output drain helper accept an explicit `Duration` while retaining the five-second production default
- carry an immutable exec drain deadline per connection and expose a narrowly scoped hidden integration-test entry point
- run the real orphaned-grandchild integration scenario with a 500 ms deadline, reducing the 66-test connection binary from about 5.03 seconds to about 2.1 seconds

## Scope

- production connection entry points and write-file draining still use five seconds
- the override is isolated to one test connection and cannot leak across parallel tests
- no vsock protocol, request payload, persistence, API, or deployment behavior changes

## Validation

- focused orphan integration test: passed once after build and five repeated warm runs at 0.50-0.51 seconds
- `cargo test -p vsock-guest --test connection` (66 passed; 2.06 seconds)
- `cargo test -p vsock-guest --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-guest --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p vsock-guest --all-features --no-deps`
- `cargo check -p vsock-guest --release --no-default-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo clippy --all-targets --all-features`
- pre-commit and commit-message hooks

Closes #24170
