### PR TITLE
refactor: claim github chat launch context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-chat.test.ts
@@ -9,9 +9,11 @@ import { env } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import {
+  clearGitHubTriggerCommentBodyFixture,
   decryptChatEventInputParamsFixture,
   findPendingChatEventInputParamsByPromptFixture,
   readChatEventContextFixture,
+  replaceGitHubLaunchMaterialWithLegacyParamsFixture,
 } from "../../../test-fixtures/chat-events";
 import {
   countGitHubRunsByPromptFixture,
@@ -471,18 +473,24 @@ describe("GitHub canonical chat threads", () => {
   it("routes pull request mentions through the same canonical table and preserves PR context", async () => {
     const fixture = await seedFixture();
     const subjectNumber = 24_001;
+    const githubFileUrl =
+      "https://github.com/user-attachments/files/12345/review.txt";
+    const rawFilePrompt = `review this pull request ${githubFileUrl}`;
+    const filePrompt = [
+      "review this pull request [GitHub file]",
+      `[URL] ${githubFileUrl}`,
+      "[FILENAME] review.txt",
+    ].join("\n");
     await sendGitHubComment({
       fixture,
       githubUserId: fixture.githubUserA,
       commentId: 30_001,
-      prompt: "review this pull request",
+      prompt: rawFilePrompt,
       subjectNumber,
       subjectKind: "pull_request",
     });
-    const run = await runState(
-      fixture.actorA.userId,
-      "review this pull request",
-    );
+    const run = await runState(fixture.actorA.userId, filePrompt);
+    expect(run.prompt).toBe(filePrompt);
     expect(run.triggerSource).toBe("github");
     expect(run.appendSystemPrompt).toContain(
       `Pull Request URL: https://github.com/${REPO}/pull/${subjectNumber}`,
@@ -515,20 +523,7 @@ describe("GitHub canonical chat threads", () => {
         orgId: fixture.actorA.orgId,
         userId: fixture.actorA.userId,
       }),
-    ).resolves.toMatchObject({
-      version: 1,
-      prompt: "follow up in FIFO order",
-      githubDelivery: {
-        installationId: fixture.installationId,
-        repo: REPO,
-        subjectNumber,
-        subjectKind: "pull_request",
-        agentId: fixture.agentId,
-        triggerCommentId: "30002",
-        triggerReactionId: expect.any(String),
-        triggerCommentBody: "@Zero follow up in FIFO order",
-      },
-    });
+    ).resolves.toStrictEqual({ version: 1 });
     await expect(
       readChatEventContextFixture(queuedParams.eventId),
     ).resolves.toMatchObject({
@@ -545,6 +540,49 @@ describe("GitHub canonical chat threads", () => {
       githubTriggerReactionId: expect.any(String),
       githubTriggerCommentBody: "@Zero follow up in FIFO order",
     });
+    await clearGitHubTriggerCommentBodyFixture(queuedParams.eventId);
+
+    const legacyQueuedPrompt = "queued before the GitHub claim cutover";
+    await sendGitHubComment({
+      fixture,
+      githubUserId: fixture.githubUserA,
+      commentId: 30_003,
+      prompt: legacyQueuedPrompt,
+      subjectNumber,
+      subjectKind: "pull_request",
+    });
+    const legacyQueuedParams =
+      await findPendingChatEventInputParamsByPromptFixture(legacyQueuedPrompt);
+    if (!legacyQueuedParams) {
+      throw new Error("Expected legacy queued GitHub chat input params");
+    }
+    const legacyContext = await readChatEventContextFixture(
+      legacyQueuedParams.eventId,
+    );
+    if (!legacyContext?.githubTriggerReactionId) {
+      throw new Error("Expected queued GitHub reaction context");
+    }
+    const legacyPrompt = "legacy queued GitHub prompt";
+    const legacySystemPrompt = "legacy queued GitHub system prompt";
+    await replaceGitHubLaunchMaterialWithLegacyParamsFixture(
+      legacyQueuedParams.eventId,
+      {
+        orgId: fixture.actorA.orgId,
+        userId: fixture.actorA.userId,
+        prompt: legacyPrompt,
+        appendSystemPrompt: legacySystemPrompt,
+        githubDelivery: {
+          installationId: fixture.installationId,
+          repo: REPO,
+          subjectNumber,
+          subjectKind: "pull_request",
+          agentId: fixture.agentId,
+          triggerCommentId: "30003",
+          triggerReactionId: legacyContext.githubTriggerReactionId,
+          triggerCommentBody: `@Zero ${legacyQueuedPrompt}`,
+        },
+      },
+    );
 
     const firstCliSession = await claimAndFinish({ fixture, run });
     const followUp = await runState(
@@ -553,10 +591,17 @@ describe("GitHub canonical chat threads", () => {
     );
     expect(followUp.chatThreadId).toBe(run.chatThreadId);
     expect(followUp.sessionId).toBe(run.sessionId);
-    await claimAndFinish({
+    const followUpCliSession = await claimAndFinish({
       fixture,
       run: followUp,
       expectedResumeSessionId: firstCliSession,
+    });
+    const legacyRun = await runState(fixture.actorA.userId, legacyPrompt);
+    expect(legacyRun.appendSystemPrompt).toContain(legacySystemPrompt);
+    await claimAndFinish({
+      fixture,
+      run: legacyRun,
+      expectedResumeSessionId: followUpCliSession,
     });
 
     const routes = await routeRows({
@@ -567,17 +612,20 @@ describe("GitHub canonical chat threads", () => {
       expect.objectContaining({
         userId: fixture.actorA.userId,
         chatThreadId: run.chatThreadId,
-        lastCommentId: "30002",
+        lastCommentId: "30003",
       }),
     ]);
     expect(fixture.postedComments).toStrictEqual([
       expect.objectContaining({
         subjectNumber,
-        body: expect.stringContaining("> @Zero review this pull request"),
+        body: expect.stringContaining(`> @Zero ${rawFilePrompt}`),
       }),
       expect.objectContaining({
         subjectNumber,
-        body: expect.stringContaining("> @Zero follow up in FIFO order"),
+      }),
+      expect.objectContaining({
+        subjectNumber,
+        body: expect.stringContaining(`> @Zero ${legacyQueuedPrompt}`),
       }),
     ]);
   });

--- a/turbo/apps/api/src/signals/services/github-chat-prompt.service.ts
+++ b/turbo/apps/api/src/signals/services/github-chat-prompt.service.ts
@@ -1,0 +1,35 @@
+import { optionalEnv } from "../../lib/env";
+
+export function githubAppBotUsername(): string | undefined {
+  const appSlug = optionalEnv("GITHUB_APP_SLUG")?.trim();
+  if (!appSlug) {
+    return undefined;
+  }
+  return `@${appSlug}[bot]`;
+}
+
+function buildIntegrationPrompt(): string {
+  const headerParts = [
+    "# Current Integration",
+    "You are currently running inside: GitHub",
+    "GitHub comments run agents when issues or pull requests mention Zero.",
+  ];
+  const botUsername = githubAppBotUsername();
+  if (botUsername) {
+    headerParts.push(`Bot username: ${botUsername}`);
+  }
+  return headerParts.join("\n");
+}
+
+export function buildGitHubPrompt(args: {
+  readonly issueContext: string;
+  readonly repo: string;
+  readonly issueNumber: number;
+  readonly subjectKind: "issue" | "pull_request";
+}): string {
+  return [buildIntegrationPrompt(), args.issueContext]
+    .filter((part): part is string => {
+      return Boolean(part);
+    })
+    .join("\n\n");
+}

--- a/turbo/apps/api/src/signals/services/github-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/github-queued-launch-context.service.ts
@@ -1,0 +1,153 @@
+import { chatEvents } from "@vm0/db/schema/chat-event";
+import { chatGithubContext } from "@vm0/db/schema/chat-github-context";
+import { githubChatThreadRoutes } from "@vm0/db/schema/github-chat-thread-route";
+import { githubInstallations } from "@vm0/db/schema/github-installation";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { and, eq } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+import {
+  githubDeliveryTargetSchema,
+  type GitHubDeliveryTarget,
+} from "./github-chat-callback-payload";
+import { buildGitHubPrompt } from "./github-chat-prompt.service";
+
+export interface GitHubQueuedLaunchMaterial {
+  readonly prompt: string;
+  readonly appendSystemPrompt: string;
+  readonly githubDelivery: GitHubDeliveryTarget;
+}
+
+type GitHubLaunchContextRow = Pick<
+  typeof chatGithubContext.$inferSelect,
+  | "repo"
+  | "subjectNumber"
+  | "subjectKind"
+  | "triggerCommentId"
+  | "issueContext"
+  | "messageText"
+  | "triggerReactionId"
+  | "triggerCommentBody"
+> & {
+  readonly installationId: string;
+  readonly agentId: string;
+};
+
+function requiredGitHubLaunchContext(row: GitHubLaunchContextRow | undefined) {
+  if (!row || row.issueContext === null || row.messageText === null) {
+    return null;
+  }
+  return {
+    ...row,
+    issueContext: row.issueContext,
+    messageText: row.messageText,
+  };
+}
+
+async function loadGitHubLaunchContext(
+  db: Db,
+  args: {
+    readonly eventId: string;
+    readonly chatThreadId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+) {
+  const [row] = await db
+    .select({
+      repo: chatGithubContext.repo,
+      subjectNumber: chatGithubContext.subjectNumber,
+      subjectKind: chatGithubContext.subjectKind,
+      triggerCommentId: chatGithubContext.triggerCommentId,
+      issueContext: chatGithubContext.issueContext,
+      messageText: chatGithubContext.messageText,
+      triggerReactionId: chatGithubContext.triggerReactionId,
+      triggerCommentBody: chatGithubContext.triggerCommentBody,
+      installationId: githubChatThreadRoutes.installationId,
+      agentId: chatThreads.agentComposeId,
+    })
+    .from(chatEvents)
+    .innerJoin(
+      chatGithubContext,
+      and(
+        eq(chatGithubContext.id, chatEvents.contextId),
+        eq(chatGithubContext.chatThreadId, chatEvents.chatThreadId),
+      ),
+    )
+    .innerJoin(
+      githubChatThreadRoutes,
+      and(
+        eq(githubChatThreadRoutes.chatThreadId, chatEvents.chatThreadId),
+        eq(githubChatThreadRoutes.repo, chatGithubContext.repo),
+        eq(
+          githubChatThreadRoutes.subjectNumber,
+          chatGithubContext.subjectNumber,
+        ),
+        eq(githubChatThreadRoutes.userId, args.userId),
+      ),
+    )
+    .innerJoin(
+      githubInstallations,
+      and(
+        eq(githubInstallations.id, githubChatThreadRoutes.installationId),
+        eq(githubInstallations.orgId, args.orgId),
+      ),
+    )
+    .innerJoin(
+      chatThreads,
+      and(
+        eq(chatThreads.id, chatEvents.chatThreadId),
+        eq(chatThreads.userId, args.userId),
+      ),
+    )
+    .where(
+      and(
+        eq(chatEvents.id, args.eventId),
+        eq(chatEvents.chatThreadId, args.chatThreadId),
+        eq(chatEvents.contextType, "github"),
+        eq(chatEvents.triggerSource, "github"),
+      ),
+    )
+    .limit(1);
+  return requiredGitHubLaunchContext(row);
+}
+
+export async function loadGitHubQueuedLaunchMaterial(
+  db: Db,
+  args: {
+    readonly eventId: string;
+    readonly chatThreadId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+): Promise<GitHubQueuedLaunchMaterial | null> {
+  const context = await loadGitHubLaunchContext(db, args);
+  if (!context) {
+    return null;
+  }
+  return {
+    prompt: context.messageText,
+    appendSystemPrompt: buildGitHubPrompt({
+      issueContext: context.issueContext,
+      repo: context.repo,
+      issueNumber: context.subjectNumber,
+      subjectKind: context.subjectKind,
+    }),
+    githubDelivery: githubDeliveryTargetSchema.parse({
+      installationId: context.installationId,
+      repo: context.repo,
+      subjectNumber: context.subjectNumber,
+      subjectKind: context.subjectKind,
+      agentId: context.agentId,
+      ...(context.triggerCommentId !== null
+        ? { triggerCommentId: context.triggerCommentId }
+        : {}),
+      ...(context.triggerReactionId !== null
+        ? { triggerReactionId: context.triggerReactionId }
+        : {}),
+      ...(context.triggerCommentBody !== null
+        ? { triggerCommentBody: context.triggerCommentBody }
+        : {}),
+    }),
+  };
+}

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -179,6 +179,10 @@ import {
   loadTeamsQueuedLaunchMaterial,
   type TeamsQueuedLaunchMaterial,
 } from "./teams-queued-launch-context.service";
+import {
+  loadGitHubQueuedLaunchMaterial,
+  type GitHubQueuedLaunchMaterial,
+} from "./github-queued-launch-context.service";
 
 const log = logger("callback:chat");
 const PG_FOREIGN_KEY_VIOLATION = "23503";
@@ -2695,7 +2699,8 @@ type LaunchLoader = (
 type NativeQueuedLaunchMaterial =
   | SlackQueuedLaunchMaterial
   | FeishuQueuedLaunchMaterial
-  | TeamsQueuedLaunchMaterial;
+  | TeamsQueuedLaunchMaterial
+  | (GitHubQueuedLaunchMaterial & { readonly userInfoExtras?: undefined });
 
 function launchLoader<Material extends NativeQueuedLaunchMaterial>(
   load: (db: Db, args: QueuedLaunchLoaderArgs) => Promise<Material | null>,
@@ -2719,6 +2724,7 @@ function launchLoader<Material extends NativeQueuedLaunchMaterial>(
 
 async function resolveQueuedLaunchMaterial(
   args: CreateQueuedChatRunInputArgs,
+  sourceParams: QueuedSourceParams,
 ): Promise<QueuedLaunchMaterial | null> {
   const launchLoaders: Partial<Record<TriggerSource, LaunchLoader>> = {
     slack: launchLoader(loadSlackQueuedLaunchMaterial, (material) => {
@@ -2729,6 +2735,9 @@ async function resolveQueuedLaunchMaterial(
     }),
     teams: launchLoader(loadTeamsQueuedLaunchMaterial, (material) => {
       return { teamsDelivery: material.teamsDelivery };
+    }),
+    github: launchLoader(loadGitHubQueuedLaunchMaterial, (material) => {
+      return { githubDelivery: material.githubDelivery };
     }),
   };
   const load = launchLoaders[args.queuedMessage.triggerSource];
@@ -2743,6 +2752,14 @@ async function resolveQueuedLaunchMaterial(
   });
   if (material) {
     return material;
+  }
+  if (
+    args.queuedMessage.triggerSource === "github" &&
+    sourceParams?.prompt !== undefined &&
+    sourceParams.appendSystemPrompt !== undefined &&
+    sourceParams.githubDelivery
+  ) {
+    return null;
   }
   throw new Error(
     `${args.queuedMessage.triggerSource} queue item is missing launch material`,
@@ -2897,13 +2914,10 @@ function agentPhoneQueuedMessageAdmissionFailure(
 
 function githubQueuedMessageAdmissionFailure(
   args: CreateQueuedChatRunInputArgs,
-  sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
+  githubDelivery: CreateQueuedChatRunInput["githubDelivery"],
   error: QueuedMessageModelRouteError,
 ): GitHubQueuedMessageAdmissionFailure | null {
-  if (
-    args.queuedMessage.triggerSource !== "github" ||
-    !sourceParams?.githubDelivery
-  ) {
+  if (args.queuedMessage.triggerSource !== "github" || !githubDelivery) {
     return null;
   }
   return {
@@ -2913,7 +2927,7 @@ function githubQueuedMessageAdmissionFailure(
     agentId: args.agent.id,
     threadId: args.threadId,
     queuedMessage: args.queuedMessage,
-    githubDelivery: sourceParams.githubDelivery,
+    githubDelivery,
     error,
   };
 }
@@ -2958,7 +2972,8 @@ function queuedMessageAdmissionFailure(
     github: (resolverArgs) => {
       return githubQueuedMessageAdmissionFailure(
         resolverArgs.args,
-        resolverArgs.sourceParams,
+        resolverArgs.launchMaterial?.delivery.githubDelivery ??
+          resolverArgs.sourceParams?.githubDelivery,
         resolverArgs.error,
       );
     },
@@ -2982,6 +2997,9 @@ function queuedMessagePrompt(args: {
 }): string {
   if (args.launchMaterial) {
     return args.launchMaterial.prompt;
+  }
+  if (args.triggerSource === "github") {
+    return args.sourceParams?.prompt ?? "";
   }
   if (args.triggerSource === "workflow-schedule") {
     return args.sourceParams?.prompt ?? args.projectedPrompt;
@@ -3032,7 +3050,7 @@ async function loadQueuedRunMaterial(args: CreateQueuedChatRunInputArgs) {
   if (args.queuedMessage.triggerSource !== "web" && !sourceParams) {
     throw new Error("Canonical integration queue item is missing run params");
   }
-  const launchMaterial = await resolveQueuedLaunchMaterial(args);
+  const launchMaterial = await resolveQueuedLaunchMaterial(args, sourceParams);
   return {
     sourceParams,
     launchMaterial,

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -32,6 +32,7 @@ import {
 } from "./github-issues-api.service";
 import { getGithubInstallationAccessToken } from "./github-app.service";
 import { signGithubConnectParams } from "./github-oauth.service";
+import { githubAppBotUsername } from "./github-chat-prompt.service";
 import { resolveIntegrationModelRouteForUser$ } from "./integration-model-route.service";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import { drainChatThreadQueueForThread$ } from "./chat-thread-queue-drain.service";
@@ -316,14 +317,6 @@ function githubSubjectUrl(args: {
   return `https://github.com/${args.repo}/${pathSegment}/${args.issueNumber}`;
 }
 
-function githubAppBotUsername(): string | undefined {
-  const appSlug = optionalEnv("GITHUB_APP_SLUG")?.trim();
-  if (!appSlug) {
-    return undefined;
-  }
-  return `@${appSlug}[bot]`;
-}
-
 function githubAppMentionHandles(): readonly string[] {
   const handles: string[] = [...GITHUB_ALIAS_MENTION_HANDLES];
   const appSlug = optionalEnv("GITHUB_APP_SLUG")?.trim().replace(/^@+/, "");
@@ -362,49 +355,6 @@ function githubIssueCommentSubjectKind(
   issue: GitHubIssue,
 ): GitHubAutomationKind {
   return issue.pull_request === undefined ? "issue" : "pull_request";
-}
-
-function buildIntegrationPrompt(): string {
-  const headerParts = [
-    "# Current Integration",
-    "You are currently running inside: GitHub",
-    "GitHub comments run agents when issues or pull requests mention Zero.",
-  ];
-  const botUsername = githubAppBotUsername();
-  if (botUsername) {
-    headerParts.push(`Bot username: ${botUsername}`);
-  }
-  return headerParts.join("\n");
-}
-
-function buildGitHubPrompt(args: {
-  readonly issueContext: string;
-  readonly repo: string;
-  readonly issueNumber: number;
-  readonly subjectKind: GitHubAutomationKind;
-}): string {
-  return [buildIntegrationPrompt(), args.issueContext]
-    .filter((part): part is string => {
-      return Boolean(part);
-    })
-    .join("\n\n");
-}
-
-function buildPromptParts(
-  prompt: string,
-  args: {
-    readonly issueContext: string;
-    readonly repo: string;
-    readonly issueNumber: number;
-    readonly subjectKind: GitHubAutomationKind;
-  },
-): {
-  readonly prompt: string;
-  readonly appendSystemPrompt: string | undefined;
-} {
-  const appendSystemPrompt = buildGitHubPrompt(args) || undefined;
-
-  return { prompt, appendSystemPrompt };
 }
 
 function buildGithubMentionConnectUrl(args: {
@@ -1244,28 +1194,13 @@ async function insertGitHubChatInput(args: {
   readonly params: DispatchParams;
   readonly target: GitHubRunTarget;
   readonly prompt: string;
-  readonly promptParts: ReturnType<typeof buildPromptParts>;
   readonly issueContext: string;
   readonly reactionId: string | undefined;
   readonly currentTime: Date;
 }): Promise<{ readonly chatEventId: string; readonly inserted: boolean }> {
   const issueNumber = args.params.issue.number;
   const encryptedParams = await encryptQueuedUserMessageRunParams(
-    {
-      version: 1,
-      prompt: args.promptParts.prompt,
-      appendSystemPrompt: args.promptParts.appendSystemPrompt ?? "",
-      githubDelivery: {
-        installationId: args.route.installationId,
-        repo: args.params.repo,
-        subjectNumber: issueNumber,
-        subjectKind: args.params.subjectKind,
-        agentId: args.target.composeId,
-        triggerCommentId: args.params.commentId,
-        triggerReactionId: args.reactionId,
-        triggerCommentBody: args.params.comment?.body,
-      },
-    },
+    { version: 1 },
     { orgId: args.target.orgId, userId: args.params.vm0UserId },
   );
 
@@ -1305,7 +1240,7 @@ async function insertGitHubChatInput(args: {
           subjectKind: args.params.subjectKind,
           triggerCommentId: args.params.commentId ?? null,
           issueContext: args.issueContext,
-          messageText: args.promptParts.prompt,
+          messageText: args.prompt,
           triggerReactionId: args.reactionId ?? null,
           triggerCommentBody: args.params.comment?.body ?? null,
         },
@@ -1390,13 +1325,6 @@ const dispatchGithubAgentRun$ = command(
       issueNumber,
       signal,
     });
-    const promptParts = buildPromptParts(prompt, {
-      issueContext,
-      repo: params.repo,
-      issueNumber,
-      subjectKind: params.subjectKind,
-    });
-
     const reactionId = await maybeAddCommentReaction({
       token,
       repo: params.repo,
@@ -1411,7 +1339,6 @@ const dispatchGithubAgentRun$ = command(
       params,
       target,
       prompt,
-      promptParts,
       issueContext,
       reactionId,
       currentTime,

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -35,7 +35,11 @@ import {
 } from "../signals/services/zero-chat-event.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
-import { decryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
+import type { GitHubDeliveryTarget } from "../signals/services/github-chat-callback-payload";
+import {
+  decryptQueuedUserMessageRunParams,
+  encryptQueuedUserMessageRunParams,
+} from "../signals/services/zero-chat-queued-event.service";
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
@@ -582,6 +586,68 @@ export async function decryptChatEventInputParamsFixture(
     return null;
   }
   return await decryptQueuedUserMessageRunParams(row.encryptedParams, ctx);
+}
+
+export async function replaceGitHubLaunchMaterialWithLegacyParamsFixture(
+  eventId: string,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly prompt: string;
+    readonly appendSystemPrompt: string;
+    readonly githubDelivery: GitHubDeliveryTarget;
+  },
+): Promise<void> {
+  const [event] = await db()
+    .select({ contextId: chatEvents.contextId })
+    .from(chatEvents)
+    .where(eq(chatEvents.id, eventId))
+    .limit(1);
+  if (!event?.contextId) {
+    throw new Error("Expected pending GitHub event context");
+  }
+  const contextId = event.contextId;
+  const encryptedParams = await encryptQueuedUserMessageRunParams(
+    {
+      version: 1,
+      prompt: args.prompt,
+      appendSystemPrompt: args.appendSystemPrompt,
+      githubDelivery: args.githubDelivery,
+    },
+    { orgId: args.orgId, userId: args.userId },
+  );
+  await db().transaction(async (tx) => {
+    await tx
+      .update(chatGithubContext)
+      .set({
+        issueContext: null,
+        messageText: null,
+        triggerReactionId: null,
+        triggerCommentBody: null,
+      })
+      .where(eq(chatGithubContext.id, contextId));
+    await tx
+      .update(chatEventInputParams)
+      .set({ encryptedParams })
+      .where(eq(chatEventInputParams.eventId, eventId));
+  });
+}
+
+export async function clearGitHubTriggerCommentBodyFixture(
+  eventId: string,
+): Promise<void> {
+  const [event] = await db()
+    .select({ contextId: chatEvents.contextId })
+    .from(chatEvents)
+    .where(eq(chatEvents.id, eventId))
+    .limit(1);
+  if (!event?.contextId) {
+    throw new Error("Expected pending GitHub event context");
+  }
+  await db()
+    .update(chatGithubContext)
+    .set({ triggerCommentBody: null })
+    .where(eq(chatGithubContext.id, event.contextId));
 }
 
 export async function findPendingChatEventInputParamsByPromptFixture(

--- a/turbo/apps/api/src/test-fixtures/github-chat.ts
+++ b/turbo/apps/api/src/test-fixtures/github-chat.ts
@@ -11,6 +11,7 @@ import { dispatchGitHubChatDeliveryOnce } from "../signals/services/internal-git
 export interface GitHubRunStateFixture {
   readonly id: string;
   readonly userId: string;
+  readonly prompt: string;
   readonly sessionId: string;
   readonly continuedFromSessionId: string | null;
   readonly appendSystemPrompt: string | null;
@@ -51,6 +52,7 @@ export async function findGitHubRunStateFixture(
     .select({
       id: agentRuns.id,
       userId: agentRuns.userId,
+      prompt: agentRuns.prompt,
       sessionId: agentRuns.sessionId,
       continuedFromSessionId: agentRuns.continuedFromSessionId,
       appendSystemPrompt: agentRuns.appendSystemPrompt,


### PR DESCRIPTION
## Summary

- add claim-time GitHub chat launch-material assembly from `chat_events`, `chat_github_context`, the canonical route, and its chat thread
- prefer context-backed prompt, system prompt, and delivery metadata while retaining the encrypted-blob fallback for pre-cutover queue items
- stop writing GitHub chat launch material to `chat_event_input_params`; new rows now store only `{ "version": 1 }`
- preserve `message_text` byte-for-byte after the existing GitHub file-reference replacement and run `buildGitHubPrompt` only at claim time

This is PR 2 of 3 for #24514, following #24515. The fallback remains until the production queue is reconciled with the exact original = run replacement + rejection + revocation gate.

## Derived fields

- `installationId` is joined from `github_chat_thread_routes.installation_id` and scoped through `github_installations.org_id`; it is not duplicated in context
- `agentId` is derived from `chat_threads.agent_compose_id`; ingress guarantees equality with `args.target.composeId` by creating/rebinding the route to a thread with that compose before inserting the event
- existing `repo`, `subject_number`, `subject_kind`, and `trigger_comment_id` columns remain the canonical delivery values

## Compatibility

- context is preferred when the new fields exist
- legacy encrypted params remain a fallback for queue rows created before this cutover
- new writers stop adding `prompt`, `appendSystemPrompt`, and `githubDelivery` to the blob
- no GitHub automation or queue-monitor files are changed

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- targeted Prettier and `git diff --check`
- did not run local Vitest or start a dev server, per issue instructions; PR CI owns integration execution

Integration coverage includes issue comments, pull-request comments, stored GitHub file-reference transformations, context-only launch, legacy fallback, correct issue/PR delivery and saved reaction metadata, and claim with a null comment body.