### PR TITLE
perf(api): skip execute row schema lint for irrelevant files

### DIFF
--- a/turbo/packages/eslint-rules/src/api/__tests__/require-execute-row-schema.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-execute-row-schema.test.ts
@@ -436,7 +436,7 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
     },
     {
       code: `${drizzlePreamble}
-        const { ex\\u0065cute: run } = db;
+        const { ["e\\x78ecute"]: run } = db;
       `,
       errors: [{ messageId: "executeReference" }],
     },

--- a/turbo/packages/eslint-rules/src/api/__tests__/require-execute-row-schema.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-execute-row-schema.test.ts
@@ -25,6 +25,7 @@ const ruleTester = new RuleTester({
     },
   },
 });
+const untypedRuleTester = new RuleTester();
 
 const drizzlePreamble = `
     type DrizzleDatabase =
@@ -411,6 +412,18 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
     },
     {
       code: `${drizzlePreamble}
+        const result = await db.ex\\u0065cute(query);
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        const result = await db["e\\x78ecute"](query);
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
         const execute = db.execute.bind(db);
       `,
       errors: [{ messageId: "executeReference" }],
@@ -421,5 +434,20 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
       `,
       errors: [{ messageId: "executeReference" }],
     },
+    {
+      code: `${drizzlePreamble}
+        const { ex\\u0065cute: run } = db;
+      `,
+      errors: [{ messageId: "executeReference" }],
+    },
   ],
 });
+
+untypedRuleTester.run(
+  "require-execute-row-schema without parser services",
+  requireExecuteRowSchema,
+  {
+    valid: ["const value = 1;"],
+    invalid: [],
+  },
+);

