### PR TITLE
test(python): cover mixed built-in and inline firewall compilation

### DIFF
--- a/crates/runner/mitm-addon/tests/test_registry_builtin_core_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_core_cache.py
@@ -3,6 +3,8 @@
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import builtin_firewall_cache
 import matching
 import registry
@@ -77,6 +79,84 @@ class TestRegistryBuiltinCoreCache:
         assert second_result.api_entry is second_vm_info["firewalls"][0]["apis"][0]
         assert first_result.api_entry["id"] == "run-github-a:0"
         assert second_result.api_entry["id"] == "run-github-b:0"
+
+    @pytest.mark.parametrize("builtin_index", [0, 1], ids=["builtin-first", "inline-first"])
+    def test_mixed_builtin_and_inline_firewalls_preserve_order_and_cache_semantics(
+        self, tmp_path, mitm_ctx, builtin_index: int
+    ):
+        inline_index = 1 - builtin_index
+        expected_names = ["github", "example"]
+        if builtin_index == 1:
+            expected_names.reverse()
+
+        def mixed_vm(run_id: str) -> dict:
+            builtin_entry = builtin_vm(run_id, "github")["firewalls"][0]
+            inline_entry = inline_vm(run_id)["firewalls"][0]
+            firewalls = [builtin_entry, inline_entry]
+            if builtin_index == 1:
+                firewalls.reverse()
+            return {"runId": run_id, "firewalls": firewalls}
+
+        path, cache_path = write_registry_with_cache(
+            tmp_path,
+            {
+                "10.200.0.1": mixed_vm("run-mixed-a"),
+                "10.200.0.2": mixed_vm("run-mixed-b"),
+            },
+            {"github": github_cache_firewall()},
+        )
+
+        with mitm_ctx(
+            registry_path=str(path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            first_context = registry.get_vm_context("10.200.0.1", str(path))
+            second_context = registry.get_vm_context("10.200.0.2", str(path))
+
+        assert first_context is not None
+        assert second_context is not None
+        first_vm_info, first_compiled, first_policies = first_context
+        second_vm_info, second_compiled, _second_policies = second_context
+        assert first_compiled is not None
+        assert second_compiled is not None
+
+        assert [firewall["name"] for firewall in first_vm_info["firewalls"]] == expected_names
+        assert [firewall.name for firewall in first_compiled.firewalls] == expected_names
+        assert [firewall.name for firewall in second_compiled.firewalls] == expected_names
+        assert [firewall["apis"][0]["id"] for firewall in first_vm_info["firewalls"]] == [
+            "run-mixed-a:0",
+            "run-mixed-a:1",
+        ]
+        assert [firewall["apis"][0]["id"] for firewall in second_vm_info["firewalls"]] == [
+            "run-mixed-b:0",
+            "run-mixed-b:1",
+        ]
+
+        builtin_result = matching.match_compiled_firewall_request(
+            "https://api.github.com/repos/vm0-ai/vm0",
+            "GET",
+            first_compiled,
+            first_policies,
+        )
+        inline_result = matching.match_compiled_firewall_request(
+            "https://api.example.com/items",
+            "GET",
+            first_compiled,
+            first_policies,
+        )
+
+        assert isinstance(builtin_result, matching.FirewallAllow)
+        assert isinstance(inline_result, matching.FirewallAllow)
+        assert builtin_result.api_entry is first_vm_info["firewalls"][builtin_index]["apis"][0]
+        assert inline_result.api_entry is first_vm_info["firewalls"][inline_index]["apis"][0]
+        assert (
+            first_compiled.firewalls[builtin_index].core
+            is second_compiled.firewalls[builtin_index].core
+        )
+        assert (
+            first_compiled.firewalls[inline_index].core
+            is not second_compiled.firewalls[inline_index].core
+        )
 
     def test_builtin_firewall_refs_share_static_payload_but_keep_vm_api_shells(
         self, tmp_path, mitm_ctx


### PR DESCRIPTION
## Summary

- cover mixed built-in and inline registry firewall compilation in both entry orders
- verify run-scoped API IDs and request matching through the production registry and matcher entry points
- prove built-in compiled cores are shared across VMs while inline cores remain independent

This PR changes tests only. It does not change production behavior, schemas, persisted data, APIs, protocols, or deployment compatibility.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_registry_builtin_core_cache.py` (11 passed)
- `uv run --no-sync python -m pytest tests/` (4,565 passed)
- mutation check: both new order cases fail when mixed inline compilation is omitted

Closes #24622
