### PR TITLE
refactor(guest-mock-claude): split process responsibilities

### DIFF
--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -1,44 +1,11 @@
-use crate::args::ParsedArgs;
-use crate::scenario::{MockScenario, echo_session_id, parse_echo_jsonl};
-use crate::transcript::{
-    JsonlTranscript, assistant_text_event, create_session_history, generate_session_id, init_event,
-    is_valid_session_history_id, replayed_user_event, result_event, tool_result_event,
-    tool_use_event,
-};
-use guest_mock_claude::process_group_child::ProcessGroupChild;
-use serde_json::Value;
-use serde_json::json;
-use std::collections::BTreeMap;
-use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
-#[cfg(unix)]
-use std::os::fd::AsRawFd;
-use std::os::unix::net::UnixListener;
-use std::path::Path;
-use std::process::{Command, ExitCode, Stdio};
-#[cfg(unix)]
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-};
-use std::thread;
-use std::time::Duration;
+mod fixtures;
+mod shell_execution;
+mod stream_json_input;
 
-const REAPABLE_HANG_DURATION: Duration = Duration::from_secs(3600);
-const ACTIVE_INPUT_READY_RESULT: &str = "READY_FOR_ACTIVE_INPUT";
-const TERMINATION_READY_EVENT: &str = "vm0_mock_termination_ready";
-const POST_RESULT_READY_EVENT: &str = "vm0_mock_post_result_ready";
-const POST_RESULT_ACTIVITY_ONE_EVENT: &str = "vm0_mock_post_result_activity_1_ready";
-const POST_RESULT_ACTIVITY_TWO_EVENT: &str = "vm0_mock_post_result_activity_2_ready";
-const POST_RESULT_LIVENESS_EVENT: &str = "vm0_mock_post_result_stale_deadline_survived";
-const POST_RESULT_RELEASE_ONE_SOCKET: &str = ".vm0-post-result-release-1.sock";
-const POST_RESULT_RELEASE_TWO_SOCKET: &str = ".vm0-post-result-release-2.sock";
-const STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES: usize = 1024 * 1024;
-const STREAM_JSON_SHELL_READ_BUFFER_BYTES: usize = 8 * 1024;
-// Integration contract with guest-agent's ordinary stdout framing policy.
-const ORDINARY_STDOUT_MAX_LINE_BYTES: usize = 16 * 1024 * 1024;
-const STDOUT_STREAM_CHUNK_BYTES: usize = 8 * 1024;
-#[cfg(unix)]
-const STREAM_JSON_SHELL_CANCEL_POLL_TIMEOUT_MS: libc::c_int = 100;
+use crate::args::ParsedArgs;
+use crate::scenario::MockScenario;
+use std::io::BufReader;
+use std::process::ExitCode;
 
 pub(crate) fn run(parsed: ParsedArgs) -> ExitCode {
     if parsed.input_format == "stream-json" {
@@ -48,32 +15,25 @@ pub(crate) fn run(parsed: ParsedArgs) -> ExitCode {
     run_prompt_scenario(&parsed.prompt, &parsed.output_format)
 }
 
-#[derive(Debug)]
-struct StreamJsonUserFrame {
-    content: String,
-    uuid: Option<String>,
-}
-
 fn run_stream_json_input(parsed: ParsedArgs) -> ExitCode {
     let stdin = std::io::stdin();
     let mut reader = BufReader::new(stdin.lock());
-    let first_frame =
-        match read_next_stream_json_user_frame(&mut reader, StreamJsonFrameKind::First) {
-            Ok(Some(frame)) => frame,
-            Ok(None) => {
-                eprintln!("stream-json stdin did not contain a user message");
-                return ExitCode::from(1);
-            }
-            Err(message) => {
-                eprintln!("{message}");
-                return ExitCode::from(1);
-            }
-        };
+    let first_frame = match stream_json_input::read_initial_user_frame(&mut reader) {
+        Ok(Some(frame)) => frame,
+        Ok(None) => {
+            eprintln!("stream-json stdin did not contain a user message");
+            return ExitCode::from(1);
+        }
+        Err(message) => {
+            eprintln!("{message}");
+            return ExitCode::from(1);
+        }
+    };
 
-    match MockScenario::from_prompt(&first_frame.content) {
+    match MockScenario::from_prompt(first_frame.content()) {
         MockScenario::ActiveInputSmoke {
             expected_follow_ups,
-        } => run_active_input_smoke_scenario(
+        } => stream_json_input::run_active_input_smoke_scenario(
             &parsed.output_format,
             parsed.replay_user_messages,
             first_frame,
@@ -81,22 +41,18 @@ fn run_stream_json_input(parsed: ParsedArgs) -> ExitCode {
             expected_follow_ups,
         ),
         MockScenario::InvalidActiveInputSmokeCount(count) => {
-            eprintln!("{}", invalid_active_input_count_message(count));
+            eprintln!(
+                "{}",
+                stream_json_input::invalid_active_input_count_message(count)
+            );
             ExitCode::from(1)
         }
-        scenario => run_scenario(scenario, &first_frame.content, &parsed.output_format),
+        scenario => run_scenario(scenario, first_frame.content(), &parsed.output_format),
     }
 }
 
 fn run_prompt_scenario(prompt: &str, output_format: &str) -> ExitCode {
     run_scenario(MockScenario::from_prompt(prompt), prompt, output_format)
-}
-
-fn invalid_active_input_count_message(count: &str) -> String {
-    format!(
-        "invalid @active-input-smoke follow-up count ({} bytes)",
-        count.len()
-    )
 }
 
 fn run_scenario(scenario: MockScenario<'_>, prompt: &str, output_format: &str) -> ExitCode {
@@ -106,815 +62,47 @@ fn run_scenario(scenario: MockScenario<'_>, prompt: &str, output_format: &str) -
             ExitCode::from(1)
         }
         MockScenario::InvalidActiveInputSmokeCount(count) => {
-            eprintln!("{}", invalid_active_input_count_message(count));
+            eprintln!(
+                "{}",
+                stream_json_input::invalid_active_input_count_message(count)
+            );
             ExitCode::from(1)
         }
-        MockScenario::EchoJsonl(payload) => run_echo_jsonl_mode(payload, false),
-        MockScenario::EchoJsonlAndHang(payload) => run_echo_jsonl_mode(payload, true),
-        MockScenario::FailNoNewline(msg) => {
-            eprint!("{msg}");
-            let _ = std::io::stderr().flush();
-            ExitCode::from(1)
-        }
-        MockScenario::FailInvalidUtf8 => {
-            let _ = std::io::stderr().write_all(b"invalid-\xff-stderr\n");
-            let _ = std::io::stderr().flush();
-            ExitCode::from(1)
-        }
-        MockScenario::FailInvalidUtf8Long => {
-            let invalid = vec![0xff; 16 * 1024];
-            let _ = std::io::stderr().write_all(&invalid);
-            let _ = std::io::stderr().write_all(b"\n");
-            let _ = std::io::stderr().flush();
-            ExitCode::from(1)
-        }
-        MockScenario::Fail(msg) => {
-            eprintln!("{msg}");
-            ExitCode::from(1)
-        }
+        MockScenario::EchoJsonl(payload) => fixtures::run_echo_jsonl_mode(payload, false),
+        MockScenario::EchoJsonlAndHang(payload) => fixtures::run_echo_jsonl_mode(payload, true),
+        MockScenario::FailNoNewline(msg) => fixtures::run_fail_no_newline(msg),
+        MockScenario::FailInvalidUtf8 => fixtures::run_fail_invalid_utf8(),
+        MockScenario::FailInvalidUtf8Long => fixtures::run_fail_invalid_utf8_long(),
+        MockScenario::Fail(msg) => fixtures::run_fail(msg),
         MockScenario::StdoutOverLimit { newline } => {
-            run_stdout_over_limit_scenario(output_format, newline)
+            fixtures::run_stdout_over_limit_scenario(output_format, newline)
         }
-        MockScenario::StdoutInvalidUtf8 => run_stdout_invalid_utf8_scenario(output_format),
+        MockScenario::StdoutInvalidUtf8 => {
+            fixtures::run_stdout_invalid_utf8_scenario(output_format)
+        }
         MockScenario::StdoutRecordBoundaries => {
-            run_stdout_record_boundaries_scenario(output_format)
+            fixtures::run_stdout_record_boundaries_scenario(output_format)
         }
         MockScenario::StuckTool { deaf, close_stdout } => {
-            run_stuck_tool_scenario(output_format, deaf, close_stdout)
+            fixtures::run_stuck_tool_scenario(output_format, deaf, close_stdout)
         }
-        MockScenario::OrphanPipe => {
-            if output_format == "stream-json" {
-                emit_post_result_pair();
-
-                // Spawn a child after flushing the completed stream. It inherits
-                // stdout and keeps the pipe open after this process exits.
-                let _ = Command::new("sleep")
-                    .arg(REAPABLE_HANG_DURATION.as_secs().to_string())
-                    .spawn();
-            }
-            ExitCode::SUCCESS
-        }
+        MockScenario::OrphanPipe => fixtures::run_orphan_pipe_scenario(output_format),
         MockScenario::HangAfterResult { deaf } => {
-            run_hang_after_result_scenario(output_format, deaf)
+            fixtures::run_hang_after_result_scenario(output_format, deaf)
         }
         MockScenario::HangAfterResultThenEvent => {
-            run_hang_after_result_then_event_scenario(output_format)
+            fixtures::run_hang_after_result_then_event_scenario(output_format)
         }
         MockScenario::HangAfterResultPeriodicEvents => {
-            run_hang_after_result_periodic_events_scenario(output_format)
+            fixtures::run_hang_after_result_periodic_events_scenario(output_format)
         }
-        MockScenario::HangAfterErrorResult => run_hang_after_error_result_scenario(output_format),
-        MockScenario::ExitAfterResult => {
-            if output_format == "stream-json" {
-                emit_post_result_pair();
-                // Exit immediately. Exercises the happy path: guest-agent
-                // either arms post-result reap and observes `child.wait()`
-                // before the deadline, or observes `child.wait()` first and
-                // never arms reap. No signal should be sent.
-            }
-            ExitCode::SUCCESS
+        MockScenario::HangAfterErrorResult => {
+            fixtures::run_hang_after_error_result_scenario(output_format)
         }
-        MockScenario::WriteEnvJson(path) => run_write_env_json_scenario(output_format, path),
-        MockScenario::Shell => {
-            let session_id = generate_session_id();
-
-            if output_format == "stream-json" {
-                run_stream_json_mode(prompt, &session_id)
-            } else {
-                run_text_mode(prompt)
-            }
+        MockScenario::ExitAfterResult => fixtures::run_exit_after_result_scenario(output_format),
+        MockScenario::WriteEnvJson(path) => {
+            fixtures::run_write_env_json_scenario(output_format, path)
         }
+        MockScenario::Shell => shell_execution::run(prompt, output_format),
     }
-}
-
-#[derive(Clone, Copy)]
-enum StreamJsonFrameKind {
-    First,
-    FollowUp { index: usize },
-}
-
-fn read_next_stream_json_user_frame(
-    reader: &mut impl BufRead,
-    kind: StreamJsonFrameKind,
-) -> Result<Option<StreamJsonUserFrame>, String> {
-    let mut line = String::new();
-    loop {
-        line.clear();
-        let bytes = reader
-            .read_line(&mut line)
-            .map_err(|e| format!("read stream-json stdin: {e}"))?;
-        if bytes == 0 {
-            return Ok(None);
-        }
-
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        return parse_stream_json_user_frame(trimmed, kind).map(Some);
-    }
-}
-
-fn parse_stream_json_user_frame(
-    line: &str,
-    kind: StreamJsonFrameKind,
-) -> Result<StreamJsonUserFrame, String> {
-    let event: Value = serde_json::from_str(line).map_err(|e| match kind {
-        StreamJsonFrameKind::First => format!("parse stream-json stdin: {e}"),
-        StreamJsonFrameKind::FollowUp { index } => {
-            format!("parse stream-json stdin follow-up message {index}: {e}")
-        }
-    })?;
-
-    let description = match kind {
-        StreamJsonFrameKind::First => "first message".to_string(),
-        StreamJsonFrameKind::FollowUp { index } => format!("follow-up message {index}"),
-    };
-
-    if event.get("type").and_then(Value::as_str) != Some("user") {
-        return Err(format!(
-            "stream-json stdin {description} must have type \"user\""
-        ));
-    }
-    if let Some(role) = event.pointer("/message/role").and_then(Value::as_str)
-        && role != "user"
-    {
-        return Err(format!(
-            "stream-json stdin {description} role must be \"user\""
-        ));
-    }
-
-    let content = event
-        .pointer("/message/content")
-        .and_then(Value::as_str)
-        .map(str::to_string)
-        .ok_or_else(|| {
-            format!("stream-json stdin {description} must contain string message.content")
-        })?;
-    let uuid = event
-        .get("uuid")
-        .and_then(Value::as_str)
-        .map(str::to_string);
-
-    Ok(StreamJsonUserFrame { content, uuid })
-}
-
-fn run_active_input_smoke_scenario(
-    output_format: &str,
-    replay_user_messages: bool,
-    initial_frame: StreamJsonUserFrame,
-    stdin: &mut impl BufRead,
-    expected_follow_ups: usize,
-) -> ExitCode {
-    if output_format != "stream-json" {
-        eprintln!("@active-input-smoke requires --output-format stream-json");
-        return ExitCode::from(1);
-    }
-
-    let session_id = generate_session_id();
-    let mut transcript = JsonlTranscript::default();
-
-    transcript.emit_value(init_event(&session_id, &["Bash"]));
-    if replay_user_messages {
-        transcript.emit_value(replayed_user_event(
-            &session_id,
-            initial_frame.uuid.as_deref(),
-            &initial_frame.content,
-        ));
-    }
-    transcript.emit_value(result_event(&session_id, false, ACTIVE_INPUT_READY_RESULT));
-    let _ = std::io::stdout().flush();
-
-    let mut follow_up_contents = Vec::new();
-    for index in 1..=expected_follow_ups {
-        let frame = match read_next_stream_json_user_frame(
-            stdin,
-            StreamJsonFrameKind::FollowUp { index },
-        ) {
-            Ok(Some(frame)) => frame,
-            Ok(None) => {
-                eprintln!(
-                    "active-input stdin closed after {} of {expected_follow_ups} follow-up user messages",
-                    follow_up_contents.len()
-                );
-                return ExitCode::from(1);
-            }
-            Err(message) => {
-                eprintln!("{message}");
-                return ExitCode::from(1);
-            }
-        };
-
-        if replay_user_messages {
-            transcript.emit_value(replayed_user_event(
-                &session_id,
-                frame.uuid.as_deref(),
-                &frame.content,
-            ));
-            let _ = std::io::stdout().flush();
-        }
-        follow_up_contents.push(frame.content);
-    }
-
-    transcript.emit_value(result_event(
-        &session_id,
-        false,
-        &format!("RESULT={}", follow_up_contents.join("+")),
-    ));
-    transcript.write_session_history(&session_id);
-    let _ = std::io::stdout().flush();
-    ExitCode::SUCCESS
-}
-
-fn run_echo_jsonl_mode(payload: &str, hang_after_output: bool) -> ExitCode {
-    let events = match parse_echo_jsonl(payload) {
-        Ok(events) => events,
-        Err(msg) => {
-            eprintln!("{msg}");
-            return ExitCode::from(1);
-        }
-    };
-
-    let session_id = echo_session_id(&events).map(str::to_owned);
-    if let Some(session_id) = session_id.as_deref()
-        && !is_valid_session_history_id(session_id)
-    {
-        eprintln!("invalid @ECHO@ session_id: {session_id:?}");
-        return ExitCode::from(1);
-    }
-
-    let mut transcript = JsonlTranscript::default();
-    for (line, _) in events {
-        transcript.emit_raw_line(line);
-    }
-    if let Some(session_id) = session_id.as_deref() {
-        transcript.write_session_history(session_id);
-    }
-    let _ = std::io::stdout().flush();
-    if hang_after_output {
-        hang_until_reaped();
-    }
-    ExitCode::SUCCESS
-}
-
-/// Emit the init + result JSONL pair shared by post-result mock test
-/// prefixes, flush stdout so guest-agent sees them, and write the
-/// session history checkpoint file. Caller decides which post-result
-/// behavior follows (hang / exit / ignore SIGTERM / orphan stdout).
-fn emit_post_result_pair() {
-    let _ = emit_result_pair(false, "Done.");
-}
-
-fn emit_result_pair(is_error: bool, result: &str) -> String {
-    let session_id = generate_session_id();
-    let mut transcript = JsonlTranscript::default();
-    transcript.emit_value(init_event(&session_id, &["Bash"]));
-    transcript.emit_value(result_event(&session_id, is_error, result));
-    transcript.write_session_history(&session_id);
-
-    let _ = std::io::stdout().flush();
-    session_id
-}
-
-fn emit_stuck_tool_events() {
-    let session_id = generate_session_id();
-    let mut transcript = JsonlTranscript::default();
-
-    transcript.emit_value(init_event(&session_id, &["WebFetch"]));
-    transcript.emit_value(tool_use_event(
-        &session_id,
-        "toolu_stuck_001",
-        "WebFetch",
-        json!({"url": "https://example.com/hang"}),
-    ));
-
-    // Flush stdout so guest-agent receives the events before we hang.
-    // When piped, stdout is fully buffered and println! may not flush.
-    let _ = std::io::stdout().flush();
-}
-
-fn ignore_sigterm() {
-    // SAFETY: signal(SIGTERM, SIG_IGN) is async-signal-safe and these mock
-    // scenarios do not share signal handler state after installing it.
-    unsafe {
-        libc::signal(libc::SIGTERM, libc::SIG_IGN);
-    }
-}
-
-fn emit_termination_ready_fence() {
-    if let Ok(home) = std::env::var("HOME") {
-        let _ = std::fs::write(format!("{home}/.vm0-mock-sigterm-ignored"), b"");
-    }
-    emit_stream_event_fence(TERMINATION_READY_EVENT);
-}
-
-fn emit_stream_event_fence(event_type: &str) {
-    println!(
-        "{}",
-        json!({"type": "stream_event", "event": {"type": event_type}})
-    );
-    let _ = std::io::stdout().flush();
-}
-
-fn emit_fence_and_wait_for_release(
-    event_type: &str,
-    release_socket_name: &str,
-) -> Result<(), String> {
-    let home = std::env::var("HOME").map_err(|error| format!("read HOME: {error}"))?;
-    let release_socket = Path::new(&home).join(release_socket_name);
-    let listener = UnixListener::bind(&release_socket)
-        .map_err(|error| format!("bind {}: {error}", release_socket.display()))?;
-    emit_stream_event_fence(event_type);
-    listener
-        .accept()
-        .map_err(|error| format!("accept {}: {error}", release_socket.display()))?;
-    Ok(())
-}
-
-fn hang_until_reaped() {
-    std::thread::sleep(REAPABLE_HANG_DURATION);
-}
-
-fn write_stdout_limit(stdout: &mut impl Write, byte: u8) -> std::io::Result<()> {
-    let chunk = [byte; STDOUT_STREAM_CHUNK_BYTES];
-    for _ in 0..ORDINARY_STDOUT_MAX_LINE_BYTES / STDOUT_STREAM_CHUNK_BYTES {
-        stdout.write_all(&chunk)?;
-    }
-    Ok(())
-}
-
-fn run_stdout_over_limit_scenario(output_format: &str, newline: bool) -> ExitCode {
-    if output_format != "stream-json" {
-        return ExitCode::from(1);
-    }
-
-    let stdout = std::io::stdout();
-    let mut stdout = stdout.lock();
-    let _ = write_stdout_limit(&mut stdout, b'x');
-    let suffix: &[u8] = if newline { b"x\n" } else { b"x" };
-    let _ = stdout.write_all(suffix);
-    let _ = stdout.flush();
-    drop(stdout);
-    hang_until_reaped();
-    ExitCode::from(1)
-}
-
-fn run_stdout_invalid_utf8_scenario(output_format: &str) -> ExitCode {
-    if output_format != "stream-json" {
-        return ExitCode::from(1);
-    }
-
-    let stdout = std::io::stdout();
-    let mut stdout = stdout.lock();
-    let _ = stdout.write_all(b"do-not-log-invalid-stdout-\xff\n");
-    let _ = stdout.flush();
-    drop(stdout);
-    hang_until_reaped();
-    ExitCode::from(1)
-}
-
-fn run_stdout_record_boundaries_scenario(output_format: &str) -> ExitCode {
-    if output_format != "stream-json" {
-        return ExitCode::from(1);
-    }
-
-    let stdout = std::io::stdout();
-    let mut stdout = stdout.lock();
-    let result = stdout
-        .write_all(b"crlf-record\r\n")
-        .and_then(|()| write_stdout_limit(&mut stdout, b'x'))
-        .and_then(|()| stdout.write_all(b"\neof-record"))
-        .and_then(|()| stdout.flush());
-    if let Err(error) = result {
-        eprintln!("write stdout record-boundary fixture: {error}");
-        return ExitCode::from(1);
-    }
-    ExitCode::SUCCESS
-}
-
-fn run_stuck_tool_scenario(output_format: &str, deaf: bool, close_stdout: bool) -> ExitCode {
-    if output_format == "stream-json" {
-        if deaf {
-            ignore_sigterm();
-        }
-        emit_stuck_tool_events();
-
-        if deaf {
-            emit_termination_ready_fence();
-        }
-
-        if close_stdout {
-            // SAFETY: this mock process has finished writing all test events
-            // and is about to park forever. Closing fd 1 simulates a CLI that
-            // no longer has stdout open while the process is still alive.
-            unsafe {
-                libc::close(libc::STDOUT_FILENO);
-            }
-        }
-
-        // Hang forever - simulates a stuck WebFetch
-        hang_until_reaped();
-    }
-    ExitCode::from(1)
-}
-
-fn run_hang_after_result_scenario(output_format: &str, deaf: bool) -> ExitCode {
-    if output_format == "stream-json" {
-        if deaf {
-            // Ignore SIGTERM so only SIGKILL can terminate this process.
-            // Exercises the SigtermPending -> SigkillPending -> Done escalation
-            // branch of the reap FSM.
-            ignore_sigterm();
-        }
-        emit_post_result_pair();
-        if deaf {
-            emit_termination_ready_fence();
-        }
-        // Hang this process forever. guest-agent's post-result reap SIGTERMs
-        // it within POST_RESULT_SIGTERM_GRACE_SECS unless SIGTERM is ignored.
-        hang_until_reaped();
-    }
-    ExitCode::SUCCESS
-}
-
-fn run_hang_after_result_then_event_scenario(output_format: &str) -> ExitCode {
-    if output_format == "stream-json" {
-        let session_id = emit_result_pair(false, "Done.");
-        if let Err(error) =
-            emit_fence_and_wait_for_release(POST_RESULT_READY_EVENT, POST_RESULT_RELEASE_ONE_SOCKET)
-        {
-            eprintln!("{error}");
-            return ExitCode::from(1);
-        }
-        let mut transcript = JsonlTranscript::default();
-        transcript.emit_value(assistant_text_event(&session_id, "post-result event"));
-        if let Err(error) = emit_fence_and_wait_for_release(
-            POST_RESULT_ACTIVITY_ONE_EVENT,
-            POST_RESULT_RELEASE_TWO_SOCKET,
-        ) {
-            eprintln!("{error}");
-            return ExitCode::from(1);
-        }
-        emit_stream_event_fence(POST_RESULT_LIVENESS_EVENT);
-        hang_until_reaped();
-    }
-    ExitCode::SUCCESS
-}
-
-fn run_hang_after_result_periodic_events_scenario(output_format: &str) -> ExitCode {
-    if output_format == "stream-json" {
-        let session_id = emit_result_pair(false, "Done.");
-        if let Err(error) =
-            emit_fence_and_wait_for_release(POST_RESULT_READY_EVENT, POST_RESULT_RELEASE_ONE_SOCKET)
-        {
-            eprintln!("{error}");
-            return ExitCode::from(1);
-        }
-        let mut transcript = JsonlTranscript::default();
-        transcript.emit_value(assistant_text_event(
-            &session_id,
-            "post-result periodic event 0",
-        ));
-        if let Err(error) = emit_fence_and_wait_for_release(
-            POST_RESULT_ACTIVITY_ONE_EVENT,
-            POST_RESULT_RELEASE_TWO_SOCKET,
-        ) {
-            eprintln!("{error}");
-            return ExitCode::from(1);
-        }
-        transcript.emit_value(assistant_text_event(
-            &session_id,
-            "post-result periodic event 1",
-        ));
-        emit_stream_event_fence(POST_RESULT_ACTIVITY_TWO_EVENT);
-        hang_until_reaped();
-    }
-    ExitCode::SUCCESS
-}
-
-fn run_hang_after_error_result_scenario(output_format: &str) -> ExitCode {
-    if output_format == "stream-json" {
-        let _ = emit_result_pair(true, "Mock Claude error.");
-        hang_until_reaped();
-    }
-    ExitCode::SUCCESS
-}
-
-fn run_write_env_json_scenario(output_format: &str, path: &str) -> ExitCode {
-    if output_format != "stream-json" {
-        return ExitCode::from(1);
-    }
-
-    let env: BTreeMap<String, String> = std::env::vars().collect();
-    if let Some(parent) = Path::new(path).parent()
-        && !parent.as_os_str().is_empty()
-        && let Err(e) = std::fs::create_dir_all(parent)
-    {
-        eprintln!("create env json parent: {e}");
-        return ExitCode::from(1);
-    }
-    let payload = match serde_json::to_vec(&env) {
-        Ok(payload) => payload,
-        Err(e) => {
-            eprintln!("serialize env json: {e}");
-            return ExitCode::from(1);
-        }
-    };
-    if let Err(e) = std::fs::write(path, payload) {
-        eprintln!("write env json: {e}");
-        return ExitCode::from(1);
-    }
-
-    emit_post_result_pair();
-    ExitCode::SUCCESS
-}
-
-/// Execute prompt in text mode: inherited stdio, propagate exit code.
-fn run_text_mode(prompt: &str) -> ExitCode {
-    match Command::new("bash")
-        .args(["-c", prompt])
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
-    {
-        Ok(status) => ExitCode::from(status.code().unwrap_or(1) as u8),
-        Err(_) => ExitCode::from(1),
-    }
-}
-
-#[derive(Default)]
-struct CapturedShellStream {
-    bytes: Vec<u8>,
-    truncated: bool,
-}
-
-struct CapturedShellOutput {
-    stdout: CapturedShellStream,
-    stderr: CapturedShellStream,
-    exit_code: i32,
-}
-
-impl CapturedShellOutput {
-    fn failed() -> Self {
-        Self {
-            stdout: CapturedShellStream::default(),
-            stderr: CapturedShellStream::default(),
-            exit_code: 1,
-        }
-    }
-}
-
-fn new_captured_shell_stream() -> CapturedShellStream {
-    CapturedShellStream {
-        bytes: Vec::with_capacity(STREAM_JSON_SHELL_READ_BUFFER_BYTES),
-        truncated: false,
-    }
-}
-
-fn retain_captured_shell_bytes(stream: &mut CapturedShellStream, bytes: &[u8]) {
-    let remaining = STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES.saturating_sub(stream.bytes.len());
-    if remaining == 0 {
-        stream.truncated = true;
-        return;
-    }
-
-    let retained = remaining.min(bytes.len());
-    stream.bytes.extend(bytes.iter().take(retained).copied());
-    if retained < bytes.len() {
-        stream.truncated = true;
-    }
-}
-
-#[cfg(not(unix))]
-fn capture_shell_stream(mut reader: impl Read) -> std::io::Result<CapturedShellStream> {
-    let mut stream = new_captured_shell_stream();
-    let mut buffer = [0_u8; STREAM_JSON_SHELL_READ_BUFFER_BYTES];
-
-    loop {
-        let read = match reader.read(&mut buffer) {
-            Ok(0) => break,
-            Ok(read) => read,
-            Err(error) if error.kind() == ErrorKind::Interrupted => continue,
-            Err(error) => return Err(error),
-        };
-
-        let Some(chunk) = buffer.get(..read) else {
-            return Err(std::io::Error::other("shell stream read exceeded buffer"));
-        };
-        retain_captured_shell_bytes(&mut stream, chunk);
-    }
-
-    Ok(stream)
-}
-
-#[cfg(unix)]
-fn capture_shell_stream_until_cancelled<R>(
-    mut reader: R,
-    cancel: Arc<AtomicBool>,
-) -> std::io::Result<CapturedShellStream>
-where
-    R: Read + AsRawFd,
-{
-    let fd = reader.as_raw_fd();
-    let mut stream = new_captured_shell_stream();
-    let mut buffer = [0_u8; STREAM_JSON_SHELL_READ_BUFFER_BYTES];
-
-    loop {
-        // After bash exits, escaped descendants can keep the write end open.
-        // Cancellation switches to a zero-timeout final drain instead of
-        // waiting for EOF from those descendants.
-        let cancelled = cancel.load(Ordering::Acquire);
-        if cancelled && stream.truncated {
-            break;
-        }
-        let timeout_ms = if cancelled {
-            0
-        } else {
-            STREAM_JSON_SHELL_CANCEL_POLL_TIMEOUT_MS
-        };
-        let mut pollfd = libc::pollfd {
-            fd,
-            events: libc::POLLIN,
-            revents: 0,
-        };
-        let poll_result = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
-        if poll_result < 0 {
-            let error = std::io::Error::last_os_error();
-            if error.kind() == ErrorKind::Interrupted {
-                continue;
-            }
-            return Err(error);
-        }
-        if poll_result == 0 {
-            if cancelled {
-                break;
-            }
-            continue;
-        }
-        if pollfd.revents & libc::POLLNVAL != 0 {
-            break;
-        }
-        if pollfd.revents & (libc::POLLIN | libc::POLLHUP) == 0 {
-            if pollfd.revents & libc::POLLERR != 0 || cancelled {
-                break;
-            }
-            continue;
-        }
-
-        let read = match reader.read(&mut buffer) {
-            Ok(0) => break,
-            Ok(read) => read,
-            Err(error) if error.kind() == ErrorKind::Interrupted => continue,
-            Err(error) if error.kind() == ErrorKind::WouldBlock => continue,
-            Err(error) => return Err(error),
-        };
-        let Some(chunk) = buffer.get(..read) else {
-            return Err(std::io::Error::other("shell stream read exceeded buffer"));
-        };
-        retain_captured_shell_bytes(&mut stream, chunk);
-    }
-
-    Ok(stream)
-}
-
-fn join_captured_shell_stream(
-    handle: thread::JoinHandle<std::io::Result<CapturedShellStream>>,
-) -> std::io::Result<CapturedShellStream> {
-    match handle.join() {
-        Ok(result) => result,
-        Err(payload) => std::panic::resume_unwind(payload),
-    }
-}
-
-fn spawn_captured_shell(prompt: &str) -> std::io::Result<ProcessGroupChild> {
-    let mut command = Command::new("bash");
-    command
-        .args(["-c", prompt])
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    ProcessGroupChild::spawn(&mut command)
-}
-
-fn capture_shell_output(prompt: &str) -> CapturedShellOutput {
-    let mut child = match spawn_captured_shell(prompt) {
-        Ok(child) => child,
-        Err(_) => return CapturedShellOutput::failed(),
-    };
-
-    let Some(stdout) = child.take_stdout() else {
-        child.terminate();
-        return CapturedShellOutput::failed();
-    };
-    let Some(stderr) = child.take_stderr() else {
-        child.terminate();
-        return CapturedShellOutput::failed();
-    };
-    #[cfg(unix)]
-    let cancel_streams = Arc::new(AtomicBool::new(false));
-
-    #[cfg(unix)]
-    let stdout_thread = {
-        let cancel = Arc::clone(&cancel_streams);
-        thread::spawn(move || capture_shell_stream_until_cancelled(stdout, cancel))
-    };
-    #[cfg(unix)]
-    let stderr_thread = {
-        let cancel = Arc::clone(&cancel_streams);
-        thread::spawn(move || capture_shell_stream_until_cancelled(stderr, cancel))
-    };
-
-    #[cfg(not(unix))]
-    let stdout_thread = thread::spawn(move || capture_shell_stream(stdout));
-    #[cfg(not(unix))]
-    let stderr_thread = thread::spawn(move || capture_shell_stream(stderr));
-
-    let exit_code = child
-        .wait_with_group_cleanup()
-        .map_or(1, |status| status.code().unwrap_or(1));
-    #[cfg(unix)]
-    cancel_streams.store(true, Ordering::Release);
-
-    let stdout = join_captured_shell_stream(stdout_thread);
-    let stderr = join_captured_shell_stream(stderr_thread);
-    let (Ok(stdout), Ok(stderr)) = (stdout, stderr) else {
-        return CapturedShellOutput::failed();
-    };
-
-    CapturedShellOutput {
-        stdout,
-        stderr,
-        exit_code,
-    }
-}
-
-fn append_truncation_marker(output: &mut String, stream_name: &str) {
-    output.push_str("\n[");
-    output.push_str(stream_name);
-    output.push_str(" truncated after ");
-    output.push_str(&STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES.to_string());
-    output.push_str(" bytes]\n");
-}
-
-fn format_captured_shell_output(captured: &CapturedShellOutput) -> String {
-    let mut output = String::from_utf8_lossy(&captured.stdout.bytes).into_owned();
-    if captured.stdout.truncated {
-        append_truncation_marker(&mut output, "stdout");
-    }
-
-    if captured.exit_code != 0 {
-        output.push_str(&String::from_utf8_lossy(&captured.stderr.bytes));
-        if captured.stderr.truncated {
-            append_truncation_marker(&mut output, "stderr");
-        }
-    }
-
-    output
-}
-
-/// Execute prompt in stream-json mode: output JSONL events, capture output.
-fn run_stream_json_mode(prompt: &str, session_id: &str) -> ExitCode {
-    let session_history_file = create_session_history(session_id);
-    let mut transcript = JsonlTranscript::default();
-
-    // 1. System init event
-    transcript.emit_value(init_event(session_id, &["Bash"]));
-
-    // 2. Assistant text event
-    transcript.emit_value(assistant_text_event(session_id, "Executing command..."));
-
-    // 3. Assistant tool_use event
-    transcript.emit_value(tool_use_event(
-        session_id,
-        "toolu_mock_001",
-        "Bash",
-        json!({"command": prompt}),
-    ));
-
-    // 4. Execute bash and capture bounded output
-    let captured = capture_shell_output(prompt);
-    let output = format_captured_shell_output(&captured);
-    let exit_code = captured.exit_code;
-
-    let is_error = exit_code != 0;
-
-    // 5. User tool_result event
-    transcript.emit_value(tool_result_event(
-        session_id,
-        "toolu_mock_001",
-        &output,
-        is_error,
-    ));
-
-    // 6. Result event
-    transcript.emit_value(result_event(session_id, is_error, &output));
-
-    // Write session history
-    if let Some(path) = session_history_file {
-        transcript.write_session_history_file(&path);
-    }
-
-    ExitCode::from(exit_code as u8)
 }

--- a/crates/guest-mock-claude/src/process/fixtures.rs
+++ b/crates/guest-mock-claude/src/process/fixtures.rs
@@ -1,0 +1,380 @@
+use crate::scenario::{echo_session_id, parse_echo_jsonl};
+use crate::transcript::{
+    JsonlTranscript, assistant_text_event, generate_session_id, init_event,
+    is_valid_session_history_id, result_event, tool_use_event,
+};
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::os::unix::net::UnixListener;
+use std::path::Path;
+use std::process::{Command, ExitCode};
+use std::time::Duration;
+
+const REAPABLE_HANG_DURATION: Duration = Duration::from_secs(3600);
+const TERMINATION_READY_EVENT: &str = "vm0_mock_termination_ready";
+const POST_RESULT_READY_EVENT: &str = "vm0_mock_post_result_ready";
+const POST_RESULT_ACTIVITY_ONE_EVENT: &str = "vm0_mock_post_result_activity_1_ready";
+const POST_RESULT_ACTIVITY_TWO_EVENT: &str = "vm0_mock_post_result_activity_2_ready";
+const POST_RESULT_LIVENESS_EVENT: &str = "vm0_mock_post_result_stale_deadline_survived";
+const POST_RESULT_RELEASE_ONE_SOCKET: &str = ".vm0-post-result-release-1.sock";
+const POST_RESULT_RELEASE_TWO_SOCKET: &str = ".vm0-post-result-release-2.sock";
+// Integration contract with guest-agent's ordinary stdout framing policy.
+const ORDINARY_STDOUT_MAX_LINE_BYTES: usize = 16 * 1024 * 1024;
+const STDOUT_STREAM_CHUNK_BYTES: usize = 8 * 1024;
+
+pub(super) fn run_fail_no_newline(msg: &str) -> ExitCode {
+    eprint!("{msg}");
+    let _ = std::io::stderr().flush();
+    ExitCode::from(1)
+}
+
+pub(super) fn run_fail_invalid_utf8() -> ExitCode {
+    let _ = std::io::stderr().write_all(b"invalid-\xff-stderr\n");
+    let _ = std::io::stderr().flush();
+    ExitCode::from(1)
+}
+
+pub(super) fn run_fail_invalid_utf8_long() -> ExitCode {
+    let invalid = vec![0xff; 16 * 1024];
+    let _ = std::io::stderr().write_all(&invalid);
+    let _ = std::io::stderr().write_all(b"\n");
+    let _ = std::io::stderr().flush();
+    ExitCode::from(1)
+}
+
+pub(super) fn run_fail(msg: &str) -> ExitCode {
+    eprintln!("{msg}");
+    ExitCode::from(1)
+}
+
+pub(super) fn run_echo_jsonl_mode(payload: &str, hang_after_output: bool) -> ExitCode {
+    let events = match parse_echo_jsonl(payload) {
+        Ok(events) => events,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let session_id = echo_session_id(&events).map(str::to_owned);
+    if let Some(session_id) = session_id.as_deref()
+        && !is_valid_session_history_id(session_id)
+    {
+        eprintln!("invalid @ECHO@ session_id: {session_id:?}");
+        return ExitCode::from(1);
+    }
+
+    let mut transcript = JsonlTranscript::default();
+    for (line, _) in events {
+        transcript.emit_raw_line(line);
+    }
+    if let Some(session_id) = session_id.as_deref() {
+        transcript.write_session_history(session_id);
+    }
+    let _ = std::io::stdout().flush();
+    if hang_after_output {
+        hang_until_reaped();
+    }
+    ExitCode::SUCCESS
+}
+
+/// Emit the init + result JSONL pair shared by post-result mock test
+/// prefixes, flush stdout so guest-agent sees them, and write the
+/// session history checkpoint file. Caller decides which post-result
+/// behavior follows (hang / exit / ignore SIGTERM / orphan stdout).
+fn emit_post_result_pair() {
+    let _ = emit_result_pair(false, "Done.");
+}
+
+fn emit_result_pair(is_error: bool, result: &str) -> String {
+    let session_id = generate_session_id();
+    let mut transcript = JsonlTranscript::default();
+    transcript.emit_value(init_event(&session_id, &["Bash"]));
+    transcript.emit_value(result_event(&session_id, is_error, result));
+    transcript.write_session_history(&session_id);
+
+    let _ = std::io::stdout().flush();
+    session_id
+}
+
+fn emit_stuck_tool_events() {
+    let session_id = generate_session_id();
+    let mut transcript = JsonlTranscript::default();
+
+    transcript.emit_value(init_event(&session_id, &["WebFetch"]));
+    transcript.emit_value(tool_use_event(
+        &session_id,
+        "toolu_stuck_001",
+        "WebFetch",
+        json!({"url": "https://example.com/hang"}),
+    ));
+
+    // Flush stdout so guest-agent receives the events before we hang.
+    // When piped, stdout is fully buffered and println! may not flush.
+    let _ = std::io::stdout().flush();
+}
+
+fn ignore_sigterm() {
+    // SAFETY: signal(SIGTERM, SIG_IGN) is async-signal-safe and these mock
+    // scenarios do not share signal handler state after installing it.
+    unsafe {
+        libc::signal(libc::SIGTERM, libc::SIG_IGN);
+    }
+}
+
+fn emit_termination_ready_fence() {
+    if let Ok(home) = std::env::var("HOME") {
+        let _ = std::fs::write(format!("{home}/.vm0-mock-sigterm-ignored"), b"");
+    }
+    emit_stream_event_fence(TERMINATION_READY_EVENT);
+}
+
+fn emit_stream_event_fence(event_type: &str) {
+    println!(
+        "{}",
+        json!({"type": "stream_event", "event": {"type": event_type}})
+    );
+    let _ = std::io::stdout().flush();
+}
+
+fn emit_fence_and_wait_for_release(
+    event_type: &str,
+    release_socket_name: &str,
+) -> Result<(), String> {
+    let home = std::env::var("HOME").map_err(|error| format!("read HOME: {error}"))?;
+    let release_socket = Path::new(&home).join(release_socket_name);
+    let listener = UnixListener::bind(&release_socket)
+        .map_err(|error| format!("bind {}: {error}", release_socket.display()))?;
+    emit_stream_event_fence(event_type);
+    listener
+        .accept()
+        .map_err(|error| format!("accept {}: {error}", release_socket.display()))?;
+    Ok(())
+}
+
+fn hang_until_reaped() {
+    std::thread::sleep(REAPABLE_HANG_DURATION);
+}
+
+fn write_stdout_limit(stdout: &mut impl Write, byte: u8) -> std::io::Result<()> {
+    let chunk = [byte; STDOUT_STREAM_CHUNK_BYTES];
+    for _ in 0..ORDINARY_STDOUT_MAX_LINE_BYTES / STDOUT_STREAM_CHUNK_BYTES {
+        stdout.write_all(&chunk)?;
+    }
+    Ok(())
+}
+
+pub(super) fn run_stdout_over_limit_scenario(output_format: &str, newline: bool) -> ExitCode {
+    if output_format != "stream-json" {
+        return ExitCode::from(1);
+    }
+
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    let _ = write_stdout_limit(&mut stdout, b'x');
+    let suffix: &[u8] = if newline { b"x\n" } else { b"x" };
+    let _ = stdout.write_all(suffix);
+    let _ = stdout.flush();
+    drop(stdout);
+    hang_until_reaped();
+    ExitCode::from(1)
+}
+
+pub(super) fn run_stdout_invalid_utf8_scenario(output_format: &str) -> ExitCode {
+    if output_format != "stream-json" {
+        return ExitCode::from(1);
+    }
+
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    let _ = stdout.write_all(b"do-not-log-invalid-stdout-\xff\n");
+    let _ = stdout.flush();
+    drop(stdout);
+    hang_until_reaped();
+    ExitCode::from(1)
+}
+
+pub(super) fn run_stdout_record_boundaries_scenario(output_format: &str) -> ExitCode {
+    if output_format != "stream-json" {
+        return ExitCode::from(1);
+    }
+
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    let result = stdout
+        .write_all(b"crlf-record\r\n")
+        .and_then(|()| write_stdout_limit(&mut stdout, b'x'))
+        .and_then(|()| stdout.write_all(b"\neof-record"))
+        .and_then(|()| stdout.flush());
+    if let Err(error) = result {
+        eprintln!("write stdout record-boundary fixture: {error}");
+        return ExitCode::from(1);
+    }
+    ExitCode::SUCCESS
+}
+
+pub(super) fn run_stuck_tool_scenario(
+    output_format: &str,
+    deaf: bool,
+    close_stdout: bool,
+) -> ExitCode {
+    if output_format == "stream-json" {
+        if deaf {
+            ignore_sigterm();
+        }
+        emit_stuck_tool_events();
+
+        if deaf {
+            emit_termination_ready_fence();
+        }
+
+        if close_stdout {
+            // SAFETY: this mock process has finished writing all test events
+            // and is about to park forever. Closing fd 1 simulates a CLI that
+            // no longer has stdout open while the process is still alive.
+            unsafe {
+                libc::close(libc::STDOUT_FILENO);
+            }
+        }
+
+        // Hang forever - simulates a stuck WebFetch
+        hang_until_reaped();
+    }
+    ExitCode::from(1)
+}
+
+pub(super) fn run_orphan_pipe_scenario(output_format: &str) -> ExitCode {
+    if output_format == "stream-json" {
+        emit_post_result_pair();
+
+        // Spawn a child after flushing the completed stream. It inherits
+        // stdout and keeps the pipe open after this process exits.
+        let _ = Command::new("sleep")
+            .arg(REAPABLE_HANG_DURATION.as_secs().to_string())
+            .spawn();
+    }
+    ExitCode::SUCCESS
+}
+
+pub(super) fn run_hang_after_result_scenario(output_format: &str, deaf: bool) -> ExitCode {
+    if output_format == "stream-json" {
+        if deaf {
+            // Ignore SIGTERM so only SIGKILL can terminate this process.
+            // Exercises the SigtermPending -> SigkillPending -> Done escalation
+            // branch of the reap FSM.
+            ignore_sigterm();
+        }
+        emit_post_result_pair();
+        if deaf {
+            emit_termination_ready_fence();
+        }
+        // Hang this process forever. guest-agent's post-result reap SIGTERMs
+        // it within POST_RESULT_SIGTERM_GRACE_SECS unless SIGTERM is ignored.
+        hang_until_reaped();
+    }
+    ExitCode::SUCCESS
+}
+
+pub(super) fn run_hang_after_result_then_event_scenario(output_format: &str) -> ExitCode {
+    if output_format == "stream-json" {
+        let session_id = emit_result_pair(false, "Done.");
+        if let Err(error) =
+            emit_fence_and_wait_for_release(POST_RESULT_READY_EVENT, POST_RESULT_RELEASE_ONE_SOCKET)
+        {
+            eprintln!("{error}");
+            return ExitCode::from(1);
+        }
+        let mut transcript = JsonlTranscript::default();
+        transcript.emit_value(assistant_text_event(&session_id, "post-result event"));
+        if let Err(error) = emit_fence_and_wait_for_release(
+            POST_RESULT_ACTIVITY_ONE_EVENT,
+            POST_RESULT_RELEASE_TWO_SOCKET,
+        ) {
+            eprintln!("{error}");
+            return ExitCode::from(1);
+        }
+        emit_stream_event_fence(POST_RESULT_LIVENESS_EVENT);
+        hang_until_reaped();
+    }
+    ExitCode::SUCCESS
+}
+
+pub(super) fn run_hang_after_result_periodic_events_scenario(output_format: &str) -> ExitCode {
+    if output_format == "stream-json" {
+        let session_id = emit_result_pair(false, "Done.");
+        if let Err(error) =
+            emit_fence_and_wait_for_release(POST_RESULT_READY_EVENT, POST_RESULT_RELEASE_ONE_SOCKET)
+        {
+            eprintln!("{error}");
+            return ExitCode::from(1);
+        }
+        let mut transcript = JsonlTranscript::default();
+        transcript.emit_value(assistant_text_event(
+            &session_id,
+            "post-result periodic event 0",
+        ));
+        if let Err(error) = emit_fence_and_wait_for_release(
+            POST_RESULT_ACTIVITY_ONE_EVENT,
+            POST_RESULT_RELEASE_TWO_SOCKET,
+        ) {
+            eprintln!("{error}");
+            return ExitCode::from(1);
+        }
+        transcript.emit_value(assistant_text_event(
+            &session_id,
+            "post-result periodic event 1",
+        ));
+        emit_stream_event_fence(POST_RESULT_ACTIVITY_TWO_EVENT);
+        hang_until_reaped();
+    }
+    ExitCode::SUCCESS
+}
+
+pub(super) fn run_hang_after_error_result_scenario(output_format: &str) -> ExitCode {
+    if output_format == "stream-json" {
+        let _ = emit_result_pair(true, "Mock Claude error.");
+        hang_until_reaped();
+    }
+    ExitCode::SUCCESS
+}
+
+pub(super) fn run_exit_after_result_scenario(output_format: &str) -> ExitCode {
+    if output_format == "stream-json" {
+        emit_post_result_pair();
+        // Exit immediately. Exercises the happy path: guest-agent
+        // either arms post-result reap and observes `child.wait()`
+        // before the deadline, or observes `child.wait()` first and
+        // never arms reap. No signal should be sent.
+    }
+    ExitCode::SUCCESS
+}
+
+pub(super) fn run_write_env_json_scenario(output_format: &str, path: &str) -> ExitCode {
+    if output_format != "stream-json" {
+        return ExitCode::from(1);
+    }
+
+    let env: BTreeMap<String, String> = std::env::vars().collect();
+    if let Some(parent) = Path::new(path).parent()
+        && !parent.as_os_str().is_empty()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        eprintln!("create env json parent: {e}");
+        return ExitCode::from(1);
+    }
+    let payload = match serde_json::to_vec(&env) {
+        Ok(payload) => payload,
+        Err(e) => {
+            eprintln!("serialize env json: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    if let Err(e) = std::fs::write(path, payload) {
+        eprintln!("write env json: {e}");
+        return ExitCode::from(1);
+    }
+
+    emit_post_result_pair();
+    ExitCode::SUCCESS
+}

--- a/crates/guest-mock-claude/src/process/shell_execution.rs
+++ b/crates/guest-mock-claude/src/process/shell_execution.rs
@@ -1,0 +1,320 @@
+use crate::transcript::{
+    JsonlTranscript, assistant_text_event, create_session_history, generate_session_id, init_event,
+    result_event, tool_result_event, tool_use_event,
+};
+use guest_mock_claude::process_group_child::ProcessGroupChild;
+use serde_json::json;
+use std::io::{ErrorKind, Read};
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+use std::process::{Command, ExitCode, Stdio};
+#[cfg(unix)]
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::thread;
+
+const STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES: usize = 1024 * 1024;
+const STREAM_JSON_SHELL_READ_BUFFER_BYTES: usize = 8 * 1024;
+#[cfg(unix)]
+const STREAM_JSON_SHELL_CANCEL_POLL_TIMEOUT_MS: libc::c_int = 100;
+
+pub(super) fn run(prompt: &str, output_format: &str) -> ExitCode {
+    let session_id = generate_session_id();
+
+    if output_format == "stream-json" {
+        run_stream_json_mode(prompt, &session_id)
+    } else {
+        run_text_mode(prompt)
+    }
+}
+
+/// Execute prompt in text mode: inherited stdio, propagate exit code.
+fn run_text_mode(prompt: &str) -> ExitCode {
+    match Command::new("bash")
+        .args(["-c", prompt])
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+    {
+        Ok(status) => ExitCode::from(status.code().unwrap_or(1) as u8),
+        Err(_) => ExitCode::from(1),
+    }
+}
+
+#[derive(Default)]
+struct CapturedShellStream {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+struct CapturedShellOutput {
+    stdout: CapturedShellStream,
+    stderr: CapturedShellStream,
+    exit_code: i32,
+}
+
+impl CapturedShellOutput {
+    fn failed() -> Self {
+        Self {
+            stdout: CapturedShellStream::default(),
+            stderr: CapturedShellStream::default(),
+            exit_code: 1,
+        }
+    }
+}
+
+fn new_captured_shell_stream() -> CapturedShellStream {
+    CapturedShellStream {
+        bytes: Vec::with_capacity(STREAM_JSON_SHELL_READ_BUFFER_BYTES),
+        truncated: false,
+    }
+}
+
+fn retain_captured_shell_bytes(stream: &mut CapturedShellStream, bytes: &[u8]) {
+    let remaining = STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES.saturating_sub(stream.bytes.len());
+    if remaining == 0 {
+        stream.truncated = true;
+        return;
+    }
+
+    let retained = remaining.min(bytes.len());
+    stream.bytes.extend(bytes.iter().take(retained).copied());
+    if retained < bytes.len() {
+        stream.truncated = true;
+    }
+}
+
+#[cfg(not(unix))]
+fn capture_shell_stream(mut reader: impl Read) -> std::io::Result<CapturedShellStream> {
+    let mut stream = new_captured_shell_stream();
+    let mut buffer = [0_u8; STREAM_JSON_SHELL_READ_BUFFER_BYTES];
+
+    loop {
+        let read = match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        };
+
+        let Some(chunk) = buffer.get(..read) else {
+            return Err(std::io::Error::other("shell stream read exceeded buffer"));
+        };
+        retain_captured_shell_bytes(&mut stream, chunk);
+    }
+
+    Ok(stream)
+}
+
+#[cfg(unix)]
+fn capture_shell_stream_until_cancelled<R>(
+    mut reader: R,
+    cancel: Arc<AtomicBool>,
+) -> std::io::Result<CapturedShellStream>
+where
+    R: Read + AsRawFd,
+{
+    let fd = reader.as_raw_fd();
+    let mut stream = new_captured_shell_stream();
+    let mut buffer = [0_u8; STREAM_JSON_SHELL_READ_BUFFER_BYTES];
+
+    loop {
+        // After bash exits, escaped descendants can keep the write end open.
+        // Cancellation switches to a zero-timeout final drain instead of
+        // waiting for EOF from those descendants.
+        let cancelled = cancel.load(Ordering::Acquire);
+        if cancelled && stream.truncated {
+            break;
+        }
+        let timeout_ms = if cancelled {
+            0
+        } else {
+            STREAM_JSON_SHELL_CANCEL_POLL_TIMEOUT_MS
+        };
+        let mut pollfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let poll_result = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
+        if poll_result < 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() == ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error);
+        }
+        if poll_result == 0 {
+            if cancelled {
+                break;
+            }
+            continue;
+        }
+        if pollfd.revents & libc::POLLNVAL != 0 {
+            break;
+        }
+        if pollfd.revents & (libc::POLLIN | libc::POLLHUP) == 0 {
+            if pollfd.revents & libc::POLLERR != 0 || cancelled {
+                break;
+            }
+            continue;
+        }
+
+        let read = match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+            Err(error) if error.kind() == ErrorKind::WouldBlock => continue,
+            Err(error) => return Err(error),
+        };
+        let Some(chunk) = buffer.get(..read) else {
+            return Err(std::io::Error::other("shell stream read exceeded buffer"));
+        };
+        retain_captured_shell_bytes(&mut stream, chunk);
+    }
+
+    Ok(stream)
+}
+
+fn join_captured_shell_stream(
+    handle: thread::JoinHandle<std::io::Result<CapturedShellStream>>,
+) -> std::io::Result<CapturedShellStream> {
+    match handle.join() {
+        Ok(result) => result,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
+fn spawn_captured_shell(prompt: &str) -> std::io::Result<ProcessGroupChild> {
+    let mut command = Command::new("bash");
+    command
+        .args(["-c", prompt])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    ProcessGroupChild::spawn(&mut command)
+}
+
+fn capture_shell_output(prompt: &str) -> CapturedShellOutput {
+    let mut child = match spawn_captured_shell(prompt) {
+        Ok(child) => child,
+        Err(_) => return CapturedShellOutput::failed(),
+    };
+
+    let Some(stdout) = child.take_stdout() else {
+        child.terminate();
+        return CapturedShellOutput::failed();
+    };
+    let Some(stderr) = child.take_stderr() else {
+        child.terminate();
+        return CapturedShellOutput::failed();
+    };
+    #[cfg(unix)]
+    let cancel_streams = Arc::new(AtomicBool::new(false));
+
+    #[cfg(unix)]
+    let stdout_thread = {
+        let cancel = Arc::clone(&cancel_streams);
+        thread::spawn(move || capture_shell_stream_until_cancelled(stdout, cancel))
+    };
+    #[cfg(unix)]
+    let stderr_thread = {
+        let cancel = Arc::clone(&cancel_streams);
+        thread::spawn(move || capture_shell_stream_until_cancelled(stderr, cancel))
+    };
+
+    #[cfg(not(unix))]
+    let stdout_thread = thread::spawn(move || capture_shell_stream(stdout));
+    #[cfg(not(unix))]
+    let stderr_thread = thread::spawn(move || capture_shell_stream(stderr));
+
+    let exit_code = child
+        .wait_with_group_cleanup()
+        .map_or(1, |status| status.code().unwrap_or(1));
+    #[cfg(unix)]
+    cancel_streams.store(true, Ordering::Release);
+
+    let stdout = join_captured_shell_stream(stdout_thread);
+    let stderr = join_captured_shell_stream(stderr_thread);
+    let (Ok(stdout), Ok(stderr)) = (stdout, stderr) else {
+        return CapturedShellOutput::failed();
+    };
+
+    CapturedShellOutput {
+        stdout,
+        stderr,
+        exit_code,
+    }
+}
+
+fn append_truncation_marker(output: &mut String, stream_name: &str) {
+    output.push_str("\n[");
+    output.push_str(stream_name);
+    output.push_str(" truncated after ");
+    output.push_str(&STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES.to_string());
+    output.push_str(" bytes]\n");
+}
+
+fn format_captured_shell_output(captured: &CapturedShellOutput) -> String {
+    let mut output = String::from_utf8_lossy(&captured.stdout.bytes).into_owned();
+    if captured.stdout.truncated {
+        append_truncation_marker(&mut output, "stdout");
+    }
+
+    if captured.exit_code != 0 {
+        output.push_str(&String::from_utf8_lossy(&captured.stderr.bytes));
+        if captured.stderr.truncated {
+            append_truncation_marker(&mut output, "stderr");
+        }
+    }
+
+    output
+}
+
+/// Execute prompt in stream-json mode: output JSONL events, capture output.
+fn run_stream_json_mode(prompt: &str, session_id: &str) -> ExitCode {
+    let session_history_file = create_session_history(session_id);
+    let mut transcript = JsonlTranscript::default();
+
+    // 1. System init event
+    transcript.emit_value(init_event(session_id, &["Bash"]));
+
+    // 2. Assistant text event
+    transcript.emit_value(assistant_text_event(session_id, "Executing command..."));
+
+    // 3. Assistant tool_use event
+    transcript.emit_value(tool_use_event(
+        session_id,
+        "toolu_mock_001",
+        "Bash",
+        json!({"command": prompt}),
+    ));
+
+    // 4. Execute bash and capture bounded output
+    let captured = capture_shell_output(prompt);
+    let output = format_captured_shell_output(&captured);
+    let exit_code = captured.exit_code;
+
+    let is_error = exit_code != 0;
+
+    // 5. User tool_result event
+    transcript.emit_value(tool_result_event(
+        session_id,
+        "toolu_mock_001",
+        &output,
+        is_error,
+    ));
+
+    // 6. Result event
+    transcript.emit_value(result_event(session_id, is_error, &output));
+
+    // Write session history
+    if let Some(path) = session_history_file {
+        transcript.write_session_history_file(&path);
+    }
+
+    ExitCode::from(exit_code as u8)
+}

--- a/crates/guest-mock-claude/src/process/stream_json_input.rs
+++ b/crates/guest-mock-claude/src/process/stream_json_input.rs
@@ -1,0 +1,173 @@
+use crate::transcript::{
+    JsonlTranscript, generate_session_id, init_event, replayed_user_event, result_event,
+};
+use serde_json::Value;
+use std::io::{BufRead, Write};
+use std::process::ExitCode;
+
+const ACTIVE_INPUT_READY_RESULT: &str = "READY_FOR_ACTIVE_INPUT";
+
+#[derive(Debug)]
+pub(super) struct StreamJsonUserFrame {
+    content: String,
+    uuid: Option<String>,
+}
+
+impl StreamJsonUserFrame {
+    pub(super) fn content(&self) -> &str {
+        &self.content
+    }
+}
+
+#[derive(Clone, Copy)]
+enum StreamJsonFrameKind {
+    First,
+    FollowUp { index: usize },
+}
+
+pub(super) fn read_initial_user_frame(
+    reader: &mut impl BufRead,
+) -> Result<Option<StreamJsonUserFrame>, String> {
+    read_next_stream_json_user_frame(reader, StreamJsonFrameKind::First)
+}
+
+pub(super) fn invalid_active_input_count_message(count: &str) -> String {
+    format!(
+        "invalid @active-input-smoke follow-up count ({} bytes)",
+        count.len()
+    )
+}
+
+fn read_next_stream_json_user_frame(
+    reader: &mut impl BufRead,
+    kind: StreamJsonFrameKind,
+) -> Result<Option<StreamJsonUserFrame>, String> {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let bytes = reader
+            .read_line(&mut line)
+            .map_err(|e| format!("read stream-json stdin: {e}"))?;
+        if bytes == 0 {
+            return Ok(None);
+        }
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        return parse_stream_json_user_frame(trimmed, kind).map(Some);
+    }
+}
+
+fn parse_stream_json_user_frame(
+    line: &str,
+    kind: StreamJsonFrameKind,
+) -> Result<StreamJsonUserFrame, String> {
+    let event: Value = serde_json::from_str(line).map_err(|e| match kind {
+        StreamJsonFrameKind::First => format!("parse stream-json stdin: {e}"),
+        StreamJsonFrameKind::FollowUp { index } => {
+            format!("parse stream-json stdin follow-up message {index}: {e}")
+        }
+    })?;
+
+    let description = match kind {
+        StreamJsonFrameKind::First => "first message".to_string(),
+        StreamJsonFrameKind::FollowUp { index } => format!("follow-up message {index}"),
+    };
+
+    if event.get("type").and_then(Value::as_str) != Some("user") {
+        return Err(format!(
+            "stream-json stdin {description} must have type \"user\""
+        ));
+    }
+    if let Some(role) = event.pointer("/message/role").and_then(Value::as_str)
+        && role != "user"
+    {
+        return Err(format!(
+            "stream-json stdin {description} role must be \"user\""
+        ));
+    }
+
+    let content = event
+        .pointer("/message/content")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| {
+            format!("stream-json stdin {description} must contain string message.content")
+        })?;
+    let uuid = event
+        .get("uuid")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+
+    Ok(StreamJsonUserFrame { content, uuid })
+}
+
+pub(super) fn run_active_input_smoke_scenario(
+    output_format: &str,
+    replay_user_messages: bool,
+    initial_frame: StreamJsonUserFrame,
+    stdin: &mut impl BufRead,
+    expected_follow_ups: usize,
+) -> ExitCode {
+    if output_format != "stream-json" {
+        eprintln!("@active-input-smoke requires --output-format stream-json");
+        return ExitCode::from(1);
+    }
+
+    let session_id = generate_session_id();
+    let mut transcript = JsonlTranscript::default();
+
+    transcript.emit_value(init_event(&session_id, &["Bash"]));
+    if replay_user_messages {
+        transcript.emit_value(replayed_user_event(
+            &session_id,
+            initial_frame.uuid.as_deref(),
+            &initial_frame.content,
+        ));
+    }
+    transcript.emit_value(result_event(&session_id, false, ACTIVE_INPUT_READY_RESULT));
+    let _ = std::io::stdout().flush();
+
+    let mut follow_up_contents = Vec::new();
+    for index in 1..=expected_follow_ups {
+        let frame = match read_next_stream_json_user_frame(
+            stdin,
+            StreamJsonFrameKind::FollowUp { index },
+        ) {
+            Ok(Some(frame)) => frame,
+            Ok(None) => {
+                eprintln!(
+                    "active-input stdin closed after {} of {expected_follow_ups} follow-up user messages",
+                    follow_up_contents.len()
+                );
+                return ExitCode::from(1);
+            }
+            Err(message) => {
+                eprintln!("{message}");
+                return ExitCode::from(1);
+            }
+        };
+
+        if replay_user_messages {
+            transcript.emit_value(replayed_user_event(
+                &session_id,
+                frame.uuid.as_deref(),
+                &frame.content,
+            ));
+            let _ = std::io::stdout().flush();
+        }
+        follow_up_contents.push(frame.content);
+    }
+
+    transcript.emit_value(result_event(
+        &session_id,
+        false,
+        &format!("RESULT={}", follow_up_contents.join("+")),
+    ));
+    transcript.write_session_history(&session_id);
+    let _ = std::io::stdout().flush();
+    ExitCode::SUCCESS
+}


### PR DESCRIPTION
## Summary

- keep `process.rs` focused on entry-mode orchestration and scenario dispatch
- move stream input, synthetic fixtures, and shell execution into private child modules
- preserve all mock CLI output, lifecycle, history, and process-group behavior

## Exclusions

- no CLI, protocol, or marker behavior changes
- no public runtime abstraction or test-only exports

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p guest-mock-claude --all-targets --all-features`
- `cd crates && cargo doc -p guest-mock-claude --all-features --no-deps`
- `cd crates && cargo test -p guest-mock-claude --all-targets --all-features`
- `cd crates && cargo test -p guest-agent --all-targets --all-features`

Closes #24529
