### PR TITLE
refactor(guest-download): decouple telemetry from scheduling

### DIFF
--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -2,9 +2,10 @@ use crate::LOG_TAG;
 use crate::archive;
 use crate::error::DownloadError;
 use crate::source;
-use guest_common::{log_error, log_info, log_warn, telemetry::record_sandbox_op};
+use crate::telemetry;
+use guest_common::{log_error, log_info, log_warn};
 use std::any::Any;
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::sync::mpsc;
@@ -19,60 +20,54 @@ type TaskRunner = fn(DownloadTask) -> bool;
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct DownloadTask {
     label: String,
-    archive_kind: ArchiveKind,
     url: String,
     mount_path: String,
-    kind: DownloadTaskKind,
+    telemetry: telemetry::TaskMetadata,
 }
 
 impl DownloadTask {
-    #[cfg(test)]
-    pub(crate) fn new(
+    pub(crate) fn storage(
         label: String,
-        archive_kind: ArchiveKind,
         url: String,
         mount_path: String,
+        instructions_target_filename: Option<&str>,
     ) -> Self {
-        Self::new_with_kind(
-            label,
-            archive_kind,
-            url,
-            mount_path,
-            DownloadTaskKind::Other,
-        )
-    }
-
-    pub(crate) fn new_with_kind(
-        label: String,
-        archive_kind: ArchiveKind,
-        url: String,
-        mount_path: String,
-        kind: DownloadTaskKind,
-    ) -> Self {
+        let normalized_mount_path = normalize_mount_path(&mount_path);
+        let telemetry = telemetry::TaskMetadata::storage(
+            &url,
+            &normalized_mount_path,
+            instructions_target_filename,
+        );
         Self {
             label,
-            archive_kind,
             url,
             mount_path,
-            kind,
+            telemetry,
         }
+    }
+
+    pub(crate) fn artifact(label: String, url: String, mount_path: String) -> Self {
+        let normalized_mount_path = normalize_mount_path(&mount_path);
+        let telemetry = telemetry::TaskMetadata::artifact(&url, normalized_mount_path.as_path());
+        Self {
+            label,
+            url,
+            mount_path,
+            telemetry,
+        }
+    }
+
+    #[cfg(test)]
+    fn test_storage(label: String, url: String, mount_path: String) -> Self {
+        Self::storage(label, url, mount_path, None)
     }
 
     pub(crate) fn mount_path(&self) -> &str {
         &self.mount_path
     }
 
-    #[cfg(test)]
-    pub(crate) fn kind(&self) -> DownloadTaskKind {
-        self.kind
-    }
-
-    fn is_remote_url(&self) -> bool {
-        self.url.starts_with("http://") || self.url.starts_with("https://")
-    }
-
-    fn is_file_url(&self) -> bool {
-        self.url.starts_with("file://")
+    fn telemetry_snapshot(&self) -> telemetry::TaskSnapshot {
+        telemetry::TaskSnapshot::new(self.telemetry, normalize_mount_path(&self.mount_path))
     }
 
     fn failure_detail(&self, error: &DownloadError) -> String {
@@ -80,224 +75,19 @@ impl DownloadTask {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum ArchiveKind {
-    Storage,
-    Artifact,
-}
-
-impl ArchiveKind {
-    fn total_action(self) -> &'static str {
-        match self {
-            Self::Storage => "storage_download",
-            Self::Artifact => "artifact_download",
-        }
-    }
-
-    fn request_to_response_headers_action(self) -> &'static str {
-        match self {
-            Self::Storage => "storage_download_remote_request_to_response_headers",
-            Self::Artifact => "artifact_download_remote_request_to_response_headers",
-        }
-    }
-
-    fn body_read_action(self) -> &'static str {
-        match self {
-            Self::Storage => "storage_download_remote_body_read",
-            Self::Artifact => "artifact_download_remote_body_read",
-        }
-    }
-
-    fn extract_outside_body_read_action(self) -> &'static str {
-        match self {
-            Self::Storage => "storage_download_remote_extract_outside_body_read",
-            Self::Artifact => "artifact_download_remote_extract_outside_body_read",
-        }
-    }
-
-    fn compressed_bytes_consumed_action(self, bytes: u64) -> &'static str {
-        match (self, CompressedBytesBucket::from_bytes(bytes)) {
-            (Self::Storage, CompressedBytesBucket::Zero) => {
-                "storage_download_remote_compressed_bytes_consumed_zero"
-            }
-            (Self::Storage, CompressedBytesBucket::Under64Kib) => {
-                "storage_download_remote_compressed_bytes_consumed_lt_64_kib"
-            }
-            (Self::Storage, CompressedBytesBucket::Kib64To256) => {
-                "storage_download_remote_compressed_bytes_consumed_64_kib_to_256_kib"
-            }
-            (Self::Storage, CompressedBytesBucket::Kib256To1Mib) => {
-                "storage_download_remote_compressed_bytes_consumed_256_kib_to_1_mib"
-            }
-            (Self::Storage, CompressedBytesBucket::Mib1To4) => {
-                "storage_download_remote_compressed_bytes_consumed_1_mib_to_4_mib"
-            }
-            (Self::Storage, CompressedBytesBucket::Mib4To16) => {
-                "storage_download_remote_compressed_bytes_consumed_4_mib_to_16_mib"
-            }
-            (Self::Storage, CompressedBytesBucket::Mib16To64) => {
-                "storage_download_remote_compressed_bytes_consumed_16_mib_to_64_mib"
-            }
-            (Self::Storage, CompressedBytesBucket::Mib64Plus) => {
-                "storage_download_remote_compressed_bytes_consumed_64_mib_plus"
-            }
-            (Self::Artifact, CompressedBytesBucket::Zero) => {
-                "artifact_download_remote_compressed_bytes_consumed_zero"
-            }
-            (Self::Artifact, CompressedBytesBucket::Under64Kib) => {
-                "artifact_download_remote_compressed_bytes_consumed_lt_64_kib"
-            }
-            (Self::Artifact, CompressedBytesBucket::Kib64To256) => {
-                "artifact_download_remote_compressed_bytes_consumed_64_kib_to_256_kib"
-            }
-            (Self::Artifact, CompressedBytesBucket::Kib256To1Mib) => {
-                "artifact_download_remote_compressed_bytes_consumed_256_kib_to_1_mib"
-            }
-            (Self::Artifact, CompressedBytesBucket::Mib1To4) => {
-                "artifact_download_remote_compressed_bytes_consumed_1_mib_to_4_mib"
-            }
-            (Self::Artifact, CompressedBytesBucket::Mib4To16) => {
-                "artifact_download_remote_compressed_bytes_consumed_4_mib_to_16_mib"
-            }
-            (Self::Artifact, CompressedBytesBucket::Mib16To64) => {
-                "artifact_download_remote_compressed_bytes_consumed_16_mib_to_64_mib"
-            }
-            (Self::Artifact, CompressedBytesBucket::Mib64Plus) => {
-                "artifact_download_remote_compressed_bytes_consumed_64_mib_plus"
-            }
-        }
-    }
-
-    fn attempt_count_action(self, attempts: u32) -> &'static str {
-        match (self, attempts) {
-            (Self::Storage, 1) => "storage_download_remote_attempt_count_1",
-            (Self::Storage, 2) => "storage_download_remote_attempt_count_2",
-            (Self::Storage, _) => "storage_download_remote_attempt_count_3",
-            (Self::Artifact, 1) => "artifact_download_remote_attempt_count_1",
-            (Self::Artifact, 2) => "artifact_download_remote_attempt_count_2",
-            (Self::Artifact, _) => "artifact_download_remote_attempt_count_3",
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
-enum CompressedBytesBucket {
-    Zero,
-    Under64Kib,
-    Kib64To256,
-    Kib256To1Mib,
-    Mib1To4,
-    Mib4To16,
-    Mib16To64,
-    Mib64Plus,
-}
-
-impl CompressedBytesBucket {
-    fn from_bytes(bytes: u64) -> Self {
-        match bytes {
-            0 => Self::Zero,
-            1..65_536 => Self::Under64Kib,
-            65_536..262_144 => Self::Kib64To256,
-            262_144..1_048_576 => Self::Kib256To1Mib,
-            1_048_576..4_194_304 => Self::Mib1To4,
-            4_194_304..16_777_216 => Self::Mib4To16,
-            16_777_216..67_108_864 => Self::Mib16To64,
-            _ => Self::Mib64Plus,
-        }
-    }
-}
-
-#[derive(Default)]
-struct RemoteArchiveTaskMetrics {
-    request_to_response_headers: Duration,
-    body_read: Duration,
-    extract_outside_body_read: Duration,
-    compressed_bytes_consumed: u64,
-    attempts: u32,
-}
-
-impl RemoteArchiveTaskMetrics {
-    fn begin_attempt(&mut self) {
-        self.attempts = self.attempts.saturating_add(1);
-    }
-
-    fn record_attempt(
-        &mut self,
-        metrics: source::RemoteArchiveAttemptSnapshot,
-        extract_wall: Duration,
-    ) {
-        self.request_to_response_headers = self
-            .request_to_response_headers
-            .saturating_add(metrics.request_to_response_headers);
-        self.body_read = self.body_read.saturating_add(metrics.body_read);
-        self.extract_outside_body_read = self
-            .extract_outside_body_read
-            .saturating_add(extract_wall.saturating_sub(metrics.body_read));
-        self.compressed_bytes_consumed = self
-            .compressed_bytes_consumed
-            .saturating_add(metrics.compressed_bytes_consumed);
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum DownloadTaskKind {
-    FrameworkHomeInstructions,
-    FrameworkSkillChild,
-    Other,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum DownloadConflictKind {
-    InstructionsSkill,
-    ExactPath,
-    OtherParentChild,
+struct ScheduledDownload {
+    id: usize,
+    task: DownloadTask,
 }
 
 struct ActiveDownload {
     id: usize,
     mount_path: PathBuf,
-    kind: DownloadTaskKind,
 }
 
 struct DownloadCompletion {
     id: usize,
     outcome: DownloadOutcome,
-}
-
-#[derive(Default)]
-struct DownloadScheduleStats {
-    conflict_deferrals: DownloadConflictDeferralStats,
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-struct DownloadConflictDeferralStats {
-    total: usize,
-    instructions_skill: usize,
-    exact_path: usize,
-    other_parent_child: usize,
-}
-
-impl DownloadConflictDeferralStats {
-    fn record(&mut self, kind: DownloadConflictKind) {
-        self.total += 1;
-        match kind {
-            DownloadConflictKind::InstructionsSkill => self.instructions_skill += 1,
-            DownloadConflictKind::ExactPath => self.exact_path += 1,
-            DownloadConflictKind::OtherParentChild => self.other_parent_child += 1,
-        }
-    }
-
-    fn merge(&mut self, other: Self) {
-        self.total += other.total;
-        self.instructions_skill += other.instructions_skill;
-        self.exact_path += other.exact_path;
-        self.other_parent_child += other.other_parent_child;
-    }
-}
-
-struct StartableDownload {
-    selected: Option<(usize, PathBuf, DownloadTaskKind)>,
-    conflict_deferrals: DownloadConflictDeferralStats,
 }
 
 enum DownloadOutcome {
@@ -312,66 +102,11 @@ pub(crate) fn download_all_parallel(tasks: Vec<DownloadTask>) -> bool {
     download_all_parallel_with_runner(tasks, run_download_task)
 }
 
-fn record_download_attribution(tasks: &[DownloadTask]) {
-    record_sandbox_op(
-        guest_download_task_count_action(tasks.len()),
-        Duration::ZERO,
-        true,
-        None,
-    );
-    let remote_urls = tasks.iter().filter(|task| task.is_remote_url()).count();
-    record_sandbox_op(
-        guest_download_remote_url_count_action(remote_urls),
-        Duration::ZERO,
-        true,
-        None,
-    );
-    let file_urls = tasks.iter().filter(|task| task.is_file_url()).count();
-    record_sandbox_op(
-        guest_download_file_url_count_action(file_urls),
-        Duration::ZERO,
-        true,
-        None,
-    );
-    let skill_child_tasks = tasks
-        .iter()
-        .filter(|task| task.kind == DownloadTaskKind::FrameworkSkillChild)
-        .count();
-    record_sandbox_op(
-        guest_download_skill_child_task_count_action(skill_child_tasks),
-        Duration::ZERO,
-        true,
-        None,
-    );
-    let instructions_present = tasks
-        .iter()
-        .any(|task| task.kind == DownloadTaskKind::FrameworkHomeInstructions);
-    record_sandbox_op(
-        guest_download_framework_home_instructions_task_action(instructions_present),
-        Duration::ZERO,
-        true,
-        None,
-    );
-    record_sandbox_op(
-        guest_download_potential_parent_child_overlap_count_action(
-            potential_parent_child_overlap_count(tasks),
-        ),
-        Duration::ZERO,
-        true,
-        None,
-    );
-}
-
 fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: TaskRunner) -> bool {
-    record_download_attribution(&tasks);
+    let mut recorder =
+        telemetry::BatchRecorder::new(tasks.iter().map(DownloadTask::telemetry_snapshot));
     if tasks.is_empty() {
-        record_sandbox_op(
-            guest_download_mount_conflict_deferral_count_action(0),
-            Duration::ZERO,
-            true,
-            None,
-        );
-        record_conflict_deferral_attribution(DownloadConflictDeferralStats::default());
+        recorder.finish();
         return true;
     }
 
@@ -382,12 +117,14 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
         MAX_CONCURRENT
     );
 
-    let mut stats = DownloadScheduleStats::default();
     let success = thread::scope(|scope| {
         let (completion_tx, completion_rx) = mpsc::channel();
-        let mut pending = VecDeque::from(tasks);
+        let mut pending: VecDeque<ScheduledDownload> = tasks
+            .into_iter()
+            .enumerate()
+            .map(|(id, task)| ScheduledDownload { id, task })
+            .collect();
         let mut active = Vec::new();
-        let mut next_id = 0;
         let mut all_success = true;
 
         start_ready_downloads(
@@ -395,9 +132,10 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
             &mut pending,
             &mut active,
             &completion_tx,
-            &mut next_id,
             task_runner,
-            &mut stats,
+            &mut |pending_id, pending_path, active_id, active_path| {
+                recorder.record_conflict(pending_id, pending_path, active_id, active_path);
+            },
         );
 
         while !active.is_empty() {
@@ -428,218 +166,39 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
                 &mut pending,
                 &mut active,
                 &completion_tx,
-                &mut next_id,
                 task_runner,
-                &mut stats,
+                &mut |pending_id, pending_path, active_id, active_path| {
+                    recorder.record_conflict(pending_id, pending_path, active_id, active_path);
+                },
             );
         }
 
         all_success && pending.is_empty()
     });
-    record_sandbox_op(
-        guest_download_mount_conflict_deferral_count_action(stats.conflict_deferrals.total),
-        Duration::ZERO,
-        true,
-        None,
-    );
-    record_conflict_deferral_attribution(stats.conflict_deferrals);
+    recorder.finish();
     success
-}
-
-fn record_conflict_deferral_attribution(stats: DownloadConflictDeferralStats) {
-    record_sandbox_op(
-        guest_download_instructions_skill_conflict_deferral_count_action(stats.instructions_skill),
-        Duration::ZERO,
-        true,
-        None,
-    );
-    record_sandbox_op(
-        guest_download_exact_path_conflict_deferral_count_action(stats.exact_path),
-        Duration::ZERO,
-        true,
-        None,
-    );
-    record_sandbox_op(
-        guest_download_other_parent_child_conflict_deferral_count_action(stats.other_parent_child),
-        Duration::ZERO,
-        true,
-        None,
-    );
-}
-
-fn guest_download_task_count_action(count: usize) -> &'static str {
-    match count_bucket(count) {
-        CountBucket::Zero => "guest_download_task_count_0",
-        CountBucket::One => "guest_download_task_count_1",
-        CountBucket::Two => "guest_download_task_count_2",
-        CountBucket::ThreeToFour => "guest_download_task_count_3_4",
-        CountBucket::FiveToEight => "guest_download_task_count_5_8",
-        CountBucket::NineToSixteen => "guest_download_task_count_9_16",
-        CountBucket::SeventeenPlus => "guest_download_task_count_17_plus",
-    }
-}
-
-fn guest_download_remote_url_count_action(count: usize) -> &'static str {
-    match count_bucket(count) {
-        CountBucket::Zero => "guest_download_remote_url_count_0",
-        CountBucket::One => "guest_download_remote_url_count_1",
-        CountBucket::Two => "guest_download_remote_url_count_2",
-        CountBucket::ThreeToFour => "guest_download_remote_url_count_3_4",
-        CountBucket::FiveToEight => "guest_download_remote_url_count_5_8",
-        CountBucket::NineToSixteen => "guest_download_remote_url_count_9_16",
-        CountBucket::SeventeenPlus => "guest_download_remote_url_count_17_plus",
-    }
-}
-
-fn guest_download_file_url_count_action(count: usize) -> &'static str {
-    match count_bucket(count) {
-        CountBucket::Zero => "guest_download_file_url_count_0",
-        CountBucket::One => "guest_download_file_url_count_1",
-        CountBucket::Two => "guest_download_file_url_count_2",
-        CountBucket::ThreeToFour => "guest_download_file_url_count_3_4",
-        CountBucket::FiveToEight => "guest_download_file_url_count_5_8",
-        CountBucket::NineToSixteen => "guest_download_file_url_count_9_16",
-        CountBucket::SeventeenPlus => "guest_download_file_url_count_17_plus",
-    }
-}
-
-fn guest_download_skill_child_task_count_action(count: usize) -> &'static str {
-    match count_bucket(count) {
-        CountBucket::Zero => "guest_download_skill_child_task_count_0",
-        CountBucket::One => "guest_download_skill_child_task_count_1",
-        CountBucket::Two => "guest_download_skill_child_task_count_2",
-        CountBucket::ThreeToFour => "guest_download_skill_child_task_count_3_4",
-        CountBucket::FiveToEight => "guest_download_skill_child_task_count_5_8",
-        CountBucket::NineToSixteen => "guest_download_skill_child_task_count_9_16",
-        CountBucket::SeventeenPlus => "guest_download_skill_child_task_count_17_plus",
-    }
-}
-
-fn guest_download_framework_home_instructions_task_action(present: bool) -> &'static str {
-    if present {
-        "guest_download_framework_home_instructions_task_present"
-    } else {
-        "guest_download_framework_home_instructions_task_absent"
-    }
-}
-
-fn guest_download_potential_parent_child_overlap_count_action(count: usize) -> &'static str {
-    match count_bucket(count) {
-        CountBucket::Zero => "guest_download_potential_parent_child_overlap_count_0",
-        CountBucket::One => "guest_download_potential_parent_child_overlap_count_1",
-        CountBucket::Two => "guest_download_potential_parent_child_overlap_count_2",
-        CountBucket::ThreeToFour => "guest_download_potential_parent_child_overlap_count_3_4",
-        CountBucket::FiveToEight => "guest_download_potential_parent_child_overlap_count_5_8",
-        CountBucket::NineToSixteen => "guest_download_potential_parent_child_overlap_count_9_16",
-        CountBucket::SeventeenPlus => "guest_download_potential_parent_child_overlap_count_17_plus",
-    }
-}
-
-fn guest_download_mount_conflict_deferral_count_action(count: usize) -> &'static str {
-    match count_bucket(count) {
-        CountBucket::Zero => "guest_download_mount_conflict_deferral_count_0",
-        CountBucket::One => "guest_download_mount_conflict_deferral_count_1",
-        CountBucket::Two => "guest_download_mount_conflict_deferral_count_2",
-        CountBucket::ThreeToFour => "guest_download_mount_conflict_deferral_count_3_4",
-        CountBucket::FiveToEight => "guest_download_mount_conflict_deferral_count_5_8",
-        CountBucket::NineToSixteen => "guest_download_mount_conflict_deferral_count_9_16",
-        CountBucket::SeventeenPlus => "guest_download_mount_conflict_deferral_count_17_plus",
-    }
-}
-
-fn guest_download_instructions_skill_conflict_deferral_count_action(count: usize) -> &'static str {
-    match count_bucket(count) {
-        CountBucket::Zero => "guest_download_instructions_skill_conflict_deferral_count_0",
-        CountBucket::One => "guest_download_instructions_skill_conflict_deferral_count_1",
-        CountBucket::Two => "guest_download_instructions_skill_conflict_deferral_count_2",
-        CountBucket::ThreeToFour => "guest_download_instructions_skill_conflict_deferral_count_3_4",
-        CountBucket::FiveToEight => "guest_download_instructions_skill_conflict_deferral_count_5_8",
-        CountBucket::NineToSixteen => {
-            "guest_download_instructions_skill_conflict_deferral_count_9_16"
-        }
-        CountBucket::SeventeenPlus => {
-            "guest_download_instructions_skill_conflict_deferral_count_17_plus"
-        }
-    }
-}
-
-fn guest_download_exact_path_conflict_deferral_count_action(count: usize) -> &'static str {
-    match count_bucket(count) {
-        CountBucket::Zero => "guest_download_exact_path_conflict_deferral_count_0",
-        CountBucket::One => "guest_download_exact_path_conflict_deferral_count_1",
-        CountBucket::Two => "guest_download_exact_path_conflict_deferral_count_2",
-        CountBucket::ThreeToFour => "guest_download_exact_path_conflict_deferral_count_3_4",
-        CountBucket::FiveToEight => "guest_download_exact_path_conflict_deferral_count_5_8",
-        CountBucket::NineToSixteen => "guest_download_exact_path_conflict_deferral_count_9_16",
-        CountBucket::SeventeenPlus => "guest_download_exact_path_conflict_deferral_count_17_plus",
-    }
-}
-
-fn guest_download_other_parent_child_conflict_deferral_count_action(count: usize) -> &'static str {
-    match count_bucket(count) {
-        CountBucket::Zero => "guest_download_other_parent_child_conflict_deferral_count_0",
-        CountBucket::One => "guest_download_other_parent_child_conflict_deferral_count_1",
-        CountBucket::Two => "guest_download_other_parent_child_conflict_deferral_count_2",
-        CountBucket::ThreeToFour => "guest_download_other_parent_child_conflict_deferral_count_3_4",
-        CountBucket::FiveToEight => "guest_download_other_parent_child_conflict_deferral_count_5_8",
-        CountBucket::NineToSixteen => {
-            "guest_download_other_parent_child_conflict_deferral_count_9_16"
-        }
-        CountBucket::SeventeenPlus => {
-            "guest_download_other_parent_child_conflict_deferral_count_17_plus"
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
-enum CountBucket {
-    Zero,
-    One,
-    Two,
-    ThreeToFour,
-    FiveToEight,
-    NineToSixteen,
-    SeventeenPlus,
-}
-
-fn count_bucket(count: usize) -> CountBucket {
-    match count {
-        0 => CountBucket::Zero,
-        1 => CountBucket::One,
-        2 => CountBucket::Two,
-        3 | 4 => CountBucket::ThreeToFour,
-        5..=8 => CountBucket::FiveToEight,
-        9..=16 => CountBucket::NineToSixteen,
-        _ => CountBucket::SeventeenPlus,
-    }
 }
 
 fn start_ready_downloads<'scope, 'env: 'scope>(
     scope: &'scope thread::Scope<'scope, 'env>,
-    pending: &mut VecDeque<DownloadTask>,
+    pending: &mut VecDeque<ScheduledDownload>,
     active: &mut Vec<ActiveDownload>,
     completion_tx: &mpsc::Sender<DownloadCompletion>,
-    next_id: &mut usize,
     task_runner: TaskRunner,
-    stats: &mut DownloadScheduleStats,
+    on_conflict: &mut impl FnMut(usize, &Path, usize, &Path),
 ) {
     while active.len() < MAX_CONCURRENT {
-        let startable = find_startable_download(pending, active);
-        stats.conflict_deferrals.merge(startable.conflict_deferrals);
-        let Some((index, mount_path, kind)) = startable.selected else {
+        let Some((index, mount_path)) = find_startable_download(pending, active, on_conflict)
+        else {
             break;
         };
-        let Some(task) = pending.remove(index) else {
+        let Some(download) = pending.remove(index) else {
             log_error!(LOG_TAG, "Download scheduler selected a missing task");
             break;
         };
-        let id = *next_id;
-        *next_id += 1;
-        active.push(ActiveDownload {
-            id,
-            mount_path,
-            kind,
-        });
+        let id = download.id;
+        let task = download.task;
+        active.push(ActiveDownload { id, mount_path });
 
         let completion_tx = completion_tx.clone();
         scope.spawn(move || {
@@ -653,116 +212,32 @@ fn start_ready_downloads<'scope, 'env: 'scope>(
 }
 
 fn find_startable_download(
-    pending: &VecDeque<DownloadTask>,
+    pending: &VecDeque<ScheduledDownload>,
     active: &[ActiveDownload],
-) -> StartableDownload {
+    on_conflict: &mut impl FnMut(usize, &Path, usize, &Path),
+) -> Option<(usize, PathBuf)> {
     // Scan the pending queue instead of using strict FIFO so an active
     // parent/child mount-path conflict does not leave a slot idle when a later
     // independent task can start.
-    let mut conflict_deferrals = DownloadConflictDeferralStats::default();
-    for (index, task) in pending.iter().enumerate() {
-        let mount_path = normalize_mount_path(task.mount_path());
+    for (index, download) in pending.iter().enumerate() {
+        let mount_path = normalize_mount_path(download.task.mount_path());
 
-        if let Some(conflict) = active.iter().find_map(|download| {
-            classify_download_conflict(
-                mount_path.as_path(),
-                task.kind,
-                download.mount_path.as_path(),
-                download.kind,
-            )
+        if let Some(blocking) = active.iter().find(|active_download| {
+            mount_paths_conflict(mount_path.as_path(), active_download.mount_path.as_path())
         }) {
-            conflict_deferrals.record(conflict);
+            on_conflict(
+                download.id,
+                mount_path.as_path(),
+                blocking.id,
+                blocking.mount_path.as_path(),
+            );
             continue;
         }
 
-        return StartableDownload {
-            selected: Some((index, mount_path, task.kind)),
-            conflict_deferrals,
-        };
+        return Some((index, mount_path));
     }
 
-    StartableDownload {
-        selected: None,
-        conflict_deferrals,
-    }
-}
-
-pub(crate) fn classify_download_task_kind(
-    mount_path: &str,
-    instructions_target_filename: Option<&str>,
-) -> DownloadTaskKind {
-    if instructions_target_filename.is_some() {
-        return DownloadTaskKind::FrameworkHomeInstructions;
-    }
-
-    if is_framework_skill_child_path(&normalize_mount_path(mount_path)) {
-        return DownloadTaskKind::FrameworkSkillChild;
-    }
-
-    DownloadTaskKind::Other
-}
-
-fn classify_download_conflict(
-    left_path: &Path,
-    left_kind: DownloadTaskKind,
-    right_path: &Path,
-    right_kind: DownloadTaskKind,
-) -> Option<DownloadConflictKind> {
-    if !mount_paths_conflict(left_path, right_path) {
-        return None;
-    }
-    if left_path == right_path {
-        return Some(DownloadConflictKind::ExactPath);
-    }
-    if task_kinds_are_instructions_and_skill(left_kind, right_kind) {
-        return Some(DownloadConflictKind::InstructionsSkill);
-    }
-    Some(DownloadConflictKind::OtherParentChild)
-}
-
-fn task_kinds_are_instructions_and_skill(left: DownloadTaskKind, right: DownloadTaskKind) -> bool {
-    matches!(
-        (left, right),
-        (
-            DownloadTaskKind::FrameworkHomeInstructions,
-            DownloadTaskKind::FrameworkSkillChild
-        ) | (
-            DownloadTaskKind::FrameworkSkillChild,
-            DownloadTaskKind::FrameworkHomeInstructions
-        )
-    )
-}
-
-fn potential_parent_child_overlap_count(tasks: &[DownloadTask]) -> usize {
-    let normalized_paths: Vec<PathBuf> = tasks
-        .iter()
-        .map(|task| normalize_mount_path(task.mount_path()))
-        .collect();
-    let mut path_counts = HashMap::new();
-    for path in &normalized_paths {
-        *path_counts.entry(path.clone()).or_insert(0usize) += 1;
-    }
-
-    let mut count = 0;
-
-    for path in &normalized_paths {
-        for ancestor in path.ancestors().skip(1) {
-            if let Some(ancestor_count) = path_counts.get(ancestor) {
-                count += ancestor_count;
-            }
-        }
-    }
-
-    count
-}
-
-fn is_framework_skill_child_path(path: &Path) -> bool {
-    is_child_path(path, Path::new("/home/user/.codex/skills"))
-        || is_child_path(path, Path::new("/home/user/.claude/skills"))
-}
-
-fn is_child_path(path: &Path, parent: &Path) -> bool {
-    path.starts_with(parent) && path != parent
+    None
 }
 
 fn normalize_mount_path(path: &str) -> PathBuf {
@@ -804,15 +279,12 @@ fn panic_message(payload: &(dyn Any + Send)) -> String {
 fn run_download_task(task: DownloadTask) -> bool {
     let start = Instant::now();
     log_info!(LOG_TAG, "Downloading {} to {}", task.label, task.mount_path);
-    let mut remote_metrics = task.is_remote_url().then(RemoteArchiveTaskMetrics::default);
+    let mut recorder = telemetry::TaskRecorder::new(task.telemetry);
 
-    match download_with_retry(&task.url, &task.mount_path, remote_metrics.as_mut()) {
+    match download_with_retry(&task.url, &task.mount_path, &mut recorder) {
         Ok(()) => {
             let elapsed = start.elapsed();
-            record_sandbox_op(task.archive_kind.total_action(), elapsed, true, None);
-            if let Some(metrics) = &remote_metrics {
-                record_remote_archive_attribution(task.archive_kind, metrics, true);
-            }
+            recorder.finish(elapsed, true, None);
             log_info!(
                 LOG_TAG,
                 "{} downloaded in {}ms",
@@ -823,56 +295,11 @@ fn run_download_task(task: DownloadTask) -> bool {
         }
         Err(e) => {
             let failure_detail = task.failure_detail(&e);
-            record_sandbox_op(
-                task.archive_kind.total_action(),
-                start.elapsed(),
-                false,
-                Some(&failure_detail),
-            );
-            if let Some(metrics) = &remote_metrics {
-                record_remote_archive_attribution(task.archive_kind, metrics, false);
-            }
+            recorder.finish(start.elapsed(), false, Some(&failure_detail));
             log_error!(LOG_TAG, "{failure_detail}");
             false
         }
     }
-}
-
-fn record_remote_archive_attribution(
-    archive_kind: ArchiveKind,
-    metrics: &RemoteArchiveTaskMetrics,
-    success: bool,
-) {
-    record_sandbox_op(
-        archive_kind.request_to_response_headers_action(),
-        metrics.request_to_response_headers,
-        success,
-        None,
-    );
-    record_sandbox_op(
-        archive_kind.body_read_action(),
-        metrics.body_read,
-        success,
-        None,
-    );
-    record_sandbox_op(
-        archive_kind.extract_outside_body_read_action(),
-        metrics.extract_outside_body_read,
-        success,
-        None,
-    );
-    record_sandbox_op(
-        archive_kind.compressed_bytes_consumed_action(metrics.compressed_bytes_consumed),
-        Duration::ZERO,
-        success,
-        None,
-    );
-    record_sandbox_op(
-        archive_kind.attempt_count_action(metrics.attempts),
-        Duration::ZERO,
-        success,
-        None,
-    );
 }
 
 /// Download and extract an archive, retrying retriable failures.
@@ -883,16 +310,14 @@ fn record_remote_archive_attribution(
 fn download_with_retry(
     url: &str,
     target_path: &str,
-    mut remote_metrics: Option<&mut RemoteArchiveTaskMetrics>,
+    recorder: &mut telemetry::TaskRecorder,
 ) -> Result<(), DownloadError> {
     let mut last_error = None;
 
     for attempt in 1..=MAX_RETRIES {
-        if let Some(metrics) = remote_metrics.as_deref_mut() {
-            metrics.begin_attempt();
-        }
+        let attempt_metrics = recorder.begin_attempt();
         let attempt_start = Instant::now();
-        match download_and_extract(url, target_path, remote_metrics.as_deref_mut()) {
+        match download_and_extract(url, target_path, attempt_metrics, recorder) {
             Ok(()) => return Ok(()),
             Err(e) => {
                 log_warn!(
@@ -918,20 +343,18 @@ fn download_with_retry(
 fn download_and_extract(
     url: &str,
     target_path: &str,
-    remote_metrics: Option<&mut RemoteArchiveTaskMetrics>,
+    attempt_metrics: Option<source::RemoteArchiveAttemptMetrics>,
+    recorder: &mut telemetry::TaskRecorder,
 ) -> Result<(), DownloadError> {
     fs::create_dir_all(target_path).map_err(|e| {
         DownloadError::fatal(format!("Failed to create directory {target_path}: {e}"))
     })?;
 
-    let attempt_metrics = remote_metrics
-        .is_some()
-        .then(source::RemoteArchiveAttemptMetrics::default);
     let reader = match source::open_archive(url, attempt_metrics.as_ref()) {
         Ok(reader) => reader,
         Err(error) => {
-            if let (Some(metrics), Some(attempt_metrics)) = (remote_metrics, &attempt_metrics) {
-                metrics.record_attempt(attempt_metrics.snapshot(), Duration::ZERO);
+            if let Some(attempt_metrics) = attempt_metrics.as_ref() {
+                recorder.record_attempt(attempt_metrics, Duration::ZERO);
             }
             return Err(error);
         }
@@ -939,8 +362,8 @@ fn download_and_extract(
     let extract_start = Instant::now();
     let result = archive::extract_tar_gz(reader, target_path);
     let extract_wall = extract_start.elapsed();
-    if let (Some(metrics), Some(attempt_metrics)) = (remote_metrics, &attempt_metrics) {
-        metrics.record_attempt(attempt_metrics.snapshot(), extract_wall);
+    if let Some(attempt_metrics) = attempt_metrics.as_ref() {
+        recorder.record_attempt(attempt_metrics, extract_wall);
     }
     result
 }
@@ -948,46 +371,15 @@ fn download_and_extract(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
-    use std::sync::{Mutex, MutexGuard};
 
-    static SANDBOX_OP_TEST_LOCK: Mutex<()> = Mutex::new(());
-
-    struct SandboxOpsLogGuard {
-        _lock: MutexGuard<'static, ()>,
-    }
-
-    impl SandboxOpsLogGuard {
-        fn set(path: impl AsRef<Path>) -> Self {
-            let lock = SANDBOX_OP_TEST_LOCK
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            guest_common::telemetry::set_sandbox_ops_log_file(path);
-            Self { _lock: lock }
-        }
-    }
-
-    impl Drop for SandboxOpsLogGuard {
-        fn drop(&mut self) {
-            guest_common::telemetry::clear_sandbox_ops_log_file();
-        }
-    }
-
-    fn task_at(path: &str, kind: DownloadTaskKind) -> DownloadTask {
-        DownloadTask::new_with_kind(
-            format!("task {path}"),
-            ArchiveKind::Storage,
-            "file:///tmp/archive.tar.gz".to_owned(),
-            path.to_owned(),
-            kind,
-        )
-    }
-
-    fn active_at(path: &str, kind: DownloadTaskKind) -> ActiveDownload {
-        ActiveDownload {
-            id: 0,
-            mount_path: normalize_mount_path(path),
-            kind,
+    fn scheduled_at(id: usize, path: &str) -> ScheduledDownload {
+        ScheduledDownload {
+            id,
+            task: DownloadTask::test_storage(
+                format!("task {path}"),
+                "file:///tmp/archive.tar.gz".to_owned(),
+                path.to_owned(),
+            ),
         }
     }
 
@@ -1032,122 +424,6 @@ mod tests {
     }
 
     #[test]
-    fn task_kind_classification_identifies_instructions_and_skill_children() {
-        assert_eq!(
-            classify_download_task_kind("/home/user/.codex", Some("AGENTS.md")),
-            DownloadTaskKind::FrameworkHomeInstructions
-        );
-        assert_eq!(
-            classify_download_task_kind("/home/user/.codex/skills/workflow", None),
-            DownloadTaskKind::FrameworkSkillChild
-        );
-        assert_eq!(
-            classify_download_task_kind("/home/user/.claude/skills/tool", None),
-            DownloadTaskKind::FrameworkSkillChild
-        );
-        assert_eq!(
-            classify_download_task_kind("/home/user/.codex/skills", None),
-            DownloadTaskKind::Other
-        );
-        assert_eq!(
-            classify_download_task_kind("/workspace", None),
-            DownloadTaskKind::Other
-        );
-    }
-
-    #[test]
-    fn task_kind_classification_uses_normalized_component_paths() {
-        assert_eq!(
-            classify_download_task_kind("/home/user/.codex/skills/./workflow", None),
-            DownloadTaskKind::FrameworkSkillChild
-        );
-        assert_eq!(
-            classify_download_task_kind("/home/user/.claude/skills/./tool", None),
-            DownloadTaskKind::FrameworkSkillChild
-        );
-        assert_eq!(
-            classify_download_task_kind("/home/user/.codex/skills/../workflow", None),
-            DownloadTaskKind::Other
-        );
-        assert_eq!(
-            classify_download_task_kind("/home/user/.claude/skills", None),
-            DownloadTaskKind::Other
-        );
-        assert_eq!(
-            classify_download_task_kind("/home/user/.claude/skills-old/tool", None),
-            DownloadTaskKind::Other
-        );
-    }
-
-    #[test]
-    fn conflict_classifier_buckets_exact_instruction_skill_and_other_parent_child() {
-        assert_eq!(
-            classify_download_conflict(
-                &normalize_mount_path("/home/user/.codex/skills/foo"),
-                DownloadTaskKind::FrameworkSkillChild,
-                &normalize_mount_path("/home/user/.codex"),
-                DownloadTaskKind::FrameworkHomeInstructions,
-            ),
-            Some(DownloadConflictKind::InstructionsSkill)
-        );
-        assert_eq!(
-            classify_download_conflict(
-                &normalize_mount_path("/same"),
-                DownloadTaskKind::Other,
-                &normalize_mount_path("/same"),
-                DownloadTaskKind::Other,
-            ),
-            Some(DownloadConflictKind::ExactPath)
-        );
-        assert_eq!(
-            classify_download_conflict(
-                &normalize_mount_path("/tmp/parent/child"),
-                DownloadTaskKind::Other,
-                &normalize_mount_path("/tmp/parent"),
-                DownloadTaskKind::Other,
-            ),
-            Some(DownloadConflictKind::OtherParentChild)
-        );
-        assert_eq!(
-            classify_download_conflict(
-                &normalize_mount_path("/home/user/.codex/skills/foo"),
-                DownloadTaskKind::FrameworkSkillChild,
-                &normalize_mount_path("/home/user/.codex/skills/bar"),
-                DownloadTaskKind::FrameworkSkillChild,
-            ),
-            None
-        );
-    }
-
-    #[test]
-    fn conflict_classifier_does_not_overlap_staged_instructions_with_skill_children() {
-        assert_eq!(
-            classify_download_conflict(
-                &normalize_mount_path("/home/user/.codex/skills/workflow"),
-                DownloadTaskKind::FrameworkSkillChild,
-                &normalize_mount_path(
-                    "/home/user/.vm0/guest-agent/runs/run-id/storage-instructions/0",
-                ),
-                DownloadTaskKind::FrameworkHomeInstructions,
-            ),
-            None
-        );
-    }
-
-    #[test]
-    fn potential_parent_child_overlap_count_excludes_exact_paths_and_siblings() {
-        let tasks = [
-            task_at("/workspace", DownloadTaskKind::Other),
-            task_at("/workspace/src", DownloadTaskKind::Other),
-            task_at("/workspace/tests", DownloadTaskKind::Other),
-            task_at("/workspace/src", DownloadTaskKind::Other),
-            task_at("/workspace/src/nested", DownloadTaskKind::Other),
-        ];
-
-        assert_eq!(potential_parent_child_overlap_count(&tasks), 6);
-    }
-
-    #[test]
     fn task_panic_returns_false_without_unwinding() {
         guest_common::log::clear_system_log_file();
 
@@ -1161,15 +437,13 @@ mod tests {
         let result = std::panic::catch_unwind(|| {
             download_all_parallel_with_runner(
                 vec![
-                    DownloadTask::new(
+                    DownloadTask::test_storage(
                         "panic".to_owned(),
-                        ArchiveKind::Storage,
                         "panic".to_owned(),
                         "/tmp/panic".to_owned(),
                     ),
-                    DownloadTask::new(
+                    DownloadTask::test_storage(
                         "success".to_owned(),
-                        ArchiveKind::Storage,
                         "success".to_owned(),
                         "/tmp/success".to_owned(),
                     ),
@@ -1182,173 +456,55 @@ mod tests {
     }
 
     #[test]
-    fn find_startable_download_counts_mount_conflict_deferrals() {
+    fn find_startable_download_observes_conflict_and_selects_later_task() {
         let pending = VecDeque::from(vec![
-            DownloadTask::new(
-                "blocked child".to_owned(),
-                ArchiveKind::Storage,
-                "file:///tmp/archive.tar.gz".to_owned(),
-                "/tmp/mount/child".to_owned(),
-            ),
-            DownloadTask::new(
-                "independent".to_owned(),
-                ArchiveKind::Artifact,
-                "https://example.com/archive.tar.gz".to_owned(),
-                "/tmp/other".to_owned(),
-            ),
+            scheduled_at(3, "/tmp/mount/child"),
+            scheduled_at(4, "/tmp/other"),
         ]);
         let active = vec![ActiveDownload {
-            id: 0,
+            id: 2,
             mount_path: normalize_mount_path("/tmp/mount"),
-            kind: DownloadTaskKind::Other,
         }];
+        let mut conflicts = Vec::new();
 
-        let startable = find_startable_download(&pending, &active);
+        let selected =
+            find_startable_download(&pending, &active, &mut |pending_id, _, active_id, _| {
+                conflicts.push((pending_id, active_id));
+            });
 
-        assert_eq!(
-            startable.conflict_deferrals,
-            DownloadConflictDeferralStats {
-                total: 1,
-                instructions_skill: 0,
-                exact_path: 0,
-                other_parent_child: 1,
-            }
-        );
-        assert_eq!(startable.selected.map(|(index, _, _)| index), Some(1));
+        assert_eq!(conflicts, [(3, 2)]);
+        assert_eq!(selected.map(|(index, _)| index), Some(1));
     }
 
     #[test]
-    fn find_startable_download_buckets_instruction_skill_deferrals_in_both_directions() {
-        let independent = task_at("/tmp/other", DownloadTaskKind::Other);
+    fn find_startable_download_reports_only_first_active_conflict() {
+        let pending = VecDeque::from([scheduled_at(4, "/tmp/mount/child")]);
+        let active = vec![
+            ActiveDownload {
+                id: 2,
+                mount_path: normalize_mount_path("/tmp/mount"),
+            },
+            ActiveDownload {
+                id: 3,
+                mount_path: normalize_mount_path("/tmp/mount/child"),
+            },
+        ];
+        let mut conflicts = Vec::new();
 
-        let pending_child = VecDeque::from(vec![
-            task_at(
-                "/home/user/.codex/skills/workflow",
-                DownloadTaskKind::FrameworkSkillChild,
-            ),
-            independent,
-        ]);
-        let active_parent = vec![active_at(
-            "/home/user/.codex",
-            DownloadTaskKind::FrameworkHomeInstructions,
-        )];
-        let child_startable = find_startable_download(&pending_child, &active_parent);
+        let selected =
+            find_startable_download(&pending, &active, &mut |pending_id, _, active_id, _| {
+                conflicts.push((pending_id, active_id));
+            });
 
-        assert_eq!(
-            child_startable.conflict_deferrals,
-            DownloadConflictDeferralStats {
-                total: 1,
-                instructions_skill: 1,
-                exact_path: 0,
-                other_parent_child: 0,
-            }
-        );
-        assert_eq!(child_startable.selected.map(|(index, _, _)| index), Some(1));
-
-        let pending_parent = VecDeque::from(vec![
-            task_at(
-                "/home/user/.claude",
-                DownloadTaskKind::FrameworkHomeInstructions,
-            ),
-            task_at("/tmp/other", DownloadTaskKind::Other),
-        ]);
-        let active_child = vec![active_at(
-            "/home/user/.claude/skills/workflow",
-            DownloadTaskKind::FrameworkSkillChild,
-        )];
-        let parent_startable = find_startable_download(&pending_parent, &active_child);
-
-        assert_eq!(
-            parent_startable.conflict_deferrals,
-            DownloadConflictDeferralStats {
-                total: 1,
-                instructions_skill: 1,
-                exact_path: 0,
-                other_parent_child: 0,
-            }
-        );
-        assert_eq!(
-            parent_startable.selected.map(|(index, _, _)| index),
-            Some(1)
-        );
-    }
-
-    #[test]
-    fn find_startable_download_buckets_exact_path_deferrals() {
-        let pending = VecDeque::from(vec![
-            task_at("/tmp/mount", DownloadTaskKind::Other),
-            task_at("/tmp/other", DownloadTaskKind::Other),
-        ]);
-        let active = vec![active_at("/tmp/mount", DownloadTaskKind::Other)];
-
-        let startable = find_startable_download(&pending, &active);
-
-        assert_eq!(
-            startable.conflict_deferrals,
-            DownloadConflictDeferralStats {
-                total: 1,
-                instructions_skill: 0,
-                exact_path: 1,
-                other_parent_child: 0,
-            }
-        );
-        assert_eq!(startable.selected.map(|(index, _, _)| index), Some(1));
-    }
-
-    #[test]
-    fn download_all_parallel_records_conflict_shape_actions() {
-        let dir = tempfile::tempdir().unwrap();
-        let ops_path = dir.path().join("sandbox-ops.jsonl");
-        let _ops_guard = SandboxOpsLogGuard::set(&ops_path);
-
-        fn runner(_task: DownloadTask) -> bool {
-            true
-        }
-
-        let success = download_all_parallel_with_runner(
-            vec![
-                task_at(
-                    "/home/user/.codex",
-                    DownloadTaskKind::FrameworkHomeInstructions,
-                ),
-                task_at(
-                    "/home/user/.codex/skills/workflow",
-                    DownloadTaskKind::FrameworkSkillChild,
-                ),
-            ],
-            runner,
-        );
-
-        assert!(success);
-        let ops = std::fs::read_to_string(&ops_path).unwrap();
-        assert!(ops.contains(r#""action_type":"guest_download_task_count_2""#));
-        assert!(ops.contains(r#""action_type":"guest_download_skill_child_task_count_1""#));
-        assert!(ops.contains(
-            r#""action_type":"guest_download_framework_home_instructions_task_present""#
-        ));
-        assert!(
-            ops.contains(
-                r#""action_type":"guest_download_potential_parent_child_overlap_count_1""#
-            )
-        );
-        assert!(ops.contains(r#""action_type":"guest_download_mount_conflict_deferral_count_1""#));
-        assert!(ops.contains(
-            r#""action_type":"guest_download_instructions_skill_conflict_deferral_count_1""#
-        ));
-        assert!(
-            ops.contains(r#""action_type":"guest_download_exact_path_conflict_deferral_count_0""#)
-        );
-        assert!(ops.contains(
-            r#""action_type":"guest_download_other_parent_child_conflict_deferral_count_0""#
-        ));
+        assert_eq!(selected, None);
+        assert_eq!(conflicts, [(4, 2)]);
     }
 
     #[test]
     fn download_task_failure_detail_includes_entry_metadata() {
-        let task = DownloadTask::new(
+        let task = DownloadTask::test_storage(
             "storage 1 mountPath=/workspace vasStorageName=repo vasVersionId=v1 urlScheme=file cached=false"
                 .into(),
-            ArchiveKind::Storage,
             "file:///tmp/archive.tar.gz".into(),
             "/workspace".into(),
         );

--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -2,7 +2,9 @@ use crate::LOG_TAG;
 use crate::archive;
 use crate::error::DownloadError;
 use crate::source;
-use crate::telemetry;
+use crate::telemetry::{
+    DownloadIdentity, DownloadRunTelemetry, DownloadTaskTelemetry, RemoteArchiveTaskMetrics,
+};
 use guest_common::{log_error, log_info, log_warn};
 use std::any::Any;
 use std::collections::VecDeque;
@@ -22,7 +24,8 @@ pub(crate) struct DownloadTask {
     label: String,
     url: String,
     mount_path: String,
-    telemetry: telemetry::TaskMetadata,
+    normalized_mount_path: PathBuf,
+    telemetry: DownloadTaskTelemetry,
 }
 
 impl DownloadTask {
@@ -30,44 +33,34 @@ impl DownloadTask {
         label: String,
         url: String,
         mount_path: String,
-        instructions_target_filename: Option<&str>,
+        has_instructions_target: bool,
     ) -> Self {
         let normalized_mount_path = normalize_mount_path(&mount_path);
-        let telemetry = telemetry::TaskMetadata::storage(
-            &url,
-            &normalized_mount_path,
-            instructions_target_filename,
-        );
+        let telemetry =
+            DownloadTaskTelemetry::storage(&url, &normalized_mount_path, has_instructions_target);
         Self {
             label,
             url,
             mount_path,
+            normalized_mount_path,
             telemetry,
         }
     }
 
     pub(crate) fn artifact(label: String, url: String, mount_path: String) -> Self {
         let normalized_mount_path = normalize_mount_path(&mount_path);
-        let telemetry = telemetry::TaskMetadata::artifact(&url, normalized_mount_path.as_path());
+        let telemetry = DownloadTaskTelemetry::artifact(&url, &normalized_mount_path);
         Self {
             label,
             url,
             mount_path,
+            normalized_mount_path,
             telemetry,
         }
     }
 
-    #[cfg(test)]
-    fn test_storage(label: String, url: String, mount_path: String) -> Self {
-        Self::storage(label, url, mount_path, None)
-    }
-
     pub(crate) fn mount_path(&self) -> &str {
         &self.mount_path
-    }
-
-    fn telemetry_snapshot(&self) -> telemetry::TaskSnapshot {
-        telemetry::TaskSnapshot::new(self.telemetry, normalize_mount_path(&self.mount_path))
     }
 
     fn failure_detail(&self, error: &DownloadError) -> String {
@@ -75,18 +68,27 @@ impl DownloadTask {
     }
 }
 
-struct ScheduledDownload {
-    id: usize,
+struct PendingDownload {
+    identity: DownloadIdentity,
     task: DownloadTask,
 }
 
+impl PendingDownload {
+    fn new(sequence: usize, task: DownloadTask) -> Self {
+        Self {
+            identity: task.telemetry.identity(sequence),
+            task,
+        }
+    }
+}
+
 struct ActiveDownload {
-    id: usize,
+    identity: DownloadIdentity,
     mount_path: PathBuf,
 }
 
 struct DownloadCompletion {
-    id: usize,
+    identity: DownloadIdentity,
     outcome: DownloadOutcome,
 }
 
@@ -103,27 +105,31 @@ pub(crate) fn download_all_parallel(tasks: Vec<DownloadTask>) -> bool {
 }
 
 fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: TaskRunner) -> bool {
-    let mut recorder =
-        telemetry::BatchRecorder::new(tasks.iter().map(DownloadTask::telemetry_snapshot));
-    if tasks.is_empty() {
-        recorder.finish();
+    let mut pending = tasks
+        .into_iter()
+        .enumerate()
+        .map(|(sequence, task)| PendingDownload::new(sequence, task))
+        .collect::<VecDeque<_>>();
+    let mut telemetry = DownloadRunTelemetry::start(pending.iter().map(|download| {
+        (
+            download.task.telemetry,
+            download.task.normalized_mount_path.as_path(),
+        )
+    }));
+    if pending.is_empty() {
+        telemetry.finish();
         return true;
     }
 
     log_info!(
         LOG_TAG,
         "Downloading {} items (max {} concurrent)",
-        tasks.len(),
+        pending.len(),
         MAX_CONCURRENT
     );
 
     let success = thread::scope(|scope| {
         let (completion_tx, completion_rx) = mpsc::channel();
-        let mut pending: VecDeque<ScheduledDownload> = tasks
-            .into_iter()
-            .enumerate()
-            .map(|(id, task)| ScheduledDownload { id, task })
-            .collect();
         let mut active = Vec::new();
         let mut all_success = true;
 
@@ -133,9 +139,7 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
             &mut active,
             &completion_tx,
             task_runner,
-            &mut |pending_id, pending_path, active_id, active_path| {
-                recorder.record_conflict(pending_id, pending_path, active_id, active_path);
-            },
+            &mut telemetry,
         );
 
         while !active.is_empty() {
@@ -147,7 +151,7 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
                 }
             };
 
-            active.retain(|download| download.id != completion.id);
+            active.retain(|download| download.identity != completion.identity);
 
             match completion.outcome {
                 DownloadOutcome::Finished(success) => {
@@ -167,74 +171,74 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
                 &mut active,
                 &completion_tx,
                 task_runner,
-                &mut |pending_id, pending_path, active_id, active_path| {
-                    recorder.record_conflict(pending_id, pending_path, active_id, active_path);
-                },
+                &mut telemetry,
             );
         }
 
         all_success && pending.is_empty()
     });
-    recorder.finish();
+    telemetry.finish();
     success
 }
 
 fn start_ready_downloads<'scope, 'env: 'scope>(
     scope: &'scope thread::Scope<'scope, 'env>,
-    pending: &mut VecDeque<ScheduledDownload>,
+    pending: &mut VecDeque<PendingDownload>,
     active: &mut Vec<ActiveDownload>,
     completion_tx: &mpsc::Sender<DownloadCompletion>,
     task_runner: TaskRunner,
-    on_conflict: &mut impl FnMut(usize, &Path, usize, &Path),
+    telemetry: &mut DownloadRunTelemetry,
 ) {
     while active.len() < MAX_CONCURRENT {
-        let Some((index, mount_path)) = find_startable_download(pending, active, on_conflict)
-        else {
+        let Some((index, mount_path)) = find_startable_download(pending, active, telemetry) else {
             break;
         };
         let Some(download) = pending.remove(index) else {
             log_error!(LOG_TAG, "Download scheduler selected a missing task");
             break;
         };
-        let id = download.id;
-        let task = download.task;
-        active.push(ActiveDownload { id, mount_path });
+        let identity = download.identity;
+        active.push(ActiveDownload {
+            identity,
+            mount_path,
+        });
 
         let completion_tx = completion_tx.clone();
         scope.spawn(move || {
-            let outcome = std::panic::catch_unwind(|| task_runner(task))
+            let outcome = std::panic::catch_unwind(|| task_runner(download.task))
                 .map(DownloadOutcome::Finished)
                 .unwrap_or_else(|e| DownloadOutcome::Panicked(panic_message(e.as_ref())));
 
-            let _ = completion_tx.send(DownloadCompletion { id, outcome });
+            let _ = completion_tx.send(DownloadCompletion { identity, outcome });
         });
     }
 }
 
 fn find_startable_download(
-    pending: &VecDeque<ScheduledDownload>,
+    pending: &VecDeque<PendingDownload>,
     active: &[ActiveDownload],
-    on_conflict: &mut impl FnMut(usize, &Path, usize, &Path),
+    telemetry: &mut DownloadRunTelemetry,
 ) -> Option<(usize, PathBuf)> {
     // Scan the pending queue instead of using strict FIFO so an active
     // parent/child mount-path conflict does not leave a slot idle when a later
     // independent task can start.
     for (index, download) in pending.iter().enumerate() {
-        let mount_path = normalize_mount_path(download.task.mount_path());
+        let mount_path = &download.task.normalized_mount_path;
 
-        if let Some(blocking) = active.iter().find(|active_download| {
-            mount_paths_conflict(mount_path.as_path(), active_download.mount_path.as_path())
-        }) {
-            on_conflict(
-                download.id,
-                mount_path.as_path(),
-                blocking.id,
-                blocking.mount_path.as_path(),
+        if let Some(active_download) = active
+            .iter()
+            .find(|active_download| mount_paths_conflict(mount_path, &active_download.mount_path))
+        {
+            telemetry.record_conflict(
+                download.identity,
+                mount_path,
+                active_download.identity,
+                &active_download.mount_path,
             );
             continue;
         }
 
-        return Some((index, mount_path));
+        return Some((index, mount_path.clone()));
     }
 
     None
@@ -279,12 +283,13 @@ fn panic_message(payload: &(dyn Any + Send)) -> String {
 fn run_download_task(task: DownloadTask) -> bool {
     let start = Instant::now();
     log_info!(LOG_TAG, "Downloading {} to {}", task.label, task.mount_path);
-    let mut recorder = telemetry::TaskRecorder::new(task.telemetry);
+    let mut remote_metrics = task.telemetry.remote_metrics();
 
-    match download_with_retry(&task.url, &task.mount_path, &mut recorder) {
+    match download_with_retry(&task.url, &task.mount_path, remote_metrics.as_mut()) {
         Ok(()) => {
             let elapsed = start.elapsed();
-            recorder.finish(elapsed, true, None);
+            task.telemetry
+                .record_result(elapsed, true, None, remote_metrics.as_ref());
             log_info!(
                 LOG_TAG,
                 "{} downloaded in {}ms",
@@ -295,7 +300,12 @@ fn run_download_task(task: DownloadTask) -> bool {
         }
         Err(e) => {
             let failure_detail = task.failure_detail(&e);
-            recorder.finish(start.elapsed(), false, Some(&failure_detail));
+            task.telemetry.record_result(
+                start.elapsed(),
+                false,
+                Some(&failure_detail),
+                remote_metrics.as_ref(),
+            );
             log_error!(LOG_TAG, "{failure_detail}");
             false
         }
@@ -310,14 +320,16 @@ fn run_download_task(task: DownloadTask) -> bool {
 fn download_with_retry(
     url: &str,
     target_path: &str,
-    recorder: &mut telemetry::TaskRecorder,
+    mut remote_metrics: Option<&mut RemoteArchiveTaskMetrics>,
 ) -> Result<(), DownloadError> {
     let mut last_error = None;
 
     for attempt in 1..=MAX_RETRIES {
-        let attempt_metrics = recorder.begin_attempt();
+        if let Some(metrics) = remote_metrics.as_deref_mut() {
+            metrics.begin_attempt();
+        }
         let attempt_start = Instant::now();
-        match download_and_extract(url, target_path, attempt_metrics, recorder) {
+        match download_and_extract(url, target_path, remote_metrics.as_deref_mut()) {
             Ok(()) => return Ok(()),
             Err(e) => {
                 log_warn!(
@@ -343,18 +355,20 @@ fn download_with_retry(
 fn download_and_extract(
     url: &str,
     target_path: &str,
-    attempt_metrics: Option<source::RemoteArchiveAttemptMetrics>,
-    recorder: &mut telemetry::TaskRecorder,
+    remote_metrics: Option<&mut RemoteArchiveTaskMetrics>,
 ) -> Result<(), DownloadError> {
     fs::create_dir_all(target_path).map_err(|e| {
         DownloadError::fatal(format!("Failed to create directory {target_path}: {e}"))
     })?;
 
+    let attempt_metrics = remote_metrics
+        .is_some()
+        .then(source::RemoteArchiveAttemptMetrics::default);
     let reader = match source::open_archive(url, attempt_metrics.as_ref()) {
         Ok(reader) => reader,
         Err(error) => {
-            if let Some(attempt_metrics) = attempt_metrics.as_ref() {
-                recorder.record_attempt(attempt_metrics, Duration::ZERO);
+            if let (Some(metrics), Some(attempt_metrics)) = (remote_metrics, &attempt_metrics) {
+                metrics.record_attempt(attempt_metrics.snapshot(), Duration::ZERO);
             }
             return Err(error);
         }
@@ -362,8 +376,8 @@ fn download_and_extract(
     let extract_start = Instant::now();
     let result = archive::extract_tar_gz(reader, target_path);
     let extract_wall = extract_start.elapsed();
-    if let Some(attempt_metrics) = attempt_metrics.as_ref() {
-        recorder.record_attempt(attempt_metrics, extract_wall);
+    if let (Some(metrics), Some(attempt_metrics)) = (remote_metrics, &attempt_metrics) {
+        metrics.record_attempt(attempt_metrics.snapshot(), extract_wall);
     }
     result
 }
@@ -371,16 +385,47 @@ fn download_and_extract(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
+    use std::sync::{Mutex, MutexGuard};
 
-    fn scheduled_at(id: usize, path: &str) -> ScheduledDownload {
-        ScheduledDownload {
-            id,
-            task: DownloadTask::test_storage(
-                format!("task {path}"),
-                "file:///tmp/archive.tar.gz".to_owned(),
-                path.to_owned(),
-            ),
+    static SANDBOX_OP_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct SandboxOpsLogGuard {
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl SandboxOpsLogGuard {
+        fn set(path: impl AsRef<Path>) -> Self {
+            let lock = SANDBOX_OP_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            guest_common::telemetry::set_sandbox_ops_log_file(path);
+            Self { _lock: lock }
         }
+    }
+
+    impl Drop for SandboxOpsLogGuard {
+        fn drop(&mut self) {
+            guest_common::telemetry::clear_sandbox_ops_log_file();
+        }
+    }
+
+    fn task_at(path: &str) -> DownloadTask {
+        DownloadTask::storage(
+            format!("task {path}"),
+            "file:///tmp/archive.tar.gz".to_owned(),
+            path.to_owned(),
+            false,
+        )
+    }
+
+    fn instruction_task_at(path: &str) -> DownloadTask {
+        DownloadTask::storage(
+            format!("task {path}"),
+            "file:///tmp/archive.tar.gz".to_owned(),
+            path.to_owned(),
+            true,
+        )
     }
 
     #[test]
@@ -437,15 +482,17 @@ mod tests {
         let result = std::panic::catch_unwind(|| {
             download_all_parallel_with_runner(
                 vec![
-                    DownloadTask::test_storage(
+                    DownloadTask::storage(
                         "panic".to_owned(),
                         "panic".to_owned(),
                         "/tmp/panic".to_owned(),
+                        false,
                     ),
-                    DownloadTask::test_storage(
+                    DownloadTask::storage(
                         "success".to_owned(),
                         "success".to_owned(),
                         "/tmp/success".to_owned(),
+                        false,
                     ),
                 ],
                 runner,
@@ -456,57 +503,92 @@ mod tests {
     }
 
     #[test]
-    fn find_startable_download_observes_conflict_and_selects_later_task() {
-        let pending = VecDeque::from(vec![
-            scheduled_at(3, "/tmp/mount/child"),
-            scheduled_at(4, "/tmp/other"),
-        ]);
+    fn find_startable_download_skips_conflicts_for_later_independent_tasks() {
+        let tasks = vec![
+            task_at("/tmp/mount"),
+            DownloadTask::storage(
+                "blocked child".to_owned(),
+                "file:///tmp/archive.tar.gz".to_owned(),
+                "/tmp/mount/child".to_owned(),
+                false,
+            ),
+            DownloadTask::artifact(
+                "independent".to_owned(),
+                "https://example.com/archive.tar.gz".to_owned(),
+                "/tmp/other".to_owned(),
+            ),
+        ];
+        let mut telemetry = DownloadRunTelemetry::start(
+            tasks
+                .iter()
+                .map(|task| (task.telemetry, task.normalized_mount_path.as_path())),
+        );
+        let mut tasks = tasks.into_iter();
+        let active_task = tasks.next().expect("active task");
         let active = vec![ActiveDownload {
-            id: 2,
-            mount_path: normalize_mount_path("/tmp/mount"),
+            identity: active_task.telemetry.identity(0),
+            mount_path: active_task.normalized_mount_path,
         }];
-        let mut conflicts = Vec::new();
+        let pending = tasks
+            .enumerate()
+            .map(|(index, task)| PendingDownload::new(index + 1, task))
+            .collect();
 
-        let selected =
-            find_startable_download(&pending, &active, &mut |pending_id, _, active_id, _| {
-                conflicts.push((pending_id, active_id));
-            });
+        let startable = find_startable_download(&pending, &active, &mut telemetry);
 
-        assert_eq!(conflicts, [(3, 2)]);
-        assert_eq!(selected.map(|(index, _)| index), Some(1));
+        assert_eq!(startable.map(|(index, _)| index), Some(1));
     }
 
     #[test]
-    fn find_startable_download_reports_only_first_active_conflict() {
-        let pending = VecDeque::from([scheduled_at(4, "/tmp/mount/child")]);
-        let active = vec![
-            ActiveDownload {
-                id: 2,
-                mount_path: normalize_mount_path("/tmp/mount"),
-            },
-            ActiveDownload {
-                id: 3,
-                mount_path: normalize_mount_path("/tmp/mount/child"),
-            },
-        ];
-        let mut conflicts = Vec::new();
+    fn download_all_parallel_records_conflict_shape_actions() {
+        let dir = tempfile::tempdir().unwrap();
+        let ops_path = dir.path().join("sandbox-ops.jsonl");
+        let _ops_guard = SandboxOpsLogGuard::set(&ops_path);
 
-        let selected =
-            find_startable_download(&pending, &active, &mut |pending_id, _, active_id, _| {
-                conflicts.push((pending_id, active_id));
-            });
+        fn runner(_task: DownloadTask) -> bool {
+            true
+        }
 
-        assert_eq!(selected, None);
-        assert_eq!(conflicts, [(4, 2)]);
+        let success = download_all_parallel_with_runner(
+            vec![
+                instruction_task_at("/home/user/.codex"),
+                task_at("/home/user/.codex/skills/workflow"),
+            ],
+            runner,
+        );
+
+        assert!(success);
+        let ops = std::fs::read_to_string(&ops_path).unwrap();
+        assert!(ops.contains(r#""action_type":"guest_download_task_count_2""#));
+        assert!(ops.contains(r#""action_type":"guest_download_skill_child_task_count_1""#));
+        assert!(ops.contains(
+            r#""action_type":"guest_download_framework_home_instructions_task_present""#
+        ));
+        assert!(
+            ops.contains(
+                r#""action_type":"guest_download_potential_parent_child_overlap_count_1""#
+            )
+        );
+        assert!(ops.contains(r#""action_type":"guest_download_mount_conflict_deferral_count_1""#));
+        assert!(ops.contains(
+            r#""action_type":"guest_download_instructions_skill_conflict_deferral_count_1""#
+        ));
+        assert!(
+            ops.contains(r#""action_type":"guest_download_exact_path_conflict_deferral_count_0""#)
+        );
+        assert!(ops.contains(
+            r#""action_type":"guest_download_other_parent_child_conflict_deferral_count_0""#
+        ));
     }
 
     #[test]
     fn download_task_failure_detail_includes_entry_metadata() {
-        let task = DownloadTask::test_storage(
+        let task = DownloadTask::storage(
             "storage 1 mountPath=/workspace vasStorageName=repo vasVersionId=v1 urlScheme=file cached=false"
                 .into(),
             "file:///tmp/archive.tar.gz".into(),
             "/workspace".into(),
+            false,
         );
         let error = DownloadError::fatal("Failed to read archive entries: invalid gzip header");
 

--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -2,9 +2,7 @@ use crate::LOG_TAG;
 use crate::archive;
 use crate::error::DownloadError;
 use crate::source;
-use crate::telemetry::{
-    DownloadIdentity, DownloadRunTelemetry, DownloadTaskTelemetry, RemoteArchiveTaskMetrics,
-};
+use crate::telemetry::{DownloadRunTelemetry, DownloadTaskTelemetry, RemoteArchiveTaskMetrics};
 use guest_common::{log_error, log_info, log_warn};
 use std::any::Any;
 use std::collections::VecDeque;
@@ -69,26 +67,23 @@ impl DownloadTask {
 }
 
 struct PendingDownload {
-    identity: DownloadIdentity,
+    id: usize,
     task: DownloadTask,
 }
 
 impl PendingDownload {
-    fn new(sequence: usize, task: DownloadTask) -> Self {
-        Self {
-            identity: task.telemetry.identity(sequence),
-            task,
-        }
+    fn new(id: usize, task: DownloadTask) -> Self {
+        Self { id, task }
     }
 }
 
 struct ActiveDownload {
-    identity: DownloadIdentity,
+    id: usize,
     mount_path: PathBuf,
 }
 
 struct DownloadCompletion {
-    identity: DownloadIdentity,
+    id: usize,
     outcome: DownloadOutcome,
 }
 
@@ -139,7 +134,9 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
             &mut active,
             &completion_tx,
             task_runner,
-            &mut telemetry,
+            &mut |pending_id, pending_path, active_id, active_path| {
+                telemetry.record_conflict(pending_id, pending_path, active_id, active_path);
+            },
         );
 
         while !active.is_empty() {
@@ -151,7 +148,7 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
                 }
             };
 
-            active.retain(|download| download.identity != completion.identity);
+            active.retain(|download| download.id != completion.id);
 
             match completion.outcome {
                 DownloadOutcome::Finished(success) => {
@@ -171,7 +168,9 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
                 &mut active,
                 &completion_tx,
                 task_runner,
-                &mut telemetry,
+                &mut |pending_id, pending_path, active_id, active_path| {
+                    telemetry.record_conflict(pending_id, pending_path, active_id, active_path);
+                },
             );
         }
 
@@ -187,21 +186,19 @@ fn start_ready_downloads<'scope, 'env: 'scope>(
     active: &mut Vec<ActiveDownload>,
     completion_tx: &mpsc::Sender<DownloadCompletion>,
     task_runner: TaskRunner,
-    telemetry: &mut DownloadRunTelemetry,
+    on_conflict: &mut impl FnMut(usize, &Path, usize, &Path),
 ) {
     while active.len() < MAX_CONCURRENT {
-        let Some((index, mount_path)) = find_startable_download(pending, active, telemetry) else {
+        let Some((index, mount_path)) = find_startable_download(pending, active, on_conflict)
+        else {
             break;
         };
         let Some(download) = pending.remove(index) else {
             log_error!(LOG_TAG, "Download scheduler selected a missing task");
             break;
         };
-        let identity = download.identity;
-        active.push(ActiveDownload {
-            identity,
-            mount_path,
-        });
+        let id = download.id;
+        active.push(ActiveDownload { id, mount_path });
 
         let completion_tx = completion_tx.clone();
         scope.spawn(move || {
@@ -209,7 +206,7 @@ fn start_ready_downloads<'scope, 'env: 'scope>(
                 .map(DownloadOutcome::Finished)
                 .unwrap_or_else(|e| DownloadOutcome::Panicked(panic_message(e.as_ref())));
 
-            let _ = completion_tx.send(DownloadCompletion { identity, outcome });
+            let _ = completion_tx.send(DownloadCompletion { id, outcome });
         });
     }
 }
@@ -217,7 +214,7 @@ fn start_ready_downloads<'scope, 'env: 'scope>(
 fn find_startable_download(
     pending: &VecDeque<PendingDownload>,
     active: &[ActiveDownload],
-    telemetry: &mut DownloadRunTelemetry,
+    on_conflict: &mut impl FnMut(usize, &Path, usize, &Path),
 ) -> Option<(usize, PathBuf)> {
     // Scan the pending queue instead of using strict FIFO so an active
     // parent/child mount-path conflict does not leave a slot idle when a later
@@ -225,16 +222,11 @@ fn find_startable_download(
     for (index, download) in pending.iter().enumerate() {
         let mount_path = &download.task.normalized_mount_path;
 
-        if let Some(active_download) = active
+        if let Some(blocking) = active
             .iter()
             .find(|active_download| mount_paths_conflict(mount_path, &active_download.mount_path))
         {
-            telemetry.record_conflict(
-                download.identity,
-                mount_path,
-                active_download.identity,
-                &active_download.mount_path,
-            );
+            on_conflict(download.id, mount_path, blocking.id, &blocking.mount_path);
             continue;
         }
 
@@ -385,30 +377,6 @@ fn download_and_extract(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
-    use std::sync::{Mutex, MutexGuard};
-
-    static SANDBOX_OP_TEST_LOCK: Mutex<()> = Mutex::new(());
-
-    struct SandboxOpsLogGuard {
-        _lock: MutexGuard<'static, ()>,
-    }
-
-    impl SandboxOpsLogGuard {
-        fn set(path: impl AsRef<Path>) -> Self {
-            let lock = SANDBOX_OP_TEST_LOCK
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            guest_common::telemetry::set_sandbox_ops_log_file(path);
-            Self { _lock: lock }
-        }
-    }
-
-    impl Drop for SandboxOpsLogGuard {
-        fn drop(&mut self) {
-            guest_common::telemetry::clear_sandbox_ops_log_file();
-        }
-    }
 
     fn task_at(path: &str) -> DownloadTask {
         DownloadTask::storage(
@@ -419,13 +387,8 @@ mod tests {
         )
     }
 
-    fn instruction_task_at(path: &str) -> DownloadTask {
-        DownloadTask::storage(
-            format!("task {path}"),
-            "file:///tmp/archive.tar.gz".to_owned(),
-            path.to_owned(),
-            true,
-        )
+    fn pending_at(id: usize, path: &str) -> PendingDownload {
+        PendingDownload::new(id, task_at(path))
     }
 
     #[test]
@@ -503,82 +466,50 @@ mod tests {
     }
 
     #[test]
-    fn find_startable_download_skips_conflicts_for_later_independent_tasks() {
-        let tasks = vec![
-            task_at("/tmp/mount"),
-            DownloadTask::storage(
-                "blocked child".to_owned(),
-                "file:///tmp/archive.tar.gz".to_owned(),
-                "/tmp/mount/child".to_owned(),
-                false,
-            ),
-            DownloadTask::artifact(
-                "independent".to_owned(),
-                "https://example.com/archive.tar.gz".to_owned(),
-                "/tmp/other".to_owned(),
-            ),
-        ];
-        let mut telemetry = DownloadRunTelemetry::start(
-            tasks
-                .iter()
-                .map(|task| (task.telemetry, task.normalized_mount_path.as_path())),
-        );
-        let mut tasks = tasks.into_iter();
-        let active_task = tasks.next().expect("active task");
+    fn find_startable_download_observes_conflict_and_selects_later_task() {
+        let pending = VecDeque::from([
+            pending_at(3, "/tmp/mount/child"),
+            pending_at(4, "/tmp/other"),
+        ]);
         let active = vec![ActiveDownload {
-            identity: active_task.telemetry.identity(0),
-            mount_path: active_task.normalized_mount_path,
+            id: 2,
+            mount_path: normalize_mount_path("/tmp/mount"),
         }];
-        let pending = tasks
-            .enumerate()
-            .map(|(index, task)| PendingDownload::new(index + 1, task))
-            .collect();
+        let mut conflicts = Vec::new();
 
-        let startable = find_startable_download(&pending, &active, &mut telemetry);
+        let selected =
+            find_startable_download(&pending, &active, &mut |pending_id, _, active_id, _| {
+                conflicts.push((pending_id, active_id));
+            });
 
-        assert_eq!(startable.map(|(index, _)| index), Some(1));
+        assert_eq!(conflicts, [(3, 2)]);
+        assert_eq!(selected.map(|(index, _)| index), Some(1));
     }
 
     #[test]
-    fn download_all_parallel_records_conflict_shape_actions() {
-        let dir = tempfile::tempdir().unwrap();
-        let ops_path = dir.path().join("sandbox-ops.jsonl");
-        let _ops_guard = SandboxOpsLogGuard::set(&ops_path);
+    fn find_startable_download_reports_first_active_conflict_on_each_scan() {
+        let pending = VecDeque::from([pending_at(4, "/tmp/mount/child")]);
+        let active = vec![
+            ActiveDownload {
+                id: 2,
+                mount_path: normalize_mount_path("/tmp/mount"),
+            },
+            ActiveDownload {
+                id: 3,
+                mount_path: normalize_mount_path("/tmp/mount/child"),
+            },
+        ];
+        let mut conflicts = Vec::new();
 
-        fn runner(_task: DownloadTask) -> bool {
-            true
+        for _ in 0..2 {
+            let selected =
+                find_startable_download(&pending, &active, &mut |pending_id, _, active_id, _| {
+                    conflicts.push((pending_id, active_id));
+                });
+            assert_eq!(selected, None);
         }
 
-        let success = download_all_parallel_with_runner(
-            vec![
-                instruction_task_at("/home/user/.codex"),
-                task_at("/home/user/.codex/skills/workflow"),
-            ],
-            runner,
-        );
-
-        assert!(success);
-        let ops = std::fs::read_to_string(&ops_path).unwrap();
-        assert!(ops.contains(r#""action_type":"guest_download_task_count_2""#));
-        assert!(ops.contains(r#""action_type":"guest_download_skill_child_task_count_1""#));
-        assert!(ops.contains(
-            r#""action_type":"guest_download_framework_home_instructions_task_present""#
-        ));
-        assert!(
-            ops.contains(
-                r#""action_type":"guest_download_potential_parent_child_overlap_count_1""#
-            )
-        );
-        assert!(ops.contains(r#""action_type":"guest_download_mount_conflict_deferral_count_1""#));
-        assert!(ops.contains(
-            r#""action_type":"guest_download_instructions_skill_conflict_deferral_count_1""#
-        ));
-        assert!(
-            ops.contains(r#""action_type":"guest_download_exact_path_conflict_deferral_count_0""#)
-        );
-        assert!(ops.contains(
-            r#""action_type":"guest_download_other_parent_child_conflict_deferral_count_0""#
-        ));
+        assert_eq!(conflicts, [(4, 2), (4, 2)]);
     }
 
     #[test]

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -13,6 +13,7 @@ mod instructions;
 mod manifest;
 mod plan;
 mod source;
+mod telemetry;
 
 use guest_common::{log_error, log_info, telemetry::record_sandbox_op};
 use guest_contracts::storage_manifest::Manifest;

--- a/crates/guest-download/src/plan.rs
+++ b/crates/guest-download/src/plan.rs
@@ -1,4 +1,4 @@
-use crate::download::{ArchiveKind, DownloadTask, classify_download_task_kind};
+use crate::download::DownloadTask;
 use crate::instructions::{InstructionCleanup, InstructionNormalization};
 use crate::manifest::{ArtifactEntry, Manifest, StorageEntry};
 use std::path::Path;
@@ -62,13 +62,6 @@ impl ManifestEntryKind {
         match self {
             Self::Storage => "storage",
             Self::Artifact => "artifact",
-        }
-    }
-
-    fn archive_kind(self) -> ArchiveKind {
-        match self {
-            Self::Storage => ArchiveKind::Storage,
-            Self::Artifact => ArchiveKind::Artifact,
         }
     }
 
@@ -181,20 +174,15 @@ fn append_storage_download_tasks(tasks: &mut Vec<DownloadTask>, entries: &[Stora
         } else {
             entry.mount_path.as_str()
         };
-        let task_kind = classify_download_task_kind(
-            download_mount_path,
-            entry.instructions_target_filename.as_deref(),
-        );
-        tasks.push(DownloadTask::new_with_kind(
+        tasks.push(DownloadTask::storage(
             format_entry_label(
                 ManifestEntryKind::Storage,
                 idx + 1,
                 EntryLabel::storage(entry, url),
             ),
-            ManifestEntryKind::Storage.archive_kind(),
             url.clone(),
             download_mount_path.to_string(),
-            task_kind,
+            entry.instructions_target_filename.as_deref(),
         ));
     }
 }
@@ -210,17 +198,14 @@ fn append_artifact_download_tasks(tasks: &mut Vec<DownloadTask>, entries: &[Arti
         let Some(url) = entry.archive_url.as_ref() else {
             continue;
         };
-        let task_kind = classify_download_task_kind(&entry.mount_path, None);
-        tasks.push(DownloadTask::new_with_kind(
+        tasks.push(DownloadTask::artifact(
             format_entry_label(
                 ManifestEntryKind::Artifact,
                 idx + 1,
                 EntryLabel::artifact(entry, url),
             ),
-            ManifestEntryKind::Artifact.archive_kind(),
             url.clone(),
             entry.mount_path.clone(),
-            task_kind,
         ));
     }
 }
@@ -330,27 +315,25 @@ mod tests {
         assert_eq!(plan.download_tasks.len(), 3);
         assert_eq!(
             plan.download_tasks[0],
-            DownloadTask::new(
+            DownloadTask::storage(
                 "storage 1 mountPath=/data vasStorageName=data vasVersionId=storage-v1 urlScheme=https cached=false".into(),
-                ArchiveKind::Storage,
                 "https://s3/storage.tar.gz".into(),
                 "/data".into(),
+                None,
             )
         );
         assert_eq!(
             plan.download_tasks[1],
-            DownloadTask::new(
+            DownloadTask::artifact(
                 "artifact 1 mountPath=/workspace/a vasStorageName=workspace-a vasVersionId=artifact-v1 urlScheme=https cached=false missingRootPolicy=preserveParentVersion".into(),
-                ArchiveKind::Artifact,
                 "https://s3/a.tar.gz".into(),
                 "/workspace/a".into(),
             )
         );
         assert_eq!(
             plan.download_tasks[2],
-            DownloadTask::new(
+            DownloadTask::artifact(
                 "artifact 2 mountPath=/workspace/b vasStorageName=workspace-b vasVersionId=artifact-v2 urlScheme=file cached=false missingRootPolicy=fail".into(),
-                ArchiveKind::Artifact,
                 "file:///tmp/vm0-storage-cache/b.tar.gz".into(),
                 "/workspace/b".into(),
             )
@@ -447,12 +430,11 @@ mod tests {
         assert_eq!(plan.download_tasks.len(), 1);
         assert_eq!(
             plan.download_tasks[0],
-            DownloadTask::new_with_kind(
+            DownloadTask::storage(
                 "storage 1 mountPath=/home/user/.codex vasStorageName=unknown vasVersionId=unknown urlScheme=https cached=false".into(),
-                ArchiveKind::Storage,
                 "https://s3/instructions.tar.gz".into(),
                 "/home/user/.vm0/guest-agent/runs/run-1/storage-instructions/0".into(),
-                crate::download::DownloadTaskKind::FrameworkHomeInstructions,
+                Some("AGENTS.md"),
             )
         );
     }
@@ -474,12 +456,11 @@ mod tests {
         assert_eq!(plan.download_tasks.len(), 1);
         assert_eq!(
             plan.download_tasks[0],
-            DownloadTask::new_with_kind(
+            DownloadTask::storage(
                 "storage 1 mountPath=/data vasStorageName=unknown vasVersionId=unknown urlScheme=https cached=false".into(),
-                ArchiveKind::Storage,
                 "https://s3/data.tar.gz".into(),
                 "/data".into(),
-                crate::download::DownloadTaskKind::Other,
+                None,
             )
         );
     }
@@ -504,57 +485,6 @@ mod tests {
             [
                 InstructionCleanup::new("/home/user/.codex".into(), Some("AGENTS.md".into())),
                 InstructionCleanup::new("/home/user/.claude".into(), None),
-            ]
-        );
-    }
-
-    #[test]
-    fn run_plan_derives_download_task_kinds() {
-        let json = r#"{
-            "storageMounts": [
-                {
-                    "mountPath": "/home/user/.codex",
-                    "archiveUrl": "https://s3/instructions.tar.gz",
-                    "instructionsTargetFilename": "AGENTS.md"
-                },
-                {
-                    "mountPath": "/home/user/.codex/skills/workflow",
-                    "archiveUrl": "https://s3/codex-skill.tar.gz"
-                },
-                {
-                    "mountPath": "/home/user/.claude/skills/workflow",
-                    "archiveUrl": "https://s3/claude-skill.tar.gz"
-                },
-                {
-                    "mountPath": "/workspace/storage",
-                    "archiveUrl": "https://s3/storage.tar.gz"
-                },
-                {
-                    "mountPath": "/workspace",
-                    "archiveUrl": "https://s3/artifact.tar.gz",
-                    "writeback": true
-                },
-                {
-                    "mountPath": "/home/user/.codex/skills/cached",
-                    "archiveUrl": null,
-                    "cached": true,
-                    "writeback": true
-                }
-            ]
-        }"#;
-        let manifest: Manifest = serde_json::from_str(json).unwrap();
-
-        let plan = RunPlan::from_manifest(&manifest);
-
-        let kinds: Vec<_> = plan.download_tasks.iter().map(DownloadTask::kind).collect();
-        assert_eq!(
-            kinds,
-            [
-                crate::download::DownloadTaskKind::FrameworkHomeInstructions,
-                crate::download::DownloadTaskKind::FrameworkSkillChild,
-                crate::download::DownloadTaskKind::FrameworkSkillChild,
-                crate::download::DownloadTaskKind::Other,
-                crate::download::DownloadTaskKind::Other,
             ]
         );
     }
@@ -613,13 +543,13 @@ mod tests {
         assert_eq!(plan.preserved_paths, std::slice::from_ref(&mount_path));
         assert_eq!(
             plan.download_tasks,
-            [DownloadTask::new(
+            [DownloadTask::storage(
                 format!(
                     "storage 1 mountPath={mount_path} vasStorageName=storage vasVersionId=storage-v1 urlScheme=https cached=true"
                 ),
-                ArchiveKind::Storage,
                 "https://s3/storage.tar.gz".into(),
                 mount_path,
+                None,
             )],
         );
     }
@@ -653,11 +583,10 @@ mod tests {
         assert_eq!(plan.preserved_paths, std::slice::from_ref(&mount_path));
         assert_eq!(
             plan.download_tasks,
-            [DownloadTask::new(
+            [DownloadTask::artifact(
                 format!(
                     "artifact 1 mountPath={mount_path} vasStorageName=artifact vasVersionId=artifact-v1 urlScheme=https cached=true missingRootPolicy=fail"
                 ),
-                ArchiveKind::Artifact,
                 "https://s3/artifact.tar.gz".into(),
                 mount_path,
             )],

--- a/crates/guest-download/src/plan.rs
+++ b/crates/guest-download/src/plan.rs
@@ -182,7 +182,7 @@ fn append_storage_download_tasks(tasks: &mut Vec<DownloadTask>, entries: &[Stora
             ),
             url.clone(),
             download_mount_path.to_string(),
-            entry.instructions_target_filename.as_deref(),
+            entry.instructions_target_filename.is_some(),
         ));
     }
 }
@@ -319,7 +319,7 @@ mod tests {
                 "storage 1 mountPath=/data vasStorageName=data vasVersionId=storage-v1 urlScheme=https cached=false".into(),
                 "https://s3/storage.tar.gz".into(),
                 "/data".into(),
-                None,
+                false,
             )
         );
         assert_eq!(
@@ -434,7 +434,7 @@ mod tests {
                 "storage 1 mountPath=/home/user/.codex vasStorageName=unknown vasVersionId=unknown urlScheme=https cached=false".into(),
                 "https://s3/instructions.tar.gz".into(),
                 "/home/user/.vm0/guest-agent/runs/run-1/storage-instructions/0".into(),
-                Some("AGENTS.md"),
+                true,
             )
         );
     }
@@ -460,7 +460,7 @@ mod tests {
                 "storage 1 mountPath=/data vasStorageName=unknown vasVersionId=unknown urlScheme=https cached=false".into(),
                 "https://s3/data.tar.gz".into(),
                 "/data".into(),
-                None,
+                false,
             )
         );
     }
@@ -549,7 +549,7 @@ mod tests {
                 ),
                 "https://s3/storage.tar.gz".into(),
                 mount_path,
-                None,
+                false,
             )],
         );
     }

--- a/crates/guest-download/src/telemetry.rs
+++ b/crates/guest-download/src/telemetry.rs
@@ -1,413 +1,160 @@
 use crate::source;
 use guest_common::telemetry::record_sandbox_op;
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ArchiveKind {
-    Storage,
-    Artifact,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum SourceKind {
-    Remote,
-    File,
-    Other,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum TaskKind {
-    FrameworkHomeInstructions,
-    FrameworkSkillChild,
-    Other,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct TaskMetadata {
+pub(crate) struct DownloadTaskTelemetry {
     archive_kind: ArchiveKind,
-    source_kind: SourceKind,
-    task_kind: TaskKind,
+    task_kind: DownloadTaskKind,
+    url_kind: DownloadUrlKind,
 }
 
-impl TaskMetadata {
-    pub(crate) fn storage(
-        url: &str,
-        normalized_mount_path: &Path,
-        instructions_target_filename: Option<&str>,
+impl DownloadTaskTelemetry {
+    pub(crate) fn storage(url: &str, mount_path: &Path, has_instructions_target: bool) -> Self {
+        Self {
+            archive_kind: ArchiveKind::Storage,
+            task_kind: classify_download_task_kind(mount_path, has_instructions_target),
+            url_kind: DownloadUrlKind::from_url(url),
+        }
+    }
+
+    pub(crate) fn artifact(url: &str, mount_path: &Path) -> Self {
+        Self {
+            archive_kind: ArchiveKind::Artifact,
+            task_kind: classify_download_task_kind(mount_path, false),
+            url_kind: DownloadUrlKind::from_url(url),
+        }
+    }
+
+    pub(crate) fn identity(self, sequence: usize) -> DownloadIdentity {
+        DownloadIdentity {
+            sequence,
+            task_kind: self.task_kind,
+        }
+    }
+
+    pub(crate) fn remote_metrics(self) -> Option<RemoteArchiveTaskMetrics> {
+        matches!(self.url_kind, DownloadUrlKind::Remote).then(RemoteArchiveTaskMetrics::default)
+    }
+
+    pub(crate) fn record_result(
+        self,
+        duration: Duration,
+        success: bool,
+        error: Option<&str>,
+        remote_metrics: Option<&RemoteArchiveTaskMetrics>,
+    ) {
+        record_sandbox_op(self.archive_kind.total_action(), duration, success, error);
+        if let Some(metrics) = remote_metrics {
+            record_remote_archive_attribution(self.archive_kind, metrics, success);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct DownloadIdentity {
+    sequence: usize,
+    task_kind: DownloadTaskKind,
+}
+
+impl PartialEq for DownloadIdentity {
+    fn eq(&self, other: &Self) -> bool {
+        self.sequence == other.sequence
+    }
+}
+
+impl Eq for DownloadIdentity {}
+
+#[derive(Default)]
+pub(crate) struct DownloadRunTelemetry {
+    conflict_deferrals: DownloadConflictDeferralStats,
+}
+
+impl DownloadRunTelemetry {
+    pub(crate) fn start<'a>(
+        tasks: impl IntoIterator<Item = (DownloadTaskTelemetry, &'a Path)>,
     ) -> Self {
-        Self::new(
-            ArchiveKind::Storage,
-            url,
-            normalized_mount_path,
-            instructions_target_filename,
-        )
-    }
+        let mut task_count = 0;
+        let mut remote_url_count = 0;
+        let mut file_url_count = 0;
+        let mut skill_child_task_count = 0;
+        let mut framework_home_instructions_task_present = false;
+        let mut mount_paths = Vec::new();
 
-    pub(crate) fn artifact(url: &str, normalized_mount_path: &Path) -> Self {
-        Self::new(ArchiveKind::Artifact, url, normalized_mount_path, None)
-    }
-
-    fn new(
-        archive_kind: ArchiveKind,
-        url: &str,
-        normalized_mount_path: &Path,
-        instructions_target_filename: Option<&str>,
-    ) -> Self {
-        Self {
-            archive_kind,
-            source_kind: classify_source(url),
-            task_kind: classify_task(normalized_mount_path, instructions_target_filename),
+        for (task, mount_path) in tasks {
+            task_count += 1;
+            match task.url_kind {
+                DownloadUrlKind::Remote => remote_url_count += 1,
+                DownloadUrlKind::File => file_url_count += 1,
+                DownloadUrlKind::Other => {}
+            }
+            match task.task_kind {
+                DownloadTaskKind::FrameworkHomeInstructions => {
+                    framework_home_instructions_task_present = true;
+                }
+                DownloadTaskKind::FrameworkSkillChild => skill_child_task_count += 1,
+                DownloadTaskKind::Other => {}
+            }
+            mount_paths.push(mount_path);
         }
-    }
-}
 
-fn classify_source(url: &str) -> SourceKind {
-    if url.starts_with("http://") || url.starts_with("https://") {
-        SourceKind::Remote
-    } else if url.starts_with("file://") {
-        SourceKind::File
-    } else {
-        SourceKind::Other
-    }
-}
+        record_count_metric(CountMetric::Task, task_count);
+        record_count_metric(CountMetric::RemoteUrl, remote_url_count);
+        record_count_metric(CountMetric::FileUrl, file_url_count);
+        record_count_metric(CountMetric::SkillChildTask, skill_child_task_count);
+        record_sandbox_op(
+            framework_home_instructions_task_action(framework_home_instructions_task_present),
+            Duration::ZERO,
+            true,
+            None,
+        );
+        record_count_metric(
+            CountMetric::PotentialParentChildOverlap,
+            potential_parent_child_overlap_count(&mount_paths),
+        );
 
-fn classify_task(
-    normalized_mount_path: &Path,
-    instructions_target_filename: Option<&str>,
-) -> TaskKind {
-    if instructions_target_filename.is_some() {
-        TaskKind::FrameworkHomeInstructions
-    } else if is_framework_skill_child_path(normalized_mount_path) {
-        TaskKind::FrameworkSkillChild
-    } else {
-        TaskKind::Other
-    }
-}
-
-fn is_framework_skill_child_path(path: &Path) -> bool {
-    is_child_path(path, Path::new("/home/user/.codex/skills"))
-        || is_child_path(path, Path::new("/home/user/.claude/skills"))
-}
-
-fn is_child_path(path: &Path, parent: &Path) -> bool {
-    path.starts_with(parent) && path != parent
-}
-
-pub(crate) struct TaskSnapshot {
-    metadata: TaskMetadata,
-    mount_path: PathBuf,
-}
-
-impl TaskSnapshot {
-    pub(crate) fn new(metadata: TaskMetadata, mount_path: PathBuf) -> Self {
-        Self {
-            metadata,
-            mount_path,
-        }
-    }
-}
-
-pub(crate) struct BatchRecorder {
-    task_kinds: Vec<TaskKind>,
-    conflict_deferrals: ConflictDeferralStats,
-}
-
-impl BatchRecorder {
-    pub(crate) fn new(tasks: impl IntoIterator<Item = TaskSnapshot>) -> Self {
-        let tasks: Vec<TaskSnapshot> = tasks.into_iter().collect();
-        record_batch_attribution(&tasks);
-        Self {
-            task_kinds: tasks.iter().map(|task| task.metadata.task_kind).collect(),
-            conflict_deferrals: ConflictDeferralStats::default(),
-        }
+        Self::default()
     }
 
     pub(crate) fn record_conflict(
         &mut self,
-        pending_id: usize,
+        pending: DownloadIdentity,
         pending_path: &Path,
-        active_id: usize,
+        active: DownloadIdentity,
         active_path: &Path,
     ) {
-        let pending_kind = self.task_kinds.get(pending_id).copied();
-        let active_kind = self.task_kinds.get(active_id).copied();
-        debug_assert!(
-            pending_kind.is_some() && active_kind.is_some(),
-            "download telemetry id is out of range"
-        );
-        let (Some(pending_kind), Some(active_kind)) = (pending_kind, active_kind) else {
-            return;
-        };
-        self.conflict_deferrals.record(classify_conflict(
+        self.conflict_deferrals.record(classify_download_conflict(
             pending_path,
-            pending_kind,
+            pending.task_kind,
             active_path,
-            active_kind,
+            active.task_kind,
         ));
     }
 
     pub(crate) fn finish(self) {
-        record_sandbox_op(
-            CountMetric::MountConflictDeferral.action(self.conflict_deferrals.total),
-            Duration::ZERO,
-            true,
-            None,
+        record_count_metric(
+            CountMetric::MountConflictDeferral,
+            self.conflict_deferrals.total,
         );
-        record_sandbox_op(
-            CountMetric::InstructionsSkillConflictDeferral
-                .action(self.conflict_deferrals.instructions_skill),
-            Duration::ZERO,
-            true,
-            None,
+        record_count_metric(
+            CountMetric::InstructionsSkillConflictDeferral,
+            self.conflict_deferrals.instructions_skill,
         );
-        record_sandbox_op(
-            CountMetric::ExactPathConflictDeferral.action(self.conflict_deferrals.exact_path),
-            Duration::ZERO,
-            true,
-            None,
+        record_count_metric(
+            CountMetric::ExactPathConflictDeferral,
+            self.conflict_deferrals.exact_path,
         );
-        record_sandbox_op(
-            CountMetric::OtherParentChildConflictDeferral
-                .action(self.conflict_deferrals.other_parent_child),
-            Duration::ZERO,
-            true,
-            None,
-        );
-    }
-}
-
-fn record_batch_attribution(tasks: &[TaskSnapshot]) {
-    record_sandbox_op(
-        CountMetric::Task.action(tasks.len()),
-        Duration::ZERO,
-        true,
-        None,
-    );
-    record_sandbox_op(
-        CountMetric::RemoteUrl.action(
-            tasks
-                .iter()
-                .filter(|task| task.metadata.source_kind == SourceKind::Remote)
-                .count(),
-        ),
-        Duration::ZERO,
-        true,
-        None,
-    );
-    record_sandbox_op(
-        CountMetric::FileUrl.action(
-            tasks
-                .iter()
-                .filter(|task| task.metadata.source_kind == SourceKind::File)
-                .count(),
-        ),
-        Duration::ZERO,
-        true,
-        None,
-    );
-    record_sandbox_op(
-        CountMetric::SkillChildTask.action(
-            tasks
-                .iter()
-                .filter(|task| task.metadata.task_kind == TaskKind::FrameworkSkillChild)
-                .count(),
-        ),
-        Duration::ZERO,
-        true,
-        None,
-    );
-    record_sandbox_op(
-        framework_home_instructions_action(
-            tasks
-                .iter()
-                .any(|task| task.metadata.task_kind == TaskKind::FrameworkHomeInstructions),
-        ),
-        Duration::ZERO,
-        true,
-        None,
-    );
-    record_sandbox_op(
-        CountMetric::PotentialParentChildOverlap
-            .action(potential_parent_child_overlap_count(tasks)),
-        Duration::ZERO,
-        true,
-        None,
-    );
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ConflictKind {
-    InstructionsSkill,
-    ExactPath,
-    OtherParentChild,
-}
-
-fn classify_conflict(
-    left_path: &Path,
-    left_kind: TaskKind,
-    right_path: &Path,
-    right_kind: TaskKind,
-) -> ConflictKind {
-    if left_path == right_path {
-        ConflictKind::ExactPath
-    } else if task_kinds_are_instructions_and_skill(left_kind, right_kind) {
-        ConflictKind::InstructionsSkill
-    } else {
-        ConflictKind::OtherParentChild
-    }
-}
-
-fn task_kinds_are_instructions_and_skill(left: TaskKind, right: TaskKind) -> bool {
-    matches!(
-        (left, right),
-        (
-            TaskKind::FrameworkHomeInstructions,
-            TaskKind::FrameworkSkillChild
-        ) | (
-            TaskKind::FrameworkSkillChild,
-            TaskKind::FrameworkHomeInstructions
-        )
-    )
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-struct ConflictDeferralStats {
-    total: usize,
-    instructions_skill: usize,
-    exact_path: usize,
-    other_parent_child: usize,
-}
-
-impl ConflictDeferralStats {
-    fn record(&mut self, kind: ConflictKind) {
-        self.total += 1;
-        match kind {
-            ConflictKind::InstructionsSkill => self.instructions_skill += 1,
-            ConflictKind::ExactPath => self.exact_path += 1,
-            ConflictKind::OtherParentChild => self.other_parent_child += 1,
-        }
-    }
-}
-
-fn potential_parent_child_overlap_count(tasks: &[TaskSnapshot]) -> usize {
-    let mut path_counts = HashMap::new();
-    for task in tasks {
-        *path_counts.entry(task.mount_path.clone()).or_insert(0usize) += 1;
-    }
-
-    let mut count = 0;
-    for task in tasks {
-        for ancestor in task.mount_path.ancestors().skip(1) {
-            if let Some(ancestor_count) = path_counts.get(ancestor) {
-                count += ancestor_count;
-            }
-        }
-    }
-    count
-}
-
-pub(crate) struct TaskRecorder {
-    metadata: TaskMetadata,
-    remote_metrics: Option<RemoteArchiveTaskMetrics>,
-}
-
-impl TaskRecorder {
-    pub(crate) fn new(metadata: TaskMetadata) -> Self {
-        Self {
-            metadata,
-            remote_metrics: (metadata.source_kind == SourceKind::Remote)
-                .then(RemoteArchiveTaskMetrics::default),
-        }
-    }
-
-    pub(crate) fn begin_attempt(&mut self) -> Option<source::RemoteArchiveAttemptMetrics> {
-        let metrics = self.remote_metrics.as_mut()?;
-        metrics.attempts = metrics.attempts.saturating_add(1);
-        Some(source::RemoteArchiveAttemptMetrics::default())
-    }
-
-    pub(crate) fn record_attempt(
-        &mut self,
-        metrics: &source::RemoteArchiveAttemptMetrics,
-        extract_wall: Duration,
-    ) {
-        let Some(remote_metrics) = self.remote_metrics.as_mut() else {
-            return;
-        };
-        let snapshot = metrics.snapshot();
-        remote_metrics.request_to_response_headers = remote_metrics
-            .request_to_response_headers
-            .saturating_add(snapshot.request_to_response_headers);
-        remote_metrics.body_read = remote_metrics.body_read.saturating_add(snapshot.body_read);
-        remote_metrics.extract_outside_body_read = remote_metrics
-            .extract_outside_body_read
-            .saturating_add(extract_wall.saturating_sub(snapshot.body_read));
-        remote_metrics.compressed_bytes_consumed = remote_metrics
-            .compressed_bytes_consumed
-            .saturating_add(snapshot.compressed_bytes_consumed);
-    }
-
-    pub(crate) fn finish(self, elapsed: Duration, success: bool, failure_detail: Option<&str>) {
-        record_sandbox_op(
-            archive_action(self.metadata.archive_kind, ArchiveMetric::Total),
-            elapsed,
-            success,
-            failure_detail,
-        );
-        let Some(metrics) = self.remote_metrics else {
-            return;
-        };
-        record_sandbox_op(
-            archive_action(
-                self.metadata.archive_kind,
-                ArchiveMetric::RequestToResponseHeaders,
-            ),
-            metrics.request_to_response_headers,
-            success,
-            None,
-        );
-        record_sandbox_op(
-            archive_action(self.metadata.archive_kind, ArchiveMetric::BodyRead),
-            metrics.body_read,
-            success,
-            None,
-        );
-        record_sandbox_op(
-            archive_action(
-                self.metadata.archive_kind,
-                ArchiveMetric::ExtractOutsideBodyRead,
-            ),
-            metrics.extract_outside_body_read,
-            success,
-            None,
-        );
-        record_sandbox_op(
-            archive_action(
-                self.metadata.archive_kind,
-                ArchiveMetric::CompressedBytes(CompressedBytesBucket::from_bytes(
-                    metrics.compressed_bytes_consumed,
-                )),
-            ),
-            Duration::ZERO,
-            success,
-            None,
-        );
-        record_sandbox_op(
-            archive_action(
-                self.metadata.archive_kind,
-                ArchiveMetric::AttemptCount(AttemptCountBucket::from_attempts(metrics.attempts)),
-            ),
-            Duration::ZERO,
-            success,
-            None,
+        record_count_metric(
+            CountMetric::OtherParentChildConflictDeferral,
+            self.conflict_deferrals.other_parent_child,
         );
     }
 }
 
 #[derive(Default)]
-struct RemoteArchiveTaskMetrics {
+pub(crate) struct RemoteArchiveTaskMetrics {
     request_to_response_headers: Duration,
     body_read: Duration,
     extract_outside_body_read: Duration,
@@ -415,274 +162,182 @@ struct RemoteArchiveTaskMetrics {
     attempts: u32,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum CountMetric {
-    Task,
-    RemoteUrl,
-    FileUrl,
-    SkillChildTask,
-    PotentialParentChildOverlap,
-    MountConflictDeferral,
-    InstructionsSkillConflictDeferral,
-    ExactPathConflictDeferral,
-    OtherParentChildConflictDeferral,
-}
-
-impl CountMetric {
-    fn action(self, count: usize) -> &'static str {
-        CountBucket::from_count(count).select(self.actions())
+impl RemoteArchiveTaskMetrics {
+    pub(crate) fn begin_attempt(&mut self) {
+        self.attempts = self.attempts.saturating_add(1);
     }
 
-    fn actions(self) -> [&'static str; 7] {
+    pub(crate) fn record_attempt(
+        &mut self,
+        metrics: source::RemoteArchiveAttemptSnapshot,
+        extract_wall: Duration,
+    ) {
+        self.request_to_response_headers = self
+            .request_to_response_headers
+            .saturating_add(metrics.request_to_response_headers);
+        self.body_read = self.body_read.saturating_add(metrics.body_read);
+        self.extract_outside_body_read = self
+            .extract_outside_body_read
+            .saturating_add(extract_wall.saturating_sub(metrics.body_read));
+        self.compressed_bytes_consumed = self
+            .compressed_bytes_consumed
+            .saturating_add(metrics.compressed_bytes_consumed);
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ArchiveKind {
+    Storage,
+    Artifact,
+}
+
+impl ArchiveKind {
+    fn total_action(self) -> &'static str {
         match self {
-            Self::Task => [
-                "guest_download_task_count_0",
-                "guest_download_task_count_1",
-                "guest_download_task_count_2",
-                "guest_download_task_count_3_4",
-                "guest_download_task_count_5_8",
-                "guest_download_task_count_9_16",
-                "guest_download_task_count_17_plus",
-            ],
-            Self::RemoteUrl => [
-                "guest_download_remote_url_count_0",
-                "guest_download_remote_url_count_1",
-                "guest_download_remote_url_count_2",
-                "guest_download_remote_url_count_3_4",
-                "guest_download_remote_url_count_5_8",
-                "guest_download_remote_url_count_9_16",
-                "guest_download_remote_url_count_17_plus",
-            ],
-            Self::FileUrl => [
-                "guest_download_file_url_count_0",
-                "guest_download_file_url_count_1",
-                "guest_download_file_url_count_2",
-                "guest_download_file_url_count_3_4",
-                "guest_download_file_url_count_5_8",
-                "guest_download_file_url_count_9_16",
-                "guest_download_file_url_count_17_plus",
-            ],
-            Self::SkillChildTask => [
-                "guest_download_skill_child_task_count_0",
-                "guest_download_skill_child_task_count_1",
-                "guest_download_skill_child_task_count_2",
-                "guest_download_skill_child_task_count_3_4",
-                "guest_download_skill_child_task_count_5_8",
-                "guest_download_skill_child_task_count_9_16",
-                "guest_download_skill_child_task_count_17_plus",
-            ],
-            Self::PotentialParentChildOverlap => [
-                "guest_download_potential_parent_child_overlap_count_0",
-                "guest_download_potential_parent_child_overlap_count_1",
-                "guest_download_potential_parent_child_overlap_count_2",
-                "guest_download_potential_parent_child_overlap_count_3_4",
-                "guest_download_potential_parent_child_overlap_count_5_8",
-                "guest_download_potential_parent_child_overlap_count_9_16",
-                "guest_download_potential_parent_child_overlap_count_17_plus",
-            ],
-            Self::MountConflictDeferral => [
-                "guest_download_mount_conflict_deferral_count_0",
-                "guest_download_mount_conflict_deferral_count_1",
-                "guest_download_mount_conflict_deferral_count_2",
-                "guest_download_mount_conflict_deferral_count_3_4",
-                "guest_download_mount_conflict_deferral_count_5_8",
-                "guest_download_mount_conflict_deferral_count_9_16",
-                "guest_download_mount_conflict_deferral_count_17_plus",
-            ],
-            Self::InstructionsSkillConflictDeferral => [
-                "guest_download_instructions_skill_conflict_deferral_count_0",
-                "guest_download_instructions_skill_conflict_deferral_count_1",
-                "guest_download_instructions_skill_conflict_deferral_count_2",
-                "guest_download_instructions_skill_conflict_deferral_count_3_4",
-                "guest_download_instructions_skill_conflict_deferral_count_5_8",
-                "guest_download_instructions_skill_conflict_deferral_count_9_16",
-                "guest_download_instructions_skill_conflict_deferral_count_17_plus",
-            ],
-            Self::ExactPathConflictDeferral => [
-                "guest_download_exact_path_conflict_deferral_count_0",
-                "guest_download_exact_path_conflict_deferral_count_1",
-                "guest_download_exact_path_conflict_deferral_count_2",
-                "guest_download_exact_path_conflict_deferral_count_3_4",
-                "guest_download_exact_path_conflict_deferral_count_5_8",
-                "guest_download_exact_path_conflict_deferral_count_9_16",
-                "guest_download_exact_path_conflict_deferral_count_17_plus",
-            ],
-            Self::OtherParentChildConflictDeferral => [
-                "guest_download_other_parent_child_conflict_deferral_count_0",
-                "guest_download_other_parent_child_conflict_deferral_count_1",
-                "guest_download_other_parent_child_conflict_deferral_count_2",
-                "guest_download_other_parent_child_conflict_deferral_count_3_4",
-                "guest_download_other_parent_child_conflict_deferral_count_5_8",
-                "guest_download_other_parent_child_conflict_deferral_count_9_16",
-                "guest_download_other_parent_child_conflict_deferral_count_17_plus",
-            ],
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum CountBucket {
-    Zero,
-    One,
-    Two,
-    ThreeToFour,
-    FiveToEight,
-    NineToSixteen,
-    SeventeenPlus,
-}
-
-impl CountBucket {
-    fn from_count(count: usize) -> Self {
-        match count {
-            0 => Self::Zero,
-            1 => Self::One,
-            2 => Self::Two,
-            3 | 4 => Self::ThreeToFour,
-            5..=8 => Self::FiveToEight,
-            9..=16 => Self::NineToSixteen,
-            _ => Self::SeventeenPlus,
+            Self::Storage => "storage_download",
+            Self::Artifact => "artifact_download",
         }
     }
 
-    fn select(self, actions: [&'static str; 7]) -> &'static str {
-        let [
-            zero,
-            one,
-            two,
-            three_to_four,
-            five_to_eight,
-            nine_to_sixteen,
-            seventeen_plus,
-        ] = actions;
+    fn request_to_response_headers_action(self) -> &'static str {
         match self {
-            Self::Zero => zero,
-            Self::One => one,
-            Self::Two => two,
-            Self::ThreeToFour => three_to_four,
-            Self::FiveToEight => five_to_eight,
-            Self::NineToSixteen => nine_to_sixteen,
-            Self::SeventeenPlus => seventeen_plus,
+            Self::Storage => "storage_download_remote_request_to_response_headers",
+            Self::Artifact => "artifact_download_remote_request_to_response_headers",
         }
     }
-}
 
-fn framework_home_instructions_action(present: bool) -> &'static str {
-    if present {
-        "guest_download_framework_home_instructions_task_present"
-    } else {
-        "guest_download_framework_home_instructions_task_absent"
+    fn body_read_action(self) -> &'static str {
+        match self {
+            Self::Storage => "storage_download_remote_body_read",
+            Self::Artifact => "artifact_download_remote_body_read",
+        }
     }
-}
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ArchiveMetric {
-    Total,
-    RequestToResponseHeaders,
-    BodyRead,
-    ExtractOutsideBodyRead,
-    CompressedBytes(CompressedBytesBucket),
-    AttemptCount(AttemptCountBucket),
-}
+    fn extract_outside_body_read_action(self) -> &'static str {
+        match self {
+            Self::Storage => "storage_download_remote_extract_outside_body_read",
+            Self::Artifact => "artifact_download_remote_extract_outside_body_read",
+        }
+    }
 
-fn archive_action(kind: ArchiveKind, metric: ArchiveMetric) -> &'static str {
-    match (kind, metric) {
-        (ArchiveKind::Storage, ArchiveMetric::Total) => "storage_download",
-        (ArchiveKind::Artifact, ArchiveMetric::Total) => "artifact_download",
-        (ArchiveKind::Storage, ArchiveMetric::RequestToResponseHeaders) => {
-            "storage_download_remote_request_to_response_headers"
+    fn compressed_bytes_consumed_action(self, bytes: u64) -> &'static str {
+        match (self, CompressedBytesBucket::from_bytes(bytes)) {
+            (Self::Storage, CompressedBytesBucket::Zero) => {
+                "storage_download_remote_compressed_bytes_consumed_zero"
+            }
+            (Self::Storage, CompressedBytesBucket::Under64Kib) => {
+                "storage_download_remote_compressed_bytes_consumed_lt_64_kib"
+            }
+            (Self::Storage, CompressedBytesBucket::Kib64To256) => {
+                "storage_download_remote_compressed_bytes_consumed_64_kib_to_256_kib"
+            }
+            (Self::Storage, CompressedBytesBucket::Kib256To1Mib) => {
+                "storage_download_remote_compressed_bytes_consumed_256_kib_to_1_mib"
+            }
+            (Self::Storage, CompressedBytesBucket::Mib1To4) => {
+                "storage_download_remote_compressed_bytes_consumed_1_mib_to_4_mib"
+            }
+            (Self::Storage, CompressedBytesBucket::Mib4To16) => {
+                "storage_download_remote_compressed_bytes_consumed_4_mib_to_16_mib"
+            }
+            (Self::Storage, CompressedBytesBucket::Mib16To64) => {
+                "storage_download_remote_compressed_bytes_consumed_16_mib_to_64_mib"
+            }
+            (Self::Storage, CompressedBytesBucket::Mib64Plus) => {
+                "storage_download_remote_compressed_bytes_consumed_64_mib_plus"
+            }
+            (Self::Artifact, CompressedBytesBucket::Zero) => {
+                "artifact_download_remote_compressed_bytes_consumed_zero"
+            }
+            (Self::Artifact, CompressedBytesBucket::Under64Kib) => {
+                "artifact_download_remote_compressed_bytes_consumed_lt_64_kib"
+            }
+            (Self::Artifact, CompressedBytesBucket::Kib64To256) => {
+                "artifact_download_remote_compressed_bytes_consumed_64_kib_to_256_kib"
+            }
+            (Self::Artifact, CompressedBytesBucket::Kib256To1Mib) => {
+                "artifact_download_remote_compressed_bytes_consumed_256_kib_to_1_mib"
+            }
+            (Self::Artifact, CompressedBytesBucket::Mib1To4) => {
+                "artifact_download_remote_compressed_bytes_consumed_1_mib_to_4_mib"
+            }
+            (Self::Artifact, CompressedBytesBucket::Mib4To16) => {
+                "artifact_download_remote_compressed_bytes_consumed_4_mib_to_16_mib"
+            }
+            (Self::Artifact, CompressedBytesBucket::Mib16To64) => {
+                "artifact_download_remote_compressed_bytes_consumed_16_mib_to_64_mib"
+            }
+            (Self::Artifact, CompressedBytesBucket::Mib64Plus) => {
+                "artifact_download_remote_compressed_bytes_consumed_64_mib_plus"
+            }
         }
-        (ArchiveKind::Artifact, ArchiveMetric::RequestToResponseHeaders) => {
-            "artifact_download_remote_request_to_response_headers"
-        }
-        (ArchiveKind::Storage, ArchiveMetric::BodyRead) => "storage_download_remote_body_read",
-        (ArchiveKind::Artifact, ArchiveMetric::BodyRead) => "artifact_download_remote_body_read",
-        (ArchiveKind::Storage, ArchiveMetric::ExtractOutsideBodyRead) => {
-            "storage_download_remote_extract_outside_body_read"
-        }
-        (ArchiveKind::Artifact, ArchiveMetric::ExtractOutsideBodyRead) => {
-            "artifact_download_remote_extract_outside_body_read"
-        }
-        (ArchiveKind::Storage, ArchiveMetric::CompressedBytes(CompressedBytesBucket::Zero)) => {
-            "storage_download_remote_compressed_bytes_consumed_zero"
-        }
-        (
-            ArchiveKind::Storage,
-            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Under64Kib),
-        ) => "storage_download_remote_compressed_bytes_consumed_lt_64_kib",
-        (
-            ArchiveKind::Storage,
-            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Kib64To256),
-        ) => "storage_download_remote_compressed_bytes_consumed_64_kib_to_256_kib",
-        (
-            ArchiveKind::Storage,
-            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Kib256To1Mib),
-        ) => "storage_download_remote_compressed_bytes_consumed_256_kib_to_1_mib",
-        (ArchiveKind::Storage, ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib1To4)) => {
-            "storage_download_remote_compressed_bytes_consumed_1_mib_to_4_mib"
-        }
-        (ArchiveKind::Storage, ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib4To16)) => {
-            "storage_download_remote_compressed_bytes_consumed_4_mib_to_16_mib"
-        }
-        (
-            ArchiveKind::Storage,
-            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib16To64),
-        ) => "storage_download_remote_compressed_bytes_consumed_16_mib_to_64_mib",
-        (
-            ArchiveKind::Storage,
-            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib64Plus),
-        ) => "storage_download_remote_compressed_bytes_consumed_64_mib_plus",
-        (ArchiveKind::Artifact, ArchiveMetric::CompressedBytes(CompressedBytesBucket::Zero)) => {
-            "artifact_download_remote_compressed_bytes_consumed_zero"
-        }
-        (
-            ArchiveKind::Artifact,
-            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Under64Kib),
-        ) => "artifact_download_remote_compressed_bytes_consumed_lt_64_kib",
-        (
-            ArchiveKind::Artifact,
-            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Kib64To256),
-        ) => "artifact_download_remote_compressed_bytes_consumed_64_kib_to_256_kib",
-        (
-            ArchiveKind::Artifact,
-            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Kib256To1Mib),
-        ) => "artifact_download_remote_compressed_bytes_consumed_256_kib_to_1_mib",
-        (ArchiveKind::Artifact, ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib1To4)) => {
-            "artifact_download_remote_compressed_bytes_consumed_1_mib_to_4_mib"
-        }
-        (
-            ArchiveKind::Artifact,
-            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib4To16),
-        ) => "artifact_download_remote_compressed_bytes_consumed_4_mib_to_16_mib",
-        (
-            ArchiveKind::Artifact,
-            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib16To64),
-        ) => "artifact_download_remote_compressed_bytes_consumed_16_mib_to_64_mib",
-        (
-            ArchiveKind::Artifact,
-            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib64Plus),
-        ) => "artifact_download_remote_compressed_bytes_consumed_64_mib_plus",
-        (ArchiveKind::Storage, ArchiveMetric::AttemptCount(AttemptCountBucket::One)) => {
-            "storage_download_remote_attempt_count_1"
-        }
-        (ArchiveKind::Storage, ArchiveMetric::AttemptCount(AttemptCountBucket::Two)) => {
-            "storage_download_remote_attempt_count_2"
-        }
-        (ArchiveKind::Storage, ArchiveMetric::AttemptCount(AttemptCountBucket::Three)) => {
-            "storage_download_remote_attempt_count_3"
-        }
-        (ArchiveKind::Artifact, ArchiveMetric::AttemptCount(AttemptCountBucket::One)) => {
-            "artifact_download_remote_attempt_count_1"
-        }
-        (ArchiveKind::Artifact, ArchiveMetric::AttemptCount(AttemptCountBucket::Two)) => {
-            "artifact_download_remote_attempt_count_2"
-        }
-        (ArchiveKind::Artifact, ArchiveMetric::AttemptCount(AttemptCountBucket::Three)) => {
-            "artifact_download_remote_attempt_count_3"
+    }
+
+    fn attempt_count_action(self, attempts: u32) -> &'static str {
+        match (self, attempts) {
+            (Self::Storage, 1) => "storage_download_remote_attempt_count_1",
+            (Self::Storage, 2) => "storage_download_remote_attempt_count_2",
+            (Self::Storage, _) => "storage_download_remote_attempt_count_3",
+            (Self::Artifact, 1) => "artifact_download_remote_attempt_count_1",
+            (Self::Artifact, 2) => "artifact_download_remote_attempt_count_2",
+            (Self::Artifact, _) => "artifact_download_remote_attempt_count_3",
         }
     }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DownloadTaskKind {
+    FrameworkHomeInstructions,
+    FrameworkSkillChild,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DownloadUrlKind {
+    Remote,
+    File,
+    Other,
+}
+
+impl DownloadUrlKind {
+    fn from_url(url: &str) -> Self {
+        if url.starts_with("http://") || url.starts_with("https://") {
+            Self::Remote
+        } else if url.starts_with("file://") {
+            Self::File
+        } else {
+            Self::Other
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DownloadConflictKind {
+    InstructionsSkill,
+    ExactPath,
+    OtherParentChild,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct DownloadConflictDeferralStats {
+    total: usize,
+    instructions_skill: usize,
+    exact_path: usize,
+    other_parent_child: usize,
+}
+
+impl DownloadConflictDeferralStats {
+    fn record(&mut self, kind: DownloadConflictKind) {
+        self.total += 1;
+        match kind {
+            DownloadConflictKind::InstructionsSkill => self.instructions_skill += 1,
+            DownloadConflictKind::ExactPath => self.exact_path += 1,
+            DownloadConflictKind::OtherParentChild => self.other_parent_child += 1,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
 enum CompressedBytesBucket {
     Zero,
     Under64Kib,
@@ -709,517 +364,350 @@ impl CompressedBytesBucket {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum AttemptCountBucket {
-    One,
-    Two,
-    Three,
+#[derive(Clone, Copy)]
+enum CountMetric {
+    Task,
+    RemoteUrl,
+    FileUrl,
+    SkillChildTask,
+    PotentialParentChildOverlap,
+    MountConflictDeferral,
+    InstructionsSkillConflictDeferral,
+    ExactPathConflictDeferral,
+    OtherParentChildConflictDeferral,
 }
 
-impl AttemptCountBucket {
-    fn from_attempts(attempts: u32) -> Self {
-        match attempts {
-            1 => Self::One,
-            2 => Self::Two,
-            _ => Self::Three,
+impl CountMetric {
+    fn actions(self) -> CountMetricActions {
+        match self {
+            Self::Task => CountMetricActions {
+                zero: "guest_download_task_count_0",
+                one: "guest_download_task_count_1",
+                two: "guest_download_task_count_2",
+                three_to_four: "guest_download_task_count_3_4",
+                five_to_eight: "guest_download_task_count_5_8",
+                nine_to_sixteen: "guest_download_task_count_9_16",
+                seventeen_plus: "guest_download_task_count_17_plus",
+            },
+            Self::RemoteUrl => CountMetricActions {
+                zero: "guest_download_remote_url_count_0",
+                one: "guest_download_remote_url_count_1",
+                two: "guest_download_remote_url_count_2",
+                three_to_four: "guest_download_remote_url_count_3_4",
+                five_to_eight: "guest_download_remote_url_count_5_8",
+                nine_to_sixteen: "guest_download_remote_url_count_9_16",
+                seventeen_plus: "guest_download_remote_url_count_17_plus",
+            },
+            Self::FileUrl => CountMetricActions {
+                zero: "guest_download_file_url_count_0",
+                one: "guest_download_file_url_count_1",
+                two: "guest_download_file_url_count_2",
+                three_to_four: "guest_download_file_url_count_3_4",
+                five_to_eight: "guest_download_file_url_count_5_8",
+                nine_to_sixteen: "guest_download_file_url_count_9_16",
+                seventeen_plus: "guest_download_file_url_count_17_plus",
+            },
+            Self::SkillChildTask => CountMetricActions {
+                zero: "guest_download_skill_child_task_count_0",
+                one: "guest_download_skill_child_task_count_1",
+                two: "guest_download_skill_child_task_count_2",
+                three_to_four: "guest_download_skill_child_task_count_3_4",
+                five_to_eight: "guest_download_skill_child_task_count_5_8",
+                nine_to_sixteen: "guest_download_skill_child_task_count_9_16",
+                seventeen_plus: "guest_download_skill_child_task_count_17_plus",
+            },
+            Self::PotentialParentChildOverlap => CountMetricActions {
+                zero: "guest_download_potential_parent_child_overlap_count_0",
+                one: "guest_download_potential_parent_child_overlap_count_1",
+                two: "guest_download_potential_parent_child_overlap_count_2",
+                three_to_four: "guest_download_potential_parent_child_overlap_count_3_4",
+                five_to_eight: "guest_download_potential_parent_child_overlap_count_5_8",
+                nine_to_sixteen: "guest_download_potential_parent_child_overlap_count_9_16",
+                seventeen_plus: "guest_download_potential_parent_child_overlap_count_17_plus",
+            },
+            Self::MountConflictDeferral => CountMetricActions {
+                zero: "guest_download_mount_conflict_deferral_count_0",
+                one: "guest_download_mount_conflict_deferral_count_1",
+                two: "guest_download_mount_conflict_deferral_count_2",
+                three_to_four: "guest_download_mount_conflict_deferral_count_3_4",
+                five_to_eight: "guest_download_mount_conflict_deferral_count_5_8",
+                nine_to_sixteen: "guest_download_mount_conflict_deferral_count_9_16",
+                seventeen_plus: "guest_download_mount_conflict_deferral_count_17_plus",
+            },
+            Self::InstructionsSkillConflictDeferral => CountMetricActions {
+                zero: "guest_download_instructions_skill_conflict_deferral_count_0",
+                one: "guest_download_instructions_skill_conflict_deferral_count_1",
+                two: "guest_download_instructions_skill_conflict_deferral_count_2",
+                three_to_four: "guest_download_instructions_skill_conflict_deferral_count_3_4",
+                five_to_eight: "guest_download_instructions_skill_conflict_deferral_count_5_8",
+                nine_to_sixteen: "guest_download_instructions_skill_conflict_deferral_count_9_16",
+                seventeen_plus: "guest_download_instructions_skill_conflict_deferral_count_17_plus",
+            },
+            Self::ExactPathConflictDeferral => CountMetricActions {
+                zero: "guest_download_exact_path_conflict_deferral_count_0",
+                one: "guest_download_exact_path_conflict_deferral_count_1",
+                two: "guest_download_exact_path_conflict_deferral_count_2",
+                three_to_four: "guest_download_exact_path_conflict_deferral_count_3_4",
+                five_to_eight: "guest_download_exact_path_conflict_deferral_count_5_8",
+                nine_to_sixteen: "guest_download_exact_path_conflict_deferral_count_9_16",
+                seventeen_plus: "guest_download_exact_path_conflict_deferral_count_17_plus",
+            },
+            Self::OtherParentChildConflictDeferral => CountMetricActions {
+                zero: "guest_download_other_parent_child_conflict_deferral_count_0",
+                one: "guest_download_other_parent_child_conflict_deferral_count_1",
+                two: "guest_download_other_parent_child_conflict_deferral_count_2",
+                three_to_four: "guest_download_other_parent_child_conflict_deferral_count_3_4",
+                five_to_eight: "guest_download_other_parent_child_conflict_deferral_count_5_8",
+                nine_to_sixteen: "guest_download_other_parent_child_conflict_deferral_count_9_16",
+                seventeen_plus: "guest_download_other_parent_child_conflict_deferral_count_17_plus",
+            },
         }
     }
+}
+
+#[derive(Clone, Copy)]
+struct CountMetricActions {
+    zero: &'static str,
+    one: &'static str,
+    two: &'static str,
+    three_to_four: &'static str,
+    five_to_eight: &'static str,
+    nine_to_sixteen: &'static str,
+    seventeen_plus: &'static str,
+}
+
+impl CountMetricActions {
+    fn action(self, count: usize) -> &'static str {
+        match count {
+            0 => self.zero,
+            1 => self.one,
+            2 => self.two,
+            3 | 4 => self.three_to_four,
+            5..=8 => self.five_to_eight,
+            9..=16 => self.nine_to_sixteen,
+            _ => self.seventeen_plus,
+        }
+    }
+}
+
+fn record_count_metric(metric: CountMetric, count: usize) {
+    record_sandbox_op(metric.actions().action(count), Duration::ZERO, true, None);
+}
+
+fn framework_home_instructions_task_action(present: bool) -> &'static str {
+    if present {
+        "guest_download_framework_home_instructions_task_present"
+    } else {
+        "guest_download_framework_home_instructions_task_absent"
+    }
+}
+
+fn classify_download_task_kind(
+    mount_path: &Path,
+    has_instructions_target: bool,
+) -> DownloadTaskKind {
+    if has_instructions_target {
+        return DownloadTaskKind::FrameworkHomeInstructions;
+    }
+
+    if is_framework_skill_child_path(mount_path) {
+        return DownloadTaskKind::FrameworkSkillChild;
+    }
+
+    DownloadTaskKind::Other
+}
+
+fn classify_download_conflict(
+    left_path: &Path,
+    left_kind: DownloadTaskKind,
+    right_path: &Path,
+    right_kind: DownloadTaskKind,
+) -> DownloadConflictKind {
+    if left_path == right_path {
+        return DownloadConflictKind::ExactPath;
+    }
+    if task_kinds_are_instructions_and_skill(left_kind, right_kind) {
+        return DownloadConflictKind::InstructionsSkill;
+    }
+    DownloadConflictKind::OtherParentChild
+}
+
+fn task_kinds_are_instructions_and_skill(left: DownloadTaskKind, right: DownloadTaskKind) -> bool {
+    matches!(
+        (left, right),
+        (
+            DownloadTaskKind::FrameworkHomeInstructions,
+            DownloadTaskKind::FrameworkSkillChild
+        ) | (
+            DownloadTaskKind::FrameworkSkillChild,
+            DownloadTaskKind::FrameworkHomeInstructions
+        )
+    )
+}
+
+fn potential_parent_child_overlap_count(normalized_paths: &[&Path]) -> usize {
+    let mut path_counts = HashMap::new();
+    for &path in normalized_paths {
+        *path_counts.entry(path).or_insert(0usize) += 1;
+    }
+
+    let mut count = 0;
+    for &path in normalized_paths {
+        for ancestor in path.ancestors().skip(1) {
+            if let Some(ancestor_count) = path_counts.get(ancestor) {
+                count += ancestor_count;
+            }
+        }
+    }
+    count
+}
+
+fn is_framework_skill_child_path(path: &Path) -> bool {
+    is_child_path(path, Path::new("/home/user/.codex/skills"))
+        || is_child_path(path, Path::new("/home/user/.claude/skills"))
+}
+
+fn is_child_path(path: &Path, parent: &Path) -> bool {
+    path.starts_with(parent) && path != parent
+}
+
+fn record_remote_archive_attribution(
+    archive_kind: ArchiveKind,
+    metrics: &RemoteArchiveTaskMetrics,
+    success: bool,
+) {
+    record_sandbox_op(
+        archive_kind.request_to_response_headers_action(),
+        metrics.request_to_response_headers,
+        success,
+        None,
+    );
+    record_sandbox_op(
+        archive_kind.body_read_action(),
+        metrics.body_read,
+        success,
+        None,
+    );
+    record_sandbox_op(
+        archive_kind.extract_outside_body_read_action(),
+        metrics.extract_outside_body_read,
+        success,
+        None,
+    );
+    record_sandbox_op(
+        archive_kind.compressed_bytes_consumed_action(metrics.compressed_bytes_consumed),
+        Duration::ZERO,
+        success,
+        None,
+    );
+    record_sandbox_op(
+        archive_kind.attempt_count_action(metrics.attempts),
+        Duration::ZERO,
+        success,
+        None,
+    );
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashSet;
-
-    const COUNT_METRICS: [CountMetric; 9] = [
-        CountMetric::Task,
-        CountMetric::RemoteUrl,
-        CountMetric::FileUrl,
-        CountMetric::SkillChildTask,
-        CountMetric::PotentialParentChildOverlap,
-        CountMetric::MountConflictDeferral,
-        CountMetric::InstructionsSkillConflictDeferral,
-        CountMetric::ExactPathConflictDeferral,
-        CountMetric::OtherParentChildConflictDeferral,
-    ];
-
-    const ARCHIVE_KINDS: [ArchiveKind; 2] = [ArchiveKind::Storage, ArchiveKind::Artifact];
-
-    fn metadata(task_kind: TaskKind) -> TaskMetadata {
-        TaskMetadata {
-            archive_kind: ArchiveKind::Storage,
-            source_kind: SourceKind::File,
-            task_kind,
-        }
-    }
-
-    fn snapshot(path: &str, task_kind: TaskKind) -> TaskSnapshot {
-        TaskSnapshot::new(metadata(task_kind), PathBuf::from(path))
-    }
-
-    fn assert_count_actions(metric: CountMetric, expected: [&'static str; 7]) {
-        assert_eq!(
-            [0, 1, 2, 3, 5, 9, 17].map(|count| metric.action(count)),
-            expected
-        );
-    }
+    use std::path::PathBuf;
 
     #[test]
-    fn task_metadata_classifies_sources_and_framework_paths() {
+    fn task_kind_classification_identifies_instructions_and_skill_children() {
         assert_eq!(
-            TaskMetadata::storage(
+            DownloadTaskTelemetry::storage(
                 "https://example.com/archive.tar.gz",
-                Path::new("/staged/instructions"),
-                Some("AGENTS.md"),
-            ),
-            TaskMetadata {
-                archive_kind: ArchiveKind::Storage,
-                source_kind: SourceKind::Remote,
-                task_kind: TaskKind::FrameworkHomeInstructions,
-            }
-        );
-        assert_eq!(
-            TaskMetadata::artifact(
-                "file:///tmp/archive.tar.gz",
-                Path::new("/home/user/.codex/skills/workflow"),
-            ),
-            TaskMetadata {
-                archive_kind: ArchiveKind::Artifact,
-                source_kind: SourceKind::File,
-                task_kind: TaskKind::FrameworkSkillChild,
-            }
-        );
-        assert_eq!(
-            TaskMetadata::artifact(
-                "other://archive.tar.gz",
-                Path::new("/home/user/.claude/skills"),
-            ),
-            TaskMetadata {
-                archive_kind: ArchiveKind::Artifact,
-                source_kind: SourceKind::Other,
-                task_kind: TaskKind::Other,
-            }
-        );
-        assert_eq!(
-            TaskMetadata::artifact(
-                "https://example.com/archive.tar.gz",
-                Path::new("/home/user/.claude/skills-old/tool"),
+                Path::new("/home/user/.codex"),
+                true,
             )
             .task_kind,
-            TaskKind::Other
+            DownloadTaskKind::FrameworkHomeInstructions
+        );
+        assert_eq!(
+            DownloadTaskTelemetry::storage(
+                "https://example.com/archive.tar.gz",
+                Path::new("/home/user/.codex/skills/workflow"),
+                false,
+            )
+            .task_kind,
+            DownloadTaskKind::FrameworkSkillChild
+        );
+        assert_eq!(
+            DownloadTaskTelemetry::storage(
+                "https://example.com/archive.tar.gz",
+                Path::new("/home/user/.claude/skills/tool"),
+                false,
+            )
+            .task_kind,
+            DownloadTaskKind::FrameworkSkillChild
+        );
+        assert_eq!(
+            DownloadTaskTelemetry::storage(
+                "https://example.com/archive.tar.gz",
+                Path::new("/home/user/.codex/skills"),
+                false,
+            )
+            .task_kind,
+            DownloadTaskKind::Other
+        );
+        assert_eq!(
+            DownloadTaskTelemetry::storage(
+                "https://example.com/archive.tar.gz",
+                Path::new("/workspace"),
+                false,
+            )
+            .task_kind,
+            DownloadTaskKind::Other
         );
     }
 
     #[test]
-    fn conflict_classification_uses_task_kinds_only_after_path_conflict() {
+    fn conflict_classifier_buckets_exact_instruction_skill_and_other_parent_child() {
         assert_eq!(
-            classify_conflict(
+            classify_download_conflict(
                 Path::new("/home/user/.codex/skills/foo"),
-                TaskKind::FrameworkSkillChild,
+                DownloadTaskKind::FrameworkSkillChild,
                 Path::new("/home/user/.codex"),
-                TaskKind::FrameworkHomeInstructions,
+                DownloadTaskKind::FrameworkHomeInstructions,
             ),
-            ConflictKind::InstructionsSkill
+            DownloadConflictKind::InstructionsSkill
         );
         assert_eq!(
-            classify_conflict(
+            classify_download_conflict(
                 Path::new("/same"),
-                TaskKind::Other,
+                DownloadTaskKind::Other,
                 Path::new("/same"),
-                TaskKind::Other,
+                DownloadTaskKind::Other,
             ),
-            ConflictKind::ExactPath
+            DownloadConflictKind::ExactPath
         );
         assert_eq!(
-            classify_conflict(
+            classify_download_conflict(
                 Path::new("/tmp/parent/child"),
-                TaskKind::Other,
+                DownloadTaskKind::Other,
                 Path::new("/tmp/parent"),
-                TaskKind::Other,
+                DownloadTaskKind::Other,
             ),
-            ConflictKind::OtherParentChild
+            DownloadConflictKind::OtherParentChild
         );
     }
 
     #[test]
-    fn potential_parent_child_overlap_excludes_exact_paths_and_siblings() {
-        let tasks = [
-            snapshot("/workspace", TaskKind::Other),
-            snapshot("/workspace/src", TaskKind::Other),
-            snapshot("/workspace/tests", TaskKind::Other),
-            snapshot("/workspace/src", TaskKind::Other),
-            snapshot("/workspace/src/nested", TaskKind::Other),
+    fn potential_parent_child_overlap_count_excludes_exact_paths_and_siblings() {
+        let paths = [
+            PathBuf::from("/workspace"),
+            PathBuf::from("/workspace/src"),
+            PathBuf::from("/workspace/tests"),
+            PathBuf::from("/workspace/src"),
+            PathBuf::from("/workspace/src/nested"),
         ];
 
-        assert_eq!(potential_parent_child_overlap_count(&tasks), 6);
-    }
-
-    #[test]
-    fn batch_recorder_counts_each_observed_conflict() {
-        let mut recorder = BatchRecorder::new([
-            snapshot("/home/user/.codex", TaskKind::FrameworkHomeInstructions),
-            snapshot(
-                "/home/user/.codex/skills/workflow",
-                TaskKind::FrameworkSkillChild,
+        assert_eq!(
+            potential_parent_child_overlap_count(
+                &paths.iter().map(PathBuf::as_path).collect::<Vec<_>>()
             ),
-        ]);
-
-        recorder.record_conflict(
-            1,
-            Path::new("/home/user/.codex/skills/workflow"),
-            0,
-            Path::new("/home/user/.codex"),
+            6
         );
-        recorder.record_conflict(
-            1,
-            Path::new("/home/user/.codex/skills/workflow"),
-            0,
-            Path::new("/home/user/.codex"),
-        );
-
-        assert_eq!(
-            recorder.conflict_deferrals,
-            ConflictDeferralStats {
-                total: 2,
-                instructions_skill: 2,
-                exact_path: 0,
-                other_parent_child: 0,
-            }
-        );
-    }
-
-    #[test]
-    fn count_bucket_boundaries_are_stable() {
-        assert_eq!(
-            [0, 1, 2, 3, 4, 5, 8, 9, 16, 17].map(CountBucket::from_count),
-            [
-                CountBucket::Zero,
-                CountBucket::One,
-                CountBucket::Two,
-                CountBucket::ThreeToFour,
-                CountBucket::ThreeToFour,
-                CountBucket::FiveToEight,
-                CountBucket::FiveToEight,
-                CountBucket::NineToSixteen,
-                CountBucket::NineToSixteen,
-                CountBucket::SeventeenPlus,
-            ]
-        );
-    }
-
-    #[test]
-    fn count_metric_actions_are_stable() {
-        assert_count_actions(
-            CountMetric::Task,
-            [
-                "guest_download_task_count_0",
-                "guest_download_task_count_1",
-                "guest_download_task_count_2",
-                "guest_download_task_count_3_4",
-                "guest_download_task_count_5_8",
-                "guest_download_task_count_9_16",
-                "guest_download_task_count_17_plus",
-            ],
-        );
-        assert_count_actions(
-            CountMetric::RemoteUrl,
-            [
-                "guest_download_remote_url_count_0",
-                "guest_download_remote_url_count_1",
-                "guest_download_remote_url_count_2",
-                "guest_download_remote_url_count_3_4",
-                "guest_download_remote_url_count_5_8",
-                "guest_download_remote_url_count_9_16",
-                "guest_download_remote_url_count_17_plus",
-            ],
-        );
-        assert_count_actions(
-            CountMetric::FileUrl,
-            [
-                "guest_download_file_url_count_0",
-                "guest_download_file_url_count_1",
-                "guest_download_file_url_count_2",
-                "guest_download_file_url_count_3_4",
-                "guest_download_file_url_count_5_8",
-                "guest_download_file_url_count_9_16",
-                "guest_download_file_url_count_17_plus",
-            ],
-        );
-        assert_count_actions(
-            CountMetric::SkillChildTask,
-            [
-                "guest_download_skill_child_task_count_0",
-                "guest_download_skill_child_task_count_1",
-                "guest_download_skill_child_task_count_2",
-                "guest_download_skill_child_task_count_3_4",
-                "guest_download_skill_child_task_count_5_8",
-                "guest_download_skill_child_task_count_9_16",
-                "guest_download_skill_child_task_count_17_plus",
-            ],
-        );
-        assert_count_actions(
-            CountMetric::PotentialParentChildOverlap,
-            [
-                "guest_download_potential_parent_child_overlap_count_0",
-                "guest_download_potential_parent_child_overlap_count_1",
-                "guest_download_potential_parent_child_overlap_count_2",
-                "guest_download_potential_parent_child_overlap_count_3_4",
-                "guest_download_potential_parent_child_overlap_count_5_8",
-                "guest_download_potential_parent_child_overlap_count_9_16",
-                "guest_download_potential_parent_child_overlap_count_17_plus",
-            ],
-        );
-        assert_count_actions(
-            CountMetric::MountConflictDeferral,
-            [
-                "guest_download_mount_conflict_deferral_count_0",
-                "guest_download_mount_conflict_deferral_count_1",
-                "guest_download_mount_conflict_deferral_count_2",
-                "guest_download_mount_conflict_deferral_count_3_4",
-                "guest_download_mount_conflict_deferral_count_5_8",
-                "guest_download_mount_conflict_deferral_count_9_16",
-                "guest_download_mount_conflict_deferral_count_17_plus",
-            ],
-        );
-        assert_count_actions(
-            CountMetric::InstructionsSkillConflictDeferral,
-            [
-                "guest_download_instructions_skill_conflict_deferral_count_0",
-                "guest_download_instructions_skill_conflict_deferral_count_1",
-                "guest_download_instructions_skill_conflict_deferral_count_2",
-                "guest_download_instructions_skill_conflict_deferral_count_3_4",
-                "guest_download_instructions_skill_conflict_deferral_count_5_8",
-                "guest_download_instructions_skill_conflict_deferral_count_9_16",
-                "guest_download_instructions_skill_conflict_deferral_count_17_plus",
-            ],
-        );
-        assert_count_actions(
-            CountMetric::ExactPathConflictDeferral,
-            [
-                "guest_download_exact_path_conflict_deferral_count_0",
-                "guest_download_exact_path_conflict_deferral_count_1",
-                "guest_download_exact_path_conflict_deferral_count_2",
-                "guest_download_exact_path_conflict_deferral_count_3_4",
-                "guest_download_exact_path_conflict_deferral_count_5_8",
-                "guest_download_exact_path_conflict_deferral_count_9_16",
-                "guest_download_exact_path_conflict_deferral_count_17_plus",
-            ],
-        );
-        assert_count_actions(
-            CountMetric::OtherParentChildConflictDeferral,
-            [
-                "guest_download_other_parent_child_conflict_deferral_count_0",
-                "guest_download_other_parent_child_conflict_deferral_count_1",
-                "guest_download_other_parent_child_conflict_deferral_count_2",
-                "guest_download_other_parent_child_conflict_deferral_count_3_4",
-                "guest_download_other_parent_child_conflict_deferral_count_5_8",
-                "guest_download_other_parent_child_conflict_deferral_count_9_16",
-                "guest_download_other_parent_child_conflict_deferral_count_17_plus",
-            ],
-        );
-    }
-
-    #[test]
-    fn presence_and_archive_phase_actions_are_stable() {
-        assert_eq!(
-            framework_home_instructions_action(false),
-            "guest_download_framework_home_instructions_task_absent"
-        );
-        assert_eq!(
-            framework_home_instructions_action(true),
-            "guest_download_framework_home_instructions_task_present"
-        );
-        assert_eq!(
-            archive_action(ArchiveKind::Storage, ArchiveMetric::Total),
-            "storage_download"
-        );
-        assert_eq!(
-            archive_action(ArchiveKind::Artifact, ArchiveMetric::Total),
-            "artifact_download"
-        );
-        assert_eq!(
-            archive_action(
-                ArchiveKind::Storage,
-                ArchiveMetric::RequestToResponseHeaders
-            ),
-            "storage_download_remote_request_to_response_headers"
-        );
-        assert_eq!(
-            archive_action(
-                ArchiveKind::Artifact,
-                ArchiveMetric::RequestToResponseHeaders
-            ),
-            "artifact_download_remote_request_to_response_headers"
-        );
-        assert_eq!(
-            archive_action(ArchiveKind::Storage, ArchiveMetric::BodyRead),
-            "storage_download_remote_body_read"
-        );
-        assert_eq!(
-            archive_action(ArchiveKind::Artifact, ArchiveMetric::BodyRead),
-            "artifact_download_remote_body_read"
-        );
-        assert_eq!(
-            archive_action(ArchiveKind::Storage, ArchiveMetric::ExtractOutsideBodyRead),
-            "storage_download_remote_extract_outside_body_read"
-        );
-        assert_eq!(
-            archive_action(ArchiveKind::Artifact, ArchiveMetric::ExtractOutsideBodyRead),
-            "artifact_download_remote_extract_outside_body_read"
-        );
-    }
-
-    #[test]
-    fn compressed_byte_bucket_boundaries_are_stable() {
-        assert_eq!(
-            [
-                0, 1, 65_535, 65_536, 262_143, 262_144, 1_048_575, 1_048_576, 4_194_303, 4_194_304,
-                16_777_215, 16_777_216, 67_108_863, 67_108_864,
-            ]
-            .map(CompressedBytesBucket::from_bytes),
-            [
-                CompressedBytesBucket::Zero,
-                CompressedBytesBucket::Under64Kib,
-                CompressedBytesBucket::Under64Kib,
-                CompressedBytesBucket::Kib64To256,
-                CompressedBytesBucket::Kib64To256,
-                CompressedBytesBucket::Kib256To1Mib,
-                CompressedBytesBucket::Kib256To1Mib,
-                CompressedBytesBucket::Mib1To4,
-                CompressedBytesBucket::Mib1To4,
-                CompressedBytesBucket::Mib4To16,
-                CompressedBytesBucket::Mib4To16,
-                CompressedBytesBucket::Mib16To64,
-                CompressedBytesBucket::Mib16To64,
-                CompressedBytesBucket::Mib64Plus,
-            ]
-        );
-    }
-
-    #[test]
-    fn compressed_byte_actions_are_stable() {
-        let buckets = [
-            CompressedBytesBucket::Zero,
-            CompressedBytesBucket::Under64Kib,
-            CompressedBytesBucket::Kib64To256,
-            CompressedBytesBucket::Kib256To1Mib,
-            CompressedBytesBucket::Mib1To4,
-            CompressedBytesBucket::Mib4To16,
-            CompressedBytesBucket::Mib16To64,
-            CompressedBytesBucket::Mib64Plus,
-        ];
-        assert_eq!(
-            buckets.map(|bucket| archive_action(
-                ArchiveKind::Storage,
-                ArchiveMetric::CompressedBytes(bucket)
-            )),
-            [
-                "storage_download_remote_compressed_bytes_consumed_zero",
-                "storage_download_remote_compressed_bytes_consumed_lt_64_kib",
-                "storage_download_remote_compressed_bytes_consumed_64_kib_to_256_kib",
-                "storage_download_remote_compressed_bytes_consumed_256_kib_to_1_mib",
-                "storage_download_remote_compressed_bytes_consumed_1_mib_to_4_mib",
-                "storage_download_remote_compressed_bytes_consumed_4_mib_to_16_mib",
-                "storage_download_remote_compressed_bytes_consumed_16_mib_to_64_mib",
-                "storage_download_remote_compressed_bytes_consumed_64_mib_plus",
-            ]
-        );
-        assert_eq!(
-            buckets.map(|bucket| archive_action(
-                ArchiveKind::Artifact,
-                ArchiveMetric::CompressedBytes(bucket)
-            )),
-            [
-                "artifact_download_remote_compressed_bytes_consumed_zero",
-                "artifact_download_remote_compressed_bytes_consumed_lt_64_kib",
-                "artifact_download_remote_compressed_bytes_consumed_64_kib_to_256_kib",
-                "artifact_download_remote_compressed_bytes_consumed_256_kib_to_1_mib",
-                "artifact_download_remote_compressed_bytes_consumed_1_mib_to_4_mib",
-                "artifact_download_remote_compressed_bytes_consumed_4_mib_to_16_mib",
-                "artifact_download_remote_compressed_bytes_consumed_16_mib_to_64_mib",
-                "artifact_download_remote_compressed_bytes_consumed_64_mib_plus",
-            ]
-        );
-    }
-
-    #[test]
-    fn attempt_actions_are_stable() {
-        assert_eq!(
-            [0, 1, 2, 3, 4].map(AttemptCountBucket::from_attempts),
-            [
-                AttemptCountBucket::Three,
-                AttemptCountBucket::One,
-                AttemptCountBucket::Two,
-                AttemptCountBucket::Three,
-                AttemptCountBucket::Three,
-            ]
-        );
-        let buckets = [
-            AttemptCountBucket::One,
-            AttemptCountBucket::Two,
-            AttemptCountBucket::Three,
-        ];
-        assert_eq!(
-            buckets.map(|bucket| archive_action(
-                ArchiveKind::Storage,
-                ArchiveMetric::AttemptCount(bucket)
-            )),
-            [
-                "storage_download_remote_attempt_count_1",
-                "storage_download_remote_attempt_count_2",
-                "storage_download_remote_attempt_count_3",
-            ]
-        );
-        assert_eq!(
-            buckets.map(|bucket| archive_action(
-                ArchiveKind::Artifact,
-                ArchiveMetric::AttemptCount(bucket)
-            )),
-            [
-                "artifact_download_remote_attempt_count_1",
-                "artifact_download_remote_attempt_count_2",
-                "artifact_download_remote_attempt_count_3",
-            ]
-        );
-    }
-
-    #[test]
-    fn complete_action_schema_contains_95_unique_strings() {
-        let mut actions = HashSet::new();
-        for metric in COUNT_METRICS {
-            actions.extend(metric.actions());
-        }
-        actions.insert(framework_home_instructions_action(false));
-        actions.insert(framework_home_instructions_action(true));
-        for kind in ARCHIVE_KINDS {
-            actions.insert(archive_action(kind, ArchiveMetric::Total));
-            actions.insert(archive_action(
-                kind,
-                ArchiveMetric::RequestToResponseHeaders,
-            ));
-            actions.insert(archive_action(kind, ArchiveMetric::BodyRead));
-            actions.insert(archive_action(kind, ArchiveMetric::ExtractOutsideBodyRead));
-            for bucket in [
-                CompressedBytesBucket::Zero,
-                CompressedBytesBucket::Under64Kib,
-                CompressedBytesBucket::Kib64To256,
-                CompressedBytesBucket::Kib256To1Mib,
-                CompressedBytesBucket::Mib1To4,
-                CompressedBytesBucket::Mib4To16,
-                CompressedBytesBucket::Mib16To64,
-                CompressedBytesBucket::Mib64Plus,
-            ] {
-                actions.insert(archive_action(kind, ArchiveMetric::CompressedBytes(bucket)));
-            }
-            for bucket in [
-                AttemptCountBucket::One,
-                AttemptCountBucket::Two,
-                AttemptCountBucket::Three,
-            ] {
-                actions.insert(archive_action(kind, ArchiveMetric::AttemptCount(bucket)));
-            }
-        }
-
-        assert_eq!(actions.len(), 95);
     }
 }

--- a/crates/guest-download/src/telemetry.rs
+++ b/crates/guest-download/src/telemetry.rs
@@ -28,13 +28,6 @@ impl DownloadTaskTelemetry {
         }
     }
 
-    pub(crate) fn identity(self, sequence: usize) -> DownloadIdentity {
-        DownloadIdentity {
-            sequence,
-            task_kind: self.task_kind,
-        }
-    }
-
     pub(crate) fn remote_metrics(self) -> Option<RemoteArchiveTaskMetrics> {
         matches!(self.url_kind, DownloadUrlKind::Remote).then(RemoteArchiveTaskMetrics::default)
     }
@@ -53,22 +46,8 @@ impl DownloadTaskTelemetry {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct DownloadIdentity {
-    sequence: usize,
-    task_kind: DownloadTaskKind,
-}
-
-impl PartialEq for DownloadIdentity {
-    fn eq(&self, other: &Self) -> bool {
-        self.sequence == other.sequence
-    }
-}
-
-impl Eq for DownloadIdentity {}
-
-#[derive(Default)]
 pub(crate) struct DownloadRunTelemetry {
+    task_kinds: Vec<DownloadTaskKind>,
     conflict_deferrals: DownloadConflictDeferralStats,
 }
 
@@ -82,6 +61,7 @@ impl DownloadRunTelemetry {
         let mut skill_child_task_count = 0;
         let mut framework_home_instructions_task_present = false;
         let mut mount_paths = Vec::new();
+        let mut task_kinds = Vec::new();
 
         for (task, mount_path) in tasks {
             task_count += 1;
@@ -98,6 +78,7 @@ impl DownloadRunTelemetry {
                 DownloadTaskKind::Other => {}
             }
             mount_paths.push(mount_path);
+            task_kinds.push(task.task_kind);
         }
 
         record_count_metric(CountMetric::Task, task_count);
@@ -115,21 +96,33 @@ impl DownloadRunTelemetry {
             potential_parent_child_overlap_count(&mount_paths),
         );
 
-        Self::default()
+        Self {
+            task_kinds,
+            conflict_deferrals: DownloadConflictDeferralStats::default(),
+        }
     }
 
     pub(crate) fn record_conflict(
         &mut self,
-        pending: DownloadIdentity,
+        pending_id: usize,
         pending_path: &Path,
-        active: DownloadIdentity,
+        active_id: usize,
         active_path: &Path,
     ) {
+        let pending_kind = self.task_kinds.get(pending_id).copied();
+        let active_kind = self.task_kinds.get(active_id).copied();
+        debug_assert!(
+            pending_kind.is_some() && active_kind.is_some(),
+            "download telemetry id is out of range"
+        );
+        let (Some(pending_kind), Some(active_kind)) = (pending_kind, active_kind) else {
+            return;
+        };
         self.conflict_deferrals.record(classify_download_conflict(
             pending_path,
-            pending.task_kind,
+            pending_kind,
             active_path,
-            active.task_kind,
+            active_kind,
         ));
     }
 
@@ -337,7 +330,7 @@ impl DownloadConflictDeferralStats {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CompressedBytesBucket {
     Zero,
     Under64Kib,
@@ -611,7 +604,146 @@ fn record_remote_archive_attribution(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
     use std::path::PathBuf;
+
+    const COUNT_METRICS: [CountMetric; 9] = [
+        CountMetric::Task,
+        CountMetric::RemoteUrl,
+        CountMetric::FileUrl,
+        CountMetric::SkillChildTask,
+        CountMetric::PotentialParentChildOverlap,
+        CountMetric::MountConflictDeferral,
+        CountMetric::InstructionsSkillConflictDeferral,
+        CountMetric::ExactPathConflictDeferral,
+        CountMetric::OtherParentChildConflictDeferral,
+    ];
+    const COUNT_REPRESENTATIVES: [usize; 7] = [0, 1, 2, 3, 5, 9, 17];
+    const COMPRESSED_BYTE_REPRESENTATIVES: [u64; 8] = [
+        0, 1, 65_536, 262_144, 1_048_576, 4_194_304, 16_777_216, 67_108_864,
+    ];
+    const EXPECTED_ACTION_SCHEMA: [&str; 95] = [
+        "guest_download_task_count_0",
+        "guest_download_task_count_1",
+        "guest_download_task_count_2",
+        "guest_download_task_count_3_4",
+        "guest_download_task_count_5_8",
+        "guest_download_task_count_9_16",
+        "guest_download_task_count_17_plus",
+        "guest_download_remote_url_count_0",
+        "guest_download_remote_url_count_1",
+        "guest_download_remote_url_count_2",
+        "guest_download_remote_url_count_3_4",
+        "guest_download_remote_url_count_5_8",
+        "guest_download_remote_url_count_9_16",
+        "guest_download_remote_url_count_17_plus",
+        "guest_download_file_url_count_0",
+        "guest_download_file_url_count_1",
+        "guest_download_file_url_count_2",
+        "guest_download_file_url_count_3_4",
+        "guest_download_file_url_count_5_8",
+        "guest_download_file_url_count_9_16",
+        "guest_download_file_url_count_17_plus",
+        "guest_download_skill_child_task_count_0",
+        "guest_download_skill_child_task_count_1",
+        "guest_download_skill_child_task_count_2",
+        "guest_download_skill_child_task_count_3_4",
+        "guest_download_skill_child_task_count_5_8",
+        "guest_download_skill_child_task_count_9_16",
+        "guest_download_skill_child_task_count_17_plus",
+        "guest_download_potential_parent_child_overlap_count_0",
+        "guest_download_potential_parent_child_overlap_count_1",
+        "guest_download_potential_parent_child_overlap_count_2",
+        "guest_download_potential_parent_child_overlap_count_3_4",
+        "guest_download_potential_parent_child_overlap_count_5_8",
+        "guest_download_potential_parent_child_overlap_count_9_16",
+        "guest_download_potential_parent_child_overlap_count_17_plus",
+        "guest_download_mount_conflict_deferral_count_0",
+        "guest_download_mount_conflict_deferral_count_1",
+        "guest_download_mount_conflict_deferral_count_2",
+        "guest_download_mount_conflict_deferral_count_3_4",
+        "guest_download_mount_conflict_deferral_count_5_8",
+        "guest_download_mount_conflict_deferral_count_9_16",
+        "guest_download_mount_conflict_deferral_count_17_plus",
+        "guest_download_instructions_skill_conflict_deferral_count_0",
+        "guest_download_instructions_skill_conflict_deferral_count_1",
+        "guest_download_instructions_skill_conflict_deferral_count_2",
+        "guest_download_instructions_skill_conflict_deferral_count_3_4",
+        "guest_download_instructions_skill_conflict_deferral_count_5_8",
+        "guest_download_instructions_skill_conflict_deferral_count_9_16",
+        "guest_download_instructions_skill_conflict_deferral_count_17_plus",
+        "guest_download_exact_path_conflict_deferral_count_0",
+        "guest_download_exact_path_conflict_deferral_count_1",
+        "guest_download_exact_path_conflict_deferral_count_2",
+        "guest_download_exact_path_conflict_deferral_count_3_4",
+        "guest_download_exact_path_conflict_deferral_count_5_8",
+        "guest_download_exact_path_conflict_deferral_count_9_16",
+        "guest_download_exact_path_conflict_deferral_count_17_plus",
+        "guest_download_other_parent_child_conflict_deferral_count_0",
+        "guest_download_other_parent_child_conflict_deferral_count_1",
+        "guest_download_other_parent_child_conflict_deferral_count_2",
+        "guest_download_other_parent_child_conflict_deferral_count_3_4",
+        "guest_download_other_parent_child_conflict_deferral_count_5_8",
+        "guest_download_other_parent_child_conflict_deferral_count_9_16",
+        "guest_download_other_parent_child_conflict_deferral_count_17_plus",
+        "guest_download_framework_home_instructions_task_absent",
+        "guest_download_framework_home_instructions_task_present",
+        "storage_download",
+        "storage_download_remote_request_to_response_headers",
+        "storage_download_remote_body_read",
+        "storage_download_remote_extract_outside_body_read",
+        "storage_download_remote_compressed_bytes_consumed_zero",
+        "storage_download_remote_compressed_bytes_consumed_lt_64_kib",
+        "storage_download_remote_compressed_bytes_consumed_64_kib_to_256_kib",
+        "storage_download_remote_compressed_bytes_consumed_256_kib_to_1_mib",
+        "storage_download_remote_compressed_bytes_consumed_1_mib_to_4_mib",
+        "storage_download_remote_compressed_bytes_consumed_4_mib_to_16_mib",
+        "storage_download_remote_compressed_bytes_consumed_16_mib_to_64_mib",
+        "storage_download_remote_compressed_bytes_consumed_64_mib_plus",
+        "storage_download_remote_attempt_count_1",
+        "storage_download_remote_attempt_count_2",
+        "storage_download_remote_attempt_count_3",
+        "artifact_download",
+        "artifact_download_remote_request_to_response_headers",
+        "artifact_download_remote_body_read",
+        "artifact_download_remote_extract_outside_body_read",
+        "artifact_download_remote_compressed_bytes_consumed_zero",
+        "artifact_download_remote_compressed_bytes_consumed_lt_64_kib",
+        "artifact_download_remote_compressed_bytes_consumed_64_kib_to_256_kib",
+        "artifact_download_remote_compressed_bytes_consumed_256_kib_to_1_mib",
+        "artifact_download_remote_compressed_bytes_consumed_1_mib_to_4_mib",
+        "artifact_download_remote_compressed_bytes_consumed_4_mib_to_16_mib",
+        "artifact_download_remote_compressed_bytes_consumed_16_mib_to_64_mib",
+        "artifact_download_remote_compressed_bytes_consumed_64_mib_plus",
+        "artifact_download_remote_attempt_count_1",
+        "artifact_download_remote_attempt_count_2",
+        "artifact_download_remote_attempt_count_3",
+    ];
+
+    fn action_schema() -> Vec<&'static str> {
+        let mut actions = Vec::new();
+        for metric in COUNT_METRICS {
+            actions.extend(COUNT_REPRESENTATIVES.map(|count| metric.actions().action(count)));
+        }
+        actions.extend([
+            framework_home_instructions_task_action(false),
+            framework_home_instructions_task_action(true),
+        ]);
+        for archive_kind in [ArchiveKind::Storage, ArchiveKind::Artifact] {
+            actions.extend([
+                archive_kind.total_action(),
+                archive_kind.request_to_response_headers_action(),
+                archive_kind.body_read_action(),
+                archive_kind.extract_outside_body_read_action(),
+            ]);
+            actions.extend(
+                COMPRESSED_BYTE_REPRESENTATIVES
+                    .map(|bytes| archive_kind.compressed_bytes_consumed_action(bytes)),
+            );
+            actions.extend([1, 2, 3].map(|attempts| archive_kind.attempt_count_action(attempts)));
+        }
+        actions
+    }
 
     #[test]
     fn task_kind_classification_identifies_instructions_and_skill_children() {
@@ -709,5 +841,73 @@ mod tests {
             ),
             6
         );
+    }
+
+    #[test]
+    fn count_bucket_boundaries_are_stable() {
+        assert_eq!(
+            [0, 1, 2, 3, 4, 5, 8, 9, 16, 17].map(|count| CountMetric::Task.actions().action(count)),
+            [
+                "guest_download_task_count_0",
+                "guest_download_task_count_1",
+                "guest_download_task_count_2",
+                "guest_download_task_count_3_4",
+                "guest_download_task_count_3_4",
+                "guest_download_task_count_5_8",
+                "guest_download_task_count_5_8",
+                "guest_download_task_count_9_16",
+                "guest_download_task_count_9_16",
+                "guest_download_task_count_17_plus",
+            ]
+        );
+    }
+
+    #[test]
+    fn compressed_byte_bucket_boundaries_are_stable() {
+        assert_eq!(
+            [
+                0, 1, 65_535, 65_536, 262_143, 262_144, 1_048_575, 1_048_576, 4_194_303, 4_194_304,
+                16_777_215, 16_777_216, 67_108_863, 67_108_864,
+            ]
+            .map(CompressedBytesBucket::from_bytes),
+            [
+                CompressedBytesBucket::Zero,
+                CompressedBytesBucket::Under64Kib,
+                CompressedBytesBucket::Under64Kib,
+                CompressedBytesBucket::Kib64To256,
+                CompressedBytesBucket::Kib64To256,
+                CompressedBytesBucket::Kib256To1Mib,
+                CompressedBytesBucket::Kib256To1Mib,
+                CompressedBytesBucket::Mib1To4,
+                CompressedBytesBucket::Mib1To4,
+                CompressedBytesBucket::Mib4To16,
+                CompressedBytesBucket::Mib4To16,
+                CompressedBytesBucket::Mib16To64,
+                CompressedBytesBucket::Mib16To64,
+                CompressedBytesBucket::Mib64Plus,
+            ]
+        );
+    }
+
+    #[test]
+    fn attempt_count_actions_are_stable() {
+        assert_eq!(
+            [0, 1, 2, 3, 4].map(|attempts| { ArchiveKind::Storage.attempt_count_action(attempts) }),
+            [
+                "storage_download_remote_attempt_count_3",
+                "storage_download_remote_attempt_count_1",
+                "storage_download_remote_attempt_count_2",
+                "storage_download_remote_attempt_count_3",
+                "storage_download_remote_attempt_count_3",
+            ]
+        );
+    }
+
+    #[test]
+    fn complete_action_schema_is_exact_and_unique() {
+        let actions = action_schema();
+
+        assert_eq!(actions.as_slice(), EXPECTED_ACTION_SCHEMA.as_slice());
+        assert_eq!(actions.iter().copied().collect::<HashSet<_>>().len(), 95);
     }
 }

--- a/crates/guest-download/src/telemetry.rs
+++ b/crates/guest-download/src/telemetry.rs
@@ -1,0 +1,1225 @@
+use crate::source;
+use guest_common::telemetry::record_sandbox_op;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ArchiveKind {
+    Storage,
+    Artifact,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SourceKind {
+    Remote,
+    File,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TaskKind {
+    FrameworkHomeInstructions,
+    FrameworkSkillChild,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TaskMetadata {
+    archive_kind: ArchiveKind,
+    source_kind: SourceKind,
+    task_kind: TaskKind,
+}
+
+impl TaskMetadata {
+    pub(crate) fn storage(
+        url: &str,
+        normalized_mount_path: &Path,
+        instructions_target_filename: Option<&str>,
+    ) -> Self {
+        Self::new(
+            ArchiveKind::Storage,
+            url,
+            normalized_mount_path,
+            instructions_target_filename,
+        )
+    }
+
+    pub(crate) fn artifact(url: &str, normalized_mount_path: &Path) -> Self {
+        Self::new(ArchiveKind::Artifact, url, normalized_mount_path, None)
+    }
+
+    fn new(
+        archive_kind: ArchiveKind,
+        url: &str,
+        normalized_mount_path: &Path,
+        instructions_target_filename: Option<&str>,
+    ) -> Self {
+        Self {
+            archive_kind,
+            source_kind: classify_source(url),
+            task_kind: classify_task(normalized_mount_path, instructions_target_filename),
+        }
+    }
+}
+
+fn classify_source(url: &str) -> SourceKind {
+    if url.starts_with("http://") || url.starts_with("https://") {
+        SourceKind::Remote
+    } else if url.starts_with("file://") {
+        SourceKind::File
+    } else {
+        SourceKind::Other
+    }
+}
+
+fn classify_task(
+    normalized_mount_path: &Path,
+    instructions_target_filename: Option<&str>,
+) -> TaskKind {
+    if instructions_target_filename.is_some() {
+        TaskKind::FrameworkHomeInstructions
+    } else if is_framework_skill_child_path(normalized_mount_path) {
+        TaskKind::FrameworkSkillChild
+    } else {
+        TaskKind::Other
+    }
+}
+
+fn is_framework_skill_child_path(path: &Path) -> bool {
+    is_child_path(path, Path::new("/home/user/.codex/skills"))
+        || is_child_path(path, Path::new("/home/user/.claude/skills"))
+}
+
+fn is_child_path(path: &Path, parent: &Path) -> bool {
+    path.starts_with(parent) && path != parent
+}
+
+pub(crate) struct TaskSnapshot {
+    metadata: TaskMetadata,
+    mount_path: PathBuf,
+}
+
+impl TaskSnapshot {
+    pub(crate) fn new(metadata: TaskMetadata, mount_path: PathBuf) -> Self {
+        Self {
+            metadata,
+            mount_path,
+        }
+    }
+}
+
+pub(crate) struct BatchRecorder {
+    task_kinds: Vec<TaskKind>,
+    conflict_deferrals: ConflictDeferralStats,
+}
+
+impl BatchRecorder {
+    pub(crate) fn new(tasks: impl IntoIterator<Item = TaskSnapshot>) -> Self {
+        let tasks: Vec<TaskSnapshot> = tasks.into_iter().collect();
+        record_batch_attribution(&tasks);
+        Self {
+            task_kinds: tasks.iter().map(|task| task.metadata.task_kind).collect(),
+            conflict_deferrals: ConflictDeferralStats::default(),
+        }
+    }
+
+    pub(crate) fn record_conflict(
+        &mut self,
+        pending_id: usize,
+        pending_path: &Path,
+        active_id: usize,
+        active_path: &Path,
+    ) {
+        let pending_kind = self.task_kinds.get(pending_id).copied();
+        let active_kind = self.task_kinds.get(active_id).copied();
+        debug_assert!(
+            pending_kind.is_some() && active_kind.is_some(),
+            "download telemetry id is out of range"
+        );
+        let (Some(pending_kind), Some(active_kind)) = (pending_kind, active_kind) else {
+            return;
+        };
+        self.conflict_deferrals.record(classify_conflict(
+            pending_path,
+            pending_kind,
+            active_path,
+            active_kind,
+        ));
+    }
+
+    pub(crate) fn finish(self) {
+        record_sandbox_op(
+            CountMetric::MountConflictDeferral.action(self.conflict_deferrals.total),
+            Duration::ZERO,
+            true,
+            None,
+        );
+        record_sandbox_op(
+            CountMetric::InstructionsSkillConflictDeferral
+                .action(self.conflict_deferrals.instructions_skill),
+            Duration::ZERO,
+            true,
+            None,
+        );
+        record_sandbox_op(
+            CountMetric::ExactPathConflictDeferral.action(self.conflict_deferrals.exact_path),
+            Duration::ZERO,
+            true,
+            None,
+        );
+        record_sandbox_op(
+            CountMetric::OtherParentChildConflictDeferral
+                .action(self.conflict_deferrals.other_parent_child),
+            Duration::ZERO,
+            true,
+            None,
+        );
+    }
+}
+
+fn record_batch_attribution(tasks: &[TaskSnapshot]) {
+    record_sandbox_op(
+        CountMetric::Task.action(tasks.len()),
+        Duration::ZERO,
+        true,
+        None,
+    );
+    record_sandbox_op(
+        CountMetric::RemoteUrl.action(
+            tasks
+                .iter()
+                .filter(|task| task.metadata.source_kind == SourceKind::Remote)
+                .count(),
+        ),
+        Duration::ZERO,
+        true,
+        None,
+    );
+    record_sandbox_op(
+        CountMetric::FileUrl.action(
+            tasks
+                .iter()
+                .filter(|task| task.metadata.source_kind == SourceKind::File)
+                .count(),
+        ),
+        Duration::ZERO,
+        true,
+        None,
+    );
+    record_sandbox_op(
+        CountMetric::SkillChildTask.action(
+            tasks
+                .iter()
+                .filter(|task| task.metadata.task_kind == TaskKind::FrameworkSkillChild)
+                .count(),
+        ),
+        Duration::ZERO,
+        true,
+        None,
+    );
+    record_sandbox_op(
+        framework_home_instructions_action(
+            tasks
+                .iter()
+                .any(|task| task.metadata.task_kind == TaskKind::FrameworkHomeInstructions),
+        ),
+        Duration::ZERO,
+        true,
+        None,
+    );
+    record_sandbox_op(
+        CountMetric::PotentialParentChildOverlap
+            .action(potential_parent_child_overlap_count(tasks)),
+        Duration::ZERO,
+        true,
+        None,
+    );
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ConflictKind {
+    InstructionsSkill,
+    ExactPath,
+    OtherParentChild,
+}
+
+fn classify_conflict(
+    left_path: &Path,
+    left_kind: TaskKind,
+    right_path: &Path,
+    right_kind: TaskKind,
+) -> ConflictKind {
+    if left_path == right_path {
+        ConflictKind::ExactPath
+    } else if task_kinds_are_instructions_and_skill(left_kind, right_kind) {
+        ConflictKind::InstructionsSkill
+    } else {
+        ConflictKind::OtherParentChild
+    }
+}
+
+fn task_kinds_are_instructions_and_skill(left: TaskKind, right: TaskKind) -> bool {
+    matches!(
+        (left, right),
+        (
+            TaskKind::FrameworkHomeInstructions,
+            TaskKind::FrameworkSkillChild
+        ) | (
+            TaskKind::FrameworkSkillChild,
+            TaskKind::FrameworkHomeInstructions
+        )
+    )
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct ConflictDeferralStats {
+    total: usize,
+    instructions_skill: usize,
+    exact_path: usize,
+    other_parent_child: usize,
+}
+
+impl ConflictDeferralStats {
+    fn record(&mut self, kind: ConflictKind) {
+        self.total += 1;
+        match kind {
+            ConflictKind::InstructionsSkill => self.instructions_skill += 1,
+            ConflictKind::ExactPath => self.exact_path += 1,
+            ConflictKind::OtherParentChild => self.other_parent_child += 1,
+        }
+    }
+}
+
+fn potential_parent_child_overlap_count(tasks: &[TaskSnapshot]) -> usize {
+    let mut path_counts = HashMap::new();
+    for task in tasks {
+        *path_counts.entry(task.mount_path.clone()).or_insert(0usize) += 1;
+    }
+
+    let mut count = 0;
+    for task in tasks {
+        for ancestor in task.mount_path.ancestors().skip(1) {
+            if let Some(ancestor_count) = path_counts.get(ancestor) {
+                count += ancestor_count;
+            }
+        }
+    }
+    count
+}
+
+pub(crate) struct TaskRecorder {
+    metadata: TaskMetadata,
+    remote_metrics: Option<RemoteArchiveTaskMetrics>,
+}
+
+impl TaskRecorder {
+    pub(crate) fn new(metadata: TaskMetadata) -> Self {
+        Self {
+            metadata,
+            remote_metrics: (metadata.source_kind == SourceKind::Remote)
+                .then(RemoteArchiveTaskMetrics::default),
+        }
+    }
+
+    pub(crate) fn begin_attempt(&mut self) -> Option<source::RemoteArchiveAttemptMetrics> {
+        let metrics = self.remote_metrics.as_mut()?;
+        metrics.attempts = metrics.attempts.saturating_add(1);
+        Some(source::RemoteArchiveAttemptMetrics::default())
+    }
+
+    pub(crate) fn record_attempt(
+        &mut self,
+        metrics: &source::RemoteArchiveAttemptMetrics,
+        extract_wall: Duration,
+    ) {
+        let Some(remote_metrics) = self.remote_metrics.as_mut() else {
+            return;
+        };
+        let snapshot = metrics.snapshot();
+        remote_metrics.request_to_response_headers = remote_metrics
+            .request_to_response_headers
+            .saturating_add(snapshot.request_to_response_headers);
+        remote_metrics.body_read = remote_metrics.body_read.saturating_add(snapshot.body_read);
+        remote_metrics.extract_outside_body_read = remote_metrics
+            .extract_outside_body_read
+            .saturating_add(extract_wall.saturating_sub(snapshot.body_read));
+        remote_metrics.compressed_bytes_consumed = remote_metrics
+            .compressed_bytes_consumed
+            .saturating_add(snapshot.compressed_bytes_consumed);
+    }
+
+    pub(crate) fn finish(self, elapsed: Duration, success: bool, failure_detail: Option<&str>) {
+        record_sandbox_op(
+            archive_action(self.metadata.archive_kind, ArchiveMetric::Total),
+            elapsed,
+            success,
+            failure_detail,
+        );
+        let Some(metrics) = self.remote_metrics else {
+            return;
+        };
+        record_sandbox_op(
+            archive_action(
+                self.metadata.archive_kind,
+                ArchiveMetric::RequestToResponseHeaders,
+            ),
+            metrics.request_to_response_headers,
+            success,
+            None,
+        );
+        record_sandbox_op(
+            archive_action(self.metadata.archive_kind, ArchiveMetric::BodyRead),
+            metrics.body_read,
+            success,
+            None,
+        );
+        record_sandbox_op(
+            archive_action(
+                self.metadata.archive_kind,
+                ArchiveMetric::ExtractOutsideBodyRead,
+            ),
+            metrics.extract_outside_body_read,
+            success,
+            None,
+        );
+        record_sandbox_op(
+            archive_action(
+                self.metadata.archive_kind,
+                ArchiveMetric::CompressedBytes(CompressedBytesBucket::from_bytes(
+                    metrics.compressed_bytes_consumed,
+                )),
+            ),
+            Duration::ZERO,
+            success,
+            None,
+        );
+        record_sandbox_op(
+            archive_action(
+                self.metadata.archive_kind,
+                ArchiveMetric::AttemptCount(AttemptCountBucket::from_attempts(metrics.attempts)),
+            ),
+            Duration::ZERO,
+            success,
+            None,
+        );
+    }
+}
+
+#[derive(Default)]
+struct RemoteArchiveTaskMetrics {
+    request_to_response_headers: Duration,
+    body_read: Duration,
+    extract_outside_body_read: Duration,
+    compressed_bytes_consumed: u64,
+    attempts: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CountMetric {
+    Task,
+    RemoteUrl,
+    FileUrl,
+    SkillChildTask,
+    PotentialParentChildOverlap,
+    MountConflictDeferral,
+    InstructionsSkillConflictDeferral,
+    ExactPathConflictDeferral,
+    OtherParentChildConflictDeferral,
+}
+
+impl CountMetric {
+    fn action(self, count: usize) -> &'static str {
+        CountBucket::from_count(count).select(self.actions())
+    }
+
+    fn actions(self) -> [&'static str; 7] {
+        match self {
+            Self::Task => [
+                "guest_download_task_count_0",
+                "guest_download_task_count_1",
+                "guest_download_task_count_2",
+                "guest_download_task_count_3_4",
+                "guest_download_task_count_5_8",
+                "guest_download_task_count_9_16",
+                "guest_download_task_count_17_plus",
+            ],
+            Self::RemoteUrl => [
+                "guest_download_remote_url_count_0",
+                "guest_download_remote_url_count_1",
+                "guest_download_remote_url_count_2",
+                "guest_download_remote_url_count_3_4",
+                "guest_download_remote_url_count_5_8",
+                "guest_download_remote_url_count_9_16",
+                "guest_download_remote_url_count_17_plus",
+            ],
+            Self::FileUrl => [
+                "guest_download_file_url_count_0",
+                "guest_download_file_url_count_1",
+                "guest_download_file_url_count_2",
+                "guest_download_file_url_count_3_4",
+                "guest_download_file_url_count_5_8",
+                "guest_download_file_url_count_9_16",
+                "guest_download_file_url_count_17_plus",
+            ],
+            Self::SkillChildTask => [
+                "guest_download_skill_child_task_count_0",
+                "guest_download_skill_child_task_count_1",
+                "guest_download_skill_child_task_count_2",
+                "guest_download_skill_child_task_count_3_4",
+                "guest_download_skill_child_task_count_5_8",
+                "guest_download_skill_child_task_count_9_16",
+                "guest_download_skill_child_task_count_17_plus",
+            ],
+            Self::PotentialParentChildOverlap => [
+                "guest_download_potential_parent_child_overlap_count_0",
+                "guest_download_potential_parent_child_overlap_count_1",
+                "guest_download_potential_parent_child_overlap_count_2",
+                "guest_download_potential_parent_child_overlap_count_3_4",
+                "guest_download_potential_parent_child_overlap_count_5_8",
+                "guest_download_potential_parent_child_overlap_count_9_16",
+                "guest_download_potential_parent_child_overlap_count_17_plus",
+            ],
+            Self::MountConflictDeferral => [
+                "guest_download_mount_conflict_deferral_count_0",
+                "guest_download_mount_conflict_deferral_count_1",
+                "guest_download_mount_conflict_deferral_count_2",
+                "guest_download_mount_conflict_deferral_count_3_4",
+                "guest_download_mount_conflict_deferral_count_5_8",
+                "guest_download_mount_conflict_deferral_count_9_16",
+                "guest_download_mount_conflict_deferral_count_17_plus",
+            ],
+            Self::InstructionsSkillConflictDeferral => [
+                "guest_download_instructions_skill_conflict_deferral_count_0",
+                "guest_download_instructions_skill_conflict_deferral_count_1",
+                "guest_download_instructions_skill_conflict_deferral_count_2",
+                "guest_download_instructions_skill_conflict_deferral_count_3_4",
+                "guest_download_instructions_skill_conflict_deferral_count_5_8",
+                "guest_download_instructions_skill_conflict_deferral_count_9_16",
+                "guest_download_instructions_skill_conflict_deferral_count_17_plus",
+            ],
+            Self::ExactPathConflictDeferral => [
+                "guest_download_exact_path_conflict_deferral_count_0",
+                "guest_download_exact_path_conflict_deferral_count_1",
+                "guest_download_exact_path_conflict_deferral_count_2",
+                "guest_download_exact_path_conflict_deferral_count_3_4",
+                "guest_download_exact_path_conflict_deferral_count_5_8",
+                "guest_download_exact_path_conflict_deferral_count_9_16",
+                "guest_download_exact_path_conflict_deferral_count_17_plus",
+            ],
+            Self::OtherParentChildConflictDeferral => [
+                "guest_download_other_parent_child_conflict_deferral_count_0",
+                "guest_download_other_parent_child_conflict_deferral_count_1",
+                "guest_download_other_parent_child_conflict_deferral_count_2",
+                "guest_download_other_parent_child_conflict_deferral_count_3_4",
+                "guest_download_other_parent_child_conflict_deferral_count_5_8",
+                "guest_download_other_parent_child_conflict_deferral_count_9_16",
+                "guest_download_other_parent_child_conflict_deferral_count_17_plus",
+            ],
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CountBucket {
+    Zero,
+    One,
+    Two,
+    ThreeToFour,
+    FiveToEight,
+    NineToSixteen,
+    SeventeenPlus,
+}
+
+impl CountBucket {
+    fn from_count(count: usize) -> Self {
+        match count {
+            0 => Self::Zero,
+            1 => Self::One,
+            2 => Self::Two,
+            3 | 4 => Self::ThreeToFour,
+            5..=8 => Self::FiveToEight,
+            9..=16 => Self::NineToSixteen,
+            _ => Self::SeventeenPlus,
+        }
+    }
+
+    fn select(self, actions: [&'static str; 7]) -> &'static str {
+        let [
+            zero,
+            one,
+            two,
+            three_to_four,
+            five_to_eight,
+            nine_to_sixteen,
+            seventeen_plus,
+        ] = actions;
+        match self {
+            Self::Zero => zero,
+            Self::One => one,
+            Self::Two => two,
+            Self::ThreeToFour => three_to_four,
+            Self::FiveToEight => five_to_eight,
+            Self::NineToSixteen => nine_to_sixteen,
+            Self::SeventeenPlus => seventeen_plus,
+        }
+    }
+}
+
+fn framework_home_instructions_action(present: bool) -> &'static str {
+    if present {
+        "guest_download_framework_home_instructions_task_present"
+    } else {
+        "guest_download_framework_home_instructions_task_absent"
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ArchiveMetric {
+    Total,
+    RequestToResponseHeaders,
+    BodyRead,
+    ExtractOutsideBodyRead,
+    CompressedBytes(CompressedBytesBucket),
+    AttemptCount(AttemptCountBucket),
+}
+
+fn archive_action(kind: ArchiveKind, metric: ArchiveMetric) -> &'static str {
+    match (kind, metric) {
+        (ArchiveKind::Storage, ArchiveMetric::Total) => "storage_download",
+        (ArchiveKind::Artifact, ArchiveMetric::Total) => "artifact_download",
+        (ArchiveKind::Storage, ArchiveMetric::RequestToResponseHeaders) => {
+            "storage_download_remote_request_to_response_headers"
+        }
+        (ArchiveKind::Artifact, ArchiveMetric::RequestToResponseHeaders) => {
+            "artifact_download_remote_request_to_response_headers"
+        }
+        (ArchiveKind::Storage, ArchiveMetric::BodyRead) => "storage_download_remote_body_read",
+        (ArchiveKind::Artifact, ArchiveMetric::BodyRead) => "artifact_download_remote_body_read",
+        (ArchiveKind::Storage, ArchiveMetric::ExtractOutsideBodyRead) => {
+            "storage_download_remote_extract_outside_body_read"
+        }
+        (ArchiveKind::Artifact, ArchiveMetric::ExtractOutsideBodyRead) => {
+            "artifact_download_remote_extract_outside_body_read"
+        }
+        (ArchiveKind::Storage, ArchiveMetric::CompressedBytes(CompressedBytesBucket::Zero)) => {
+            "storage_download_remote_compressed_bytes_consumed_zero"
+        }
+        (
+            ArchiveKind::Storage,
+            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Under64Kib),
+        ) => "storage_download_remote_compressed_bytes_consumed_lt_64_kib",
+        (
+            ArchiveKind::Storage,
+            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Kib64To256),
+        ) => "storage_download_remote_compressed_bytes_consumed_64_kib_to_256_kib",
+        (
+            ArchiveKind::Storage,
+            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Kib256To1Mib),
+        ) => "storage_download_remote_compressed_bytes_consumed_256_kib_to_1_mib",
+        (ArchiveKind::Storage, ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib1To4)) => {
+            "storage_download_remote_compressed_bytes_consumed_1_mib_to_4_mib"
+        }
+        (ArchiveKind::Storage, ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib4To16)) => {
+            "storage_download_remote_compressed_bytes_consumed_4_mib_to_16_mib"
+        }
+        (
+            ArchiveKind::Storage,
+            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib16To64),
+        ) => "storage_download_remote_compressed_bytes_consumed_16_mib_to_64_mib",
+        (
+            ArchiveKind::Storage,
+            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib64Plus),
+        ) => "storage_download_remote_compressed_bytes_consumed_64_mib_plus",
+        (ArchiveKind::Artifact, ArchiveMetric::CompressedBytes(CompressedBytesBucket::Zero)) => {
+            "artifact_download_remote_compressed_bytes_consumed_zero"
+        }
+        (
+            ArchiveKind::Artifact,
+            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Under64Kib),
+        ) => "artifact_download_remote_compressed_bytes_consumed_lt_64_kib",
+        (
+            ArchiveKind::Artifact,
+            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Kib64To256),
+        ) => "artifact_download_remote_compressed_bytes_consumed_64_kib_to_256_kib",
+        (
+            ArchiveKind::Artifact,
+            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Kib256To1Mib),
+        ) => "artifact_download_remote_compressed_bytes_consumed_256_kib_to_1_mib",
+        (ArchiveKind::Artifact, ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib1To4)) => {
+            "artifact_download_remote_compressed_bytes_consumed_1_mib_to_4_mib"
+        }
+        (
+            ArchiveKind::Artifact,
+            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib4To16),
+        ) => "artifact_download_remote_compressed_bytes_consumed_4_mib_to_16_mib",
+        (
+            ArchiveKind::Artifact,
+            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib16To64),
+        ) => "artifact_download_remote_compressed_bytes_consumed_16_mib_to_64_mib",
+        (
+            ArchiveKind::Artifact,
+            ArchiveMetric::CompressedBytes(CompressedBytesBucket::Mib64Plus),
+        ) => "artifact_download_remote_compressed_bytes_consumed_64_mib_plus",
+        (ArchiveKind::Storage, ArchiveMetric::AttemptCount(AttemptCountBucket::One)) => {
+            "storage_download_remote_attempt_count_1"
+        }
+        (ArchiveKind::Storage, ArchiveMetric::AttemptCount(AttemptCountBucket::Two)) => {
+            "storage_download_remote_attempt_count_2"
+        }
+        (ArchiveKind::Storage, ArchiveMetric::AttemptCount(AttemptCountBucket::Three)) => {
+            "storage_download_remote_attempt_count_3"
+        }
+        (ArchiveKind::Artifact, ArchiveMetric::AttemptCount(AttemptCountBucket::One)) => {
+            "artifact_download_remote_attempt_count_1"
+        }
+        (ArchiveKind::Artifact, ArchiveMetric::AttemptCount(AttemptCountBucket::Two)) => {
+            "artifact_download_remote_attempt_count_2"
+        }
+        (ArchiveKind::Artifact, ArchiveMetric::AttemptCount(AttemptCountBucket::Three)) => {
+            "artifact_download_remote_attempt_count_3"
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CompressedBytesBucket {
+    Zero,
+    Under64Kib,
+    Kib64To256,
+    Kib256To1Mib,
+    Mib1To4,
+    Mib4To16,
+    Mib16To64,
+    Mib64Plus,
+}
+
+impl CompressedBytesBucket {
+    fn from_bytes(bytes: u64) -> Self {
+        match bytes {
+            0 => Self::Zero,
+            1..65_536 => Self::Under64Kib,
+            65_536..262_144 => Self::Kib64To256,
+            262_144..1_048_576 => Self::Kib256To1Mib,
+            1_048_576..4_194_304 => Self::Mib1To4,
+            4_194_304..16_777_216 => Self::Mib4To16,
+            16_777_216..67_108_864 => Self::Mib16To64,
+            _ => Self::Mib64Plus,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AttemptCountBucket {
+    One,
+    Two,
+    Three,
+}
+
+impl AttemptCountBucket {
+    fn from_attempts(attempts: u32) -> Self {
+        match attempts {
+            1 => Self::One,
+            2 => Self::Two,
+            _ => Self::Three,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    const COUNT_METRICS: [CountMetric; 9] = [
+        CountMetric::Task,
+        CountMetric::RemoteUrl,
+        CountMetric::FileUrl,
+        CountMetric::SkillChildTask,
+        CountMetric::PotentialParentChildOverlap,
+        CountMetric::MountConflictDeferral,
+        CountMetric::InstructionsSkillConflictDeferral,
+        CountMetric::ExactPathConflictDeferral,
+        CountMetric::OtherParentChildConflictDeferral,
+    ];
+
+    const ARCHIVE_KINDS: [ArchiveKind; 2] = [ArchiveKind::Storage, ArchiveKind::Artifact];
+
+    fn metadata(task_kind: TaskKind) -> TaskMetadata {
+        TaskMetadata {
+            archive_kind: ArchiveKind::Storage,
+            source_kind: SourceKind::File,
+            task_kind,
+        }
+    }
+
+    fn snapshot(path: &str, task_kind: TaskKind) -> TaskSnapshot {
+        TaskSnapshot::new(metadata(task_kind), PathBuf::from(path))
+    }
+
+    fn assert_count_actions(metric: CountMetric, expected: [&'static str; 7]) {
+        assert_eq!(
+            [0, 1, 2, 3, 5, 9, 17].map(|count| metric.action(count)),
+            expected
+        );
+    }
+
+    #[test]
+    fn task_metadata_classifies_sources_and_framework_paths() {
+        assert_eq!(
+            TaskMetadata::storage(
+                "https://example.com/archive.tar.gz",
+                Path::new("/staged/instructions"),
+                Some("AGENTS.md"),
+            ),
+            TaskMetadata {
+                archive_kind: ArchiveKind::Storage,
+                source_kind: SourceKind::Remote,
+                task_kind: TaskKind::FrameworkHomeInstructions,
+            }
+        );
+        assert_eq!(
+            TaskMetadata::artifact(
+                "file:///tmp/archive.tar.gz",
+                Path::new("/home/user/.codex/skills/workflow"),
+            ),
+            TaskMetadata {
+                archive_kind: ArchiveKind::Artifact,
+                source_kind: SourceKind::File,
+                task_kind: TaskKind::FrameworkSkillChild,
+            }
+        );
+        assert_eq!(
+            TaskMetadata::artifact(
+                "other://archive.tar.gz",
+                Path::new("/home/user/.claude/skills"),
+            ),
+            TaskMetadata {
+                archive_kind: ArchiveKind::Artifact,
+                source_kind: SourceKind::Other,
+                task_kind: TaskKind::Other,
+            }
+        );
+        assert_eq!(
+            TaskMetadata::artifact(
+                "https://example.com/archive.tar.gz",
+                Path::new("/home/user/.claude/skills-old/tool"),
+            )
+            .task_kind,
+            TaskKind::Other
+        );
+    }
+
+    #[test]
+    fn conflict_classification_uses_task_kinds_only_after_path_conflict() {
+        assert_eq!(
+            classify_conflict(
+                Path::new("/home/user/.codex/skills/foo"),
+                TaskKind::FrameworkSkillChild,
+                Path::new("/home/user/.codex"),
+                TaskKind::FrameworkHomeInstructions,
+            ),
+            ConflictKind::InstructionsSkill
+        );
+        assert_eq!(
+            classify_conflict(
+                Path::new("/same"),
+                TaskKind::Other,
+                Path::new("/same"),
+                TaskKind::Other,
+            ),
+            ConflictKind::ExactPath
+        );
+        assert_eq!(
+            classify_conflict(
+                Path::new("/tmp/parent/child"),
+                TaskKind::Other,
+                Path::new("/tmp/parent"),
+                TaskKind::Other,
+            ),
+            ConflictKind::OtherParentChild
+        );
+    }
+
+    #[test]
+    fn potential_parent_child_overlap_excludes_exact_paths_and_siblings() {
+        let tasks = [
+            snapshot("/workspace", TaskKind::Other),
+            snapshot("/workspace/src", TaskKind::Other),
+            snapshot("/workspace/tests", TaskKind::Other),
+            snapshot("/workspace/src", TaskKind::Other),
+            snapshot("/workspace/src/nested", TaskKind::Other),
+        ];
+
+        assert_eq!(potential_parent_child_overlap_count(&tasks), 6);
+    }
+
+    #[test]
+    fn batch_recorder_counts_each_observed_conflict() {
+        let mut recorder = BatchRecorder::new([
+            snapshot("/home/user/.codex", TaskKind::FrameworkHomeInstructions),
+            snapshot(
+                "/home/user/.codex/skills/workflow",
+                TaskKind::FrameworkSkillChild,
+            ),
+        ]);
+
+        recorder.record_conflict(
+            1,
+            Path::new("/home/user/.codex/skills/workflow"),
+            0,
+            Path::new("/home/user/.codex"),
+        );
+        recorder.record_conflict(
+            1,
+            Path::new("/home/user/.codex/skills/workflow"),
+            0,
+            Path::new("/home/user/.codex"),
+        );
+
+        assert_eq!(
+            recorder.conflict_deferrals,
+            ConflictDeferralStats {
+                total: 2,
+                instructions_skill: 2,
+                exact_path: 0,
+                other_parent_child: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn count_bucket_boundaries_are_stable() {
+        assert_eq!(
+            [0, 1, 2, 3, 4, 5, 8, 9, 16, 17].map(CountBucket::from_count),
+            [
+                CountBucket::Zero,
+                CountBucket::One,
+                CountBucket::Two,
+                CountBucket::ThreeToFour,
+                CountBucket::ThreeToFour,
+                CountBucket::FiveToEight,
+                CountBucket::FiveToEight,
+                CountBucket::NineToSixteen,
+                CountBucket::NineToSixteen,
+                CountBucket::SeventeenPlus,
+            ]
+        );
+    }
+
+    #[test]
+    fn count_metric_actions_are_stable() {
+        assert_count_actions(
+            CountMetric::Task,
+            [
+                "guest_download_task_count_0",
+                "guest_download_task_count_1",
+                "guest_download_task_count_2",
+                "guest_download_task_count_3_4",
+                "guest_download_task_count_5_8",
+                "guest_download_task_count_9_16",
+                "guest_download_task_count_17_plus",
+            ],
+        );
+        assert_count_actions(
+            CountMetric::RemoteUrl,
+            [
+                "guest_download_remote_url_count_0",
+                "guest_download_remote_url_count_1",
+                "guest_download_remote_url_count_2",
+                "guest_download_remote_url_count_3_4",
+                "guest_download_remote_url_count_5_8",
+                "guest_download_remote_url_count_9_16",
+                "guest_download_remote_url_count_17_plus",
+            ],
+        );
+        assert_count_actions(
+            CountMetric::FileUrl,
+            [
+                "guest_download_file_url_count_0",
+                "guest_download_file_url_count_1",
+                "guest_download_file_url_count_2",
+                "guest_download_file_url_count_3_4",
+                "guest_download_file_url_count_5_8",
+                "guest_download_file_url_count_9_16",
+                "guest_download_file_url_count_17_plus",
+            ],
+        );
+        assert_count_actions(
+            CountMetric::SkillChildTask,
+            [
+                "guest_download_skill_child_task_count_0",
+                "guest_download_skill_child_task_count_1",
+                "guest_download_skill_child_task_count_2",
+                "guest_download_skill_child_task_count_3_4",
+                "guest_download_skill_child_task_count_5_8",
+                "guest_download_skill_child_task_count_9_16",
+                "guest_download_skill_child_task_count_17_plus",
+            ],
+        );
+        assert_count_actions(
+            CountMetric::PotentialParentChildOverlap,
+            [
+                "guest_download_potential_parent_child_overlap_count_0",
+                "guest_download_potential_parent_child_overlap_count_1",
+                "guest_download_potential_parent_child_overlap_count_2",
+                "guest_download_potential_parent_child_overlap_count_3_4",
+                "guest_download_potential_parent_child_overlap_count_5_8",
+                "guest_download_potential_parent_child_overlap_count_9_16",
+                "guest_download_potential_parent_child_overlap_count_17_plus",
+            ],
+        );
+        assert_count_actions(
+            CountMetric::MountConflictDeferral,
+            [
+                "guest_download_mount_conflict_deferral_count_0",
+                "guest_download_mount_conflict_deferral_count_1",
+                "guest_download_mount_conflict_deferral_count_2",
+                "guest_download_mount_conflict_deferral_count_3_4",
+                "guest_download_mount_conflict_deferral_count_5_8",
+                "guest_download_mount_conflict_deferral_count_9_16",
+                "guest_download_mount_conflict_deferral_count_17_plus",
+            ],
+        );
+        assert_count_actions(
+            CountMetric::InstructionsSkillConflictDeferral,
+            [
+                "guest_download_instructions_skill_conflict_deferral_count_0",
+                "guest_download_instructions_skill_conflict_deferral_count_1",
+                "guest_download_instructions_skill_conflict_deferral_count_2",
+                "guest_download_instructions_skill_conflict_deferral_count_3_4",
+                "guest_download_instructions_skill_conflict_deferral_count_5_8",
+                "guest_download_instructions_skill_conflict_deferral_count_9_16",
+                "guest_download_instructions_skill_conflict_deferral_count_17_plus",
+            ],
+        );
+        assert_count_actions(
+            CountMetric::ExactPathConflictDeferral,
+            [
+                "guest_download_exact_path_conflict_deferral_count_0",
+                "guest_download_exact_path_conflict_deferral_count_1",
+                "guest_download_exact_path_conflict_deferral_count_2",
+                "guest_download_exact_path_conflict_deferral_count_3_4",
+                "guest_download_exact_path_conflict_deferral_count_5_8",
+                "guest_download_exact_path_conflict_deferral_count_9_16",
+                "guest_download_exact_path_conflict_deferral_count_17_plus",
+            ],
+        );
+        assert_count_actions(
+            CountMetric::OtherParentChildConflictDeferral,
+            [
+                "guest_download_other_parent_child_conflict_deferral_count_0",
+                "guest_download_other_parent_child_conflict_deferral_count_1",
+                "guest_download_other_parent_child_conflict_deferral_count_2",
+                "guest_download_other_parent_child_conflict_deferral_count_3_4",
+                "guest_download_other_parent_child_conflict_deferral_count_5_8",
+                "guest_download_other_parent_child_conflict_deferral_count_9_16",
+                "guest_download_other_parent_child_conflict_deferral_count_17_plus",
+            ],
+        );
+    }
+
+    #[test]
+    fn presence_and_archive_phase_actions_are_stable() {
+        assert_eq!(
+            framework_home_instructions_action(false),
+            "guest_download_framework_home_instructions_task_absent"
+        );
+        assert_eq!(
+            framework_home_instructions_action(true),
+            "guest_download_framework_home_instructions_task_present"
+        );
+        assert_eq!(
+            archive_action(ArchiveKind::Storage, ArchiveMetric::Total),
+            "storage_download"
+        );
+        assert_eq!(
+            archive_action(ArchiveKind::Artifact, ArchiveMetric::Total),
+            "artifact_download"
+        );
+        assert_eq!(
+            archive_action(
+                ArchiveKind::Storage,
+                ArchiveMetric::RequestToResponseHeaders
+            ),
+            "storage_download_remote_request_to_response_headers"
+        );
+        assert_eq!(
+            archive_action(
+                ArchiveKind::Artifact,
+                ArchiveMetric::RequestToResponseHeaders
+            ),
+            "artifact_download_remote_request_to_response_headers"
+        );
+        assert_eq!(
+            archive_action(ArchiveKind::Storage, ArchiveMetric::BodyRead),
+            "storage_download_remote_body_read"
+        );
+        assert_eq!(
+            archive_action(ArchiveKind::Artifact, ArchiveMetric::BodyRead),
+            "artifact_download_remote_body_read"
+        );
+        assert_eq!(
+            archive_action(ArchiveKind::Storage, ArchiveMetric::ExtractOutsideBodyRead),
+            "storage_download_remote_extract_outside_body_read"
+        );
+        assert_eq!(
+            archive_action(ArchiveKind::Artifact, ArchiveMetric::ExtractOutsideBodyRead),
+            "artifact_download_remote_extract_outside_body_read"
+        );
+    }
+
+    #[test]
+    fn compressed_byte_bucket_boundaries_are_stable() {
+        assert_eq!(
+            [
+                0, 1, 65_535, 65_536, 262_143, 262_144, 1_048_575, 1_048_576, 4_194_303, 4_194_304,
+                16_777_215, 16_777_216, 67_108_863, 67_108_864,
+            ]
+            .map(CompressedBytesBucket::from_bytes),
+            [
+                CompressedBytesBucket::Zero,
+                CompressedBytesBucket::Under64Kib,
+                CompressedBytesBucket::Under64Kib,
+                CompressedBytesBucket::Kib64To256,
+                CompressedBytesBucket::Kib64To256,
+                CompressedBytesBucket::Kib256To1Mib,
+                CompressedBytesBucket::Kib256To1Mib,
+                CompressedBytesBucket::Mib1To4,
+                CompressedBytesBucket::Mib1To4,
+                CompressedBytesBucket::Mib4To16,
+                CompressedBytesBucket::Mib4To16,
+                CompressedBytesBucket::Mib16To64,
+                CompressedBytesBucket::Mib16To64,
+                CompressedBytesBucket::Mib64Plus,
+            ]
+        );
+    }
+
+    #[test]
+    fn compressed_byte_actions_are_stable() {
+        let buckets = [
+            CompressedBytesBucket::Zero,
+            CompressedBytesBucket::Under64Kib,
+            CompressedBytesBucket::Kib64To256,
+            CompressedBytesBucket::Kib256To1Mib,
+            CompressedBytesBucket::Mib1To4,
+            CompressedBytesBucket::Mib4To16,
+            CompressedBytesBucket::Mib16To64,
+            CompressedBytesBucket::Mib64Plus,
+        ];
+        assert_eq!(
+            buckets.map(|bucket| archive_action(
+                ArchiveKind::Storage,
+                ArchiveMetric::CompressedBytes(bucket)
+            )),
+            [
+                "storage_download_remote_compressed_bytes_consumed_zero",
+                "storage_download_remote_compressed_bytes_consumed_lt_64_kib",
+                "storage_download_remote_compressed_bytes_consumed_64_kib_to_256_kib",
+                "storage_download_remote_compressed_bytes_consumed_256_kib_to_1_mib",
+                "storage_download_remote_compressed_bytes_consumed_1_mib_to_4_mib",
+                "storage_download_remote_compressed_bytes_consumed_4_mib_to_16_mib",
+                "storage_download_remote_compressed_bytes_consumed_16_mib_to_64_mib",
+                "storage_download_remote_compressed_bytes_consumed_64_mib_plus",
+            ]
+        );
+        assert_eq!(
+            buckets.map(|bucket| archive_action(
+                ArchiveKind::Artifact,
+                ArchiveMetric::CompressedBytes(bucket)
+            )),
+            [
+                "artifact_download_remote_compressed_bytes_consumed_zero",
+                "artifact_download_remote_compressed_bytes_consumed_lt_64_kib",
+                "artifact_download_remote_compressed_bytes_consumed_64_kib_to_256_kib",
+                "artifact_download_remote_compressed_bytes_consumed_256_kib_to_1_mib",
+                "artifact_download_remote_compressed_bytes_consumed_1_mib_to_4_mib",
+                "artifact_download_remote_compressed_bytes_consumed_4_mib_to_16_mib",
+                "artifact_download_remote_compressed_bytes_consumed_16_mib_to_64_mib",
+                "artifact_download_remote_compressed_bytes_consumed_64_mib_plus",
+            ]
+        );
+    }
+
+    #[test]
+    fn attempt_actions_are_stable() {
+        assert_eq!(
+            [0, 1, 2, 3, 4].map(AttemptCountBucket::from_attempts),
+            [
+                AttemptCountBucket::Three,
+                AttemptCountBucket::One,
+                AttemptCountBucket::Two,
+                AttemptCountBucket::Three,
+                AttemptCountBucket::Three,
+            ]
+        );
+        let buckets = [
+            AttemptCountBucket::One,
+            AttemptCountBucket::Two,
+            AttemptCountBucket::Three,
+        ];
+        assert_eq!(
+            buckets.map(|bucket| archive_action(
+                ArchiveKind::Storage,
+                ArchiveMetric::AttemptCount(bucket)
+            )),
+            [
+                "storage_download_remote_attempt_count_1",
+                "storage_download_remote_attempt_count_2",
+                "storage_download_remote_attempt_count_3",
+            ]
+        );
+        assert_eq!(
+            buckets.map(|bucket| archive_action(
+                ArchiveKind::Artifact,
+                ArchiveMetric::AttemptCount(bucket)
+            )),
+            [
+                "artifact_download_remote_attempt_count_1",
+                "artifact_download_remote_attempt_count_2",
+                "artifact_download_remote_attempt_count_3",
+            ]
+        );
+    }
+
+    #[test]
+    fn complete_action_schema_contains_95_unique_strings() {
+        let mut actions = HashSet::new();
+        for metric in COUNT_METRICS {
+            actions.extend(metric.actions());
+        }
+        actions.insert(framework_home_instructions_action(false));
+        actions.insert(framework_home_instructions_action(true));
+        for kind in ARCHIVE_KINDS {
+            actions.insert(archive_action(kind, ArchiveMetric::Total));
+            actions.insert(archive_action(
+                kind,
+                ArchiveMetric::RequestToResponseHeaders,
+            ));
+            actions.insert(archive_action(kind, ArchiveMetric::BodyRead));
+            actions.insert(archive_action(kind, ArchiveMetric::ExtractOutsideBodyRead));
+            for bucket in [
+                CompressedBytesBucket::Zero,
+                CompressedBytesBucket::Under64Kib,
+                CompressedBytesBucket::Kib64To256,
+                CompressedBytesBucket::Kib256To1Mib,
+                CompressedBytesBucket::Mib1To4,
+                CompressedBytesBucket::Mib4To16,
+                CompressedBytesBucket::Mib16To64,
+                CompressedBytesBucket::Mib64Plus,
+            ] {
+                actions.insert(archive_action(kind, ArchiveMetric::CompressedBytes(bucket)));
+            }
+            for bucket in [
+                AttemptCountBucket::One,
+                AttemptCountBucket::Two,
+                AttemptCountBucket::Three,
+            ] {
+                actions.insert(archive_action(kind, ArchiveMetric::AttemptCount(bucket)));
+            }
+        }
+
+        assert_eq!(actions.len(), 95);
+    }
+}

--- a/crates/guest-download/tests/integration/binary_logging/attribution.rs
+++ b/crates/guest-download/tests/integration/binary_logging/attribution.rs
@@ -16,6 +16,14 @@ fn operation<'a>(ops: &'a [Value], action: &str) -> Option<&'a Value> {
     ops.iter().find(|entry| entry["action_type"] == action)
 }
 
+fn action_precedes(actions: &[String], earlier: &str, later: &str) -> bool {
+    let earlier_index = actions.iter().position(|action| action == earlier);
+    let later_index = actions.iter().position(|action| action == later);
+    earlier_index
+        .zip(later_index)
+        .is_some_and(|(earlier_index, later_index)| earlier_index < later_index)
+}
+
 fn deterministic_bytes(len: usize) -> Vec<u8> {
     let mut state = 0x1234_5678_u32;
     (0..len)
@@ -116,6 +124,42 @@ fn binary_records_download_scheduler_attribution() {
             "artifact_download",
             "download_total",
         ],
+    );
+    assert!(
+        action_precedes(&actions, "guest_download_task_count_2", "storage_download"),
+        "expected batch attribution before task attribution in {actions:?}"
+    );
+    assert!(
+        action_precedes(
+            &actions,
+            "storage_download",
+            "storage_download_remote_request_to_response_headers"
+        ),
+        "expected task total before remote attribution in {actions:?}"
+    );
+    assert!(
+        action_precedes(
+            &actions,
+            "storage_download_remote_attempt_count_1",
+            "guest_download_mount_conflict_deferral_count_1"
+        ),
+        "expected remote attribution before conflict totals in {actions:?}"
+    );
+    assert!(
+        action_precedes(
+            &actions,
+            "artifact_download",
+            "guest_download_mount_conflict_deferral_count_1"
+        ),
+        "expected task attribution before conflict totals in {actions:?}"
+    );
+    assert!(
+        action_precedes(
+            &actions,
+            "guest_download_mount_conflict_deferral_count_1",
+            "download_total"
+        ),
+        "expected conflict totals before run total in {actions:?}"
     );
     assert!(
         !actions
@@ -251,6 +295,15 @@ fn binary_records_remote_artifact_attribution_and_compressed_byte_bucket() {
             "artifact_download_remote_attempt_count_1",
         ],
     );
+    for remote_action in actions
+        .iter()
+        .filter(|action| action.starts_with(ARTIFACT_REMOTE_PREFIX))
+    {
+        assert!(
+            action_precedes(&actions, "artifact_download", remote_action),
+            "expected artifact total before {remote_action} in {actions:?}"
+        );
+    }
     assert!(
         !actions
             .iter()


### PR DESCRIPTION
## Summary

- move guest-download classification, aggregation, action mapping, and emission into a crate-private telemetry module
- keep scheduler selection and active state limited to opaque task identity and normalized mount paths
- centralize the nine fixed-cardinality count families behind one typed metric-to-action mapping
- precompute normalized mount paths and let the concrete run recorder observe conflicts without changing scheduling policy

## Behavior

- preserve the four-slot non-FIFO scheduler, path-overlap serialization, retry and extraction flow, and panic handling
- preserve conflict observation semantics, including repeated scans and first-active-blocker classification
- preserve all 95 action names, bucket boundaries, emission points and order, timing sources, success flags, and error payload behavior
- add compiled-binary assertions for batch, task, remote, conflict-total, and run-total emission ordering

No API, protocol, manifest, database schema, dependency, feature flag, or deployment configuration changes are included.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-download --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-download --all-features --no-deps`
- `cargo test -p guest-download --all-targets --all-features`
- source parity audit confirmed the same 95 unique static action strings before and after the refactor
- repository pre-commit hooks: Rust formatting, workspace documentation, workspace Clippy, and file-size checks

Closes #24272
