### PR TITLE
test(api): stabilize clerk cleanup synchronization

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -5119,6 +5119,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     const response = await api.requestClerkWebhook("{}", {}, [200]);
     expect(response.body).toBe("OK");
 
+    await flushWaitUntilForTest();
     await waitForExpectation(() => {
       expect(context.mocks.stripe.subscriptions.list).toHaveBeenCalledWith({
         customer: granted.customerId,


### PR DESCRIPTION
## Summary

- drain the tracked Clerk `user.deleted` `waitUntil` cleanup before asserting its final billing outcome
- keep the production webhook's immediate acknowledgement behavior unchanged
- preserve the Stripe non-cancellation assertions while removing their dependency on background scheduling speed

## Failure evidence

- Trigger: [Turbo run 30765350320](https://github.com/vm0-ai/vm0/actions/runs/30765350320), `push` on `main` at `2ecae71728d0ef0fb77449fab1d815053cc88b63`
- First causal failure: `WHCB-08: Clerk deletion webhooks tear down account state > does not update a Stripe subscription already canceled upstream`
- The test observed `["pro", "active", true]` instead of the final `["pro-suspend", null, false]` billing state and timed out
- The same SHA passed the corresponding shard in [merge-group Turbo run 30765130785](https://github.com/vm0-ai/vm0/actions/runs/30765130785)
- Two Feishu tests timed out later in the failed shard. They passed in the same-SHA comparison run and are not changed here because they are downstream load companions rather than the first causal failure

## Root cause

The Clerk webhook intentionally returns before its `waitUntil` cleanup finishes. The test waited for `stripe.subscriptions.list`, but that mock call is only an intermediate event: user and organization deletion continues afterward. Under a slower shard schedule, the billing poll could run before cleanup reached the domain-complete state.

The fix uses the existing `flushWaitUntilForTest()` domain boundary immediately after the webhook acknowledgement, so the final-state assertion starts only after all tracked cleanup work has settled.

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged repository, platform, and API type checks
- target test passed 5 consecutive isolated runs
- pre-commit and commit-message hooks passed

Additional full-file coverage reached 34/44 passing tests. The remaining 10 could not reach their assertions because the local PostgreSQL 18 migration stopped at an existing legacy-constraint audit, leaving `org_model_policies.model_provider_surface_id` unavailable. This is a local schema setup limitation, not a failure caused by this test-only diff.
