### PR TITLE
test(mitm-addon): reduce webhook server shutdown latency

### DIFF
--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -245,8 +245,13 @@ class UsageWebhookServer:
                 return None
 
         self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        server = self._server
+
+        def serve_forever() -> None:
+            server.serve_forever(poll_interval=0.01)
+
         self._thread = threading.Thread(
-            target=self._server.serve_forever,
+            target=serve_forever,
             name="usage-webhook-test-server",
             daemon=True,
         )


### PR DESCRIPTION
## Summary

- run the usage webhook test server with a 10 ms shutdown poll interval instead of the 500 ms default
- align the helper with the existing fake auth endpoint server
- reduce the full mitm-addon test suite from 224.43 seconds to 20.69 seconds locally while retaining all 4,493 tests

## Scope

This changes only the test HTTP server shutdown responsiveness. It does not change production code, test selection, assertions, or coverage.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/ -q --durations=20`
- `git diff --check`
