### PR TITLE
chore(rust): update hybrid-array to 0.4.14

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1601,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]


### PR DESCRIPTION
## Summary

- Update `hybrid-array` from 0.4.13 to 0.4.14.

## Dependencies not updated

- `generic-array` remains at 0.14.7 although 0.14.9 is available because `crypto-common` 0.1.7 pins it exactly to `=0.14.7`.

## Manual version bumps

- None.

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace --exclude runner`
- `cargo test -p runner` — 2,897 passed, 14 ignored, 0 failed; the guest-inventory integration test also passed.

The runner suite was compiled with one build job, test debug info disabled, incremental compilation disabled for the runner test target, and the Rust toolchain's bundled LLVM linker. These settings were required because the standard linker/codegen path exceeded the validation host's 3.8 GiB, no-swap memory limit; no tests were skipped or disabled.
