### PR TITLE
perf(python): avoid duplicate connector auth query parsing

### DIFF
--- a/crates/runner/mitm-addon/src/connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/connector_diagnostics.py
@@ -49,6 +49,7 @@ import flow_metadata_keys as metadata_keys
 import matching
 import network_log_sanitization
 import request_classification
+import runtime_url_parsing
 from logging_utils import log_proxy_entry
 
 _HTTP_STATUS_UNAUTHORIZED = 401
@@ -270,9 +271,50 @@ def install_response_stream_if_needed(flow: http.HTTPFlow) -> bool:
     diagnostic callback was installed, although candidate lookup may have
     populated flow-private cache state.
     """
-    if not _should_stream_response(flow):
+    if flow.response is None:
         return False
-    return _install_response_stream(flow)
+    if flow.response.status_code not in (
+        _HTTP_STATUS_UNAUTHORIZED,
+        _HTTP_STATUS_FORBIDDEN,
+    ):
+        return False
+    if _is_browser_diagnostic_skip(flow):
+        return False
+
+    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
+    if not isinstance(original_url, str):
+        return False
+    candidate = _resolve_candidate(flow, original_url=original_url)
+    if candidate is None:
+        return False
+    if _request_has_auth_material(flow, candidate, original_url):
+        return False
+
+    upstream_status = flow.response.status_code
+    _set_failure_metadata(flow, candidate)
+    body = _replace_response_content(
+        flow,
+        candidate,
+        upstream_status=upstream_status,
+    )
+    if body is None:
+        return False
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_BODY] = body
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS] = True
+
+    def stream_connector_diagnostic_response(chunk: bytes) -> bytes | tuple[bytes, ...]:
+        if chunk:
+            return _EMPTY_RESPONSE_STREAM_CHUNKS
+        if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT):
+            return _EMPTY_RESPONSE_STREAM_CHUNKS
+        flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT] = True
+        return body
+
+    flow.response.stream = stream_connector_diagnostic_response
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK] = (
+        stream_connector_diagnostic_response
+    )
+    return True
 
 
 def maybe_replace_response(
@@ -615,7 +657,7 @@ def _request_has_auth_material(
     configured_query_params = set(candidate.auth_query_param_names)
     normalized_configured_query_params = {name.lower() for name in candidate.auth_query_param_names}
     try:
-        parsed = urllib.parse.urlparse(original_url)
+        parsed = runtime_url_parsing.split_runtime_url(original_url)
     except ValueError:
         return False
     for name, value in urllib.parse.parse_qsl(parsed.query, keep_blank_values=True):
@@ -722,65 +764,6 @@ def _log_proxy_entry(
 
 def _firewall_allow_is_unknown_endpoint(allow: matching.FirewallAllow) -> bool:
     return allow.permission is None and allow.rule is None
-
-
-def _should_stream_response(flow: http.HTTPFlow) -> bool:
-    if flow.response is None:
-        return False
-    if flow.response.status_code not in (
-        _HTTP_STATUS_UNAUTHORIZED,
-        _HTTP_STATUS_FORBIDDEN,
-    ):
-        return False
-    if _is_browser_diagnostic_skip(flow):
-        return False
-
-    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
-    if not isinstance(original_url, str):
-        return False
-    candidate = _resolve_candidate(flow, original_url=original_url)
-    if candidate is None:
-        return False
-    return not _request_has_auth_material(flow, candidate, original_url)
-
-
-def _install_response_stream(flow: http.HTTPFlow) -> bool:
-    if flow.response is None:
-        return False
-    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
-    if not isinstance(original_url, str):
-        return False
-    candidate = _resolve_candidate(flow, original_url=original_url)
-    if candidate is None:
-        return False
-    if _request_has_auth_material(flow, candidate, original_url):
-        return False
-
-    upstream_status = flow.response.status_code
-    _set_failure_metadata(flow, candidate)
-    body = _replace_response_content(
-        flow,
-        candidate,
-        upstream_status=upstream_status,
-    )
-    if body is None:
-        return False
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_BODY] = body
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS] = True
-
-    def stream_connector_diagnostic_response(chunk: bytes) -> bytes | tuple[bytes, ...]:
-        if chunk:
-            return _EMPTY_RESPONSE_STREAM_CHUNKS
-        if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT):
-            return _EMPTY_RESPONSE_STREAM_CHUNKS
-        flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT] = True
-        return body
-
-    flow.response.stream = stream_connector_diagnostic_response
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK] = (
-        stream_connector_diagnostic_response
-    )
-    return True
 
 
 def _is_browser_diagnostic_skip(flow: http.HTTPFlow) -> bool:

--- a/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
@@ -1,9 +1,12 @@
 """Response hook integration tests for connector diagnostics."""
 
 import json
+import urllib.parse
+from unittest.mock import patch
 
 from mitmproxy.test import tutils
 
+import connector_diagnostics
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 from tests.connector_diagnostic_helpers import (
@@ -225,6 +228,47 @@ async def test_streams_unauthenticated_connector_401_diagnostic_without_upstream
     assert entry["response_body_encoding"] == "utf-8"
     proxy_entries = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
     assert sum(entry["type"] == "connector_diagnostic" for entry in proxy_entries) == 1
+
+
+def test_responseheaders_parses_large_connector_auth_query_once(tmp_path, real_flow, mitm_ctx):
+    reg_path = write_connector_diagnostic_capture_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="fal.run",
+        path=f"/fal-ai/nano-banana-pro?noise={'x' * 200_000}",
+        method="POST",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        record_connector_diagnostic_requestheaders_context(flow)
+        flow.response = tutils.tresp(
+            status_code=401,
+            headers=header_map({"content-type": "text/plain"}),
+            content=b"upstream",
+        )
+
+        urllib.parse.urlsplit.cache_clear()
+        try:
+            urllib.parse.urlsplit("https://stable-config.example.com")
+            stable_cache = urllib.parse.urlsplit.cache_info()
+            real_parse_qsl = urllib.parse.parse_qsl
+            with patch.object(
+                connector_diagnostics.urllib.parse,
+                "parse_qsl",
+                wraps=real_parse_qsl,
+            ) as parse_qsl:
+                mitm_addon.responseheaders(flow)
+
+            assert parse_qsl.call_count == 1
+            assert urllib.parse.urlsplit.cache_info() == stable_cache
+        finally:
+            urllib.parse.urlsplit.cache_clear()
+
+        diagnostic_body = _drain_connector_diagnostic_response_stream(flow)
+        mitm_addon.response(flow)
+
+    assert flow.response.content == diagnostic_body
 
 
 async def test_restores_connector_diagnostic_body_when_headers_end_stream(

--- a/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 
 from mitmproxy.test import tutils
 
-import connector_diagnostics
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 from tests.connector_diagnostic_helpers import (
@@ -232,11 +231,12 @@ async def test_streams_unauthenticated_connector_401_diagnostic_without_upstream
 
 def test_responseheaders_parses_large_connector_auth_query_once(tmp_path, real_flow, mitm_ctx):
     reg_path = write_connector_diagnostic_capture_registry(tmp_path)
+    query = "&".join(["noise=x"] * 25_000)
     flow = real_flow(
         with_response=False,
         client_ip="10.200.0.5",
         host="fal.run",
-        path=f"/fal-ai/nano-banana-pro?noise={'x' * 200_000}",
+        path=f"/fal-ai/nano-banana-pro?{query}",
         method="POST",
     )
 
@@ -254,7 +254,7 @@ def test_responseheaders_parses_large_connector_auth_query_once(tmp_path, real_f
             stable_cache = urllib.parse.urlsplit.cache_info()
             real_parse_qsl = urllib.parse.parse_qsl
             with patch.object(
-                connector_diagnostics.urllib.parse,
+                urllib.parse,
                 "parse_qsl",
                 wraps=real_parse_qsl,
             ) as parse_qsl:


### PR DESCRIPTION
## Summary

- make the connector diagnostic response-header installer evaluate request auth material once
- parse request-derived diagnostic URLs through the existing uncached runtime URL boundary
- add a real response-header integration regression for one query scan and unchanged global URL cache state

## Scope

This is limited to the runner mitmproxy addon. It does not add flow metadata, a custom query parser, dependencies, APIs, schemas, persistence, protocols, feature switches, or deployment-order requirements.

## Validation

- baseline regression before the production change: expected failure, `parse_qsl` called 2 times instead of 1
- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_response_handler_connector_diagnostics.py tests/test_request_handler_connector_diagnostics.py tests/test_error_handler.py` (65 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4555 passed)

Closes #24573
