### PR TITLE
perf(api): avoid locking unchanged chat threads

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -80,6 +80,7 @@ import {
   hasVm0ApiKeyLabel,
   holdChatEventFixture,
   holdChatEventQueueItemFixture,
+  holdChatThreadRowLockFixture,
   holdOrgAdmissionLockFixture,
   holdThreadSessionBindingClearFixture,
   holdThreadSessionConversationChangesFixture,
@@ -2453,6 +2454,39 @@ describe("CHAT-02: model-first provider policies", () => {
     await cancelChatRun(actor, run.runId);
   });
 
+  it("resolves an unchanged existing thread without waiting for its row lock", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    const thread = await chat.createThread(actor, { agentId });
+    const threadLock = await holdChatThreadRowLockFixture({
+      threadId: thread.id,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      threadLock.release();
+      await threadLock.done;
+    });
+
+    const sentPromise = sendChatRun(actor, {
+      agentId,
+      threadId: thread.id,
+      prompt: "continue without reconciling the thread model",
+    });
+    await expect.poll(threadLock.firstBlockedStatementKind).toBe("update");
+
+    threadLock.release();
+    const sent = await sentPromise;
+    await threadLock.done;
+    expect(apiDispatchTimingEventsForRun(sent.runId)).toContainEqual(
+      expect.objectContaining({
+        op_type:
+          "api_dispatch_pre_create_zero_web_chat_prepare_normal_send_resolve_thread",
+        model_resolution_path: "read_only",
+      }),
+    );
+    await cancelChatRun(actor, sent.runId);
+  }, 90_000);
+
   it("recovers a removed thread model through the current workspace route", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
@@ -2491,11 +2525,33 @@ describe("CHAT-02: model-first provider policies", () => {
       },
     ]);
 
-    const recovered = await sendChatRun(actor, {
+    const threadLock = await holdChatThreadRowLockFixture({
+      threadId: first.threadId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      threadLock.release();
+      await threadLock.done;
+    });
+    const recoveredPromise = sendChatRun(actor, {
       agentId,
       threadId: first.threadId,
       prompt: "continue through the current workspace default",
     });
+    await expect
+      .poll(threadLock.firstBlockedStatementKind)
+      .toBe("select_for_update");
+
+    threadLock.release();
+    const recovered = await recoveredPromise;
+    await threadLock.done;
+    expect(apiDispatchTimingEventsForRun(recovered.runId)).toContainEqual(
+      expect.objectContaining({
+        op_type:
+          "api_dispatch_pre_create_zero_web_chat_prepare_normal_send_resolve_thread",
+        model_resolution_path: "locked_reconciliation",
+      }),
+    );
     const recoveredClaim = await claimChatRun(runnerGroup, recovered.runId);
     expect(recoveredClaim.claim.cliAgentType).toBe("codex");
     expect(recoveredClaim.claim.resumeSession).toBeNull();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -970,6 +970,75 @@ describe("workflow queue", () => {
     ).resolves.toHaveLength(1);
   });
 
+  it("uses full PostgreSQL timestamp precision for workflow queue FIFO", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const firstBrief = "First precise workflow event";
+    const firstEventId = await admitPreviousDeploymentWorkflowEventFixture({
+      automationId: automation.automationId,
+      chatThreadId: automation.threadId,
+      agentId: scenario.agentId,
+      appendSystemPrompt: firstBrief,
+      triggerBrief: firstBrief,
+    });
+    const secondBrief = "Second precise workflow event";
+    const secondEventId = await admitPreviousDeploymentWorkflowEventFixture({
+      automationId: automation.automationId,
+      chatThreadId: automation.threadId,
+      agentId: scenario.agentId,
+      appendSystemPrompt: secondBrief,
+      triggerBrief: secondBrief,
+    });
+    const firstSortsBeforeSecond =
+      firstEventId.localeCompare(secondEventId) < 0;
+    const databaseFirst = firstSortsBeforeSecond
+      ? { id: secondEventId, brief: secondBrief }
+      : { id: firstEventId, brief: firstBrief };
+    const databaseSecond = firstSortsBeforeSecond
+      ? { id: firstEventId, brief: firstBrief }
+      : { id: secondEventId, brief: secondBrief };
+
+    // Both values become the same JavaScript Date. The database-first event
+    // deliberately has the lexicographically later UUID, so a millisecond
+    // conversion followed by an id sort would choose the wrong queue head.
+    await setWorkflowQueueEventCreatedAtFixture({
+      eventId: databaseFirst.id,
+      createdAt: "2019-12-31 23:54:00.000100",
+    });
+    await setWorkflowQueueEventCreatedAtFixture({
+      eventId: databaseSecond.id,
+      createdAt: "2019-12-31 23:54:00.000900",
+    });
+
+    const result = await postWorkflowWebhook(
+      automation,
+      "drain the precise workflow queue",
+    );
+    expectAcceptedWithoutRun(result);
+
+    const [runId] = await workflowRunIds(automation.threadId);
+    if (!runId) {
+      throw new Error(
+        "Expected the database-first queue event to create a run",
+      );
+    }
+    const claimedEvent = (await wf.readThreadEvents(automation.threadId)).find(
+      (event) => {
+        return event.runId === runId && event.eventType === "input.prompt";
+      },
+    );
+    expect(
+      claimedEvent
+        ? chatEventAutomationPart(claimedEvent)?.automationBrief
+        : undefined,
+    ).toBe(databaseFirst.brief);
+    expect(
+      (await pendingWorkflowEvents(automation.threadId)).map((event) => {
+        return event.id;
+      }),
+    ).toContain(databaseSecond.id);
+  });
+
   it("retries when an earlier workflow event becomes queue head during launch", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -970,6 +970,79 @@ describe("workflow queue", () => {
     ).resolves.toHaveLength(1);
   });
 
