### PR TITLE
test(api): stabilize cancellation recovery synchronization

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -2406,6 +2406,7 @@ describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
       threadId: run.threadId,
       prompt: "continue after the concurrent completion",
     });
+    await flushWaitUntilForTest();
     const checkpointGate = await holdCheckpointReadsFixture({
       signal: context.signal,
     });
@@ -2414,18 +2415,21 @@ describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
       await checkpointGate.done;
     });
 
-    const completionPromise = webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0, lastEventSequence: 0 },
-      sandboxHeaders,
-      [200],
-    );
-    await expect
-      .poll(checkpointGate.blockedWaiterCount)
-      .toBeGreaterThanOrEqual(1);
-    await api.requestCancelRun(actor, run.runId, [200]);
-    checkpointGate.release();
-    await checkpointGate.done;
-    const completion = await completionPromise;
+    const [completion] = await Promise.all([
+      webhooks.requestAgentComplete(
+        { runId: run.runId, exitCode: 0, lastEventSequence: 0 },
+        sandboxHeaders,
+        [200],
+      ),
+      (async () => {
+        await expect
+          .poll(checkpointGate.blockedWaiterCount)
+          .toBeGreaterThanOrEqual(1);
+        await api.requestCancelRun(actor, run.runId, [200]);
+        checkpointGate.release();
+        await checkpointGate.done;
+      })(),
+    ]);
     expect(completion.body).toStrictEqual({
       success: true,
       status: "failed",


### PR DESCRIPTION
## Summary

- flush tracked chat `waitUntil` work before installing the checkpoint read lock fixture
- own the completion request and the lock-observer/cancellation branch together with `Promise.all`
- keep the existing cancellation recovery and queued replacement assertions unchanged

## Failure evidence

- Trigger: [Turbo run 30738332468](https://github.com/vm0-ai/vm0/actions/runs/30738332468), `merge_group`, SHA `49267889a55738ea62ea20f9cb668753edc4698b`
- First causal failure: `CHAT-02/RUN-03: cancellation recovery barrier > records recovery when completion races the cancellation transition` timed out with `checkpointGate.blockedWaiterCount` still at `0`
- The later `AbortError: Aborted due to finished test` and unhandled completion rejection were teardown consequences after the poll failure
- The same test passed in adjacent runs [30738047513](https://github.com/vm0-ai/vm0/actions/runs/30738047513), [30738192265](https://github.com/vm0-ai/vm0/actions/runs/30738192265), and [30738406909](https://github.com/vm0-ai/vm0/actions/runs/30738406909)

## Classification

Flaky test caused by missing explicit synchronization and delayed Promise ownership. The merge-group PR did not change this test or its lock fixture, while adjacent base and main executions passed.

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` (12/12 tasks passed)
- `pnpm knip`
- all package type checks, including isolated platform and API checks
- target test passed 5 consecutive isolated runs with the root `api` Vitest project
- Lefthook pre-commit and commit-message checks passed

## Limitations

The full local Vitest suite was not run, per repository guidance; the PR pipeline provides full-suite coverage.