### PR TITLE
fix(runner): preserve full network log urls

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -610,7 +610,7 @@ def _http_network_log_entry(
         "host": host,
         "port": port,
         "method": flow.request.method,
-        "url": network_log_sanitization.sanitize_url_for_network_log(url),
+        "url": network_log_sanitization.sanitize_request_url_for_network_log(url),
         "status": status_code,
         "latency_ms": latency_ms,
         "request_size": request_size,

--- a/crates/runner/mitm-addon/src/network_log_sanitization.py
+++ b/crates/runner/mitm-addon/src/network_log_sanitization.py
@@ -80,14 +80,17 @@ def _sanitize_malformed_authority_for_network_log(
 
 
 def sanitize_url_for_network_log(value: str) -> str:
-    """Return a primary request/proxy URL string for persistent logs.
+    """Return a URL string without credentials or query data for diagnostics.
 
     Runtime metadata can keep raw URLs because firewall/auth and connector
-    billing may need query parameters. Persistent logs do not. This sanitizer
-    discards query and fragment contents before URL preprocessing and parsing.
-    It also removes userinfo from malformed HTTP(S) authority positions, but
-    still preserves ordinary paths for request diagnostics. It is not a general
-    sanitizer for arbitrary captured header values or path contents.
+    billing may need query parameters. Captured URL-bearing headers and proxy
+    diagnostics do not, so this sanitizer discards query and fragment contents
+    before URL preprocessing and parsing. Top-level HTTP network entries instead
+    use ``sanitize_request_url_for_network_log`` to retain the complete request
+    URL. This sanitizer also removes userinfo from malformed HTTP(S) authority
+    positions, but it still preserves ordinary paths for request diagnostics. It
+    is not a general sanitizer for arbitrary captured header values or path
+    contents.
     """
     retained_value = _strip_query_fragment_for_network_log(value)
     normalized_value = _normalize_for_urlsplit(retained_value)
@@ -102,3 +105,10 @@ def sanitize_url_for_network_log(value: str) -> str:
 
     netloc = _sanitize_netloc_for_network_log(parts.netloc)
     return urllib.parse.urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+
+
+def sanitize_request_url_for_network_log(value: str) -> str:
+    """Preserve a complete request URL while removing URL userinfo."""
+    retained_value = _strip_query_fragment_for_network_log(value)
+    suffix = value[len(retained_value) :]
+    return f"{sanitize_url_for_network_log(retained_value)}{suffix}"

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -490,7 +490,7 @@ class TestErrorHandler:
         assert entry["action"] == "ALLOW"
         assert entry["host"] == "slack.com"
         assert entry["method"] == "POST"
-        assert entry["url"] == "https://slack.com/api/chat.postMessage"
+        assert entry["url"] == raw_url
         assert entry["status"] == 0
         assert entry["response_size"] == 0
         assert entry["error"] == "connection reset by peer"

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -112,9 +112,7 @@ async def test_authority_validation_deny_response_logs_network_target(
     assert entry["action"] == "DENY"
     assert entry["host"] == "attacker.example.com"
     assert entry["port"] == 8443
-    assert entry["url"] == "https://attacker.example.com:8443/repos"
-    assert "code=secret" not in entry["url"]
-    assert "#frag" not in entry["url"]
+    assert entry["url"] == raw_url
     assert entry["status"] == 403
     assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
 

--- a/crates/runner/mitm-addon/tests/test_response_handler_logging.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_logging.py
@@ -227,39 +227,39 @@ def test_response_log_serializes_common_metadata_independent_of_firewall_context
     [
         (
             "https://target.example.com:9443/path?access_token=secret#fragment",
-            "https://target.example.com:9443/path",
+            "https://target.example.com:9443/path?access_token=secret#fragment",
         ),
         (
             "https://target.example.com:9443/path#fragment?access_token=secret",
-            "https://target.example.com:9443/path",
+            "https://target.example.com:9443/path#fragment?access_token=secret",
         ),
         (
             "https://[invalid.example.com/path?access_token=secret#fragment",
-            "https://[invalid.example.com/path",
+            "https://[invalid.example.com/path?access_token=secret#fragment",
         ),
         (
             "https://user:pass@[invalid.example.com/path?access_token=secret#fragment",
-            "https://[invalid.example.com/path",
+            "https://[invalid.example.com/path?access_token=secret#fragment",
         ),
         (
             "//user:pass@[invalid.example.com/path?access_token=secret#fragment",
-            "//[invalid.example.com/path",
+            "//[invalid.example.com/path?access_token=secret#fragment",
         ),
         (
             "https://user:pass@target.example.com:9443/path?access_token=secret#fragment",
-            "https://target.example.com:9443/path",
+            "https://target.example.com:9443/path?access_token=secret#fragment",
         ),
         (
             "https:////user:pass@target.example.com:9443/path?access_token=secret#fragment",
-            "https://target.example.com:9443/path",
+            "https://target.example.com:9443/path?access_token=secret#fragment",
         ),
         (
             "https://target.example.com:9443/users/alice@example.com?access_token=secret#fragment",
-            "https://target.example.com:9443/users/alice@example.com",
+            "https://target.example.com:9443/users/alice@example.com?access_token=secret#fragment",
         ),
     ],
 )
-def test_network_log_target_url_strips_query_and_fragment(
+def test_network_log_target_url_preserves_query_and_fragment_but_redacts_userinfo(
     tmp_path, real_flow, mitm_ctx, raw_url, expected_url
 ):
     flow = real_flow(with_response=False, host="request.example.com")
@@ -287,9 +287,8 @@ def test_network_log_target_url_strips_query_and_fragment(
     assert flow.metadata[metadata_keys.NETWORK_LOG_TARGET]["url"] == raw_url
 
 
-def test_network_log_discards_large_query_before_url_processing(tmp_path, real_flow, mitm_ctx):
-    retained_url = "https://target.example.com/path"
-    raw_url = f"{retained_url}?payload={'x' * 200_000}"
+def test_network_log_preserves_large_url_without_caching_runtime_url(tmp_path, real_flow, mitm_ctx):
+    raw_url = f"https://target.example.com/path?payload={'x' * 200_000}#fragment"
     flow = real_flow(with_response=False, host="target.example.com")
     log_path = str(tmp_path / "network.jsonl")
     flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
@@ -303,6 +302,34 @@ def test_network_log_discards_large_query_before_url_processing(tmp_path, real_f
         port=443,
     )
     flow.response = tutils.tresp(status_code=200, headers=header_map({"content-length": "0"}))
+
+    urllib.parse.urlsplit.cache_clear()
+    try:
+        urllib.parse.urlsplit("https://stable-config.example.com")
+        stable_cache = urllib.parse.urlsplit.cache_info()
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        assert urllib.parse.urlsplit.cache_info() == stable_cache
+    finally:
+        urllib.parse.urlsplit.cache_clear()
+
+    [entry] = read_jsonl_entries_after_flush(Path(log_path))
+    assert entry["url"] == raw_url
+
+
+def test_proxy_log_discards_large_query_before_url_processing(tmp_path, real_flow, mitm_ctx):
+    retained_url = "https://target.example.com/path"
+    raw_url = f"{retained_url}?payload={'x' * 200_000}"
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    flow = real_flow(with_response=False, host="target.example.com")
+    flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
+    flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow.metadata[metadata_keys.ORIGINAL_URL] = raw_url
+    flow.response = tutils.tresp(status_code=500, headers=http.Headers())
 
     urllib.parse.urlsplit.cache_clear()
     try:
@@ -323,8 +350,8 @@ def test_network_log_discards_large_query_before_url_processing(tmp_path, real_f
 
     # Whole-query normalization or parsing materializes at least one query-sized intermediate.
     assert peak_allocated_bytes < len(raw_url)
-    [entry] = read_jsonl_entries_after_flush(Path(log_path))
-    assert entry["url"] == retained_url
+    [entry] = read_jsonl_entries_after_flush(proxy_log_path)
+    assert entry["message"] == f"Response 500: {retained_url}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- preserve the complete original request URL, including query and fragment data, in top-level HTTP network logs
- continue removing URL userinfo and sanitizing query data from captured URL-bearing headers and proxy diagnostics
- retain prefix-first URL sanitization for log paths that intentionally discard query and fragment data

## Scope

This changes only the runner mitmproxy addon's persistent HTTP network-log projection and its integration coverage. It does not change request routing, firewall or authentication behavior, API schemas, captured-header policy, proxy-log policy, dependencies, or deployment ordering. Runner-injected connector credentials remain excluded because the network-log target is captured before authentication mutates the request.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,554 passed)
