### PR TITLE
perf: measure completion readiness race boundaries

### DIFF
--- a/crates/runner/src/cmd/start/active_reuse_keys.rs
+++ b/crates/runner/src/cmd/start/active_reuse_keys.rs
@@ -42,6 +42,14 @@ impl ActiveReuseKeyGuard {
             reuse_key,
         }
     }
+
+    pub(super) fn release(mut self) -> bool {
+        let Some(reuse_key) = self.reuse_key.take() else {
+            return false;
+        };
+        remove_active_reuse_key(&self.active_reuse_keys, &reuse_key);
+        true
+    }
 }
 
 impl Drop for ActiveReuseKeyGuard {

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -1,6 +1,7 @@
 use sandbox::SandboxId;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
+use std::time::{Duration, Instant};
 
 use crate::ids::RunId;
 use crate::provider::{CompletionAuth, JobProvider};
@@ -184,7 +185,7 @@ impl CompletionReady {
         provider: &dyn JobProvider,
         ownership: &OwnershipTransitions<'_>,
         cleanup_state: &RunCleanupState,
-    ) {
+    ) -> Duration {
         let Self {
             payload, budget, ..
         } = self;
@@ -197,6 +198,7 @@ impl CompletionReady {
             completion_auth,
         } = payload;
 
+        let provider_completion_started = Instant::now();
         provider
             .complete(
                 run_id,
@@ -207,11 +209,13 @@ impl CompletionReady {
                 completion_auth,
             )
             .await;
+        let provider_completion_duration = provider_completion_started.elapsed();
         ownership
             .active_completed(RunSandbox::new(run_id, sandbox_id))
             .await;
         cleanup_state.mark_status_removed();
         budget.release();
+        provider_completion_duration
     }
 }
 
@@ -363,7 +367,7 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
 
-        CompletionReady::new(
+        let _ = CompletionReady::new(
             test_completion_payload(run_id, sandbox_id),
             BudgetOwnership::active(ActiveBudgetLease::new(lease)),
         )
@@ -407,7 +411,7 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
 
-        CompletionReady::new(
+        let _ = CompletionReady::new(
             CompletionPayload::new(
                 run_id,
                 0,
@@ -448,7 +452,7 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
 
-        CompletionReady::new(
+        let _ = CompletionReady::new(
             test_completion_payload(run_id, sandbox_id),
             BudgetOwnership::idle_owned(),
         )
@@ -490,7 +494,7 @@ mod tests {
         status.add_run(run_id, completed_sandbox_id).await;
         status.add_run(run_id, current_sandbox_id).await;
 
-        CompletionReady::new(
+        let _ = CompletionReady::new(
             test_completion_payload(run_id, completed_sandbox_id),
             BudgetOwnership::active(ActiveBudgetLease::new(lease)),
         )
@@ -528,7 +532,7 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
 
-        CompletionReady::new(
+        let _ = CompletionReady::new(
             test_completion_payload(run_id, sandbox_id),
             BudgetOwnership::active(ActiveBudgetLease::from_idle_park_lease(lease)),
         )

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -302,6 +302,7 @@ impl FinalizationPhase {
             discovered_cli_agent_session_id,
             restored_session_identity,
         } = outcome;
+        let had_sandbox = sandbox.is_some();
         let has_restored_session_identity = restored_session_identity.is_some();
         let cleanup_state_after_finalize = cleanup_state.clone();
 
@@ -316,6 +317,7 @@ impl FinalizationPhase {
         // Cancellation can arrive after terminal logging or while
         // `sandbox.park()` is in flight. Pass the live handle so finalization
         // can synchronize the final idle-pool ownership transfer.
+        let finalization_started = Instant::now();
         let completion_ready = finalize_sandbox_for_completion(
             sandbox,
             ActiveBudgetLease::new(active_lease),
@@ -351,9 +353,37 @@ impl FinalizationPhase {
             },
         )
         .await;
+        let finalization_duration = finalization_started.elapsed();
+        let disposition = cleanup_state_after_finalize.disposition();
+        let session_affinity_changed = completion_ready.session_affinity_changed();
+        let (finalization_action, finalization_success, finalization_error) = match disposition {
+            RunCleanupDisposition::IdlePoolOwned => {
+                ("runner_host_finalization_reusable_sandbox", true, None)
+            }
+            _ if session_affinity_changed => {
+                ("runner_host_finalization_workspace_cache", true, None)
+            }
+            RunCleanupDisposition::DestroyCompleted | RunCleanupDisposition::StatusRemoved => {
+                ("runner_host_finalization_no_resource", true, None)
+            }
+            RunCleanupDisposition::ActiveOrUnknown if !had_sandbox => {
+                ("runner_host_finalization_no_resource", true, None)
+            }
+            RunCleanupDisposition::ActiveOrUnknown => (
+                "runner_host_finalization_failed",
+                false,
+                Some("sandbox ownership unresolved"),
+            ),
+        };
+        telemetry.record(
+            finalization_action,
+            finalization_duration,
+            finalization_success,
+            finalization_error,
+        );
         record_session_history_identity_park_telemetry(
             &mut telemetry,
-            cleanup_state_after_finalize.disposition(),
+            disposition,
             has_restored_session_identity,
         );
 
@@ -391,7 +421,7 @@ struct CompletionPhase {
 }
 
 impl CompletionPhase {
-    async fn complete(self, completion_ready: CompletionReady) {
+    async fn complete(self, completion_ready: CompletionReady, telemetry: &mut JobTelemetry) {
         let Self {
             run_id,
             provider,
@@ -406,10 +436,23 @@ impl CompletionPhase {
         signal_usage_flush(run_id, &usage_flush_tx);
         let ownership = OwnershipTransitions::new(status.as_ref());
         let session_affinity_changed = completion_ready.session_affinity_changed();
-        completion_ready
+        let provider_completion_duration = completion_ready
             .complete_and_release(provider.as_ref(), &ownership, &cleanup_state)
             .await;
-        drop(active_reuse_key_guard);
+        telemetry.record(
+            "runner_host_completion_fallback",
+            provider_completion_duration,
+            true,
+            None,
+        );
+        if active_reuse_key_guard.release() {
+            telemetry.record(
+                "runner_active_reuse_key_released",
+                Duration::ZERO,
+                true,
+                None,
+            );
+        }
         if session_affinity_changed {
             park_notify.notify_one();
         }
@@ -651,7 +694,7 @@ pub(super) fn spawn_job(
 
             let FinalizedJob {
                 completion_ready,
-                telemetry,
+                mut telemetry,
             } = finalization.finalize(executor_result).await;
             CompletionPhase {
                 run_id,
@@ -662,7 +705,7 @@ pub(super) fn spawn_job(
                 active_reuse_key_guard,
                 cleanup_state: cleanup_state_for_body,
             }
-            .complete(completion_ready)
+            .complete(completion_ready, &mut telemetry)
             .await;
             deferred_upload.flush(telemetry).await;
         };
@@ -917,6 +960,23 @@ mod tests {
         }
     }
 
+    fn executor_phase_outcome_without_sandbox(run_id: RunId) -> ExecutorPhaseOutcome {
+        ExecutorPhaseOutcome {
+            outcome: executor::ExecuteOutcome {
+                failure: None,
+                sandbox: None,
+                source_ip: String::new(),
+                network_log_session: None,
+                workspace_image: None,
+                discovered_cli_agent_session_id: None,
+                restored_session_identity: None,
+            },
+            exit_code: 1,
+            err: Some("sandbox unavailable".into()),
+            telemetry: JobTelemetry::new(test_http_client(), run_id, "sandbox-token".into()),
+        }
+    }
+
     #[test]
     fn generic_zero_exit_code_normalizes_to_generic_failure() {
         let failure = executor::ExecutionFailure::new(0, "", None);
@@ -979,6 +1039,10 @@ mod tests {
             ))
             .await;
 
+        assert_telemetry_action(
+            &finalized.telemetry,
+            "runner_host_finalization_reusable_sandbox",
+        );
         assert_telemetry_action(&finalized.telemetry, "session_history_identity_parked");
         assert_eq!(
             cleanup_state.disposition(),
@@ -1041,6 +1105,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn finalization_records_no_resource_when_execution_has_no_sandbox() {
+        let fixture = FinalizationTelemetryFixture::new().await;
+        let (_budget, lease) = test_budget_lease();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let finalization = fixture.finalization_phase(
+            run_id,
+            sandbox_id,
+            "sess-no-sandbox",
+            lease,
+            RunCleanupState::new(),
+        );
+
+        let finalized = finalization
+            .finalize(executor_phase_outcome_without_sandbox(run_id))
+            .await;
+
+        assert_telemetry_action(&finalized.telemetry, "runner_host_finalization_no_resource");
+    }
+
+    #[tokio::test]
     async fn completion_notifies_again_after_releasing_active_session_guard() {
         let fixture = FinalizationTelemetryFixture::new().await;
         let (_budget, lease) = test_budget_lease();
@@ -1055,7 +1140,10 @@ mod tests {
             lease,
             RunCleanupState::new(),
         );
-        let finalized = finalization
+        let FinalizedJob {
+            completion_ready,
+            mut telemetry,
+        } = finalization
             .finalize(executor_phase_outcome(
                 run_id,
                 "post-complete-refresh",
@@ -1081,8 +1169,11 @@ mod tests {
             active_reuse_key_guard,
             cleanup_state: RunCleanupState::new(),
         }
-        .complete(finalized.completion_ready)
+        .complete(completion_ready, &mut telemetry)
         .await;
+
+        assert_telemetry_action(&telemetry, "runner_host_completion_fallback");
+        assert_telemetry_action(&telemetry, "runner_active_reuse_key_released");
 
         assert!(
             super::super::active_reuse_keys::active_reuse_keys(&active_reuse_keys).is_empty(),

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -658,6 +658,7 @@ async fn run_start_with_home(
             server.token,
             ApiProviderConfig {
                 runner_id: runner_id.clone(),
+                heartbeat_generation,
                 group,
                 supported_profiles: profiles,
             },

--- a/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
@@ -1,8 +1,11 @@
 use super::super::super::*;
 use super::super::support::{
-    context_with_session, mock_run_config_with_api_url, push_job, seed_idle_pool, shutdown,
-    test_profiles,
+    context_with_session, minimal_context, mock_run_config_with_api_url,
+    mock_run_config_with_overrides_and_api_url, push_job, seed_idle_pool, shutdown, test_profiles,
+    wait_discover_entered,
 };
+use crate::paths::RunnerPaths;
+use crate::workspace_image_cache::WorkspaceImageCache;
 
 #[tokio::test]
 async fn telemetry_flush_includes_start_loop_claim_phase_spans() {
@@ -20,7 +23,10 @@ async fn telemetry_flush_includes_start_loop_claim_phase_spans() {
                 .body_includes("runner_claim_workspace_cache_state_lookup")
                 .body_includes("runner_claim_active_status_publish")
                 .body_includes("runner_claim_spawn_job_setup")
-                .body_includes("runner_claim_task_schedule_wait");
+                .body_includes("runner_claim_task_schedule_wait")
+                .body_includes("runner_host_finalization_reusable_sandbox")
+                .body_includes("runner_host_completion_fallback")
+                .body_includes("runner_active_reuse_key_released");
             then.status(200)
                 .header("content-type", "application/json")
                 .body(r#"{"success":true,"id":"ok"}"#);
@@ -38,6 +44,173 @@ async fn telemetry_flush_includes_start_loop_claim_phase_spans() {
         "vm0/default",
         Some(context_with_session(run_id, "sess-claim-timing")),
     );
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await;
+    assert!(completion.is_some(), "job should complete");
+
+    shutdown(&env, run_handle).await;
+
+    telemetry_mock.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn telemetry_flush_classifies_no_resource_finalization() {
+    use httpmock::prelude::*;
+
+    let server = MockServer::start_async().await;
+    let telemetry_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/telemetry")
+                .body_includes("runner_host_finalization_no_resource")
+                .body_includes("runner_host_completion_fallback");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"success":true,"id":"ok"}"#);
+        })
+        .await;
+
+    let (config, env) =
+        mock_run_config_with_api_url(test_profiles(), 8, 32768, 4, &server.base_url());
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await;
+    assert!(completion.is_some(), "job should complete");
+
+    shutdown(&env, run_handle).await;
+
+    telemetry_mock.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn telemetry_flush_classifies_workspace_cache_finalization() {
+    use httpmock::prelude::*;
+
+    let server = MockServer::start_async().await;
+    let telemetry_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/telemetry")
+                .body_includes("runner_host_finalization_workspace_cache")
+                .body_includes("runner_host_completion_fallback")
+                .body_includes("runner_active_reuse_key_released");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"success":true,"id":"ok"}"#);
+        })
+        .await;
+
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    overrides.push_wait_process_exit(sandbox::ProcessExit::new(1, 1, Vec::new(), Vec::new()));
+    let mut profiles = test_profiles();
+    profiles
+        .get_mut("vm0/default")
+        .expect("default profile should exist")
+        .workspace_disk_mb = 16;
+    let (mut config, env) = mock_run_config_with_overrides_and_api_url(
+        profiles,
+        8,
+        32768,
+        4,
+        Arc::clone(&overrides),
+        &server.base_url(),
+    );
+    let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
+    let workspace_cache = WorkspaceImageCache::shared(
+        runner_paths.clone(),
+        &config.paths.home,
+        &config.runner.group,
+    );
+    Arc::get_mut(&mut config.exec_config)
+        .expect("test executor config should be unique")
+        .workspace_cache = Some(workspace_cache);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(
+            run_id,
+            "sess-telemetry-workspace-cache",
+        )),
+    );
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("wait_process should enter before the workspace image is written");
+    let sandbox_id = overrides
+        .create_configs()
+        .into_iter()
+        .next()
+        .expect("sandbox create config should be recorded")
+        .id;
+    let active_image = runner_paths.active_workspace_image(&sandbox_id);
+    tokio::fs::create_dir_all(active_image.parent().expect("image should have a parent"))
+        .await
+        .unwrap();
+    let file = tokio::fs::File::create(active_image).await.unwrap();
+    file.set_len(16 * 1024 * 1024).await.unwrap();
+    drop(file);
+    overrides.clear_wait_process_lifecycle_gate();
+    wait_gate.release_one();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("job should complete");
+    assert_eq!(completion.exit_code, 1);
+
+    shutdown(&env, run_handle).await;
+
+    telemetry_mock.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn telemetry_flush_classifies_failed_finalization() {
+    use httpmock::prelude::*;
+
+    let server = MockServer::start_async().await;
+    let telemetry_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/telemetry")
+                .body_includes("runner_host_finalization_failed")
+                .body_includes("runner_host_completion_fallback");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"success":true,"id":"ok"}"#);
+        })
+        .await;
+
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_stop_panic("simulated finalization stop panic");
+    let (config, env) = mock_run_config_with_overrides_and_api_url(
+        test_profiles(),
+        8,
+        32768,
+        4,
+        overrides,
+        &server.base_url(),
+    );
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
 
     let completion = env
         .handle

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -348,6 +348,24 @@ pub(in super::super) fn mock_run_config_with_overrides(
     max_concurrent: usize,
     overrides: Arc<sandbox_mock::MockSandboxOverrides>,
 ) -> (RunConfig, MockRunEnv) {
+    mock_run_config_with_overrides_and_api_url(
+        profiles,
+        budget_vcpu,
+        budget_memory_mb,
+        max_concurrent,
+        overrides,
+        "http://localhost:0",
+    )
+}
+
+pub(in super::super) fn mock_run_config_with_overrides_and_api_url(
+    profiles: BTreeMap<String, config::ProfileConfig>,
+    budget_vcpu: u32,
+    budget_memory_mb: u32,
+    max_concurrent: usize,
+    overrides: Arc<sandbox_mock::MockSandboxOverrides>,
+    api_url: &str,
+) -> (RunConfig, MockRunEnv) {
     crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher(&overrides);
     build_mock_run_config_with_runtime(
         profiles,
@@ -356,6 +374,6 @@ pub(in super::super) fn mock_run_config_with_overrides(
         max_concurrent,
         MockJobProvider::new,
         Box::new(MockSandboxRuntime::with_overrides(overrides)),
-        "http://localhost:0",
+        api_url,
     )
 }

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -6,7 +6,8 @@ mod wait;
 
 pub(super) use self::env::{
     MockRunEnv, mock_run_config, mock_run_config_with_api_url, mock_run_config_with_delay,
-    mock_run_config_with_overrides, mock_run_config_with_runtime, test_profiles, two_profiles,
+    mock_run_config_with_overrides, mock_run_config_with_overrides_and_api_url,
+    mock_run_config_with_runtime, test_profiles, two_profiles,
 };
 pub(super) use self::idle_pool::{
     TestParkedIdleCandidateSpec, WorkspacePromotionSeedSpec, seed_idle_pool,

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -215,6 +215,7 @@ enum DiscoveryWakeup {
 pub struct ApiProvider {
     api: ApiClient,
     runner_id: String,
+    heartbeat_generation: u64,
     group: String,
     /// Profile names this runner supports (e.g., ["vm0/default"]).
     /// Sent in poll requests so the server only returns jobs this runner can handle.
@@ -241,6 +242,7 @@ pub struct BuiltinFirewallCatalogCachePaths {
 
 pub struct ApiProviderConfig {
     pub runner_id: String,
+    pub heartbeat_generation: u64,
     pub group: String,
     pub supported_profiles: Vec<String>,
 }
@@ -257,6 +259,7 @@ impl ApiProvider {
     ) -> Arc<Self> {
         let ApiProviderConfig {
             runner_id,
+            heartbeat_generation,
             group,
             supported_profiles,
         } = config;
@@ -277,6 +280,7 @@ impl ApiProvider {
         Arc::new(Self {
             api,
             runner_id,
+            heartbeat_generation,
             group,
             supported_profiles,
             poll_wakeups,
@@ -630,7 +634,12 @@ impl JobProvider for ApiProvider {
                     }
                 };
                 self.claim_cooldowns.remove(run_id).await;
-                info!(run_id = %run_id, "job claimed");
+                info!(
+                    run_id = %run_id,
+                    runner_id = %self.runner_id,
+                    heartbeat_generation = self.heartbeat_generation,
+                    "job claimed"
+                );
                 Some(claimed)
             }
             Ok(None) => {
@@ -1704,6 +1713,7 @@ mod tests {
             builtin_firewall_catalog_refresh: BuiltinFirewallCatalogRefreshController::disabled(),
             api,
             runner_id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
+            heartbeat_generation: 7,
             group: "default".to_string(),
             supported_profiles: vec![crate::profile::DEFAULT_PROFILE.to_string()],
             poll_wakeups,
@@ -3761,13 +3771,18 @@ mod tests {
             Arc::new(PollWakeups::new(false)),
         );
 
-        let claimed = provider
-            .claim(JobCandidate::new(
-                run_id,
-                crate::profile::DEFAULT_PROFILE.to_string(),
-            ))
-            .await
-            .expect("claim should succeed");
+        let (claimed, events) = capture_api_provider_events(provider.claim(JobCandidate::new(
+            run_id,
+            crate::profile::DEFAULT_PROFILE.to_string(),
+        )))
+        .await;
+        let claimed = claimed.expect("claim should succeed");
+        let event = captured_event(&events, "job claimed");
+        assert_eq!(
+            event_field(event, "runner_id"),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+        assert_eq!(event_field(event, "heartbeat_generation"), "7");
         let (context, completion_auth, active_input_source) = claimed.into_parts();
         assert_eq!(context.sandbox_token, "claim-sandbox-token");
         assert!(active_input_source.is_none());

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -11009,6 +11009,20 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
       agentId,
       prompt: "bdd cleanup wins before late event",
     });
+    const persistedEvents = sandboxOperationEventsForRunByAction(
+      runId,
+      "same_thread_runner_job_persisted",
+    );
+    expect(persistedEvents).toStrictEqual([
+      expect.objectContaining({
+        duration_ms: 0,
+        sandbox_type: "runner",
+        success: true,
+        run_id: runId,
+      }),
+    ]);
+    expect(persistedEvents[0]).not.toHaveProperty("chat_thread_id");
+    expect(persistedEvents[0]).not.toHaveProperty("predecessor_run_id");
 
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(runId);
@@ -11684,6 +11698,12 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
         "first_assistant_message_eligible",
       ),
     ).toStrictEqual([]);
+    expect(
+      sandboxOperationEventsForRunByAction(
+        queued.runId,
+        "same_thread_runner_job_persisted",
+      ),
+    ).toStrictEqual([]);
 
     mockNow(promotedAt);
     await api.requestCancelRun(actor, first.runId, [200]);
@@ -11699,6 +11719,22 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
         _time: new Date(promotedAt).toISOString(),
         source: "api",
         op_type: "first_assistant_message_eligible",
+        sandbox_type: "runner",
+        duration_ms: 0,
+        success: true,
+        run_id: queued.runId,
+      },
+    ]);
+    expect(
+      sandboxOperationEventsForRunByAction(
+        queued.runId,
+        "same_thread_runner_job_persisted",
+      ),
+    ).toStrictEqual([
+      {
+        _time: new Date(promotedAt).toISOString(),
+        source: "api",
+        op_type: "same_thread_runner_job_persisted",
         sandbox_type: "runner",
         duration_ms: 0,
         success: true,
@@ -12394,6 +12430,19 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
     const settled = await api.readRun(actor, created.runId);
     expect(settled.status).toBe("completed");
     expect(settled.error ?? null).toBeNull();
+    expect(
+      sandboxOperationEventsForRunByAction(
+        created.runId,
+        "run_terminal_transition_committed",
+      ),
+    ).toStrictEqual([
+      expect.objectContaining({
+        duration_ms: 0,
+        sandbox_type: "runner",
+        success: true,
+        run_id: created.runId,
+      }),
+    ]);
   });
 });
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -200,7 +200,10 @@ import {
 } from "./agent-run-queue-payload.service";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 import { notifyRunnerJob } from "./runner-dispatch.service";
-import { runnerJobQueueTimestamps } from "./runner-job-queue-lifecycle.service";
+import {
+  recordSameThreadRunnerJobPersisted,
+  runnerJobQueueTimestamps,
+} from "./runner-job-queue-lifecycle.service";
 import {
   connectorRuntimeCredentialStatusWithMethod,
   type ConnectorCredentialStatus,
@@ -7780,6 +7783,10 @@ async function committedAtomicLaunchResponse(args: {
   }
 
   if (args.createArgs.chatThreadId) {
+    recordSameThreadRunnerJobPersisted({
+      runId: args.committed.run.id,
+      createdAt: args.committed.runnerJobCreatedAt,
+    });
     recordFirstAssistantEventEligibility({
       runId: args.committed.run.id,
       apiStartedAt: args.createArgs.apiStartTime,

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -13,6 +13,7 @@ import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
 import type { SandboxAuth } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
+import { recordSandboxOperation } from "../external/sandbox-op-log";
 import {
   publishChatThreadDetailChangedSafely,
   publishRunChangedForUserSafely,
@@ -153,7 +154,17 @@ async function transitionRunStatus(
       ),
     )
     .returning({ id: agentRuns.id });
-  return !!updated;
+  if (!updated) {
+    return false;
+  }
+  recordSandboxOperation({
+    sandboxType: "runner",
+    actionType: "run_terminal_transition_committed",
+    durationMs: 0,
+    success: true,
+    runId,
+  });
+  return true;
 }
 
 function successResponse(

--- a/turbo/apps/api/src/signals/services/runner-job-queue-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-job-queue-lifecycle.service.ts
@@ -1,5 +1,6 @@
 import { sql, type SQL } from "drizzle-orm";
 
+import { recordSandboxOperation } from "../external/sandbox-op-log";
 import { nowDate } from "../external/time";
 
 interface RunnerJobQueueTimestamps {
@@ -18,4 +19,18 @@ export function runnerJobQueueTimestamps(): RunnerJobQueueTimestamps {
     createdAt: nowDate(),
     expiresAt: sql`clock_timestamp() AT TIME ZONE 'UTC' + interval '2 hours'`,
   };
+}
+
+export function recordSameThreadRunnerJobPersisted(args: {
+  readonly runId: string;
+  readonly createdAt: Date;
+}): void {
+  recordSandboxOperation({
+    sandboxType: "runner",
+    actionType: "same_thread_runner_job_persisted",
+    durationMs: 0,
+    success: true,
+    runId: args.runId,
+    timestamp: args.createdAt.toISOString(),
+  });
 }

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -27,7 +27,10 @@ import { logger } from "../../lib/log";
 import { activePendingRunPredicate } from "./agent-run-activity.service";
 import { decryptQueuedRunnerJobPayload } from "./agent-run-queue-payload.service";
 import { notifyRunnerJob } from "./runner-dispatch.service";
-import { runnerJobQueueTimestamps } from "./runner-job-queue-lifecycle.service";
+import {
+  recordSameThreadRunnerJobPersisted,
+  runnerJobQueueTimestamps,
+} from "./runner-job-queue-lifecycle.service";
 import { recordSandboxOperation } from "../external/sandbox-op-log";
 import {
   revokeQueuedRunAssistantMarkers,
@@ -440,6 +443,12 @@ async function promoteQueuedCandidateWithSideEffects(
 
   if (result.firstAssistantEventEligibility) {
     recordFirstAssistantEventEligibility(result.firstAssistantEventEligibility);
+  }
+  if (args.row.chatThreadId && result.runnerNotification) {
+    recordSameThreadRunnerJobPersisted({
+      runId: result.runnerNotification.runId,
+      createdAt: result.runnerNotification.createdAt,
+    });
   }
 
   await publishPromotedQueueSideEffects(db, {


### PR DESCRIPTION
## Summary

- Record the committed API terminal transition and the persisted same-thread runner job at their actual database boundaries.
- Classify runner host finalization as reusable sandbox, workspace cache, no resource, or failed, then separately measure host completion fallback and active reuse-key release.
- Add runner identity and heartbeat generation to the existing successful claim log for runner-local investigation of the winning generation; centralized production timing continues to use the existing claim observations.
- Reuse existing discovery, claim, reuse, materialization, spawn, and `api_to_spawn` observations instead of duplicating them.

## Scope

- This is measurement only: it does not add database state, queue or HTTP protocol fields, affinity hints, waits, cooldowns, heartbeat behavior, or scheduling changes.
- Run and runner identifiers remain correlation fields, not metric dimensions.
- #24557 stays open after this PR so the production cohort can record the go/no-go decision for #24355.

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm knip --workspace api`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --quiet`
- Focused runner lifecycle, telemetry, job-spawn, and provider-claim tests
- `git diff --check`

Relates to #24557

Parent: #24355
