### PR TITLE
fix(teams): preserve dispatch on realtime failure

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -192,6 +192,26 @@ export async function publishChatThreadMessageCreatedSafely(
 }
 
 /**
+ * Notify an open chat thread that a persisted run was created.
+ *
+ * Best-effort: a failed publish must not fail the committed run creation.
+ */
+export async function publishChatThreadRunCreatedSafely(
+  userId: string,
+  threadId: string,
+): Promise<void> {
+  await tapError(
+    publishUserSignal([userId], `chatThreadRunCreated:${threadId}`),
+    (error) => {
+      L.warn("Failed to publish chat thread run created signal", {
+        threadId,
+        error,
+      });
+    },
+  );
+}
+
+/**
  * Notify a chat thread's UI that its linked automation set changed (created,
  * deleted, enabled, or disabled). The chat-thread header automation menu
  * subscribes to this topic and refetches its thread-scoped list.

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -136,7 +136,7 @@ export async function publishThreadListChangedSafely(
   userId: string,
 ): Promise<void> {
   await tapError(publishThreadListChanged(userId), (error) => {
-    L.warn("Failed to publish thread list changed signal", { error });
+    L.warn("Failed to publish thread list changed signal", { userId, error });
   });
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/test-teams-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-teams-state.test.ts
@@ -472,18 +472,15 @@ describe("POST /api/test/teams-dispatch-probe", () => {
       seedConnection: true,
       seedDefaultAgent: true,
     });
-    let failedPublishCount = 0;
-    context.mocks.ably.publish.mockImplementation(() => {
-      failedPublishCount++;
-      return Promise.reject(new Error("Ably channel rate limit exceeded"));
-    });
+    const publishError = new Error("Ably channel rate limit exceeded");
+    context.mocks.axiomLogging.warn.mockClear();
+    context.mocks.ably.publish.mockRejectedValue(publishError);
 
     await dispatchTeamsMessage({
       fixture,
       text: "dispatch despite realtime failure",
     });
 
-    expect(failedPublishCount).toBeGreaterThan(0);
     expect((await readTeamsState(fixture.tenantId)).recent_runs).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -492,6 +489,20 @@ describe("POST /api/test/teams-dispatch-probe", () => {
           promptPreview: "dispatch despite realtime failure",
         }),
       ]),
+    );
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      "Failed to publish thread list changed signal",
+      expect.objectContaining({
+        userId: fixture.userId,
+        error: publishError,
+      }),
+    );
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      "Failed to publish chat thread run created signal",
+      expect.objectContaining({
+        threadId: expect.any(String),
+        error: publishError,
+      }),
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/test-teams-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-teams-state.test.ts
@@ -467,6 +467,34 @@ describe("POST /api/test/teams-dispatch-probe", () => {
     });
   });
 
+  it("drains a persisted Teams message when realtime publishing fails", async () => {
+    const fixture = await seedTeamsFixture({
+      seedConnection: true,
+      seedDefaultAgent: true,
+    });
+    let failedPublishCount = 0;
+    context.mocks.ably.publish.mockImplementation(() => {
+      failedPublishCount++;
+      return Promise.reject(new Error("Ably channel rate limit exceeded"));
+    });
+
+    await dispatchTeamsMessage({
+      fixture,
+      text: "dispatch despite realtime failure",
+    });
+
+    expect(failedPublishCount).toBeGreaterThan(0);
+    expect((await readTeamsState(fixture.tenantId)).recent_runs).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: "pending",
+          triggerSource: "teams",
+          promptPreview: "dispatch despite realtime failure",
+        }),
+      ]),
+    );
+  });
+
   it("does not enqueue runs for unlinked users or missing default agents", async () => {
     const unlinked = await seedTeamsFixture({
       seedConnection: false,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -54,6 +54,7 @@ import {
 import {
   publishChatThreadDetailChangedSafely,
   publishChatThreadMessageCreatedSafely,
+  publishChatThreadRunCreatedSafely,
   publishThreadListChanged,
   publishThreadListChangedSafely,
   publishUserSignal,
@@ -3257,15 +3258,9 @@ async function publishAutoSentQueuedRunSignals(args: {
     "api_dispatch_pre_create_zero_chat_callback_auto_send_publish_signals",
     "nested",
     async () => {
-      await publishUserSignal(
-        [args.userId],
-        `chatThreadMessageCreated:${args.threadId}`,
-      );
-      await publishUserSignal(
-        [args.userId],
-        `chatThreadRunCreated:${args.threadId}`,
-      );
-      await publishThreadListChanged(args.userId);
+      await publishChatThreadMessageCreatedSafely(args.userId, args.threadId);
+      await publishChatThreadRunCreatedSafely(args.userId, args.threadId);
+      await publishThreadListChangedSafely(args.userId);
     },
   );
 }

--- a/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
@@ -30,7 +30,7 @@ import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
 import {
   publishChatThreadMessageCreatedSafely,
-  publishThreadListChanged,
+  publishThreadListChangedSafely,
 } from "../external/realtime";
 import {
   fetchTeamsChannelMessage,
@@ -1742,7 +1742,7 @@ const runAgentForTeams$ = command(
       persisted.chatThreadId,
     );
     signal.throwIfAborted();
-    await publishThreadListChanged(args.connection.vm0UserId);
+    await publishThreadListChangedSafely(args.connection.vm0UserId);
     signal.throwIfAborted();
     await set(
       drainChatThreadQueueForThread$,


### PR DESCRIPTION
## Summary

- keep Teams dispatch progressing after its inbound message has committed, even when Ably rejects realtime invalidations
- make the remaining post-commit auto-send notifications in the same queue-drain path best-effort while preserving `AbortError` propagation
- include affected user or thread context in warnings and cover sustained realtime failure through the dispatch API route

## Failure evidence

Runner E2E run [30780382337](https://github.com/vm0-ai/vm0/actions/runs/30780382337) failed in [chunk 6](https://github.com/vm0-ai/vm0/actions/runs/30780382337/job/91584250017) while dispatching a Teams DM. Ably rejected a publish with `channel.maxRate` at the 50-publish user-channel limit. The Teams message had already committed, but a synchronously awaited invalidation rejected before the request completed its canonical queue flow.

## Behavior

- Teams message persistence and queue draining remain authoritative when non-abort realtime publication fails.
- The pre-drain thread-list invalidation and the message-created, run-created, and thread-list notifications after durable run creation use topic-specific safe publishers.
- Realtime failures are logged with the original error and an affected user or thread identifier.
- The generic realtime publisher and unrelated call sites keep their existing propagating semantics.

## Out of scope

- retries, a realtime outbox, channel redesign, or raising the Ably limit
- per-shard CI user isolation
- E2E retries, sleeps, or skipped coverage
- changing unrelated realtime topics

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-teams-state.test.ts` (9/9)
- `pnpm exec prettier --check apps/api/src/signals/external/realtime.ts apps/api/src/signals/routes/__tests__/test-teams-state.test.ts apps/api/src/signals/services/internal-chat-run-callback.service.ts apps/api/src/signals/services/zero-teams-dispatch.service.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- lefthook pre-commit: full-repository Knip and TypeScript checks (12/12 type-check tasks)
- lefthook commit-msg

Closes #24617
