### PR TITLE
refactor(api): use slug in diagnostic connector summaries

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-developer-support.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-developer-support.test.ts
@@ -11,6 +11,7 @@ import { server } from "../../../mocks/server";
 import { now } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 
@@ -388,8 +389,16 @@ describe("POST /api/zero/developer-support", () => {
     expect(response.body.error.code).toBe("INVALID_CONSENT_CODE");
   });
 
-  it("submits a diagnostic bundle with a valid consent code", async () => {
+  it("submits canonical connector summaries with a valid consent code", async () => {
     const seed = await seedSupportActor();
+    const connectors = createConnectorBddApi(context);
+    await connectors.connectManualGrant(
+      seed.actor,
+      "runtime",
+      "api-token",
+      { apiKey: "diagnostic-runtime-key" },
+      seed.agentId,
+    );
     const run = await createSupportRun(seed);
     const token = zeroToken({ ...seed, runId: run.runId });
     const consent = await accept(
@@ -412,6 +421,17 @@ describe("POST /api/zero/developer-support", () => {
     expect(requireReference(response.body)).toMatch(/^ds-[a-f0-9]{8}$/);
     const putInput = putObjectInput();
     expect(putInput.Key).toContain("developer-support/");
+    const connectorSummaries: unknown = JSON.parse(
+      zipText(uploadedZip(), "connectors.json"),
+    );
+    expect(connectorSummaries).toStrictEqual([
+      {
+        slug: "runtime",
+        authMethod: "api-token",
+        connectionStatus: "connected",
+        externalUsername: null,
+      },
+    ]);
   });
 
   it("falls back to the current runId when a run has no session", async () => {

--- a/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
+++ b/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
@@ -348,7 +348,7 @@ function safeConnectorSummaries(
 ): Record<string, unknown>[] {
   return connectors.map((connector) => {
     return {
-      type: connector.slug,
+      slug: connector.slug,
       authMethod: connector.authMethod,
       connectionStatus: connector.connectionStatus,
       externalUsername: connector.externalUsername,


### PR DESCRIPTION
## Summary

- rename the connector identity field in newly generated diagnostic `connectors.json` files from `type` to `slug`
- exercise the developer-support API with a real connector grant and assert the exact safe connector summary written to the uploaded ZIP

This completes #24347 and contributes to the connector `ref`/`type` to `slug` cleanup tracked by #23619.

## Scope

- changes only newly generated developer-support and error-report diagnostic bundles through their shared serializer
- does not change database schema, persisted records, public HTTP contracts, CLI or runner protocols, or historical bundles
- intentionally does not dual-write the legacy `type` alias because the repository has no consumer of this internal diagnostic artifact

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/diagnostic-bundle.service.ts apps/api/src/signals/routes/__tests__/zero-developer-support.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-developer-support.test.ts --silent=passed-only`
- `pnpm knip --workspace api`
- pre-commit full Turbo Knip and type checks
- `git diff --check`

Closes #24347
Parent: #23619
