### PR TITLE
perf(api): reuse thread session browser state

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -110,6 +110,7 @@ import {
   setSecretKmsClientForTests,
   type SecretKmsClient,
 } from "../../../lib/secret-kms-client";
+import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 
 /**
  * RUN-01..04 and CHAIN-RUN: successful run dispatch and lifecycle.
@@ -9453,6 +9454,19 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     const fw = createFirewallApi(context);
     const misc = createMiscRoutesApi(context);
     const actor = bdd.user();
+    if (!actor.orgId) {
+      throw new Error("Zero runner context requires an organization");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      {
+        ...actor,
+        orgId: actor.orgId,
+      },
+      {
+        [FeatureSwitchKey.ZeroBrowser]: true,
+      },
+    );
     bdd.acceptAgentStorageWrites();
     api.acceptStorageDownloads();
     api.acceptTelemetryIngest();
@@ -9640,6 +9654,12 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     expect(appendSystemPrompt).not.toContain("zero chat send");
     expect(appendSystemPrompt).not.toContain("zero chat cancel");
     expect(appendSystemPrompt).not.toContain("zero chat queued");
+    expect(appendSystemPrompt).not.toContain(
+      "`zero browser use` creates, reuses, or resumes a remote browser",
+    );
+    expect(appendSystemPrompt).not.toContain(
+      "Zero Browser is currently off for this chat thread",
+    );
     for (const otherIntegrationHint of [
       "zero slack download-file -h",
       "zero github download-file -h",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -10,6 +10,7 @@ import {
   chatThreadEventsContract,
   chatThreadsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { describe, expect, test as vitestTest } from "vitest";
 import { z } from "zod";
@@ -31,6 +32,7 @@ import {
   setBrowserTabSnapshotAsPreviousApi,
   setComputerUseHostAsPreviousApi,
 } from "./helpers/runtime-state";
+import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -193,6 +195,10 @@ async function setupBrowserScenario() {
   const callbacks = createChatCallbacksApi(context);
   const webhooks = createWebhookCallbackApi(context);
   const actor = bdd.user();
+  if (!actor.orgId) {
+    throw new Error("Managed browser tests require an organization");
+  }
+  const orgActor = { ...actor, orgId: actor.orgId };
   callbacks.acceptChatObjectStorage();
   callbacks.disableVapid();
   callbacks.failIfChatCallbackRouteIsFetched();
@@ -201,9 +207,9 @@ async function setupBrowserScenario() {
   runs.acceptTelemetryIngest();
   const runnerGroup = runs.configureRunnerGroup();
   await runs.heartbeatRunner(runnerGroup);
-  await runs.grantProEntitlement(actor);
-  await runs.ensureOrgModelProvider(actor);
-  const agent = await bdd.createAgent(actor, {
+  await runs.grantProEntitlement(orgActor);
+  await runs.ensureOrgModelProvider(orgActor);
+  const agent = await bdd.createAgent(orgActor, {
     displayName: "Managed Browser Test",
     visibility: "private",
   });
@@ -213,7 +219,7 @@ async function setupBrowserScenario() {
     runs,
     chat,
     webhooks,
-    actor,
+    actor: orgActor,
     runnerGroup,
     agent,
   };
@@ -258,6 +264,9 @@ async function reconcileBrowsers() {
 describe("zero browser route", () => {
   it("keeps managed browser access off for a default chat thread", async () => {
     const { runs, chat, actor, agent } = await setupBrowserScenario();
+    await updateFeatureSwitchesForUser(context, actor, {
+      [FeatureSwitchKey.ZeroBrowser]: true,
+    });
     const sent = await chat.requestSendEvent(
       actor,
       {
@@ -269,6 +278,10 @@ describe("zero browser route", () => {
     if (sent.status !== 201 || sent.body.runId === null) {
       throw new Error("Expected a chat run");
     }
+    const claim = await runs.claimRunnerJob(sent.body.runId);
+    expect(claim.appendSystemPrompt ?? "").toContain(
+      "Zero Browser is currently off for this chat thread",
+    );
     const browserToken = runs.zeroTokenForRunWithCapabilities(
       actor,
       sent.body.runId,
@@ -285,6 +298,34 @@ describe("zero browser route", () => {
         message: "Cloud browser is not enabled for this chat thread",
       },
     });
+  });
+
+  it("advertises managed browser access for an enabled chat thread", async () => {
+    const { runs, chat, actor, agent } = await setupBrowserScenario();
+    await updateFeatureSwitchesForUser(context, actor, {
+      [FeatureSwitchKey.ZeroBrowser]: true,
+    });
+    const sent = await chat.requestSendEvent(
+      actor,
+      {
+        agentId: agent.agentId,
+        prompt: "Open a managed browser",
+        cloudBrowserEnabled: true,
+      },
+      [201],
+    );
+    if (sent.status !== 201 || sent.body.runId === null) {
+      throw new Error("Expected a chat run");
+    }
+
+    const claim = await runs.claimRunnerJob(sent.body.runId);
+    const appendSystemPrompt = claim.appendSystemPrompt ?? "";
+    expect(appendSystemPrompt).toContain(
+      "`zero browser use` creates, reuses, or resumes a remote browser",
+    );
+    expect(appendSystemPrompt).not.toContain(
+      "Zero Browser is currently off for this chat thread",
+    );
   });
 
   it("normalizes a previous API host-only write during cloud browser rollout", async () => {

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -42,6 +42,7 @@ export interface ChatThreadSessionResolution {
   readonly sessionId: string | undefined;
   readonly action: ChatThreadSessionResolutionAction;
   readonly expected: ChatThreadSessionSnapshot;
+  readonly cloudBrowserEnabled: boolean;
 }
 
 interface HistoricalThreadSession {
@@ -308,6 +309,7 @@ export async function resolveChatThreadSession(args: {
       routeRunId: zeroRuns.id,
       routeRunCreatedAt: agentRuns.createdAt,
       cliAgentType: conversations.cliAgentType,
+      cloudBrowserEnabled: chatThreads.cloudBrowserEnabled,
     })
     .from(chatThreads)
     .leftJoin(
@@ -366,6 +368,7 @@ export async function resolveChatThreadSession(args: {
       sessionId: rotate ? undefined : thread.sessionId,
       action: rotate ? "rotated" : "reused",
       expected,
+      cloudBrowserEnabled: thread.cloudBrowserEnabled,
     };
   }
 
@@ -380,6 +383,7 @@ export async function resolveChatThreadSession(args: {
         sessionId: null,
         conversationId: null,
       },
+      cloudBrowserEnabled: thread.cloudBrowserEnabled,
     };
   }
 
@@ -399,5 +403,6 @@ export async function resolveChatThreadSession(args: {
       sessionId: historical.sessionId,
       conversationId: historical.conversationId,
     },
+    cloudBrowserEnabled: thread.cloudBrowserEnabled,
   };
 }

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -19,7 +19,6 @@ import {
   agentComposeVersions,
   agentComposes,
 } from "@vm0/db/schema/agent-compose";
-import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { command } from "ccstate";
 import { and, eq } from "drizzle-orm";
@@ -498,32 +497,6 @@ async function inferAgentIdFromSession(
   return session?.agentComposeId ?? null;
 }
 
-async function loadThreadCloudBrowserEnabled(
-  db: Db,
-  args: {
-    readonly chatThreadId: string | undefined;
-    readonly orgId: string;
-    readonly userId: string;
-  },
-): Promise<boolean | undefined> {
-  if (!args.chatThreadId) {
-    return undefined;
-  }
-  const [thread] = await db
-    .select({ cloudBrowserEnabled: chatThreads.cloudBrowserEnabled })
-    .from(chatThreads)
-    .innerJoin(agentComposes, eq(agentComposes.id, chatThreads.agentComposeId))
-    .where(
-      and(
-        eq(chatThreads.id, args.chatThreadId),
-        eq(agentComposes.orgId, args.orgId),
-        eq(chatThreads.userId, args.userId),
-      ),
-    )
-    .limit(1);
-  return thread?.cloudBrowserEnabled ?? false;
-}
-
 async function loadZeroAgent(
   db: Db,
   agentId: string,
@@ -966,6 +939,7 @@ async function resolveThreadSessionForZeroRun(
     ...input,
     command: { ...input.command, body },
     threadSessionResolution: resolution,
+    cloudBrowserEnabled: resolution.cloudBrowserEnabled,
   };
 }
 
@@ -1095,12 +1069,6 @@ const createZeroRunInternal$ = command(
       },
       signal,
     );
-    const cloudBrowserEnabled = await loadThreadCloudBrowserEnabled(db, {
-      chatThreadId: args.chatThreadId,
-      orgId: args.auth.orgId,
-      userId: args.auth.userId,
-    });
-    signal.throwIfAborted();
 
     return await set(
       createAgentRunAfterZeroPreCreate$,
@@ -1117,7 +1085,7 @@ const createZeroRunInternal$ = command(
         allowedCustomConnectorIds,
         customConnectorGrants,
         timing,
-        cloudBrowserEnabled,
+        cloudBrowserEnabled: undefined,
       },
       signal,
     );


### PR DESCRIPTION
## Summary

- select the thread's cloud-browser flag in the existing authorized session-resolution query
- refresh browser and session state together on each bounded preparation attempt
- remove the standalone post-bootstrap thread query
- cover enabled, disabled, and non-thread runner prompt behavior through public API integration tests

## Compatibility

- no database schema or persisted-data changes
- no public API, queue, runner, token format, or frontend contract changes
- existing session initialization, reuse, adoption, rotation, and stale-binding retry behavior is unchanged

## Validation

- `pnpm exec prettier --write apps/api/src/signals/services/chat-session-continuity.service.ts apps/api/src/signals/services/zero-runs-create.service.ts apps/api/src/signals/routes/__tests__/zero-browser.test.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-browser.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only` (147 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api build`

Closes #24495

Parent context: #24203
