### PR TITLE
refactor(connectors): finish local slug terminology cleanup

### DIFF
--- a/crates/runner/mitm-addon/tests/test_firewall_network_policy_decisions.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_network_policy_decisions.py
@@ -120,7 +120,7 @@ class TestFirewallNetworkPolicyDecisions:
         assert result.reason == "permission_denied"
 
     def test_unknown_policy_key_missing_defaults_to_allow(self):
-        """Ref present but unknownPolicy key absent → defaults to allow."""
+        """Firewall name present but unknownPolicy key absent defaults to allow."""
         policies = {"github": {"allow": ["repo-read"], "deny": ["repo-write"]}}
         result = match_request_with_raw_firewalls(
             "https://api.github.com/users/octocat",

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -222,8 +222,8 @@ impl Firewall {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct FirewallApi {
     /// Stable API identifier used as one component of mitm-addon auth cache keys.
-    /// Filled by the Python registry loader after built-in refs and inline firewalls
-    /// are resolved.
+    /// Filled by the Python registry loader after built-in catalog entries and
+    /// inline firewalls are resolved.
     #[serde(default)]
     pub id: String,
     pub base: String,
@@ -1108,7 +1108,7 @@ impl FirewallAwsSigv4Auth {
 
 /// Per-firewall grant configuration: which permissions are authorized and
 /// what policy applies to unknown endpoints (not matching any rule).
-/// Refs absent from the map are fully permissive (all granted + allow unknown).
+/// Firewall names absent from the map are fully permissive (all granted + allow unknown).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NetworkPolicy {

--- a/turbo/apps/platform/src/views/onboarding/onboarding-connectors.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-connectors.tsx
@@ -30,18 +30,20 @@ function parseConnectorSlugs(values: readonly string[]): ConnectorSlug[] {
 }
 
 export function OnboardingConnectorSetup({
-  connectorIds,
-  requiredIds,
+  connectorSlugs,
+  requiredConnectorSlugs,
   variant = "workflow",
   children,
 }: {
-  readonly connectorIds: readonly string[];
-  readonly requiredIds?: readonly string[];
+  readonly connectorSlugs: readonly string[];
+  readonly requiredConnectorSlugs?: readonly string[];
   readonly variant?: ConnectorSetupVariant;
   readonly children?: ReactNode;
 }) {
-  const connectorSlugs = parseConnectorSlugs(connectorIds);
-  const requiredSet = new Set(parseConnectorSlugs(requiredIds ?? []));
+  const validConnectorSlugs = parseConnectorSlugs(connectorSlugs);
+  const requiredSet = new Set(
+    parseConnectorSlugs(requiredConnectorSlugs ?? []),
+  );
   const pageSignal = useGet(pageSignal$);
   const connectorCatalogItemsLoadable = useLastLoadable(
     allConnectorCatalogItems$,
@@ -55,7 +57,7 @@ export function OnboardingConnectorSetup({
   const pollingDeviceAuthSlug = useGet(pollingOAuthDeviceAuthConnectorSlug$);
   const justConnectedSlugs = useGet(justConnectedSlugs$);
 
-  if (connectorSlugs.length === 0 && children === undefined) {
+  if (validConnectorSlugs.length === 0 && children === undefined) {
     return null;
   }
 
@@ -74,7 +76,7 @@ export function OnboardingConnectorSetup({
             : "mt-6 flex flex-col gap-3",
         )}
       >
-        {connectorSlugs.map((connectorSlug) => {
+        {validConnectorSlugs.map((connectorSlug) => {
           const item = connectorCatalogItems.find((candidate) => {
             return candidate.slug === connectorSlug;
           });

--- a/turbo/apps/platform/src/views/onboarding/onboarding-data.ts
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-data.ts
@@ -1,4 +1,5 @@
 import { WORKFLOW_TEMPLATE_ITEMS, type WorkflowTemplateItem } from "@vm0/core";
+import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import type { TFunction } from "i18next";
 import type { OnboardingChoice } from "../../signals/onboarding/onboarding-state.ts";
 
@@ -66,8 +67,8 @@ export interface OnboardingWorkflow {
   readonly title: string;
   readonly description: string;
   readonly prompt: string;
-  readonly connectors: readonly string[];
-  readonly required: readonly string[];
+  readonly connectorSlugs: readonly ConnectorSlug[];
+  readonly requiredConnectorSlugs: readonly ConnectorSlug[];
   readonly scenario: string;
   readonly detailSteps: readonly { title: string; description: string }[];
 }
@@ -82,7 +83,7 @@ export interface OnboardingWorkflowCategory {
 interface WorkflowPromptTemplate {
   readonly id: WorkflowTemplateItem["id"];
   readonly promptGuidance: string;
-  readonly connectors: readonly string[];
+  readonly connectorSlugs: readonly ConnectorSlug[];
 }
 
 interface SupplementalWorkflowTemplate extends WorkflowPromptTemplate {
@@ -92,19 +93,21 @@ interface SupplementalWorkflowTemplate extends WorkflowPromptTemplate {
 function supplementalWorkflowTemplate(input: {
   readonly id: string;
   readonly prompt: string;
-  readonly connectors: readonly string[];
-  readonly required: readonly string[];
+  readonly connectorSlugs: readonly ConnectorSlug[];
+  readonly requiredConnectorSlugs: readonly ConnectorSlug[];
 }): SupplementalWorkflowTemplate {
-  const optional = input.connectors.filter((connector) => {
-    return !input.required.includes(connector);
-  });
+  const optionalConnectorSlugs = input.connectorSlugs.filter(
+    (connectorSlug) => {
+      return !input.requiredConnectorSlugs.includes(connectorSlug);
+    },
+  );
   const connectorLine =
-    optional.length > 0
-      ? `Connectors: ${input.required.join(", ")} required; ${optional.join(", ")} optional.`
-      : `Connectors: ${input.required.join(", ")} required.`;
+    optionalConnectorSlugs.length > 0
+      ? `Connectors: ${input.requiredConnectorSlugs.join(", ")} required; ${optionalConnectorSlugs.join(", ")} optional.`
+      : `Connectors: ${input.requiredConnectorSlugs.join(", ")} required.`;
   return {
     id: `workflow-template:${input.id}`,
-    connectors: input.connectors,
+    connectorSlugs: input.connectorSlugs,
     promptGuidance: `${input.prompt}\n\n${connectorLine} Connect any missing required connectors before running.`,
   };
 }
@@ -115,57 +118,63 @@ const SUPPLEMENTAL_WORKFLOW_TEMPLATES: readonly SupplementalWorkflowTemplate[] =
       id: "watch-sentry-after-release",
       prompt:
         "@Zero compare the latest release's crash-free rate in Sentry against the previous baseline and tell #dev whether it regressed, with a rollback suggestion if it did.",
-      connectors: ["sentry", "github", "vercel", "slack"],
-      required: ["sentry", "slack"],
+      connectorSlugs: ["sentry", "github", "vercel", "slack"],
+      requiredConnectorSlugs: ["sentry", "slack"],
     }),
     supplementalWorkflowTemplate({
       id: "post-github-updates-slack",
       prompt:
         "@Zero compile my merged and in-progress work from GitHub and Linear into a short progress update and post it to Slack.",
-      connectors: ["github", "linear", "sentry", "slack"],
-      required: ["github", "slack"],
+      connectorSlugs: ["github", "linear", "sentry", "slack"],
+      requiredConnectorSlugs: ["github", "slack"],
     }),
     supplementalWorkflowTemplate({
       id: "report-ai-model-costs-slack",
       prompt:
         "@Zero report today's LLM token spend and p95 latency per model and route from Langfuse and post it to Slack.",
-      connectors: ["langfuse", "slack"],
-      required: ["langfuse", "slack"],
+      connectorSlugs: ["langfuse", "slack"],
+      requiredConnectorSlugs: ["langfuse", "slack"],
     }),
     supplementalWorkflowTemplate({
       id: "summarize-user-feedback-notion",
       prompt:
         "@Zero gather recent user feedback from Productlane, Typeform, Intercom, and GitHub, cluster it into themes, and write a ranked summary in Notion.",
-      connectors: ["productlane", "typeform", "intercom", "github", "notion"],
-      required: ["notion"],
+      connectorSlugs: [
+        "productlane",
+        "typeform",
+        "intercom",
+        "github",
+        "notion",
+      ],
+      requiredConnectorSlugs: ["notion"],
     }),
     supplementalWorkflowTemplate({
       id: "watch-brand-mentions",
       prompt:
         "@Zero search the web, Hacker News, and X for recent mentions of our product and post them to Slack.",
-      connectors: ["exa", "x", "slack"],
-      required: ["exa", "slack"],
+      connectorSlugs: ["exa", "x", "slack"],
+      requiredConnectorSlugs: ["exa", "slack"],
     }),
     supplementalWorkflowTemplate({
       id: "sort-route-zendesk-tickets",
       prompt:
         "@Zero go through the new Zendesk tickets, set each one's severity, route it to the right team, and draft a first reply.",
-      connectors: ["zendesk", "linear"],
-      required: ["zendesk"],
+      connectorSlugs: ["zendesk", "linear"],
+      requiredConnectorSlugs: ["zendesk"],
     }),
     supplementalWorkflowTemplate({
       id: "fixes-to-notion-help-docs",
       prompt:
         "@Zero take a recently resolved ticket and turn the fix into a reusable help article in Notion.",
-      connectors: ["notion", "zendesk"],
-      required: ["notion", "zendesk"],
+      connectorSlugs: ["notion", "zendesk"],
+      requiredConnectorSlugs: ["notion", "zendesk"],
     }),
     supplementalWorkflowTemplate({
       id: "morning-brief-slack",
       prompt:
         "@Zero send me a brief with today's schedule and the emails that need me and post it to Slack.",
-      connectors: ["gmail", "google-calendar", "slack"],
-      required: ["gmail", "google-calendar", "slack"],
+      connectorSlugs: ["gmail", "google-calendar", "slack"],
+      requiredConnectorSlugs: ["gmail", "google-calendar", "slack"],
     }),
   ];
 
@@ -271,10 +280,10 @@ const ALL_WORKFLOW_TEMPLATES: readonly WorkflowPromptTemplate[] = [
 // Derives the required connectors from the "Connectors: X required; Y optional"
 // line embedded in promptGuidance, so this stays the single source of truth with
 // the guidance text. Templates without that line resolve to no required connectors.
-function requiredConnectors(
+function requiredConnectorSlugs(
   promptGuidance: string,
-  connectors: readonly string[],
-): readonly string[] {
+  connectorSlugs: readonly ConnectorSlug[],
+): readonly ConnectorSlug[] {
   const match = promptGuidance.match(/Connectors:\s*([^.;\n]*?)\s+required/u);
   const captured = match?.[1];
   if (captured === undefined) {
@@ -290,8 +299,8 @@ function requiredConnectors(
         return value.length > 0;
       }),
   );
-  return connectors.filter((connector) => {
-    return declared.has(connector);
+  return connectorSlugs.filter((connectorSlug) => {
+    return declared.has(connectorSlug);
   });
 }
 
@@ -316,8 +325,11 @@ function onboardingWorkflow(
       return $.onboarding.workflows[id].description;
     }),
     prompt: template.promptGuidance,
-    connectors: template.connectors,
-    required: requiredConnectors(template.promptGuidance, template.connectors),
+    connectorSlugs: template.connectorSlugs,
+    requiredConnectorSlugs: requiredConnectorSlugs(
+      template.promptGuidance,
+      template.connectorSlugs,
+    ),
     scenario: t(($) => {
       return $.onboarding.workflows[id].scenario;
     }),

--- a/turbo/apps/platform/src/views/onboarding/onboarding-make-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-make-page.tsx
@@ -55,7 +55,7 @@ function PromptOnboarding() {
   const searchParams = useGet(searchParams$);
   const pageSignal = useGet(pageSignal$);
   const { runPrompt } = useOnboardingNavigation();
-  const connectors = (searchParams.get("connector") ?? "")
+  const connectorSlugs = (searchParams.get("connector") ?? "")
     .split(",")
     .map((value) => {
       return value.trim();
@@ -92,7 +92,10 @@ function PromptOnboarding() {
         />
       }
     >
-      <OnboardingConnectorSetup connectorIds={connectors} variant="prompt" />
+      <OnboardingConnectorSetup
+        connectorSlugs={connectorSlugs}
+        variant="prompt"
+      />
       <textarea
         id="onboarding-prompt"
         aria-label={t(($) => {

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactNode } from "react";
 import { useLastLoadable } from "ccstate-react";
+import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import { useTranslation } from "react-i18next";
 import type { OnboardingWorkflow } from "./onboarding-data.ts";
 import { connectorCatalogStatusBySlug$ } from "../../signals/external/connectors.ts";
@@ -20,7 +21,7 @@ function DiagramConnectorIcon({
   connectorSlug,
   size,
 }: {
-  readonly connectorSlug: string;
+  readonly connectorSlug: ConnectorSlug;
   readonly size: number;
 }) {
   const catalogBySlugLoadable = useLastLoadable(connectorCatalogStatusBySlug$);
@@ -95,11 +96,11 @@ const CONNECTOR_LABELS: Readonly<Record<string, string>> = {
   tldv: "tl;dv",
 };
 
-function connectorLabel(connectorId: string): string {
-  return CONNECTOR_LABELS[connectorId] ?? connectorId;
+function connectorLabel(connectorSlug: ConnectorSlug): string {
+  return CONNECTOR_LABELS[connectorSlug] ?? connectorSlug;
 }
 
-const WORKFLOW_SOURCE_CONNECTOR_IDS: ReadonlySet<string> = new Set([
+const WORKFLOW_SOURCE_CONNECTOR_SLUGS: ReadonlySet<ConnectorSlug> = new Set([
   "apollo",
   "axiom",
   "gmail",
@@ -112,7 +113,7 @@ const WORKFLOW_SOURCE_CONNECTOR_IDS: ReadonlySet<string> = new Set([
   "x",
 ]);
 
-const WORKFLOW_OUTPUT_CONNECTOR_IDS: ReadonlySet<string> = new Set([
+const WORKFLOW_OUTPUT_CONNECTOR_SLUGS: ReadonlySet<ConnectorSlug> = new Set([
   "elevenlabs",
   "gamma",
   "github",
@@ -127,7 +128,7 @@ const WORKFLOW_OUTPUT_CONNECTOR_IDS: ReadonlySet<string> = new Set([
   "vercel",
 ]);
 
-const WORKFLOW_DELIVERY_CONNECTOR_IDS: ReadonlySet<string> = new Set([
+const WORKFLOW_DELIVERY_CONNECTOR_SLUGS: ReadonlySet<ConnectorSlug> = new Set([
   "slack",
   "gmail",
   "resend",
@@ -141,104 +142,106 @@ const WORKFLOW_DELIVERY_CONNECTOR_IDS: ReadonlySet<string> = new Set([
   "heygen",
 ]);
 
-function uniqueWorkflowConnectors(
-  connectors: readonly string[],
-): readonly string[] {
-  const seen = new Set<string>();
-  return connectors.filter((connectorId) => {
-    if (seen.has(connectorId)) {
+function uniqueWorkflowConnectorSlugs(
+  connectorSlugs: readonly ConnectorSlug[],
+): readonly ConnectorSlug[] {
+  const seen = new Set<ConnectorSlug>();
+  return connectorSlugs.filter((connectorSlug) => {
+    if (seen.has(connectorSlug)) {
       return false;
     }
-    seen.add(connectorId);
+    seen.add(connectorSlug);
     return true;
   });
 }
 
 interface WorkflowDiagramModel {
-  readonly sourceConnectors: readonly string[];
+  readonly sourceConnectorSlugs: readonly ConnectorSlug[];
   readonly sourceLabel: string;
-  readonly destinationConnector: string | undefined;
+  readonly destinationConnectorSlug: ConnectorSlug | undefined;
 }
 
 function buildWorkflowDiagramModel(
   workflow: OnboardingWorkflow,
   sourceFallback: string,
 ): WorkflowDiagramModel {
-  const allConnectors = uniqueWorkflowConnectors(workflow.connectors);
-  const sourceCandidates = uniqueWorkflowConnectors([
-    ...allConnectors.filter((connectorId) => {
-      return WORKFLOW_SOURCE_CONNECTOR_IDS.has(connectorId);
+  const allConnectorSlugs = uniqueWorkflowConnectorSlugs(
+    workflow.connectorSlugs,
+  );
+  const sourceCandidates = uniqueWorkflowConnectorSlugs([
+    ...allConnectorSlugs.filter((connectorSlug) => {
+      return WORKFLOW_SOURCE_CONNECTOR_SLUGS.has(connectorSlug);
     }),
-    ...allConnectors,
+    ...allConnectorSlugs,
   ]);
-  const outputCandidates = uniqueWorkflowConnectors([
-    ...allConnectors.filter((connectorId) => {
-      return WORKFLOW_OUTPUT_CONNECTOR_IDS.has(connectorId);
+  const outputCandidates = uniqueWorkflowConnectorSlugs([
+    ...allConnectorSlugs.filter((connectorSlug) => {
+      return WORKFLOW_OUTPUT_CONNECTOR_SLUGS.has(connectorSlug);
     }),
-    ...allConnectors,
+    ...allConnectorSlugs,
   ]);
 
-  const primarySource = sourceCandidates[0] ?? allConnectors[0];
-  const destinationConnector =
-    outputCandidates.find((connectorId) => {
+  const primarySource = sourceCandidates[0] ?? allConnectorSlugs[0];
+  const destinationConnectorSlug =
+    outputCandidates.find((connectorSlug) => {
       return (
-        connectorId !== primarySource &&
-        WORKFLOW_DELIVERY_CONNECTOR_IDS.has(connectorId)
+        connectorSlug !== primarySource &&
+        WORKFLOW_DELIVERY_CONNECTOR_SLUGS.has(connectorSlug)
       );
     }) ??
-    outputCandidates.find((connectorId) => {
-      return connectorId !== primarySource;
+    outputCandidates.find((connectorSlug) => {
+      return connectorSlug !== primarySource;
     }) ??
     undefined;
-  const sourceConnectors = uniqueWorkflowConnectors([
+  const sourceConnectorSlugs = uniqueWorkflowConnectorSlugs([
     ...(primarySource ? [primarySource] : []),
-    ...allConnectors.filter((connectorId) => {
-      return connectorId !== destinationConnector;
+    ...allConnectorSlugs.filter((connectorSlug) => {
+      return connectorSlug !== destinationConnectorSlug;
     }),
   ]);
-  const primaryLabel = sourceConnectors[0]
-    ? connectorLabel(sourceConnectors[0])
+  const primaryLabel = sourceConnectorSlugs[0]
+    ? connectorLabel(sourceConnectorSlugs[0])
     : sourceFallback;
   const sourceLabel =
-    sourceConnectors.length > 1
-      ? `${primaryLabel} + ${sourceConnectors.length - 1}`
-      : sourceConnectors[0]
-        ? connectorLabel(sourceConnectors[0])
+    sourceConnectorSlugs.length > 1
+      ? `${primaryLabel} + ${sourceConnectorSlugs.length - 1}`
+      : sourceConnectorSlugs[0]
+        ? connectorLabel(sourceConnectorSlugs[0])
         : "";
 
   return {
-    sourceConnectors,
+    sourceConnectorSlugs,
     sourceLabel,
-    destinationConnector,
+    destinationConnectorSlug,
   };
 }
 
 function WorkflowDiagramNode({
   label,
-  connector,
-  connectors,
+  connectorSlug,
+  connectorSlugs,
   className,
   iconClassName,
   children,
 }: {
   readonly label: string;
-  readonly connector?: string;
-  readonly connectors?: readonly string[];
+  readonly connectorSlug?: ConnectorSlug;
+  readonly connectorSlugs?: readonly ConnectorSlug[];
   readonly className: string;
   readonly iconClassName?: string;
   readonly children?: ReactNode;
 }) {
-  const visibleConnectors = connectors?.slice(0, 3) ?? [];
-  const hiddenConnectorCount = Math.max((connectors?.length ?? 0) - 3, 0);
+  const visibleConnectorSlugs = connectorSlugs?.slice(0, 3) ?? [];
+  const hiddenConnectorCount = Math.max((connectorSlugs?.length ?? 0) - 3, 0);
 
   return (
     <div className={`owf-diagram-node ${className}`}>
       {label ? <span>{label}</span> : null}
       <span className={`owf-diagram-icon-box ${iconClassName ?? ""}`}>
         {children ??
-          (visibleConnectors.length > 1 ? (
+          (visibleConnectorSlugs.length > 1 ? (
             <span className="owf-diagram-icon-stack">
-              {visibleConnectors.map((item) => {
+              {visibleConnectorSlugs.map((item) => {
                 return (
                   <span key={item} className="owf-diagram-icon-stack-item">
                     <DiagramConnectorIcon connectorSlug={item} size={22} />
@@ -251,8 +254,8 @@ function WorkflowDiagramNode({
                 </span>
               ) : null}
             </span>
-          ) : connector ? (
-            <DiagramConnectorIcon connectorSlug={connector} size={34} />
+          ) : connectorSlug ? (
+            <DiagramConnectorIcon connectorSlug={connectorSlug} size={34} />
           ) : null)}
       </span>
     </div>
@@ -294,7 +297,7 @@ export function WorkflowPreviewDiagram({
   const lastStep = workflow.detailSteps.at(-1) ?? firstStep;
   const destinationCurvePath =
     "M485 112V148.65C485 166.79 469.17 175.85 437.51 175.85H352.59C325.19 175.85 311.5 183.7 311.5 199.4V223";
-  const beamPath = diagram.destinationConnector
+  const beamPath = diagram.destinationConnectorSlug
     ? "M170 81H485V148.65C485 166.79 469.17 175.85 437.51 175.85H352.59C325.19 175.85 311.5 183.7 311.5 199.4V356"
     : "M170 81H311.5V223H312.5V356";
 
@@ -309,7 +312,7 @@ export function WorkflowPreviewDiagram({
           aria-hidden="true"
         >
           <path d="M170 81H277" />
-          {diagram.destinationConnector ? (
+          {diagram.destinationConnectorSlug ? (
             <>
               <path d="M349 81H451" />
               <path d={destinationCurvePath} />
@@ -324,7 +327,7 @@ export function WorkflowPreviewDiagram({
           style={{ offsetPath: `path("${beamPath}")` } satisfies CSSProperties}
         />
         <span className="owf-diagram-dot-source" aria-hidden="true" />
-        {diagram.destinationConnector ? (
+        {diagram.destinationConnectorSlug ? (
           <>
             <span
               className="owf-diagram-dot-destination-in"
@@ -340,11 +343,11 @@ export function WorkflowPreviewDiagram({
         <span className="owf-diagram-vertical-control" aria-hidden="true" />
         <span className="owf-diagram-dot-action-middle" aria-hidden="true" />
         <span className="owf-diagram-dot-action-bottom" aria-hidden="true" />
-        {diagram.sourceConnectors.length > 0 ? (
+        {diagram.sourceConnectorSlugs.length > 0 ? (
           <WorkflowDiagramNode
             label={diagram.sourceLabel}
-            connector={diagram.sourceConnectors[0]}
-            connectors={diagram.sourceConnectors}
+            connectorSlug={diagram.sourceConnectorSlugs[0]}
+            connectorSlugs={diagram.sourceConnectorSlugs}
             className="owf-diagram-node-source"
           />
         ) : null}
@@ -359,10 +362,10 @@ export function WorkflowPreviewDiagram({
             <img src={ZERO_AVATAR_FACE_IMG} alt="" aria-hidden />
           </span>
         </WorkflowDiagramNode>
-        {diagram.destinationConnector ? (
+        {diagram.destinationConnectorSlug ? (
           <WorkflowDiagramNode
-            label={connectorLabel(diagram.destinationConnector)}
-            connector={diagram.destinationConnector}
+            label={connectorLabel(diagram.destinationConnectorSlug)}
+            connectorSlug={diagram.destinationConnectorSlug}
             className="owf-diagram-node-output"
           />
         ) : null}

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-picker-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-picker-page.tsx
@@ -16,6 +16,7 @@ import {
   type Icon,
 } from "@tabler/icons-react";
 import { cn } from "@vm0/ui";
+import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import { useTranslation } from "react-i18next";
 import {
   onboardingDraft$,
@@ -61,7 +62,7 @@ function WorkflowConnectorIcon({
   connectorSlug,
   size,
 }: {
-  readonly connectorSlug: string;
+  readonly connectorSlug: ConnectorSlug;
   readonly size: number;
 }) {
   const catalogBySlugLoadable = useLastLoadable(connectorCatalogStatusBySlug$);
@@ -73,13 +74,13 @@ function WorkflowConnectorIcon({
 }
 
 export function WorkflowConnectorPills({
-  connectorIds,
+  connectorSlugs,
 }: {
-  readonly connectorIds: readonly string[];
+  readonly connectorSlugs: readonly ConnectorSlug[];
 }) {
   const { t } = useTranslation();
 
-  if (connectorIds.length === 0) {
+  if (connectorSlugs.length === 0) {
     return (
       <span className="inline-flex min-h-7 items-center rounded-full border border-border bg-muted/30 px-2.5 text-xs font-medium text-muted-foreground">
         {t(($) => {
@@ -90,13 +91,13 @@ export function WorkflowConnectorPills({
   }
   return (
     <span className="flex items-center gap-1.5" aria-hidden="true">
-      {connectorIds.slice(0, 4).map((connectorId) => {
+      {connectorSlugs.slice(0, 4).map((connectorSlug) => {
         return (
           <span
-            key={connectorId}
+            key={connectorSlug}
             className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border bg-muted/30"
           >
-            <WorkflowConnectorIcon connectorSlug={connectorId} size={14} />
+            <WorkflowConnectorIcon connectorSlug={connectorSlug} size={14} />
           </span>
         );
       })}
@@ -232,7 +233,7 @@ function WorkflowCard({
         </span>
       </span>
       <span className="relative z-10 flex items-center justify-between gap-3">
-        <WorkflowConnectorPills connectorIds={workflow.connectors} />
+        <WorkflowConnectorPills connectorSlugs={workflow.connectorSlugs} />
         <button
           type="button"
           className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-muted/30 text-muted-foreground hover:border-primary/35 hover:text-primary"

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-run-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-run-page.tsx
@@ -97,7 +97,9 @@ export function OnboardingWorkflowRunPage() {
               </p>
             </div>
             <div className="flex items-center justify-between gap-3">
-              <WorkflowConnectorPills connectorIds={workflow.connectors} />
+              <WorkflowConnectorPills
+                connectorSlugs={workflow.connectorSlugs}
+              />
               <button
                 type="button"
                 className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-muted/30 text-muted-foreground hover:border-primary/35 hover:text-primary"
@@ -115,8 +117,8 @@ export function OnboardingWorkflowRunPage() {
         ) : null}
 
         <OnboardingConnectorSetup
-          connectorIds={workflow?.connectors ?? []}
-          requiredIds={workflow?.required ?? []}
+          connectorSlugs={workflow?.connectorSlugs ?? []}
+          requiredConnectorSlugs={workflow?.requiredConnectorSlugs ?? []}
         >
           <label className="sr-only" htmlFor="workflow-note">
             {custom

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -12,6 +12,7 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { user$ } from "../../signals/auth.ts";
 import { IconArrowUpRight, IconPin, IconUserPlus } from "@tabler/icons-react";
+import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
@@ -413,7 +414,7 @@ interface SuggestedPrompt {
   title: string;
   description: string;
   prompt: string;
-  connectors?: readonly string[];
+  connectorSlugs?: readonly ConnectorSlug[];
 }
 
 function SuggestedPromptButton({
@@ -428,7 +429,7 @@ function SuggestedPromptButton({
   onSelectPrompt: (prompt: string) => void;
 }) {
   const connectors =
-    item.connectors?.flatMap((connectorSlug) => {
+    item.connectorSlugs?.flatMap((connectorSlug) => {
       const connector = connectorStatusBySlug?.get(connectorSlug);
       return connector ? [{ connectorSlug, icon: connector.icon }] : [];
     }) ?? [];

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1086,7 +1086,7 @@ function workflowTemplateMatchesSearch(
     item.title,
     item.id,
     item.description,
-    item.connectors.join(" "),
+    item.connectorSlugs.join(" "),
   ].join(" ");
   return searchable.toLowerCase().includes(normalizedQuery);
 }
@@ -1469,18 +1469,18 @@ function WebsiteTemplateGrid({
 }
 
 function WorkflowTemplateConnectorIcons({
-  connectors,
+  connectorSlugs,
   compact = false,
   limit = compact ? 3 : 5,
   withDivider = false,
 }: {
-  connectors: readonly string[];
+  connectorSlugs: readonly ConnectorSlug[];
   compact?: boolean;
   limit?: number;
   withDivider?: boolean;
 }) {
   const catalogConnectors = useLastResolved(allConnectorCatalogItems$);
-  const visibleConnectors = connectors.flatMap((connectorSlug) => {
+  const visibleConnectors = connectorSlugs.flatMap((connectorSlug) => {
     const connector = catalogConnectors?.find((candidate) => {
       return candidate.slug === connectorSlug;
     });
@@ -1555,7 +1555,7 @@ function WorkflowTemplateCard({
       </p>
       <div className="mt-auto flex items-center gap-2 pt-3.5">
         <WorkflowTemplateConnectorIcons
-          connectors={item.connectors}
+          connectorSlugs={item.connectorSlugs}
           limit={4}
         />
         <button

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -1,11 +1,10 @@
+import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-
-type IdeationConnectorSlug = string;
 
 interface UseCase {
   readonly id: string;
   readonly prompt: string;
-  readonly connectors?: readonly IdeationConnectorSlug[];
+  readonly connectorSlugs?: readonly ConnectorSlug[];
   readonly featureFlag?: FeatureSwitchKey;
 }
 
@@ -27,92 +26,92 @@ const categories: readonly Category[] = [
         id: "daily-standup-report",
         prompt:
           "Set up a daily standup report that pulls data from GitHub, Sentry, Axiom, and Plausible every morning, generates a pptx, and posts it to #all-vm0",
-        connectors: ["github", "sentry", "axiom", "plausible", "slack"],
+        connectorSlugs: ["github", "sentry", "axiom", "plausible", "slack"],
       },
       {
         id: "github-progress-weekly",
         prompt:
           "Generate a weekly GitHub progress report summarized by feature modules",
-        connectors: ["github"],
+        connectorSlugs: ["github"],
       },
       {
         id: "github-pr-summarizer",
         prompt:
           "Summarize all merged GitHub PRs from the past week and save a daily report in Notion with an optional Slack post",
-        connectors: ["github", "notion", "slack"],
+        connectorSlugs: ["github", "notion", "slack"],
       },
       {
         id: "sentry-issue-digest",
         prompt:
           "Set up a daily Sentry issue digest that summarizes critical and high severity issues every morning and posts to Slack",
-        connectors: ["sentry", "slack"],
+        connectorSlugs: ["sentry", "slack"],
       },
       {
         id: "vercel-deploy-digest",
         prompt:
           "Set up a Vercel deploy digest that monitors deployments, links each to its GitHub commit, and sends Slack alerts on failures",
-        connectors: ["vercel", "github", "slack"],
+        connectorSlugs: ["vercel", "github", "slack"],
       },
       {
         id: "cloudflare-traffic-security-report",
         prompt:
           "Set up a weekly Cloudflare report that summarizes traffic analytics, WAF events, and bot activity, then posts to Slack",
-        connectors: ["cloudflare", "slack"],
+        connectorSlugs: ["cloudflare", "slack"],
       },
       {
         id: "batch-create-issues",
         prompt:
           "Create the following GitHub issues and assign them to the right people: 1) ... 2) ... 3) ...",
-        connectors: ["github"],
+        connectorSlugs: ["github"],
       },
       {
         id: "codebase-investigation",
         prompt:
           "Look at this page and search the codebase to find the root cause of the bug: [paste URL]",
-        connectors: ["github"],
+        connectorSlugs: ["github"],
       },
       {
         id: "deep-research-code-analysis",
         prompt:
           "Do a deep research on how the agent run queue locking mechanism works in our codebase",
-        connectors: ["github"],
+        connectorSlugs: ["github"],
       },
       {
         id: "security-dependency-alert-digest",
         prompt:
           "Generate a weekly GitHub security and dependency alert digest and post it to Slack",
-        connectors: ["github", "slack"],
+        connectorSlugs: ["github", "slack"],
       },
       {
         id: "jira-github-issue-sync",
         prompt:
           "Set up a bidirectional sync between Jira and GitHub so that issue status, labels, and comments stay in sync across both platforms",
-        connectors: ["jira", "github", "slack"],
+        connectorSlugs: ["jira", "github", "slack"],
       },
       {
         id: "gitlab-to-github-migration-helper",
         prompt:
           "Set up a workflow that mirrors GitLab issues to GitHub issues and notifies on Slack when new items are synced",
-        connectors: ["gitlab", "github", "slack"],
+        connectorSlugs: ["gitlab", "github", "slack"],
       },
       {
         id: "browserbase-web-testing",
         prompt:
           "Set up automated browser tests using Browserbase that check our landing page, login flow, and dashboard every day and report failures to Slack",
-        connectors: ["browserbase", "slack"],
+        connectorSlugs: ["browserbase", "slack"],
       },
       {
         id: "zapier-vm0-migration",
         prompt:
           "Help me migrate my Zapier workflows to VM0. I have zaps for: new Slack message → Notion, Gmail → Google Sheets, and GitHub PR → Slack",
-        connectors: ["zapier", "slack", "notion"],
+        connectorSlugs: ["zapier", "slack", "notion"],
         featureFlag: FeatureSwitchKey.ZapierConnector,
       },
       {
         id: "make-scenario-builder",
         prompt:
           "Design a Make scenario that watches a Gmail inbox for invoices, extracts amounts and dates, logs them to Google Sheets, and alerts on Slack",
-        connectors: ["make", "gmail", "google-sheets", "slack"],
+        connectorSlugs: ["make", "gmail", "google-sheets", "slack"],
       },
     ],
   },
@@ -133,25 +132,25 @@ const categories: readonly Category[] = [
         id: "linear-prd-implementer",
         prompt:
           "Take the product spec from Notion and create a structured Linear project with epics and issues",
-        connectors: ["notion", "linear"],
+        connectorSlugs: ["notion", "linear"],
       },
       {
         id: "feedback-router",
         prompt:
           "Set up a feedback router that watches a Slack channel and routes messages to the right team based on keywords and labels",
-        connectors: ["slack", "notion"],
+        connectorSlugs: ["slack", "notion"],
       },
       {
         id: "metabase-dashboard-digest",
         prompt:
           "Set up a weekly Metabase digest that snapshots key dashboards, captures charts, and posts them to Slack every Monday morning",
-        connectors: ["metabase", "slack"],
+        connectorSlugs: ["metabase", "slack"],
       },
       {
         id: "asana-notion-project-sync",
         prompt:
           "Set up a sync between Asana and Notion that mirrors project milestones, task progress, and due dates into a Notion dashboard",
-        connectors: ["asana", "notion", "slack"],
+        connectorSlugs: ["asana", "notion", "slack"],
       },
     ],
   },
@@ -162,103 +161,103 @@ const categories: readonly Category[] = [
         id: "content-planner",
         prompt:
           "Help me brainstorm content ideas and plan an editorial calendar for the next month in Notion",
-        connectors: ["notion"],
+        connectorSlugs: ["notion"],
       },
       {
         id: "marketing-content-planning",
         prompt:
           "Help me plan GTM use case content. Reference our team's Slack usage patterns, user interviews, and competitor analysis",
-        connectors: ["slack"],
+        connectorSlugs: ["slack"],
       },
       {
         id: "onboarding-email-use-cases",
         prompt:
           "Analyze our Slack usage records and user interviews to extract key onboarding use cases for email campaigns",
-        connectors: ["slack"],
+        connectorSlugs: ["slack"],
       },
       {
         id: "competitor-research-to-notion",
         prompt:
           "Research competitor [name] on X/Twitter and save the findings into our Notion research database",
-        connectors: ["x", "notion"],
+        connectorSlugs: ["x", "notion"],
       },
       {
         id: "social-media-content-calendar",
         prompt:
           "Generate social media content for Twitter and LinkedIn from my Google Sheets content calendar and schedule the posts",
-        connectors: ["google-sheets", "x"],
+        connectorSlugs: ["google-sheets", "x"],
       },
       {
         id: "youtube-to-x-thread-repurposer",
         prompt:
           "Set up a workflow that monitors my YouTube channel for new videos, creates a summary page in Notion, and generates a promotional X thread",
-        connectors: ["youtube", "notion", "x"],
+        connectorSlugs: ["youtube", "notion", "x"],
       },
       {
         id: "competitive-intel-scraper",
         prompt:
           "Set up a weekly competitor scraper using Firecrawl that monitors competitor websites for pricing and feature changes, saves findings to Notion, and alerts on Slack",
-        connectors: ["firecrawl", "notion", "slack"],
+        connectorSlugs: ["firecrawl", "notion", "slack"],
       },
       {
         id: "dev-to-auto-publisher",
         prompt:
           "Set up a workflow that publishes Notion pages tagged as 'ready' to Dev.to and posts a link on X",
-        connectors: ["devto", "notion", "x"],
+        connectorSlugs: ["devto", "notion", "x"],
       },
       {
         id: "instagram-engagement-tracker",
         prompt:
           "Set up an Instagram tracker that logs post engagement metrics to Google Sheets and posts a weekly summary to Slack",
-        connectors: ["instagram", "google-sheets", "slack"],
+        connectorSlugs: ["instagram", "google-sheets", "slack"],
       },
       {
         id: "similarweb-traffic-comparison",
         prompt:
           "Run a monthly SimilarWeb traffic comparison between our site and top 5 competitors, save the report to Notion",
-        connectors: ["similarweb", "notion"],
+        connectorSlugs: ["similarweb", "notion"],
       },
       {
         id: "serpapi-keyword-tracker",
         prompt:
           "Set up a weekly keyword ranking tracker using SerpAPI that monitors our target keywords and logs position changes to Google Sheets with a Slack summary",
-        connectors: ["serpapi", "google-sheets", "slack"],
+        connectorSlugs: ["serpapi", "google-sheets", "slack"],
       },
       {
         id: "apify-web-scraper-to-sheets",
         prompt:
           "Set up an Apify scraper that extracts product listings from a competitor website and saves them to Google Sheets daily",
-        connectors: ["apify", "google-sheets", "slack"],
+        connectorSlugs: ["apify", "google-sheets", "slack"],
       },
       {
         id: "marketing-automation-system",
         prompt:
           "Set up a marketing automation system with three agents: a daily researcher for information collection, a weekly monitor for tracking, and an on-demand agent for ad-hoc tasks",
-        connectors: ["slack"],
+        connectorSlugs: ["slack"],
       },
       {
         id: "discord-community-insights",
         prompt:
           "Set up a Discord community monitor that watches for feature requests and bug reports, categorizes them in Notion, and posts a weekly digest to Slack",
-        connectors: ["discord", "notion", "slack"],
+        connectorSlugs: ["discord", "notion", "slack"],
       },
       {
         id: "x-brand-monitor",
         prompt:
           "Set up an X brand monitor that watches for mentions of our product, saves relevant posts to Notion, and sends Slack alerts for high-engagement posts",
-        connectors: ["x", "notion", "slack"],
+        connectorSlugs: ["x", "notion", "slack"],
       },
       {
         id: "loops-email-campaign",
         prompt:
           "Set up a workflow that drafts email campaigns from Notion content and sends them through Loops",
-        connectors: ["loops", "notion"],
+        connectorSlugs: ["loops", "notion"],
       },
       {
         id: "brevo-email-nurture-sequence",
         prompt:
           "Set up a Brevo nurture sequence that sends onboarding emails when new contacts are added to a Notion database",
-        connectors: ["brevo", "notion", "slack"],
+        connectorSlugs: ["brevo", "notion", "slack"],
       },
     ],
   },
@@ -269,31 +268,31 @@ const categories: readonly Category[] = [
         id: "elevenlabs-audio-content",
         prompt:
           "Set up a workflow that takes blog posts from Notion, generates voice narration with ElevenLabs, and saves the audio to Google Drive",
-        connectors: ["elevenlabs", "notion", "google-drive"],
+        connectorSlugs: ["elevenlabs", "notion", "google-drive"],
       },
       {
         id: "heygen-video-from-script",
         prompt:
           "Set up a workflow that takes a script from Notion, generates a video with HeyGen, and sends a Slack notification when it's ready",
-        connectors: ["heygen", "notion", "slack"],
+        connectorSlugs: ["heygen", "notion", "slack"],
       },
       {
         id: "runway-video-from-brief",
         prompt:
           "Take a creative brief from Notion and generate a short promotional video using Runway, then notify the team on Slack when ready",
-        connectors: ["runway", "notion", "slack"],
+        connectorSlugs: ["runway", "notion", "slack"],
       },
       {
         id: "fal-ai-image-generation",
         prompt:
           "Set up a workflow that takes product descriptions from Notion, generates marketing images using Fal, and saves them to Google Drive",
-        connectors: ["fal", "notion", "google-drive"],
+        connectorSlugs: ["fal", "notion", "google-drive"],
       },
       {
         id: "cloudinary-media-optimizer",
         prompt:
           "Set up a workflow that takes images from Google Drive, optimizes them with Cloudinary for web use, and logs the results in Notion",
-        connectors: ["cloudinary", "google-drive", "notion"],
+        connectorSlugs: ["cloudinary", "google-drive", "notion"],
       },
     ],
   },
@@ -304,43 +303,43 @@ const categories: readonly Category[] = [
         id: "streak-pipeline-report",
         prompt:
           "Set up a weekly Streak pipeline report that summarizes deal stages, win rates, and upcoming follow-ups, then posts to Slack",
-        connectors: ["streak", "slack"],
+        connectorSlugs: ["streak", "slack"],
       },
       {
         id: "lead-follow-up-pipeline",
         prompt:
           "Set up a lead follow-up pipeline that monitors Gmail for new leads, analyzes them with AI, creates HubSpot tasks, and notifies the sales team on Slack",
-        connectors: ["gmail", "hubspot", "slack"],
+        connectorSlugs: ["gmail", "hubspot", "slack"],
       },
       {
         id: "win-loss-reporter",
         prompt:
           "Set up a weekly win/loss report that analyzes our HubSpot pipeline, tracks deal outcomes, and posts trends to Slack",
-        connectors: ["hubspot", "slack"],
+        connectorSlugs: ["hubspot", "slack"],
       },
       {
         id: "salesforce-pipeline-digest",
         prompt:
           "Set up a weekly Salesforce pipeline digest that summarizes new opportunities, stage changes, and close dates, then posts to Slack",
-        connectors: ["salesforce", "slack"],
+        connectorSlugs: ["salesforce", "slack"],
       },
       {
         id: "airtable-deal-tracker",
         prompt:
           "Set up an Airtable deal tracker that syncs deal records to Google Sheets and sends a Slack notification when a deal is marked as closed-won",
-        connectors: ["airtable", "google-sheets", "slack"],
+        connectorSlugs: ["airtable", "google-sheets", "slack"],
       },
       {
         id: "hubspot-sales-reporter",
         prompt:
           "Generate a weekly HubSpot sales summary and save it as a structured report in Notion",
-        connectors: ["hubspot", "notion"],
+        connectorSlugs: ["hubspot", "notion"],
       },
       {
         id: "bitrix24-lead-nurture",
         prompt:
           "Set up a lead nurture workflow that monitors Bitrix24 for new leads, creates follow-up tasks, and notifies sales on Slack",
-        connectors: ["bitrix", "slack"],
+        connectorSlugs: ["bitrix", "slack"],
       },
     ],
   },
@@ -351,31 +350,31 @@ const categories: readonly Category[] = [
         id: "support-ticket-router",
         prompt:
           "Set up a support ticket router that monitors Gmail for support emails, classifies them by category and priority, creates Notion entries, and sends Slack alerts for critical tickets",
-        connectors: ["gmail", "notion", "slack"],
+        connectorSlugs: ["gmail", "notion", "slack"],
       },
       {
         id: "intercom-conversation-triager",
         prompt:
           "Set up a workflow that takes Intercom conversations, classifies them, and creates structured tasks in Notion",
-        connectors: ["intercom", "notion"],
+        connectorSlugs: ["intercom", "notion"],
       },
       {
         id: "zendesk-notion-knowledge-base",
         prompt:
           "Set up a workflow that identifies recurring Zendesk questions, drafts FAQ entries, and adds them to our Notion knowledge base",
-        connectors: ["zendesk", "notion", "slack"],
+        connectorSlugs: ["zendesk", "notion", "slack"],
       },
       {
         id: "customer-support-bot",
         prompt:
           "Set up a customer support bot that answers questions from our Notion knowledge base and creates tasks for unanswered questions",
-        connectors: ["slack", "notion"],
+        connectorSlugs: ["slack", "notion"],
       },
       {
         id: "chatwoot-notion-support-log",
         prompt:
           "Set up a workflow that takes Chatwoot customer conversations, categorizes them by topic, and creates structured entries in Notion",
-        connectors: ["chatwoot", "notion", "slack"],
+        connectorSlugs: ["chatwoot", "notion", "slack"],
       },
     ],
   },
@@ -386,67 +385,67 @@ const categories: readonly Category[] = [
         id: "revenuecat-subscription-digest",
         prompt:
           "Set up a daily RevenueCat digest that tracks new subscriptions, renewals, and cancellations in Google Sheets and alerts on Slack for churn spikes",
-        connectors: ["revenuecat", "google-sheets", "slack"],
+        connectorSlugs: ["revenuecat", "google-sheets", "slack"],
       },
       {
         id: "xero-financial-summary",
         prompt:
           "Set up a weekly Xero financial summary that pulls profit & loss and cash flow data and posts a formatted report to Slack",
-        connectors: ["xero", "slack"],
+        connectorSlugs: ["xero", "slack"],
       },
       {
         id: "pdf-contract-processor",
         prompt:
           "Set up a workflow that processes PDF contracts, extracts key dates and terms into Notion, and sends Slack reminders before expiration dates",
-        connectors: ["pdfco", "notion", "slack"],
+        connectorSlugs: ["pdfco", "notion", "slack"],
       },
       {
         id: "jotform-intake-to-notion",
         prompt:
           "Set up a Jotform intake that routes new form submissions to the right Notion database and sends a Slack notification",
-        connectors: ["jotform", "notion", "slack"],
+        connectorSlugs: ["jotform", "notion", "slack"],
       },
       {
         id: "google-drive-file-organizer",
         prompt:
           "Set up a workflow that watches Google Drive for new files, classifies them by content, and moves them into the right folders",
-        connectors: ["google-drive"],
+        connectorSlugs: ["google-drive"],
       },
       {
         id: "google-docs-notion-migrator",
         prompt:
           "Set up a workflow that converts a folder of Google Docs into Notion pages, preserving headings, tables, and images",
-        connectors: ["google-docs", "notion"],
+        connectorSlugs: ["google-docs", "notion"],
       },
       {
         id: "monday-com-weekly-digest",
         prompt:
           "Set up a weekly Monday.com digest that summarizes board activity, completed items, and blockers, then posts to Slack",
-        connectors: ["monday", "slack"],
+        connectorSlugs: ["monday", "slack"],
       },
       {
         id: "wrike-project-reporter",
         prompt:
           "Set up a weekly Wrike report that summarizes task completion, overdue items, and blockers across all projects, then posts to Slack",
-        connectors: ["wrike", "slack"],
+        connectorSlugs: ["wrike", "slack"],
       },
       {
         id: "todoist-notion-task-sync",
         prompt:
           "Set up a sync that mirrors my Todoist tasks into a Notion database so the team can see what I'm working on",
-        connectors: ["todoist", "notion"],
+        connectorSlugs: ["todoist", "notion"],
       },
       {
         id: "clickup-slack-standups",
         prompt:
           "Set up a daily standup that pulls each team member's tasks from ClickUp and posts a formatted summary to Slack every morning",
-        connectors: ["clickup", "slack"],
+        connectorSlugs: ["clickup", "slack"],
       },
       {
         id: "agentmail-inbox",
         prompt:
           "Create a new AgentMail inbox and set up email forwarding rules",
-        connectors: ["agentmail"],
+        connectorSlugs: ["agentmail"],
       },
     ],
   },
@@ -457,37 +456,37 @@ const categories: readonly Category[] = [
         id: "personal-weekly-digest",
         prompt:
           "Create a personal weekly report workflow that merges GitHub PRs, Gmail, and Calendar data into a summary and sends it to Slack",
-        connectors: ["github", "gmail", "google-calendar", "slack"],
+        connectorSlugs: ["github", "gmail", "google-calendar", "slack"],
       },
       {
         id: "morning-brief",
         prompt:
           "Set up a morning brief that pulls updates from Gmail, Calendar, and Notion every morning and posts a daily plan to Slack",
-        connectors: ["gmail", "google-calendar", "notion", "slack"],
+        connectorSlugs: ["gmail", "google-calendar", "notion", "slack"],
       },
       {
         id: "strava-team-fitness-digest",
         prompt:
           "Set up a weekly Strava digest that summarizes team members' running and cycling activities and posts a leaderboard to Slack",
-        connectors: ["strava", "slack"],
+        connectorSlugs: ["strava", "slack"],
       },
       {
         id: "email-assistant",
         prompt:
           "Set up a daily email assistant that summarizes my inbox every morning and suggests actions for each thread",
-        connectors: ["gmail"],
+        connectorSlugs: ["gmail"],
       },
       {
         id: "calendar-optimizer",
         prompt:
           "Analyze my calendar for today and recommend how to manage conflicts, prevent overload, and schedule focus time",
-        connectors: ["google-calendar"],
+        connectorSlugs: ["google-calendar"],
       },
       {
         id: "send-messages-on-your-behalf",
         prompt:
           "Send a message to the team on my behalf: I'll be taking a day off tomorrow. Please reach out to [name] for urgent matters.",
-        connectors: ["slack"],
+        connectorSlugs: ["slack"],
       },
       {
         id: "browser-screenshots",
@@ -502,49 +501,49 @@ const categories: readonly Category[] = [
         id: "meeting-notes-pipeline",
         prompt:
           "Set up a meeting notes pipeline that takes Fireflies transcripts, generates a summary in Notion, and posts action items to Slack after each meeting",
-        connectors: ["fireflies", "notion", "slack"],
+        connectorSlugs: ["fireflies", "notion", "slack"],
       },
       {
         id: "calendly-booking-sync",
         prompt:
           "Set up a Calendly sync that adds new bookings to Google Calendar and sends a Slack notification with meeting details",
-        connectors: ["calendly", "google-calendar", "slack"],
+        connectorSlugs: ["calendly", "google-calendar", "slack"],
       },
       {
         id: "lark-slack-message-relay",
         prompt:
           "Set up a message relay between a Lark group and a Slack channel so that messages are forwarded both ways",
-        connectors: ["lark", "slack"],
+        connectorSlugs: ["lark", "slack"],
       },
       {
         id: "line-message-relay",
         prompt:
           "Set up a message relay between a LINE group and a Slack channel so messages flow both ways",
-        connectors: ["line", "slack"],
+        connectorSlugs: ["line", "slack"],
       },
       {
         id: "tl-dv-meeting-recap",
         prompt:
           "Set up a workflow that takes tl;dv meeting recordings, generates a summary with action items in Notion, and posts highlights to Slack",
-        connectors: ["tldv", "notion", "slack"],
+        connectorSlugs: ["tldv", "notion", "slack"],
       },
       {
         id: "granola-notes-to-notion",
         prompt:
           "Set up a sync that takes meeting notes from Granola and organizes them in a Notion database grouped by project",
-        connectors: ["granola", "notion"],
+        connectorSlugs: ["granola", "notion"],
       },
       {
         id: "perplexity-deep-research",
         prompt:
           "Use Perplexity to research a topic in depth, compile findings into a structured Notion page with sources and key insights",
-        connectors: ["perplexity", "notion"],
+        connectorSlugs: ["perplexity", "notion"],
       },
       {
         id: "tavily-web-research-pipeline",
         prompt:
           "Use Tavily to research the latest trends in AI agents, compile a structured report in Notion with sources and key takeaways",
-        connectors: ["tavily", "notion"],
+        connectorSlugs: ["tavily", "notion"],
       },
     ],
   },
@@ -570,14 +569,14 @@ function filterUseCase(
   }
 
   if (
-    !useCase.connectors ||
-    useCase.connectors.length === 0 ||
+    !useCase.connectorSlugs ||
+    useCase.connectorSlugs.length === 0 ||
     !visibleConnectorSlugs
   ) {
     return useCase;
   }
 
-  const allConnectorsVisible = useCase.connectors.every((connectorSlug) => {
+  const allConnectorsVisible = useCase.connectorSlugs.every((connectorSlug) => {
     return visibleConnectorSlugs.has(connectorSlug);
   });
   if (!allConnectorsVisible) {
@@ -610,7 +609,7 @@ export function getRandomPrompts(
 ): UseCase[] {
   const all = getCategories(options).flatMap((c) => {
     return c.cases.filter((u) => {
-      return u.connectors && u.connectors.length > 0;
+      return u.connectorSlugs && u.connectorSlugs.length > 0;
     });
   });
   const shuffled = [...all].sort(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -240,7 +240,7 @@ export function ZeroIdeationPage() {
                       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
                         {category.cases.map((useCase) => {
                           const connectors =
-                            useCase.connectors?.flatMap((connectorSlug) => {
+                            useCase.connectorSlugs?.flatMap((connectorSlug) => {
                               const connector =
                                 connectorStatusBySlug?.get(connectorSlug);
                               return connector

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -256,7 +256,7 @@ export type FirewallPolicies = z.infer<typeof firewallPoliciesSchema>;
 /**
  * Per-firewall grant configuration — which permissions are granted and
  * what policy applies to unknown endpoints (not matching any permission rule).
- * Refs absent from the map are fully permissive (all granted + allow unknown).
+ * Firewall names absent from the map are fully permissive (all granted + allow unknown).
  */
 export const networkPolicySchema = z.object({
   allow: z.array(z.string()),

--- a/turbo/packages/core/src/workflow-template-items.ts
+++ b/turbo/packages/core/src/workflow-template-items.ts
@@ -1,3 +1,5 @@
+import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
+
 export interface WorkflowTemplateItem {
   readonly id: `workflow-template:${string}`;
   readonly title: string;
@@ -5,10 +7,9 @@ export interface WorkflowTemplateItem {
   // Persona group used to organize the template picker. One of
   // WORKFLOW_TEMPLATE_CATEGORIES.
   readonly category: string;
-  // Connector slugs shown as icons on the card. Typed loosely because the
-  // catalog is curated by hand; the picker filters these to entries with an
-  // icon.
-  readonly connectors: readonly string[];
+  // Connector slugs shown as icons on the card. The catalog is curated by hand;
+  // the picker filters these to entries with an icon.
+  readonly connectorSlugs: readonly ConnectorSlug[];
   readonly promptGuidance: string;
 }
 
@@ -35,7 +36,7 @@ function defineWorkflowTemplate(args: {
   readonly category: string;
   readonly title: string;
   readonly description: string;
-  readonly connectors: readonly string[];
+  readonly connectorSlugs: readonly ConnectorSlug[];
   readonly behavior: readonly string[];
   readonly missingInfo: string;
 }): WorkflowTemplateItem {
@@ -44,7 +45,7 @@ function defineWorkflowTemplate(args: {
     title: args.title,
     description: args.description,
     category: args.category,
-    connectors: args.connectors,
+    connectorSlugs: args.connectorSlugs,
     promptGuidance: [
       "# Workflow Template Context",
       "",
@@ -71,7 +72,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Auto-inbox label",
     description:
       "Create a workflow that runs when a Gmail label is applied and handles the labeled inbox item.",
-    connectors: ["gmail"],
+    connectorSlugs: ["gmail"],
     behavior: [
       "Create a workflow that reacts when a named Gmail label is applied to a message.",
       "Treat the labeled message as the inbox item to process.",
@@ -87,7 +88,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Daily standup report",
     description:
       "Pull product and engineering signals each morning, create a short report, and post it to Slack.",
-    connectors: ["github", "sentry", "axiom", "plausible", "slack"],
+    connectorSlugs: ["github", "sentry", "axiom", "plausible", "slack"],
     behavior: [
       "Create a scheduled workflow that runs every weekday or every morning.",
       "Pull recent GitHub activity, Sentry issues, Axiom metrics, and Plausible traffic signals.",
@@ -103,7 +104,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "GitHub PR summarizer",
     description:
       "Collect merged pull requests, save a structured report in Notion, and optionally post to Slack.",
-    connectors: ["github", "notion", "slack"],
+    connectorSlugs: ["github", "notion", "slack"],
     behavior: [
       "Create a daily or weekly scheduled workflow for one or more GitHub repositories.",
       "Find merged pull requests in the selected time window and group them by product or code area.",
@@ -119,7 +120,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Sentry issue digest",
     description:
       "Send a daily digest of critical and high-severity Sentry issues to Slack.",
-    connectors: ["sentry", "slack"],
+    connectorSlugs: ["sentry", "slack"],
     behavior: [
       "Create a daily scheduled workflow that checks selected Sentry projects.",
       "Group active issues by severity, recency, affected users, and ownership when available.",
@@ -135,7 +136,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Vercel deploy digest",
     description:
       "Monitor Vercel deployments, link them to GitHub commits, and alert Slack on failures.",
-    connectors: ["vercel", "github", "slack"],
+    connectorSlugs: ["vercel", "github", "slack"],
     behavior: [
       "Create a workflow that monitors selected Vercel projects on a schedule or via webhook when available.",
       "Link deployments to GitHub commits, pull requests, and authors when possible.",
@@ -151,7 +152,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Auto-merge GitHub PRs",
     description:
       "Review PRs labeled ready-to-merge, wait for CI, then merge and post to Slack.",
-    connectors: ["github", "vercel", "slack"],
+    connectorSlugs: ["github", "vercel", "slack"],
     behavior: [
       "A PR is labeled ready-to-merge",
       "Zero reviews and waits on CI",
@@ -166,7 +167,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "File Sentry crashes as GitHub issues",
     description:
       "Rank new Sentry errors by user impact and file the worst as GitHub issues.",
-    connectors: ["sentry", "github", "linear", "slack"],
+    connectorSlugs: ["sentry", "github", "linear", "slack"],
     behavior: [
       "Zero pulls new Sentry errors",
       "Ranked by user impact",
@@ -181,7 +182,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Draft GitHub release notes in Notion",
     description:
       "Turn the PRs merged since the last release into clean notes in Notion.",
-    connectors: ["github", "notion", "slack"],
+    connectorSlugs: ["github", "notion", "slack"],
     behavior: [
       "A PR is labeled shipped",
       "Zero gathers merged PRs",
@@ -196,7 +197,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Feedback router",
     description:
       "Watch a Slack channel and route product feedback into Notion with labels and owners.",
-    connectors: ["slack", "notion"],
+    connectorSlugs: ["slack", "notion"],
     behavior: [
       "Create a workflow that reviews messages from a selected Slack feedback channel.",
       "Classify feedback into themes, priority, sentiment, and affected product area.",
@@ -212,7 +213,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Turn a GitHub idea into a Notion spec",
     description:
       "Expand a labeled GitHub issue into a structured product spec in Notion.",
-    connectors: ["github", "notion", "figma"],
+    connectorSlugs: ["github", "notion", "figma"],
     behavior: [
       "An issue is labeled needs-spec",
       "Zero expands it into a PRD",
@@ -227,7 +228,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Post release notes to Slack",
     description:
       "Draft a changelog from recently shipped work and post it to Slack.",
-    connectors: ["github", "slack", "notion"],
+    connectorSlugs: ["github", "slack", "notion"],
     behavior: [
       "A PR is labeled release",
       "Zero drafts the changelog",
@@ -241,7 +242,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "Product",
     title: "Sync the Linear roadmap to Notion",
     description: "Keep a Notion roadmap in sync with your Linear issue status.",
-    connectors: ["linear", "notion"],
+    connectorSlugs: ["linear", "notion"],
     behavior: [
       "Zero reads Linear status",
       "Mapped to Now / Next / Later",
@@ -256,7 +257,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Track feature usage with PostHog",
     description:
       "Surface the biggest weekly shifts in feature usage from PostHog.",
-    connectors: ["posthog", "slack"],
+    connectorSlugs: ["posthog", "slack"],
     behavior: [
       "Zero reads PostHog",
       "Compared week over week",
@@ -270,7 +271,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "Product",
     title: "Flag Figma designs without a task",
     description: "Flag Figma designs that have no linked Linear task yet.",
-    connectors: ["figma", "linear", "slack"],
+    connectorSlugs: ["figma", "linear", "slack"],
     behavior: [
       "Zero scans Figma frames",
       "Finds frames without a task",
@@ -285,7 +286,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "RevenueCat subscription digest",
     description:
       "Track subscriptions in Sheets and alert Slack when churn or cancellation patterns change.",
-    connectors: ["revenuecat", "google-sheets", "slack"],
+    connectorSlugs: ["revenuecat", "google-sheets", "slack"],
     behavior: [
       "Create a daily scheduled workflow that pulls RevenueCat subscription activity.",
       "Log new subscriptions, renewals, cancellations, and notable churn signals in Google Sheets.",
@@ -301,7 +302,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Post daily metrics to Slack",
     description:
       "Post daily visitors, signups, and activation numbers to Slack.",
-    connectors: ["plausible", "slack", "posthog", "clerk"],
+    connectorSlugs: ["plausible", "slack", "posthog", "clerk"],
     behavior: [
       "Zero pulls the metrics",
       "Assembled into a KPI snapshot",
@@ -316,7 +317,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Run a daily query into Google Sheets",
     description:
       "Run your saved SQL on a schedule and append the results to a Sheet.",
-    connectors: ["snowflake", "google-sheets", "slack"],
+    connectorSlugs: ["snowflake", "google-sheets", "slack"],
     behavior: [
       "Zero runs the query",
       "Results formatted",
@@ -331,7 +332,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Check the PostHog signup funnel",
     description:
       "Track the signup funnel and post the biggest drop-off to Slack.",
-    connectors: ["posthog", "slack"],
+    connectorSlugs: ["posthog", "slack"],
     behavior: [
       "Zero runs the funnel",
       "Biggest drop-off identified",
@@ -346,7 +347,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Alert when a metric moves",
     description:
       "Watch your key metrics and alert Slack when one moves sharply.",
-    connectors: ["plausible", "slack", "posthog"],
+    connectorSlugs: ["plausible", "slack", "posthog"],
     behavior: [
       "Zero checks the metric",
       "Compared to normal range",
@@ -360,7 +361,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "Data",
     title: "Track signup sources in Google Sheets",
     description: "Attribute each new signup to its source in a tracking Sheet.",
-    connectors: ["clerk", "google-sheets", "plausible"],
+    connectorSlugs: ["clerk", "google-sheets", "plausible"],
     behavior: [
       "Zero reads new signups",
       "Attributed to a channel",
@@ -375,7 +376,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Build the weekly deck in Gamma",
     description:
       "Turn the week's metrics into a ready-to-present deck in Gamma.",
-    connectors: ["google-sheets", "gamma", "plausible", "slack"],
+    connectorSlugs: ["google-sheets", "gamma", "plausible", "slack"],
     behavior: [
       "Zero gathers the numbers",
       "Deck built in Gamma",
@@ -390,7 +391,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Competitive intel monitor",
     description:
       "Monitor competitor sites for pricing and feature changes, save findings to Notion, and alert Slack.",
-    connectors: ["firecrawl", "notion", "slack"],
+    connectorSlugs: ["firecrawl", "notion", "slack"],
     behavior: [
       "Create a weekly or daily scheduled workflow for a list of competitor pages.",
       "Use Firecrawl to detect meaningful pricing, packaging, messaging, and feature changes.",
@@ -406,7 +407,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "X brand monitor",
     description:
       "Track brand mentions on X, save relevant posts in Notion, and alert Slack on high-signal mentions.",
-    connectors: ["x", "notion", "slack"],
+    connectorSlugs: ["x", "notion", "slack"],
     behavior: [
       "Create a scheduled workflow that searches X for product, company, or keyword mentions.",
       "Filter posts for relevance, engagement, sentiment, and response urgency.",
@@ -422,7 +423,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Track keyword ranks with Ahrefs",
     description:
       "Track keyword rankings in Ahrefs and report the movers in Notion.",
-    connectors: ["ahrefs", "similarweb", "notion"],
+    connectorSlugs: ["ahrefs", "similarweb", "notion"],
     behavior: [
       "Zero reads keyword positions",
       "Movers identified",
@@ -437,7 +438,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Publish scheduled posts to Buffer",
     description:
       "Publish the day's scheduled content and queue the social posts.",
-    connectors: ["notion", "strapi", "buffer"],
+    connectorSlugs: ["notion", "strapi", "buffer"],
     behavior: [
       "Zero reads today's calendar",
       "Published to the CMS",
@@ -452,7 +453,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Turn blog posts into social posts",
     description:
       "Turn each new blog post into social variants queued via Buffer.",
-    connectors: ["strapi", "buffer", "x"],
+    connectorSlugs: ["strapi", "buffer", "x"],
     behavior: [
       "Zero finds new posts",
       "Cut into social variants",
@@ -467,7 +468,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Draft the newsletter in Mailchimp",
     description:
       "Assemble recent updates into a newsletter draft in Mailchimp.",
-    connectors: ["github", "mailchimp"],
+    connectorSlugs: ["github", "mailchimp"],
     behavior: [
       "Zero gathers what shipped",
       "Newsletter drafted",
@@ -482,7 +483,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Compare Google Ads vs last month",
     description:
       "Compare ad spend and ROAS to last month and flag anomalies in Slack.",
-    connectors: ["google-ads", "slack", "meta-ads"],
+    connectorSlugs: ["google-ads", "slack", "meta-ads"],
     behavior: [
       "Zero reads ad performance",
       "Compared to prior period",
@@ -497,7 +498,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Salesforce pipeline digest",
     description:
       "Summarize Salesforce opportunity changes and close-date risks in Slack each week.",
-    connectors: ["salesforce", "slack"],
+    connectorSlugs: ["salesforce", "slack"],
     behavior: [
       "Create a weekly scheduled workflow that reviews selected Salesforce opportunities.",
       "Summarize new opportunities, stage changes, close-date movement, and blocked deals.",
@@ -513,7 +514,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Catch leads from Gmail",
     description:
       "Spot buying signals in new email and log the qualified leads.",
-    connectors: ["gmail", "apollo", "google-sheets", "slack"],
+    connectorSlugs: ["gmail", "apollo", "google-sheets", "slack"],
     behavior: [
       "Zero scans new mail",
       "Lead enriched and logged",
@@ -527,7 +528,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "Sales",
     title: "Add new Gmail contacts to HubSpot",
     description: "Add and enrich unknown email senders as HubSpot contacts.",
-    connectors: ["gmail", "hubspot", "apollo"],
+    connectorSlugs: ["gmail", "hubspot", "apollo"],
     behavior: [
       "Zero spots an unknown sender",
       "Contact created and enriched",
@@ -541,7 +542,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "Sales",
     title: "Research new signups",
     description: "Research each new signup and post a quick snapshot.",
-    connectors: ["clerk", "slack", "apollo"],
+    connectorSlugs: ["clerk", "slack", "apollo"],
     behavior: [
       "Zero reads new signups",
       "Researched with Apollo",
@@ -555,7 +556,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "Sales",
     title: "Send Gmail follow-ups automatically",
     description: "Find contacts who didn't reply and draft the next follow-up.",
-    connectors: ["instantly", "gmail", "apollo"],
+    connectorSlugs: ["instantly", "gmail", "apollo"],
     behavior: [
       "Zero checks sequence status",
       "Next touch drafted",
@@ -570,7 +571,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Prep for Google Calendar meetings",
     description:
       "Research external attendees and send a prep brief before meetings.",
-    connectors: ["google-calendar", "apollo", "gong", "slack"],
+    connectorSlugs: ["google-calendar", "apollo", "gong", "slack"],
     behavior: [
       "A meeting is added",
       "Attendee researched",
@@ -585,7 +586,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Log Gong calls to HubSpot",
     description:
       "Pull notes and next steps from a Gong call into the HubSpot deal.",
-    connectors: ["gong", "hubspot", "slack"],
+    connectorSlugs: ["gong", "hubspot", "slack"],
     behavior: [
       "Zero reads the transcript",
       "Summary and next steps drafted",
@@ -600,7 +601,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Support ticket router",
     description:
       "Classify support emails, create Notion records, and alert Slack for critical tickets.",
-    connectors: ["gmail", "notion", "slack"],
+    connectorSlugs: ["gmail", "notion", "slack"],
     behavior: [
       "Create a workflow that runs from a Gmail trigger or scheduled inbox scan.",
       "Classify support messages by category, priority, customer, and requested action.",
@@ -616,7 +617,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Zendesk knowledge base",
     description:
       "Find recurring Zendesk questions, draft FAQ entries, and save them to Notion.",
-    connectors: ["zendesk", "notion", "slack"],
+    connectorSlugs: ["zendesk", "notion", "slack"],
     behavior: [
       "Create a scheduled workflow that reviews recent Zendesk conversations or tickets.",
       "Cluster recurring questions, gaps, and confusing product areas.",
@@ -631,7 +632,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "Support",
     title: "Draft replies from your Notion FAQ",
     description: "Draft ticket replies grounded in your Notion FAQ.",
-    connectors: ["intercom", "notion", "gmail"],
+    connectorSlugs: ["intercom", "notion", "gmail"],
     behavior: [
       "A question arrives",
       "Zero checks the Notion FAQ",
@@ -646,7 +647,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Send bugs to GitHub and Slack",
     description:
       "File bug-tagged reports as GitHub issues and alert the team on Slack.",
-    connectors: ["github", "slack", "linear"],
+    connectorSlugs: ["github", "slack", "linear"],
     behavior: [
       "An issue is labeled bug",
       "Repro and impact packaged",
@@ -660,7 +661,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "Support",
     title: "Spot churn risk in Stripe and Zendesk",
     description: "Flag accounts at risk of churn and draft a recovery email.",
-    connectors: ["clerk", "stripe", "zendesk", "resend", "slack"],
+    connectorSlugs: ["clerk", "stripe", "zendesk", "resend", "slack"],
     behavior: [
       "Zero scans accounts",
       "At-risk accounts flagged",
@@ -675,7 +676,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Summarize Zendesk tickets daily",
     description:
       "Summarize the last day of Zendesk tickets and post it to Slack.",
-    connectors: ["zendesk", "slack"],
+    connectorSlugs: ["zendesk", "slack"],
     behavior: [
       "Zero reads the queue",
       "Grouped by severity and age",
@@ -690,7 +691,14 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Post a daily company brief to Slack",
     description:
       "Pull product, growth, and revenue into a daily brief on Slack.",
-    connectors: ["plausible", "slack", "clerk", "stripe", "github", "sentry"],
+    connectorSlugs: [
+      "plausible",
+      "slack",
+      "clerk",
+      "stripe",
+      "github",
+      "sentry",
+    ],
     behavior: [
       "Zero gathers the signals",
       "Assembled into a pulse",
@@ -705,7 +713,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Post daily industry news to Slack",
     description:
       "Round up the day's relevant industry news into a Slack brief.",
-    connectors: ["exa", "slack"],
+    connectorSlugs: ["exa", "slack"],
     behavior: [
       "Zero scans the news",
       "Distilled into a brief",
@@ -720,7 +728,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Build the business review in Gamma",
     description:
       "Turn the month's metrics into a business review deck in Gamma.",
-    connectors: ["stripe", "gamma", "clerk"],
+    connectorSlugs: ["stripe", "gamma", "clerk"],
     behavior: [
       "Zero pulls the numbers",
       "Deck built in Gamma",
@@ -734,7 +742,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "CEO",
     title: "Highlight key emails in Gmail",
     description: "Surface the few emails that actually need your attention.",
-    connectors: ["gmail", "slack"],
+    connectorSlugs: ["gmail", "slack"],
     behavior: [
       "Zero reads the inbox",
       "Priorities identified",
@@ -749,7 +757,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Draft the investor update in Google Docs",
     description:
       "Assemble metrics and highlights into an investor update in Docs.",
-    connectors: ["stripe", "google-docs", "google-sheets"],
+    connectorSlugs: ["stripe", "google-docs", "google-sheets"],
     behavior: [
       "Zero gathers KPIs",
       "Update drafted",
@@ -763,7 +771,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "CEO",
     title: "Get Gmail reconnect reminders",
     description: "Surface important contacts you haven't emailed in a while.",
-    connectors: ["gmail", "google-calendar", "slack"],
+    connectorSlugs: ["gmail", "google-calendar", "slack"],
     behavior: [
       "Zero reviews your contacts",
       "Quiet relationships surfaced",
@@ -778,7 +786,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "ClickUp Slack standup",
     description:
       "Pull ClickUp tasks each morning and post a team standup summary to Slack.",
-    connectors: ["clickup", "slack"],
+    connectorSlugs: ["clickup", "slack"],
     behavior: [
       "Create a daily scheduled workflow that reads selected ClickUp spaces, folders, lists, or assignees.",
       "Summarize active tasks, completed work, blockers, and overdue items by person or team.",
@@ -793,7 +801,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "Operations",
     title: "Sync Asana projects to Notion",
     description: "Roll up Asana project status into a single board in Notion.",
-    connectors: ["asana", "notion"],
+    connectorSlugs: ["asana", "notion"],
     behavior: ["Zero reads Asana", "Rolled into one board", "Digest posted"],
     missingInfo:
       "Connectors: asana, notion required.\nSuggested trigger: Add a schedule trigger (e.g. every morning). Asana has no native event trigger, so poll on a cadence.\n\nCreate the workflow draft first. Before adding or enabling its automation, ask one short question for the next missing trigger or safety detail. Do not inspect connector setup until the workflow or trigger command reports that it is required.",
@@ -803,7 +811,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "Operations",
     title: "Turn meeting notes into Asana tasks",
     description: "Turn meeting notes into assigned, due-dated tasks in Asana.",
-    connectors: ["fireflies", "asana"],
+    connectorSlugs: ["fireflies", "asana"],
     behavior: [
       "Zero reads the transcript",
       "Action items extracted",
@@ -817,7 +825,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "Operations",
     title: "File Gmail invoices to Google Drive",
     description: "File invoice emails to Drive and log each one in a Sheet.",
-    connectors: ["gmail", "google-drive", "google-sheets"],
+    connectorSlugs: ["gmail", "google-drive", "google-sheets"],
     behavior: [
       "An invoice is labeled",
       "Filed to Google Drive",
@@ -832,7 +840,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Onboard new hires in Asana",
     description:
       "Create the onboarding task checklist for each new hire in Asana.",
-    connectors: ["deel", "asana", "google-drive"],
+    connectorSlugs: ["deel", "asana", "google-drive"],
     behavior: [
       "A new hire is added",
       "Checklist created in Asana",
@@ -846,7 +854,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "Operations",
     title: "Chase overdue Asana tasks",
     description: "Find overdue Asana tasks and nudge their owners on Slack.",
-    connectors: ["asana", "slack"],
+    connectorSlugs: ["asana", "slack"],
     behavior: ["Zero scans Asana", "Owners identified", "Nudges sent in Slack"],
     missingInfo:
       "Connectors: asana, slack required.\nSuggested trigger: Add a schedule trigger (e.g. every morning).\n\nCreate the workflow draft first. Before adding or enabling its automation, ask one short question for the next missing trigger or safety detail. Do not inspect connector setup until the workflow or trigger command reports that it is required.",
@@ -856,7 +864,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "Operations",
     title: "Catch Google Calendar conflicts",
     description: "Scan your calendar for double-bookings and alert you early.",
-    connectors: ["google-calendar", "cal-com", "slack"],
+    connectorSlugs: ["google-calendar", "cal-com", "slack"],
     behavior: [
       "An event is created",
       "Checked for conflicts",
@@ -871,7 +879,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Personal weekly digest",
     description:
       "Summarize GitHub, Gmail, and Calendar activity into one weekly Slack update.",
-    connectors: ["github", "gmail", "google-calendar", "slack"],
+    connectorSlugs: ["github", "gmail", "google-calendar", "slack"],
     behavior: [
       "Create a weekly scheduled workflow for the selected owner.",
       "Collect recent pull requests, important inbox threads, and upcoming or completed calendar events.",
@@ -887,7 +895,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Morning brief",
     description:
       "Turn Gmail, Calendar, and Notion updates into a short daily plan in Slack.",
-    connectors: ["gmail", "google-calendar", "notion", "slack"],
+    connectorSlugs: ["gmail", "google-calendar", "notion", "slack"],
     behavior: [
       "Create a daily scheduled workflow that prepares a morning planning brief.",
       "Review important email, calendar events, and relevant Notion updates.",
@@ -903,7 +911,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Sort Gmail and draft replies",
     description:
       "Sort your inbox and draft replies to the emails that need them.",
-    connectors: ["gmail"],
+    connectorSlugs: ["gmail"],
     behavior: ["Zero reads new mail", "Sorted by urgency", "Replies drafted"],
     missingInfo:
       "Connectors: gmail required.\nSuggested trigger: Add a gmail-new-message event trigger so it runs on each new incoming email.\n\nCreate the workflow draft first. Before adding or enabling its automation, ask one short question for the next missing trigger or safety detail. Do not inspect connector setup until the workflow or trigger command reports that it is required.",
@@ -914,7 +922,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Research your calendar meetings",
     description:
       "Research the people you're meeting before each calendar event.",
-    connectors: ["google-calendar", "exa", "slack"],
+    connectorSlugs: ["google-calendar", "exa", "slack"],
     behavior: [
       "A meeting is added",
       "Attendees researched",
@@ -928,7 +936,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "Everyone",
     title: "Summarize Gmail newsletters",
     description: "Digest the newsletters in your inbox into one short summary.",
-    connectors: ["gmail", "slack"],
+    connectorSlugs: ["gmail", "slack"],
     behavior: [
       "Zero collects newsletters",
       "Digested into one summary",
@@ -943,7 +951,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     title: "Get meeting recaps in Slack",
     description:
       "Share a recap with decisions and action items after each meeting.",
-    connectors: ["fireflies", "gmail", "slack"],
+    connectorSlugs: ["fireflies", "gmail", "slack"],
     behavior: ["Zero reads the transcript", "Recap written", "Sent to you"],
     missingInfo:
       "Connectors: fireflies required; gmail, slack optional.\nSuggested trigger: Add a google-meet-transcript-generated event trigger if you meet on Google Meet; otherwise a schedule trigger, since Fireflies has no native event trigger.\n\nCreate the workflow draft first. Before adding or enabling its automation, ask one short question for the next missing trigger or safety detail. Do not inspect connector setup until the workflow or trigger command reports that it is required.",
@@ -953,7 +961,7 @@ export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
     category: "Everyone",
     title: "Turn flagged Gmail into Todoist tasks",
     description: "Turn the emails you flag into Todoist tasks automatically.",
-    connectors: ["gmail", "todoist"],
+    connectorSlugs: ["gmail", "todoist"],
     behavior: [
       "You flag an email",
       "Zero researches it",


### PR DESCRIPTION
## Summary

- rename workflow-template, onboarding, and ideation collections that contain official connector slugs to `connectorSlugs`
- use `ConnectorSlug` for already-validated local official connector identities
- replace the remaining stale firewall `ref` wording with firewall/catalog terminology

## Compatibility

- preserve the historical permission-action URL `ref` fallback and its focused tests
- preserve historical migrations, snapshots, and migration-consistency fixtures
- no API, runner, or realtime wire shape changes
- no database schema or persisted-data changes
- no connector values or runtime behavior changes

## Validation

- Prettier, workspace lint, full Turbo type checking, and Knip
- `@vm0/core`: 213 tests passed
- `@vm0/connectors`: 820 tests passed
- Platform focused integration tests: 93 passed
- API template-prompt integration tests: 11 passed
- runner: Cargo fmt, Clippy, docs, and 2,912 tests passed
- mitm-addon: uv lock/sync, Ruff, basedpyright, and 4,550 tests passed
- `git diff --check`

Relates to #23619
