### PR TITLE
test(guest-agent): drive post-result timers with virtual time

### DIFF
--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -26,11 +26,13 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::io;
 use std::os::fd::{AsFd, AsRawFd, OwnedFd};
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::{
     Arc, Mutex,
     atomic::{AtomicU64, AtomicUsize, Ordering},
 };
+use std::task::Poll;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -53,6 +55,12 @@ pub const SIGKILL_EXIT: i32 = 137;
 pub const CLEAN_EXIT: i32 = 0;
 
 pub const MOCK_TERMINATION_READY_EVENT: &str = "vm0_mock_termination_ready";
+pub const MOCK_POST_RESULT_READY_EVENT: &str = "vm0_mock_post_result_ready";
+pub const MOCK_POST_RESULT_ACTIVITY_ONE_EVENT: &str = "vm0_mock_post_result_activity_1_ready";
+pub const MOCK_POST_RESULT_ACTIVITY_TWO_EVENT: &str = "vm0_mock_post_result_activity_2_ready";
+pub const MOCK_POST_RESULT_LIVENESS_EVENT: &str = "vm0_mock_post_result_stale_deadline_survived";
+pub const MOCK_POST_RESULT_RELEASE_ONE_SOCKET: &str = ".vm0-post-result-release-1.sock";
+pub const MOCK_POST_RESULT_RELEASE_TWO_SOCKET: &str = ".vm0-post-result-release-2.sock";
 
 /// Documented maximum number of stderr lines returned in
 /// `guest_agent::cli::CliExecutionResult`.
@@ -1017,9 +1025,26 @@ pub async fn execute_cli_with_cancellation_for_runtime(
 }
 
 pub struct VirtualTimeCheckpoint<'a> {
-    pub file: &'a str,
-    pub needle: &'a str,
-    pub advance: Duration,
+    file: &'a str,
+    needle: &'a str,
+    advance: Duration,
+    release_socket: Option<&'a Path>,
+}
+
+impl<'a> VirtualTimeCheckpoint<'a> {
+    pub fn new(file: &'a str, needle: &'a str, advance: Duration) -> Self {
+        Self {
+            file,
+            needle,
+            advance,
+            release_socket: None,
+        }
+    }
+
+    pub fn release_after_advance(mut self, release_socket: &'a Path) -> Self {
+        self.release_socket = Some(release_socket);
+        self
+    }
 }
 
 pub async fn execute_with_virtual_time_checkpoints<F>(
@@ -1039,7 +1064,7 @@ where
     }
 
     tokio::pin!(future);
-    for checkpoint in checkpoints {
+    for (index, checkpoint) in checkpoints.iter().enumerate() {
         tokio::select! {
             _ = &mut future => {
                 return Err(format!(
@@ -1063,7 +1088,35 @@ where
 
         tokio::time::pause();
         tokio::time::advance(checkpoint.advance).await;
+
+        let execution_poll =
+            std::future::poll_fn(|context| Poll::Ready(future.as_mut().poll(context))).await;
+        let release_result = if matches!(&execution_poll, Poll::Pending)
+            && let Some(release_socket) = checkpoint.release_socket
+        {
+            UnixStream::connect(release_socket)
+                .map(|_| ())
+                .map_err(|error| {
+                    format!(
+                        "release virtual-time checkpoint through {}: {error}",
+                        release_socket.display()
+                    )
+                })
+        } else {
+            Ok(())
+        };
         tokio::time::resume();
+        release_result?;
+
+        if let Poll::Ready(output) = execution_poll {
+            if index + 1 == checkpoints.len() && checkpoint.release_socket.is_none() {
+                return Ok(output);
+            }
+            return Err(format!(
+                "CLI execution completed after advancing time for {:?} before all checkpoint stages finished",
+                checkpoint.needle
+            ));
+        }
     }
 
     Ok(future.await)

--- a/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
@@ -29,11 +29,11 @@ async fn heartbeat_panic_reap_escalates_to_sigkill_when_sigterm_ignored()
         panic!("heartbeat panic for reap test")
     });
 
-    let checkpoints = [common::VirtualTimeCheckpoint {
-        file: runtime.paths.system_log_file(),
-        needle: "Heartbeat task panicked, SIGTERM",
-        advance: runtime.config.post_result_sigkill_grace,
-    }];
+    let checkpoints = [common::VirtualTimeCheckpoint::new(
+        runtime.paths.system_log_file(),
+        "Heartbeat task panicked, SIGTERM",
+        runtime.config.post_result_sigkill_grace,
+    )];
 
     // The transition log and SIGKILL deadline are committed in one poll.
     // Keep the outer timeout as a real subprocess/reaping regression bound.

--- a/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
@@ -32,11 +32,11 @@ async fn heartbeat_failure_reap_escalates_to_sigkill_when_sigterm_ignored()
         ))
     });
 
