### PR TITLE
chore(api): validate drizzle decoder provenance

### DIFF
--- a/.claude/skills/database-development/SKILL.md
+++ b/.claude/skills/database-development/SKILL.md
@@ -110,6 +110,14 @@ not add or replace its decoder. A PostgreSQL cast such as `::int` changes the
 server-side value representation, while `.mapWith(...)` defines the client-side
 runtime decoder. A TypeScript assertion changes neither one.
 
+Use only statically inspectable decoder provenance in `.mapWith(...)`: a real
+schema column, a reviewed decoder from `db-structured-result.ts`, or a decoder
+constructed through its Zod, enum, or nullable factories. Immutable local
+`const` alias chains may preserve that provenance. Built-in coercers such as
+`Number` and `String`, inline callbacks, assertions, mutable aliases, and opaque
+values declared as `DriverValueDecoder` do not establish a reviewed runtime
+contract and are rejected by lint.
+
 The same rule applies to `db.query.<table>.findMany(...)` and
 `findFirst(...)`, including callback-form `extras` and `extras` nested below
 `with`. Keep relational configs inline or in inspectable local variables so

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -10,7 +10,7 @@ import { delay } from "signal-timers";
 import { describe, expect, it } from "vitest";
 
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
-import { now } from "../../../lib/time";
+import { now, withMockNowForTest } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-context";
 import {
   createBddApi,
@@ -173,6 +173,26 @@ async function completeRun(
     headers,
     [200],
   );
+}
+
+async function completeRunAfter(
+  actor: ApiTestUser,
+  runId: string,
+  durationMs: number,
+): Promise<void> {
+  const detail = await api.requestReadRun(actor, runId, [200]);
+  mustOk(detail, "claimed run detail");
+  const startedAt = detail.body.startedAt;
+  if (typeof startedAt !== "string") {
+    throw new Error("Claimed run is missing its start time");
+  }
+  const startedAtMs = Date.parse(startedAt);
+  if (!Number.isFinite(startedAtMs)) {
+    throw new Error("Claimed run has an invalid start time");
+  }
+  await withMockNowForTest(startedAtMs + durationMs, async () => {
+    await completeRun(runId, api.sandboxTokenForRun(actor, runId));
+  });
 }
 
 describe("RUN-03/RUN-04: run read surface auth matrix", () => {
@@ -464,6 +484,56 @@ describe("RUN-03/RUN-04: direct run list, detail, and queue reads", () => {
     const drained = await api.readRunQueue(actor);
     expect(drained.body.concurrency.active).toBe(0);
     expect(drained.body.queue).toStrictEqual([]);
+  });
+
+  it("returns validated run duration estimates across the numeric domain", async () => {
+    const actor = await entitledActor();
+    const compose = await createClaudeCompose(actor, "bdd-duration-estimate");
+
+    const emptyQueue = await api.readRunQueue(actor);
+    expect(emptyQueue.body.estimatedTimePerRun).toBeNull();
+
+    const zeroRun = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "zero duration estimate",
+    });
+    await api.claimRunnerJob(zeroRun.runId);
+    await completeRunAfter(actor, zeroRun.runId, 0);
+    const zeroQueue = await api.readRunQueue(actor);
+    expect(zeroQueue.body.estimatedTimePerRun).toBe(0);
+
+    const fractionalRun = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "fractional average estimate",
+    });
+    await api.claimRunnerJob(fractionalRun.runId);
+    await completeRunAfter(actor, fractionalRun.runId, 1);
+    const fractionalQueue = await api.readRunQueue(actor);
+    expect(fractionalQueue.body.estimatedTimePerRun).toBe(1);
+
+    const normalRun = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "normal duration estimate",
+    });
+    await api.claimRunnerJob(normalRun.runId);
+    await completeRunAfter(actor, normalRun.runId, 2999);
+    const normalQueue = await api.readRunQueue(actor);
+    expect(normalQueue.body.estimatedTimePerRun).toBe(1000);
+
+    const largeActor = await entitledActor();
+    const largeCompose = await createClaudeCompose(
+      largeActor,
+      "bdd-large-duration-estimate",
+    );
+    const largeRun = await api.createDirectRun(largeActor, {
+      agentComposeId: largeCompose.composeId,
+      prompt: "large duration estimate",
+    });
+    await api.claimRunnerJob(largeRun.runId);
+    const largeDurationMs = 200_000_000_000_000;
+    await completeRunAfter(largeActor, largeRun.runId, largeDurationMs);
+    const largeQueue = await api.readRunQueue(largeActor);
+    expect(largeQueue.body.estimatedTimePerRun).toBe(largeDurationMs);
   });
 });
 

