### PR TITLE
refactor: require teams launch context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -18,7 +18,6 @@ import {
   findPendingChatEventInputParamsByPromptFixture,
   readChatEventContextFixture,
   readChatEventInputParamsFixture,
-  replaceTeamsLaunchMaterialWithLegacyParamsFixture,
 } from "../../../test-fixtures/chat-events";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { zeroTeamsConnectRoutes } from "../zero-teams-connect";
@@ -686,68 +685,6 @@ describe("Teams chat callbacks", () => {
       }),
     ).resolves.toStrictEqual({ version: 1 });
 
-    const legacyPrompt = "claim legacy Teams launch params";
-    await postTeamsPersonalMessage({
-      fixture: teams.fixture,
-      activityId: "activity-queue-params-legacy",
-      text: legacyPrompt,
-    });
-    const legacyParams =
-      await findPendingChatEventInputParamsByPromptFixture(legacyPrompt);
-    if (!legacyParams) {
-      throw new Error("Expected queued legacy Teams params");
-    }
-    const legacyContext = await readChatEventContextFixture(
-      legacyParams.eventId,
-    );
-    if (!legacyContext?.teamsConnectionId) {
-      throw new Error("Expected queued legacy Teams context");
-    }
-    const legacyIntegrationPrompt = [
-      "# Current Integration",
-      "You are currently running inside: Microsoft Teams",
-      `Tenant ID: ${teams.fixture.teamsTenantId}`,
-      `Tenant name: ${teams.fixture.teamsTenantName}`,
-      `Conversation ID: a:personal-${teams.fixture.teamsUserId}`,
-      "Conversation type: personal",
-      "Thread ID: activity-queue-params-legacy",
-      "Activity ID: activity-queue-params-legacy",
-      `Teams app ID: ${BOT_APP_ID}`,
-      "Bot ID: 28:bot-1",
-      "Bot name: Zero",
-    ].join("\n");
-    await replaceTeamsLaunchMaterialWithLegacyParamsFixture(
-      legacyParams.eventId,
-      {
-        orgId: teams.fixture.orgId,
-        userId: teams.fixture.userId,
-        prompt: legacyPrompt,
-        appendSystemPrompt: legacyIntegrationPrompt,
-        teamsDelivery: {
-          tenantId: teams.fixture.teamsTenantId,
-          tenantName: teams.fixture.teamsTenantName,
-          teamId: null,
-          teamName: null,
-          channelId: null,
-          conversationId: `a:personal-${teams.fixture.teamsUserId}`,
-          conversationType: "personal",
-          threadId: `direct-message:${teams.defaultAgentId}:claude-sonnet-4-6`,
-          activityId: "activity-queue-params-legacy",
-          serviceUrl: teams.fixture.serviceUrl,
-          connectionId: legacyContext.teamsConnectionId,
-          teamsUserId: teams.fixture.teamsUserId,
-          teamsUserDisplayName: "Ada Lovelace",
-          teamsUserPrincipalName: "ada@example.com",
-          botId: "28:bot-1",
-          botName: "Zero",
-          files: [],
-        },
-        teamsUserDisplayName: "Ada Lovelace",
-        teamsUserPrincipalName: "ada@example.com",
-        teamsUserId: teams.fixture.teamsUserId,
-      },
-    );
-
     await completeSandboxRun({
       runId: firstRunId,
       sandboxToken: firstClaim.sandboxToken,
@@ -780,17 +717,6 @@ describe("Teams chat callbacks", () => {
       sandboxToken: queuedClaim.sandboxToken,
       exitCode: 0,
     });
-    const legacyRunId = await runIdForPrompt(teams.actor, legacyPrompt);
-    const legacyClaim = await claimTeamsRun({
-      runnerGroup: teams.runnerGroup,
-      runId: legacyRunId,
-    });
-    expect(legacyClaim.prompt).toBe(legacyPrompt);
-    expect(legacyClaim.appendSystemPrompt).toContain(legacyIntegrationPrompt);
-    await expect(
-      readChatEventInputParamsFixture(legacyParams.eventId),
-    ).resolves.toBeNull();
-    await runsApi.requestCancelRun(teams.actor, legacyRunId, [200]);
   });
 
   it("falls back to installation bot identity when the activity omits it", async () => {

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2680,12 +2680,10 @@ function slackQueuedMessageAdmissionFailure(
 
 function teamsQueuedMessageAdmissionFailure(
   args: CreateQueuedChatRunInputArgs,
-  sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
   teamsLaunchMaterial: TeamsQueuedLaunchMaterial | null,
   error: QueuedMessageModelRouteError,
 ): TeamsQueuedMessageAdmissionFailure | null {
-  const teamsDelivery =
-    teamsLaunchMaterial?.teamsDelivery ?? sourceParams?.teamsDelivery;
+  const teamsDelivery = teamsLaunchMaterial?.teamsDelivery;
   if (args.queuedMessage.triggerSource !== "teams" || !teamsDelivery) {
     return null;
   }
@@ -2796,12 +2794,7 @@ function queuedMessageAdmissionFailure(
 ): QueuedMessageAdmissionFailure | null {
   return (
     slackQueuedMessageAdmissionFailure(args, slackLaunchMaterial, error) ??
-    teamsQueuedMessageAdmissionFailure(
-      args,
-      sourceParams,
-      teamsLaunchMaterial,
-      error,
-    ) ??
+    teamsQueuedMessageAdmissionFailure(args, teamsLaunchMaterial, error) ??
     telegramQueuedMessageAdmissionFailure(args, sourceParams, error) ??
     agentPhoneQueuedMessageAdmissionFailure(args, sourceParams, error) ??
     githubQueuedMessageAdmissionFailure(args, sourceParams, error) ??
@@ -2827,8 +2820,7 @@ function queuedIntegrationDeliveries(
   return {
     slackDelivery: slackLaunchMaterial?.slackDelivery,
     feishuDelivery: feishuLaunchMaterial?.feishuDelivery,
-    teamsDelivery:
-      teamsLaunchMaterial?.teamsDelivery ?? sourceParams?.teamsDelivery,
+    teamsDelivery: teamsLaunchMaterial?.teamsDelivery,
     telegramDelivery: sourceParams?.telegramDelivery,
     agentphoneDelivery: sourceParams?.agentphoneDelivery,
     githubDelivery: sourceParams?.githubDelivery,
@@ -2874,7 +2866,6 @@ async function resolveFeishuQueuedLaunchMaterial(
 
 async function resolveTeamsQueuedLaunchMaterial(
   args: CreateQueuedChatRunInputArgs,
-  sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
 ): Promise<TeamsQueuedLaunchMaterial | null> {
   if (args.queuedMessage.triggerSource !== "teams") {
     return null;
@@ -2888,14 +2879,7 @@ async function resolveTeamsQueuedLaunchMaterial(
   if (material) {
     return material;
   }
-  if (
-    sourceParams?.prompt === undefined ||
-    sourceParams.appendSystemPrompt === undefined ||
-    !sourceParams.teamsDelivery
-  ) {
-    throw new Error("Teams queue item is missing launch material");
-  }
-  return null;
+  throw new Error("Teams queue item is missing launch material");
 }
 
 function queuedMessagePrompt(args: {
@@ -2921,7 +2905,10 @@ function queuedMessagePrompt(args: {
     return args.feishuLaunchMaterial.prompt;
   }
   if (args.triggerSource === "teams") {
-    return args.teamsLaunchMaterial?.prompt ?? args.sourceParams?.prompt ?? "";
+    if (!args.teamsLaunchMaterial) {
+      throw new Error("Teams queue item is missing launch material");
+    }
+    return args.teamsLaunchMaterial.prompt;
   }
   if (args.triggerSource === "workflow-schedule") {
     return args.sourceParams?.prompt ?? args.projectedPrompt;
@@ -2951,11 +2938,10 @@ function queuedIntegrationPrompt(args: {
     return args.feishuLaunchMaterial.appendSystemPrompt;
   }
   if (args.triggerSource === "teams") {
-    return (
-      args.teamsLaunchMaterial?.appendSystemPrompt ??
-      args.sourceParams?.appendSystemPrompt ??
-      buildWebChatPrompt()
-    );
+    if (!args.teamsLaunchMaterial) {
+      throw new Error("Teams queue item is missing launch material");
+    }
+    return args.teamsLaunchMaterial.appendSystemPrompt;
   }
   return args.sourceParams?.appendSystemPrompt ?? buildWebChatPrompt();
 }
@@ -2994,10 +2980,7 @@ async function loadQueuedLaunchMaterials(args: CreateQueuedChatRunInputArgs) {
   }
   const slackLaunchMaterial = await resolveSlackQueuedLaunchMaterial(args);
   const feishuLaunchMaterial = await resolveFeishuQueuedLaunchMaterial(args);
-  const teamsLaunchMaterial = await resolveTeamsQueuedLaunchMaterial(
-    args,
-    sourceParams,
-  );
+  const teamsLaunchMaterial = await resolveTeamsQueuedLaunchMaterial(args);
   return {
     sourceParams,
     slackLaunchMaterial,

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -65,7 +65,6 @@ import {
 import { noGoalChangeAfterQueueEvent } from "./chat-goal-queue.service";
 import { agentphoneDeliveryTargetSchema } from "./agentphone-chat-callback-payload";
 import { githubDeliveryTargetSchema } from "./github-chat-callback-payload";
-import { teamsDeliveryTargetSchema } from "./teams-chat-callback-payload";
 import { telegramDeliveryTargetSchema } from "./telegram-chat-callback-payload";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { resolveArtifactObject$ } from "./artifact-storage.service";
@@ -89,7 +88,6 @@ const queuedUserMessageRunParamsSchema = z.object({
   version: z.literal(1),
   prompt: z.string().optional(),
   appendSystemPrompt: z.string().optional(),
-  teamsDelivery: teamsDeliveryTargetSchema.optional(),
   telegramDelivery: telegramDeliveryTargetSchema.optional(),
   agentphoneDelivery: agentphoneDeliveryTargetSchema.optional(),
   githubDelivery: githubDeliveryTargetSchema.optional(),
@@ -105,9 +103,6 @@ const queuedUserMessageRunParamsSchema = z.object({
     .object({
       slackDisplayName: z.string().optional(),
       slackUserId: z.string().optional(),
-      teamsUserDisplayName: z.string().optional(),
-      teamsUserPrincipalName: z.string().optional(),
-      teamsUserId: z.string().optional(),
       telegramDisplayName: z.string().optional(),
       telegramUsername: z.string().optional(),
       telegramUserId: z.string().optional(),

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -33,11 +33,7 @@ import {
 } from "../signals/services/zero-chat-event.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
-import type { TeamsDeliveryTarget } from "../signals/services/teams-chat-callback-payload";
-import {
-  decryptQueuedUserMessageRunParams,
-  encryptQueuedUserMessageRunParams,
-} from "../signals/services/zero-chat-queued-event.service";
+import { decryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
@@ -571,70 +567,6 @@ export async function findPendingChatEventInputParamsByPromptFixture(
     });
   });
   return row ?? null;
-}
-
-export async function replaceTeamsLaunchMaterialWithLegacyParamsFixture(
-  eventId: string,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly prompt: string;
-    readonly appendSystemPrompt: string;
-    readonly teamsDelivery: TeamsDeliveryTarget;
-    readonly teamsUserDisplayName?: string;
-    readonly teamsUserPrincipalName?: string;
-    readonly teamsUserId: string;
-  },
-): Promise<void> {
-  const [event] = await db()
-    .select({ contextId: chatEvents.contextId })
-    .from(chatEvents)
-    .where(eq(chatEvents.id, eventId))
-    .limit(1);
-  if (!event?.contextId) {
-    throw new Error("Expected pending Teams event context");
-  }
-  await db()
-    .update(chatTeamsContext)
-    .set({
-      threadContext: null,
-      messageText: null,
-      messageFiles: null,
-      tenantName: null,
-      teamName: null,
-      threadId: null,
-      serviceUrl: null,
-      teamsAppId: null,
-      botId: null,
-      botName: null,
-      senderUserId: null,
-      senderDisplayName: null,
-      senderPrincipalName: null,
-      connectionId: null,
-    })
-    .where(eq(chatTeamsContext.id, event.contextId));
-  const encryptedParams = await encryptQueuedUserMessageRunParams(
-    {
-      version: 1,
-      prompt: args.prompt,
-      appendSystemPrompt: args.appendSystemPrompt,
-      teamsDelivery: args.teamsDelivery,
-      userInfoExtras: {
-        ...(args.teamsUserDisplayName
-          ? { teamsUserDisplayName: args.teamsUserDisplayName }
-          : {}),
-        ...(args.teamsUserPrincipalName
-          ? { teamsUserPrincipalName: args.teamsUserPrincipalName }
-          : {}),
-        teamsUserId: args.teamsUserId,
-      },
-    },
-    { orgId: args.orgId, userId: args.userId },
-  );
-  await db()
-    .update(chatEventInputParams)
-    .set({ encryptedParams })
-    .where(eq(chatEventInputParams.eventId, eventId));
 }
 
 /**


### PR DESCRIPTION
## Summary

- remove the drained Teams prompt, system prompt, delivery, and user-info fallback from `chat_event_input_params`
- require queued Teams claims to assemble launch material from `chat_events` and `chat_teams_context`
- remove the legacy fallback fixture while retaining coverage that queued Teams params contain only the version placeholder and are deleted after claim

Closes #24469 (rollout PR 3 of 3).

## Drain gate

- rollout PR #24471 added and dual-wrote the Teams launch context
- rollout PR #24475 switched claims to context-first reads and stopped writing launch material to the encrypted blob; its production `deploy-api` job completed successfully at 2026-08-01T10:10:25Z
- a read-only MaskDB check against `vm0-prod-ro` at 2026-08-01T10:10:55Z found 0 total Teams trigger events and 0 unclaimed Teams `input.prompt` originals
- a Slack control query on the same database and filter path returned 212 historical events
- therefore there are no historical pending Teams events requiring a run replacement or revocation, and the real old-format unclaimed backlog is 0

## Scope

- Teams only
- no changes to other integration sources or abandoned display columns on other context tables
- no changes to `cron-monitor-chat-event-queue`

## Validation

- `pnpm exec prettier --write apps/api/src/signals/services/zero-chat-queued-event.service.ts apps/api/src/signals/services/internal-chat-run-callback.service.ts apps/api/src/test-fixtures/chat-events.ts apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- `git diff --check`

Per the issue instructions, local Vitest and the dev server were not run; PR CI is the test authority.