### PR TITLE
fix(ci): recover transient runner promotion ssh failures

### DIFF
--- a/.github/scripts/tests/ansible-ssh-control-path-test.sh
+++ b/.github/scripts/tests/ansible-ssh-control-path-test.sh
@@ -5,6 +5,8 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../../.." && pwd)"
 ansible_config="$repo_root/ansible/ansible.cfg"
 playbook="$script_dir/fixtures/ansible-ssh-control-path.yml"
+promote_playbook="$repo_root/ansible/playbooks/promote-runner.yml"
+rollback_playbook="$repo_root/ansible/playbooks/rollback-runner.yml"
 
 if ! command -v ansible-playbook >/dev/null; then
   echo "ansible-playbook is required" >&2
@@ -24,6 +26,8 @@ fake_ssh="$tmp/ssh"
 cat > "$fake_ssh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+
+printf '%s\n' "$*" >> "$SSH_INVOCATIONS"
 
 actual_control_path=""
 
@@ -48,26 +52,102 @@ if [ ! -d "$(dirname "$EXPECTED_CONTROL_PATH")" ]; then
   exit 1
 fi
 
+case "$SSH_SCENARIO" in
+  success)
+    ;;
+  transient)
+    if [ ! -e "$SSH_TRANSIENT_MARKER" ]; then
+      touch "$SSH_TRANSIENT_MARKER"
+      exit 255
+    fi
+    ;;
+  remote-failure)
+    exit 1
+    ;;
+  *)
+    echo "unexpected SSH scenario: $SSH_SCENARIO" >&2
+    exit 2
+    ;;
+esac
+
 touch "$SSH_MARKER"
 printf 'ansible ssh transport ok\n'
 EOF
 chmod +x "$fake_ssh"
 
 expected_control_path="$test_home/.ssh/vm0-ssh-%C"
-ssh_marker="$tmp/ssh-ran"
-HOME="$test_home" \
-  ANSIBLE_CONFIG="$ansible_config" \
-  ANSIBLE_NOCOLOR=1 \
-  ANSIBLE_SSH_CONTROL_PATH="$test_home/.ssh/vm0-ssh-%%C" \
-  EXPECTED_CONTROL_PATH="$expected_control_path" \
-  SSH_MARKER="$ssh_marker" \
-  ansible-playbook \
+run_ansible() {
+  local scenario=$1
+  local invocation_log=$2
+  local ssh_marker=$3
+  shift 3
+
+  HOME="$test_home" \
+    ANSIBLE_CONFIG="$ansible_config" \
+    ANSIBLE_NOCOLOR=1 \
+    ANSIBLE_SSH_CONTROL_PATH="$test_home/.ssh/vm0-ssh-%%C" \
+    EXPECTED_CONTROL_PATH="$expected_control_path" \
+    SSH_INVOCATIONS="$invocation_log" \
+    SSH_MARKER="$ssh_marker" \
+    SSH_SCENARIO="$scenario" \
+    SSH_TRANSIENT_MARKER="$tmp/transient-failed" \
+    ansible-playbook \
     -i "ansible-test.invalid," \
     -e "ansible_ssh_executable=$fake_ssh" \
-    "$playbook" >/dev/null
+    "$@" \
+    "$playbook"
+}
 
-if [ ! -f "$ssh_marker" ]; then
+assert_invocation_count() {
+  local invocation_log=$1
+  local expected=$2
+  local actual
+  actual=$(wc -l < "$invocation_log")
+  if [ "$actual" -ne "$expected" ]; then
+    echo "expected ${expected} SSH invocation(s), got ${actual}" >&2
+    cat "$invocation_log" >&2
+    exit 1
+  fi
+}
+
+success_invocations="$tmp/success-invocations"
+success_marker="$tmp/success-ran"
+: > "$success_invocations"
+run_ansible success "$success_invocations" "$success_marker" >/dev/null
+
+if [ ! -f "$success_marker" ]; then
   echo "expected Ansible to complete an SSH-backed task" >&2
