### PR TITLE
fix(platform): stack preference setting rows on narrow screens

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
@@ -140,32 +140,34 @@ export function LanguageSettings() {
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-center gap-4 bg-card p-4 rounded-xl zero-border">
-        <div className="shrink-0">
-          <div className="flex h-7 w-7 items-center justify-center">
-            <IconWorld
-              size={22}
-              stroke={1.5}
-              className="text-muted-foreground"
-            />
+      <div className="flex flex-col gap-3 bg-card p-4 rounded-xl zero-border sm:flex-row sm:items-center sm:gap-4">
+        <div className="flex flex-1 items-center gap-4 min-w-0">
+          <div className="shrink-0">
+            <div className="flex h-7 w-7 items-center justify-center">
+              <IconWorld
+                size={22}
+                stroke={1.5}
+                className="text-muted-foreground"
+              />
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col gap-1 min-w-0">
+            <div className="text-sm font-medium text-foreground">
+              {t(($) => {
+                return $.settings.preferences.language.title;
+              })}
+            </div>
+            <div className="text-sm text-muted-foreground">
+              {t(
+                ($) => {
+                  return $.settings.preferences.language.description;
+                },
+                { brandName },
+              )}
+            </div>
           </div>
         </div>
-        <div className="flex flex-1 flex-col gap-1 min-w-0">
-          <div className="text-sm font-medium text-foreground">
-            {t(($) => {
-              return $.settings.preferences.language.title;
-            })}
-          </div>
-          <div className="text-sm text-muted-foreground">
-            {t(
-              ($) => {
-                return $.settings.preferences.language.description;
-              },
-              { brandName },
-            )}
-          </div>
-        </div>
-        <div className="w-40 shrink-0">
+        <div className="w-full shrink-0 sm:w-40">
           <Select value={locale} disabled={saving} onValueChange={handleChange}>
             <SelectTrigger
               aria-label={t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/morning-brief-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/morning-brief-settings.tsx
@@ -84,54 +84,56 @@ export function MorningBriefSettings() {
   }
 
   return (
-    <div className="flex items-center gap-4 bg-card p-4 rounded-xl zero-border">
-      <div className="shrink-0">
-        <div className="flex h-7 w-7 items-center justify-center">
-          <IconSunrise
-            size={22}
-            stroke={1.5}
-            className="text-muted-foreground"
-          />
-        </div>
-      </div>
-      <div className="flex flex-1 flex-col gap-1 min-w-0">
-        <div className="text-sm font-medium text-foreground">
-          {t(($) => {
-            return $.settings.preferences.morningBrief.title;
-          })}
-        </div>
-        <div className="text-sm text-muted-foreground">
-          {t(($) => {
-            return $.settings.preferences.morningBrief.description;
-          })}
-        </div>
-        {preferences.morningBriefEnabled && (
-          <div className="text-xs text-muted-foreground">
-            {nextRun === null
-              ? t(($) => {
-                  return $.settings.preferences.morningBrief.notScheduled;
-                })
-              : preferences.timezone
-                ? t(
-                    ($) => {
-                      return $.settings.preferences.morningBrief
-                        .nextEmailInTimezone;
-                    },
-                    {
-                      date: nextRun,
-                      timezone: preferences.timezone,
-                    },
-                  )
-                : t(
-                    ($) => {
-                      return $.settings.preferences.morningBrief.nextEmail;
-                    },
-                    {
-                      date: nextRun,
-                    },
-                  )}
+    <div className="flex flex-col gap-3 bg-card p-4 rounded-xl zero-border sm:flex-row sm:items-center sm:gap-4">
+      <div className="flex flex-1 items-center gap-4 min-w-0">
+        <div className="shrink-0">
+          <div className="flex h-7 w-7 items-center justify-center">
+            <IconSunrise
+              size={22}
+              stroke={1.5}
+              className="text-muted-foreground"
+            />
           </div>
-        )}
+        </div>
+        <div className="flex flex-1 flex-col gap-1 min-w-0">
+          <div className="text-sm font-medium text-foreground">
+            {t(($) => {
+              return $.settings.preferences.morningBrief.title;
+            })}
+          </div>
+          <div className="text-sm text-muted-foreground">
+            {t(($) => {
+              return $.settings.preferences.morningBrief.description;
+            })}
+          </div>
+          {preferences.morningBriefEnabled && (
+            <div className="text-xs text-muted-foreground">
+              {nextRun === null
+                ? t(($) => {
+                    return $.settings.preferences.morningBrief.notScheduled;
+                  })
+                : preferences.timezone
+                  ? t(
+                      ($) => {
+                        return $.settings.preferences.morningBrief
+                          .nextEmailInTimezone;
+                      },
+                      {
+                        date: nextRun,
+                        timezone: preferences.timezone,
+                      },
+                    )
+                  : t(
+                      ($) => {
+                        return $.settings.preferences.morningBrief.nextEmail;
+                      },
+                      {
+                        date: nextRun,
+                      },
+                    )}
+            </div>
+          )}
+        </div>
       </div>
       <div className="flex shrink-0 items-center gap-3">
         {manualEnabled && (

--- a/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
@@ -121,29 +121,31 @@ export function TimezoneSettings() {
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-center gap-4 bg-card p-4 rounded-xl zero-border">
-        <div className="shrink-0">
-          <div className="flex h-7 w-7 items-center justify-center">
-            <IconClock
-              size={22}
-              stroke={1.5}
-              className="text-muted-foreground"
-            />
+      <div className="flex flex-col gap-3 bg-card p-4 rounded-xl zero-border sm:flex-row sm:items-center sm:gap-4">
+        <div className="flex flex-1 items-center gap-4 min-w-0">
+          <div className="shrink-0">
+            <div className="flex h-7 w-7 items-center justify-center">
+              <IconClock
+                size={22}
+                stroke={1.5}
+                className="text-muted-foreground"
+              />
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col gap-1 min-w-0">
+            <div className="text-sm font-medium text-foreground">
+              {t(($) => {
+                return $.settings.preferences.timezone.rowTitle;
+              })}
+            </div>
+            <div className="text-sm text-muted-foreground">
+              {t(($) => {
+                return $.settings.preferences.timezone.rowDescription;
+              })}
+            </div>
           </div>
         </div>
-        <div className="flex flex-1 flex-col gap-1 min-w-0">
-          <div className="text-sm font-medium text-foreground">
-            {t(($) => {
-              return $.settings.preferences.timezone.rowTitle;
-            })}
-          </div>
-          <div className="text-sm text-muted-foreground">
-            {t(($) => {
-              return $.settings.preferences.timezone.rowDescription;
-            })}
-          </div>
-        </div>
-        <div className="relative shrink-0 w-64">
+        <div className="relative w-full shrink-0 sm:w-64">
           <Select
             value={currentTimezone}
             onValueChange={handleChange}

--- a/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
@@ -60,29 +60,31 @@ function AppearanceSettings() {
           return $.settings.preferences.appearance.description;
         })}
       </p>
-      <div className="flex items-center gap-4 bg-card p-4 rounded-xl zero-border">
-        <div className="shrink-0">
-          <div className="flex h-7 w-7 items-center justify-center">
-            <IconPalette
-              size={22}
-              stroke={1.5}
-              className="text-muted-foreground"
-            />
+      <div className="flex flex-col gap-3 bg-card p-4 rounded-xl zero-border sm:flex-row sm:items-center sm:gap-4">
+        <div className="flex flex-1 items-center gap-4 min-w-0">
+          <div className="shrink-0">
+            <div className="flex h-7 w-7 items-center justify-center">
+              <IconPalette
+                size={22}
+                stroke={1.5}
+                className="text-muted-foreground"
+              />
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col gap-1 min-w-0">
+            <div className="text-sm font-medium text-foreground">
+              {t(($) => {
+                return $.settings.preferences.appearance.theme.title;
+              })}
+            </div>
+            <div className="text-sm text-muted-foreground">
+              {t(($) => {
+                return $.settings.preferences.appearance.theme.description;
+              })}
+            </div>
           </div>
         </div>
-        <div className="flex flex-1 flex-col gap-1 min-w-0">
-          <div className="text-sm font-medium text-foreground">
-            {t(($) => {
-              return $.settings.preferences.appearance.theme.title;
-            })}
-          </div>
-          <div className="text-sm text-muted-foreground">
-            {t(($) => {
-              return $.settings.preferences.appearance.theme.description;
-            })}
-          </div>
-        </div>
-        <div className="flex gap-2 shrink-0">
+        <div className="flex flex-wrap gap-2 shrink-0">
           {THEME_OPTIONS.map(({ value, icon: Icon }) => {
             const label =
               value === "light"
@@ -144,33 +146,35 @@ function SendModeSettings() {
           return $.settings.preferences.send.description;
         })}
       </p>
-      <div className="flex items-center gap-4 bg-card p-4 rounded-xl zero-border">
-        <div className="shrink-0">
-          <div className="flex h-7 w-7 items-center justify-center">
-            <IconKeyboard
-              size={22}
-              stroke={1.5}
-              className="text-muted-foreground"
-            />
+      <div className="flex flex-col gap-3 bg-card p-4 rounded-xl zero-border sm:flex-row sm:items-center sm:gap-4">
+        <div className="flex flex-1 items-center gap-4 min-w-0">
+          <div className="shrink-0">
+            <div className="flex h-7 w-7 items-center justify-center">
+              <IconKeyboard
+                size={22}
+                stroke={1.5}
+                className="text-muted-foreground"
+              />
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col gap-1 min-w-0">
+            <div className="text-sm font-medium text-foreground">
+              {t(($) => {
+                return $.settings.preferences.send.title;
+              })}
+            </div>
+            <div className="text-sm text-muted-foreground">
+              {(saving ?? current) === "enter"
+                ? t(($) => {
+                    return $.settings.preferences.send.enterDescription;
+                  })
+                : t(($) => {
+                    return $.settings.preferences.send.cmdEnterDescription;
+                  })}
+            </div>
           </div>
         </div>
-        <div className="flex flex-1 flex-col gap-1 min-w-0">
-          <div className="text-sm font-medium text-foreground">
-            {t(($) => {
-              return $.settings.preferences.send.title;
-            })}
-          </div>
-          <div className="text-sm text-muted-foreground">
-            {(saving ?? current) === "enter"
-              ? t(($) => {
-                  return $.settings.preferences.send.enterDescription;
-                })
-              : t(($) => {
-                  return $.settings.preferences.send.cmdEnterDescription;
-                })}
-          </div>
-        </div>
-        <div className="flex gap-2 shrink-0">
+        <div className="flex flex-wrap gap-2 shrink-0">
           {SEND_OPTIONS.map((value) => {
             const isActive =
               saving === value ? true : saving === null && current === value;


### PR DESCRIPTION
## Problem

In the Preference settings (dialog and `/settings`), the **Language**, **Time zone** and **Morning Brief** rows used a fixed horizontal layout (`flex items-center gap-4`) with a fixed-width control (`w-40` / `w-64` / button + switch). On mobile and PWA widths the description column is squeezed to roughly 60px and wraps to about one word per line, and the time zone value is truncated. Reported on iOS PWA.

## Fix

Apply the responsive pattern the **Theme** and **Send** rows in the same dialog already use:

- outer row: `flex flex-col gap-3 ... sm:flex-row sm:items-center sm:gap-4`
- icon + text wrapped in `flex flex-1 items-center gap-4 min-w-0`
- control becomes `w-full` below `sm`, keeps its fixed width from `sm` up

Applied to `language-settings.tsx`, `timezone-settings.tsx`, `morning-brief-settings.tsx` (shared by the settings dialog and `/settings`), and to the two local Theme / Send blocks in `zero-account-page.tsx`, which render the same non-responsive row on `/settings`.

Desktop layout is unchanged at `sm` and above.

## Verification

- `pnpm format`, `pnpm -F @vm0/app check-types`, `pnpm -F @vm0/app lint` — pass
- `vitest run settings-dialog.test.tsx preferences-page.test.tsx` — 33 passed
- Rendered the before/after markup at a 390px viewport: the collapsed text column is gone and each control takes the full row width

🤖 Generated with [Claude Code](https://claude.com/claude-code)