### PR TITLE
test(api): stabilize competing binding admission race

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -3539,36 +3539,39 @@ describe("CHAT-02: run-level model overrides", () => {
 
     const firstEventId = randomUUID();
     const secondEventId = randomUUID();
-    const requests = [
-      {
-        eventId: firstEventId,
-        prompt: "first competing binding send",
-        response: chat.requestSendEvent(
-          actor,
-          {
-            agentId,
-            threadId: established.threadId,
-            prompt: "first competing binding send",
-            clientEventId: firstEventId,
-          },
-          [201],
-        ),
-      },
-      {
-        eventId: secondEventId,
-        prompt: "second competing binding send",
-        response: chat.requestSendEvent(
-          actor,
-          {
-            agentId,
-            threadId: established.threadId,
-            prompt: "second competing binding send",
-            clientEventId: secondEventId,
-          },
-          [201],
-        ),
-      },
-    ] as const;
+    const firstRequest = {
+      eventId: firstEventId,
+      prompt: "first competing binding send",
+      response: chat.requestSendEvent(
+        actor,
+        {
+          agentId,
+          threadId: established.threadId,
+          prompt: "first competing binding send",
+          clientEventId: firstEventId,
+        },
+        [201],
+      ),
+    } as const;
+    // Make the queue head the first admission-lock waiter so the second
+    // prepared request observes the binding committed by the first.
+    await expect.poll(admissionLock.waiterCount).toBe(1);
+
+    const secondRequest = {
+      eventId: secondEventId,
+      prompt: "second competing binding send",
+      response: chat.requestSendEvent(
+        actor,
+        {
+          agentId,
+          threadId: established.threadId,
+          prompt: "second competing binding send",
+          clientEventId: secondEventId,
+        },
+        [201],
+      ),
+    } as const;
+    const requests = [firstRequest, secondRequest] as const;
 
     await expect
       .poll(async () => {


### PR DESCRIPTION
## Summary

- start the queue-head send before the competing send
- wait until the queue head is blocked on the organization admission lock before starting its competitor
- keep the existing stale-binding telemetry and single-preparation assertions unchanged

## Root cause

The test launched both sends simultaneously and only waited until both were blocked on the same advisory lock. Occasionally the non-head request entered the lock queue first, legitimately lost its queue claim with a current session snapshot, and never exercised the stale-binding branch that the test intended to verify.

This change makes the queue head the first lock waiter, so the second prepared request consistently observes the binding committed by the first. Production behavior is unchanged.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- target test passed 10 consecutive focused runs before rebase
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts --reporter=dot` (63 passed)
- target test passed again after rebasing onto the latest `origin/main`
- pre-commit full Turbo Knip and type checks passed