### PR TITLE
test(connectors): remove legacy client migration fixtures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents.test.ts
@@ -5,7 +5,6 @@ import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-co
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { createApp } from "../../../app-factory";
 import {
   deleteFeatureSwitchesForUser,
   updateFeatureSwitchesForUser,
@@ -65,7 +64,7 @@ describe("GET /api/zero/agents/:id/user-connectors", () => {
     await deleteFeatureSwitchesForUser(context, actor);
   });
 
-  it("updates canonical connector slugs and rejects legacy aliases", async () => {
+  it("updates canonical connector slugs", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
@@ -108,18 +107,5 @@ describe("GET /api/zero/agents/:id/user-connectors", () => {
     expect(new Set(added.body.enabledConnectorSlugs)).toStrictEqual(
       new Set(["github", "slack"]),
     );
-
-    const legacy = await createApp({ signal: context.signal }).request(
-      `/api/zero/agents/${created.body.agentId}/user-connectors`,
-      {
-        method: "PUT",
-        headers: {
-          authorization: "Bearer clerk-session",
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({ enabledTypes: ["github"] }),
-      },
-    );
-    expect(legacy.status).toBe(400);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-check.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-check.test.ts
@@ -300,23 +300,6 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
     );
     expect(malformed.status).toBe(400);
 
-    const legacyIdentity = await createApp({
-      signal: context.signal,
-    }).request("/api/zero/connectors/diagnostics/check", {
-      method: "POST",
-      headers: {
-        authorization: "Bearer clerk-session",
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        mode: "url",
-        method: "GET",
-        url: "https://api.github.com/repos/vm0-ai/vm0",
-        connectorRef: "github",
-      }),
-    });
-    expect(legacyIdentity.status).toBe(400);
-
     const invalidMethod = await checkWithSession(actor, {
       mode: "url",
       method: "TRACE",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -219,7 +219,7 @@ describe("zero user permission grants", () => {
     });
   });
 
-  it("accepts canonical connector slugs and rejects legacy aliases", async () => {
+  it("accepts canonical connector slugs", async () => {
     const fixture = await createFixture();
     const agentId = await seedAgent(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
@@ -244,30 +244,6 @@ describe("zero user permission grants", () => {
     expect(canonical.body[0]).toMatchObject({
       connectorSlug: SLACK_CONNECTOR,
     });
-
-    const app = createApp({ signal: context.signal });
-    const legacy = await app.request("/api/zero/user-permission-grants/apply", {
-      method: "PUT",
-      headers: {
-        authorization: AUTH_HEADERS.authorization,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ ...base, connectorRef: SLACK_CONNECTOR }),
-    });
-    expect(legacy.status).toBe(400);
-
-    const missing = await app.request(
-      "/api/zero/user-permission-grants/apply",
-      {
-        method: "PUT",
-        headers: {
-          authorization: AUTH_HEADERS.authorization,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify(base),
-      },
-    );
-    expect(missing.status).toBe(400);
   });
 
   it("uses visible-agent scope for private and cross-org agents", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
@@ -123,57 +123,6 @@ describe("connector callback page", () => {
     );
   });
 
-  it("ignores stale legacy callback metadata while completing the callback", async () => {
-    const legacyIcon = createGithubIcon();
-    context.store.set(
-      setConnectorAppOauthCallbackMetadata$,
-      JSON.stringify({
-        connectorRef: "github",
-        icon: legacyIcon,
-      }),
-    );
-    let observedQuery: Readonly<Record<string, string | undefined>> = {};
-    context.mocks.api(
-      connectorsSlugCallbackContract.callback,
-      ({ params, query, respond }) => {
-        expect(params.connectorSlug).toBe("github");
-        observedQuery = query;
-        return respond(200, {
-          status: "success",
-          username: "octocat",
-        });
-      },
-    );
-
-    detachedSetupPage({
-      context,
-      path: "/connectors/github/callback?code=oauth-code&state=oauth-state",
-      user: null,
-      session: null,
-    });
-
-    const heading = await screen.findByRole("heading", {
-      name: "GitHub connected",
-    });
-    expect(heading.parentElement?.querySelector("img")).toBeNull();
-    expect(
-      screen.getByText("Connected as octocat. You can close this window."),
-    ).toBeInTheDocument();
-    expect(observedQuery).toMatchObject({
-      code: "oauth-code",
-      state: "oauth-state",
-      responseMode: "json",
-    });
-    await waitFor(() => {
-      expect(pathname()).toBe("/connectors/github/callback/success");
-    });
-    const resultSearchParams = new URLSearchParams(search());
-    expect(resultSearchParams.get("username")).toBe("octocat");
-    expect(resultSearchParams.get("iconUrl")).toBeNull();
-    expect(resultSearchParams.get("iconInvertInDarkMode")).toBeNull();
-    expect(resultSearchParams.get("iconScale")).toBeNull();
-  });
-
   it("renders the API failure result without retaining OAuth parameters", async () => {
     context.mocks.api(
       connectorsSlugCallbackContract.callback,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1708,7 +1708,6 @@ describe("connectors page", () => {
       connectorAppOauthCallbackMetadata$,
     );
     expect(callbackMetadata).toContain('"connectorSlug":"google-maps"');
-    expect(callbackMetadata).not.toContain("connectorRef");
     expect(
       screen.queryByRole("dialog", { name: "Google Maps" }),
     ).not.toBeInTheDocument();

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
@@ -195,178 +195,10 @@ describe("connector client response contracts", () => {
       connectorChangedPayloadSchema.parse({ connectorSlug: "github" }),
     ).toStrictEqual({ connectorSlug: "github" });
   });
-
-  it("parses the previous expanded responses and strips legacy aliases", () => {
-    expect(
-      connectorResponseSchema.parse({ ...connector, type: "github" }),
-    ).toStrictEqual(connector);
-    expect(
-      connectorListResponseSchema.parse({
-        connectors: [{ ...connector, type: "github" }],
-        configuredTypes: ["github"],
-        configuredConnectorSlugs: ["github"],
-        connectorProvidedBindings: [
-          {
-            connectorType: "github",
-            connectorSlug: "github",
-            authMethod: "oauth",
-            namespace: "secrets",
-            name: "GITHUB_TOKEN",
-            optional: false,
-            source: { kind: "connector-secret", name: "accessToken" },
-          },
-        ],
-      }),
-    ).toStrictEqual({
-      connectors: [connector],
-      configuredConnectorSlugs: ["github"],
-      connectorProvidedBindings: [
-        {
-          connectorSlug: "github",
-          authMethod: "oauth",
-          namespace: "secrets",
-          name: "GITHUB_TOKEN",
-          optional: false,
-          source: { kind: "connector-secret", name: "accessToken" },
-        },
-      ],
-    });
-    expect(
-      connectorOauthDeviceAuthSessionStartResponseSchema.parse({
-        sessionId: "00000000-0000-4000-a000-000000000003",
-        sessionToken: "session-token",
-        type: "github",
-        connectorSlug: "github",
-        status: "pending",
-        userCode: "ABCD-EFGH",
-        verificationUri: "https://example.test/device",
-        expiresIn: 600,
-        interval: 5,
-      }),
-    ).not.toHaveProperty("type");
-    expect(
-      connectorExternalCodeSessionStartResponseSchema.parse({
-        sessionId: "00000000-0000-4000-a000-000000000004",
-        sessionToken: "session-token",
-        type: "aws",
-        connectorSlug: "aws",
-        status: "pending",
-        authorizationUrl: "https://example.test/authorize",
-        expiresIn: 600,
-      }),
-    ).not.toHaveProperty("type");
-    expect(
-      zeroConnectorsSearchContract.search.responses[200].parse({
-        connectors: [
-          {
-            id: "github",
-            slug: "github",
-            label: "GitHub",
-            description: "GitHub connector",
-            authMethods: ["oauth"],
-          },
-        ],
-      }),
-    ).toStrictEqual({
-      connectors: [
-        {
-          slug: "github",
-          label: "GitHub",
-          description: "GitHub connector",
-          authMethods: ["oauth"],
-        },
-      ],
-    });
-    expect(
-      zeroConnectorCatalogContract.list.responses[200].parse({
-        connectors: [{ ...catalogItem, connectorRef: "github" }],
-      }),
-    ).toStrictEqual({ connectors: [catalogItem] });
-    expect(
-      zeroConnectorCatalogContract.permissions.responses[200].parse({
-        permissions: {
-          connectorRef: "github",
-          connectorSlug: "github",
-          label: "GitHub",
-          icon: catalogItem.icon,
-          permissionCount: 0,
-          permissions: [],
-          categories: null,
-          defaultPolicy: {
-            permissionDefault: "ask",
-            unknownPolicy: "ask",
-          },
-        },
-      }),
-    ).not.toHaveProperty("permissions.connectorRef");
-    expect(
-      connectorCheckDiagnosticResultSchema.parse({
-        outcome: "ambiguous",
-        candidates: [
-          { connectorSlug: "github", connectorRef: "github", label: "GitHub" },
-          { connectorSlug: "gitlab", connectorRef: "gitlab", label: "GitLab" },
-        ],
-      }),
-    ).toStrictEqual({
-      outcome: "ambiguous",
-      candidates: [
-        { connectorSlug: "github", label: "GitHub" },
-        { connectorSlug: "gitlab", label: "GitLab" },
-      ],
-    });
-    expect(
-      userConnectorEnabledSlugsSchema.parse({
-        enabledTypes: ["github"],
-        enabledConnectorSlugs: ["github"],
-      }),
-    ).toStrictEqual({ enabledConnectorSlugs: ["github"] });
-    expect(
-      userPermissionGrantResponseSchema.parse({
-        agentId: AGENT_ID,
-        connectorRef: "github",
-        connectorSlug: "github",
-        permission: "contents:read",
-        action: "allow",
-        expiresAt: null,
-        createdAt: "2026-07-29T00:00:00.000Z",
-        updatedAt: "2026-07-29T00:00:00.000Z",
-      }),
-    ).not.toHaveProperty("connectorRef");
-    expect(
-      zeroWorkflowConnectorReadinessResponseSchema.parse({
-        connectors: [
-          {
-            connectorSlug: "github",
-            connectorRef: "github",
-            label: "GitHub",
-            icon: catalogItem.icon,
-            reason: "Connect GitHub",
-            status: "not-connected",
-          },
-        ],
-      }),
-    ).toStrictEqual({
-      connectors: [
-        {
-          connectorSlug: "github",
-          label: "GitHub",
-          icon: catalogItem.icon,
-          reason: "Connect GitHub",
-          status: "not-connected",
-        },
-      ],
-    });
-    expect(
-      connectorChangedPayloadSchema.parse({
-        connectorRef: "github",
-        connectorSlug: "github",
-      }),
-    ).toStrictEqual({ connectorSlug: "github" });
-  });
 });
 
 describe("connector client request contracts", () => {
-  it("accepts canonical connector check requests and rejects legacy aliases", () => {
+  it("accepts canonical connector check requests", () => {
     const base = {
       mode: "url" as const,
       method: "GET",
@@ -380,22 +212,9 @@ describe("connector client request contracts", () => {
       }),
     ).toStrictEqual({ ...base, connectorSlug: "github" });
     expect(connectorCheckRequestSchema.parse(base)).toStrictEqual(base);
-    expect(
-      connectorCheckRequestSchema.safeParse({
-        ...base,
-        connectorRef: "github",
-      }).success,
-    ).toBe(false);
-    expect(
-      connectorCheckRequestSchema.safeParse({
-        ...base,
-        connectorSlug: "github",
-        connectorRef: "github",
-      }).success,
-    ).toBe(false);
   });
 
-  it("accepts canonical user connector updates and rejects legacy aliases", () => {
+  it("accepts canonical user connector updates", () => {
     expect(
       userConnectorUpdateSchema.parse({
         enabledConnectorSlugs: ["github"],
@@ -405,21 +224,9 @@ describe("connector client request contracts", () => {
       enabledConnectorSlugs: ["github"],
       operation: "add",
     });
-    expect(userConnectorUpdateSchema.safeParse({}).success).toBe(false);
-    expect(
-      userConnectorUpdateSchema.safeParse({
-        enabledTypes: ["github"],
-      }).success,
-    ).toBe(false);
-    expect(
-      userConnectorUpdateSchema.safeParse({
-        enabledConnectorSlugs: ["github"],
-        enabledTypes: ["github"],
-      }).success,
-    ).toBe(false);
   });
 
-  it("accepts canonical permission grants and rejects legacy aliases", () => {
+  it("accepts canonical permission grants", () => {
     const base = {
       agentId: AGENT_ID,
       mode: "patch" as const,
@@ -432,22 +239,6 @@ describe("connector client request contracts", () => {
         connectorSlug: "github",
       }),
     ).toStrictEqual({ ...base, connectorSlug: "github" });
-    expect(applyUserPermissionGrantsRequestSchema.safeParse(base).success).toBe(
-      false,
-    );
-    expect(
-      applyUserPermissionGrantsRequestSchema.safeParse({
-        ...base,
-        connectorRef: "github",
-      }).success,
-    ).toBe(false);
-    expect(
-      applyUserPermissionGrantsRequestSchema.safeParse({
-        ...base,
-        connectorSlug: "github",
-        connectorRef: "github",
-      }).success,
-    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Remove migration-only fixtures for expanded legacy connector responses and legacy request aliases.
- Remove stale legacy OAuth callback metadata coverage and a redundant negative serialization assertion.
- Keep canonical connector client behavior coverage and the intentional historical permission-link compatibility tests.

## Scope

- Test-only cleanup: no production code, API contract, database schema, persisted data, or runtime behavior changes.
- Connector catalog diagnostics and the internal firewall adapter representation are unchanged.

## Validation

- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/connector-client-contract.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-agents.test.ts src/signals/routes/__tests__/zero-connector-check.test.ts src/signals/routes/__tests__/zero-user-permission-grants.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm knip`
- Pre-commit hooks: Prettier, Knip, full Turbo type checking, and file-size validation

Relates to #23814
