### PR TITLE
docs(rust): document quiesce state contract

### DIFF
--- a/crates/vsock-guest/src/quiesce.rs
+++ b/crates/vsock-guest/src/quiesce.rs
@@ -1,6 +1,29 @@
+//! Guest-operation admission and quiesce state for one host connection.
+//!
+//! An [`OperationState`] starts open. Each successful
+//! [`OperationState::acquire`] admits one logical operation and increments its
+//! pending count. [`OperationState::enter_quiescing`] atomically closes
+//! admission before inspecting that count, so both [`QuiesceResult::Quiesced`]
+//! and [`QuiesceResult::Busy`] leave new operations fenced.
+//!
+//! Entering quiescing does not wait for pending operations, register a waiter,
+//! or send a later notification. A busy result is a point-in-time count; the
+//! existing operations finish independently. Once they finish, the host must
+//! retry the quiesce request to receive a quiesced acknowledgement. If the
+//! attempt is abandoned instead, [`OperationState::resume`] explicitly reopens
+//! admission, including while previously admitted operations remain pending.
+//!
+//! One acquire creates one shared [`OperationGuard`]. Cloning the guard shares
+//! ownership of that logical operation and does not increment the pending
+//! count. The count is released by [`OperationGuard::release`] or, if it is not
+//! released explicitly, when the final guard clone drops.
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
+/// Shared operation-admission state owned by one connection dispatcher.
+///
+/// Clones refer to the same mode and pending-operation count.
 #[derive(Clone, Default)]
 pub(crate) struct OperationState {
     inner: Arc<Mutex<Inner>>,
@@ -26,17 +49,32 @@ impl Default for Inner {
     }
 }
 
+/// Reason a new guest operation cannot be admitted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AcquireOperationError {
+    /// The connection has fenced new operations for quiescing.
     Quiescing,
 }
 
+/// Result of fencing new operations and observing the pending count.
+///
+/// Both variants leave the state quiescing until [`OperationState::resume`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum QuiesceResult {
+    /// Admission is fenced and no operations are pending.
     Quiesced,
-    Busy { pending: usize },
+    /// Admission is fenced, but previously admitted operations remain active.
+    Busy {
+        /// Point-in-time number of pending logical operations.
+        pending: usize,
+    },
 }
 
