### PR TITLE
perf(api): stop blocked stale-session preparation retries

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -141,6 +141,9 @@ const API_DISPATCH_THREAD_SESSION_BINDING_ACTION_TYPES = [
   "api_dispatch_validate_thread_session_snapshot_thread",
   "api_dispatch_update_thread_session_binding",
 ] as const;
+const API_DISPATCH_QUEUE_FIRST_ADMISSION_ACTION_TYPES = [
+  "api_dispatch_resolve_queue_first_admission",
+] as const;
 const API_DISPATCH_REUSED_THREAD_READ_ACTION_TYPES = [
   "api_dispatch_queue_first_thread_lock_wait",
   "api_dispatch_load_thread_session_binding",
@@ -1003,6 +1006,7 @@ describe("CHAT-02: web chat send and client ids", () => {
       [
         "api_dispatch_admission_lock_held",
         "api_dispatch_claim_queue_first_message",
+        ...API_DISPATCH_QUEUE_FIRST_ADMISSION_ACTION_TYPES,
       ],
       "nested",
     );
@@ -1685,6 +1689,11 @@ describe("CHAT-02: org queue markers", () => {
       API_DISPATCH_QUEUED_PERSISTENCE_ACTION_TYPES,
       "nested",
     );
+    expect(
+      queuedTimingEvents.filter((event) => {
+        return event.op_type === "api_dispatch_resolve_queue_first_admission";
+      }),
+    ).toHaveLength(1);
 
     const queuedThread = queuedRun.body.threadId;
     const beforeDequeue = await waitForThreadMessages(
@@ -3383,6 +3392,196 @@ describe("CHAT-02: run-level model overrides", () => {
     await cancelChatRun(primary.actor, primarySecond.runId);
   }, 90_000);
 
+  it("does not repeat preparation after a competing run changes the binding", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor for binding admission");
+    }
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const established = await sendChatRun(actor, {
+      agentId,
+      prompt: "establish the binding before competing sends",
+    });
+    const establishedClaim = await claimChatRun(runnerGroup, established.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(established.runId, establishedClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
+
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: actor.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+
+    const firstEventId = randomUUID();
+    const secondEventId = randomUUID();
+    const requests = [
+      {
+        eventId: firstEventId,
+        prompt: "first competing binding send",
+        response: chat.requestSendEvent(
+          actor,
+          {
+            agentId,
+            threadId: established.threadId,
+            prompt: "first competing binding send",
+            clientEventId: firstEventId,
+          },
+          [201],
+        ),
+      },
+      {
+        eventId: secondEventId,
+        prompt: "second competing binding send",
+        response: chat.requestSendEvent(
+          actor,
+          {
+            agentId,
+            threadId: established.threadId,
+            prompt: "second competing binding send",
+            clientEventId: secondEventId,
+          },
+          [201],
+        ),
+      },
+    ] as const;
+
+    await expect
+      .poll(async () => {
+        const messages = await chat.listThreadEvents(
+          actor,
+          established.threadId,
+        );
+        return requests.every(({ eventId }) => {
+          return messages.events.some((event) => {
+            return event.id === eventId;
+          });
+        });
+      })
+      .toBe(true);
+    await expect.poll(admissionLock.waiterCount).toBe(2);
+
+    admissionLock.release();
+    const responses = await Promise.all(
+      requests.map(({ response }) => {
+        return response;
+      }),
+    );
+    await admissionLock.done;
+
+    const winners = responses.flatMap((response, index) => {
+      if (response.status !== 201 || response.body.runId === null) {
+        return [];
+      }
+      return [
+        {
+          eventId: requests[index]!.eventId,
+          runId: response.body.runId,
+        },
+      ];
+    });
+    expect(winners).toHaveLength(1);
+    const winner = winners[0];
+    if (!winner) {
+      throw new Error("Expected one competing send to create a run");
+    }
+    const loser = requests.find(({ eventId }) => {
+      return eventId !== winner.eventId;
+    });
+    if (!loser) {
+      throw new Error("Expected one competing send to lose admission");
+    }
+    expect(
+      responses.filter((response) => {
+        return response.status === 201 && response.body.runId === null;
+      }),
+    ).toHaveLength(1);
+
+    const messages = await chat.listThreadEvents(actor, established.threadId);
+    expect(
+      userMessages(messages.events).filter((message) => {
+        return (
+          message.revokesEventId === winner.eventId &&
+          message.runId === winner.runId
+        );
+      }),
+    ).toHaveLength(1);
+    expect(
+      userMessages(messages.events).filter((message) => {
+        return (
+          message.revokesEventId === loser.eventId &&
+          message.runId !== undefined
+        );
+      }),
+    ).toHaveLength(0);
+    const queuedLoser = userMessages(messages.events).find((message) => {
+      return message.id === loser.eventId;
+    });
+    if (!queuedLoser) {
+      throw new Error("Expected the losing message to remain queued");
+    }
+    expect(queuedLoser.runId).toBeUndefined();
+    expect(chatEventDisplayText(queuedLoser)).toBe(loser.prompt);
+    await expect(
+      readThreadSessionBinding(context, established.threadId),
+    ).resolves.toMatchObject({
+      agent_session_run_id: winner.runId,
+    });
+
+    const staleBlockedAdmission = sandboxOperationEvents().find((event) => {
+      return (
+        event.op_type === "api_dispatch_resolve_queue_first_admission" &&
+        event.queue_first_admission_result === "blocked" &&
+        event.thread_session_snapshot_state === "binding_changed" &&
+        event.queue_first_launch_outcome === "claim_lost"
+      );
+    });
+    expect(staleBlockedAdmission).toBeDefined();
+    const discardedRunId = staleBlockedAdmission?.run_id;
+    if (typeof discardedRunId !== "string") {
+      throw new Error("Expected blocked admission timing to identify its run");
+    }
+    const lostTimingEvents = apiDispatchTimingEventsForRun(discardedRunId);
+    for (const actionType of [
+      "api_dispatch_prepare_run_context",
+      "api_dispatch_build_runner_job_payload",
+      "api_dispatch_insert_run_with_concurrency",
+      "api_dispatch_admission_lock_wait",
+      "api_dispatch_resolve_queue_first_admission",
+      "api_dispatch_claim_queue_first_message",
+    ]) {
+      expect(
+        lostTimingEvents.filter((event) => {
+          return event.op_type === actionType;
+        }),
+      ).toHaveLength(1);
+    }
+    expect(
+      sandboxOperationEvents().filter((event) => {
+        return (
+          event.op_type === "chat_thread_session_binding_retry" &&
+          event.chat_thread_id === established.threadId
+        );
+      }),
+    ).toHaveLength(0);
+
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: established.threadId,
+        revokesEventId: loser.eventId,
+        clientEventId: randomUUID(),
+      },
+      [201],
+    );
+    await cancelChatRun(actor, winner.runId);
+  }, 90_000);
+
   it("retries preparation when the canonical binding changes", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     if (!actor.orgId) {
@@ -3465,6 +3664,26 @@ describe("CHAT-02: run-level model overrides", () => {
         retry_reason: "binding_changed",
       }),
     );
+    const retryTimingEvents = apiDispatchTimingEventsForRun(second.runId);
+    for (const actionType of [
+      "api_dispatch_prepare_run_context",
+      "api_dispatch_build_runner_job_payload",
+      "api_dispatch_insert_run_with_concurrency",
+      "api_dispatch_resolve_queue_first_admission",
+    ]) {
+      expect(
+        retryTimingEvents.filter((event) => {
+          return event.op_type === actionType;
+        }),
+      ).toHaveLength(2);
+    }
+    expect(retryTimingEvents).toContainEqual(
+      expect.objectContaining({
+        op_type: "api_dispatch_resolve_queue_first_admission",
+        queue_first_admission_result: "idle",
+        thread_session_snapshot_state: "binding_changed",
+      }),
+    );
     const secondBinding = await readThreadSessionBinding(
       context,
       first.threadId,
@@ -3536,6 +3755,26 @@ describe("CHAT-02: run-level model overrides", () => {
         binding_action: "retried",
         resolution_action: "reused",
         retry_reason: "session_changed",
+      }),
+    );
+    const retryTimingEvents = apiDispatchTimingEventsForRun(second.runId);
+    for (const actionType of [
+      "api_dispatch_prepare_run_context",
+      "api_dispatch_build_runner_job_payload",
+      "api_dispatch_insert_run_with_concurrency",
+      "api_dispatch_resolve_queue_first_admission",
+    ]) {
+      expect(
+        retryTimingEvents.filter((event) => {
+          return event.op_type === actionType;
+        }),
+      ).toHaveLength(2);
+    }
+    expect(retryTimingEvents).toContainEqual(
+      expect.objectContaining({
+        op_type: "api_dispatch_resolve_queue_first_admission",
+        queue_first_admission_result: "idle",
+        thread_session_snapshot_state: "session_changed",
       }),
     );
     const secondBinding = await readThreadSessionBinding(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -217,8 +217,11 @@ import {
   claimQueueFirstRunAssociation,
   recordQueueFirstClaimedRun,
   recordQueueFirstFailedRun,
+  resolveQueueFirstRunAdmission,
+  type QueueFirstRunAdmission,
   type QueueFirstRunAssociation,
   type QueueFirstRunClaimResult,
+  type QueueFirstRunSessionSnapshotState,
 } from "./zero-chat-queued-event.service";
 import { recordFirstAssistantEventEligibility } from "./zero-chat-first-assistant-event-metric.service";
 import {
@@ -5835,13 +5838,13 @@ async function checkRunConcurrencyPreflight(args: {
   });
 }
 
-async function claimQueueFirstAssociationForLaunch(args: {
+async function resolveQueueFirstAdmissionForLaunch(args: {
   readonly tx: DbTransaction;
   readonly createArgs: CreateAgentRunArgs;
-  readonly identity: LaunchRunIdentity;
+  readonly sessionSnapshotState: QueueFirstRunSessionSnapshotState;
+  readonly threadAlreadyLocked?: true;
   readonly timing: ApiDispatchTimingCollector;
-  readonly validatedThreadSession: ValidatedThreadSessionSnapshot | undefined;
-}): Promise<QueueFirstRunClaimResult | undefined> {
+}): Promise<QueueFirstRunAdmission | undefined> {
   const association = args.createArgs.queueFirstAssociation;
   if (!association) {
     return undefined;
@@ -5849,14 +5852,34 @@ async function claimQueueFirstAssociationForLaunch(args: {
   if (association.threadId !== args.createArgs.chatThreadId) {
     throw new Error("Queue-first association must match the run chat thread");
   }
+  return await resolveQueueFirstRunAdmission(args.tx, {
+    apiStartTime: args.createArgs.apiStartTime,
+    sessionSnapshotState: args.sessionSnapshotState,
+    threadId: association.threadId,
+    timing: args.timing,
+    ...(args.threadAlreadyLocked ? { threadAlreadyLocked: true } : {}),
+  });
+}
+
+async function claimQueueFirstAssociationForLaunch(args: {
+  readonly tx: DbTransaction;
+  readonly admission: QueueFirstRunAdmission | undefined;
+  readonly createArgs: CreateAgentRunArgs;
+  readonly identity: LaunchRunIdentity;
+  readonly timing: ApiDispatchTimingCollector;
+}): Promise<QueueFirstRunClaimResult | undefined> {
+  const association = args.createArgs.queueFirstAssociation;
+  if (!association) {
+    return undefined;
+  }
+  if (!args.admission) {
+    throw new Error("Queue-first claim requires resolved thread admission");
+  }
   return await claimQueueFirstRunAssociation(args.tx, {
     ...association,
-    apiStartTime: args.createArgs.apiStartTime,
+    admission: args.admission,
     runId: args.identity.runId,
     timing: args.timing,
-    ...(args.validatedThreadSession?.chatThreadId === association.threadId
-      ? { threadAlreadyLocked: true }
-      : {}),
   });
 }
 
@@ -5872,12 +5895,18 @@ async function commitFailedLaunch(args: {
   const message = runFailureMessage(args.error);
   const committed = await args.db.transaction(
     async (tx): Promise<FailedLaunchCommitResult> => {
+      const queueFirstAdmission = await resolveQueueFirstAdmissionForLaunch({
+        tx,
+        createArgs: args.createArgs,
+        sessionSnapshotState: "unvalidated",
+        timing: args.timing,
+      });
       const queueFirstClaim = await claimQueueFirstAssociationForLaunch({
         tx,
+        admission: queueFirstAdmission,
         createArgs: args.createArgs,
         identity: args.identity,
         timing: args.timing,
-        validatedThreadSession: undefined,
       });
       if (queueFirstClaim?.kind === "lost") {
         return { kind: "queue-first-claim-lost" };
@@ -6332,7 +6361,27 @@ async function commitPreparedLaunchUnderLock(
     timing: args.timing,
   });
   if (threadSessionValidation?.kind === "thread-session-snapshot-stale") {
-    return threadSessionValidation;
+    const queueFirstAdmission = await resolveQueueFirstAdmissionForLaunch({
+      tx,
+      createArgs: args.createArgs,
+      sessionSnapshotState: threadSessionValidation.reason,
+      threadAlreadyLocked: true,
+      timing: args.timing,
+    });
+    if (!queueFirstAdmission || queueFirstAdmission.kind === "idle") {
+      return threadSessionValidation;
+    }
+    const queueFirstClaim = await claimQueueFirstAssociationForLaunch({
+      tx,
+      admission: queueFirstAdmission,
+      createArgs: args.createArgs,
+      identity: args.identity,
+      timing: args.timing,
+    });
+    if (queueFirstClaim?.kind !== "lost") {
+      throw new Error("Blocked queue-first admission must lose its claim");
+    }
+    return { kind: "queue-first-claim-lost" };
   }
   const validatedThreadSession = threadSessionValidation;
   const concurrency = await args.timing.measure(
@@ -6350,12 +6399,19 @@ async function commitPreparedLaunchUnderLock(
     if (!args.encryptedQueuedParams) {
       return { kind: "queue-payload-required" };
     }
+    const queueFirstAdmission = await resolveQueueFirstAdmissionForLaunch({
+      tx,
+      createArgs: args.createArgs,
+      sessionSnapshotState: validatedThreadSession ? "current" : "unvalidated",
+      ...(validatedThreadSession ? { threadAlreadyLocked: true } : {}),
+      timing: args.timing,
+    });
     const queueFirstClaim = await claimQueueFirstAssociationForLaunch({
       tx,
+      admission: queueFirstAdmission,
       createArgs: args.createArgs,
       identity: args.identity,
       timing: args.timing,
-      validatedThreadSession,
     });
     if (queueFirstClaim?.kind === "lost") {
       return { kind: "queue-first-claim-lost" };
@@ -6369,12 +6425,19 @@ async function commitPreparedLaunchUnderLock(
     );
   }
 
+  const queueFirstAdmission = await resolveQueueFirstAdmissionForLaunch({
+    tx,
+    createArgs: args.createArgs,
+    sessionSnapshotState: validatedThreadSession ? "current" : "unvalidated",
+    ...(validatedThreadSession ? { threadAlreadyLocked: true } : {}),
+    timing: args.timing,
+  });
   const queueFirstClaim = await claimQueueFirstAssociationForLaunch({
     tx,
+    admission: queueFirstAdmission,
     createArgs: args.createArgs,
     identity: args.identity,
     timing: args.timing,
-    validatedThreadSession,
   });
   if (queueFirstClaim?.kind === "lost") {
     return { kind: "queue-first-claim-lost" };

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -135,6 +135,7 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_check_concurrency_limit"
   | "api_dispatch_concurrency_preflight_lock_wait"
   | "api_dispatch_concurrency_preflight_check"
+  | "api_dispatch_resolve_queue_first_admission"
   | "api_dispatch_claim_queue_first_message"
   | "api_dispatch_queue_first_thread_lock_wait"
   | "api_dispatch_insert_run_record"

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -175,6 +175,16 @@ export type QueueFirstRunClaimResult =
     }
   | { readonly kind: "lost" };
 
+export type QueueFirstRunAdmission =
+  | { readonly kind: "blocked" }
+  | { readonly kind: "idle" };
+
+export type QueueFirstRunSessionSnapshotState =
+  | "binding_changed"
+  | "current"
+  | "session_changed"
+  | "unvalidated";
+
 /**
  * Establish the thread-first lock order shared by every event-backed queue
  * claim, rejection, and revocation.
@@ -430,11 +440,6 @@ async function claimGoalQueueFirstRunAssociation(
   return { kind: "claimed", createdAt: claimed.createdAt };
 }
 
-/**
- * Authoritatively arbitrate a queue-first launch inside its final persistence
- * transaction. Successful launches acquire the organization admission lock
- * first; failed launches do not acquire that lock or create active state.
- */
 function queueFirstRunAdmissionBlocked(
   db: DbTransaction,
   args: { readonly apiStartTime: number; readonly threadId: string },
@@ -445,18 +450,24 @@ function queueFirstRunAdmissionBlocked(
   });
 }
 
-export async function claimQueueFirstRunAssociation(
+/**
+ * Resolve the transaction-scoped thread admission consumed by queue claim.
+ * Successful launches hold the organization admission lock; failed launches
+ * preserve their existing thread-only arbitration.
+ */
+export async function resolveQueueFirstRunAdmission(
   db: DbTransaction,
-  args: QueueFirstRunAssociation & {
+  args: {
     readonly apiStartTime: number;
-    readonly runId: string;
-    readonly timing: ApiDispatchTimingCollector;
+    readonly sessionSnapshotState: QueueFirstRunSessionSnapshotState;
     readonly threadAlreadyLocked?: true;
+    readonly threadId: string;
+    readonly timing: ApiDispatchTimingCollector;
   },
-): Promise<QueueFirstRunClaimResult> {
-  let outcome: "claimed" | "lost" | "error" = "error";
+): Promise<QueueFirstRunAdmission> {
+  let outcome: QueueFirstRunAdmission["kind"] | undefined;
   return await args.timing.measure(
-    "api_dispatch_claim_queue_first_message",
+    "api_dispatch_resolve_queue_first_admission",
     "nested",
     async () => {
       const threadExists =
@@ -469,11 +480,41 @@ export async function claimQueueFirstRunAssociation(
           },
         ));
       if (!threadExists) {
-        outcome = "lost";
-        return { kind: "lost" };
+        outcome = "blocked";
+        return { kind: "blocked" };
       }
 
       if (await queueFirstRunAdmissionBlocked(db, args)) {
+        outcome = "blocked";
+        return { kind: "blocked" };
+      }
+
+      outcome = "idle";
+      return { kind: "idle" };
+    },
+    () => {
+      return {
+        ...(outcome ? { queue_first_admission_result: outcome } : {}),
+        thread_session_snapshot_state: args.sessionSnapshotState,
+      };
+    },
+  );
+}
+
+export async function claimQueueFirstRunAssociation(
+  db: DbTransaction,
+  args: QueueFirstRunAssociation & {
+    readonly admission: QueueFirstRunAdmission;
+    readonly runId: string;
+    readonly timing: ApiDispatchTimingCollector;
+  },
+): Promise<QueueFirstRunClaimResult> {
+  let outcome: "claimed" | "lost" | "error" = "error";
+  return await args.timing.measure(
+    "api_dispatch_claim_queue_first_message",
+    "nested",
+    async () => {
+      if (args.admission.kind === "blocked") {
         outcome = "lost";
         return { kind: "lost" };
       }


### PR DESCRIPTION
## Summary

- separate authoritative thread admission resolution from association-specific queue claim
- stop a stale session attempt when the locked thread is still blocked by an active run or cancellation recovery
- preserve full preparation retry when the stale thread is idle
- add low-cardinality admission timing and real-database coverage for the competing binding path

## Ordering and compatibility

- stale snapshots resolve admission immediately while the thread remains locked
- current snapshots preserve concurrency and queued-payload handling before resolving admission at the existing claim boundary
- failed launches resolve admission immediately before their existing claim
- admission state never crosses a transaction boundary
- no schema, migration, persisted-state, public API, frontend, runner, guest, or queue-payload change

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts apps/api/src/signals/services/agent-run-create.service.ts apps/api/src/signals/services/api-dispatch-timing.service.ts apps/api/src/signals/services/zero-chat-queued-event.service.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api build`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts` (61 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts src/signals/routes/__tests__/chat-callbacks.bdd.test.ts src/signals/routes/__tests__/zero-goals.test.ts src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts` (92 passed)
- the new blocked-stale concurrency test passed five consecutive focused runs
- pre-commit repository Knip, type checking, and file-size checks
- current-head required CI and all selected GitHub checks passed

Closes #24298

Parent: #24203
