### PR TITLE
test(platform): split oversized body-link preview test

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -238,6 +238,54 @@ function clipboardFileItem(file: File): DataTransferItem {
   } as DataTransferItem;
 }
 
+/**
+ * Seed one assistant message whose body carries every previewable link kind.
+ *
+ * Each test that renders this message asserts a subset of the resulting
+ * previews so no single test has to drive all eight open/close cycles within
+ * one test timeout.
+ */
+function setupBodyPreviewLinks(): void {
+  const audioUrl = "https://cdn.vm7.io/artifacts/test/body-audio/briefing.mp3";
+  const videoUrl = "https://cdn.vm7.io/artifacts/test/body-video/demo.mp4";
+  const imageUrl = "https://cdn.vm7.io/artifacts/test/body-image/chart.png";
+  const markdownUrl =
+    "https://cdn.vm7.io/artifacts/test/body-markdown/release-notes.md";
+  const csvUrl =
+    "https://cdn.vm7.io/artifacts/test/body-csv/launch-metrics.csv";
+  const pdfUrl = "https://cdn.vm7.io/artifacts/test/body-pdf/rollout-plan.pdf";
+  const htmlUrl =
+    "https://cdn.vm7.io/artifacts/test/body-html/launch-site.html";
+  const archiveUrl = "https://cdn.vm7.io/artifacts/test/body-file/archive.bin";
+  context.mocks.http.get(markdownUrl, () => {
+    return new Response("# Release notes\n\nBody link rollout is ready.", {
+      headers: { "Content-Type": "text/markdown" },
+    });
+  });
+  context.mocks.http.get(csvUrl, () => {
+    return new Response("metric,value\nactivation,87", {
+      headers: { "Content-Type": "text/csv" },
+    });
+  });
+  context.mocks.http.get(archiveUrl, () => {
+    return new Response(null, { status: 500 });
+  });
+  mockChatLifecycle(context, {
+    threadId: THREAD_ID,
+    chatEvents: [
+      {
+        id: "msg-body-preview-links",
+        role: "assistant",
+        content: `Generated preview links:\n\n${audioUrl}\n${videoUrl}\n${imageUrl}\n${markdownUrl}\n${csvUrl}\n${pdfUrl}\n[Launch site](${htmlUrl})\n${archiveUrl}`,
+        runId: "run-body-previews",
+        createdAt: "2026-03-10T00:00:00Z",
+      },
+    ],
+  });
+
+  detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+}
+
 describe("zero attachment chips", () => {
   it("shows pending upload progress for composer attachments", async () => {
     context.mocks.upload.pending({
@@ -2174,48 +2222,8 @@ describe("zero attachment chips", () => {
     });
   });
 
-  it("opens media and file previews parsed from chat message links", async () => {
-    const audioUrl =
-      "https://cdn.vm7.io/artifacts/test/body-audio/briefing.mp3";
-    const videoUrl = "https://cdn.vm7.io/artifacts/test/body-video/demo.mp4";
-    const imageUrl = "https://cdn.vm7.io/artifacts/test/body-image/chart.png";
-    const markdownUrl =
-      "https://cdn.vm7.io/artifacts/test/body-markdown/release-notes.md";
-    const csvUrl =
-      "https://cdn.vm7.io/artifacts/test/body-csv/launch-metrics.csv";
-    const pdfUrl =
-      "https://cdn.vm7.io/artifacts/test/body-pdf/rollout-plan.pdf";
-    const htmlUrl =
-      "https://cdn.vm7.io/artifacts/test/body-html/launch-site.html";
-    const archiveUrl =
-      "https://cdn.vm7.io/artifacts/test/body-file/archive.bin";
-    context.mocks.http.get(markdownUrl, () => {
-      return new Response("# Release notes\n\nBody link rollout is ready.", {
-        headers: { "Content-Type": "text/markdown" },
-      });
-    });
-    context.mocks.http.get(csvUrl, () => {
-      return new Response("metric,value\nactivation,87", {
-        headers: { "Content-Type": "text/csv" },
-      });
-    });
-    context.mocks.http.get(archiveUrl, () => {
-      return new Response(null, { status: 500 });
-    });
-    mockChatLifecycle(context, {
-      threadId: THREAD_ID,
-      chatEvents: [
-        {
-          id: "msg-body-preview-links",
-          role: "assistant",
-          content: `Generated preview links:\n\n${audioUrl}\n${videoUrl}\n${imageUrl}\n${markdownUrl}\n${csvUrl}\n${pdfUrl}\n[Launch site](${htmlUrl})\n${archiveUrl}`,
-          runId: "run-body-previews",
-          createdAt: "2026-03-10T00:00:00Z",
-        },
-      ],
-    });
-
-    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+  it("renders media and file previews parsed from chat message links", async () => {
+    setupBodyPreviewLinks();
 
     await waitFor(() => {
       expect(screen.getByText("Generated preview links:")).toBeInTheDocument();
@@ -2247,6 +2255,16 @@ describe("zero attachment chips", () => {
       "bg-black",
     );
     expect(bodyVideoPreview).not.toHaveClass("w-[50px]");
+  });
+
+  it("opens audio, video, and image previews parsed from chat message links", async () => {
+    setupBodyPreviewLinks();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Open audio preview for briefing.mp3"),
+      ).toBeInTheDocument();
+    });
 
     click(screen.getByLabelText("Open audio preview for briefing.mp3"));
 
@@ -2300,13 +2318,15 @@ describe("zero attachment chips", () => {
       userSelect: "none",
       width: "100%",
     });
+  });
 
-    click(screen.getByLabelText("Close"));
+  it("opens markdown and csv previews parsed from chat message links", async () => {
+    setupBodyPreviewLinks();
 
     await waitFor(() => {
       expect(
-        screen.queryByTestId("attachment-lightbox"),
-      ).not.toBeInTheDocument();
+        screen.getByLabelText("Open markdown preview for release-notes.md"),
+      ).toBeInTheDocument();
     });
 
     click(screen.getByLabelText("Open markdown preview for release-notes.md"));
@@ -2332,13 +2352,15 @@ describe("zero attachment chips", () => {
       expect(screen.getByTestId("attachment-lightbox")).toBeInTheDocument();
       expect(screen.getByText("activation")).toBeInTheDocument();
     });
+  });
 
-    click(screen.getByLabelText("Close"));
+  it("opens pdf and html previews and reports download failures parsed from chat message links", async () => {
+    setupBodyPreviewLinks();
 
     await waitFor(() => {
       expect(
-        screen.queryByTestId("attachment-lightbox"),
-      ).not.toBeInTheDocument();
+        screen.getByLabelText("Open pdf preview for rollout-plan.pdf"),
+      ).toBeInTheDocument();
     });
 
     click(screen.getByLabelText("Open pdf preview for rollout-plan.pdf"));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -2318,6 +2318,14 @@ describe("zero attachment chips", () => {
       userSelect: "none",
       width: "100%",
     });
+
+    click(screen.getByLabelText("Close"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("attachment-lightbox"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("opens markdown and csv previews parsed from chat message links", async () => {
@@ -2351,6 +2359,14 @@ describe("zero attachment chips", () => {
     await waitFor(() => {
       expect(screen.getByTestId("attachment-lightbox")).toBeInTheDocument();
       expect(screen.getByText("activation")).toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Close"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("attachment-lightbox"),
+      ).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Problem

`test-app (5)` failed in [run 30620158453](https://github.com/vm0-ai/vm0/actions/runs/30620158453/job/91122729619) with:

```
FAIL  @vm0/app  src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
      > zero attachment chips > opens media and file previews parsed from chat message links
Error: Test timed out in 5000ms.
```

This is not a race and not an infrastructure failure. The test was steadily consuming most of its own timeout budget, so ordinary runner contention pushed it over.

That single `it()` drove **eight preview open/close cycles plus a download failure** — 16 `waitFor` calls — on top of the `detachedSetupPage` bootstrap, all inside one 5000ms budget.

Its duration on recent passing runs of the same shard:

| Run | This test | Whole file |
| --- | --- | --- |
| [30620157068](https://github.com/vm0-ai/vm0/actions/runs/30620157068) | 3453ms | 38421ms |
| [30618881918](https://github.com/vm0-ai/vm0/actions/runs/30618881918) | 3774ms | 50476ms |
| [30619244007](https://github.com/vm0-ai/vm0/actions/runs/30619244007) | 4399ms | 57123ms |
| **30620158453 (failed)** | **>5000ms** | **68773ms** |

Steady state was already 69–88% of the budget. On the failing run the whole file took 68.8s against 38–57s normally, so the runner was ~1.8x slower. The test/file duration ratio holds at 0.075–0.090 across runs, which puts this test at ~5.5s on that run — exactly the observed timeout.

Ruled out as causal:
- The `[W][zero-attachment-url] downloadUrl: fetch failed 500` line in the log belongs to a **different, passing** test (`opens canonical markdown and text previews...`) and is its own mocked 500.
- No `PromiseRejectionHandledWarning`, no pre-teardown `AbortError`, no unhandled rejection.
- Adjacent merge_group runs on the same SHA ([30620156960](https://github.com/vm0-ai/vm0/actions/runs/30620156960), [30620157068](https://github.com/vm0-ai/vm0/actions/runs/30620157068)) were green, and the other 34 tests in the file passed.

## Fix

Split the oversized test into four scenario-sized tests, following the convention this file already uses for persisted attachments (`opens persisted canonical audio, video, and document attachments` / `opens persisted canonical csv, pdf, and html document previews`, ~2s each in CI).

A file-local `setupBodyPreviewLinks()` helper seeds **the same** assistant message carrying all eight link kinds, and each test renders that full message before asserting its own subset:

1. `renders media and file previews...` — all eight chips render, plus the video preview sizing classes
2. `opens audio, video, and image previews...`
3. `opens markdown and csv previews...`
4. `opens pdf and html previews and reports download failures...`

The product contract is fully preserved: every test still renders the complete multi-kind link message, so "parse all eight previewable link kinds out of one message body" stays covered by each one. Every original assertion is kept, including the lightbox image `draggable` / `pointerEvents` / `userSelect` style assertions and the download failure toast.

The regrouping is assertion-neutral. The first commit accidentally dropped the trailing close-and-dismiss assertion after the image lightbox and after the csv preview (7 close/dismiss pairs -> 5); `84abc1c` restores both. The group is now a strict superset of the original: the same 7 close/dismiss pairs, plus 3 new per-test readiness gates that replace the sequencing the single test used to get implicitly.

No timeout increase, no sleep, no retry, no `clearAllDetached()`, no skipped test.

## Validation

Same-machine before/after via `git stash`:

- **Before:** 2872 / 2634 / 2599ms for the single test
- **After:** 5 consecutive runs, 38/38 green each time; worst test 1184ms (~0.52s / 1.13s / 0.92s / 1.10s)

Peak per-test budget consumption drops ~2.4x. Scaled by the failing shard's contention factor, the worst split test lands near 2.4s, in line with the file's other healthy tests (2.0–2.5s in CI).

Checks run: `pnpm format`, `eslint` on the changed file, `pnpm -F @vm0/app check-types` (with `.tsbuildinfo` removed first to avoid a cache replay), `pnpm knip --workspace apps/platform`. The change is confined to one test file's local helper and touches no shared fixture, signal, or cleanup helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

