### PR TITLE
refactor(runner): finish workspace image cache cutover

### DIFF
--- a/crates/runner/src/cmd/start/active_reuse_keys.rs
+++ b/crates/runner/src/cmd/start/active_reuse_keys.rs
@@ -63,29 +63,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn active_sessions_are_ref_counted() {
-        let active_sessions = new_active_reuse_keys();
-        insert_active_reuse_key(&active_sessions, "session:sess-1");
-        insert_active_reuse_key(&active_sessions, "session:sess-1");
+    fn active_reuse_keys_are_ref_counted() {
+        let registry = new_active_reuse_keys();
+        insert_active_reuse_key(&registry, "thread:thread-1");
+        insert_active_reuse_key(&registry, "thread:thread-1");
 
-        assert!(active_reuse_keys(&active_sessions).contains("session:sess-1"));
+        assert!(active_reuse_keys(&registry).contains("thread:thread-1"));
 
-        remove_active_reuse_key(&active_sessions, "session:sess-1");
-        assert!(active_reuse_keys(&active_sessions).contains("session:sess-1"));
+        remove_active_reuse_key(&registry, "thread:thread-1");
+        assert!(active_reuse_keys(&registry).contains("thread:thread-1"));
 
-        remove_active_reuse_key(&active_sessions, "session:sess-1");
-        assert!(!active_reuse_keys(&active_sessions).contains("session:sess-1"));
+        remove_active_reuse_key(&registry, "thread:thread-1");
+        assert!(!active_reuse_keys(&registry).contains("thread:thread-1"));
     }
 
     #[test]
     fn active_reuse_key_guard_registers_and_unregisters_initial_key() {
-        let active_sessions = new_active_reuse_keys();
-        let guard =
-            ActiveReuseKeyGuard::new(Arc::clone(&active_sessions), Some("thread:thread-1".into()));
+        let registry = new_active_reuse_keys();
+        let guard = ActiveReuseKeyGuard::new(Arc::clone(&registry), Some("thread:thread-2".into()));
 
-        assert!(active_reuse_keys(&active_sessions).contains("thread:thread-1"));
+        assert!(active_reuse_keys(&registry).contains("thread:thread-2"));
 
         drop(guard);
-        assert!(!active_reuse_keys(&active_sessions).contains("thread:thread-1"));
+        assert!(!active_reuse_keys(&registry).contains("thread:thread-2"));
     }
 }

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use futures_util::future::BoxFuture;
 use tracing::{debug, info};
 
-use super::active_sessions::{ActiveReuseKeys, active_reuse_keys};
+use super::active_reuse_keys::{ActiveReuseKeys, active_reuse_keys};
 use crate::config::ProfileConfig;
 use crate::error::{RunnerError, RunnerResult};
 use crate::idle_pool::IdlePool;
@@ -16,7 +16,7 @@ use crate::types::{
     HeartbeatState, HeldSessionState, HeldWorkspaceState, MAX_HELD_SESSION_STATES,
     MAX_WORKSPACE_CACHES_PER_REUSE_KEY,
 };
-use crate::workspace_image_cache::{SessionWorkspaceCache, cap_held_workspace_states};
+use crate::workspace_image_cache::{WorkspaceImageCache, cap_held_workspace_states};
 
 /// Period between routine heartbeat ticks sent to the server. First tick is
 /// deferred by one period via `interval_at`.
@@ -35,7 +35,7 @@ pub(super) struct HeartbeatContext<'a> {
     profiles: &'a BTreeMap<String, ProfileConfig>,
     budget: &'a ResourceBudget,
     provider: &'a dyn JobProvider,
-    workspace_cache: Option<SessionWorkspaceCache>,
+    workspace_cache: Option<WorkspaceImageCache>,
     active_reuse_keys: &'a ActiveReuseKeys,
     workspace_cache_snapshot: WorkspaceCacheStateSnapshot,
 }
@@ -49,7 +49,7 @@ pub(super) struct HeartbeatContextInit<'a> {
     pub(super) profiles: &'a BTreeMap<String, ProfileConfig>,
     pub(super) budget: &'a ResourceBudget,
     pub(super) provider: &'a dyn JobProvider,
-    pub(super) workspace_cache: Option<SessionWorkspaceCache>,
+    pub(super) workspace_cache: Option<WorkspaceImageCache>,
     pub(super) active_reuse_keys: &'a ActiveReuseKeys,
     pub(super) workspace_cache_snapshot: WorkspaceCacheStateSnapshot,
 }
