### PR TITLE
refactor(connectors): prepare slug compatibility evaluations

### DIFF
--- a/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
@@ -42,7 +42,7 @@ import { writeDb$ } from "../../external/db";
 import { nowDate } from "../../external/time";
 import { appendChatThreadEvent } from "../../services/zero-chat-thread-event.service";
 import {
-  connectorCatalogExecutableCapabilityState,
+  connectorCatalogExecutableCapabilityStates,
   persistConnectorCatalogCompatibility,
 } from "../../services/connector-catalog-compatibility.service";
 import {
@@ -213,7 +213,7 @@ async function seedBenchConnectorCatalog(): Promise<void> {
   const catalogDigest = sha256Digest(rawBytes);
   const catalogGzip = encodeConnectorCatalogSnapshot(rawBytes);
   const source = connectorCatalogSource();
-  const capability = connectorCatalogExecutableCapabilityState();
+  const capabilities = connectorCatalogExecutableCapabilityStates();
   const activatedAt = nowDate();
   const db = store.set(writeDb$);
   const syncStateValues = {
@@ -281,7 +281,7 @@ async function seedBenchConnectorCatalog(): Promise<void> {
         catalogDigest,
       },
       artifact: BENCH_CONNECTOR_CATALOG,
-      capability,
+      capabilities,
       validator: currentConnectorCatalogValidatorIdentity(),
     });
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -47,8 +47,10 @@ import { server } from "../../../mocks/server";
 import {
   apiTestConnectorCatalogValidationAuthority,
   deleteApiTestConnectorCatalogCompatibility,
+  deleteApiTestConnectorCatalogCompatibilityEvaluation,
   invalidateApiTestConnectorCatalogCompatibility,
   mockApiTestConnectorProviderConfiguration,
+  readApiTestConnectorCatalogCompatibilityEvaluations,
   readApiTestConnectorCatalogValidationAuthority,
   replaceApiTestConnectorCatalogStoredBytes,
   setApiTestConnectorCatalogValidationAuthority,
@@ -100,6 +102,10 @@ const DIAGNOSTICS_ORG_ID = `org_${randomUUID()}`;
 const PRIVATE_VALUE = "SECRET_TOKEN";
 const DEFAULT_API_VERSION = apiPackage.version;
 const ZERO_DIGEST = `sha256:${"0".repeat(64)}`;
+const EXPECTED_LEGACY_CAPABILITY_DIGEST =
+  "sha256:53a770117015a00103988a57526a537a687f63dde3dd4c020a9265fed483cc09";
+const EXPECTED_CANONICAL_CAPABILITY_DIGEST =
+  "sha256:f28faa130eeea8dbc27f816003b6fe162dc1792dd27f5e9173856c5bedb7eea7";
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";
@@ -1469,6 +1475,23 @@ function expectRejectedBeforeAcceptance(
   });
 }
 