+  exit 1
+fi
+assert_invocation_count "$success_invocations" 1
+
+transient_invocations="$tmp/transient-invocations"
+transient_marker="$tmp/transient-ran"
+: > "$transient_invocations"
+run_ansible transient "$transient_invocations" "$transient_marker" \
+  -e "ansible_ssh_retries=1" >/dev/null
+
+if [ ! -f "$transient_marker" ]; then
+  echo "expected Ansible to recover from one transient SSH failure" >&2
+  exit 1
+fi
+assert_invocation_count "$transient_invocations" 2
+
+remote_failure_invocations="$tmp/remote-failure-invocations"
+: > "$remote_failure_invocations"
+if run_ansible remote-failure "$remote_failure_invocations" "$tmp/remote-failure-ran" \
+  -e "ansible_ssh_retries=1" >"$tmp/remote-failure-output" 2>&1; then
+  echo "expected a normal remote failure to fail the play" >&2
+  exit 1
+fi
+assert_invocation_count "$remote_failure_invocations" 1
+
+if ! grep -Fq "ansible_ssh_retries: 1" "$promote_playbook"; then
+  echo "expected runner promotion to configure one SSH connection retry" >&2
+  exit 1
+fi
+if grep -Fq "ansible_ssh_retries" "$rollback_playbook" "$ansible_config"; then
+  echo "expected the SSH connection retry to remain promotion-scoped" >&2
   exit 1
 fi
 

--- a/.github/scripts/tests/fixtures/runner-promotion-local.ini
+++ b/.github/scripts/tests/fixtures/runner-promotion-local.ini
@@ -1,0 +1,3 @@
+[runner_promotion]
+runner-promotion-a ansible_connection=local ansible_become=false
+runner-promotion-b ansible_connection=local ansible_become=false

--- a/.github/scripts/tests/runner-promotion-ansible-test.sh
+++ b/.github/scripts/tests/runner-promotion-ansible-test.sh
@@ -58,10 +58,34 @@ trap cleanup EXIT
 
 test_home="$tmp/home"
 data_dir="$tmp/vm0-runner"
+test_bin="$tmp/bin"
 runner_name=v999.0.0
 runner_dir="$data_dir/bin/$runner_name"
 invocation_log="$data_dir/runner-invocations"
-mkdir -p "$test_home" "$data_dir/locks" "$data_dir/runners/$runner_name" "$runner_dir"
+gc_arrivals="$data_dir/gc-arrivals"
+mkdir -p \
+  "$test_home" \
+  "$test_bin" \
+  "$data_dir/locks" \
+  "$data_dir/runners/$runner_name" \
+  "$gc_arrivals" \
+  "$runner_dir"
+
+ln -s "$(command -v flock)" "$test_bin/real-flock"
+cat > "$test_bin/flock" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" != "--exclusive" ] || [ -z "${2:-}" ]; then
+  echo "unexpected flock invocation: $*" >&2
+  exit 1
+fi
+
+data_dir="$(cd "$(dirname "$2")/.." && pwd)"
+touch "$data_dir/gc-arrivals/$BASHPID"
+exec "$(dirname "$0")/real-flock" "$@"
+EOF
+chmod +x "$test_bin/flock"
 
 fake_runner="$runner_dir/runner"
 cat > "$fake_runner" <<'EOF'
@@ -95,7 +119,23 @@ case "${1:-}" in
       exit 1
     fi
     trap 'rmdir "$active_dir"' EXIT
-    sleep 1
+
+    arrivals_ready=false
+    for ((attempt = 0; attempt < 1000; attempt++)); do
+      arrival_count=$(
+        find "$data_dir/gc-arrivals" -mindepth 1 -maxdepth 1 -type f -print |
+          wc -l
+      )
+      if [ "$arrival_count" -ge 2 ]; then
+        arrivals_ready=true
+        break
+      fi
+      /bin/sleep 0.01
+    done
+    if [ "$arrivals_ready" != "true" ]; then
+      echo "timed out waiting for both gc lock contenders" >&2
+      exit 1
+    fi
     exit 0
     ;;
 esac
@@ -116,7 +156,8 @@ assert_contains "$promote_playbook" "include_tasks: ../tasks/garbage-collect-run
 assert_contains "$rollback_playbook" "include_tasks: ../tasks/garbage-collect-runner.yml"
 assert_contains "$gc_task" "{{ data_dir }}/locks/deployment-gc.lock"
 
