### PR TITLE
fix(python): reject superseded catalog owners

### DIFF
--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -96,6 +96,7 @@ class _InFlight:
     future: asyncio.Future[_CacheEntry | None] = field(repr=False)
     prefetch_owner: bool
     waiters: int = 0
+    observed_etag: str | None = field(default=None, repr=False)
 
 
 @dataclass
@@ -857,11 +858,12 @@ def finalize_response(flow: http.HTTPFlow) -> None:
         if isinstance(validated, str):
             _set_not_stored(flow, state, validated, now=now)
             return
-        if state.key in _entries:
+        body, content_type, etag = validated
+        observed_etag = state.in_flight.observed_etag
+        if state.key in _entries or (observed_etag is not None and observed_etag != etag):
             _set_not_stored(flow, state, "concurrent_change", now=now)
             return
 
-        body, content_type, etag = validated
         entry = _CacheEntry(
             body=body,
             content_type=content_type,
@@ -915,6 +917,10 @@ def observe_authenticated_models_etag(flow: http.HTTPFlow) -> None:
     credential_digest = _credential_digest(flow)
     if credential_digest is None:
         return
+
+    for key, in_flight in _in_flight.items():
+        if key.credential_digest == credential_digest:
+            in_flight.observed_etag = signal_etag
 
     keys = [key for key in _entries if key.credential_digest == credential_digest]
     if not keys:

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_coordination.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_coordination.py
@@ -263,6 +263,88 @@ async def test_singleflight_rechecks_entry_after_etag_invalidation(real_flow):
     catalog_cache.handle_error(follower)
 
 
+async def test_etag_signal_supersedes_in_flight_owner_and_releases_follower(real_flow):
+    superseded_owner = catalog_flow(real_flow, version="superseded-owner")
+    matching_owner = catalog_flow(real_flow, version="matching-owner")
+    isolated_owner = catalog_flow(
+        real_flow,
+        version="isolated-owner",
+        auth_value="auth-b",
+    )
+    for owner in (superseded_owner, matching_owner, isolated_owner):
+        await prepare_miss(owner)
+
+    follower = catalog_flow(real_flow, version="superseded-owner")
+    follower_prepare = asyncio.create_task(
+        catalog_cache.prepare_request(follower, request_end_stream=True)
+    )
+    await asyncio.sleep(0)
+    assert not follower_prepare.done()
+
+    signal = responses_flow(real_flow, etag='"catalog-v2"')
+    mitm_addon.responseheaders(signal)
+
+    matching_body = b'{"models":[{"slug":"matching"}]}'
+    matching_owner.response = catalog_response(
+        body=matching_body,
+        etag='"catalog-v2"',
+        encoding="br",
+    )
+    assert finish_response(matching_owner)["model_catalog_cache_status"] == (
+        "model_catalog_cold_stored"
+    )
+
+    isolated_body = b'{"models":[{"slug":"isolated"}]}'
+    isolated_owner.response = catalog_response(
+        body=isolated_body,
+        etag='"catalog-v1"',
+        encoding="br",
+    )
+    assert finish_response(isolated_owner)["model_catalog_cache_status"] == (
+        "model_catalog_cold_stored"
+    )
+
+    superseded_owner.response = catalog_response(etag='"catalog-v1"', encoding="br")
+    superseded_telemetry = finish_response(superseded_owner)
+    await asyncio.wait_for(follower_prepare, timeout=0.1)
+
+    validation_latency = superseded_telemetry.pop("model_catalog_cache_validation_latency_ms")
+    assert isinstance(validation_latency, int)
+    assert validation_latency >= 0
+    assert superseded_telemetry == {
+        "model_catalog_cache_status": "model_catalog_cold_not_stored",
+        "model_catalog_cache_bypass_reason": "concurrent_change",
+        "model_catalog_cache_upstream_encoding": "br",
+    }
+    assert follower.response is None
+    assert follower.request.headers["Accept-Encoding"] == "br"
+
+    replacement_body = b'{"models":[{"slug":"replacement"}]}'
+    follower.response = catalog_response(
+        body=replacement_body,
+        etag='"catalog-v2"',
+        encoding="br",
+    )
+    assert finish_response(follower)["model_catalog_cache_status"] == ("model_catalog_cold_stored")
+
+    expected_hits = (
+        (catalog_flow(real_flow, version="superseded-owner"), replacement_body),
+        (catalog_flow(real_flow, version="matching-owner"), matching_body),
+        (
+            catalog_flow(
+                real_flow,
+                version="isolated-owner",
+                auth_value="auth-b",
+            ),
+            isolated_body,
+        ),
+    )
+    for hit, expected_body in expected_hits:
+        await catalog_cache.prepare_request(hit, request_end_stream=True)
+        assert hit.response is not None
+        assert hit.response.content == expected_body
+
+
 async def test_singleflight_waiter_bound_bypasses_excess_requests(real_flow):
     owner = catalog_flow(real_flow, version="waiter-capacity")
     await prepare_miss(owner)


### PR DESCRIPTION
## Summary

- retain the latest authenticated Responses model ETag on matching live catalog singleflight owners
- reject a validated owner response when its ETag was superseded before completion
- wake existing followers through the normal non-store path so one can fetch and publish the replacement catalog
- cover matching owners and credential isolation through real mitmproxy flow hooks

## Behavior and safety

- new state is scoped to the existing bounded `_InFlight` lifecycle; there is no credential registry or independent cleanup policy
- response decoding and catalog validation still complete before the cache-store decision
- matching responses remain cacheable, and other credential partitions are unchanged
- superseded responses reuse `model_catalog_cold_not_stored` with `concurrent_change`, so no API or telemetry schema changes are required
- no database, persisted state, API endpoint, runner/guest protocol, feature switch, or migration changes

## Validation

- regression failed on the pre-fix implementation with the stale owner reported as `model_catalog_cold_stored`
- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_codex_model_catalog_cache_coordination.py` — 13 passed
- `uv run --no-sync python -m pytest tests/` — 4,556 passed
- `git diff --check`

Closes #24593
