### PR TITLE
fix(runner): emit distinct sandbox reuse result reasons

### DIFF
--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -37,9 +37,8 @@ pub const SANDBOX_ID_ENV: &str = "VM0_SANDBOX_ID";
 
 /// Wire value for the runner's sandbox-reuse decision.
 ///
-/// `reused` means an idle VM was unparked. Other values name the branch that
-/// caused the runner to create a fresh sandbox instead, such as `poolMiss` or
-/// `noSessionId`.
+/// `reused` means an idle VM was unparked. Other values describe why reuse did
+/// not happen, such as `poolMiss`, `noReuseKey`, or `invalidResumeSessionId`.
 pub const SANDBOX_REUSE_RESULT_ENV: &str = "VM0_SANDBOX_REUSE_RESULT";
 
 /// Logical run-payload field name for the user prompt.

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -168,7 +168,7 @@ pub(super) async fn handle_discovered_job(
                 claimed,
                 cancellation,
                 LocalAdmissionResource::Reusable(reservation),
-                SandboxReuseResult::NoSessionId,
+                SandboxReuseResult::InvalidResumeSessionId,
                 error,
                 &mut ctx,
             )
@@ -696,8 +696,10 @@ async fn activate_reserved_idle(
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
 
     if !resume_session_valid || requested_reuse_key != Some(reserved_reuse_key.as_str()) {
-        let reuse_result = if requested_reuse_key.is_none() || !resume_session_valid {
-            SandboxReuseResult::NoSessionId
+        let reuse_result = if !resume_session_valid {
+            SandboxReuseResult::InvalidResumeSessionId
+        } else if requested_reuse_key.is_none() {
+            SandboxReuseResult::NoReuseKey
         } else {
             SandboxReuseResult::PoolMiss
         };
@@ -865,20 +867,14 @@ async fn try_reuse_from_pool(
         return (
             None,
             job_lease,
-            SandboxReuseResult::NoSessionId,
+            SandboxReuseResult::InvalidResumeSessionId,
             None,
             false,
         );
     }
     let Some(reuse_key) = context.reuse_key() else {
         pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
-        return (
-            None,
-            job_lease,
-            SandboxReuseResult::NoSessionId,
-            None,
-            false,
-        );
+        return (None, job_lease, SandboxReuseResult::NoReuseKey, None, false);
     };
     // Take the entry under the pool lock, then drop the lock before any awaits
     // so unpark does not block other take/park operations.

--- a/crates/runner/src/cmd/start/tests/idle_reuse/affinity.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/affinity.rs
@@ -1,7 +1,8 @@
 use super::super::super::*;
 use super::super::support::{
-    context_with_session, minimal_context, mock_run_config, push_job, seed_idle_pool, shutdown,
-    test_profiles, two_profiles, wait_budget_count, wait_idle_pool_reuse_keys,
+    context_with_session, minimal_context, mock_run_config, mock_run_config_with_overrides,
+    push_job, seed_idle_pool, shutdown, test_profiles, two_profiles, wait_budget_count,
+    wait_idle_pool_reuse_keys,
 };
 
 use crate::types::SandboxReuseResult;
@@ -66,16 +67,15 @@ async fn session_affinity_reuses_idle_vm() {
 }
 
 // -----------------------------------------------------------------------
-// Test 13b: Job with no session reports NoSessionId
+// Test 13b: Job with no reuse key reports NoReuseKey
 // -----------------------------------------------------------------------
 
 #[tokio::test(start_paused = true)]
-async fn job_without_session_reports_no_session_id() {
+async fn job_without_reuse_key_reports_no_reuse_key() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
 
     let run_handle = tokio::spawn(run(config));
 
-    // No resume_session → NoSessionId branch.
     let run_id = RunId::new_v4();
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
 
@@ -88,7 +88,7 @@ async fn job_without_session_reports_no_session_id() {
     assert_eq!(completion.exit_code, 0);
     assert_eq!(
         completion.reuse_result,
-        Some(SandboxReuseResult::NoSessionId),
+        Some(SandboxReuseResult::NoReuseKey),
     );
     assert!(
         completion.sandbox_id.is_some(),
@@ -141,7 +141,7 @@ async fn invalid_resume_session_does_not_reuse_idle_vm() {
     assert_eq!(completion.exit_code, 1);
     assert_eq!(
         completion.reuse_result,
-        Some(SandboxReuseResult::NoSessionId),
+        Some(SandboxReuseResult::InvalidResumeSessionId),
     );
     assert_eq!(completion.sandbox_id, None);
     let error = completion.error.as_deref().expect("error should be set");
@@ -153,6 +153,45 @@ async fn invalid_resume_session_does_not_reuse_idle_vm() {
         seeded_sandbox_id,
         "invalid continuation metadata must restore the reserved sandbox",
     );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn invalid_resume_session_fails_before_fresh_sandbox_creation() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, Arc::clone(&overrides));
+    let budget = Arc::clone(&config.capacity.budget);
+    let run_handle = tokio::spawn(run(config));
+    let run_id = RunId::new_v4();
+    let invalid_session_id = "../invalid-fresh-session";
+
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(run_id, invalid_session_id)),
+    );
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("job should complete");
+    assert_eq!(completion.exit_code, 1);
+    assert_eq!(
+        completion.reuse_result,
+        Some(SandboxReuseResult::InvalidResumeSessionId),
+    );
+    let error = completion.error.as_deref().expect("error should be set");
+    assert!(error.contains("invalid session_id"));
+    assert!(!error.contains(invalid_session_id));
+    assert!(
+        overrides.create_configs().is_empty(),
+        "invalid continuation metadata must fail before sandbox creation",
+    );
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/executor/session_history_restore_plan.rs
+++ b/crates/runner/src/executor/session_history_restore_plan.rs
@@ -238,7 +238,8 @@ pub(crate) fn build_session_history_restore_plan(
                 )))
             }
         }
