### PR TITLE
test(sandbox-fc): stabilize firewall restore payload checks

### DIFF
--- a/crates/sandbox-fc/src/network/pool/firewall.rs
+++ b/crates/sandbox-fc/src/network/pool/firewall.rs
@@ -634,6 +634,28 @@ async fn run_firewall_restore(
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    fn restore_capture_command(dir: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let command = dir.join("verify-restore");
+        let payload = dir.join("payload");
+        std::fs::write(
+            &command,
+            r#"#!/bin/sh
+[ "$1" = "--wait" ] || exit 2
+[ "$2" = "--noflush" ] || exit 3
+PAYLOAD="${0%/*}/payload"
+while IFS= read -r LINE; do
+    printf '%s\n' "$LINE"
+done < "$3" > "$PAYLOAD"
+"#,
+        )
+        .unwrap();
+        std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
+        (command, payload)
+    }
+
     #[tokio::test]
     async fn xtables_status_prepends_bare_wait() {
         exec_xtables_status_with_timeout(
@@ -648,26 +670,8 @@ mod tests {
     #[tokio::test]
     #[cfg(unix)]
     async fn firewall_restore_applies_insert_and_append_rules_in_one_waiting_mutation() {
-        use std::os::unix::fs::PermissionsExt;
-
         let dir = tempfile::tempdir().unwrap();
-        let command = dir.path().join("verify-restore");
-        std::fs::write(
-            &command,
-            r#"#!/bin/sh
-[ "$1" = "--wait" ] || exit 2
-[ "$2" = "--noflush" ] || exit 3
-EXPECTED='*raw
--I PREROUTING 1 -m comment --comment vm0-ns-00-00 -j DROP
-COMMIT
-*filter
--A FORWARD -m comment --comment vm0-ns-00-00 -j ACCEPT
-COMMIT'
-[ "$(cat "$3")" = "$EXPECTED" ] || exit 4
-"#,
-        )
-        .unwrap();
-        std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let (command, payload) = restore_capture_command(dir.path());
 
         apply_firewall_rules_with_restore(
             command.to_str().unwrap(),
@@ -684,6 +688,11 @@ COMMIT'
         )
         .await
         .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(payload).unwrap(),
+            "*raw\n-I PREROUTING 1 -m comment --comment vm0-ns-00-00 -j DROP\nCOMMIT\n*filter\n-A FORWARD -m comment --comment vm0-ns-00-00 -j ACCEPT\nCOMMIT\n"
+        );
     }
 
     #[test]
@@ -718,26 +727,8 @@ COMMIT'
     #[tokio::test]
     #[cfg(unix)]
     async fn firewall_restore_batches_tables_in_one_waiting_mutation() {
-        use std::os::unix::fs::PermissionsExt;
-
         let dir = tempfile::tempdir().unwrap();
-        let command = dir.path().join("verify-restore");
-        std::fs::write(
-            &command,
-            r#"#!/bin/sh
-[ "$1" = "--wait" ] || exit 2
-[ "$2" = "--noflush" ] || exit 3
-EXPECTED='*raw
--D PREROUTING -m comment --comment vm0-ns-00-00 -j DROP
-COMMIT
-*filter
--D FORWARD -m comment --comment vm0-ns-00-00 -j ACCEPT
-COMMIT'
-[ "$(cat "$3")" = "$EXPECTED" ] || exit 4
-"#,
-        )
-        .unwrap();
-        std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let (command, payload) = restore_capture_command(dir.path());
 
         let outcome = delete_firewall_rules_with_restore(
             command.to_str().unwrap(),
@@ -759,6 +750,10 @@ COMMIT'
         .await;
 
         assert_eq!(outcome, NamespaceDeleteOutcome::Deleted);
+        assert_eq!(
+            std::fs::read_to_string(payload).unwrap(),
+            "*raw\n-D PREROUTING -m comment --comment vm0-ns-00-00 -j DROP\nCOMMIT\n*filter\n-D FORWARD -m comment --comment vm0-ns-00-00 -j ACCEPT\nCOMMIT\n"
+        );
     }
 
     #[tokio::test]
@@ -778,28 +773,8 @@ COMMIT'
     #[tokio::test]
     #[cfg(unix)]
     async fn incomplete_snapshot_deletes_captured_rules_and_remains_abandoned() {
-        use std::os::unix::fs::PermissionsExt;
-
         let dir = tempfile::tempdir().unwrap();
-        let command = dir.path().join("verify-restore");
-        let called = dir.path().join("called");
-        std::fs::write(
-            &command,
-            format!(
-                r#"#!/bin/sh
-[ "$1" = "--wait" ] || exit 2
-[ "$2" = "--noflush" ] || exit 3
-EXPECTED='*raw
--D PREROUTING -m comment --comment vm0-ns-00-00 -j DROP
-COMMIT'
-[ "$(cat "$3")" = "$EXPECTED" ] || exit 4
-touch "{}"
-"#,
-                called.display()
-            ),
-        )
-        .unwrap();
-        std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let (command, payload) = restore_capture_command(dir.path());
 
         let captured = FirewallTableSnapshot {
             table: "raw",
@@ -816,7 +791,10 @@ touch "{}"
 
         let outcome = delete_firewall_restore_selection(command.to_str().unwrap(), selection).await;
 
-        assert!(called.exists());
         assert_eq!(outcome, NamespaceDeleteOutcome::Abandoned);
+        assert_eq!(
+            std::fs::read_to_string(payload).unwrap(),
+            "*raw\n-D PREROUTING -m comment --comment vm0-ns-00-00 -j DROP\nCOMMIT\n"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- replace the firewall restore test scripts’ `cat` and `touch` subprocesses with one shell-builtin payload capture fixture
- compare the captured restore payloads in Rust so mismatches retain exact diagnostics
- leave production firewall capture and cleanup behavior unchanged

## Root cause

The incomplete-snapshot test used `cat` in command substitution and `touch` as a sentinel. If either helper command was unavailable or could not be spawned under CI process pressure, the fake restore script exited before creating the sentinel. The aggregate cleanup outcome still correctly remained `Abandoned`, so the test surfaced only as a missing marker.

The old fixture reproduces deterministically when the test binary runs without those helpers in `PATH`; the updated fixture passes because it uses shell builtins only.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox-fc --all-features --no-deps`
- `cargo test -p sandbox-fc --all-targets --all-features` (793 passed)
- affected test with `PATH=/nonexistent` (passed)
- affected test repeated 200 times with `PATH=/nonexistent` (passed)