### PR TITLE
feat: add conditional image recognition fallback

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -222,6 +222,39 @@ describe("auth tokens", () => {
     );
   });
 
+  it("gates image recognition on both the rollout and run eligibility", () => {
+    const staffOrgId = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
+    const ineligibleToken = generateZeroToken(
+      "user_zero",
+      "run_zero",
+      staffOrgId,
+    );
+    const eligibleToken = generateZeroToken(
+      "user_zero",
+      "run_zero",
+      staffOrgId,
+      undefined,
+      { imageRecognitionAvailable: true },
+    );
+    const rolloutDisabledToken = generateZeroToken(
+      "user_zero",
+      "run_zero",
+      staffOrgId,
+      { [FeatureSwitchKey.ZeroImageRecognition]: false },
+      { imageRecognitionAvailable: true },
+    );
+
+    expect(verifyZeroToken(ineligibleToken)?.capabilities).not.toContain(
+      "image-recognition:write",
+    );
+    expect(verifyZeroToken(eligibleToken)?.capabilities).toContain(
+      "image-recognition:write",
+    );
+    expect(verifyZeroToken(rolloutDisabledToken)?.capabilities).not.toContain(
+      "image-recognition:write",
+    );
+  });
+
   it("gates browser capabilities on both the rollout and thread access", () => {
     const defaultToken = generateZeroToken(
       "user_zero",

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -33,11 +33,18 @@ const CONDITIONAL_CAPABILITIES = [
   ["browser:read", FeatureSwitchKey.ZeroBrowser],
   ["browser:write", FeatureSwitchKey.ZeroBrowser],
   ["connector:write", FeatureSwitchKey.CustomConnectorCliCreate],
+  ["image-recognition:write", FeatureSwitchKey.ZeroImageRecognition],
 ] as const satisfies readonly (readonly [ZeroCapability, FeatureSwitchKey])[];
 
 const AGENT_EXCLUDED_CAPABILITIES = [
   "agent:delete",
 ] as const satisfies readonly ZeroCapability[];
+
+interface ZeroTokenOptions {
+  readonly computerUseHostId?: string;
+  readonly cloudBrowserEnabled?: boolean;
+  readonly imageRecognitionAvailable?: boolean;
+}
 
 const jwtBaseSchema = z.object({
   userId: z.string().min(1),
@@ -140,6 +147,29 @@ function isZeroCapabilityEnabled(
       ? { userId, orgId, overrides }
       : { userId, orgId },
   );
+}
+
+function isCapabilityAvailableToAgent(
+  capability: ZeroCapability,
+  options: ZeroTokenOptions | undefined,
+): boolean {
+  if (
+    AGENT_EXCLUDED_CAPABILITIES.some((excludedCapability) => {
+      return excludedCapability === capability;
+    })
+  ) {
+    return false;
+  }
+  if (capability === "computer-use:write") {
+    return options?.computerUseHostId !== undefined;
+  }
+  if (capability === "browser:read" || capability === "browser:write") {
+    return options?.cloudBrowserEnabled === true;
+  }
+  if (capability === "image-recognition:write") {
+    return options?.imageRecognitionAvailable === true;
+  }
+  return true;
 }
 
 const getJwtKey = singleton((): Buffer => {
@@ -300,28 +330,12 @@ export function generateZeroToken(
   runId: string,
   orgId: string,
   overrides?: Partial<Record<FeatureSwitchKey, boolean>>,
-  options?: {
-    readonly computerUseHostId?: string;
-    readonly cloudBrowserEnabled?: boolean;
-  },
+  options?: ZeroTokenOptions,
 ): string {
   const nowSeconds = Math.floor(now() / 1000);
   const capabilities: ZeroCapability[] = [];
   for (const capability of ZERO_CAPABILITIES) {
-    if (capability === "computer-use:write" && !options?.computerUseHostId) {
-      continue;
-    }
-    if (
-      (capability === "browser:read" || capability === "browser:write") &&
-      options?.cloudBrowserEnabled !== true
-    ) {
-      continue;
-    }
-    if (
-      AGENT_EXCLUDED_CAPABILITIES.some((excludedCapability) => {
-        return excludedCapability === capability;
-      })
-    ) {
+    if (!isCapabilityAvailableToAgent(capability, options)) {
       continue;
     }
     if (isZeroCapabilityEnabled(capability, userId, orgId, overrides)) {

--- a/turbo/apps/api/src/signals/external/openrouter.ts
+++ b/turbo/apps/api/src/signals/external/openrouter.ts
@@ -1,8 +1,9 @@
 import { optionalEnv } from "../../lib/env";
-import { tapError } from "../utils";
+import { readBoundedResponseText, safeJsonParse } from "../utils";
 
 const OPENROUTER_CHAT_COMPLETIONS_URL =
   "https://openrouter.ai/api/v1/chat/completions";
+const OPENROUTER_ERROR_RESPONSE_MAX_BYTES = 64 * 1024;
 
 export interface OpenRouterTextPart {
   readonly type: "text";
@@ -39,21 +40,130 @@ interface OpenRouterTextGeneration {
   readonly usage?: OpenRouterUsage;
 }
 
+interface OpenRouterChoice {
+  readonly finish_reason: string | null;
+  readonly native_finish_reason?: string | null;
+  readonly error?: unknown;
+  readonly message?: {
+    readonly content?: unknown;
+  };
+}
+
 interface OpenRouterResponse {
   readonly usage?: OpenRouterUsage;
-  readonly choices: readonly {
-    readonly finish_reason: string | null;
-    readonly native_finish_reason?: string | null;
-    readonly message: {
-      readonly content: string;
-    };
-  }[];
+  readonly error?: unknown;
+  readonly choices?: readonly OpenRouterChoice[];
 }
 
 interface OpenRouterGenerateTextOptions {
   readonly signal?: AbortSignal;
   readonly responseFormat?: { readonly type: "json_object" };
   readonly temperature?: number;
+}
+
+export class OpenRouterRequestError extends Error {
+  readonly status: number;
+  readonly errorType: string | undefined;
+
+  constructor(args: {
+    readonly message: string;
+    readonly status: number;
+    readonly errorType?: string;
+  }) {
+    super(args.message);
+    this.name = "OpenRouterRequestError";
+    this.status = args.status;
+    this.errorType = args.errorType;
+  }
+}
+
+function objectProperty(value: unknown, property: string): unknown | undefined {
+  if (typeof value !== "object" || value === null || !(property in value)) {
+    return undefined;
+  }
+  return value[property as keyof typeof value];
+}
+
+function openRouterErrorType(value: unknown): string | undefined {
+  const error = objectProperty(value, "error") ?? value;
+  const metadata = objectProperty(error, "metadata");
+  const errorType = objectProperty(metadata, "error_type");
+  return typeof errorType === "string" && errorType.length <= 128
+    ? errorType
+    : undefined;
+}
+
+function openRouterRequestError(args: {
+  readonly message: string;
+  readonly status: number;
+  readonly value: unknown;
+}): OpenRouterRequestError {
+  const errorType = openRouterErrorType(args.value);
+  return new OpenRouterRequestError({
+    message: args.message,
+    status: args.status,
+    ...(errorType === undefined ? {} : { errorType }),
+  });
+}
+
+async function ensureOpenRouterResponseOk(response: Response): Promise<void> {
+  if (response.ok) {
+    return;
+  }
+  const errorBody = await readBoundedResponseText(
+    response,
+    OPENROUTER_ERROR_RESPONSE_MAX_BYTES,
+  );
+  const errorValue =
+    errorBody.kind === "text" ? safeJsonParse(errorBody.text) : undefined;
+  throw openRouterRequestError({
+    message: "OpenRouter request failed",
+    status: response.status,
+    value: errorValue,
+  });
+}
+
+function parseOpenRouterGeneration(
+  data: OpenRouterResponse,
+): OpenRouterTextGeneration {
+  const choice = data.choices?.[0];
+  if (!choice) {
+    if (data.error !== undefined) {
+      throw openRouterRequestError({
+        message: "OpenRouter request failed",
+        status: 502,
+        value: data,
+      });
+    }
+    throw new Error("OpenRouter returned no choices");
+  }
+  if (choice.finish_reason === "error") {
+    throw openRouterRequestError({
+      message: "OpenRouter completion failed",
+      status: 502,
+      value: choice.error ?? data.error,
+    });
+  }
+  if (choice.finish_reason !== "stop") {
+    const nativeReason = choice.native_finish_reason
+      ? ` (native: ${choice.native_finish_reason})`
+      : "";
+    throw new Error(
+      `OpenRouter completion finished with ${choice.finish_reason ?? "unknown"}${nativeReason}`,
+    );
+  }
+
+  const rawContent = choice.message?.content;
+  if (typeof rawContent !== "string") {
+    throw new Error("OpenRouter returned invalid content");
+  }
+  const content = rawContent.trim();
+  if (!content) {
+    throw new Error("OpenRouter returned empty content");
+  }
+  return data.usage === undefined
+    ? { text: content }
+    : { text: content, usage: data.usage };
 }
 
 /**
@@ -118,31 +228,7 @@ export async function generateTextWithUsage(
     }),
     signal: options?.signal,
   });
-
-  if (!response.ok) {
-    const text = (await tapError(response.text())) ?? "unknown error";
-    throw new Error(`OpenRouter request failed: ${response.status} ${text}`);
-  }
-
+  await ensureOpenRouterResponseOk(response);
   const data = (await response.json()) as OpenRouterResponse;
-  const choice = data.choices[0];
-  if (!choice) {
-    throw new Error("OpenRouter returned no choices");
-  }
-  if (choice.finish_reason !== "stop") {
-    const nativeReason = choice.native_finish_reason
-      ? ` (native: ${choice.native_finish_reason})`
-      : "";
-    throw new Error(
-      `OpenRouter completion finished with ${choice.finish_reason ?? "unknown"}${nativeReason}`,
-    );
-  }
-
-  const content = choice.message.content.trim();
-  if (!content) {
-    throw new Error("OpenRouter returned empty content");
-  }
-  return data.usage === undefined
-    ? { text: content }
-    : { text: content, usage: data.usage };
+  return parseOpenRouterGeneration(data);
 }

--- a/turbo/apps/api/src/signals/external/openrouter.ts
+++ b/turbo/apps/api/src/signals/external/openrouter.ts
@@ -89,7 +89,8 @@ function openRouterErrorType(value: unknown): string | undefined {
   const error = objectProperty(value, "error") ?? value;
   const metadata = objectProperty(error, "metadata");
   const errorType = objectProperty(metadata, "error_type");
-  return typeof errorType === "string" && errorType.length <= 128
+  return typeof errorType === "string" &&
+    /^[a-z][a-z0-9_]{0,127}$/u.test(errorType)
     ? errorType
     : undefined;
 }

--- a/turbo/apps/api/src/signals/external/openrouter.ts
+++ b/turbo/apps/api/src/signals/external/openrouter.ts
@@ -70,7 +70,8 @@ export class OpenRouterRequestError extends Error {
     readonly status: number;
     readonly errorType?: string;
   }) {
-    super(args.message);
+    const errorType = args.errorType ? ` (${args.errorType})` : "";
+    super(`${args.message}: ${String(args.status)}${errorType}`);
     this.name = "OpenRouterRequestError";
     this.status = args.status;
     this.errorType = args.errorType;

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -118,6 +118,7 @@ import { zeroOrgReadRoutes } from "./routes/zero-org-read";
 import { zeroPushSubscriptionsRoutes } from "./routes/zero-push-subscriptions";
 import { zeroQueuePositionRoutes } from "./routes/zero-queue-position";
 import { zeroRealtimeTokenRoutes } from "./routes/zero-realtime-token";
+import { zeroRecognitionRoutes } from "./routes/zero-recognition";
 import { zeroReportErrorRoutes } from "./routes/zero-report-error";
 import { zeroRunDetailRoutes } from "./routes/zero-run-detail";
 import { zeroRunsRoutes } from "./routes/zero-runs";
@@ -318,6 +319,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroWebDownloadRoutes,
   ...zeroQueuePositionRoutes,
   ...zeroRealtimeTokenRoutes,
+  ...zeroRecognitionRoutes,
   ...zeroReportErrorRoutes,
   ...zeroRunDetailRoutes,
   ...zeroRunsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -37,6 +37,7 @@ import { testContext } from "../../../__tests__/test-context";
 import { server } from "../../../mocks/server";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise } from "../../utils";
+import { verifyZeroToken } from "../../auth/tokens";
 import {
   deleteUsagePricingRows,
   seedOrgMetadata,
@@ -5456,6 +5457,132 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     expect(claim.modelUsageProvider).toBe(selectedModel);
 
     await api.requestCancelRun(actor, sent.body.runId, [200]);
+  });
+
+  it("offers image recognition only for enabled image-unsupported models", async () => {
+    const api = createRunsApi(context);
+    const chat = createChatFilesBddApi(context);
+    const connectors = createConnectorBddApi(context);
+    const unsupportedModel = "deepseek-v4-flash";
+    const supportedModel = "claude-sonnet-4-6";
+    const unknownModel = "gpt-5.6-sol";
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const { providerId: anthropicProviderId } =
+      await api.ensureOrgModelProvider(actor);
+    const { providerId: deepseekProviderId } = await api.createOrgModelProvider(
+      actor,
+      {
+        type: "deepseek-codex",
+        secret: "recognition-deepseek-key",
+      },
+    );
+    const { providerId: openaiProviderId } = await api.createOrgModelProvider(
+      actor,
+      {
+        type: "openai-api-key",
+        secret: "recognition-openai-key",
+      },
+    );
+
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: unsupportedModel,
+        isDefault: true,
+        defaultProviderType: "deepseek-codex",
+        credentialScope: "org",
+        modelProviderId: deepseekProviderId,
+      },
+      {
+        model: supportedModel,
+        isDefault: false,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: anthropicProviderId,
+      },
+      {
+        model: unknownModel,
+        isDefault: false,
+        defaultProviderType: "openai-api-key",
+        credentialScope: "org",
+        modelProviderId: openaiProviderId,
+      },
+    ]);
+
+    async function claimModel(model: string) {
+      const sent = await chat.requestSendEvent(
+        actor,
+        {
+          agentId,
+          prompt: `recognition eligibility for ${model}`,
+          model,
+        },
+        [201],
+      );
+      if (sent.status !== 201 || sent.body.runId === null) {
+        throw new Error(`Expected ${model} to create a run`);
+      }
+      await api.heartbeatRunner(runnerGroup);
+      return {
+        claim: await api.claimRunnerJob(sent.body.runId),
+        runId: sent.body.runId,
+      };
+    }
+
+    const disabledUnsupported = await claimModel(unsupportedModel);
+    const disabledToken = disabledUnsupported.claim.environment?.ZERO_TOKEN;
+    if (!disabledToken) {
+      throw new Error("Expected the disabled run to expose ZERO_TOKEN");
+    }
+    expect(disabledUnsupported.claim.appendSystemPrompt ?? "").not.toContain(
+      "zero recognize",
+    );
+    expect(verifyZeroToken(disabledToken)?.capabilities).not.toContain(
+      "image-recognition:write",
+    );
+    await api.requestCancelRun(actor, disabledUnsupported.runId, [200]);
+
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ZeroImageRecognition]: true,
+    });
+
+    const enabledUnsupported = await claimModel(unsupportedModel);
+    const enabledToken = enabledUnsupported.claim.environment?.ZERO_TOKEN;
+    if (!enabledToken) {
+      throw new Error("Expected the enabled run to expose ZERO_TOKEN");
+    }
+    expect(enabledUnsupported.claim.appendSystemPrompt ?? "").toContain(
+      'zero recognize --file <image-path> --prompt "<instruction>"',
+    );
+    expect(verifyZeroToken(enabledToken)?.capabilities).toContain(
+      "image-recognition:write",
+    );
+    await api.requestCancelRun(actor, enabledUnsupported.runId, [200]);
+
+    const enabledSupported = await claimModel(supportedModel);
+    const supportedToken = enabledSupported.claim.environment?.ZERO_TOKEN;
+    if (!supportedToken) {
+      throw new Error("Expected the supported-model run to expose ZERO_TOKEN");
+    }
+    expect(enabledSupported.claim.appendSystemPrompt ?? "").not.toContain(
+      "zero recognize",
+    );
+    expect(verifyZeroToken(supportedToken)?.capabilities).not.toContain(
+      "image-recognition:write",
+    );
+    await api.requestCancelRun(actor, enabledSupported.runId, [200]);
+
+    const enabledUnknown = await claimModel(unknownModel);
+    const unknownToken = enabledUnknown.claim.environment?.ZERO_TOKEN;
+    if (!unknownToken) {
+      throw new Error("Expected the unknown-model run to expose ZERO_TOKEN");
+    }
+    expect(enabledUnknown.claim.appendSystemPrompt ?? "").not.toContain(
+      "zero recognize",
+    );
+    expect(verifyZeroToken(unknownToken)?.capabilities).not.toContain(
+      "image-recognition:write",
+    );
+    await api.requestCancelRun(actor, enabledUnknown.runId, [200]);
   });
 
   it("injects codex multi-auth provider credentials and proves them via firewall auth", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-recognition.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-recognition.test.ts
@@ -422,20 +422,13 @@ describe("POST /api/zero/recognize", () => {
     await expectNoUsage(actor);
   });
 
-  it("rejects usable text when provider usage metadata is missing", async () => {
+  it("rejects usable text when provider usage metadata is incomplete", async () => {
     mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    server.use(
-      http.post(OPENROUTER_URL, () => {
-        return HttpResponse.json({
-          choices: [
-            {
-              finish_reason: "stop",
-              message: { content: "Unbilled result" },
-            },
-          ],
-        });
-      }),
-    );
+    const usages = [
+      undefined,
+      { prompt_tokens: 10 },
+      { completion_tokens: 10 },
+    ] as const;
     const actor = await seedActor();
     await seedBilling(actor);
     const fileId = randomUUID();
@@ -443,14 +436,29 @@ describe("POST /api/zero/recognize", () => {
       { userId: actor.userId, id: fileId, filename: "screen.webp", size: 12 },
     ]);
 
-    const response = await requestRecognition({
-      token: zeroToken(actor),
-      fileId,
-    });
-    expect(response.status).toBe(502);
-    expect(response.body).toMatchObject({
-      error: { code: "MISSING_PROVIDER_USAGE" },
-    });
+    for (const usage of usages) {
+      server.use(
+        http.post(OPENROUTER_URL, () => {
+          return HttpResponse.json({
+            choices: [
+              {
+                finish_reason: "stop",
+                message: { content: "Unbilled result" },
+              },
+            ],
+            ...(usage === undefined ? {} : { usage }),
+          });
+        }),
+      );
+      const response = await requestRecognition({
+        token: zeroToken(actor),
+        fileId,
+      });
+      expect(response.status).toBe(502);
+      expect(response.body).toMatchObject({
+        error: { code: "MISSING_PROVIDER_USAGE" },
+      });
+    }
     await expectNoUsage(actor);
   });
 
@@ -521,7 +529,7 @@ describe("POST /api/zero/recognize", () => {
               message: { content: "This text must not be returned" },
             },
           ],
-          usage: { completion_tokens: 100 },
+          usage: { prompt_tokens: 100, completion_tokens: 100 },
         });
       }),
     );
@@ -546,6 +554,6 @@ describe("POST /api/zero/recognize", () => {
         { scope: "organization", id: actor.orgId },
         context.signal,
       ),
-    ).resolves.toStrictEqual({ raw: 1, hourly: 0 });
+    ).resolves.toStrictEqual({ raw: 2, hourly: 0 });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-recognition.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-recognition.test.ts
@@ -1,12 +1,15 @@
 import { randomUUID } from "node:crypto";
 
 import { createStore } from "ccstate";
-import { ZERO_RECOGNITION_MAX_FILE_BYTES } from "@vm0/api-contracts/contracts/zero-recognition";
+import {
+  ZERO_RECOGNITION_MAX_FILE_BYTES,
+  zeroRecognitionContract,
+} from "@vm0/api-contracts/contracts/zero-recognition";
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
+import { zeroUsageRunsContract } from "@vm0/api-contracts/contracts/zero-usage-daily";
 import { HttpResponse, http } from "msw";
 
-import { createAppWithRoutes } from "../../../app-factory-core";
-import { testContext } from "../../../__tests__/test-context";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { buildArtifactKey } from "../../../lib/file-url";
 import { mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
@@ -15,16 +18,9 @@ import {
   seedOrgMetadata,
   seedUsagePricingRows,
 } from "../../../test-fixtures/system-config-seeds";
-import { signSandboxJwtForTests } from "../../auth/tokens";
-import { now } from "../../external/time";
-import { zeroRecognitionRoutes } from "../zero-recognition";
-import { zeroUsageRunsRoutes } from "../zero-usage-runs";
-import { seedOrgMembership$ } from "./helpers/zero-org-membership";
-import {
-  seedCompose$,
-  seedRun$,
-  readUsageStorageCounts$,
-} from "./helpers/zero-usage-insight";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+import { readUsageStorageCounts$ } from "./helpers/zero-usage-insight";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -60,9 +56,8 @@ const RECOGNITION_PRICING_ROWS = [
   },
 ] as const;
 
-interface RecognitionActor {
+interface RecognitionActor extends ApiTestUser {
   readonly orgId: string;
-  readonly userId: string;
   readonly runId: string;
 }
 
@@ -73,48 +68,52 @@ interface StoredObject {
   readonly size: number;
 }
 
-function createApp() {
-  return createAppWithRoutes({
-    signal: context.signal,
-    routes: [...zeroRecognitionRoutes, ...zeroUsageRunsRoutes],
-  });
-}
-
 function zeroToken(
   actor: RecognitionActor,
   capabilities: readonly ZeroCapability[] = ["image-recognition:write"],
 ): string {
-  const seconds = Math.floor(now() / 1000);
-  return signSandboxJwtForTests({
-    scope: "zero",
-    userId: actor.userId,
-    orgId: actor.orgId,
-    runId: actor.runId,
+  return createRunsApi(context).zeroTokenForRunWithCapabilities(
+    actor,
+    actor.runId,
     capabilities,
-    iat: seconds,
-    exp: seconds + 60,
-  });
+  );
 }
 
 async function seedActor(): Promise<RecognitionActor> {
-  const orgId = randomUUID();
-  const userId = randomUUID();
-  await store.set(
-    seedOrgMembership$,
-    { orgId, userId, role: "admin" },
-    context.signal,
-  );
-  const { composeId } = await store.set(
-    seedCompose$,
-    { orgId, userId },
-    context.signal,
-  );
-  const { runId } = await store.set(
-    seedRun$,
-    { orgId, userId, composeId, triggerSource: "web" },
-    context.signal,
-  );
-  return { orgId, userId, runId };
+  const actor = createBddApi(context).user();
+  if (!actor.orgId) {
+    throw new Error("Recognition tests require an organization");
+  }
+  await seedOrgMetadata({
+    orgId: actor.orgId,
+    tier: "pro",
+    credits: STARTING_CREDITS,
+  });
+  const api = createRunsApi(context);
+  const name = `recognition-${randomUUID().slice(0, 8)}`;
+  const compose = await api.createCompose(actor, {
+    version: "1.0",
+    agents: {
+      [name]: {
+        framework: "claude-code",
+        environment: { ANTHROPIC_API_KEY: "recognition-test-key" },
+      },
+    },
+  });
+  const run = await api.createDirectRun(actor, {
+    agentComposeId: compose.composeId,
+    prompt: "Recognize an uploaded image",
+  });
+  context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue({
+    data: [
+      {
+        role: actor.orgRole ?? "org:admin",
+        organization: { id: actor.orgId },
+        publicUserData: { userId: actor.userId },
+      },
+    ],
+  });
+  return { ...actor, orgId: actor.orgId, runId: run.runId };
 }
 
 function setStoredObjects(objects: readonly StoredObject[]): void {
@@ -130,28 +129,24 @@ function setStoredObjects(objects: readonly StoredObject[]): void {
 }
 
 function requestRecognition(args: {
-  readonly app: ReturnType<typeof createApp>;
   readonly token?: string;
   readonly fileId: string;
   readonly prompt?: string;
   readonly clientRequestId?: string;
-}): Promise<Response> {
-  return Promise.resolve(
-    args.app.request("/api/zero/recognize", {
-      method: "POST",
-      headers: {
-        ...(args.token ? { authorization: `Bearer ${args.token}` } : {}),
-        "content-type": "application/json",
-        ...(args.clientRequestId
-          ? { "x-vm0-client-request-id": args.clientRequestId }
-          : {}),
-      },
-      body: JSON.stringify({
-        fileId: args.fileId,
-        prompt: args.prompt ?? "Describe this image",
-      }),
-    }),
-  );
+}) {
+  const headers = {
+    ...(args.token ? { authorization: `Bearer ${args.token}` } : {}),
+    ...(args.clientRequestId
+      ? { "x-vm0-client-request-id": args.clientRequestId }
+      : {}),
+  };
+  return setupApp({ context })(zeroRecognitionContract).recognize({
+    headers,
+    body: {
+      fileId: args.fileId,
+      prompt: args.prompt ?? "Describe this image",
+    },
+  });
 }
 
 async function seedBilling(actor: RecognitionActor): Promise<void> {
@@ -167,27 +162,17 @@ function mockClerkUserLookup(): void {
   context.mocks.clerk.users.getUserList.mockResolvedValue({ data: [] });
 }
 
-async function readRunUsage(
-  app: ReturnType<typeof createApp>,
-  actor: RecognitionActor,
-) {
+async function readRunUsage(actor: RecognitionActor) {
   mockClerkUserLookup();
   mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
-  const response = await app.request(
-    `/api/zero/usage/runs?runId=${actor.runId}`,
-    { headers: { authorization: "Bearer clerk-session" } },
+  const response = await accept(
+    setupApp({ context })(zeroUsageRunsContract).get({
+      headers: { authorization: "Bearer clerk-session" },
+      query: { runId: actor.runId },
+    }),
+    [200],
   );
-  expect(response.status).toBe(200);
-  const body = (await response.json()) as {
-    runs: readonly {
-      runId: string;
-      inputTokens: number;
-      outputTokens: number;
-      cacheTokens: number;
-      creditsCharged: number;
-    }[];
-  };
-  return body.runs;
+  return response.body.runs;
 }
 
 async function expectNoUsage(actor: RecognitionActor): Promise<void> {
@@ -242,19 +227,17 @@ describe("POST /api/zero/recognize", () => {
     setStoredObjects([
       { userId: actor.userId, id: fileId, filename: "screen.png", size: 1024 },
     ]);
-    const app = createApp();
     const clientRequestId = randomUUID();
 
     for (let invocation = 0; invocation < 2; invocation += 1) {
       const response = await requestRecognition({
-        app,
         token: zeroToken(actor),
         fileId,
         prompt: "Read the warning",
         clientRequestId,
       });
       expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toStrictEqual({
+      expect(response.body).toStrictEqual({
         text: "A red warning banner is visible.",
         metadata: { creditsCharged: EXPECTED_CHARGE },
       });
@@ -286,7 +269,7 @@ describe("POST /api/zero/recognize", () => {
         context.signal,
       ),
     ).resolves.toStrictEqual({ raw: 6, hourly: 0 });
-    await expect(readRunUsage(app, actor)).resolves.toStrictEqual([
+    await expect(readRunUsage(actor)).resolves.toStrictEqual([
       expect.objectContaining({
         runId: actor.runId,
         inputTokens: 4000,
@@ -299,14 +282,12 @@ describe("POST /api/zero/recognize", () => {
 
   it("enforces Zero-only capability authorization before object access", async () => {
     const actor = await seedActor();
-    const app = createApp();
     const fileId = randomUUID();
 
-    const unauthenticated = await requestRecognition({ app, fileId });
+    const unauthenticated = await requestRecognition({ fileId });
     expect(unauthenticated.status).toBe(401);
 
     const missingCapability = await requestRecognition({
-      app,
       token: zeroToken(actor, ["file:write"]),
       fileId,
     });
@@ -314,7 +295,6 @@ describe("POST /api/zero/recognize", () => {
 
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
     const sessionResponse = await requestRecognition({
-      app,
       token: "clerk-session",
       fileId,
     });
@@ -324,7 +304,6 @@ describe("POST /api/zero/recognize", () => {
 
   it("rejects non-owned and invalid uploaded image metadata", async () => {
     const actor = await seedActor();
-    const app = createApp();
     const otherUserFileId = randomUUID();
     const gifId = randomUUID();
     const emptyId = randomUUID();
@@ -355,13 +334,13 @@ describe("POST /api/zero/recognize", () => {
     ] as const;
     for (const testCase of cases) {
       const response = await requestRecognition({
-        app,
         token,
         fileId: testCase.fileId,
       });
       expect(response.status).toBe(testCase.status);
-      const body = (await response.json()) as { error: { code: string } };
-      expect(body.error.code).toBe(testCase.code);
+      expect(response.body).toMatchObject({
+        error: { code: testCase.code },
+      });
     }
     await expectNoUsage(actor);
   });
@@ -380,12 +359,10 @@ describe("POST /api/zero/recognize", () => {
     setStoredObjects([
       { userId: actor.userId, id: fileId, filename: "screen.jpg", size: 100 },
     ]);
-    const app = createApp();
     await seedOrgMetadata({ orgId: actor.orgId, tier: "pro", credits: 0 });
     await seedUsagePricingRows(RECOGNITION_PRICING_ROWS);
 
     const noCredits = await requestRecognition({
-      app,
       token: zeroToken(actor),
       fileId,
     });
@@ -404,7 +381,6 @@ describe("POST /api/zero/recognize", () => {
       }),
     );
     const noPricing = await requestRecognition({
-      app,
       token: zeroToken(actor),
       fileId,
     });
@@ -436,12 +412,11 @@ describe("POST /api/zero/recognize", () => {
     ]);
 
     const response = await requestRecognition({
-      app: createApp(),
       token: zeroToken(actor),
       fileId,
     });
     expect(response.status).toBe(400);
-    const responseText = await response.text();
+    const responseText = JSON.stringify(response.body);
     expect(responseText).toContain("INVALID_IMAGE");
     expect(responseText).not.toContain("raw-provider-secret-detail");
     await expectNoUsage(actor);
@@ -469,12 +444,11 @@ describe("POST /api/zero/recognize", () => {
     ]);
 
     const response = await requestRecognition({
-      app: createApp(),
       token: zeroToken(actor),
       fileId,
     });
     expect(response.status).toBe(502);
-    await expect(response.json()).resolves.toMatchObject({
+    expect(response.body).toMatchObject({
       error: { code: "MISSING_PROVIDER_USAGE" },
     });
     await expectNoUsage(actor);
@@ -514,16 +488,14 @@ describe("POST /api/zero/recognize", () => {
     setStoredObjects([
       { userId: actor.userId, id: fileId, filename: "screen.png", size: 12 },
     ]);
-    const app = createApp();
 
     for (let invocation = 0; invocation < 2; invocation += 1) {
       const response = await requestRecognition({
-        app,
         token: zeroToken(actor),
         fileId,
       });
       expect(response.status).toBe(502);
-      await expect(response.json()).resolves.toMatchObject({
+      expect(response.body).toMatchObject({
         error: { code: "IMAGE_RECOGNITION_FAILED" },
       });
     }
@@ -561,12 +533,11 @@ describe("POST /api/zero/recognize", () => {
     ]);
 
     const response = await requestRecognition({
-      app: createApp(),
       token: zeroToken(actor),
       fileId,
     });
     expect(response.status).toBe(500);
-    await expect(response.text()).resolves.not.toContain(
+    expect(JSON.stringify(response.body)).not.toContain(
       "This text must not be returned",
     );
     await expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-recognition.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-recognition.test.ts
@@ -391,13 +391,20 @@ describe("POST /api/zero/recognize", () => {
 
   it("maps provider image errors without exposing raw provider text", async () => {
     mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    let providerCall = 0;
     server.use(
       http.post(OPENROUTER_URL, () => {
+        providerCall += 1;
         return HttpResponse.json(
           {
             error: {
               message: "raw-provider-secret-detail",
-              metadata: { error_type: "invalid_image" },
+              metadata: {
+                error_type:
+                  providerCall === 1
+                    ? "invalid_image"
+                    : "invalid_image\ninjected",
+              },
             },
           },
           { status: 400 },
@@ -419,6 +426,13 @@ describe("POST /api/zero/recognize", () => {
     const responseText = JSON.stringify(response.body);
     expect(responseText).toContain("INVALID_IMAGE");
     expect(responseText).not.toContain("raw-provider-secret-detail");
+
+    const malformedType = await requestRecognition({
+      token: zeroToken(actor),
+      fileId,
+    });
+    expect(malformedType.status).toBe(502);
+    expect(JSON.stringify(malformedType.body)).not.toContain("injected");
     await expectNoUsage(actor);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-recognition.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-recognition.test.ts
@@ -1,0 +1,580 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { ZERO_RECOGNITION_MAX_FILE_BYTES } from "@vm0/api-contracts/contracts/zero-recognition";
+import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
+import { HttpResponse, http } from "msw";
+
+import { createAppWithRoutes } from "../../../app-factory-core";
+import { testContext } from "../../../__tests__/test-context";
+import { buildArtifactKey } from "../../../lib/file-url";
+import { mockOptionalEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
+import {
+  deleteUsagePricingRows,
+  seedOrgMetadata,
+  seedUsagePricingRows,
+} from "../../../test-fixtures/system-config-seeds";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { now } from "../../external/time";
+import { zeroRecognitionRoutes } from "../zero-recognition";
+import { zeroUsageRunsRoutes } from "../zero-usage-runs";
+import { seedOrgMembership$ } from "./helpers/zero-org-membership";
+import {
+  seedCompose$,
+  seedRun$,
+  readUsageStorageCounts$,
+} from "./helpers/zero-usage-insight";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const mocks = createZeroRouteMocks(context);
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+const STARTING_CREDITS = 1000;
+const EXPECTED_CHARGE = 13;
+const RECOGNITION_PRICING_ROWS = [
+  {
+    kind: "model",
+    provider: "google/gemini-3.5-flash",
+    category: "tokens.input",
+    unitPrice: 1500,
+    unitSize: 1_000_000,
+  },
+  {
+    kind: "model",
+    provider: "google/gemini-3.5-flash",
+    category: "tokens.cache_read",
+    unitPrice: 150,
+    unitSize: 1_000_000,
+  },
+  {
+    kind: "model",
+    provider: "google/gemini-3.5-flash",
+    category: "tokens.output",
+    unitPrice: 9000,
+    unitSize: 1_000_000,
+  },
+] as const;
+
+interface RecognitionActor {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly runId: string;
+}
+
+interface StoredObject {
+  readonly userId: string;
+  readonly id: string;
+  readonly filename: string;
+  readonly size: number;
+}
+
+function createApp() {
+  return createAppWithRoutes({
+    signal: context.signal,
+    routes: [...zeroRecognitionRoutes, ...zeroUsageRunsRoutes],
+  });
+}
+
+function zeroToken(
+  actor: RecognitionActor,
+  capabilities: readonly ZeroCapability[] = ["image-recognition:write"],
+): string {
+  const seconds = Math.floor(now() / 1000);
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: actor.userId,
+    orgId: actor.orgId,
+    runId: actor.runId,
+    capabilities,
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+async function seedActor(): Promise<RecognitionActor> {
+  const orgId = randomUUID();
+  const userId = randomUUID();
+  await store.set(
+    seedOrgMembership$,
+    { orgId, userId, role: "admin" },
+    context.signal,
+  );
+  const { composeId } = await store.set(
+    seedCompose$,
+    { orgId, userId },
+    context.signal,
+  );
+  const { runId } = await store.set(
+    seedRun$,
+    { orgId, userId, composeId, triggerSource: "web" },
+    context.signal,
+  );
+  return { orgId, userId, runId };
+}
+
+function setStoredObjects(objects: readonly StoredObject[]): void {
+  mocks.s3.listObjects(
+    objects.map((object) => {
+      return {
+        bucket: "test-user-artifacts",
+        key: buildArtifactKey(object.userId, object.id, object.filename),
+        size: object.size,
+      };
+    }),
+  );
+}
+
+function requestRecognition(args: {
+  readonly app: ReturnType<typeof createApp>;
+  readonly token?: string;
+  readonly fileId: string;
+  readonly prompt?: string;
+  readonly clientRequestId?: string;
+}): Promise<Response> {
+  return Promise.resolve(
+    args.app.request("/api/zero/recognize", {
+      method: "POST",
+      headers: {
+        ...(args.token ? { authorization: `Bearer ${args.token}` } : {}),
+        "content-type": "application/json",
+        ...(args.clientRequestId
+          ? { "x-vm0-client-request-id": args.clientRequestId }
+          : {}),
+      },
+      body: JSON.stringify({
+        fileId: args.fileId,
+        prompt: args.prompt ?? "Describe this image",
+      }),
+    }),
+  );
+}
+
+async function seedBilling(actor: RecognitionActor): Promise<void> {
+  await seedOrgMetadata({
+    orgId: actor.orgId,
+    tier: "pro",
+    credits: STARTING_CREDITS,
+  });
+  await seedUsagePricingRows(RECOGNITION_PRICING_ROWS);
+}
+
+function mockClerkUserLookup(): void {
+  context.mocks.clerk.users.getUserList.mockResolvedValue({ data: [] });
+}
+
+async function readRunUsage(
+  app: ReturnType<typeof createApp>,
+  actor: RecognitionActor,
+) {
+  mockClerkUserLookup();
+  mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
+  const response = await app.request(
+    `/api/zero/usage/runs?runId=${actor.runId}`,
+    { headers: { authorization: "Bearer clerk-session" } },
+  );
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as {
+    runs: readonly {
+      runId: string;
+      inputTokens: number;
+      outputTokens: number;
+      cacheTokens: number;
+      creditsCharged: number;
+    }[];
+  };
+  return body.runs;
+}
+
+async function expectNoUsage(actor: RecognitionActor): Promise<void> {
+  await expect(
+    store.set(
+      readUsageStorageCounts$,
+      { scope: "organization", id: actor.orgId },
+      context.signal,
+    ),
+  ).resolves.toStrictEqual({ raw: 0, hourly: 0 });
+}
+
+describe("POST /api/zero/recognize", () => {
+  const trackPricing = createFixtureTracker(
+    async (
+      rows: readonly {
+        readonly kind: string;
+        readonly provider: string;
+        readonly category: string;
+        readonly unitPrice: number;
+        readonly unitSize: number;
+      }[],
+    ) => {
+      await seedUsagePricingRows(rows);
+    },
+  );
+
+  it("recognizes one owned image and settles each real invocation", async () => {
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    const requestBodies: unknown[] = [];
+    server.use(
+      http.post(OPENROUTER_URL, async ({ request }) => {
+        requestBodies.push(await request.json());
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: { content: "A red warning banner is visible." },
+            },
+          ],
+          usage: {
+            prompt_tokens: 3000,
+            completion_tokens: 1000,
+            prompt_tokens_details: { cached_tokens: 1000 },
+          },
+        });
+      }),
+    );
+    const actor = await seedActor();
+    await seedBilling(actor);
+    const fileId = randomUUID();
+    setStoredObjects([
+      { userId: actor.userId, id: fileId, filename: "screen.png", size: 1024 },
+    ]);
+    const app = createApp();
+    const clientRequestId = randomUUID();
+
+    for (let invocation = 0; invocation < 2; invocation += 1) {
+      const response = await requestRecognition({
+        app,
+        token: zeroToken(actor),
+        fileId,
+        prompt: "Read the warning",
+        clientRequestId,
+      });
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toStrictEqual({
+        text: "A red warning banner is visible.",
+        metadata: { creditsCharged: EXPECTED_CHARGE },
+      });
+    }
+
+    expect(requestBodies).toHaveLength(2);
+    expect(requestBodies[0]).toMatchObject({
+      model: "google/gemini-3.5-flash",
+      max_tokens: 8192,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Read the warning" },
+            {
+              type: "image_url",
+              image_url: {
+                url: expect.stringContaining(fileId),
+              },
+            },
+          ],
+        },
+      ],
+    });
+    await expect(
+      store.set(
+        readUsageStorageCounts$,
+        { scope: "organization", id: actor.orgId },
+        context.signal,
+      ),
+    ).resolves.toStrictEqual({ raw: 6, hourly: 0 });
+    await expect(readRunUsage(app, actor)).resolves.toStrictEqual([
+      expect.objectContaining({
+        runId: actor.runId,
+        inputTokens: 4000,
+        outputTokens: 2000,
+        cacheTokens: 2000,
+        creditsCharged: EXPECTED_CHARGE * 2,
+      }),
+    ]);
+  });
+
+  it("enforces Zero-only capability authorization before object access", async () => {
+    const actor = await seedActor();
+    const app = createApp();
+    const fileId = randomUUID();
+
+    const unauthenticated = await requestRecognition({ app, fileId });
+    expect(unauthenticated.status).toBe(401);
+
+    const missingCapability = await requestRecognition({
+      app,
+      token: zeroToken(actor, ["file:write"]),
+      fileId,
+    });
+    expect(missingCapability.status).toBe(403);
+
+    mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
+    const sessionResponse = await requestRecognition({
+      app,
+      token: "clerk-session",
+      fileId,
+    });
+    expect(sessionResponse.status).toBe(403);
+    expect(context.mocks.s3.send).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-owned and invalid uploaded image metadata", async () => {
+    const actor = await seedActor();
+    const app = createApp();
+    const otherUserFileId = randomUUID();
+    const gifId = randomUUID();
+    const emptyId = randomUUID();
+    const oversizedId = randomUUID();
+    setStoredObjects([
+      {
+        userId: randomUUID(),
+        id: otherUserFileId,
+        filename: "other.png",
+        size: 10,
+      },
+      { userId: actor.userId, id: gifId, filename: "image.gif", size: 10 },
+      { userId: actor.userId, id: emptyId, filename: "empty.png", size: 0 },
+      {
+        userId: actor.userId,
+        id: oversizedId,
+        filename: "large.webp",
+        size: ZERO_RECOGNITION_MAX_FILE_BYTES + 1,
+      },
+    ]);
+    const token = zeroToken(actor);
+
+    const cases = [
+      { fileId: otherUserFileId, status: 404, code: "NOT_FOUND" },
+      { fileId: gifId, status: 400, code: "UNSUPPORTED_IMAGE_TYPE" },
+      { fileId: emptyId, status: 400, code: "EMPTY_IMAGE" },
+      { fileId: oversizedId, status: 413, code: "IMAGE_TOO_LARGE" },
+    ] as const;
+    for (const testCase of cases) {
+      const response = await requestRecognition({
+        app,
+        token,
+        fileId: testCase.fileId,
+      });
+      expect(response.status).toBe(testCase.status);
+      const body = (await response.json()) as { error: { code: string } };
+      expect(body.error.code).toBe(testCase.code);
+    }
+    await expectNoUsage(actor);
+  });
+
+  it("fails before the provider when credits or pricing are unavailable", async () => {
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    let providerCalled = false;
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        providerCalled = true;
+        return HttpResponse.json({});
+      }),
+    );
+    const actor = await seedActor();
+    const fileId = randomUUID();
+    setStoredObjects([
+      { userId: actor.userId, id: fileId, filename: "screen.jpg", size: 100 },
+    ]);
+    const app = createApp();
+    await seedOrgMetadata({ orgId: actor.orgId, tier: "pro", credits: 0 });
+    await seedUsagePricingRows(RECOGNITION_PRICING_ROWS);
+
+    const noCredits = await requestRecognition({
+      app,
+      token: zeroToken(actor),
+      fileId,
+    });
+    expect(noCredits.status).toBe(402);
+
+    await seedOrgMetadata({
+      orgId: actor.orgId,
+      tier: "pro",
+      credits: STARTING_CREDITS,
+    });
+    await trackPricing(
+      deleteUsagePricingRows({
+        kind: "model",
+        provider: "google/gemini-3.5-flash",
+        categories: ["tokens.input", "tokens.cache_read", "tokens.output"],
+      }),
+    );
+    const noPricing = await requestRecognition({
+      app,
+      token: zeroToken(actor),
+      fileId,
+    });
+    expect(noPricing.status).toBe(503);
+    expect(providerCalled).toBeFalsy();
+    await expectNoUsage(actor);
+  });
+
+  it("maps provider image errors without exposing raw provider text", async () => {
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "raw-provider-secret-detail",
+              metadata: { error_type: "invalid_image" },
+            },
+          },
+          { status: 400 },
+        );
+      }),
+    );
+    const actor = await seedActor();
+    await seedBilling(actor);
+    const fileId = randomUUID();
+    setStoredObjects([
+      { userId: actor.userId, id: fileId, filename: "broken.png", size: 12 },
+    ]);
+
+    const response = await requestRecognition({
+      app: createApp(),
+      token: zeroToken(actor),
+      fileId,
+    });
+    expect(response.status).toBe(400);
+    const responseText = await response.text();
+    expect(responseText).toContain("INVALID_IMAGE");
+    expect(responseText).not.toContain("raw-provider-secret-detail");
+    await expectNoUsage(actor);
+  });
+
+  it("rejects usable text when provider usage metadata is missing", async () => {
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: { content: "Unbilled result" },
+            },
+          ],
+        });
+      }),
+    );
+    const actor = await seedActor();
+    await seedBilling(actor);
+    const fileId = randomUUID();
+    setStoredObjects([
+      { userId: actor.userId, id: fileId, filename: "screen.webp", size: 12 },
+    ]);
+
+    const response = await requestRecognition({
+      app: createApp(),
+      token: zeroToken(actor),
+      fileId,
+    });
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "MISSING_PROVIDER_USAGE" },
+    });
+    await expectNoUsage(actor);
+  });
+
+  it("rejects incomplete or empty provider output without recording usage", async () => {
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    let providerCall = 0;
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        providerCall += 1;
+        if (providerCall === 1) {
+          return HttpResponse.json({
+            choices: [
+              {
+                finish_reason: "length",
+                message: { content: "Incomplete result" },
+              },
+            ],
+            usage: { prompt_tokens: 10, completion_tokens: 10 },
+          });
+        }
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: { content: "   " },
+            },
+          ],
+          usage: { prompt_tokens: 10, completion_tokens: 10 },
+        });
+      }),
+    );
+    const actor = await seedActor();
+    await seedBilling(actor);
+    const fileId = randomUUID();
+    setStoredObjects([
+      { userId: actor.userId, id: fileId, filename: "screen.png", size: 12 },
+    ]);
+    const app = createApp();
+
+    for (let invocation = 0; invocation < 2; invocation += 1) {
+      const response = await requestRecognition({
+        app,
+        token: zeroToken(actor),
+        fileId,
+      });
+      expect(response.status).toBe(502);
+      await expect(response.json()).resolves.toMatchObject({
+        error: { code: "IMAGE_RECOGNITION_FAILED" },
+      });
+    }
+    expect(providerCall).toBe(2);
+    await expectNoUsage(actor);
+  });
+
+  it("does not return text when settlement reports a billing error", async () => {
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    server.use(
+      http.post(OPENROUTER_URL, async () => {
+        await trackPricing(
+          deleteUsagePricingRows({
+            kind: "model",
+            provider: "google/gemini-3.5-flash",
+            categories: ["tokens.output"],
+          }),
+        );
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: { content: "This text must not be returned" },
+            },
+          ],
+          usage: { completion_tokens: 100 },
+        });
+      }),
+    );
+    const actor = await seedActor();
+    await seedBilling(actor);
+    const fileId = randomUUID();
+    setStoredObjects([
+      { userId: actor.userId, id: fileId, filename: "screen.png", size: 12 },
+    ]);
+
+    const response = await requestRecognition({
+      app: createApp(),
+      token: zeroToken(actor),
+      fileId,
+    });
+    expect(response.status).toBe(500);
+    await expect(response.text()).resolves.not.toContain(
+      "This text must not be returned",
+    );
+    await expect(
+      store.set(
+        readUsageStorageCounts$,
+        { scope: "organization", id: actor.orgId },
+        context.signal,
+      ),
+    ).resolves.toStrictEqual({ raw: 1, hourly: 0 });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-recognition.ts
+++ b/turbo/apps/api/src/signals/routes/zero-recognition.ts
@@ -1,0 +1,38 @@
+import { zeroRecognitionContract } from "@vm0/api-contracts/contracts/zero-recognition";
+import { command } from "ccstate";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import { zeroRecognition$ } from "../services/zero-recognition.service";
+
+const recognitionBody$ = bodyResultOf(zeroRecognitionContract.recognize);
+
+const recognizeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  if (auth.tokenType !== "zero") {
+    throw new Error("Zero recognition route requires Zero authentication");
+  }
+  const bodyResult = await get(recognitionBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+  return await set(zeroRecognition$, { auth, body: bodyResult.data }, signal);
+});
+
+export const zeroRecognitionRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroRecognitionContract.recognize,
+    handler: authRoute(
+      {
+        accept: ["zero"],
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "image-recognition:write",
+      },
+      recognizeInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -22,6 +22,7 @@ import {
   getModelProviderCodexRuntimeConfig,
   getModelProviderFirewall,
   getModelProviderEnvBindings,
+  getModelImageInputSupport,
   getFrameworkForType,
   getProviderRuntimeModel,
   getSecretNameForType,
@@ -69,8 +70,10 @@ import {
 } from "@vm0/core/frameworks";
 import {
   getAllFeatureStates,
+  isFeatureEnabled,
   type FeatureSwitchContext,
 } from "@vm0/core/feature-switch";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { resolveSkillRef, parseGitHubTreeUrl } from "@vm0/core/github-url";
 import {
   getCustomConnectorSkillName,
@@ -299,6 +302,8 @@ type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
 const CODEX_WEB_IMAGE_GENERATION_UPLOAD_PROMPT =
   "If you use the built-in image generation tool and it saves generated output image file(s) to local paths, upload each output file you intend to show with `zero web upload-file -f <path>` before telling the web chat user the image is available. Quote the path when needed. Do not provide only sandbox-local paths, because users cannot open local files.";
+const ZERO_IMAGE_RECOGNITION_PROMPT =
+  '# Image Recognition Fallback\n\nThis run\'s selected model cannot inspect images directly. To inspect one local PNG, JPEG, or WebP image up to 20 MB, run `zero recognize --file <image-path> --prompt "<instruction>"`.';
 
 function withZeroTokenSecret(
   body: CreateRunBody,
@@ -317,21 +322,26 @@ function withPendingZeroTokenSecret(body: CreateRunBody): CreateRunBody {
   return withZeroTokenSecret(body, "__pending_zero_token__");
 }
 
-function withFinalFrameworkAppendSystemPrompt(
+function withFinalRunAppendSystemPrompt(
   body: CreateRunBody,
   framework: SupportedFramework,
   chatThreadId: string | undefined,
+  imageRecognitionAvailable: boolean,
 ): CreateRunBody {
-  if (framework !== "codex" || body.triggerSource !== "web" || !chatThreadId) {
+  const appendedParts: string[] = [];
+  if (imageRecognitionAvailable) {
+    appendedParts.push(ZERO_IMAGE_RECOGNITION_PROMPT);
+  }
+  if (framework === "codex" && body.triggerSource === "web" && chatThreadId) {
+    appendedParts.push(CODEX_WEB_IMAGE_GENERATION_UPLOAD_PROMPT);
+  }
+  if (appendedParts.length === 0) {
     return body;
   }
 
   return {
     ...body,
-    appendSystemPrompt: [
-      body.appendSystemPrompt,
-      CODEX_WEB_IMAGE_GENERATION_UPLOAD_PROMPT,
-    ]
+    appendSystemPrompt: [body.appendSystemPrompt, ...appendedParts]
       .filter((part): part is string => {
         return Boolean(part);
       })
@@ -5639,6 +5649,7 @@ interface BuildRunnerJobPayloadInput {
   readonly includeZeroTokenSecret: boolean | undefined;
   readonly zeroTokenComputerUseHostId: string | undefined;
   readonly zeroTokenCloudBrowserEnabled: boolean | undefined;
+  readonly imageRecognitionAvailable: boolean;
   readonly chatThreadId: string | undefined;
   readonly extraEnvironment: Record<string, string> | undefined;
   readonly userTimezone: string | undefined;
@@ -5671,18 +5682,15 @@ function buildRunnerJobPayload(
             args.run.id,
             args.orgId,
             featureSwitchOverrides,
-            args.zeroTokenComputerUseHostId ||
-              args.zeroTokenCloudBrowserEnabled === true
-              ? {
-                  ...(args.zeroTokenComputerUseHostId
-                    ? {
-                        computerUseHostId: args.zeroTokenComputerUseHostId,
-                      }
-                    : {}),
-                  cloudBrowserEnabled:
-                    args.zeroTokenCloudBrowserEnabled === true,
-                }
-              : undefined,
+            {
+              ...(args.zeroTokenComputerUseHostId
+                ? {
+                    computerUseHostId: args.zeroTokenComputerUseHostId,
+                  }
+                : {}),
+              cloudBrowserEnabled: args.zeroTokenCloudBrowserEnabled === true,
+              imageRecognitionAvailable: args.imageRecognitionAvailable,
+            },
           ),
         )
       : args.body;
@@ -6522,6 +6530,7 @@ function buildAtomicLaunchPayload(
     includeZeroTokenSecret: args.createArgs.includeZeroTokenSecret,
     zeroTokenComputerUseHostId: args.createArgs.zeroTokenComputerUseHostId,
     zeroTokenCloudBrowserEnabled: args.createArgs.zeroTokenCloudBrowserEnabled,
+    imageRecognitionAvailable: args.context.imageRecognitionAvailable,
     chatThreadId: args.createArgs.chatThreadId,
     extraEnvironment: args.createArgs.extraEnvironment,
     userTimezone: args.context.userTimezone,
@@ -6581,6 +6590,7 @@ interface PreparedRunContext {
   readonly additionalVolumeSources: AdditionalVolumeSources;
   readonly userTimezone: string | undefined;
   readonly featureSwitchContext: FeatureSwitchContext;
+  readonly imageRecognitionAvailable: boolean;
 }
 
 async function resolveRunModelProvider(
@@ -7331,6 +7341,21 @@ function prepareRunOutputMetadata(args: {
   };
 }
 
+function isImageRecognitionAvailableForRun(args: {
+  readonly includeZeroTokenSecret: boolean | undefined;
+  readonly featureSwitchContext: FeatureSwitchContext;
+  readonly selectedModel: string | undefined;
+}): boolean {
+  return (
+    args.includeZeroTokenSecret === true &&
+    isFeatureEnabled(
+      FeatureSwitchKey.ZeroImageRecognition,
+      args.featureSwitchContext,
+    ) &&
+    getModelImageInputSupport(args.selectedModel) === "unsupported"
+  );
+}
+
 function prepareRunContext(input: {
   readonly db: Db;
   readonly args: CreateAgentRunArgs;
@@ -7454,6 +7479,13 @@ function prepareRunContext(input: {
         additionalVolumeSources: outputMetadata.additionalVolumeSources,
         userTimezone,
         featureSwitchContext: bodyContext.featureSwitchContext,
+        imageRecognitionAvailable: isImageRecognitionAvailableForRun({
+          includeZeroTokenSecret: args.includeZeroTokenSecret,
+          featureSwitchContext: bodyContext.featureSwitchContext,
+          selectedModel:
+            runtimeContext.modelProvider?.selectedModel ??
+            args.selectedModelOverride,
+        }),
       };
     },
   );
@@ -7791,13 +7823,14 @@ function finalizePreparedRunContext(
 ): PreparedRunContext {
   return {
     ...prepared.context,
-    body: withFinalFrameworkAppendSystemPrompt(
+    body: withFinalRunAppendSystemPrompt(
       {
         ...prepared.context.body,
         appendSystemPrompt: finalAppendSystemPrompt,
       },
       prepared.context.framework,
       prepared.args.chatThreadId,
+      prepared.context.imageRecognitionAvailable,
     ),
   };
 }

--- a/turbo/apps/api/src/signals/services/artifact-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-storage.service.ts
@@ -43,7 +43,7 @@ type StoredGeneratedArtifactObject = Omit<
   readonly metadata: Readonly<Record<string, string>>;
 };
 
-interface ResolvedArtifactObject {
+export interface ResolvedArtifactObject {
   readonly key: string;
   readonly url: string;
   readonly filename: string;

--- a/turbo/apps/api/src/signals/services/openrouter-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/openrouter-usage.service.ts
@@ -22,7 +22,7 @@ const OPENROUTER_USAGE_CATEGORIES = [
 ] as const;
 
 interface OpenRouterUsageEntry {
-  readonly category: string;
+  readonly category: (typeof OPENROUTER_USAGE_CATEGORIES)[number];
   readonly quantity: number;
 }
 
@@ -35,6 +35,11 @@ interface RecordOpenRouterUsageArgs {
   readonly operationId: string;
   readonly usage: OpenRouterUsage | undefined;
 }
+
+type OpenRouterUsageSettlement =
+  | { readonly kind: "no-usage" }
+  | { readonly kind: "settled"; readonly creditsCharged: number }
+  | { readonly kind: "unsettled" };
 
 function positiveInteger(value: number | undefined): number {
   if (value === undefined || !Number.isFinite(value) || value <= 0) {
@@ -58,11 +63,12 @@ function usageEntries(
   const inputTokens = promptTokens - cachedTokens;
   const outputTokens = positiveInteger(usage.completion_tokens);
 
-  return [
+  const entries: OpenRouterUsageEntry[] = [
     { category: INPUT_CATEGORY, quantity: inputTokens },
     { category: CACHE_READ_CATEGORY, quantity: cachedTokens },
     { category: OUTPUT_CATEGORY, quantity: outputTokens },
-  ].filter((entry) => {
+  ];
+  return entries.filter((entry) => {
     return entry.quantity > 0;
   });
 }
@@ -115,39 +121,66 @@ export const recordOpenRouterUsage$ = command(
     { set },
     args: RecordOpenRouterUsageArgs,
     signal: AbortSignal,
-  ): Promise<void> => {
+  ): Promise<OpenRouterUsageSettlement> => {
     const entries = usageEntries(args.usage);
     if (entries.length === 0) {
-      return;
+      return { kind: "no-usage" };
     }
 
     const writeDb = set(writeDb$);
+    const eventRows = entries.map((entry) => {
+      return {
+        runId: args.runId ?? null,
+        idempotencyKey: usageIdempotencyKey({
+          orgId: args.orgId,
+          operation: args.operation,
+          operationId: args.operationId,
+          provider: args.provider,
+          category: entry.category,
+        }),
+        orgId: args.orgId,
+        userId: args.userId,
+        kind: USAGE_KIND,
+        provider: args.provider,
+        category: entry.category,
+        quantity: entry.quantity,
+      };
+    });
     await writeDb
       .insert(usageEvent)
-      .values(
-        entries.map((entry) => {
-          return {
-            runId: args.runId ?? null,
-            idempotencyKey: usageIdempotencyKey({
-              orgId: args.orgId,
-              operation: args.operation,
-              operationId: args.operationId,
-              provider: args.provider,
-              category: entry.category,
-            }),
-            orgId: args.orgId,
-            userId: args.userId,
-            kind: USAGE_KIND,
-            provider: args.provider,
-            category: entry.category,
-            quantity: entry.quantity,
-          };
-        }),
-      )
+      .values(eventRows)
       .onConflictDoNothing({ target: [usageEvent.idempotencyKey] });
     signal.throwIfAborted();
 
     await set(processOrgUsageEvents$, args.orgId, signal);
     signal.throwIfAborted();
+
+    const processed = await writeDb
+      .select({
+        billingError: usageEvent.billingError,
+        creditsCharged: usageEvent.creditsCharged,
+      })
+      .from(usageEvent)
+      .where(
+        inArray(
+          usageEvent.idempotencyKey,
+          eventRows.map((event) => {
+            return event.idempotencyKey;
+          }),
+        ),
+      );
+    signal.throwIfAborted();
+    if (processed.length !== eventRows.length) {
+      return { kind: "unsettled" };
+    }
+
+    let creditsCharged = 0;
+    for (const event of processed) {
+      if (event.billingError !== null || event.creditsCharged === null) {
+        return { kind: "unsettled" };
+      }
+      creditsCharged += event.creditsCharged;
+    }
+    return { kind: "settled", creditsCharged };
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-recognition.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-recognition.service.ts
@@ -17,6 +17,7 @@ import {
   isLlmConfigured,
   OpenRouterRequestError,
   type OpenRouterContentPart,
+  type OpenRouterUsage,
 } from "../external/openrouter";
 import { settle } from "../utils";
 import {
@@ -97,6 +98,34 @@ function providerError(error: unknown) {
     502,
     "IMAGE_RECOGNITION_FAILED",
     "Image recognition failed to produce a usable response",
+  );
+}
+
+function isPositiveSafeInteger(value: number | undefined): value is number {
+  return value !== undefined && Number.isSafeInteger(value) && value > 0;
+}
+
+function hasCompleteRecognitionUsage(
+  usage: OpenRouterUsage | undefined,
+): boolean {
+  if (usage === undefined) {
+    return false;
+  }
+  const promptTokens = usage.prompt_tokens;
+  const completionTokens = usage.completion_tokens;
+  if (
+    !isPositiveSafeInteger(promptTokens) ||
+    !isPositiveSafeInteger(completionTokens)
+  ) {
+    return false;
+  }
+
+  const cachedTokens = usage.prompt_tokens_details?.cached_tokens;
+  return (
+    cachedTokens === undefined ||
+    (Number.isSafeInteger(cachedTokens) &&
+      cachedTokens >= 0 &&
+      cachedTokens <= promptTokens)
   );
 }
 
@@ -194,11 +223,11 @@ export const zeroRecognition$ = command(
         "Image recognition returned too much text",
       );
     }
-    if (generated.value.usage === undefined) {
+    if (!hasCompleteRecognitionUsage(generated.value.usage)) {
       return recognitionError(
         502,
         "MISSING_PROVIDER_USAGE",
-        "Image recognition did not report billable usage",
+        "Image recognition did not report complete billable usage",
       );
     }
 

--- a/turbo/apps/api/src/signals/services/zero-recognition.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-recognition.service.ts
@@ -1,0 +1,237 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  ZERO_RECOGNITION_MAX_FILE_BYTES,
+  ZERO_RECOGNITION_MAX_TEXT_CHARS,
+  zeroRecognitionImageMimeTypeSchema,
+  type ZeroRecognitionRequest,
+  type ZeroRecognitionResponse,
+} from "@vm0/api-contracts/contracts/zero-recognition";
+import { command } from "ccstate";
+
+import { insufficientCredits, notConfigured, notFound } from "../../lib/error";
+import type { ZeroAuthContext } from "../../types/auth";
+import { requestSignal$ } from "../context/hono";
+import {
+  generateTextWithUsage,
+  isLlmConfigured,
+  OpenRouterRequestError,
+  type OpenRouterContentPart,
+} from "../external/openrouter";
+import { settle } from "../utils";
+import {
+  resolveArtifactObject$,
+  type ResolvedArtifactObject,
+} from "./artifact-storage.service";
+import { checkBillableOperationCredits$ } from "./billable-operation-admission.service";
+import {
+  checkOpenRouterUsagePricing$,
+  recordOpenRouterUsage$,
+} from "./openrouter-usage.service";
+
+const ZERO_RECOGNITION_MODEL = "google/gemini-3.5-flash";
+const ZERO_RECOGNITION_MAX_TOKENS = 8192;
+
+type RecognitionAuth = Extract<ZeroAuthContext, { readonly orgId: string }>;
+
+interface RecognitionArgs {
+  readonly auth: RecognitionAuth;
+  readonly body: ZeroRecognitionRequest;
+}
+
+function recognitionError<Status extends number>(
+  status: Status,
+  code: string,
+  message: string,
+) {
+  return {
+    status,
+    body: { error: { message, code } },
+  } as const;
+}
+
+function providerError(error: unknown) {
+  if (!(error instanceof OpenRouterRequestError)) {
+    return recognitionError(
+      502,
+      "IMAGE_RECOGNITION_FAILED",
+      "Image recognition failed to produce a usable response",
+    );
+  }
+  if (
+    error.errorType === "invalid_image" ||
+    error.errorType === "image_too_small" ||
+    error.errorType === "unsupported_image_format"
+  ) {
+    return recognitionError(
+      400,
+      "INVALID_IMAGE",
+      "The uploaded file is not a valid PNG, JPEG, or WebP image",
+    );
+  }
+  if (error.errorType === "image_too_large") {
+    return recognitionError(
+      413,
+      "IMAGE_TOO_LARGE",
+      "The image exceeds the recognition provider's size limit",
+    );
+  }
+  if (
+    error.errorType === "image_not_found" ||
+    error.errorType === "image_download_failed"
+  ) {
+    return recognitionError(
+      502,
+      "IMAGE_UNAVAILABLE",
+      "The recognition provider could not read the uploaded image",
+    );
+  }
+  if (error.status === 429 || error.status >= 500) {
+    return recognitionError(
+      503,
+      "PROVIDER_UNAVAILABLE",
+      "Image recognition is temporarily unavailable",
+    );
+  }
+  return recognitionError(
+    502,
+    "IMAGE_RECOGNITION_FAILED",
+    "Image recognition failed to produce a usable response",
+  );
+}
+
+function validateArtifact(artifact: ResolvedArtifactObject | null) {
+  if (artifact === null) {
+    return notFound("Uploaded image not found");
+  }
+  if (
+    !zeroRecognitionImageMimeTypeSchema.safeParse(artifact.contentType).success
+  ) {
+    return recognitionError(
+      400,
+      "UNSUPPORTED_IMAGE_TYPE",
+      "Image must be a PNG, JPEG, or WebP file",
+    );
+  }
+  if (artifact.size <= 0) {
+    return recognitionError(400, "EMPTY_IMAGE", "Image file must not be empty");
+  }
+  if (artifact.size > ZERO_RECOGNITION_MAX_FILE_BYTES) {
+    return recognitionError(
+      413,
+      "IMAGE_TOO_LARGE",
+      "Image file must be 20 MB or smaller",
+    );
+  }
+  return artifact;
+}
+
+export const zeroRecognition$ = command(
+  async ({ get, set }, args: RecognitionArgs, signal: AbortSignal) => {
+    const requestSignal = AbortSignal.any([signal, get(requestSignal$)]);
+    requestSignal.throwIfAborted();
+
+    const resolved = await set(
+      resolveArtifactObject$,
+      { userId: args.auth.userId, id: args.body.fileId },
+      requestSignal,
+    );
+    signal.throwIfAborted();
+    requestSignal.throwIfAborted();
+    const artifact = validateArtifact(resolved);
+    if ("status" in artifact) {
+      return artifact;
+    }
+
+    if (!isLlmConfigured()) {
+      return notConfigured("Image recognition is not configured");
+    }
+    const hasCredits = await set(
+      checkBillableOperationCredits$,
+      { orgId: args.auth.orgId },
+      requestSignal,
+    );
+    signal.throwIfAborted();
+    requestSignal.throwIfAborted();
+    if (!hasCredits) {
+      return insufficientCredits();
+    }
+    const missingPricing = await set(
+      checkOpenRouterUsagePricing$,
+      { provider: ZERO_RECOGNITION_MODEL },
+      requestSignal,
+    );
+    signal.throwIfAborted();
+    requestSignal.throwIfAborted();
+    if (missingPricing.length > 0) {
+      return notConfigured("Image recognition pricing is not configured");
+    }
+
+    const content: OpenRouterContentPart[] = [
+      { type: "text", text: args.body.prompt },
+      { type: "image_url", image_url: { url: artifact.url } },
+    ];
+    const operationId = randomUUID();
+    const generated = await settle(
+      generateTextWithUsage(
+        ZERO_RECOGNITION_MODEL,
+        [{ role: "user", content }],
+        ZERO_RECOGNITION_MAX_TOKENS,
+        { signal: requestSignal },
+      ),
+    );
+    signal.throwIfAborted();
+    if (!generated.ok) {
+      return providerError(generated.error);
+    }
+    if (generated.value === null) {
+      return notConfigured("Image recognition is not configured");
+    }
+    if (generated.value.text.length > ZERO_RECOGNITION_MAX_TEXT_CHARS) {
+      return recognitionError(
+        502,
+        "IMAGE_RECOGNITION_FAILED",
+        "Image recognition returned too much text",
+      );
+    }
+    if (generated.value.usage === undefined) {
+      return recognitionError(
+        502,
+        "MISSING_PROVIDER_USAGE",
+        "Image recognition did not report billable usage",
+      );
+    }
+
+    // Provider work is complete, so a client disconnect must not skip billing.
+    const settlement = await set(
+      recordOpenRouterUsage$,
+      {
+        orgId: args.auth.orgId,
+        userId: args.auth.userId,
+        runId: args.auth.runId,
+        provider: ZERO_RECOGNITION_MODEL,
+        operation: "image-recognition",
+        operationId,
+        usage: generated.value.usage,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    if (settlement.kind === "no-usage") {
+      return recognitionError(
+        502,
+        "MISSING_PROVIDER_USAGE",
+        "Image recognition did not report billable usage",
+      );
+    }
+    if (settlement.kind === "unsettled") {
+      throw new Error("Failed to settle image recognition usage");
+    }
+
+    const body: ZeroRecognitionResponse = {
+      text: generated.value.text,
+      metadata: { creditsCharged: settlement.creditsCharged },
+    };
+    return { status: 200 as const, body };
+  },
+);

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -44,6 +44,7 @@ function buildCommands(): Command[] {
     new Command("scrape"),
     new Command("people-search"),
     new Command("web-search"),
+    new Command("recognize"),
     new Command("finance"),
     new Command("banking"),
     new Command("goal"),
@@ -728,6 +729,42 @@ describe("registerZeroCommands", () => {
     vi.stubEnv("ZERO_TOKEN", enabledToken);
 
     expect(visibleCommandNames(buildProgram())).toContain("browser");
+  });
+
+  it("should expose recognition only to eligible Zero runs", () => {
+    vi.stubEnv("ZERO_TOKEN", undefined);
+    const noTokenProgram = buildProgram({
+      [FeatureSwitchKey.ZeroImageRecognition]: true,
+    });
+    expect(registeredCommandNames(noTokenProgram)).toContain("recognize");
+    expect(hiddenCommandNames(noTokenProgram)).toContain("recognize");
+
+    const missingCapabilityToken = buildZeroToken({
+      scope: "zero",
+      userId: "user-1",
+      orgId: "org-1",
+      capabilities: [],
+      featureSwitchOverrides: {
+        [FeatureSwitchKey.ZeroImageRecognition]: true,
+      },
+    });
+    vi.stubEnv("ZERO_TOKEN", missingCapabilityToken);
+    expect(hiddenCommandNames(buildProgram())).toContain("recognize");
+
+    const eligibleToken = buildZeroToken({
+      scope: "zero",
+      userId: "user-1",
+      orgId: "org-1",
+      capabilities: ["image-recognition:write"],
+      featureSwitchOverrides: {
+        [FeatureSwitchKey.ZeroImageRecognition]: true,
+      },
+    });
+    vi.stubEnv("ZERO_TOKEN", eligibleToken);
+    expect(visibleCommandNames(buildProgram())).toContain("recognize");
+    expect(buildZeroHelpText(decodeZeroTokenPayload(eligibleToken))).toContain(
+      "Recognize an image?",
+    );
   });
 
   it("should show billing help examples only for billing capabilities", () => {

--- a/turbo/apps/cli/src/commands/zero/recognize/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/recognize/__tests__/index.test.ts
@@ -1,0 +1,229 @@
+import { mkdirSync, rmSync, truncateSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import {
+  ZERO_RECOGNITION_MAX_FILE_BYTES,
+  ZERO_RECOGNITION_MAX_PROMPT_CHARS,
+} from "@vm0/api-contracts/contracts/zero-recognition";
+import { HttpResponse, http } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { server } from "../../../../mocks/server";
+import { zeroRecognizeCommand } from "../index";
+
+const PREPARE_URL = "http://localhost:3000/api/zero/uploads/prepare";
+const COMPLETE_URL = "http://localhost:3000/api/zero/uploads/complete";
+const RECOGNIZE_URL = "http://localhost:3000/api/zero/recognize";
+const PUT_URL = "https://mock-r2.test/recognition-upload";
+
+function installUploadHandlers(fileId: string, filename: string, size: number) {
+  server.use(
+    http.post(PREPARE_URL, async ({ request }) => {
+      expect(request.headers.get("authorization")).toBe("Bearer test-token");
+      await expect(request.json()).resolves.toMatchObject({
+        filename,
+        contentType: "image/png",
+        size,
+      });
+      return HttpResponse.json({
+        id: fileId,
+        filename,
+        contentType: "image/png",
+        size,
+        uploadUrl: PUT_URL,
+        uploadHeaders: { "x-amz-meta-artifact-id": fileId },
+        url: `https://cdn.example.test/${fileId}/${filename}`,
+      });
+    }),
+    http.put(PUT_URL, ({ request }) => {
+      expect(request.headers.get("content-type")).toBe("image/png");
+      expect(request.headers.get("x-amz-meta-artifact-id")).toBe(fileId);
+      return new HttpResponse(null, { status: 200 });
+    }),
+    http.post(COMPLETE_URL, async ({ request }) => {
+      await expect(request.json()).resolves.toStrictEqual({
+        id: fileId,
+        contentType: "image/png",
+      });
+      return HttpResponse.json({
+        id: fileId,
+        filename,
+        contentType: "image/png",
+        size,
+        url: `https://cdn.example.test/${fileId}/${filename}`,
+      });
+    }),
+  );
+}
+
+describe("zero recognize command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+    return undefined as never;
+  });
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+  let tempDir: string;
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("ZERO_TOKEN", "test-token");
+    tempDir = join(tmpdir(), `zero-recognize-${randomUUID()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("uploads one image, recognizes it, and prints only text", async () => {
+    const fileId = randomUUID();
+    const filePath = join(tempDir, "screen.png");
+    const bytes = Buffer.from("fake-png-bytes");
+    writeFileSync(filePath, bytes);
+    installUploadHandlers(fileId, "screen.png", bytes.length);
+    let recognizeCalls = 0;
+    server.use(
+      http.post(RECOGNIZE_URL, async ({ request }) => {
+        recognizeCalls += 1;
+        expect(request.headers.get("authorization")).toBe("Bearer test-token");
+        await expect(request.json()).resolves.toStrictEqual({
+          fileId,
+          prompt: "Read the error message",
+        });
+        return HttpResponse.json({
+          text: "The dialog says access denied.",
+          metadata: { creditsCharged: 7 },
+        });
+      }),
+    );
+
+    await zeroRecognizeCommand.parseAsync([
+      "node",
+      "zero",
+      "--file",
+      filePath,
+      "--prompt",
+      "  Read the error message  ",
+    ]);
+
+    expect(recognizeCalls).toBe(1);
+    expect(mockConsoleLog.mock.calls).toStrictEqual([
+      ["The dialog says access denied."],
+    ]);
+    expect(mockConsoleError).not.toHaveBeenCalled();
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid local inputs before upload", async () => {
+    const empty = join(tempDir, "empty.png");
+    const missing = join(tempDir, "missing.png");
+    const unsupported = join(tempDir, "animation.gif");
+    const oversized = join(tempDir, "large.webp");
+    writeFileSync(empty, Buffer.alloc(0));
+    writeFileSync(unsupported, "gif");
+    writeFileSync(oversized, "x");
+    truncateSync(oversized, ZERO_RECOGNITION_MAX_FILE_BYTES + 1);
+    let networkCalled = false;
+    server.use(
+      http.post(PREPARE_URL, () => {
+        networkCalled = true;
+        return HttpResponse.json({});
+      }),
+      http.post(RECOGNIZE_URL, () => {
+        networkCalled = true;
+        return HttpResponse.json({});
+      }),
+    );
+
+    const invalidInputs = [
+      { file: missing, prompt: "describe", message: "no such file" },
+      { file: tempDir, prompt: "describe", message: "Not a regular file" },
+      { file: empty, prompt: "describe", message: "must not be empty" },
+      {
+        file: unsupported,
+        prompt: "describe",
+        message: "PNG, JPEG, or WebP",
+      },
+      { file: oversized, prompt: "describe", message: "20 MB or smaller" },
+      {
+        file: unsupported,
+        prompt: "   ",
+        message: "prompt must not be empty",
+      },
+      {
+        file: unsupported,
+        prompt: "x".repeat(ZERO_RECOGNITION_MAX_PROMPT_CHARS + 1),
+        message: "characters or fewer",
+      },
+    ] as const;
+
+    for (const input of invalidInputs) {
+      mockConsoleError.mockClear();
+      await zeroRecognizeCommand.parseAsync([
+        "node",
+        "zero",
+        "--file",
+        input.file,
+        "--prompt",
+        input.prompt,
+      ]);
+      expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+        input.message,
+      );
+    }
+    expect(networkCalled).toBe(false);
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
+  it("prints API failures to stderr without printing billing metadata", async () => {
+    const fileId = randomUUID();
+    const filePath = join(tempDir, "screen.png");
+    writeFileSync(filePath, "png");
+    installUploadHandlers(fileId, "screen.png", 3);
+    server.use(
+      http.post(RECOGNIZE_URL, () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Image recognition is temporarily unavailable",
+              code: "PROVIDER_UNAVAILABLE",
+            },
+          },
+          { status: 503 },
+        );
+      }),
+    );
+
+    await zeroRecognizeCommand.parseAsync([
+      "node",
+      "zero",
+      "--file",
+      filePath,
+      "--prompt",
+      "describe",
+    ]);
+
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "temporarily unavailable",
+    );
+    expect(mockConsoleError.mock.calls.flat().join("\n")).not.toContain(
+      "creditsCharged",
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("exposes no model, retry, JSON, or billing options", () => {
+    const optionNames = zeroRecognizeCommand.options.map((option) => {
+      return option.attributeName();
+    });
+    expect(optionNames).toStrictEqual(["file", "prompt"]);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/recognize/index.ts
+++ b/turbo/apps/cli/src/commands/zero/recognize/index.ts
@@ -1,0 +1,106 @@
+import { statSync } from "node:fs";
+
+import {
+  ZERO_RECOGNITION_MAX_FILE_BYTES,
+  ZERO_RECOGNITION_MAX_PROMPT_CHARS,
+  zeroRecognitionImageMimeTypeSchema,
+  type ZeroRecognitionImageMimeType,
+} from "@vm0/api-contracts/contracts/zero-recognition";
+import { Command } from "commander";
+
+import {
+  ApiRequestError,
+  callZeroRecognition,
+  inferWebUploadContentType,
+  uploadWebFile,
+} from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+interface RecognizeOptions {
+  readonly file: string;
+  readonly prompt: string;
+}
+
+function validatePrompt(prompt: string): string {
+  const trimmed = prompt.trim();
+  if (!trimmed) {
+    throw new ApiRequestError(
+      "Recognition prompt must not be empty",
+      "BAD_REQUEST",
+      400,
+    );
+  }
+  if (trimmed.length > ZERO_RECOGNITION_MAX_PROMPT_CHARS) {
+    throw new ApiRequestError(
+      `Recognition prompt must be ${ZERO_RECOGNITION_MAX_PROMPT_CHARS} characters or fewer`,
+      "BAD_REQUEST",
+      400,
+    );
+  }
+  return trimmed;
+}
+
+function validateImageFile(file: string): ZeroRecognitionImageMimeType {
+  const stats = statSync(file);
+  if (!stats.isFile()) {
+    throw new ApiRequestError(
+      `Not a regular file: ${file}`,
+      "BAD_REQUEST",
+      400,
+    );
+  }
+  if (stats.size === 0) {
+    throw new ApiRequestError(
+      "Image file must not be empty",
+      "BAD_REQUEST",
+      400,
+    );
+  }
+  if (stats.size > ZERO_RECOGNITION_MAX_FILE_BYTES) {
+    throw new ApiRequestError(
+      "Image file must be 20 MB or smaller",
+      "PAYLOAD_TOO_LARGE",
+      413,
+    );
+  }
+
+  const contentType = inferWebUploadContentType(file);
+  const parsed = zeroRecognitionImageMimeTypeSchema.safeParse(contentType);
+  if (!parsed.success) {
+    throw new ApiRequestError(
+      "Image must be a PNG, JPEG, or WebP file",
+      "BAD_REQUEST",
+      400,
+    );
+  }
+  return parsed.data;
+}
+
+export const zeroRecognizeCommand = new Command()
+  .name("recognize")
+  .description("Recognize one image through a managed multimodal model")
+  .requiredOption("-f, --file <path>", "Local PNG, JPEG, or WebP image")
+  .requiredOption("-p, --prompt <instruction>", "Recognition instruction")
+  .action(
+    withErrorHandler(async (options: RecognizeOptions) => {
+      const prompt = validatePrompt(options.prompt);
+      const contentType = validateImageFile(options.file);
+      const uploaded = await uploadWebFile(options.file, { contentType });
+      const response = await callZeroRecognition({
+        fileId: uploaded.id,
+        prompt,
+      });
+      console.log(response.text);
+    }),
+  )
+  .addHelpText(
+    "after",
+    `
+Example:
+  zero recognize --file ./screenshot.png --prompt "Describe the error shown"
+
+Notes:
+  - Available only in runs whose selected model does not support image input
+  - Accepts one PNG, JPEG, or WebP image up to 20 MB
+  - Uses a fixed vm0-managed recognition model and prints only recognized text`,
+  );

--- a/turbo/apps/cli/src/lib/api/domains/zero-recognition.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-recognition.ts
@@ -1,0 +1,20 @@
+import {
+  zeroRecognitionContract,
+  type ZeroRecognitionRequest,
+  type ZeroRecognitionResponse,
+} from "@vm0/api-contracts/contracts/zero-recognition";
+import { initClient } from "@vm0/api-contracts/contracts/trpc-contract";
+
+import { getClientConfig, handleError } from "../core/client-factory";
+
+export async function callZeroRecognition(
+  body: ZeroRecognitionRequest,
+): Promise<ZeroRecognitionResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroRecognitionContract, config);
+  const result = await client.recognize({ headers: {}, body });
+  if (result.status === 200) {
+    return result.body;
+  }
+  handleError(result, "Failed to recognize image");
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -259,6 +259,7 @@ export {
   callZeroWebSearch,
   type ZeroWebSearchResponse,
 } from "./domains/zero-web-search";
+export { callZeroRecognition } from "./domains/zero-recognition";
 export {
   callZeroFinanceChart,
   callZeroFinanceProfile,

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -66,6 +66,7 @@ const COMMAND_CAPABILITY_MAP: Record<
   scrape: "scrape:read",
   "people-search": "people-search:read",
   "web-search": "web-search:read",
+  recognize: "image-recognition:write",
   finance: "finance:read",
   banking: "banking:read",
 };
@@ -74,7 +75,10 @@ const COMMAND_FEATURE_SWITCH_MAP: Readonly<
   Partial<Record<string, FeatureSwitchKey>>
 > = {
   browser: FeatureSwitchKey.ZeroBrowser,
+  recognize: FeatureSwitchKey.ZeroImageRecognition,
 };
+
+const RUN_ONLY_COMMANDS = new Set(["recognize"]);
 
 type FeatureSwitchOverrides = Partial<Record<FeatureSwitchKey, boolean>>;
 
@@ -355,6 +359,13 @@ const ZERO_COMMAND_DEFINITIONS: readonly ZeroCommandDefinition[] = [
     },
   },
   {
+    name: "recognize",
+    description: "Recognize one image through a managed multimodal model",
+    load: async () => {
+      return (await import("./commands/zero/recognize")).zeroRecognizeCommand;
+    },
+  },
+  {
     name: "finance",
     description: "Query financial instruments through managed zero finance",
     load: async () => {
@@ -392,7 +403,7 @@ function shouldHideCommand(
   if (!isCommandFeatureEnabled(name, payload, featureSwitchOverrides)) {
     return true;
   }
-  if (!payload) return false;
+  if (!payload) return RUN_ONLY_COMMANDS.has(name);
   const requiredCap = COMMAND_CAPABILITY_MAP[name];
   if (requiredCap === undefined) return true;
   if (requiredCap === null) return false;
@@ -569,6 +580,12 @@ export function buildZeroHelpText(
     ...commandExampleIfVisible(
       "web-search",
       '  Search the public web? zero web-search "latest news" --json',
+      payload,
+      featureSwitchOverrides,
+    ),
+    ...commandExampleIfVisible(
+      "recognize",
+      '  Recognize an image?    zero recognize --file ./image.png --prompt "Describe it"',
       payload,
       featureSwitchOverrides,
     ),

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -617,7 +617,8 @@ export function buildZeroHelpText(
  * Register commands with visibility based on ZERO_TOKEN capabilities.
  * Commands not granted by the token are registered as hidden via
  * Commander's public `addCommand(cmd, { hidden: true })` API.
- * When no ZERO_TOKEN is present, all commands remain visible.
+ * Without ZERO_TOKEN, globally available commands stay visible while
+ * run-only commands remain hidden.
  *
  * @param commands - override default commands (used in tests)
  */

--- a/turbo/packages/api-contracts/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/composes.test.ts
@@ -40,8 +40,8 @@ describe("agentDefinitionSchema strips unknown experimental_capabilities", () =>
 });
 
 describe("ZERO_CAPABILITIES", () => {
-  it("should have exactly 38 capabilities", () => {
-    expect(ZERO_CAPABILITIES).toHaveLength(38);
+  it("should have exactly 39 capabilities", () => {
+    expect(ZERO_CAPABILITIES).toHaveLength(39);
   });
 
   it("should follow {resource}:{action} naming pattern", () => {
@@ -113,6 +113,10 @@ describe("ZERO_CAPABILITIES", () => {
   it("should include managed web-search read capability", () => {
     expect(ZERO_CAPABILITIES).toContain("web-search:read");
     expect(ZERO_CAPABILITIES).toContain("people-search:read");
+  });
+
+  it("should include managed image recognition capability", () => {
+    expect(ZERO_CAPABILITIES).toContain("image-recognition:write");
   });
 
   it("should include managed finance read capability", () => {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/zero-recognition.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/zero-recognition.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ZERO_RECOGNITION_MAX_PROMPT_CHARS,
+  ZERO_RECOGNITION_MAX_TEXT_CHARS,
+  zeroRecognitionImageMimeTypeSchema,
+  zeroRecognitionRequestSchema,
+  zeroRecognitionResponseSchema,
+} from "../zero-recognition";
+
+describe("zero recognition contract", () => {
+  it("accepts one owned file id and a trimmed prompt", () => {
+    expect(
+      zeroRecognitionRequestSchema.parse({
+        fileId: "00000000-0000-4000-8000-000000000001",
+        prompt: "  describe this image  ",
+      }),
+    ).toStrictEqual({
+      fileId: "00000000-0000-4000-8000-000000000001",
+      prompt: "describe this image",
+    });
+  });
+
+  it("rejects empty and oversized prompts", () => {
+    expect(
+      zeroRecognitionRequestSchema.safeParse({
+        fileId: "00000000-0000-4000-8000-000000000001",
+        prompt: "   ",
+      }).success,
+    ).toBe(false);
+    expect(
+      zeroRecognitionRequestSchema.safeParse({
+        fileId: "00000000-0000-4000-8000-000000000001",
+        prompt: "x".repeat(ZERO_RECOGNITION_MAX_PROMPT_CHARS + 1),
+      }).success,
+    ).toBe(false);
+  });
+
+  it("shares the supported image MIME policy", () => {
+    for (const contentType of ["image/png", "image/jpeg", "image/webp"]) {
+      expect(zeroRecognitionImageMimeTypeSchema.parse(contentType)).toBe(
+        contentType,
+      );
+    }
+    expect(
+      zeroRecognitionImageMimeTypeSchema.safeParse("image/gif").success,
+    ).toBe(false);
+  });
+
+  it("bounds successful recognition output", () => {
+    expect(
+      zeroRecognitionResponseSchema.safeParse({
+        text: "x".repeat(ZERO_RECOGNITION_MAX_TEXT_CHARS + 1),
+        metadata: { creditsCharged: 1 },
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/composes.ts
+++ b/turbo/packages/api-contracts/src/contracts/composes.ts
@@ -51,6 +51,7 @@ export const ZERO_CAPABILITIES = [
   "scrape:read",
   "people-search:read",
   "web-search:read",
+  "image-recognition:write",
   "finance:read",
   "computer-use:write",
   "browser:read",
@@ -169,6 +170,10 @@ export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
     "web-search:read": {
       group: "Web Search",
       label: "Use managed web search",
+    },
+    "image-recognition:write": {
+      group: "Image Recognition",
+      label: "Recognize uploaded images",
     },
     "finance:read": {
       group: "Finance",

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -144,6 +144,19 @@ export {
   type TestAgentRunsContract,
 } from "./test-agent-runs";
 export {
+  ZERO_RECOGNITION_MAX_FILE_BYTES,
+  ZERO_RECOGNITION_MAX_PROMPT_CHARS,
+  ZERO_RECOGNITION_MAX_TEXT_CHARS,
+  zeroRecognitionContract,
+  zeroRecognitionImageMimeTypeSchema,
+  zeroRecognitionRequestSchema,
+  zeroRecognitionResponseSchema,
+  type ZeroRecognitionContract,
+  type ZeroRecognitionImageMimeType,
+  type ZeroRecognitionRequest,
+  type ZeroRecognitionResponse,
+} from "./zero-recognition";
+export {
   zeroModelPoliciesMainContract,
   type ZeroModelPoliciesMainContract,
 } from "./zero-model-policies";

--- a/turbo/packages/api-contracts/src/contracts/zero-recognition.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-recognition.ts
@@ -45,6 +45,7 @@ const recognitionResponses = {
   403: apiErrorSchema,
   404: apiErrorSchema,
   413: apiErrorSchema,
+  500: apiErrorSchema,
   502: apiErrorSchema,
   503: apiErrorSchema,
 } as const;

--- a/turbo/packages/api-contracts/src/contracts/zero-recognition.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-recognition.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const ZERO_RECOGNITION_MAX_FILE_BYTES = 20 * 1024 * 1024;
+export const ZERO_RECOGNITION_MAX_PROMPT_CHARS = 8_192;
+export const ZERO_RECOGNITION_MAX_TEXT_CHARS = 32_768;
+
+export const zeroRecognitionImageMimeTypeSchema = z.enum([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+]);
+
+export const zeroRecognitionRequestSchema = z.object({
+  fileId: z.string().uuid(),
+  prompt: z.string().trim().min(1).max(ZERO_RECOGNITION_MAX_PROMPT_CHARS),
+});
+
+export const zeroRecognitionResponseSchema = z.object({
+  text: z.string().trim().min(1).max(ZERO_RECOGNITION_MAX_TEXT_CHARS),
+  metadata: z.object({
+    creditsCharged: z.number().int().nonnegative(),
+  }),
+});
+
+export type ZeroRecognitionImageMimeType = z.infer<
+  typeof zeroRecognitionImageMimeTypeSchema
+>;
+export type ZeroRecognitionRequest = z.infer<
+  typeof zeroRecognitionRequestSchema
+>;
+export type ZeroRecognitionResponse = z.infer<
+  typeof zeroRecognitionResponseSchema
+>;
+
+const recognitionResponses = {
+  200: zeroRecognitionResponseSchema,
+  400: apiErrorSchema,
+  401: apiErrorSchema,
+  402: apiErrorSchema,
+  403: apiErrorSchema,
+  404: apiErrorSchema,
+  413: apiErrorSchema,
+  502: apiErrorSchema,
+  503: apiErrorSchema,
+} as const;
+
+export const zeroRecognitionContract = c.router({
+  recognize: {
+    method: "POST",
+    path: "/api/zero/recognize",
+    headers: authHeadersSchema,
+    body: zeroRecognitionRequestSchema,
+    responses: recognitionResponses,
+    summary: "Recognize one owned image through a managed multimodal model",
+  },
+});
+
+export type ZeroRecognitionContract = typeof zeroRecognitionContract;

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -54,6 +54,9 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.ZeroChatMessaging, {})).toBe(
       false,
     );
+    expect(isFeatureEnabled(FeatureSwitchKey.ZeroImageRecognition, {})).toBe(
+      false,
+    );
   });
 
   it("should return false for disabled switch with non-matching userId", () => {
@@ -127,6 +130,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroBrowser]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroChatMessaging]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ZeroImageRecognition]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ClaudeSessionPruning]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(true);
@@ -159,6 +163,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroBrowser]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroChatMessaging]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ZeroImageRecognition]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ClaudeSessionPruning]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -43,6 +43,7 @@ export enum FeatureSwitchKey {
   ZeroDebug = "zeroDebug",
   ZeroBrowser = "zeroBrowser",
   ZeroChatMessaging = "zeroChatMessaging",
+  ZeroImageRecognition = "zeroImageRecognition",
   ZeroMailReplyFollowUp = "zeroMailReplyFollowUp",
   Banking = "banking",
   Lab = "lab",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -509,6 +509,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ZeroImageRecognition]: {
+    maintainer: "liangyou@vm0.ai",
+    description:
+      "Enable managed image recognition for Zero runs whose selected model does not support image input.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ComposerConnectorPermissions]: {
     maintainer: "ming@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add a feature-gated `zero recognize --file <path> --prompt <instruction>` fallback for runs whose final routed model explicitly does not support image input
- derive prompt guidance and the dedicated `image-recognition:write` capability from the same final-run eligibility decision
- add a Zero-only owned-artifact API that performs one fixed Gemini recognition call and returns text only after exact usage settlement
- validate image and prompt bounds in both the CLI and API, map bounded provider failures, and keep raw provider responses out of API errors

## Scope

- no runner or guest protocol change
- no schema or data migration
- no selectable recognition model, retry, arbitrary image URL, or automatic replacement of the run model
- rollout remains gated by `ZeroImageRecognition`; production must have all three `google/gemini-3.5-flash` usage-pricing categories before enablement

## Validation

- `pnpm format`
- Core: lint, typecheck, and full package Vitest (213 tests)
- API contracts: lint, typecheck, and full package Vitest (524 tests)
- CLI: lint, typecheck, and full package Vitest (988 passed, 1 skipped)
- API: lint and typecheck
- focused API recognition, token, and run-lifecycle integration tests
- `pnpm knip`
- `lefthook run pre-commit`
- `git diff --check`

The full local API package suite was also investigated. It exposes pre-existing shared-database and order-dependent failures that pass in isolation; all API integration tests covering this change pass.

Closes #24377
