### PR TITLE
refactor: remove chat_event_input_params readers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -12,7 +12,6 @@ import { describe, expect, it } from "vitest";
 import { testContext } from "../../../__tests__/test-context";
 import { server } from "../../../mocks/server";
 import {
-  decryptChatEventInputParamsFixture,
   findAgentphoneChatEventByPromptFixture,
   readChatEventContextFixture,
 } from "../../../test-fixtures/chat-events";
@@ -634,15 +633,9 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     const secondEvent = await findAgentphoneChatEventByPromptFixture(
       "second queued prompt",
     );
-    if (!secondEvent || !actor.orgId) {
-      throw new Error("Expected pending AgentPhone queue item owner");
+    if (!secondEvent) {
+      throw new Error("Expected pending AgentPhone queue item");
     }
-    await expect(
-      decryptChatEventInputParamsFixture(secondEvent.eventId, {
-        orgId: actor.orgId,
-        userId: actor.userId,
-      }),
-    ).resolves.toStrictEqual({ version: 1 });
     await ap.postAgentPhoneInboundMessage({
       channel: "sms",
       from: phone,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -24,7 +24,7 @@ import { readGoalQueueStateFixture } from "../../../test-fixtures/goal-queue";
 import {
   holdCheckpointReadsFixture,
   holdChatEventInsertTransactionFixture,
-  invalidatePendingChatEventInputParamsFixture,
+  insertQueuedSlackMissingContextFixture,
   readChatEventContextFixture,
   removeAcknowledgedCancellationLifecycleFixture,
 } from "../../../test-fixtures/chat-events";
@@ -2547,10 +2547,9 @@ describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
     });
     await claimChatRun(runnerGroup, poisonedRun.runId);
     await claimChatRun(runnerGroup, healthyRun.runId);
-    const poisonedEventId = await queueChatEvent(actor, {
-      agentId,
+    const poisonedEventId = await insertQueuedSlackMissingContextFixture({
       threadId: poisonedRun.threadId,
-      prompt: "fail this expired recovery drain",
+      content: "fail this expired recovery drain",
     });
     const healthyEventId = await queueChatEvent(actor, {
       agentId,
@@ -2561,8 +2560,6 @@ describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
     await api.requestCancelRun(actor, poisonedRun.runId, [200]);
     await api.requestCancelRun(actor, healthyRun.runId, [200]);
     await flushWaitUntilForTest();
-    await invalidatePendingChatEventInputParamsFixture(poisonedEventId);
-
     mockNow(startedAt + CANCELLATION_RECOVERY_STALE_AFTER_MS + 1);
     await accept(
       cancellationRecoveryCronClient().reconcile({

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -85,7 +85,6 @@ import {
   holdThreadSessionBindingClearFixture,
   holdThreadSessionConversationChangesFixture,
   holdThreadSessionConversationClearFixture,
-  readChatEventInputParamsFixture,
   replayPendingChatInputQueueEventFixture,
   replaceBddVm0ApiKeys,
   replaceThreadSessionBindingFixture,
@@ -5784,7 +5783,6 @@ describe("CHAT-02: queued attachments on auto-send", () => {
       [201],
     );
     expect(queued.body).toMatchObject({ runId: null });
-    await expect(readChatEventInputParamsFixture(queuedId)).resolves.toBeNull();
     // Completing the anchor run promotes the queued message into a fresh
     // run whose prompt carries the resolved attachment references.
     chatCallbacks.mockChatOutputEvents([]);
@@ -5811,7 +5809,6 @@ describe("CHAT-02: queued attachments on auto-send", () => {
     if (!promoted?.runId) {
       throw new Error("Expected the queued message to auto-send into a run");
     }
-    await expect(readChatEventInputParamsFixture(queuedId)).resolves.toBeNull();
     expect(promoted.content).toBeNull();
     expect(chatEventDisplayText(promoted)).toBe("queued with attachment");
     expect(promoted.attachFiles).toMatchObject([
@@ -6283,21 +6280,11 @@ describe("CHAT-02: shared user message queue", () => {
       [201],
     );
     expect(previewQueued.body).toMatchObject({ runId: null });
-    await expect(
-      readChatEventInputParamsFixture(previewMessageId),
-    ).resolves.toBeNull();
-
     const replayedPreviewMessageId = randomUUID();
     await replayPendingChatInputQueueEventFixture({
       eventId: previewMessageId,
       replacementId: replayedPreviewMessageId,
     });
-    await expect(
-      readChatEventInputParamsFixture(previewMessageId),
-    ).resolves.toBeNull();
-    await expect(
-      readChatEventInputParamsFixture(replayedPreviewMessageId),
-    ).resolves.toBeNull();
     const mockMessageId = randomUUID();
     const mockQueued = await chat.requestSendEvent(
       actor,
@@ -6311,10 +6298,6 @@ describe("CHAT-02: shared user message queue", () => {
       [201],
     );
     expect(mockQueued.body).toMatchObject({ runId: null });
-    await expect(
-      readChatEventInputParamsFixture(mockMessageId),
-    ).resolves.toBeNull();
-
     await updateFeatureSwitchesForUser(context, actorWithOrg, {
       [FeatureSwitchKey.RealAgentInPreview]: true,
     });
@@ -6350,9 +6333,6 @@ describe("CHAT-02: shared user message queue", () => {
     );
     expect(previewClaim.claim.prompt).toContain(`[ID] ${previewFileId}`);
     expect(previewClaim.claim.realAgentInPreview).toBeTruthy();
-    await expect(
-      readChatEventInputParamsFixture(replayedPreviewMessageId),
-    ).resolves.toBeNull();
     await updateFeatureSwitchesForUser(context, actorWithOrg, {
       [FeatureSwitchKey.RealAgentInPreview]: false,
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -43,14 +43,12 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import {
   holdOrgAdmissionLockFixture,
-  readChatEventInputParamsFixture,
   readChatEventContextFixture,
   setQueuedUserMessageCreatedAtFixture,
 } from "../../../test-fixtures/chat-events";
 import {
   insertQueuedWebUserMessageFixture,
   readMorningBriefDeliveryFixture,
-  readMorningBriefQueuedParamsForDeliveryFixture,
   setMorningBriefTriggeredAtFixture,
 } from "../../../test-fixtures/morning-brief";
 import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
@@ -1383,14 +1381,6 @@ describe("cron execute morning briefs", () => {
         );
       });
     };
-    const queuedParams = await readMorningBriefQueuedParamsForDeliveryFixture({
-      deliveryId: delivery.id,
-      threadId,
-      orgId: scenario.actor.orgId,
-      userId: scenario.actor.userId,
-    });
-    expect(queuedParams).toStrictEqual({ version: 1 });
-
     const queuedEvents = await readMorningBriefThreadEvents(scenario, threadId);
     const strandedEvent = queuedEvents.find((event) => {
       return (
@@ -1412,12 +1402,6 @@ describe("cron execute morning briefs", () => {
       morningBriefTimezone: TIMEZONE,
       morningBriefTriggeredAt: new Date(AFTER_SEVEN_LOCAL),
     });
-    await expect(
-      readChatEventInputParamsFixture(strandedEvent.id),
-    ).resolves.toMatchObject({
-      eventId: strandedEvent.id,
-      encryptedParams: expect.any(String),
-    });
     await chat.requestSendEvent(
       scenario.actor,
       {
@@ -1428,10 +1412,6 @@ describe("cron execute morning briefs", () => {
       },
       [201],
     );
-    await expect(
-      readChatEventInputParamsFixture(strandedEvent.id),
-    ).resolves.toBeNull();
-
     routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
     const readmitted = await accept(
       morningBriefTriggerClient().trigger({
@@ -1473,13 +1453,6 @@ describe("cron execute morning briefs", () => {
     if (!readmittedEvent) {
       throw new Error("Expected the readmitted Morning Brief queue event");
     }
-    await expect(
-      readChatEventInputParamsFixture(readmittedEvent.id),
-    ).resolves.toMatchObject({
-      eventId: readmittedEvent.id,
-      encryptedParams: expect.any(String),
-    });
-
     const legacyTriggeredAt = new Date(AFTER_SEVEN_LOCAL - DAY_MS - 60 * 1000);
     await setQueuedUserMessageCreatedAtFixture({
       eventId: readmittedEvent.id,
@@ -1545,9 +1518,6 @@ describe("cron execute morning briefs", () => {
         expiresIn: DAY_MS / 1000,
       },
     ]);
-    await expect(
-      readChatEventInputParamsFixture(readmittedEvent.id),
-    ).resolves.toBeNull();
     expect(previousBriefDate).not.toBe(BRIEF_DATE);
     const { prompt, appendSystemPrompt } = await completeMorningBriefRun(
       scenario,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
@@ -18,6 +18,7 @@ const CRON_SECRET = "test-cron-secret";
 interface MonitorFixture {
   readonly composeId: string;
   readonly eventId: string;
+  readonly eventIds: readonly string[];
 }
 
 function apiClient() {
@@ -51,7 +52,19 @@ async function seedFixture(
   if (!response.compose_id || !response.event_id) {
     throw new Error("orphan monitor seed response is missing fixture IDs");
   }
-  return { composeId: response.compose_id, eventId: response.event_id };
+  if (
+    !Array.isArray(response.event_ids) ||
+    !response.event_ids.every((eventId) => {
+      return typeof eventId === "string";
+    })
+  ) {
+    throw new Error("orphan monitor seed response is missing event IDs");
+  }
+  return {
+    composeId: response.compose_id,
+    eventId: response.event_id,
+    eventIds: response.event_ids,
+  };
 }
 
 async function cleanupFixture(fixture: MonitorFixture): Promise<void> {
@@ -84,13 +97,12 @@ describe("cron monitor chat event queue", () => {
       trackFixture(seedFixture("queued-message")),
       trackFixture(seedFixture("revoked-message")),
     ]);
-    await trackFixture(seedFixture("orphan"));
 
     const response = await accept(
       stateClient().monitor({
         body: {
-          event_ids: fixtures.map((fixture) => {
-            return fixture.eventId;
+          event_ids: fixtures.flatMap((fixture) => {
+            return fixture.eventIds;
           }),
         },
       }),
@@ -104,11 +116,11 @@ describe("cron monitor chat event queue", () => {
     expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
   });
 
-  it("raises the existing error alert for a malformed pending event", async () => {
+  it("raises a grouped alert for every source with a missing context row", async () => {
     const fixture = await trackFixture(seedFixture("orphan"));
 
     const response = await accept(
-      stateClient().monitor({ body: { event_ids: [fixture.eventId] } }),
+      stateClient().monitor({ body: { event_ids: [...fixture.eventIds] } }),
       [500],
     );
 
@@ -120,7 +132,18 @@ describe("cron monitor chat event queue", () => {
     ).toMatchObject({
       name: "OrphanedQueuedChatEventsError",
       code: "ORPHANED_QUEUED_CHAT_MESSAGES",
-      orphanedMessages: 1,
+      orphanedMessages: 9,
+      orphanedMessagesBySource: {
+        agentphone: 1,
+        automation: 1,
+        feishu: 1,
+        github: 1,
+        goal: 1,
+        morning_brief: 1,
+        slack: 1,
+        teams: 1,
+        telegram: 1,
+      },
     });
     const [, fields] = context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
     expect(fields).toMatchObject({
@@ -131,26 +154,50 @@ describe("cron monitor chat event queue", () => {
       error: {
         name: "OrphanedQueuedChatEventsError",
         code: "ORPHANED_QUEUED_CHAT_MESSAGES",
-        orphanedMessages: 1,
+        orphanedMessages: 9,
+        orphanedMessagesBySource: {
+          agentphone: 1,
+          automation: 1,
+          feishu: 1,
+          github: 1,
+          goal: 1,
+          morning_brief: 1,
+          slack: 1,
+          teams: 1,
+          telegram: 1,
+        },
       },
     });
   });
 
-  it("detects an automation event missing its typed context", async () => {
+  it("does not flag input.automation without legacy encrypted params", async () => {
     const fixture = await trackFixture(seedFixture("orphaned-automation"));
 
     const response = await accept(
       stateClient().monitor({ body: { event_ids: [fixture.eventId] } }),
-      [500],
+      [200],
     );
 
-    expect(response.body).toStrictEqual({ error: "Internal server error" });
-    expect(
-      context.mocks.sentry.captureException.mock.calls.at(-1)?.[0],
-    ).toMatchObject({
-      code: "ORPHANED_QUEUED_CHAT_MESSAGES",
-      orphanedMessages: 1,
+    expect(response.body).toStrictEqual({
+      success: true,
+      orphanedMessages: 0,
     });
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("does not alert for a newly queued event below the age threshold", async () => {
+    const fixture = await trackFixture(seedFixture("queued-integration"));
+
+    const response = await accept(
+      stateClient().monitor({ body: { event_ids: [fixture.eventId] } }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      orphanedMessages: 0,
+    });
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
   });
 
   it("does not expose scoped monitoring in production", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -12,10 +12,8 @@ import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { installApiTestConnectorCatalog } from "../../../test-fixtures/connector-catalog";
 import {
-  decryptChatEventInputParamsFixture,
-  findPendingChatEventInputParamsByPromptFixture,
+  findPendingChatEventByPromptFixture,
   readChatEventContextFixture,
-  readChatEventInputParamsFixture,
 } from "../../../test-fixtures/chat-events";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -295,8 +293,14 @@ async function pollRunnerRun(
 ): Promise<string> {
   await runs.heartbeatRunner(runnerGroup);
   await flushWaitUntilForTest();
-  const poll = await runs.pollRunner(runnerGroup);
-  const runId = poll.body.job?.runId;
+  let runId: string | null = null;
+  await expect
+    .poll(async () => {
+      const poll = await runs.pollRunner(runnerGroup);
+      runId = poll.body.job?.runId ?? null;
+      return runId;
+    })
+    .toStrictEqual(expect.any(String));
   if (!runId) {
     throw new Error(message);
   }
@@ -310,12 +314,12 @@ async function pollSlackRun(runnerGroup: string): Promise<string> {
   );
 }
 
-async function requirePendingChatEventInputParams(prompt: string) {
-  const params = await findPendingChatEventInputParamsByPromptFixture(prompt);
-  if (!params) {
-    throw new Error(`Expected queued input params for ${prompt}`);
+async function requirePendingChatEvent(prompt: string) {
+  const event = await findPendingChatEventByPromptFixture(prompt);
+  if (!event) {
+    throw new Error(`Expected queued event for ${prompt}`);
   }
-  return params;
+  return event;
 }
 
 async function pollQueuedWebAndSlackRuns(args: {
@@ -1756,19 +1760,12 @@ describe("INT-01: Slack app deep webhook flows", () => {
         }),
       ]),
     );
-    const queuedSlackParams = await requirePendingChatEventInputParams(
+    const queuedSlackParams = await requirePendingChatEvent(
       "stay canonical on the same route",
     );
     expect(queuedSlackParams).toMatchObject({
       eventId: expect.any(String),
-      encryptedParams: expect.any(String),
     });
-    await expect(
-      decryptChatEventInputParamsFixture(queuedSlackParams.eventId, {
-        orgId,
-        userId: actor.userId,
-      }),
-    ).resolves.toStrictEqual({ version: 1 });
     await expect(
       readChatEventContextFixture(queuedSlackParams.eventId),
     ).resolves.toMatchObject({
@@ -1894,9 +1891,6 @@ describe("INT-01: Slack app deep webhook flows", () => {
       run2Id,
       claim2,
     }));
-    await expect(
-      readChatEventInputParamsFixture(queuedSlackParams.eventId),
-    ).resolves.toBeNull();
     expect(claim2.resumeSession?.sessionId).toBe(`bdd-slack-cli-${webRunId}`);
     state = await integrations.readSlackTestState(teamId);
     expect(state.recent_runs).toContainEqual(

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -14,10 +14,8 @@ import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import {
-  decryptChatEventInputParamsFixture,
-  findPendingChatEventInputParamsByPromptFixture,
+  findPendingChatEventByPromptFixture,
   readChatEventContextFixture,
-  readChatEventInputParamsFixture,
 } from "../../../test-fixtures/chat-events";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { zeroTeamsConnectRoutes } from "../zero-teams-connect";
@@ -645,13 +643,12 @@ describe("Teams chat callbacks", () => {
       text: queuedPrompt,
     });
     const queuedParams =
-      await findPendingChatEventInputParamsByPromptFixture(queuedPrompt);
+      await findPendingChatEventByPromptFixture(queuedPrompt);
     expect(queuedParams).toMatchObject({
       eventId: expect.any(String),
-      encryptedParams: expect.any(String),
     });
     if (!queuedParams) {
-      throw new Error("Expected queued Teams transport params");
+      throw new Error("Expected queued Teams event");
     }
     await expect(
       readChatEventContextFixture(queuedParams.eventId),
@@ -678,22 +675,12 @@ describe("Teams chat callbacks", () => {
       teamsSenderPrincipalName: "ada@example.com",
       teamsConnectionId: expect.any(String),
     });
-    await expect(
-      decryptChatEventInputParamsFixture(queuedParams.eventId, {
-        orgId: teams.fixture.orgId,
-        userId: teams.fixture.userId,
-      }),
-    ).resolves.toStrictEqual({ version: 1 });
-
     await completeSandboxRun({
       runId: firstRunId,
       sandboxToken: firstClaim.sandboxToken,
       exitCode: 0,
     });
     const queuedRunId = await runIdForPrompt(teams.actor, queuedPrompt);
-    await expect(
-      readChatEventInputParamsFixture(queuedParams.eventId),
-    ).resolves.toBeNull();
     const queuedClaim = await claimTeamsRun({
       runnerGroup: teams.runnerGroup,
       runId: queuedRunId,
@@ -740,9 +727,9 @@ describe("Teams chat callbacks", () => {
       omitRecipient: true,
     });
     const queuedParams =
-      await findPendingChatEventInputParamsByPromptFixture(queuedPrompt);
+      await findPendingChatEventByPromptFixture(queuedPrompt);
     if (!queuedParams) {
-      throw new Error("Expected queued Teams bot fallback params");
+      throw new Error("Expected queued Teams bot fallback event");
     }
     await expect(
       readChatEventContextFixture(queuedParams.eventId),
@@ -750,13 +737,6 @@ describe("Teams chat callbacks", () => {
       teamsBotId: null,
       teamsBotName: null,
     });
-    await expect(
-      decryptChatEventInputParamsFixture(queuedParams.eventId, {
-        orgId: teams.fixture.orgId,
-        userId: teams.fixture.userId,
-      }),
-    ).resolves.toStrictEqual({ version: 1 });
-
     await completeSandboxRun({
       runId: firstRunId,
       sandboxToken: firstClaim.sandboxToken,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-chat.test.ts
@@ -10,8 +10,7 @@ import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import {
   clearGitHubTriggerCommentBodyFixture,
-  decryptChatEventInputParamsFixture,
-  findPendingChatEventInputParamsByPromptFixture,
+  findPendingChatEventByPromptFixture,
   readChatEventContextFixture,
 } from "../../../test-fixtures/chat-events";
 import {
@@ -508,21 +507,12 @@ describe("GitHub canonical chat threads", () => {
         "follow up in FIFO order",
       ),
     ).resolves.toBe(0);
-    const queuedParams = await findPendingChatEventInputParamsByPromptFixture(
+    const queuedParams = await findPendingChatEventByPromptFixture(
       "follow up in FIFO order",
     );
     if (!queuedParams) {
-      throw new Error("Expected queued GitHub chat input params");
+      throw new Error("Expected queued GitHub chat event");
     }
-    if (!fixture.actorA.orgId) {
-      throw new Error("Expected org-scoped GitHub actor");
-    }
-    await expect(
-      decryptChatEventInputParamsFixture(queuedParams.eventId, {
-        orgId: fixture.actorA.orgId,
-        userId: fixture.actorA.userId,
-      }),
-    ).resolves.toStrictEqual({ version: 1 });
     await expect(
       readChatEventContextFixture(queuedParams.eventId),
     ).resolves.toMatchObject({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -29,10 +29,8 @@ import { env, mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { extractFileFromTarGz } from "../../../lib/tar";
 import { server } from "../../../mocks/server";
 import {
-  decryptChatEventInputParamsFixture,
-  findPendingChatEventInputParamsByPromptFixture,
+  findPendingChatEventByPromptFixture,
   readChatEventContextFixture,
-  readChatEventInputParamsFixture,
 } from "../../../test-fixtures/chat-events";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { now } from "../../external/time";
@@ -3004,24 +3002,13 @@ describe("Feishu integration", () => {
       ),
     ).toBeFalsy();
     const queuedFeishuParams =
-      await findPendingChatEventInputParamsByPromptFixture(secondPrompt);
+      await findPendingChatEventByPromptFixture(secondPrompt);
     expect(queuedFeishuParams).toMatchObject({
       eventId: expect.any(String),
-      encryptedParams: expect.any(String),
     });
     if (!queuedFeishuParams) {
-      throw new Error("Expected queued canonical Feishu transport params");
+      throw new Error("Expected queued canonical Feishu event");
     }
-    const secondOrgId = requireValue(
-      secondActor.orgId,
-      "Expected the second Feishu actor organization",
-    );
-    await expect(
-      decryptChatEventInputParamsFixture(queuedFeishuParams.eventId, {
-        orgId: secondOrgId,
-        userId: secondActor.userId,
-      }),
-    ).resolves.toStrictEqual({ version: 1 });
     await runsApi.heartbeatRunner(runnerGroup);
     const firstClaim = await runsApi.claimRunnerJob(firstRun.id);
     const firstCliSessionId = `bdd-feishu-canonical-group-${firstRun.id}`;
@@ -3034,9 +3021,6 @@ describe("Feishu integration", () => {
     });
 
     const secondRun = await findRun(secondActor, secondPrompt);
-    await expect(
-      readChatEventInputParamsFixture(queuedFeishuParams.eventId),
-    ).resolves.toBeNull();
     await runsApi.heartbeatRunner(runnerGroup);
     const secondClaim = await runsApi.claimRunnerJob(secondRun.id);
     expect(secondClaim.prompt).toBe(secondPrompt);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -19,11 +19,9 @@ import { clearMockedEnv, mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { nowDate } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import {
-  decryptChatEventInputParamsFixture,
-  findPendingChatEventInputParamsByPromptFixture,
+  findPendingChatEventByPromptFixture,
   findTelegramChatEventByPromptFixture,
   readChatEventContextFixture,
-  readChatEventInputParamsFixture,
   setTelegramThinkingMessageIdFixture,
 } from "../../../test-fixtures/chat-events";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -1449,20 +1447,13 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     ).toBe(200);
     await flushWaitUntilForTest();
     const queuedParams =
-      await findPendingChatEventInputParamsByPromptFixture(queuedPrompt);
+      await findPendingChatEventByPromptFixture(queuedPrompt);
     expect(queuedParams).toMatchObject({
       eventId: expect.any(String),
-      encryptedParams: expect.any(String),
     });
     if (!queuedParams) {
-      throw new Error("Expected queued Telegram transport params");
+      throw new Error("Expected queued Telegram event");
     }
-    await expect(
-      decryptChatEventInputParamsFixture(queuedParams.eventId, {
-        orgId: fixture.orgId,
-        userId: fixture.userId,
-      }),
-    ).resolves.toStrictEqual({ version: 1 });
     const queuedLaunchContext = await readChatEventContextFixture(
       queuedParams.eventId,
     );
@@ -1489,10 +1480,6 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     if (!queuedRunId) {
       throw new Error("Expected the queued Telegram run");
     }
-    await expect(
-      readChatEventInputParamsFixture(queuedParams.eventId),
-    ).resolves.toBeNull();
-
     const queuedClaim = await claimTelegramRun(queuedRunId, runnerGroup);
     expect(queuedClaim.prompt).toBe(queuedPrompt);
     const queuedThreadContext = queuedLaunchContext?.telegramThreadContext;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -38,7 +38,6 @@ import {
   holdChatEventQueueAdmissionLockFixture,
   holdOrgAdmissionLockFixture,
   readChatEventContextFixture,
-  readChatEventInputParamsFixture,
   setQueuedUserMessageCreatedAtFixture,
   setWorkflowQueueEventCreatedAtFixture,
 } from "../../../test-fixtures/chat-events";
@@ -622,12 +621,6 @@ describe("workflow queue", () => {
     if (!secondEvent || !thirdEvent) {
       throw new Error("Expected two pending workflow queue events");
     }
-    await expect(
-      readChatEventInputParamsFixture(secondEvent.id),
-    ).resolves.toBeNull();
-    await expect(
-      readChatEventInputParamsFixture(thirdEvent.id),
-    ).resolves.toBeNull();
     await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
       firstRunId,
     ]);
@@ -638,17 +631,11 @@ describe("workflow queue", () => {
     await completeRunThroughSandbox(scenario, firstRunId);
     const afterFirst = await workflowRunIds(automation.threadId);
     expect(afterFirst).toHaveLength(2);
-    await expect(
-      readChatEventInputParamsFixture(secondEvent.id),
-    ).resolves.toBeNull();
     const secondClaim = await completeRunThroughSandbox(
       scenario,
       afterFirst[1]!,
     );
     expect(secondClaim.apiStartTime).toBe(dequeuedAt);
-    await expect(
-      readChatEventInputParamsFixture(thirdEvent.id),
-    ).resolves.toBeNull();
   });
 
   it("keeps workflow events queued until cancellation recovery completes", async () => {
@@ -853,9 +840,6 @@ describe("workflow queue", () => {
     ).resolves.toMatchObject({
       automationId: created.body.id,
     });
-    await expect(
-      readChatEventInputParamsFixture(coalescedEvent.id),
-    ).resolves.toBeNull();
     await completeRunThroughSandbox(scenario, busyRunId);
     const afterBusy = await workflowRunIds(webhookAutomation.threadId);
     expect(afterBusy).toHaveLength(2);
@@ -1141,10 +1125,6 @@ describe("workflow queue", () => {
     if (!rejectedEvent?.revokesEventId) {
       throw new Error("Expected the rejected event to revoke its queue input");
     }
-    await expect(
-      readChatEventInputParamsFixture(rejectedEvent.revokesEventId),
-    ).resolves.toBeNull();
-
     await runsApi.ensureOrgModelProvider(scenario.actor);
     const runId = await expectAcceptedRunId(
       await postWorkflowWebhook(automation, "next trigger"),

--- a/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
@@ -41,6 +41,54 @@ type FixtureKind = Extract<
   { readonly action: "seed-fixture" }
 >["fixture_kind"];
 
+const STALE_CONTEXT_FIXTURES = [
+  {
+    contextType: "slack",
+    eventType: "input.prompt",
+    triggerSource: "slack",
+  },
+  {
+    contextType: "feishu",
+    eventType: "input.prompt",
+    triggerSource: "feishu",
+  },
+  {
+    contextType: "teams",
+    eventType: "input.prompt",
+    triggerSource: "teams",
+  },
+  {
+    contextType: "telegram",
+    eventType: "input.prompt",
+    triggerSource: "telegram",
+  },
+  {
+    contextType: "github",
+    eventType: "input.prompt",
+    triggerSource: "github",
+  },
+  {
+    contextType: "agentphone",
+    eventType: "input.prompt",
+    triggerSource: "agentphone",
+  },
+  {
+    contextType: "automation",
+    eventType: "input.automation",
+    triggerSource: "workflow-event",
+  },
+  {
+    contextType: "goal",
+    eventType: "input.goal",
+    triggerSource: null,
+  },
+  {
+    contextType: "morning_brief",
+    eventType: "input.prompt",
+    triggerSource: "workflow-schedule",
+  },
+] as const;
+
 function actionOk(extra: Record<string, unknown> = {}) {
   return {
     status: 200 as const,
@@ -123,7 +171,7 @@ async function seedFixture(
     throw new Error("Failed to seed orphan monitor thread");
   }
 
-  const event = await db.transaction(async (tx) => {
+  const events = await db.transaction(async (tx) => {
     const baseEvent = {
       chatThreadId: thread.id,
       userMessage: createUserMessageDocument({
@@ -131,43 +179,55 @@ async function seedFixture(
       }),
       runId: null,
     };
-    if (fixtureKind === "orphaned-automation") {
-      const [orphanedAutomation] = await tx
+    if (fixtureKind === "orphan") {
+      return await tx
         .insert(chatEvents)
-        .values({
-          chatThreadId: thread.id,
-          eventType: "input.automation",
-          runId: null,
-          triggerSource: "workflow-event",
-          seqId: 1,
-        })
+        .values(
+          STALE_CONTEXT_FIXTURES.map((fixture, index) => {
+            return {
+              ...baseEvent,
+              ...fixture,
+              contextId: randomUUID(),
+              createdAt: new Date(0),
+              seqId: index + 1,
+            };
+          }),
+        )
         .returning({ id: chatEvents.id });
-      return orphanedAutomation ?? null;
     }
-    return fixtureKind === "failed-message"
-      ? await insertChatEvent(tx, {
-          ...baseEvent,
-          eventType: "input.rejected",
-          error: "INSUFFICIENT_CREDITS",
-        })
-      : await insertChatEvent(tx, {
-          ...baseEvent,
-          eventType: "input.prompt",
-          triggerSource:
-            fixtureKind === "orphan" || fixtureKind === "queued-integration"
-              ? "slack"
-              : "web",
-        });
+    if (fixtureKind === "orphaned-automation") {
+      const automation = await insertChatEvent(tx, {
+        ...baseEvent,
+        eventType: "input.automation",
+        createdAt: new Date(0),
+        automationId: randomUUID(),
+        triggerSource: "workflow-event",
+        triggerBrief: null,
+      });
+      return [automation];
+    }
+    const event =
+      fixtureKind === "failed-message"
+        ? await insertChatEvent(tx, {
+            ...baseEvent,
+            eventType: "input.rejected",
+            error: "INSUFFICIENT_CREDITS",
+          })
+        : await insertChatEvent(tx, {
+            ...baseEvent,
+            eventType: "input.prompt",
+            triggerSource:
+              fixtureKind === "queued-integration" ? "slack" : "web",
+          });
+    return [event];
   });
   signal.throwIfAborted();
+  const event = events[0];
   if (!event) {
     throw new Error("Failed to seed orphan monitor message");
   }
 
-  if (
-    fixtureKind === "queued-integration" ||
-    fixtureKind === "orphaned-automation"
-  ) {
+  if (fixtureKind === "queued-integration") {
     await db.insert(chatEventInputParams).values({
       eventId: event.id,
       encryptedParams: "encrypted-monitor-params",
@@ -192,7 +252,16 @@ async function seedFixture(
   }
   signal.throwIfAborted();
 
-  return actionOk({ compose_id: compose.id, event_id: event.id });
+  return actionOk({
+    compose_id: compose.id,
+    event_id: event.id,
+    event_ids: events.map((candidate) => {
+      if (!candidate) {
+        throw new Error("Failed to seed orphan monitor message");
+      }
+      return candidate.id;
+    }),
+  });
 }
 
 const mutateTestCronMonitorChatEventQueueState$ = command(

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -23,7 +23,7 @@ import { drainGoalQueueForThread$ } from "./zero-goal-queue-drain.service";
 import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
 
 const DRAIN_SWEEP_LIMIT = 20;
-const STALE_QUEUE_ITEM_AGE_MS = 5 * 60 * 1000;
+export const STALE_QUEUE_ITEM_AGE_MS = 5 * 60 * 1000;
 const L = logger("ChatThreadQueueDrain");
 
 type QueueDrainSweepCandidate =

--- a/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
@@ -548,15 +548,10 @@ export const cleanupSandboxes$ = command(
     signal.throwIfAborted();
     const drainedCount = await set(drainStaleQueues$, signal);
     signal.throwIfAborted();
-    await tapError(
-      set(
-        drainStaleChatThreadQueues$,
-        { dispatchFailedCallbacks: dispatchFailedRunCallbacks },
-        signal,
-      ),
-      (error) => {
-        L.error("Failed to drain stale chat thread queues", { error });
-      },
+    await set(
+      drainStaleChatThreadQueues$,
+      { dispatchFailedCallbacks: dispatchFailedRunCallbacks },
+      signal,
     );
     signal.throwIfAborted();
     await tapError(set(drainStaleCanonicalSlackIngress$, signal), (error) => {

--- a/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
@@ -1,22 +1,186 @@
+import { chatAgentphoneContext } from "@vm0/db/schema/chat-agentphone-context";
 import { chatAutomationContext } from "@vm0/db/schema/chat-automation-context";
-import { chatEventInputParams } from "@vm0/db/schema/chat-event-input-params";
 import { chatEvents } from "@vm0/db/schema/chat-event";
+import { chatFeishuContext } from "@vm0/db/schema/chat-feishu-context";
+import { chatGithubContext } from "@vm0/db/schema/chat-github-context";
+import { chatGoalContext } from "@vm0/db/schema/chat-goal-context";
+import { chatMorningBriefContext } from "@vm0/db/schema/chat-morning-brief-context";
+import { chatSlackContext } from "@vm0/db/schema/chat-slack-context";
+import { chatTeamsContext } from "@vm0/db/schema/chat-teams-context";
+import { chatTelegramContext } from "@vm0/db/schema/chat-telegram-context";
 import { command } from "ccstate";
-import { and, count, eq, inArray, isNull, or } from "drizzle-orm";
+import {
+  and,
+  count,
+  eq,
+  inArray,
+  isNull,
+  lt,
+  notExists,
+  notInArray,
+  or,
+  sql,
+} from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 
+import {
+  nullableDriverValueDecoder,
+  pgTextDecoder,
+} from "../../lib/db-structured-result";
 import { writeDb$, type Db } from "../external/db";
-import { visibleChatEventCondition } from "./zero-chat-event-shared.service";
+import { nowDate } from "../external/time";
+import { STALE_QUEUE_ITEM_AGE_MS } from "./chat-thread-queue-drain.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
 
 const ORPHANED_CHAT_EVENT_ERROR_CODE = "ORPHANED_QUEUED_CHAT_MESSAGES";
+const monitoredEventRevoker = alias(chatEvents, "monitored_event_revoker");
 
 class OrphanedQueuedChatEventsError extends Error {
   readonly code = ORPHANED_CHAT_EVENT_ERROR_CODE;
 
-  constructor(readonly orphanedMessages: number) {
+  constructor(
+    readonly orphanedMessages: number,
+    readonly orphanedMessagesBySource: Readonly<Record<string, number>>,
+  ) {
     super("Orphaned queued chat messages detected");
     this.name = "OrphanedQueuedChatEventsError";
   }
+}
+
+function missingChatIntegrationContextRowCondition(db: Db) {
+  return or(
+    and(
+      eq(chatEvents.contextType, "slack"),
+      notExists(
+        db
+          .select({ id: chatSlackContext.id })
+          .from(chatSlackContext)
+          .where(
+            and(
+              eq(chatSlackContext.id, chatEvents.contextId),
+              eq(chatSlackContext.chatThreadId, chatEvents.chatThreadId),
+            ),
+          ),
+      ),
+    ),
+    and(
+      eq(chatEvents.contextType, "feishu"),
+      notExists(
+        db
+          .select({ id: chatFeishuContext.id })
+          .from(chatFeishuContext)
+          .where(
+            and(
+              eq(chatFeishuContext.id, chatEvents.contextId),
+              eq(chatFeishuContext.chatThreadId, chatEvents.chatThreadId),
+            ),
+          ),
+      ),
+    ),
+    and(
+      eq(chatEvents.contextType, "teams"),
+      notExists(
+        db
+          .select({ id: chatTeamsContext.id })
+          .from(chatTeamsContext)
+          .where(
+            and(
+              eq(chatTeamsContext.id, chatEvents.contextId),
+              eq(chatTeamsContext.chatThreadId, chatEvents.chatThreadId),
+            ),
+          ),
+      ),
+    ),
+    and(
+      eq(chatEvents.contextType, "telegram"),
+      notExists(
+        db
+          .select({ id: chatTelegramContext.id })
+          .from(chatTelegramContext)
+          .where(
+            and(
+              eq(chatTelegramContext.id, chatEvents.contextId),
+              eq(chatTelegramContext.chatThreadId, chatEvents.chatThreadId),
+            ),
+          ),
+      ),
+    ),
+    and(
+      eq(chatEvents.contextType, "github"),
+      notExists(
+        db
+          .select({ id: chatGithubContext.id })
+          .from(chatGithubContext)
+          .where(
+            and(
+              eq(chatGithubContext.id, chatEvents.contextId),
+              eq(chatGithubContext.chatThreadId, chatEvents.chatThreadId),
+            ),
+          ),
+      ),
+    ),
+  );
+}
+
+function missingScheduledContextRowCondition(db: Db) {
+  return or(
+    and(
+      eq(chatEvents.contextType, "agentphone"),
+      notExists(
+        db
+          .select({ id: chatAgentphoneContext.id })
+          .from(chatAgentphoneContext)
+          .where(
+            and(
+              eq(chatAgentphoneContext.id, chatEvents.contextId),
+              eq(chatAgentphoneContext.chatThreadId, chatEvents.chatThreadId),
+            ),
+          ),
+      ),
+    ),
+    and(
+      eq(chatEvents.contextType, "automation"),
+      notExists(
+        db
+          .select({ id: chatAutomationContext.id })
+          .from(chatAutomationContext)
+          .where(
+            and(
+              eq(chatAutomationContext.id, chatEvents.contextId),
+              eq(chatAutomationContext.chatThreadId, chatEvents.chatThreadId),
+            ),
+          ),
+      ),
+    ),
+    and(
+      eq(chatEvents.contextType, "goal"),
+      notExists(
+        db
+          .select({ id: chatGoalContext.id })
+          .from(chatGoalContext)
+          .where(
+            and(
+              eq(chatGoalContext.id, chatEvents.contextId),
+              eq(chatGoalContext.chatThreadId, chatEvents.chatThreadId),
+            ),
+          ),
+      ),
+    ),
+    and(
+      eq(chatEvents.contextType, "morning_brief"),
+      notExists(
+        db
+          .select({ id: chatMorningBriefContext.id })
+          .from(chatMorningBriefContext)
+          .where(
+            and(
+              eq(chatMorningBriefContext.id, chatEvents.contextId),
+              eq(chatMorningBriefContext.chatThreadId, chatEvents.chatThreadId),
+            ),
+          ),
+      ),
+    ),
+  );
 }
 
 async function monitorChatEventQueue(
@@ -24,54 +188,60 @@ async function monitorChatEventQueue(
   signal: AbortSignal,
   eventIds?: readonly string[],
 ) {
-  const [result] = await db
-    .select({ orphanedMessages: count() })
+  const staleBefore = new Date(nowDate().getTime() - STALE_QUEUE_ITEM_AGE_MS);
+  const orphanedSource =
+    sql`coalesce(${chatEvents.contextType}, ${chatEvents.triggerSource})`.mapWith(
+      nullableDriverValueDecoder(pgTextDecoder),
+    );
+  const results = await db
+    .select({ source: orphanedSource, orphanedMessages: count() })
     .from(chatEvents)
-    .leftJoin(
-      chatEventInputParams,
-      eq(chatEventInputParams.eventId, chatEvents.id),
-    )
-    .leftJoin(
-      chatAutomationContext,
-      and(
-        eq(chatEvents.contextType, "automation"),
-        eq(chatAutomationContext.id, chatEvents.contextId),
-      ),
-    )
     .where(
       and(
         eventIds === undefined
           ? undefined
           : inArray(chatEvents.id, [...eventIds]),
+        chatEventTypeIn(["input.prompt", "input.automation", "input.goal"]),
         isNull(chatEvents.runId),
-        visibleChatEventCondition(db),
+        notExists(
+          db
+            .select({ id: monitoredEventRevoker.id })
+            .from(monitoredEventRevoker)
+            .where(eq(monitoredEventRevoker.revokesEventId, chatEvents.id)),
+        ),
+        lt(chatEvents.createdAt, staleBefore),
         or(
           and(
-            chatEventTypeIn(["input.automation"]),
+            isNull(chatEvents.contextType),
             or(
-              isNull(chatAutomationContext.automationId),
-              isNull(chatEvents.triggerSource),
-              isNull(chatEventInputParams.encryptedParams),
+              chatEventTypeIn(["input.goal"]),
+              notInArray(chatEvents.triggerSource, ["web", "test", "agent"]),
             ),
           ),
-          and(
-            chatEventTypeIn(["input.prompt"]),
-            inArray(chatEvents.triggerSource, [
-              "slack",
-              "feishu",
-              "teams",
-              "telegram",
-            ]),
-            isNull(chatEventInputParams.encryptedParams),
-          ),
+          missingChatIntegrationContextRowCondition(db),
+          missingScheduledContextRowCondition(db),
         ),
       ),
-    );
+    )
+    .groupBy(orphanedSource);
   signal.throwIfAborted();
 
-  const orphanedMessages = result?.orphanedMessages ?? 0;
+  const orphanedMessagesBySource = Object.fromEntries(
+    results.map((result) => {
+      return [result.source ?? "(unknown)", result.orphanedMessages];
+    }),
+  );
+  const orphanedMessages = Object.values(orphanedMessagesBySource).reduce(
+    (total, sourceCount) => {
+      return total + sourceCount;
+    },
+    0,
+  );
   if (orphanedMessages > 0) {
-    throw new OrphanedQueuedChatEventsError(orphanedMessages);
+    throw new OrphanedQueuedChatEventsError(
+      orphanedMessages,
+      orphanedMessagesBySource,
+    );
   }
 
   return {

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -141,7 +141,6 @@ import {
 } from "./assistant-event-id";
 import { attachCanonicalPublishedAssetsToCompletionEvent } from "./canonical-published-asset-event.service";
 import {
-  decryptQueuedUserMessageRunParams,
   discardUnclaimedUserMessageInTransaction,
   failQueuedUserMessage,
   loadNextUnclaimedQueuedUserMessage,
@@ -3033,13 +3032,6 @@ function resolveQueuedMessageGenerationTemplatePrompt(args: {
 }
 
 async function loadQueuedRunMaterial(args: CreateQueuedChatRunInputArgs) {
-  const sourceParams = await decryptQueuedUserMessageRunParams(
-    args.queuedMessage.encryptedParams,
-    { orgId: args.agent.orgId, userId: args.userId },
-  );
-  if (args.queuedMessage.triggerSource !== "web" && !sourceParams) {
-    throw new Error("Canonical integration queue item is missing run params");
-  }
   return await resolveQueuedLaunchMaterial(args);
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -421,7 +421,6 @@ export interface LoadedChatEventReplacementTarget extends StoredChatEventContext
   readonly chatThreadId: string;
   readonly createdAt: Date;
   readonly eventType: NonNullable<ChatEventInsert["eventType"]>;
-  readonly encryptedParams: string | null;
 }
 
 type NewDisplayContext =
@@ -1166,13 +1165,8 @@ export async function replaceChatEvent(
       eventType: chatEvents.eventType,
       contextType: chatEvents.contextType,
       contextId: chatEvents.contextId,
-      encryptedParams: chatEventInputParams.encryptedParams,
     })
     .from(chatEvents)
-    .leftJoin(
-      chatEventInputParams,
-      eq(chatEventInputParams.eventId, chatEvents.id),
-    )
     .where(eq(chatEvents.id, eventId))
     .limit(1);
   if (!target) {
@@ -1206,28 +1200,18 @@ export async function replaceLoadedChatEvent(
     );
   }
 
-  const replacementWithParams =
-    isPendingInputEvent(replacement) && target.encryptedParams
-      ? {
-          ...replacement,
-          encryptedParams:
-            "encryptedParams" in replacement && replacement.encryptedParams
-              ? replacement.encryptedParams
-              : target.encryptedParams,
-        }
-      : replacement;
   const replacementId = replacement.id ?? randomUUID();
   const { pointer: contextPointer, displayContext } = replacementContext(
     target,
     replacementId,
-    replacementWithParams,
+    replacement,
   );
   const seqId = await reserveChatEventSeqIds(tx, replacement.chatThreadId, 1);
   const rows = await tx
     .insert(chatEvents)
     .values({
       ...persistedChatEventValues(
-        { ...replacementWithParams, createdAt },
+        { ...replacement, createdAt },
         {
           id: replacementId,
           ...contextPointer,
@@ -1250,7 +1234,7 @@ export async function replaceLoadedChatEvent(
   if (displayContext) {
     await insertDisplayContext(tx, displayContext, inserted.createdAt);
   }
-  await insertEventInputParams(tx, inserted.id, replacementWithParams);
+  await insertEventInputParams(tx, inserted.id, replacement);
   if (options?.preserveAssetRefs !== false) {
     await tx
       .insert(chatEventAssetRefs)

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -3,7 +3,6 @@ import type { ChatEventType } from "@vm0/api-contracts/contracts/chat-events";
 import { command } from "ccstate";
 import { chatAutomationContext } from "@vm0/db/schema/chat-automation-context";
 import { chatGoalContext } from "@vm0/db/schema/chat-goal-context";
-import { chatEventInputParams } from "@vm0/db/schema/chat-event-input-params";
 import {
   chatEvents,
   type ChatEventAttachFileMetadata,
@@ -58,10 +57,7 @@ import { touchChatThreadLastMessageAt } from "./zero-chat-event-shared.service";
 import { chatThreadAdmissionBlocked } from "./zero-chat-active-run.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
-import {
-  decryptPersistentSecretsMap,
-  encryptPersistentSecretsMap,
-} from "./crypto.utils";
+import { encryptPersistentSecretsMap } from "./crypto.utils";
 import { noGoalChangeAfterQueueEvent } from "./chat-goal-queue.service";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { resolveArtifactObject$ } from "./artifact-storage.service";
@@ -91,7 +87,6 @@ type QueuedUserMessageRunParams = z.infer<
 
 const queuedChatEvent = alias(chatEvents, "queued_chat_event");
 const queuedChatEventRevoker = alias(chatEvents, "queued_chat_event_revoker");
-const queuedEncryptedParams = chatEventInputParams.encryptedParams;
 const queueFirstReplacementTargetFields = {
   id: chatEvents.id,
   chatThreadId: chatEvents.chatThreadId,
@@ -99,7 +94,6 @@ const queueFirstReplacementTargetFields = {
   eventType: chatEvents.eventType,
   contextType: chatEvents.contextType,
   contextId: chatEvents.contextId,
-  encryptedParams: queuedEncryptedParams,
 } as const;
 
 export interface QueuedUserMessage {
@@ -121,7 +115,6 @@ export interface QueuedUserMessage {
     | "agentphone"
     | "github"
     | "workflow-schedule";
-  readonly encryptedParams: string | null;
 }
 
 export type QueueFirstRunAssociation =
@@ -195,21 +188,6 @@ export async function encryptQueuedUserMessageRunParams(
     throw new Error("Failed to encrypt queued user message run params");
   }
   return encrypted;
-}
-
-export async function decryptQueuedUserMessageRunParams(
-  encryptedParams: string | null,
-  ctx: { readonly orgId: string; readonly userId: string },
-): Promise<QueuedUserMessageRunParams | null> {
-  if (!encryptedParams) {
-    return null;
-  }
-  const decrypted = await decryptPersistentSecretsMap(encryptedParams, ctx);
-  const raw = decrypted?.[USER_MESSAGE_QUEUE_RUN_PARAMS_KEY];
-  if (!raw) {
-    return null;
-  }
-  return queuedUserMessageRunParamsSchema.parse(JSON.parse(raw) as unknown);
 }
 
 export const resolveAttachFileMetadata$ = command(
@@ -312,14 +290,9 @@ export async function loadNextUnclaimedQueuedUserMessage(
       modelProviderCredentialScope: sql`NULL`.mapWith(pgNullDecoder),
       selectedModel: chatThreads.selectedModel,
       triggerSource: chatEvents.triggerSource,
-      encryptedParams: queuedEncryptedParams,
     })
     .from(chatEvents)
     .innerJoin(chatThreads, eq(chatThreads.id, chatEvents.chatThreadId))
-    .leftJoin(
-      chatEventInputParams,
-      eq(chatEventInputParams.eventId, chatEvents.id),
-    )
     .where(
       and(
         eq(chatEvents.id, head.id),
@@ -380,7 +353,6 @@ function replacementTargetFromQueueHead(
     eventType: head.eventType,
     contextType: head.contextType,
     contextId: head.contextId,
-    encryptedParams: head.encryptedParams,
   };
 }
 
@@ -397,10 +369,6 @@ async function resolveUserQueueFirstClaimSnapshot(
       triggerSource: chatEvents.triggerSource,
     })
     .from(chatEvents)
-    .leftJoin(
-      chatEventInputParams,
-      eq(chatEventInputParams.eventId, chatEvents.id),
-    )
     .where(
       and(
         eq(chatEvents.chatThreadId, args.threadId),
@@ -449,10 +417,6 @@ async function resolveWorkflowQueueFirstClaimSnapshot(
       workflowName: zeroWorkflows.name,
     })
     .from(chatEvents)
-    .leftJoin(
-      chatEventInputParams,
-      eq(chatEventInputParams.eventId, chatEvents.id),
-    )
     .leftJoin(
       chatAutomationContext,
       and(
@@ -537,10 +501,6 @@ async function resolveGoalQueueFirstClaimSnapshot(
       goalBrief: chatGoalContext.objectiveBrief,
     })
     .from(chatEvents)
-    .leftJoin(
-      chatEventInputParams,
-      eq(chatEventInputParams.eventId, chatEvents.id),
-    )
     .leftJoin(
       threadGoals,
       and(

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -13,7 +13,6 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { chatAutomationContext } from "@vm0/db/schema/chat-automation-context";
 import { chatAgentphoneContext } from "@vm0/db/schema/chat-agentphone-context";
-import { chatEventInputParams } from "@vm0/db/schema/chat-event-input-params";
 import { chatFeishuContext } from "@vm0/db/schema/chat-feishu-context";
 import { chatGithubContext } from "@vm0/db/schema/chat-github-context";
 import { chatGoalContext } from "@vm0/db/schema/chat-goal-context";
@@ -36,7 +35,6 @@ import {
 } from "../signals/services/zero-chat-event.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
-import { decryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
@@ -54,11 +52,6 @@ const blockedByPidRowSchema = z.object({ blocked: z.boolean() });
 const blockedQueryRowSchema = z.object({ query: z.string() });
 
 type ChatThreadBlockedStatementKind = "select_for_update" | "update" | "other";
-
-interface ChatEventInputParamsFixture {
-  readonly eventId: string;
-  readonly encryptedParams: string;
-}
 
 interface ChatEventContextFixture {
   readonly id: string;
@@ -644,31 +637,6 @@ export async function seedChatEventAnnotationProjectionFixture(
   return { claimedPendingId, rejectedPendingId };
 }
 
-export async function readChatEventInputParamsFixture(
-  eventId: string,
-): Promise<ChatEventInputParamsFixture | null> {
-  const [row] = await db()
-    .select({
-      eventId: chatEventInputParams.eventId,
-      encryptedParams: chatEventInputParams.encryptedParams,
-    })
-    .from(chatEventInputParams)
-    .where(eq(chatEventInputParams.eventId, eventId))
-    .limit(1);
-  return row ?? null;
-}
-
-export async function decryptChatEventInputParamsFixture(
-  eventId: string,
-  ctx: { readonly orgId: string; readonly userId: string },
-) {
-  const row = await readChatEventInputParamsFixture(eventId);
-  if (!row) {
-    return null;
-  }
-  return await decryptQueuedUserMessageRunParams(row.encryptedParams, ctx);
-}
-
 async function pendingTelegramEventContext(eventId: string) {
   const [row] = await db()
     .select({
@@ -779,17 +747,15 @@ export async function findAgentphoneChatEventByPromptFixture(
   return row ?? null;
 }
 
-export async function findPendingChatEventInputParamsByPromptFixture(
+export async function findPendingChatEventByPromptFixture(
   prompt: string,
-): Promise<ChatEventInputParamsFixture | null> {
+): Promise<{ readonly eventId: string } | null> {
   const rows = await db()
     .select({
-      eventId: chatEventInputParams.eventId,
-      encryptedParams: chatEventInputParams.encryptedParams,
+      eventId: chatEvents.id,
       userMessage: chatEvents.userMessage,
     })
-    .from(chatEventInputParams)
-    .innerJoin(chatEvents, eq(chatEvents.id, chatEventInputParams.eventId))
+    .from(chatEvents)
     .where(isNull(chatEvents.runId));
   const row = rows.find((candidate) => {
     return candidate.userMessage?.parts.some((part) => {
@@ -799,27 +765,39 @@ export async function findPendingChatEventInputParamsByPromptFixture(
   return row ?? null;
 }
 
-/**
- * Makes one pending queue item fail while loading its private run parameters.
- * Product APIs cannot persist malformed encrypted state.
- */
-export async function invalidatePendingChatEventInputParamsFixture(
-  eventId: string,
-): Promise<void> {
-  const rows = await db()
-    .insert(chatEventInputParams)
-    .values({
-      eventId,
-      encryptedParams: "invalid-encrypted-queue-params",
-    })
-    .onConflictDoUpdate({
-      target: chatEventInputParams.eventId,
-      set: { encryptedParams: "invalid-encrypted-queue-params" },
-    })
-    .returning({ eventId: chatEventInputParams.eventId });
-  if (rows.length !== 1) {
-    throw new Error("Expected one pending queue item to become invalid");
-  }
+/** Inserts a pending Slack event, then removes the context its claim requires. */
+export async function insertQueuedSlackMissingContextFixture(args: {
+  readonly threadId: string;
+  readonly content: string;
+}): Promise<string> {
+  return await db().transaction(async (tx) => {
+    const event = await insertChatEvent(tx, {
+      chatThreadId: args.threadId,
+      eventType: "input.prompt",
+      userMessage: createUserMessageDocument({ text: args.content }),
+      runId: null,
+      triggerSource: "slack",
+      slackContext: {
+        messagePermalink: null,
+        channelId: "C_MONITOR_FAILURE",
+        messageTs: "1.000001",
+        conversationContext: "",
+        messageText: args.content,
+        messageFiles: [],
+        mentionDisplayNames: {},
+        senderDisplayName: "Queue Monitor Fixture",
+        senderUserId: "U_MONITOR_FAILURE",
+        channelType: "channel",
+        threadTs: "1.000001",
+        routeThreadTs: null,
+      },
+    });
+    if (!event) {
+      throw new Error("Failed to insert queued Slack fixture");
+    }
+    await tx.delete(chatSlackContext).where(eq(chatSlackContext.id, event.id));
+    return event.id;
+  });
 }
 
 export async function replayPendingChatInputQueueEventFixture(args: {

--- a/turbo/apps/api/src/test-fixtures/morning-brief.ts
+++ b/turbo/apps/api/src/test-fixtures/morning-brief.ts
@@ -1,13 +1,11 @@
 import { randomUUID } from "node:crypto";
 
-import { chatEventInputParams } from "@vm0/db/schema/chat-event-input-params";
 import { chatEvents } from "@vm0/db/schema/chat-event";
 import { chatMorningBriefContext } from "@vm0/db/schema/chat-morning-brief-context";
 import { morningBriefDeliveries } from "@vm0/db/schema/morning-brief";
 import { and, eq } from "drizzle-orm";
 
 import { db } from "../lib/db";
-import { decryptQueuedUserMessageRunParams } from "../signals/services/zero-chat-queued-event.service";
 import { insertChatEvent } from "../signals/services/zero-chat-event.service";
 import { touchChatThreadLastMessageAt } from "../signals/services/zero-chat-event-shared.service";
 import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
@@ -36,43 +34,6 @@ export async function readMorningBriefDeliveryFixture(args: {
     )
     .limit(1);
   return delivery ?? null;
-}
-
-export async function readMorningBriefQueuedParamsForDeliveryFixture(args: {
-  readonly deliveryId: string;
-  readonly threadId: string;
-  readonly orgId: string;
-  readonly userId: string;
-}) {
-  const messages = await db()
-    .select({
-      deliveryId: chatMorningBriefContext.deliveryId,
-      encryptedParams: chatEventInputParams.encryptedParams,
-    })
-    .from(chatEvents)
-    .leftJoin(
-      chatMorningBriefContext,
-      and(
-        eq(chatMorningBriefContext.id, chatEvents.contextId),
-        eq(chatMorningBriefContext.chatThreadId, chatEvents.chatThreadId),
-      ),
-    )
-    .leftJoin(
-      chatEventInputParams,
-      eq(chatEventInputParams.eventId, chatEvents.id),
-    )
-    .where(eq(chatEvents.chatThreadId, args.threadId));
-  for (const message of messages) {
-    if (message.deliveryId !== args.deliveryId) {
-      continue;
-    }
-    const params = await decryptQueuedUserMessageRunParams(
-      message.encryptedParams,
-      { orgId: args.orgId, userId: args.userId },
-    );
-    return params;
-  }
-  return null;
 }
 
 export async function setMorningBriefTriggeredAtFixture(args: {


### PR DESCRIPTION
## Summary

- rebuild `cron-monitor-chat-event-queue` around the nine typed context tables
- apply the shared 5-minute stale threshold and group alerts by `coalesce(context_type, trigger_source)`
- remove every `chat_event_input_params` read, including test-side reads and the unused decrypt helper
- let `drainStaleChatThreadQueues$` failures reach the request error handler so Sentry and the unhandled-request alert path see them

## Root cause

The previous monitor treated missing legacy `encrypted_params` as orphan evidence. That now produces false positives for healthy `input.automation` events, while the placeholder rows written by four integrations make the other branch inert. It also had no age threshold, so normal queue residency could alert.

The queue claim path no longer consumes this table. This PR removes readers first while deliberately preserving the table and every writer for the required staged rollout.

## Safety boundary

This is PR 1 of the required three-PR sequence for #24576.

- `chat_event_input_params` remains present
- all production and test writers remain active
- no `user_message`, API contract, event-stream, client-rendering, or `chat_*_context` column changes
- PR 2 will only stop writes after this PR is released and observed
- PR 3 will only add the drop migration after PR 2 is released, observed, and the deploy-day production gate is zero

## Monitor behavior

A pending, unrevoked event is eligible only after five minutes. Missing pointers and missing typed context rows are checked for Slack, Feishu, Teams, Telegram, GitHub, AgentPhone, automation, goal, and Morning Brief. Counts are grouped by `coalesce(context_type, trigger_source)`.

The healthy automation regression fixture is deliberately older than the threshold and has no legacy params row, proving that its valid context prevents an alert. A separate fresh Slack fixture proves that an event younger than the threshold does not alert.

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- `pnpm format` plus `git diff --check`
- CI-pinned PG17: 9 relevant integration files, 150 tests passed
- CI-pinned PG17: cleanup cron, 21 tests passed
- CI-pinned PG17: recovery isolation and queued Web preview/attachment paths, 3 tests passed

## Production rollout record

| Step | PR | Production time | Observation |
| --- | --- | --- | --- |
| PR 1: remove readers and rewrite monitor | #24615 | API promoted 2026-08-03T03:55:57Z; release completed 2026-08-03T03:57:39Z via release PR #24599 / run 30782584247 | 2026-08-03T03:56:13Z-04:10:03Z: cleanup cron 15/15 HTTP 200; orphan-queue and stale-drain alerts 0; Axiom queries non-partial with no warnings |
| PR 2: stop writers and retain the table | #24644 | API promoted 2026-08-03T05:36:10Z; release completed 2026-08-03T05:38:47Z via release PR #24641 / run 30785183076 | 2026-08-03T05:36:10Z-05:46:20Z: cleanup cron 10/10 and queue monitor 10/10 HTTP 200; orphan-queue and stale-drain alerts 0; Axiom queries non-partial with no warnings |
| PR 3: drop the table | #24677 | Release PR #24688 merged 2026-08-03T08:26:10Z; production migration ran 08:37:44Z-08:37:46Z; API promoted 08:37:48Z-08:37:51Z; final release attempt completed 08:43:48Z via run 30797383193 | Migration 0808 ran the issue's exact SELECT gates immediately before its same-transaction fail-closed assertion; db:migrate printed Migrations complete, proving the table was empty at deployment and the drop committed. From 08:37:51Z-08:48:47Z, cleanup was 12/12, queue monitor 12/12, and browser reconcile 11/11 HTTP 200; both alert messages and chat_event_input_params log references were 0; Axiom queries were non-partial with no warnings. All production deployment jobs succeeded. Attempt 1 ended failure only because the auxiliary next-release-PR refresh lost its GitHub connection with other side closed; attempt 2 reran that auxiliary job successfully at 08:43:47Z, so the final workflow conclusion is success. The no-input host-worker deploy was skipped. |

Refs #24576