### PR TITLE
test(python): cover verified compressed x interruption billing

### DIFF
--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -588,6 +588,45 @@ class TestXConnectorErrorPipeline:
         assert "connector_response_finish" not in flow.metadata
         assert "connector_response_report_on_interruption" not in flow.metadata
 
+    @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
+    def test_full_pipeline_complete_compressed_stream_error_reports_verified_rows(
+        self, tmp_path, real_flow, mitm_ctx, headers, usage_webhook_api, encoding_case
+    ):
+        """A connection error still bills rows from a verified compressed member."""
+        flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
+        assert flow.response is not None
+        flow.response.headers["content-encoding"] = encoding_case
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(
+            _compress_body(
+                encoding_case,
+                b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n{"data":{"id":"2"}}\n',
+            )
+        )
+        assert flow.metadata[metadata_keys.X_NDJSON_STATE]["data_count"] == 2
+        flow.error = Error("connection reset by peer")
+
+        with usage_webhook_api() as webhook:
+            mitm_addon.error(flow)
+            usage.flush_usage_events(trigger="test")
+
+        payloads = webhook.usage_events()
+        by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
+        assert webhook.request_count == 1
+        assert len(payloads) == len(by_cat)
+        assert by_cat == {"posts.read": 2, "user.read": 1}
+
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+        entries = read_jsonl_entries_after_flush(proxy_log)
+        assert any(entry["type"] == "connection_error" for entry in entries)
+        assert all("unparseable" not in entry["message"].lower() for entry in entries)
+        assert all("parse_error" not in entry for entry in entries)
+        assert "connector_response_finish" not in flow.metadata
+        assert "connector_response_report_on_interruption" not in flow.metadata
+        assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata
+        assert flow.response.stream is False
+
     def test_full_pipeline_stream_error_midflight(
         self, tmp_path, real_flow, mitm_ctx, headers, usage_webhook_api
     ):

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -590,7 +590,7 @@ class TestXConnectorErrorPipeline:
 
     @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
     def test_full_pipeline_complete_compressed_stream_error_reports_verified_rows(
-        self, tmp_path, real_flow, mitm_ctx, headers, usage_webhook_api, encoding_case
+        self, tmp_path, real_flow, usage_webhook_api, encoding_case
     ):
         """A connection error still bills rows from a verified compressed member."""
         flow = make_x_stream_pipeline_flow(real_flow, tmp_path)


### PR DESCRIPTION
## Summary

- add parameterized full-pipeline coverage for complete gzip and deflate X NDJSON streams that terminate through the connection-error hook
- verify the two observed row categories are reported exactly once after decoder integrity succeeds
- verify no compression underbilling diagnostic is emitted and terminal response-stream parser state is released

## Scope

This is a test-only change. It does not change production decoding, parsing, billing, API, persistence, or deployment behavior, and it leaves the existing incomplete-compression and uncompressed-interruption tests unchanged.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_x_connector_pipeline.py::TestXConnectorErrorPipeline::test_full_pipeline_complete_compressed_stream_error_reports_verified_rows -v` (2 passed)
- `uv run --no-sync python -m pytest tests/test_x_connector_pipeline.py -v` (29 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4558 passed)
- focused mutation check: suppressing reporting only after successful compressed NDJSON finalization made both new cases fail; restoring the implementation made both pass

Closes #24596
