### PR TITLE
refactor(connectors): retire compatibility sweeper

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -49,7 +49,6 @@ import {
   deleteApiTestConnectorCatalogCompatibility,
   deleteApiTestConnectorCatalogCompatibilityEvaluation,
   invalidateApiTestConnectorCatalogCompatibility,
-  insertApiTestLegacyConnectorCatalogCompatibilityEvaluation,
   mockApiTestConnectorProviderConfiguration,
   readApiTestConnectorCatalogCompatibilityEvaluations,
   readApiTestConnectorCatalogValidationAuthority,
@@ -105,7 +104,6 @@ const DEFAULT_API_VERSION = apiPackage.version;
 const ZERO_DIGEST = `sha256:${"0".repeat(64)}`;
 const EXPECTED_CAPABILITY_DIGEST =
   "sha256:f28faa130eeea8dbc27f816003b6fe162dc1792dd27f5e9173856c5bedb7eea7";
-const DRAINING_WRITER_CAPABILITY_DIGEST = `sha256:${"d".repeat(64)}`;
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";
@@ -5074,39 +5072,7 @@ describe("connector catalog executable compatibility", () => {
     expect(evaluation?.payload).toStrictEqual({
       filteredAuthMethods: expectedMethods,
     });
-    expect(JSON.stringify(evaluation?.payload)).not.toContain("connectorRef");
     expect(wireMethods).toStrictEqual(expectedMethods);
-  });
-
-  it("removes a draining writer array on current-authority reconciliation", async () => {
-    configureSource();
-    mockApiTestConnectorProviderConfiguration();
-    const release = buildRelease({
-      version: "2026-07-31.draining-writer-evaluation",
-    });
-    serveObjects(catalogObjects([release], release));
-    await syncCatalog();
-    const beforeLegacyWrite =
-      await readApiTestConnectorCatalogCompatibilityEvaluations();
-    expect(beforeLegacyWrite).toHaveLength(1);
-
-    await insertApiTestLegacyConnectorCatalogCompatibilityEvaluation(
-      DRAINING_WRITER_CAPABILITY_DIGEST,
-    );
-    const afterLegacyWrite =
-      await readApiTestConnectorCatalogCompatibilityEvaluations();
-    expect(afterLegacyWrite).toHaveLength(2);
-    expect(
-      afterLegacyWrite.filter(({ payload }) => {
-        return Array.isArray(payload);
-      }),
-    ).toHaveLength(1);
-
-    mockNow(new Date("2026-07-31T08:01:00.000Z"));
-    expect((await syncCatalog()).body.outcome).toBe("unchanged");
-    await expect(
-      readApiTestConnectorCatalogCompatibilityEvaluations(),
-    ).resolves.toStrictEqual(beforeLegacyWrite);
   });
 
   it("fails closed and reconciles a missing compatibility evaluation", async () => {

--- a/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
@@ -405,36 +405,6 @@ async function persistConnectorCatalogCompatibilityEvaluation(args: {
     });
 }
 
-async function deleteLegacyConnectorCatalogCompatibilityEvaluations(args: {
-  readonly db: Db;
-  readonly sourceId: string;
-  readonly identity: ConnectorCatalogCompatibilityIdentity;
-}): Promise<void> {
-  await args.db
-    .delete(connectorCatalogCompatibilityEvaluation)
-    .where(
-      and(
-        eq(connectorCatalogCompatibilityEvaluation.sourceId, args.sourceId),
-        eq(
-          connectorCatalogCompatibilityEvaluation.schemaVersion,
-          SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
-        ),
-        eq(
-          connectorCatalogCompatibilityEvaluation.catalogVersion,
-          args.identity.catalogVersion,
-        ),
-        eq(
-          connectorCatalogCompatibilityEvaluation.catalogDigest,
-          args.identity.catalogDigest,
-        ),
-        eq(
-          sql`jsonb_typeof(${connectorCatalogCompatibilityEvaluation.filteredAuthMethods})`,
-          "array",
-        ),
-      ),
-    );
-}
-
 export async function persistConnectorCatalogCompatibility(args: {
   readonly db: Db;
   readonly sourceId: string;
@@ -461,11 +431,6 @@ export async function persistConnectorCatalogCompatibility(args: {
     capabilityDigest: args.capability.digest,
     evaluatedAt,
     payload,
-  });
-  await deleteLegacyConnectorCatalogCompatibilityEvaluations({
-    db: args.db,
-    sourceId: args.sourceId,
-    identity: args.identity,
   });
 }
 
@@ -580,11 +545,6 @@ async function reconcileCompatibility(args: {
       validator: args.validator,
     })
   ) {
-    await deleteLegacyConnectorCatalogCompatibilityEvaluations({
-      db: args.db,
-      sourceId: args.sourceId,
-      identity: snapshot,
-    });
     return;
   }
 

--- a/turbo/apps/api/src/test-fixtures/connector-catalog.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog.ts
@@ -7,7 +7,7 @@ import {
   connectorCatalogCompatibilityEvaluation,
   connectorCatalogSyncState,
 } from "@vm0/db/schema/connector-catalog";
-import { and, asc, eq, sql } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 
 import { mockOptionalEnv } from "../lib/env";
 import { writeDb$ } from "../signals/external/db";
@@ -417,45 +417,6 @@ export async function invalidateApiTestConnectorCatalogCompatibility(): Promise<
     .where(currentApiTestConnectorCatalogCompatibilityWhere(identity))
     .returning({ sourceId: connectorCatalogCompatibilityEvaluation.sourceId });
   requireSingleCatalogMutation(updated, "compatibility corruption");
-}
-
-export async function insertApiTestLegacyConnectorCatalogCompatibilityEvaluation(
-  capabilityDigest: string,
-): Promise<void> {
-  const identity = await currentApiTestConnectorCatalogIdentity();
-  const validator = currentConnectorCatalogValidatorIdentity();
-  const evaluatedAt = nowDate();
-  const legacyPayload = JSON.stringify([
-    {
-      connectorRef: "external-test",
-      authMethodId: "api-token",
-      reasons: ["missing-grant-provider"],
-    },
-  ]);
-  const db = store.set(writeDb$);
-  await db.execute(sql`
-    INSERT INTO ${connectorCatalogCompatibilityEvaluation} (
-      "source_id",
-      "schema_version",
-      "catalog_version",
-      "catalog_digest",
-      "executable_capability_digest",
-      "catalog_validation_backend_version",
-      "catalog_validation_build_commit_sha",
-      "evaluated_at",
-      "filtered_auth_methods"
-    ) VALUES (
-      ${identity.sourceId},
-      ${SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION},
-      ${identity.catalogVersion},
-      ${identity.catalogDigest},
-      ${capabilityDigest},
-      ${validator.backendVersion},
-      ${validator.buildCommitSha},
-      ${evaluatedAt},
-      ${legacyPayload}::jsonb
-    )
-  `);
 }
 
 export async function deleteApiTestConnectorCatalogCompatibility(): Promise<void> {


### PR DESCRIPTION
## Summary

- remove the connector catalog root-array compatibility sweeper from persistence and current-authority reconciliation
- remove the retired draining-writer fixture and integration story
- keep canonical object-envelope behavior and historical migration 0784 coverage unchanged

## Why

The sweeper existed only for rolling overlap with a pre-cutover API that could reintroduce array payloads containing `connectorRef`. That writer is outside the supported deployment window, so every reconciliation was continuing to pay for an unsupported compatibility state.

## Compatibility and risk

- no schema, migration, persisted canonical shape, API, Platform, runner, realtime, or catalog artifact change
- current evaluations remain strict object envelopes whose filtered methods use `connectorSlug`
- a deliberate rollback behind PR #24324 must restore its own legacy-writer transition handling
- migration `0784_remove_legacy_connector_catalog_compatibility.sql` and its migration-consistency scenario remain unchanged

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run --maxWorkers=1 src/signals/routes/__tests__/cron-connector-catalog.test.ts` (107 tests)
- `pnpm knip`
- pre-commit Prettier and Knip hooks

Closes #24425

Parent: #23619
