### PR TITLE
refactor: assemble slack launch prompts at claim

### DIFF
--- a/turbo/apps/api/src/lib/slack-webhook-context.ts
+++ b/turbo/apps/api/src/lib/slack-webhook-context.ts
@@ -424,7 +424,7 @@ function formatContextForAgent(
   )}\n\n---`;
 }
 
-export function formatCurrentMessageFiles(files: readonly SlackFile[]): string {
+function formatCurrentMessageFiles(files: readonly SlackFile[]): string {
   return files.map(formatFileInfo).join("\n");
 }
 
@@ -436,7 +436,7 @@ export interface SlackPromptAsset {
   readonly status: "pending" | "ready" | "failed";
 }
 
-export function canonicalSlackFilesPrompt(
+function canonicalSlackFilesPrompt(
   files: readonly SlackFile[] | undefined,
   assets: readonly SlackPromptAsset[],
 ): string {

--- a/turbo/apps/api/src/lib/slack-webhook-context.ts
+++ b/turbo/apps/api/src/lib/slack-webhook-context.ts
@@ -297,7 +297,7 @@ function formatAttachmentImage(attachment: SlackAttachment): string | null {
   return parts.join("\n");
 }
 
-function resolveUserMentions(
+export function resolveUserMentions(
   text: string,
   userInfoMap?: Map<string, SlackUserInfo>,
   includeSlackUserId = true,
@@ -426,6 +426,76 @@ function formatContextForAgent(
 
 export function formatCurrentMessageFiles(files: readonly SlackFile[]): string {
   return files.map(formatFileInfo).join("\n");
+}
+
+export interface SlackPromptAsset {
+  readonly assetId: string;
+  readonly position: number;
+  readonly filename: string;
+  readonly contentType: string;
+  readonly status: "pending" | "ready" | "failed";
+}
+
+export function canonicalSlackFilesPrompt(
+  files: readonly SlackFile[] | undefined,
+  assets: readonly SlackPromptAsset[],
+): string {
+  if (!files || files.length === 0) {
+    return "";
+  }
+  const assetByPosition = new Map(
+    assets.map((asset) => {
+      return [asset.position, asset] as const;
+    }),
+  );
+  return files
+    .flatMap((file, position) => {
+      const asset = assetByPosition.get(position);
+      if (asset?.status === "ready") {
+        return [
+          `[Web file] ${asset.filename} (${asset.contentType})\n   [ID] ${asset.assetId}`,
+        ];
+      }
+      return [formatCurrentMessageFiles([file])];
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function canonicalSlackAgentPrompt(
+  messagePrompt: string,
+  files: readonly SlackFile[] | undefined,
+  assets: readonly SlackPromptAsset[],
+): string {
+  return [messagePrompt, canonicalSlackFilesPrompt(files, assets)]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+export function buildSlackSystemPrompt(args: {
+  readonly botUserId: string;
+  readonly channelId: string;
+  readonly channelType: "channel" | "dm" | "group_dm";
+  readonly threadTs: string;
+  readonly executionContext: string;
+}): string {
+  const typeLabel =
+    args.channelType === "dm"
+      ? "Direct message"
+      : args.channelType === "group_dm"
+        ? "Group direct message"
+        : "Channel";
+  return [
+    "# Current Integration",
+    "You are currently running inside: Slack",
+    `Your bot user ID: ${args.botUserId}`,
+    `Channel ID: ${args.channelId}`,
+    `Channel type: ${typeLabel}`,
+    `Thread ID: ${args.threadTs}`,
+    args.executionContext,
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 function countBucket(count: number): string {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -12,9 +12,11 @@ import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { installApiTestConnectorCatalog } from "../../../test-fixtures/connector-catalog";
 import {
+  decryptChatEventInputParamsFixture,
   findPendingChatEventInputParamsByPromptFixture,
   readChatEventContextFixture,
   readChatEventInputParamsFixture,
+  replaceSlackLaunchMaterialWithLegacyParamsFixture,
 } from "../../../test-fixtures/chat-events";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -307,6 +309,14 @@ async function pollSlackRun(runnerGroup: string): Promise<string> {
     runnerGroup,
     "Expected a Slack-triggered run in the runner queue",
   );
+}
+
+async function requirePendingChatEventInputParams(prompt: string) {
+  const params = await findPendingChatEventInputParamsByPromptFixture(prompt);
+  if (!params) {
+    throw new Error(`Expected queued input params for ${prompt}`);
+  }
+  return params;
 }
 
 async function pollQueuedWebAndSlackRuns(args: {
@@ -1454,6 +1464,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     }
     const orgId = actor.orgId;
     const slackUserId = uniqueSlackUserId();
+    const mentionedSlackUserId = uniqueSlackUserId();
     const { teamId, botUserId } = await integrations.installSlackWorkspace(
       actor,
       {
@@ -1473,7 +1484,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     const event = {
       type: "app_mention",
       user: slackUserId,
-      text: `<@${botUserId}> admit this event once`,
+      text: `<@${botUserId}> admit this event once with <@${mentionedSlackUserId}>`,
       ts: threadTs,
       channel: channelId,
       channel_type: "channel",
@@ -1584,6 +1595,21 @@ describe("INT-01: Slack app deep webhook flows", () => {
     ).events;
     const canonicalInputAssetId =
       requireCanonicalSlackInputAssetId(visibleMessages);
+    const canonicalInputMessage = slackInputMessageByText(
+      visibleMessages,
+      "admit this event once with @Slack User",
+    );
+    if (!canonicalInputMessage) {
+      throw new Error("Expected the canonical Slack input message");
+    }
+    await expect(
+      readChatEventContextFixture(canonicalInputMessage.id),
+    ).resolves.toMatchObject({
+      slackMessageText: `admit this event once with <@${mentionedSlackUserId}>`,
+      slackMentionDisplayNames: {
+        [mentionedSlackUserId]: "Slack User",
+      },
+    });
     expect(visibleMessages).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -1598,7 +1624,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
                 filenameSnapshot: "source-notes.txt",
                 contentType: "text/plain",
               },
-              { type: "text", text: "admit this event once" },
+              { type: "text", text: "admit this event once with @Slack User" },
               {
                 type: "source",
                 kind: "slack",
@@ -1642,10 +1668,12 @@ describe("INT-01: Slack app deep webhook flows", () => {
       "https://vm0.slack.com/archives/C_BDD_CANONICAL_INGRESS/p2900000100",
     );
     const canonicalInputRun = await runs.readRun(actor, run1Id);
-    expect(canonicalInputRun.prompt).toContain(
-      `[Web file] source-notes.txt (text/plain)`,
+    expect(canonicalInputRun.prompt).toBe(
+      `admit this event once with @Slack User (${mentionedSlackUserId})\n\n[Web file] source-notes.txt (text/plain)\n   [ID] ${canonicalInputAssetId}`,
     );
-    expect(canonicalInputRun.prompt).toContain(`[ID] ${canonicalInputAssetId}`);
+    expect(canonicalInputRun.appendSystemPrompt).toContain(
+      `# Current Integration\nYou are currently running inside: Slack\nYour bot user ID: ${botUserId}\nChannel ID: ${channelId}\nChannel type: Channel\nThread ID: ${threadTs}`,
+    );
     expect(canonicalInputRun.appendSystemPrompt).toContain(
       "zero web download-file -h",
     );
