### PR TITLE
refactor(api): make cancellation recovery unconditional after runner rollout

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -28,6 +28,7 @@ import {
   holdCheckpointReadsFixture,
   holdChatEventInsertTransactionFixture,
   invalidatePendingChatEventInputParamsFixture,
+  markCancellationRecoveryUnsupportedFixture,
   readChatEventContextFixture,
   removeAcknowledgedCancellationLifecycleFixture,
 } from "../../../test-fixtures/chat-events";
@@ -2087,20 +2088,74 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
 });
 
 describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
-  it("ignores unknown claim capabilities and preserves immediate release", async () => {
+  it("ignores unknown claim capabilities without disabling recovery", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const run = await startChatRun(actor, {
       agentId,
       prompt: "cancel an unknown-capability run",
     });
-    await claimChatRun(runnerGroup, run.runId, [
+    const sandboxHeaders = await claimChatRun(runnerGroup, run.runId, [
       "future-cancellation-recovery-v2",
     ]);
     const queuedEventId = await queueChatEvent(actor, {
       agentId,
       threadId: run.threadId,
       prompt: "continue after an unknown capability",
+    });
+
+    context.mocks.ably.publish.mockClear();
+    await api.requestCancelRun(actor, run.runId, [200]);
+    await flushWaitUntilForTest();
+    await waitForRunStatus(actor, run.runId, "cancelled");
+    await expectCancellationRecoveryPending(actor, run.threadId, true);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith("cancel", {
+      runId: run.runId,
+      mode: "cooperative",
+    });
+    const beforeCompletion = await chat.listThreadEvents(actor, run.threadId);
+    expect(
+      userMessages(beforeCompletion.events).filter((event) => {
+        return (
+          event.revokesEventId === queuedEventId && event.runId !== undefined
+        );
+      }),
+    ).toHaveLength(0);
+
+    await webhooks.requestAgentComplete(
+      { runId: run.runId, exitCode: 1, error: "Run cancelled" },
+      sandboxHeaders,
+      [200],
+    );
+    await flushWaitUntilForTest();
+    const replacementRunId = await waitForQueuedEventReplacement(
+      actor,
+      run.threadId,
+      queuedEventId,
+    );
+    expect(replacementRunId).not.toBe(run.runId);
+    await expectCancellationRecoveryPending(actor, run.threadId, false);
+
+    await api.requestCancelRun(actor, replacementRunId, [200]);
+    await waitForRunStatus(actor, replacementRunId, "cancelled");
+    await flushWaitUntilForTest();
+  }, 90_000);
+
+  it("preserves immediate release for a historical unsupported claim", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    const run = await startChatRun(actor, {
+      agentId,
+      prompt: "cancel a historical unsupported run",
+    });
+    await claimChatRun(runnerGroup, run.runId, [
+      RUNNER_CANCELLATION_RECOVERY_CAPABILITY,
+    ]);
+    await markCancellationRecoveryUnsupportedFixture({ runId: run.runId });
+    const queuedEventId = await queueChatEvent(actor, {
+      agentId,
+      threadId: run.threadId,
+      prompt: "continue after historical cancellation",
     });
 
     context.mocks.ably.publish.mockClear();
@@ -2112,6 +2167,10 @@ describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
     );
     expect(replacementRunId).not.toBe(run.runId);
     await expectCancellationRecoveryPending(actor, run.threadId, false);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith("cancel", {
+      runId: run.runId,
+      mode: "hard",
+    });
     expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
       `chatThreadDetailChanged:${run.threadId}`,
       null,
@@ -2455,7 +2514,9 @@ describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
       sandboxHeaders,
       [200],
     );
-    await expect.poll(checkpointGate.blockedWaiterCount).toBe(1);
+    await expect
+      .poll(checkpointGate.blockedWaiterCount)
+      .toBeGreaterThanOrEqual(1);
     await api.requestCancelRun(actor, run.runId, [200]);
     checkpointGate.release();
     await checkpointGate.done;

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -377,9 +377,12 @@ async function claimChatRun(
 }> {
   await api.heartbeatRunner(runnerGroup);
   const claim = await api.claimRunnerJob(runId);
+  const sandboxHeaders = {
+    authorization: `Bearer ${claim.sandboxToken}`,
+  };
   return {
     claim,
-    sandboxHeaders: { authorization: `Bearer ${claim.sandboxToken}` },
+    sandboxHeaders,
   };
 }
 
@@ -665,9 +668,17 @@ async function failChatRun(
   );
 }
 
-async function cancelChatRun(actor: ApiTestUser, runId: string): Promise<void> {
+async function cancelChatRun(
+  actor: ApiTestUser,
+  runId: string,
+  sandboxHeaders?: { readonly authorization: string },
+): Promise<void> {
   await api.requestCancelRun(actor, runId, [200]);
   await waitForRunStatus(actor, runId, "cancelled");
+  if (sandboxHeaders) {
+    await failChatRun(runId, sandboxHeaders, "Run cancelled");
+    await flushWaitUntilForTest();
+  }
 }
 
 function assistantMessages(messages: readonly ChatEvent[]): AssistantMessage[] {
@@ -2486,7 +2497,7 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(["claude-opus-4-6", "claude-sonnet-5"]).toContain(
       claimEnvironment(racedClaim.claim).ANTHROPIC_MODEL,
     );
-    await cancelChatRun(actor, sent.body.runId);
+    await cancelChatRun(actor, sent.body.runId, racedClaim.sandboxHeaders);
 
     const followUp = await sendChatRun(actor, {
       agentId,
@@ -2596,9 +2607,9 @@ describe("CHAT-02: model-first provider policies", () => {
     expect((await readThreadProjection(actor, fast.threadId)).serviceTier).toBe(
       "priority",
     );
-    const { claim } = await claimChatRun(runnerGroup, fast.runId);
-    const environment = claimEnvironment(claim);
-    expect(claim.cliAgentType).toBe("codex");
+    const fastClaim = await claimChatRun(runnerGroup, fast.runId);
+    const environment = claimEnvironment(fastClaim.claim);
+    expect(fastClaim.claim.cliAgentType).toBe("codex");
     expect(environment.OPENAI_MODEL).toBe("gpt-5.6-sol");
     expect(environment.VM0_CODEX_SERVICE_TIER).toBe("fast");
     expect(environment.CHATGPT_ACCESS_TOKEN).toBe(
@@ -2607,7 +2618,7 @@ describe("CHAT-02: model-first provider policies", () => {
         "CHATGPT_ACCESS_TOKEN",
       ),
     );
-    await cancelChatRun(actor, fast.runId);
+    await cancelChatRun(actor, fast.runId, fastClaim.sandboxHeaders);
     expect((await readThreadProjection(actor, fast.threadId)).serviceTier).toBe(
       "priority",
     );
@@ -5416,7 +5427,7 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
       { bearer: zeroTokenFromClaim(grantedClaim.claim) },
       [200],
     );
-    await cancelChatRun(actor, granted.runId);
+    await cancelChatRun(actor, granted.runId, grantedClaim.sandboxHeaders);
 
     // Follow-up sends without the field stay granted via the sticky host.
     const sticky = await sendChatRun(actor, {
@@ -5430,7 +5441,7 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
       { bearer: zeroTokenFromClaim(stickyClaim.claim) },
       [200],
     );
-    await cancelChatRun(actor, sticky.runId);
+    await cancelChatRun(actor, sticky.runId, stickyClaim.sandboxHeaders);
 
     // An explicit null clears the sticky host: the next run on the same
     // thread is no longer granted.
@@ -5446,7 +5457,7 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
       { bearer: zeroTokenFromClaim(clearedClaim.claim) },
       [403],
     );
-    await cancelChatRun(actor, cleared.runId);
+    await cancelChatRun(actor, cleared.runId, clearedClaim.sandboxHeaders);
 
     mockNow(now() + 91_000);
     const staleGranted = await sendChatRun(actor, {
@@ -5824,7 +5835,7 @@ describe("CHAT-02: shared user message queue", () => {
     await expect(
       readChatEventInputParamsFixture(replayedPreviewMessageId),
     ).resolves.toBeNull();
-    await cancelChatRun(actor, previewRunId);
+    await cancelChatRun(actor, previewRunId, previewClaim.sandboxHeaders);
 
     const mockMessages = await waitForThreadMessages(
       actor,
@@ -6497,7 +6508,7 @@ describe("CHAT-02: shared user message queue", () => {
       agentId,
       prompt: "thread deletion after queue-first launch anchor",
     });
-    await claimChatRun(runnerGroup, anchor.runId);
+    const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
     const messageId = randomUUID();
     const prompt = "queued auto-send deleted before its marker";
     const queued = await chat.requestSendEvent(
@@ -6540,7 +6551,13 @@ describe("CHAT-02: shared user message queue", () => {
       }
     });
 
-    await cancelChatRun(actor, anchor.runId);
+    await api.requestCancelRun(actor, anchor.runId, [200]);
+    await waitForRunStatus(actor, anchor.runId, "cancelled");
+    await failChatRun(
+      anchor.runId,
+      anchorClaim.sandboxHeaders,
+      "Run cancelled",
+    );
     await queuePublishStarted.promise;
 
     const runList = await api.listAgentRuns(actor, {
@@ -6721,7 +6738,7 @@ describe("CHAT-02: shared user message queue", () => {
     await cancelChatRun(actor, promoted.runId);
   }, 90_000);
 
-  it("auto-fires queued messages when the active run is cancelled", async () => {
+  it("auto-fires queued messages after cancellation recovery completes", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
@@ -6729,7 +6746,7 @@ describe("CHAT-02: shared user message queue", () => {
       agentId,
       prompt: "queue-first anchor to cancel",
     });
-    await claimChatRun(runnerGroup, anchor.runId);
+    const { sandboxHeaders } = await claimChatRun(runnerGroup, anchor.runId);
 
     const queuedId = randomUUID();
     const queued = await chat.requestSendEvent(
@@ -6744,10 +6761,21 @@ describe("CHAT-02: shared user message queue", () => {
     );
     expect(queued.body).toMatchObject({ runId: null });
 
-    // Cancelling the anchor frees the thread; the cancel side effects drain
-    // the queue, so the queued message gets a fresh associated row without
-    // waiting for a completed-run callback or another send (#21392).
-    await cancelChatRun(actor, anchor.runId);
+    // Cancellation is public immediately, but a claimed run keeps the thread
+    // barrier until the runner reports cancellation recovery.
+    await api.requestCancelRun(actor, anchor.runId, [200]);
+    await waitForRunStatus(actor, anchor.runId, "cancelled");
+    const beforeRecovery = await chat.listThreadEvents(actor, anchor.threadId);
+    expect(
+      userMessages(beforeRecovery.events).filter((message) => {
+        return (
+          message.revokesEventId === queuedId && message.runId !== undefined
+        );
+      }),
+    ).toHaveLength(0);
+
+    await failChatRun(anchor.runId, sandboxHeaders, "Run cancelled");
+    await flushWaitUntilForTest();
     const messages = await waitForThreadMessages(
       actor,
       anchor.threadId,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9568,7 +9568,7 @@ describe("RUN-03: cancellation of dispatched and terminal runs", () => {
       .toBe(true);
     expect(context.mocks.ably.publish).toHaveBeenCalledWith("cancel", {
       runId: run.runId,
-      mode: "hard",
+      mode: "cooperative",
     });
 
     const repeated = await api.requestCancelRun(actor, run.runId, [200]);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
@@ -30,6 +30,7 @@ import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import { createComputerUseBddApi } from "./helpers/api-bdd-computer-use";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createUserConfigBddApi } from "./helpers/api-bdd-user-config";
+import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import {
   installTeamsForTest,
   removeTeamsForTest,
@@ -49,6 +50,7 @@ const authOrgApi = createAuthOrgAgentsBddApi(context);
 const computerUseApi = createComputerUseBddApi(context);
 const runsApi = createRunsApi(context);
 const userConfigApi = createUserConfigBddApi(context);
+const webhooksApi = createWebhookCallbackApi(context);
 const trackTeamsFixture = createFixtureTracker<TeamsConnectFixture>(
   async (fixture) => {
     await removeTeamsForTest(context.signal, fixture);
@@ -709,6 +711,18 @@ async function runIdForPrompt(
     throw new Error(`Expected Teams run for prompt: ${prompt}`);
   }
   return run.id;
+}
+
+async function completeCancelledRun(
+  runId: string,
+  sandboxToken: string,
+): Promise<void> {
+  await webhooksApi.requestAgentComplete(
+    { runId, exitCode: 1, error: "Run cancelled" },
+    { authorization: `Bearer ${sandboxToken}` },
+    [200],
+  );
+  await flushWaitUntilForTest();
 }
 
 function requestTokenFromUrl(authorizationUrl: string): string {
@@ -2025,8 +2039,9 @@ describe("POST /api/zero/teams/bot", () => {
     await readTeamsBotResponseAndFlush(initialResponse);
     const initialRunId = await runIdForPrompt(actor, "run before switching");
     await runsApi.heartbeatRunner(runnerGroup);
-    await runsApi.claimRunnerJob(initialRunId);
+    const initialClaim = await runsApi.claimRunnerJob(initialRunId);
     await runsApi.requestCancelRun(actor, initialRunId, [200]);
+    await completeCancelledRun(initialRunId, initialClaim.sandboxToken);
 
     const switchAgentResponse = await postTeamsActivity({
       activity: teamsPersonalMessageActivity({
@@ -2064,6 +2079,10 @@ describe("POST /api/zero/teams/bot", () => {
       "Your name is Teams switched agent.",
     );
     await runsApi.requestCancelRun(actor, switchedAgentRunId, [200]);
+    await completeCancelledRun(
+      switchedAgentRunId,
+      switchedAgentClaim.sandboxToken,
+    );
 
     const switchModelResponse = await postTeamsActivity({
       activity: teamsPersonalMessageActivity({
@@ -2805,6 +2824,7 @@ describe("POST /api/zero/teams/bot", () => {
       host.hostId,
     );
     await runsApi.requestCancelRun(actor, firstRunId, [200]);
+    await completeCancelledRun(firstRunId, firstClaim.sandboxToken);
 
     const secondResponse = await postTeamsActivity({
       activity: teamsPersonalThreadMessageActivity({

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -5,7 +5,6 @@ import {
   elapsedSinceApiStartMs,
   NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
   RESUME_SESSION_HISTORY_MAX_BYTES,
-  RUNNER_CANCELLATION_RECOVERY_CAPABILITY,
   runnersNetworkPolicyRefreshContract,
   runnersBuiltinFirewallsResolveContract,
   runnersHeartbeatContract,
@@ -929,7 +928,6 @@ async function lockRunnerJob(
 async function transitionClaimedJobToRunning(
   db: Db,
   runId: string,
-  cancellationRecoverySupported: boolean,
   signal: AbortSignal,
   timing: ClaimRouteTimingCollector,
 ): Promise<ClaimTransitionResult> {
@@ -978,7 +976,7 @@ async function transitionClaimedJobToRunning(
               status = 'running',
               started_at = claim_clock."claimedAt",
               last_heartbeat_at = claim_clock."claimedAt",
-              cancellation_recovery_completed = ${cancellationRecoverySupported ? false : null}
+              cancellation_recovery_completed = false
             FROM locked_run
             INNER JOIN locked_job
               ON locked_job."runId" = locked_run."id"
@@ -2178,7 +2176,6 @@ const claimAuthorizedJob$ = command(
       readonly runId: string;
       readonly authType: RunnerAuthContext["type"];
       readonly jobWithRun: ClaimableJob;
-      readonly cancellationRecoverySupported: boolean;
       readonly telemetry: ClaimTimingTelemetry | undefined;
       readonly claimRequestStartedAtMs: number;
       readonly claimRouteTiming: ClaimRouteTimingCollector;
@@ -2250,7 +2247,6 @@ const claimAuthorizedJob$ = command(
         return await transitionClaimedJobToRunning(
           db,
           runId,
-          args.cancellationRecoverySupported,
           signal,
           claimRouteTiming,
         );
@@ -2318,10 +2314,6 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     runId,
     authType: auth.type,
     jobWithRun,
-    cancellationRecoverySupported:
-      body.data.capabilities?.includes(
-        RUNNER_CANCELLATION_RECOVERY_CAPABILITY,
-      ) === true,
     telemetry: body.data.telemetry,
     claimRequestStartedAtMs,
     claimRouteTiming,

--- a/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
@@ -228,8 +228,8 @@ async function publishRunnerCancellation(
   ) {
     return;
   }
-  // A null marker means the claim did not negotiate the API recovery barrier,
-  // so cooperative cancellation is unsafe even when the caller requested it.
+  // A null marker identifies a historical claim without the API recovery
+  // barrier, so cooperative cancellation is unsafe even when requested.
   const mode =
     result.cancellationRecoveryCompleted === null
       ? "hard"

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -550,6 +550,31 @@ export async function removeAcknowledgedCancellationLifecycleFixture(args: {
   });
 }
 
+/**
+ * Reproduces a historical running claim without cancellation recovery.
+ * Current product claims always initialize recovery as pending.
+ */
+export async function markCancellationRecoveryUnsupportedFixture(args: {
+  readonly runId: string;
+}): Promise<void> {
+  const updated = await db()
+    .update(agentRuns)
+    .set({ cancellationRecoveryCompleted: null })
+    .where(
+      and(
+        eq(agentRuns.id, args.runId),
+        eq(agentRuns.status, "running"),
+        eq(agentRuns.cancellationRecoveryCompleted, false),
+      ),
+    )
+    .returning({ id: agentRuns.id });
+  if (updated.length !== 1) {
+    throw new Error(
+      "Expected one recovery-pending running claim to become historical",
+    );
+  }
+}
+
 async function transitiveBlockedWaiterCount(
   holderPid: number,
 ): Promise<number> {

--- a/turbo/packages/db/src/schema/agent-run-session-conversation.ts
+++ b/turbo/packages/db/src/schema/agent-run-session-conversation.ts
@@ -60,9 +60,10 @@ export const agentRuns = pgTable(
     // "profileMismatch" | "deviceLimitMismatch" | "unparkFailed". Null means
     // unknown (old runner or historical row).
     sandboxReuseResult: varchar("sandbox_reuse_result", { length: 50 }),
-    // Null means the claim did not advertise cancellation recovery support.
-    // False/true records whether recovery completion has been reported; the
-    // barrier is active only while the public run status is cancelled.
+    // Null identifies a historical claim without cancellation recovery.
+    // Current claims initialize false; false/true records whether recovery
+    // completion has been reported. The barrier is active only while the
+    // public run status is cancelled.
     cancellationRecoveryCompleted: boolean("cancellation_recovery_completed"),
     result: jsonb("result").$type<AgentRunResult>(),
     error: text("error"),


### PR DESCRIPTION
## Summary

- initialize cancellation recovery as pending for every newly claimed run, independent of runner capability advertisement
- preserve historical nullable rows and their hard-cancellation, immediate-release behavior
- update chat and Teams integration flows to report cancellation recovery before starting same-thread follow-up work

## Compatibility

- claim requests still accept omitted, named, and unknown capabilities
- runner capability advertisement remains unchanged for overlapping older API deployments
- no migration, backfill, runner, guest-agent, scheduler, timeout, or UI change is included
- runner `0.150.5` remains the minimum supported rollback target for this cleanup phase

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/db lint`
- `pnpm -F @vm0/db check-types`
- `pnpm knip --workspace api`
- all 8 isolated API CI shards, resetting the database before each shard: 179 files and 2,561 tests passed
- post-rebase focused integration coverage: 45 cancellation callback tests, 60 chat event tests, the omitted-capability cancellation test, and 2 Teams same-thread recovery tests

Closes #23944

Parent: #23867

Follow-up: #23951
