### PR TITLE
test(api): drain terminal work before deleting run provenance

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -3742,6 +3742,8 @@ describe("CHAT-02: run-level model overrides", () => {
     );
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(second.runId, secondClaim.sandboxHeaders);
+    // Settle terminal materialization before simulating later retention.
+    await flushWaitUntilForTest();
     const originalBinding = await readThreadSessionBinding(
       context,
       first.threadId,


### PR DESCRIPTION
## Summary

- settle the completion webhook's tracked terminal side effects before the provenance-deletion BDD journey removes the completed run
- preserve the real `agent_runs` deletion and `chat_threads.agent_session_run_id` `ON DELETE SET NULL` behavior
- surface detached callback failures instead of allowing the test to pass after PostgreSQL selects the callback as the deadlock victim

## Root cause

The completion response intentionally precedes its `waitUntil` terminal work. The test immediately deleted the same run through a direct retention fixture, allowing the callback's `chat_threads` update and the delete's foreign-key action to acquire the thread and run locks in a cycle.

Before the change, a local targeted run reproduced `40P01` immediately. PostgreSQL aborted the callback transaction, so Vitest appeared green while terminal materialization was lost. CI had observed the complementary victim choice, where PostgreSQL aborted the fixture delete and failed the test.

## Scope

This changes only the test journey. It does not change production completion semantics, database locking, retry policy, timeouts, schema, the deletion fixture, or session-rotation assertions.

## Verification

- targeted journey passed 5 consecutive serial runs with no `40P01` or callback error
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts --reporter=dot` — 61 passed
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `git diff --check`
- pre-commit hooks: Prettier, full-workspace Knip, full-workspace type checks, and file-size validation

Closes #24236