-    let checkpoints = [common::VirtualTimeCheckpoint {
-        file: runtime.paths.system_log_file(),
-        needle: "Heartbeat failed, SIGTERM",
-        advance: runtime.config.post_result_sigkill_grace,
-    }];
+    let checkpoints = [common::VirtualTimeCheckpoint::new(
+        runtime.paths.system_log_file(),
+        "Heartbeat failed, SIGTERM",
+        runtime.config.post_result_sigkill_grace,
+    )];
 
     // The transition log and SIGKILL deadline are committed in one poll.
     // Keep the outer timeout as a real subprocess/reaping regression bound.

--- a/crates/guest-agent/tests/initial_prompt_stdin_reap_sigkill.rs
+++ b/crates/guest-agent/tests/initial_prompt_stdin_reap_sigkill.rs
@@ -32,11 +32,11 @@ tail -f /dev/null
     let runtime = common::guest_runtime_from_process_env()?;
 
     let masker = SecretMasker::from_raw("");
-    let checkpoints = [common::VirtualTimeCheckpoint {
-        file: runtime.paths.system_log_file(),
-        needle: "Claude stdin writer failed, SIGTERM",
-        advance: runtime.config.post_result_sigkill_grace,
-    }];
+    let checkpoints = [common::VirtualTimeCheckpoint::new(
+        runtime.paths.system_log_file(),
+        "Claude stdin writer failed, SIGTERM",
+        runtime.config.post_result_sigkill_grace,
+    )];
 
     // The write-failure log and SIGKILL deadline are committed in one poll.
     // Keep the outer timeout as a real subprocess/reaping regression bound.

--- a/crates/guest-agent/tests/post_result_reap_execution_deadline.rs
+++ b/crates/guest-agent/tests/post_result_reap_execution_deadline.rs
@@ -35,21 +35,21 @@ async fn execution_deadline_preserves_post_result_sigkill_pending()
         .checked_sub(execution_deadline_after_sigterm)
         .expect("SIGKILL deadline should follow the execution deadline");
     let checkpoints = [
-        common::VirtualTimeCheckpoint {
-            file: runtime.paths.agent_log_file(),
-            needle: common::MOCK_TERMINATION_READY_EVENT,
-            advance: runtime.config.post_result_sigterm_grace,
-        },
-        common::VirtualTimeCheckpoint {
-            file: runtime.paths.system_log_file(),
-            needle: "Post-result cleanup quiet_timeout reached",
-            advance: execution_deadline_after_sigterm,
-        },
-        common::VirtualTimeCheckpoint {
-            file: runtime.paths.system_log_file(),
-            needle: "Agent execution deadline reached during post-result SIGKILL grace",
-            advance: sigkill_deadline_after_execution,
-        },
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.agent_log_file(),
+            common::MOCK_TERMINATION_READY_EVENT,
+            runtime.config.post_result_sigterm_grace,
+        ),
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.system_log_file(),
+            "Post-result cleanup quiet_timeout reached",
+            execution_deadline_after_sigterm,
+        ),
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.system_log_file(),
+            "Agent execution deadline reached during post-result SIGKILL grace",
+            sigkill_deadline_after_execution,
+        ),
     ];
 
     // Each checkpoint proves the preceding state transition before virtual

