### PR TITLE
refactor(platform): stop intercepting fetch in the service worker

### DIFF
--- a/turbo/apps/platform/public/sw.js
+++ b/turbo/apps/platform/public/sw.js
@@ -1,19 +1,5 @@
-const CACHE_VERSION = String(Date.now());
-const STATIC_CACHE = `static-${CACHE_VERSION}`;
+const LEGACY_CACHE_PREFIX = "static-";
 const OKOU_ROOT_DOMAINS = ["okou.ai", "omby.ai", "okou-app.pages.dev"];
-
-const STATIC_RE =
-  /\.(?:js|css|png|svg|jpe?g|gif|ico|woff2?|ttf|eot|webp|avif|json|wasm|map)$/i;
-
-function isStaticAsset(url) {
-  return url.origin === self.location.origin && STATIC_RE.test(url.pathname);
-}
-
-function isApiRequest(url) {
-  return (
-    url.origin === self.location.origin && url.pathname.startsWith("/api/")
-  );
-}
 
 function defaultNotificationTitle() {
   const hostname = self.location.hostname.toLowerCase();
@@ -23,108 +9,25 @@ function defaultNotificationTitle() {
   return isOkou ? "Okou" : "VM0";
 }
 
-function isCacheableAssetResponse(response) {
-  const contentType = response.headers.get("content-type") ?? "";
-  return (
-    response.ok &&
-    !response.redirected &&
-    !contentType.toLowerCase().includes("text/html")
-  );
-}
-
 self.addEventListener("install", (_event) => {
   self.skipWaiting();
 });
 
-// Activate: delete old cache versions, then claim all clients
+// Activate: drop the Cache Storage entries written by earlier versions of this
+// worker. There is no `fetch` handler anymore, so requests go straight to the
+// network and the browser HTTP cache; nothing reads those caches.
 self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches
-      .keys()
-      .then((keys) =>
-        Promise.all(
-          keys.filter((k) => k !== STATIC_CACHE).map((k) => caches.delete(k)),
-        ),
-      )
-      .then(() => self.clients.claim()),
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter((key) => key.startsWith(LEGACY_CACHE_PREFIX))
+          .map((key) => caches.delete(key)),
+      );
+      await self.clients.claim();
+    })(),
   );
-});
-
-// Fetch: cache static assets, keep API requests network-only, and serve
-// navigations network-first with a cached offline fallback.
-self.addEventListener("fetch", (event) => {
-  if (event.request.method !== "GET") {
-    return;
-  }
-
-  const url = new URL(event.request.url);
-
-  if (isStaticAsset(url)) {
-    // Cache-First: Vite content-hashed filenames are immutable.
-    event.respondWith(
-      (async () => {
-        const cache = await caches.open(STATIC_CACHE);
-        const cached = await cache.match(event.request);
-        if (cached && isCacheableAssetResponse(cached)) {
-          return cached;
-        }
-
-        if (cached) {
-          await cache.delete(event.request);
-        }
-
-        const r = await fetch(event.request, { cache: "reload" });
-        if (isCacheableAssetResponse(r)) {
-          await cache.put(event.request, r.clone());
-        }
-        return r;
-      })(),
-    );
-    return;
-  }
-
-  if (isApiRequest(url)) {
-    // API: network only, no caching.
-    event.respondWith(fetch(event.request));
-    return;
-  }
-
-  if (event.request.mode === "navigate") {
-    // Network-First: cache the app shell on each successful navigation so
-    // the PWA can cold-open offline. Production serves index.html with
-    // `cache-control: must-revalidate`, which prevents the browser's HTTP
-    // cache from being used without a server check. The SW Cache Storage
-    // is not bound by HTTP cache directives, so we cache explicitly here
-    // and serve from cache when the network is unreachable.
-    event.respondWith(
-      (async () => {
-        try {
-          const response = await fetch(event.request);
-          if (response.ok && !response.redirected) {
-            const cache = await caches.open(STATIC_CACHE);
-            await cache.put(event.request, response.clone());
-          }
-          return response;
-        } catch {
-          const cached = await caches.match(event.request);
-          if (cached) {
-            return cached;
-          }
-          return new Response(
-            "You are offline. Connect to the internet and try again.",
-            {
-              status: 503,
-              headers: { "Content-Type": "text/plain" },
-            },
-          );
-        }
-      })(),
-    );
-    return;
-  }
-
-  // All other requests (third-party, etc.): pass through to the browser's
-  // default handling without SW interception.
 });
 
 // --- Web Push Notifications ---


### PR DESCRIPTION
## Summary

Remove the `fetch` listener from the platform service worker. It now only handles web push notifications; every request goes straight to the network and the browser HTTP cache with no service-worker layer in between.

## Why

The interception was hard to reason about and bought little:

- Static assets were served Cache-First from Cache Storage, but `CACHE_VERSION` was `Date.now()` evaluated on every script evaluation. The worker is re-evaluated whenever the browser restarts it after idle termination, so `STATIC_CACHE` changed name, the reopened cache was empty, and the previous entries were orphaned until the next `activate`. Hit rate was far below what the code implied.
- Static-asset matching ran before the `/api/` check and only looked at the pathname suffix, so a same-origin `/api/*.json` or `/api/*.map` path would have been treated as an immutable asset.
- The `/api/` branch was `respondWith(fetch(request))` — a pass-through that added a worker round trip and nothing else.
- Hashed assets are already served `public, max-age=31536000, immutable` and `index.html` as `must-revalidate` (`.github/pages/okou-app/_headers`), so the HTTP cache covers the warm-load case on its own.

## Trade-off

The navigation Network-First branch cached the app shell so an installed PWA could cold-open offline; that is gone. Offline cold start now shows the browser's own offline page instead of the cached shell.

## Changes

- Delete the `fetch` listener and the static/API helpers and cache constants.
- `activate` now deletes the `static-*` caches written by earlier worker versions so existing installs do not keep dead Cache Storage entries.
- `install`, `push`, and `notificationclick` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
