### PR TITLE
test(ci): make systemd reload assertion unit-scoped

### DIFF
--- a/.github/scripts/runner-behavior-systemd-reload.sh
+++ b/.github/scripts/runner-behavior-systemd-reload.sh
@@ -128,8 +128,8 @@ for UNIT in "$UNIT_A" "$UNIT_B"; do
     || fail "$UNIT file remained after uninstall"
   [ ! -e "/run/systemd/system/${UNIT}.d/50-vm0-drain.conf" ] \
     || fail "$UNIT drain override remained after uninstall"
-  [ "$(sudo systemctl show "$UNIT" --property=NeedDaemonReload --value)" = "no" ] \
-    || fail "systemd remained dirty after uninstalling $UNIT"
+  [ "$(sudo systemctl show "$UNIT" --property=LoadState --value)" = "not-found" ] \
+    || fail "$UNIT remained loaded after uninstall"
 done
 
 SESSION_SCOPE="unit session-${XDG_SESSION_ID}.scope"


### PR DESCRIPTION
## Summary

- replace the post-uninstall manager-global `NeedDaemonReload` assertion with the unit-scoped `LoadState=not-found` postcondition
- preserve concurrent lifecycle coverage, filesystem checks, and the session-scoped systemd reload budget
- avoid retries, timeout changes, workflow serialization, and production runner changes

## Validation

- `bash -n .github/scripts/runner-behavior-systemd-reload.sh`
- `shellcheck .github/scripts/runner-behavior-systemd-reload.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh .github/workflows/crates.yml`
- `git diff --check`

Closes #24241
