### PR TITLE
perf(python): avoid caching request urls

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -54,6 +54,7 @@ from firewall_auth_config import (
     auth_config_injects_ordinary_upstream_credentials,
 )
 from logging_utils import log_proxy_entry
+from runtime_url_parsing import split_runtime_url
 from url_syntax import has_unsafe_runtime_url_syntax
 from url_utils import build_rewrite_url
 
@@ -398,14 +399,14 @@ def _trusted_aws_sigv4_url(flow: http.HTTPFlow) -> str:
         raise AwsSigV4SigningError("AWS request URL is malformed")
 
     try:
-        original = urllib.parse.urlsplit(url)
+        original = split_runtime_url(url)
     except ValueError as e:
         raise AwsSigV4SigningError("AWS request URL is malformed") from e
 
     if has_unsafe_runtime_url_syntax(flow.request.path, allow_backslash=True):
         raise AwsSigV4SigningError("AWS request URL is malformed")
     try:
-        current_query = urllib.parse.urlsplit(flow.request.path).query
+        current_query = split_runtime_url(flow.request.path).query
     except ValueError as e:
         raise AwsSigV4SigningError("AWS request URL is malformed") from e
     if current_query == original.query:

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -36,6 +36,7 @@ from authority_utils import (
 )
 from host_normalization import normalize_idna_hostname
 from http_header_syntax import has_forbidden_header_value_control, is_http_header_name