-if ! HOME="$test_home" \
+if ! PATH="$test_bin:$PATH" \
+  HOME="$test_home" \
   ANSIBLE_CONFIG="$ansible_config" \
   ANSIBLE_NOCOLOR=1 \
   ansible-playbook \

--- a/.github/scripts/tests/runner-promotion-ansible-test.sh
+++ b/.github/scripts/tests/runner-promotion-ansible-test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+ansible_config="$repo_root/ansible/ansible.cfg"
+inventory="$script_dir/fixtures/runner-promotion-local.ini"
+promote_playbook="$repo_root/ansible/playbooks/promote-runner.yml"
+rollback_playbook="$repo_root/ansible/playbooks/rollback-runner.yml"
+gc_task="$repo_root/ansible/tasks/garbage-collect-runner.yml"
+
+if ! command -v ansible-playbook >/dev/null; then
+  echo "ansible-playbook is required" >&2
+  exit 1
+fi
+
+assert_contains() {
+  local file=$1
+  local expected=$2
+  if ! grep -Fq -- "$expected" "$file"; then
+    echo "expected ${file} to contain: ${expected}" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_line_count() {
+  local file=$1
+  local expected=$2
+  local pattern=$3
+  local actual
+  actual=$(grep -Fxc -- "$pattern" "$file" || true)
+  if [ "$actual" -ne "$expected" ]; then
+    echo "expected ${file} to contain ${expected} exact line(s): ${pattern}; got ${actual}" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+case "$(uname -m)" in
+  x86_64)
+    runner_target=x86_64-unknown-linux-musl
+    ;;
+  aarch64)
+    runner_target=aarch64-unknown-linux-musl
+    ;;
+  *)
+    echo "unsupported test architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+tmp="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+test_home="$tmp/home"
+data_dir="$tmp/vm0-runner"
+runner_name=v999.0.0
+runner_dir="$data_dir/bin/$runner_name"
+invocation_log="$data_dir/runner-invocations"
+mkdir -p "$test_home" "$data_dir/locks" "$data_dir/runners/$runner_name" "$runner_dir"
+
+fake_runner="$runner_dir/runner"
+cat > "$fake_runner" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+data_dir="$(cd "$(dirname "$0")/../.." && pwd)"
+invocation_log="$data_dir/runner-invocations"
+printf '%s\n' "$*" >> "$invocation_log"
+
+case "${1:-}" in
+  service)
+    case "${2:-}" in
+      install|wait-running|drain)
+        exit 0
+        ;;
+    esac
+    ;;
+  doctor)
+    exit 0
+    ;;
+  gc)
+    if [ "$*" != "gc --keep-latest 6 --protect-version v999.0.0" ]; then
+      echo "unexpected gc arguments: $*" >&2
+      exit 1
+    fi
+
+    active_dir="$data_dir/gc-active"
+    if ! mkdir "$active_dir"; then
+      echo "runner gc invocations overlapped" >&2
+      exit 1
+    fi
+    trap 'rmdir "$active_dir"' EXIT
+    sleep 1
+    exit 0
+    ;;
+esac
+
+echo "unexpected runner invocation: $*" >&2
+exit 1
+EOF
+chmod +x "$fake_runner"
+
+for playbook in "$promote_playbook" "$rollback_playbook"; do
+  HOME="$test_home" \
+    ANSIBLE_CONFIG="$ansible_config" \
+    ANSIBLE_NOCOLOR=1 \
+    ansible-playbook -i "$inventory" --syntax-check "$playbook" >/dev/null
+done
+
+assert_contains "$promote_playbook" "include_tasks: ../tasks/garbage-collect-runner.yml"
+assert_contains "$rollback_playbook" "include_tasks: ../tasks/garbage-collect-runner.yml"
+assert_contains "$gc_task" "{{ data_dir }}/locks/deployment-gc.lock"
+
+if ! HOME="$test_home" \
+  ANSIBLE_CONFIG="$ansible_config" \
+  ANSIBLE_NOCOLOR=1 \
+  ansible-playbook \
+    -i "$inventory" \
+    --forks 2 \
+    -e "data_dir=$data_dir" \
+    -e "runner_version=999.0.0" \
+    -e "runner_target=$runner_target" \
+    "$promote_playbook" >"$tmp/promote-output" 2>&1; then
+  cat "$tmp/promote-output" >&2
+  exit 1
+fi
+
+assert_line_count "$invocation_log" 2 \
+  "gc --keep-latest 6 --protect-version $runner_name"
+assert_line_count "$invocation_log" 4 "doctor --name $runner_name"
+assert_line_count "$invocation_log" 2 \
+  "service wait-running --name $runner_name --timeout-secs 120"
+
+echo "runner-promotion-ansible-test: ok"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -234,6 +234,7 @@ jobs:
             .github/scripts/tests/cloudflare-ssh-command-test.sh \
             .github/scripts/tests/cloudflare-ssh-preconnect-test.sh \
             .github/scripts/tests/cloudflare-ssh-proxy-test.sh \
