### PR TITLE
test(e2e): exercise real claude attachment path

### DIFF
--- a/.github/scripts/runner-image-context.sh
+++ b/.github/scripts/runner-image-context.sh
@@ -20,7 +20,7 @@ turbo-consumer:
   change booleans used by turbo.yml.
 
 playwright-consumer:
-  Computes whether Playwright needs a mock runner.
+  Computes whether Playwright needs a dedicated runner.
 
 crates-consumer:
   Computes whether Crates runner tests are a runner image consumer from the

--- a/.github/scripts/tests/runner-image-workflow-test.sh
+++ b/.github/scripts/tests/runner-image-workflow-test.sh
@@ -25,7 +25,7 @@ jq -e '
     .env.PLAYWRIGHT_RUNNER_CONSUMER_NEEDED ==
       "${{ steps.turbo.outputs.playwright-runner-consumer-needed }}"
   )
-' <<<"$workflow_json" >/dev/null || fail "Playwright mock-runner demand must reach runner image selection"
+' <<<"$workflow_json" >/dev/null || fail "Playwright dedicated-runner demand must reach runner image selection"
 
 jq -e '
   .jobs["cancel-superseded"].name == "Cancel superseded merge-group CI" and

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+WORKFLOW="${REPO_ROOT}/.github/workflows/turbo.yml"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+grep -Fq "local RUNNER_DIRNAME=\"\${RUNNER_DIR##*/}\"" "$WORKFLOW" ||
+  fail "runner config dirname must come from the manifest runner directory"
+grep -Fq -- "--runner-dirname \${RUNNER_DIRNAME}" "$WORKFLOW" ||
+  fail "runner config must be written beneath the manifest runner directory"
+grep -Fq -- "--config \${RUNNER_DIR}/runner.yaml" "$WORKFLOW" ||
+  fail "runner service must read the config from the manifest runner directory"
+if grep -Fq -- "--runner-dirname \${RUNNER_SERVICE_REF}" "$WORKFLOW"; then
+  fail "runner service identity must not select the manifest config directory"
+fi
+
+echo "turbo-playwright-runner-workflow-test: ok"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2322,6 +2322,7 @@ jobs:
             local HOST=$1
             local HOST_INDEX=$2
             local RUNNER_NAME="${RUNNER_SERVICE_REF}-${HOST_INDEX}"
+            local RUNNER_DIRNAME="${RUNNER_DIR##*/}"
             local REMOTE="${METAL_USER}@${HOST}"
             local MC
             echo "=== Starting runner ${RUNNER_NAME} on ${HOST} ==="
@@ -2351,7 +2352,7 @@ jobs:
               --snapshot-hash ${SNAPSHOT_HASH} \
               --name ${RUNNER_NAME} \
               --group ${RUNNER_GROUP} \
-              --runner-dirname ${RUNNER_SERVICE_REF} \
+              --runner-dirname ${RUNNER_DIRNAME} \
               --concurrency-factor 1.5 \
               --api-url ${RUNNER_API_URL} \
               --token vm0_official_${OFFICIAL_RUNNER_SECRET}"