+  it("retries when an earlier workflow event becomes queue head during launch", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const originalEventId = await admitPreviousDeploymentWorkflowEventFixture({
+      automationId: automation.automationId,
+      chatThreadId: automation.threadId,
+      agentId: scenario.agentId,
+      appendSystemPrompt: "Original queued workflow event",
+      triggerBrief: "Original queued workflow event",
+    });
+    await setWorkflowQueueEventCreatedAtFixture({
+      eventId: originalEventId,
+      createdAt: new Date("2019-12-31T23:55:00.000Z"),
+    });
+
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: scenario.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+
+    const workflowRequest = postWorkflowWebhook(
+      automation,
+      "launch while queue head changes",
+    );
+    await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
+
+    const preemptingBrief = "Earlier workflow event admitted during launch";
+    const preemptingEventId = await admitPreviousDeploymentWorkflowEventFixture(
+      {
+        automationId: automation.automationId,
+        chatThreadId: automation.threadId,
+        agentId: scenario.agentId,
+        appendSystemPrompt: preemptingBrief,
+        triggerBrief: preemptingBrief,
+      },
+    );
+    await setWorkflowQueueEventCreatedAtFixture({
+      eventId: preemptingEventId,
+      createdAt: new Date("2019-12-31T23:54:00.000Z"),
+    });
+
+    admissionLock.release();
+    const result = await workflowRequest;
+    await admissionLock.done;
+    expectAcceptedWithoutRun(result);
+
+    const [runId] = await workflowRunIds(automation.threadId);
+    if (!runId) {
+      throw new Error("Expected the replacement queue head to create a run");
+    }
+    const claimedEvent = (await wf.readThreadEvents(automation.threadId)).find(
+      (event) => {
+        return event.runId === runId && event.eventType === "input.prompt";
+      },
+    );
+    expect(
+      claimedEvent
+        ? chatEventAutomationPart(claimedEvent)?.automationBrief
+        : undefined,
+    ).toBe(preemptingBrief);
+    const pendingEventIds = (
+      await pendingWorkflowEvents(automation.threadId)
+    ).map((event) => {
+      return event.id;
+    });
+    expect(pendingEventIds).toHaveLength(2);
+    expect(pendingEventIds).toContain(originalEventId);
+  });
+
   it("keeps claimed automation context after the automation is deleted", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);

