### PR TITLE
test(api): isolate parallel database state

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
@@ -88,7 +88,11 @@ describe("cron monitor chat event queue", () => {
 
     const response = await accept(
       stateClient().monitor({
-        body: { event_ids: fixtures.map((fixture) => fixture.eventId) },
+        body: {
+          event_ids: fixtures.map((fixture) => {
+            return fixture.eventId;
+          }),
+        },
       }),
       [200],
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
@@ -1,12 +1,12 @@
 import { cronMonitorChatEventQueueContract } from "@vm0/api-contracts/contracts/cron";
-import type {
-  TestCronMonitorChatEventQueueStateActionBody,
-  TestCronMonitorChatEventQueueStateActionResponse,
+import {
+  testCronMonitorChatEventQueueStateContract,
+  type TestCronMonitorChatEventQueueStateActionBody,
+  type TestCronMonitorChatEventQueueStateActionResponse,
 } from "@vm0/api-contracts/contracts/test-cron-monitor-chat-event-queue-state";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { createApp } from "../../../app-factory";
-import { createAppWithRoutes } from "../../../app-factory-core";
+import { setupAppWithRoutes } from "../../../__tests__/test-app";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockEnv } from "../../../lib/env";
 import { testCronMonitorChatEventQueueStateRoutes } from "../test-cron-monitor-chat-event-queue-state";
@@ -14,56 +14,28 @@ import { createFixtureTracker } from "./helpers/zero-route-test";
 
 const context = testContext();
 const CRON_SECRET = "test-cron-secret";
-const STATE_ROUTE = "/api/test/cron-monitor-chat-event-queue-state/action";
 
 interface MonitorFixture {
   readonly composeId: string;
+  readonly eventId: string;
 }
 
 function apiClient() {
   return setupApp({ context })(cronMonitorChatEventQueueContract);
 }
 
-function cronHeaders(secret = CRON_SECRET) {
-  return { authorization: `Bearer ${secret}` };
-}
-
-async function rawCronRequest(
-  headers: Record<string, string> = {},
-): Promise<Response> {
-  const app = createApp({ signal: context.signal });
-  return await app.request("/api/cron/monitor-chat-event-queue", {
-    method: "GET",
-    headers,
-  });
+function stateClient() {
+  return setupAppWithRoutes({
+    context,
+    routes: testCronMonitorChatEventQueueStateRoutes,
+  })(testCronMonitorChatEventQueueStateContract);
 }
 
 async function postState(
   body: TestCronMonitorChatEventQueueStateActionBody,
 ): Promise<TestCronMonitorChatEventQueueStateActionResponse> {
-  const app = createAppWithRoutes({
-    signal: context.signal,
-    routes: testCronMonitorChatEventQueueStateRoutes,
-  });
-  const response = await app.request(STATE_ROUTE, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  if (!response.ok) {
-    throw new Error(
-      `orphan monitor state action failed with ${response.status}`,
-    );
-  }
-  return (await response.json()) as TestCronMonitorChatEventQueueStateActionResponse;
-}
-
-function stringField(body: Record<string, unknown>, key: string): string {
-  const value = body[key];
-  if (typeof value !== "string") {
-    throw new Error(`orphan monitor state response missing ${key}`);
-  }
-  return value;
+  const response = await accept(stateClient().action({ body }), [200]);
+  return response.body;
 }
 
 async function seedFixture(
@@ -76,7 +48,10 @@ async function seedFixture(
     action: "seed-fixture",
     fixture_kind: fixtureKind,
   });
-  return { composeId: stringField(response, "compose_id") };
+  if (!response.compose_id || !response.event_id) {
+    throw new Error("orphan monitor seed response is missing fixture IDs");
+  }
+  return { composeId: response.compose_id, eventId: response.event_id };
 }
 
 async function cleanupFixture(fixture: MonitorFixture): Promise<void> {
@@ -102,16 +77,19 @@ describe("cron monitor chat event queue", () => {
   });
 
   it("reports zero for legitimate unassociated user messages", async () => {
-    await Promise.all([
+    const fixtures = await Promise.all([
       trackFixture(seedFixture("active-run")),
       trackFixture(seedFixture("failed-message")),
       trackFixture(seedFixture("queued-integration")),
       trackFixture(seedFixture("queued-message")),
       trackFixture(seedFixture("revoked-message")),
     ]);
+    await trackFixture(seedFixture("orphan"));
 
     const response = await accept(
-      apiClient().monitor({ headers: cronHeaders() }),
+      stateClient().monitor({
+        body: { event_ids: fixtures.map((fixture) => fixture.eventId) },
+      }),
       [200],
     );
 
@@ -123,12 +101,14 @@ describe("cron monitor chat event queue", () => {
   });
 
   it("raises the existing error alert for a malformed pending event", async () => {
-    await trackFixture(seedFixture("orphan"));
+    const fixture = await trackFixture(seedFixture("orphan"));
 
-    const response = await rawCronRequest(cronHeaders());
+    const response = await accept(
+      stateClient().monitor({ body: { event_ids: [fixture.eventId] } }),
+      [500],
+    );
 
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toStrictEqual({
+    expect(response.body).toStrictEqual({
       error: "Internal server error",
     });
     expect(
@@ -141,8 +121,8 @@ describe("cron monitor chat event queue", () => {
     const [, fields] = context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
     expect(fields).toMatchObject({
       type: "unhandled_request_error",
-      route: "/api/cron/monitor-chat-event-queue",
-      method: "GET",
+      route: "/api/test/cron-monitor-chat-event-queue-state/monitor",
+      method: "POST",
       errorCode: "ORPHANED_QUEUED_CHAT_MESSAGES",
       error: {
         name: "OrphanedQueuedChatEventsError",
@@ -153,16 +133,32 @@ describe("cron monitor chat event queue", () => {
   });
 
   it("detects an automation event missing its typed context", async () => {
-    await trackFixture(seedFixture("orphaned-automation"));
+    const fixture = await trackFixture(seedFixture("orphaned-automation"));
 
-    const response = await rawCronRequest(cronHeaders());
+    const response = await accept(
+      stateClient().monitor({ body: { event_ids: [fixture.eventId] } }),
+      [500],
+    );
 
-    expect(response.status).toBe(500);
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
     expect(
       context.mocks.sentry.captureException.mock.calls.at(-1)?.[0],
     ).toMatchObject({
       code: "ORPHANED_QUEUED_CHAT_MESSAGES",
       orphanedMessages: 1,
     });
+  });
+
+  it("does not expose scoped monitoring in production", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await accept(
+      stateClient().monitor({
+        body: { event_ids: ["00000000-0000-4000-8000-000000000001"] },
+      }),
+      [404],
+    );
+
+    expect(response.body).toBe("Not found");
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
@@ -1,5 +1,6 @@
 import { createHmac, randomUUID } from "node:crypto";
 
+import { testWorkflowAutomationExecutionContract } from "@vm0/api-contracts/contracts/test-workflow-automation-execution";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
@@ -19,16 +20,13 @@ import {
 import { chatEventAutomationPart } from "./helpers/chat-event";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
 const wf = createWorkflowsBddApi(context);
 const runsApi = createRunsApi(context);
-const CRON_EXECUTE_WORKFLOW_AUTOMATIONS_PATH =
-  "/api/cron/execute-workflow-automations";
-
 const WORKFLOW_NAME = "notion-webhook-workflow";
-const CRON_SECRET = "test-cron-secret";
 const NOTION_WEBHOOK_TOKEN = "notion-webhook-verification-token";
 const NOTION_WORKSPACE_ID = "33333333-3333-4333-8333-333333333333";
 const NOTION_SUBSCRIPTION_ID = "44444444-4444-4444-8444-444444444444";
@@ -82,6 +80,13 @@ function authHeaders() {
 
 function automationsClient() {
   return setupApp({ context })(zeroWorkflowAutomationsContract);
+}
+
+function workflowAutomationExecutionClient() {
+  return setupApp({
+    context,
+    routes: testWorkflowAutomationExecutionRoutes,
+  })(testWorkflowAutomationExecutionContract);
 }
 
 async function enableNotionWorkflowAutomations(
@@ -362,15 +367,13 @@ async function verifyNotionWebhook(): Promise<void> {
   });
 }
 
-async function executeDueWorkflowAutomations(): Promise<{
-  readonly status: number;
-  readonly body: unknown;
-}> {
-  const response = await createApp({ signal: context.signal }).request(
-    CRON_EXECUTE_WORKFLOW_AUTOMATIONS_PATH,
-    { headers: { authorization: `Bearer ${CRON_SECRET}` } },
+async function executeDueWorkflowAutomations(automationId: string) {
+  return await accept(
+    workflowAutomationExecutionClient().execute({
+      body: { automation_id: automationId },
+    }),
+    [200],
   );
-  return { status: response.status, body: await response.json() };
 }
 
 function record(value: unknown, label: string): Record<string, unknown> {
@@ -781,7 +784,6 @@ describe("POST /api/webhooks/notion", () => {
 
   it("executes due page content updated events with the latest page context", async () => {
     const runnerGroup = runsApi.configureRunnerGroup();
-    mockEnv("CRON_SECRET", CRON_SECRET);
     const scenario = await setupFixture();
     const { fixture, workflowId, entities } = scenario;
     await enableNotionWorkflowAutomations(fixture);
@@ -850,13 +852,12 @@ describe("POST /api/webhooks/notion", () => {
     });
     mockNow(new Date("2026-07-06T12:20:00.000Z"));
 
-    // The sweep is global on the shared database, so only assert that this
-    // tick executed at least our due pending event.
-    const executed = await executeDueWorkflowAutomations();
-    expect(executed.status).toBe(200);
-    const executedBody = record(executed.body, "cron response");
-    expect(executedBody.success).toBeTruthy();
-    expect(executedBody.executed).toBeGreaterThanOrEqual(1);
+    const executed = await executeDueWorkflowAutomations(created.body.id);
+    expect(executed.body).toStrictEqual({
+      success: true,
+      executed: 1,
+      skipped: 0,
+    });
 
     // The run landed in the automation's bound chat thread with the friendly
     // Notion brief, linked to the created run.

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
@@ -153,15 +153,7 @@ function configureNotionChildPageMock(
     http.get(
       "https://api.notion.com/v1/pages/:pageId",
       ({ request, params }) => {
-        // Pending events left behind by earlier runs of this file may probe
-        // other page ids during the global cron sweep; only this test's page
-        // resolves.
-        if (params.pageId !== entities.childPageId) {
-          return HttpResponse.json(
-            { object: "error", status: 404, code: "object_not_found" },
-            { status: 404 },
-          );
-        }
+        expect(params.pageId).toBe(entities.childPageId);
         expect(request.headers.get("authorization")).toBe(
           "Bearer notion-access-token",
         );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-strapi-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-strapi-integration.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { testWorkflowAutomationExecutionContract } from "@vm0/api-contracts/contracts/test-workflow-automation-execution";
 import { zeroStrapiIntegrationsContract } from "@vm0/api-contracts/contracts/zero-strapi-integrations";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
+import { fnv1a } from "@vm0/core/identity-hash";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -21,10 +22,70 @@ const workflows = createWorkflowsBddApi(context);
 const runs = createRunsApi(context);
 
 const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
-// Synthetic tenant whose FNV-1a value matches the staff rollout allowlist, so
-// tenant isolation can be exercised entirely through external API behavior.
-const SECOND_ROLLOUT_ORG_ID = "org_j3tn5H";
+const FNV_PRIME = 16_777_619;
+const FNV_PRIME_INVERSE = 899_433_627;
+const ROLLOUT_COLLISION_ALPHABET =
+  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 const WORKFLOW_NAME = "publish-strapi-blog";
+
+function advanceFnv1a(hash: number, character: string): number {
+  return Math.imul(hash ^ character.charCodeAt(0), FNV_PRIME) >>> 0;
+}
+
+function reverseFnv1a(hash: number, character: string): number {
+  return (Math.imul(hash, FNV_PRIME_INVERSE) ^ character.charCodeAt(0)) >>> 0;
+}
+
+function rolloutCollisionSuffix(
+  prefix: string,
+  targetHash: number,
+): string | null {
+  const prefixHash = Number.parseInt(fnv1a(prefix), 16);
+  const firstHalves = new Map<number, string>();
+  for (const first of ROLLOUT_COLLISION_ALPHABET) {
+    for (const second of ROLLOUT_COLLISION_ALPHABET) {
+      for (const third of ROLLOUT_COLLISION_ALPHABET) {
+        const hash = advanceFnv1a(
+          advanceFnv1a(advanceFnv1a(prefixHash, first), second),
+          third,
+        );
+        firstHalves.set(hash, `${first}${second}${third}`);
+      }
+    }
+  }
+
+  for (const fourth of ROLLOUT_COLLISION_ALPHABET) {
+    for (const fifth of ROLLOUT_COLLISION_ALPHABET) {
+      for (const sixth of ROLLOUT_COLLISION_ALPHABET) {
+        const precedingHash = reverseFnv1a(
+          reverseFnv1a(reverseFnv1a(targetHash, sixth), fifth),
+          fourth,
+        );
+        const firstHalf = firstHalves.get(precedingHash);
+        if (firstHalf) {
+          return `${firstHalf}${fourth}${fifth}${sixth}`;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function uniqueRolloutOrgId(): string {
+  const targetHash = Number.parseInt(fnv1a(STAFF_ORG_ID), 16);
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const prefix = `org_${randomUUID()}_`;
+    const suffix = rolloutCollisionSuffix(prefix, targetHash);
+    if (suffix) {
+      return `${prefix}${suffix}`;
+    }
+  }
+  throw new Error("Failed to generate a unique Strapi rollout organization");
+}
+
+// Each test process gets an unshared tenant that still exercises the real
+// organization-hash rollout path.
+const SECOND_ROLLOUT_ORG_ID = uniqueRolloutOrgId();
 
 function authHeaders() {
   return { authorization: "Bearer clerk-session" } as const;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-strapi-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-strapi-integration.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 
+import { testWorkflowAutomationExecutionContract } from "@vm0/api-contracts/contracts/test-workflow-automation-execution";
 import { zeroStrapiIntegrationsContract } from "@vm0/api-contracts/contracts/zero-strapi-integrations";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -12,6 +13,7 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { chatEventAutomationPart } from "./helpers/chat-event";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -22,9 +24,7 @@ const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 // Synthetic tenant whose FNV-1a value matches the staff rollout allowlist, so
 // tenant isolation can be exercised entirely through external API behavior.
 const SECOND_ROLLOUT_ORG_ID = "org_j3tn5H";
-const CRON_SECRET = "strapi-cron-secret";
 const WORKFLOW_NAME = "publish-strapi-blog";
-const STRAPI_AUTOMATION_USER_ID = "user_strapi_automation_admin";
 
 function authHeaders() {
   return { authorization: "Bearer clerk-session" } as const;
@@ -36,6 +36,13 @@ function integrationsClient() {
 
 function automationsClient() {
   return setupApp({ context })(zeroWorkflowAutomationsContract);
+}
+
+function workflowAutomationExecutionClient() {
+  return setupApp({
+    context,
+    routes: testWorkflowAutomationExecutionRoutes,
+  })(testWorkflowAutomationExecutionContract);
 }
 
 async function postStrapiEvent(args: {
@@ -97,7 +104,6 @@ async function workflowAutomationRuns(threadId: string, workflowId: string) {
 beforeEach(() => {
   clearMockNow();
   mockEnv("VM0_WEB_URL", "https://www.vm0.test");
-  mockEnv("CRON_SECRET", CRON_SECRET);
   context.mocks.s3.send.mockResolvedValue({});
 });
 
@@ -262,8 +268,7 @@ describe("Strapi integration", () => {
 
   it("tests the external webhook and coalesces localized publishes", async () => {
     const actor = workflows.user({
-      userId: STRAPI_AUTOMATION_USER_ID,
-      orgId: STAFF_ORG_ID,
+      orgId: SECOND_ROLLOUT_ORG_ID,
       orgRole: "org:admin",
     });
     await runs.grantProEntitlement(actor, { tier: "team" });
@@ -413,36 +418,22 @@ describe("Strapi integration", () => {
     mockNow(publishStartedAt + 46_000);
     const cronResponses = await Promise.all(
       [0, 1].map(() => {
-        return createApp({ signal: context.signal }).request(
-          "/api/cron/execute-workflow-automations",
-          { headers: { authorization: `Bearer ${CRON_SECRET}` } },
+        return accept(
+          workflowAutomationExecutionClient().execute({
+            body: { automation_id: automation.body.id },
+          }),
+          [200],
         );
       }),
     );
     expect(
-      cronResponses.map((response) => {
-        return response.status;
-      }),
-    ).toStrictEqual([200, 200]);
-    const cronBodies = (await Promise.all(
-      cronResponses.map(async (response) => {
-        return (await response.json()) as {
-          readonly success: boolean;
-          readonly executed: number;
-        };
-      }),
-    )) satisfies readonly {
-      readonly success: boolean;
-      readonly executed: number;
-    }[];
-    expect(
-      cronBodies.every((body) => {
-        return body.success;
+      cronResponses.every((response) => {
+        return response.body.success;
       }),
     ).toBeTruthy();
     expect(
-      cronBodies.reduce((total, body) => {
-        return total + body.executed;
+      cronResponses.reduce((total, response) => {
+        return total + response.body.executed;
       }, 0),
     ).toBe(1);
 
@@ -495,13 +486,13 @@ describe("Strapi integration", () => {
     });
 
     mockNow(nextPublishStartedAt + 46_000);
-    const successorCron = await createApp({
-      signal: context.signal,
-    }).request("/api/cron/execute-workflow-automations", {
-      headers: { authorization: `Bearer ${CRON_SECRET}` },
-    });
-    expect(successorCron.status).toBe(200);
-    await expect(successorCron.json()).resolves.toMatchObject({
+    const successorCron = await accept(
+      workflowAutomationExecutionClient().execute({
+        body: { automation_id: automation.body.id },
+      }),
+      [200],
+    );
+    expect(successorCron.body).toMatchObject({
       success: true,
       executed: 1,
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-strapi-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-strapi-integration.test.ts
@@ -23,6 +23,7 @@ const runs = createRunsApi(context);
 
 const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 const FNV_PRIME = 16_777_619;
+// Multiplicative inverse of FNV_PRIME modulo 2^32.
 const FNV_PRIME_INVERSE = 899_433_627;
 const ROLLOUT_COLLISION_ALPHABET =
   "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
@@ -40,6 +41,8 @@ function rolloutCollisionSuffix(
   prefix: string,
   targetHash: number,
 ): string | null {
+  // Meet in the middle over two three-character halves instead of scanning
+  // all 62^6 suffixes. FNV-1a is reversible one character at a time.
   const prefixHash = Number.parseInt(fnv1a(prefix), 16);
   const firstHalves = new Map<number, string>();
   for (const first of ROLLOUT_COLLISION_ALPHABET) {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-strapi-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-strapi-integration.test.ts
@@ -480,7 +480,7 @@ describe("Strapi integration", () => {
     });
 
     mockNow(publishStartedAt + 46_000);
-    const cronResponses = await Promise.all(
+    const executionResponses = await Promise.all(
       [0, 1].map(() => {
         return accept(
           workflowAutomationExecutionClient().execute({
@@ -491,12 +491,12 @@ describe("Strapi integration", () => {
       }),
     );
     expect(
-      cronResponses.every((response) => {
+      executionResponses.every((response) => {
         return response.body.success;
       }),
     ).toBeTruthy();
     expect(
-      cronResponses.reduce((total, response) => {
+      executionResponses.reduce((total, response) => {
         return total + response.body.executed;
       }, 0),
     ).toBe(1);
@@ -550,13 +550,13 @@ describe("Strapi integration", () => {
     });
 
     mockNow(nextPublishStartedAt + 46_000);
-    const successorCron = await accept(
+    const successorExecution = await accept(
       workflowAutomationExecutionClient().execute({
         body: { automation_id: automation.body.id },
       }),
       [200],
     );
-    expect(successorCron.body).toMatchObject({
+    expect(successorExecution.body).toMatchObject({
       success: true,
       executed: 1,
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 
+import { testWorkflowAutomationExecutionContract } from "@vm0/api-contracts/contracts/test-workflow-automation-execution";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import {
   zeroAgentsByIdContract,
@@ -23,6 +24,7 @@ import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
 import { chatEventAutomationPart } from "./helpers/chat-event";
 import { seedOrgMembership$ } from "./helpers/zero-org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
 
 const context = testContext();
 const store = createStore();
@@ -55,8 +57,11 @@ function automationsClient() {
   return setupApp({ context })(zeroWorkflowAutomationsContract);
 }
 
-async function readJson<T>(response: Response): Promise<T> {
-  return (await response.json()) as T;
+function workflowAutomationExecutionClient() {
+  return setupApp({
+    context,
+    routes: testWorkflowAutomationExecutionRoutes,
+  })(testWorkflowAutomationExecutionContract);
 }
 
 function expectOk(response: Response, operation: string): void {
@@ -144,14 +149,15 @@ async function disableAutomation(automationId: string): Promise<void> {
 }
 
 async function executeDueWorkflowAutomations(
-  route = CRON_EXECUTE_WORKFLOW_AUTOMATIONS_ROUTE,
+  automationId: string,
 ): Promise<void> {
-  const response = await createApp({ signal: context.signal }).request(route, {
-    headers: { authorization: `Bearer ${CRON_SECRET}` },
-  });
-  await expectOk(response, "execute workflow automations cron");
-  const body = await readJson<{ readonly success: boolean }>(response);
-  expect(body.success).toBeTruthy();
+  const response = await accept(
+    workflowAutomationExecutionClient().execute({
+      body: { automation_id: automationId },
+    }),
+    [200],
+  );
+  expect(response.body.success).toBeTruthy();
 }
 
 interface WorkflowRunMessage {
@@ -245,6 +251,51 @@ async function deleteWorkflowViaApi(scenario: Scenario): Promise<void> {
 }
 
 describe("zero workflow automation scheduler", () => {
+  it("rejects unauthenticated production cron requests", async () => {
+    mockEnv("CRON_SECRET", CRON_SECRET);
+
+    const response = await createApp({ signal: context.signal }).request(
+      CRON_EXECUTE_WORKFLOW_AUTOMATIONS_ROUTE,
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("does not expose scoped workflow execution in production", async () => {
+    mockEnv("ENV", "production");
+
+    const response = await accept(
+      workflowAutomationExecutionClient().execute({
+        body: {
+          automation_id: "00000000-0000-4000-8000-000000000001",
+        },
+      }),
+      [404],
+    );
+
+    expect(response.body).toBe("Not found");
+  });
+
+  it("executes only the selected due automation", async () => {
+    const scenario = await setup();
+    const selected = await createDueLoopAutomation(scenario, 3600);
+    const unselected = await createDueLoopAutomation(scenario, 3600);
+
+    await executeDueWorkflowAutomations(selected.automationId);
+
+    await expect(workflowRunMessages(selected.threadId)).resolves.toHaveLength(
+      1,
+    );
+    const untouched = await wf.readAutomation(unselected.automationId);
+    expect(untouched.lastRunAt).toBeNull();
+    expect(untouched.nextRunAt).toBe(unselected.nextRunAt);
+    await disableAutomation(selected.automationId);
+    await disableAutomation(unselected.automationId);
+  });
+
   it("inherits the chat thread computer-use grant for automation runs", async () => {
     const scenario = await setup();
     const automation = await createDueLoopAutomation(scenario, 3600);
@@ -257,7 +308,7 @@ describe("zero workflow automation scheduler", () => {
       host.hostId,
     );
 
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(automation.automationId);
 
     const run = await onlyWorkflowRunMessage(automation.threadId);
     await runsApi.heartbeatRunner(scenario.runnerGroup);
@@ -277,7 +328,7 @@ describe("zero workflow automation scheduler", () => {
     const scenario = await setup();
     const automation = await createDueLoopAutomation(scenario, 3600);
 
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(automation.automationId);
 
     const run = await onlyWorkflowRunMessage(automation.threadId);
     await runsApi.heartbeatRunner(scenario.runnerGroup);
@@ -320,7 +371,7 @@ describe("zero workflow automation scheduler", () => {
 
     const automation = await createDueLoopAutomation(scenario, 60);
 
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(automation.automationId);
 
     const run = await onlyWorkflowRunMessage(automation.threadId);
     await runsApi.heartbeatRunner(scenario.runnerGroup);
@@ -335,7 +386,7 @@ describe("zero workflow automation scheduler", () => {
     const scenario = await setup();
     const automation = await createDueLoopAutomation(scenario, 60);
 
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(automation.automationId);
 
     const run = await onlyWorkflowRunMessage(automation.threadId);
     await runsApi.heartbeatRunner(scenario.runnerGroup);
@@ -369,7 +420,7 @@ describe("zero workflow automation scheduler", () => {
     }
 
     mockNow(Date.parse(created.body.nextRunAt) + 60_000);
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(created.body.id);
 
     const run = await onlyWorkflowRunMessage(threadId);
     expect(run.triggerSource).toBe("workflow-schedule");
@@ -409,7 +460,7 @@ describe("zero workflow automation scheduler", () => {
     }
 
     mockNow(Date.parse(created.body.nextRunAt) + 60_000);
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(created.body.id);
 
     const onceRun = await onlyWorkflowRunMessage(threadId);
     const emittedCallbacks = await store.set(
@@ -452,7 +503,7 @@ describe("zero workflow automation scheduler", () => {
     const scenario = await setup({ timezone: "Asia/Shanghai" });
     const automation = await createDueLoopAutomation(scenario, 3600);
 
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(automation.automationId);
 
     const run = await onlyWorkflowRunMessage(automation.threadId);
     expect(run.triggerBrief).toMatch(
@@ -514,7 +565,7 @@ describe("zero workflow automation scheduler", () => {
       [200],
     );
 
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(created.body.id);
 
     // Restore visibility so the member's product reads work again; the skip
     // already happened during the tick above.
@@ -562,7 +613,7 @@ describe("zero workflow automation scheduler", () => {
     }
 
     mockNow(Date.parse(created.body.nextRunAt) + 60_000);
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(created.body.id);
     const run = await onlyWorkflowRunMessage(threadId);
     const emittedCallbacks = await store.set(
       readAgentRunCallbacks$,
@@ -602,7 +653,7 @@ describe("zero workflow automation scheduler", () => {
     const scenario = await setup();
     const automation = await createDueLoopAutomation(scenario, 300);
 
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(automation.automationId);
     const before = now();
     const run = await onlyWorkflowRunMessage(automation.threadId);
     const emittedCallbacks = await store.set(
@@ -653,7 +704,7 @@ describe("zero workflow automation scheduler", () => {
       if (failure > 1) {
         mockNow(base + (failure - 1) * 320_000);
       }
-      await executeDueWorkflowAutomations();
+      await executeDueWorkflowAutomations(automation.automationId);
       const messages = await workflowRunMessages(automation.threadId);
       const nextRun = messages.find((message) => {
         return !seenRunIds.has(message.runId);
@@ -685,7 +736,7 @@ describe("zero workflow automation scheduler", () => {
     const scenario = await setup();
     const automation = await createDueLoopAutomation(scenario, 300);
 
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(automation.automationId);
     const run = await onlyWorkflowRunMessage(automation.threadId);
     expect(run).toMatchObject({
       workflowId: scenario.workflowId,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
@@ -698,7 +698,7 @@ describe("zero workflow automation scheduler", () => {
     const base = now();
     const seenRunIds = new Set<string>();
 
-    // Three fire + failed-completion cycles through the public cron, runner,
+    // Three fire + failed-completion cycles through scoped execution, runner,
     // and sandbox completion surfaces auto-disable the automation.
     for (let failure = 1; failure <= 3; failure += 1) {
       if (failure > 1) {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -4,6 +4,7 @@ import {
   chatEventsContract,
   chatThreadEventsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { testWorkflowAutomationExecutionContract } from "@vm0/api-contracts/contracts/test-workflow-automation-execution";
 import { zeroModelProvidersByTypeContract } from "@vm0/api-contracts/contracts/zero-model-providers";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { onTestFinished, test as vitestTest } from "vitest";
@@ -31,6 +32,7 @@ import {
 import { readThreadSessionBinding } from "./helpers/runtime-state";
 import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
 import {
   completeRunWithoutCallbacksFixture,
   holdChatEventQueueAdmissionLockFixture,
@@ -50,8 +52,6 @@ const chatCallbacks = createChatCallbacksApi(context);
 
 const WORKFLOW_NAME = "workflow-queue-workflow";
 const CRON_CLEANUP_SANDBOXES_ROUTE = "/api/cron/cleanup-sandboxes";
-const CRON_EXECUTE_WORKFLOW_AUTOMATIONS_ROUTE =
-  "/api/cron/execute-workflow-automations";
 const CRON_SECRET = "test-cron-secret";
 
 function it(name: string, test: () => Promise<void>, timeout?: number): void {
@@ -70,6 +70,13 @@ function authHeaders() {
 
 function automationsClient() {
   return setupApp({ context })(zeroWorkflowAutomationsContract);
+}
+
+function workflowAutomationExecutionClient() {
+  return setupApp({
+    context,
+    routes: testWorkflowAutomationExecutionRoutes,
+  })(testWorkflowAutomationExecutionContract);
 }
 
 function chatEventsClient() {
@@ -324,12 +331,16 @@ async function completeRunThroughSandbox(scenario: Scenario, runId: string) {
   return claim;
 }
 
-async function executeDueWorkflowAutomations(): Promise<void> {
-  const response = await createApp({ signal: context.signal }).request(
-    CRON_EXECUTE_WORKFLOW_AUTOMATIONS_ROUTE,
-    { headers: { authorization: `Bearer ${CRON_SECRET}` } },
+async function executeDueWorkflowAutomations(
+  automationId: string,
+): Promise<void> {
+  const response = await accept(
+    workflowAutomationExecutionClient().execute({
+      body: { automation_id: automationId },
+    }),
+    [200],
   );
-  expect(response.status).toBe(200);
+  expect(response.body.success).toBeTruthy();
 }
 
 async function cleanupSandboxes(): Promise<void> {
@@ -676,7 +687,6 @@ describe("workflow queue", () => {
   });
 
   it("labels a queued schedule tick with the time it fired, not the time it drained", async () => {
-    // Keep this global cron scan before schedules created by parallel test files.
     mockNow(Date.UTC(2020, 0, 2));
     const scenario = await setup();
     const webhookAutomation = await createWebhookAutomation(scenario);
@@ -706,7 +716,7 @@ describe("workflow queue", () => {
 
     const firedAt = Date.parse(created.body.nextRunAt) + 60_000;
     mockNow(firedAt);
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(created.body.id);
     const pendingTick = await pendingWorkflowEventForAutomation(
       webhookAutomation.threadId,
       created.body.id,
@@ -775,7 +785,6 @@ describe("workflow queue", () => {
   });
 
   it("coalesces schedule ticks: at most one pending tick per automation", async () => {
-    // Keep this global cron scan before schedules created by parallel test files.
     mockNow(Date.UTC(2020, 0, 1));
     const scenario = await setup();
     const webhookAutomation = await createWebhookAutomation(scenario);
@@ -808,7 +817,7 @@ describe("workflow queue", () => {
 
     // Two due ticks while busy: the second coalesces into the pending one.
     mockNow(Date.parse(created.body.nextRunAt) + 60_000);
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(created.body.id);
     expect(kms.generateDataKeyCalls).toBe(1);
     const updated = await accept(
       automationsClient().update({
@@ -829,7 +838,7 @@ describe("workflow queue", () => {
     }
     const coalescedKms = useSecretKmsProbe();
     mockNow(Date.parse(updated.body.nextRunAt) + 60_000);
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(created.body.id);
     expect(coalescedKms.generateDataKeyCalls).toBe(0);
     const coalescedEvents = await pendingWorkflowEvents(
       webhookAutomation.threadId,
@@ -1169,8 +1178,8 @@ describe("workflow queue", () => {
     );
 
     mockNow(Date.parse(created.body.nextRunAt) + 60_000);
-    await executeDueWorkflowAutomations();
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(created.body.id);
+    await executeDueWorkflowAutomations(created.body.id);
 
     const automation = await wf.readAutomation(created.body.id);
     expect(automation.nextRunAt).not.toBeNull();
@@ -1184,7 +1193,7 @@ describe("workflow queue", () => {
       throw new Error("Expected the failed recurring schedule to re-arm");
     }
     mockNow(Date.parse(automation.nextRunAt) + 60_000);
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(created.body.id);
     await expect(
       workflowRunIds(created.body.chatThreadId),
     ).resolves.toHaveLength(1);
@@ -1218,7 +1227,7 @@ describe("workflow queue", () => {
     expect(created.body.chatThreadId).toBe(webhookAutomation.threadId);
 
     mockNow(Date.parse(created.body.nextRunAt) + 60_000);
-    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations(created.body.id);
     const claimed = await wf.readAutomation(created.body.id);
     expect(claimed.enabled).toBeTruthy();
     expect(claimed.nextRunAt).toBeNull();

--- a/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
@@ -23,6 +23,7 @@ import {
   replaceChatEvent,
 } from "../services/zero-chat-event.service";
 import { createUserMessageDocument } from "../services/zero-chat-user-message.service";
+import { monitorChatEventQueueForEvents$ } from "../services/cron-monitor-chat-event-queue.service";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -30,6 +31,9 @@ import {
 
 const actionBody$ = bodyResultOf(
   testCronMonitorChatEventQueueStateContract.action,
+);
+const monitorBody$ = bodyResultOf(
+  testCronMonitorChatEventQueueStateContract.monitor,
 );
 
 type FixtureKind = Extract<
@@ -188,7 +192,7 @@ async function seedFixture(
   }
   signal.throwIfAborted();
 
-  return actionOk({ compose_id: compose.id });
+  return actionOk({ compose_id: compose.id, event_id: event.id });
 }
 
 const mutateTestCronMonitorChatEventQueueState$ = command(
@@ -215,9 +219,34 @@ const mutateTestCronMonitorChatEventQueueState$ = command(
   },
 );
 
+const monitorTestCronMonitorChatEventQueueState$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const bodyResult = await get(monitorBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const body = await set(
+      monitorChatEventQueueForEvents$,
+      bodyResult.data.event_ids,
+      signal,
+    );
+    signal.throwIfAborted();
+    return { status: 200 as const, body };
+  },
+);
+
 export const testCronMonitorChatEventQueueStateRoutes: readonly RouteEntry[] = [
   {
     route: testCronMonitorChatEventQueueStateContract.action,
     handler: mutateTestCronMonitorChatEventQueueState$,
+  },
+  {
+    route: testCronMonitorChatEventQueueStateContract.monitor,
+    handler: monitorTestCronMonitorChatEventQueueState$,
   },
 ];

--- a/turbo/apps/api/src/signals/routes/test-workflow-automation-execution.ts
+++ b/turbo/apps/api/src/signals/routes/test-workflow-automation-execution.ts
@@ -1,0 +1,63 @@
+import { testWorkflowAutomationExecutionContract } from "@vm0/api-contracts/contracts/test-workflow-automation-execution";
+import { command } from "ccstate";
+
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import { executeDueNotionWorkflowEventsForAutomation$ } from "../services/notion-workflow-event.service";
+import { executeDueStrapiWorkflowEventsForAutomation$ } from "../services/strapi-workflow-event.service";
+import { executeDueWorkflowAutomationsForAutomation$ } from "../services/zero-workflow-automation-poller.service";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+const body$ = bodyResultOf(testWorkflowAutomationExecutionContract.execute);
+
+const executeTestWorkflowAutomation$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+
+    const bodyResult = await get(body$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const automationId = bodyResult.data.automation_id;
+    const scheduled = await set(
+      executeDueWorkflowAutomationsForAutomation$,
+      automationId,
+      signal,
+    );
+    const notion = await set(
+      executeDueNotionWorkflowEventsForAutomation$,
+      automationId,
+      signal,
+    );
+    const strapi = await set(
+      executeDueStrapiWorkflowEventsForAutomation$,
+      automationId,
+      signal,
+    );
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: {
+        success: true as const,
+        executed: scheduled.executed + notion.executed + strapi.executed,
+        skipped: scheduled.skipped + notion.skipped + strapi.skipped,
+      },
+    };
+  },
+);
+
+export const testWorkflowAutomationExecutionRoutes: readonly RouteEntry[] = [
+  {
+    route: testWorkflowAutomationExecutionContract.execute,
+    handler: executeTestWorkflowAutomation$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
@@ -4,7 +4,7 @@ import { chatEvents } from "@vm0/db/schema/chat-event";
 import { command } from "ccstate";
 import { and, count, eq, inArray, isNull, or } from "drizzle-orm";
 
-import { writeDb$ } from "../external/db";
+import { writeDb$, type Db } from "../external/db";
 import { visibleChatEventCondition } from "./zero-chat-event-shared.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
 
@@ -19,59 +19,73 @@ class OrphanedQueuedChatEventsError extends Error {
   }
 }
 
-export const monitorChatEventQueue$ = command(
-  async ({ set }, signal: AbortSignal) => {
-    const db = set(writeDb$);
-    const [result] = await db
-      .select({ orphanedMessages: count() })
-      .from(chatEvents)
-      .leftJoin(
-        chatEventInputParams,
-        eq(chatEventInputParams.eventId, chatEvents.id),
-      )
-      .leftJoin(
-        chatAutomationContext,
-        and(
-          eq(chatEvents.contextType, "automation"),
-          eq(chatAutomationContext.id, chatEvents.contextId),
-        ),
-      )
-      .where(
-        and(
-          isNull(chatEvents.runId),
-          visibleChatEventCondition(db),
-          or(
-            and(
-              chatEventTypeIn(["input.automation"]),
-              or(
-                isNull(chatAutomationContext.automationId),
-                isNull(chatEvents.triggerSource),
-                isNull(chatEventInputParams.encryptedParams),
-              ),
-            ),
-            and(
-              chatEventTypeIn(["input.prompt"]),
-              inArray(chatEvents.triggerSource, [
-                "slack",
-                "feishu",
-                "teams",
-                "telegram",
-              ]),
+async function monitorChatEventQueue(
+  db: Db,
+  signal: AbortSignal,
+  eventIds?: readonly string[],
+) {
+  const [result] = await db
+    .select({ orphanedMessages: count() })
+    .from(chatEvents)
+    .leftJoin(
+      chatEventInputParams,
+      eq(chatEventInputParams.eventId, chatEvents.id),
+    )
+    .leftJoin(
+      chatAutomationContext,
+      and(
+        eq(chatEvents.contextType, "automation"),
+        eq(chatAutomationContext.id, chatEvents.contextId),
+      ),
+    )
+    .where(
+      and(
+        eventIds ? inArray(chatEvents.id, [...eventIds]) : undefined,
+        isNull(chatEvents.runId),
+        visibleChatEventCondition(db),
+        or(
+          and(
+            chatEventTypeIn(["input.automation"]),
+            or(
+              isNull(chatAutomationContext.automationId),
+              isNull(chatEvents.triggerSource),
               isNull(chatEventInputParams.encryptedParams),
             ),
           ),
+          and(
+            chatEventTypeIn(["input.prompt"]),
+            inArray(chatEvents.triggerSource, [
+              "slack",
+              "feishu",
+              "teams",
+              "telegram",
+            ]),
+            isNull(chatEventInputParams.encryptedParams),
+          ),
         ),
-      );
-    signal.throwIfAborted();
+      ),
+    );
+  signal.throwIfAborted();
 
-    const orphanedMessages = result?.orphanedMessages ?? 0;
-    if (orphanedMessages > 0) {
-      throw new OrphanedQueuedChatEventsError(orphanedMessages);
-    }
+  const orphanedMessages = result?.orphanedMessages ?? 0;
+  if (orphanedMessages > 0) {
+    throw new OrphanedQueuedChatEventsError(orphanedMessages);
+  }
 
-    return {
-      success: true as const,
-      orphanedMessages,
-    };
+  return {
+    success: true as const,
+    orphanedMessages,
+  };
+}
+
+export const monitorChatEventQueue$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    return await monitorChatEventQueue(set(writeDb$), signal);
+  },
+);
+
+export const monitorChatEventQueueForEvents$ = command(
+  async ({ set }, eventIds: readonly string[], signal: AbortSignal) => {
+    return await monitorChatEventQueue(set(writeDb$), signal, eventIds);
   },
 );

--- a/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
@@ -40,7 +40,9 @@ async function monitorChatEventQueue(
     )
     .where(
       and(
-        eventIds ? inArray(chatEvents.id, [...eventIds]) : undefined,
+        eventIds === undefined
+          ? undefined
+          : inArray(chatEvents.id, [...eventIds]),
         isNull(chatEvents.runId),
         visibleChatEventCondition(db),
         or(

--- a/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
@@ -1649,9 +1649,9 @@ async function loadDueNotionPendingEvents(args: {
     .from(notionWorkflowPendingEvents)
     .where(
       and(
-        args.automationId
-          ? eq(notionWorkflowPendingEvents.automationId, args.automationId)
-          : undefined,
+        args.automationId === undefined
+          ? undefined
+          : eq(notionWorkflowPendingEvents.automationId, args.automationId),
         eq(notionWorkflowPendingEvents.status, "pending"),
         lte(notionWorkflowPendingEvents.runAfter, args.currentTime),
       ),

--- a/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
@@ -1642,12 +1642,16 @@ async function loadDueNotionPendingEvents(args: {
   readonly db: Db;
   readonly currentTime: Date;
   readonly signal: AbortSignal;
+  readonly automationId?: string;
 }): Promise<readonly NotionPendingRow[]> {
   const rows = await args.db
     .select(notionPendingEventColumns())
     .from(notionWorkflowPendingEvents)
     .where(
       and(
+        args.automationId
+          ? eq(notionWorkflowPendingEvents.automationId, args.automationId)
+          : undefined,
         eq(notionWorkflowPendingEvents.status, "pending"),
         lte(notionWorkflowPendingEvents.runAfter, args.currentTime),
       ),
@@ -1656,6 +1660,45 @@ async function loadDueNotionPendingEvents(args: {
     .limit(NOTION_PENDING_BATCH_SIZE);
   args.signal.throwIfAborted();
   return rows;
+}
+
+async function executeDueNotionWorkflowEvents(args: {
+  readonly db: Db;
+  readonly signal: AbortSignal;
+  readonly automationId?: string;
+  readonly startRun: NotionRunStarter;
+}): Promise<ExecuteDueNotionEventsResult> {
+  const dueEvents = await loadDueNotionPendingEvents({
+    db: args.db,
+    currentTime: nowDate(),
+    signal: args.signal,
+    automationId: args.automationId,
+  });
+  let executed = 0;
+  let skipped = 0;
+  for (const pending of dueEvents) {
+    const claimed = await claimNotionPendingEvent({
+      db: args.db,
+      pending,
+      currentTime: nowDate(),
+      signal: args.signal,
+    });
+    if (!claimed) {
+      continue;
+    }
+    const outcome = await processClaimedNotionPendingEvent({
+      db: args.db,
+      pending: claimed,
+      signal: args.signal,
+      startRun: args.startRun,
+    });
+    if (outcome === "executed") {
+      executed += 1;
+    } else {
+      skipped += 1;
+    }
+  }
+  return { executed, skipped };
 }
 
 async function claimNotionPendingEvent(args: {
@@ -2493,38 +2536,29 @@ export const executeDueNotionWorkflowEvents$ = command(
     { set },
     signal: AbortSignal,
   ): Promise<ExecuteDueNotionEventsResult> => {
-    const db = set(writeDb$);
-    const dueEvents = await loadDueNotionPendingEvents({
-      db,
-      currentTime: nowDate(),
+    return await executeDueNotionWorkflowEvents({
+      db: set(writeDb$),
       signal,
+      startRun: (input, childSignal) => {
+        return set(runWorkflowAutomationNow$, input, childSignal);
+      },
     });
-    let executed = 0;
-    let skipped = 0;
-    for (const pending of dueEvents) {
-      const claimed = await claimNotionPendingEvent({
-        db,
-        pending,
-        currentTime: nowDate(),
-        signal,
-      });
-      if (!claimed) {
-        continue;
-      }
-      const outcome = await processClaimedNotionPendingEvent({
-        db,
-        pending: claimed,
-        signal,
-        startRun: (input, childSignal) => {
-          return set(runWorkflowAutomationNow$, input, childSignal);
-        },
-      });
-      if (outcome === "executed") {
-        executed += 1;
-      } else {
-        skipped += 1;
-      }
-    }
-    return { executed, skipped };
+  },
+);
+
+export const executeDueNotionWorkflowEventsForAutomation$ = command(
+  async (
+    { set },
+    automationId: string,
+    signal: AbortSignal,
+  ): Promise<ExecuteDueNotionEventsResult> => {
+    return await executeDueNotionWorkflowEvents({
+      db: set(writeDb$),
+      automationId,
+      signal,
+      startRun: (input, childSignal) => {
+        return set(runWorkflowAutomationNow$, input, childSignal);
+      },
+    });
   },
 );

--- a/turbo/apps/api/src/signals/services/strapi-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/strapi-workflow-event.service.ts
@@ -650,66 +650,103 @@ async function processPendingEvent(args: {
   return "executed";
 }
 
-export const executeDueStrapiWorkflowEvents$ = command(
-  async (
-    { set },
-    signal: AbortSignal,
-  ): Promise<{ readonly executed: number; readonly skipped: number }> => {
-    const db = set(writeDb$);
-    const due = await db
-      .select(pendingColumns())
-      .from(strapiWorkflowPendingEvents)
-      .where(
-        and(
-          eq(strapiWorkflowPendingEvents.status, "pending"),
-          lte(strapiWorkflowPendingEvents.runAfter, nowDate()),
-        ),
-      )
-      .orderBy(asc(strapiWorkflowPendingEvents.runAfter))
-      .limit(STRAPI_PENDING_BATCH_SIZE);
-    signal.throwIfAborted();
+type ExecuteDueStrapiResult = {
+  readonly executed: number;
+  readonly skipped: number;
+};
 
-    let executed = 0;
-    let skipped = 0;
-    for (const pending of due) {
-      const result = await settle(
-        processPendingEvent({
-          db,
-          pending,
-          signal,
-          startRun: (input, childSignal) => {
-            return set(runWorkflowAutomationNow$, input, childSignal);
-          },
-        }),
-        signal,
-      );
-      if (!result.ok) {
-        if (result.error instanceof StrapiPendingEventChangedError) {
-          continue;
-        }
-        log.error("Failed to process Strapi workflow event", {
-          automationId: pending.automationId,
-          pendingEventId: pending.id,
-          error: result.error,
-        });
-        await retryPendingEvent({
-          db,
-          pending,
-          message:
-            result.error instanceof Error
-              ? result.error.message
-              : "Unknown error",
-          signal,
-        });
-        skipped += 1;
+async function executeDueStrapiWorkflowEvents(args: {
+  readonly db: Db;
+  readonly signal: AbortSignal;
+  readonly automationId?: string;
+  readonly startRun: (
+    input: RunWorkflowAutomationNowArgs,
+    signal: AbortSignal,
+  ) => Promise<RunWorkflowAutomationResult>;
+}): Promise<ExecuteDueStrapiResult> {
+  const due = await args.db
+    .select(pendingColumns())
+    .from(strapiWorkflowPendingEvents)
+    .where(
+      and(
+        args.automationId
+          ? eq(strapiWorkflowPendingEvents.automationId, args.automationId)
+          : undefined,
+        eq(strapiWorkflowPendingEvents.status, "pending"),
+        lte(strapiWorkflowPendingEvents.runAfter, nowDate()),
+      ),
+    )
+    .orderBy(asc(strapiWorkflowPendingEvents.runAfter))
+    .limit(STRAPI_PENDING_BATCH_SIZE);
+  args.signal.throwIfAborted();
+
+  let executed = 0;
+  let skipped = 0;
+  for (const pending of due) {
+    const result = await settle(
+      processPendingEvent({
+        db: args.db,
+        pending,
+        signal: args.signal,
+        startRun: args.startRun,
+      }),
+      args.signal,
+    );
+    if (!result.ok) {
+      if (result.error instanceof StrapiPendingEventChangedError) {
         continue;
       }
-      if (result.value === "executed") {
-        executed += 1;
-      } else {
-        skipped += 1;
-      }
+      log.error("Failed to process Strapi workflow event", {
+        automationId: pending.automationId,
+        pendingEventId: pending.id,
+        error: result.error,
+      });
+      await retryPendingEvent({
+        db: args.db,
+        pending,
+        message:
+          result.error instanceof Error
+            ? result.error.message
+            : "Unknown error",
+        signal: args.signal,
+      });
+      skipped += 1;
+      continue;
     }
-    return { executed, skipped };
+    if (result.value === "executed") {
+      executed += 1;
+    } else {
+      skipped += 1;
+    }
+  }
+  return { executed, skipped };
+}
+
+export const executeDueStrapiWorkflowEvents$ = command(
+  async ({ set }, signal: AbortSignal): Promise<ExecuteDueStrapiResult> => {
+    return await executeDueStrapiWorkflowEvents({
+      db: set(writeDb$),
+      signal,
+      startRun: (input, childSignal) => {
+        return set(runWorkflowAutomationNow$, input, childSignal);
+      },
+    });
+  },
+);
+
+export const executeDueStrapiWorkflowEventsForAutomation$ = command(
+  async (
+    { set },
+    automationId: string,
+    signal: AbortSignal,
+  ): Promise<ExecuteDueStrapiResult> => {
+    return await executeDueStrapiWorkflowEvents({
+      db: set(writeDb$),
+      automationId,
+      signal,
+      startRun: (input, childSignal) => {
+        return set(runWorkflowAutomationNow$, input, childSignal);
+      },
+    });
   },
 );

--- a/turbo/apps/api/src/signals/services/strapi-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/strapi-workflow-event.service.ts
@@ -669,9 +669,9 @@ async function executeDueStrapiWorkflowEvents(args: {
     .from(strapiWorkflowPendingEvents)
     .where(
       and(
-        args.automationId
-          ? eq(strapiWorkflowPendingEvents.automationId, args.automationId)
-          : undefined,
+        args.automationId === undefined
+          ? undefined
+          : eq(strapiWorkflowPendingEvents.automationId, args.automationId),
         eq(strapiWorkflowPendingEvents.status, "pending"),
         lte(strapiWorkflowPendingEvents.runAfter, nowDate()),
       ),

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-poller.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-poller.service.ts
@@ -20,6 +20,8 @@ import {
   type DueWorkflowAutomation,
   type RunFailure,
   type AutomationRow,
+  type RunWorkflowAutomationNowArgs,
+  type RunWorkflowAutomationResult,
 } from "./zero-workflow-automation-run.service";
 import { workflowAutomationCanFire } from "./zero-workflow-automation-access.service";
 import { buildWorkflowScheduleAutomationBrief } from "./zero-workflow-automation-brief.service";
@@ -221,6 +223,7 @@ async function dueWorkflowAutomationRows(
   db: Db,
   currentTime: Date,
   signal: AbortSignal,
+  automationId?: string,
 ): Promise<DueWorkflowAutomationRow[]> {
   const rows = await db
     .select({
@@ -259,6 +262,7 @@ async function dueWorkflowAutomationRows(
     )
     .where(
       and(
+        automationId ? eq(zeroWorkflowAutomations.id, automationId) : undefined,
         eq(zeroWorkflowAutomations.enabled, true),
         eq(zeroWorkflowAutomations.kind, "schedule"),
         lte(zeroWorkflowAutomations.nextRunAt, currentTime),
@@ -267,6 +271,143 @@ async function dueWorkflowAutomationRows(
     .limit(DUE_BATCH_LIMIT);
   signal.throwIfAborted();
   return rows;
+}
+
+async function executeDueWorkflowAutomations(args: {
+  readonly db: Db;
+  readonly signal: AbortSignal;
+  readonly automationId?: string;
+  readonly startRun: (
+    input: RunWorkflowAutomationNowArgs,
+    signal: AbortSignal,
+  ) => Promise<RunWorkflowAutomationResult>;
+}): Promise<ExecuteResult> {
+  const currentTime = nowDate();
+  const rows = await dueWorkflowAutomationRows(
+    args.db,
+    currentTime,
+    args.signal,
+    args.automationId,
+  );
+  let executed = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    const ownerIsMember = await hasOrgMembership(args.db, {
+      orgId: row.automation.orgId,
+      userId: row.automation.ownerUserId,
+    });
+    args.signal.throwIfAborted();
+    if (!ownerIsMember) {
+      log.warn(
+        "Disabling workflow automation: owner is no longer an org member",
+        {
+          automationId: row.automation.id,
+          orgId: row.automation.orgId,
+          userId: row.automation.ownerUserId,
+        },
+      );
+      await args.db
+        .update(zeroWorkflowAutomations)
+        .set({ enabled: false, nextRunAt: null, updatedAt: currentTime })
+        .where(eq(zeroWorkflowAutomations.id, row.automation.id));
+      args.signal.throwIfAborted();
+      skipped++;
+      continue;
+    }
+
+    const canFire = await workflowAutomationCanFire(args.db, {
+      automation: row.automation,
+      agentId: row.agentId,
+      signal: args.signal,
+    });
+    args.signal.throwIfAborted();
+    if (!canFire) {
+      log.debug("Workflow automation skipped: automation is paused", {
+        automationId: row.automation.id,
+        workflowId: row.automation.workflowId,
+        agentId: row.agentId,
+        orgId: row.automation.orgId,
+        userId: row.automation.ownerUserId,
+      });
+      skipped++;
+      continue;
+    }
+
+    const claimed = await claimAutomation(args.db, row.automation, currentTime);
+    args.signal.throwIfAborted();
+    if (!claimed) {
+      skipped++;
+      continue;
+    }
+
+    const chatThreadId = await ensureDueWorkflowAutomationChatThread(
+      args.db,
+      row,
+      currentTime,
+    );
+    args.signal.throwIfAborted();
+
+    const due: DueWorkflowAutomation = {
+      automation: claimed,
+      agentId: row.agentId,
+      chatThreadId,
+    };
+
+    // The tick owns the fire time, so it builds the trigger line here rather
+    // than letting a later drain guess it from its own clock.
+    const scheduleContext = scheduleTriggerContext({
+      automation: claimed,
+      workflowName: row.workflowName,
+      firedAt: currentTime,
+    });
+    const result = await tapError(
+      args.startRun(
+        {
+          due,
+          automationContext: scheduleContext,
+          apiStartTime: now(),
+          triggerBrief:
+            buildWorkflowScheduleAutomationBrief({
+              createdAt: currentTime,
+              scheduleType: claimed.scheduleType,
+              cronExpression: claimed.cronExpression,
+              intervalSeconds: claimed.intervalSeconds,
+              atTime: claimed.atTime,
+              automationTimezone: claimed.timezone,
+              userTimezone: row.userTimezone,
+            }) ?? undefined,
+          dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+        },
+        args.signal,
+      ),
+      async (error) => {
+        await recordPreRunFailure(args.db, claimed, error, args.signal);
+        skipped++;
+      },
+    );
+    args.signal.throwIfAborted();
+    if (!result) {
+      continue;
+    }
+    if (result.kind === "enqueued") {
+      executed++;
+      continue;
+    }
+    if (result.kind !== "ok") {
+      await recordPreRunFailure(args.db, claimed, result, args.signal);
+      skipped++;
+      continue;
+    }
+    executed++;
+  }
+
+  log.debug("execute-workflow-automations tick complete", {
+    dueCount: rows.length,
+    executed,
+    skipped,
+  });
+  return { executed, skipped };
 }
 
 /**
@@ -279,129 +420,29 @@ async function dueWorkflowAutomationRows(
  */
 export const executeDueWorkflowAutomations$ = command(
   async ({ set }, signal: AbortSignal): Promise<ExecuteResult> => {
-    const db = set(writeDb$);
-    const currentTime = nowDate();
-
-    const rows = await dueWorkflowAutomationRows(db, currentTime, signal);
-    let executed = 0;
-    let skipped = 0;
-
-    for (const row of rows) {
-      const ownerIsMember = await hasOrgMembership(db, {
-        orgId: row.automation.orgId,
-        userId: row.automation.ownerUserId,
-      });
-      signal.throwIfAborted();
-      if (!ownerIsMember) {
-        log.warn(
-          "Disabling workflow automation: owner is no longer an org member",
-          {
-            automationId: row.automation.id,
-            orgId: row.automation.orgId,
-            userId: row.automation.ownerUserId,
-          },
-        );
-        await db
-          .update(zeroWorkflowAutomations)
-          .set({ enabled: false, nextRunAt: null, updatedAt: currentTime })
-          .where(eq(zeroWorkflowAutomations.id, row.automation.id));
-        signal.throwIfAborted();
-        skipped++;
-        continue;
-      }
-
-      const canFire = await workflowAutomationCanFire(db, {
-        automation: row.automation,
-        agentId: row.agentId,
-        signal,
-      });
-      signal.throwIfAborted();
-      if (!canFire) {
-        log.debug("Workflow automation skipped: automation is paused", {
-          automationId: row.automation.id,
-          workflowId: row.automation.workflowId,
-          agentId: row.agentId,
-          orgId: row.automation.orgId,
-          userId: row.automation.ownerUserId,
-        });
-        skipped++;
-        continue;
-      }
-
-      const claimed = await claimAutomation(db, row.automation, currentTime);
-      signal.throwIfAborted();
-      if (!claimed) {
-        skipped++;
-        continue;
-      }
-
-      const chatThreadId = await ensureDueWorkflowAutomationChatThread(
-        db,
-        row,
-        currentTime,
-      );
-      signal.throwIfAborted();
-
-      const due: DueWorkflowAutomation = {
-        automation: claimed,
-        agentId: row.agentId,
-        chatThreadId,
-      };
-
-      // The tick owns the fire time, so it builds the trigger line here rather
-      // than letting a later drain guess it from its own clock.
-      const scheduleContext = scheduleTriggerContext({
-        automation: claimed,
-        workflowName: row.workflowName,
-        firedAt: currentTime,
-      });
-      const result = await tapError(
-        set(
-          runWorkflowAutomationNow$,
-          {
-            due,
-            automationContext: scheduleContext,
-            apiStartTime: now(),
-            triggerBrief:
-              buildWorkflowScheduleAutomationBrief({
-                createdAt: currentTime,
-                scheduleType: claimed.scheduleType,
-                cronExpression: claimed.cronExpression,
-                intervalSeconds: claimed.intervalSeconds,
-                atTime: claimed.atTime,
-                automationTimezone: claimed.timezone,
-                userTimezone: row.userTimezone,
-              }) ?? undefined,
-            dispatchFailedCallbacks: dispatchFailedRunCallbacks,
-          },
-          signal,
-        ),
-        async (error) => {
-          await recordPreRunFailure(db, claimed, error, signal);
-          skipped++;
-        },
-      );
-      signal.throwIfAborted();
-      if (!result) {
-        continue;
-      }
-      if (result.kind === "enqueued") {
-        executed++;
-        continue;
-      }
-      if (result.kind !== "ok") {
-        await recordPreRunFailure(db, claimed, result, signal);
-        skipped++;
-        continue;
-      }
-      executed++;
-    }
-
-    log.debug("execute-workflow-automations tick complete", {
-      dueCount: rows.length,
-      executed,
-      skipped,
+    return await executeDueWorkflowAutomations({
+      db: set(writeDb$),
+      signal,
+      startRun: (input, childSignal) => {
+        return set(runWorkflowAutomationNow$, input, childSignal);
+      },
     });
-    return { executed, skipped };
+  },
+);
+
+export const executeDueWorkflowAutomationsForAutomation$ = command(
+  async (
+    { set },
+    automationId: string,
+    signal: AbortSignal,
+  ): Promise<ExecuteResult> => {
+    return await executeDueWorkflowAutomations({
+      db: set(writeDb$),
+      automationId,
+      signal,
+      startRun: (input, childSignal) => {
+        return set(runWorkflowAutomationNow$, input, childSignal);
+      },
+    });
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-poller.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-poller.service.ts
@@ -262,7 +262,9 @@ async function dueWorkflowAutomationRows(
     )
     .where(
       and(
-        automationId ? eq(zeroWorkflowAutomations.id, automationId) : undefined,
+        automationId === undefined
+          ? undefined
+          : eq(zeroWorkflowAutomations.id, automationId),
         eq(zeroWorkflowAutomations.enabled, true),
         eq(zeroWorkflowAutomations.kind, "schedule"),
         lte(zeroWorkflowAutomations.nextRunAt, currentTime),

--- a/turbo/packages/api-contracts/src/contracts/test-cron-monitor-chat-event-queue-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-cron-monitor-chat-event-queue-state.ts
@@ -29,8 +29,21 @@ export const testCronMonitorChatEventQueueStateActionBodySchema =
 export const testCronMonitorChatEventQueueStateActionResponseSchema = z
   .object({
     ok: z.literal(true),
+    compose_id: z.string().uuid().optional(),
+    event_id: z.string().uuid().optional(),
   })
   .passthrough();
+
+export const testCronMonitorChatEventQueueStateMonitorBodySchema = z.object({
+  event_ids: z.array(z.string().uuid()).min(1),
+});
+
+export const testCronMonitorChatEventQueueStateMonitorResponseSchema = z.object(
+  {
+    success: z.literal(true),
+    orphanedMessages: z.number().int().nonnegative(),
+  },
+);
 
 export const testCronMonitorChatEventQueueStateContract = c.router({
   action: {
@@ -43,6 +56,17 @@ export const testCronMonitorChatEventQueueStateContract = c.router({
     },
     summary: "Mutate orphaned queued chat message monitor test state",
   },
+  monitor: {
+    method: "POST",
+    path: "/api/test/cron-monitor-chat-event-queue-state/monitor",
+    body: testCronMonitorChatEventQueueStateMonitorBodySchema,
+    responses: {
+      200: testCronMonitorChatEventQueueStateMonitorResponseSchema,
+      404: z.string(),
+      500: z.object({ error: z.string() }),
+    },
+    summary: "Monitor selected queued chat events in API tests",
+  },
 });
 
 export type TestCronMonitorChatEventQueueStateActionBody = z.infer<
@@ -50,6 +74,9 @@ export type TestCronMonitorChatEventQueueStateActionBody = z.infer<
 >;
 export type TestCronMonitorChatEventQueueStateActionResponse = z.infer<
   typeof testCronMonitorChatEventQueueStateActionResponseSchema
+>;
+export type TestCronMonitorChatEventQueueStateMonitorBody = z.infer<
+  typeof testCronMonitorChatEventQueueStateMonitorBodySchema
 >;
 export type TestCronMonitorChatEventQueueStateContract =
   typeof testCronMonitorChatEventQueueStateContract;

--- a/turbo/packages/api-contracts/src/contracts/test-workflow-automation-execution.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-workflow-automation-execution.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const testWorkflowAutomationExecutionRequestSchema = z.object({
+  automation_id: z.string().uuid(),
+});
+
+export const testWorkflowAutomationExecutionResponseSchema = z.object({
+  success: z.literal(true),
+  executed: z.number().int().nonnegative(),
+  skipped: z.number().int().nonnegative(),
+});
+
+export const testWorkflowAutomationExecutionContract = c.router({
+  execute: {
+    method: "POST",
+    path: "/api/test/workflow-automation-execution/execute",
+    body: testWorkflowAutomationExecutionRequestSchema,
+    responses: {
+      200: testWorkflowAutomationExecutionResponseSchema,
+      404: z.string(),
+    },
+    summary: "Execute one workflow automation in API tests",
+  },
+});
+
+export type TestWorkflowAutomationExecutionRequest = z.infer<
+  typeof testWorkflowAutomationExecutionRequestSchema
+>;
+export type TestWorkflowAutomationExecutionResponse = z.infer<
+  typeof testWorkflowAutomationExecutionResponseSchema
+>;
+export type TestWorkflowAutomationExecutionContract =
+  typeof testWorkflowAutomationExecutionContract;


### PR DESCRIPTION
## Summary

- add test-only event-ID-scoped monitoring for queued chat events so parallel files cannot affect monitor assertions
- add one automation-ID-scoped test execution boundary covering schedule, Notion, and Strapi pollers
- migrate every API test caller away from the shared production sweep and give each Strapi test process a unique synthetic tenant that exercises the real rollout hash

## Scope

- production cron routes, command signatures, execution order, and response behavior remain unchanged
- test-only routes return 404 in production and are registered explicitly only by tests
- no schema, migration, public API, frontend, runner, timeout, or test-serialization changes

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm knip`
- focused affected API tests with `--maxWorkers=4`: 5 files, 50 tests passed
- Strapi integration test repeated twice against the same database: 3 tests passed on each run
- full Turbo Vitest suite with an independent database reset/migrate/seed and `--maxWorkers=4`: 181 files, 2597 tests passed
- repeated the independent full-suite run: 181 files, 2597 tests passed

Closes #24555
