### PR TITLE
docs(python): clarify parsed empty x stream contract

### DIFF
--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
@@ -89,8 +89,8 @@ def test_x_stream_all_failed_rows_logs_risk_without_billing(x_usage, tmp_path, r
 
 
 def test_x_stream_empty_emits_no_billing(x_usage, tmp_path, real_flow):
-    """Stream that delivered 0 tweets emits no usage_event row, and
-    in particular does NOT trigger _X_UNPARSEABLE_READ_FALLBACK."""
+    """A parsed NDJSON stream with zero resources and no row failures
+    emits no usage event or lost-visibility log."""
     flow = x_usage.make_flow(
         real_flow,
         tmp_path,


### PR DESCRIPTION
## Summary

- describe the empty X NDJSON test in terms of parsed zero-resource behavior
- remove the stale `_X_UNPARSEABLE_READ_FALLBACK` implementation reference
- keep production billing behavior, fixtures, assertions, dependencies, and lockfiles unchanged

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/x_connector_usage/test_unparseable.py::test_x_stream_empty_emits_no_billing` (1 passed)
- `uv run --no-sync python -m pytest tests/` (4549 passed)
- `lefthook run pre-commit`

Closes #24443
