### PR TITLE
refactor: require agentphone launch context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -15,7 +15,6 @@ import {
   decryptChatEventInputParamsFixture,
   findAgentphoneChatEventByPromptFixture,
   readChatEventContextFixture,
-  replaceAgentphoneLaunchMaterialWithLegacyParamsFixture,
 } from "../../../test-fixtures/chat-events";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { settle } from "../../utils";
@@ -644,15 +643,6 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
         userId: actor.userId,
       }),
     ).resolves.toStrictEqual({ version: 1 });
-    await replaceAgentphoneLaunchMaterialWithLegacyParamsFixture(
-      secondEvent.eventId,
-      {
-        orgId: actor.orgId,
-        userId: actor.userId,
-        prompt: "legacy second queued prompt",
-        appendSystemPrompt: "legacy AgentPhone system prompt",
-      },
-    );
     await ap.postAgentPhoneInboundMessage({
       channel: "sms",
       from: phone,
@@ -665,11 +655,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     await completeSandboxRun(run1.sandboxToken, run1.runId, 0);
     const sharedSession = await waitForRunSessionIdPresent(actor, run1.runId);
     const run2 = await claimDispatchedRun(runnerGroup);
-    expect(run2.prompt).toBe("legacy second queued prompt");
-    expectExactSystemPromptSuffix(
-      run2.appendSystemPrompt,
-      "legacy AgentPhone system prompt",
-    );
+    expect(run2.prompt).toBe("second queued prompt");
     await completeSandboxRun(run2.sandboxToken, run2.runId, 0);
     await waitForRunSessionId(actor, run2.runId, sharedSession);
 

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2803,14 +2803,6 @@ async function resolveQueuedLaunchMaterial(
   ) {
     return null;
   }
-  if (
-    args.queuedMessage.triggerSource === "agentphone" &&
-    sourceParams?.prompt !== undefined &&
-    sourceParams.appendSystemPrompt !== undefined &&
-    sourceParams.agentphoneDelivery
-  ) {
-    return null;
-  }
   throw new Error(
     `${args.queuedMessage.triggerSource} queue item is missing launch material`,
   );
@@ -2830,9 +2822,6 @@ function queuedIntegrationDeliveries(
   > = {
     telegram: (params) => {
       return { telegramDelivery: params?.telegramDelivery };
-    },
-    agentphone: (params) => {
-      return { agentphoneDelivery: params?.agentphoneDelivery };
     },
     "workflow-schedule": (params) => {
       return { morningBriefDelivery: params?.morningBriefDelivery };
@@ -3015,8 +3004,7 @@ function queuedMessageAdmissionFailure(
     agentphone: (resolverArgs) => {
       return agentPhoneQueuedMessageAdmissionFailure(
         resolverArgs.args,
-        resolverArgs.launchMaterial?.delivery.agentphoneDelivery ??
-          resolverArgs.sourceParams?.agentphoneDelivery,
+        resolverArgs.launchMaterial?.delivery.agentphoneDelivery,
         resolverArgs.error,
       );
     },
@@ -3051,9 +3039,6 @@ function queuedMessagePrompt(args: {
   }
   if (args.triggerSource === "workflow-schedule") {
     return args.sourceParams?.prompt ?? args.projectedPrompt;
-  }
-  if (args.triggerSource === "agentphone") {
-    return args.sourceParams?.prompt ?? "";
   }
   return args.projectedPrompt;
 }

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -63,7 +63,6 @@ import {
   encryptPersistentSecretsMap,
 } from "./crypto.utils";
 import { noGoalChangeAfterQueueEvent } from "./chat-goal-queue.service";
-import { agentphoneDeliveryTargetSchema } from "./agentphone-chat-callback-payload";
 import { telegramDeliveryTargetSchema } from "./telegram-chat-callback-payload";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { resolveArtifactObject$ } from "./artifact-storage.service";
@@ -88,7 +87,6 @@ const queuedUserMessageRunParamsSchema = z.object({
   prompt: z.string().optional(),
   appendSystemPrompt: z.string().optional(),
   telegramDelivery: telegramDeliveryTargetSchema.optional(),
-  agentphoneDelivery: agentphoneDeliveryTargetSchema.optional(),
   morningBriefDelivery: z
     .object({
       deliveryId: z.string(),
@@ -105,7 +103,6 @@ const queuedUserMessageRunParamsSchema = z.object({
       telegramUsername: z.string().optional(),
       telegramUserId: z.string().optional(),
       telegramLanguage: z.string().optional(),
-      agentphoneHandle: z.string().optional(),
     })
     .optional(),
 });

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -36,11 +36,7 @@ import {
 } from "../signals/services/zero-chat-event.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
-import {
-  decryptQueuedUserMessageRunParams,
-  encryptQueuedUserMessageRunParams,
-} from "../signals/services/zero-chat-queued-event.service";
-import { agentphoneDeliveryTargetSchema } from "../signals/services/agentphone-chat-callback-payload";
+import { decryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
@@ -614,99 +610,6 @@ export async function decryptChatEventInputParamsFixture(
     return null;
   }
   return await decryptQueuedUserMessageRunParams(row.encryptedParams, ctx);
-}
-
-export async function replaceAgentphoneLaunchMaterialWithLegacyParamsFixture(
-  eventId: string,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly prompt: string;
-    readonly appendSystemPrompt: string;
-  },
-): Promise<void> {
-  const [row] = await db()
-    .select({
-      contextId: chatAgentphoneContext.id,
-      messageId: chatAgentphoneContext.messageId,
-      conversationId: chatAgentphoneContext.conversationId,
-      channel: chatAgentphoneContext.channel,
-      isGroup: chatAgentphoneContext.isGroup,
-      rootMessageId: chatAgentphoneContext.rootMessageId,
-      phoneHandle: chatAgentphoneContext.phoneHandle,
-      fromNumber: chatAgentphoneContext.fromNumber,
-      toNumber: chatAgentphoneContext.toNumber,
-      userLinkId: chatAgentphoneContext.userLinkId,
-      agentId: chatThreads.agentComposeId,
-      agentphoneAgentId: chatAgentphoneContext.agentphoneAgentId,
-    })
-    .from(chatEvents)
-    .innerJoin(
-      chatAgentphoneContext,
-      and(
-        eq(chatAgentphoneContext.id, chatEvents.contextId),
-        eq(chatAgentphoneContext.chatThreadId, chatEvents.chatThreadId),
-      ),
-    )
-    .innerJoin(chatThreads, eq(chatThreads.id, chatEvents.chatThreadId))
-    .where(
-      and(
-        eq(chatEvents.id, eventId),
-        eq(chatEvents.contextType, "agentphone"),
-        eq(chatEvents.triggerSource, "agentphone"),
-        isNull(chatEvents.runId),
-      ),
-    )
-    .limit(1);
-  if (!row) {
-    throw new Error("Expected pending AgentPhone launch context");
-  }
-  const agentphoneDelivery = agentphoneDeliveryTargetSchema.parse({
-    messageId: row.messageId,
-    conversationId: row.conversationId,
-    channel: row.channel,
-    isGroup: row.isGroup,
-    rootMessageId: row.rootMessageId,
-    phoneHandle: row.phoneHandle,
-    fromNumber: row.fromNumber,
-    toNumber: row.toNumber,
-    userLinkId: row.userLinkId,
-    agentId: row.agentId,
-    agentphoneAgentId: row.agentphoneAgentId,
-  });
-  const encryptedParams = await encryptQueuedUserMessageRunParams(
-    {
-      version: 1,
-      prompt: args.prompt,
-      appendSystemPrompt: args.appendSystemPrompt,
-      agentphoneDelivery,
-      userInfoExtras: { agentphoneHandle: agentphoneDelivery.phoneHandle },
-    },
-    { orgId: args.orgId, userId: args.userId },
-  );
-  await db().transaction(async (tx) => {
-    await tx
-      .update(chatAgentphoneContext)
-      .set({
-        messageText: null,
-        threadContext: null,
-        messageId: null,
-        rootMessageId: null,
-        conversationId: null,
-        channel: null,
-        isGroup: null,
-        phoneHandle: null,
-        fromNumber: null,
-        toNumber: null,
-        userLinkId: null,
-        agentphoneAgentId: null,
-      })
-      .where(eq(chatAgentphoneContext.id, row.contextId));
-    await tx
-      .update(chatEventInputParams)
-      .set({ encryptedParams })
-      .where(eq(chatEventInputParams.eventId, eventId));
-  });
 }
 
 export async function clearGitHubTriggerCommentBodyFixture(


### PR DESCRIPTION
## Summary

- complete step 8 of #24362 and PR 3 of 3 for #24518
- require pending AgentPhone turns to load prompt, delivery, and user info from `chat_events` plus `chat_agentphone_context`
- remove the AgentPhone launch fields from the encrypted queue params schema and delete the legacy fallback fixture
- keep new queue params at `{ "version": 1 }`

PR 1: #24523  
PR 2: #24535

## Rollout gate

- PR #24535 API deployment succeeded in [Turbo run 30735259017, deploy-api job 91462885105](https://github.com/vm0-ai/vm0/actions/runs/30735259017/job/91462885105) at 2026-08-02T06:07:48Z
- after that deployment, a read-only MaskDB aggregate found `0` pending AgentPhone `input.prompt` events with `run_id IS NULL`
- with no original pending event left to reconcile, the AgentPhone fallback drain identity is `0 = 0`

## Compatibility and source history

- this removes only the AgentPhone fallback after the measured drain; workflow-schedule and Telegram compatibility paths remain unchanged
- source parts are created for new AgentPhone turns only; historical turns are not backfilled because there is no per-message deep link and no migration requirement
- `cron-monitor-chat-event-queue` is unchanged

## Validation

- `pnpm exec prettier --write` on changed files
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- full integration coverage is delegated to PR CI as requested

Closes #24518