### PR TITLE
fix(mitm-addon): support multi-member gzip billing bodies

### DIFF
--- a/crates/runner/mitm-addon/src/billing_body.py
+++ b/crates/runner/mitm-addon/src/billing_body.py
@@ -11,20 +11,33 @@ from body_limits import REQUEST_BODY_BILLING_INSPECTION_LIMIT
 def _decode_zlib_request_body_for_billing(
     data: bytes, encoding: Literal["gzip", "deflate"], max_output: int
 ) -> bytes | None:
+    """Decode every gzip member or one deflate stream under one output cap."""
     wbits_options = (
         (16 + zlib.MAX_WBITS,) if encoding == "gzip" else (zlib.MAX_WBITS, -zlib.MAX_WBITS)
     )
     for wbits in wbits_options:
-        obj = zlib.decompressobj(wbits)
-        try:
-            decoded = obj.decompress(data, max_length=max_output + 1)
-        except zlib.error:
-            continue
-        if len(decoded) > max_output:
-            return None
-        if not obj.eof or obj.unused_data:
-            continue
-        return decoded
+        remaining = data
+        decoded = bytearray()
+        while remaining:
+            obj = zlib.decompressobj(wbits)
+            try:
+                decoded.extend(
+                    obj.decompress(
+                        remaining,
+                        max_length=max_output - len(decoded) + 1,
+                    )
+                )
+            except zlib.error:
+                break
+            if len(decoded) > max_output:
+                return None
+            if not obj.eof:
+                break
+            remaining = obj.unused_data
+            if not remaining:
+                return bytes(decoded)
+            if encoding != "gzip":
+                break
     return None
 
 
