### PR TITLE
refactor: reduce fallback slop in spotify auth

### DIFF
--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/spotify.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/spotify.test.ts
@@ -77,6 +77,34 @@ describe("connector/providers/spotify", () => {
       expect(result.userInfo.email).toBe("test@example.com");
     });
 
+    it("rejects user info without the required Spotify user id", async () => {
+      const tokenHandler = http.post(
+        "https://accounts.spotify.com/api/token",
+        () => {
+          return HttpResponse.json({
+            access_token: "spotify-test-token",
+          });
+        },
+      );
+      const meHandler = http.get("https://api.spotify.com/v1/me", () => {
+        return HttpResponse.json({
+          display_name: "Test Spotify User",
+          email: "test@example.com",
+        });
+      });
+      server.use(tokenHandler, meHandler);
+
+      await expect(
+        exchangeSpotifyCode(
+          authCodeGrant(),
+          "client-id",
+          "client-secret",
+          "test-code",
+          "https://example.com/callback",
+        ),
+      ).rejects.toThrow("No user id in Spotify user info response");
+    });
+
     it("throws when Spotify returns an error in response body", async () => {
       const tokenHandler = http.post(
         "https://accounts.spotify.com/api/token",

--- a/turbo/packages/connectors/src/auth-providers/connectors/spotify/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/spotify/oauth.ts
@@ -193,8 +193,12 @@ async function fetchSpotifyUserInfo(
     })
     .parse(await response.json());
 
+  if (!data.id) {
+    throw new Error("No user id in Spotify user info response");
+  }
+
   return {
-    id: data.id ?? "",
+    id: data.id,
     username: data.display_name ?? null,
     email: data.email ?? null,
   };


### PR DESCRIPTION
## Summary

- Reject Spotify `/v1/me` responses that omit the required user ID instead of constructing a connector grant identity with `id: ""`.
- Add regression coverage for the complete OAuth token and user-info exchange when Spotify omits that ID.

## Scan

- Timestamp: `2026-08-02T20:01:32.107Z`
- Base commit: `97ca272d150383c8cc69252bce125a00be04ff93`
- Files scanned: 3,939
- High-confidence production actionable candidates: 233
- Initial 5% edit budget: 12
- Candidates changed after manual safety review: 1

### Matches by category

| Category | Matches |
| --- | ---: |
| nullish | 6,229 |
| nullish-chain | 135 |
| field-fallback-chain | 106 |
| optional-prop | 6,107 |
| zod-optional | 2,592 |
| zod-loose-optional | 5 |
| loose-record | 1,092 |
| loose-index-signature | 3 |
| as-any | 0 |
| as-unknown-as | 30 |
| empty-fallback | 630 |
| string-fallback | 670 |
| null-undefined-fallback | 1,698 |
| empty-catch | 3 |
| promise-catch-swallow | 16 |
| rust-unwrap-or | 667 |
| rust-ok-discard | 156 |

## Files changed

- `turbo/packages/connectors/src/auth-providers/connectors/spotify/oauth.ts`: fail fast before constructing `SpotifyUserInfo` because vm0 requires a stable external identity ID and Spotify's current-user profile contract supplies it.
- `turbo/packages/connectors/src/auth-providers/connectors/__tests__/spotify.test.ts`: cover both the successful full exchange and the missing-required-ID response at the external HTTP boundary.

The post-change scan reduced `string-fallback` from 670 to 669 and `nullish` from 6,229 to 6,228. The other candidates were intentionally left for later daily runs because they require separate compatibility analysis or are lower-confidence display/external-adapter fallbacks.

## Verification

- Connectors Vitest package suite: 33 files, 823 tests passed.
- `pnpm --filter @vm0/connectors lint` passed; it reported one pre-existing `unicorn(no-useless-spread)` warning in `src/firewall-types.ts`.
- `pnpm --filter @vm0/connectors check-types` passed.
- `git diff --check` passed.

