### PR TITLE
perf(mitm-addon): bypass decoding for plain ascii paths

### DIFF
--- a/crates/runner/mitm-addon/src/path_security.py
+++ b/crates/runner/mitm-addon/src/path_security.py
@@ -16,7 +16,10 @@ def has_unsafe_path(path: str) -> bool:
     """Return True when a URL path contains or may hide unsafe path syntax."""
     if "\\" in path:
         return True
-    return any(_segment_has_unsafe_path(raw_segment) for raw_segment in path.split("/"))
+    raw_segments = path.split("/")
+    if path.isascii() and path.isprintable() and "%" not in path:
+        return any(_path_part_is_dot_segment(segment) for segment in raw_segments)
+    return any(_segment_has_unsafe_path(raw_segment) for raw_segment in raw_segments)
 
 
 def has_unsafe_url_path(url: str) -> bool:

--- a/crates/runner/mitm-addon/tests/test_path_security.py
+++ b/crates/runner/mitm-addon/tests/test_path_security.py
@@ -1,5 +1,7 @@
 """Tests for URL path safety helpers."""
 
+from unittest.mock import patch
+
 import pytest
 
 import path_security
@@ -76,6 +78,19 @@ def test_has_unsafe_path_blocks_percent_encoded_unsafe_codepoints(path):
 @pytest.mark.parametrize(
     "path",
     [
+        "/api/\x00/admin",
+        "/api/\x1f/admin",
+        "/api/\x7f/admin",
+        "/api/\ud800/admin",
+    ],
+)
+def test_has_unsafe_path_blocks_raw_unsafe_codepoints(path):
+    assert path_security.has_unsafe_path(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
         "/api/%ef%bc%8e%ef%bc%8e/admin",
         "/api/%ef%bc%8e./admin",
         "/api/%ef%bc%8f../admin",
@@ -117,6 +132,7 @@ def test_has_unsafe_path_blocks_invalid_percent_encoded_utf8(path):
         "/api/..hidden/admin",
         "/api/a..b/admin",
         "/api/callback;matrix=1",
+        "/api/user name",
         "/api/foo%2Fbar",
         "/api/foo%252Fbar",
         "/api/%E2%9C%93",
@@ -133,3 +149,23 @@ def test_has_unsafe_path_blocks_invalid_percent_encoded_utf8(path):
 )
 def test_has_unsafe_path_allows_regular_segments(path):
     assert path_security.has_unsafe_path(path) is False
+
+
+def test_plain_ascii_path_bypasses_compatibility_pipeline():
+    with (
+        patch.object(
+            path_security.urllib.parse,
+            "unquote_to_bytes",
+            wraps=path_security.urllib.parse.unquote_to_bytes,
+        ) as percent_decode,
+        patch.object(
+            path_security.unicodedata,
+            "normalize",
+            wraps=path_security.unicodedata.normalize,
+        ) as unicode_normalize,
+    ):
+        unsafe = path_security.has_unsafe_path("/repos/vm0-ai/vm0/issues/24254.json;view=full")
+
+    assert unsafe is False
+    percent_decode.assert_not_called()
+    unicode_normalize.assert_not_called()

--- a/crates/runner/mitm-addon/tests/test_path_security.py
+++ b/crates/runner/mitm-addon/tests/test_path_security.py
@@ -127,6 +127,7 @@ def test_has_unsafe_path_blocks_invalid_percent_encoded_utf8(path):
 @pytest.mark.parametrize(
     "path",
     [
+        "",
         "/",
         "/api/users",
         "/api/..hidden/admin",


### PR DESCRIPTION
## Summary

- fast-path printable ASCII paths that contain neither percent escapes nor backslashes
- reuse the existing dot-segment predicate so direct and matrix-parameter dot segments remain blocked
- keep the existing percent-decoding, Unicode-normalization, and fail-closed pipeline unchanged for every fallback input
- cover empty input, raw controls, surrogates, raw space, and deterministic decode/NFKC bypass behavior

## Scope

This intentionally does not add a segment-level fast path for mixed encoded or Unicode paths. Local
diagnostics show that optimization could help those inputs, but the current evidence is for ordinary
ASCII request paths and does not justify a second security-sensitive branch.

## Performance

Python 3.14.0 in the local aarch64 development container, best of five runs:

| Path | Direct baseline | Direct fast path | Matcher baseline | Matcher fast path |
| --- | ---: | ---: | ---: | ---: |
| Short | 2.459 µs | 0.343 µs (-86.0%) | 20.353 µs | 17.276 µs (-15.1%) |
| GitHub-style | 6.298 µs | 0.622 µs (-90.1%) | 25.276 µs | 18.838 µs (-25.5%) |
| Long | 9.213 µs | 0.841 µs (-90.9%) | 31.009 µs | 21.176 µs (-31.7%) |

The implemented helper also matched the retained baseline across 299,593 exhaustive ASCII cases,
200,000 seeded random printable-ASCII cases, and 11 encoded/Unicode/control/surrogate/backslash edge
cases. Timings are diagnostic only; tests contain no wall-clock thresholds.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_path_security.py` (74 passed)
- `uv run --no-sync python -m pytest tests/` (4,502 passed)

Closes #24254