--- a/crates/guest-agent/tests/post_result_reap_refresh.rs
+++ b/crates/guest-agent/tests/post_result_reap_refresh.rs
@@ -20,15 +20,50 @@ async fn post_result_reap_refreshes_quiet_deadline_on_meaningful_event()
 
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
+    let event_offset = Duration::from_secs(1);
+    let stale_deadline_after_event = runtime
+        .config
+        .post_result_sigterm_grace
+        .checked_sub(event_offset)
+        .expect("the meaningful event should precede the original quiet deadline");
+    let refreshed_deadline_after_stale = runtime
+        .config
+        .post_result_sigterm_grace
+        .checked_sub(stale_deadline_after_event)
+        .expect("the refreshed quiet deadline should follow the original deadline");
+    let release_one = tmp.path().join(common::MOCK_POST_RESULT_RELEASE_ONE_SOCKET);
+    let release_two = tmp.path().join(common::MOCK_POST_RESULT_RELEASE_TWO_SOCKET);
+    let checkpoints = [
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.agent_log_file(),
+            common::MOCK_POST_RESULT_READY_EVENT,
+            event_offset,
+        )
+        .release_after_advance(&release_one),
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.agent_log_file(),
+            common::MOCK_POST_RESULT_ACTIVITY_ONE_EVENT,
+            stale_deadline_after_event,
+        )
+        .release_after_advance(&release_two),
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.agent_log_file(),
+            common::MOCK_POST_RESULT_LIVENESS_EVENT,
+            refreshed_deadline_after_stale,
+        ),
+    ];
 
+    // Poll at the original quiet deadline before releasing the liveness
+    // fence, so a missing live deadline reset terminates the mock early.
     let result = tokio::time::timeout(
         Duration::from_secs(12),
-        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+        common::execute_with_virtual_time_checkpoints(
+            common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+            &checkpoints,
+        ),
     )
     .await
-    .expect("execute_cli did not return within 12s");
-
-    let result = result.expect("execute_cli returned Err");
+    .expect("execute_cli did not return within 12s")??;
     assert_eq!(result.exit_code, common::SIGTERM_EXIT);
     let termination = result
         .cli_termination

--- a/crates/guest-agent/tests/post_result_reap_sigkill.rs
+++ b/crates/guest-agent/tests/post_result_reap_sigkill.rs
@@ -38,16 +38,16 @@ async fn post_result_reap_escalates_to_sigkill_when_sigterm_ignored()
         .agent_execution_timeout
         .expect("test config should set an execution timeout");
     let checkpoints = [
-        common::VirtualTimeCheckpoint {
-            file: runtime.paths.agent_log_file(),
-            needle: common::MOCK_TERMINATION_READY_EVENT,
-            advance: execution_timeout,
-        },
-        common::VirtualTimeCheckpoint {
-            file: runtime.paths.system_log_file(),
-            needle: "Agent execution deadline reached during post-result cleanup",
-            advance: runtime.config.post_result_sigkill_grace,
-        },
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.agent_log_file(),
+            common::MOCK_TERMINATION_READY_EVENT,
+            execution_timeout,
+        ),
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.system_log_file(),
+            "Agent execution deadline reached during post-result cleanup",
+            runtime.config.post_result_sigkill_grace,
+        ),
     ];
 
     // The mock fence proves result ingestion armed cleanup before the

