### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -121,8 +121,8 @@ AGENT_BROWSER_VERSION="0.33.0-vm0.1"
 AGENT_BROWSER_LINUX_X64_SHA256="a9e3fbe24c537960b9ac0d1f358224a10eb70d87a619aec7bcb1175222a46a18"
 AGENT_BROWSER_LINUX_ARM64_SHA256="6a74dba04c299a69d564eae5aff67adc2ffc6fda5ddf672994ff75b73d64a9fe"
 PNPM_VERSION="11.18.0"
-CHROMIUM_VERSION="150.0.7871.181-1~deb12u1"
-CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260723T024428Z"
+CHROMIUM_VERSION="151.0.7922.71-1~deb12u1"
+CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260731T162426Z"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

- Update Debian Chromium from `150.0.7871.181-1~deb12u1` to `151.0.7922.71-1~deb12u1`.
- Advance the Debian security snapshot from `20260723T024428Z` to `20260731T162426Z`.
- Confirm that `chromium`, `chromium-common`, and `chromium-sandbox` are available at the pinned version for both amd64 and arm64 in the new snapshot.

## Verification

- `git diff --check`
- `bash -n crates/runner/scripts/build-template.sh`
- `cargo fmt -p runner -- --check`
- `cargo clippy -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p runner --no-deps`
- `cargo test -p runner cmd::build::scripts::tests -- --nocapture` (26 passed)