### PR TITLE
fix(platform): keep chat skeleton until initial event request resolves

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -168,7 +168,7 @@ export interface ChatThreadSignals {
   // -- Paged events (sole rendering path) ----------------------------------
   latestRunFinishCreatedAt$: Computed<Promise<string | undefined>>;
   latestAssistantTextCreatedAt$: Computed<Promise<string | undefined>>;
-  indexedDbEventsLoading$: Computed<boolean>;
+  chatSkeletonVisible$: Computed<boolean>;
   visibleRenderedChatGroups$: Computed<Promise<ChatEventGroup[]>>;
   visibleRenderedChatGroupsReady$: Computed<Promise<boolean>>;
   eventImageGroups$: Computed<Promise<EventImageGroupProjection[]>>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2222,12 +2222,14 @@ function createSyncRemoteEventsCommand({
   threadId,
   persistentEvents$,
   hasReachedOldestEvent$,
+  initialRemoteEventsResolved$,
   mergePersistentEvents$,
   dataSource,
 }: {
   threadId: string;
   persistentEvents$: PersistentChatEvents$;
   hasReachedOldestEvent$: Computed<boolean>;
+  initialRemoteEventsResolved$: State<boolean>;
   mergePersistentEvents$: Command<
     Promise<void>,
     [PersistedChatEvent[], AbortSignal]
@@ -2249,12 +2251,16 @@ function createSyncRemoteEventsCommand({
     async function syncEventsAfter(): Promise<void> {
       const requestedSinceSeqId = sinceSeqId;
       const isInitialPage = requestedSinceSeqId === undefined;
+      const resolvesInitialRemoteEvents = !get(initialRemoteEventsResolved$);
       const events = await set(
         dataSource.listEventsAfter$,
         { threadId, sinceSeqId: requestedSinceSeqId },
         signal,
       );
       signal.throwIfAborted();
+      if (resolvesInitialRemoteEvents) {
+        set(initialRemoteEventsResolved$, true);
+      }
       L.debug("syncRemoteMessages$ listEventsAfter result", {
         threadId,
         sinceSeqId: requestedSinceSeqId ?? null,
@@ -2501,7 +2507,6 @@ function createIndexedDbEventCacheSignals({
   persistentEvents$: PersistentChatEvents$;
   registerBodyBlocks: BodyBlocksRenderer;
 }) {
-  const indexedDbEventsLoading$ = state(true);
   const loadIndexedDbEventsIntoPersistentEvents$ = command(
     async ({ set }, signal: AbortSignal): Promise<void> => {
       const result = await settle(
@@ -2509,7 +2514,6 @@ function createIndexedDbEventCacheSignals({
         signal,
       );
       if (!result.ok) {
-        set(indexedDbEventsLoading$, false);
         throw result.error;
       }
       if (result.value.length > 0) {
@@ -2525,17 +2529,11 @@ function createIndexedDbEventCacheSignals({
           return mergeRegisteredEvents([previous, registeredEvents]);
         });
       }
-      set(indexedDbEventsLoading$, false);
       signal.throwIfAborted();
     },
   );
 
-  return {
-    indexedDbEventsLoading$: computed((get) => {
-      return get(indexedDbEventsLoading$);
-    }),
-    loadIndexedDbEventsIntoPersistentEvents$,
-  };
+  return { loadIndexedDbEventsIntoPersistentEvents$ };
 }
 
 function createMailDraftCardSignalsById(
@@ -2683,6 +2681,47 @@ function createPagedEventProjections({
   };
 }
 
+function createRemoteEventSyncSignals({
+  threadId,
+  persistentEvents$,
+  projections,
+  mergePersistentEvents$,
+  dataSource,
+}: {
+  threadId: string;
+  persistentEvents$: PersistentChatEvents$;
+  projections: Pick<
+    ReturnType<typeof createPagedEventProjections>,
+    "hasReachedOldestEvent$" | "rawEvents$"
+  >;
+  mergePersistentEvents$: Command<
+    Promise<void>,
+    [PersistedChatEvent[], AbortSignal]
+  >;
+  dataSource: ChatThreadRemote;
+}) {
+  const initialRemoteEventsResolved$ = state(false);
+  const chatSkeletonVisible$ = computed((get): boolean => {
+    return (
+      !get(initialRemoteEventsResolved$) &&
+      get(projections.rawEvents$).length === 0
+    );
+  });
+  const syncRemoteEvents$ = createSyncRemoteEventsCommand({
+    threadId,
+    persistentEvents$,
+    hasReachedOldestEvent$: projections.hasReachedOldestEvent$,
+    initialRemoteEventsResolved$,
+    mergePersistentEvents$,
+    dataSource,
+  });
+  return {
+    initialRemoteEventsResolved$,
+    chatSkeletonVisible$,
+    syncRemoteEvents$,
+  };
+}
+
 function createEventChangeEffects(
   threadId: string,
   rawEvents$: Computed<ChatEventProjectionEntry[]>,
@@ -2820,6 +2859,13 @@ function createPagedEvents(
       signal.throwIfAborted();
     },
   );
+  const remoteEventSync = createRemoteEventSyncSignals({
+    threadId,
+    persistentEvents$: persistentChatEvents$,
+    projections,
+    mergePersistentEvents$,
+    dataSource,
+  });
   const initializeIndexedDbEvents$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
       const scrollPosition = get(effects.scroll.threadScrollPosition$);
@@ -2843,21 +2889,13 @@ function createPagedEvents(
       signal.throwIfAborted();
     },
   );
-  const syncRemoteEvents$ = createSyncRemoteEventsCommand({
-    threadId,
-    persistentEvents$: persistentChatEvents$,
-    hasReachedOldestEvent$: projections.hasReachedOldestEvent$,
-    mergePersistentEvents$,
-    dataSource,
-  });
 
   return {
     scroll: effects.scroll,
     sidebar: effects.sidebar,
-    indexedDbEventsLoading$: indexedDbEventCache.indexedDbEventsLoading$,
+    ...remoteEventSync,
     initializeIndexedDbEvents$,
     mergePersistentEvents$,
-    syncRemoteEvents$,
     appendOptimisticEvent$,
     ...projections,
     ...resources.publicSignals,
@@ -2986,6 +3024,7 @@ function createEventRunIndicatorState(
 interface RunTrackingDeps {
   threadId: string;
   latestRunFinishCreatedAt$: Computed<Promise<string | undefined>>;
+  initialRemoteEventsResolved$: State<boolean>;
   initializeIndexedDbEvents$: Command<Promise<void>, [AbortSignal]>;
   mergePersistentEvents$: Command<
     Promise<void>,
@@ -3230,6 +3269,7 @@ function createMarkThreadReadIfNeeded({
 
 function createOnSubscribedCommand({
   threadId,
+  initialRemoteEventsResolved$,
   syncRemoteEvents$,
   reloadArtifacts$,
   reloadMailDrafts$,
@@ -3239,6 +3279,7 @@ function createOnSubscribedCommand({
 }: Pick<
   RunTrackingDeps,
   | "threadId"
+  | "initialRemoteEventsResolved$"
   | "syncRemoteEvents$"
   | "reloadArtifacts$"
   | "reloadMailDrafts$"
@@ -3263,7 +3304,9 @@ function createOnSubscribedCommand({
       get(dataSource.cancellationRecoveryPending$),
       set(reloadComposerWorkflows$, signal),
     ];
-    if (!get(optimisticCreateUnsettled$)) {
+    if (get(optimisticCreateUnsettled$)) {
+      set(initialRemoteEventsResolved$, true);
+    } else {
       catchUpPromises.push(set(syncRemoteEvents$, signal));
     }
     await Promise.all(catchUpPromises);
@@ -3303,6 +3346,7 @@ function createReceiveSyncedEventsCommand({
 function createRunTracking({
   threadId,
   latestRunFinishCreatedAt$,
+  initialRemoteEventsResolved$,
   initializeIndexedDbEvents$,
   mergePersistentEvents$,
   syncRemoteEvents$,
@@ -3330,6 +3374,7 @@ function createRunTracking({
 
   const onSubscribed$ = createOnSubscribedCommand({
     threadId,
+    initialRemoteEventsResolved$,
     syncRemoteEvents$,
     reloadArtifacts$,
     reloadMailDrafts$,
@@ -4675,7 +4720,7 @@ function publicChatThreadEventSignals(
     latestAssistantTextCreatedAt$: events.latestAssistantTextCreatedAt$,
     visibleRenderedChatGroups$: events.visibleRenderedChatGroups$,
     visibleRenderedChatGroupsReady$: events.visibleRenderedChatGroupsReady$,
-    indexedDbEventsLoading$: events.indexedDbEventsLoading$,
+    chatSkeletonVisible$: events.chatSkeletonVisible$,
     eventImageGroups$: events.eventImageGroups$,
     artifactSignalsForUrl: events.artifactSignalsForUrl,
     agentReferenceSignalsForId: events.agentReferenceSignalsForId,
@@ -4774,6 +4819,7 @@ export function createChatThreadSignals(
   const runTracking = createRunTracking({
     threadId,
     latestRunFinishCreatedAt$: events.latestRunFinishCreatedAt$,
+    initialRemoteEventsResolved$: events.initialRemoteEventsResolved$,
     initializeIndexedDbEvents$: events.initializeIndexedDbEvents$,
     mergePersistentEvents$: events.mergePersistentEvents$,
     syncRemoteEvents$: events.syncRemoteEvents$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
@@ -191,7 +191,7 @@ describe("chat lifecycle", () => {
         expect(initialPageRequested).toBeTruthy();
       });
       expect(beforeSeqIds).toStrictEqual([]);
-      expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
+      expect(document.querySelector("[data-chat-skeleton]")).not.toBeNull();
 
       initialPageGate.resolve();
       await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -528,7 +528,51 @@ describe("zero chat thread IndexedDB fallback", () => {
     }
   });
 
-  it("hides the message skeleton after IndexedDB loads without waiting for remote events", async () => {
+  it("hides the message skeleton when IndexedDB loads any cached event", async () => {
+    prepareDefaultAgent();
+    mockCurrentThreadDetail();
+    mockSidebarThread();
+    const runtimeDb = await primeRuntimeChatDb();
+    await runtimeDb.put(CHAT_MESSAGES_STORE, {
+      id: "00000000-0000-4000-8000-000000000103",
+      threadId: THREAD_ID,
+      eventType: "usage.recorded",
+      runId: "run-cached-usage",
+      content: null,
+      usage: {
+        version: 1,
+        totalCredits: 1,
+        settledAt: "2026-03-10T00:00:01Z",
+        breakdown: [],
+      },
+      seqId: 1,
+      createdAt: "2026-03-10T00:00:01Z",
+    });
+
+    const initialMessageList = context.mocks.deferred<void>();
+    const messageListRequested = context.mocks.deferred<void>();
+    context.mocks.api(chatThreadEventsContract.list, async ({ respond }) => {
+      messageListRequested.resolve();
+      await initialMessageList.promise;
+      return respond(200, { events: [] });
+    });
+
+    try {
+      setupChatPage();
+      await messageListRequested.promise;
+
+      await waitFor(() => {
+        expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
+      });
+    } finally {
+      if (!initialMessageList.settled()) {
+        initialMessageList.resolve();
+      }
+      runtimeDb.close();
+    }
+  });
+
+  it("shows the message skeleton until the initial remote event request resolves", async () => {
     prepareDefaultAgent();
     mockCurrentThreadDetail();
     mockSidebarThread();
@@ -547,11 +591,8 @@ describe("zero chat thread IndexedDB fallback", () => {
       await messageListRequested.promise;
 
       await waitFor(() => {
-        expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
+        expect(document.querySelector("[data-chat-skeleton]")).not.toBeNull();
       });
-      expect(
-        screen.getByText("Send a message to start the conversation"),
-      ).toBeInTheDocument();
       expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
 
       initialMessageList.resolve();

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3487,8 +3487,8 @@ function RunGroupFoldRow({
 }
 
 function ChatThreadSkeletonOverlay({ thread }: { thread: ChatThreadSignals }) {
-  const indexedDbEventsLoading = useGet(thread.indexedDbEventsLoading$);
-  if (!indexedDbEventsLoading) {
+  const chatSkeletonVisible = useGet(thread.chatSkeletonVisible$);
+  if (!chatSkeletonVisible) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

- track completion of the first remote chat-event request with synchronous per-thread state
- derive skeleton visibility in ccstate only while that request is unresolved and the raw event list is empty
- stop treating IndexedDB read completion as the skeleton lifecycle
- cover uncached histories and cached non-rendered events with page-level regressions

## User impact

Opening an existing chat with no locally cached events keeps the message skeleton until the initial remote event request resolves instead of flashing the empty state. Any cached or optimistic event removes the skeleton immediately.

## Verification

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx src/views/zero-page/__tests__/chat-history-navigation.test.tsx --silent=passed-only` (40 tests passed)
