### PR TITLE
refactor: reduce fallback slop in airtable auth

### DIFF
--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/airtable.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/airtable.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { HttpResponse, http } from "msw";
+import { exchangeAirtableCode } from "../airtable/oauth";
+import { server } from "../../__tests__/test-server";
+import { authCodeGrantFixture } from "./auth-code-grant-fixture";
+
+function authCodeGrant() {
+  return authCodeGrantFixture(["data.records:read"]);
+}
+
+describe("connector/providers/airtable", () => {
+  describe("exchangeAirtableCode", () => {
+    it("exchanges code for access token and user info", async () => {
+      const tokenHandler = http.post(
+        "https://airtable.com/oauth2/v1/token",
+        () => {
+          return HttpResponse.json({
+            access_token: "airtable-test-token",
+            refresh_token: "airtable-refresh-token",
+            expires_in: 3600,
+            scope: "data.records:read",
+          });
+        },
+      );
+      const whoamiHandler = http.get(
+        "https://api.airtable.com/v0/meta/whoami",
+        () => {
+          return HttpResponse.json({
+            id: "airtable-user-123",
+            email: "test@example.com",
+          });
+        },
+      );
+      server.use(tokenHandler, whoamiHandler);
+
+      const result = await exchangeAirtableCode(
+        authCodeGrant(),
+        "client-id",
+        "client-secret",
+        "test-code",
+        "https://example.com/callback",
+        "test-code-verifier",
+      );
+
+      expect(result.accessToken).toBe("airtable-test-token");
+      expect(result.refreshToken).toBe("airtable-refresh-token");
+      expect(result.expiresIn).toBe(3600);
+      expect(result.scopes).toEqual(["data.records:read"]);
+      expect(result.userInfo).toEqual({
+        id: "airtable-user-123",
+        username: "test@example.com",
+        email: "test@example.com",
+      });
+    });
+
+    it("rejects user info without the required Airtable user id", async () => {
+      const tokenHandler = http.post(
+        "https://airtable.com/oauth2/v1/token",
+        () => {
+          return HttpResponse.json({
+            access_token: "airtable-test-token",
+            refresh_token: "airtable-refresh-token",
+            expires_in: 3600,
+            scope: "data.records:read",
+          });
+        },
+      );
+      const whoamiHandler = http.get(
+        "https://api.airtable.com/v0/meta/whoami",
+        () => {
+          return HttpResponse.json({ email: "test@example.com" });
+        },
+      );
+      server.use(tokenHandler, whoamiHandler);
+
+      await expect(
+        exchangeAirtableCode(
+          authCodeGrant(),
+          "client-id",
+          "client-secret",
+          "test-code",
+          "https://example.com/callback",
+          "test-code-verifier",
+        ),
+      ).rejects.toThrow("No user id in Airtable user info response");
+    });
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/connectors/airtable/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/airtable/oauth.ts
@@ -227,8 +227,12 @@ async function fetchAirtableUserInfo(
     })
     .parse(await response.json());
 
+  if (!data.id) {
+    throw new Error("No user id in Airtable user info response");
+  }
+
   return {
-    id: data.id ?? "",
+    id: data.id,
     username: data.email ?? null,
     email: data.email ?? null,
   };


### PR DESCRIPTION
## Summary

- Reject Airtable `/v0/meta/whoami` responses that omit the required user ID instead of creating a connector grant identity with `id: ""`.
- Cover the complete authorization-code exchange with success and missing-ID regression cases.

## Scan

- Timestamp: `2026-08-01T20:01:55.942Z`
- Base commit: `2cdd0f6f3024e6076c9493c6e034d3ea9e3ac163`
- Files scanned: 3,917
- Total matches: 20,135

| Category | Matches |
| --- | ---: |
| `nullish` | 6,219 |
| `nullish-chain` | 134 |
| `field-fallback-chain` | 105 |
| `optional-prop` | 6,112 |
| `zod-optional` | 2,612 |
| `zod-loose-optional` | 5 |
| `loose-record` | 1,093 |
| `loose-index-signature` | 3 |
| `as-any` | 0 |
| `as-unknown-as` | 30 |
| `empty-fallback` | 628 |
| `string-fallback` | 666 |
| `null-undefined-fallback` | 1,686 |
| `empty-catch` | 3 |
| `promise-catch-swallow` | 16 |
| `rust-unwrap-or` | 667 |
| `rust-ok-discard` | 156 |

The scanner initially reported 233 high-confidence production-actionable matches and a suggested 5% budget of 12. Manual contract and call-site review found one candidate safe enough for this run; the other reviewed matches were compatibility adapters, display fallbacks, tolerant readers, or test infrastructure. Therefore:

- `actionable_total`: 1
- `edit_budget`: 1
- Candidates changed: 1

## Changes

- `turbo/packages/connectors/src/auth-providers/connectors/airtable/oauth.ts`: fail fast when Airtable omits `id`. This is safe because vm0's grant contract requires `userInfo.id`, and the API persists it as the connector grant's `externalId`.
- `turbo/packages/connectors/src/auth-providers/connectors/__tests__/airtable.test.ts`: exercise the complete token plus `/whoami` exchange and assert the missing-ID rejection.

## Verification

- `pnpm exec prettier --write` on both changed files
- `pnpm --filter @vm0/connectors exec vitest run src/auth-providers/connectors/__tests__/airtable.test.ts` (2 tests passed)
- `pnpm --filter @vm0/connectors lint` (passed; one pre-existing non-blocking warning in `src/firewall-types.ts`)
- `pnpm --filter @vm0/connectors check-types`
- Pre-commit hooks: Prettier, Knip, all workspace type checks, and file-size check
- `git diff --check`
- Rescan: `nullish` 6,219 -> 6,218; `string-fallback` 666 -> 665

This workflow intentionally leaves the remaining candidates for later daily runs.
