### PR TITLE
refactor: derive queued launch metadata at claim

### DIFF
--- a/e2e/helpers/codex-zero.bash
+++ b/e2e/helpers/codex-zero.bash
@@ -210,11 +210,10 @@ send_chat_run_message() {
     local selected_model="$3"
     local payload body client_event_id
     client_event_id=$(cat /proc/sys/kernel/random/uuid)
-    # realAgentInPreview=true bypasses USE_MOCK_CODEX in the runner so the real
-    # codex CLI executes against $OPENAI_API_KEY. Without it, CI's
-    # USE_MOCK_CODEX=true env var causes guest-mock-codex to echo the prompt
-    # verbatim — see crates/runner/src/executor.rs (insert_codex_env) and
-    # guest_mock_codex::build_events.
+    # The caller enables the claim-time RealAgentInPreview switch around this
+    # request so the real codex CLI executes against $OPENAI_API_KEY. Keep the
+    # request field to mirror the current web API contract; it is no longer the
+    # source of the claimed run setting.
     payload=$(jq -nc \
         --arg agentId "$agent_id" \
         --arg prompt "$prompt" \

--- a/e2e/helpers/setup.bash
+++ b/e2e/helpers/setup.bash
@@ -124,6 +124,28 @@ require_e2e_api_credentials() {
     e2e_api_token >/dev/null && e2e_api_url >/dev/null
 }
 
+set_real_agent_in_preview() {
+    local enabled="$1"
+    e2e_api_curl "/api/zero/feature-switches" \
+        -X POST \
+        -d "{\"switches\":{\"realAgentInPreview\":${enabled}}}" \
+        >/dev/null
+}
+
+# The chat create call claims an idle thread synchronously, so the switch only
+# needs to be enabled around that request. Restore it immediately to avoid
+# changing unrelated preview runs that share the E2E identity.
+with_real_agent_preview_claim() {
+    local previous
+    previous=$(e2e_api_curl "/api/zero/feature-switches" | jq -er '.effectiveSwitches.realAgentInPreview | select(type == "boolean") | tostring') || return 1
+    set_real_agent_in_preview true || return 1
+    local command_status=0
+    local reset_status=0
+    "$@" || command_status=$?
+    set_real_agent_in_preview "$previous" || reset_status=$?
+    [[ "$command_status" -eq 0 && "$reset_status" -eq 0 ]]
+}
+
 e2e_api_curl() {
     local path="$1"; shift
     local token base

--- a/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
+++ b/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
@@ -98,7 +98,7 @@ teardown_file() {
     # `export` from the helper would not propagate back to this scope, and
     # LAST_THREAD_ID / LAST_RUN_ID would arrive empty. The helper returns
     # non-zero on failure, which fails the test naturally.
-    send_chat_run_message "$AGENT_ID" \
+    with_real_agent_preview_claim send_chat_run_message "$AGENT_ID" \
         "Compute 123+456 and reply with exactly: RESULT=<answer>" \
         "gpt-5.5"
 
@@ -121,7 +121,7 @@ teardown_file() {
 }
 
 @test "t-codex-zero-byok-smoke-2: gpt-5.6-luna via zero web layer" {
-    send_chat_run_message "$AGENT_ID" \
+    with_real_agent_preview_claim send_chat_run_message "$AGENT_ID" \
         "Compute 234+567 and reply with exactly: LUNA_RESULT=<answer>" \
         "gpt-5.6-luna"
 

--- a/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
+++ b/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
@@ -17,6 +17,19 @@ setup_file() {
         skip "ANTHROPIC_API_KEY not set — required for real Claude calls"
     fi
 
+    local serial_credentials="/tmp/e2e-api-credentials-serial.json"
+    E2E_API_TOKEN=$(jq -er '.token | select(type == "string" and length > 0)' "$serial_credentials")
+    E2E_API_URL=$(jq -er '.apiUrl | select(type == "string" and length > 0)' "$serial_credentials")
+    export E2E_API_TOKEN E2E_API_URL
+
+    # This file uses the isolated serial identity so its claim-time preview
+    # switch cannot race other runner chunks. Mirror the runner bootstrap's
+    # model-first defaults for that otherwise uninitialized workspace.
+    e2e_api_curl "/api/zero/model-policies" \
+        -X PUT \
+        -d '{"policies":[{"model":"claude-opus-4-7","isDefault":false,"defaultProviderType":"vm0","credentialScope":"org","modelProviderId":null},{"model":"claude-sonnet-4-6","isDefault":true,"defaultProviderType":"vm0","credentialScope":"org","modelProviderId":null},{"model":"deepseek-v4-pro","isDefault":false,"defaultProviderType":"vm0","credentialScope":"org","modelProviderId":null},{"model":"gpt-5.5","isDefault":false,"defaultProviderType":"vm0","credentialScope":"org","modelProviderId":null}]}' \
+        >/dev/null
+
     export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
     export TEST_DIR="$(mktemp -d)"
     export RUN_AGENT_NAME="e2e-billable-runner-${UNIQUE_ID}"
@@ -85,7 +98,7 @@ teardown_file() {
 }
 
 @test "t54-1: vm0 meta-provider — firewall billable" {
-    zero_chat_run_with_model \
+    with_real_agent_preview_claim zero_chat_run_with_model \
         "$AGENT_ID" \
         "Reply with exactly: DONE" \
         "claude-sonnet-4-6" \

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1134,7 +1134,7 @@ describe("CHAT-02: completed chat callback", () => {
       clearMockNow();
     });
 
-    await queueChatEvent(actor, {
+    const queuedEventId = await queueChatEvent(actor, {
       agentId,
       threadId: first.threadId,
       prompt: queuedPrompt,
@@ -1169,10 +1169,17 @@ describe("CHAT-02: completed chat callback", () => {
     if (!claimed?.runId) {
       throw new Error("Expected the queued Web message to auto-send");
     }
+    const queuedMessage = userMessages(afterAutoSend.events).find((message) => {
+      return message.id === queuedEventId;
+    });
+    if (!queuedMessage) {
+      throw new Error("Expected the original queued Web message");
+    }
+    const apiStartedAt = Date.parse(queuedMessage.createdAt);
 
     const acknowledgedAt = dequeuedAt + 7000;
     const secondClaim = await claimChatRunJob(runnerGroup, claimed.runId);
-    expect(secondClaim.apiStartTime).toBe(queuedAt);
+    expect(secondClaim.apiStartTime).toBe(apiStartedAt);
     const secondHeaders = {
       authorization: `Bearer ${secondClaim.sandboxToken}`,
     };
@@ -1201,7 +1208,7 @@ describe("CHAT-02: completed chat callback", () => {
     expect(firstAssistantEventsForRun(claimed.runId)).toStrictEqual([
       expect.objectContaining({
         _time: new Date(acknowledgedAt).toISOString(),
-        duration_ms: acknowledgedAt - dequeuedAt,
+        duration_ms: acknowledgedAt - apiStartedAt,
         run_id: claimed.runId,
       }),
     ]);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1117,7 +1117,7 @@ describe("CHAT-02: completed chat callback", () => {
     await waitForRunStatus(actor, claimed.runId, "cancelled");
   }, 90_000);
 
-  it("uses the dequeue API start when a queued message auto-sends", async () => {
+  it("uses the queued event creation time when a message auto-sends", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
@@ -1172,7 +1172,7 @@ describe("CHAT-02: completed chat callback", () => {
 
     const acknowledgedAt = dequeuedAt + 7000;
     const secondClaim = await claimChatRunJob(runnerGroup, claimed.runId);
-    expect(secondClaim.apiStartTime).toBe(dequeuedAt);
+    expect(secondClaim.apiStartTime).toBe(queuedAt);
     const secondHeaders = {
       authorization: `Bearer ${secondClaim.sandboxToken}`,
     };

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -5592,8 +5592,10 @@ describe("CHAT-02: queued attachments on auto-send", () => {
     const fileId = randomUUID();
     const secondFileId = randomUUID();
     const queuedId = randomUUID();
-    chat.mockCompletedUploadObject(actor, fileId, "notes.txt", 12);
-    chat.mockCompletedUploadObject(actor, secondFileId, "details.json", 24);
+    chat.mockCompletedUploadObjects(actor, [
+      { id: fileId, filename: "notes.txt", size: 12 },
+      { id: secondFileId, filename: "details.json", size: 24 },
+    ]);
     const queued = await chat.requestSendEvent(
       actor,
       {
@@ -6308,7 +6310,7 @@ describe("CHAT-02: shared user message queue", () => {
     ).resolves.toBeNull();
     await expect(
       readChatEventInputParamsFixture(claimedMessage.id),
-    ).resolves.toMatchObject({ attachFileMetadata: null });
+    ).resolves.toBeNull();
     await cancelChatRun(actor, runId, claim.sandboxHeaders);
   }, 90_000);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -88,6 +88,7 @@ import {
   replayPendingChatInputQueueEventFixture,
   replaceBddVm0ApiKeys,
   replaceThreadSessionBindingFixture,
+  writeLegacyQueuedUserMessageParamsFixture,
 } from "../../../test-fixtures/chat-events";
 
 /**
@@ -4758,6 +4759,7 @@ describe("CHAT-02: generation templates and attachments", () => {
         },
       ],
     };
+    chat.mockCompletedUploadObject(actor, fileId, "brief.pdf", 42);
 
     const sent = await sendChatRun(actor, {
       agentId,
@@ -4920,6 +4922,7 @@ describe("CHAT-02: generation templates and attachments", () => {
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
     const fileId = randomUUID();
+    chat.mockCompletedUploadObject(actor, fileId, "api-input.txt", 12);
     const sent = await sendChatRun(actor, {
       agentId,
       prompt: "plain API attachment",
@@ -5442,6 +5445,7 @@ describe("CHAT-02: generation templates and attachments", () => {
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const fileId = randomUUID();
     const filename = "diagram final 100%.png";
+    chat.mockCompletedUploadObject(actor, fileId, filename, 42);
 
     const run = await sendChatRun(actor, {
       agentId,
@@ -5517,6 +5521,7 @@ describe("CHAT-02: queued attachments on auto-send", () => {
         },
       ],
     };
+    chat.mockCompletedUploadObject(actor, fileId, "ordered.txt", 12);
     const queued = await chat.requestSendEvent(
       actor,
       {
@@ -5587,6 +5592,8 @@ describe("CHAT-02: queued attachments on auto-send", () => {
     const fileId = randomUUID();
     const secondFileId = randomUUID();
     const queuedId = randomUUID();
+    chat.mockCompletedUploadObject(actor, fileId, "notes.txt", 12);
+    chat.mockCompletedUploadObject(actor, secondFileId, "details.json", 24);
     const queued = await chat.requestSendEvent(
       actor,
       {
@@ -5613,24 +5620,7 @@ describe("CHAT-02: queued attachments on auto-send", () => {
       [201],
     );
     expect(queued.body).toMatchObject({ runId: null });
-    await expect(
-      readChatEventInputParamsFixture(queuedId),
-    ).resolves.toMatchObject({
-      eventId: queuedId,
-      encryptedParams: expect.any(String),
-      attachFileMetadata: [
-        expect.objectContaining({
-          id: fileId,
-          filename: "notes.txt",
-          contentType: "text/plain",
-        }),
-        expect.objectContaining({
-          id: secondFileId,
-          filename: "details.json",
-          contentType: "application/json",
-        }),
-      ],
-    });
+    await expect(readChatEventInputParamsFixture(queuedId)).resolves.toBeNull();
     // Completing the anchor run promotes the queued message into a fresh
     // run whose prompt carries the resolved attachment references.
     chatCallbacks.mockChatOutputEvents([]);
@@ -6084,9 +6074,16 @@ describe("CHAT-02: shared user message queue", () => {
     await cancelChatRun(actor, runId);
   }, 90_000);
 
-  it("preserves real-agent preview mode across queued auto-sends", async () => {
+  it("derives real-agent preview mode when queued messages are claimed", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor");
+    }
+    const actorWithOrg = { ...actor, orgId: actor.orgId };
+    await updateFeatureSwitchesForUser(context, actorWithOrg, {
+      [FeatureSwitchKey.RealAgentInPreview]: false,
+    });
 
     const anchor = await sendChatRun(actor, {
       agentId,
@@ -6096,6 +6093,12 @@ describe("CHAT-02: shared user message queue", () => {
 
     const previewMessageId = randomUUID();
     const previewFileId = randomUUID();
+    chat.mockCompletedUploadObject(
+      actor,
+      previewFileId,
+      "preview-notes.txt",
+      18,
+    );
     const previewQueued = await chat.requestSendEvent(
       actor,
       {
@@ -6116,22 +6119,9 @@ describe("CHAT-02: shared user message queue", () => {
       [201],
     );
     expect(previewQueued.body).toMatchObject({ runId: null });
-    const previewParams =
-      await readChatEventInputParamsFixture(previewMessageId);
-    expect(previewParams).toMatchObject({
-      eventId: previewMessageId,
-      encryptedParams: expect.any(String),
-      attachFileMetadata: [
-        expect.objectContaining({
-          id: previewFileId,
-          filename: "preview-notes.txt",
-          contentType: "text/plain",
-        }),
-      ],
-    });
-    if (!previewParams) {
-      throw new Error("Expected the original preview queue params");
-    }
+    await expect(
+      readChatEventInputParamsFixture(previewMessageId),
+    ).resolves.toBeNull();
 
     const replayedPreviewMessageId = randomUUID();
     await replayPendingChatInputQueueEventFixture({
@@ -6143,10 +6133,7 @@ describe("CHAT-02: shared user message queue", () => {
     ).resolves.toBeNull();
     await expect(
       readChatEventInputParamsFixture(replayedPreviewMessageId),
-    ).resolves.toStrictEqual({
-      ...previewParams,
-      eventId: replayedPreviewMessageId,
-    });
+    ).resolves.toBeNull();
     const mockMessageId = randomUUID();
     const mockQueued = await chat.requestSendEvent(
       actor,
@@ -6155,6 +6142,7 @@ describe("CHAT-02: shared user message queue", () => {
         threadId: anchor.threadId,
         prompt: "queued preview mock run",
         clientEventId: mockMessageId,
+        realAgentInPreview: true,
       },
       [201],
     );
@@ -6162,6 +6150,10 @@ describe("CHAT-02: shared user message queue", () => {
     await expect(
       readChatEventInputParamsFixture(mockMessageId),
     ).resolves.toBeNull();
+
+    await updateFeatureSwitchesForUser(context, actorWithOrg, {
+      [FeatureSwitchKey.RealAgentInPreview]: true,
+    });
 
     // Terminal callbacks and the cleanup safety sweep use the same queued
     // auto-send builder; finishing the anchor guarantees that builder owns both.
@@ -6197,6 +6189,9 @@ describe("CHAT-02: shared user message queue", () => {
     await expect(
       readChatEventInputParamsFixture(replayedPreviewMessageId),
     ).resolves.toBeNull();
+    await updateFeatureSwitchesForUser(context, actorWithOrg, {
+      [FeatureSwitchKey.RealAgentInPreview]: false,
+    });
     await cancelChatRun(actor, previewRunId, previewClaim.sandboxHeaders);
 
     const mockMessages = await waitForThreadMessages(
@@ -6222,6 +6217,99 @@ describe("CHAT-02: shared user message queue", () => {
     expect(mockClaim.claim.prompt).toBe("queued preview mock run");
     expect(mockClaim.claim.realAgentInPreview).toBeUndefined();
     await cancelChatRun(actor, mockRunId);
+  }, 90_000);
+
+  it("falls back to legacy queued launch fields until the backlog drains", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor");
+    }
+    const actorWithOrg = { ...actor, orgId: actor.orgId };
+    await updateFeatureSwitchesForUser(context, actorWithOrg, {
+      [FeatureSwitchKey.RealAgentInPreview]: false,
+    });
+
+    const anchor = await sendChatRun(actor, {
+      agentId,
+      prompt: "legacy fallback queue anchor",
+    });
+    const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
+    const messageId = randomUUID();
+    const fileId = randomUUID();
+    const legacyApiStartTime = now() - 30_000;
+    const prompt = "legacy queued launch material";
+    const queued = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: anchor.threadId,
+        prompt,
+        clientEventId: messageId,
+        attachFiles: [
+          {
+            id: fileId,
+            filename: "legacy.txt",
+            contentType: "text/plain",
+            size: 14,
+          },
+        ],
+      },
+      [201],
+    );
+    expect(queued.body).toMatchObject({ runId: null });
+    await writeLegacyQueuedUserMessageParamsFixture({
+      eventId: messageId,
+      orgId: actor.orgId,
+      userId: actor.userId,
+      prompt,
+      appendSystemPrompt: "",
+      realAgentInPreview: true,
+      apiStartTime: legacyApiStartTime,
+      attachFileMetadata: [
+        {
+          id: fileId,
+          filename: "legacy.txt",
+          contentType: "text/plain",
+          size: 14,
+          objectKey: `artifacts/${actor.userId}/${fileId}/legacy.txt`,
+        },
+      ],
+    });
+
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    const messages = await waitForThreadMessages(
+      actor,
+      anchor.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.revokesEventId === messageId &&
+            typeof message.runId === "string"
+          );
+        });
+      },
+    );
+    const claimedMessage = userMessages(messages.events).find((message) => {
+      return message.revokesEventId === messageId;
+    });
+    const runId = claimedMessage?.runId;
+    if (!claimedMessage || !runId) {
+      throw new Error("Expected the legacy queued message to auto-send");
+    }
+
+    const claim = await claimChatRun(runnerGroup, runId);
+    expect(claim.claim.apiStartTime).toBe(legacyApiStartTime);
+    expect(claim.claim.realAgentInPreview).toBeTruthy();
+    expect(claim.claim.prompt).toContain(`[ID] ${fileId}`);
+    await expect(
+      readChatEventInputParamsFixture(messageId),
+    ).resolves.toBeNull();
+    await expect(
+      readChatEventInputParamsFixture(claimedMessage.id),
+    ).resolves.toMatchObject({ attachFileMetadata: null });
+    await cancelChatRun(actor, runId, claim.sandboxHeaders);
   }, 90_000);
 
   it("appends a claimed queued message after messages that are still queued", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -1643,7 +1643,7 @@ describe("cron execute morning briefs", () => {
       throw new Error("Expected the old-format queue item to drain");
     }
     await expect(readRunApiStart(context, claimed.runId)).resolves.toBe(
-      new Date(AFTER_SEVEN_LOCAL).toISOString(),
+      new Date(BEFORE_SEVEN_LOCAL).toISOString(),
     );
     const runInput = await completeMorningBriefRun(scenario, claimed.runId, 0);
     expect(runInput.prompt).toBe(realPrompt);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -54,6 +54,10 @@ import {
 } from "@vm0/api-contracts/contracts/zero-uploads";
 import { setupAppWithRoutes } from "../../../../__tests__/test-app";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
+import {
+  buildArtifactKey,
+  sanitizeArtifactFilename,
+} from "../../../../lib/file-url";
 import { createAgentComposeFixture } from "../../../../test-fixtures/agent-composes";
 import { zeroChatEventsRoutes } from "../../zero-chat-events";
 import { zeroArtifactCatalogRoutes } from "../../zero-artifact-catalog";
@@ -211,6 +215,29 @@ export function persistedAttachment(
 export function createChatFilesBddApi(context: TestContext) {
   const mocks = createZeroRouteMocks(context);
 
+  function mockCompletedUploadObjects(
+    actor: ApiTestUser,
+    objects: readonly {
+      readonly id: string;
+      readonly filename: string;
+      readonly size: number;
+    }[],
+  ): void {
+    mocks.s3.listObjects(
+      objects.map((object) => {
+        return {
+          bucket: "test-user-artifacts",
+          key: buildArtifactKey(
+            actor.userId,
+            object.id,
+            sanitizeArtifactFilename(object.filename),
+          ),
+          size: object.size,
+        };
+      }),
+    );
+  }
+
   function threadsClient() {
     return chatFilesApp(context)(chatThreadsContract);
   }
@@ -326,14 +353,10 @@ export function createChatFilesBddApi(context: TestContext) {
       filename: string,
       size: number,
     ): void {
-      mocks.s3.listObjects([
-        {
-          bucket: "test-user-artifacts",
-          key: `artifacts/${actor.userId}/${uploadId}/${filename}`,
-          size,
-        },
-      ]);
+      mockCompletedUploadObjects(actor, [{ id: uploadId, filename, size }]);
     },
+
+    mockCompletedUploadObjects,
 
     mockObjectStorageObjectsExist(): void {
       mockObjectStorageObjectsExist(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -10771,6 +10771,7 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
     }
     const apiStartedAt = Date.parse(apiStartedAtIso);
     const acknowledgedAt = apiStartedAt + 4321;
+    mockNow(apiStartedAt);
     await flushWaitUntilForTest();
     expect(
       sandboxOperationEventsForRunByAction(
@@ -10802,8 +10803,6 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
     context.mocks.ably.publish.mockRejectedValueOnce(
       new Error("first chat assistant publish failed"),
     );
-    mockNow(apiStartedAt);
-
     await webhooks.requestAgentEvents(
       {
         runId,
@@ -11091,6 +11090,7 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
     }
     const apiStartedAt = Date.parse(apiStartedAtIso);
     const acknowledgedAt = apiStartedAt + 5000;
+    mockNow(apiStartedAt);
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(runId);
     await flushWaitUntilForTest();
@@ -11211,6 +11211,7 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
     }
     const apiStartedAt = Date.parse(apiStartedAtIso);
     const acknowledgedAt = apiStartedAt + 2468;
+    mockNow(apiStartedAt);
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(runId);
     await flushWaitUntilForTest();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -10755,9 +10755,8 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     failIfChatCallbackRouteIsFetched();
-    const apiStartedAt = Date.parse("2026-07-23T08:00:00.000Z");
-    const acknowledgedAt = apiStartedAt + 4321;
-    mockNow(apiStartedAt);
+    const requestedAt = Date.parse("2026-07-23T08:00:00.000Z");
+    mockNow(requestedAt);
     onTestFinished(() => {
       clearMockNow();
     });
@@ -10766,6 +10765,12 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
       agentId,
       prompt: "bdd assistant events",
     });
+    const apiStartedAtIso = await readRunApiStart(context, runId);
+    if (apiStartedAtIso === null) {
+      throw new Error("Expected chat run to have an API start time");
+    }
+    const apiStartedAt = Date.parse(apiStartedAtIso);
+    const acknowledgedAt = apiStartedAt + 4321;
     await flushWaitUntilForTest();
     expect(
       sandboxOperationEventsForRunByAction(
@@ -10774,7 +10779,7 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
       ),
     ).toStrictEqual([
       {
-        _time: new Date(apiStartedAt).toISOString(),
+        _time: apiStartedAtIso,
         source: "api",
         op_type: "first_assistant_message_eligible",
         sandbox_type: "runner",
@@ -10797,6 +10802,7 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
     context.mocks.ably.publish.mockRejectedValueOnce(
       new Error("first chat assistant publish failed"),
     );
+    mockNow(apiStartedAt);
 
     await webhooks.requestAgentEvents(
       {
@@ -10832,7 +10838,7 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
       ),
     ).toStrictEqual([
       {
-        _time: new Date(apiStartedAt).toISOString(),
+        _time: apiStartedAtIso,
         source: "api",
         op_type: "api_to_first_assistant_message",
         sandbox_type: "runner",
@@ -10889,7 +10895,7 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
       ),
     ).toStrictEqual([
       {
-        _time: new Date(apiStartedAt).toISOString(),
+        _time: apiStartedAtIso,
         source: "api",
         op_type: "api_to_first_assistant_message",
         sandbox_type: "runner",
@@ -11069,9 +11075,8 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     failIfChatCallbackRouteIsFetched();
-    const apiStartedAt = Date.parse("2026-07-23T08:30:00.000Z");
-    const acknowledgedAt = apiStartedAt + 5000;
-    mockNow(apiStartedAt);
+    const requestedAt = Date.parse("2026-07-23T08:30:00.000Z");
+    mockNow(requestedAt);
     onTestFinished(() => {
       clearMockNow();
     });
@@ -11080,6 +11085,12 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
       agentId,
       prompt: "bdd concurrent assistant acknowledgements",
     });
+    const apiStartedAtIso = await readRunApiStart(context, runId);
+    if (apiStartedAtIso === null) {
+      throw new Error("Expected chat run to have an API start time");
+    }
+    const apiStartedAt = Date.parse(apiStartedAtIso);
+    const acknowledgedAt = apiStartedAt + 5000;
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(runId);
     await flushWaitUntilForTest();
@@ -11184,9 +11195,8 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     failIfChatCallbackRouteIsFetched();
-    const apiStartedAt = Date.parse("2026-07-23T09:00:00.000Z");
-    const acknowledgedAt = apiStartedAt + 2468;
-    mockNow(apiStartedAt);
+    const requestedAt = Date.parse("2026-07-23T09:00:00.000Z");
+    mockNow(requestedAt);
     onTestFinished(() => {
       clearMockNow();
     });
@@ -11195,6 +11205,12 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
       agentId,
       prompt: "bdd Codex first assistant output",
     });
+    const apiStartedAtIso = await readRunApiStart(context, runId);
+    if (apiStartedAtIso === null) {
+      throw new Error("Expected chat run to have an API start time");
+    }
+    const apiStartedAt = Date.parse(apiStartedAtIso);
+    const acknowledgedAt = apiStartedAt + 2468;
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(runId);
     await flushWaitUntilForTest();

--- a/turbo/apps/api/src/signals/routes/zero-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-events.ts
@@ -119,9 +119,10 @@ import {
 import { appendQueuedRunAssistantMarker } from "../services/zero-chat-queue-marker.service";
 import {
   discardUnclaimedUserMessage,
-  encryptQueuedUserMessageRunParams,
+  loadNextUnclaimedQueuedUserMessage,
   loadNextUnclaimedQueuedUserMessageId,
   lockUserMessageQueueThread,
+  resolveAttachFileMetadata$,
 } from "../services/zero-chat-queued-event.service";
 import {
   appendChatThreadEvent,
@@ -661,7 +662,7 @@ function attachFileIds(
   return ids && ids.length > 0 ? ids : null;
 }
 
-const resolveAttachFileMetadata$ = command(
+const resolveIncomingAttachFileMetadata$ = command(
   async (
     { set },
     args: {
@@ -1593,7 +1594,6 @@ function appendUnassociatedUserMessage(params: {
   readonly touchThreadSort: boolean;
   readonly userMessage: UserMessageDocument;
   readonly generationTemplate: IncomingGenerationTemplate;
-  readonly encryptedParams: string | undefined;
   readonly revokesEventId: string | undefined;
 }): Promise<ClientEventIdResolution> {
   return params.db.transaction(async (tx) => {
@@ -1620,9 +1620,7 @@ function appendUnassociatedUserMessage(params: {
       userMessage: params.userMessage,
       runId: null,
       triggerSource: "web",
-      encryptedParams: params.encryptedParams,
       attachFiles: fileIds,
-      attachFileMetadata: fileMetadata,
       generationTemplate: params.generationTemplate,
     };
     const inserted = params.revokesEventId
@@ -2490,7 +2488,7 @@ const prepareNormalSend$ = command(
       return computerAccess;
     }
     const attachFileMetadata = await set(
-      resolveAttachFileMetadata$,
+      resolveIncomingAttachFileMetadata$,
       {
         userId: args.userId,
         attachFiles: runtimeBody.attachFiles,
@@ -2530,17 +2528,6 @@ async function queueUnassociatedNormalEvent(params: {
   /** Set when this call inserted a queue-first message. */
   readonly queuedEventId: string | undefined;
 }> {
-  const encryptedParams = params.body.realAgentInPreview
-    ? await encryptQueuedUserMessageRunParams(
-        {
-          version: 1,
-          prompt: params.prepared.body.agentPrompt,
-          appendSystemPrompt: buildWebChatPrompt(),
-          realAgentInPreview: true,
-        },
-        { orgId: params.orgId, userId: params.userId },
-      )
-    : undefined;
   const resolution = await appendUnassociatedUserMessage({
     db: params.prepared.db,
     threadId: params.prepared.thread.threadId,
@@ -2554,7 +2541,6 @@ async function queueUnassociatedNormalEvent(params: {
     touchThreadSort: params.touchThreadSort,
     userMessage: params.body.userMessage,
     generationTemplate: params.body.generationTemplate,
-    encryptedParams,
     revokesEventId: params.body.revokesEventId,
   });
   if (resolution.kind === "queued" && resolution.inserted) {
@@ -3038,6 +3024,7 @@ function codexServiceTierForRun(params: {
 function buildCreateZeroRunArgs(params: {
   readonly args: NormalSendArgs;
   readonly prepared: PreparedNormalSend;
+  readonly realAgentInPreviewEnabled: boolean;
 }) {
   const { args, prepared } = params;
   const { modelPin, providerAdmission, codexServiceTier } =
@@ -3080,7 +3067,7 @@ function buildCreateZeroRunArgs(params: {
       ...(providerAdmission.effectiveModelProvider
         ? { modelProvider: providerAdmission.effectiveModelProvider }
         : {}),
-      ...(args.body.realAgentInPreview ? { realAgentInPreview: true } : {}),
+      ...(params.realAgentInPreviewEnabled ? { realAgentInPreview: true } : {}),
     },
     triggerSource: "web" as const,
     dispatchFailedCallbacks: dispatchFailedRunCallbacks,
@@ -3100,6 +3087,7 @@ function buildCreateZeroRunArgs(params: {
 async function buildTimedCreateZeroRunArgs(params: {
   readonly args: NormalSendArgs;
   readonly prepared: PreparedNormalSend;
+  readonly realAgentInPreviewEnabled: boolean;
 }): Promise<ReturnType<typeof buildCreateZeroRunArgs>> {
   return await measureApiDispatchTiming(
     params.args.timing,
@@ -3204,9 +3192,45 @@ const createNormalChatRun$ = command(
       });
     }
 
+    const queuedMessage = await loadNextUnclaimedQueuedUserMessage(
+      prepared.db,
+      prepared.thread.threadId,
+    );
+    signal.throwIfAborted();
+    if (!queuedMessage || queuedMessage.id !== params.queueFirstEventId) {
+      return await resolveQueueFirstEventAfterLostClaim({
+        db: prepared.db,
+        threadId: prepared.thread.threadId,
+        userId: args.userId,
+        eventId: params.queueFirstEventId,
+      });
+    }
+    const attachFileMetadata = queuedMessage.attachFileMetadata
+      ? [...queuedMessage.attachFileMetadata]
+      : await set(
+          resolveAttachFileMetadata$,
+          {
+            userId: args.userId,
+            attachFiles: queuedMessage.attachFiles,
+          },
+          signal,
+        );
+    signal.throwIfAborted();
+
+    const featureSwitchContext = await loadUserFeatureSwitchContext(
+      prepared.db,
+      args.orgId,
+      args.userId,
+    );
+    signal.throwIfAborted();
+
     const createRunArgs = await buildTimedCreateZeroRunArgs({
       args,
       prepared,
+      realAgentInPreviewEnabled: isFeatureEnabled(
+        FeatureSwitchKey.RealAgentInPreview,
+        featureSwitchContext,
+      ),
     });
     signal.throwIfAborted();
 
@@ -3223,10 +3247,14 @@ const createNormalChatRun$ = command(
       createQueueFirstZeroRun$,
       {
         ...createRunArgs,
+        apiStartTime: queuedMessage.createdAt.getTime(),
         queueFirstAssociation: {
           kind: "user_message",
           threadId: prepared.thread.threadId,
           eventId: queueFirstEventId,
+          orgId: args.orgId,
+          userId: args.userId,
+          attachFileMetadata,
         },
       },
       signal,

--- a/turbo/apps/api/src/signals/routes/zero-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-events.ts
@@ -3172,7 +3172,7 @@ const createNormalChatRun$ = command(
     },
     signal: AbortSignal,
   ) => {
-    const { args, prepared } = params;
+    const { args, prepared, queueFirstEventId } = params;
     const createNormalRunStartedAt = now();
     const { modelPin, providerAdmission } = prepared.runConfiguration;
     if (providerAdmission.error) {
@@ -3188,7 +3188,7 @@ const createNormalChatRun$ = command(
           args.zeroPreCreateSource,
           prepared.thread.isNewThread,
         ),
-        queueFirstEventId: params.queueFirstEventId,
+        queueFirstEventId,
       });
     }
 
@@ -3197,12 +3197,12 @@ const createNormalChatRun$ = command(
       prepared.thread.threadId,
     );
     signal.throwIfAborted();
-    if (!queuedMessage || queuedMessage.id !== params.queueFirstEventId) {
+    if (!queuedMessage || queuedMessage.id !== queueFirstEventId) {
       return await resolveQueueFirstEventAfterLostClaim({
         db: prepared.db,
         threadId: prepared.thread.threadId,
         userId: args.userId,
-        eventId: params.queueFirstEventId,
+        eventId: queueFirstEventId,
       });
     }
     const attachFileMetadata = queuedMessage.attachFileMetadata
@@ -3234,8 +3234,6 @@ const createNormalChatRun$ = command(
     });
     signal.throwIfAborted();
 
-    const queueFirstEventId = params.queueFirstEventId;
-
     if (args.timing) {
       args.timing.recordElapsed(
         "api_dispatch_pre_create_zero_web_chat_create_normal_run",
@@ -3254,6 +3252,7 @@ const createNormalChatRun$ = command(
           eventId: queueFirstEventId,
           orgId: args.orgId,
           userId: args.userId,
+          admissionTime: args.apiStartTime,
           attachFileMetadata,
         },
       },

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -5858,7 +5858,10 @@ async function resolveQueueFirstAdmissionForLaunch(args: {
     throw new Error("Queue-first association must match the run chat thread");
   }
   return await resolveQueueFirstRunAdmission(args.tx, {
-    apiStartTime: args.createArgs.apiStartTime,
+    admissionTime:
+      association.kind === "user_message"
+        ? association.admissionTime
+        : args.createArgs.apiStartTime,
     sessionSnapshotState: args.sessionSnapshotState,
     threadId: association.threadId,
     timing: args.timing,

--- a/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
@@ -298,7 +298,6 @@ async function persistCanonicalFeishuIngress(args: {
       version: 1,
       prompt: args.message.text,
       appendSystemPrompt: args.appendSystemPrompt,
-      apiStartTime: args.ingress.createdAt.getTime(),
       feishuDelivery: {
         installationId: args.message.installationId,
         connectionId: args.connection.id,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -404,7 +404,7 @@ type CreatedQueuedRun = {
 
 type CreateQueuedRun = (
   input: CreateQueuedChatRunInput,
-  apiStartTime: number,
+  admissionTime: number,
   signal: AbortSignal,
 ) => Promise<CreatedQueuedRun | null>;
 
@@ -749,7 +749,7 @@ function generateCallbackSecret(): string {
 
 function buildQueuedCreateZeroRunArgs(
   input: CreateQueuedChatRunInput,
-  apiStartTime: number,
+  admissionTime: number,
   dispatchFailedCallbacks?: DispatchFailedRunCallbacks,
 ) {
   return {
@@ -759,7 +759,7 @@ function buildQueuedCreateZeroRunArgs(
       orgId: input.orgId,
       orgRole: "member" as const,
     },
-    apiStartTime,
+    apiStartTime: input.apiStartTime,
     chatThreadId: input.threadId,
     computerUseHostId: input.computerUseHostGrant?.hostId,
     modelProviderId: input.modelPin.modelProviderId ?? undefined,
@@ -824,6 +824,7 @@ function buildQueuedCreateZeroRunArgs(
       eventId: input.queuedMessage.id,
       orgId: input.orgId,
       userId: input.userId,
+      admissionTime,
       attachFileMetadata: input.attachFileMetadata,
       ...(input.morningBriefDelivery
         ? {
@@ -3437,6 +3438,7 @@ async function handleQueuedMessageAdmissionFailure(args: {
 }
 
 interface AutoSendQueuedMessageArgs {
+  readonly admissionTime: number;
   readonly createRun: (
     input: CreateQueuedChatRunInput,
   ) => Promise<CreatedQueuedRun | null>;
@@ -3459,34 +3461,23 @@ interface AutoSendQueuedMessageArgs {
 function chatThreadAdmissionBlockedForAutoSend(
   args: AutoSendQueuedMessageArgs,
   threadId: string,
-  apiStartTime: number,
 ): Promise<boolean> {
   return chatThreadAdmissionBlocked(args.db, {
     threadId,
-    apiStartTime,
+    apiStartTime: args.admissionTime,
   });
 }
 
-function autoSendAdmissionBlocked(args: {
-  readonly autoSend: AutoSendQueuedMessageArgs;
-  readonly queuedMessage: QueuedUserMessage;
-  readonly runInput: Exclude<
-    Awaited<ReturnType<typeof buildCreateQueuedChatRunInput>>,
-    null
-  >;
-}): Promise<boolean> {
+function autoSendAdmissionBlocked(
+  args: AutoSendQueuedMessageArgs,
+  threadId: string,
+): Promise<boolean> {
   return measureChatCallbackPreCreateTiming(
-    args.autoSend.timing,
+    args.timing,
     "api_dispatch_pre_create_zero_chat_callback_auto_send_check_active_run",
     "nested",
     () => {
-      return chatThreadAdmissionBlockedForAutoSend(
-        args.autoSend,
-        args.autoSend.chatThreadId,
-        "kind" in args.runInput
-          ? args.queuedMessage.createdAt.getTime()
-          : args.runInput.apiStartTime,
-      );
+      return chatThreadAdmissionBlockedForAutoSend(args, threadId);
     },
   );
 }
@@ -3554,11 +3545,7 @@ async function autoSendQueuedMessageForThread(
   if (!runInput) {
     return;
   }
-  const activeRunExists = await autoSendAdmissionBlocked({
-    autoSend: args,
-    queuedMessage,
-    runInput,
-  });
+  const activeRunExists = await autoSendAdmissionBlocked(args, threadId);
   if (activeRunExists) {
     return;
   }
@@ -4698,10 +4685,10 @@ const buildChatCallbackDependencies$ = command(
     };
     const dependencies: ChatCallbackDependencies = {
       ...baseDependencies,
-      createQueuedRun: async (runInput, apiStartTime, inputSignal) => {
+      createQueuedRun: async (runInput, admissionTime, inputSignal) => {
         const createArgs = buildQueuedCreateZeroRunArgs(
           runInput,
-          apiStartTime,
+          admissionTime,
           buildQueuedChatDispatchFailedCallbacks({
             dependencies: baseDependencies,
             runInput,
@@ -4797,9 +4784,11 @@ export const drainQueuedUserMessagesForThread$ = command(
     if (!createQueuedRun) {
       return;
     }
+    const admissionTime = args.apiStartTime ?? now();
     await autoSendQueuedMessageForThread({
       db,
       chatThreadId: args.chatThreadId,
+      admissionTime,
       userId: thread.userId,
       agentId: thread.agentId,
       queueItemCreatedBefore: args.queueItemCreatedBefore,
@@ -4825,7 +4814,7 @@ export const drainQueuedUserMessagesForThread$ = command(
           input,
           signal,
           createRun: (runInput) => {
-            return createQueuedRun(runInput, runInput.apiStartTime, signal);
+            return createQueuedRun(runInput, admissionTime, signal);
           },
         });
       },

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -16,6 +16,7 @@ import { runOutputMaterializations } from "@vm0/db/schema/run-output-materializa
 import {
   chatEventTerminalPredicate,
   chatEvents,
+  type ChatEventAttachFileMetadata,
   type ChatEventGenerationTemplate,
   type ChatEventRecommendedFollowups,
   type ChatEventUserMessage,
@@ -138,6 +139,7 @@ import {
   discardUnclaimedUserMessageInTransaction,
   failQueuedUserMessage,
   loadNextUnclaimedQueuedUserMessage,
+  resolveAttachFileMetadata$,
   type QueuedUserMessage,
 } from "./zero-chat-queued-event.service";
 import { handleMorningBriefEmailInternalCallback } from "./internal-morning-brief-run-callback.service";
@@ -581,6 +583,7 @@ interface CreateQueuedChatRunInput {
     readonly displayName: string;
   } | null;
   readonly triggerSource: QueuedUserMessage["triggerSource"];
+  readonly attachFileMetadata: readonly ChatEventAttachFileMetadata[] | null;
   readonly realAgentInPreview?: boolean;
   readonly slackDelivery?: {
     readonly channelId: string;
@@ -598,7 +601,7 @@ interface CreateQueuedChatRunInput {
     readonly secret: string;
     readonly payload: unknown;
   };
-  readonly apiStartTime?: number;
+  readonly apiStartTime: number;
   readonly userInfoExtras?: {
     readonly slackDisplayName?: string;
     readonly slackUserId?: string;
@@ -819,6 +822,9 @@ function buildQueuedCreateZeroRunArgs(
       kind: "user_message" as const,
       threadId: input.threadId,
       eventId: input.queuedMessage.id,
+      orgId: input.orgId,
+      userId: input.userId,
+      attachFileMetadata: input.attachFileMetadata,
       ...(input.morningBriefDelivery
         ? {
             morningBriefDeliveryId: input.morningBriefDelivery.deliveryId,
@@ -2592,6 +2598,12 @@ interface CreateQueuedChatRunInputArgs {
   readonly agent: AgentForAutoSend;
   readonly queuedMessage: QueuedUserMessage;
   readonly timing?: ChatCallbackPreCreateTimingCollector;
+  readonly signal: AbortSignal;
+  readonly resolveAttachFileMetadata: (
+    userId: string,
+    attachFiles: readonly string[] | null,
+    signal: AbortSignal,
+  ) => Promise<ChatEventAttachFileMetadata[] | null>;
 }
 
 function loadQueuedMessageSessionState(
@@ -2780,13 +2792,10 @@ function queuedMessageAdmissionFailure(
 }
 
 function queuedMessageApiStartTime(
-  triggerSource: QueuedUserMessage["triggerSource"],
+  queuedMessage: QueuedUserMessage,
   sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
-): number | undefined {
-  if (triggerSource === "workflow-schedule") {
-    return undefined;
-  }
-  return sourceParams?.apiStartTime;
+): number {
+  return sourceParams?.apiStartTime ?? queuedMessage.createdAt.getTime();
 }
 
 function queuedIntegrationDeliveries(
@@ -2865,6 +2874,14 @@ async function buildCreateQueuedChatRunInput(
 
   const [startNewSession, loadedIncompleteContext, featureSwitchContext] =
     await loadQueuedMessageSessionState(args, modelRoute);
+  const attachFileMetadata = args.queuedMessage.attachFileMetadata
+    ? [...args.queuedMessage.attachFileMetadata]
+    : await args.resolveAttachFileMetadata(
+        args.userId,
+        args.queuedMessage.attachFiles,
+        args.signal,
+      );
+  args.signal.throwIfAborted();
   const inlineTemplatesEnabled = isFeatureEnabled(
     FeatureSwitchKey.StructuredPromptInlineTemplates,
     featureSwitchContext,
@@ -2939,12 +2956,15 @@ async function buildCreateQueuedChatRunInput(
     codexServiceTier: modelRoute.codexServiceTier,
     computerUseHostGrant,
     triggerSource: args.queuedMessage.triggerSource,
-    realAgentInPreview: sourceParams?.realAgentInPreview,
+    attachFileMetadata,
+    realAgentInPreview:
+      sourceParams?.realAgentInPreview ??
+      isFeatureEnabled(
+        FeatureSwitchKey.RealAgentInPreview,
+        featureSwitchContext,
+      ),
     ...queuedIntegrationDeliveries(sourceParams),
-    apiStartTime: queuedMessageApiStartTime(
-      args.queuedMessage.triggerSource,
-      sourceParams,
-    ),
+    apiStartTime: queuedMessageApiStartTime(args.queuedMessage, sourceParams),
     userInfoExtras: sourceParams?.userInfoExtras,
   };
 }
@@ -3417,7 +3437,6 @@ async function handleQueuedMessageAdmissionFailure(args: {
 }
 
 interface AutoSendQueuedMessageArgs {
-  readonly apiStartTime?: number;
   readonly createRun: (
     input: CreateQueuedChatRunInput,
   ) => Promise<CreatedQueuedRun | null>;
@@ -3428,6 +3447,7 @@ interface AutoSendQueuedMessageArgs {
   readonly queueItemCreatedBefore?: Date;
   readonly timing: ChatCallbackPreCreateTimingCollector;
   readonly signal: AbortSignal;
+  readonly resolveAttachFileMetadata: CreateQueuedChatRunInputArgs["resolveAttachFileMetadata"];
   readonly formatIntegrationRunError: ChatCallbackDependencies["formatIntegrationRunError"];
   readonly deliverSlackAdmissionFailure: ChatCallbackDependencies["deliverSlackAdmissionFailure"];
   readonly deliverTeamsAdmissionFailure: ChatCallbackDependencies["deliverTeamsAdmissionFailure"];
@@ -3439,11 +3459,36 @@ interface AutoSendQueuedMessageArgs {
 function chatThreadAdmissionBlockedForAutoSend(
   args: AutoSendQueuedMessageArgs,
   threadId: string,
+  apiStartTime: number,
 ): Promise<boolean> {
   return chatThreadAdmissionBlocked(args.db, {
     threadId,
-    apiStartTime: args.apiStartTime,
+    apiStartTime,
   });
+}
+
+function autoSendAdmissionBlocked(args: {
+  readonly autoSend: AutoSendQueuedMessageArgs;
+  readonly queuedMessage: QueuedUserMessage;
+  readonly runInput: Exclude<
+    Awaited<ReturnType<typeof buildCreateQueuedChatRunInput>>,
+    null
+  >;
+}): Promise<boolean> {
+  return measureChatCallbackPreCreateTiming(
+    args.autoSend.timing,
+    "api_dispatch_pre_create_zero_chat_callback_auto_send_check_active_run",
+    "nested",
+    () => {
+      return chatThreadAdmissionBlockedForAutoSend(
+        args.autoSend,
+        args.autoSend.chatThreadId,
+        "kind" in args.runInput
+          ? args.queuedMessage.createdAt.getTime()
+          : args.runInput.apiStartTime,
+      );
+    },
+  );
 }
 
 /**
@@ -3501,20 +3546,19 @@ async function autoSendQueuedMessageForThread(
         agent,
         queuedMessage,
         timing: args.timing,
+        signal: args.signal,
+        resolveAttachFileMetadata: args.resolveAttachFileMetadata,
       });
     },
   );
   if (!runInput) {
     return;
   }
-  const activeRunExists = await measureChatCallbackPreCreateTiming(
-    args.timing,
-    "api_dispatch_pre_create_zero_chat_callback_auto_send_check_active_run",
-    "nested",
-    () => {
-      return chatThreadAdmissionBlockedForAutoSend(args, threadId);
-    },
-  );
+  const activeRunExists = await autoSendAdmissionBlocked({
+    autoSend: args,
+    queuedMessage,
+    runInput,
+  });
   if (activeRunExists) {
     return;
   }
@@ -4753,16 +4797,21 @@ export const drainQueuedUserMessagesForThread$ = command(
     if (!createQueuedRun) {
       return;
     }
-    const apiStartTime = args.apiStartTime ?? now();
     await autoSendQueuedMessageForThread({
       db,
       chatThreadId: args.chatThreadId,
-      apiStartTime,
       userId: thread.userId,
       agentId: thread.agentId,
       queueItemCreatedBefore: args.queueItemCreatedBefore,
       timing: args.timing ?? new ChatCallbackPreCreateTimingCollector(),
       signal,
+      resolveAttachFileMetadata: (userId, attachFiles, inputSignal) => {
+        return set(
+          resolveAttachFileMetadata$,
+          { userId, attachFiles },
+          inputSignal,
+        );
+      },
       formatIntegrationRunError: dependencies.formatIntegrationRunError,
       deliverSlackAdmissionFailure: dependencies.deliverSlackAdmissionFailure,
       deliverTeamsAdmissionFailure: dependencies.deliverTeamsAdmissionFailure,
@@ -4776,11 +4825,7 @@ export const drainQueuedUserMessagesForThread$ = command(
           input,
           signal,
           createRun: (runInput) => {
-            return createQueuedRun(
-              runInput,
-              runInput.apiStartTime ?? apiStartTime,
-              signal,
-            );
+            return createQueuedRun(runInput, runInput.apiStartTime, signal);
           },
         });
       },

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -1264,7 +1264,6 @@ async function insertGitHubChatInput(args: {
         triggerReactionId: args.reactionId,
         triggerCommentBody: args.params.comment?.body,
       },
-      apiStartTime: args.params.apiStartTime,
     },
     { orgId: args.target.orgId, userId: args.params.vm0UserId },
   );

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -1568,7 +1568,6 @@ async function persistAgentPhoneChatMessage(args: {
         args.threadContext,
       ),
       agentphoneDelivery: agentPhoneDeliveryTarget(args),
-      apiStartTime: args.apiStartTime,
       userInfoExtras: args.userInfoExtras,
     },
     {

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -1,5 +1,6 @@
 import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
 import type { ChatEventType } from "@vm0/api-contracts/contracts/chat-events";
+import { command } from "ccstate";
 import { chatAutomationContext } from "@vm0/db/schema/chat-automation-context";
 import { chatGoalContext } from "@vm0/db/schema/chat-goal-context";
 import { chatEventInputParams } from "@vm0/db/schema/chat-event-input-params";
@@ -63,6 +64,8 @@ import { githubDeliveryTargetSchema } from "./github-chat-callback-payload";
 import { teamsDeliveryTargetSchema } from "./teams-chat-callback-payload";
 import { telegramDeliveryTargetSchema } from "./telegram-chat-callback-payload";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
+import { resolveArtifactObject$ } from "./artifact-storage.service";
+import { attachCanonicalWebInputAssetsToEvent } from "./canonical-asset.service";
 
 type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
@@ -154,6 +157,7 @@ const queueFirstReplacementTargetFields = {
 
 export interface QueuedUserMessage {
   readonly id: string;
+  readonly createdAt: Date;
   readonly userMessage: ChatEventUserMessage;
   readonly attachFiles: readonly string[] | null;
   readonly attachFileMetadata: readonly ChatEventAttachFileMetadata[] | null;
@@ -179,6 +183,11 @@ export type QueueFirstRunAssociation =
       readonly kind: "user_message";
       readonly threadId: string;
       readonly eventId: string;
+      readonly orgId: string;
+      readonly userId: string;
+      readonly attachFileMetadata:
+        | readonly ChatEventAttachFileMetadata[]
+        | null;
       readonly morningBriefDeliveryId?: string;
     }
   | {
@@ -256,6 +265,41 @@ export async function decryptQueuedUserMessageRunParams(
   return queuedUserMessageRunParamsSchema.parse(JSON.parse(raw) as unknown);
 }
 
+export const resolveAttachFileMetadata$ = command(
+  async (
+    { set },
+    args: {
+      readonly userId: string;
+      readonly attachFiles: readonly string[] | null;
+    },
+    signal: AbortSignal,
+  ): Promise<ChatEventAttachFileMetadata[] | null> => {
+    if (!args.attachFiles || args.attachFiles.length === 0) {
+      return null;
+    }
+    const metadata: ChatEventAttachFileMetadata[] = [];
+    for (const id of args.attachFiles) {
+      const object = await set(
+        resolveArtifactObject$,
+        { userId: args.userId, id },
+        signal,
+      );
+      signal.throwIfAborted();
+      if (!object) {
+        throw new Error(`Queued attachment not found: ${id}`);
+      }
+      metadata.push({
+        id,
+        filename: object.filename,
+        contentType: object.contentType,
+        size: object.size,
+        objectKey: object.key,
+      });
+    }
+    return metadata;
+  },
+);
+
 /** Whether the outer ChatEvent row is an unclaimed, unrevoked prompt. */
 export function queuedUserMessageExists(db: Pick<Db, "select">): SQL {
   return exists(
@@ -297,6 +341,7 @@ export async function loadNextUnclaimedQueuedUserMessage(
   const [event] = await db
     .select({
       id: chatEvents.id,
+      createdAt: chatEvents.createdAt,
       userMessage: chatEvents.userMessage,
       attachFiles: chatEvents.attachFiles,
       attachFileMetadata: queuedAttachFileMetadata,
@@ -432,9 +477,7 @@ async function resolveUserQueueFirstClaimSnapshot(
       userMessage: head.userMessage,
       runId: args.runId,
       attachFiles: head.attachFiles ? [...head.attachFiles] : null,
-      attachFileMetadata: head.attachFileMetadata
-        ? [...head.attachFileMetadata]
-        : null,
+      attachFileMetadata: null,
       generationTemplate: head.generationTemplate,
       ...(head.triggerSource ? { triggerSource: head.triggerSource } : {}),
     },
@@ -748,6 +791,20 @@ export async function claimQueueFirstRunAssociation(
         }
         outcome = "lost";
         return { kind: "lost" };
+      }
+      if (
+        args.kind === "user_message" &&
+        "triggerSource" in snapshot.replacement &&
+        snapshot.replacement.triggerSource === "web" &&
+        args.attachFileMetadata
+      ) {
+        await attachCanonicalWebInputAssetsToEvent(db, {
+          eventId: claimed.id,
+          chatThreadId: args.threadId,
+          userId: args.userId,
+          orgId: args.orgId,
+          files: args.attachFileMetadata,
+        });
       }
 
       outcome = "claimed";

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -10,6 +10,10 @@ import {
   type ChatEventGenerationTemplate,
   type ChatEventUserMessage,
 } from "@vm0/db/schema/chat-event";
+import {
+  CANONICAL_ASSET_VERSION,
+  runUploadedFiles,
+} from "@vm0/db/schema/run-uploaded-file";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { morningBriefDeliveries } from "@vm0/db/schema/morning-brief";
 import { threadGoals } from "@vm0/db/schema/thread-goal";
@@ -34,7 +38,7 @@ import {
   pgBooleanDecoder,
   pgNullDecoder,
 } from "../../lib/db-structured-result";
-import type { Db } from "../external/db";
+import { db$, type Db } from "../external/db";
 import {
   listPendingChatQueueEvents,
   loadPendingChatQueueEvent,
@@ -185,6 +189,7 @@ export type QueueFirstRunAssociation =
       readonly eventId: string;
       readonly orgId: string;
       readonly userId: string;
+      readonly admissionTime: number;
       readonly attachFileMetadata:
         | readonly ChatEventAttachFileMetadata[]
         | null;
@@ -267,7 +272,7 @@ export async function decryptQueuedUserMessageRunParams(
 
 export const resolveAttachFileMetadata$ = command(
   async (
-    { set },
+    { get, set },
     args: {
       readonly userId: string;
       readonly attachFiles: readonly string[] | null;
@@ -277,22 +282,37 @@ export const resolveAttachFileMetadata$ = command(
     if (!args.attachFiles || args.attachFiles.length === 0) {
       return null;
     }
+    const db = get(db$);
     const metadata: ChatEventAttachFileMetadata[] = [];
     for (const id of args.attachFiles) {
-      const object = await set(
-        resolveArtifactObject$,
-        { userId: args.userId, id },
-        signal,
-      );
+      const [object, [asset]] = await Promise.all([
+        set(resolveArtifactObject$, { userId: args.userId, id }, signal),
+        db
+          .select({
+            filename: runUploadedFiles.filename,
+            contentType: runUploadedFiles.contentType,
+            size: runUploadedFiles.sizeBytes,
+          })
+          .from(runUploadedFiles)
+          .where(
+            and(
+              eq(runUploadedFiles.userId, args.userId),
+              eq(runUploadedFiles.assetVersion, CANONICAL_ASSET_VERSION),
+              eq(runUploadedFiles.idempotencyScope, "web-input"),
+              eq(runUploadedFiles.idempotencyKey, id),
+            ),
+          )
+          .limit(1),
+      ]);
       signal.throwIfAborted();
       if (!object) {
         throw new Error(`Queued attachment not found: ${id}`);
       }
       metadata.push({
         id,
-        filename: object.filename,
-        contentType: object.contentType,
-        size: object.size,
+        filename: asset?.filename ?? object.filename,
+        contentType: asset?.contentType ?? object.contentType,
+        size: asset?.size ?? object.size,
         objectKey: object.key,
       });
     }
@@ -673,11 +693,11 @@ async function resolveQueueFirstClaimSnapshot(
 
 function queueFirstRunAdmissionBlocked(
   db: DbTransaction,
-  args: { readonly apiStartTime: number; readonly threadId: string },
+  args: { readonly admissionTime: number; readonly threadId: string },
 ): Promise<boolean> {
   return chatThreadAdmissionBlocked(db, {
     threadId: args.threadId,
-    apiStartTime: args.apiStartTime,
+    apiStartTime: args.admissionTime,
   });
 }
 
@@ -689,7 +709,7 @@ function queueFirstRunAdmissionBlocked(
 export async function resolveQueueFirstRunAdmission(
   db: DbTransaction,
   args: {
-    readonly apiStartTime: number;
+    readonly admissionTime: number;
     readonly sessionSnapshotState: QueueFirstRunSessionSnapshotState;
     readonly threadAlreadyLocked?: true;
     readonly threadId: string;

--- a/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
@@ -1658,7 +1658,6 @@ async function persistTeamsChatMessage(args: {
         threadContext: args.promptContext.text,
       }),
       teamsDelivery: delivery,
-      apiStartTime: args.apiStartTime,
       userInfoExtras: {
         teamsUserDisplayName: args.activity.sender.name ?? undefined,
         teamsUserPrincipalName:

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -1841,7 +1841,6 @@ async function persistTelegramChatMessage(args: {
       prompt: args.prompt,
       appendSystemPrompt,
       telegramDelivery: delivery,
-      apiStartTime: args.source.apiStartTime,
       userInfoExtras: args.userInfoExtras,
     },
     {

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -25,6 +25,7 @@ import {
   insertChatEvent,
   replaceChatEvent,
 } from "../signals/services/zero-chat-event.service";
+import { encryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
 import { createDeferredPromise, onRejection } from "../signals/utils";
@@ -429,6 +430,46 @@ export async function invalidatePendingChatEventInputParamsFixture(
     .returning({ eventId: chatEventInputParams.eventId });
   if (rows.length !== 1) {
     throw new Error("Expected one pending queue item to become invalid");
+  }
+}
+
+export async function writeLegacyQueuedUserMessageParamsFixture(args: {
+  readonly eventId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly prompt: string;
+  readonly appendSystemPrompt: string;
+  readonly realAgentInPreview?: boolean;
+  readonly apiStartTime?: number;
+  readonly attachFileMetadata?: typeof chatEventInputParams.$inferInsert.attachFileMetadata;
+}): Promise<void> {
+  const encryptedParams = await encryptQueuedUserMessageRunParams(
+    {
+      version: 1,
+      prompt: args.prompt,
+      appendSystemPrompt: args.appendSystemPrompt,
+      realAgentInPreview: args.realAgentInPreview,
+      apiStartTime: args.apiStartTime,
+    },
+    { orgId: args.orgId, userId: args.userId },
+  );
+  const rows = await db()
+    .insert(chatEventInputParams)
+    .values({
+      eventId: args.eventId,
+      encryptedParams,
+      attachFileMetadata: args.attachFileMetadata,
+    })
+    .onConflictDoUpdate({
+      target: chatEventInputParams.eventId,
+      set: {
+        encryptedParams,
+        attachFileMetadata: args.attachFileMetadata,
+      },
+    })
+    .returning({ eventId: chatEventInputParams.eventId });
+  if (rows.length !== 1) {
+    throw new Error("Expected one pending queue item to receive legacy params");
   }
 }
 


### PR DESCRIPTION
## Summary

- resolve queued web attachment metadata from `chat_events.attach_files` at claim time, while retaining legacy `attach_file_metadata` reads for pending backlog
- derive `realAgentInPreview` from the owning thread user/org feature-switch context at claim time
- use the queued `chat_events.created_at` value as `apiStartTime` and stop all chat ingress writers from persisting it
- stop web preview sends from creating `chat_event_input_params` rows solely for preview mode
- preserve canonical attachment materialization and the existing encrypted-params queue monitor contract

This is rollout PR 1 for #24363 and the first step of #24362. The column and compatibility fallbacks remain until production has drained all rows with non-null `attach_file_metadata`.

## Scope

No changes to chat context tables, prompt construction, delivery targets, `userInfoExtras`, callbacks, the public API contract, or `user_message`.

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- focused DB-backed Vitest cases are delegated to CI because this worktree has no valid `DATABASE_URL`
