### PR TITLE
refactor(runner): remove retired claim capability surface

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -25,7 +25,6 @@ import {
   holdCheckpointReadsFixture,
   holdChatEventInsertTransactionFixture,
   invalidatePendingChatEventInputParamsFixture,
-  markCancellationRecoveryUnsupportedFixture,
   readChatEventContextFixture,
   removeAcknowledgedCancellationLifecycleFixture,
 } from "../../../test-fixtures/chat-events";
@@ -358,22 +357,13 @@ async function createGoalForRun(
   );
 }
 
-async function claimChatRunJob(
-  runnerGroup: string,
-  runId: string,
-  capabilities?: readonly string[],
-) {
+async function claimChatRunJob(runnerGroup: string, runId: string) {
   await api.heartbeatRunner(runnerGroup);
   let claim: Awaited<ReturnType<typeof api.requestClaimRunnerJob>> | undefined;
   await expect
     .poll(
       async () => {
-        claim = await api.requestClaimRunnerJob(
-          true,
-          runId,
-          [200, 404],
-          capabilities === undefined ? {} : { capabilities: [...capabilities] },
-        );
+        claim = await api.requestClaimRunnerJob(true, runId, [200, 404]);
         return claim.status;
       },
       { interval: 100, timeout: 10_000 },
@@ -388,9 +378,8 @@ async function claimChatRunJob(
 async function claimChatRun(
   runnerGroup: string,
   runId: string,
-  capabilities?: readonly string[],
 ): Promise<{ readonly authorization: string }> {
-  const claim = await claimChatRunJob(runnerGroup, runId, capabilities);
+  const claim = await claimChatRunJob(runnerGroup, runId);
   return { authorization: `Bearer ${claim.sandboxToken}` };
 }
 
@@ -2085,97 +2074,6 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
 });
 
 describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
-  it("ignores unknown claim capabilities without disabling recovery", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    chatCallbacks.failIfChatCallbackRouteIsFetched();
-    const run = await startChatRun(actor, {
-      agentId,
-      prompt: "cancel an unknown-capability run",
-    });
-    const sandboxHeaders = await claimChatRun(runnerGroup, run.runId, [
-      "future-cancellation-recovery-v2",
-    ]);
-    const queuedEventId = await queueChatEvent(actor, {
-      agentId,
-      threadId: run.threadId,
-      prompt: "continue after an unknown capability",
-    });
-
-    context.mocks.ably.publish.mockClear();
-    await api.requestCancelRun(actor, run.runId, [200]);
-    await flushWaitUntilForTest();
-    await waitForRunStatus(actor, run.runId, "cancelled");
-    await expectCancellationRecoveryPending(actor, run.threadId, true);
-    expect(context.mocks.ably.publish).toHaveBeenCalledWith("cancel", {
-      runId: run.runId,
-      mode: "cooperative",
-    });
-    const beforeCompletion = await chat.listThreadEvents(actor, run.threadId);
-    expect(
-      userMessages(beforeCompletion.events).filter((event) => {
-        return (
-          event.revokesEventId === queuedEventId && event.runId !== undefined
-        );
-      }),
-    ).toHaveLength(0);
-
-    await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 1, error: "Run cancelled" },
-      sandboxHeaders,
-      [200],
-    );
-    await flushWaitUntilForTest();
-    const replacementRunId = await waitForQueuedEventReplacement(
-      actor,
-      run.threadId,
-      queuedEventId,
-    );
-    expect(replacementRunId).not.toBe(run.runId);
-    await expectCancellationRecoveryPending(actor, run.threadId, false);
-
-    await api.requestCancelRun(actor, replacementRunId, [200]);
-    await waitForRunStatus(actor, replacementRunId, "cancelled");
-    await flushWaitUntilForTest();
-  }, 90_000);
-
-  it("preserves immediate release for a historical unsupported claim", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    chatCallbacks.failIfChatCallbackRouteIsFetched();
-    const run = await startChatRun(actor, {
-      agentId,
-      prompt: "cancel a historical unsupported run",
-    });
-    await claimChatRun(runnerGroup, run.runId);
-    await markCancellationRecoveryUnsupportedFixture({ runId: run.runId });
-    const queuedEventId = await queueChatEvent(actor, {
-      agentId,
-      threadId: run.threadId,
-      prompt: "continue after historical cancellation",
-    });
-
-    context.mocks.ably.publish.mockClear();
-    await api.requestCancelRun(actor, run.runId, [200]);
-    const replacementRunId = await waitForQueuedEventReplacement(
-      actor,
-      run.threadId,
-      queuedEventId,
-    );
-    expect(replacementRunId).not.toBe(run.runId);
-    await expectCancellationRecoveryPending(actor, run.threadId, false);
-    expect(context.mocks.ably.publish).toHaveBeenCalledWith("cancel", {
-      runId: run.runId,
-      mode: "hard",
-    });
-    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
-      `chatThreadDetailChanged:${run.threadId}`,
-      null,
-    );
-
-    await api.requestCancelRun(actor, replacementRunId, [200]);
-    await waitForRunStatus(actor, replacementRunId, "cancelled");
-    await flushWaitUntilForTest();
-  }, 90_000);
-
   it("preserves immediate release when a pending run is cancelled", async () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2150,10 +2150,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, created.runId, [200]);
   });
 
