### PR TITLE
refactor: derive feishu tenant key at claim

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -33,6 +33,7 @@ import {
   findPendingChatEventInputParamsByPromptFixture,
   readChatEventContextFixture,
   readChatEventInputParamsFixture,
+  useLegacyFeishuTenantKeyFixture,
 } from "../../../test-fixtures/chat-events";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { now } from "../../external/time";
@@ -2390,6 +2391,17 @@ describe("Feishu integration", () => {
       null,
     );
     const run = await findRun(actor, "do the Feishu task");
+    const pendingParams = requireValue(
+      await findPendingChatEventInputParamsByPromptFixture(
+        "do the Feishu task",
+      ),
+      "Expected pending Feishu launch params",
+    );
+    expect(
+      (await readChatEventContextFixture(pendingParams.eventId))
+        ?.feishuTenantKey,
+    ).toBeNull();
+    await useLegacyFeishuTenantKeyFixture(pendingParams.eventId, TENANT_KEY);
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
     const threadEvents = await accept(
       setupApp({ context })(chatThreadsContract).events({
@@ -2443,6 +2455,7 @@ describe("Feishu integration", () => {
       "Feishu open ID: ou_feishu_user",
     );
     expect(claim.appendSystemPrompt).toContain("Scope: Direct message");
+    expect(claim.appendSystemPrompt).toContain(`Tenant key: ${TENANT_KEY}`);
     expect(claim.appendSystemPrompt).toContain("Chat ID: oc_feishu_dm");
     expect(claim.appendSystemPrompt).not.toContain("Group ID:");
     expect(claim.appendSystemPrompt).toContain(
@@ -3139,6 +3152,9 @@ describe("Feishu integration", () => {
     const groupClaim = await runsApi.claimRunnerJob(groupRun.id);
     expect(groupClaim.prompt).toBe("handle this group task");
     expect(groupClaim.appendSystemPrompt).toContain("Scope: Group mention");
+    expect(groupClaim.appendSystemPrompt).toContain(
+      `Tenant key: ${TENANT_KEY}`,
+    );
     expect(groupClaim.appendSystemPrompt).toContain("Chat ID: oc_feishu_group");
     expect(groupClaim.appendSystemPrompt).toContain(
       "Group ID: oc_feishu_group (same as Chat ID; use it directly as the `--chat` value for `zero feishu message send`)",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -2391,17 +2391,11 @@ describe("Feishu integration", () => {
       null,
     );
     const run = await findRun(actor, "do the Feishu task");
-    const pendingParams = requireValue(
-      await findPendingChatEventInputParamsByPromptFixture(
-        "do the Feishu task",
-      ),
-      "Expected pending Feishu launch params",
+    const legacyTenantKeyFixture = await useLegacyFeishuTenantKeyFixture(
+      run.id,
+      TENANT_KEY,
     );
-    expect(
-      (await readChatEventContextFixture(pendingParams.eventId))
-        ?.feishuTenantKey,
-    ).toBeNull();
-    await useLegacyFeishuTenantKeyFixture(pendingParams.eventId, TENANT_KEY);
+    expect(legacyTenantKeyFixture.previousTenantKey).toBeNull();
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
     const threadEvents = await accept(
       setupApp({ context })(chatThreadsContract).events({

--- a/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
@@ -252,7 +252,6 @@ interface CanonicalFeishuLaunchContext {
     readonly type: "file" | "image";
   }[];
   readonly chatType: "group" | "p2p" | "topic_group";
-  readonly tenantKey: string;
   readonly chatId: string;
   readonly messageId: string;
   readonly threadId: string;
@@ -285,7 +284,6 @@ function canonicalFeishuLaunchContext(args: {
       };
     }),
     chatType: args.message.chatType,
-    tenantKey: args.message.tenantKey,
     chatId: args.message.chatId,
     messageId: args.message.messageId,
     threadId:

--- a/turbo/apps/api/src/signals/services/feishu-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-queued-launch-context.service.ts
@@ -25,7 +25,6 @@ type FeishuLaunchContextRow = Pick<
   | "messageText"
   | "messageFiles"
   | "chatType"
-  | "tenantKey"
   | "chatId"
   | "messageId"
   | "threadId"
@@ -35,18 +34,21 @@ type FeishuLaunchContextRow = Pick<
   | "connectionId"
   | "installationId"
 > & {
+  readonly tenantKey: string | null;
+  readonly legacyTenantKey: string | null;
   readonly routeThreadId: string;
   readonly feishuDisplayName: string | null;
 };
 
 function requiredFeishuLaunchContext(row: FeishuLaunchContextRow | undefined) {
+  const tenantKey = row?.tenantKey ?? row?.legacyTenantKey ?? null;
   if (
     !row ||
     row.conversationHistory === null ||
     row.messageText === null ||
     row.messageFiles === null ||
     row.chatType === null ||
-    row.tenantKey === null ||
+    tenantKey === null ||
     row.chatId === null ||
     row.messageId === null ||
     row.threadId === null ||
@@ -63,7 +65,7 @@ function requiredFeishuLaunchContext(row: FeishuLaunchContextRow | undefined) {
     messageText: row.messageText,
     messageFiles: row.messageFiles,
     chatType: row.chatType,
-    tenantKey: row.tenantKey,
+    tenantKey,
     chatId: row.chatId,
     messageId: row.messageId,
     threadId: row.threadId,
@@ -89,7 +91,8 @@ async function loadFeishuLaunchContext(
       messageText: chatFeishuContext.messageText,
       messageFiles: chatFeishuContext.messageFiles,
       chatType: chatFeishuContext.chatType,
-      tenantKey: chatFeishuContext.tenantKey,
+      tenantKey: feishuOrgInstallations.feishuTenantKey,
+      legacyTenantKey: chatFeishuContext.tenantKey,
       chatId: chatFeishuContext.chatId,
       messageId: chatFeishuContext.messageId,
       threadId: chatFeishuContext.threadId,

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -69,7 +69,6 @@ type ChatEventDisplayContext =
         readonly messageText: string;
         readonly messageFiles: ChatFeishuMessageFiles;
         readonly chatType: "group" | "p2p" | "topic_group";
-        readonly tenantKey: string;
         readonly chatId: string;
         readonly messageId: string;
         readonly threadId: string;
@@ -381,7 +380,6 @@ type NewDisplayContext =
       readonly messageText: string;
       readonly messageFiles: ChatFeishuMessageFiles;
       readonly chatType: "group" | "p2p" | "topic_group";
-      readonly tenantKey: string;
       readonly chatId: string;
       readonly messageId: string;
       readonly threadId: string;
@@ -651,7 +649,6 @@ async function insertDisplayContext(
       messageText: context.messageText,
       messageFiles: context.messageFiles,
       chatType: context.chatType,
-      tenantKey: context.tenantKey,
       chatId: context.chatId,
       messageId: context.messageId,
       threadId: context.threadId,

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -20,6 +20,7 @@ import { chatTeamsContext } from "@vm0/db/schema/chat-teams-context";
 import { chatTelegramContext } from "@vm0/db/schema/chat-telegram-context";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { chatEvents } from "@vm0/db/schema/chat-event";
+import { feishuOrgInstallations } from "@vm0/db/schema/feishu-org-installation";
 import { checkpoints } from "@vm0/db/schema/checkpoint";
 import { and, count, eq, isNull, like, or, sql } from "drizzle-orm";
 import { z } from "zod";
@@ -200,6 +201,37 @@ export async function readChatEventContextFixture(
   return event ?? null;
 }
 
+export async function useLegacyFeishuTenantKeyFixture(
+  eventId: string,
+  tenantKey: string,
+): Promise<void> {
+  const [context] = await db()
+    .select({
+      id: chatFeishuContext.id,
+      installationId: chatFeishuContext.installationId,
+    })
+    .from(chatEvents)
+    .innerJoin(
+      chatFeishuContext,
+      eq(chatFeishuContext.id, chatEvents.contextId),
+    )
+    .where(eq(chatEvents.id, eventId))
+    .limit(1);
+  if (!context?.installationId) {
+    throw new Error("Expected a Feishu launch context fixture");
+  }
+  await db().transaction(async (tx) => {
+    await tx
+      .update(chatFeishuContext)
+      .set({ tenantKey })
+      .where(eq(chatFeishuContext.id, context.id));
+    await tx
+      .update(feishuOrgInstallations)
+      .set({ feishuTenantKey: null })
+      .where(eq(feishuOrgInstallations.id, context.installationId));
+  });
+}
+
 const annotationProjectionInputs = [
   {
     text: "slack linked",
@@ -233,7 +265,6 @@ const annotationProjectionInputs = [
         messageText: "feishu linked",
         messageFiles: [],
         chatType: "p2p",
-        tenantKey: "tenant-1",
         chatId: "oc_123",
         messageId: "om_123",
         threadId: "om_123",

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -202,22 +202,24 @@ export async function readChatEventContextFixture(
 }
 
 export async function useLegacyFeishuTenantKeyFixture(
-  eventId: string,
+  runId: string,
   tenantKey: string,
-): Promise<void> {
+): Promise<{ readonly previousTenantKey: string | null }> {
   const [context] = await db()
     .select({
       id: chatFeishuContext.id,
       installationId: chatFeishuContext.installationId,
+      tenantKey: chatFeishuContext.tenantKey,
     })
     .from(chatEvents)
     .innerJoin(
       chatFeishuContext,
       eq(chatFeishuContext.id, chatEvents.contextId),
     )
-    .where(eq(chatEvents.id, eventId))
+    .where(eq(chatEvents.runId, runId))
     .limit(1);
-  if (!context?.installationId) {
+  const installationId = context?.installationId;
+  if (!context || !installationId) {
     throw new Error("Expected a Feishu launch context fixture");
   }
   await db().transaction(async (tx) => {
@@ -228,8 +230,9 @@ export async function useLegacyFeishuTenantKeyFixture(
     await tx
       .update(feishuOrgInstallations)
       .set({ feishuTenantKey: null })
-      .where(eq(feishuOrgInstallations.id, context.installationId));
+      .where(eq(feishuOrgInstallations.id, installationId));
   });
+  return { previousTenantKey: context.tenantKey };
 }
 
 const annotationProjectionInputs = [


### PR DESCRIPTION
## Summary

- derive the Feishu tenant key at claim from the already-joined installation row
- preserve the legacy context value as a transitional fallback when the installation value is null
- stop canonical Feishu ingress from writing `chat_feishu_context.tenant_key`
- cover byte-identical `Tenant key:` prompt lines for p2p and group mention claims

## Why

`tenant_key` is installation-level configuration reachable through the stored installation ID. Keeping a per-firing copy violates the context-minimization design rule in #24202.

This is PR 1 of 2 for #24488. A follow-up PR will drop the column and remove the fallback after this change merges.

## Validation

Local Vitest and the dev server were intentionally not run per the requested rollout workflow. The PR CI pipeline is the validation gate. The existing Feishu integration coverage now also verifies:

- a newly admitted context does not store the tenant key
- a legacy context still supplies it when the installation value is null
- p2p and group mention claims retain the exact `Tenant key: tenant_feishu_integration_test` line