### PR TITLE
fix(runner): distinguish cancellation intent

### DIFF
--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -1844,6 +1844,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unknown_cancel_notification_mode_defaults_to_hard_signal() {
+        let run_id: RunId = "00000000-0000-0000-0000-000000000002".parse().unwrap();
+        let tokens = RunCancellationRegistry::new();
+        let registration = tokens.register(run_id).await.unwrap();
+        let signals = registration.handle().signals();
+        let wakeups = PollWakeups::new(true);
+        let direct_candidates = direct_candidate_inbox();
+        let profiles = default_profiles();
+        let msg = make_message(
+            Some("cancel"),
+            serde_json::json!({ "runId": run_id, "mode": "future-mode" }),
+        );
+
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
+
+        assert!(signals.any().is_cancelled());
+        assert!(signals.hard().is_cancelled());
+        assert!(!signals.cooperative_user().is_cancelled());
+        assert_no_direct_candidate(&direct_candidates).await;
+    }
+
+    #[tokio::test]
     async fn broadcast_supported_job_notification_enqueues_direct_candidate() {
         let tokens = RunCancellationRegistry::new();
         let wakeups = PollWakeups::new(true);
@@ -2243,21 +2265,5 @@ mod tests {
             "00000000-0000-0000-0000-000000000002"
         );
         assert_eq!(notification.mode, CancelNotificationMode::Cooperative);
-    }
-
-    #[test]
-    fn parse_cancel_notification_defaults_unknown_mode_to_hard() {
-        let msg = make_message(
-            Some("cancel"),
-            serde_json::json!({
-                "runId": "00000000-0000-0000-0000-000000000002",
-                "mode": "future-mode"
-            }),
-        );
-
-        assert_eq!(
-            parse_cancel_notification(&msg).unwrap().mode,
-            CancelNotificationMode::Hard
-        );
     }
 }

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -637,11 +637,20 @@ async fn handle_ably_message_with_network_policy_refresh(
 ) {
     let notification_received_at = StdInstant::now();
 
-    if let Some(run_id) = parse_cancel_notification(msg) {
+    if let Some(notification) = parse_cancel_notification(msg) {
+        let run_id = notification.run_id;
         let handle = cancel_tokens.handle(run_id).await;
         if let Some(handle) = handle {
-            info!(run_id = %run_id, "ably: cancel notification, requesting cooperative cancellation");
-            handle.request_cooperative_user_cancellation().await;
+            match notification.mode {
+                CancelNotificationMode::Cooperative => {
+                    info!(run_id = %run_id, "ably: cancel notification, requesting cooperative cancellation");
+                    handle.request_cooperative_user_cancellation().await;
+                }
+                CancelNotificationMode::Hard => {
+                    info!(run_id = %run_id, "ably: cancel notification, requesting hard cancellation");
+                    handle.request_hard_cancellation().await;
+                }
+            }
         }
         return;
     }
@@ -801,18 +810,48 @@ fn log_direct_candidate_pruned(
     );
 }
 
-fn parse_cancel_notification(msg: &ably_subscriber::Message) -> Option<RunId> {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CancelNotificationMode {
+    Cooperative,
+    Hard,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CancelNotification {
+    run_id: RunId,
+    mode: CancelNotificationMode,
+}
+
+fn parse_cancel_notification(msg: &ably_subscriber::Message) -> Option<CancelNotification> {
     if msg.name.as_deref() != Some("cancel") {
         return None;
     }
     let raw = msg.data.get("runId").and_then(|v| v.as_str())?;
-    match raw.parse() {
-        Ok(id) => Some(id),
+    let run_id = match raw.parse() {
+        Ok(id) => id,
         Err(e) => {
             warn!(value = %raw, error = %e, "ably: invalid cancel runId");
-            None
+            return None;
         }
-    }
+    };
+    let mode = match msg.data.get("mode") {
+        Some(serde_json::Value::String(mode)) if mode == "cooperative" => {
+            CancelNotificationMode::Cooperative
+        }
+        Some(serde_json::Value::String(mode)) if mode == "hard" => CancelNotificationMode::Hard,
+        Some(mode) => {
+            warn!(
+                run_id = %run_id,
+                mode = %mode,
+                "ably: unknown cancel mode, using hard cancellation"
+            );
+            CancelNotificationMode::Hard
+        }
+        // Older APIs omitted the mode. Defaulting to hard preserves their
+        // pre-capability cancellation behavior during mixed deployments.
+        None => CancelNotificationMode::Hard,
+    };
+    Some(CancelNotification { run_id, mode })
 }
 
 fn parse_network_policy_refresh_notification(
@@ -1741,7 +1780,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancel_notification_cancels_token_without_discovery() {
+    async fn cooperative_cancel_notification_uses_cooperative_signal_without_discovery() {
         let run_id: RunId = "00000000-0000-0000-0000-000000000002".parse().unwrap();
         let tokens = RunCancellationRegistry::new();
         let registration = tokens.register(run_id).await.unwrap();
@@ -1750,13 +1789,57 @@ mod tests {
         let wakeups = PollWakeups::new(true);
         let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
-        let msg = make_message(Some("cancel"), serde_json::json!({ "runId": run_id }));
+        let msg = make_message(
+            Some("cancel"),
+            serde_json::json!({ "runId": run_id, "mode": "cooperative" }),
+        );
 
         handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
         assert!(token.is_cancelled());
         assert!(signals.cooperative_user().is_cancelled());
         assert!(!signals.hard().is_cancelled());
+        assert_no_direct_candidate(&direct_candidates).await;
+    }
+
+    #[tokio::test]
+    async fn hard_cancel_notification_uses_hard_signal_without_discovery() {
+        let run_id: RunId = "00000000-0000-0000-0000-000000000002".parse().unwrap();
+        let tokens = RunCancellationRegistry::new();
+        let registration = tokens.register(run_id).await.unwrap();
+        let signals = registration.handle().signals();
+        let wakeups = PollWakeups::new(true);
+        let direct_candidates = direct_candidate_inbox();
+        let profiles = default_profiles();
+        let msg = make_message(
+            Some("cancel"),
+            serde_json::json!({ "runId": run_id, "mode": "hard" }),
+        );
+
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
+
+        assert!(signals.any().is_cancelled());
+        assert!(signals.hard().is_cancelled());
+        assert!(!signals.cooperative_user().is_cancelled());
+        assert_no_direct_candidate(&direct_candidates).await;
+    }
+
+    #[tokio::test]
+    async fn legacy_cancel_notification_defaults_to_hard_signal() {
+        let run_id: RunId = "00000000-0000-0000-0000-000000000002".parse().unwrap();
+        let tokens = RunCancellationRegistry::new();
+        let registration = tokens.register(run_id).await.unwrap();
+        let signals = registration.handle().signals();
+        let wakeups = PollWakeups::new(true);
+        let direct_candidates = direct_candidate_inbox();
+        let profiles = default_profiles();
+        let msg = make_message(Some("cancel"), serde_json::json!({ "runId": run_id }));
+
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
+
+        assert!(signals.any().is_cancelled());
+        assert!(signals.hard().is_cancelled());
+        assert!(!signals.cooperative_user().is_cancelled());
         assert_no_direct_candidate(&direct_candidates).await;
     }
 
@@ -2149,9 +2232,32 @@ mod tests {
     fn parse_cancel_notification_valid() {
         let msg = make_message(
             Some("cancel"),
-            serde_json::json!({ "runId": "00000000-0000-0000-0000-000000000002" }),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000002",
+                "mode": "cooperative"
+            }),
         );
-        let run_id = parse_cancel_notification(&msg).unwrap();
-        assert_eq!(run_id.to_string(), "00000000-0000-0000-0000-000000000002");
+        let notification = parse_cancel_notification(&msg).unwrap();
+        assert_eq!(
+            notification.run_id.to_string(),
+            "00000000-0000-0000-0000-000000000002"
+        );
+        assert_eq!(notification.mode, CancelNotificationMode::Cooperative);
+    }
+
+    #[test]
+    fn parse_cancel_notification_defaults_unknown_mode_to_hard() {
+        let msg = make_message(
+            Some("cancel"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000002",
+                "mode": "future-mode"
+            }),
+        );
+
+        assert_eq!(
+            parse_cancel_notification(&msg).unwrap().mode,
+            CancelNotificationMode::Hard
+        );
     }
 }

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -322,10 +322,11 @@ export async function publishOrgSignal(
 export async function publishCancelToRunnerGroup(
   group: string,
   runId: string,
+  mode: "cooperative" | "hard",
 ): Promise<void> {
   const client = ablyClient();
   const channel = client.channels.get(`runner-group:${group}`);
-  await channel.publish("cancel", { runId });
+  await channel.publish("cancel", { runId, mode });
   L.debug(`Published cancel ${runId} to runner-group:${group}`);
 }
 

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -315,19 +315,21 @@ export async function publishOrgSignal(
   L.debug(`Published "${topic}" to org:${orgId}`);
 }
 
+export type RunnerCancellationMode = "cooperative" | "hard";
+
 /**
  * Notify a runner-group channel that a run should halt. The runner subscribes
- * to its group's channel and aborts the matching run on receipt.
+ * to its group's channel and applies the requested cancellation mode.
  */
 export async function publishCancelToRunnerGroup(
   group: string,
   runId: string,
-  mode: "cooperative" | "hard",
+  mode: RunnerCancellationMode,
 ): Promise<void> {
   const client = ablyClient();
   const channel = client.channels.get(`runner-group:${group}`);
   await channel.publish("cancel", { runId, mode });
-  L.debug(`Published cancel ${runId} to runner-group:${group}`);
+  L.debug(`Published ${mode} cancel ${runId} to runner-group:${group}`);
 }
 
 export async function publishNetworkPolicyRefreshToRunnerGroup(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -25,6 +25,7 @@ import {
   getModelProviderFirewall,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
+import { RUNNER_CANCELLATION_RECOVERY_CAPABILITY } from "@vm0/api-contracts/contracts/runners";
 import {
   zeroModelProviderConnectionsByIdContract,
   zeroModelProviderConnectionsMainContract,
@@ -1171,13 +1172,18 @@ describe("CHAT-02: web chat send and client ids", () => {
 
 describe("CHAT-02: interrupting active chat runs", () => {
   it("interrupts an active run, guards interrupt ids, and feeds cancelled rounds into the next run", async () => {
-    const { actor, agentId } = await entitledChatActor();
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
     const first = await sendChatRun(actor, {
       agentId,
       prompt: "long task to interrupt",
     });
+    await api.heartbeatRunner(runnerGroup);
+    const firstClaim = await api.claimRunnerJob(first.runId, {
+      capabilities: [RUNNER_CANCELLATION_RECOVERY_CAPABILITY],
+    });
+    context.mocks.ably.publish.mockClear();
 
     const interruptId = randomUUID();
     const interrupted = await chat.requestSendEvent(
@@ -1195,6 +1201,17 @@ describe("CHAT-02: interrupting active chat runs", () => {
     }
     expect(interrupted.body.runId).toBeNull();
     await waitForRunStatus(actor, first.runId, "cancelled");
+    await flushWaitUntilForTest();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith("cancel", {
+      runId: first.runId,
+      mode: "cooperative",
+    });
+    await webhooks.requestAgentComplete(
+      { runId: first.runId, exitCode: 1 },
+      { authorization: `Bearer ${firstClaim.sandboxToken}` },
+      [200],
+    );
+    await flushWaitUntilForTest();
 
     const messages = await waitForThreadMessages(
       actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
 import { DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL } from "@vm0/api-contracts/contracts/model-providers";
+import { RUNNER_CANCELLATION_RECOVERY_CAPABILITY } from "@vm0/api-contracts/contracts/runners";
 import { zeroGoalsContract } from "@vm0/api-contracts/contracts/zero-goals";
 import { describe, expect, it, onTestFinished } from "vitest";
 
@@ -1327,7 +1328,10 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       agentId,
       prompt: "delete cascade anchor",
     });
-    await claimChatRun(runnerGroup, main.runId);
+    await api.heartbeatRunner(runnerGroup);
+    await api.claimRunnerJob(main.runId, {
+      capabilities: [RUNNER_CANCELLATION_RECOVERY_CAPABILITY],
+    });
 
     await expect(chat.listActiveChatThreadIds(actor)).resolves.toContain(
       main.threadId,
@@ -1365,8 +1369,14 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       cancellationRecoveryPending: false,
     });
 
+    context.mocks.ably.publish.mockClear();
     const deleted = await chat.requestDeleteThread(actor, main.threadId, [204]);
     expect(deleted.body).toBeUndefined();
+    await flushWaitUntilForTest();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith("cancel", {
+      runId: main.runId,
+      mode: "hard",
+    });
 
     expect((await api.readRun(actor, main.runId)).status).toBe("cancelled");
     expect((await api.readRun(actor, sibling.runId)).status).toBe("completed");

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9563,7 +9563,7 @@ describe("RUN-03: cancellation of dispatched and terminal runs", () => {
       .toBe(true);
     expect(context.mocks.ably.publish).toHaveBeenCalledWith("cancel", {
       runId: run.runId,
-      mode: "cooperative",
+      mode: "hard",
     });
 
     const repeated = await api.requestCancelRun(actor, run.runId, [200]);
@@ -9604,6 +9604,10 @@ describe("RUN-03: cancellation of dispatched and terminal runs", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
     await flushWaitUntilForTest();
     expect(callbackRequests).toBe(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith("cancel", {
+      runId: run.runId,
+      mode: "cooperative",
+    });
 
     await api.requestCancelRun(actor, run.runId, [200]);
     await flushWaitUntilForTest();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9561,6 +9561,10 @@ describe("RUN-03: cancellation of dispatched and terminal runs", () => {
         );
       })
       .toBe(true);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith("cancel", {
+      runId: run.runId,
+      mode: "cooperative",
+    });
 
     const repeated = await api.requestCancelRun(actor, run.runId, [200]);
     expect(repeated.status).toBe(200);

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2,7 +2,10 @@ import { createHash, randomInt, randomUUID } from "node:crypto";
 
 import { createStore } from "ccstate";
 import { LIMITED_FREE1_DEFAULT_RUN_MODEL } from "@vm0/api-contracts/contracts/model-providers";
-import { RESUME_SESSION_HISTORY_MAX_BYTES } from "@vm0/api-contracts/contracts/runners";
+import {
+  RESUME_SESSION_HISTORY_MAX_BYTES,
+  RUNNER_CANCELLATION_RECOVERY_CAPABILITY,
+} from "@vm0/api-contracts/contracts/runners";
 import { MAX_FILE_SIZE_BYTES } from "@vm0/api-contracts/contracts/storages";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it, onTestFinished } from "vitest";
@@ -5182,6 +5185,9 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
       modelProvider: "anthropic-api-key",
     });
     expect(run.status).toBe("pending");
+    await runs.claimRunnerJob(run.runId, {
+      capabilities: [RUNNER_CANCELLATION_RECOVERY_CAPABILITY],
+    });
     await store.set(
       insertUsageEvent$,
       {
@@ -5262,6 +5268,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
       await compactionLock.done;
       await flushWaitUntilForTest();
     });
+    context.mocks.ably.publish.mockClear();
     api.verifyNextClerkWebhook({
       type: "user.deleted",
       data: { id: doomed.userId },
@@ -5279,6 +5286,10 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     compactionLock.release();
     await compactionLock.done;
     await flushWaitUntilForTest();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith("cancel", {
+      runId: run.runId,
+      mode: "hard",
+    });
     const firstCleanupS3Prefix = commandInput(
       context.mocks.s3.send.mock.calls[s3CallCountBeforeCleanup]?.[0],
     ).Prefix;

--- a/turbo/apps/api/src/signals/routes/zero-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-events.ts
@@ -2146,6 +2146,7 @@ const handleInterruptSend$ = command(
         runId: args.body.interruptsRunId,
         userId: args.userId,
         orgId: args.orgId,
+        runnerCancellationMode: "cooperative",
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/routes/zero-runs-cancel.ts
+++ b/turbo/apps/api/src/signals/routes/zero-runs-cancel.ts
@@ -34,6 +34,7 @@ const cancelInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       runId: params.id,
       userId: auth.userId,
       orgId: auth.orgId,
+      runnerCancellationMode: "cooperative",
       apiStartTime,
     },
     signal,

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -71,13 +71,16 @@ async function publishCancelBestEffort(
   if (!runnerGroup) {
     return;
   }
-  await tapError(publishCancelToRunnerGroup(runnerGroup, runId), (error) => {
-    L.warn("failed to publish run cancellation", {
-      runId,
-      runnerGroup,
-      error,
-    });
-  });
+  await tapError(
+    publishCancelToRunnerGroup(runnerGroup, runId, "hard"),
+    (error) => {
+      L.warn("failed to publish run cancellation", {
+        runId,
+        runnerGroup,
+        error,
+      });
+    },
+  );
 }
 
 async function cancelOrgRuns(db: Db, orgId: string): Promise<void> {

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -2515,7 +2515,12 @@ export const deleteChatThread$ = command(
     for (const run of deletion.activeRuns) {
       const result = await set(
         cancelRun$,
-        { runId: run.runId, userId: args.userId, orgId: run.orgId },
+        {
+          runId: run.runId,
+          userId: args.userId,
+          orgId: run.orgId,
+          runnerCancellationMode: "hard",
+        },
         signal,
       );
       signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
@@ -212,6 +212,30 @@ async function publishCancellationRecoveryEntered(
   signal.throwIfAborted();
 }
 
+async function publishCooperativeRunnerCancellation(
+  result: CancelRunResult,
+  signal: AbortSignal,
+): Promise<void> {
+  if (
+    result.alreadyCancelled ||
+    result.previousStatus !== "running" ||
+    !result.runnerGroup
+  ) {
+    return;
+  }
+  await tapError(
+    publishCancelToRunnerGroup(result.runnerGroup, result.runId, "cooperative"),
+    (error) => {
+      L.error("Failed to publish cancel to runner group", {
+        runId: result.runId,
+        runnerGroup: result.runnerGroup,
+        error,
+      });
+    },
+  );
+  signal.throwIfAborted();
+}
+
 /**
  * Post-cancel side effects:
  *  - Notify the runner group to halt the cancelled run (if it was
@@ -244,23 +268,7 @@ export const dispatchCancelSideEffects$ = command(
     const recoveryRedrive = result.alreadyCancelled;
     const db = set(writeDb$);
     await publishCancellationRecoveryEntered(result, signal);
-    if (
-      !recoveryRedrive &&
-      result.previousStatus === "running" &&
-      result.runnerGroup
-    ) {
-      await tapError(
-        publishCancelToRunnerGroup(result.runnerGroup, result.runId),
-        (error) => {
-          L.error("Failed to publish cancel to runner group", {
-            runId: result.runId,
-            runnerGroup: result.runnerGroup,
-            error,
-          });
-        },
-      );
-      signal.throwIfAborted();
-    }
+    await publishCooperativeRunnerCancellation(result, signal);
     if (!recoveryRedrive) {
       await tapError(
         publishOrgSignal(result.orgId, "queue:changed"),

--- a/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
@@ -12,6 +12,7 @@ import {
   publishChatThreadDetailChangedSafely,
   publishOrgSignal,
   publishUserSignal,
+  type RunnerCancellationMode,
 } from "../external/realtime";
 import { logger } from "../../lib/log";
 import { notFound, runNotCancellable } from "../../lib/error";
@@ -38,6 +39,7 @@ export interface CancelRunResult {
   readonly runnerGroup: string | null;
   readonly chatThreadId: string | null;
   readonly cancellationRecoveryCompleted: boolean | null;
+  readonly runnerCancellationMode: RunnerCancellationMode;
   readonly alreadyCancelled: boolean;
 }
 
@@ -70,6 +72,7 @@ export const cancelRun$ = command(
       readonly runId: string;
       readonly userId: string;
       readonly orgId: string;
+      readonly runnerCancellationMode: RunnerCancellationMode;
       readonly apiStartTime?: number;
     },
     signal: AbortSignal,
@@ -121,6 +124,7 @@ export const cancelRun$ = command(
           runnerGroup: run.runnerGroup,
           chatThreadId: zeroRun?.chatThreadId ?? null,
           cancellationRecoveryCompleted: run.cancellationRecoveryCompleted,
+          runnerCancellationMode: args.runnerCancellationMode,
           alreadyCancelled: true,
         };
       }
@@ -160,6 +164,7 @@ export const cancelRun$ = command(
         runnerGroup: run.runnerGroup,
         chatThreadId: zeroRun?.chatThreadId ?? null,
         cancellationRecoveryCompleted: run.cancellationRecoveryCompleted,
+        runnerCancellationMode: args.runnerCancellationMode,
         alreadyCancelled: false,
       };
     });
@@ -212,7 +217,7 @@ async function publishCancellationRecoveryEntered(
   signal.throwIfAborted();
 }
 
-async function publishCooperativeRunnerCancellation(
+async function publishRunnerCancellation(
   result: CancelRunResult,
   signal: AbortSignal,
 ): Promise<void> {
@@ -223,8 +228,14 @@ async function publishCooperativeRunnerCancellation(
   ) {
     return;
   }
+  // A null marker means the claim did not negotiate the API recovery barrier,
+  // so cooperative cancellation is unsafe even when the caller requested it.
+  const mode =
+    result.cancellationRecoveryCompleted === null
+      ? "hard"
+      : result.runnerCancellationMode;
   await tapError(
-    publishCancelToRunnerGroup(result.runnerGroup, result.runId, "cooperative"),
+    publishCancelToRunnerGroup(result.runnerGroup, result.runId, mode),
     (error) => {
       L.error("Failed to publish cancel to runner group", {
         runId: result.runId,
@@ -268,7 +279,7 @@ export const dispatchCancelSideEffects$ = command(
     const recoveryRedrive = result.alreadyCancelled;
     const db = set(writeDb$);
     await publishCancellationRecoveryEntered(result, signal);
-    await publishCooperativeRunnerCancellation(result, signal);
+    await publishRunnerCancellation(result, signal);
     if (!recoveryRedrive) {
       await tapError(
         publishOrgSignal(result.orgId, "queue:changed"),


### PR DESCRIPTION
## Summary

- add an explicit `cooperative` / `hard` cancellation mode to runner-group cancellation events
- make direct run cancellation and chat interruption cooperative only when the claimed runner negotiated cancellation recovery
- keep chat-thread deletion and Clerk user/organization cleanup hard even for recovery-capable runs
- make fixed runners treat missing, malformed, or unknown modes as hard for mixed-deployment safety

## Context

This is a follow-up to #24200. That PR made every Ably `cancel` event cooperative, but destructive cleanup paths use the same event to stop active runs. Allowing those cancellations to checkpoint for up to 90 seconds could race deletion and recreate data after cleanup.

The cancellation producer now declares its intent explicitly. The API then downgrades a requested cooperative cancellation to hard when `cancellation_recovery_completed` is `NULL`, which means the claim did not negotiate the durable API recovery barrier.

## Behavior

| Cancellation source | Recovery-capable claim | Published mode |
| --- | --- | --- |
| Direct run cancellation | Yes | `cooperative` |
| Chat interruption | Yes | `cooperative` |
| Direct cancellation or interruption | No | `hard` |
| Chat-thread deletion | Either | `hard` |
| Clerk user/organization cleanup | Either | `hard` |

## Deployment status and rollout

#24200 has already shipped in `runner-rs` 0.150.4 through #24201, and its merge commit is included in the current successful production API and app deployments. Treat this PR as a post-release safety fix.

The updated API cannot remediate runner 0.150.4 instances by itself because that runner ignores `mode` and keeps treating every cancel event as cooperative. Publish and roll out a fixed runner release promptly, then wait for 0.150.4 instances to drain. A fixed runner overlapping an older API safely treats the missing `mode` as hard, so recovery may be temporarily disabled but destructive cleanup remains contained.

## Compatibility

- a pre-#24200 runner ignores the additive `mode` field and retains legacy hard cancellation
- the released #24200 runner 0.150.4 ignores `mode` and retains its all-cooperative behavior until it drains; this PR does not widen that existing overlap
- this fixed runner with an older API treats a missing `mode` as hard cancellation, temporarily preferring safe legacy behavior over recovery
- this fixed runner with the updated API makes only capability-negotiated direct cancellation and interruption cooperative

This does not change HTTP APIs, database schema or persisted values, guest recovery logic, or sandbox finalization.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (2900 passed, 14 ignored; guest inventory passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- focused API integration coverage for capable and non-capable direct cancellation, chat interruption, chat-thread deletion, and Clerk deletion (5 passed)
- repository pre-commit checks, including full Knip and Turbo type checking

Related to #23870.
Parent delivery issue: #23867.