--- a/crates/guest-agent/tests/post_result_reap_total_cap.rs
+++ b/crates/guest-agent/tests/post_result_reap_total_cap.rs
@@ -26,15 +26,44 @@ async fn post_result_reap_total_cap_bounds_periodic_meaningful_events()
 
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
+    let event_interval = Duration::from_secs(1);
+    let total_cap_after_events = runtime
+        .config
+        .post_result_total_cap
+        .checked_sub(event_interval)
+        .and_then(|remaining| remaining.checked_sub(event_interval))
+        .expect("the total cap should follow both meaningful events");
+    let release_one = tmp.path().join(common::MOCK_POST_RESULT_RELEASE_ONE_SOCKET);
+    let release_two = tmp.path().join(common::MOCK_POST_RESULT_RELEASE_TWO_SOCKET);
+    let checkpoints = [
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.agent_log_file(),
+            common::MOCK_POST_RESULT_READY_EVENT,
+            event_interval,
+        )
+        .release_after_advance(&release_one),
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.agent_log_file(),
+            common::MOCK_POST_RESULT_ACTIVITY_ONE_EVENT,
+            event_interval,
+        )
+        .release_after_advance(&release_two),
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.agent_log_file(),
+            common::MOCK_POST_RESULT_ACTIVITY_TWO_EVENT,
+            total_cap_after_events,
+        ),
+    ];
 
     let result = tokio::time::timeout(
         Duration::from_secs(8),
-        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+        common::execute_with_virtual_time_checkpoints(
+            common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+            &checkpoints,
+        ),
     )
     .await
-    .expect("execute_cli did not return within 8s");
-
-    let result = result.expect("execute_cli returned Err");
+    .expect("execute_cli did not return within 8s")??;
     assert_eq!(result.exit_code, common::SIGTERM_EXIT);
     let termination = result
         .cli_termination
@@ -48,6 +77,6 @@ async fn post_result_reap_total_cap_bounds_periodic_meaningful_events()
         .find(|line| line.contains("post_result_cleanup_terminated"))
         .expect("post-result cleanup telemetry should be recorded");
     assert!(cleanup_line.contains("trigger=total_cap"), "{ops}");
-    assert!(!cleanup_line.contains("meaningful_events=0"), "{ops}");
+    assert!(cleanup_line.contains("meaningful_events=2"), "{ops}");
     Ok(())
 }

--- a/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
@@ -23,16 +23,16 @@ async fn stuck_tool_reap_escalates_to_sigkill_when_sigterm_ignored()
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
     let checkpoints = [
-        common::VirtualTimeCheckpoint {
-            file: runtime.paths.agent_log_file(),
-            needle: common::MOCK_TERMINATION_READY_EVENT,
-            advance: Duration::from_secs(5),
-        },
-        common::VirtualTimeCheckpoint {
-            file: runtime.paths.system_log_file(),
-            needle: "Tool timeout: WebFetch stuck for",
-            advance: runtime.config.post_result_sigkill_grace,
-        },
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.agent_log_file(),
+            common::MOCK_TERMINATION_READY_EVENT,
+            Duration::from_secs(5),
+        ),
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.system_log_file(),
+            "Tool timeout: WebFetch stuck for",
+            runtime.config.post_result_sigkill_grace,
+        ),
     ];
 
     // The mock fence proves WebFetch is tracked before the watchdog jump. The

--- a/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
@@ -23,16 +23,16 @@ async fn stuck_tool_reap_survives_stdout_eof_before_child_exit()
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
     let checkpoints = [
-        common::VirtualTimeCheckpoint {
-            file: runtime.paths.agent_log_file(),
-            needle: common::MOCK_TERMINATION_READY_EVENT,
-            advance: Duration::from_secs(5),
-        },
-        common::VirtualTimeCheckpoint {
-            file: runtime.paths.system_log_file(),
-            needle: "Tool timeout: WebFetch stuck for",
-            advance: runtime.config.post_result_sigkill_grace,
-        },
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.agent_log_file(),
+            common::MOCK_TERMINATION_READY_EVENT,
+            Duration::from_secs(5),
+        ),
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.system_log_file(),
+            "Tool timeout: WebFetch stuck for",
+            runtime.config.post_result_sigkill_grace,
+        ),
     ];
 
     // The mock fence proves WebFetch is tracked before stdout closes and the

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -33,11 +33,11 @@
 //!                               can terminate it; tests the
 //!                               SigkillPending->Done escalation path
 //!   @hang-after-result-then-event
