### PR TITLE
test(cli): remove completed connector ref assertions

### DIFF
--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/permission-request.test.ts
@@ -84,7 +84,6 @@ describe("zero connector permission-request command", () => {
     expect(logCalls).toContain("[Manage Slack permissions]");
     expect(logCalls).toContain("/agents/agent-abc-123/permissions?");
     expect(logCalls).toContain("connectorSlug=slack");
-    expect(logCalls).not.toContain("ref=");
     expect(logCalls).toContain(
       `permission=${encodeURIComponent(SLACK_READ_PERMISSION)}`,
     );
@@ -136,7 +135,6 @@ describe("zero connector permission-request command", () => {
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("connectorSlug=slack");
-    expect(logCalls).not.toContain("ref=");
     expect(logCalls).toContain("action=allow");
     expect(logCalls).toContain("threadId=thread-abc-123");
     expect(logCalls).toContain(


### PR DESCRIPTION
## Summary

- remove two migration-only negative assertions for the retired connector identity query parameter
- keep canonical `connectorSlug` command output coverage unchanged

## Scope

- test-only; no CLI runtime, API, schema, persisted data, Platform compatibility reader, or R2 changes

## Validation

- `pnpm format`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm knip --workspace @vm0/cli`
- `pnpm -F @vm0/cli exec vitest run --maxWorkers=1 src/commands/zero/connector/__tests__/permission-request.test.ts` (28 tests)

Closes #24463

Parent: #23619
