### PR TITLE
fix: apply context-tiered pricing to managed models

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -160,6 +160,11 @@ Model-provider usage
   Entries are released before ``websocket_end()`` after each source-preserving
   report attempt. Zero-only entries are also released immediately because
   observable model-provider flows already carry ``MODEL_USAGE_PROVIDER``.
+- ``MODEL_PROVIDER_USAGE_TIERS``: bounded insertion-ordered mapping from
+  WebSocket response id to the concrete billing tier decision selected from
+  its input partition. Zero-only decisions remain provisional until the first
+  positive billing item. Written by model-provider billing and cleared at the
+  WebSocket terminal lifecycle boundary.
 - ``MODEL_USAGE_PROVIDER``: optional ``str`` canonical model id from registry VM
   info. Read by model-provider usage observability and reported-model selection.
 - ``MODEL_JSON_USAGE_FINALIZED``: ``bool`` written when JSON usage finalization
@@ -223,6 +228,7 @@ TRUSTED_AUTHORITY_HOST: Final = "trusted_authority_host"
 # Usage and streaming metadata
 MODEL_PROVIDER_USAGE: Final = "model_provider_usage"
 MODEL_PROVIDER_USAGE_SOURCES: Final = "model_provider_usage_sources"
+MODEL_PROVIDER_USAGE_TIERS: Final = "model_provider_usage_tiers"
 MODEL_USAGE_PROVIDER: Final = "model_usage_provider"
 MODEL_JSON_USAGE_FINALIZED: Final = "_model_json_usage_finalized"
 RESPONSE_STREAM_STATE: Final = "response_stream_state"

