### PR TITLE
test(ably-subscriber): shorten reconnect rate-limit wait

### DIFF
--- a/crates/ably-subscriber/tests/integration/reconnect.rs
+++ b/crates/ably-subscriber/tests/integration/reconnect.rs
@@ -362,7 +362,7 @@ async fn repeated_clean_close_reconnect_is_rate_limited() {
     });
 
     let mut timing = TimingConfig::default();
-    timing.min_reconnect_interval = Duration::from_secs(2);
+    timing.min_reconnect_interval = Duration::from_secs(1);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

- reduce the reconnect rate-limit integration test's explicit minimum interval from two seconds to one second
- preserve the real 250 ms pre-deadline negative assertion, eventual third handshake, and post-reconnect message
- leave production reconnect behavior, defaults, timeouts, test selection, and coverage unchanged

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p ably-subscriber --all-features --no-deps`
- focused reconnect test passed 30 consecutive direct executions
- full 76-test integration binary passed 10 consecutive direct executions
- zero-interval mutation triggered `third reconnect should wait for the minimum reconnect interval`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets --all-features`
- repository pre-commit Rust format, documentation, and Clippy checks
- `git diff --check`

Closes #24233
