### PR TITLE
test(mitm-addon): remove jsonl flush acknowledgement race

### DIFF
--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -399,12 +399,12 @@ class TestRunnerUsageFlushSignal:
         self, runner_usage_flush_files: RunnerUsageFlushFiles
     ):
         log_path = runner_usage_flush_files.write_jsonl_flush_request()
+        logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
 
         with (
             patch.object(logging_utils.ctx, "log", MagicMock(), create=True),
             running_jsonl_flush_worker(runner_usage_flush_files),
         ):
-            logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
             state = wait_for_jsonl_flush_state(runner_usage_flush_files)
 
         entry = json.loads(log_path.read_text().strip())


### PR DESCRIPTION
## Summary

- accept the network-log entry before starting the JSONL flush watcher so the entry is included in the watcher's accepted-write snapshot
- preserve the real asynchronous writer, watcher, acknowledgement state, and persisted-entry assertions
- remove the schedule-dependent `FileNotFoundError` without changing production behavior

## Scope

- test-only change in `test_runner_usage_flush_signal.py`
- no production Python, Rust runner, protocol, dependency, migration, compatibility, or rollout changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- focused acknowledgement test: passed
- 50 separate focused pytest invocations: passed
- complete `test_runner_usage_flush_signal.py`: 24 passed
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- complete mitm-addon suite: 4,556 passed
- `./scripts/check-file-size.sh crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py`

Closes #24597