+from runtime_url_parsing import split_runtime_url
 
 HOP_BY_HOP: frozenset[str] = frozenset(
     (
@@ -882,7 +883,7 @@ async def _resolve_validated_addresses(
 
 
 def _prepare_forward_request(url: str) -> _PreparedForwardRequest:
-    parsed = urllib.parse.urlsplit(url)
+    parsed = split_runtime_url(url)
     _connection_factory(parsed.scheme.lower())
     _reject_userinfo(parsed)
     host = _normalized_forward_request_host(parsed)

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from enum import Enum
 
 from http_header_syntax import has_forbidden_header_value_control, is_http_header_name
+from runtime_url_parsing import split_runtime_url
 
 _AWS4_REQUEST = "aws4_request"
 _HMAC_ALGORITHM = "AWS4-HMAC-SHA256"
@@ -219,7 +220,7 @@ def _parse_url_for_signing(url: str) -> _SigningUrl:
     if _has_malformed_percent_encoding(url):
         raise AwsSigV4SigningError("AWS request URL is malformed")
     try:
-        parts = urllib.parse.urlsplit(url)
+        parts = split_runtime_url(url)
     except ValueError as e:
         raise AwsSigV4SigningError("AWS request URL is malformed") from e
     return _SigningUrl(

--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -17,6 +17,7 @@ from mitmproxy import http
 
 import body_decoding
 import flow_metadata
+from runtime_url_parsing import split_runtime_url
 
 FRESH_SECONDS = 60.0
 MAX_ENTRY_BYTES = 1024 * 1024
@@ -208,7 +209,7 @@ def _credential_digest(flow: http.HTTPFlow) -> bytes | None:
 
 def _split_expected_url(original_url: str) -> urllib.parse.SplitResult | None:
     try:
-        parsed = urllib.parse.urlsplit(original_url)
+        parsed = split_runtime_url(original_url)
         port = parsed.port
     except ValueError:
         return None

--- a/crates/runner/mitm-addon/src/firewall_matching/base_url.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/base_url.py
@@ -27,6 +27,7 @@ from host_normalization import (
     translate_idna_dot_separators,
 )
 from path_security import has_unsafe_url_path
+from runtime_url_parsing import split_runtime_url
 from url_syntax import (
     has_raw_whitespace,
     has_unsafe_runtime_url_syntax,
@@ -204,7 +205,7 @@ def _split_base_match_url(
         return None
 
     try:
-        parts = urlsplit(value)
+        parts = split_runtime_url(value)
     except ValueError:
         return None
     if not parts.scheme or not parts.netloc:

--- a/crates/runner/mitm-addon/src/http_local_responses.py
+++ b/crates/runner/mitm-addon/src/http_local_responses.py
@@ -13,6 +13,7 @@ import http_network_log
 import matching
 import registry
 from logging_utils import log_proxy_entry
+from runtime_url_parsing import split_runtime_url
 from url_utils import AuthorityValidationError
 
 _BUILTIN_HOST_POLICY_DENIED_ERROR: Final = "builtin_host_policy_denied"
@@ -238,7 +239,7 @@ def set_firewall_block_response(flow: http.HTTPFlow, result: matching.FirewallBl
         result.permissions[0] if len(result.permissions) == 1 else ""
     )
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
-    diagnostic_parts = urllib.parse.urlsplit(original_url)
+    diagnostic_parts = split_runtime_url(original_url)
     diagnostic_url = urllib.parse.urlunsplit(
         (diagnostic_parts.scheme, diagnostic_parts.netloc, diagnostic_parts.path, "", "")
     )
@@ -285,7 +286,7 @@ def set_firewall_ambiguous_response(
     flow.metadata[metadata_keys.CONNECTOR_ROUTE_REASON] = result.reason
     flow.metadata[metadata_keys.CONNECTOR_ROUTE_CANDIDATES] = candidates
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
-    diagnostic_parts = urllib.parse.urlsplit(original_url)
+    diagnostic_parts = split_runtime_url(original_url)
     diagnostic_url = urllib.parse.urlunsplit(
         (diagnostic_parts.scheme, diagnostic_parts.netloc, diagnostic_parts.path, "", "")
     )

--- a/crates/runner/mitm-addon/src/network_log_sanitization.py
+++ b/crates/runner/mitm-addon/src/network_log_sanitization.py
@@ -2,6 +2,8 @@
 
 import urllib.parse
 
+from runtime_url_parsing import split_runtime_url
+
 _URLSPLIT_LEADING_STRIP_CHARACTERS = "".join(chr(codepoint) for codepoint in range(0x21))
 _URLSPLIT_REMOVABLE_CHARACTERS = "\t\r\n"
 _SPECIAL_URL_SCHEMES = ("http", "https")
@@ -86,7 +88,7 @@ def sanitize_url_for_network_log(value: str) -> str:
     """
     normalized_value = _normalize_for_urlsplit(value)
     try:
-        parts = urllib.parse.urlsplit(normalized_value)
+        parts = split_runtime_url(normalized_value)
     except ValueError:
         return _sanitize_url_text_fallback_for_network_log(normalized_value)
 

--- a/crates/runner/mitm-addon/src/runtime_url_parsing.py
+++ b/crates/runner/mitm-addon/src/runtime_url_parsing.py
@@ -1,0 +1,10 @@
+"""URL parsing for request-lifetime inputs that must not enter global caches."""
+
+import urllib.parse
+
+_uncached_urlsplit = urllib.parse.urlsplit.__wrapped__
+
+
+def split_runtime_url(value: str) -> urllib.parse.SplitResult:
+    """Split a runtime URL without retaining it in urllib's process-wide LRU."""
+    return _uncached_urlsplit(value)

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+import runtime_url_parsing
 from aws_sigv4 import (
     AwsSigV4Credentials,
     AwsSigV4SigningError,
@@ -279,8 +280,12 @@ def test_sign_request_splits_input_url_once(
     url: str,
     headers: list[tuple[str, str]],
 ) -> None:
-    real_urlsplit = urllib.parse.urlsplit
-    with patch.object(urllib.parse, "urlsplit", wraps=real_urlsplit) as urlsplit:
+    real_urlsplit = runtime_url_parsing._uncached_urlsplit
+    with patch.object(
+        runtime_url_parsing,
+        "_uncached_urlsplit",
+        wraps=real_urlsplit,
+    ) as urlsplit:
         sign_request(
             method="GET",
             url=url,

--- a/crates/runner/mitm-addon/tests/test_firewall_request_matching.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_request_matching.py
@@ -1,5 +1,7 @@
 """Raw firewall request matching tests through the production compiled matcher."""
 
+import urllib.parse
+
 import matching
 from tests.firewall_helpers import grant_all, match_request_with_raw_firewalls, wrap_firewalls
 
@@ -51,6 +53,38 @@ class TestFirewallRequestMatching:
         assert result.permission == "repo-read"
         assert result.params == {"owner": "octocat", "repo": "hello"}
         assert result.rule == "GET /repos/{owner}/{repo}"
+
+    def test_runtime_url_does_not_enter_global_parse_cache(self):
+        fw_configs = wrap_firewalls(
+            [
+                {
+                    "base": "https://api.example.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "read", "rules": ["GET /items/{id}"]}],
+                }
+            ],
+            name="example",
+        )
+        compiled = matching.compile_firewalls(fw_configs)
+        assert compiled is not None
+
+        urllib.parse.urlsplit.cache_clear()
+        try:
+            assert matching.firewall_base_config_is_valid("https://stable-config.example.com")
+            stable_cache = urllib.parse.urlsplit.cache_info()
+            assert stable_cache.currsize > 0
+
+            result = matching.match_compiled_firewall_request(
+                f"https://api.example.com/items/123?payload={'x' * 200_000}",
+                "GET",
+                compiled,
+                grant_all(fw_configs),
+            )
+
+            assert isinstance(result, matching.FirewallAllow)
+            assert urllib.parse.urlsplit.cache_info() == stable_cache
+        finally:
+            urllib.parse.urlsplit.cache_clear()
 
     def test_aws_sigv4_auth_config_allows_matching(self):
         fw_configs = wrap_firewalls(

--- a/crates/runner/mitm-addon/tests/test_response_handler_logging.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_logging.py
@@ -1,6 +1,7 @@
 """Response hook integration tests for network and proxy logging."""
 
 import time
+import urllib.parse
 from pathlib import Path
 
 import pytest
@@ -279,6 +280,38 @@ def test_network_log_target_url_strips_query_and_fragment(
     assert entry["url"] == expected_url
     assert flow.metadata[metadata_keys.ORIGINAL_URL] == raw_url
     assert flow.metadata[metadata_keys.NETWORK_LOG_TARGET]["url"] == raw_url
+
+
+def test_network_log_does_not_cache_runtime_url(tmp_path, real_flow, mitm_ctx):
+    raw_url = f"https://target.example.com/path?payload={'x' * 200_000}#fragment"
+    flow = real_flow(with_response=False, host="target.example.com")
+    log_path = str(tmp_path / "network.jsonl")
+    flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow.metadata[metadata_keys.ORIGINAL_URL] = raw_url
+    http_network_log.set_target(
+        flow,
+        url=raw_url,
+        host="target.example.com",
+        port=443,
+    )
+    flow.response = tutils.tresp(status_code=200, headers=header_map({"content-length": "0"}))
+
+    urllib.parse.urlsplit.cache_clear()
+    try:
+        urllib.parse.urlsplit("https://stable-config.example.com")
+        stable_cache = urllib.parse.urlsplit.cache_info()
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        assert urllib.parse.urlsplit.cache_info() == stable_cache
+    finally:
+        urllib.parse.urlsplit.cache_clear()
+
+    [entry] = read_jsonl_entries_after_flush(Path(log_path))
+    assert entry["url"] == "https://target.example.com/path"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add a request-lifetime URL split boundary that invokes the undecorated stdlib parser without populating `urllib.parse`'s process-wide LRU
- migrate audited request-derived URL parsing in firewall matching, network-log sanitization, local responses, AWS signing, Codex catalog handling, and auth-base forwarding while retaining cached parsing for stable configuration/platform URLs
- cover both compiled matching and the real logged-response lifecycle with deterministic cache-state assertions, and preserve the SigV4 once-per-input parse contract

## Why this scope

A matcher-only change is insufficient: enabled response network logging parses the same full runtime URL again while sanitizing it. The before diagnostic still retained 48.89 MiB after simulating an uncached matcher followed by the real sanitizer. This PR fixes the complete ordinary lifecycle and the other confirmed request-derived direct `urlsplit()` consumers through one narrow shared boundary.

Stable firewall/auth/host-policy configuration and platform-owned API/webhook URLs continue using the bounded stdlib cache. URL parsing results, failure behavior, matching, redaction, signing, forwarding, and external contracts are unchanged.

## Validation

- `uv lock --check`
- `uv sync --locked`
- focused matcher, response/logging, AWS, Codex catalog, auth-base forwarding, and firewall dispatch suites (571 tests passed across two runs)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,547 passed)
- 128-request matcher-plus-sanitizer diagnostic: cache entries `128 -> 0`, retained traced memory `48.89 MiB -> 0.00 MiB`
- pre-commit Ruff, file-size, and commit-message checks

No dependency, lockfile, API, schema, persisted-data, protocol, migration, or rollout change is included.

Closes #24316
