### PR TITLE
docs(rust): correct run and sandbox identity contract

### DIFF
--- a/crates/runner/src/ids.rs
+++ b/crates/runner/src/ids.rs
@@ -1,4 +1,7 @@
-//! Newtype wrapper for the per-job identifier that the runner assigns.
+//! Newtype wrapper for the per-job identifier used by the runner.
+//!
+//! Normal API jobs receive their `RunId` from the control plane, while
+//! `runner local submit` allocates one locally.
 //!
 //! `RunId` is the server/API-facing job handle — visible on dashboards,
 //! used in claim/complete/cancel. It is distinct from [`sandbox::SandboxId`]
@@ -15,17 +18,20 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-/// Per-job identifier assigned by the server (or `runner local submit`).
+/// Per-job identifier supplied by the server or allocated by `runner local submit`.
 /// This is what the user sees on dashboards and what API claim/complete use.
 ///
-/// Distinct from [`sandbox::SandboxId`] — the two are equal on the first
-/// run but diverge on sandbox reuse, when the FC keeps its original
-/// `SandboxId` while each successive job gets a fresh `RunId`.
+/// A fresh sandbox receives an independently allocated [`sandbox::SandboxId`].
+/// On reuse, the sandbox keeps its existing `SandboxId` while the new job has
+/// its own `RunId`. The two identifiers are not interchangeable.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct RunId(Uuid);
 
 impl RunId {
+    /// Allocate a random v4 identifier for runner-local use.
+    ///
+    /// Normal API jobs receive their `RunId` from the control plane instead.
     pub fn new_v4() -> Self {
         Self(Uuid::new_v4())
     }

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -5,12 +5,13 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 /// Identity of a Firecracker VM sandbox — the workspace directory basename
-/// and socket directory name. Survives sandbox reuse: the first job creates
-/// the sandbox with this ID, and subsequent reuse jobs inherit it.
+/// and socket directory name. A newly created sandbox receives this ID, and
+/// subsequent reuse jobs retain it.
 ///
 /// Distinct from `RunId` (a per-job server identifier defined in the
-/// `runner` crate). The two are equal on the first run but diverge on
-/// sandbox reuse.
+/// `runner` crate). A new sandbox receives its ID independently of the current
+/// job's `RunId`. A reused sandbox keeps its existing `SandboxId` while the
+/// new job has its own `RunId`; the two identifiers are not interchangeable.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct SandboxId(uuid::Uuid);


### PR DESCRIPTION
## Summary

- correct `RunId` documentation to distinguish control-plane and local allocation
- document independent fresh `SandboxId` allocation and stable identity across sandbox reuse
- add Rustdoc for runner-local `RunId::new_v4` allocation

## Scope

Documentation only. This does not change runtime allocation, wire formats, status schemas, persisted state, or command behavior.

## Validation

- `cargo fmt --check`
- `cargo doc -p sandbox -p runner --all-features --no-deps`
- `git diff --check`
- pre-commit `cargo-doc`
- pre-commit `cargo-clippy`

Closes #24234
