### PR TITLE
refactor(api): switch terminal event indexes

### DIFF
--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -52,6 +52,13 @@ briefly run against the migrated schema. Migrations must be backward-compatible
 with the currently deployed backend until that backend is no longer serving
 traffic.
 
+Migrations marked with `-- vm0:non-transactional` run one statement at a time
+outside a transaction. Successfully executed statements are not rolled back
+after a later failure, and the entire migration runs again on retry, so every
+statement must be idempotent under a full retry from the beginning. Migration
+`0778` demonstrates the required pattern with
+`DROP INDEX CONCURRENTLY IF EXISTS` followed by `CREATE INDEX CONCURRENTLY`.
+
 This is a traffic-promotion guarantee, not a guarantee that no deployment
 preparation has happened yet. Staged Vercel builds, runner rootfs/snapshot
 builds, host provisioning, and other non-serving preparation jobs may complete

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -20,6 +20,7 @@ import {
   type ChatEvent,
   type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { isChatRunTerminalEventType } from "@vm0/api-contracts/contracts/chat-events";
 import { zeroMailContract } from "@vm0/api-contracts/contracts/zero-mail";
 import {
   getModelProviderFirewall,
@@ -1265,6 +1266,14 @@ describe("CHAT-02: interrupting active chat runs", () => {
           message.eventType === "run.cancelled" &&
           message.runId === first.runId &&
           message.runLifecycleEvent === "cancelled"
+        );
+      }),
+    ).toHaveLength(1);
+    expect(
+      assistantMessages(messages.events).filter((message) => {
+        return (
+          message.runId === first.runId &&
+          isChatRunTerminalEventType(message.eventType)
         );
       }),
     ).toHaveLength(1);

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -14,6 +14,7 @@ import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { runOutputMaterializations } from "@vm0/db/schema/run-output-materialization";
 import {
+  chatEventTerminalPredicate,
   chatEvents,
   type ChatEventGenerationTemplate,
   type ChatEventRecommendedFollowups,
@@ -1427,7 +1428,10 @@ async function teamsRunLifecycleMarkerExists(
     .select({ id: chatEvents.id })
     .from(chatEvents)
     .where(
-      and(eq(chatEvents.runId, runId), isNotNull(chatEvents.runLifecycleEvent)),
+      and(
+        eq(chatEvents.runId, runId),
+        chatEventTerminalPredicate(chatEvents.eventType),
+      ),
     )
     .limit(1);
   return marker !== undefined;

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -9,6 +9,7 @@ import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import { chatAutomationContext } from "@vm0/db/schema/chat-automation-context";
 import { chatEventInputParams } from "@vm0/db/schema/chat-event-input-params";
 import {
+  chatEventTerminalPredicate,
   chatEvents,
   type ChatEventGoalSnapshot,
 } from "@vm0/db/schema/chat-event";
@@ -20,7 +21,7 @@ import { chatTeamsContext } from "@vm0/db/schema/chat-teams-context";
 import { chatTelegramContext } from "@vm0/db/schema/chat-telegram-context";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { chatEventAssetRefs } from "@vm0/db/schema/run-uploaded-file";
-import { eq, isNotNull, sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 import type { Db } from "../external/db";
 import { nowDate } from "../external/time";
@@ -741,7 +742,7 @@ export async function insertChatEvent(
           ? await query
               .onConflictDoNothing({
                 target: chatEvents.runId,
-                where: isNotNull(chatEvents.runLifecycleEvent),
+                where: chatEventTerminalPredicate(chatEvents.eventType),
               })
               .returning({
                 id: chatEvents.id,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread-read-state-query.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread-read-state-query.ts
@@ -1,9 +1,11 @@
-import { and, desc, eq } from "drizzle-orm";
-import { chatEvents } from "@vm0/db/schema/chat-event";
+import { and, desc, eq, sql } from "drizzle-orm";
+import {
+  chatEventTerminalPredicate,
+  chatEvents,
+} from "@vm0/db/schema/chat-event";
 import type { chatThreads } from "@vm0/db/schema/chat-thread";
 
 import type { Db } from "../external/db";
-import { chatEventTypeIn } from "./zero-chat-event-type.service";
 
 export function latestRunFinishEventSubquery(
   db: Pick<Db, "select">,
@@ -17,10 +19,10 @@ export function latestRunFinishEventSubquery(
     .where(
       and(
         eq(chatEvents.chatThreadId, threadId),
-        chatEventTypeIn(["run.completed", "run.failed", "run.cancelled"]),
+        chatEventTerminalPredicate(chatEvents.eventType),
       ),
     )
-    .orderBy(desc(chatEvents.createdAt), desc(chatEvents.id))
+    .orderBy(sql`${desc(chatEvents.createdAt)} NULLS LAST`, desc(chatEvents.id))
     .limit(1)
     .as("latest_run_finish_message");
 }

--- a/turbo/packages/db/scripts/test-migration-consistency-schema.ts
+++ b/turbo/packages/db/scripts/test-migration-consistency-schema.ts
@@ -12339,6 +12339,7 @@ async function validateChatEventTerminalIndexExpansion(): Promise<void> {
   const testDbUrl = createTestDbUrl(testDb);
   const composeId = "00000000-0000-4000-8000-000000077801";
   const threadId = "00000000-0000-4000-8000-000000077802";
+  const otherThreadId = "00000000-0000-4000-8000-000000077807";
   const completedRunId = "00000000-0000-4000-8000-000000077803";
   const failedRunId = "00000000-0000-4000-8000-000000077804";
   const cancelledRunId = "00000000-0000-4000-8000-000000077805";
@@ -12397,9 +12398,14 @@ async function validateChatEventTerminalIndexExpansion(): Promise<void> {
             'terminal-index-test-user',
             $2,
             'terminal index test'
+          ), (
+            $3,
+            'terminal-index-test-user',
+            $2,
+            'terminal index plan selectivity test'
           )
         `,
-        [threadId, composeId],
+        [threadId, composeId, otherThreadId],
       );
       await client.query(
         `
@@ -12429,6 +12435,46 @@ async function validateChatEventTerminalIndexExpansion(): Promise<void> {
           cancelledRunId,
           queuedRunId,
         ],
+      );
+      await client.query(
+        `
+          INSERT INTO "chat_events" (
+            "chat_thread_id",
+            "event_type",
+            "seq_id",
+            "created_at"
+          )
+          SELECT
+            $1,
+            'run.queued',
+            4 + "generated"."offset",
+            TIMESTAMP '2026-07-31 00:00:03'
+              + "generated"."offset" * INTERVAL '1 second'
+          FROM generate_series(1, 500) AS "generated"("offset")
+        `,
+        [threadId],
+      );
+      await client.query(
+        `
+          INSERT INTO "chat_events" (
+            "chat_thread_id",
+            "run_id",
+            "event_type",
+            "run_lifecycle_event",
+            "seq_id",
+            "created_at"
+          )
+          SELECT
+            $1,
+            gen_random_uuid(),
+            'run.completed',
+            'completed',
+            "generated"."offset",
+            TIMESTAMP '2026-07-31 00:00:00'
+              + "generated"."offset" * INTERVAL '1 second'
+          FROM generate_series(1, 500) AS "generated"("offset")
+        `,
+        [otherThreadId],
       );
 
       const terminalRowsBefore = await client.query<{
@@ -12544,6 +12590,38 @@ async function validateChatEventTerminalIndexExpansion(): Promise<void> {
         }
       }
 
+      await client.query(`ANALYZE "chat_events"`);
+      await client.query(`SET enable_seqscan = off`);
+      const terminalReadPlan = await client.query<{ "QUERY PLAN": string }>(
+        `
+          EXPLAIN (COSTS OFF)
+          SELECT "created_at"
+          FROM "chat_events"
+          WHERE "chat_thread_id" = $1
+            AND "event_type" IN (
+              'run.completed',
+              'run.failed',
+              'run.cancelled'
+            )
+          ORDER BY "created_at" DESC NULLS LAST, "id" DESC
+          LIMIT 1
+        `,
+        [threadId],
+      );
+      const terminalReadPlanText = terminalReadPlan.rows
+        .map((row) => {
+          return row["QUERY PLAN"];
+        })
+        .join("\n");
+      assert.match(
+        terminalReadPlanText,
+        /\bidx_chat_events_thread_run_terminal_created\b/u,
+      );
+      assert.doesNotMatch(
+        terminalReadPlanText,
+        /\bidx_chat_events_thread_run_finish_created\b/u,
+      );
+
       const terminalRowDifference = await client.query<{ id: string }>(`
         (
           SELECT "id"
@@ -12651,6 +12729,7 @@ async function validateChatEventTerminalIndexExpansion(): Promise<void> {
       console.log(
         "   ✅ Both valid unique indexes independently arbitrate duplicate terminal events",
       );
+      console.log("   ✅ Terminal ordering uses the event_type partial index");
       console.log(
         "   ✅ Concurrent retry-safe builds preserve the old index pair\n",
       );

--- a/turbo/packages/db/src/schema/chat-event.ts
+++ b/turbo/packages/db/src/schema/chat-event.ts
@@ -1,4 +1,4 @@
-import { sql } from "drizzle-orm";
+import { sql, type SQL, type SQLWrapper } from "drizzle-orm";
 import type { ChatEventType } from "@vm0/api-contracts/contracts/chat-events";
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import {
@@ -44,6 +44,14 @@ export type {
   ChatEventWebsiteGenerationTemplate,
   ChatEventWorkflowGenerationTemplate,
 } from "@vm0/db/jsonb-contracts/chat-event";
+
+/**
+ * Shared literal predicate for partial-index selection and ON CONFLICT
+ * inference. Keep the values inline rather than parameterizing this condition.
+ */
+export function chatEventTerminalPredicate(eventType: SQLWrapper): SQL {
+  return sql`${eventType} IN ('run.completed', 'run.failed', 'run.cancelled')`;
+}
 
 /**
  * Physical storage for the immutable ChatEvent stream.
@@ -148,9 +156,7 @@ export const chatEvents = pgTable(
         .where(sql`${table.runLifecycleEvent} IS NOT NULL`),
       index("idx_chat_events_thread_run_terminal_created")
         .on(table.chatThreadId, table.createdAt.desc())
-        .where(
-          sql`${table.eventType} IN ('run.completed', 'run.failed', 'run.cancelled')`,
-        ),
+        .where(chatEventTerminalPredicate(table.eventType)),
       index("idx_chat_events_run_id").on(table.runId),
       index("chat_events_usage_run_id_idx")
         .on(table.runId)
@@ -185,9 +191,7 @@ export const chatEvents = pgTable(
         .where(sql`${table.runLifecycleEvent} IS NOT NULL`),
       uniqueIndex("chat_events_run_terminal_unique")
         .on(table.runId)
-        .where(
-          sql`${table.eventType} IN ('run.completed', 'run.failed', 'run.cancelled')`,
-        ),
+        .where(chatEventTerminalPredicate(table.eventType)),
       uniqueIndex("chat_events_run_thinking_unique")
         .on(table.runId)
         .where(sql`${table.thinking} IS NOT NULL`),


### PR DESCRIPTION
## Summary

- implement Release 2 of the four-step terminal-event rollout in #24215 by switching the targeted run-lifecycle `ON CONFLICT` clause and terminal read consumers to the `event_type` predicate introduced in Release 1
- make terminal ordering explicitly use `created_at DESC NULLS LAST`, matching `idx_chat_events_thread_run_terminal_created` without changing behavior because `created_at` is non-null
- keep writing `run_lifecycle_event`, retain both legacy indexes and the column, and leave the `runLifecycleEvent` wire contract unchanged for mixed-version safety
- document the retry/idempotency constraint for `-- vm0:non-transactional` migrations, using `0778` as the example

## Predicate and index inference

`chatEventTerminalPredicate()` emits the literal predicate `event_type IN ('run.completed', 'run.failed', 'run.cancelled')`. Both the Drizzle definition of `chat_events_run_terminal_unique` and the targeted `onConflictDoNothing` call use that same helper, so they cannot drift or become parameterized independently. This is textually equivalent to migration `0778`'s index predicate. The runtime BDD exercises the actual targeted conflict path without a PostgreSQL `42P10` inference error, while the PostgreSQL 17.10 populated-upgrade coverage verifies both new and legacy unique indexes independently arbitrate duplicate terminal rows.

The populated-upgrade coverage also uses `EXPLAIN` to prove the terminal ordering query selects `idx_chat_events_thread_run_terminal_created` rather than the legacy `idx_chat_events_thread_run_finish_created`.

## Rollout

This is step 2 of 4 in #24215 and contains no migration.

Release 1 gate was rechecked before implementation: migration `0778` shipped in `db-v1.158.4` and `api-v1.359.1` at 2026-07-31 06:02 UTC. Zero's production verification confirmed both concurrent indexes built with no `23505`, lock incident, blocked chat writes, or first-run non-transactional migration error.

Release 3 must not stop writing `run_lifecycle_event` until this release is fully rolled out and every rollback target that still uses the legacy predicate has drained.

## Validation

- `pnpm exec prettier --check` for all changed files
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/db lint`
- `pnpm -F @vm0/db check-types`
- targeted Vitest: 3 files / 3 tests passed for duplicate terminal arbitration, event-type terminal reads, and Teams callback terminal detection
- PostgreSQL 17.10 `pnpm -F @vm0/db test:migration-consistency`: all 783 migrations/snapshots, populated old/new index coexistence, independent arbitration, new terminal ordering plan, and fresh schema regeneration passed

The full Vitest suite is intentionally left to the PR pipeline.

## Post-release verification

- no new `23505` errors from terminal-event writes
- no duplicate terminal events for any run
- no `ON CONFLICT` inference failures (`42P10` / `no unique or exclusion constraint matching the ON CONFLICT specification`)
- terminal ordering continues using the new partial index

Refs #24215