### PR TITLE
fix(platform): keep chat skeleton until the initial remote event sync resolves

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -169,6 +169,9 @@ export interface ChatThreadSignals {
   latestRunFinishCreatedAt$: Computed<Promise<string | undefined>>;
   latestAssistantTextCreatedAt$: Computed<Promise<string | undefined>>;
   indexedDbEventsLoading$: Computed<boolean>;
+  // Resolves once the initial remote event sync (first network fetch) has
+  // completed, so an empty thread is not rendered until we know it is empty.
+  initialEventsSyncResolved$: Computed<boolean>;
   visibleRenderedChatGroups$: Computed<Promise<ChatEventGroup[]>>;
   visibleRenderedChatGroupsReady$: Computed<Promise<boolean>>;
   eventImageGroups$: Computed<Promise<EventImageGroupProjection[]>>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -3231,6 +3231,7 @@ function createMarkThreadReadIfNeeded({
 function createOnSubscribedCommand({
   threadId,
   syncRemoteEvents$,
+  initialEventsSyncResolved$,
   reloadArtifacts$,
   reloadMailDrafts$,
   reloadComposerWorkflows$,
@@ -3246,6 +3247,7 @@ function createOnSubscribedCommand({
   | "dataSource"
 > & {
   markThreadReadIfNeeded$: Command<Promise<void>, [AbortSignal]>;
+  initialEventsSyncResolved$: State<boolean>;
 }): Command<Promise<void>, [AbortSignal]> {
   const optimisticCreateUnsettled$ =
     optimisticChatThreadCreateUnsettled(threadId);
@@ -3264,7 +3266,24 @@ function createOnSubscribedCommand({
       set(reloadComposerWorkflows$, signal),
     ];
     if (!get(optimisticCreateUnsettled$)) {
-      catchUpPromises.push(set(syncRemoteEvents$, signal));
+      // The skeleton stays visible until the first remote events fetch
+      // resolves, so an unsynced thread is not mistaken for an empty one.
+      // The flag also resolves on failure so a broken fetch never leaves the
+      // chat stuck on the skeleton.
+      catchUpPromises.push(
+        set(syncRemoteEvents$, signal).then(
+          () => {
+            set(initialEventsSyncResolved$);
+          },
+          () => {
+            set(initialEventsSyncResolved$);
+          },
+        ),
+      );
+    } else {
+      // Optimistic creates skip the initial remote events fetch; resolve
+      // immediately so the empty state can render once the create settles.
+      set(initialEventsSyncResolved$);
     }
     await Promise.all(catchUpPromises);
     signal.throwIfAborted();
@@ -3314,6 +3333,7 @@ function createRunTracking({
   dataSource,
 }: RunTrackingDeps) {
   const locallyMarkedReadAt$ = state<string | undefined>(undefined);
+  const initialEventsSyncResolved$ = state(false);
 
   const markThreadReadIfNeeded$ = createMarkThreadReadIfNeeded({
     threadId,
@@ -3331,6 +3351,7 @@ function createRunTracking({
   const onSubscribed$ = createOnSubscribedCommand({
     threadId,
     syncRemoteEvents$,
+    initialEventsSyncResolved$,
     reloadArtifacts$,
     reloadMailDrafts$,
     reloadComposerWorkflows$,
@@ -3390,7 +3411,13 @@ function createRunTracking({
     ]);
   });
 
-  return { receiveSyncedEvents$, subscribeChatThread$ };
+  return {
+    receiveSyncedEvents$,
+    subscribeChatThread$,
+    initialEventsSyncResolved$: computed((get) => {
+      return get(initialEventsSyncResolved$);
+    }),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -4831,6 +4858,7 @@ export function createChatThreadSignals(
     ...publicChatThreadEventSignals(events),
     receiveSyncedEvents$: runTracking.receiveSyncedEvents$,
     subscribeChatThread$: runTracking.subscribeChatThread$,
+    initialEventsSyncResolved$: runTracking.initialEventsSyncResolved$,
     ...createThinkingIndicatorSignals(
       events.thinkingText$,
       events.thinkingEventId$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
@@ -191,7 +191,7 @@ describe("chat lifecycle", () => {
         expect(initialPageRequested).toBeTruthy();
       });
       expect(beforeSeqIds).toStrictEqual([]);
-      expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
+      expect(document.querySelector("[data-chat-skeleton]")).not.toBeNull();
 
       initialPageGate.resolve();
       await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -528,7 +528,7 @@ describe("zero chat thread IndexedDB fallback", () => {
     }
   });
 
-  it("hides the message skeleton after IndexedDB loads without waiting for remote events", async () => {
+  it("shows the message skeleton until an uncached remote thread is confirmed empty", async () => {
     prepareDefaultAgent();
     mockCurrentThreadDetail();
     mockSidebarThread();
@@ -547,11 +547,13 @@ describe("zero chat thread IndexedDB fallback", () => {
       await messageListRequested.promise;
 
       await waitFor(() => {
-        expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
+        expect(document.querySelector("[data-chat-skeleton]")).toBeInstanceOf(
+          HTMLElement,
+        );
       });
       expect(
-        screen.getByText("Send a message to start the conversation"),
-      ).toBeInTheDocument();
+        screen.queryByText("Send a message to start the conversation"),
+      ).not.toBeInTheDocument();
       expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
 
       initialMessageList.resolve();

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2639,7 +2639,13 @@ function ChatThreadEmptyState({ thread }: { thread: ChatThreadSignals }) {
     useLastResolved(thread.visibleRenderedChatGroupsReady$) ?? false;
   const threadSettledInServer = useGet(thread.threadSettledInServer$);
   const hasEvents = useLastResolved(thread.hasEvents$);
-  if (!renderedGroupsReady || !threadSettledInServer || hasEvents !== false) {
+  const initialEventsSyncResolved = useGet(thread.initialEventsSyncResolved$);
+  if (
+    !renderedGroupsReady ||
+    !threadSettledInServer ||
+    hasEvents !== false ||
+    !initialEventsSyncResolved
+  ) {
     return null;
   }
   return (
@@ -3487,8 +3493,15 @@ function RunGroupFoldRow({
 }
 
 function ChatThreadSkeletonOverlay({ thread }: { thread: ChatThreadSignals }) {
-  const indexedDbEventsLoading = useGet(thread.indexedDbEventsLoading$);
-  if (!indexedDbEventsLoading) {
+  const renderedGroupsReadyLoadable = useLastLoadable(
+    thread.visibleRenderedChatGroupsReady$,
+  );
+  const sessionError = resolveSessionError(renderedGroupsReadyLoadable);
+  const hasEvents = useLastResolved(thread.hasEvents$);
+  const initialEventsSyncResolved = useGet(thread.initialEventsSyncResolved$);
+  // Keep the skeleton until the first remote events fetch resolves so an
+  // unsynced thread is not shown as an empty one before we know it is empty.
+  if (hasEvents !== false || initialEventsSyncResolved || sessionError) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Restores the pre-#24335 behavior where a chat thread that has no locally synced events keeps showing the skeleton until the first remote events fetch resolves, instead of flashing the empty state ("Send a message to start the conversation") while the initial sync is still in flight.

- Re-introduce a per-thread `initialEventsSyncResolved$` signal that resolves after the first remote events sync (or immediately for optimistic unsettled creates, which skip the initial fetch)
- `ChatThreadSkeletonOverlay` now shows while `hasEvents === false && !initialEventsSyncResolved`
- `ChatThreadEmptyState` additionally requires `initialEventsSyncResolved`, so an unsynced thread is not rendered as empty before we know it is empty
- Revert the two test assertions changed by #24335 that encoded the premature-empty-state behavior

## Why

PR #24335 ("fix(platform): unify chat event loading and scroll effects") replaced the skeleton condition (previously `hasEvents === false && hasNewEventsState === "loading"`, where `hasNewEvents$` awaited the initial remote event sync) with a check on `indexedDbEventsLoading$`, which only covers the IndexedDB read. The empty state was un-gated, so a completely unsynced local thread shows the empty state before the first network request finishes.

## Testing

- `pnpm format` (style matched manually, no pnpm available in guest env)
- platform-scoped Vitest relies on the PR pipeline per AGENTS.md workflow