### PR TITLE
refactor: remove morning brief launch fallback

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -48,16 +48,13 @@ import {
   setQueuedUserMessageCreatedAtFixture,
 } from "../../../test-fixtures/chat-events";
 import {
-  insertOldFormatQueuedUserMessageFixture,
   insertQueuedWebUserMessageFixture,
   readMorningBriefDeliveryFixture,
   readMorningBriefQueuedParamsForDeliveryFixture,
-  readMorningBriefQueuedParamsFixture,
   setMorningBriefTriggeredAtFixture,
 } from "../../../test-fixtures/morning-brief";
 import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
 import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
-import { readRunApiStart } from "./helpers/runtime-state";
 
 /**
  * MORNING-BRIEF: the daily 7:00 local-time brief end to end.
@@ -1713,79 +1710,6 @@ describe("cron execute morning briefs", () => {
     }
     expect(userRunId).not.toBe(briefRunId);
     await completeMorningBriefRun(scenario, userRunId, 0);
-    clearMockNow();
-  }, 90_000);
-
-  it("drains an old-format queued params payload without new delivery fields", async () => {
-    context.mocks.resend.send.mockResolvedValue({
-      data: { id: "resend-old-format" },
-      error: null,
-    });
-    const scenario = await setupMorningBriefActor();
-    await updateFeatureSwitchesForUser(context, scenario.actor, {
-      [FeatureSwitchKey.ManualMorningBrief]: true,
-    });
-    mockNow(AFTER_SEVEN_LOCAL);
-    routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
-    const triggered = await accept(
-      morningBriefTriggerClient().trigger({
-        headers: actorHeaders(),
-        body: {},
-      }),
-      [200],
-    );
-    if (!triggered.body.runId) {
-      throw new Error("Expected the initial Morning Brief run");
-    }
-    const triggeredRunId = triggered.body.runId;
-    const thread = await findMorningBriefThread(scenario);
-
-    const displayContent = "Legacy queued Morning Brief display text.";
-    const realPrompt = "Legacy queued Morning Brief execution prompt.";
-    const appendSystemPrompt = "Legacy Morning Brief system instructions.";
-    const messageId = await insertOldFormatQueuedUserMessageFixture({
-      threadId: thread.threadId,
-      orgId: scenario.actor.orgId,
-      userId: scenario.actor.userId,
-      content: displayContent,
-      prompt: realPrompt,
-      appendSystemPrompt,
-      createdAt: new Date(BEFORE_SEVEN_LOCAL),
-    });
-    const oldParams = await readMorningBriefQueuedParamsFixture({
-      messageId,
-      orgId: scenario.actor.orgId,
-      userId: scenario.actor.userId,
-    });
-    expect(oldParams).toStrictEqual({
-      version: 1,
-      prompt: realPrompt,
-      appendSystemPrompt,
-    });
-
-    mockUploadedBriefOutput(VALID_OUTPUT);
-    await completeMorningBriefRun(scenario, triggeredRunId, 0);
-    await drainOutbox();
-    const events = await readMorningBriefThreadEvents(
-      scenario,
-      thread.threadId,
-    );
-    const claimed = events.find((event) => {
-      return (
-        event.eventType === "input.prompt" &&
-        chatEventDisplayText(event) === displayContent &&
-        event.runId !== undefined
-      );
-    });
-    if (!claimed?.runId) {
-      throw new Error("Expected the old-format queue item to drain");
-    }
-    await expect(readRunApiStart(context, claimed.runId)).resolves.toBe(
-      new Date(BEFORE_SEVEN_LOCAL).toISOString(),
-    );
-    const runInput = await completeMorningBriefRun(scenario, claimed.runId, 0);
-    expect(runInput.prompt).toBe(realPrompt);
-    expect(runInput.appendSystemPrompt).toContain(appendSystemPrompt);
     clearMockNow();
   }, 90_000);
 

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2748,7 +2748,6 @@ function launchLoader<Material extends NativeQueuedLaunchMaterial>(
 
 async function resolveQueuedLaunchMaterial(
   args: CreateQueuedChatRunInputArgs,
-  sourceParams: QueuedSourceParams,
 ): Promise<QueuedLaunchMaterial | null> {
   const launchLoaders: Partial<Record<TriggerSource, LaunchLoader>> = {
     slack: launchLoader(loadSlackQueuedLaunchMaterial, (material) => {
@@ -2796,13 +2795,6 @@ async function resolveQueuedLaunchMaterial(
   if (material) {
     return material;
   }
-  if (
-    args.queuedMessage.triggerSource === "workflow-schedule" &&
-    sourceParams?.prompt !== undefined &&
-    sourceParams.appendSystemPrompt !== undefined
-  ) {
-    return null;
-  }
   throw new Error(
     `${args.queuedMessage.triggerSource} queue item is missing launch material`,
   );
@@ -2822,9 +2814,6 @@ function queuedIntegrationDeliveries(
   > = {
     telegram: (params) => {
       return { telegramDelivery: params?.telegramDelivery };
-    },
-    "workflow-schedule": (params) => {
-      return { morningBriefDelivery: params?.morningBriefDelivery };
     },
   };
   return (
@@ -2887,7 +2876,6 @@ function teamsQueuedMessageAdmissionFailure(
 
 function morningBriefQueuedMessageAdmissionFailure(
   args: CreateQueuedChatRunInputArgs,
-  sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
   launchMaterial: QueuedLaunchMaterial | null,
   error: QueuedMessageModelRouteError,
 ): MorningBriefQueuedMessageAdmissionFailure | null {
@@ -2898,9 +2886,7 @@ function morningBriefQueuedMessageAdmissionFailure(
     kind: "morning_brief_admission_failure",
     threadId: args.threadId,
     queuedMessage: args.queuedMessage,
-    morningBriefDelivery:
-      launchMaterial?.delivery.morningBriefDelivery ??
-      sourceParams?.morningBriefDelivery,
+    morningBriefDelivery: launchMaterial?.delivery.morningBriefDelivery,
     error,
   };
 }
@@ -3018,7 +3004,6 @@ function queuedMessageAdmissionFailure(
     "workflow-schedule": (resolverArgs) => {
       return morningBriefQueuedMessageAdmissionFailure(
         resolverArgs.args,
-        resolverArgs.sourceParams,
         resolverArgs.launchMaterial,
         resolverArgs.error,
       );
@@ -3029,18 +3014,10 @@ function queuedMessageAdmissionFailure(
 }
 
 function queuedMessagePrompt(args: {
-  readonly triggerSource: QueuedUserMessage["triggerSource"];
   readonly launchMaterial: QueuedLaunchMaterial | null;
-  readonly sourceParams: QueuedSourceParams;
   readonly projectedPrompt: string;
 }): string {
-  if (args.launchMaterial) {
-    return args.launchMaterial.prompt;
-  }
-  if (args.triggerSource === "workflow-schedule") {
-    return args.sourceParams?.prompt ?? args.projectedPrompt;
-  }
-  return args.projectedPrompt;
+  return args.launchMaterial?.prompt ?? args.projectedPrompt;
 }
 
 function queuedIntegrationPrompt(args: {
@@ -3086,7 +3063,7 @@ async function loadQueuedRunMaterial(args: CreateQueuedChatRunInputArgs) {
   if (args.queuedMessage.triggerSource !== "web" && !sourceParams) {
     throw new Error("Canonical integration queue item is missing run params");
   }
-  const launchMaterial = await resolveQueuedLaunchMaterial(args, sourceParams);
+  const launchMaterial = await resolveQueuedLaunchMaterial(args);
   return {
     sourceParams,
     launchMaterial,
@@ -3195,9 +3172,7 @@ async function buildCreateQueuedChatRunInput(
     },
   );
   const prompt = queuedMessagePrompt({
-    triggerSource: args.queuedMessage.triggerSource,
     launchMaterial,
-    sourceParams,
     projectedPrompt: userMessageProjection.agentPrompt,
   });
 

--- a/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-import { chatEventInputParams } from "@vm0/db/schema/chat-event-input-params";
 import { chatMorningBriefContext } from "@vm0/db/schema/chat-morning-brief-context";
 import {
   morningBriefDeliveries,
@@ -39,10 +38,7 @@ import {
 import { buildMorningBriefChatMessage } from "./morning-brief-run-prompt";
 import { insertChatEvent } from "./zero-chat-event.service";
 import { touchChatThreadLastMessageAt } from "./zero-chat-event-shared.service";
-import {
-  decryptQueuedUserMessageRunParams,
-  encryptQueuedUserMessageRunParams,
-} from "./zero-chat-queued-event.service";
+import { encryptQueuedUserMessageRunParams } from "./zero-chat-queued-event.service";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { resolveDefaultAgent } from "./zero-email-common.service";
 import { createAutomationChatThread } from "./zero-workflow-user-automation-thread.service";
@@ -468,8 +464,6 @@ type ManualMorningBriefDeliveryAdmission =
 async function hasPendingMorningBriefQueueEvent(
   db: Db,
   args: {
-    readonly orgId: string;
-    readonly userId: string;
     readonly chatThreadId: string;
     readonly deliveryId: string;
   },
@@ -485,7 +479,6 @@ async function hasPendingMorningBriefQueueEvent(
   const messages = await db
     .select({
       deliveryId: chatMorningBriefContext.deliveryId,
-      encryptedParams: chatEventInputParams.encryptedParams,
     })
     .from(chatEvents)
     .leftJoin(
@@ -495,10 +488,6 @@ async function hasPendingMorningBriefQueueEvent(
         eq(chatMorningBriefContext.chatThreadId, chatEvents.chatThreadId),
       ),
     )
-    .leftJoin(
-      chatEventInputParams,
-      eq(chatEventInputParams.eventId, chatEvents.id),
-    )
     .where(
       and(
         inArray(chatEvents.id, pendingMessageIds),
@@ -507,13 +496,6 @@ async function hasPendingMorningBriefQueueEvent(
     );
   for (const message of messages) {
     if (message.deliveryId === args.deliveryId) {
-      return true;
-    }
-    const params = await decryptQueuedUserMessageRunParams(
-      message.encryptedParams,
-      { orgId: args.orgId, userId: args.userId },
-    );
-    if (params?.morningBriefDelivery?.deliveryId === args.deliveryId) {
       return true;
     }
   }
@@ -569,8 +551,6 @@ async function admitManualMorningBriefDelivery(
   }
   if (existing.status === "queued" && args.chatThreadId) {
     const hasPendingEvent = await hasPendingMorningBriefQueueEvent(db, {
-      orgId: args.orgId,
-      userId: args.userId,
       chatThreadId: args.chatThreadId,
       deliveryId: existing.id,
     });

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -87,14 +87,6 @@ const queuedUserMessageRunParamsSchema = z.object({
   prompt: z.string().optional(),
   appendSystemPrompt: z.string().optional(),
   telegramDelivery: telegramDeliveryTargetSchema.optional(),
-  morningBriefDelivery: z
-    .object({
-      deliveryId: z.string(),
-      internalKind: z.literal("morning-brief:email"),
-      secret: z.string(),
-      payload: z.unknown(),
-    })
-    .optional(),
   userInfoExtras: z
     .object({
       slackDisplayName: z.string().optional(),

--- a/turbo/apps/api/src/test-fixtures/morning-brief.ts
+++ b/turbo/apps/api/src/test-fixtures/morning-brief.ts
@@ -7,10 +7,7 @@ import { morningBriefDeliveries } from "@vm0/db/schema/morning-brief";
 import { and, eq } from "drizzle-orm";
 
 import { db } from "../lib/db";
-import {
-  decryptQueuedUserMessageRunParams,
-  encryptQueuedUserMessageRunParams,
-} from "../signals/services/zero-chat-queued-event.service";
+import { decryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
 import { insertChatEvent } from "../signals/services/zero-chat-event.service";
 import { touchChatThreadLastMessageAt } from "../signals/services/zero-chat-event-shared.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
@@ -92,28 +89,6 @@ export async function setMorningBriefTriggeredAtFixture(args: {
   }
 }
 
-export async function readMorningBriefQueuedParamsFixture(args: {
-  readonly messageId: string;
-  readonly orgId: string;
-  readonly userId: string;
-}) {
-  const [event] = await db()
-    .select({
-      encryptedParams: chatEventInputParams.encryptedParams,
-    })
-    .from(chatEvents)
-    .leftJoin(
-      chatEventInputParams,
-      eq(chatEventInputParams.eventId, chatEvents.id),
-    )
-    .where(eq(chatEvents.id, args.messageId))
-    .limit(1);
-  return await decryptQueuedUserMessageRunParams(
-    event?.encryptedParams ?? null,
-    { orgId: args.orgId, userId: args.userId },
-  );
-}
-
 /**
  * Appends a normal web user message without invoking a drain. Product sends
  * persist this same event before draining, but cannot pause at that boundary.
@@ -136,52 +111,6 @@ export async function insertQueuedWebUserMessageFixture(args: {
     });
     if (!inserted) {
       throw new Error("Expected the queued web user message fixture");
-    }
-    await touchChatThreadLastMessageAt(
-      tx,
-      args.threadId,
-      inserted.createdAt,
-      inserted.id,
-    );
-  });
-  return messageId;
-}
-
-/**
- * Inserts the pre-Morning-Brief-extension queued params shape. No product API
- * can create an integration queue item with a historical encrypted payload.
- */
-export async function insertOldFormatQueuedUserMessageFixture(args: {
-  readonly threadId: string;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly content: string;
-  readonly prompt: string;
-  readonly appendSystemPrompt: string;
-  readonly createdAt?: Date;
-}): Promise<string> {
-  const messageId = randomUUID();
-  const encryptedParams = await encryptQueuedUserMessageRunParams(
-    {
-      version: 1,
-      prompt: args.prompt,
-      appendSystemPrompt: args.appendSystemPrompt,
-    },
-    { orgId: args.orgId, userId: args.userId },
-  );
-  await db().transaction(async (tx) => {
-    const inserted = await insertChatEvent(tx, {
-      id: messageId,
-      chatThreadId: args.threadId,
-      eventType: "input.prompt",
-      userMessage: createUserMessageDocument({ text: args.content }),
-      runId: null,
-      triggerSource: "workflow-schedule",
-      encryptedParams,
-      ...(args.createdAt ? { createdAt: args.createdAt } : {}),
-    });
-    if (!inserted) {
-      throw new Error("Expected the old-format queued message fixture");
     }
     await touchChatThreadLastMessageAt(
       tx,


### PR DESCRIPTION
## Summary

- require Morning Brief queue claims to load launch material from `chat_events`, `chat_morning_brief_context`, and the referenced delivery row
- remove the legacy prompt, system-prompt, callback, secret, and duplicate-detection fallbacks from `encrypted_params`
- remove the historical fallback fixture and integration case now that the production backlog is drained

This is PR 3 of 3 for #24519. Closes #24519.

## Production drain gate

PR #24527 was released by release PR #24532 at merge commit `8aab75160aa3500ca9bdc130d1e567ee74dbaede`.

- [Turbo main run 30737867157](https://github.com/vm0-ai/vm0/actions/runs/30737867157): success
- [release-please production run 30737867161](https://github.com/vm0-ai/vm0/actions/runs/30737867161): success, including `promote-api-production` and `deploy-api-schema`

A read-only MaskDB reconciliation on `vm0-prod-ro` at 2026-08-02 07:44:15 UTC found:

- original legacy Morning Brief `input.prompt` rows (`workflow-schedule`, no context, no run): **24**
- claimed run replacements with the same source and no context: **24**
- rejected replacements: **0**
- reconciliation: **24 original = 24 run replacements**

The identity also closes independently in every one of the six fixed Morning Brief threads: each has **4 originals = 4 run replacements**. Every replacement is in the same thread, follows its original at the immediately adjacent sequence number, and was created seconds later. Queue claim writes that replacement with the unique revoke edge atomically, so no current Morning Brief event remains dependent on the legacy blob.

## Preserved behavior

- `brief_date` remains deliberately omitted from `chat_morning_brief_context` and is joined from `morning_brief_deliveries`; only the non-reconstructible `timezone` and `triggered_at` are stored in context.
- callback payload remains reconstructed as `{deliveryId}` and `generateCallbackSecret()` still mints the secret at claim; no secret is persisted.
- PR #24527's intentional prompt behavior remains: all prompt bytes are preserved except `inputUrl` and `outputUrl`, which are freshly signed at claim from `input_key` / `output_key` with a full TTL. This URL-only difference is the deliberate fix for queued briefs receiving partially expired admission-time URLs.
- new Morning Brief admissions continue to store only `{version: 1}` in `encrypted_params`.

## Scope

- Morning Brief fallback removal only
- no changes to `cron-monitor-chat-event-queue`
- no changes to the `morning_brief_deliveries` or `morning_brief_schedules` schemas
- no API, `user_message`, or client-rendering changes

## Validation

- `pnpm exec prettier --write <changed files>`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- `git diff --check`

Per #24519, no local full Vitest run or dev server was started; PR CI is the runtime validation gate.
