### PR TITLE
refactor(connectors): finish slug terminology cleanup

### DIFF
--- a/e2e/tests/03-runner/t42-firewall-placeholder.bats
+++ b/e2e/tests/03-runner/t42-firewall-placeholder.bats
@@ -9,7 +9,7 @@
 load '../../helpers/setup'
 
 # Set up connectors ONCE before parallel tests to avoid race conditions.
-# Both tests write to the same connector record (orgId + userId + type),
+# Both tests write to the same connector record (orgId + userId + connector slug),
 # so concurrent setup_test_connector calls would overwrite each other.
 setup_file() {
     if [[ -z "$VM0_API_BACKEND_URL" ]]; then

--- a/e2e/tests/03-runner/t53-test-oauth-connector.bats
+++ b/e2e/tests/03-runner/t53-test-oauth-connector.bats
@@ -12,7 +12,7 @@
 # 1. Compose an agent that references TEST_OAUTH_TOKEN.
 # 2. Connect test-oauth through the real authorization-code OAuth flow.
 # 3. Enable the connector for the compose via /api/cli/auth/test-enable-connector
-#    so the zero run flow passes it in allowedConnectorTypes.
+#    so the Zero run includes it in the enabled connector slugs.
 # 4. Create a Zero chat run for an agent that curls the echo endpoint.
 #    The firewall rule
 #    matches any `{pr}.vm6.ai` subdomain; mitm-addon intercepts, the webhook
@@ -96,7 +96,7 @@ enable_test_oauth_feature_switch() {
 }
 
 # Enable the test-oauth connector for a specific compose (user_connectors row).
-# Required for zero-run to pass it in allowedConnectorTypes.
+# Required for the Zero run to include it in the enabled connector slugs.
 enable_test_oauth_for_compose() {
     local compose_id="$1"
 

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -137,15 +137,15 @@ async function executeMorningBriefsCron(): Promise<void> {
 
 async function connectOauthConnector(
   actor: ApiTestUser,
-  type: "github" | "gmail" | "google-calendar",
+  connectorSlug: "github" | "gmail" | "google-calendar",
   code: string,
 ): Promise<void> {
-  const oauth = await connectors.startOauth(actor, type, "oauth");
+  const oauth = await connectors.startOauth(actor, connectorSlug, "oauth");
   const state = new URL(oauth.authorizationUrl).searchParams.get("state");
   if (!state) {
-    throw new Error(`Expected ${type} OAuth state`);
+    throw new Error(`Expected ${connectorSlug} OAuth state`);
   }
-  await connectors.completeOauthCallback(type, { code, state });
+  await connectors.completeOauthCallback(connectorSlug, { code, state });
 }
 
 function mockMorningBriefDataSources(gmailAfterSeconds: number[]): void {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-workflows.ts
@@ -230,15 +230,17 @@ export function createWorkflowsBddApi(context: TestContext) {
      */
     async connectConnector(
       actor: ApiTestUser,
-      type: "gmail" | "google-calendar" | "notion",
+      connectorSlug: "gmail" | "google-calendar" | "notion",
     ): Promise<void> {
-      const start = await connectors.startOauth(actor, type, "oauth");
+      const start = await connectors.startOauth(actor, connectorSlug, "oauth");
       const state = new URL(start.authorizationUrl).searchParams.get("state");
       if (!state) {
-        throw new Error(`Expected ${type} OAuth start URL to include state`);
+        throw new Error(
+          `Expected ${connectorSlug} OAuth start URL to include state`,
+        );
       }
-      await connectors.completeOauthCallback(type, {
-        code: `${type}-code`,
+      await connectors.completeOauthCallback(connectorSlug, {
+        code: `${connectorSlug}-code`,
         state,
       });
     },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -776,7 +776,7 @@ describe("GET /api/zero/connector-catalog", () => {
     }
   });
 
-  it("returns 404 for hidden connector catalog refs", async () => {
+  it("returns 404 for hidden connector catalog slugs", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
@@ -795,7 +795,7 @@ describe("GET /api/zero/connector-catalog", () => {
     );
   });
 
-  it("rejects connector catalog refs outside the public connector-ref bounds", async () => {
+  it("rejects connector catalog slugs outside the public slug bounds", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-delete.test.ts
@@ -153,7 +153,7 @@ describe("DELETE /api/zero/connectors/:connectorSlug", () => {
     });
   });
 
-  it("returns 404 when no connector state exists for that type", async () => {
+  it("returns 404 when no connector state exists for that slug", async () => {
     const fixture = await track(seedFixture());
     mocks.clerk.session(fixture.userId, fixture.orgId);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-get.test.ts
@@ -112,7 +112,7 @@ describe("GET /api/zero/connectors/:connectorSlug", () => {
     expect(response.body.error.code).toBe("UNAUTHORIZED");
   });
 
-  it("returns 404 when no connector of that type exists", async () => {
+  it("returns 404 when no connector with that slug exists", async () => {
     const fixture = seedAuthenticatedFixture();
     mocks.clerk.session(fixture.userId, fixture.orgId);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts
@@ -98,7 +98,7 @@ describe("GET /api/zero/connectors/:connectorSlug/scope-diff", () => {
     );
   });
 
-  it("returns 404 when no connector is configured for the type", async () => {
+  it("returns 404 when no connector is configured for the slug", async () => {
     const actor = bdd.user();
     const response = await connectorsApi.requestScopeDiff(
       actor,

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
@@ -240,7 +240,7 @@ describe("zero agent view command", () => {
       expect(logCalls).not.toContain("slack (0/");
     });
 
-    it("should load a server-authored connector once per unique ref", async () => {
+    it("should load a server-authored connector once per unique slug", async () => {
       let permissionRequests = 0;
       const serverOnlyDetail = catalogPermissionDetail({
         connectorSlug: "server-only",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -2618,7 +2618,7 @@ describe("chat event action cards", () => {
     expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
   });
 
-  it("completes catalog-visible connectors without a bundled type", async () => {
+  it("completes catalog-visible connectors without a bundled definition", async () => {
     const user = userEvent.setup({ delay: null });
     const connectorAuthorizeUrl = `${window.location.origin}/connectors/future-connector/authorize?agentId=${AGENT_ID}`;
     let connected = false;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -156,7 +156,7 @@ describe("zero ideation page", () => {
     expect(screen.queryByText("Daily standup report")).not.toBeInTheDocument();
   });
 
-  it("hides connector-only use cases when catalog omits all refs", async () => {
+  it("hides connector-only use cases when catalog omits all connector slugs", async () => {
     mockConnectorCatalogStatus([]);
 
     detachedSetupPage({

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -55,7 +55,7 @@ export const zeroConnectorsBySlugContract = c.router({
       403: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary: "Get connector by type (zero proxy)",
+    summary: "Get connector by slug (zero proxy)",
   },
   delete: {
     method: "DELETE",

--- a/turbo/packages/eslint-rules/src/ccstate/rules/no-duplicate-route-param.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/rules/no-duplicate-route-param.ts
@@ -27,7 +27,7 @@ interface ParamOccurrence {
 /**
  * Extract (segment, paramName) pairs from a route path string.
  * For "/agents/:agentId/chat", returns [["agents", "agentId"]].
- * For "/connectors/:type/connect", returns [["connectors", "type"]].
+ * For "/connectors/:connectorSlug/connect", returns [["connectors", "connectorSlug"]].
  */
 function extractSegmentParamPairs(
   path: string,


### PR DESCRIPTION
## Summary

- replace remaining connector `ref` / `type` terminology where the value is an official connector slug
- rename local OAuth helper parameters to `connectorSlug`
- preserve genuine indirect references, discriminators, historical migrations, and changelog entries

## Compatibility

- no API path, request, or response fields change
- no schema or persisted data changes
- no runtime behavior changes
- independent of the compatibility-sweeper removal in #24433

## Validation

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- API focused Vitest: 59 passed
- CLI focused Vitest: 19 passed
- Platform focused Vitest: 56 passed
- `pnpm knip`
- `git diff --check`

Closes #24426
Parent: #23619
