### PR TITLE
refactor(connectors): use slug identity in firewall policy internals

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -781,10 +781,7 @@ describe("zero user permission grants", () => {
         .sort(),
     ).toStrictEqual([UNKNOWN_PERMISSION_GRANT, SLACK_WRITE_PERMISSION].sort());
 
-    const firewallGrants = active.map((grant) => {
-      return { ...grant, connectorRef: grant.connectorSlug };
-    });
-    expect(permissionGrantsToFirewallPolicies(firewallGrants)).toStrictEqual({
+    expect(permissionGrantsToFirewallPolicies(active)).toStrictEqual({
       slack: {
         policies: { [SLACK_WRITE_PERMISSION]: "deny" },
         unknownPolicy: "deny",

--- a/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
@@ -411,8 +411,7 @@ export function materializeZeroRunBootstrapContext(
           );
         }
         permissionGrants.push({
-          // TODO(#23619): Rename with the runner permission-grant payload.
-          connectorRef: row.name,
+          connectorSlug: row.name,
           permission: row.detail,
           action: row.action,
         });
@@ -430,7 +429,7 @@ export function materializeZeroRunBootstrapContext(
 
   permissionGrants.sort((left, right) => {
     return (
-      left.connectorRef.localeCompare(right.connectorRef) ||
+      left.connectorSlug.localeCompare(right.connectorSlug) ||
       left.permission.localeCompare(right.permission)
     );
   });

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -66,7 +66,7 @@ const userPermissionGrantSelection = Object.freeze({
   orgId: userPermissionGrants.orgId,
   userId: userPermissionGrants.userId,
   agentId: userPermissionGrants.agentId,
-  connectorRef: userPermissionGrants.connectorSlug,
+  connectorSlug: userPermissionGrants.connectorSlug,
   permission: userPermissionGrants.permission,
   action: userPermissionGrants.action,
   expiresAt: userPermissionGrants.expiresAt,
@@ -74,14 +74,11 @@ const userPermissionGrantSelection = Object.freeze({
   updatedAt: userPermissionGrants.updatedAt,
 });
 
-type UserPermissionGrantRow = Omit<
-  typeof userPermissionGrants.$inferSelect,
-  "connectorSlug"
-> & { readonly connectorRef: string };
+type UserPermissionGrantRow = typeof userPermissionGrants.$inferSelect;
 type StoredPermissionGrantRow = UserPermissionGrantRow;
 type ResolvedPermissionGrant = Pick<
   UserPermissionGrantRow,
-  "connectorRef" | "permission" | "action" | "expiresAt"
+  "connectorSlug" | "permission" | "action" | "expiresAt"
 >;
 type UserPermissionGrantAction = UserPermissionGrantResponse["action"];
 
@@ -279,7 +276,7 @@ function earliestTemporaryAllowExpiresAt(
   let earliest: Date | null = null;
   for (const grant of grants) {
     if (
-      grant.connectorRef !== connectorSlug ||
+      grant.connectorSlug !== connectorSlug ||
       grant.action !== "allow" ||
       !grant.expiresAt
     ) {
@@ -480,7 +477,7 @@ export async function resolveActiveNetworkPolicyRefreshesFromBaseline(
         catalogDigest: connectorCatalogActiveSnapshot.catalogDigest,
       },
       grant: {
-        connectorRef: userPermissionGrants.connectorSlug,
+        connectorSlug: userPermissionGrants.connectorSlug,
         permission: userPermissionGrants.permission,
         action: userPermissionGrants.action,
         expiresAt: userPermissionGrants.expiresAt,
@@ -587,7 +584,7 @@ export function mergeNetworkPolicyRefreshes(
 function formatUserPermissionGrant(
   row: Pick<
     StoredPermissionGrantRow,
-    | "connectorRef"
+    | "connectorSlug"
     | "permission"
     | "action"
     | "expiresAt"
@@ -598,7 +595,7 @@ function formatUserPermissionGrant(
 ): UserPermissionGrantResponse {
   return {
     ...scope,
-    connectorSlug: row.connectorRef,
+    connectorSlug: row.connectorSlug,
     permission: row.permission,
     action: row.action,
     expiresAt: row.expiresAt?.toISOString() ?? null,
@@ -687,7 +684,7 @@ async function validateApplyUserPermissionGrants(
 ): Promise<ValidationErrorResponse | null> {
   const index = await catalog.loadPermissionIndex(apply.connectorSlug);
   if (!index) {
-    return validationError(`Unknown connector ref: ${apply.connectorSlug}`);
+    return validationError(`Unknown connector slug: ${apply.connectorSlug}`);
   }
 
   const seenPermissions = new Set<string>();

--- a/turbo/apps/cli/src/commands/zero/shared/firewall-permissions.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/firewall-permissions.ts
@@ -101,9 +101,7 @@ export async function loadConnectorPermissionInfos(args: {
   );
   const resolvedPolicies = resolveFirewallMetadataPolicies(
     args.storedPolicies,
-    defaultPolicyMetadata.map(({ connectorSlug, ...metadata }) => {
-      return { ...metadata, connectorRef: connectorSlug };
-    }),
+    defaultPolicyMetadata,
   );
 
   return args.displayConnectorSlugs.map((connectorSlug) => {
@@ -118,21 +116,12 @@ export async function loadConnectorPermissionInfos(args: {
 export function connectorPermissionGrantsToFirewallPolicies(
   grants: readonly ZeroUserPermissionGrant[],
 ): FirewallPolicies | null {
-  return permissionGrantsToFirewallPolicies(
-    grants.map(({ connectorSlug, ...grant }) => {
-      return { ...grant, connectorRef: connectorSlug };
-    }),
-  );
+  return permissionGrantsToFirewallPolicies(grants);
 }
 
 export function hasConnectorFirewallMetadataPermission(
   metadata: ZeroConnectorCatalogPermissionDetail,
   permission: string,
 ): boolean {
-  return (
-    findFirewallMetadataPermission(
-      { ...metadata, connectorRef: metadata.connectorSlug },
-      permission,
-    ) !== null
-  );
+  return findFirewallMetadataPermission(metadata, permission) !== null;
 }

--- a/turbo/apps/platform/src/signals/user-permission-grants.ts
+++ b/turbo/apps/platform/src/signals/user-permission-grants.ts
@@ -38,11 +38,7 @@ function userPermissionGrantsToActiveFirewallPolicies(
   checkedAtMs = now(),
 ): FirewallPolicies | null {
   return permissionGrantsToFirewallPolicies(
-    activeUserPermissionGrants(grants, checkedAtMs).map(
-      ({ connectorSlug, ...grant }) => {
-        return { ...grant, connectorRef: connectorSlug };
-      },
-    ),
+    activeUserPermissionGrants(grants, checkedAtMs),
   );
 }
 
@@ -56,11 +52,7 @@ export function activeUserPermissionGrantSnapshot(
   const activeGrants = activeUserPermissionGrants(grants, checkedAtMs);
   return {
     grants: activeGrants,
-    policies: permissionGrantsToFirewallPolicies(
-      activeGrants.map(({ connectorSlug, ...grant }) => {
-        return { ...grant, connectorRef: connectorSlug };
-      }),
-    ),
+    policies: permissionGrantsToFirewallPolicies(activeGrants),
   };
 }
 
@@ -72,12 +64,7 @@ export function resolveActiveUserPermissionGrantPolicy(
 ): FirewallPolicyValue | undefined {
   const policies = resolveFirewallMetadataPolicies(
     userPermissionGrantsToActiveFirewallPolicies(grants, checkedAtMs),
-    [
-      {
-        ...metadata,
-        connectorRef: metadata.connectorSlug,
-      },
-    ],
+    [metadata],
   )?.[metadata.connectorSlug];
   return permission === UNKNOWN_PERMISSION_GRANT
     ? policies?.unknownPolicy

--- a/turbo/apps/platform/src/signals/zero-page/settings/permission-grant-save.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permission-grant-save.ts
@@ -235,7 +235,7 @@ function changedUserGrantPolicies({
   expiresInByPermission: GrantExpirationSelections;
 }): ChangedUserGrantPolicy[] {
   const initial = resolveFirewallMetadataPolicies(initialPolicies, [
-    { ...metadata, connectorRef: metadata.connectorSlug },
+    metadata,
   ])?.[connectorSlug];
   const current = policies[connectorSlug];
   const changes = new Map<string, ChangedUserGrantPolicy>();
@@ -275,10 +275,7 @@ function defaultFirewallPoliciesForConnector(
   metadata: PlatformConnectorPermissionMetadata,
 ): FirewallPolicies {
   return {
-    [metadata.connectorSlug]: expandFirewallMetadataDefaultPolicy({
-      ...metadata,
-      connectorRef: metadata.connectorSlug,
-    }),
+    [metadata.connectorSlug]: expandFirewallMetadataDefaultPolicy(metadata),
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -355,10 +355,10 @@ function buildSortedGroups(
   metadata: PlatformConnectorPermissionMetadata,
 ): { category: string; permissions: ConnectorPermission[] }[] | null {
   return (
-    groupFirewallMetadataPermissionsByCategory(metadata.permissions, {
-      ...metadata,
-      connectorRef: metadata.connectorSlug,
-    })?.map((group) => {
+    groupFirewallMetadataPermissionsByCategory(
+      metadata.permissions,
+      metadata,
+    )?.map((group) => {
       return { ...group, permissions: sortPermissions(group.permissions) };
     }) ?? null
   );

--- a/turbo/packages/connectors/src/firewall-metadata/policy.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/policy.ts
@@ -40,12 +40,9 @@ interface FirewallPermissionPolicyMetadataBase {
   readonly defaultPolicy: FirewallPermissionPolicyDefaultMetadata;
 }
 
-export type FirewallPermissionPolicyMetadata =
-  FirewallPermissionPolicyMetadataBase &
-    // TODO(#23619): Rename with the catalog artifact metadata contract.
-    (| { readonly connectorRef: string; readonly type?: string }
-      | { readonly connectorRef?: undefined; readonly type: string }
-    );
+export interface FirewallPermissionPolicyMetadata extends FirewallPermissionPolicyMetadataBase {
+  readonly connectorSlug: string;
+}
 
 export interface FirewallMetadataPermissionGroup<T extends { name: string }> {
   readonly category: string;
@@ -58,16 +55,9 @@ export type FirewallPermissionGrantAction = Extract<
 >;
 
 export interface FirewallPermissionGrant {
-  // TODO(#23619): Rename with the permission-grant wire and storage fields.
-  readonly connectorRef: string;
+  readonly connectorSlug: string;
   readonly permission: string;
   readonly action: FirewallPermissionGrantAction;
-}
-
-function metadataConnectorSlug(
-  metadata: FirewallPermissionPolicyMetadata,
-): string {
-  return metadata.connectorRef ?? metadata.type;
 }
 
 export { createFirewallMetadataPolicyResolver };
@@ -137,12 +127,11 @@ export function resolveFirewallMetadataPolicies(
 ): FirewallPolicies | null {
   let resolved: FirewallPolicies | null = stored;
   for (const detail of metadata) {
-    const connectorSlug = metadataConnectorSlug(detail);
     const defaults = expandFirewallMetadataDefaultPolicy(detail);
-    const existing = resolved?.[connectorSlug];
+    const existing = resolved?.[detail.connectorSlug];
     resolved = {
       ...resolved,
-      [connectorSlug]: {
+      [detail.connectorSlug]: {
         policies: { ...defaults.policies, ...existing?.policies },
         ...(existing?.unknownPolicy !== undefined
           ? { unknownPolicy: existing.unknownPolicy }
@@ -158,16 +147,16 @@ export function permissionGrantsToFirewallPolicies(
 ): FirewallPolicies | null {
   const policies: FirewallPolicies = {};
   for (const grant of grants) {
-    const current = policies[grant.connectorRef] ?? { policies: {} };
+    const current = policies[grant.connectorSlug] ?? { policies: {} };
     if (grant.permission === UNKNOWN_PERMISSION_GRANT) {
-      policies[grant.connectorRef] = {
+      policies[grant.connectorSlug] = {
         ...current,
         unknownPolicy: grant.action,
       };
       continue;
     }
     current.policies[grant.permission] = grant.action;
-    policies[grant.connectorRef] = current;
+    policies[grant.connectorSlug] = current;
   }
   return Object.keys(policies).length > 0 ? policies : null;
 }


### PR DESCRIPTION
## Summary

- make `connectorSlug` the canonical identity in the private firewall policy metadata and grant helpers
- remove API, CLI, and Platform adapters that renamed `connectorSlug` to `connectorRef`
- align the adjacent validation message with the canonical slug terminology

## Scope

This is an atomic internal rename. It does not change database schemas, persisted data, public API schemas, runner protocols, realtime payloads, or historical permission links.

## Validation

- `pnpm check-types`
- `pnpm -F @vm0/connectors test`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-user-permission-grants.test.ts`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/__tests__/whoami.test.ts src/commands/zero/agent/__tests__/view.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/permission-allow/__tests__/permission-allow-page.test.tsx src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/app lint`
- `pnpm knip`

Closes #24221

Parent: #23619