--- a/turbo/apps/api/src/signals/services/zero-runs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs.service.ts
@@ -33,7 +33,12 @@ import {
   or,
   sql,
 } from "drizzle-orm";
+import { z } from "zod";
 
+import {
+  nullableDriverValueDecoder,
+  zodDriverValueDecoder,
+} from "../../lib/db-structured-result";
 import { now } from "../../lib/time";
 import { db$, type Db } from "../external/db";
 import { activePendingRunPredicate } from "./agent-run-activity.service";
@@ -47,6 +52,15 @@ import { loadOrgPlanCapabilities } from "./org-plan-entitlement-read.service";
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
 const RECENT_RUNS_FOR_ETA = 10;
 const PROMPT_TRUNCATE_LENGTH = 200;
+const runDurationMillisecondsDecoder = zodDriverValueDecoder(
+  z
+    .string()
+    .regex(/^(?:0|[1-9]\d*)(?:\.\d+)?$/)
+    .transform((value) => {
+      return Number(value);
+    })
+    .pipe(z.number().finite().nonnegative().max(Number.MAX_SAFE_INTEGER)),
+);
 type ReadDb = Pick<Db, "select">;
 type QueueItem = QueueResponse["queue"][number];
 type RunningTaskItem = QueueResponse["runningTasks"][number];
