### PR TITLE
refactor: remove image style r2 feature switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -4784,7 +4784,7 @@ describe("CHAT-02: generation templates and attachments", () => {
     await cancelChatRun(actor, website.runId);
   }, 90_000);
 
-  it("uses R2 by default and preserves GitHub fallback through the user feature switch", async () => {
+  it("uses R2 for archive-backed styles", async () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const style = ILLUSTRATION_TEMPLATE_ITEMS.find((item) => {
@@ -4809,32 +4809,6 @@ describe("CHAT-02: generation templates and attachments", () => {
     );
     expect(defaultR2Prompt).toContain("--compile --style-source r2");
     await cancelChatRun(actor, defaultR2Run.runId);
-
-    if (!actor.orgId) {
-      throw new Error("Expected an org-scoped actor");
-    }
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.ImageStyleR2]: false },
-    );
-
-    const githubRun = await sendChatRun(actor, {
-      agentId,
-      prompt: "draw a flower shop",
-      generationTemplate: {
-        type: "illustration",
-        selection: { illustrationStyleId: style.illustrationStyleId },
-      },
-    });
-    const githubPrompt =
-      (await api.readRun(actor, githubRun.runId)).appendSystemPrompt ?? "";
-    expect(githubPrompt).toContain(
-      "Style source: vm0-ai/vm0-skills@main:illustration-template/ink-storefront",
-    );
-    expect(githubPrompt).not.toContain("private R2 registry resource");
-    expect(githubPrompt).not.toContain("--style-source r2");
-    await cancelChatRun(actor, githubRun.runId);
   }, 90_000);
 
   it("is one-shot: a follow-up without re-attaching the style gets no template context", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
@@ -144,12 +144,14 @@ describe("buildGenerationTemplatePrompt", () => {
       `- Style description: ${imageStyle.description}`,
     );
     expect(result.prompt).toContain(
-      `zero generate image --provider built-in --style ${item.illustrationStyleId} --prompt "<user request>" --compile`,
+      `zero generate image --provider built-in --style ${item.illustrationStyleId} --prompt "<user request>" --compile --style-source r2`,
     );
-    expect(result.prompt).toContain("Style source: vm0-ai/vm0-skills@main:");
+    expect(result.prompt).toContain(
+      `Style source: private R2 registry resource ${imageStyle.id}`,
+    );
     expect(result.prompt).toContain("Follow the returned packet completely");
     expect(result.prompt).toContain(
-      "If the source is unavailable, stop without generating",
+      "If the R2 source is unavailable, stop without generating; do not fall back to GitHub.",
     );
     expect(result.prompt).toContain("--compiled-prompt");
     expect(result.prompt).toContain("resolved compatible CLI options");

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -69,17 +69,8 @@ type GenerationTemplatePromptResult =
       readonly message: string;
     };
 
-interface BuildGenerationTemplatePromptOptions {
-  /**
-   * When true, archive-enabled image styles resolve through private R2.
-   * When false, the existing vm0-skills GitHub source remains unchanged.
-   */
-  readonly imageStyleR2Enabled?: boolean;
-}
-
 export function buildGenerationTemplatePrompt(
   generationTemplate: GenerationTemplateInput | null | undefined,
-  options?: BuildGenerationTemplatePromptOptions,
 ): GenerationTemplatePromptResult {
   if (!generationTemplate) {
     return { status: "resolved", prompt: "" };
@@ -89,10 +80,7 @@ export function buildGenerationTemplatePrompt(
     return buildVideoGenerationTemplatePrompt(generationTemplate);
   }
   if (generationTemplate.type === "illustration") {
-    return buildIllustrationGenerationTemplatePrompt(
-      generationTemplate,
-      options,
-    );
+    return buildIllustrationGenerationTemplatePrompt(generationTemplate);
   }
   if (generationTemplate.type === "workflow") {
     return buildWorkflowGenerationTemplatePrompt(generationTemplate);
@@ -120,14 +108,13 @@ function stripGenerationTemplateContext(prompt: string): string {
 
 export function buildGenerationTemplatesPrompt(
   generationTemplates: readonly GenerationTemplateInput[],
-  options?: BuildGenerationTemplatePromptOptions,
 ): GenerationTemplatePromptResult {
   if (generationTemplates.length === 0) {
     return { status: "resolved", prompt: "" };
   }
   const details: string[] = [];
   for (const [index, generationTemplate] of generationTemplates.entries()) {
-    const built = buildGenerationTemplatePrompt(generationTemplate, options);
+    const built = buildGenerationTemplatePrompt(generationTemplate);
     if (built.status === "invalid") {
       return built;
     }
@@ -302,7 +289,6 @@ function buildVideoGenerationTemplatePrompt(
 
 function buildIllustrationGenerationTemplatePrompt(
   generationTemplate: IllustrationGenerationTemplateInput,
-  options?: BuildGenerationTemplatePromptOptions,
 ): GenerationTemplatePromptResult {
   const imageStyle = findImageStyle(
     generationTemplate.selection.illustrationStyleId,
@@ -310,8 +296,7 @@ function buildIllustrationGenerationTemplatePrompt(
   if (!imageStyle) {
     return { status: "invalid", message: "Unknown generation image style" };
   }
-  const useR2 =
-    options?.imageStyleR2Enabled === true && hasR2Archive(imageStyle);
+  const useR2 = hasR2Archive(imageStyle);
   const styleSource = useR2
     ? `private R2 registry resource ${imageStyle.id}`
     : imageStyle.source.repo && imageStyle.source.ref

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -4,7 +4,6 @@ import {
   findPresentationRunbookPackage,
   findVideoTemplate,
   findWebsiteTemplatePackage,
-  hasR2Archive,
   resolvePresentationRunbookColorToken,
   type PresentationRunbookPackage,
   type WebsiteTemplatePackage,
@@ -296,20 +295,10 @@ function buildIllustrationGenerationTemplatePrompt(
   if (!imageStyle) {
     return { status: "invalid", message: "Unknown generation image style" };
   }
-  const useR2 = hasR2Archive(imageStyle);
-  const styleSource = useR2
-    ? `private R2 registry resource ${imageStyle.id}`
-    : imageStyle.source.repo && imageStyle.source.ref
-      ? `${imageStyle.source.repo}@${imageStyle.source.ref}:${imageStyle.source.path}`
-      : imageStyle.source.path;
-  const compileCommand = [
-    `zero generate image --provider built-in --style ${imageStyle.id}`,
-    '--prompt "<user request>" --compile',
-    ...(useR2 ? ["--style-source r2"] : []),
-  ].join(" ");
-  const sourceInstruction = useR2
-    ? "Follow the returned packet completely, including pulling the private R2 package and reading its extracted SKILL.md. If the R2 source is unavailable, stop without generating; do not fall back to GitHub."
-    : `Follow the returned packet completely, including reading its style source (${styleSource}) and SKILL.md. If the source is unavailable, stop without generating.`;
+  const styleSource = `private R2 registry resource ${imageStyle.id}`;
+  const compileCommand = `zero generate image --provider built-in --style ${imageStyle.id} --prompt "<user request>" --compile --style-source r2`;
+  const sourceInstruction =
+    "Follow the returned packet completely, including pulling the private R2 package and reading its extracted SKILL.md. If the R2 source is unavailable, stop without generating; do not fall back to GitHub.";
 
   return {
     status: "resolved",

--- a/turbo/apps/api/src/signals/routes/thread-generation-template.ts
+++ b/turbo/apps/api/src/signals/routes/thread-generation-template.ts
@@ -14,19 +14,14 @@ import {
 export function resolveThreadGenerationTemplatePrompt(args: {
   readonly explicit: GenerationTemplateRequest | null | undefined;
   readonly explicitTemplates?: readonly GenerationTemplateRequest[];
-  readonly imageStyleR2Enabled?: boolean;
 }): string {
   if (args.explicitTemplates && args.explicitTemplates.length > 0) {
-    const built = buildGenerationTemplatesPrompt(args.explicitTemplates, {
-      imageStyleR2Enabled: args.imageStyleR2Enabled,
-    });
+    const built = buildGenerationTemplatesPrompt(args.explicitTemplates);
     return built.status === "resolved" ? built.prompt : "";
   }
   if (!args.explicit) {
     return "";
   }
-  const built = buildGenerationTemplatePrompt(args.explicit, {
-    imageStyleR2Enabled: args.imageStyleR2Enabled,
-  });
+  const built = buildGenerationTemplatePrompt(args.explicit);
   return built.status === "resolved" ? built.prompt : "";
 }

--- a/turbo/apps/api/src/signals/routes/zero-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-events.ts
@@ -280,7 +280,6 @@ interface NormalSendFeatureSwitches {
   readonly artifactKeyV2Enabled: boolean;
   readonly codexFastModeEnabled: boolean;
   readonly userMessageInlineTemplatesEnabled: boolean;
-  readonly imageStyleR2Enabled: boolean;
 }
 
 interface RuntimeNormalSendBody extends Omit<NormalSendBody, "userMessage"> {
@@ -1054,10 +1053,6 @@ async function resolveNormalSendFeatureSwitches(
     ),
     userMessageInlineTemplatesEnabled: isFeatureEnabled(
       FeatureSwitchKey.StructuredPromptInlineTemplates,
-      context,
-    ),
-    imageStyleR2Enabled: isFeatureEnabled(
-      FeatureSwitchKey.ImageStyleR2,
       context,
     ),
   };
@@ -2479,7 +2474,6 @@ const prepareNormalSend$ = command(
         runtimeBody.userMessageGenerationTemplates.length > 0
           ? runtimeBody.userMessageGenerationTemplates
           : undefined,
-      imageStyleR2Enabled: featureSwitches.imageStyleR2Enabled,
     });
     const persistedExplicitSelection =
       await maybePersistTimedExplicitModelFirstSelection(args, db);

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2818,7 +2818,6 @@ function resolveQueuedMessageGenerationTemplatePrompt(args: {
   readonly userMessageProjection:
     | ReturnType<typeof projectUserMessage>
     | undefined;
-  readonly imageStyleR2Enabled: boolean;
   readonly inlineTemplatesEnabled: boolean;
 }) {
   return measureChatCallbackPreCreateTiming(
@@ -2833,7 +2832,6 @@ function resolveQueuedMessageGenerationTemplatePrompt(args: {
         explicitTemplates: args.inlineTemplatesEnabled
           ? args.userMessageProjection?.generationTemplates
           : undefined,
-        imageStyleR2Enabled: args.imageStyleR2Enabled,
       });
     },
   );
@@ -2902,10 +2900,6 @@ async function buildCreateQueuedChatRunInput(
     await resolveQueuedMessageGenerationTemplatePrompt({
       input: args,
       userMessageProjection,
-      imageStyleR2Enabled: isFeatureEnabled(
-        FeatureSwitchKey.ImageStyleR2,
-        featureSwitchContext,
-      ),
       inlineTemplatesEnabled,
     });
   const computerUseHostGrant = await measureChatCallbackPreCreateTiming(

--- a/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
@@ -3,11 +3,7 @@ import chalk from "chalk";
 import { generateWebImage } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 import { createStyledImageCompilationPacket } from "./image-style-authoring";
-import {
-  findImageStyle,
-  hasR2Archive,
-  listImageStyles,
-} from "./resource-registry";
+import { findImageStyle, listImageStyles } from "./resource-registry";
 import { formatRegistryListing } from "./resource-listing";
 import { dispatchGenerate } from "../generate/lib/dispatch";
 import type { GenerationType } from "../generate/lib/lister";
@@ -357,11 +353,6 @@ ${formatRegistryListing(styles, "image styles")}`;
           const style = findImageStyle(styleId);
           if (!style) {
             throw unknownStyleError(styleId, config.usageCommand);
-          }
-          if (options.styleSource === "r2" && !hasR2Archive(style)) {
-            throw new Error(
-              `Image style ${style.id} does not provide an R2 archive`,
-            );
           }
 
           const packet = createStyledImageCompilationPacket({

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -12,7 +12,6 @@ import {
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
-    expect(isFeatureEnabled(FeatureSwitchKey.ImageStyleR2, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.VideoArtifactPosters, {})).toBe(
       true,
     );
@@ -164,7 +163,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.SlackDmSessionRouting]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ArtifactKeyV2]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.HostedArtifactVersions]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ImageStyleR2]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(
       staffOrgStates[FeatureSwitchKey.StructuredPromptInlineTemplates],
@@ -211,7 +209,6 @@ describe("getAllFeatureStates", () => {
     );
     expect(otherOrgStates[FeatureSwitchKey.SlackDmSessionRouting]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ArtifactKeyV2]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ImageStyleR2]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(
       otherOrgStates[FeatureSwitchKey.StructuredPromptInlineTemplates],
@@ -312,9 +309,6 @@ describe("user-overridable switches", () => {
     );
     expect(getUserOverridableFeatureSwitchKeys()).toContain(
       FeatureSwitchKey.ComposerConnectorPermissions,
-    );
-    expect(getUserOverridableFeatureSwitchKeys()).toContain(
-      FeatureSwitchKey.ImageStyleR2,
     );
 
     expect(

--- a/turbo/packages/core/src/__tests__/illustration-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/illustration-template-items.spec.ts
@@ -5,11 +5,7 @@ import {
   ILLUSTRATION_TEMPLATE_ITEMS,
   illustrationAssetUrl,
 } from "../illustration-template-items";
-import {
-  findImageStyle,
-  hasR2Archive,
-  listImageStyles,
-} from "../resource-registry";
+import { findImageStyle, listImageStyles } from "../resource-registry";
 
 describe("illustration template items", () => {
   it("resolve every image style against the resource registry", () => {
@@ -24,7 +20,10 @@ describe("illustration template items", () => {
   it("registers the 32 manually published image style archives", () => {
     const imageStyles = listImageStyles();
 
-    expect(imageStyles.filter(hasR2Archive)).toHaveLength(32);
+    expect(imageStyles).toHaveLength(32);
+    for (const imageStyle of imageStyles) {
+      expect(imageStyle.source.archive, imageStyle.id).toBeDefined();
+    }
     expect(findImageStyle("image-style:chibi-hero")).toBeUndefined();
   });
 

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -86,7 +86,6 @@ export enum FeatureSwitchKey {
   ArtifactKeyV2 = "artifactKeyV2",
   HostedArtifactVersions = "hostedArtifactVersions",
   VideoArtifactPosters = "videoArtifactPosters",
-  ImageStyleR2 = "imageStyleR2",
   WorkflowConnectorReadiness = "workflowConnectorReadiness",
   ComposerConnectorPermissions = "composerConnectorPermissions",
   ThreeColumnNav = "threeColumnNav",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -526,12 +526,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Generate poster images asynchronously when video artifacts are recorded.",
     enabled: true,
   },
-  [FeatureSwitchKey.ImageStyleR2]: {
-    maintainer: "bingjie@vm0.ai",
-    description:
-      "Resolve archive-enabled image styles from private R2 packages. When off, image style authoring continues reading vm0-skills from GitHub.",
-    enabled: true,
-  },
   [FeatureSwitchKey.WorkflowConnectorReadiness]: {
     maintainer: "lancy@vm0.ai",
     description:

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -188,25 +188,15 @@ function imageStyleArchiveSha256(slug: string): string {
   return sha256;
 }
 
-function vm0ImageStyleSource(
-  slug: string,
-  r2ArchiveAvailable = true,
-): ResourceSourceRef {
-  const archiveSha256 = r2ArchiveAvailable
-    ? imageStyleArchiveSha256(slug)
-    : undefined;
+function vm0ImageStyleSource(slug: string): ResourceSourceRef {
   return {
     repo: VM0_SKILLS_REPO,
     ref: VM0_SKILLS_REF,
     path: `illustration-template/${slug}`,
-    ...(archiveSha256
-      ? {
-          archive: {
-            type: "tar.gz" as const,
-            sha256: archiveSha256,
-          },
-        }
-      : {}),
+    archive: {
+      type: "tar.gz",
+      sha256: imageStyleArchiveSha256(slug),
+    },
   };
 }
 
@@ -3936,10 +3926,6 @@ export function findImageStyle(id: string): RegistryEntry | undefined {
   return listImageStyles().find((entry) => {
     return entry.id === id;
   });
-}
-
-export function hasR2Archive(entry: RegistryEntry): boolean {
-  return entry.source.archive !== undefined;
 }
 
 const VIDEO_TEMPLATE_ID_ALIASES: Readonly<Record<string, string>> = {


### PR DESCRIPTION
## Summary

- remove the globally enabled, user-overridable `ImageStyleR2` feature switch
- remove the API feature-switch plumbing for normal and queued chat runs
- require every registered image style to provide an R2 archive and remove `hasR2Archive` plus its optional fallback paths
- route selected image styles through R2 unconditionally

Supersedes #23674 with a fresh branch based on current `main`.

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm --filter @vm0/core exec vitest run src/__tests__/illustration-template-items.spec.ts`
- `pnpm --filter @vm0/cli exec vitest run src/commands/zero/generate/__tests__/image.test.ts`
- `DATABASE_URL=postgresql://user@localhost:55432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/generation-template-prompt.test.ts`
- `DATABASE_URL=postgresql://user@localhost:55432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t 'uses R2 for archive-backed styles'`
