### PR TITLE
test: remove deferred finally cleanup

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -905,32 +905,28 @@ describe("thread-owned utility sidebar", () => {
       });
     });
 
-    try {
-      setupChatThread({
-        autoOpenEnabled: true,
-        waitForHistoryResponse: async () => {
-          historyRequestStarted.resolve();
-          await releaseHistoryResponse.promise;
+    setupChatThread({
+      autoOpenEnabled: true,
+      waitForHistoryResponse: async () => {
+        historyRequestStarted.resolve();
+        await releaseHistoryResponse.promise;
+      },
+      messages: [
+        {
+          id: "c0000000-0000-4000-a000-000000000054",
+          eventType: "browser.started",
+          content: null,
+          seqId: 51,
+          createdAt: "2026-03-10T00:00:00Z",
         },
-        messages: [
-          {
-            id: "c0000000-0000-4000-a000-000000000054",
-            eventType: "browser.started",
-            content: null,
-            seqId: 51,
-            createdAt: "2026-03-10T00:00:00Z",
-          },
-        ],
-      });
+      ],
+    });
 
-      await historyRequestStarted.promise;
-      await expect(
-        screen.findByTitle("Live browser: Thread browser"),
-      ).resolves.toBeInTheDocument();
-      expect(releaseHistoryResponse.settled()).toBeFalsy();
-    } finally {
-      releaseHistoryResponse.resolve();
-    }
+    await historyRequestStarted.promise;
+    await expect(
+      screen.findByTitle("Live browser: Thread browser"),
+    ).resolves.toBeInTheDocument();
+    expect(releaseHistoryResponse.settled()).toBeFalsy();
   });
 
   it("auto-opens when older history contains the unmatched browser start", async () => {
@@ -1194,13 +1190,9 @@ describe("thread-owned utility sidebar", () => {
     ]);
 
     await markReadStarted.promise;
-    try {
-      await expect(
-        screen.findByTitle("Live browser: Thread browser"),
-      ).resolves.toBeInTheDocument();
-    } finally {
-      finishMarkRead.resolve();
-    }
+    await expect(
+      screen.findByTitle("Live browser: Thread browser"),
+    ).resolves.toBeInTheDocument();
   });
 
   it("does not reopen the same browser start after the user closes it", async () => {


### PR DESCRIPTION
## Summary

- Remove 2 validated cleanup-only `finally` wrappers around `context.mocks.deferred()` gates.
- Preserve the test body while relying on the mock context cleanup lifecycle to settle the gates.
- Limit the change to the high-confidence end-of-test patterns in the thread sidebar suite.

## Scan

- Timestamp: `2026-08-03T03:02:42.171Z`
- Base commit: `65df99aa6e733d5aa665da960bd7a023f97afa56`
- Tracked TypeScript/TSX test files scanned: 675
- Validated cleanup-only blocks changed: 2
- Files changed: 1
- Codemod ambiguous skips: 0
- Excluded after targeted verification: 2 candidates in `activity-detail-polling.test.tsx`; those resolves release gates required by later assertions, so their edits were restored.

## Files changed

- `turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx`

## Verification

- `git diff --check`
- Prettier check on the changed file
- Targeted Oxlint, type-aware Oxlint, and ESLint on the changed file
- `pnpm vitest --run apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx` — 20 tests passed
- Candidate validation: the activity-detail targeted suite failed at the later gated assertions with the candidate edits, confirming those 2 resolves are tested behavior; both edits were removed from this PR.

Only validated high-confidence cleanup-only patterns are changed.