### PR TITLE
test(mitm-addon): cover cross-chunk sse discard bounds

### DIFF
--- a/crates/runner/mitm-addon/tests/test_sse.py
+++ b/crates/runner/mitm-addon/tests/test_sse.py
@@ -309,6 +309,21 @@ def test_long_malformed_control_line_recovers_for_next_event() -> None:
     assert handler.events == [("target", b"ok")]
 
 
+def test_long_malformed_control_line_does_not_retain_cross_chunk_continuation() -> None:
+    max_control_line_bytes = 16
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler, max_control_line_bytes=max_control_line_bytes)
+
+    scanner.feed(b"x" * (max_control_line_bytes + 1))
+    for _ in range(64):
+        scanner.feed(b"y" * 4096)
+        assert len(scanner._line_buf) <= max_control_line_bytes
+
+    scanner.feed(b"\nevent: target\ndata: ok\n\n")
+
+    assert handler.events == [("target", b"ok")]
+
+
 def test_long_malformed_control_line_discards_current_event() -> None:
     handler = _CaptureHandler({"target"})
     scanner = SseUsageScanner(handler)


### PR DESCRIPTION
## Summary

- add deterministic coverage for an overlong malformed SSE control line that continues across later `feed()` calls
- verify retained control-line state stays within the configured bound after every unterminated continuation chunk
- verify the scanner recovers after the discarded line terminates and captures the following target event

This is test-only. It does not change production code, dependencies, APIs, schemas, persisted data, protocols, deployment behavior, or cross-version compatibility.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest -q tests/test_sse.py` (25 passed)
- runtime retention mutation check (the new test failed as required with 4,096 retained bytes against a 16-byte bound)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,538 passed)
- repository pre-commit hooks (Ruff, file-size, and commitlint)

Closes #24315
