### PR TITLE
test(e2e): isolate real preview switch identity

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1148,7 +1148,7 @@ jobs:
           done
 
           # Create test users + orgs (browser is created via UI sign-up flow)
-          for variant in serial runner; do
+          for variant in serial runner real-preview; do
             email="${JOB_REF}+clerk_test+${variant}@vm0-e2e.ai"
             encoded_email=$(jq -rn --arg email "$email" '$email|@uri')
             existing_users=$(curl -sS -X GET \
@@ -1194,6 +1194,9 @@ jobs:
           e2e/scripts/generate-test-token.sh \
             "${JOB_REF}+clerk_test+runner@vm0-e2e.ai" \
             "/tmp/e2e-api-credentials-runner.json"
+          e2e/scripts/generate-test-token.sh \
+            "${JOB_REF}+clerk_test+real-preview@vm0-e2e.ai" \
+            "/tmp/e2e-api-credentials-real-preview.json"
         env:
           VM0_API_BACKEND_URL: ${{ steps.api-alias.outputs.url || steps.api-deploy.outputs.url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
@@ -1206,6 +1209,7 @@ jobs:
           path: |
             /tmp/e2e-api-credentials-serial.json
             /tmp/e2e-api-credentials-runner.json
+            /tmp/e2e-api-credentials-real-preview.json
           retention-days: 1
 
   # Build the canonical Cloudflare app artifact independently of Vercel, then

--- a/e2e/helpers/codex-zero.bash
+++ b/e2e/helpers/codex-zero.bash
@@ -58,16 +58,13 @@ enable_codex_beta() {
         >/dev/null
 }
 
-# Do not clear feature-switch overrides in teardown. Runner E2E files execute
-# in parallel and share the same authenticated runner user; DELETE
-# /api/zero/feature-switches removes every override for that shared user, which
-# can race another file between enable_codex_beta and its gated API call.
-#
-# Leaving codexBeta enabled is intentional for the shared E2E runner user.
-# Tests that need feature-off behavior must use a dedicated token/user and
-# explicitly force the switch off for that isolated identity.
+# This helper is used with the dedicated real-preview E2E identity, so restoring
+# the switch cannot affect mock-runner files executing in parallel.
 disable_codex_beta() {
-    return 0
+    _codex_zero_curl "/api/zero/feature-switches" \
+        -X POST \
+        -d '{"switches":{"codexBeta":false}}' \
+        >/dev/null
 }
 
 configure_codex_zero_model_policy() {

--- a/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
+++ b/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
@@ -24,6 +24,14 @@ load '../../helpers/codex-zero'
 export BATS_TEST_TIMEOUT=300
 
 setup_file() {
+    local real_preview_credentials="/tmp/e2e-api-credentials-real-preview.json"
+    E2E_API_TOKEN=$(jq -er '.token | select(type == "string" and length > 0)' "$real_preview_credentials")
+    E2E_API_URL=$(jq -er '.apiUrl | select(type == "string" and length > 0)' "$real_preview_credentials")
+    export E2E_API_TOKEN E2E_API_URL
+
+    # realAgentInPreview is a user-scoped switch read when an idle thread is
+    # claimed. Keep its brief true window on a dedicated identity so parallel
+    # mock-runner tests cannot be routed to a real CLI with mock credentials.
     export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
     export TEST_DIR="$(mktemp -d)"
     export AGENT_NAME="e2e-codex-byok-${UNIQUE_ID}"


### PR DESCRIPTION
## Summary

- provision a dedicated `real-preview` E2E user and organization
- run `t-codex-zero-byok-smoke.bats` with that isolated identity before toggling `realAgentInPreview`
- restore the dedicated identity's `codexBeta` override during teardown

## Root cause

PR #24365 moved `realAgentInPreview` derivation to runner claim time. The Codex BYOK smoke test then temporarily enabled that user-scoped switch on the same runner E2E identity used by every parallel runner shard.

When a Slack, Telegram, or Teams round-trip was claimed during that window, the runner suppressed `USE_MOCK_CLAUDE`, launched the real Claude CLI with the E2E mock OAuth token, and failed with `Not logged in - Please run /login`. The failing channel moved between otherwise unrelated shards in adjacent merge-group runs, which is consistent with the shared-state race:

- Slack: run [30646453032](https://github.com/vm0-ai/vm0/actions/runs/30646453032)
- Telegram: trigger run [30647031037](https://github.com/vm0-ai/vm0/actions/runs/30647031037), job [91211879078](https://github.com/vm0-ai/vm0/actions/runs/30647031037/job/91211879078)
- Teams: run [30649559175](https://github.com/vm0-ai/vm0/actions/runs/30649559175)

The independent t54 usage-settlement timeout from the trigger run was fixed separately by #24392 and is intentionally not duplicated here.

## Why this is deterministic

The real-preview switch is scoped to the authenticated user. Giving the only test that enables it a dedicated identity removes the shared mutable state from all mock-runner shards. Tests within the Codex file remain non-parallel, so its two real claims cannot overlap each other.

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` (12/12 tasks)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `bash -n e2e/helpers/codex-zero.bash`
- `pnpm exec prettier --check ../.github/workflows/turbo.yml`
- `git diff --check`

The deployed runner E2E is left to the PR pipeline, per repository guidance.
