### PR TITLE
refactor(api): cut over runner affinity to canonical sandbox state

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -244,7 +244,6 @@ function runnerHeartbeatBody(
     readonly allocatedMemoryMb?: RunnerHeartbeatBody["allocatedMemoryMb"];
     readonly runningCount?: RunnerHeartbeatBody["runningCount"];
     readonly heldSandboxStates?: RunnerHeartbeatBody["heldSandboxStates"];
-    readonly heldSessionStates?: RunnerHeartbeatBody["heldSessionStates"];
     readonly heldWorkspaceStates?: RunnerHeartbeatBody["heldWorkspaceStates"];
     readonly mode?: RunnerHeartbeatBody["mode"];
   } = {},
@@ -262,10 +261,7 @@ function runnerHeartbeatBody(
     allocatedMemoryMb: args.allocatedMemoryMb ?? 0,
     runningCount: args.runningCount ?? 0,
     admittableProfiles: args.admittableProfiles ?? ["vm0/default"],
-    ...(args.heldSandboxStates === undefined
-      ? {}
-      : { heldSandboxStates: args.heldSandboxStates }),
-    heldSessionStates: args.heldSessionStates ?? [],
+    heldSandboxStates: args.heldSandboxStates ?? [],
     heldWorkspaceStates: args.heldWorkspaceStates ?? [],
     mode: args.mode ?? "running",
   };
@@ -1094,7 +1090,6 @@ export function createRunsApi(context: TestContext) {
         readonly allocatedMemoryMb?: RunnerHeartbeatBody["allocatedMemoryMb"];
         readonly runningCount?: RunnerHeartbeatBody["runningCount"];
         readonly heldSandboxStates?: RunnerHeartbeatBody["heldSandboxStates"];
-        readonly heldSessionStates?: RunnerHeartbeatBody["heldSessionStates"];
         readonly heldWorkspaceStates?: RunnerHeartbeatBody["heldWorkspaceStates"];
         readonly mode?: RunnerHeartbeatBody["mode"];
       } = {},

--- a/turbo/apps/api/src/signals/routes/__tests__/run-cron.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-cron.bdd.test.ts
@@ -174,12 +174,11 @@ describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", (
     expect(missingContext.body.error.code).toBe("NOT_FOUND");
   });
 
