### PR TITLE
docs(rust): clarify read_file non-regular path semantics

### DIFF
--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -336,11 +336,12 @@ pub trait Sandbox: Send + Sync + Any {
     /// The guest path must be non-empty and must not contain NUL bytes.
     /// `max_bytes` must be positive and is subject to the backend read limit.
     ///
-    /// Returns `Ok(None)` when the backend cannot establish that the path
-    /// resolves to a regular file. This includes missing paths, paths to
-    /// non-regular filesystem objects, broken symlinks, and paths whose guest
-    /// filesystem metadata cannot be inspected. Symlinks that resolve to
-    /// regular files are followed and read.
+    /// Returns `Ok(None)` when the backend's guest-filesystem check cannot
+    /// establish that the path resolves to a regular file. This includes
+    /// missing paths, paths to non-regular filesystem objects, broken
+    /// symlinks, and paths whose guest filesystem metadata cannot be
+    /// inspected. Symlinks that resolve to regular files are followed and
+    /// read.
     ///
     /// A read that races with a path transition can also return `Ok(None)` if
     /// regular-file status can no longer be established. Invalid input,

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -336,7 +336,16 @@ pub trait Sandbox: Send + Sync + Any {
     /// The guest path must be non-empty and must not contain NUL bytes.
     /// `max_bytes` must be positive and is subject to the backend read limit.
     ///
-    /// Missing files return `Ok(None)`. Other read failures return an error.
+    /// Returns `Ok(None)` when the backend cannot establish that the path
+    /// resolves to a regular file. This includes missing paths, paths to
+    /// non-regular filesystem objects, broken symlinks, and paths whose guest
+    /// filesystem metadata cannot be inspected. Symlinks that resolve to
+    /// regular files are followed and read.
+    ///
+    /// A read that races with a path transition can also return `Ok(None)` if
+    /// regular-file status can no longer be established. Invalid input,
+    /// guest-operation or capture failures, size-limit violations, and read
+    /// failures for a path still established as regular return an error.
     async fn read_file(&self, path: &str, max_bytes: u64) -> Result<Option<Vec<u8>>>;
 
     /// Stream a guest file to a host path and publish copied contents.

--- a/crates/vsock-host/src/file/read.rs
+++ b/crates/vsock-host/src/file/read.rs
@@ -145,8 +145,17 @@ impl VsockHost {
     /// `max_bytes` must be positive and fit within the exec capture limit.
     /// `timeout_ms` must be positive.
     ///
-    /// Missing files return `Ok(None)`. Files larger than `max_bytes` return
-    /// an error instead of silently returning truncated bytes.
+    /// Returns `Ok(None)` when the guest-side check cannot establish that the
+    /// path resolves to a regular file. This includes missing paths, paths to
+    /// non-regular filesystem objects, broken symlinks, and paths whose
+    /// filesystem metadata cannot be inspected. Symlinks that resolve to
+    /// regular files are followed and read.
+    ///
+    /// A failed read is checked again and can return `Ok(None)` if
+    /// regular-file status can no longer be established. Invalid input, exec
+    /// or capture failures, and read failures for a path still established as
+    /// regular return an error. Files larger than `max_bytes` return an error
+    /// instead of silently returning truncated bytes.
     pub async fn read_file(
         &self,
         path: &str,
@@ -165,7 +174,8 @@ impl VsockHost {
     /// Read a small file and report when the helper exec frame is about to be
     /// written to the guest.
     ///
-    /// This has the same read semantics and input validation as `read_file`.
+    /// This has the same path classification, read, and input validation
+    /// semantics as [`read_file`](Self::read_file).
     pub async fn read_file_with_write_observer(
         &self,
         path: &str,


### PR DESCRIPTION
## Summary

- define `Sandbox::read_file`'s `None` result by whether regular-file status can be established
- document non-regular, broken-symlink, inaccessible-metadata, and retry-race outcomes on `VsockHost::read_file`
- link the write-observer variant to the canonical read contract

## Scope

This is documentation-only. It does not change runtime behavior, API shape, guest/host protocol, persisted data, or tests.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p sandbox -p vsock-host`
- `git diff --check`

Closes #24589
