### PR TITLE
test(python): cover flow-metadata match or-pattern keys

### DIFF
--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/match_or_pattern_keys.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/match_or_pattern_keys.base.py.txt
@@ -1,0 +1,3 @@
+match flow.metadata:
+    case {"vm_run_id": _} | {"firewall_name": _}:
+        pass

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/match_or_pattern_keys.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/match_or_pattern_keys.expected.txt
@@ -1,0 +1,2 @@
+match_or_pattern_keys.py:2: use metadata_keys.VM_RUN_ID for flow.metadata access
+match_or_pattern_keys.py:2: use metadata_keys.FIREWALL_NAME for flow.metadata access

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -191,6 +191,17 @@ def test_registered_flow_metadata_guard_flags_direct_literals(tmp_path):
     )
 
 
+def test_registered_flow_metadata_guard_flags_match_or_pattern_keys(tmp_path):
+    source_path = tmp_path / "match_or_pattern_keys.py"
+    _write_python_source(source_path, "match_or_pattern_keys.base.py.txt")
+
+    violations = flow_metadata_key_linter.metadata_key_violations(source_path)
+
+    assert _normalized_violations(source_path, violations) == _expected_lines(
+        "match_or_pattern_keys.expected.txt"
+    )
+
+
 def test_registered_flow_metadata_guard_flags_direct_unbound_mapping_reads(tmp_path):
     source_path = tmp_path / "unbound_calls.py"
     _write_python_source(source_path, "unbound_calls.base.py.txt")


### PR DESCRIPTION
## Summary

- add a dedicated flow-metadata mapping or-pattern source fixture
- assert both registered raw keys through the public file-analysis contract
- isolate the regression from the large Python-version-specific violation fixtures

## Scope

Test coverage only. This PR does not change linter runtime behavior, schemas, protocols, persisted data, deployment compatibility, or rollout behavior.

## Validation

- focused test passes with the current implementation
- focused mutation removing only `ast.MatchOr` traversal fails with both diagnostics missing, then passes again after restoration
- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`4556 passed`)
- `git diff --check`

Closes #24595
