### PR TITLE
fix(guest-agent): ignore secondary codex thread events

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -23,7 +23,7 @@ use super::codex_app_server::{
 };
 use super::codex_app_server_events::{
     CodexOutputItemKind, CodexOutputItemStart, IGNORED_NOTIFICATION_METHODS,
-    codex_output_item_start, notification_to_codex_event,
+    codex_output_item_start, notification_thread_id, notification_to_codex_event,
 };
 use super::event_delivery::{EventDeliveryRuntime, EventDeliverySender};
 use super::{
@@ -42,12 +42,16 @@ const API_TO_CODEX_AGENT_MESSAGE_ITEM_STARTED: &str = "api_to_codex_agent_messag
 
 struct NotificationIngestResult {
     emitted_thread_started: bool,
+    active_input_ready: bool,
+    terminal_exit_code: Option<i32>,
 }
 
+#[derive(Default)]
 struct PreparedNotificationIngest {
     event: Option<Value>,
     output_item_start: Option<CodexOutputItemStart>,
     emitted_thread_started: bool,
+    active_input_ready: bool,
     terminal_exit_code: Option<i32>,
 }
 
@@ -217,6 +221,7 @@ async fn run_codex_app_server(
         let thread_identity = thread_identity_from_response(&thread_response)?;
         validate_resumed_thread_id(&thread_identity.canonical_id, resume_thread_id.as_deref())?;
         let mut thread_started_emitted = false;
+        let mut secondary_thread_notification_logged = false;
 
         while let Some(notification) = client.pop_notification() {
             let mut sink = EventIngestSink {
@@ -234,6 +239,7 @@ async fn run_codex_app_server(
                 &thread_identity.canonical_id,
                 "",
                 None,
+                &mut secondary_thread_notification_logged,
             )
             .await?;
             thread_started_emitted = thread_started_emitted || ingest_result.emitted_thread_started;
@@ -295,19 +301,18 @@ async fn run_codex_app_server(
                         thread_id: &thread_identity.canonical_id,
                         turn_id: &turn_id,
                     };
-                    let notification_ready_for_active_input =
-                        is_active_input_ready_notification(&notification, &turn_id);
-                    let terminal_exit_code = ingest_run_notification(
+                    let ingest_result = ingest_run_notification(
                         notification,
                         &mut sink,
                         &active_input,
                         &mut thread_started_emitted,
                         &notification_scope,
+                        &mut secondary_thread_notification_logged,
                     )
                     .await?;
                     turn_started_observed =
-                        turn_started_observed || notification_ready_for_active_input;
-                    if let Some(exit_code) = terminal_exit_code {
+                        turn_started_observed || ingest_result.active_input_ready;
+                    if let Some(exit_code) = ingest_result.terminal_exit_code {
                         active_input.close_terminal();
                         break exit_code;
                     }
@@ -345,6 +350,7 @@ async fn run_codex_app_server(
                         &active_input,
                         &mut thread_started_emitted,
                         &notification_scope,
+                        &mut secondary_thread_notification_logged,
                     )
                     .await?
                     {
@@ -647,16 +653,6 @@ fn can_read_active_input(active_input_open: bool, active_input_ready: bool) -> b
     active_input_open && active_input_ready
 }
 
-fn is_active_input_ready_notification(notification: &ServerNotification, turn_id: &str) -> bool {
-    notification.method == "turn/started"
-        && notification
-            .params
-            .as_ref()
-            .and_then(|params| params.pointer("/turn/id"))
-            .and_then(Value::as_str)
-            == Some(turn_id)
-}
-
 async fn steer_active_input(
     client: &mut CodexAppServerClient,
     active_input: &ActiveInputWriter,
@@ -744,6 +740,7 @@ async fn drain_queued_notifications(
     active_input: &ActiveInputWriter,
     thread_started_emitted: &mut bool,
     scope: &CodexTurnScope<'_>,
+    secondary_thread_notification_logged: &mut bool,
 ) -> Result<Option<i32>, AgentError> {
     let mut prepared_notifications = Vec::new();
     let mut prepared_thread_started_emitted = *thread_started_emitted;
@@ -753,6 +750,7 @@ async fn drain_queued_notifications(
             prepared_thread_started_emitted,
             scope.thread_id,
             scope.turn_id,
+            secondary_thread_notification_logged,
         )?;
         prepared_thread_started_emitted =
             prepared_thread_started_emitted || prepared.emitted_thread_started;
@@ -782,12 +780,14 @@ async fn ingest_run_notification(
     active_input: &ActiveInputWriter,
     thread_started_emitted: &mut bool,
     scope: &CodexTurnScope<'_>,
-) -> Result<Option<i32>, AgentError> {
+    secondary_thread_notification_logged: &mut bool,
+) -> Result<NotificationIngestResult, AgentError> {
     let prepared = prepare_notification_ingest(
         notification,
         *thread_started_emitted,
         scope.thread_id,
         scope.turn_id,
+        secondary_thread_notification_logged,
     )?;
     record_output_item_start(prepared.output_item_start.as_ref(), sink);
     // Close before any ingest await so the control path cannot accept input
@@ -795,12 +795,16 @@ async fn ingest_run_notification(
     if prepared.terminal_exit_code.is_some() {
         active_input.close_terminal();
     }
-    let terminal_exit_code = prepared.terminal_exit_code;
+    let result = NotificationIngestResult {
+        emitted_thread_started: prepared.emitted_thread_started,
+        active_input_ready: prepared.active_input_ready,
+        terminal_exit_code: prepared.terminal_exit_code,
+    };
     if let Some(event) = prepared.event {
         ingest_event(event, sink).await?;
     }
     *thread_started_emitted = *thread_started_emitted || prepared.emitted_thread_started;
-    Ok(terminal_exit_code)
+    Ok(result)
 }
 
 fn app_server_error(masker: &SecretMasker, error: impl std::fmt::Display) -> AgentError {
@@ -838,12 +842,14 @@ async fn ingest_notification(
     expected_thread_id: &str,
     active_turn_id: &str,
     terminal_active_input: Option<&ActiveInputWriter>,
+    secondary_thread_notification_logged: &mut bool,
 ) -> Result<NotificationIngestResult, AgentError> {
     let prepared = prepare_notification_ingest(
         notification,
         thread_started_emitted,
         expected_thread_id,
         active_turn_id,
+        secondary_thread_notification_logged,
     )?;
     record_output_item_start(prepared.output_item_start.as_ref(), sink);
     if prepared.terminal_exit_code.is_some()
@@ -851,12 +857,15 @@ async fn ingest_notification(
     {
         active_input.close_terminal();
     }
+    let result = NotificationIngestResult {
+        emitted_thread_started: prepared.emitted_thread_started,
+        active_input_ready: prepared.active_input_ready,
+        terminal_exit_code: prepared.terminal_exit_code,
+    };
     if let Some(event) = prepared.event {
         ingest_event(event, sink).await?;
     }
-    Ok(NotificationIngestResult {
-        emitted_thread_started: prepared.emitted_thread_started,
-    })
+    Ok(result)
 }
 
 fn prepare_notification_ingest(
@@ -864,7 +873,22 @@ fn prepare_notification_ingest(
     thread_started_emitted: bool,
     expected_thread_id: &str,
     active_turn_id: &str,
+    secondary_thread_notification_logged: &mut bool,
 ) -> Result<PreparedNotificationIngest, AgentError> {
+    if let Some(secondary_thread_id) =
+        secondary_notification_thread_id(&notification, expected_thread_id)
+    {
+        if !*secondary_thread_notification_logged {
+            log_info!(
+                LOG_TAG,
+                "Ignoring codex app-server notification for secondary thread: method={} thread_id={secondary_thread_id}",
+                notification.method
+            );
+            *secondary_thread_notification_logged = true;
+        }
+        return Ok(PreparedNotificationIngest::default());
+    }
+
     let output_item_start = codex_output_item_start(&notification)
         .map_err(|error| AgentError::Execution(error.to_string()))?;
     if let Some(start) = &output_item_start {
@@ -879,29 +903,37 @@ fn prepare_notification_ingest(
         .map_err(|error| AgentError::Execution(error.to_string()))?
     else {
         return Ok(PreparedNotificationIngest {
-            event: None,
             output_item_start,
-            emitted_thread_started: false,
-            terminal_exit_code: None,
+            ..PreparedNotificationIngest::default()
         });
     };
     validate_event_scope(&event, expected_thread_id, active_turn_id)?;
     if is_duplicate_thread_started(&event, thread_started_emitted, expected_thread_id) {
         return Ok(PreparedNotificationIngest {
-            event: None,
             output_item_start,
-            emitted_thread_started: false,
-            terminal_exit_code: None,
+            ..PreparedNotificationIngest::default()
         });
     }
     let emitted_thread_started = is_thread_started_event(&event, expected_thread_id);
+    let active_input_ready = is_turn_started_event(&event);
     let terminal_exit_code = terminal_exit_code(&event, expected_thread_id, active_turn_id);
     Ok(PreparedNotificationIngest {
         event: Some(event),
         output_item_start,
         emitted_thread_started,
+        active_input_ready,
         terminal_exit_code,
     })
+}
+
+fn secondary_notification_thread_id(
+    notification: &ServerNotification,
+    expected_canonical_thread_id: &str,
+) -> Option<String> {
+    let canonical_thread_id = guest_contracts::codex_thread_id::canonical_codex_thread_id(
+        notification_thread_id(notification)?,
+    )?;
+    (canonical_thread_id != expected_canonical_thread_id).then_some(canonical_thread_id)
 }
 
 fn validate_event_scope(
@@ -1018,6 +1050,10 @@ fn is_thread_started_event(event: &Value, expected_canonical_thread_id: &str) ->
             .is_some_and(|thread_id| {
                 thread_id_matches_canonical(thread_id, expected_canonical_thread_id)
             })
+}
+
+fn is_turn_started_event(event: &Value) -> bool {
+    event.get("type").and_then(Value::as_str) == Some("turn.started")
 }
 
 fn terminal_exit_code(
@@ -1149,51 +1185,6 @@ mod tests {
         assert!(!can_read_active_input(false, true));
         assert!(!can_read_active_input(true, false));
         assert!(can_read_active_input(true, true));
-    }
-
-    #[test]
-    fn turn_started_notification_enables_active_input_for_matching_turn() {
-        let matching_notification = ServerNotification {
-            method: "turn/started".to_string(),
-            params: Some(json!({
-                "threadId": "thread-1",
-                "turn": {
-                    "id": "turn-1",
-                    "status": "inProgress"
-                }
-            })),
-        };
-        let wrong_turn_notification = ServerNotification {
-            method: "turn/started".to_string(),
-            params: Some(json!({
-                "threadId": "thread-1",
-                "turn": {
-                    "id": "turn-2",
-                    "status": "inProgress"
-                }
-            })),
-        };
-        let thread_started_notification = ServerNotification {
-            method: "thread/started".to_string(),
-            params: Some(json!({
-                "thread": {
-                    "id": "thread-1"
-                }
-            })),
-        };
-
-        assert!(is_active_input_ready_notification(
-            &matching_notification,
-            "turn-1"
-        ));
-        assert!(!is_active_input_ready_notification(
-            &wrong_turn_notification,
-            "turn-1"
-        ));
-        assert!(!is_active_input_ready_notification(
-            &thread_started_notification,
-            "turn-1"
-        ));
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -106,6 +106,17 @@ pub(super) enum CodexAppServerEventError {
     InvalidField { method: String, field: &'static str },
 }
 
+pub(super) fn notification_thread_id(notification: &ServerNotification) -> Option<&str> {
+    let params = notification.params.as_ref()?;
+    let thread_id = match notification.method.as_str() {
+        "thread/started" => params.pointer("/thread/id"),
+        "turn/started" | "turn/completed" | "turn/plan/updated" | "item/started"
+        | "item/completed" | "error" | "warning" => params.get("threadId"),
+        _ => None,
+    }?;
+    thread_id.as_str().filter(|thread_id| !thread_id.is_empty())
+}
+
 pub(super) fn codex_output_item_start(
     notification: &ServerNotification,
 ) -> Result<Option<CodexOutputItemStart>, CodexAppServerEventError> {

--- a/crates/guest-agent/tests/codex_app_server_backend_secondary_thread.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_secondary_thread.rs
@@ -1,0 +1,110 @@
+//! Secondary-thread notification coverage for the experimental Codex app-server backend.
+//!
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
+
+mod common;
+
+use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
+use guest_agent::masker::SecretMasker;
+use serde_json::Value;
+use std::time::Duration;
+
+const SECONDARY_THREAD_ID: &str = "00000000-0000-4000-8000-000000000def";
+const SECONDARY_NOTIFICATION_LOG: &str =
+    "Ignoring codex app-server notification for secondary thread";
+
+#[tokio::test]
+async fn codex_app_server_backend_ignores_secondary_thread_notifications()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+
+    unsafe {
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-secondary-thread-test",
+                prompt: "ignore multiplexed secondary thread notifications",
+                scenario: Some("secondary-thread-notifications"),
+                resume_session_id: None,
+            },
+        )?;
+        std::env::set_var("VM0_API_START_TIME", "1699999999000");
+    }
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+
+    let active_input = ActiveInputRuntime::new_with_initial_prompt(
+        &runtime.config.run_id,
+        true,
+        &runtime.config.prompt,
+    );
+    let payload = common::active_input_payload("must wait for the top-level turn")?;
+    assert_eq!(
+        active_input
+            .controller()
+            .handle_control_payload("secondary-thread-active-input", &payload),
+        ActiveInputControlOutcome::Accepted
+    );
+
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        common::execute_cli_with_active_input_for_runtime(
+            &runtime,
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            active_input.into_writer(),
+        ),
+    )
+    .await
+    .expect("execute_cli_with_active_input should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
+    assert!(cli_result.failure_diagnostic.is_none());
+
+    let input_events = common::read_codex_session_history_events_for_paths(&runtime.paths)?
+        .into_iter()
+        .filter(|event| event.get("type").and_then(Value::as_str) == Some("mock.app_server.input"))
+        .collect::<Vec<_>>();
+    assert_eq!(input_events.len(), 1);
+    assert_eq!(input_events[0]["kind"], "initial");
+
+    let events = read_jsonl(runtime.paths.agent_log_file())?;
+    let event_types = events
+        .iter()
+        .filter_map(|event| event.get("type").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        event_types,
+        [
+            "thread.started",
+            "warning",
+            "item.completed",
+            "turn.completed"
+        ]
+    );
+    assert!(events.iter().all(|event| {
+        event.get("thread_id").and_then(Value::as_str) != Some(SECONDARY_THREAD_ID)
+    }));
+
+    let sandbox_ops = std::fs::read_to_string(runtime.paths.sandbox_ops_file()).unwrap_or_default();
+    assert!(!sandbox_ops.contains("api_to_codex_output_item_started"));
+    assert!(!sandbox_ops.contains("api_to_codex_agent_message_item_started"));
+
+    let system_log = std::fs::read_to_string(runtime.paths.system_log_file())?;
+    assert_eq!(system_log.matches(SECONDARY_NOTIFICATION_LOG).count(), 1);
+    assert!(system_log.contains("method=thread/started"));
+    assert!(system_log.contains(SECONDARY_THREAD_ID));
+
+    Ok(())
+}
+
+fn read_jsonl(path: &str) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    std::fs::read_to_string(path)?
+        .lines()
+        .map(|line| serde_json::from_str(line).map_err(Into::into))
+        .collect()
+}

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -1,4 +1,5 @@
 use super::messages::{
+    agent_message_item_started_notification, assistant_item_completed_notification,
     initialize_response, large_server_notification, large_warning_notification,
     reasoning_item_started_notification, server_notification, server_notification_with_index,
     server_request, thread_response, thread_started_notification, turn,
@@ -19,6 +20,8 @@ const OVERSIZED_STDOUT_BYTES: usize = 65 * 1024 * 1024;
 const EVENT_DELIVERY_FLOOD_COUNT: usize = 640;
 const EVENT_DELIVERY_LARGE_EVENT_COUNT: usize = 10;
 const EVENT_DELIVERY_LARGE_EVENT_BYTES: usize = 2 * 1024 * 1024;
+const SECONDARY_THREAD_ID: &str = "00000000-0000-4000-8000-000000000def";
+const SECONDARY_ITEM_STARTED_AT_MS: u64 = 1_700_000_000_000;
 
 impl AppServerState {
     pub(super) fn handle_initialize<W: Write>(
@@ -145,7 +148,7 @@ impl AppServerState {
                 )?;
                 write_success(output, id, result)?;
             }
-            Scenario::RuntimeTurnComplete => {
+            Scenario::RuntimeTurnComplete | Scenario::SecondaryThreadNotifications => {
                 write_json_line(output, &thread_started_notification(&thread_id))?;
                 write_success(output, id, result)?;
             }
@@ -302,6 +305,10 @@ impl AppServerState {
                 &turn_completed_notification("unexpected-thread-id", &turn_id),
             )?;
             return Ok(ServerAction::Stop);
+        }
+        if self.scenario == Scenario::SecondaryThreadNotifications {
+            write_secondary_thread_notifications(output, &thread_id, &turn_id)?;
+            return Ok(ServerAction::Continue);
         }
         if self.scenario.writes_turn_started_before_steer() {
             if let Some(current_thread) = &mut self.current_thread
@@ -477,6 +484,42 @@ impl AppServerState {
         write_success(output, id, json!({ "completed": true }))?;
         Ok(ServerAction::Continue)
     }
+}
+
+fn write_secondary_thread_notifications<W: Write>(
+    output: &mut W,
+    thread_id: &str,
+    turn_id: &str,
+) -> io::Result<()> {
+    write_json_line(output, &thread_started_notification(SECONDARY_THREAD_ID))?;
+    write_json_line(output, &warning_notification(thread_id, 0))?;
+    write_json_line(
+        output,
+        &turn_started_notification(SECONDARY_THREAD_ID, turn_id),
+    )?;
+    write_json_line(
+        output,
+        &agent_message_item_started_notification(
+            SECONDARY_THREAD_ID,
+            turn_id,
+            "secondary-agent-message-item",
+            SECONDARY_ITEM_STARTED_AT_MS,
+        ),
+    )?;
+    write_json_line(
+        output,
+        &assistant_item_completed_notification(thread_id, turn_id),
+    )?;
+    write_json_line(output, &warning_notification(SECONDARY_THREAD_ID, 1))?;
+    write_json_line(
+        output,
+        &assistant_item_completed_notification(SECONDARY_THREAD_ID, turn_id),
+    )?;
+    write_json_line(
+        output,
+        &turn_completed_notification(SECONDARY_THREAD_ID, turn_id),
+    )?;
+    write_json_line(output, &turn_completed_notification(thread_id, turn_id))
 }
 
 fn validate_initialize_params(params: &Value) -> Result<(), &'static str> {

--- a/crates/guest-mock-codex/src/app_server/messages.rs
+++ b/crates/guest-mock-codex/src/app_server/messages.rs
@@ -124,7 +124,7 @@ pub(super) fn agent_message_item_started_notification(
     })
 }
 
-fn assistant_item_completed_notification(thread_id: &str, turn_id: &str) -> Value {
+pub(super) fn assistant_item_completed_notification(thread_id: &str, turn_id: &str) -> Value {
     json!({
         "method": "item/completed",
         "params": {

--- a/crates/guest-mock-codex/src/app_server/scenario.rs
+++ b/crates/guest-mock-codex/src/app_server/scenario.rs
@@ -40,6 +40,7 @@ pub(super) enum Scenario {
     UnexpectedThreadOutputItemStarted,
     UnexpectedTurnOutputItemStarted,
     UnexpectedThreadTurnCompleted,
+    SecondaryThreadNotifications,
 }
 
 impl Scenario {
@@ -96,6 +97,7 @@ impl Scenario {
                 }
                 "unexpected-turn-output-item-started" => Ok(Self::UnexpectedTurnOutputItemStarted),
                 "unexpected-thread-turn-completed" => Ok(Self::UnexpectedThreadTurnCompleted),
+                "secondary-thread-notifications" => Ok(Self::SecondaryThreadNotifications),
                 _ => Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     format!("unsupported MOCK_CODEX_APP_SERVER_SCENARIO={value:?}"),


### PR DESCRIPTION
## Summary

- Ignore supported Codex app-server notifications that belong to a valid secondary thread before they can affect the active run's events, output timing, terminal state, or active-input readiness.
- Keep strict validation for the active thread, malformed thread identifiers, and mismatched active turn identifiers, while logging the first ignored secondary-thread notification once per run.
- Add an integration scenario that interleaves parent and secondary thread events and verifies the parent run completes without leaking child events or enabling steering from a child `turn/started` event.

## Scope

- This does not expose or route subagent activity as separate vm0 runs.
- This does not relax protocol validation for notifications attributed to the active thread.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent -p guest-mock-codex --all-targets --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p guest-agent --all-features --quiet`
- `cargo test -p guest-agent --test codex_app_server_backend_secondary_thread --all-features`
- `cargo test -p guest-agent --test codex_app_server_backend_scope --test codex_app_server_backend_output_timing_stale_scope --all-features`

Closes #24462
