### PR TITLE
test(api): avoid nintendo pin substring collision

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -77,6 +77,8 @@ const NINTENDO_SWITCH_PARENTAL_CONTROLS_INITIAL_SESSION_TOKEN =
   "bdd-switch-parental-controls-session-token";
 const NINTENDO_SWITCH_PARENTAL_CONTROLS_REPLACEMENT_SESSION_TOKEN =
   "bdd-switch-parental-controls-replacement-session-token";
+const NINTENDO_SWITCH_PARENTAL_CONTROLS_UNLOCK_CODE =
+  "bdd-switch-parental-controls-unlock-code-must-not-leak";
 
 async function awsActor(): Promise<ApiTestUser> {
   const bdd = createBddApi(context);
@@ -259,7 +261,8 @@ function mockNintendoSwitchParentalControlsExternalCodeProvider(): {
                 label: "Family room",
                 device: {
                   serialNumber: "bdd-serial-must-not-leak",
-                  synchronizedUnlockCode: "1234",
+                  synchronizedUnlockCode:
+                    NINTENDO_SWITCH_PARENTAL_CONTROLS_UNLOCK_CODE,
                 },
               },
             ],
@@ -764,7 +767,10 @@ describe("CONN-02: external-code session lifecycle", () => {
       "bdd-switch-parental-controls-access-token",
     );
     expectNoVisibleSecret(complete, "bdd-serial-must-not-leak");
-    expectNoVisibleSecret(complete, "1234");
+    expectNoVisibleSecret(
+      complete,
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_UNLOCK_CODE,
+    );
 
     const listed = await connectorsApi.listConnectors(actor);
     for (const name of [


### PR DESCRIPTION
## Summary

- replace the generic four-digit Nintendo unlock-code fixture with a unique leak sentinel
- keep the existing full serialized-response secret check, without weakening the redaction contract
- leave product code and connector behavior unchanged

## Trigger

- Turbo run: https://github.com/vm0-ai/vm0/actions/runs/30686793402
- Event: `push` to `main`
- Failing SHA: `a9b89b71385641a76b5238fd88fab0ebc1bed31b`
- First substantive failure: `test-api (1)` in `connectors-external-code.bdd.test.ts`

## Root cause

Classification: test assertion scoping over nondeterministic generated data.

The test serialized the complete connector response and asserted that it did not contain the short PIN string `1234`. The random public connector ID in the failing run was `b2aca1f1-920b-4337-b761-feb512343639`, whose final UUID segment contains `1234`. No PIN field or secret value was returned; the broad substring assertion matched unrelated public data.

The outcome was intermittent because connector IDs are randomly generated. The same SHA passed `test-api (1)` in merge-group run 30686570687.

## Fix

Use a distinctive Nintendo unlock-code leak sentinel in the mocked provider response and assert that the same sentinel is absent from the full API response. This preserves the original security assertion while removing collisions with generated UUIDs and timestamps.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts`
- `pnpm -F api exec eslint src/signals/routes/__tests__/connectors-external-code.bdd.test.ts`
- `pnpm -F api check-types`
- `git diff --check`
- verified the failing connector UUID contains `1234` at offset 28

The targeted Vitest file was attempted locally, but the API suite could not initialize because PostgreSQL was unavailable at `localhost:5432`; all 9 tests were skipped before execution. The PR pipeline is the remaining targeted runtime validation.