### PR TITLE
perf(python): bound x ndjson row inspection work

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -4,7 +4,6 @@ Computes per-permission billable resource counts from successful requests
 through the X firewall and buffers them for aggregate platform upload.
 """
 
-import json
 import re
 import urllib.parse
 from collections.abc import Callable
@@ -30,7 +29,6 @@ from ...json_selective import (
     JsonExtractionResult,
     JsonSelectiveExtractor,
     ScalarField,
-    json_nesting_within_limit,
 )
 from ...reporting_context import usage_reporting_context
 from ...underbilling import log_usage_underbilling
@@ -104,6 +102,9 @@ def _strip_request_target_query(request_target: str) -> str:
 # exceeding it indicates malformed or hostile upstream data, so the parser
 # discards that row through its terminating newline to protect memory.
 _MAX_NDJSON_LINE_BYTES = LARGE_RESPONSE_DECOMPRESS_LIMIT
+# Bound dense syntax and slow scalar inspection while keeping multi-megabyte
+# ordinary discarded strings on the selective parser's bulk-scan path.
+_MAX_NDJSON_ROW_WORK_UNITS = 65_536
 _REQUEST_BODY_REFINEMENT_LIMIT = REQUEST_BODY_BILLING_INSPECTION_LIMIT
 _REQUEST_QUERY_HINT_MAX_BYTES = 64 * 1024
 _REQUEST_QUERY_HINT_KEY_MAX_CHARS = 128
@@ -243,6 +244,14 @@ def _create_x_json_selective_extractor() -> JsonSelectiveExtractor:
     )
 
 
+def _create_x_ndjson_row_extractor() -> JsonSelectiveExtractor:
+    return JsonSelectiveExtractor(
+        wildcard_array_count_paths={("includes", "*")},
+        object_presence_paths={("data",)},
+        max_work_units=_MAX_NDJSON_ROW_WORK_UNITS,
+    )
+
+
 def _parse_x_json_response_fields(extracted: JsonExtractionResult) -> dict:
     result: dict = {}
 
@@ -329,15 +338,17 @@ class _NdjsonExtractor:
       include quantities that are unsafe for category emission or exceed the
       per-stream unknown-category budget.
     - ``lines_parsed``: int — JSON-parseable non-blank lines.
-    - ``lines_failed``: int — lines that failed JSON decoding or exceeded
-      the single-line safety cap.
+    - ``lines_failed``: int — lines that failed JSON validation or exceeded a
+      single-line inspection bound.
 
-    The parser keeps a ``line_buf`` holding the in-flight partial line
-    across chunk boundaries.  If a single line ever exceeds
-    :data:`_MAX_NDJSON_LINE_BYTES` the whole line is discarded until its
-    terminating newline (malformed / hostile upstream). ``finish`` finalizes a
+    The parser keeps a ``line_buf`` holding the in-flight partial line across
+    chunk boundaries. If a single line ever exceeds
+    :data:`_MAX_NDJSON_LINE_BYTES`, the whole line is discarded until its
+    terminating newline. Complete rows are validated with bounded selective
+    extraction so unrelated fields are not materialized. ``finish`` finalizes a
     complete trailing line that arrived without a final ``\\n`` and treats
-    malformed or incomplete trailing data as a failed, unbilled line.
+    malformed, incomplete, or inspection-bound-exceeding trailing data as a
+    failed, unbilled line.
     """
 
     def __init__(self) -> None:
@@ -405,24 +416,18 @@ class _NdjsonExtractor:
         line = raw_line.rstrip(b"\r")
         if not line:
             return  # keep-alive blank line
-        if not json_nesting_within_limit(line):
-            self.state["lines_failed"] += 1
-            return
-        try:
-            obj = json.loads(line)
-        except (ValueError, RecursionError):
+        extractor = _create_x_ndjson_row_extractor()
+        extractor.feed(line)
+        extracted = extractor.finish()
+        if not extracted.complete:
             self.state["lines_failed"] += 1
             return
         self.state["lines_parsed"] += 1
