### PR TITLE
refactor(connectors): use slug catalog compatibility evaluations

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -2032,6 +2032,13 @@ describe("connector catalog valid lifecycle", () => {
     serveObjects(catalogObjects([compatibilityRelease], compatibilityRelease));
     await syncCatalog();
     await invalidateApiTestConnectorCatalogCompatibility();
+    const corruptedEvaluations =
+      await readApiTestConnectorCatalogCompatibilityEvaluations();
+    expect(corruptedEvaluations).toHaveLength(2);
+    const retainedLegacy = corruptedEvaluations.find(({ capabilityDigest }) => {
+      return capabilityDigest === EXPECTED_LEGACY_CAPABILITY_DIGEST;
+    });
+    expect(Array.isArray(retainedLegacy?.payload)).toBeTruthy();
     const compatibilityResponse = await accept(
       setupApp({ context })(zeroConnectorCatalogContract).list({
         headers: { authorization: "Bearer clerk-session" },
@@ -2047,6 +2054,12 @@ describe("connector catalog valid lifecycle", () => {
     serveObjects(catalogObjects([missingRelease], missingRelease));
     await syncCatalog();
     await deleteApiTestConnectorCatalogCompatibility();
+    const remainingEvaluations =
+      await readApiTestConnectorCatalogCompatibilityEvaluations();
+    expect(remainingEvaluations).toHaveLength(1);
+    expect(remainingEvaluations[0]?.capabilityDigest).toBe(
+      EXPECTED_LEGACY_CAPABILITY_DIGEST,
+    );
     const missingResponse = await accept(
       setupApp({ context })(zeroConnectorCatalogContract).list({
         headers: { authorization: "Bearer clerk-session" },
@@ -5037,7 +5050,7 @@ describe("connector catalog executable compatibility", () => {
     );
     expect(canonical.capabilityDigest).not.toBe(legacy.capabilityDigest);
     expect(synced.body.filtering).toStrictEqual({
-      capabilityDigest: legacy.capabilityDigest,
+      capabilityDigest: canonical.capabilityDigest,
       evaluatedAt: FIRST_SYNC_TIME,
       stale: false,
       filteredAuthMethods: [],
@@ -5125,7 +5138,7 @@ describe("connector catalog executable compatibility", () => {
     );
   });
 
-  it("reconciles a missing canonical evaluation without switching readers", async () => {
+  it("fails closed and reconciles a missing canonical evaluation", async () => {
     configureSource();
     mockApiTestConnectorProviderConfiguration();
     const release = buildRelease({
@@ -5140,6 +5153,20 @@ describe("connector catalog executable compatibility", () => {
     const [legacy] =
       await readApiTestConnectorCatalogCompatibilityEvaluations();
     expect(legacy?.capabilityDigest).toBe(EXPECTED_LEGACY_CAPABILITY_DIGEST);
+    expect(legacy?.payload).toStrictEqual([]);
+
+    const stale = await readStatus();
+    expect(stale.body.filtering).toStrictEqual({
+      capabilityDigest: EXPECTED_CANONICAL_CAPABILITY_DIGEST,
+      evaluatedAt: null,
+      stale: true,
+      filteredAuthMethods: [],
+    });
+    zeroMocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+    const headers = { authorization: "Bearer clerk-session" };
+    const catalogClient = setupApp({ context })(zeroConnectorCatalogContract);
+    const unavailable = await accept(catalogClient.list({ headers }), [503]);
+    expect(unavailable.body.error.code).toBe("PROVIDER_UNAVAILABLE");
 
     mockNow(new Date("2026-07-31T08:01:00.000Z"));
     const reconciled = await syncCatalog();
@@ -5148,10 +5175,19 @@ describe("connector catalog executable compatibility", () => {
 
     expect(reconciled.body.outcome).toBe("unchanged");
     expect(reconciled.body.filtering.capabilityDigest).toBe(
-      EXPECTED_LEGACY_CAPABILITY_DIGEST,
+      EXPECTED_CANONICAL_CAPABILITY_DIGEST,
     );
     expect(evaluations).toHaveLength(2);
-    requireLegacyAndCanonicalEvaluations(evaluations);
+    const repaired = requireLegacyAndCanonicalEvaluations(evaluations);
+    expect(repaired.legacy.payload).toStrictEqual([]);
+    expect(repaired.canonical.payload).toStrictEqual({
+      filteredAuthMethods: [],
+    });
+    expect(
+      (await accept(catalogClient.list({ headers }), [200])).body,
+    ).toMatchObject({
+      connectors: [expect.objectContaining({ slug: release.connectorSlug })],
+    });
   });
 
   it("replaces both evaluation formats with a new catalog", async () => {
@@ -5188,7 +5224,13 @@ describe("connector catalog executable compatibility", () => {
         return evaluation.catalogDigest === firstCatalogDigest;
       }),
     ).toBeFalsy();
-    requireLegacyAndCanonicalEvaluations(replacementEvaluations);
+    const replacement = requireLegacyAndCanonicalEvaluations(
+      replacementEvaluations,
+    );
+    expect(replacement.legacy.payload).toStrictEqual([]);
+    expect(replacement.canonical.payload).toStrictEqual({
+      filteredAuthMethods: [],
+    });
   });
 
   it("repairs missing and preserves newer catalog validation authorities", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -114,6 +114,7 @@ export async function mutateRunnerJobConnectorPermissionBaseline(
   mode:
     | "remove"
     | "malformed"
+    | "legacy-capability"
     | "catalog-mismatch"
     | "authority-mismatch"
     | "inconsistent"

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8260,6 +8260,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         path: "full_invalid_baseline",
       },
       {
+        mode: "legacy-capability",
+        path: "full_incompatible_baseline",
+      },
+      {
         mode: "catalog-mismatch",
         path: "full_incompatible_baseline",
       },

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -49,6 +49,7 @@ import {
   onRejection,
   settleIncludingAbort,
 } from "../utils";
+import { connectorCatalogExecutableCapabilityStates } from "../services/connector-catalog-compatibility.service";
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
 import {
   isTestEndpointAllowed,
@@ -369,6 +370,17 @@ async function mutateRunnerJobConnectorPermissionBaseline(
         ${runnerJobQueue.executionContext},
         '{connectorPermissionBaseline}',
         '{"version":2}'::jsonb,
+        true
+      )`;
+      break;
+    }
+    case "legacy-capability": {
+      const legacyCapabilityDigest =
+        connectorCatalogExecutableCapabilityStates().legacy.digest;
+      executionContext = sql`jsonb_set(
+        ${runnerJobQueue.executionContext},
+        '{connectorPermissionBaseline,catalogIdentity,capabilityDigest}',
+        to_jsonb(${legacyCapabilityDigest}::text),
         true
       )`;
       break;

--- a/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
@@ -55,7 +55,7 @@ const COMPATIBILITY_REASON_ORDER = [
   "missing-platform-configuration",
 ] as const satisfies readonly ConnectorCatalogCompatibilityReason[];
 
-export const legacyConnectorCatalogCompatibilityEvaluationSchema: z.ZodType<LegacyConnectorCatalogCompatibilityEvaluation> =
+const legacyConnectorCatalogCompatibilityEvaluationSchema: z.ZodType<LegacyConnectorCatalogCompatibilityEvaluation> =
   z.array(
     z
       .object({
@@ -65,6 +65,21 @@ export const legacyConnectorCatalogCompatibilityEvaluationSchema: z.ZodType<Lega
       })
       .strict(),
   );
+
+export const canonicalConnectorCatalogCompatibilityEvaluationSchema: z.ZodType<CanonicalConnectorCatalogCompatibilityEvaluation> =
+  z
+    .object({
+      filteredAuthMethods: z.array(
+        z
+          .object({
+            connectorSlug: connectorSlugSchema,
+            authMethodId: connectorAuthMethodIdSchema,
+            reasons: z.array(connectorCatalogCompatibilityReasonSchema).min(1),
+          })
+          .strict(),
+      ),
+    })
+    .strict();
 
 const LEGACY_EXECUTABLE_CAPABILITY_EVALUATOR_VERSION = 1;
 const CANONICAL_EXECUTABLE_CAPABILITY_EVALUATOR_VERSION = 2;
@@ -200,13 +215,12 @@ export function connectorCatalogExecutableCapabilityStates(): ExecutableCapabili
   };
 }
 
-// TODO(#24184): Switch active readers only after the canonical row is observed.
 export function connectorCatalogExecutableCapabilityState(): ExecutableCapabilityState {
   const facts = connectorCatalogExecutableCapabilityFacts();
   return createExecutableCapabilityState({
     facts,
-    evaluatorVersion: LEGACY_EXECUTABLE_CAPABILITY_EVALUATOR_VERSION,
-    digestRegistrations: facts.registrations.map(legacyRegistrationCapability),
+    evaluatorVersion: CANONICAL_EXECUTABLE_CAPABILITY_EVALUATOR_VERSION,
+    digestRegistrations: facts.registrations,
   });
 }
 
@@ -481,17 +495,20 @@ export async function persistConnectorCatalogCompatibility(args: {
     capability: args.capabilities.canonical,
   });
   const evaluatedAt = nowDate();
-  const legacyPayload: LegacyConnectorCatalogCompatibilityEvaluation =
-    filteredAuthMethods.map((method) => {
-      return {
-        connectorRef: method.connectorSlug,
-        authMethodId: method.authMethodId,
-        reasons: method.reasons,
-      };
+  const legacyPayload =
+    legacyConnectorCatalogCompatibilityEvaluationSchema.parse(
+      filteredAuthMethods.map((method) => {
+        return {
+          connectorRef: method.connectorSlug,
+          authMethodId: method.authMethodId,
+          reasons: method.reasons,
+        };
+      }),
+    );
+  const canonicalPayload =
+    canonicalConnectorCatalogCompatibilityEvaluationSchema.parse({
+      filteredAuthMethods,
     });
-  const canonicalPayload: CanonicalConnectorCatalogCompatibilityEvaluation = {
-    filteredAuthMethods,
-  };
   await persistConnectorCatalogCompatibilityEvaluation({
     ...args,
     capabilityDigest: args.capabilities.legacy.digest,
@@ -648,12 +665,12 @@ async function reconcileCompatibility(args: {
 }
 
 function diagnosticFilteredAuthMethods(
-  filteredAuthMethods: LegacyConnectorCatalogCompatibilityEvaluation,
+  filteredAuthMethods: readonly CanonicalConnectorCatalogFilteredAuthMethod[],
 ): ConnectorCatalogFilteredAuthMethod[] {
   return filteredAuthMethods.map((method) => {
     return {
-      connectorSlug: method.connectorRef,
-      connectorRef: method.connectorRef,
+      connectorSlug: method.connectorSlug,
+      connectorRef: method.connectorSlug,
       authMethodId: method.authMethodId,
       reasons: [...method.reasons],
     };
@@ -707,9 +724,9 @@ async function compatibilityStatus(args: {
     evaluatedAt: result.evaluatedAt.toISOString(),
     stale: false,
     filteredAuthMethods: diagnosticFilteredAuthMethods(
-      legacyConnectorCatalogCompatibilityEvaluationSchema.parse(
+      canonicalConnectorCatalogCompatibilityEvaluationSchema.parse(
         result.filteredAuthMethods,
-      ),
+      ).filteredAuthMethods,
     ),
   };
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -40,8 +40,8 @@ import {
 import { connectorCatalogIconUrl } from "./connector-catalog-artifacts/icon";
 import { deriveConnectorCatalogFirewallPermissions } from "./connector-catalog-artifacts/relationships";
 import {
+  canonicalConnectorCatalogCompatibilityEvaluationSchema,
   connectorCatalogExecutableCapabilityDigest,
-  legacyConnectorCatalogCompatibilityEvaluationSchema,
 } from "./connector-catalog-compatibility.service";
 import type { ConnectorFeatureStates } from "./connector-catalog-feature-states";
 import type { ConnectorCatalogLoadTiming } from "./connector-catalog-load-timing.service";
@@ -390,7 +390,7 @@ async function readCurrentCatalog(args: {
     "api_dispatch_connector_catalog_validate_compatibility",
     () => {
       const parsed =
-        legacyConnectorCatalogCompatibilityEvaluationSchema.safeParse(
+        canonicalConnectorCatalogCompatibilityEvaluationSchema.safeParse(
           row.filteredAuthMethods,
         );
       if (!parsed.success) {
@@ -403,7 +403,7 @@ async function readCurrentCatalog(args: {
         );
         throw new ExternalConnectorCatalogUnavailableError();
       }
-      return parsed.data;
+      return parsed.data.filteredAuthMethods;
     },
   );
   const artifact = decoded.artifact;
@@ -424,7 +424,7 @@ async function readCurrentCatalog(args: {
         privateMethodFacts: privateMethodFacts(artifact),
         filteredMethodKeys: new Set(
           filteredAuthMethods.map((filtered) => {
-            return authMethodKey(filtered.connectorRef, filtered.authMethodId);
+            return authMethodKey(filtered.connectorSlug, filtered.authMethodId);
           }),
         ),
       };

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -39,6 +39,7 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     mode: z.enum([
       "remove",
       "malformed",
+      "legacy-capability",
       "catalog-mismatch",
       "authority-mismatch",
       "inconsistent",


### PR DESCRIPTION
## Summary

- switch the current executable-capability selector from the legacy evaluator-v1
  digest to the canonical evaluator-v2 digest
- parse only canonical compatibility object payloads and build accepted catalog
  filter keys from `connectorSlug`
- keep diagnostics backward compatible by mapping canonical slugs to the
  retained `connectorRef` alias
- validate both persisted payload formats while dual writes remain required for
  the rolling-release window
- cover strict no-fallback behavior and previous-release permission baseline
  refreshes through API integration tests

## Compatibility

- #24183 and this release both continue writing and reconciling legacy and
  canonical rows
- missing or malformed canonical data fails closed even when the legacy row is
  healthy
- accepted catalog caches and new permission baselines move with the canonical
  capability digest
- a #24183 legacy-digest permission baseline uses the existing
  `full_incompatible_baseline` refresh path
- rollback remains cache-warm because the legacy row is retained

## Exclusions

- no database schema or migration changes
- no compatibility format/version column
- no canonical-to-legacy reader fallback
- no legacy row, digest, writer, parser, diagnostics alias, or Platform fallback
  cleanup; that remains in #24186 after the reader release drains

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts test -- --silent=passed-only` (513 tests)
- runtime API schema compatibility against `runtime-api-schema-prod`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts --silent=passed-only` (107 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-catalog.test.ts --silent=passed-only` (29 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --silent=passed-only` (134 tests)
- `pnpm knip`
- `pnpm -F api build`
- staged pre-commit formatting, Knip, repository type checks, file-size checks,
  and commitlint

## Rollout gate

Before merge or rollout approval, record the production canonical row's exact
digest, object root, filtering equality with the legacy row, and current
validator authority as required by #24184.

Closes #24184

Part of #23775
