### PR TITLE
perf(api): reduce queue-first claim work under the organization lock

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -144,6 +144,10 @@ const API_DISPATCH_THREAD_SESSION_BINDING_ACTION_TYPES = [
 const API_DISPATCH_QUEUE_FIRST_ADMISSION_ACTION_TYPES = [
   "api_dispatch_resolve_queue_first_admission",
 ] as const;
+const API_DISPATCH_QUEUE_FIRST_CLAIM_PHASE_ACTION_TYPES = [
+  "api_dispatch_resolve_queue_first_claim_snapshot",
+  "api_dispatch_persist_queue_first_replacement",
+] as const;
 const API_DISPATCH_REUSED_THREAD_READ_ACTION_TYPES = [
   "api_dispatch_queue_first_thread_lock_wait",
   "api_dispatch_load_thread_session_binding",
@@ -5527,6 +5531,7 @@ describe("CHAT-02: queued attachments on auto-send", () => {
     const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
 
     const fileId = randomUUID();
+    const secondFileId = randomUUID();
     const queuedId = randomUUID();
     const queued = await chat.requestSendEvent(
       actor,
@@ -5543,6 +5548,12 @@ describe("CHAT-02: queued attachments on auto-send", () => {
             contentType: "text/plain",
             size: 12,
           },
+          {
+            id: secondFileId,
+            filename: "details.json",
+            contentType: "application/json",
+            size: 24,
+          },
         ],
       },
       [201],
@@ -5558,6 +5569,11 @@ describe("CHAT-02: queued attachments on auto-send", () => {
           id: fileId,
           filename: "notes.txt",
           contentType: "text/plain",
+        }),
+        expect.objectContaining({
+          id: secondFileId,
+          filename: "details.json",
+          contentType: "application/json",
         }),
       ],
     });
@@ -5590,13 +5606,22 @@ describe("CHAT-02: queued attachments on auto-send", () => {
     await expect(readChatEventInputParamsFixture(queuedId)).resolves.toBeNull();
     expect(promoted.content).toBeNull();
     expect(chatEventDisplayText(promoted)).toBe("queued with attachment");
-    expect(promoted.attachFiles?.[0]).toMatchObject({
-      id: fileId,
-      filename: "notes.txt",
-      contentType: "text/plain",
-      size: 12,
-      url: expect.stringContaining(`${fileId}/notes.txt`),
-    });
+    expect(promoted.attachFiles).toMatchObject([
+      {
+        id: fileId,
+        filename: "notes.txt",
+        contentType: "text/plain",
+        size: 12,
+        url: expect.stringContaining(`${fileId}/notes.txt`),
+      },
+      {
+        id: secondFileId,
+        filename: "details.json",
+        contentType: "application/json",
+        size: 24,
+        url: expect.stringContaining(`${secondFileId}/details.json`),
+      },
+    ]);
     const original = userMessages(messages.events).find((message) => {
       return message.id === queuedId;
     });
@@ -5614,6 +5639,10 @@ describe("CHAT-02: queued attachments on auto-send", () => {
     expect(followUp.prompt).toContain("queued with attachment");
     expect(followUp.prompt).toContain("[Web file] notes.txt (text/plain)");
     expect(followUp.prompt).toContain(`[ID] ${fileId}`);
+    expect(followUp.prompt).toContain(
+      "[Web file] details.json (application/json)",
+    );
+    expect(followUp.prompt).toContain(`[ID] ${secondFileId}`);
     await cancelChatRun(actor, promoted.runId);
   }, 90_000);
 });
@@ -5972,11 +6001,31 @@ describe("CHAT-02: shared user message queue", () => {
     );
     await expect
       .poll(() => {
-        return apiDispatchActionTypes(apiDispatchTimingEventsForRun(runId)).has(
-          "api_dispatch_claim_queue_first_message",
+        const actionTypes = apiDispatchActionTypes(
+          apiDispatchTimingEventsForRun(runId),
         );
+        return [
+          "api_dispatch_claim_queue_first_message",
+          ...API_DISPATCH_QUEUE_FIRST_CLAIM_PHASE_ACTION_TYPES,
+        ].every((actionType) => {
+          return actionTypes.has(actionType);
+        });
       })
       .toBe(true);
+    const claimTimingEvents = apiDispatchTimingEventsForRun(runId);
+    expectApiDispatchSpanKind(
+      claimTimingEvents,
+      API_DISPATCH_QUEUE_FIRST_CLAIM_PHASE_ACTION_TYPES,
+      "nested",
+    );
+    for (const actionType of API_DISPATCH_QUEUE_FIRST_CLAIM_PHASE_ACTION_TYPES) {
+      expect(claimTimingEvents).toContainEqual(
+        expect.objectContaining({
+          op_type: actionType,
+          queue_first_association_kind: "user_message",
+        }),
+      );
+    }
 
     await cancelChatRun(actor, runId);
   }, 90_000);

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -137,6 +137,8 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_concurrency_preflight_check"
   | "api_dispatch_resolve_queue_first_admission"
   | "api_dispatch_claim_queue_first_message"
+  | "api_dispatch_resolve_queue_first_claim_snapshot"
+  | "api_dispatch_persist_queue_first_replacement"
   | "api_dispatch_queue_first_thread_lock_wait"
   | "api_dispatch_insert_run_record"
   | "api_dispatch_validate_thread_session_snapshot_thread"

--- a/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
@@ -105,7 +105,7 @@ export async function admitGoalQueueEvent(
   });
 }
 
