### PR TITLE
refactor(api): stop selecting legacy run lifecycle column

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -132,7 +132,6 @@ type ChatEventRow = {
   readonly runEventId: string | null;
   readonly goalEvent: ChatEventGoalEvent | null;
   readonly error: string | null;
-  readonly runLifecycleEvent: string | null;
   readonly seqId: number;
   readonly sequenceNumber: number | null;
   readonly createdAt: Date;
@@ -270,7 +269,6 @@ const eventColumns = {
   runEventId: chatEvents.runEventId,
   goalEvent: chatEvents.goalEvent,
   error: chatEvents.error,
-  runLifecycleEvent: chatEvents.runLifecycleEvent,
   seqId: chatEvents.seqId,
   sequenceNumber: chatEvents.sequenceNumber,
   createdAt: chatEvents.createdAt,


### PR DESCRIPTION
## Summary

- complete **PR 1 (prepare, no migration)** of the two-PR `chat_events.run_lifecycle_event` contraction
- remove the legacy column from the `eventColumns` projection used by `selectChatEventsWithMetadata()`
- remove the corresponding field from `ChatEventRow`
- keep the terminal response leaves byte-identical: `"completed"`, `"failed"`, and `"cancelled"` are still derived from canonical `event_type` leaves

This PR intentionally contains only two deleted lines.

## Why this is a separate PR

Production migrations run before API promotion. Dropping the column in this PR would make draining previous-release API instances fail `/api/zero/chat-threads/:threadId/events` with PostgreSQL `42703`, because those instances still select `chat_events.run_lifecycle_event`.

Accordingly, this prepare step adds no migration and leaves all database objects unchanged:

- the `run_lifecycle_event` column and its Drizzle declaration
- `chat_events_run_lifecycle_unique`
- `idx_chat_events_thread_run_finish_created`
- the canonical terminal predicate and terminal indexes

## Repository sweep

A repository-wide scan covered direct Drizzle references, insert object fields, camel-case wire fields, raw SQL, and index names.

- no application code selects `chatEvents.runLifecycleEvent` after this change
- production writers already exclude the column from their insert type, and no active predicate reads it
- the three remaining service fields are the required wire derivations for `run.completed`, `run.failed`, and `run.cancelled`
- one test-only conflicting legacy-payload fixture remains to prove readers use `event_type`
- remaining database references are the intentionally retained Drizzle column/legacy indexes, immutable migration SQL and snapshots, and the migration-consistency fixture

PR #23109 is still open and also edits this service. The branch was rebased on current `origin/main`, then rechecked to confirm the projection was not reintroduced.

## PR 2 gate

PR 2 must wait until this prepare change has shipped, the release is fully deployed, and its rollback target has drained. Only then may the separate contract PR run the live catalog preflight and remove the two legacy indexes and column.

## Validation

Passed locally:

- Prettier 3.8.1 for the changed file
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `git diff --check`
- final repository sweep and post-rebase projection/wire review

The focused chat-thread integration test was attempted, but this host runs PostgreSQL 18.4 while the repository and CI pin PostgreSQL 17.10. The migration chain stopped at its existing connector contraction catalog preflight before the test reached this code path. The temporary test database was removed; integration coverage is delegated to PR CI.

## Post-release verification

Before starting PR 2, verify:

- zero PostgreSQL `42703` errors naming `chat_events.run_lifecycle_event`, especially on `/api/zero/chat-threads/:threadId/events`
- terminal event API responses remain unchanged, including the exact `runLifecycleEvent` values

Refs #24413
Refs #24215