### PR TITLE
perf(api): reuse zero bootstrap timezone

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1182,6 +1182,16 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         feature_switch_context_source: "preloaded",
       }),
     );
+    expect(
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_prepare_context_load_user_timezone",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        user_timezone_source: "preloaded",
+      }),
+    );
     expectApiDispatchActions(
       timingEvents,
       API_DISPATCH_PERMISSION_MANIFEST_SUBSTEP_ACTION_TYPES,
@@ -1278,6 +1288,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "test-oauth-secret",
       "fixture-confidential-secret",
     ]);
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(created.runId);
+    expect(claim.appendSystemPrompt ?? "").toContain("Timezone: UTC");
+    expect(claim.userTimezone).toBeUndefined();
 
     const {
       actor: warmActor,
@@ -1537,8 +1551,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
   });
 
   it("retains direct plan admission and emits create timing", async () => {
+    const bdd = createBddApi(context);
     const api = createRunsApi(context);
-    const { actor } = await entitledRunActor();
+    const { actor, runnerGroup } = await entitledRunActor();
+    await bdd.updateUserTimezone(actor, "Asia/Shanghai");
     const prompt = "direct service dispatch timing should not leak prompt";
     const composeName = `bdd-direct-service-timing-${randomUUID().slice(0, 8)}`;
     const compose = await api.createCompose(actor, {
@@ -1634,6 +1650,16 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         feature_switch_context_source: "database",
       }),
     );
+    expect(
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_prepare_context_load_user_timezone",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        user_timezone_source: "database",
+      }),
+    );
     expectApiDispatchSpanKind(
       timingEvents,
       ["api_dispatch_pre_create_agent_run"],
@@ -1646,6 +1672,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "fixture-confidential-secret",
     ]);
 
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(created.runId);
+    expect(claim.userTimezone).toBe("Asia/Shanghai");
     await api.requestCancelRun(actor, created.runId, [200]);
 
     if (!actor.orgId) {
@@ -9623,6 +9652,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     expect(appendSystemPrompt).toContain("Name: BDD User");
     expect(appendSystemPrompt).toContain(`Email: ${actor.email}`);
     expect(appendSystemPrompt).toContain("Timezone: America/Los_Angeles");
+    expect(claim.userTimezone).toBe("America/Los_Angeles");
 
     expect(claim.featureFlags).toMatchObject({
       [FeatureSwitchKey.ZeroChatMessaging]: false,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -6914,6 +6914,28 @@ async function loadUserTimezone(
   return row?.timezone ?? undefined;
 }
 
+async function resolvePreparedUserTimezone(input: {
+  readonly db: Db;
+  readonly args: CreateAgentRunArgs;
+  readonly timing: ApiDispatchTimingCollector;
+  readonly preloadedUserTimezone: string | null | undefined;
+}): Promise<string | undefined> {
+  return await input.timing.measure(
+    "api_dispatch_prepare_context_load_user_timezone",
+    "nested",
+    async () => {
+      if (input.preloadedUserTimezone !== undefined) {
+        return input.preloadedUserTimezone ?? undefined;
+      }
+      return await loadUserTimezone(input.db, input.args);
+    },
+    {
+      user_timezone_source:
+        input.preloadedUserTimezone === undefined ? "database" : "preloaded",
+    },
+  );
+}
+
 async function loadRunConnectorContexts(
   db: Db,
   args: {
@@ -7590,6 +7612,7 @@ function prepareRunContext(input: {
   readonly timing: ApiDispatchTimingCollector;
   readonly signal: AbortSignal;
   readonly preloadedFeatureSwitchContext: FeatureSwitchContext | undefined;
+  readonly preloadedUserTimezone: string | null | undefined;
   readonly preloadedConnectorCatalogSnapshot:
     | ConnectorRuntimeSnapshot
     | undefined;
@@ -7664,13 +7687,7 @@ function prepareRunContext(input: {
         return validation;
       }
 
-      const userTimezone = await timing.measure(
-        "api_dispatch_prepare_context_load_user_timezone",
-        "nested",
-        async () => {
-          return await loadUserTimezone(db, args);
-        },
-      );
+      const userTimezone = await resolvePreparedUserTimezone(input);
       signal.throwIfAborted();
 
       const outputMetadata = await timing.measure(
@@ -8037,6 +8054,7 @@ interface PrepareAgentRunArgs {
   readonly timing: ApiDispatchTimingCollector;
   readonly checkOrgPlanStatusBeforeContext: boolean;
   readonly preloadedFeatureSwitchContext?: FeatureSwitchContext;
+  readonly preloadedUserTimezone?: string | null;
   readonly preloadedConnectorCatalogSnapshot?: ConnectorRuntimeSnapshot;
 }
 
@@ -8109,6 +8127,7 @@ export const prepareAgentRun$ = command(
             timing,
             signal,
             preloadedFeatureSwitchContext: input.preloadedFeatureSwitchContext,
+            preloadedUserTimezone: input.preloadedUserTimezone,
             preloadedConnectorCatalogSnapshot:
               input.preloadedConnectorCatalogSnapshot,
           }),

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -8054,6 +8054,7 @@ interface PrepareAgentRunArgs {
   readonly timing: ApiDispatchTimingCollector;
   readonly checkOrgPlanStatusBeforeContext: boolean;
   readonly preloadedFeatureSwitchContext?: FeatureSwitchContext;
+  // Undefined means not preloaded; null is an authoritative missing value.
   readonly preloadedUserTimezone?: string | null;
   readonly preloadedConnectorCatalogSnapshot?: ConnectorRuntimeSnapshot;
 }

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -1001,6 +1001,7 @@ const createAgentRunAfterZeroPreCreate$ = command(
           timing: input.timing,
           checkOrgPlanStatusBeforeContext: false,
           preloadedFeatureSwitchContext: input.featureSwitchContext,
+          preloadedUserTimezone: input.userInfo.timezone,
           preloadedConnectorCatalogSnapshot: input.connectorCatalogSnapshot,
         },
         signal,


### PR DESCRIPTION
## Summary

- reuse the authorized Zero bootstrap timezone during generic run preparation
- preserve the database lookup for direct callers and report a fixed preloaded/database timing source
- cover null, explicit Zero, and direct database timezone behavior through route and runner-claim integration tests

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api build`
- repository pre-commit checks

## Compatibility

This changes private API preparation state only. It adds no schema, persisted-data, public API, queue, runner, or frontend contract.

Closes #24496
Relates to #24203
