### PR TITLE
docs(guest-agent): document app-server event policy

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -1,9 +1,38 @@
-//! Compatibility mapping from Codex app-server notifications to Codex JSONL events.
+//! Compatibility policy for adapting Codex app-server notifications to Codex JSONL events.
+//!
+//! This module is the normalization boundary between the evolving app-server
+//! notification surface and the established JSONL shape consumed by guest-agent
+//! event ingestion. Notifications are not forwarded verbatim: supported
+//! lifecycle, plan, item, warning, and error notifications are validated and
+//! translated into the existing event and diagnostic conventions. Malformed
+//! required data on a supported notification returns an error so the backend
+//! fails the execution instead of emitting a partial event.
+//!
+//! Item and command delta/progress notifications do not emit events because
+//! completed-item snapshots provide the canonical output and emitting both would
+//! duplicate partial content. Other configured opt-out methods likewise do not
+//! emit, and unknown methods are ignored for forward compatibility.
+//!
+//! Item starts are deliberately asymmetric. Command execution starts become
+//! JSONL `item.started` events, while reasoning and agent-message starts are
+//! captured separately as first-output timing metadata. Other item starts are
+//! ignored. Completed items with known types receive strict, type-specific
+//! normalization. Unknown completed types use a bounded, shallow, and lossy
+//! projection: names become snake case, scalar data is retained, nested data is
+//! dropped, and collections beyond fixed limits are omitted.
+//!
+//! Statuses, file-change patch kinds, and error fields are normalized into the
+//! legacy JSONL and failure-diagnostic shapes rather than preserving their raw
+//! app-server representation.
 
 use serde_json::{Map, Value, json};
 
 use super::codex_app_server::ServerNotification;
 
+/// Notification methods that emit no JSONL event and are requested as app-server opt-outs.
+///
+/// The backend advertises this set during initialization. If app-server still
+/// sends one of these notifications, the mapper ignores it.
 pub(super) const IGNORED_NOTIFICATION_METHODS: &[&str] = &[
     "command/exec/outputDelta",
     "process/outputDelta",
@@ -106,6 +135,11 @@ pub(super) enum CodexAppServerEventError {
     InvalidField { method: String, field: &'static str },
 }
 
+/// Extract a notification's thread id for early secondary-thread filtering.
+///
+/// This is a best-effort lookup performed before strict event mapping. Missing,
+/// empty, malformed, or unsupported thread-id locations return `None`; a later
+/// supported mapper can still reject the notification as malformed.
 pub(super) fn notification_thread_id(notification: &ServerNotification) -> Option<&str> {
     let params = notification.params.as_ref()?;
     let thread_id = match notification.method.as_str() {
@@ -117,6 +151,12 @@ pub(super) fn notification_thread_id(notification: &ServerNotification) -> Optio
     thread_id.as_str().filter(|thread_id| !thread_id.is_empty())
 }
 
+/// Extract first-output timing metadata from a reasoning or agent-message start.
+///
+/// Non-`item/started` notifications and other valid started item kinds return
+/// `Ok(None)`. Selected starts require valid thread, turn, and epoch timestamp
+/// fields. The backend records this metadata separately because these starts do
+/// not become JSONL item events.
 pub(super) fn codex_output_item_start(
     notification: &ServerNotification,
 ) -> Result<Option<CodexOutputItemStart>, CodexAppServerEventError> {
@@ -152,8 +192,10 @@ pub(super) fn codex_output_item_start(
 
 /// Convert a Codex app-server notification into the existing Codex JSONL event shape.
 ///
-/// Unsupported notifications and app-server delta/progress notifications return `Ok(None)`.
-/// Supported notifications with malformed required fields return an error.
+/// `Ok(Some(_))` contains a normalized event. Deliberately non-emitting
+/// notifications, unknown methods, and started item kinds without a JSONL event
+/// return `Ok(None)`. Supported notifications with malformed required fields
+/// return an error.
 pub(super) fn notification_to_codex_event(
     notification: &ServerNotification,
 ) -> Result<Option<Value>, CodexAppServerEventError> {

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -18,8 +18,9 @@
 //! captured separately as first-output timing metadata. Other item starts are
 //! ignored. Completed items with known types receive strict, type-specific
 //! normalization. Unknown completed types use a bounded, shallow, and lossy
-//! projection: names become snake case, scalar data is retained, nested data is
-//! dropped, and collections beyond fixed limits are omitted.
+//! projection: names become snake case, scalar values and scalar members of
+//! shallow collections are retained, deeper collections are dropped, and
+//! collections beyond fixed limits are omitted.
 //!
 //! Statuses, file-change patch kinds, and error fields are normalized into the
 //! legacy JSONL and failure-diagnostic shapes rather than preserving their raw


### PR DESCRIPTION
## Summary

- document the private compatibility boundary from Codex app-server notifications to the established JSONL event shape
- explain strict supported mappings, deliberate non-emitting notifications, asymmetric item-start timing, and the bounded generic completed-item fallback
- add concise contracts for the ignored-method set and backend-facing mapping helpers

## Compatibility

- documentation only; no runtime behavior or event shapes changed
- no API, runner protocol, schema, persisted data, dependency, performance, or rollout changes

## Tests

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p guest-agent --all-targets --all-features`
- `cd crates && cargo doc -p guest-agent --all-features --no-deps`
- `cd crates && cargo test -p guest-agent codex_app_server_events`
- `cd crates && cargo test -p guest-agent --test codex_app_server_backend`
- pre-commit hooks: cargo-fmt, cargo-doc, cargo-clippy, check-file-size

Closes #24571