-//!                             - Emit result, later emit a meaningful event,
-//!                               then hang
+//!                             - Emit result, then one release-gated meaningful
+//!                               event, then hang
 //!   @hang-after-result-periodic-events
-//!                             - Emit result, then keep emitting meaningful
-//!                               events until reaped
+//!                             - Emit result, then two release-gated meaningful
+//!                               events, then hang
 //!   @hang-after-error-result  - Emit an error result, then hang
 //!   @exit-after-result        - Emit result event, exit(0) immediately;
 //!                               tests that reap stays no-op on the

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -12,6 +12,7 @@ use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
+use std::os::unix::net::UnixListener;
 use std::path::Path;
 use std::process::{Command, ExitCode, Stdio};
 #[cfg(unix)]
@@ -24,8 +25,13 @@ use std::time::Duration;
 
 const REAPABLE_HANG_DURATION: Duration = Duration::from_secs(3600);
 const ACTIVE_INPUT_READY_RESULT: &str = "READY_FOR_ACTIVE_INPUT";
-const TERMINATION_READY_EVENT: &str =
-    r#"{"type":"stream_event","event":{"type":"vm0_mock_termination_ready"}}"#;
+const TERMINATION_READY_EVENT: &str = "vm0_mock_termination_ready";
+const POST_RESULT_READY_EVENT: &str = "vm0_mock_post_result_ready";
+const POST_RESULT_ACTIVITY_ONE_EVENT: &str = "vm0_mock_post_result_activity_1_ready";
+const POST_RESULT_ACTIVITY_TWO_EVENT: &str = "vm0_mock_post_result_activity_2_ready";
+const POST_RESULT_LIVENESS_EVENT: &str = "vm0_mock_post_result_stale_deadline_survived";
+const POST_RESULT_RELEASE_ONE_SOCKET: &str = ".vm0-post-result-release-1.sock";
+const POST_RESULT_RELEASE_TWO_SOCKET: &str = ".vm0-post-result-release-2.sock";
 const STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES: usize = 1024 * 1024;
 const STREAM_JSON_SHELL_READ_BUFFER_BYTES: usize = 8 * 1024;
 // Integration contract with guest-agent's ordinary stdout framing policy.
