### PR TITLE
refactor: require telegram launch context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -24,7 +24,6 @@ import {
   findTelegramChatEventByPromptFixture,
   readChatEventContextFixture,
   readChatEventInputParamsFixture,
-  replaceTelegramLaunchMaterialWithLegacyParamsFixture,
   setTelegramThinkingMessageIdFixture,
 } from "../../../test-fixtures/chat-events";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -1389,7 +1388,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     await runsApi.requestCancelRun(actorForFixture(fixture), runId, [200]);
   });
 
-  it("rebuilds queued Telegram launch material and preserves the legacy fallback", async () => {
+  it("rebuilds queued Telegram launch material from context", async () => {
     const runnerGroup = configureCanonicalTelegramRunner();
     const fixture = await trackFixture(
       seedTelegramPostFixture({ linkTelegramUser: true }),
@@ -1494,50 +1493,6 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       readChatEventInputParamsFixture(queuedParams.eventId),
     ).resolves.toBeNull();
 
-    const legacyQueuedPrompt = "legacy Telegram queue fallback";
-    expect(
-      (
-        await postWebhook({
-          telegramBotId: fixture.telegramBotId,
-          secret: fixture.webhookSecret,
-          body: {
-            update_id: 203,
-            message: {
-              message_id: 2203,
-              chat: { id: chatId, type: "private" },
-              from: {
-                id: Number(fixture.telegramUserId),
-                username: "alice",
-                first_name: "Alice",
-              },
-              text: legacyQueuedPrompt,
-            },
-          },
-        })
-      ).status,
-    ).toBe(200);
-    await flushWaitUntilForTest();
-    const legacyQueuedParams =
-      await findPendingChatEventInputParamsByPromptFixture(legacyQueuedPrompt);
-    if (!legacyQueuedParams) {
-      throw new Error("Expected legacy Telegram fallback queue item");
-    }
-    await expect(
-      decryptChatEventInputParamsFixture(legacyQueuedParams.eventId, {
-        orgId: fixture.orgId,
-        userId: fixture.userId,
-      }),
-    ).resolves.toStrictEqual({ version: 1 });
-    await replaceTelegramLaunchMaterialWithLegacyParamsFixture(
-      legacyQueuedParams.eventId,
-      {
-        orgId: fixture.orgId,
-        userId: fixture.userId,
-        prompt: "legacy Telegram launch prompt",
-        appendSystemPrompt: "legacy Telegram system prompt",
-      },
-    );
-
     const queuedClaim = await claimTelegramRun(queuedRunId, runnerGroup);
     expect(queuedClaim.prompt).toBe(queuedPrompt);
     const queuedThreadContext = queuedLaunchContext?.telegramThreadContext;
@@ -1567,30 +1522,6 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       chat_id: String(chatId),
       message_id: 701,
     });
-
-    let legacyRunId: string | null = null;
-    await expect
-      .poll(async () => {
-        legacyRunId =
-          (await telegramPostRunState(fixture, "legacy Telegram launch prompt"))
-            .run?.id ?? null;
-        return legacyRunId;
-      })
-      .toStrictEqual(expect.any(String));
-    if (!legacyRunId) {
-      throw new Error("Expected the legacy Telegram fallback run");
-    }
-    const legacyClaim = await claimTelegramRun(legacyRunId, runnerGroup);
-    expect(legacyClaim.prompt).toBe("legacy Telegram launch prompt");
-    expectExactSystemPromptFragment(
-      legacyClaim.appendSystemPrompt,
-      "legacy Telegram system prompt",
-    );
-    await runsApi.requestCancelRun(
-      actorForFixture(fixture),
-      legacyRunId,
-      [200],
-    );
   });
 
   it("shares one canonical DM session with web and keeps the legacy cursor monotonic", async () => {

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2684,10 +2684,6 @@ function loadQueuedMessageSessionState(
   );
 }
 
-type QueuedSourceParams = Awaited<
-  ReturnType<typeof decryptQueuedUserMessageRunParams>
->;
-
 type QueuedIntegrationDeliveries = Pick<
   CreateQueuedChatRunInput,
   | "slackDelivery"
@@ -2753,7 +2749,6 @@ function launchLoader<Material extends NativeQueuedLaunchMaterial>(
 
 async function resolveQueuedLaunchMaterial(
   args: CreateQueuedChatRunInputArgs,
-  sourceParams: QueuedSourceParams,
 ): Promise<QueuedLaunchMaterial | null> {
   const launchLoaders: Partial<Record<TriggerSource, LaunchLoader>> = {
     slack: launchLoader(loadSlackQueuedLaunchMaterial, (material) => {
@@ -2804,45 +2799,19 @@ async function resolveQueuedLaunchMaterial(
   if (material) {
     return material;
   }
-  if (
-    args.queuedMessage.triggerSource === "telegram" &&
-    sourceParams?.prompt !== undefined &&
-    sourceParams.appendSystemPrompt !== undefined &&
-    sourceParams.telegramDelivery
-  ) {
-    return null;
-  }
   throw new Error(
     `${args.queuedMessage.triggerSource} queue item is missing launch material`,
   );
 }
 
-type SourceParamDeliveryLoader = (
-  sourceParams: QueuedSourceParams,
-) => QueuedIntegrationDeliveries;
-
 function queuedIntegrationDeliveries(
-  triggerSource: QueuedUserMessage["triggerSource"],
-  sourceParams: QueuedSourceParams,
   launchMaterial: QueuedLaunchMaterial | null,
 ): QueuedIntegrationDeliveries {
-  const sourceParamDeliveryLoaders: Partial<
-    Record<TriggerSource, SourceParamDeliveryLoader>
-  > = {
-    telegram: (params) => {
-      return { telegramDelivery: params?.telegramDelivery };
-    },
-  };
-  return (
-    launchMaterial?.delivery ??
-    sourceParamDeliveryLoaders[triggerSource]?.(sourceParams) ??
-    {}
-  );
+  return launchMaterial?.delivery ?? {};
 }
 
 interface QueuedAdmissionFailureResolverArgs {
   readonly args: CreateQueuedChatRunInputArgs;
-  readonly sourceParams: QueuedSourceParams;
   readonly launchMaterial: QueuedLaunchMaterial | null;
   readonly error: QueuedMessageModelRouteError;
 }
@@ -2973,7 +2942,6 @@ function githubQueuedMessageAdmissionFailure(
 
 function queuedMessageAdmissionFailure(
   args: CreateQueuedChatRunInputArgs,
-  sourceParams: QueuedSourceParams,
   launchMaterial: QueuedLaunchMaterial | null,
   error: QueuedMessageModelRouteError,
 ): QueuedMessageAdmissionFailure | null {
@@ -2997,8 +2965,7 @@ function queuedMessageAdmissionFailure(
     telegram: (resolverArgs) => {
       return telegramQueuedMessageAdmissionFailure(
         resolverArgs.args,
-        resolverArgs.launchMaterial?.delivery.telegramDelivery ??
-          resolverArgs.sourceParams?.telegramDelivery,
+        resolverArgs.launchMaterial?.delivery.telegramDelivery,
         resolverArgs.error,
       );
     },
@@ -3025,33 +2992,20 @@ function queuedMessageAdmissionFailure(
     },
   };
   const resolve = admissionFailureResolvers[args.queuedMessage.triggerSource];
-  return resolve?.({ args, sourceParams, launchMaterial, error }) ?? null;
+  return resolve?.({ args, launchMaterial, error }) ?? null;
 }
 
 function queuedMessagePrompt(args: {
-  readonly triggerSource: QueuedUserMessage["triggerSource"];
   readonly launchMaterial: QueuedLaunchMaterial | null;
-  readonly sourceParams: QueuedSourceParams;
   readonly projectedPrompt: string;
 }): string {
-  if (args.launchMaterial) {
-    return args.launchMaterial.prompt;
-  }
-  if (args.triggerSource === "telegram") {
-    return args.sourceParams?.prompt ?? "";
-  }
-  return args.projectedPrompt;
+  return args.launchMaterial?.prompt ?? args.projectedPrompt;
 }
 
 function queuedIntegrationPrompt(args: {
   readonly launchMaterial: QueuedLaunchMaterial | null;
-  readonly sourceParams: QueuedSourceParams;
 }): string {
-  return (
-    args.launchMaterial?.appendSystemPrompt ??
-    args.sourceParams?.appendSystemPrompt ??
-    buildWebChatPrompt()
-  );
+  return args.launchMaterial?.appendSystemPrompt ?? buildWebChatPrompt();
 }
 
 function resolveQueuedMessageGenerationTemplatePrompt(args: {
@@ -3086,11 +3040,7 @@ async function loadQueuedRunMaterial(args: CreateQueuedChatRunInputArgs) {
   if (args.queuedMessage.triggerSource !== "web" && !sourceParams) {
     throw new Error("Canonical integration queue item is missing run params");
   }
-  const launchMaterial = await resolveQueuedLaunchMaterial(args, sourceParams);
-  return {
-    sourceParams,
-    launchMaterial,
-  };
+  return await resolveQueuedLaunchMaterial(args);
 }
 
 function queuedUserMessageProjection(
@@ -3110,21 +3060,18 @@ function queuedUserMessageProjection(
 }
 
 function queuedIntegrationLaunchFields(
-  triggerSource: QueuedUserMessage["triggerSource"],
-  sourceParams: QueuedSourceParams,
   launchMaterial: QueuedLaunchMaterial | null,
 ) {
   return {
-    ...queuedIntegrationDeliveries(triggerSource, sourceParams, launchMaterial),
-    userInfoExtras:
-      launchMaterial?.userInfoExtras ?? sourceParams?.userInfoExtras,
+    ...queuedIntegrationDeliveries(launchMaterial),
+    userInfoExtras: launchMaterial?.userInfoExtras,
   };
 }
 
 async function buildCreateQueuedChatRunInput(
   args: CreateQueuedChatRunInputArgs,
 ): Promise<CreateQueuedChatRunInput | QueuedMessageAdmissionFailure | null> {
-  const { sourceParams, launchMaterial } = await loadQueuedRunMaterial(args);
+  const launchMaterial = await loadQueuedRunMaterial(args);
   const modelRouteResolution = await resolveQueuedMessageModelRoute({
     db: args.db,
     threadId: args.threadId,
@@ -3136,7 +3083,6 @@ async function buildCreateQueuedChatRunInput(
   if ("error" in modelRouteResolution) {
     return queuedMessageAdmissionFailure(
       args,
-      sourceParams,
       launchMaterial,
       modelRouteResolution.error,
     );
@@ -3195,9 +3141,7 @@ async function buildCreateQueuedChatRunInput(
     },
   );
   const prompt = queuedMessagePrompt({
-    triggerSource: args.queuedMessage.triggerSource,
     launchMaterial,
-    sourceParams,
     projectedPrompt: userMessageProjection.agentPrompt,
   });
 
@@ -3209,7 +3153,6 @@ async function buildCreateQueuedChatRunInput(
     appendSystemPrompt: buildAppendSystemPrompt(
       queuedIntegrationPrompt({
         launchMaterial,
-        sourceParams,
       }),
       incompleteContext,
       priorContext,
@@ -3229,11 +3172,7 @@ async function buildCreateQueuedChatRunInput(
       FeatureSwitchKey.RealAgentInPreview,
       featureSwitchContext,
     ),
-    ...queuedIntegrationLaunchFields(
-      args.queuedMessage.triggerSource,
-      sourceParams,
-      launchMaterial,
-    ),
+    ...queuedIntegrationLaunchFields(launchMaterial),
     apiStartTime: args.queuedMessage.createdAt.getTime(),
   };
 }

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -63,7 +63,6 @@ import {
   encryptPersistentSecretsMap,
 } from "./crypto.utils";
 import { noGoalChangeAfterQueueEvent } from "./chat-goal-queue.service";
-import { telegramDeliveryTargetSchema } from "./telegram-chat-callback-payload";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { resolveArtifactObject$ } from "./artifact-storage.service";
 import { attachCanonicalWebInputAssetsToEvent } from "./canonical-asset.service";
@@ -84,19 +83,6 @@ const queuedUserMessageTriggerSourceSchema = z.enum([
 
 const queuedUserMessageRunParamsSchema = z.object({
   version: z.literal(1),
-  prompt: z.string().optional(),
-  appendSystemPrompt: z.string().optional(),
-  telegramDelivery: telegramDeliveryTargetSchema.optional(),
-  userInfoExtras: z
-    .object({
-      slackDisplayName: z.string().optional(),
-      slackUserId: z.string().optional(),
-      telegramDisplayName: z.string().optional(),
-      telegramUsername: z.string().optional(),
-      telegramUserId: z.string().optional(),
-      telegramLanguage: z.string().optional(),
-    })
-    .optional(),
 });
 
 type QueuedUserMessageRunParams = z.infer<

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -36,11 +36,7 @@ import {
 } from "../signals/services/zero-chat-event.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
-import {
-  decryptQueuedUserMessageRunParams,
-  encryptQueuedUserMessageRunParams,
-} from "../signals/services/zero-chat-queued-event.service";
-import { loadTelegramQueuedLaunchMaterial } from "../signals/services/telegram-queued-launch-context.service";
+import { decryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
@@ -676,7 +672,6 @@ export async function decryptChatEventInputParamsFixture(
 async function pendingTelegramEventContext(eventId: string) {
   const [row] = await db()
     .select({
-      chatThreadId: chatEvents.chatThreadId,
       contextId: chatTelegramContext.id,
     })
     .from(chatEvents)
@@ -711,59 +706,6 @@ export async function setTelegramThinkingMessageIdFixture(
     .update(chatTelegramContext)
     .set({ thinkingMessageId })
     .where(eq(chatTelegramContext.id, event.contextId));
-}
-
-export async function replaceTelegramLaunchMaterialWithLegacyParamsFixture(
-  eventId: string,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly prompt: string;
-    readonly appendSystemPrompt: string;
-  },
-): Promise<void> {
-  const event = await pendingTelegramEventContext(eventId);
-  const material = await loadTelegramQueuedLaunchMaterial(db(), {
-    eventId,
-    chatThreadId: event.chatThreadId,
-    orgId: args.orgId,
-    userId: args.userId,
-  });
-  if (!material) {
-    throw new Error("Expected complete Telegram launch context");
-  }
-  const encryptedParams = await encryptQueuedUserMessageRunParams(
-    {
-      version: 1,
-      prompt: args.prompt,
-      appendSystemPrompt: args.appendSystemPrompt,
-      telegramDelivery: material.telegramDelivery,
-      userInfoExtras: material.userInfoExtras,
-    },
-    { orgId: args.orgId, userId: args.userId },
-  );
-  await db().transaction(async (tx) => {
-    await tx
-      .update(chatTelegramContext)
-      .set({
-        messageText: null,
-        threadContext: null,
-        rootMessageId: null,
-        thinkingMessageId: null,
-        userLinkId: null,
-        userLinkKind: null,
-        chatType: null,
-        senderUserId: null,
-        senderDisplayName: null,
-        senderUsername: null,
-        senderLanguage: null,
-      })
-      .where(eq(chatTelegramContext.id, event.contextId));
-    await tx
-      .update(chatEventInputParams)
-      .set({ encryptedParams })
-      .where(eq(chatEventInputParams.eventId, eventId));
-  });
 }
 
 export async function clearGitHubTriggerCommentBodyFixture(


### PR DESCRIPTION
## Summary

PR 3 of 3 for #24517, step 7 of #24362.

- remove the Telegram launch-material fallback from `chat_event_input_params`
- require Telegram claim, prompt assembly, delivery reconstruction, admission-failure delivery, and user extras to come from `chat_events` plus `chat_telegram_context`
- contract the shared queued-run wire schema to `{ version: 1 }`, since Telegram was the last source using the legacy prompt/system-prompt/delivery/user-info fields
- remove the legacy-row test injector while retaining context-backed DM queue, frozen thread snapshot, delivery, and thinking-message cleanup coverage

`cron-monitor-chat-event-queue` is unchanged and remains scheduled for the unified step 10 rebuild.

## Production drain gate

The PR 2 merge commit `7d47941a345cc8b4c0ec1418dbb40cb751b7335a` completed the production `deploy-api` job before the gate was measured.

Read-only MaskDB aggregates on `vm0-prod-ro` at 2026-08-02 close the Telegram queue identity exactly:

- original `input.prompt` rows with Telegram context and no run: **0**
- run replacements (`input.prompt` with Telegram context and a run): **0**
- rejected replacements (`input.rejected` with Telegram context): **0**
- control revocations (`control.revoke` with Telegram context): **0**
- run replacements + rejected replacements + revocations: **0**

Replacement events reuse the target's Telegram context, and `chat_events_revokes_event_id_unique` makes each replacement/revocation one-to-one with its original event. The identity therefore closes at **0 = 0 + 0 + 0**. A separate legacy-oriented aggregate also found **0** pending `input.prompt` rows with `trigger_source = telegram`, so no current Telegram queue row depends on the removed blob fields.

## Compatibility

Installation ID, bot ID, bot username, and agent ID remain configuration-derived at claim from Telegram installation/user-link configuration and `chat_threads.agent_compose_id`; they are not stored in context. Per-firing delivery is reconstructed from context columns and remains validated by `telegramDeliveryTargetSchema.parse`.

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- Prettier and `git diff --check`

No local Vitest suite or dev server was run; PR CI is the authoritative integration check.

Closes #24517
