### PR TITLE
test(mitm-addon): cover rejected sigv4 signing contexts

### DIFF
--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -51,11 +51,17 @@ def _aws_s3_example_credentials() -> AwsSigV4Credentials:
 
 def _header_auth_headers(
     amz_date: str = DEFAULT_SIGV4_TIMESTAMP,
+    *,
+    authorization: str | None = None,
 ) -> list[tuple[str, str]]:
     return [
         (
             "Authorization",
-            aws_sigv4_authorization(date=amz_date[:8]),
+            (
+                aws_sigv4_authorization(date=amz_date[:8])
+                if authorization is None
+                else authorization
+            ),
         ),
         ("X-Amz-Date", amz_date),
         ("Host", STS_HOST),
@@ -109,6 +115,54 @@ def _presigned_url(
     timestamp: str = DEFAULT_SIGV4_TIMESTAMP,
 ) -> str:
     return aws_sigv4_presigned_url(host, date=timestamp[:8], timestamp=timestamp)
+
+
+_REJECTED_SIGNING_CONTEXTS = (
+    pytest.param(
+        _presigned_url(STS_HOST),
+        _header_auth_headers(),
+        "Ambiguous AWS auth location",
+        id="mixed-header-query-auth",
+    ),
+    pytest.param(
+        f"https://{STS_HOST}/",
+        _header_auth_headers(authorization=aws_sigv4_authorization(algorithm="AWS4-HMAC-SHA1")),
+        "Unsupported AWS signing algorithm",
+        id="unsupported-algorithm",
+    ),
+    pytest.param(
+        f"https://{STS_HOST}/",
+        _header_auth_headers(authorization=aws_sigv4_authorization(service="s3express")),
+        "S3 Express signing is not supported by this runner",
+        id="s3express",
+    ),
+)
+
+
+@pytest.mark.parametrize(("url", "headers", "error"), _REJECTED_SIGNING_CONTEXTS)
+def test_request_requires_body_for_signing_rejects_invalid_signing_context(
+    url: str,
+    headers: list[tuple[str, str]],
+    error: str,
+) -> None:
+    with pytest.raises(AwsSigV4SigningError, match=error):
+        request_requires_body_for_signing(url=url, headers=headers)
+
+
+@pytest.mark.parametrize(("url", "headers", "error"), _REJECTED_SIGNING_CONTEXTS)
+def test_sign_request_rejects_invalid_signing_context(
+    url: str,
+    headers: list[tuple[str, str]],
+    error: str,
+) -> None:
+    with pytest.raises(AwsSigV4SigningError, match=error):
+        sign_request(
+            method="GET",
+            url=url,
+            headers=headers,
+            body=None,
+            credentials=_credentials(),
+        )
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -398,6 +398,29 @@ async def test_re_signs_query_sigv4_request_preserves_literal_plus(
     assert query["EncodedPlus"] == "c+d"
 
 
+async def test_mixed_header_query_sigv4_request_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    authorization = aws_sigv4_authorization()
+    flow = real_flow(
+        with_response=False,
+        host=STS_HOST,
+        path=aws_sigv4_presigned_query_path(),
+        method="GET",
+        request_headers=headers(
+            *aws_sigv4_header_auth_headers(authorization=authorization),
+        ),
+    )
+
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+
+    assert_sigv4_failed_closed(result, flow, "Ambiguous AWS auth location")
+    assert flow.request.headers["authorization"] == authorization
+
+
 async def test_sigv4a_request_fails_closed(real_flow, headers, tmp_path, mitm_ctx):
     flow = real_flow(
         with_response=False,


### PR DESCRIPTION
## Summary

- cover mixed header/query auth, unsupported algorithms, and `s3express` through both public SigV4 signer entry points
- verify the firewall returns a local failure and preserves placeholder auth instead of producing a real-credential upstream request
- mutation-check each guard so removing it fails the focused tests

## Scope

Test-only change. This does not modify signing behavior or add support for new AWS signing modes.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_aws_sigv4.py tests/test_firewall_aws_sigv4_auth.py` (134 passed)
- `uv run --no-sync python -m pytest tests/` (4544 passed)
- temporary removal of each targeted guard caused both corresponding public-entry tests to fail
- `git diff --check`

Closes #24314
