### PR TITLE
refactor: claim teams launch context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -18,6 +18,7 @@ import {
   findPendingChatEventInputParamsByPromptFixture,
   readChatEventContextFixture,
   readChatEventInputParamsFixture,
+  replaceTeamsLaunchMaterialWithLegacyParamsFixture,
 } from "../../../test-fixtures/chat-events";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { zeroTeamsConnectRoutes } from "../zero-teams-connect";
@@ -445,6 +446,7 @@ async function postTeamsPersonalMessage(args: {
   readonly activityId: string;
   readonly threadId?: string;
   readonly text: string;
+  readonly omitRecipient?: boolean;
 }): Promise<void> {
   const response = await postTeamsActivityForTest({
     signal: context.signal,
@@ -464,6 +466,7 @@ async function postTeamsPersonalMessage(args: {
       text: args.text,
       entities: [],
       replyToId: args.threadId ?? null,
+      ...(args.omitRecipient ? { recipient: undefined } : {}),
     }),
   });
   expect(response.status).toBe(200);
@@ -623,7 +626,7 @@ afterEach(async () => {
 });
 
 describe("Teams chat callbacks", () => {
-  it("keeps queued Teams transport params until the input is claimed", async () => {
+  it("claims Teams launch material from context with a legacy fallback", async () => {
     const teams = await setupConnectedTeamsActor();
     teamsApiMocks({ serviceUrl: teams.fixture.serviceUrl });
     const firstRunId = await dispatchTeamsPersonalRun({
@@ -636,7 +639,7 @@ describe("Teams chat callbacks", () => {
       runId: firstRunId,
     });
 
-    const queuedPrompt = "claim Teams queue transport params";
+    const queuedPrompt = "claim Teams launch context";
     await postTeamsPersonalMessage({
       fixture: teams.fixture,
       activityId: "activity-queue-params-second",
@@ -681,27 +684,70 @@ describe("Teams chat callbacks", () => {
         orgId: teams.fixture.orgId,
         userId: teams.fixture.userId,
       }),
-    ).resolves.toMatchObject({
-      version: 1,
-      prompt: queuedPrompt,
-      appendSystemPrompt: expect.stringContaining(
-        "You are currently running inside: Microsoft Teams",
-      ),
-      teamsDelivery: {
-        tenantId: teams.fixture.teamsTenantId,
-        conversationId: `a:personal-${teams.fixture.teamsUserId}`,
-        threadId: `direct-message:${teams.defaultAgentId}:claude-sonnet-4-6`,
-        serviceUrl: teams.fixture.serviceUrl,
-        teamsUserId: teams.fixture.teamsUserId,
-        botId: "28:bot-1",
-        botName: "Zero",
-      },
-      userInfoExtras: {
+    ).resolves.toStrictEqual({ version: 1 });
+
+    const legacyPrompt = "claim legacy Teams launch params";
+    await postTeamsPersonalMessage({
+      fixture: teams.fixture,
+      activityId: "activity-queue-params-legacy",
+      text: legacyPrompt,
+    });
+    const legacyParams =
+      await findPendingChatEventInputParamsByPromptFixture(legacyPrompt);
+    if (!legacyParams) {
+      throw new Error("Expected queued legacy Teams params");
+    }
+    const legacyContext = await readChatEventContextFixture(
+      legacyParams.eventId,
+    );
+    if (!legacyContext?.teamsConnectionId) {
+      throw new Error("Expected queued legacy Teams context");
+    }
+    const legacyIntegrationPrompt = [
+      "# Current Integration",
+      "You are currently running inside: Microsoft Teams",
+      `Tenant ID: ${teams.fixture.teamsTenantId}`,
+      `Tenant name: ${teams.fixture.teamsTenantName}`,
+      `Conversation ID: a:personal-${teams.fixture.teamsUserId}`,
+      "Conversation type: personal",
+      "Thread ID: activity-queue-params-legacy",
+      "Activity ID: activity-queue-params-legacy",
+      `Teams app ID: ${BOT_APP_ID}`,
+      "Bot ID: 28:bot-1",
+      "Bot name: Zero",
+    ].join("\n");
+    await replaceTeamsLaunchMaterialWithLegacyParamsFixture(
+      legacyParams.eventId,
+      {
+        orgId: teams.fixture.orgId,
+        userId: teams.fixture.userId,
+        prompt: legacyPrompt,
+        appendSystemPrompt: legacyIntegrationPrompt,
+        teamsDelivery: {
+          tenantId: teams.fixture.teamsTenantId,
+          tenantName: teams.fixture.teamsTenantName,
+          teamId: null,
+          teamName: null,
+          channelId: null,
+          conversationId: `a:personal-${teams.fixture.teamsUserId}`,
+          conversationType: "personal",
+          threadId: `direct-message:${teams.defaultAgentId}:claude-sonnet-4-6`,
+          activityId: "activity-queue-params-legacy",
+          serviceUrl: teams.fixture.serviceUrl,
+          connectionId: legacyContext.teamsConnectionId,
+          teamsUserId: teams.fixture.teamsUserId,
+          teamsUserDisplayName: "Ada Lovelace",
+          teamsUserPrincipalName: "ada@example.com",
+          botId: "28:bot-1",
+          botName: "Zero",
+          files: [],
+        },
         teamsUserDisplayName: "Ada Lovelace",
         teamsUserPrincipalName: "ada@example.com",
         teamsUserId: teams.fixture.teamsUserId,
       },
-    });
+    );
+
     await completeSandboxRun({
       runId: firstRunId,
       sandboxToken: firstClaim.sandboxToken,
@@ -715,9 +761,89 @@ describe("Teams chat callbacks", () => {
       runnerGroup: teams.runnerGroup,
       runId: queuedRunId,
     });
+    const queuedRun = (
+      await runsApi.listAgentRuns(teams.actor, { limit: 20 })
+    ).runs.find((run) => {
+      return run.id === queuedRunId;
+    });
+    expect(queuedClaim.prompt).toBe(queuedRun?.prompt);
+    expect(queuedClaim.appendSystemPrompt).toBe(queuedRun?.appendSystemPrompt);
     expect(queuedClaim.appendSystemPrompt).toContain(
       "You are currently running inside: Microsoft Teams",
     );
+    expect(queuedClaim.appendSystemPrompt).toContain(
+      "Thread ID: activity-queue-params-second",
+    );
+
+    await completeSandboxRun({
+      runId: queuedRunId,
+      sandboxToken: queuedClaim.sandboxToken,
+      exitCode: 0,
+    });
+    const legacyRunId = await runIdForPrompt(teams.actor, legacyPrompt);
+    const legacyClaim = await claimTeamsRun({
+      runnerGroup: teams.runnerGroup,
+      runId: legacyRunId,
+    });
+    expect(legacyClaim.prompt).toBe(legacyPrompt);
+    expect(legacyClaim.appendSystemPrompt).toContain(legacyIntegrationPrompt);
+    await expect(
+      readChatEventInputParamsFixture(legacyParams.eventId),
+    ).resolves.toBeNull();
+    await runsApi.requestCancelRun(teams.actor, legacyRunId, [200]);
+  });
+
+  it("falls back to installation bot identity when the activity omits it", async () => {
+    const teams = await setupConnectedTeamsActor();
+    teamsApiMocks({ serviceUrl: teams.fixture.serviceUrl });
+    const firstRunId = await dispatchTeamsPersonalRun({
+      fixture: teams.fixture,
+      activityId: "activity-bot-fallback-first",
+      text: "hold the Teams bot fallback queue",
+    });
+    const firstClaim = await claimTeamsRun({
+      runnerGroup: teams.runnerGroup,
+      runId: firstRunId,
+    });
+
+    const queuedPrompt = "claim without an activity recipient";
+    await postTeamsPersonalMessage({
+      fixture: teams.fixture,
+      activityId: "activity-bot-fallback-second",
+      text: queuedPrompt,
+      omitRecipient: true,
+    });
+    const queuedParams =
+      await findPendingChatEventInputParamsByPromptFixture(queuedPrompt);
+    if (!queuedParams) {
+      throw new Error("Expected queued Teams bot fallback params");
+    }
+    await expect(
+      readChatEventContextFixture(queuedParams.eventId),
+    ).resolves.toMatchObject({
+      teamsBotId: null,
+      teamsBotName: null,
+    });
+    await expect(
+      decryptChatEventInputParamsFixture(queuedParams.eventId, {
+        orgId: teams.fixture.orgId,
+        userId: teams.fixture.userId,
+      }),
+    ).resolves.toStrictEqual({ version: 1 });
+
+    await completeSandboxRun({
+      runId: firstRunId,
+      sandboxToken: firstClaim.sandboxToken,
+      exitCode: 0,
+    });
+    const queuedRunId = await runIdForPrompt(teams.actor, queuedPrompt);
+    const queuedClaim = await claimTeamsRun({
+      runnerGroup: teams.runnerGroup,
+      runId: queuedRunId,
+    });
+    expect(queuedClaim.prompt).toBe(queuedPrompt);
+    expect(queuedClaim.appendSystemPrompt).toContain("Bot ID: 28:bot-1");
+    expect(queuedClaim.appendSystemPrompt).toContain("Bot name: Zero");
     await runsApi.requestCancelRun(teams.actor, queuedRunId, [200]);
   });
 

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -174,6 +174,10 @@ import {
   loadFeishuQueuedLaunchMaterial,
   type FeishuQueuedLaunchMaterial,
 } from "./feishu-queued-launch-context.service";
+import {
+  loadTeamsQueuedLaunchMaterial,
+  type TeamsQueuedLaunchMaterial,
+} from "./teams-queued-launch-context.service";
 
 const log = logger("callback:chat");
 const PG_FOREIGN_KEY_VIOLATION = "23503";
@@ -2677,12 +2681,12 @@ function slackQueuedMessageAdmissionFailure(
 function teamsQueuedMessageAdmissionFailure(
   args: CreateQueuedChatRunInputArgs,
   sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
+  teamsLaunchMaterial: TeamsQueuedLaunchMaterial | null,
   error: QueuedMessageModelRouteError,
 ): TeamsQueuedMessageAdmissionFailure | null {
-  if (
-    args.queuedMessage.triggerSource !== "teams" ||
-    !sourceParams?.teamsDelivery
-  ) {
+  const teamsDelivery =
+    teamsLaunchMaterial?.teamsDelivery ?? sourceParams?.teamsDelivery;
+  if (args.queuedMessage.triggerSource !== "teams" || !teamsDelivery) {
     return null;
   }
   return {
@@ -2692,7 +2696,7 @@ function teamsQueuedMessageAdmissionFailure(
     agentId: args.agent.id,
     threadId: args.threadId,
     queuedMessage: args.queuedMessage,
-    teamsDelivery: sourceParams.teamsDelivery,
+    teamsDelivery,
     error,
   };
 }
@@ -2787,11 +2791,17 @@ function queuedMessageAdmissionFailure(
   args: CreateQueuedChatRunInputArgs,
   sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
   slackLaunchMaterial: SlackQueuedLaunchMaterial | null,
+  teamsLaunchMaterial: TeamsQueuedLaunchMaterial | null,
   error: QueuedMessageModelRouteError,
 ): QueuedMessageAdmissionFailure | null {
   return (
     slackQueuedMessageAdmissionFailure(args, slackLaunchMaterial, error) ??
-    teamsQueuedMessageAdmissionFailure(args, sourceParams, error) ??
+    teamsQueuedMessageAdmissionFailure(
+      args,
+      sourceParams,
+      teamsLaunchMaterial,
+      error,
+    ) ??
     telegramQueuedMessageAdmissionFailure(args, sourceParams, error) ??
     agentPhoneQueuedMessageAdmissionFailure(args, sourceParams, error) ??
     githubQueuedMessageAdmissionFailure(args, sourceParams, error) ??
@@ -2803,6 +2813,7 @@ function queuedIntegrationDeliveries(
   sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
   slackLaunchMaterial: SlackQueuedLaunchMaterial | null,
   feishuLaunchMaterial: FeishuQueuedLaunchMaterial | null,
+  teamsLaunchMaterial: TeamsQueuedLaunchMaterial | null,
 ): Pick<
   CreateQueuedChatRunInput,
   | "slackDelivery"
@@ -2816,7 +2827,8 @@ function queuedIntegrationDeliveries(
   return {
     slackDelivery: slackLaunchMaterial?.slackDelivery,
     feishuDelivery: feishuLaunchMaterial?.feishuDelivery,
-    teamsDelivery: sourceParams?.teamsDelivery,
+    teamsDelivery:
+      teamsLaunchMaterial?.teamsDelivery ?? sourceParams?.teamsDelivery,
     telegramDelivery: sourceParams?.telegramDelivery,
     agentphoneDelivery: sourceParams?.agentphoneDelivery,
     githubDelivery: sourceParams?.githubDelivery,
@@ -2860,10 +2872,37 @@ async function resolveFeishuQueuedLaunchMaterial(
   throw new Error("Feishu queue item is missing launch material");
 }
 
+async function resolveTeamsQueuedLaunchMaterial(
+  args: CreateQueuedChatRunInputArgs,
+  sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
+): Promise<TeamsQueuedLaunchMaterial | null> {
+  if (args.queuedMessage.triggerSource !== "teams") {
+    return null;
+  }
+  const material = await loadTeamsQueuedLaunchMaterial(args.db, {
+    eventId: args.queuedMessage.id,
+    chatThreadId: args.threadId,
+    orgId: args.agent.orgId,
+    userId: args.userId,
+  });
+  if (material) {
+    return material;
+  }
+  if (
+    sourceParams?.prompt === undefined ||
+    sourceParams.appendSystemPrompt === undefined ||
+    !sourceParams.teamsDelivery
+  ) {
+    throw new Error("Teams queue item is missing launch material");
+  }
+  return null;
+}
+
 function queuedMessagePrompt(args: {
   readonly triggerSource: QueuedUserMessage["triggerSource"];
   readonly slackLaunchMaterial: SlackQueuedLaunchMaterial | null;
   readonly feishuLaunchMaterial: FeishuQueuedLaunchMaterial | null;
+  readonly teamsLaunchMaterial: TeamsQueuedLaunchMaterial | null;
   readonly sourceParams: Awaited<
     ReturnType<typeof decryptQueuedUserMessageRunParams>
   >;
@@ -2881,6 +2920,9 @@ function queuedMessagePrompt(args: {
     }
     return args.feishuLaunchMaterial.prompt;
   }
+  if (args.triggerSource === "teams") {
+    return args.teamsLaunchMaterial?.prompt ?? args.sourceParams?.prompt ?? "";
+  }
   if (args.triggerSource === "workflow-schedule") {
     return args.sourceParams?.prompt ?? args.projectedPrompt;
   }
@@ -2891,6 +2933,7 @@ function queuedIntegrationPrompt(args: {
   readonly triggerSource: QueuedUserMessage["triggerSource"];
   readonly slackLaunchMaterial: SlackQueuedLaunchMaterial | null;
   readonly feishuLaunchMaterial: FeishuQueuedLaunchMaterial | null;
+  readonly teamsLaunchMaterial: TeamsQueuedLaunchMaterial | null;
   readonly sourceParams: Awaited<
     ReturnType<typeof decryptQueuedUserMessageRunParams>
   >;
@@ -2906,6 +2949,13 @@ function queuedIntegrationPrompt(args: {
       throw new Error("Feishu queue item is missing launch material");
     }
     return args.feishuLaunchMaterial.appendSystemPrompt;
+  }
+  if (args.triggerSource === "teams") {
+    return (
+      args.teamsLaunchMaterial?.appendSystemPrompt ??
+      args.sourceParams?.appendSystemPrompt ??
+      buildWebChatPrompt()
+    );
   }
   return args.sourceParams?.appendSystemPrompt ?? buildWebChatPrompt();
 }
@@ -2944,14 +2994,64 @@ async function loadQueuedLaunchMaterials(args: CreateQueuedChatRunInputArgs) {
   }
   const slackLaunchMaterial = await resolveSlackQueuedLaunchMaterial(args);
   const feishuLaunchMaterial = await resolveFeishuQueuedLaunchMaterial(args);
-  return { sourceParams, slackLaunchMaterial, feishuLaunchMaterial };
+  const teamsLaunchMaterial = await resolveTeamsQueuedLaunchMaterial(
+    args,
+    sourceParams,
+  );
+  return {
+    sourceParams,
+    slackLaunchMaterial,
+    feishuLaunchMaterial,
+    teamsLaunchMaterial,
+  };
+}
+
+function queuedUserMessageProjection(
+  message: QueuedUserMessage["userMessage"],
+  inlineTemplatesEnabled: boolean,
+) {
+  const queuedUserMessage = requiredUserMessageForEvent(
+    "input.prompt",
+    message,
+  );
+  if (!queuedUserMessage) {
+    throw new Error("Queued input event is missing userMessage");
+  }
+  return projectUserMessage(queuedUserMessage, {
+    inlineTemplates: inlineTemplatesEnabled,
+  });
+}
+
+function queuedIntegrationLaunchFields(
+  sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
+  slackLaunchMaterial: SlackQueuedLaunchMaterial | null,
+  feishuLaunchMaterial: FeishuQueuedLaunchMaterial | null,
+  teamsLaunchMaterial: TeamsQueuedLaunchMaterial | null,
+) {
+  return {
+    ...queuedIntegrationDeliveries(
+      sourceParams,
+      slackLaunchMaterial,
+      feishuLaunchMaterial,
+      teamsLaunchMaterial,
+    ),
+    userInfoExtras:
+      slackLaunchMaterial?.userInfoExtras ??
+      feishuLaunchMaterial?.userInfoExtras ??
+      teamsLaunchMaterial?.userInfoExtras ??
+      sourceParams?.userInfoExtras,
+  };
 }
 
 async function buildCreateQueuedChatRunInput(
   args: CreateQueuedChatRunInputArgs,
 ): Promise<CreateQueuedChatRunInput | QueuedMessageAdmissionFailure | null> {
-  const { sourceParams, slackLaunchMaterial, feishuLaunchMaterial } =
-    await loadQueuedLaunchMaterials(args);
+  const {
+    sourceParams,
+    slackLaunchMaterial,
+    feishuLaunchMaterial,
+    teamsLaunchMaterial,
+  } = await loadQueuedLaunchMaterials(args);
   const modelRouteResolution = await resolveQueuedMessageModelRoute({
     db: args.db,
     threadId: args.threadId,
@@ -2965,6 +3065,7 @@ async function buildCreateQueuedChatRunInput(
       args,
       sourceParams,
       slackLaunchMaterial,
+      teamsLaunchMaterial,
       modelRouteResolution.error,
     );
   }
@@ -2982,16 +3083,10 @@ async function buildCreateQueuedChatRunInput(
     FeatureSwitchKey.StructuredPromptInlineTemplates,
     featureSwitchContext,
   );
-  const queuedUserMessage = requiredUserMessageForEvent(
-    "input.prompt",
+  const userMessageProjection = queuedUserMessageProjection(
     args.queuedMessage.userMessage,
+    inlineTemplatesEnabled,
   );
-  if (!queuedUserMessage) {
-    throw new Error("Queued input event is missing userMessage");
-  }
-  const userMessageProjection = projectUserMessage(queuedUserMessage, {
-    inlineTemplates: inlineTemplatesEnabled,
-  });
   const incompleteContext = startNewSession ? "" : loadedIncompleteContext;
   const priorContext = await measureChatCallbackPreCreateTiming(
     args.timing,
@@ -3031,6 +3126,7 @@ async function buildCreateQueuedChatRunInput(
     triggerSource: args.queuedMessage.triggerSource,
     slackLaunchMaterial,
     feishuLaunchMaterial,
+    teamsLaunchMaterial,
     sourceParams,
     projectedPrompt: userMessageProjection.agentPrompt,
   });
@@ -3045,6 +3141,7 @@ async function buildCreateQueuedChatRunInput(
         triggerSource: args.queuedMessage.triggerSource,
         slackLaunchMaterial,
         feishuLaunchMaterial,
+        teamsLaunchMaterial,
         sourceParams,
       }),
       incompleteContext,
@@ -3065,16 +3162,13 @@ async function buildCreateQueuedChatRunInput(
       FeatureSwitchKey.RealAgentInPreview,
       featureSwitchContext,
     ),
-    ...queuedIntegrationDeliveries(
+    ...queuedIntegrationLaunchFields(
       sourceParams,
       slackLaunchMaterial,
       feishuLaunchMaterial,
+      teamsLaunchMaterial,
     ),
     apiStartTime: args.queuedMessage.createdAt.getTime(),
-    userInfoExtras:
-      slackLaunchMaterial?.userInfoExtras ??
-      feishuLaunchMaterial?.userInfoExtras ??
-      sourceParams?.userInfoExtras,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/teams-prompt.ts
+++ b/turbo/apps/api/src/signals/services/teams-prompt.ts
@@ -16,7 +16,11 @@ export function appendTeamsFilesToPrompt(
     return prompt;
   }
 
-  const fileContext = files.map(formatTeamsFileForContext).join("\n");
+  const fileContext = files
+    .map((file) => {
+      return `[Web file] ${file.name} (${file.contentType})\n   [ID] ${file.fileId}`;
+    })
+    .join("\n");
   return [prompt, fileContext]
     .filter((part) => {
       return part.length > 0;

--- a/turbo/apps/api/src/signals/services/teams-prompt.ts
+++ b/turbo/apps/api/src/signals/services/teams-prompt.ts
@@ -1,0 +1,70 @@
+import type { ChatTeamsMessageFile } from "@vm0/db/jsonb-contracts/chat-teams-context";
+
+export function formatTeamsFileForContext(file: ChatTeamsMessageFile): string {
+  return [
+    `[Teams file] ${file.name} (${file.contentType})`,
+    ...(file.sourceId ? [`   [Teams attachment ID] ${file.sourceId}`] : []),
+    `   [ID] ${file.fileId}`,
+  ].join("\n");
+}
+
+export function appendTeamsFilesToPrompt(
+  prompt: string,
+  files: readonly ChatTeamsMessageFile[],
+): string {
+  if (files.length === 0) {
+    return prompt;
+  }
+
+  const fileContext = files.map(formatTeamsFileForContext).join("\n");
+  return [prompt, fileContext]
+    .filter((part) => {
+      return part.length > 0;
+    })
+    .join("\n\n");
+}
+
+function optionalLine(
+  label: string,
+  value: string | null | undefined,
+): string[] {
+  return value ? [`${label}: ${value}`] : [];
+}
+
+export function buildTeamsPrompt(args: {
+  readonly tenantId: string;
+  readonly tenantName: string | null;
+  readonly teamId: string | null;
+  readonly teamName: string | null;
+  readonly channelId: string | null;
+  readonly conversationId: string;
+  readonly conversationType: string | null;
+  readonly threadId: string;
+  readonly activityId: string | null;
+  readonly teamsAppId: string | null;
+  readonly botId: string | null;
+  readonly botName: string | null;
+  readonly threadContext: string;
+}): string {
+  return [
+    "# Current Integration",
+    "You are currently running inside: Microsoft Teams",
+    `Tenant ID: ${args.tenantId}`,
+    ...optionalLine("Tenant name", args.tenantName),
+    ...optionalLine("Team ID", args.teamId),
+    ...optionalLine("Team name", args.teamName),
+    ...optionalLine("Channel ID", args.channelId),
+    `Conversation ID: ${args.conversationId}`,
+    ...optionalLine("Conversation type", args.conversationType),
+    `Thread ID: ${args.threadId}`,
+    ...optionalLine("Activity ID", args.activityId),
+    ...optionalLine("Teams app ID", args.teamsAppId),
+    ...optionalLine("Bot ID", args.botId),
+    ...optionalLine("Bot name", args.botName),
+    args.threadContext,
+  ]
+    .filter((line): line is string => {
+      return line.length > 0;
+    })
+    .join("\n");
+}

--- a/turbo/apps/api/src/signals/services/teams-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/teams-queued-launch-context.service.ts
@@ -1,0 +1,260 @@
+import { chatEvents } from "@vm0/db/schema/chat-event";
+import { chatTeamsContext } from "@vm0/db/schema/chat-teams-context";
+import { teamsChatThreadRoutes } from "@vm0/db/schema/teams-chat-thread-route";
+import { teamsOrgConnections } from "@vm0/db/schema/teams-org-connection";
+import { teamsOrgInstallations } from "@vm0/db/schema/teams-org-installation";
+import { and, eq } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+import {
+  teamsDeliveryTargetSchema,
+  type TeamsDeliveryTarget,
+} from "./teams-chat-callback-payload";
+import { appendTeamsFilesToPrompt, buildTeamsPrompt } from "./teams-prompt";
+
+export interface TeamsQueuedLaunchMaterial {
+  readonly prompt: string;
+  readonly appendSystemPrompt: string;
+  readonly teamsDelivery: TeamsDeliveryTarget;
+  readonly userInfoExtras: {
+    readonly teamsUserDisplayName?: string;
+    readonly teamsUserPrincipalName?: string;
+    readonly teamsUserId: string;
+  };
+}
+
+type TeamsLaunchContextRow = Pick<
+  typeof chatTeamsContext.$inferSelect,
+  | "tenantId"
+  | "tenantName"
+  | "teamId"
+  | "teamName"
+  | "channelId"
+  | "conversationId"
+  | "conversationType"
+  | "threadId"
+  | "activityId"
+  | "serviceUrl"
+  | "teamsAppId"
+  | "botId"
+  | "botName"
+  | "senderUserId"
+  | "senderDisplayName"
+  | "senderPrincipalName"
+  | "connectionId"
+  | "threadContext"
+  | "messageText"
+  | "messageFiles"
+> & {
+  readonly userMessage: typeof chatEvents.$inferSelect.userMessage;
+  readonly installationBotId: string | null;
+  readonly installationBotName: string | null;
+};
+
+function requiredTeamsLaunchContext(row: TeamsLaunchContextRow | undefined) {
+  if (
+    !row ||
+    row.threadId === null ||
+    row.serviceUrl === null ||
+    row.senderUserId === null ||
+    row.connectionId === null ||
+    row.threadContext === null ||
+    row.messageText === null ||
+    row.messageFiles === null ||
+    row.userMessage === null
+  ) {
+    return null;
+  }
+  return {
+    ...row,
+    threadId: row.threadId,
+    serviceUrl: row.serviceUrl,
+    senderUserId: row.senderUserId,
+    connectionId: row.connectionId,
+    threadContext: row.threadContext,
+    messageText: row.messageText,
+    messageFiles: row.messageFiles,
+    userMessage: row.userMessage,
+  };
+}
+
+async function loadTeamsLaunchContext(
+  db: Db,
+  args: {
+    readonly eventId: string;
+    readonly chatThreadId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+) {
+  const [row] = await db
+    .select({
+      tenantId: chatTeamsContext.tenantId,
+      tenantName: chatTeamsContext.tenantName,
+      teamId: chatTeamsContext.teamId,
+      teamName: chatTeamsContext.teamName,
+      channelId: chatTeamsContext.channelId,
+      conversationId: chatTeamsContext.conversationId,
+      conversationType: chatTeamsContext.conversationType,
+      threadId: chatTeamsContext.threadId,
+      activityId: chatTeamsContext.activityId,
+      serviceUrl: chatTeamsContext.serviceUrl,
+      teamsAppId: chatTeamsContext.teamsAppId,
+      botId: chatTeamsContext.botId,
+      botName: chatTeamsContext.botName,
+      senderUserId: chatTeamsContext.senderUserId,
+      senderDisplayName: chatTeamsContext.senderDisplayName,
+      senderPrincipalName: chatTeamsContext.senderPrincipalName,
+      connectionId: chatTeamsContext.connectionId,
+      threadContext: chatTeamsContext.threadContext,
+      messageText: chatTeamsContext.messageText,
+      messageFiles: chatTeamsContext.messageFiles,
+      userMessage: chatEvents.userMessage,
+      installationBotId: teamsOrgInstallations.botId,
+      installationBotName: teamsOrgInstallations.botName,
+    })
+    .from(chatEvents)
+    .innerJoin(
+      chatTeamsContext,
+      and(
+        eq(chatTeamsContext.id, chatEvents.contextId),
+        eq(chatTeamsContext.chatThreadId, chatEvents.chatThreadId),
+      ),
+    )
+    .innerJoin(
+      teamsChatThreadRoutes,
+      and(
+        eq(teamsChatThreadRoutes.chatThreadId, chatEvents.chatThreadId),
+        eq(teamsChatThreadRoutes.connectionId, chatTeamsContext.connectionId),
+        eq(
+          teamsChatThreadRoutes.conversationId,
+          chatTeamsContext.conversationId,
+        ),
+        eq(teamsChatThreadRoutes.threadId, chatTeamsContext.threadId),
+        eq(teamsChatThreadRoutes.userId, args.userId),
+      ),
+    )
+    .innerJoin(
+      teamsOrgConnections,
+      and(
+        eq(teamsOrgConnections.id, chatTeamsContext.connectionId),
+        eq(teamsOrgConnections.teamsTenantId, chatTeamsContext.tenantId),
+        eq(teamsOrgConnections.vm0UserId, args.userId),
+      ),
+    )
+    .innerJoin(
+      teamsOrgInstallations,
+      and(
+        eq(teamsOrgInstallations.teamsTenantId, chatTeamsContext.tenantId),
+        eq(teamsOrgInstallations.orgId, args.orgId),
+      ),
+    )
+    .where(
+      and(
+        eq(chatEvents.id, args.eventId),
+        eq(chatEvents.chatThreadId, args.chatThreadId),
+        eq(chatEvents.contextType, "teams"),
+        eq(chatEvents.triggerSource, "teams"),
+      ),
+    )
+    .limit(1);
+  return requiredTeamsLaunchContext(row);
+}
+
+function promptFiles(context: {
+  readonly messageFiles: NonNullable<
+    typeof chatTeamsContext.$inferSelect.messageFiles
+  >;
+  readonly userMessage: NonNullable<typeof chatEvents.$inferSelect.userMessage>;
+}) {
+  // messageFiles also retains fetched context files for delivery. Only the
+  // current message's file parts belonged to the legacy agent prompt.
+  const promptFileIds = new Set(
+    context.userMessage.parts.flatMap((part) => {
+      return part.type === "file" ? [part.fileId] : [];
+    }),
+  );
+  return context.messageFiles.filter((file) => {
+    return promptFileIds.has(file.fileId);
+  });
+}
+
+function promptThreadId(context: {
+  readonly conversationType: string | null;
+  readonly threadId: string;
+  readonly activityId: string | null;
+}): string {
+  if (
+    context.conversationType === "personal" &&
+    context.activityId &&
+    context.threadId.startsWith("direct-message:")
+  ) {
+    return context.activityId;
+  }
+  return context.threadId;
+}
+
+export async function loadTeamsQueuedLaunchMaterial(
+  db: Db,
+  args: {
+    readonly eventId: string;
+    readonly chatThreadId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+): Promise<TeamsQueuedLaunchMaterial | null> {
+  const context = await loadTeamsLaunchContext(db, args);
+  if (!context) {
+    return null;
+  }
+  const botId = context.botId ?? context.installationBotId;
+  const botName = context.botName ?? context.installationBotName;
+  return {
+    prompt: appendTeamsFilesToPrompt(context.messageText, promptFiles(context)),
+    appendSystemPrompt: buildTeamsPrompt({
+      tenantId: context.tenantId,
+      tenantName: context.tenantName,
+      teamId: context.teamId,
+      teamName: context.teamName,
+      channelId: context.channelId,
+      conversationId: context.conversationId,
+      conversationType: context.conversationType,
+      threadId: promptThreadId(context),
+      activityId: context.activityId,
+      teamsAppId: context.teamsAppId,
+      botId,
+      botName,
+      threadContext: context.threadContext,
+    }),
+    teamsDelivery: teamsDeliveryTargetSchema.parse({
+      tenantId: context.tenantId,
+      tenantName: context.tenantName,
+      teamId: context.teamId,
+      teamName: context.teamName,
+      channelId: context.channelId,
+      conversationId: context.conversationId,
+      conversationType: context.conversationType,
+      threadId: context.threadId,
+      activityId: context.activityId,
+      serviceUrl: context.serviceUrl,
+      connectionId: context.connectionId,
+      teamsUserId: context.senderUserId,
+      teamsUserDisplayName: context.senderDisplayName,
+      teamsUserPrincipalName: context.senderPrincipalName,
+      botId,
+      botName,
+      files: context.messageFiles.map((file) => {
+        return { fileId: file.fileId, ...file.payload };
+      }),
+    }),
+    userInfoExtras: {
+      ...(context.senderDisplayName
+        ? { teamsUserDisplayName: context.senderDisplayName }
+        : {}),
+      ...(context.senderPrincipalName
+        ? { teamsUserPrincipalName: context.senderPrincipalName }
+        : {}),
+      teamsUserId: context.senderUserId,
+    },
+  };
+}

--- a/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
@@ -54,11 +54,8 @@ import {
 } from "./integration-model-route.service";
 import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
 import { listOrgModelPolicies$ } from "./zero-model-policy.service";
-import {
-  teamsDeliveryTargetSchema,
-  type TeamsDeliveryTarget,
-} from "./teams-chat-callback-payload";
 import { ensureTeamsChatThreadRoute } from "./teams-chat-ingress.service";
+import { formatTeamsFileForContext } from "./teams-prompt";
 import type { TeamsFileTokenPayload } from "./teams-file-token";
 import {
   updateUserModelPreference$,
@@ -179,18 +176,6 @@ type TeamsMessageDispatchResult =
       readonly kind: "accepted" | "queued";
       readonly runId?: string;
     };
-
-function nonEmpty(value: string | null | undefined): string | undefined {
-  return value && value.length > 0 ? value : undefined;
-}
-
-function optionalLine(
-  label: string,
-  value: string | null | undefined,
-): string[] {
-  const normalized = nonEmpty(value);
-  return normalized ? [`${label}: ${normalized}`] : [];
-}
 
 function isTeamsBotCommand(value: string): value is TeamsBotCommand {
   return (
@@ -537,30 +522,6 @@ function teamsPromptFiles(activity: TeamsMessageActivity): TeamsPromptFile[] {
     const file = teamsPromptFile(activity, attachment);
     return file ? [file] : [];
   });
-}
-
-function formatTeamsFileForContext(file: TeamsPromptFile): string {
-  return [
-    `[Teams file] ${file.name} (${file.contentType})`,
-    ...(file.sourceId ? [`   [Teams attachment ID] ${file.sourceId}`] : []),
-    `   [ID] ${file.fileId}`,
-  ].join("\n");
-}
-
-function appendTeamsFilesToPrompt(
-  prompt: string,
-  files: readonly TeamsPromptFile[],
-): string {
-  if (files.length === 0) {
-    return prompt;
-  }
-
-  const fileContext = files.map(formatTeamsFileForContext).join("\n");
-  return [prompt, fileContext]
-    .filter((part) => {
-      return part.length > 0;
-    })
-    .join("\n\n");
 }
 
 function graphAttachmentContent(
@@ -1517,65 +1478,6 @@ async function fetchTeamsPromptContext(args: {
   };
 }
 
-function buildTeamsPrompt(args: {
-  readonly activity: TeamsMessageActivity;
-  readonly installation: TeamsInstallation;
-  readonly threadContext: string;
-}): string {
-  const recipient = args.activity.recipient;
-  return [
-    "# Current Integration",
-    "You are currently running inside: Microsoft Teams",
-    `Tenant ID: ${args.activity.tenantId}`,
-    ...optionalLine("Tenant name", args.activity.tenantName),
-    ...optionalLine("Team ID", args.activity.teamId),
-    ...optionalLine("Team name", args.activity.teamName),
-    ...optionalLine("Channel ID", args.activity.channelId),
-    `Conversation ID: ${args.activity.conversationId}`,
-    ...optionalLine("Conversation type", args.activity.conversationType),
-    `Thread ID: ${args.activity.threadId}`,
-    ...optionalLine("Activity ID", args.activity.activityId),
-    ...optionalLine("Teams app ID", args.activity.teamsAppId),
-    ...optionalLine("Bot ID", recipient?.id ?? args.installation.botId),
-    ...optionalLine("Bot name", recipient?.name ?? args.installation.botName),
-    args.threadContext,
-  ]
-    .filter((line): line is string => {
-      return line.length > 0;
-    })
-    .join("\n");
-}
-
-function teamsDeliveryTarget(args: {
-  readonly activity: TeamsMessageActivity;
-  readonly installation: TeamsInstallation;
-  readonly connection: TeamsConnection;
-  readonly threadId: string;
-  readonly files: readonly TeamsPromptFile[];
-}): TeamsDeliveryTarget {
-  return teamsDeliveryTargetSchema.parse({
-    tenantId: args.activity.tenantId,
-    tenantName: args.activity.tenantName,
-    teamId: args.activity.teamId,
-    teamName: args.activity.teamName,
-    channelId: args.activity.channelId,
-    conversationId: args.activity.conversationId,
-    conversationType: args.activity.conversationType,
-    threadId: args.threadId,
-    activityId: args.activity.activityId,
-    serviceUrl: args.activity.serviceUrl,
-    connectionId: args.connection.id,
-    teamsUserId: args.activity.sender.id,
-    teamsUserDisplayName: args.activity.sender.name,
-    teamsUserPrincipalName: args.activity.sender.userPrincipalName,
-    botId: args.activity.recipient?.id ?? args.installation.botId,
-    botName: args.activity.recipient?.name ?? args.installation.botName,
-    files: args.files.map((file) => {
-      return { fileId: file.fileId, ...file.payload };
-    }),
-  });
-}
-
 interface CanonicalTeamsLaunchContext {
   readonly tenantId: string;
   readonly tenantName: string | null;
@@ -1628,13 +1530,6 @@ function canonicalTeamsLaunchContext(args: {
     messageText: args.activity.text,
     messageFiles: args.messageFiles,
   };
-}
-
-function promptForTeamsRun(args: {
-  readonly activity: TeamsMessageActivity;
-  readonly promptFiles: readonly TeamsPromptFile[];
-}): string {
-  return appendTeamsFilesToPrompt(args.activity.text, args.promptFiles);
 }
 
 function teamsChatMessageId(
@@ -1691,31 +1586,8 @@ async function persistTeamsChatMessage(args: {
     threadContext: args.promptContext.text,
     messageFiles: [...args.promptFiles, ...args.promptContext.files],
   });
-  const delivery = teamsDeliveryTarget({
-    activity: args.activity,
-    installation: args.installation,
-    connection: args.connection,
-    threadId,
-    files: launchContext.messageFiles,
-  });
-  const prompt = promptForTeamsRun(args);
   const encryptedParams = await encryptQueuedUserMessageRunParams(
-    {
-      version: 1,
-      prompt,
-      appendSystemPrompt: buildTeamsPrompt({
-        activity: args.activity,
-        installation: args.installation,
-        threadContext: args.promptContext.text,
-      }),
-      teamsDelivery: delivery,
-      userInfoExtras: {
-        teamsUserDisplayName: args.activity.sender.name ?? undefined,
-        teamsUserPrincipalName:
-          args.activity.sender.userPrincipalName ?? undefined,
-        teamsUserId: args.activity.sender.id,
-      },
-    },
+    { version: 1 },
     {
       orgId: args.installation.orgId,
       userId: args.connection.vm0UserId,
@@ -1742,9 +1614,9 @@ async function persistTeamsChatMessage(args: {
           }),
           nonContentPart: createChatEventSourcePart({
             kind: "teams",
-            tenantId: delivery.tenantId,
-            channelId: delivery.channelId,
-            activityId: delivery.activityId,
+            tenantId: launchContext.tenantId,
+            channelId: launchContext.channelId,
+            activityId: launchContext.activityId,
           }),
         }),
         runId: null,

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -33,7 +33,11 @@ import {
 } from "../signals/services/zero-chat-event.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
-import { decryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
+import type { TeamsDeliveryTarget } from "../signals/services/teams-chat-callback-payload";
+import {
+  decryptQueuedUserMessageRunParams,
+  encryptQueuedUserMessageRunParams,
+} from "../signals/services/zero-chat-queued-event.service";
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
@@ -567,6 +571,70 @@ export async function findPendingChatEventInputParamsByPromptFixture(
     });
   });
   return row ?? null;
+}
+
+export async function replaceTeamsLaunchMaterialWithLegacyParamsFixture(
+  eventId: string,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly prompt: string;
+    readonly appendSystemPrompt: string;
+    readonly teamsDelivery: TeamsDeliveryTarget;
+    readonly teamsUserDisplayName?: string;
+    readonly teamsUserPrincipalName?: string;
+    readonly teamsUserId: string;
+  },
+): Promise<void> {
+  const [event] = await db()
+    .select({ contextId: chatEvents.contextId })
+    .from(chatEvents)
+    .where(eq(chatEvents.id, eventId))
+    .limit(1);
+  if (!event?.contextId) {
+    throw new Error("Expected pending Teams event context");
+  }
+  await db()
+    .update(chatTeamsContext)
+    .set({
+      threadContext: null,
+      messageText: null,
+      messageFiles: null,
+      tenantName: null,
+      teamName: null,
+      threadId: null,
+      serviceUrl: null,
+      teamsAppId: null,
+      botId: null,
+      botName: null,
+      senderUserId: null,
+      senderDisplayName: null,
+      senderPrincipalName: null,
+      connectionId: null,
+    })
+    .where(eq(chatTeamsContext.id, event.contextId));
+  const encryptedParams = await encryptQueuedUserMessageRunParams(
+    {
+      version: 1,
+      prompt: args.prompt,
+      appendSystemPrompt: args.appendSystemPrompt,
+      teamsDelivery: args.teamsDelivery,
+      userInfoExtras: {
+        ...(args.teamsUserDisplayName
+          ? { teamsUserDisplayName: args.teamsUserDisplayName }
+          : {}),
+        ...(args.teamsUserPrincipalName
+          ? { teamsUserPrincipalName: args.teamsUserPrincipalName }
+          : {}),
+        teamsUserId: args.teamsUserId,
+      },
+    },
+    { orgId: args.orgId, userId: args.userId },
+  );
+  await db()
+    .update(chatEventInputParams)
+    .set({ encryptedParams })
+    .where(eq(chatEventInputParams.eventId, eventId));
 }
 
 /**


### PR DESCRIPTION
## Summary

- load Teams launch prompt, system prompt, delivery, and user metadata from `chat_events` plus `chat_teams_context` at claim time
- preserve the stored model-routed `thread_id`, rebuild delivery through `teamsDeliveryTargetSchema.parse`, and fall back to installation bot identity only when the activity values were absent
- stop writing Teams launch material into `chat_event_input_params.encrypted_params` while keeping a context-first legacy blob fallback for rows already queued
- keep current-message attachment prompt semantics while retaining fetched context files in delivery

This is rollout step 2 of 3 for #24469 and the Teams source only. It intentionally does not change `cron-monitor-chat-event-queue`.

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- formatter and `git diff --check`
- local Vitest and the dev server were not run, per the issue rollout instructions; PR CI owns integration coverage
