### PR TITLE
fix(platform): allow feature-gated visual attachments

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -40,6 +40,7 @@ describe("/api/zero/feature-switches", () => {
         FeatureSwitchKey.StructuredPromptInlineTemplates
       ],
     ).toBeTruthy();
+    expect(updated.body.supportsImageRecognition).toBeTruthy();
 
     const current = await accept(client().get({ headers }), [200]);
     expect(current.body.switches).toStrictEqual({
@@ -47,6 +48,7 @@ describe("/api/zero/feature-switches", () => {
     });
     expect(current.body.supportsCustomConnectorOAuth2).toBeTruthy();
     expect(current.body.supportsCustomModelGateways).toBeTruthy();
+    expect(current.body.supportsImageRecognition).toBeTruthy();
     expect(
       current.body.effectiveSwitches[
         FeatureSwitchKey.StructuredPromptInlineTemplates

--- a/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
@@ -28,6 +28,7 @@ function featureSwitchResponseBody(params: {
   readonly supportsStructuredInlineTemplates: boolean;
   readonly supportsCustomConnectorOAuth2: boolean;
   readonly supportsCustomModelGateways: boolean;
+  readonly supportsImageRecognition: boolean;
 }) {
   const effectiveSwitches = getAllFeatureStates({
     orgId: params.orgId,
@@ -43,6 +44,7 @@ function featureSwitchResponseBody(params: {
     supportsStructuredInlineTemplates: params.supportsStructuredInlineTemplates,
     supportsCustomConnectorOAuth2: params.supportsCustomConnectorOAuth2,
     supportsCustomModelGateways: params.supportsCustomModelGateways,
+    supportsImageRecognition: params.supportsImageRecognition,
   };
 }
 
@@ -63,6 +65,7 @@ const getFeatureSwitchesInner$ = computed(async (get): Promise<unknown> => {
       supportsStructuredInlineTemplates: true,
       supportsCustomConnectorOAuth2: true,
       supportsCustomModelGateways,
+      supportsImageRecognition: true,
     }),
   };
 });
@@ -102,6 +105,7 @@ const updateFeatureSwitchesInner$ = command(
         supportsStructuredInlineTemplates: true,
         supportsCustomConnectorOAuth2: true,
         supportsCustomModelGateways,
+        supportsImageRecognition: true,
       }),
     };
   },

--- a/turbo/apps/platform/src/mocks/handlers/api-feature-switches.helpers.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-feature-switches.helpers.ts
@@ -27,6 +27,7 @@ export function setMockFeatureSwitches(
         supportsStructuredInlineTemplates: true,
         supportsCustomConnectorOAuth2: true,
         supportsCustomModelGateways: true,
+        supportsImageRecognition: true,
       });
     }),
   );

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts
@@ -73,6 +73,55 @@ describe("bootstrap feature switch hydration", () => {
     ).toBeFalsy();
   });
 
