### PR TITLE
fix: allow overriding every feature switch

### DIFF
--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -5,10 +5,7 @@ import {
   ZeroCapability,
 } from "@vm0/api-contracts/contracts/composes";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-import {
-  isFeatureEnabled,
-  isUserOverridableFeatureSwitch,
-} from "@vm0/core/feature-switch";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { z } from "zod";
 
 import { env } from "../../lib/env";
@@ -141,12 +138,7 @@ function isZeroCapabilityEnabled(
     return true;
   }
 
-  return isFeatureEnabled(
-    featureSwitch,
-    isUserOverridableFeatureSwitch(featureSwitch)
-      ? { userId, orgId, overrides }
-      : { userId, orgId },
-  );
+  return isFeatureEnabled(featureSwitch, { userId, orgId, overrides });
 }
 
 function isCapabilityAvailableToAgent(

--- a/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
@@ -152,10 +152,10 @@ describe("OPS-01: feature switches and report-error routes", () => {
     expect(enabled.body.switches[FeatureSwitchKey.Dummy]).toBeFalsy();
     expect(
       enabled.body.switches[FeatureSwitchKey.ComposerUploadPopover],
-    ).toBeUndefined();
+    ).toBeTruthy();
     expect(
       enabled.body.effectiveSwitches[FeatureSwitchKey.ComposerUploadPopover],
-    ).toBeFalsy();
+    ).toBeTruthy();
 
     const merged = await accept(
       featureSwitchesClient().update({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { describe, expect, it } from "vitest";
@@ -14,9 +16,11 @@ function client() {
 }
 
 describe("/api/zero/feature-switches", () => {
-  it("exposes mail reply follow-up only to staff", async () => {
+  it("defaults mail reply follow-up to staff and accepts user overrides", async () => {
     const mocks = createZeroRouteMocks(context);
     const headers = { authorization: "Bearer clerk-session" };
+    const nonStaffUserId = `user_${randomUUID()}`;
+    const nonStaffOrgId = `org_${randomUUID()}`;
     mockOptionalEnv("ZERO_MAIL_REPLY_FOLLOW_UP_ROLLOUT_ENABLED", "true");
 
     mocks.clerk.session("user_staff_feature_switch_test", STAFF_ORG_ID);
@@ -25,14 +29,29 @@ describe("/api/zero/feature-switches", () => {
       staff.body.effectiveSwitches[FeatureSwitchKey.ZeroMailReplyFollowUp],
     ).toBeTruthy();
 
-    mocks.clerk.session(
-      "user_nonstaff_feature_switch_test",
-      "org_nonstaff_feature_switch_test",
-    );
+    mocks.clerk.session(nonStaffUserId, nonStaffOrgId);
     const nonStaff = await accept(client().get({ headers }), [200]);
     expect(
       nonStaff.body.effectiveSwitches[FeatureSwitchKey.ZeroMailReplyFollowUp],
     ).toBeFalsy();
+
+    const overridden = await accept(
+      client().update({
+        headers,
+        body: {
+          switches: {
+            [FeatureSwitchKey.ZeroMailReplyFollowUp]: true,
+          },
+        },
+      }),
+      [200],
+    );
+    expect(
+      overridden.body.switches[FeatureSwitchKey.ZeroMailReplyFollowUp],
+    ).toBeTruthy();
+    expect(
+      overridden.body.effectiveSwitches[FeatureSwitchKey.ZeroMailReplyFollowUp],
+    ).toBeTruthy();
   });
 
   it("persists and activates inline templates for a non-staff org", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
@@ -883,9 +883,9 @@ describe("POST /api/zero/mail/drafts/link", () => {
       featureSwitchesClient().get({ headers: authHeaders() }),
       [200],
     );
-    expect(featureSwitches.body.switches).not.toHaveProperty(
-      FeatureSwitchKey.ZeroMailReplyFollowUp,
-    );
+    expect(
+      featureSwitches.body.switches[FeatureSwitchKey.ZeroMailReplyFollowUp],
+    ).toBeTruthy();
     expect(
       featureSwitches.body.effectiveSwitches[
         FeatureSwitchKey.ZeroMailReplyFollowUp

--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -1,6 +1,6 @@
 import { command, computed, type Computed } from "ccstate";
 import {
-  filterUserOverridableFeatureSwitchOverrides,
+  filterFeatureSwitchOverrides,
   type FeatureSwitchContext,
 } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -26,12 +26,11 @@ function splitFeatureSwitchesByScope(switches: Record<string, boolean>): {
   readonly userSwitches: Record<string, boolean>;
   readonly orgSwitches: Record<string, boolean>;
 } {
-  const userOverridableSwitches =
-    filterUserOverridableFeatureSwitchOverrides(switches);
+  const registeredSwitches = filterFeatureSwitchOverrides(switches);
   const userSwitches: Record<string, boolean> = {};
   const orgSwitches: Record<string, boolean> = {};
 
-  for (const [key, value] of Object.entries(userOverridableSwitches)) {
+  for (const [key, value] of Object.entries(registeredSwitches)) {
     if (isOrgScopedFeatureSwitchKey(key)) {
       orgSwitches[key] = value;
     } else {
@@ -80,7 +79,7 @@ export function userFeatureSwitchOverridesFromRows(
   let orgSwitches: Record<string, boolean> = {};
 
   for (const row of rows) {
-    const switches = filterUserOverridableFeatureSwitchOverrides(row.switches);
+    const switches = filterFeatureSwitchOverrides(row.switches);
     if (row.userId === userId) {
       userSwitches = switches;
     }
@@ -213,8 +212,8 @@ async function upsertFeatureSwitches(
   const existing =
     (existingRow?.switches as Record<string, boolean> | undefined) ?? {};
   const merged: Record<string, boolean> = {
-    ...filterUserOverridableFeatureSwitchOverrides(existing),
-    ...filterUserOverridableFeatureSwitchOverrides(switches),
+    ...filterFeatureSwitchOverrides(existing),
+    ...filterFeatureSwitchOverrides(switches),
   };
   const now = nowDate();
 

--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -84,8 +84,8 @@ describe("lab page", () => {
       expect(screen.getByText("Other")).toBeInTheDocument();
       expect(screen.getAllByText("Connectors").length).toBeGreaterThan(0);
       expect(
-        screen.queryByText(FeatureSwitchKey.ComposerUploadPopover),
-      ).not.toBeInTheDocument();
+        screen.getByText(FeatureSwitchKey.ComposerUploadPopover),
+      ).toBeInTheDocument();
       expect(
         screen.getAllByText("Maintainer: liangyou@vm0.ai").length,
       ).toBeGreaterThan(0);

--- a/turbo/apps/platform/src/views/lab-page/lab-page.tsx
+++ b/turbo/apps/platform/src/views/lab-page/lab-page.tsx
@@ -2,7 +2,6 @@ import { useGet, useLastResolved, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
   getFeatureSwitchMetadata,
-  getUserOverridableFeatureSwitchKeys,
   type FeatureSwitchMetadata,
 } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -39,7 +38,7 @@ function compareByName(a: FeatureSwitchKey, b: FeatureSwitchKey): number {
 }
 
 function sortedFeatureSwitchKeys(): FeatureSwitchKey[] {
-  return [...getUserOverridableFeatureSwitchKeys()].sort(compareByName);
+  return Object.values(FeatureSwitchKey).sort(compareByName);
 }
 
 function maintainerLabel(email: string): string {
@@ -282,7 +281,7 @@ export function LabPage() {
   const pageSignal = useGet(pageSignal$);
   const metadata = getFeatureSwitchMetadata();
   const sorted = sortedFeatureSwitchKeys();
-  const allKeys = getUserOverridableFeatureSwitchKeys();
+  const allKeys = Object.values(FeatureSwitchKey);
   const maintainerOptions = maintainerFilterOptions({
     keys: allKeys,
     metadata,

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -3,10 +3,9 @@ import { FeatureSwitchKey } from "../feature-switch-key";
 import {
   isFeatureEnabled,
   getAllFeatureStates,
-  filterUserOverridableFeatureSwitchOverrides,
+  filterFeatureSwitchOverrides,
   getFeatureSwitchDescriptions,
   getFeatureSwitchMetadata,
-  getUserOverridableFeatureSwitchKeys,
 } from "../feature-switch";
 
 describe("isFeatureEnabled", () => {
@@ -225,58 +224,20 @@ describe("getAllFeatureStates", () => {
   });
 });
 
-describe("user-overridable switches", () => {
-  it("excludes internal switches from user override helpers", () => {
-    expect(getUserOverridableFeatureSwitchKeys()).not.toContain(
-      FeatureSwitchKey.ComposerUploadPopover,
-    );
-    expect(getUserOverridableFeatureSwitchKeys()).not.toContain(
-      FeatureSwitchKey.WorkflowConnectorReadiness,
-    );
-    expect(getUserOverridableFeatureSwitchKeys()).not.toContain(
-      FeatureSwitchKey.PwaChatKeyboardGestures,
-    );
-    expect(getUserOverridableFeatureSwitchKeys()).not.toContain(
-      FeatureSwitchKey.ZeroMailReplyFollowUp,
-    );
-    expect(getUserOverridableFeatureSwitchKeys()).toContain(
-      FeatureSwitchKey.ZeroBrowser,
-    );
-    expect(getUserOverridableFeatureSwitchKeys()).not.toContain(
-      FeatureSwitchKey.GithubWebhookAutomations,
-    );
-    expect(getUserOverridableFeatureSwitchKeys()).not.toContain(
-      FeatureSwitchKey.StrapiIntegration,
-    );
-    expect(getUserOverridableFeatureSwitchKeys()).toContain(
-      FeatureSwitchKey.StructuredPromptInlineTemplates,
-    );
-    expect(getUserOverridableFeatureSwitchKeys()).toContain(
-      FeatureSwitchKey.ComposerConnectorPermissions,
+describe("feature switch override filtering", () => {
+  it("keeps overrides for every registered switch", () => {
+    const switches = Object.fromEntries(
+      Object.values(FeatureSwitchKey).map((key) => {
+        return [key, true];
+      }),
     );
 
-    expect(
-      filterUserOverridableFeatureSwitchOverrides({
-        [FeatureSwitchKey.ComposerUploadPopover]: true,
-        [FeatureSwitchKey.WorkflowConnectorReadiness]: true,
-        [FeatureSwitchKey.PwaChatKeyboardGestures]: true,
-        [FeatureSwitchKey.StructuredPromptInlineTemplates]: true,
-        [FeatureSwitchKey.ZeroMailReplyFollowUp]: true,
-        [FeatureSwitchKey.ZeroBrowser]: true,
-        [FeatureSwitchKey.ComposerConnectorPermissions]: true,
-        [FeatureSwitchKey.Dummy]: false,
-      }),
-    ).toStrictEqual({
-      [FeatureSwitchKey.ZeroBrowser]: true,
-      [FeatureSwitchKey.ComposerConnectorPermissions]: true,
-      [FeatureSwitchKey.Dummy]: false,
-      [FeatureSwitchKey.StructuredPromptInlineTemplates]: true,
-    });
+    expect(filterFeatureSwitchOverrides(switches)).toStrictEqual(switches);
   });
 
   it("ignores persisted overrides for removed switches", () => {
     expect(
-      filterUserOverridableFeatureSwitchOverrides({
+      filterFeatureSwitchOverrides({
         zeroPeopleSearch: false,
       }),
     ).toStrictEqual({});

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -4,9 +4,8 @@
  * Provides centralized feature flag management with user-identity based overrides.
  * User IDs are stored as FNV-1a hashes to avoid exposing plain-text identifiers in source code.
  *
- * NOT AN AUTHORIZATION BOUNDARY. User-overridable switches can be self-enabled
- * through `POST /api/zero/feature-switches`, and `userOverridable: false` only
- * excludes a switch from that API. For money-granting, credential, or
+ * NOT AN AUTHORIZATION BOUNDARY. Every registered switch accepts user overrides
+ * through `POST /api/zero/feature-switches`. For money-granting, credential, or
  * privilege-escalation endpoints, gate with a hard identity check (e.g.
  * `isStaffOrg()` from `./staff-org`) instead of this system.
  */
@@ -21,13 +20,11 @@ export interface FeatureSwitch {
   readonly enabledUserHashes?: readonly string[];
   readonly enabledEmailHashes?: readonly string[];
   readonly enabledOrgIdHashes?: readonly string[];
-  readonly userOverridable?: boolean;
 }
 
 export interface FeatureSwitchMetadata {
   readonly maintainer: string;
   readonly description?: string;
-  readonly userOverridable: boolean;
 }
 
 export interface FeatureSwitchContext {
@@ -252,7 +249,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable the daily 7:00 local-time Morning Brief email built from GitHub, Gmail, and Google Calendar.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-    userOverridable: true,
   },
   [FeatureSwitchKey.ManualMorningBrief]: {
     maintainer: "ethan@vm0.ai",
@@ -260,7 +256,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Show a Send now button in Settings that triggers a Morning Brief immediately for testing.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-    userOverridable: true,
   },
   [FeatureSwitchKey.NotionWorkflowAutomations]: {
     maintainer: "lancy@vm0.ai",
@@ -275,7 +270,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Show creation entry points for GitHub workflow job, pull request review, deployment status, and issue comment automations.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-    userOverridable: false,
   },
   [FeatureSwitchKey.TestOauthConnector]: {
     maintainer: "liangyou@vm0.ai",
@@ -330,7 +324,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Use the Upload popover in the chat composer instead of the legacy paperclip attachment button.",
     enabled: false,
-    userOverridable: false,
   },
   [FeatureSwitchKey.StructuredPromptInlineTemplates]: {
     maintainer: "bingjie@vm0.ai",
@@ -338,7 +331,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable multiple inline artifact templates in structured chat prompts.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-    userOverridable: true,
   },
   [FeatureSwitchKey.CustomModelGateways]: {
     maintainer: "ethan@vm0.ai",
@@ -346,7 +338,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable admin-defined Anthropic Messages and OpenAI Responses model gateway connections.",
     enabled: false,
     enabledOrgIdHashes: CUSTOM_MODEL_GATEWAY_ORG_ID_HASHES,
-    userOverridable: false,
   },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@vm0.ai",
@@ -381,7 +372,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Keep the PWA chat composer pinned above the software keyboard and support swipe-to-dismiss gestures.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-    userOverridable: false,
   },
   [FeatureSwitchKey.ChatThreadSidebarAutoOpen]: {
     maintainer: "ethan@vm0.ai",
@@ -403,7 +393,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Open an artifact clicked in a chat thread inside the already-open artifact sidebar instead of stacking the page-global lightbox over it.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-    userOverridable: true,
   },
   [FeatureSwitchKey.ComposerSkillSubstringSearch]: {
     maintainer: "yuma@vm0.ai",
@@ -452,7 +441,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable Strapi integration settings and Strapi entry-published workflow automations.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-    userOverridable: false,
   },
   [FeatureSwitchKey.ArtifactKeyV2]: {
     maintainer: "yuma@vm0.ai",
@@ -486,7 +474,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Show the manual connector readiness check on workflow settings pages.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-    userOverridable: false,
   },
   [FeatureSwitchKey.ZeroMailReplyFollowUp]: {
     maintainer: "yuma@vm0.ai",
@@ -494,7 +481,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable Zero Mail reply follow-up for staff after all API deployments can read Gmail event configurations with threadId.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-    userOverridable: false,
   },
   [FeatureSwitchKey.ZeroBrowser]: {
     maintainer: "liangyou@vm0.ai",
@@ -522,7 +508,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Show the configure-permissions entry in the chat composer connector popover, opening the agent×connector firewall dialog inline.",
     enabled: false,
-    userOverridable: true,
   },
   [FeatureSwitchKey.CustomConnectorCliCreate]: {
     maintainer: "liangyou@vm0.ai",
@@ -633,31 +618,18 @@ export function getFeatureSwitchMetadata(): Record<
     result[key] = {
       maintainer: featureSwitch.maintainer,
       description: featureSwitch.description,
-      userOverridable: featureSwitch.userOverridable !== false,
     };
   }
   return result;
 }
 
-export function isUserOverridableFeatureSwitch(
-  key: string,
-): key is FeatureSwitchKey {
-  if (!(key in FEATURE_SWITCHES)) {
-    return false;
-  }
-  return FEATURE_SWITCHES[key as FeatureSwitchKey].userOverridable !== false;
-}
-
-export function getUserOverridableFeatureSwitchKeys(): readonly FeatureSwitchKey[] {
-  return Object.values(FeatureSwitchKey).filter(isUserOverridableFeatureSwitch);
-}
-
-export function filterUserOverridableFeatureSwitchOverrides(
+/** Keep overrides for currently registered feature switches. */
+export function filterFeatureSwitchOverrides(
   switches: Record<string, boolean>,
 ): Record<string, boolean> {
   const filtered: Record<string, boolean> = {};
   for (const [key, value] of Object.entries(switches)) {
-    if (isUserOverridableFeatureSwitch(key)) {
+    if (key in FEATURE_SWITCHES) {
       filtered[key] = value;
     }
   }

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -730,13 +730,11 @@ export {
 } from "./frameworks";
 export { FeatureSwitchKey } from "./feature-switch-key";
 export {
+  filterFeatureSwitchOverrides,
   getAllFeatureStates,
-  filterUserOverridableFeatureSwitchOverrides,
   getFeatureSwitchDescriptions,
   getFeatureSwitchMetadata,
-  getUserOverridableFeatureSwitchKeys,
   isFeatureEnabled,
-  isUserOverridableFeatureSwitch,
   type FeatureSwitch,
   type FeatureSwitchContext,
   type FeatureSwitchMetadata,


### PR DESCRIPTION
## Summary

- remove the `userOverridable` feature-switch field, metadata, and helper API
- persist and apply overrides for every registered feature switch while still filtering removed keys
- show every feature switch in Lab and always honor overrides when issuing conditional capabilities
- preserve the Mail Reply Follow-up staff default and verify non-staff users can explicitly override it

The frontend/backend request and response shapes are unchanged.

## Testing

- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm knip --workspace @vm0/core`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/hooks-ops.bdd.test.ts src/signals/auth/__tests__/tokens.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feature-switches.test.ts`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/lab-page/__tests__/lab-page.test.tsx`