### PR TITLE
chore(rust): update clap to 4.6.5

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -786,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -796,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",


### PR DESCRIPTION
## Summary

- Update `clap` from 4.6.4 to 4.6.5.
- Update `clap_builder` from 4.6.2 to 4.6.5.

## Dependencies not updated

- `generic-array` remains at 0.14.7 although 0.14.9 is available because `crypto-common` 0.1.7 pins it exactly to `=0.14.7`.

## Manual version bumps

- None.

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace --exclude runner`
- `cargo test -p runner` — 2,903 passed, 14 ignored, 0 failed; the guest-inventory integration test also passed.

The runner suite was compiled with one build job, test debug info disabled, incremental compilation disabled for the runner test target, and the Rust toolchain's bundled LLVM linker. These settings keep the complete suite within the validation host's 3.8 GiB, no-swap memory limit; no tests were newly skipped or disabled.
