### PR TITLE
perf(python): skip unconnected client binding scans

### DIFF
--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -509,13 +509,13 @@ def flow_matches_normalized_destination(
             allowed_kinds=allowed_kinds,
         ) and _server_binding_matches_current_destination(server, binding)
 
-    matching_client_bindings = _matching_client_bindings(
-        flow.client_conn,
-        host=destination.host,
-        port=destination.port,
-        allowed_kinds=allowed_kinds,
-    )
     if bool(getattr(server, "connected", False)):
+        matching_client_bindings = _matching_client_bindings(
+            flow.client_conn,
+            host=destination.host,
+            port=destination.port,
+            allowed_kinds=allowed_kinds,
+        )
         return (
             _client_binding_connected_endpoint(
                 client=flow.client_conn,

--- a/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
@@ -714,8 +714,8 @@ async def test_firewall_allow_prior_client_binding_endpoint_match_still_requires
     assert flow.server_conn.id not in upstream_destination_binding.binding_snapshot_for_tests()
 
 
-async def test_firewall_allow_header_auth_requestheaders_retargets_unconnected_upstream(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+async def test_firewall_allow_header_auth_unconnected_skips_prior_client_binding_scan(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
 ):
     reg_path = _write_github_firewall_registry(
         tmp_path,
@@ -732,6 +732,39 @@ async def test_firewall_allow_header_auth_requestheaders_retargets_unconnected_u
             ("Host", "api.github.com"),
             ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
         ),
+    )
+    prior_server = connection.Server(address=("198.18.20.34", 443))
+    seed_server_binding(
+        prior_server,
+        client=flow.client_conn,
+        host="api.github.com",
+        port=443,
+        kinds=frozenset(("connector_auth",)),
+        original_address=("198.18.20.34", 443),
+    )
+    client_binding_lookups = 0
+    matching_client_bindings = upstream_destination_binding._matching_client_bindings
+
+    def track_matching_client_bindings(
+        client: object,
+        *,
+        host: str,
+        port: int,
+        allowed_kinds: frozenset[upstream_destination_binding.BindingKind],
+    ) -> tuple[upstream_destination_binding.UpstreamDestinationBinding, ...]:
+        nonlocal client_binding_lookups
+        client_binding_lookups += 1
+        return matching_client_bindings(
+            client,
+            host=host,
+            port=port,
+            allowed_kinds=allowed_kinds,
+        )
+
+    monkeypatch.setattr(
+        upstream_destination_binding,
+        "_matching_client_bindings",
+        track_matching_client_bindings,
     )
 
     with (
@@ -752,6 +785,7 @@ async def test_firewall_allow_header_auth_requestheaders_retargets_unconnected_u
     assert flow.response is None
     assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
     assert flow.metadata[metadata_keys.REQUEST_STREAM_COMPLETE] is True
+    assert client_binding_lookups == 0
     binding = upstream_destination_binding.binding_snapshot_for_tests()[flow.server_conn.id]
     assert binding.host == "api.github.com"
     assert binding.kinds == frozenset(("connector_auth",))


### PR DESCRIPTION
## Summary

- skip client-associated binding enumeration when the current upstream is unconnected
- keep connected prior-client fallback and authoritative endpoint validation unchanged
- cover the performance contract through the real requestheaders admission path

## Scope

This only changes evaluation order in the runner's Python mitmproxy addon. It does not change direct binding precedence, binding ownership or cleanup, diagnostics, APIs, protocols, schemas, migrations, or persisted data. Connected fallback optimization and destination-specific indexes remain intentionally out of scope.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- focused unconnected skip and connected fallback tests: 2 passed
- connector/API admission suites: 69 passed
- `uv run --no-sync python -m pytest tests/`: 4549 passed
- `lefthook run pre-commit`

The new regression fails on the previous implementation with one client-binding lookup and passes after the branch reorder with zero lookups. A local benchmark remains approximately 0.003 ms per unconnected match from 0 through 5,000 retained client bindings.

Closes #24444