-        if not isinstance(obj, dict):
-            return
-        if isinstance(obj.get("data"), dict):
+        if ("data",) in extracted.object_present:
             self.state["data_count"] += 1
-        inc = obj.get("includes")
-        if isinstance(inc, dict):
-            for k, v in inc.items():
-                if isinstance(v, list):
-                    self._record_include_count(k, len(v))
+        includes = extracted.wildcard_array_counts.get(("includes", "*"), {})
+        for key, count in includes.items():
+            self._record_include_count(key, count)
 
     def _record_include_count(self, key: str, count: int) -> None:
         if count <= 0:

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -19,6 +19,7 @@ from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.x_flow_helpers import (
     json_body_that_exceeds_integer_digit_limit,
     json_body_that_exceeds_nesting_limit,
+    json_body_that_exceeds_x_ndjson_work_limit,
     make_x_pipeline_flow,
     make_x_stream_pipeline_flow,
 )
@@ -365,6 +366,10 @@ class TestXConnectorResponsePipeline:
         [
             pytest.param(json_body_that_exceeds_nesting_limit(), id="excessive-nesting"),
             pytest.param(json_body_that_exceeds_integer_digit_limit(), id="integer-digit-limit"),
+            pytest.param(
+                json_body_that_exceeds_x_ndjson_work_limit(),
+                id="work-limit",
+            ),
         ],
     )
     def test_full_streaming_pipeline_continues_after_uninspectable_json_row(

--- a/crates/runner/mitm-addon/tests/test_x_response_parsers.py
+++ b/crates/runner/mitm-addon/tests/test_x_response_parsers.py
@@ -10,7 +10,10 @@ import mitm_addon
 import response_streaming
 from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT, STREAM_BUFFER_LIMIT
 from tests.flow_helpers import response_stream
-from tests.x_flow_helpers import make_x_response_flow
+from tests.x_flow_helpers import (
+    json_body_that_exceeds_x_ndjson_work_limit,
+    make_x_response_flow,
+)
 
 _OVERSIZED_NDJSON_LINE_BYTES = LARGE_RESPONSE_DECOMPRESS_LIMIT + 1024
 
@@ -119,6 +122,58 @@ class TestNdjsonExtractor:
         assert state["data_count"] == 2
         assert state["lines_parsed"] == 2
         assert state["lines_failed"] == 1
+
+    @pytest.mark.parametrize(
+        "failed_line",
+        [
+            pytest.param(
+                b'{"data":{"id":"blocked"},"includes":{"users":[{},{},{}]},'
+                b'"matching_rules":[' + b",".join([b"0"] * 40_000) + b"]}",
+                id="dense-array",
+            ),
+            pytest.param(
+                json_body_that_exceeds_x_ndjson_work_limit(),
+                id="dense-objects",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("split_failed_row", [False, True], ids=["one-chunk", "split-row"])
+    def test_work_limited_line_forwards_and_recovers(
+        self,
+        real_flow,
+        failed_line,
+        split_failed_row,
+    ):
+        parse, state = self._stream_parser(real_flow)
+        valid_line = b'{"data":{"id":"after"},"includes":{"users":[{}]}}\n'
+        body = failed_line + b"\n" + valid_line
+        chunks = (
+            [body]
+            if not split_failed_row
+            else [body[:37], body[37 : len(failed_line) + 1], valid_line]
+        )
+
+        for chunk in chunks:
+            assert parse(chunk) == chunk
+
+        assert state["lines_failed"] == 1
+        assert state["lines_parsed"] == 1
+        assert state["data_count"] == 1
+        assert state["includes"] == {"users": 1}
+
+    def test_byte_cap_line_with_bulk_discarded_string_is_accepted(self, real_flow):
+        parse, state = self._stream_parser(real_flow)
+        prefix = b'{"data":{"id":"1"},"discarded":"'
+        suffix = b'"}'
+        line = (
+            prefix + b"x" * (LARGE_RESPONSE_DECOMPRESS_LIMIT - len(prefix) - len(suffix)) + suffix
+        )
+
+        assert len(line) == LARGE_RESPONSE_DECOMPRESS_LIMIT
+        assert parse(line + b"\n") == line + b"\n"
+        assert state["lines_failed"] == 0
+        assert state["lines_parsed"] == 1
+        assert state["data_count"] == 1
 
     def test_invalid_utf8_line_increments_failures_and_continues(self, real_flow):
         parse, state = self._stream_parser(real_flow)

--- a/crates/runner/mitm-addon/tests/test_x_response_parsers.py
+++ b/crates/runner/mitm-addon/tests/test_x_response_parsers.py
@@ -168,9 +168,10 @@ class TestNdjsonExtractor:
         line = (
             prefix + b"x" * (LARGE_RESPONSE_DECOMPRESS_LIMIT - len(prefix) - len(suffix)) + suffix
         )
+        body = line + b"\n"
 
         assert len(line) == LARGE_RESPONSE_DECOMPRESS_LIMIT
-        assert parse(line + b"\n") == line + b"\n"
+        assert parse(body) == body
         assert state["lines_failed"] == 0
         assert state["lines_parsed"] == 1
         assert state["data_count"] == 1

--- a/crates/runner/mitm-addon/tests/x_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/x_flow_helpers.py
@@ -14,6 +14,7 @@ from tests.stream_buffer_helpers import set_response_stream_buffer
 RealFlowFactory = Callable[..., http.HTTPFlow]
 _JSON_EXCESSIVE_NESTING_DEPTH = 10_000
 _JSON_INTEGER_DIGIT_LIMIT_DIGITS = 10_000
+_X_NDJSON_DENSE_OBJECT_COUNT = 30_000
 
 
 def x_original_url(path: str, query: str = "") -> str:
@@ -32,6 +33,13 @@ def json_body_that_exceeds_nesting_limit() -> bytes:
 
 def json_body_that_exceeds_integer_digit_limit() -> bytes:
     return b'{"n":' + b"1" * _JSON_INTEGER_DIGIT_LIMIT_DIGITS + b"}"
+
+
+def json_body_that_exceeds_x_ndjson_work_limit() -> bytes:
+    return (
+        b'{"data":{"id":"blocked"},"includes":{"users":[{},{},{}]},'
+        b'"matching_rules":[' + b",".join([b"{}"] * _X_NDJSON_DENSE_OBJECT_COUNT) + b"]}"
+    )
 
 
 def make_x_response_flow(


### PR DESCRIPTION
## Summary

- replace X NDJSON's nesting pre-scan and full `json.loads()` row decoding with
  selective extraction of only top-level `data` object presence and
  `includes.*` array lengths
- cap synchronous inspection at 65,536 work units per row and discard every
  partial observation when a row exceeds any parser bound
- preserve response bytes, 5 MiB line framing, CRLF/blank/trailing-line
  behavior, cross-row include bounds, and recovery for later valid rows
- add deterministic response-stream and full connector-pipeline coverage for
  dense arrays/objects, chunk boundaries, later-row recovery, and a byte-cap
  bulk discarded string

## Scope

This is runner-local Python only. It does not change APIs, schemas, queue
payloads, persisted state, the non-streaming X parser, or the existing
cross-row include-category budget. The bounded raw NDJSON line buffer remains;
the change removes the much larger decoded object graph without rewriting the
established line-framing state machine.

The selective parser has higher normal-row CPU overhead than CPython's C JSON
decoder. A local diagnostic measured about 55 µs for a 161-byte representative
row and 218 µs for a 3.6 KiB row, while bounding the demonstrated dense-row
path that previously exceeded one second and fully materialized unrelated
fields.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_x_response_parsers.py tests/test_x_connector_pipeline.py tests/test_json_selective_work_limit.py` — 74 passed
- `uv run --no-sync python -m pytest tests/` — 4,492 passed

Closes #24176
