### PR TITLE
feat: fully enable deepseek v4 flash feature switch

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -30,6 +30,7 @@ describe("isFeatureEnabled", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.Dummy, { userId: "any-user" }),
     ).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.DeepSeekV4Flash, {})).toBe(true);
   });
 
   it("should return false for disabled switch without context", () => {
@@ -54,7 +55,6 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.ZeroChatMessaging, {})).toBe(
       false,
     );
-    expect(isFeatureEnabled(FeatureSwitchKey.DeepSeekV4Flash, {})).toBe(false);
   });
 
   it("should return false for disabled switch with non-matching userId", () => {
@@ -189,7 +189,7 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.StrapiIntegration]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.DeepSeekV4Flash]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.DeepSeekV4Flash]).toBe(true);
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -351,8 +351,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.DeepSeekV4Flash]: {
     maintainer: "ethan@vm0.ai",
     description: "Show DeepSeek V4 Flash in the workspace Add model selector.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@vm0.ai",


### PR DESCRIPTION
## Summary

Fully enable the `DeepSeekV4Flash` feature switch so `deepseek-v4-flash` appears in the workspace **Add model** selector for all orgs, instead of staff-only grayscale.

## Changes

- `turbo/packages/core/src/feature-switch.ts`: flip `DeepSeekV4Flash` from `enabled: false` + `STAFF_ORG_ID_HASHES` to `enabled: true`.
- `turbo/packages/core/src/__tests__/feature-switch.test.ts`: update assertions to reflect the new globally enabled default.

## Tests

Updated the core feature-switch unit tests; relies on the PR pipeline for checks.