### PR TITLE
test(e2e): report auth completion failures

### DIFF
--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -74,19 +74,22 @@ encode_uri_component() {
 
 wait_for_auth_completion() {
   local auth_path="$1"
+  local completion_expression
 
   if [[ -n "${VM0_AUTH_REDIRECT_URL:-}" ]]; then
     local redirect_url_json
     redirect_url_json=$(node -e \
       'process.stdout.write(JSON.stringify(process.argv[1]))' \
       "$VM0_AUTH_REDIRECT_URL")
-    wait_for_browser_target --fn \
-      "window.location.href.startsWith(${redirect_url_json})"
-    return
+    completion_expression="window.location.href.startsWith(${redirect_url_json})"
+  else
+    completion_expression="!window.location.pathname.includes('/${auth_path}')"
   fi
 
-  wait_for_browser_target --fn \
-    "!window.location.pathname.includes('/${auth_path}')"
+  if ! wait_for_browser_target --fn "$completion_expression"; then
+    report_auth_page_failure
+    return 1
+  fi
 }
 
 open_auth_form() {


### PR DESCRIPTION
## Summary

- report the existing redacted auth-page diagnostics when browser E2E authentication completion fails
- preserve the original non-zero result for both redirect-URL and auth-path completion checks

## Context

The browser E2E job in [run 30684709778](https://github.com/vm0-ai/vm0/actions/runs/30684709778/job/91328359643) submitted the Clerk sign-in verification and then remained on `/sign-in` until the completion wait expired. The same head passed on rerun, but the original failure did not include the page state, browser errors, failed requests, or console output needed to distinguish a Clerk response from a frontend or redirect failure.

## Exclusions

- no production authentication changes
- no test retry, timeout increase, or skipped assertion
- no change to successful browser E2E behavior

## Validation

- `shellcheck -x -s bash e2e/tests/02-browser/brw-t01-platform-e2e.bats`
- `./e2e/test/libs/bats/bin/bats --count ./e2e/tests/02-browser/brw-t01-platform-e2e.bats` (2 tests)
- focused Bash behavior probe for success, redirect failure, and auth-path failure
- `./scripts/check-file-size.sh e2e/tests/02-browser/brw-t01-platform-e2e.bats`
- `git diff --check`
- `lefthook run pre-commit`

The live Clerk flow requires a deployed preview and remains covered by the browser E2E CI job.