@@ -39,7 +52,9 @@ def decode_request_body_for_billing(
 
     Unlike response capture helpers, billing must fail closed: unsupported,
     invalid, incomplete, or oversized encoded bodies are treated as
-    uninspectable rather than falling back to raw bytes.
+    uninspectable rather than falling back to raw bytes. Complete gzip member
+    sequences share one decoded-output budget; deflate accepts one zlib-wrapped
+    or raw stream.
     """
     if not raw_content:
         return None

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -20,10 +20,29 @@ from tests.x_flow_helpers import (
 )
 from usage.providers.connectors import x_billing
 
+_PLAIN_TEXT_TWEET_BODY = b'{"text":"hello world"}'
+_GZIP_WBITS = 16 + zlib.MAX_WBITS
+_ZLIB_DEFLATE_WBITS = zlib.MAX_WBITS
+_RAW_DEFLATE_WBITS = -zlib.MAX_WBITS
+
+
+def _gzip_members(*payloads: bytes) -> bytes:
+    return b"".join(gzip.compress(payload, mtime=0) for payload in payloads)
+
 
 def _raw_deflate_body(payload: bytes) -> bytes:
-    compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+    compressor = zlib.compressobj(wbits=_RAW_DEFLATE_WBITS)
     return compressor.compress(payload) + compressor.flush()
+
+
+def _tweet_body_with_size(size: int) -> bytes:
+    framing = b'{"text":""}'
+    return b'{"text":"' + b"x" * (size - len(framing)) + b'"}'
+
+
+_GZIP_TWEET_BODY = _gzip_members(_PLAIN_TEXT_TWEET_BODY)
+_ZLIB_DEFLATE_TWEET_BODY = zlib.compress(_PLAIN_TEXT_TWEET_BODY)
+_RAW_DEFLATE_TWEET_BODY = _raw_deflate_body(_PLAIN_TEXT_TWEET_BODY)
 
 
 def test_logs_write_operation_charges_one(x_usage, tmp_path, real_flow):
@@ -138,18 +157,23 @@ def test_lowercase_post_tweet_create_plain_text_downgrades(x_usage, tmp_path, re
     [
         pytest.param(
             "gzip",
-            gzip.compress(json.dumps({"text": "hello world"}).encode()),
+            _GZIP_TWEET_BODY,
             id="gzip",
         ),
         pytest.param(
             "deflate",
-            zlib.compress(json.dumps({"text": "hello world"}).encode()),
+            _ZLIB_DEFLATE_TWEET_BODY,
             id="deflate-zlib",
         ),
         pytest.param(
             "deflate",
-            _raw_deflate_body(json.dumps({"text": "hello world"}).encode()),
+            _RAW_DEFLATE_TWEET_BODY,
             id="deflate-raw",
+        ),
+        pytest.param(
+            "gzip",
+            _gzip_members(_PLAIN_TEXT_TWEET_BODY[:10], _PLAIN_TEXT_TWEET_BODY[10:]),
+            id="gzip-multiple-members",
         ),
     ],
 )
@@ -171,6 +195,139 @@ def test_tweet_create_compressed_plain_text_downgrades_to_content_create(
     flow.request.method = "POST"
     p = x_usage.call_and_get_single_billing(flow)
     assert p["category"] == "content.create"
+    assert p["quantity"] == 1
+
+
+@pytest.mark.parametrize(
+    ("decoded_size", "trailing_data", "expected_category"),
+    [
+        pytest.param(
+            REQUEST_BODY_BILLING_INSPECTION_LIMIT,
+            _gzip_members(b""),
+            "content.create",
+            id="exact-limit-with-empty-member",
+        ),
+        pytest.param(
+            REQUEST_BODY_BILLING_INSPECTION_LIMIT,
+            b"trailing garbage",
+            "content.create_with_url",
+            id="exact-limit-with-trailing-garbage",
+        ),
+        pytest.param(
+            REQUEST_BODY_BILLING_INSPECTION_LIMIT + 1,
+            b"",
+            "content.create_with_url",
+            id="over-limit",
+        ),
+    ],
+)
+def test_tweet_create_multi_member_gzip_enforces_total_decoded_cap(
+    x_usage, tmp_path, real_flow, decoded_size, trailing_data, expected_category
+):
+    request_payload = _tweet_body_with_size(decoded_size)
+    split = len(request_payload) // 2
+    request_body = _gzip_members(request_payload[:split], request_payload[split:]) + trailing_data
+    assert len(request_payload) == decoded_size
+    assert len(request_body) < REQUEST_BODY_BILLING_INSPECTION_LIMIT
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path="/2/tweets",
+        body=json.dumps({"data": {"id": "1"}}).encode(),
+        status=201,
+        permission="tweet.write",
+        rule="POST /2/tweets",
+        request_body=request_body,
+        request_encoding="gzip",
+    )
+    flow.request.method = "POST"
+
+    p = x_usage.call_and_get_single_billing(flow)
+
+    assert p["category"] == expected_category
+    assert p["quantity"] == 1
+
+
+@pytest.mark.parametrize(
+    ("request_encoding", "request_body", "wbits"),
+    [
+        pytest.param(
+            "gzip",
+            _GZIP_TWEET_BODY[:-1],
+            _GZIP_WBITS,
+            id="gzip-truncated-first-member",
+        ),
+        pytest.param(
+            "gzip",
+            _GZIP_TWEET_BODY + _gzip_members(b"")[:-1],
+            _GZIP_WBITS,
+            id="gzip-truncated-later-member",
+        ),
+        pytest.param(
+            "gzip",
+            _GZIP_TWEET_BODY + b"trailing garbage",
+            _GZIP_WBITS,
+            id="gzip-trailing-garbage",
+        ),
+        pytest.param(
+            "deflate",
+            _ZLIB_DEFLATE_TWEET_BODY[:-1],
+            _ZLIB_DEFLATE_WBITS,
+            id="deflate-zlib-truncated",
+        ),
+        pytest.param(
+            "deflate",
+            _ZLIB_DEFLATE_TWEET_BODY + b"trailing garbage",
+            _ZLIB_DEFLATE_WBITS,
+            id="deflate-zlib-trailing-garbage",
+        ),
+        pytest.param(
+            "deflate",
+            _ZLIB_DEFLATE_TWEET_BODY + _ZLIB_DEFLATE_TWEET_BODY,
+            _ZLIB_DEFLATE_WBITS,
+            id="deflate-zlib-second-stream",
+        ),
+        pytest.param(
+            "deflate",
+            _RAW_DEFLATE_TWEET_BODY[:-1],
+            _RAW_DEFLATE_WBITS,
+            id="deflate-raw-truncated",
+        ),
+        pytest.param(
+            "deflate",
+            _RAW_DEFLATE_TWEET_BODY + b"trailing garbage",
+            _RAW_DEFLATE_WBITS,
+            id="deflate-raw-trailing-garbage",
+        ),
+        pytest.param(
+            "deflate",
+            _RAW_DEFLATE_TWEET_BODY + _RAW_DEFLATE_TWEET_BODY,
+            _RAW_DEFLATE_WBITS,
+            id="deflate-raw-second-stream",
+        ),
+    ],
+)
+def test_tweet_create_incomplete_or_trailing_compressed_body_stays_conservative(
+    x_usage, tmp_path, real_flow, request_encoding, request_body, wbits
+):
+    prefix_decoder = zlib.decompressobj(wbits)
+    assert prefix_decoder.decompress(request_body) == _PLAIN_TEXT_TWEET_BODY
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path="/2/tweets",
+        body=json.dumps({"data": {"id": "1"}}).encode(),
+        status=201,
+        permission="tweet.write",
+        rule="POST /2/tweets",
+        request_body=request_body,
+        request_encoding=request_encoding,
+    )
+    flow.request.method = "POST"
+
+    p = x_usage.call_and_get_single_billing(flow)
+
+    assert p["category"] == "content.create_with_url"
     assert p["quantity"] == 1
 
 


### PR DESCRIPTION
## Summary

- decode every RFC 1952 gzip member under one bounded billing-inspection output budget
- keep zlib-wrapped and raw deflate limited to one complete stream and reject unvalidated trailing input
- cover valid split-member gzip, exact-limit validation, cross-member overflow, truncated members, trailing garbage, and extra deflate streams through X billing integration tests

## Compatibility

- old runners remain conservative for valid multi-member gzip during deployment overlap
- usage event schemas, category names, APIs, databases, persisted data, and runner protocols are unchanged
- shared response/capture decoder policies are intentionally out of scope

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/x_connector_usage/test_writes.py` — 105 passed
- `uv run --no-sync python -m pytest tests/` — 4,508 passed
- mutation probes confirmed the focused tests reject bypasses of incomplete-member, gzip trailing-garbage, and extra-deflate-stream validation
- `git diff --check`

Closes #24252
