### PR TITLE
test(e2e): isolate real-agent preview identities

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1148,7 +1148,7 @@ jobs:
           done
 
           # Create test users + orgs (browser is created via UI sign-up flow)
-          for variant in serial runner; do
+          for variant in serial runner runner-real-codex runner-real-claude; do
             email="${JOB_REF}+clerk_test+${variant}@vm0-e2e.ai"
             encoded_email=$(jq -rn --arg email "$email" '$email|@uri')
             existing_users=$(curl -sS -X GET \
@@ -1194,6 +1194,12 @@ jobs:
           e2e/scripts/generate-test-token.sh \
             "${JOB_REF}+clerk_test+runner@vm0-e2e.ai" \
             "/tmp/e2e-api-credentials-runner.json"
+          e2e/scripts/generate-test-token.sh \
+            "${JOB_REF}+clerk_test+runner-real-codex@vm0-e2e.ai" \
+            "/tmp/e2e-api-credentials-runner-real-codex.json"
+          e2e/scripts/generate-test-token.sh \
+            "${JOB_REF}+clerk_test+runner-real-claude@vm0-e2e.ai" \
+            "/tmp/e2e-api-credentials-runner-real-claude.json"
         env:
           VM0_API_BACKEND_URL: ${{ steps.api-alias.outputs.url || steps.api-deploy.outputs.url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
@@ -1206,6 +1212,8 @@ jobs:
           path: |
             /tmp/e2e-api-credentials-serial.json
             /tmp/e2e-api-credentials-runner.json
+            /tmp/e2e-api-credentials-runner-real-codex.json
+            /tmp/e2e-api-credentials-runner-real-claude.json
           retention-days: 1
 
   # Build the canonical Cloudflare app artifact independently of Vercel, then

--- a/e2e/helpers/codex-zero.bash
+++ b/e2e/helpers/codex-zero.bash
@@ -210,10 +210,10 @@ send_chat_run_message() {
     local selected_model="$3"
     local payload body client_event_id
     client_event_id=$(cat /proc/sys/kernel/random/uuid)
-    # The caller enables the claim-time RealAgentInPreview switch around this
-    # request so the real codex CLI executes against $OPENAI_API_KEY. Keep the
-    # request field to mirror the current web API contract; it is no longer the
-    # source of the claimed run setting.
+    # The caller uses a dedicated identity whose claim-time
+    # RealAgentInPreview switch is enabled, so the real codex CLI executes
+    # against $OPENAI_API_KEY. Keep the request field to mirror the current web
+    # API contract; it is no longer the source of the claimed run setting.
     payload=$(jq -nc \
         --arg agentId "$agent_id" \
         --arg prompt "$prompt" \

--- a/e2e/helpers/codex-zero.bash
+++ b/e2e/helpers/codex-zero.bash
@@ -58,18 +58,6 @@ enable_codex_beta() {
         >/dev/null
 }
 
-# Do not clear feature-switch overrides in teardown. Runner E2E files execute
-# in parallel and share the same authenticated runner user; DELETE
-# /api/zero/feature-switches removes every override for that shared user, which
-# can race another file between enable_codex_beta and its gated API call.
-#
-# Leaving codexBeta enabled is intentional for the shared E2E runner user.
-# Tests that need feature-off behavior must use a dedicated token/user and
-# explicitly force the switch off for that isolated identity.
-disable_codex_beta() {
-    return 0
-}
-
 configure_codex_zero_model_policy() {
     local model="$1"
     local provider_type="$2"

--- a/e2e/helpers/setup.bash
+++ b/e2e/helpers/setup.bash
@@ -124,26 +124,20 @@ require_e2e_api_credentials() {
     e2e_api_token >/dev/null && e2e_api_url >/dev/null
 }
 
+use_e2e_api_credentials() {
+    local variant="$1"
+    local credentials="/tmp/e2e-api-credentials-${variant}.json"
+    E2E_API_TOKEN=$(jq -er '.token | select(type == "string" and length > 0)' "$credentials") || return 1
+    E2E_API_URL=$(jq -er '.apiUrl | select(type == "string" and length > 0)' "$credentials") || return 1
+    export E2E_API_TOKEN E2E_API_URL
+}
+
 set_real_agent_in_preview() {
     local enabled="$1"
     e2e_api_curl "/api/zero/feature-switches" \
         -X POST \
         -d "{\"switches\":{\"realAgentInPreview\":${enabled}}}" \
         >/dev/null
-}
-
-# The chat create call claims an idle thread synchronously, so the switch only
-# needs to be enabled around that request. Restore it immediately to avoid
-# changing unrelated preview runs that share the E2E identity.
-with_real_agent_preview_claim() {
-    local previous
-    previous=$(e2e_api_curl "/api/zero/feature-switches" | jq -er '.effectiveSwitches.realAgentInPreview | select(type == "boolean") | tostring') || return 1
-    set_real_agent_in_preview true || return 1
-    local command_status=0
-    local reset_status=0
-    "$@" || command_status=$?
-    set_real_agent_in_preview "$previous" || reset_status=$?
-    [[ "$command_status" -eq 0 && "$reset_status" -eq 0 ]]
 }
 
 e2e_api_curl() {

--- a/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
+++ b/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
@@ -24,6 +24,9 @@ load '../../helpers/codex-zero'
 export BATS_TEST_TIMEOUT=300
 
 setup_file() {
+    use_e2e_api_credentials "runner-real-codex"
+    set_real_agent_in_preview true
+
     export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
     export TEST_DIR="$(mktemp -d)"
     export AGENT_NAME="e2e-codex-byok-${UNIQUE_ID}"
@@ -98,7 +101,7 @@ teardown_file() {
     # `export` from the helper would not propagate back to this scope, and
     # LAST_THREAD_ID / LAST_RUN_ID would arrive empty. The helper returns
     # non-zero on failure, which fails the test naturally.
-    with_real_agent_preview_claim send_chat_run_message "$AGENT_ID" \
+    send_chat_run_message "$AGENT_ID" \
         "Compute 123+456 and reply with exactly: RESULT=<answer>" \
         "gpt-5.5"
 
@@ -121,7 +124,7 @@ teardown_file() {
 }
 
 @test "t-codex-zero-byok-smoke-2: gpt-5.6-luna via zero web layer" {
-    with_real_agent_preview_claim send_chat_run_message "$AGENT_ID" \
+    send_chat_run_message "$AGENT_ID" \
         "Compute 234+567 and reply with exactly: LUNA_RESULT=<answer>" \
         "gpt-5.6-luna"
 

--- a/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
+++ b/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
@@ -86,7 +86,6 @@ teardown_file() {
     if [[ -n "${AGENT_ID:-}" ]]; then
         delete_e2e_agent "$AGENT_ID" >/dev/null 2>&1 || true
     fi
-    disable_codex_beta
     if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
         rm -rf "$TEST_DIR"
     fi

--- a/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
+++ b/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
@@ -17,13 +17,11 @@ setup_file() {
         skip "ANTHROPIC_API_KEY not set — required for real Claude calls"
     fi
 
-    local serial_credentials="/tmp/e2e-api-credentials-serial.json"
-    E2E_API_TOKEN=$(jq -er '.token | select(type == "string" and length > 0)' "$serial_credentials")
-    E2E_API_URL=$(jq -er '.apiUrl | select(type == "string" and length > 0)' "$serial_credentials")
-    export E2E_API_TOKEN E2E_API_URL
+    use_e2e_api_credentials "runner-real-claude"
+    set_real_agent_in_preview true
 
-    # This file uses the isolated serial identity so its claim-time preview
-    # switch cannot race other runner chunks. Mirror the runner bootstrap's
+    # This file uses a dedicated real Claude identity so its claim-time preview
+    # mode cannot race other runner chunks. Mirror the runner bootstrap's
     # model-first defaults for that otherwise uninitialized workspace.
     e2e_api_curl "/api/zero/model-policies" \
         -X PUT \
@@ -98,7 +96,7 @@ teardown_file() {
 }
 
 @test "t54-1: vm0 meta-provider — firewall billable" {
-    with_real_agent_preview_claim zero_chat_run_with_model \
+    zero_chat_run_with_model \
         "$AGENT_ID" \
         "Reply with exactly: DONE" \
         "claude-sonnet-4-6" \


### PR DESCRIPTION
## Summary

- provision dedicated preview E2E identities for real Codex and real Claude web-chat coverage
- keep each identity's `realAgentInPreview` mode stable for the test-file lifetime
- remove the non-atomic feature-switch read/write/restore helper from the shared runner identity

## Problem

All runner E2E matrix jobs used the same authenticated identity. A real Codex test temporarily enabled the user-scoped `realAgentInPreview` switch while unrelated Teams and Slack tests were claiming runs. A Teams run could therefore be marked as real-agent, suppress `USE_MOCK_CLAUDE`, and fail with an authentication error against its intentionally empty fixture credential.

## Implementation

- add `runner-real-codex` and `runner-real-claude` to preview account and token provisioning
- add fail-fast E2E credential selection by identity variant
- move the two canonical real-agent web-chat files to their dedicated identities
- retain each fresh organization's existing provider and model-policy setup

This does not change production feature-switch semantics, run payload handling, Teams or Slack behavior, runner runtime selection, retries, timeouts, or test scheduling.

## Validation

- `cd turbo && pnpm exec prettier --check --ignore-unknown ../.github/workflows/turbo.yml ../e2e/helpers/setup.bash ../e2e/helpers/codex-zero.bash ../e2e/tests/03-runner/t-codex-zero-byok-smoke.bats ../e2e/tests/03-runner/t54-vm0-billable-firewall.bats`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/turbo.yml`
- `PATH="$HOME/go/bin:$PATH" .github/scripts/check-workflow-shell-compatibility.sh .github/workflows/turbo.yml`
- `bash -n e2e/helpers/setup.bash e2e/helpers/codex-zero.bash`
- `shellcheck -e SC2016,SC2103,SC2155,SC2164 e2e/helpers/setup.bash e2e/helpers/codex-zero.bash`
- `e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/t-codex-zero-byok-smoke.bats e2e/tests/03-runner/t54-vm0-billable-firewall.bats`
- `lefthook run pre-commit`

Closes #24415
