### PR TITLE
refactor: remove deepseek v4 flash feature switch

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-providers-tab.test.tsx
@@ -317,16 +317,12 @@ function mockGatewayConnectionLifecycle() {
   };
 }
 
-async function openProvidersTab(
-  customModelGateways = false,
-  deepSeekV4Flash = false,
-): Promise<void> {
+async function openProvidersTab(customModelGateways = false): Promise<void> {
   detachedSetupPage({
     context,
     path: "/?settings=model",
     featureSwitches: {
       [FeatureSwitchKey.CustomModelGateways]: customModelGateways,
-      [FeatureSwitchKey.DeepSeekV4Flash]: deepSeekV4Flash,
     },
   });
   await waitFor(() => {
@@ -692,7 +688,7 @@ describe("organization model providers settings", () => {
     ).resolves.toBeInTheDocument();
   });
 
-  it("only offers OpenAI and Anthropic models when adding a model", async () => {
+  it("only offers supported workspace models when adding a model", async () => {
     mockAdminOrg();
     context.mocks.data.orgModelProviders([]);
     context.mocks.data.orgModelPolicies([]);
@@ -720,29 +716,11 @@ describe("organization model providers settings", () => {
     expect(
       screen.queryByRole("option", { name: "DeepSeek V4 Pro" }),
     ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("option", { name: "DeepSeek V4 Flash" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("option", { name: "Kimi K2.7 Code" }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("offers DeepSeek V4 Flash when its feature switch is enabled", async () => {
-    mockAdminOrg();
-    context.mocks.data.orgModelProviders([]);
-    context.mocks.data.orgModelPolicies([]);
-    await openProvidersTab(false, true);
-
-    click(buttonByText("Add model"));
-    const dialog = screen.getByRole("dialog", { name: "Add model" });
-    click(within(dialog).getByRole("combobox"));
-
     await expect(
       screen.findByRole("option", { name: "DeepSeek V4 Flash" }),
     ).resolves.toBeInTheDocument();
     expect(
-      screen.queryByRole("option", { name: "DeepSeek V4 Pro" }),
+      screen.queryByRole("option", { name: "Kimi K2.7 Code" }),
     ).not.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
@@ -1713,8 +1713,6 @@ export function OrgModelPoliciesSection() {
   const featureSwitches = useGet(featureSwitch$);
   const customGatewaysEnabled =
     featureSwitches[FeatureSwitchKey.CustomModelGateways] ?? false;
-  const deepSeekV4FlashEnabled =
-    featureSwitches[FeatureSwitchKey.DeepSeekV4Flash] ?? false;
   const openAddModelDialog = useSet(openAddModelPolicyDialog$);
   const openEditModelDialog = useSet(openEditModelPolicyDialog$);
   const openSettingsBillingPlans = useSet(openSettingsBillingPlans$);
@@ -1756,8 +1754,7 @@ export function OrgModelPoliciesSection() {
   );
   const addableModels = SUPPORTED_RUN_MODELS.filter((model) => {
     return (
-      (isOpenAIOrAnthropicModel(model) ||
-        (deepSeekV4FlashEnabled && model === "deepseek-v4-flash")) &&
+      (isOpenAIOrAnthropicModel(model) || model === "deepseek-v4-flash") &&
       !configuredModels.has(model)
     );
   });

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -30,7 +30,6 @@ describe("isFeatureEnabled", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.Dummy, { userId: "any-user" }),
     ).toBe(true);
-    expect(isFeatureEnabled(FeatureSwitchKey.DeepSeekV4Flash, {})).toBe(true);
   });
 
   it("should return false for disabled switch without context", () => {
@@ -153,7 +152,6 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.StrapiIntegration]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.DeepSeekV4Flash]).toBe(true);
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
@@ -189,7 +187,6 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.StrapiIntegration]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.DeepSeekV4Flash]).toBe(true);
   });
 
   it("should apply overrides to enable disabled features", () => {
@@ -245,9 +242,6 @@ describe("user-overridable switches", () => {
       FeatureSwitchKey.StrapiIntegration,
     );
     expect(getUserOverridableFeatureSwitchKeys()).toContain(
-      FeatureSwitchKey.DeepSeekV4Flash,
-    );
-    expect(getUserOverridableFeatureSwitchKeys()).toContain(
       FeatureSwitchKey.StructuredPromptInlineTemplates,
     );
     expect(getUserOverridableFeatureSwitchKeys()).toContain(
@@ -262,13 +256,11 @@ describe("user-overridable switches", () => {
         [FeatureSwitchKey.StructuredPromptInlineTemplates]: true,
         [FeatureSwitchKey.ZeroMailReplyFollowUp]: true,
         [FeatureSwitchKey.ZeroBrowser]: true,
-        [FeatureSwitchKey.DeepSeekV4Flash]: true,
         [FeatureSwitchKey.ComposerConnectorPermissions]: true,
         [FeatureSwitchKey.Dummy]: false,
       }),
     ).toStrictEqual({
       [FeatureSwitchKey.ZeroBrowser]: true,
-      [FeatureSwitchKey.DeepSeekV4Flash]: true,
       [FeatureSwitchKey.ComposerConnectorPermissions]: true,
       [FeatureSwitchKey.Dummy]: false,
       [FeatureSwitchKey.StructuredPromptInlineTemplates]: true,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -61,7 +61,6 @@ export enum FeatureSwitchKey {
   ComposerUploadPopover = "composerUploadPopover",
   StructuredPromptInlineTemplates = "structuredPromptInlineTemplates",
   CustomModelGateways = "customModelGateways",
-  DeepSeekV4Flash = "deepSeekV4Flash",
 
   ZapierConnector = "zapierConnector",
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -348,11 +348,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabledOrgIdHashes: CUSTOM_MODEL_GATEWAY_ORG_ID_HASHES,
     userOverridable: false,
   },
-  [FeatureSwitchKey.DeepSeekV4Flash]: {
-    maintainer: "ethan@vm0.ai",
-    description: "Show DeepSeek V4 Flash in the workspace Add model selector.",
-    enabled: true,
-  },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- remove the globally enabled `DeepSeekV4Flash` key and registry entry
- make `deepseek-v4-flash` always available in the workspace Add model selector
- remove switch-only fixture plumbing and assertions while retaining page-level availability coverage

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` for all non-API workspaces
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api lint`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/org-providers-tab.test.tsx`