-  it("returns canonical storage manifests with and without the retired capability", async () => {
+  it("returns canonical storage manifests without API-only ownership fields", async () => {
     const api = createRunsApi(context);
     const { actor, runnerGroup } = await entitledRunActor();
-    const composeName = `bdd-storage-capability-${randomUUID().slice(0, 8)}`;
+    const composeName = `bdd-storage-manifest-${randomUUID().slice(0, 8)}`;
     const compose = await api.createCompose(actor, {
       version: "1",
       agents: {
@@ -2191,34 +2191,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       expect(mount).not.toHaveProperty("userId");
     }
 
-    const retiredCapabilityRun = await api.createDirectRun(actor, {
-      agentComposeVersionId: compose.versionId,
-      prompt: "retired storage capability claim",
-    });
-    // Receiver versions deployed before capability retirement keep sending this
-    // open-ended claim field while the new API rolls out.
-    const retiredCapabilityClaim = await api.claimRunnerJob(
-      retiredCapabilityRun.runId,
-      {
-        capabilities: ["storage-mounts-v1"],
-      },
-    );
-    const retiredCapabilityManifest = expectCanonicalStorageManifest(
-      retiredCapabilityClaim.storageManifest,
-    );
-    if (!retiredCapabilityManifest) {
-      throw new Error("Expected canonical mounts for the retired capability");
-    }
-    expect(retiredCapabilityManifest).not.toHaveProperty("storages");
-    expect(retiredCapabilityManifest).not.toHaveProperty("artifacts");
-    expect(retiredCapabilityManifest.storageMounts).toStrictEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ name: "memory", writeback: true }),
-      ]),
-    );
-
     await api.requestCancelRun(actor, canonicalRun.runId, [200]);
-    await api.requestCancelRun(actor, retiredCapabilityRun.runId, [200]);
   });
 
   it("persists canonical mounts across session continuation", async () => {

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -1300,7 +1300,7 @@ async function insertAssistantErrorEvent(args: {
   readonly threadId: string;
   readonly userId: string;
   readonly lifecycleEvent: "failed" | "cancelled";
-  readonly cancellationRecoveryCapable: boolean;
+  readonly hasCancellationRecoveryState: boolean;
   readonly getFormattedError: () => Promise<string>;
   readonly slackDelivery?: SlackDeliveryTarget;
   readonly feishuDelivery?: FeishuDeliveryTarget;
@@ -1399,7 +1399,10 @@ async function insertAssistantErrorEvent(args: {
 
   await publishChatThreadMessageCreatedSafely(args.userId, args.threadId);
   await publishThreadListChangedSafely(args.userId);
-  if (args.lifecycleEvent === "cancelled" && args.cancellationRecoveryCapable) {
+  if (
+    args.lifecycleEvent === "cancelled" &&
+    args.hasCancellationRecoveryState
+  ) {
     await publishChatThreadDetailChangedSafely(args.userId, args.threadId);
   }
   return {
@@ -2025,7 +2028,7 @@ async function handleFailedChatCallback(args: {
   readonly runId: string;
   readonly chatThread: ChatThreadForRunRow;
   readonly errorMessage: string;
-  readonly cancellationRecoveryCapable: boolean;
+  readonly hasCancellationRecoveryState: boolean;
   readonly getFormattedError: () => Promise<string>;
   readonly slackDelivery?: SlackDeliveryTarget;
   readonly feishuDelivery?: FeishuDeliveryTarget;
@@ -2045,7 +2048,7 @@ async function handleFailedChatCallback(args: {
     threadId: args.chatThread.chatThreadId,
     userId: args.chatThread.userId,
     lifecycleEvent,
-    cancellationRecoveryCapable: args.cancellationRecoveryCapable,
+    hasCancellationRecoveryState: args.hasCancellationRecoveryState,
     getFormattedError: args.getFormattedError,
     slackDelivery: args.slackDelivery,
     feishuDelivery: args.feishuDelivery,
@@ -3772,7 +3775,7 @@ async function prepareFailedTerminalChatCallbackWork(args: {
         runId: args.runId,
         chatThread: args.chatThread,
         errorMessage: args.errorMessage,
-        cancellationRecoveryCapable:
+        hasCancellationRecoveryState:
           args.run.cancellationRecoveryCompleted !== null,
         getFormattedError: () => {
           return args.dependencies.formatRunError(

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -550,31 +550,6 @@ export async function removeAcknowledgedCancellationLifecycleFixture(args: {
   });
 }
 
-/**
- * Reproduces a historical running claim without cancellation recovery.
- * Current product claims always initialize recovery as pending.
- */
-export async function markCancellationRecoveryUnsupportedFixture(args: {
-  readonly runId: string;
-}): Promise<void> {
-  const updated = await db()
-    .update(agentRuns)
-    .set({ cancellationRecoveryCompleted: null })
-    .where(
-      and(
-        eq(agentRuns.id, args.runId),
-        eq(agentRuns.status, "running"),
-        eq(agentRuns.cancellationRecoveryCompleted, false),
-      ),
-    )
-    .returning({ id: agentRuns.id });
-  if (updated.length !== 1) {
-    throw new Error(
-      "Expected one recovery-pending running claim to become historical",
-    );
-  }
-}
-
 async function transitiveBlockedWaiterCount(
   holderPid: number,
 ): Promise<number> {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -814,15 +814,7 @@ describe("runner resume session contract", () => {
   });
 });
 
-describe("runner claim capability contract", () => {
-  it("accepts unknown capabilities for forward compatibility", () => {
-    const result = runnersJobClaimContract.claim.body.safeParse({
-      capabilities: ["futureCapability"],
-    });
-
-    expect(result.success).toBe(true);
-  });
-
+describe("runner claim request contract", () => {
   it("accepts optional direct candidate timing telemetry", () => {
     const result = runnersJobClaimContract.claim.body.safeParse({
       telemetry: {
@@ -852,7 +844,7 @@ describe("runner claim capability contract", () => {
     expect(body.telemetry).toEqual({});
   });
 
-  it("discards malformed diagnostic telemetry without weakening capabilities", () => {
+  it("discards malformed diagnostic telemetry", () => {
     const body = runnersJobClaimContract.claim.body.parse({
       telemetry: {
         pollReason: "future-reason",
@@ -861,11 +853,6 @@ describe("runner claim capability contract", () => {
     });
 
     expect(body.telemetry).toEqual({});
-    expect(
-      runnersJobClaimContract.claim.body.safeParse({
-        capabilities: [123],
-      }).success,
-    ).toBe(false);
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -511,10 +511,6 @@ export const resumeSessionSchema = z.union([
   resumeSessionRefSchema,
 ]);
 
-// Capability names are intentionally open-ended so a newer runner can claim
-// jobs through an older API; the API ignores capabilities it does not know.
-export const runnerClaimCapabilitySchema = z.string().min(1);
-
 export const secretConnectorMetadataSchema = z.object({
   sourceType: z.enum(["connector", "model-provider", "platform-secret"]),
   sourceUserId: z.string().optional(),
@@ -701,7 +697,6 @@ export const runnersJobClaimContract = c.router({
     }),
     body: z.object({
       telemetry: runnerClaimTelemetrySchema.optional(),
-      capabilities: z.array(runnerClaimCapabilitySchema).optional(),
     }),
     responses: {
       200: executionContextSchema,
@@ -881,5 +876,3 @@ export type SessionHistorySizeBucket = z.infer<
 export type SessionAffinityResource = z.infer<
   typeof sessionAffinityResourceSchema
 >;
-
-export type RunnerClaimCapability = z.infer<typeof runnerClaimCapabilitySchema>;


### PR DESCRIPTION
## Summary

- remove the unused generic runner claim capability schema, request field, and exported type now that the last rollout capabilities are retired
- delete the retired cancellation-recovery and `storage-mounts-v1` compatibility branches from integration tests, together with their dedicated fixture and helper plumbing
- rename the remaining cancellation callback flag to describe persisted recovery state instead of a retired runner capability

## Compatibility

The current runner already omits claim capabilities after #24318, and the API has no production capability consumer on the claim route. Zod continues to accept and strip unknown top-level request fields, so briefly overlapping old runners that still send `capabilities` can claim jobs normally.

This is a protocol-surface and test cleanup only. It does not change the cancellation recovery state machine, historical nullable-row handling, hard fallback, canonical storage manifests, or sandbox-token capability authorization. The runner serialization assertion that current claim requests omit `capabilities` remains in place.

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts test` (512 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=4 --silent=passed-only` (177 tests)
- `pnpm knip`
- `pnpm -F @vm0/api-contracts generate:rust`
- repository pre-commit hooks, including workspace-wide Turbo type checking

Follow-up to #24318 and #23951.

Parent context: #23867.
