### PR TITLE
test(mitm-addon): cover active shared-base suppression

### DIFF
--- a/crates/runner/mitm-addon/tests/connector_diagnostic_helpers.py
+++ b/crates/runner/mitm-addon/tests/connector_diagnostic_helpers.py
@@ -62,6 +62,41 @@ def connector_diagnostic_test_firewalls() -> dict[str, dict]:
     }
 
 
+def _shared_base_catalog_firewall(
+    name: str,
+    token_name: str,
+    *,
+    auth: dict[str, object] | None = None,
+    permissions: list[dict[str, object]] | None = None,
+) -> dict:
+    resolved_auth = (
+        {
+            "headers": {
+                "Authorization": f"Bearer ${{{{ secrets.{token_name} }}}}",
+            },
+            "query": {
+                "api_key": f"${{{{ secrets.{token_name} }}}}",
+            },
+        }
+        if auth is None
+        else auth
+    )
+    return {
+        "name": name,
+        "apis": [
+            {
+                "base": "https://shared.example.com",
+                "hostPolicy": {
+                    "kind": "providerOwned",
+                    "exactHosts": ["shared.example.com"],
+                },
+                "auth": resolved_auth,
+                "permissions": permissions or [],
+            }
+        ],
+    }
+
+
 def write_connector_diagnostic_catalog_cache(
     tmp_path: Path,
     *,
@@ -88,6 +123,29 @@ def write_connector_diagnostic_catalog_cache(
     replacement_path.chmod(0o600)
     replacement_path.replace(cache_path)
     return cache_path
+
+
+def write_shared_base_diagnostic_catalog(
+    tmp_path: Path,
+    *,
+    active_permissions: list[dict[str, object]] | None = None,
+    inactive_auth: dict[str, object] | None = None,
+    inactive_permissions: list[dict[str, object]] | None = None,
+) -> None:
+    firewalls = {
+        "active-shared": _shared_base_catalog_firewall(
+            "active-shared",
+            "ACTIVE_TOKEN",
+            permissions=active_permissions,
+        ),
+        "inactive-shared": _shared_base_catalog_firewall(
+            "inactive-shared",
+            "INACTIVE_TOKEN",
+            auth=inactive_auth,
+            permissions=inactive_permissions,
+        ),
+    }
+    write_connector_diagnostic_catalog_cache(tmp_path, firewalls=firewalls)
 
 
 def write_connector_diagnostic_capture_registry(tmp_path: Path) -> Path:

--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
@@ -11,6 +11,7 @@ import request_streaming
 import upstream_destination_binding
 from tests.connector_diagnostic_helpers import (
     write_connector_diagnostic_catalog_cache,
+    write_shared_base_diagnostic_catalog,
 )
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import (
@@ -75,64 +76,6 @@ def _write_shared_base_active_firewall_registry(
     )
 
 
-def _shared_base_catalog_firewall(
-    name: str,
-    token_name: str,
-    *,
-    auth: dict[str, object] | None = None,
-    permissions: list[dict[str, object]] | None = None,
-) -> dict:
-    resolved_auth = (
-        {
-            "headers": {
-                "Authorization": f"Bearer ${{{{ secrets.{token_name} }}}}",
-            },
-            "query": {
-                "api_key": f"${{{{ secrets.{token_name} }}}}",
-            },
-        }
-        if auth is None
-        else auth
-    )
-    return {
-        "name": name,
-        "apis": [
-            {
-                "base": "https://shared.example.com",
-                "hostPolicy": {
-                    "kind": "providerOwned",
-                    "exactHosts": ["shared.example.com"],
-                },
-                "auth": resolved_auth,
-                "permissions": permissions or [],
-            }
-        ],
-    }
-
-
-def _write_shared_base_diagnostic_catalog(
-    tmp_path,
-    *,
-    active_permissions: list[dict[str, object]] | None = None,
-    inactive_auth: dict[str, object] | None = None,
-    inactive_permissions: list[dict[str, object]] | None = None,
-) -> None:
-    firewalls = {
-        "active-shared": _shared_base_catalog_firewall(
-            "active-shared",
-            "ACTIVE_TOKEN",
-            permissions=active_permissions,
-        ),
-        "inactive-shared": _shared_base_catalog_firewall(
-            "inactive-shared",
-            "INACTIVE_TOKEN",
-            auth=inactive_auth,
-            permissions=inactive_permissions,
-        ),
-    }
-    write_connector_diagnostic_catalog_cache(tmp_path, firewalls=firewalls)
-
-
 def _assert_shared_base_inactive_diagnostic(flow):
     assert flow.response is not None
     assert flow.response.status_code == 424
@@ -160,7 +103,7 @@ def _assert_shared_base_inactive_diagnostic(flow):
 async def test_shared_base_unknown_endpoint_diagnoses_inactive_sibling_before_auth(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    _write_shared_base_diagnostic_catalog(
+    write_shared_base_diagnostic_catalog(
         tmp_path,
         active_permissions=[{"name": "active-read", "rules": ["GET /active"]}],
         inactive_permissions=[{"name": "inactive-read", "rules": ["GET /inactive"]}],
@@ -198,7 +141,7 @@ async def test_shared_base_unknown_endpoint_diagnoses_inactive_sibling_before_au
 async def test_shared_base_connector_intent_diagnoses_inside_candidate_set_before_auth(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    _write_shared_base_diagnostic_catalog(tmp_path)
+    write_shared_base_diagnostic_catalog(tmp_path)
     reg_path = _write_shared_base_active_firewall_registry(tmp_path)
     flow = real_flow(
         with_response=False,
@@ -232,7 +175,7 @@ async def test_shared_base_connector_intent_diagnoses_inside_candidate_set_befor
 async def test_shared_base_active_connector_intent_keeps_active_auth_path(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    _write_shared_base_diagnostic_catalog(tmp_path)
+    write_shared_base_diagnostic_catalog(tmp_path)
     reg_path = _write_shared_base_active_firewall_registry(tmp_path)
     flow = real_flow(
         with_response=False,
@@ -278,7 +221,7 @@ async def test_shared_base_unknown_endpoint_with_configured_auth_keeps_active_au
     path,
     request_header_pairs,
 ):
-    _write_shared_base_diagnostic_catalog(
+    write_shared_base_diagnostic_catalog(
         tmp_path,
         active_permissions=[{"name": "active-read", "rules": ["GET /active"]}],
         inactive_auth={
@@ -320,7 +263,7 @@ async def test_shared_base_unknown_endpoint_with_configured_auth_keeps_active_au
 async def test_shared_base_malformed_connector_intent_is_ignored_and_stripped(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    _write_shared_base_diagnostic_catalog(tmp_path)
+    write_shared_base_diagnostic_catalog(tmp_path)
     reg_path = _write_shared_base_active_firewall_registry(tmp_path)
     flow = real_flow(
         with_response=False,
@@ -350,7 +293,7 @@ async def test_shared_base_malformed_connector_intent_is_ignored_and_stripped(
 async def test_shared_base_known_permission_skips_pre_auth_diagnostic(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers
 ):
-    _write_shared_base_diagnostic_catalog(
+    write_shared_base_diagnostic_catalog(
         tmp_path,
         active_permissions=[{"name": "active-read", "rules": ["GET /active"]}],
         inactive_permissions=[{"name": "inactive-read", "rules": ["GET /inactive"]}],
@@ -380,7 +323,7 @@ async def test_shared_base_known_permission_skips_pre_auth_diagnostic(
 async def test_shared_base_requestheaders_diagnoses_before_stream_safe_auth(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    _write_shared_base_diagnostic_catalog(
+    write_shared_base_diagnostic_catalog(
         tmp_path,
         active_permissions=[{"name": "active-read", "rules": ["GET /active"]}],
         inactive_permissions=[{"name": "inactive-write", "rules": ["POST /inactive"]}],

--- a/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
@@ -16,7 +16,11 @@ from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
     read_jsonl_entries_after_flush,
 )
-from tests.request_handler_helpers import _vm_without_firewalls, _write_registry
+from tests.request_handler_helpers import (
+    _single_firewall_vm,
+    _vm_without_firewalls,
+    _write_registry,
+)
 
 
 def _drain_connector_diagnostic_response_stream(flow, *, upstream_chunk: bytes = b"upstream"):
@@ -80,6 +84,114 @@ async def test_replaces_unauthenticated_connector_401_body(tmp_path, real_flow, 
     assert proxy_entry["type"] == "connector_diagnostic"
     assert proxy_entry["connector"] == "fal"
     assert proxy_entry["upstream_status"] == 401
+
+
+async def test_active_shared_base_owner_preserves_ordinary_allow_401(tmp_path, real_flow, mitm_ctx):
+    write_connector_diagnostic_catalog_cache(
+        tmp_path,
+        firewalls={
+            "active": {
+                "name": "active",
+                "apis": [
+                    {
+                        "base": "https://shared.example.com",
+                        "auth": {
+                            "headers": {
+                                "Authorization": "Bearer ${{ secrets.ACTIVE_TOKEN }}",
+                            }
+                        },
+                        "permissions": [
+                            {
+                                "name": "messages-read",
+                                "rules": ["GET /messages/{id}"],
+                            }
+                        ],
+                    }
+                ],
+            },
+            "inactive": {
+                "name": "inactive",
+                "apis": [
+                    {
+                        "base": "https://shared.example.com",
+                        "auth": {
+                            "headers": {
+                                "Authorization": "Bearer ${{ secrets.INACTIVE_TOKEN }}",
+                            }
+                        },
+                        "permissions": [
+                            {
+                                "name": "other-read",
+                                "rules": ["GET /other/{id}"],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+    )
+    # Keep the catalog owner active while a nonmatching runtime base forces ordinary Allow.
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="active",
+            api_entry={
+                "base": "https://shared.example.com/runtime",
+                "auth": {
+                    "headers": {
+                        "Authorization": "Bearer ${{ secrets.ACTIVE_TOKEN }}",
+                    }
+                },
+                "permissions": [
+                    {
+                        "name": "runtime-read",
+                        "rules": ["GET /{path+}"],
+                    }
+                ],
+            },
+            network_policy={
+                "allow": ["runtime-read"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+    upstream_body = b"upstream auth error"
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path="/messages/123",
+        method="GET",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        record_connector_diagnostic_requestheaders_context(flow)
+        flow.response = tutils.tresp(
+            status_code=401,
+            headers=header_map({"content-type": "text/plain"}),
+            content=upstream_body,
+        )
+        mitm_addon.responseheaders(flow)
+        assert response_stream(flow)(upstream_body) == upstream_body
+        mitm_addon.response(flow)
+
+    assert flow.response.status_code == 401
+    assert flow.response.headers["content-type"] == "text/plain"
+    assert flow.response.content == upstream_body
+    assert metadata_keys.FIREWALL_ERROR not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
+    [network_entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+    assert network_entry["status"] == 401
+    assert network_entry["response_size"] == len(upstream_body)
+    assert "firewall_error" not in network_entry
+    assert "connector_diagnostic_slug" not in network_entry
+    proxy_entries = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert any(entry["type"] == "http_error" for entry in proxy_entries)
+    assert all(entry["type"] != "connector_diagnostic" for entry in proxy_entries)
 
 
 async def test_streams_unauthenticated_connector_401_diagnostic_without_upstream_body(

--- a/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
@@ -189,9 +189,9 @@ async def test_active_shared_base_owner_preserves_ordinary_allow_401(tmp_path, r
     assert network_entry["response_size"] == len(upstream_body)
     assert "firewall_error" not in network_entry
     assert "connector_diagnostic_slug" not in network_entry
-    proxy_entries = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
-    assert any(entry["type"] == "http_error" for entry in proxy_entries)
-    assert all(entry["type"] != "connector_diagnostic" for entry in proxy_entries)
+    [proxy_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert proxy_entry["type"] == "http_error"
+    assert proxy_entry["status"] == 401
 
 
 async def test_streams_unauthenticated_connector_401_diagnostic_without_upstream_body(

--- a/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
@@ -10,6 +10,7 @@ from tests.connector_diagnostic_helpers import (
     record_connector_diagnostic_requestheaders_context,
     write_connector_diagnostic_capture_registry,
     write_connector_diagnostic_catalog_cache,
+    write_shared_base_diagnostic_catalog,
 )
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import (
@@ -87,55 +88,27 @@ async def test_replaces_unauthenticated_connector_401_body(tmp_path, real_flow, 
 
 
 async def test_active_shared_base_owner_preserves_ordinary_allow_401(tmp_path, real_flow, mitm_ctx):
-    write_connector_diagnostic_catalog_cache(
+    write_shared_base_diagnostic_catalog(
         tmp_path,
-        firewalls={
-            "active": {
-                "name": "active",
-                "apis": [
-                    {
-                        "base": "https://shared.example.com",
-                        "auth": {
-                            "headers": {
-                                "Authorization": "Bearer ${{ secrets.ACTIVE_TOKEN }}",
-                            }
-                        },
-                        "permissions": [
-                            {
-                                "name": "messages-read",
-                                "rules": ["GET /messages/{id}"],
-                            }
-                        ],
-                    }
-                ],
-            },
-            "inactive": {
-                "name": "inactive",
-                "apis": [
-                    {
-                        "base": "https://shared.example.com",
-                        "auth": {
-                            "headers": {
-                                "Authorization": "Bearer ${{ secrets.INACTIVE_TOKEN }}",
-                            }
-                        },
-                        "permissions": [
-                            {
-                                "name": "other-read",
-                                "rules": ["GET /other/{id}"],
-                            }
-                        ],
-                    }
-                ],
-            },
-        },
+        active_permissions=[
+            {
+                "name": "messages-read",
+                "rules": ["GET /messages/{id}"],
+            }
+        ],
+        inactive_permissions=[
+            {
+                "name": "other-read",
+                "rules": ["GET /other/{id}"],
+            }
+        ],
     )
     # Keep the catalog owner active while a nonmatching runtime base forces ordinary Allow.
     reg_path = _write_registry(
         tmp_path,
         vm_info=_single_firewall_vm(
             tmp_path,
-            firewall_name="active",
+            firewall_name="active-shared",
             api_entry={
                 "base": "https://shared.example.com/runtime",
                 "auth": {


### PR DESCRIPTION
## Summary

- cover active unique route ownership on a shared diagnostic catalog base through the real ordinary-allow response lifecycle
- preserve the upstream 401 response and require exactly the normal HTTP error log without connector diagnostic side effects
- share the existing shared-base catalog fixture across request- and response-hook integration suites
- verify the test fails when only the active-owner suppression guard is removed

## Scope

This is a test-only change. It does not modify production behavior, schemas, persistence, APIs,
runner protocols, generated catalogs, or deployment compatibility.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_response_handler_connector_diagnostics.py::test_active_shared_base_owner_preserves_ordinary_allow_401`
- `uv run --no-sync python -m pytest -q tests/test_request_handler_connector_diagnostics.py tests/test_response_handler_connector_diagnostics.py` (42 passed)
- `uv run --no-sync python -m pytest -q tests/` (4550 passed)
- mutation verification: the focused test fails when only `_find_shared_base_candidate()` active-owner suppression is removed
- applicable lefthook pre-commit and commit-message checks

Closes #24446
