### PR TITLE
perf(api): shorten the organization admission-lock critical section

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -139,8 +139,11 @@ const API_DISPATCH_ZERO_INTERNAL_ENTRYPOINT_ACTION_TYPES = [
 ] as const;
 const API_DISPATCH_THREAD_SESSION_BINDING_ACTION_TYPES = [
   "api_dispatch_validate_thread_session_snapshot_thread",
-  "api_dispatch_load_thread_session_binding",
   "api_dispatch_update_thread_session_binding",
+] as const;
+const API_DISPATCH_REUSED_THREAD_READ_ACTION_TYPES = [
+  "api_dispatch_queue_first_thread_lock_wait",
+  "api_dispatch_load_thread_session_binding",
 ] as const;
 const API_DISPATCH_QUEUED_PERSISTENCE_ACTION_TYPES = [
   "api_dispatch_persist_custom_connector_auth_refs",
@@ -991,6 +994,18 @@ describe("CHAT-02: web chat send and client ids", () => {
       timingEvents,
       API_DISPATCH_THREAD_SESSION_BINDING_ACTION_TYPES,
       "nested",
+    );
+    expectApiDispatchSpanKind(
+      timingEvents,
+      [
+        "api_dispatch_admission_lock_held",
+        "api_dispatch_claim_queue_first_message",
+      ],
+      "nested",
+    );
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_REUSED_THREAD_READ_ACTION_TYPES,
     );
     expect(timingEvents).toContainEqual(
       expect.objectContaining({

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -228,6 +228,7 @@ const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_persist_runner_job_queue",
   ...API_DISPATCH_QUEUE_PERSISTENCE_ACTION_TYPES,
   "api_dispatch_admission_lock_wait",
+  "api_dispatch_admission_lock_held",
   "api_dispatch_check_concurrency_limit",
   "api_dispatch_insert_run_record",
   "api_dispatch_prepare_storage_manifest",

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1296,6 +1296,73 @@ describe("RUN-01/RUN-02: session continuation, memory policies, and volume pinni
 });
 
 describe("RUN-01: direct run admission boundaries", () => {
+  it("serializes concurrent direct runs at a one-run limit", async () => {
+    const actor = await entitledActor();
+    const compose = await createClaudeCompose(actor, "bdd-admission-race");
+    mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+
+    const attempts = await Promise.all([
+      reads.requestCreateDirectRun(
+        actor,
+        {
+          agentComposeId: compose.composeId,
+          prompt: "concurrent admission candidate one",
+        },
+        [201, 429],
+      ),
+      reads.requestCreateDirectRun(
+        actor,
+        {
+          agentComposeId: compose.composeId,
+          prompt: "concurrent admission candidate two",
+        },
+        [201, 429],
+      ),
+    ]);
+
+    expect(
+      attempts
+        .map((attempt) => {
+          return attempt.status;
+        })
+        .sort(),
+    ).toStrictEqual([201, 429]);
+
+    const rejected = attempts.find((attempt) => {
+      return attempt.status === 429;
+    });
+    if (!rejected || rejected.status !== 429) {
+      throw new Error("Expected one concurrent run to be rejected");
+    }
+    expectApiError(rejected.body);
+    expect(rejected.body.error.code).toBe("CONCURRENT_RUN_LIMIT");
+
+    const accepted = attempts.find((attempt) => {
+      return attempt.status === 201;
+    });
+    if (!accepted || accepted.status !== 201) {
+      throw new Error("Expected one concurrent run to be accepted");
+    }
+    const pending = await reads.requestListAgentRuns(
+      actor,
+      { status: "pending" },
+      [200],
+    );
+    expect(
+      pending.body.runs.map((run) => {
+        return run.id;
+      }),
+    ).toStrictEqual([accepted.body.runId]);
+    const queued = await reads.requestListAgentRuns(
+      actor,
+      { status: "queued" },
+      [200],
+    );
+    expect(queued.body.runs).toStrictEqual([]);
+
+    await api.requestCancelRun(actor, accepted.body.runId, [200]);
+  });
+
   it("enforces direct-run concurrency, caps, and the production capture gate", async () => {
     const actor = await entitledActor();
     const compose = await createClaudeCompose(actor, "bdd-admission");

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -171,7 +171,6 @@ import {
   loadCustomConnectorPermissionBundle,
   type CustomConnectorPermissionBundle,
 } from "./custom-connector-permission-bundle.service";
-import { activePendingRunPredicate } from "./agent-run-activity.service";
 import {
   prepareAgentRunStorage,
   type PreparedAgentRunStorage,
@@ -223,8 +222,8 @@ import {
 } from "./zero-chat-queued-event.service";
 import { recordFirstAssistantEventEligibility } from "./zero-chat-first-assistant-event-metric.service";
 import {
-  activePaidConcurrencySlots,
   cappedBaseConcurrencyLimit,
+  loadOrgConcurrencyState,
   totalConcurrencyLimit,
 } from "./org-concurrency-entitlements.service";
 import { loadOrgPlanCapabilities } from "./org-plan-entitlement-read.service";
@@ -504,6 +503,12 @@ interface ThreadSessionSnapshotStale {
   readonly agentSessionRunId: string;
   readonly resolutionAction: ChatThreadSessionResolutionAction;
   readonly reason: "binding_changed" | "session_changed";
+}
+
+interface ValidatedThreadSessionSnapshot {
+  readonly kind: "validated-thread-session-snapshot";
+  readonly chatThreadId: string;
+  readonly agentSessionId: string | null;
 }
 
 type AtomicLaunchCommitResult =
@@ -4422,36 +4427,21 @@ async function checkRunConcurrencyLimit(
   tx: DbTransaction,
   orgId: string,
 ): Promise<CreateRunErrorResult | null> {
-  const [capabilities, paidSlots] = await Promise.all([
-    loadOrgPlanCapabilities(tx, orgId),
-    activePaidConcurrencySlots(tx, orgId),
-  ]);
+  const at = nowDate();
+  const state = await loadOrgConcurrencyState(tx, {
+    orgId,
+    at,
+    activePendingAfter: new Date(at.getTime() - PENDING_RUN_TTL_MS),
+  });
   const limit = getEffectiveConcurrencyLimit(
-    capabilities?.baseConcurrencyLimit ?? 0,
-    paidSlots,
+    state.baseConcurrencyLimit,
+    state.paidSlots,
   );
   if (limit === 0) {
     return null;
   }
 
-  const staleThreshold = new Date(now() - PENDING_RUN_TTL_MS);
-  const [activeResult] = await tx
-    .select({ count: count() })
-    .from(agentRuns)
-    .where(
-      and(
-        eq(agentRuns.orgId, orgId),
-        or(
-          eq(agentRuns.status, "running"),
-          and(
-            eq(agentRuns.status, "pending"),
-            activePendingRunPredicate(staleThreshold),
-          ),
-        ),
-      ),
-    );
-  const activeCount = Number(activeResult?.count ?? 0);
-  return activeCount >= limit ? concurrentRunLimit() : null;
+  return state.activeRunCount >= limit ? concurrentRunLimit() : null;
 }
 
 async function checkFinalRunAdmission(
@@ -5838,6 +5828,7 @@ async function claimQueueFirstAssociationForLaunch(args: {
   readonly createArgs: CreateAgentRunArgs;
   readonly identity: LaunchRunIdentity;
   readonly timing: ApiDispatchTimingCollector;
+  readonly validatedThreadSession: ValidatedThreadSessionSnapshot | undefined;
 }): Promise<QueueFirstRunClaimResult | undefined> {
   const association = args.createArgs.queueFirstAssociation;
   if (!association) {
@@ -5851,6 +5842,9 @@ async function claimQueueFirstAssociationForLaunch(args: {
     apiStartTime: args.createArgs.apiStartTime,
     runId: args.identity.runId,
     timing: args.timing,
+    ...(args.validatedThreadSession?.chatThreadId === association.threadId
+      ? { threadAlreadyLocked: true }
+      : {}),
   });
 }
 
@@ -5871,6 +5865,7 @@ async function commitFailedLaunch(args: {
         createArgs: args.createArgs,
         identity: args.identity,
         timing: args.timing,
+        validatedThreadSession: undefined,
       });
       if (queueFirstClaim?.kind === "lost") {
         return { kind: "queue-first-claim-lost" };
@@ -6007,6 +6002,7 @@ async function persistThreadSessionBinding(
     readonly identity: LaunchRunIdentity;
     readonly resolution: ChatThreadSessionResolution | undefined;
     readonly timing: ApiDispatchTimingCollector;
+    readonly validatedThreadSession: ValidatedThreadSessionSnapshot | undefined;
   },
 ): Promise<ThreadSessionBindingWrite | undefined> {
   if (!args.chatThreadId) {
@@ -6014,27 +6010,36 @@ async function persistThreadSessionBinding(
   }
   const chatThreadId = args.chatThreadId;
 
-  const [thread] = await args.timing.measure(
-    "api_dispatch_load_thread_session_binding",
-    "nested",
-    async () => {
-      return await tx
-        .select({ agentSessionId: chatThreads.agentSessionId })
-        .from(chatThreads)
-        .where(eq(chatThreads.id, chatThreadId))
-        .for("update")
-        .limit(1);
-    },
-  );
-  if (!thread) {
-    throw new Error("Chat thread not found while persisting session binding");
+  let previousAgentSessionId: string | null;
+  if (args.validatedThreadSession) {
+    if (args.validatedThreadSession.chatThreadId !== chatThreadId) {
+      throw new Error("Validated chat thread does not match binding target");
+    }
+    previousAgentSessionId = args.validatedThreadSession.agentSessionId;
+  } else {
+    const [thread] = await args.timing.measure(
+      "api_dispatch_load_thread_session_binding",
+      "nested",
+      async () => {
+        return await tx
+          .select({ agentSessionId: chatThreads.agentSessionId })
+          .from(chatThreads)
+          .where(eq(chatThreads.id, chatThreadId))
+          .for("update")
+          .limit(1);
+      },
+    );
+    if (!thread) {
+      throw new Error("Chat thread not found while persisting session binding");
+    }
+    previousAgentSessionId = thread.agentSessionId;
   }
 
   const action: ThreadSessionBindingAction =
     args.resolution?.action ??
-    (thread.agentSessionId === null
+    (previousAgentSessionId === null
       ? "initialized"
-      : thread.agentSessionId === args.identity.sessionId
+      : previousAgentSessionId === args.identity.sessionId
         ? "reused"
         : "rotated");
   const [updated] = await args.timing.measure(
@@ -6090,7 +6095,9 @@ async function validateThreadSessionSnapshot(
     readonly identity: LaunchRunIdentity;
     readonly timing: ApiDispatchTimingCollector;
   },
-): Promise<ThreadSessionSnapshotStale | undefined> {
+): Promise<
+  ThreadSessionSnapshotStale | ValidatedThreadSessionSnapshot | undefined
+> {
   const resolution = args.createArgs.threadSessionResolution;
   const chatThreadId = args.createArgs.chatThreadId;
   if (!resolution || !chatThreadId) {
@@ -6128,7 +6135,11 @@ async function validateThreadSessionSnapshot(
 
   const expectedSessionId = resolution.expected.sessionId;
   if (expectedSessionId === null) {
-    return undefined;
+    return {
+      kind: "validated-thread-session-snapshot",
+      chatThreadId,
+      agentSessionId: thread.agentSessionId,
+    };
   }
   const [session] = await args.timing.measure(
     "api_dispatch_validate_thread_session_snapshot_session",
@@ -6152,7 +6163,11 @@ async function validateThreadSessionSnapshot(
       reason: "session_changed",
     });
   }
-  return undefined;
+  return {
+    kind: "validated-thread-session-snapshot",
+    chatThreadId,
+    agentSessionId: thread.agentSessionId,
+  };
 }
 
 async function commitQueuedPreparedLaunch(
@@ -6160,6 +6175,7 @@ async function commitQueuedPreparedLaunch(
   args: CommitPreparedLaunchArgs,
   payload: RunnerJobPayload,
   queueFirstClaim: QueueFirstRunClaimed | undefined,
+  validatedThreadSession: ValidatedThreadSessionSnapshot | undefined,
 ): Promise<Extract<AtomicLaunchCommitResult, { readonly kind: "queued" }>> {
   if (!args.encryptedQueuedParams) {
     throw new Error("Missing encrypted queued runner job payload");
@@ -6216,6 +6232,7 @@ async function commitQueuedPreparedLaunch(
     identity: args.identity,
     resolution: args.createArgs.threadSessionResolution,
     timing: args.timing,
+    validatedThreadSession,
   });
   return {
     kind: "queued",
@@ -6234,6 +6251,7 @@ async function commitPendingPreparedLaunch(
   args: CommitPreparedLaunchArgs,
   payload: RunnerJobPayload,
   queueFirstClaim: QueueFirstRunClaimed | undefined,
+  validatedThreadSession: ValidatedThreadSessionSnapshot | undefined,
 ): Promise<Extract<AtomicLaunchCommitResult, { readonly kind: "pending" }>> {
   const run = await insertAtomicLaunchRunRecord({
     tx,
@@ -6278,6 +6296,7 @@ async function commitPendingPreparedLaunch(
     identity: args.identity,
     resolution: args.createArgs.threadSessionResolution,
     timing: args.timing,
+    validatedThreadSession,
   });
   return {
     kind: "pending",
@@ -6290,11 +6309,77 @@ async function commitPendingPreparedLaunch(
   };
 }
 
+async function commitPreparedLaunchUnderLock(
+  tx: DbTransaction,
+  args: CommitPreparedLaunchArgs,
+  payload: RunnerJobPayload,
+): Promise<AtomicLaunchCommitResult | CreateRunErrorResult> {
+  const threadSessionValidation = await validateThreadSessionSnapshot(tx, {
+    createArgs: args.createArgs,
+    identity: args.identity,
+    timing: args.timing,
+  });
+  if (threadSessionValidation?.kind === "thread-session-snapshot-stale") {
+    return threadSessionValidation;
+  }
+  const validatedThreadSession = threadSessionValidation;
+  const concurrency = await args.timing.measure(
+    "api_dispatch_check_concurrency_limit",
+    "nested",
+    async () => {
+      return await checkRunConcurrencyLimit(tx, args.createArgs.orgId);
+    },
+  );
+
+  if (concurrency) {
+    if (!args.createArgs.queueOnConcurrencyLimit) {
+      return concurrency;
+    }
+    if (!args.encryptedQueuedParams) {
+      return { kind: "queue-payload-required" };
+    }
+    const queueFirstClaim = await claimQueueFirstAssociationForLaunch({
+      tx,
+      createArgs: args.createArgs,
+      identity: args.identity,
+      timing: args.timing,
+      validatedThreadSession,
+    });
+    if (queueFirstClaim?.kind === "lost") {
+      return { kind: "queue-first-claim-lost" };
+    }
+    return await commitQueuedPreparedLaunch(
+      tx,
+      args,
+      payload,
+      queueFirstClaim,
+      validatedThreadSession,
+    );
+  }
+
+  const queueFirstClaim = await claimQueueFirstAssociationForLaunch({
+    tx,
+    createArgs: args.createArgs,
+    identity: args.identity,
+    timing: args.timing,
+    validatedThreadSession,
+  });
+  if (queueFirstClaim?.kind === "lost") {
+    return { kind: "queue-first-claim-lost" };
+  }
+  return await commitPendingPreparedLaunch(
+    tx,
+    args,
+    payload,
+    queueFirstClaim,
+    validatedThreadSession,
+  );
+}
+
 async function commitPreparedLaunch(
   args: CommitPreparedLaunchArgs,
 ): Promise<AtomicLaunchCommitResult | CreateRunErrorResult> {
-  const payload = args.launch.runnerJobPayload;
-  return await args.db.transaction(async (tx) => {
+  const committed = await args.db.transaction(async (tx) => {
     await args.timing.measure(
       "api_dispatch_admission_lock_wait",
       "nested",
@@ -6304,62 +6389,22 @@ async function commitPreparedLaunch(
         );
       },
     );
-    const staleThreadSession = await validateThreadSessionSnapshot(tx, {
-      createArgs: args.createArgs,
-      identity: args.identity,
-      timing: args.timing,
-    });
-    if (staleThreadSession) {
-      return staleThreadSession;
-    }
-    const concurrency = await args.timing.measure(
-      "api_dispatch_check_concurrency_limit",
-      "nested",
-      async () => {
-        return await checkRunConcurrencyLimit(tx, args.createArgs.orgId);
-      },
-    );
-
-    if (concurrency) {
-      if (!args.createArgs.queueOnConcurrencyLimit) {
-        return concurrency;
-      }
-      if (!args.encryptedQueuedParams) {
-        return { kind: "queue-payload-required" };
-      }
-      const queueFirstClaim = await claimQueueFirstAssociationForLaunch({
-        tx,
-        createArgs: args.createArgs,
-        identity: args.identity,
-        timing: args.timing,
-      });
-      if (queueFirstClaim?.kind === "lost") {
-        return { kind: "queue-first-claim-lost" };
-      }
-      return await commitQueuedPreparedLaunch(
+    const admissionLockHeldStartedAt = now();
+    return {
+      result: await commitPreparedLaunchUnderLock(
         tx,
         args,
-        payload,
-        queueFirstClaim,
-      );
-    }
-
-    const queueFirstClaim = await claimQueueFirstAssociationForLaunch({
-      tx,
-      createArgs: args.createArgs,
-      identity: args.identity,
-      timing: args.timing,
-    });
-    if (queueFirstClaim?.kind === "lost") {
-      return { kind: "queue-first-claim-lost" };
-    }
-    return await commitPendingPreparedLaunch(
-      tx,
-      args,
-      payload,
-      queueFirstClaim,
-    );
+        args.launch.runnerJobPayload,
+      ),
+      admissionLockHeldStartedAt,
+    };
   });
+  args.timing.recordElapsed(
+    "api_dispatch_admission_lock_held",
+    "nested",
+    committed.admissionLockHeldStartedAt,
+  );
+  return committed.result;
 }
 
 function buildAtomicLaunchPayload(

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -131,6 +131,7 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_persist_custom_connector_auth_refs"
   | "api_dispatch_insert_runner_job_queue"
   | "api_dispatch_admission_lock_wait"
+  | "api_dispatch_admission_lock_held"
   | "api_dispatch_check_concurrency_limit"
   | "api_dispatch_concurrency_preflight_lock_wait"
   | "api_dispatch_concurrency_preflight_check"

--- a/turbo/apps/api/src/signals/services/org-concurrency-entitlements.service.ts
+++ b/turbo/apps/api/src/signals/services/org-concurrency-entitlements.service.ts
@@ -1,10 +1,14 @@
+import { agentRuns } from "@vm0/db/schema/agent-run";
 import { orgConcurrencySubscriptions } from "@vm0/db/schema/org-concurrency-subscription";
-import { and, eq, gt, inArray, sql, sum } from "drizzle-orm";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { orgPlanEntitlements } from "@vm0/db/schema/org-plan-entitlement";
+import { and, count, eq, gt, inArray, or, sql, sum } from "drizzle-orm";
 
 import { pgIntegerDecoder } from "../../lib/db-structured-result";
 import { env } from "../../lib/env";
 import { nowDate } from "../external/time";
 import type { Db } from "../external/db";
+import { activePendingRunPredicate } from "./agent-run-activity.service";
 
 export const CONCURRENCY_SUBSCRIPTION_PURPOSE = "concurrency_subscription";
 const CONCURRENCY_SUBSCRIPTION_ACTIVE_STATUSES = [
@@ -24,6 +28,12 @@ export interface ActiveConcurrencySubscription {
   readonly quantity: number;
   readonly currentPeriodEnd: Date | null;
   readonly cancelAtPeriodEnd: boolean;
+}
+
+interface OrgConcurrencyState {
+  readonly baseConcurrencyLimit: number;
+  readonly paidSlots: number;
+  readonly activeRunCount: number;
 }
 
 function dbTimestamp(value: Date | string | null | undefined): Date | null {
@@ -66,6 +76,20 @@ function activePaidThroughCutoff(at: Date): Date {
   return new Date(at.getTime() - CONCURRENCY_PAYMENT_FAILURE_GRACE_MS);
 }
 
+function activeConcurrencySubscriptionPredicate(orgId: string, at: Date) {
+  return and(
+    eq(orgConcurrencySubscriptions.orgId, orgId),
+    inArray(orgConcurrencySubscriptions.subscriptionStatus, [
+      ...CONCURRENCY_SUBSCRIPTION_ACTIVE_STATUSES,
+      ...CONCURRENCY_SUBSCRIPTION_PAYMENT_FAILED_STATUSES,
+    ]),
+    gt(
+      orgConcurrencySubscriptions.currentPeriodEnd,
+      activePaidThroughCutoff(at),
+    ),
+  );
+}
+
 export async function activePaidConcurrencySlots(
   db: ReadDb,
   orgId: string,
@@ -79,21 +103,71 @@ export async function activePaidConcurrencySlots(
         ),
     })
     .from(orgConcurrencySubscriptions)
-    .where(
-      and(
-        eq(orgConcurrencySubscriptions.orgId, orgId),
-        inArray(orgConcurrencySubscriptions.subscriptionStatus, [
-          ...CONCURRENCY_SUBSCRIPTION_ACTIVE_STATUSES,
-          ...CONCURRENCY_SUBSCRIPTION_PAYMENT_FAILED_STATUSES,
-        ]),
-        gt(
-          orgConcurrencySubscriptions.currentPeriodEnd,
-          activePaidThroughCutoff(at),
-        ),
-      ),
-    );
+    .where(activeConcurrencySubscriptionPredicate(orgId, at));
 
   return row?.slots ?? 0;
+}
+
+export async function loadOrgConcurrencyState(
+  db: ReadDb,
+  args: {
+    readonly orgId: string;
+    readonly at: Date;
+    readonly activePendingAfter: Date;
+  },
+): Promise<OrgConcurrencyState> {
+  const paidSlotTotals = db
+    .select({
+      slots: sql`COALESCE(${sum(orgConcurrencySubscriptions.slots)}, 0)::int`
+        .mapWith(pgIntegerDecoder)
+        .as("slots"),
+    })
+    .from(orgConcurrencySubscriptions)
+    .where(activeConcurrencySubscriptionPredicate(args.orgId, args.at))
+    .as("paid_concurrency_slot_totals");
+  const activeRunTotals = db
+    .select({
+      count: count().as("active_run_count"),
+    })
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.orgId, args.orgId),
+        or(
+          eq(agentRuns.status, "running"),
+          and(
+            eq(agentRuns.status, "pending"),
+            activePendingRunPredicate(args.activePendingAfter),
+          ),
+        ),
+      ),
+    )
+    .as("active_concurrency_run_totals");
+
+  const [row] = await db
+    .select({
+      entitlementOrgId: orgPlanEntitlements.orgId,
+      metadataOrgId: orgMetadata.orgId,
+      baseConcurrencyLimit: orgPlanEntitlements.baseConcurrencyLimit,
+      paidSlots: paidSlotTotals.slots,
+      activeRunCount: activeRunTotals.count,
+    })
+    .from(paidSlotTotals)
+    .crossJoin(activeRunTotals)
+    .leftJoin(orgPlanEntitlements, eq(orgPlanEntitlements.orgId, args.orgId))
+    .leftJoin(orgMetadata, eq(orgMetadata.orgId, args.orgId));
+  if (!row) {
+    throw new Error("Concurrency state aggregate returned no row");
+  }
+  if (row.entitlementOrgId === null && row.metadataOrgId !== null) {
+    throw new Error(`Missing org plan entitlement for ${args.orgId}`);
+  }
+
+  return {
+    baseConcurrencyLimit: row.baseConcurrencyLimit ?? 0,
+    paidSlots: row.paidSlots,
+    activeRunCount: row.activeRunCount,
+  };
 }
 
 export async function activeConcurrencySubscriptions(
@@ -109,19 +183,7 @@ export async function activeConcurrencySubscriptions(
       cancelAtPeriodEnd: orgConcurrencySubscriptions.cancelAtPeriodEnd,
     })
     .from(orgConcurrencySubscriptions)
-    .where(
-      and(
-        eq(orgConcurrencySubscriptions.orgId, orgId),
-        inArray(orgConcurrencySubscriptions.subscriptionStatus, [
-          ...CONCURRENCY_SUBSCRIPTION_ACTIVE_STATUSES,
-          ...CONCURRENCY_SUBSCRIPTION_PAYMENT_FAILED_STATUSES,
-        ]),
-        gt(
-          orgConcurrencySubscriptions.currentPeriodEnd,
-          activePaidThroughCutoff(at),
-        ),
-      ),
-    );
+    .where(activeConcurrencySubscriptionPredicate(orgId, at));
 
   return rows
     .map((row) => {

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -451,6 +451,7 @@ export async function claimQueueFirstRunAssociation(
     readonly apiStartTime: number;
     readonly runId: string;
     readonly timing: ApiDispatchTimingCollector;
+    readonly threadAlreadyLocked?: true;
   },
 ): Promise<QueueFirstRunClaimResult> {
   let outcome: "claimed" | "lost" | "error" = "error";
@@ -458,13 +459,15 @@ export async function claimQueueFirstRunAssociation(
     "api_dispatch_claim_queue_first_message",
     "nested",
     async () => {
-      const threadExists = await args.timing.measure(
-        "api_dispatch_queue_first_thread_lock_wait",
-        "nested",
-        async () => {
-          return await lockUserMessageQueueThread(db, args.threadId);
-        },
-      );
+      const threadExists =
+        args.threadAlreadyLocked ??
+        (await args.timing.measure(
+          "api_dispatch_queue_first_thread_lock_wait",
+          "nested",
+          async () => {
+            return await lockUserMessageQueueThread(db, args.threadId);
+          },
+        ));
       if (!threadExists) {
         outcome = "lost";
         return { kind: "lost" };

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -35,11 +35,10 @@ import {
 } from "./zero-chat-queue-marker.service";
 import { recordFirstAssistantEventEligibility } from "./zero-chat-first-assistant-event-metric.service";
 import {
-  activePaidConcurrencySlots,
   cappedBaseConcurrencyLimit,
+  loadOrgConcurrencyState,
   totalConcurrencyLimit,
 } from "./org-concurrency-entitlements.service";
-import { loadOrgPlanCapabilities } from "./org-plan-entitlement-read.service";
 import { tapError } from "../utils";
 
 const L = logger("ZeroRunQueue");
@@ -49,16 +48,21 @@ const QUEUED_RUN_EXPIRED_REASON = "Queued run expired (exceeded queue TTL)";
 const QUEUED_RUN_LAUNCH_ORPHAN_REASON =
   "Queued run timed out before queue entry was persisted";
 
-async function effectiveOrgConcurrencyLimit(
+async function effectiveOrgConcurrencyState(
   db: Pick<Db, "select">,
   orgId: string,
-): Promise<number> {
-  const capabilities = await loadOrgPlanCapabilities(db, orgId);
-  const baseLimit = cappedBaseConcurrencyLimit(
-    capabilities?.baseConcurrencyLimit ?? 0,
-  );
-  const paidSlots = await activePaidConcurrencySlots(db, orgId);
-  return totalConcurrencyLimit({ baseLimit, paidSlots });
+): Promise<{ readonly activeRunCount: number; readonly limit: number }> {
+  const at = nowDate();
+  const state = await loadOrgConcurrencyState(db, {
+    orgId,
+    at,
+    activePendingAfter: new Date(at.getTime() - PENDING_RUN_TTL_MS),
+  });
+  const baseLimit = cappedBaseConcurrencyLimit(state.baseConcurrencyLimit);
+  return {
+    activeRunCount: state.activeRunCount,
+    limit: totalConcurrencyLimit({ baseLimit, paidSlots: state.paidSlots }),
+  };
 }
 
 type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
@@ -143,29 +147,6 @@ async function timedOutQueuedRunsWithMarkerNotifications(
   return timedOutRuns;
 }
 
-async function activeConcurrencyCount(
-  db: Pick<Db, "select">,
-  orgId: string,
-): Promise<number> {
-  const staleThreshold = new Date(now() - PENDING_RUN_TTL_MS);
-  const [activeRow] = await db
-    .select({ count: count() })
-    .from(agentRuns)
-    .where(
-      and(
-        eq(agentRuns.orgId, orgId),
-        or(
-          eq(agentRuns.status, "running"),
-          and(
-            eq(agentRuns.status, "pending"),
-            activePendingRunPredicate(staleThreshold),
-          ),
-        ),
-      ),
-    );
-  return Number(activeRow?.count ?? 0);
-}
-
 async function insertPromotedRunnerJob(
   tx: DbTransaction,
   args: {
@@ -228,10 +209,8 @@ async function loadDrainCandidates(
   return await db.transaction(async (tx) => {
     await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
 
-    const limit = await effectiveOrgConcurrencyLimit(tx, orgId);
-
-    const activeCount = await activeConcurrencyCount(tx, orgId);
-    if (activeCount >= limit) {
+    const concurrency = await effectiveOrgConcurrencyState(tx, orgId);
+    if (concurrency.activeRunCount >= concurrency.limit) {
       return [];
     }
 
@@ -265,10 +244,8 @@ async function promoteQueuedCandidate(
       sql`SELECT pg_advisory_xact_lock(hashtext(${args.orgId}))`,
     );
 
-    const limit = await effectiveOrgConcurrencyLimit(tx, args.orgId);
-
-    const activeCount = await activeConcurrencyCount(tx, args.orgId);
-    if (activeCount >= limit) {
+    const concurrency = await effectiveOrgConcurrencyState(tx, args.orgId);
+    if (concurrency.activeRunCount >= concurrency.limit) {
       return { status: "full" };
     }
 


### PR DESCRIPTION
## Summary

- consolidate the plan entitlement, paid concurrency slots, and active run count into one authoritative SQL statement after acquiring the organization admission lock
- reuse the validated `chat_threads` row lock for queue-first claiming and session binding persistence
- add a fixed `api_dispatch_admission_lock_held` timing and concurrent direct-admission coverage

## Critical-section change

For a resolved queue-first chat launch:

- concurrency state: 3 statements -> 1
- queue-first thread lock: 1 statement -> 0
- session binding read: 1 statement -> 0

The final organization-locked transaction remains authoritative for the concurrency decision and pending/queued run plus durable queue writes. Queue-payload encryption remains outside database transactions, and notifications remain after commit.

Queue draining and final promotion use the same consolidated concurrency-state statement while preserving their existing decrypt/recheck flow.

## Compatibility and exclusions

- no schema, migration, public API, queue payload, frontend, runner/guest protocol, feature switch, or coordinated rollout
- no entitlement input moves before the organization lock
- the pre-existing usage-allowance Stripe refresh boundary is unchanged and tracked separately in #24257

## Validation

- `pnpm exec prettier --check <changed files>`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api build`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts --maxWorkers=1 --silent=passed-only` (19 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts --maxWorkers=1 --silent=passed-only` (61 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only` (134 passed)
- pre-commit repository Knip and workspace type checks

Closes #24205

Parent objective: #24203
