### PR TITLE
test(api): synchronize stale sweep on durable queue event

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -409,17 +409,32 @@ describe("workflow queue", () => {
     mockNow(Date.UTC(2020, 0, 1));
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
-    const admissionLock = await holdOrgAdmissionLockFixture({
-      orgId: scenario.orgId,
-      signal: context.signal,
-    });
-    onTestFinished(async () => {
-      admissionLock.release();
-      await admissionLock.done;
+    const workflowPublishStarted = createDeferredPromise<void>(context.signal);
+    const releaseWorkflowPublish = createDeferredPromise<void>(context.signal);
+    let heldWorkflowPublish = false;
+    context.mocks.ably.publish.mockImplementation((topic: unknown) => {
+      if (
+        !heldWorkflowPublish &&
+        topic === `chatThreadMessageCreated:${automation.threadId}`
+      ) {
+        heldWorkflowPublish = true;
+        workflowPublishStarted.resolve(undefined);
+        return releaseWorkflowPublish.promise;
+      }
+      return Promise.resolve(undefined);
     });
 
     const workflowRequest = postWorkflowWebhook(automation, "fresh event");
-    await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
+    onTestFinished(async () => {
+      if (!releaseWorkflowPublish.settled()) {
+        releaseWorkflowPublish.resolve(undefined);
+      }
+      await Promise.allSettled([workflowRequest]);
+    });
+    // The first realtime publish happens after the queue event transaction has
+    // committed and before this request can drain it. This is the durable
+    // product milestone the stale sweep races, without observing pg_locks.
+    await workflowPublishStarted.promise;
     const event = (await pendingWorkflowEvents(automation.threadId))[0];
     if (!event) {
       throw new Error("Expected a pending workflow event");
@@ -430,9 +445,8 @@ describe("workflow queue", () => {
     await cleanupSandboxes();
     await expectSweepLeftQueueUntouched(automation.threadId, [event.id]);
 
-    admissionLock.release();
+    releaseWorkflowPublish.resolve(undefined);
     const result = await workflowRequest;
-    await admissionLock.done;
     const runId = await expectAcceptedRunId(result, automation.threadId);
     await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
       runId,


### PR DESCRIPTION
## Why

Turbo main run https://github.com/vm0-ai/vm0/actions/runs/30645817009 at SHA `0f590fb7d83663174f8d1242cd4aa56a0ab41ab3` failed in `test-api (5)` with:

```
workflow queue > does not let the stale sweep race a newly admitted workflow event
AssertionError: expected 0 to be greater than or equal to 1
Caused by: Error: Matcher did not succeed in time.
```

The same SHA passed in merge-group run https://github.com/vm0-ai/vm0/actions/runs/30645296996. In the passing run the file finished in 13.5s and this test in 605ms; in the failing main run the file took 29.7s and this test burned 2.43s. The queued PR #24380 did not touch this test or its synchronization path.

This test was introduced by #23051. #23065 and #23084 removed exact equality against the cluster-wide waiter count, but retained a lower-bound `expect.poll(admissionLock.waiterCount)` as the entry barrier. That still requires the request to traverse queue persistence, realtime publication, and drain setup far enough to block on the org advisory lock within the default poll window. Under shard contention it had not reached that internal lock before the poll expired, so the observed count remained zero. The trailing `AbortError: Aborted due to finished test` is teardown noise after the assertion failure.

The run also had two independent failures that are not duplicated here:

- `deploy-app` could not connect to `api.cloudflare.com:443` (`curl: (7)`), an external network failure.
- `serializes concurrent workflow admissions for the same thread` observed no run after a queue-head claim loss. #24379 already retries that production race and is ahead in the merge queue; its API shard passes.

## Fix

Synchronize the stale-sweep test on the durable product boundary instead of `pg_locks`:

- pause the first `chatThreadMessageCreated` realtime publish for this thread; this call occurs after the queue event transaction commits and before the admitting request can drain it
- run the stale sweep while the committed event is held at that boundary
- assert through thread event state that the fresh event remains pending and no run was created
- release the publish and await the original request
- make teardown release and settle the owned request on assertion failure

No sleeps, retries, raised timeouts, or production changes.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (all packages and API Oxlint passed; API ESLint initially exhausted the default 2 GiB heap)
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api exec eslint . --max-warnings 0`
- final changed-file Oxlint, type-aware Oxlint, and ESLint
- `pnpm knip`
- staged repository type checks, including `pnpm --filter api run check-types`
- `zero-workflow-queue.test.ts`: 20/20 passed
- exact failed test: 4 additional clean processes, 5/5 total including the full-file run
- `git diff --check`

Local API tests used an isolated PostgreSQL 18 cluster. The current migration guard required dropping four legacy connector identity constraints in that temporary database before migrations could finish; no schema or migration file was changed. The PR pipeline remains authoritative for PostgreSQL 16 coverage.