### PR TITLE
refactor: derive workflow automation launch context at claim

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
@@ -2304,7 +2304,9 @@ describe("zero workflow automations", () => {
   });
 
   it("runs a one-time automation immediately in its bound chat thread", async () => {
-    mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+    const requestedAt = Date.UTC(2026, 7, 1, 12, 34, 56);
+    mockNow(requestedAt);
+    const runnerGroup = runs.configureRunnerGroup();
     const { workflowId } = await setupFixture();
     const created = await accept(
       automationsClient().create({
@@ -2376,6 +2378,33 @@ describe("zero workflow automations", () => {
       ]),
     );
     expect(JSON.stringify(timingEvents)).not.toContain(WORKFLOW_NAME);
+
+    await runs.heartbeatRunner(runnerGroup);
+    const claim = await runs.claimRunnerJob(run.body.runId);
+    const requestedAtIso = new Date(requestedAt).toISOString();
+    expect(claim.prompt).toBe(
+      `/${WORKFLOW_NAME}\nTrigger: manual run requested at ${requestedAtIso}.`,
+    );
+    expect(claim.appendSystemPrompt).toContain(
+      [
+        "# Current context",
+        `Run created by workflow automation "${WORKFLOW_NAME}".`,
+        `Trigger: manual run requested at ${requestedAtIso}.`,
+        `Procedure: skill "${WORKFLOW_NAME}".`,
+        "Output destination: this web chat thread, read by the user.",
+        "",
+        "# This run's event",
+        JSON.stringify(
+          {
+            automationId: created.body.id,
+            trigger: "manual",
+            requestedAt: requestedAtIso,
+          },
+          null,
+          2,
+        ),
+      ].join("\n"),
+    );
 
     const automation = await wf.readAutomation(created.body.id);
     expect(typeof automation.lastRunAt).toBe("string");

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -41,8 +41,10 @@ import {
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import {
   completeRunWithoutCallbacksFixture,
+  decryptWorkflowEventInputParamsFixture,
   holdChatEventQueueAdmissionLockFixture,
   holdOrgAdmissionLockFixture,
+  invalidatePendingChatEventInputParamsFixture,
   readChatEventContextFixture,
   readChatEventInputParamsFixture,
   setQueuedUserMessageCreatedAtFixture,
@@ -631,9 +633,18 @@ describe("workflow queue", () => {
       eventId: thirdEvent.id,
       encryptedParams: expect.any(String),
     });
+    await expect(
+      decryptWorkflowEventInputParamsFixture(thirdEvent.id, {
+        orgId: scenario.orgId,
+        userId: scenario.userId,
+      }),
+    ).resolves.toStrictEqual({ version: 1 });
     await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
       firstRunId,
     ]);
+
+    // Complete context wins without reading the transitional marker blob.
+    await invalidatePendingChatEventInputParamsFixture(secondEvent.id);
 
     // Completing the run drains exactly one event into the next run.
     const dequeuedAt = secondApiStartTime + 10_000;

--- a/turbo/apps/api/src/signals/services/__tests__/workflow-automation-context.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/workflow-automation-context.test.ts
@@ -4,6 +4,11 @@ import {
   EVENT_NOTES,
   EVENT_POLICY,
   TRIGGER_RENDERERS,
+  persistedWorkflowAutomationEventPayload,
+  restoredWorkflowAutomationEventPayload,
+  storedWorkflowAutomationContext,
+  workflowAutomationAppendSystemPrompt,
+  workflowAutomationPrompt,
   workflowAutomationTrigger,
   type WorkflowAutomationEventPolicy,
   type WorkflowAutomationEventType,
@@ -24,6 +29,24 @@ const manualPolicy = {
   recordLastRunId: true,
   recordLastRunAt: true,
 } as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function reverseObjectKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(reverseObjectKeys);
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  const result: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value).reverse()) {
+    result[key] = reverseObjectKeys(item);
+  }
+  return result;
+}
 
 interface WorkflowAutomationContextCase {
   readonly eventType: WorkflowAutomationEventType;
@@ -259,6 +282,10 @@ const cases: readonly WorkflowAutomationContextCase[] = [
     payload: {
       receivedAt: "2026-08-01T12:00:04.000Z",
       deliveryId: "delivery-webhook",
+      body: {
+        event: "vm0-timing-sensitive-ping",
+        value: "vm0-timing-secret-value",
+      },
     },
     trigger:
       "signed workflow webhook received an HTTP POST at 2026-08-01T12:00:04.000Z (delivery delivery-webhook).",
@@ -309,6 +336,36 @@ describe("workflow automation context lookup contracts", () => {
       ).toBe(trigger);
       expect(EVENT_NOTES[eventType]).toStrictEqual(notes);
       expect(EVENT_POLICY[eventType]).toStrictEqual(policy);
+
+      const persistedPayload = reverseObjectKeys(
+        persistedWorkflowAutomationEventPayload(payload),
+      );
+      if (!isRecord(persistedPayload)) {
+        throw new Error("Expected persisted event payload to be an object");
+      }
+      const restoredPayload =
+        restoredWorkflowAutomationEventPayload(persistedPayload);
+      if (!restoredPayload) {
+        throw new Error("Expected persisted event payload key order");
+      }
+      const legacyContext = {
+        workflowName: "workflow-context-test",
+        eventType,
+        trigger,
+        notes,
+        event: payload,
+      };
+      const restoredContext = storedWorkflowAutomationContext({
+        workflowName: legacyContext.workflowName,
+        eventType,
+        eventPayload: restoredPayload,
+      });
+      expect(workflowAutomationPrompt(restoredContext)).toBe(
+        workflowAutomationPrompt(legacyContext),
+      );
+      expect(workflowAutomationAppendSystemPrompt(restoredContext)).toBe(
+        workflowAutomationAppendSystemPrompt(legacyContext),
+      );
     },
   );
 

--- a/turbo/apps/api/src/signals/services/workflow-automation-context.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-context.service.ts
@@ -19,10 +19,135 @@ export interface WorkflowAutomationEventPolicy {
 
 type TriggerRenderer = (payload: WorkflowAutomationEventPayload) => string;
 
+const EVENT_PAYLOAD_OBJECT_KEY_ORDER = "__vm0EventPayloadObjectKeyOrderV1";
+const eventPayloadObjectKeyOrderSchema = z.array(
+  z.object({
+    path: z.array(z.union([z.string(), z.number()])),
+    keys: z.array(z.string()),
+  }),
+);
+
+interface EventPayloadObjectKeyOrder {
+  readonly path: readonly (string | number)[];
+  readonly keys: readonly string[];
+}
+
 function isEventPayload(
   value: object,
 ): value is WorkflowAutomationEventPayload {
   return !Array.isArray(value);
+}
+
+function collectEventPayloadObjectKeyOrder(
+  value: unknown,
+  path: readonly (string | number)[],
+  result: EventPayloadObjectKeyOrder[],
+): void {
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) {
+      collectEventPayloadObjectKeyOrder(item, [...path, index], result);
+    }
+    return;
+  }
+  if (typeof value !== "object" || value === null || !isEventPayload(value)) {
+    return;
+  }
+  const keys = Object.keys(value);
+  result.push({ path, keys });
+  for (const key of keys) {
+    collectEventPayloadObjectKeyOrder(value[key], [...path, key], result);
+  }
+}
+
+function eventPayloadPathKey(path: readonly (string | number)[]): string {
+  return JSON.stringify(path);
+}
+
+function restoreEventPayloadObjectKeyOrder(
+  value: unknown,
+  path: readonly (string | number)[],
+  keyOrder: ReadonlyMap<string, readonly string[]>,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item, index) => {
+      return restoreEventPayloadObjectKeyOrder(
+        item,
+        [...path, index],
+        keyOrder,
+      );
+    });
+  }
+  if (typeof value !== "object" || value === null || !isEventPayload(value)) {
+    return value;
+  }
+  const persistedKeys = Object.keys(value).filter((key) => {
+    return path.length > 0 || key !== EVENT_PAYLOAD_OBJECT_KEY_ORDER;
+  });
+  const persistedKeySet = new Set(persistedKeys);
+  const orderedKeys = keyOrder.get(eventPayloadPathKey(path))?.filter((key) => {
+    return persistedKeySet.has(key);
+  });
+  const knownKeys = new Set(orderedKeys ?? []);
+  const result: Record<string, unknown> = {};
+  for (const key of [
+    ...(orderedKeys ?? []),
+    ...persistedKeys.filter((persistedKey) => {
+      return !knownKeys.has(persistedKey);
+    }),
+  ]) {
+    result[key] = restoreEventPayloadObjectKeyOrder(
+      value[key],
+      [...path, key],
+      keyOrder,
+    );
+  }
+  return result;
+}
+
+/**
+ * JSONB reorders object keys. Persist their original order alongside the values
+ * so claim can reproduce the pre-queue system prompt byte for byte.
+ */
+export function persistedWorkflowAutomationEventPayload(
+  payload: WorkflowAutomationEventPayload,
+): WorkflowAutomationEventPayload {
+  if (EVENT_PAYLOAD_OBJECT_KEY_ORDER in payload) {
+    throw new Error("Workflow automation event payload uses a reserved field");
+  }
+  const objectKeyOrder: EventPayloadObjectKeyOrder[] = [];
+  collectEventPayloadObjectKeyOrder(payload, [], objectKeyOrder);
+  return {
+    ...payload,
+    [EVENT_PAYLOAD_OBJECT_KEY_ORDER]: objectKeyOrder,
+  };
+}
+
+/** Rows admitted before key-order metadata was written must use the blob. */
+export function restoredWorkflowAutomationEventPayload(
+  payload: WorkflowAutomationEventPayload,
+): WorkflowAutomationEventPayload | null {
+  const parsed = eventPayloadObjectKeyOrderSchema.safeParse(
+    payload[EVENT_PAYLOAD_OBJECT_KEY_ORDER],
+  );
+  if (!parsed.success) {
+    return null;
+  }
+  const keyOrder = new Map(
+    parsed.data.map((entry) => {
+      return [eventPayloadPathKey(entry.path), entry.keys] as const;
+    }),
+  );
+  const restored = restoreEventPayloadObjectKeyOrder(payload, [], keyOrder);
+  if (
+    typeof restored !== "object" ||
+    restored === null ||
+    !isEventPayload(restored)
+  ) {
+    throw new Error(
+      "Stored workflow automation event payload is not an object",
+    );
+  }
+  return restored;
 }
 
 function objectField(

--- a/turbo/apps/api/src/signals/services/workflow-automation-context.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-context.service.ts
@@ -1,9 +1,13 @@
-import type { ZeroWorkflowEventType } from "@vm0/api-contracts/contracts/zero-workflows";
+import { zeroWorkflowEventTypeSchema } from "@vm0/api-contracts/contracts/zero-workflows";
+import { z } from "zod";
 
-export type WorkflowAutomationEventType =
-  | ZeroWorkflowEventType
-  | "schedule"
-  | "manual";
+export const workflowAutomationEventTypeSchema = zeroWorkflowEventTypeSchema.or(
+  z.enum(["schedule", "manual"]),
+);
+
+export type WorkflowAutomationEventType = z.infer<
+  typeof workflowAutomationEventTypeSchema
+>;
 
 export type WorkflowAutomationEventPayload = Readonly<Record<string, unknown>>;
 
@@ -346,6 +350,20 @@ export function workflowAutomationTrigger(args: {
   readonly eventPayload: WorkflowAutomationEventPayload;
 }): string {
   return TRIGGER_RENDERERS[args.eventType](args.eventPayload);
+}
+
+export function storedWorkflowAutomationContext(args: {
+  readonly workflowName: string;
+  readonly eventType: WorkflowAutomationEventType;
+  readonly eventPayload: WorkflowAutomationEventPayload;
+}): WorkflowAutomationContext {
+  return {
+    workflowName: args.workflowName,
+    eventType: args.eventType,
+    trigger: workflowAutomationTrigger(args),
+    notes: EVENT_NOTES[args.eventType],
+    event: args.eventPayload,
+  };
 }
 
 /**

--- a/turbo/apps/api/src/signals/services/workflow-automation-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-queued-launch-context.service.ts
@@ -1,5 +1,6 @@
 import {
   EVENT_POLICY,
+  restoredWorkflowAutomationEventPayload,
   storedWorkflowAutomationContext,
   workflowAutomationAppendSystemPrompt,
   workflowAutomationEventTypeSchema,
@@ -40,10 +41,16 @@ export function buildWorkflowAutomationQueuedLaunchMaterial(args: {
     return null;
   }
   const eventType = workflowAutomationEventTypeSchema.parse(args.eventType);
+  const eventPayload = restoredWorkflowAutomationEventPayload(
+    args.eventPayload,
+  );
+  if (!eventPayload) {
+    return null;
+  }
   const context = storedWorkflowAutomationContext({
     workflowName: args.workflowName,
     eventType,
-    eventPayload: args.eventPayload,
+    eventPayload,
   });
   return {
     workflowName: args.workflowName,

--- a/turbo/apps/api/src/signals/services/workflow-automation-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-queued-launch-context.service.ts
@@ -1,0 +1,66 @@
+import {
+  EVENT_POLICY,
+  storedWorkflowAutomationContext,
+  workflowAutomationAppendSystemPrompt,
+  workflowAutomationEventTypeSchema,
+  workflowAutomationPrompt,
+  type WorkflowAutomationEventPayload,
+} from "./workflow-automation-context.service";
+import {
+  buildChatOnlyWorkflowAutomationCallbacks,
+  buildWorkflowAutomationCallbacks,
+  type AutomationRow,
+  type RunWorkflowAutomationNowArgs,
+} from "./zero-workflow-automation-launch.service";
+
+export interface WorkflowAutomationQueuedLaunchMaterial {
+  readonly workflowName: string;
+  readonly prompt?: string;
+  readonly appendSystemPrompt?: string;
+  readonly callbacks?: RunWorkflowAutomationNowArgs["callbacks"];
+  readonly activePreviousRunPolicy?: RunWorkflowAutomationNowArgs["activePreviousRunPolicy"];
+  readonly recordLastRunId?: boolean;
+  readonly recordLastRunAt?: boolean;
+  readonly allowClaimedOnceScheduleAutomation?: boolean;
+}
+
+export function buildWorkflowAutomationQueuedLaunchMaterial(args: {
+  readonly workflowName: string | null;
+  readonly eventType: string | null;
+  readonly eventPayload: WorkflowAutomationEventPayload | null;
+  readonly automation: AutomationRow;
+  readonly agentId: string;
+  readonly chatThreadId: string;
+}): WorkflowAutomationQueuedLaunchMaterial | null {
+  if (
+    args.workflowName === null ||
+    args.eventType === null ||
+    args.eventPayload === null
+  ) {
+    return null;
+  }
+  const eventType = workflowAutomationEventTypeSchema.parse(args.eventType);
+  const context = storedWorkflowAutomationContext({
+    workflowName: args.workflowName,
+    eventType,
+    eventPayload: args.eventPayload,
+  });
+  return {
+    workflowName: args.workflowName,
+    prompt: workflowAutomationPrompt(context),
+    appendSystemPrompt: workflowAutomationAppendSystemPrompt(context),
+    callbacks:
+      eventType === "schedule"
+        ? buildWorkflowAutomationCallbacks(
+            args.automation,
+            args.agentId,
+            args.chatThreadId,
+          )
+        : buildChatOnlyWorkflowAutomationCallbacks(
+            args.chatThreadId,
+            args.agentId,
+          ),
+    ...EVENT_POLICY[eventType],
+    allowClaimedOnceScheduleAutomation: args.automation.scheduleType === "once",
+  };
+}

--- a/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
@@ -65,11 +65,14 @@ const workflowQueueEventParamsWireSchema = z.object({
     .optional(),
   recordLastRunId: z.boolean().optional(),
   recordLastRunAt: z.boolean().optional(),
-  activePreviousRunPolicy: z.enum(["block", "allow"]),
+  activePreviousRunPolicy: z.enum(["block", "allow"]).optional(),
   allowClaimedOnceScheduleAutomation: z.boolean().optional(),
 });
 
-/** Queue-only run parameters retained as persistent-secret ciphertext. */
+/**
+ * The current writer encrypts only the version marker. Optional fields remain
+ * readable until historical pending automation events have drained.
+ */
 export interface WorkflowQueueEventParams {
   readonly version: 1;
   readonly prompt?: string;
@@ -81,7 +84,7 @@ export interface WorkflowQueueEventParams {
   }[];
   readonly recordLastRunId?: boolean;
   readonly recordLastRunAt?: boolean;
-  readonly activePreviousRunPolicy: "block" | "allow";
+  readonly activePreviousRunPolicy?: "block" | "allow";
   readonly allowClaimedOnceScheduleAutomation?: boolean;
 }
 
@@ -302,7 +305,10 @@ export interface PendingWorkflowQueueEvent {
   readonly chatThreadId: string;
   readonly triggerSource: TriggerSource;
   readonly triggerBrief: string | null;
-  readonly encryptedParams: string;
+  readonly workflowName: string | null;
+  readonly workflowAutomationEventType: string | null;
+  readonly workflowAutomationEventPayload: WorkflowAutomationEventPayload | null;
+  readonly encryptedParams: string | null;
   readonly createdAt: Date;
 }
 
@@ -344,6 +350,9 @@ export async function loadNextWorkflowQueueEvent(
         chatThreadId: chatEvents.chatThreadId,
         triggerSource: chatEvents.triggerSource,
         triggerBrief: chatAutomationContext.triggerBrief,
+        workflowName: chatAutomationContext.workflowName,
+        workflowAutomationEventType: chatAutomationContext.eventType,
+        workflowAutomationEventPayload: chatAutomationContext.eventPayload,
         encryptedParams: chatEventInputParams.encryptedParams,
         createdAt: chatEvents.createdAt,
       })
