### PR TITLE
perf(python): avoid parsing discarded local-response queries

### DIFF
--- a/crates/runner/mitm-addon/src/http_local_responses.py
+++ b/crates/runner/mitm-addon/src/http_local_responses.py
@@ -13,7 +13,7 @@ import http_network_log
 import matching
 import registry
 from logging_utils import log_proxy_entry
-from runtime_url_parsing import split_runtime_url
+from runtime_url_parsing import split_runtime_url, strip_url_query_and_fragment
 from url_utils import AuthorityValidationError
 
 _BUILTIN_HOST_POLICY_DENIED_ERROR: Final = "builtin_host_policy_denied"
@@ -21,6 +21,12 @@ _AMBIGUOUS_CONNECTOR_ROUTE_ERROR: Final = "ambiguous_connector_route"
 _STALE_TLS_ADMISSION_ERROR: Final = "stale_tls_admission"
 _UPSTREAM_DESTINATION_UNBOUND_ERROR: Final = "upstream_destination_unbound"
 _HTTP_STATUS_CONFLICT = 409
+
+
+def _diagnostic_url_without_query_or_fragment(original_url: str) -> str:
+    retained_url = strip_url_query_and_fragment(original_url)
+    parts = split_runtime_url(retained_url)
+    return urllib.parse.urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
 
 
 def block_authority_validation_error(
@@ -239,10 +245,7 @@ def set_firewall_block_response(flow: http.HTTPFlow, result: matching.FirewallBl
         result.permissions[0] if len(result.permissions) == 1 else ""
     )
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
-    diagnostic_parts = split_runtime_url(original_url)
-    diagnostic_url = urllib.parse.urlunsplit(
-        (diagnostic_parts.scheme, diagnostic_parts.netloc, diagnostic_parts.path, "", "")
-    )
+    diagnostic_url = _diagnostic_url_without_query_or_fragment(original_url)
     error_body = json.dumps(
         {
             "error": "permission_denied",
@@ -286,10 +289,7 @@ def set_firewall_ambiguous_response(
     flow.metadata[metadata_keys.CONNECTOR_ROUTE_REASON] = result.reason
     flow.metadata[metadata_keys.CONNECTOR_ROUTE_CANDIDATES] = candidates
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
-    diagnostic_parts = split_runtime_url(original_url)
-    diagnostic_url = urllib.parse.urlunsplit(
-        (diagnostic_parts.scheme, diagnostic_parts.netloc, diagnostic_parts.path, "", "")
-    )
+    diagnostic_url = _diagnostic_url_without_query_or_fragment(original_url)
     flow.response = http.Response.make(
         _HTTP_STATUS_CONFLICT,
         json.dumps(

--- a/crates/runner/mitm-addon/src/network_log_sanitization.py
+++ b/crates/runner/mitm-addon/src/network_log_sanitization.py
@@ -2,7 +2,7 @@
 
 import urllib.parse
 
-from runtime_url_parsing import split_runtime_url
+from runtime_url_parsing import split_runtime_url, strip_url_query_and_fragment
 
 _URLSPLIT_LEADING_STRIP_CHARACTERS = "".join(chr(codepoint) for codepoint in range(0x21))
 _URLSPLIT_REMOVABLE_CHARACTERS = "\t\r\n"
@@ -22,16 +22,6 @@ def _sanitize_netloc_for_network_log(netloc: str) -> str:
     if "@" not in netloc:
         return netloc
     return netloc.rsplit("@", 1)[1]
-
-
-def _strip_query_fragment_for_network_log(value: str) -> str:
-    query_start = value.find("?")
-    fragment_start = value.find("#", 0, query_start if query_start >= 0 else len(value))
-    if fragment_start >= 0:
-        return value[:fragment_start]
-    if query_start >= 0:
-        return value[:query_start]
-    return value
 
 
 def _sanitize_url_text_fallback_for_network_log(value: str) -> str:
@@ -92,7 +82,7 @@ def sanitize_url_for_network_log(value: str) -> str:
     is not a general sanitizer for arbitrary captured header values or path
     contents.
     """
-    retained_value = _strip_query_fragment_for_network_log(value)
+    retained_value = strip_url_query_and_fragment(value)
     normalized_value = _normalize_for_urlsplit(retained_value)
     try:
         parts = split_runtime_url(normalized_value)
@@ -109,6 +99,6 @@ def sanitize_url_for_network_log(value: str) -> str:
 
 def sanitize_request_url_for_network_log(value: str) -> str:
     """Preserve a complete request URL while removing URL userinfo."""
-    retained_value = _strip_query_fragment_for_network_log(value)
+    retained_value = strip_url_query_and_fragment(value)
     suffix = value[len(retained_value) :]
     return f"{sanitize_url_for_network_log(retained_value)}{suffix}"

--- a/crates/runner/mitm-addon/src/runtime_url_parsing.py
+++ b/crates/runner/mitm-addon/src/runtime_url_parsing.py
@@ -1,8 +1,19 @@
-"""URL parsing for request-lifetime inputs that must not enter global caches."""
+"""URL operations for request-lifetime inputs."""
 
 import urllib.parse
 
 _uncached_urlsplit = urllib.parse.urlsplit.__wrapped__
+
+
+def strip_url_query_and_fragment(value: str) -> str:
+    """Return the URL prefix before its raw query or fragment delimiter."""
+    query_start = value.find("?")
+    fragment_start = value.find("#", 0, query_start if query_start >= 0 else len(value))
+    if fragment_start >= 0:
+        return value[:fragment_start]
+    if query_start >= 0:
+        return value[:query_start]
+    return value
 
 
 def split_runtime_url(value: str) -> urllib.parse.SplitResult:

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -1,11 +1,16 @@
 """Core firewall dispatch and network policy tests for the request hook."""
 
 import json
+import urllib.parse
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import patch
 
 import pytest
 
 import connector_intent
 import flow_metadata_keys as metadata_keys
+import http_local_responses
 import mitm_addon
 import upstream_destination_binding
 from body_limits import STREAM_BUFFER_LIMIT
@@ -17,6 +22,26 @@ from tests.request_handler_helpers import (
     _write_registry,
 )
 from tests.upstream_connection_helpers import seed_server_binding
+
+
+@contextmanager
+def _observe_local_response_parser_inputs() -> Iterator[list[str]]:
+    parsed_urls: list[str] = []
+    real_split_runtime_url = http_local_responses.split_runtime_url
+
+    def observe_runtime_url_parse(value: str) -> urllib.parse.SplitResult:
+        cache_before = urllib.parse.urlsplit.cache_info()
+        parts = real_split_runtime_url(value)
+        assert urllib.parse.urlsplit.cache_info() == cache_before
+        parsed_urls.append(value)
+        return parts
+
+    with patch.object(
+        http_local_responses,
+        "split_runtime_url",
+        side_effect=observe_runtime_url_parse,
+    ):
+        yield parsed_urls
 
 
 async def test_firewall_match_calls_handler(
@@ -205,6 +230,38 @@ async def test_ambiguous_connector_route_fails_before_auth_and_logs_candidates(
     assert network_log_entry["connector_route_reason"] == reason
     assert network_log_entry["connector_route_candidates"] == ["auditor", "primary"]
     assert "firewall_name" not in network_log_entry
+
+
+async def test_ambiguous_response_discards_large_fragment_before_url_parsing(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+):
+    reg_path = _write_registry(tmp_path, vm_info=_shared_route_vm(tmp_path))
+    retained_url = "https://shared.example.com/items/123"
+    discarded_suffix = f"#fragment={'x' * 200_000}?sensitive=query"
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path=f"/items/123{discarded_suffix}",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+        _observe_local_response_parser_inputs() as parsed_urls,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_awaited()
+    assert parsed_urls == [retained_url]
+    assert flow.response is not None
+    assert flow.response.status_code == 409
+    body = json.loads(flow.response.content)
+    assert body["path"] == "/items/123"
+    assert body["url"] == retained_url
 
 
 async def test_firewall_permission_blocks_unmatched(tmp_path, real_flow, mitm_ctx, headers):
@@ -730,23 +787,28 @@ async def test_firewall_block_response_url_preserves_raw_encoded_path_without_qu
         ),
     )
 
+    retained_url = "https://api.github.com/repos/%2e%2e/repo"
     flow = real_flow(
         with_response=False,
         client_ip="10.200.0.5",
         host="api.github.com",
-        path="/repos/%2e%2e/repo?token=secret#fragment",
+        path=f"/repos/%2e%2e/repo?token={'x' * 200_000}#fragment",
     )
 
-    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        _observe_local_response_parser_inputs() as parsed_urls,
+    ):
         await mitm_addon.request(flow)
 
+    assert parsed_urls == [retained_url]
     assert flow.response is not None
     assert flow.response.status_code == 403
     raw_body = flow.response.content.decode()
     body = json.loads(raw_body)
     assert body["path"] == "/repos/%2e%2e/repo"
-    assert body["url"] == "https://api.github.com/repos/%2e%2e/repo"
-    assert "token=secret" not in raw_body
+    assert body["url"] == retained_url
+    assert "token=" not in raw_body
     assert "fragment" not in raw_body
 
 


### PR DESCRIPTION
## Summary

- isolate raw query and fragment suffixes before local-response runtime URL parsing
- share the delimiter-only primitive with network-log sanitization while keeping response and logging policies separate
- centralize the query-free diagnostic URL projection used by firewall block and ambiguous-route responses
- cover query-first and fragment-first large suffixes through the real request hook with deterministic parser-boundary assertions

## Scope

This changes only the Python mitmproxy addon's request-lifetime URL helper and local rejection response construction. It preserves response status codes, JSON fields, scheme/authority/path output, encoded paths, parser errors, logs, and stdlib cache behavior.

It does not change APIs, schemas, persisted data, migrations, dependencies, queue payloads, runner/guest protocols, deployment ordering, or feature switches.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_request_handler_firewall_dispatch.py tests/test_response_handler_logging.py` (116 passed)
- `uv run --no-sync python -m pytest tests/` (4,556 passed)
- `lefthook run pre-commit --file crates/runner/mitm-addon/src/runtime_url_parsing.py --file crates/runner/mitm-addon/src/network_log_sanitization.py --file crates/runner/mitm-addon/src/http_local_responses.py --file crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py`
- `git diff --check`

## Performance check

A local diagnostic using the production helper measured the 200 KB parse-and-project case at approximately 167.6 microseconds before prefix isolation and 1.4 microseconds after it, with peak traced allocation dropping from about 400 KB to 411 bytes. At 1 MB, it measured approximately 829.6 microseconds versus 1.5 microseconds and about 2 MB versus 411 bytes. These measurements are supporting evidence only; committed regressions assert the deterministic parser boundary rather than timing or allocator thresholds.

Closes #24591
