### PR TITLE
refactor(runner): separate lifecycle state from signal handling

### DIFF
--- a/crates/runner/src/cmd/service/gate.rs
+++ b/crates/runner/src/cmd/service/gate.rs
@@ -24,7 +24,7 @@ pub(super) fn runner_base_dir(unit: &RunnerServiceUnit) -> Option<PathBuf> {
 /// Parsed snapshot of the runner's status.json.
 pub(super) struct RunnerStatusSnapshot {
     /// Mode string sourced verbatim from status.json. Valid values are the
-    /// lowercase serialization of [`crate::status::RunnerMode`]: `"starting"`,
+    /// lowercase serialization of [`crate::lifecycle::RunnerMode`]: `"starting"`,
     /// `"running"`, `"draining"`, `"stopping"`, `"stopped"`. Unknown values
     /// (e.g. from a newer runner writing a future variant) are preserved and
     /// routed to the normal refuse branch by [`decide_gate`].
@@ -90,7 +90,7 @@ enum GateDecision {
 /// 3. Otherwise refuse; `draining=true` when `mode == "draining"` so the
 ///    error message suggests waiting rather than re-running `drain`.
 ///
-/// Mode strings mirror [`crate::status::RunnerMode`] (serde lowercase).
+/// Mode strings mirror [`crate::lifecycle::RunnerMode`] (serde lowercase).
 fn decide_gate(status: &RunnerStatusSnapshot) -> GateDecision {
     if matches!(status.mode.as_str(), "stopped" | "stopping") {
         return GateDecision::Bypass;

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -9,9 +9,9 @@ use super::active_sessions::{ActiveCliAgentSessions, active_cli_agent_session_id
 use crate::config::ProfileConfig;
 use crate::error::{RunnerError, RunnerResult};
 use crate::idle_pool::IdlePool;
+use crate::lifecycle::RunnerMode;
 use crate::provider::JobProvider;
 use crate::resource_budget::ResourceBudget;
-use crate::status::RunnerMode;
 use crate::types::{
     HeartbeatState, HeldSessionState, MAX_HELD_SESSION_STATES, MAX_WORKSPACE_CACHES_PER_SESSION,
 };

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -31,11 +31,12 @@ use crate::idle_pool::{
     RestoreReservedIdleResult, ReusableIdleSandbox,
 };
 use crate::ids::RunId;
+use crate::lifecycle::RunnerMode;
 use crate::paths::short_digest;
 use crate::provider::{ClaimedJob, JobCandidate};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::run_cancellation::{RunCancellationRegistration, RunCancellationRegistry};
-use crate::status::{RunnerMode, StatusTracker};
+use crate::status::StatusTracker;
 use crate::types::{
     ExecutionContext, HeldSessionState, SandboxReuseResult, SessionAffinityResource,
     WORKSPACE_AFFINITY_VERSION,

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -18,7 +18,7 @@
 //! - `orphan_reap`: orphan active-run reconciliation.
 //! - `ownership`: active/idle/orphan ownership transition ordering.
 //! - `sandbox_finalization`: post-executor sandbox park/destroy finalization.
-//! - `signals`: lifecycle signal registration and mode transitions.
+//! - `signals`: lifecycle signal registration, task ownership, and dispatch.
 //!
 //! Important invariants:
 //! - one process owns the canonical `base_dir` lock;
@@ -57,6 +57,7 @@ use crate::host;
 use crate::http::{HttpClient, HttpClientConfig};
 use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkingGate};
 use crate::kmsg_log;
+use crate::lifecycle::RunnerMode;
 use crate::lock;
 use crate::network_log_drain::{DrainableLineReaderExit, NetworkLogDrainCoordinator};
 use crate::network_log_manager::NetworkLogManager;
@@ -70,7 +71,7 @@ use crate::proxy;
 use crate::resource_budget::ResourceBudget;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::run_cancellation::{RunCancellationRegistration, RunCancellationRegistry};
-use crate::status::{RunnerMode, StatusTracker, remove_stale_status_file};
+use crate::status::{StatusTracker, remove_stale_status_file};
 use crate::workspace_image_cache::SessionWorkspaceCache;
 
 mod active_sessions;

--- a/crates/runner/src/cmd/start/signals.rs
+++ b/crates/runner/src/cmd/start/signals.rs
@@ -1,14 +1,9 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-};
-
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::idle_pool::ParkingGate;
+use crate::lifecycle::{LifecycleController, RunnerMode, SoftDrainOutcome};
 use crate::run_cancellation::RunCancellationRegistry;
-use crate::status::RunnerMode;
 
 /// Pre-registered signal streams.
 ///
@@ -54,145 +49,6 @@ impl EarlySignals {
             sigusr1,
             sigusr2,
         })
-    }
-}
-
-/// Ordered lifecycle transition handle shared between signal handlers, tests,
-/// and the main run loop's internal Draining -> Stopping transition.
-///
-/// Parking state is updated before publishing the externally visible mode so a
-/// task that observes `Running` can also rely on parking already being open.
-#[derive(Clone)]
-pub(crate) struct LifecycleController {
-    mode_tx: tokio::sync::watch::Sender<RunnerMode>,
-    parking_gate: ParkingGate,
-    startup_ready: Arc<AtomicBool>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DrainSignalOutcome {
-    EnteredDraining,
-    AlreadyDraining,
-    Ignored(RunnerMode),
-}
-
-impl LifecycleController {
-    pub(crate) fn new(
-        mode_tx: tokio::sync::watch::Sender<RunnerMode>,
-        parking_gate: ParkingGate,
-    ) -> Self {
-        let startup_ready = *mode_tx.borrow() != RunnerMode::Starting;
-        Self {
-            mode_tx,
-            parking_gate,
-            startup_ready: Arc::new(AtomicBool::new(startup_ready)),
-        }
-    }
-
-    pub(crate) fn current_mode(&self) -> RunnerMode {
-        *self.mode_tx.borrow()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn mode_tx(&self) -> &tokio::sync::watch::Sender<RunnerMode> {
-        &self.mode_tx
-    }
-
-    fn enter_soft_drain(&self) -> DrainSignalOutcome {
-        let gate = self.parking_gate.clone();
-        let mut outcome = DrainSignalOutcome::Ignored(self.current_mode());
-        let _ = self.mode_tx.send_if_modified(|mode| match *mode {
-            RunnerMode::Starting | RunnerMode::Running => {
-                let original_mode = *mode;
-                if gate.soft_drain() {
-                    *mode = RunnerMode::Draining;
-                    outcome = DrainSignalOutcome::EnteredDraining;
-                    true
-                } else {
-                    outcome = DrainSignalOutcome::Ignored(original_mode);
-                    false
-                }
-            }
-            RunnerMode::Draining => {
-                outcome = DrainSignalOutcome::AlreadyDraining;
-                false
-            }
-            mode => {
-                outcome = DrainSignalOutcome::Ignored(mode);
-                false
-            }
-        });
-        outcome
-    }
-
-    pub(crate) fn resume_from_soft_drain(&self) -> bool {
-        if !self.startup_ready.load(Ordering::SeqCst) {
-            return false;
-        }
-        let gate = self.parking_gate.clone();
-        let mut transitioned = false;
-        let _ = self.mode_tx.send_if_modified(|mode| {
-            if *mode == RunnerMode::Draining && gate.open_after_soft_drain() {
-                *mode = RunnerMode::Running;
-                transitioned = true;
-                true
-            } else {
-                false
-            }
-        });
-        transitioned
-    }
-
-    pub(crate) fn mark_startup_ready(&self) -> RunnerMode {
-        self.startup_ready.store(true, Ordering::SeqCst);
-        let mut current = self.current_mode();
-        let _ = self.mode_tx.send_if_modified(|mode| {
-            current = *mode;
-            if *mode == RunnerMode::Starting {
-                *mode = RunnerMode::Running;
-                current = RunnerMode::Running;
-                true
-            } else {
-                false
-            }
-        });
-        current
-    }
-
-    pub(crate) fn hard_stop(&self) -> bool {
-        let gate = self.parking_gate.clone();
-        let mut transitioned = false;
-        let _ = self.mode_tx.send_if_modified(|mode| {
-            if *mode != RunnerMode::Stopping {
-                gate.close();
-                *mode = RunnerMode::Stopping;
-                transitioned = true;
-                true
-            } else {
-                false
-            }
-        });
-        transitioned
-    }
-
-    pub(crate) fn stop_after_natural_drain(&self) -> bool {
-        let gate = self.parking_gate.clone();
-        let mut transitioned = false;
-        let _ = self.mode_tx.send_if_modified(|mode| {
-            if *mode == RunnerMode::Draining {
-                gate.close();
-                *mode = RunnerMode::Stopping;
-                transitioned = true;
-                true
-            } else {
-                false
-            }
-        });
-        transitioned
-    }
-
-    pub(crate) fn close_parking(&self) {
-        self.parking_gate.close();
     }
 }
 
@@ -333,13 +189,13 @@ pub(super) async fn recv_handler_task(
 
 pub(super) fn handle_drain_signal(lifecycle: &LifecycleController) {
     match lifecycle.enter_soft_drain() {
-        DrainSignalOutcome::EnteredDraining => {
+        SoftDrainOutcome::EnteredDraining => {
             info!("received SIGUSR1, entering Draining (soft drain)");
         }
-        DrainSignalOutcome::AlreadyDraining => {
+        SoftDrainOutcome::AlreadyDraining => {
             info!("received SIGUSR1 while already Draining");
         }
-        DrainSignalOutcome::Ignored(mode) => {
+        SoftDrainOutcome::Ignored(mode) => {
             warn!(mode = ?mode, "SIGUSR1 ignored — soft drain is no longer actionable");
         }
     }
@@ -492,141 +348,6 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), dropped.notified())
             .await
             .expect("dropping signal handler task should abort the task");
-    }
-
-    /// `enter_soft_drain` state guard: SIGUSR1 transitions from Starting or
-    /// Running; repeated SIGUSR1 in Draining is an idempotent no-op, while
-    /// teardown modes stay ignored.
-    #[test]
-    fn drain_signal_state_guards() {
-        use crate::idle_pool::ParkingState;
-
-        // Starting -> Draining (startup drain intent must not be lost).
-        let gate = ParkingGate::new_open();
-        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Starting);
-        let lifecycle = LifecycleController::new(tx, gate.clone());
-        assert_eq!(
-            lifecycle.enter_soft_drain(),
-            DrainSignalOutcome::EnteredDraining
-        );
-        assert_eq!(lifecycle.current_mode(), RunnerMode::Draining);
-        assert_eq!(gate.state(), ParkingState::SoftDraining);
-
-        // Running → Draining (sanity: the steady-state legal transition).
-        let gate = ParkingGate::new_open();
-        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Running);
-        let lifecycle = LifecycleController::new(tx, gate.clone());
-        assert_eq!(
-            lifecycle.enter_soft_drain(),
-            DrainSignalOutcome::EnteredDraining
-        );
-        assert_eq!(lifecycle.current_mode(), RunnerMode::Draining);
-        assert_eq!(gate.state(), ParkingState::SoftDraining);
-
-        // Draining → idempotent no-op (no warning-worthy self-transition).
-        let gate = ParkingGate::new_open();
-        gate.soft_drain();
-        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Draining);
-        let lifecycle = LifecycleController::new(tx, gate.clone());
-        assert_eq!(
-            lifecycle.enter_soft_drain(),
-            DrainSignalOutcome::AlreadyDraining
-        );
-        assert_eq!(lifecycle.current_mode(), RunnerMode::Draining);
-        assert_eq!(gate.state(), ParkingState::SoftDraining);
-
-        // Stopping → ignored (cannot reverse teardown).
-        let gate = ParkingGate::new_open();
-        gate.close();
-        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Stopping);
-        let lifecycle = LifecycleController::new(tx, gate.clone());
-        assert_eq!(
-            lifecycle.enter_soft_drain(),
-            DrainSignalOutcome::Ignored(RunnerMode::Stopping)
-        );
-        assert_eq!(lifecycle.current_mode(), RunnerMode::Stopping);
-        assert_eq!(gate.state(), ParkingState::Closed);
-
-        // Stopped → ignored (runner has exited its loop).
-        let gate = ParkingGate::new_open();
-        gate.close();
-        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Stopped);
-        let lifecycle = LifecycleController::new(tx, gate.clone());
-        assert_eq!(
-            lifecycle.enter_soft_drain(),
-            DrainSignalOutcome::Ignored(RunnerMode::Stopped)
-        );
-        assert_eq!(lifecycle.current_mode(), RunnerMode::Stopped);
-        assert_eq!(gate.state(), ParkingState::Closed);
-    }
-
-    /// `handle_resume_signal` state guard: SIGUSR2 is honored only from
-    /// Draining after startup is ready. The integration test
-    /// `resume_after_stopping_is_ignored` covers the Stopping case; this pins
-    /// the full matrix as a unit test.
-    #[test]
-    fn resume_signal_state_guards() {
-        use crate::idle_pool::ParkingState;
-
-        // Draining → Running (sanity: the one legal transition).
-        let gate = ParkingGate::new_open();
-        gate.soft_drain();
-        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Draining);
-        let lifecycle = LifecycleController::new(tx, gate.clone());
-        handle_resume_signal(&lifecycle);
-        assert_eq!(lifecycle.current_mode(), RunnerMode::Running);
-        assert_eq!(gate.state(), ParkingState::Open);
-
-        // Draining entered during startup cannot resume until startup is ready.
-        let gate = ParkingGate::new_open();
-        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Starting);
-        let lifecycle = LifecycleController::new(tx, gate.clone());
-        assert_eq!(
-            lifecycle.enter_soft_drain(),
-            DrainSignalOutcome::EnteredDraining
-        );
-        handle_resume_signal(&lifecycle);
-        assert_eq!(lifecycle.current_mode(), RunnerMode::Draining);
-        assert_eq!(gate.state(), ParkingState::SoftDraining);
-
-        assert_eq!(lifecycle.mark_startup_ready(), RunnerMode::Draining);
-        handle_resume_signal(&lifecycle);
-        assert_eq!(lifecycle.current_mode(), RunnerMode::Running);
-        assert_eq!(gate.state(), ParkingState::Open);
-
-        // Starting → ignored (nothing to resume from).
-        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Starting);
-        let gate = ParkingGate::new_open();
-        let lifecycle = LifecycleController::new(tx, gate.clone());
-        handle_resume_signal(&lifecycle);
-        assert_eq!(lifecycle.current_mode(), RunnerMode::Starting);
-        assert_eq!(gate.state(), ParkingState::Open);
-
-        // Running → ignored (nothing to resume from).
-        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Running);
-        let gate = ParkingGate::new_open();
-        let lifecycle = LifecycleController::new(tx, gate.clone());
-        handle_resume_signal(&lifecycle);
-        assert_eq!(lifecycle.current_mode(), RunnerMode::Running);
-        assert_eq!(gate.state(), ParkingState::Open);
-
-        // Stopping → ignored (too late).
-        let gate = ParkingGate::new_open();
-        gate.close();
-        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Stopping);
-        let lifecycle = LifecycleController::new(tx, gate.clone());
-        handle_resume_signal(&lifecycle);
-        assert_eq!(lifecycle.current_mode(), RunnerMode::Stopping);
-        assert_eq!(gate.state(), ParkingState::Closed);
-
-        // Stopped → ignored.
-        let gate = ParkingGate::new_open();
-        gate.close();
-        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Stopped);
-        let lifecycle = LifecycleController::new(tx, gate.clone());
-        handle_resume_signal(&lifecycle);
-        assert_eq!(lifecycle.current_mode(), RunnerMode::Stopped);
-        assert_eq!(gate.state(), ParkingState::Closed);
     }
 
     /// `handle_stopping_signal` idempotency: a repeat invocation takes the

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -1,10 +1,11 @@
 use super::super::super::signals::{
-    LifecycleController, handle_drain_signal, handle_resume_signal, handle_stopping_signal,
+    handle_drain_signal, handle_resume_signal, handle_stopping_signal,
 };
 use super::super::super::*;
 use std::collections::BTreeMap;
 
 use crate::executor;
