### PR TITLE
refactor(api): use drizzle transaction config

### DIFF
--- a/turbo/apps/api/src/signals/services/connector-check.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-check.service.ts
@@ -254,85 +254,87 @@ async function loadStoredRuntimeState(
     readonly snapshot: ConnectorRuntimeSnapshot;
   },
 ): Promise<StoredRuntimeState> {
-  return await db.transaction(async (tx) => {
-    await tx.execute(
-      sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`,
-    );
+  return await db.transaction(
+    async (tx) => {
+      const connectorRows = await tx
+        .select({
+          connectorId: connectors.id,
+          connectorSlug: sql`${connectors.connectorSlug}`
+            .mapWith(pgTextDecoder)
+            .as("connector_slug"),
+          authMethod: connectors.authMethod,
+          storageVersion: connectors.storageVersion,
+        })
+        .from(connectors)
+        .where(
+          and(
+            eq(connectors.orgId, args.orgId),
+            eq(connectors.userId, args.userId),
+            isNotNull(connectors.connectorSlug),
+          ),
+        );
 
-    const connectorRows = await tx
-      .select({
-        connectorId: connectors.id,
-        connectorSlug: sql`${connectors.connectorSlug}`
-          .mapWith(pgTextDecoder)
-          .as("connector_slug"),
-        authMethod: connectors.authMethod,
-        storageVersion: connectors.storageVersion,
-      })
-      .from(connectors)
-      .where(
-        and(
-          eq(connectors.orgId, args.orgId),
-          eq(connectors.userId, args.userId),
-          isNotNull(connectors.connectorSlug),
-        ),
+      const pending = pendingStoredConnectorRuntimes(connectorRows, args);
+
+      const readGroups = [...pending.values()].flatMap((value) => {
+        return value === null || value.storageNameByRuntimeName.size === 0
+          ? []
+          : [
+              {
+                access: value.access,
+                names: [...value.storageNameByRuntimeName.values()],
+              },
+            ];
+      });
+      const variableRows =
+        readGroups.length === 0
+          ? []
+          : await tx
+              .select({ name: variables.name, value: variables.value })
+              .from(variables)
+              .where(
+                connectorCredentialVariableReadCondition({
+                  db: tx,
+                  groups: readGroups,
+                }),
+              );
+      const valueByStorageName = new Map(
+        variableRows.map((row) => {
+          return [row.name, row.value] as const;
+        }),
       );
-
-    const pending = pendingStoredConnectorRuntimes(connectorRows, args);
-
-    const readGroups = [...pending.values()].flatMap((value) => {
-      return value === null || value.storageNameByRuntimeName.size === 0
-        ? []
-        : [
-            {
-              access: value.access,
-              names: [...value.storageNameByRuntimeName.values()],
-            },
-          ];
-    });
-    const variableRows =
-      readGroups.length === 0
-        ? []
-        : await tx
-            .select({ name: variables.name, value: variables.value })
-            .from(variables)
-            .where(
-              connectorCredentialVariableReadCondition({
-                db: tx,
-                groups: readGroups,
-              }),
-            );
-    const valueByStorageName = new Map(
-      variableRows.map((row) => {
-        return [row.name, row.value] as const;
-      }),
-    );
-    const baseUrlVarsBySlug = new Map<
-      ConnectorSlug,
-      Readonly<Record<string, string>> | null
-    >();
-    for (const [connectorSlug, pendingState] of pending) {
-      if (pendingState === null) {
-        baseUrlVarsBySlug.set(connectorSlug, null);
-        continue;
-      }
-      const values: Record<string, string> = {};
-      let complete = true;
-      for (const [
-        runtimeName,
-        storageName,
-      ] of pendingState.storageNameByRuntimeName) {
-        const value = valueByStorageName.get(storageName);
-        if (!value) {
-          complete = false;
-          break;
+      const baseUrlVarsBySlug = new Map<
+        ConnectorSlug,
+        Readonly<Record<string, string>> | null
+      >();
+      for (const [connectorSlug, pendingState] of pending) {
+        if (pendingState === null) {
+          baseUrlVarsBySlug.set(connectorSlug, null);
+          continue;
         }
-        values[runtimeName] = value;
+        const values: Record<string, string> = {};
+        let complete = true;
+        for (const [
+          runtimeName,
+          storageName,
+        ] of pendingState.storageNameByRuntimeName) {
+          const value = valueByStorageName.get(storageName);
+          if (!value) {
+            complete = false;
+            break;
+          }
+          values[runtimeName] = value;
+        }
+        baseUrlVarsBySlug.set(connectorSlug, complete ? values : null);
       }
-      baseUrlVarsBySlug.set(connectorSlug, complete ? values : null);
-    }
 
-    return { baseUrlVarsBySlug };
-  });
+      return { baseUrlVarsBySlug };
+    },
+    {
+      isolationLevel: "repeatable read",
+      accessMode: "read only",
+    },
+  );
 }
 
 function routesToDecisionPermissions(

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -927,8 +927,90 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         db.select().from(users).orderBy(sql\`random()\`);
       `,
     },
+    {
+      name: "typed and unsupported transaction configurations stay valid",
+      code: `${drizzlePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        declare const lookalike: {
+          execute(query: SQL): Promise<void>;
+          setTransaction(config: { accessMode?: string }): Promise<void>;
+        };
+        declare const dynamicMode: string;
+        declare function fakeSql(
+          strings: TemplateStringsArray,
+        ): SQL;
+        await db.transaction(
+          async (tx) => {
+            await tx.setTransaction({
+              isolationLevel: "repeatable read",
+              accessMode: "read only",
+            });
+            await tx.execute(
+              sql\`SET LOCAL TRANSACTION ISOLATION LEVEL REPEATABLE READ\`,
+            );
+            await tx.execute(
+              sql\`SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY\`,
+            );
+            await tx.execute(
+              sql\`SET TRANSACTION SNAPSHOT 'snapshot-id'\`,
+            );
+            await tx.execute(
+              sql\`SET TRANSACTION READ ONLY, READ WRITE\`,
+            );
+            await tx.execute(sql\`SET TRANSACTION \${dynamicMode}\`);
+            await tx.execute(sql\`SET TRANSACTION\`);
+            await tx.execute(sql\`SET TRANSACTION READ ONLY; SELECT 1\`);
+            await tx.execute(fakeSql\`SET TRANSACTION READ ONLY\`);
+            const indirect = sql\`SET TRANSACTION READ ONLY\`;
+            await tx.execute(indirect);
+          },
+          {
+            isolationLevel: "repeatable read",
+            accessMode: "read only",
+          },
+        );
+        await db.execute(sql\`SET TRANSACTION READ ONLY\`);
+        await lookalike.execute(sql\`SET TRANSACTION READ ONLY\`);
+      `,
+    },
   ],
   invalid: [
+    {
+      name: "raw transaction configuration has a typed drizzle API",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        await db.transaction(async (tx) => {
+          await tx.execute(
+            sql\`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY\`,
+          );
+        });
+      `,
+      errors: [{ messageId: "transactionConfig" }],
+    },
+    {
+      name: "all supported transaction characteristics are recognized",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        await db.transaction(async (tx) => {
+          await tx.execute(
+            sql\`SET TRANSACTION READ WRITE, ISOLATION LEVEL SERIALIZABLE, DEFERRABLE\`,
+          );
+          await tx.execute(
+            sql\`SET TRANSACTION ISOLATION LEVEL READ COMMITTED\`,
+          );
+          await tx.execute(
+            sql\`SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED\`,
+          );
+          await tx.execute(sql\`SET TRANSACTION NOT DEFERRABLE;\`);
+        });
+      `,
+      errors: [
+        { messageId: "transactionConfig" },
+        { messageId: "transactionConfig" },
+        { messageId: "transactionConfig" },
+        { messageId: "transactionConfig" },
+      ],
+    },
     {
       name: "directly nested identity column wrapper",
       code: `${drizzlePreamble}

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -48,6 +48,7 @@ import { createExecuteRawRowsMatcher } from "../execute-raw-rows.ts";
 import {
   analyzeSql,
   analyzeSqlSource,
+  isDrizzleTransactionConfigSql,
   sqlTagMightContainHelper,
   type SqlAnalysis,
   type SqlAnalysisContext,
@@ -169,6 +170,8 @@ export const preferDrizzleApis = createRule({
         "Use a Drizzle select builder for this complete schema-backed query.",
       scalarCteQueryBuilder:
         "Use Drizzle $with(...), select(), and joins for this complete scalar CTE projection.",
+      transactionConfig:
+        "Use Drizzle transaction configuration APIs for this equivalent SET TRANSACTION statement.",
       unstableGrouping:
         "Group by a reusable expression or real input field instead of a repeated expression, positional ordinal, or computed output alias.",
       structuredScalarQuery:
@@ -536,6 +539,46 @@ export const preferDrizzleApis = createRule({
         isDrizzleSymbol(checker, receiverType.getSymbol()) &&
         update?.declarations?.some(isDrizzlePgCoreDeclaration) === true
       );
+    }
+
+    function isDrizzlePgTransaction(node: TSESTree.Expression): boolean {
+      const receiver = services.esTreeNodeToTSNodeMap.get(node);
+      const receiverType = checker.getTypeAtLocation(receiver);
+      const setTransaction = resolvedSymbol(
+        checker,
+        checker.getPropertyOfType(receiverType, "setTransaction"),
+      );
+      return (
+        setTransaction?.declarations?.some(isDrizzlePgCoreDeclaration) === true
+      );
+    }
+
+    function inspectTransactionConfigCall(node: TSESTree.CallExpression): void {
+      if (
+        node.parent.type !== AST_NODE_TYPES.AwaitExpression ||
+        node.parent.argument !== node ||
+        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        node.callee.object.type === AST_NODE_TYPES.Super ||
+        memberName(node.callee) !== "execute" ||
+        node.arguments.length !== 1
+      ) {
+        return;
+      }
+      const query = node.arguments[0];
+      if (
+        query?.type !== AST_NODE_TYPES.TaggedTemplateExpression ||
+        !isDrizzleTransactionConfigSql(
+          query,
+          checker,
+          services,
+          sqlSourceComposer,
+        ) ||
+        !isDrizzleMethodCall(node, "execute") ||
+        !isDrizzlePgTransaction(node.callee.object)
+      ) {
+        return;
+      }
+      context.report({ node: query, messageId: "transactionConfig" });
     }
 
     function methodReturnsDrizzleProperty(
@@ -2586,6 +2629,7 @@ export const preferDrizzleApis = createRule({
     return {
       CallExpression(node: TSESTree.CallExpression): void {
         inspectRawQueryCall(node);
+        inspectTransactionConfigCall(node);
         inspectPredicateCall(node);
         inspectColumnEncodedComparisonValue(node);
         inspectSqlJoinCall(node);

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -1382,6 +1382,169 @@ function parseSqlVariant(
   };
 }
 
+const TRANSACTION_CONFIG_STATEMENT_KEYS = new Set(["args", "kind", "name"]);
+const TRANSACTION_CONFIG_PARSED_STATEMENT_KEYS = new Set(["stmt", "stmt_len"]);
+const TRANSACTION_CONFIG_STATEMENT_WRAPPER_KEYS = new Set(["VariableSetStmt"]);
+const TRANSACTION_CONFIG_DEFINITION_KEYS = new Set([
+  "arg",
+  "defaction",
+  "defname",
+  "location",
+]);
+const TRANSACTION_CONFIG_DEFINITION_WRAPPER_KEYS = new Set(["DefElem"]);
+const TRANSACTION_CONFIG_CONSTANT_KEYS = new Set(["location", "sval"]);
+const TRANSACTION_CONFIG_CONSTANT_WRAPPER_KEYS = new Set(["A_Const"]);
+const TRANSACTION_CONFIG_INTEGER_KEYS = new Set(["ival", "location"]);
+const TRANSACTION_CONFIG_INTEGER_VALUE_KEYS = new Set(["ival"]);
+const TRANSACTION_CONFIG_STRING_VALUE_KEYS = new Set(["sval"]);
+const TRANSACTION_CONFIG_PREFIX = /^\s*SET\s+TRANSACTION\b/iu;
+const TRANSACTION_ISOLATION_LEVELS = new Set([
+  "read committed",
+  "read uncommitted",
+  "repeatable read",
+  "serializable",
+]);
+
+function transactionIsolationConstant(value: unknown): boolean {
+  const constant = recordProperty(value, "A_Const");
+  const string = recordProperty(constant, "sval");
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, TRANSACTION_CONFIG_CONSTANT_WRAPPER_KEYS) &&
+    constant !== undefined &&
+    hasOnlyKeys(constant, TRANSACTION_CONFIG_CONSTANT_KEYS) &&
+    typeof constant.location === "number" &&
+    string !== undefined &&
+    hasOnlyKeys(string, TRANSACTION_CONFIG_STRING_VALUE_KEYS) &&
+    typeof string.sval === "string" &&
+    TRANSACTION_ISOLATION_LEVELS.has(string.sval)
+  );
+}
+
+function transactionBooleanConstant(value: unknown): boolean {
+  const constant = recordProperty(value, "A_Const");
+  const integer = recordProperty(constant, "ival");
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, TRANSACTION_CONFIG_CONSTANT_WRAPPER_KEYS) &&
+    constant !== undefined &&
+    hasOnlyKeys(constant, TRANSACTION_CONFIG_INTEGER_KEYS) &&
+    typeof constant.location === "number" &&
+    integer !== undefined &&
+    hasOnlyKeys(integer, TRANSACTION_CONFIG_INTEGER_VALUE_KEYS) &&
+    (integer.ival === undefined || integer.ival === 0 || integer.ival === 1)
+  );
+}
+
+function transactionConfigCharacteristicName(
+  value: unknown,
+): string | undefined {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, TRANSACTION_CONFIG_DEFINITION_WRAPPER_KEYS)
+  ) {
+    return undefined;
+  }
+  const definition = recordProperty(value, "DefElem");
+  if (
+    definition === undefined ||
+    !hasOnlyKeys(definition, TRANSACTION_CONFIG_DEFINITION_KEYS) ||
+    definition.defaction !== "DEFELEM_UNSPEC" ||
+    typeof definition.defname !== "string" ||
+    typeof definition.location !== "number"
+  ) {
+    return undefined;
+  }
+  const valid =
+    definition.defname === "transaction_isolation"
+      ? transactionIsolationConstant(definition.arg)
+      : definition.defname === "transaction_read_only" ||
+          definition.defname === "transaction_deferrable"
+        ? transactionBooleanConstant(definition.arg)
+        : false;
+  return valid ? definition.defname : undefined;
+}
+
+function isTransactionConfigStatement(value: unknown): boolean {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, TRANSACTION_CONFIG_PARSED_STATEMENT_KEYS) ||
+    (value.stmt_len !== undefined && typeof value.stmt_len !== "number")
+  ) {
+    return false;
+  }
+  const statement = recordProperty(value, "stmt");
+  if (
+    statement === undefined ||
+    !hasOnlyKeys(statement, TRANSACTION_CONFIG_STATEMENT_WRAPPER_KEYS)
+  ) {
+    return false;
+  }
+  const set = recordProperty(statement, "VariableSetStmt");
+  if (
+    set === undefined ||
+    !hasOnlyKeys(set, TRANSACTION_CONFIG_STATEMENT_KEYS) ||
+    set.kind !== "VAR_SET_MULTI" ||
+    set.name !== "TRANSACTION" ||
+    !Array.isArray(set.args) ||
+    set.args.length === 0 ||
+    set.args.length > 3
+  ) {
+    return false;
+  }
+  const characteristics = set.args.map(transactionConfigCharacteristicName);
+  return (
+    characteristics.every((name): name is string => name !== undefined) &&
+    new Set(characteristics).size === characteristics.length
+  );
+}
+
+export function isDrizzleTransactionConfigSql(
+  node: TSESTree.TaggedTemplateExpression,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+  composer: SqlSourceComposer,
+): boolean {
+  const firstQuasi = node.quasi.quasis[0];
+  if (
+    node.quasi.expressions.length !== 0 ||
+    firstQuasi === undefined ||
+    !TRANSACTION_CONFIG_PREFIX.test(
+      firstQuasi.value.cooked ?? firstQuasi.value.raw,
+    )
+  ) {
+    return false;
+  }
+  const source = composer.compose(node);
+  if (
+    source === null ||
+    source.hasLocalExpansion ||
+    source.expandedTemplates.size !== 1 ||
+    !source.expandedTemplates.has(node) ||
+    source.variants.length !== 1
+  ) {
+    return false;
+  }
+  const variant = source.variants[0];
+  if (
+    variant === undefined ||
+    variant.chunks.some((chunk) => {
+      return chunk.kind !== "literal";
+    })
+  ) {
+    return false;
+  }
+  const parsed = parseSqlVariant(
+    variant,
+    "statement",
+    false,
+    checker,
+    services,
+    undefined,
+  );
+  return parsed !== null && isTransactionConfigStatement(parsed.statement);
+}
+
 function stringNodeValue(value: unknown): string | undefined {
   const stringNode = recordProperty(value, "String");
   return stringNode !== undefined &&


### PR DESCRIPTION
## Summary

- configure the connector runtime snapshot through Drizzle's typed
  repeatable-read, read-only transaction options, folding the former
  `SET TRANSACTION` round trip into `BEGIN`
- extend `api/prefer-drizzle-apis` with a parser-backed classifier for complete
  transaction characteristics that map to `PgTransactionConfig`
- require a real Drizzle `PgTransaction` receiver and keep local, session,
  dynamic, indirect, unsupported, malformed, multiple-statement, and lookalike
  forms opaque

## Compatibility

This changes no schema, persisted data, public API, runner protocol, or rollout
behavior. The connector reads and result construction remain inside the same
transaction callback.

## Validation

- `pnpm -F @vm0/eslint-rules exec vitest run src/api/__tests__/prefer-drizzle-apis.test.ts src/api/__tests__/prefer-drizzle-apis-write.test.ts --maxWorkers=1 --no-file-parallelism --silent=passed-only` (373 passed)
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-check.test.ts --maxWorkers=1 --no-file-parallelism --silent=passed-only` (8 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- affected Prettier checks and `git diff --check`
- five alternating API ESLint performance pairs: median wall time -14.36% and
  median peak process-tree RSS +1.85% versus the exact base (gates: +5% and
  +10%)

Closes #24211

Parent: #23047
