### PR TITLE
test(guest-agent): avoid real-time execution-timeout waits

### DIFF
--- a/crates/guest-agent/tests/codex_app_server_backend_execution_timeout.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_execution_timeout.rs
@@ -28,13 +28,32 @@ async fn codex_app_server_execution_timeout_interrupts_hung_turn_start()
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
     let masker = SecretMasker::from_raw("");
+    let ready_file = tmp.path().join(common::MOCK_CODEX_TURN_START_READY_FILE);
+    let ready_file = ready_file
+        .to_str()
+        .ok_or_else(|| std::io::Error::other("mock readiness path is not valid UTF-8"))?;
+    let execution_timeout = runtime
+        .config
+        .agent_execution_timeout
+        .expect("test config should set an execution timeout");
+    let checkpoints = [common::VirtualTimeCheckpoint::new(
+        ready_file,
+        common::MOCK_CODEX_TURN_START_READY_EVENT,
+        execution_timeout,
+    )];
 
+    // The mock file proves turn/start reached the parked request handler
+    // before the deadline jump. Keep the outer timeout as a real process and
+    // IPC regression bound.
     let result = tokio::time::timeout(
         Duration::from_secs(10),
-        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+        common::execute_with_virtual_time_checkpoints(
+            common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+            &checkpoints,
+        ),
     )
     .await
-    .expect("execution deadline did not interrupt the app-server request")?;
+    .expect("execution deadline did not interrupt the app-server request")??;
 
     assert_eq!(result.exit_code, AGENT_EXECUTION_TIMEOUT_EXIT_CODE);
     let error = result

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -55,6 +55,8 @@ pub const SIGKILL_EXIT: i32 = 137;
 pub const CLEAN_EXIT: i32 = 0;
 
 pub const MOCK_TERMINATION_READY_EVENT: &str = "vm0_mock_termination_ready";
+pub const MOCK_CODEX_TURN_START_READY_FILE: &str = ".vm0-mock-codex-turn-start-ready";
+pub const MOCK_CODEX_TURN_START_READY_EVENT: &str = "vm0_mock_codex_turn_start_ready";
 pub const MOCK_POST_RESULT_READY_EVENT: &str = "vm0_mock_post_result_ready";
 pub const MOCK_POST_RESULT_ACTIVITY_ONE_EVENT: &str = "vm0_mock_post_result_activity_1_ready";
 pub const MOCK_POST_RESULT_ACTIVITY_TWO_EVENT: &str = "vm0_mock_post_result_activity_2_ready";

--- a/crates/guest-agent/tests/execution_timeout.rs
+++ b/crates/guest-agent/tests/execution_timeout.rs
@@ -17,13 +17,35 @@ async fn execution_timeout_reaps_a_sigterm_deaf_cli() -> Result<(), Box<dyn std:
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let masker = SecretMasker::from_raw("");
+    let execution_timeout = runtime
+        .config
+        .agent_execution_timeout
+        .expect("test config should set an execution timeout");
+    let checkpoints = [
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.agent_log_file(),
+            common::MOCK_TERMINATION_READY_EVENT,
+            execution_timeout,
+        ),
+        common::VirtualTimeCheckpoint::new(
+            runtime.paths.system_log_file(),
+            "Agent execution timed out after",
+            runtime.config.post_result_sigkill_grace,
+        ),
+    ];
 
+    // The mock fence proves SIGTERM immunity before the execution-deadline
+    // jump. The transition log proves SIGTERM armed the SIGKILL deadline.
+    // Keep the outer timeout as a real subprocess/reaping regression bound.
     let result = tokio::time::timeout(
         Duration::from_secs(10),
-        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+        common::execute_with_virtual_time_checkpoints(
+            common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+            &checkpoints,
+        ),
     )
     .await
-    .expect("execution deadline did not reap the CLI process group")?;
+    .expect("execution deadline did not reap the CLI process group")??;
 
     let error = result
         .control_error

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -12,9 +12,12 @@ use super::scenario::Scenario;
 use super::{AppServerState, INVALID_REQUEST, PendingResponse, ServerAction, spawn_stderr_holder};
 use serde_json::{Value, json};
 use std::io::{self, Write};
+use std::path::PathBuf;
 use std::thread;
 use uuid::Uuid;
 
+const HANG_ON_TURN_START_READY_FILE: &str = ".vm0-mock-codex-turn-start-ready";
+const HANG_ON_TURN_START_READY_EVENT: &str = "vm0_mock_codex_turn_start_ready";
 const NOTIFICATION_OVERFLOW_COUNT: usize = 129;
 const OVERSIZED_STDOUT_BYTES: usize = 65 * 1024 * 1024;
 const EVENT_DELIVERY_FLOOD_COUNT: usize = 640;
@@ -222,6 +225,12 @@ impl AppServerState {
             return Ok(ServerAction::Stop);
         }
         if self.scenario == Scenario::HangOnTurnStart {
+            let home = std::env::var_os("HOME")
+                .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME is not set"))?;
+            std::fs::write(
+                PathBuf::from(home).join(HANG_ON_TURN_START_READY_FILE),
+                HANG_ON_TURN_START_READY_EVENT,
+            )?;
             loop {
                 thread::park();
             }


### PR DESCRIPTION
## Summary

- drive the ordinary CLI execution deadline and SIGKILL grace through the existing child-readiness and transition-log checkpoints
- expose a mock Codex `turn/start` readiness fence and drive the app-server execution deadline with the shared virtual-time harness
- preserve the real subprocess, signal, explicit termination, reaping, exit-code, error, and diagnostic assertions while reducing the warm combined test duration from 3.02s to about 0.02s

## Scope and compatibility

- test and mock-fixture code only
- no production timeout, runtime, API, protocol, schema, persistence, migration, or deployment behavior changes
- `execution_timeout_recovery.rs` remains unchanged because its separately spawned guest-agent owns an independent clock

## Validation

- 20 sequential repeated runs of `cargo test -p guest-agent --test execution_timeout`
- 20 sequential repeated runs of `cargo test -p guest-agent --test codex_app_server_backend_execution_timeout`
- `cargo test -p guest-agent --test codex_app_server_backend_heartbeat --test codex_app_server_backend_user_cancellation -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent -p guest-mock-codex --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-agent -p guest-mock-codex --no-deps --all-features`
- `cargo test -p guest-agent -p guest-mock-codex --all-targets --all-features`
- repository pre-commit and commit-message hooks

Closes #24618
