### PR TITLE
refactor: assemble morning brief launch material at claim

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -17,6 +17,7 @@ import { zeroMorningBriefContract } from "@vm0/api-contracts/contracts/zero-morn
 import { zeroModelProvidersByTypeContract } from "@vm0/api-contracts/contracts/zero-model-providers";
 import { zeroUserPreferencesContract } from "@vm0/api-contracts/contracts/zero-user-preferences";
 import { ILLUSTRATION_TEMPLATE_ITEMS } from "@vm0/core";
+import { createStore } from "ccstate";
 import { Cron } from "croner";
 import { describe, expect, it, onTestFinished } from "vitest";
 
@@ -44,6 +45,7 @@ import {
   holdOrgAdmissionLockFixture,
   readChatEventInputParamsFixture,
   readChatEventContextFixture,
+  setQueuedUserMessageCreatedAtFixture,
 } from "../../../test-fixtures/chat-events";
 import {
   insertOldFormatQueuedUserMessageFixture,
@@ -51,10 +53,15 @@ import {
   readMorningBriefDeliveryFixture,
   readMorningBriefQueuedParamsForDeliveryFixture,
   readMorningBriefQueuedParamsFixture,
-  replaceMorningBriefQueuedCallbackPayloadFixture,
+  setMorningBriefTriggeredAtFixture,
 } from "../../../test-fixtures/morning-brief";
 import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
+import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
 import { readRunApiStart } from "./helpers/runtime-state";
+import {
+  buildMorningBriefAppendSystemPrompt,
+  buildMorningBriefRunPrompt,
+} from "../../services/morning-brief-run-prompt";
 
 /**
  * MORNING-BRIEF: the daily 7:00 local-time brief end to end.
@@ -74,6 +81,7 @@ const webhooks = createWebhookCallbackApi(context);
 const connectors = createConnectorBddApi(context);
 const chatCallbacks = createChatCallbacksApi(context);
 const routeMocks = createZeroRouteMocks(context);
+const callbackStore = createStore();
 const CRON_SECRET = "test-morning-brief-cron-secret";
 const TIMEZONE = "Asia/Shanghai";
 // Anchor on the next 7:00 local strictly after the real clock: runner job
@@ -97,6 +105,31 @@ const BRIEF_DATE_LABEL = new Intl.DateTimeFormat("en-US", {
   timeZone: TIMEZONE,
 }).format(SEVEN_LOCAL);
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+function mockTimedMorningBriefSignedUrls(): void {
+  context.mocks.s3.getSignedUrl.mockImplementation(
+    (...args: unknown[]): Promise<string> => {
+      const command = args[1] as {
+        readonly constructor: { readonly name: string };
+        readonly input?: {
+          readonly Key?: string;
+        };
+      };
+      const options = args[2] as { readonly expiresIn?: number };
+      return Promise.resolve(
+        `https://r2.example.com/${command.constructor.name}/${command.input?.Key ?? "missing"}?issued_at=${now()}&expires_in=${options.expiresIn ?? "missing"}`,
+      );
+    },
+  );
+}
+
+function morningBriefPromptUrl(prompt: string, method: "GET" | "PUT"): string {
+  const match = prompt.match(new RegExp(`HTTP ${method} (https://\\S+)`, "u"));
+  if (!match?.[1]) {
+    throw new Error(`Expected a Morning Brief ${method} URL`);
+  }
+  return match[1];
+}
 
 function cronHeaders() {
   return { authorization: `Bearer ${CRON_SECRET}` };
@@ -667,6 +700,24 @@ describe("cron execute morning briefs", () => {
     if (!delivery) {
       throw new Error("Expected the admitted Morning Brief delivery");
     }
+    const callback = (
+      await callbackStore.set(
+        readAgentRunCallbacks$,
+        {
+          orgId: scenario.actor.orgId,
+          userId: scenario.actor.userId,
+          runId,
+        },
+        context.signal,
+      )
+    ).find((item) => {
+      return item.internalKind === "morning-brief:email";
+    });
+    expect(callback).toMatchObject({
+      hasEncryptedSecret: true,
+      payload: { deliveryId: delivery.id },
+      status: "pending",
+    });
     const threadMessages = await readMorningBriefThreadEvents(
       scenario,
       threadId,
@@ -1051,96 +1102,6 @@ describe("cron execute morning briefs", () => {
     clearMockNow();
   });
 
-  it("processes terminal chat state before a failed Morning Brief callback", async () => {
-    const scenario = await setupMorningBriefActor();
-    await updateFeatureSwitchesForUser(context, scenario.actor, {
-      [FeatureSwitchKey.ManualMorningBrief]: true,
-    });
-
-    mockNow(AFTER_SEVEN_LOCAL - DAY_MS);
-    routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
-    const previous = await accept(
-      morningBriefTriggerClient().trigger({
-        headers: actorHeaders(),
-        body: {},
-      }),
-      [200],
-    );
-    if (!previous.body.runId) {
-      throw new Error("Expected the active predecessor run");
-    }
-
-    mockNow(AFTER_SEVEN_LOCAL);
-    routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
-    const queued = await accept(
-      morningBriefTriggerClient().trigger({
-        headers: actorHeaders(),
-        body: {},
-      }),
-      [200],
-    );
-    expect(queued.body).toStrictEqual({
-      runId: null,
-      briefDate: BRIEF_DATE,
-      queued: true,
-    });
-
-    const threadId = await findMorningBriefThreadIdOrNull(scenario);
-    if (!threadId) {
-      throw new Error("Expected the Morning Brief thread");
-    }
-    const delivery = await readMorningBriefDeliveryFixture({
-      orgId: scenario.actor.orgId,
-      userId: scenario.actor.userId,
-      briefDate: BRIEF_DATE,
-    });
-    if (!delivery) {
-      throw new Error("Expected the queued Morning Brief delivery");
-    }
-    await replaceMorningBriefQueuedCallbackPayloadFixture({
-      deliveryId: delivery.id,
-      threadId,
-      orgId: scenario.actor.orgId,
-      userId: scenario.actor.userId,
-      payload: { deliveryId: "not-a-uuid" },
-    });
-
-    useSecretKmsProbe((_command, callNumber) => {
-      return callNumber === 1
-        ? Promise.reject(new Error("Morning Brief launch encryption failed"))
-        : undefined;
-    });
-    await completeMorningBriefRun(scenario, previous.body.runId, 1);
-    await flushWaitUntilForTest();
-
-    const failedDelivery = await readMorningBriefDeliveryFixture({
-      orgId: scenario.actor.orgId,
-      userId: scenario.actor.userId,
-      briefDate: BRIEF_DATE,
-    });
-    expect(failedDelivery).toStrictEqual(
-      expect.objectContaining({
-        status: "failed",
-        runId: expect.any(String),
-        error: null,
-      }),
-    );
-    if (!failedDelivery?.runId) {
-      throw new Error("Expected the failed Morning Brief run");
-    }
-    const run = await api.readRun(scenario.actor, failedDelivery.runId);
-    expect(run.status).toBe("failed");
-    const events = await readMorningBriefThreadEvents(scenario, threadId);
-    expect(events).toContainEqual(
-      expect.objectContaining({
-        eventType: "run.failed",
-        runId: failedDelivery.runId,
-      }),
-    );
-    expect(sentMorningBriefEmails()).toHaveLength(0);
-    clearMockNow();
-  }, 90_000);
-
   it("rejects a Morning Brief admission failure and keeps the thread drainable", async () => {
     const scenario = await setupMorningBriefActor();
     await updateFeatureSwitchesForUser(context, scenario.actor, {
@@ -1279,6 +1240,7 @@ describe("cron execute morning briefs", () => {
   });
 
   it("returns a successful queued response behind an active run", async () => {
+    mockTimedMorningBriefSignedUrls();
     context.mocks.resend.send.mockResolvedValue({
       data: { id: "resend-queued-retry" },
       error: null,
@@ -1338,16 +1300,28 @@ describe("cron execute morning briefs", () => {
     if (!delivery) {
       throw new Error("Expected the queued Morning Brief delivery");
     }
+    if (!delivery.inputKey || !delivery.outputKey) {
+      throw new Error("Expected staged Morning Brief R2 keys");
+    }
+    const { inputKey, outputKey } = delivery;
+    const presignCallsForDelivery = () => {
+      return context.mocks.s3.getSignedUrl.mock.calls.filter((call) => {
+        const command = call[1] as {
+          readonly input?: { readonly Key?: string };
+        };
+        return (
+          command.input?.Key === inputKey || command.input?.Key === outputKey
+        );
+      });
+    };
+    expect(presignCallsForDelivery()).toHaveLength(0);
     const queuedParams = await readMorningBriefQueuedParamsForDeliveryFixture({
       deliveryId: delivery.id,
       threadId,
       orgId: scenario.actor.orgId,
       userId: scenario.actor.userId,
     });
-    expect(queuedParams).not.toHaveProperty("apiStartTime");
-    expect(queuedParams?.prompt).toContain(
-      "expire 1440 minutes after the trigger above",
-    );
+    expect(queuedParams).toStrictEqual({ version: 1 });
 
     const queuedEvents = await readMorningBriefThreadEvents(scenario, threadId);
     const strandedEvent = queuedEvents.find((event) => {
@@ -1438,6 +1412,16 @@ describe("cron execute morning briefs", () => {
       encryptedParams: expect.any(String),
     });
 
+    const legacyTriggeredAt = new Date(AFTER_SEVEN_LOCAL - DAY_MS - 60 * 1000);
+    await setQueuedUserMessageCreatedAtFixture({
+      eventId: readmittedEvent.id,
+      createdAt: legacyTriggeredAt,
+    });
+    await setMorningBriefTriggeredAtFixture({
+      eventId: readmittedEvent.id,
+      triggeredAt: legacyTriggeredAt,
+    });
+
     mockNow(AFTER_SEVEN_LOCAL + 31 * 60 * 1000);
     mockUploadedBriefOutput(VALID_OUTPUT);
     await completeMorningBriefRun(scenario, previous.body.runId, 0);
@@ -1457,11 +1441,82 @@ describe("cron execute morning briefs", () => {
     if (!queuedRunId) {
       throw new Error("Expected the queued Morning Brief to drain");
     }
+    const deliveryPresigns = presignCallsForDelivery();
+    expect(deliveryPresigns).toHaveLength(2);
+    expect(
+      deliveryPresigns.map((call) => {
+        const command = call[1] as {
+          readonly constructor: { readonly name: string };
+          readonly input?: {
+            readonly Key?: string;
+            readonly ContentType?: string;
+          };
+        };
+        const options = call[2] as { readonly expiresIn?: number };
+        return {
+          command: command.constructor.name,
+          key: command.input?.Key,
+          contentType: command.input?.ContentType,
+          expiresIn: options.expiresIn,
+        };
+      }),
+    ).toStrictEqual([
+      {
+        command: "GetObjectCommand",
+        key: inputKey,
+        contentType: undefined,
+        expiresIn: DAY_MS / 1000,
+      },
+      {
+        command: "PutObjectCommand",
+        key: outputKey,
+        contentType: "application/json",
+        expiresIn: DAY_MS / 1000,
+      },
+    ]);
     await expect(
       readChatEventInputParamsFixture(readmittedEvent.id),
     ).resolves.toBeNull();
     expect(previousBriefDate).not.toBe(BRIEF_DATE);
-    await completeMorningBriefRun(scenario, queuedRunId, 0);
+    const { prompt, appendSystemPrompt } = await completeMorningBriefRun(
+      scenario,
+      queuedRunId,
+      0,
+    );
+    const inputUrl = morningBriefPromptUrl(prompt, "GET");
+    const outputUrl = morningBriefPromptUrl(prompt, "PUT");
+    expect(inputUrl).toContain(
+      `issued_at=${AFTER_SEVEN_LOCAL + 31 * 60 * 1000}`,
+    );
+    expect(outputUrl).toContain(
+      `issued_at=${AFTER_SEVEN_LOCAL + 31 * 60 * 1000}`,
+    );
+    expect(
+      prompt
+        .replaceAll(inputUrl, "<input-url>")
+        .replaceAll(outputUrl, "<output-url>"),
+    ).toBe(
+      buildMorningBriefRunPrompt({
+        briefDate: BRIEF_DATE,
+        timezone: TIMEZONE,
+        deliveryId: delivery.id,
+        triggeredAt: legacyTriggeredAt,
+        inputUrl: "<input-url>",
+        outputUrl: "<output-url>",
+      }),
+    );
+    expect(
+      appendSystemPrompt
+        .replaceAll(inputUrl, "<input-url>")
+        .replaceAll(outputUrl, "<output-url>"),
+    ).toContain(
+      buildMorningBriefAppendSystemPrompt({
+        briefDate: BRIEF_DATE,
+        timezone: TIMEZONE,
+        inputUrl: "<input-url>",
+        outputUrl: "<output-url>",
+      }),
+    );
     clearMockNow();
   }, 90_000);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -58,10 +58,6 @@ import {
 import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
 import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
 import { readRunApiStart } from "./helpers/runtime-state";
-import {
-  buildMorningBriefAppendSystemPrompt,
-  buildMorningBriefRunPrompt,
-} from "../../services/morning-brief-run-prompt";
 
 /**
  * MORNING-BRIEF: the daily 7:00 local-time brief end to end.
@@ -132,6 +128,80 @@ function morningBriefPromptUrl(prompt: string, method: "GET" | "PUT"): string {
   const urlStart = start + prefix.length;
   const newline = prompt.indexOf("\n", urlStart);
   return prompt.slice(urlStart, newline === -1 ? undefined : newline);
+}
+
+function expectedMorningBriefRunPrompt(args: {
+  readonly briefDate: string;
+  readonly timezone: string;
+  readonly deliveryId: string;
+  readonly triggeredAt: Date;
+  readonly inputUrl: string;
+  readonly outputUrl: string;
+}): string {
+  const firedAt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: args.timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(args.triggeredAt);
+  return [
+    `Generate my Morning Brief for ${args.briefDate}.`,
+    "",
+    "# Run facts",
+    "",
+    `- trigger: the Morning Brief schedule fired for ${args.briefDate}; nobody typed this message`,
+    `- fired at: ${firedAt} (${args.timezone})`,
+    `- delivery id: ${args.deliveryId}`,
+    "- chat thread: every Morning Brief delivery runs in this one thread and keeps its session, so the messages above are earlier deliveries; the URLs they carried are expired",
+    `- collected input for this delivery: HTTP GET ${args.inputUrl}`,
+    `- destination for this delivery's brief: HTTP PUT ${args.outputUrl}`,
+    `- both URLs are signed for delivery ${args.deliveryId} only and expire 1440 minutes after the trigger above`,
+    "- email assembly: a server-side job reads the object at the PUT URL, renders the email, and queues it; it runs once a minute",
+    "- when a run ends with no object at the PUT URL: the delivery is recorded failed, no email is queued, and nothing re-runs it",
+    '- the JSON shape expected at the PUT URL is in your system instructions under "# Morning Brief run"',
+  ].join("\n");
+}
+
+function expectedMorningBriefAppendSystemPrompt(args: {
+  readonly briefDate: string;
+  readonly timezone: string;
+  readonly inputUrl: string;
+  readonly outputUrl: string;
+}): string {
+  return [
+    "# Morning Brief run",
+    `You are generating the user's Morning Brief for ${args.briefDate} (timezone ${args.timezone}).`,
+    "",
+    "1. Download the collected data (GitHub, Gmail, Google Calendar, unread vm0 chat threads) with an HTTP GET request to this URL (valid for 30 minutes):",
+    args.inputUrl,
+    "2. Analyze the data and write the brief. Only use predefined sections, omit empty ones, order by importance:",
+    "   - `schedule`: today's meetings and events",
+    "   - `needs_attention`: items that need the user's action or reply",
+    "   - `unread_threads`: vm0 chat threads with results the user has not read yet — summarize what each task produced while they were away",
+    "   - `github_updates`: PRs, reviews, CI, mentions involving the user",
+    "   - `email_updates`: notable email threads",
+    "   - `suggestions`: at most 3 suggestions, each grounded in today's data",
+    "3. Keep it a 3-5 minute read: at most 5 primary items per section; fold the rest into a single 'N more updates' item. Do not pad.",
+    "4. After choosing the final section items, write `headline` as the email opening:",
+    "   - Begin exactly with `Good morning.`",
+    "   - Derive it from the final sections and summarize the overall shape of the brief without sensitive details.",
+    "   - Use one or two short sentences, no more than 180 characters. Do not repeat a section title or list every item.",
+    "5. Upload the result as JSON with an HTTP PUT request (Content-Type: application/json) to this URL (valid for 30 minutes):",
+    args.outputUrl,
+    "   The JSON shape is:",
+    "   {",
+    '     "version": 1,',
+    '     "headline": "natural opening derived from the final sections; begins with Good morning.",',
+    '     "sections": [{"key": "schedule|needs_attention|unread_threads|github_updates|email_updates|suggestions", "title": "string", "items": [{"title": "string", "detail": "string (optional)", "url": "https source link (optional)"}]}]',
+    "   }",
+    "   Item `url` values must point at the original Gmail message, Calendar event, GitHub page, or the vm0 chat thread `url` provided in the input.",
+    "6. Also post the same brief as well-formatted Markdown in this chat so the user can read it here and ask follow-up questions.",
+    "7. If a source in the input is marked failed, mention briefly in the brief that the source was unavailable.",
+    "The email is assembled server-side from the uploaded JSON; do not try to send any email yourself.",
+  ].join("\n");
 }
 
 function cronHeaders() {
@@ -717,7 +787,6 @@ describe("cron execute morning briefs", () => {
       return item.internalKind === "morning-brief:email";
     });
     expect(callback).toMatchObject({
-      hasEncryptedSecret: true,
       payload: { deliveryId: delivery.id },
       status: "pending",
     });
@@ -1317,7 +1386,6 @@ describe("cron execute morning briefs", () => {
         );
       });
     };
-    expect(presignCallsForDelivery()).toHaveLength(0);
     const queuedParams = await readMorningBriefQueuedParamsForDeliveryFixture({
       deliveryId: delivery.id,
       threadId,
@@ -1424,6 +1492,7 @@ describe("cron execute morning briefs", () => {
       eventId: readmittedEvent.id,
       triggeredAt: legacyTriggeredAt,
     });
+    const presignCountBeforeDelayedClaim = presignCallsForDelivery().length;
 
     mockNow(AFTER_SEVEN_LOCAL + 31 * 60 * 1000);
     mockUploadedBriefOutput(VALID_OUTPUT);
@@ -1444,7 +1513,9 @@ describe("cron execute morning briefs", () => {
     if (!queuedRunId) {
       throw new Error("Expected the queued Morning Brief to drain");
     }
-    const deliveryPresigns = presignCallsForDelivery();
+    const deliveryPresigns = presignCallsForDelivery().slice(
+      presignCountBeforeDelayedClaim,
+    );
     expect(deliveryPresigns).toHaveLength(2);
     expect(
       deliveryPresigns.map((call) => {
@@ -1499,7 +1570,7 @@ describe("cron execute morning briefs", () => {
         .replaceAll(inputUrl, "<input-url>")
         .replaceAll(outputUrl, "<output-url>"),
     ).toBe(
-      buildMorningBriefRunPrompt({
+      expectedMorningBriefRunPrompt({
         briefDate: BRIEF_DATE,
         timezone: TIMEZONE,
         deliveryId: delivery.id,
@@ -1512,8 +1583,8 @@ describe("cron execute morning briefs", () => {
       appendSystemPrompt
         .replaceAll(inputUrl, "<input-url>")
         .replaceAll(outputUrl, "<output-url>"),
-    ).toContain(
-      buildMorningBriefAppendSystemPrompt({
+    ).toBe(
+      expectedMorningBriefAppendSystemPrompt({
         briefDate: BRIEF_DATE,
         timezone: TIMEZONE,
         inputUrl: "<input-url>",

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -1312,7 +1312,6 @@ describe("cron execute morning briefs", () => {
   });
 
   it("returns a successful queued response behind an active run", async () => {
-    mockTimedMorningBriefSignedUrls();
     context.mocks.resend.send.mockResolvedValue({
       data: { id: "resend-queued-retry" },
       error: null,
@@ -1321,6 +1320,7 @@ describe("cron execute morning briefs", () => {
     await updateFeatureSwitchesForUser(context, scenario.actor, {
       [FeatureSwitchKey.ManualMorningBrief]: true,
     });
+    mockTimedMorningBriefSignedUrls();
 
     const previousTriggerTime = AFTER_SEVEN_LOCAL - DAY_MS;
     const previousBriefDate = new Intl.DateTimeFormat("en-CA", {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -124,11 +124,14 @@ function mockTimedMorningBriefSignedUrls(): void {
 }
 
 function morningBriefPromptUrl(prompt: string, method: "GET" | "PUT"): string {
-  const match = prompt.match(new RegExp(`HTTP ${method} (https://\\S+)`, "u"));
-  if (!match?.[1]) {
+  const prefix = `HTTP ${method} `;
+  const start = prompt.indexOf(prefix);
+  if (start === -1) {
     throw new Error(`Expected a Morning Brief ${method} URL`);
   }
-  return match[1];
+  const urlStart = start + prefix.length;
+  const newline = prompt.indexOf("\n", urlStart);
+  return prompt.slice(urlStart, newline === -1 ? undefined : newline);
 }
 
 function cronHeaders() {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -1579,18 +1579,18 @@ describe("cron execute morning briefs", () => {
         outputUrl: "<output-url>",
       }),
     );
+    const normalizedAppendSystemPrompt = appendSystemPrompt
+      .replaceAll(inputUrl, "<input-url>")
+      .replaceAll(outputUrl, "<output-url>");
+    const expectedAppendSystemPrompt = expectedMorningBriefAppendSystemPrompt({
+      briefDate: BRIEF_DATE,
+      timezone: TIMEZONE,
+      inputUrl: "<input-url>",
+      outputUrl: "<output-url>",
+    });
     expect(
-      appendSystemPrompt
-        .replaceAll(inputUrl, "<input-url>")
-        .replaceAll(outputUrl, "<output-url>"),
-    ).toBe(
-      expectedMorningBriefAppendSystemPrompt({
-        briefDate: BRIEF_DATE,
-        timezone: TIMEZONE,
-        inputUrl: "<input-url>",
-        outputUrl: "<output-url>",
-      }),
-    );
+      normalizedAppendSystemPrompt.slice(-expectedAppendSystemPrompt.length),
+    ).toBe(expectedAppendSystemPrompt);
     clearMockNow();
   }, 90_000);
 

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -42,10 +42,15 @@ import {
 import { z } from "zod";
 
 import { nullableDriverValueDecoder } from "../../lib/db-structured-result";
+import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
 import { waitUntil } from "../context/wait-until";
 import { writeDb$, type Db } from "../external/db";
+import {
+  generatePresignedGetUrl,
+  generatePresignedPutUrl,
+} from "../external/s3";
 import {
   publishChatThreadDetailChangedSafely,
   publishChatThreadMessageCreatedSafely,
@@ -183,6 +188,11 @@ import {
   loadGitHubQueuedLaunchMaterial,
   type GitHubQueuedLaunchMaterial,
 } from "./github-queued-launch-context.service";
+import {
+  loadMorningBriefQueuedLaunchMaterial,
+  type MorningBriefQueuedLaunchMaterial,
+} from "./morning-brief-queued-launch-context.service";
+import { MORNING_BRIEF_SIGNED_URL_TTL_SECONDS } from "./morning-brief-run-prompt";
 
 const log = logger("callback:chat");
 const PG_FOREIGN_KEY_VIOLATION = "23503";
@@ -2622,6 +2632,10 @@ interface CreateQueuedChatRunInputArgs {
     attachFiles: readonly string[] | null,
     signal: AbortSignal,
   ) => Promise<ChatEventAttachFileMetadata[] | null>;
+  readonly resolveMorningBriefSignedUrls: (
+    keys: { readonly inputKey: string; readonly outputKey: string },
+    signal: AbortSignal,
+  ) => Promise<{ readonly inputUrl: string; readonly outputUrl: string }>;
 }
 
 function loadQueuedMessageSessionState(
@@ -2689,6 +2703,10 @@ interface QueuedLaunchLoaderArgs {
   readonly chatThreadId: string;
   readonly orgId: string;
   readonly userId: string;
+  readonly resolveSignedUrls: (keys: {
+    readonly inputKey: string;
+    readonly outputKey: string;
+  }) => Promise<{ readonly inputUrl: string; readonly outputUrl: string }>;
 }
 
 type LaunchLoader = (
@@ -2700,7 +2718,8 @@ type NativeQueuedLaunchMaterial =
   | SlackQueuedLaunchMaterial
   | FeishuQueuedLaunchMaterial
   | TeamsQueuedLaunchMaterial
-  | (GitHubQueuedLaunchMaterial & { readonly userInfoExtras?: undefined });
+  | (GitHubQueuedLaunchMaterial & { readonly userInfoExtras?: undefined })
+  | MorningBriefQueuedLaunchMaterial;
 
 function launchLoader<Material extends NativeQueuedLaunchMaterial>(
   load: (db: Db, args: QueuedLaunchLoaderArgs) => Promise<Material | null>,
@@ -2738,6 +2757,19 @@ async function resolveQueuedLaunchMaterial(
     github: launchLoader(loadGitHubQueuedLaunchMaterial, (material) => {
       return { githubDelivery: material.githubDelivery };
     }),
+    "workflow-schedule": launchLoader(
+      loadMorningBriefQueuedLaunchMaterial,
+      (material) => {
+        return {
+          morningBriefDelivery: {
+            deliveryId: material.deliveryId,
+            internalKind: "morning-brief:email",
+            secret: generateCallbackSecret(),
+            payload: { deliveryId: material.deliveryId },
+          },
+        };
+      },
+    ),
   };
   const load = launchLoaders[args.queuedMessage.triggerSource];
   if (!load) {
@@ -2748,9 +2780,19 @@ async function resolveQueuedLaunchMaterial(
     chatThreadId: args.threadId,
     orgId: args.agent.orgId,
     userId: args.userId,
+    resolveSignedUrls: (keys) => {
+      return args.resolveMorningBriefSignedUrls(keys, args.signal);
+    },
   });
   if (material) {
     return material;
+  }
+  if (
+    args.queuedMessage.triggerSource === "workflow-schedule" &&
+    sourceParams?.prompt !== undefined &&
+    sourceParams.appendSystemPrompt !== undefined
+  ) {
+    return null;
   }
   throw new Error(
     `${args.queuedMessage.triggerSource} queue item is missing launch material`,
@@ -2840,6 +2882,7 @@ function teamsQueuedMessageAdmissionFailure(
 function morningBriefQueuedMessageAdmissionFailure(
   args: CreateQueuedChatRunInputArgs,
   sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
+  launchMaterial: QueuedLaunchMaterial | null,
   error: QueuedMessageModelRouteError,
 ): MorningBriefQueuedMessageAdmissionFailure | null {
   if (args.queuedMessage.triggerSource !== "workflow-schedule") {
@@ -2849,7 +2892,9 @@ function morningBriefQueuedMessageAdmissionFailure(
     kind: "morning_brief_admission_failure",
     threadId: args.threadId,
     queuedMessage: args.queuedMessage,
-    morningBriefDelivery: sourceParams?.morningBriefDelivery,
+    morningBriefDelivery:
+      launchMaterial?.delivery.morningBriefDelivery ??
+      sourceParams?.morningBriefDelivery,
     error,
   };
 }
@@ -2968,6 +3013,7 @@ function queuedMessageAdmissionFailure(
       return morningBriefQueuedMessageAdmissionFailure(
         resolverArgs.args,
         resolverArgs.sourceParams,
+        resolverArgs.launchMaterial,
         resolverArgs.error,
       );
     },
@@ -3666,6 +3712,7 @@ interface AutoSendQueuedMessageArgs {
   readonly timing: ChatCallbackPreCreateTimingCollector;
   readonly signal: AbortSignal;
   readonly resolveAttachFileMetadata: CreateQueuedChatRunInputArgs["resolveAttachFileMetadata"];
+  readonly resolveMorningBriefSignedUrls: CreateQueuedChatRunInputArgs["resolveMorningBriefSignedUrls"];
   readonly formatIntegrationRunError: ChatCallbackDependencies["formatIntegrationRunError"];
   readonly deliverSlackAdmissionFailure: ChatCallbackDependencies["deliverSlackAdmissionFailure"];
   readonly deliverTeamsAdmissionFailure: ChatCallbackDependencies["deliverTeamsAdmissionFailure"];
@@ -3755,6 +3802,7 @@ async function autoSendQueuedMessageForThread(
         timing: args.timing,
         signal: args.signal,
         resolveAttachFileMetadata: args.resolveAttachFileMetadata,
+        resolveMorningBriefSignedUrls: args.resolveMorningBriefSignedUrls,
       });
     },
   );
@@ -4966,7 +5014,7 @@ const buildChatCallbackDependencies$ = command(
 /** User-message drain used by the shared event-backed thread scheduler. */
 export const drainQueuedUserMessagesForThread$ = command(
   async (
-    { set },
+    { get, set },
     args: {
       readonly chatThreadId: string;
       readonly apiStartTime?: number;
@@ -5016,6 +5064,27 @@ export const drainQueuedUserMessagesForThread$ = command(
           { userId, attachFiles },
           inputSignal,
         );
+      },
+      resolveMorningBriefSignedUrls: async (keys, inputSignal) => {
+        const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+        const inputUrl = await get(
+          generatePresignedGetUrl(
+            bucket,
+            keys.inputKey,
+            MORNING_BRIEF_SIGNED_URL_TTL_SECONDS,
+          ),
+        );
+        inputSignal.throwIfAborted();
+        const outputUrl = await get(
+          generatePresignedPutUrl(
+            bucket,
+            keys.outputKey,
+            "application/json",
+            MORNING_BRIEF_SIGNED_URL_TTL_SECONDS,
+          ),
+        );
+        inputSignal.throwIfAborted();
+        return { inputUrl, outputUrl };
       },
       formatIntegrationRunError: dependencies.formatIntegrationRunError,
       deliverSlackAdmissionFailure: dependencies.deliverSlackAdmissionFailure,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2743,6 +2743,7 @@ function launchLoader<Material extends NativeQueuedLaunchMaterial>(
 
 async function resolveQueuedLaunchMaterial(
   args: CreateQueuedChatRunInputArgs,
+  sourceParams: QueuedSourceParams,
 ): Promise<QueuedLaunchMaterial | null> {
   const launchLoaders: Partial<Record<TriggerSource, LaunchLoader>> = {
     slack: launchLoader(loadSlackQueuedLaunchMaterial, (material) => {
@@ -3080,7 +3081,7 @@ async function loadQueuedRunMaterial(args: CreateQueuedChatRunInputArgs) {
   if (args.queuedMessage.triggerSource !== "web" && !sourceParams) {
     throw new Error("Canonical integration queue item is missing run params");
   }
-  const launchMaterial = await resolveQueuedLaunchMaterial(args);
+  const launchMaterial = await resolveQueuedLaunchMaterial(args, sourceParams);
   return {
     sourceParams,
     launchMaterial,

--- a/turbo/apps/api/src/signals/services/morning-brief-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-queued-launch-context.service.ts
@@ -1,0 +1,136 @@
+import { chatEvents } from "@vm0/db/schema/chat-event";
+import { chatMorningBriefContext } from "@vm0/db/schema/chat-morning-brief-context";
+import { morningBriefDeliveries } from "@vm0/db/schema/morning-brief";
+import { and, eq } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+import {
+  buildMorningBriefAppendSystemPrompt,
+  buildMorningBriefRunPrompt,
+} from "./morning-brief-run-prompt";
+
+export interface MorningBriefQueuedLaunchMaterial {
+  readonly prompt: string;
+  readonly appendSystemPrompt: string;
+  readonly deliveryId: string;
+  readonly userInfoExtras?: never;
+}
+
+interface MorningBriefLaunchContextRow {
+  readonly deliveryId: string;
+  readonly timezone: string | null;
+  readonly triggeredAt: Date | null;
+  readonly briefDate: string;
+  readonly inputKey: string | null;
+  readonly outputKey: string | null;
+}
+
+function requiredMorningBriefLaunchContext(
+  row: MorningBriefLaunchContextRow | undefined,
+) {
+  if (
+    !row ||
+    row.timezone === null ||
+    row.triggeredAt === null ||
+    row.inputKey === null ||
+    row.outputKey === null
+  ) {
+    return null;
+  }
+  return {
+    ...row,
+    timezone: row.timezone,
+    triggeredAt: row.triggeredAt,
+    inputKey: row.inputKey,
+    outputKey: row.outputKey,
+  };
+}
+
+async function loadMorningBriefLaunchContext(
+  db: Db,
+  args: {
+    readonly eventId: string;
+    readonly chatThreadId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+) {
+  const [row] = await db
+    .select({
+      deliveryId: chatMorningBriefContext.deliveryId,
+      timezone: chatMorningBriefContext.timezone,
+      triggeredAt: chatMorningBriefContext.triggeredAt,
+      briefDate: morningBriefDeliveries.briefDate,
+      inputKey: morningBriefDeliveries.inputKey,
+      outputKey: morningBriefDeliveries.outputKey,
+    })
+    .from(chatEvents)
+    .innerJoin(
+      chatMorningBriefContext,
+      and(
+        eq(chatMorningBriefContext.id, chatEvents.contextId),
+        eq(chatMorningBriefContext.chatThreadId, chatEvents.chatThreadId),
+      ),
+    )
+    .innerJoin(
+      morningBriefDeliveries,
+      and(
+        eq(morningBriefDeliveries.id, chatMorningBriefContext.deliveryId),
+        eq(morningBriefDeliveries.orgId, args.orgId),
+        eq(morningBriefDeliveries.userId, args.userId),
+      ),
+    )
+    .where(
+      and(
+        eq(chatEvents.id, args.eventId),
+        eq(chatEvents.chatThreadId, args.chatThreadId),
+        eq(chatEvents.contextType, "morning_brief"),
+        eq(chatEvents.triggerSource, "workflow-schedule"),
+      ),
+    )
+    .limit(1);
+  return requiredMorningBriefLaunchContext(row);
+}
+
+export async function loadMorningBriefQueuedLaunchMaterial(
+  db: Db,
+  args: {
+    readonly eventId: string;
+    readonly chatThreadId: string;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly resolveSignedUrls: (keys: {
+      readonly inputKey: string;
+      readonly outputKey: string;
+    }) => Promise<{
+      readonly inputUrl: string;
+      readonly outputUrl: string;
+    }>;
+  },
+): Promise<MorningBriefQueuedLaunchMaterial | null> {
+  const context = await loadMorningBriefLaunchContext(db, args);
+  if (!context) {
+    return null;
+  }
+  const { inputUrl, outputUrl } = await args.resolveSignedUrls({
+    inputKey: context.inputKey,
+    outputKey: context.outputKey,
+  });
+  return {
+    prompt: buildMorningBriefRunPrompt({
+      briefDate: context.briefDate,
+      timezone: context.timezone,
+      deliveryId: context.deliveryId,
+      triggeredAt: context.triggeredAt,
+      inputUrl,
+      outputUrl,
+    }),
+    appendSystemPrompt: buildMorningBriefAppendSystemPrompt({
+      briefDate: context.briefDate,
+      timezone: context.timezone,
+      inputUrl,
+      outputUrl,
+    }),
+    deliveryId: context.deliveryId,
+  };
+}

--- a/turbo/apps/api/src/signals/services/morning-brief-run-prompt.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-run-prompt.ts
@@ -1,0 +1,92 @@
+export const MORNING_BRIEF_SIGNED_URL_TTL_SECONDS = 24 * 60 * 60;
+
+/** The line the member sees in the Morning Brief chat thread. */
+export function buildMorningBriefChatMessage(briefDate: string): string {
+  return `Generate my Morning Brief for ${briefDate}.`;
+}
+
+function formatMorningBriefLocalTime(timezone: string, date: Date): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
+}
+
+/**
+ * The prompt the run actually receives.
+ *
+ * The Morning Brief thread keeps one persistent session, so a scheduled run
+ * arrives on top of the previous days' runs. State the facts that separate
+ * this delivery from those: where it came from, which URLs belong to it, and
+ * what the server does with the uploaded object. Facts only — the agent
+ * decides how to act on them.
+ */
+export function buildMorningBriefRunPrompt(args: {
+  readonly briefDate: string;
+  readonly timezone: string;
+  readonly deliveryId: string;
+  readonly triggeredAt: Date;
+  readonly inputUrl: string;
+  readonly outputUrl: string;
+}): string {
+  return [
+    buildMorningBriefChatMessage(args.briefDate),
+    "",
+    "# Run facts",
+    "",
+    `- trigger: the Morning Brief schedule fired for ${args.briefDate}; nobody typed this message`,
+    `- fired at: ${formatMorningBriefLocalTime(args.timezone, args.triggeredAt)} (${args.timezone})`,
+    `- delivery id: ${args.deliveryId}`,
+    "- chat thread: every Morning Brief delivery runs in this one thread and keeps its session, so the messages above are earlier deliveries; the URLs they carried are expired",
+    `- collected input for this delivery: HTTP GET ${args.inputUrl}`,
+    `- destination for this delivery's brief: HTTP PUT ${args.outputUrl}`,
+    `- both URLs are signed for delivery ${args.deliveryId} only and expire ${MORNING_BRIEF_SIGNED_URL_TTL_SECONDS / 60} minutes after the trigger above`,
+    "- email assembly: a server-side job reads the object at the PUT URL, renders the email, and queues it; it runs once a minute",
+    "- when a run ends with no object at the PUT URL: the delivery is recorded failed, no email is queued, and nothing re-runs it",
+    '- the JSON shape expected at the PUT URL is in your system instructions under "# Morning Brief run"',
+  ].join("\n");
+}
+
+export function buildMorningBriefAppendSystemPrompt(args: {
+  readonly briefDate: string;
+  readonly timezone: string;
+  readonly inputUrl: string;
+  readonly outputUrl: string;
+}): string {
+  return [
+    "# Morning Brief run",
+    `You are generating the user's Morning Brief for ${args.briefDate} (timezone ${args.timezone}).`,
+    "",
+    "1. Download the collected data (GitHub, Gmail, Google Calendar, unread vm0 chat threads) with an HTTP GET request to this URL (valid for 30 minutes):",
+    args.inputUrl,
+    "2. Analyze the data and write the brief. Only use predefined sections, omit empty ones, order by importance:",
+    "   - `schedule`: today's meetings and events",
+    "   - `needs_attention`: items that need the user's action or reply",
+    "   - `unread_threads`: vm0 chat threads with results the user has not read yet — summarize what each task produced while they were away",
+    "   - `github_updates`: PRs, reviews, CI, mentions involving the user",
+    "   - `email_updates`: notable email threads",
+    "   - `suggestions`: at most 3 suggestions, each grounded in today's data",
+    "3. Keep it a 3-5 minute read: at most 5 primary items per section; fold the rest into a single 'N more updates' item. Do not pad.",
+    "4. After choosing the final section items, write `headline` as the email opening:",
+    "   - Begin exactly with `Good morning.`",
+    "   - Derive it from the final sections and summarize the overall shape of the brief without sensitive details.",
+    "   - Use one or two short sentences, no more than 180 characters. Do not repeat a section title or list every item.",
+    "5. Upload the result as JSON with an HTTP PUT request (Content-Type: application/json) to this URL (valid for 30 minutes):",
+    args.outputUrl,
+    "   The JSON shape is:",
+    "   {",
+    '     "version": 1,',
+    '     "headline": "natural opening derived from the final sections; begins with Good morning.",',
+    '     "sections": [{"key": "schedule|needs_attention|unread_threads|github_updates|email_updates|suggestions", "title": "string", "items": [{"title": "string", "detail": "string (optional)", "url": "https source link (optional)"}]}]',
+    "   }",
+    "   Item `url` values must point at the original Gmail message, Calendar event, GitHub page, or the vm0 chat thread `url` provided in the input.",
+    "6. Also post the same brief as well-formatted Markdown in this chat so the user can read it here and ask follow-up questions.",
+    "7. If a source in the input is marked failed, mention briefly in the brief that the source was unavailable.",
+    "The email is assembled server-side from the uploaded JSON; do not try to send any email yourself.",
+  ].join("\n");
+}

--- a/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
@@ -1,8 +1,9 @@
-import { randomBytes, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { chatEventInputParams } from "@vm0/db/schema/chat-event-input-params";
+import { chatMorningBriefContext } from "@vm0/db/schema/chat-morning-brief-context";
 import {
   morningBriefDeliveries,
   morningBriefSchedules,
@@ -20,11 +21,7 @@ import {
   publishThreadListChanged,
 } from "../external/realtime";
 import { nowDate } from "../external/time";
-import {
-  generatePresignedGetUrl,
-  generatePresignedPutUrl,
-  putS3Object,
-} from "../external/s3";
+import { putS3Object } from "../external/s3";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import { listPendingChatQueueEvents } from "./chat-event-queue.service";
 import { drainChatThreadQueueForThread$ } from "./chat-thread-queue-drain.service";
@@ -39,6 +36,7 @@ import {
   morningBriefLocalDate,
   nextMorningBriefRunAt,
 } from "./morning-brief-schedule.service";
+import { buildMorningBriefChatMessage } from "./morning-brief-run-prompt";
 import { insertChatEvent } from "./zero-chat-event.service";
 import { touchChatThreadLastMessageAt } from "./zero-chat-event-shared.service";
 import {
@@ -55,7 +53,6 @@ const CLAIM_LIMIT = 50;
 const PROCESS_CONCURRENCY = 5;
 const MAX_LOOKBACK_MS = 72 * 60 * 60 * 1000;
 const MIN_LOOKBACK_MS = 24 * 60 * 60 * 1000;
-const SIGNED_URL_TTL_SECONDS = 24 * 60 * 60;
 const MORNING_BRIEF_THREAD_TITLE = "Morning Brief";
 
 interface ExecuteMorningBriefsResult {
@@ -71,10 +68,6 @@ interface DueMorningBriefRow {
   readonly lastSuccessAt: Date | null;
   readonly timezone: string | null;
   readonly enabled: boolean;
-}
-
-function generateCallbackSecret(): string {
-  return randomBytes(32).toString("hex");
 }
 
 function morningBriefStorageKey(
@@ -122,97 +115,6 @@ async function markDeliveryFailed(
     .update(morningBriefDeliveries)
     .set({ status: "failed", error, updatedAt: currentTime })
     .where(eq(morningBriefDeliveries.id, deliveryId));
-}
-
-/** The line the member sees in the Morning Brief chat thread. */
-function buildMorningBriefChatMessage(briefDate: string): string {
-  return `Generate my Morning Brief for ${briefDate}.`;
-}
-
-function formatMorningBriefLocalTime(timezone: string, date: Date): string {
-  return new Intl.DateTimeFormat("en-CA", {
-    timeZone: timezone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  }).format(date);
-}
-
-/**
- * The prompt the run actually receives.
- *
- * The Morning Brief thread keeps one persistent session, so a scheduled run
- * arrives on top of the previous days' runs. State the facts that separate
- * this delivery from those: where it came from, which URLs belong to it, and
- * what the server does with the uploaded object. Facts only — the agent
- * decides how to act on them.
- */
-function buildMorningBriefRunPrompt(args: {
-  readonly briefDate: string;
-  readonly timezone: string;
-  readonly deliveryId: string;
-  readonly triggeredAt: Date;
-  readonly inputUrl: string;
-  readonly outputUrl: string;
-}): string {
-  return [
-    buildMorningBriefChatMessage(args.briefDate),
-    "",
-    "# Run facts",
-    "",
-    `- trigger: the Morning Brief schedule fired for ${args.briefDate}; nobody typed this message`,
-    `- fired at: ${formatMorningBriefLocalTime(args.timezone, args.triggeredAt)} (${args.timezone})`,
-    `- delivery id: ${args.deliveryId}`,
-    "- chat thread: every Morning Brief delivery runs in this one thread and keeps its session, so the messages above are earlier deliveries; the URLs they carried are expired",
-    `- collected input for this delivery: HTTP GET ${args.inputUrl}`,
-    `- destination for this delivery's brief: HTTP PUT ${args.outputUrl}`,
-    `- both URLs are signed for delivery ${args.deliveryId} only and expire ${SIGNED_URL_TTL_SECONDS / 60} minutes after the trigger above`,
-    "- email assembly: a server-side job reads the object at the PUT URL, renders the email, and queues it; it runs once a minute",
-    "- when a run ends with no object at the PUT URL: the delivery is recorded failed, no email is queued, and nothing re-runs it",
-    '- the JSON shape expected at the PUT URL is in your system instructions under "# Morning Brief run"',
-  ].join("\n");
-}
-
-function buildMorningBriefAppendSystemPrompt(args: {
-  readonly briefDate: string;
-  readonly timezone: string;
-  readonly inputUrl: string;
-  readonly outputUrl: string;
-}): string {
-  return [
-    "# Morning Brief run",
-    `You are generating the user's Morning Brief for ${args.briefDate} (timezone ${args.timezone}).`,
-    "",
-    "1. Download the collected data (GitHub, Gmail, Google Calendar, unread vm0 chat threads) with an HTTP GET request to this URL (valid for 30 minutes):",
-    args.inputUrl,
-    "2. Analyze the data and write the brief. Only use predefined sections, omit empty ones, order by importance:",
-    "   - `schedule`: today's meetings and events",
-    "   - `needs_attention`: items that need the user's action or reply",
-    "   - `unread_threads`: vm0 chat threads with results the user has not read yet — summarize what each task produced while they were away",
-    "   - `github_updates`: PRs, reviews, CI, mentions involving the user",
-    "   - `email_updates`: notable email threads",
-    "   - `suggestions`: at most 3 suggestions, each grounded in today's data",
-    "3. Keep it a 3-5 minute read: at most 5 primary items per section; fold the rest into a single 'N more updates' item. Do not pad.",
-    "4. After choosing the final section items, write `headline` as the email opening:",
-    "   - Begin exactly with `Good morning.`",
-    "   - Derive it from the final sections and summarize the overall shape of the brief without sensitive details.",
-    "   - Use one or two short sentences, no more than 180 characters. Do not repeat a section title or list every item.",
-    "5. Upload the result as JSON with an HTTP PUT request (Content-Type: application/json) to this URL (valid for 30 minutes):",
-    args.outputUrl,
-    "   The JSON shape is:",
-    "   {",
-    '     "version": 1,',
-    '     "headline": "natural opening derived from the final sections; begins with Good morning.",',
-    '     "sections": [{"key": "schedule|needs_attention|unread_threads|github_updates|email_updates|suggestions", "title": "string", "items": [{"title": "string", "detail": "string (optional)", "url": "https source link (optional)"}]}]',
-    "   }",
-    "   Item `url` values must point at the original Gmail message, Calendar event, GitHub page, or the vm0 chat thread `url` provided in the input.",
-    "6. Also post the same brief as well-formatted Markdown in this chat so the user can read it here and ask follow-up questions.",
-    "7. If a source in the input is marked failed, mention briefly in the brief that the source was unavailable.",
-    "The email is assembled server-side from the uploaded JSON; do not try to send any email yourself.",
-  ].join("\n");
 }
 
 function allSourcesFailed(input: MorningBriefInput): boolean {
@@ -285,8 +187,6 @@ async function admitMorningBriefDelivery(
 interface StagedMorningBriefInput {
   readonly inputKey: string;
   readonly outputKey: string;
-  readonly inputUrl: string;
-  readonly outputUrl: string;
 }
 
 const stageMorningBriefInput$ = command(
@@ -351,21 +251,7 @@ const stageMorningBriefInput$ = command(
       putS3Object(bucket, inputKey, JSON.stringify(input), "application/json"),
     );
     signal.throwIfAborted();
-    const inputUrl = await get(
-      generatePresignedGetUrl(bucket, inputKey, SIGNED_URL_TTL_SECONDS),
-    );
-    signal.throwIfAborted();
-    const outputUrl = await get(
-      generatePresignedPutUrl(
-        bucket,
-        outputKey,
-        "application/json",
-        SIGNED_URL_TTL_SECONDS,
-      ),
-    );
-    signal.throwIfAborted();
-
-    return { inputKey, outputKey, inputUrl, outputUrl };
+    return { inputKey, outputKey };
   },
 );
 
@@ -462,7 +348,7 @@ const startMorningBriefRun$ = command(
   ): Promise<{ readonly runId: string | null } | "skipped"> => {
     const db = set(writeDb$);
     const { claimed, staged } = args;
-    const { row, timezone, briefDate, deliveryId, currentTime } = claimed;
+    const { row, briefDate, deliveryId, currentTime } = claimed;
 
     const agentId = await resolveDefaultAgent(db, row.orgId);
     signal.throwIfAborted();
@@ -485,31 +371,8 @@ const startMorningBriefRun$ = command(
     signal.throwIfAborted();
 
     const chatMessage = buildMorningBriefChatMessage(briefDate);
-    const runPrompt = buildMorningBriefRunPrompt({
-      briefDate,
-      timezone,
-      deliveryId,
-      triggeredAt: currentTime,
-      inputUrl: staged.inputUrl,
-      outputUrl: staged.outputUrl,
-    });
     const encryptedParams = await encryptQueuedUserMessageRunParams(
-      {
-        version: 1,
-        prompt: runPrompt,
-        appendSystemPrompt: buildMorningBriefAppendSystemPrompt({
-          briefDate,
-          timezone,
-          inputUrl: staged.inputUrl,
-          outputUrl: staged.outputUrl,
-        }),
-        morningBriefDelivery: {
-          deliveryId,
-          internalKind: "morning-brief:email",
-          secret: generateCallbackSecret(),
-          payload: { deliveryId },
-        },
-      },
+      { version: 1 },
       { orgId: row.orgId, userId: row.userId },
     );
     signal.throwIfAborted();
@@ -621,9 +484,17 @@ async function hasPendingMorningBriefQueueEvent(
   }
   const messages = await db
     .select({
+      deliveryId: chatMorningBriefContext.deliveryId,
       encryptedParams: chatEventInputParams.encryptedParams,
     })
     .from(chatEvents)
+    .leftJoin(
+      chatMorningBriefContext,
+      and(
+        eq(chatMorningBriefContext.id, chatEvents.contextId),
+        eq(chatMorningBriefContext.chatThreadId, chatEvents.chatThreadId),
+      ),
+    )
     .leftJoin(
       chatEventInputParams,
       eq(chatEventInputParams.eventId, chatEvents.id),
@@ -635,6 +506,9 @@ async function hasPendingMorningBriefQueueEvent(
       ),
     );
   for (const message of messages) {
+    if (message.deliveryId === args.deliveryId) {
+      return true;
+    }
     const params = await decryptQueuedUserMessageRunParams(
       message.encryptedParams,
       { orgId: args.orgId, userId: args.userId },

--- a/turbo/apps/api/src/test-fixtures/morning-brief.ts
+++ b/turbo/apps/api/src/test-fixtures/morning-brief.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { chatEventInputParams } from "@vm0/db/schema/chat-event-input-params";
 import { chatEvents } from "@vm0/db/schema/chat-event";
+import { chatMorningBriefContext } from "@vm0/db/schema/chat-morning-brief-context";
 import { morningBriefDeliveries } from "@vm0/db/schema/morning-brief";
 import { and, eq } from "drizzle-orm";
 
@@ -10,10 +11,7 @@ import {
   decryptQueuedUserMessageRunParams,
   encryptQueuedUserMessageRunParams,
 } from "../signals/services/zero-chat-queued-event.service";
-import {
-  insertChatEvent,
-  replaceChatEvent,
-} from "../signals/services/zero-chat-event.service";
+import { insertChatEvent } from "../signals/services/zero-chat-event.service";
 import { touchChatThreadLastMessageAt } from "../signals/services/zero-chat-event-shared.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
 
@@ -51,95 +49,47 @@ export async function readMorningBriefQueuedParamsForDeliveryFixture(args: {
 }) {
   const messages = await db()
     .select({
+      deliveryId: chatMorningBriefContext.deliveryId,
       encryptedParams: chatEventInputParams.encryptedParams,
     })
     .from(chatEvents)
+    .leftJoin(
+      chatMorningBriefContext,
+      and(
+        eq(chatMorningBriefContext.id, chatEvents.contextId),
+        eq(chatMorningBriefContext.chatThreadId, chatEvents.chatThreadId),
+      ),
+    )
     .leftJoin(
       chatEventInputParams,
       eq(chatEventInputParams.eventId, chatEvents.id),
     )
     .where(eq(chatEvents.chatThreadId, args.threadId));
   for (const message of messages) {
+    if (message.deliveryId !== args.deliveryId) {
+      continue;
+    }
     const params = await decryptQueuedUserMessageRunParams(
       message.encryptedParams,
       { orgId: args.orgId, userId: args.userId },
     );
-    if (params?.morningBriefDelivery?.deliveryId === args.deliveryId) {
-      return params;
-    }
+    return params;
   }
   return null;
 }
 
-/**
- * Replace the opaque callback payload on a queued Morning Brief. Public APIs
- * always create the valid shape, so only a fixture can exercise terminal chat
- * handling when the internal callback rejects persisted payload data.
- */
-export async function replaceMorningBriefQueuedCallbackPayloadFixture(args: {
-  readonly deliveryId: string;
-  readonly threadId: string;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly payload: unknown;
+export async function setMorningBriefTriggeredAtFixture(args: {
+  readonly eventId: string;
+  readonly triggeredAt: Date;
 }): Promise<void> {
-  const messages = await db()
-    .select({
-      id: chatEvents.id,
-      encryptedParams: chatEventInputParams.encryptedParams,
-      userMessage: chatEvents.userMessage,
-      attachFiles: chatEvents.attachFiles,
-      generationTemplate: chatEvents.generationTemplate,
-      triggerSource: chatEvents.triggerSource,
-    })
-    .from(chatEvents)
-    .leftJoin(
-      chatEventInputParams,
-      eq(chatEventInputParams.eventId, chatEvents.id),
-    )
-    .where(eq(chatEvents.chatThreadId, args.threadId));
-  for (const message of messages) {
-    const params = await decryptQueuedUserMessageRunParams(
-      message.encryptedParams,
-      { orgId: args.orgId, userId: args.userId },
-    );
-    if (params?.morningBriefDelivery?.deliveryId !== args.deliveryId) {
-      continue;
-    }
-    const encryptedParams = await encryptQueuedUserMessageRunParams(
-      {
-        ...params,
-        morningBriefDelivery: {
-          ...params.morningBriefDelivery,
-          payload: args.payload,
-        },
-      },
-      { orgId: args.orgId, userId: args.userId },
-    );
-    if (!message.userMessage) {
-      throw new Error("Expected the queued Morning Brief user message");
-    }
-    const userMessage = message.userMessage;
-    const replaced = await db().transaction(async (tx) => {
-      return await replaceChatEvent(tx, message.id, {
-        chatThreadId: args.threadId,
-        eventType: "input.prompt",
-        userMessage,
-        runId: null,
-        encryptedParams,
-        attachFiles: message.attachFiles ? [...message.attachFiles] : null,
-        generationTemplate: message.generationTemplate,
-        ...(message.triggerSource
-          ? { triggerSource: message.triggerSource }
-          : {}),
-      });
-    });
-    if (!replaced) {
-      throw new Error("Expected the queued Morning Brief callback payload");
-    }
-    return;
+  const updated = await db()
+    .update(chatMorningBriefContext)
+    .set({ triggeredAt: args.triggeredAt })
+    .where(eq(chatMorningBriefContext.id, args.eventId))
+    .returning({ id: chatMorningBriefContext.id });
+  if (updated.length !== 1) {
+    throw new Error("Expected one queued Morning Brief context");
   }
-  throw new Error("Expected the queued Morning Brief delivery");
 }
 
 export async function readMorningBriefQueuedParamsFixture(args: {


### PR DESCRIPTION
## Summary

- load Morning Brief launch context at claim from `chat_events` and `chat_morning_brief_context`, joining the referenced delivery for `brief_date`, `input_key`, and `output_key`
- freshly presign the delivery's R2 input GET and JSON output PUT URLs with a 24-hour TTL at claim
- mint the `morning-brief:email` callback secret with `generateCallbackSecret()` at claim and reconstruct its payload as `{ deliveryId }`
- stop writing prompts, delivery callback data, secrets, and URLs into new encrypted queue params; new rows retain only `{ version: 1 }`
- retain the legacy encrypted-blob fallback for pending pre-cutover rows until the measured drain follow-up

This is PR 2 of #24519, after the context dual-write in #24521 and the trigger-source dispatch prerequisite in #24520.

## Intentional prompt difference

This is the only #24362 source with an intentional prompt change. The prompt is byte-for-byte identical after replacing the two signed URL values, but those URLs now have new signatures and later expiration timestamps because they are minted when the queue item is claimed instead of when it is admitted.

That difference fixes the existing expiry defect: a Morning Brief queued longer than the old URL TTL now receives usable input and output URLs. No other prompt text changes.

## Context shape

`brief_date` remains out of `chat_morning_brief_context` because claim can derive it from the referenced `morning_brief_deliveries` row together with the R2 keys. `timezone` and `triggered_at` remain in context because the delivery row cannot provide them. The context's `delivery_id` intentionally has no foreign key.

## Compatibility and scope

- complete legacy Morning Brief prompt params remain readable until PR 3 removes the fallback after production drain
- duplicate manual admission checks prefer `chat_morning_brief_context` and retain the old blob lookup only for pending legacy rows
- `cron-monitor-chat-event-queue`, `morning_brief_deliveries`, and `morning_brief_schedules` schemas are unchanged

## Coverage

The Morning Brief integration scenario now verifies:

- newly queued params decrypt to exactly `{ version: 1 }`
- no input/output URL is signed while the new delivery waits behind an active run
- a queue item aged past the former 24-hour TTL receives fresh GET and PUT signatures at claim for the delivery's exact R2 keys
- after normalizing only those two URLs, the claimed run and system prompts match the existing prompt builders byte-for-byte
- the output URL is signed for `application/json`
- the claim-created email callback stores an encrypted secret and reconstructs `{ deliveryId }`
- the existing end-to-end completion still reads the staged input path, writes/loads output, authenticates the callback, and sends the email
- a historical prompt-only blob still drains through the rollout fallback

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- targeted Prettier checks
- `git diff --check`

A focused single-worker Morning Brief Vitest run is blocked before these scenarios by the local PostgreSQL schema missing `org_model_policies.model_provider_surface_id` (`42703`). PR CI uses the repository's pinned migrated database and will run the integration coverage. No full local Vitest suite or development server was run.
