### PR TITLE
refactor(api): stop run lifecycle event dual-write

### DIFF
--- a/turbo/apps/api/src/scripts/__tests__/dev-bench-seed.test.ts
+++ b/turbo/apps/api/src/scripts/__tests__/dev-bench-seed.test.ts
@@ -69,6 +69,11 @@ describe("dev bench seed profile rows", () => {
         }),
       ).toBeFalsy();
       expect(
+        rows.eventRows.some((row) => {
+          return "runLifecycleEvent" in row;
+        }),
+      ).toBeFalsy();
+      expect(
         countWhere(rows.eventRows, (row) => {
           return chatEventCompatibilityRole(row.eventType) === "user";
         }),
@@ -85,12 +90,12 @@ describe("dev bench seed profile rows", () => {
       ).toBe(expected.nullRunEvents);
       expect(
         countWhere(rows.eventRows, (row) => {
-          return row.runLifecycleEvent === "completed";
+          return row.eventType === "run.completed";
         }),
       ).toBe(expected.completedLifecycleEvents);
       expect(
         countWhere(rows.eventRows, (row) => {
-          return row.runLifecycleEvent === "failed";
+          return row.eventType === "run.failed";
         }),
       ).toBe(expected.failedLifecycleEvents);
       expect(

--- a/turbo/apps/api/src/scripts/dev-bench-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-bench-seed.ts
@@ -31,7 +31,10 @@ type Database = ReturnType<typeof db>;
 type AgentRunInsert = typeof agentRuns.$inferInsert;
 type ZeroRunInsert = typeof zeroRuns.$inferInsert;
 type ChatEventInsert = typeof chatEvents.$inferInsert;
-type SeedChatEventRow = Omit<ChatEventInsert, "role" | "seqId"> & {
+type SeedChatEventRow = Omit<
+  ChatEventInsert,
+  "role" | "runLifecycleEvent" | "seqId"
+> & {
   id: string;
   createdAt: Date;
   sequenceNumber?: number | null;
@@ -797,7 +800,6 @@ function appendLifecycleEvent(args: {
     eventType: args.failed ? "run.failed" : "run.completed",
     content: null,
     error: args.failed ? "Synthetic benchmark failure" : null,
-    runLifecycleEvent: args.failed ? "failed" : "completed",
     createdAt: addMs(args.baseCreatedAt, 45_000 + args.eventCount * 100),
   });
 }

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -1,10 +1,7 @@
 /** Typed append-only commands for the canonical ChatEvent stream. */
 import { randomUUID } from "node:crypto";
 
-import {
-  chatEventRunLifecycle,
-  isValidChatEventRevocation,
-} from "@vm0/api-contracts/contracts/chat-events";
+import { isValidChatEventRevocation } from "@vm0/api-contracts/contracts/chat-events";
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import { chatAutomationContext } from "@vm0/db/schema/chat-automation-context";
 import { chatEventInputParams } from "@vm0/db/schema/chat-event-input-params";
@@ -293,7 +290,10 @@ interface ChatEventBatchCommandResult {
 type InsertChatEventConflict = "none" | "any" | "id" | "run-lifecycle";
 type InsertChatEventsConflict = "any" | "run-sequence";
 
-type PersistedChatEvent = Omit<ChatEventInsert, "role" | "seqId">;
+type PersistedChatEvent = Omit<
+  ChatEventInsert,
+  "role" | "runLifecycleEvent" | "seqId"
+>;
 
 type ChatEventContextPointer = Pick<
   ChatEventInsert,
@@ -631,7 +631,6 @@ function persistedChatEventValues(
     Pick<ChatEventInsert, "id" | "contextType" | "contextId">
   >,
 ): PersistedChatEvent {
-  const runLifecycleEvent = chatEventRunLifecycle(values.eventType);
   const { goalBrief: _goalBrief, ...persistedValues } = {
     goalBrief: undefined,
     ...values,
@@ -646,7 +645,6 @@ function persistedChatEventValues(
       ? { content: null }
       : {}),
     eventType: values.eventType,
-    ...(runLifecycleEvent === null ? {} : { runLifecycleEvent }),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
@@ -192,7 +192,7 @@ async function cancellationLifecyclePublished(
     .where(
       and(
         eq(chatEvents.runId, runId),
-        eq(chatEvents.runLifecycleEvent, "cancelled"),
+        eq(chatEvents.eventType, "run.cancelled"),
       ),
     )
     .limit(1);

--- a/turbo/packages/api-contracts/src/contracts/chat-events.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-events.ts
@@ -137,36 +137,6 @@ export function chatEventCompatibilityRole(
   }
 }
 
-export function chatEventRunLifecycle(
-  eventType: ChatEventType,
-): ChatEventRunLifecycle | null {
-  switch (eventType) {
-    case "run.completed":
-      return "completed";
-    case "run.failed":
-      return "failed";
-    case "run.cancelled":
-      return "cancelled";
-    case "input.prompt":
-    case "input.automation":
-    case "input.goal":
-    case "input.rejected":
-    case "output.message":
-    case "output.error":
-    case "output.thinking":
-    case "output.followups":
-    case "run.queued":
-    case "run.dequeued":
-    case "control.interrupt":
-    case "control.revoke":
-    case "browser.started":
-    case "browser.stopped":
-    case "goal.changed":
-    case "usage.recorded":
-      return null;
-  }
-}
-
 export function isChatRunTerminalEventType(
   eventType: ChatEventType,
 ): eventType is "run.completed" | "run.failed" | "run.cancelled" {

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -26,7 +26,6 @@ export {
 export {
   CHAT_EVENT_TYPES,
   chatEventCompatibilityRole,
-  chatEventRunLifecycle,
   chatEventTypeSchema,
   foldActiveChatGoalObjective,
   foldPendingChatQueueEvents,

--- a/turbo/packages/db/src/schema/chat-event.ts
+++ b/turbo/packages/db/src/schema/chat-event.ts
@@ -69,9 +69,9 @@ export function chatEventTerminalPredicate(eventType: SQLWrapper): SQL {
  * idempotent, lock-free inserts from both the event consumer and the callback's
  * final sweep.
  *
- * Terminal-state assistant rows carry `run_lifecycle_event` set to one of
- * `completed | failed | cancelled`. Exactly one such row exists per `run_id`;
- * the indicator and dim finish line are derived from this row.
+ * Terminal-state assistant rows use the `run.completed | run.failed |
+ * run.cancelled` event types. The legacy `run_lifecycle_event` column remains
+ * during rollout step 3, but new writers leave it null.
  *
  * Summaries (tool-use activity) are NOT stored here — the client fetches
  * them in real-time from the telemetry/logs endpoint for active runs.
@@ -128,7 +128,7 @@ export const chatEvents = pgTable(
     userMessage: jsonb("user_message").$type<ChatEventUserMessage>(),
     thinking: text("thinking"),
     error: text("error"),
-    /** "completed" | "failed" | "cancelled"; null for non-terminal rows. */
+    /** Legacy terminal marker retained through rollout step 3. */
     runLifecycleEvent: text("run_lifecycle_event"),
     sequenceNumber: integer("sequence_number"),
     runEventId: text("run_event_id"), // Anthropic message ID from event.message.id (e.g. "msg_01abc...")


### PR DESCRIPTION
## Summary

- complete step 3 of 4 in the `chat_events.run_lifecycle_event` retirement by stopping canonical API and dev-bench writers from populating the legacy column
- make cancellation recovery read the exact canonical predicate `event_type = 'run.cancelled'`; it intentionally does not use the broader terminal-event predicate
- remove the now-unused `chatEventRunLifecycle()` write helper while preserving the wire-level `runLifecycleEvent` field derived from canonical leaf events

This PR does not add a migration, drop the legacy column/indexes/FK, change the wire contract, or modify `zero-chat-thread.service.ts`.

## Rollout gate

The step-3 entry gate was verified before implementation:

- `api-v1.361.0` (contains R2) published at 2026-07-31 09:55:12 UTC
- a later DB wave, `db-v1.159.2`, published at 2026-07-31 10:48:38 UTC
- a later API wave, `api-v1.362.0`, published at 2026-07-31 11:54:09 UTC

This is the only rollout step with a real invariant window: once new writers leave `run_lifecycle_event` null, the old partial unique index no longer protects them. R2 must therefore be fully deployed and its rollback target drained before this writer switch.

## Repository sweep

A repository-wide rescan covered direct column references, value equality, `inArray`, and raw SQL.

- no production writer remains
- no active predicate reads `run_lifecycle_event`; cancellation recovery now uses exact `event_type = 'run.cancelled'`
- `zero-chat-thread.service.ts` retains the intentionally harmless select and wire derivation for Release 4
- one test-only conflicting-legacy-payload fixture remains to prove readers ignore the legacy value
- remaining raw SQL references are limited to immutable historical migrations and migration-consistency fixtures
- the schema column, `chat_events_run_lifecycle_unique`, `idx_chat_events_thread_run_finish_created`, and existing constraints/FKs remain in place

## PostgreSQL catalog preflight

Applied the complete migration chain to PostgreSQL 17.10 with pgvector, then inspected persisted dependencies on `public.chat_events.run_lifecycle_event`.

- functions: 0
- triggers: 0
- defaults: 0
- generated expressions: 0
- views/materialized views: 0
- rules: 0
- policies: 0

The column is nullable and has no default or generation expression. Both legacy indexes and both canonical `event_type` terminal indexes are present; table constraints and FKs are unchanged.

## Validation

- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/db lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/db check-types`
- targeted dev-bench integration test
- targeted cancellation lifecycle-first redrive integration test
- Prettier checks for all changed files
- `git diff --check`

The cancellation integration path produced exactly two canonical `run.cancelled` terminal rows, both with a null legacy marker, and no duplicate terminal run IDs. Standard Knip completed with the repository's existing baseline findings and reported no remaining reference to the removed helper.

## Release 4 gate and post-release verification

Release 4 remains a separate PR. Do not drop the legacy column or indexes until this release has fully rolled out and the rollback target that still writes the legacy marker has drained.

After deployment, verify:

- zero duplicate terminal events per run
- zero PostgreSQL `23505` conflicts for terminal-event uniqueness
- zero PostgreSQL `42P10` conflict-target errors

Refs #24215
Closes #24372