+  it("keeps image recognition disabled when the API lacks support", async () => {
+    context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
+      return respond(200, {
+        switches: { [FeatureSwitchKey.ZeroImageRecognition]: true },
+        effectiveSwitches: {
+          [FeatureSwitchKey.ZeroImageRecognition]: true,
+        },
+        supportsStructuredInlineTemplates: true,
+        supportsCustomConnectorOAuth2: true,
+        supportsCustomModelGateways: true,
+      });
+    });
+
+    await setupPage({
+      context,
+      path: "/error",
+      withoutRender: true,
+    });
+
+    expect(
+      context.store.get(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition],
+    ).toBeFalsy();
+  });
+
+  it("hydrates image recognition when the API confirms support", async () => {
+    context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
+      return respond(200, {
+        switches: { [FeatureSwitchKey.ZeroImageRecognition]: true },
+        effectiveSwitches: {
+          [FeatureSwitchKey.ZeroImageRecognition]: true,
+        },
+        supportsStructuredInlineTemplates: true,
+        supportsCustomConnectorOAuth2: true,
+        supportsCustomModelGateways: true,
+        supportsImageRecognition: true,
+      });
+    });
+
+    await setupPage({
+      context,
+      path: "/error",
+      withoutRender: true,
+    });
+
+    expect(
+      context.store.get(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition],
+    ).toBeTruthy();
+  });
+
   it("skips feature switch hydration without an authenticated organization", async () => {
     context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
       return respond(500, {

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts
@@ -1,9 +1,13 @@
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { setupPage } from "../../__tests__/page-helper.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
+import { detachedSetupPage, setupPage } from "../../__tests__/page-helper.ts";
+import {
+  featureSwitch$,
+  zeroImageRecognitionEnabled$,
+} from "../external/feature-switch.ts";
 import { testContext } from "./test-helpers.ts";
 
 const context = testContext();
@@ -92,12 +96,10 @@ describe("bootstrap feature switch hydration", () => {
       withoutRender: true,
     });
 
-    expect(
-      context.store.get(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition],
-    ).toBeFalsy();
+    expect(context.store.get(zeroImageRecognitionEnabled$)).toBeFalsy();
   });
 
-  it("hydrates image recognition when the API confirms support", async () => {
+  it("waits for current API support before trusting cached image recognition", async () => {
     context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
       return respond(200, {
         switches: { [FeatureSwitchKey.ZeroImageRecognition]: true },
@@ -111,15 +113,19 @@ describe("bootstrap feature switch hydration", () => {
       });
     });
 
-    await setupPage({
+    detachedSetupPage({
       context,
       path: "/error",
+      featureSwitches: {
+        [FeatureSwitchKey.ZeroImageRecognition]: true,
+      },
       withoutRender: true,
     });
 
-    expect(
-      context.store.get(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition],
-    ).toBeTruthy();
+    expect(context.store.get(zeroImageRecognitionEnabled$)).toBeFalsy();
+    await waitFor(() => {
+      expect(context.store.get(zeroImageRecognitionEnabled$)).toBeTruthy();
+    });
   });
 
   it("skips feature switch hydration without an authenticated organization", async () => {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -32,7 +32,6 @@ import { buildDraftPersistencePayload } from "../zero-page/draft-persistence.ts"
 import {
   collectSuccessfulAttachmentInfos,
   prepareUserMessageFromDraft$,
-  shouldExcludeVisualAttachmentsForModel,
 } from "./resolve-draft-attachments.ts";
 import {
   appendOptimisticChatEvent$,
@@ -3183,10 +3182,10 @@ function createPerformSendMessage(deps: SendMessageDeps) {
               draft,
               request.prompt,
               {
-                excludeVisualAttachments:
-                  shouldExcludeVisualAttachmentsForModel(
-                    request.modelSelection?.selectedModel,
-                  ),
+                selectedModel: request.modelSelection?.selectedModel,
+                imageRecognitionEnabled:
+                  get(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition] ??
+                  false,
               },
               signal,
             );
@@ -3338,14 +3337,15 @@ function createQueueMessage(deps: QueueMessageDeps) {
       const generationTemplate = options.generationTemplate;
       const modelSelection = await set(modelSelectionForSend$, signal);
       signal.throwIfAborted();
+      const features = get(featureSwitch$);
       const result = await set(
         prepareUserMessageFromDraft$,
         draft,
         prompt,
         {
-          excludeVisualAttachments: shouldExcludeVisualAttachmentsForModel(
-            modelSelection?.selectedModel,
-          ),
+          selectedModel: modelSelection?.selectedModel,
+          imageRecognitionEnabled:
+            features[FeatureSwitchKey.ZeroImageRecognition] ?? false,
         },
         signal,
       );
@@ -3353,8 +3353,6 @@ function createQueueMessage(deps: QueueMessageDeps) {
         return false;
       }
       signal.throwIfAborted();
-
-      const features = get(featureSwitch$);
       const userMessage = queueUserMessage(options, result);
 
       set(cancelDraftSync$);

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -72,6 +72,7 @@ import {
   codexFastModeEnabled$,
   featureSwitch$,
   zeroBrowserEnabled$,
+  zeroImageRecognitionEnabled$,
 } from "../external/feature-switch.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { pinnedAgentIds$ } from "../zero-page/zero-pinned-agents.ts";
@@ -3183,9 +3184,7 @@ function createPerformSendMessage(deps: SendMessageDeps) {
               request.prompt,
               {
                 selectedModel: request.modelSelection?.selectedModel,
-                imageRecognitionEnabled:
-                  get(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition] ??
-                  false,
+                imageRecognitionEnabled: get(zeroImageRecognitionEnabled$),
               },
               signal,
             );
@@ -3344,8 +3343,7 @@ function createQueueMessage(deps: QueueMessageDeps) {
         prompt,
         {
           selectedModel: modelSelection?.selectedModel,
-          imageRecognitionEnabled:
-            features[FeatureSwitchKey.ZeroImageRecognition] ?? false,
+          imageRecognitionEnabled: get(zeroImageRecognitionEnabled$),
         },
         signal,
       );

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -32,6 +32,7 @@ import { buildDraftPersistencePayload } from "../zero-page/draft-persistence.ts"
 import {
   collectSuccessfulAttachmentInfos,
   prepareUserMessageFromDraft$,
+  shouldExcludeVisualAttachmentsForModel,
 } from "./resolve-draft-attachments.ts";
 import {
   appendOptimisticChatEvent$,
@@ -3183,8 +3184,11 @@ function createPerformSendMessage(deps: SendMessageDeps) {
               draft,
               request.prompt,
               {
-                selectedModel: request.modelSelection?.selectedModel,
-                imageRecognitionEnabled: get(zeroImageRecognitionEnabled$),
+                excludeVisualAttachments:
+                  shouldExcludeVisualAttachmentsForModel(
+                    request.modelSelection?.selectedModel,
+                    get(zeroImageRecognitionEnabled$),
+                  ),
               },
               signal,
             );
@@ -3342,8 +3346,10 @@ function createQueueMessage(deps: QueueMessageDeps) {
         draft,
         prompt,
         {
-          selectedModel: modelSelection?.selectedModel,
-          imageRecognitionEnabled: get(zeroImageRecognitionEnabled$),
+          excludeVisualAttachments: shouldExcludeVisualAttachmentsForModel(
+            modelSelection?.selectedModel,
+            get(zeroImageRecognitionEnabled$),
+          ),
         },
         signal,
       );

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -3340,7 +3340,6 @@ function createQueueMessage(deps: QueueMessageDeps) {
       const generationTemplate = options.generationTemplate;
       const modelSelection = await set(modelSelectionForSend$, signal);
       signal.throwIfAborted();
-      const features = get(featureSwitch$);
       const result = await set(
         prepareUserMessageFromDraft$,
         draft,
@@ -3357,6 +3356,7 @@ function createQueueMessage(deps: QueueMessageDeps) {
         return false;
       }
       signal.throwIfAborted();
+      const features = get(featureSwitch$);
       const userMessage = queueUserMessage(options, result);
 
       set(cancelDraftSync$);

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -33,7 +33,10 @@ import {
 } from "../zero-page/model-default-selection.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { userModelPreference$ } from "../external/user-model-preference.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
+import {
+  featureSwitch$,
+  zeroImageRecognitionEnabled$,
+} from "../external/feature-switch.ts";
 import { codexFastModeLocalDefault$ } from "../zero-page/codex-fast-local-default.ts";
 import { logger } from "../log.ts";
 import { runOptionsFromModelProviderSelection } from "./model-selection-request.ts";
@@ -494,21 +497,20 @@ const sendNewThreadMessage$ = command(
     if (!resolvedModelSelection) {
       return null;
     }
-    const features = get(featureSwitch$);
     const prepared = await set(
       prepareUserMessageFromDraft$,
       draft,
       prompt,
       {
         selectedModel: resolvedModelSelection.selectedModel,
-        imageRecognitionEnabled:
-          features[FeatureSwitchKey.ZeroImageRecognition] ?? false,
+        imageRecognitionEnabled: get(zeroImageRecognitionEnabled$),
       },
       signal,
     );
     if (!prepared) {
       return null;
     }
+    const features = get(featureSwitch$);
     const userMessage = userMessageForNewThread(request, prepared);
     const threadId = crypto.randomUUID();
     const clientEventId = crypto.randomUUID();

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -19,10 +19,7 @@ import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import { loadRightThread$ } from "./chat-thread-panes.ts";
 import { talkDraft$ } from "../zero-page/chat-draft.ts";
 import { clearAgentDraftById$ } from "../zero-page/agent-draft.ts";
-import {
-  prepareUserMessageFromDraft$,
-  shouldExcludeVisualAttachmentsForModel,
-} from "./resolve-draft-attachments.ts";
+import { prepareUserMessageFromDraft$ } from "./resolve-draft-attachments.ts";
 import {
   appendOptimisticChatEvent$,
   createOptimisticChatEventEntry,
@@ -497,21 +494,21 @@ const sendNewThreadMessage$ = command(
     if (!resolvedModelSelection) {
       return null;
     }
+    const features = get(featureSwitch$);
     const prepared = await set(
       prepareUserMessageFromDraft$,
       draft,
       prompt,
       {
-        excludeVisualAttachments: shouldExcludeVisualAttachmentsForModel(
-          resolvedModelSelection.selectedModel,
-        ),
+        selectedModel: resolvedModelSelection.selectedModel,
+        imageRecognitionEnabled:
+          features[FeatureSwitchKey.ZeroImageRecognition] ?? false,
       },
       signal,
     );
     if (!prepared) {
       return null;
     }
-    const features = get(featureSwitch$);
     const userMessage = userMessageForNewThread(request, prepared);
     const threadId = crypto.randomUUID();
     const clientEventId = crypto.randomUUID();

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -19,7 +19,10 @@ import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import { loadRightThread$ } from "./chat-thread-panes.ts";
 import { talkDraft$ } from "../zero-page/chat-draft.ts";
 import { clearAgentDraftById$ } from "../zero-page/agent-draft.ts";
-import { prepareUserMessageFromDraft$ } from "./resolve-draft-attachments.ts";
+import {
+  prepareUserMessageFromDraft$,
+  shouldExcludeVisualAttachmentsForModel,
+} from "./resolve-draft-attachments.ts";
 import {
   appendOptimisticChatEvent$,
   createOptimisticChatEventEntry,
@@ -502,8 +505,10 @@ const sendNewThreadMessage$ = command(
       draft,
       prompt,
       {
-        selectedModel: resolvedModelSelection.selectedModel,
-        imageRecognitionEnabled: get(zeroImageRecognitionEnabled$),
+        excludeVisualAttachments: shouldExcludeVisualAttachmentsForModel(
+          resolvedModelSelection.selectedModel,
+          get(zeroImageRecognitionEnabled$),
+        ),
       },
       signal,
     );

--- a/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
+++ b/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
@@ -4,6 +4,10 @@ import type {
   ChatPromptEvent,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { getModelImageInputSupport } from "@vm0/api-contracts/contracts/model-providers";
+import {
+  ZERO_RECOGNITION_MAX_FILE_BYTES,
+  zeroRecognitionImageMimeTypeSchema,
+} from "@vm0/api-contracts/contracts/zero-recognition";
 import type {
   DraftSignals,
   ZeroChatAttachment,
@@ -50,14 +54,19 @@ interface VisualAttachmentDescriptor {
   filename?: string | null;
 }
 
+interface AttachmentDescriptor extends VisualAttachmentDescriptor {
+  size: number;
+}
+
 interface PrepareUserMessageOptions {
-  excludeVisualAttachments?: boolean;
+  selectedModel: string | null | undefined;
+  imageRecognitionEnabled: boolean;
 }
 
 const VISUAL_ATTACHMENT_EXTENSION_RE =
   /\.(?:png|jpe?g|gif|webp|avif|heic|heif|bmp|svg|mp4|m4v|mov|webm|avi|mkv)$/i;
 
-export function isVisualAttachment({
+function isVisualAttachment({
   contentType,
   filename,
 }: VisualAttachmentDescriptor): boolean {
@@ -71,10 +80,29 @@ export function isVisualAttachment({
   return VISUAL_ATTACHMENT_EXTENSION_RE.test(filename ?? "");
 }
 
-export function shouldExcludeVisualAttachmentsForModel(
+function isRecognitionCompatibleImage({
+  contentType,
+  size,
+}: AttachmentDescriptor): boolean {
+  return (
+    size > 0 &&
+    size <= ZERO_RECOGNITION_MAX_FILE_BYTES &&
+    zeroRecognitionImageMimeTypeSchema.safeParse(contentType).success
+  );
+}
+
+export function shouldExcludeAttachmentForModel(
+  attachment: AttachmentDescriptor,
   selectedModel: string | null | undefined,
+  imageRecognitionEnabled: boolean,
 ): boolean {
-  return getModelImageInputSupport(selectedModel) === "unsupported";
+  if (
+    getModelImageInputSupport(selectedModel) !== "unsupported" ||
+    !isVisualAttachment(attachment)
+  ) {
+    return false;
+  }
+  return !imageRecognitionEnabled || !isRecognitionCompatibleImage(attachment);
 }
 
 export function collectSuccessfulAttachmentInfos(
@@ -146,11 +174,13 @@ export const prepareUserMessageFromDraft$ = command(
     signal: AbortSignal,
   ): Promise<PreparedUserMessage | null> => {
     const draftAttachments = get(draft.attachments$);
-    const allAttachments = options.excludeVisualAttachments
-      ? draftAttachments.filter((attachment) => {
-          return !isVisualAttachment(attachment);
-        })
-      : draftAttachments;
+    const allAttachments = draftAttachments.filter((attachment) => {
+      return !shouldExcludeAttachmentForModel(
+        attachment,
+        options.selectedModel,
+        options.imageRecognitionEnabled,
+      );
+    });
     const allInfos = await Promise.allSettled(
       allAttachments.map((a) => {
         return get(a.fileInfo$);

--- a/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
+++ b/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
@@ -4,10 +4,6 @@ import type {
   ChatPromptEvent,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { getModelImageInputSupport } from "@vm0/api-contracts/contracts/model-providers";
-import {
-  ZERO_RECOGNITION_MAX_FILE_BYTES,
-  zeroRecognitionImageMimeTypeSchema,
-} from "@vm0/api-contracts/contracts/zero-recognition";
 import type {
   DraftSignals,
   ZeroChatAttachment,
@@ -54,19 +50,14 @@ interface VisualAttachmentDescriptor {
   filename?: string | null;
 }
 
-interface AttachmentDescriptor extends VisualAttachmentDescriptor {
-  size: number;
-}
-
 interface PrepareUserMessageOptions {
-  selectedModel: string | null | undefined;
-  imageRecognitionEnabled: boolean;
+  excludeVisualAttachments?: boolean;
 }
 
 const VISUAL_ATTACHMENT_EXTENSION_RE =
   /\.(?:png|jpe?g|gif|webp|avif|heic|heif|bmp|svg|mp4|m4v|mov|webm|avi|mkv)$/i;
 
-function isVisualAttachment({
+export function isVisualAttachment({
   contentType,
   filename,
 }: VisualAttachmentDescriptor): boolean {
@@ -80,29 +71,14 @@ function isVisualAttachment({
   return VISUAL_ATTACHMENT_EXTENSION_RE.test(filename ?? "");
 }
 
-function isRecognitionCompatibleImage({
-  contentType,
-  size,
-}: AttachmentDescriptor): boolean {
-  return (
-    size > 0 &&
-    size <= ZERO_RECOGNITION_MAX_FILE_BYTES &&
-    zeroRecognitionImageMimeTypeSchema.safeParse(contentType).success
-  );
-}
-
-export function shouldExcludeAttachmentForModel(
-  attachment: AttachmentDescriptor,
+export function shouldExcludeVisualAttachmentsForModel(
   selectedModel: string | null | undefined,
   imageRecognitionEnabled: boolean,
 ): boolean {
-  if (
-    getModelImageInputSupport(selectedModel) !== "unsupported" ||
-    !isVisualAttachment(attachment)
-  ) {
-    return false;
-  }
-  return !imageRecognitionEnabled || !isRecognitionCompatibleImage(attachment);
+  return (
+    !imageRecognitionEnabled &&
+    getModelImageInputSupport(selectedModel) === "unsupported"
+  );
 }
 
 export function collectSuccessfulAttachmentInfos(
@@ -174,13 +150,11 @@ export const prepareUserMessageFromDraft$ = command(
     signal: AbortSignal,
   ): Promise<PreparedUserMessage | null> => {
     const draftAttachments = get(draft.attachments$);
-    const allAttachments = draftAttachments.filter((attachment) => {
-      return !shouldExcludeAttachmentForModel(
-        attachment,
-        options.selectedModel,
-        options.imageRecognitionEnabled,
-      );
-    });
+    const allAttachments = options.excludeVisualAttachments
+      ? draftAttachments.filter((attachment) => {
+          return !isVisualAttachment(attachment);
+        })
+      : draftAttachments;
     const allInfos = await Promise.allSettled(
       allAttachments.map((a) => {
         return get(a.fileInfo$);

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -10,7 +10,7 @@ import { unauthorizedRedirectSuppressionUntil$ } from "../auth-retry.ts";
 import { rootSignal$ } from "../root-signal.ts";
 import { localStorageSignals } from "./local-storage.ts";
 
-export const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v3";
+export const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v4";
 
 const { set$: setFeatureSwitchLocalStorage$, get$: featureSwitchCache$ } =
   localStorageSignals(FEATURE_SWITCH_CACHE_KEY);
@@ -129,6 +129,9 @@ export const reloadFeatureSwitch$ = command(
     }
     if (result.body.supportsCustomModelGateways !== true) {
       combined[FeatureSwitchKey.CustomModelGateways] = false;
+    }
+    if (result.body.supportsImageRecognition !== true) {
+      combined[FeatureSwitchKey.ZeroImageRecognition] = false;
     }
 
     set(setFeatureSwitchLocalStorage$, JSON.stringify(combined));

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -1,4 +1,4 @@
-import { command, computed } from "ccstate";
+import { command, computed, state } from "ccstate";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -10,10 +10,11 @@ import { unauthorizedRedirectSuppressionUntil$ } from "../auth-retry.ts";
 import { rootSignal$ } from "../root-signal.ts";
 import { localStorageSignals } from "./local-storage.ts";
 
-export const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v4";
+export const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v3";
 
 const { set$: setFeatureSwitchLocalStorage$, get$: featureSwitchCache$ } =
   localStorageSignals(FEATURE_SWITCH_CACHE_KEY);
+const imageRecognitionApiSupported$ = state(false);
 
 // Pinned to the API backend: feature switches bootstrap before the platform API
 // client is available.
@@ -58,6 +59,13 @@ export const featureSwitch$ = computed((get) => {
   return JSON.parse(raw) as Record<FeatureSwitchKey, boolean>;
 });
 
+export const zeroImageRecognitionEnabled$ = computed((get): boolean => {
+  return (
+    get(imageRecognitionApiSupported$) &&
+    (get(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition] ?? false)
+  );
+});
+
 export const artifactSidebarInlineOpenEnabled$ = computed((get): boolean => {
   return (
     get(featureSwitch$)[FeatureSwitchKey.ArtifactSidebarInlineOpen] ?? false
@@ -98,6 +106,7 @@ export const composerConnectorPermissionsEnabled$ = computed((get): boolean => {
 
 export const reloadFeatureSwitch$ = command(
   async ({ get, set }, signal: AbortSignal) => {
+    set(imageRecognitionApiSupported$, false);
     const clerk = await get(clerk$);
     signal.throwIfAborted();
     if (!clerk.user || !clerk.organization) {
@@ -130,11 +139,14 @@ export const reloadFeatureSwitch$ = command(
     if (result.body.supportsCustomModelGateways !== true) {
       combined[FeatureSwitchKey.CustomModelGateways] = false;
     }
-    if (result.body.supportsImageRecognition !== true) {
+    const supportsImageRecognition =
+      result.body.supportsImageRecognition === true;
+    if (!supportsImageRecognition) {
       combined[FeatureSwitchKey.ZeroImageRecognition] = false;
     }
 
     set(setFeatureSwitchLocalStorage$, JSON.stringify(combined));
+    set(imageRecognitionApiSupported$, supportsImageRecognition);
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -147,7 +147,7 @@ function uploadContentTypeByExtension(ext: string): string | undefined {
   return contentTypeByExtension[ext];
 }
 
-function inferUploadContentType(file: File): string {
+export function inferUploadContentType(file: File): string {
   const explicitType = file.type.split(";")[0]?.trim().toLowerCase();
   if (explicitType && explicitType !== "application/octet-stream") {
     return explicitType;

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -147,7 +147,7 @@ function uploadContentTypeByExtension(ext: string): string | undefined {
   return contentTypeByExtension[ext];
 }
 
-export function inferUploadContentType(file: File): string {
+function inferUploadContentType(file: File): string {
   const explicitType = file.type.split(";")[0]?.trim().toLowerCase();
   if (explicitType && explicitType !== "application/octet-stream") {
     return explicitType;

--- a/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
@@ -4,11 +4,10 @@ import type {
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ZeroAgentResponse } from "@vm0/api-contracts/contracts/zero-agents";
 import { foldActiveChatGoalObjective } from "@vm0/api-contracts/contracts/chat-events";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import { onRef, withCleanup } from "../utils.ts";
 import { shouldExcludeAttachmentForModel } from "../chat-page/resolve-draft-attachments.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
+import { zeroImageRecognitionEnabled$ } from "../external/feature-switch.ts";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import type { DraftSignals, ZeroChatAttachment } from "./chat-draft.ts";
 import type { ComposerFeedbackModel } from "./chat-feedback.ts";
@@ -614,8 +613,7 @@ function createComposerSubmissionSignals(
       let hasContent = get(workflowComposer.hasInput$);
       if (!hasContent && attachments.length > 0) {
         const modelSelection = await get(options.modelSelection$);
-        const imageRecognitionEnabled =
-          get(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition] ?? false;
+        const imageRecognitionEnabled = get(zeroImageRecognitionEnabled$);
         hasContent = hasVisibleAttachment(
           modelSelection,
           attachments,
@@ -669,9 +667,7 @@ function createComposerSubmissionSignals(
             }
             const modelSelection = await get(options.modelSelection$);
             signal.throwIfAborted();
-            const imageRecognitionEnabled =
-              get(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition] ??
-              false;
+            const imageRecognitionEnabled = get(zeroImageRecognitionEnabled$);
             if (
               !hasVisibleAttachment(
                 modelSelection,

--- a/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
@@ -3,11 +3,12 @@ import type {
   PersistedAttachment,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ZeroAgentResponse } from "@vm0/api-contracts/contracts/zero-agents";
-import { getModelImageInputSupport } from "@vm0/api-contracts/contracts/model-providers";
 import { foldActiveChatGoalObjective } from "@vm0/api-contracts/contracts/chat-events";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import { onRef, withCleanup } from "../utils.ts";
-import { isVisualAttachment } from "../chat-page/resolve-draft-attachments.ts";
+import { shouldExcludeAttachmentForModel } from "../chat-page/resolve-draft-attachments.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import type { DraftSignals, ZeroChatAttachment } from "./chat-draft.ts";
 import type { ComposerFeedbackModel } from "./chat-feedback.ts";
@@ -321,12 +322,14 @@ function composerTemplateSignals(
 function hasVisibleAttachment(
   selection: ModelProviderSelection | null,
   attachments: readonly ZeroChatAttachment[],
+  imageRecognitionEnabled: boolean,
 ): boolean {
-  if (getModelImageInputSupport(selection?.selectedModel) !== "unsupported") {
-    return attachments.length > 0;
-  }
   return attachments.some((attachment) => {
-    return !isVisualAttachment(attachment);
+    return !shouldExcludeAttachmentForModel(
+      attachment,
+      selection?.selectedModel,
+      imageRecognitionEnabled,
+    );
   });
 }
 
@@ -611,7 +614,13 @@ function createComposerSubmissionSignals(
       let hasContent = get(workflowComposer.hasInput$);
       if (!hasContent && attachments.length > 0) {
         const modelSelection = await get(options.modelSelection$);
-        hasContent = hasVisibleAttachment(modelSelection, attachments);
+        const imageRecognitionEnabled =
+          get(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition] ?? false;
+        hasContent = hasVisibleAttachment(
+          modelSelection,
+          attachments,
+          imageRecognitionEnabled,
+        );
       }
       const canSend = uploadsReady && hasContent;
       const sending = await get(eventSignals.sending$);
@@ -660,7 +669,16 @@ function createComposerSubmissionSignals(
             }
             const modelSelection = await get(options.modelSelection$);
             signal.throwIfAborted();
-            if (!hasVisibleAttachment(modelSelection, attachments)) {
+            const imageRecognitionEnabled =
+              get(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition] ??
+              false;
+            if (
+              !hasVisibleAttachment(
+                modelSelection,
+                attachments,
+                imageRecognitionEnabled,
+              )
+            ) {
               return false;
             }
           }

--- a/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
@@ -6,7 +6,10 @@ import type { ZeroAgentResponse } from "@vm0/api-contracts/contracts/zero-agents
 import { foldActiveChatGoalObjective } from "@vm0/api-contracts/contracts/chat-events";
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import { onRef, withCleanup } from "../utils.ts";
-import { shouldExcludeAttachmentForModel } from "../chat-page/resolve-draft-attachments.ts";
+import {
+  isVisualAttachment,
+  shouldExcludeVisualAttachmentsForModel,
+} from "../chat-page/resolve-draft-attachments.ts";
 import { zeroImageRecognitionEnabled$ } from "../external/feature-switch.ts";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import type { DraftSignals, ZeroChatAttachment } from "./chat-draft.ts";
@@ -323,12 +326,16 @@ function hasVisibleAttachment(
   attachments: readonly ZeroChatAttachment[],
   imageRecognitionEnabled: boolean,
 ): boolean {
-  return attachments.some((attachment) => {
-    return !shouldExcludeAttachmentForModel(
-      attachment,
+  if (
+    !shouldExcludeVisualAttachmentsForModel(
       selection?.selectedModel,
       imageRecognitionEnabled,
-    );
+    )
+  ) {
+    return attachments.length > 0;
+  }
+  return attachments.some((attachment) => {
+    return !isVisualAttachment(attachment);
   });
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -21,6 +21,7 @@ import { zeroModelPoliciesMainContract } from "@vm0/api-contracts/contracts/zero
 import { zeroBillingStatusContract } from "@vm0/api-contracts/contracts/zero-billing";
 import { zeroUserModelPreferenceContract } from "@vm0/api-contracts/contracts/zero-user-model-preference";
 import { zeroWorkflowsCollectionContract } from "@vm0/api-contracts/contracts/zero-workflows";
+import { ZERO_RECOGNITION_MAX_FILE_BYTES } from "@vm0/api-contracts/contracts/zero-recognition";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { triggerAblyEvent } from "../../../mocks/ably.ts";
 import { emitMockedClerkEvent } from "../../../__tests__/mock-auth.ts";
@@ -2060,6 +2061,164 @@ describe("chat composer models", () => {
     });
   });
 
+  it("accepts recognition-compatible images for fallback-enabled text-only models", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockOrgModelRoutes("glm-5.1");
+    mockAgent();
+    context.mocks.upload.success({
+      id: "recognition-compatible-upload",
+      filename: "uploaded.png",
+      contentType: "image/png",
+      size: 3,
+      url: "https://example.com/uploaded.png",
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.ZeroImageRecognition]: true,
+      },
+    });
+
+    await expectComposerModel("GLM-5.1");
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]')!;
+
+    await user.upload(
+      fileInput,
+      new File(["png"], "uploaded.png", { type: "image/png" }),
+    );
+    await expect(
+      screen.findByLabelText("Open image preview for uploaded.png"),
+    ).resolves.toBeInTheDocument();
+
+    const editor = await findComposerEditor();
+    fireEvent.paste(editor, {
+      clipboardData: {
+        getData: () => {
+          return "";
+        },
+        items: [
+          {
+            kind: "file",
+            getAsFile: () => {
+              return new File(["jpeg"], "pasted.jpg", {
+                type: "image/jpeg",
+              });
+            },
+          },
+        ],
+      },
+    });
+
+    await expect(
+      screen.findByLabelText("Open image preview for pasted.jpg"),
+    ).resolves.toBeInTheDocument();
+
+    fireEvent.paste(editor, {
+      clipboardData: {
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return chatClipboardHtml({
+              text: "Compare the restored image",
+              attachments: [
+                {
+                  id: "restored-recognition-image",
+                  url: "https://example.com/restored.png",
+                  filename: "restored.png",
+                  contentType: "image/png",
+                  size: 42,
+                },
+              ],
+            });
+          }
+          return "";
+        },
+        items: [],
+      },
+    });
+
+    await expect(
+      screen.findByLabelText("Open image preview for restored.png"),
+    ).resolves.toBeInTheDocument();
+
+    const composer = composerElementFrom(editor);
+    fireEvent.drop(composer, {
+      dataTransfer: {
+        files: [new File(["webp"], "dropped.webp", { type: "image/webp" })],
+      },
+    });
+
+    await expect(
+      screen.findByLabelText("Open image preview for dropped.webp"),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.queryByText(/GLM-5\.1 cannot recognize images or videos/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("rejects media outside the recognition contract for fallback-enabled text-only models", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockOrgModelRoutes("glm-5.1");
+    mockAgent();
+    context.mocks.upload.success({
+      id: "recognition-boundary-text",
+      filename: "notes.txt",
+      contentType: "text/plain",
+      size: 5,
+      url: "https://example.com/notes.txt",
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.ZeroImageRecognition]: true,
+      },
+    });
+
+    await expectComposerModel("GLM-5.1");
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    const oversizedImage = new File(["png"], "oversized.png", {
+      type: "image/png",
+    });
+    Object.defineProperty(oversizedImage, "size", {
+      configurable: true,
+      value: ZERO_RECOGNITION_MAX_FILE_BYTES + 1,
+    });
+
+    await user.upload(fileInput, [
+      new File(["gif"], "animated.gif", { type: "image/gif" }),
+      new File([], "empty.png", { type: "image/png" }),
+      oversizedImage,
+      new File(["video"], "clip.mp4", { type: "video/mp4" }),
+    ]);
+
+    await expect(
+      screen.findAllByText(/GLM-5\.1 cannot recognize images or videos/i),
+    ).resolves.not.toHaveLength(0);
+    expect(
+      screen.queryByLabelText("Open image preview for animated.gif"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Open image preview for empty.png"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Open image preview for oversized.png"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Remove clip.mp4")).not.toBeInTheDocument();
+
+    await user.upload(
+      fileInput,
+      new File(["notes"], "notes.txt", { type: "text/plain" }),
+    );
+    await expect(
+      screen.findByLabelText("Remove notes.txt"),
+    ).resolves.toBeInTheDocument();
+  });
+
   it("hides an accepted visual attachment after switching to a text-only model", async () => {
     const user = userEvent.setup({ delay: null });
     mockOrgModelRoutes("claude-sonnet-4-6");
@@ -2098,6 +2257,53 @@ describe("chat composer models", () => {
       ).toBeGreaterThan(0);
       expect(
         screen.queryByLabelText("Open image preview for storyboard.png"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps a compatible image after switching to a fallback-enabled text-only model", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockOrgModelRoutes("claude-sonnet-4-6");
+    mockAgent();
+    context.mocks.upload.success({
+      id: "recognition-model-switch",
+      filename: "storyboard.png",
+      contentType: "image/png",
+      size: 128,
+      url: "https://example.com/storyboard.png",
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.ZeroImageRecognition]: true,
+      },
+    });
+
+    await expectComposerModel("Claude Sonnet 4.6");
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    await user.upload(
+      fileInput,
+      new File(["image"], "storyboard.png", { type: "image/png" }),
+    );
+
+    await expect(
+      screen.findByLabelText("Open image preview for storyboard.png"),
+    ).resolves.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
+    );
+    await user.click(await screen.findByRole("option", { name: /GLM-5\.1/ }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Open image preview for storyboard.png"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/GLM-5\.1 cannot recognize images or videos/i),
       ).not.toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -2061,7 +2061,7 @@ describe("chat composer models", () => {
     });
   });
 
-  it("accepts recognition-compatible images for fallback-enabled text-only models", async () => {
+  it("accepts visual attachments across composer paths for fallback-enabled text-only models", async () => {
     const user = userEvent.setup({ delay: null });
     mockOrgModelRoutes("glm-5.1");
     mockAgent();
@@ -2158,16 +2158,16 @@ describe("chat composer models", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("rejects media outside the recognition contract for fallback-enabled text-only models", async () => {
+  it("accepts media outside the direct recognition contract for fallback-enabled text-only models", async () => {
     const user = userEvent.setup({ delay: null });
     mockOrgModelRoutes("glm-5.1");
     mockAgent();
     context.mocks.upload.success({
-      id: "recognition-boundary-text",
-      filename: "notes.txt",
-      contentType: "text/plain",
+      id: "recognition-boundary-visual",
+      filename: "uploaded-visual",
+      contentType: "application/octet-stream",
       size: 5,
-      url: "https://example.com/notes.txt",
+      url: "https://example.com/uploaded-visual",
     });
 
     detachedSetupPage({
@@ -2197,26 +2197,20 @@ describe("chat composer models", () => {
     ]);
 
     await expect(
-      screen.findAllByText(/GLM-5\.1 cannot recognize images or videos/i),
-    ).resolves.not.toHaveLength(0);
-    expect(
-      screen.queryByLabelText("Open image preview for animated.gif"),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByLabelText("Open image preview for empty.png"),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByLabelText("Open image preview for oversized.png"),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Remove clip.mp4")).not.toBeInTheDocument();
-
-    await user.upload(
-      fileInput,
-      new File(["notes"], "notes.txt", { type: "text/plain" }),
-    );
-    await expect(
-      screen.findByLabelText("Remove notes.txt"),
+      screen.findByLabelText("Open image preview for animated.gif"),
     ).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByLabelText("Open image preview for empty.png"),
+    ).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByLabelText("Open image preview for oversized.png"),
+    ).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByLabelText("Remove clip.mp4"),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.queryByText(/GLM-5\.1 cannot recognize images or videos/i),
+    ).not.toBeInTheDocument();
   });
 
   it("hides an accepted visual attachment after switching to a text-only model", async () => {
@@ -2261,16 +2255,16 @@ describe("chat composer models", () => {
     });
   });
 
-  it("keeps a compatible image after switching to a fallback-enabled text-only model", async () => {
+  it("keeps a non-native image after switching to a fallback-enabled text-only model", async () => {
     const user = userEvent.setup({ delay: null });
     mockOrgModelRoutes("claude-sonnet-4-6");
     mockAgent();
     context.mocks.upload.success({
       id: "recognition-model-switch",
-      filename: "storyboard.png",
-      contentType: "image/png",
+      filename: "storyboard.gif",
+      contentType: "image/gif",
       size: 128,
-      url: "https://example.com/storyboard.png",
+      url: "https://example.com/storyboard.gif",
     });
 
     detachedSetupPage({
@@ -2286,11 +2280,11 @@ describe("chat composer models", () => {
       document.querySelector<HTMLInputElement>('input[type="file"]')!;
     await user.upload(
       fileInput,
-      new File(["image"], "storyboard.png", { type: "image/png" }),
+      new File(["image"], "storyboard.gif", { type: "image/gif" }),
     );
 
     await expect(
-      screen.findByLabelText("Open image preview for storyboard.png"),
+      screen.findByLabelText("Open image preview for storyboard.gif"),
     ).resolves.toBeInTheDocument();
 
     await user.click(
@@ -2300,7 +2294,7 @@ describe("chat composer models", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByLabelText("Open image preview for storyboard.png"),
+        screen.getByLabelText("Open image preview for storyboard.gif"),
       ).toBeInTheDocument();
       expect(
         screen.queryByText(/GLM-5\.1 cannot recognize images or videos/i),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -578,8 +578,8 @@ describe("chat lifecycle", () => {
       },
     });
 
-    const textarea = await waitFor(() => {
-      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
     });
     const fileInput =
       document.querySelector<HTMLInputElement>('input[type="file"]');
@@ -593,9 +593,14 @@ describe("chat lifecycle", () => {
     );
 
     await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: "GLM-5.1" }),
+      ).toBeInTheDocument();
       expect(screen.getByLabelText("Remove brief.png")).toBeInTheDocument();
     });
+    await screen.findByLabelText("Send");
 
+    const textarea = screen.getByPlaceholderText(PLACEHOLDER);
     await sendMessageInUI(user, textarea, "Summarize this visual brief");
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -528,17 +528,25 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("starts a new chat with a visual attachment", async () => {
+  it("starts a new fallback-enabled text-only chat with an image attachment", async () => {
     const user = userEvent.setup({ delay: null });
+    let sentAttachFiles:
+      | {
+          id: string;
+          filename: string;
+          contentType: string;
+          size: number;
+        }[]
+      | undefined;
     context.mocks.data.userModelPreference({
-      selectedModel: "claude-sonnet-4-6",
+      selectedModel: "glm-5.1",
       updatedAt: "2026-03-10T00:00:00Z",
     });
     context.mocks.data.orgModelPolicies([
       {
         id: "00000000-0000-4000-a000-000000000719",
-        model: "claude-sonnet-4-6",
-        modelLabel: "Claude Sonnet 4.6",
+        model: "glm-5.1",
+        modelLabel: "GLM-5.1",
         isDefault: true,
         defaultProviderType: "vm0",
         credentialScope: "org",
@@ -549,7 +557,11 @@ describe("chat lifecycle", () => {
         updatedAt: "2026-07-14T00:00:00.000Z",
       },
     ]);
-    mockChatLifecycle(context);
+    mockChatLifecycle(context, {
+      onRunCreate: (body) => {
+        sentAttachFiles = body.attachFiles;
+      },
+    });
     context.mocks.upload.success({
       id: "upload-visual-brief",
       filename: "brief.png",
@@ -558,7 +570,13 @@ describe("chat lifecycle", () => {
       url: "https://cdn.vm7.io/artifacts/test/upload-visual-brief/brief.png",
     });
 
-    detachedSetupPage({ context, path: AGENT_CHAT_PATH });
+    detachedSetupPage({
+      context,
+      path: AGENT_CHAT_PATH,
+      featureSwitches: {
+        [FeatureSwitchKey.ZeroImageRecognition]: true,
+      },
+    });
 
     const textarea = await waitFor(() => {
       return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
@@ -571,7 +589,7 @@ describe("chat lifecycle", () => {
 
     await user.upload(
       fileInput,
-      new File(["image-bytes"], "brief.png", { type: "image/png" }),
+      new File([new Uint8Array(128)], "brief.png", { type: "image/png" }),
     );
 
     await waitFor(() => {
@@ -585,6 +603,100 @@ describe("chat lifecycle", () => {
         screen.getByText("Summarize this visual brief"),
       ).toBeInTheDocument();
       expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      expect(sentAttachFiles).toStrictEqual([
+        {
+          id: "upload-visual-brief",
+          filename: "brief.png",
+          contentType: "image/png",
+          size: 128,
+        },
+      ]);
+    });
+  });
+
+  it("sends an image attachment in an existing fallback-enabled text-only chat", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "b0000000-0000-4000-a000-000000000994";
+    let sentAttachFiles:
+      | {
+          id: string;
+          filename: string;
+          contentType: string;
+          size: number;
+        }[]
+      | undefined;
+    context.mocks.data.userModelPreference({
+      selectedModel: "glm-5.1",
+      updatedAt: "2026-03-10T00:00:00Z",
+    });
+    context.mocks.data.orgModelPolicies([
+      {
+        id: "00000000-0000-4000-a000-000000000720",
+        model: "glm-5.1",
+        modelLabel: "GLM-5.1",
+        isDefault: true,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+        routeStatus: "valid",
+        routeStatusReason: null,
+        createdAt: "2026-07-14T00:00:00.000Z",
+        updatedAt: "2026-07-14T00:00:00.000Z",
+      },
+    ]);
+    mockChatLifecycle(context, {
+      threadId,
+      selectedModel: "glm-5.1",
+      onRunCreate: (body) => {
+        sentAttachFiles = body.attachFiles;
+      },
+    });
+    context.mocks.upload.success({
+      id: "upload-existing-visual",
+      filename: "existing.jpg",
+      contentType: "image/jpeg",
+      size: 64,
+      url: "https://cdn.vm7.io/artifacts/test/upload-existing-visual/existing.jpg",
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ZeroImageRecognition]: true,
+      },
+    });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!fileInput) {
+      throw new Error("file input not found");
+    }
+    await user.upload(
+      fileInput,
+      new File([new Uint8Array(64)], "existing.jpg", {
+        type: "image/jpeg",
+      }),
+    );
+
+    await expect(
+      screen.findByLabelText("Open image preview for existing.jpg"),
+    ).resolves.toBeInTheDocument();
+
+    await sendMessageInUI(user, textarea, "Inspect this existing image");
+
+    await waitFor(() => {
+      expect(sentAttachFiles).toStrictEqual([
+        {
+          id: "upload-existing-visual",
+          filename: "existing.jpg",
+          contentType: "image/jpeg",
+          size: 64,
+        },
+      ]);
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { describe, expect, it, onTestFinished } from "vitest";
 import { chatThreadEventsContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { ZERO_RECOGNITION_MAX_FILE_BYTES } from "@vm0/api-contracts/contracts/zero-recognition";
 import { eventDrivenChatThread } from "../../../signals/chat-page/chat-thread-event-sourcing.ts";
 import { queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
 import {
@@ -528,7 +529,7 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("starts a new fallback-enabled text-only chat with an image attachment", async () => {
+  it("starts a new fallback-enabled text-only chat with an image above the direct recognition limit", async () => {
     const user = userEvent.setup({ delay: null });
     let sentAttachFiles:
       | {
@@ -566,7 +567,7 @@ describe("chat lifecycle", () => {
       id: "upload-visual-brief",
       filename: "brief.png",
       contentType: "image/png",
-      size: 128,
+      size: ZERO_RECOGNITION_MAX_FILE_BYTES + 1,
       url: "https://cdn.vm7.io/artifacts/test/upload-visual-brief/brief.png",
     });
 
@@ -587,10 +588,12 @@ describe("chat lifecycle", () => {
       throw new Error("file input not found");
     }
 
-    await user.upload(
-      fileInput,
-      new File([new Uint8Array(128)], "brief.png", { type: "image/png" }),
-    );
+    const brief = new File(["image"], "brief.png", { type: "image/png" });
+    Object.defineProperty(brief, "size", {
+      configurable: true,
+      value: ZERO_RECOGNITION_MAX_FILE_BYTES + 1,
+    });
+    await user.upload(fileInput, brief);
 
     await waitFor(() => {
       expect(
@@ -613,13 +616,13 @@ describe("chat lifecycle", () => {
           id: "upload-visual-brief",
           filename: "brief.png",
           contentType: "image/png",
-          size: 128,
+          size: ZERO_RECOGNITION_MAX_FILE_BYTES + 1,
         },
       ]);
     });
   });
 
-  it("sends an image attachment in an existing fallback-enabled text-only chat", async () => {
+  it("sends a video attachment in an existing fallback-enabled text-only chat", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "b0000000-0000-4000-a000-000000000994";
     let sentAttachFiles:
@@ -658,10 +661,10 @@ describe("chat lifecycle", () => {
     });
     context.mocks.upload.success({
       id: "upload-existing-visual",
-      filename: "existing.jpg",
-      contentType: "image/jpeg",
+      filename: "existing.mov",
+      contentType: "video/quicktime",
       size: 64,
-      url: "https://cdn.vm7.io/artifacts/test/upload-existing-visual/existing.jpg",
+      url: "https://cdn.vm7.io/artifacts/test/upload-existing-visual/existing.mov",
     });
 
     detachedSetupPage({
@@ -682,23 +685,23 @@ describe("chat lifecycle", () => {
     }
     await user.upload(
       fileInput,
-      new File([new Uint8Array(64)], "existing.jpg", {
-        type: "image/jpeg",
+      new File([new Uint8Array(64)], "existing.mov", {
+        type: "video/quicktime",
       }),
     );
 
     await expect(
-      screen.findByLabelText("Open image preview for existing.jpg"),
+      screen.findByLabelText("Remove existing.mov"),
     ).resolves.toBeInTheDocument();
 
-    await sendMessageInUI(user, textarea, "Inspect this existing image");
+    await sendMessageInUI(user, textarea, "Inspect this existing video");
 
     await waitFor(() => {
       expect(sentAttachFiles).toStrictEqual([
         {
           id: "upload-existing-visual",
-          filename: "existing.jpg",
-          contentType: "image/jpeg",
+          filename: "existing.mov",
+          contentType: "video/quicktime",
           size: 64,
         },
       ]);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -721,13 +721,20 @@ describe("chat run queue", () => {
     });
   });
 
-  it("queues an attachment-only follow-up during an active run", async () => {
+  it("queues an image-only follow-up for a fallback-enabled text-only model", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "b0000000-0000-4000-a000-000000000902";
     let queuedBody: QueuedMessageCapture | null = null;
 
+    context.mocks.data.orgModelPolicies([
+      buildModelPolicy({
+        model: "glm-5.1",
+        modelLabel: "GLM-5.1",
+      }),
+    ]);
     mockChatLifecycle(context, {
       threadId,
+      selectedModel: "glm-5.1",
       chatEvents: [
         {
           id: "msg-active-attachment-user",
@@ -750,14 +757,20 @@ describe("chat run queue", () => {
       },
     });
     context.mocks.upload.success({
-      id: "upload-notes",
-      filename: "notes.txt",
-      contentType: "text/plain",
+      id: "upload-queued-image",
+      filename: "queued.png",
+      contentType: "image/png",
       size: 12,
-      url: "https://cdn.vm7.io/artifacts/test/upload-notes/notes.txt",
+      url: "https://cdn.vm7.io/artifacts/test/upload-queued-image/queued.png",
     });
 
-    detachedSetupPage({ context, path: `/chats/${threadId}` });
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ZeroImageRecognition]: true,
+      },
+    });
 
     await waitFor(() => {
       expect(screen.getByLabelText("Stop")).toBeInTheDocument();
@@ -770,30 +783,32 @@ describe("chat run queue", () => {
     }
     await user.upload(
       fileInput,
-      new File(["release note"], "notes.txt", { type: "text/plain" }),
+      new File([new Uint8Array(12)], "queued.png", { type: "image/png" }),
     );
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Remove notes.txt")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Open image preview for queued.png"),
+      ).toBeInTheDocument();
     });
 
-    await user.click(screen.getByLabelText("Send"));
+    await user.click(await screen.findByLabelText("Send"));
 
     await waitFor(() => {
       expect(screen.getByText("1 message waiting")).toBeInTheDocument();
       expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-        "[File: notes.txt]",
+        "[File: queued.png]",
       );
       expect(queuedBody).toMatchObject({
         content: "(see attached files)",
         hasTextContent: false,
         attachments: [
           {
-            id: "upload-notes",
-            filename: "notes.txt",
-            contentType: "text/plain",
+            id: "upload-queued-image",
+            filename: "queued.png",
+            contentType: "image/png",
             size: 12,
-            url: "https://cdn.vm7.io/artifacts/test/upload-notes/notes.txt",
+            url: "https://cdn.vm7.io/artifacts/test/upload-queued-image/queued.png",
           },
         ],
       });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -721,7 +721,7 @@ describe("chat run queue", () => {
     });
   });
 
-  it("queues an image-only follow-up for a fallback-enabled text-only model", async () => {
+  it("queues a video-only follow-up for a fallback-enabled text-only model", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "b0000000-0000-4000-a000-000000000902";
     let queuedBody: QueuedMessageCapture | null = null;
@@ -757,11 +757,11 @@ describe("chat run queue", () => {
       },
     });
     context.mocks.upload.success({
-      id: "upload-queued-image",
-      filename: "queued.png",
-      contentType: "image/png",
+      id: "upload-queued-video",
+      filename: "queued.mp4",
+      contentType: "video/mp4",
       size: 12,
-      url: "https://cdn.vm7.io/artifacts/test/upload-queued-image/queued.png",
+      url: "https://cdn.vm7.io/artifacts/test/upload-queued-video/queued.mp4",
     });
 
     detachedSetupPage({
@@ -783,13 +783,11 @@ describe("chat run queue", () => {
     }
     await user.upload(
       fileInput,
-      new File([new Uint8Array(12)], "queued.png", { type: "image/png" }),
+      new File([new Uint8Array(12)], "queued.mp4", { type: "video/mp4" }),
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByLabelText("Open image preview for queued.png"),
-      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Remove queued.mp4")).toBeInTheDocument();
     });
 
     await user.click(await screen.findByLabelText("Send"));
@@ -797,18 +795,18 @@ describe("chat run queue", () => {
     await waitFor(() => {
       expect(screen.getByText("1 message waiting")).toBeInTheDocument();
       expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-        "[File: queued.png]",
+        "[File: queued.mp4]",
       );
       expect(queuedBody).toMatchObject({
         content: "(see attached files)",
         hasTextContent: false,
         attachments: [
           {
-            id: "upload-queued-image",
-            filename: "queued.png",
-            contentType: "image/png",
+            id: "upload-queued-video",
+            filename: "queued.mp4",
+            contentType: "video/mp4",
             size: 12,
-            url: "https://cdn.vm7.io/artifacts/test/upload-queued-image/queued.png",
+            url: "https://cdn.vm7.io/artifacts/test/upload-queued-video/queued.mp4",
           },
         ],
       });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -155,6 +155,7 @@ import {
   composerUploadPopoverEnabled$,
   composerConnectorPermissionsEnabled$,
   featureSwitch$,
+  zeroImageRecognitionEnabled$,
 } from "../../signals/external/feature-switch.ts";
 import {
   computerUseHosts$,
@@ -7031,8 +7032,7 @@ function useComposerVisualAttachmentUnsupported(
   signals: ComposerSignals,
 ): VisualAttachmentUnsupportedState | null {
   const modelSelection = useLastResolved(signals.model.modelSelection$) ?? null;
-  const imageRecognitionEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition] ?? false;
+  const imageRecognitionEnabled = useGet(zeroImageRecognitionEnabled$);
   return getVisualAttachmentUnsupportedState(
     {
       value: modelSelection,
@@ -7339,8 +7339,7 @@ function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
   const setModelSelection = useSet(signals.model.setModelSelection$);
   const configureSelectedModel = useSet(signals.model.configureSelectedModel$);
   const attachments = useGet(signals.draft.attachments$);
-  const imageRecognitionEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition] ?? false;
+  const imageRecognitionEnabled = useGet(zeroImageRecognitionEnabled$);
   const pageSignal = useGet(pageSignal$);
   const value = modelSelection.state === "hasData" ? modelSelection.data : null;
   const modelPickerLoading = modelSelection.state === "loading";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -87,7 +87,8 @@ import {
 import { sendMode$ } from "../../signals/send-mode.ts";
 import type { ComposerTemplateAttachment } from "../../signals/zero-page/tiptap-workflow-composer.ts";
 import type { TemplatePreviewRuntime } from "../../signals/zero-page/template-preview-runtime.ts";
-import { isVisualAttachment } from "../../signals/chat-page/resolve-draft-attachments.ts";
+import { shouldExcludeAttachmentForModel } from "../../signals/chat-page/resolve-draft-attachments.ts";
+import { inferUploadContentType } from "../../signals/zero-page/chat-draft.ts";
 import type {
   GenerationTemplateRequest,
   PersistedAttachment,
@@ -313,15 +314,19 @@ function resolveComposerModelForSelection(
 
 interface VisualAttachmentUnsupportedState {
   currentModelName: string;
+  selectedModel: string;
+  imageRecognitionEnabled: boolean;
 }
 
 interface VisualAttachmentCandidate {
   contentType: string;
   filename: string;
+  size: number;
 }
 
 function getVisualAttachmentUnsupportedState(
   modelPicker: ComposerModelPicker | undefined,
+  imageRecognitionEnabled: boolean,
   selection: ModelProviderSelection | null = modelPicker?.value ?? null,
 ): VisualAttachmentUnsupportedState | null {
   const currentModel = resolveComposerModelForSelection(modelPicker, selection);
@@ -333,14 +338,33 @@ function getVisualAttachmentUnsupportedState(
   }
   return {
     currentModelName: getModelDisplayName(currentModel.selectedModel),
+    selectedModel: currentModel.selectedModel,
+    imageRecognitionEnabled,
   };
 }
 
-function isVisualAttachmentFile(file: File): boolean {
-  return isVisualAttachment({
-    contentType: file.type,
+function visualAttachmentCandidateFromFile(
+  file: File,
+): VisualAttachmentCandidate {
+  return {
+    contentType: inferUploadContentType(file),
     filename: file.name,
-  });
+    size: file.size,
+  };
+}
+
+function shouldExcludeVisualAttachment(
+  state: VisualAttachmentUnsupportedState | null,
+  attachment: VisualAttachmentCandidate,
+): boolean {
+  return (
+    state !== null &&
+    shouldExcludeAttachmentForModel(
+      attachment,
+      state.selectedModel,
+      state.imageRecognitionEnabled,
+    )
+  );
 }
 
 function showVisualAttachmentUnsupportedToast(
@@ -367,7 +391,10 @@ function resolveVisibleAttachments<T extends VisualAttachmentCandidate>(
     return attachments;
   }
   return attachments.filter((attachment) => {
-    return !isVisualAttachment(attachment);
+    return !shouldExcludeVisualAttachment(
+      visualAttachmentUnsupported,
+      attachment,
+    );
   });
 }
 
@@ -6951,10 +6978,10 @@ function restoreChatClipboardPayload({
   }
   const allowedAttachments = visualAttachmentUnsupported
     ? persistedAttachments.filter((attachment) => {
-        return !isVisualAttachment({
-          contentType: attachment.contentType,
-          filename: attachment.filename,
-        });
+        return !shouldExcludeVisualAttachment(
+          visualAttachmentUnsupported,
+          attachment,
+        );
       })
     : persistedAttachments;
   if (
@@ -7004,10 +7031,15 @@ function useComposerVisualAttachmentUnsupported(
   signals: ComposerSignals,
 ): VisualAttachmentUnsupportedState | null {
   const modelSelection = useLastResolved(signals.model.modelSelection$) ?? null;
-  return getVisualAttachmentUnsupportedState({
-    value: modelSelection,
-    onChange: () => {},
-  });
+  const imageRecognitionEnabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition] ?? false;
+  return getVisualAttachmentUnsupportedState(
+    {
+      value: modelSelection,
+      onChange: () => {},
+    },
+    imageRecognitionEnabled,
+  );
 }
 
 function useComposerTemplatePicker(
@@ -7067,7 +7099,13 @@ function useComposerFileUpload(
   const rootSignal = useGet(rootSignal$);
   const { t } = useTranslation();
   return (file) => {
-    if (visualAttachmentUnsupported && isVisualAttachmentFile(file)) {
+    if (
+      visualAttachmentUnsupported &&
+      shouldExcludeVisualAttachment(
+        visualAttachmentUnsupported,
+        visualAttachmentCandidateFromFile(file),
+      )
+    ) {
       showVisualAttachmentUnsupportedToast(visualAttachmentUnsupported);
       return false;
     }
@@ -7301,6 +7339,8 @@ function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
   const setModelSelection = useSet(signals.model.setModelSelection$);
   const configureSelectedModel = useSet(signals.model.configureSelectedModel$);
   const attachments = useGet(signals.draft.attachments$);
+  const imageRecognitionEnabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition] ?? false;
   const pageSignal = useGet(pageSignal$);
   const value = modelSelection.state === "hasData" ? modelSelection.data : null;
   const modelPickerLoading = modelSelection.state === "loading";
@@ -7310,12 +7350,13 @@ function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
         value,
         onChange: onModelPickerChange,
       },
+      imageRecognitionEnabled,
       selection,
     );
     if (
       nextUnsupported &&
       attachments.some((attachment) => {
-        return isVisualAttachment(attachment);
+        return shouldExcludeVisualAttachment(nextUnsupported, attachment);
       })
     ) {
       showVisualAttachmentUnsupportedToast(nextUnsupported);

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -87,8 +87,10 @@ import {
 import { sendMode$ } from "../../signals/send-mode.ts";
 import type { ComposerTemplateAttachment } from "../../signals/zero-page/tiptap-workflow-composer.ts";
 import type { TemplatePreviewRuntime } from "../../signals/zero-page/template-preview-runtime.ts";
-import { shouldExcludeAttachmentForModel } from "../../signals/chat-page/resolve-draft-attachments.ts";
-import { inferUploadContentType } from "../../signals/zero-page/chat-draft.ts";
+import {
+  isVisualAttachment,
+  shouldExcludeVisualAttachmentsForModel,
+} from "../../signals/chat-page/resolve-draft-attachments.ts";
 import type {
   GenerationTemplateRequest,
   PersistedAttachment,
@@ -124,7 +126,6 @@ import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import type { CustomConnectorResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
-import { getModelImageInputSupport } from "@vm0/api-contracts/contracts/model-providers";
 import { getModelDisplayName } from "@vm0/core/model-display-name";
 import {
   ModelProviderPicker,
@@ -315,14 +316,11 @@ function resolveComposerModelForSelection(
 
 interface VisualAttachmentUnsupportedState {
   currentModelName: string;
-  selectedModel: string;
-  imageRecognitionEnabled: boolean;
 }
 
 interface VisualAttachmentCandidate {
   contentType: string;
   filename: string;
-  size: number;
 }
 
 function getVisualAttachmentUnsupportedState(
@@ -332,40 +330,24 @@ function getVisualAttachmentUnsupportedState(
 ): VisualAttachmentUnsupportedState | null {
   const currentModel = resolveComposerModelForSelection(modelPicker, selection);
   if (
-    getModelImageInputSupport(currentModel?.selectedModel) !== "unsupported" ||
-    !currentModel
+    !currentModel ||
+    !shouldExcludeVisualAttachmentsForModel(
+      currentModel.selectedModel,
+      imageRecognitionEnabled,
+    )
   ) {
     return null;
   }
   return {
     currentModelName: getModelDisplayName(currentModel.selectedModel),
-    selectedModel: currentModel.selectedModel,
-    imageRecognitionEnabled,
   };
 }
 
-function visualAttachmentCandidateFromFile(
-  file: File,
-): VisualAttachmentCandidate {
-  return {
-    contentType: inferUploadContentType(file),
+function isVisualAttachmentFile(file: File): boolean {
+  return isVisualAttachment({
+    contentType: file.type,
     filename: file.name,
-    size: file.size,
-  };
-}
-
-function shouldExcludeVisualAttachment(
-  state: VisualAttachmentUnsupportedState | null,
-  attachment: VisualAttachmentCandidate,
-): boolean {
-  return (
-    state !== null &&
-    shouldExcludeAttachmentForModel(
-      attachment,
-      state.selectedModel,
-      state.imageRecognitionEnabled,
-    )
-  );
+  });
 }
 
 function showVisualAttachmentUnsupportedToast(
@@ -392,10 +374,7 @@ function resolveVisibleAttachments<T extends VisualAttachmentCandidate>(
     return attachments;
   }
   return attachments.filter((attachment) => {
-    return !shouldExcludeVisualAttachment(
-      visualAttachmentUnsupported,
-      attachment,
-    );
+    return !isVisualAttachment(attachment);
   });
 }
 
@@ -6979,10 +6958,7 @@ function restoreChatClipboardPayload({
   }
   const allowedAttachments = visualAttachmentUnsupported
     ? persistedAttachments.filter((attachment) => {
-        return !shouldExcludeVisualAttachment(
-          visualAttachmentUnsupported,
-          attachment,
-        );
+        return !isVisualAttachment(attachment);
       })
     : persistedAttachments;
   if (
@@ -7099,13 +7075,7 @@ function useComposerFileUpload(
   const rootSignal = useGet(rootSignal$);
   const { t } = useTranslation();
   return (file) => {
-    if (
-      visualAttachmentUnsupported &&
-      shouldExcludeVisualAttachment(
-        visualAttachmentUnsupported,
-        visualAttachmentCandidateFromFile(file),
-      )
-    ) {
+    if (visualAttachmentUnsupported && isVisualAttachmentFile(file)) {
       showVisualAttachmentUnsupportedToast(visualAttachmentUnsupported);
       return false;
     }
@@ -7355,7 +7325,7 @@ function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
     if (
       nextUnsupported &&
       attachments.some((attachment) => {
-        return shouldExcludeVisualAttachment(nextUnsupported, attachment);
+        return isVisualAttachment(attachment);
       })
     ) {
       showVisualAttachmentUnsupportedToast(nextUnsupported);

--- a/turbo/packages/api-contracts/src/contracts/zero-feature-switches.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-feature-switches.ts
@@ -22,6 +22,11 @@ export const featureSwitchesResponseSchema = z.object({
    * Older API deployments omit this field.
    */
   supportsCustomModelGateways: z.boolean().optional(),
+  /**
+   * Optional capability handshake for managed image recognition.
+   * Older API deployments omit this field.
+   */
+  supportsImageRecognition: z.boolean().optional(),
 });
 
 export type FeatureSwitchesResponse = z.infer<


### PR DESCRIPTION
## Summary

- allow visual attachments to remain ordinary web files for explicitly image-input-unsupported models when the `ZeroImageRecognition` feature switch is effective
- use the same feature-gated decision for upload, paste, drop, restore, model switching, display, new-thread sends, existing-thread sends, and queued sends
- retain the optional API capability handshake so the behavior remains fail-closed across independently deployed API and Platform versions

## Compatibility and exclusions

- the fallback is effective only when both `FeatureSwitchKey.ZeroImageRecognition` and the live API `supportsImageRecognition: true` capability are present
- page startup, a disabled switch, and older API deployments that omit the optional capability continue to exclude visual attachments for explicitly unsupported models
- supported or unknown model behavior is unchanged, and older platforms ignore the additive API response field
- GIFs, videos, empty images, large images, and other visual formats are admitted as files when the fallback is effective; direct `zero recognize` validation remains at command invocation time, where the agent can preprocess files or use other Zero tools
- normal Platform attachment validation and upload limits still apply
- no runner protocol, queue schema, database, persisted-data, CLI, or recognition endpoint changes

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts test` (525 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run --silent=passed-only src/signals/routes/__tests__/zero-feature-switches.test.ts` (1 test)
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run --silent=passed-only src/signals/__tests__/bootstrap-feature-switch.test.ts src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx src/views/zero-page/__tests__/chat-lifecycle.test.tsx src/views/zero-page/__tests__/chat-run-queue.test.tsx` (96 tests)
- post-review `pnpm -F @vm0/app exec vitest run --silent=passed-only src/views/zero-page/__tests__/chat-run-queue.test.tsx` (16 tests)
- `pnpm knip`
- pre-commit hooks, including repository-wide Turbo type checks

Closes #24610
