### PR TITLE
fix(api): terminalize queued admission failures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -28,6 +28,8 @@ import {
   readChatEventContextFixture,
   removeAcknowledgedCancellationLifecycleFixture,
 } from "../../../test-fixtures/chat-events";
+import { upsertOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
+import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { testContext } from "../../../__tests__/test-context";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -3339,6 +3341,167 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
     await expect(
       readThreadTitleFromEvents(actor, first.threadId),
     ).resolves.toBe(beforeTitle);
+  }, 90_000);
+});
+
+describe("CHAT-02: drain-time admission failure", () => {
+  it("terminalizes a queued Web message when credits are lost before drain", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped Web chat actor");
+    }
+    const startedAt = now();
+    mockNow(startedAt);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    mockEnv("CRON_SECRET", CANCELLATION_RECOVERY_CRON_SECRET);
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const anchor = await startChatRun(actor, {
+      agentId,
+      prompt: "finish after queued Web credit loss",
+    });
+    const anchorHeaders = await claimChatRun(runnerGroup, anchor.runId);
+    const queuedEventId = randomUUID();
+    const queuedPrompt = "reject this queued Web message after credit loss";
+    const queued = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: anchor.threadId,
+        prompt: queuedPrompt,
+        clientEventId: queuedEventId,
+      },
+      [201],
+    );
+    if ("error" in queued.body) {
+      throw new Error(queued.body.error.message);
+    }
+    expect(queued.body.runId).toBeNull();
+
+    await seedOrgMetadata({
+      orgId: actor.orgId,
+      tier: "pro-suspend",
+      credits: 0,
+    });
+    await upsertOrgPlanEntitlementFixture({
+      orgId: actor.orgId,
+      status: "suspended",
+      canBuyCredits: true,
+    });
+    context.mocks.ably.publish.mockClear();
+
+    await completeChatRunOk(anchor.runId, anchorHeaders);
+    await flushWaitUntilForTest();
+    const terminal = await waitForThreadMessages(
+      actor,
+      anchor.threadId,
+      (events) => {
+        return (
+          userMessages(events).some((event) => {
+            return (
+              event.eventType === "input.rejected" &&
+              event.revokesEventId === queuedEventId &&
+              event.error === "insufficient_credits"
+            );
+          }) &&
+          assistantMessages(events).some((event) => {
+            return (
+              event.eventType === "output.error" &&
+              event.error === "insufficient_credits"
+            );
+          })
+        );
+      },
+    );
+    const original = userMessages(terminal.events).find((event) => {
+      return event.id === queuedEventId;
+    });
+    expect(original).toMatchObject({
+      eventType: "input.prompt",
+    });
+    expect(original ? chatEventDisplayText(original) : null).toBe(queuedPrompt);
+    const replacements = userMessages(terminal.events).filter((event) => {
+      return event.revokesEventId === queuedEventId;
+    });
+    expect(replacements).toStrictEqual([
+      expect.objectContaining({
+        eventType: "input.rejected",
+        error: "insufficient_credits",
+      }),
+    ]);
+    const errors = assistantMessages(terminal.events).filter((event) => {
+      return (
+        event.eventType === "output.error" &&
+        event.error === "insufficient_credits"
+      );
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.content).toContain("Add credits");
+    expect(errors[0]?.content).toContain("settings=billing");
+    expect(
+      (await api.listAgentRuns(actor, { limit: 20 })).runs.filter((run) => {
+        return run.prompt === queuedPrompt;
+      }),
+    ).toHaveLength(0);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadMessageCreated:${anchor.threadId}`,
+      null,
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
+      null,
+    );
+    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
+      `chatThreadRunCreated:${anchor.threadId}`,
+      null,
+    );
+
+    mockNow(startedAt + CANCELLATION_RECOVERY_STALE_AFTER_MS + 1);
+    await accept(
+      cancellationRecoveryCronClient().reconcile({
+        headers: {
+          authorization: `Bearer ${CANCELLATION_RECOVERY_CRON_SECRET}`,
+        },
+      }),
+      [200],
+    );
+    const retried = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: anchor.threadId,
+        prompt: queuedPrompt,
+        clientEventId: queuedEventId,
+      },
+      [201],
+    );
+    if ("error" in retried.body) {
+      throw new Error(retried.body.error.message);
+    }
+    expect(retried.body.runId).toBeNull();
+    await flushWaitUntilForTest();
+
+    const afterRecovery = await chat.listThreadEvents(actor, anchor.threadId);
+    expect(
+      userMessages(afterRecovery.events).filter((event) => {
+        return event.revokesEventId === queuedEventId;
+      }),
+    ).toHaveLength(1);
+    expect(
+      assistantMessages(afterRecovery.events).filter((event) => {
+        return (
+          event.eventType === "output.error" &&
+          event.error === "insufficient_credits"
+        );
+      }),
+    ).toHaveLength(1);
+    expect(
+      (await api.listAgentRuns(actor, { limit: 20 })).runs.filter((run) => {
+        return run.prompt === queuedPrompt;
+      }),
+    ).toHaveLength(0);
   }, 90_000);
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -1222,10 +1222,23 @@ describe("cron execute morning briefs", () => {
     if (!rejectedBrief) {
       throw new Error("Expected the rejected Morning Brief input event");
     }
+    const replacement = events.find((event) => {
+      return (
+        event.eventType === "input.rejected" &&
+        event.revokesEventId === rejectedBrief.id
+      );
+    });
+    if (
+      !replacement ||
+      replacement.eventType !== "input.rejected" ||
+      !replacement.error
+    ) {
+      throw new Error("Expected the rejected Morning Brief replacement");
+    }
     expect(events).toContainEqual(
       expect.objectContaining({
-        eventType: "control.revoke",
-        revokesEventId: rejectedBrief.id,
+        eventType: "output.error",
+        error: replacement.error,
       }),
     );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -34,6 +34,8 @@ import {
   findPendingChatEventByPromptFixture,
   readChatEventContextFixture,
 } from "../../../test-fixtures/chat-events";
+import { upsertOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
+import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { now } from "../../external/time";
 import { createDeferredPromise } from "../../utils";
@@ -112,6 +114,7 @@ interface CapturedFeishuMessage {
   readonly msgType: "interactive" | "text";
   readonly content: Readonly<Record<string, unknown>>;
   readonly replyInThread: boolean;
+  readonly idempotencyKey?: string;
 }
 
 interface FeishuMessageRequestBody {
@@ -119,6 +122,7 @@ interface FeishuMessageRequestBody {
   readonly msg_type: "interactive" | "text";
   readonly content: string;
   readonly reply_in_thread?: boolean;
+  readonly uuid?: string;
 }
 
 interface FeishuRunFixture {
@@ -414,6 +418,7 @@ describe("Feishu integration", () => {
   let removedReactions: string[];
   let historyMessages: readonly Readonly<Record<string, unknown>>[];
   let failedSendTargets: string[];
+  let failedSendContentFragments: string[];
   let oauthTokenExpiresInSeconds: number;
   let oauthTokenGrantTypes: string[];
   let oauthTokenRedirectUris: string[];
@@ -468,6 +473,7 @@ describe("Feishu integration", () => {
     removedReactions = [];
     historyMessages = [];
     failedSendTargets = [];
+    failedSendContentFragments = [];
     oauthTokenExpiresInSeconds = 7200;
     oauthTokenGrantTypes = [];
     oauthTokenRedirectUris = [];
@@ -547,6 +553,18 @@ describe("Feishu integration", () => {
         "https://open.feishu.cn/open-apis/im/v1/messages",
         async ({ request }) => {
           const body = (await request.json()) as FeishuMessageRequestBody;
+          const failedContentIndex = failedSendContentFragments.findIndex(
+            (fragment) => {
+              return body.content.includes(fragment);
+            },
+          );
+          if (failedContentIndex !== -1) {
+            failedSendContentFragments.splice(failedContentIndex, 1);
+            return HttpResponse.json({
+              code: 1,
+              msg: "temporary message failure",
+            });
+          }
           const failedTargetIndex = failedSendTargets.indexOf(
             body.receive_id ?? "",
           );
@@ -565,6 +583,7 @@ describe("Feishu integration", () => {
               Record<string, unknown>
             >,
             replyInThread: false,
+            ...(body.uuid ? { idempotencyKey: body.uuid } : {}),
           });
           return HttpResponse.json({
             code: 0,
@@ -3013,6 +3032,288 @@ describe("Feishu integration", () => {
       }),
       [200],
     );
+  });
+
+  it("terminalizes and delivers a queued Feishu admission failure exactly once", async () => {
+    const fixture = await setupFeishuRunFixture();
+    const { actor, runnerGroup, appId, callbackUrl, defaultAgentId } = fixture;
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped Feishu actor");
+    }
+    await connectFixtureUser(fixture);
+    context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue({
+      data: [
+        {
+          organization: { id: actor.orgId },
+          role: "org:admin",
+        },
+      ],
+    });
+
+    const firstPrompt = "finish before queued Feishu credit loss";
+    const firstMessageId = `om_${randomUUID()}`;
+    await postEvent(
+      callbackUrl,
+      directMessage(appId, firstPrompt, "ou_feishu_user", {
+        messageId: firstMessageId,
+      }),
+      { encrypted: true },
+    );
+    await flushWaitUntilForTest();
+    const firstRun = await findRun(actor, firstPrompt);
+    await runsApi.heartbeatRunner(runnerGroup);
+    const firstClaim = await runsApi.claimRunnerJob(firstRun.id);
+
+    const queuedPrompt = "reject this queued Feishu message after credit loss";
+    const queuedMessageId = `om_${randomUUID()}`;
+    const queuedPayload = directMessage(appId, queuedPrompt, "ou_feishu_user", {
+      messageId: queuedMessageId,
+    });
+    await postEvent(callbackUrl, queuedPayload, { encrypted: true });
+    await flushWaitUntilForTest();
+    const queuedEvent = await findPendingChatEventByPromptFixture(queuedPrompt);
+    if (!queuedEvent) {
+      throw new Error("Expected the queued Feishu input event");
+    }
+    expect(
+      (await runsApi.listAgentRuns(actor, { limit: 20 })).runs.filter((run) => {
+        return run.prompt === queuedPrompt;
+      }),
+    ).toHaveLength(0);
+
+    await seedOrgMetadata({
+      orgId: actor.orgId,
+      tier: "pro-suspend",
+      credits: 0,
+    });
+    await upsertOrgPlanEntitlementFixture({
+      orgId: actor.orgId,
+      status: "suspended",
+      canBuyCredits: true,
+    });
+    outboundMessages = [];
+    context.mocks.ably.publish.mockClear();
+    await completeRunSession({
+      runId: firstRun.id,
+      sandboxToken: firstClaim.sandboxToken,
+      sessionId: `bdd-feishu-admission-${firstRun.id}`,
+      history: `bdd Feishu admission history ${firstRun.id}`,
+      assistantText: "First Feishu task completed",
+    });
+
+    mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const threadEvents = await accept(
+      setupApp({ context })(chatThreadsContract).events({
+        headers: { authorization: "Bearer clerk-session" },
+        query: {},
+      }),
+      [200],
+    );
+    const thread = requireValue(
+      threadEvents.body.events.find((event) => {
+        return event.kind === "created" && event.agentId === defaultAgentId;
+      }),
+      "Expected the queued Feishu chat thread",
+    );
+    const messages = await accept(
+      setupApp({ context })(chatThreadEventsContract).list({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { threadId: thread.chatThreadId },
+        query: {},
+      }),
+      [200],
+    );
+    const original = messages.body.events.find((event) => {
+      return event.id === queuedEvent.eventId;
+    });
+    if (!original || original.eventType !== "input.prompt") {
+      throw new Error("Expected the original queued Feishu prompt");
+    }
+    expect(original.runId).toBeUndefined();
+    expect(original.userMessage.parts).toContainEqual({
+      type: "text",
+      text: queuedPrompt,
+    });
+    const replacements = messages.body.events.filter((event) => {
+      return event.revokesEventId === queuedEvent.eventId;
+    });
+    expect(replacements).toStrictEqual([
+      expect.objectContaining({
+        eventType: "input.rejected",
+        error: "insufficient_credits",
+      }),
+    ]);
+    const errors = messages.body.events.filter((event) => {
+      return (
+        event.eventType === "output.error" &&
+        event.error === "insufficient_credits"
+      );
+    });
+    expect(errors).toHaveLength(1);
+    const errorEvent = requireValue(
+      errors[0],
+      "Expected the queued Feishu output error",
+    );
+    expect(errorEvent.content).toContain("Add credits");
+    const deliveredErrors = outboundMessages.filter((message) => {
+      return messageContent(message).includes("Add credits");
+    });
+    expect(deliveredErrors).toStrictEqual([
+      expect.objectContaining({
+        kind: "send",
+        target: "oc_feishu_dm",
+        idempotencyKey: errorEvent.id,
+      }),
+    ]);
+    expect(
+      removedReactions.filter((messageId) => {
+        return messageId === queuedMessageId;
+      }),
+    ).toHaveLength(1);
+    expect(
+      (await runsApi.listAgentRuns(actor, { limit: 20 })).runs.filter((run) => {
+        return run.prompt === queuedPrompt;
+      }),
+    ).toHaveLength(0);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadMessageCreated:${thread.chatThreadId}`,
+      null,
+    );
+    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
+      `chatThreadRunCreated:${thread.chatThreadId}`,
+      null,
+    );
+
+    await postEvent(callbackUrl, queuedPayload, { encrypted: true });
+    await flushWaitUntilForTest();
+    expect(
+      outboundMessages.filter((message) => {
+        return messageContent(message).includes("Add credits");
+      }),
+    ).toHaveLength(1);
+    const afterReplay = await accept(
+      setupApp({ context })(chatThreadEventsContract).list({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { threadId: thread.chatThreadId },
+        query: {},
+      }),
+      [200],
+    );
+    expect(
+      afterReplay.body.events.filter((event) => {
+        return event.revokesEventId === queuedEvent.eventId;
+      }),
+    ).toHaveLength(1);
+    expect(
+      afterReplay.body.events.filter((event) => {
+        return (
+          event.eventType === "output.error" &&
+          event.error === "insufficient_credits"
+        );
+      }),
+    ).toHaveLength(1);
+
+    await seedOrgMetadata({
+      orgId: actor.orgId,
+      tier: "pro",
+      credits: 20_000,
+    });
+    await upsertOrgPlanEntitlementFixture({
+      orgId: actor.orgId,
+      status: "active",
+      canBuyCredits: true,
+    });
+    const failedDeliveryAnchorPrompt =
+      "finish before queued Feishu delivery failure";
+    await postEvent(
+      callbackUrl,
+      directMessage(appId, failedDeliveryAnchorPrompt, "ou_feishu_user", {
+        messageId: `om_${randomUUID()}`,
+      }),
+      { encrypted: true },
+    );
+    await flushWaitUntilForTest();
+    const failedDeliveryAnchor = await findRun(
+      actor,
+      failedDeliveryAnchorPrompt,
+    );
+    await runsApi.heartbeatRunner(runnerGroup);
+    const failedDeliveryAnchorClaim = await runsApi.claimRunnerJob(
+      failedDeliveryAnchor.id,
+    );
+
+    const failedDeliveryPrompt =
+      "persist this queued Feishu failure before delivery fails";
+    const failedDeliveryMessageId = `om_${randomUUID()}`;
+    await postEvent(
+      callbackUrl,
+      directMessage(appId, failedDeliveryPrompt, "ou_feishu_user", {
+        messageId: failedDeliveryMessageId,
+      }),
+      { encrypted: true },
+    );
+    await flushWaitUntilForTest();
+    const failedDeliveryEvent =
+      await findPendingChatEventByPromptFixture(failedDeliveryPrompt);
+    if (!failedDeliveryEvent) {
+      throw new Error("Expected the failed-delivery Feishu input event");
+    }
+    await seedOrgMetadata({
+      orgId: actor.orgId,
+      tier: "pro-suspend",
+      credits: 0,
+    });
+    await upsertOrgPlanEntitlementFixture({
+      orgId: actor.orgId,
+      status: "suspended",
+      canBuyCredits: true,
+    });
+    outboundMessages = [];
+    failedSendContentFragments.push("Add credits");
+    await completeRunSession({
+      runId: failedDeliveryAnchor.id,
+      sandboxToken: failedDeliveryAnchorClaim.sandboxToken,
+      sessionId: `bdd-feishu-delivery-failure-${failedDeliveryAnchor.id}`,
+      history: `bdd Feishu delivery failure history ${failedDeliveryAnchor.id}`,
+      assistantText: "Second Feishu task completed",
+    });
+
+    const afterDeliveryFailure = await accept(
+      setupApp({ context })(chatThreadEventsContract).list({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { threadId: thread.chatThreadId },
+        query: {},
+      }),
+      [200],
+    );
+    expect(
+      afterDeliveryFailure.body.events.filter((event) => {
+        return (
+          event.eventType === "input.rejected" &&
+          event.revokesEventId === failedDeliveryEvent.eventId &&
+          event.error === "insufficient_credits"
+        );
+      }),
+    ).toHaveLength(1);
+    expect(
+      afterDeliveryFailure.body.events.filter((event) => {
+        return (
+          event.eventType === "output.error" &&
+          event.error === "insufficient_credits"
+        );
+      }),
+    ).toHaveLength(2);
+    expect(
+      (await runsApi.listAgentRuns(actor, { limit: 20 })).runs.filter((run) => {
+        return run.prompt === failedDeliveryPrompt;
+      }),
+    ).toHaveLength(0);
+    expect(
+      removedReactions.filter((messageId) => {
+        return messageId === failedDeliveryMessageId;
+      }),
+    ).toHaveLength(1);
+    expect(failedSendContentFragments).toHaveLength(0);
   });
 
   it("keeps Feishu group control cases out of runs and resumes queued tasks through the canonical session", async () => {

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -7,7 +7,6 @@ import {
   type ChatEventType,
 } from "@vm0/api-contracts/contracts/chat-events";
 import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
-import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import { modelProviderCredentialScopeSchema } from "@vm0/api-contracts/contracts/model-providers";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -83,6 +82,7 @@ import {
 } from "./internal-slack-chat-run-callback.service";
 import {
   clearCanonicalFeishuThinkingReaction,
+  deliverFeishuChatAdmissionFailure,
   dispatchFeishuChatDeliveryOnce,
 } from "./internal-feishu-chat-run-callback.service";
 import {
@@ -141,7 +141,6 @@ import {
 } from "./assistant-event-id";
 import { attachCanonicalPublishedAssetsToCompletionEvent } from "./canonical-published-asset-event.service";
 import {
-  discardUnclaimedUserMessageInTransaction,
   failQueuedUserMessage,
   loadNextUnclaimedQueuedUserMessage,
   resolveAttachFileMetadata$,
@@ -512,6 +511,16 @@ interface ChatCallbackDependencies {
     callbackId: string,
     signal: AbortSignal,
   ) => Promise<void>;
+  readonly deliverFeishuAdmissionFailure: (
+    args: {
+      readonly chatThreadId: string;
+      readonly userId: string;
+      readonly orgId: string;
+      readonly target: FeishuDeliveryTarget;
+      readonly chatEventId: string;
+    },
+    signal: AbortSignal,
+  ) => Promise<void>;
   readonly clearFeishuThinkingReaction: (
     target: FeishuDeliveryTarget,
     signal: AbortSignal,
@@ -667,6 +676,25 @@ interface SlackQueuedMessageAdmissionFailure {
   readonly error: QueuedMessageModelRouteError;
 }
 
+interface WebQueuedMessageAdmissionFailure {
+  readonly kind: "web_admission_failure";
+  readonly orgId: string;
+  readonly userId: string;
+  readonly threadId: string;
+  readonly queuedMessage: QueuedUserMessage;
+  readonly error: QueuedMessageModelRouteError;
+}
+
+interface FeishuQueuedMessageAdmissionFailure {
+  readonly kind: "feishu_admission_failure";
+  readonly orgId: string;
+  readonly userId: string;
+  readonly threadId: string;
+  readonly queuedMessage: QueuedUserMessage;
+  readonly feishuDelivery: FeishuDeliveryTarget;
+  readonly error: QueuedMessageModelRouteError;
+}
+
 interface TeamsQueuedMessageAdmissionFailure {
   readonly kind: "teams_admission_failure";
   readonly orgId: string;
@@ -680,9 +708,11 @@ interface TeamsQueuedMessageAdmissionFailure {
 
 interface MorningBriefQueuedMessageAdmissionFailure {
   readonly kind: "morning_brief_admission_failure";
+  readonly orgId: string;
+  readonly userId: string;
   readonly threadId: string;
   readonly queuedMessage: QueuedUserMessage;
-  readonly morningBriefDelivery?: NonNullable<
+  readonly morningBriefDelivery: NonNullable<
     CreateQueuedChatRunInput["morningBriefDelivery"]
   >;
   readonly error: QueuedMessageModelRouteError;
@@ -722,7 +752,9 @@ interface GitHubQueuedMessageAdmissionFailure {
 }
 
 type QueuedMessageAdmissionFailure =
+  | WebQueuedMessageAdmissionFailure
   | SlackQueuedMessageAdmissionFailure
+  | FeishuQueuedMessageAdmissionFailure
   | TeamsQueuedMessageAdmissionFailure
   | TelegramQueuedMessageAdmissionFailure
   | AgentPhoneQueuedMessageAdmissionFailure
@@ -2602,17 +2634,9 @@ async function resolveQueuedMessageModelRoute(args: {
         return unpinnedRoute;
       }
     }
-    log.warn("Auto-send aborted: current model route is unavailable", {
-      threadId: args.threadId,
-      error: modelContext.body.error.message,
-    });
     return { error: modelContext.body.error };
   }
   if (modelContext.providerAdmission.error) {
-    log.warn("Auto-send aborted: current model route was not admitted", {
-      threadId: args.threadId,
-      error: modelContext.providerAdmission.error.body.error.message,
-    });
     return { error: modelContext.providerAdmission.error.body.error };
   }
   return {
@@ -2749,22 +2773,50 @@ function launchLoader<Material extends NativeQueuedLaunchMaterial>(
 async function resolveQueuedLaunchMaterial(
   args: CreateQueuedChatRunInputArgs,
 ): Promise<QueuedLaunchMaterial | null> {
-  const launchLoaders: Partial<Record<TriggerSource, LaunchLoader>> = {
-    slack: launchLoader(loadSlackQueuedLaunchMaterial, (material) => {
-      return { slackDelivery: material.slackDelivery };
-    }),
-    feishu: launchLoader(loadFeishuQueuedLaunchMaterial, (material) => {
-      return { feishuDelivery: material.feishuDelivery };
-    }),
-    teams: launchLoader(loadTeamsQueuedLaunchMaterial, (material) => {
-      return { teamsDelivery: material.teamsDelivery };
-    }),
-    github: launchLoader(loadGitHubQueuedLaunchMaterial, (material) => {
-      return { githubDelivery: material.githubDelivery };
-    }),
-    "workflow-schedule": launchLoader(
-      loadMorningBriefQueuedLaunchMaterial,
-      (material) => {
+  const triggerSource = args.queuedMessage.triggerSource;
+  let load: LaunchLoader;
+  switch (triggerSource) {
+    case "web": {
+      return null;
+    }
+    case "slack": {
+      load = launchLoader(loadSlackQueuedLaunchMaterial, (material) => {
+        return { slackDelivery: material.slackDelivery };
+      });
+      break;
+    }
+    case "feishu": {
+      load = launchLoader(loadFeishuQueuedLaunchMaterial, (material) => {
+        return { feishuDelivery: material.feishuDelivery };
+      });
+      break;
+    }
+    case "teams": {
+      load = launchLoader(loadTeamsQueuedLaunchMaterial, (material) => {
+        return { teamsDelivery: material.teamsDelivery };
+      });
+      break;
+    }
+    case "telegram": {
+      load = launchLoader(loadTelegramQueuedLaunchMaterial, (material) => {
+        return { telegramDelivery: material.telegramDelivery };
+      });
+      break;
+    }
+    case "agentphone": {
+      load = launchLoader(loadAgentPhoneQueuedLaunchMaterial, (material) => {
+        return { agentphoneDelivery: material.agentphoneDelivery };
+      });
+      break;
+    }
+    case "github": {
+      load = launchLoader(loadGitHubQueuedLaunchMaterial, (material) => {
+        return { githubDelivery: material.githubDelivery };
+      });
+      break;
+    }
+    case "workflow-schedule": {
+      load = launchLoader(loadMorningBriefQueuedLaunchMaterial, (material) => {
         return {
           morningBriefDelivery: {
             deliveryId: material.deliveryId,
@@ -2773,18 +2825,12 @@ async function resolveQueuedLaunchMaterial(
             payload: { deliveryId: material.deliveryId },
           },
         };
-      },
-    ),
-    agentphone: launchLoader(loadAgentPhoneQueuedLaunchMaterial, (material) => {
-      return { agentphoneDelivery: material.agentphoneDelivery };
-    }),
-    telegram: launchLoader(loadTelegramQueuedLaunchMaterial, (material) => {
-      return { telegramDelivery: material.telegramDelivery };
-    }),
-  };
-  const load = launchLoaders[args.queuedMessage.triggerSource];
-  if (!load) {
-    return null;
+      });
+      break;
+    }
+    default: {
+      return unreachableQueuedTriggerSource(triggerSource);
+    }
   }
   const material = await load(args.db, {
     eventId: args.queuedMessage.id,
@@ -2798,9 +2844,7 @@ async function resolveQueuedLaunchMaterial(
   if (material) {
     return material;
   }
-  throw new Error(
-    `${args.queuedMessage.triggerSource} queue item is missing launch material`,
-  );
+  throw new Error(`${triggerSource} queue item is missing launch material`);
 }
 
 function queuedIntegrationDeliveries(
@@ -2809,189 +2853,115 @@ function queuedIntegrationDeliveries(
   return launchMaterial?.delivery ?? {};
 }
 
-interface QueuedAdmissionFailureResolverArgs {
-  readonly args: CreateQueuedChatRunInputArgs;
-  readonly launchMaterial: QueuedLaunchMaterial | null;
-  readonly error: QueuedMessageModelRouteError;
+function unreachableQueuedTriggerSource(triggerSource: never): never {
+  throw new Error(
+    `Unsupported queued trigger source: ${String(triggerSource)}`,
+  );
 }
 
-type QueuedAdmissionFailureResolver = (
-  args: QueuedAdmissionFailureResolverArgs,
-) => QueuedMessageAdmissionFailure | null;
-
-function slackQueuedMessageAdmissionFailure(
-  args: CreateQueuedChatRunInputArgs,
-  slackDelivery: CreateQueuedChatRunInput["slackDelivery"],
-  error: QueuedMessageModelRouteError,
-): SlackQueuedMessageAdmissionFailure | null {
-  if (args.queuedMessage.triggerSource !== "slack" || !slackDelivery) {
-    return null;
+function requiredQueuedDelivery<Delivery>(
+  delivery: Delivery | undefined,
+  triggerSource: QueuedUserMessage["triggerSource"],
+): Delivery {
+  if (!delivery) {
+    throw new Error(`${triggerSource} queue item is missing delivery material`);
   }
-  return {
-    kind: "slack_admission_failure",
-    orgId: args.agent.orgId,
-    userId: args.userId,
-    agentId: args.agent.id,
-    threadId: args.threadId,
-    queuedMessage: args.queuedMessage,
-    slackDelivery,
-    error,
-  };
-}
-
-function teamsQueuedMessageAdmissionFailure(
-  args: CreateQueuedChatRunInputArgs,
-  teamsDelivery: CreateQueuedChatRunInput["teamsDelivery"],
-  error: QueuedMessageModelRouteError,
-): TeamsQueuedMessageAdmissionFailure | null {
-  if (args.queuedMessage.triggerSource !== "teams" || !teamsDelivery) {
-    return null;
-  }
-  return {
-    kind: "teams_admission_failure",
-    orgId: args.agent.orgId,
-    userId: args.userId,
-    agentId: args.agent.id,
-    threadId: args.threadId,
-    queuedMessage: args.queuedMessage,
-    teamsDelivery,
-    error,
-  };
-}
-
-function morningBriefQueuedMessageAdmissionFailure(
-  args: CreateQueuedChatRunInputArgs,
-  launchMaterial: QueuedLaunchMaterial | null,
-  error: QueuedMessageModelRouteError,
-): MorningBriefQueuedMessageAdmissionFailure | null {
-  if (args.queuedMessage.triggerSource !== "workflow-schedule") {
-    return null;
-  }
-  return {
-    kind: "morning_brief_admission_failure",
-    threadId: args.threadId,
-    queuedMessage: args.queuedMessage,
-    morningBriefDelivery: launchMaterial?.delivery.morningBriefDelivery,
-    error,
-  };
-}
-
-function telegramQueuedMessageAdmissionFailure(
-  args: CreateQueuedChatRunInputArgs,
-  telegramDelivery: CreateQueuedChatRunInput["telegramDelivery"],
-  error: QueuedMessageModelRouteError,
-): TelegramQueuedMessageAdmissionFailure | null {
-  if (args.queuedMessage.triggerSource !== "telegram" || !telegramDelivery) {
-    return null;
-  }
-  return {
-    kind: "telegram_admission_failure",
-    orgId: args.agent.orgId,
-    userId: args.userId,
-    agentId: args.agent.id,
-    threadId: args.threadId,
-    queuedMessage: args.queuedMessage,
-    telegramDelivery,
-    error,
-  };
-}
-
-function agentPhoneQueuedMessageAdmissionFailure(
-  args: CreateQueuedChatRunInputArgs,
-  agentphoneDelivery: CreateQueuedChatRunInput["agentphoneDelivery"],
-  error: QueuedMessageModelRouteError,
-): AgentPhoneQueuedMessageAdmissionFailure | null {
-  if (
-    args.queuedMessage.triggerSource !== "agentphone" ||
-    !agentphoneDelivery
-  ) {
-    return null;
-  }
-  return {
-    kind: "agentphone_admission_failure",
-    orgId: args.agent.orgId,
-    userId: args.userId,
-    agentId: args.agent.id,
-    threadId: args.threadId,
-    queuedMessage: args.queuedMessage,
-    agentphoneDelivery,
-    error,
-  };
-}
-
-function githubQueuedMessageAdmissionFailure(
-  args: CreateQueuedChatRunInputArgs,
-  githubDelivery: CreateQueuedChatRunInput["githubDelivery"],
-  error: QueuedMessageModelRouteError,
-): GitHubQueuedMessageAdmissionFailure | null {
-  if (args.queuedMessage.triggerSource !== "github" || !githubDelivery) {
-    return null;
-  }
-  return {
-    kind: "github_admission_failure",
-    orgId: args.agent.orgId,
-    userId: args.userId,
-    agentId: args.agent.id,
-    threadId: args.threadId,
-    queuedMessage: args.queuedMessage,
-    githubDelivery,
-    error,
-  };
+  return delivery;
 }
 
 function queuedMessageAdmissionFailure(
   args: CreateQueuedChatRunInputArgs,
   launchMaterial: QueuedLaunchMaterial | null,
   error: QueuedMessageModelRouteError,
-): QueuedMessageAdmissionFailure | null {
-  const admissionFailureResolvers: Partial<
-    Record<TriggerSource, QueuedAdmissionFailureResolver>
-  > = {
-    slack: (resolverArgs) => {
-      return slackQueuedMessageAdmissionFailure(
-        resolverArgs.args,
-        resolverArgs.launchMaterial?.delivery.slackDelivery,
-        resolverArgs.error,
-      );
-    },
-    teams: (resolverArgs) => {
-      return teamsQueuedMessageAdmissionFailure(
-        resolverArgs.args,
-        resolverArgs.launchMaterial?.delivery.teamsDelivery,
-        resolverArgs.error,
-      );
-    },
-    telegram: (resolverArgs) => {
-      return telegramQueuedMessageAdmissionFailure(
-        resolverArgs.args,
-        resolverArgs.launchMaterial?.delivery.telegramDelivery,
-        resolverArgs.error,
-      );
-    },
-    agentphone: (resolverArgs) => {
-      return agentPhoneQueuedMessageAdmissionFailure(
-        resolverArgs.args,
-        resolverArgs.launchMaterial?.delivery.agentphoneDelivery,
-        resolverArgs.error,
-      );
-    },
-    github: (resolverArgs) => {
-      return githubQueuedMessageAdmissionFailure(
-        resolverArgs.args,
-        resolverArgs.launchMaterial?.delivery.githubDelivery,
-        resolverArgs.error,
-      );
-    },
-    "workflow-schedule": (resolverArgs) => {
-      return morningBriefQueuedMessageAdmissionFailure(
-        resolverArgs.args,
-        resolverArgs.launchMaterial,
-        resolverArgs.error,
-      );
-    },
+): QueuedMessageAdmissionFailure {
+  const common = {
+    orgId: args.agent.orgId,
+    userId: args.userId,
+    agentId: args.agent.id,
+    threadId: args.threadId,
+    queuedMessage: args.queuedMessage,
+    error,
   };
-  const resolve = admissionFailureResolvers[args.queuedMessage.triggerSource];
-  return resolve?.({ args, launchMaterial, error }) ?? null;
+  const triggerSource = args.queuedMessage.triggerSource;
+  switch (triggerSource) {
+    case "web": {
+      return { kind: "web_admission_failure", ...common };
+    }
+    case "slack": {
+      return {
+        kind: "slack_admission_failure",
+        ...common,
+        slackDelivery: requiredQueuedDelivery(
+          launchMaterial?.delivery.slackDelivery,
+          triggerSource,
+        ),
+      };
+    }
+    case "feishu": {
+      return {
+        kind: "feishu_admission_failure",
+        ...common,
+        feishuDelivery: requiredQueuedDelivery(
+          launchMaterial?.delivery.feishuDelivery,
+          triggerSource,
+        ),
+      };
+    }
+    case "teams": {
+      return {
+        kind: "teams_admission_failure",
+        ...common,
+        teamsDelivery: requiredQueuedDelivery(
+          launchMaterial?.delivery.teamsDelivery,
+          triggerSource,
+        ),
+      };
+    }
+    case "telegram": {
+      return {
+        kind: "telegram_admission_failure",
+        ...common,
+        telegramDelivery: requiredQueuedDelivery(
+          launchMaterial?.delivery.telegramDelivery,
+          triggerSource,
+        ),
+      };
+    }
+    case "agentphone": {
+      return {
+        kind: "agentphone_admission_failure",
+        ...common,
+        agentphoneDelivery: requiredQueuedDelivery(
+          launchMaterial?.delivery.agentphoneDelivery,
+          triggerSource,
+        ),
+      };
+    }
+    case "github": {
+      return {
+        kind: "github_admission_failure",
+        ...common,
+        githubDelivery: requiredQueuedDelivery(
+          launchMaterial?.delivery.githubDelivery,
+          triggerSource,
+        ),
+      };
+    }
+    case "workflow-schedule": {
+      return {
+        kind: "morning_brief_admission_failure",
+        ...common,
+        morningBriefDelivery: requiredQueuedDelivery(
+          launchMaterial?.delivery.morningBriefDelivery,
+          triggerSource,
+        ),
+        error,
+      };
+    }
+    default: {
+      return unreachableQueuedTriggerSource(triggerSource);
+    }
+  }
 }
 
 function queuedMessagePrompt(args: {
@@ -3062,7 +3032,7 @@ function queuedIntegrationLaunchFields(
 
 async function buildCreateQueuedChatRunInput(
   args: CreateQueuedChatRunInputArgs,
-): Promise<CreateQueuedChatRunInput | QueuedMessageAdmissionFailure | null> {
+): Promise<CreateQueuedChatRunInput | QueuedMessageAdmissionFailure> {
   const launchMaterial = await loadQueuedRunMaterial(args);
   const modelRouteResolution = await resolveQueuedMessageModelRoute({
     db: args.db,
@@ -3262,6 +3232,127 @@ async function publishAutoSentQueuedRunSignals(args: {
   );
 }
 
+function recordQueuedMessageAdmissionFailure(
+  failure: QueuedMessageAdmissionFailure,
+): void {
+  const fields = {
+    threadId: failure.threadId,
+    userMessageId: failure.queuedMessage.id,
+    triggerSource: failure.queuedMessage.triggerSource,
+    code: failure.error.code,
+  };
+  if (failure.error.code === "INSUFFICIENT_CREDITS") {
+    log.debug("Queued message rejected by current model admission", fields);
+    return;
+  }
+  log.warn("Queued message rejected because the model route is unavailable", {
+    ...fields,
+    error: failure.error.message,
+  });
+}
+
+async function handleWebQueuedMessageAdmissionFailure(args: {
+  readonly db: Db;
+  readonly failure: WebQueuedMessageAdmissionFailure;
+  readonly signal: AbortSignal;
+  readonly formatError: ChatCallbackDependencies["formatIntegrationRunError"];
+}): Promise<void> {
+  const displayError = await args.formatError(
+    {
+      orgId: args.failure.orgId,
+      userId: args.failure.userId,
+      code: args.failure.error.code,
+      message: args.failure.error.message,
+    },
+    args.signal,
+  );
+  args.signal.throwIfAborted();
+  const failed = await failQueuedUserMessage(args.db, {
+    threadId: args.failure.threadId,
+    eventId: args.failure.queuedMessage.id,
+    assistantContent: displayError,
+    errorMarker: args.failure.error.code.toLowerCase(),
+    currentTime: nowDate(),
+  });
+  args.signal.throwIfAborted();
+  if (!failed) {
+    return;
+  }
+
+  recordQueuedMessageAdmissionFailure(args.failure);
+  await publishUserSignal(
+    [args.failure.userId],
+    `chatThreadMessageCreated:${args.failure.threadId}`,
+  );
+  await publishThreadListChanged(args.failure.userId);
+}
+
+async function handleFeishuQueuedMessageAdmissionFailure(args: {
+  readonly db: Db;
+  readonly failure: FeishuQueuedMessageAdmissionFailure;
+  readonly signal: AbortSignal;
+  readonly formatError: ChatCallbackDependencies["formatIntegrationRunError"];
+  readonly deliver: ChatCallbackDependencies["deliverFeishuAdmissionFailure"];
+  readonly clearThinking: ChatCallbackDependencies["clearFeishuThinkingReaction"];
+}): Promise<void> {
+  const displayError = await args.formatError(
+    {
+      orgId: args.failure.orgId,
+      userId: args.failure.userId,
+      code: args.failure.error.code,
+      message: args.failure.error.message,
+    },
+    args.signal,
+  );
+  args.signal.throwIfAborted();
+  const failed = await failQueuedUserMessage(args.db, {
+    threadId: args.failure.threadId,
+    eventId: args.failure.queuedMessage.id,
+    assistantContent: displayError,
+    errorMarker: args.failure.error.code.toLowerCase(),
+    currentTime: nowDate(),
+  });
+  args.signal.throwIfAborted();
+  if (!failed) {
+    return;
+  }
+
+  recordQueuedMessageAdmissionFailure(args.failure);
+  await publishUserSignal(
+    [args.failure.userId],
+    `chatThreadMessageCreated:${args.failure.threadId}`,
+  );
+  await publishThreadListChanged(args.failure.userId);
+  args.signal.throwIfAborted();
+  await tapError(
+    args.deliver(
+      {
+        chatThreadId: args.failure.threadId,
+        userId: args.failure.userId,
+        orgId: args.failure.orgId,
+        target: args.failure.feishuDelivery,
+        chatEventId: failed.assistantEventId,
+      },
+      args.signal,
+    ),
+    (error) => {
+      log.warn("Failed to deliver canonical Feishu admission error", {
+        threadId: args.failure.threadId,
+        error,
+      });
+    },
+  );
+  await tapError(
+    args.clearThinking(args.failure.feishuDelivery, args.signal),
+    (error) => {
+      log.warn("Failed to clear Feishu admission thinking reaction", {
+        threadId: args.failure.threadId,
+        error,
+      });
+    },
+  );
+}
+
 async function handleSlackQueuedMessageAdmissionFailure(args: {
   readonly db: Db;
   readonly failure: SlackQueuedMessageAdmissionFailure;
@@ -3291,6 +3382,7 @@ async function handleSlackQueuedMessageAdmissionFailure(args: {
     return;
   }
 
+  recordQueuedMessageAdmissionFailure(args.failure);
   await publishUserSignal(
     [args.failure.userId],
     `chatThreadMessageCreated:${args.failure.threadId}`,
@@ -3351,6 +3443,7 @@ async function handleTeamsQueuedMessageAdmissionFailure(args: {
     return;
   }
 
+  recordQueuedMessageAdmissionFailure(args.failure);
   await publishUserSignal(
     [args.failure.userId],
     `chatThreadMessageCreated:${args.failure.threadId}`,
@@ -3407,6 +3500,7 @@ async function handleTelegramQueuedMessageAdmissionFailure(args: {
     return;
   }
 
+  recordQueuedMessageAdmissionFailure(args.failure);
   await publishUserSignal(
     [args.failure.userId],
     `chatThreadMessageCreated:${args.failure.threadId}`,
@@ -3463,6 +3557,7 @@ async function handleAgentPhoneQueuedMessageAdmissionFailure(args: {
     return;
   }
 
+  recordQueuedMessageAdmissionFailure(args.failure);
   await publishUserSignal(
     [args.failure.userId],
     `chatThreadMessageCreated:${args.failure.threadId}`,
@@ -3519,6 +3614,7 @@ async function handleGitHubQueuedMessageAdmissionFailure(args: {
     return;
   }
 
+  recordQueuedMessageAdmissionFailure(args.failure);
   await publishUserSignal(
     [args.failure.userId],
     `chatThreadMessageCreated:${args.failure.threadId}`,
@@ -3546,94 +3642,163 @@ async function handleGitHubQueuedMessageAdmissionFailure(args: {
   );
 }
 
+async function handleMorningBriefQueuedMessageAdmissionFailure(args: {
+  readonly db: Db;
+  readonly failure: MorningBriefQueuedMessageAdmissionFailure;
+  readonly signal: AbortSignal;
+  readonly formatError: ChatCallbackDependencies["formatIntegrationRunError"];
+}): Promise<void> {
+  const displayError = await args.formatError(
+    {
+      orgId: args.failure.orgId,
+      userId: args.failure.userId,
+      code: args.failure.error.code,
+      message: args.failure.error.message,
+    },
+    args.signal,
+  );
+  args.signal.throwIfAborted();
+  const failed = await failQueuedUserMessage(args.db, {
+    threadId: args.failure.threadId,
+    eventId: args.failure.queuedMessage.id,
+    assistantContent: displayError,
+    errorMarker: args.failure.error.code.toLowerCase(),
+    currentTime: nowDate(),
+  });
+  args.signal.throwIfAborted();
+  if (!failed) {
+    return;
+  }
+
+  const [delivery] = await args.db
+    .update(morningBriefDeliveries)
+    .set({
+      status: "failed",
+      error: args.failure.error.message,
+      updatedAt: nowDate(),
+    })
+    .where(
+      eq(
+        morningBriefDeliveries.id,
+        args.failure.morningBriefDelivery.deliveryId,
+      ),
+    )
+    .returning({ id: morningBriefDeliveries.id });
+  args.signal.throwIfAborted();
+  if (!delivery) {
+    throw new Error("Failed to record Morning Brief admission failure");
+  }
+
+  recordQueuedMessageAdmissionFailure(args.failure);
+  await publishUserSignal(
+    [args.failure.userId],
+    `chatThreadMessageCreated:${args.failure.threadId}`,
+  );
+  await publishThreadListChanged(args.failure.userId);
+}
+
 async function handleQueuedMessageAdmissionFailure(args: {
   readonly db: Db;
   readonly failure: QueuedMessageAdmissionFailure;
   readonly signal: AbortSignal;
   readonly formatError: ChatCallbackDependencies["formatIntegrationRunError"];
   readonly deliverSlack: ChatCallbackDependencies["deliverSlackAdmissionFailure"];
+  readonly deliverFeishu: ChatCallbackDependencies["deliverFeishuAdmissionFailure"];
+  readonly clearFeishuThinking: ChatCallbackDependencies["clearFeishuThinkingReaction"];
   readonly deliverTeams: ChatCallbackDependencies["deliverTeamsAdmissionFailure"];
   readonly deliverTelegram: ChatCallbackDependencies["deliverTelegramAdmissionFailure"];
   readonly deliverAgentPhone: ChatCallbackDependencies["deliverAgentPhoneAdmissionFailure"];
   readonly deliverGitHub: ChatCallbackDependencies["deliverGitHubAdmissionFailure"];
-  readonly continueDrain: () => Promise<void>;
 }): Promise<void> {
-  if (args.failure.kind === "slack_admission_failure") {
-    await handleSlackQueuedMessageAdmissionFailure({
-      db: args.db,
-      failure: args.failure,
-      signal: args.signal,
-      formatError: args.formatError,
-      deliver: args.deliverSlack,
-    });
-    return;
-  }
-  if (args.failure.kind === "telegram_admission_failure") {
-    await handleTelegramQueuedMessageAdmissionFailure({
-      db: args.db,
-      failure: args.failure,
-      signal: args.signal,
-      formatError: args.formatError,
-      deliver: args.deliverTelegram,
-    });
-    return;
-  }
-  if (args.failure.kind === "github_admission_failure") {
-    await handleGitHubQueuedMessageAdmissionFailure({
-      db: args.db,
-      failure: args.failure,
-      signal: args.signal,
-      formatError: args.formatError,
-      deliver: args.deliverGitHub,
-    });
-    return;
-  }
-  if (args.failure.kind === "teams_admission_failure") {
-    await handleTeamsQueuedMessageAdmissionFailure({
-      db: args.db,
-      failure: args.failure,
-      signal: args.signal,
-      formatError: args.formatError,
-      deliver: args.deliverTeams,
-    });
-    return;
-  }
-  if (args.failure.kind === "agentphone_admission_failure") {
-    await handleAgentPhoneQueuedMessageAdmissionFailure({
-      db: args.db,
-      failure: args.failure,
-      signal: args.signal,
-      formatError: args.formatError,
-      deliver: args.deliverAgentPhone,
-    });
-    return;
-  }
   const failure = args.failure;
-  await args.db.transaction(async (tx) => {
-    const discarded = await discardUnclaimedUserMessageInTransaction(tx, {
-      threadId: failure.threadId,
-      eventId: failure.queuedMessage.id,
-    });
-    if (!discarded || !failure.morningBriefDelivery) {
+  switch (failure.kind) {
+    case "web_admission_failure": {
+      await handleWebQueuedMessageAdmissionFailure({
+        db: args.db,
+        failure,
+        signal: args.signal,
+        formatError: args.formatError,
+      });
       return;
     }
-    const [delivery] = await tx
-      .update(morningBriefDeliveries)
-      .set({
-        status: "failed",
-        error: failure.error.message,
-        updatedAt: nowDate(),
-      })
-      .where(
-        eq(morningBriefDeliveries.id, failure.morningBriefDelivery.deliveryId),
-      )
-      .returning({ id: morningBriefDeliveries.id });
-    if (!delivery) {
-      throw new Error("Failed to record Morning Brief admission failure");
+    case "slack_admission_failure": {
+      await handleSlackQueuedMessageAdmissionFailure({
+        db: args.db,
+        failure,
+        signal: args.signal,
+        formatError: args.formatError,
+        deliver: args.deliverSlack,
+      });
+      return;
     }
-  });
-  args.signal.throwIfAborted();
-  await args.continueDrain();
+    case "feishu_admission_failure": {
+      await handleFeishuQueuedMessageAdmissionFailure({
+        db: args.db,
+        failure,
+        signal: args.signal,
+        formatError: args.formatError,
+        deliver: args.deliverFeishu,
+        clearThinking: args.clearFeishuThinking,
+      });
+      return;
+    }
+    case "teams_admission_failure": {
+      await handleTeamsQueuedMessageAdmissionFailure({
+        db: args.db,
+        failure,
+        signal: args.signal,
+        formatError: args.formatError,
+        deliver: args.deliverTeams,
+      });
+      return;
+    }
+    case "telegram_admission_failure": {
+      await handleTelegramQueuedMessageAdmissionFailure({
+        db: args.db,
+        failure,
+        signal: args.signal,
+        formatError: args.formatError,
+        deliver: args.deliverTelegram,
+      });
+      return;
+    }
+    case "agentphone_admission_failure": {
+      await handleAgentPhoneQueuedMessageAdmissionFailure({
+        db: args.db,
+        failure,
+        signal: args.signal,
+        formatError: args.formatError,
+        deliver: args.deliverAgentPhone,
+      });
+      return;
+    }
+    case "github_admission_failure": {
+      await handleGitHubQueuedMessageAdmissionFailure({
+        db: args.db,
+        failure,
+        signal: args.signal,
+        formatError: args.formatError,
+        deliver: args.deliverGitHub,
+      });
+      return;
+    }
+    case "morning_brief_admission_failure": {
+      await handleMorningBriefQueuedMessageAdmissionFailure({
+        db: args.db,
+        failure,
+        signal: args.signal,
+        formatError: args.formatError,
+      });
+      return;
+    }
+    default: {
+      return unreachableQueuedAdmissionFailure(failure);
+    }
+  }
+}
+
+function unreachableQueuedAdmissionFailure(failure: never): never {
+  throw new Error(`Unsupported queued admission failure: ${String(failure)}`);
 }
 
 interface AutoSendQueuedMessageArgs {
@@ -3652,6 +3817,8 @@ interface AutoSendQueuedMessageArgs {
   readonly resolveMorningBriefSignedUrls: CreateQueuedChatRunInputArgs["resolveMorningBriefSignedUrls"];
   readonly formatIntegrationRunError: ChatCallbackDependencies["formatIntegrationRunError"];
   readonly deliverSlackAdmissionFailure: ChatCallbackDependencies["deliverSlackAdmissionFailure"];
+  readonly deliverFeishuAdmissionFailure: ChatCallbackDependencies["deliverFeishuAdmissionFailure"];
+  readonly clearFeishuThinkingReaction: ChatCallbackDependencies["clearFeishuThinkingReaction"];
   readonly deliverTeamsAdmissionFailure: ChatCallbackDependencies["deliverTeamsAdmissionFailure"];
   readonly deliverTelegramAdmissionFailure: ChatCallbackDependencies["deliverTelegramAdmissionFailure"];
   readonly deliverAgentPhoneAdmissionFailure: ChatCallbackDependencies["deliverAgentPhoneAdmissionFailure"];
@@ -3743,9 +3910,6 @@ async function autoSendQueuedMessageForThread(
       });
     },
   );
-  if (!runInput) {
-    return;
-  }
   const activeRunExists = await autoSendAdmissionBlocked(args, threadId);
   if (activeRunExists) {
     return;
@@ -3757,13 +3921,12 @@ async function autoSendQueuedMessageForThread(
       signal: args.signal,
       formatError: args.formatIntegrationRunError,
       deliverSlack: args.deliverSlackAdmissionFailure,
+      deliverFeishu: args.deliverFeishuAdmissionFailure,
+      clearFeishuThinking: args.clearFeishuThinkingReaction,
       deliverTeams: args.deliverTeamsAdmissionFailure,
       deliverTelegram: args.deliverTelegramAdmissionFailure,
       deliverAgentPhone: args.deliverAgentPhoneAdmissionFailure,
       deliverGitHub: args.deliverGitHubAdmissionFailure,
-      continueDrain: async () => {
-        await autoSendQueuedMessageForThread(args);
-      },
     });
     return;
   }
@@ -4480,6 +4643,7 @@ function withoutQueuedRunDependency(
     refreshSlackThreadStatus: dependencies.refreshSlackThreadStatus,
     formatIntegrationRunError: dependencies.formatIntegrationRunError,
     deliverSlackAdmissionFailure: dependencies.deliverSlackAdmissionFailure,
+    deliverFeishuAdmissionFailure: dependencies.deliverFeishuAdmissionFailure,
     deliverTeamsAdmissionFailure: dependencies.deliverTeamsAdmissionFailure,
     deliverTelegramAdmissionFailure:
       dependencies.deliverTelegramAdmissionFailure,
@@ -4654,6 +4818,27 @@ async function handleChatInternalCallback(args: {
   return { success: true };
 }
 
+function feishuChatDeliveryDependencies(
+  db: Db,
+): Pick<
+  ChatCallbackDependencies,
+  | "deliverFeishuAdmissionFailure"
+  | "dispatchFeishuDelivery"
+  | "clearFeishuThinkingReaction"
+> {
+  return {
+    deliverFeishuAdmissionFailure: (params, signal) => {
+      return deliverFeishuChatAdmissionFailure({ db, ...params, signal });
+    },
+    dispatchFeishuDelivery: (callbackId, signal) => {
+      return dispatchFeishuChatDeliveryOnce(db, callbackId, signal);
+    },
+    clearFeishuThinkingReaction: (target, signal) => {
+      return clearCanonicalFeishuThinkingReaction(db, target, signal);
+    },
+  };
+}
+
 function teamsChatDeliveryDependencies(
   db: Db,
 ): Pick<
@@ -4801,16 +4986,11 @@ export async function handleChatInternalCallbackWithoutCcstate(
           signal: inputSignal,
         });
       },
-      dispatchFeishuDelivery: (callbackId, inputSignal) => {
-        return dispatchFeishuChatDeliveryOnce(db, callbackId, inputSignal);
-      },
+      ...feishuChatDeliveryDependencies(db),
       ...teamsChatDeliveryDependencies(db),
       ...telegramChatDeliveryDependencies(db),
       ...agentPhoneChatDeliveryDependencies(db),
       ...githubChatDeliveryDependencies(db),
-      clearFeishuThinkingReaction: (target, inputSignal) => {
-        return clearCanonicalFeishuThinkingReaction(db, target, inputSignal);
-      },
     },
   });
 }
@@ -4872,16 +5052,11 @@ const buildChatCallbackDependencies$ = command(
           signal: inputSignal,
         });
       },
-      dispatchFeishuDelivery: (callbackId, inputSignal) => {
-        return dispatchFeishuChatDeliveryOnce(db, callbackId, inputSignal);
-      },
+      ...feishuChatDeliveryDependencies(db),
       ...teamsChatDeliveryDependencies(db),
       ...telegramChatDeliveryDependencies(db),
       ...agentPhoneChatDeliveryDependencies(db),
       ...githubChatDeliveryDependencies(db),
-      clearFeishuThinkingReaction: (target, inputSignal) => {
-        return clearCanonicalFeishuThinkingReaction(db, target, inputSignal);
-      },
       drainThreadQueue: input.drainThreadQueue,
     };
     const dependencies: ChatCallbackDependencies = {
@@ -5025,6 +5200,8 @@ export const drainQueuedUserMessagesForThread$ = command(
       },
       formatIntegrationRunError: dependencies.formatIntegrationRunError,
       deliverSlackAdmissionFailure: dependencies.deliverSlackAdmissionFailure,
+      deliverFeishuAdmissionFailure: dependencies.deliverFeishuAdmissionFailure,
+      clearFeishuThinkingReaction: dependencies.clearFeishuThinkingReaction,
       deliverTeamsAdmissionFailure: dependencies.deliverTeamsAdmissionFailure,
       deliverTelegramAdmissionFailure:
         dependencies.deliverTelegramAdmissionFailure,

--- a/turbo/apps/api/src/signals/services/internal-feishu-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-feishu-chat-run-callback.service.ts
@@ -195,6 +195,97 @@ async function countFeishuMentioners(args: {
   return row?.count ?? 0;
 }
 
+async function loadFeishuAdmissionFailureContext(args: {
+  readonly db: Db;
+  readonly chatThreadId: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly target: FeishuDeliveryTarget;
+  readonly chatEventId: string;
+  readonly signal: AbortSignal;
+}): Promise<{ readonly messageContent: string }> {
+  const [eventRows, bindingRows] = await Promise.all([
+    args.db
+      .select({ content: chatEvents.content })
+      .from(chatEvents)
+      .where(
+        and(
+          eq(chatEvents.id, args.chatEventId),
+          eq(chatEvents.chatThreadId, args.chatThreadId),
+          chatEventTypeIn(["output.error"]),
+          isNotNull(chatEvents.content),
+        ),
+      )
+      .limit(1),
+    args.db
+      .select({ id: feishuChatThreadRoutes.id })
+      .from(feishuChatThreadRoutes)
+      .innerJoin(
+        feishuOrgConnections,
+        eq(feishuOrgConnections.id, feishuChatThreadRoutes.connectionId),
+      )
+      .innerJoin(
+        feishuOrgInstallations,
+        eq(feishuOrgInstallations.id, feishuOrgConnections.installationId),
+      )
+      .where(
+        and(
+          eq(feishuChatThreadRoutes.chatThreadId, args.chatThreadId),
+          eq(feishuChatThreadRoutes.chatId, args.target.chatId),
+          eq(feishuChatThreadRoutes.threadId, args.target.threadId),
+          eq(feishuChatThreadRoutes.userId, args.userId),
+          eq(feishuChatThreadRoutes.connectionId, args.target.connectionId),
+          eq(feishuOrgConnections.vm0UserId, args.userId),
+          eq(feishuOrgConnections.installationId, args.target.installationId),
+          eq(feishuOrgInstallations.id, args.target.installationId),
+          eq(feishuOrgInstallations.orgId, args.orgId),
+        ),
+      )
+      .limit(1),
+  ]);
+  args.signal.throwIfAborted();
+  const event = eventRows[0];
+  if (!event?.content || !bindingRows[0]) {
+    throw new Error("Feishu admission failure delivery context is unavailable");
+  }
+  return { messageContent: event.content };
+}
+
+export async function deliverFeishuChatAdmissionFailure(args: {
+  readonly db: Db;
+  readonly chatThreadId: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly target: FeishuDeliveryTarget;
+  readonly chatEventId: string;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const context = await loadFeishuAdmissionFailureContext(args);
+  const message = buildFeishuAgentResponseMessage({
+    text: context.messageContent,
+  });
+  if (args.target.replyInThread) {
+    await replyWithFeishuMessage({
+      db: args.db,
+      installationId: args.target.installationId,
+      messageId: args.target.messageId,
+      message,
+      replyInThread: true,
+      signal: args.signal,
+    });
+    return;
+  }
+  await sendFeishuMessage({
+    db: args.db,
+    installationId: args.target.installationId,
+    receiveIdType: "chat_id",
+    receiveId: args.target.chatId,
+    message,
+    idempotencyKey: args.chatEventId,
+    signal: args.signal,
+  });
+}
+
 async function deliverClaimedFeishuChatCallback(args: {
   readonly db: Db;
   readonly callback: ClaimedFeishuChatDelivery;

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -816,7 +816,7 @@ export async function recordQueueFirstFailedRun(
  * Discard a queue-first user message that never dispatched by appending a
  * tombstone. The revoke edge removes it from both queue and visible history.
  */
-export async function discardUnclaimedUserMessageInTransaction(
+async function discardUnclaimedUserMessageInTransaction(
   db: DbTransaction,
   args: {
     readonly threadId: string;
@@ -887,6 +887,7 @@ export async function failQueuedUserMessage(
         userMessage: chatEvents.userMessage,
         attachFiles: chatEvents.attachFiles,
         generationTemplate: chatEvents.generationTemplate,
+        createdAt: chatEvents.createdAt,
       })
       .from(chatEvents)
       .where(
@@ -905,6 +906,9 @@ export async function failQueuedUserMessage(
     if (!queued.userMessage) {
       throw new Error("Queued input event is missing userMessage");
     }
+    const terminalAt = new Date(
+      Math.max(args.currentTime.getTime(), queued.createdAt.getTime() + 1),
+    );
 
     const replacement = await replaceChatEvent(tx, args.eventId, {
       chatThreadId: args.threadId,
@@ -914,7 +918,7 @@ export async function failQueuedUserMessage(
       generationTemplate: queued.generationTemplate,
       runId: null,
       error: args.errorMarker,
-      createdAt: args.currentTime,
+      createdAt: terminalAt,
     });
     if (!replacement) {
       return null;
@@ -926,7 +930,7 @@ export async function failQueuedUserMessage(
       content: args.assistantContent,
       runId: null,
       error: args.errorMarker,
-      createdAt: new Date(args.currentTime.getTime() + 1),
+      createdAt: new Date(terminalAt.getTime() + 1),
     });
     if (!assistant) {
       throw new Error("Failed to append integration admission error");


### PR DESCRIPTION
## Summary

- make drain-time model-admission failures exhaustive across every queued user-message source
- preserve queued prompts and append canonical `input.rejected` plus `output.error` terminal events before publishing realtime invalidations
- deliver Feishu admission errors through the canonical target after persistence, with stable send idempotency and best-effort reaction cleanup
- retain one-head-at-a-time queue draining and classify insufficient-credit terminalization as an expected debug-level outcome

## Root cause

The drain-time failure resolver was a nullable partial dispatch keyed by the broader trigger-source contract. Web and Feishu queue heads therefore returned silently without a run or terminal event and remained eligible for both stale sweeps.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- focused Web queued-drain admission regression
- focused Feishu queued-drain persistence, exactly-once delivery, replay, and delivery-failure regression
- focused Morning Brief terminalization regression
- existing direct Web insufficient-credit regression

Fixes #24625