### PR TITLE
test(platform): split body-link preview specs by media type

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -238,6 +238,75 @@ function clipboardFileItem(file: File): DataTransferItem {
   } as DataTransferItem;
 }
 
+const BODY_LINK_PREVIEWS = {
+  audio: "https://cdn.vm7.io/artifacts/test/body-audio/briefing.mp3",
+  video: "https://cdn.vm7.io/artifacts/test/body-video/demo.mp4",
+  image: "https://cdn.vm7.io/artifacts/test/body-image/chart.png",
+  markdown: "https://cdn.vm7.io/artifacts/test/body-markdown/release-notes.md",
+  csv: "https://cdn.vm7.io/artifacts/test/body-csv/launch-metrics.csv",
+  pdf: "https://cdn.vm7.io/artifacts/test/body-pdf/rollout-plan.pdf",
+  html: "https://cdn.vm7.io/artifacts/test/body-html/launch-site.html",
+  archive: "https://cdn.vm7.io/artifacts/test/body-file/archive.bin",
+} as const;
+
+// Renders one assistant message carrying every supported preview link type and
+// waits until each parsed chip is on screen. The media and document preview
+// specs share this setup so that each spec opens only its own previews within
+// the default test timeout.
+async function setupBodyLinkPreviews(): Promise<void> {
+  const { audio, video, image, markdown, csv, pdf, html, archive } =
+    BODY_LINK_PREVIEWS;
+  context.mocks.http.get(markdown, () => {
+    return new Response("# Release notes\n\nBody link rollout is ready.", {
+      headers: { "Content-Type": "text/markdown" },
+    });
+  });
+  context.mocks.http.get(csv, () => {
+    return new Response("metric,value\nactivation,87", {
+      headers: { "Content-Type": "text/csv" },
+    });
+  });
+  context.mocks.http.get(archive, () => {
+    return new Response(null, { status: 500 });
+  });
+  mockChatLifecycle(context, {
+    threadId: THREAD_ID,
+    chatEvents: [
+      {
+        id: "msg-body-preview-links",
+        role: "assistant",
+        content: `Generated preview links:\n\n${audio}\n${video}\n${image}\n${markdown}\n${csv}\n${pdf}\n[Launch site](${html})\n${archive}`,
+        runId: "run-body-previews",
+        createdAt: "2026-03-10T00:00:00Z",
+      },
+    ],
+  });
+
+  detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+  await waitFor(() => {
+    expect(screen.getByText("Generated preview links:")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Open audio preview for briefing.mp3"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Preview demo.mp4")).toBeInTheDocument();
+    expect(screen.getByAltText("chart.png")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Open markdown preview for release-notes.md"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Open csv preview for launch-metrics.csv"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Open pdf preview for rollout-plan.pdf"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Open html preview for Launch site"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Download archive.bin")).toBeInTheDocument();
+  });
+}
+
 describe("zero attachment chips", () => {
   it("shows pending upload progress for composer attachments", async () => {
     context.mocks.upload.pending({
@@ -2174,70 +2243,8 @@ describe("zero attachment chips", () => {
     });
   });
 
-  it("opens media and file previews parsed from chat message links", async () => {
-    const audioUrl =
-      "https://cdn.vm7.io/artifacts/test/body-audio/briefing.mp3";
-    const videoUrl = "https://cdn.vm7.io/artifacts/test/body-video/demo.mp4";
-    const imageUrl = "https://cdn.vm7.io/artifacts/test/body-image/chart.png";
-    const markdownUrl =
-      "https://cdn.vm7.io/artifacts/test/body-markdown/release-notes.md";
-    const csvUrl =
-      "https://cdn.vm7.io/artifacts/test/body-csv/launch-metrics.csv";
-    const pdfUrl =
-      "https://cdn.vm7.io/artifacts/test/body-pdf/rollout-plan.pdf";
-    const htmlUrl =
-      "https://cdn.vm7.io/artifacts/test/body-html/launch-site.html";
-    const archiveUrl =
-      "https://cdn.vm7.io/artifacts/test/body-file/archive.bin";
-    context.mocks.http.get(markdownUrl, () => {
-      return new Response("# Release notes\n\nBody link rollout is ready.", {
-        headers: { "Content-Type": "text/markdown" },
-      });
-    });
-    context.mocks.http.get(csvUrl, () => {
-      return new Response("metric,value\nactivation,87", {
-        headers: { "Content-Type": "text/csv" },
-      });
-    });
-    context.mocks.http.get(archiveUrl, () => {
-      return new Response(null, { status: 500 });
-    });
-    mockChatLifecycle(context, {
-      threadId: THREAD_ID,
-      chatEvents: [
-        {
-          id: "msg-body-preview-links",
-          role: "assistant",
-          content: `Generated preview links:\n\n${audioUrl}\n${videoUrl}\n${imageUrl}\n${markdownUrl}\n${csvUrl}\n${pdfUrl}\n[Launch site](${htmlUrl})\n${archiveUrl}`,
-          runId: "run-body-previews",
-          createdAt: "2026-03-10T00:00:00Z",
-        },
-      ],
-    });
-
-    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
-
-    await waitFor(() => {
-      expect(screen.getByText("Generated preview links:")).toBeInTheDocument();
-      expect(
-        screen.getByLabelText("Open audio preview for briefing.mp3"),
-      ).toBeInTheDocument();
-      expect(screen.getByLabelText("Preview demo.mp4")).toBeInTheDocument();
-      expect(screen.getByAltText("chart.png")).toBeInTheDocument();
-      expect(
-        screen.getByLabelText("Open markdown preview for release-notes.md"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByLabelText("Open csv preview for launch-metrics.csv"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByLabelText("Open pdf preview for rollout-plan.pdf"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByLabelText("Open html preview for Launch site"),
-      ).toBeInTheDocument();
-      expect(screen.getByLabelText("Download archive.bin")).toBeInTheDocument();
-    });
+  it("opens media previews parsed from chat message links", async () => {
+    await setupBodyLinkPreviews();
 
     const bodyVideoPreview = screen.getByLabelText("Preview demo.mp4");
     expect(bodyVideoPreview).toHaveClass(
@@ -2308,6 +2315,10 @@ describe("zero attachment chips", () => {
         screen.queryByTestId("attachment-lightbox"),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("opens document previews parsed from chat message links", async () => {
+    await setupBodyLinkPreviews();
 
     click(screen.getByLabelText("Open markdown preview for release-notes.md"));
 


### PR DESCRIPTION
## Triggering failure

- Turbo run: https://github.com/vm0-ai/vm0/actions/runs/30620158453
- Event: `merge_group` (queued PR #24317), head SHA `9fbb35269e6c71f2671838bf3ba359065e82e7a1`
- First substantive failure: `test-app (5)` → `src/views/zero-page/__tests__/zero-attachment-chips.test.tsx:2177` > `zero attachment chips > opens media and file previews parsed from chat message links` → `Error: Test timed out in 5000ms.` (observed 5359ms)
- `test-api (4)` was a fail-fast cancellation and `ci-gate-turbo` is the aggregate gate; neither is causal.

The queued PR #24317 only touches `turbo/apps/api/src/signals/**`, which cannot affect this `@vm0/app` frontend spec, so the failure is not owned by the queued change.

## Root-cause classification

Test-design budget exhaustion — the spec's total wall-clock work exceeded the default 5000ms `testTimeout`. This is not a product race, not state pollution, and not an external incident: no assertion failed, no rejection was raised, and the other 34 specs in the same file and worker passed.

## First causal event and why it was intermittent

The single spec drove eight independent preview contracts in one test body — audio, video, markdown-image, markdown, csv, pdf, html, and a failed archive download — as eight sequential open/close cycles (~16 `waitFor` round trips) on top of one `detachedSetupPage` bootstrap.

Measured on an idle 2-core box with a full-file run, it was the file's clear outlier:

| Spec | Duration |
| --- | --- |
| opens media and file previews parsed from chat message links | **2552ms** |
| opens canonical markdown and text previews, shares a document link, and reports download failures | 1105ms |
| shows pending upload progress for composer attachments | 1052ms |
| opens persisted canonical csv, pdf, and html document previews | 1040ms |

At ~2.6s it had under 2x headroom against the 5000ms budget, while `@vm0/app` page-rendering specs are known to vary by roughly 2-3x under CPU contention. The outcome therefore flipped on scheduling alone: whichever CI shard ran it under load crossed 5000ms.

Reproduced deterministically by running the full file with 4 `node` busy-loop processes on 2 cores: the same spec failed at **5239ms** with the identical `Test timed out in 5000ms` at line 2177, with all 34 sibling specs passing.

## Fix

Split the spec into `opens media previews parsed from chat message links` (audio, video, markdown image) and `opens document previews parsed from chat message links` (markdown, csv, pdf, html, failed download), and extracted the shared message setup into `setupBodyLinkPreviews()`.

This follows the boundary the file already uses for the equivalent persisted-canonical coverage (`opens persisted canonical audio, video, and document attachments` / `opens persisted canonical csv, pdf, and html document previews`).

Product contract is preserved:

- Every original assertion is retained verbatim; none was weakened or removed.
- Both specs still assert that **all eight** link types parse from one assistant message body, via the shared setup, so the multi-link parsing contract is still covered twice.
- No timeout increase, sleep, retry, fake timer, skip, or manual detached cleanup was used.

## Validation

Targeted full-file runs (never `-t`-filtered, which distorts first-render cost):

- 5 consecutive clean runs: `36 passed (36)` each. New specs stable at media 1335-1435ms, documents 1660-1791ms — down from 2552ms and now with ~3x headroom.
- 1 run under the exact 4-busy-loop contention that reproduced the failure: `36 passed (36)`, media 3619ms, documents 3940ms, where the original spec failed at 5239ms.
- Whole-file duration is unchanged (42.4s before, 42.9s after), so the split adds no meaningful cost.

Checks: `prettier --check` pass, `oxlint` exit 0, `eslint --max-warnings 0` exit 0, `tsc -p tsconfig.tests.json --noEmit` exit 0, `git diff --check` clean.

## Evidence limitations

- Contention was simulated locally with busy-loop processes rather than observed on the CI runner; the CI-side evidence is the single 5359ms timeout in the triggering run.
- `apps/api` type-check and the full repository Vitest suite were not run locally (sandbox RAM limits, and out of scope for this one-file test change); the PR pipeline covers both.
