### PR TITLE
fix: use redux themes for mermaid diagrams

### DIFF
--- a/turbo/apps/platform/src/mocks/mermaid.ts
+++ b/turbo/apps/platform/src/mocks/mermaid.ts
@@ -34,8 +34,14 @@ function isSupportedDiagram(text: string): boolean {
   });
 }
 
+type MermaidInitializeConfig = { readonly theme?: string };
+
+let activeTheme = "";
+
 const mermaid = {
-  initialize: () => {},
+  initialize: (config: MermaidInitializeConfig) => {
+    activeTheme = config.theme ?? "";
+  },
   parse: (text: string) => {
     if (!isSupportedDiagram(text)) {
       return Promise.resolve(false as const);
@@ -44,7 +50,7 @@ const mermaid = {
   },
   render: (id: string) => {
     return Promise.resolve({
-      svg: `<svg data-testid="mermaid-svg" id="${id}"></svg>`,
+      svg: `<svg data-testid="mermaid-svg" data-mermaid-theme="${activeTheme}" id="${id}"></svg>`,
     });
   },
 };

--- a/turbo/apps/platform/src/signals/mermaid-diagram.ts
+++ b/turbo/apps/platform/src/signals/mermaid-diagram.ts
@@ -88,7 +88,7 @@ const loadMermaid$ = command(
       securityLevel: "strict",
       // Without this mermaid injects its own error diagram into the document.
       suppressErrorRendering: true,
-      theme: theme === "dark" ? "dark" : "default",
+      theme: theme === "dark" ? "redux-dark" : "redux",
       // Resolved to a concrete stack rather than passed as `var(...)`: the same
       // SVG is also shown inside an <img> in the lightbox, where page-level CSS
       // custom properties do not resolve.

--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -168,6 +168,34 @@ describe("assistant markdown", () => {
     expect(screen.getByText("Diagram source")).toBeInTheDocument();
   });
 
+  it("uses redux themes for light and dark diagrams", async () => {
+    mockThread("```mermaid\nflowchart TD\n  A --> B\n```");
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-markdown",
+      featureSwitches: { [FeatureSwitchKey.MermaidDiagrams]: true },
+    });
+
+    const settingsDialog = await openSettingsDialog();
+
+    click(getButtonByText(settingsDialog, "Light"));
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-testid="mermaid-svg"]'),
+      ).toHaveAttribute("data-mermaid-theme", "redux");
+    });
+
+    click(getButtonByText(settingsDialog, "Dark"));
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-testid="mermaid-svg"]'),
+      ).toHaveAttribute("data-mermaid-theme", "redux-dark");
+    });
+  });
+
   it("opens a rendered mermaid diagram in the zoomable lightbox", async () => {
     mockThread("```mermaid\nflowchart TD\n  A --> B\n```");
 


### PR DESCRIPTION
## Summary

- Use Mermaid's built-in `redux` theme for light mode.
- Use the paired `redux-dark` theme for dark mode.
- Add page-level coverage for both theme variants.

## Testing

- `corepack pnpm --filter @vm0/app exec vitest run src/views/components/__tests__/markdown.test.tsx`
- `corepack pnpm --filter @vm0/app check-types`
- `corepack pnpm exec prettier --check apps/platform/src/signals/mermaid-diagram.ts apps/platform/src/mocks/mermaid.ts apps/platform/src/views/components/__tests__/markdown.test.tsx`