--- a/turbo/apps/api/src/signals/routes/zero-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-events.ts
@@ -97,7 +97,9 @@ import {
 } from "../services/zero-model-selection.service";
 import {
   chatThreadModelPinColumns,
+  persistedChatThreadModelSnapshotColumns,
   resolvePersistedChatThreadModel,
+  type PersistedChatThreadModelResolutionPath,
 } from "../services/zero-chat-thread-model.service";
 import {
   touchChatThreadLastMessageAt,
@@ -231,6 +233,7 @@ interface ResolvedRunConfiguration {
 interface ResolvedThreadAndRunConfiguration {
   readonly thread: ResolvedThread;
   readonly runConfiguration: ResolvedRunConfiguration;
+  readonly modelResolutionPath?: PersistedChatThreadModelResolutionPath;
 }
 
 type IncomingModelSelection = NormalSendBody["modelSelection"];
@@ -1491,6 +1494,7 @@ async function resolveThread(params: {
       id: chatThreads.id,
       computerUseHostId: chatThreads.computerUseHostId,
       cloudBrowserEnabled: chatThreads.cloudBrowserEnabled,
+      ...persistedChatThreadModelSnapshotColumns(),
     })
     .from(chatThreads)
     .where(
@@ -1505,12 +1509,16 @@ async function resolveThread(params: {
   }
 
   let runConfiguration = params.explicitRunConfiguration;
+  let persistedModelResolutionPath:
+    | PersistedChatThreadModelResolutionPath
+    | undefined;
   if (!runConfiguration) {
     const persisted = await resolvePersistedChatThreadModel({
       db: params.db,
       orgId: params.orgId,
       userId: params.userId,
       threadId: thread.id,
+      threadSnapshot: thread,
       requestedCodexServiceTier: params.requestedCodexServiceTier,
       persistRequestedCodexServiceTier: params.persistRequestedCodexServiceTier,
       codexFastModeEnabled: params.codexFastModeEnabled,
@@ -1526,6 +1534,7 @@ async function resolveThread(params: {
       providerAdmission: persisted.providerAdmission,
       codexServiceTier: persisted.runCodexServiceTier,
     };
+    persistedModelResolutionPath = persisted.resolutionPath;
   }
 
   const [sessionResolution, incompleteContext] = await Promise.all([
@@ -1556,6 +1565,9 @@ async function resolveThread(params: {
       isClientThreadRetry: false,
     },
     runConfiguration,
+    ...(persistedModelResolutionPath
+      ? { modelResolutionPath: persistedModelResolutionPath }
+      : {}),
   };
 }
 
@@ -2251,12 +2263,13 @@ function resolveTimedThread(
   explicitRunConfiguration: ResolvedRunConfiguration | undefined,
   featureSwitches: NormalSendFeatureSwitches,
 ): ReturnType<typeof resolveThread> {
+  let modelResolutionPath: PersistedChatThreadModelResolutionPath | undefined;
   return measureApiDispatchTiming(
     args.timing,
     "api_dispatch_pre_create_zero_web_chat_prepare_normal_send_resolve_thread",
     "nested",
-    () => {
-      return resolveThread({
+    async () => {
+      const resolved = await resolveThread({
         db,
         orgId: args.orgId,
         userId: args.userId,
@@ -2274,6 +2287,15 @@ function resolveTimedThread(
         userMessageInlineTemplatesEnabled:
           featureSwitches.userMessageInlineTemplatesEnabled,
       });
+      if (!("status" in resolved)) {
+        modelResolutionPath = resolved.modelResolutionPath;
+      }
+      return resolved;
+    },
+    () => {
+      return modelResolutionPath
+        ? { model_resolution_path: modelResolutionPath }
+        : undefined;
     },
   );
 }

--- a/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
@@ -1,7 +1,15 @@
-import { foldPendingChatQueueEvents } from "@vm0/api-contracts/contracts/chat-events";
 import { chatEvents } from "@vm0/db/schema/chat-event";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
-import { and, asc, eq, isNull, lt, notExists } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  isNull,
+  lt,
+  notExists,
+  sql,
+  type SQL,
+} from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
 import type { Db } from "../external/db";
@@ -36,11 +44,21 @@ export function pendingChatQueueEventCondition(db: ChatQueueReadDb) {
   );
 }
 
+export function chatQueueEventPriority(): SQL {
+  return sql`CASE ${chatEvents.eventType}
+    WHEN 'input.prompt' THEN 0
+    WHEN 'input.automation' THEN 1
+    WHEN 'input.goal' THEN 2
+    ELSE 3
+  END`;
+}
+
 /**
- * Fold one thread's immutable input events into its pending queue. User input
- * keeps absolute priority over automation input, automation stays ahead of
- * goal continuation, then each class is FIFO by the original event timestamp
- * and id.
+ * List one thread's pending queue in its authoritative database order. User
+ * input keeps absolute priority over automation input, automation stays ahead
+ * of goal continuation, then each class is FIFO by the original event
+ * timestamp and id. Keep the sort in PostgreSQL so sub-millisecond timestamp
+ * precision matches the final queue-claim queries.
  */
 export async function listPendingChatQueueEvents(
   db: ChatQueueReadDb,
@@ -52,7 +70,6 @@ export async function listPendingChatQueueEvents(
       id: chatEvents.id,
       chatThreadId: chatEvents.chatThreadId,
       eventType: chatEvents.eventType,
-      runId: chatEvents.runId,
       createdAt: chatEvents.createdAt,
     })
     .from(chatEvents)
@@ -63,17 +80,13 @@ export async function listPendingChatQueueEvents(
         createdBefore ? lt(chatEvents.createdAt, createdBefore) : undefined,
       ),
     )
-    .orderBy(asc(chatEvents.createdAt), asc(chatEvents.id));
+    .orderBy(
+      chatQueueEventPriority(),
+      asc(chatEvents.createdAt),
+      asc(chatEvents.id),
+    );
 
-  const folded = foldPendingChatQueueEvents(
-    rows.map((row) => {
-      return {
-        ...row,
-        createdAt: row.createdAt.toISOString(),
-      };
-    }),
-  );
-  return folded.flatMap((event) => {
+  return rows.flatMap((event) => {
     if (
       event.eventType !== "input.prompt" &&
       event.eventType !== "input.automation" &&
@@ -86,7 +99,7 @@ export async function listPendingChatQueueEvents(
         id: event.id,
         chatThreadId: event.chatThreadId,
         eventType: event.eventType,
-        createdAt: new Date(event.createdAt),
+        createdAt: event.createdAt,
       },
     ];
   });

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -40,6 +40,7 @@ import {
 } from "../../lib/db-structured-result";
 import { db$, type Db } from "../external/db";
 import {
+  chatQueueEventPriority,
   listPendingChatQueueEvents,
   loadPendingChatQueueEvent,
   lockChatQueueThread,
@@ -423,15 +424,6 @@ interface QueueFirstClaimSnapshot {
   readonly replacement: NewChatEvent;
 }
 
-function queueFirstHeadPriority(): SQL {
-  return sql`CASE ${chatEvents.eventType}
-    WHEN 'input.prompt' THEN 0
-    WHEN 'input.automation' THEN 1
-    WHEN 'input.goal' THEN 2
-    ELSE 3
-  END`;
-}
-
 function replacementTargetFromQueueHead(
   head: LoadedChatEventReplacementTarget,
 ): LoadedChatEventReplacementTarget {
@@ -470,7 +462,7 @@ async function resolveUserQueueFirstClaimSnapshot(
       ),
     )
     .orderBy(
-      queueFirstHeadPriority(),
+      chatQueueEventPriority(),
       asc(chatEvents.createdAt),
       asc(chatEvents.id),
     )
@@ -537,7 +529,7 @@ async function resolveWorkflowQueueFirstClaimSnapshot(
       ),
     )
     .orderBy(
-      queueFirstHeadPriority(),
+      chatQueueEventPriority(),
       asc(chatEvents.createdAt),
       asc(chatEvents.id),
     )
@@ -627,7 +619,7 @@ async function resolveGoalQueueFirstClaimSnapshot(
       ),
     )
     .orderBy(
-      queueFirstHeadPriority(),
+      chatQueueEventPriority(),
       asc(chatEvents.createdAt),
       asc(chatEvents.id),
     )

--- a/turbo/apps/api/src/signals/services/zero-chat-thread-model.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread-model.service.ts
@@ -47,13 +47,25 @@ interface ResolvePersistedChatThreadModelParams {
   readonly orgId: string;
   readonly userId: string;
   readonly threadId: string;
+  readonly threadSnapshot?: PersistedChatThreadModelSnapshot;
   readonly fallbackSelectedModel?: string | null;
   readonly requestedCodexServiceTier?: CodexServiceTier;
   readonly persistRequestedCodexServiceTier: boolean;
   readonly codexFastModeEnabled: boolean;
 }
 
-interface LockedChatThreadModel {
+export function persistedChatThreadModelSnapshotColumns() {
+  return {
+    selectedModel: chatThreads.selectedModel,
+    modelProviderId: chatThreads.modelProviderId,
+    modelProviderType: chatThreads.modelProviderType,
+    modelProviderCredentialScope: chatThreads.modelProviderCredentialScope,
+    codexServiceTier: chatThreads.codexServiceTier,
+    agentComposeId: chatThreads.agentComposeId,
+  };
+}
+
+interface PersistedChatThreadModelSnapshot {
   readonly selectedModel: string | null;
   readonly modelProviderId: string | null;
   readonly modelProviderType: string | null;
@@ -62,13 +74,38 @@ interface LockedChatThreadModel {
   readonly agentComposeId: string;
 }
 
+export type PersistedChatThreadModelResolutionPath =
+  | "read_only"
+  | "locked_reconciliation";
+
 export interface ResolvedPersistedChatThreadModel {
   readonly pin: ModelFirstPin;
   readonly providerAdmission: ModelFirstProviderAdmission;
   readonly runCodexServiceTier: "fast" | undefined;
   readonly persistedCodexServiceTier: CodexServiceTier | null;
   readonly selectedModelChanged: boolean;
+  readonly resolutionPath: PersistedChatThreadModelResolutionPath;
 }
+
+interface PersistedChatThreadModelEvaluation {
+  readonly pin: ModelFirstPin;
+  readonly providerAdmission: ModelFirstProviderAdmission;
+  readonly runCodexServiceTier: "fast" | undefined;
+  readonly persistedCodexServiceTier: CodexServiceTier | null;
+  readonly selectedModelChanged: boolean;
+  readonly tierChanged: boolean;
+  readonly requiresReconciliation: boolean;
+}
+
+type PersistedChatThreadModelEvaluationResult =
+  | {
+      readonly kind: "resolved";
+      readonly evaluation: PersistedChatThreadModelEvaluation;
+    }
+  | {
+      readonly kind: "error";
+      readonly error: ReturnType<typeof badRequestMessage>;
+    };
 
 interface PersistedChatThreadModelTransactionResult {
   readonly resolved:
@@ -104,16 +141,9 @@ function transactionResultWithoutPublish(
 async function loadLockedChatThreadModel(
   tx: ChatThreadModelTransaction,
   params: Pick<ResolvePersistedChatThreadModelParams, "threadId" | "userId">,
-): Promise<LockedChatThreadModel | undefined> {
+): Promise<PersistedChatThreadModelSnapshot | undefined> {
   const [thread] = await tx
-    .select({
-      selectedModel: chatThreads.selectedModel,
-      modelProviderId: chatThreads.modelProviderId,
-      modelProviderType: chatThreads.modelProviderType,
-      modelProviderCredentialScope: chatThreads.modelProviderCredentialScope,
-      codexServiceTier: chatThreads.codexServiceTier,
-      agentComposeId: chatThreads.agentComposeId,
-    })
+    .select(persistedChatThreadModelSnapshotColumns())
     .from(chatThreads)
     .where(
       and(
@@ -123,6 +153,23 @@ async function loadLockedChatThreadModel(
     )
     .limit(1)
     .for("update");
+  return thread;
+}
+
+async function loadChatThreadModel(
+  db: Db,
+  params: Pick<ResolvePersistedChatThreadModelParams, "threadId" | "userId">,
+): Promise<PersistedChatThreadModelSnapshot | undefined> {
+  const [thread] = await db
+    .select(persistedChatThreadModelSnapshotColumns())
+    .from(chatThreads)
+    .where(
+      and(
+        eq(chatThreads.id, params.threadId),
+        eq(chatThreads.userId, params.userId),
+      ),
+    )
+    .limit(1);
   return thread;
 }
 
@@ -168,7 +215,9 @@ function resolveCodexTier(args: {
   };
 }
 
-function legacyProviderPinPresent(thread: LockedChatThreadModel): boolean {
+function legacyProviderPinPresent(
+  thread: PersistedChatThreadModelSnapshot,
+): boolean {
   return (
     thread.modelProviderId !== null ||
     thread.modelProviderType !== null ||
@@ -179,7 +228,7 @@ function legacyProviderPinPresent(thread: LockedChatThreadModel): boolean {
 async function persistReconciledChatThreadModel(args: {
   readonly tx: ChatThreadModelTransaction;
   readonly params: ResolvePersistedChatThreadModelParams;
-  readonly thread: LockedChatThreadModel;
+  readonly thread: PersistedChatThreadModelSnapshot;
   readonly pin: ModelFirstPin;
   readonly persistedCodexServiceTier: CodexServiceTier | null;
   readonly selectedModelChanged: boolean;
@@ -233,27 +282,24 @@ async function persistReconciledChatThreadModel(args: {
   }
 }
 
-async function resolvePersistedChatThreadModelInTransaction(
-  tx: ChatThreadModelTransaction,
+async function evaluatePersistedChatThreadModel(
+  db: Db,
   params: ResolvePersistedChatThreadModelParams,
-): Promise<PersistedChatThreadModelTransactionResult> {
-  const thread = await loadLockedChatThreadModel(tx, params);
-  if (!thread) {
-    return transactionResultWithoutPublish(null);
-  }
-
+  thread: PersistedChatThreadModelSnapshot,
+): Promise<PersistedChatThreadModelEvaluationResult> {
   const modelResolution = await resolvePersistedModelFirstRoute({
-    db: tx,
+    db,
     orgId: params.orgId,
     userId: params.userId,
     selectedModel: thread.selectedModel ?? params.fallbackSelectedModel ?? null,
   });
   if (!modelResolution.route) {
-    return transactionResultWithoutPublish(
-      badRequestMessage(
+    return {
+      kind: "error",
+      error: badRequestMessage(
         "No valid model route is configured for this workspace",
       ),
-    );
+    };
   }
 
   const pin: ModelFirstPin = {
@@ -264,7 +310,7 @@ async function resolvePersistedChatThreadModelInTransaction(
     selectedModel: modelResolution.route.selectedModel,
   };
   const providerAdmission = await resolveModelFirstProviderAdmission({
-    db: tx,
+    db,
     orgId: params.orgId,
     userId: params.userId,
     modelPin: pin,
@@ -285,28 +331,72 @@ async function resolvePersistedChatThreadModelInTransaction(
     selectedModelChanged,
   });
   if (tier.kind === "error") {
-    return transactionResultWithoutPublish(tier.error);
+    return { kind: "error", error: tier.error };
   }
 
-  await persistReconciledChatThreadModel({
-    tx,
-    params,
-    thread,
-    pin,
-    persistedCodexServiceTier: tier.persistedCodexServiceTier,
-    selectedModelChanged,
-    tierChanged: tier.tierChanged,
-  });
   return {
-    resolved: {
+    kind: "resolved",
+    evaluation: {
       pin,
       providerAdmission,
       runCodexServiceTier: tier.runCodexServiceTier,
       persistedCodexServiceTier: tier.persistedCodexServiceTier,
       selectedModelChanged,
+      tierChanged: tier.tierChanged,
+      requiresReconciliation:
+        selectedModelChanged ||
+        tier.tierChanged ||
+        legacyProviderPinPresent(thread),
     },
-    publishThreadList: selectedModelChanged || tier.tierChanged,
-    publishThreadDetail: tier.tierChanged,
+  };
+}
+
+function resolvedPersistedChatThreadModel(
+  evaluation: PersistedChatThreadModelEvaluation,
+  resolutionPath: PersistedChatThreadModelResolutionPath,
+): ResolvedPersistedChatThreadModel {
+  return {
+    pin: evaluation.pin,
+    providerAdmission: evaluation.providerAdmission,
+    runCodexServiceTier: evaluation.runCodexServiceTier,
+    persistedCodexServiceTier: evaluation.persistedCodexServiceTier,
+    selectedModelChanged: evaluation.selectedModelChanged,
+    resolutionPath,
+  };
+}
+
+async function resolvePersistedChatThreadModelInTransaction(
+  tx: ChatThreadModelTransaction,
+  params: ResolvePersistedChatThreadModelParams,
+): Promise<PersistedChatThreadModelTransactionResult> {
+  const thread = await loadLockedChatThreadModel(tx, params);
+  if (!thread) {
+    return transactionResultWithoutPublish(null);
+  }
+
+  const evaluated = await evaluatePersistedChatThreadModel(tx, params, thread);
+  if (evaluated.kind === "error") {
+    return transactionResultWithoutPublish(evaluated.error);
+  }
+  const { evaluation } = evaluated;
+
+  await persistReconciledChatThreadModel({
+    tx,
+    params,
+    thread,
+    pin: evaluation.pin,
+    persistedCodexServiceTier: evaluation.persistedCodexServiceTier,
+    selectedModelChanged: evaluation.selectedModelChanged,
+    tierChanged: evaluation.tierChanged,
+  });
+  return {
+    resolved: resolvedPersistedChatThreadModel(
+      evaluation,
+      "locked_reconciliation",
+    ),
+    publishThreadList:
+      evaluation.selectedModelChanged || evaluation.tierChanged,
+    publishThreadDetail: evaluation.tierChanged,
   };
 }
 
@@ -315,6 +405,27 @@ export async function resolvePersistedChatThreadModel(
 ): Promise<
   ResolvedPersistedChatThreadModel | ReturnType<typeof badRequestMessage> | null
 > {
+  const thread =
+    params.threadSnapshot ?? (await loadChatThreadModel(params.db, params));
+  if (!thread) {
+    return null;
+  }
+  const evaluated = await evaluatePersistedChatThreadModel(
+    params.db,
+    params,
+    thread,
+  );
+  if (evaluated.kind === "error") {
+    return evaluated.error;
+  }
+  // An optimistic snapshot is authoritative only when this send writes
+  // nothing back to the thread.
+  if (!evaluated.evaluation.requiresReconciliation) {
+    return resolvedPersistedChatThreadModel(evaluated.evaluation, "read_only");
+  }
+
+  // Discard every optimistic decision before a possible write so a concurrent
+  // explicit model or tier update cannot be restored from the stale snapshot.
   const result = await params.db.transaction((tx) => {
     return resolvePersistedChatThreadModelInTransaction(tx, params);
   });

--- a/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
@@ -24,8 +24,8 @@ import {
 
 const log = logger("ZeroWorkflowQueueDrain");
 
-// Consecutive stale events (deleted/disabled automations) skipped per drain call
-// before giving up; a successful run creation always stops the loop.
+// Consecutive stale events or claims invalidated by concurrent queue changes
+// are retried per drain call; a successful run creation always stops the loop.
 const MAX_DRAIN_ATTEMPTS = 5;
 
 interface DequeueTarget {
@@ -126,9 +126,13 @@ async function handleWorkflowLaunchResult(
   launchHint: WorkflowEventLaunch | undefined,
   signal: AbortSignal,
 ): Promise<WorkflowQueueDrainStep> {
-  if (result.kind === "ok" || result.kind === "enqueued") {
+  if (result.kind === "ok") {
     await publishQueueEventChanged(event, signal);
     return { eventId: event.id, result };
+  }
+  if (result.kind === "enqueued") {
+    await publishQueueEventChanged(event, signal);
+    return CONTINUE_DRAIN;
   }
   if (result.kind === "conflict") {
     log.debug("Consuming unfireable workflow queue event", {

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -41,6 +41,9 @@ const VM0_BDD_API_KEY_PREFIXES = [
 const databasePidRowSchema = z.object({ pid: z.int() });
 const waiterCountRowSchema = z.object({ waiterCount: z.int() });
 const blockedByPidRowSchema = z.object({ blocked: z.boolean() });
+const blockedQueryRowSchema = z.object({ query: z.string() });
+
+type ChatThreadBlockedStatementKind = "select_for_update" | "update" | "other";
 
 interface ChatEventInputParamsFixture {
   readonly eventId: string;
@@ -662,6 +665,91 @@ async function directBlockedWaiterCount(holderPid: number): Promise<number> {
     waiterCountRowSchema,
   );
   return rows[0]?.waiterCount ?? 0;
+}
+
+async function firstDirectBlockedStatementKind(
+  holderPid: number,
+): Promise<ChatThreadBlockedStatementKind | null> {
+  const rows = await executeRawRows(
+    db(),
+    sql`
+      SELECT activity.query AS "query"
+      FROM pg_stat_activity AS activity
+      WHERE ${holderPid} = ANY(pg_blocking_pids(activity.pid))
+      ORDER BY activity.query_start, activity.pid
+      LIMIT 1
+    `,
+    blockedQueryRowSchema,
+  );
+  const query = rows[0]?.query.toLowerCase().replaceAll(/\s+/g, " ").trim();
+  if (!query) {
+    return null;
+  }
+  if (
+    query.startsWith("select") &&
+    query.includes('from "chat_threads"') &&
+    query.includes("for update")
+  ) {
+    return "select_for_update";
+  }
+  if (query.startsWith('update "chat_threads"')) {
+    return "update";
+  }
+  return "other";
+}
+
+/**
+ * Holds one thread row so route tests can observe the first product statement
+ * that requires a write-oriented lock. Product APIs cannot pause at this
+ * boundary, and the fixture does not change the held row.
+ */
+export async function holdChatThreadRowLockFixture(args: {
+  readonly threadId: string;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly release: () => void;
+  readonly done: Promise<void>;
+  readonly firstBlockedStatementKind: () => Promise<ChatThreadBlockedStatementKind | null>;
+}> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const [thread] = await tx
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, args.threadId))
+      .for("update")
+      .limit(1);
+    if (!thread) {
+      throw new Error("Expected the chat thread row");
+    }
+    const pidRows = await executeRawRows(
+      tx,
+      sql`
+        SELECT pg_backend_pid() AS "pid"
+      `,
+      databasePidRowSchema,
+    );
+    const holderPid = pidRows[0]?.pid;
+    if (!holderPid) {
+      throw new Error("Expected the chat thread lock holder pid");
+    }
+    started.resolve(holderPid);
+    await released.promise;
+  });
+  const holderPid = await started.promise;
+
+  return {
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+    done,
+    firstBlockedStatementKind: async () => {
+      return await firstDirectBlockedStatementKind(holderPid);
+    },
+  };
 }
 
 async function pidIsBlocked(waiterPid: number): Promise<boolean> {

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -475,17 +475,22 @@ export async function replayPendingChatInputQueueEventFixture(args: {
 
 /**
  * Move one exact workflow event into historical state without waiting for real
- * time to pass. Product APIs cannot construct an already-stale queue item.
+ * time to pass. A string preserves PostgreSQL precision beyond JavaScript
+ * milliseconds. Product APIs cannot construct an already-stale queue item.
  */
 export async function setWorkflowQueueEventCreatedAtFixture(args: {
   readonly eventId: string;
-  readonly createdAt: Date;
+  readonly createdAt: Date | string;
 }): Promise<void> {
+  const createdAt =
+    typeof args.createdAt === "string"
+      ? sql`CAST(${args.createdAt} AS timestamp)`
+      : args.createdAt;
   const updated = await db().transaction(async (tx) => {
     await tx.execute(sql`SET LOCAL session_replication_role = replica`);
     return await tx
       .update(chatEvents)
-      .set({ createdAt: args.createdAt })
+      .set({ createdAt })
       .where(
         and(
           eq(chatEvents.id, args.eventId),

--- a/turbo/apps/api/src/test-fixtures/workflow-queue.ts
+++ b/turbo/apps/api/src/test-fixtures/workflow-queue.ts
@@ -29,7 +29,7 @@ interface PreviousDeploymentWorkflowEventArgs {
  */
 export async function admitPreviousDeploymentWorkflowEventFixture(
   args: PreviousDeploymentWorkflowEventArgs,
-): Promise<void> {
+): Promise<string> {
   const [row] = await db()
     .select({
       automation: zeroWorkflowAutomations,
@@ -73,4 +73,5 @@ export async function admitPreviousDeploymentWorkflowEventFixture(
       `Expected the previous-deployment event to be inserted, got ${admission.kind}`,
     );
   }
+  return admission.eventId;
 }


### PR DESCRIPTION
## Summary

- reuse the existing-thread snapshot to resolve unchanged persisted model configuration without a `chat_threads` row lock
- re-read and recompute model routing, provider admission, credits, and tier under `FOR UPDATE` before any reconciliation write
- record the fixed `model_resolution_path` timing dimension and cover both lock paths with real-database integration tests
- keep workflow queue reads and final claims on the same PostgreSQL ordering, and retry bounded claim losses when concurrent admission changes the queue head

## Compatibility

- no schema, migration, public API, queue payload, frontend, runner, or guest changes
- existing session resolution and final launch validation remain unchanged
- reconciliation keeps the existing lock-before-write behavior for mixed-version API deployments
- queue priority remains user input, workflow automation, then goal continuation; only precision and progress under contention are corrected

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api build`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts src/signals/routes/__tests__/chat-callbacks.bdd.test.ts src/signals/routes/__tests__/zero-goals.test.ts src/signals/routes/__tests__/zero-workflow-automations.test.ts src/signals/routes/__tests__/zero-workflow-queue.test.ts --maxWorkers=1 --silent=passed-only` (188 passed)
- repeated concurrent workflow admission stability runs
- `pnpm knip`
- pre-commit repository type checks

Closes #24300

Parent: #24203
