### PR TITLE
perf(api): cache completed result-method hint misses

### DIFF
--- a/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
@@ -470,6 +470,15 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
         db.select(emptyFields);
       `,
     },
+    {
+      code: `${drizzlePreamble}
+        type Callback = () => void;
+        type AliasedCallback = Callback;
+        declare const callback: AliasedCallback;
+        callback();
+        callback();
+      `,
+    },
   ],
   invalid: [
     {

--- a/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
@@ -365,7 +365,10 @@ export const requireSqlResultMapping = createRule({
     const services = ESLintUtils.getParserServices(context);
     const checker = services.program.getTypeChecker();
     const resultMethodNameByType = new Map<Type, string | null>();
-    const resultMethodHintVariables = new Set<TSESLint.Scope.Variable>();
+    const resultMethodHintByVariable = new Map<
+      TSESLint.Scope.Variable,
+      boolean
+    >();
     const resultMethodHintVariablesInProgress =
       new Set<TSESLint.Scope.Variable>();
 
@@ -951,9 +954,7 @@ export const requireSqlResultMapping = createRule({
       let scope: TSESLint.Scope.Scope | null =
         context.sourceCode.getScope(node);
       while (scope !== null) {
-        const variable = scope.variables.find((candidate) => {
-          return candidate.name === name;
-        });
+        const variable = scope.set.get(name);
         if (variable !== undefined) {
           return variable;
         }
@@ -965,12 +966,15 @@ export const requireSqlResultMapping = createRule({
     function variableHasResultMethodHint(
       variable: TSESLint.Scope.Variable,
     ): boolean {
-      if (resultMethodHintVariables.has(variable)) {
-        return true;
+      const cachedResult = resultMethodHintByVariable.get(variable);
+      if (cachedResult !== undefined) {
+        return cachedResult;
       }
       if (resultMethodHintVariablesInProgress.has(variable)) {
         return false;
       }
+      const isOutermostAnalysis =
+        resultMethodHintVariablesInProgress.size === 0;
       resultMethodHintVariablesInProgress.add(variable);
 
       for (const definition of variable.defs) {
@@ -982,7 +986,7 @@ export const requireSqlResultMapping = createRule({
           continue;
         }
         if (hasResultMethodHint(context.sourceCode.getText(definition.node))) {
-          resultMethodHintVariables.add(variable);
+          resultMethodHintByVariable.set(variable, true);
           resultMethodHintVariablesInProgress.delete(variable);
           return true;
         }
@@ -995,13 +999,16 @@ export const requireSqlResultMapping = createRule({
             referencedVariable !== null &&
             variableHasResultMethodHint(referencedVariable)
           ) {
-            resultMethodHintVariables.add(variable);
+            resultMethodHintByVariable.set(variable, true);
             resultMethodHintVariablesInProgress.delete(variable);
             return true;
           }
         }
       }
       resultMethodHintVariablesInProgress.delete(variable);
+      if (isOutermostAnalysis) {
+        resultMethodHintByVariable.set(variable, false);
+      }
       return false;
     }
 


### PR DESCRIPTION
## Summary

- cache completed outermost negative result-method hint analyses while preserving the existing recursive lookup semantics
- retain positive caching at every depth and use the scope manager's indexed variable lookup
- cover repeated conventional type-alias misses through the public lint-rule behavior

## Performance

- measured five alternating baseline/candidate runs of the rule against the API lint workload
- candidate rule time was lower in all five pairs, with a median paired improvement of 6.01%
- median paired peak RSS changed by +0.63%, with no material memory regression
- end-to-end wall time was noisy on the shared development container and was not used as the acceptance signal

## Validation

- `pnpm exec prettier --check packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts`
- `git diff --check`
- `pnpm -F @vm0/eslint-rules exec vitest run src/api/__tests__/require-sql-result-mapping.test.ts`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F @vm0/eslint-rules test`
- `pnpm -F api lint`
- `pnpm knip --workspace @vm0/eslint-rules`

Closes #24275

Parent: #23047
