### PR TITLE
test(api): split canonical slack retry scenarios

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -1520,7 +1520,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     }
     await flushWaitUntilForTest();
 
-    let state = await integrations.readSlackTestState(teamId);
+    const state = await integrations.readSlackTestState(teamId);
     expect(state.chat_thread_routes).toHaveLength(1);
     expect(state.chat_thread_routes[0]).toMatchObject({
       channelId,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -1680,6 +1680,80 @@ describe("INT-01: Slack app deep webhook flows", () => {
       channel: channelId,
       message_ts: threadTs,
     });
+    await completeSlackTriggeredRun({
+      runId: run1Id,
+      sandboxToken: claim1.sandboxToken,
+      cliAgentType: claim1.cliAgentType,
+      assistantText: "Canonical Slack retry answer",
+    });
+    await flushWaitUntilForTest();
+  });
+
+  it("keeps queued Web and Slack sends on one canonical session", async () => {
+    const actor = bdd.user();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    const runnerGroup = runs.configureRunnerGroup();
+    integrations.configureSlackAppMocks();
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+    if (!actor.orgId) {
+      throw new Error("Expected canonical Slack actor to belong to an org");
+    }
+    const orgId = actor.orgId;
+    const slackUserId = uniqueSlackUserId();
+    const { teamId, botUserId } = await integrations.installSlackWorkspace(
+      actor,
+      {
+        installerSlackUserId: slackUserId,
+      },
+    );
+    const channelId = "C_BDD_CANONICAL_SESSION";
+    const threadTs = "2901.000100";
+    const eventId = "EvBDD" + randomUUID().replace(/-/g, "");
+    const fileBody = "canonical Slack session attachment";
+    context.mocks.slack.fetchFile.mockResolvedValue(
+      new Response(fileBody, {
+        headers: { "Content-Type": "text/plain" },
+      }),
+    );
+    const event = {
+      type: "app_mention",
+      user: slackUserId,
+      text: "<@" + botUserId + "> establish the canonical session",
+      ts: threadTs,
+      channel: channelId,
+      channel_type: "channel",
+      files: [
+        {
+          id: "F_CANONICAL_SESSION",
+          name: "session-notes.txt",
+          mimetype: "text/plain",
+          size: fileBody.length,
+          url_private_download: "https://files.slack.com/F_CANONICAL_SESSION",
+        },
+      ],
+    };
+    const eventBody = JSON.stringify({
+      type: "event_callback",
+      team_id: teamId,
+      event_id: eventId,
+      event,
+    });
+    await integrations.requestSlackEvent(
+      eventBody,
+      integrations.signedSlackIngressHeaders(eventBody),
+      [200],
+    );
+    await flushWaitUntilForTest();
+
+    let state = await integrations.readSlackTestState(teamId);
+    const canonicalChatThreadId = state.chat_thread_routes[0]?.chatThreadId;
+    if (!canonicalChatThreadId) {
+      throw new Error("Expected canonical Slack route to own a chat thread");
+    }
+    const run1Id = await pollSlackRun(runnerGroup);
+    const claim1 = await runs.claimRunnerJob(run1Id);
     const defaultAgentId = state.default_agent?.id;
     if (!defaultAgentId) {
       throw new Error("Expected canonical Slack thread to use a default agent");


### PR DESCRIPTION
## Summary

- split canonical Slack retry deduplication from the queued Web and Slack session lifecycle
- seed each scenario independently so shard contention cannot consume one shared 5-second test budget
- preserve the existing public API, session, callback, attachment, telemetry, and cancellation assertions
- leave production behavior and the global test timeout unchanged

## Trigger

- Turbo run: https://github.com/vm0-ai/vm0/actions/runs/30687910984
- event: `merge_group`
- failing SHA: `b2d5198661821c2df974ad5a52365eb482d445c8`
- queued PR: #24437
- first substantive failure: `test-api (4)`, `integrations.bdd.test.ts > deduplicates canonical Slack retries`

## Root cause

Classification: test-budget exhaustion under CI shard contention.

The failing test serialized retry deduplication, canonical input projection, shared Web and Slack queueing, session reuse, failed callback delivery, overlapping status updates, and cancellation in one test. The first causal event was the shard running at roughly twice its recent baseline: the file took 32,285 ms instead of 15,224-16,636 ms, while this test grew from 1,837-2,273 ms in five passing runs to 5,050 ms and hit the global 5-second timeout.

The merge-group change does not touch this file, and PR #24437 passed the same `test-api (4)` shard. Aggregate gate failure and other test logs were not causal.

## Fix

The retry-deduplication scenario now finishes after validating the canonical input and binding, then completes its claimed run. The queued Web and Slack continuation lifecycle starts from its own canonical Slack fixture in a separate test. All assertions from the original test remain in one of the two scenarios.

This gives each independent behavior its own existing timeout budget without retries, sleeps, timeout increases, or weakened coverage.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts`
- `pnpm -F api exec eslint src/signals/routes/__tests__/integrations.bdd.test.ts`
- `pnpm -F api check-types`
- `git diff --check`
- PR `test-api (4)`: 341 tests passed
  - `deduplicates canonical Slack retries`: 770 ms
  - `keeps queued Web and Slack sends on one canonical session`: 1,512 ms
  - full `integrations.bdd.test.ts`: 14,912 ms

Targeted repeated Vitest validation could not execute locally because the API suite could not connect to PostgreSQL at `localhost:5432`; all 35 tests were skipped during suite initialization. No local database or development server was started. The PR shard provides the runtime validation for both split scenarios.
