### PR TITLE
test(e2e): settle late runner usage deterministically

### DIFF
--- a/e2e/helpers/setup.bash
+++ b/e2e/helpers/setup.bash
@@ -331,6 +331,15 @@ zero_usage_runs_response() {
     e2e_api_curl "/api/zero/usage/runs?runId=$run_id&pageSize=1"
 }
 
+settle_zero_usage_run() {
+    local run_id="$1"
+    local payload
+    payload=$(jq -nc --arg runId "$run_id" '{run_id: $runId}')
+    e2e_api_curl "/api/test/usage-settlement/process" \
+        -X POST \
+        -d "$payload" >/dev/null
+}
+
 zero_run_response() {
     local run_id="$1"
     e2e_api_curl "/api/zero/runs/$run_id"
@@ -375,6 +384,7 @@ wait_for_zero_usage_run() {
     local count=""
 
     while (( SECONDS - start < timeout )); do
+        settle_zero_usage_run "$run_id" || return 1
         if body=$(zero_usage_runs_response "$run_id" 2>&1); then
             count=$(printf '%s' "$body" | jq -r '.runs | length')
             if [[ "$count" == "1" ]]; then

--- a/turbo/apps/api/src/signals/e2e-routes.ts
+++ b/turbo/apps/api/src/signals/e2e-routes.ts
@@ -15,6 +15,7 @@ import { testTelegramStateRoutes } from "./routes/test-telegram-state";
 import { testTeamsDispatchProbeRoutes } from "./routes/test-teams-dispatch-probe";
 import { testTeamsMockRoutes } from "./routes/test-teams-mock";
 import { testTeamsStateRoutes } from "./routes/test-teams-state";
+import { testUsageSettlementRoutes } from "./routes/test-usage-settlement";
 import { testZeroAgentStateRoutes } from "./routes/test-zero-agent-state";
 
 /**
@@ -38,13 +39,16 @@ import { testZeroAgentStateRoutes } from "./routes/test-zero-agent-state";
  * - state routes and the Teams dispatch probe: fixture seeding and provider
  *   ingress used by `e2e/helpers/slack.bash`, `e2e/helpers/telegram.bash`,
  *   and `e2e/helpers/teams.bash`.
+ * - `test-usage-settlement`: an explicit billing barrier for runner E2E after
+ *   proxy usage delivery races run completion.
  *
  * Every route here is gated by `isTestEndpointAllowed` (development or
  * preview-with-bypass only) and returns 404 in production.
  *
- * API integration tests (vitest) must NOT use these routes: construct state
- * through real production APIs, mock external providers with MSW, and assert
- * through product read surfaces instead.
+ * API integration tests (vitest) must NOT use these routes as fixture
+ * shortcuts: outside route-specific contract tests, construct state through
+ * real production APIs, mock external providers with MSW, and assert through
+ * product read surfaces instead.
  */
 export const E2E_ROUTES: readonly RouteEntry[] = [
   ...cliAuthTestRoutes,
@@ -63,5 +67,6 @@ export const E2E_ROUTES: readonly RouteEntry[] = [
   ...testTeamsDispatchProbeRoutes,
   ...testTeamsMockRoutes,
   ...testTeamsStateRoutes,
+  ...testUsageSettlementRoutes,
   ...testZeroAgentStateRoutes,
 ];

--- a/turbo/apps/api/src/signals/routes/__tests__/test-usage-settlement.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-usage-settlement.test.ts
@@ -45,6 +45,43 @@ describe("POST /api/test/usage-settlement/process", () => {
     await expect(response.text()).resolves.toBe("Not found");
   });
 
+  it("returns 400 for an invalid run ID", async () => {
+    const app = createAppWithRoutes({
+      signal: context.signal,
+      routes: testUsageSettlementRoutes,
+    });
+
+    const response = await app.request(
+      testUsageSettlementContract.process.path,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ run_id: "not-a-run-id" }),
+      },
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 404 for an unknown run ID", async () => {
+    const app = createAppWithRoutes({
+      signal: context.signal,
+      routes: testUsageSettlementRoutes,
+    });
+
+    const response = await app.request(
+      testUsageSettlementContract.process.path,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ run_id: randomUUID() }),
+      },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+  });
+
   it("settles usage that arrives after an earlier run settlement", async () => {
     const fixture = await store.set(
       seedUsageInsightFixture$,

--- a/turbo/apps/api/src/signals/routes/__tests__/test-usage-settlement.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-usage-settlement.test.ts
@@ -16,6 +16,8 @@ import {
   deleteUsageInsightFixture$,
   insertUsageEvent$,
   readUsageEventState$,
+  seedCompose$,
+  seedRun$,
   seedUsageInsightFixture$,
 } from "./helpers/zero-usage-insight";
 
@@ -41,6 +43,63 @@ describe("POST /api/test/usage-settlement/process", () => {
 
     expect(response.status).toBe(404);
     await expect(response.text()).resolves.toBe("Not found");
+  });
+
+  it("settles usage that arrives after an earlier run settlement", async () => {
+    const fixture = await store.set(
+      seedUsageInsightFixture$,
+      undefined,
+      context.signal,
+    );
+    onTestFinished(async () => {
+      await store.set(deleteUsageInsightFixture$, fixture, context.signal);
+    });
+    const compose = await store.set(seedCompose$, fixture, context.signal);
+    const { runId } = await store.set(
+      seedRun$,
+      { ...fixture, composeId: compose.composeId },
+      context.signal,
+    );
+    const app = createAppWithRoutes({
+      signal: context.signal,
+      routes: testUsageSettlementRoutes,
+    });
+    const requestSettlement = () => {
+      return app.request(testUsageSettlementContract.process.path, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ run_id: runId }),
+      });
+    };
+
+    expect((await requestSettlement()).status).toBe(200);
+
+    const idempotencyKey = randomUUID();
+    await store.set(
+      insertUsageEvent$,
+      {
+        ...fixture,
+        runId,
+        kind: "model",
+        provider: "historical-model",
+        category: "tokens.input",
+        quantity: 100,
+        grossCredits: 7,
+        idempotencyKey,
+      },
+      context.signal,
+    );
+
+    const response = await requestSettlement();
+
+    expect(response.status).toBe(200);
+    await expect(
+      store.set(readUsageEventState$, idempotencyKey, context.signal),
+    ).resolves.toMatchObject({
+      status: "processed",
+      grossCredits: 7,
+      creditsCharged: 7,
+    });
   });
 
   it("uses precomputed credits only for historical model events", async () => {

--- a/turbo/apps/api/src/signals/routes/test-usage-settlement.ts
+++ b/turbo/apps/api/src/signals/routes/test-usage-settlement.ts
@@ -1,8 +1,11 @@
 import { testUsageSettlementContract } from "@vm0/api-contracts/contracts/test-usage-settlement";
+import { agentRuns } from "@vm0/db/schema/agent-run";
 import { command } from "ccstate";
+import { eq } from "drizzle-orm";
 
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
+import { db$ } from "../external/db";
 import type { RouteEntry } from "../route-entry";
 import { processOrgUsageEvents$ } from "../services/zero-credit-usage.service";
 import {
@@ -24,7 +27,23 @@ const processUsageSettlement$ = command(
       return bodyResult.response;
     }
 
-    await set(processOrgUsageEvents$, bodyResult.data.org_id, signal);
+    let orgId: string;
+    if ("org_id" in bodyResult.data) {
+      orgId = bodyResult.data.org_id;
+    } else {
+      const [run] = await get(db$)
+        .select({ orgId: agentRuns.orgId })
+        .from(agentRuns)
+        .where(eq(agentRuns.id, bodyResult.data.run_id))
+        .limit(1);
+      signal.throwIfAborted();
+      if (!run) {
+        return testEndpointNotFoundResponse();
+      }
+      orgId = run.orgId;
+    }
+
+    await set(processOrgUsageEvents$, orgId, signal);
     signal.throwIfAborted();
     return { status: 200 as const, body: { ok: true as const } };
   },

--- a/turbo/packages/api-contracts/src/contracts/test-usage-settlement.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-usage-settlement.ts
@@ -5,9 +5,14 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
-export const testUsageSettlementRequestSchema = z.object({
-  org_id: z.string().min(1),
-});
+export const testUsageSettlementRequestSchema = z.union([
+  z.object({
+    org_id: z.string().min(1),
+  }),
+  z.object({
+    run_id: z.string().min(1),
+  }),
+]);
 
 export const testUsageSettlementResponseSchema = z.object({
   ok: z.literal(true),
@@ -23,7 +28,7 @@ export const testUsageSettlementContract = c.router({
       400: apiErrorSchema,
       404: z.string(),
     },
-    summary: "Process one organization's usage in API tests",
+    summary: "Process one organization's usage in tests",
   },
 });
 

--- a/turbo/packages/api-contracts/src/contracts/test-usage-settlement.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-usage-settlement.ts
@@ -10,7 +10,7 @@ export const testUsageSettlementRequestSchema = z.union([
     org_id: z.string().min(1),
   }),
   z.object({
-    run_id: z.string().min(1),
+    run_id: z.string().uuid(),
   }),
 ]);
 


### PR DESCRIPTION
## Summary

- resolve preview-only usage settlement by run ID
- settle pending usage during runner E2E usage polling
- cover usage that arrives after completion-time settlement

## Root cause

Runner completion triggers proxy usage flushing without waiting. The API can settle the organization before the proxy webhook inserts usage. Preview deployments do not run the production usage-processing cron, so late usage remains pending and the runner E2E test polls finalized usage until timeout.

Original failure: https://github.com/vm0-ai/vm0/actions/runs/30645849552/job/91207667851

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-usage-settlement.test.ts`
- `pnpm -F @vm0/api-contracts test`
- `pnpm knip`
- `bash -n e2e/helpers/setup.bash`