### PR TITLE
refactor(platform): drop the legacy cache cleanup from the service worker

### DIFF
--- a/turbo/apps/platform/public/sw.js
+++ b/turbo/apps/platform/public/sw.js
@@ -1,4 +1,3 @@
-const LEGACY_CACHE_PREFIX = "static-";
 const OKOU_ROOT_DOMAINS = ["okou.ai", "omby.ai", "okou-app.pages.dev"];
 
 function defaultNotificationTitle() {
@@ -11,23 +10,6 @@ function defaultNotificationTitle() {
 
 self.addEventListener("install", (_event) => {
   self.skipWaiting();
-});
-
-// Activate: drop the Cache Storage entries written by earlier versions of this
-// worker. There is no `fetch` handler anymore, so requests go straight to the
-// network and the browser HTTP cache; nothing reads those caches.
-self.addEventListener("activate", (event) => {
-  event.waitUntil(
-    (async () => {
-      const keys = await caches.keys();
-      await Promise.all(
-        keys
-          .filter((key) => key.startsWith(LEGACY_CACHE_PREFIX))
-          .map((key) => caches.delete(key)),
-      );
-      await self.clients.claim();
-    })(),
-  );
 });
 
 // --- Web Push Notifications ---


### PR DESCRIPTION
## Summary

Follow-up cleanup to #24350. The service worker no longer has a `fetch` handler, so its `activate` handler was doing two things that no longer matter:

- purging `static-*` Cache Storage entries written by earlier worker versions — nothing reads Cache Storage anymore;
- `clients.claim()` — control is irrelevant without a `fetch` handler. `notificationclick` already uses `clients.matchAll({ includeUncontrolled: true })`, and nothing under `turbo/apps/platform/src` reads `navigator.serviceWorker.controller`.

`sw.js` is now `install` (skipWaiting) + `push` + `notificationclick`, 61 lines.

## Trade-off

#24350 has not been released yet, so the `static-*` purge never ran for any user. Dropping it now means installs that still hold the old caching worker keep their orphaned `static-*` entries indefinitely. They are never read, and the browser evicts them under storage pressure, but they are not actively reclaimed.

If we would rather reclaim that space, the alternative is to keep the purge for one production release and delete it afterwards.

## Changes

- Delete the `activate` listener and the `LEGACY_CACHE_PREFIX` constant.
- `install`, `push`, and `notificationclick` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