+/// Shared ownership token for one admitted logical operation.
+///
+/// A successful [`OperationState::acquire`] increments the pending count once.
+/// Cloning this guard does not increment it again. Unless any clone calls
+/// [`Self::release`], the count is decremented when the final clone drops.
 #[derive(Clone)]
 pub(crate) struct OperationGuard {
     inner: Arc<OperationGuardInner>,
@@ -48,6 +86,11 @@ struct OperationGuardInner {
 }
 
 impl OperationState {
+    /// Admit one logical operation and increment the pending count.
+    ///
+    /// The mode check and increment share the same lock as
+    /// [`Self::enter_quiescing`], so an operation is either admitted before the
+    /// quiescing fence or rejected after it; it cannot cross the transition.
     pub(crate) fn acquire(&self) -> Result<OperationGuard, AcquireOperationError> {
         let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if inner.mode == Mode::Quiescing {
@@ -62,6 +105,13 @@ impl OperationState {
         })
     }
 
+    /// Fence new operations and report the current pending count.
+    ///
+    /// The state is latched to quiescing before the count is inspected. A
+    /// [`QuiesceResult::Busy`] result therefore does not roll back admission,
+    /// wait for the reported operations, or arrange a later notification. The
+    /// caller must retry after they finish or call [`Self::resume`] to reopen
+    /// admission.
     pub(crate) fn enter_quiescing(&self) -> QuiesceResult {
         let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         inner.mode = Mode::Quiescing;
@@ -74,10 +124,18 @@ impl OperationState {
         }
     }
 
+    /// Reopen operation admission without changing the pending count.
+    ///
+    /// This is the explicit recovery transition after a completed, failed, or
+    /// aborted quiesce attempt.
     pub(crate) fn resume(&self) {
         self.inner.lock().unwrap_or_else(|e| e.into_inner()).mode = Mode::Open;
     }
 
+    /// Return whether new operations are currently fenced.
+    ///
+    /// This is only a snapshot; unlike [`Self::acquire`], it does not reserve
+    /// admission for a new operation.
     pub(crate) fn is_quiescing(&self) -> bool {
         self.inner.lock().unwrap_or_else(|e| e.into_inner()).mode == Mode::Quiescing
     }
@@ -94,6 +152,10 @@ impl OperationState {
 }
 
 impl OperationGuard {
+    /// Release this logical operation before the final guard clone drops.
+    ///
+    /// Release is shared by all clones and idempotent: the first call
+    /// decrements the pending count, and later calls or drops do nothing.
     pub(crate) fn release(&self) {
         if !self.inner.released.swap(true, Ordering::AcqRel) {
             self.inner.state.release_one();

--- a/crates/vsock-host/src/connection/request.rs
+++ b/crates/vsock-host/src/connection/request.rs
@@ -501,11 +501,31 @@ impl VsockHost {
 
     /// Ask the guest to quiesce its own operation dispatcher.
     ///
+    /// On receipt, the guest atomically fences new operations before checking
+    /// its pending-operation count. If the guest reports that operations are
+    /// still pending, this method returns an error but guest admission remains
+    /// fenced. Those operations finish independently; the guest does not wait
+    /// or send a later acknowledgement. The caller must either retry this
+    /// method after they drain or call [`Self::resume_operations`] to abandon
+    /// the attempt and reopen guest admission.
+    ///
     /// This does not fence host-side normal operations. Callers that need a
     /// no-new-normal-operation boundary must hold a
     /// [`crate::NormalOperationFence`] before sending this lifecycle request.
+    /// A transport error or timeout does not reveal whether the guest received
+    /// the request. A caller that keeps using the guest after such an uncertain
+    /// attempt must explicitly resume guest operations before releasing its
+    /// host-side fence.
+    ///
     /// The timeout covers waiting for the shared writer, writing the request,
     /// and waiting for the response.
+    ///
+    /// # Errors
+    ///
+    /// Returns the request error if the guest cannot be reached, does not
+    /// respond before the deadline, or reports pending operations or another
+    /// lifecycle error. An unexpected response type or non-empty
+    /// acknowledgement returns [`io::ErrorKind::InvalidData`].
     pub async fn quiesce_operations(&self, timeout: Duration) -> io::Result<()> {
         self.lifecycle_request(
             MSG_QUIESCE_OPERATIONS,
@@ -518,8 +538,22 @@ impl VsockHost {
 
     /// Resume guest operations after a failed or aborted quiesce attempt.
     ///
+    /// Resume reopens guest admission immediately without waiting for
+    /// previously admitted operations to finish. The transition is idempotent,
+    /// so callers may use it after a guest-reported busy result or a
+    /// delivery-uncertain quiesce failure. This does not release a held
+    /// [`crate::NormalOperationFence`]; the caller retains ownership of that
+    /// host-side boundary.
+    ///
     /// The timeout covers waiting for the shared writer, writing the request,
     /// and waiting for the response.
+    ///
+    /// # Errors
+    ///
+    /// Returns the request error if the guest cannot be reached, does not
+    /// respond before the deadline, or reports a lifecycle error. An unexpected
+    /// response type or non-empty acknowledgement returns
+    /// [`io::ErrorKind::InvalidData`].
     pub async fn resume_operations(&self, timeout: Duration) -> io::Result<()> {
         self.lifecycle_request(
             MSG_RESUME_OPERATIONS,


### PR DESCRIPTION
## Summary

- document the guest operation admission and quiesce state flow, including stateful busy results and explicit retry/resume behavior
- document shared `OperationGuard` clone, drop, and idempotent early-release ownership
- clarify public host lifecycle recovery while distinguishing guest-confirmed busy responses from delivery-uncertain errors

## Scope

- documentation only
- no runtime behavior, API signature, protocol message, synchronization, test, migration, or rollout changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo clippy -p vsock-guest --release --no-default-features --all-targets`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p vsock-guest -p vsock-host`
- `git diff --check`

Closes #24570
