### PR TITLE
test(python): cover sigv4 signed-header host requirement

### DIFF
--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -887,6 +887,23 @@ async def test_header_sigv4_with_duplicate_signed_header_fails_closed(
     assert_sigv4_failed_closed(result, flow, "Malformed AWS signed headers")
 
 
+async def test_header_sigv4_without_host_signed_header_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    flow = make_sts_header_sigv4_flow(
+        real_flow,
+        headers,
+        signed_headers="x-amz-date",
+    )
+
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+
+    assert_sigv4_failed_closed(result, flow, "AWS signed headers must include host")
+
+
 async def test_header_sigv4_with_empty_signed_header_segment_fails_closed(
     real_flow,
     headers,
@@ -1069,6 +1086,22 @@ async def test_query_sigv4_with_duplicate_signed_header_fails_closed(
     result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
     assert_sigv4_failed_closed(result, flow, "Malformed AWS signed headers")
+
+
+async def test_query_sigv4_without_host_signed_header_fails_closed(
+    real_flow,
+    tmp_path,
+    mitm_ctx,
+):
+    flow = make_sts_query_sigv4_flow(
+        real_flow,
+        path=aws_sigv4_presigned_query_path(signed_headers="x-test"),
+    )
+    flow.request.headers["X-Test"] = "signed-value"
+
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+
+    assert_sigv4_failed_closed(result, flow, "AWS signed headers must include host")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- cover authorization-header SigV4 placeholders that omit `host` from `SignedHeaders`
- cover presigned-query placeholders through the same firewall-auth boundary with an otherwise reconstructable signed header
- assert the existing HTTP 502 `aws_sigv4_auth_failed` contract and host-requirement message

## Scope

This is test-only. It does not change production signing behavior, APIs, schemas, migrations, persisted data, dependencies, or deployment compatibility.

## Validation

- `uv lock --check`
- `uv sync --locked`
- focused pytest selection for both new cases
- `uv run --no-sync python -m pytest tests/test_firewall_aws_sigv4_auth.py` (48 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4552 passed)
- mutation check: removing only the production `host` guard made both new tests fail with `CONTINUE_UPSTREAM`; the guard was restored before final validation and commit

Closes #24539
