### PR TITLE
test(python): cover model catalog cache hit recency eviction

### DIFF
--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_lifecycle.py
@@ -142,6 +142,34 @@ async def test_failed_responses_etag_does_not_invalidate_catalog(real_flow):
     assert telemetry == {}
 
 
+async def test_fresh_hit_changes_count_bound_eviction_order(real_flow):
+    small_body = b'{"models":[]}'
+    for index in range(catalog_cache.MAX_ENTRIES):
+        await install_catalog(
+            catalog_flow(real_flow, version=f"lru-{index}"),
+            body=small_body,
+            etag=f'"lru-{index}"',
+        )
+
+    recently_used = catalog_flow(real_flow, version="lru-0")
+    await catalog_cache.prepare_request(recently_used, request_end_stream=True)
+    assert recently_used.response is not None
+
+    await install_catalog(
+        catalog_flow(real_flow, version="lru-overflow"),
+        body=small_body,
+        etag='"lru-overflow"',
+    )
+
+    untouched = catalog_flow(real_flow, version="lru-1")
+    await prepare_miss(untouched)
+    catalog_cache.handle_error(untouched)
+
+    retained = catalog_flow(real_flow, version="lru-0")
+    await catalog_cache.prepare_request(retained, request_end_stream=True)
+    assert retained.response is not None
+
+
 async def test_count_and_byte_bounds_evict_least_recent_entries(real_flow):
     small_body = b'{"models":[]}'
     for index in range(catalog_cache.MAX_ENTRIES + 1):


### PR DESCRIPTION
## Summary

- add focused integration coverage for fresh-hit LRU promotion in the Codex model catalog cache
- force the real count bound through public request and response lifecycle hooks
- verify an untouched entry is evicted while the recently hit entry remains cached

## Scope

This PR changes tests only. It does not change cache behavior, limits, APIs, protocols, persistent state, dependencies, deployment compatibility, or documentation.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`4555 passed`)
- mutation check: removing the fresh-hit `_entries.move_to_end(key)` makes the new test fail at the expected eviction assertion

Closes #24572
