### PR TITLE
docs(runner): document firewall catalog boundary

### DIFF
--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -1,4 +1,45 @@
-//! Runner-owned builtin firewall catalog cache refresh.
+//! Runner-owned builtin firewall catalog publication boundary.
+//!
+//! # Lifecycle
+//!
+//! The catalog returned by the API is untrusted. The API client validates its
+//! envelope and firewall payload before an initial or periodic refresh can
+//! reach `write_catalog_cache`. The writer validates the schema-tagged cache
+//! again, bounds its serialized size, and, on Unix runner hosts, publishes it
+//! through a private atomic target-path replacement. The Python addon then
+//! opens that file as a separate trust boundary and independently validates its
+//! ownership, permissions, schema, and firewall payload.
+//!
+//! Cache publication contains unresolved builtin definitions. For each VM, the
+//! Python registry path substitutes base URL variables, validates the resolved
+//! credentialed destination and host policy, assigns run-scoped API IDs, and
+//! compiles matchers before request enforcement.
+//!
+//! # Failure behavior
+//!
+//! A catalog that remains unavailable or invalid after the initial refresh
+//! retries prevents provider startup readiness. A rejected periodic refresh
+//! never replaces the published file, so any previously published valid cache
+//! remains available. If the Python consumer rejects a new file identity, it
+//! exposes no catalog for that identity and marks builtin-dependent VM entries
+//! invalid until a usable cache is loaded.
+//!
+//! # Cross-language compatibility
+//!
+//! Catalog changes must stay compatible with TypeScript artifact validation in
+//! `turbo/apps/api/src/signals/services/connector-catalog-artifacts/firewall.ts`
+//! and `turbo/packages/connectors/src/firewall-types.ts`, the runtime projection
+//! in
+//! `turbo/packages/connectors/src/firewall-metadata/runner-runtime-catalog.ts`,
+//! and the Python cache and resolver boundaries in
+//! `crates/runner/mitm-addon/src/builtin_firewall_cache.py` and
+//! `crates/runner/mitm-addon/src/registry_firewalls.py`. Changes to base URL,
+//! auth, `hostPolicy`, permission, or serialized firewall semantics must be
+//! reconciled across all three owners; cache-schema changes must be reconciled
+//! between Rust and Python. The shared base URL cases live in
+//! `turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json`
+//! and are exercised by TypeScript and Python. Keep individual parser rules in
+//! executable validation and tests rather than duplicating them here.
 
 use std::collections::BTreeMap;
 use std::future::Future;

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -194,8 +194,14 @@ pub enum FirewallEntry {
     Inline { firewall: Firewall },
 }
 
-/// A single firewall config with its name and API entries.
-/// `name` is the canonical identifier (also used as the networkPolicies map key).
+/// A firewall definition shared by inline execution entries and builtin catalogs.
+///
+/// `name` is the canonical identifier and is also used as the `networkPolicies`
+/// map key. For builtin catalogs, changes to base URL, auth, `hostPolicy`,
+/// permission, or serialized-shape semantics must remain compatible with the
+/// TypeScript catalog producer and projection and the Python cache and runtime
+/// validators. Detailed validity rules belong in executable validators and
+/// shared behavioral contracts.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Firewall {
     pub name: String,
@@ -203,6 +209,16 @@ pub struct Firewall {
 }
 
 impl Firewall {
+    /// Validates an unresolved builtin firewall before cache publication.
+    ///
+    /// This gate checks the structural and syntax invariants available before
+    /// per-VM resolution. Catalog API IDs must be empty because the Python
+    /// registry resolver assigns run-scoped IDs after resolving the entries.
+    ///
+    /// The Python consumer still independently validates the cache file,
+    /// schema, and payload, then owns base-variable resolution, final
+    /// credentialed-destination and host-policy checks, matcher compilation,
+    /// and request-time enforcement.
     pub(crate) fn validate_for_cache(&self) -> Result<(), String> {
         if self.name.is_empty() {
             return Err("firewall name must be non-empty".to_string());


### PR DESCRIPTION
## Summary

- document the builtin firewall catalog lifecycle from the untrusted API response through Rust validation and private cache publication to Python revalidation and runtime resolution
- record initial, periodic, and consumer-side failure semantics at the Rust cache owner
- document the shared `Firewall` shape, publication-time validation boundary, empty API-ID invariant, deferred runtime checks, and cross-language maintenance pointers

## Scope

Documentation-only Rust changes. This PR does not change runtime behavior, accepted firewall values, APIs, protocols, cache schema, persisted data, dependencies, migrations, feature switches, or rollout behavior. It does not duplicate individual parser rules or add a standalone architecture document.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo doc -p runner --all-features --no-deps`
- `cd crates && cargo clippy -p runner --all-targets --all-features`
- `cd crates && cargo test -p runner` (2919 passed, 14 ignored; guest inventory passed)
- `git diff --check`
- staged pre-commit checks: workspace Cargo formatting, Clippy, Rustdoc, and file-size validation
- commitlint

Closes #24620
