### PR TITLE
test(connectors): rename credential state wire identity to slug

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
@@ -38,7 +38,7 @@ export async function readConnectorCredentialStorageState(
     action: "read",
     org_id: args.orgId,
     user_id: args.userId,
-    connector_ref: args.connectorSlug,
+    connector_slug: args.connectorSlug,
     secret_names: [...(args.secretNames ?? [])],
     variable_names: [...(args.variableNames ?? [])],
   });
@@ -61,7 +61,7 @@ export async function seedOwnedConnectorSecret(
     action: "seed-owned-secret",
     org_id: args.orgId,
     user_id: args.userId,
-    connector_ref: args.connectorSlug,
+    connector_slug: args.connectorSlug,
     auth_method: args.authMethod,
     storage_version: args.storageVersion,
     name: args.name,
@@ -88,7 +88,7 @@ export async function seedConnectorStorageRow(
     action: "seed-connector",
     org_id: args.orgId,
     user_id: args.userId,
-    connector_ref: args.connectorSlug,
+    connector_slug: args.connectorSlug,
     auth_method: args.authMethod,
     storage_version: args.storageVersion,
   });
@@ -112,7 +112,7 @@ export async function setConnectorCredentialStorageState(
     action: "set-connector-state",
     org_id: args.orgId,
     user_id: args.userId,
-    connector_ref: args.connectorSlug,
+    connector_slug: args.connectorSlug,
     storage_version: args.storageVersion,
     ...(args.tokenExpiresAt === undefined
       ? {}

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -59,7 +59,7 @@ async function readState(
       and(
         eq(connectors.orgId, body.org_id),
         eq(connectors.userId, body.user_id),
-        eq(connectors.connectorSlug, body.connector_ref),
+        eq(connectors.connectorSlug, body.connector_slug),
       ),
     )
     .limit(1);
@@ -137,7 +137,7 @@ async function seedOwnedSecret(
       .values({
         orgId: body.org_id,
         userId: body.user_id,
-        connectorSlug: body.connector_ref,
+        connectorSlug: body.connector_slug,
         authMethod: body.auth_method,
         storageVersion: body.storage_version,
       })
@@ -170,7 +170,7 @@ async function seedConnector(
     .values({
       orgId: body.org_id,
       userId: body.user_id,
-      connectorSlug: body.connector_ref,
+      connectorSlug: body.connector_slug,
       authMethod: body.auth_method,
       storageVersion: body.storage_version,
     })
@@ -204,7 +204,7 @@ async function setConnectorState(
       and(
         eq(connectors.orgId, body.org_id),
         eq(connectors.userId, body.user_id),
-        eq(connectors.connectorSlug, body.connector_ref),
+        eq(connectors.connectorSlug, body.connector_slug),
       ),
     )
     .returning({ id: connectors.id });

--- a/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
@@ -21,15 +21,13 @@ const variableStateSchema = z.object({
   connector_id: z.uuid(),
 });
 
-// TODO(#23619): Rename the test-only `connector_ref` wire fields with their
-// persisted connector lookup.
 export const testConnectorCredentialStorageStateActionBodySchema =
   z.discriminatedUnion("action", [
     z.object({
       action: z.literal("read"),
       org_id: z.string(),
       user_id: z.string(),
-      connector_ref: z.string(),
+      connector_slug: z.string(),
       secret_names: z.array(z.string()),
       variable_names: z.array(z.string()),
     }),
@@ -37,7 +35,7 @@ export const testConnectorCredentialStorageStateActionBodySchema =
       action: z.literal("seed-owned-secret"),
       org_id: z.string(),
       user_id: z.string(),
-      connector_ref: z.string(),
+      connector_slug: z.string(),
       auth_method: z.string(),
       storage_version: z.number().int().positive(),
       name: z.string(),
@@ -48,7 +46,7 @@ export const testConnectorCredentialStorageStateActionBodySchema =
       action: z.literal("seed-connector"),
       org_id: z.string(),
       user_id: z.string(),
-      connector_ref: z.string(),
+      connector_slug: z.string(),
       auth_method: z.string(),
       storage_version: z.number().int().positive(),
     }),
@@ -56,7 +54,7 @@ export const testConnectorCredentialStorageStateActionBodySchema =
       action: z.literal("set-connector-state"),
       org_id: z.string(),
       user_id: z.string(),
-      connector_ref: z.string(),
+      connector_slug: z.string(),
       storage_version: z.number().int().positive(),
       token_expires_at: z.iso.datetime().nullable().optional(),
     }),


### PR DESCRIPTION
## Summary

- Rename the test-only connector credential storage-state request identity from
  `connector_ref` to `connector_slug` across the typed contract, route, and
  shared integration-test helper.
- Remove the completed connector identity migration TODO.
- Preserve fixture validation and behavior without a compatibility alias or
  fallback.

## Compatibility

- No production API, frontend, runner, queue, cache, catalog artifact, database
  schema, migration, or persisted-data change.
- The affected route is mounted only by the shared test helper in the same
  repository revision.

## Validation

- `pnpm exec prettier --check packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts apps/api/src/signals/routes/test-connector-credential-storage-state.ts apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api --workspace @vm0/api-contracts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/cron-connector-catalog.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/test-usage-insight-state.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts src/signals/routes/__tests__/zero-connector-check.test.ts src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts src/signals/routes/__tests__/zero-mail.test.ts --maxWorkers=1 --silent=passed-only`
- `git diff --check`
- Exact `connector_ref` audit for the three affected live-source files

Closes #24348

Parent: #23619
