### PR TITLE
fix(platform): unify chat event loading and scroll effects

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -196,6 +196,12 @@ export default [
     },
   },
   {
+    files: ["src/signals/utils.ts"],
+    rules: {
+      "api/no-new-promise": "off",
+    },
+  },
+  {
     files: ["src/lib/db-raw-rows.ts"],
     rules: {
       // This is the single reviewed boundary that turns driver rows into

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -189,10 +189,11 @@ export default [
       "ccstate/no-direct-local-storage": "off",
     },
   },
-  // Allow new Promise() in dedicated infrastructure helpers that wrap browser
-  // primitives. App code should continue using createDeferredPromise().
+  // Allow Promise primitives in the centralized deferred helper and dedicated
+  // browser wrappers. App code should continue using createDeferredPromise().
   {
     files: [
+      "src/signals/utils.ts",
       "src/polyfill.ts",
       "src/views/zero-page/components/org-manage/read-image-dimensions.ts",
     ],

--- a/turbo/apps/platform/src/mocks/ably.ts
+++ b/turbo/apps/platform/src/mocks/ably.ts
@@ -3,6 +3,8 @@
 // In the long term, this file should also stop using .cache and .zyn.
 // confirmed by ethan@vm0.ai
 // oxlint-disable promise/prefer-await-to-then
+import { createDeferredPromise } from "../signals/utils.ts";
+
 /**
  * Mock ably module for tests.
  *
@@ -139,7 +141,9 @@ export function rejectNextAblySubscribe(message: string): void {
 }
 
 function invokeAuthCallback(cb: AuthCallback): Promise<AuthCallbackToken> {
-  const deferred = Promise.withResolvers<AuthCallbackToken>();
+  const deferred = createDeferredPromise<AuthCallbackToken>(
+    AbortSignal.any([]),
+  );
   cb({}, (error, token) => {
     if (error) {
       const message =

--- a/turbo/apps/platform/src/mocks/msw-contract.ts
+++ b/turbo/apps/platform/src/mocks/msw-contract.ts
@@ -66,15 +66,13 @@ async function withSignal<T>(
   if (signal.aborted) {
     throw getAbortReason(signal);
   }
-  const { promise: aborted, reject } = Promise.withResolvers<never>();
-  const onAbort = () => {
-    reject(getAbortReason(signal));
-  };
-  signal.addEventListener("abort", onAbort, { once: true });
+  const aborted = createDeferredPromise<never>(signal);
   try {
-    return await Promise.race([promise, aborted]);
+    return await Promise.race([promise, aborted.promise]);
   } finally {
-    signal.removeEventListener("abort", onAbort);
+    if (!aborted.settled()) {
+      aborted.reject(getAbortReason(signal));
+    }
   }
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
@@ -60,12 +60,13 @@ export interface BrowserSessionSignals extends BrowserSessionDescriptor {
 
 export interface BrowserLifecycleOptimisticEvents {
   readonly append$: Command<
-    void,
+    Promise<void>,
     [
       {
         readonly eventId: string;
         readonly eventType: "browser.started" | "browser.stopped";
       },
+      AbortSignal,
     ]
   >;
 }
@@ -191,10 +192,15 @@ function createStartBrowserSignals({
     const eventId = crypto.randomUUID();
     set(startingState$, true);
     if (optimisticEvents) {
-      set(optimisticEvents.append$, {
-        eventId,
-        eventType: "browser.started",
-      });
+      await set(
+        optimisticEvents.append$,
+        {
+          eventId,
+          eventType: "browser.started",
+        },
+        signal,
+      );
+      signal.throwIfAborted();
     }
     const started = await settle(
       accept(
@@ -243,10 +249,15 @@ function createStopBrowserSignals({
     signal.throwIfAborted();
     set(stoppingState$, true);
     if (optimisticEvents) {
-      set(optimisticEvents.append$, {
-        eventId,
-        eventType: "browser.stopped",
-      });
+      await set(
+        optimisticEvents.append$,
+        {
+          eventId,
+          eventType: "browser.stopped",
+        },
+        signal,
+      );
+      signal.throwIfAborted();
     }
     if (current.ok && current.value) {
       const stoppedAt = nowDate().toISOString();

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-background-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-background-sync.ts
@@ -13,7 +13,6 @@ import {
   currentRightThread$,
   SIDEBAR_PARAM,
 } from "./chat-thread-panes.ts";
-import { autoOpenThreadSidebar$ } from "./thread-sidebar-coordinator.ts";
 import {
   CHAT_EVENTS_PAGE_LIMIT,
   listEventsAfter$,
@@ -152,22 +151,8 @@ const receiveSyncedEventsInVisibleThreads$ = command(
     });
 
     await Promise.all(
-      visibleThreads.map(async (thread) => {
-        // Receiving merges the new events before it awaits read-state work, so
-        // start it first and let sidebar selection proceed from that projection.
-        const receiveEventsPromise = set(
-          thread.receiveSyncedEvents$,
-          events,
-          signal,
-        );
-        if (events.length === 0) {
-          await receiveEventsPromise;
-          return;
-        }
-        await Promise.all([
-          receiveEventsPromise,
-          set(autoOpenThreadSidebar$, thread, signal),
-        ]);
+      visibleThreads.map((thread) => {
+        return set(thread.receiveSyncedEvents$, events, signal);
       }),
     );
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -33,10 +33,6 @@ import {
 import { createRemoteChatThreadDataSource } from "./remote-chat-thread-data-source.ts";
 import { syncPrimaryThread$ } from "./sync-primary-thread.ts";
 import {
-  autoOpenInitialThreadSidebar$,
-  autoOpenThreadSidebar$,
-} from "./thread-sidebar-coordinator.ts";
-import {
   createComposerConnectorAuthorizationSignals,
   type ComposerConnectorAuthorizationSignals,
 } from "../zero-page/zero-connectors.ts";
@@ -211,8 +207,6 @@ const resolvePaneThread$ = command(
     await Promise.all([
       set(loadDraft$, thread, isNew, signal),
       set(thread.subscribeChatThread$, signal),
-      set(autoOpenInitialThreadSidebar$, thread, signal),
-      set(autoOpenThreadSidebar$, thread, signal),
     ]);
     signal.throwIfAborted();
     L.debug("resolvePaneThread$ Promise.all done", {

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -24,9 +24,9 @@ interface ChatThreadScrollSignals {
   >;
   readonly threadScrollPosition$: Computed<ThreadScrollPosition | null>;
   readonly awayFromBottom$: Computed<boolean>;
-  readonly requestScrollAfterRender$: Command<
-    void,
-    [ThreadScrollPosition | null]
+  readonly autoScroll$: Command<
+    Promise<void>,
+    [ThreadScrollPosition | null, AbortSignal]
   >;
   readonly scrollTo$: Command<void, [ThreadScrollPosition]>;
   readonly scrollToTop$: Command<void, []>;
@@ -285,8 +285,13 @@ function createScrollNavigationSignals(
       });
     },
   );
-  const requestScrollAfterRender$ = command(
-    ({ set }, position: ThreadScrollPosition | null): void => {
+  const autoScroll$ = command(
+    (
+      { set },
+      position: ThreadScrollPosition | null,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      signal.throwIfAborted();
       if (position === null) {
         set(scroll.clearThreadScrollPosition$);
       }
@@ -301,9 +306,13 @@ function createScrollNavigationSignals(
         targetEventId: position?.targetEventId ?? null,
         viewportOffsetTop: position?.viewportOffsetTop ?? null,
       });
-      animationFrame(() => {
-        set(commitScrollAfterRender$, request);
-      });
+      animationFrame(
+        () => {
+          set(commitScrollAfterRender$, request);
+        },
+        { signal },
+      );
+      return Promise.resolve();
     },
   );
 
@@ -312,7 +321,7 @@ function createScrollNavigationSignals(
     scrollToBottom$,
     scrollToTop$,
     restoreAfterResize$,
-    requestScrollAfterRender$,
+    autoScroll$,
   };
 }
 
@@ -409,7 +418,7 @@ export function createChatThreadScrollSignals(
     scrollContainerOnRef$,
     threadScrollPosition$: scroll.threadScrollPosition$,
     awayFromBottom$: scroll.awayFromBottom$,
-    requestScrollAfterRender$: navigation.requestScrollAfterRender$,
+    autoScroll$: navigation.autoScroll$,
     scrollTo$: navigation.scrollTo$,
     scrollToTop$: navigation.scrollToTop$,
     scrollToBottom$: navigation.scrollToBottom$,

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -22,7 +22,6 @@ import type { ComposerConnectorSignals } from "../zero-page/zero-connectors.ts";
 import type { EditorDocumentSnapshot } from "../zero-page/user-message-document-codec.ts";
 import type { AgentReferenceSignals } from "./agent-reference-signals.ts";
 import type { ArtifactSignals } from "./artifact-card-signals.ts";
-import type { ThreadSidebarAutoOpenCandidate } from "./thread-sidebar-auto-open.ts";
 import type { ThreadScrollPosition } from "./chat-thread-scroll.ts";
 import type { AssistantErrorRecovery } from "./assistant-error-recovery.ts";
 
@@ -169,22 +168,15 @@ export interface ChatThreadSignals {
   // -- Paged events (sole rendering path) ----------------------------------
   latestRunFinishCreatedAt$: Computed<Promise<string | undefined>>;
   latestAssistantTextCreatedAt$: Computed<Promise<string | undefined>>;
-  indexedDbEventsInitialized$: Computed<Promise<void>>;
+  indexedDbEventsLoading$: Computed<boolean>;
   visibleRenderedChatGroups$: Computed<Promise<ChatEventGroup[]>>;
   visibleRenderedChatGroupsReady$: Computed<Promise<boolean>>;
-  sidebarAutoOpenCandidate$: Computed<
-    Promise<ThreadSidebarAutoOpenCandidate | null>
-  >;
   eventImageGroups$: Computed<Promise<EventImageGroupProjection[]>>;
   artifactSignalsForUrl: (url: string) => ArtifactSignals | undefined;
   agentReferenceSignalsForId: (agentId: string) => AgentReferenceSignals;
   mailDraftCardSignalsById$: Computed<ReadonlyMap<string, MailDraftSignals>>;
   browserSessionSignals: BrowserSessionSignals;
   hasEvents$: Computed<Promise<boolean>>;
-  hasNewEvents$: Computed<Promise<boolean>>;
-  initialRemoteEventsReady$: Computed<Promise<void>>;
-  initialBrowserLifecycleAuthoritative$: Computed<Promise<boolean>>;
-  initialRemoteEventsComplete$: Computed<Promise<void>>;
   hasQueuedEvents$: Computed<Promise<boolean>>;
   queuedEventItems$: Computed<Promise<readonly QueuedChatEventItem[]>>;
   emptyQueuedEventItems$: Computed<Promise<readonly QueuedChatEventItem[]>>;
@@ -194,9 +186,7 @@ export interface ChatThreadSignals {
   recommendedFollowupSource$: Computed<
     Promise<RecommendedFollowupSource | null>
   >;
-  // Approximate history backfill progress in [0, 1]; null when there is no
-  // backfill to show (no events loaded yet or history fully loaded).
-  historyBackfillProgress$: Computed<Promise<number | null>>;
+  historyBackfillPending$: Computed<boolean>;
   activeGoalObjective$: Computed<Promise<string | null>>;
   loadMoreRenderedChatGroups$: Command<Promise<boolean>, [AbortSignal]>;
   resetRenderedChatGroupsIfAtBottom$: Command<void, []>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -20,7 +20,12 @@ import {
 } from "../utils.ts";
 import { createHeaderAutomationSignals } from "./header-automation-menu.ts";
 import { createThreadSidebarSignals } from "./thread-sidebar.ts";
-import { createThreadSidebarAutoOpenCandidate } from "./thread-sidebar-auto-open.ts";
+import {
+  createThreadSidebarAutoOpenCandidate,
+  threadSidebarAutoOpenCandidateKey,
+} from "./thread-sidebar-auto-open.ts";
+import { activeThreadSidebar$ } from "./thread-sidebar-coordinator.ts";
+import { CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY } from "./chat-thread-sidebar-layout.ts";
 import {
   createChatThreadScrollSignals,
   type ThreadScrollPosition,
@@ -73,8 +78,10 @@ import { captureTaskCompletedSuccessfully } from "../../lib/posthog.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { agentById } from "../agent.ts";
 import {
+  chatThreadSidebarAutoOpenEnabled$,
   codexFastModeEnabled$,
   featureSwitch$,
+  zeroBrowserEnabled$,
 } from "../external/feature-switch.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { pinnedAgentIds$ } from "../zero-page/zero-pinned-agents.ts";
@@ -1005,7 +1012,6 @@ function createThreadOwnedSignals(
   return {
     ...createAgentInfoSignals(threadMeta$),
     headerAutomations: createHeaderAutomationSignals(threadId),
-    sidebar: createThreadSidebarSignals(threadId),
     ...createThreadUIState(),
   };
 }
@@ -1462,57 +1468,41 @@ function registerChatEvent(
   return { event, blocks };
 }
 
-function createMergePersistentEvents({
-  threadId,
-  persistentEvents$,
+function registerPersistentEvents({
+  persistentEvents,
+  events,
   registerBodyBlocks,
   artifactCardSignals,
   agentReferenceSignals,
-  scroll,
 }: {
-  threadId: string;
-  persistentEvents$: PersistentChatEvents$;
+  persistentEvents: readonly RegisteredChatEvent[];
+  events: readonly PersistedChatEvent[];
   registerBodyBlocks: BodyBlocksRenderer;
   artifactCardSignals: ArtifactCardSignalsRegistry;
   agentReferenceSignals: AgentReferenceSignalsRegistry;
-  scroll: {
-    threadScrollPosition$: Computed<ThreadScrollPosition | null>;
-    requestScrollAfterRender$: Command<void, [ThreadScrollPosition | null]>;
-  };
-}) {
-  return command(({ get, set }, events: PersistedChatEvent[]): void => {
-    if (events.length === 0) {
-      return;
-    }
-    const scrollPosition = get(scroll.threadScrollPosition$);
-    const reportedCompletedRunIds = new Set(
-      completedRunIdsFromEvents(
-        get(persistentEvents$).map((entry) => {
-          return entry.event;
-        }),
-      ),
+}): RegisteredChatEvent[] {
+  const reportedCompletedRunIds = new Set(
+    completedRunIdsFromEvents(
+      persistentEvents.map((entry) => {
+        return entry.event;
+      }),
+    ),
+  );
+  const newlyCompletedRunIds = completedRunIdsFromEvents(events).filter(
+    (runId) => {
+      return !reportedCompletedRunIds.has(runId);
+    },
+  );
+  for (const _ of newlyCompletedRunIds) {
+    captureTaskCompletedSuccessfully();
+  }
+  return events.map((event) => {
+    return registerChatEvent(
+      event,
+      registerBodyBlocks,
+      artifactCardSignals,
+      agentReferenceSignals,
     );
-    const newlyCompletedRunIds = completedRunIdsFromEvents(events).filter(
-      (runId) => {
-        return !reportedCompletedRunIds.has(runId);
-      },
-    );
-    for (const _ of newlyCompletedRunIds) {
-      captureTaskCompletedSuccessfully();
-    }
-    const registeredEvents = events.map((event) => {
-      return registerChatEvent(
-        event,
-        registerBodyBlocks,
-        artifactCardSignals,
-        agentReferenceSignals,
-      );
-    });
-    set(persistentEvents$, (prev) => {
-      return mergeRegisteredEvents([prev, registeredEvents]);
-    });
-    set(reconcileOptimisticChatEvents$, { threadId, events: events });
-    set(scroll.requestScrollAfterRender$, scrollPosition);
   });
 }
 
@@ -2138,103 +2128,6 @@ function createEventSemanticSignals(
   };
 }
 
-interface EventSyncTracking {
-  readonly completion: Promise<void>;
-  readonly initialRemoteEventsReady: Promise<boolean>;
-}
-
-type MarkInitialRemoteEventsReady = (
-  browserLifecycleAuthoritative: boolean,
-) => void;
-
-async function eventSyncCompletionAsAuthoritative(
-  completion: Promise<void>,
-): Promise<boolean> {
-  await completion;
-  return true;
-}
-
-function createEventSyncSignals(hasEvents$: Computed<Promise<boolean>>) {
-  const initialSyncStarted = Promise.withResolvers<void>();
-  const internalEventSync$ = state<EventSyncTracking | null>(null);
-  const eventSyncTracking$ = computed(
-    async (get): Promise<EventSyncTracking> => {
-      await initialSyncStarted.promise;
-      const tracking = get(internalEventSync$);
-      if (!tracking) {
-        throw new Error("Initial chat event sync tracking is missing");
-      }
-      return tracking;
-    },
-  );
-  const initialRemoteEventsComplete$ = computed(async (get): Promise<void> => {
-    await (
-      await get(eventSyncTracking$)
-    ).completion;
-  });
-  const hasNewEvents$ = computed(async (get): Promise<boolean> => {
-    await get(initialRemoteEventsComplete$);
-    return await get(hasEvents$);
-  });
-  const initialBrowserLifecycleAuthoritative$ = computed(
-    async (get): Promise<boolean> => {
-      return await (
-        await get(eventSyncTracking$)
-      ).initialRemoteEventsReady;
-    },
-  );
-  const initialRemoteEventsReady$ = computed(async (get): Promise<void> => {
-    await get(initialBrowserLifecycleAuthoritative$);
-  });
-  const trackEventSync$ = command(
-    ({ set }, tracking: EventSyncTracking): void => {
-      set(internalEventSync$, tracking);
-      initialSyncStarted.resolve(undefined);
-    },
-  );
-  const settleEventSync$ = command(({ set }): Promise<void> => {
-    const promise = Promise.resolve();
-    set(trackEventSync$, {
-      completion: promise,
-      initialRemoteEventsReady: Promise.resolve(true),
-    });
-    return promise;
-  });
-  return {
-    hasNewEvents$,
-    initialRemoteEventsReady$,
-    initialBrowserLifecycleAuthoritative$,
-    initialRemoteEventsComplete$,
-    trackEventSync$,
-    settleEventSync$,
-  };
-}
-
-function createTrackedEventSyncCommand(
-  runSyncRemoteEvents$: Command<
-    Promise<void>,
-    [MarkInitialRemoteEventsReady, AbortSignal]
-  >,
-  trackEventSync$: Command<void, [EventSyncTracking]>,
-): Command<Promise<void>, [AbortSignal]> {
-  return command(({ set }, signal: AbortSignal): Promise<void> => {
-    const initialRemoteEventsReady = Promise.withResolvers<boolean>();
-    const completion = set(
-      runSyncRemoteEvents$,
-      initialRemoteEventsReady.resolve,
-      signal,
-    );
-    set(trackEventSync$, {
-      completion,
-      initialRemoteEventsReady: Promise.race([
-        initialRemoteEventsReady.promise,
-        eventSyncCompletionAsAuthoritative(completion),
-      ]),
-    });
-    return completion;
-  });
-}
-
 function isServerProjectionEntry(entry: ChatEventProjectionEntry): boolean {
   return entry.source === "server";
 }
@@ -2315,13 +2208,6 @@ const HISTORY_BACKFILL_MERGE_BATCH_SIZE = 300;
 /** Per-thread chat event sequences start at 1, so this marks the oldest event. */
 const FIRST_CHAT_EVENT_SEQ_ID = 1;
 
-function isBrowserLifecycleEvent(event: PersistedChatEvent): boolean {
-  return (
-    event.eventType === "browser.started" ||
-    event.eventType === "browser.stopped"
-  );
-}
-
 function createSyncRemoteEventsCommand({
   threadId,
   persistentEvents$,
@@ -2332,136 +2218,125 @@ function createSyncRemoteEventsCommand({
   threadId: string;
   persistentEvents$: PersistentChatEvents$;
   hasReachedOldestEvent$: Computed<boolean>;
-  mergePersistentEvents$: Command<void, [PersistedChatEvent[]]>;
+  mergePersistentEvents$: Command<
+    Promise<void>,
+    [PersistedChatEvent[], AbortSignal]
+  >;
   dataSource: ChatThreadRemote;
-}): Command<Promise<void>, [MarkInitialRemoteEventsReady, AbortSignal]> {
-  return command(
-    async (
-      { get, set },
-      markInitialRemoteEventsReady: MarkInitialRemoteEventsReady,
-      signal: AbortSignal,
-    ) => {
-      const mergeEvents = (events: PersistedChatEvent[]): void => {
-        set(mergePersistentEvents$, events);
-      };
-      const persistentEvents = get(persistentEvents$);
-      const accumulatedEvents: PersistedChatEvent[] = [];
-      let mergedEventCount = 0;
-      const latestPersistentEvent = persistentEvents.at(-1);
-      let sinceSeqId = latestPersistentEvent?.event.seqId;
-      let initialPageOldestEvent: PersistedChatEvent | undefined;
-      let browserLifecycleObserved = persistentEvents.some(({ event }) => {
-        return isBrowserLifecycleEvent(event);
+}): Command<Promise<void>, [AbortSignal]> {
+  return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const mergeEvents = async (events: PersistedChatEvent[]): Promise<void> => {
+      await set(mergePersistentEvents$, events, signal);
+      signal.throwIfAborted();
+    };
+    const persistentEvents = get(persistentEvents$);
+    const accumulatedEvents: PersistedChatEvent[] = [];
+    let mergedEventCount = 0;
+    const latestPersistentEvent = persistentEvents.at(-1);
+    let sinceSeqId = latestPersistentEvent?.event.seqId;
+    let initialPageOldestEvent: PersistedChatEvent | undefined;
+
+    async function syncEventsAfter(): Promise<void> {
+      const requestedSinceSeqId = sinceSeqId;
+      const isInitialPage = requestedSinceSeqId === undefined;
+      const events = await set(
+        dataSource.listEventsAfter$,
+        { threadId, sinceSeqId: requestedSinceSeqId },
+        signal,
+      );
+      signal.throwIfAborted();
+      L.debug("syncRemoteMessages$ listEventsAfter result", {
+        threadId,
+        sinceSeqId: requestedSinceSeqId ?? null,
+        gotCount: events.length,
       });
 
-      async function syncEventsAfter(): Promise<void> {
-        const requestedSinceSeqId = sinceSeqId;
-        const isInitialPage = requestedSinceSeqId === undefined;
-        const events = await set(
-          dataSource.listEventsAfter$,
-          { threadId, sinceSeqId: requestedSinceSeqId },
-          signal,
-        );
-        signal.throwIfAborted();
-        L.debug("syncRemoteMessages$ listEventsAfter result", {
-          threadId,
-          sinceSeqId: requestedSinceSeqId ?? null,
-          gotCount: events.length,
-        });
-
-        if (events.length === 0) {
-          return;
-        }
-        browserLifecycleObserved ||= events.some(isBrowserLifecycleEvent);
-
-        await set(writeIndexedDbChatEvents$, threadId, events, signal);
-        signal.throwIfAborted();
-        if (isInitialPage) {
-          initialPageOldestEvent = events[0]!;
-          mergeEvents(events);
-        } else {
-          accumulatedEvents.push(...events);
-        }
-        sinceSeqId = events.at(-1)!.seqId;
-
-        if (
-          requestedSinceSeqId !== undefined &&
-          events.length < CHAT_EVENTS_PAGE_LIMIT
-        ) {
-          return;
-        }
-        return syncEventsAfter();
+      if (events.length === 0) {
+        return;
       }
-      await syncEventsAfter();
-      signal.throwIfAborted();
-      // When IndexedDB supplied the starting cursor, forward catch-up events
-      // were accumulated rather than merged. Apply them before the sidebar
-      // reads the lifecycle projection so cached state cannot win over remote
-      // events that happened later.
-      mergeEvents(accumulatedEvents.slice(mergedEventCount));
-      mergedEventCount = accumulatedEvents.length;
-      markInitialRemoteEventsReady(
-        browserLifecycleObserved || get(hasReachedOldestEvent$),
-      );
 
-      if (!get(hasReachedOldestEvent$)) {
-        const oldestEvent =
-          persistentEvents[0]?.event ??
-          initialPageOldestEvent ??
-          accumulatedEvents[0];
-        if (oldestEvent !== undefined) {
-          let beforeSeqId = oldestEvent.seqId;
-          async function syncEventsBefore(): Promise<void> {
-            const events = await set(
-              dataSource.listEventsBefore$,
-              { threadId, beforeSeqId },
-              signal,
-            );
+      await set(writeIndexedDbChatEvents$, threadId, events, signal);
+      signal.throwIfAborted();
+      if (isInitialPage) {
+        initialPageOldestEvent = events[0]!;
+        await mergeEvents(events);
+      } else {
+        accumulatedEvents.push(...events);
+      }
+      sinceSeqId = events.at(-1)!.seqId;
+
+      if (
+        requestedSinceSeqId !== undefined &&
+        events.length < CHAT_EVENTS_PAGE_LIMIT
+      ) {
+        return;
+      }
+      return syncEventsAfter();
+    }
+    await syncEventsAfter();
+    signal.throwIfAborted();
+    await mergeEvents(accumulatedEvents.slice(mergedEventCount));
+    signal.throwIfAborted();
+    mergedEventCount = accumulatedEvents.length;
+
+    if (!get(hasReachedOldestEvent$)) {
+      const oldestEvent =
+        persistentEvents[0]?.event ??
+        initialPageOldestEvent ??
+        accumulatedEvents[0];
+      if (oldestEvent !== undefined) {
+        let beforeSeqId = oldestEvent.seqId;
+        async function syncEventsBefore(): Promise<void> {
+          const events = await set(
+            dataSource.listEventsBefore$,
+            { threadId, beforeSeqId },
+            signal,
+          );
+          signal.throwIfAborted();
+          L.debug("syncRemoteMessages$ listEventsBefore result", {
+            threadId,
+            beforeSeqId,
+            gotCount: events.length,
+          });
+
+          const oldestInPage = events[0];
+          if (oldestInPage !== undefined) {
+            accumulatedEvents.push(...events);
+            await set(writeIndexedDbChatEvents$, threadId, events, signal);
             signal.throwIfAborted();
-            L.debug("syncRemoteMessages$ listEventsBefore result", {
-              threadId,
-              beforeSeqId,
-              gotCount: events.length,
-            });
-
-            const oldestInPage = events[0];
-            if (oldestInPage !== undefined) {
-              accumulatedEvents.push(...events);
-              await set(writeIndexedDbChatEvents$, threadId, events, signal);
-              signal.throwIfAborted();
-              // Flush periodically so long backfills surface incrementally
-              // (e.g. the history backfill progress bar) instead of appearing
-              // only after every page has been fetched.
-              if (
-                accumulatedEvents.length - mergedEventCount >=
-                HISTORY_BACKFILL_MERGE_BATCH_SIZE
-              ) {
-                mergeEvents(accumulatedEvents.slice(mergedEventCount));
-                mergedEventCount = accumulatedEvents.length;
-              }
-            }
-
-            // A thread's first event always carries seqId 1, so reaching it is
-            // the only stop condition for walking history backwards. An empty
-            // page leaves no usable cursor, which also ends the walk.
+            // Flush periodically so long backfills surface incrementally
+            // (e.g. the history backfill skeleton) instead of appearing
+            // only after every page has been fetched.
             if (
-              oldestInPage === undefined ||
-              oldestInPage.seqId <= FIRST_CHAT_EVENT_SEQ_ID
+              accumulatedEvents.length - mergedEventCount >=
+              HISTORY_BACKFILL_MERGE_BATCH_SIZE
             ) {
-              return;
+              await mergeEvents(accumulatedEvents.slice(mergedEventCount));
+              signal.throwIfAborted();
+              mergedEventCount = accumulatedEvents.length;
             }
-
-            beforeSeqId = oldestInPage.seqId;
-
-            return syncEventsBefore();
           }
-          await syncEventsBefore();
+
+          // A thread's first event always carries seqId 1, so reaching it is
+          // the only stop condition for walking history backwards. An empty
+          // page leaves no usable cursor, which also ends the walk.
+          if (
+            oldestInPage === undefined ||
+            oldestInPage.seqId <= FIRST_CHAT_EVENT_SEQ_ID
+          ) {
+            return;
+          }
+
+          beforeSeqId = oldestInPage.seqId;
+
+          return syncEventsBefore();
         }
+        await syncEventsBefore();
       }
-      signal.throwIfAborted();
-      mergeEvents(accumulatedEvents.slice(mergedEventCount));
-    },
-  );
+    }
+    signal.throwIfAborted();
+    await mergeEvents(accumulatedEvents.slice(mergedEventCount));
+  });
 }
 
 function createActiveGoalObjectiveComputed(
@@ -2603,67 +2478,53 @@ function createBodyBlocksRenderer({
   };
 }
 
-function createInitializeIndexedDbEvents({
+function createIndexedDbEventCacheSignals({
   artifactCardSignals,
   agentReferenceSignals,
   threadId,
   persistentEvents$,
   registerBodyBlocks,
-  scroll,
 }: {
   artifactCardSignals: ArtifactCardSignalsRegistry;
   agentReferenceSignals: AgentReferenceSignalsRegistry;
   threadId: string;
   persistentEvents$: PersistentChatEvents$;
   registerBodyBlocks: BodyBlocksRenderer;
-  scroll: {
-    threadScrollPosition$: Computed<ThreadScrollPosition | null>;
-    requestScrollAfterRender$: Command<void, [ThreadScrollPosition | null]>;
-  };
 }) {
-  const initialized = Promise.withResolvers<void>();
-  const mergeIndexedDbEvents$ = command(
-    ({ get, set }, events: PersistedChatEvent[]): void => {
-      if (events.length === 0) {
-        return;
-      }
-      const scrollPosition = get(scroll.threadScrollPosition$);
-      const registeredEvents = events.map((event) => {
-        return registerChatEvent(
-          event,
-          registerBodyBlocks,
-          artifactCardSignals,
-          agentReferenceSignals,
-        );
-      });
-      set(persistentEvents$, (previous) => {
-        return mergeRegisteredEvents([previous, registeredEvents]);
-      });
-      set(scroll.requestScrollAfterRender$, scrollPosition);
-    },
-  );
-
-  const initializeIndexedDbEvents$ = command(
+  const indexedDbEventsLoading$ = state(true);
+  const loadIndexedDbEventsIntoPersistentEvents$ = command(
     async ({ set }, signal: AbortSignal): Promise<void> => {
       const result = await settle(
         set(loadIndexedDbChatEvents$, threadId, signal),
         signal,
       );
-      if (result.ok) {
-        set(mergeIndexedDbEvents$, result.value);
-      }
-      initialized.resolve(undefined);
       if (!result.ok) {
+        set(indexedDbEventsLoading$, false);
         throw result.error;
       }
+      if (result.value.length > 0) {
+        const registeredEvents = result.value.map((event) => {
+          return registerChatEvent(
+            event,
+            registerBodyBlocks,
+            artifactCardSignals,
+            agentReferenceSignals,
+          );
+        });
+        set(persistentEvents$, (previous) => {
+          return mergeRegisteredEvents([previous, registeredEvents]);
+        });
+      }
+      set(indexedDbEventsLoading$, false);
+      signal.throwIfAborted();
     },
   );
 
   return {
-    indexedDbEventsInitialized$: computed(() => {
-      return initialized.promise;
+    indexedDbEventsLoading$: computed((get) => {
+      return get(indexedDbEventsLoading$);
     }),
-    initializeIndexedDbEvents$,
+    loadIndexedDbEventsIntoPersistentEvents$,
   };
 }
 
@@ -2677,60 +2538,25 @@ function createMailDraftCardSignalsById(
   });
 }
 
-function createEventHistoryBackfillProgress(
-  hasReachedOldestEvent$: Computed<boolean>,
+function createEventHistoryBackfillPending(
   persistentEvents$: PersistentChatEvents$,
-): Computed<Promise<number | null>> {
-  // Approximate backfill progress from the loaded seqId range. The thread's
-  // true max seqId is not exposed to the client, so the newest loaded event
-  // stands in for it. The reached-oldest computed hides progress once the
-  // first persistent seqId is 1. Null hides the loading skeleton.
-  return computed((get): Promise<number | null> => {
-    if (get(hasReachedOldestEvent$)) {
-      return Promise.resolve(null);
-    }
-    const events = get(persistentEvents$);
-    const first = events[0];
-    const last = events.at(-1);
-    if (first === undefined || last === undefined) {
-      return Promise.resolve(null);
-    }
-    return Promise.resolve(
-      (last.event.seqId - first.event.seqId) / last.event.seqId,
-    );
+): Computed<boolean> {
+  return computed((get): boolean => {
+    const first = get(persistentEvents$)[0];
+    return first !== undefined && first.event.seqId !== FIRST_CHAT_EVENT_SEQ_ID;
   });
-}
-
-function createBrowserLifecycleOptimisticEvents(
-  threadId: string,
-): BrowserLifecycleOptimisticEvents {
-  return {
-    append$: command(({ set }, { eventId, eventType }): void => {
-      set(
-        appendOptimisticChatEvent$,
-        createOptimisticChatEventEntry({
-          threadId,
-          event: {
-            id: eventId,
-            threadId,
-            eventType,
-            content: null,
-            createdAt: nowDate().toISOString(),
-          },
-        }),
-      );
-    }),
-  };
 }
 
 function createPagedEventResources(
   threadId: string,
   previewImageUrlsByUrl$: Computed<Promise<ReadonlyMap<string, string>>>,
+  browserLifecycleOptimisticEvents: BrowserLifecycleOptimisticEvents,
+  initialOptimisticEntries: readonly OptimisticChatEventEntry[],
 ) {
   const mailDraftCardSignals = createMailDraftCardSignalsRegistry(threadId);
   const browserSessionCardSignals = createBrowserSessionCardSignalsRegistry(
     threadId,
-    createBrowserLifecycleOptimisticEvents(threadId),
+    browserLifecycleOptimisticEvents,
   );
   const artifactCardSignals = createArtifactCardSignalsRegistry(
     previewImageUrlsByUrl$,
@@ -2748,161 +2574,283 @@ function createPagedEventResources(
     browserSessionCardSignals,
   });
   const registerBodyBlocks = bodyBlocksRenderer("register");
+  const registerOptimisticEventResources = (
+    entry: OptimisticChatEventEntry,
+  ): void => {
+    registerBodyBlocks(entry.parsedBodyBlocks);
+    registerEventAttachments(entry.event, artifactCardSignals);
+    registerEventAgentReferences(entry.event, agentReferenceSignals);
+  };
+  for (const entry of initialOptimisticEntries) {
+    registerOptimisticEventResources(entry);
+  }
   return {
     agentReferenceSignals,
     artifactCardSignals,
-    browserSessionCardSignals,
     mailDraftCardSignals,
-    registerBodyBlocks,
-    registerOptimisticEventResources(entry: OptimisticChatEventEntry): void {
-      registerBodyBlocks(entry.parsedBodyBlocks);
-      registerEventAttachments(entry.event, artifactCardSignals);
-      registerEventAgentReferences(entry.event, agentReferenceSignals);
+    publicSignals: {
+      reloadMailDrafts$: mailDraftCardSignals.reload$,
+      browserSessionSignals: browserSessionCardSignals.browser,
+      subscribeBrowserSessions$: browserSessionCardSignals.subscribe$,
+      artifactSignalsForUrl: (url: string): ArtifactSignals | undefined => {
+        return artifactCardSignals.find(url);
+      },
+      agentReferenceSignalsForId: (agentId: string) => {
+        return agentReferenceSignals.resolve(agentId);
+      },
     },
+    registerBodyBlocks,
+    registerOptimisticEventResources,
     resolveBodyBlocks: bodyBlocksRenderer("resolve"),
   };
 }
 
 type OptimisticScrollBehavior = "preserve" | "bottom";
 type AppendOptimisticEventCommand = Command<
-  void,
-  [OptimisticChatEventInput, OptimisticScrollBehavior]
+  Promise<void>,
+  [OptimisticChatEventInput, OptimisticScrollBehavior, AbortSignal]
 >;
+
+interface BrowserLifecycleOptimisticEvent {
+  readonly eventId: string;
+  readonly eventType: "browser.started" | "browser.stopped";
+}
+
+function browserLifecycleOptimisticEventInput(
+  threadId: string,
+  { eventId, eventType }: BrowserLifecycleOptimisticEvent,
+): OptimisticChatEventInput {
+  return {
+    threadId,
+    event: {
+      id: eventId,
+      threadId,
+      eventType,
+      content: null,
+      createdAt: nowDate().toISOString(),
+    },
+  };
+}
+
+function createPagedEventProjections({
+  persistentEvents$,
+  optimisticEvents$,
+  resolveBodyBlocks,
+  mailDraftCardSignals,
+}: {
+  persistentEvents$: PersistentChatEvents$;
+  optimisticEvents$: Computed<OptimisticChatEventEntry[]>;
+  resolveBodyBlocks: BodyBlocksRenderer;
+  mailDraftCardSignals: MailDraftCardSignalsRegistry;
+}) {
+  const rawEvents$ = createRawEventsComputed({
+    persistentEvents$,
+    optimisticEvents$,
+    resolveBodyBlocks,
+  });
+  const hasReachedOldestEvent$ = computed((get): boolean => {
+    return get(persistentEvents$)[0]?.event.seqId === FIRST_CHAT_EVENT_SEQ_ID;
+  });
+  const historyBackfillPending$ =
+    createEventHistoryBackfillPending(persistentEvents$);
+  const semanticEvents$ = computed((get): SemanticChatEvent[] => {
+    return semanticTranscriptEventsFromRaw(get(rawEvents$));
+  });
+  const eventRunIndicatorState$ = createEventRunIndicatorState(rawEvents$);
+  return {
+    hasReachedOldestEvent$,
+    rawEvents$,
+    historyBackfillPending$,
+    eventRunIndicatorState$,
+    activeGoalObjective$: createActiveGoalObjectiveComputed(rawEvents$),
+    mailDraftCardSignalsById$: createMailDraftCardSignalsById(
+      rawEvents$,
+      mailDraftCardSignals,
+    ),
+    ...createLatestEventSignals(rawEvents$),
+    ...createEventSemanticSignals(semanticEvents$, eventRunIndicatorState$),
+    ...createRenderedChatGroups(semanticEvents$),
+  };
+}
+
+function createEventChangeEffects(
+  threadId: string,
+  rawEvents$: Computed<ChatEventProjectionEntry[]>,
+) {
+  const scroll = createChatThreadScrollSignals(threadId);
+  const sidebar = createThreadSidebarSignals(threadId);
+  const sidebarAutoOpenCandidate$ =
+    createThreadSidebarAutoOpenCandidate(rawEvents$);
+  const autoOpenSidebar$ = command(
+    ({ get, set }, signal: AbortSignal): void => {
+      signal.throwIfAborted();
+      if (
+        !get(chatThreadSidebarAutoOpenEnabled$) ||
+        !get(zeroBrowserEnabled$) ||
+        typeof window === "undefined" ||
+        !window.matchMedia(CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY).matches
+      ) {
+        return;
+      }
+      const candidate = get(sidebarAutoOpenCandidate$);
+      if (
+        !candidate ||
+        get(sidebar.target$) !== null ||
+        get(activeThreadSidebar$) !== null
+      ) {
+        return;
+      }
+      const candidateKey = threadSidebarAutoOpenCandidateKey(candidate);
+      if (!set(sidebar.claimAutoOpenCandidate$, candidateKey)) {
+        return;
+      }
+      set(sidebar.open$, { type: "browser" });
+    },
+  );
+  const afterEventsChange$ = command(
+    async (
+      { set },
+      scrollPosition: ThreadScrollPosition | null,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      await Promise.all([
+        set(autoOpenSidebar$, signal),
+        set(scroll.autoScroll$, scrollPosition, signal),
+      ]);
+      signal.throwIfAborted();
+    },
+  );
+  return { scroll, sidebar, afterEventsChange$ };
+}
 
 function createPagedEvents(
   threadId: string,
   dataSource: ChatThreadRemote,
   initialOptimisticEntries: readonly OptimisticChatEventEntry[],
   previewImageUrlsByUrl$: Computed<Promise<ReadonlyMap<string, string>>>,
-  scroll: {
-    threadScrollPosition$: Computed<ThreadScrollPosition | null>;
-    requestScrollAfterRender$: Command<void, [ThreadScrollPosition | null]>;
-  },
 ) {
-  const {
-    agentReferenceSignals,
-    artifactCardSignals,
-    browserSessionCardSignals,
-    mailDraftCardSignals,
-    registerBodyBlocks,
-    registerOptimisticEventResources,
-    resolveBodyBlocks,
-  } = createPagedEventResources(threadId, previewImageUrlsByUrl$);
-
-  for (const entry of initialOptimisticEntries) {
-    registerOptimisticEventResources(entry);
-  }
   const persistentChatEvents$ = state<RegisteredChatEvent[]>([]);
-  const hasReachedOldestEvent$ = computed((get): boolean => {
-    return (
-      get(persistentChatEvents$)[0]?.event.seqId === FIRST_CHAT_EVENT_SEQ_ID
-    );
-  });
   const optimisticEvents$ = createOptimisticChatEventsForThread(threadId);
-  const appendOptimisticEvent$ = command(
-    (
+  const browserLifecycleOptimisticEvents: BrowserLifecycleOptimisticEvents = {
+    append$: command(
+      async (
+        { set },
+        event: BrowserLifecycleOptimisticEvent,
+        signal: AbortSignal,
+      ): Promise<void> => {
+        await set(
+          appendOptimisticEvent$,
+          browserLifecycleOptimisticEventInput(threadId, event),
+          "preserve",
+          signal,
+        );
+      },
+    ),
+  };
+  const resources = createPagedEventResources(
+    threadId,
+    previewImageUrlsByUrl$,
+    browserLifecycleOptimisticEvents,
+    initialOptimisticEntries,
+  );
+
+  const projections = createPagedEventProjections({
+    persistentEvents$: persistentChatEvents$,
+    optimisticEvents$,
+    resolveBodyBlocks: resources.resolveBodyBlocks,
+    mailDraftCardSignals: resources.mailDraftCardSignals,
+  });
+  const effects = createEventChangeEffects(threadId, projections.rawEvents$);
+  const appendOptimisticEvent$: AppendOptimisticEventCommand = command(
+    async (
       { get, set },
       input: OptimisticChatEventInput,
       scrollBehavior: OptimisticScrollBehavior,
-    ): void => {
+      signal: AbortSignal,
+    ): Promise<void> => {
       const scrollPosition =
         scrollBehavior === "preserve"
-          ? get(scroll.threadScrollPosition$)
+          ? get(effects.scroll.threadScrollPosition$)
           : null;
       const entry = createOptimisticChatEventEntry(input);
-      registerOptimisticEventResources(entry);
+      resources.registerOptimisticEventResources(entry);
       set(appendOptimisticChatEvent$, entry);
-      set(scroll.requestScrollAfterRender$, scrollPosition);
+      await set(effects.afterEventsChange$, scrollPosition, signal);
     },
   );
-
-  const rawEvents$ = createRawEventsComputed({
-    persistentEvents$: persistentChatEvents$,
-    optimisticEvents$,
-    resolveBodyBlocks,
-  });
-  const sidebarAutoOpenCandidate$ =
-    createThreadSidebarAutoOpenCandidate(rawEvents$);
-  const historyBackfillProgress$ = createEventHistoryBackfillProgress(
-    hasReachedOldestEvent$,
-    persistentChatEvents$,
-  );
-  const semanticEvents$ = computed((get): SemanticChatEvent[] => {
-    return semanticTranscriptEventsFromRaw(get(rawEvents$));
-  });
-  const eventRunIndicatorState$ = createEventRunIndicatorState(rawEvents$);
-  const semanticSignals = createEventSemanticSignals(
-    semanticEvents$,
-    eventRunIndicatorState$,
-  );
-  const eventSync = createEventSyncSignals(semanticSignals.hasEvents$);
-
-  // The thread's active goal, folded from lifecycle control events so the
-  // composer reads it without polling a separate resource. Reads rawEvents$
-  // because goal markers are control rows, not transcript rows.
-  const activeGoalObjective$ = createActiveGoalObjectiveComputed(rawEvents$);
-
-  const renderedGroups = createRenderedChatGroups(semanticEvents$);
-
-  const mailDraftCardSignalsById$ = createMailDraftCardSignalsById(
-    rawEvents$,
-    mailDraftCardSignals,
-  );
-  const mergePersistentEvents$ = createMergePersistentEvents({
+  const indexedDbEventCache = createIndexedDbEventCacheSignals({
+    artifactCardSignals: resources.artifactCardSignals,
+    agentReferenceSignals: resources.agentReferenceSignals,
     threadId,
     persistentEvents$: persistentChatEvents$,
-    registerBodyBlocks,
-    artifactCardSignals,
-    agentReferenceSignals,
-    scroll,
+    registerBodyBlocks: resources.registerBodyBlocks,
   });
-  const indexedDbEvents = createInitializeIndexedDbEvents({
-    artifactCardSignals,
-    agentReferenceSignals,
+  const mergePersistentEvents$ = command(
+    async (
+      { get, set },
+      events: PersistedChatEvent[],
+      signal: AbortSignal,
+    ): Promise<void> => {
+      if (events.length === 0) {
+        return;
+      }
+      const scrollPosition = get(effects.scroll.threadScrollPosition$);
+      const registeredEvents = registerPersistentEvents({
+        persistentEvents: get(persistentChatEvents$),
+        events,
+        registerBodyBlocks: resources.registerBodyBlocks,
+        artifactCardSignals: resources.artifactCardSignals,
+        agentReferenceSignals: resources.agentReferenceSignals,
+      });
+      set(persistentChatEvents$, (previous) => {
+        return mergeRegisteredEvents([previous, registeredEvents]);
+      });
+      set(reconcileOptimisticChatEvents$, { threadId, events });
+      await set(effects.afterEventsChange$, scrollPosition, signal);
+      signal.throwIfAborted();
+    },
+  );
+  const initializeIndexedDbEvents$ = command(
+    async ({ get, set }, signal: AbortSignal): Promise<void> => {
+      const scrollPosition = get(effects.scroll.threadScrollPosition$);
+      const result = await settle(
+        set(
+          indexedDbEventCache.loadIndexedDbEventsIntoPersistentEvents$,
+          signal,
+        ),
+        signal,
+      );
+      if (!result.ok) {
+        set(effects.sidebar.enableEntryAnimations$);
+        throw result.error;
+      }
+      const afterEventsChangePromise =
+        get(projections.rawEvents$).length === 0
+          ? Promise.resolve()
+          : set(effects.afterEventsChange$, scrollPosition, signal);
+      set(effects.sidebar.enableEntryAnimations$);
+      await afterEventsChangePromise;
+      signal.throwIfAborted();
+    },
+  );
+  const syncRemoteEvents$ = createSyncRemoteEventsCommand({
     threadId,
     persistentEvents$: persistentChatEvents$,
-    registerBodyBlocks,
-    scroll,
-  });
-
-  const latestEventSignals = createLatestEventSignals(rawEvents$);
-
-  const runSyncRemoteEvents$ = createSyncRemoteEventsCommand({
-    threadId,
-    persistentEvents$: persistentChatEvents$,
-    hasReachedOldestEvent$,
+    hasReachedOldestEvent$: projections.hasReachedOldestEvent$,
     mergePersistentEvents$,
     dataSource,
   });
-  const syncRemoteEvents$ = createTrackedEventSyncCommand(
-    runSyncRemoteEvents$,
-    eventSync.trackEventSync$,
-  );
 
   return {
-    ...indexedDbEvents,
+    scroll: effects.scroll,
+    sidebar: effects.sidebar,
+    indexedDbEventsLoading$: indexedDbEventCache.indexedDbEventsLoading$,
+    initializeIndexedDbEvents$,
     mergePersistentEvents$,
-    ...latestEventSignals,
-    appendOptimisticEvent$,
-    ...semanticSignals,
-    ...eventSync,
-    ...renderedGroups,
-    rawEvents$,
-    sidebarAutoOpenCandidate$,
-    historyBackfillProgress$,
-    eventRunIndicatorState$,
-    activeGoalObjective$,
-    mailDraftCardSignalsById$,
-    reloadMailDrafts$: mailDraftCardSignals.reload$,
-    browserSessionSignals: browserSessionCardSignals.browser,
-    subscribeBrowserSessions$: browserSessionCardSignals.subscribe$,
-    artifactSignalsForUrl: (url: string): ArtifactSignals | undefined => {
-      return artifactCardSignals.find(url);
-    },
-    agentReferenceSignalsForId: (agentId: string) => {
-      return agentReferenceSignals.resolve(agentId);
-    },
     syncRemoteEvents$,
+    appendOptimisticEvent$,
+    ...projections,
+    ...resources.publicSignals,
   };
 }
 
@@ -2910,17 +2858,11 @@ function createChatThreadEventPipeline({
   threadId,
   dataSource,
   initialOptimisticEntries,
-  threadScrollPosition$,
-  requestScrollAfterRender$,
-  awayFromBottom$,
   previewImageUrlsByUrl$,
 }: {
   threadId: string;
   dataSource: ChatThreadRemote;
   initialOptimisticEntries: readonly OptimisticChatEventEntry[];
-  threadScrollPosition$: Computed<ThreadScrollPosition | null>;
-  requestScrollAfterRender$: Command<void, [ThreadScrollPosition | null]>;
-  awayFromBottom$: Computed<boolean>;
   previewImageUrlsByUrl$: Computed<Promise<ReadonlyMap<string, string>>>;
 }) {
   const pagedEvents = createPagedEvents(
@@ -2928,21 +2870,29 @@ function createChatThreadEventPipeline({
     dataSource,
     initialOptimisticEntries,
     previewImageUrlsByUrl$,
-    { threadScrollPosition$, requestScrollAfterRender$ },
   );
   const renderWindow = createChatRenderWindow({
     threadId,
     allRenderedChatGroups$: pagedEvents.allRenderedChatGroups$,
-    threadScrollPosition$,
-    awayFromBottom$,
+    threadScrollPosition$: pagedEvents.scroll.threadScrollPosition$,
+    awayFromBottom$: pagedEvents.scroll.awayFromBottom$,
   });
 
-  const loadMoreRenderedChatGroups$ =
-    createLoadMoreRenderedChatGroupsWithPrependScroll(
-      threadScrollPosition$,
-      requestScrollAfterRender$,
-      renderWindow.loadMoreRenderedChatGroups$,
-    );
+  const loadMoreRenderedChatGroups$ = command(
+    async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
+      const scrollPosition = get(pagedEvents.scroll.threadScrollPosition$);
+      const didPrepend = await set(
+        renderWindow.loadMoreRenderedChatGroups$,
+        signal,
+      );
+      signal.throwIfAborted();
+      if (didPrepend) {
+        await set(pagedEvents.scroll.autoScroll$, scrollPosition, signal);
+        signal.throwIfAborted();
+      }
+      return didPrepend;
+    },
+  );
   return {
     ...pagedEvents,
     ...renderWindow,
@@ -3019,22 +2969,6 @@ function createEventRunIndicatorState(
   });
 }
 
-function createLoadMoreRenderedChatGroupsWithPrependScroll(
-  threadScrollPosition$: Computed<ThreadScrollPosition | null>,
-  requestScrollAfterRender$: Command<void, [ThreadScrollPosition | null]>,
-  loadMoreRenderedChatGroups$: Command<Promise<boolean>, [AbortSignal]>,
-) {
-  return command(async ({ get, set }, signal: AbortSignal) => {
-    const scrollPosition = get(threadScrollPosition$);
-    const didPrepend = await set(loadMoreRenderedChatGroups$, signal);
-    signal.throwIfAborted();
-    if (didPrepend) {
-      set(requestScrollAfterRender$, scrollPosition);
-    }
-    return didPrepend;
-  });
-}
-
 // ---------------------------------------------------------------------------
 // Factory: createRunTracking
 // ---------------------------------------------------------------------------
@@ -3043,9 +2977,11 @@ interface RunTrackingDeps {
   threadId: string;
   latestRunFinishCreatedAt$: Computed<Promise<string | undefined>>;
   initializeIndexedDbEvents$: Command<Promise<void>, [AbortSignal]>;
-  mergePersistentEvents$: Command<void, [PersistedChatEvent[]]>;
+  mergePersistentEvents$: Command<
+    Promise<void>,
+    [PersistedChatEvent[], AbortSignal]
+  >;
   syncRemoteEvents$: Command<Promise<void>, [AbortSignal]>;
-  settleEventSync$: Command<Promise<void>, []>;
   reloadArtifacts$: Command<void, []>;
   reloadMailDrafts$: Command<void, []>;
   subscribeBrowserSessions$: Command<Promise<void>, [AbortSignal]>;
@@ -3285,7 +3221,6 @@ function createMarkThreadReadIfNeeded({
 function createOnSubscribedCommand({
   threadId,
   syncRemoteEvents$,
-  settleEventSync$,
   reloadArtifacts$,
   reloadMailDrafts$,
   reloadComposerWorkflows$,
@@ -3295,7 +3230,6 @@ function createOnSubscribedCommand({
   RunTrackingDeps,
   | "threadId"
   | "syncRemoteEvents$"
-  | "settleEventSync$"
   | "reloadArtifacts$"
   | "reloadMailDrafts$"
   | "reloadComposerWorkflows$"
@@ -3315,13 +3249,14 @@ function createOnSubscribedCommand({
     } else {
       set(hasSubscribed$, true);
     }
-    await Promise.all([
+    const catchUpPromises = [
       get(dataSource.cancellationRecoveryPending$),
       set(reloadComposerWorkflows$, signal),
-      get(optimisticCreateUnsettled$)
-        ? set(settleEventSync$)
-        : set(syncRemoteEvents$, signal),
-    ]);
+    ];
+    if (!get(optimisticCreateUnsettled$)) {
+      catchUpPromises.push(set(syncRemoteEvents$, signal));
+    }
+    await Promise.all(catchUpPromises);
     signal.throwIfAborted();
     await set(markThreadReadIfNeeded$, signal);
     signal.throwIfAborted();
@@ -3347,7 +3282,8 @@ function createReceiveSyncedEventsCommand({
         threadId,
         count: events.length,
       });
-      set(mergePersistentEvents$, events);
+      await set(mergePersistentEvents$, events, signal);
+      signal.throwIfAborted();
       await set(markThreadReadIfNeeded$, signal);
       signal.throwIfAborted();
     },
@@ -3360,7 +3296,6 @@ function createRunTracking({
   initializeIndexedDbEvents$,
   mergePersistentEvents$,
   syncRemoteEvents$,
-  settleEventSync$,
   reloadArtifacts$,
   reloadMailDrafts$,
   subscribeBrowserSessions$,
@@ -3386,7 +3321,6 @@ function createRunTracking({
   const onSubscribed$ = createOnSubscribedCommand({
     threadId,
     syncRemoteEvents$,
-    settleEventSync$,
     reloadArtifacts$,
     reloadMailDrafts$,
     reloadComposerWorkflows$,
@@ -3609,7 +3543,7 @@ function createAppendOptimisticSendEvent(
   appendOptimisticEvent$: AppendOptimisticEventCommand,
 ) {
   return command(
-    (
+    async (
       { set },
       args: {
         readonly threadId: string;
@@ -3622,14 +3556,15 @@ function createAppendOptimisticSendEvent(
         readonly userMessage: UserMessageDocument;
         readonly options: SendMessageOptions | undefined;
       },
-    ) => {
+      signal: AbortSignal,
+    ): Promise<void> => {
       set(touchOptimisticChatThreadSort$, {
         id: args.chatThreadSortEventId,
         threadId: args.threadId,
         agentId: args.agentId,
         createdAt: args.createdAt,
       });
-      set(
+      await set(
         appendOptimisticEvent$,
         createSendOptimisticEventEntry({
           threadId: args.threadId,
@@ -3641,7 +3576,9 @@ function createAppendOptimisticSendEvent(
           options: args.options,
         }),
         "bottom",
+        signal,
       );
+      signal.throwIfAborted();
     },
   );
 }
@@ -3787,17 +3724,22 @@ function createPerformSendMessage(deps: SendMessageDeps) {
       const clientEventId = crypto.randomUUID();
       const chatThreadSortEventId = crypto.randomUUID();
       const createdAt = nowDate().toISOString();
-      set(appendOptimisticSendEvent$, {
-        threadId,
-        agentId: request.agentId,
-        clientEventId,
-        chatThreadSortEventId,
-        createdAt,
-        result,
-        generationTemplate,
-        userMessage,
-        options: request.options,
-      });
+      await set(
+        appendOptimisticSendEvent$,
+        {
+          threadId,
+          agentId: request.agentId,
+          clientEventId,
+          chatThreadSortEventId,
+          createdAt,
+          result,
+          generationTemplate,
+          userMessage,
+          options: request.options,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
       const runId = await set(
         postSendMessage$,
         {
@@ -3956,7 +3898,7 @@ function createQueueMessage(deps: QueueMessageDeps) {
         agentId,
         createdAt: nowIso,
       });
-      set(
+      await set(
         appendOptimisticEvent$,
         {
           threadId,
@@ -3973,7 +3915,9 @@ function createQueueMessage(deps: QueueMessageDeps) {
           },
         },
         "bottom",
+        signal,
       );
+      signal.throwIfAborted();
 
       const { runOptions, realAgentInPreviewEnabled } = queueRuntimeOptions(
         features,
@@ -4046,7 +3990,7 @@ function createRecallMessage(deps: RecallMessageDeps) {
     }
 
     const clientEventId = crypto.randomUUID();
-    set(
+    await set(
       appendOptimisticEvent$,
       {
         threadId,
@@ -4060,7 +4004,9 @@ function createRecallMessage(deps: RecallMessageDeps) {
         },
       },
       "preserve",
+      signal,
     );
+    signal.throwIfAborted();
     const userMessage = event.userMessage;
     const templatePart = userMessage.parts.find((part) => {
       return part.type === "template";
@@ -4122,7 +4068,7 @@ function createSkipAutomationEvent({
       }
 
       const clientEventId = crypto.randomUUID();
-      set(
+      await set(
         appendOptimisticEvent$,
         {
           threadId,
@@ -4136,7 +4082,9 @@ function createSkipAutomationEvent({
           },
         },
         "preserve",
+        signal,
       );
+      signal.throwIfAborted();
       await set(
         dataSource.recallEvent$,
         {
@@ -4206,24 +4154,28 @@ function createCancelRunWithQueuedRecall({
     const queuedEvents = queuedEventsFromRaw(raw).filter((event) => {
       return event.eventType === "input.prompt";
     });
+    const optimisticAppendPromises: Promise<void>[] = [];
 
     const interruptRequests = cancellableRunIdsFromRawEvents(raw).map(
       (runId) => {
         const clientEventId = crypto.randomUUID();
-        set(
-          appendOptimisticEvent$,
-          {
-            threadId,
-            event: {
-              id: clientEventId,
+        optimisticAppendPromises.push(
+          set(
+            appendOptimisticEvent$,
+            {
               threadId,
-              eventType: "control.interrupt",
-              content: null,
-              interruptsRunId: runId,
-              createdAt: nowDate().toISOString(),
+              event: {
+                id: clientEventId,
+                threadId,
+                eventType: "control.interrupt",
+                content: null,
+                interruptsRunId: runId,
+                createdAt: nowDate().toISOString(),
+              },
             },
-          },
-          "preserve",
+            "preserve",
+            signal,
+          ),
         );
         return { runId, clientEventId };
       },
@@ -4231,20 +4183,23 @@ function createCancelRunWithQueuedRecall({
 
     const recallRequests = queuedEvents.map((event) => {
       const clientEventId = crypto.randomUUID();
-      set(
-        appendOptimisticEvent$,
-        {
-          threadId,
-          event: {
-            id: clientEventId,
+      optimisticAppendPromises.push(
+        set(
+          appendOptimisticEvent$,
+          {
             threadId,
-            eventType: "control.revoke",
-            content: null,
-            revokesEventId: event.id,
-            createdAt: nowDate().toISOString(),
+            event: {
+              id: clientEventId,
+              threadId,
+              eventType: "control.revoke",
+              content: null,
+              revokesEventId: event.id,
+              createdAt: nowDate().toISOString(),
+            },
           },
-        },
-        "preserve",
+          "preserve",
+          signal,
+        ),
       );
       return {
         threadId,
@@ -4255,6 +4210,7 @@ function createCancelRunWithQueuedRecall({
     });
 
     await Promise.all([
+      Promise.all(optimisticAppendPromises),
       set(
         dataSource.cancelRuns$,
         {
@@ -4709,19 +4665,13 @@ function publicChatThreadEventSignals(
     latestAssistantTextCreatedAt$: events.latestAssistantTextCreatedAt$,
     visibleRenderedChatGroups$: events.visibleRenderedChatGroups$,
     visibleRenderedChatGroupsReady$: events.visibleRenderedChatGroupsReady$,
-    indexedDbEventsInitialized$: events.indexedDbEventsInitialized$,
-    sidebarAutoOpenCandidate$: events.sidebarAutoOpenCandidate$,
+    indexedDbEventsLoading$: events.indexedDbEventsLoading$,
     eventImageGroups$: events.eventImageGroups$,
     artifactSignalsForUrl: events.artifactSignalsForUrl,
     agentReferenceSignalsForId: events.agentReferenceSignalsForId,
     mailDraftCardSignalsById$: events.mailDraftCardSignalsById$,
     browserSessionSignals: events.browserSessionSignals,
     hasEvents$: events.hasEvents$,
-    hasNewEvents$: events.hasNewEvents$,
-    initialRemoteEventsReady$: events.initialRemoteEventsReady$,
-    initialBrowserLifecycleAuthoritative$:
-      events.initialBrowserLifecycleAuthoritative$,
-    initialRemoteEventsComplete$: events.initialRemoteEventsComplete$,
     hasQueuedEvents$: events.hasQueuedEvents$,
     queuedEventItems$: events.queuedEventItems$,
     emptyQueuedEventItems$: events.emptyQueuedEventItems$,
@@ -4729,7 +4679,7 @@ function publicChatThreadEventSignals(
     thinkingEventId$: events.thinkingEventId$,
     thinkingText$: events.thinkingText$,
     recommendedFollowupSource$: events.recommendedFollowupSource$,
-    historyBackfillProgress$: events.historyBackfillProgress$,
+    historyBackfillPending$: events.historyBackfillPending$,
     activeGoalObjective$: events.activeGoalObjective$,
     donePhrase$: events.donePhrase$,
     loadMoreRenderedChatGroups$: events.loadMoreRenderedChatGroups$,
@@ -4788,7 +4738,6 @@ export function createChatThreadSignals(
     threadMeta$,
     dataSource,
   );
-  const scroll = createChatThreadScrollSignals(threadId);
   const container = createChatThreadContainerSignals();
   const composerFileInput = createComposerFileInput();
   const threadOwned = createThreadOwnedSignals(threadId, threadMeta$);
@@ -4807,9 +4756,6 @@ export function createChatThreadSignals(
     threadId,
     dataSource,
     initialOptimisticEntries,
-    threadScrollPosition$: scroll.threadScrollPosition$,
-    requestScrollAfterRender$: scroll.requestScrollAfterRender$,
-    awayFromBottom$: scroll.awayFromBottom$,
     previewImageUrlsByUrl$,
   });
   const { queueDraftSync$, cancelDraftSync$, flushDraftClear$ } =
@@ -4821,7 +4767,6 @@ export function createChatThreadSignals(
     initializeIndexedDbEvents$: events.initializeIndexedDbEvents$,
     mergePersistentEvents$: events.mergePersistentEvents$,
     syncRemoteEvents$: events.syncRemoteEvents$,
-    settleEventSync$: events.settleEventSync$,
     reloadArtifacts$: artifact.reloadArtifacts$,
     reloadMailDrafts$: events.reloadMailDrafts$,
     subscribeBrowserSessions$: events.subscribeBrowserSessions$,
@@ -4860,17 +4805,18 @@ export function createChatThreadSignals(
     ...messageActions,
     ...assistantErrorRecovery,
     composerSendButtonStatus$: composerSendButton.composerSendButtonStatus$,
-    scrollContainerOnRef$: scroll.scrollContainerOnRef$,
-    threadScrollPosition$: scroll.threadScrollPosition$,
-    awayFromBottom$: scroll.awayFromBottom$,
-    scrollTo$: scroll.scrollTo$,
-    scrollToTop$: scroll.scrollToTop$,
-    scrollToBottom$: scroll.scrollToBottom$,
+    scrollContainerOnRef$: events.scroll.scrollContainerOnRef$,
+    threadScrollPosition$: events.scroll.threadScrollPosition$,
+    awayFromBottom$: events.scroll.awayFromBottom$,
+    scrollTo$: events.scroll.scrollTo$,
+    scrollToTop$: events.scroll.scrollToTop$,
+    scrollToBottom$: events.scroll.scrollToBottom$,
     ...container,
     draft,
     ...composer,
     ...composerFileInput,
     ...threadOwned,
+    sidebar: events.sidebar,
     queueDraftSync$,
     ...publicChatThreadEventSignals(events),
     receiveSyncedEvents$: runTracking.receiveSyncedEvents$,

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar-auto-open.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar-auto-open.ts
@@ -2,7 +2,7 @@ import { computed, type Computed } from "ccstate";
 
 import type { ChatEvent } from "./chat-event-types.ts";
 
-export interface ThreadSidebarAutoOpenCandidate {
+interface ThreadSidebarAutoOpenCandidate {
   readonly type: "browser";
   readonly resourceKey: string;
 }
@@ -13,7 +13,7 @@ interface RawChatEventProjection {
 
 export function createThreadSidebarAutoOpenCandidate(
   rawEvents$: Computed<readonly RawChatEventProjection[]>,
-): Computed<Promise<ThreadSidebarAutoOpenCandidate | null>> {
+): Computed<ThreadSidebarAutoOpenCandidate | null> {
   return computed((get) => {
     let activeStartEventId: string | null = null;
     for (const { event } of get(rawEvents$)) {
@@ -23,11 +23,9 @@ export function createThreadSidebarAutoOpenCandidate(
         activeStartEventId = null;
       }
     }
-    return Promise.resolve(
-      activeStartEventId === null
-        ? null
-        : { type: "browser", resourceKey: activeStartEventId },
-    );
+    return activeStartEventId === null
+      ? null
+      : { type: "browser", resourceKey: activeStartEventId };
   });
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar-coordinator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar-coordinator.ts
@@ -1,10 +1,6 @@
 import { command, computed } from "ccstate";
 
 import {
-  chatThreadSidebarAutoOpenEnabled$,
-  zeroBrowserEnabled$,
-} from "../external/feature-switch.ts";
-import {
   classifyChatAttachment,
   previewAttachmentFromUrl,
 } from "./parse-body-blocks.ts";
@@ -13,13 +9,7 @@ import {
   currentRightThread$,
 } from "./chat-thread-pane-state.ts";
 import type { ChatThreadSignals } from "./chat-thread-signals.ts";
-import { CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY } from "./chat-thread-sidebar-layout.ts";
 import type { ArtifactRef, ThreadSidebarTarget } from "./thread-sidebar.ts";
-import {
-  threadSidebarAutoOpenCandidateKey,
-  type ThreadSidebarAutoOpenCandidate,
-} from "./thread-sidebar-auto-open.ts";
-import { settle } from "../utils.ts";
 
 // ---------------------------------------------------------------------------
 // Page-level coordinator for the thread-owned utility sidebar. Sidebar state
@@ -65,103 +55,6 @@ const openOnThread$ = command(
       }
     }
     set(thread.sidebar.open$, target);
-  },
-);
-
-function targetFromAutoOpenCandidate(
-  _candidate: ThreadSidebarAutoOpenCandidate,
-): ThreadSidebarTarget {
-  return { type: "browser" };
-}
-
-const autoOpenThreadSidebarFromBrowserLifecycle$ = command(
-  async (
-    { get, set },
-    thread: ChatThreadSignals,
-    signal: AbortSignal,
-  ): Promise<void> => {
-    if (
-      !get(chatThreadSidebarAutoOpenEnabled$) ||
-      !get(zeroBrowserEnabled$) ||
-      typeof window === "undefined" ||
-      !window.matchMedia(CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY).matches
-    ) {
-      return;
-    }
-
-    const candidate = await get(thread.sidebarAutoOpenCandidate$);
-    signal.throwIfAborted();
-    if (!candidate) {
-      return;
-    }
-
-    const visible = [get(currentLeftThread$), get(currentRightThread$)].some(
-      (current) => {
-        return current === thread;
-      },
-    );
-    if (!visible) {
-      return;
-    }
-
-    const candidateKey = threadSidebarAutoOpenCandidateKey(candidate);
-    if (!set(thread.sidebar.claimAutoOpenCandidate$, candidateKey)) {
-      return;
-    }
-    if (
-      !get(chatThreadSidebarAutoOpenEnabled$) ||
-      !get(zeroBrowserEnabled$) ||
-      typeof window === "undefined" ||
-      !window.matchMedia(CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY).matches ||
-      get(activeThreadSidebar$) !== null
-    ) {
-      return;
-    }
-    set(openOnThread$, thread, targetFromAutoOpenCandidate(candidate));
-  },
-);
-
-export const autoOpenInitialThreadSidebar$ = command(
-  async (
-    { get, set },
-    thread: ChatThreadSignals,
-    signal: AbortSignal,
-  ): Promise<void> => {
-    await get(thread.indexedDbEventsInitialized$);
-    signal.throwIfAborted();
-    // A lifecycle event in the locally cached/forward-synced window is
-    // authoritative because every newer remote event has already been merged.
-    // When that window has no lifecycle event and does not reach seqId 1,
-    // older history may still contain an unmatched browser.started, so finish
-    // the backfill before deciding that the browser is inactive.
-    const browserLifecycleAuthoritative = await get(
-      thread.initialBrowserLifecycleAuthoritative$,
-    );
-    signal.throwIfAborted();
-    if (!browserLifecycleAuthoritative) {
-      await get(thread.initialRemoteEventsComplete$);
-    }
-    signal.throwIfAborted();
-    const result = await settle(
-      set(autoOpenThreadSidebarFromBrowserLifecycle$, thread, signal),
-      signal,
-    );
-    set(thread.sidebar.enableEntryAnimations$);
-    if (!result.ok) {
-      throw result.error;
-    }
-  },
-);
-
-export const autoOpenThreadSidebar$ = command(
-  async (
-    { get, set },
-    thread: ChatThreadSignals,
-    signal: AbortSignal,
-  ): Promise<void> => {
-    await get(thread.initialRemoteEventsReady$);
-    signal.throwIfAborted();
-    await set(autoOpenThreadSidebarFromBrowserLifecycle$, thread, signal);
   },
 );
 

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar.ts
@@ -57,11 +57,10 @@ export interface ThreadSidebarSignals {
   readonly close$: Command<void, []>;
   /**
    * Whether the current sidebar session should animate into the split layout.
-   * The first local-message auto-open captures `false`; later opens capture
-   * `true` after that initial decision completes.
+   * The first IndexedDB-driven auto-open captures `false`; later opens capture
+   * `true` after the initial cache read completes.
    */
   readonly animateEntry$: Computed<boolean>;
-  readonly initialAutoOpenDecisionCompleted$: Computed<Promise<void>>;
   readonly enableEntryAnimations$: Command<void, []>;
   readonly editingAutomationId$: Computed<string | null>;
   readonly setEditingAutomationId$: Command<void, [string | null]>;
@@ -101,7 +100,6 @@ export function createThreadSidebarSignals(
   const internalFullscreen$ = state(false);
   const internalEditingAutomationId$ = state<string | null>(null);
   const internalClaimedAutoOpenCandidateKey$ = state<string | null>(null);
-  const initialAutoOpenDecision = Promise.withResolvers<void>();
   const resetSession$ = resetSignal();
 
   const artifactCatalog = createArtifactCatalogSignals({
@@ -172,12 +170,8 @@ export function createThreadSidebarSignals(
     animateEntry$: computed((get) => {
       return get(internalAnimateEntry$);
     }),
-    initialAutoOpenDecisionCompleted$: computed(() => {
-      return initialAutoOpenDecision.promise;
-    }),
     enableEntryAnimations$: command(({ set }) => {
       set(internalEntryAnimationsEnabled$, true);
-      initialAutoOpenDecision.resolve(undefined);
     }),
     editingAutomationId$: computed((get) => {
       return get(internalEditingAutomationId$);

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -680,7 +680,7 @@ function createVoiceSegmentCapture(
 
   return async (reason, upload): Promise<RecordedVoiceSegment> => {
     const previousCapture = captureQueue;
-    const nextCapture = Promise.withResolvers<void>();
+    const nextCapture = createDeferredPromise<void>(options.signal);
     captureQueue = nextCapture.promise;
 
     await previousCapture;
@@ -700,7 +700,7 @@ function createVoiceSegmentCapture(
         options.signal.throwIfAborted();
       })(),
       () => {
-        nextCapture.resolve();
+        nextCapture.resolve(undefined);
       },
     );
 

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -2550,7 +2550,7 @@ describe("activity detail polling", () => {
     const secondRunId = "a0000000-0000-4000-a000-000000000502";
     const firstCursor = "time:asc:2026-03-10T17%3A00%3A01Z:cursor-first-2";
     const secondCursor = "time:asc:2026-03-10T18%3A00%3A01Z:cursor-second-2";
-    const stalePage = Promise.withResolvers<void>();
+    const stalePage = context.mocks.deferred<void>();
     let firstSecondPageRequested = false;
 
     const logEntry = (timestamp: string, url: string): NetworkLogEntry => {
@@ -2710,8 +2710,8 @@ describe("activity detail polling", () => {
   it("does not render stale context after changing activity", async () => {
     const firstRunId = "a0000000-0000-4000-a000-000000000505";
     const secondRunId = "a0000000-0000-4000-a000-000000000506";
-    const secondContextResponse = Promise.withResolvers<void>();
-    const secondContextRequested = Promise.withResolvers<void>();
+    const secondContextResponse = context.mocks.deferred<void>();
+    const secondContextRequested = context.mocks.deferred<void>();
 
     context.mocks.data.composesList([]);
     context.mocks.api(logsByIdContract.getById, ({ params, respond }) => {
@@ -2793,8 +2793,8 @@ describe("activity detail polling", () => {
   it("does not render stale step messages after changing activity", async () => {
     const firstRunId = "a0000000-0000-4000-a000-000000000503";
     const secondRunId = "a0000000-0000-4000-a000-000000000504";
-    const secondEventsResponse = Promise.withResolvers<void>();
-    const secondEventsRequested = Promise.withResolvers<void>();
+    const secondEventsResponse = context.mocks.deferred<void>();
+    const secondEventsRequested = context.mocks.deferred<void>();
 
     const assistantTextEvent = (
       sequenceNumber: number,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -1861,8 +1861,8 @@ describe("chat event action cards", () => {
       configurable: true,
     });
     const openAuthWindow = context.mocks.browser.open(authWindow);
-    const refreshStarted = Promise.withResolvers<void>();
-    const completeRefresh = Promise.withResolvers<void>();
+    const refreshStarted = context.mocks.deferred<void>();
+    const completeRefresh = context.mocks.deferred<void>();
     let reconnectRequired = true;
     let pauseReadyRefresh = false;
     let catalogRequests = 0;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
@@ -191,7 +191,7 @@ describe("chat lifecycle", () => {
         expect(initialPageRequested).toBeTruthy();
       });
       expect(beforeSeqIds).toStrictEqual([]);
-      expect(document.querySelector("[data-chat-skeleton]")).not.toBeNull();
+      expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
 
       initialPageGate.resolve();
       await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
@@ -461,6 +461,78 @@ function mockLiveThread({
   };
 }
 
+function mockBackfilledHistoryScroll({
+  threadId,
+  finalScrollHeight,
+}: {
+  readonly threadId: string;
+  readonly finalScrollHeight: number;
+}): {
+  readonly historyGate: ReturnType<typeof context.mocks.deferred<void>>;
+  readonly historyMessage: string;
+  readonly currentMessage: string;
+} {
+  const clientHeight = 300;
+  const currentMessageHeight = 80;
+  const historyGate = context.mocks.deferred<void>();
+  const historyMessage = `Backfilled history ${threadId}`;
+  const currentMessage = `Current tail ${threadId}`;
+  const currentEventId = `backfill-tail-current-${threadId}`;
+  mockChatLifecycle(context, {
+    threadId,
+    threadTitle: "Backfill tail",
+    historyEvents: [
+      {
+        id: `backfill-tail-history-${threadId}`,
+        role: "user",
+        content: historyMessage,
+        runId: `backfill-tail-history-run-${threadId}`,
+        createdAt: "2026-07-30T09:00:00Z",
+      },
+    ],
+    chatEvents: [
+      {
+        id: currentEventId,
+        role: "user",
+        content: currentMessage,
+        runId: `backfill-tail-current-run-${threadId}`,
+        createdAt: "2026-07-30T10:00:00Z",
+      },
+    ],
+    beforeHistoryGate: historyGate.promise,
+  });
+  const historyRendered = () => {
+    return document.body.textContent?.includes(historyMessage) ?? false;
+  };
+  installChatLayout(
+    new Map([
+      [
+        threadId,
+        {
+          clientHeight: () => {
+            return clientHeight;
+          },
+          scrollHeight: () => {
+            return historyRendered() ? finalScrollHeight : 160;
+          },
+          eventRect: (eventId) => {
+            if (eventId !== currentEventId) {
+              return undefined;
+            }
+            return {
+              top: historyRendered()
+                ? finalScrollHeight - currentMessageHeight
+                : 80,
+              height: currentMessageHeight,
+            };
+          },
+        },
+      ],
+    ]),
+  );
+  return { historyGate, historyMessage, currentMessage };
+}
+
 describe("chat scroll position", () => {
   it("does not scroll an empty thread", async () => {
     const threadId = "b0000000-0000-4000-a000-000000000800";
@@ -495,6 +567,59 @@ describe("chat scroll position", () => {
       screen.findByText("Send a message to start the conversation"),
     ).resolves.toBeInTheDocument();
     expect(chatScrollContainer().scrollTop).toBe(0);
+  });
+
+  it("keeps scrollTop at zero when backfilled history does not fill the viewport", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000807";
+    const { historyGate, historyMessage, currentMessage } =
+      mockBackfilledHistoryScroll({ threadId, finalScrollHeight: 260 });
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+    const container = await waitFor(() => {
+      expect(screen.getByText(currentMessage)).toBeInTheDocument();
+      expect(
+        document.querySelector("[data-history-backfill-skeleton]"),
+      ).not.toBeNull();
+      const current = chatScrollContainer();
+      expect(current.scrollTop).toBe(0);
+      return current;
+    });
+    historyGate.resolve();
+    await waitFor(() => {
+      expect(screen.getByText(historyMessage)).toBeInTheDocument();
+      expect(
+        document.querySelector("[data-history-backfill-skeleton]"),
+      ).toBeNull();
+      expect(container.scrollHeight).toBeLessThan(container.clientHeight);
+      expect(container.scrollTop).toBe(0);
+    });
+  });
+
+  it("scrolls to the bottom when backfilled history fills beyond the viewport", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000808";
+    const { historyGate, historyMessage, currentMessage } =
+      mockBackfilledHistoryScroll({ threadId, finalScrollHeight: 700 });
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+    const container = await waitFor(() => {
+      expect(screen.getByText(currentMessage)).toBeInTheDocument();
+      expect(
+        document.querySelector("[data-history-backfill-skeleton]"),
+      ).not.toBeNull();
+      const current = chatScrollContainer();
+      expect(current.scrollTop).toBe(0);
+      return current;
+    });
+    historyGate.resolve();
+    await waitFor(() => {
+      expect(screen.getByText(historyMessage)).toBeInTheDocument();
+      expect(
+        document.querySelector("[data-history-backfill-skeleton]"),
+      ).toBeNull();
+      expect(container.scrollHeight).toBeGreaterThan(container.clientHeight);
+      expect(container.scrollTop).toBeGreaterThan(0);
+      expect(container.scrollTop).toBe(
+        container.scrollHeight - container.clientHeight,
+      );
+    });
   });
 
   it("follows the tail when a new message arrives while at the bottom", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -382,7 +382,7 @@ describe("thread-owned utility sidebar", () => {
     context.mocks.api(zeroBrowserContract.leaseByThread, ({ respond }) => {
       return respond(200, { browser: browserSession({ liveUrl: null }) });
     });
-    const finishStop = Promise.withResolvers<void>();
+    const finishStop = context.mocks.deferred<void>();
     let stopEventId: string | null = null;
     context.mocks.api(
       zeroBrowserContract.stop,
@@ -849,6 +849,47 @@ describe("thread-owned utility sidebar", () => {
     });
   });
 
+  it("auto-opens the browser sidebar before the event scroll animation frame", async () => {
+    const pendingFrames: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      pendingFrames.push(callback);
+      return pendingFrames.length;
+    });
+    context.mocks.browser.matchMedia((query) => {
+      return query === CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY;
+    });
+    context.mocks.api(zeroBrowserContract.get, ({ respond }) => {
+      return respond(200, { browser: browserSession() });
+    });
+    context.mocks.api(zeroBrowserContract.leaseByThread, ({ respond }) => {
+      return respond(200, {
+        browser: browserSession({ liveUrl: null }),
+      });
+    });
+
+    setupChatThread({
+      autoOpenEnabled: true,
+      messages: [
+        {
+          id: "c0000000-0000-4000-a000-000000000058",
+          eventType: "browser.started",
+          content: null,
+          seqId: 1,
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    await expect(
+      screen.findByLabelText("Live browser"),
+    ).resolves.toHaveAttribute("data-browser-session-sidebar");
+    expect(pendingFrames.length).toBeGreaterThan(0);
+
+    for (const callback of pendingFrames.splice(0)) {
+      callback(0);
+    }
+  });
+
   it("auto-opens from the first remote page while older history is still loading", async () => {
     const historyRequestStarted = context.mocks.deferred<void>();
     const releaseHistoryResponse = context.mocks.deferred<void>();
@@ -1095,8 +1136,8 @@ describe("thread-owned utility sidebar", () => {
   });
 
   it("auto-opens a background-synced browser start before mark-read completes", async () => {
-    const markReadStarted = Promise.withResolvers<void>();
-    const finishMarkRead = Promise.withResolvers<void>();
+    const markReadStarted = context.mocks.deferred<void>();
+    const finishMarkRead = context.mocks.deferred<void>();
     context.mocks.browser.matchMedia((query) => {
       return query === CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY;
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -400,7 +400,7 @@ describe("zero chat thread IndexedDB fallback", () => {
     }
   });
 
-  it("does not auto-open from a cached browser start superseded by a remote stop", async () => {
+  it("keeps a sidebar opened from cached browser state when remote sync later stops it", async () => {
     prepareDefaultAgent();
     mockCurrentThreadDetail();
     mockSidebarThread();
@@ -458,7 +458,7 @@ describe("zero chat thread IndexedDB fallback", () => {
       ).resolves.toBeInTheDocument();
       expect(
         document.querySelector("[data-browser-session-sidebar]"),
-      ).toBeNull();
+      ).toBeInstanceOf(HTMLElement);
     } finally {
       runtimeDb.close();
     }
@@ -528,7 +528,7 @@ describe("zero chat thread IndexedDB fallback", () => {
     }
   });
 
-  it("shows the message skeleton until an uncached remote thread is confirmed empty", async () => {
+  it("hides the message skeleton after IndexedDB loads without waiting for remote events", async () => {
     prepareDefaultAgent();
     mockCurrentThreadDetail();
     mockSidebarThread();
@@ -547,13 +547,11 @@ describe("zero chat thread IndexedDB fallback", () => {
       await messageListRequested.promise;
 
       await waitFor(() => {
-        expect(document.querySelector("[data-chat-skeleton]")).toBeInstanceOf(
-          HTMLElement,
-        );
+        expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
       });
       expect(
-        screen.queryByText("Send a message to start the conversation"),
-      ).not.toBeInTheDocument();
+        screen.getByText("Send a message to start the conversation"),
+      ).toBeInTheDocument();
       expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
 
       initialMessageList.resolve();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -243,7 +243,7 @@ describe("directed connector authorize page", () => {
 
   it("does not reuse stale loaded authorization across agents", async () => {
     mockConnectedConnector("gmail");
-    const secondAgentResponse = Promise.withResolvers<void>();
+    const secondAgentResponse = context.mocks.deferred<void>();
     let secondAgentRequested = false;
     context.mocks.api(
       zeroUserConnectorsContract.get,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -8,7 +8,6 @@ import type {
 import {
   useGet,
   useSet,
-  useLoadableState,
   useLastLoadable,
   useLastResolved,
   useLoadable,
@@ -2609,13 +2608,7 @@ function ChatThreadEmptyState({ thread }: { thread: ChatThreadSignals }) {
     useLastResolved(thread.visibleRenderedChatGroupsReady$) ?? false;
   const threadSettledInServer = useGet(thread.threadSettledInServer$);
   const hasEvents = useLastResolved(thread.hasEvents$);
-  const hasNewEventsState = useLoadableState(thread.hasNewEvents$);
-  if (
-    !renderedGroupsReady ||
-    !threadSettledInServer ||
-    hasEvents !== false ||
-    hasNewEventsState === "loading"
-  ) {
+  if (!renderedGroupsReady || !threadSettledInServer || hasEvents !== false) {
     return null;
   }
   return (
@@ -3483,15 +3476,8 @@ function RunGroupFoldRow({
 }
 
 function ChatThreadSkeletonOverlay({ thread }: { thread: ChatThreadSignals }) {
-  const renderedGroupsReadyLoadable = useLastLoadable(
-    thread.visibleRenderedChatGroupsReady$,
-  );
-  const sessionError = resolveSessionError(renderedGroupsReadyLoadable);
-  const hasEvents = useLastResolved(thread.hasEvents$);
-  const hasNewEventsState = useLoadableState(thread.hasNewEvents$);
-  const skeletonVisible =
-    hasEvents === false && hasNewEventsState === "loading";
-  if (!skeletonVisible || sessionError) {
+  const indexedDbEventsLoading = useGet(thread.indexedDbEventsLoading$);
+  if (!indexedDbEventsLoading) {
     return null;
   }
 
@@ -3560,8 +3546,8 @@ function ChatHistoryBackfillSkeleton({
   thread: ChatThreadSignals;
 }) {
   const { t } = useTranslation();
-  const progress = useLastResolved(thread.historyBackfillProgress$);
-  if (progress === null || progress === undefined) {
+  const historyBackfillPending = useGet(thread.historyBackfillPending$);
+  if (!historyBackfillPending) {
     return null;
   }
   return (

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-new-promise.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-new-promise.test.ts
@@ -32,5 +32,11 @@ ruleTester.run("no-new-promise", noNewPromise, {
       `,
       errors: [{ messageId: "noNewPromise" }],
     },
+    {
+      code: `
+        const deferred = Promise.withResolvers<void>();
+      `,
+      errors: [{ messageId: "noPromiseWithResolvers" }],
+    },
   ],
 });

--- a/turbo/packages/eslint-rules/src/api/rules/no-new-promise.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-new-promise.ts
@@ -8,13 +8,16 @@ export const noNewPromise = createRule({
   meta: {
     type: "problem",
     docs: {
-      description: "Disallow direct Promise construction",
+      description:
+        "Disallow direct Promise construction and Promise.withResolvers()",
       recommended: true,
     },
     schema: [],
     messages: {
       noNewPromise:
         "`new Promise()` is not allowed. Use signal-aware helpers such as createDeferredPromise(), delay(), or an existing abstraction instead.",
+      noPromiseWithResolvers:
+        "`Promise.withResolvers()` is not allowed. Use createDeferredPromise(signal) so the deferred inherits its owner signal.",
     },
   },
   create(context) {
@@ -27,6 +30,20 @@ export const noNewPromise = createRule({
           context.report({
             node,
             messageId: "noNewPromise",
+          });
+        }
+      },
+      CallExpression(node: TSESTree.CallExpression): void {
+        if (
+          node.callee.type === AST_NODE_TYPES.MemberExpression &&
+          node.callee.object.type === AST_NODE_TYPES.Identifier &&
+          node.callee.object.name === "Promise" &&
+          node.callee.property.type === AST_NODE_TYPES.Identifier &&
+          node.callee.property.name === "withResolvers"
+        ) {
+          context.report({
+            node,
+            messageId: "noPromiseWithResolvers",
           });
         }
       },

--- a/turbo/packages/eslint-rules/src/ccstate/__tests__/no-new-promise.test.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/__tests__/no-new-promise.test.ts
@@ -31,5 +31,11 @@ ruleTester.run("no-new-promise", rule, {
       `,
       errors: [{ messageId: "noNewPromise" }],
     },
+    {
+      code: `
+        const deferred = Promise.withResolvers<void>();
+      `,
+      errors: [{ messageId: "noPromiseWithResolvers" }],
+    },
   ],
 });

--- a/turbo/packages/eslint-rules/src/ccstate/rules/no-new-promise.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/rules/no-new-promise.ts
@@ -1,7 +1,7 @@
 /**
  * ESLint rule: no-new-promise
  *
- * Prevents direct instantiation of Promise.
+ * Prevents direct construction of deferred promises.
  * Use existing signal-aware helpers and higher-level abstractions instead.
  */
 
@@ -15,13 +15,15 @@ export default createRule({
     type: "problem",
     docs: {
       description:
-        "Disallow `new Promise()`. Use signal-aware helpers or existing abstractions instead.",
+        "Disallow `new Promise()` and `Promise.withResolvers()`. Use signal-aware helpers or existing abstractions instead.",
       recommended: true,
     },
     schema: [],
     messages: {
       noNewPromise:
         "`new Promise()` is not allowed. Use signal-aware helpers (for example createDeferredPromise(), never(), delay(), withSignal()) or an existing abstraction instead.",
+      noPromiseWithResolvers:
+        "`Promise.withResolvers()` is not allowed. Use createDeferredPromise(signal) so the deferred inherits its owner signal.",
     },
   },
   create(context) {
@@ -34,6 +36,20 @@ export default createRule({
           context.report({
             node,
             messageId: "noNewPromise",
+          });
+        }
+      },
+      CallExpression(node: TSESTree.CallExpression) {
+        if (
+          node.callee.type === AST_NODE_TYPES.MemberExpression &&
+          node.callee.object.type === AST_NODE_TYPES.Identifier &&
+          node.callee.object.name === "Promise" &&
+          node.callee.property.type === AST_NODE_TYPES.Identifier &&
+          node.callee.property.name === "withResolvers"
+        ) {
+          context.report({
+            node,
+            messageId: "noPromiseWithResolvers",
           });
         }
       },


### PR DESCRIPTION
## Summary

- simplify initial chat loading around the first IndexedDB read
- derive history backfill skeleton visibility from the first persistent event sequence
- coordinate sidebar auto-open and autoscroll after persistent and optimistic event changes
- route browser lifecycle optimistic events through the unified event-change path
- require the signal-aware deferred helper instead of direct Promise.withResolvers usage
- cover short and overflowing history backfill scroll behavior

## Testing

- pnpm format
- pnpm lint
- pnpm check-types
- platform scoped Vitest: 11 files, 155 tests
- eslint-rules Vitest: 47 files, 1025 tests
- pnpm knip --workspace @vm0/app --workspace @vm0/eslint-rules