+use crate::lifecycle::LifecycleController;
 use crate::provider::mock::{MockJobProvider, MockProviderHandle};
 use crate::run_cancellation::RunCancellationRegistry;
 use sandbox_mock::MockSandboxRuntime;

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -1294,7 +1294,7 @@ impl IdlePool {
 
     /// Drain all entries from the pool. Parking permission is controlled by
     /// [`ParkingGate`] so soft-drain resume can reopen parking before
-    /// `RunnerMode::Running` becomes visible.
+    /// [`crate::lifecycle::RunnerMode::Running`] becomes visible.
     pub fn drain(&mut self) -> Vec<IdleDestroyJob> {
         let jobs: Vec<IdleDestroyJob> = self
             .entries

--- a/crates/runner/src/lifecycle.rs
+++ b/crates/runner/src/lifecycle.rs
@@ -1,0 +1,303 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+use serde::Serialize;
+
+use crate::idle_pool::ParkingGate;
+
+/// Runner lifecycle state.
+///
+/// - `Starting`: startup/readiness work is still in progress. The process is
+///   alive, but must not discover or claim new jobs.
+/// - `Running`: normal operation — discover and claim new jobs.
+/// - `Draining`: soft drain. No new jobs claimed; in-flight jobs keep
+///   running; idle pool destroyed. **Resumable** via SIGUSR2.
+/// - `Stopping`: irreversible teardown in progress — discovery released,
+///   per-job tokens cancelled, factories/proxy/kmsg/dns shutting down.
+///   Reached via SIGTERM/SIGINT, or automatically from `Draining` once
+///   `jobs.is_empty()`.
+/// - `Stopped`: teardown complete. The process exits immediately after
+///   writing this state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RunnerMode {
+    Starting,
+    Running,
+    Draining,
+    Stopping,
+    Stopped,
+}
+
+/// Ordered lifecycle transition handle shared by signal adapters and the main
+/// run loop.
+///
+/// Parking state is updated before publishing the externally visible mode so a
+/// task that observes `Running` can also rely on parking already being open.
+#[derive(Clone)]
+pub(crate) struct LifecycleController {
+    mode_tx: tokio::sync::watch::Sender<RunnerMode>,
+    parking_gate: ParkingGate,
+    startup_ready: Arc<AtomicBool>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SoftDrainOutcome {
+    EnteredDraining,
+    AlreadyDraining,
+    Ignored(RunnerMode),
+}
+
+impl LifecycleController {
+    pub(crate) fn new(
+        mode_tx: tokio::sync::watch::Sender<RunnerMode>,
+        parking_gate: ParkingGate,
+    ) -> Self {
+        let startup_ready = *mode_tx.borrow() != RunnerMode::Starting;
+        Self {
+            mode_tx,
+            parking_gate,
+            startup_ready: Arc::new(AtomicBool::new(startup_ready)),
+        }
+    }
+
+    pub(crate) fn current_mode(&self) -> RunnerMode {
+        *self.mode_tx.borrow()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn mode_tx(&self) -> &tokio::sync::watch::Sender<RunnerMode> {
+        &self.mode_tx
+    }
+
+    pub(crate) fn enter_soft_drain(&self) -> SoftDrainOutcome {
+        let gate = self.parking_gate.clone();
+        let mut outcome = SoftDrainOutcome::Ignored(self.current_mode());
+        let _ = self.mode_tx.send_if_modified(|mode| match *mode {
+            RunnerMode::Starting | RunnerMode::Running => {
+                let original_mode = *mode;
+                if gate.soft_drain() {
+                    *mode = RunnerMode::Draining;
+                    outcome = SoftDrainOutcome::EnteredDraining;
+                    true
+                } else {
+                    outcome = SoftDrainOutcome::Ignored(original_mode);
+                    false
+                }
+            }
+            RunnerMode::Draining => {
+                outcome = SoftDrainOutcome::AlreadyDraining;
+                false
+            }
+            mode => {
+                outcome = SoftDrainOutcome::Ignored(mode);
+                false
+            }
+        });
+        outcome
+    }
+
+    pub(crate) fn resume_from_soft_drain(&self) -> bool {
+        if !self.startup_ready.load(Ordering::SeqCst) {
+            return false;
+        }
+        let gate = self.parking_gate.clone();
+        let mut transitioned = false;
+        let _ = self.mode_tx.send_if_modified(|mode| {
+            if *mode == RunnerMode::Draining && gate.open_after_soft_drain() {
+                *mode = RunnerMode::Running;
+                transitioned = true;
+                true
+            } else {
+                false
+            }
+        });
+        transitioned
+    }
+
+    pub(crate) fn mark_startup_ready(&self) -> RunnerMode {
+        self.startup_ready.store(true, Ordering::SeqCst);
+        let mut current = self.current_mode();
+        let _ = self.mode_tx.send_if_modified(|mode| {
+            current = *mode;
+            if *mode == RunnerMode::Starting {
+                *mode = RunnerMode::Running;
+                current = RunnerMode::Running;
+                true
+            } else {
+                false
+            }
+        });
+        current
+    }
+
+    pub(crate) fn hard_stop(&self) -> bool {
+        let gate = self.parking_gate.clone();
+        let mut transitioned = false;
+        let _ = self.mode_tx.send_if_modified(|mode| {
+            if *mode != RunnerMode::Stopping {
+                gate.close();
+                *mode = RunnerMode::Stopping;
+                transitioned = true;
+                true
+            } else {
+                false
+            }
+        });
+        transitioned
+    }
+
+    pub(crate) fn stop_after_natural_drain(&self) -> bool {
+        let gate = self.parking_gate.clone();
+        let mut transitioned = false;
+        let _ = self.mode_tx.send_if_modified(|mode| {
+            if *mode == RunnerMode::Draining {
+                gate.close();
+                *mode = RunnerMode::Stopping;
+                transitioned = true;
+                true
+            } else {
+                false
+            }
+        });
+        transitioned
+    }
+
+    pub(crate) fn close_parking(&self) {
+        self.parking_gate.close();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::idle_pool::ParkingState;
+
+    /// Soft drain transitions from Starting or Running; repeated drain in
+    /// Draining is an idempotent no-op, while teardown modes stay ignored.
+    #[test]
+    fn soft_drain_state_guards() {
+        // Starting -> Draining (startup drain intent must not be lost).
+        let gate = ParkingGate::new_open();
+        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Starting);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        assert_eq!(
+            lifecycle.enter_soft_drain(),
+            SoftDrainOutcome::EnteredDraining
+        );
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Draining);
+        assert_eq!(gate.state(), ParkingState::SoftDraining);
+
+        // Running → Draining (sanity: the steady-state legal transition).
+        let gate = ParkingGate::new_open();
+        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Running);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        assert_eq!(
+            lifecycle.enter_soft_drain(),
+            SoftDrainOutcome::EnteredDraining
+        );
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Draining);
+        assert_eq!(gate.state(), ParkingState::SoftDraining);
+
+        // Draining → idempotent no-op.
+        let gate = ParkingGate::new_open();
+        gate.soft_drain();
+        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Draining);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        assert_eq!(
+            lifecycle.enter_soft_drain(),
+            SoftDrainOutcome::AlreadyDraining
+        );
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Draining);
+        assert_eq!(gate.state(), ParkingState::SoftDraining);
+
+        // Stopping → ignored (cannot reverse teardown).
+        let gate = ParkingGate::new_open();
+        gate.close();
+        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Stopping);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        assert_eq!(
+            lifecycle.enter_soft_drain(),
+            SoftDrainOutcome::Ignored(RunnerMode::Stopping)
+        );
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Stopping);
+        assert_eq!(gate.state(), ParkingState::Closed);
+
+        // Stopped → ignored (runner has exited its loop).
+        let gate = ParkingGate::new_open();
+        gate.close();
+        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Stopped);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        assert_eq!(
+            lifecycle.enter_soft_drain(),
+            SoftDrainOutcome::Ignored(RunnerMode::Stopped)
+        );
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Stopped);
+        assert_eq!(gate.state(), ParkingState::Closed);
+    }
+
+    /// Resume is honored only from Draining after startup is ready.
+    #[test]
+    fn resume_state_guards() {
+        // Draining → Running (sanity: the one legal transition).
+        let gate = ParkingGate::new_open();
+        gate.soft_drain();
+        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Draining);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        assert!(lifecycle.resume_from_soft_drain());
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Running);
+        assert_eq!(gate.state(), ParkingState::Open);
+
+        // Draining entered during startup cannot resume until startup is ready.
+        let gate = ParkingGate::new_open();
+        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Starting);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        assert_eq!(
+            lifecycle.enter_soft_drain(),
+            SoftDrainOutcome::EnteredDraining
+        );
+        assert!(!lifecycle.resume_from_soft_drain());
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Draining);
+        assert_eq!(gate.state(), ParkingState::SoftDraining);
+
+        assert_eq!(lifecycle.mark_startup_ready(), RunnerMode::Draining);
+        assert!(lifecycle.resume_from_soft_drain());
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Running);
+        assert_eq!(gate.state(), ParkingState::Open);
+
+        // Starting → ignored (nothing to resume from).
+        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Starting);
+        let gate = ParkingGate::new_open();
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        assert!(!lifecycle.resume_from_soft_drain());
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Starting);
+        assert_eq!(gate.state(), ParkingState::Open);
+
+        // Running → ignored (nothing to resume from).
+        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Running);
+        let gate = ParkingGate::new_open();
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        assert!(!lifecycle.resume_from_soft_drain());
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Running);
+        assert_eq!(gate.state(), ParkingState::Open);
+
+        // Stopping → ignored (too late).
+        let gate = ParkingGate::new_open();
+        gate.close();
+        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Stopping);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        assert!(!lifecycle.resume_from_soft_drain());
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Stopping);
+        assert_eq!(gate.state(), ParkingState::Closed);
+
+        // Stopped → ignored.
+        let gate = ParkingGate::new_open();
+        gate.close();
+        let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Stopped);
+        let lifecycle = LifecycleController::new(tx, gate.clone());
+        assert!(!lifecycle.resume_from_soft_drain());
+        assert_eq!(lifecycle.current_mode(), RunnerMode::Stopped);
+        assert_eq!(gate.state(), ParkingState::Closed);
+    }
+}

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -22,6 +22,7 @@ mod ids;
 mod image_hash;
 mod io_limits;
 mod kmsg_log;
