### PR TITLE
docs(mitm-addon): document websocket retention contract

### DIFF
--- a/crates/runner/mitm-addon/src/websocket_retention.py
+++ b/crates/runner/mitm-addon/src/websocket_retention.py
@@ -1,11 +1,11 @@
 """Bound completed WebSocket history for registered mitmproxy flows.
 
-Mitmproxy shares each flow's message list with every addon in the current
-WebSocket hook chain. Registered flows therefore defer trimming until that
-chain finishes, while unregistered flows keep mitmproxy's normal history. The
-callback retains the latest complete message present when it runs. This bounds
-completed-message history, not pre-hook message assembly or the size of the
-retained message.
+Mitmproxy shares each flow's message list across addon hook dispatch. Registered
+flows therefore defer trimming to the event loop, preserving unchanged history
+for subsequent synchronous addon hooks in the same dispatch. Unregistered flows
+keep mitmproxy's normal history. The callback retains the latest complete
+message present when it runs. This bounds completed-message history, not
+pre-hook message assembly or the size of the retained message.
 
 See ``tests/test_websocket_retention.py`` and
 ``tests/test_deferred_scheduler.py`` for the executable contract.
@@ -23,9 +23,9 @@ def schedule_message_trim(flow: http.HTTPFlow) -> None:
     """Schedule one deferred history trim for a registered WebSocket flow.
 
     Flows without a run ID or WebSocket are left unchanged. Repeated calls
-    coalesce into one pending callback, leaving history intact for the rest of
-    the current hook chain. The callback mutates the existing message list in
-    place and keeps whichever message is latest when it runs instead of
+    coalesce into one pending callback, leaving history intact until control
+    returns to the event loop. The callback mutates the existing message list
+    in place and keeps whichever message is latest when it runs instead of
     capturing the message that triggered scheduling.
     """
     if not flow_metadata.run_id(flow.metadata) or flow.websocket is None:

--- a/crates/runner/mitm-addon/src/websocket_retention.py
+++ b/crates/runner/mitm-addon/src/websocket_retention.py
@@ -1,4 +1,15 @@
-"""WebSocket message retention for registered mitmproxy flows."""
+"""Bound completed WebSocket history for registered mitmproxy flows.
+
+Mitmproxy shares each flow's message list with every addon in the current
+WebSocket hook chain. Registered flows therefore defer trimming until that
+chain finishes, while unregistered flows keep mitmproxy's normal history. The
+callback retains the latest complete message present when it runs. This bounds
+completed-message history, not pre-hook message assembly or the size of the
+retained message.
+
+See ``tests/test_websocket_retention.py`` and
+``tests/test_deferred_scheduler.py`` for the executable contract.
+"""
 
 from mitmproxy import http
 
@@ -9,6 +20,14 @@ _WEBSOCKET_MESSAGE_TRIM_SCHEDULED = "_websocket_message_trim_scheduled"
 
 
 def schedule_message_trim(flow: http.HTTPFlow) -> None:
+    """Schedule one deferred history trim for a registered WebSocket flow.
+
+    Flows without a run ID or WebSocket are left unchanged. Repeated calls
+    coalesce into one pending callback, leaving history intact for the rest of
+    the current hook chain. The callback mutates the existing message list in
+    place and keeps whichever message is latest when it runs instead of
+    capturing the message that triggered scheduling.
+    """
     if not flow_metadata.run_id(flow.metadata) or flow.websocket is None:
         return
     if flow.metadata.get(_WEBSOCKET_MESSAGE_TRIM_SCHEDULED, False):
@@ -18,6 +37,12 @@ def schedule_message_trim(flow: http.HTTPFlow) -> None:
 
 
 def release_terminal_messages(flow: http.HTTPFlow) -> None:
+    """Release retained messages at a registered flow's terminal boundary.
+
+    The scheduling marker is removed before the existing message list is
+    cleared. A callback that was already queued may still run afterward, but it
+    safely finds the cleared list. Unregistered flow history remains unchanged.
+    """
     flow.metadata.pop(_WEBSOCKET_MESSAGE_TRIM_SCHEDULED, None)
     if not flow_metadata.run_id(flow.metadata):
         return


### PR DESCRIPTION
## Summary

- document why registered WebSocket message trimming is deferred until control returns to the event loop
- clarify that deferral preserves unchanged history for subsequent synchronous addon hooks in the same dispatch
- record callback coalescing, in-place latest-at-callback retention, and terminal cleanup semantics beside their public helpers
- distinguish completed-message history from pre-hook assembly and the size of the retained message
- link the integration tests that define the executable contract

## Scope

- documentation-only change in `websocket_retention.py`
- no executable, API, schema, protocol, dependency, configuration, migration, deployment, feature-switch, or cleanup change

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,497 passed)

Closes #24271
