### PR TITLE
refactor: require feishu launch context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -33,7 +33,6 @@ import {
   findPendingChatEventInputParamsByPromptFixture,
   readChatEventContextFixture,
   readChatEventInputParamsFixture,
-  replaceFeishuLaunchMaterialWithLegacyParamsFixture,
 } from "../../../test-fixtures/chat-events";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { now } from "../../external/time";
@@ -3023,44 +3022,6 @@ describe("Feishu integration", () => {
         userId: secondActor.userId,
       }),
     ).resolves.toStrictEqual({ version: 1 });
-    const queuedFeishuContext = await readChatEventContextFixture(
-      queuedFeishuParams.eventId,
-    );
-    if (
-      !queuedFeishuContext?.feishuInstallationId ||
-      !queuedFeishuContext.feishuConnectionId ||
-      !queuedFeishuContext.feishuChatId ||
-      !queuedFeishuContext.feishuMessageId ||
-      queuedFeishuContext.feishuReplyInThread === null ||
-      !queuedFeishuContext.feishuSenderOpenId
-    ) {
-      throw new Error("Expected queued Feishu launch context");
-    }
-    const legacyPrompt = "legacy queued Feishu prompt";
-    const legacySystemPrompt = "legacy queued Feishu system prompt";
-    await replaceFeishuLaunchMaterialWithLegacyParamsFixture(
-      queuedFeishuParams.eventId,
-      {
-        orgId: secondOrgId,
-        userId: secondActor.userId,
-        prompt: legacyPrompt,
-        appendSystemPrompt: legacySystemPrompt,
-        feishuDelivery: {
-          installationId: queuedFeishuContext.feishuInstallationId,
-          connectionId: queuedFeishuContext.feishuConnectionId,
-          chatId: queuedFeishuContext.feishuChatId,
-          messageId: queuedFeishuContext.feishuMessageId,
-          threadId: firstMessageId,
-          replyInThread: queuedFeishuContext.feishuReplyInThread,
-          ...(queuedFeishuContext.feishuReactionId
-            ? { reactionId: queuedFeishuContext.feishuReactionId }
-            : {}),
-          files: [...(queuedFeishuContext.feishuMessageFiles ?? [])],
-        },
-        feishuDisplayName: "Canonical Group User",
-        feishuOpenId: queuedFeishuContext.feishuSenderOpenId,
-      },
-    );
     await runsApi.heartbeatRunner(runnerGroup);
     const firstClaim = await runsApi.claimRunnerJob(firstRun.id);
     const firstCliSessionId = `bdd-feishu-canonical-group-${firstRun.id}`;
@@ -3072,14 +3033,14 @@ describe("Feishu integration", () => {
       assistantText: "First canonical group answer",
     });
 
-    const secondRun = await findRun(secondActor, legacyPrompt);
+    const secondRun = await findRun(secondActor, secondPrompt);
     await expect(
       readChatEventInputParamsFixture(queuedFeishuParams.eventId),
     ).resolves.toBeNull();
     await runsApi.heartbeatRunner(runnerGroup);
     const secondClaim = await runsApi.claimRunnerJob(secondRun.id);
