### PR TITLE
chore(rust): update ipnet and time

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1834,9 +1834,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3348,9 +3348,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",


### PR DESCRIPTION
## Summary

- Update `ipnet` from 2.12.0 to 2.12.1.
- Update `time` from 0.3.54 to 0.3.55.

## Dependencies not updated

- `generic-array` remains at 0.14.7 although 0.14.9 is available because `crypto-common` 0.1.7 pins it exactly to `=0.14.7`.

## Manual version bumps

- None.

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace --exclude runner`
- `cargo test -p runner` — 2,913 passed, 14 ignored, 0 failed; the guest-inventory integration test also passed.

The runner suite was compiled with one build job, test debug info disabled, incremental compilation disabled for the runner test target, and the Rust toolchain's bundled LLVM linker. These settings keep the complete suite within the validation host's 3.8 GiB, no-swap memory limit; no tests were newly skipped or disabled.
