### PR TITLE
test(sandbox-fc): cover guest dns readiness policy

### DIFF
--- a/crates/sandbox-fc/src/guest_dns_readiness.rs
+++ b/crates/sandbox-fc/src/guest_dns_readiness.rs
@@ -538,12 +538,38 @@ mod tests {
     }
 
     #[test]
-    fn guest_dns_readiness_retries_only_proven_guest_terminal_failures() {
-        assert!(GuestDnsReadinessFailure::TimedOut.retryable());
-        assert!(GuestDnsReadinessFailure::ExitNonZero(2).retryable());
-        assert!(GuestDnsReadinessFailure::UnexpectedAnswer.retryable());
-        assert!(!GuestDnsReadinessFailure::Deadline.retryable());
-        assert!(!GuestDnsReadinessFailure::Transport(io::ErrorKind::TimedOut).retryable());
+    fn guest_dns_readiness_maps_every_failure_policy() {
+        use GuestDnsReadinessFailure as Failure;
+        use SandboxGuestDnsReadinessReason as Reason;
+
+        for (failure, expected_retryable, expected_reason) in [
+            (Failure::Deadline, false, Reason::Deadline),
+            (
+                Failure::Transport(io::ErrorKind::TimedOut),
+                false,
+                Reason::Other,
+            ),
+            (Failure::TimedOut, true, Reason::ProcessTimeout),
+            (Failure::Cancelled, false, Reason::Other),
+            (Failure::StartFailed, false, Reason::Other),
+            (Failure::WaitFailed, false, Reason::Other),
+            (Failure::ExitNonZero(2), true, Reason::DnsPath),
+            (Failure::ExitNonZero(1), false, Reason::Other),
+            (Failure::OutputTruncated, false, Reason::Other),
+            (Failure::InvalidOutput, false, Reason::Other),
+            (Failure::UnexpectedAnswer, true, Reason::DnsPath),
+        ] {
+            assert_eq!(
+                failure.retryable(),
+                expected_retryable,
+                "unexpected retry policy for {failure:?}",
+            );
+            assert_eq!(
+                failure.sandbox_reason(),
+                expected_reason,
+                "unexpected sandbox reason for {failure:?}",
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- replace the partial guest DNS retry-policy assertions with one combined table-driven policy matrix
- cover every current `GuestDnsReadinessFailure` variant, including transport timeout and both exit-code classes
- assert both same-attachment retryability and the public sandbox reason for every representative case

## Exclusions

- no production behavior, dependency, API, protocol, schema, persisted-data, configuration, or deployment changes
- no changes to existing Unix-stream readiness or runner recovery lifecycle tests
- no enum-iteration or parameterized-test framework

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc guest_dns_readiness -- --test-threads=1` (8 passed)
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features` (793 passed)
- `git diff --check`
- repository pre-commit and commit-message hooks

Closes #24431
