### PR TITLE
refactor: claim agentphone launch context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -176,6 +176,13 @@ function lastSend(sends: AgentPhoneSendCapture): AgentPhoneProviderSend {
   return send;
 }
 
+function expectExactSystemPromptSuffix(
+  appendSystemPrompt: string,
+  expectedSuffix: string,
+): void {
+  expect(appendSystemPrompt.slice(-expectedSuffix.length)).toBe(expectedSuffix);
+}
+
 async function waitForTyping(
   sends: AgentPhoneSendCapture,
   expected: readonly string[],
@@ -359,7 +366,8 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
 
     const run1 = await claimDispatchedRun(runnerGroup);
     expect(run1.prompt).toBe("summarize my inbox");
-    expect(run1.appendSystemPrompt).toBe(
+    expectExactSystemPromptSuffix(
+      run1.appendSystemPrompt,
       [
         "# Current Integration",
         "You are currently running inside: AgentPhone",
@@ -518,7 +526,8 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
       agentphoneAgentId: AGENTPHONE_BDD_AGENT_ID,
     });
     const phoneRun1 = await claimDispatchedRun(runnerGroup);
-    expect(phoneRun1.appendSystemPrompt).toBe(
+    expectExactSystemPromptSuffix(
+      phoneRun1.appendSystemPrompt,
       [
         "# Current Integration",
         "You are currently running inside: AgentPhone",
@@ -657,7 +666,10 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     const sharedSession = await waitForRunSessionIdPresent(actor, run1.runId);
     const run2 = await claimDispatchedRun(runnerGroup);
     expect(run2.prompt).toBe("legacy second queued prompt");
-    expect(run2.appendSystemPrompt).toBe("legacy AgentPhone system prompt");
+    expectExactSystemPromptSuffix(
+      run2.appendSystemPrompt,
+      "legacy AgentPhone system prompt",
+    );
     await completeSandboxRun(run2.sandboxToken, run2.runId, 0);
     await waitForRunSessionId(actor, run2.runId, sharedSession);
 
@@ -930,7 +942,8 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     if (!groupThreadContext) {
       throw new Error("Expected AgentPhone group launch thread context");
     }
-    expect(run1.appendSystemPrompt).toBe(
+    expectExactSystemPromptSuffix(
+      run1.appendSystemPrompt,
       [
         "# Current Integration",
         "You are currently running inside: AgentPhone",

--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -12,8 +12,10 @@ import { describe, expect, it } from "vitest";
 import { testContext } from "../../../__tests__/test-context";
 import { server } from "../../../mocks/server";
 import {
+  decryptChatEventInputParamsFixture,
   findAgentphoneChatEventByPromptFixture,
   readChatEventContextFixture,
+  replaceAgentphoneLaunchMaterialWithLegacyParamsFixture,
 } from "../../../test-fixtures/chat-events";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { settle } from "../../utils";
@@ -357,22 +359,19 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
 
     const run1 = await claimDispatchedRun(runnerGroup);
     expect(run1.prompt).toBe("summarize my inbox");
-    expect(run1.appendSystemPrompt).toContain(
-      "# Current Integration\nYou are currently running inside: AgentPhone",
+    expect(run1.appendSystemPrompt).toBe(
+      [
+        "# Current Integration",
+        "You are currently running inside: AgentPhone",
+        `Shared AgentPhone number: ${AGENTPHONE_BDD_PHONE_NUMBER}`,
+        `User phone handle: ${phone}`,
+        `AgentPhone Agent ID: ${AGENTPHONE_BDD_AGENT_ID}`,
+        "Channel: imessage",
+        "Conversation type: dm",
+        `Conversation ID: ${conversationId}`,
+        `Message ID: ${messageId1}`,
+      ].join("\n"),
     );
-    expect(run1.appendSystemPrompt).toContain(
-      `Shared AgentPhone number: ${AGENTPHONE_BDD_PHONE_NUMBER}`,
-    );
-    expect(run1.appendSystemPrompt).toContain(`User phone handle: ${phone}`);
-    expect(run1.appendSystemPrompt).toContain(
-      `AgentPhone Agent ID: ${AGENTPHONE_BDD_AGENT_ID}`,
-    );
-    expect(run1.appendSystemPrompt).toContain("Channel: imessage");
-    expect(run1.appendSystemPrompt).toContain("Conversation type: dm");
-    expect(run1.appendSystemPrompt).toContain(
-      `Conversation ID: ${conversationId}`,
-    );
-    expect(run1.appendSystemPrompt).toContain(`Message ID: ${messageId1}`);
 
     // Agent event dispatch refreshes the iMessage indicator while the run's
     // AgentPhone callback is still pending.
@@ -490,7 +489,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     const chat = createChatFilesBddApi(context);
     const { actor, phone, runnerGroup, sends } = await entitledLinkedActor();
 
-    await ap.postAgentPhoneInboundMessage({
+    const smsMessageId = await ap.postAgentPhoneInboundMessage({
       channel: "sms",
       from: phone,
       body: "start on my phone",
@@ -500,12 +499,14 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     if (!admittedSms) {
       throw new Error("Expected admitted AgentPhone SMS input event");
     }
-    await expect(
-      readChatEventContextFixture(admittedSms.eventId),
-    ).resolves.toMatchObject({
+    const smsLaunchContext = await readChatEventContextFixture(
+      admittedSms.eventId,
+    );
+    expect(smsLaunchContext).toMatchObject({
       contextType: "agentphone",
       agentphoneMessageText: "start on my phone",
       agentphoneThreadContext: "",
+      agentphoneMessageId: smsMessageId,
       agentphoneRootMessageId: "dm",
       agentphoneConversationId: null,
       agentphoneChannel: "sms",
@@ -517,7 +518,24 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
       agentphoneAgentId: AGENTPHONE_BDD_AGENT_ID,
     });
     const phoneRun1 = await claimDispatchedRun(runnerGroup);
+    expect(phoneRun1.appendSystemPrompt).toBe(
+      [
+        "# Current Integration",
+        "You are currently running inside: AgentPhone",
+        `Shared AgentPhone number: ${AGENTPHONE_BDD_PHONE_NUMBER}`,
+        `User phone handle: ${phone}`,
+        `AgentPhone Agent ID: ${AGENTPHONE_BDD_AGENT_ID}`,
+        "Channel: sms",
+        "Conversation type: dm",
+        `Message ID: ${smsMessageId}`,
+      ].join("\n"),
+    );
+    const beforePhoneCompletion = sends.messages.length;
     await completeSandboxRun(phoneRun1.sandboxToken, phoneRun1.runId, 0);
+    await waitForSendCount(sends, beforePhoneCompletion + 1);
+    const smsReply = lastSend(sends);
+    expect(smsReply.toNumber).toBe(phone);
+    expect(smsReply.body).toBe("Task completed successfully.");
     const sharedSession = await waitForRunSessionIdPresent(
       actor,
       phoneRun1.runId,
@@ -605,6 +623,27 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
       from: phone,
       body: "second queued prompt",
     });
+    const secondEvent = await findAgentphoneChatEventByPromptFixture(
+      "second queued prompt",
+    );
+    if (!secondEvent || !actor.orgId) {
+      throw new Error("Expected pending AgentPhone queue item owner");
+    }
+    await expect(
+      decryptChatEventInputParamsFixture(secondEvent.eventId, {
+        orgId: actor.orgId,
+        userId: actor.userId,
+      }),
+    ).resolves.toStrictEqual({ version: 1 });
+    await replaceAgentphoneLaunchMaterialWithLegacyParamsFixture(
+      secondEvent.eventId,
+      {
+        orgId: actor.orgId,
+        userId: actor.userId,
+        prompt: "legacy second queued prompt",
+        appendSystemPrompt: "legacy AgentPhone system prompt",
+      },
+    );
     await ap.postAgentPhoneInboundMessage({
       channel: "sms",
       from: phone,
@@ -617,7 +656,8 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     await completeSandboxRun(run1.sandboxToken, run1.runId, 0);
     const sharedSession = await waitForRunSessionIdPresent(actor, run1.runId);
     const run2 = await claimDispatchedRun(runnerGroup);
-    expect(run2.prompt).toBe("second queued prompt");
+    expect(run2.prompt).toBe("legacy second queued prompt");
+    expect(run2.appendSystemPrompt).toBe("legacy AgentPhone system prompt");
     await completeSandboxRun(run2.sandboxToken, run2.runId, 0);
     await waitForRunSessionId(actor, run2.runId, sharedSession);
 
@@ -867,9 +907,10 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     if (!admittedGroup) {
       throw new Error("Expected admitted AgentPhone group input event");
     }
-    await expect(
-      readChatEventContextFixture(admittedGroup.eventId),
-    ).resolves.toMatchObject({
+    const groupLaunchContext = await readChatEventContextFixture(
+      admittedGroup.eventId,
+    );
+    expect(groupLaunchContext).toMatchObject({
       contextType: "agentphone",
       agentphoneMessageText: "summarize this thread",
       agentphoneThreadContext: expect.stringContaining("Earlier group context"),
@@ -885,8 +926,25 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     });
     const run1 = await claimDispatchedRun(runnerGroup);
     expect(run1.prompt).toBe("summarize this thread");
-    expect(run1.appendSystemPrompt).toContain("Conversation type: group");
-    expect(run1.appendSystemPrompt).toContain("Earlier group context");
+    const groupThreadContext = groupLaunchContext?.agentphoneThreadContext;
+    if (!groupThreadContext) {
+      throw new Error("Expected AgentPhone group launch thread context");
+    }
+    expect(run1.appendSystemPrompt).toBe(
+      [
+        "# Current Integration",
+        "You are currently running inside: AgentPhone",
+        `Shared AgentPhone number: ${AGENTPHONE_BDD_PHONE_NUMBER}`,
+        `User phone handle: ${phone}`,
+        `AgentPhone Agent ID: ${AGENTPHONE_BDD_AGENT_ID}`,
+        "Channel: imessage",
+        "Conversation type: group",
+        `Conversation ID: ${conversationId}`,
+        `Message ID: ${groupMessageId}`,
+        "",
+        groupThreadContext,
+      ].join("\n"),
+    );
 
     // The completion replies into the conversation, not to a number.
     const beforeGroupCompletion = sends.messages.length;

--- a/turbo/apps/api/src/signals/services/agentphone-prompt.ts
+++ b/turbo/apps/api/src/signals/services/agentphone-prompt.ts
@@ -1,0 +1,34 @@
+export function buildAgentPhonePrompt(
+  opts: {
+    readonly sharedNumber: string;
+    readonly phoneHandle: string;
+    readonly conversationId?: string | null;
+    readonly channel?: string | null;
+    readonly isGroup?: boolean;
+    readonly messageId?: string;
+    readonly agentphoneAgentId?: string;
+  },
+  threadContext: string,
+): string {
+  const headerParts = [
+    "# Current Integration\nYou are currently running inside: AgentPhone",
+  ];
+  headerParts.push(`Shared AgentPhone number: ${opts.sharedNumber}`);
+  headerParts.push(`User phone handle: ${opts.phoneHandle}`);
+  if (opts.agentphoneAgentId) {
+    headerParts.push(`AgentPhone Agent ID: ${opts.agentphoneAgentId}`);
+  }
+  if (opts.channel) {
+    headerParts.push(`Channel: ${opts.channel}`);
+  }
+  if (opts.isGroup !== undefined) {
+    headerParts.push(`Conversation type: ${opts.isGroup ? "group" : "dm"}`);
+  }
+  if (opts.conversationId) {
+    headerParts.push(`Conversation ID: ${opts.conversationId}`);
+  }
+  if (opts.messageId) {
+    headerParts.push(`Message ID: ${opts.messageId}`);
+  }
+  return [headerParts.join("\n"), threadContext].filter(Boolean).join("\n\n");
+}

--- a/turbo/apps/api/src/signals/services/agentphone-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/agentphone-queued-launch-context.service.ts
@@ -1,0 +1,167 @@
+import { chatAgentphoneContext } from "@vm0/db/schema/chat-agentphone-context";
+import { chatEvents } from "@vm0/db/schema/chat-event";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { and, eq } from "drizzle-orm";
+
+import { optionalEnv } from "../../lib/env";
+import type { Db } from "../external/db";
+import {
+  agentphoneDeliveryTargetSchema,
+  type AgentPhoneDeliveryTarget,
+} from "./agentphone-chat-callback-payload";
+import { buildAgentPhonePrompt } from "./agentphone-prompt";
+
+export interface AgentPhoneQueuedLaunchMaterial {
+  readonly prompt: string;
+  readonly appendSystemPrompt: string;
+  readonly agentphoneDelivery: AgentPhoneDeliveryTarget;
+  readonly userInfoExtras: {
+    readonly agentphoneHandle: string;
+  };
+}
+
+type AgentPhoneLaunchContextRow = Pick<
+  typeof chatAgentphoneContext.$inferSelect,
+  | "messageText"
+  | "threadContext"
+  | "messageId"
+  | "rootMessageId"
+  | "conversationId"
+  | "channel"
+  | "isGroup"
+  | "phoneHandle"
+  | "fromNumber"
+  | "toNumber"
+  | "userLinkId"
+  | "agentphoneAgentId"
+> & { readonly agentId: string };
+
+function requiredAgentPhoneLaunchContext(
+  row: AgentPhoneLaunchContextRow | undefined,
+) {
+  if (
+    !row ||
+    row.messageText === null ||
+    row.threadContext === null ||
+    row.messageId === null ||
+    row.rootMessageId === null ||
+    row.channel === null ||
+    row.isGroup === null ||
+    row.phoneHandle === null ||
+    row.fromNumber === null ||
+    row.toNumber === null ||
+    row.userLinkId === null ||
+    row.agentphoneAgentId === null
+  ) {
+    return null;
+  }
+  return {
+    ...row,
+    messageText: row.messageText,
+    threadContext: row.threadContext,
+    messageId: row.messageId,
+    rootMessageId: row.rootMessageId,
+    channel: row.channel,
+    isGroup: row.isGroup,
+    phoneHandle: row.phoneHandle,
+    fromNumber: row.fromNumber,
+    toNumber: row.toNumber,
+    userLinkId: row.userLinkId,
+    agentphoneAgentId: row.agentphoneAgentId,
+  };
+}
+
+async function loadAgentPhoneLaunchContext(
+  db: Db,
+  args: {
+    readonly eventId: string;
+    readonly chatThreadId: string;
+    readonly userId: string;
+  },
+) {
+  const [row] = await db
+    .select({
+      messageText: chatAgentphoneContext.messageText,
+      threadContext: chatAgentphoneContext.threadContext,
+      messageId: chatAgentphoneContext.messageId,
+      rootMessageId: chatAgentphoneContext.rootMessageId,
+      conversationId: chatAgentphoneContext.conversationId,
+      channel: chatAgentphoneContext.channel,
+      isGroup: chatAgentphoneContext.isGroup,
+      phoneHandle: chatAgentphoneContext.phoneHandle,
+      fromNumber: chatAgentphoneContext.fromNumber,
+      toNumber: chatAgentphoneContext.toNumber,
+      userLinkId: chatAgentphoneContext.userLinkId,
+      agentphoneAgentId: chatAgentphoneContext.agentphoneAgentId,
+      agentId: chatThreads.agentComposeId,
+    })
+    .from(chatEvents)
+    .innerJoin(
+      chatAgentphoneContext,
+      and(
+        eq(chatAgentphoneContext.id, chatEvents.contextId),
+        eq(chatAgentphoneContext.chatThreadId, chatEvents.chatThreadId),
+      ),
+    )
+    .innerJoin(
+      chatThreads,
+      and(
+        eq(chatThreads.id, chatEvents.chatThreadId),
+        eq(chatThreads.userId, args.userId),
+      ),
+    )
+    .where(
+      and(
+        eq(chatEvents.id, args.eventId),
+        eq(chatEvents.chatThreadId, args.chatThreadId),
+        eq(chatEvents.contextType, "agentphone"),
+        eq(chatEvents.triggerSource, "agentphone"),
+      ),
+    )
+    .limit(1);
+  return requiredAgentPhoneLaunchContext(row);
+}
+
+export async function loadAgentPhoneQueuedLaunchMaterial(
+  db: Db,
+  args: {
+    readonly eventId: string;
+    readonly chatThreadId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+): Promise<AgentPhoneQueuedLaunchMaterial | null> {
+  const context = await loadAgentPhoneLaunchContext(db, args);
+  if (!context) {
+    return null;
+  }
+  return {
+    prompt: context.messageText,
+    appendSystemPrompt: buildAgentPhonePrompt(
+      {
+        sharedNumber: optionalEnv("AGENTPHONE_PHONE_NUMBER") ?? "",
+        phoneHandle: context.phoneHandle,
+        conversationId: context.conversationId,
+        channel: context.channel,
+        isGroup: context.isGroup,
+        messageId: context.messageId,
+        agentphoneAgentId: context.agentphoneAgentId,
+      },
+      context.threadContext,
+    ),
+    agentphoneDelivery: agentphoneDeliveryTargetSchema.parse({
+      messageId: context.messageId,
+      conversationId: context.conversationId,
+      channel: context.channel,
+      isGroup: context.isGroup,
+      rootMessageId: context.rootMessageId,
+      phoneHandle: context.phoneHandle,
+      fromNumber: context.fromNumber,
+      toNumber: context.toNumber,
+      userLinkId: context.userLinkId,
+      agentId: context.agentId,
+      agentphoneAgentId: context.agentphoneAgentId,
+    }),
+    userInfoExtras: { agentphoneHandle: context.phoneHandle },
+  };
+}

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -193,6 +193,10 @@ import {
   type MorningBriefQueuedLaunchMaterial,
 } from "./morning-brief-queued-launch-context.service";
 import { MORNING_BRIEF_SIGNED_URL_TTL_SECONDS } from "./morning-brief-run-prompt";
+import {
+  loadAgentPhoneQueuedLaunchMaterial,
+  type AgentPhoneQueuedLaunchMaterial,
+} from "./agentphone-queued-launch-context.service";
 
 const log = logger("callback:chat");
 const PG_FOREIGN_KEY_VIOLATION = "23503";
@@ -2719,6 +2723,7 @@ type NativeQueuedLaunchMaterial =
   | FeishuQueuedLaunchMaterial
   | TeamsQueuedLaunchMaterial
   | (GitHubQueuedLaunchMaterial & { readonly userInfoExtras?: undefined })
+  | AgentPhoneQueuedLaunchMaterial
   | MorningBriefQueuedLaunchMaterial;
 
 function launchLoader<Material extends NativeQueuedLaunchMaterial>(
@@ -2771,6 +2776,9 @@ async function resolveQueuedLaunchMaterial(
         };
       },
     ),
+    agentphone: launchLoader(loadAgentPhoneQueuedLaunchMaterial, (material) => {
+      return { agentphoneDelivery: material.agentphoneDelivery };
+    }),
   };
   const load = launchLoaders[args.queuedMessage.triggerSource];
   if (!load) {
@@ -2792,6 +2800,14 @@ async function resolveQueuedLaunchMaterial(
     args.queuedMessage.triggerSource === "workflow-schedule" &&
     sourceParams?.prompt !== undefined &&
     sourceParams.appendSystemPrompt !== undefined
+  ) {
+    return null;
+  }
+  if (
+    args.queuedMessage.triggerSource === "agentphone" &&
+    sourceParams?.prompt !== undefined &&
+    sourceParams.appendSystemPrompt !== undefined &&
+    sourceParams.agentphoneDelivery
   ) {
     return null;
   }
@@ -2925,12 +2941,12 @@ function telegramQueuedMessageAdmissionFailure(
 
 function agentPhoneQueuedMessageAdmissionFailure(
   args: CreateQueuedChatRunInputArgs,
-  sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
+  agentphoneDelivery: CreateQueuedChatRunInput["agentphoneDelivery"],
   error: QueuedMessageModelRouteError,
 ): AgentPhoneQueuedMessageAdmissionFailure | null {
   if (
     args.queuedMessage.triggerSource !== "agentphone" ||
-    !sourceParams?.agentphoneDelivery
+    !agentphoneDelivery
   ) {
     return null;
   }
@@ -2941,7 +2957,7 @@ function agentPhoneQueuedMessageAdmissionFailure(
     agentId: args.agent.id,
     threadId: args.threadId,
     queuedMessage: args.queuedMessage,
-    agentphoneDelivery: sourceParams.agentphoneDelivery,
+    agentphoneDelivery,
     error,
   };
 }
@@ -2999,7 +3015,8 @@ function queuedMessageAdmissionFailure(
     agentphone: (resolverArgs) => {
       return agentPhoneQueuedMessageAdmissionFailure(
         resolverArgs.args,
-        resolverArgs.sourceParams,
+        resolverArgs.launchMaterial?.delivery.agentphoneDelivery ??
+          resolverArgs.sourceParams?.agentphoneDelivery,
         resolverArgs.error,
       );
     },
@@ -3034,6 +3051,9 @@ function queuedMessagePrompt(args: {
   }
   if (args.triggerSource === "workflow-schedule") {
     return args.sourceParams?.prompt ?? args.projectedPrompt;
+  }
+  if (args.triggerSource === "agentphone") {
+    return args.sourceParams?.prompt ?? "";
   }
   return args.projectedPrompt;
 }

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -20,7 +20,7 @@ import { chatEvents } from "@vm0/db/schema/chat-event";
 import { and, desc, eq, isNull, notExists, or } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
-import { env, optionalEnv } from "../../lib/env";
+import { env } from "../../lib/env";
 import { inferMimetype } from "../../lib/mimetype";
 import { now } from "../external/time";
 import {
@@ -46,10 +46,6 @@ import {
   type AgentPhoneChannel,
   type AgentPhoneUserLink,
 } from "./agentphone-shared.service";
-import {
-  agentphoneDeliveryTargetSchema,
-  type AgentPhoneDeliveryTarget,
-} from "./agentphone-chat-callback-payload";
 import { ensureAgentPhoneChatThreadRoute } from "./agentphone-chat-ingress.service";
 import { createChatEventSourcePart } from "./chat-event-annotation.service";
 import {
@@ -884,16 +880,10 @@ function buildAgentPhoneContextBlock(
 
 function enrichAgentPhonePrompt(opts: {
   readonly prompt: string;
-  readonly phoneHandle: string;
-  readonly channel: AgentPhoneChannel;
   readonly messageId: string;
   readonly mediaUrl: string | null;
   readonly isGroup: boolean;
-}): {
-  readonly prompt: string;
-  readonly userInfoExtras: { readonly agentphoneHandle: string };
-} {
-  const normalized = normalizeAgentPhoneHandle(opts.phoneHandle, opts.channel);
+}): string {
   const promptText = opts.isGroup
     ? stripZeroMention(opts.prompt)
     : opts.prompt.trim();
@@ -906,47 +896,7 @@ function enrichAgentPhonePrompt(opts: {
       }),
     );
   }
-  return {
-    prompt: parts.filter(Boolean).join("\n\n"),
-    userInfoExtras: { agentphoneHandle: normalized },
-  };
-}
-
-function buildIntegrationPrompt(platform: string): string {
-  return `# Current Integration\nYou are currently running inside: ${platform}`;
-}
-
-function buildAgentPhonePrompt(
-  opts: {
-    readonly sharedNumber: string;
-    readonly phoneHandle: string;
-    readonly conversationId?: string | null;
-    readonly channel?: string | null;
-    readonly isGroup?: boolean;
-    readonly messageId?: string;
-    readonly agentphoneAgentId?: string;
-  },
-  threadContext: string,
-): string {
-  const headerParts = [buildIntegrationPrompt("AgentPhone")];
-  headerParts.push(`Shared AgentPhone number: ${opts.sharedNumber}`);
-  headerParts.push(`User phone handle: ${opts.phoneHandle}`);
-  if (opts.agentphoneAgentId) {
-    headerParts.push(`AgentPhone Agent ID: ${opts.agentphoneAgentId}`);
-  }
-  if (opts.channel) {
-    headerParts.push(`Channel: ${opts.channel}`);
-  }
-  if (opts.isGroup !== undefined) {
-    headerParts.push(`Conversation type: ${opts.isGroup ? "group" : "dm"}`);
-  }
-  if (opts.conversationId) {
-    headerParts.push(`Conversation ID: ${opts.conversationId}`);
-  }
-  if (opts.messageId) {
-    headerParts.push(`Message ID: ${opts.messageId}`);
-  }
-  return [headerParts.join("\n"), threadContext].filter(Boolean).join("\n\n");
+  return parts.filter(Boolean).join("\n\n");
 }
 
 function parseAgentPhoneCommand(text: string): string | undefined {
@@ -1487,27 +1437,6 @@ const handleAgentPhoneCommandIfPresent$ = command(
   },
 );
 
-function agentPhoneDeliveryTarget(args: {
-  readonly event: AgentPhoneMessageEvent;
-  readonly userLink: AgentPhoneUserLink;
-  readonly agent: WorkspaceAgent;
-  readonly rootMessageId: string;
-}): AgentPhoneDeliveryTarget {
-  return agentphoneDeliveryTargetSchema.parse({
-    messageId: args.event.messageId,
-    conversationId: args.event.conversationId,
-    channel: args.event.channel,
-    isGroup: isAgentPhoneGroupEvent(args.event),
-    rootMessageId: args.rootMessageId,
-    phoneHandle: args.event.fromNumber,
-    fromNumber: args.event.fromNumber,
-    toNumber: args.event.toNumber,
-    userLinkId: args.userLink.id,
-    agentId: args.agent.composeId,
-    agentphoneAgentId: args.event.agentphoneAgentId,
-  });
-}
-
 function agentPhoneChatMessageId(args: {
   readonly event: AgentPhoneMessageEvent;
   readonly userLinkId: string;
@@ -1527,7 +1456,6 @@ async function persistAgentPhoneChatMessage(args: {
   readonly rootMessageId: string;
   readonly prompt: string;
   readonly threadContext: string;
-  readonly userInfoExtras: { readonly agentphoneHandle: string };
   readonly apiStartTime: number;
   readonly modelRoute: ModelRoutePin | undefined;
   readonly signal: AbortSignal;
@@ -1553,24 +1481,7 @@ async function persistAgentPhoneChatMessage(args: {
   args.signal.throwIfAborted();
 
   const encryptedParams = await encryptQueuedUserMessageRunParams(
-    {
-      version: 1,
-      prompt: args.prompt,
-      appendSystemPrompt: buildAgentPhonePrompt(
-        {
-          sharedNumber: optionalEnv("AGENTPHONE_PHONE_NUMBER") ?? "",
-          phoneHandle: args.event.fromNumber,
-          conversationId: args.event.conversationId,
-          channel: args.event.channel,
-          isGroup: isAgentPhoneGroupEvent(args.event),
-          messageId: args.event.messageId,
-          agentphoneAgentId: args.event.agentphoneAgentId,
-        },
-        args.threadContext,
-      ),
-      agentphoneDelivery: agentPhoneDeliveryTarget(args),
-      userInfoExtras: args.userInfoExtras,
-    },
+    { version: 1 },
     {
       orgId: args.userLink.orgId,
       userId: args.userLink.vm0UserId,
@@ -1703,7 +1614,6 @@ const runAgentForAgentPhone$ = command(
       readonly rootMessageId: string;
       readonly prompt: string;
       readonly threadContext: string;
-      readonly userInfoExtras: { readonly agentphoneHandle: string };
       readonly apiStartTime: number;
       readonly modelRoute: ModelRoutePin | undefined;
     },
@@ -1829,10 +1739,8 @@ export const handleAgentPhoneMessage$ = command(
     });
     signal.throwIfAborted();
 
-    const { prompt, userInfoExtras } = enrichAgentPhonePrompt({
+    const prompt = enrichAgentPhonePrompt({
       prompt: params.event.body,
-      phoneHandle: params.event.fromNumber,
-      channel: params.event.channel,
       messageId: params.event.messageId,
       mediaUrl: params.event.mediaUrl,
       isGroup,
@@ -1847,7 +1755,6 @@ export const handleAgentPhoneMessage$ = command(
         rootMessageId,
         prompt,
         threadContext: executionContext,
-        userInfoExtras,
         event: params.event,
         apiStartTime: params.apiStartTime,
         modelRoute,

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -36,7 +36,11 @@ import {
 } from "../signals/services/zero-chat-event.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
-import { decryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
+import {
+  decryptQueuedUserMessageRunParams,
+  encryptQueuedUserMessageRunParams,
+} from "../signals/services/zero-chat-queued-event.service";
+import { agentphoneDeliveryTargetSchema } from "../signals/services/agentphone-chat-callback-payload";
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
@@ -610,6 +614,99 @@ export async function decryptChatEventInputParamsFixture(
     return null;
   }
   return await decryptQueuedUserMessageRunParams(row.encryptedParams, ctx);
+}
+
+export async function replaceAgentphoneLaunchMaterialWithLegacyParamsFixture(
+  eventId: string,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly prompt: string;
+    readonly appendSystemPrompt: string;
+  },
+): Promise<void> {
+  const [row] = await db()
+    .select({
+      contextId: chatAgentphoneContext.id,
+      messageId: chatAgentphoneContext.messageId,
+      conversationId: chatAgentphoneContext.conversationId,
+      channel: chatAgentphoneContext.channel,
+      isGroup: chatAgentphoneContext.isGroup,
+      rootMessageId: chatAgentphoneContext.rootMessageId,
+      phoneHandle: chatAgentphoneContext.phoneHandle,
+      fromNumber: chatAgentphoneContext.fromNumber,
+      toNumber: chatAgentphoneContext.toNumber,
+      userLinkId: chatAgentphoneContext.userLinkId,
+      agentId: chatThreads.agentComposeId,
+      agentphoneAgentId: chatAgentphoneContext.agentphoneAgentId,
+    })
+    .from(chatEvents)
+    .innerJoin(
+      chatAgentphoneContext,
+      and(
+        eq(chatAgentphoneContext.id, chatEvents.contextId),
+        eq(chatAgentphoneContext.chatThreadId, chatEvents.chatThreadId),
+      ),
+    )
+    .innerJoin(chatThreads, eq(chatThreads.id, chatEvents.chatThreadId))
+    .where(
+      and(
+        eq(chatEvents.id, eventId),
+        eq(chatEvents.contextType, "agentphone"),
+        eq(chatEvents.triggerSource, "agentphone"),
+        isNull(chatEvents.runId),
+      ),
+    )
+    .limit(1);
+  if (!row) {
+    throw new Error("Expected pending AgentPhone launch context");
+  }
+  const agentphoneDelivery = agentphoneDeliveryTargetSchema.parse({
+    messageId: row.messageId,
+    conversationId: row.conversationId,
+    channel: row.channel,
+    isGroup: row.isGroup,
+    rootMessageId: row.rootMessageId,
+    phoneHandle: row.phoneHandle,
+    fromNumber: row.fromNumber,
+    toNumber: row.toNumber,
+    userLinkId: row.userLinkId,
+    agentId: row.agentId,
+    agentphoneAgentId: row.agentphoneAgentId,
+  });
+  const encryptedParams = await encryptQueuedUserMessageRunParams(
+    {
+      version: 1,
+      prompt: args.prompt,
+      appendSystemPrompt: args.appendSystemPrompt,
+      agentphoneDelivery,
+      userInfoExtras: { agentphoneHandle: agentphoneDelivery.phoneHandle },
+    },
+    { orgId: args.orgId, userId: args.userId },
+  );
+  await db().transaction(async (tx) => {
+    await tx
+      .update(chatAgentphoneContext)
+      .set({
+        messageText: null,
+        threadContext: null,
+        messageId: null,
+        rootMessageId: null,
+        conversationId: null,
+        channel: null,
+        isGroup: null,
+        phoneHandle: null,
+        fromNumber: null,
+        toNumber: null,
+        userLinkId: null,
+        agentphoneAgentId: null,
+      })
+      .where(eq(chatAgentphoneContext.id, row.contextId));
+    await tx
+      .update(chatEventInputParams)
+      .set({ encryptedParams })
+      .where(eq(chatEventInputParams.eventId, eventId));
+  });
 }
 
 export async function clearGitHubTriggerCommentBodyFixture(


### PR DESCRIPTION
## Summary

- load AgentPhone prompt, delivery, and user metadata from explicit `chat_events` and `chat_agentphone_context` projections at claim time
- derive `agentId` from `chat_threads.agent_compose_id` and the shared AgentPhone number from service configuration; the AgentPhone user link has neither value and is not joined
- stop writing AgentPhone launch material into new encrypted queue params while retaining a narrow fallback for already-queued legacy rows
- preserve the current prompt byte-for-byte, including the fetched/stored `thread_context` already used by AgentPhone

## Compatibility and rollout

This is PR 2 of issue #24518, after #24523 and #24520. New queue rows store only `{ version: 1 }`; pre-cutover rows can still claim from their encrypted prompt, system prompt, delivery, and user metadata until the drain gate is zero. PR 3 will remove that fallback and the legacy schema fields.

Historical AgentPhone turns are not backfilled with source parts. Source annotations apply to newly admitted turns only, matching the decision documented in PR #24523.

No changes are made to `cron-monitor-chat-event-queue`.

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- Prettier and targeted Oxlint/ESLint checks for changed files
- no local Vitest or dev server, per issue instructions; integration coverage runs in PR CI

## Acceptance coverage

- exact prompt equality for iMessage 1:1, SMS, and iMessage group ingress
- reply delivery assertions for iMessage 1:1, SMS, and group conversations
- context-first FIFO claim plus legacy encrypted-params fallback
- new queue rows verified to contain only `{ version: 1 }`

Refs #24518