### PR TITLE
fix(api): preserve database precision in queue ordering

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -654,6 +654,63 @@ describe("workflow queue", () => {
     ).resolves.toBeNull();
   });
 
+  it("preserves sub-millisecond FIFO order when draining workflow events", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const busyRunId = await expectAcceptedRunId(
+      await postWorkflowWebhook(automation, "busy"),
+      automation.threadId,
+    );
+
+    expectAcceptedWithoutRun(
+      await postWorkflowWebhook(automation, "older pending event"),
+    );
+    expectAcceptedWithoutRun(
+      await postWorkflowWebhook(automation, "newer pending event"),
+    );
+    const pendingEvents = await pendingWorkflowEvents(automation.threadId);
+    expect(pendingEvents).toHaveLength(2);
+    const [lowerIdEvent, higherIdEvent] = [...pendingEvents].sort(
+      (left, right) => {
+        return left.id < right.id ? -1 : 1;
+      },
+    );
+    if (!lowerIdEvent || !higherIdEvent) {
+      throw new Error("Expected two pending workflow events");
+    }
+
+    // Make the lexicographically larger id the older event. Converting these
+    // database timestamps to JavaScript Date values collapses both to the same
+    // millisecond and would incorrectly make the lower id the queue head.
+    const sameMillisecond = new Date("2020-01-01T00:00:00.000Z");
+    await setWorkflowQueueEventCreatedAtFixture({
+      eventId: higherIdEvent.id,
+      createdAt: sameMillisecond,
+      microsecondOffset: 100,
+    });
+    await setWorkflowQueueEventCreatedAtFixture({
+      eventId: lowerIdEvent.id,
+      createdAt: sameMillisecond,
+      microsecondOffset: 900,
+    });
+
+    await completeRunThroughSandbox(scenario, busyRunId);
+    await expect(
+      wf.readThreadEvents(automation.threadId),
+    ).resolves.toContainEqual(
+      expect.objectContaining({
+        eventType: "input.prompt",
+        revokesEventId: higherIdEvent.id,
+        runId: expect.any(String),
+      }),
+    );
+    await expect(
+      pendingWorkflowEvents(automation.threadId),
+    ).resolves.toStrictEqual([
+      expect.objectContaining({ id: lowerIdEvent.id }),
+    ]);
+  });
+
   it("keeps workflow events queued until cancellation recovery completes", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);

--- a/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
@@ -1,7 +1,15 @@
-import { foldPendingChatQueueEvents } from "@vm0/api-contracts/contracts/chat-events";
 import { chatEvents } from "@vm0/db/schema/chat-event";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
-import { and, asc, eq, isNull, lt, notExists } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  isNull,
+  lt,
+  notExists,
+  sql,
+  type SQL,
+} from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
 import type { Db } from "../external/db";
@@ -36,11 +44,22 @@ export function pendingChatQueueEventCondition(db: ChatQueueReadDb) {
   );
 }
 
+/** Database-native class priority shared by queue reads and atomic claims. */
+export function chatQueueEventPriority(): SQL {
+  return sql`CASE ${chatEvents.eventType}
+    WHEN 'input.prompt' THEN 0
+    WHEN 'input.automation' THEN 1
+    WHEN 'input.goal' THEN 2
+    ELSE 3
+  END`;
+}
+
 /**
- * Fold one thread's immutable input events into its pending queue. User input
+ * Read one thread's immutable input events as its pending queue. User input
  * keeps absolute priority over automation input, automation stays ahead of
  * goal continuation, then each class is FIFO by the original event timestamp
- * and id.
+ * and id. PostgreSQL must perform the ordering: JavaScript Date values discard
+ * database microseconds, while the atomic claim compares the full timestamp.
  */
 export async function listPendingChatQueueEvents(
   db: ChatQueueReadDb,
@@ -52,7 +71,6 @@ export async function listPendingChatQueueEvents(
       id: chatEvents.id,
       chatThreadId: chatEvents.chatThreadId,
       eventType: chatEvents.eventType,
-      runId: chatEvents.runId,
       createdAt: chatEvents.createdAt,
     })
     .from(chatEvents)
@@ -63,17 +81,13 @@ export async function listPendingChatQueueEvents(
         createdBefore ? lt(chatEvents.createdAt, createdBefore) : undefined,
       ),
     )
-    .orderBy(asc(chatEvents.createdAt), asc(chatEvents.id));
+    .orderBy(
+      chatQueueEventPriority(),
+      asc(chatEvents.createdAt),
+      asc(chatEvents.id),
+    );
 