-    expect(secondClaim.prompt).toBe(legacyPrompt);
-    expect(secondClaim.appendSystemPrompt).toContain(legacySystemPrompt);
+    expect(secondClaim.prompt).toBe(secondPrompt);
+    expect(secondClaim.appendSystemPrompt).toContain("Scope: Group mention");
     expect(secondClaim.resumeSession?.sessionId).toBe(firstCliSessionId);
     await runsApi.requestCancelRun(secondActor, secondRun.id, [200]);
     await flushWaitUntilForTest();

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2815,8 +2815,7 @@ function queuedIntegrationDeliveries(
 > {
   return {
     slackDelivery: slackLaunchMaterial?.slackDelivery,
-    feishuDelivery:
-      feishuLaunchMaterial?.feishuDelivery ?? sourceParams?.feishuDelivery,
+    feishuDelivery: feishuLaunchMaterial?.feishuDelivery,
     teamsDelivery: sourceParams?.teamsDelivery,
     telegramDelivery: sourceParams?.telegramDelivery,
     agentphoneDelivery: sourceParams?.agentphoneDelivery,
@@ -2845,7 +2844,6 @@ async function resolveSlackQueuedLaunchMaterial(
 
 async function resolveFeishuQueuedLaunchMaterial(
   args: CreateQueuedChatRunInputArgs,
-  sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
 ): Promise<FeishuQueuedLaunchMaterial | null> {
   if (args.queuedMessage.triggerSource !== "feishu") {
     return null;
@@ -2859,14 +2857,7 @@ async function resolveFeishuQueuedLaunchMaterial(
   if (material) {
     return material;
   }
-  if (
-    sourceParams?.prompt === undefined ||
-    sourceParams.appendSystemPrompt === undefined ||
-    !sourceParams.feishuDelivery
-  ) {
-    throw new Error("Feishu queue item is missing launch material");
-  }
-  return null;
+  throw new Error("Feishu queue item is missing launch material");
 }
 
 function queuedMessagePrompt(args: {
@@ -2885,7 +2876,10 @@ function queuedMessagePrompt(args: {
     return args.slackLaunchMaterial.prompt;
   }
   if (args.triggerSource === "feishu") {
-    return args.feishuLaunchMaterial?.prompt ?? args.sourceParams?.prompt ?? "";
+    if (!args.feishuLaunchMaterial) {
+      throw new Error("Feishu queue item is missing launch material");
+    }
+    return args.feishuLaunchMaterial.prompt;
   }
   if (args.triggerSource === "workflow-schedule") {
     return args.sourceParams?.prompt ?? args.projectedPrompt;
@@ -2908,11 +2902,10 @@ function queuedIntegrationPrompt(args: {
     return args.slackLaunchMaterial.appendSystemPrompt;
   }
   if (args.triggerSource === "feishu") {
-    return (
-      args.feishuLaunchMaterial?.appendSystemPrompt ??
-      args.sourceParams?.appendSystemPrompt ??
-      buildWebChatPrompt()
-    );
+    if (!args.feishuLaunchMaterial) {
+      throw new Error("Feishu queue item is missing launch material");
+    }
+    return args.feishuLaunchMaterial.appendSystemPrompt;
   }
   return args.sourceParams?.appendSystemPrompt ?? buildWebChatPrompt();
 }
@@ -2950,10 +2943,7 @@ async function loadQueuedLaunchMaterials(args: CreateQueuedChatRunInputArgs) {
     throw new Error("Canonical integration queue item is missing run params");
   }
   const slackLaunchMaterial = await resolveSlackQueuedLaunchMaterial(args);
-  const feishuLaunchMaterial = await resolveFeishuQueuedLaunchMaterial(
-    args,
-    sourceParams,
-  );
+  const feishuLaunchMaterial = await resolveFeishuQueuedLaunchMaterial(args);
   return { sourceParams, slackLaunchMaterial, feishuLaunchMaterial };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -63,7 +63,6 @@ import {
   encryptPersistentSecretsMap,
 } from "./crypto.utils";
 import { noGoalChangeAfterQueueEvent } from "./chat-goal-queue.service";
-import { feishuOrgCallbackFileSchema } from "./feishu-org-callback-payload";
 import { agentphoneDeliveryTargetSchema } from "./agentphone-chat-callback-payload";
 import { githubDeliveryTargetSchema } from "./github-chat-callback-payload";
 import { teamsDeliveryTargetSchema } from "./teams-chat-callback-payload";
@@ -90,18 +89,6 @@ const queuedUserMessageRunParamsSchema = z.object({
   version: z.literal(1),
   prompt: z.string().optional(),
   appendSystemPrompt: z.string().optional(),
-  feishuDelivery: z
-    .object({
-      installationId: z.string(),
-      connectionId: z.string(),
-      chatId: z.string(),
-      messageId: z.string(),
-      threadId: z.string(),
-      replyInThread: z.boolean(),
-      reactionId: z.string().optional(),
-      files: z.array(feishuOrgCallbackFileSchema).optional(),
-    })
-    .optional(),
   teamsDelivery: teamsDeliveryTargetSchema.optional(),
   telegramDelivery: telegramDeliveryTargetSchema.optional(),
   agentphoneDelivery: agentphoneDeliveryTargetSchema.optional(),
@@ -118,8 +105,6 @@ const queuedUserMessageRunParamsSchema = z.object({
     .object({
       slackDisplayName: z.string().optional(),
       slackUserId: z.string().optional(),
-      feishuDisplayName: z.string().optional(),
-      feishuOpenId: z.string().optional(),
       teamsUserDisplayName: z.string().optional(),
       teamsUserPrincipalName: z.string().optional(),
       teamsUserId: z.string().optional(),

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -32,11 +32,7 @@ import {
 } from "../signals/services/zero-chat-event.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
-import type { FeishuDeliveryTarget } from "../signals/services/feishu-chat-callback-payload";
-import {
-  decryptQueuedUserMessageRunParams,
-  encryptQueuedUserMessageRunParams,
-} from "../signals/services/zero-chat-queued-event.service";
+import { decryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
@@ -494,65 +490,6 @@ export async function findPendingChatEventInputParamsByPromptFixture(
     });
   });
   return row ?? null;
-}
-
-export async function replaceFeishuLaunchMaterialWithLegacyParamsFixture(
-  eventId: string,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly prompt: string;
-    readonly appendSystemPrompt: string;
-    readonly feishuDelivery: FeishuDeliveryTarget;
-    readonly feishuDisplayName?: string;
-    readonly feishuOpenId: string;
-  },
-): Promise<void> {
-  const [event] = await db()
-    .select({ contextId: chatEvents.contextId })
-    .from(chatEvents)
-    .where(eq(chatEvents.id, eventId))
-    .limit(1);
-  if (!event?.contextId) {
-    throw new Error("Expected pending Feishu event context");
-  }
-  await db()
-    .update(chatFeishuContext)
-    .set({
-      conversationHistory: null,
-      messageText: null,
-      messageFiles: null,
-      chatType: null,
-      tenantKey: null,
-      chatId: null,
-      messageId: null,
-      threadId: null,
-      replyInThread: null,
-      reactionId: null,
-      senderOpenId: null,
-      connectionId: null,
-      installationId: null,
-    })
-    .where(eq(chatFeishuContext.id, event.contextId));
-  const encryptedParams = await encryptQueuedUserMessageRunParams(
-    {
-      version: 1,
-      prompt: args.prompt,
-      appendSystemPrompt: args.appendSystemPrompt,
-      feishuDelivery: args.feishuDelivery,
-      userInfoExtras: {
-        ...(args.feishuDisplayName
-          ? { feishuDisplayName: args.feishuDisplayName }
-          : {}),
-        feishuOpenId: args.feishuOpenId,
-      },
-    },
-    { orgId: args.orgId, userId: args.userId },
-  );
-  await db()
-    .update(chatEventInputParams)
-    .set({ encryptedParams })
-    .where(eq(chatEventInputParams.eventId, eventId));
 }
 
 /**


### PR DESCRIPTION
## Summary

- remove the drained Feishu prompt, system prompt, delivery, and user-info fallback from `chat_event_input_params`
- require queued Feishu claims to assemble launch material from `chat_events` and `chat_feishu_context`
- remove the legacy fallback fixture while retaining coverage that queued Feishu params contain only the version placeholder and are deleted after claim

Closes #24450 (rollout PR 3 of 3).

## Drain gate

- rollout PR #24455 added and dual-wrote the Feishu launch context
- rollout PR #24461 switched claims to context-first reads and stopped writing launch material to the encrypted blob
- a read-only MaskDB check against `vm0-prod-ro` found 0 total Feishu trigger events and 0 unclaimed Feishu `input.prompt` originals; a Slack control query returned 105 historical originals, confirming the database and filter path
- therefore there are no historical pending Feishu events requiring a run replacement or revocation, and the real old-format unclaimed backlog is 0

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- targeted Prettier write/check

Per the issue instructions, local Vitest and the dev server were not run; PR CI is the test authority.