### PR TITLE
refactor: claim telegram launch context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -176,14 +176,14 @@ function expectOk(response: Response, operation: string): void {
   throw new Error(`${operation} failed with ${response.status}`);
 }
 
-function expectExactSystemPromptSuffix(
+function expectExactSystemPromptFragment(
   appendSystemPrompt: string | null | undefined,
-  expectedSuffix: string,
+  expectedFragment: string,
 ): void {
   if (!appendSystemPrompt) {
     throw new Error("Expected Telegram append system prompt");
   }
-  expect(appendSystemPrompt.slice(-expectedSuffix.length)).toBe(expectedSuffix);
+  expect(appendSystemPrompt.split(expectedFragment)).toHaveLength(2);
 }
 
 async function postTelegramStateAction(
@@ -1192,7 +1192,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     expect(run?.prompt).toBe("hello from telegram");
     expect(run?.appendSystemPrompt).toContain("Telegram username: @alice");
     expect(run?.appendSystemPrompt).toContain("Bot ID:");
-    expectExactSystemPromptSuffix(
+    expectExactSystemPromptFragment(
       run?.appendSystemPrompt,
       [
         "# Current Integration",
@@ -1544,7 +1544,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     if (!queuedThreadContext) {
       throw new Error("Expected frozen queued Telegram thread context");
     }
-    expectExactSystemPromptSuffix(
+    expectExactSystemPromptFragment(
       queuedClaim.appendSystemPrompt,
       [
         "# Current Integration",
@@ -1582,7 +1582,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     }
     const legacyClaim = await claimTelegramRun(legacyRunId, runnerGroup);
     expect(legacyClaim.prompt).toBe("legacy Telegram launch prompt");
-    expectExactSystemPromptSuffix(
+    expectExactSystemPromptFragment(
       legacyClaim.appendSystemPrompt,
       "legacy Telegram system prompt",
     );
@@ -1803,7 +1803,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       telegramUserLinkKind: "custom",
       telegramChatType: "supergroup",
     });
-    expectExactSystemPromptSuffix(
+    expectExactSystemPromptFragment(
       firstState.run?.appendSystemPrompt,
       [
         "# Current Integration",
@@ -1918,7 +1918,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     if (!followUpThreadContext) {
       throw new Error("Expected frozen Telegram forum thread context");
     }
-    expectExactSystemPromptSuffix(
+    expectExactSystemPromptFragment(
       followUpState.run?.appendSystemPrompt,
       [
         "# Current Integration",
@@ -2137,7 +2137,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     const run = await latestRunForFixture(fixture);
     expect(run?.prompt).toBe("summarize this thread");
     expect(run?.appendSystemPrompt).toContain("Chat type: supergroup");
-    expectExactSystemPromptSuffix(
+    expectExactSystemPromptFragment(
       run?.appendSystemPrompt,
       [
         "# Current Integration",
@@ -2207,7 +2207,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     expect(run?.appendSystemPrompt).toContain(
       "Bot username: @official_zero_bot",
     );
-    expectExactSystemPromptSuffix(
+    expectExactSystemPromptFragment(
       run?.appendSystemPrompt,
       [
         "# Current Integration",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -19,10 +19,13 @@ import { clearMockedEnv, mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { nowDate } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import {
+  decryptChatEventInputParamsFixture,
   findPendingChatEventInputParamsByPromptFixture,
   findTelegramChatEventByPromptFixture,
   readChatEventContextFixture,
   readChatEventInputParamsFixture,
+  replaceTelegramLaunchMaterialWithLegacyParamsFixture,
+  setTelegramThinkingMessageIdFixture,
 } from "../../../test-fixtures/chat-events";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import {
@@ -75,6 +78,11 @@ interface TelegramSendMessageBody {
   };
 }
 
+interface TelegramDeleteMessageBody {
+  readonly chat_id: string | number;
+  readonly message_id: number;
+}
+
 function newTelegramBotId(): string {
   return String(Math.floor(Math.random() * 9_000_000_000) + 1_000_000_000);
 }
@@ -113,9 +121,11 @@ function configureOfficialBotEnv(): void {
 function telegramApiMocks(token = TEST_BOT_TOKEN): {
   readonly chatActions: unknown[];
   readonly sentMessages: TelegramSendMessageBody[];
+  readonly deletedMessages: TelegramDeleteMessageBody[];
 } {
   const chatActions: unknown[] = [];
   const sentMessages: TelegramSendMessageBody[] = [];
+  const deletedMessages: TelegramDeleteMessageBody[] = [];
   let nextMessageId = 700;
 
   server.use(
@@ -141,9 +151,18 @@ function telegramApiMocks(token = TEST_BOT_TOKEN): {
         });
       },
     ),
+    http.post(
+      `https://api.telegram.org/bot${token}/deleteMessage`,
+      async ({ request }) => {
+        deletedMessages.push(
+          (await request.json()) as TelegramDeleteMessageBody,
+        );
+        return HttpResponse.json({ ok: true, result: true });
+      },
+    ),
   );
 
-  return { chatActions, sentMessages };
+  return { chatActions, sentMessages, deletedMessages };
 }
 
 async function readJson<T>(response: Response): Promise<T> {
@@ -155,6 +174,16 @@ function expectOk(response: Response, operation: string): void {
     return;
   }
   throw new Error(`${operation} failed with ${response.status}`);
+}
+
+function expectExactSystemPromptSuffix(
+  appendSystemPrompt: string | null | undefined,
+  expectedSuffix: string,
+): void {
+  if (!appendSystemPrompt) {
+    throw new Error("Expected Telegram append system prompt");
+  }
+  expect(appendSystemPrompt.slice(-expectedSuffix.length)).toBe(expectedSuffix);
 }
 
 async function postTelegramStateAction(
@@ -1163,6 +1192,19 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     expect(run?.prompt).toBe("hello from telegram");
     expect(run?.appendSystemPrompt).toContain("Telegram username: @alice");
     expect(run?.appendSystemPrompt).toContain("Bot ID:");
+    expectExactSystemPromptSuffix(
+      run?.appendSystemPrompt,
+      [
+        "# Current Integration",
+        "You are currently running inside: Telegram",
+        `Bot ID: ${fixture.telegramBotId}`,
+        `Bot username: @bot_${fixture.telegramBotId}`,
+        "Chat ID: 77001",
+        "Chat type: private",
+        "Message ID: 42",
+        "Root message ID: dm",
+      ].join("\n"),
+    );
     const admitted = await findTelegramChatEventByPromptFixture(
       "hello from telegram",
     );
@@ -1347,12 +1389,12 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     await runsApi.requestCancelRun(actorForFixture(fixture), runId, [200]);
   });
 
-  it("keeps queued Telegram transport params until the input is claimed", async () => {
+  it("rebuilds queued Telegram launch material and preserves the legacy fallback", async () => {
     const runnerGroup = configureCanonicalTelegramRunner();
     const fixture = await trackFixture(
       seedTelegramPostFixture({ linkTelegramUser: true }),
     );
-    telegramApiMocks();
+    const telegramMocks = telegramApiMocks();
     const chatId = 77_002;
     const firstPrompt = "hold the Telegram queue";
     expect(
@@ -1416,6 +1458,23 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     if (!queuedParams) {
       throw new Error("Expected queued Telegram transport params");
     }
+    await expect(
+      decryptChatEventInputParamsFixture(queuedParams.eventId, {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      }),
+    ).resolves.toStrictEqual({ version: 1 });
+    const queuedLaunchContext = await readChatEventContextFixture(
+      queuedParams.eventId,
+    );
+    expect(queuedLaunchContext).toMatchObject({
+      telegramMessageText: queuedPrompt,
+      telegramThreadContext: expect.stringContaining(firstPrompt),
+      telegramMessageId: "2202",
+      telegramRootMessageId: "dm",
+      telegramUserLinkKind: "custom",
+    });
+    await setTelegramThinkingMessageIdFixture(queuedParams.eventId, "701");
     await completeCanonicalChatRun({
       runId: firstRunId,
       sandboxToken: firstClaim.sandboxToken,
@@ -1434,14 +1493,102 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     await expect(
       readChatEventInputParamsFixture(queuedParams.eventId),
     ).resolves.toBeNull();
+
+    const legacyQueuedPrompt = "legacy Telegram queue fallback";
+    expect(
+      (
+        await postWebhook({
+          telegramBotId: fixture.telegramBotId,
+          secret: fixture.webhookSecret,
+          body: {
+            update_id: 203,
+            message: {
+              message_id: 2203,
+              chat: { id: chatId, type: "private" },
+              from: {
+                id: Number(fixture.telegramUserId),
+                username: "alice",
+                first_name: "Alice",
+              },
+              text: legacyQueuedPrompt,
+            },
+          },
+        })
+      ).status,
+    ).toBe(200);
+    await flushWaitUntilForTest();
+    const legacyQueuedParams =
+      await findPendingChatEventInputParamsByPromptFixture(legacyQueuedPrompt);
+    if (!legacyQueuedParams) {
+      throw new Error("Expected legacy Telegram fallback queue item");
+    }
+    await expect(
+      decryptChatEventInputParamsFixture(legacyQueuedParams.eventId, {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      }),
+    ).resolves.toStrictEqual({ version: 1 });
+    await replaceTelegramLaunchMaterialWithLegacyParamsFixture(
+      legacyQueuedParams.eventId,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        prompt: "legacy Telegram launch prompt",
+        appendSystemPrompt: "legacy Telegram system prompt",
+      },
+    );
+
     const queuedClaim = await claimTelegramRun(queuedRunId, runnerGroup);
     expect(queuedClaim.prompt).toBe(queuedPrompt);
-    expect(queuedClaim.appendSystemPrompt).toContain(
-      "You are currently running inside: Telegram",
+    const queuedThreadContext = queuedLaunchContext?.telegramThreadContext;
+    if (!queuedThreadContext) {
+      throw new Error("Expected frozen queued Telegram thread context");
+    }
+    expectExactSystemPromptSuffix(
+      queuedClaim.appendSystemPrompt,
+      [
+        "# Current Integration",
+        "You are currently running inside: Telegram",
+        `Bot ID: ${fixture.telegramBotId}`,
+        `Bot username: @bot_${fixture.telegramBotId}`,
+        `Chat ID: ${chatId}`,
+        "Chat type: private",
+        "Message ID: 2202",
+        "Root message ID: dm",
+        "",
+        queuedThreadContext,
+      ].join("\n"),
+    );
+    await completeCanonicalChatRun({
+      runId: queuedRunId,
+      sandboxToken: queuedClaim.sandboxToken,
+    });
+    expect(telegramMocks.deletedMessages).toContainEqual({
+      chat_id: String(chatId),
+      message_id: 701,
+    });
+
+    let legacyRunId: string | null = null;
+    await expect
+      .poll(async () => {
+        legacyRunId =
+          (await telegramPostRunState(fixture, "legacy Telegram launch prompt"))
+            .run?.id ?? null;
+        return legacyRunId;
+      })
+      .toStrictEqual(expect.any(String));
+    if (!legacyRunId) {
+      throw new Error("Expected the legacy Telegram fallback run");
+    }
+    const legacyClaim = await claimTelegramRun(legacyRunId, runnerGroup);
+    expect(legacyClaim.prompt).toBe("legacy Telegram launch prompt");
+    expectExactSystemPromptSuffix(
+      legacyClaim.appendSystemPrompt,
+      "legacy Telegram system prompt",
     );
     await runsApi.requestCancelRun(
       actorForFixture(fixture),
-      queuedRunId,
+      legacyRunId,
       [200],
     );
   });
@@ -1641,9 +1788,10 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     if (!admittedForum) {
       throw new Error("Expected admitted Telegram forum input event");
     }
-    await expect(
-      readChatEventContextFixture(admittedForum.eventId),
-    ).resolves.toMatchObject({
+    const forumLaunchContext = await readChatEventContextFixture(
+      admittedForum.eventId,
+    );
+    expect(forumLaunchContext).toMatchObject({
       contextType: "telegram",
       telegramChatId: String(chatId),
       telegramMessageId: "2201",
@@ -1655,6 +1803,19 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       telegramUserLinkKind: "custom",
       telegramChatType: "supergroup",
     });
+    expectExactSystemPromptSuffix(
+      firstState.run?.appendSystemPrompt,
+      [
+        "# Current Integration",
+        "You are currently running inside: Telegram",
+        `Bot ID: ${fixture.telegramBotId}`,
+        `Bot username: @${botUsername}`,
+        `Chat ID: ${chatId}`,
+        "Chat type: supergroup",
+        "Message ID: 2201",
+        `Message thread ID: ${messageThreadId}`,
+      ].join("\n"),
+    );
     expect(
       stateRecords((await readTelegramState(fixture.telegramBotId)).routes),
     ).toHaveLength(0);
@@ -1738,9 +1899,10 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     if (!admittedFollowUp) {
       throw new Error("Expected admitted Telegram forum follow-up event");
     }
-    await expect(
-      readChatEventContextFixture(admittedFollowUp.eventId),
-    ).resolves.toMatchObject({
+    const followUpLaunchContext = await readChatEventContextFixture(
+      admittedFollowUp.eventId,
+    );
+    expect(followUpLaunchContext).toMatchObject({
       contextType: "telegram",
       telegramMessageThreadId: messageThreadId,
       telegramMessageText: followUpAgentPrompt,
@@ -1751,6 +1913,27 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     });
 
     const followUpState = await telegramPostRunState(fixture);
+    expect(followUpState.run?.prompt).toBe(followUpAgentPrompt);
+    const followUpThreadContext = followUpLaunchContext?.telegramThreadContext;
+    if (!followUpThreadContext) {
+      throw new Error("Expected frozen Telegram forum thread context");
+    }
+    expectExactSystemPromptSuffix(
+      followUpState.run?.appendSystemPrompt,
+      [
+        "# Current Integration",
+        "You are currently running inside: Telegram",
+        `Bot ID: ${fixture.telegramBotId}`,
+        `Bot username: @${botUsername}`,
+        `Chat ID: ${chatId}`,
+        "Chat type: supergroup",
+        "Message ID: 2202",
+        "Root message ID: 700",
+        `Message thread ID: ${messageThreadId}`,
+        "",
+        followUpThreadContext,
+      ].join("\n"),
+    );
     expect(followUpState.zeroRun?.chatThreadId).toBe(
       firstState.zeroRun?.chatThreadId,
     );
@@ -1954,6 +2137,18 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     const run = await latestRunForFixture(fixture);
     expect(run?.prompt).toBe("summarize this thread");
     expect(run?.appendSystemPrompt).toContain("Chat type: supergroup");
+    expectExactSystemPromptSuffix(
+      run?.appendSystemPrompt,
+      [
+        "# Current Integration",
+        "You are currently running inside: Telegram",
+        `Bot ID: ${fixture.telegramBotId}`,
+        `Bot username: @${botUsername}`,
+        "Chat ID: -10099002",
+        "Chat type: supergroup",
+        "Message ID: 101",
+      ].join("\n"),
+    );
     const admitted = await findTelegramChatEventByPromptFixture(
       "summarize this thread",
     );
@@ -2011,6 +2206,19 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     expect(run?.prompt).toBe("run through official bot");
     expect(run?.appendSystemPrompt).toContain(
       "Bot username: @official_zero_bot",
+    );
+    expectExactSystemPromptSuffix(
+      run?.appendSystemPrompt,
+      [
+        "# Current Integration",
+        "You are currently running inside: Telegram",
+        `Bot ID: ${OFFICIAL_TELEGRAM_BOT_ID}`,
+        `Bot username: @${OFFICIAL_BOT_USERNAME}`,
+        "Chat ID: 88002",
+        "Chat type: private",
+        "Message ID: 51",
+        "Root message ID: dm",
+      ].join("\n"),
     );
     const admitted = await findTelegramChatEventByPromptFixture(
       "run through official bot",

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -197,6 +197,10 @@ import {
   loadAgentPhoneQueuedLaunchMaterial,
   type AgentPhoneQueuedLaunchMaterial,
 } from "./agentphone-queued-launch-context.service";
+import {
+  loadTelegramQueuedLaunchMaterial,
+  type TelegramQueuedLaunchMaterial,
+} from "./telegram-queued-launch-context.service";
 
 const log = logger("callback:chat");
 const PG_FOREIGN_KEY_VIOLATION = "23503";
@@ -2724,6 +2728,7 @@ type NativeQueuedLaunchMaterial =
   | TeamsQueuedLaunchMaterial
   | (GitHubQueuedLaunchMaterial & { readonly userInfoExtras?: undefined })
   | AgentPhoneQueuedLaunchMaterial
+  | TelegramQueuedLaunchMaterial
   | MorningBriefQueuedLaunchMaterial;
 
 function launchLoader<Material extends NativeQueuedLaunchMaterial>(
@@ -2748,6 +2753,7 @@ function launchLoader<Material extends NativeQueuedLaunchMaterial>(
 
 async function resolveQueuedLaunchMaterial(
   args: CreateQueuedChatRunInputArgs,
+  sourceParams: QueuedSourceParams,
 ): Promise<QueuedLaunchMaterial | null> {
   const launchLoaders: Partial<Record<TriggerSource, LaunchLoader>> = {
     slack: launchLoader(loadSlackQueuedLaunchMaterial, (material) => {
@@ -2778,6 +2784,9 @@ async function resolveQueuedLaunchMaterial(
     agentphone: launchLoader(loadAgentPhoneQueuedLaunchMaterial, (material) => {
       return { agentphoneDelivery: material.agentphoneDelivery };
     }),
+    telegram: launchLoader(loadTelegramQueuedLaunchMaterial, (material) => {
+      return { telegramDelivery: material.telegramDelivery };
+    }),
   };
   const load = launchLoaders[args.queuedMessage.triggerSource];
   if (!load) {
@@ -2794,6 +2803,14 @@ async function resolveQueuedLaunchMaterial(
   });
   if (material) {
     return material;
+  }
+  if (
+    args.queuedMessage.triggerSource === "telegram" &&
+    sourceParams?.prompt !== undefined &&
+    sourceParams.appendSystemPrompt !== undefined &&
+    sourceParams.telegramDelivery
+  ) {
+    return null;
   }
   throw new Error(
     `${args.queuedMessage.triggerSource} queue item is missing launch material`,
@@ -2893,13 +2910,10 @@ function morningBriefQueuedMessageAdmissionFailure(
 
 function telegramQueuedMessageAdmissionFailure(
   args: CreateQueuedChatRunInputArgs,
-  sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
+  telegramDelivery: CreateQueuedChatRunInput["telegramDelivery"],
   error: QueuedMessageModelRouteError,
 ): TelegramQueuedMessageAdmissionFailure | null {
-  if (
-    args.queuedMessage.triggerSource !== "telegram" ||
-    !sourceParams?.telegramDelivery
-  ) {
+  if (args.queuedMessage.triggerSource !== "telegram" || !telegramDelivery) {
     return null;
   }
   return {
@@ -2909,7 +2923,7 @@ function telegramQueuedMessageAdmissionFailure(
     agentId: args.agent.id,
     threadId: args.threadId,
     queuedMessage: args.queuedMessage,
-    telegramDelivery: sourceParams.telegramDelivery,
+    telegramDelivery,
     error,
   };
 }
@@ -2983,7 +2997,8 @@ function queuedMessageAdmissionFailure(
     telegram: (resolverArgs) => {
       return telegramQueuedMessageAdmissionFailure(
         resolverArgs.args,
-        resolverArgs.sourceParams,
+        resolverArgs.launchMaterial?.delivery.telegramDelivery ??
+          resolverArgs.sourceParams?.telegramDelivery,
         resolverArgs.error,
       );
     },
@@ -3014,10 +3029,18 @@ function queuedMessageAdmissionFailure(
 }
 
 function queuedMessagePrompt(args: {
+  readonly triggerSource: QueuedUserMessage["triggerSource"];
   readonly launchMaterial: QueuedLaunchMaterial | null;
+  readonly sourceParams: QueuedSourceParams;
   readonly projectedPrompt: string;
 }): string {
-  return args.launchMaterial?.prompt ?? args.projectedPrompt;
+  if (args.launchMaterial) {
+    return args.launchMaterial.prompt;
+  }
+  if (args.triggerSource === "telegram") {
+    return args.sourceParams?.prompt ?? "";
+  }
+  return args.projectedPrompt;
 }
 
 function queuedIntegrationPrompt(args: {
@@ -3063,7 +3086,7 @@ async function loadQueuedRunMaterial(args: CreateQueuedChatRunInputArgs) {
   if (args.queuedMessage.triggerSource !== "web" && !sourceParams) {
     throw new Error("Canonical integration queue item is missing run params");
   }
-  const launchMaterial = await resolveQueuedLaunchMaterial(args);
+  const launchMaterial = await resolveQueuedLaunchMaterial(args, sourceParams);
   return {
     sourceParams,
     launchMaterial,
@@ -3172,7 +3195,9 @@ async function buildCreateQueuedChatRunInput(
     },
   );
   const prompt = queuedMessagePrompt({
+    triggerSource: args.queuedMessage.triggerSource,
     launchMaterial,
+    sourceParams,
     projectedPrompt: userMessageProjection.agentPrompt,
   });
 

--- a/turbo/apps/api/src/signals/services/telegram-prompt.ts
+++ b/turbo/apps/api/src/signals/services/telegram-prompt.ts
@@ -1,0 +1,39 @@
+export function buildTelegramPrompt(
+  opts: {
+    readonly botId?: string;
+    readonly botUsername?: string | null;
+    readonly chatId?: string;
+    readonly chatType?: string;
+    readonly messageId?: string;
+    readonly rootMessageId?: string | null;
+    readonly messageThreadId?: string | number | null;
+  },
+  threadContext: string,
+): string {
+  const headerParts = [
+    "# Current Integration",
+    "You are currently running inside: Telegram",
+  ];
+  if (opts.botId) {
+    headerParts.push(`Bot ID: ${opts.botId}`);
+  }
+  if (opts.botUsername) {
+    headerParts.push(`Bot username: @${opts.botUsername}`);
+  }
+  if (opts.chatId) {
+    headerParts.push(`Chat ID: ${opts.chatId}`);
+  }
+  if (opts.chatType) {
+    headerParts.push(`Chat type: ${opts.chatType}`);
+  }
+  if (opts.messageId) {
+    headerParts.push(`Message ID: ${opts.messageId}`);
+  }
+  if (opts.rootMessageId) {
+    headerParts.push(`Root message ID: ${opts.rootMessageId}`);
+  }
+  if (opts.messageThreadId) {
+    headerParts.push(`Message thread ID: ${opts.messageThreadId}`);
+  }
+  return [headerParts.join("\n"), threadContext].filter(Boolean).join("\n\n");
+}

--- a/turbo/apps/api/src/signals/services/telegram-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/telegram-queued-launch-context.service.ts
@@ -1,0 +1,249 @@
+import { OFFICIAL_TELEGRAM_BOT_ID } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import { chatEvents } from "@vm0/db/schema/chat-event";
+import { chatTelegramContext } from "@vm0/db/schema/chat-telegram-context";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
+import { telegramOfficialUserLinks } from "@vm0/db/schema/telegram-official-user-link";
+import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
+import { and, eq } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+import { getOfficialTelegramBotConfig } from "../external/telegram-official";
+import {
+  telegramDeliveryTargetSchema,
+  type TelegramDeliveryTarget,
+} from "./telegram-chat-callback-payload";
+import { buildTelegramPrompt } from "./telegram-prompt";
+
+export interface TelegramQueuedLaunchMaterial {
+  readonly prompt: string;
+  readonly appendSystemPrompt: string;
+  readonly telegramDelivery: TelegramDeliveryTarget;
+  readonly userInfoExtras: {
+    readonly telegramDisplayName?: string;
+    readonly telegramUsername?: string;
+    readonly telegramUserId?: string;
+    readonly telegramLanguage?: string;
+  };
+}
+
+type TelegramLaunchContextRow = Pick<
+  typeof chatTelegramContext.$inferSelect,
+  | "chatId"
+  | "messageId"
+  | "isDm"
+  | "messageThreadId"
+  | "messageText"
+  | "threadContext"
+  | "rootMessageId"
+  | "thinkingMessageId"
+  | "userLinkId"
+  | "userLinkKind"
+  | "chatType"
+  | "senderUserId"
+  | "senderDisplayName"
+  | "senderUsername"
+  | "senderLanguage"
+> & {
+  readonly agentId: string;
+  readonly customUserLinkId: string | null;
+  readonly customInstallationId: string | null;
+  readonly customBotUsername: string | null;
+  readonly officialUserLinkId: string | null;
+};
+
+function requiredTelegramLaunchContext(
+  row: TelegramLaunchContextRow | undefined,
+) {
+  if (
+    !row ||
+    row.messageText === null ||
+    row.threadContext === null ||
+    row.userLinkId === null ||
+    row.userLinkKind === null ||
+    row.chatType === null
+  ) {
+    return null;
+  }
+  if (
+    row.userLinkKind === "custom" &&
+    (row.customUserLinkId === null || row.customInstallationId === null)
+  ) {
+    return null;
+  }
+  if (row.userLinkKind === "official" && row.officialUserLinkId === null) {
+    return null;
+  }
+  return {
+    ...row,
+    messageText: row.messageText,
+    threadContext: row.threadContext,
+    userLinkId: row.userLinkId,
+    userLinkKind: row.userLinkKind,
+    chatType: row.chatType,
+  };
+}
+
+async function loadTelegramLaunchContext(
+  db: Db,
+  args: {
+    readonly eventId: string;
+    readonly chatThreadId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+) {
+  const [row] = await db
+    .select({
+      chatId: chatTelegramContext.chatId,
+      messageId: chatTelegramContext.messageId,
+      isDm: chatTelegramContext.isDm,
+      messageThreadId: chatTelegramContext.messageThreadId,
+      messageText: chatTelegramContext.messageText,
+      threadContext: chatTelegramContext.threadContext,
+      rootMessageId: chatTelegramContext.rootMessageId,
+      thinkingMessageId: chatTelegramContext.thinkingMessageId,
+      userLinkId: chatTelegramContext.userLinkId,
+      userLinkKind: chatTelegramContext.userLinkKind,
+      chatType: chatTelegramContext.chatType,
+      senderUserId: chatTelegramContext.senderUserId,
+      senderDisplayName: chatTelegramContext.senderDisplayName,
+      senderUsername: chatTelegramContext.senderUsername,
+      senderLanguage: chatTelegramContext.senderLanguage,
+      agentId: chatThreads.agentComposeId,
+      customUserLinkId: telegramUserLinks.id,
+      customInstallationId: telegramInstallations.telegramBotId,
+      customBotUsername: telegramInstallations.botUsername,
+      officialUserLinkId: telegramOfficialUserLinks.id,
+    })
+    .from(chatEvents)
+    .innerJoin(
+      chatTelegramContext,
+      and(
+        eq(chatTelegramContext.id, chatEvents.contextId),
+        eq(chatTelegramContext.chatThreadId, chatEvents.chatThreadId),
+      ),
+    )
+    .innerJoin(
+      chatThreads,
+      and(
+        eq(chatThreads.id, chatEvents.chatThreadId),
+        eq(chatThreads.userId, args.userId),
+      ),
+    )
+    .leftJoin(
+      telegramUserLinks,
+      and(
+        eq(chatTelegramContext.userLinkKind, "custom"),
+        eq(telegramUserLinks.id, chatTelegramContext.userLinkId),
+        eq(telegramUserLinks.vm0UserId, args.userId),
+      ),
+    )
+    .leftJoin(
+      telegramInstallations,
+      and(
+        eq(
+          telegramInstallations.telegramBotId,
+          telegramUserLinks.installationId,
+        ),
+        eq(telegramInstallations.orgId, args.orgId),
+      ),
+    )
+    .leftJoin(
+      telegramOfficialUserLinks,
+      and(
+        eq(chatTelegramContext.userLinkKind, "official"),
+        eq(telegramOfficialUserLinks.id, chatTelegramContext.userLinkId),
+        eq(telegramOfficialUserLinks.vm0UserId, args.userId),
+        eq(telegramOfficialUserLinks.orgId, args.orgId),
+      ),
+    )
+    .where(
+      and(
+        eq(chatEvents.id, args.eventId),
+        eq(chatEvents.chatThreadId, args.chatThreadId),
+        eq(chatEvents.contextType, "telegram"),
+        eq(chatEvents.triggerSource, "telegram"),
+      ),
+    )
+    .limit(1);
+  return requiredTelegramLaunchContext(row);
+}
+
+function telegramUserInfoExtras(
+  context: NonNullable<ReturnType<typeof requiredTelegramLaunchContext>>,
+): TelegramQueuedLaunchMaterial["userInfoExtras"] {
+  return {
+    ...(context.senderDisplayName !== null
+      ? { telegramDisplayName: context.senderDisplayName }
+      : {}),
+    ...(context.senderUsername !== null
+      ? { telegramUsername: context.senderUsername }
+      : {}),
+    ...(context.senderUserId !== null
+      ? { telegramUserId: context.senderUserId }
+      : {}),
+    ...(context.senderLanguage !== null
+      ? { telegramLanguage: context.senderLanguage }
+      : {}),
+  };
+}
+
+export async function loadTelegramQueuedLaunchMaterial(
+  db: Db,
+  args: {
+    readonly eventId: string;
+    readonly chatThreadId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+): Promise<TelegramQueuedLaunchMaterial | null> {
+  const context = await loadTelegramLaunchContext(db, args);
+  if (!context) {
+    return null;
+  }
+  const officialBotConfig = getOfficialTelegramBotConfig();
+  const installationId =
+    context.userLinkKind === "custom"
+      ? context.customInstallationId
+      : OFFICIAL_TELEGRAM_BOT_ID;
+  if (installationId === null) {
+    return null;
+  }
+  const botUsername =
+    context.userLinkKind === "custom"
+      ? context.customBotUsername
+      : officialBotConfig.botUsername;
+  return {
+    prompt: context.messageText,
+    appendSystemPrompt: buildTelegramPrompt(
+      {
+        botId: installationId,
+        botUsername,
+        chatId: context.chatId,
+        chatType: context.chatType,
+        messageId: context.messageId,
+        rootMessageId: context.rootMessageId,
+        messageThreadId: context.messageThreadId,
+      },
+      context.threadContext,
+    ),
+    telegramDelivery: telegramDeliveryTargetSchema.parse({
+      installationId,
+      chatId: context.chatId,
+      messageId: context.messageId,
+      rootMessageId: context.rootMessageId,
+      userLinkId: context.userLinkId,
+      userLinkKind: context.userLinkKind,
+      agentId: context.agentId,
+      isDM: context.isDm,
+      ...(context.messageThreadId !== null
+        ? { messageThreadId: context.messageThreadId }
+        : {}),
+      ...(context.thinkingMessageId !== null
+        ? { thinkingMessageId: context.thinkingMessageId }
+        : {}),
+    }),
+    userInfoExtras: telegramUserInfoExtras(context),
+  };
+}

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -74,7 +74,6 @@ import {
   ensureTelegramChatThreadRoute,
   type TelegramOwnerLink,
 } from "./telegram-chat-ingress.service";
-import type { TelegramDeliveryTarget } from "./telegram-chat-callback-payload";
 import { touchChatThreadLastMessageAt } from "./zero-chat-event-shared.service";
 import { insertChatEvent } from "./zero-chat-event.service";
 import { createChatEventSourcePart } from "./chat-event-annotation.service";
@@ -1605,46 +1604,6 @@ async function fetchTelegramContext(args: {
   ].join("\n");
 }
 
-function buildTelegramPrompt(
-  opts: {
-    readonly botId?: string;
-    readonly botUsername?: string | null;
-    readonly chatId?: string;
-    readonly chatType?: string;
-    readonly messageId?: string;
-    readonly rootMessageId?: string | null;
-    readonly messageThreadId?: string | number | null;
-  },
-  threadContext: string,
-): string {
-  const headerParts = [
-    "# Current Integration",
-    "You are currently running inside: Telegram",
-  ];
-  if (opts.botId) {
-    headerParts.push(`Bot ID: ${opts.botId}`);
-  }
-  if (opts.botUsername) {
-    headerParts.push(`Bot username: @${opts.botUsername}`);
-  }
-  if (opts.chatId) {
-    headerParts.push(`Chat ID: ${opts.chatId}`);
-  }
-  if (opts.chatType) {
-    headerParts.push(`Chat type: ${opts.chatType}`);
-  }
-  if (opts.messageId) {
-    headerParts.push(`Message ID: ${opts.messageId}`);
-  }
-  if (opts.rootMessageId) {
-    headerParts.push(`Root message ID: ${opts.rootMessageId}`);
-  }
-  if (opts.messageThreadId) {
-    headerParts.push(`Message thread ID: ${opts.messageThreadId}`);
-  }
-  return [headerParts.join("\n"), threadContext].filter(Boolean).join("\n\n");
-}
-
 function agentMessageScope(args: {
   readonly userLinkKind: "custom" | "official";
   readonly botId: string;
@@ -1741,46 +1700,25 @@ async function resetTelegramDmConversation(
     );
 }
 
-function telegramDeliveryTarget(args: {
+function telegramLaunchContext(args: {
   readonly source: TelegramAgentMessageArgs;
   readonly chatId: string;
   readonly rootMessageId: string | undefined;
-}): TelegramDeliveryTarget {
+  readonly context: string;
+  readonly prompt: string;
+  readonly userInfoExtras: TelegramUserInfoExtras;
+}) {
   return {
-    installationId: args.source.botId,
     chatId: args.chatId,
     messageId: String(args.source.message.message_id),
-    rootMessageId: args.rootMessageId ?? null,
-    userLinkId: args.source.userLink.id,
-    userLinkKind: args.source.userLinkKind,
-    agentId: args.source.composeId,
-    isDM: args.source.isDM,
-    ...(args.source.message.message_thread_id !== undefined
-      ? { messageThreadId: args.source.message.message_thread_id }
-      : {}),
-  };
-}
-
-function telegramLaunchContext(
-  args: {
-    readonly source: TelegramAgentMessageArgs;
-    readonly context: string;
-    readonly prompt: string;
-    readonly userInfoExtras: TelegramUserInfoExtras;
-  },
-  delivery: TelegramDeliveryTarget,
-) {
-  return {
-    chatId: delivery.chatId,
-    messageId: delivery.messageId,
-    isDm: delivery.isDM,
-    messageThreadId: delivery.messageThreadId ?? null,
+    isDm: args.source.isDM,
+    messageThreadId: args.source.message.message_thread_id ?? null,
     messageText: args.prompt,
     threadContext: args.context,
-    rootMessageId: delivery.rootMessageId,
-    thinkingMessageId: delivery.thinkingMessageId ?? null,
-    userLinkId: delivery.userLinkId,
-    userLinkKind: delivery.userLinkKind,
+    rootMessageId: args.rootMessageId ?? null,
+    thinkingMessageId: null,
+    userLinkId: args.source.userLink.id,
+    userLinkKind: args.source.userLinkKind,
     chatType: args.source.message.chat.type,
     senderUserId: args.userInfoExtras.telegramUserId ?? null,
     senderDisplayName: args.userInfoExtras.telegramDisplayName ?? null,
@@ -1850,27 +1788,8 @@ async function persistTelegramChatMessage(args: {
         });
   args.signal.throwIfAborted();
 
-  const delivery = telegramDeliveryTarget(args);
-  const appendSystemPrompt = buildTelegramPrompt(
-    {
-      botId: args.source.botId,
-      botUsername: args.source.botUsername,
-      chatId: args.chatId,
-      chatType: args.source.message.chat.type,
-      messageId: String(args.source.message.message_id),
-      rootMessageId: args.rootMessageId ?? null,
-      messageThreadId: args.source.message.message_thread_id,
-    },
-    args.context,
-  );
   const encryptedParams = await encryptQueuedUserMessageRunParams(
-    {
-      version: 1,
-      prompt: args.prompt,
-      appendSystemPrompt,
-      telegramDelivery: delivery,
-      userInfoExtras: args.userInfoExtras,
-    },
+    { version: 1 },
     {
       orgId: args.source.orgId,
       userId: args.source.userLink.vm0UserId,
@@ -1890,15 +1809,15 @@ async function persistTelegramChatMessage(args: {
           text: args.prompt,
           nonContentPart: createChatEventSourcePart({
             kind: "telegram",
-            chatId: delivery.chatId,
-            messageId: delivery.messageId,
-            isDm: delivery.isDM,
+            chatId: args.chatId,
+            messageId: String(args.source.message.message_id),
+            isDm: args.source.isDM,
           }),
         }),
         runId: null,
         triggerSource: "telegram",
         encryptedParams,
-        telegramContext: telegramLaunchContext(args, delivery),
+        telegramContext: telegramLaunchContext(args),
         createdAt: currentTime,
       },
       "id",

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -36,7 +36,11 @@ import {
 } from "../signals/services/zero-chat-event.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
-import { decryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
+import {
+  decryptQueuedUserMessageRunParams,
+  encryptQueuedUserMessageRunParams,
+} from "../signals/services/zero-chat-queued-event.service";
+import { loadTelegramQueuedLaunchMaterial } from "../signals/services/telegram-queued-launch-context.service";
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
@@ -667,6 +671,99 @@ export async function decryptChatEventInputParamsFixture(
     return null;
   }
   return await decryptQueuedUserMessageRunParams(row.encryptedParams, ctx);
+}
+
+async function pendingTelegramEventContext(eventId: string) {
+  const [row] = await db()
+    .select({
+      chatThreadId: chatEvents.chatThreadId,
+      contextId: chatTelegramContext.id,
+    })
+    .from(chatEvents)
+    .innerJoin(
+      chatTelegramContext,
+      and(
+        eq(chatTelegramContext.id, chatEvents.contextId),
+        eq(chatTelegramContext.chatThreadId, chatEvents.chatThreadId),
+      ),
+    )
+    .where(
+      and(
+        eq(chatEvents.id, eventId),
+        eq(chatEvents.contextType, "telegram"),
+        eq(chatEvents.triggerSource, "telegram"),
+        isNull(chatEvents.runId),
+      ),
+    )
+    .limit(1);
+  if (!row) {
+    throw new Error("Expected pending Telegram launch context");
+  }
+  return row;
+}
+
+export async function setTelegramThinkingMessageIdFixture(
+  eventId: string,
+  thinkingMessageId: string,
+): Promise<void> {
+  const event = await pendingTelegramEventContext(eventId);
+  await db()
+    .update(chatTelegramContext)
+    .set({ thinkingMessageId })
+    .where(eq(chatTelegramContext.id, event.contextId));
+}
+
+export async function replaceTelegramLaunchMaterialWithLegacyParamsFixture(
+  eventId: string,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly prompt: string;
+    readonly appendSystemPrompt: string;
+  },
+): Promise<void> {
+  const event = await pendingTelegramEventContext(eventId);
+  const material = await loadTelegramQueuedLaunchMaterial(db(), {
+    eventId,
+    chatThreadId: event.chatThreadId,
+    orgId: args.orgId,
+    userId: args.userId,
+  });
+  if (!material) {
+    throw new Error("Expected complete Telegram launch context");
+  }
+  const encryptedParams = await encryptQueuedUserMessageRunParams(
+    {
+      version: 1,
+      prompt: args.prompt,
+      appendSystemPrompt: args.appendSystemPrompt,
+      telegramDelivery: material.telegramDelivery,
+      userInfoExtras: material.userInfoExtras,
+    },
+    { orgId: args.orgId, userId: args.userId },
+  );
+  await db().transaction(async (tx) => {
+    await tx
+      .update(chatTelegramContext)
+      .set({
+        messageText: null,
+        threadContext: null,
+        rootMessageId: null,
+        thinkingMessageId: null,
+        userLinkId: null,
+        userLinkKind: null,
+        chatType: null,
+        senderUserId: null,
+        senderDisplayName: null,
+        senderUsername: null,
+        senderLanguage: null,
+      })
+      .where(eq(chatTelegramContext.id, event.contextId));
+    await tx
+      .update(chatEventInputParams)
+      .set({ encryptedParams })
+      .where(eq(chatEventInputParams.eventId, eventId));
+  });
 }
 
 export async function clearGitHubTriggerCommentBodyFixture(


### PR DESCRIPTION
Part of #24517. Follows #24541.

## Summary

- register a Telegram queued-launch loader in the shared claim-time registry
- rebuild prompt, append-system prompt, sender extras, and delivery from `chat_events`, `chat_telegram_context`, and configuration joins
- stop writing Telegram launch fields into `chat_event_input_params`; new rows retain only `{ version: 1 }`
- preserve the legacy encrypted-params fallback for pre-cutover queue items

## Claim-time derivation

The loader anchors the claimed event to its Telegram context and chat thread. The admission-time `message_text` and frozen `thread_context` remain snapshots; re-reading `telegram_messages` is intentionally avoided because later arrivals would change the prompt.

Configuration-level values are derived instead of stored:

- custom `installationId`, `bot_id`, and `bot_username` resolve through the stored custom user-link id and `telegram_installations`
- official delivery uses the official installation identity and runtime bot username configuration after validating the stored official user-link id
- `agentId` resolves from `chat_threads.agent_compose_id`

The reconstructed delivery always passes through `telegramDeliveryTargetSchema.parse`. Optional forum and thinking-message identifiers are restored from the context only when present.

## Compatibility and coverage

If a pre-cutover Telegram row has incomplete context but still has the legacy prompt, system prompt, and delivery blob, claim uses that fallback. New admissions no longer write those fields.

Route-level integration coverage verifies:

- byte-exact Telegram integration prompt suffixes for custom DMs, supergroups, forum topics, and official DMs
- frozen forum/DM history is used at claim
- replies target the stored chat and forum thread
- a stored `thinking_message_id` is propagated through delivery and cleared
- custom and official configuration joins
- new encrypted params contain only `{ version: 1 }`
- a synthetic pre-cutover item still claims through the legacy fallback

The chat-event queue monitor is unchanged.

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- `git diff --check`

Per the issue rollout instructions, I did not run the full local Vitest suite or start a dev server; PR CI owns integration validation.
