### PR TITLE
chore(runner): clean up chat thread reuse key rollout

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -685,8 +685,7 @@ async fn activate_reserved_idle(
     let reserved_reuse_key = reservation.reuse_key().to_owned();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
 
-    if !resume_session_valid || requested_reuse_key.as_deref() != Some(reserved_reuse_key.as_str())
-    {
+    if !resume_session_valid || requested_reuse_key != Some(reserved_reuse_key.as_str()) {
         let reuse_result = if requested_reuse_key.is_none() || !resume_session_valid {
             SandboxReuseResult::NoSessionId
         } else {
@@ -875,7 +874,7 @@ async fn try_reuse_from_pool(
     // so unpark does not block other take/park operations.
     let (taken, snapshot) = {
         let mut pool = ctx.idle_pool.lock().await;
-        let taken = pool.take(&reuse_key);
+        let taken = pool.take(reuse_key);
         let snapshot = taken.as_ref().map(|_| pool.status_snapshot());
         (taken, snapshot)
     };
@@ -886,7 +885,7 @@ async fn try_reuse_from_pool(
         && ctx
             .spawn_ctx
             .held_session_snapshot
-            .might_contain_workspace_cache_reuse_key(&reuse_key);
+            .might_contain_workspace_cache_reuse_key(reuse_key);
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::HeldSessionStateRefresh, started_at);
     let needs_session_affinity_refresh = took_idle_session || claimed_workspace_cache_reuse_key;
     match taken {
@@ -908,8 +907,8 @@ async fn try_reuse_from_pool(
                 if let Err(mismatch) = validation {
                     warn!(
                         run_id = %run_id,
-                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reuse_key),
-                        reuse_key_kind = reuse_key_kind(&reuse_key),
+                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
+                        reuse_key_kind = reuse_key_kind(reuse_key),
                         profile = %profile_name,
                         mismatch = mismatch.as_str(),
                         "workspace promotion identity mismatch, destroying idle VM and falling through to fresh create"
@@ -938,8 +937,8 @@ async fn try_reuse_from_pool(
                 } => {
                     info!(
                         run_id = %run_id,
-                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reuse_key),
-                        reuse_key_kind = reuse_key_kind(&reuse_key),
+                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
+                        reuse_key_kind = reuse_key_kind(reuse_key),
                         "reusing idle VM for reuse key"
                     );
                     // Idle entry already holds budget. Drop the speculative
@@ -957,8 +956,8 @@ async fn try_reuse_from_pool(
                 IdleUnparkResult::Failed { destroy_job, error } => {
                     warn!(
                         run_id = %run_id,
-                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reuse_key),
-                        reuse_key_kind = reuse_key_kind(&reuse_key),
+                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
+                        reuse_key_kind = reuse_key_kind(reuse_key),
                         error = %error,
                         "unpark failed, destroying idle VM and falling through to fresh create"
                     );
@@ -976,8 +975,8 @@ async fn try_reuse_from_pool(
         Some(stale) if stale.profile_name() == profile_name => {
             info!(
                 run_id = %run_id,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reuse_key),
-                reuse_key_kind = reuse_key_kind(&reuse_key),
+                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
+                reuse_key_kind = reuse_key_kind(reuse_key),
                 profile = %profile_name,
                 "idle VM device rate limiter mismatch, destroying"
             );
@@ -997,8 +996,8 @@ async fn try_reuse_from_pool(
         Some(stale) => {
             info!(
                 run_id = %run_id,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reuse_key),
-                reuse_key_kind = reuse_key_kind(&reuse_key),
+                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
+                reuse_key_kind = reuse_key_kind(reuse_key),
                 old_profile = %stale.profile_name(),
                 new_profile = %profile_name,
                 "idle VM profile mismatch, destroying"
@@ -1019,8 +1018,8 @@ async fn try_reuse_from_pool(
         None => {
             info!(
                 run_id = %run_id,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reuse_key),
-                reuse_key_kind = reuse_key_kind(&reuse_key),
+                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
+                reuse_key_kind = reuse_key_kind(reuse_key),
                 "no idle VM found for reuse key"
             );
             (

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -3,7 +3,6 @@
 //! `run()` owns the provider discovery future and reactor scheduling. This
 //! module owns the body that turns a discovered job into a claimed spawned job.
 
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Instant;
@@ -171,7 +170,7 @@ pub(super) async fn handle_discovered_job(
     // briefly advertise stale workspace-cache affinity for an active session.
     let active_reuse_key_guard = ActiveReuseKeyGuard::new(
         ctx.spawn_ctx.active_reuse_keys.clone(),
-        claimed.context().reuse_key().map(Cow::into_owned),
+        claimed.context().reuse_key().map(str::to_owned),
     );
 
     let (reuse_entry, active_lease, reuse_result, idle_snapshot, needs_session_affinity_refresh) =

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -4,7 +4,6 @@
 //! owns the spawned task body: executor orchestration, provider completion,
 //! deferred telemetry/network-log uploads, and outer-task panic cleanup.
 
-use std::borrow::Cow;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -505,7 +504,7 @@ pub(super) fn spawn_job(
     } = request;
     let (context, completion_auth, active_input_source) = claimed.into_parts();
     let run_id = context.run_id;
-    let reuse_key = context.reuse_key().map(Cow::into_owned);
+    let reuse_key = context.reuse_key().map(str::to_owned);
     let cli_agent_session_id = if executor::validate_resume_session_id(&context).is_ok() {
         context.cli_agent_session_id().map(String::from)
     } else {

--- a/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
@@ -20,6 +20,7 @@ fn context_with_session_opt(
 ) -> crate::types::ExecutionContext {
     let mut ctx = minimal_context(run_id);
     if let Some(sid) = session_id {
+        ctx.reuse_key = Some(format!("session:{sid}"));
         ctx.resume_session = Some(crate::types::ResumeSession::inline(
             sid.to_string(),
             String::new(),

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -599,9 +599,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
     let expected_promotion_reuse_key = if resume_session_error.is_some() {
         idle_reuse_key.as_str()
     } else {
-        claimed_reuse_key
-            .as_deref()
-            .unwrap_or(idle_reuse_key.as_str())
+        claimed_reuse_key.unwrap_or(idle_reuse_key.as_str())
     };
     let workspace_image = match resolve_reused_workspace_promotion(
         config.workspace_cache.as_ref(),
@@ -643,7 +641,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
                         run_id,
                         sandbox_id,
                         profile_name: &params.profile_name,
-                        reuse_key: claimed_reuse_key.as_deref(),
+                        reuse_key: claimed_reuse_key,
                         cli_agent_session_id: context.cli_agent_session_id(),
                         working_dir: CANONICAL_WORKING_DIR,
                         image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -763,7 +763,7 @@ pub(super) async fn prepare_workspace_image(
                 run_id: context.run_id,
                 sandbox_id,
                 profile_name,
-                reuse_key: reuse_key.as_deref(),
+                reuse_key,
                 cli_agent_session_id: context.cli_agent_session_id(),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -1,5 +1,17 @@
 use super::*;
 
+fn set_session_affinity(
+    context: &mut crate::types::ExecutionContext,
+    session_id: &str,
+    session_history: &str,
+) {
+    context.reuse_key = Some(format!("session:{session_id}"));
+    context.resume_session = Some(ResumeSession::inline(
+        session_id.into(),
+        session_history.into(),
+    ));
+}
+
 #[tokio::test]
 async fn workspace_mount_retry_starts_a_new_codex_catalog_prefetch_owner() {
     let dir = tempfile::tempdir().unwrap();
@@ -17,10 +29,7 @@ async fn workspace_mount_retry_starts_a_new_codex_catalog_prefetch_owner() {
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = codex_oauth_context();
     let session_id = "00000000-0000-4000-8000-000000023425";
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -95,10 +104,7 @@ async fn execute_inner_retries_fresh_after_workspace_cache_hit_create_failure() 
         storages: vec![storage],
         artifacts: Vec::new(),
     });
-    ctx.resume_session = Some(ResumeSession::inline(
-        "sess-cache-hit".into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(&mut ctx, "sess-cache-hit", r#"{"type":"init"}"#);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -200,10 +206,7 @@ async fn execute_inner_dns_readiness_retry_replaces_consumed_workspace_cache_hit
     }));
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        "sess-cache-dns-retry".into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(&mut ctx, "sess-cache-dns-retry", r#"{"type":"init"}"#);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -281,10 +284,7 @@ async fn process_timeout_invalidates_consumed_workspace_cache_without_fallback()
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let session_id = "sess-cache-dns-process-timeout";
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -379,10 +379,11 @@ async fn dns_replacement_records_completion_when_fresh_storage_prepare_fails() {
     let storage_fingerprints =
         crate::storage_fingerprints::StorageFingerprints::from_manifest(&manifest);
     ctx.storage_manifest = Some(manifest);
-    ctx.resume_session = Some(ResumeSession::inline(
-        "sess-cache-dns-prepare-failure".into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(
+        &mut ctx,
+        "sess-cache-dns-prepare-failure",
+        r#"{"type":"init"}"#,
+    );
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -448,10 +449,11 @@ async fn execute_inner_cache_hit_retry_requires_completed_cleanup() {
     overrides.push_destroy_panic("simulated destroy panic");
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        "sess-cache-cleanup-uncertain".into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(
+        &mut ctx,
+        "sess-cache-cleanup-uncertain",
+        r#"{"type":"init"}"#,
+    );
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -498,10 +500,7 @@ async fn execute_inner_uses_workspace_cache_when_configured() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        "sess-cache-default".into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(&mut ctx, "sess-cache-default", r#"{"type":"init"}"#);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -570,10 +569,7 @@ async fn execute_inner_records_workspace_cache_lock_busy_prepare_telemetry() {
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
     let session_id = "sess-cache-lock-busy-prepare";
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -640,10 +636,7 @@ async fn execute_inner_does_not_retry_workspace_cache_hit_after_proxy_register_f
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        "sess-register-fail".into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(&mut ctx, "sess-register-fail", r#"{"type":"init"}"#);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -736,10 +729,7 @@ async fn execute_job_reuse_uses_workspace_cache_when_configured() {
     let (idle_sandbox, _lease) = make_reusable_idle_sandbox(sandbox, source_ip, session_id).await;
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -790,10 +780,7 @@ async fn cached_reuse_workspace_promotion_identity_mismatch_stops_before_agent()
     .await;
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -846,10 +833,7 @@ async fn execute_job_reuse_without_workspace_cache_config_invalidates_held_cache
             .await;
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -905,10 +889,7 @@ async fn unconfigured_cache_reuse_stops_when_cache_invalidation_fails() {
     tokio::fs::create_dir(&current_image).await.unwrap();
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -948,10 +929,7 @@ async fn cached_reuse_validation_failure_keeps_workspace_cache_hidden() {
             .await;
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
     ctx.environment = Some(HashMap::from([(
         "OPENAI_API_KEY".into(),
         "sk-proj-real-openai-secret".into(),
@@ -1008,10 +986,7 @@ async fn cached_reuse_invalid_resume_session_keeps_existing_workspace_cache_hidd
 
     let raw_session_id = "../invalid-resume";
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        raw_session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(&mut ctx, raw_session_id, r#"{"type":"init"}"#);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -1080,10 +1055,7 @@ async fn cached_reuse_invalid_resume_session_without_promotion_skips_workspace_l
 
     let raw_session_id = "../invalid-resume";
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        raw_session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_affinity(&mut ctx, raw_session_id, r#"{"type":"init"}"#);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1,6 +1,5 @@
 //! [`JobProvider`] backed by an Ably control plane + HTTP polling + REST API.
 
-use std::borrow::Cow;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -552,7 +551,7 @@ impl JobProvider for ApiProvider {
                         return None;
                     }
                     let run_id = job.run_id;
-                    let reuse_key = job.reuse_key().map(Cow::into_owned);
+                    let reuse_key = job.reuse_key().map(str::to_owned);
                     let cli_agent_session_id = job.cli_agent_session_id;
                     let history_generation_run_id = job.history_generation_run_id;
                     let history_generation_affinity_protected_until =

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -692,12 +692,7 @@ async fn handle_ably_message_with_network_policy_refresh(
                         notif.run_id,
                         profile.to_owned(),
                         notification_received_at,
-                        notif.reuse_key.map(str::to_owned).or_else(|| {
-                            // TODO(deployment-compatibility): Remove this fallback after the next release.
-                            notif
-                                .cli_agent_session_id
-                                .map(|session_id| format!("session:{session_id}"))
-                        }),
+                        notif.reuse_key.map(str::to_owned),
                         notif.cli_agent_session_id.map(str::to_owned),
                         notif.affinity_protected_until.map(str::to_owned),
                     )
@@ -1897,6 +1892,7 @@ mod tests {
                 "runId": "00000000-0000-0000-0000-000000000001",
                 "profile": "vm0/default",
                 "cliAgentSessionId": "sess-ably",
+                "reuseKey": "thread:chat-thread",
                 "historyGenerationRunId": "00000000-0000-0000-0000-000000000098",
                 "historyGenerationAffinityProtectedUntil": "2999-01-01T00:00:00.000Z",
                 "affinityProtectedUntil": "2999-01-01T00:00:00.000Z",
@@ -1913,7 +1909,7 @@ mod tests {
         );
         assert_eq!(candidate.profile_name(), "vm0/default");
         let candidate = candidate.into_job_candidate();
-        assert_eq!(candidate.reuse_key(), Some("session:sess-ably"));
+        assert_eq!(candidate.reuse_key(), Some("thread:chat-thread"));
         assert_eq!(candidate.cli_agent_session_id(), Some("sess-ably"));
         assert_eq!(
             candidate.history_generation_run_id(),

--- a/crates/runner/src/provider/local/mod.rs
+++ b/crates/runner/src/provider/local/mod.rs
@@ -168,10 +168,14 @@ impl JobProvider for LocalProvider {
         };
 
         let environment_merge = merge_local_environments(req.environment, req.secret_environment);
+        let reuse_key = req
+            .session_id
+            .as_ref()
+            .map(|session_id| format!("session:{session_id}"));
 
         let context = ExecutionContext {
             run_id,
-            reuse_key: None,
+            reuse_key,
             prompt: req.prompt,
             append_system_prompt: None,
             vars: req.vars,

--- a/crates/runner/src/provider/local/tests/discovery.rs
+++ b/crates/runner/src/provider/local/tests/discovery.rs
@@ -44,12 +44,14 @@ async fn discover_exposes_session_affinity_before_claim() {
 
     let candidate = provider.discover().await.unwrap();
     assert_eq!(candidate.cli_agent_session_id(), Some("session-123"));
+    assert_eq!(candidate.reuse_key(), Some("session:session-123"));
 
     let claimed = provider.claim(candidate).await.unwrap();
     assert_eq!(
         claimed.context().cli_agent_session_id(),
         Some("session-123")
     );
+    assert_eq!(claimed.context().reuse_key(), Some("session:session-123"));
 }
 
 #[tokio::test]

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::IpAddr;
 use std::sync::Arc;
@@ -48,16 +47,6 @@ pub struct Job {
     pub session_affinity_resource: Option<SessionAffinityResource>,
 }
 
-fn deployment_compatible_reuse_key<'a>(
-    reuse_key: Option<&'a str>,
-    cli_agent_session_id: Option<&'a str>,
-) -> Option<Cow<'a, str>> {
-    reuse_key.map(Cow::Borrowed).or_else(|| {
-        // TODO(deployment-compatibility): Remove this fallback after the next release.
-        cli_agent_session_id.map(|session_id| Cow::Owned(format!("session:{session_id}")))
-    })
-}
-
 pub(crate) fn reuse_key_kind(reuse_key: &str) -> &'static str {
     if reuse_key.starts_with("thread:") {
         "thread"
@@ -67,11 +56,8 @@ pub(crate) fn reuse_key_kind(reuse_key: &str) -> &'static str {
 }
 
 impl Job {
-    pub(crate) fn reuse_key(&self) -> Option<Cow<'_, str>> {
-        deployment_compatible_reuse_key(
-            self.reuse_key.as_deref(),
-            self.cli_agent_session_id.as_deref(),
-        )
+    pub(crate) fn reuse_key(&self) -> Option<&str> {
+        self.reuse_key.as_deref()
     }
 }
 
@@ -1262,8 +1248,8 @@ where
 }
 
 impl ExecutionContext {
-    pub(crate) fn reuse_key(&self) -> Option<Cow<'_, str>> {
-        deployment_compatible_reuse_key(self.reuse_key.as_deref(), self.cli_agent_session_id())
+    pub(crate) fn reuse_key(&self) -> Option<&str> {
+        self.reuse_key.as_deref()
     }
 
     /// Extract the Claude/Codex CLI agent session id from `resume_session`.
@@ -1463,6 +1449,7 @@ mod tests {
             "job": {
                 "runId": "550e8400-e29b-41d4-a716-446655440000",
                 "experimentalProfile": "browser",
+                "cliAgentSessionId": "legacy-session",
                 "sessionAffinityResource": "workspaceCache"
             }
         });
@@ -1480,26 +1467,6 @@ mod tests {
             Some(SessionAffinityResource::WorkspaceCache)
         );
         assert!(job.reuse_key().is_none());
-    }
-
-    #[test]
-    fn job_reuse_key_prefers_snapshot_and_falls_back_to_cli_session() {
-        let explicit: Job = serde_json::from_value(json!({
-            "runId": "550e8400-e29b-41d4-a716-446655440000",
-            "experimentalProfile": "browser",
-            "cliAgentSessionId": "cli-session",
-            "reuseKey": "thread:chat-thread"
-        }))
-        .unwrap();
-        assert_eq!(explicit.reuse_key().as_deref(), Some("thread:chat-thread"));
-
-        let fallback: Job = serde_json::from_value(json!({
-            "runId": "550e8400-e29b-41d4-a716-446655440000",
-            "experimentalProfile": "browser",
-            "cliAgentSessionId": "cli-session"
-        }))
-        .unwrap();
-        assert_eq!(fallback.reuse_key().as_deref(), Some("session:cli-session"));
     }
 
     #[test]

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -352,6 +352,7 @@ export async function publishRunnerJobNotification(
   runId: string,
   profile: string,
   metadata?: {
+    /** Raw key required for runner-local affinity matching; it stays on the internal runner-group channel. */
     readonly reuseKey: string | null;
     readonly cliAgentSessionId: string | null;
     readonly historyGenerationAffinityProtectedUntil: string | null;

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3595,6 +3595,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         expect(events[0]).toStrictEqual(
           expect.objectContaining({
             session_affinity_resource: resource,
+            reuse_key_kind: "session",
           }),
         );
       }
@@ -3800,6 +3801,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           session_affinity: "protected",
           session_affinity_resource: "reusableSandbox",
           history_generation_affinity: "protected",
+          reuse_key_kind: "session",
         }),
       );
     }
@@ -4522,6 +4524,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
           session_affinity: "no_session",
           session_affinity_resource: "none",
           history_generation_affinity: "no_session",
+          reuse_key_kind: "none",
         }),
       );
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -1301,6 +1301,17 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       sessionAffinityResource: "reusableSandbox",
       affinityProtectedUntil: expect.any(String),
     });
+    for (const actionType of [
+      "runner_notification_queue_to_entry",
+      "runner_poll_pending_job_lookup",
+    ]) {
+      expect(sandboxOperationEventsForRun(runId)).toContainEqual(
+        expect.objectContaining({
+          op_type: actionType,
+          reuse_key_kind: "thread",
+        }),
+      );
+    }
 
     const claim = await runsApi.claimRunnerJob(runId);
     expect(claim.reuseKey).toBe(reuseKey);

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -89,6 +89,7 @@ import {
   tryNormalizeSessionHistoryBlobEncoding,
 } from "../services/session-history-blobs";
 import {
+  runnerReuseKeyTelemetryKind,
   runnerSessionAffinityPollPriority,
   runnerSessionAffinityLookupError,
   runnerSessionAffinityProtection,
@@ -505,6 +506,7 @@ function recordPollTimingMetrics(args: {
   readonly sessionAffinity: string;
   readonly sessionAffinityResource: string;
   readonly historyGenerationAffinity: string;
+  readonly reuseKeyKind: "thread" | "session" | "none";
   readonly queueCreatedAtMs: number;
   readonly pollRequestStartedAtMs: number;
   readonly pendingJobLookupStartedAtMs: number;
@@ -518,6 +520,7 @@ function recordPollTimingMetrics(args: {
     session_affinity: args.sessionAffinity,
     session_affinity_resource: args.sessionAffinityResource,
     history_generation_affinity: args.historyGenerationAffinity,
+    reuse_key_kind: args.reuseKeyKind,
   };
   if (args.pollReason) {
     dimensions.poll_reason = args.pollReason;
@@ -655,7 +658,6 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!pendingJob) {
     return { status: 200 as const, body: { job: null } };
   }
-
   const affinity =
     (await tapError(
       runnerSessionAffinityProtection({
@@ -677,7 +679,6 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       },
     )) ?? runnerSessionAffinityLookupError();
   signal.throwIfAborted();
-  const pollResponseAtMs = now();
   recordPollTimingMetrics({
     runId: pendingJob.runId,
     runnerGroup: group,
@@ -687,11 +688,12 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     sessionAffinity: affinity.status,
     sessionAffinityResource: runnerSessionAffinityTelemetryResource(affinity),
     historyGenerationAffinity: affinity.historyGenerationStatus,
+    reuseKeyKind: runnerReuseKeyTelemetryKind(pendingJob.reuseKey),
     queueCreatedAtMs: pendingJob.createdAt.getTime(),
     pollRequestStartedAtMs,
     pendingJobLookupStartedAtMs,
     pendingJobLookupFinishedAtMs,
-    pollResponseAtMs,
+    pollResponseAtMs: now(),
   });
 
   return {

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -4,6 +4,7 @@ import { now } from "../external/time";
 import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
 import {
+  runnerReuseKeyTelemetryKind,
   runnerSessionAffinityLookupError,
   runnerSessionAffinityProtection,
   runnerSessionAffinityTelemetryResource,
@@ -76,6 +77,7 @@ export async function notifyRunnerJob(
     session_affinity: affinity.status,
     session_affinity_resource: runnerSessionAffinityTelemetryResource(affinity),
     history_generation_affinity: affinity.historyGenerationStatus,
+    reuse_key_kind: runnerReuseKeyTelemetryKind(args.reuseKey),
   };
   // Queue-relative actions are cumulative boundaries. Affinity and publish
   // durations are nested children and must not be added to those boundaries.

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -368,3 +368,12 @@ export function runnerSessionAffinityTelemetryResource(
 ): "reusableSandbox" | "workspaceCache" | "none" {
   return affinity.resource ?? "none";
 }
+
+export function runnerReuseKeyTelemetryKind(
+  reuseKey: string | null,
+): "thread" | "session" | "none" {
+  if (reuseKey === null) {
+    return "none";
+  }
+  return reuseKey.startsWith("thread:") ? "thread" : "session";
+}


### PR DESCRIPTION
## Summary

- remove the expired runner compatibility fallback that synthesized `session:{cliAgentSessionId}` when `reuseKey` was absent, including the Ably direct-candidate path
- keep the raw realtime `reuseKey` and document why runner-local affinity matching requires it
- add `reuse_key_kind` (`thread`, `session`, or `none`) to the API-side sandbox operation telemetry emitted for runner poll and realtime dispatch

## Realtime reuse key conclusion

The raw field must remain in the job notification. `api_ably_supervisor.rs` reads it into the direct candidate, and `api_direct_candidates.rs` carries it into local admission and IdlePool matching. Replacing it with a fingerprint would make the local runner miss the affinity key.

The `runner-group:{group}` channel is an internal API-to-runner control channel: the runner token route requires runner authentication, grants subscribe-only capability for that group, and platform user tokens cover only `user:{id}` channels. The source audit found no raw reuse key in logs or telemetry; runner logs use `short_digest` fingerprints plus the non-sensitive kind.

## Deployment compatibility

The API has written the reuse-key snapshot for every enqueued run since `api-v1.360.0`, the compatible runner is live as `runner-rs-v0.151.0`, and legacy queue rows have expired beyond the two-hour TTL. Missing `reuseKey` now means no affinity in both poll and realtime notification paths.

The runner Axiom WARN+ threshold is unchanged, and no dataset is added.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `pnpm exec prettier --check` for all changed API files
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`

Runner compilation and targeted Rust tests are left to Linux CI because the local macOS build stops in unchanged `process-control-ipc` code on Linux-only `libc::accept4` / `SOCK_CLOEXEC`. Targeted API integration tests were attempted but the local test database is behind main and the migration command has no valid synced `DATABASE_URL`; PR CI remains the authoritative database-backed validation.

Closes #24331
Part of #24191
