### PR TITLE
docs(sandbox): clarify workspace seed ownership

### DIFF
--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -101,11 +101,15 @@ pub struct DeviceRateLimits {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum WorkspaceDriveSeedImage {
     /// Copy the host-local ext4 image into this sandbox's active workspace
-    /// image. The source must remain intact and must never be mounted
-    /// read-write by the provider.
+    /// image. The caller retains ownership, and the source must remain intact
+    /// and must never be mounted read-write by the provider.
     Copy(PathBuf),
     /// Move the host-local ext4 image into this sandbox's active workspace
-    /// image. The source is consumed when sandbox preparation succeeds.
+    /// image. The caller retains ownership until the provider completes the
+    /// transfer and consumes the source from its original path. If the
+    /// transfer fails before that boundary, the source remains caller-owned.
+    /// After that boundary, a later sandbox-creation failure does not return
+    /// ownership or require the provider to restore the original path.
     Move(PathBuf),
 }
 

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -298,10 +298,17 @@ pub trait SandboxFactory: Send + Sync {
     fn config_hash(&self) -> String;
     /// Create a new sandbox instance with the given per-sandbox configuration.
     ///
+    /// If `config` uses [`crate::WorkspaceDriveSeedImage::Move`], this method
+    /// may return an error after source ownership has transferred to the
+    /// provider. Callers must not infer source availability from the final
+    /// result.
+    ///
     /// The returned sandbox belongs to this factory's lifecycle and should be
     /// released through [`destroy`](Self::destroy) on the normal teardown path.
     async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>>;
     /// Create a sandbox while reporting create-stage timings to `observer`.
+    ///
+    /// Seed-image ownership and failure semantics match [`Self::create`].
     ///
     /// Implementations can report only the boundaries applicable to their
     /// provider. Callers must not assume a complete callback set after an error


### PR DESCRIPTION
## Summary

- define the provider-neutral ownership-transfer boundary for workspace seed image moves
- clarify that copy sources remain caller-owned and intact
- document that factory creation can fail after a move source has been consumed
- align `create_with_observer` with the same seed-image ownership semantics

## Scope

Documentation only. This does not change sandbox provider behavior, runner cache handling, rollback, persistence, protocols, configuration, or deployment.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox --all-targets --all-features`
- `cargo doc -p sandbox --all-features --no-deps`
- `cargo test -p sandbox`
- pre-commit workspace Rust formatting, Clippy, Rustdoc, and file-size checks
- commit message lint

Closes #24172
