### PR TITLE
test(api): stabilize thread model lock synchronization

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -2467,16 +2467,18 @@ describe("CHAT-02: model-first provider policies", () => {
       await threadLock.done;
     });
 
-    const sentPromise = sendChatRun(actor, {
-      agentId,
-      threadId: thread.id,
-      prompt: "continue without reconciling the thread model",
-    });
-    await expect.poll(threadLock.firstBlockedStatementKind).toBe("update");
-
-    threadLock.release();
-    const sent = await sentPromise;
-    await threadLock.done;
+    const [sent] = await Promise.all([
+      sendChatRun(actor, {
+        agentId,
+        threadId: thread.id,
+        prompt: "continue without reconciling the thread model",
+      }),
+      (async () => {
+        await expect.poll(threadLock.firstBlockedStatementKind).toBe("update");
+        threadLock.release();
+        await threadLock.done;
+      })(),
+    ]);
     expect(apiDispatchTimingEventsForRun(sent.runId)).toContainEqual(
       expect.objectContaining({
         op_type:
@@ -2513,6 +2515,7 @@ describe("CHAT-02: model-first provider policies", () => {
     );
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(first.runId, firstClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
 
     await seedVm0ManagedModelKey("gpt-5.6-terra");
     await api.updateOrgModelPolicies(actor, [
@@ -2533,18 +2536,20 @@ describe("CHAT-02: model-first provider policies", () => {
       threadLock.release();
       await threadLock.done;
     });
-    const recoveredPromise = sendChatRun(actor, {
-      agentId,
-      threadId: first.threadId,
-      prompt: "continue through the current workspace default",
-    });
-    await expect
-      .poll(threadLock.firstBlockedStatementKind)
-      .toBe("select_for_update");
-
-    threadLock.release();
-    const recovered = await recoveredPromise;
-    await threadLock.done;
+    const [recovered] = await Promise.all([
+      sendChatRun(actor, {
+        agentId,
+        threadId: first.threadId,
+        prompt: "continue through the current workspace default",
+      }),
+      (async () => {
+        await expect
+          .poll(threadLock.firstBlockedStatementKind)
+          .toBe("select_for_update");
+        threadLock.release();
+        await threadLock.done;
+      })(),
+    ]);
     expect(apiDispatchTimingEventsForRun(recovered.runId)).toContainEqual(
       expect.objectContaining({
         op_type:


### PR DESCRIPTION
## Summary

- flush terminal chat `waitUntil` work before taking the completed run's thread row lock
- own each overlapping send and lock observation immediately with `Promise.all`
- preserve the exact `UPDATE` versus `SELECT ... FOR UPDATE` business assertions

## Failure evidence

- Triggering Turbo run: https://github.com/vm0-ai/vm0/actions/runs/30689336522
- Event: `merge_group`
- Failing SHA: `dfc479f6de2203a3ee1fd6ae1feadf9323f9238a`
- First substantive failure: `test-api (6)` / `chat-events.bdd.test.ts` / `recovers a removed thread model through the current workspace route`
- First causal event: the row-lock fixture observed `UPDATE chat_threads` as the first blocked statement instead of the recovery request's expected `SELECT ... FOR UPDATE`

## Root cause

Classification: missing test synchronization plus delayed Promise ownership.

`completeChatRunOk()` returns after the completion route schedules terminal callback side effects through `waitUntil()`. Those side effects persist terminal chat events and reserve sequence IDs with an `UPDATE chat_threads`. The test could acquire the same thread row lock before that work finished, so the terminal event update sometimes became the fixture's first waiter. If it finished first, the recovery request was the first waiter and the test passed.

The send Promise was also only awaited after the polling assertion. When the assertion failed and test teardown aborted the request, its rejection handler was attached too late, producing `PromiseRejectionHandledWarning` and secondary `AbortError` / HTTP 500 noise.

PR #24455 did not modify this test or lock fixture. Its pull-request Turbo run, adjacent main runs, and the regenerated merge-group `test-api (6)` job all passed, which is consistent with this scheduling race rather than a deterministic Feishu regression.

## Fix

The test now calls `flushWaitUntilForTest()` at the run-completion boundary before entering the row-lock scenario. Both lock-path tests also await the send and lock-observation branches in one `Promise.all`, so rejection ownership exists from creation while the lock release remains deterministic.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts`
- `pnpm -F api exec oxlint src/signals/routes/__tests__/chat-events.bdd.test.ts --type-aware -c ../../.oxlintrc.typeaware.json`
- `pnpm -F api exec eslint src/signals/routes/__tests__/chat-events.bdd.test.ts --max-warnings 0`
- `pnpm -F api check-types`
- `git diff --check`
- Targeted Vitest command attempted, but the local environment has no PostgreSQL listener; suite setup stopped before the test with `ECONNREFUSED ::1:5432` / `127.0.0.1:5432`. Repeated real-database validation is therefore delegated to the PR Turbo pipeline.

No product contract or assertion was weakened.