@@ -377,7 +377,7 @@ pub(super) async fn send_heartbeat(
 /// snapshot, which may also contain updates merged from concurrent promotions.
 pub(super) async fn refresh_workspace_cache_snapshot(
     snapshot: &WorkspaceCacheStateSnapshot,
-    workspace_cache: Option<&SessionWorkspaceCache>,
+    workspace_cache: Option<&WorkspaceImageCache>,
     profiles: &BTreeMap<String, ProfileConfig>,
 ) -> Vec<HeldWorkspaceState> {
     let refresh = snapshot.begin_workspace_cache_refresh();
@@ -386,7 +386,7 @@ pub(super) async fn refresh_workspace_cache_snapshot(
 }
 
 async fn workspace_cache_states(
-    workspace_cache: Option<&SessionWorkspaceCache>,
+    workspace_cache: Option<&WorkspaceImageCache>,
     profiles: &BTreeMap<String, ProfileConfig>,
 ) -> Vec<HeldWorkspaceState> {
     let Some(cache) = workspace_cache else {
@@ -697,7 +697,7 @@ mod tests {
     }
 
     async fn seed_workspace_cache_state(
-        cache: &SessionWorkspaceCache,
+        cache: &WorkspaceImageCache,
         paths: &RunnerPaths,
         reuse_key: &str,
         completed_at: &str,
@@ -711,7 +711,6 @@ mod tests {
                     sandbox_id,
                     profile_name: "vm0/default",
                     reuse_key: Some(reuse_key),
-                    cli_agent_session_id: None,
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: 1024 * 1024,
                 },
@@ -732,7 +731,6 @@ mod tests {
             lease
                 .promote(
                     run_id,
-                    None,
                     WorkspaceCacheTerminalStatus::Success,
                     completed_at.into(),
                     &crate::storage_fingerprints::StorageFingerprints::default(),
@@ -900,11 +898,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
         seed_workspace_cache_state(&cache, &paths, reuse_key, "2026-06-01T00:00:00.000Z").await;
         let profiles = test_profiles();
         let budget = ResourceBudget::new(8, 32768, 1.0, 4);
-        let active_reuse_keys = super::super::active_sessions::new_active_reuse_keys();
+        let active_reuse_keys = super::super::active_reuse_keys::new_active_reuse_keys();
         let (provider, _) = MockJobProvider::new(tokio_util::sync::CancellationToken::new());
         let workspace_cache_snapshot = WorkspaceCacheStateSnapshot::new();
         let hb = HeartbeatContext::new(HeartbeatContextInit {
@@ -959,11 +957,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
         seed_workspace_cache_state(&cache, &paths, "sess-cache", "2026-06-01T00:00:00.000Z").await;
         seed_workspace_cache_state(&cache, &paths, "sess-claimed", "2026-06-01T00:00:01.000Z")
             .await;
-        let active_reuse_keys = super::super::active_sessions::new_active_reuse_keys();
+        let active_reuse_keys = super::super::active_reuse_keys::new_active_reuse_keys();
         let profiles = test_profiles();
         let cache_states = workspace_cache_states(Some(&cache), &profiles).await;
         let states = filter_current_held_workspace_states(
@@ -993,8 +991,8 @@ mod tests {
                 held_workspace_state("sess-active", "2026-06-01T00:00:04.000Z", &["vm0/default"]),
             ],
         );
-        let active_reuse_keys = super::super::active_sessions::new_active_reuse_keys();
-        super::super::active_sessions::insert_active_reuse_key(&active_reuse_keys, "sess-active");
+        let active_reuse_keys = super::super::active_reuse_keys::new_active_reuse_keys();
+        super::super::active_reuse_keys::insert_active_reuse_key(&active_reuse_keys, "sess-active");
         let states =
             snapshot.current_held_workspace_states(&active_reuse_keys, Some("sess-claimed"));
 
@@ -1056,7 +1054,7 @@ mod tests {
             });
         }
 
-        let active_reuse_keys = super::super::active_sessions::new_active_reuse_keys();
+        let active_reuse_keys = super::super::active_reuse_keys::new_active_reuse_keys();
         let states = snapshot.current_held_workspace_states(&active_reuse_keys, None);
 
         assert_eq!(states.len(), MAX_HELD_WORKSPACE_STATES);
@@ -1091,7 +1089,7 @@ mod tests {
         );
         assert_eq!(refreshed, vec![merged.clone()]);
 
-        let active_reuse_keys = super::super::active_sessions::new_active_reuse_keys();
+        let active_reuse_keys = super::super::active_reuse_keys::new_active_reuse_keys();
         let states = snapshot.current_held_workspace_states(&active_reuse_keys, None);
         assert_eq!(states, vec![merged]);
 
@@ -1108,8 +1106,11 @@ mod tests {
 
     #[test]
     fn held_session_states_filter_active_reuse_keys() {
-        let active_reuse_keys = super::super::active_sessions::new_active_reuse_keys();
-        super::super::active_sessions::insert_active_reuse_key(&active_reuse_keys, "thread-active");
+        let active_reuse_keys = super::super::active_reuse_keys::new_active_reuse_keys();
+        super::super::active_reuse_keys::insert_active_reuse_key(
+            &active_reuse_keys,
+            "thread-active",
+        );
         let states = vec![
             HeldSessionState {
                 session_id: "provider-session-active".into(),

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -225,7 +225,8 @@ mod tests {
 
     #[tokio::test]
     async fn destroy_idle_jobs_and_wait_reports_workspace_cache_promotion() {
-        let fixture = WorkspacePromotionFixture::new("sess-idle-destroy-cache").await;
+        let fixture = WorkspacePromotionFixture::new("thread:idle-destroy-cache").await;
+        let provider_session_id = "sess-idle-destroy-cache";
         let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
         add_healthy_reuse_preparation_matcher(&overrides);
         let factory: Arc<Box<dyn SandboxFactory>> =
@@ -248,8 +249,8 @@ mod tests {
             run_id: crate::ids::RunId::new_v4(),
             sandbox,
             factory,
-            reuse_key: fixture.session_id.clone(),
-            cli_agent_session_id: fixture.session_id.clone(),
+            reuse_key: fixture.reuse_key.clone(),
+            cli_agent_session_id: provider_session_id.into(),
             sandbox_id: fixture.sandbox_id,
             profile_name: "vm0/default".into(),
             device_rate_limits: None,
@@ -279,6 +280,6 @@ mod tests {
         assert_eq!(budget.allocated(), (0, 0, 0));
         let held = fixture.cache.held_workspace_states().await;
         assert_eq!(held.len(), 1);
-        assert_eq!(held[0].reuse_key, fixture.session_id);
+        assert_eq!(held[0].reuse_key, fixture.reuse_key);
     }
 }

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -12,7 +12,7 @@ use sandbox::SandboxId;
 use tokio::task::JoinSet;
 use tracing::{info, warn};
 
-use super::active_sessions::ActiveReuseKeyGuard;
+use super::active_reuse_keys::ActiveReuseKeyGuard;
 use super::factory_lifecycle::SharedFactory;
 use super::idle_lifecycle::{
     SharedIdlePool, add_preparing_run_with_idle_status_snapshot,
@@ -533,7 +533,7 @@ async fn prepare_affinity_protected_candidate(
         reuse_key_fingerprint = %reuse_key_fingerprint,
         reuse_key_kind = reuse_key_kind(&reuse_key),
         delay_ms = delay.as_millis(),
-        "same-session affinity protected by another runner, deferring claim"
+        "same-reuse-key affinity protected by another runner, deferring claim"
     );
     ctx.spawn_ctx.provider.defer_poll_after(delay).await;
     None

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -14,7 +14,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tracing::{error, warn};
 
-use super::active_sessions::{ActiveReuseKeyGuard, ActiveReuseKeys};
+use super::active_reuse_keys::{ActiveReuseKeyGuard, ActiveReuseKeys};
 use super::factory_lifecycle::SharedFactory;
 use super::heartbeat::WorkspaceCacheStateSnapshot;
 use super::idle_lifecycle::SharedIdlePool;
@@ -1067,7 +1067,7 @@ mod tests {
             "finalizer should send the early park refresh"
         );
 
-        let active_reuse_keys = super::super::active_sessions::new_active_reuse_keys();
+        let active_reuse_keys = super::super::active_reuse_keys::new_active_reuse_keys();
         let active_reuse_key_guard =
             ActiveReuseKeyGuard::new(Arc::clone(&active_reuse_keys), Some(session_id.to_owned()));
         let (usage_flush_tx, _usage_flush_rx) = mpsc::channel(1);
@@ -1085,7 +1085,7 @@ mod tests {
         .await;
 
         assert!(
-            super::super::active_sessions::active_reuse_keys(&active_reuse_keys).is_empty(),
+            super::super::active_reuse_keys::active_reuse_keys(&active_reuse_keys).is_empty(),
             "completion should release the active reuse-key guard before notifying"
         );
         assert!(

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -72,9 +72,9 @@ use crate::resource_budget::ResourceBudget;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::run_cancellation::{RunCancellationRegistration, RunCancellationRegistry};
 use crate::status::{StatusTracker, remove_stale_status_file};
-use crate::workspace_image_cache::SessionWorkspaceCache;
+use crate::workspace_image_cache::WorkspaceImageCache;
 
-mod active_sessions;
+mod active_reuse_keys;
 mod factory_lifecycle;
 mod heartbeat;
 mod identity;
@@ -89,7 +89,7 @@ mod ownership;
 mod sandbox_finalization;
 mod signals;
 
-use active_sessions::new_active_reuse_keys;
+use active_reuse_keys::new_active_reuse_keys;
 use factory_lifecycle::{shutdown_factory_instances, shutdown_runtime, start_factories};
 use heartbeat::{
     HEARTBEAT_PERIOD, HeartbeatContext, HeartbeatContextInit, HeartbeatController,
@@ -685,7 +685,7 @@ async fn run_start_with_home(
         session_history_probe: SessionHistoryProbe::default(),
         fresh_archive_delivery: crate::storage_cache::FreshArchiveDeliveryAdmission::new(),
         home: home.clone(),
-        workspace_cache: Some(SessionWorkspaceCache::shared(
+        workspace_cache: Some(WorkspaceImageCache::shared(
             paths.clone(),
             &home,
             &group_name,

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -174,7 +174,6 @@ pub(super) async fn finalize_sandbox_for_completion(
         workspace_image.into_promotion_context(WorkspaceImagePromotionRequest {
             run_id,
             sandbox_id,
-            cli_agent_session_id_override: resolved_cli_agent_session_id,
             restored_session_identity: restored_session_identity.as_ref(),
             terminal_status,
             completed_at: completed_at.clone(),
@@ -787,7 +786,7 @@ mod tests {
     use crate::storage_plan::build_storage_plan;
     use crate::types::{ResumeSessionHistoryRefKind, SandboxReuseResult};
     use crate::workspace_image_cache::{
-        SessionWorkspaceCache, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
+        WorkspaceImageCache, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
         WorkspaceImagePromotionContext, WorkspaceImagePromotionIdentityRequest,
         WorkspaceImagePromotionOutcome, WorkspaceImagePromotionRequest,
         WorkspaceSessionHistorySidecarRepresentation,
@@ -898,10 +897,10 @@ mod tests {
 
     async fn prepare_test_workspace_image_lease(
         paths: &RunnerPaths,
-        cache: &SessionWorkspaceCache,
+        cache: &WorkspaceImageCache,
         run_id: RunId,
         sandbox_id: SandboxId,
-        session_id: &str,
+        reuse_key: &str,
     ) -> WorkspaceImageLease {
         let lease = cache
             .prepare(WorkspaceImagePrepareRequest {
@@ -909,8 +908,7 @@ mod tests {
                     run_id,
                     sandbox_id,
                     profile_name: "vm0/default",
-                    reuse_key: Some(session_id),
-                    cli_agent_session_id: Some(session_id),
+                    reuse_key: Some(reuse_key),
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: b"image".len() as u64,
                 },
@@ -974,7 +972,7 @@ mod tests {
 
     async fn seed_workspace_cache_with_sidecar(
         paths: &RunnerPaths,
-        cache: &SessionWorkspaceCache,
+        cache: &WorkspaceImageCache,
         reuse_key: &str,
         session_id: &str,
         history: &[u8],
@@ -993,7 +991,6 @@ mod tests {
                     sandbox_id,
                     profile_name: "vm0/default",
                     reuse_key: Some(reuse_key),
-                    cli_agent_session_id: Some(session_id),
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: b"image".len() as u64,
                 },
@@ -1010,7 +1007,6 @@ mod tests {
             .into_promotion_context(WorkspaceImagePromotionRequest {
                 run_id,
                 sandbox_id,
-                cli_agent_session_id_override: None,
                 restored_session_identity: Some(&restored_session_identity),
                 terminal_status: WorkspaceCacheTerminalStatus::Success,
                 completed_at: "2026-07-31T00:00:00.000Z".into(),
@@ -1045,7 +1041,6 @@ mod tests {
         lease: WorkspaceImageLease,
         run_id: RunId,
         sandbox_id: SandboxId,
-        session_id: &str,
         terminal_status: WorkspaceCacheTerminalStatus,
         storage_fingerprints: crate::storage_fingerprints::StorageFingerprints,
     ) -> WorkspaceImagePromotionContext {
@@ -1053,7 +1048,6 @@ mod tests {
             .into_promotion_context(WorkspaceImagePromotionRequest {
                 run_id,
                 sandbox_id,
-                cli_agent_session_id_override: Some(session_id),
                 restored_session_identity: None,
                 terminal_status,
                 completed_at: local_completed_at(),
@@ -1147,7 +1141,7 @@ mod tests {
         let workspace_dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(workspace_dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
         let workspace_image = prepare_test_workspace_image_lease(
             &paths,
             &cache,
@@ -1316,7 +1310,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let lease =
@@ -1327,7 +1321,6 @@ mod tests {
             lease,
             run_id,
             sandbox_id,
-            "sess-promote",
             WorkspaceCacheTerminalStatus::Success,
             crate::storage_fingerprints::StorageFingerprints::default(),
         );
@@ -1349,7 +1342,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
 
         for (terminal_name, terminal_status) in [
             ("nonzero", WorkspaceCacheTerminalStatus::NonzeroExit),
@@ -1386,7 +1379,6 @@ mod tests {
                     seed_lease,
                     seed_run_id,
                     seed_sandbox_id,
-                    &session_id,
                     WorkspaceCacheTerminalStatus::Success,
                     previous_storage.clone(),
                 );
@@ -1454,7 +1446,6 @@ mod tests {
                     lease,
                     run_id,
                     sandbox_id,
-                    &session_id,
                     terminal_status,
                     StorageFingerprints::from_manifest(&current_manifest),
                 );
@@ -1473,7 +1464,6 @@ mod tests {
                             sandbox_id: SandboxId::new_v4(),
                             profile_name: "vm0/default",
                             reuse_key: Some(&session_id),
-                            cli_agent_session_id: Some(&session_id),
                             working_dir: CANONICAL_WORKING_DIR,
                             image_size_bytes: b"image".len() as u64,
                         },
@@ -1531,7 +1521,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let lease =
@@ -1543,7 +1533,6 @@ mod tests {
             lease,
             run_id,
             sandbox_id,
-            "sess-failed",
             WorkspaceCacheTerminalStatus::Success,
             crate::storage_fingerprints::StorageFingerprints::default(),
         );
@@ -1567,7 +1556,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let workspace_image = cache
@@ -1577,7 +1566,6 @@ mod tests {
                     sandbox_id,
                     profile_name: "vm0/default",
                     reuse_key: Some("unused-context-session"),
-                    cli_agent_session_id: None,
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: b"image".len() as u64,
                 },
@@ -1637,7 +1625,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let workspace_image = cache
@@ -1647,7 +1635,6 @@ mod tests {
                     sandbox_id,
                     profile_name: "vm0/default",
                     reuse_key: Some("sess-mismatch"),
-                    cli_agent_session_id: Some("sess-mismatch"),
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: b"image".len() as u64,
                 },
@@ -1720,7 +1707,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
         let reuse_key = "thread:rotating-provider";
         let previous_session_id = "claude-session-a";
         let previous_history = br#"{"type":"message","content":"claude-a"}"#;
@@ -1733,7 +1720,7 @@ mod tests {
         )
         .await;
         let seeded_entry = cache.inspect().await.unwrap().entries.remove(0);
-        let entry_dir = paths.session_workspace_cache_entry_dir(&seeded_entry.cache_key);
+        let entry_dir = paths.workspace_image_cache_entry_dir(&seeded_entry.cache_key);
         let sidecar_metadata_path = entry_dir.join("session-history.metadata.json");
 
         let run_id = RunId::new_v4();
@@ -1745,7 +1732,6 @@ mod tests {
                     sandbox_id,
                     profile_name: "vm0/default",
                     reuse_key: Some(reuse_key),
-                    cli_agent_session_id: None,
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: b"image".len() as u64,
                 },
@@ -1779,7 +1765,7 @@ mod tests {
             .await
             .unwrap();
         tokio::fs::rename(
-            paths.session_workspace_cache_current_image(&seeded_entry.cache_key),
+            paths.workspace_image_cache_current_image(&seeded_entry.cache_key),
             paths.active_workspace_image(&sandbox_id),
         )
         .await
@@ -1827,7 +1813,7 @@ mod tests {
         assert_eq!(states.len(), 1);
         assert_eq!(states[0].reuse_key, reuse_key);
         let workspace_metadata: serde_json::Value = serde_json::from_slice(
-            &tokio::fs::read(paths.session_workspace_cache_metadata(&seeded_entry.cache_key))
+            &tokio::fs::read(paths.workspace_image_cache_metadata(&seeded_entry.cache_key))
                 .await
                 .unwrap(),
         )
@@ -1849,7 +1835,6 @@ mod tests {
                     sandbox_id: SandboxId::new_v4(),
                     profile_name: "vm0/default",
                     reuse_key: Some(reuse_key),
-                    cli_agent_session_id: Some(previous_session_id),
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: b"image".len() as u64,
                 },
@@ -1874,7 +1859,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
         let reuse_key = "thread:verified-provider-rotation";
         let previous_history = br#"{"type":"message","content":"claude-a"}"#;
         let previous_identity = seed_workspace_cache_with_sidecar(
@@ -1895,7 +1880,6 @@ mod tests {
                     sandbox_id,
                     profile_name: "vm0/default",
                     reuse_key: Some(reuse_key),
-                    cli_agent_session_id: None,
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: b"image".len() as u64,
                 },
@@ -1915,7 +1899,7 @@ mod tests {
             .await
             .unwrap();
         tokio::fs::rename(
-            paths.session_workspace_cache_current_image(&seeded_entry.cache_key),
+            paths.workspace_image_cache_current_image(&seeded_entry.cache_key),
             paths.active_workspace_image(&sandbox_id),
         )
         .await
@@ -1977,7 +1961,6 @@ mod tests {
                     sandbox_id: SandboxId::new_v4(),
                     profile_name: "vm0/default",
                     reuse_key: Some(reuse_key),
-                    cli_agent_session_id: Some(next_session_id),
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: b"image".len() as u64,
                 },
@@ -2003,25 +1986,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn finalizer_promotes_workspace_cache_from_lease_session_without_resolved_session() {
+    async fn finalizer_promotes_workspace_cache_from_reuse_key_without_resolved_session() {
         let (_budget, lease) = test_budget_lease();
         let fixture = FinalizeTestFixture::new().await;
         let network_log_session = fixture.network_log_session().await;
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        let session_id = "sess-lease-only";
+        let reuse_key = "thread:lease-only";
         let workspace_image = cache
             .prepare(WorkspaceImagePrepareRequest {
                 identity: WorkspaceImageLeaseIdentity {
                     run_id,
                     sandbox_id,
                     profile_name: "vm0/default",
-                    reuse_key: Some(session_id),
-                    cli_agent_session_id: Some(session_id),
+                    reuse_key: Some(reuse_key),
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: b"image".len() as u64,
                 },
@@ -2049,7 +2031,7 @@ mod tests {
         let workspace_cache_snapshot = context.workspace_cache_snapshot.clone();
 
         let _completion_ready = finalize_sandbox_for_completion(
-            Some(Box::new(MockSandbox::new("lease-session-promotion"))),
+            Some(Box::new(MockSandbox::new("reuse-key-promotion"))),
             ActiveBudgetLease::new(lease),
             CompletionPayload::new(
                 run_id,
@@ -2066,12 +2048,12 @@ mod tests {
         assert_eq!(fixture.idle_pool.lock().await.len(), 0);
         let cache_states = cache.held_workspace_states().await;
         assert_eq!(cache_states.len(), 1);
-        assert_eq!(cache_states[0].reuse_key, session_id);
-        let active_reuse_keys = super::super::active_sessions::new_active_reuse_keys();
+        assert_eq!(cache_states[0].reuse_key, reuse_key);
+        let active_reuse_keys = super::super::active_reuse_keys::new_active_reuse_keys();
         let snapshot_states =
             workspace_cache_snapshot.current_held_workspace_states(&active_reuse_keys, None);
         assert_eq!(snapshot_states.len(), 1);
-        assert_eq!(snapshot_states[0].reuse_key, session_id);
+        assert_eq!(snapshot_states[0].reuse_key, reuse_key);
         assert_eq!(snapshot_states[0].workspace_caches.len(), 1);
         assert_eq!(
             snapshot_states[0].workspace_caches[0].profile,
@@ -2087,7 +2069,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let reuse_key = "thread:first-run-failure";
@@ -2098,7 +2080,6 @@ mod tests {
                     sandbox_id,
                     profile_name: "vm0/default",
                     reuse_key: Some(reuse_key),
-                    cli_agent_session_id: None,
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: b"image".len() as u64,
                 },
@@ -2162,14 +2143,14 @@ mod tests {
         );
         let metadata: serde_json::Value = serde_json::from_slice(
             &tokio::fs::read(
-                paths.session_workspace_cache_metadata(&inspection.entries[0].cache_key),
+                paths.workspace_image_cache_metadata(&inspection.entries[0].cache_key),
             )
             .await
             .unwrap(),
         )
         .unwrap();
         assert!(metadata.get("cliAgentSessionId").is_none());
-        let active_reuse_keys = super::super::active_sessions::new_active_reuse_keys();
+        let active_reuse_keys = super::super::active_reuse_keys::new_active_reuse_keys();
         let snapshot_states =
             workspace_cache_snapshot.current_held_workspace_states(&active_reuse_keys, None);
         assert_eq!(snapshot_states.len(), 1);
@@ -2185,7 +2166,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let session_id = "sess-active-stop-error";
@@ -2231,7 +2212,7 @@ mod tests {
         assert_eq!(overrides.destroy_call_count(), 1);
         assert!(cache.held_workspace_states().await.is_empty());
         assert_eq!(fixture.idle_pool.lock().await.len(), 0);
-        let active_reuse_keys = super::super::active_sessions::new_active_reuse_keys();
+        let active_reuse_keys = super::super::active_reuse_keys::new_active_reuse_keys();
         assert!(
             workspace_cache_snapshot
                 .current_held_workspace_states(&active_reuse_keys, None)
@@ -2258,7 +2239,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let workspace_image = cache
@@ -2268,7 +2249,6 @@ mod tests {
                     sandbox_id,
                     profile_name: "vm0/default",
                     reuse_key: Some("sess-new"),
-                    cli_agent_session_id: Some("sess-new"),
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: b"image".len() as u64,
                 },
@@ -2323,7 +2303,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
 
         let old_run_id = RunId::new_v4();
         let old_sandbox_id = SandboxId::new_v4();
@@ -2339,7 +2319,6 @@ mod tests {
             old_workspace_image,
             old_run_id,
             old_sandbox_id,
-            session_id,
             WorkspaceCacheTerminalStatus::Success,
             crate::storage_fingerprints::StorageFingerprints::default(),
         );

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -260,9 +260,9 @@ async fn budget_exhausted_reclaims_expired_before_oldest_idle() {
 
     wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
 
-    let sessions = idle_pool.lock().await.held_sessions();
+    let reuse_keys = idle_pool.lock().await.held_reuse_keys();
     assert_eq!(
-        sessions,
+        reuse_keys,
         vec!["sess-old-active".to_string()],
         "expired idle entry should be reclaimed before oldest active entry"
     );
@@ -351,9 +351,9 @@ async fn budget_exhausted_evicts_oldest_when_expired_reclaim_insufficient() {
 
     wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
 
-    let sessions = idle_pool.lock().await.held_sessions();
+    let reuse_keys = idle_pool.lock().await.held_reuse_keys();
     assert_eq!(
-        sessions,
+        reuse_keys,
         vec!["sess-new-active".to_string()],
         "expired entry and oldest active entry should be reclaimed"
     );

--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -8,7 +8,7 @@ use super::support::assert_no_completion_for_run;
 
 use crate::idle_pool::ParkingState;
 use crate::paths::RunnerPaths;
-use crate::workspace_image_cache::SessionWorkspaceCache;
+use crate::workspace_image_cache::WorkspaceImageCache;
 use sandbox_mock::MockLifecycleGate;
 
 fn severe_memory_retention() -> sandbox::SandboxParkOutcome {
@@ -118,7 +118,7 @@ async fn assert_workspace_cache_after_park_cleanup(
     let (mut config, env) =
         mock_run_config_with_overrides(profiles, 8, 32768, 4, Arc::clone(&overrides));
     let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
-    let workspace_cache = SessionWorkspaceCache::shared(
+    let workspace_cache = WorkspaceImageCache::shared(
         runner_paths.clone(),
         &config.paths.home,
         &config.runner.group,
@@ -433,7 +433,7 @@ async fn assert_workspace_cache_after_late_cancellation(
     let (mut config, env) =
         mock_run_config_with_overrides(profiles, 8, 32768, 4, Arc::clone(&overrides));
     let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
-    let workspace_cache = SessionWorkspaceCache::shared(
+    let workspace_cache = WorkspaceImageCache::shared(
         runner_paths.clone(),
         &config.paths.home,
         &config.runner.group,
@@ -608,7 +608,7 @@ async fn pool_full_rejected_vm_keeps_budget_until_destroy_and_completion() {
     wait_budget_count(&budget, 1, Duration::from_secs(2)).await;
     let pool = idle_pool.lock().await;
     assert_eq!(pool.len(), 1);
-    assert_eq!(pool.held_sessions(), vec!["sess-existing"]);
+    assert_eq!(pool.held_reuse_keys(), vec!["sess-existing"]);
     drop(pool);
 
     shutdown(&env, run_handle).await;

--- a/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
@@ -58,7 +58,7 @@ async fn unpark_failure_destroys_idle_entry_and_falls_through() {
 
     let run_handle = tokio::spawn(run(config));
 
-    // Push a job for the same session — runner will try to reuse,
+    // Push a job for the same reuse key — runner will try to reuse,
     // unpark() will fail, idle entry gets destroyed, fresh create runs.
     let run_id = RunId::new_v4();
     env.provider.set_claim_result(

--- a/crates/runner/src/cmd/start/tests/idle_reuse/affinity.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/affinity.rs
@@ -1,7 +1,7 @@
 use super::super::super::*;
 use super::super::support::{
     context_with_session, minimal_context, mock_run_config, push_job, seed_idle_pool, shutdown,
-    test_profiles, two_profiles, wait_budget_count, wait_idle_pool_sessions,
+    test_profiles, two_profiles, wait_budget_count, wait_idle_pool_reuse_keys,
 };
 
 use crate::types::SandboxReuseResult;
@@ -23,7 +23,7 @@ async fn session_affinity_reuses_idle_vm() {
 
     let run_handle = tokio::spawn(run(config));
 
-    // Push job for same session — should reuse the idle VM.
+    // Push job for same reuse key — should reuse the idle VM.
     let run_id = RunId::new_v4();
     push_job(
         &env,
@@ -51,7 +51,7 @@ async fn session_affinity_reuses_idle_vm() {
     );
 
     // After reuse + re-park: pool should still have 1 entry, budget count=1.
-    wait_idle_pool_sessions(&idle_pool, &["sess-reuse"], Duration::from_secs(5)).await;
+    wait_idle_pool_reuse_keys(&idle_pool, &["sess-reuse"], Duration::from_secs(5)).await;
     {
         let pool = idle_pool.lock().await;
         assert_eq!(pool.len(), 1, "VM should be re-parked after reuse");
@@ -137,7 +137,7 @@ async fn invalid_resume_session_does_not_reuse_idle_vm() {
     let error = completion.error.as_deref().expect("error should be set");
     assert!(error.contains("invalid session_id"));
     assert!(!error.contains(invalid_session_id));
-    wait_idle_pool_sessions(&idle_pool, &[invalid_session_id], Duration::from_secs(5)).await;
+    wait_idle_pool_reuse_keys(&idle_pool, &[invalid_session_id], Duration::from_secs(5)).await;
 
     shutdown(&env, run_handle).await;
 }
@@ -157,7 +157,7 @@ async fn profile_mismatch_destroys_stale_vm() {
 
     let run_handle = tokio::spawn(run(config));
 
-    // Push job for "vm0/large" (4vcpu) with same session — profile mismatch.
+    // Push job for "vm0/large" (4vcpu) with same reuse key — profile mismatch.
     let run_id = RunId::new_v4();
     push_job(
         &env,

--- a/crates/runner/src/cmd/start/tests/idle_reuse/drain.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/drain.rs
@@ -1,8 +1,8 @@
 use super::super::super::*;
 use super::super::support::{
     assert_run_exits_within, context_with_session, mock_run_config, mock_run_config_with_overrides,
-    push_job, seed_idle_pool, shutdown, test_profiles, wait_cancel_token, wait_idle_pool_sessions,
-    wait_parking_state, wait_status_idle_sessions_and_active_runs,
+    push_job, seed_idle_pool, shutdown, test_profiles, wait_cancel_token,
+    wait_idle_pool_reuse_keys, wait_parking_state, wait_status_idle_sessions_and_active_runs,
 };
 
 use crate::idle_pool::ParkingState;
@@ -203,7 +203,7 @@ async fn shutdown_clears_idle_vms_in_status_json() {
         .handle
         .wait_completion(run_id, Duration::from_secs(5))
         .await;
-    wait_idle_pool_sessions(&idle_pool, &["sess-status-clean"], Duration::from_secs(5)).await;
+    wait_idle_pool_reuse_keys(&idle_pool, &["sess-status-clean"], Duration::from_secs(5)).await;
     assert_eq!(idle_pool.lock().await.len(), 1, "VM parked");
 
     // Pre-shutdown sanity: status.json lists the idle VM.

--- a/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
@@ -2,7 +2,7 @@ use super::super::super::*;
 use super::super::support::{
     context_with_session, minimal_context, mock_run_config, mock_run_config_with_overrides,
     push_job, seed_idle_pool, shutdown, test_profiles, wait_budget_count,
-    wait_idle_pool_session_states, wait_idle_pool_sessions, wait_sandbox_lifecycle_counts,
+    wait_idle_pool_reuse_keys, wait_idle_pool_session_states, wait_sandbox_lifecycle_counts,
 };
 
 use crate::types::SandboxReuseResult;
@@ -20,7 +20,7 @@ fn context_with_session_opt(
 ) -> crate::types::ExecutionContext {
     let mut ctx = minimal_context(run_id);
     if let Some(sid) = session_id {
-        ctx.reuse_key = Some(format!("session:{sid}"));
+        ctx.reuse_key = Some(format!("thread:idle-{sid}"));
         ctx.resume_session = Some(crate::types::ResumeSession::inline(
             sid.to_string(),
             String::new(),
@@ -47,7 +47,10 @@ async fn job_with_session_parks_vm() {
 
     let pool = env.idle_pool.lock().await;
     assert_eq!(pool.len(), 1, "VM should be parked when session is present");
-    assert!(pool.held_sessions().contains(&"session:sess-1".to_string()));
+    assert!(
+        pool.held_reuse_keys()
+            .contains(&"thread:idle-sess-1".to_string())
+    );
     drop(pool);
 
     shutdown(&env, run_handle).await;
@@ -108,12 +111,12 @@ async fn successful_job_parks_in_idle_pool() {
     assert_eq!(completion.unwrap().exit_code, 0);
 
     // VM should be parked in idle pool, holding budget.
-    wait_idle_pool_sessions(&idle_pool, &["sess-park"], Duration::from_secs(5)).await;
+    wait_idle_pool_reuse_keys(&idle_pool, &["sess-park"], Duration::from_secs(5)).await;
     {
         let pool = idle_pool.lock().await;
         assert_eq!(pool.len(), 1, "VM should be parked");
         assert!(
-            pool.held_sessions().contains(&"sess-park".to_string()),
+            pool.held_reuse_keys().contains(&"sess-park".to_string()),
             "parked session should be sess-park"
         );
     }
@@ -158,21 +161,21 @@ async fn job_without_session_destroys_sandbox() {
 }
 
 // -----------------------------------------------------------------------
-// Test 19: Two sequential jobs for same session → take + reuse + re-park
+// Test 19: Two sequential jobs for same reuse key → take + reuse + re-park
 //
-// Exercises the full session affinity cycle: park → take → reuse → park.
+// Exercises the full reuse cycle: park → take → reuse → park.
 // After two jobs the pool should have exactly 1 entry (the second job's
 // VM) and the budget count should be 1.
 // -----------------------------------------------------------------------
 
 #[tokio::test(start_paused = true)]
-async fn sequential_same_session_reuse_cycle() {
+async fn sequential_same_reuse_key_cycle() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
 
-    // Job 1: parks VM for session "sess-seq".
+    // Job 1: parks VM for reuse key "sess-seq".
     let id1 = RunId::new_v4();
     push_job(
         &env,
@@ -188,7 +191,7 @@ async fn sequential_same_session_reuse_cycle() {
     wait_idle_pool_session_states(&idle_pool, &["sess-seq"], Duration::from_secs(5)).await;
     assert_eq!(idle_pool.lock().await.len(), 1, "job 1 VM should be parked");
 
-    // Job 2: same session → take → reuse → re-park.
+    // Job 2: same reuse key → take → reuse → re-park.
     let id2 = RunId::new_v4();
     push_job(
         &env,
@@ -206,7 +209,7 @@ async fn sequential_same_session_reuse_cycle() {
         Some(SandboxReuseResult::Reused),
         "job 2 should reuse the first job's parked VM",
     );
-    wait_idle_pool_sessions(&idle_pool, &["sess-seq"], Duration::from_secs(5)).await;
+    wait_idle_pool_reuse_keys(&idle_pool, &["sess-seq"], Duration::from_secs(5)).await;
 
     assert_eq!(
         idle_pool.lock().await.len(),
@@ -254,7 +257,7 @@ async fn same_thread_reuses_vm_across_provider_session_change() {
     );
     wait_idle_pool_session_states(&idle_pool, &["provider-session-b"], Duration::from_secs(5))
         .await;
-    wait_idle_pool_sessions(&idle_pool, &[reuse_key], Duration::from_secs(5)).await;
+    wait_idle_pool_reuse_keys(&idle_pool, &[reuse_key], Duration::from_secs(5)).await;
 
     shutdown(&env, run_handle).await;
 }
@@ -303,7 +306,7 @@ async fn park_evicts_via_discovered_cli_agent_session_id() {
     let pool = idle_pool.lock().await;
     assert_eq!(pool.len(), 1, "pool should have the newly parked entry");
     assert_eq!(
-        pool.held_sessions(),
+        pool.held_reuse_keys(),
         vec!["sess-evict"],
         "parked session should match discovered_cli_agent_session_id"
     );
@@ -316,7 +319,7 @@ async fn park_evicts_via_discovered_cli_agent_session_id() {
 // Tests 23-25: park / unpark idle-transition orchestration (#9102)
 // -----------------------------------------------------------------------
 
-/// Two sequential jobs on the same session produce park=2 / unpark=1:
+/// Two sequential jobs on the same reuse key produce park=2 / unpark=1:
 /// the first job's post-exit park, plus the second job's take (unpark)
 /// and post-exit re-park. Verifies the full reuse cycle drives the
 /// new trait hooks symmetrically.
@@ -345,7 +348,7 @@ async fn reuse_cycle_invokes_park_and_unpark_symmetrically() {
     wait_sandbox_lifecycle_counts(&counter, 1, 0, Duration::from_secs(5)).await;
     wait_idle_pool_session_states(&idle_pool, &["sess-reuse-cycle"], Duration::from_secs(5)).await;
 
-    // Job 2: same session → take (unpark) → run → re-park.
+    // Job 2: same reuse key → take (unpark) → run → re-park.
     let id2 = RunId::new_v4();
     push_job(
         &env,
@@ -400,7 +403,7 @@ async fn park_called_when_vm_enters_idle_pool() {
     assert!(c.is_some(), "job should complete");
 
     wait_sandbox_lifecycle_counts(&counter, 1, 0, Duration::from_secs(5)).await;
-    wait_idle_pool_sessions(&idle_pool, &["sess-park-hook"], Duration::from_secs(5)).await;
+    wait_idle_pool_reuse_keys(&idle_pool, &["sess-park-hook"], Duration::from_secs(5)).await;
     assert_eq!(
         counter.park_call_count(),
         1,

--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -3,24 +3,25 @@ use super::super::support::{
     WorkspacePromotionSeedSpec, context_with_session, mock_run_config,
     mock_run_config_with_overrides, push_job, seed_idle_pool,
     seed_idle_pool_with_workspace_promotion, shutdown, test_profiles, wait_budget_count,
-    wait_discover_entered, wait_idle_pool_session_states, wait_idle_pool_sessions,
+    wait_discover_entered, wait_idle_pool_reuse_keys, wait_idle_pool_session_states,
 };
 
 use crate::paths::RunnerPaths;
 use crate::types::{SandboxReuseResult, SessionAffinityResource};
-use crate::workspace_image_cache::SessionWorkspaceCache;
+use crate::workspace_image_cache::WorkspaceImageCache;
 
 const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
 
 fn reusable_candidate(
     run_id: RunId,
     profile_name: &str,
-    session_id: &str,
+    reuse_key: &str,
+    provider_session_id: &str,
 ) -> crate::provider::JobCandidate {
     crate::provider::JobCandidate::new(run_id, profile_name.to_string())
         .with_affinity_metadata(
-            Some(session_id.to_string()),
-            Some(session_id.to_string()),
+            Some(reuse_key.to_string()),
+            Some(provider_session_id.to_string()),
             Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
         )
         .with_session_affinity_resource(Some(SessionAffinityResource::ReusableSandbox))
@@ -66,7 +67,7 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
     let (mut config, env) =
         mock_run_config_with_overrides(profiles, 8, 32768, 4, Arc::clone(&overrides));
     let runner_paths = crate::paths::RunnerPaths::new(config.paths.base_dir.clone());
-    let workspace_cache = crate::workspace_image_cache::SessionWorkspaceCache::shared(
+    let workspace_cache = crate::workspace_image_cache::WorkspaceImageCache::shared(
         runner_paths.clone(),
         &config.paths.home,
         &config.runner.group,
@@ -80,8 +81,10 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
     let before = env.handle.heartbeat_count();
 
     let run_id = RunId::new_v4();
-    let session_id = "sess-cache-heartbeat";
-    let ctx = context_with_session(run_id, session_id);
+    let provider_session_id = "provider-session-cache-heartbeat";
+    let reuse_key = "thread:cache-heartbeat";
+    let mut ctx = context_with_session(run_id, provider_session_id);
+    ctx.reuse_key = Some(reuse_key.into());
     push_job(&env, run_id, "vm0/default", Some(ctx));
 
     wait_gate
@@ -120,7 +123,7 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
         wait_heartbeat_with_workspace_after(
             &env.handle,
             before,
-            session_id,
+            reuse_key,
             Duration::from_secs(5),
         )
         .await,
@@ -132,12 +135,9 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
     overrides.push_wait_process_exit(sandbox::ProcessExit::new(1, 1, Vec::new(), Vec::new()));
     let second_before = env.handle.heartbeat_count();
     let second_run_id = RunId::new_v4();
-    push_job(
-        &env,
-        second_run_id,
-        "vm0/default",
-        Some(context_with_session(second_run_id, session_id)),
-    );
+    let mut second_context = context_with_session(second_run_id, provider_session_id);
+    second_context.reuse_key = Some(reuse_key.into());
+    push_job(&env, second_run_id, "vm0/default", Some(second_context));
     second_gate
         .wait_entered(1, Duration::from_secs(5))
         .await
@@ -146,7 +146,7 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
         env.handle
             .wait_heartbeat_past(second_before, Duration::from_secs(5))
             .await,
-        "claiming a workspace-cache-only session should trigger an immediate heartbeat",
+        "claiming a workspace-cache-only reuse key should trigger an immediate heartbeat",
     );
     let post_claim_heartbeats = {
         let heartbeats = env
@@ -161,7 +161,7 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
             heartbeat
                 .held_workspace_states
                 .iter()
-                .all(|state| state.reuse_key != session_id)
+                .all(|state| state.reuse_key != reuse_key)
         }),
         "post-claim heartbeat should stop advertising the active workspace cache; heartbeats: {post_claim_heartbeats:?}",
     );
@@ -183,7 +183,7 @@ async fn workspace_promotion_mismatch_destroys_stale_idle_vm_and_fresh_creates()
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
     let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
-    let workspace_cache = SessionWorkspaceCache::shared(
+    let workspace_cache = WorkspaceImageCache::shared(
         runner_paths.clone(),
         &config.paths.home,
         &config.runner.group,
@@ -191,14 +191,16 @@ async fn workspace_promotion_mismatch_destroys_stale_idle_vm_and_fresh_creates()
     Arc::get_mut(&mut config.exec_config)
         .unwrap()
         .workspace_cache = Some(workspace_cache.clone());
-    let session_id = "sess-workspace-promotion-mismatch";
+    let provider_session_id = "sess-workspace-promotion-mismatch";
+    let reuse_key = "thread:workspace-promotion-mismatch";
     let stale_sandbox_id = seed_idle_pool_with_workspace_promotion(
         &idle_pool,
         &budget,
         &workspace_cache,
         &runner_paths,
         WorkspacePromotionSeedSpec {
-            session_id,
+            provider_session_id,
+            reuse_key,
             profile_name: "vm0/default",
             vcpu: 2,
             memory_mb: 4096,
@@ -209,11 +211,17 @@ async fn workspace_promotion_mismatch_destroys_stale_idle_vm_and_fresh_creates()
 
     let run_handle = tokio::spawn(run(config));
     let run_id = RunId::new_v4();
-    env.provider
-        .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
+    let mut context = context_with_session(run_id, provider_session_id);
+    context.reuse_key = Some(reuse_key.into());
+    env.provider.set_claim_result(run_id, Some(context));
     env.handle
         .discover_tx
-        .send(reusable_candidate(run_id, "vm0/default", session_id))
+        .send(reusable_candidate(
+            run_id,
+            "vm0/default",
+            reuse_key,
+            provider_session_id,
+        ))
         .unwrap();
 
     let completion = env
@@ -228,7 +236,7 @@ async fn workspace_promotion_mismatch_destroys_stale_idle_vm_and_fresh_creates()
         Some(stale_sandbox_id),
         "workspace promotion mismatch should force a fresh sandbox"
     );
-    wait_idle_pool_sessions(&idle_pool, &[session_id], Duration::from_secs(5)).await;
+    wait_idle_pool_reuse_keys(&idle_pool, &[reuse_key], Duration::from_secs(5)).await;
     wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
     assert!(
         workspace_cache.held_workspace_states().await.is_empty(),
@@ -252,7 +260,7 @@ async fn reuse_take_preserves_cached_workspace_snapshot_state() {
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
     let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
-    let workspace_cache = SessionWorkspaceCache::shared(
+    let workspace_cache = WorkspaceImageCache::shared(
         runner_paths.clone(),
         &config.paths.home,
         &config.runner.group,

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use crate::paths::RunnerPaths;
 use crate::types::{SandboxReuseResult, SessionAffinityResource};
-use crate::workspace_image_cache::SessionWorkspaceCache;
+use crate::workspace_image_cache::WorkspaceImageCache;
 
 const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
 
@@ -297,7 +297,7 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     wait_cancel_token_removed(&env.cancel_tokens, conflict_run_id, Duration::from_secs(5)).await;
     assert_eq!(
-        idle_pool.lock().await.held_sessions(),
+        idle_pool.lock().await.held_reuse_keys(),
         vec![session_id.to_string()],
         "claim conflict should restore the exact idle reservation"
     );
@@ -348,7 +348,7 @@ async fn reusable_affinity_reservation_is_restored_after_claim_conflict() {
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
     assert_eq!(
-        idle_pool.lock().await.held_sessions(),
+        idle_pool.lock().await.held_reuse_keys(),
         vec![session_id.to_string()],
         "lost claim should restore the generic reusable reservation"
     );
@@ -444,7 +444,7 @@ async fn generation_protected_different_idle_sandbox_defers_before_claim() {
     );
     assert_eq!(env.handle.deferred_poll_delays().len(), 1);
     let pool = idle_pool.lock().await;
-    assert_eq!(pool.held_sessions(), vec![session_id.to_string()]);
+    assert_eq!(pool.held_reuse_keys(), vec![session_id.to_string()]);
     assert_eq!(
         pool.held_session_states()[0]
             .reusable_sandbox
@@ -484,7 +484,7 @@ async fn affinity_protected_candidate_without_local_session_defers_before_claim(
 
     assert!(
         env.handle.claim_candidates().is_empty(),
-        "runner must not claim a protected same-session candidate unless it holds the session"
+        "runner must not claim a protected same-reuse-key candidate without local reusable state"
     );
     assert_eq!(
         env.handle.deferred_poll_delays().len(),
@@ -558,7 +558,7 @@ async fn affinity_protected_candidate_without_resource_defers_even_when_session_
     );
     assert_eq!(env.handle.deferred_poll_delays().len(), 1);
     assert_eq!(
-        idle_pool.lock().await.held_sessions(),
+        idle_pool.lock().await.held_reuse_keys(),
         vec![session_id.to_string()]
     );
 
@@ -777,13 +777,14 @@ async fn expired_generation_protection_preserves_local_session_claim() {
 
 #[tokio::test]
 async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspace() {
-    let session_id = "sess-cache-local";
+    let reuse_key = "thread:cache-local";
+    let provider_session_id = "provider-session-cache-local";
     let image_size_bytes = 1024 * 1024;
     let mut profiles = test_profiles();
     profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 1;
     let (mut config, env) = mock_run_config(profiles, 8, 32768, 4);
     let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
-    let workspace_cache = SessionWorkspaceCache::shared(
+    let workspace_cache = WorkspaceImageCache::shared(
         runner_paths.clone(),
         &config.paths.home,
         &config.runner.group,
@@ -791,15 +792,15 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
     seed_workspace_cache_state(
         &workspace_cache,
         &runner_paths,
-        session_id,
+        reuse_key,
         "vm0/default",
         image_size_bytes,
     )
     .await;
-    let cache_key = crate::paths::scoped_session_workspace_cache_key(
+    let cache_key = crate::paths::scoped_workspace_image_cache_key(
         &config.runner.group,
         "vm0/default",
-        session_id,
+        reuse_key,
         CANONICAL_WORKING_DIR,
         image_size_bytes,
     );
@@ -816,15 +817,15 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
     wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     let reusable_protected_run_id = RunId::new_v4();
-    env.provider.set_claim_result(
-        reusable_protected_run_id,
-        Some(context_with_session(reusable_protected_run_id, session_id)),
-    );
+    let mut reusable_context = context_with_session(reusable_protected_run_id, provider_session_id);
+    reusable_context.reuse_key = Some(reuse_key.into());
+    env.provider
+        .set_claim_result(reusable_protected_run_id, Some(reusable_context));
     env.handle
         .discover_tx
         .send(reusable_affinity_protected_candidate(
             reusable_protected_run_id,
-            session_id,
+            reuse_key,
         ))
         .unwrap();
     wait_discover_entered(&env, Duration::from_secs(5)).await;
@@ -836,18 +837,16 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
 
     tokio::fs::remove_dir_all(&cache_entry_dir).await.unwrap();
     let generation_protected_run_id = RunId::new_v4();
-    env.provider.set_claim_result(
-        generation_protected_run_id,
-        Some(context_with_session(
-            generation_protected_run_id,
-            session_id,
-        )),
-    );
+    let mut generation_context =
+        context_with_session(generation_protected_run_id, provider_session_id);
+    generation_context.reuse_key = Some(reuse_key.into());
+    env.provider
+        .set_claim_result(generation_protected_run_id, Some(generation_context));
     env.handle
         .discover_tx
         .send(generation_affinity_protected_candidate(
             generation_protected_run_id,
-            session_id,
+            reuse_key,
             RunId::new_v4(),
         ))
         .unwrap();
@@ -859,12 +858,14 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
     assert_eq!(env.handle.deferred_poll_delays().len(), 2);
 
     let run_id = RunId::new_v4();
+    let mut workspace_context = context_with_session(run_id, provider_session_id);
+    workspace_context.reuse_key = Some(reuse_key.into());
     env.provider
-        .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
+        .set_claim_result(run_id, Some(workspace_context));
     env.handle
         .discover_tx
         .send(
-            workspace_affinity_protected_candidate(run_id, session_id)
+            workspace_affinity_protected_candidate(run_id, reuse_key)
                 .with_history_generation_run_id(Some(RunId::new_v4())),
         )
         .unwrap();
@@ -898,13 +899,14 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
 
 #[tokio::test]
 async fn saturated_cache_only_holder_defers_before_reclaiming_unrelated_idle() {
-    let session_id = "sess-cache-saturated";
+    let reuse_key = "thread:cache-saturated";
+    let provider_session_id = "provider-session-cache-saturated";
     let image_size_bytes = 1024 * 1024;
     let mut profiles = test_profiles();
     profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 1;
     let (mut config, env) = mock_run_config(profiles, 2, 4096, 1);
     let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
-    let workspace_cache = SessionWorkspaceCache::shared(
+    let workspace_cache = WorkspaceImageCache::shared(
         runner_paths.clone(),
         &config.paths.home,
         &config.runner.group,
@@ -912,7 +914,7 @@ async fn saturated_cache_only_holder_defers_before_reclaiming_unrelated_idle() {
     seed_workspace_cache_state(
         &workspace_cache,
         &runner_paths,
-        session_id,
+        reuse_key,
         "vm0/default",
         image_size_bytes,
     )
@@ -936,11 +938,12 @@ async fn saturated_cache_only_holder_defers_before_reclaiming_unrelated_idle() {
     wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     let run_id = RunId::new_v4();
-    env.provider
-        .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
+    let mut context = context_with_session(run_id, provider_session_id);
+    context.reuse_key = Some(reuse_key.into());
+    env.provider.set_claim_result(run_id, Some(context));
     env.handle
         .discover_tx
-        .send(workspace_affinity_protected_candidate(run_id, session_id))
+        .send(workspace_affinity_protected_candidate(run_id, reuse_key))
         .unwrap();
 
     wait_discover_entered(&env, Duration::from_secs(5)).await;
@@ -954,7 +957,7 @@ async fn saturated_cache_only_holder_defers_before_reclaiming_unrelated_idle() {
         "workspace-selected work should defer when fresh budget is unavailable"
     );
     assert_eq!(
-        idle_pool.lock().await.held_sessions(),
+        idle_pool.lock().await.held_reuse_keys(),
         vec!["sess-unrelated-idle".to_string()],
         "affinity deferral must happen before candidate-aware reclamation"
     );
@@ -1148,7 +1151,7 @@ async fn duplicate_discovery_deduplicated() {
         .unwrap();
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     assert_eq!(
-        idle_pool.lock().await.held_sessions(),
+        idle_pool.lock().await.held_reuse_keys(),
         vec![session_id.to_string()],
         "duplicate rejection should restore the reusable reservation"
     );

--- a/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
@@ -17,7 +17,7 @@ async fn telemetry_flush_includes_start_loop_claim_phase_spans() {
                 .body_includes("runner_claim_resume_session_validation")
                 .body_includes("runner_claim_device_rate_limits")
                 .body_includes("runner_claim_idle_reuse_lookup")
-                .body_includes("runner_claim_held_session_state_refresh")
+                .body_includes("runner_claim_workspace_cache_state_lookup")
                 .body_includes("runner_claim_active_status_publish")
                 .body_includes("runner_claim_spawn_job_setup")
                 .body_includes("runner_claim_task_schedule_wait");
@@ -61,7 +61,7 @@ async fn telemetry_flush_includes_reuse_hit_claim_phase_spans() {
                 .path("/api/webhooks/agent/telemetry")
                 .body_includes("sandbox_reuse_hit")
                 .body_includes("runner_claim_idle_reuse_lookup")
-                .body_includes("runner_claim_held_session_state_refresh")
+                .body_includes("runner_claim_workspace_cache_state_lookup")
                 .body_includes("runner_claim_idle_unpark")
                 .body_includes("runner_claim_task_schedule_wait");
             then.status(200)

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -8,7 +8,7 @@ use crate::paths::RunnerPaths;
 use crate::resource_budget::BudgetLease;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::workspace_image_cache::{
-    SessionWorkspaceCache, WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity,
+    WorkspaceCacheTerminalStatus, WorkspaceImageCache, WorkspaceImageLeaseIdentity,
     WorkspaceImagePrepareRequest, WorkspaceImagePromotionRequest,
 };
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
@@ -169,7 +169,8 @@ async fn seed_idle_pool_with_overrides_and_generation(
 }
 
 pub(in super::super) struct WorkspacePromotionSeedSpec<'a> {
-    pub(in super::super) session_id: &'a str,
+    pub(in super::super) provider_session_id: &'a str,
+    pub(in super::super) reuse_key: &'a str,
     pub(in super::super) profile_name: &'a str,
     pub(in super::super) vcpu: u32,
     pub(in super::super) memory_mb: u32,
@@ -179,7 +180,7 @@ pub(in super::super) struct WorkspacePromotionSeedSpec<'a> {
 pub(in super::super) async fn seed_idle_pool_with_workspace_promotion(
     pool: &SharedIdlePool,
     budget: &Arc<ResourceBudget>,
-    cache: &SessionWorkspaceCache,
+    cache: &WorkspaceImageCache,
     paths: &RunnerPaths,
     spec: WorkspacePromotionSeedSpec<'_>,
 ) -> SandboxId {
@@ -191,8 +192,7 @@ pub(in super::super) async fn seed_idle_pool_with_workspace_promotion(
                 run_id,
                 sandbox_id,
                 profile_name: spec.profile_name,
-                reuse_key: Some(spec.session_id),
-                cli_agent_session_id: Some(spec.session_id),
+                reuse_key: Some(spec.reuse_key),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: spec.image_size_bytes,
             },
@@ -210,7 +210,6 @@ pub(in super::super) async fn seed_idle_pool_with_workspace_promotion(
         .into_promotion_context(WorkspaceImagePromotionRequest {
             run_id,
             sandbox_id,
-            cli_agent_session_id_override: Some(spec.session_id),
             restored_session_identity: None,
             terminal_status: WorkspaceCacheTerminalStatus::Success,
             completed_at: TEST_SESSION_LAST_COMPLETED_AT.into(),
@@ -219,7 +218,8 @@ pub(in super::super) async fn seed_idle_pool_with_workspace_promotion(
         .expect("workspace image should be promotable");
     let budget_lease = ResourceBudget::try_reserve_lease(budget, spec.vcpu, spec.memory_mb)
         .expect("reserve budget");
-    let candidate = ParkedIdleCandidateBuilder::new(spec.session_id, budget_lease)
+    let candidate = ParkedIdleCandidateBuilder::new(spec.provider_session_id, budget_lease)
+        .with_reuse_key(spec.reuse_key)
         .with_mock_sandbox_name("idle-workspace-promotion-test")
         .with_sandbox_id(sandbox_id)
         .with_profile_name(spec.profile_name)
@@ -233,9 +233,9 @@ pub(in super::super) async fn seed_idle_pool_with_workspace_promotion(
 }
 
 pub(in super::super) async fn seed_workspace_cache_state(
-    cache: &SessionWorkspaceCache,
+    cache: &WorkspaceImageCache,
     paths: &RunnerPaths,
-    session_id: &str,
+    reuse_key: &str,
     profile_name: &str,
     image_size_bytes: u64,
 ) {
@@ -247,8 +247,7 @@ pub(in super::super) async fn seed_workspace_cache_state(
                 run_id,
                 sandbox_id,
                 profile_name,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes,
             },
@@ -266,7 +265,6 @@ pub(in super::super) async fn seed_workspace_cache_state(
         lease
             .promote(
                 run_id,
-                None,
                 WorkspaceCacheTerminalStatus::Success,
                 TEST_SESSION_LAST_COMPLETED_AT.into(),
                 &StorageFingerprints::default(),

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -26,6 +26,6 @@ pub(super) use self::wait::{
     assert_run_exits_within, wait_budget_count, wait_budget_exhausted_reactor, wait_cancel_handle,
     wait_cancel_token, wait_cancel_token_removed, wait_discover_entered,
     wait_idle_cleanup_processed_with_expired_entries, wait_idle_pool_len,
-    wait_idle_pool_session_states, wait_idle_pool_sessions, wait_parking_state,
+    wait_idle_pool_reuse_keys, wait_idle_pool_session_states, wait_parking_state,
     wait_sandbox_lifecycle_counts, wait_usage_flush_requested, wait_workspace_cache_reuse_keys,
 };

--- a/crates/runner/src/cmd/start/tests/support/wait.rs
+++ b/crates/runner/src/cmd/start/tests/support/wait.rs
@@ -4,7 +4,7 @@ use std::future::Future;
 
 use crate::idle_pool::ParkingState;
 use crate::run_cancellation::{RunCancellationHandle, RunCancellationRegistry};
-use crate::workspace_image_cache::SessionWorkspaceCache;
+use crate::workspace_image_cache::WorkspaceImageCache;
 
 const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
@@ -90,23 +90,23 @@ pub(in super::super) async fn wait_idle_pool_len(
     .await;
 }
 
-pub(in super::super) async fn wait_idle_pool_sessions(
+pub(in super::super) async fn wait_idle_pool_reuse_keys(
     pool: &SharedIdlePool,
     expected: &[&str],
     timeout: Duration,
 ) {
     let mut expected: Vec<String> = expected
         .iter()
-        .map(|session| (*session).to_string())
+        .map(|reuse_key| (*reuse_key).to_string())
         .collect();
     expected.sort_unstable();
     wait_for_probe(timeout, || async {
-        let actual = pool.lock().await.held_sessions();
+        let actual = pool.lock().await.held_reuse_keys();
         if actual == expected {
             WaitProbe::Ready(())
         } else {
             WaitProbe::Pending(format!(
-                "idle pool sessions did not reach {expected:?} within {timeout:?} (actual: {actual:?})",
+                "idle pool reuse keys did not reach {expected:?} within {timeout:?} (actual: {actual:?})",
             ))
         }
     })
@@ -146,7 +146,7 @@ pub(in super::super) async fn wait_idle_pool_session_states(
 }
 
 pub(in super::super) async fn wait_workspace_cache_reuse_keys(
-    cache: &SessionWorkspaceCache,
+    cache: &WorkspaceImageCache,
     expected: &[&str],
     timeout: Duration,
 ) {

--- a/crates/runner/src/cmd/workspace_image_cache.rs
+++ b/crates/runner/src/cmd/workspace_image_cache.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::{HomePaths, RunnerPaths};
 use crate::workspace_image_cache::{
-    CacheBudget, FsStats, SessionWorkspaceCache, WorkspaceImageCacheInspection,
+    CacheBudget, FsStats, WorkspaceImageCache, WorkspaceImageCacheInspection,
     WorkspaceImageCacheInspectionEntry, WorkspaceImageCacheInspectionStatus,
     WorkspaceImageCacheInspectionSummary,
 };
@@ -31,7 +31,7 @@ enum WorkspaceImageCacheCommand {
     /// Status-category, temporary-path, and size summary values are lower bounds
     /// when `lockedEntries` is greater than zero.
     List(WorkspaceImageCacheListArgs),
-    /// Clean up session workspace image cache entries
+    /// Clean up workspace image cache entries
     Gc(WorkspaceImageCacheGcArgs),
 }
 
@@ -120,8 +120,8 @@ async fn run_workspace_image_cache_with_home(
     }
 }
 
-fn shared_cache(home: &HomePaths) -> SessionWorkspaceCache {
-    SessionWorkspaceCache::shared(
+fn shared_cache(home: &HomePaths) -> WorkspaceImageCache {
+    WorkspaceImageCache::shared(
         RunnerPaths::new(home.runners_dir().join("_cache-gc")),
         home,
         "",
@@ -317,7 +317,7 @@ mod tests {
     use std::path::PathBuf;
 
     use crate::ids::RunId;
-    use crate::paths::session_workspace_cache_key;
+    use crate::paths::workspace_image_cache_key;
 
     fn tmp_image_path(home: &HomePaths, cache_key: &str, run_id: RunId) -> PathBuf {
         home.workspace_image_cache_dir()
@@ -530,7 +530,7 @@ mod tests {
     async fn workspace_image_cache_gc_cleans_shared_cache_root() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("home"));
-        let cache_key = session_workspace_cache_key("sess-1", "/workspace");
+        let cache_key = workspace_image_cache_key("sess-1", "/workspace");
         let tmp = tmp_image_path(&home, &cache_key, RunId::new_v4());
         tokio::fs::create_dir_all(tmp.parent().unwrap())
             .await
@@ -555,7 +555,7 @@ mod tests {
     async fn workspace_image_cache_gc_dry_run_preserves_files() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("home"));
-        let cache_key = session_workspace_cache_key("sess-1", "/workspace");
+        let cache_key = workspace_image_cache_key("sess-1", "/workspace");
         let tmp = tmp_image_path(&home, &cache_key, RunId::new_v4());
         tokio::fs::create_dir_all(tmp.parent().unwrap())
             .await

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -143,7 +143,7 @@ use crate::proxy::{MitmJsonlFlushHandle, ProxyRegistryHandle};
 use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, SandboxReuseResult};
 use crate::workspace_image_cache::{
-    SessionWorkspaceCache, WorkspaceImageActiveLeaseRequest, WorkspaceImageLease,
+    WorkspaceImageActiveLeaseRequest, WorkspaceImageCache, WorkspaceImageLease,
     WorkspaceImageLeaseIdentity, WorkspaceImagePromotionContext,
     WorkspaceImagePromotionIdentityFailure, WorkspaceImagePromotionIdentityMismatch,
     WorkspaceImagePromotionIdentityRequest,
@@ -182,7 +182,7 @@ pub struct ExecutorConfig {
     pub(crate) session_history_probe: SessionHistoryProbe,
     pub(crate) fresh_archive_delivery: crate::storage_cache::FreshArchiveDeliveryAdmission,
     pub home: HomePaths,
-    pub workspace_cache: Option<SessionWorkspaceCache>,
+    pub workspace_cache: Option<WorkspaceImageCache>,
 }
 
 /// Per-job VM parameters resolved from the profile config.
@@ -642,7 +642,6 @@ pub(crate) async fn execute_job_reuse_with_hooks(
                         sandbox_id,
                         profile_name: &params.profile_name,
                         reuse_key: claimed_reuse_key,
-                        cli_agent_session_id: context.cli_agent_session_id(),
                         working_dir: CANONICAL_WORKING_DIR,
                         image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
                     },
@@ -689,7 +688,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
 }
 
 async fn resolve_reused_workspace_promotion(
-    cache: Option<&SessionWorkspaceCache>,
+    cache: Option<&WorkspaceImageCache>,
     promotion: Option<WorkspaceImagePromotionContext>,
     run_id: RunId,
     sandbox_id: SandboxId,
@@ -737,7 +736,7 @@ async fn resolve_reused_workspace_promotion(
 }
 
 fn reused_promotion_into_active_lease(
-    cache: &SessionWorkspaceCache,
+    cache: &WorkspaceImageCache,
     promotion: WorkspaceImagePromotionContext,
     run_id: RunId,
     sandbox_id: SandboxId,

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -764,7 +764,6 @@ pub(super) async fn prepare_workspace_image(
                 sandbox_id,
                 profile_name,
                 reuse_key,
-                cli_agent_session_id: context.cli_agent_session_id(),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,
             },

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -46,8 +46,7 @@ impl RunnerPreSpawnPhase {
             }
             Self::DeviceRateLimits => "runner_claim_device_rate_limits",
             Self::IdleReuseLookup => "runner_claim_idle_reuse_lookup",
-            // Keep the established action type stable for existing telemetry consumers.
-            Self::WorkspaceCacheStateLookup => "runner_claim_held_session_state_refresh",
+            Self::WorkspaceCacheStateLookup => "runner_claim_workspace_cache_state_lookup",
             Self::WorkspacePromotionValidation => "runner_claim_workspace_promotion_validation",
             Self::IdleUnpark => "runner_claim_idle_unpark",
             Self::ActiveStatusPublish => "runner_claim_active_status_publish",
@@ -223,8 +222,7 @@ pub(super) fn record_workspace_cache_result(
     let action_type = match result {
         WorkspaceCacheCheckoutResult::Hit => "workspace_image_cache_hit",
         WorkspaceCacheCheckoutResult::Miss => "workspace_image_cache_miss",
-        // Keep the established action type stable for existing telemetry consumers.
-        WorkspaceCacheCheckoutResult::NoReuseKey => "workspace_image_cache_no_session",
+        WorkspaceCacheCheckoutResult::NoReuseKey => "workspace_image_cache_no_reuse_key",
         WorkspaceCacheCheckoutResult::InvalidWorkingDir => {
             "workspace_image_cache_invalid_working_dir"
         }

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -39,11 +39,11 @@ use super::support::{
     test_executor_config, test_telemetry,
 };
 use crate::ids::RunId;
-use crate::paths::{RunnerPaths, scoped_session_workspace_cache_key};
+use crate::paths::{RunnerPaths, scoped_workspace_image_cache_key};
 use crate::storage_manifest::StorageManifest;
 use crate::types::{FirewallEntry, ResumeSession, SandboxReuseResult};
 use crate::workspace_image_cache::{
-    SessionWorkspaceCache, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
+    WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus, WorkspaceImageCache,
     WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
 };
 use tracing::Level;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
@@ -104,7 +104,7 @@ async fn execute_job_reuse_claude_tool_validation_failure_returns_sandbox() {
 #[tokio::test]
 async fn execute_job_reuse_invalid_resume_session_does_not_lease_workspace_image() {
     let dir = tempfile::tempdir().unwrap();
-    let cache = SessionWorkspaceCache::new(RunnerPaths::new(dir.path().join("runner")));
+    let cache = WorkspaceImageCache::new(RunnerPaths::new(dir.path().join("runner")));
     let mut config = test_executor_config(dir.path()).await;
     config.workspace_cache = Some(cache);
     let params = JobParams {

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -1,11 +1,11 @@
 use super::*;
 
-fn set_session_affinity(
+fn set_reuse_and_session_identity(
     context: &mut crate::types::ExecutionContext,
     session_id: &str,
     session_history: &str,
 ) {
-    context.reuse_key = Some(format!("session:{session_id}"));
+    context.reuse_key = Some(format!("thread:workspace-cache-{session_id}"));
     context.resume_session = Some(ResumeSession::inline(
         session_id.into(),
         session_history.into(),
@@ -16,7 +16,7 @@ fn set_session_affinity(
 async fn workspace_mount_retry_starts_a_new_codex_catalog_prefetch_owner() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
     let mut config = test_executor_config(dir.path()).await;
     config.workspace_cache = Some(cache.clone());
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -29,7 +29,7 @@ async fn workspace_mount_retry_starts_a_new_codex_catalog_prefetch_owner() {
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = codex_oauth_context();
     let session_id = "00000000-0000-4000-8000-000000023425";
-    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
+    set_reuse_and_session_identity(&mut ctx, session_id, r#"{"type":"init"}"#);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -76,7 +76,7 @@ async fn workspace_mount_retry_starts_a_new_codex_catalog_prefetch_owner() {
 async fn execute_inner_retries_fresh_after_workspace_cache_hit_create_failure() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
     let mut config = test_executor_config(dir.path()).await;
     config.workspace_cache = Some(cache.clone());
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -104,7 +104,7 @@ async fn execute_inner_retries_fresh_after_workspace_cache_hit_create_failure() 
         storages: vec![storage],
         artifacts: Vec::new(),
     });
-    set_session_affinity(&mut ctx, "sess-cache-hit", r#"{"type":"init"}"#);
+    set_reuse_and_session_identity(&mut ctx, "sess-cache-hit", r#"{"type":"init"}"#);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -196,7 +196,7 @@ async fn execute_inner_retries_fresh_after_workspace_cache_hit_create_failure() 
 async fn execute_inner_dns_readiness_retry_replaces_consumed_workspace_cache_hit() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
     let mut config = test_executor_config(dir.path()).await;
     config.workspace_cache = Some(cache.clone());
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -206,7 +206,7 @@ async fn execute_inner_dns_readiness_retry_replaces_consumed_workspace_cache_hit
     }));
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
-    set_session_affinity(&mut ctx, "sess-cache-dns-retry", r#"{"type":"init"}"#);
+    set_reuse_and_session_identity(&mut ctx, "sess-cache-dns-retry", r#"{"type":"init"}"#);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -273,7 +273,7 @@ async fn execute_inner_dns_readiness_retry_replaces_consumed_workspace_cache_hit
 async fn process_timeout_invalidates_consumed_workspace_cache_without_fallback() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
     let mut config = test_executor_config(dir.path()).await;
     config.workspace_cache = Some(cache.clone());
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -284,7 +284,7 @@ async fn process_timeout_invalidates_consumed_workspace_cache_without_fallback()
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let session_id = "sess-cache-dns-process-timeout";
     let mut ctx = minimal_context();
-    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
+    set_reuse_and_session_identity(&mut ctx, session_id, r#"{"type":"init"}"#);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -341,8 +341,7 @@ async fn process_timeout_invalidates_consumed_workspace_cache_without_fallback()
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),
                 profile_name: &params.profile_name,
-                reuse_key: Some(&format!("session:{session_id}")),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(&format!("thread:workspace-cache-{session_id}")),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
             },
@@ -356,7 +355,7 @@ async fn process_timeout_invalidates_consumed_workspace_cache_without_fallback()
 async fn dns_replacement_records_completion_when_fresh_storage_prepare_fails() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
     let mut config = test_executor_config(dir.path()).await;
     config.workspace_cache = Some(cache.clone());
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -379,7 +378,7 @@ async fn dns_replacement_records_completion_when_fresh_storage_prepare_fails() {
     let storage_fingerprints =
         crate::storage_fingerprints::StorageFingerprints::from_manifest(&manifest);
     ctx.storage_manifest = Some(manifest);
-    set_session_affinity(
+    set_reuse_and_session_identity(
         &mut ctx,
         "sess-cache-dns-prepare-failure",
         r#"{"type":"init"}"#,
@@ -439,7 +438,7 @@ async fn dns_replacement_records_completion_when_fresh_storage_prepare_fails() {
 async fn execute_inner_cache_hit_retry_requires_completed_cleanup() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
     let mut config = test_executor_config(dir.path()).await;
     config.workspace_cache = Some(cache.clone());
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -449,7 +448,7 @@ async fn execute_inner_cache_hit_retry_requires_completed_cleanup() {
     overrides.push_destroy_panic("simulated destroy panic");
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
-    set_session_affinity(
+    set_reuse_and_session_identity(
         &mut ctx,
         "sess-cache-cleanup-uncertain",
         r#"{"type":"init"}"#,
@@ -494,13 +493,13 @@ async fn execute_inner_cache_hit_retry_requires_completed_cleanup() {
 async fn execute_inner_uses_workspace_cache_when_configured() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
     let mut config = test_executor_config(dir.path()).await;
     config.workspace_cache = Some(cache.clone());
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
-    set_session_affinity(&mut ctx, "sess-cache-default", r#"{"type":"init"}"#);
+    set_reuse_and_session_identity(&mut ctx, "sess-cache-default", r#"{"type":"init"}"#);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -562,22 +561,22 @@ async fn execute_inner_uses_workspace_cache_when_configured() {
 async fn execute_inner_records_workspace_cache_lock_busy_prepare_telemetry() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
     let mut config = test_executor_config(dir.path()).await;
     config.workspace_cache = Some(cache);
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
     let session_id = "sess-cache-lock-busy-prepare";
-    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
+    set_reuse_and_session_identity(&mut ctx, session_id, r#"{"type":"init"}"#);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
     };
-    let cache_key = scoped_session_workspace_cache_key(
+    let cache_key = scoped_workspace_image_cache_key(
         "",
         &params.profile_name,
-        &format!("session:{session_id}"),
+        &format!("thread:workspace-cache-{session_id}"),
         CANONICAL_WORKING_DIR,
         u64::from(params.workspace_disk_mb) * 1024 * 1024,
     );
@@ -627,7 +626,7 @@ async fn execute_inner_records_workspace_cache_lock_busy_prepare_telemetry() {
 async fn execute_inner_does_not_retry_workspace_cache_hit_after_proxy_register_failure() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
     let mut config = test_executor_config(dir.path()).await;
     config.workspace_cache = Some(cache.clone());
     tokio::fs::remove_file(dir.path().join("proxy-registry.json"))
@@ -636,7 +635,7 @@ async fn execute_inner_does_not_retry_workspace_cache_hit_after_proxy_register_f
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
-    set_session_affinity(&mut ctx, "sess-register-fail", r#"{"type":"init"}"#);
+    set_reuse_and_session_identity(&mut ctx, "sess-register-fail", r#"{"type":"init"}"#);
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -704,7 +703,7 @@ async fn execute_inner_does_not_retry_workspace_cache_hit_after_proxy_register_f
 async fn execute_job_reuse_uses_workspace_cache_when_configured() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths);
+    let cache = WorkspaceImageCache::new(runner_paths);
     let mut config = test_executor_config(dir.path()).await;
     config.workspace_cache = Some(cache.clone());
     let params = JobParams {
@@ -729,7 +728,7 @@ async fn execute_job_reuse_uses_workspace_cache_when_configured() {
     let (idle_sandbox, _lease) = make_reusable_idle_sandbox(sandbox, source_ip, session_id).await;
 
     let mut ctx = minimal_context();
-    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
+    set_reuse_and_session_identity(&mut ctx, session_id, r#"{"type":"init"}"#);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -744,8 +743,7 @@ async fn execute_job_reuse_uses_workspace_cache_when_configured() {
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),
                 profile_name: &params.profile_name,
-                reuse_key: Some(&format!("session:{session_id}")),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(&format!("thread:workspace-cache-{session_id}")),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
             },
@@ -759,7 +757,7 @@ async fn execute_job_reuse_uses_workspace_cache_when_configured() {
 async fn cached_reuse_workspace_promotion_identity_mismatch_stops_before_agent() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
     let mut config = test_executor_config(dir.path()).await;
     config.workspace_cache = Some(cache.clone());
     let promotion_params = JobParams {
@@ -780,7 +778,7 @@ async fn cached_reuse_workspace_promotion_identity_mismatch_stops_before_agent()
     .await;
 
     let mut ctx = minimal_context();
-    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
+    set_reuse_and_session_identity(&mut ctx, session_id, r#"{"type":"init"}"#);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -806,8 +804,7 @@ async fn cached_reuse_workspace_promotion_identity_mismatch_stops_before_agent()
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),
                 profile_name: &promotion_params.profile_name,
-                reuse_key: Some(&format!("session:{session_id}")),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(&format!("thread:workspace-cache-{session_id}")),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: u64::from(promotion_params.workspace_disk_mb) * 1024 * 1024,
             },
@@ -821,7 +818,7 @@ async fn cached_reuse_workspace_promotion_identity_mismatch_stops_before_agent()
 async fn execute_job_reuse_without_workspace_cache_config_invalidates_held_cache_entry() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
     let config = test_executor_config(dir.path()).await;
     let params = JobParams {
         workspace_disk_mb: 16,
@@ -833,7 +830,7 @@ async fn execute_job_reuse_without_workspace_cache_config_invalidates_held_cache
             .await;
 
     let mut ctx = minimal_context();
-    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
+    set_reuse_and_session_identity(&mut ctx, session_id, r#"{"type":"init"}"#);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -846,8 +843,7 @@ async fn execute_job_reuse_without_workspace_cache_config_invalidates_held_cache
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),
                 profile_name: &params.profile_name,
-                reuse_key: Some(&format!("session:{session_id}")),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(&format!("thread:workspace-cache-{session_id}")),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
             },
@@ -861,7 +857,7 @@ async fn execute_job_reuse_without_workspace_cache_config_invalidates_held_cache
 async fn unconfigured_cache_reuse_stops_when_cache_invalidation_fails() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
     let config = test_executor_config(dir.path()).await;
     let params = JobParams {
         workspace_disk_mb: 16,
@@ -875,21 +871,21 @@ async fn unconfigured_cache_reuse_stops_when_cache_invalidation_fails() {
         session_id,
     )
     .await;
-    let cache_key = scoped_session_workspace_cache_key(
+    let cache_key = scoped_workspace_image_cache_key(
         "",
         &params.profile_name,
-        &format!("session:{session_id}"),
+        &format!("thread:workspace-cache-{session_id}"),
         CANONICAL_WORKING_DIR,
         u64::from(params.workspace_disk_mb) * 1024 * 1024,
     );
-    let current_image = runner_paths.session_workspace_cache_current_image(&cache_key);
+    let current_image = runner_paths.workspace_image_cache_current_image(&cache_key);
     tokio::fs::create_dir_all(current_image.parent().unwrap())
         .await
         .unwrap();
     tokio::fs::create_dir(&current_image).await.unwrap();
 
     let mut ctx = minimal_context();
-    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
+    set_reuse_and_session_identity(&mut ctx, session_id, r#"{"type":"init"}"#);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -916,7 +912,7 @@ async fn unconfigured_cache_reuse_stops_when_cache_invalidation_fails() {
 async fn cached_reuse_validation_failure_keeps_workspace_cache_hidden() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
     let mut config = test_executor_config(dir.path()).await;
     config.workspace_cache = Some(cache.clone());
     let params = JobParams {
@@ -929,7 +925,7 @@ async fn cached_reuse_validation_failure_keeps_workspace_cache_hidden() {
             .await;
 
     let mut ctx = minimal_context();
-    set_session_affinity(&mut ctx, session_id, r#"{"type":"init"}"#);
+    set_reuse_and_session_identity(&mut ctx, session_id, r#"{"type":"init"}"#);
     ctx.environment = Some(HashMap::from([(
         "OPENAI_API_KEY".into(),
         "sk-proj-real-openai-secret".into(),
@@ -953,8 +949,7 @@ async fn cached_reuse_validation_failure_keeps_workspace_cache_hidden() {
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),
                 profile_name: &params.profile_name,
-                reuse_key: Some(&format!("session:{session_id}")),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(&format!("thread:workspace-cache-{session_id}")),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
             },
@@ -972,7 +967,7 @@ async fn cached_reuse_validation_failure_keeps_workspace_cache_hidden() {
 async fn cached_reuse_invalid_resume_session_keeps_existing_workspace_cache_hidden() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
     let mut config = test_executor_config(dir.path()).await;
     config.workspace_cache = Some(cache.clone());
     let params = JobParams {
@@ -986,7 +981,7 @@ async fn cached_reuse_invalid_resume_session_keeps_existing_workspace_cache_hidd
 
     let raw_session_id = "../invalid-resume";
     let mut ctx = minimal_context();
-    set_session_affinity(&mut ctx, raw_session_id, r#"{"type":"init"}"#);
+    set_reuse_and_session_identity(&mut ctx, raw_session_id, r#"{"type":"init"}"#);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -1009,8 +1004,7 @@ async fn cached_reuse_invalid_resume_session_keeps_existing_workspace_cache_hidd
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),
                 profile_name: &params.profile_name,
-                reuse_key: Some(&format!("session:{session_id}")),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(&format!("thread:workspace-cache-{session_id}")),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
             },
@@ -1028,7 +1022,7 @@ async fn cached_reuse_invalid_resume_session_keeps_existing_workspace_cache_hidd
 async fn cached_reuse_invalid_resume_session_without_promotion_skips_workspace_lease() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(runner_paths);
+    let cache = WorkspaceImageCache::new(runner_paths);
     let mut config = test_executor_config(dir.path()).await;
     config.workspace_cache = Some(cache);
     let params = JobParams {
@@ -1055,7 +1049,7 @@ async fn cached_reuse_invalid_resume_session_without_promotion_skips_workspace_l
 
     let raw_session_id = "../invalid-resume";
     let mut ctx = minimal_context();
-    set_session_affinity(&mut ctx, raw_session_id, r#"{"type":"init"}"#);
+    set_reuse_and_session_identity(&mut ctx, raw_session_id, r#"{"type":"init"}"#);
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -1074,7 +1068,7 @@ async fn cached_reuse_invalid_resume_session_without_promotion_skips_workspace_l
 }
 
 async fn reusable_idle_sandbox_with_workspace_promotion(
-    cache: &SessionWorkspaceCache,
+    cache: &WorkspaceImageCache,
     runner_paths: &RunnerPaths,
     params: &JobParams,
     session_id: &str,
@@ -1089,7 +1083,7 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
     };
     use crate::storage_fingerprints::StorageFingerprints;
 
-    let reuse_key = format!("session:{session_id}");
+    let reuse_key = format!("thread:workspace-cache-{session_id}");
     let current_image =
         seed_workspace_image_cache(cache, runner_paths, session_id, params.workspace_disk_mb).await;
 
@@ -1102,7 +1096,6 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
                 sandbox_id,
                 profile_name: &params.profile_name,
                 reuse_key: Some(&reuse_key),
-                cli_agent_session_id: Some(session_id),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
             },
@@ -1115,7 +1108,6 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
             crate::workspace_image_cache::WorkspaceImagePromotionRequest {
                 run_id,
                 sandbox_id,
-                cli_agent_session_id_override: Some(session_id),
                 restored_session_identity: None,
                 terminal_status: WorkspaceCacheTerminalStatus::Success,
                 completed_at: "2026-06-01T00:00:01.000Z".into(),
@@ -1185,7 +1177,7 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
 }
 
 async fn reusable_idle_sandbox_with_fresh_workspace_promotion(
-    cache: &SessionWorkspaceCache,
+    cache: &WorkspaceImageCache,
     runner_paths: &RunnerPaths,
     params: &JobParams,
     session_id: &str,
@@ -1199,7 +1191,7 @@ async fn reusable_idle_sandbox_with_fresh_workspace_promotion(
     };
     use crate::storage_fingerprints::StorageFingerprints;
 
-    let reuse_key = format!("session:{session_id}");
+    let reuse_key = format!("thread:workspace-cache-{session_id}");
     let run_id = RunId::new_v4();
     let sandbox_id = SandboxId::new_v4();
     let lease = cache
@@ -1209,7 +1201,6 @@ async fn reusable_idle_sandbox_with_fresh_workspace_promotion(
                 sandbox_id,
                 profile_name: &params.profile_name,
                 reuse_key: Some(&reuse_key),
-                cli_agent_session_id: None,
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
             },
@@ -1229,7 +1220,6 @@ async fn reusable_idle_sandbox_with_fresh_workspace_promotion(
             crate::workspace_image_cache::WorkspaceImagePromotionRequest {
                 run_id,
                 sandbox_id,
-                cli_agent_session_id_override: Some(session_id),
                 restored_session_identity: None,
                 terminal_status: WorkspaceCacheTerminalStatus::Success,
                 completed_at: "2026-06-01T00:00:01.000Z".into(),

--- a/crates/runner/src/executor/tests/support/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/support/workspace_cache.rs
@@ -4,15 +4,15 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use sandbox::SandboxId;
 
 use crate::ids::RunId;
-use crate::paths::{RunnerPaths, scoped_session_workspace_cache_key};
+use crate::paths::{RunnerPaths, scoped_workspace_image_cache_key};
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::workspace_image_cache::{
-    SessionWorkspaceCache, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
+    WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus, WorkspaceImageCache,
     WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
 };
 
 pub(in crate::executor::tests) async fn seed_workspace_image_cache(
-    cache: &SessionWorkspaceCache,
+    cache: &WorkspaceImageCache,
     runner_paths: &RunnerPaths,
     session_id: &str,
     workspace_disk_mb: u32,
@@ -28,7 +28,7 @@ pub(in crate::executor::tests) async fn seed_workspace_image_cache(
 }
 
 pub(in crate::executor::tests) async fn seed_workspace_image_cache_with_fingerprints(
-    cache: &SessionWorkspaceCache,
+    cache: &WorkspaceImageCache,
     runner_paths: &RunnerPaths,
     session_id: &str,
     workspace_disk_mb: u32,
@@ -36,7 +36,7 @@ pub(in crate::executor::tests) async fn seed_workspace_image_cache_with_fingerpr
 ) -> PathBuf {
     let sandbox_id = SandboxId::new_v4();
     let run_id = RunId::new_v4();
-    let reuse_key = format!("session:{session_id}");
+    let reuse_key = format!("thread:workspace-cache-{session_id}");
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
@@ -44,7 +44,6 @@ pub(in crate::executor::tests) async fn seed_workspace_image_cache_with_fingerpr
                 sandbox_id,
                 profile_name: "vm0/default",
                 reuse_key: Some(&reuse_key),
-                cli_agent_session_id: Some(session_id),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,
             },
@@ -67,7 +66,6 @@ pub(in crate::executor::tests) async fn seed_workspace_image_cache_with_fingerpr
         lease
             .promote(
                 run_id,
-                None,
                 WorkspaceCacheTerminalStatus::Success,
                 "2026-06-01T00:00:00.000Z".into(),
                 storage_fingerprints,
@@ -76,12 +74,12 @@ pub(in crate::executor::tests) async fn seed_workspace_image_cache_with_fingerpr
             .unwrap()
     );
 
-    let cache_key = scoped_session_workspace_cache_key(
+    let cache_key = scoped_workspace_image_cache_key(
         "",
         "vm0/default",
         &reuse_key,
         CANONICAL_WORKING_DIR,
         u64::from(workspace_disk_mb) * 1024 * 1024,
     );
-    runner_paths.session_workspace_cache_current_image(&cache_key)
+    runner_paths.workspace_image_cache_current_image(&cache_key)
 }

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -449,7 +449,7 @@ const RUNNER_PRE_SPAWN_PHASE_ACTIONS: &[&str] = &[
     "runner_claim_session_history_materializer_start",
     "runner_claim_device_rate_limits",
     "runner_claim_idle_reuse_lookup",
-    "runner_claim_held_session_state_refresh",
+    "runner_claim_workspace_cache_state_lookup",
     "runner_claim_workspace_promotion_validation",
     "runner_claim_idle_unpark",
     "runner_claim_active_status_publish",

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -21,7 +21,7 @@ use crate::status::IdleVm;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::{HeldSessionState, ReusableSandboxState};
 use crate::workspace_image_cache::{
-    SessionWorkspaceCache, WorkspaceImagePromotionContext, WorkspaceImagePromotionIdentityMismatch,
+    WorkspaceImageCache, WorkspaceImagePromotionContext, WorkspaceImagePromotionIdentityMismatch,
     WorkspaceImagePromotionIdentityRequest,
 };
 use crate::workspace_promotion::{
@@ -131,7 +131,7 @@ impl Default for ParkingGate {
     }
 }
 
-/// One-shot request to transition an active sandbox into same-session idle
+/// One-shot request to transition an active sandbox into same-reuse-key idle
 /// ownership.
 #[must_use = "idle park requests own active sandbox and budget; call park_for_idle"]
 pub(crate) struct IdleParkRequest {
@@ -230,7 +230,7 @@ enum WorkspacePromotionPolicy {
 /// Active-owned sandbox after `Sandbox::park()` succeeds, before idle-pool
 /// ownership is accepted.
 ///
-/// This state proves only same-session idle park. It does not imply clean
+/// This state proves only same-reuse-key idle park. It does not imply clean
 /// cross-run reuse, snapshot readiness, or any broader VM correctness.
 #[must_use = "parked idle candidates must be accepted by the idle pool or explicitly destroyed"]
 pub struct ParkedIdleCandidate {
@@ -958,7 +958,7 @@ impl IdleEntry {
 
     pub fn validate_workspace_promotion_identity(
         &self,
-        cache: &SessionWorkspaceCache,
+        cache: &WorkspaceImageCache,
         working_dir: &str,
         image_size_bytes: u64,
     ) -> Result<(), WorkspaceImagePromotionIdentityMismatch> {
@@ -1018,7 +1018,7 @@ impl ReservedIdleSandbox {
 
     pub fn validate_workspace_promotion_identity(
         &self,
-        cache: &SessionWorkspaceCache,
+        cache: &WorkspaceImageCache,
         working_dir: &str,
         image_size_bytes: u64,
     ) -> Result<(), WorkspaceImagePromotionIdentityMismatch> {
@@ -1043,7 +1043,7 @@ impl ReservedIdleSandbox {
 /// Pool of idle sandboxes keyed by reuse key.
 ///
 /// After a job completes successfully, its sandbox can be parked here
-/// instead of being destroyed. A subsequent job for the same session
+/// instead of being destroyed. A subsequent job for the same reuse key
 /// can reuse the parked sandbox, skipping VM creation and startup.
 pub struct IdlePool {
     entries: HashMap<String, IdleEntry>,
@@ -1285,10 +1285,10 @@ impl IdlePool {
     }
 
     #[cfg(test)]
-    pub fn held_sessions(&self) -> Vec<String> {
-        let mut sessions: Vec<String> = self.entries.keys().cloned().collect();
-        sessions.sort_unstable();
-        sessions
+    pub fn held_reuse_keys(&self) -> Vec<String> {
+        let mut reuse_keys: Vec<String> = self.entries.keys().cloned().collect();
+        reuse_keys.sort_unstable();
+        reuse_keys
     }
 
     /// Number of idle VMs in the pool.
@@ -2098,13 +2098,13 @@ mod tests {
     }
 
     #[test]
-    fn held_sessions() {
+    fn held_reuse_keys() {
         let mut pool = IdlePool::new(pool_config(0));
         let _ = pool.park(make_candidate_for("s1", 2, 2048));
         let _ = pool.park(make_candidate_for("s2", 2, 2048));
 
-        let sessions = pool.held_sessions();
-        assert_eq!(sessions, vec!["s1", "s2"]);
+        let reuse_keys = pool.held_reuse_keys();
+        assert_eq!(reuse_keys, vec!["s1", "s2"]);
     }
 
     #[test]

--- a/crates/runner/src/idle_pool/destroy_tests.rs
+++ b/crates/runner/src/idle_pool/destroy_tests.rs
@@ -176,7 +176,7 @@ async fn idle_destroy_job_publishes_frozen_workspace_only_after_successful_stop(
     assert_eq!(budget.allocated(), (0, 0, 0));
     let states = fixture.cache.held_workspace_states().await;
     assert_eq!(states.len(), 1);
-    assert_eq!(states[0].reuse_key, fixture.session_id);
+    assert_eq!(states[0].reuse_key, fixture.reuse_key);
     let paths = RunnerPaths::new(fixture._dir.path().join("runner"));
     assert!(
         !tokio::fs::try_exists(paths.active_workspace_image(&fixture.sandbox_id))
@@ -188,7 +188,7 @@ async fn idle_destroy_job_publishes_frozen_workspace_only_after_successful_stop(
         .await
         .unwrap();
     assert_eq!(
-        WorkspacePromotionFixture::checkout_result(&fixture.cache, &fixture.session_id).await,
+        WorkspacePromotionFixture::checkout_result(&fixture.cache, &fixture.reuse_key).await,
         WorkspaceCacheCheckoutResult::Hit,
         "removing the destroyed sandbox workspace must not remove the promoted cache entry"
     );

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -99,7 +99,7 @@ enum Command {
     Kill(cmd::KillArgs),
     /// Clean up unused runner resources, artifacts, logs, and caches
     Gc(cmd::GcArgs),
-    /// Inspect and clean up session workspace image cache entries
+    /// Inspect and clean up workspace image cache entries
     WorkspaceImageCache(cmd::WorkspaceImageCacheArgs),
     /// Runtime health diagnostics for all runners on the host
     Doctor(cmd::DoctorArgs),

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -24,6 +24,8 @@ use sha2::{Digest, Sha256};
 use crate::error::RunnerResult;
 use crate::ids::RunId;
 
+const WORKSPACE_IMAGE_CACHE_KEY_DOMAIN: &[u8] = b"workspace-image-cache:v1\0";
+
 /// Short hex digests for storage name and version components, used when
 /// building filesystem paths from untrusted manifest fields.
 ///
@@ -61,11 +63,11 @@ pub(crate) fn base_dir_lock_name(base_dir: &Path) -> String {
 /// includes the cache scope, profile, drive layout version, and logical image
 /// size so incompatible workspace images never share a host entry.
 #[cfg(test)]
-pub(crate) fn session_workspace_cache_key(reuse_key: &str, working_dir: &str) -> String {
-    scoped_session_workspace_cache_key("", "vm0/default", reuse_key, working_dir, 5)
+pub(crate) fn workspace_image_cache_key(reuse_key: &str, working_dir: &str) -> String {
+    scoped_workspace_image_cache_key("", "vm0/default", reuse_key, working_dir, 5)
 }
 
-pub(crate) fn scoped_session_workspace_cache_key(
+pub(crate) fn scoped_workspace_image_cache_key(
     cache_scope: &str,
     profile_name: &str,
     reuse_key: &str,
@@ -73,7 +75,7 @@ pub(crate) fn scoped_session_workspace_cache_key(
     image_size_bytes: u64,
 ) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(b"session-workspace-cache:v4\0");
+    hasher.update(WORKSPACE_IMAGE_CACHE_KEY_DOMAIN);
     hasher.update(cache_scope.as_bytes());
     hasher.update(b"\0");
     hasher.update(profile_name.as_bytes());
@@ -171,25 +173,25 @@ impl RunnerPaths {
     }
 
     #[cfg(test)]
-    pub fn session_workspace_cache_entry_dir(&self, cache_key: &str) -> PathBuf {
+    pub fn workspace_image_cache_entry_dir(&self, cache_key: &str) -> PathBuf {
         self.workspace_image_cache_dir().join(cache_key)
     }
 
     #[cfg(test)]
-    pub fn session_workspace_cache_metadata(&self, cache_key: &str) -> PathBuf {
-        self.session_workspace_cache_entry_dir(cache_key)
+    pub fn workspace_image_cache_metadata(&self, cache_key: &str) -> PathBuf {
+        self.workspace_image_cache_entry_dir(cache_key)
             .join("metadata.json")
     }
 
     #[cfg(test)]
-    pub fn session_workspace_cache_current_image(&self, cache_key: &str) -> PathBuf {
-        self.session_workspace_cache_entry_dir(cache_key)
+    pub fn workspace_image_cache_current_image(&self, cache_key: &str) -> PathBuf {
+        self.workspace_image_cache_entry_dir(cache_key)
             .join("current.ext4")
     }
 
     #[cfg(test)]
-    pub fn session_workspace_cache_tmp_image(&self, cache_key: &str, run_id: RunId) -> PathBuf {
-        self.session_workspace_cache_entry_dir(cache_key)
+    pub fn workspace_image_cache_tmp_image(&self, cache_key: &str, run_id: RunId) -> PathBuf {
+        self.workspace_image_cache_entry_dir(cache_key)
             .join(format!("current.ext4.tmp.{run_id}"))
     }
 }

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -534,7 +534,7 @@ pub trait JobProvider: Send + Sync {
     /// the future to enforce single-flight and lifecycle ordering.
     async fn heartbeat(&self, state: &HeartbeatState);
 
-    /// Delay the next API-backed poll until a protected same-session job can
+    /// Delay the next API-backed poll until a protected same-reuse-key job can
     /// fall back to normal compatible-runner claiming.
     /// Default no-op — only relevant for API-backed providers.
     async fn defer_poll_after(&self, _delay: Duration) {}

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -52,7 +52,7 @@ pub(crate) fn reuse_key_kind(reuse_key: &str) -> &'static str {
     if reuse_key.starts_with("thread:") {
         "thread"
     } else {
-        "session"
+        "other"
     }
 }
 

--- a/crates/runner/src/workspace_image_cache/entry.rs
+++ b/crates/runner/src/workspace_image_cache/entry.rs
@@ -2,11 +2,11 @@ use std::path::{Path, PathBuf};
 
 use crate::ids::RunId;
 use crate::paths::{
-    scoped_session_workspace_cache_key, workspace_image_cache_capacity_lock_path,
+    scoped_workspace_image_cache_key, workspace_image_cache_capacity_lock_path,
     workspace_image_cache_lock_path,
 };
 
-use super::SessionWorkspaceCache;
+use super::WorkspaceImageCache;
 use super::metadata::WorkspaceCacheMetadata;
 
 #[derive(Clone, Debug)]
@@ -14,7 +14,6 @@ pub(super) struct CacheEntryPaths {
     entry_dir: PathBuf,
     metadata: PathBuf,
     current_image: PathBuf,
-    session_history_sidecar: PathBuf,
     session_history_sidecar_metadata: PathBuf,
 }
 
@@ -24,7 +23,6 @@ impl CacheEntryPaths {
         Self {
             metadata: entry_dir.join("metadata.json"),
             current_image: entry_dir.join("current.ext4"),
-            session_history_sidecar: entry_dir.join("session-history.blob"),
             session_history_sidecar_metadata: entry_dir.join("session-history.metadata.json"),
             entry_dir,
         }
@@ -46,10 +44,6 @@ impl CacheEntryPaths {
         &self.current_image
     }
 
-    pub(super) fn session_history_sidecar(&self) -> &Path {
-        &self.session_history_sidecar
-    }
-
     pub(super) fn session_history_sidecar_metadata(&self) -> &Path {
         &self.session_history_sidecar_metadata
     }
@@ -69,7 +63,7 @@ impl CacheEntryPaths {
     }
 }
 
-impl SessionWorkspaceCache {
+impl WorkspaceImageCache {
     pub(super) fn workspace_image_cache_dir(&self) -> &Path {
         &self.inner.cache_dir
     }
@@ -78,19 +72,19 @@ impl SessionWorkspaceCache {
         super::fs::existing_fs_stats_path(self.workspace_image_cache_dir())
     }
 
-    pub(super) fn session_workspace_cache_entry_dir(&self, cache_key: &str) -> PathBuf {
+    pub(super) fn workspace_image_cache_entry_dir(&self, cache_key: &str) -> PathBuf {
         self.entry_paths(cache_key).entry_dir().to_path_buf()
     }
 
-    pub(super) fn session_workspace_cache_metadata(&self, cache_key: &str) -> PathBuf {
+    pub(super) fn workspace_image_cache_metadata(&self, cache_key: &str) -> PathBuf {
         self.entry_paths(cache_key).metadata().to_path_buf()
     }
 
-    pub(super) fn session_workspace_cache_current_image(&self, cache_key: &str) -> PathBuf {
+    pub(super) fn workspace_image_cache_current_image(&self, cache_key: &str) -> PathBuf {
         self.entry_paths(cache_key).current_image().to_path_buf()
     }
 
-    pub(super) fn session_workspace_cache_tmp_image(
+    pub(super) fn workspace_image_cache_tmp_image(
         &self,
         cache_key: &str,
         run_id: RunId,
@@ -98,7 +92,7 @@ impl SessionWorkspaceCache {
         self.entry_paths(cache_key).tmp_image(run_id)
     }
 
-    pub(super) fn session_workspace_cache_tmp_sidecar(
+    pub(super) fn workspace_image_cache_tmp_sidecar(
         &self,
         cache_key: &str,
         run_id: RunId,
@@ -107,7 +101,7 @@ impl SessionWorkspaceCache {
             .tmp_session_history_sidecar(run_id)
     }
 
-    pub(super) fn session_workspace_cache_tmp_sidecar_metadata(
+    pub(super) fn workspace_image_cache_tmp_sidecar_metadata(
         &self,
         cache_key: &str,
         run_id: RunId,
@@ -123,7 +117,7 @@ impl SessionWorkspaceCache {
         working_dir: &str,
         image_size_bytes: u64,
     ) -> String {
-        scoped_session_workspace_cache_key(
+        scoped_workspace_image_cache_key(
             &self.inner.cache_scope,
             profile_name,
             reuse_key,
@@ -137,7 +131,7 @@ impl SessionWorkspaceCache {
         cache_key: &str,
         metadata: &WorkspaceCacheMetadata,
     ) -> bool {
-        scoped_session_workspace_cache_key(
+        scoped_workspace_image_cache_key(
             &metadata.cache_scope,
             &metadata.profile_name,
             &metadata.reuse_key,

--- a/crates/runner/src/workspace_image_cache/fs.rs
+++ b/crates/runner/src/workspace_image_cache/fs.rs
@@ -12,12 +12,12 @@ use chrono::SecondsFormat;
 
 use crate::error::{RunnerError, RunnerResult};
 
-use super::SessionWorkspaceCache;
+use super::WorkspaceImageCache;
 use super::types::{CacheBudget, FsStats};
 
 pub(super) const WORKSPACE_IMAGE_COPY_TIMEOUT: Duration = Duration::from_secs(300);
 
-impl SessionWorkspaceCache {
+impl WorkspaceImageCache {
     pub(super) async fn fs_stats(&self) -> RunnerResult<FsStats> {
         #[cfg(test)]
         {

--- a/crates/runner/src/workspace_image_cache/gc.rs
+++ b/crates/runner/src/workspace_image_cache/gc.rs
@@ -20,9 +20,7 @@ use super::metadata::{
 };
 use super::path_safety::is_safe_guest_working_dir;
 use super::types::{CacheBudget, FsStats};
-use super::{
-    CACHE_FORMAT_VERSION, CACHE_KEY_VERSION, SessionWorkspaceCache, WORKSPACE_DRIVE_LAYOUT,
-};
+use super::{CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceImageCache};
 
 pub(super) struct GcCandidate {
     pub(super) cache_key: String,
@@ -81,7 +79,7 @@ pub(super) fn gc_budget_satisfied(
                 >= budget.min_free_bytes)
 }
 
-impl SessionWorkspaceCache {
+impl WorkspaceImageCache {
     pub(crate) async fn gc(&self, dry_run: bool) -> RunnerResult<u64> {
         let _capacity_lock = crate::lock::acquire(self.capacity_lock_path()).await?;
         self.gc_locked(dry_run).await
@@ -146,8 +144,7 @@ impl SessionWorkspaceCache {
                     "[dry-run] would delete workspace image cache entry"
                 );
             } else if let Err(e) =
-                fs::remove_dir_all(self.session_workspace_cache_entry_dir(&candidate.cache_key))
-                    .await
+                fs::remove_dir_all(self.workspace_image_cache_entry_dir(&candidate.cache_key)).await
             {
                 warn!(
                     cache_key = candidate.cache_key,
@@ -204,7 +201,7 @@ impl SessionWorkspaceCache {
         entry: &GcCacheEntry,
         dry_run: bool,
     ) -> RunnerResult<GcEntryInventory> {
-        let current = self.session_workspace_cache_current_image(&entry.cache_key);
+        let current = self.workspace_image_cache_current_image(&entry.cache_key);
         let current_metadata = match fs::symlink_metadata(&current).await {
             Ok(metadata) => metadata,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -214,7 +211,7 @@ impl SessionWorkspaceCache {
             }
             Err(e) => return Err(e.into()),
         };
-        let metadata_path = self.session_workspace_cache_metadata(&entry.cache_key);
+        let metadata_path = self.workspace_image_cache_metadata(&entry.cache_key);
         let metadata = match self.read_metadata_file(&metadata_path).await {
             Ok(metadata) => metadata,
             Err(RunnerError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -408,9 +405,6 @@ impl SessionWorkspaceCache {
         if metadata.format_version != CACHE_FORMAT_VERSION {
             return Some("metadata format version mismatch");
         }
-        if metadata.key_version != CACHE_KEY_VERSION {
-            return Some("metadata key version mismatch");
-        }
         if metadata.drive_layout != WORKSPACE_DRIVE_LAYOUT {
             return Some("drive layout mismatch");
         }
@@ -517,12 +511,12 @@ impl SessionWorkspaceCache {
     }
 
     pub(super) async fn gc_candidate(&self, cache_key: String) -> Option<GcCandidate> {
-        let entry_dir = self.session_workspace_cache_entry_dir(&cache_key);
+        let entry_dir = self.workspace_image_cache_entry_dir(&cache_key);
         if !cache_entry_dir_is_dir(&entry_dir).await.ok()? {
             return None;
         }
-        let metadata_path = self.session_workspace_cache_metadata(&cache_key);
-        let current_path = self.session_workspace_cache_current_image(&cache_key);
+        let metadata_path = self.workspace_image_cache_metadata(&cache_key);
+        let current_path = self.workspace_image_cache_current_image(&cache_key);
         let file_metadata = fs::symlink_metadata(&current_path).await.ok()?;
         if !file_metadata.is_file() {
             return None;

--- a/crates/runner/src/workspace_image_cache/inspection.rs
+++ b/crates/runner/src/workspace_image_cache/inspection.rs
@@ -14,9 +14,9 @@ use super::types::{
     CacheBudget, FsStats, WorkspaceImageCacheInspection, WorkspaceImageCacheInspectionEntry,
     WorkspaceImageCacheInspectionStatus, WorkspaceImageCacheInspectionSummary,
 };
-use super::{SessionWorkspaceCache, TemporaryPathStats};
+use super::{TemporaryPathStats, WorkspaceImageCache};
 
-impl SessionWorkspaceCache {
+impl WorkspaceImageCache {
     pub(crate) async fn inspect(&self) -> RunnerResult<WorkspaceImageCacheInspection> {
         let fs_stats = self.fs_stats().await?;
         let budget = CacheBudget::from_fs_stats(fs_stats);
@@ -122,7 +122,7 @@ impl SessionWorkspaceCache {
         }
         let temporary = inspect_temporary_paths(&entry_dir).await?;
 
-        let current = self.session_workspace_cache_current_image(&cache_key);
+        let current = self.workspace_image_cache_current_image(&cache_key);
         let current_metadata = match fs::symlink_metadata(&current).await {
             Ok(metadata) => Some(metadata),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
@@ -131,7 +131,7 @@ impl SessionWorkspaceCache {
                 return Err(e.into());
             }
         };
-        let metadata_path = self.session_workspace_cache_metadata(&cache_key);
+        let metadata_path = self.workspace_image_cache_metadata(&cache_key);
         let (metadata, metadata_read_error) = match self.read_metadata_file(&metadata_path).await {
             Ok(metadata) => (Some(metadata), None),
             Err(RunnerError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => (None, None),

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -39,16 +39,13 @@ use super::types::{
     WorkspaceSessionHistorySidecar, WorkspaceSessionHistorySidecarMiss,
     WorkspaceSessionHistorySidecarPromotionSource, WorkspaceSessionHistorySidecarPublication,
 };
-use super::{
-    CACHE_FORMAT_VERSION, CACHE_KEY_VERSION, SessionWorkspaceCache, WORKSPACE_DRIVE_LAYOUT,
-};
+use super::{CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceImageCache};
 
 pub(crate) struct WorkspaceImageLease {
-    cache: SessionWorkspaceCache,
+    cache: WorkspaceImageCache,
     pub(super) cache_key: Option<String>,
     profile_name: String,
     reuse_key: Option<String>,
-    cli_agent_session_id: Option<String>,
     working_dir: String,
     active_image: PathBuf,
     pub(super) source_image: Option<PathBuf>,
@@ -61,14 +58,13 @@ pub(crate) struct WorkspaceImageLease {
 }
 
 pub(crate) struct WorkspaceImagePromotionContext {
-    cache: SessionWorkspaceCache,
+    cache: WorkspaceImageCache,
     cache_key: String,
     entry_lock: Option<Flock<std::fs::File>>,
     run_id: RunId,
     sandbox_id: sandbox::SandboxId,
     profile_name: String,
     reuse_key: String,
-    cli_agent_session_id: Option<String>,
     working_dir: String,
     active_image: PathBuf,
     image_size_bytes: u64,
@@ -80,7 +76,7 @@ pub(crate) struct WorkspaceImagePromotionContext {
 }
 
 pub(crate) struct WorkspaceSessionHistorySidecarEntryGuard {
-    cache: SessionWorkspaceCache,
+    cache: WorkspaceImageCache,
     cache_key: String,
     run_id: RunId,
     restored_session_identity: crate::restored_session_identity::RestoredSessionIdentity,
@@ -104,7 +100,6 @@ struct WorkspaceImagePromotionInput<'a> {
     cache_key: &'a str,
     profile_name: &'a str,
     reuse_key: &'a str,
-    cli_agent_session_id: Option<&'a str>,
     working_dir: &'a str,
     active_image: &'a Path,
     image_size_bytes: u64,
@@ -117,14 +112,12 @@ struct WorkspaceImagePromotionInput<'a> {
 struct WorkspaceImagePromotionTarget {
     cache_key: String,
     reuse_key: String,
-    cli_agent_session_id: Option<String>,
 }
 
 struct WorkspaceImageLeaseCommon<'a> {
     run_id: RunId,
     profile_name: &'a str,
     reuse_key: Option<&'a str>,
-    cli_agent_session_id: Option<&'a str>,
     raw_working_dir: &'a str,
     normalized_working_dir: Option<String>,
     active_image: PathBuf,
@@ -132,10 +125,9 @@ struct WorkspaceImageLeaseCommon<'a> {
 }
 
 struct WorkspaceImageLeaseBase {
-    cache: SessionWorkspaceCache,
+    cache: WorkspaceImageCache,
     profile_name: String,
     reuse_key: Option<String>,
-    cli_agent_session_id: Option<String>,
     working_dir: String,
     active_image: PathBuf,
     image_size_bytes: u64,
@@ -157,12 +149,11 @@ fn workspace_image_size_mb(image_size_bytes: u64) -> u32 {
 }
 
 impl<'a> WorkspaceImageLeaseCommon<'a> {
-    fn new(cache: &SessionWorkspaceCache, identity: WorkspaceImageLeaseIdentity<'a>) -> Self {
+    fn new(cache: &WorkspaceImageCache, identity: WorkspaceImageLeaseIdentity<'a>) -> Self {
         Self {
             run_id: identity.run_id,
             profile_name: identity.profile_name,
             reuse_key: identity.reuse_key,
-            cli_agent_session_id: identity.cli_agent_session_id,
             raw_working_dir: identity.working_dir,
             normalized_working_dir: normalize_safe_guest_working_dir(identity.working_dir),
             active_image: cache.paths().active_workspace_image(&identity.sandbox_id),
@@ -178,12 +169,7 @@ impl<'a> WorkspaceImageLeaseCommon<'a> {
         self.safe_working_dir().unwrap_or(self.raw_working_dir)
     }
 
-    fn cache_key(
-        &self,
-        cache: &SessionWorkspaceCache,
-        reuse_key: &str,
-        working_dir: &str,
-    ) -> String {
+    fn cache_key(&self, cache: &WorkspaceImageCache, reuse_key: &str, working_dir: &str) -> String {
         cache.scoped_cache_key(
             self.profile_name,
             reuse_key,
@@ -192,12 +178,11 @@ impl<'a> WorkspaceImageLeaseCommon<'a> {
         )
     }
 
-    fn lease_base(&self, cache: &SessionWorkspaceCache) -> WorkspaceImageLeaseBase {
+    fn lease_base(&self, cache: &WorkspaceImageCache) -> WorkspaceImageLeaseBase {
         WorkspaceImageLeaseBase {
             cache: cache.clone(),
             profile_name: self.profile_name.to_owned(),
             reuse_key: self.reuse_key.map(str::to_owned),
-            cli_agent_session_id: self.cli_agent_session_id.map(str::to_owned),
             working_dir: self.lease_working_dir().to_owned(),
             active_image: self.active_image.clone(),
             image_size_bytes: self.image_size_bytes,
@@ -212,7 +197,6 @@ impl WorkspaceImageLease {
             cache_key: state.cache_key,
             profile_name: base.profile_name,
             reuse_key: base.reuse_key,
-            cli_agent_session_id: base.cli_agent_session_id,
             working_dir: base.working_dir,
             active_image: base.active_image,
             source_image: state.source_image,
@@ -226,7 +210,7 @@ impl WorkspaceImageLease {
     }
 }
 
-impl SessionWorkspaceCache {
+impl WorkspaceImageCache {
     pub(crate) fn expected_promotion_identity(
         &self,
         request: WorkspaceImagePromotionIdentityRequest<'_>,
@@ -430,7 +414,7 @@ impl SessionWorkspaceCache {
             }
         };
 
-        let entry_dir = self.session_workspace_cache_entry_dir(&cache_key);
+        let entry_dir = self.workspace_image_cache_entry_dir(&cache_key);
         match remove_non_directory_workspace_cache_entry(&entry_dir).await {
             Ok(true) => {
                 info!(
@@ -468,8 +452,8 @@ impl SessionWorkspaceCache {
             }
         }
 
-        let metadata_path = self.session_workspace_cache_metadata(&cache_key);
-        let current_path = self.session_workspace_cache_current_image(&cache_key);
+        let metadata_path = self.workspace_image_cache_metadata(&cache_key);
+        let current_path = self.workspace_image_cache_current_image(&cache_key);
         let hit = match self
             .read_valid_metadata(
                 &metadata_path,
@@ -517,7 +501,7 @@ impl SessionWorkspaceCache {
                     error = %e,
                     "workspace image cache metadata invalid; using fresh workspace image"
                 );
-                let entry_dir = self.session_workspace_cache_entry_dir(&cache_key);
+                let entry_dir = self.workspace_image_cache_entry_dir(&cache_key);
                 match fs::remove_dir_all(&entry_dir).await {
                     Ok(()) => {
                         info!(
@@ -629,7 +613,7 @@ impl SessionWorkspaceCache {
             let Ok(lock) = crate::lock::try_acquire(self.entry_lock_path(cache_key)).await else {
                 continue;
             };
-            let metadata_path = self.session_workspace_cache_metadata(cache_key);
+            let metadata_path = self.workspace_image_cache_metadata(cache_key);
             let metadata = match self.read_metadata_file(&metadata_path).await {
                 Ok(metadata) => metadata,
                 Err(_) => {
@@ -683,7 +667,6 @@ impl SessionWorkspaceCache {
         profile_image_sizes_bytes: Option<&BTreeMap<&str, u64>>,
     ) -> bool {
         metadata.format_version == CACHE_FORMAT_VERSION
-            && metadata.key_version == CACHE_KEY_VERSION
             && metadata.cache_scope == self.inner.cache_scope
             && metadata.drive_layout == WORKSPACE_DRIVE_LAYOUT
             && metadata.state == WorkspaceCacheEntryState::Current
@@ -707,7 +690,7 @@ impl SessionWorkspaceCache {
         cache_key: &str,
         reason: &str,
     ) -> RunnerResult<bool> {
-        let entry_dir = self.session_workspace_cache_entry_dir(cache_key);
+        let entry_dir = self.workspace_image_cache_entry_dir(cache_key);
         match remove_workspace_cache_path_if_exists(&entry_dir).await {
             Ok(removed) => {
                 if removed {
@@ -729,7 +712,7 @@ impl SessionWorkspaceCache {
         input: WorkspaceImagePromotionInput<'_>,
     ) -> RunnerResult<WorkspaceImagePromotionOutcome> {
         let promotion_started = Instant::now();
-        let cache_dir = self.session_workspace_cache_entry_dir(input.cache_key);
+        let cache_dir = self.workspace_image_cache_entry_dir(input.cache_key);
         if remove_non_directory_workspace_cache_entry(&cache_dir).await? {
             info!(
                 run_id = %input.run_id,
@@ -738,7 +721,7 @@ impl SessionWorkspaceCache {
                 "removed non-directory workspace image cache entry before promotion"
             );
         }
-        let metadata_path = self.session_workspace_cache_metadata(input.cache_key);
+        let metadata_path = self.workspace_image_cache_metadata(input.cache_key);
         match self
             .read_valid_metadata(
                 &metadata_path,
@@ -839,7 +822,7 @@ impl SessionWorkspaceCache {
             return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
         }
         ensure_workspace_cache_entry_dir(&cache_dir).await?;
-        let tmp = self.session_workspace_cache_tmp_image(input.cache_key, input.run_id);
+        let tmp = self.workspace_image_cache_tmp_image(input.cache_key, input.run_id);
         let _ = remove_workspace_cache_path_if_exists(&tmp).await;
         let rename_started = Instant::now();
         let (transfer_mode, transfer_duration) = match fs::rename(input.active_image, &tmp).await {
@@ -922,7 +905,7 @@ impl SessionWorkspaceCache {
             );
             return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
         }
-        let current = self.session_workspace_cache_current_image(input.cache_key);
+        let current = self.workspace_image_cache_current_image(input.cache_key);
         match fs::symlink_metadata(&current).await {
             Ok(metadata) if metadata.is_dir() => {
                 remove_workspace_cache_path_if_exists(&current).await?;
@@ -967,11 +950,9 @@ impl SessionWorkspaceCache {
         let allocated = allocated_bytes(&current_metadata);
         let metadata = WorkspaceCacheMetadata {
             format_version: CACHE_FORMAT_VERSION,
-            key_version: CACHE_KEY_VERSION,
             cache_scope: self.inner.cache_scope.clone(),
             profile_name: input.profile_name.to_owned(),
             reuse_key: input.reuse_key.to_owned(),
-            cli_agent_session_id: input.cli_agent_session_id.map(str::to_owned),
             working_dir: input.working_dir.to_owned(),
             last_completed_at: input.completed_at.to_owned(),
             last_used_at: local_timestamp(),
@@ -1076,7 +1057,7 @@ impl WorkspaceImageLease {
                 .invalidate_cache_entry(run_id, cache_key, reason)
                 .await;
         }
-        let current = self.cache.session_workspace_cache_current_image(cache_key);
+        let current = self.cache.workspace_image_cache_current_image(cache_key);
         self.cache
             .invalidate_current_image(run_id, cache_key, &current, reason)
             .await
@@ -1086,7 +1067,6 @@ impl WorkspaceImageLease {
     pub(crate) async fn promote(
         self,
         run_id: RunId,
-        cli_agent_session_id_override: Option<&str>,
         terminal_status: WorkspaceCacheTerminalStatus,
         completed_at: String,
         storage_fingerprints: &StorageFingerprints,
@@ -1094,7 +1074,6 @@ impl WorkspaceImageLease {
         let Some(promotion) = self.into_promotion_context(WorkspaceImagePromotionRequest {
             run_id,
             sandbox_id: sandbox::SandboxId::new_v4(),
-            cli_agent_session_id_override,
             restored_session_identity: None,
             terminal_status,
             completed_at,
@@ -1110,10 +1089,7 @@ impl WorkspaceImageLease {
         Ok(matches!(outcome, WorkspaceImagePromotionOutcome::Promoted))
     }
 
-    fn promotion_target(
-        &self,
-        cli_agent_session_id_override: Option<&str>,
-    ) -> Option<WorkspaceImagePromotionTarget> {
+    fn promotion_target(&self) -> Option<WorkspaceImagePromotionTarget> {
         if !self.workspace_drive_enabled || !is_safe_guest_working_dir(&self.working_dir) {
             return None;
         }
@@ -1123,10 +1099,6 @@ impl WorkspaceImageLease {
                 Some(WorkspaceImagePromotionTarget {
                     cache_key: self.cache_key.clone()?,
                     reuse_key: self.reuse_key.clone()?,
-                    cli_agent_session_id: self
-                        .cli_agent_session_id
-                        .clone()
-                        .or_else(|| cli_agent_session_id_override.map(str::to_owned)),
                 })
             }
             WorkspaceCacheCheckoutResult::NoReuseKey => None,
@@ -1144,13 +1116,12 @@ impl WorkspaceImageLease {
         let WorkspaceImagePromotionRequest {
             run_id,
             sandbox_id,
-            cli_agent_session_id_override,
             restored_session_identity,
             terminal_status,
             completed_at,
             storage_fingerprints,
         } = request;
-        let target = self.promotion_target(cli_agent_session_id_override)?;
+        let target = self.promotion_target()?;
         let storage_fingerprints = match terminal_status {
             WorkspaceCacheTerminalStatus::Success => storage_fingerprints,
             WorkspaceCacheTerminalStatus::NonzeroExit | WorkspaceCacheTerminalStatus::Cancelled => {
@@ -1166,7 +1137,6 @@ impl WorkspaceImageLease {
             sandbox_id,
             profile_name: self.profile_name.clone(),
             reuse_key: target.reuse_key,
-            cli_agent_session_id: target.cli_agent_session_id,
             working_dir: self.working_dir.clone(),
             active_image: self.active_image.clone(),
             image_size_bytes: self.image_size_bytes,
@@ -1232,7 +1202,7 @@ impl WorkspaceImagePromotionContext {
 
     pub(crate) fn validate_expected_identity(
         &self,
-        cache: &SessionWorkspaceCache,
+        cache: &WorkspaceImageCache,
         request: WorkspaceImagePromotionIdentityRequest<'_>,
     ) -> Result<(), WorkspaceImagePromotionIdentityMismatch> {
         let expected = cache.expected_promotion_identity(request)?;
@@ -1320,7 +1290,6 @@ impl WorkspaceImagePromotionContext {
                 cache_key: &self.cache_key,
                 profile_name: &self.profile_name,
                 reuse_key: &self.reuse_key,
-                cli_agent_session_id: self.cli_agent_session_id.as_deref(),
                 working_dir: &self.working_dir,
                 active_image: &self.active_image,
                 image_size_bytes: self.image_size_bytes,
@@ -1341,7 +1310,6 @@ impl WorkspaceImagePromotionContext {
             sandbox_id,
             profile_name,
             reuse_key,
-            cli_agent_session_id: _,
             consumed_cache_hit,
             ..
         } = self;
@@ -1363,7 +1331,7 @@ impl WorkspaceImagePromotionContext {
                 .invalidate_cache_entry(run_id, &cache_key, reason)
                 .await;
         }
-        let current = cache.session_workspace_cache_current_image(&cache_key);
+        let current = cache.workspace_image_cache_current_image(&cache_key);
         cache
             .invalidate_current_image(run_id, &cache_key, &current, reason)
             .await
@@ -1401,7 +1369,7 @@ impl WorkspaceImagePromotionContext {
                 .invalidate_cache_entry(run_id, &cache_key, reason)
                 .await;
         }
-        let current = cache.session_workspace_cache_current_image(&cache_key);
+        let current = cache.workspace_image_cache_current_image(&cache_key);
         cache
             .invalidate_current_image(run_id, &cache_key, &current, reason)
             .await
@@ -1440,7 +1408,6 @@ impl WorkspaceImagePromotionContext {
             sandbox_id: _,
             profile_name,
             reuse_key,
-            cli_agent_session_id,
             working_dir,
             active_image,
             image_size_bytes,
@@ -1454,7 +1421,6 @@ impl WorkspaceImagePromotionContext {
             cache,
             profile_name,
             reuse_key: Some(reuse_key),
-            cli_agent_session_id,
             working_dir,
             active_image,
             image_size_bytes,
@@ -1477,7 +1443,7 @@ impl WorkspaceImagePromotionContext {
 impl WorkspaceSessionHistorySidecarEntryGuard {
     pub(crate) fn session_history_sidecar_tmp_path(&self) -> PathBuf {
         self.cache
-            .session_workspace_cache_tmp_sidecar(&self.cache_key, self.run_id)
+            .workspace_image_cache_tmp_sidecar(&self.cache_key, self.run_id)
     }
 
     pub(crate) fn session_history_sidecar_source(

--- a/crates/runner/src/workspace_image_cache/metadata.rs
+++ b/crates/runner/src/workspace_image_cache/metadata.rs
@@ -13,9 +13,7 @@ use super::fs::{
     allocated_bytes, ensure_workspace_cache_entry_dir, remove_workspace_cache_path_if_exists,
 };
 use super::types::WorkspaceCacheTerminalStatus;
-use super::{
-    CACHE_FORMAT_VERSION, CACHE_KEY_VERSION, SessionWorkspaceCache, WORKSPACE_DRIVE_LAYOUT,
-};
+use super::{CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceImageCache};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -35,12 +33,9 @@ pub(super) enum WorkspaceTrust {
 #[serde(rename_all = "camelCase")]
 pub(super) struct WorkspaceCacheMetadata {
     pub(super) format_version: u32,
-    pub(super) key_version: u32,
     pub(super) cache_scope: String,
     pub(super) profile_name: String,
     pub(super) reuse_key: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(super) cli_agent_session_id: Option<String>,
     pub(super) working_dir: String,
     pub(super) last_completed_at: String,
     pub(super) last_used_at: String,
@@ -72,7 +67,7 @@ impl WorkspaceImageFileIdentity {
     }
 }
 
-impl SessionWorkspaceCache {
+impl WorkspaceImageCache {
     pub(super) async fn read_valid_metadata(
         &self,
         metadata_path: &Path,
@@ -88,7 +83,7 @@ impl SessionWorkspaceCache {
             }
             Err(e) => return Err(e),
         };
-        let current_path = self.session_workspace_cache_current_image(&self.scoped_cache_key(
+        let current_path = self.workspace_image_cache_current_image(&self.scoped_cache_key(
             profile_name,
             reuse_key,
             working_dir,
@@ -117,7 +112,7 @@ impl SessionWorkspaceCache {
         cache_key: &str,
         metadata: &WorkspaceCacheMetadata,
     ) -> bool {
-        let current_path = self.session_workspace_cache_current_image(cache_key);
+        let current_path = self.workspace_image_cache_current_image(cache_key);
         let Ok(current_metadata) = fs::symlink_metadata(current_path).await else {
             return false;
         };
@@ -144,7 +139,7 @@ impl SessionWorkspaceCache {
         run_id: RunId,
         metadata: WorkspaceCacheMetadata,
     ) -> RunnerResult<()> {
-        let metadata_path = self.session_workspace_cache_metadata(cache_key);
+        let metadata_path = self.workspace_image_cache_metadata(cache_key);
         let tmp = metadata_path.with_file_name(format!("metadata.json.tmp.{run_id}"));
         if let Some(parent) = metadata_path.parent() {
             ensure_workspace_cache_entry_dir(parent).await?;
@@ -198,12 +193,6 @@ fn validate_metadata(
         return Err(RunnerError::Internal(format!(
             "workspace metadata format version {} does not match {CACHE_FORMAT_VERSION}",
             metadata.format_version
-        )));
-    }
-    if metadata.key_version != CACHE_KEY_VERSION {
-        return Err(RunnerError::Internal(format!(
-            "workspace metadata key version {} does not match {CACHE_KEY_VERSION}",
-            metadata.key_version
         )));
     }
     if metadata.cache_scope != cache_scope {

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -69,8 +69,7 @@ pub(crate) use types::{
     WorkspaceSessionHistorySidecarRepresentation,
 };
 
-const CACHE_FORMAT_VERSION: u32 = 1;
-const CACHE_KEY_VERSION: u32 = 1;
+const CACHE_FORMAT_VERSION: u32 = 2;
 const WORKSPACE_DRIVE_LAYOUT: &str = "workspace-drive-v1";
 const GIB: u64 = 1024 * 1024 * 1024;
 const MIN_FREE_BYTES_FLOOR: u64 = 50 * GIB;
@@ -82,11 +81,11 @@ const TEST_FS_TOTAL_BYTES: u64 = 2_000 * GIB;
 const TEST_FS_AVAILABLE_BYTES: u64 = 1_000 * GIB;
 
 #[derive(Clone)]
-pub(crate) struct SessionWorkspaceCache {
-    inner: Arc<SessionWorkspaceCacheInner>,
+pub(crate) struct WorkspaceImageCache {
+    inner: Arc<WorkspaceImageCacheInner>,
 }
 
-struct SessionWorkspaceCacheInner {
+struct WorkspaceImageCacheInner {
     paths: RunnerPaths,
     cache_dir: PathBuf,
     lock_dir: PathBuf,
@@ -103,7 +102,7 @@ struct TemporaryPathStats {
     allocated_bytes: u64,
 }
 
-impl SessionWorkspaceCache {
+impl WorkspaceImageCache {
     #[cfg(test)]
     pub(crate) fn new(paths: RunnerPaths) -> Self {
         let cache_dir = paths.workspace_image_cache_dir();
@@ -150,7 +149,7 @@ impl SessionWorkspaceCache {
         #[cfg(not(test))]
         {
             Self {
-                inner: Arc::new(SessionWorkspaceCacheInner {
+                inner: Arc::new(WorkspaceImageCacheInner {
                     paths,
                     cache_dir,
                     lock_dir,
@@ -169,7 +168,7 @@ impl SessionWorkspaceCache {
         fs_stats: FsStats,
     ) -> Self {
         Self {
-            inner: Arc::new(SessionWorkspaceCacheInner {
+            inner: Arc::new(WorkspaceImageCacheInner {
                 paths,
                 cache_dir,
                 lock_dir,

--- a/crates/runner/src/workspace_image_cache/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/sidecar.rs
@@ -21,9 +21,8 @@ use super::types::{
     WorkspaceSessionHistorySidecarPromotionSource, WorkspaceSessionHistorySidecarPublication,
     WorkspaceSessionHistorySidecarRepresentation,
 };
-use super::{SessionWorkspaceCache, entry::CacheEntryPaths};
+use super::{WorkspaceImageCache, entry::CacheEntryPaths};
 
-const LEGACY_SESSION_HISTORY_SIDECAR_FORMAT_VERSION: u8 = 1;
 const SESSION_HISTORY_SIDECAR_FORMAT_VERSION: u8 = 2;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -37,7 +36,7 @@ impl WorkspaceSessionHistorySidecarBodySlot {
     const ALL: [Self; 2] = [Self::First, Self::Second];
 
     fn next(metadata: Option<&WorkspaceSessionHistorySidecarMetadata>) -> Self {
-        match metadata.and_then(|metadata| metadata.body_slot) {
+        match metadata.map(|metadata| metadata.body_slot) {
             Some(Self::First) => Self::Second,
             Some(Self::Second) | None => Self::First,
         }
@@ -51,14 +50,9 @@ impl WorkspaceSessionHistorySidecarBodySlot {
     }
 }
 
-fn session_history_sidecar_body_paths(paths: &CacheEntryPaths) -> [std::path::PathBuf; 3] {
-    let [first_body_path, second_body_path] = WorkspaceSessionHistorySidecarBodySlot::ALL
-        .map(|body_slot| paths.entry_dir().join(body_slot.file_name()));
-    [
-        paths.session_history_sidecar().to_path_buf(),
-        first_body_path,
-        second_body_path,
-    ]
+fn session_history_sidecar_body_paths(paths: &CacheEntryPaths) -> [std::path::PathBuf; 2] {
+    WorkspaceSessionHistorySidecarBodySlot::ALL
+        .map(|body_slot| paths.entry_dir().join(body_slot.file_name()))
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -73,8 +67,7 @@ struct WorkspaceSessionHistorySidecarMetadata {
     representation: WorkspaceSessionHistorySidecarRepresentation,
     encoded_size: u64,
     body_file: WorkspaceImageFileIdentity,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    body_slot: Option<WorkspaceSessionHistorySidecarBodySlot>,
+    body_slot: WorkspaceSessionHistorySidecarBodySlot,
 }
 
 impl WorkspaceSessionHistorySidecarMetadata {
@@ -100,32 +93,19 @@ impl WorkspaceSessionHistorySidecarMetadata {
             representation: source.representation,
             encoded_size: source.encoded_size,
             body_file: WorkspaceImageFileIdentity::from_metadata(body_metadata),
-            body_slot: Some(body_slot),
+            body_slot,
         })
     }
 
-    fn body_path(&self, paths: &CacheEntryPaths) -> Option<std::path::PathBuf> {
-        match (self.version, self.body_slot) {
-            (LEGACY_SESSION_HISTORY_SIDECAR_FORMAT_VERSION, None) => {
-                Some(paths.session_history_sidecar().to_path_buf())
-            }
-            (SESSION_HISTORY_SIDECAR_FORMAT_VERSION, Some(body_slot)) => {
-                Some(paths.entry_dir().join(body_slot.file_name()))
-            }
-            _ => None,
-        }
+    fn body_path(&self, paths: &CacheEntryPaths) -> std::path::PathBuf {
+        paths.entry_dir().join(self.body_slot.file_name())
     }
 
     fn validate_for_request(
         &self,
         expected: &RestoredSessionIdentity,
     ) -> Result<(), WorkspaceSessionHistorySidecarMiss> {
-        let supported_format = match self.version {
-            LEGACY_SESSION_HISTORY_SIDECAR_FORMAT_VERSION => self.body_slot.is_none(),
-            SESSION_HISTORY_SIDECAR_FORMAT_VERSION => self.body_slot.is_some(),
-            _ => false,
-        };
-        if !supported_format {
+        if self.version != SESSION_HISTORY_SIDECAR_FORMAT_VERSION {
             return Err(WorkspaceSessionHistorySidecarMiss::InvalidMetadata);
         }
         if self.encoded_size == 0 || self.encoded_size > RESUME_SESSION_HISTORY_MAX_BYTES {
@@ -170,7 +150,7 @@ impl WorkspaceSessionHistorySidecarMetadata {
     }
 }
 
-impl SessionWorkspaceCache {
+impl WorkspaceImageCache {
     pub(super) async fn probe_session_history_sidecar(
         &self,
         cache_key: &str,
@@ -181,9 +161,7 @@ impl SessionWorkspaceCache {
             .read_session_history_sidecar_metadata(paths.session_history_sidecar_metadata())
             .await?;
         metadata.validate_for_request(expected)?;
-        let body_path = metadata
-            .body_path(&paths)
-            .ok_or(WorkspaceSessionHistorySidecarMiss::InvalidMetadata)?;
+        let body_path = metadata.body_path(&paths);
         let body_metadata = fs::symlink_metadata(&body_path).await.map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
                 WorkspaceSessionHistorySidecarMiss::BodyMissing
@@ -275,8 +253,7 @@ impl SessionWorkspaceCache {
             return Ok(());
         };
         ensure_workspace_cache_entry_dir(paths.entry_dir()).await?;
-        let tmp_metadata_path =
-            self.session_workspace_cache_tmp_sidecar_metadata(cache_key, run_id);
+        let tmp_metadata_path = self.workspace_image_cache_tmp_sidecar_metadata(cache_key, run_id);
         let sidecar_metadata_path = paths.session_history_sidecar_metadata();
         let sidecar_body_path = paths.entry_dir().join(body_slot.file_name());
         let _ = remove_workspace_cache_path_if_exists(&tmp_metadata_path).await;
@@ -310,13 +287,10 @@ impl SessionWorkspaceCache {
         let paths = self.entry_paths(cache_key);
         let metadata_result =
             remove_workspace_cache_path_if_exists(paths.session_history_sidecar_metadata()).await;
-        let [legacy_body_path, first_body_path, second_body_path] =
-            session_history_sidecar_body_paths(&paths);
-        let legacy_body_result = remove_workspace_cache_path_if_exists(&legacy_body_path).await;
+        let [first_body_path, second_body_path] = session_history_sidecar_body_paths(&paths);
         let first_body_result = remove_workspace_cache_path_if_exists(&first_body_path).await;
         let second_body_result = remove_workspace_cache_path_if_exists(&second_body_path).await;
         metadata_result?;
-        legacy_body_result?;
         first_body_result?;
         second_body_result?;
         Ok(())

--- a/crates/runner/src/workspace_image_cache/tests/gc.rs
+++ b/crates/runner/src/workspace_image_cache/tests/gc.rs
@@ -6,16 +6,16 @@ use super::super::metadata::{
     WorkspaceCacheMetadata, WorkspaceCacheState, WorkspaceImageFileIdentity, WorkspaceTrust,
 };
 use super::super::{
-    CACHE_FORMAT_VERSION, CACHE_KEY_VERSION, CacheBudget, FsStats, SessionWorkspaceCache,
-    TEST_FS_AVAILABLE_BYTES, TEST_FS_TOTAL_BYTES, WORKSPACE_DRIVE_LAYOUT,
-    WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
+    CACHE_FORMAT_VERSION, CacheBudget, FsStats, TEST_FS_AVAILABLE_BYTES, TEST_FS_TOTAL_BYTES,
+    WORKSPACE_DRIVE_LAYOUT, WorkspaceCacheTerminalStatus, WorkspaceImageCache,
+    WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
 };
 use super::support::{
     TEST_PROFILE_NAME, local_cache, promote_current_cache_entry, timestamp_for_index,
     write_current_cache_entry,
 };
 use crate::ids::RunId;
-use crate::paths::{HomePaths, RunnerPaths, session_workspace_cache_key};
+use crate::paths::{HomePaths, RunnerPaths, workspace_image_cache_key};
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::MAX_HELD_WORKSPACE_STATES;
 
@@ -34,8 +34,8 @@ async fn global_gc_preserves_other_group_cache_entries_when_under_budget() {
     tokio::fs::create_dir_all(runner_b.base_dir())
         .await
         .unwrap();
-    let cache_a = SessionWorkspaceCache::shared(runner_a.clone(), &home, "group-a");
-    let cache_b = SessionWorkspaceCache::shared(runner_b, &home, "group-b");
+    let cache_a = WorkspaceImageCache::shared(runner_a.clone(), &home, "group-a");
+    let cache_b = WorkspaceImageCache::shared(runner_b, &home, "group-b");
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
 
@@ -46,7 +46,6 @@ async fn global_gc_preserves_other_group_cache_entries_when_under_budget() {
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: Some("sess-1"),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -62,7 +61,6 @@ async fn global_gc_preserves_other_group_cache_entries_when_under_budget() {
         lease
             .promote(
                 run_id,
-                None,
                 WorkspaceCacheTerminalStatus::Success,
                 "2026-05-01T00:00:00.000Z".into(),
                 &StorageFingerprints::default(),
@@ -89,8 +87,8 @@ async fn maintenance_gc_preserves_valid_group_scoped_entry() {
     tokio::fs::create_dir_all(maintenance_runner.base_dir())
         .await
         .unwrap();
-    let cache = SessionWorkspaceCache::shared(runner.clone(), &home, "group-a");
-    let maintenance_cache = SessionWorkspaceCache::shared(maintenance_runner, &home, "");
+    let cache = WorkspaceImageCache::shared(runner.clone(), &home, "group-a");
+    let maintenance_cache = WorkspaceImageCache::shared(maintenance_runner, &home, "");
     let key = promote_current_cache_entry(
         &cache,
         &runner,
@@ -99,13 +97,85 @@ async fn maintenance_gc_preserves_valid_group_scoped_entry() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let current = cache.session_workspace_cache_current_image(&key);
-    let metadata = cache.session_workspace_cache_metadata(&key);
+    let current = cache.workspace_image_cache_current_image(&key);
+    let metadata = cache.workspace_image_cache_metadata(&key);
 
     maintenance_cache.gc(false).await.unwrap();
 
     assert!(current.exists());
     assert!(metadata.exists());
+}
+
+#[tokio::test]
+async fn unknown_metadata_format_is_not_reused_or_advertised_and_is_reclaimed() {
+    let (_dir, paths, cache) = local_cache().await;
+    let checkout_reuse_key = "thread:unknown-format-checkout";
+    let checkout_key = write_current_cache_entry(
+        &cache,
+        RunId::new_v4(),
+        checkout_reuse_key,
+        "/workspace",
+        "2026-05-01T00:00:00.000Z",
+        "2026-05-01T00:00:00.000Z",
+    )
+    .await;
+    let checkout_metadata_path = paths.workspace_image_cache_metadata(&checkout_key);
+    let mut checkout_metadata = cache
+        .read_metadata_file(&checkout_metadata_path)
+        .await
+        .unwrap();
+    checkout_metadata.format_version = CACHE_FORMAT_VERSION + 1;
+    cache
+        .write_metadata(&checkout_key, RunId::new_v4(), checkout_metadata)
+        .await
+        .unwrap();
+
+    let gc_reuse_key = "thread:unknown-format-gc";
+    let gc_key = write_current_cache_entry(
+        &cache,
+        RunId::new_v4(),
+        gc_reuse_key,
+        "/workspace",
+        "2026-05-01T00:00:00.000Z",
+        "2026-05-01T00:00:00.000Z",
+    )
+    .await;
+    let gc_metadata_path = paths.workspace_image_cache_metadata(&gc_key);
+    let mut gc_metadata = cache.read_metadata_file(&gc_metadata_path).await.unwrap();
+    gc_metadata.format_version = CACHE_FORMAT_VERSION + 1;
+    cache
+        .write_metadata(&gc_key, RunId::new_v4(), gc_metadata)
+        .await
+        .unwrap();
+
+    assert!(cache.held_workspace_states().await.is_empty());
+    let checkout = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                reuse_key: Some(checkout_reuse_key),
+                working_dir: "/workspace",
+                image_size_bytes: format!("image-{checkout_reuse_key}").len() as u64,
+            },
+            workspace_drive_required: true,
+        })
+        .await;
+    assert_eq!(
+        checkout.result(),
+        super::super::WorkspaceCacheCheckoutResult::Miss
+    );
+    assert!(
+        !paths
+            .workspace_image_cache_entry_dir(&checkout_key)
+            .exists()
+    );
+
+    let freed = cache.gc(false).await.unwrap();
+
+    assert!(freed > 0);
+    assert!(!paths.workspace_image_cache_entry_dir(&gc_key).exists());
 }
 
 #[tokio::test]
@@ -123,8 +193,8 @@ async fn global_gc_candidates_include_other_group_cache_entries() {
     tokio::fs::create_dir_all(runner_b.base_dir())
         .await
         .unwrap();
-    let cache_a = SessionWorkspaceCache::shared(runner_a.clone(), &home, "group-a");
-    let cache_b = SessionWorkspaceCache::shared(runner_b.clone(), &home, "group-b");
+    let cache_a = WorkspaceImageCache::shared(runner_a.clone(), &home, "group-a");
+    let cache_b = WorkspaceImageCache::shared(runner_b.clone(), &home, "group-b");
 
     let group_a_key = promote_current_cache_entry(
         &cache_a,
@@ -186,14 +256,14 @@ async fn global_gc_evicts_old_entry_from_other_group_under_free_space_pressure()
     };
     let cache_dir = home.workspace_image_cache_dir();
     let lock_dir = home.locks_dir();
-    let cache_a = SessionWorkspaceCache::with_cache_dirs_and_fs_stats(
+    let cache_a = WorkspaceImageCache::with_cache_dirs_and_fs_stats(
         runner_a.clone(),
         cache_dir.clone(),
         lock_dir.clone(),
         "group-a",
         pressure_stats,
     );
-    let cache_b = SessionWorkspaceCache::with_cache_dirs_and_fs_stats(
+    let cache_b = WorkspaceImageCache::with_cache_dirs_and_fs_stats(
         runner_b.clone(),
         cache_dir,
         lock_dir,
@@ -225,13 +295,13 @@ async fn global_gc_evicts_old_entry_from_other_group_under_free_space_pressure()
     assert!(freed > 0);
     assert!(
         !cache_a
-            .session_workspace_cache_current_image(&old_key)
+            .workspace_image_cache_current_image(&old_key)
             .exists(),
         "oldest global candidate can be evicted even when it belongs to another group"
     );
     assert!(
         cache_b
-            .session_workspace_cache_current_image(&new_key)
+            .workspace_image_cache_current_image(&new_key)
             .exists(),
         "newer candidate from the current group should be retained once pressure is relieved"
     );
@@ -257,14 +327,14 @@ async fn global_gc_prunes_oldest_entries_above_limit_across_runner_groups() {
         total_bytes: TEST_FS_TOTAL_BYTES,
         available_bytes: TEST_FS_AVAILABLE_BYTES,
     };
-    let cache_a = SessionWorkspaceCache::with_cache_dirs_and_fs_stats(
+    let cache_a = WorkspaceImageCache::with_cache_dirs_and_fs_stats(
         runner_a.clone(),
         cache_dir.clone(),
         lock_dir.clone(),
         "group-a",
         fs_stats,
     );
-    let cache_b = SessionWorkspaceCache::with_cache_dirs_and_fs_stats(
+    let cache_b = WorkspaceImageCache::with_cache_dirs_and_fs_stats(
         runner_b.clone(),
         cache_dir,
         lock_dir,
@@ -283,12 +353,12 @@ async fn global_gc_prunes_oldest_entries_above_limit_across_runner_groups() {
     .await;
     let mut newest_key = String::new();
     for index in 1..=MAX_HELD_WORKSPACE_STATES {
-        let session_id = format!("sess-b-{index:04}");
+        let reuse_key = format!("sess-b-{index:04}");
         let timestamp = timestamp_for_index(index);
         let key = write_current_cache_entry(
             &cache_b,
             run_id,
-            &session_id,
+            &reuse_key,
             "/workspace",
             &timestamp,
             &timestamp,
@@ -304,13 +374,13 @@ async fn global_gc_prunes_oldest_entries_above_limit_across_runner_groups() {
     assert!(freed > 0);
     assert!(
         !cache_a
-            .session_workspace_cache_current_image(&oldest_key)
+            .workspace_image_cache_current_image(&oldest_key)
             .exists(),
         "oldest global candidate should be removed when the shared cache exceeds the entry cap"
     );
     assert!(
         cache_b
-            .session_workspace_cache_current_image(&newest_key)
+            .workspace_image_cache_current_image(&newest_key)
             .exists(),
         "newest candidate should be retained"
     );
@@ -382,10 +452,10 @@ fn gc_budget_satisfied_enforces_entry_cap_even_without_disk_pressure() {
 async fn gc_candidate_detects_replaced_image_with_same_timestamp() {
     let (_dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
-    let cache_key = session_workspace_cache_key("sess-1", "/workspace");
-    let entry_dir = paths.session_workspace_cache_entry_dir(&cache_key);
+    let cache_key = workspace_image_cache_key("sess-1", "/workspace");
+    let entry_dir = paths.workspace_image_cache_entry_dir(&cache_key);
     tokio::fs::create_dir_all(&entry_dir).await.unwrap();
-    let current = paths.session_workspace_cache_current_image(&cache_key);
+    let current = paths.workspace_image_cache_current_image(&cache_key);
     tokio::fs::write(&current, b"old image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -394,11 +464,9 @@ async fn gc_candidate_detects_replaced_image_with_same_timestamp() {
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
                 reuse_key: "sess-1".into(),
-                cli_agent_session_id: Some("sess-1".into()),
                 working_dir: "/workspace".into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
                 last_used_at: "2026-05-01T00:00:00.000Z".into(),
@@ -431,11 +499,11 @@ async fn gc_candidate_detects_replaced_image_with_same_timestamp() {
 #[tokio::test]
 async fn gc_candidate_includes_current_image_without_metadata() {
     let (_dir, paths, cache) = local_cache().await;
-    let cache_key = session_workspace_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.session_workspace_cache_entry_dir(&cache_key))
+    let cache_key = workspace_image_cache_key("sess-1", "/workspace");
+    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&cache_key))
         .await
         .unwrap();
-    let current = paths.session_workspace_cache_current_image(&cache_key);
+    let current = paths.workspace_image_cache_current_image(&cache_key);
     tokio::fs::write(&current, b"orphan image").await.unwrap();
 
     let candidate = cache.gc_candidate(cache_key.clone()).await.unwrap();
@@ -447,7 +515,7 @@ async fn gc_candidate_includes_current_image_without_metadata() {
 }
 
 #[tokio::test]
-async fn gc_counts_busy_entry_when_pruning_above_held_session_limit() {
+async fn gc_counts_busy_entry_when_pruning_above_held_workspace_limit() {
     let (_dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
 
@@ -455,12 +523,12 @@ async fn gc_counts_busy_entry_when_pruning_above_held_session_limit() {
     let mut second_oldest_key = String::new();
     let mut newest_key = String::new();
     for index in 0..=MAX_HELD_WORKSPACE_STATES {
-        let session_id = format!("sess-{index:04}");
+        let reuse_key = format!("sess-{index:04}");
         let timestamp = timestamp_for_index(index);
         let key = write_current_cache_entry(
             &cache,
             run_id,
-            &session_id,
+            &reuse_key,
             "/workspace",
             &timestamp,
             &timestamp,
@@ -486,19 +554,19 @@ async fn gc_counts_busy_entry_when_pruning_above_held_session_limit() {
     assert!(freed > 0);
     assert!(
         paths
-            .session_workspace_cache_current_image(&oldest_key)
+            .workspace_image_cache_current_image(&oldest_key)
             .exists(),
         "the oldest busy entry must remain protected by its entry lock"
     );
     assert!(
         !paths
-            .session_workspace_cache_entry_dir(&second_oldest_key)
+            .workspace_image_cache_entry_dir(&second_oldest_key)
             .exists(),
         "a valid busy entry must still count toward the cap and force eviction of the next eligible candidate"
     );
     assert!(
         paths
-            .session_workspace_cache_current_image(&newest_key)
+            .workspace_image_cache_current_image(&newest_key)
             .exists(),
         "newest cache entry should be retained"
     );
@@ -525,7 +593,7 @@ async fn gc_removes_stale_entry_without_current_image() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    tokio::fs::remove_file(paths.session_workspace_cache_current_image(&key))
+    tokio::fs::remove_file(paths.workspace_image_cache_current_image(&key))
         .await
         .unwrap();
 
@@ -533,7 +601,7 @@ async fn gc_removes_stale_entry_without_current_image() {
 
     assert!(freed > 0);
     assert!(
-        !paths.session_workspace_cache_entry_dir(&key).exists(),
+        !paths.workspace_image_cache_entry_dir(&key).exists(),
         "stale metadata-only entries should not accumulate and slow heartbeat scans"
     );
 }
@@ -541,12 +609,12 @@ async fn gc_removes_stale_entry_without_current_image() {
 #[tokio::test]
 async fn gc_removes_unusable_current_entry_without_metadata() {
     let (_dir, paths, cache) = local_cache().await;
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    let key = workspace_image_cache_key("sess-1", "/workspace");
+    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
     tokio::fs::write(
-        paths.session_workspace_cache_current_image(&key),
+        paths.workspace_image_cache_current_image(&key),
         b"orphan image",
     )
     .await
@@ -556,7 +624,7 @@ async fn gc_removes_unusable_current_entry_without_metadata() {
 
     assert!(freed > 0);
     assert!(
-        !paths.session_workspace_cache_entry_dir(&key).exists(),
+        !paths.workspace_image_cache_entry_dir(&key).exists(),
         "current images without metadata are not reusable and should not accumulate"
     );
 }
@@ -564,13 +632,13 @@ async fn gc_removes_unusable_current_entry_without_metadata() {
 #[tokio::test]
 async fn gc_removes_unusable_current_symlink_loop_without_aborting() {
     let (_dir, paths, cache) = local_cache().await;
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    let key = workspace_image_cache_key("sess-1", "/workspace");
+    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
     std::os::unix::fs::symlink(
         "current.ext4",
-        paths.session_workspace_cache_current_image(&key),
+        paths.workspace_image_cache_current_image(&key),
     )
     .unwrap();
 
@@ -578,7 +646,7 @@ async fn gc_removes_unusable_current_symlink_loop_without_aborting() {
 
     assert!(freed > 0);
     assert!(
-        !paths.session_workspace_cache_entry_dir(&key).exists(),
+        !paths.workspace_image_cache_entry_dir(&key).exists(),
         "symlink-loop current images are unusable and should not abort cache GC"
     );
 }
@@ -586,17 +654,17 @@ async fn gc_removes_unusable_current_symlink_loop_without_aborting() {
 #[tokio::test]
 async fn gc_removes_unusable_current_entry_with_unreadable_metadata_path() {
     let (_dir, paths, cache) = local_cache().await;
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    let key = workspace_image_cache_key("sess-1", "/workspace");
+    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
     tokio::fs::write(
-        paths.session_workspace_cache_current_image(&key),
+        paths.workspace_image_cache_current_image(&key),
         b"orphan image",
     )
     .await
     .unwrap();
-    tokio::fs::create_dir(paths.session_workspace_cache_metadata(&key))
+    tokio::fs::create_dir(paths.workspace_image_cache_metadata(&key))
         .await
         .unwrap();
 
@@ -604,7 +672,7 @@ async fn gc_removes_unusable_current_entry_with_unreadable_metadata_path() {
 
     assert!(freed > 0);
     assert!(
-        !paths.session_workspace_cache_entry_dir(&key).exists(),
+        !paths.workspace_image_cache_entry_dir(&key).exists(),
         "unreadable metadata paths make entries unusable and should not block cache GC"
     );
 }
@@ -612,10 +680,10 @@ async fn gc_removes_unusable_current_entry_with_unreadable_metadata_path() {
 #[tokio::test]
 async fn gc_dry_run_counts_temporary_only_entry_once() {
     let (_dir, paths, cache) = local_cache().await;
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    let entry_dir = paths.session_workspace_cache_entry_dir(&key);
+    let key = workspace_image_cache_key("sess-1", "/workspace");
+    let entry_dir = paths.workspace_image_cache_entry_dir(&key);
     tokio::fs::create_dir_all(&entry_dir).await.unwrap();
-    let tmp = paths.session_workspace_cache_tmp_image(&key, RunId::new_v4());
+    let tmp = paths.workspace_image_cache_tmp_image(&key, RunId::new_v4());
     tokio::fs::write(&tmp, vec![1_u8; 4096]).await.unwrap();
     let expected = workspace_cache_path_allocated_bytes(&entry_dir).await;
 
@@ -632,12 +700,12 @@ async fn gc_dry_run_counts_temporary_only_entry_once() {
 #[tokio::test]
 async fn gc_dry_run_counts_unusable_entry_with_temporary_path_once() {
     let (_dir, paths, cache) = local_cache().await;
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    let entry_dir = paths.session_workspace_cache_entry_dir(&key);
+    let key = workspace_image_cache_key("sess-1", "/workspace");
+    let entry_dir = paths.workspace_image_cache_entry_dir(&key);
     tokio::fs::create_dir_all(&entry_dir).await.unwrap();
-    let current = paths.session_workspace_cache_current_image(&key);
+    let current = paths.workspace_image_cache_current_image(&key);
     tokio::fs::write(&current, b"orphan image").await.unwrap();
-    let tmp = paths.session_workspace_cache_tmp_image(&key, RunId::new_v4());
+    let tmp = paths.workspace_image_cache_tmp_image(&key, RunId::new_v4());
     tokio::fs::write(&tmp, vec![1_u8; 4096]).await.unwrap();
     let expected = workspace_cache_path_allocated_bytes(&entry_dir).await;
 
@@ -657,7 +725,7 @@ async fn gc_dry_run_uses_pre_cleanup_freed_bytes_for_disk_pressure() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
     tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-    let setup_cache = SessionWorkspaceCache::new(paths.clone());
+    let setup_cache = WorkspaceImageCache::new(paths.clone());
     let run_id = RunId::new_v4();
     let key = write_current_cache_entry(
         &setup_cache,
@@ -668,7 +736,7 @@ async fn gc_dry_run_uses_pre_cleanup_freed_bytes_for_disk_pressure() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let tmp = paths.session_workspace_cache_tmp_image(&key, run_id);
+    let tmp = paths.workspace_image_cache_tmp_image(&key, run_id);
     tokio::fs::write(&tmp, vec![1_u8; 4096]).await.unwrap();
     let temporary_allocated = workspace_cache_path_allocated_bytes(&tmp).await;
     assert!(temporary_allocated > 0);
@@ -679,7 +747,7 @@ async fn gc_dry_run_uses_pre_cleanup_freed_bytes_for_disk_pressure() {
         available_bytes: fs_total,
     })
     .min_free_bytes;
-    let cache = SessionWorkspaceCache::new_with_fs_stats(
+    let cache = WorkspaceImageCache::new_with_fs_stats(
         paths.clone(),
         FsStats {
             total_bytes: fs_total,
@@ -695,7 +763,7 @@ async fn gc_dry_run_uses_pre_cleanup_freed_bytes_for_disk_pressure() {
     );
     assert!(tmp.exists());
     assert!(
-        paths.session_workspace_cache_current_image(&key).exists(),
+        paths.workspace_image_cache_current_image(&key).exists(),
         "dry-run must not preview deleting a valid entry when temporary cleanup would relieve disk pressure"
     );
 }
@@ -704,14 +772,14 @@ async fn gc_dry_run_uses_pre_cleanup_freed_bytes_for_disk_pressure() {
 async fn gc_removes_current_directory_even_when_metadata_matches() {
     let (dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
-    let session_id = "sess-1";
+    let reuse_key = "sess-1";
     let working_dir = "/workspace";
     let probe = dir.path().join("current-probe");
     tokio::fs::create_dir_all(&probe).await.unwrap();
     let image_size_bytes = fs::metadata(&probe).await.unwrap().len();
     tokio::fs::remove_dir_all(&probe).await.unwrap();
-    let key = cache.scoped_cache_key(TEST_PROFILE_NAME, session_id, working_dir, image_size_bytes);
-    let current = paths.session_workspace_cache_current_image(&key);
+    let key = cache.scoped_cache_key(TEST_PROFILE_NAME, reuse_key, working_dir, image_size_bytes);
+    let current = paths.workspace_image_cache_current_image(&key);
     tokio::fs::create_dir_all(&current).await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -720,11 +788,9 @@ async fn gc_removes_current_directory_even_when_metadata_matches() {
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: cache.inner.cache_scope.clone(),
                 profile_name: TEST_PROFILE_NAME.into(),
-                reuse_key: session_id.into(),
-                cli_agent_session_id: Some(session_id.into()),
+                reuse_key: reuse_key.into(),
                 working_dir: working_dir.into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
                 last_used_at: "2026-05-01T00:00:00.000Z".into(),
@@ -745,7 +811,7 @@ async fn gc_removes_current_directory_even_when_metadata_matches() {
 
     assert!(freed > 0);
     assert!(
-        !paths.session_workspace_cache_entry_dir(&key).exists(),
+        !paths.workspace_image_cache_entry_dir(&key).exists(),
         "current directories must not remain as reusable workspace cache entries"
     );
 }
@@ -754,11 +820,11 @@ async fn gc_removes_current_directory_even_when_metadata_matches() {
 async fn gc_counts_nested_current_directory_bytes() {
     let (_dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
-    let session_id = "sess-1";
+    let reuse_key = "sess-1";
     let working_dir = "/workspace";
     let image_size_bytes = 1024 * 1024;
-    let key = cache.scoped_cache_key(TEST_PROFILE_NAME, session_id, working_dir, image_size_bytes);
-    let current = paths.session_workspace_cache_current_image(&key);
+    let key = cache.scoped_cache_key(TEST_PROFILE_NAME, reuse_key, working_dir, image_size_bytes);
+    let current = paths.workspace_image_cache_current_image(&key);
     let nested = current.join("nested");
     tokio::fs::create_dir_all(&nested).await.unwrap();
     tokio::fs::write(
@@ -774,11 +840,9 @@ async fn gc_counts_nested_current_directory_bytes() {
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: cache.inner.cache_scope.clone(),
                 profile_name: TEST_PROFILE_NAME.into(),
-                reuse_key: session_id.into(),
-                cli_agent_session_id: Some(session_id.into()),
+                reuse_key: reuse_key.into(),
                 working_dir: working_dir.into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
                 last_used_at: "2026-05-01T00:00:00.000Z".into(),
@@ -801,18 +865,18 @@ async fn gc_counts_nested_current_directory_bytes() {
         freed >= image_size_bytes,
         "GC must report nested current directory bytes so callers refresh disk stats after cleanup"
     );
-    assert!(!paths.session_workspace_cache_entry_dir(&key).exists());
+    assert!(!paths.workspace_image_cache_entry_dir(&key).exists());
 }
 
 #[tokio::test]
 async fn gc_keeps_unusable_current_entry_when_entry_lock_is_held() {
     let (_dir, paths, cache) = local_cache().await;
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    let key = workspace_image_cache_key("sess-1", "/workspace");
+    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
     tokio::fs::write(
-        paths.session_workspace_cache_current_image(&key),
+        paths.workspace_image_cache_current_image(&key),
         b"orphan image",
     )
     .await
@@ -825,7 +889,7 @@ async fn gc_keeps_unusable_current_entry_when_entry_lock_is_held() {
 
     assert_eq!(freed, 0);
     assert!(
-        paths.session_workspace_cache_entry_dir(&key).exists(),
+        paths.workspace_image_cache_entry_dir(&key).exists(),
         "entry locks must protect in-progress promotions from GC removal"
     );
 }
@@ -843,7 +907,7 @@ async fn gc_keeps_stale_entry_without_current_image_when_entry_lock_is_held() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    tokio::fs::remove_file(paths.session_workspace_cache_current_image(&key))
+    tokio::fs::remove_file(paths.workspace_image_cache_current_image(&key))
         .await
         .unwrap();
     let _lock = crate::lock::acquire(cache.entry_lock_path(&key))
@@ -854,7 +918,7 @@ async fn gc_keeps_stale_entry_without_current_image_when_entry_lock_is_held() {
 
     assert_eq!(freed, 0);
     assert!(
-        paths.session_workspace_cache_entry_dir(&key).exists(),
+        paths.workspace_image_cache_entry_dir(&key).exists(),
         "entry locks must protect stale entries from GC removal"
     );
 }
@@ -863,13 +927,13 @@ async fn gc_keeps_stale_entry_without_current_image_when_entry_lock_is_held() {
 async fn gc_removes_orphan_temporary_workspace_cache_files() {
     let (_dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
-    let cache_key = session_workspace_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.session_workspace_cache_entry_dir(&cache_key))
+    let cache_key = workspace_image_cache_key("sess-1", "/workspace");
+    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&cache_key))
         .await
         .unwrap();
-    let tmp = paths.session_workspace_cache_tmp_image(&cache_key, run_id);
+    let tmp = paths.workspace_image_cache_tmp_image(&cache_key, run_id);
     let metadata_tmp = paths
-        .session_workspace_cache_metadata(&cache_key)
+        .workspace_image_cache_metadata(&cache_key)
         .with_file_name(format!("metadata.json.tmp.{run_id}"));
     tokio::fs::write(&tmp, b"partial image").await.unwrap();
     tokio::fs::write(&metadata_tmp, b"partial metadata")
@@ -896,9 +960,9 @@ async fn gc_removes_orphan_temporary_workspace_cache_directories() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let tmp = paths.session_workspace_cache_tmp_image(&cache_key, run_id);
+    let tmp = paths.workspace_image_cache_tmp_image(&cache_key, run_id);
     let metadata_tmp = paths
-        .session_workspace_cache_metadata(&cache_key)
+        .workspace_image_cache_metadata(&cache_key)
         .with_file_name(format!("metadata.json.tmp.{run_id}"));
     tokio::fs::create_dir_all(&tmp).await.unwrap();
     tokio::fs::write(tmp.join("partial-image"), b"partial image")
@@ -916,7 +980,7 @@ async fn gc_removes_orphan_temporary_workspace_cache_directories() {
     assert!(!metadata_tmp.exists());
     assert!(
         paths
-            .session_workspace_cache_current_image(&cache_key)
+            .workspace_image_cache_current_image(&cache_key)
             .exists()
     );
 }
@@ -934,7 +998,7 @@ async fn gc_counts_nested_temporary_workspace_cache_directories() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let tmp = paths.session_workspace_cache_tmp_image(&cache_key, run_id);
+    let tmp = paths.workspace_image_cache_tmp_image(&cache_key, run_id);
     let nested = tmp.join("nested");
     tokio::fs::create_dir_all(&nested).await.unwrap();
     tokio::fs::write(nested.join("partial-image"), vec![1_u8; 4096])
@@ -950,7 +1014,7 @@ async fn gc_counts_nested_temporary_workspace_cache_directories() {
     assert!(!tmp.exists());
     assert!(
         paths
-            .session_workspace_cache_current_image(&cache_key)
+            .workspace_image_cache_current_image(&cache_key)
             .exists()
     );
 }
@@ -959,13 +1023,13 @@ async fn gc_counts_nested_temporary_workspace_cache_directories() {
 async fn gc_keeps_temporary_workspace_cache_files_when_entry_lock_is_held() {
     let (_dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
-    let cache_key = session_workspace_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.session_workspace_cache_entry_dir(&cache_key))
+    let cache_key = workspace_image_cache_key("sess-1", "/workspace");
+    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&cache_key))
         .await
         .unwrap();
-    let tmp = paths.session_workspace_cache_tmp_image(&cache_key, run_id);
+    let tmp = paths.workspace_image_cache_tmp_image(&cache_key, run_id);
     let metadata_tmp = paths
-        .session_workspace_cache_metadata(&cache_key)
+        .workspace_image_cache_metadata(&cache_key)
         .with_file_name(format!("metadata.json.tmp.{run_id}"));
     tokio::fs::write(&tmp, b"partial image").await.unwrap();
     tokio::fs::write(&metadata_tmp, b"partial metadata")

--- a/crates/runner/src/workspace_image_cache/tests/inspection.rs
+++ b/crates/runner/src/workspace_image_cache/tests/inspection.rs
@@ -7,20 +7,19 @@ use super::super::metadata::{
     WorkspaceCacheMetadata, WorkspaceCacheState, WorkspaceImageFileIdentity, WorkspaceTrust,
 };
 use super::super::{
-    CACHE_FORMAT_VERSION, CACHE_KEY_VERSION, CacheBudget, SessionWorkspaceCache,
-    TEST_FS_TOTAL_BYTES, WORKSPACE_DRIVE_LAYOUT, WorkspaceCacheTerminalStatus,
-    WorkspaceImageCacheInspectionStatus,
+    CACHE_FORMAT_VERSION, CacheBudget, TEST_FS_TOTAL_BYTES, WORKSPACE_DRIVE_LAYOUT,
+    WorkspaceCacheTerminalStatus, WorkspaceImageCache, WorkspaceImageCacheInspectionStatus,
 };
 use super::support::{TEST_PROFILE_NAME, local_cache, write_current_cache_entry};
 use crate::ids::RunId;
-use crate::paths::{RunnerPaths, session_workspace_cache_key};
+use crate::paths::{RunnerPaths, workspace_image_cache_key};
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 
 #[tokio::test]
 async fn inspect_missing_cache_dir_returns_empty_summary() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(paths);
+    let cache = WorkspaceImageCache::new(paths);
 
     let inspection = cache.inspect().await.unwrap();
 
@@ -40,10 +39,10 @@ async fn inspect_reports_reusable_entry_with_storage_counts() {
     let (_dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let key = cache.scoped_cache_key(TEST_PROFILE_NAME, "sess-1", "/workspace", 5);
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
-    let current = paths.session_workspace_cache_current_image(&key);
+    let current = paths.workspace_image_cache_current_image(&key);
     fs::write(&current, b"image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -52,11 +51,9 @@ async fn inspect_reports_reusable_entry_with_storage_counts() {
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
                 reuse_key: "sess-1".into(),
-                cli_agent_session_id: Some("sess-1".into()),
                 working_dir: "/workspace".into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
                 last_used_at: "2026-05-01T00:01:00.000Z".into(),
@@ -104,10 +101,10 @@ async fn inspect_reports_invalid_metadata_reason() {
     let (_dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let key = cache.scoped_cache_key(TEST_PROFILE_NAME, "sess-1", "/workspace", 5);
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
-    let current = paths.session_workspace_cache_current_image(&key);
+    let current = paths.workspace_image_cache_current_image(&key);
     fs::write(&current, b"image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -116,11 +113,9 @@ async fn inspect_reports_invalid_metadata_reason() {
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
                 reuse_key: "other-session".into(),
-                cli_agent_session_id: Some("other-session".into()),
                 working_dir: "/workspace".into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
                 last_used_at: "2026-05-01T00:01:00.000Z".into(),
@@ -156,12 +151,12 @@ async fn inspect_rejects_symlink_current_image() {
         "/workspace",
         image.len() as u64,
     );
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
     let target = dir.path().join("target.ext4");
     fs::write(&target, image).await.unwrap();
-    let current = paths.session_workspace_cache_current_image(&key);
+    let current = paths.workspace_image_cache_current_image(&key);
     std::os::unix::fs::symlink(&target, &current).unwrap();
     let current_target_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -170,11 +165,9 @@ async fn inspect_rejects_symlink_current_image() {
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
                 reuse_key: "sess-1".into(),
-                cli_agent_session_id: Some("sess-1".into()),
                 working_dir: "/workspace".into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
                 last_used_at: "2026-05-01T00:01:00.000Z".into(),
@@ -203,14 +196,14 @@ async fn inspect_rejects_symlink_current_image() {
 async fn inspect_reports_current_directory_as_invalid() {
     let (dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
-    let session_id = "sess-1";
+    let reuse_key = "sess-1";
     let working_dir = "/workspace";
     let probe = dir.path().join("current-probe");
     tokio::fs::create_dir_all(&probe).await.unwrap();
     let image_size_bytes = fs::metadata(&probe).await.unwrap().len();
     tokio::fs::remove_dir_all(&probe).await.unwrap();
-    let key = cache.scoped_cache_key(TEST_PROFILE_NAME, session_id, working_dir, image_size_bytes);
-    let current = paths.session_workspace_cache_current_image(&key);
+    let key = cache.scoped_cache_key(TEST_PROFILE_NAME, reuse_key, working_dir, image_size_bytes);
+    let current = paths.workspace_image_cache_current_image(&key);
     fs::create_dir_all(&current).await.unwrap();
     fs::write(current.join("nested"), vec![1_u8; 4096])
         .await
@@ -222,11 +215,9 @@ async fn inspect_reports_current_directory_as_invalid() {
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
-                reuse_key: session_id.into(),
-                cli_agent_session_id: Some(session_id.into()),
+                reuse_key: reuse_key.into(),
                 working_dir: working_dir.into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
                 last_used_at: "2026-05-01T00:01:00.000Z".into(),
@@ -267,7 +258,7 @@ async fn inspect_reports_stale_entry_without_current_image() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    fs::remove_file(paths.session_workspace_cache_current_image(&key))
+    fs::remove_file(paths.workspace_image_cache_current_image(&key))
         .await
         .unwrap();
 
@@ -283,8 +274,8 @@ async fn inspect_reports_stale_entry_without_current_image() {
 #[tokio::test]
 async fn inspect_reports_temporary_only_entry() {
     let (_dir, paths, cache) = local_cache().await;
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    let tmp = paths.session_workspace_cache_tmp_image(&key, RunId::new_v4());
+    let key = workspace_image_cache_key("sess-1", "/workspace");
+    let tmp = paths.workspace_image_cache_tmp_image(&key, RunId::new_v4());
     fs::create_dir_all(tmp.parent().unwrap()).await.unwrap();
     fs::write(&tmp, b"partial image").await.unwrap();
     let tmp_metadata = fs::metadata(&tmp).await.unwrap();
@@ -308,8 +299,8 @@ async fn inspect_reports_temporary_only_entry() {
 #[tokio::test]
 async fn inspect_reports_temporary_only_directory() {
     let (_dir, paths, cache) = local_cache().await;
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    let tmp = paths.session_workspace_cache_tmp_image(&key, RunId::new_v4());
+    let key = workspace_image_cache_key("sess-1", "/workspace");
+    let tmp = paths.workspace_image_cache_tmp_image(&key, RunId::new_v4());
     fs::create_dir_all(&tmp).await.unwrap();
     fs::write(tmp.join("partial-image"), vec![1_u8; 4096])
         .await
@@ -336,12 +327,12 @@ async fn inspect_reports_temporary_only_directory() {
 #[tokio::test]
 async fn inspect_reports_locked_entry_without_blocking() {
     let (_dir, paths, cache) = local_cache().await;
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    let key = workspace_image_cache_key("sess-1", "/workspace");
+    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
     fs::write(
-        paths.session_workspace_cache_tmp_image(&key, RunId::new_v4()),
+        paths.workspace_image_cache_tmp_image(&key, RunId::new_v4()),
         b"partial image",
     )
     .await
@@ -364,9 +355,9 @@ async fn inspect_reports_locked_entry_without_blocking() {
 async fn inspect_propagates_lock_path_errors() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(paths.clone());
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    let cache = WorkspaceImageCache::new(paths.clone());
+    let key = workspace_image_cache_key("sess-1", "/workspace");
+    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
     fs::write(paths.base_dir().join("locks"), b"not a directory")
@@ -385,9 +376,9 @@ async fn inspect_propagates_lock_path_errors() {
 async fn inspect_entry_skips_directory_removed_after_scan() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(paths.clone());
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    let entry_dir = paths.session_workspace_cache_entry_dir(&key);
+    let cache = WorkspaceImageCache::new(paths.clone());
+    let key = workspace_image_cache_key("sess-1", "/workspace");
+    let entry_dir = paths.workspace_image_cache_entry_dir(&key);
     fs::create_dir_all(&entry_dir).await.unwrap();
     fs::remove_dir_all(&entry_dir).await.unwrap();
 
@@ -400,9 +391,9 @@ async fn inspect_entry_skips_directory_removed_after_scan() {
 async fn inspect_entry_skips_symlink_replacement_after_scan() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(paths.clone());
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    let entry_dir = paths.session_workspace_cache_entry_dir(&key);
+    let cache = WorkspaceImageCache::new(paths.clone());
+    let key = workspace_image_cache_key("sess-1", "/workspace");
+    let entry_dir = paths.workspace_image_cache_entry_dir(&key);
     fs::create_dir_all(entry_dir.parent().unwrap())
         .await
         .unwrap();
@@ -419,15 +410,15 @@ async fn inspect_entry_skips_symlink_replacement_after_scan() {
 async fn inspect_reports_non_file_metadata_as_invalid_entry() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(paths.clone());
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    let cache = WorkspaceImageCache::new(paths.clone());
+    let key = workspace_image_cache_key("sess-1", "/workspace");
+    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
-    fs::write(paths.session_workspace_cache_current_image(&key), b"image")
+    fs::write(paths.workspace_image_cache_current_image(&key), b"image")
         .await
         .unwrap();
-    fs::create_dir(paths.session_workspace_cache_metadata(&key))
+    fs::create_dir(paths.workspace_image_cache_metadata(&key))
         .await
         .unwrap();
 
@@ -443,7 +434,7 @@ async fn inspect_reports_non_file_metadata_as_invalid_entry() {
 async fn inspect_rejects_metadata_symlink_without_following_it() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(paths.clone());
+    let cache = WorkspaceImageCache::new(paths.clone());
     let key = write_current_cache_entry(
         &cache,
         RunId::new_v4(),
@@ -453,7 +444,7 @@ async fn inspect_rejects_metadata_symlink_without_following_it() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let metadata_path = paths.session_workspace_cache_metadata(&key);
+    let metadata_path = paths.workspace_image_cache_metadata(&key);
     let outside = dir.path().join("outside-metadata.json");
     fs::rename(&metadata_path, &outside).await.unwrap();
     std::os::unix::fs::symlink(&outside, &metadata_path).unwrap();
@@ -470,16 +461,16 @@ async fn inspect_rejects_metadata_symlink_without_following_it() {
 async fn inspect_rejects_oversized_metadata() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(paths.clone());
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    let cache = WorkspaceImageCache::new(paths.clone());
+    let key = workspace_image_cache_key("sess-1", "/workspace");
+    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
-    fs::write(paths.session_workspace_cache_current_image(&key), b"image")
+    fs::write(paths.workspace_image_cache_current_image(&key), b"image")
         .await
         .unwrap();
     fs::write(
-        paths.session_workspace_cache_metadata(&key),
+        paths.workspace_image_cache_metadata(&key),
         vec![b' '; crate::state_file::WORKSPACE_METADATA_MAX_BYTES as usize + 1],
     )
     .await

--- a/crates/runner/src/workspace_image_cache/tests/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/tests/lifecycle.rs
@@ -5,18 +5,17 @@ use super::super::metadata::{
     WorkspaceCacheMetadata, WorkspaceCacheState, WorkspaceImageFileIdentity, WorkspaceTrust,
 };
 use super::super::{
-    CACHE_FORMAT_VERSION, CACHE_KEY_VERSION, CacheBudget, FsStats, SessionWorkspaceCache,
-    TEST_FS_TOTAL_BYTES, WORKSPACE_DRIVE_LAYOUT, WorkspaceCacheCheckoutResult,
-    WorkspaceCacheTerminalStatus, WorkspaceImageActiveLeaseRequest, WorkspaceImageLeaseIdentity,
-    WorkspaceImagePrepareRequest,
+    CACHE_FORMAT_VERSION, CacheBudget, FsStats, TEST_FS_TOTAL_BYTES, WORKSPACE_DRIVE_LAYOUT,
+    WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus, WorkspaceImageActiveLeaseRequest,
+    WorkspaceImageCache, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
 };
 use super::support::{TEST_PROFILE_NAME, local_cache, write_current_cache_entry};
 use crate::ids::RunId;
-use crate::paths::{HomePaths, RunnerPaths, session_workspace_cache_key};
+use crate::paths::{HomePaths, RunnerPaths, workspace_image_cache_key};
 use crate::storage_fingerprints::StorageFingerprints;
 
 #[tokio::test]
-async fn thread_cache_is_reusable_across_cli_session_rotation() {
+async fn thread_cache_is_reusable_across_runs() {
     let (_dir, paths, cache) = local_cache().await;
     let reuse_key = "thread:chat-thread";
     let first_run_id = RunId::new_v4();
@@ -28,7 +27,6 @@ async fn thread_cache_is_reusable_across_cli_session_rotation() {
                 sandbox_id: first_sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some(reuse_key),
-                cli_agent_session_id: Some("provider-session-a"),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -45,7 +43,6 @@ async fn thread_cache_is_reusable_across_cli_session_rotation() {
         first
             .promote(
                 first_run_id,
-                None,
                 WorkspaceCacheTerminalStatus::Success,
                 "2026-05-01T00:00:00.000Z".into(),
                 &StorageFingerprints::default(),
@@ -61,7 +58,6 @@ async fn thread_cache_is_reusable_across_cli_session_rotation() {
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some(reuse_key),
-                cli_agent_session_id: Some("provider-session-b"),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -87,8 +83,8 @@ async fn shared_cache_is_reusable_across_runner_base_dirs() {
     tokio::fs::create_dir_all(runner_b.base_dir())
         .await
         .unwrap();
-    let cache_a = SessionWorkspaceCache::shared(runner_a.clone(), &home, "test-group");
-    let cache_b = SessionWorkspaceCache::shared(runner_b.clone(), &home, "test-group");
+    let cache_a = WorkspaceImageCache::shared(runner_a.clone(), &home, "test-group");
+    let cache_b = WorkspaceImageCache::shared(runner_b.clone(), &home, "test-group");
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
 
@@ -99,7 +95,6 @@ async fn shared_cache_is_reusable_across_runner_base_dirs() {
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: Some("sess-1"),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -116,7 +111,6 @@ async fn shared_cache_is_reusable_across_runner_base_dirs() {
         lease
             .promote(
                 run_id,
-                None,
                 WorkspaceCacheTerminalStatus::Success,
                 "2026-05-01T00:00:00.000Z".into(),
                 &StorageFingerprints::default(),
@@ -132,7 +126,6 @@ async fn shared_cache_is_reusable_across_runner_base_dirs() {
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: Some("sess-1"),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -177,7 +170,7 @@ async fn cache_hit_removes_metadata_and_returns_move_seed() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let current = paths.session_workspace_cache_current_image(&key);
+    let current = paths.workspace_image_cache_current_image(&key);
     let image_size = fs::metadata(&current).await.unwrap().len();
 
     let lease = cache
@@ -187,7 +180,6 @@ async fn cache_hit_removes_metadata_and_returns_move_seed() {
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-move-hit"),
-                cli_agent_session_id: Some("sess-move-hit"),
                 working_dir: "/workspace",
                 image_size_bytes: image_size,
             },
@@ -205,7 +197,7 @@ async fn cache_hit_removes_metadata_and_returns_move_seed() {
     );
     assert!(current.exists());
     assert!(matches!(
-        fs::metadata(paths.session_workspace_cache_metadata(&key)).await,
+        fs::metadata(paths.workspace_image_cache_metadata(&key)).await,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound
     ));
 }
@@ -223,7 +215,7 @@ async fn consumed_cache_hit_invalidation_tolerates_missing_current() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let current = paths.session_workspace_cache_current_image(&key);
+    let current = paths.workspace_image_cache_current_image(&key);
     let image_size = fs::metadata(&current).await.unwrap().len();
 
     let lease = cache
@@ -233,7 +225,6 @@ async fn consumed_cache_hit_invalidation_tolerates_missing_current() {
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-move-invalidate"),
-                cli_agent_session_id: Some("sess-move-invalidate"),
                 working_dir: "/workspace",
                 image_size_bytes: image_size,
             },
@@ -249,7 +240,7 @@ async fn consumed_cache_hit_invalidation_tolerates_missing_current() {
             .await
             .unwrap()
     );
-    assert!(!paths.session_workspace_cache_entry_dir(&key).exists());
+    assert!(!paths.workspace_image_cache_entry_dir(&key).exists());
 }
 
 #[tokio::test]
@@ -267,8 +258,8 @@ async fn shared_cache_same_key_lock_blocks_other_runner_without_deadlock() {
     tokio::fs::create_dir_all(runner_b.base_dir())
         .await
         .unwrap();
-    let cache_a = SessionWorkspaceCache::shared(runner_a, &home, "test-group");
-    let cache_b = SessionWorkspaceCache::shared(runner_b, &home, "test-group");
+    let cache_a = WorkspaceImageCache::shared(runner_a, &home, "test-group");
+    let cache_b = WorkspaceImageCache::shared(runner_b, &home, "test-group");
 
     let lease_a = cache_a
         .prepare(WorkspaceImagePrepareRequest {
@@ -277,7 +268,6 @@ async fn shared_cache_same_key_lock_blocks_other_runner_without_deadlock() {
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: Some("sess-1"),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -293,7 +283,6 @@ async fn shared_cache_same_key_lock_blocks_other_runner_without_deadlock() {
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: Some("sess-1"),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -320,7 +309,6 @@ async fn shared_cache_same_key_lock_blocks_other_runner_without_deadlock() {
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: Some("sess-1"),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -349,8 +337,8 @@ async fn shared_cache_is_scoped_by_runner_group() {
     tokio::fs::create_dir_all(runner_b.base_dir())
         .await
         .unwrap();
-    let cache_a = SessionWorkspaceCache::shared(runner_a.clone(), &home, "group-a");
-    let cache_b = SessionWorkspaceCache::shared(runner_b.clone(), &home, "group-b");
+    let cache_a = WorkspaceImageCache::shared(runner_a.clone(), &home, "group-a");
+    let cache_b = WorkspaceImageCache::shared(runner_b.clone(), &home, "group-b");
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
 
@@ -361,7 +349,6 @@ async fn shared_cache_is_scoped_by_runner_group() {
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: Some("sess-1"),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -378,7 +365,6 @@ async fn shared_cache_is_scoped_by_runner_group() {
         lease
             .promote(
                 run_id,
-                None,
                 WorkspaceCacheTerminalStatus::Success,
                 "2026-05-01T00:00:00.000Z".into(),
                 &StorageFingerprints::default(),
@@ -394,7 +380,6 @@ async fn shared_cache_is_scoped_by_runner_group() {
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: Some("sess-1"),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -415,7 +400,7 @@ async fn cache_hit_checkout_and_same_filesystem_promotion_do_not_require_copy_he
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
     tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-    let setup_cache = SessionWorkspaceCache::new(paths.clone());
+    let setup_cache = WorkspaceImageCache::new(paths.clone());
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let image = vec![1_u8; 4096];
@@ -425,10 +410,10 @@ async fn cache_hit_checkout_and_same_filesystem_promotion_do_not_require_copy_he
         "/workspace",
         image.len() as u64,
     );
-    tokio::fs::create_dir_all(paths.session_workspace_cache_entry_dir(&cache_key))
+    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&cache_key))
         .await
         .unwrap();
-    let current = paths.session_workspace_cache_current_image(&cache_key);
+    let current = paths.workspace_image_cache_current_image(&cache_key);
     tokio::fs::write(&current, &image).await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     let actual_allocated_bytes = allocated_bytes(&current_metadata);
@@ -442,11 +427,9 @@ async fn cache_hit_checkout_and_same_filesystem_promotion_do_not_require_copy_he
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
                 reuse_key: "sess-1".into(),
-                cli_agent_session_id: Some("sess-1".into()),
                 working_dir: "/workspace".into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
                 last_used_at: "2026-05-01T00:00:00.000Z".into(),
@@ -467,7 +450,7 @@ async fn cache_hit_checkout_and_same_filesystem_promotion_do_not_require_copy_he
         available_bytes: TEST_FS_TOTAL_BYTES,
     })
     .min_free_bytes;
-    let cache = SessionWorkspaceCache::new_with_fs_stats(
+    let cache = WorkspaceImageCache::new_with_fs_stats(
         paths.clone(),
         FsStats {
             total_bytes: TEST_FS_TOTAL_BYTES,
@@ -482,7 +465,6 @@ async fn cache_hit_checkout_and_same_filesystem_promotion_do_not_require_copy_he
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: Some("sess-1"),
                 working_dir: "/workspace",
                 image_size_bytes: current_metadata.len(),
             },
@@ -502,7 +484,7 @@ async fn cache_hit_checkout_and_same_filesystem_promotion_do_not_require_copy_he
         "move checkout keeps the source in place until sandbox preparation consumes it"
     );
     assert!(
-        !tokio::fs::try_exists(paths.session_workspace_cache_metadata(&cache_key))
+        !tokio::fs::try_exists(paths.workspace_image_cache_metadata(&cache_key))
             .await
             .unwrap(),
         "move checkout removes metadata before handing the current image to sandbox preparation"
@@ -517,7 +499,6 @@ async fn cache_hit_checkout_and_same_filesystem_promotion_do_not_require_copy_he
         lease
             .promote(
                 run_id,
-                None,
                 WorkspaceCacheTerminalStatus::Success,
                 "2026-05-02T00:00:00.000Z".into(),
                 &StorageFingerprints::default(),
@@ -537,14 +518,14 @@ async fn cache_hit_checkout_and_same_filesystem_promotion_do_not_require_copy_he
 }
 
 #[tokio::test]
-async fn active_lease_hides_cached_session_until_dropped() {
+async fn active_lease_hides_cached_reuse_key_until_dropped() {
     let (_dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
-    let cache_key = session_workspace_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.session_workspace_cache_entry_dir(&cache_key))
+    let cache_key = workspace_image_cache_key("sess-1", "/workspace");
+    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&cache_key))
         .await
         .unwrap();
-    let current = paths.session_workspace_cache_current_image(&cache_key);
+    let current = paths.workspace_image_cache_current_image(&cache_key);
     tokio::fs::write(&current, b"image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -553,11 +534,9 @@ async fn active_lease_hides_cached_session_until_dropped() {
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
                 reuse_key: "sess-1".into(),
-                cli_agent_session_id: Some("sess-1".into()),
                 working_dir: "/workspace".into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
                 last_used_at: local_timestamp(),
@@ -583,7 +562,6 @@ async fn active_lease_hides_cached_session_until_dropped() {
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: Some("sess-1"),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },

--- a/crates/runner/src/workspace_image_cache/tests/metadata.rs
+++ b/crates/runner/src/workspace_image_cache/tests/metadata.rs
@@ -5,8 +5,8 @@ use super::super::metadata::{
     WorkspaceCacheMetadata, WorkspaceCacheState, WorkspaceImageFileIdentity, WorkspaceTrust,
 };
 use super::super::{
-    CACHE_FORMAT_VERSION, CACHE_KEY_VERSION, SessionWorkspaceCache, WORKSPACE_DRIVE_LAYOUT,
-    WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity,
+    CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceCacheCheckoutResult,
+    WorkspaceCacheTerminalStatus, WorkspaceImageCache, WorkspaceImageLeaseIdentity,
     WorkspaceImagePrepareRequest,
 };
 use super::support::{TEST_PROFILE_NAME, local_cache};
@@ -19,8 +19,8 @@ async fn prepare_removes_symlink_cache_entry_without_following_it() {
     let (dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
-    let session_id = "sess-entry-symlink";
-    let key = cache.scoped_cache_key(TEST_PROFILE_NAME, session_id, "/workspace", 5);
+    let reuse_key = "sess-entry-symlink";
+    let key = cache.scoped_cache_key(TEST_PROFILE_NAME, reuse_key, "/workspace", 5);
     let outside_entry = dir.path().join("outside-cache-entry");
     fs::create_dir_all(&outside_entry).await.unwrap();
     let outside_current = outside_entry.join("current.ext4");
@@ -28,11 +28,9 @@ async fn prepare_removes_symlink_cache_entry_without_following_it() {
     let current_metadata = fs::metadata(&outside_current).await.unwrap();
     let metadata = WorkspaceCacheMetadata {
         format_version: CACHE_FORMAT_VERSION,
-        key_version: CACHE_KEY_VERSION,
         cache_scope: cache.inner.cache_scope.clone(),
         profile_name: TEST_PROFILE_NAME.into(),
-        reuse_key: session_id.into(),
-        cli_agent_session_id: Some(session_id.into()),
+        reuse_key: reuse_key.into(),
         working_dir: "/workspace".into(),
         last_completed_at: "2026-05-01T00:00:00.000Z".into(),
         last_used_at: "2026-05-01T00:00:00.000Z".into(),
@@ -51,7 +49,7 @@ async fn prepare_removes_symlink_cache_entry_without_following_it() {
     )
     .await
     .unwrap();
-    let entry_dir = paths.session_workspace_cache_entry_dir(&key);
+    let entry_dir = paths.workspace_image_cache_entry_dir(&key);
     fs::create_dir_all(entry_dir.parent().unwrap())
         .await
         .unwrap();
@@ -63,8 +61,7 @@ async fn prepare_removes_symlink_cache_entry_without_following_it() {
                 run_id,
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -91,10 +88,10 @@ async fn prepare_removes_symlink_cache_entry_without_following_it() {
 async fn metadata_missing_current_present_is_not_a_cache_hit() {
     let (_dir, paths, cache) = local_cache().await;
     let key = cache.scoped_cache_key(TEST_PROFILE_NAME, "sess-no-metadata", "/workspace", 5);
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
-    fs::write(paths.session_workspace_cache_current_image(&key), b"image")
+    fs::write(paths.workspace_image_cache_current_image(&key), b"image")
         .await
         .unwrap();
 
@@ -105,7 +102,6 @@ async fn metadata_missing_current_present_is_not_a_cache_hit() {
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-no-metadata"),
-                cli_agent_session_id: Some("sess-no-metadata"),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -126,13 +122,13 @@ async fn metadata_missing_current_present_is_not_a_cache_hit() {
 async fn metadata_validation_rejects_metadata_mismatch() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().to_path_buf());
-    let cache = SessionWorkspaceCache::new(paths.clone());
+    let cache = WorkspaceImageCache::new(paths.clone());
     let run_id = RunId::new_v4();
     let key = cache.scoped_cache_key(TEST_PROFILE_NAME, "sess-1", "/workspace", 1024);
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
-    let current = paths.session_workspace_cache_current_image(&key);
+    let current = paths.workspace_image_cache_current_image(&key);
     fs::write(&current, b"image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -141,11 +137,9 @@ async fn metadata_validation_rejects_metadata_mismatch() {
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
                 reuse_key: "other".into(),
-                cli_agent_session_id: Some("other".into()),
                 working_dir: "/workspace".into(),
                 last_completed_at: local_timestamp(),
                 last_used_at: local_timestamp(),
@@ -164,7 +158,7 @@ async fn metadata_validation_rejects_metadata_mismatch() {
 
     let err = cache
         .read_valid_metadata(
-            &paths.session_workspace_cache_metadata(&key),
+            &paths.workspace_image_cache_metadata(&key),
             TEST_PROFILE_NAME,
             "sess-1",
             "/workspace",
@@ -180,16 +174,16 @@ async fn write_metadata_replaces_stale_tmp_symlink_without_following_it() {
     let (dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let key = cache.scoped_cache_key(TEST_PROFILE_NAME, "sess-1", "/workspace", 5);
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
-    let current = paths.session_workspace_cache_current_image(&key);
+    let current = paths.workspace_image_cache_current_image(&key);
     fs::write(&current, b"image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     let outside = dir.path().join("outside-metadata-target");
     fs::write(&outside, b"outside").await.unwrap();
     let metadata_tmp = paths
-        .session_workspace_cache_metadata(&key)
+        .workspace_image_cache_metadata(&key)
         .with_file_name(format!("metadata.json.tmp.{run_id}"));
     std::os::unix::fs::symlink(&outside, &metadata_tmp).unwrap();
 
@@ -199,11 +193,9 @@ async fn write_metadata_replaces_stale_tmp_symlink_without_following_it() {
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
                 reuse_key: "sess-1".into(),
-                cli_agent_session_id: Some("sess-1".into()),
                 working_dir: "/workspace".into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
                 last_used_at: "2026-05-01T00:01:00.000Z".into(),
@@ -221,7 +213,7 @@ async fn write_metadata_replaces_stale_tmp_symlink_without_following_it() {
         .unwrap();
 
     assert_eq!(fs::read(&outside).await.unwrap(), b"outside");
-    let metadata_path = paths.session_workspace_cache_metadata(&key);
+    let metadata_path = paths.workspace_image_cache_metadata(&key);
     let metadata_file_type = fs::symlink_metadata(&metadata_path)
         .await
         .unwrap()
@@ -234,15 +226,15 @@ async fn write_metadata_replaces_stale_tmp_symlink_without_following_it() {
 async fn prepare_removes_invalid_metadata_entry_and_allows_repromotion() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().to_path_buf());
-    let cache = SessionWorkspaceCache::new(paths.clone());
+    let cache = WorkspaceImageCache::new(paths.clone());
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let image_size = b"old image".len() as u64;
     let key = cache.scoped_cache_key(TEST_PROFILE_NAME, "sess-1", "/workspace", image_size);
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
-    let current = paths.session_workspace_cache_current_image(&key);
+    let current = paths.workspace_image_cache_current_image(&key);
     fs::write(&current, b"old image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -251,11 +243,9 @@ async fn prepare_removes_invalid_metadata_entry_and_allows_repromotion() {
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
                 reuse_key: "other".into(),
-                cli_agent_session_id: Some("other".into()),
                 working_dir: "/workspace".into(),
                 last_completed_at: local_timestamp(),
                 last_used_at: local_timestamp(),
@@ -279,7 +269,6 @@ async fn prepare_removes_invalid_metadata_entry_and_allows_repromotion() {
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: Some("sess-1"),
                 working_dir: "/workspace",
                 image_size_bytes: image_size,
             },
@@ -289,7 +278,7 @@ async fn prepare_removes_invalid_metadata_entry_and_allows_repromotion() {
 
     assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Miss);
     assert!(
-        !paths.session_workspace_cache_entry_dir(&key).exists(),
+        !paths.workspace_image_cache_entry_dir(&key).exists(),
         "invalid entry should be removed while the entry lock is held"
     );
 
@@ -302,7 +291,6 @@ async fn prepare_removes_invalid_metadata_entry_and_allows_repromotion() {
         lease
             .promote(
                 run_id,
-                None,
                 WorkspaceCacheTerminalStatus::Success,
                 "2026-06-01T00:00:00.000Z".into(),
                 &StorageFingerprints::default(),
@@ -311,11 +299,14 @@ async fn prepare_removes_invalid_metadata_entry_and_allows_repromotion() {
             .unwrap()
     );
 
-    let metadata = cache
-        .read_metadata_file(&paths.session_workspace_cache_metadata(&key))
-        .await
-        .unwrap();
-    assert_eq!(metadata.cli_agent_session_id.as_deref(), Some("sess-1"));
+    let metadata_path = paths.workspace_image_cache_metadata(&key);
+    let metadata = cache.read_metadata_file(&metadata_path).await.unwrap();
+    let serialized_metadata: serde_json::Value =
+        serde_json::from_slice(&fs::read(metadata_path).await.unwrap()).unwrap();
+    assert_eq!(serialized_metadata["formatVersion"], CACHE_FORMAT_VERSION);
+    assert!(serialized_metadata.get("keyVersion").is_none());
+    assert!(serialized_metadata.get("cliAgentSessionId").is_none());
+    assert_eq!(metadata.reuse_key, "sess-1");
     assert_eq!(cache.held_workspace_states().await.len(), 1);
 }
 
@@ -323,7 +314,7 @@ async fn prepare_removes_invalid_metadata_entry_and_allows_repromotion() {
 async fn metadata_validation_rejects_replaced_current_image() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().to_path_buf());
-    let cache = SessionWorkspaceCache::new(paths.clone());
+    let cache = WorkspaceImageCache::new(paths.clone());
     let run_id = RunId::new_v4();
     let key = cache.scoped_cache_key(
         TEST_PROFILE_NAME,
@@ -331,10 +322,10 @@ async fn metadata_validation_rejects_replaced_current_image() {
         "/workspace",
         b"old image".len() as u64,
     );
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
-    let current = paths.session_workspace_cache_current_image(&key);
+    let current = paths.workspace_image_cache_current_image(&key);
     fs::write(&current, b"old image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -343,11 +334,9 @@ async fn metadata_validation_rejects_replaced_current_image() {
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
                 reuse_key: "sess-1".into(),
-                cli_agent_session_id: Some("sess-1".into()),
                 working_dir: "/workspace".into(),
                 last_completed_at: local_timestamp(),
                 last_used_at: local_timestamp(),
@@ -364,14 +353,14 @@ async fn metadata_validation_rejects_replaced_current_image() {
         .await
         .unwrap();
     let replacement = paths
-        .session_workspace_cache_entry_dir(&key)
+        .workspace_image_cache_entry_dir(&key)
         .join("replacement.ext4");
     fs::write(&replacement, b"new image").await.unwrap();
     fs::rename(&replacement, &current).await.unwrap();
 
     let err = cache
         .read_valid_metadata(
-            &paths.session_workspace_cache_metadata(&key),
+            &paths.workspace_image_cache_metadata(&key),
             TEST_PROFILE_NAME,
             "sess-1",
             "/workspace",
@@ -391,7 +380,7 @@ async fn metadata_validation_rejects_replaced_current_image() {
 async fn metadata_validation_rejects_symlink_current_image() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().to_path_buf());
-    let cache = SessionWorkspaceCache::new(paths.clone());
+    let cache = WorkspaceImageCache::new(paths.clone());
     let run_id = RunId::new_v4();
     let key = cache.scoped_cache_key(
         TEST_PROFILE_NAME,
@@ -399,12 +388,12 @@ async fn metadata_validation_rejects_symlink_current_image() {
         "/workspace",
         b"image".len() as u64,
     );
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
     let target = dir.path().join("target.ext4");
     fs::write(&target, b"image").await.unwrap();
-    let current = paths.session_workspace_cache_current_image(&key);
+    let current = paths.workspace_image_cache_current_image(&key);
     std::os::unix::fs::symlink(&target, &current).unwrap();
     let current_target_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -413,11 +402,9 @@ async fn metadata_validation_rejects_symlink_current_image() {
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
                 reuse_key: "sess-1".into(),
-                cli_agent_session_id: Some("sess-1".into()),
                 working_dir: "/workspace".into(),
                 last_completed_at: local_timestamp(),
                 last_used_at: local_timestamp(),
@@ -436,7 +423,7 @@ async fn metadata_validation_rejects_symlink_current_image() {
 
     let err = cache
         .read_valid_metadata(
-            &paths.session_workspace_cache_metadata(&key),
+            &paths.workspace_image_cache_metadata(&key),
             TEST_PROFILE_NAME,
             "sess-1",
             "/workspace",
@@ -454,7 +441,7 @@ async fn metadata_validation_rejects_symlink_current_image() {
     let freed = cache.gc(false).await.unwrap();
 
     assert!(freed > 0);
-    assert!(!paths.session_workspace_cache_entry_dir(&key).exists());
+    assert!(!paths.workspace_image_cache_entry_dir(&key).exists());
     assert!(
         target.exists(),
         "GC must remove the symlink, not its target"

--- a/crates/runner/src/workspace_image_cache/tests/promotion.rs
+++ b/crates/runner/src/workspace_image_cache/tests/promotion.rs
@@ -4,17 +4,18 @@ use tokio::fs;
 
 use super::super::fs::local_timestamp;
 use super::super::{
-    CacheBudget, FsStats, SessionWorkspaceCache, TEST_FS_AVAILABLE_BYTES, TEST_FS_TOTAL_BYTES,
-    WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity,
-    WorkspaceImagePrepareRequest, WorkspaceImagePromotionIdentityMismatch,
-    WorkspaceImagePromotionIdentityRequest, WorkspaceImagePromotionRequest,
+    CacheBudget, FsStats, TEST_FS_AVAILABLE_BYTES, TEST_FS_TOTAL_BYTES,
+    WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus, WorkspaceImageCache,
+    WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
+    WorkspaceImagePromotionIdentityMismatch, WorkspaceImagePromotionIdentityRequest,
+    WorkspaceImagePromotionRequest,
 };
 use super::support::{
     TEST_PROFILE_NAME, local_cache, promote_current_cache_entry, write_current_cache_entry,
 };
 use crate::error::RunnerError;
 use crate::ids::RunId;
-use crate::paths::{RunnerPaths, session_workspace_cache_key};
+use crate::paths::{RunnerPaths, workspace_image_cache_key};
 use crate::storage_fingerprints::StorageFingerprints;
 
 async fn cross_filesystem_cache(
@@ -23,7 +24,7 @@ async fn cross_filesystem_cache(
     tempfile::TempDir,
     tempfile::TempDir,
     RunnerPaths,
-    SessionWorkspaceCache,
+    WorkspaceImageCache,
 ) {
     let runner_dir = tempfile::tempdir_in("/tmp").unwrap();
     let cache_dir = tempfile::tempdir_in("/dev/shm").unwrap();
@@ -38,7 +39,7 @@ async fn cross_filesystem_cache(
         "cross-filesystem promotion tests require /tmp and /dev/shm on distinct devices"
     );
     let lock_dir = runner_dir.path().join("locks");
-    let cache = SessionWorkspaceCache::with_cache_dirs_and_fs_stats(
+    let cache = WorkspaceImageCache::with_cache_dirs_and_fs_stats(
         paths.clone(),
         cache_root,
         lock_dir,
@@ -51,8 +52,8 @@ async fn cross_filesystem_cache(
 #[tokio::test]
 async fn promotion_does_not_overwrite_newer_cache_entry() {
     let (_dir, paths, cache) = local_cache().await;
-    let session_id = "sess-race";
-    let existing_image = format!("image-{session_id}").into_bytes();
+    let reuse_key = "sess-race";
+    let existing_image = format!("image-{reuse_key}").into_bytes();
     let image_size = existing_image.len() as u64;
     let stale_run_id = RunId::new_v4();
     let stale_sandbox_id = sandbox::SandboxId::new_v4();
@@ -62,8 +63,7 @@ async fn promotion_does_not_overwrite_newer_cache_entry() {
                 run_id: stale_run_id,
                 sandbox_id: stale_sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace",
                 image_size_bytes: image_size,
             },
@@ -81,7 +81,7 @@ async fn promotion_does_not_overwrite_newer_cache_entry() {
     let key = write_current_cache_entry(
         &cache,
         stale_run_id,
-        session_id,
+        reuse_key,
         "/workspace",
         "2026-06-02T00:00:00.000Z",
         "2026-06-02T00:00:00.000Z",
@@ -91,7 +91,6 @@ async fn promotion_does_not_overwrite_newer_cache_entry() {
     let promoted = stale_lease
         .promote(
             stale_run_id,
-            None,
             WorkspaceCacheTerminalStatus::Success,
             "2026-06-01T00:00:00.000Z".into(),
             &StorageFingerprints::default(),
@@ -101,11 +100,11 @@ async fn promotion_does_not_overwrite_newer_cache_entry() {
 
     assert!(!promoted);
     let metadata = cache
-        .read_metadata_file(&paths.session_workspace_cache_metadata(&key))
+        .read_metadata_file(&paths.workspace_image_cache_metadata(&key))
         .await
         .unwrap();
     assert_eq!(metadata.last_completed_at, "2026-06-02T00:00:00.000Z");
-    let current = tokio::fs::read(paths.session_workspace_cache_current_image(&key))
+    let current = tokio::fs::read(paths.workspace_image_cache_current_image(&key))
         .await
         .unwrap();
     assert_eq!(current, existing_image);
@@ -114,9 +113,9 @@ async fn promotion_does_not_overwrite_newer_cache_entry() {
 #[tokio::test]
 async fn promotion_does_not_overwrite_same_completed_at_cache_entry() {
     let (_dir, paths, cache) = local_cache().await;
-    let session_id = "sess-same-completed-at";
+    let reuse_key = "sess-same-completed-at";
     let completed_at = "2026-06-02T00:00:00.000Z";
-    let existing_image = format!("image-{session_id}").into_bytes();
+    let existing_image = format!("image-{reuse_key}").into_bytes();
     let image_size = existing_image.len() as u64;
     let competing_run_id = RunId::new_v4();
     let competing_sandbox_id = sandbox::SandboxId::new_v4();
@@ -126,8 +125,7 @@ async fn promotion_does_not_overwrite_same_completed_at_cache_entry() {
                 run_id: competing_run_id,
                 sandbox_id: competing_sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace",
                 image_size_bytes: image_size,
             },
@@ -145,7 +143,7 @@ async fn promotion_does_not_overwrite_same_completed_at_cache_entry() {
     let key = write_current_cache_entry(
         &cache,
         competing_run_id,
-        session_id,
+        reuse_key,
         "/workspace",
         completed_at,
         completed_at,
@@ -155,7 +153,6 @@ async fn promotion_does_not_overwrite_same_completed_at_cache_entry() {
     let promoted = competing_lease
         .promote(
             competing_run_id,
-            None,
             WorkspaceCacheTerminalStatus::Success,
             completed_at.into(),
             &StorageFingerprints::default(),
@@ -165,11 +162,11 @@ async fn promotion_does_not_overwrite_same_completed_at_cache_entry() {
 
     assert!(!promoted);
     let metadata = cache
-        .read_metadata_file(&paths.session_workspace_cache_metadata(&key))
+        .read_metadata_file(&paths.workspace_image_cache_metadata(&key))
         .await
         .unwrap();
     assert_eq!(metadata.last_completed_at, completed_at);
-    let current = tokio::fs::read(paths.session_workspace_cache_current_image(&key))
+    let current = tokio::fs::read(paths.workspace_image_cache_current_image(&key))
         .await
         .unwrap();
     assert_eq!(current, existing_image);
@@ -178,12 +175,12 @@ async fn promotion_does_not_overwrite_same_completed_at_cache_entry() {
 #[tokio::test]
 async fn promotion_overwrites_older_cache_entry() {
     let (_dir, paths, cache) = local_cache().await;
-    let session_id = "sess-newer";
+    let reuse_key = "sess-newer";
     let image_size = b"old image".len() as u64;
     let key = promote_current_cache_entry(
         &cache,
         &paths,
-        session_id,
+        reuse_key,
         b"old image",
         "2026-06-01T00:00:00.000Z",
     )
@@ -196,8 +193,7 @@ async fn promotion_overwrites_older_cache_entry() {
                 run_id: newer_run_id,
                 sandbox_id: newer_sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace",
                 image_size_bytes: image_size,
             },
@@ -216,7 +212,6 @@ async fn promotion_overwrites_older_cache_entry() {
     let promoted = newer_lease
         .promote(
             newer_run_id,
-            None,
             WorkspaceCacheTerminalStatus::Success,
             "2026-06-02T00:00:00.000Z".into(),
             &StorageFingerprints::default(),
@@ -226,11 +221,11 @@ async fn promotion_overwrites_older_cache_entry() {
 
     assert!(promoted);
     let metadata = cache
-        .read_metadata_file(&paths.session_workspace_cache_metadata(&key))
+        .read_metadata_file(&paths.workspace_image_cache_metadata(&key))
         .await
         .unwrap();
     assert_eq!(metadata.last_completed_at, "2026-06-02T00:00:00.000Z");
-    let current = tokio::fs::read(paths.session_workspace_cache_current_image(&key))
+    let current = tokio::fs::read(paths.workspace_image_cache_current_image(&key))
         .await
         .unwrap();
     assert_eq!(current, b"new image");
@@ -277,7 +272,7 @@ async fn successful_multi_entry_promotion_scans_cache_root_once() {
     for cache_key in [first_key, second_key, promoted_key] {
         assert!(
             paths
-                .session_workspace_cache_current_image(&cache_key)
+                .workspace_image_cache_current_image(&cache_key)
                 .exists(),
             "healthy under-budget entries should remain after post-promotion GC"
         );
@@ -287,18 +282,18 @@ async fn successful_multi_entry_promotion_scans_cache_root_once() {
 #[tokio::test]
 async fn abandoned_cache_hit_promotion_context_invalidates_consumed_entry() {
     let (_dir, paths, cache) = local_cache().await;
-    let session_id = "sess-abandon-hit";
+    let reuse_key = "sess-abandon-hit";
     let cache_run_id = RunId::new_v4();
     let cache_key = write_current_cache_entry(
         &cache,
         cache_run_id,
-        session_id,
+        reuse_key,
         "/workspace",
         "2026-05-01T00:00:00.000Z",
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let current = paths.session_workspace_cache_current_image(&cache_key);
+    let current = paths.workspace_image_cache_current_image(&cache_key);
     let image_size_bytes = fs::metadata(&current).await.unwrap().len();
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
@@ -308,8 +303,7 @@ async fn abandoned_cache_hit_promotion_context_invalidates_consumed_entry() {
                 run_id,
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace",
                 image_size_bytes,
             },
@@ -319,7 +313,7 @@ async fn abandoned_cache_hit_promotion_context_invalidates_consumed_entry() {
     assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Hit);
     assert!(lease.consumed_cache_hit);
     assert!(
-        !fs::try_exists(paths.session_workspace_cache_metadata(&cache_key))
+        !fs::try_exists(paths.workspace_image_cache_metadata(&cache_key))
             .await
             .unwrap()
     );
@@ -327,7 +321,6 @@ async fn abandoned_cache_hit_promotion_context_invalidates_consumed_entry() {
         .into_promotion_context(WorkspaceImagePromotionRequest {
             run_id,
             sandbox_id,
-            cli_agent_session_id_override: None,
             restored_session_identity: None,
             terminal_status: WorkspaceCacheTerminalStatus::Success,
             completed_at: "2026-05-02T00:00:00.000Z".into(),
@@ -342,7 +335,7 @@ async fn abandoned_cache_hit_promotion_context_invalidates_consumed_entry() {
             .unwrap()
     );
     assert!(
-        !fs::try_exists(paths.session_workspace_cache_entry_dir(&cache_key))
+        !fs::try_exists(paths.workspace_image_cache_entry_dir(&cache_key))
             .await
             .unwrap()
     );
@@ -353,8 +346,7 @@ async fn abandoned_cache_hit_promotion_context_invalidates_consumed_entry() {
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace",
                 image_size_bytes,
             },
@@ -378,7 +370,7 @@ async fn consumed_cache_hit_promotion_moves_active_image_back_to_cache() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let current = paths.session_workspace_cache_current_image(&key);
+    let current = paths.workspace_image_cache_current_image(&key);
     let image_size = fs::metadata(&current).await.unwrap().len();
     let active_image = paths.active_workspace_image(&sandbox_id);
 
@@ -389,7 +381,6 @@ async fn consumed_cache_hit_promotion_moves_active_image_back_to_cache() {
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-move-promote"),
-                cli_agent_session_id: Some("sess-move-promote"),
                 working_dir: "/workspace",
                 image_size_bytes: image_size,
             },
@@ -410,7 +401,6 @@ async fn consumed_cache_hit_promotion_moves_active_image_back_to_cache() {
         lease
             .promote(
                 run_id,
-                None,
                 WorkspaceCacheTerminalStatus::Success,
                 "2026-05-02T00:00:00.000Z".into(),
                 &StorageFingerprints::default(),
@@ -431,7 +421,7 @@ async fn consumed_cache_hit_promotion_moves_active_image_back_to_cache() {
         "same-filesystem promotion must publish the moved image without copying its extents"
     );
     let metadata = cache
-        .read_metadata_file(&paths.session_workspace_cache_metadata(&key))
+        .read_metadata_file(&paths.workspace_image_cache_metadata(&key))
         .await
         .unwrap();
     assert_eq!(metadata.logical_image_size_bytes, image_size);
@@ -447,7 +437,7 @@ async fn cross_filesystem_promotion_falls_back_to_sparse_copy() {
     .await;
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
-    let session_id = "sess-cross-filesystem";
+    let reuse_key = "sess-cross-filesystem";
     let image = vec![b'x'; 4096];
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
@@ -455,8 +445,7 @@ async fn cross_filesystem_promotion_falls_back_to_sparse_copy() {
                 run_id,
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace",
                 image_size_bytes: image.len() as u64,
             },
@@ -474,7 +463,6 @@ async fn cross_filesystem_promotion_falls_back_to_sparse_copy() {
         lease
             .promote(
                 run_id,
-                None,
                 WorkspaceCacheTerminalStatus::Success,
                 "2026-05-02T00:00:00.000Z".into(),
                 &StorageFingerprints::default(),
@@ -489,11 +477,11 @@ async fn cross_filesystem_promotion_falls_back_to_sparse_copy() {
     );
     let cache_key = cache.scoped_cache_key(
         TEST_PROFILE_NAME,
-        session_id,
+        reuse_key,
         "/workspace",
         image.len() as u64,
     );
-    let current = cache.session_workspace_cache_current_image(&cache_key);
+    let current = cache.workspace_image_cache_current_image(&cache_key);
     assert_eq!(fs::read(&current).await.unwrap(), image);
     assert_ne!(
         fs::metadata(&active_image).await.unwrap().dev(),
@@ -515,7 +503,7 @@ async fn cross_filesystem_promotion_still_requires_copy_headroom() {
     .await;
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
-    let session_id = "sess-cross-filesystem-headroom";
+    let reuse_key = "sess-cross-filesystem-headroom";
     let image = vec![b'x'; 4096];
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
@@ -523,8 +511,7 @@ async fn cross_filesystem_promotion_still_requires_copy_headroom() {
                 run_id,
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace",
                 image_size_bytes: image.len() as u64,
             },
@@ -541,7 +528,6 @@ async fn cross_filesystem_promotion_still_requires_copy_headroom() {
         !lease
             .promote(
                 run_id,
-                None,
                 WorkspaceCacheTerminalStatus::Success,
                 "2026-05-02T00:00:00.000Z".into(),
                 &StorageFingerprints::default(),
@@ -553,12 +539,12 @@ async fn cross_filesystem_promotion_still_requires_copy_headroom() {
     assert!(fs::try_exists(&active_image).await.unwrap());
     let cache_key = cache.scoped_cache_key(
         TEST_PROFILE_NAME,
-        session_id,
+        reuse_key,
         "/workspace",
         image.len() as u64,
     );
     assert!(
-        !fs::try_exists(cache.session_workspace_cache_current_image(&cache_key))
+        !fs::try_exists(cache.workspace_image_cache_current_image(&cache_key))
             .await
             .unwrap()
     );
@@ -580,7 +566,6 @@ async fn lock_busy_checkout_cannot_promote_without_entry_lock() {
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: Some("sess-1"),
                 working_dir: "/workspace",
                 image_size_bytes: 1024,
             },
@@ -593,7 +578,6 @@ async fn lock_busy_checkout_cannot_promote_without_entry_lock() {
         !lease
             .promote(
                 run_id,
-                None,
                 WorkspaceCacheTerminalStatus::Success,
                 local_timestamp(),
                 &StorageFingerprints::default(),
@@ -603,7 +587,7 @@ async fn lock_busy_checkout_cannot_promote_without_entry_lock() {
     );
     assert!(
         !paths
-            .session_workspace_cache_current_image(&cache_key)
+            .workspace_image_cache_current_image(&cache_key)
             .exists()
     );
 }
@@ -613,7 +597,7 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
     let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
-    let session_id = "sess-locked-context";
+    let reuse_key = "sess-locked-context";
     let image_size_bytes = 16 * 1024 * 1024;
 
     let lease = cache
@@ -622,8 +606,7 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
                 run_id,
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace",
                 image_size_bytes,
             },
@@ -636,7 +619,6 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
         .into_promotion_context(WorkspaceImagePromotionRequest {
             run_id,
             sandbox_id,
-            cli_agent_session_id_override: Some(session_id),
             restored_session_identity: None,
             terminal_status: WorkspaceCacheTerminalStatus::Success,
             completed_at: local_timestamp(),
@@ -650,8 +632,7 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace",
                 image_size_bytes,
             },
@@ -667,7 +648,7 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
         .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
             profile_name: TEST_PROFILE_NAME,
-            reuse_key: session_id,
+            reuse_key,
             working_dir: "/workspace",
             image_size_bytes,
         })
@@ -680,8 +661,7 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace",
                 image_size_bytes,
             },
@@ -700,8 +680,7 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace",
                 image_size_bytes,
             },
@@ -716,7 +695,7 @@ async fn promotion_context_validates_expected_identity() {
     let (_dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
-    let session_id = "sess-identity";
+    let reuse_key = "sess-identity";
     let image_size_bytes = 16 * 1024 * 1024;
 
     let lease = cache
@@ -725,8 +704,7 @@ async fn promotion_context_validates_expected_identity() {
                 run_id,
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace//repo/",
                 image_size_bytes,
             },
@@ -737,7 +715,6 @@ async fn promotion_context_validates_expected_identity() {
         .into_promotion_context(WorkspaceImagePromotionRequest {
             run_id,
             sandbox_id,
-            cli_agent_session_id_override: Some(session_id),
             restored_session_identity: None,
             terminal_status: WorkspaceCacheTerminalStatus::Success,
             completed_at: local_timestamp(),
@@ -749,7 +726,7 @@ async fn promotion_context_validates_expected_identity() {
         .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
             profile_name: TEST_PROFILE_NAME,
-            reuse_key: session_id,
+            reuse_key,
             working_dir: "/workspace/repo",
             image_size_bytes,
         })
@@ -760,7 +737,7 @@ async fn promotion_context_validates_expected_identity() {
         .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
             sandbox_id: sandbox::SandboxId::new_v4(),
             profile_name: TEST_PROFILE_NAME,
-            reuse_key: session_id,
+            reuse_key,
             working_dir: "/workspace/repo",
             image_size_bytes,
         })
@@ -770,7 +747,7 @@ async fn promotion_context_validates_expected_identity() {
         Err(WorkspaceImagePromotionIdentityMismatch::SandboxId),
     );
 
-    let wrong_session = cache
+    let wrong_reuse_key = cache
         .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
             profile_name: TEST_PROFILE_NAME,
@@ -780,7 +757,7 @@ async fn promotion_context_validates_expected_identity() {
         })
         .unwrap();
     assert_eq!(
-        promotion.validate_identity(&wrong_session),
+        promotion.validate_identity(&wrong_reuse_key),
         Err(WorkspaceImagePromotionIdentityMismatch::ReuseKey),
     );
 
@@ -788,7 +765,7 @@ async fn promotion_context_validates_expected_identity() {
         .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
             profile_name: TEST_PROFILE_NAME,
-            reuse_key: session_id,
+            reuse_key,
             working_dir: "/workspace/repo",
             image_size_bytes: image_size_bytes + 1,
         })
@@ -798,7 +775,7 @@ async fn promotion_context_validates_expected_identity() {
         Err(WorkspaceImagePromotionIdentityMismatch::ImageSizeBytes),
     );
 
-    let scoped_cache = SessionWorkspaceCache::with_cache_dirs(
+    let scoped_cache = WorkspaceImageCache::with_cache_dirs(
         paths.clone(),
         paths.workspace_image_cache_dir(),
         paths.base_dir().join("locks"),
@@ -808,7 +785,7 @@ async fn promotion_context_validates_expected_identity() {
         .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
             profile_name: TEST_PROFILE_NAME,
-            reuse_key: session_id,
+            reuse_key,
             working_dir: "/workspace/repo",
             image_size_bytes,
         })
@@ -822,7 +799,7 @@ async fn promotion_context_validates_expected_identity() {
         cache.expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
             profile_name: TEST_PROFILE_NAME,
-            reuse_key: session_id,
+            reuse_key,
             working_dir: "/",
             image_size_bytes,
         }),
@@ -835,15 +812,14 @@ async fn promote_skips_symlink_active_image_without_following_it() {
     let (dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
-    let session_id = "sess-active-symlink";
+    let reuse_key = "sess-active-symlink";
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -861,7 +837,6 @@ async fn promote_skips_symlink_active_image_without_following_it() {
     let promoted = lease
         .promote(
             run_id,
-            None,
             WorkspaceCacheTerminalStatus::Success,
             "2026-05-01T00:00:00.000Z".into(),
             &StorageFingerprints::default(),
@@ -869,11 +844,11 @@ async fn promote_skips_symlink_active_image_without_following_it() {
         .await
         .unwrap();
 
-    let cache_key = session_workspace_cache_key(session_id, "/workspace");
+    let cache_key = workspace_image_cache_key(reuse_key, "/workspace");
     assert!(!promoted);
     assert!(
         !paths
-            .session_workspace_cache_current_image(&cache_key)
+            .workspace_image_cache_current_image(&cache_key)
             .exists()
     );
     assert_eq!(tokio::fs::read(&outside_image).await.unwrap(), b"image");
@@ -891,15 +866,14 @@ async fn promote_replaces_symlink_cache_entry_dir_without_following_it() {
     let (dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
-    let session_id = "sess-promote-entry-symlink";
+    let reuse_key = "sess-promote-entry-symlink";
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -911,8 +885,8 @@ async fn promote_replaces_symlink_cache_entry_dir_without_following_it() {
         .await
         .unwrap();
     tokio::fs::write(&active_image, b"image").await.unwrap();
-    let cache_key = session_workspace_cache_key(session_id, "/workspace");
-    let entry_dir = paths.session_workspace_cache_entry_dir(&cache_key);
+    let cache_key = workspace_image_cache_key(reuse_key, "/workspace");
+    let entry_dir = paths.workspace_image_cache_entry_dir(&cache_key);
     let outside_entry = dir.path().join("outside-promotion-entry");
     tokio::fs::create_dir_all(&outside_entry).await.unwrap();
     tokio::fs::write(outside_entry.join("marker"), b"marker")
@@ -926,7 +900,6 @@ async fn promote_replaces_symlink_cache_entry_dir_without_following_it() {
     let promoted = lease
         .promote(
             run_id,
-            None,
             WorkspaceCacheTerminalStatus::Success,
             "2026-05-01T00:00:00.000Z".into(),
             &StorageFingerprints::default(),
@@ -939,7 +912,7 @@ async fn promote_replaces_symlink_cache_entry_dir_without_following_it() {
     assert!(entry_metadata.is_dir());
     assert!(!entry_metadata.file_type().is_symlink());
     assert_eq!(
-        fs::read(paths.session_workspace_cache_current_image(&cache_key))
+        fs::read(paths.workspace_image_cache_current_image(&cache_key))
             .await
             .unwrap(),
         b"image"
@@ -963,7 +936,6 @@ async fn promote_removes_current_image_when_metadata_write_fails() {
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: None,
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -976,14 +948,13 @@ async fn promote_removes_current_image_when_metadata_write_fails() {
     let active_image = paths.active_workspace_image(&sandbox_id);
     tokio::fs::write(&active_image, b"image").await.unwrap();
 
-    let cache_key = session_workspace_cache_key("sess-1", "/workspace");
-    let metadata_path = paths.session_workspace_cache_metadata(&cache_key);
+    let cache_key = workspace_image_cache_key("sess-1", "/workspace");
+    let metadata_path = paths.workspace_image_cache_metadata(&cache_key);
     tokio::fs::create_dir_all(&metadata_path).await.unwrap();
 
     let err = lease
         .promote(
             run_id,
-            Some("sess-1"),
             WorkspaceCacheTerminalStatus::Success,
             "2026-05-01T00:00:00.000Z".into(),
             &StorageFingerprints::default(),
@@ -998,12 +969,12 @@ async fn promote_removes_current_image_when_metadata_write_fails() {
     );
     assert!(
         !paths
-            .session_workspace_cache_current_image(&cache_key)
+            .workspace_image_cache_current_image(&cache_key)
             .exists()
     );
     assert!(
         !paths
-            .session_workspace_cache_tmp_image(&cache_key, run_id)
+            .workspace_image_cache_tmp_image(&cache_key, run_id)
             .exists()
     );
     assert!(
@@ -1025,7 +996,6 @@ async fn promote_removes_stale_temporary_directory_before_transfer() {
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: None,
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -1038,8 +1008,8 @@ async fn promote_removes_stale_temporary_directory_before_transfer() {
     tokio::fs::write(paths.active_workspace_image(&sandbox_id), b"image")
         .await
         .unwrap();
-    let cache_key = session_workspace_cache_key("sess-1", "/workspace");
-    let tmp = paths.session_workspace_cache_tmp_image(&cache_key, run_id);
+    let cache_key = workspace_image_cache_key("sess-1", "/workspace");
+    let tmp = paths.workspace_image_cache_tmp_image(&cache_key, run_id);
     tokio::fs::create_dir_all(&tmp).await.unwrap();
     tokio::fs::write(tmp.join("stale"), b"stale").await.unwrap();
 
@@ -1047,7 +1017,6 @@ async fn promote_removes_stale_temporary_directory_before_transfer() {
         lease
             .promote(
                 run_id,
-                Some("sess-1"),
                 WorkspaceCacheTerminalStatus::Success,
                 "2026-05-01T00:00:00.000Z".into(),
                 &StorageFingerprints::default(),
@@ -1056,7 +1025,7 @@ async fn promote_removes_stale_temporary_directory_before_transfer() {
             .unwrap()
     );
 
-    let current = paths.session_workspace_cache_current_image(&cache_key);
+    let current = paths.workspace_image_cache_current_image(&cache_key);
     assert!(!tmp.exists());
     assert!(fs::metadata(&current).await.unwrap().is_file());
     assert_eq!(fs::read(current).await.unwrap(), b"image");
@@ -1074,7 +1043,6 @@ async fn promote_replaces_stale_current_directory_before_rename() {
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: None,
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -1087,8 +1055,8 @@ async fn promote_replaces_stale_current_directory_before_rename() {
     tokio::fs::write(paths.active_workspace_image(&sandbox_id), b"image")
         .await
         .unwrap();
-    let cache_key = session_workspace_cache_key("sess-1", "/workspace");
-    let current = paths.session_workspace_cache_current_image(&cache_key);
+    let cache_key = workspace_image_cache_key("sess-1", "/workspace");
+    let current = paths.workspace_image_cache_current_image(&cache_key);
     tokio::fs::create_dir_all(&current).await.unwrap();
     tokio::fs::write(current.join("stale"), b"stale")
         .await
@@ -1098,7 +1066,6 @@ async fn promote_replaces_stale_current_directory_before_rename() {
         lease
             .promote(
                 run_id,
-                Some("sess-1"),
                 WorkspaceCacheTerminalStatus::Success,
                 "2026-05-01T00:00:00.000Z".into(),
                 &StorageFingerprints::default(),
@@ -1123,7 +1090,6 @@ async fn promote_skips_transferred_image_with_unexpected_logical_size() {
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-size-mismatch"),
-                cli_agent_session_id: Some("sess-size-mismatch"),
                 working_dir: "/workspace",
                 image_size_bytes: 16 * 1024 * 1024,
             },
@@ -1136,13 +1102,12 @@ async fn promote_skips_transferred_image_with_unexpected_logical_size() {
     tokio::fs::write(paths.active_workspace_image(&sandbox_id), b"truncated")
         .await
         .unwrap();
-    let cache_key = session_workspace_cache_key("sess-size-mismatch", "/workspace");
+    let cache_key = workspace_image_cache_key("sess-size-mismatch", "/workspace");
 
     assert!(
         !lease
             .promote(
                 run_id,
-                None,
                 WorkspaceCacheTerminalStatus::Success,
                 "2026-05-01T00:00:00.000Z".into(),
                 &StorageFingerprints::default(),
@@ -1152,7 +1117,7 @@ async fn promote_skips_transferred_image_with_unexpected_logical_size() {
     );
     assert!(
         !paths
-            .session_workspace_cache_current_image(&cache_key)
+            .workspace_image_cache_current_image(&cache_key)
             .exists()
     );
     assert!(cache.held_workspace_states().await.is_empty());
@@ -1170,7 +1135,6 @@ async fn promote_skips_when_capacity_lock_is_busy() {
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-capacity-lock"),
-                cli_agent_session_id: Some("sess-capacity-lock"),
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -1183,7 +1147,7 @@ async fn promote_skips_when_capacity_lock_is_busy() {
     tokio::fs::write(paths.active_workspace_image(&sandbox_id), b"image")
         .await
         .unwrap();
-    let cache_key = session_workspace_cache_key("sess-capacity-lock", "/workspace");
+    let cache_key = workspace_image_cache_key("sess-capacity-lock", "/workspace");
     let _capacity_lock = crate::lock::acquire(cache.capacity_lock_path())
         .await
         .unwrap();
@@ -1191,7 +1155,6 @@ async fn promote_skips_when_capacity_lock_is_busy() {
     let promoted = lease
         .promote(
             run_id,
-            None,
             WorkspaceCacheTerminalStatus::Success,
             "2026-05-01T00:00:00.000Z".into(),
             &StorageFingerprints::default(),
@@ -1202,18 +1165,18 @@ async fn promote_skips_when_capacity_lock_is_busy() {
     assert!(!promoted);
     assert!(
         !paths
-            .session_workspace_cache_current_image(&cache_key)
+            .workspace_image_cache_current_image(&cache_key)
             .exists()
     );
     assert!(cache.held_workspace_states().await.is_empty());
 }
 
 #[tokio::test]
-async fn no_reuse_key_checkout_without_session_has_no_promotion_context() {
+async fn no_reuse_key_checkout_has_no_promotion_context() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
     tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-    let cache = SessionWorkspaceCache::new(paths);
+    let cache = WorkspaceImageCache::new(paths);
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
@@ -1223,7 +1186,6 @@ async fn no_reuse_key_checkout_without_session_has_no_promotion_context() {
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: None,
-                cli_agent_session_id: None,
                 working_dir: "/workspace",
                 image_size_bytes: 5,
             },
@@ -1237,7 +1199,6 @@ async fn no_reuse_key_checkout_without_session_has_no_promotion_context() {
             .into_promotion_context(WorkspaceImagePromotionRequest {
                 run_id,
                 sandbox_id,
-                cli_agent_session_id_override: None,
                 restored_session_identity: None,
                 terminal_status: WorkspaceCacheTerminalStatus::Success,
                 completed_at: "2026-05-01T00:00:00.000Z".into(),
@@ -1249,71 +1210,21 @@ async fn no_reuse_key_checkout_without_session_has_no_promotion_context() {
 }
 
 #[tokio::test]
-async fn no_reuse_key_checkout_cannot_promote_with_late_discovered_cli_agent_session_id() {
-    let (_dir, paths, cache) = local_cache().await;
-    let run_id = RunId::new_v4();
-    let sandbox_id = sandbox::SandboxId::new_v4();
-    let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
-            identity: WorkspaceImageLeaseIdentity {
-                run_id,
-                sandbox_id,
-                profile_name: TEST_PROFILE_NAME,
-                reuse_key: None,
-                cli_agent_session_id: None,
-                working_dir: "/workspace",
-                image_size_bytes: 5,
-            },
-            workspace_drive_required: false,
-        })
-        .await;
-    tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
-        .await
-        .unwrap();
-    tokio::fs::write(paths.active_workspace_image(&sandbox_id), b"image")
-        .await
-        .unwrap();
-
-    assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::NoReuseKey);
-    assert!(
-        !lease
-            .promote(
-                run_id,
-                Some("sess-1"),
-                WorkspaceCacheTerminalStatus::Success,
-                "2026-05-01T00:00:00.000Z".into(),
-                &StorageFingerprints::default(),
-            )
-            .await
-            .unwrap(),
-        "late CLI session discovery must not create affinity for a run enqueued without a reuse key"
-    );
-
-    let cache_key = session_workspace_cache_key("sess-1", "/workspace");
-    assert!(
-        !paths
-            .session_workspace_cache_current_image(&cache_key)
-            .exists()
-    );
-}
-
-#[tokio::test]
 async fn no_lock_promotion_context_survives_reuse_active_lease() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
     tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-    let cache = SessionWorkspaceCache::new(paths);
+    let cache = WorkspaceImageCache::new(paths);
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
-    let session_id = "sess-reused-late-context";
+    let reuse_key = "thread:reused-unlocked-context";
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: None,
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace//repo/",
                 image_size_bytes: 5,
             },
@@ -1324,7 +1235,6 @@ async fn no_lock_promotion_context_survives_reuse_active_lease() {
         .into_promotion_context(WorkspaceImagePromotionRequest {
             run_id,
             sandbox_id,
-            cli_agent_session_id_override: Some(session_id),
             restored_session_identity: None,
             terminal_status: WorkspaceCacheTerminalStatus::Success,
             completed_at: "2026-05-01T00:00:00.000Z".into(),
@@ -1336,7 +1246,7 @@ async fn no_lock_promotion_context_survives_reuse_active_lease() {
         .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
             profile_name: TEST_PROFILE_NAME,
-            reuse_key: session_id,
+            reuse_key,
             working_dir: "/workspace//repo/",
             image_size_bytes: 5,
         })
@@ -1349,13 +1259,12 @@ async fn no_lock_promotion_context_survives_reuse_active_lease() {
             .into_promotion_context(WorkspaceImagePromotionRequest {
                 run_id: RunId::new_v4(),
                 sandbox_id,
-                cli_agent_session_id_override: Some(session_id),
                 restored_session_identity: None,
                 terminal_status: WorkspaceCacheTerminalStatus::Success,
                 completed_at: "2026-05-01T00:00:01.000Z".into(),
                 storage_fingerprints: StorageFingerprints::default(),
             })
             .is_some(),
-        "reusing an idle sandbox created before the CLI reported a session id must not lose the future cache promotion"
+        "converting an unlocked promotion context back into an active lease must preserve future cache promotion"
     );
 }

--- a/crates/runner/src/workspace_image_cache/tests/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/tests/sidecar.rs
@@ -11,7 +11,7 @@ use super::super::types::{
     WorkspaceSessionHistorySidecarMiss, WorkspaceSessionHistorySidecarPublication,
 };
 use super::super::{
-    SessionWorkspaceCache, WorkspaceSessionHistorySidecarPromotionSource,
+    WorkspaceImageCache, WorkspaceSessionHistorySidecarPromotionSource,
     WorkspaceSessionHistorySidecarRepresentation,
 };
 use super::support::{TEST_PROFILE_NAME, local_cache, write_current_cache_entry};
@@ -31,13 +31,13 @@ fn test_restored_session_identity(session_id: &str, history: &[u8]) -> RestoredS
 }
 
 async fn publish_test_session_history_sidecar(
-    cache: &SessionWorkspaceCache,
+    cache: &WorkspaceImageCache,
     cache_key: &str,
     run_id: RunId,
     session_id: &str,
     history: &[u8],
 ) -> RestoredSessionIdentity {
-    let tmp_path = cache.session_workspace_cache_tmp_sidecar(cache_key, run_id);
+    let tmp_path = cache.workspace_image_cache_tmp_sidecar(cache_key, run_id);
     fs::write(&tmp_path, history).await.unwrap();
     let identity = test_restored_session_identity(session_id, history);
     let source = WorkspaceSessionHistorySidecarPromotionSource {
@@ -76,7 +76,7 @@ async fn session_history_sidecar_publish_and_probe_hit() {
     let identity =
         publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
     let metadata_path = paths
-        .session_workspace_cache_entry_dir(&cache_key)
+        .workspace_image_cache_entry_dir(&cache_key)
         .join("session-history.metadata.json");
     let metadata: serde_json::Value =
         serde_json::from_slice(&fs::read(&metadata_path).await.unwrap()).unwrap();
@@ -118,7 +118,7 @@ async fn previous_session_history_sidecar_metadata_remains_restoreable() {
     let identity =
         publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
     let metadata_path = paths
-        .session_workspace_cache_entry_dir(&cache_key)
+        .workspace_image_cache_entry_dir(&cache_key)
         .join("session-history.metadata.json");
     let mut metadata: serde_json::Value =
         serde_json::from_slice(&fs::read(&metadata_path).await.unwrap()).unwrap();
@@ -181,7 +181,7 @@ async fn invalid_session_history_sidecars_are_rejected_by_probe() {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
         let run_id = RunId::new_v4();
         let session_id = "sess-sidecar-invalid-observation";
         let history = br#"{"type":"message","content":"invalid"}"#;
@@ -197,7 +197,7 @@ async fn invalid_session_history_sidecars_are_rejected_by_probe() {
         let identity =
             publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history)
                 .await;
-        let entry_dir = paths.session_workspace_cache_entry_dir(&cache_key);
+        let entry_dir = paths.workspace_image_cache_entry_dir(&cache_key);
         let metadata_path = entry_dir.join("session-history.metadata.json");
         let body_path = cache
             .probe_session_history_sidecar(&cache_key, &identity)
@@ -322,7 +322,7 @@ async fn session_history_sidecar_invalid_replacement_preserves_existing_sidecar(
     .await;
     let identity =
         publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
-    let invalid_tmp_path = cache.session_workspace_cache_tmp_sidecar(&cache_key, RunId::new_v4());
+    let invalid_tmp_path = cache.workspace_image_cache_tmp_sidecar(&cache_key, RunId::new_v4());
     fs::write(&invalid_tmp_path, b"new").await.unwrap();
     let invalid_source = WorkspaceSessionHistorySidecarPromotionSource {
         tmp_path: invalid_tmp_path,
@@ -382,47 +382,6 @@ async fn session_history_sidecar_preserve_keeps_existing_sidecar() {
 }
 
 #[tokio::test]
-async fn session_history_sidecar_reads_legacy_single_body_format() {
-    let (_dir, paths, cache) = local_cache().await;
-    let run_id = RunId::new_v4();
-    let session_id = "sess-sidecar-legacy";
-    let history = br#"{"type":"message","content":"legacy"}"#;
-    let cache_key = write_current_cache_entry(
-        &cache,
-        run_id,
-        session_id,
-        CANONICAL_WORKING_DIR,
-        "2026-05-01T00:00:00.000Z",
-        "2026-05-01T00:00:00.000Z",
-    )
-    .await;
-    let identity =
-        publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
-    let published = cache
-        .probe_session_history_sidecar(&cache_key, &identity)
-        .await
-        .unwrap();
-    let entry_dir = paths.session_workspace_cache_entry_dir(&cache_key);
-    let legacy_body_path = entry_dir.join("session-history.blob");
-    fs::rename(published.path, &legacy_body_path).await.unwrap();
-    let metadata_path = entry_dir.join("session-history.metadata.json");
-    let mut metadata: serde_json::Value =
-        serde_json::from_slice(&fs::read(&metadata_path).await.unwrap()).unwrap();
-    metadata["version"] = 1.into();
-    metadata.as_object_mut().unwrap().remove("bodySlot");
-    fs::write(&metadata_path, serde_json::to_vec(&metadata).unwrap())
-        .await
-        .unwrap();
-
-    let sidecar = cache
-        .probe_session_history_sidecar(&cache_key, &identity)
-        .await
-        .unwrap();
-    assert_eq!(sidecar.path, legacy_body_path);
-    assert_eq!(fs::read(sidecar.path).await.unwrap(), history);
-}
-
-#[tokio::test]
 async fn session_history_sidecar_failed_replacement_preserves_committed_sidecar() {
     let (_dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
@@ -444,14 +403,14 @@ async fn session_history_sidecar_failed_replacement_preserves_committed_sidecar(
         .await
         .unwrap();
     let metadata_path = paths
-        .session_workspace_cache_entry_dir(&cache_key)
+        .workspace_image_cache_entry_dir(&cache_key)
         .join("session-history.metadata.json");
     let metadata_a = fs::read(&metadata_path).await.unwrap();
 
     let replacement_run_id = RunId::new_v4();
     let history_b = br#"{"type":"message","content":"b"}"#;
     let identity_b = test_restored_session_identity("session-b", history_b);
-    let tmp_path = cache.session_workspace_cache_tmp_sidecar(&cache_key, replacement_run_id);
+    let tmp_path = cache.workspace_image_cache_tmp_sidecar(&cache_key, replacement_run_id);
     fs::write(&tmp_path, history_b).await.unwrap();
     let replacement = WorkspaceSessionHistorySidecarPromotionSource {
         tmp_path,
@@ -460,7 +419,7 @@ async fn session_history_sidecar_failed_replacement_preserves_committed_sidecar(
         restored_session_identity: identity_b,
     };
     let blocked_slot = paths
-        .session_workspace_cache_entry_dir(&cache_key)
+        .workspace_image_cache_entry_dir(&cache_key)
         .join("session-history.second.blob");
     fs::create_dir(&blocked_slot).await.unwrap();
 
@@ -507,7 +466,7 @@ async fn session_history_sidecar_verified_replacement_supersedes_previous_identi
     let history_b = br#"{"type":"message","content":"b"}"#;
     let identity_b = test_restored_session_identity("session-b", history_b);
     let replacement_run_id = RunId::new_v4();
-    let tmp_path = cache.session_workspace_cache_tmp_sidecar(&cache_key, replacement_run_id);
+    let tmp_path = cache.workspace_image_cache_tmp_sidecar(&cache_key, replacement_run_id);
     fs::write(&tmp_path, history_b).await.unwrap();
     let replacement = WorkspaceSessionHistorySidecarPromotionSource {
         tmp_path,
@@ -591,7 +550,7 @@ async fn session_history_sidecar_counts_toward_gc_candidate_and_inspection() {
     .await;
     publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
     let current_allocated = workspace_cache_path_allocated_bytes(
-        &paths.session_workspace_cache_current_image(&cache_key),
+        &paths.workspace_image_cache_current_image(&cache_key),
     )
     .await;
     let sidecar_allocated = cache

--- a/crates/runner/src/workspace_image_cache/tests/state.rs
+++ b/crates/runner/src/workspace_image_cache/tests/state.rs
@@ -13,15 +13,15 @@ use super::super::path_safety::{
     normalize_safe_guest_working_dir,
 };
 use super::super::{
-    CACHE_FORMAT_VERSION, CACHE_KEY_VERSION, SessionWorkspaceCache, WORKSPACE_DRIVE_LAYOUT,
-    WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity,
+    CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceCacheCheckoutResult,
+    WorkspaceCacheTerminalStatus, WorkspaceImageCache, WorkspaceImageLeaseIdentity,
     WorkspaceImagePrepareRequest,
 };
 use super::support::{
     TEST_PROFILE_NAME, local_cache, timestamp_for_index, write_current_cache_entry_for_profile,
 };
 use crate::ids::RunId;
-use crate::paths::{RunnerPaths, scoped_session_workspace_cache_key, session_workspace_cache_key};
+use crate::paths::{RunnerPaths, scoped_workspace_image_cache_key, workspace_image_cache_key};
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::types::{
     HeldWorkspaceState, MAX_HELD_WORKSPACE_STATES, MAX_WORKSPACE_CACHES_PER_HEARTBEAT,
@@ -29,17 +29,31 @@ use crate::types::{
 };
 
 #[test]
+fn cache_key_has_stable_current_format() {
+    assert_eq!(
+        scoped_workspace_image_cache_key(
+            "vm0/test",
+            "vm0/default",
+            "thread:thread-1",
+            "/workspace",
+            5,
+        ),
+        "fb89abd2f9a7b7784f27cdd974db105a35cc86a135a6a499e42904ba61e30bc7"
+    );
+}
+
+#[test]
 fn cache_key_separates_profile_and_image_size() {
     let base =
-        scoped_session_workspace_cache_key("vm0/test", "vm0/default", "sess-1", "/workspace", 5);
+        scoped_workspace_image_cache_key("vm0/test", "vm0/default", "sess-1", "/workspace", 5);
 
     assert_ne!(
         base,
-        scoped_session_workspace_cache_key("vm0/test", "vm0/browser", "sess-1", "/workspace", 5,)
+        scoped_workspace_image_cache_key("vm0/test", "vm0/browser", "sess-1", "/workspace", 5,)
     );
     assert_ne!(
         base,
-        scoped_session_workspace_cache_key("vm0/test", "vm0/default", "sess-1", "/workspace", 6,)
+        scoped_workspace_image_cache_key("vm0/test", "vm0/default", "sess-1", "/workspace", 6,)
     );
 }
 
@@ -192,7 +206,7 @@ async fn held_workspace_states_for_profiles_filters_and_aggregates_current_ident
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
     fs::create_dir_all(paths.base_dir()).await.unwrap();
-    let cache = SessionWorkspaceCache::new(paths);
+    let cache = WorkspaceImageCache::new(paths);
     let run_id = RunId::new_v4();
     let reuse_key = "thread:multi-profile";
     let image_size = format!("image-{reuse_key}").len() as u64;
@@ -291,7 +305,7 @@ async fn invalid_working_dir_allocates_only_required_workspace_drive() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
     tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-    let cache = SessionWorkspaceCache::new(paths);
+    let cache = WorkspaceImageCache::new(paths);
 
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
@@ -300,7 +314,6 @@ async fn invalid_working_dir_allocates_only_required_workspace_drive() {
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: Some("sess-1"),
                 working_dir: "/",
                 image_size_bytes: 1024,
             },
@@ -321,7 +334,6 @@ async fn invalid_working_dir_allocates_only_required_workspace_drive() {
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: None,
-                cli_agent_session_id: None,
                 working_dir: "/",
                 image_size_bytes: 1024,
             },
@@ -342,7 +354,6 @@ async fn invalid_working_dir_allocates_only_required_workspace_drive() {
                 sandbox_id: sandbox::SandboxId::new_v4(),
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: Some("sess-1"),
                 working_dir: "/",
                 image_size_bytes: 1024,
             },
@@ -359,7 +370,6 @@ async fn invalid_working_dir_allocates_only_required_workspace_drive() {
         !snapshot_restore_lease
             .promote(
                 RunId::new_v4(),
-                Some("sess-1"),
                 WorkspaceCacheTerminalStatus::Success,
                 local_timestamp(),
                 &StorageFingerprints::default(),
@@ -383,7 +393,6 @@ async fn prepare_normalizes_working_dir_for_cache_identity() {
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
                 reuse_key: Some("sess-1"),
-                cli_agent_session_id: Some("sess-1"),
                 working_dir: "/workspace//repo/",
                 image_size_bytes: 1024,
             },
@@ -400,7 +409,7 @@ async fn prepare_normalizes_working_dir_for_cache_identity() {
 async fn held_workspace_states_reject_metadata_under_wrong_cache_key() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().to_path_buf());
-    let cache = SessionWorkspaceCache::new(paths.clone());
+    let cache = WorkspaceImageCache::new(paths.clone());
     let run_id = RunId::new_v4();
     let key = cache.scoped_cache_key(
         TEST_PROFILE_NAME,
@@ -408,10 +417,10 @@ async fn held_workspace_states_reject_metadata_under_wrong_cache_key() {
         "/workspace",
         b"old image".len() as u64,
     );
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
-    let current = paths.session_workspace_cache_current_image(&key);
+    let current = paths.workspace_image_cache_current_image(&key);
     fs::write(&current, b"image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -420,11 +429,9 @@ async fn held_workspace_states_reject_metadata_under_wrong_cache_key() {
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
                 reuse_key: "sess-other".into(),
-                cli_agent_session_id: Some("sess-other".into()),
                 working_dir: "/workspace".into(),
                 last_completed_at: local_timestamp(),
                 last_used_at: local_timestamp(),
@@ -451,13 +458,13 @@ async fn held_workspace_states_reject_metadata_under_wrong_cache_key() {
 async fn held_workspace_states_reject_unsafe_working_dir_metadata() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().to_path_buf());
-    let cache = SessionWorkspaceCache::new(paths.clone());
+    let cache = WorkspaceImageCache::new(paths.clone());
     let run_id = RunId::new_v4();
-    let key = session_workspace_cache_key("sess-1", "/");
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+    let key = workspace_image_cache_key("sess-1", "/");
+    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
-    let current = paths.session_workspace_cache_current_image(&key);
+    let current = paths.workspace_image_cache_current_image(&key);
     fs::write(&current, b"image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -466,11 +473,9 @@ async fn held_workspace_states_reject_unsafe_working_dir_metadata() {
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
                 reuse_key: "sess-1".into(),
-                cli_agent_session_id: Some("sess-1".into()),
                 working_dir: "/".into(),
                 last_completed_at: local_timestamp(),
                 last_used_at: local_timestamp(),

--- a/crates/runner/src/workspace_image_cache/tests/storage.rs
+++ b/crates/runner/src/workspace_image_cache/tests/storage.rs
@@ -4,7 +4,7 @@ use super::super::fs::{
     allocated_bytes, has_copy_headroom, sparse_copy_with_timeout,
     workspace_cache_path_allocated_bytes,
 };
-use super::super::{CacheBudget, FsStats, GIB, SessionWorkspaceCache};
+use super::super::{CacheBudget, FsStats, GIB, WorkspaceImageCache};
 use crate::paths::RunnerPaths;
 
 #[test]
@@ -36,7 +36,7 @@ fn fs_stats_path_prefers_existing_cache_dir() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
     std::fs::create_dir_all(paths.workspace_image_cache_dir()).unwrap();
-    let cache = SessionWorkspaceCache::new(paths.clone());
+    let cache = WorkspaceImageCache::new(paths.clone());
 
     assert_eq!(
         cache.workspace_image_cache_fs_stats_path(),
@@ -49,7 +49,7 @@ fn fs_stats_path_falls_back_to_existing_parent_when_cache_dir_is_missing() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
     std::fs::create_dir_all(paths.base_dir()).unwrap();
-    let cache = SessionWorkspaceCache::new(paths.clone());
+    let cache = WorkspaceImageCache::new(paths.clone());
 
     assert_eq!(
         cache.workspace_image_cache_fs_stats_path(),

--- a/crates/runner/src/workspace_image_cache/tests/support.rs
+++ b/crates/runner/src/workspace_image_cache/tests/support.rs
@@ -3,8 +3,8 @@ use super::super::metadata::{
     WorkspaceCacheMetadata, WorkspaceCacheState, WorkspaceImageFileIdentity, WorkspaceTrust,
 };
 use super::super::{
-    CACHE_FORMAT_VERSION, CACHE_KEY_VERSION, SessionWorkspaceCache, WORKSPACE_DRIVE_LAYOUT,
-    WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
+    CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceCacheTerminalStatus,
+    WorkspaceImageCache, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
 };
 use crate::ids::RunId;
 use crate::paths::RunnerPaths;
@@ -16,18 +16,18 @@ pub(super) fn timestamp_for_index(index: usize) -> String {
     format!("2026-05-01T00:{:02}:{:02}.000Z", index / 60, index % 60)
 }
 
-pub(super) async fn local_cache() -> (tempfile::TempDir, RunnerPaths, SessionWorkspaceCache) {
+pub(super) async fn local_cache() -> (tempfile::TempDir, RunnerPaths, WorkspaceImageCache) {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
     tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-    let cache = SessionWorkspaceCache::new(paths.clone());
+    let cache = WorkspaceImageCache::new(paths.clone());
     (dir, paths, cache)
 }
 
 pub(super) async fn write_current_cache_entry(
-    cache: &SessionWorkspaceCache,
+    cache: &WorkspaceImageCache,
     run_id: RunId,
-    session_id: &str,
+    reuse_key: &str,
     working_dir: &str,
     last_completed_at: &str,
     last_used_at: &str,
@@ -36,7 +36,7 @@ pub(super) async fn write_current_cache_entry(
         cache,
         run_id,
         TEST_PROFILE_NAME,
-        session_id,
+        reuse_key,
         working_dir,
         last_completed_at,
         last_used_at,
@@ -45,20 +45,20 @@ pub(super) async fn write_current_cache_entry(
 }
 
 pub(super) async fn write_current_cache_entry_for_profile(
-    cache: &SessionWorkspaceCache,
+    cache: &WorkspaceImageCache,
     run_id: RunId,
     profile_name: &str,
-    session_id: &str,
+    reuse_key: &str,
     working_dir: &str,
     last_completed_at: &str,
     last_used_at: &str,
 ) -> String {
-    let image = format!("image-{session_id}");
-    let key = cache.scoped_cache_key(profile_name, session_id, working_dir, image.len() as u64);
-    tokio::fs::create_dir_all(cache.session_workspace_cache_entry_dir(&key))
+    let image = format!("image-{reuse_key}");
+    let key = cache.scoped_cache_key(profile_name, reuse_key, working_dir, image.len() as u64);
+    tokio::fs::create_dir_all(cache.workspace_image_cache_entry_dir(&key))
         .await
         .unwrap();
-    let current = cache.session_workspace_cache_current_image(&key);
+    let current = cache.workspace_image_cache_current_image(&key);
     tokio::fs::write(&current, image).await.unwrap();
     let current_metadata = tokio::fs::metadata(&current).await.unwrap();
     cache
@@ -67,11 +67,9 @@ pub(super) async fn write_current_cache_entry_for_profile(
             run_id,
             WorkspaceCacheMetadata {
                 format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
                 cache_scope: cache.inner.cache_scope.clone(),
                 profile_name: profile_name.into(),
-                reuse_key: session_id.into(),
-                cli_agent_session_id: Some(session_id.into()),
+                reuse_key: reuse_key.into(),
                 working_dir: working_dir.into(),
                 last_completed_at: last_completed_at.into(),
                 last_used_at: last_used_at.into(),
@@ -91,9 +89,9 @@ pub(super) async fn write_current_cache_entry_for_profile(
 }
 
 pub(super) async fn promote_current_cache_entry(
-    cache: &SessionWorkspaceCache,
+    cache: &WorkspaceImageCache,
     paths: &RunnerPaths,
-    session_id: &str,
+    reuse_key: &str,
     image: &[u8],
     last_completed_at: &str,
 ) -> String {
@@ -105,8 +103,7 @@ pub(super) async fn promote_current_cache_entry(
                 run_id,
                 sandbox_id,
                 profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: "/workspace",
                 image_size_bytes: image.len() as u64,
             },
@@ -122,7 +119,6 @@ pub(super) async fn promote_current_cache_entry(
         lease
             .promote(
                 run_id,
-                None,
                 WorkspaceCacheTerminalStatus::Success,
                 last_completed_at.into(),
                 &StorageFingerprints::default(),
@@ -132,7 +128,7 @@ pub(super) async fn promote_current_cache_entry(
     );
     cache.scoped_cache_key(
         TEST_PROFILE_NAME,
-        session_id,
+        reuse_key,
         "/workspace",
         image.len() as u64,
     )

--- a/crates/runner/src/workspace_image_cache/types.rs
+++ b/crates/runner/src/workspace_image_cache/types.rs
@@ -32,7 +32,6 @@ pub(crate) struct WorkspaceImageLeaseIdentity<'a> {
     pub(crate) sandbox_id: sandbox::SandboxId,
     pub(crate) profile_name: &'a str,
     pub(crate) reuse_key: Option<&'a str>,
-    pub(crate) cli_agent_session_id: Option<&'a str>,
     pub(crate) working_dir: &'a str,
     pub(crate) image_size_bytes: u64,
 }
@@ -105,7 +104,6 @@ impl std::fmt::Display for WorkspaceImagePromotionIdentityMismatch {
 pub(crate) struct WorkspaceImagePromotionRequest<'a> {
     pub(crate) run_id: RunId,
     pub(crate) sandbox_id: sandbox::SandboxId,
-    pub(crate) cli_agent_session_id_override: Option<&'a str>,
     pub(crate) restored_session_identity:
         Option<&'a crate::restored_session_identity::RestoredSessionIdentity>,
     pub(crate) terminal_status: WorkspaceCacheTerminalStatus,

--- a/crates/runner/src/workspace_promotion/test_support.rs
+++ b/crates/runner/src/workspace_promotion/test_support.rs
@@ -6,7 +6,7 @@ use crate::paths::RunnerPaths;
 use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::workspace_image_cache::{
-    SessionWorkspaceCache, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
+    WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus, WorkspaceImageCache,
     WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest, WorkspaceImagePromotionContext,
     WorkspaceImagePromotionOutcome, WorkspaceImagePromotionRequest,
 };
@@ -17,41 +17,25 @@ pub(crate) const TEST_WORKSPACE_IMAGE_SIZE_BYTES: u64 = TEST_WORKSPACE_IMAGE.len
 
 pub(crate) struct WorkspacePromotionFixture {
     pub(crate) _dir: tempfile::TempDir,
-    pub(crate) cache: SessionWorkspaceCache,
+    pub(crate) cache: WorkspaceImageCache,
     pub(crate) promotion: WorkspaceImagePromotionContext,
     pub(crate) sandbox_id: SandboxId,
-    pub(crate) session_id: String,
+    pub(crate) reuse_key: String,
 }
 
 impl WorkspacePromotionFixture {
-    pub(crate) async fn new(session_id: &str) -> Self {
-        Self::new_with_restored_session_identity(session_id, None).await
+    pub(crate) async fn new(reuse_key: &str) -> Self {
+        Self::new_with_restored_session_identity(reuse_key, None).await
     }
 
     pub(crate) async fn new_with_restored_session_identity(
-        session_id: &str,
-        restored_session_identity: Option<&RestoredSessionIdentity>,
-    ) -> Self {
-        Self::new_with_lease_session_id(session_id, Some(session_id), restored_session_identity)
-            .await
-    }
-
-    pub(crate) async fn new_late_session_with_restored_session_identity(
-        session_id: &str,
-        restored_session_identity: &RestoredSessionIdentity,
-    ) -> Self {
-        Self::new_with_lease_session_id(session_id, None, Some(restored_session_identity)).await
-    }
-
-    async fn new_with_lease_session_id(
-        session_id: &str,
-        lease_session_id: Option<&str>,
+        reuse_key: &str,
         restored_session_identity: Option<&RestoredSessionIdentity>,
     ) -> Self {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-        let cache = SessionWorkspaceCache::new(paths.clone());
+        let cache = WorkspaceImageCache::new(paths.clone());
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let workspace_image = cache
@@ -60,8 +44,7 @@ impl WorkspacePromotionFixture {
                     run_id,
                     sandbox_id,
                     profile_name: "vm0/default",
-                    reuse_key: Some(session_id),
-                    cli_agent_session_id: lease_session_id,
+                    reuse_key: Some(reuse_key),
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: TEST_WORKSPACE_IMAGE_SIZE_BYTES,
                 },
@@ -81,7 +64,6 @@ impl WorkspacePromotionFixture {
             .into_promotion_context(WorkspaceImagePromotionRequest {
                 run_id,
                 sandbox_id,
-                cli_agent_session_id_override: Some(session_id),
                 restored_session_identity,
                 terminal_status: WorkspaceCacheTerminalStatus::Success,
                 completed_at: TEST_COMPLETED_AT.into(),
@@ -94,12 +76,12 @@ impl WorkspacePromotionFixture {
             cache,
             promotion,
             sandbox_id,
-            session_id: session_id.into(),
+            reuse_key: reuse_key.into(),
         }
     }
 
-    pub(crate) async fn new_from_cache_hit(session_id: &str) -> Self {
-        let seed = Self::new(session_id).await;
+    pub(crate) async fn new_from_cache_hit(reuse_key: &str) -> Self {
+        let seed = Self::new(reuse_key).await;
         assert_eq!(
             seed.promotion.promote().await.unwrap(),
             WorkspaceImagePromotionOutcome::Promoted
@@ -109,7 +91,7 @@ impl WorkspacePromotionFixture {
             cache,
             promotion,
             sandbox_id: _,
-            session_id,
+            reuse_key,
         } = seed;
         drop(promotion);
 
@@ -121,8 +103,7 @@ impl WorkspacePromotionFixture {
                     run_id,
                     sandbox_id,
                     profile_name: "vm0/default",
-                    reuse_key: Some(&session_id),
-                    cli_agent_session_id: Some(&session_id),
+                    reuse_key: Some(&reuse_key),
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: TEST_WORKSPACE_IMAGE_SIZE_BYTES,
                 },
@@ -134,7 +115,6 @@ impl WorkspacePromotionFixture {
             .into_promotion_context(WorkspaceImagePromotionRequest {
                 run_id,
                 sandbox_id,
-                cli_agent_session_id_override: Some(&session_id),
                 restored_session_identity: None,
                 terminal_status: WorkspaceCacheTerminalStatus::Success,
                 completed_at: "2026-06-04T00:00:00.000Z".into(),
@@ -147,13 +127,13 @@ impl WorkspacePromotionFixture {
             cache,
             promotion,
             sandbox_id,
-            session_id,
+            reuse_key,
         }
     }
 
     pub(crate) async fn checkout_result(
-        cache: &SessionWorkspaceCache,
-        session_id: &str,
+        cache: &WorkspaceImageCache,
+        reuse_key: &str,
     ) -> WorkspaceCacheCheckoutResult {
         cache
             .prepare(WorkspaceImagePrepareRequest {
@@ -161,8 +141,7 @@ impl WorkspacePromotionFixture {
                     run_id: RunId::new_v4(),
                     sandbox_id: SandboxId::new_v4(),
                     profile_name: "vm0/default",
-                    reuse_key: Some(session_id),
-                    cli_agent_session_id: Some(session_id),
+                    reuse_key: Some(reuse_key),
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: TEST_WORKSPACE_IMAGE_SIZE_BYTES,
                 },

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -295,16 +295,17 @@ async fn parked_workspace_promotion_unparks_and_freezes_before_publish() {
     assert!(promoted);
     let states = fixture.cache.held_workspace_states().await;
     assert_eq!(states.len(), 1);
-    assert_eq!(states[0].reuse_key, fixture.session_id);
+    assert_eq!(states[0].reuse_key, fixture.reuse_key);
 }
 
 #[tokio::test]
 async fn active_workspace_promotion_exports_session_history_sidecar() {
+    let reuse_key = "thread:active-sidecar-promote";
     let session_id = "sess-active-sidecar-promote";
     let history = br#"{"type":"message","content":"cached"}"#;
     let restored_identity = test_restored_session_identity(session_id, history);
     let fixture = WorkspacePromotionFixture::new_with_restored_session_identity(
-        session_id,
+        reuse_key,
         Some(&restored_identity),
     )
     .await;
@@ -382,8 +383,7 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),
                 profile_name: "vm0/default",
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: TEST_WORKSPACE_IMAGE_SIZE_BYTES,
             },
@@ -400,11 +400,12 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn active_workspace_promotion_keeps_history_read_failure_warning() {
+    let reuse_key = "thread:active-sidecar-read-failure";
     let session_id = "sess-active-sidecar-read-failure";
     let history = br#"{"type":"message","content":"read failure"}"#;
     let restored_identity = test_restored_session_identity(session_id, history);
     let fixture = WorkspacePromotionFixture::new_with_restored_session_identity(
-        session_id,
+        reuse_key,
         Some(&restored_identity),
     )
     .await;
@@ -433,13 +434,14 @@ async fn active_workspace_promotion_keeps_history_read_failure_warning() {
 }
 
 #[tokio::test]
-async fn late_session_sidecar_staging_is_protected_from_gc() {
+async fn session_history_sidecar_staging_is_protected_from_gc() {
+    let reuse_key = "thread:late-sidecar-gc";
     let session_id = "sess-late-sidecar-gc";
     let history = br#"{"type":"message","content":"late cached"}"#;
     let restored_identity = test_restored_session_identity(session_id, history);
-    let fixture = WorkspacePromotionFixture::new_late_session_with_restored_session_identity(
-        session_id,
-        &restored_identity,
+    let fixture = WorkspacePromotionFixture::new_with_restored_session_identity(
+        reuse_key,
+        Some(&restored_identity),
     )
     .await;
     let cache = fixture.cache.clone();
@@ -486,8 +488,7 @@ async fn late_session_sidecar_staging_is_protected_from_gc() {
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),
                 profile_name: "vm0/default",
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: TEST_WORKSPACE_IMAGE_SIZE_BYTES,
             },
@@ -503,13 +504,14 @@ async fn late_session_sidecar_staging_is_protected_from_gc() {
 }
 
 #[tokio::test]
-async fn late_session_sidecar_staging_cleans_source_and_unlocks_when_cancelled() {
+async fn session_history_sidecar_staging_cleans_source_and_unlocks_when_cancelled() {
+    let reuse_key = "thread:late-sidecar-cancelled";
     let session_id = "sess-late-sidecar-cancelled";
     let history = br#"{"type":"message","content":"cancelled"}"#;
     let restored_identity = test_restored_session_identity(session_id, history);
-    let fixture = WorkspacePromotionFixture::new_late_session_with_restored_session_identity(
-        session_id,
-        &restored_identity,
+    let fixture = WorkspacePromotionFixture::new_with_restored_session_identity(
+        reuse_key,
+        Some(&restored_identity),
     )
     .await;
     let cache = fixture.cache.clone();
@@ -551,8 +553,7 @@ async fn late_session_sidecar_staging_cleans_source_and_unlocks_when_cancelled()
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),
                 profile_name: "vm0/default",
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: TEST_WORKSPACE_IMAGE_SIZE_BYTES,
             },
@@ -563,13 +564,14 @@ async fn late_session_sidecar_staging_cleans_source_and_unlocks_when_cancelled()
 }
 
 #[tokio::test]
-async fn late_session_sidecar_staging_cleans_source_and_unlocks_after_freeze_failure() {
+async fn session_history_sidecar_staging_cleans_source_and_unlocks_after_freeze_failure() {
+    let reuse_key = "thread:late-sidecar-freeze-failure";
     let session_id = "sess-late-sidecar-freeze-failure";
     let history = br#"{"type":"message","content":"freeze"}"#;
     let restored_identity = test_restored_session_identity(session_id, history);
-    let fixture = WorkspacePromotionFixture::new_late_session_with_restored_session_identity(
-        session_id,
-        &restored_identity,
+    let fixture = WorkspacePromotionFixture::new_with_restored_session_identity(
+        reuse_key,
+        Some(&restored_identity),
     )
     .await;
     let cache = fixture.cache.clone();
@@ -605,8 +607,7 @@ async fn late_session_sidecar_staging_cleans_source_and_unlocks_after_freeze_fai
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),
                 profile_name: "vm0/default",
-                reuse_key: Some(session_id),
-                cli_agent_session_id: Some(session_id),
+                reuse_key: Some(reuse_key),
                 working_dir: CANONICAL_WORKING_DIR,
                 image_size_bytes: TEST_WORKSPACE_IMAGE_SIZE_BYTES,
             },
@@ -643,7 +644,7 @@ async fn parked_workspace_promotion_unpark_error_skips_cache() {
 async fn parked_workspace_promotion_unpark_error_abandons_consumed_cache_hit() {
     let fixture = WorkspacePromotionFixture::new_from_cache_hit("sess-hit-unpark-error").await;
     let cache = fixture.cache.clone();
-    let session_id = fixture.session_id.clone();
+    let reuse_key = fixture.reuse_key.clone();
     let overrides = Arc::new(MockSandboxOverrides::new());
     overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
         transition: sandbox::SandboxIdleTransition::Unpark,
@@ -661,52 +662,58 @@ async fn parked_workspace_promotion_unpark_error_abandons_consumed_cache_hit() {
     assert!(prepared.is_none());
     assert_eq!(overrides.unpark_call_count(), 1);
     assert_eq!(
-        WorkspacePromotionFixture::checkout_result(&cache, &session_id).await,
+        WorkspacePromotionFixture::checkout_result(&cache, &reuse_key).await,
         WorkspaceCacheCheckoutResult::Miss
     );
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn parked_workspace_promotion_warning_hashes_reuse_key() {
-    let reuse_key = "thread:sensitive-promotion-17975";
-    let fixture = WorkspacePromotionFixture::new(reuse_key).await;
-    let overrides = Arc::new(MockSandboxOverrides::new());
-    overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
-        transition: sandbox::SandboxIdleTransition::Unpark,
-        message: "simulated unpark failure".into(),
-    }));
-    let mut sandbox = mock_sandbox_with_overrides(fixture.sandbox_id, Arc::clone(&overrides)).await;
+async fn parked_workspace_promotion_warning_hashes_and_classifies_reuse_key() {
+    for (reuse_key, expected_kind) in [
+        ("thread:sensitive-promotion-17975", "thread"),
+        ("opaque-sensitive-promotion-17975", "other"),
+    ] {
+        let fixture = WorkspacePromotionFixture::new(reuse_key).await;
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
+            transition: sandbox::SandboxIdleTransition::Unpark,
+            message: "simulated unpark failure".into(),
+        }));
+        let mut sandbox =
+            mock_sandbox_with_overrides(fixture.sandbox_id, Arc::clone(&overrides)).await;
 
-    let (prepared, events) = capture_promotion_events(prepare_workspace_image_from_parked_sandbox(
-        sandbox.as_mut(),
-        Some(fixture.promotion),
-        "test",
-    ))
-    .await;
+        let (prepared, events) =
+            capture_promotion_events(prepare_workspace_image_from_parked_sandbox(
+                sandbox.as_mut(),
+                Some(fixture.promotion),
+                "test",
+            ))
+            .await;
 
-    assert!(prepared.is_none());
-    let event = captured_event(
-        &events,
-        "workspace image cache promotion skipped because idle sandbox unpark failed",
-    );
-    assert_eq!(
-        event
-            .fields
-            .get("reuse_key_fingerprint")
-            .map(String::as_str),
-        Some(crate::paths::short_digest(reuse_key).as_str())
-    );
-    assert_eq!(
-        event.fields.get("reuse_key_kind").map(String::as_str),
-        Some("thread")
-    );
-    assert!(
-        event
-            .fields
-            .values()
-            .all(|value| !value.contains(reuse_key)),
-        "workspace promotion logs must not contain the raw reuse key"
-    );
+        assert!(prepared.is_none());
+        let event = captured_event(
+            &events,
+            "workspace image cache promotion skipped because idle sandbox unpark failed",
+        );
+        assert_eq!(
+            event
+                .fields
+                .get("reuse_key_fingerprint")
+                .map(String::as_str),
+            Some(crate::paths::short_digest(reuse_key).as_str())
+        );
+        assert_eq!(
+            event.fields.get("reuse_key_kind").map(String::as_str),
+            Some(expected_kind)
+        );
+        assert!(
+            event
+                .fields
+                .values()
+                .all(|value| !value.contains(reuse_key)),
+            "workspace promotion logs must not contain the raw reuse key"
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- remove provider session ownership from runner-local workspace image cache metadata and plumbing
- replace the retired cache key namespace and metadata shape with one current, versioned format
- remove the legacy single-body session history sidecar path while retaining the crash-safe two-slot format
- rename remaining session-owned cache vocabulary and obsolete telemetry action names around reuse keys
- keep exact provider session identity only where sandbox reuse, completion, and session history require it

## Rollout

- existing runner-local cache entries intentionally become cold misses and remain reclaimable by generic GC
- missing session history sidecars continue to fall back to authoritative remote history
- this does not change API contracts, database schema, heartbeat persistence, or affinity queries

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- exhaustive searches for retired cache types, paths, versions, modules, and telemetry action names

Closes #24387

Parent: #24375
