### PR TITLE
fix: trigger api platform and runner releases

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1,4 +1,4 @@
-// Trigger another runner release on 2026-07-28.
+// Trigger another runner release on 2026-07-31.
 mod active_input;
 mod axiom_layer;
 mod ca;

--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createApp } from "./app-factory";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed again on 2026-07-28)
+// (no-op API release marker refreshed again on 2026-07-31)
 
 const app = (() => {
   const instanceAbortController = new AbortController();

--- a/turbo/apps/platform/src/main.ts
+++ b/turbo/apps/platform/src/main.ts
@@ -11,7 +11,7 @@ import { setLogErrorHandler } from "./signals/log.ts";
 import { detach, Reason } from "./signals/utils.ts";
 import { setupRouter } from "./views/main.tsx";
 
-// (no-op Platform release marker refreshed again on 2026-07-28)
+// (no-op Platform release marker refreshed again on 2026-07-31)
 
 // Initialize Sentry before bootstrap so errors during startup are captured
 initSentry();


### PR DESCRIPTION
## Summary

- refresh the existing no-op release markers for API, Platform, and Runner
- trigger patch releases for all three release-please components without changing runtime behavior

## Validation

- `scripts/prepare.sh`
- `pnpm prettier --check apps/api/src/index.ts apps/platform/src/main.ts`
- `pnpm knip`
- `pnpm check-types` (pre-commit hook)
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features` (pre-commit hook)
- `cargo doc --workspace --all-features --no-deps` (pre-commit hook)
- `pnpm -F @vm0/db db:migrate`

Runtime tests are not applicable because this PR only updates no-op release marker comments.