### PR TITLE
test(e2e): retry stalled clerk bootstrap

### DIFF
--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -1,4 +1,4 @@
-import { clerk } from "@clerk/testing/playwright";
+import { clerk, setupClerkTestingToken } from "@clerk/testing/playwright";
 import type { Page } from "@playwright/test";
 
 export interface ClerkTestingSignInOptions {
@@ -34,6 +34,7 @@ export async function signInWithClerkTestingHelper(
   options: ClerkTestingSignInOptions,
 ): Promise<void> {
   const helperUrl = new URL("/_/skeleton", appUrl);
+  await setupClerkTestingToken({ page });
   await page.goto(helperUrl.toString(), { waitUntil: "domcontentloaded" });
   await page.waitForFunction(() => Boolean(window.Clerk?.loaded), undefined, {
     timeout: 30_000,

--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -1,5 +1,8 @@
-import { clerk, setupClerkTestingToken } from "@clerk/testing/playwright";
-import type { Page } from "@playwright/test";
+import { clerk } from "@clerk/testing/playwright";
+import { errors, type Page } from "@playwright/test";
+
+const CLERK_BOOTSTRAP_ATTEMPTS = 2;
+const CLERK_BOOTSTRAP_ATTEMPT_TIMEOUT_MS = 15_000;
 
 export interface ClerkTestingSignInOptions {
   readonly activeOrganizationId?: string;
@@ -34,11 +37,7 @@ export async function signInWithClerkTestingHelper(
   options: ClerkTestingSignInOptions,
 ): Promise<void> {
   const helperUrl = new URL("/_/skeleton", appUrl);
-  await setupClerkTestingToken({ page });
-  await page.goto(helperUrl.toString(), { waitUntil: "domcontentloaded" });
-  await page.waitForFunction(() => Boolean(window.Clerk?.loaded), undefined, {
-    timeout: 30_000,
-  });
+  await navigateToLoadedClerk(page, helperUrl);
   const clerkStateBefore = await page.evaluate(() => {
     return {
       hasLoadedClerk: Boolean(window.Clerk?.loaded),
@@ -104,6 +103,35 @@ export async function signInWithClerkTestingHelper(
   });
 
   await gotoAboutBlankAfterClerkNavigation(page);
+}
+
+async function navigateToLoadedClerk(
+  page: Page,
+  helperUrl: URL,
+): Promise<void> {
+  for (let attempt = 1; attempt <= CLERK_BOOTSTRAP_ATTEMPTS; attempt += 1) {
+    await page.goto(helperUrl.toString(), { waitUntil: "domcontentloaded" });
+    try {
+      await page.waitForFunction(
+        () => Boolean(window.Clerk?.loaded),
+        undefined,
+        {
+          timeout: CLERK_BOOTSTRAP_ATTEMPT_TIMEOUT_MS,
+        },
+      );
+      return;
+    } catch (error) {
+      if (
+        !(error instanceof errors.TimeoutError) ||
+        attempt === CLERK_BOOTSTRAP_ATTEMPTS
+      ) {
+        throw error;
+      }
+      // Clerk's testing-token route allows a single FAPI fetch to consume 30s.
+      // Reload within the same total budget so a stalled fetch is aborted and retried.
+      console.warn("[e2e] Clerk bootstrap stalled; retrying navigation");
+    }
+  }
 }
 
 async function gotoAboutBlankAfterClerkNavigation(page: Page): Promise<void> {

--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -1,8 +1,7 @@
 import { clerk } from "@clerk/testing/playwright";
 import { errors, type Page } from "@playwright/test";
 
-const CLERK_BOOTSTRAP_ATTEMPTS = 2;
-const CLERK_BOOTSTRAP_ATTEMPT_TIMEOUT_MS = 15_000;
+const CLERK_BOOTSTRAP_TIMEOUTS_MS = [15_000, 30_000] as const;
 
 export interface ClerkTestingSignInOptions {
   readonly activeOrganizationId?: string;
@@ -109,26 +108,26 @@ async function navigateToLoadedClerk(
   page: Page,
   helperUrl: URL,
 ): Promise<void> {
-  for (let attempt = 1; attempt <= CLERK_BOOTSTRAP_ATTEMPTS; attempt += 1) {
+  for (const [attempt, timeout] of CLERK_BOOTSTRAP_TIMEOUTS_MS.entries()) {
     await page.goto(helperUrl.toString(), { waitUntil: "domcontentloaded" });
     try {
       await page.waitForFunction(
         () => Boolean(window.Clerk?.loaded),
         undefined,
         {
-          timeout: CLERK_BOOTSTRAP_ATTEMPT_TIMEOUT_MS,
+          timeout,
         },
       );
       return;
     } catch (error) {
       if (
         !(error instanceof errors.TimeoutError) ||
-        attempt === CLERK_BOOTSTRAP_ATTEMPTS
+        attempt === CLERK_BOOTSTRAP_TIMEOUTS_MS.length - 1
       ) {
         throw error;
       }
       // Clerk's testing-token route allows a single FAPI fetch to consume 30s.
-      // Reload within the same total budget so a stalled fetch is aborted and retried.
+      // Retry sooner, then retain the original 30s tolerance on the final attempt.
       console.warn("[e2e] Clerk bootstrap stalled; retrying navigation");
     }
   }


### PR DESCRIPTION
## Summary

- retry the initial Clerk bootstrap by reloading `/_/skeleton` when the first 15-second load attempt stalls
- preserve the original 30-second Clerk tolerance on the final attempt
- keep the shared browser-context testing-token route and all existing sign-in assertions unchanged

## Root cause

The failing merge-queue job timed out in both Playwright workers while waiting for `window.Clerk.loaded` on `/_/skeleton`. The shared Playwright fixture had already installed Clerk's testing-token route before either page was created, so adding the same route again in the sign-in helper would be idempotent and would not change the failing path.

Clerk's route helper uses Playwright `route.fetch()` without a custom timeout. Playwright gives each such request a 30-second default timeout, exactly matching the test's only Clerk load attempt. A stalled bootstrap request can therefore consume the entire test-side wait before Clerk's own retry loop gets a chance to run.

This change gives the bootstrap a 15-second first attempt. If it times out, reloading abandons the stalled page bootstrap and starts a fresh one. The final attempt retains the original full 30-second tolerance so a slow but progressing request that previously passed does not become a false failure. Non-timeout errors and a second timeout still fail.

Original failure: https://github.com/vm0-ai/vm0/actions/runs/30650189520/job/91222106303

## Exclusions

- no production authentication behavior changes
- no Playwright test-level retries, sleeps, skipped assertions, or global timeout changes
- no fork or upgrade of `@clerk/testing`

## Validation

- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test`
- `cd turbo && pnpm prettier --check ../e2e/playwright/lib/auth.ts`
- `git diff --check`
- real-browser fault injection against the failed job's app preview: held the first `/v1/dev_browser` request for 20 seconds; the first attempt timed out at 15 seconds, the second navigation loaded Clerk, and the helper reached sign-in in 20.5 seconds

