### PR TITLE
test(guest-agent): avoid event recovery retry waits

### DIFF
--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -29,6 +29,8 @@ use uuid::Uuid;
 const LOG_TAG: &str = "sandbox:guest-agent";
 const HTTP_TOO_MANY_REQUESTS: u16 = 429;
 const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(1);
+#[cfg(debug_assertions)]
+const TEST_DISABLE_HTTP_RETRY_DELAY_ENV: &str = "VM0_TEST_DISABLE_HTTP_RETRY_DELAY";
 const GUEST_AGENT_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Content-safe facts published before one event request is awaited.
@@ -184,7 +186,21 @@ impl HttpClient {
                 api: None,
             });
         };
-        Self::build(Some(api), DEFAULT_RETRY_DELAY)
+        let retry_delay = {
+            #[cfg(debug_assertions)]
+            {
+                if std::env::var_os(TEST_DISABLE_HTTP_RETRY_DELAY_ENV).is_some() {
+                    Duration::ZERO
+                } else {
+                    DEFAULT_RETRY_DELAY
+                }
+            }
+            #[cfg(not(debug_assertions))]
+            {
+                DEFAULT_RETRY_DELAY
+            }
+        };
+        Self::build(Some(api), retry_delay)
     }
 
     pub fn has_api(&self) -> bool {

--- a/crates/guest-agent/tests/event_delivery_failure_recovery.rs
+++ b/crates/guest-agent/tests/event_delivery_failure_recovery.rs
@@ -138,6 +138,7 @@ async fn run_event_failure_case(
         Duration::from_secs(20),
         Command::new(env!("CARGO_BIN_EXE_guest-agent"))
             .env_clear()
+            .env("VM0_TEST_DISABLE_HTTP_RETRY_DELAY", "1")
             .env(
                 "PATH",
                 std::env::var("PATH")


### PR DESCRIPTION
## Summary

- add a debug-only test seam at the existing HTTP client retry-delay boundary
- disable only inter-attempt sleeps in the event delivery recovery subprocess fixture
- reduce the focused test runtime from about 4.05 seconds to about 0.03 seconds while preserving real HTTP attempts, diagnostics, and exit behavior

## Behavior and compatibility

- release builds continue to use the production one-second retry delay; the test environment-variable lookup is compiled out
- retry counts, HTTP status handling, request timeouts, event delivery behavior, and the test's 20-second hang guard remain unchanged
- no API, protocol, database, configuration, or rollout changes

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo check --manifest-path crates/Cargo.toml -p guest-agent --release`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test event_delivery_failure_recovery -- --nocapture`
- focused test repeated sequentially 10 times, all passing in about 0.03 seconds per run
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features --quiet`

Closes #24169