-  const folded = foldPendingChatQueueEvents(
-    rows.map((row) => {
-      return {
-        ...row,
-        createdAt: row.createdAt.toISOString(),
-      };
-    }),
-  );
-  return folded.flatMap((event) => {
+  return rows.flatMap((event) => {
     if (
       event.eventType !== "input.prompt" &&
       event.eventType !== "input.automation" &&
@@ -86,7 +100,7 @@ export async function listPendingChatQueueEvents(
         id: event.id,
         chatThreadId: event.chatThreadId,
         eventType: event.eventType,
-        createdAt: new Date(event.createdAt),
+        createdAt: event.createdAt,
       },
     ];
   });

--- a/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
@@ -44,14 +44,22 @@ export function pendingChatQueueEventCondition(db: ChatQueueReadDb) {
   );
 }
 
-/** Database-native class priority shared by queue reads and atomic claims. */
-export function chatQueueEventPriority(): SQL {
+function chatQueueEventPriority(): SQL {
   return sql`CASE ${chatEvents.eventType}
     WHEN 'input.prompt' THEN 0
     WHEN 'input.automation' THEN 1
     WHEN 'input.goal' THEN 2
     ELSE 3
   END`;
+}
+
+/** Complete database-native order shared by queue reads and atomic claims. */
+export function chatQueueEventOrderBy(): readonly [SQL, SQL, SQL] {
+  return [
+    chatQueueEventPriority(),
+    asc(chatEvents.createdAt),
+    asc(chatEvents.id),
+  ];
 }
 
 /**
@@ -81,11 +89,7 @@ export async function listPendingChatQueueEvents(
         createdBefore ? lt(chatEvents.createdAt, createdBefore) : undefined,
       ),
     )
-    .orderBy(
-      chatQueueEventPriority(),
-      asc(chatEvents.createdAt),
-      asc(chatEvents.id),
-    );
+    .orderBy(...chatQueueEventOrderBy());
 
   return rows.flatMap((event) => {
     if (

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -40,6 +40,7 @@ import {
 } from "../../lib/db-structured-result";
 import { db$, type Db } from "../external/db";
 import {
+  chatQueueEventPriority,
   listPendingChatQueueEvents,
   loadPendingChatQueueEvent,
   lockChatQueueThread,
@@ -423,15 +424,6 @@ interface QueueFirstClaimSnapshot {
   readonly replacement: NewChatEvent;
 }
 
-function queueFirstHeadPriority(): SQL {
-  return sql`CASE ${chatEvents.eventType}
-    WHEN 'input.prompt' THEN 0
-    WHEN 'input.automation' THEN 1
-    WHEN 'input.goal' THEN 2
-    ELSE 3
-  END`;
-}
-
 function replacementTargetFromQueueHead(
   head: LoadedChatEventReplacementTarget,
 ): LoadedChatEventReplacementTarget {
@@ -470,7 +462,7 @@ async function resolveUserQueueFirstClaimSnapshot(
       ),
     )
     .orderBy(
-      queueFirstHeadPriority(),
+      chatQueueEventPriority(),
       asc(chatEvents.createdAt),
       asc(chatEvents.id),
     )
@@ -537,7 +529,7 @@ async function resolveWorkflowQueueFirstClaimSnapshot(
       ),
     )
     .orderBy(
-      queueFirstHeadPriority(),
+      chatQueueEventPriority(),
       asc(chatEvents.createdAt),
       asc(chatEvents.id),
     )
@@ -627,7 +619,7 @@ async function resolveGoalQueueFirstClaimSnapshot(
       ),
     )
     .orderBy(
-      queueFirstHeadPriority(),
+      chatQueueEventPriority(),
       asc(chatEvents.createdAt),
       asc(chatEvents.id),
     )

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -21,16 +21,7 @@ import {
   zeroWorkflowAutomations,
   zeroWorkflows,
 } from "@vm0/db/schema/zero-workflow";
-import {
-  and,
-  asc,
-  eq,
-  exists,
-  isNull,
-  notExists,
-  sql,
-  type SQL,
-} from "drizzle-orm";
+import { and, eq, exists, isNull, notExists, sql, type SQL } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
 
@@ -40,7 +31,7 @@ import {
 } from "../../lib/db-structured-result";
 import { db$, type Db } from "../external/db";
 import {
-  chatQueueEventPriority,
+  chatQueueEventOrderBy,
   listPendingChatQueueEvents,
   loadPendingChatQueueEvent,
   lockChatQueueThread,
@@ -461,11 +452,7 @@ async function resolveUserQueueFirstClaimSnapshot(
         pendingChatQueueEventCondition(db),
       ),
     )
-    .orderBy(
-      chatQueueEventPriority(),
-      asc(chatEvents.createdAt),
-      asc(chatEvents.id),
-    )
+    .orderBy(...chatQueueEventOrderBy())
     .for("update", { of: chatEvents })
     .limit(1);
   if (!head || head.eventType !== "input.prompt" || head.id !== args.eventId) {
@@ -528,11 +515,7 @@ async function resolveWorkflowQueueFirstClaimSnapshot(
         pendingChatQueueEventCondition(db),
       ),
     )
-    .orderBy(
-      chatQueueEventPriority(),
-      asc(chatEvents.createdAt),
-      asc(chatEvents.id),
-    )
+    .orderBy(...chatQueueEventOrderBy())
     .for("update", { of: chatEvents })
     .limit(1);
   if (
@@ -618,11 +601,7 @@ async function resolveGoalQueueFirstClaimSnapshot(
         pendingChatQueueEventCondition(db),
       ),
     )
-    .orderBy(
-      chatQueueEventPriority(),
-      asc(chatEvents.createdAt),
-      asc(chatEvents.id),
-    )
+    .orderBy(...chatQueueEventOrderBy())
     .for("update", { of: chatEvents })
     .limit(1);
   if (

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -495,7 +495,7 @@ export async function setWorkflowQueueEventCreatedAtFixture(args: {
       .returning({ id: chatEvents.id });
   });
   if (updated.length !== 1) {
-    throw new Error("Expected one workflow queue event to become historical");
+    throw new Error("Expected one workflow queue event timestamp to update");
   }
 }
 

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -470,19 +470,22 @@ export async function replayPendingChatInputQueueEventFixture(args: {
   });
 }
 
-/**
- * Move one exact workflow event into historical state without waiting for real
- * time to pass. Product APIs cannot construct an already-stale queue item.
- */
+/** Set one exact workflow event's queue timestamp, including sub-ms ordering. */
 export async function setWorkflowQueueEventCreatedAtFixture(args: {
   readonly eventId: string;
   readonly createdAt: Date;
+  readonly microsecondOffset?: number;
 }): Promise<void> {
   const updated = await db().transaction(async (tx) => {
     await tx.execute(sql`SET LOCAL session_replication_role = replica`);
     return await tx
       .update(chatEvents)
-      .set({ createdAt: args.createdAt })
+      .set({
+        createdAt:
+          args.microsecondOffset === undefined
+            ? args.createdAt
+            : sql`${args.createdAt.toISOString()}::timestamp + ${args.microsecondOffset} * interval '1 microsecond'`,
+      })
       .where(
         and(
           eq(chatEvents.id, args.eventId),


### PR DESCRIPTION
## Summary

- keep authoritative pending queue ordering inside PostgreSQL so sub-millisecond timestamps remain intact
- define the complete queue order once — class priority, full `created_at`, then ID — and reuse it for pending reads plus user, workflow, and goal atomic claims
- add a route-level regression with two workflow events in the same millisecond whose UUID order opposes their true FIFO order

## Root cause

The [failing API test job](https://github.com/vm0-ai/vm0/actions/runs/30647845579/job/91213700626) exposed a real queue race. `listPendingChatQueueEvents` converted PostgreSQL timestamps to JavaScript `Date`/ISO values before sorting. That truncates PostgreSQL microseconds to milliseconds. When two admissions landed in the same millisecond, the read path could select the newer event by UUID while the atomic claim selected the true older event by the full database timestamp. Concurrent launches then lost their claims and left both events pending with no active run.

The precision loss existed after the ChatEvent queue cutover. It became a persistent claim mismatch after #24356 made the atomic claim independently resolve the authoritative head in PostgreSQL.

## Design

PostgreSQL is the source of truth for queue ordering. The shared order is:

1. `input.prompt`
2. `input.automation`
3. `input.goal`
4. within each class, full-precision original event timestamp and then ID

The fix deliberately does not switch FIFO to `seq_id`. `seq_id` is append/persistence order, while the queue contract preserves original-event time and some external ingress paths persist their source timestamp. Using `seq_id` would silently change queue behavior for delayed or out-of-order ingress.

There is no schema, migration, persisted-data, public API, frontend, runner, or deployment-protocol change.

## Validation

- exact failing CI shard on the final implementation (`api --shard=5/8` with coverage): 22 files, 277 tests passed
- full workflow queue integration file: 21 tests passed
- focused sub-millisecond FIFO and concurrent admission regressions: 2 tests passed
- API lint: passed
- API typecheck: passed
- API-scoped Knip: passed
- pre-commit Prettier, full Knip, full monorepo typecheck (12/12), file-size, and commitlint: passed
