### PR TITLE
refactor: reduce fallback slop in box auth

### DIFF
--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/box.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/box.test.ts
@@ -74,6 +74,34 @@ describe("connector/providers/box", () => {
       expect(result.userInfo.email).toBe("test@example.com");
     });
 
+    it("rejects user info without the required Box user id", async () => {
+      const tokenHandler = http.post("https://api.box.com/oauth2/token", () => {
+        return HttpResponse.json({
+          access_token: "box-test-token",
+          refresh_token: "box-refresh-token",
+          expires_in: 3600,
+          scope: "root_readwrite",
+        });
+      });
+      const meHandler = http.get("https://api.box.com/2.0/users/me", () => {
+        return HttpResponse.json({
+          name: "Test User",
+          login: "test@example.com",
+        });
+      });
+      server.use(tokenHandler, meHandler);
+
+      await expect(
+        exchangeBoxCode(
+          authCodeGrant(),
+          "client-id",
+          "client-secret",
+          "test-code",
+          "https://example.com/callback",
+        ),
+      ).rejects.toThrow("No user id in Box user info response");
+    });
+
     it("throws when Box returns an error in response body", async () => {
       const tokenHandler = http.post("https://api.box.com/oauth2/token", () => {
         return HttpResponse.json({

--- a/turbo/packages/connectors/src/auth-providers/connectors/box/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/box/oauth.ts
@@ -171,8 +171,12 @@ async function fetchBoxUserInfo(accessToken: string): Promise<BoxUserInfo> {
     })
     .parse(await response.json());
 
+  if (!data.id) {
+    throw new Error("No user id in Box user info response");
+  }
+
   return {
-    id: data.id ?? "",
+    id: data.id,
     username: data.name ?? data.login ?? null,
     email: data.login ?? null,
   };


### PR DESCRIPTION
## Summary

- Reject Box `/users/me` responses that omit their required user ID instead of creating an OAuth grant identity with `id: ""`.
- Keep the existing nullable handling for Box names and email addresses unchanged.
- Add a focused regression test for a successful token exchange followed by malformed user info without an ID.

User-visible impact: malformed Box identity responses now fail clearly during connection setup instead of persisting an empty external user identifier.

## Repository scan

- Scan timestamp: `2026-07-31T20:03:01.532Z`
- Base commit: `67bdf3b66cc9a6a374e7d348e24fef41e2237fb7`
- Files scanned: 3,889
- Raw matches: 20,073
- Scanner actionable matches: 4,351
- Scanner high-confidence production matches: 233
- Scanner suggested 5% budget: 12
- Context-reviewed `actionable_total`: 1
- Adjusted `edit_budget`: 1 (`max(1, ceil(1 * 0.05))`)
- Candidates changed: 1

Matches by category:

| Category | Count |
| --- | ---: |
| `nullish` | 6,201 |
| `nullish-chain` | 134 |
| `field-fallback-chain` | 105 |
| `optional-prop` | 6,076 |
| `zod-optional` | 2,624 |
| `zod-loose-optional` | 5 |
| `loose-record` | 1,088 |
| `loose-index-signature` | 3 |
| `as-any` | 0 |
| `as-unknown-as` | 30 |
| `empty-fallback` | 624 |
| `string-fallback` | 660 |
| `null-undefined-fallback` | 1,683 |
| `empty-catch` | 3 |
| `promise-catch-swallow` | 16 |
| `rust-unwrap-or` | 665 |
| `rust-ok-discard` | 156 |

## Files changed

- `turbo/packages/connectors/src/auth-providers/connectors/box/oauth.ts`: validates the downstream-required Box user ID before constructing the connector grant identity.
- `turbo/packages/connectors/src/auth-providers/connectors/__tests__/box.test.ts`: verifies a Box user-info response without an ID is rejected with a clear error.

The manual budget was reduced because the other reviewed candidates were intentional precedence chains, external compatibility fields without a proven hard requirement, presentational fallbacks, tests, or rule examples. The Box grant contract requires a non-empty identity, so no valid behavior depends on the removed fallback.

## Verification

- `pnpm exec prettier --check` on both changed files
- `pnpm --filter @vm0/connectors lint` (passed; one pre-existing `no-useless-spread` warning in `src/firewall-types.ts`)
- `pnpm --filter @vm0/connectors check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter @vm0/connectors exec vitest run src/auth-providers/connectors/__tests__/box.test.ts` — 8 passed
- Full pre-commit hook: Prettier, Knip, workspace type checks, and file-size checks passed
- `git diff --check`
- Follow-up scanner: raw matches decreased from 20,073 to 20,071 and `string-fallback` decreased from 660 to 659; the Box empty-ID fallback is no longer reported

This workflow intentionally leaves all remaining scan candidates for later daily runs.