-function noGoalChangeAfterQueueEvent(db: Pick<Db, "select">) {
+export function noGoalChangeAfterQueueEvent(db: Pick<Db, "select">) {
   return notExists(
     db
       .select({ id: laterGoalChange.id })
@@ -212,42 +212,6 @@ export async function loadGoalQueueTarget(
     objective: goal.objective,
     objectiveBrief: goal.objectiveBrief,
   };
-}
-
-/** Final-claim goal snapshot check after expensive run preparation. */
-export async function goalQueueEventMatchesActiveGoal(
-  db: Pick<Db, "select">,
-  args: {
-    readonly chatThreadId: string;
-    readonly goalId: string;
-    readonly eventId: string;
-    readonly orgId: string;
-    readonly userId: string;
-  },
-): Promise<boolean> {
-  const [goal] = await db
-    .select({
-      status: threadGoals.status,
-    })
-    .from(threadGoals)
-    .innerJoin(
-      chatEvents,
-      and(
-        eq(chatEvents.id, args.eventId),
-        eq(chatEvents.chatThreadId, threadGoals.chatThreadId),
-      ),
-    )
-    .where(
-      and(
-        eq(threadGoals.id, args.goalId),
-        eq(threadGoals.chatThreadId, args.chatThreadId),
-        eq(threadGoals.orgId, args.orgId),
-        eq(threadGoals.ownerUserId, args.userId),
-        noGoalChangeAfterQueueEvent(db),
-      ),
-    )
-    .limit(1);
-  return goal?.status === "active";
 }
 
 async function pendingGoalEventStillExists(

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -305,6 +305,17 @@ interface StoredChatEventContextPointer {
   readonly contextId: string | null;
 }
 
+export interface LoadedChatEventReplacementTarget extends StoredChatEventContextPointer {
+  readonly id: string;
+  readonly chatThreadId: string;
+  readonly createdAt: Date;
+  readonly eventType: NonNullable<ChatEventInsert["eventType"]>;
+  readonly encryptedParams: string | null;
+  readonly attachFileMetadata:
+    | typeof chatEventInputParams.$inferSelect.attachFileMetadata
+    | null;
+}
+
 type NewDisplayContext =
   | {
       readonly type: "slack";
@@ -817,6 +828,7 @@ export async function replaceChatEvent(
 ): Promise<ChatEventCommandResult | null> {
   const [target] = await tx
     .select({
+      id: chatEvents.id,
       chatThreadId: chatEvents.chatThreadId,
       createdAt: chatEvents.createdAt,
       eventType: chatEvents.eventType,
@@ -835,10 +847,20 @@ export async function replaceChatEvent(
   if (!target) {
     throw new Error("Cannot revoke a missing chat event");
   }
+  return await replaceLoadedChatEvent(tx, target, replacement, options);
+}
+
+/** Append a replacement for a target already loaded by an authoritative read. */
+export async function replaceLoadedChatEvent(
+  tx: ChatEventWriteTransaction,
+  target: LoadedChatEventReplacementTarget,
+  replacement: NewChatEvent,
+  options?: { readonly preserveAssetRefs?: boolean },
+): Promise<ChatEventCommandResult | null> {
   if (target.chatThreadId !== replacement.chatThreadId) {
     throw new Error("Cannot revoke a chat event from another thread");
   }
-  if (replacement.id === eventId) {
+  if (replacement.id === target.id) {
     throw new Error("A chat event cannot revoke itself");
   }
   const createdAt =
@@ -885,7 +907,7 @@ export async function replaceChatEvent(
         },
       ),
       seqId,
-      revokesEventId: eventId,
+      revokesEventId: target.id,
     })
     .onConflictDoNothing()
     .returning({
@@ -903,31 +925,28 @@ export async function replaceChatEvent(
   }
   await insertEventInputParams(tx, inserted.id, replacementWithParams);
   if (options?.preserveAssetRefs !== false) {
-    const assetRefs = await tx
-      .select({
-        assetId: chatEventAssetRefs.assetId,
-        position: chatEventAssetRefs.position,
-      })
-      .from(chatEventAssetRefs)
-      .where(eq(chatEventAssetRefs.chatEventId, eventId));
-    if (assetRefs.length > 0) {
-      await tx
-        .insert(chatEventAssetRefs)
-        .values(
-          assetRefs.map((assetRef) => {
-            return {
-              chatEventId: inserted.id,
-              assetId: assetRef.assetId,
-              position: assetRef.position,
-            };
-          }),
-        )
-        .onConflictDoNothing();
-    }
+    await tx
+      .insert(chatEventAssetRefs)
+      .select(
+        tx
+          .select({
+            chatEventId: sql`${inserted.id}`
+              .mapWith(chatEventAssetRefs.chatEventId)
+              .as("chat_event_id"),
+            assetId: chatEventAssetRefs.assetId,
+            position: chatEventAssetRefs.position,
+            createdAt: sql`now()`
+              .mapWith(chatEventAssetRefs.createdAt)
+              .as("created_at"),
+          })
+          .from(chatEventAssetRefs)
+          .where(eq(chatEventAssetRefs.chatEventId, target.id)),
+      )
+      .onConflictDoNothing();
   }
   await tx
     .delete(chatEventInputParams)
-    .where(eq(chatEventInputParams.eventId, eventId));
+    .where(eq(chatEventInputParams.eventId, target.id));
   return inserted;
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -11,25 +11,41 @@ import {
 } from "@vm0/db/schema/chat-event";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { morningBriefDeliveries } from "@vm0/db/schema/morning-brief";
+import { threadGoals } from "@vm0/db/schema/thread-goal";
 import {
   zeroWorkflowAutomations,
   zeroWorkflows,
 } from "@vm0/db/schema/zero-workflow";
-import { and, eq, exists, isNull, notExists, sql, type SQL } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  exists,
+  isNull,
+  notExists,
+  sql,
+  type SQL,
+} from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
 
-import { pgNullDecoder } from "../../lib/db-structured-result";
+import {
+  pgBooleanDecoder,
+  pgNullDecoder,
+} from "../../lib/db-structured-result";
 import type { Db } from "../external/db";
 import {
-  hasPendingUserChatQueueEvent,
   listPendingChatQueueEvents,
   loadPendingChatQueueEvent,
   lockChatQueueThread,
+  pendingChatQueueEventCondition,
 } from "./chat-event-queue.service";
 import {
   insertChatEvent,
+  type LoadedChatEventReplacementTarget,
+  type NewChatEvent,
   revokeChatEvent,
+  replaceLoadedChatEvent,
   replaceChatEvent,
 } from "./zero-chat-event.service";
 import { touchChatThreadLastMessageAt } from "./zero-chat-event-shared.service";
@@ -40,7 +56,7 @@ import {
   decryptPersistentSecretsMap,
   encryptPersistentSecretsMap,
 } from "./crypto.utils";
-import { goalQueueEventMatchesActiveGoal } from "./chat-goal-queue.service";
+import { noGoalChangeAfterQueueEvent } from "./chat-goal-queue.service";
 import { feishuOrgCallbackFileSchema } from "./feishu-org-callback-payload";
 import { agentphoneDeliveryTargetSchema } from "./agentphone-chat-callback-payload";
 import { githubDeliveryTargetSchema } from "./github-chat-callback-payload";
@@ -125,6 +141,16 @@ const queuedChatEvent = alias(chatEvents, "queued_chat_event");
 const queuedChatEventRevoker = alias(chatEvents, "queued_chat_event_revoker");
 const queuedEncryptedParams = chatEventInputParams.encryptedParams;
 const queuedAttachFileMetadata = chatEventInputParams.attachFileMetadata;
+const queueFirstReplacementTargetFields = {
+  id: chatEvents.id,
+  chatThreadId: chatEvents.chatThreadId,
+  createdAt: chatEvents.createdAt,
+  eventType: chatEvents.eventType,
+  contextType: chatEvents.contextType,
+  contextId: chatEvents.contextId,
+  encryptedParams: queuedEncryptedParams,
+  attachFileMetadata: queuedAttachFileMetadata,
+} as const;
 
 export interface QueuedUserMessage {
   readonly id: string;
@@ -327,41 +353,50 @@ export async function loadNextUnclaimedQueuedUserMessageId(
   return head?.eventType === "input.prompt" ? head.id : null;
 }
 
-async function hasUnclaimedQueuedUserMessage(
-  db: Db,
-  threadId: string,
-): Promise<boolean> {
-  return await hasPendingUserChatQueueEvent(db, threadId);
+type QueueFirstClaimArgs = QueueFirstRunAssociation & {
+  readonly admission: QueueFirstRunAdmission;
+  readonly runId: string;
+  readonly timing: ApiDispatchTimingCollector;
+};
+
+interface QueueFirstClaimSnapshot {
+  readonly target: LoadedChatEventReplacementTarget;
+  readonly replacement: NewChatEvent;
 }
 
-interface ClaimedUserMessage {
-  readonly createdAt: Date;
+function queueFirstHeadPriority(): SQL {
+  return sql`CASE ${chatEvents.eventType}
+    WHEN 'input.prompt' THEN 0
+    WHEN 'input.automation' THEN 1
+    WHEN 'input.goal' THEN 2
+    ELSE 3
+  END`;
 }
 
-/**
- * Append the run-associated replacement for a pending user event. The revoke
- * edge on the replacement is the atomic queue claim.
- */
-async function appendClaimedUserMessage(
+function replacementTargetFromQueueHead(
+  head: LoadedChatEventReplacementTarget,
+): LoadedChatEventReplacementTarget {
+  return {
+    id: head.id,
+    chatThreadId: head.chatThreadId,
+    createdAt: head.createdAt,
+    eventType: head.eventType,
+    contextType: head.contextType,
+    contextId: head.contextId,
+    encryptedParams: head.encryptedParams,
+    attachFileMetadata: head.attachFileMetadata,
+  };
+}
+
+async function resolveUserQueueFirstClaimSnapshot(
   db: DbTransaction,
-  args: {
-    readonly threadId: string;
-    readonly eventId: string;
-    readonly runId: string;
-  },
-): Promise<ClaimedUserMessage | null> {
-  const pending = await loadPendingChatQueueEvent(db, {
-    chatThreadId: args.threadId,
-    eventId: args.eventId,
-  });
-  if (pending?.eventType !== "input.prompt") {
-    return null;
-  }
-  const [queued] = await db
+  args: Extract<QueueFirstClaimArgs, { readonly kind: "user_message" }>,
+): Promise<QueueFirstClaimSnapshot | null> {
+  const [head] = await db
     .select({
+      ...queueFirstReplacementTargetFields,
       userMessage: chatEvents.userMessage,
       attachFiles: chatEvents.attachFiles,
-      attachFileMetadata: queuedAttachFileMetadata,
       generationTemplate: chatEvents.generationTemplate,
       triggerSource: chatEvents.triggerSource,
     })
@@ -372,124 +407,47 @@ async function appendClaimedUserMessage(
     )
     .where(
       and(
-        eq(chatEvents.id, args.eventId),
         eq(chatEvents.chatThreadId, args.threadId),
-        chatEventTypeIn(["input.prompt"]),
-        isNull(chatEvents.runId),
+        pendingChatQueueEventCondition(db),
       ),
+    )
+    .orderBy(
+      queueFirstHeadPriority(),
+      asc(chatEvents.createdAt),
+      asc(chatEvents.id),
     )
     .for("update", { of: chatEvents })
     .limit(1);
-  if (!queued) {
+  if (!head || head.eventType !== "input.prompt" || head.id !== args.eventId) {
     return null;
   }
-  if (!queued.userMessage) {
+  if (!head.userMessage) {
     throw new Error("Queued input event is missing userMessage");
   }
-
-  const claimed = await replaceChatEvent(db, args.eventId, {
-    chatThreadId: args.threadId,
-    eventType: "input.prompt",
-    userMessage: queued.userMessage,
-    runId: args.runId,
-    attachFiles: queued.attachFiles ? [...queued.attachFiles] : null,
-    attachFileMetadata: queued.attachFileMetadata
-      ? [...queued.attachFileMetadata]
-      : null,
-    generationTemplate: queued.generationTemplate,
-    ...(queued.triggerSource ? { triggerSource: queued.triggerSource } : {}),
-  });
-  if (!claimed) {
-    return null;
-  }
-  return claimed;
+  return {
+    target: replacementTargetFromQueueHead(head),
+    replacement: {
+      chatThreadId: args.threadId,
+      eventType: "input.prompt",
+      userMessage: head.userMessage,
+      runId: args.runId,
+      attachFiles: head.attachFiles ? [...head.attachFiles] : null,
+      attachFileMetadata: head.attachFileMetadata
+        ? [...head.attachFileMetadata]
+        : null,
+      generationTemplate: head.generationTemplate,
+      ...(head.triggerSource ? { triggerSource: head.triggerSource } : {}),
+    },
+  };
 }
 
-type GoalQueueFirstRunAssociation = Extract<
-  QueueFirstRunAssociation,
-  { readonly kind: "goal_event" }
-> & { readonly runId: string };
-type WorkflowQueueFirstRunAssociation = Extract<
-  QueueFirstRunAssociation,
-  { readonly kind: "workflow_event" }
-> & { readonly runId: string };
-
-async function claimGoalQueueFirstRunAssociation(
+async function resolveWorkflowQueueFirstClaimSnapshot(
   db: DbTransaction,
-  args: GoalQueueFirstRunAssociation,
-): Promise<QueueFirstRunClaimResult> {
-  const pending = await listPendingChatQueueEvents(db, args.threadId);
-  const goalMatches = await goalQueueEventMatchesActiveGoal(db, {
-    chatThreadId: args.threadId,
-    goalId: args.goalId,
-    eventId: args.eventId,
-    orgId: args.orgId,
-    userId: args.userId,
-  });
-  const head = pending[0];
-  if (
-    head?.eventType !== "input.goal" ||
-    head.id !== args.eventId ||
-    !goalMatches
-  ) {
-    return { kind: "lost" };
-  }
-
-  const [goalEvent] = await db
+  args: Extract<QueueFirstClaimArgs, { readonly kind: "workflow_event" }>,
+): Promise<QueueFirstClaimSnapshot | null> {
+  const [head] = await db
     .select({
-      userMessage: chatEvents.userMessage,
-      goalBrief: chatGoalContext.objectiveBrief,
-    })
-    .from(chatEvents)
-    .leftJoin(
-      chatGoalContext,
-      and(
-        eq(chatEvents.contextType, "goal"),
-        eq(chatGoalContext.id, chatEvents.contextId),
-      ),
-    )
-    .where(eq(chatEvents.id, args.eventId))
-    .limit(1);
-  const userMessage =
-    goalEvent?.userMessage ??
-    (goalEvent?.goalBrief
-      ? createUserMessageDocument({
-          text: null,
-          nonContentPart: {
-            type: "goal",
-            goalBrief: goalEvent.goalBrief,
-          },
-        })
-      : null);
-  if (!userMessage) {
-    throw new Error("Goal queue event is missing its user message");
-  }
-  const claimed = await replaceChatEvent(db, args.eventId, {
-    chatThreadId: args.threadId,
-    eventType: "input.prompt",
-    userMessage,
-    runId: args.runId,
-    runGroupId: args.goalId,
-    triggerSource: "workflow-event",
-  });
-  if (!claimed) {
-    throw new Error("Claimed goal queue event disappeared");
-  }
-  return { kind: "claimed", createdAt: claimed.createdAt };
-}
-
-async function claimWorkflowQueueFirstRunAssociation(
-  db: DbTransaction,
-  args: WorkflowQueueFirstRunAssociation,
-): Promise<QueueFirstRunClaimResult> {
-  if (await hasUnclaimedQueuedUserMessage(db, args.threadId)) {
-    return { kind: "lost" };
-  }
-
-  const pending = await listPendingChatQueueEvents(db, args.threadId);
-  const head = pending[0];
-  const [automationEvent] = await db
-    .select({
+      ...queueFirstReplacementTargetFields,
       automationId: chatAutomationContext.automationId,
       triggerSource: chatEvents.triggerSource,
       triggerBrief: chatAutomationContext.triggerBrief,
@@ -498,6 +456,10 @@ async function claimWorkflowQueueFirstRunAssociation(
       workflowName: zeroWorkflows.name,
     })
     .from(chatEvents)
+    .leftJoin(
+      chatEventInputParams,
+      eq(chatEventInputParams.eventId, chatEvents.id),
+    )
     .leftJoin(
       chatAutomationContext,
       and(
@@ -513,50 +475,157 @@ async function claimWorkflowQueueFirstRunAssociation(
       zeroWorkflows,
       eq(zeroWorkflows.id, zeroWorkflowAutomations.workflowId),
     )
-    .where(eq(chatEvents.id, args.eventId))
+    .where(
+      and(
+        eq(chatEvents.chatThreadId, args.threadId),
+        pendingChatQueueEventCondition(db),
+      ),
+    )
+    .orderBy(
+      queueFirstHeadPriority(),
+      asc(chatEvents.createdAt),
+      asc(chatEvents.id),
+    )
+    .for("update", { of: chatEvents })
     .limit(1);
   if (
-    head?.eventType !== "input.automation" ||
+    !head ||
+    head.eventType !== "input.automation" ||
     head.id !== args.eventId ||
-    automationEvent?.automationId !== args.runGroupId
+    head.automationId !== args.runGroupId
   ) {
-    return { kind: "lost" };
+    return null;
   }
-
   const userMessage =
-    automationEvent.userMessage ??
-    (automationEvent.workflowName === null
+    head.userMessage ??
+    (head.workflowName === null
       ? null
       : createUserMessageDocument({
           text: null,
           nonContentPart: {
             type: "automation",
-            workflowName: automationEvent.workflowName,
-            ...(automationEvent.workflowId === null
+            workflowName: head.workflowName,
+            ...(head.workflowId === null
               ? {}
-              : { workflowId: automationEvent.workflowId }),
-            ...(automationEvent.triggerBrief === null
+              : { workflowId: head.workflowId }),
+            ...(head.triggerBrief === null
               ? {}
-              : { automationBrief: automationEvent.triggerBrief }),
+              : { automationBrief: head.triggerBrief }),
           },
         }));
   if (!userMessage) {
     throw new Error("Workflow queue event is missing its user message");
   }
-  const claimed = await replaceChatEvent(db, args.eventId, {
-    chatThreadId: args.threadId,
-    eventType: "input.prompt",
-    userMessage,
-    runId: args.runId,
-    runGroupId: args.runGroupId,
-    ...(automationEvent.triggerSource
-      ? { triggerSource: automationEvent.triggerSource }
-      : {}),
-  });
-  if (!claimed) {
-    throw new Error("Claimed workflow queue event disappeared");
+  return {
+    target: replacementTargetFromQueueHead(head),
+    replacement: {
+      chatThreadId: args.threadId,
+      eventType: "input.prompt",
+      userMessage,
+      runId: args.runId,
+      runGroupId: args.runGroupId,
+      ...(head.triggerSource ? { triggerSource: head.triggerSource } : {}),
+    },
+  };
+}
+
+async function resolveGoalQueueFirstClaimSnapshot(
+  db: DbTransaction,
+  args: Extract<QueueFirstClaimArgs, { readonly kind: "goal_event" }>,
+): Promise<QueueFirstClaimSnapshot | null> {
+  const [head] = await db
+    .select({
+      ...queueFirstReplacementTargetFields,
+      goalId: threadGoals.id,
+      goalStatus: threadGoals.status,
+      goalSnapshotCurrent:
+        noGoalChangeAfterQueueEvent(db).mapWith(pgBooleanDecoder),
+      userMessage: chatEvents.userMessage,
+      goalBrief: chatGoalContext.objectiveBrief,
+    })
+    .from(chatEvents)
+    .leftJoin(
+      chatEventInputParams,
+      eq(chatEventInputParams.eventId, chatEvents.id),
+    )
+    .leftJoin(
+      threadGoals,
+      and(
+        eq(threadGoals.id, args.goalId),
+        eq(threadGoals.chatThreadId, chatEvents.chatThreadId),
+        eq(threadGoals.orgId, args.orgId),
+        eq(threadGoals.ownerUserId, args.userId),
+        eq(chatEvents.runGroupId, threadGoals.id),
+      ),
+    )
+    .leftJoin(
+      chatGoalContext,
+      and(
+        eq(chatEvents.contextType, "goal"),
+        eq(chatGoalContext.id, chatEvents.contextId),
+      ),
+    )
+    .where(
+      and(
+        eq(chatEvents.chatThreadId, args.threadId),
+        pendingChatQueueEventCondition(db),
+      ),
+    )
+    .orderBy(
+      queueFirstHeadPriority(),
+      asc(chatEvents.createdAt),
+      asc(chatEvents.id),
+    )
+    .for("update", { of: chatEvents })
+    .limit(1);
+  if (
+    !head ||
+    head.eventType !== "input.goal" ||
+    head.id !== args.eventId ||
+    head.goalId !== args.goalId ||
+    head.goalStatus !== "active" ||
+    !head.goalSnapshotCurrent
+  ) {
+    return null;
   }
-  return { kind: "claimed", createdAt: claimed.createdAt };
+  const userMessage =
+    head.userMessage ??
+    (head.goalBrief
+      ? createUserMessageDocument({
+          text: null,
+          nonContentPart: {
+            type: "goal",
+            goalBrief: head.goalBrief,
+          },
+        })
+      : null);
+  if (!userMessage) {
+    throw new Error("Goal queue event is missing its user message");
+  }
+  return {
+    target: replacementTargetFromQueueHead(head),
+    replacement: {
+      chatThreadId: args.threadId,
+      eventType: "input.prompt",
+      userMessage,
+      runId: args.runId,
+      runGroupId: args.goalId,
+      triggerSource: "workflow-event",
+    },
+  };
+}
+
+async function resolveQueueFirstClaimSnapshot(
+  db: DbTransaction,
+  args: QueueFirstClaimArgs,
+): Promise<QueueFirstClaimSnapshot | null> {
+  if (args.kind === "user_message") {
+    return await resolveUserQueueFirstClaimSnapshot(db, args);
+  }
+  if (args.kind === "workflow_event") {
+    return await resolveWorkflowQueueFirstClaimSnapshot(db, args);
+  }
+  return await resolveGoalQueueFirstClaimSnapshot(db, args);
 }
 
 function queueFirstRunAdmissionBlocked(
@@ -622,13 +691,12 @@ export async function resolveQueueFirstRunAdmission(
 
 export async function claimQueueFirstRunAssociation(
   db: DbTransaction,
-  args: QueueFirstRunAssociation & {
-    readonly admission: QueueFirstRunAdmission;
-    readonly runId: string;
-    readonly timing: ApiDispatchTimingCollector;
-  },
+  args: QueueFirstClaimArgs,
 ): Promise<QueueFirstRunClaimResult> {
   let outcome: "claimed" | "lost" | "error" = "error";
+  const claimDimensions = {
+    queue_first_association_kind: args.kind,
+  };
   return await args.timing.measure(
     "api_dispatch_claim_queue_first_message",
     "nested",
@@ -638,28 +706,21 @@ export async function claimQueueFirstRunAssociation(
         return { kind: "lost" };
       }
 
-      if (args.kind === "goal_event") {
-        const claim = await claimGoalQueueFirstRunAssociation(db, args);
-        outcome = claim.kind;
-        return claim;
-      }
-
-      if (args.kind === "workflow_event") {
-        const claim = await claimWorkflowQueueFirstRunAssociation(db, args);
-        outcome = claim.kind;
-        return claim;
-      }
-
-      const headEventId = await loadNextUnclaimedQueuedUserMessageId(
-        db,
-        args.threadId,
+      const snapshot = await args.timing.measure(
+        "api_dispatch_resolve_queue_first_claim_snapshot",
+        "nested",
+        async () => {
+          return await resolveQueueFirstClaimSnapshot(db, args);
+        },
+        claimDimensions,
       );
-      if (headEventId !== args.eventId) {
+      if (!snapshot) {
         outcome = "lost";
         return { kind: "lost" };
       }
 
       if (
+        args.kind === "user_message" &&
         !(await lockUnclaimedMorningBriefDelivery(
           db,
           args.morningBriefDeliveryId,
@@ -669,12 +730,22 @@ export async function claimQueueFirstRunAssociation(
         return { kind: "lost" };
       }
 
-      const claimed = await appendClaimedUserMessage(db, {
-        threadId: args.threadId,
-        eventId: args.eventId,
-        runId: args.runId,
-      });
+      const claimed = await args.timing.measure(
+        "api_dispatch_persist_queue_first_replacement",
+        "nested",
+        async () => {
+          return await replaceLoadedChatEvent(
+            db,
+            snapshot.target,
+            snapshot.replacement,
+          );
+        },
+        claimDimensions,
+      );
       if (!claimed) {
+        if (args.kind !== "user_message") {
+          throw new Error(`Claimed ${args.kind} queue event disappeared`);
+        }
         outcome = "lost";
         return { kind: "lost" };
       }
@@ -683,7 +754,7 @@ export async function claimQueueFirstRunAssociation(
       return {
         kind: "claimed",
         createdAt: claimed.createdAt,
-        ...(args.morningBriefDeliveryId
+        ...(args.kind === "user_message" && args.morningBriefDeliveryId
           ? { morningBriefDeliveryId: args.morningBriefDeliveryId }
           : {}),
       };


### PR DESCRIPTION
## Summary

- resolve and lock the authoritative queue head with one priority-ordered snapshot query for user, workflow, and goal associations
- reuse the loaded target when appending the immutable replacement instead of reloading the same event through the generic writer
- copy attachment asset references with `INSERT ... SELECT` and add fixed, low-cardinality timings for snapshot resolution and replacement persistence

## Scope

- API-only internal performance change
- preserves queue priority, revoke-edge claims, Morning Brief delivery locking, goal/workflow eligibility, event sequencing, and post-commit notification ordering
- no schema, migration, public API, queue representation, frontend, runner/guest protocol, feature switch, or coordinated deployment change

## Validation

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api build`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts --maxWorkers=1 --silent=passed-only` (61 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts --maxWorkers=1 --silent=passed-only` (20 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts --maxWorkers=1 --silent=passed-only` (43 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts --maxWorkers=1 --silent=passed-only` (13 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-goals.test.ts --maxWorkers=1 --silent=passed-only` (14 tests)
- pre-commit hook: repository Prettier, Knip, and check-types

Closes #24299

Parent objective: #24203
