### PR TITLE
refactor: claim feishu launch context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -29,9 +29,11 @@ import { env, mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { extractFileFromTarGz } from "../../../lib/tar";
 import { server } from "../../../mocks/server";
 import {
+  decryptChatEventInputParamsFixture,
   findPendingChatEventInputParamsByPromptFixture,
   readChatEventContextFixture,
   readChatEventInputParamsFixture,
+  replaceFeishuLaunchMaterialWithLegacyParamsFixture,
 } from "../../../test-fixtures/chat-events";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { now } from "../../external/time";
@@ -2119,17 +2121,17 @@ describe("Feishu integration", () => {
     );
     await flushWaitUntilForTest();
 
-    const canonicalFilePrompt =
-      "[Web file] quarterly-report.pdf (application/pdf)";
+    const feishuFilePrompt = "[Feishu file] quarterly-report.pdf";
     const listed = await runsApi.listAgentRuns(actor, { limit: 20 });
     const run = requireValue(
       listed.runs.find((candidate) => {
-        return candidate.prompt.includes(canonicalFilePrompt);
+        return candidate.prompt.includes(feishuFilePrompt);
       }),
       "Expected Feishu file run",
     );
     await runsApi.heartbeatRunner(runnerGroup);
     const claim = await runsApi.claimRunnerJob(run.id);
+    expect(claim.prompt).toBe(run.prompt);
     expect(oauthTokenGrantTypes).toStrictEqual([
       "authorization_code",
       "refresh_token",
@@ -2171,12 +2173,14 @@ describe("Feishu integration", () => {
         },
       ),
     ).toBeTruthy();
-    expect(claim.prompt).toContain(canonicalFilePrompt);
-    const fileId = claim.prompt.match(/ {3}\[ID\] ([^\n]+)/u)?.[1];
+    expect(claim.prompt).toContain(feishuFilePrompt);
+    expect(claim.prompt).toContain("   [MESSAGE_ID] om_file_message");
+    expect(claim.prompt).toContain("   [TYPE] file");
+    const fileId = claim.prompt.match(/ {3}\[FILE_KEY\] ([^\n]+)/u)?.[1];
     expect(fileId).toMatch(/^feishu_file_[A-Za-z0-9_-]{22}$/u);
     expect(fileId?.length).toBeLessThan(64);
     expect(claim.prompt).not.toContain(fileKey);
-    expect(claim.prompt).toContain(`   [ID] ${fileId}`);
+    expect(claim.prompt).toContain(`   [FILE_KEY] ${fileId}`);
     expect(claim.appendSystemPrompt).toContain("zero feishu download-file -h");
     expect(claim.appendSystemPrompt).toContain("zero feishu upload-file -h");
 
@@ -2291,6 +2295,38 @@ describe("Feishu integration", () => {
     expect(wrongRunResponse.status).toBe(400);
   });
 
+  it("claims a Feishu message when conversation history loading fails", async () => {
+    const fixture = await setupFeishuRunFixture();
+    const { actor, runnerGroup, appId, callbackUrl } = fixture;
+    await connectFixtureUser(fixture);
+    server.use(
+      http.get("https://open.feishu.cn/open-apis/im/v1/messages", () => {
+        return HttpResponse.json(
+          { code: 99_999, msg: "history unavailable" },
+          { status: 500 },
+        );
+      }),
+    );
+
+    const prompt = "continue without Feishu history";
+    await postEvent(
+      callbackUrl,
+      directMessage(appId, prompt, "ou_feishu_user"),
+      { encrypted: true },
+    );
+    await flushWaitUntilForTest();
+
+    const run = await findRun(actor, prompt);
+    await runsApi.heartbeatRunner(runnerGroup);
+    const claim = await runsApi.claimRunnerJob(run.id);
+    expect(claim.prompt).toBe(prompt);
+    expect(claim.appendSystemPrompt).toContain("Scope: Direct message");
+    expect(claim.appendSystemPrompt).not.toContain("# Recent Channel Messages");
+    expect(claim.appendSystemPrompt).not.toContain("# Feishu Thread Context");
+    await runsApi.requestCancelRun(actor, run.id, [200]);
+    await flushWaitUntilForTest();
+  });
+
   it("builds Feishu DM context and canonical response metadata", async () => {
     const fixture = await setupFeishuRunFixture({
       useAlternateInstallationDefault: true,
@@ -2395,6 +2431,7 @@ describe("Feishu integration", () => {
     );
     await runsApi.heartbeatRunner(runnerGroup);
     const claim = await runsApi.claimRunnerJob(run.id);
+    expect(claim.prompt).toBe("do the Feishu task");
     expect(claim.environment?.ZERO_AGENT_ID).toBe(alternateAgentId);
     expect(claim.appendSystemPrompt).toContain(
       "You are currently running inside: Feishu",
@@ -2976,6 +3013,54 @@ describe("Feishu integration", () => {
     if (!queuedFeishuParams) {
       throw new Error("Expected queued canonical Feishu transport params");
     }
+    const secondOrgId = requireValue(
+      secondActor.orgId,
+      "Expected the second Feishu actor organization",
+    );
+    await expect(
+      decryptChatEventInputParamsFixture(queuedFeishuParams.eventId, {
+        orgId: secondOrgId,
+        userId: secondActor.userId,
+      }),
+    ).resolves.toStrictEqual({ version: 1 });
+    const queuedFeishuContext = await readChatEventContextFixture(
+      queuedFeishuParams.eventId,
+    );
+    if (
+      !queuedFeishuContext?.feishuInstallationId ||
+      !queuedFeishuContext.feishuConnectionId ||
+      !queuedFeishuContext.feishuChatId ||
+      !queuedFeishuContext.feishuMessageId ||
+      queuedFeishuContext.feishuReplyInThread === null ||
+      !queuedFeishuContext.feishuSenderOpenId
+    ) {
+      throw new Error("Expected queued Feishu launch context");
+    }
+    const legacyPrompt = "legacy queued Feishu prompt";
+    const legacySystemPrompt = "legacy queued Feishu system prompt";
+    await replaceFeishuLaunchMaterialWithLegacyParamsFixture(
+      queuedFeishuParams.eventId,
+      {
+        orgId: secondOrgId,
+        userId: secondActor.userId,
+        prompt: legacyPrompt,
+        appendSystemPrompt: legacySystemPrompt,
+        feishuDelivery: {
+          installationId: queuedFeishuContext.feishuInstallationId,
+          connectionId: queuedFeishuContext.feishuConnectionId,
+          chatId: queuedFeishuContext.feishuChatId,
+          messageId: queuedFeishuContext.feishuMessageId,
+          threadId: firstMessageId,
+          replyInThread: queuedFeishuContext.feishuReplyInThread,
+          ...(queuedFeishuContext.feishuReactionId
+            ? { reactionId: queuedFeishuContext.feishuReactionId }
+            : {}),
+          files: [...(queuedFeishuContext.feishuMessageFiles ?? [])],
+        },
+        feishuDisplayName: "Canonical Group User",
+        feishuOpenId: queuedFeishuContext.feishuSenderOpenId,
+      },
+    );
     await runsApi.heartbeatRunner(runnerGroup);
     const firstClaim = await runsApi.claimRunnerJob(firstRun.id);
     const firstCliSessionId = `bdd-feishu-canonical-group-${firstRun.id}`;
@@ -2987,12 +3072,14 @@ describe("Feishu integration", () => {
       assistantText: "First canonical group answer",
     });
 
-    const secondRun = await findRun(secondActor, secondPrompt);
+    const secondRun = await findRun(secondActor, legacyPrompt);
     await expect(
       readChatEventInputParamsFixture(queuedFeishuParams.eventId),
     ).resolves.toBeNull();
     await runsApi.heartbeatRunner(runnerGroup);
     const secondClaim = await runsApi.claimRunnerJob(secondRun.id);
+    expect(secondClaim.prompt).toBe(legacyPrompt);
+    expect(secondClaim.appendSystemPrompt).toContain(legacySystemPrompt);
     expect(secondClaim.resumeSession?.sessionId).toBe(firstCliSessionId);
     await runsApi.requestCancelRun(secondActor, secondRun.id, [200]);
     await flushWaitUntilForTest();
@@ -3089,6 +3176,7 @@ describe("Feishu integration", () => {
     );
     await runsApi.heartbeatRunner(runnerGroup);
     const groupClaim = await runsApi.claimRunnerJob(groupRun.id);
+    expect(groupClaim.prompt).toBe("handle this group task");
     expect(groupClaim.appendSystemPrompt).toContain("Scope: Group mention");
     expect(groupClaim.appendSystemPrompt).toContain("Chat ID: oc_feishu_group");
     expect(groupClaim.appendSystemPrompt).toContain(

--- a/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
@@ -38,7 +38,6 @@ import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { encryptQueuedUserMessageRunParams } from "./zero-chat-queued-event.service";
 import {
   addFeishuThinkingReaction,
-  buildFeishuSystemPrompt,
   dispatchConnectedFeishuCommand$,
   loadFeishuConversationHistory,
   markFeishuMessageReceived,
@@ -332,7 +331,6 @@ async function persistCanonicalFeishuIngress(args: {
   readonly selectedModel: string | null;
   readonly reactionId: string | undefined;
   readonly launchContext: CanonicalFeishuLaunchContext;
-  readonly appendSystemPrompt: string;
   readonly signal: AbortSignal;
 }): Promise<PersistedCanonicalFeishuIngress> {
   const routeThreadId = canonicalThreadId({
@@ -355,22 +353,6 @@ async function persistCanonicalFeishuIngress(args: {
   const encryptedParams = await encryptQueuedUserMessageRunParams(
     {
       version: 1,
-      prompt: args.message.text,
-      appendSystemPrompt: args.appendSystemPrompt,
-      feishuDelivery: {
-        installationId: args.message.installationId,
-        connectionId: args.connection.id,
-        chatId: args.message.chatId,
-        messageId: args.message.messageId,
-        threadId: routeThreadId,
-        replyInThread: args.launchContext.replyInThread,
-        reactionId: args.reactionId,
-        files: args.launchContext.messageFiles,
-      },
-      userInfoExtras: {
-        feishuDisplayName: args.connection.feishuUserName ?? undefined,
-        feishuOpenId: args.message.openId,
-      },
     },
     {
       orgId: args.installation.orgId,
@@ -597,10 +579,6 @@ async function processClaimedIngress(args: {
       reactionId,
       conversationHistory: history.text,
       files: history.files,
-    }),
-    appendSystemPrompt: buildFeishuSystemPrompt({
-      message,
-      history: history.text,
     }),
     signal: args.signal,
   });

--- a/turbo/apps/api/src/signals/services/feishu-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-queued-launch-context.service.ts
@@ -1,0 +1,193 @@
+import { chatEvents } from "@vm0/db/schema/chat-event";
+import { chatFeishuContext } from "@vm0/db/schema/chat-feishu-context";
+import { feishuChatThreadRoutes } from "@vm0/db/schema/feishu-chat-thread-route";
+import { feishuOrgConnections } from "@vm0/db/schema/feishu-org-connection";
+import { feishuOrgInstallations } from "@vm0/db/schema/feishu-org-installation";
+import { and, eq } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+import type { FeishuDeliveryTarget } from "./feishu-chat-callback-payload";
+import { buildFeishuSystemPrompt } from "./zero-feishu-dispatch.service";
+
+export interface FeishuQueuedLaunchMaterial {
+  readonly prompt: string;
+  readonly appendSystemPrompt: string;
+  readonly feishuDelivery: FeishuDeliveryTarget;
+  readonly userInfoExtras: {
+    readonly feishuDisplayName?: string;
+    readonly feishuOpenId: string;
+  };
+}
+
+type FeishuLaunchContextRow = Pick<
+  typeof chatFeishuContext.$inferSelect,
+  | "conversationHistory"
+  | "messageText"
+  | "messageFiles"
+  | "chatType"
+  | "tenantKey"
+  | "chatId"
+  | "messageId"
+  | "threadId"
+  | "replyInThread"
+  | "reactionId"
+  | "senderOpenId"
+  | "connectionId"
+  | "installationId"
+> & {
+  readonly routeThreadId: string;
+  readonly feishuDisplayName: string | null;
+};
+
+function requiredFeishuLaunchContext(row: FeishuLaunchContextRow | undefined) {
+  if (
+    !row ||
+    row.conversationHistory === null ||
+    row.messageText === null ||
+    row.messageFiles === null ||
+    row.chatType === null ||
+    row.tenantKey === null ||
+    row.chatId === null ||
+    row.messageId === null ||
+    row.threadId === null ||
+    row.replyInThread === null ||
+    row.senderOpenId === null ||
+    row.connectionId === null ||
+    row.installationId === null
+  ) {
+    return null;
+  }
+  return {
+    ...row,
+    conversationHistory: row.conversationHistory,
+    messageText: row.messageText,
+    messageFiles: row.messageFiles,
+    chatType: row.chatType,
+    tenantKey: row.tenantKey,
+    chatId: row.chatId,
+    messageId: row.messageId,
+    threadId: row.threadId,
+    replyInThread: row.replyInThread,
+    senderOpenId: row.senderOpenId,
+    connectionId: row.connectionId,
+    installationId: row.installationId,
+  };
+}
+
+async function loadFeishuLaunchContext(
+  db: Db,
+  args: {
+    readonly eventId: string;
+    readonly chatThreadId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+) {
+  const [row] = await db
+    .select({
+      conversationHistory: chatFeishuContext.conversationHistory,
+      messageText: chatFeishuContext.messageText,
+      messageFiles: chatFeishuContext.messageFiles,
+      chatType: chatFeishuContext.chatType,
+      tenantKey: chatFeishuContext.tenantKey,
+      chatId: chatFeishuContext.chatId,
+      messageId: chatFeishuContext.messageId,
+      threadId: chatFeishuContext.threadId,
+      replyInThread: chatFeishuContext.replyInThread,
+      reactionId: chatFeishuContext.reactionId,
+      senderOpenId: chatFeishuContext.senderOpenId,
+      connectionId: chatFeishuContext.connectionId,
+      installationId: chatFeishuContext.installationId,
+      routeThreadId: feishuChatThreadRoutes.threadId,
+      feishuDisplayName: feishuOrgConnections.feishuUserName,
+    })
+    .from(chatEvents)
+    .innerJoin(
+      chatFeishuContext,
+      and(
+        eq(chatFeishuContext.id, chatEvents.contextId),
+        eq(chatFeishuContext.chatThreadId, chatEvents.chatThreadId),
+      ),
+    )
+    .innerJoin(
+      feishuChatThreadRoutes,
+      and(
+        eq(feishuChatThreadRoutes.chatThreadId, chatEvents.chatThreadId),
+        eq(feishuChatThreadRoutes.connectionId, chatFeishuContext.connectionId),
+        eq(feishuChatThreadRoutes.chatId, chatFeishuContext.chatId),
+        eq(feishuChatThreadRoutes.userId, args.userId),
+      ),
+    )
+    .innerJoin(
+      feishuOrgConnections,
+      and(
+        eq(feishuOrgConnections.id, chatFeishuContext.connectionId),
+        eq(
+          feishuOrgConnections.installationId,
+          chatFeishuContext.installationId,
+        ),
+        eq(feishuOrgConnections.vm0UserId, args.userId),
+      ),
+    )
+    .innerJoin(
+      feishuOrgInstallations,
+      and(
+        eq(feishuOrgInstallations.id, chatFeishuContext.installationId),
+        eq(feishuOrgInstallations.orgId, args.orgId),
+      ),
+    )
+    .where(
+      and(
+        eq(chatEvents.id, args.eventId),
+        eq(chatEvents.chatThreadId, args.chatThreadId),
+        eq(chatEvents.contextType, "feishu"),
+        eq(chatEvents.triggerSource, "feishu"),
+      ),
+    )
+    .limit(1);
+  return requiredFeishuLaunchContext(row);
+}
+
+export async function loadFeishuQueuedLaunchMaterial(
+  db: Db,
+  args: {
+    readonly eventId: string;
+    readonly chatThreadId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+): Promise<FeishuQueuedLaunchMaterial | null> {
+  const context = await loadFeishuLaunchContext(db, args);
+  if (!context) {
+    return null;
+  }
+  return {
+    prompt: context.messageText,
+    appendSystemPrompt: buildFeishuSystemPrompt({
+      chatType: context.chatType,
+      installationId: context.installationId,
+      tenantKey: context.tenantKey,
+      chatId: context.chatId,
+      threadId: context.threadId,
+      messageId: context.messageId,
+      senderOpenId: context.senderOpenId,
+      history: context.conversationHistory,
+    }),
+    feishuDelivery: {
+      installationId: context.installationId,
+      connectionId: context.connectionId,
+      chatId: context.chatId,
+      messageId: context.messageId,
+      threadId: context.routeThreadId,
+      replyInThread: context.replyInThread,
+      ...(context.reactionId ? { reactionId: context.reactionId } : {}),
+      files: [...context.messageFiles],
+    },
+    userInfoExtras: {
+      ...(context.feishuDisplayName
+        ? { feishuDisplayName: context.feishuDisplayName }
+        : {}),
+      feishuOpenId: context.senderOpenId,
+    },
+  };
+}

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -170,6 +170,10 @@ import {
   loadSlackQueuedLaunchMaterial,
   type SlackQueuedLaunchMaterial,
 } from "./slack-queued-launch-context.service";
+import {
+  loadFeishuQueuedLaunchMaterial,
+  type FeishuQueuedLaunchMaterial,
+} from "./feishu-queued-launch-context.service";
 
 const log = logger("callback:chat");
 const PG_FOREIGN_KEY_VIOLATION = "23503";
@@ -2798,6 +2802,7 @@ function queuedMessageAdmissionFailure(
 function queuedIntegrationDeliveries(
   sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
   slackLaunchMaterial: SlackQueuedLaunchMaterial | null,
+  feishuLaunchMaterial: FeishuQueuedLaunchMaterial | null,
 ): Pick<
   CreateQueuedChatRunInput,
   | "slackDelivery"
@@ -2810,7 +2815,8 @@ function queuedIntegrationDeliveries(
 > {
   return {
     slackDelivery: slackLaunchMaterial?.slackDelivery,
-    feishuDelivery: sourceParams?.feishuDelivery,
+    feishuDelivery:
+      feishuLaunchMaterial?.feishuDelivery ?? sourceParams?.feishuDelivery,
     teamsDelivery: sourceParams?.teamsDelivery,
     telegramDelivery: sourceParams?.telegramDelivery,
     agentphoneDelivery: sourceParams?.agentphoneDelivery,
@@ -2837,9 +2843,36 @@ async function resolveSlackQueuedLaunchMaterial(
   throw new Error("Slack queue item is missing launch material");
 }
 
+async function resolveFeishuQueuedLaunchMaterial(
+  args: CreateQueuedChatRunInputArgs,
+  sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
+): Promise<FeishuQueuedLaunchMaterial | null> {
+  if (args.queuedMessage.triggerSource !== "feishu") {
+    return null;
+  }
+  const material = await loadFeishuQueuedLaunchMaterial(args.db, {
+    eventId: args.queuedMessage.id,
+    chatThreadId: args.threadId,
+    orgId: args.agent.orgId,
+    userId: args.userId,
+  });
+  if (material) {
+    return material;
+  }
+  if (
+    sourceParams?.prompt === undefined ||
+    sourceParams.appendSystemPrompt === undefined ||
+    !sourceParams.feishuDelivery
+  ) {
+    throw new Error("Feishu queue item is missing launch material");
+  }
+  return null;
+}
+
 function queuedMessagePrompt(args: {
   readonly triggerSource: QueuedUserMessage["triggerSource"];
   readonly slackLaunchMaterial: SlackQueuedLaunchMaterial | null;
+  readonly feishuLaunchMaterial: FeishuQueuedLaunchMaterial | null;
   readonly sourceParams: Awaited<
     ReturnType<typeof decryptQueuedUserMessageRunParams>
   >;
@@ -2851,6 +2884,9 @@ function queuedMessagePrompt(args: {
     }
     return args.slackLaunchMaterial.prompt;
   }
+  if (args.triggerSource === "feishu") {
+    return args.feishuLaunchMaterial?.prompt ?? args.sourceParams?.prompt ?? "";
+  }
   if (args.triggerSource === "workflow-schedule") {
     return args.sourceParams?.prompt ?? args.projectedPrompt;
   }
@@ -2860,6 +2896,7 @@ function queuedMessagePrompt(args: {
 function queuedIntegrationPrompt(args: {
   readonly triggerSource: QueuedUserMessage["triggerSource"];
   readonly slackLaunchMaterial: SlackQueuedLaunchMaterial | null;
+  readonly feishuLaunchMaterial: FeishuQueuedLaunchMaterial | null;
   readonly sourceParams: Awaited<
     ReturnType<typeof decryptQueuedUserMessageRunParams>
   >;
@@ -2869,6 +2906,13 @@ function queuedIntegrationPrompt(args: {
       throw new Error("Slack queue item is missing launch material");
     }
     return args.slackLaunchMaterial.appendSystemPrompt;
+  }
+  if (args.triggerSource === "feishu") {
+    return (
+      args.feishuLaunchMaterial?.appendSystemPrompt ??
+      args.sourceParams?.appendSystemPrompt ??
+      buildWebChatPrompt()
+    );
   }
   return args.sourceParams?.appendSystemPrompt ?? buildWebChatPrompt();
 }
@@ -2897,9 +2941,7 @@ function resolveQueuedMessageGenerationTemplatePrompt(args: {
   );
 }
 
-async function buildCreateQueuedChatRunInput(
-  args: CreateQueuedChatRunInputArgs,
-): Promise<CreateQueuedChatRunInput | QueuedMessageAdmissionFailure | null> {
+async function loadQueuedLaunchMaterials(args: CreateQueuedChatRunInputArgs) {
   const sourceParams = await decryptQueuedUserMessageRunParams(
     args.queuedMessage.encryptedParams,
     { orgId: args.agent.orgId, userId: args.userId },
@@ -2908,6 +2950,18 @@ async function buildCreateQueuedChatRunInput(
     throw new Error("Canonical integration queue item is missing run params");
   }
   const slackLaunchMaterial = await resolveSlackQueuedLaunchMaterial(args);
+  const feishuLaunchMaterial = await resolveFeishuQueuedLaunchMaterial(
+    args,
+    sourceParams,
+  );
+  return { sourceParams, slackLaunchMaterial, feishuLaunchMaterial };
+}
+
+async function buildCreateQueuedChatRunInput(
+  args: CreateQueuedChatRunInputArgs,
+): Promise<CreateQueuedChatRunInput | QueuedMessageAdmissionFailure | null> {
+  const { sourceParams, slackLaunchMaterial, feishuLaunchMaterial } =
+    await loadQueuedLaunchMaterials(args);
   const modelRouteResolution = await resolveQueuedMessageModelRoute({
     db: args.db,
     threadId: args.threadId,
@@ -2986,6 +3040,7 @@ async function buildCreateQueuedChatRunInput(
   const prompt = queuedMessagePrompt({
     triggerSource: args.queuedMessage.triggerSource,
     slackLaunchMaterial,
+    feishuLaunchMaterial,
     sourceParams,
     projectedPrompt: userMessageProjection.agentPrompt,
   });
@@ -2999,6 +3054,7 @@ async function buildCreateQueuedChatRunInput(
       queuedIntegrationPrompt({
         triggerSource: args.queuedMessage.triggerSource,
         slackLaunchMaterial,
+        feishuLaunchMaterial,
         sourceParams,
       }),
       incompleteContext,
@@ -3019,11 +3075,16 @@ async function buildCreateQueuedChatRunInput(
       FeatureSwitchKey.RealAgentInPreview,
       featureSwitchContext,
     ),
-    ...queuedIntegrationDeliveries(sourceParams, slackLaunchMaterial),
+    ...queuedIntegrationDeliveries(
+      sourceParams,
+      slackLaunchMaterial,
+      feishuLaunchMaterial,
+    ),
     apiStartTime: args.queuedMessage.createdAt.getTime(),
-    userInfoExtras: slackLaunchMaterial
-      ? slackLaunchMaterial.userInfoExtras
-      : sourceParams?.userInfoExtras,
+    userInfoExtras:
+      slackLaunchMaterial?.userInfoExtras ??
+      feishuLaunchMaterial?.userInfoExtras ??
+      sourceParams?.userInfoExtras,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-feishu-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-feishu-dispatch.service.ts
@@ -628,30 +628,31 @@ export async function loadFeishuConversationHistory(args: {
 }
 
 export function buildFeishuSystemPrompt(args: {
-  readonly message: FeishuInboundMessage;
+  readonly chatType: FeishuInboundMessage["chatType"];
+  readonly installationId: string;
+  readonly tenantKey: string;
+  readonly chatId: string;
+  readonly threadId: string;
+  readonly messageId: string;
+  readonly senderOpenId: string;
   readonly history: string;
 }): string {
-  const isDirectMessage = args.message.chatType === "p2p";
+  const isDirectMessage = args.chatType === "p2p";
   const typeLabel = isDirectMessage ? "Direct message" : "Group mention";
   const groupIdLine = isDirectMessage
     ? ""
-    : `Group ID: ${args.message.chatId} (same as Chat ID; use it directly as the \`--chat\` value for \`zero feishu message send\`)`;
+    : `Group ID: ${args.chatId} (same as Chat ID; use it directly as the \`--chat\` value for \`zero feishu message send\`)`;
   return [
     "# Current Integration",
     "You are currently running inside: Feishu",
     `Scope: ${typeLabel}`,
-    `Installation ID: ${args.message.installationId}`,
-    `Tenant key: ${args.message.tenantKey}`,
-    `Chat ID: ${args.message.chatId}`,
+    `Installation ID: ${args.installationId}`,
+    `Tenant key: ${args.tenantKey}`,
+    `Chat ID: ${args.chatId}`,
     groupIdLine,
-    `Thread ID: ${
-      args.message.threadId ??
-      args.message.rootId ??
-      args.message.parentId ??
-      args.message.messageId
-    }`,
-    `Message ID: ${args.message.messageId}`,
-    `Sender open ID: ${args.message.openId}`,
+    `Thread ID: ${args.threadId}`,
+    `Message ID: ${args.messageId}`,
+    `Sender open ID: ${args.senderOpenId}`,
     args.history,
   ]
     .filter(Boolean)

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -32,7 +32,11 @@ import {
 } from "../signals/services/zero-chat-event.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
-import { decryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
+import type { FeishuDeliveryTarget } from "../signals/services/feishu-chat-callback-payload";
+import {
+  decryptQueuedUserMessageRunParams,
+  encryptQueuedUserMessageRunParams,
+} from "../signals/services/zero-chat-queued-event.service";
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
@@ -490,6 +494,65 @@ export async function findPendingChatEventInputParamsByPromptFixture(
     });
   });
   return row ?? null;
+}
+
+export async function replaceFeishuLaunchMaterialWithLegacyParamsFixture(
+  eventId: string,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly prompt: string;
+    readonly appendSystemPrompt: string;
+    readonly feishuDelivery: FeishuDeliveryTarget;
+    readonly feishuDisplayName?: string;
+    readonly feishuOpenId: string;
+  },
+): Promise<void> {
+  const [event] = await db()
+    .select({ contextId: chatEvents.contextId })
+    .from(chatEvents)
+    .where(eq(chatEvents.id, eventId))
+    .limit(1);
+  if (!event?.contextId) {
+    throw new Error("Expected pending Feishu event context");
+  }
+  await db()
+    .update(chatFeishuContext)
+    .set({
+      conversationHistory: null,
+      messageText: null,
+      messageFiles: null,
+      chatType: null,
+      tenantKey: null,
+      chatId: null,
+      messageId: null,
+      threadId: null,
+      replyInThread: null,
+      reactionId: null,
+      senderOpenId: null,
+      connectionId: null,
+      installationId: null,
+    })
+    .where(eq(chatFeishuContext.id, event.contextId));
+  const encryptedParams = await encryptQueuedUserMessageRunParams(
+    {
+      version: 1,
+      prompt: args.prompt,
+      appendSystemPrompt: args.appendSystemPrompt,
+      feishuDelivery: args.feishuDelivery,
+      userInfoExtras: {
+        ...(args.feishuDisplayName
+          ? { feishuDisplayName: args.feishuDisplayName }
+          : {}),
+        feishuOpenId: args.feishuOpenId,
+      },
+    },
+    { orgId: args.orgId, userId: args.userId },
+  );
+  await db()
+    .update(chatEventInputParams)
+    .set({ encryptedParams })
+    .where(eq(chatEventInputParams.eventId, eventId));
 }
 
 /**


### PR DESCRIPTION
## Summary

- assemble Feishu prompt, system prompt, delivery target, and user info from `chat_events` and `chat_feishu_context` at claim time
- resolve the connection-level Feishu display name from `feishu_org_connections` and preserve the canonical reply route through `feishu_chat_thread_routes`
- stop writing Feishu launch material to `chat_event_input_params` while retaining a context-first legacy blob fallback
- cover direct messages, files, group mentions, history-load failure, reaction/reply behavior, the version-only placeholder, and legacy fallback

Part of #24450 (rollout PR 2 of 3).

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- targeted Prettier check

Per the issue instructions, local Vitest and the dev server were not run; PR CI is the test authority.