@@ -1729,17 +1757,19 @@ describe("INT-01: Slack app deep webhook flows", () => {
         }),
       ]),
     );
-    const queuedSlackParams =
-      await findPendingChatEventInputParamsByPromptFixture(
-        "stay canonical on the same route",
-      );
+    const queuedSlackParams = await requirePendingChatEventInputParams(
+      "stay canonical on the same route",
+    );
     expect(queuedSlackParams).toMatchObject({
       eventId: expect.any(String),
       encryptedParams: expect.any(String),
     });
-    if (!queuedSlackParams) {
-      throw new Error("Expected queued canonical Slack transport params");
-    }
+    await expect(
+      decryptChatEventInputParamsFixture(queuedSlackParams.eventId, {
+        orgId,
+        userId: actor.userId,
+      }),
+    ).resolves.toStrictEqual({ version: 1 });
     await expect(
       readChatEventContextFixture(queuedSlackParams.eventId),
     ).resolves.toMatchObject({
@@ -2002,6 +2032,76 @@ describe("INT-01: Slack app deep webhook flows", () => {
       thread_ts: threadTs,
       status: "",
     });
+
+    const fallbackAnchorBody = JSON.stringify({
+      type: "event_callback",
+      team_id: teamId,
+      event_id: `EvBDD${randomUUID().replace(/-/g, "")}`,
+      event: {
+        ...event,
+        text: "block the legacy Slack fallback",
+        ts: "2900.000400",
+        thread_ts: threadTs,
+      },
+    });
+    await integrations.requestSlackEvent(
+      fallbackAnchorBody,
+      integrations.signedSlackIngressHeaders(fallbackAnchorBody),
+      [200],
+    );
+    await flushWaitUntilForTest();
+    const fallbackAnchorRunId = await pollSlackRun(runnerGroup);
+    const legacyFallbackBody = JSON.stringify({
+      type: "event_callback",
+      team_id: teamId,
+      event_id: `EvBDD${randomUUID().replace(/-/g, "")}`,
+      event: {
+        ...event,
+        text: "claim legacy Slack params",
+        ts: "2900.000500",
+        thread_ts: threadTs,
+      },
+    });
+    await integrations.requestSlackEvent(
+      legacyFallbackBody,
+      integrations.signedSlackIngressHeaders(legacyFallbackBody),
+      [200],
+    );
+    await flushWaitUntilForTest();
+    const legacyFallbackParams = await requirePendingChatEventInputParams(
+      "claim legacy Slack params",
+    );
+    await replaceSlackLaunchMaterialWithLegacyParamsFixture({
+      eventId: legacyFallbackParams.eventId,
+      orgId,
+      userId: actor.userId,
+      prompt: "legacy Slack prompt",
+      appendSystemPrompt: "legacy Slack system prompt",
+      channelId,
+      threadTs,
+    });
+    await runs.requestCancelRun(actor, fallbackAnchorRunId, [200]);
+    await expect
+      .poll(async () => {
+        return (await runs.readRun(actor, fallbackAnchorRunId)).status;
+      })
+      .toBe("cancelled");
+    await flushWaitUntilForTest();
+    const legacyFallbackRunId = await pollSlackRun(runnerGroup);
+    const legacyFallbackClaim = await runs.claimRunnerJob(legacyFallbackRunId);
+    const legacyFallbackRun = await runs.readRun(actor, legacyFallbackRunId);
+    expect(legacyFallbackRun.prompt).toBe("legacy Slack prompt");
+    expect(legacyFallbackRun.appendSystemPrompt).toContain(
+      "legacy Slack system prompt",
+    );
+    await runs.requestCancelRun(actor, legacyFallbackRunId, [200]);
+    await expect
+      .poll(async () => {
+        return (await runs.readRun(actor, legacyFallbackRunId)).status;
+      })
+      .toBe("cancelled");
+    expect(legacyFallbackClaim.sandboxToken).toStrictEqual(expect.any(String));
+    await flushWaitUntilForTest();
     expect(
       (await chat.listThreadEvents(actor, canonicalChatThreadId)).events,
     ).toStrictEqual(

--- a/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
@@ -10,7 +10,6 @@ import { logger } from "../../lib/log";
 import {
   enrichMessageContent,
   fetchConversationContexts,
-  formatCurrentMessageFiles,
   type SlackFile,
 } from "../../lib/slack-webhook-context";
 import { nowDate } from "../external/time";
@@ -103,70 +102,8 @@ function slackPhysicalThreadTs(event: SlackAgentEvent): string {
   return event.thread_ts ?? event.ts;
 }
 
-function buildSlackSystemPrompt(args: {
-  readonly botUserId: string;
-  readonly channelId: string;
-  readonly channelType: "channel" | "dm" | "group_dm";
-  readonly threadTs: string;
-  readonly executionContext: string;
-}): string {
-  const typeLabel =
-    args.channelType === "dm"
-      ? "Direct message"
-      : args.channelType === "group_dm"
-        ? "Group direct message"
-        : "Channel";
-  return [
-    "# Current Integration",
-    "You are currently running inside: Slack",
-    `Your bot user ID: ${args.botUserId}`,
-    `Channel ID: ${args.channelId}`,
-    `Channel type: ${typeLabel}`,
-    `Thread ID: ${args.threadTs}`,
-    args.executionContext,
-  ]
-    .filter(Boolean)
-    .join("\n");
-}
-
 function stripBotMention(text: string, botUserId: string): string {
   return text.replaceAll(`<@${botUserId}>`, "").trim();
-}
-
-function canonicalSlackFilesPrompt(
-  files: readonly SlackFile[] | undefined,
-  assets: readonly CanonicalSlackInputAsset[],
-): string {
-  if (!files || files.length === 0) {
-    return "";
-  }
-  const assetByPosition = new Map(
-    assets.map((asset) => {
-      return [asset.position, asset] as const;
-    }),
-  );
-  return files
-    .flatMap((file, position) => {
-      const asset = assetByPosition.get(position);
-      if (asset?.status === "ready") {
-        return [
-          `[Web file] ${asset.filename} (${asset.contentType})\n   [ID] ${asset.assetId}`,
-        ];
-      }
-      return [formatCurrentMessageFiles([file])];
-    })
-    .filter(Boolean)
-    .join("\n");
-}
-
-function canonicalSlackAgentPrompt(
-  messagePrompt: string,
-  files: readonly SlackFile[] | undefined,
-  assets: readonly CanonicalSlackInputAsset[],
-): string {
-  return [messagePrompt, canonicalSlackFilesPrompt(files, assets)]
-    .filter(Boolean)
-    .join("\n\n");
 }
 
 async function claimIngress(db: Db, ingressId: string, currentTime: Date) {
@@ -381,7 +318,7 @@ function canonicalSlackLaunchContext(args: {
     messageFiles: args.event.files ?? [],
     mentionDisplayNames: args.mentionDisplayNames,
     senderDisplayName: args.userInfoExtras.slackDisplayName ?? null,
-    senderUserId: args.event.user,
+    senderUserId: args.userInfoExtras.slackUserId ?? null,
     channelType: slackChannelType(args.event),
     threadTs,
     routeThreadTs: threadTs === args.routeThreadTs ? null : args.routeThreadTs,
@@ -538,31 +475,9 @@ const persistClaimedCanonicalSlackIngress$ = command(
         error: permalinkResult.error,
       });
     }
-    const agentPrompt = canonicalSlackAgentPrompt(
-      enriched.prompt,
-      event.files,
-      canonicalAssets,
-    );
-
     const encryptedParams = await encryptQueuedUserMessageRunParams(
       {
         version: 1,
-        prompt: agentPrompt,
-        appendSystemPrompt: buildSlackSystemPrompt({
-          botUserId: ingress.botUserId,
-          channelId: ingress.channelId,
-          channelType: slackChannelType(event),
-          threadTs,
-          executionContext: context.executionContext,
-        }),
-        slackDelivery: {
-          channelId: ingress.channelId,
-          threadTs,
-          ...(threadTs === ingress.threadTs
-            ? {}
-            : { routeThreadTs: ingress.threadTs }),
-        },
-        userInfoExtras: enriched.userInfoExtras,
       },
       { orgId, userId: ingress.userId },
     );

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -166,6 +166,10 @@ import {
   type ModelFirstPin,
 } from "./zero-model-selection.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
+import {
+  loadSlackQueuedLaunchMaterial,
+  type SlackQueuedLaunchMaterial,
+} from "./slack-queued-launch-context.service";
 
 const log = logger("callback:chat");
 const PG_FOREIGN_KEY_VIOLATION = "23503";
@@ -2648,12 +2652,12 @@ function loadQueuedMessageSessionState(
 function slackQueuedMessageAdmissionFailure(
   args: CreateQueuedChatRunInputArgs,
   sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
+  slackLaunchMaterial: SlackQueuedLaunchMaterial | null,
   error: QueuedMessageModelRouteError,
 ): SlackQueuedMessageAdmissionFailure | null {
-  if (
-    args.queuedMessage.triggerSource !== "slack" ||
-    !sourceParams?.slackDelivery
-  ) {
+  const slackDelivery =
+    slackLaunchMaterial?.slackDelivery ?? sourceParams?.slackDelivery;
+  if (args.queuedMessage.triggerSource !== "slack" || !slackDelivery) {
     return null;
   }
   return {
@@ -2663,7 +2667,7 @@ function slackQueuedMessageAdmissionFailure(
     agentId: args.agent.id,
     threadId: args.threadId,
     queuedMessage: args.queuedMessage,
-    slackDelivery: sourceParams.slackDelivery,
+    slackDelivery,
     error,
   };
 }
@@ -2780,10 +2784,16 @@ function githubQueuedMessageAdmissionFailure(
 function queuedMessageAdmissionFailure(
   args: CreateQueuedChatRunInputArgs,
   sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
+  slackLaunchMaterial: SlackQueuedLaunchMaterial | null,
   error: QueuedMessageModelRouteError,
 ): QueuedMessageAdmissionFailure | null {
   return (
-    slackQueuedMessageAdmissionFailure(args, sourceParams, error) ??
+    slackQueuedMessageAdmissionFailure(
+      args,
+      sourceParams,
+      slackLaunchMaterial,
+      error,
+    ) ??
     teamsQueuedMessageAdmissionFailure(args, sourceParams, error) ??
     telegramQueuedMessageAdmissionFailure(args, sourceParams, error) ??
     agentPhoneQueuedMessageAdmissionFailure(args, sourceParams, error) ??
@@ -2794,6 +2804,7 @@ function queuedMessageAdmissionFailure(
 
 function queuedIntegrationDeliveries(
   sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
+  slackLaunchMaterial: SlackQueuedLaunchMaterial | null,
 ): Pick<
   CreateQueuedChatRunInput,
   | "slackDelivery"
@@ -2805,7 +2816,8 @@ function queuedIntegrationDeliveries(
   | "morningBriefDelivery"
 > {
   return {
-    slackDelivery: sourceParams?.slackDelivery,
+    slackDelivery:
+      slackLaunchMaterial?.slackDelivery ?? sourceParams?.slackDelivery,
     feishuDelivery: sourceParams?.feishuDelivery,
     teamsDelivery: sourceParams?.teamsDelivery,
     telegramDelivery: sourceParams?.telegramDelivery,
@@ -2813,6 +2825,62 @@ function queuedIntegrationDeliveries(
     githubDelivery: sourceParams?.githubDelivery,
     morningBriefDelivery: sourceParams?.morningBriefDelivery,
   };
+}
+
+async function resolveSlackQueuedLaunchMaterial(
+  args: CreateQueuedChatRunInputArgs,
+  sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
+): Promise<SlackQueuedLaunchMaterial | null> {
+  if (args.queuedMessage.triggerSource !== "slack") {
+    return null;
+  }
+  const material = await loadSlackQueuedLaunchMaterial(args.db, {
+    eventId: args.queuedMessage.id,
+    chatThreadId: args.threadId,
+    orgId: args.agent.orgId,
+    userId: args.userId,
+  });
+  if (material) {
+    return material;
+  }
+  if (
+    sourceParams?.prompt === undefined ||
+    sourceParams.appendSystemPrompt === undefined ||
+    !sourceParams.slackDelivery
+  ) {
+    throw new Error("Slack queue item is missing launch material");
+  }
+  return null;
+}
+
+function queuedMessagePrompt(args: {
+  readonly triggerSource: QueuedUserMessage["triggerSource"];
+  readonly slackLaunchMaterial: SlackQueuedLaunchMaterial | null;
+  readonly sourceParams: Awaited<
+    ReturnType<typeof decryptQueuedUserMessageRunParams>
+  >;
+  readonly projectedPrompt: string;
+}): string {
+  if (args.triggerSource === "slack") {
+    return args.slackLaunchMaterial?.prompt ?? args.sourceParams?.prompt ?? "";
+  }
+  if (args.triggerSource === "workflow-schedule") {
+    return args.sourceParams?.prompt ?? args.projectedPrompt;
+  }
+  return args.projectedPrompt;
+}
+
+function queuedIntegrationPrompt(args: {
+  readonly slackLaunchMaterial: SlackQueuedLaunchMaterial | null;
+  readonly sourceParams: Awaited<
+    ReturnType<typeof decryptQueuedUserMessageRunParams>
+  >;
+}): string {
+  return (
+    args.slackLaunchMaterial?.appendSystemPrompt ??
+    args.sourceParams?.appendSystemPrompt ??
+    buildWebChatPrompt()
+  );
 }
 
 function resolveQueuedMessageGenerationTemplatePrompt(args: {
@@ -2849,6 +2917,10 @@ async function buildCreateQueuedChatRunInput(
   if (args.queuedMessage.triggerSource !== "web" && !sourceParams) {
     throw new Error("Canonical integration queue item is missing run params");
   }
+  const slackLaunchMaterial = await resolveSlackQueuedLaunchMaterial(
+    args,
+    sourceParams,
+  );
   const modelRouteResolution = await resolveQueuedMessageModelRoute({
     db: args.db,
     threadId: args.threadId,
@@ -2861,6 +2933,7 @@ async function buildCreateQueuedChatRunInput(
     return queuedMessageAdmissionFailure(
       args,
       sourceParams,
+      slackLaunchMaterial,
       modelRouteResolution.error,
     );
   }
@@ -2923,10 +2996,12 @@ async function buildCreateQueuedChatRunInput(
       });
     },
   );
-  const prompt =
-    args.queuedMessage.triggerSource === "workflow-schedule"
-      ? (sourceParams?.prompt ?? userMessageProjection.agentPrompt)
-      : userMessageProjection.agentPrompt;
+  const prompt = queuedMessagePrompt({
+    triggerSource: args.queuedMessage.triggerSource,
+    slackLaunchMaterial,
+    sourceParams,
+    projectedPrompt: userMessageProjection.agentPrompt,
+  });
 
   return {
     orgId: args.agent.orgId,
@@ -2934,7 +3009,7 @@ async function buildCreateQueuedChatRunInput(
     agentId: args.agent.id,
     prompt,
     appendSystemPrompt: buildAppendSystemPrompt(
-      sourceParams?.appendSystemPrompt ?? buildWebChatPrompt(),
+      queuedIntegrationPrompt({ slackLaunchMaterial, sourceParams }),
       incompleteContext,
       priorContext,
       generationTemplatePrompt,
@@ -2953,9 +3028,10 @@ async function buildCreateQueuedChatRunInput(
       FeatureSwitchKey.RealAgentInPreview,
       featureSwitchContext,
     ),
-    ...queuedIntegrationDeliveries(sourceParams),
+    ...queuedIntegrationDeliveries(sourceParams, slackLaunchMaterial),
     apiStartTime: args.queuedMessage.createdAt.getTime(),
-    userInfoExtras: sourceParams?.userInfoExtras,
+    userInfoExtras:
+      slackLaunchMaterial?.userInfoExtras ?? sourceParams?.userInfoExtras,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/slack-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/slack-queued-launch-context.service.ts
@@ -1,0 +1,252 @@
+import { chatEvents } from "@vm0/db/schema/chat-event";
+import { chatSlackContext } from "@vm0/db/schema/chat-slack-context";
+import { slackChatThreadRoutes } from "@vm0/db/schema/slack-chat-thread-route";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import {
+  CANONICAL_ASSET_VERSION,
+  chatEventAssetRefs,
+  runUploadedFiles,
+} from "@vm0/db/schema/run-uploaded-file";
+import { and, asc, eq, isNull, or } from "drizzle-orm";
+
+import {
+  buildSlackSystemPrompt,
+  canonicalSlackAgentPrompt,
+  resolveUserMentions,
+  type SlackPromptAsset,
+} from "../../lib/slack-webhook-context";
+import { inferMimetype } from "../../lib/mimetype";
+import type { SlackUserInfo } from "../external/slack-message-client";
+import type { Db } from "../external/db";
+
+export interface SlackQueuedLaunchMaterial {
+  readonly prompt: string;
+  readonly appendSystemPrompt: string;
+  readonly slackDelivery: {
+    readonly channelId: string;
+    readonly threadTs: string;
+    readonly routeThreadTs?: string;
+  };
+  readonly userInfoExtras?: {
+    readonly slackDisplayName?: string;
+    readonly slackUserId?: string;
+  };
+}
+
+type SlackLaunchContextRow = Pick<
+  typeof chatSlackContext.$inferSelect,
+  | "channelId"
+  | "conversationContext"
+  | "messageText"
+  | "messageFiles"
+  | "mentionDisplayNames"
+  | "senderDisplayName"
+  | "senderUserId"
+  | "channelType"
+  | "threadTs"
+  | "routeThreadTs"
+> & { readonly botUserId: string };
+
+function requiredSlackLaunchContext(row: SlackLaunchContextRow | undefined) {
+  if (
+    !row ||
+    row.channelId === null ||
+    row.conversationContext === null ||
+    row.messageText === null ||
+    row.messageFiles === null ||
+    row.mentionDisplayNames === null ||
+    row.channelType === null ||
+    row.threadTs === null
+  ) {
+    return null;
+  }
+  return {
+    ...row,
+    channelId: row.channelId,
+    conversationContext: row.conversationContext,
+    messageText: row.messageText,
+    messageFiles: row.messageFiles,
+    mentionDisplayNames: row.mentionDisplayNames,
+    channelType: row.channelType,
+    threadTs: row.threadTs,
+  };
+}
+
+async function loadSlackLaunchContext(
+  db: Db,
+  args: {
+    readonly eventId: string;
+    readonly chatThreadId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+) {
+  const [row] = await db
+    .select({
+      botUserId: slackOrgInstallations.botUserId,
+      channelId: chatSlackContext.channelId,
+      conversationContext: chatSlackContext.conversationContext,
+      messageText: chatSlackContext.messageText,
+      messageFiles: chatSlackContext.messageFiles,
+      mentionDisplayNames: chatSlackContext.mentionDisplayNames,
+      senderDisplayName: chatSlackContext.senderDisplayName,
+      senderUserId: chatSlackContext.senderUserId,
+      channelType: chatSlackContext.channelType,
+      threadTs: chatSlackContext.threadTs,
+      routeThreadTs: chatSlackContext.routeThreadTs,
+    })
+    .from(chatEvents)
+    .innerJoin(
+      chatSlackContext,
+      and(
+        eq(chatSlackContext.id, chatEvents.contextId),
+        eq(chatSlackContext.chatThreadId, chatEvents.chatThreadId),
+      ),
+    )
+    .innerJoin(
+      slackChatThreadRoutes,
+      and(
+        eq(slackChatThreadRoutes.chatThreadId, chatEvents.chatThreadId),
+        eq(slackChatThreadRoutes.channelId, chatSlackContext.channelId),
+        or(
+          and(
+            isNull(chatSlackContext.routeThreadTs),
+            eq(slackChatThreadRoutes.threadTs, chatSlackContext.threadTs),
+          ),
+          eq(slackChatThreadRoutes.threadTs, chatSlackContext.routeThreadTs),
+        ),
+        eq(slackChatThreadRoutes.userId, args.userId),
+      ),
+    )
+    .innerJoin(
+      slackOrgConnections,
+      and(
+        eq(slackOrgConnections.id, slackChatThreadRoutes.connectionId),
+        eq(slackOrgConnections.vm0UserId, args.userId),
+      ),
+    )
+    .innerJoin(
+      slackOrgInstallations,
+      and(
+        eq(
+          slackOrgInstallations.slackWorkspaceId,
+          slackOrgConnections.slackWorkspaceId,
+        ),
+        eq(slackOrgInstallations.orgId, args.orgId),
+      ),
+    )
+    .where(
+      and(
+        eq(chatEvents.id, args.eventId),
+        eq(chatEvents.chatThreadId, args.chatThreadId),
+        eq(chatEvents.contextType, "slack"),
+        eq(chatEvents.triggerSource, "slack"),
+      ),
+    )
+    .limit(1);
+  return requiredSlackLaunchContext(row);
+}
+
+async function loadSlackPromptAssets(
+  db: Db,
+  args: { readonly eventId: string; readonly userId: string },
+): Promise<SlackPromptAsset[]> {
+  const rows = await db
+    .select({
+      assetId: runUploadedFiles.id,
+      position: chatEventAssetRefs.position,
+      filename: runUploadedFiles.filename,
+      contentType: runUploadedFiles.contentType,
+      status: runUploadedFiles.materializationStatus,
+    })
+    .from(chatEventAssetRefs)
+    .innerJoin(
+      runUploadedFiles,
+      eq(runUploadedFiles.id, chatEventAssetRefs.assetId),
+    )
+    .where(
+      and(
+        eq(chatEventAssetRefs.chatEventId, args.eventId),
+        eq(runUploadedFiles.userId, args.userId),
+        eq(runUploadedFiles.assetVersion, CANONICAL_ASSET_VERSION),
+        eq(runUploadedFiles.classification, "input"),
+      ),
+    )
+    .orderBy(asc(chatEventAssetRefs.position));
+  return rows.map((row) => {
+    const filename = row.filename ?? row.assetId;
+    return {
+      assetId: row.assetId,
+      position: row.position,
+      filename,
+      contentType: row.contentType ?? inferMimetype(filename),
+      status: row.status ?? "failed",
+    };
+  });
+}
+
+function mentionUserInfoMap(
+  mentionDisplayNames: Readonly<Record<string, string>>,
+): Map<string, SlackUserInfo> {
+  return new Map(
+    Object.entries(mentionDisplayNames).map(([id, name]) => {
+      return [id, { id, name }] as const;
+    }),
+  );
+}
+
+export async function loadSlackQueuedLaunchMaterial(
+  db: Db,
+  args: {
+    readonly eventId: string;
+    readonly chatThreadId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+): Promise<SlackQueuedLaunchMaterial | null> {
+  const context = await loadSlackLaunchContext(db, args);
+  if (!context) {
+    return null;
+  }
+  const assets = await loadSlackPromptAssets(db, {
+    eventId: args.eventId,
+    userId: args.userId,
+  });
+  const messagePrompt = resolveUserMentions(
+    context.messageText,
+    mentionUserInfoMap(context.mentionDisplayNames),
+  );
+  return {
+    prompt: canonicalSlackAgentPrompt(
+      messagePrompt,
+      context.messageFiles,
+      assets,
+    ),
+    appendSystemPrompt: buildSlackSystemPrompt({
+      botUserId: context.botUserId,
+      channelId: context.channelId,
+      channelType: context.channelType,
+      threadTs: context.threadTs,
+      executionContext: context.conversationContext,
+    }),
+    slackDelivery: {
+      channelId: context.channelId,
+      threadTs: context.threadTs,
+      ...(context.routeThreadTs
+        ? { routeThreadTs: context.routeThreadTs }
+        : {}),
+    },
+    userInfoExtras:
+      context.senderDisplayName || context.senderUserId
+        ? {
+            ...(context.senderDisplayName
+              ? { slackDisplayName: context.senderDisplayName }
+              : {}),
+            ...(context.senderUserId
+              ? { slackUserId: context.senderUserId }
+              : {}),
+          }
+        : undefined,
+  };
+}

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -88,8 +88,8 @@ const queuedUserMessageTriggerSourceSchema = z.enum([
 
 const queuedUserMessageRunParamsSchema = z.object({
   version: z.literal(1),
-  prompt: z.string(),
-  appendSystemPrompt: z.string(),
+  prompt: z.string().optional(),
+  appendSystemPrompt: z.string().optional(),
   slackDelivery: z
     .object({
       channelId: z.string(),

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -31,6 +31,10 @@ import {
 } from "../signals/services/zero-chat-event.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
+import {
+  decryptQueuedUserMessageRunParams,
+  encryptQueuedUserMessageRunParams,
+} from "../signals/services/zero-chat-queued-event.service";
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
@@ -418,6 +422,68 @@ export async function readChatEventInputParamsFixture(
     .where(eq(chatEventInputParams.eventId, eventId))
     .limit(1);
   return row ?? null;
+}
+
+export async function decryptChatEventInputParamsFixture(
+  eventId: string,
+  ctx: { readonly orgId: string; readonly userId: string },
+) {
+  const row = await readChatEventInputParamsFixture(eventId);
+  if (!row) {
+    return null;
+  }
+  return await decryptQueuedUserMessageRunParams(row.encryptedParams, ctx);
+}
+
+export async function replaceSlackLaunchMaterialWithLegacyParamsFixture(args: {
+  readonly eventId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly prompt: string;
+  readonly appendSystemPrompt: string;
+  readonly channelId: string;
+  readonly threadTs: string;
+}): Promise<void> {
+  const encryptedParams = await encryptQueuedUserMessageRunParams(
+    {
+      version: 1,
+      prompt: args.prompt,
+      appendSystemPrompt: args.appendSystemPrompt,
+      slackDelivery: {
+        channelId: args.channelId,
+        threadTs: args.threadTs,
+      },
+    },
+    { orgId: args.orgId, userId: args.userId },
+  );
+  await db().transaction(async (tx) => {
+    const [event] = await tx
+      .select({ contextId: chatEvents.contextId })
+      .from(chatEvents)
+      .where(eq(chatEvents.id, args.eventId))
+      .limit(1);
+    if (!event?.contextId) {
+      throw new Error("Expected legacy Slack fixture context");
+    }
+    await tx
+      .update(chatSlackContext)
+      .set({
+        conversationContext: null,
+        messageText: null,
+        messageFiles: null,
+        mentionDisplayNames: null,
+        senderDisplayName: null,
+        senderUserId: null,
+        channelType: null,
+        threadTs: null,
+        routeThreadTs: null,
+      })
+      .where(eq(chatSlackContext.id, event.contextId));
+    await tx
+      .update(chatEventInputParams)
+      .set({ encryptedParams })
+      .where(eq(chatEventInputParams.eventId, args.eventId));
+  });
 }
 
 export async function findPendingChatEventInputParamsByPromptFixture(


### PR DESCRIPTION
## Summary

- assemble Slack agent and system prompts at claim from `chat_events`, `chat_slack_context`, and event-associated canonical assets
- resolve `bot_user_id` through the canonical route, connection, and installation chain; the claim path never reads `slack_chat_ingress`
- prefer complete Slack context while retaining the rollout fallback to legacy encrypted launch params
- stop writing `prompt`, `appendSystemPrompt`, `slackDelivery`, and `userInfoExtras` into new Slack params while retaining the encrypted `{ version: 1 }` monitor signal

This is rollout step 2 of #24419 and follows #24424.

## Compatibility

The context reader falls back only when required launch-context columns are null. This preserves pending messages written before the dual-write deployment while new Slack inputs use context-only launch material.

No Feishu, Teams, Telegram, GitHub, AgentPhone, Morning Brief, automation, API-contract, `user_message`, client-rendering, or `message_permalink` behavior changes.

## Coverage

The canonical Slack integration scenario now verifies:

- exact agent prompt rendering for a user mention plus canonical attachment
- the unchanged Slack system-prompt header assembled with the installation bot ID
- display rendering remains `@name` while the agent receives `@name (U123)`
- new encrypted Slack params decrypt to exactly `{ version: 1 }`
- permalink failure still queues and claims through context
- an explicit legacy context-null/blob fallback claims with its old prompt and system prompt
- existing DM coverage keeps replying to the physical message thread when the route key differs

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- targeted ESLint and Prettier checks
- `git diff --check`

A focused integration run cannot start against the local PostgreSQL instance because it cannot replay an older connector-identity migration. PR CI uses the repository's pinned PostgreSQL environment and will run the integration coverage. Per #24419, no full local Vitest suite or development server was run.