+mod lifecycle;
 mod live_runner_instances;
 mod local_queue;
 mod lock;

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -9,29 +9,7 @@ use tracing::warn;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
-
-/// Runner lifecycle state.
-///
-/// - `Starting`: startup/readiness work is still in progress. The process is
-///   alive, but must not discover or claim new jobs.
-/// - `Running`: normal operation — discover and claim new jobs.
-/// - `Draining`: soft drain. No new jobs claimed; in-flight jobs keep
-///   running; idle pool destroyed. **Resumable** via SIGUSR2.
-/// - `Stopping`: irreversible teardown in progress — discovery released,
-///   per-job tokens cancelled, factories/proxy/kmsg/dns shutting down.
-///   Reached via SIGTERM/SIGINT, or automatically from `Draining` once
-///   `jobs.is_empty()`.
-/// - `Stopped`: teardown complete. The process exits immediately after
-///   writing this state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum RunnerMode {
-    Starting,
-    Running,
-    Draining,
-    Stopping,
-    Stopped,
-}
+use crate::lifecycle::RunnerMode;
 
 /// Active run lifecycle phase serialized as `active_runs[*].phase`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -48,7 +48,7 @@ When you test a CLI command via `command.parseAsync()`, you're already exercisin
 
 - **Security-critical code** where the stakes of a bug are high and the logic is genuinely independent.
 - **Algorithmically complex code** with non-obvious invariants (e.g. parsers, serializers, cryptographic routines).