@@ -157,7 +171,7 @@ async function estimatedTimePerRun(
     .select({
       durationMs:
         sql`EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000`
-          .mapWith(Number)
+          .mapWith(runDurationMillisecondsDecoder)
           .as("duration_ms"),
     })
     .from(agentRuns)
@@ -173,9 +187,16 @@ async function estimatedTimePerRun(
     .limit(RECENT_RUNS_FOR_ETA)
     .as("recent_runs");
   const [etaResult] = await db
-    .select({ avgMs: avg(recentRuns.durationMs) })
+    .select({
+      avgMs: avg(recentRuns.durationMs).mapWith(
+        nullableDriverValueDecoder(runDurationMillisecondsDecoder),
+      ),
+    })
     .from(recentRuns);
-  return etaResult?.avgMs ? Math.round(Number(etaResult.avgMs)) : null;
+  const averageMs = etaResult?.avgMs;
+  return averageMs === null || averageMs === undefined
+    ? null
+    : Math.round(averageMs);
 }
 
 async function userEmailMap(

--- a/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
@@ -596,6 +596,32 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
     },
     {
       code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const assertedContainer = {} as {
+          readonly decoder: typeof users.name;
+        };
+        const assertedTable = {} as typeof users;
+        db.select({
+          value: sql\`'value'\`.mapWith(assertedContainer.decoder),
+          tableValue: sql\`'value'\`.mapWith(assertedTable.name),
+        });
+      `,
+      errors: [
+        { messageId: "uninspectableResultDecoder" },
+        { messageId: "uninspectableResultDecoder" },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type DriverValueDecoder } from "drizzle-orm";
+        const first: DriverValueDecoder<string, unknown> = second;
+        const second: DriverValueDecoder<string, unknown> = first;
+        db.select({ value: sql\`'value'\`.mapWith(first) });
+      `,
+      errors: [{ messageId: "uninspectableResultDecoder" }],
+    },
+    {
+      code: `${drizzlePreamble}
         import { sql, type DriverValueDecoder } from "drizzle-orm";
         import { pgTextDecoder } from
           "../../apps/api/src/lib/db-structured-result";

--- a/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
@@ -94,6 +94,69 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
     {
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
+        const nameDecoder = users.name;
+        const chainedDecoder = nameDecoder;
+        db.select({
+          value: sql\`upper(\${users.name})\`.mapWith(chainedDecoder),
+        });
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        import { z } from "zod";
+        import {
+          pgTextDecoder,
+          pgTextDecoder as textDecoder,
+          zodDriverValueDecoder as makeDecoder,
+        } from "../../apps/api/src/lib/db-structured-result";
+        import * as structuredResult from
+          "../../apps/api/src/lib/db-structured-result";
+
+        const directAlias = textDecoder;
+        const chainedAlias = directAlias;
+        const parsedDecoder = makeDecoder(z.string());
+        const enumDecoder = structuredResult.zodEnumDriverValueDecoder(
+          z.enum(["left", "right"]),
+        );
+        const nullableDecoder = structuredResult.nullableDriverValueDecoder(
+          chainedAlias,
+        );
+        const parsedSql = sql\`'value'\`.mapWith(parsedDecoder);
+        const inlineFactorySql = sql\`'value'\`.mapWith(
+          makeDecoder(z.string()),
+        );
+        db.select({
+          direct: sql\`'value'\`.mapWith(pgTextDecoder),
+          importedAlias: sql\`'value'\`.mapWith(textDecoder),
+          aliased: sql\`'value'\`.mapWith(chainedAlias),
+          namespace: sql\`'value'\`.mapWith(
+            structuredResult.pgTextDecoder,
+          ),
+          enumValue: sql\`'left'\`.mapWith(enumDecoder),
+          nullableValue: sql\`NULL::text\`.mapWith(nullableDecoder),
+          inlineNullable: sql\`NULL::text\`.mapWith(
+            structuredResult.nullableDriverValueDecoder(textDecoder),
+          ),
+        });
+        void parsedSql;
+        void inlineFactorySql;
+      `,
+    },
+    {
+      code: `
+        class LocalSql {
+          mapWith<T>(decoder: (value: unknown) => T): T {
+            return decoder("value");
+          }
+        }
+        const local = new LocalSql();
+        void local.mapWith(String);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
         db.select({
           get value() {
             return sql\`upper(\${users.name})\`.mapWith(users.name);
@@ -194,17 +257,6 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
         db.select(messageColumns);
         db.select({ nested: messageColumns });
         db.select({ ...messageColumns });
-      `,
-    },
-    {
-      code: `${drizzlePreamble}
-        import { sql, type DriverValueDecoder } from "drizzle-orm";
-        declare const nullableTextDecoder:
-          DriverValueDecoder<string | null, unknown>;
-        db.select({
-          nullableValue: sql\`NULLIF(\${users.name}, '')\`
-            .mapWith(nullableTextDecoder),
-        });
       `,
     },
     {
@@ -412,15 +464,6 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
     },
     {
       code: `${drizzlePreamble}
-        import { sql } from "drizzle-orm";
-        function mapped<T>(value: T) {
-          return sql\`upper(\${users.name})\`.mapWith(() => value);
-        }
-        db.select({ value: mapped<string>("value") });
-      `,
-    },
-    {
-      code: `${drizzlePreamble}
         import { SQL } from "drizzle-orm";
         class MetadataSql<T> extends SQL {
           constructor(readonly metadata: T) {
@@ -429,21 +472,6 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
         }
         const predicate = new MetadataSql<string>("metadata");
         await db.select().from(users).where(predicate);
-      `,
-    },
-    {
-      code: `${drizzlePreamble}
-        import { SQL } from "drizzle-orm";
-        class TypedSql extends SQL {
-          override _: { brand: "SQL"; type: string } = {
-            brand: "SQL",
-            type: "",
-          };
-        }
-        const predicate = new TypedSql([]);
-        const mapped = new TypedSql([]).mapWith(String);
-        await db.select().from(users).where(predicate);
-        db.select({ value: mapped });
       `,
     },
     {
@@ -481,6 +509,173 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
     },
   ],
   invalid: [
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          numberValue: sql\`1::numeric\`.mapWith(Number),
+          stringValue: sql\`'value'\`.mapWith(String),
+          booleanValue: sql\`TRUE\`.mapWith(Boolean),
+        });
+      `,
+      errors: [
+        { messageId: "uninspectableResultDecoder" },
+        { messageId: "uninspectableResultDecoder" },
+        { messageId: "uninspectableResultDecoder" },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          arrow: sql\`'value'\`.mapWith((value: unknown) => String(value)),
+          expression: sql\`'value'\`.mapWith(function decode(
+            value: unknown,
+          ): string {
+            return String(value);
+          }),
+        });
+      `,
+      errors: [
+        { messageId: "uninspectableResultDecoder" },
+        { messageId: "uninspectableResultDecoder" },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type DriverValueDecoder } from "drizzle-orm";
+        declare const opaqueDecoder:
+          DriverValueDecoder<string | null, unknown>;
+        db.select({
+          value: sql\`NULL::text\`.mapWith(opaqueDecoder),
+        });
+      `,
+      errors: [{ messageId: "uninspectableResultDecoder" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        import { z } from "zod";
+        import {
+          pgTextDecoder,
+          zodDriverValueDecoder,
+        } from "../../apps/api/src/lib/db-structured-result";
+        let mutableDecoder = pgTextDecoder;
+        let mutableFactory = zodDriverValueDecoder;
+        db.select({
+          decoder: sql\`'value'\`.mapWith(mutableDecoder),
+        });
+        void sql\`'value'\`.mapWith(mutableFactory(z.string()));
+      `,
+      errors: [
+        { messageId: "uninspectableResultDecoder" },
+        { messageId: "uninspectableResultDecoder" },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type DriverValueDecoder } from "drizzle-orm";
+        import { pgTextDecoder } from
+          "../../apps/api/src/lib/db-structured-result";
+        const asserted = pgTextDecoder as
+          DriverValueDecoder<string, unknown>;
+        const hiddenAssertion = asserted;
+        db.select({
+          hidden: sql\`'value'\`.mapWith(hiddenAssertion),
+          direct: sql\`'value'\`.mapWith(
+            pgTextDecoder as DriverValueDecoder<string, unknown>,
+          ),
+          nonNull: sql\`'value'\`.mapWith(pgTextDecoder!),
+        });
+      `,
+      errors: [
+        { messageId: "uninspectableResultDecoder" },
+        { messageId: "uninspectableResultDecoder" },
+        { messageId: "uninspectableResultDecoder" },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type DriverValueDecoder } from "drizzle-orm";
+        import { pgTextDecoder } from
+          "../../apps/api/src/lib/db-structured-result";
+        function zodDriverValueDecoder():
+          DriverValueDecoder<string, unknown> {
+          return {
+            mapFromDriverValue(value: unknown): string {
+              return String(value);
+            },
+          };
+        }
+        function nullableDriverValueDecoder(
+          decoder: DriverValueDecoder<string, unknown>,
+        ): DriverValueDecoder<string | null, unknown> {
+          return decoder;
+        }
+        db.select({
+          fakeZod: sql\`'value'\`.mapWith(zodDriverValueDecoder()),
+          fakeNullable: sql\`NULL::text\`.mapWith(
+            nullableDriverValueDecoder(pgTextDecoder),
+          ),
+        });
+      `,
+      errors: [
+        { messageId: "uninspectableResultDecoder" },
+        { messageId: "uninspectableResultDecoder" },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type DriverValueDecoder } from "drizzle-orm";
+        import { nullableDriverValueDecoder } from
+          "../../apps/api/src/lib/db-structured-result";
+        declare const opaqueDecoder: DriverValueDecoder<string, unknown>;
+        db.select({
+          value: sql\`NULL::text\`.mapWith(
+            nullableDriverValueDecoder(opaqueDecoder),
+          ),
+        });
+      `,
+      errors: [{ messageId: "uninspectableResultDecoder" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        declare const decoders: readonly [typeof users.name];
+        sql\`'value'\`.mapWith(...decoders);
+        sql\`'value'\`.mapWith();
+      `,
+      errors: [
+        { messageId: "uninspectableResultDecoder" },
+        { messageId: "uninspectableResultDecoder" },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        function mapped<T>(value: T) {
+          return sql\`upper(\${users.name})\`.mapWith(() => value);
+        }
+        db.select({ value: mapped<string>("value") });
+      `,
+      errors: [{ messageId: "uninspectableResultDecoder" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { SQL } from "drizzle-orm";
+        class TypedSql extends SQL {
+          override _: { brand: "SQL"; type: string } = {
+            brand: "SQL",
+            type: "",
+          };
+        }
+        const predicate = new TypedSql([]);
+        const mapped = new TypedSql([]).mapWith(String);
+        await db.select().from(users).where(predicate);
+        db.select({ value: mapped });
+      `,
+      errors: [{ messageId: "uninspectableResultDecoder" }],
+    },
     {
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";

--- a/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
@@ -15,7 +15,9 @@ import {
   isMethodDeclaration,
   isNonNullExpression,
   isObjectLiteralExpression,
+  isParameter,
   isParenthesizedExpression,
+  isPropertyAssignment,
   isPropertyAccessExpression,
   isSatisfiesExpression,
   isSpreadElement,
@@ -399,6 +401,7 @@ export const requireSqlResultMapping = createRule({
     const resultMethodHintVariablesInProgress =
       new Set<TSESLint.Scope.Variable>();
     const decoderProvenanceByNode = new WeakMap<Node, boolean>();
+    const schemaTableCallByNode = new WeakMap<Node, boolean>();
 
     function symbolAt(node: TSESTree.Node): TypeScriptSymbol | undefined {
       const tsNode = services.esTreeNodeToTSNodeMap.get(node);
@@ -488,11 +491,16 @@ export const requireSqlResultMapping = createRule({
 
     function reviewedDecoderFactorySymbol(
       node: Expression,
+      state: DecoderProvenanceState,
       visited: Set<TypeScriptSymbol>,
     ): TypeScriptSymbol | undefined {
+      state.steps += 1;
+      if (state.steps > MAX_DECODER_PROVENANCE_STEPS) {
+        return undefined;
+      }
       const transparent = transparentDecoderExpression(node);
       if (transparent !== undefined) {
-        return reviewedDecoderFactorySymbol(transparent, visited);
+        return reviewedDecoderFactorySymbol(transparent, state, visited);
       }
       if (
         isAsExpression(node) ||
@@ -527,6 +535,7 @@ export const requireSqlResultMapping = createRule({
       visited.add(symbol);
       const target = reviewedDecoderFactorySymbol(
         declaration.initializer,
+        state,
         visited,
       );
       visited.delete(symbol);
@@ -608,6 +617,103 @@ export const requireSqlResultMapping = createRule({
       readonly symbols: Set<TypeScriptSymbol>;
     }
 
+    function isSchemaTableCall(node: Expression): boolean {
+      const cached = schemaTableCallByNode.get(node);
+      if (cached !== undefined) {
+        return cached;
+      }
+      const symbol = isCallExpression(node)
+        ? expressionSymbol(node.expression)
+        : undefined;
+      const inspected =
+        symbol !== undefined &&
+        (symbol.getName() === "pgTable" || symbol.getName() === "table") &&
+        isDrizzleSymbol(checker, symbol);
+      schemaTableCallByNode.set(node, inspected);
+      return inspected;
+    }
+
+    function hasInspectableColumnContainerProvenance(
+      node: Expression,
+      state: DecoderProvenanceState,
+    ): boolean {
+      state.steps += 1;
+      if (state.steps > MAX_DECODER_PROVENANCE_STEPS) {
+        return false;
+      }
+      const transparent = transparentDecoderExpression(node);
+      if (transparent !== undefined) {
+        return hasInspectableColumnContainerProvenance(transparent, state);
+      }
+      if (
+        isAsExpression(node) ||
+        isTypeAssertionExpression(node) ||
+        isNonNullExpression(node)
+      ) {
+        return false;
+      }
+      if (isCallExpression(node)) {
+        return isSchemaTableCall(node);
+      }
+      const symbol = expressionSymbol(node);
+      const declaration = symbol?.valueDeclaration;
+      if (
+        declaration !== undefined &&
+        isParameter(declaration) &&
+        declaration.type === undefined
+      ) {
+        return true;
+      }
+      if (
+        symbol === undefined ||
+        declaration === undefined ||
+        !isVariableDeclaration(declaration) ||
+        !isConstVariable(declaration) ||
+        declaration.initializer === undefined ||
+        state.symbols.has(symbol)
+      ) {
+        return false;
+      }
+      state.symbols.add(symbol);
+      const inspected = hasInspectableColumnContainerProvenance(
+        declaration.initializer,
+        state,
+      );
+      state.symbols.delete(symbol);
+      return inspected;
+    }
+
+    function isSchemaColumnDeclaration(node: Node): boolean {
+      if (
+        !isPropertyAssignment(node) ||
+        !isObjectLiteralExpression(node.parent)
+      ) {
+        return false;
+      }
+      const tableCall = node.parent.parent;
+      if (
+        !isCallExpression(tableCall) ||
+        tableCall.arguments[1] !== node.parent
+      ) {
+        return false;
+      }
+      return isSchemaTableCall(tableCall);
+    }
+
+    function isInspectableSchemaColumn(
+      node: Expression,
+      state: DecoderProvenanceState,
+    ): boolean {
+      return (
+        (isPropertyAccessExpression(node) || isElementAccessExpression(node)) &&
+        isDrizzleColumnType(checker, checker.getTypeAtLocation(node), node) &&
+        expressionSymbol(node)?.declarations?.some(
+          isSchemaColumnDeclaration,
+        ) === true &&
+        hasInspectableColumnContainerProvenance(node.expression, state)
+      );
+    }
+
     function isReviewedDecoderFactoryCall(
       node: Expression,
       state: DecoderProvenanceState,
@@ -615,7 +721,11 @@ export const requireSqlResultMapping = createRule({
       if (!isCallExpression(node)) {
         return false;
       }
-      const target = reviewedDecoderFactorySymbol(node.expression, new Set());
+      const target = reviewedDecoderFactorySymbol(
+        node.expression,
+        state,
+        new Set(),
+      );
       if (target === undefined || node.arguments.length !== 1) {
         return false;
       }
@@ -656,10 +766,7 @@ export const requireSqlResultMapping = createRule({
         isNonNullExpression(node)
       ) {
         inspected = false;
-      } else if (
-        (isPropertyAccessExpression(node) || isElementAccessExpression(node)) &&
-        isDrizzleColumnType(checker, checker.getTypeAtLocation(node), node)
-      ) {
+      } else if (isInspectableSchemaColumn(node, state)) {
         inspected = true;
       } else if (isCallExpression(node)) {
         inspected = isReviewedDecoderFactoryCall(node, state);

--- a/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
@@ -6,10 +6,25 @@ import {
 } from "@typescript-eslint/utils";
 import {
   IndexKind,
+  isAsExpression,
+  isCallExpression,
+  isElementAccessExpression,
+  isExpression,
+  isFunctionDeclaration,
+  isIdentifier,
+  isMethodDeclaration,
+  isNonNullExpression,
+  isObjectLiteralExpression,
+  isParenthesizedExpression,
+  isPropertyAccessExpression,
+  isSatisfiesExpression,
+  isSpreadElement,
+  isTypeAssertionExpression,
   isVariableDeclaration,
   isVariableDeclarationList,
   NodeFlags,
   TypeFlags,
+  type Expression,
   type Node,
   type Symbol as TypeScriptSymbol,
   type Type,
@@ -18,6 +33,7 @@ import {
 } from "typescript";
 
 import {
+  isDrizzleColumnType,
   isDrizzleDeclaration,
   isDrizzleSqlTag as isDrizzleSqlTagExpression,
   isDrizzleSymbol,
@@ -43,6 +59,15 @@ const RESULT_METHOD_NAMES = [
 const RESULT_METHOD_HINTS = RESULT_METHOD_NAMES.map((name) => {
   return name.toLowerCase();
 });
+
+const SHARED_DECODER_SOURCE_SUFFIX =
+  "/turbo/apps/api/src/lib/db-structured-result.ts";
+const VALIDATING_DECODER_FACTORIES = new Set([
+  "zodDriverValueDecoder",
+  "zodEnumDriverValueDecoder",
+]);
+const NULLABLE_DECODER_FACTORY = "nullableDriverValueDecoder";
+const MAX_DECODER_PROVENANCE_STEPS = 64;
 
 type SelectionTypeStatus = "safe" | "unmapped" | "uninspectable";
 
@@ -359,6 +384,8 @@ export const requireSqlResultMapping = createRule({
         "Relational query config must be an inline object or a local variable so raw SQL extras can be inspected.",
       unmappedResult:
         "Raw SQL in a structured Drizzle result must derive a concrete output from .mapWith(...) or a trusted schema-aware helper.",
+      uninspectableResultDecoder:
+        "Drizzle .mapWith(...) must use an inspectable schema column or reviewed runtime decoder.",
     },
   },
   create(context) {
@@ -371,6 +398,7 @@ export const requireSqlResultMapping = createRule({
     >();
     const resultMethodHintVariablesInProgress =
       new Set<TSESLint.Scope.Variable>();
+    const decoderProvenanceByNode = new WeakMap<Node, boolean>();
 
     function symbolAt(node: TSESTree.Node): TypeScriptSymbol | undefined {
       const tsNode = services.esTreeNodeToTSNodeMap.get(node);
@@ -425,6 +453,279 @@ export const requireSqlResultMapping = createRule({
         isVariableDeclarationList(declaration.parent) &&
         (declaration.parent.flags & NodeFlags.Const) !== 0
       );
+    }
+
+    function isSharedDecoderDeclaration(node: Node): boolean {
+      return node
+        .getSourceFile()
+        .fileName.replaceAll("\\", "/")
+        .endsWith(SHARED_DECODER_SOURCE_SUFFIX);
+    }
+
+    function expressionSymbol(node: Expression): TypeScriptSymbol | undefined {
+      if (isIdentifier(node)) {
+        return resolvedSymbol(checker, checker.getSymbolAtLocation(node));
+      }
+      if (isPropertyAccessExpression(node)) {
+        return resolvedSymbol(checker, checker.getSymbolAtLocation(node.name));
+      }
+      if (isElementAccessExpression(node)) {
+        return resolvedSymbol(
+          checker,
+          checker.getSymbolAtLocation(node.argumentExpression),
+        );
+      }
+      return undefined;
+    }
+
+    function transparentDecoderExpression(
+      node: Expression,
+    ): Expression | undefined {
+      return isParenthesizedExpression(node) || isSatisfiesExpression(node)
+        ? node.expression
+        : undefined;
+    }
+
+    function reviewedDecoderFactorySymbol(
+      node: Expression,
+      visited: Set<TypeScriptSymbol>,
+    ): TypeScriptSymbol | undefined {
+      const transparent = transparentDecoderExpression(node);
+      if (transparent !== undefined) {
+        return reviewedDecoderFactorySymbol(transparent, visited);
+      }
+      if (
+        isAsExpression(node) ||
+        isTypeAssertionExpression(node) ||
+        isNonNullExpression(node)
+      ) {
+        return undefined;
+      }
+      const symbol = expressionSymbol(node);
+      if (
+        symbol?.declarations?.some((declaration) => {
+          return (
+            isFunctionDeclaration(declaration) &&
+            isSharedDecoderDeclaration(declaration)
+          );
+        }) === true
+      ) {
+        return symbol;
+      }
+      if (symbol === undefined || visited.has(symbol)) {
+        return undefined;
+      }
+      const declaration = symbol.valueDeclaration;
+      if (
+        declaration === undefined ||
+        !isVariableDeclaration(declaration) ||
+        !isConstVariable(declaration) ||
+        declaration.initializer === undefined
+      ) {
+        return undefined;
+      }
+      visited.add(symbol);
+      const target = reviewedDecoderFactorySymbol(
+        declaration.initializer,
+        visited,
+      );
+      visited.delete(symbol);
+      return target;
+    }
+
+    function isRealDriverValueDecoderType(type: Type, location: Node): boolean {
+      const mapFromDriverValue = checker.getPropertyOfType(
+        type,
+        "mapFromDriverValue",
+      );
+      return (
+        mapFromDriverValue !== undefined &&
+        isDrizzleSymbol(checker, mapFromDriverValue) &&
+        checker
+          .getTypeOfSymbolAtLocation(mapFromDriverValue, location)
+          .getCallSignatures().length > 0
+      );
+    }
+
+    function isGlobalObjectFreezeCall(node: Expression): boolean {
+      if (
+        !isCallExpression(node) ||
+        !isPropertyAccessExpression(node.expression) ||
+        node.expression.expression.getText() !== "Object" ||
+        node.expression.name.text !== "freeze"
+      ) {
+        return false;
+      }
+      const symbol = resolvedSymbol(
+        checker,
+        checker.getSymbolAtLocation(node.expression.name),
+      );
+      return (
+        symbol?.declarations?.some((declaration) => {
+          const source = declaration
+            .getSourceFile()
+            .fileName.replaceAll("\\", "/");
+          return /\/lib\.es\d+(?:\.[^.]+)*\.d\.ts$/.test(source);
+        }) === true
+      );
+    }
+
+    function isReviewedFrozenDecoder(
+      declaration: VariableDeclaration,
+    ): boolean {
+      const initializer = declaration.initializer;
+      if (
+        !isSharedDecoderDeclaration(declaration) ||
+        !isConstVariable(declaration) ||
+        initializer === undefined ||
+        !isRealDriverValueDecoderType(
+          checker.getTypeAtLocation(declaration.name),
+          declaration.name,
+        ) ||
+        !isCallExpression(initializer) ||
+        !isGlobalObjectFreezeCall(initializer) ||
+        initializer.arguments.length !== 1
+      ) {
+        return false;
+      }
+      const value = initializer.arguments[0];
+      return (
+        value !== undefined &&
+        !isSpreadElement(value) &&
+        isObjectLiteralExpression(value) &&
+        value.properties.some((property) => {
+          return (
+            isMethodDeclaration(property) &&
+            property.name.getText().replaceAll(/["']/g, "") ===
+              "mapFromDriverValue"
+          );
+        })
+      );
+    }
+
+    interface DecoderProvenanceState {
+      steps: number;
+      readonly symbols: Set<TypeScriptSymbol>;
+    }
+
+    function isReviewedDecoderFactoryCall(
+      node: Expression,
+      state: DecoderProvenanceState,
+    ): boolean {
+      if (!isCallExpression(node)) {
+        return false;
+      }
+      const target = reviewedDecoderFactorySymbol(node.expression, new Set());
+      if (target === undefined || node.arguments.length !== 1) {
+        return false;
+      }
+      const argument = node.arguments[0];
+      if (argument === undefined || isSpreadElement(argument)) {
+        return false;
+      }
+      const name = target.getName();
+      if (VALIDATING_DECODER_FACTORIES.has(name)) {
+        return true;
+      }
+      return (
+        name === NULLABLE_DECODER_FACTORY &&
+        hasInspectableDecoderProvenance(argument, state)
+      );
+    }
+
+    function hasInspectableDecoderProvenance(
+      node: Expression,
+      state: DecoderProvenanceState,
+    ): boolean {
+      const cached = decoderProvenanceByNode.get(node);
+      if (cached !== undefined) {
+        return cached;
+      }
+      state.steps += 1;
+      if (state.steps > MAX_DECODER_PROVENANCE_STEPS) {
+        return false;
+      }
+
+      const transparent = transparentDecoderExpression(node);
+      let inspected: boolean;
+      if (transparent !== undefined) {
+        inspected = hasInspectableDecoderProvenance(transparent, state);
+      } else if (
+        isAsExpression(node) ||
+        isTypeAssertionExpression(node) ||
+        isNonNullExpression(node)
+      ) {
+        inspected = false;
+      } else if (
+        (isPropertyAccessExpression(node) || isElementAccessExpression(node)) &&
+        isDrizzleColumnType(checker, checker.getTypeAtLocation(node), node)
+      ) {
+        inspected = true;
+      } else if (isCallExpression(node)) {
+        inspected = isReviewedDecoderFactoryCall(node, state);
+      } else {
+        const symbol = expressionSymbol(node);
+        const declaration = symbol?.valueDeclaration;
+        if (
+          symbol === undefined ||
+          declaration === undefined ||
+          !isVariableDeclaration(declaration) ||
+          !isConstVariable(declaration) ||
+          declaration.initializer === undefined ||
+          state.symbols.has(symbol)
+        ) {
+          inspected = false;
+        } else if (isReviewedFrozenDecoder(declaration)) {
+          inspected = true;
+        } else {
+          state.symbols.add(symbol);
+          inspected = hasInspectableDecoderProvenance(
+            declaration.initializer,
+            state,
+          );
+          state.symbols.delete(symbol);
+        }
+      }
+      decoderProvenanceByNode.set(node, inspected);
+      return inspected;
+    }
+
+    function isDrizzleMapWithCall(node: TSESTree.CallExpression): boolean {
+      if (
+        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        resolvedMemberName(node.callee) !== "mapWith"
+      ) {
+        return false;
+      }
+      return isDrizzleSymbol(checker, symbolAt(node.callee.property));
+    }
+
+    function checkResultDecoder(node: TSESTree.CallExpression): void {
+      if (!isDrizzleMapWithCall(node)) {
+        return;
+      }
+      const argument = node.arguments[0];
+      if (
+        node.arguments.length !== 1 ||
+        argument === undefined ||
+        argument.type === AST_NODE_TYPES.SpreadElement
+      ) {
+        context.report({ node, messageId: "uninspectableResultDecoder" });
+        return;
+      }
+      const tsArgument = services.esTreeNodeToTSNodeMap.get(argument);
+      if (
+        !isExpression(tsArgument) ||
+        !hasInspectableDecoderProvenance(tsArgument, {
+          steps: 0,
+          symbols: new Set(),
+        })
+      ) {
+        context.report({
+          node: argument,
+          messageId: "uninspectableResultDecoder",
+        });
+      }
     }
 
     function localVariableInitializer(
@@ -1337,6 +1638,7 @@ export const requireSqlResultMapping = createRule({
         }
       },
       CallExpression(node: TSESTree.CallExpression): void {
+        checkResultDecoder(node);
         if (
           node.typeArguments?.params.length === 1 &&
           isDrizzleSqlTag(node.callee)


### PR DESCRIPTION
## Summary

- require real Drizzle `.mapWith(...)` calls to use a schema column or a reviewed, statically inspectable decoder provenance
- prove schema-column mappers originate from real `pgTable`/`table` declarations, including relational callback fields, while rejecting hidden assertions and cyclic aliases
- replace the ETA duration coercer with a Zod-backed PostgreSQL numeric decoder at both the inner duration and final `avg(...)` boundaries
- preserve exact zero ETA values and cover null, fractional rounding, normal, and large safe durations through the API
- document the accepted structured-result decoder boundary in the existing database development guidance

## Compatibility and scope

- generated ETA SQL text and ordered parameters are exactly unchanged
- no database schema, persisted data, public API schema, runner/queue protocol, feature switch, or rollout bridge changes
- no additional retained SQL templates are converted

## Validation

- `pnpm format`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F @vm0/eslint-rules test -- --silent=passed-only` (47 files, 1045 tests)
- focused type-aware rule suite (124 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts --silent=passed-only` (20 tests)
- `pnpm check-types` (12 workspaces, via the pre-commit hook)
- `pnpm knip`
- `git diff --check`
- exact generated-query comparison: identical SQL and parameters `[orgId, "completed", 10]`
- six balanced, interleaved, same-machine/same-filesystem API ESLint measurements: median wall `33.00s -> 33.27s` (+0.8%); peak RSS `3287MB -> 3317MB` (+0.9%)

Closes #24367

Parent context: #22310
