### PR TITLE
fix(mail): restrict reply follow-up switch to staff

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -3,15 +3,38 @@ import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
+const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 
 function client() {
   return setupApp({ context })(zeroFeatureSwitchesContract);
 }
 
 describe("/api/zero/feature-switches", () => {
+  it("exposes mail reply follow-up only to staff", async () => {
+    const mocks = createZeroRouteMocks(context);
+    const headers = { authorization: "Bearer clerk-session" };
+    mockOptionalEnv("ZERO_MAIL_REPLY_FOLLOW_UP_ROLLOUT_ENABLED", "true");
+
+    mocks.clerk.session("user_staff_feature_switch_test", STAFF_ORG_ID);
+    const staff = await accept(client().get({ headers }), [200]);
+    expect(
+      staff.body.effectiveSwitches[FeatureSwitchKey.ZeroMailReplyFollowUp],
+    ).toBeTruthy();
+
+    mocks.clerk.session(
+      "user_nonstaff_feature_switch_test",
+      "org_nonstaff_feature_switch_test",
+    );
+    const nonStaff = await accept(client().get({ headers }), [200]);
+    expect(
+      nonStaff.body.effectiveSwitches[FeatureSwitchKey.ZeroMailReplyFollowUp],
+    ).toBeFalsy();
+  });
+
   it("persists and activates inline templates for a non-staff org", async () => {
     createZeroRouteMocks(context).clerk.session(
       "user_nonstaff_feature_switch_test",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
@@ -761,15 +761,6 @@ describe("POST /api/zero/mail/drafts/link", () => {
       replyFollowUpEnabled: true,
     });
     mockGmailDraftApi();
-    const featureSwitches = await accept(
-      featureSwitchesClient().get({ headers: authHeaders() }),
-      [200],
-    );
-    expect(
-      featureSwitches.body.effectiveSwitches[
-        FeatureSwitchKey.ZeroMailReplyFollowUp
-      ],
-    ).toBeTruthy();
 
     const linked = await linkDraft(fixture);
     await accept(

--- a/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
@@ -35,6 +35,7 @@ function featureSwitchResponseBody(params: {
     overrides: params.switches,
   });
   effectiveSwitches[FeatureSwitchKey.ZeroMailReplyFollowUp] =
+    effectiveSwitches[FeatureSwitchKey.ZeroMailReplyFollowUp] &&
     isZeroMailReplyFollowUpRolloutEnabled();
 
   return {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -15,9 +15,6 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.VideoArtifactPosters, {})).toBe(
       true,
     );
-    expect(isFeatureEnabled(FeatureSwitchKey.ZeroMailReplyFollowUp, {})).toBe(
-      true,
-    );
     expect(
       isFeatureEnabled(FeatureSwitchKey.ComposerSkillSubstringSearch, {}),
     ).toBe(true);
@@ -55,6 +52,9 @@ describe("isFeatureEnabled", () => {
       false,
     );
     expect(isFeatureEnabled(FeatureSwitchKey.ZeroImageRecognition, {})).toBe(
+      false,
+    );
+    expect(isFeatureEnabled(FeatureSwitchKey.ZeroMailReplyFollowUp, {})).toBe(
       false,
     );
   });
@@ -131,6 +131,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ZeroBrowser]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroChatMessaging]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroImageRecognition]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ZeroMailReplyFollowUp]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ClaudeSessionPruning]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(true);
@@ -164,6 +165,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ZeroBrowser]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroChatMessaging]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroImageRecognition]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ZeroMailReplyFollowUp]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ClaudeSessionPruning]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -491,8 +491,9 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ZeroMailReplyFollowUp]: {
     maintainer: "yuma@vm0.ai",
     description:
-      "Enable Zero Mail reply follow-up after all API deployments can read Gmail event configurations with threadId.",
-    enabled: true,
+      "Enable Zero Mail reply follow-up for staff after all API deployments can read Gmail event configurations with threadId.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
     userOverridable: false,
   },
   [FeatureSwitchKey.ZeroBrowser]: {


### PR DESCRIPTION
## Summary

- restrict the Zero Mail reply follow-up feature switch to staff organizations
- preserve the deployment compatibility gate when resolving the effective switch
- cover staff and non-staff visibility through the feature-switch API

## Test plan

- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feature-switches.test.ts src/signals/routes/__tests__/zero-mail.test.ts`
- `pnpm -F @vm0/core lint`
- `pnpm -F api lint`
- `pnpm knip`
- `pnpm check-types`