--- a/turbo/packages/eslint-rules/src/api/rules/require-execute-row-schema.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-execute-row-schema.ts
@@ -163,8 +163,8 @@ export const requireExecuteRowSchema = createRule({
     },
   },
   create(context) {
-    // ESTree decodes escaped identifiers and string literals, so a backslash
-    // may be part of a source spelling of "execute".
+    // ESTree decodes escaped identifiers and string literals. Every spelling
+    // this rule recognizes either contains "execute" or uses a backslash escape.
     if (
       !context.sourceCode.text.includes("execute") &&
       !context.sourceCode.text.includes("\\")

--- a/turbo/packages/eslint-rules/src/api/rules/require-execute-row-schema.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-execute-row-schema.ts
@@ -163,6 +163,15 @@ export const requireExecuteRowSchema = createRule({
     },
   },
   create(context) {
+    // ESTree decodes escaped identifiers and string literals, so a backslash
+    // may be part of a source spelling of "execute".
+    if (
+      !context.sourceCode.text.includes("execute") &&
+      !context.sourceCode.text.includes("\\")
+    ) {
+      return {};
+    }
+
     const services = ESLintUtils.getParserServices(context);
     const checker = services.program.getTypeChecker();
 


### PR DESCRIPTION
## Summary

- skip `api/require-execute-row-schema` initialization and visitors when a
  source file cannot contain any `execute` spelling recognized by the rule
- conservatively admit files containing either the ordinary `execute`
  substring or a backslash so escaped identifiers and string literals retain
  full coverage
- add type-aware escaped direct, computed, and destructured cases plus an
  irrelevant untyped case that proves the rule exits before parser-service
  access

The existing Drizzle symbol checks, result-usage analysis, diagnostics, and
messages are unchanged. This PR adds no generic prefilter framework, lint
configuration exception, runtime query change, schema/data change, API or
protocol change, feature switch, or deployment compatibility behavior.

## Correctness

`memberName(...)` and `propertyName(...)` recognize only ESTree identifiers and
string literals whose decoded value is `execute`. Every source spelling that
can produce that value either contains the ordinary `execute` substring or a
backslash escape. The preflight is therefore only a conservative negative
filter. Unrelated backslashes can admit extra files, but the unchanged semantic
rule still decides whether to report a diagnostic.

The tests cover escaped identifier member access, escaped computed string
member access, escaped computed string destructuring, existing ordinary and
non-Drizzle forms, and an irrelevant file without type-aware parser services.

## Performance

- measurement base: `500686d4faabc756efe2ce116f5b19f7b8772f73`
- measured candidate rule code: `fc52cc85593646517de8005a15167d281eee67ba`
- current PR head: `99a7cd4a0b` (later commits only refine test coverage and the
  invariant comment)
- shared development container; results are observations, not stable benchmark
  claims
- full API ESLint `--stats` plus aggregate process-tree RSS sampling every 25 ms
- one warm-up per variant, followed by ten baseline/candidate pairs
- only the preflight lines changed between variants
- 734 of 977 API TypeScript files skip rule-specific initialization and visitors

Recorded values are baseline / candidate:

| Pair | Rule time (ms) | Wall time (ms) | Parser time (ms) | Peak RSS (KiB) |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 1,433.29 / 1,521.90 | 36,458.84 / 38,015.48 | 15,262.84 / 15,698.37 | 3,488,408 / 3,573,860 |
| 2 | 2,804.51 / 2,238.84 | 55,847.65 / 54,980.39 | 24,250.94 / 23,601.56 | 3,452,112 / 3,505,752 |
| 3 | 1,807.79 / 2,071.91 | 50,945.47 / 47,916.68 | 21,283.97 / 20,830.71 | 3,554,684 / 3,638,392 |
| 4 | 1,706.44 / 1,447.08 | 44,521.36 / 45,187.42 | 20,480.53 / 18,134.73 | 3,569,668 / 3,477,540 |
| 5 | 1,476.67 / 1,315.54 | 37,751.12 / 35,220.75 | 15,635.30 / 14,342.63 | 3,513,052 / 3,515,824 |
| 6 | 2,082.79 / 1,769.09 | 55,385.92 / 43,389.41 | 23,068.19 / 19,474.31 | 3,487,988 / 3,569,380 |
| 7 | 1,700.92 / 1,245.12 | 42,751.94 / 37,479.14 | 19,534.19 / 16,050.21 | 3,544,236 / 3,541,808 |
| 8 | 1,573.99 / 1,418.84 | 35,688.56 / 34,476.69 | 14,285.14 / 14,003.88 | 3,520,420 / 3,567,160 |
| 9 | 1,422.26 / 1,362.36 | 35,351.98 / 32,913.06 | 14,925.92 / 12,906.45 | 3,522,712 / 3,479,040 |
| 10 | 1,418.29 / 1,987.97 | 35,572.35 / 70,792.66 | 14,135.50 / 32,550.29 | 3,567,880 / 3,526,296 |

| Metric | Baseline median | Candidate median | Median change | Median paired change |
| --- | ---: | ---: | ---: | ---: |
| Rule time | 1,637.45 ms | 1,484.49 ms | -9.34% | -10.38% |
| Full wall time | 40,251.53 ms | 40,702.44 ms | +1.12% | -4.67% |
| Parser time | 17,584.75 ms | 17,092.47 ms | -2.80% | -5.47% |
| Peak process-tree RSS | 3,521,566 KiB | 3,534,052 KiB | +0.35% | +0.70% |

Rule time improved in 7/10 pairs. The final candidate observation is retained:
its +99.01% wall change coincided with a +130.27% parser-time change. Shared
container contention makes wall time too noisy for an end-to-end claim. The
retention decision is based on the material rule-local median and the absence
of a material memory regression; every paired RSS change stayed between -2.58%
and +2.45%.

## Validation

- `pnpm exec prettier --check packages/eslint-rules/src/api/rules/require-execute-row-schema.ts packages/eslint-rules/src/api/__tests__/require-execute-row-schema.test.ts`
- `pnpm -F @vm0/eslint-rules exec vitest run src/api/__tests__/require-execute-row-schema.test.ts --maxWorkers=1` (51 tests)
- `pnpm -F @vm0/eslint-rules test` (1,031 tests)
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace @vm0/eslint-rules`
- pre-commit full Knip and affected full-repository type checks
- `git diff --check`

Closes #24276

Parent context: #23047
