### PR TITLE
docs(runner): document session-history sidecar contract

### DIFF
--- a/crates/runner/src/workspace_image_cache/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/sidecar.rs
@@ -1,3 +1,47 @@
+//! Opportunistic session-history storage attached to workspace image cache entries.
+//!
+//! A sidecar keeps the history bytes needed to resume the session associated
+//! with a cached workspace image. It is a local optimization, not an
+//! authoritative history store: a probe miss, or a non-cancellation failure to
+//! materialize or restore a probed body, falls back to the authoritative
+//! session-history materializer.
+//!
+//! ## Probe contract
+//!
+//! A probe accepts only supported metadata whose framework, hashed session ID,
+//! history reference kind, history hash, and raw history size exactly match the
+//! requested restored-session identity. A raw body is accepted only when its
+//! encoded length equals the raw history size; a `CodexZstd` body is accepted
+//! only for Codex. The encoded size must also be nonzero and within the
+//! resume-history limit. The referenced body must still be a regular file with
+//! the recorded file identity and encoded length. Probe failures are classified
+//! by `WorkspaceSessionHistorySidecarMiss`, whose stable values let callers
+//! record why remote materialization was used instead.
+//!
+//! ## Publication contract
+//!
+//! Publication runs while the workspace cache entry is guarded. Promotion can
+//! preserve the committed sidecar after consuming a cache hit, replace it from
+//! a staged source, or prune it when a non-hit workspace has no replacement. A
+//! replacement source must be a regular file whose actual length matches its
+//! declared nonzero encoded size, must fit the resume-history limit, and must
+//! carry complete restored-session cache identity fields. An invalid source is
+//! discarded without changing the committed metadata/body pair.
+//!
+//! Replacement alternates between two body slots. It writes new metadata to a
+//! temporary file, moves the staged body into the inactive slot, and atomically
+//! renames the metadata into place as the commit point. Before that rename, the
+//! previous metadata still selects the previous body, so a failed replacement
+//! leaves the last committed sidecar usable. Only after the metadata commit does
+//! publication attempt to remove the old body slot.
+//!
+//! Sidecar publication is best-effort relative to workspace image promotion. A
+//! sidecar failure does not reject an otherwise valid image promotion, but a
+//! failure to publish the enclosing workspace cache metadata removes the image
+//! and prunes the sidecar. The sidecar metadata and both body slots belong to
+//! the cache entry and participate in its inspection, allocated-byte accounting,
+//! garbage collection, and cleanup.
+
 use std::path::Path;
 
 use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;

--- a/crates/runner/src/workspace_image_cache/types.rs
+++ b/crates/runner/src/workspace_image_cache/types.rs
@@ -111,39 +111,74 @@ pub(crate) struct WorkspaceImagePromotionRequest<'a> {
     pub(crate) storage_fingerprints: StorageFingerprints,
 }
 
+/// Encoding of the bytes stored in a workspace session-history sidecar body.
 pub(crate) type WorkspaceSessionHistorySidecarRepresentation =
     guest_contracts::session_history_identity::SessionHistorySidecarRepresentation;
 
+/// A committed sidecar body that passed metadata, request, and file validation.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct WorkspaceSessionHistorySidecar {
+    /// Path to the body slot selected by the committed sidecar metadata.
     pub(crate) path: PathBuf,
+    /// Encoding to use when materializing the stored bytes.
     pub(crate) representation: WorkspaceSessionHistorySidecarRepresentation,
+    /// Validated length of the encoded body.
     pub(crate) encoded_size: u64,
 }
 
+/// A guarded temporary body proposed for the next sidecar publication.
+///
+/// The restored-session identity is persisted with the source when promotion
+/// succeeds. Publication consumes the temporary path by moving it into the
+/// cache entry, or discards it when the source is invalid or promotion fails.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct WorkspaceSessionHistorySidecarPromotionSource {
+    /// Runner-managed temporary body path inside the guarded cache entry.
     pub(crate) tmp_path: PathBuf,
+    /// Encoding of the staged body.
     pub(crate) representation: WorkspaceSessionHistorySidecarRepresentation,
+    /// Declared encoded length checked before publication.
     pub(crate) encoded_size: u64,
+    /// Identity fields to commit with the staged body.
     pub(crate) restored_session_identity: crate::restored_session_identity::RestoredSessionIdentity,
 }
 
+/// Sidecar policy applied while publishing the enclosing workspace image.
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum WorkspaceSessionHistorySidecarPublication<'a> {
+    /// Keep the committed sidecar after promoting a consumed workspace cache hit
+    /// when finalization did not stage a replacement.
     PreserveExisting,
+    /// Publish a guarded staged source with the promoted workspace image.
     Replace(&'a WorkspaceSessionHistorySidecarPromotionSource),
+    /// Remove any committed sidecar when promoting a non-hit workspace without
+    /// a staged source.
     Prune,
 }
 
+/// Non-fatal reason a local sidecar cannot satisfy a restore request.
+///
+/// Callers can record the stable string form as miss telemetry before using the
+/// authoritative session-history materializer.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum WorkspaceSessionHistorySidecarMiss {
+    /// The workspace image itself was not obtained from this cache entry.
     NoCacheHit,
+    /// No committed sidecar metadata exists for the cache entry.
     Missing,
+    /// Metadata could not be read, decoded, or accepted as a supported version
+    /// with a valid encoded-size bound.
     InvalidMetadata,
+    /// The requested restored-session identity is incomplete or differs from
+    /// the identity recorded in the metadata.
     IdentityMismatch,
+    /// The recorded framework, representation, and size relationship is not
+    /// supported by the materializer.
     UnsupportedFormat,
+    /// Metadata selects a body slot that no longer exists.
     BodyMissing,
+    /// The selected body is not the recorded regular file with the expected
+    /// encoded length.
     FileIdentityMismatch,
 }
 


### PR DESCRIPTION
## Summary

- document the workspace session-history sidecar's opportunistic restore role, exact probe boundary, and authoritative fallback
- document the two-slot publication commit protocol, failure behavior, and workspace-cache cleanup/accounting ownership
- document the validated sidecar types, publication policies, and telemetry miss classifications

## Scope

Documentation only. This does not change runtime behavior, persisted metadata, APIs, schemas, compatibility, or rollout requirements.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --bin runner workspace_image_cache::tests::sidecar` (10 passed)
- lefthook pre-commit checks, including workspace Rust formatting, documentation, Clippy, file-size, and commit-message validation

Closes #24590