-  it("keeps official runner held-session heartbeat and empty polling visible through public endpoints", async () => {
+  it("keeps official runner held-sandbox heartbeat and empty polling visible through public endpoints", async () => {
     const api = createRunsApi(context);
     const runnerGroup = api.configureRunnerGroup();
-    const heldSessionStates = [
+    const heldSandboxStates = [
       {
-        sessionId: "session-bdd-held",
         reuseKey: "thread:cron-bdd-held",
         lastCompletedAt: new Date(now()).toISOString(),
         reusableSandbox: { profile: "vm0/default" },
@@ -187,7 +186,7 @@ describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", (
     ];
 
     const heartbeat = await api.requestHeartbeatRunner(true, [200], {
-      heldSessionStates,
+      heldSandboxStates,
     });
     if (heartbeat.status !== 200) {
       throw new Error(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3335,7 +3335,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       runnerId: randomUUID(),
       group: runnerGroup,
       admittableProfiles: [],
-      heldSessionStates: [],
     });
 
     const resumed = await api.createRun(actor, {
@@ -3460,7 +3459,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
               },
             ]
           : [],
-        heldSessionStates: [],
         heldWorkspaceStates: args.workspaceCaches
           ? [
               {
@@ -3529,7 +3527,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         allocatedVcpu: 0,
         allocatedMemoryMb: 0,
         runningCount: 0,
-        heldSessionStates: [],
         heldWorkspaceStates: [],
         mode: "running",
         ...extra,
@@ -3539,15 +3536,23 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const missingProfileListHeartbeat = await api.requestRawHeartbeatRunner(
       true,
       [400],
-      rawHeartbeatBody({}),
+      rawHeartbeatBody({ heldSandboxStates: [] }),
     );
     expectApiError(missingProfileListHeartbeat.body);
+
+    const missingSandboxStatesHeartbeat = await api.requestRawHeartbeatRunner(
+      true,
+      [400],
+      rawHeartbeatBody({ admittableProfiles: ["vm0/default"] }),
+    );
+    expectApiError(missingSandboxStatesHeartbeat.body);
 
     const canonicalHeartbeat = await api.requestRawHeartbeatRunner(
       true,
       [200],
       rawHeartbeatBody({
         admittableProfiles: ["vm0/default"],
+        heldSandboxStates: [],
       }),
     );
     expect(canonicalHeartbeat.body).toStrictEqual({
@@ -3559,6 +3564,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         [400],
         rawHeartbeatBody({
           admittableProfiles: ["vm0/default"],
+          heldSandboxStates: [],
           heldWorkspaceStates: [
             {
               reuseKey,
@@ -3588,27 +3594,32 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       sessionAffinityResource(canonicalHeartbeatHolder.job),
     ).toBeUndefined();
 
-    await api.requestHeartbeatRunner(true, [200], {
-      runnerId: affinityRunnerId,
-      group: runnerGroup,
-      snapshotGeneration: 1,
-      snapshotSequence: nextAffinitySnapshotSequence(),
-      admittableProfiles: [],
-      heldSandboxStates: [],
-      heldSessionStates: [
-        {
-          sessionId: cliAgentSessionId,
-          reuseKey,
-          lastCompletedAt: nowDate().toISOString(),
-          reusableSandbox: { profile: "vm0/default" },
-        },
-      ],
-    });
-    const currentEmptyWins = await pollFollowUp(
-      "ignore legacy state when current state is explicitly empty",
+    const dualFieldHeartbeat = await api.requestRawHeartbeatRunner(
+      true,
+      [200],
+      rawHeartbeatBody({
+        admittableProfiles: [],
+        heldSandboxStates: [],
+        heldSessionStates: [
+          {
+            sessionId: cliAgentSessionId,
+            reuseKey,
+            lastCompletedAt: nowDate().toISOString(),
+            reusableSandbox: { profile: "vm0/default" },
+          },
+        ],
+      }),
     );
-    expect(sessionAffinityProtectedUntil(currentEmptyWins.job)).toBeNull();
-    expect(sessionAffinityResource(currentEmptyWins.job)).toBeUndefined();
+    expect(dualFieldHeartbeat.body).toStrictEqual({ ok: true });
+    const ignoredLegacyProjection = await pollFollowUp(
+      "ignore the deployed runner's extra legacy projection",
+    );
+    expect(
+      sessionAffinityProtectedUntil(ignoredLegacyProjection.job),
+    ).toBeNull();
+    expect(
+      sessionAffinityResource(ignoredLegacyProjection.job),
+    ).toBeUndefined();
 
     await api.requestHeartbeatRunner(true, [200], {
       runnerId: affinityRunnerId,
@@ -3616,7 +3627,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       snapshotGeneration: 1,
       snapshotSequence: nextAffinitySnapshotSequence(),
       admittableProfiles: ["vm0/default"],
-      heldSessionStates: [],
       heldWorkspaceStates: [
         {
           reuseKey,
@@ -3658,9 +3668,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       snapshotGeneration: 1,
       snapshotSequence: 1,
       admittableProfiles: [],
-      heldSessionStates: [
+      heldSandboxStates: [
         {
-          sessionId: cliAgentSessionId,
           reuseKey,
           lastCompletedAt: nowDate().toISOString(),
           reusableSandbox: { profile: "vm0/default" },
@@ -3686,7 +3695,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       snapshotGeneration: 1,
       snapshotSequence: 2,
       admittableProfiles: [],
-      heldSessionStates: [],
       mode: "stopping",
     });
 
@@ -4093,11 +4101,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         snapshotGeneration: args.generation,
         snapshotSequence: args.sequence,
         admittableProfiles: ["vm0/default"],
-        heldSessionStates:
+        heldSandboxStates:
           args.resource === "reusableSandbox"
             ? [
                 {
-                  sessionId: cliAgentSessionId,
                   reuseKey,
                   lastCompletedAt,
                   reusableSandbox: { profile: "vm0/default" },
@@ -4235,9 +4242,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       runnerId: affinityRunnerId,
       group: runnerGroup,
       admittableProfiles: [],
-      heldSessionStates: [
+      heldSandboxStates: [
         {
-          sessionId: cliAgentSessionId,
           reuseKey,
           lastCompletedAt: nowDate().toISOString(),
           reusableSandbox: {
@@ -4311,9 +4317,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       runnerId: affinityRunnerId,
       group: runnerGroup,
       admittableProfiles: [],
-      heldSessionStates: [
+      heldSandboxStates: [
         {
-          sessionId: cliAgentSessionId,
           reuseKey,
           lastCompletedAt: nowDate().toISOString(),
           reusableSandbox: { profile: "vm0/default" },
@@ -4397,7 +4402,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       runnerId: workspaceRunnerId,
       group: runnerGroup,
       admittableProfiles: ["vm0/default"],
-      heldSessionStates: [],
       heldWorkspaceStates: [
         {
           reuseKey,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -1272,9 +1272,8 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       runnerId,
       group: runnerGroup,
       admittableProfiles: [],
-      heldSessionStates: [
+      heldSandboxStates: [
         {
-          sessionId: "diagnostic-session-does-not-match",
           reuseKey,
           lastCompletedAt: nowDate().toISOString(),
           reusableSandbox: { profile: "vm0/default" },

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -439,10 +439,8 @@ const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return badRequestMessage("Invalid runner group");
   }
 
-  // Old runners omit the exact field. #24489 removes this fallback after the
-  // #24486 runner rollout and rollback window complete.
   const heldSandboxStates = canonicalizeHeldSandboxStates(
-    body.data.heldSandboxStates ?? body.data.heldSessionStates,
+    body.data.heldSandboxStates,
   );
   const heldWorkspaceStates = canonicalizeHeldWorkspaceStates(
     body.data.heldWorkspaceStates,
@@ -469,7 +467,7 @@ const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       allocatedMemoryMb: body.data.allocatedMemoryMb,
       runningCount: body.data.runningCount,
       admittableProfiles,
-      heldSessionStates: heldSandboxStates,
+      heldSandboxStates,
       heldWorkspaceStates,
       mode: body.data.mode,
       lastSeenAt: currentDate,
@@ -488,7 +486,7 @@ const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         allocatedMemoryMb: body.data.allocatedMemoryMb,
         runningCount: body.data.runningCount,
         admittableProfiles,
-        heldSessionStates: heldSandboxStates,
+        heldSandboxStates,
         heldWorkspaceStates,
         mode: body.data.mode,
         lastSeenAt: currentDate,

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -41,13 +41,13 @@ function reusableSandboxCondition(args: {
         'historyGenerationRunId', cast(${args.historyGenerationRunId} as text)
       )`
       : sql`jsonb_build_object('profile', cast(${args.profile} as text))`;
-  const heldSessionStates = sql`jsonb_build_array(
+  const heldSandboxStates = sql`jsonb_build_array(
     jsonb_build_object(
       'reuseKey', cast(${args.reuseKey} as text),
       'reusableSandbox', ${reusableSandbox}
     )
   )`;
-  return arrayContains(runnerState.heldSessionStates, heldSessionStates);
+  return arrayContains(runnerState.heldSandboxStates, heldSandboxStates);
 }
 
 function capableWorkspaceCondition(args: {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -10,7 +10,6 @@ import {
   executionContextSchema,
   heartbeatBodySchema,
   heldSandboxStateSchema,
-  heldSessionStateSchema,
   heldWorkspaceStateSchema,
   jobSchema,
   NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX,
@@ -477,22 +476,6 @@ describe("runner resume session contract", () => {
     );
     expect(job.sessionAffinityResource).toBe("reusableSandbox");
 
-    const heldSessionState = heldSessionStateSchema.parse({
-      sessionId: "sess-123",
-      reuseKey: "thread:22222222-2222-4222-8222-222222222223",
-      lastCompletedAt: "2026-07-15T00:00:00.000Z",
-      reusableSandbox: {
-        profile: "vm0/default",
-        historyGenerationRunId,
-      },
-    });
-    expect(heldSessionState.reusableSandbox.historyGenerationRunId).toBe(
-      historyGenerationRunId,
-    );
-    expect(heldSessionState.reuseKey).toBe(
-      "thread:22222222-2222-4222-8222-222222222223",
-    );
-
     const heldSandboxState = heldSandboxStateSchema.parse({
       reuseKey: "thread:22222222-2222-4222-8222-222222222223",
       lastCompletedAt: "2026-07-15T00:00:00.000Z",
@@ -548,7 +531,7 @@ describe("runner resume session contract", () => {
       allocatedMemoryMb: 0,
       runningCount: 0,
       admittableProfiles: ["vm0/default"],
-      heldSessionStates: [],
+      heldSandboxStates: [],
       heldWorkspaceStates: [],
       mode: "running",
     } as const;
@@ -598,6 +581,56 @@ describe("runner resume session contract", () => {
     ).toBe(false);
   });
 
+  it("requires canonical heartbeat state and strips the legacy projection", () => {
+    const heartbeat = {
+      runnerId: "33333333-3333-4333-8333-333333333333",
+      runnerName: "runner-contract-test",
+      group: "vm0/test",
+      snapshotGeneration: 1,
+      snapshotSequence: 1,
+      totalVcpu: 8,
+      totalMemoryMb: 16_384,
+      maxConcurrent: 4,
+      allocatedVcpu: 0,
+      allocatedMemoryMb: 0,
+      runningCount: 0,
+      admittableProfiles: ["vm0/default"],
+      heldSandboxStates: [],
+      heldWorkspaceStates: [],
+      mode: "running",
+    } as const;
+
+    expect(
+      heartbeatBodySchema.safeParse({
+        ...heartbeat,
+        heldSandboxStates: undefined,
+        heldSessionStates: [],
+      }).success,
+    ).toBe(false);
+
+    const parsed = heartbeatBodySchema.parse({
+      ...heartbeat,
+      heldSandboxStates: [
+        {
+          reuseKey: "thread:canonical",
+          lastCompletedAt: "2026-07-15T00:00:00.000Z",
+          reusableSandbox: { profile: "vm0/default" },
+        },
+      ],
+      heldSessionStates: [
+        {
+          sessionId: "legacy-session",
+          reuseKey: "thread:legacy",
+          lastCompletedAt: "2026-07-15T00:00:00.000Z",
+          reusableSandbox: { profile: "vm0/default" },
+        },
+      ],
+    });
+    expect(parsed.heldSandboxStates).toHaveLength(1);
+    expect(parsed.heldSandboxStates[0]?.reuseKey).toBe("thread:canonical");
+    expect(parsed).not.toHaveProperty("heldSessionStates");
+  });
+
   it("bounds profile-qualified workspace cache heartbeat state", () => {
     const heartbeat = {
       runnerId: "33333333-3333-4333-8333-333333333333",
@@ -612,7 +645,7 @@ describe("runner resume session contract", () => {
       allocatedMemoryMb: 0,
       runningCount: 0,
       admittableProfiles: ["vm0/default"],
-      heldSessionStates: [],
+      heldSandboxStates: [],
       heldWorkspaceStates: [],
       mode: "running",
     } as const;

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -297,10 +297,6 @@ export const heldSandboxStateSchema = z.object({
   }),
 });
 
-export const heldSessionStateSchema = heldSandboxStateSchema.extend({
-  sessionId: z.string(),
-});
-
 export const heldWorkspaceStateSchema = z.object({
   reuseKey: z.string(),
   lastCompletedAt: z.string().datetime({ offset: true }),
@@ -785,8 +781,7 @@ export const heartbeatBodySchema = z
     allocatedMemoryMb: z.number().int().nonnegative(),
     runningCount: z.number().int().nonnegative(),
     admittableProfiles: runnerProfileListSchema,
-    heldSandboxStates: z.array(heldSandboxStateSchema).max(1024).optional(),
-    heldSessionStates: z.array(heldSessionStateSchema).max(1024),
+    heldSandboxStates: z.array(heldSandboxStateSchema).max(1024),
     heldWorkspaceStates: z.array(heldWorkspaceStateSchema).max(1024),
     mode: z.enum(["starting", "running", "draining", "stopping"]),
   })
@@ -837,7 +832,6 @@ export type RunnersBuiltinFirewallsResolveContract =
   typeof runnersBuiltinFirewallsResolveContract;
 export type Job = z.infer<typeof jobSchema>;
 export type HeldSandboxState = z.infer<typeof heldSandboxStateSchema>;
-export type HeldSessionState = z.infer<typeof heldSessionStateSchema>;
 export type HeldWorkspaceState = z.infer<typeof heldWorkspaceStateSchema>;
 export type ExecutionContext = z.infer<typeof executionContextSchema>;
 export type StoredExecutionContext = z.infer<

--- a/turbo/packages/db/scripts/compare-schemas-normalized.ts
+++ b/turbo/packages/db/scripts/compare-schemas-normalized.ts
@@ -32,13 +32,6 @@ interface ConstraintInfo {
   constraint_def: string;
 }
 
-// Migration 0800 physically owns this column while the runtime schema remains
-// legacy-only for deploy-before-migrate safety. #24510 removes this allowance
-// when it declares both Drizzle properties.
-const TRANSITIONAL_RUNNER_SANDBOX_STATE_COLUMNS = new Set([
-  "runner_state.held_sandbox_states",
-]);
-
 // Get database URLs from command line args
 const db1Url = process.argv[2];
 const db2Url = process.argv[3];
@@ -67,11 +60,7 @@ async function getTableColumns(client: Client): Promise<TableColumn[]> {
       AND t.table_type = 'BASE TABLE'
     ORDER BY c.table_name, c.column_name
   `);
-  return result.rows.filter((column) => {
-    return !TRANSITIONAL_RUNNER_SANDBOX_STATE_COLUMNS.has(
-      `${column.table_name}.${column.column_name}`,
-    );
-  });
+  return result.rows;
 }
 
 async function getIndexes(client: Client): Promise<IndexInfo[]> {

--- a/turbo/packages/db/scripts/test-migration-consistency-schema.ts
+++ b/turbo/packages/db/scripts/test-migration-consistency-schema.ts
@@ -15989,16 +15989,99 @@ async function validateRunnerSandboxStateExpansion(): Promise<void> {
     await client.connect();
     try {
       const database = drizzle(client);
+      function heartbeatLastSeenAt(sequence: number): Date {
+        return new Date(Date.UTC(2026, 7, 2, 0, 0, sequence));
+      }
+
       async function writeLegacyHeartbeat(args: {
         readonly generation: number;
         readonly runnerId: string;
         readonly sequence: number;
         readonly states: RunnerHeldSandboxStates;
       }): Promise<void> {
-        const lastSeenAt = new Date(
-          `2026-08-02T00:${String(args.sequence).padStart(2, "0")}:00.000Z`,
+        const lastSeenAt = heartbeatLastSeenAt(args.sequence);
+        await client.query(
+          `
+            INSERT INTO "runner_state" (
+              "runner_id",
+              "runner_name",
+              "runner_group",
+              "heartbeat_generation",
+              "heartbeat_sequence",
+              "total_vcpu",
+              "total_memory_mb",
+              "max_concurrent",
+              "allocated_vcpu",
+              "allocated_memory_mb",
+              "running_count",
+              "admittable_profiles",
+              "held_session_states",
+              "held_workspace_states",
+              "mode",
+              "last_seen_at"
+            )
+            VALUES (
+              $1,
+              'migration-runner',
+              'default',
+              $2,
+              $3,
+              8,
+              16384,
+              4,
+              2,
+              4096,
+              1,
+              '["standard", "browser"]'::jsonb,
+              $4::jsonb,
+              '[]'::jsonb,
+              'running',
+              $5
+            )
+            ON CONFLICT ("runner_id") DO UPDATE SET
+              "runner_name" = EXCLUDED."runner_name",
+              "runner_group" = EXCLUDED."runner_group",
+              "heartbeat_generation" = EXCLUDED."heartbeat_generation",
+              "heartbeat_sequence" = EXCLUDED."heartbeat_sequence",
+              "total_vcpu" = EXCLUDED."total_vcpu",
+              "total_memory_mb" = EXCLUDED."total_memory_mb",
+              "max_concurrent" = EXCLUDED."max_concurrent",
+              "allocated_vcpu" = EXCLUDED."allocated_vcpu",
+              "allocated_memory_mb" = EXCLUDED."allocated_memory_mb",
+              "running_count" = EXCLUDED."running_count",
+              "admittable_profiles" = EXCLUDED."admittable_profiles",
+              "held_session_states" = EXCLUDED."held_session_states",
+              "held_workspace_states" = EXCLUDED."held_workspace_states",
+              "mode" = EXCLUDED."mode",
+              "last_seen_at" = EXCLUDED."last_seen_at"
+            WHERE
+              "runner_state"."heartbeat_generation"
+                < EXCLUDED."heartbeat_generation"
+              OR (
+                "runner_state"."heartbeat_generation"
+                  = EXCLUDED."heartbeat_generation"
+                AND "runner_state"."heartbeat_sequence"
+                  < EXCLUDED."heartbeat_sequence"
+              )
+          `,
+          [
+            args.runnerId,
+            args.generation,
+            args.sequence,
+            JSON.stringify(args.states),
+            lastSeenAt,
+          ],
         );
-        await database
+      }
+
+      async function writeCanonicalHeartbeat(args: {
+        readonly generation: number;
+        readonly runnerId: string;
+        readonly sequence: number;
+        readonly states: RunnerHeldSandboxStates;
+      }): Promise<void> {
+        const lastSeenAt = heartbeatLastSeenAt(args.sequence);
+        const query = database
           .insert(runnerState)
           .values({
             runnerId: args.runnerId,
@@ -16013,7 +16096,7 @@ async function validateRunnerSandboxStateExpansion(): Promise<void> {
             allocatedMemoryMb: 4096,
             runningCount: 1,
             admittableProfiles: ["standard", "browser"],
-            heldSessionStates: args.states,
+            heldSandboxStates: args.states,
             heldWorkspaceStates: [],
             mode: "running",
             lastSeenAt,
@@ -16032,7 +16115,7 @@ async function validateRunnerSandboxStateExpansion(): Promise<void> {
               allocatedMemoryMb: 4096,
               runningCount: 1,
               admittableProfiles: ["standard", "browser"],
-              heldSessionStates: args.states,
+              heldSandboxStates: args.states,
               heldWorkspaceStates: [],
               mode: "running",
               lastSeenAt,
@@ -16045,6 +16128,19 @@ async function validateRunnerSandboxStateExpansion(): Promise<void> {
               ),
             ),
           });
+
+        const [insertSql, conflictSql] = query
+          .toSQL()
+          .sql.split(" on conflict ");
+        assert.ok(insertSql);
+        assert.ok(conflictSql);
+        assert.match(
+          insertSql,
+          /"held_sandbox_states", "held_session_states", "held_workspace_states"/u,
+        );
+        assert.match(insertSql, /values \([^)]*\$\d+, default, \$\d+,/u);
+        assert.doesNotMatch(conflictSql, /held_session_states/u);
+        await query;
       }
 
       async function readRunnerState(runnerId: string): Promise<{
@@ -16219,21 +16315,12 @@ async function validateRunnerSandboxStateExpansion(): Promise<void> {
         sequence: "2",
       });
 
-      await client.query(
-        `
-          INSERT INTO "runner_state" (
-            "runner_id",
-            "runner_name",
-            "runner_group",
-            "heartbeat_generation",
-            "heartbeat_sequence",
-            "held_sandbox_states",
-            "last_seen_at"
-          )
-          VALUES ($1, 'next-api-runner', 'default', 1, 1, $2::jsonb, NOW())
-        `,
-        [runnerIds.next, JSON.stringify(states.canonicalInitial)],
-      );
+      await writeCanonicalHeartbeat({
+        generation: 1,
+        runnerId: runnerIds.next,
+        sequence: 1,
+        states: states.canonicalInitial,
+      });
       assert.deepEqual(await readRunnerState(runnerIds.next), {
         canonical: states.canonicalInitial,
         generation: "1",
@@ -16241,50 +16328,24 @@ async function validateRunnerSandboxStateExpansion(): Promise<void> {
         sequence: "1",
       });
 
-      const canonicalHeartbeatUpsert = `
-        INSERT INTO "runner_state" (
-          "runner_id",
-          "runner_name",
-          "runner_group",
-          "heartbeat_generation",
-          "heartbeat_sequence",
-          "held_sandbox_states",
-          "last_seen_at"
-        )
-        VALUES ($1, 'next-api-runner', 'default', $2, $3, $4::jsonb, NOW())
-        ON CONFLICT ("runner_id") DO UPDATE SET
-          "heartbeat_generation" = EXCLUDED."heartbeat_generation",
-          "heartbeat_sequence" = EXCLUDED."heartbeat_sequence",
-          "held_sandbox_states" = EXCLUDED."held_sandbox_states",
-          "last_seen_at" = EXCLUDED."last_seen_at"
-        WHERE
-          "runner_state"."heartbeat_generation"
-            < EXCLUDED."heartbeat_generation"
-          OR (
-            "runner_state"."heartbeat_generation"
-              = EXCLUDED."heartbeat_generation"
-            AND "runner_state"."heartbeat_sequence"
-              < EXCLUDED."heartbeat_sequence"
-          )
-      `;
-      await client.query(canonicalHeartbeatUpsert, [
-        runnerIds.next,
-        2,
-        1,
-        JSON.stringify(states.canonicalUpdate),
-      ]);
+      await writeCanonicalHeartbeat({
+        generation: 2,
+        runnerId: runnerIds.next,
+        sequence: 1,
+        states: states.canonicalUpdate,
+      });
       assert.deepEqual(await readRunnerState(runnerIds.next), {
         canonical: states.canonicalUpdate,
         generation: "2",
         legacy: states.canonicalUpdate,
         sequence: "1",
       });
-      await client.query(canonicalHeartbeatUpsert, [
-        runnerIds.next,
-        1,
-        99,
-        JSON.stringify(states.stale),
-      ]);
+      await writeCanonicalHeartbeat({
+        generation: 1,
+        runnerId: runnerIds.next,
+        sequence: 99,
+        states: states.stale,
+      });
       assert.deepEqual(await readRunnerState(runnerIds.next), {
         canonical: states.canonicalUpdate,
         generation: "2",

--- a/turbo/packages/db/src/schema/runner-state.ts
+++ b/turbo/packages/db/src/schema/runner-state.ts
@@ -42,8 +42,12 @@ export const runnerState = pgTable(
       .$type<RunnerAdmittableProfiles>()
       .default([])
       .notNull(),
-    // Migration 0800 physically bridges held_sandbox_states while this release
-    // remains legacy-only. #24510 declares/cuts over; #24512 removes this field.
+    heldSandboxStates: jsonb("held_sandbox_states")
+      .$type<RunnerHeldSandboxStates>()
+      .default([])
+      .notNull(),
+    // Migration 0800 keeps this column synchronized for API rollback.
+    // #24512 removes the bridge and this declaration.
     heldSessionStates: jsonb("held_session_states")
       .$type<RunnerHeldSandboxStates>()
       .default([])


### PR DESCRIPTION
## Summary

- require the canonical `heldSandboxStates` projection in runner heartbeats and remove the API fallback to `heldSessionStates`
- write and query runner affinity through `runner_state.held_sandbox_states` while migration 0800 continues synchronizing the rollback column
- cover canonical-only, missing-canonical, deployed dual-field, ordered heartbeat, and old/new database writer behavior

## Scope

- no database migration is added by this PR
- the migration 0800 bridge and `held_session_states` declaration remain for API rollback and are removed by #24512
- the runner's legacy heartbeat projection remains until #24511

## Validation

- `pnpm exec prettier --check <changed TypeScript files>`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/db lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/db check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts exec vitest run`
- `pnpm -F @vm0/db exec vitest run`
- targeted API runner lifecycle, cron, and Telegram integration tests (189 tests)
- `pnpm -F @vm0/db test:migration-consistency`
- `pnpm knip`

Closes #24510

Parent: #24489
