### PR TITLE
perf(python): strip discarded log query before parsing

### DIFF
--- a/crates/runner/mitm-addon/src/network_log_sanitization.py
+++ b/crates/runner/mitm-addon/src/network_log_sanitization.py
@@ -25,14 +25,16 @@ def _sanitize_netloc_for_network_log(netloc: str) -> str:
 
 
 def _strip_query_fragment_for_network_log(value: str) -> str:
-    cut_points = [index for marker in ("?", "#") if (index := value.find(marker)) != -1]
-    if not cut_points:
-        return value
-    return value[: min(cut_points)]
+    query_start = value.find("?")
+    fragment_start = value.find("#", 0, query_start if query_start >= 0 else len(value))
+    if fragment_start >= 0:
+        return value[:fragment_start]
+    if query_start >= 0:
+        return value[:query_start]
+    return value
 
 
 def _sanitize_url_text_fallback_for_network_log(value: str) -> str:
-    value = _strip_query_fragment_for_network_log(value)
     scheme, scheme_sep, rest = value.partition("://")
     if scheme_sep:
         netloc, sep, path = rest.partition("/")
@@ -82,11 +84,13 @@ def sanitize_url_for_network_log(value: str) -> str:
 
     Runtime metadata can keep raw URLs because firewall/auth and connector
     billing may need query parameters. Persistent logs do not. This sanitizer
-    also removes userinfo from malformed HTTP(S) authority positions, but it
+    discards query and fragment contents before URL preprocessing and parsing.
+    It also removes userinfo from malformed HTTP(S) authority positions, but
     still preserves ordinary paths for request diagnostics. It is not a general
     sanitizer for arbitrary captured header values or path contents.
     """
-    normalized_value = _normalize_for_urlsplit(value)
+    retained_value = _strip_query_fragment_for_network_log(value)
+    normalized_value = _normalize_for_urlsplit(retained_value)
     try:
         parts = split_runtime_url(normalized_value)
     except ValueError:

--- a/crates/runner/mitm-addon/tests/test_response_handler_logging.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_logging.py
@@ -1,6 +1,7 @@
 """Response hook integration tests for network and proxy logging."""
 
 import time
+import tracemalloc
 import urllib.parse
 from pathlib import Path
 
@@ -229,6 +230,10 @@ def test_response_log_serializes_common_metadata_independent_of_firewall_context
             "https://target.example.com:9443/path",
         ),
         (
+            "https://target.example.com:9443/path#fragment?access_token=secret",
+            "https://target.example.com:9443/path",
+        ),
+        (
             "https://[invalid.example.com/path?access_token=secret#fragment",
             "https://[invalid.example.com/path",
         ),
@@ -282,8 +287,9 @@ def test_network_log_target_url_strips_query_and_fragment(
     assert flow.metadata[metadata_keys.NETWORK_LOG_TARGET]["url"] == raw_url
 
 
-def test_network_log_does_not_cache_runtime_url(tmp_path, real_flow, mitm_ctx):
-    raw_url = f"https://target.example.com/path?payload={'x' * 200_000}#fragment"
+def test_network_log_discards_large_query_before_url_processing(tmp_path, real_flow, mitm_ctx):
+    retained_url = "https://target.example.com/path"
+    raw_url = f"{retained_url}?payload={'x' * 200_000}"
     flow = real_flow(with_response=False, host="target.example.com")
     log_path = str(tmp_path / "network.jsonl")
     flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
@@ -303,15 +309,22 @@ def test_network_log_does_not_cache_runtime_url(tmp_path, real_flow, mitm_ctx):
         urllib.parse.urlsplit("https://stable-config.example.com")
         stable_cache = urllib.parse.urlsplit.cache_info()
 
-        with mitm_ctx():
-            mitm_addon.response(flow)
+        tracemalloc.start()
+        try:
+            with mitm_ctx():
+                mitm_addon.response(flow)
+            peak_allocated_bytes = tracemalloc.get_traced_memory()[1]
+        finally:
+            tracemalloc.stop()
 
         assert urllib.parse.urlsplit.cache_info() == stable_cache
     finally:
         urllib.parse.urlsplit.cache_clear()
 
+    # Whole-query normalization or parsing materializes at least one query-sized intermediate.
+    assert peak_allocated_bytes < len(raw_url)
     [entry] = read_jsonl_entries_after_flush(Path(log_path))
-    assert entry["url"] == "https://target.example.com/path"
+    assert entry["url"] == retained_url
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- discard network-log query and fragment suffixes before URL compatibility normalization and parsing
- bound fragment lookup to the retained prefix when a query delimiter is already known
- preserve malformed-authority, userinfo-redaction, uncached parsing, and raw runtime metadata behavior
- cover fragment-before-query ordering and prevent query-sized response-hook allocations

## Scope

This changes only the Python mitmproxy addon's persistent-log URL projection and its response-hook integration coverage. It does not change runtime request URLs, firewall/auth/connector behavior, API contracts, persisted schemas, dependencies, or deployment ordering.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,551 passed)
- `lefthook run pre-commit --file crates/runner/mitm-addon/src/network_log_sanitization.py --file crates/runner/mitm-addon/tests/test_response_handler_logging.py`
- `git diff --check`

Closes #24537
