### PR TITLE
test(api): split Slack DM session routing scenarios

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -444,6 +444,30 @@ async function completeSlackTriggeredRun(args: {
   }
 }
 
+async function setupSlackDmSessionRouting() {
+  const actor = bdd.user();
+  bdd.acceptAgentStorageWrites();
+  runs.acceptStorageDownloads();
+  runs.acceptTelemetryIngest();
+  integrations.configureSlackAppMocks();
+  integrations.acceptSlackSessionHistoryDownloads();
+  const runnerGroup = runs.configureRunnerGroup();
+  await runs.grantProEntitlement(actor);
+  await integrations.configureSlackRunModelPolicies(actor);
+  await bdd.readOnboardingStatus(actor);
+  const slackUserId = uniqueSlackUserId();
+  const { teamId } = await integrations.installSlackWorkspace(actor, {
+    installerSlackUserId: slackUserId,
+  });
+  integrations.clearSlackCallHistory();
+  return {
+    actor,
+    runnerGroup,
+    slackUserId,
+    teamId,
+  };
+}
+
 function telegramDomainProbe() {
   return http.head("https://oauth.telegram.org/auth", () => {
     return new HttpResponse(null, {
@@ -2008,24 +2032,10 @@ describe("INT-01: Slack app deep webhook flows", () => {
     expect(run2.result?.agentSessionId).toBe(webSessionId);
   });
 
-  it("forks Slack DM threads without replacing the main session", async () => {
-    const actor = bdd.user();
-    bdd.acceptAgentStorageWrites();
-    runs.acceptStorageDownloads();
-    runs.acceptTelemetryIngest();
-    integrations.configureSlackAppMocks();
-    integrations.acceptSlackSessionHistoryDownloads();
-    const runnerGroup = runs.configureRunnerGroup();
-    await runs.grantProEntitlement(actor);
-    await integrations.configureSlackRunModelPolicies(actor);
-    await bdd.readOnboardingStatus(actor);
-    const slackUserId = uniqueSlackUserId();
-    const { teamId } = await integrations.installSlackWorkspace(actor, {
-      installerSlackUserId: slackUserId,
-    });
-    integrations.clearSlackCallHistory();
-
-    const channelId = "D_BDD_SESSION_ROUTING";
+  it("continues the main Slack DM session", async () => {
+    const { runnerGroup, slackUserId, teamId } =
+      await setupSlackDmSessionRouting();
+    const channelId = "D_BDD_SESSION_CONTINUATION";
     const firstMessageTs = "2950.000100";
     await integrations.postSlackEvent(teamId, {
       type: "message",
@@ -2081,6 +2091,30 @@ describe("INT-01: Slack app deep webhook flows", () => {
         text: "Continued main Slack DM answer",
       }),
     );
+  });
+
+  it("keeps the main Slack DM session when an alternate agent runs", async () => {
+    const { actor, runnerGroup, slackUserId, teamId } =
+      await setupSlackDmSessionRouting();
+    const channelId = "D_BDD_SESSION_AGENT_SWITCH";
+    const firstMessageTs = "2951.000100";
+    await integrations.postSlackEvent(teamId, {
+      type: "message",
+      channel_type: "im",
+      user: slackUserId,
+      text: "remember the main Slack DM before switching agents",
+      ts: firstMessageTs,
+      channel: channelId,
+    });
+    const firstRunId = await pollSlackRun(runnerGroup);
+    const firstClaim = await runs.claimRunnerJob(firstRunId);
+    expect(firstClaim.resumeSession).toBeNull();
+    await completeSlackTriggeredRun({
+      runId: firstRunId,
+      sandboxToken: firstClaim.sandboxToken,
+      cliAgentType: firstClaim.cliAgentType,
+    });
+    await flushWaitUntilForTest();
 
     const alternateAgent = await bdd.createAgent(actor, {
       displayName: "BDD alternate Slack DM agent",
@@ -2098,7 +2132,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       channel_type: "im",
       user: slackUserId,
       text: "use an alternate Slack DM agent",
-      ts: "2950.000250",
+      ts: "2951.000200",
       channel: channelId,
     });
     const alternateRunId = await pollSlackRun(runnerGroup);
@@ -2123,9 +2157,47 @@ describe("INT-01: Slack app deep webhook flows", () => {
       type: "message",
       channel_type: "im",
       user: slackUserId,
+      text: "return to the main Slack DM after switching agents",
+      ts: "2951.000300",
+      channel: channelId,
+    });
+    const returnToMainRunId = await pollSlackRun(runnerGroup);
+    const returnToMainClaim = await runs.claimRunnerJob(returnToMainRunId);
+    expect(returnToMainClaim.resumeSession?.sessionId).toBe(
+      `bdd-slack-cli-${firstRunId}`,
+    );
+  });
+
+  it("forks Slack DM threads without replacing the main session", async () => {
+    const { runnerGroup, slackUserId, teamId } =
+      await setupSlackDmSessionRouting();
+    const channelId = "D_BDD_SESSION_THREAD";
+    const mainMessageTs = "2952.000100";
+    await integrations.postSlackEvent(teamId, {
+      type: "message",
+      channel_type: "im",
+      user: slackUserId,
+      text: "remember the main Slack DM before opening a thread",
+      ts: mainMessageTs,
+      channel: channelId,
+    });
+    const mainRunId = await pollSlackRun(runnerGroup);
+    const mainClaim = await runs.claimRunnerJob(mainRunId);
+    expect(mainClaim.resumeSession).toBeNull();
+    await completeSlackTriggeredRun({
+      runId: mainRunId,
+      sandboxToken: mainClaim.sandboxToken,
+      cliAgentType: mainClaim.cliAgentType,
+    });
+    await flushWaitUntilForTest();
+
+    await integrations.postSlackEvent(teamId, {
+      type: "message",
+      channel_type: "im",
+      user: slackUserId,
       text: "open a Slack DM thread",
-      ts: "2950.000300",
-      thread_ts: secondMessageTs,
+      ts: "2952.000200",
+      thread_ts: mainMessageTs,
       channel: channelId,
     });
     const threadRunId = await pollSlackRun(runnerGroup);
@@ -2143,8 +2215,8 @@ describe("INT-01: Slack app deep webhook flows", () => {
       channel_type: "im",
       user: slackUserId,
       text: "continue the Slack DM thread",
-      ts: "2950.000400",
-      thread_ts: secondMessageTs,
+      ts: "2952.000300",
+      thread_ts: mainMessageTs,
       channel: channelId,
     });
     const threadFollowUpRunId = await pollSlackRun(runnerGroup);
@@ -2164,13 +2236,13 @@ describe("INT-01: Slack app deep webhook flows", () => {
       channel_type: "im",
       user: slackUserId,
       text: "return to the main Slack DM",
-      ts: "2950.000500",
+      ts: "2952.000400",
       channel: channelId,
     });
     const returnToMainRunId = await pollSlackRun(runnerGroup);
     const returnToMainClaim = await runs.claimRunnerJob(returnToMainRunId);
     expect(returnToMainClaim.resumeSession?.sessionId).toBe(
-      `bdd-slack-cli-${secondRunId}`,
+      `bdd-slack-cli-${mainRunId}`,
     );
   });
 


### PR DESCRIPTION
## Why

Turbo merge-group run https://github.com/vm0-ai/vm0/actions/runs/30646453032 at SHA `9323cd067f1b2ede7b1fb763c8d72c187f6b2408` failed in `test-api (4)` with:

```
INT-01: Slack app deep webhook flows > forks Slack DM threads without replacing the main session
Error: Test timed out in 5000ms.
```

The test had already completed three Slack-triggered runs when its single 5-second budget expired. The same test passed in 1.708s on the adjacent main run and 1.851s in PR #24389's pipeline, while another Slack test in the failed shard slowed to 4.172s. PR #24389 only changes release-trigger comments, so this is load-sensitive test structure rather than a deterministic product regression.

The test was introduced by #23280 and combined three independent journeys under one timeout:

1. top-level DM continuation
2. alternate-agent session isolation and return to the main agent
3. thread session fork/continuation and return to the top-level DM

No open PR or queued merge-group entry already repairs this test. The later `t40-slack-roundtrip.bats` failure in the same workflow reported `Not logged in · Please run /login`; that is an independent deployed-runner/auth failure and is not changed here.

## Fix

- extract the common Slack DM session-routing setup
- split the oversized scenario into three independently budgeted tests
- retain the original resume-session and Slack callback assertions at each business boundary
- complete every claimed run that must release queue ownership before the next message

No production code, sleeps, retries, or raised timeouts.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (all packages and API Oxlint phases passed; API ESLint exhausted the default 2 GiB heap)
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api run lint`
- `pnpm knip`
- staged repository type checks, including `pnpm --filter @vm0/app run check-types` and `pnpm --filter api run check-types`
- `git diff --check`

Local API execution used the only installed database, PostgreSQL 18. The target file and the untouched main-branch version both failed at the same runner-queue dispatch boundary under that environment, so the PR pipeline's PostgreSQL 16 API shard is the authoritative behavioral check.
