### PR TITLE
refactor(runner): retire reuse key fallback

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -3,7 +3,6 @@
 //! `run()` owns the provider discovery future and reactor scheduling. This
 //! module owns the body that turns a discovered job into a claimed spawned job.
 
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Instant;
@@ -171,7 +170,7 @@ pub(super) async fn handle_discovered_job(
     // briefly advertise stale workspace-cache affinity for an active session.
     let active_reuse_key_guard = ActiveReuseKeyGuard::new(
         ctx.spawn_ctx.active_reuse_keys.clone(),
-        claimed.context().reuse_key().map(Cow::into_owned),
+        claimed.context().reuse_key().map(str::to_owned),
     );
 
     let (reuse_entry, active_lease, reuse_result, idle_snapshot, needs_session_affinity_refresh) =
@@ -686,8 +685,7 @@ async fn activate_reserved_idle(
     let reserved_reuse_key = reservation.reuse_key().to_owned();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
 
-    if !resume_session_valid || requested_reuse_key.as_deref() != Some(reserved_reuse_key.as_str())
-    {
+    if !resume_session_valid || requested_reuse_key != Some(reserved_reuse_key.as_str()) {
         let reuse_result = if requested_reuse_key.is_none() || !resume_session_valid {
             SandboxReuseResult::NoSessionId
         } else {
@@ -876,7 +874,7 @@ async fn try_reuse_from_pool(
     // so unpark does not block other take/park operations.
     let (taken, snapshot) = {
         let mut pool = ctx.idle_pool.lock().await;
-        let taken = pool.take(&reuse_key);
+        let taken = pool.take(reuse_key);
         let snapshot = taken.as_ref().map(|_| pool.status_snapshot());
         (taken, snapshot)
     };
@@ -887,7 +885,7 @@ async fn try_reuse_from_pool(
         && ctx
             .spawn_ctx
             .held_session_snapshot
-            .might_contain_workspace_cache_reuse_key(&reuse_key);
+            .might_contain_workspace_cache_reuse_key(reuse_key);
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::HeldSessionStateRefresh, started_at);
     let needs_session_affinity_refresh = took_idle_session || claimed_workspace_cache_reuse_key;
     match taken {
@@ -909,8 +907,8 @@ async fn try_reuse_from_pool(
                 if let Err(mismatch) = validation {
                     warn!(
                         run_id = %run_id,
-                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reuse_key),
-                        reuse_key_kind = reuse_key_kind(&reuse_key),
+                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
+                        reuse_key_kind = reuse_key_kind(reuse_key),
                         profile = %profile_name,
                         mismatch = mismatch.as_str(),
                         "workspace promotion identity mismatch, destroying idle VM and falling through to fresh create"
@@ -939,8 +937,8 @@ async fn try_reuse_from_pool(
                 } => {
                     info!(
                         run_id = %run_id,
-                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reuse_key),
-                        reuse_key_kind = reuse_key_kind(&reuse_key),
+                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
+                        reuse_key_kind = reuse_key_kind(reuse_key),
                         "reusing idle VM for reuse key"
                     );
                     // Idle entry already holds budget. Drop the speculative
@@ -958,8 +956,8 @@ async fn try_reuse_from_pool(
                 IdleUnparkResult::Failed { destroy_job, error } => {
                     warn!(
                         run_id = %run_id,
-                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reuse_key),
-                        reuse_key_kind = reuse_key_kind(&reuse_key),
+                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
+                        reuse_key_kind = reuse_key_kind(reuse_key),
                         error = %error,
                         "unpark failed, destroying idle VM and falling through to fresh create"
                     );
@@ -977,8 +975,8 @@ async fn try_reuse_from_pool(
         Some(stale) if stale.profile_name() == profile_name => {
             info!(
                 run_id = %run_id,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reuse_key),
-                reuse_key_kind = reuse_key_kind(&reuse_key),
+                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
+                reuse_key_kind = reuse_key_kind(reuse_key),
                 profile = %profile_name,
                 "idle VM device rate limiter mismatch, destroying"
             );
@@ -998,8 +996,8 @@ async fn try_reuse_from_pool(
         Some(stale) => {
             info!(
                 run_id = %run_id,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reuse_key),
-                reuse_key_kind = reuse_key_kind(&reuse_key),
+                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
+                reuse_key_kind = reuse_key_kind(reuse_key),
                 old_profile = %stale.profile_name(),
                 new_profile = %profile_name,
                 "idle VM profile mismatch, destroying"
@@ -1020,8 +1018,8 @@ async fn try_reuse_from_pool(
         None => {
             info!(
                 run_id = %run_id,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reuse_key),
-                reuse_key_kind = reuse_key_kind(&reuse_key),
+                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
+                reuse_key_kind = reuse_key_kind(reuse_key),
                 "no idle VM found for reuse key"
             );
             (

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -4,7 +4,6 @@
 //! owns the spawned task body: executor orchestration, provider completion,
 //! deferred telemetry/network-log uploads, and outer-task panic cleanup.
 
-use std::borrow::Cow;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -505,7 +504,7 @@ pub(super) fn spawn_job(
     } = request;
     let (context, completion_auth, active_input_source) = claimed.into_parts();
     let run_id = context.run_id;
-    let reuse_key = context.reuse_key().map(Cow::into_owned);
+    let reuse_key = context.reuse_key().map(str::to_owned);
     let cli_agent_session_id = if executor::validate_resume_session_id(&context).is_ok() {
         context.cli_agent_session_id().map(String::from)
     } else {

--- a/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
@@ -8,33 +8,32 @@ use super::super::support::{
 use crate::types::SandboxReuseResult;
 
 // -----------------------------------------------------------------------
-// Test 9: idle pool park/take is gated on session ID availability
+// Test 9: idle pool park/take is gated on reuse-key availability
 //
-// With a session ID, the VM is parked after execution; without one,
-// the VM is destroyed (no key to re-find it under).
+// With a reuse key, the VM is parked after execution; a CLI session ID alone
+// does not provide a key to re-find it under.
 // -----------------------------------------------------------------------
 
-fn context_with_session_opt(
+fn context_with_session_reuse_key(
     run_id: RunId,
-    session_id: Option<&str>,
+    session_id: &str,
 ) -> crate::types::ExecutionContext {
     let mut ctx = minimal_context(run_id);
-    if let Some(sid) = session_id {
-        ctx.resume_session = Some(crate::types::ResumeSession::inline(
-            sid.to_string(),
-            String::new(),
-        ));
-    }
+    ctx.reuse_key = Some(format!("session:{session_id}"));
+    ctx.resume_session = Some(crate::types::ResumeSession::inline(
+        session_id.to_string(),
+        String::new(),
+    ));
     ctx
 }
 
 #[tokio::test(start_paused = true)]
-async fn job_with_session_parks_vm() {
+async fn job_with_reuse_key_parks_vm() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
-    let ctx = context_with_session_opt(run_id, Some("sess-1"));
+    let ctx = context_with_session_reuse_key(run_id, "sess-1");
     push_job(&env, run_id, "vm0/default", Some(ctx));
 
     let c = env
@@ -53,13 +52,16 @@ async fn job_with_session_parks_vm() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn job_without_session_does_not_park() {
+async fn job_without_reuse_key_does_not_park() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
-    // No session — parking requires a session ID.
-    let ctx = context_with_session_opt(run_id, None);
+    let mut ctx = minimal_context(run_id);
+    ctx.resume_session = Some(crate::types::ResumeSession::inline(
+        "sess-1".to_string(),
+        String::new(),
+    ));
     push_job(&env, run_id, "vm0/default", Some(ctx));
 
     let c = env
@@ -70,11 +72,7 @@ async fn job_without_session_does_not_park() {
     assert_eq!(c.unwrap().exit_code, 0);
 
     let pool = env.idle_pool.lock().await;
-    assert_eq!(
-        pool.len(),
-        0,
-        "VM should NOT be parked without a session ID"
-    );
+    assert_eq!(pool.len(), 0, "VM should NOT be parked without a reuse key");
     drop(pool);
 
     shutdown(&env, run_handle).await;

--- a/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
@@ -44,7 +44,11 @@ async fn job_with_reuse_key_parks_vm() {
     assert_eq!(c.unwrap().exit_code, 0);
 
     let pool = env.idle_pool.lock().await;
-    assert_eq!(pool.len(), 1, "VM should be parked when session is present");
+    assert_eq!(
+        pool.len(),
+        1,
+        "VM should be parked when a reuse key is present"
+    );
     assert!(pool.held_sessions().contains(&"session:sess-1".to_string()));
     drop(pool);
 

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -599,9 +599,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
     let expected_promotion_reuse_key = if resume_session_error.is_some() {
         idle_reuse_key.as_str()
     } else {
-        claimed_reuse_key
-            .as_deref()
-            .unwrap_or(idle_reuse_key.as_str())
+        claimed_reuse_key.unwrap_or(idle_reuse_key.as_str())
     };
     let workspace_image = match resolve_reused_workspace_promotion(
         config.workspace_cache.as_ref(),
@@ -643,7 +641,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
                         run_id,
                         sandbox_id,
                         profile_name: &params.profile_name,
-                        reuse_key: claimed_reuse_key.as_deref(),
+                        reuse_key: claimed_reuse_key,
                         cli_agent_session_id: context.cli_agent_session_id(),
                         working_dir: CANONICAL_WORKING_DIR,
                         image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -763,7 +763,7 @@ pub(super) async fn prepare_workspace_image(
                 run_id: context.run_id,
                 sandbox_id,
                 profile_name,
-                reuse_key: reuse_key.as_deref(),
+                reuse_key,
                 cli_agent_session_id: context.cli_agent_session_id(),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+fn set_session_identity(context: &mut crate::types::ExecutionContext, session_id: &str) {
+    context.reuse_key = Some(format!("session:{session_id}"));
+    context.resume_session = Some(ResumeSession::inline(
+        session_id.into(),
+        r#"{"type":"init"}"#.into(),
+    ));
+}
+
 #[tokio::test]
 async fn workspace_mount_retry_starts_a_new_codex_catalog_prefetch_owner() {
     let dir = tempfile::tempdir().unwrap();
@@ -17,10 +25,7 @@ async fn workspace_mount_retry_starts_a_new_codex_catalog_prefetch_owner() {
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = codex_oauth_context();
     let session_id = "00000000-0000-4000-8000-000000023425";
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_identity(&mut ctx, session_id);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -95,10 +100,7 @@ async fn execute_inner_retries_fresh_after_workspace_cache_hit_create_failure() 
         storages: vec![storage],
         artifacts: Vec::new(),
     });
-    ctx.resume_session = Some(ResumeSession::inline(
-        "sess-cache-hit".into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_identity(&mut ctx, "sess-cache-hit");
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -200,10 +202,7 @@ async fn execute_inner_dns_readiness_retry_replaces_consumed_workspace_cache_hit
     }));
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        "sess-cache-dns-retry".into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_identity(&mut ctx, "sess-cache-dns-retry");
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -281,10 +280,7 @@ async fn process_timeout_invalidates_consumed_workspace_cache_without_fallback()
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let session_id = "sess-cache-dns-process-timeout";
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_identity(&mut ctx, session_id);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -379,10 +375,7 @@ async fn dns_replacement_records_completion_when_fresh_storage_prepare_fails() {
     let storage_fingerprints =
         crate::storage_fingerprints::StorageFingerprints::from_manifest(&manifest);
     ctx.storage_manifest = Some(manifest);
-    ctx.resume_session = Some(ResumeSession::inline(
-        "sess-cache-dns-prepare-failure".into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_identity(&mut ctx, "sess-cache-dns-prepare-failure");
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -448,10 +441,7 @@ async fn execute_inner_cache_hit_retry_requires_completed_cleanup() {
     overrides.push_destroy_panic("simulated destroy panic");
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        "sess-cache-cleanup-uncertain".into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_identity(&mut ctx, "sess-cache-cleanup-uncertain");
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -498,10 +488,7 @@ async fn execute_inner_uses_workspace_cache_when_configured() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        "sess-cache-default".into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_identity(&mut ctx, "sess-cache-default");
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -570,10 +557,7 @@ async fn execute_inner_records_workspace_cache_lock_busy_prepare_telemetry() {
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
     let session_id = "sess-cache-lock-busy-prepare";
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_identity(&mut ctx, session_id);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -640,10 +624,7 @@ async fn execute_inner_does_not_retry_workspace_cache_hit_after_proxy_register_f
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        "sess-register-fail".into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_identity(&mut ctx, "sess-register-fail");
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -736,10 +717,7 @@ async fn execute_job_reuse_uses_workspace_cache_when_configured() {
     let (idle_sandbox, _lease) = make_reusable_idle_sandbox(sandbox, source_ip, session_id).await;
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_identity(&mut ctx, session_id);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -790,10 +768,7 @@ async fn cached_reuse_workspace_promotion_identity_mismatch_stops_before_agent()
     .await;
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_identity(&mut ctx, session_id);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -846,10 +821,7 @@ async fn execute_job_reuse_without_workspace_cache_config_invalidates_held_cache
             .await;
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_identity(&mut ctx, session_id);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -905,10 +877,7 @@ async fn unconfigured_cache_reuse_stops_when_cache_invalidation_fails() {
     tokio::fs::create_dir(&current_image).await.unwrap();
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_identity(&mut ctx, session_id);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -948,10 +917,7 @@ async fn cached_reuse_validation_failure_keeps_workspace_cache_hidden() {
             .await;
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession::inline(
-        session_id.into(),
-        r#"{"type":"init"}"#.into(),
-    ));
+    set_session_identity(&mut ctx, session_id);
     ctx.environment = Some(HashMap::from([(
         "OPENAI_API_KEY".into(),
         "sk-proj-real-openai-secret".into(),

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1,6 +1,5 @@
 //! [`JobProvider`] backed by an Ably control plane + HTTP polling + REST API.
 
-use std::borrow::Cow;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -552,7 +551,7 @@ impl JobProvider for ApiProvider {
                         return None;
                     }
                     let run_id = job.run_id;
-                    let reuse_key = job.reuse_key().map(Cow::into_owned);
+                    let reuse_key = job.reuse_key().map(str::to_owned);
                     let cli_agent_session_id = job.cli_agent_session_id;
                     let history_generation_run_id = job.history_generation_run_id;
                     let history_generation_affinity_protected_until =
@@ -2223,7 +2222,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_returns_http_poll_job_after_wakeup() {
+    async fn discover_http_poll_does_not_infer_reuse_key_from_cli_session() {
         let server = MockServer::start_async().await;
         let run_id: RunId = "00000000-0000-0000-0000-000000000003".parse().unwrap();
         let history_generation_run_id: RunId =
@@ -2258,6 +2257,7 @@ mod tests {
 
         assert_eq!(discovered.run_id(), run_id);
         assert_eq!(discovered.profile_name(), "vm0/large");
+        assert!(discovered.reuse_key().is_none());
         assert_eq!(discovered.cli_agent_session_id(), Some("sess-poll"));
         assert_eq!(
             discovered.history_generation_run_id(),
@@ -3443,6 +3443,10 @@ mod tests {
             "test-region"
         );
         assert_eq!(context.storage_manifest.as_ref().unwrap().storages.len(), 1);
+        assert_eq!(
+            context.reuse_key(),
+            Some("thread:00000000-0000-4000-8000-000000020986")
+        );
         assert_eq!(context.cli_agent_session_id(), Some("fixture-session-id"));
         assert_eq!(
             context.environment.as_ref().unwrap()["FIXTURE_MODEL"],
@@ -3574,6 +3578,46 @@ mod tests {
         assert_eq!(context.prompt, "previous response");
         assert!(context.append_system_prompt.is_none());
         assert!(context.billable_firewalls.is_empty());
+        claim_mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn api_provider_claim_does_not_infer_reuse_key_from_resume_session() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::nil();
+        let claim_path = format!("/api/runners/jobs/{run_id}/claim");
+        let claim_mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(claim_path.as_str());
+                then.status(200).json_body(serde_json::json!({
+                    "runId": run_id,
+                    "prompt": "response without reuse key",
+                    "sandboxToken": "no-reuse-key-sandbox-token",
+                    "cliAgentType": "claude_code",
+                    "resumeSession": {
+                        "sessionId": "sess-claim",
+                        "sessionHistory": "{}"
+                    }
+                }));
+            })
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+
+        let claimed = provider
+            .claim(JobCandidate::new(
+                run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+            ))
+            .await
+            .expect("claim response without reuse key should decode");
+        let context = claimed.context();
+
+        assert_eq!(context.cli_agent_session_id(), Some("sess-claim"));
+        assert!(context.reuse_key().is_none());
         claim_mock.assert_calls_async(1).await;
     }
 

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -692,12 +692,7 @@ async fn handle_ably_message_with_network_policy_refresh(
                         notif.run_id,
                         profile.to_owned(),
                         notification_received_at,
-                        notif.reuse_key.map(str::to_owned).or_else(|| {
-                            // TODO(deployment-compatibility): Remove this fallback after the next release.
-                            notif
-                                .cli_agent_session_id
-                                .map(|session_id| format!("session:{session_id}"))
-                        }),
+                        notif.reuse_key.map(str::to_owned),
                         notif.cli_agent_session_id.map(str::to_owned),
                         notif.affinity_protected_until.map(str::to_owned),
                     )
@@ -1896,6 +1891,7 @@ mod tests {
             serde_json::json!({
                 "runId": "00000000-0000-0000-0000-000000000001",
                 "profile": "vm0/default",
+                "reuseKey": "thread:ably-thread",
                 "cliAgentSessionId": "sess-ably",
                 "historyGenerationRunId": "00000000-0000-0000-0000-000000000098",
                 "historyGenerationAffinityProtectedUntil": "2999-01-01T00:00:00.000Z",
@@ -1913,7 +1909,7 @@ mod tests {
         );
         assert_eq!(candidate.profile_name(), "vm0/default");
         let candidate = candidate.into_job_candidate();
-        assert_eq!(candidate.reuse_key(), Some("session:sess-ably"));
+        assert_eq!(candidate.reuse_key(), Some("thread:ably-thread"));
         assert_eq!(candidate.cli_agent_session_id(), Some("sess-ably"));
         assert_eq!(
             candidate.history_generation_run_id(),
@@ -1927,6 +1923,30 @@ mod tests {
         );
         assert_no_direct_candidate(&direct_candidates).await;
         assert!(!wakeups.snapshot().await.poll_now);
+    }
+
+    #[tokio::test]
+    async fn job_notification_does_not_infer_reuse_key_from_cli_session() {
+        let tokens = RunCancellationRegistry::new();
+        let wakeups = PollWakeups::new(true);
+        let direct_candidates = direct_candidate_inbox();
+        let profiles = default_profiles();
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000001",
+                "profile": "vm0/default",
+                "cliAgentSessionId": "sess-ably"
+            }),
+        );
+
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
+
+        let candidate = pop_direct_candidate(&direct_candidates)
+            .await
+            .into_job_candidate();
+        assert!(candidate.reuse_key().is_none());
+        assert_eq!(candidate.cli_agent_session_id(), Some("sess-ably"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::IpAddr;
 use std::sync::Arc;
@@ -48,16 +47,6 @@ pub struct Job {
     pub session_affinity_resource: Option<SessionAffinityResource>,
 }
 
-fn deployment_compatible_reuse_key<'a>(
-    reuse_key: Option<&'a str>,
-    cli_agent_session_id: Option<&'a str>,
-) -> Option<Cow<'a, str>> {
-    reuse_key.map(Cow::Borrowed).or_else(|| {
-        // TODO(deployment-compatibility): Remove this fallback after the next release.
-        cli_agent_session_id.map(|session_id| Cow::Owned(format!("session:{session_id}")))
-    })
-}
-
 pub(crate) fn reuse_key_kind(reuse_key: &str) -> &'static str {
     if reuse_key.starts_with("thread:") {
         "thread"
@@ -67,11 +56,8 @@ pub(crate) fn reuse_key_kind(reuse_key: &str) -> &'static str {
 }
 
 impl Job {
-    pub(crate) fn reuse_key(&self) -> Option<Cow<'_, str>> {
-        deployment_compatible_reuse_key(
-            self.reuse_key.as_deref(),
-            self.cli_agent_session_id.as_deref(),
-        )
+    pub(crate) fn reuse_key(&self) -> Option<&str> {
+        self.reuse_key.as_deref()
     }
 }
 
@@ -1262,8 +1248,8 @@ where
 }
 
 impl ExecutionContext {
-    pub(crate) fn reuse_key(&self) -> Option<Cow<'_, str>> {
-        deployment_compatible_reuse_key(self.reuse_key.as_deref(), self.cli_agent_session_id())
+    pub(crate) fn reuse_key(&self) -> Option<&str> {
+        self.reuse_key.as_deref()
     }
 
     /// Extract the Claude/Codex CLI agent session id from `resume_session`.
@@ -1480,26 +1466,6 @@ mod tests {
             Some(SessionAffinityResource::WorkspaceCache)
         );
         assert!(job.reuse_key().is_none());
-    }
-
-    #[test]
-    fn job_reuse_key_prefers_snapshot_and_falls_back_to_cli_session() {
-        let explicit: Job = serde_json::from_value(json!({
-            "runId": "550e8400-e29b-41d4-a716-446655440000",
-            "experimentalProfile": "browser",
-            "cliAgentSessionId": "cli-session",
-            "reuseKey": "thread:chat-thread"
-        }))
-        .unwrap();
-        assert_eq!(explicit.reuse_key().as_deref(), Some("thread:chat-thread"));
-
-        let fallback: Job = serde_json::from_value(json!({
-            "runId": "550e8400-e29b-41d4-a716-446655440000",
-            "experimentalProfile": "browser",
-            "cliAgentSessionId": "cli-session"
-        }))
-        .unwrap();
-        assert_eq!(fallback.reuse_key().as_deref(), Some("session:cli-session"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- remove the Runner fallback that derived `reuseKey` from a CLI agent session ID
- consume only the explicit `reuseKey` supplied by HTTP poll, HTTP claim, or Ably job payloads
- keep CLI session identity independent for resume/history behavior and update reuse/cache tests to provide explicit keys

## Scope

- Runner-only change; no API, queue schema, database, or generated contract changes
- missing `reuseKey` remains a valid cold-path job and does not fail decoding or execution
- local-provider session reuse remains explicit and unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p runner --all-targets --all-features`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features -- --test-threads=4`

## Deployment gate

Merge only after old API producers have drained, the current API is at least `api-v1.360.0`, the compatibility observation window has elapsed, no queued legacy payload remains, and `runner-rs-v0.151.0` or newer is healthy.

Closes #24311