@@ -365,7 +374,7 @@ export async function loadNextWorkflowQueueEvent(
     if (!event) {
       return null;
     }
-    if (!event.automationId || !event.triggerSource || !event.encryptedParams) {
+    if (!event.automationId || !event.triggerSource) {
       throw new Error(
         `Workflow queue event ${event.id} is missing its typed payload`,
       );
@@ -374,7 +383,6 @@ export async function loadNextWorkflowQueueEvent(
       ...event,
       automationId: event.automationId,
       triggerSource: event.triggerSource,
-      encryptedParams: event.encryptedParams,
     };
   });
 }

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
@@ -160,12 +160,15 @@ function workflowAutomationRunMetadata(
  * render). Cron and once both use the cron callback; once carries no
  * cronExpression so it does not recur.
  */
-function buildWorkflowAutomationCallbacks(
+export function buildWorkflowAutomationCallbacks(
   automation: AutomationRow,
   agentId: string,
   chatThreadId: string,
 ): InternalRunCallbackInput[] {
   const callbacks: InternalRunCallbackInput[] = [];
+  if (automation.kind !== "schedule") {
+    return buildChatOnlyWorkflowAutomationCallbacks(chatThreadId, agentId);
+  }
   if (automation.scheduleType === "loop") {
     callbacks.push({
       internalKind: "workflow-automation:loop",

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -11,6 +11,7 @@ import {
   ApiDispatchTimingCollector,
   measureApiDispatchTiming,
 } from "./api-dispatch-timing.service";
+import { persistedWorkflowAutomationEventPayload } from "./workflow-automation-context.service";
 import type {
   RunWorkflowAutomationNowArgs,
   RunWorkflowAutomationResult,
@@ -65,7 +66,10 @@ export const runWorkflowAutomationNow$ = command(
           automation,
           workflowName: args.automationContext.workflowName,
           workflowAutomationEventType: args.automationContext.eventType,
-          workflowAutomationEventPayload: args.automationContext.event,
+          workflowAutomationEventPayload:
+            persistedWorkflowAutomationEventPayload(
+              args.automationContext.event,
+            ),
           chatThreadId,
           triggerSource: args.triggerSource ?? "workflow-schedule",
           triggerBrief: args.triggerBrief,

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -26,29 +26,11 @@ export {
   type RunWorkflowAutomationResult,
 } from "./zero-workflow-automation-launch.service";
 
-function queueEventParams(
-  args: RunWorkflowAutomationNowArgs,
-): WorkflowQueueEventParams {
+function queueEventParams(): WorkflowQueueEventParams {
+  // Keep only the wire-version marker until the encrypted-params fallback is
+  // removed after historical pending automation events have drained.
   return {
     version: 1,
-    ...(args.prompt !== undefined ? { prompt: args.prompt } : {}),
-    ...(args.appendSystemPrompt !== undefined
-      ? { appendSystemPrompt: args.appendSystemPrompt }
-      : {}),
-    ...(args.callbacks ? { callbacks: args.callbacks } : {}),
-    ...(args.recordLastRunId !== undefined
-      ? { recordLastRunId: args.recordLastRunId }
-      : {}),
-    ...(args.recordLastRunAt !== undefined
-      ? { recordLastRunAt: args.recordLastRunAt }
-      : {}),
-    activePreviousRunPolicy: args.activePreviousRunPolicy ?? "block",
-    ...(args.due.allowClaimedOnceScheduleAutomation !== undefined
-      ? {
-          allowClaimedOnceScheduleAutomation:
-            args.due.allowClaimedOnceScheduleAutomation,
-        }
-      : {}),
   };
 }
 
@@ -88,7 +70,7 @@ export const runWorkflowAutomationNow$ = command(
           triggerSource: args.triggerSource ?? "workflow-schedule",
           triggerBrief: args.triggerBrief,
           coalescePendingScheduleRun: args.coalescePendingScheduleRun !== false,
-          params: queueEventParams(args),
+          params: queueEventParams(),
           persistSourceTransition: args.persistSourceTransition,
         });
       },

--- a/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
@@ -18,6 +18,10 @@ import {
 } from "./workflow-chat-event-queue.service";
 import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
 import {
+  buildWorkflowAutomationQueuedLaunchMaterial,
+  type WorkflowAutomationQueuedLaunchMaterial,
+} from "./workflow-automation-queued-launch-context.service";
+import {
   launchQueuedWorkflowAutomation$,
   type RunWorkflowAutomationResult,
 } from "./zero-workflow-automation-launch.service";
@@ -32,6 +36,47 @@ interface DequeueTarget {
   readonly automation: typeof zeroWorkflowAutomations.$inferSelect;
   readonly agentId: string;
   readonly workflowName: string;
+}
+
+async function loadWorkflowQueueLaunchMaterial(
+  event: PendingWorkflowQueueEvent,
+  target: DequeueTarget,
+): Promise<WorkflowAutomationQueuedLaunchMaterial | null> {
+  const storedMaterial = buildWorkflowAutomationQueuedLaunchMaterial({
+    workflowName: event.workflowName,
+    eventType: event.workflowAutomationEventType,
+    eventPayload: event.workflowAutomationEventPayload,
+    automation: target.automation,
+    agentId: target.agentId,
+    chatThreadId: event.chatThreadId,
+  });
+  if (storedMaterial) {
+    return storedMaterial;
+  }
+  if (!event.encryptedParams) {
+    return null;
+  }
+  const legacyParams = await decryptWorkflowQueueEventParams(
+    event.encryptedParams,
+    {
+      userId: target.automation.ownerUserId,
+      orgId: target.automation.orgId,
+    },
+  );
+  if (!legacyParams) {
+    return null;
+  }
+  return {
+    workflowName: target.workflowName,
+    prompt: legacyParams.prompt,
+    appendSystemPrompt: legacyParams.appendSystemPrompt,
+    callbacks: legacyParams.callbacks,
+    activePreviousRunPolicy: legacyParams.activePreviousRunPolicy,
+    recordLastRunId: legacyParams.recordLastRunId,
+    recordLastRunAt: legacyParams.recordLastRunAt,
+    allowClaimedOnceScheduleAutomation:
+      legacyParams.allowClaimedOnceScheduleAutomation,
+  };
 }
 
 async function loadDequeueTarget(
@@ -213,15 +258,12 @@ export const drainWorkflowQueueForThread$ = command(
         continue;
       }
 
-      const params = await decryptWorkflowQueueEventParams(
-        event.encryptedParams,
-        {
-          userId: target.automation.ownerUserId,
-          orgId: target.automation.orgId,
-        },
+      const launchMaterial = await loadWorkflowQueueLaunchMaterial(
+        event,
+        target,
       );
       signal.throwIfAborted();
-      if (!params) {
+      if (!launchMaterial) {
         log.error("Consuming undecryptable workflow queue event", {
           eventId: event.id,
           automationId: event.automationId,
@@ -249,22 +291,22 @@ export const drainWorkflowQueueForThread$ = command(
           due: {
             automation: target.automation,
             agentId: target.agentId,
-            workflowName: target.workflowName,
+            workflowName: launchMaterial.workflowName,
             chatThreadId: event.chatThreadId,
             allowClaimedOnceScheduleAutomation:
-              params.allowClaimedOnceScheduleAutomation,
+              launchMaterial.allowClaimedOnceScheduleAutomation,
           },
           queueEventId: event.id,
           queueEventCreatedAt: event.createdAt,
           apiStartTime: launchHint?.apiStartTime ?? args.apiStartTime ?? now(),
-          prompt: params.prompt,
+          prompt: launchMaterial.prompt,
           triggerBrief: event.triggerBrief ?? undefined,
           triggerSource: event.triggerSource,
-          appendSystemPrompt: params.appendSystemPrompt,
-          callbacks: params.callbacks,
-          activePreviousRunPolicy: params.activePreviousRunPolicy,
-          recordLastRunId: params.recordLastRunId,
-          recordLastRunAt: params.recordLastRunAt,
+          appendSystemPrompt: launchMaterial.appendSystemPrompt,
+          callbacks: launchMaterial.callbacks,
+          activePreviousRunPolicy: launchMaterial.activePreviousRunPolicy,
+          recordLastRunId: launchMaterial.recordLastRunId,
+          recordLastRunAt: launchMaterial.recordLastRunAt,
           dispatchFailedCallbacks: args.dispatchFailedCallbacks,
           timing: launchHint?.timing,
         },

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -35,6 +35,7 @@ import {
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
 import { decryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
+import { decryptWorkflowQueueEventParams } from "../signals/services/workflow-chat-event-queue.service";
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
@@ -554,6 +555,17 @@ export async function decryptChatEventInputParamsFixture(
     return null;
   }
   return await decryptQueuedUserMessageRunParams(row.encryptedParams, ctx);
+}
+
+export async function decryptWorkflowEventInputParamsFixture(
+  eventId: string,
+  ctx: { readonly orgId: string; readonly userId: string },
+) {
+  const row = await readChatEventInputParamsFixture(eventId);
+  if (!row) {
+    return null;
+  }
+  return await decryptWorkflowQueueEventParams(row.encryptedParams, ctx);
 }
 
 export async function findPendingChatEventInputParamsByPromptFixture(

--- a/turbo/packages/db/src/schema/chat-automation-context.ts
+++ b/turbo/packages/db/src/schema/chat-automation-context.ts
@@ -29,8 +29,9 @@ export const chatAutomationContext = pgTable(
     /**
      * Server-private workflow automation launch material retained permanently.
      * Raw third-party content is intentionally retained as its only database
-     * copy; read paths must project only explicitly required columns, and no
-     * caller may project the entire row.
+     * copy. Server-only object-key ordering metadata preserves byte-identical
+     * prompt rendering and is stripped at claim. Read paths must project only
+     * explicitly required columns, and no caller may project the entire row.
      */
     eventPayload: jsonb("event_payload").$type<JsonObject>(),
     createdAt: timestamp("created_at").defaultNow().notNull(),


### PR DESCRIPTION
## Summary

PR 2 of 3 for #24480.

- prefer the three `chat_automation_context` launch columns and reconstruct the trigger, prompt, system prompt, notes, policy, and callbacks at claim time
- keep the encrypted launch blob only as a fallback for historical pending rows that lack complete context or byte-preserving payload metadata
- write only the encrypted `{ "version": 1 }` marker for newly admitted automation events
- generate callback secrets at claim; schedule events receive loop/cron plus chat callbacks, while manual and event-driven firings receive chat only
- derive `allowClaimedOnceScheduleAutomation` from `automation.scheduleType === "once"`

## Compatibility

The context path does not decrypt or otherwise depend on `chat_event_input_params`; an integration assertion deliberately corrupts a new row's marker ciphertext and verifies that the complete context still drains. The previous-deployment fixture continues to cover the blob fallback.

PostgreSQL JSONB canonicalizes object key order, while the existing system prompt embeds `JSON.stringify(eventPayload)`. To preserve the required byte-for-byte output, new payloads carry server-private recursive key-order metadata inside `event_payload`; claim restores the original insertion order and strips that metadata before rendering. This metadata stores only object paths and key names, never a second copy of payload values. Rows admitted by PR 1 do not have the metadata, so they deliberately use the legacy blob fallback.

The wire schema keeps all legacy fields optional for this rollout window. PR 3 will remove the fallback and the workflow queue encryption helpers after the pending-row gate is clear.

`EVENT_POLICY.schedule.recordLastRunAt` remains `false`, matching the current schedule call path: the poller already stamps the fire time during its optimistic claim, and the queue launch currently omits `recordLastRunAt`. Setting it to `true` would replace that fire time with the later drain time.

## Tests

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/db lint`
- `pnpm -F @vm0/db check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/services/__tests__/workflow-automation-context.test.ts --silent=passed-only` (23 passed)
- every event type is round-tripped through simulated JSONB key reordering and asserted byte-for-byte against the previous trigger/system-prompt rendering
- added integration coverage for marker-only ciphertext, context-first behavior with unreadable ciphertext, and exact manual Run now prompt/system context

The focused DB integration file could not run locally because the repository's historical connector-identity migration gate rejects the local `vm0_test` database even after an isolated schema reset. No migration is changed here; the PR's pinned CI database lane is the authoritative integration run.