-        SandboxReuseResult::NoSessionId
+        SandboxReuseResult::NoReuseKey
+        | SandboxReuseResult::InvalidResumeSessionId
         | SandboxReuseResult::PoolMiss
         | SandboxReuseResult::ProfileMismatch
         | SandboxReuseResult::DeviceLimitMismatch

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -206,7 +206,8 @@ impl RunnerSpawnTiming {
 pub(super) fn record_reuse_result(telemetry: &mut JobTelemetry, result: SandboxReuseResult) {
     let action_type = match result {
         SandboxReuseResult::Reused => "sandbox_reuse_hit",
-        SandboxReuseResult::NoSessionId
+        SandboxReuseResult::NoReuseKey
+        | SandboxReuseResult::InvalidResumeSessionId
         | SandboxReuseResult::PoolMiss
         | SandboxReuseResult::ProfileMismatch
         | SandboxReuseResult::DeviceLimitMismatch

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -407,7 +407,11 @@ fn build_env_json_sandbox_reuse_result_wire_format() {
     let sid = SandboxId::new_v4().to_string();
     for (variant, expected) in [
         (SandboxReuseResult::Reused, "reused"),
-        (SandboxReuseResult::NoSessionId, "noSessionId"),
+        (SandboxReuseResult::NoReuseKey, "noReuseKey"),
+        (
+            SandboxReuseResult::InvalidResumeSessionId,
+            "invalidResumeSessionId",
+        ),
         (SandboxReuseResult::PoolMiss, "poolMiss"),
         (SandboxReuseResult::ProfileMismatch, "profileMismatch"),
         (

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1222,7 +1222,7 @@ async fn execute_job_wraps_execute_inner() {
         minimal_context(),
         NewSandboxDispatch {
             id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::NoSessionId,
+            reuse_result: SandboxReuseResult::NoReuseKey,
         },
         &config,
         &default_params(),
@@ -1247,7 +1247,7 @@ async fn execute_job_create_failure_returns_exit_1() {
         minimal_context(),
         NewSandboxDispatch {
             id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::NoSessionId,
+            reuse_result: SandboxReuseResult::NoReuseKey,
         },
         &config,
         &default_params(),
@@ -1275,7 +1275,7 @@ async fn execute_job_model_provider_env_validation_failure_returns_run_failure()
         ctx,
         NewSandboxDispatch {
             id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::NoSessionId,
+            reuse_result: SandboxReuseResult::NoReuseKey,
         },
         &config,
         &default_params(),
@@ -1309,7 +1309,7 @@ async fn execute_job_claude_tool_validation_failure_skips_sandbox_create() {
         ctx,
         NewSandboxDispatch {
             id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::NoSessionId,
+            reuse_result: SandboxReuseResult::NoReuseKey,
         },
         &config,
         &default_params(),
@@ -1345,7 +1345,7 @@ async fn execute_job_codex_ignores_claude_tool_validation() {
         ctx,
         NewSandboxDispatch {
             id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::NoSessionId,
+            reuse_result: SandboxReuseResult::NoReuseKey,
         },
         &config,
         &default_params(),
@@ -1370,7 +1370,7 @@ async fn execute_job_nonzero_exit_still_returns_sandbox() {
         minimal_context(),
         NewSandboxDispatch {
             id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::NoSessionId,
+            reuse_result: SandboxReuseResult::NoReuseKey,
         },
         &config,
         &default_params(),

--- a/crates/runner/src/executor/tests/sandbox_run_tests/idle_pool.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/idle_pool.rs
@@ -17,7 +17,7 @@ async fn idle_pool_park_and_reuse_cycle() {
         minimal_context(),
         NewSandboxDispatch {
             id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::NoSessionId,
+            reuse_result: SandboxReuseResult::NoReuseKey,
         },
         &config,
         &default_params(),

--- a/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
@@ -17,7 +17,7 @@ async fn execute_job_reuse_succeeds() {
         minimal_context(),
         NewSandboxDispatch {
             id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::NoSessionId,
+            reuse_result: SandboxReuseResult::NoReuseKey,
         },
         &config,
         &default_params(),
@@ -188,7 +188,7 @@ async fn execute_job_reuse_with_session_context() {
         ctx,
         NewSandboxDispatch {
             id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::NoSessionId,
+            reuse_result: SandboxReuseResult::NoReuseKey,
         },
         &config,
         &default_params(),

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -494,7 +494,8 @@ fn record_reuse_result_emits_hit_for_reuse() {
 #[test]
 fn record_reuse_result_emits_miss_for_every_miss_variant() {
     let variants = [
-        SandboxReuseResult::NoSessionId,
+        SandboxReuseResult::NoReuseKey,
+        SandboxReuseResult::InvalidResumeSessionId,
         SandboxReuseResult::PoolMiss,
         SandboxReuseResult::ProfileMismatch,
         SandboxReuseResult::DeviceLimitMismatch,
@@ -557,7 +558,7 @@ async fn execute_job_reuse_records_sandbox_reuse_hit_in_telemetry() {
         minimal_context(),
         NewSandboxDispatch {
             id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::NoSessionId,
+            reuse_result: SandboxReuseResult::NoReuseKey,
         },
         &config,
         &default_params(),
@@ -884,7 +885,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
         minimal_context(),
         NewSandboxDispatch {
             id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::NoSessionId,
+            reuse_result: SandboxReuseResult::NoReuseKey,
         },
         &config,
         &default_params(),

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -3447,6 +3447,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn api_client_complete_serializes_new_reuse_results() {
+        for (reuse_result, expected_wire) in [
+            (SandboxReuseResult::NoReuseKey, "noReuseKey"),
+            (
+                SandboxReuseResult::InvalidResumeSessionId,
+                "invalidResumeSessionId",
+            ),
+        ] {
+            let server = MockServer::start_async().await;
+            let run_id = RunId::nil();
+            let mock = server
+                .mock_async(|when, then| {
+                    when.method(POST)
+                        .path(routes::webhooks::agent::complete::COMPLETE.path)
+                        .header("authorization", "Bearer sandbox-token")
+                        .json_body(serde_json::json!({
+                            "runId": run_id,
+                            "exitCode": 0,
+                            "sandboxReuseResult": expected_wire,
+                        }));
+                    then.status(200);
+                })
+                .await;
+            let api = api_client_for_server(&server);
+
+            api.complete("sandbox-token", run_id, 0, None, None, Some(reuse_result))
+                .await
+                .unwrap();
+
+            mock.assert_async().await;
+        }
+    }
+
+    #[tokio::test]
     async fn api_provider_claim_accepts_shared_current_response_fixture() {
         let server = MockServer::start_async().await;
         let run_id: RunId = RUNNER_CLAIM_RESPONSE_FIXTURE_RUN_ID.parse().unwrap();

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1405,13 +1405,14 @@ pub struct CompleteRequest {
 }
 
 /// Outcome of the sandbox-reuse decision made at job dispatch time. `Reused`
-/// means the VM was unparked from the idle pool; the other variants name the
-/// branch that caused a fresh create. Wire name: `sandboxReuseResult`.
+/// means the VM was unparked from the idle pool; the other variants describe
+/// why reuse did not happen. Wire name: `sandboxReuseResult`.
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum SandboxReuseResult {
     Reused,
-    NoSessionId,
+    NoReuseKey,
+    InvalidResumeSessionId,
     PoolMiss,
     ProfileMismatch,
     DeviceLimitMismatch,
@@ -1424,7 +1425,8 @@ impl SandboxReuseResult {
     pub const fn as_wire(self) -> &'static str {
         match self {
             Self::Reused => "reused",
-            Self::NoSessionId => "noSessionId",
+            Self::NoReuseKey => "noReuseKey",
+            Self::InvalidResumeSessionId => "invalidResumeSessionId",
             Self::PoolMiss => "poolMiss",
             Self::ProfileMismatch => "profileMismatch",
             Self::DeviceLimitMismatch => "deviceLimitMismatch",
@@ -1781,8 +1783,12 @@ mod tests {
     #[test]
     fn sandbox_reuse_result_serializes_camel_case() {
         assert_eq!(
-            serde_json::to_value(SandboxReuseResult::NoSessionId).unwrap(),
-            serde_json::json!("noSessionId"),
+            serde_json::to_value(SandboxReuseResult::NoReuseKey).unwrap(),
+            serde_json::json!("noReuseKey"),
+        );
+        assert_eq!(
+            serde_json::to_value(SandboxReuseResult::InvalidResumeSessionId).unwrap(),
+            serde_json::json!("invalidResumeSessionId"),
         );
         assert_eq!(
             serde_json::to_value(SandboxReuseResult::PoolMiss).unwrap(),
@@ -1808,7 +1814,8 @@ mod tests {
     fn as_wire_matches_serde_serialization() {
         for variant in [
             SandboxReuseResult::Reused,
-            SandboxReuseResult::NoSessionId,
+            SandboxReuseResult::NoReuseKey,
+            SandboxReuseResult::InvalidResumeSessionId,
             SandboxReuseResult::PoolMiss,
             SandboxReuseResult::ProfileMismatch,
             SandboxReuseResult::DeviceLimitMismatch,


### PR DESCRIPTION
## Summary

- Replace the Runner-only `NoSessionId` writer variant with `NoReuseKey` and `InvalidResumeSessionId`.
- Preserve missing-key, invalid-continuation, reservation, sandbox lifecycle, session-history, and generic telemetry behavior while reporting the actual cause.
- Pin both wire values at the serde, guest environment, and real HTTP client boundaries, with main-loop coverage for fresh and reserved invalid continuations.

## Scope

- TypeScript readers continue accepting legacy `noSessionId` from preceding runners and historical records.
- No API, Platform, database, migration, reuse policy, parking, workspace-cache, heartbeat, or telemetry-action changes are included.
- Parent delivery objective: #24508.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::idle_reuse::affinity`
- Focused Runner HTTP, environment, telemetry, and serde tests
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner -p guest-contracts --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner -p guest-contracts --all-features --no-deps`
- `git diff --check`

Closes #24551
