### PR TITLE
refactor: require github chat launch context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-chat.test.ts
@@ -13,7 +13,6 @@ import {
   decryptChatEventInputParamsFixture,
   findPendingChatEventInputParamsByPromptFixture,
   readChatEventContextFixture,
-  replaceGitHubLaunchMaterialWithLegacyParamsFixture,
 } from "../../../test-fixtures/chat-events";
 import {
   countGitHubRunsByPromptFixture,
@@ -542,48 +541,6 @@ describe("GitHub canonical chat threads", () => {
     });
     await clearGitHubTriggerCommentBodyFixture(queuedParams.eventId);
 
-    const legacyQueuedPrompt = "queued before the GitHub claim cutover";
-    await sendGitHubComment({
-      fixture,
-      githubUserId: fixture.githubUserA,
-      commentId: 30_003,
-      prompt: legacyQueuedPrompt,
-      subjectNumber,
-      subjectKind: "pull_request",
-    });
-    const legacyQueuedParams =
-      await findPendingChatEventInputParamsByPromptFixture(legacyQueuedPrompt);
-    if (!legacyQueuedParams) {
-      throw new Error("Expected legacy queued GitHub chat input params");
-    }
-    const legacyContext = await readChatEventContextFixture(
-      legacyQueuedParams.eventId,
-    );
-    if (!legacyContext?.githubTriggerReactionId) {
-      throw new Error("Expected queued GitHub reaction context");
-    }
-    const legacyPrompt = "legacy queued GitHub prompt";
-    const legacySystemPrompt = "legacy queued GitHub system prompt";
-    await replaceGitHubLaunchMaterialWithLegacyParamsFixture(
-      legacyQueuedParams.eventId,
-      {
-        orgId: fixture.actorA.orgId,
-        userId: fixture.actorA.userId,
-        prompt: legacyPrompt,
-        appendSystemPrompt: legacySystemPrompt,
-        githubDelivery: {
-          installationId: fixture.installationId,
-          repo: REPO,
-          subjectNumber,
-          subjectKind: "pull_request",
-          agentId: fixture.agentId,
-          triggerCommentId: "30003",
-          triggerReactionId: legacyContext.githubTriggerReactionId,
-          triggerCommentBody: `@Zero ${legacyQueuedPrompt}`,
-        },
-      },
-    );
-
     const firstCliSession = await claimAndFinish({ fixture, run });
     const followUp = await runState(
       fixture.actorA.userId,
@@ -591,17 +548,10 @@ describe("GitHub canonical chat threads", () => {
     );
     expect(followUp.chatThreadId).toBe(run.chatThreadId);
     expect(followUp.sessionId).toBe(run.sessionId);
-    const followUpCliSession = await claimAndFinish({
+    await claimAndFinish({
       fixture,
       run: followUp,
       expectedResumeSessionId: firstCliSession,
-    });
-    const legacyRun = await runState(fixture.actorA.userId, legacyPrompt);
-    expect(legacyRun.appendSystemPrompt).toContain(legacySystemPrompt);
-    await claimAndFinish({
-      fixture,
-      run: legacyRun,
-      expectedResumeSessionId: followUpCliSession,
     });
 
     const routes = await routeRows({
@@ -612,7 +562,7 @@ describe("GitHub canonical chat threads", () => {
       expect.objectContaining({
         userId: fixture.actorA.userId,
         chatThreadId: run.chatThreadId,
-        lastCommentId: "30003",
+        lastCommentId: "30002",
       }),
     ]);
     expect(fixture.postedComments).toStrictEqual([
@@ -622,10 +572,6 @@ describe("GitHub canonical chat threads", () => {
       }),
       expect.objectContaining({
         subjectNumber,
-      }),
-      expect.objectContaining({
-        subjectNumber,
-        body: expect.stringContaining(`> @Zero ${legacyQueuedPrompt}`),
       }),
     ]);
   });

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2724,7 +2724,6 @@ function launchLoader<Material extends NativeQueuedLaunchMaterial>(
 
 async function resolveQueuedLaunchMaterial(
   args: CreateQueuedChatRunInputArgs,
-  sourceParams: QueuedSourceParams,
 ): Promise<QueuedLaunchMaterial | null> {
   const launchLoaders: Partial<Record<TriggerSource, LaunchLoader>> = {
     slack: launchLoader(loadSlackQueuedLaunchMaterial, (material) => {
@@ -2753,14 +2752,6 @@ async function resolveQueuedLaunchMaterial(
   if (material) {
     return material;
   }
-  if (
-    args.queuedMessage.triggerSource === "github" &&
-    sourceParams?.prompt !== undefined &&
-    sourceParams.appendSystemPrompt !== undefined &&
-    sourceParams.githubDelivery
-  ) {
-    return null;
-  }
   throw new Error(
     `${args.queuedMessage.triggerSource} queue item is missing launch material`,
   );
@@ -2783,9 +2774,6 @@ function queuedIntegrationDeliveries(
     },
     agentphone: (params) => {
       return { agentphoneDelivery: params?.agentphoneDelivery };
-    },
-    github: (params) => {
-      return { githubDelivery: params?.githubDelivery };
     },
     "workflow-schedule": (params) => {
       return { morningBriefDelivery: params?.morningBriefDelivery };
@@ -2972,8 +2960,7 @@ function queuedMessageAdmissionFailure(
     github: (resolverArgs) => {
       return githubQueuedMessageAdmissionFailure(
         resolverArgs.args,
-        resolverArgs.launchMaterial?.delivery.githubDelivery ??
-          resolverArgs.sourceParams?.githubDelivery,
+        resolverArgs.launchMaterial?.delivery.githubDelivery,
         resolverArgs.error,
       );
     },
@@ -2997,9 +2984,6 @@ function queuedMessagePrompt(args: {
 }): string {
   if (args.launchMaterial) {
     return args.launchMaterial.prompt;
-  }
-  if (args.triggerSource === "github") {
-    return args.sourceParams?.prompt ?? "";
   }
   if (args.triggerSource === "workflow-schedule") {
     return args.sourceParams?.prompt ?? args.projectedPrompt;
@@ -3050,7 +3034,7 @@ async function loadQueuedRunMaterial(args: CreateQueuedChatRunInputArgs) {
   if (args.queuedMessage.triggerSource !== "web" && !sourceParams) {
     throw new Error("Canonical integration queue item is missing run params");
   }
-  const launchMaterial = await resolveQueuedLaunchMaterial(args, sourceParams);
+  const launchMaterial = await resolveQueuedLaunchMaterial(args);
   return {
     sourceParams,
     launchMaterial,

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -64,7 +64,6 @@ import {
 } from "./crypto.utils";
 import { noGoalChangeAfterQueueEvent } from "./chat-goal-queue.service";
 import { agentphoneDeliveryTargetSchema } from "./agentphone-chat-callback-payload";
-import { githubDeliveryTargetSchema } from "./github-chat-callback-payload";
 import { telegramDeliveryTargetSchema } from "./telegram-chat-callback-payload";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { resolveArtifactObject$ } from "./artifact-storage.service";
@@ -90,7 +89,6 @@ const queuedUserMessageRunParamsSchema = z.object({
   appendSystemPrompt: z.string().optional(),
   telegramDelivery: telegramDeliveryTargetSchema.optional(),
   agentphoneDelivery: agentphoneDeliveryTargetSchema.optional(),
-  githubDelivery: githubDeliveryTargetSchema.optional(),
   morningBriefDelivery: z
     .object({
       deliveryId: z.string(),

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -35,11 +35,7 @@ import {
 } from "../signals/services/zero-chat-event.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
-import type { GitHubDeliveryTarget } from "../signals/services/github-chat-callback-payload";
-import {
-  decryptQueuedUserMessageRunParams,
-  encryptQueuedUserMessageRunParams,
-} from "../signals/services/zero-chat-queued-event.service";
+import { decryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
@@ -586,51 +582,6 @@ export async function decryptChatEventInputParamsFixture(
     return null;
   }
   return await decryptQueuedUserMessageRunParams(row.encryptedParams, ctx);
-}
-
-export async function replaceGitHubLaunchMaterialWithLegacyParamsFixture(
-  eventId: string,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly prompt: string;
-    readonly appendSystemPrompt: string;
-    readonly githubDelivery: GitHubDeliveryTarget;
-  },
-): Promise<void> {
-  const [event] = await db()
-    .select({ contextId: chatEvents.contextId })
-    .from(chatEvents)
-    .where(eq(chatEvents.id, eventId))
-    .limit(1);
-  if (!event?.contextId) {
-    throw new Error("Expected pending GitHub event context");
-  }
-  const contextId = event.contextId;
-  const encryptedParams = await encryptQueuedUserMessageRunParams(
-    {
-      version: 1,
-      prompt: args.prompt,
-      appendSystemPrompt: args.appendSystemPrompt,
-      githubDelivery: args.githubDelivery,
-    },
-    { orgId: args.orgId, userId: args.userId },
-  );
-  await db().transaction(async (tx) => {
-    await tx
-      .update(chatGithubContext)
-      .set({
-        issueContext: null,
-        messageText: null,
-        triggerReactionId: null,
-        triggerCommentBody: null,
-      })
-      .where(eq(chatGithubContext.id, contextId));
-    await tx
-      .update(chatEventInputParams)
-      .set({ encryptedParams })
-      .where(eq(chatEventInputParams.eventId, eventId));
-  });
 }
 
 export async function clearGitHubTriggerCommentBodyFixture(


### PR DESCRIPTION
## Summary

- remove the legacy GitHub chat launch fields from `chat_event_input_params.encrypted_params`
- require GitHub chat claims and admission failures to load prompt, system prompt, and delivery from `chat_events`, `chat_github_context`, `github_chat_thread_routes`, and `chat_threads`
- remove the legacy fallback fixture and retain context-only issue/PR, file-reference, reaction, reply, and null-comment-body coverage

This is PR 3 of 3 for #24514. Closes #24514.

## Production drain gate

PR #24522 was deployed by [Turbo run 30733035797](https://github.com/vm0-ai/vm0/actions/runs/30733035797), production `deploy-api` job 91456841128, which completed successfully at 2026-08-02 04:54:55 UTC.

A read-only production reconciliation at 2026-08-02 04:56:15 UTC found:

- original pending GitHub `input.prompt` events: 0
- replacement GitHub `input.prompt` events with `run_id`: 0
- GitHub `input.rejected` events: 0
- GitHub `control.revoke` events: 0
- reconciliation: `0 original = 0 run replacements + 0 rejected + 0 revoked`

The exact drain identity is satisfied, so no GitHub chat event still requires the legacy fallback.

## Scope

- GitHub chat only
- no GitHub automation changes
- no `cron-monitor-chat-event-queue` changes

## Validation

- `pnpm exec prettier --write <changed files>`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- `git diff --check`

Per #24514, no local full Vitest run or dev server was started; PR CI is the runtime validation gate.