### PR TITLE
refactor(runner): emit exact heartbeat capabilities

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -624,7 +624,7 @@ mod tests {
     };
     use crate::paths::RunnerPaths;
     use crate::provider::mock::MockJobProvider;
-    use crate::types::{MAX_HELD_WORKSPACE_STATES, WorkspaceCacheState};
+    use crate::types::{MAX_HELD_WORKSPACE_STATES, ReusableSandboxState, WorkspaceCacheCapability};
     use crate::workspace_image_cache::{
         WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
     };
@@ -674,10 +674,10 @@ mod tests {
         snapshot.finish_workspace_cache_refresh(refresh, states);
     }
 
-    fn workspace_cache(profile: &str) -> WorkspaceCacheState {
-        WorkspaceCacheState {
+    fn workspace_cache(profile: &str) -> WorkspaceCacheCapability {
+        WorkspaceCacheCapability {
             profile: profile.to_owned(),
-            workspace_affinity_version: Some(crate::types::WORKSPACE_AFFINITY_VERSION),
+            workspace_affinity_version: crate::types::WORKSPACE_AFFINITY_VERSION,
         }
     }
 
@@ -1115,13 +1115,19 @@ mod tests {
                 session_id: "provider-session-active".into(),
                 reuse_key: "thread-active".into(),
                 last_completed_at: "2026-06-01T00:00:01.000Z".into(),
-                reusable_sandbox: None,
+                reusable_sandbox: ReusableSandboxState {
+                    profile: "vm0/default".into(),
+                    history_generation_run_id: None,
+                },
             },
             HeldSessionState {
                 session_id: "provider-session-held".into(),
                 reuse_key: "thread-held".into(),
                 last_completed_at: "2026-06-01T00:00:02.000Z".into(),
-                reusable_sandbox: None,
+                reusable_sandbox: ReusableSandboxState {
+                    profile: "vm0/default".into(),
+                    history_generation_run_id: None,
+                },
             },
         ];
 
@@ -1133,10 +1139,9 @@ mod tests {
     }
 
     #[test]
-    fn merge_held_workspace_state_keeps_newest_timestamp_and_capability() {
+    fn merge_held_workspace_state_keeps_newest_timestamp_and_merges_profiles() {
         let mut existing =
             held_workspace_state("thread-1", "2026-06-01T00:00:02.000Z", &["vm0/default"]);
-        existing.workspace_caches[0].workspace_affinity_version = None;
         let incoming = held_workspace_state(
             "thread-1",
             "2026-06-01T00:00:01.000Z",

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -509,7 +509,7 @@ async fn prepare_affinity_protected_candidate(
                 .flat_map(|state| &state.workspace_caches)
                 .any(|workspace| {
                     workspace.profile == profile_name
-                        && workspace.workspace_affinity_version == Some(WORKSPACE_AFFINITY_VERSION)
+                        && workspace.workspace_affinity_version == WORKSPACE_AFFINITY_VERSION
                 });
             if has_capable_workspace
                 && let Some(lease) =

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -37,7 +37,7 @@ use crate::run_cancellation::RunCancellationHandle;
 use crate::status::StatusTracker;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::reuse_key_kind;
-use crate::types::{HeldWorkspaceState, WORKSPACE_AFFINITY_VERSION, WorkspaceCacheState};
+use crate::types::{HeldWorkspaceState, WORKSPACE_AFFINITY_VERSION, WorkspaceCacheCapability};
 use crate::workspace_image_cache::{
     WorkspaceCacheTerminalStatus, WorkspaceImageLease, WorkspaceImagePromotionContext,
     WorkspaceImagePromotionRequest,
@@ -70,9 +70,9 @@ fn mark_workspace_cache_snapshot_promoted(
         snapshot.upsert_workspace_cache_state(HeldWorkspaceState {
             reuse_key: reuse_key.to_owned(),
             last_completed_at: completed_at.to_owned(),
-            workspace_caches: vec![WorkspaceCacheState {
+            workspace_caches: vec![WorkspaceCacheCapability {
                 profile: profile_name.to_owned(),
-                workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                workspace_affinity_version: WORKSPACE_AFFINITY_VERSION,
             }],
         });
     }

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -448,8 +448,7 @@ async fn generation_protected_different_idle_sandbox_defers_before_claim() {
     assert_eq!(
         pool.held_session_states()[0]
             .reusable_sandbox
-            .as_ref()
-            .and_then(|sandbox| sandbox.history_generation_run_id),
+            .history_generation_run_id,
         Some(held_generation_run_id),
         "the different generation must remain available for fallback after expiry"
     );

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -1273,10 +1273,10 @@ impl IdlePool {
                         session_id: entry.cli_agent_session_id().to_owned(),
                         reuse_key: reuse_key.clone(),
                         last_completed_at: last_completed_at.clone(),
-                        reusable_sandbox: Some(ReusableSandboxState {
+                        reusable_sandbox: ReusableSandboxState {
                             profile: entry.metadata.profile_name.clone(),
                             history_generation_run_id: entry.metadata.history_generation_run_id,
-                        }),
+                        },
                     })
             })
             .collect();
@@ -2131,19 +2131,19 @@ mod tests {
                     session_id: "sess-a".to_string(),
                     reuse_key: "sess-a".to_string(),
                     last_completed_at: "2026-05-28T00:00:00.000Z".to_string(),
-                    reusable_sandbox: Some(ReusableSandboxState {
+                    reusable_sandbox: ReusableSandboxState {
                         profile: "vm0/default".to_string(),
                         history_generation_run_id: Some(history_generation_run_id),
-                    }),
+                    },
                 },
                 HeldSessionState {
                     session_id: "sess-b".to_string(),
                     reuse_key: "sess-b".to_string(),
                     last_completed_at: "2026-05-28T00:00:01.000Z".to_string(),
-                    reusable_sandbox: Some(ReusableSandboxState {
+                    reusable_sandbox: ReusableSandboxState {
                         profile: "vm0/default".to_string(),
                         history_generation_run_id: None,
-                    }),
+                    },
                 },
             ],
         );

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -829,6 +829,7 @@ fn classify_claim_failure(error: &ClaimApiError) -> ClaimFailureDecision {
 
 fn log_heartbeat_failure(state: &HeartbeatState, error: &RunnerError) {
     let sessions = state.held_session_states.len();
+    let workspace_states = state.held_workspace_states.len();
     if let RunnerError::ApiTransport(api_error) = error {
         let request = &api_error.request;
         warn!(
@@ -848,6 +849,7 @@ fn log_heartbeat_failure(state: &HeartbeatState, error: &RunnerError) {
             mode = %state.mode,
             running = state.running_count,
             sessions,
+            workspace_states,
             "heartbeat failed"
         );
         return;
@@ -861,6 +863,7 @@ fn log_heartbeat_failure(state: &HeartbeatState, error: &RunnerError) {
         mode = %state.mode,
         running = state.running_count,
         sessions,
+        workspace_states,
         "heartbeat failed"
     );
 }
@@ -1761,11 +1764,21 @@ mod tests {
             admittable_profiles: vec![crate::profile::DEFAULT_PROFILE.to_string()],
             held_session_states: vec![crate::types::HeldSessionState {
                 session_id: "held-session-test".to_string(),
-                reuse_key: "held-session-test".to_string(),
+                reuse_key: "thread:heartbeat-test".to_string(),
                 last_completed_at: "2026-07-08T00:00:00.000Z".to_string(),
-                reusable_sandbox: None,
+                reusable_sandbox: crate::types::ReusableSandboxState {
+                    profile: crate::profile::DEFAULT_PROFILE.to_string(),
+                    history_generation_run_id: None,
+                },
             }],
-            held_workspace_states: Vec::new(),
+            held_workspace_states: vec![crate::types::HeldWorkspaceState {
+                reuse_key: "thread:heartbeat-test".to_string(),
+                last_completed_at: "2026-07-08T00:00:00.000Z".to_string(),
+                workspace_caches: vec![crate::types::WorkspaceCacheCapability {
+                    profile: crate::profile::DEFAULT_PROFILE.to_string(),
+                    workspace_affinity_version: crate::types::WORKSPACE_AFFINITY_VERSION,
+                }],
+            }],
             mode: "running".to_string(),
         }
     }
@@ -1905,6 +1918,7 @@ mod tests {
         assert_eq!(event_field(event, "mode"), "running");
         assert_eq!(event_field(event, "running"), "1");
         assert_eq!(event_field(event, "sessions"), "1");
+        assert_eq!(event_field(event, "workspace_states"), "1");
         assert_eq!(event_field(event, "endpoint"), "heartbeat");
         assert_eq!(event_field(event, "method"), "POST");
         assert_eq!(
@@ -1935,6 +1949,37 @@ mod tests {
         assert!(
             !event_debug.contains("runner-token") && !event_debug.contains("held-session-test"),
             "event should not include bearer token or heartbeat body: {event_debug}"
+        );
+    }
+
+    #[tokio::test]
+    async fn heartbeat_status_failure_logs_held_state_counts_without_body() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let api_url = format!("http://{}", listener.local_addr().unwrap());
+        let server_task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut socket).await;
+            write_http_status_response(&mut socket, 500).await;
+        });
+        let provider = api_provider_for_test(
+            api_url,
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+        let state = heartbeat_state_for_test();
+
+        let (_, events) = capture_api_provider_events(provider.heartbeat(&state)).await;
+        server_task.await.unwrap();
+        let event = captured_event(&events, "heartbeat failed");
+
+        assert_eq!(event.level, Level::WARN);
+        assert_eq!(event_field(event, "sessions"), "1");
+        assert_eq!(event_field(event, "workspace_states"), "1");
+        let event_debug = format!("{event:#?}");
+        assert!(
+            !event_debug.contains("held-session-test")
+                && !event_debug.contains("thread:heartbeat-test"),
+            "event should not include heartbeat body: {event_debug}"
         );
     }
 

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1269,11 +1269,11 @@ impl ExecutionContext {
 // Heartbeat
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ReusableSandboxState {
     pub profile: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub history_generation_run_id: Option<RunId>,
 }
 
@@ -1334,16 +1334,15 @@ impl SessionHistorySizeBucket {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct WorkspaceCacheState {
+pub struct WorkspaceCacheCapability {
     pub profile: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workspace_affinity_version: Option<u8>,
+    pub workspace_affinity_version: u8,
 }
 
 /// Runner state snapshot sent to the server via heartbeat.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct HeldSessionState {
     /// Compatibility wire name is `sessionId`; this remains the Claude/Codex
@@ -1351,18 +1350,17 @@ pub struct HeldSessionState {
     pub session_id: String,
     pub reuse_key: String,
     pub last_completed_at: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reusable_sandbox: Option<ReusableSandboxState>,
+    pub reusable_sandbox: ReusableSandboxState,
 }
 
 /// Workspace cache state owned by a runner reuse key rather than a provider
 /// session identity.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct HeldWorkspaceState {
     pub reuse_key: String,
     pub last_completed_at: String,
-    pub workspace_caches: Vec<WorkspaceCacheState>,
+    pub workspace_caches: Vec<WorkspaceCacheCapability>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1381,7 +1379,6 @@ pub struct HeartbeatState {
     pub running_count: usize,
     pub admittable_profiles: Vec<String>,
     pub held_session_states: Vec<HeldSessionState>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub held_workspace_states: Vec<HeldWorkspaceState>,
     pub mode: String,
 }
@@ -2158,19 +2155,19 @@ mod tests {
                 session_id: "session-abc".into(),
                 reuse_key: "thread:thread-abc".into(),
                 last_completed_at: "2026-05-28T00:00:00.000Z".into(),
-                reusable_sandbox: Some(ReusableSandboxState {
+                reusable_sandbox: ReusableSandboxState {
                     profile: "vm0/default".into(),
                     history_generation_run_id: Some(
                         "11111111-1111-4111-8111-111111111111".parse().unwrap(),
                     ),
-                }),
+                },
             }],
             held_workspace_states: vec![HeldWorkspaceState {
                 reuse_key: "thread:thread-abc".into(),
                 last_completed_at: "2026-05-28T00:00:00.000Z".into(),
-                workspace_caches: vec![WorkspaceCacheState {
+                workspace_caches: vec![WorkspaceCacheCapability {
                     profile: "vm0/large".into(),
-                    workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                    workspace_affinity_version: WORKSPACE_AFFINITY_VERSION,
                 }],
             }],
             mode: "running".into(),
@@ -2214,27 +2211,47 @@ mod tests {
     }
 
     #[test]
-    fn held_session_state_accepts_minimal_shape_and_omits_absent_capability() {
-        let state: HeldSessionState = serde_json::from_value(json!({
-            "sessionId": "session-minimal",
-            "reuseKey": "session:session-minimal",
-            "lastCompletedAt": "2026-05-28T00:00:00.000Z",
-            "reusableSandbox": {
-                "profile": "vm0/default"
-            }
-        }))
-        .unwrap();
-        assert!(
-            state
-                .reusable_sandbox
-                .as_ref()
-                .is_some_and(|sandbox| sandbox.history_generation_run_id.is_none())
-        );
+    fn held_session_state_serializes_required_sandbox_without_optional_history_generation() {
+        let state = HeldSessionState {
+            session_id: "session-current".into(),
+            reuse_key: "thread:thread-current".into(),
+            last_completed_at: "2026-05-28T00:00:00.000Z".into(),
+            reusable_sandbox: ReusableSandboxState {
+                profile: "vm0/default".into(),
+                history_generation_run_id: None,
+            },
+        };
         let serialized = serde_json::to_value(state).unwrap();
+        assert_eq!(serialized["reusableSandbox"]["profile"], "vm0/default");
         assert!(
             serialized["reusableSandbox"]
                 .get("historyGenerationRunId")
                 .is_none()
         );
+    }
+
+    #[test]
+    fn heartbeat_state_serializes_empty_held_state_arrays() {
+        let state = HeartbeatState {
+            runner_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            runner_name: "runner-1".into(),
+            group: "vm0/production".into(),
+            snapshot_generation: 7,
+            snapshot_sequence: 42,
+            total_vcpu: 16,
+            total_memory_mb: 32768,
+            max_concurrent: 8,
+            allocated_vcpu: 0,
+            allocated_memory_mb: 0,
+            running_count: 0,
+            admittable_profiles: vec!["vm0/default".into()],
+            held_session_states: Vec::new(),
+            held_workspace_states: Vec::new(),
+            mode: "running".into(),
+        };
+
+        let serialized = serde_json::to_value(state).unwrap();
+        assert_eq!(serialized["heldSessionStates"], json!([]));
+        assert_eq!(serialized["heldWorkspaceStates"], json!([]));
     }
 }

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -15,7 +15,7 @@ use crate::ids::RunId;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::{
     HeldWorkspaceState, MAX_HELD_WORKSPACE_STATES, MAX_WORKSPACE_CACHES_PER_HEARTBEAT,
-    MAX_WORKSPACE_CACHES_PER_REUSE_KEY, WORKSPACE_AFFINITY_VERSION, WorkspaceCacheState,
+    MAX_WORKSPACE_CACHES_PER_REUSE_KEY, WORKSPACE_AFFINITY_VERSION, WorkspaceCacheCapability,
 };
 
 use super::entry::is_cache_key_name;
@@ -648,9 +648,9 @@ impl SessionWorkspaceCache {
                 states.push(HeldWorkspaceState {
                     reuse_key: metadata.reuse_key,
                     last_completed_at: metadata.last_completed_at,
-                    workspace_caches: vec![WorkspaceCacheState {
+                    workspace_caches: vec![WorkspaceCacheCapability {
                         profile: metadata.profile_name,
-                        workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                        workspace_affinity_version: WORKSPACE_AFFINITY_VERSION,
                     }],
                 });
             }
@@ -1524,7 +1524,7 @@ pub(crate) fn cap_held_workspace_states(
 ) -> Vec<HeldWorkspaceState> {
     struct ObservedWorkspaceState {
         last_completed_at: String,
-        workspace_caches: BTreeMap<String, (String, WorkspaceCacheState)>,
+        workspace_caches: BTreeMap<String, (String, WorkspaceCacheCapability)>,
     }
 
     let mut by_reuse_key = BTreeMap::<String, ObservedWorkspaceState>::new();

--- a/crates/runner/src/workspace_image_cache/tests/state.rs
+++ b/crates/runner/src/workspace_image_cache/tests/state.rs
@@ -25,8 +25,7 @@ use crate::paths::{RunnerPaths, scoped_session_workspace_cache_key, session_work
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::types::{
     HeldWorkspaceState, MAX_HELD_WORKSPACE_STATES, MAX_WORKSPACE_CACHES_PER_HEARTBEAT,
-    MAX_WORKSPACE_CACHES_PER_REUSE_KEY, WORKSPACE_AFFINITY_VERSION,
-    WorkspaceCacheState as HeldWorkspaceCacheState,
+    MAX_WORKSPACE_CACHES_PER_REUSE_KEY, WORKSPACE_AFFINITY_VERSION, WorkspaceCacheCapability,
 };
 
 #[test]
@@ -104,18 +103,18 @@ fn cap_held_workspace_states_dedupes_and_keeps_newest() {
         .map(|index| HeldWorkspaceState {
             reuse_key: format!("sess-{index:04}"),
             last_completed_at: timestamp_for_index(index),
-            workspace_caches: vec![HeldWorkspaceCacheState {
+            workspace_caches: vec![WorkspaceCacheCapability {
                 profile: TEST_PROFILE_NAME.to_owned(),
-                workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                workspace_affinity_version: WORKSPACE_AFFINITY_VERSION,
             }],
         })
         .collect();
     states.push(HeldWorkspaceState {
         reuse_key: "sess-0001".into(),
         last_completed_at: timestamp_for_index(MAX_HELD_WORKSPACE_STATES + 1),
-        workspace_caches: vec![HeldWorkspaceCacheState {
+        workspace_caches: vec![WorkspaceCacheCapability {
             profile: TEST_PROFILE_NAME.to_owned(),
-            workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+            workspace_affinity_version: WORKSPACE_AFFINITY_VERSION,
         }],
     });
 
@@ -143,9 +142,9 @@ fn cap_held_workspace_states_bounds_nested_resources() {
         .map(|index| HeldWorkspaceState {
             reuse_key: "sess-multi".into(),
             last_completed_at: timestamp_for_index(index),
-            workspace_caches: vec![HeldWorkspaceCacheState {
+            workspace_caches: vec![WorkspaceCacheCapability {
                 profile: format!("vm0/profile-{index:02}"),
-                workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                workspace_affinity_version: WORKSPACE_AFFINITY_VERSION,
             }],
         })
         .collect();
@@ -165,9 +164,9 @@ fn cap_held_workspace_states_bounds_nested_resources() {
             reuse_key: format!("sess-{index:04}"),
             last_completed_at: timestamp_for_index(index),
             workspace_caches: (0..8)
-                .map(|profile| HeldWorkspaceCacheState {
+                .map(|profile| WorkspaceCacheCapability {
                     profile: format!("vm0/profile-{profile}"),
-                    workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                    workspace_affinity_version: WORKSPACE_AFFINITY_VERSION,
                 })
                 .collect(),
         })
@@ -241,13 +240,13 @@ async fn held_workspace_states_for_profiles_filters_and_aggregates_current_ident
             reuse_key: reuse_key.into(),
             last_completed_at: "2026-05-01T00:00:02.000Z".into(),
             workspace_caches: vec![
-                HeldWorkspaceCacheState {
+                WorkspaceCacheCapability {
                     profile: "vm0/default".into(),
-                    workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                    workspace_affinity_version: WORKSPACE_AFFINITY_VERSION,
                 },
-                HeldWorkspaceCacheState {
+                WorkspaceCacheCapability {
                     profile: "vm0/large".into(),
-                    workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                    workspace_affinity_version: WORKSPACE_AFFINITY_VERSION,
                 },
             ],
         }]


### PR DESCRIPTION
## Summary

- make Runner heartbeat capability models producer-only and require the reusable-sandbox and workspace-affinity values that current producers always supply
- always serialize both held-state arrays, including an explicit empty `heldWorkspaceStates`
- distinguish advertised `WorkspaceCacheCapability` from the on-disk cache lifecycle state and report workspace counts on both heartbeat failure paths
- replace compatibility-only fixtures with current serialization, producer, admission, and provider-entry-point coverage

## Compatibility and exclusions

- keeps the TypeScript heartbeat parser permissive for draining older runners
- does not change API behavior, database persistence, queue payloads, workspace-cache metadata or keys, or session-history sidecars
- remains valid against the previously deployed API, which already accepts explicit workspace arrays and current capability values

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (`2911 passed`, `14 ignored`; guest inventory passed)
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts` (`59 passed`)

Closes #24386

Parent delivery context: #24375