+function requireLegacyAndCanonicalEvaluations(
+  evaluations: Awaited<
+    ReturnType<typeof readApiTestConnectorCatalogCompatibilityEvaluations>
+  >,
+) {
+  const legacy = evaluations.find(({ payload }) => {
+    return Array.isArray(payload);
+  });
+  const canonical = evaluations.find(({ payload }) => {
+    return !Array.isArray(payload);
+  });
+  if (legacy === undefined || canonical === undefined) {
+    throw new Error("Expected legacy and canonical compatibility evaluations");
+  }
+  return { legacy, canonical };
+}
+
 beforeEach(() => {
   mockEnv("CRON_SECRET", CRON_SECRET);
   mockNow(new Date(FIRST_SYNC_TIME));
@@ -2346,6 +2369,7 @@ describe("connector catalog valid lifecycle", () => {
     const synced = await syncCatalog();
     expect(synced.body.filtering.filteredAuthMethods).toStrictEqual([
       {
+        connectorSlug: "agora",
         connectorRef: "agora",
         authMethodId: "legacy",
         reasons: ["missing-access-provider"],
@@ -4992,6 +5016,181 @@ describe("connector catalog valid lifecycle", () => {
 });
 
 describe("connector catalog executable compatibility", () => {
+  it("writes deterministic empty legacy and canonical evaluations", async () => {
+    configureSource();
+    mockApiTestConnectorProviderConfiguration();
+    const release = buildRelease({
+      version: "2026-07-31.dual-empty-evaluations",
+    });
+    serveObjects(catalogObjects([release], release));
+
+    const synced = await syncCatalog();
+    const evaluations =
+      await readApiTestConnectorCatalogCompatibilityEvaluations();
+    expect(evaluations).toHaveLength(2);
+    const { legacy, canonical } =
+      requireLegacyAndCanonicalEvaluations(evaluations);
+
+    expect(legacy.capabilityDigest).toBe(EXPECTED_LEGACY_CAPABILITY_DIGEST);
+    expect(canonical.capabilityDigest).toBe(
+      EXPECTED_CANONICAL_CAPABILITY_DIGEST,
+    );
+    expect(canonical.capabilityDigest).not.toBe(legacy.capabilityDigest);
+    expect(synced.body.filtering).toStrictEqual({
+      capabilityDigest: legacy.capabilityDigest,
+      evaluatedAt: FIRST_SYNC_TIME,
+      stale: false,
+      filteredAuthMethods: [],
+    });
+    expect(legacy.payload).toStrictEqual([]);
+    expect(canonical.payload).toStrictEqual({ filteredAuthMethods: [] });
+    expect(canonical.validationAuthority).toStrictEqual(
+      legacy.validationAuthority,
+    );
+    expect(canonical.evaluatedAt).toBe(legacy.evaluatedAt);
+
+    zeroMocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+    const headers = { authorization: "Bearer clerk-session" };
+    const client = diagnosticsClient();
+    await accept(client.list({ headers }), [200]);
+    await accept(client.status({ headers }), [200]);
+    await accept(
+      client.get({
+        headers,
+        params: { connectorSlug: release.connectorSlug },
+      }),
+      [200],
+    );
+  });
+
+  it("persists equal non-empty legacy and canonical filtering", async () => {
+    configureSource();
+    const release = buildRelease({
+      version: "2026-07-31.dual-filtered-evaluations",
+      connectorSlug: "future-auth",
+      mutateCatalog: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          publicAuthMethod({ id: "oauth", grantKind: "device-auth" }),
+        ]);
+      },
+      mutateRuntime: (artifact) => {
+        setArtifactAuthMethods(artifact, [devicePrivateAuthMethod()]);
+      },
+    });
+    serveObjects(catalogObjects([release], release));
+
+    const synced = await syncCatalog();
+    const evaluations =
+      await readApiTestConnectorCatalogCompatibilityEvaluations();
+    expect(evaluations).toHaveLength(2);
+    const { legacy, canonical } =
+      requireLegacyAndCanonicalEvaluations(evaluations);
+    const wireMethods = synced.body.filtering.filteredAuthMethods;
+    const expectedLegacy = wireMethods.map((method) => {
+      return {
+        connectorRef: method.connectorRef,
+        authMethodId: method.authMethodId,
+        reasons: method.reasons,
+      };
+    });
+    const expectedCanonical = wireMethods.map((method) => {
+      if (method.connectorSlug === undefined) {
+        throw new Error("Expected canonical diagnostics connector slug");
+      }
+      return {
+        connectorSlug: method.connectorSlug,
+        authMethodId: method.authMethodId,
+        reasons: method.reasons,
+      };
+    });
+
+    expect(legacy.payload).toStrictEqual(expectedLegacy);
+    expect(canonical.payload).toStrictEqual({
+      filteredAuthMethods: expectedCanonical,
+    });
+    expect(JSON.stringify(legacy.payload)).not.toContain("connectorSlug");
+    expect(JSON.stringify(canonical.payload)).not.toContain("connectorRef");
+    expect(canonical.validationAuthority).toStrictEqual(
+      legacy.validationAuthority,
+    );
+    expect(wireMethods).toStrictEqual(
+      expectedCanonical.map((method) => {
+        return {
+          connectorSlug: method.connectorSlug,
+          connectorRef: method.connectorSlug,
+          authMethodId: method.authMethodId,
+          reasons: method.reasons,
+        };
+      }),
+    );
+  });
+
+  it("reconciles a missing canonical evaluation without switching readers", async () => {
+    configureSource();
+    mockApiTestConnectorProviderConfiguration();
+    const release = buildRelease({
+      version: "2026-07-31.missing-canonical-evaluation",
+    });
+    serveObjects(catalogObjects([release], release));
+    await syncCatalog();
+
+    await deleteApiTestConnectorCatalogCompatibilityEvaluation(
+      EXPECTED_CANONICAL_CAPABILITY_DIGEST,
+    );
+    const [legacy] =
+      await readApiTestConnectorCatalogCompatibilityEvaluations();
+    expect(legacy?.capabilityDigest).toBe(EXPECTED_LEGACY_CAPABILITY_DIGEST);
+
+    mockNow(new Date("2026-07-31T08:01:00.000Z"));
+    const reconciled = await syncCatalog();
+    const evaluations =
+      await readApiTestConnectorCatalogCompatibilityEvaluations();
+
+    expect(reconciled.body.outcome).toBe("unchanged");
+    expect(reconciled.body.filtering.capabilityDigest).toBe(
+      EXPECTED_LEGACY_CAPABILITY_DIGEST,
+    );
+    expect(evaluations).toHaveLength(2);
+    requireLegacyAndCanonicalEvaluations(evaluations);
+  });
+
+  it("replaces both evaluation formats with a new catalog", async () => {
+    configureSource();
+    const first = buildRelease({
+      version: "2026-07-31.dual-replacement-1",
+    });
+    serveObjects(catalogObjects([first], first));
+    await syncCatalog();
+    const firstEvaluations =
+      await readApiTestConnectorCatalogCompatibilityEvaluations();
+    expect(firstEvaluations).toHaveLength(2);
+    const firstCatalogDigest = firstEvaluations[0]?.catalogDigest;
+    if (firstCatalogDigest === undefined) {
+      throw new Error("Expected initial compatibility evaluations");
+    }
+
+    const second = buildRelease({
+      version: "2026-07-31.dual-replacement-2",
+    });
+    serveObjects(catalogObjects([first, second], second));
+    const replaced = await syncCatalog();
+    const replacementEvaluations =
+      await readApiTestConnectorCatalogCompatibilityEvaluations();
+
+    expect(replacementEvaluations).toHaveLength(2);
+    expect(
+      replacementEvaluations.every((evaluation) => {
+        return evaluation.catalogDigest === replaced.body.active?.catalogDigest;
+      }),
+    ).toBeTruthy();
+    expect(
+      replacementEvaluations.some((evaluation) => {
+        return evaluation.catalogDigest === firstCatalogDigest;
+      }),
+    ).toBeFalsy();
+    requireLegacyAndCanonicalEvaluations(replacementEvaluations);
+  });
+
   it("repairs missing and preserves newer catalog validation authorities", async () => {
     configureSource();
     const release = buildRelease({
@@ -5048,6 +5247,17 @@ describe("connector catalog executable compatibility", () => {
       backendVersion: "1.319.0",
       buildCommitSha: null,
     });
+    const evaluations =
+      await readApiTestConnectorCatalogCompatibilityEvaluations();
+    expect(evaluations).toHaveLength(2);
+    expect(
+      evaluations.map((evaluation) => {
+        return evaluation.validationAuthority;
+      }),
+    ).toStrictEqual([
+      { backendVersion: "1.319.0", buildCommitSha: null },
+      { backendVersion: "1.319.0", buildCommitSha: null },
+    ]);
   });
 
   it("prevents a draining older API release from downgrading validation authority", async () => {
@@ -5085,6 +5295,16 @@ describe("connector catalog executable compatibility", () => {
       backendVersion: "1.319.0",
       buildCommitSha: null,
     });
+    const evaluations =
+      await readApiTestConnectorCatalogCompatibilityEvaluations();
+    expect(
+      evaluations.map((evaluation) => {
+        return evaluation.validationAuthority;
+      }),
+    ).toStrictEqual([
+      { backendVersion: "1.319.0", buildCommitSha: null },
+      { backendVersion: "1.319.0", buildCommitSha: null },
+    ]);
   });
 
   it("repairs accepted validation authority after a preview build", async () => {
@@ -5339,6 +5559,7 @@ describe("connector catalog executable compatibility", () => {
       (await syncCatalog()).body.filtering.filteredAuthMethods,
     ).toStrictEqual([
       {
+        connectorSlug: "cloudflare",
         connectorRef: "cloudflare",
         authMethodId: "future-web",
         reasons: ["missing-grant-provider", "provider-contract-mismatch"],
@@ -5511,6 +5732,26 @@ describe("connector catalog executable compatibility", () => {
     expect((await readStatus()).body.filtering).toStrictEqual(
       missingConfiguration.body.filtering,
     );
+    const rollingEvaluations =
+      await readApiTestConnectorCatalogCompatibilityEvaluations();
+    expect(rollingEvaluations).toHaveLength(4);
+    expect(
+      rollingEvaluations.filter(({ payload }) => {
+        return Array.isArray(payload);
+      }),
+    ).toHaveLength(2);
+    expect(
+      rollingEvaluations.filter(({ payload }) => {
+        return !Array.isArray(payload);
+      }),
+    ).toHaveLength(2);
+    expect(
+      new Set(
+        rollingEvaluations.map((evaluation) => {
+          return evaluation.catalogDigest;
+        }),
+      ),
+    ).toStrictEqual(new Set([missingConfiguration.body.active?.catalogDigest]));
 
     const second = buildRelease({
       version: "2026-07-15.steam-2",
@@ -5558,6 +5799,7 @@ describe("connector catalog executable compatibility", () => {
     const response = await syncCatalog();
     expect(response.body.filtering.filteredAuthMethods).toStrictEqual([
       {
+        connectorSlug: "steam",
         connectorRef: "steam",
         authMethodId: "openid",
         reasons: ["provider-contract-mismatch"],

--- a/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
@@ -1,11 +1,15 @@
 import { createHash } from "node:crypto";
 
 import {
-  connectorCatalogFilteredAuthMethodsSchema,
+  connectorCatalogCompatibilityReasonSchema,
   type ConnectorCatalogCompatibilityReason,
   type ConnectorCatalogFilteredAuthMethod,
   type ConnectorCatalogFilteringStatus,
 } from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
+import {
+  connectorAuthMethodIdSchema,
+  connectorSlugSchema,
+} from "@vm0/api-contracts/contracts/connector-identity";
 import {
   CONNECTOR_GENERIC_AUTH_CAPABILITY_VERSIONS,
   getConnectorAuthProviderRegistrationCapabilities,
@@ -17,8 +21,15 @@ import {
   connectorCatalogCompatibilityEvaluation,
   connectorCatalogSyncState,
 } from "@vm0/db/schema/connector-catalog";
+import type {
+  CanonicalConnectorCatalogCompatibilityEvaluation,
+  CanonicalConnectorCatalogFilteredAuthMethod,
+  ConnectorCatalogCompatibilityEvaluationPayload,
+  LegacyConnectorCatalogCompatibilityEvaluation,
+} from "@vm0/db/jsonb-contracts/connector-catalog";
 import { command } from "ccstate";
-import { and, eq, isNull, lte, ne, or, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, lte, ne, or, sql } from "drizzle-orm";
+import { z } from "zod";
 
 import { optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
@@ -44,14 +55,41 @@ const COMPATIBILITY_REASON_ORDER = [
   "missing-platform-configuration",
 ] as const satisfies readonly ConnectorCatalogCompatibilityReason[];
 
-// Bump when evaluator semantics change without changing a provider or generic
-// capability projection, so rolling builds cannot reuse each other's reports.
-const EXECUTABLE_CAPABILITY_EVALUATOR_VERSION = 1;
+export const legacyConnectorCatalogCompatibilityEvaluationSchema: z.ZodType<LegacyConnectorCatalogCompatibilityEvaluation> =
+  z.array(
+    z
+      .object({
+        connectorRef: connectorSlugSchema,
+        authMethodId: connectorAuthMethodIdSchema,
+        reasons: z.array(connectorCatalogCompatibilityReasonSchema).min(1),
+      })
+      .strict(),
+  );
+
+const LEGACY_EXECUTABLE_CAPABILITY_EVALUATOR_VERSION = 1;
+const CANONICAL_EXECUTABLE_CAPABILITY_EVALUATOR_VERSION = 2;
+
+type LegacyConnectorAuthProviderRegistrationCapability = Omit<
+  ConnectorAuthProviderRegistrationCapability,
+  "connectorSlug"
+> & {
+  readonly connectorRef: string;
+};
 
 export interface ExecutableCapabilityState {
   readonly digest: string;
   readonly configuredNames: ReadonlySet<string>;
   readonly registrations: readonly ConnectorAuthProviderRegistrationCapability[];
+}
+
+export interface ExecutableCapabilityStates {
+  readonly legacy: ExecutableCapabilityState;
+  readonly canonical: ExecutableCapabilityState;
+}
+
+interface ExecutableCapabilityConfiguration {
+  readonly name: string;
+  readonly present: boolean;
 }
 
 interface ConnectorCatalogCompatibilityIdentity {
@@ -72,7 +110,35 @@ function registrationKey(connectorSlug: string, authMethodId: string): string {
   return `${connectorSlug}\0${authMethodId}`;
 }
 
-export function connectorCatalogExecutableCapabilityState(): ExecutableCapabilityState {
+function executableCapabilityDigest(args: {
+  readonly evaluatorVersion: number;
+  readonly registrations:
+    | readonly ConnectorAuthProviderRegistrationCapability[]
+    | readonly LegacyConnectorAuthProviderRegistrationCapability[];
+  readonly configuration: readonly ExecutableCapabilityConfiguration[];
+}): string {
+  const preimage = JSON.stringify({
+    evaluatorVersion: args.evaluatorVersion,
+    generic: CONNECTOR_GENERIC_AUTH_CAPABILITY_VERSIONS,
+    registrations: args.registrations,
+    configuration: args.configuration,
+  });
+  return `sha256:${createHash("sha256").update(preimage).digest("hex")}`;
+}
+
+function legacyRegistrationCapability(
+  registration: ConnectorAuthProviderRegistrationCapability,
+): LegacyConnectorAuthProviderRegistrationCapability {
+  return {
+    connectorRef: registration.connectorSlug,
+    authMethodId: registration.authMethodId,
+    handlers: registration.handlers,
+    contract: registration.contract,
+    requiredConfigurationNames: registration.requiredConfigurationNames,
+  };
+}
+
+export function connectorCatalogExecutableCapabilityStates(): ExecutableCapabilityStates {
   const registrations = getConnectorAuthProviderRegistrationCapabilities();
   const configurationNames = [
     ...new Set(
@@ -84,21 +150,36 @@ export function connectorCatalogExecutableCapabilityState(): ExecutableCapabilit
   const configuration = configurationNames.map((name) => {
     return { name, present: optionalEnv(name) !== undefined };
   });
-  const preimage = JSON.stringify({
-    evaluatorVersion: EXECUTABLE_CAPABILITY_EVALUATOR_VERSION,
-    generic: CONNECTOR_GENERIC_AUTH_CAPABILITY_VERSIONS,
-    registrations,
-    configuration,
-  });
+  const configuredNames = new Set(
+    configuration.flatMap(({ name, present }) => {
+      return present ? [name] : [];
+    }),
+  );
   return {
-    digest: `sha256:${createHash("sha256").update(preimage).digest("hex")}`,
-    configuredNames: new Set(
-      configuration.flatMap(({ name, present }) => {
-        return present ? [name] : [];
+    legacy: {
+      digest: executableCapabilityDigest({
+        evaluatorVersion: LEGACY_EXECUTABLE_CAPABILITY_EVALUATOR_VERSION,
+        registrations: registrations.map(legacyRegistrationCapability),
+        configuration,
       }),
-    ),
-    registrations,
+      configuredNames,
+      registrations,
+    },
+    canonical: {
+      digest: executableCapabilityDigest({
+        evaluatorVersion: CANONICAL_EXECUTABLE_CAPABILITY_EVALUATOR_VERSION,
+        registrations,
+        configuration,
+      }),
+      configuredNames,
+      registrations,
+    },
   };
+}
+
+// TODO(#24184): Switch active readers only after the canonical row is observed.
+export function connectorCatalogExecutableCapabilityState(): ExecutableCapabilityState {
+  return connectorCatalogExecutableCapabilityStates().legacy;
 }
 
 export function connectorCatalogExecutableCapabilityDigest(): string {
@@ -245,11 +326,11 @@ function evaluateMethod(args: {
 function evaluateConnectorCatalogCompatibility(args: {
   readonly artifact: ConnectorCatalogArtifact;
   readonly capability: ExecutableCapabilityState;
-}): readonly ConnectorCatalogFilteredAuthMethod[] {
+}): readonly CanonicalConnectorCatalogFilteredAuthMethod[] {
   const registrations = new Map(
     args.capability.registrations.map((registration) => {
       return [
-        registrationKey(registration.connectorRef, registration.authMethodId),
+        registrationKey(registration.connectorSlug, registration.authMethodId),
         registration,
       ];
     }),
@@ -267,7 +348,7 @@ function evaluateConnectorCatalogCompatibility(args: {
         ? []
         : [
             {
-              connectorRef: connector.slug,
+              connectorSlug: connector.slug,
               authMethodId: method.id,
               reasons,
             },
@@ -276,7 +357,7 @@ function evaluateConnectorCatalogCompatibility(args: {
   });
   return filtered.sort((left, right) => {
     return (
-      compareStrings(left.connectorRef, right.connectorRef) ||
+      compareStrings(left.connectorSlug, right.connectorSlug) ||
       compareStrings(left.authMethodId, right.authMethodId)
     );
   });
@@ -304,25 +385,15 @@ async function deleteReplacedEvaluations(args: {
     );
 }
 
-export async function persistConnectorCatalogCompatibility(args: {
+async function persistConnectorCatalogCompatibilityEvaluation(args: {
   readonly db: Db;
   readonly sourceId: string;
   readonly identity: ConnectorCatalogCompatibilityIdentity;
-  readonly artifact: ConnectorCatalogArtifact;
-  readonly capability: ExecutableCapabilityState;
+  readonly capabilityDigest: string;
   readonly validator: ConnectorCatalogValidatorIdentity;
+  readonly evaluatedAt: Date;
+  readonly payload: ConnectorCatalogCompatibilityEvaluationPayload;
 }): Promise<void> {
-  await deleteReplacedEvaluations({
-    db: args.db,
-    sourceId: args.sourceId,
-    catalogDigest: args.identity.catalogDigest,
-  });
-  const filteredAuthMethods = evaluateConnectorCatalogCompatibility({
-    artifact: args.artifact,
-    capability: args.capability,
-  });
-  const evaluatedAt = nowDate();
-  const persistedFilteredAuthMethods = [...filteredAuthMethods];
   await args.db
     .insert(connectorCatalogCompatibilityEvaluation)
     .values({
@@ -330,11 +401,11 @@ export async function persistConnectorCatalogCompatibility(args: {
       schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
       catalogVersion: args.identity.catalogVersion,
       catalogDigest: args.identity.catalogDigest,
-      executableCapabilityDigest: args.capability.digest,
+      executableCapabilityDigest: args.capabilityDigest,
       catalogValidationBackendVersion: args.validator.backendVersion,
       catalogValidationBuildCommitSha: args.validator.buildCommitSha,
-      evaluatedAt,
-      filteredAuthMethods: persistedFilteredAuthMethods,
+      evaluatedAt: args.evaluatedAt,
+      filteredAuthMethods: args.payload,
     })
     .onConflictDoUpdate({
       target: [
@@ -347,8 +418,8 @@ export async function persistConnectorCatalogCompatibility(args: {
       set: {
         catalogValidationBackendVersion: args.validator.backendVersion,
         catalogValidationBuildCommitSha: args.validator.buildCommitSha,
-        evaluatedAt,
-        filteredAuthMethods: persistedFilteredAuthMethods,
+        evaluatedAt: args.evaluatedAt,
+        filteredAuthMethods: args.payload,
       },
       // A draining older API release must not downgrade an attestation written
       // by a newer release during a rolling deployment.
@@ -362,6 +433,49 @@ export async function persistConnectorCatalogCompatibility(args: {
         ),
       ),
     });
+}
+
+export async function persistConnectorCatalogCompatibility(args: {
+  readonly db: Db;
+  readonly sourceId: string;
+  readonly identity: ConnectorCatalogCompatibilityIdentity;
+  readonly artifact: ConnectorCatalogArtifact;
+  readonly capabilities: ExecutableCapabilityStates;
+  readonly validator: ConnectorCatalogValidatorIdentity;
+}): Promise<void> {
+  await deleteReplacedEvaluations({
+    db: args.db,
+    sourceId: args.sourceId,
+    catalogDigest: args.identity.catalogDigest,
+  });
+  const filteredAuthMethods = evaluateConnectorCatalogCompatibility({
+    artifact: args.artifact,
+    capability: args.capabilities.canonical,
+  });
+  const evaluatedAt = nowDate();
+  const legacyPayload: LegacyConnectorCatalogCompatibilityEvaluation =
+    filteredAuthMethods.map((method) => {
+      return {
+        connectorRef: method.connectorSlug,
+        authMethodId: method.authMethodId,
+        reasons: method.reasons,
+      };
+    });
+  const canonicalPayload: CanonicalConnectorCatalogCompatibilityEvaluation = {
+    filteredAuthMethods,
+  };
+  await persistConnectorCatalogCompatibilityEvaluation({
+    ...args,
+    capabilityDigest: args.capabilities.legacy.digest,
+    evaluatedAt,
+    payload: legacyPayload,
+  });
+  await persistConnectorCatalogCompatibilityEvaluation({
+    ...args,
+    capabilityDigest: args.capabilities.canonical.digest,
+    evaluatedAt,
+    payload: canonicalPayload,
+  });
 }
 
 async function lockSyncState(db: Db, sourceId: string): Promise<boolean> {
@@ -422,7 +536,7 @@ function staleFilteringStatus(
 async function reconcileCompatibility(args: {
   readonly db: Db;
   readonly sourceId: string;
-  readonly capability: ExecutableCapabilityState;
+  readonly capabilities: ExecutableCapabilityStates;
   readonly validator: ConnectorCatalogValidatorIdentity;
 }): Promise<void> {
   const hasState = await lockSyncState(args.db, args.sourceId);
@@ -434,8 +548,14 @@ async function reconcileCompatibility(args: {
     return;
   }
 
-  const [existing] = await args.db
+  const capabilityStates = [
+    args.capabilities.legacy,
+    args.capabilities.canonical,
+  ];
+  const existing = await args.db
     .select({
+      executableCapabilityDigest:
+        connectorCatalogCompatibilityEvaluation.executableCapabilityDigest,
       catalogValidationBackendVersion:
         connectorCatalogCompatibilityEvaluation.catalogValidationBackendVersion,
       catalogValidationBuildCommitSha:
@@ -457,24 +577,34 @@ async function reconcileCompatibility(args: {
           connectorCatalogCompatibilityEvaluation.catalogDigest,
           snapshot.catalogDigest,
         ),
-        eq(
+        inArray(
           connectorCatalogCompatibilityEvaluation.executableCapabilityDigest,
-          args.capability.digest,
+          capabilityStates.map((capability) => {
+            return capability.digest;
+          }),
         ),
       ),
-    )
-    .limit(1);
-  if (
-    existing !== undefined &&
-    existing.catalogValidationBackendVersion !== null &&
-    connectorCatalogValidationAuthorityIsCurrentOrNewer({
-      authority: {
-        backendVersion: existing.catalogValidationBackendVersion,
-        buildCommitSha: existing.catalogValidationBuildCommitSha,
-      },
-      validator: args.validator,
-    })
-  ) {
+    );
+  const existingByDigest = new Map(
+    existing.map((evaluation) => {
+      return [evaluation.executableCapabilityDigest, evaluation];
+    }),
+  );
+  const allCurrentOrNewer = capabilityStates.every((capability) => {
+    const evaluation = existingByDigest.get(capability.digest);
+    return (
+      evaluation !== undefined &&
+      evaluation.catalogValidationBackendVersion !== null &&
+      connectorCatalogValidationAuthorityIsCurrentOrNewer({
+        authority: {
+          backendVersion: evaluation.catalogValidationBackendVersion,
+          buildCommitSha: evaluation.catalogValidationBuildCommitSha,
+        },
+        validator: args.validator,
+      })
+    );
+  });
+  if (allCurrentOrNewer) {
     return;
   }
 
@@ -484,8 +614,21 @@ async function reconcileCompatibility(args: {
     sourceId: args.sourceId,
     identity: snapshot,
     artifact: decoded.artifact,
-    capability: args.capability,
+    capabilities: args.capabilities,
     validator: args.validator,
+  });
+}
+
+function diagnosticFilteredAuthMethods(
+  filteredAuthMethods: LegacyConnectorCatalogCompatibilityEvaluation,
+): ConnectorCatalogFilteredAuthMethod[] {
+  return filteredAuthMethods.map((method) => {
+    return {
+      connectorSlug: method.connectorRef,
+      connectorRef: method.connectorRef,
+      authMethodId: method.authMethodId,
+      reasons: [...method.reasons],
+    };
   });
 }
 
@@ -535,8 +678,10 @@ async function compatibilityStatus(args: {
     capabilityDigest: args.capabilityDigest,
     evaluatedAt: result.evaluatedAt.toISOString(),
     stale: false,
-    filteredAuthMethods: connectorCatalogFilteredAuthMethodsSchema.parse(
-      result.filteredAuthMethods,
+    filteredAuthMethods: diagnosticFilteredAuthMethods(
+      legacyConnectorCatalogCompatibilityEvaluationSchema.parse(
+        result.filteredAuthMethods,
+      ),
     ),
   };
 }
@@ -544,13 +689,13 @@ async function compatibilityStatus(args: {
 export const reconcileConnectorCatalogCompatibility$ = command(
   async ({ set }, signal: AbortSignal): Promise<void> => {
     const source = connectorCatalogSource();
-    const capability = connectorCatalogExecutableCapabilityState();
+    const capabilities = connectorCatalogExecutableCapabilityStates();
     const validator = currentConnectorCatalogValidatorIdentity();
     await set(writeDb$).transaction(async (tx) => {
       await reconcileCompatibility({
         db: tx,
         sourceId: source.sourceId,
-        capability,
+        capabilities,
         validator,
       });
     });

--- a/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
@@ -92,6 +92,12 @@ interface ExecutableCapabilityConfiguration {
   readonly present: boolean;
 }
 
+interface ExecutableCapabilityFacts {
+  readonly registrations: readonly ConnectorAuthProviderRegistrationCapability[];
+  readonly configuration: readonly ExecutableCapabilityConfiguration[];
+  readonly configuredNames: ReadonlySet<string>;
+}
+
 interface ConnectorCatalogCompatibilityIdentity {
   readonly catalogVersion: string;
   readonly catalogDigest: string;
@@ -138,7 +144,7 @@ function legacyRegistrationCapability(
   };
 }
 
-export function connectorCatalogExecutableCapabilityStates(): ExecutableCapabilityStates {
+function connectorCatalogExecutableCapabilityFacts(): ExecutableCapabilityFacts {
   const registrations = getConnectorAuthProviderRegistrationCapabilities();
   const configurationNames = [
     ...new Set(
@@ -155,31 +161,53 @@ export function connectorCatalogExecutableCapabilityStates(): ExecutableCapabili
       return present ? [name] : [];
     }),
   );
+  return { registrations, configuration, configuredNames };
+}
+
+function createExecutableCapabilityState(args: {
+  readonly facts: ExecutableCapabilityFacts;
+  readonly evaluatorVersion: number;
+  readonly digestRegistrations:
+    | readonly ConnectorAuthProviderRegistrationCapability[]
+    | readonly LegacyConnectorAuthProviderRegistrationCapability[];
+}): ExecutableCapabilityState {
   return {
-    legacy: {
-      digest: executableCapabilityDigest({
-        evaluatorVersion: LEGACY_EXECUTABLE_CAPABILITY_EVALUATOR_VERSION,
-        registrations: registrations.map(legacyRegistrationCapability),
-        configuration,
-      }),
-      configuredNames,
-      registrations,
-    },
-    canonical: {
-      digest: executableCapabilityDigest({
-        evaluatorVersion: CANONICAL_EXECUTABLE_CAPABILITY_EVALUATOR_VERSION,
-        registrations,
-        configuration,
-      }),
-      configuredNames,
-      registrations,
-    },
+    digest: executableCapabilityDigest({
+      evaluatorVersion: args.evaluatorVersion,
+      registrations: args.digestRegistrations,
+      configuration: args.facts.configuration,
+    }),
+    configuredNames: args.facts.configuredNames,
+    registrations: args.facts.registrations,
+  };
+}
+
+export function connectorCatalogExecutableCapabilityStates(): ExecutableCapabilityStates {
+  const facts = connectorCatalogExecutableCapabilityFacts();
+  return {
+    legacy: createExecutableCapabilityState({
+      facts,
+      evaluatorVersion: LEGACY_EXECUTABLE_CAPABILITY_EVALUATOR_VERSION,
+      digestRegistrations: facts.registrations.map(
+        legacyRegistrationCapability,
+      ),
+    }),
+    canonical: createExecutableCapabilityState({
+      facts,
+      evaluatorVersion: CANONICAL_EXECUTABLE_CAPABILITY_EVALUATOR_VERSION,
+      digestRegistrations: facts.registrations,
+    }),
   };
 }
 
 // TODO(#24184): Switch active readers only after the canonical row is observed.
 export function connectorCatalogExecutableCapabilityState(): ExecutableCapabilityState {
-  return connectorCatalogExecutableCapabilityStates().legacy;
+  const facts = connectorCatalogExecutableCapabilityFacts();
+  return createExecutableCapabilityState({
+    facts,
+    evaluatorVersion: LEGACY_EXECUTABLE_CAPABILITY_EVALUATOR_VERSION,
+    digestRegistrations: facts.registrations.map(legacyRegistrationCapability),
+  });
 }
 
 export function connectorCatalogExecutableCapabilityDigest(): string {

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -1,4 +1,3 @@
-import { connectorCatalogFilteredAuthMethodsSchema } from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { ConnectorSearchItem } from "@vm0/api-contracts/contracts/zero-connectors";
@@ -40,7 +39,10 @@ import {
 } from "./connector-catalog-artifacts/loader";
 import { connectorCatalogIconUrl } from "./connector-catalog-artifacts/icon";
 import { deriveConnectorCatalogFirewallPermissions } from "./connector-catalog-artifacts/relationships";
-import { connectorCatalogExecutableCapabilityDigest } from "./connector-catalog-compatibility.service";
+import {
+  connectorCatalogExecutableCapabilityDigest,
+  legacyConnectorCatalogCompatibilityEvaluationSchema,
+} from "./connector-catalog-compatibility.service";
 import type { ConnectorFeatureStates } from "./connector-catalog-feature-states";
 import type { ConnectorCatalogLoadTiming } from "./connector-catalog-load-timing.service";
 import { connectorCatalogSource } from "./connector-catalog-source";
@@ -387,9 +389,10 @@ async function readCurrentCatalog(args: {
     args.timing,
     "api_dispatch_connector_catalog_validate_compatibility",
     () => {
-      const parsed = connectorCatalogFilteredAuthMethodsSchema.safeParse(
-        row.filteredAuthMethods,
-      );
+      const parsed =
+        legacyConnectorCatalogCompatibilityEvaluationSchema.safeParse(
+          row.filteredAuthMethods,
+        );
       if (!parsed.success) {
         log.error(
           "Rejected persisted connector catalog compatibility evaluation",

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -84,7 +84,7 @@ const providerRegistrations = singleton(() => {
   return new Map(
     getConnectorAuthProviderRegistrationCapabilities().map((registration) => {
       return [
-        methodKey(registration.connectorRef, registration.authMethodId),
+        methodKey(registration.connectorSlug, registration.authMethodId),
         registration,
       ];
     }),

--- a/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
@@ -35,9 +35,9 @@ import {
   type ValidatedConnectorCatalogCandidate,
 } from "./connector-catalog-artifacts/loader";
 import {
-  connectorCatalogExecutableCapabilityState,
+  connectorCatalogExecutableCapabilityStates,
   persistConnectorCatalogCompatibility,
-  type ExecutableCapabilityState,
+  type ExecutableCapabilityStates,
 } from "./connector-catalog-compatibility.service";
 import {
   connectorCatalogRejectionIsReusable,
@@ -640,7 +640,7 @@ async function commitCandidate(args: {
   readonly skillRegistrations: readonly PreparedConnectorSkillRegistration[];
   readonly pointerObservation: PointerObservation;
   readonly attemptedAt: Date;
-  readonly capability: ExecutableCapabilityState;
+  readonly capabilities: ExecutableCapabilityStates;
   readonly validator: ConnectorCatalogValidatorIdentity;
   readonly signal: AbortSignal;
 }): Promise<CandidateCommitResult> {
@@ -657,7 +657,7 @@ async function commitCandidate(args: {
         sourceId: args.sourceId,
         identity: args.candidate.identity,
         artifact: args.candidate.artifact,
-        capability: args.capability,
+        capabilities: args.capabilities,
         validator: args.validator,
       });
       return "accepted" as const;
@@ -727,7 +727,7 @@ async function rejectCandidate(args: {
 }
 
 interface ConnectorCatalogSyncRuntime {
-  readonly capability: ExecutableCapabilityState;
+  readonly capabilities: ExecutableCapabilityStates;
   readonly db: Db;
   readonly reader: ConnectorCatalogArtifactReader;
   readonly readActivePointer: (
@@ -907,7 +907,7 @@ async function commitValidatedCandidate(
     baseline,
     candidate,
     catalogGzip,
-    capability: runtime.capability,
+    capabilities: runtime.capabilities,
     validator: runtime.validator,
     skillRegistrations,
     pointerObservation,
@@ -1082,7 +1082,7 @@ export const syncConnectorCatalog$ = command(
   ): Promise<ConnectorCatalogRawSyncResponse> => {
     const source = connectorCatalogSource();
     const runtime: ConnectorCatalogSyncRuntime = {
-      capability: connectorCatalogExecutableCapabilityState(),
+      capabilities: connectorCatalogExecutableCapabilityStates(),
       db: set(writeDb$),
       source,
       signal,

--- a/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
@@ -56,7 +56,7 @@ function providerCapability(
   const capability = getConnectorAuthProviderRegistrationCapabilities().find(
     (candidate) => {
       return (
-        candidate.connectorRef === connectorSlug &&
+        candidate.connectorSlug === connectorSlug &&
         candidate.authMethodId === authMethodId
       );
     },

--- a/turbo/apps/api/src/test-fixtures/connector-catalog.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog.ts
@@ -2,12 +2,13 @@ import { createHash } from "node:crypto";
 
 import { createStore } from "ccstate";
 import { getConnectorAuthProviderRegistrationCapabilities } from "@vm0/connectors/auth-providers";
+import type { ConnectorCatalogCompatibilityEvaluationPayload } from "@vm0/db/jsonb-contracts/connector-catalog";
 import {
   connectorCatalogActiveSnapshot,
   connectorCatalogCompatibilityEvaluation,
   connectorCatalogSyncState,
 } from "@vm0/db/schema/connector-catalog";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 
 import { mockOptionalEnv } from "../lib/env";
 import { writeDb$ } from "../signals/external/db";
@@ -23,6 +24,7 @@ import {
 } from "../signals/services/connector-catalog-artifacts/relationships";
 import {
   connectorCatalogExecutableCapabilityState,
+  connectorCatalogExecutableCapabilityStates,
   persistConnectorCatalogCompatibility,
 } from "../signals/services/connector-catalog-compatibility.service";
 import { connectorCatalogSource } from "../signals/services/connector-catalog-source";
@@ -90,7 +92,7 @@ export async function installApiTestConnectorCatalog(
   const catalogDigest = sha256Digest(rawBytes);
   const catalogGzip = encodeConnectorCatalogSnapshot(rawBytes);
   const source = connectorCatalogSource();
-  const capability = connectorCatalogExecutableCapabilityState();
+  const capabilities = connectorCatalogExecutableCapabilityStates();
   const activatedAt = nowDate();
   const db = store.set(writeDb$);
   const syncStateValues = {
@@ -158,7 +160,7 @@ export async function installApiTestConnectorCatalog(
         catalogDigest,
       },
       artifact: catalog,
-      capability,
+      capabilities,
       validator: currentConnectorCatalogValidatorIdentity(),
     });
   });
@@ -238,6 +240,65 @@ export function apiTestConnectorCatalogValidationAuthority(): ConnectorCatalogVa
     backendVersion: validator.backendVersion,
     buildCommitSha: validator.buildCommitSha,
   };
+}
+
+interface ApiTestConnectorCatalogCompatibilityEvaluation {
+  readonly catalogVersion: string;
+  readonly catalogDigest: string;
+  readonly capabilityDigest: string;
+  readonly validationAuthority: ConnectorCatalogValidationAuthority | null;
+  readonly evaluatedAt: string;
+  readonly payload: ConnectorCatalogCompatibilityEvaluationPayload;
+}
+
+export async function readApiTestConnectorCatalogCompatibilityEvaluations(): Promise<
+  readonly ApiTestConnectorCatalogCompatibilityEvaluation[]
+> {
+  const sourceId = connectorCatalogSource().sourceId;
+  const db = store.set(writeDb$);
+  const rows = await db
+    .select({
+      catalogVersion: connectorCatalogCompatibilityEvaluation.catalogVersion,
+      catalogDigest: connectorCatalogCompatibilityEvaluation.catalogDigest,
+      capabilityDigest:
+        connectorCatalogCompatibilityEvaluation.executableCapabilityDigest,
+      catalogValidationBackendVersion:
+        connectorCatalogCompatibilityEvaluation.catalogValidationBackendVersion,
+      catalogValidationBuildCommitSha:
+        connectorCatalogCompatibilityEvaluation.catalogValidationBuildCommitSha,
+      evaluatedAt: connectorCatalogCompatibilityEvaluation.evaluatedAt,
+      payload: connectorCatalogCompatibilityEvaluation.filteredAuthMethods,
+    })
+    .from(connectorCatalogCompatibilityEvaluation)
+    .where(
+      and(
+        eq(connectorCatalogCompatibilityEvaluation.sourceId, sourceId),
+        eq(
+          connectorCatalogCompatibilityEvaluation.schemaVersion,
+          SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+        ),
+      ),
+    )
+    .orderBy(
+      asc(connectorCatalogCompatibilityEvaluation.catalogDigest),
+      asc(connectorCatalogCompatibilityEvaluation.executableCapabilityDigest),
+    );
+  return rows.map((row) => {
+    return {
+      catalogVersion: row.catalogVersion,
+      catalogDigest: row.catalogDigest,
+      capabilityDigest: row.capabilityDigest,
+      validationAuthority:
+        row.catalogValidationBackendVersion === null
+          ? null
+          : {
+              backendVersion: row.catalogValidationBackendVersion,
+              buildCommitSha: row.catalogValidationBuildCommitSha,
+            },
+      evaluatedAt: row.evaluatedAt.toISOString(),
+      payload: row.payload,
+    };
+  });
 }
 
 export async function readApiTestConnectorCatalogValidationAuthority(): Promise<ConnectorCatalogValidationAuthority | null> {
@@ -366,4 +427,21 @@ export async function deleteApiTestConnectorCatalogCompatibility(): Promise<void
     .where(currentApiTestConnectorCatalogCompatibilityWhere(identity))
     .returning({ sourceId: connectorCatalogCompatibilityEvaluation.sourceId });
   requireSingleCatalogMutation(deleted, "compatibility deletion");
+}
+
+export async function deleteApiTestConnectorCatalogCompatibilityEvaluation(
+  capabilityDigest: string,
+): Promise<void> {
+  const identity = await currentApiTestConnectorCatalogIdentity();
+  const db = store.set(writeDb$);
+  const deleted = await db
+    .delete(connectorCatalogCompatibilityEvaluation)
+    .where(
+      currentApiTestConnectorCatalogCompatibilityWhere({
+        ...identity,
+        capabilityDigest,
+      }),
+    )
+    .returning({ sourceId: connectorCatalogCompatibilityEvaluation.sourceId });
+  requireSingleCatalogMutation(deleted, "compatibility evaluation deletion");
 }

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -354,6 +354,7 @@ export const apiConnectorsHandlers = [
         stale: false,
         filteredAuthMethods: [
           {
+            connectorSlug: "github",
             connectorRef: "github",
             authMethodId: "oauth",
             reasons: ["missing-revoke-provider"],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
@@ -1095,6 +1095,52 @@ describe("settings dialog", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders connector catalog diagnostics from a ref-only API", async () => {
+    context.mocks.api(
+      zeroConnectorCatalogContract.diagnostics,
+      ({ respond }) => {
+        return respond(200, {
+          state: "current",
+          active: {
+            catalogVersion: "2026-07-25.1",
+            catalogDigest: `sha256:${"a".repeat(64)}`,
+            activatedAt: "2026-07-25T01:00:00.000Z",
+          },
+          lastAttempt: null,
+          lastSuccessAt: "2026-07-25T01:00:00.000Z",
+          rejectedCandidate: null,
+          filtering: {
+            capabilityDigest: `sha256:${"b".repeat(64)}`,
+            evaluatedAt: "2026-07-25T01:00:00.000Z",
+            stale: false,
+            filteredAuthMethods: [
+              {
+                connectorRef: "legacy-github",
+                authMethodId: "oauth",
+                reasons: ["missing-revoke-provider"],
+              },
+            ],
+          },
+          credentialStorage: {
+            missingConnectorVersions: 0,
+            unownedConnectorSecrets: 0,
+            unownedConnectorVariables: 0,
+            unresolvedBridgeCredentials: 0,
+          },
+        });
+      },
+    );
+
+    await openDialog("admin", "debug");
+
+    const diagnostics = await screen.findByRole("region", {
+      name: "Connector catalog",
+    });
+    expect(
+      within(diagnostics).getByText("legacy-github / oauth"),
+    ).toBeInTheDocument();
+  });
+
   it("does not describe an uncached rejection as a fresh evaluation", async () => {
     context.mocks.api(
       zeroConnectorCatalogContract.diagnostics,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx
@@ -421,13 +421,15 @@ function DiagnosticsContent({
           ) : (
             <div className="flex min-w-0 flex-col gap-2">
               {filteredAuthMethods.map((method) => {
+                const connectorSlug =
+                  method.connectorSlug ?? method.connectorRef;
                 return (
                   <div
-                    key={`${method.connectorRef}:${method.authMethodId}`}
+                    key={`${connectorSlug}:${method.authMethodId}`}
                     className="min-w-0 rounded-lg bg-muted/40 px-3 py-2"
                   >
                     <code className="block break-all text-xs font-medium text-foreground">
-                      {method.connectorRef} / {method.authMethodId}
+                      {connectorSlug} / {method.authMethodId}
                     </code>
                     <div className="mt-1 text-xs text-muted-foreground">
                       {method.reasons.map(formatEnumValue).join(", ")}

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-catalog-diagnostics.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-catalog-diagnostics.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { connectorCatalogFilteredAuthMethodSchema } from "../connector-catalog-diagnostics";
+
+describe("connector catalog diagnostics contract", () => {
+  it("supports the ref-to-slug receiver transition without divergent identities", () => {
+    const method = {
+      authMethodId: "oauth",
+      reasons: ["missing-revoke-provider"],
+    };
+
+    expect(
+      connectorCatalogFilteredAuthMethodSchema.safeParse({
+        ...method,
+        connectorRef: "github",
+      }).success,
+    ).toBeTruthy();
+    expect(
+      connectorCatalogFilteredAuthMethodSchema.safeParse({
+        ...method,
+        connectorSlug: "github",
+        connectorRef: "github",
+      }).success,
+    ).toBeTruthy();
+    expect(
+      connectorCatalogFilteredAuthMethodSchema.safeParse({
+        ...method,
+        connectorSlug: "gitlab",
+        connectorRef: "github",
+      }).success,
+    ).toBeFalsy();
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/connector-catalog-diagnostics.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-catalog-diagnostics.ts
@@ -27,12 +27,23 @@ export const connectorCatalogCompatibilityReasonSchema = z.enum([
   "missing-platform-configuration",
 ]);
 
-export const connectorCatalogFilteredAuthMethodSchema = z.object({
-  // TODO(#23619): Rename this diagnostics wire field after clients migrate.
-  connectorRef: connectorSlugSchema,
-  authMethodId: connectorAuthMethodIdSchema,
-  reasons: z.array(connectorCatalogCompatibilityReasonSchema).min(1),
-});
+export const connectorCatalogFilteredAuthMethodSchema = z
+  .object({
+    connectorSlug: connectorSlugSchema.optional(),
+    // TODO(#24186): Remove after the prepared Platform receiver is required.
+    connectorRef: connectorSlugSchema,
+    authMethodId: connectorAuthMethodIdSchema,
+    reasons: z.array(connectorCatalogCompatibilityReasonSchema).min(1),
+  })
+  .refine(
+    ({ connectorSlug, connectorRef }) => {
+      return connectorSlug === undefined || connectorSlug === connectorRef;
+    },
+    {
+      message: "connectorSlug and connectorRef must match",
+      path: ["connectorSlug"],
+    },
+  );
 
 export const connectorCatalogFilteredAuthMethodsSchema = z.array(
   connectorCatalogFilteredAuthMethodSchema,

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -238,11 +238,7 @@ export const CONNECTOR_GENERIC_AUTH_CAPABILITY_VERSIONS = {
 } as const;
 
 export interface ConnectorAuthProviderRegistrationCapability {
-  /**
-   * TODO(#23619): Rename only when the persisted capability digest identity
-   * migrates; this property is part of the deterministic digest preimage.
-   */
-  readonly connectorRef: string;
+  readonly connectorSlug: string;
   readonly authMethodId: string;
   readonly handlers: ConnectorAuthProviderRegistryCapability;
   readonly contract: ConnectorAuthProviderMethodContract;
@@ -377,7 +373,7 @@ function connectorAuthProviderRegistrationCapability(
   contract: ConnectorAuthProviderMethodContract,
 ): ConnectorAuthProviderRegistrationCapability {
   return {
-    connectorRef: registration.connectorSlug,
+    connectorSlug: registration.connectorSlug,
     authMethodId: registration.authMethodId,
     handlers: connectorAuthProviderRegistryCapability(registration.entry),
     contract,
@@ -1098,7 +1094,7 @@ export function getConnectorAuthProviderRegistrationCapabilities(): readonly Con
     );
   }).sort((left, right) => {
     return (
-      compareCapabilityStrings(left.connectorRef, right.connectorRef) ||
+      compareCapabilityStrings(left.connectorSlug, right.connectorSlug) ||
       compareCapabilityStrings(left.authMethodId, right.authMethodId)
     );
   });

--- a/turbo/packages/db/src/jsonb-contracts/connector-catalog.ts
+++ b/turbo/packages/db/src/jsonb-contracts/connector-catalog.ts
@@ -1,4 +1,29 @@
-import type { ConnectorCatalogFilteredAuthMethod } from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
+import type {
+  ConnectorAuthMethodId,
+  ConnectorSlug,
+} from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorCatalogCompatibilityReason } from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
 
-export type ConnectorCatalogFilteredAuthMethods =
-  ConnectorCatalogFilteredAuthMethod[];
+export interface LegacyConnectorCatalogFilteredAuthMethod {
+  readonly connectorRef: ConnectorSlug;
+  readonly authMethodId: ConnectorAuthMethodId;
+  readonly reasons: readonly ConnectorCatalogCompatibilityReason[];
+}
+
+export type LegacyConnectorCatalogCompatibilityEvaluation =
+  readonly LegacyConnectorCatalogFilteredAuthMethod[];
+
+export interface CanonicalConnectorCatalogFilteredAuthMethod {
+  readonly connectorSlug: ConnectorSlug;
+  readonly authMethodId: ConnectorAuthMethodId;
+  readonly reasons: readonly ConnectorCatalogCompatibilityReason[];
+}
+
+export interface CanonicalConnectorCatalogCompatibilityEvaluation {
+  readonly filteredAuthMethods: readonly CanonicalConnectorCatalogFilteredAuthMethod[];
+}
+
+// TODO(#24186): Remove the legacy array after canonical readers have drained it.
+export type ConnectorCatalogCompatibilityEvaluationPayload =
+  | LegacyConnectorCatalogCompatibilityEvaluation
+  | CanonicalConnectorCatalogCompatibilityEvaluation;

--- a/turbo/packages/db/src/schema/connector-catalog.ts
+++ b/turbo/packages/db/src/schema/connector-catalog.ts
@@ -12,7 +12,7 @@ import {
   timestamp,
   varchar,
 } from "drizzle-orm/pg-core";
-import type { ConnectorCatalogFilteredAuthMethods } from "@vm0/db/jsonb-contracts/connector-catalog";
+import type { ConnectorCatalogCompatibilityEvaluationPayload } from "@vm0/db/jsonb-contracts/connector-catalog";
 
 export const CONNECTOR_CATALOG_ATTEMPT_OUTCOMES = [
   "accepted",
@@ -260,7 +260,7 @@ export const connectorCatalogCompatibilityEvaluation = pgTable(
     ),
     evaluatedAt: timestamp("evaluated_at").notNull(),
     filteredAuthMethods: jsonb("filtered_auth_methods")
-      .$type<ConnectorCatalogFilteredAuthMethods>()
+      .$type<ConnectorCatalogCompatibilityEvaluationPayload>()
       .notNull(),
   },
   (table) => {


### PR DESCRIPTION
## Summary

- rename the canonical connector provider capability identity from `connectorRef` to `connectorSlug`
- freeze the exact evaluator-v1 legacy digest projection and generate an evaluator-v2 canonical digest from the same registration and configuration snapshot
- evaluate compatibility once and atomically persist both the legacy root-array payload and canonical root-object payload
- keep all active catalog readers on the legacy digest while preparing diagnostics for old/new API and Platform overlap
- preserve validation-authority downgrade protection, same-catalog alternate digests, and catalog-replacement cleanup for both rows

## Compatibility

- the existing singular capability selector and accepted catalog readers remain legacy
- the new API emits `connectorSlug` with a temporary matching `connectorRef` alias
- the new Platform prefers `connectorSlug` and falls back to a ref-only response from an older API
- rollback remains cache-warm because the legacy row is still written and read

## Exclusions

- no SQL schema change or database migration
- no `compatibility_format_version`
- no active reader or permission-baseline cutover
- no legacy row, diagnostics alias, or Platform fallback removal

## Validation

- `pnpm format`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors test`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- production runtime API schema compatibility check
- `pnpm -F @vm0/api-contracts test`
- `pnpm -F @vm0/db lint`
- `pnpm -F @vm0/db check-types`
- `pnpm -F @vm0/db test`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts` (107 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-catalog.test.ts` (29 tests)
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/settings-dialog.test.tsx` (32 tests)
- `pnpm knip`
- repository pre-commit hook, including full Turbo type checking

Closes #24183

Parent context: #23775

Follow-up reader cutover: #24184

Follow-up cleanup: #24186
