### PR TITLE
feat(feishu): add managed connector permission controls

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -33,6 +33,7 @@ import {
   zeroCustomConnectorValuesContract,
   zeroCustomConnectorsContract,
   type CreateCustomConnectorBody,
+  type CustomConnectorPermissionBundleResponse,
   type CustomConnectorResponse,
   type CustomConnectorValueInput,
   type PatchCustomConnectorBody,
@@ -1647,6 +1648,34 @@ export function createConnectorBddApi(context: TestContext) {
       const response = await api.requestListCustomConnectors(actor, [200]);
       expectStatus(response, 200);
       return response.body.connectors;
+    },
+
+    async requestCustomConnectorPermissions(
+      actor: ApiTestUser | null,
+      connectorId: string,
+      statuses: readonly (200 | 401 | 403 | 404 | 500)[],
+    ) {
+      const client = setupApp({ context })(zeroCustomConnectorByIdContract);
+      return await accept(
+        client.permissions({
+          params: { id: connectorId },
+          headers: authenticate(actor),
+        }),
+        statuses,
+      );
+    },
+
+    async readCustomConnectorPermissions(
+      actor: ApiTestUser,
+      connectorId: string,
+    ): Promise<CustomConnectorPermissionBundleResponse> {
+      const response = await api.requestCustomConnectorPermissions(
+        actor,
+        connectorId,
+        [200],
+      );
+      expectStatus(response, 200);
+      return response.body;
     },
 
     async requestPatchCustomConnector(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
@@ -170,6 +170,45 @@ async function createCustomConnectorWithOptionalPrefixVariable(
   return connector;
 }
 
+describe("GET /api/zero/custom-connectors/:id/permissions", () => {
+  it("returns permission metadata for a custom connector with a bundle", async () => {
+    const actor = bdd.user();
+    const connector = await createPermissionedCustomConnector(
+      actor,
+      "permission-metadata",
+    );
+
+    const response = await connectors.readCustomConnectorPermissions(
+      actor,
+      connector.id,
+    );
+
+    expect(response.ref).toBe("builtin:slack@1");
+    expect(response.permissions).toContainEqual(
+      expect.objectContaining({ name: "chat:write" }),
+    );
+    expect(response.defaultPolicies["chat:write"]).toBe("deny");
+  });
+
+  it("returns 404 when the custom connector has no permission bundle", async () => {
+    const actor = bdd.user();
+    const connector = await createCustomConnector(actor, "no-permissions");
+
+    const response = await connectors.requestCustomConnectorPermissions(
+      actor,
+      connector.id,
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Custom connector permission bundle not found",
+        code: "NOT_FOUND",
+      },
+    });
+  });
+});
+
 describe("GET /api/zero/agents/:id/custom-connectors", () => {
   it("returns 401 when the request is unauthenticated", async () => {
     const response = await connectors.requestAgentCustomConnectors(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -1372,14 +1372,14 @@ describe("Feishu integration", () => {
     expect(permissionBundle.body).toMatchObject({
       ref: "builtin:feishu@1",
       defaultPolicies: {
-        "standard:use": "ask",
+        "standard:use": "allow",
         "messages:send-as-user": "deny",
         "resources:delete": "deny",
-        "sharing:manage": "ask",
+        "sharing:manage": "allow",
         "chats:manage": "deny",
-        "comments:write": "ask",
-        "calendar:write": "ask",
-        "tasks:write": "ask",
+        "comments:write": "allow",
+        "calendar:write": "allow",
+        "tasks:write": "allow",
       },
     });
 
@@ -2249,15 +2249,15 @@ describe("Feishu integration", () => {
       },
     });
     expect(claim.networkPolicies?.[internalName]).toStrictEqual({
-      allow: [],
-      deny: ["messages:send-as-user", "resources:delete", "chats:manage"],
-      ask: [
+      allow: [
         "standard:use",
         "sharing:manage",
         "comments:write",
         "calendar:write",
         "tasks:write",
       ],
+      deny: ["messages:send-as-user", "resources:delete", "chats:manage"],
+      ask: [],
       unknownPolicy: "deny",
     });
     const permissionGrant = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -18,6 +18,7 @@ import {
   zeroCustomConnectorSecretContract,
   zeroCustomConnectorsContract,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { zeroFeishuConnectContract } from "@vm0/api-contracts/contracts/zero-feishu-connect";
 import { zeroFeishuOauthContract } from "@vm0/api-contracts/contracts/zero-feishu-oauth";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -2106,6 +2107,19 @@ describe("Feishu integration", () => {
       connectorList.body.connectors[0],
       "Expected connected Feishu custom connector",
     );
+    const customConnectorGrants = await accept(
+      setupApp({ context })(zeroAgentCustomConnectorsContract).get({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { id: defaultAgentId },
+      }),
+      [200],
+    );
+    expect(customConnectorGrants.body.grants).toStrictEqual([
+      {
+        customConnectorId: managedConnector.id,
+        permissionNames: [],
+      },
+    ]);
     const fileKey = `file_v2_${"a".repeat(1400)}`;
     await postEvent(
       callbackUrl,
@@ -2156,10 +2170,98 @@ describe("Feishu integration", () => {
                 Authorization: expect.stringContaining("secrets."),
               },
             },
+            permissions: expect.arrayContaining([
+              expect.objectContaining({
+                name: "standard:use",
+                rules: expect.arrayContaining([
+                  "GET /authen/v1/user_info",
+                  "GET /docx/{path*}",
+                ]),
+              }),
+              expect.objectContaining({
+                name: "messages:send-as-user",
+                rules: expect.arrayContaining([
+                  "POST /im/v1/messages",
+                  "POST /im/v1/messages/{message_id}/forward",
+                  "DELETE /im/v1/messages/{message_id}",
+                ]),
+              }),
+              expect.objectContaining({
+                name: "resources:delete",
+                rules: expect.arrayContaining([
+                  "DELETE /drive/{path*}",
+                  "DELETE /docx/{path*}",
+                ]),
+              }),
+              expect.objectContaining({
+                name: "sharing:manage",
+                rules: expect.arrayContaining([
+                  "PATCH /drive/v2/permissions/{path*}",
+                ]),
+              }),
+              expect.objectContaining({
+                name: "chats:manage",
+                rules: expect.arrayContaining([
+                  "POST /im/v1/chats/{chat_id}/members",
+                ]),
+              }),
+              expect.objectContaining({
+                name: "comments:write",
+                rules: expect.arrayContaining([
+                  "POST /drive/v1/files/{file_token}/comments",
+                ]),
+              }),
+              expect.objectContaining({
+                name: "calendar:write",
+                rules: expect.arrayContaining([
+                  "POST /calendar/v4/calendars/{calendar_id}/events",
+                ]),
+              }),
+              expect.objectContaining({
+                name: "tasks:write",
+                rules: expect.arrayContaining(["POST /task/v2/{path*}"]),
+              }),
+            ]),
           },
         ],
       },
     });
+    expect(claim.networkPolicies?.[internalName]).toStrictEqual({
+      allow: [],
+      deny: [
+        "messages:send-as-user",
+        "resources:delete",
+        "sharing:manage",
+        "chats:manage",
+        "comments:write",
+        "calendar:write",
+        "tasks:write",
+      ],
+      ask: ["standard:use"],
+      unknownPolicy: "deny",
+    });
+    const permissionGrant = await accept(
+      setupApp({ context })(zeroAgentCustomConnectorsContract).update({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { id: defaultAgentId },
+        body: {
+          grants: [
+            {
+              customConnectorId: managedConnector.id,
+              permissionNames: ["messages:send-as-user"],
+            },
+          ],
+          operation: "replace",
+        },
+      }),
+      [200],
+    );
+    expect(permissionGrant.body.grants).toStrictEqual([
+      {
+        customConnectorId: managedConnector.id,
+        permissionNames: ["messages:send-as-user"],
+      },
+    ]);
     expect(
       expectCanonicalStorageManifest(claim.storageManifest)?.storageMounts.some(
         (storage) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -14,6 +14,7 @@ import {
   chatThreadsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import {
+  zeroCustomConnectorByIdContract,
   zeroCustomConnectorOAuth2Contract,
   zeroCustomConnectorSecretContract,
   zeroCustomConnectorsContract,
@@ -1331,6 +1332,7 @@ describe("Feishu integration", () => {
         },
       ],
       authMode: "oauth",
+      permissionBundleRef: "builtin:feishu@1",
       connected: false,
       oauthConfig: {
         providerAdapter: "feishu",
@@ -1360,6 +1362,26 @@ describe("Feishu integration", () => {
     );
     expect(skillMarkdown).not.toContain("Okou Feishu");
     expect(skillMarkdown).not.toContain(managedConnector.id);
+    const permissionBundle = await accept(
+      setupApp({ context })(zeroCustomConnectorByIdContract).permissions({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { id: managedConnector.id },
+      }),
+      [200],
+    );
+    expect(permissionBundle.body).toMatchObject({
+      ref: "builtin:feishu@1",
+      defaultPolicies: {
+        "standard:use": "ask",
+        "messages:send-as-user": "deny",
+        "resources:delete": "deny",
+        "sharing:manage": "ask",
+        "chats:manage": "deny",
+        "comments:write": "ask",
+        "calendar:write": "ask",
+        "tasks:write": "ask",
+      },
+    });
 
     const customConnectorOAuthClient = setupApp({ context })(
       zeroCustomConnectorOAuth2Contract,
@@ -2228,16 +2250,14 @@ describe("Feishu integration", () => {
     });
     expect(claim.networkPolicies?.[internalName]).toStrictEqual({
       allow: [],
-      deny: [
-        "messages:send-as-user",
-        "resources:delete",
+      deny: ["messages:send-as-user", "resources:delete", "chats:manage"],
+      ask: [
+        "standard:use",
         "sharing:manage",
-        "chats:manage",
         "comments:write",
         "calendar:write",
         "tasks:write",
       ],
-      ask: ["standard:use"],
       unknownPolicy: "deny",
     });
     const permissionGrant = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -2213,6 +2213,7 @@ describe("Feishu integration", () => {
                 rules: expect.arrayContaining([
                   "DELETE /drive/{path*}",
                   "DELETE /docx/{path*}",
+                  "POST /bitable/v1/apps/{app_token}/tables/batch_delete",
                 ]),
               }),
               expect.objectContaining({
@@ -2225,6 +2226,8 @@ describe("Feishu integration", () => {
                 name: "chats:manage",
                 rules: expect.arrayContaining([
                   "POST /im/v1/chats/{chat_id}/members",
+                  "POST /im/v1/chats/{chat_id}/{path*}",
+                  "PATCH /im/v1/chats/{chat_id}/{path*}",
                 ]),
               }),
               expect.objectContaining({

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-get.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-get.ts
@@ -4,7 +4,10 @@ import { zeroCustomConnectorByIdContract } from "@vm0/api-contracts/contracts/ze
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf } from "../context/request";
-import { getCustomConnectorResponse } from "../services/zero-custom-connector.service";
+import {
+  getCustomConnectorPermissionBundle,
+  getCustomConnectorResponse,
+} from "../services/zero-custom-connector.service";
 import { notFound } from "../../lib/error";
 import type { RouteEntry } from "../route-entry";
 
@@ -24,6 +27,21 @@ const getInner$ = computed(async (get) => {
   return { status: 200 as const, body: connector };
 });
 
+const getPermissionsInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(zeroCustomConnectorByIdContract.permissions));
+  const permissions = await get(
+    getCustomConnectorPermissionBundle({
+      orgId: auth.orgId,
+      connectorId: params.id,
+    }),
+  );
+  if (!permissions) {
+    return notFound("Custom connector permission bundle not found");
+  }
+  return { status: 200 as const, body: permissions };
+});
+
 export const zeroCustomConnectorsGetRoutes: readonly RouteEntry[] = [
   {
     route: zeroCustomConnectorByIdContract.get,
@@ -34,6 +52,17 @@ export const zeroCustomConnectorsGetRoutes: readonly RouteEntry[] = [
         requiredCapability: "connector:read",
       },
       getInner$,
+    ),
+  },
+  {
+    route: zeroCustomConnectorByIdContract.permissions,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "connector:read",
+      },
+      getPermissionsInner$,
     ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -187,6 +187,7 @@ import {
   loadCustomConnectorPermissionBundle,
   type CustomConnectorPermissionBundle,
 } from "./custom-connector-permission-bundle.service";
+import { effectiveCustomConnectorPermissionBundleRef } from "./feishu-custom-connector-permissions";
 import {
   prepareAgentRunStorage,
   type PreparedAgentRunStorage,
@@ -3727,6 +3728,26 @@ interface BuildCustomConnectorRuntimeContextArgs {
   readonly timing?: ApiDispatchTimingCollector;
 }
 
+async function loadEffectiveCustomConnectorPermissionBundle(args: {
+  readonly row: CustomConnectorRuntimeDataRows[number];
+  readonly snapshot: ConnectorRuntimeSnapshot;
+}): Promise<CustomConnectorPermissionBundle | null | undefined> {
+  const ref = effectiveCustomConnectorPermissionBundleRef({
+    slug: args.row.connector.slug,
+    authMode: args.row.connector.authMode,
+    oauthProviderAdapter:
+      args.row.connector.oauthConfig?.providerAdapter ?? null,
+    prefixTemplates: args.row.connector.prefixTemplates,
+    permissionBundleRef: args.row.connector.permissionBundleRef,
+  });
+  return ref
+    ? ((await loadCustomConnectorPermissionBundle({
+        snapshot: args.snapshot,
+        ref,
+      })) ?? undefined)
+    : null;
+}
+
 function buildCustomConnectorPermissionPolicy(args: {
   readonly bundle: CustomConnectorPermissionBundle;
   readonly selectedPermissionNames: readonly string[];
@@ -3800,13 +3821,10 @@ async function buildCustomConnectorRuntimeContext(
       stats.recordNoAuthInjectionConnector();
       continue;
     }
-    const permissionBundle = row.connector.permissionBundleRef
-      ? await loadCustomConnectorPermissionBundle({
-          snapshot: args.connectorCatalogSnapshot,
-          ref: row.connector.permissionBundleRef,
-        })
-      : null;
-    if (row.connector.permissionBundleRef && !permissionBundle) {
+    const permissionBundle = await loadEffectiveCustomConnectorPermissionBundle(
+      { row, snapshot: args.connectorCatalogSnapshot },
+    );
+    if (permissionBundle === undefined) {
       continue;
     }
     const apis = await buildCustomConnectorRuntimeApis({

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -187,6 +187,7 @@ import {
   loadCustomConnectorPermissionBundle,
   type CustomConnectorPermissionBundle,
 } from "./custom-connector-permission-bundle.service";
+import { effectiveCustomConnectorPermissionBundleRef } from "./feishu-custom-connector-permissions";
 import {
   prepareAgentRunStorage,
   type PreparedAgentRunStorage,
@@ -3727,6 +3728,46 @@ interface BuildCustomConnectorRuntimeContextArgs {
   readonly timing?: ApiDispatchTimingCollector;
 }
 
+async function loadEffectiveCustomConnectorPermissionBundle(args: {
+  readonly row: CustomConnectorRuntimeDataRows[number];
+  readonly snapshot: ConnectorRuntimeSnapshot;
+}): Promise<CustomConnectorPermissionBundle | null | undefined> {
+  const ref = effectiveCustomConnectorPermissionBundleRef({
+    slug: args.row.connector.slug,
+    authMode: args.row.connector.authMode,
+    oauthProviderAdapter:
+      args.row.connector.oauthConfig?.providerAdapter ?? null,
+    prefixTemplates: args.row.connector.prefixTemplates,
+    permissionBundleRef: args.row.connector.permissionBundleRef,
+  });
+  return ref
+    ? ((await loadCustomConnectorPermissionBundle({
+        snapshot: args.snapshot,
+        ref,
+      })) ?? undefined)
+    : null;
+}
+
+function buildCustomConnectorPermissionPolicy(args: {
+  readonly bundle: CustomConnectorPermissionBundle;
+  readonly selectedPermissionNames: readonly string[];
+}): FirewallPolicy {
+  const selectedPermissionNames = new Set(args.selectedPermissionNames);
+  return {
+    policies: Object.fromEntries(
+      [...args.bundle.permissionNames].map((permissionName) => {
+        return [
+          permissionName,
+          selectedPermissionNames.has(permissionName)
+            ? "allow"
+            : (args.bundle.defaultPolicies[permissionName] ?? "deny"),
+        ];
+      }),
+    ),
+    unknownPolicy: "deny",
+  };
+}
+
 async function buildCustomConnectorRuntimeContext(
   args: BuildCustomConnectorRuntimeContextArgs,
 ): Promise<CustomConnectorRuntimeContext> {
@@ -3780,13 +3821,10 @@ async function buildCustomConnectorRuntimeContext(
       stats.recordNoAuthInjectionConnector();
       continue;
     }
-    const permissionBundle = row.connector.permissionBundleRef
-      ? await loadCustomConnectorPermissionBundle({
-          snapshot: args.connectorCatalogSnapshot,
-          ref: row.connector.permissionBundleRef,
-        })
-      : null;
-    if (row.connector.permissionBundleRef && !permissionBundle) {
+    const permissionBundle = await loadEffectiveCustomConnectorPermissionBundle(
+      { row, snapshot: args.connectorCatalogSnapshot },
+    );
+    if (permissionBundle === undefined) {
       continue;
     }
     const apis = await buildCustomConnectorRuntimeApis({
@@ -3808,20 +3846,12 @@ async function buildCustomConnectorRuntimeContext(
       apis,
     });
     if (permissionBundle) {
-      const selectedPermissionNames = new Set(
-        grantByConnectorId.get(row.connector.id) ?? [],
-      );
-      permissionPolicies[customConnectorInternalName(row.connector.id)] = {
-        policies: Object.fromEntries(
-          [...permissionBundle.permissionNames].map((permissionName) => {
-            return [
-              permissionName,
-              selectedPermissionNames.has(permissionName) ? "allow" : "deny",
-            ];
-          }),
-        ),
-        unknownPolicy: "deny",
-      };
+      permissionPolicies[customConnectorInternalName(row.connector.id)] =
+        buildCustomConnectorPermissionPolicy({
+          bundle: permissionBundle,
+          selectedPermissionNames:
+            grantByConnectorId.get(row.connector.id) ?? [],
+        });
     }
     if (row.connector.skillMarkdown !== null) {
       skills.push({

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -187,7 +187,6 @@ import {
   loadCustomConnectorPermissionBundle,
   type CustomConnectorPermissionBundle,
 } from "./custom-connector-permission-bundle.service";
-import { effectiveCustomConnectorPermissionBundleRef } from "./feishu-custom-connector-permissions";
 import {
   prepareAgentRunStorage,
   type PreparedAgentRunStorage,
@@ -3728,26 +3727,6 @@ interface BuildCustomConnectorRuntimeContextArgs {
   readonly timing?: ApiDispatchTimingCollector;
 }
 
-async function loadEffectiveCustomConnectorPermissionBundle(args: {
-  readonly row: CustomConnectorRuntimeDataRows[number];
-  readonly snapshot: ConnectorRuntimeSnapshot;
-}): Promise<CustomConnectorPermissionBundle | null | undefined> {
-  const ref = effectiveCustomConnectorPermissionBundleRef({
-    slug: args.row.connector.slug,
-    authMode: args.row.connector.authMode,
-    oauthProviderAdapter:
-      args.row.connector.oauthConfig?.providerAdapter ?? null,
-    prefixTemplates: args.row.connector.prefixTemplates,
-    permissionBundleRef: args.row.connector.permissionBundleRef,
-  });
-  return ref
-    ? ((await loadCustomConnectorPermissionBundle({
-        snapshot: args.snapshot,
-        ref,
-      })) ?? undefined)
-    : null;
-}
-
 function buildCustomConnectorPermissionPolicy(args: {
   readonly bundle: CustomConnectorPermissionBundle;
   readonly selectedPermissionNames: readonly string[];
@@ -3821,10 +3800,13 @@ async function buildCustomConnectorRuntimeContext(
       stats.recordNoAuthInjectionConnector();
       continue;
     }
-    const permissionBundle = await loadEffectiveCustomConnectorPermissionBundle(
-      { row, snapshot: args.connectorCatalogSnapshot },
-    );
-    if (permissionBundle === undefined) {
+    const permissionBundle = row.connector.permissionBundleRef
+      ? await loadCustomConnectorPermissionBundle({
+          snapshot: args.connectorCatalogSnapshot,
+          ref: row.connector.permissionBundleRef,
+        })
+      : null;
+    if (row.connector.permissionBundleRef && !permissionBundle) {
       continue;
     }
     const apis = await buildCustomConnectorRuntimeApis({

--- a/turbo/apps/api/src/signals/services/custom-connector-permission-bundle.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-permission-bundle.service.ts
@@ -3,9 +3,17 @@ import {
   type ConnectorSlug,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import type { CustomConnectorPermissionBundleRef } from "@vm0/api-contracts/contracts/zero-custom-connectors";
-import type { ExpandedFirewallConfig } from "@vm0/connectors/firewall-types";
+import type {
+  ExpandedFirewallConfig,
+  FirewallPolicyValue,
+} from "@vm0/connectors/firewall-types";
 
 import type { ConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
+import {
+  FEISHU_CUSTOM_CONNECTOR_DEFAULT_POLICIES,
+  FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF,
+  FEISHU_CUSTOM_CONNECTOR_PERMISSIONS,
+} from "./feishu-custom-connector-permissions";
 
 const PERMISSION_BUNDLE_REF_PATTERN = /^builtin:([^@]+)@1$/u;
 
@@ -18,6 +26,7 @@ export interface CustomConnectorPermissionBundle {
   readonly connectorSlug: ConnectorSlug;
   readonly permissionNames: ReadonlySet<string>;
   readonly permissions: FirewallPermissions;
+  readonly defaultPolicies: Readonly<Record<string, FirewallPolicyValue>>;
 }
 
 function customConnectorPermissionBundleSlug(
@@ -32,6 +41,20 @@ export async function loadCustomConnectorPermissionBundle(args: {
   readonly snapshot: ConnectorRuntimeSnapshot;
   readonly ref: CustomConnectorPermissionBundleRef;
 }): Promise<CustomConnectorPermissionBundle | null> {
+  if (args.ref === FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF) {
+    return {
+      ref: args.ref,
+      connectorSlug: "feishu",
+      permissionNames: new Set(
+        FEISHU_CUSTOM_CONNECTOR_PERMISSIONS.map((permission) => {
+          return permission.name;
+        }),
+      ),
+      permissions: [...FEISHU_CUSTOM_CONNECTOR_PERMISSIONS],
+      defaultPolicies: FEISHU_CUSTOM_CONNECTOR_DEFAULT_POLICIES,
+    };
+  }
+
   const connectorSlug = customConnectorPermissionBundleSlug(args.ref);
   if (!connectorSlug || !args.snapshot.serverFirewalls.has(connectorSlug)) {
     return null;
@@ -76,5 +99,10 @@ export async function loadCustomConnectorPermissionBundle(args: {
     connectorSlug,
     permissionNames,
     permissions,
+    defaultPolicies: Object.fromEntries(
+      [...permissionNames].map((permissionName) => {
+        return [permissionName, "deny" as const];
+      }),
+    ),
   };
 }

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector-permissions.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector-permissions.ts
@@ -4,6 +4,10 @@ import type {
   FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
 
+const FEISHU_API_PREFIX = "https://open.feishu.cn/open-apis/";
+const FEISHU_MANAGED_CONNECTOR_SLUG_PATTERN =
+  /^_feishu-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+
 export const FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF =
   "builtin:feishu@1" satisfies CustomConnectorPermissionBundleRef;
 
@@ -77,7 +81,7 @@ export const FEISHU_CUSTOM_CONNECTOR_PERMISSIONS = [
   {
     name: "resources:delete",
     description:
-      "Delete Feishu files, documents, sheets, Base records, Wiki nodes, or slides.",
+      "Delete Feishu files, documents, sheets, Base tables or records, Wiki nodes, or slides.",
     rules: [
       "DELETE /drive/{path*}",
       "DELETE /docx/{path*}",
@@ -86,6 +90,7 @@ export const FEISHU_CUSTOM_CONNECTOR_PERMISSIONS = [
       "DELETE /bitable/{path*}",
       "DELETE /wiki/{path*}",
       "DELETE /slides/{path*}",
+      "POST /bitable/v1/apps/{app_token}/tables/batch_delete",
       "POST /bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_delete",
     ],
   },
@@ -130,6 +135,10 @@ export const FEISHU_CUSTOM_CONNECTOR_PERMISSIONS = [
       "POST /im/v1/chats/{chat_id}/managers/{path*}",
       "DELETE /im/v1/chats/{chat_id}/managers/{path*}",
       "POST /im/v1/chats/{chat_id}/link",
+      "POST /im/v1/chats/{chat_id}/{path*}",
+      "PUT /im/v1/chats/{chat_id}/{path*}",
+      "PATCH /im/v1/chats/{chat_id}/{path*}",
+      "DELETE /im/v1/chats/{chat_id}/{path*}",
     ],
   },
   {
@@ -195,3 +204,30 @@ export const FEISHU_CUSTOM_CONNECTOR_DEFAULT_POLICIES = Object.fromEntries(
     return [permission.name, policy];
   }),
 ) satisfies Readonly<Record<string, FirewallPolicyValue>>;
+
+function isManagedFeishuCustomConnector(args: {
+  readonly slug: string;
+  readonly authMode: string;
+  readonly oauthProviderAdapter: string | null;
+  readonly prefixTemplates: readonly string[];
+}): boolean {
+  return (
+    FEISHU_MANAGED_CONNECTOR_SLUG_PATTERN.test(args.slug) &&
+    args.authMode === "oauth" &&
+    args.oauthProviderAdapter === "feishu" &&
+    args.prefixTemplates.length === 1 &&
+    args.prefixTemplates[0] === FEISHU_API_PREFIX
+  );
+}
+
+export function effectiveCustomConnectorPermissionBundleRef(args: {
+  readonly slug: string;
+  readonly authMode: string;
+  readonly oauthProviderAdapter: string | null;
+  readonly prefixTemplates: readonly string[];
+  readonly permissionBundleRef: CustomConnectorPermissionBundleRef | null;
+}): CustomConnectorPermissionBundleRef | null {
+  return isManagedFeishuCustomConnector(args)
+    ? FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF
+    : args.permissionBundleRef;
+}

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector-permissions.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector-permissions.ts
@@ -1,0 +1,225 @@
+import type { CustomConnectorPermissionBundleRef } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import type {
+  ExpandedFirewallConfig,
+  FirewallPolicyValue,
+} from "@vm0/connectors/firewall-types";
+
+const FEISHU_API_PREFIX = "https://open.feishu.cn/open-apis/";
+const FEISHU_MANAGED_CONNECTOR_SLUG_PATTERN =
+  /^_feishu-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+
+export const FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF =
+  "builtin:feishu@1" satisfies CustomConnectorPermissionBundleRef;
+
+type FirewallPermissions = NonNullable<
+  ExpandedFirewallConfig["apis"][number]["permissions"]
+>;
+
+const approvalMethods = ["GET", "POST", "PUT", "PATCH"] as const;
+const approvalAreas = [
+  "contact",
+  "im",
+  "drive",
+  "docx",
+  "docs",
+  "sheets",
+  "bitable",
+  "wiki",
+  "search",
+  "slides",
+  "board",
+  "calendar",
+  "task",
+] as const;
+
+function buildStandardApprovalRules(): string[] {
+  return [
+    "GET /authen/v1/user_info",
+    ...approvalAreas.flatMap((area) => {
+      return approvalMethods.map((method) => {
+        return `${method} /${area}/{path*}`;
+      });
+    }),
+    "DELETE /im/v1/messages/{message_id}/reactions/{reaction_id}",
+    "POST /calendar/v4/calendars/search",
+    "POST /calendar/v4/calendars/{calendar_id}/events/search",
+    "POST /calendar/v4/freebusy/list",
+    "POST /calendar/v4/freebusy/batch",
+    "POST /task/v2/tasks/search",
+    "POST /task/v2/tasklists/search",
+    "POST /task/v2/task_v2/list_related_task",
+  ];
+}
+
+export const FEISHU_CUSTOM_CONNECTOR_PERMISSIONS = [
+  {
+    name: "standard:use",
+    description:
+      "Use Feishu APIs that do not match a higher-risk action. Each request requires approval.",
+    rules: buildStandardApprovalRules(),
+  },
+  {
+    name: "messages:send-as-user",
+    description:
+      "Send, forward, reply to, edit, recall, or urgently notify from messages as the connected user.",
+    rules: [
+      "POST /im/v1/messages",
+      "POST /im/v1/messages/merge_forward",
+      "POST /im/v1/messages/{message_id}/reply",
+      "POST /im/v1/messages/{message_id}/forward",
+      "PUT /im/v1/messages/{message_id}",
+      "PATCH /im/v1/messages/{message_id}",
+      "DELETE /im/v1/messages/{message_id}",
+      "POST /im/v1/messages/{message_id}/push_follow_up",
+      "PATCH /im/v1/messages/{message_id}/urgent_app",
+      "PATCH /im/v1/messages/{message_id}/urgent_phone",
+      "PATCH /im/v1/messages/{message_id}/urgent_sms",
+      "POST /im/v1/batch_messages",
+      "DELETE /im/v1/batch_messages/{batch_message_id}",
+      "POST /message/v4/batch_send",
+    ],
+  },
+  {
+    name: "resources:delete",
+    description:
+      "Delete Feishu files, documents, sheets, Base records, Wiki nodes, or slides.",
+    rules: [
+      "DELETE /drive/{path*}",
+      "DELETE /docx/{path*}",
+      "DELETE /docs/{path*}",
+      "DELETE /sheets/{path*}",
+      "DELETE /bitable/{path*}",
+      "DELETE /wiki/{path*}",
+      "DELETE /slides/{path*}",
+      "POST /bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_delete",
+    ],
+  },
+  {
+    name: "sharing:manage",
+    description:
+      "Add, update, or remove collaborators; change public sharing; or transfer ownership.",
+    rules: [
+      "POST /drive/v1/permissions/{path*}",
+      "PUT /drive/v1/permissions/{path*}",
+      "PATCH /drive/v1/permissions/{path*}",
+      "DELETE /drive/v1/permissions/{path*}",
+      "POST /drive/v2/permissions/{path*}",
+      "PUT /drive/v2/permissions/{path*}",
+      "PATCH /drive/v2/permissions/{path*}",
+      "DELETE /drive/v2/permissions/{path*}",
+      "POST /drive/permission/{path*}",
+      "PUT /drive/permission/{path*}",
+      "PATCH /drive/permission/{path*}",
+      "DELETE /drive/permission/{path*}",
+      "POST /wiki/v2/spaces/{space_id}/members",
+      "PUT /wiki/v2/spaces/{space_id}/members/{member_id}",
+      "PATCH /wiki/v2/spaces/{space_id}/members/{member_id}",
+      "DELETE /wiki/v2/spaces/{space_id}/members/{member_id}",
+      "PATCH /wiki/v2/spaces/{space_id}/setting",
+    ],
+  },
+  {
+    name: "chats:manage",
+    description:
+      "Create or dissolve chats, change chat settings, manage members or administrators, or create invite links.",
+    rules: [
+      "POST /im/v1/chats",
+      "PUT /im/v1/chats/{chat_id}",
+      "PATCH /im/v1/chats/{chat_id}",
+      "DELETE /im/v1/chats/{chat_id}",
+      "POST /im/v1/chats/{chat_id}/members",
+      "DELETE /im/v1/chats/{chat_id}/members",
+      "PATCH /im/v1/chats/{chat_id}/members/me_join",
+      "POST /im/v1/chats/{chat_id}/managers",
+      "DELETE /im/v1/chats/{chat_id}/managers",
+      "POST /im/v1/chats/{chat_id}/managers/{path*}",
+      "DELETE /im/v1/chats/{chat_id}/managers/{path*}",
+      "POST /im/v1/chats/{chat_id}/link",
+    ],
+  },
+  {
+    name: "comments:write",
+    description:
+      "Create, edit, resolve, or delete document or task comments as the connected user.",
+    rules: [
+      "POST /drive/v1/files/{file_token}/comments",
+      "PATCH /drive/v1/files/{file_token}/comments/{comment_id}",
+      "DELETE /drive/v1/files/{file_token}/comments/{comment_id}",
+      "POST /drive/v1/files/{file_token}/comments/{comment_id}/replies",
+      "PATCH /drive/v1/files/{file_token}/comments/{comment_id}/replies/{reply_id}",
+      "DELETE /drive/v1/files/{file_token}/comments/{comment_id}/replies/{reply_id}",
+      "POST /task/v2/comments",
+      "PUT /task/v2/comments/{comment_id}",
+      "PATCH /task/v2/comments/{comment_id}",
+      "DELETE /task/v2/comments/{comment_id}",
+    ],
+  },
+  {
+    name: "calendar:write",
+    description:
+      "Create or change calendars, meetings, attendees, invitations, replies, or calendar access controls.",
+    rules: [
+      "POST /calendar/v4/calendars",
+      "PATCH /calendar/v4/calendars/{calendar_id}",
+      "DELETE /calendar/v4/calendars/{calendar_id}",
+      "POST /calendar/v4/calendars/{calendar_id}/events",
+      "PUT /calendar/v4/calendars/{calendar_id}/events/{event_id}",
+      "PATCH /calendar/v4/calendars/{calendar_id}/events/{event_id}",
+      "DELETE /calendar/v4/calendars/{calendar_id}/events/{event_id}",
+      "POST /calendar/v4/calendars/{calendar_id}/events/{event_id}/{path*}",
+      "PUT /calendar/v4/calendars/{calendar_id}/events/{event_id}/{path*}",
+      "PATCH /calendar/v4/calendars/{calendar_id}/events/{event_id}/{path*}",
+      "DELETE /calendar/v4/calendars/{calendar_id}/events/{event_id}/{path*}",
+      "POST /calendar/v4/calendars/{calendar_id}/access_controls",
+      "PUT /calendar/v4/calendars/{calendar_id}/access_controls/{access_control_id}",
+      "PATCH /calendar/v4/calendars/{calendar_id}/access_controls/{access_control_id}",
+      "DELETE /calendar/v4/calendars/{calendar_id}/access_controls/{access_control_id}",
+    ],
+  },
+  {
+    name: "tasks:write",
+    description:
+      "Create or change tasks, task lists, assignments, followers, collaborators, dependencies, reminders, or sections.",
+    rules: [
+      "POST /task/v2/{path*}",
+      "PUT /task/v2/{path*}",
+      "PATCH /task/v2/{path*}",
+      "DELETE /task/v2/{path*}",
+    ],
+  },
+] as const satisfies FirewallPermissions;
+
+export const FEISHU_CUSTOM_CONNECTOR_DEFAULT_POLICIES = Object.fromEntries(
+  FEISHU_CUSTOM_CONNECTOR_PERMISSIONS.map((permission) => {
+    const policy: FirewallPolicyValue =
+      permission.name === "standard:use" ? "ask" : "deny";
+    return [permission.name, policy];
+  }),
+) satisfies Readonly<Record<string, FirewallPolicyValue>>;
+
+function isManagedFeishuCustomConnector(args: {
+  readonly slug: string;
+  readonly authMode: string;
+  readonly oauthProviderAdapter: string | null;
+  readonly prefixTemplates: readonly string[];
+}): boolean {
+  return (
+    FEISHU_MANAGED_CONNECTOR_SLUG_PATTERN.test(args.slug) &&
+    args.authMode === "oauth" &&
+    args.oauthProviderAdapter === "feishu" &&
+    args.prefixTemplates.length === 1 &&
+    args.prefixTemplates[0] === FEISHU_API_PREFIX
+  );
+}
+
+export function effectiveCustomConnectorPermissionBundleRef(args: {
+  readonly slug: string;
+  readonly authMode: string;
+  readonly oauthProviderAdapter: string | null;
+  readonly prefixTemplates: readonly string[];
+  readonly permissionBundleRef: CustomConnectorPermissionBundleRef | null;
+}): CustomConnectorPermissionBundleRef | null {
+  return isManagedFeishuCustomConnector(args)
+    ? FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF
+    : args.permissionBundleRef;
+}

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector-permissions.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector-permissions.ts
@@ -50,8 +50,7 @@ function buildStandardApprovalRules(): string[] {
 export const FEISHU_CUSTOM_CONNECTOR_PERMISSIONS = [
   {
     name: "standard:use",
-    description:
-      "Use Feishu APIs that do not match a higher-risk action. Each request requires approval.",
+    description: "Use Feishu APIs that do not match a higher-risk action.",
     rules: buildStandardApprovalRules(),
   },
   {
@@ -192,7 +191,7 @@ export const FEISHU_CUSTOM_CONNECTOR_DEFAULT_POLICIES = Object.fromEntries(
       permission.name === "resources:delete" ||
       permission.name === "chats:manage"
         ? "deny"
-        : "ask";
+        : "allow";
     return [permission.name, policy];
   }),
 ) satisfies Readonly<Record<string, FirewallPolicyValue>>;

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector-permissions.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector-permissions.ts
@@ -4,10 +4,6 @@ import type {
   FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
 
-const FEISHU_API_PREFIX = "https://open.feishu.cn/open-apis/";
-const FEISHU_MANAGED_CONNECTOR_SLUG_PATTERN =
-  /^_feishu-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
-
 export const FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF =
   "builtin:feishu@1" satisfies CustomConnectorPermissionBundleRef;
 
@@ -192,34 +188,11 @@ export const FEISHU_CUSTOM_CONNECTOR_PERMISSIONS = [
 export const FEISHU_CUSTOM_CONNECTOR_DEFAULT_POLICIES = Object.fromEntries(
   FEISHU_CUSTOM_CONNECTOR_PERMISSIONS.map((permission) => {
     const policy: FirewallPolicyValue =
-      permission.name === "standard:use" ? "ask" : "deny";
+      permission.name === "messages:send-as-user" ||
+      permission.name === "resources:delete" ||
+      permission.name === "chats:manage"
+        ? "deny"
+        : "ask";
     return [permission.name, policy];
   }),
 ) satisfies Readonly<Record<string, FirewallPolicyValue>>;
-
-function isManagedFeishuCustomConnector(args: {
-  readonly slug: string;
-  readonly authMode: string;
-  readonly oauthProviderAdapter: string | null;
-  readonly prefixTemplates: readonly string[];
-}): boolean {
-  return (
-    FEISHU_MANAGED_CONNECTOR_SLUG_PATTERN.test(args.slug) &&
-    args.authMode === "oauth" &&
-    args.oauthProviderAdapter === "feishu" &&
-    args.prefixTemplates.length === 1 &&
-    args.prefixTemplates[0] === FEISHU_API_PREFIX
-  );
-}
-
-export function effectiveCustomConnectorPermissionBundleRef(args: {
-  readonly slug: string;
-  readonly authMode: string;
-  readonly oauthProviderAdapter: string | null;
-  readonly prefixTemplates: readonly string[];
-  readonly permissionBundleRef: CustomConnectorPermissionBundleRef | null;
-}): CustomConnectorPermissionBundleRef | null {
-  return isManagedFeishuCustomConnector(args)
-    ? FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF
-    : args.permissionBundleRef;
-}

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
@@ -12,7 +12,6 @@ import { secrets } from "@vm0/db/schema/secret";
 import { nowDate } from "../external/time";
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { syncCustomConnectorSkillVolume$ } from "./custom-connector-skill-volume.service";
-import { FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF } from "./feishu-custom-connector-permissions";
 
 const FEISHU_API_PREFIX = "https://open.feishu.cn/open-apis/";
 const FEISHU_AUTHORIZATION_URL =
@@ -175,7 +174,7 @@ function desiredConnectorDefinition(installation: FeishuConnectorInstallation) {
     queryInjections: [],
     authMode: "oauth" as const,
     enabled: true,
-    permissionBundleRef: FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF,
+    permissionBundleRef: null,
     skillMarkdown: FEISHU_SKILL_MARKDOWN,
   };
 }
@@ -201,19 +200,6 @@ function connectorDefinitionMatches(
 ): boolean {
   const desired = desiredConnectorDefinition(installation);
   return (
-    connectorDefinitionMatchesWithoutPermissionBundle(
-      connector,
-      installation,
-    ) && connector.permissionBundleRef === desired.permissionBundleRef
-  );
-}
-
-function connectorDefinitionMatchesWithoutPermissionBundle(
-  connector: typeof orgCustomConnectors.$inferSelect,
-  installation: FeishuConnectorInstallation,
-): boolean {
-  const desired = desiredConnectorDefinition(installation);
-  return (
     connector.displayName === desired.displayName &&
     isDeepStrictEqual(connector.prefixes, desired.prefixes) &&
     connector.headerName === desired.headerName &&
@@ -224,6 +210,7 @@ function connectorDefinitionMatchesWithoutPermissionBundle(
     isDeepStrictEqual(connector.queryInjections, desired.queryInjections) &&
     connector.authMode === desired.authMode &&
     connector.enabled === desired.enabled &&
+    connector.permissionBundleRef === desired.permissionBundleRef &&
     connector.skillMarkdown === desired.skillMarkdown
   );
 }
@@ -326,26 +313,6 @@ async function repairFeishuCustomConnector(
   };
 }
 
-async function backfillFeishuPermissionBundle(
-  tx: DbTransaction,
-  connectorId: string,
-  installation: FeishuConnectorInstallation,
-  signal: AbortSignal,
-): Promise<ReconciledFeishuCustomConnector> {
-  await tx
-    .update(orgCustomConnectors)
-    .set({
-      permissionBundleRef: FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF,
-      updatedAt: nowDate(),
-    })
-    .where(eq(orgCustomConnectors.id, connectorId));
-  signal.throwIfAborted();
-  return {
-    connectorId,
-    displayName: feishuCustomConnectorDisplayName(installation.botName),
-  };
-}
-
 async function reconcileFeishuCustomConnector(
   tx: DbTransaction,
   args: EnsureFeishuCustomConnectorArgs,
@@ -416,21 +383,6 @@ async function reconcileFeishuCustomConnector(
       connectorId: existing.connector.id,
       displayName: feishuCustomConnectorDisplayName(installation.botName),
     };
-  }
-  if (
-    !args.configurationChanged &&
-    connectorDefinitionMatchesWithoutPermissionBundle(
-      existing.connector,
-      installation,
-    ) &&
-    oauthConfigMatches(existing.oauthConfig, installation)
-  ) {
-    return await backfillFeishuPermissionBundle(
-      tx,
-      existing.connector.id,
-      installation,
-      signal,
-    );
   }
   return await repairFeishuCustomConnector(
     tx,

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
@@ -12,6 +12,7 @@ import { secrets } from "@vm0/db/schema/secret";
 import { nowDate } from "../external/time";
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { syncCustomConnectorSkillVolume$ } from "./custom-connector-skill-volume.service";
+import { FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF } from "./feishu-custom-connector-permissions";
 
 const FEISHU_API_PREFIX = "https://open.feishu.cn/open-apis/";
 const FEISHU_AUTHORIZATION_URL =
@@ -174,7 +175,7 @@ function desiredConnectorDefinition(installation: FeishuConnectorInstallation) {
     queryInjections: [],
     authMode: "oauth" as const,
     enabled: true,
-    permissionBundleRef: null,
+    permissionBundleRef: FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF,
     skillMarkdown: FEISHU_SKILL_MARKDOWN,
   };
 }
@@ -200,6 +201,19 @@ function connectorDefinitionMatches(
 ): boolean {
   const desired = desiredConnectorDefinition(installation);
   return (
+    connectorDefinitionMatchesWithoutPermissionBundle(
+      connector,
+      installation,
+    ) && connector.permissionBundleRef === desired.permissionBundleRef
+  );
+}
+
+function connectorDefinitionMatchesWithoutPermissionBundle(
+  connector: typeof orgCustomConnectors.$inferSelect,
+  installation: FeishuConnectorInstallation,
+): boolean {
+  const desired = desiredConnectorDefinition(installation);
+  return (
     connector.displayName === desired.displayName &&
     isDeepStrictEqual(connector.prefixes, desired.prefixes) &&
     connector.headerName === desired.headerName &&
@@ -210,7 +224,6 @@ function connectorDefinitionMatches(
     isDeepStrictEqual(connector.queryInjections, desired.queryInjections) &&
     connector.authMode === desired.authMode &&
     connector.enabled === desired.enabled &&
-    connector.permissionBundleRef === desired.permissionBundleRef &&
     connector.skillMarkdown === desired.skillMarkdown
   );
 }
@@ -313,6 +326,26 @@ async function repairFeishuCustomConnector(
   };
 }
 
+async function backfillFeishuPermissionBundle(
+  tx: DbTransaction,
+  connectorId: string,
+  installation: FeishuConnectorInstallation,
+  signal: AbortSignal,
+): Promise<ReconciledFeishuCustomConnector> {
+  await tx
+    .update(orgCustomConnectors)
+    .set({
+      permissionBundleRef: FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF,
+      updatedAt: nowDate(),
+    })
+    .where(eq(orgCustomConnectors.id, connectorId));
+  signal.throwIfAborted();
+  return {
+    connectorId,
+    displayName: feishuCustomConnectorDisplayName(installation.botName),
+  };
+}
+
 async function reconcileFeishuCustomConnector(
   tx: DbTransaction,
   args: EnsureFeishuCustomConnectorArgs,
@@ -383,6 +416,21 @@ async function reconcileFeishuCustomConnector(
       connectorId: existing.connector.id,
       displayName: feishuCustomConnectorDisplayName(installation.botName),
     };
+  }
+  if (
+    !args.configurationChanged &&
+    connectorDefinitionMatchesWithoutPermissionBundle(
+      existing.connector,
+      installation,
+    ) &&
+    oauthConfigMatches(existing.oauthConfig, installation)
+  ) {
+    return await backfillFeishuPermissionBundle(
+      tx,
+      existing.connector.id,
+      installation,
+      signal,
+    );
   }
   return await repairFeishuCustomConnector(
     tx,

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -12,6 +12,7 @@ import {
 import { connectors as connectorConnections } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
+import { orgCustomConnectorOauthConfigs } from "@vm0/db/schema/org-custom-connector-oauth-config";
 import { orgCustomConnectorValues } from "@vm0/db/schema/org-custom-connector-value";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
@@ -23,6 +24,10 @@ import {
   type ConnectorRuntimeSnapshot,
 } from "./connector-catalog-runtime.service";
 import { loadCustomConnectorPermissionBundle } from "./custom-connector-permission-bundle.service";
+import {
+  effectiveCustomConnectorPermissionBundleRef,
+  FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF,
+} from "./feishu-custom-connector-permissions";
 
 type UpdateUserConnectorsResult =
   | {
@@ -362,6 +367,7 @@ async function lockZeroAgentForConnectorReplace(
 
 interface LockedCustomConnectorRow {
   readonly id: string;
+  readonly slug: string;
   readonly prefixes: readonly string[];
   readonly prefixTemplates: readonly string[];
   readonly headerTemplate: string;
@@ -369,6 +375,7 @@ interface LockedCustomConnectorRow {
   readonly headerInjections: readonly OrgCustomConnectorHeaderInjection[];
   readonly queryInjections: readonly OrgCustomConnectorQueryInjection[];
   readonly authMode: OrgCustomConnectorAuthMode;
+  readonly oauthProviderAdapter: string | null;
   readonly permissionBundleRef: string | null;
   readonly revision: number;
 }
@@ -485,6 +492,7 @@ async function lockCustomConnectorsForReplace(
     const [locked] = await db
       .select({
         id: orgCustomConnectors.id,
+        slug: orgCustomConnectors.slug,
         prefixes: orgCustomConnectors.prefixes,
         prefixTemplates: orgCustomConnectors.prefixTemplates,
         headerTemplate: orgCustomConnectors.headerTemplate,
@@ -492,10 +500,21 @@ async function lockCustomConnectorsForReplace(
         headerInjections: orgCustomConnectors.headerInjections,
         queryInjections: orgCustomConnectors.queryInjections,
         authMode: orgCustomConnectors.authMode,
+        oauthProviderAdapter: orgCustomConnectorOauthConfigs.providerAdapter,
         permissionBundleRef: orgCustomConnectors.permissionBundleRef,
         revision: orgCustomConnectors.revision,
       })
       .from(orgCustomConnectors)
+      .leftJoin(
+        orgCustomConnectorOauthConfigs,
+        and(
+          eq(
+            orgCustomConnectorOauthConfigs.connectorId,
+            orgCustomConnectors.id,
+          ),
+          eq(orgCustomConnectorOauthConfigs.orgId, orgCustomConnectors.orgId),
+        ),
+      )
       .where(
         and(
           eq(orgCustomConnectors.orgId, args.orgId),
@@ -503,7 +522,7 @@ async function lockCustomConnectorsForReplace(
           eq(orgCustomConnectors.enabled, true),
         ),
       )
-      .for("update")
+      .for("update", { of: orgCustomConnectors })
       .limit(1);
     if (locked) {
       lockedRows.push(locked);
@@ -561,7 +580,16 @@ async function lockCustomConnectorsForReplace(
     ),
     permissionBundleRefs: new Map(
       lockedRows.map((row) => {
-        return [row.id, row.permissionBundleRef] as const;
+        return [
+          row.id,
+          effectiveCustomConnectorPermissionBundleRef({
+            slug: row.slug,
+            authMode: row.authMode,
+            oauthProviderAdapter: row.oauthProviderAdapter,
+            prefixTemplates: row.prefixTemplates,
+            permissionBundleRef: row.permissionBundleRef,
+          }),
+        ] as const;
       }),
     ),
   };
@@ -768,7 +796,12 @@ async function validateCustomConnectorPermissionSelection(args: {
 > {
   if (!args.explicitGrants) {
     const connectorIds = args.enabledIds.filter((connectorId) => {
-      return (args.permissionBundleRefs.get(connectorId) ?? null) !== null;
+      const permissionBundleRef =
+        args.permissionBundleRefs.get(connectorId) ?? null;
+      return (
+        permissionBundleRef !== null &&
+        permissionBundleRef !== FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF
+      );
     });
     return connectorIds.length === 0
       ? {

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -12,6 +12,7 @@ import {
 import { connectors as connectorConnections } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
+import { orgCustomConnectorOauthConfigs } from "@vm0/db/schema/org-custom-connector-oauth-config";
 import { orgCustomConnectorValues } from "@vm0/db/schema/org-custom-connector-value";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
@@ -23,7 +24,10 @@ import {
   type ConnectorRuntimeSnapshot,
 } from "./connector-catalog-runtime.service";
 import { loadCustomConnectorPermissionBundle } from "./custom-connector-permission-bundle.service";
-import { FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF } from "./feishu-custom-connector-permissions";
+import {
+  effectiveCustomConnectorPermissionBundleRef,
+  FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF,
+} from "./feishu-custom-connector-permissions";
 
 type UpdateUserConnectorsResult =
   | {
@@ -363,6 +367,7 @@ async function lockZeroAgentForConnectorReplace(
 
 interface LockedCustomConnectorRow {
   readonly id: string;
+  readonly slug: string;
   readonly prefixes: readonly string[];
   readonly prefixTemplates: readonly string[];
   readonly headerTemplate: string;
@@ -370,6 +375,7 @@ interface LockedCustomConnectorRow {
   readonly headerInjections: readonly OrgCustomConnectorHeaderInjection[];
   readonly queryInjections: readonly OrgCustomConnectorQueryInjection[];
   readonly authMode: OrgCustomConnectorAuthMode;
+  readonly oauthProviderAdapter: string | null;
   readonly permissionBundleRef: string | null;
   readonly revision: number;
 }
@@ -486,6 +492,7 @@ async function lockCustomConnectorsForReplace(
     const [locked] = await db
       .select({
         id: orgCustomConnectors.id,
+        slug: orgCustomConnectors.slug,
         prefixes: orgCustomConnectors.prefixes,
         prefixTemplates: orgCustomConnectors.prefixTemplates,
         headerTemplate: orgCustomConnectors.headerTemplate,
@@ -493,10 +500,21 @@ async function lockCustomConnectorsForReplace(
         headerInjections: orgCustomConnectors.headerInjections,
         queryInjections: orgCustomConnectors.queryInjections,
         authMode: orgCustomConnectors.authMode,
+        oauthProviderAdapter: orgCustomConnectorOauthConfigs.providerAdapter,
         permissionBundleRef: orgCustomConnectors.permissionBundleRef,
         revision: orgCustomConnectors.revision,
       })
       .from(orgCustomConnectors)
+      .leftJoin(
+        orgCustomConnectorOauthConfigs,
+        and(
+          eq(
+            orgCustomConnectorOauthConfigs.connectorId,
+            orgCustomConnectors.id,
+          ),
+          eq(orgCustomConnectorOauthConfigs.orgId, orgCustomConnectors.orgId),
+        ),
+      )
       .where(
         and(
           eq(orgCustomConnectors.orgId, args.orgId),
@@ -504,7 +522,7 @@ async function lockCustomConnectorsForReplace(
           eq(orgCustomConnectors.enabled, true),
         ),
       )
-      .for("update")
+      .for("update", { of: orgCustomConnectors })
       .limit(1);
     if (locked) {
       lockedRows.push(locked);
@@ -562,7 +580,16 @@ async function lockCustomConnectorsForReplace(
     ),
     permissionBundleRefs: new Map(
       lockedRows.map((row) => {
-        return [row.id, row.permissionBundleRef] as const;
+        return [
+          row.id,
+          effectiveCustomConnectorPermissionBundleRef({
+            slug: row.slug,
+            authMode: row.authMode,
+            oauthProviderAdapter: row.oauthProviderAdapter,
+            prefixTemplates: row.prefixTemplates,
+            permissionBundleRef: row.permissionBundleRef,
+          }),
+        ] as const;
       }),
     ),
   };

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -12,7 +12,6 @@ import {
 import { connectors as connectorConnections } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
-import { orgCustomConnectorOauthConfigs } from "@vm0/db/schema/org-custom-connector-oauth-config";
 import { orgCustomConnectorValues } from "@vm0/db/schema/org-custom-connector-value";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
@@ -24,10 +23,7 @@ import {
   type ConnectorRuntimeSnapshot,
 } from "./connector-catalog-runtime.service";
 import { loadCustomConnectorPermissionBundle } from "./custom-connector-permission-bundle.service";
-import {
-  effectiveCustomConnectorPermissionBundleRef,
-  FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF,
-} from "./feishu-custom-connector-permissions";
+import { FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF } from "./feishu-custom-connector-permissions";
 
 type UpdateUserConnectorsResult =
   | {
@@ -367,7 +363,6 @@ async function lockZeroAgentForConnectorReplace(
 
 interface LockedCustomConnectorRow {
   readonly id: string;
-  readonly slug: string;
   readonly prefixes: readonly string[];
   readonly prefixTemplates: readonly string[];
   readonly headerTemplate: string;
@@ -375,7 +370,6 @@ interface LockedCustomConnectorRow {
   readonly headerInjections: readonly OrgCustomConnectorHeaderInjection[];
   readonly queryInjections: readonly OrgCustomConnectorQueryInjection[];
   readonly authMode: OrgCustomConnectorAuthMode;
-  readonly oauthProviderAdapter: string | null;
   readonly permissionBundleRef: string | null;
   readonly revision: number;
 }
@@ -492,7 +486,6 @@ async function lockCustomConnectorsForReplace(
     const [locked] = await db
       .select({
         id: orgCustomConnectors.id,
-        slug: orgCustomConnectors.slug,
         prefixes: orgCustomConnectors.prefixes,
         prefixTemplates: orgCustomConnectors.prefixTemplates,
         headerTemplate: orgCustomConnectors.headerTemplate,
@@ -500,21 +493,10 @@ async function lockCustomConnectorsForReplace(
         headerInjections: orgCustomConnectors.headerInjections,
         queryInjections: orgCustomConnectors.queryInjections,
         authMode: orgCustomConnectors.authMode,
-        oauthProviderAdapter: orgCustomConnectorOauthConfigs.providerAdapter,
         permissionBundleRef: orgCustomConnectors.permissionBundleRef,
         revision: orgCustomConnectors.revision,
       })
       .from(orgCustomConnectors)
-      .leftJoin(
-        orgCustomConnectorOauthConfigs,
-        and(
-          eq(
-            orgCustomConnectorOauthConfigs.connectorId,
-            orgCustomConnectors.id,
-          ),
-          eq(orgCustomConnectorOauthConfigs.orgId, orgCustomConnectors.orgId),
-        ),
-      )
       .where(
         and(
           eq(orgCustomConnectors.orgId, args.orgId),
@@ -522,7 +504,7 @@ async function lockCustomConnectorsForReplace(
           eq(orgCustomConnectors.enabled, true),
         ),
       )
-      .for("update", { of: orgCustomConnectors })
+      .for("update")
       .limit(1);
     if (locked) {
       lockedRows.push(locked);
@@ -580,16 +562,7 @@ async function lockCustomConnectorsForReplace(
     ),
     permissionBundleRefs: new Map(
       lockedRows.map((row) => {
-        return [
-          row.id,
-          effectiveCustomConnectorPermissionBundleRef({
-            slug: row.slug,
-            authMode: row.authMode,
-            oauthProviderAdapter: row.oauthProviderAdapter,
-            prefixTemplates: row.prefixTemplates,
-            permissionBundleRef: row.permissionBundleRef,
-          }),
-        ] as const;
+        return [row.id, row.permissionBundleRef] as const;
       }),
     ),
   };

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -49,6 +49,7 @@ import { userFeatureSwitchContext } from "./feature-switches.service";
 import { addUserCustomConnector } from "./user-connectors.service";
 import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
 import { loadCustomConnectorPermissionBundle } from "./custom-connector-permission-bundle.service";
+import { effectiveCustomConnectorPermissionBundleRef } from "./feishu-custom-connector-permissions";
 import { syncCustomConnectorSkillVolume$ } from "./custom-connector-skill-volume.service";
 
 const L = logger("CustomConnectorService");
@@ -438,6 +439,18 @@ function computeMissingRequiredFields(args: {
     });
 }
 
+function effectivePermissionBundleRef(
+  row: CustomConnectorRow,
+): CustomConnectorPermissionBundleRef | null {
+  return effectiveCustomConnectorPermissionBundleRef({
+    slug: row.slug,
+    authMode: row.authMode,
+    oauthProviderAdapter: row.oauthConfig?.providerAdapter ?? null,
+    prefixTemplates: row.prefixTemplates,
+    permissionBundleRef: row.permissionBundleRef,
+  });
+}
+
 export function serialiseCustomConnector(args: {
   readonly row: CustomConnectorRow;
   readonly valueMarkers: readonly ValueMarker[];
@@ -479,7 +492,7 @@ export function serialiseCustomConnector(args: {
     ...(args.row.oauthConfig
       ? { oauthConfig: serialiseOAuthConfig(args.row.oauthConfig) }
       : {}),
-    permissionBundleRef: args.row.permissionBundleRef,
+    permissionBundleRef: effectivePermissionBundleRef(args.row),
     skillMarkdown: args.row.skillMarkdown,
     revision: args.row.revision,
     connected,
@@ -1875,13 +1888,17 @@ export function getCustomConnectorPermissionBundle(args: {
   return computed(async (get) => {
     const db = get(db$);
     const connector = await get(getCustomConnectorById(args));
-    if (!connector?.permissionBundleRef) {
+    if (!connector) {
+      return null;
+    }
+    const permissionBundleRef = effectivePermissionBundleRef(connector);
+    if (!permissionBundleRef) {
       return null;
     }
     const snapshot = await loadConnectorRuntimeSnapshot(db);
     const bundle = await loadCustomConnectorPermissionBundle({
       snapshot,
-      ref: connector.permissionBundleRef,
+      ref: permissionBundleRef,
     });
     if (!bundle) {
       return null;

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -11,6 +11,7 @@ import type {
   CustomConnectorOAuthConfig,
   CustomConnectorOAuthConfigInput,
   CustomConnectorPermissionBundleRef,
+  CustomConnectorPermissionBundleResponse,
   CustomConnectorProposal,
   CustomConnectorQueryInjection,
   CustomConnectorResponse,
@@ -1864,6 +1865,39 @@ export function getCustomConnectorResponse(args: {
       valueMarkers: markers,
       oauthConnected: oauthConnections.has(connector.id),
     });
+  });
+}
+
+export function getCustomConnectorPermissionBundle(args: {
+  readonly orgId: string;
+  readonly connectorId: string;
+}): Computed<Promise<CustomConnectorPermissionBundleResponse | null>> {
+  return computed(async (get) => {
+    const db = get(db$);
+    const connector = await get(getCustomConnectorById(args));
+    if (!connector?.permissionBundleRef) {
+      return null;
+    }
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    const bundle = await loadCustomConnectorPermissionBundle({
+      snapshot,
+      ref: connector.permissionBundleRef,
+    });
+    if (!bundle) {
+      return null;
+    }
+    return {
+      ref: bundle.ref,
+      permissions: bundle.permissions.map((permission) => {
+        return {
+          name: permission.name,
+          ...(permission.description
+            ? { description: permission.description }
+            : {}),
+        };
+      }),
+      defaultPolicies: { ...bundle.defaultPolicies },
+    };
   });
 }
 

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -96,6 +96,12 @@ export const composerConnectorPermissionsEnabled$ = computed((get): boolean => {
   );
 });
 
+export const customConnectorPermissionsEnabled$ = computed((get): boolean => {
+  return (
+    get(featureSwitch$)[FeatureSwitchKey.CustomConnectorPermissions] ?? false
+  );
+});
+
 export const reloadFeatureSwitch$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const clerk = await get(clerk$);

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/custom-connectors.ts
@@ -1,10 +1,19 @@
 import { command, computed, state } from "ccstate";
-import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import {
+  zeroAgentCustomConnectorsContract,
+  type AgentCustomConnectorGrant,
+  type AgentCustomConnectorResponse,
+} from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import {
+  zeroCustomConnectorByIdContract,
+  type CustomConnectorPermissionBundleResponse,
+} from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import { zeroClient$ } from "../../api-client.ts";
 import { withCleanup } from "../../utils.ts";
 import { accept } from "../../../lib/accept.ts";
 import { agentDetail$ } from "./detail.ts";
 import { reloadCustomConnectorAuthorizedAgents$ } from "../settings/custom-connectors.ts";
+import { customConnectorPermissionsEnabled$ } from "../../external/feature-switch.ts";
 
 // ---------------------------------------------------------------------------
 // Per-agent custom connector authorization — mirrors connectors.ts but keyed
@@ -19,19 +28,111 @@ const reloadAgentCustomConnectors$ = command(({ set }) => {
   });
 });
 
+const seededCustomConnectorAccess$ = computed(
+  async (get): Promise<AgentCustomConnectorResponse> => {
+    get(internalReload$);
+    const detail = await get(agentDetail$);
+    if (!detail?.agentId) {
+      return { enabledIds: [], grants: [] };
+    }
+    const client = get(zeroClient$)(zeroAgentCustomConnectorsContract);
+    const result = await accept(
+      client.get({ params: { id: detail.agentId } }),
+      [200],
+    );
+    return result.body;
+  },
+);
+
 const seededCustomConnectors$ = computed(async (get): Promise<string[]> => {
-  get(internalReload$);
-  const detail = await get(agentDetail$);
-  if (!detail?.agentId) {
-    return [];
-  }
-  const client = get(zeroClient$)(zeroAgentCustomConnectorsContract);
-  const result = await accept(
-    client.get({ params: { id: detail.agentId } }),
-    [200],
-  );
-  return result.body.enabledIds;
+  return (await get(seededCustomConnectorAccess$)).enabledIds;
 });
+
+export const agentCustomConnectorGrants$ = computed(
+  async (get): Promise<readonly AgentCustomConnectorGrant[]> => {
+    return (await get(seededCustomConnectorAccess$)).grants ?? [];
+  },
+);
+
+const internalPermissionTargetId$ = state<string | null>(null);
+
+export const customConnectorPermissionTargetId$ = computed((get) => {
+  return get(internalPermissionTargetId$);
+});
+
+interface CustomConnectorPermissionDraft {
+  readonly connectorId: string;
+  readonly initialPermissionNames: readonly string[];
+  readonly permissionNames: readonly string[];
+}
+
+const internalPermissionDraft$ = state<CustomConnectorPermissionDraft | null>(
+  null,
+);
+
+export const customConnectorPermissionDraft$ = computed((get) => {
+  return get(internalPermissionDraft$);
+});
+
+export const openCustomConnectorPermissions$ = command(
+  (
+    { set },
+    args: {
+      readonly connectorId: string;
+      readonly permissionNames: readonly string[];
+    },
+  ): void => {
+    set(internalPermissionTargetId$, args.connectorId);
+    set(internalPermissionDraft$, {
+      connectorId: args.connectorId,
+      initialPermissionNames: [...args.permissionNames],
+      permissionNames: [...args.permissionNames],
+    });
+  },
+);
+
+export const closeCustomConnectorPermissions$ = command(({ set }): void => {
+  set(internalPermissionTargetId$, null);
+  set(internalPermissionDraft$, null);
+});
+
+export const setCustomConnectorPermissionDraftValue$ = command(
+  (
+    { set },
+    args: { readonly permissionName: string; readonly allow: boolean },
+  ): void => {
+    set(internalPermissionDraft$, (current) => {
+      if (!current) {
+        return null;
+      }
+      const permissionNames = new Set(current.permissionNames);
+      if (args.allow) {
+        permissionNames.add(args.permissionName);
+      } else {
+        permissionNames.delete(args.permissionName);
+      }
+      return { ...current, permissionNames: [...permissionNames] };
+    });
+  },
+);
+
+export const agentCustomConnectorPermissionBundle$ = computed(
+  async (get): Promise<CustomConnectorPermissionBundleResponse | null> => {
+    if (!get(customConnectorPermissionsEnabled$)) {
+      return null;
+    }
+    const connectorId = get(customConnectorPermissionTargetId$);
+    if (!connectorId) {
+      return null;
+    }
+    const client = get(zeroClient$)(zeroCustomConnectorByIdContract);
+    const result = await accept(
+      client.permissions({ params: { id: connectorId } }),
+      [200, 404],
+    );
+    return result.status === 200 ? result.body : null;
+  },
+);
 
 type CustomConnectorsDraft = {
   readonly agentId: string;
@@ -182,5 +283,47 @@ export const toggleAgentCustomConnector$ = command(
     );
     signal.throwIfAborted();
     return true;
+  },
+);
+
+export const saveAgentCustomConnectorPermissions$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly connectorId: string;
+      readonly permissionNames: readonly string[];
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const detail = await get(agentDetail$);
+    signal.throwIfAborted();
+    if (!detail?.agentId) {
+      throw new Error("No agent detail loaded");
+    }
+    const client = get(zeroClient$)(zeroAgentCustomConnectorsContract);
+    await withCleanup(
+      accept(
+        client.update({
+          params: { id: detail.agentId },
+          body: {
+            grants: [
+              {
+                customConnectorId: args.connectorId,
+                permissionNames: [...args.permissionNames],
+              },
+            ],
+            operation: "add",
+          },
+          fetchOptions: { signal },
+        }),
+        [200],
+      ),
+      () => {
+        set(clearAgentCustomConnectorDraft$, detail.agentId);
+        set(reloadAgentCustomConnectors$);
+        set(reloadCustomConnectorAuthorizedAgents$);
+      },
+    );
+    signal.throwIfAborted();
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/custom-connectors.ts
@@ -54,13 +54,17 @@ export const agentCustomConnectorGrants$ = computed(
   },
 );
 
-const internalPermissionTargetId$ = state<string | null>(null);
+interface CustomConnectorPermissionTarget {
+  readonly agentId: string;
+  readonly connectorId: string;
+}
 
-export const customConnectorPermissionTargetId$ = computed((get) => {
-  return get(internalPermissionTargetId$);
-});
+const internalPermissionTarget$ = state<CustomConnectorPermissionTarget | null>(
+  null,
+);
 
 interface CustomConnectorPermissionDraft {
+  readonly agentId: string;
   readonly connectorId: string;
   readonly initialPermissionNames: readonly string[];
   readonly permissionNames: readonly string[];
@@ -78,12 +82,17 @@ export const openCustomConnectorPermissions$ = command(
   (
     { set },
     args: {
+      readonly agentId: string;
       readonly connectorId: string;
       readonly permissionNames: readonly string[];
     },
   ): void => {
-    set(internalPermissionTargetId$, args.connectorId);
+    set(internalPermissionTarget$, {
+      agentId: args.agentId,
+      connectorId: args.connectorId,
+    });
     set(internalPermissionDraft$, {
+      agentId: args.agentId,
       connectorId: args.connectorId,
       initialPermissionNames: [...args.permissionNames],
       permissionNames: [...args.permissionNames],
@@ -91,19 +100,42 @@ export const openCustomConnectorPermissions$ = command(
   },
 );
 
-export const closeCustomConnectorPermissions$ = command(({ set }): void => {
-  set(internalPermissionTargetId$, null);
-  set(internalPermissionDraft$, null);
-});
+export const closeCustomConnectorPermissions$ = command(
+  (
+    { set },
+    args: { readonly agentId: string; readonly connectorId: string },
+  ): void => {
+    set(internalPermissionTarget$, (current) => {
+      return current?.agentId === args.agentId &&
+        current.connectorId === args.connectorId
+        ? null
+        : current;
+    });
+    set(internalPermissionDraft$, (current) => {
+      return current?.agentId === args.agentId &&
+        current.connectorId === args.connectorId
+        ? null
+        : current;
+    });
+  },
+);
 
 export const setCustomConnectorPermissionDraftValue$ = command(
   (
     { set },
-    args: { readonly permissionName: string; readonly allow: boolean },
+    args: {
+      readonly agentId: string;
+      readonly connectorId: string;
+      readonly permissionName: string;
+      readonly allow: boolean;
+    },
   ): void => {
     set(internalPermissionDraft$, (current) => {
-      if (!current) {
-        return null;
+      if (
+        current?.agentId !== args.agentId ||
+        current.connectorId !== args.connectorId
+      ) {
+        return current;
       }
       const permissionNames = new Set(current.permissionNames);
       if (args.allow) {
@@ -121,13 +153,17 @@ export const agentCustomConnectorPermissionBundle$ = computed(
     if (!get(customConnectorPermissionsEnabled$)) {
       return null;
     }
-    const connectorId = get(customConnectorPermissionTargetId$);
-    if (!connectorId) {
+    const target = get(internalPermissionTarget$);
+    if (!target) {
+      return null;
+    }
+    const detail = await get(agentDetail$);
+    if (detail?.agentId !== target.agentId) {
       return null;
     }
     const client = get(zeroClient$)(zeroCustomConnectorByIdContract);
     const result = await accept(
-      client.permissions({ params: { id: connectorId } }),
+      client.permissions({ params: { id: target.connectorId } }),
       [200, 404],
     );
     return result.status === 200 ? result.body : null;
@@ -290,21 +326,18 @@ export const saveAgentCustomConnectorPermissions$ = command(
   async (
     { get, set },
     args: {
+      readonly agentId: string;
       readonly connectorId: string;
       readonly permissionNames: readonly string[];
     },
     signal: AbortSignal,
   ): Promise<void> => {
-    const detail = await get(agentDetail$);
     signal.throwIfAborted();
-    if (!detail?.agentId) {
-      throw new Error("No agent detail loaded");
-    }
     const client = get(zeroClient$)(zeroAgentCustomConnectorsContract);
     await withCleanup(
       accept(
         client.update({
-          params: { id: detail.agentId },
+          params: { id: args.agentId },
           body: {
             grants: [
               {
@@ -319,7 +352,7 @@ export const saveAgentCustomConnectorPermissions$ = command(
         [200],
       ),
       () => {
-        set(clearAgentCustomConnectorDraft$, detail.agentId);
+        set(clearAgentCustomConnectorDraft$, args.agentId);
         set(reloadAgentCustomConnectors$);
         set(reloadCustomConnectorAuthorizedAgents$);
       },

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -642,7 +642,7 @@ describe("team page navigation", () => {
             },
           ],
           defaultPolicies: {
-            "standard:use": "ask",
+            "standard:use": "allow",
             "messages:send-as-user": "deny",
             "resources:delete": "deny",
           },
@@ -712,6 +712,80 @@ describe("team page navigation", () => {
       });
       expect(screen.getByText("Permissions updated")).toBeInTheDocument();
     });
+  });
+
+  it("does not show a custom connector permission draft on another agent", async () => {
+    const customConnector = {
+      ...createCustomConnector(),
+      permissionBundleRef: "builtin:feishu@1" as const,
+    };
+    const updatedAgentIds: string[] = [];
+    mockTeamAPIs({ customConnector });
+    context.mocks.api(
+      zeroCustomConnectorByIdContract.permissions,
+      ({ respond }) => {
+        return respond(200, {
+          ref: "builtin:feishu@1",
+          permissions: [
+            {
+              name: "messages:send-as-user",
+              description: "Send or edit messages as the connected user.",
+            },
+          ],
+          defaultPolicies: {
+            "messages:send-as-user": "deny",
+          },
+        });
+      },
+    );
+    context.mocks.api(
+      zeroAgentCustomConnectorsContract.update,
+      ({ body, params, respond }) => {
+        updatedAgentIds.push(params.id);
+        return respond(200, {
+          enabledIds: [customConnector.id],
+          grants:
+            "grants" in body
+              ? body.grants
+              : [
+                  {
+                    customConnectorId: customConnector.id,
+                    permissionNames: [],
+                  },
+                ],
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${researchAgentId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.CustomConnectorPermissions]: true,
+      },
+    });
+
+    await screen.findByText("Acme Search");
+    click(screen.getByLabelText("Manage Acme Search permissions"));
+    const messagePermission = await screen.findByText("messages:send-as-user");
+    const permissionRow = messagePermission.parentElement?.parentElement;
+    if (!(permissionRow instanceof HTMLElement)) {
+      throw new Error("custom connector permission row not found");
+    }
+    click(buttonByText("Allow", permissionRow));
+
+    context.store.set(detachedNavigateTo$, ROUTES.agentDetail, {
+      pathParams: { agentId: zeroAgentId },
+      searchParams: new URLSearchParams(),
+    });
+
+    await screen.findByRole("heading", { name: "Zero" });
+    await waitFor(() => {
+      expect(
+        screen.queryByText("messages:send-as-user"),
+      ).not.toBeInTheDocument();
+    });
+    expect(updatedAgentIds).toStrictEqual([]);
   });
 
   it("hides custom connector permission management without a bundle", async () => {

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -33,9 +33,11 @@ import {
   zeroUserPermissionGrantsContract,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import {
+  zeroCustomConnectorByIdContract,
   zeroCustomConnectorsContract,
   type CustomConnectorResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { describe, expect, it } from "vitest";
@@ -609,6 +611,123 @@ describe("team page navigation", () => {
     expect(updateCalls).toBe(0);
     expect(
       screen.queryByText("Custom connectors saved"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("manages grant-required custom connector permissions from the agent auth tab", async () => {
+    const customConnector = {
+      ...createCustomConnector(),
+      permissionBundleRef: "builtin:feishu@1" as const,
+    };
+    let capturedUpdate: AgentCustomConnectorUpdate | null = null;
+    mockTeamAPIs({ customConnector });
+    context.mocks.api(
+      zeroCustomConnectorByIdContract.permissions,
+      ({ params, respond }) => {
+        expect(params.id).toBe(customConnector.id);
+        return respond(200, {
+          ref: "builtin:feishu@1",
+          permissions: [
+            {
+              name: "standard:use",
+              description: "Use standard Feishu APIs with approval.",
+            },
+            {
+              name: "messages:send-as-user",
+              description: "Send or edit messages as the connected user.",
+            },
+            {
+              name: "resources:delete",
+              description: "Delete Feishu content.",
+            },
+          ],
+          defaultPolicies: {
+            "standard:use": "ask",
+            "messages:send-as-user": "deny",
+            "resources:delete": "deny",
+          },
+        });
+      },
+    );
+    context.mocks.api(zeroAgentCustomConnectorsContract.get, ({ respond }) => {
+      return respond(200, {
+        enabledIds: [customConnector.id],
+        grants: [
+          {
+            customConnectorId: customConnector.id,
+            permissionNames: [],
+          },
+        ],
+      });
+    });
+    context.mocks.api(
+      zeroAgentCustomConnectorsContract.update,
+      ({ body, respond }) => {
+        capturedUpdate = body;
+        return respond(200, {
+          enabledIds: [customConnector.id],
+          grants:
+            "grants" in body
+              ? body.grants
+              : [
+                  {
+                    customConnectorId: customConnector.id,
+                    permissionNames: [],
+                  },
+                ],
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${researchAgentId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.CustomConnectorPermissions]: true,
+      },
+    });
+
+    await screen.findByText("Acme Search");
+    click(screen.getByLabelText("Manage Acme Search permissions"));
+
+    const messagePermission = await screen.findByText("messages:send-as-user");
+    const drawer = dialogForElement(messagePermission);
+    expect(within(drawer).queryByText("standard:use")).not.toBeInTheDocument();
+    const messageRow = messagePermission.parentElement?.parentElement;
+    if (!(messageRow instanceof HTMLElement)) {
+      throw new Error("custom connector permission row not found");
+    }
+    click(buttonByText("Allow", messageRow));
+    click(buttonByText("Apply", drawer));
+
+    await waitFor(() => {
+      expect(capturedUpdate).toStrictEqual({
+        grants: [
+          {
+            customConnectorId: customConnector.id,
+            permissionNames: ["messages:send-as-user"],
+          },
+        ],
+        operation: "add",
+      });
+      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+    });
+  });
+
+  it("hides custom connector permission management without a bundle", async () => {
+    mockTeamAPIs();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${researchAgentId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.CustomConnectorPermissions]: true,
+      },
+    });
+
+    await screen.findByText("Acme Search");
+    expect(
+      screen.queryByLabelText("Manage Acme Search permissions"),
     ).not.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/team-page/custom-connector-permissions-drawer.tsx
+++ b/turbo/apps/platform/src/views/team-page/custom-connector-permissions-drawer.tsx
@@ -37,10 +37,12 @@ function permissionSelectionsEqual(
 }
 
 function LoadedCustomConnectorPermissions({
+  agentId,
   connectorId,
   bundle,
   onClose,
 }: {
+  readonly agentId: string;
   readonly connectorId: string;
   readonly bundle: CustomConnectorPermissionBundleResponse;
   readonly onClose: () => void;
@@ -55,17 +57,22 @@ function LoadedCustomConnectorPermissions({
   const permissions = bundle.permissions.filter((permission) => {
     return bundle.defaultPolicies[permission.name] === "deny";
   });
-  const selected = new Set(
-    draft?.connectorId === connectorId ? draft.permissionNames : [],
-  );
+  const draftMatches =
+    draft?.agentId === agentId && draft.connectorId === connectorId;
+  const selected = new Set(draftMatches ? draft.permissionNames : []);
   const initialSelections = new Set(
-    draft?.connectorId === connectorId ? draft.initialPermissionNames : [],
+    draftMatches ? draft.initialPermissionNames : [],
   );
   const saving = saveLoadable.state === "loading";
   const changed = !permissionSelectionsEqual(selected, initialSelections);
 
   const setPermission = (permissionName: string, allow: boolean) => {
-    setDraftPermission({ permissionName, allow });
+    setDraftPermission({
+      agentId,
+      connectorId,
+      permissionName,
+      allow,
+    });
   };
 
   const handleApply = () => {
@@ -76,6 +83,7 @@ function LoadedCustomConnectorPermissions({
       (async () => {
         await save(
           {
+            agentId,
             connectorId,
             permissionNames: permissions
               .map((permission) => {
@@ -153,6 +161,7 @@ function LoadedCustomConnectorPermissions({
 }
 
 export function CustomConnectorPermissionsDrawer({
+  agentId,
   connectorId,
   connectorName,
   agentName,
@@ -161,6 +170,7 @@ export function CustomConnectorPermissionsDrawer({
   loadError,
   onClose,
 }: {
+  readonly agentId: string;
   readonly connectorId: string;
   readonly connectorName: string;
   readonly agentName: string;
@@ -214,6 +224,7 @@ export function CustomConnectorPermissionsDrawer({
         {bundle ? (
           <LoadedCustomConnectorPermissions
             key={connectorId}
+            agentId={agentId}
             connectorId={connectorId}
             bundle={bundle}
             onClose={onClose}

--- a/turbo/apps/platform/src/views/team-page/custom-connector-permissions-drawer.tsx
+++ b/turbo/apps/platform/src/views/team-page/custom-connector-permissions-drawer.tsx
@@ -1,0 +1,258 @@
+import { IconLoader2 } from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
+import type { CustomConnectorPermissionBundleResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import {
+  Button,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@vm0/ui";
+import { useLoadableSet } from "ccstate-react/experimental";
+import { useGet, useSet } from "ccstate-react";
+import { toast } from "@vm0/ui/components/ui/sonner";
+
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import {
+  customConnectorPermissionDraft$,
+  saveAgentCustomConnectorPermissions$,
+  setCustomConnectorPermissionDraftValue$,
+} from "../../signals/zero-page/job-detail/custom-connectors.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import { CustomConnectorIcon } from "../zero-page/components/settings/custom-connector-icon.tsx";
+import { PermissionPolicyToggle } from "../zero-page/components/settings/permission-policy-toggle.tsx";
+
+function permissionSelectionsEqual(
+  left: ReadonlySet<string>,
+  right: ReadonlySet<string>,
+): boolean {
+  return (
+    left.size === right.size &&
+    [...left].every((permissionName) => {
+      return right.has(permissionName);
+    })
+  );
+}
+
+function LoadedCustomConnectorPermissions({
+  connectorId,
+  bundle,
+  onClose,
+}: {
+  readonly connectorId: string;
+  readonly bundle: CustomConnectorPermissionBundleResponse;
+  readonly onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  const draft = useGet(customConnectorPermissionDraft$);
+  const setDraftPermission = useSet(setCustomConnectorPermissionDraftValue$);
+  const [saveLoadable, save] = useLoadableSet(
+    saveAgentCustomConnectorPermissions$,
+  );
+  const pageSignal = useGet(pageSignal$);
+  const permissions = bundle.permissions.filter((permission) => {
+    return bundle.defaultPolicies[permission.name] === "deny";
+  });
+  const selected = new Set(
+    draft?.connectorId === connectorId ? draft.permissionNames : [],
+  );
+  const initialSelections = new Set(
+    draft?.connectorId === connectorId ? draft.initialPermissionNames : [],
+  );
+  const saving = saveLoadable.state === "loading";
+  const changed = !permissionSelectionsEqual(selected, initialSelections);
+
+  const setPermission = (permissionName: string, allow: boolean) => {
+    setDraftPermission({ permissionName, allow });
+  };
+
+  const handleApply = () => {
+    if (saving || !changed) {
+      return;
+    }
+    detach(
+      (async () => {
+        await save(
+          {
+            connectorId,
+            permissionNames: permissions
+              .map((permission) => {
+                return permission.name;
+              })
+              .filter((permissionName) => {
+                return selected.has(permissionName);
+              }),
+          },
+          pageSignal,
+        );
+        toast.success(
+          t(($) => {
+            return $.connectors.access.permissionsUpdated;
+          }),
+        );
+        onClose();
+      })(),
+      Reason.DomCallback,
+    );
+  };
+
+  return (
+    <>
+      <div className="flex flex-1 flex-col overflow-y-auto -mx-6 px-6">
+        {permissions.map((permission) => {
+          const allowed = selected.has(permission.name);
+          return (
+            <div
+              key={permission.name}
+              className="flex items-center gap-3 border-b border-border/50 py-3 last:border-b-0"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-medium text-foreground">
+                  {permission.name}
+                </div>
+                {permission.description ? (
+                  <p className="mt-0.5 text-xs leading-5 text-muted-foreground">
+                    {permission.description}
+                  </p>
+                ) : null}
+              </div>
+              <PermissionPolicyToggle
+                policy={allowed ? "allow" : "deny"}
+                disabled={saving}
+                onAllow={() => {
+                  setPermission(permission.name, true);
+                }}
+                onDeny={() => {
+                  setPermission(permission.name, false);
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+      <SheetFooter>
+        <Button variant="outline" onClick={onClose} disabled={saving}>
+          {t(($) => {
+            return $.connectors.actions.cancel;
+          })}
+        </Button>
+        <Button onClick={handleApply} disabled={saving || !changed}>
+          {saving
+            ? t(($) => {
+                return $.connectors.actions.saving;
+              })
+            : t(($) => {
+                return $.connectors.actions.apply;
+              })}
+        </Button>
+      </SheetFooter>
+    </>
+  );
+}
+
+export function CustomConnectorPermissionsDrawer({
+  connectorId,
+  connectorName,
+  agentName,
+  bundle,
+  loading,
+  loadError,
+  onClose,
+}: {
+  readonly connectorId: string;
+  readonly connectorName: string;
+  readonly agentName: string;
+  readonly bundle: CustomConnectorPermissionBundleResponse | null;
+  readonly loading: boolean;
+  readonly loadError: boolean;
+  readonly onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <Sheet
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <SheetContent side="right">
+        <SheetHeader>
+          <div className="flex items-center gap-3">
+            <CustomConnectorIcon
+              id={connectorId}
+              displayName={connectorName}
+              size={24}
+            />
+            <SheetTitle className="text-base">
+              {t(
+                ($) => {
+                  return $.connectors.permissions.title;
+                },
+                { connector: connectorName },
+              )}
+              <span className="ml-1 text-sm font-normal text-muted-foreground">
+                {t(
+                  ($) => {
+                    return $.connectors.permissions.forTarget;
+                  },
+                  { target: agentName },
+                )}
+              </span>
+            </SheetTitle>
+          </div>
+          <SheetDescription>
+            {t(($) => {
+              return $.connectors.permissions.descriptionAgent;
+            })}
+          </SheetDescription>
+        </SheetHeader>
+
+        {bundle ? (
+          <LoadedCustomConnectorPermissions
+            key={connectorId}
+            connectorId={connectorId}
+            bundle={bundle}
+            onClose={onClose}
+          />
+        ) : (
+          <>
+            <div className="flex flex-1 items-center justify-center">
+              {loading ? (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <IconLoader2 size={16} className="animate-spin" />
+                  {t(($) => {
+                    return $.connectors.permissions.loading;
+                  })}
+                </div>
+              ) : (
+                <p className="text-sm text-destructive">
+                  {loadError
+                    ? t(($) => {
+                        return $.connectors.permissions.loadError;
+                      })
+                    : t(
+                        ($) => {
+                          return $.connectors.permissions.metadataMissing;
+                        },
+                        { connector: connectorName },
+                      )}
+                </p>
+              )}
+            </div>
+            <SheetFooter>
+              <Button variant="outline" onClick={onClose}>
+                {t(($) => {
+                  return $.connectors.actions.cancel;
+                })}
+              </Button>
+            </SheetFooter>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
+++ b/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
@@ -24,7 +24,7 @@ import {
   agentCustomConnectorPermissionBundle$,
   agentAddedCustomConnectors$,
   closeCustomConnectorPermissions$,
-  customConnectorPermissionTargetId$,
+  customConnectorPermissionDraft$,
   openCustomConnectorPermissions$,
   toggleAgentCustomConnector$,
 } from "../../signals/zero-page/job-detail/custom-connectors.ts";
@@ -142,7 +142,7 @@ export function JobCustomConnectorsSection() {
   const pageSignal = useGet(pageSignal$);
   const saving = useGet(agentCustomConnectorToggleSaving$);
   const permissionEditingEnabled = useGet(customConnectorPermissionsEnabled$);
-  const permissionTargetId = useGet(customConnectorPermissionTargetId$);
+  const permissionDraft = useGet(customConnectorPermissionDraft$);
   const openPermissions = useSet(openCustomConnectorPermissions$);
   const closePermissions = useSet(closeCustomConnectorPermissions$);
   const permissionBundleLoadable = useLoadable(
@@ -174,11 +174,20 @@ export function JobCustomConnectorsSection() {
     );
   };
 
-  const permissionTarget = permissionTargetId
+  const activePermissionDraft =
+    permissionDraft?.agentId === detail?.agentId ? permissionDraft : null;
+  const permissionTargetConnector = activePermissionDraft
     ? connectors.find((connector) => {
-        return connector.id === permissionTargetId;
+        return connector.id === activePermissionDraft.connectorId;
       })
     : undefined;
+  const permissionTarget =
+    activePermissionDraft && permissionTargetConnector
+      ? {
+          connector: permissionTargetConnector,
+          draft: activePermissionDraft,
+        }
+      : null;
   const permissionBundle =
     permissionBundleLoadable.state === "hasData"
       ? permissionBundleLoadable.data
@@ -205,14 +214,19 @@ export function JobCustomConnectorsSection() {
               c.hasSecret &&
               c.permissionBundleRef !== null &&
               c.permissionBundleRef !== undefined &&
-              grantsLoadable.state === "hasData"
+              grantsLoadable.state === "hasData" &&
+              detail?.agentId !== undefined
             }
             isLast={i === connectors.length - 1}
             onToggle={(checked) => {
               return handleToggle(c.id, checked);
             }}
             onManage={() => {
+              if (!detail?.agentId) {
+                return;
+              }
               openPermissions({
+                agentId: detail.agentId,
                 connectorId: c.id,
                 permissionNames:
                   grantsLoadable.state === "hasData"
@@ -227,8 +241,9 @@ export function JobCustomConnectorsSection() {
       })}
       {permissionTarget ? (
         <CustomConnectorPermissionsDrawer
-          connectorId={permissionTarget.id}
-          connectorName={permissionTarget.displayName}
+          agentId={permissionTarget.draft.agentId}
+          connectorId={permissionTarget.connector.id}
+          connectorName={permissionTarget.connector.displayName}
           agentName={
             detail?.displayName ??
             t(($) => {
@@ -239,7 +254,10 @@ export function JobCustomConnectorsSection() {
           loading={permissionBundleLoadable.state === "loading"}
           loadError={permissionBundleLoadable.state === "hasError"}
           onClose={() => {
-            closePermissions();
+            closePermissions({
+              agentId: permissionTarget.draft.agentId,
+              connectorId: permissionTarget.draft.connectorId,
+            });
           }}
         />
       ) : null}

--- a/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
+++ b/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
@@ -1,35 +1,61 @@
-import { useGet, useLastLoadable, useLastResolved } from "ccstate-react";
+import {
+  useGet,
+  useLastLoadable,
+  useLastResolved,
+  useLoadable,
+  useSet,
+} from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
+import { IconAdjustmentsHorizontal } from "@tabler/icons-react";
 import { toast } from "@vm0/ui/components/ui/sonner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vm0/ui";
 import type { CustomConnectorResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { customConnectors$ } from "../../signals/zero-page/settings/custom-connectors.ts";
 import {
   agentCustomConnectorToggleSaving$,
+  agentCustomConnectorGrants$,
+  agentCustomConnectorPermissionBundle$,
   agentAddedCustomConnectors$,
+  closeCustomConnectorPermissions$,
+  customConnectorPermissionTargetId$,
+  openCustomConnectorPermissions$,
   toggleAgentCustomConnector$,
 } from "../../signals/zero-page/job-detail/custom-connectors.ts";
+import { agentDetail$ } from "../../signals/zero-page/job-detail/detail.ts";
+import { customConnectorPermissionsEnabled$ } from "../../signals/external/feature-switch.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { CustomConnectorIcon } from "../zero-page/components/settings/custom-connector-icon.tsx";
+import { CustomConnectorPermissionsDrawer } from "./custom-connector-permissions-drawer.tsx";
 
 function CustomConnectorPermissionRow({
   connector,
   enabled,
   loading,
   disabled,
+  showManage,
   isLast,
   onToggle,
+  onManage,
 }: {
   connector: CustomConnectorResponse;
   enabled: boolean;
   loading: boolean;
   disabled: boolean;
+  showManage: boolean;
   isLast: boolean;
   onToggle: (checked: boolean) => void;
+  onManage: () => void;
 }) {
   const { t } = useTranslation("agents");
+  const { t: tCommon } = useTranslation();
   return (
     <div
       className={
@@ -55,6 +81,34 @@ function CustomConnectorPermissionRow({
             })}
         </div>
       </div>
+      {showManage ? (
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={onManage}
+                className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                aria-label={tCommon(
+                  ($) => {
+                    return $.connectors.card.managePermissionsFor;
+                  },
+                  { connector: connector.displayName },
+                )}
+              >
+                <IconAdjustmentsHorizontal size={15} stroke={1.5} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              <p className="text-xs">
+                {tCommon(($) => {
+                  return $.connectors.card.managePermissions;
+                })}
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : null}
       <LoadingSwitch
         checked={enabled}
         loading={loading}
@@ -87,6 +141,15 @@ export function JobCustomConnectorsSection() {
   const [, toggle] = useLoadableSet(toggleAgentCustomConnector$);
   const pageSignal = useGet(pageSignal$);
   const saving = useGet(agentCustomConnectorToggleSaving$);
+  const permissionEditingEnabled = useGet(customConnectorPermissionsEnabled$);
+  const permissionTargetId = useGet(customConnectorPermissionTargetId$);
+  const openPermissions = useSet(openCustomConnectorPermissions$);
+  const closePermissions = useSet(closeCustomConnectorPermissions$);
+  const permissionBundleLoadable = useLoadable(
+    agentCustomConnectorPermissionBundle$,
+  );
+  const grantsLoadable = useLastLoadable(agentCustomConnectorGrants$);
+  const detail = useLastResolved(agentDetail$);
 
   if (!connectors || connectors.length === 0) {
     return null;
@@ -111,6 +174,16 @@ export function JobCustomConnectorsSection() {
     );
   };
 
+  const permissionTarget = permissionTargetId
+    ? connectors.find((connector) => {
+        return connector.id === permissionTargetId;
+      })
+    : undefined;
+  const permissionBundle =
+    permissionBundleLoadable.state === "hasData"
+      ? permissionBundleLoadable.data
+      : null;
+
   return (
     <div className="zero-card">
       <div className="px-5 pt-4 pb-3 text-sm text-muted-foreground border-b border-border/50">
@@ -127,13 +200,49 @@ export function JobCustomConnectorsSection() {
             enabled={enabled}
             loading={saving}
             disabled={!c.hasSecret && !enabled}
+            showManage={
+              permissionEditingEnabled &&
+              c.hasSecret &&
+              c.permissionBundleRef !== null &&
+              c.permissionBundleRef !== undefined &&
+              grantsLoadable.state === "hasData"
+            }
             isLast={i === connectors.length - 1}
             onToggle={(checked) => {
               return handleToggle(c.id, checked);
             }}
+            onManage={() => {
+              openPermissions({
+                connectorId: c.id,
+                permissionNames:
+                  grantsLoadable.state === "hasData"
+                    ? (grantsLoadable.data.find((grant) => {
+                        return grant.customConnectorId === c.id;
+                      })?.permissionNames ?? [])
+                    : [],
+              });
+            }}
           />
         );
       })}
+      {permissionTarget ? (
+        <CustomConnectorPermissionsDrawer
+          connectorId={permissionTarget.id}
+          connectorName={permissionTarget.displayName}
+          agentName={
+            detail?.displayName ??
+            t(($) => {
+              return $.fallbackName;
+            })
+          }
+          bundle={permissionBundle}
+          loading={permissionBundleLoadable.state === "loading"}
+          loadError={permissionBundleLoadable.state === "hasError"}
+          onClose={() => {
+            closePermissions();
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
@@ -80,6 +80,20 @@ export type CustomConnectorPermissionBundleRef = z.infer<
   typeof customConnectorPermissionBundleRefSchema
 >;
 
+const customConnectorPermissionSchema = z.object({
+  name: z.string().min(1).max(128),
+  description: z.string().optional(),
+});
+
+export const customConnectorPermissionBundleSchema = z.object({
+  ref: customConnectorPermissionBundleRefSchema,
+  permissions: z.array(customConnectorPermissionSchema),
+  defaultPolicies: z.record(z.string(), z.enum(["allow", "deny", "ask"])),
+});
+export type CustomConnectorPermissionBundleResponse = z.infer<
+  typeof customConnectorPermissionBundleSchema
+>;
+
 export const customConnectorSkillMarkdownSchema = z.string().refine(
   (value) => {
     return new TextEncoder().encode(value).byteLength <= 65_536;
@@ -330,6 +344,20 @@ export const zeroCustomConnectorByIdContract = c.router({
       500: apiErrorSchema,
     },
     summary: "Update an org custom connector",
+  },
+  permissions: {
+    method: "GET",
+    path: "/api/zero/custom-connectors/:id/permissions",
+    headers: authHeadersSchema,
+    pathParams: z.object({ id: z.string().uuid() }),
+    responses: {
+      200: customConnectorPermissionBundleSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get an org custom connector permission bundle",
   },
 });
 export type ZeroCustomConnectorByIdContract =

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -86,4 +86,5 @@ export enum FeatureSwitchKey {
   CustomConnectorCliCreate = "customConnectorCliCreate",
   CustomConnectorOAuth2 = "customConnectorOAuth2",
   MermaidDiagrams = "mermaidDiagrams",
+  CustomConnectorPermissions = "customConnectorPermissions",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -537,6 +537,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.CustomConnectorPermissions]: {
+    maintainer: "yuma@vm0.ai",
+    description:
+      "Allow users to manage agent permission grants for custom connectors.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary

- persist the versioned Feishu permission bundle when the managed custom connector is created, with a connection-preserving backfill for existing connectors
- require explicit agent grants only for sending, editing, or recalling user messages; deleting content; and managing chats or groups
- keep other known Feishu operations on per-request approval and deny unknown routes
- add a feature-gated custom connector permission editor to the agent Authorization tab, shown only for configured connectors with a permission bundle
- expose custom connector permission metadata and save selections through the existing per-agent custom connector grants API
- document the supported Feishu API areas and operating rules in the generated connector skill

## Testing

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts src/signals/routes/__tests__/zero-feishu-integration.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/team-page/__tests__/team-navigation.test.tsx --maxWorkers=1 --silent=passed-only`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts --maxWorkers=1 --silent=passed-only`
- affected workspace formatting, lint, and type checks
- `pnpm knip`
- full pre-commit Prettier, Knip, repository type checks, file-size check, and commitlint hooks