--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -35,16 +35,27 @@ test("complete app onboarding to chat page", async ({ browser, page }) => {
 
   await refreshClerkSessionToken(page, { activeOrganizationId: orgId });
 
+  const token = await page.evaluate(async () => {
+    return (await window.Clerk?.session?.getToken({ skipCache: true })) ?? null;
+  });
+  if (!token) {
+    throw new Error("Clerk session token unavailable for Playwright setup");
+  }
+
+  // Keep the pipeline-owned runner and VM, but bypass their mock agent CLIs.
+  const featureSwitchResponse = await page.request.post(
+    new URL("/api/zero/feature-switches", apiUrl).toString(),
+    {
+      headers: authHeadersForToken(token),
+      data: {
+        switches: { realAgentInPreview: true },
+      },
+    },
+  );
+  expect(featureSwitchResponse.status()).toBe(200);
+
   const runnerGroup = process.env.E2E_RUNNER_GROUP;
   if (runnerGroup) {
-    const token = await page.evaluate(async () => {
-      return (
-        (await window.Clerk?.session?.getToken({ skipCache: true })) ?? null
-      );
-    });
-    if (!token) {
-      throw new Error("Clerk session token unavailable for runner setup");
-    }
     const response = await page.request.post(
       new URL("/api/test/agent-composes", apiUrl).toString(),
       {

--- a/e2e/playwright/tests/webchat.spec.ts
+++ b/e2e/playwright/tests/webchat.spec.ts
@@ -1,36 +1,127 @@
 import { expect, test } from "../fixtures";
 import { deriveAppUrl } from "../playwright.config";
 
-const appUrl = deriveAppUrl(process.env.VM0_API_BACKEND_URL!);
+const apiUrl = process.env.VM0_API_BACKEND_URL!;
+const appUrl = deriveAppUrl(apiUrl);
+const attachmentImage = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
 
-test("send a chat message and start an assistant response", async ({
+test("upload an attachment and receive a real Claude response", async ({
   page,
 }) => {
+  const attachmentName = `playwright-real-upload-${Date.now()}.png`;
+  await page.route(`**/*${attachmentName}*`, async (route) => {
+    const method = route.request().method();
+    if (method === "OPTIONS") {
+      const requestedHeaders = route.request().headers()[
+        "access-control-request-headers"
+      ];
+      await route.fulfill({
+        status: 204,
+        headers: {
+          "access-control-allow-headers": requestedHeaders ?? "content-type",
+          "access-control-allow-methods": "PUT, OPTIONS",
+          "access-control-allow-origin": appUrl,
+        },
+      });
+      return;
+    }
+    if (method === "PUT") {
+      // Proxy the signed request outside browser CORS while preserving the
+      // real object-storage write needed by the agent runtime.
+      const response = await route.fetch();
+      await route.fulfill({
+        response,
+        headers: {
+          ...response.headers(),
+          "access-control-allow-origin": appUrl,
+        },
+      });
+      return;
+    }
+    await route.continue();
+  });
+
   await page.goto(appUrl);
   await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+  await page.waitForFunction(() => {
+    const cached = localStorage.getItem("vm0:feature-switch-cache:v3");
+    if (cached === null) {
+      return false;
+    }
+    const parsed: unknown = JSON.parse(cached);
+    return (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "realAgentInPreview" in parsed &&
+      parsed.realAgentInPreview === true
+    );
+  });
 
   const composer = page.locator('[contenteditable="true"]').first();
   await expect(composer).toBeVisible({ timeout: 20_000 });
 
   const modelPicker = page.locator(".zero-composer").getByRole("combobox");
   await modelPicker.click();
-  await page.getByRole("option", { name: /^GPT 5\.6 Terra\b/ }).click();
+  await page.getByRole("option", { name: /^Claude Sonnet 5\b/ }).click();
   await expect(
     page
       .locator(".zero-composer")
-      .getByRole("combobox", { name: "GPT 5.6 Terra", exact: true }),
+      .getByRole("combobox", { name: "Claude Sonnet 5", exact: true }),
   ).toBeVisible();
 
-  const prompt = "Hello from Zero.";
+  await page.locator('input[type="file"]').first().setInputFiles({
+    name: attachmentName,
+    mimeType: "image/png",
+    buffer: attachmentImage,
+  });
+  await expect(page.getByLabel(`Remove ${attachmentName}`)).toBeVisible({
+    timeout: 20_000,
+  });
+
+  const prompt = "Reply with exactly: Hello from Zero. Do not use tools.";
   await composer.fill(prompt);
-  await page.getByRole("button", { name: "Send", exact: true }).click();
+  const [sendRequest] = await Promise.all([
+    page.waitForRequest((request) => {
+      return (
+        request.method() === "POST" &&
+        request.url() === new URL("/api/zero/chat/events", apiUrl).toString()
+      );
+    }),
+    page.getByRole("button", { name: "Send", exact: true }).click(),
+  ]);
+
+  const sendBody: unknown = JSON.parse(sendRequest.postData() ?? "null");
+  expect(sendBody).toMatchObject({ realAgentInPreview: true });
 
   const userMessage = page.locator('[data-role="user"]').last();
   await expect(userMessage.getByText(prompt, { exact: true })).toBeVisible({
     timeout: 10_000,
   });
-
-  await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
-    timeout: 120_000,
+  const attachmentLink = userMessage.getByRole("link", {
+    name: `Preview ${attachmentName}`,
   });
+  await expect(attachmentLink).toBeVisible();
+  const attachmentUrl = await attachmentLink.getAttribute("href");
+  if (attachmentUrl === null) {
+    throw new Error("Uploaded attachment URL is unavailable");
+  }
+  const attachmentResponse = await page.request.get(
+    new URL(attachmentUrl, appUrl).toString(),
+  );
+  expect(attachmentResponse.status()).toBe(200);
+  expect(attachmentResponse.headers()["content-type"]).toContain("image/png");
+
+  const assistantReply = page
+    .locator('[data-role="assistant"]:not([data-thinking-indicator])')
+    .locator(".zero-chat-bubble-assistant")
+    .filter({ hasText: /\S/u })
+    .last();
+  await expect(assistantReply).toBeVisible({ timeout: 120_000 });
+  await expect(assistantReply).not.toContainText("Oops, something went wrong");
+  await expect(
+    page.getByRole("button", { name: "Send", exact: true }),
+  ).toBeVisible();
 });


### PR DESCRIPTION
## Summary

- upload the Playwright attachment through the real signed PUT and verify the stored object is readable
- enable `realAgentInPreview` for the suite and explicitly select Claude Sonnet 5 for real-agent coverage
- align the dedicated Playwright staging runner config directory with its generated manifest and add a workflow regression test

## Why

The attachment request was previously acknowledged with a synthetic response, so the browser and runner could observe different storage state. The staging runner also wrote `runner.yaml` under `playwright-staging` while starting the service from the manifest-specific `staging-<sha>` directory.

## Validation

- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test`
- `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `bash .github/scripts/tests/runner-image-context-test.sh`
- ShellCheck for the changed runner scripts and tests
- Prettier for the changed TypeScript and workflow files

The hosted Playwright path is left to PR preview CI because it provides the isolated runner group, VM, credentials, and external model environment required for the real-agent test.