--- a/crates/runner/mitm-addon/src/terminal_usage.py
+++ b/crates/runner/mitm-addon/src/terminal_usage.py
@@ -46,4 +46,5 @@ def report_model_provider_usage_once(flow: http.HTTPFlow, run_id: str) -> None:
 def release_model_websocket_terminal_state(flow: http.HTTPFlow) -> None:
     if response_streaming.is_model_websocket_usage_enabled(flow):
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {}
+        usage.release_model_provider_usage_tiers(flow)
         response_streaming.release_model_websocket_usage_state(flow)

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -72,6 +72,7 @@ from .providers.connectors import (
 from .providers.model_provider import (
     has_positive_model_provider_usage,
     is_model_provider_usage_observable,
+    release_model_provider_usage_tiers,
     report_model_provider_usage,
     report_model_provider_usage_observation,
     report_model_provider_usage_source,
@@ -107,6 +108,7 @@ __all__ = [
     "merge_openai_responses_usage_result",
     "needs_connector_response_buffer_fallback",
     "read_usage_flush_request_id",
+    "release_model_provider_usage_tiers",
     "report_connector_usage",
     "report_model_provider_usage",
     "report_model_provider_usage_observation",

--- a/crates/runner/mitm-addon/src/usage/model_tokens.py
+++ b/crates/runner/mitm-addon/src/usage/model_tokens.py
@@ -4,6 +4,10 @@ MODEL_USAGE_CATEGORY_INPUT = "tokens.input"
 MODEL_USAGE_CATEGORY_OUTPUT = "tokens.output"
 MODEL_USAGE_CATEGORY_CACHE_READ = "tokens.cache_read"
 MODEL_USAGE_CATEGORY_CACHE_CREATION = "tokens.cache_creation"
+MODEL_USAGE_CATEGORY_INPUT_LONG_CONTEXT = "tokens.input.long_context"
+MODEL_USAGE_CATEGORY_OUTPUT_LONG_CONTEXT = "tokens.output.long_context"
+MODEL_USAGE_CATEGORY_CACHE_READ_LONG_CONTEXT = "tokens.cache_read.long_context"
+MODEL_USAGE_CATEGORY_CACHE_CREATION_LONG_CONTEXT = "tokens.cache_creation.long_context"
 
 ANTHROPIC_USAGE_FIELD_CATEGORIES = {
     "input_tokens": MODEL_USAGE_CATEGORY_INPUT,

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -15,8 +15,10 @@ id the proxy should report for model token usage. Billable rows go to
 """
 
 import uuid
+from collections import OrderedDict
 from collections.abc import Iterator
-from typing import TypeGuard
+from dataclasses import dataclass
+from typing import Literal, TypeGuard
 
 from mitmproxy import http
 
@@ -40,19 +42,53 @@ from ..idempotency import (
 from ..model_tokens import (
     MODEL_USAGE_CATEGORIES,
     MODEL_USAGE_CATEGORY_CACHE_CREATION,
+    MODEL_USAGE_CATEGORY_CACHE_CREATION_LONG_CONTEXT,
     MODEL_USAGE_CATEGORY_CACHE_READ,
+    MODEL_USAGE_CATEGORY_CACHE_READ_LONG_CONTEXT,
     MODEL_USAGE_CATEGORY_INPUT,
+    MODEL_USAGE_CATEGORY_INPUT_LONG_CONTEXT,
     MODEL_USAGE_CATEGORY_OUTPUT,
+    MODEL_USAGE_CATEGORY_OUTPUT_LONG_CONTEXT,
 )
 from ..reporting_context import UsageReportingContext, usage_reporting_context
 from ..underbilling import log_usage_underbilling
 
 MODEL_USAGE_KIND = "model"
+type _ModelUsageTier = Literal["base", "long_context"]
+_MODEL_USAGE_TIER_BASE: _ModelUsageTier = "base"
+_MODEL_USAGE_TIER_LONG_CONTEXT: _ModelUsageTier = "long_context"
+
+
+@dataclass(frozen=True, slots=True)
+class _ModelUsageTierDecision:
+    tier: _ModelUsageTier
+    committed: bool
+
+
+_OPENAI_LONG_CONTEXT_MODELS = frozenset(
+    (
+        "gpt-5.5",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+    )
+)
+_OPENAI_LONG_CONTEXT_MIN_INPUT_TOKENS = 272_001
+_MODEL_USAGE_LONG_CONTEXT_CATEGORY_BY_BASE = {
+    MODEL_USAGE_CATEGORY_INPUT: MODEL_USAGE_CATEGORY_INPUT_LONG_CONTEXT,
+    MODEL_USAGE_CATEGORY_OUTPUT: MODEL_USAGE_CATEGORY_OUTPUT_LONG_CONTEXT,
+    MODEL_USAGE_CATEGORY_CACHE_READ: MODEL_USAGE_CATEGORY_CACHE_READ_LONG_CONTEXT,
+    MODEL_USAGE_CATEGORY_CACHE_CREATION: MODEL_USAGE_CATEGORY_CACHE_CREATION_LONG_CONTEXT,
+}
+_MODEL_PROVIDER_USAGE_TIER_SOURCE_LIMIT = 100
 _MODEL_INPUT_PARTITION_CATEGORIES = frozenset(
     (
         MODEL_USAGE_CATEGORY_INPUT,
         MODEL_USAGE_CATEGORY_CACHE_READ,
         MODEL_USAGE_CATEGORY_CACHE_CREATION,
+        MODEL_USAGE_CATEGORY_INPUT_LONG_CONTEXT,
+        MODEL_USAGE_CATEGORY_CACHE_READ_LONG_CONTEXT,
+        MODEL_USAGE_CATEGORY_CACHE_CREATION_LONG_CONTEXT,
     )
 )
 
@@ -160,7 +196,9 @@ def report_model_provider_usage_source(
     in a later frame. Callers can drop the source from flow metadata after this
     returns: observable flows carry the canonical ``MODEL_USAGE_PROVIDER``, so
     zero-usage source model hints do not need to be retained for later
-    same-response-id frames.
+    same-response-id frames. Tiered OpenAI models retain only their bounded
+    concrete tier decision so later or duplicate output-only frames derive the
+    same billable category.
     """
     usage_events: list[UsageEvent] = []
     observations: list[ModelUsageObservation] = []
@@ -169,13 +207,24 @@ def report_model_provider_usage_source(
     can_report_usage = _is_billable_model_provider(flow, run_id)
     can_report_observation = bool(run_id and is_model_provider_usage_observable(flow))
     if can_report_usage:
-        usage_events = _build_usage_events(
-            run_id,
-            source_id,
+        billing_tier = _source_model_usage_tier(
+            flow,
+            message_id,
             provider,
             source_usage,
-            USAGE_EVENT_NAMESPACE_MODEL,
         )
+        if billing_tier is None:
+            if has_positive_model_provider_usage(source_usage):
+                _log_model_usage_tier_unresolved(flow, run_id, provider)
+        else:
+            usage_events = _build_usage_events(
+                run_id,
+                source_id,
+                provider,
+                source_usage,
+                USAGE_EVENT_NAMESPACE_MODEL,
+                billing_tier,
+            )
     if can_report_observation:
         observations = _build_model_usage_observations(
             run_id,
@@ -209,6 +258,11 @@ def report_model_provider_usage_source(
             run_id,
             observations,
         )
+
+
+def release_model_provider_usage_tiers(flow: http.HTTPFlow) -> None:
+    """Release bounded WebSocket response tier decisions at terminal cleanup."""
+    flow.metadata.pop(metadata_keys.MODEL_PROVIDER_USAGE_TIERS, None)
 
 
 def _buffer_model_provider_usage_events(
@@ -352,6 +406,11 @@ def _build_model_provider_usage_events(
     events: list[UsageEvent] = []
     for source_id, usage in _iter_model_provider_usage_sources(flow):
         provider = _reported_model(flow, usage)
+        billing_tier = _model_usage_tier(provider, usage)
+        if billing_tier is None:
+            if has_positive_model_provider_usage(usage):
+                _log_model_usage_tier_unresolved(flow, run_id, provider)
+            continue
         events.extend(
             _build_usage_events(
                 run_id,
@@ -359,6 +418,7 @@ def _build_model_provider_usage_events(
                 provider,
                 usage,
                 namespace,
+                billing_tier,
             )
         )
     return events
@@ -448,24 +508,110 @@ def _build_usage_events(
     provider: str,
     usage: dict,
     namespace: uuid.UUID,
+    billing_tier: _ModelUsageTier,
 ) -> list[UsageEvent]:
     events: list[UsageEvent] = []
     for category in MODEL_USAGE_CATEGORIES:
         quantity = usage.get(category)
         if not _is_positive_int(quantity):
             continue
+        billable_category = (
+            _MODEL_USAGE_LONG_CONTEXT_CATEGORY_BY_BASE[category]
+            if billing_tier == _MODEL_USAGE_TIER_LONG_CONTEXT
+            else category
+        )
         event: UsageEvent = {
             "idempotencyKey": derive_usage_idempotency_key(
                 namespace,
-                (run_id, source_id, category),
+                (run_id, source_id, billable_category),
             ),
             "kind": MODEL_USAGE_KIND,
             "provider": provider,
-            "category": category,
+            "category": billable_category,
             "quantity": quantity,
         }
         events.append(event)
     return events
+
+
+def _source_model_usage_tier(
+    flow: http.HTTPFlow,
+    message_id: str,
+    provider: str,
+    usage: dict,
+) -> _ModelUsageTier | None:
+    billing_tier = _model_usage_tier(provider, usage)
+    if provider not in _OPENAI_LONG_CONTEXT_MODELS:
+        return billing_tier
+
+    tiers = _model_provider_usage_tiers(flow)
+    remembered_decision = tiers.get(message_id)
+    if remembered_decision is not None:
+        tier = remembered_decision.tier
+        if not remembered_decision.committed and billing_tier is not None:
+            tier = billing_tier
+        tiers[message_id] = _ModelUsageTierDecision(
+            tier=tier,
+            committed=remembered_decision.committed or has_positive_model_provider_usage(usage),
+        )
+        tiers.move_to_end(message_id)
+        return tier
+    if billing_tier is None:
+        return None
+
+    tiers[message_id] = _ModelUsageTierDecision(
+        tier=billing_tier,
+        committed=has_positive_model_provider_usage(usage),
+    )
+    if len(tiers) > _MODEL_PROVIDER_USAGE_TIER_SOURCE_LIMIT:
+        tiers.popitem(last=False)
+    return billing_tier
+
+
+def _model_provider_usage_tiers(
+    flow: http.HTTPFlow,
+) -> OrderedDict[str, _ModelUsageTierDecision]:
+    tiers = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE_TIERS)
+    if isinstance(tiers, OrderedDict):
+        return tiers
+    new_tiers: OrderedDict[str, _ModelUsageTierDecision] = OrderedDict()
+    flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_TIERS] = new_tiers
+    return new_tiers
+
+
+def _model_usage_tier(provider: str, usage: dict) -> _ModelUsageTier | None:
+    if provider not in _OPENAI_LONG_CONTEXT_MODELS:
+        return _MODEL_USAGE_TIER_BASE
+
+    input_tokens = usage.get(MODEL_USAGE_CATEGORY_INPUT)
+    if not _is_non_negative_int(input_tokens):
+        return None
+    total_input_tokens = input_tokens
+    for category in (
+        MODEL_USAGE_CATEGORY_CACHE_READ,
+        MODEL_USAGE_CATEGORY_CACHE_CREATION,
+    ):
+        quantity = usage.get(category)
+        if _is_non_negative_int(quantity):
+            total_input_tokens += quantity
+    if total_input_tokens >= _OPENAI_LONG_CONTEXT_MIN_INPUT_TOKENS:
+        return _MODEL_USAGE_TIER_LONG_CONTEXT
+    return _MODEL_USAGE_TIER_BASE
+
+
+def _log_model_usage_tier_unresolved(
+    flow: http.HTTPFlow,
+    run_id: str,
+    provider: str,
+) -> None:
+    log_usage_underbilling(
+        flow_metadata.proxy_log_path(flow.metadata),
+        "Cannot classify tiered model usage without an input partition",
+        "model_long_context_tier_unresolved",
+        "risk",
+        run_id=run_id,
+        provider=provider,
+    )
 
 
 def _reported_model(flow: http.HTTPFlow, usage: dict) -> str:
@@ -478,6 +624,10 @@ def _reported_model(flow: http.HTTPFlow, usage: dict) -> str:
 
 def _is_positive_int(value: object) -> TypeGuard[int]:
     return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def _is_non_negative_int(value: object) -> TypeGuard[int]:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
 
 
 def _positive_int_or_zero(value: object) -> int:

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -65,15 +65,13 @@ class _ModelUsageTierDecision:
     committed: bool
 
 
-_OPENAI_LONG_CONTEXT_MODELS = frozenset(
-    (
-        "gpt-5.5",
-        "gpt-5.6-sol",
-        "gpt-5.6-terra",
-        "gpt-5.6-luna",
-    )
-)
-_OPENAI_LONG_CONTEXT_MIN_INPUT_TOKENS = 272_001
+_MODEL_LONG_CONTEXT_MIN_INPUT_TOKENS = {
+    "gpt-5.5": 272_001,
+    "gpt-5.6-sol": 272_001,
+    "gpt-5.6-terra": 272_001,
+    "gpt-5.6-luna": 272_001,
+    "MiniMax-M3": 512_001,
+}
 _MODEL_USAGE_LONG_CONTEXT_CATEGORY_BY_BASE = {
     MODEL_USAGE_CATEGORY_INPUT: MODEL_USAGE_CATEGORY_INPUT_LONG_CONTEXT,
     MODEL_USAGE_CATEGORY_OUTPUT: MODEL_USAGE_CATEGORY_OUTPUT_LONG_CONTEXT,
@@ -541,7 +539,7 @@ def _source_model_usage_tier(
     usage: dict,
 ) -> _ModelUsageTier | None:
     billing_tier = _model_usage_tier(provider, usage)
-    if provider not in _OPENAI_LONG_CONTEXT_MODELS:
+    if provider not in _MODEL_LONG_CONTEXT_MIN_INPUT_TOKENS:
         return billing_tier
 
     tiers = _model_provider_usage_tiers(flow)
@@ -580,7 +578,8 @@ def _model_provider_usage_tiers(
 
 
 def _model_usage_tier(provider: str, usage: dict) -> _ModelUsageTier | None:
-    if provider not in _OPENAI_LONG_CONTEXT_MODELS:
+    min_input_tokens = _MODEL_LONG_CONTEXT_MIN_INPUT_TOKENS.get(provider)
+    if min_input_tokens is None:
         return _MODEL_USAGE_TIER_BASE
 
     input_tokens = usage.get(MODEL_USAGE_CATEGORY_INPUT)
@@ -594,7 +593,7 @@ def _model_usage_tier(provider: str, usage: dict) -> _ModelUsageTier | None:
         quantity = usage.get(category)
         if _is_non_negative_int(quantity):
             total_input_tokens += quantity
-    if total_input_tokens >= _OPENAI_LONG_CONTEXT_MIN_INPUT_TOKENS:
+    if total_input_tokens >= min_input_tokens:
         return _MODEL_USAGE_TIER_LONG_CONTEXT
     return _MODEL_USAGE_TIER_BASE
 

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -65,7 +65,7 @@ class _ModelUsageTierDecision:
     committed: bool
 
 
-_MODEL_LONG_CONTEXT_MIN_INPUT_TOKENS = {
+_MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS = {
     "gpt-5.5": 272_001,
     "gpt-5.6-sol": 272_001,
     "gpt-5.6-terra": 272_001,
@@ -194,9 +194,9 @@ def report_model_provider_usage_source(
     in a later frame. Callers can drop the source from flow metadata after this
     returns: observable flows carry the canonical ``MODEL_USAGE_PROVIDER``, so
     zero-usage source model hints do not need to be retained for later
-    same-response-id frames. Tiered OpenAI models retain only their bounded
-    concrete tier decision so later or duplicate output-only frames derive the
-    same billable category.
+    same-response-id frames. Tiered models retain only their bounded concrete
+    tier decision so later or duplicate output-only frames derive the same
+    billable category.
     """
     usage_events: list[UsageEvent] = []
     observations: list[ModelUsageObservation] = []
@@ -539,7 +539,7 @@ def _source_model_usage_tier(
     usage: dict,
 ) -> _ModelUsageTier | None:
     billing_tier = _model_usage_tier(provider, usage)
-    if provider not in _MODEL_LONG_CONTEXT_MIN_INPUT_TOKENS:
+    if provider not in _MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS:
         return billing_tier
 
     tiers = _model_provider_usage_tiers(flow)
@@ -578,7 +578,7 @@ def _model_provider_usage_tiers(
 
 
 def _model_usage_tier(provider: str, usage: dict) -> _ModelUsageTier | None:
-    min_input_tokens = _MODEL_LONG_CONTEXT_MIN_INPUT_TOKENS.get(provider)
+    min_input_tokens = _MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS.get(provider)
     if min_input_tokens is None:
         return _MODEL_USAGE_TIER_BASE
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py
@@ -70,10 +70,16 @@ class TestModelProviderJsonFallback:
     def test_openai_non_streaming_json_fallback(self, tmp_path, real_flow):
         """Legacy JSON fallback should use OpenAI Responses mapping."""
         provider_case = OPENAI_RESPONSES_CASE
-        cache_write_tokens = 15
+        input_tokens = 272_001
+        output_tokens = 20
+        cached_tokens = 70_000
+        cache_write_tokens = 2_001
         flow = model_provider_flow(real_flow, tmp_path, provider_case)
         body = standard_success_payload(
             provider_case,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cached_tokens=cached_tokens,
             cache_write_tokens=cache_write_tokens,
         )
         set_response_stream_buffer(flow, body)
@@ -89,6 +95,9 @@ class TestModelProviderJsonFallback:
         extracted = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]
         expected = expected_model_usage(
             provider_case,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cached_tokens=cached_tokens,
             cache_write_tokens=cache_write_tokens,
         )
         assert extracted["message_id"] == expected["message_id"]
@@ -100,10 +109,12 @@ class TestModelProviderJsonFallback:
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         assert len(events) == len(by_category)
-        assert by_category == expected_event_quantities(
-            provider_case,
-            cache_write_tokens=cache_write_tokens,
-        )
+        assert by_category == {
+            "tokens.input.long_context": 200_000,
+            "tokens.output.long_context": output_tokens,
+            "tokens.cache_read.long_context": cached_tokens,
+            "tokens.cache_creation.long_context": cache_write_tokens,
+        }
 
     def test_anthropic_json_fallback_parse_error_logs_proxy_warning(self, tmp_path, real_flow):
         """Legacy JSON fallback parse failures should be observable."""

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py
@@ -3,6 +3,7 @@
 import gzip
 import json
 import zlib
+from dataclasses import replace
 
 import brotli
 import pytest
@@ -69,7 +70,7 @@ class TestModelProviderJsonFallback:
 
     def test_openai_non_streaming_json_fallback(self, tmp_path, real_flow):
         """Legacy JSON fallback should use OpenAI Responses mapping."""
-        provider_case = OPENAI_RESPONSES_CASE
+        provider_case = replace(OPENAI_RESPONSES_CASE, model="gpt-5.6-sol")
         input_tokens = 272_001
         output_tokens = 20
         cached_tokens = 70_000

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -130,6 +130,32 @@ class TestModelProviderSseUsage:
             "tokens.cache_creation": 15,
         }
 
+    def test_full_pipeline_openai_sse_reports_long_context_items(self, tmp_path, real_flow):
+        flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(
+            b"event: response.completed\n"
+            b'data: {"response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":272001,"output_tokens":20,'
+            b'"input_tokens_details":{"cached_tokens":70000,'
+            b'"cache_write_tokens":2001}}}}\n\n'
+        )
+
+        webhook = self._run_response(flow)
+
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+            "tokens.input.long_context": 200_000,
+            "tokens.output.long_context": 20,
+            "tokens.cache_read.long_context": 70_000,
+            "tokens.cache_creation.long_context": 2_001,
+        }
+        assert compact_observation_quantities(webhook.model_usage_observation_events()) == {
+            "tokens.input": 200_000,
+            "tokens.output": 20,
+            "tokens.cache_read": 70_000,
+            "tokens.cache_creation": 2_001,
+        }
+
     def test_full_pipeline_openai_sse_reports_usage_with_oversized_type(self, tmp_path, real_flow):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         mitm_addon.responseheaders(flow)

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -156,6 +156,40 @@ class TestModelProviderSseUsage:
             "tokens.cache_creation": 2_001,
         }
 
+    def test_full_pipeline_minimax_sse_reports_long_context_items(self, tmp_path, real_flow):
+        flow = _model_provider_sse_flow(
+            tmp_path,
+            real_flow,
+            host="api.minimax.io",
+            original_url="https://api.minimax.io/anthropic/v1/messages",
+            firewall_name="model-provider:minimax-api-key",
+            model_usage_provider="MiniMax-M3",
+        )
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(
+            b"event: message_start\n"
+            b'data: {"type":"message_start","message":'
+            b'{"id":"msg_minimax_long_context","model":"MiniMax-M3",'
+            b'"usage":{"input_tokens":500000,"output_tokens":1,'
+            b'"cache_read_input_tokens":12001,"cache_creation_input_tokens":0}}}\n\n'
+            b"event: message_delta\n"
+            b'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},'
+            b'"usage":{"output_tokens":20}}\n\n'
+        )
+
+        webhook = self._run_response(flow)
+
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+            "tokens.input.long_context": 500_000,
+            "tokens.output.long_context": 20,
+            "tokens.cache_read.long_context": 12_001,
+        }
+        assert compact_observation_quantities(webhook.model_usage_observation_events()) == {
+            "tokens.input": 500_000,
+            "tokens.output": 20,
+            "tokens.cache_read": 12_001,
+        }
+
     def test_full_pipeline_openai_sse_reports_usage_with_oversized_type(self, tmp_path, real_flow):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         mitm_addon.responseheaders(flow)

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -45,7 +45,10 @@ def _model_provider_sse_flow(
 
 
 def _openai_responses_sse_flow(
-    tmp_path: Path, real_flow: Callable[..., http.HTTPFlow]
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    *,
+    model_usage_provider: str = "gpt-5.5",
 ) -> http.HTTPFlow:
     return _model_provider_sse_flow(
         tmp_path,
@@ -54,7 +57,7 @@ def _openai_responses_sse_flow(
         original_url="https://api.openai.com/v1/responses",
         firewall_name="model-provider:openai-api-key",
         cli_agent_type="codex",
-        model_usage_provider="gpt-5.5",
+        model_usage_provider=model_usage_provider,
     )
 
 
@@ -106,13 +109,17 @@ class TestModelProviderSseUsage:
 
     def test_full_pipeline_model_sse_finalizes_trailing_event(self, tmp_path, real_flow):
         """response() must flush a trailing SSE usage event before reporting."""
-        flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        flow = _openai_responses_sse_flow(
+            tmp_path,
+            real_flow,
+            model_usage_provider="gpt-5.6-sol",
+        )
         mitm_addon.responseheaders(flow)
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
         response_stream(flow)(
             b"event: response.completed\n"
-            b'data: {"response":{"model":"gpt-5.5",'
+            b'data: {"response":{"model":"gpt-5.6-sol",'
             b'"usage":{"input_tokens":50,"output_tokens":20,'
             b'"input_tokens_details":{"cached_tokens":10,'
             b'"cache_write_tokens":15}}}}'
@@ -131,11 +138,15 @@ class TestModelProviderSseUsage:
         }
 
     def test_full_pipeline_openai_sse_reports_long_context_items(self, tmp_path, real_flow):
-        flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        flow = _openai_responses_sse_flow(
+            tmp_path,
+            real_flow,
+            model_usage_provider="gpt-5.6-sol",
+        )
         mitm_addon.responseheaders(flow)
         response_stream(flow)(
             b"event: response.completed\n"
-            b'data: {"response":{"model":"gpt-5.5",'
+            b'data: {"response":{"model":"gpt-5.6-sol",'
             b'"usage":{"input_tokens":272001,"output_tokens":20,'
             b'"input_tokens_details":{"cached_tokens":70000,'
             b'"cache_write_tokens":2001}}}}\n\n'

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -91,10 +91,12 @@ class TestReportModelProviderUsage:
             ("gpt-5.6-sol", 272_001, ".long_context"),
             ("gpt-5.6-terra", 272_001, ".long_context"),
             ("gpt-5.6-luna", 272_001, ".long_context"),
+            ("MiniMax-M3", 512_000, ""),
+            ("MiniMax-M3", 512_001, ".long_context"),
             ("claude-opus-4-6", 300_000, ""),
         ],
     )
-    def test_classifies_openai_long_context_usage_at_normalized_boundary(
+    def test_classifies_long_context_usage_at_model_boundary(
         self,
         real_flow,
         usage_webhook_api,

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -83,6 +83,107 @@ class TestReportModelProviderUsage:
         for event in body["events"]:
             uuid.UUID(event["idempotencyKey"])
 
+    @pytest.mark.parametrize(
+        ("provider", "input_tokens", "expected_suffix"),
+        [
+            ("gpt-5.5", 272_000, ""),
+            ("gpt-5.5", 272_001, ".long_context"),
+            ("gpt-5.6-sol", 272_001, ".long_context"),
+            ("gpt-5.6-terra", 272_001, ".long_context"),
+            ("gpt-5.6-luna", 272_001, ".long_context"),
+            ("claude-opus-4-6", 300_000, ""),
+        ],
+    )
+    def test_classifies_openai_long_context_usage_at_normalized_boundary(
+        self,
+        real_flow,
+        usage_webhook_api,
+        provider,
+        input_tokens,
+        expected_suffix,
+    ):
+        flow = real_flow(with_response=False, host="api.openai.com")
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:openai-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = provider
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
+            "tokens.input": input_tokens,
+            "tokens.output": 7,
+        }
+
+        with usage_webhook_api() as webhook:
+            usage.report_model_provider_usage(flow, "run-abc-123")
+            usage.flush_usage_events(trigger="test")
+
+        by_category = {event["category"]: event["quantity"] for event in webhook.usage_events()}
+        assert by_category == {
+            f"tokens.input{expected_suffix}": input_tokens,
+            f"tokens.output{expected_suffix}": 7,
+        }
+
+    def test_cache_partitions_select_long_context_without_changing_observation(
+        self,
+        real_flow,
+        usage_webhook_api,
+    ):
+        flow = real_flow(with_response=False, host="api.openai.com")
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:openai-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.6-sol"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
+            "tokens.input": 200_000,
+            "tokens.output": 9,
+            "tokens.cache_read": 70_000,
+            "tokens.cache_creation": 2_001,
+        }
+
+        with usage_webhook_api() as webhook:
+            usage.report_model_provider_usage(flow, "run-abc-123")
+            usage.report_model_provider_usage_observation(flow, "run-abc-123")
+            usage.flush_usage_events(trigger="test")
+
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+            "tokens.input.long_context": 200_000,
+            "tokens.output.long_context": 9,
+            "tokens.cache_read.long_context": 70_000,
+            "tokens.cache_creation.long_context": 2_001,
+        }
+        assert compact_observation_quantities(webhook.model_usage_observation_events()) == {
+            "tokens.input": 200_000,
+            "tokens.output": 9,
+            "tokens.cache_read": 70_000,
+            "tokens.cache_creation": 2_001,
+        }
+
+    def test_aggregate_buffer_keeps_base_and_long_context_items_separate(
+        self,
+        real_flow,
+        usage_webhook_api,
+    ):
+        flows = []
+        for input_tokens in (10, 272_001):
+            flow = real_flow(with_response=False, host="api.openai.com")
+            flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:openai-api-key"
+            flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+            flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+            flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+            flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
+                "tokens.input": input_tokens,
+            }
+            flows.append(flow)
+
+        with usage_webhook_api() as webhook:
+            for flow in flows:
+                usage.report_model_provider_usage(flow, "run-abc-123")
+            usage.flush_usage_events(trigger="test")
+
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+            "tokens.input": 10,
+            "tokens.input.long_context": 272_001,
+        }
+
     def test_falls_back_to_response_model_then_unknown(self, real_flow, usage_webhook_api):
         """Provider falls back only when selected vm0 model metadata is absent."""
         flow = real_flow(with_response=False, host="api.anthropic.com")

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -579,6 +579,7 @@ class TestModelProviderWebSocketUsage:
         self, tmp_path, real_flow
     ):
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.6-sol"
         mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
@@ -588,7 +589,7 @@ class TestModelProviderWebSocketUsage:
                     "type": "response.completed",
                     "response": {
                         "id": "resp_ws_partition",
-                        "model": "gpt-5.5",
+                        "model": "gpt-5.6-sol",
                         "usage": {
                             "input_tokens": 300_000,
                             "output_tokens": 0,
@@ -602,7 +603,7 @@ class TestModelProviderWebSocketUsage:
                     "type": "response.done",
                     "response": {
                         "id": "resp_ws_partition",
-                        "model": "gpt-5.5",
+                        "model": "gpt-5.6-sol",
                         "usage": {
                             "input_tokens": 300_000,
                             "output_tokens": 40,

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -390,6 +390,191 @@ class TestModelProviderWebSocketUsage:
         _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
         _assert_usage_event_rows(webhook.model_usage_observation_events(), "model", expected_rows)
 
+    def test_model_websocket_late_output_reuses_long_context_tier_for_duplicates(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        webhook = self._run_websocket_messages_and_end(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_long_context",
+                        "model": "gpt-5.5",
+                        "usage": {"input_tokens": 272_001},
+                    },
+                }
+            ).encode(),
+            json.dumps(
+                {
+                    "type": "response.done",
+                    "response": {
+                        "id": "resp_ws_long_context",
+                        "model": "gpt-5.5",
+                        "usage": {"output_tokens": 12},
+                    },
+                }
+            ).encode(),
+            json.dumps(
+                {
+                    "type": "response.done",
+                    "response": {
+                        "id": "resp_ws_long_context",
+                        "model": "gpt-5.5",
+                        "usage": {"output_tokens": 7},
+                    },
+                }
+            ).encode(),
+        )
+
+        expected_billing_rows = [
+            ("gpt-5.5", "tokens.input.long_context", 272_001),
+            ("gpt-5.5", "tokens.output.long_context", 12),
+        ]
+        _assert_usage_event_rows(
+            webhook.usage_events(),
+            "provider",
+            expected_billing_rows,
+        )
+        _assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            [
+                ("gpt-5.5", "tokens.input", 272_001),
+                ("gpt-5.5", "tokens.output", 12),
+            ],
+        )
+        underbilling_entries = [
+            entry
+            for entry in read_jsonl_entries_after_flush(
+                Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+            )
+            if entry.get("type") == "usage_underbilling"
+        ]
+        assert underbilling_entries == []
+
+    def test_model_websocket_explicit_zero_input_selects_base_tier_for_late_output(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        webhook = self._run_websocket_messages_and_end(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_zero_input",
+                        "model": "gpt-5.5",
+                        "usage": {"input_tokens": 0},
+                    },
+                }
+            ).encode(),
+            json.dumps(
+                {
+                    "type": "response.done",
+                    "response": {
+                        "id": "resp_ws_zero_input",
+                        "model": "gpt-5.5",
+                        "usage": {"output_tokens": 12},
+                    },
+                }
+            ).encode(),
+        )
+
+        _assert_usage_event_rows(
+            webhook.usage_events(),
+            "provider",
+            [("gpt-5.5", "tokens.output", 12)],
+        )
+        _assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            [("gpt-5.5", "tokens.output", 12)],
+        )
+
+    def test_model_websocket_output_without_input_skips_unclassifiable_billing(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        webhook = self._run_websocket_messages_and_end(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.done",
+                    "response": {
+                        "id": "resp_ws_missing_input",
+                        "model": "gpt-5.5",
+                        "usage": {"output_tokens": 12},
+                    },
+                }
+            ).encode(),
+        )
+
+        assert webhook.usage_events() == []
+        _assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            [("gpt-5.5", "tokens.output", 12)],
+        )
+        [entry] = [
+            entry
+            for entry in read_jsonl_entries_after_flush(
+                Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+            )
+            if entry.get("type") == "usage_underbilling"
+        ]
+        assert entry["reason"] == "model_long_context_tier_unresolved"
+        assert entry["underbilling_class"] == "risk"
+        assert entry["run_id"] == "run-abc-123"
+        assert entry["provider"] == "gpt-5.5"
+
+    def test_model_websocket_tier_state_is_bounded_and_terminally_released(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        for index in range(101):
+            feed_websocket_server_message(
+                flow,
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": f"resp_ws_tier_{index}",
+                            "model": "gpt-5.5",
+                            "usage": {"input_tokens": 0},
+                        },
+                    }
+                ).encode(),
+            )
+
+        tiers = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_TIERS]
+        assert isinstance(tiers, dict)
+        assert len(tiers) == 100
+        assert "resp_ws_tier_0" not in tiers
+        assert tiers["resp_ws_tier_100"].tier == "base"
+        assert tiers["resp_ws_tier_100"].committed is False
+
+        mitm_addon.websocket_end(flow)
+
+        assert metadata_keys.MODEL_PROVIDER_USAGE_TIERS not in flow.metadata
+
     def test_model_websocket_late_same_id_snapshot_does_not_mix_input_partition(
         self, tmp_path, real_flow
     ):
@@ -405,9 +590,9 @@ class TestModelProviderWebSocketUsage:
                         "id": "resp_ws_partition",
                         "model": "gpt-5.5",
                         "usage": {
-                            "input_tokens": 100,
+                            "input_tokens": 300_000,
                             "output_tokens": 0,
-                            "input_tokens_details": {"cached_tokens": 20},
+                            "input_tokens_details": {"cached_tokens": 20_000},
                         },
                     },
                 }
@@ -419,11 +604,11 @@ class TestModelProviderWebSocketUsage:
                         "id": "resp_ws_partition",
                         "model": "gpt-5.5",
                         "usage": {
-                            "input_tokens": 100,
+                            "input_tokens": 300_000,
                             "output_tokens": 40,
                             "input_tokens_details": {
-                                "cached_tokens": 20,
-                                "cache_write_tokens": 30,
+                                "cached_tokens": 20_000,
+                                "cache_write_tokens": 30_000,
                             },
                         },
                     },
@@ -436,21 +621,23 @@ class TestModelProviderWebSocketUsage:
         assert len(events) == len(by_category) == 3
         assert len({event["idempotencyKey"] for event in events}) == 3
         assert by_category == {
-            "tokens.input": 80,
-            "tokens.output": 40,
-            "tokens.cache_read": 20,
+            "tokens.input.long_context": 280_000,
+            "tokens.output.long_context": 40,
+            "tokens.cache_read.long_context": 20_000,
         }
         observation_events = webhook.model_usage_observation_events()
         observations_by_category = compact_observation_quantities(observation_events)
         assert len(observation_events) == 2
         assert len({event["idempotencyKey"] for event in observation_events}) == 2
-        assert observations_by_category == by_category
+        assert observations_by_category == {
+            "tokens.input": 280_000,
+            "tokens.output": 40,
+            "tokens.cache_read": 20_000,
+        }
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
         assert model_provider_usage_sources(flow) == {}
 
-    def test_model_websocket_zero_frame_model_is_used_by_later_positive_frame(
-        self, tmp_path, real_flow
-    ):
+    def test_model_websocket_zero_frame_does_not_commit_base_tier(self, tmp_path, real_flow):
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
 
@@ -471,7 +658,7 @@ class TestModelProviderWebSocketUsage:
                     "type": "response.done",
                     "response": {
                         "id": "resp_ws_1",
-                        "usage": {"input_tokens": 20, "output_tokens": 12},
+                        "usage": {"input_tokens": 272_001, "output_tokens": 12},
                     },
                 }
             ).encode(),
@@ -479,11 +666,18 @@ class TestModelProviderWebSocketUsage:
 
         assert model_provider_usage_sources(flow) == {}
         expected_rows = [
-            ("gpt-5.5", "tokens.input", 20),
-            ("gpt-5.5", "tokens.output", 12),
+            ("gpt-5.5", "tokens.input.long_context", 272_001),
+            ("gpt-5.5", "tokens.output.long_context", 12),
         ]
         _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
-        _assert_usage_event_rows(webhook.model_usage_observation_events(), "model", expected_rows)
+        _assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            [
+                ("gpt-5.5", "tokens.input", 272_001),
+                ("gpt-5.5", "tokens.output", 12),
+            ],
+        )
 
     def test_model_websocket_zero_frame_without_model_releases_source(self, tmp_path, real_flow):
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)

--- a/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
@@ -41,6 +41,7 @@ class TestUsageReportingIdempotency:
         )
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "model": "gpt-5.5",
+            "tokens.input": 0,
             "tokens.output": 20,
         }
         body = b'{"id":"resp_1","usage":{"input_tokens":'
@@ -82,7 +83,10 @@ class TestUsageReportingIdempotency:
             firewall_name="model-provider:openai-api-key",
             cli_agent_type="codex",
         )
-        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {"model": "gpt-5.5"}
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
+            "model": "gpt-5.5",
+            "tokens.input": 0,
+        }
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),

--- a/turbo/apps/api/src/scripts/dev-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-seed.ts
@@ -117,12 +117,41 @@ const GPT_5_6_SOL_PRICING: readonly UsagePricingRow[] = [
   ["tokens.output", usd(30), 1_000_000],
 ];
 
-const GPT_5_6_LUNA_PRICING: readonly UsagePricingRow[] = [
-  ["tokens.input", usd(1), 1_000_000],
-  ["tokens.cache_read", usd(0.1), 1_000_000],
-  ["tokens.cache_creation", usd(1.25), 1_000_000],
-  ["tokens.output", usd(6), 1_000_000],
+const GPT_5_6_TERRA_PRICING: readonly UsagePricingRow[] = [
+  ["tokens.input", usd(2), 1_000_000],
+  ["tokens.cache_read", usd(0.2), 1_000_000],
+  ["tokens.cache_creation", usd(2.5), 1_000_000],
+  ["tokens.output", usd(12), 1_000_000],
 ];
+
+const GPT_5_6_LUNA_PRICING: readonly UsagePricingRow[] = [
+  ["tokens.input", usd(0.2), 1_000_000],
+  ["tokens.cache_read", usd(0.02), 1_000_000],
+  ["tokens.cache_creation", usd(0.25), 1_000_000],
+  ["tokens.output", usd(1.2), 1_000_000],
+];
+
+const GPT_5_5_PRICING: readonly UsagePricingRow[] = [
+  ["tokens.input", usd(5), 1_000_000],
+  ["tokens.cache_read", usd(0.5), 1_000_000],
+  ["tokens.output", usd(30), 1_000_000],
+];
+
+function withOpenAiLongContextPricing(
+  rows: readonly UsagePricingRow[],
+): readonly UsagePricingRow[] {
+  return [
+    ...rows,
+    ...rows.map(([category, unitPrice, unitSize]) => {
+      const multiplier = category === "tokens.output" ? 1.5 : 2;
+      return [
+        `${category}.long_context`,
+        unitPrice * multiplier,
+        unitSize,
+      ] as const;
+    }),
+  ];
+}
 
 function buildSeedSkillValues(
   names: readonly string[],
@@ -403,24 +432,28 @@ const USAGE_PRICING: readonly (typeof usagePricing.$inferInsert)[] = [
     ["tokens.cache_read", usd(0.145), 1_000_000],
     ["tokens.cache_creation", 0, 1_000_000],
   ]),
-  // OpenAI API pricing retrieved 2026-05-06 from:
-  // https://openai.com/api/pricing/
+  // OpenAI API pricing retrieved 2026-07-31 from:
   // https://developers.openai.com/api/docs/pricing
-  // GPT-5.6 preview pricing retrieved 2026-07-09 from:
-  // https://openai.com/index/previewing-gpt-5-6-sol/
-  ...usageGroup("model", "gpt-5.6-sol", GPT_5_6_SOL_PRICING),
-  ...usageGroup("model", "gpt-5.6-terra", [
-    ["tokens.input", usd(2.5), 1_000_000],
-    ["tokens.cache_read", usd(0.25), 1_000_000],
-    ["tokens.cache_creation", usd(3.125), 1_000_000],
-    ["tokens.output", usd(15), 1_000_000],
-  ]),
-  ...usageGroup("model", "gpt-5.6-luna", GPT_5_6_LUNA_PRICING),
-  ...usageGroup("model", "gpt-5.5", [
-    ["tokens.input", usd(5), 1_000_000],
-    ["tokens.cache_read", usd(0.5), 1_000_000],
-    ["tokens.output", usd(30), 1_000_000],
-  ]),
+  ...usageGroup(
+    "model",
+    "gpt-5.6-sol",
+    withOpenAiLongContextPricing(GPT_5_6_SOL_PRICING),
+  ),
+  ...usageGroup(
+    "model",
+    "gpt-5.6-terra",
+    withOpenAiLongContextPricing(GPT_5_6_TERRA_PRICING),
+  ),
+  ...usageGroup(
+    "model",
+    "gpt-5.6-luna",
+    withOpenAiLongContextPricing(GPT_5_6_LUNA_PRICING),
+  ),
+  ...usageGroup(
+    "model",
+    "gpt-5.5",
+    withOpenAiLongContextPricing(GPT_5_5_PRICING),
+  ),
   // OpenRouter-backed edit helpers. Pricing retrieved 2026-07-10 from:
   // https://developers.openai.com/api/docs/models/gpt-4.1-mini
   // https://ai.google.dev/gemini-api/docs/pricing

--- a/turbo/apps/api/src/scripts/dev-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-seed.ts
@@ -137,13 +137,23 @@ const GPT_5_5_PRICING: readonly UsagePricingRow[] = [
   ["tokens.output", usd(30), 1_000_000],
 ];
 
-function withOpenAiLongContextPricing(
+const MINIMAX_M3_PRICING: readonly UsagePricingRow[] = [
+  ["tokens.input", usd(0.3), 1_000_000],
+  ["tokens.cache_read", usd(0.06), 1_000_000],
+  ["tokens.cache_creation", 0, 1_000_000],
+  ["tokens.output", usd(1.2), 1_000_000],
+];
+
+function withLongContextPricing(
   rows: readonly UsagePricingRow[],
+  inputFamilyMultiplier: number,
+  outputMultiplier: number,
 ): readonly UsagePricingRow[] {
   return [
     ...rows,
     ...rows.map(([category, unitPrice, unitSize]) => {
-      const multiplier = category === "tokens.output" ? 1.5 : 2;
+      const multiplier =
+        category === "tokens.output" ? outputMultiplier : inputFamilyMultiplier;
       return [
         `${category}.long_context`,
         unitPrice * multiplier,
@@ -420,12 +430,13 @@ const USAGE_PRICING: readonly (typeof usagePricing.$inferInsert)[] = [
     ["tokens.cache_read", usd(0.021), 1_000_000],
     ["tokens.cache_creation", 0, 1_000_000],
   ]),
-  ...usageGroup("model", "MiniMax-M3", [
-    ["tokens.input", usd(0.6), 1_000_000],
-    ["tokens.output", usd(2.4), 1_000_000],
-    ["tokens.cache_read", usd(0.12), 1_000_000],
-    ["tokens.cache_creation", 0, 1_000_000],
-  ]),
+  // MiniMax API pricing retrieved 2026-07-31 from:
+  // https://platform.minimax.io/subscribe/token-plan?tab=api-enterprise
+  ...usageGroup(
+    "model",
+    "MiniMax-M3",
+    withLongContextPricing(MINIMAX_M3_PRICING, 2, 2),
+  ),
   ...usageGroup("model", "deepseek-v4-pro", [
     ["tokens.input", usd(1.74), 1_000_000],
     ["tokens.output", usd(3.48), 1_000_000],
@@ -437,22 +448,22 @@ const USAGE_PRICING: readonly (typeof usagePricing.$inferInsert)[] = [
   ...usageGroup(
     "model",
     "gpt-5.6-sol",
-    withOpenAiLongContextPricing(GPT_5_6_SOL_PRICING),
+    withLongContextPricing(GPT_5_6_SOL_PRICING, 2, 1.5),
   ),
   ...usageGroup(
     "model",
     "gpt-5.6-terra",
-    withOpenAiLongContextPricing(GPT_5_6_TERRA_PRICING),
+    withLongContextPricing(GPT_5_6_TERRA_PRICING, 2, 1.5),
   ),
   ...usageGroup(
     "model",
     "gpt-5.6-luna",
-    withOpenAiLongContextPricing(GPT_5_6_LUNA_PRICING),
+    withLongContextPricing(GPT_5_6_LUNA_PRICING, 2, 1.5),
   ),
   ...usageGroup(
     "model",
     "gpt-5.5",
-    withOpenAiLongContextPricing(GPT_5_5_PRICING),
+    withLongContextPricing(GPT_5_5_PRICING, 2, 1.5),
   ),
   // OpenRouter-backed edit helpers. Pricing retrieved 2026-07-10 from:
   // https://developers.openai.com/api/docs/models/gpt-4.1-mini

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
@@ -638,12 +638,27 @@ describe("GET /api/zero/usage/insight", () => {
     await reportRunUsage(actor, runId, [
       { kind: "model", category: "tokens.input", quantity: 100, credits: 10 },
       { kind: "model", category: "tokens.output", quantity: 50, credits: 0 },
-      { kind: "model", category: "tokens.input", quantity: 30, credits: 3 },
-      { kind: "model", category: "tokens.output", quantity: 20, credits: 2 },
-      { kind: "model", category: "tokens.cache_read", quantity: 5, credits: 1 },
       {
         kind: "model",
-        category: "tokens.cache_creation",
+        category: "tokens.input.long_context",
+        quantity: 30,
+        credits: 3,
+      },
+      {
+        kind: "model",
+        category: "tokens.output.long_context",
+        quantity: 20,
+        credits: 2,
+      },
+      {
+        kind: "model",
+        category: "tokens.cache_read.long_context",
+        quantity: 5,
+        credits: 1,
+      },
+      {
+        kind: "model",
+        category: "tokens.cache_creation.long_context",
         quantity: 10,
         credits: 4,
       },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -45,7 +45,20 @@ const GOOGLE_GEOCODING_URL =
 const MODEL_TOKEN_CATEGORIES = {
   input: "tokens.input",
   output: "tokens.output",
+  inputLongContext: "tokens.input.long_context",
+  outputLongContext: "tokens.output.long_context",
+  cacheReadLongContext: "tokens.cache_read.long_context",
+  cacheCreationLongContext: "tokens.cache_creation.long_context",
 } as const;
+
+interface ModelTokenCounts {
+  readonly input?: number;
+  readonly output?: number;
+  readonly inputLongContext?: number;
+  readonly outputLongContext?: number;
+  readonly cacheReadLongContext?: number;
+  readonly cacheCreationLongContext?: number;
+}
 
 function authHeaders() {
   return { authorization: "Bearer clerk-session" };
@@ -255,12 +268,10 @@ async function recordModelUsage(
   actor: ApiTestUser,
   runId: string,
   model: string,
-  tokens: { readonly input?: number; readonly output?: number },
+  tokens: ModelTokenCounts,
 ): Promise<void> {
   const events = (
-    Object.keys(
-      MODEL_TOKEN_CATEGORIES,
-    ) as (keyof typeof MODEL_TOKEN_CATEGORIES)[]
+    Object.keys(MODEL_TOKEN_CATEGORIES) as (keyof ModelTokenCounts)[]
   ).flatMap((key) => {
     const quantity = tokens[key];
     if (!quantity) {
@@ -734,8 +745,10 @@ describe("GET /api/zero/usage/record", () => {
       createdAt: createdAt(10),
     });
     await recordModelUsage(fixture.actor, webhookRun.runId, model, {
-      input: 25,
-      output: 5,
+      inputLongContext: 25,
+      outputLongContext: 5,
+      cacheReadLongContext: 7,
+      cacheCreationLongContext: 3,
     });
 
     await billing.processOrgUsageEvents(fixture.actor);
@@ -756,8 +769,8 @@ describe("GET /api/zero/usage/record", () => {
       threadId: null,
       runId: webhookRun.runId,
       title: "Webhook triggered run",
-      credits: 30,
-      tokens: 30,
+      credits: 40,
+      tokens: 40,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-runs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-runs.test.ts
@@ -35,6 +35,10 @@ const MODEL_TOKEN_CATEGORIES = {
   output: "tokens.output",
   cacheRead: "tokens.cache_read",
   cacheCreation: "tokens.cache_creation",
+  inputLongContext: "tokens.input.long_context",
+  outputLongContext: "tokens.output.long_context",
+  cacheReadLongContext: "tokens.cache_read.long_context",
+  cacheCreationLongContext: "tokens.cache_creation.long_context",
 } as const;
 
 interface ModelTokenCounts {
@@ -42,6 +46,10 @@ interface ModelTokenCounts {
   readonly output?: number;
   readonly cacheRead?: number;
   readonly cacheCreation?: number;
+  readonly inputLongContext?: number;
+  readonly outputLongContext?: number;
+  readonly cacheReadLongContext?: number;
+  readonly cacheCreationLongContext?: number;
 }
 
 function authHeaders() {
@@ -329,8 +337,10 @@ describe("GET /api/zero/usage/runs", () => {
       createdAt: createdAt(1),
     });
     await recordModelUsage(actor, included.runId, model, {
-      input: 123,
-      output: 45,
+      inputLongContext: 123,
+      outputLongContext: 45,
+      cacheReadLongContext: 11,
+      cacheCreationLongContext: 7,
     });
     await recordModelUsage(actor, excluded.runId, model, {
       input: 999,
@@ -360,7 +370,8 @@ describe("GET /api/zero/usage/runs", () => {
       model,
       inputTokens: 123,
       outputTokens: 45,
-      creditsCharged: 168,
+      cacheTokens: 18,
+      creditsCharged: 186,
     });
   });
 
@@ -523,7 +534,9 @@ describe("GET /api/zero/usage/runs", () => {
     await seedModelPricing(model);
     for (const member of members) {
       const run = await createBillableRun(member);
-      await recordModelUsage(member, run.runId, model, { output: 10 });
+      await recordModelUsage(member, run.runId, model, {
+        outputLongContext: 10,
+      });
     }
     await billing.processOrgUsageEvents(actor);
     mockClerkUserLookup();
@@ -533,16 +546,22 @@ describe("GET /api/zero/usage/runs", () => {
       tz: "UTC",
     });
 
-    expect(
-      response.body.members.map((member) => {
-        return member.userId;
-      }),
-    ).toStrictEqual(
+    expect(response.body.members).toStrictEqual(
       members
         .map((member) => {
           return member.userId;
         })
-        .sort(),
+        .sort()
+        .map((userId) => {
+          return expect.objectContaining({
+            userId,
+            inputTokens: 0,
+            outputTokens: 10,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            creditsCharged: 10,
+          });
+        }),
     );
   });
 

--- a/turbo/apps/api/src/signals/services/model-token-categories.ts
+++ b/turbo/apps/api/src/signals/services/model-token-categories.ts
@@ -1,0 +1,46 @@
+const TOKEN_CATEGORY_INPUT = "tokens.input";
+const TOKEN_CATEGORY_OUTPUT = "tokens.output";
+const TOKEN_CATEGORY_CACHE_READ = "tokens.cache_read";
+const TOKEN_CATEGORY_CACHE_CREATION = "tokens.cache_creation";
+const TOKEN_CATEGORY_INPUT_LONG_CONTEXT = "tokens.input.long_context";
+const TOKEN_CATEGORY_OUTPUT_LONG_CONTEXT = "tokens.output.long_context";
+const TOKEN_CATEGORY_CACHE_READ_LONG_CONTEXT = "tokens.cache_read.long_context";
+const TOKEN_CATEGORY_CACHE_CREATION_LONG_CONTEXT =
+  "tokens.cache_creation.long_context";
+
+export const MODEL_TOKEN_CATEGORIES = [
+  TOKEN_CATEGORY_INPUT,
+  TOKEN_CATEGORY_OUTPUT,
+  TOKEN_CATEGORY_CACHE_READ,
+  TOKEN_CATEGORY_CACHE_CREATION,
+  TOKEN_CATEGORY_INPUT_LONG_CONTEXT,
+  TOKEN_CATEGORY_OUTPUT_LONG_CONTEXT,
+  TOKEN_CATEGORY_CACHE_READ_LONG_CONTEXT,
+  TOKEN_CATEGORY_CACHE_CREATION_LONG_CONTEXT,
+] as const;
+
+export const MODEL_INPUT_TOKEN_CATEGORIES = [
+  TOKEN_CATEGORY_INPUT,
+  TOKEN_CATEGORY_INPUT_LONG_CONTEXT,
+  "tokens.input.text",
+  "tokens.input.audio",
+] as const;
+
+export const MODEL_OUTPUT_TOKEN_CATEGORIES = [
+  TOKEN_CATEGORY_OUTPUT,
+  TOKEN_CATEGORY_OUTPUT_LONG_CONTEXT,
+  "tokens.output.text",
+  "tokens.output.audio",
+] as const;
+
+export const MODEL_CACHE_READ_TOKEN_CATEGORIES = [
+  TOKEN_CATEGORY_CACHE_READ,
+  TOKEN_CATEGORY_CACHE_READ_LONG_CONTEXT,
+  "tokens.input.cached_text",
+  "tokens.input.cached_audio",
+] as const;
+
+export const MODEL_CACHE_CREATION_TOKEN_CATEGORIES = [
+  TOKEN_CATEGORY_CACHE_CREATION,
+  TOKEN_CATEGORY_CACHE_CREATION_LONG_CONTEXT,
+] as const;

--- a/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
@@ -44,14 +44,9 @@ import {
   type FinalizedUsageRelation,
 } from "./finalized-usage-relation";
 import { normalizeFinalizedUsagePeriod } from "./finalized-usage-time";
+import { MODEL_TOKEN_CATEGORIES } from "./model-token-categories";
 
 const MODEL_USAGE_KIND = "model";
-const MODEL_TOKEN_CATEGORIES = [
-  "tokens.input",
-  "tokens.output",
-  "tokens.cache_read",
-  "tokens.cache_creation",
-] as const;
 const CHANNEL_SOURCES = ["email", "slack"] as const;
 const channelSourceDecoder = zodEnumDriverValueDecoder(z.enum(CHANNEL_SOURCES));
 

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -42,6 +42,7 @@ import {
   type FinalizedUsageRelation,
 } from "./finalized-usage-relation";
 import { normalizeFinalizedUsagePeriod } from "./finalized-usage-time";
+import { MODEL_TOKEN_CATEGORIES } from "./model-token-categories";
 import { getOrgBillingPeriod$ } from "./zero-org-billing-period.service";
 import { resolveEmails } from "./zero-usage.service";
 import {
@@ -51,12 +52,6 @@ import {
 } from "./usage-period";
 
 const MODEL_USAGE_KIND = "model";
-const MODEL_TOKEN_CATEGORIES = [
-  "tokens.input",
-  "tokens.output",
-  "tokens.cache_read",
-  "tokens.cache_creation",
-] as const;
 const THREADED_SOURCES = ["chat", "automation"] as const;
 const USAGE_RECORD_KINDS = ["model", "image", "video", "connector"] as const;
 const PASSTHROUGH_TRIGGER_SOURCES = [

--- a/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
@@ -20,38 +20,17 @@ import {
   type FinalizedUsageRelation,
 } from "./finalized-usage-relation";
 import { normalizeFinalizedUsagePeriod } from "./finalized-usage-time";
+import {
+  MODEL_CACHE_CREATION_TOKEN_CATEGORIES,
+  MODEL_CACHE_READ_TOKEN_CATEGORIES,
+  MODEL_INPUT_TOKEN_CATEGORIES,
+  MODEL_OUTPUT_TOKEN_CATEGORIES,
+} from "./model-token-categories";
 
 const MODEL_USAGE_KIND = "model";
-const TOKEN_CATEGORY_INPUT = "tokens.input";
-const TOKEN_CATEGORY_OUTPUT = "tokens.output";
-const TOKEN_CATEGORY_CACHE_READ = "tokens.cache_read";
-const TOKEN_CATEGORY_CACHE_CREATION = "tokens.cache_creation";
-
-const INPUT_TOKEN_CATEGORIES = [
-  TOKEN_CATEGORY_INPUT,
-  "tokens.input.text",
-  "tokens.input.audio",
-] as const;
-
-const OUTPUT_TOKEN_CATEGORIES = [
-  TOKEN_CATEGORY_OUTPUT,
-  "tokens.output.text",
-  "tokens.output.audio",
-] as const;
-
-const CACHE_READ_TOKEN_CATEGORIES = [
-  TOKEN_CATEGORY_CACHE_READ,
-  "tokens.input.cached_text",
-  "tokens.input.cached_audio",
-] as const;
-
-const CACHE_CREATION_TOKEN_CATEGORIES = [
-  TOKEN_CATEGORY_CACHE_CREATION,
-] as const;
-
 const ALL_CACHE_TOKEN_CATEGORIES = [
-  ...CACHE_READ_TOKEN_CATEGORIES,
-  ...CACHE_CREATION_TOKEN_CATEGORIES,
+  ...MODEL_CACHE_READ_TOKEN_CATEGORIES,
+  ...MODEL_CACHE_CREATION_TOKEN_CATEGORIES,
 ] as const;
 const nullableTextDecoder = nullableDriverValueDecoder(pgTextDecoder);
 
@@ -93,22 +72,22 @@ export async function getMemberUsageTotals(
     userId: usage.userId,
     inputTokens: finalizedUsageTokenSum(
       usage,
-      INPUT_TOKEN_CATEGORIES,
+      MODEL_INPUT_TOKEN_CATEGORIES,
       "input_tokens",
     ),
     outputTokens: finalizedUsageTokenSum(
       usage,
-      OUTPUT_TOKEN_CATEGORIES,
+      MODEL_OUTPUT_TOKEN_CATEGORIES,
       "output_tokens",
     ),
     cacheReadInputTokens: finalizedUsageTokenSum(
       usage,
-      CACHE_READ_TOKEN_CATEGORIES,
+      MODEL_CACHE_READ_TOKEN_CATEGORIES,
       "cache_read_input_tokens",
     ),
     cacheCreationInputTokens: finalizedUsageTokenSum(
       usage,
-      CACHE_CREATION_TOKEN_CATEGORIES,
+      MODEL_CACHE_CREATION_TOKEN_CATEGORIES,
       "cache_creation_input_tokens",
     ),
     creditsCharged: usageCreditsSum(usage, "credits_charged"),
@@ -127,22 +106,22 @@ export function buildFinalizedUsageRunTotalsSubquery(db: Db, orgId: string) {
     runId: usage.runId,
     inputTokens: finalizedUsageTokenSum(
       usage,
-      INPUT_TOKEN_CATEGORIES,
+      MODEL_INPUT_TOKEN_CATEGORIES,
       "input_tokens_sum",
     ),
     outputTokens: finalizedUsageTokenSum(
       usage,
-      OUTPUT_TOKEN_CATEGORIES,
+      MODEL_OUTPUT_TOKEN_CATEGORIES,
       "output_tokens_sum",
     ),
     cacheReadInputTokens: finalizedUsageTokenSum(
       usage,
-      CACHE_READ_TOKEN_CATEGORIES,
+      MODEL_CACHE_READ_TOKEN_CATEGORIES,
       "cache_read_input_tokens_sum",
     ),
     cacheCreationInputTokens: finalizedUsageTokenSum(
       usage,
-      CACHE_CREATION_TOKEN_CATEGORIES,
+      MODEL_CACHE_CREATION_TOKEN_CATEGORIES,
       "cache_creation_input_tokens_sum",
     ),
     cacheTokens: finalizedUsageTokenSum(


### PR DESCRIPTION
## Summary

- classify managed GPT-5.5, GPT-5.6 Sol/Terra/Luna, and MiniMax-M3 usage into concrete base or `.long_context` billing items at each model's normalized-input boundary
- preserve one tier across split and duplicate response frames with bounded runner-local state while leaving raw model usage observations unchanged
- include long-context items in API token summaries and add current base and long-context prices to development seed data

## Model rules

| Models | Base tier | Long-context tier |
| --- | ---: | ---: |
| `gpt-5.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` | total input <= 272,000 | total input >= 272,001 |
| `MiniMax-M3` | total input <= 512,000 | total input >= 512,001 |

Normalized total input is ordinary input plus cache-read and cache-creation
tokens. Models absent from the runner's threshold table continue emitting only
ordinary categories.

## Scope

- no Runner/API payload field or database schema change
- no production pricing mutation or migration
- development seed uses OpenAI's current standard prices and MiniMax-M3's currently billed permanent-discount prices
- flat-priced models and raw `model_usage_observation` semantics remain unchanged

## Deployment compatibility

The API accepts both existing and long-context categories, so it can deploy
before the runner. Matching production `usage_pricing` rows for every OpenAI
and MiniMax-M3 long-context category must be installed and verified before
publishing a runner containing this change, and must remain available while
older runners drain or rollback remains possible.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,511 passed)
- `uv run --no-sync python -m pytest tests/test_model_provider_json_fallback.py tests/test_model_provider_sse_usage.py tests/test_model_provider_usage.py` (126 passed after the JSON/SSE test-realism review fix)
- `uv run --no-sync python -m pytest tests/test_model_provider_websocket_usage.py -k 'late_same_id_snapshot_does_not_mix_input_partition'` (1 passed after the WebSocket test-realism review fix)
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/scripts/__tests__/dev-seed.test.ts src/signals/routes/__tests__/zero-usage-record.test.ts src/signals/routes/__tests__/zero-usage-insight.test.ts src/signals/routes/__tests__/zero-usage-runs.test.ts` (54 passed)
- `pnpm -F api db:dev-seed`
- queried seeded MiniMax-M3 rows and verified all 8 base/long-context categories and prices

Closes #24206