+            .github/scripts/tests/runner-promotion-ansible-test.sh \
             .github/scripts/tests/run-semgrep-test.sh \
             .github/scripts/tests/semgrep-results-test.sh \
             .github/scripts/tests/runner-behavior-balloon-test.sh \

--- a/ansible/playbooks/promote-runner.yml
+++ b/ansible/playbooks/promote-runner.yml
@@ -29,6 +29,9 @@
   become: true
 
   vars:
+    # Connection failures can replay the current task. Keep remote tasks
+    # convergent or protect their complete operation with a stable lock.
+    ansible_ssh_retries: 1
     runner_name: "v{{ runner_version }}"
     data_dir: /var/lib/vm0-runner
     bin_dir: "{{ data_dir }}/bin/{{ runner_name }}"
@@ -97,7 +100,7 @@
       ignore_errors: true
 
     - name: Garbage collect old artifacts
-      command: "{{ bin_dir }}/runner gc --keep-latest 6 --protect-version {{ runner_name }}"
+      include_tasks: ../tasks/garbage-collect-runner.yml
 
     # ========================================
     # Phase 6: Final health check

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -505,7 +505,7 @@
     #
     # gc respects `--protect-version` so the rollback target is never swept.
     - name: Garbage collect old artifacts
-      command: "{{ bin_dir }}/runner gc --keep-latest 6 --protect-version {{ runner_name }}"
+      include_tasks: ../tasks/garbage-collect-runner.yml
 
     - name: Verify runner health after cleanup
       command: "{{ bin_dir }}/runner doctor --name {{ runner_name }}"

--- a/ansible/tasks/garbage-collect-runner.yml
+++ b/ansible/tasks/garbage-collect-runner.yml
@@ -1,0 +1,12 @@
+- name: Run serialized runner garbage collection
+  ansible.builtin.command:
+    argv:
+      - flock
+      - --exclusive
+      - "{{ data_dir }}/locks/deployment-gc.lock"
+      - "{{ bin_dir }}/runner"
+      - gc
+      - --keep-latest
+      - "6"
+      - --protect-version
+      - "{{ runner_name }}"


### PR DESCRIPTION
## Summary

- retry one Ansible-classified SSH connection failure during runner promotion
- serialize promotion and rollback garbage collection with one shared host-local lock
- cover connection retry classification and the production promotion playbook with integration tests

## Scope

The retry is declared only by `promote-runner.yml`. Global Ansible
configuration, the shared SSH wrapper, rollback retry behavior, the runner
binary, and deployment protocols are unchanged.

## Validation

- `bash .github/scripts/tests/ansible-ssh-control-path-test.sh`
- `bash .github/scripts/tests/runner-promotion-ansible-test.sh`
- `bash .github/scripts/tests/cloudflare-ssh-command-test.sh`
- `bash .github/scripts/tests/cloudflare-ssh-preconnect-test.sh`
- all `.github/scripts/tests/*.sh` scripts through the Security workflow loop
- Security workflow Bash syntax and ShellCheck command
- `.github/scripts/check-workflow-shell-compatibility.sh`
- actionlint 1.7.12
- `git diff --check`
- staged-path pre-commit and commit-message hooks

Closes #24261