-- **State-machine transition matrices.** When a handler's contract is the full N×M table of (current state, input) → next state, pinning every cell via integration tests balloons setup cost without catching more bugs than a direct unit test would. The canonical example is the runner signal-handler matrix in `crates/runner/src/cmd/start.rs` (`drain_signal_state_guards`, `resume_signal_state_guards`, `stopping_signal_repeat_is_idempotent`): each test is a 3–4-cell table calling a private `fn` directly, and the happy-path transitions are still covered by full-`run()` integration tests alongside.
+- **State-machine transition matrices.** When a handler's contract is the full N×M table of (current state, input) → next state, pinning every cell via integration tests balloons setup cost without catching more bugs than a direct unit test would. The canonical example is the runner lifecycle matrix in `crates/runner/src/lifecycle.rs` (`soft_drain_state_guards`, `resume_state_guards`): each test is a multi-cell table calling the lifecycle controller directly, and the happy-path transitions are still covered by full-`run()` integration tests alongside.
 
 ### E2E Tests: Happy Path Only
 


### PR DESCRIPTION
## Summary

- move `RunnerMode`, `LifecycleController`, soft-drain outcomes, and transition-matrix tests into a crate-level lifecycle module
- keep Unix signal registration, handler-task ownership, signal logging, and cancellation dispatch in the signal adapter
- redirect status, heartbeat, discovery, start-loop tests, and Rust documentation to the lifecycle-owned types
- update the testing guide's state-machine exception example to the new lifecycle test location

## Explicit exclusions

- no lifecycle transition, watch-channel, atomic, or parking-gate behavior changes
- no status or heartbeat serialization changes
- no runner/backend protocol, database, migration, feature-switch, or deployment compatibility changes

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner lifecycle::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::signals::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (2900 passed, 14 ignored; guest inventory passed)
- pre-commit workspace Rust formatting, Clippy, documentation, file-size, and commit-message checks

Closes #24231
