### PR TITLE
refactor: remove slack launch params fallback

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -16,7 +16,6 @@ import {
   findPendingChatEventInputParamsByPromptFixture,
   readChatEventContextFixture,
   readChatEventInputParamsFixture,
-  replaceSlackLaunchMaterialWithLegacyParamsFixture,
 } from "../../../test-fixtures/chat-events";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -2033,75 +2032,6 @@ describe("INT-01: Slack app deep webhook flows", () => {
       status: "",
     });
 
-    const fallbackAnchorBody = JSON.stringify({
-      type: "event_callback",
-      team_id: teamId,
-      event_id: `EvBDD${randomUUID().replace(/-/g, "")}`,
-      event: {
-        ...event,
-        text: "block the legacy Slack fallback",
-        ts: "2900.000400",
-        thread_ts: threadTs,
-      },
-    });
-    await integrations.requestSlackEvent(
-      fallbackAnchorBody,
-      integrations.signedSlackIngressHeaders(fallbackAnchorBody),
-      [200],
-    );
-    await flushWaitUntilForTest();
-    const fallbackAnchorRunId = await pollSlackRun(runnerGroup);
-    const legacyFallbackBody = JSON.stringify({
-      type: "event_callback",
-      team_id: teamId,
-      event_id: `EvBDD${randomUUID().replace(/-/g, "")}`,
-      event: {
-        ...event,
-        text: "claim legacy Slack params",
-        ts: "2900.000500",
-        thread_ts: threadTs,
-      },
-    });
-    await integrations.requestSlackEvent(
-      legacyFallbackBody,
-      integrations.signedSlackIngressHeaders(legacyFallbackBody),
-      [200],
-    );
-    await flushWaitUntilForTest();
-    const legacyFallbackParams = await requirePendingChatEventInputParams(
-      "claim legacy Slack params",
-    );
-    await replaceSlackLaunchMaterialWithLegacyParamsFixture({
-      eventId: legacyFallbackParams.eventId,
-      orgId,
-      userId: actor.userId,
-      prompt: "legacy Slack prompt",
-      appendSystemPrompt: "legacy Slack system prompt",
-      channelId,
-      threadTs,
-    });
-    await runs.requestCancelRun(actor, fallbackAnchorRunId, [200]);
-    await expect
-      .poll(async () => {
-        return (await runs.readRun(actor, fallbackAnchorRunId)).status;
-      })
-      .toBe("cancelled");
-    await flushWaitUntilForTest();
-    const legacyFallbackRunId = await pollSlackRun(runnerGroup);
-    const legacyFallbackClaim = await runs.claimRunnerJob(legacyFallbackRunId);
-    const legacyFallbackRun = await runs.readRun(actor, legacyFallbackRunId);
-    expect(legacyFallbackRun.prompt).toBe("legacy Slack prompt");
-    expect(legacyFallbackRun.appendSystemPrompt).toContain(
-      "legacy Slack system prompt",
-    );
-    await runs.requestCancelRun(actor, legacyFallbackRunId, [200]);
-    await expect
-      .poll(async () => {
-        return (await runs.readRun(actor, legacyFallbackRunId)).status;
-      })
-      .toBe("cancelled");
-    expect(legacyFallbackClaim.sandboxToken).toStrictEqual(expect.any(String));
-    await flushWaitUntilForTest();
     expect(
       (await chat.listThreadEvents(actor, canonicalChatThreadId)).events,
     ).toStrictEqual(

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2651,12 +2651,10 @@ function loadQueuedMessageSessionState(
 
 function slackQueuedMessageAdmissionFailure(
   args: CreateQueuedChatRunInputArgs,
-  sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
   slackLaunchMaterial: SlackQueuedLaunchMaterial | null,
   error: QueuedMessageModelRouteError,
 ): SlackQueuedMessageAdmissionFailure | null {
-  const slackDelivery =
-    slackLaunchMaterial?.slackDelivery ?? sourceParams?.slackDelivery;
+  const slackDelivery = slackLaunchMaterial?.slackDelivery;
   if (args.queuedMessage.triggerSource !== "slack" || !slackDelivery) {
     return null;
   }
@@ -2788,12 +2786,7 @@ function queuedMessageAdmissionFailure(
   error: QueuedMessageModelRouteError,
 ): QueuedMessageAdmissionFailure | null {
   return (
-    slackQueuedMessageAdmissionFailure(
-      args,
-      sourceParams,
-      slackLaunchMaterial,
-      error,
-    ) ??
+    slackQueuedMessageAdmissionFailure(args, slackLaunchMaterial, error) ??
     teamsQueuedMessageAdmissionFailure(args, sourceParams, error) ??
     telegramQueuedMessageAdmissionFailure(args, sourceParams, error) ??
     agentPhoneQueuedMessageAdmissionFailure(args, sourceParams, error) ??
@@ -2816,8 +2809,7 @@ function queuedIntegrationDeliveries(
   | "morningBriefDelivery"
 > {
   return {
-    slackDelivery:
-      slackLaunchMaterial?.slackDelivery ?? sourceParams?.slackDelivery,
+    slackDelivery: slackLaunchMaterial?.slackDelivery,
     feishuDelivery: sourceParams?.feishuDelivery,
     teamsDelivery: sourceParams?.teamsDelivery,
     telegramDelivery: sourceParams?.telegramDelivery,
@@ -2829,7 +2821,6 @@ function queuedIntegrationDeliveries(
 
 async function resolveSlackQueuedLaunchMaterial(
   args: CreateQueuedChatRunInputArgs,
-  sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
 ): Promise<SlackQueuedLaunchMaterial | null> {
   if (args.queuedMessage.triggerSource !== "slack") {
     return null;
@@ -2843,14 +2834,7 @@ async function resolveSlackQueuedLaunchMaterial(
   if (material) {
     return material;
   }
-  if (
-    sourceParams?.prompt === undefined ||
-    sourceParams.appendSystemPrompt === undefined ||
-    !sourceParams.slackDelivery
-  ) {
-    throw new Error("Slack queue item is missing launch material");
-  }
-  return null;
+  throw new Error("Slack queue item is missing launch material");
 }
 
 function queuedMessagePrompt(args: {
@@ -2862,7 +2846,10 @@ function queuedMessagePrompt(args: {
   readonly projectedPrompt: string;
 }): string {
   if (args.triggerSource === "slack") {
-    return args.slackLaunchMaterial?.prompt ?? args.sourceParams?.prompt ?? "";
+    if (!args.slackLaunchMaterial) {
+      throw new Error("Slack queue item is missing launch material");
+    }
+    return args.slackLaunchMaterial.prompt;
   }
   if (args.triggerSource === "workflow-schedule") {
     return args.sourceParams?.prompt ?? args.projectedPrompt;
@@ -2871,16 +2858,19 @@ function queuedMessagePrompt(args: {
 }
 
 function queuedIntegrationPrompt(args: {
+  readonly triggerSource: QueuedUserMessage["triggerSource"];
   readonly slackLaunchMaterial: SlackQueuedLaunchMaterial | null;
   readonly sourceParams: Awaited<
     ReturnType<typeof decryptQueuedUserMessageRunParams>
   >;
 }): string {
-  return (
-    args.slackLaunchMaterial?.appendSystemPrompt ??
-    args.sourceParams?.appendSystemPrompt ??
-    buildWebChatPrompt()
-  );
+  if (args.triggerSource === "slack") {
+    if (!args.slackLaunchMaterial) {
+      throw new Error("Slack queue item is missing launch material");
+    }
+    return args.slackLaunchMaterial.appendSystemPrompt;
+  }
+  return args.sourceParams?.appendSystemPrompt ?? buildWebChatPrompt();
 }
 
 function resolveQueuedMessageGenerationTemplatePrompt(args: {
@@ -2917,10 +2907,7 @@ async function buildCreateQueuedChatRunInput(
   if (args.queuedMessage.triggerSource !== "web" && !sourceParams) {
     throw new Error("Canonical integration queue item is missing run params");
   }
-  const slackLaunchMaterial = await resolveSlackQueuedLaunchMaterial(
-    args,
-    sourceParams,
-  );
+  const slackLaunchMaterial = await resolveSlackQueuedLaunchMaterial(args);
   const modelRouteResolution = await resolveQueuedMessageModelRoute({
     db: args.db,
     threadId: args.threadId,
@@ -3009,7 +2996,11 @@ async function buildCreateQueuedChatRunInput(
     agentId: args.agent.id,
     prompt,
     appendSystemPrompt: buildAppendSystemPrompt(
-      queuedIntegrationPrompt({ slackLaunchMaterial, sourceParams }),
+      queuedIntegrationPrompt({
+        triggerSource: args.queuedMessage.triggerSource,
+        slackLaunchMaterial,
+        sourceParams,
+      }),
       incompleteContext,
       priorContext,
       generationTemplatePrompt,
@@ -3030,8 +3021,9 @@ async function buildCreateQueuedChatRunInput(
     ),
     ...queuedIntegrationDeliveries(sourceParams, slackLaunchMaterial),
     apiStartTime: args.queuedMessage.createdAt.getTime(),
-    userInfoExtras:
-      slackLaunchMaterial?.userInfoExtras ?? sourceParams?.userInfoExtras,
+    userInfoExtras: slackLaunchMaterial
+      ? slackLaunchMaterial.userInfoExtras
+      : sourceParams?.userInfoExtras,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -90,13 +90,6 @@ const queuedUserMessageRunParamsSchema = z.object({
   version: z.literal(1),
   prompt: z.string().optional(),
   appendSystemPrompt: z.string().optional(),
-  slackDelivery: z
-    .object({
-      channelId: z.string(),
-      threadTs: z.string(),
-      routeThreadTs: z.string().optional(),
-    })
-    .optional(),
   feishuDelivery: z
     .object({
       installationId: z.string(),

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -31,10 +31,7 @@ import {
 } from "../signals/services/zero-chat-event.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
-import {
-  decryptQueuedUserMessageRunParams,
-  encryptQueuedUserMessageRunParams,
-} from "../signals/services/zero-chat-queued-event.service";
+import { decryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
@@ -433,57 +430,6 @@ export async function decryptChatEventInputParamsFixture(
     return null;
   }
   return await decryptQueuedUserMessageRunParams(row.encryptedParams, ctx);
-}
-
-export async function replaceSlackLaunchMaterialWithLegacyParamsFixture(args: {
-  readonly eventId: string;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly prompt: string;
-  readonly appendSystemPrompt: string;
-  readonly channelId: string;
-  readonly threadTs: string;
-}): Promise<void> {
-  const encryptedParams = await encryptQueuedUserMessageRunParams(
-    {
-      version: 1,
-      prompt: args.prompt,
-      appendSystemPrompt: args.appendSystemPrompt,
-      slackDelivery: {
-        channelId: args.channelId,
-        threadTs: args.threadTs,
-      },
-    },
-    { orgId: args.orgId, userId: args.userId },
-  );
-  await db().transaction(async (tx) => {
-    const [event] = await tx
-      .select({ contextId: chatEvents.contextId })
-      .from(chatEvents)
-      .where(eq(chatEvents.id, args.eventId))
-      .limit(1);
-    if (!event?.contextId) {
-      throw new Error("Expected legacy Slack fixture context");
-    }
-    await tx
-      .update(chatSlackContext)
-      .set({
-        conversationContext: null,
-        messageText: null,
-        messageFiles: null,
-        mentionDisplayNames: null,
-        senderDisplayName: null,
-        senderUserId: null,
-        channelType: null,
-        threadTs: null,
-        routeThreadTs: null,
-      })
-      .where(eq(chatSlackContext.id, event.contextId));
-    await tx
-      .update(chatEventInputParams)
-      .set({ encryptedParams })
-      .where(eq(chatEventInputParams.eventId, args.eventId));
-  });
 }
 
 export async function findPendingChatEventInputParamsByPromptFixture(


### PR DESCRIPTION
## Summary

- complete rollout step 3 for #24419 by requiring Slack launch material from `chat_events` and `chat_slack_context` at claim
- remove the Slack delivery fallback from encrypted queue params and keep prompt, system prompt, delivery, and user info context-only
- remove the legacy fallback fixture and BDD coverage after the production backlog gate passed

## Rollout gate

- step 1 merged in #24424 and deployed the context columns plus dual-write
- step 2 merged in #24435 and deployed context-first claim plus the empty Slack params payload
- the read-only production check found 102 historical Slack `input.prompt` originals with `run_id IS NULL`; grouping their complete event lineage by `context_id` showed 102/102 have exactly two events and exactly one run-associated replacement, so the actual unclaimed old-format backlog is zero
- no new Slack original was present after 2026-07-31T14:28:49.050Z, well before both rollout deployments

## Scope

- Slack only
- no ingress reads
- no changes to `user_message`, API contracts, client rendering, other integrations, or `chat_slack_context.message_permalink`

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- Prettier on the four changed files
- no local Vitest or dev server, per issue rollout instructions; PR CI owns behavior tests

Closes #24419