@@ -400,8 +406,30 @@ fn emit_termination_ready_fence() {
     if let Ok(home) = std::env::var("HOME") {
         let _ = std::fs::write(format!("{home}/.vm0-mock-sigterm-ignored"), b"");
     }
-    println!("{TERMINATION_READY_EVENT}");
+    emit_stream_event_fence(TERMINATION_READY_EVENT);
+}
+
+fn emit_stream_event_fence(event_type: &str) {
+    println!(
+        "{}",
+        json!({"type": "stream_event", "event": {"type": event_type}})
+    );
     let _ = std::io::stdout().flush();
+}
+
+fn emit_fence_and_wait_for_release(
+    event_type: &str,
+    release_socket_name: &str,
+) -> Result<(), String> {
+    let home = std::env::var("HOME").map_err(|error| format!("read HOME: {error}"))?;
+    let release_socket = Path::new(&home).join(release_socket_name);
+    let listener = UnixListener::bind(&release_socket)
+        .map_err(|error| format!("bind {}: {error}", release_socket.display()))?;
+    emit_stream_event_fence(event_type);
+    listener
+        .accept()
+        .map_err(|error| format!("accept {}: {error}", release_socket.display()))?;
+    Ok(())
 }
 
 fn hang_until_reaped() {
@@ -513,10 +541,22 @@ fn run_hang_after_result_scenario(output_format: &str, deaf: bool) -> ExitCode {
 fn run_hang_after_result_then_event_scenario(output_format: &str) -> ExitCode {
     if output_format == "stream-json" {
         let session_id = emit_result_pair(false, "Done.");
-        thread::sleep(Duration::from_millis(1_000));
+        if let Err(error) =
+            emit_fence_and_wait_for_release(POST_RESULT_READY_EVENT, POST_RESULT_RELEASE_ONE_SOCKET)
+        {
+            eprintln!("{error}");
+            return ExitCode::from(1);
+        }
         let mut transcript = JsonlTranscript::default();
         transcript.emit_value(assistant_text_event(&session_id, "post-result event"));
-        let _ = std::io::stdout().flush();
+        if let Err(error) = emit_fence_and_wait_for_release(
+            POST_RESULT_ACTIVITY_ONE_EVENT,
+            POST_RESULT_RELEASE_TWO_SOCKET,
+        ) {
+            eprintln!("{error}");
+            return ExitCode::from(1);
+        }
+        emit_stream_event_fence(POST_RESULT_LIVENESS_EVENT);
         hang_until_reaped();
     }
     ExitCode::SUCCESS
@@ -525,15 +565,29 @@ fn run_hang_after_result_then_event_scenario(output_format: &str) -> ExitCode {
 fn run_hang_after_result_periodic_events_scenario(output_format: &str) -> ExitCode {
     if output_format == "stream-json" {
         let session_id = emit_result_pair(false, "Done.");
-        let mut transcript = JsonlTranscript::default();
-        for index in 0..20 {
-            thread::sleep(Duration::from_millis(250));
-            transcript.emit_value(assistant_text_event(
-                &session_id,
-                &format!("post-result periodic event {index}"),
-            ));
-            let _ = std::io::stdout().flush();
+        if let Err(error) =
+            emit_fence_and_wait_for_release(POST_RESULT_READY_EVENT, POST_RESULT_RELEASE_ONE_SOCKET)
+        {
+            eprintln!("{error}");
+            return ExitCode::from(1);
         }
+        let mut transcript = JsonlTranscript::default();
+        transcript.emit_value(assistant_text_event(
+            &session_id,
+            "post-result periodic event 0",
+        ));
+        if let Err(error) = emit_fence_and_wait_for_release(
+            POST_RESULT_ACTIVITY_ONE_EVENT,
+            POST_RESULT_RELEASE_TWO_SOCKET,
+        ) {
+            eprintln!("{error}");
+            return ExitCode::from(1);
+        }
+        transcript.emit_value(assistant_text_event(
+            &session_id,
+            "post-result periodic event 1",
+        ));
+        emit_stream_event_fence(POST_RESULT_ACTIVITY_TWO_EVENT);
         hang_until_reaped();
     }
     ExitCode::SUCCESS


### PR DESCRIPTION
## Summary

- replace real-time sleeps in the post-result refresh and total-cap integration tests with run-local Unix socket checkpoints and Tokio virtual time
- explicitly poll the execution future at the stale deadline so the refresh test still detects a missing live timer reset
- generalize the existing virtual-time checkpoint harness and migrate its current callers to the constructor-based API

This is test-only: production behavior, timer durations, protocols, and configuration are unchanged.

## Validation

- `cargo test -p guest-agent --test post_result_reap_refresh --test post_result_reap_total_cap`
- repeated both focused tests five times; each binary completed in about 0.01 seconds
- temporarily removed the live deadline reset and confirmed both focused tests fail, then restored it and confirmed they pass
- `cargo test -p guest-agent -p guest-mock-claude`
- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent -p guest-mock-claude --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-agent -p guest-mock-claude --all-features --no-deps`
- `git diff --check`

Closes #24309
