### PR TITLE
test(runner): cover drain rollback failures

### DIFF
--- a/crates/runner/src/cmd/service/drain_resume.rs
+++ b/crates/runner/src/cmd/service/drain_resume.rs
@@ -1177,6 +1177,94 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn drain_signal_failure_reports_rollback_failures() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            remove_error: true,
+            reload_errors: VecDeque::from([false, true]),
+            signal_error: true,
+            restore_enablement_error: true,
+            ..FakeDrainOps::default()
+        };
+
+        let error = drain_with_ops(&unit, &mut ops).await.unwrap_err();
+        let message = error.to_string();
+
+        assert!(message.contains("signal failed"));
+        assert!(message.contains("additionally rollback failed"));
+        assert!(message.contains("failed to roll back drain transition"));
+        assert!(message.contains("(signal_drain)"));
+        assert!(message.contains("remove drain restart override"));
+        assert!(message.contains("remove failed"));
+        assert!(message.contains("restore boot enablement"));
+        assert!(message.contains("restore enablement failed"));
+        assert!(message.contains("reload restored systemd state"));
+        assert!(message.contains("reload failed"));
+        assert_eq!(
+            ops.events,
+            [
+                "is_active",
+                "is_enabled",
+                "write_restart_override",
+                "disable",
+                "daemon_reload",
+                "restart_policy",
+                "signal_drain",
+                "remove_restart_override",
+                "restore_enabled",
+                "daemon_reload",
+            ]
+        );
+        assert_eq!(
+            ops.reload_requirements,
+            [
+                SystemdReloadRequirement::dirty().with_drain_override(true),
+                SystemdReloadRequirement::dirty().with_drain_override(false),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_signal_failure_reports_unavailable_prior_enablement() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            enablement_results: VecDeque::from([Err(fake_error("enablement read failed"))]),
+            signal_error: true,
+            ..FakeDrainOps::default()
+        };
+
+        let error = drain_with_ops(&unit, &mut ops).await.unwrap_err();
+        let message = error.to_string();
+
+        assert!(message.contains("signal failed"));
+        assert!(message.contains("additionally rollback failed"));
+        assert!(message.contains("failed to roll back drain transition"));
+        assert!(message.contains("(signal_drain)"));
+        assert!(message.contains("prior boot enablement is unavailable"));
+        assert_eq!(
+            ops.events,
+            [
+                "is_active",
+                "is_enabled",
+                "write_restart_override",
+                "disable",
+                "daemon_reload",
+                "restart_policy",
+                "signal_drain",
+                "remove_restart_override",
+                "daemon_reload",
+            ]
+        );
+        assert_eq!(
+            ops.reload_requirements,
+            [
+                SystemdReloadRequirement::dirty().with_drain_override(true),
+                SystemdReloadRequirement::dirty().with_drain_override(false),
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn drain_already_gone_still_disables_unit() {
         let unit = service_unit();
         let mut ops = FakeDrainOps {

--- a/crates/runner/src/cmd/service/drain_resume.rs
+++ b/crates/runner/src/cmd/service/drain_resume.rs
@@ -1190,16 +1190,19 @@ mod tests {
         let error = drain_with_ops(&unit, &mut ops).await.unwrap_err();
         let message = error.to_string();
 
-        assert!(message.contains("signal failed"));
-        assert!(message.contains("additionally rollback failed"));
-        assert!(message.contains("failed to roll back drain transition"));
-        assert!(message.contains("(signal_drain)"));
-        assert!(message.contains("remove drain restart override"));
-        assert!(message.contains("remove failed"));
-        assert!(message.contains("restore boot enablement"));
-        assert!(message.contains("restore enablement failed"));
-        assert!(message.contains("reload restored systemd state"));
-        assert!(message.contains("reload failed"));
+        assert!(message.contains(
+            "drain failed for vm0-runner-test: internal error: signal failed; additionally rollback failed"
+        ));
+        assert!(
+            message.contains(
+                "failed to roll back drain transition for vm0-runner-test (signal_drain)"
+            )
+        );
+        assert!(message.contains("remove drain restart override: internal error: remove failed"));
+        assert!(
+            message.contains("restore boot enablement: internal error: restore enablement failed")
+        );
+        assert!(message.contains("reload restored systemd state: internal error: reload failed"));
         assert_eq!(
             ops.events,
             [
@@ -1236,10 +1239,14 @@ mod tests {
         let error = drain_with_ops(&unit, &mut ops).await.unwrap_err();
         let message = error.to_string();
 
-        assert!(message.contains("signal failed"));
-        assert!(message.contains("additionally rollback failed"));
-        assert!(message.contains("failed to roll back drain transition"));
-        assert!(message.contains("(signal_drain)"));
+        assert!(message.contains(
+            "drain failed for vm0-runner-test: internal error: signal failed; additionally rollback failed"
+        ));
+        assert!(
+            message.contains(
+                "failed to roll back drain transition for vm0-runner-test (signal_drain)"
+            )
+        );
         assert!(message.contains("prior boot enablement is unavailable"));
         assert_eq!(
             ops.events,


### PR DESCRIPTION
## Summary

- cover a drain signal failure combined with override-removal, enablement-restoration, and corrective-reload failures
- verify every best-effort rollback operation still runs in order and every diagnostic survives error composition
- cover rollback after the prior boot enablement read fails, including override removal and corrective reload without a restoration attempt

## Scope

This is a test-only change. It does not change runner behavior, CLI contracts, systemd operations, APIs, protocols, schemas, persisted state, or deployment compatibility.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner cmd::service::drain_resume::tests` (22 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features` (2,920 passed, 14 ignored)
- `git diff --check`
- Rust pre-commit and commit-message hooks

Closes #24577
