### PR TITLE
refactor: stop writing queued chat event params

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -51,7 +51,6 @@ import {
   readMorningBriefDeliveryFixture,
   setMorningBriefTriggeredAtFixture,
 } from "../../../test-fixtures/morning-brief";
-import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
 import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
 
 /**
@@ -1123,49 +1122,6 @@ describe("cron execute morning briefs", () => {
         );
       }),
     ).toHaveLength(1);
-    clearMockNow();
-  });
-
-  it("marks a failed queued launch failed and dispatches its failure callback", async () => {
-    const scenario = await setupMorningBriefActor();
-    await updateFeatureSwitchesForUser(context, scenario.actor, {
-      [FeatureSwitchKey.ManualMorningBrief]: true,
-    });
-    useSecretKmsProbe((_command, callNumber) => {
-      return callNumber === 2
-        ? Promise.reject(new Error("Morning Brief launch encryption failed"))
-        : undefined;
-    });
-
-    mockNow(AFTER_SEVEN_LOCAL);
-    routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
-    await accept(
-      morningBriefTriggerClient().trigger({
-        headers: actorHeaders(),
-        body: {},
-      }),
-      [400],
-    );
-    await flushWaitUntilForTest();
-
-    const delivery = await readMorningBriefDeliveryFixture({
-      orgId: scenario.actor.orgId,
-      userId: scenario.actor.userId,
-      briefDate: BRIEF_DATE,
-    });
-    expect(delivery).toStrictEqual(
-      expect.objectContaining({
-        status: "failed",
-        runId: expect.any(String),
-        error: expect.stringContaining("launch encryption failed"),
-      }),
-    );
-    if (!delivery?.runId) {
-      throw new Error("Expected the failed Morning Brief run");
-    }
-    const run = await api.readRun(scenario.actor, delivery.runId);
-    expect(run.status).toBe("failed");
-    expect(sentMorningBriefEmails()).toHaveLength(0);
     clearMockNow();
   });
 

--- a/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
@@ -7,7 +7,6 @@ import {
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
-import { chatEventInputParams } from "@vm0/db/schema/chat-event-input-params";
 import { chatEvents } from "@vm0/db/schema/chat-event";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
@@ -227,12 +226,7 @@ async function seedFixture(
     throw new Error("Failed to seed orphan monitor message");
   }
 
-  if (fixtureKind === "queued-integration") {
-    await db.insert(chatEventInputParams).values({
-      eventId: event.id,
-      encryptedParams: "encrypted-monitor-params",
-    });
-  } else if (fixtureKind === "revoked-message") {
+  if (fixtureKind === "revoked-message") {
     await db.transaction(async (tx) => {
       await replaceChatEvent(tx, event.id, {
         chatThreadId: thread.id,

--- a/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
@@ -35,7 +35,6 @@ import { touchChatThreadLastMessageAt } from "./zero-chat-event-shared.service";
 import { insertChatEvent } from "./zero-chat-event.service";
 import { createChatEventSourcePart } from "./chat-event-annotation.service";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
-import { encryptQueuedUserMessageRunParams } from "./zero-chat-queued-event.service";
 import {
   addFeishuThinkingReaction,
   dispatchConnectedFeishuCommand$,
@@ -348,17 +347,6 @@ async function persistCanonicalFeishuIngress(args: {
   });
   args.signal.throwIfAborted();
 
-  const encryptedParams = await encryptQueuedUserMessageRunParams(
-    {
-      version: 1,
-    },
-    {
-      orgId: args.installation.orgId,
-      userId: args.connection.vm0UserId,
-    },
-  );
-  args.signal.throwIfAborted();
-
   await args.db.transaction(async (tx) => {
     const chatOpenUrl = buildFeishuChatOpenUrl(args.message.chatId);
     const inserted = await insertChatEvent(
@@ -370,7 +358,6 @@ async function persistCanonicalFeishuIngress(args: {
         userMessage: feishuInboundUserMessage(args.message, chatOpenUrl),
         runId: null,
         triggerSource: "feishu",
-        encryptedParams,
         feishuContext: {
           chatOpenUrl,
           ...args.launchContext,

--- a/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
@@ -46,7 +46,6 @@ import { touchChatThreadLastMessageAt } from "./zero-chat-event-shared.service";
 import { insertChatEvent } from "./zero-chat-event.service";
 import { createChatEventSourcePart } from "./chat-event-annotation.service";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
-import { encryptQueuedUserMessageRunParams } from "./zero-chat-queued-event.service";
 
 const L = logger("CanonicalSlackIngressProcessor");
 const PROCESSING_STALE_AFTER_MS = 5 * 60 * 1000;
@@ -333,9 +332,6 @@ async function persistCanonicalSlackMessage(
     readonly displayContent: string;
     readonly slackContext: CanonicalSlackLaunchContext;
     readonly canonicalAssets: readonly CanonicalSlackInputAsset[];
-    readonly encryptedParams: Awaited<
-      ReturnType<typeof encryptQueuedUserMessageRunParams>
-    >;
   },
   signal: AbortSignal,
 ): Promise<void> {
@@ -362,7 +358,6 @@ async function persistCanonicalSlackMessage(
         }),
         runId: null,
         triggerSource: "slack",
-        encryptedParams: args.encryptedParams,
         slackContext: args.slackContext,
         createdAt: args.ingress.createdAt,
       },
@@ -475,14 +470,6 @@ const persistClaimedCanonicalSlackIngress$ = command(
         error: permalinkResult.error,
       });
     }
-    const encryptedParams = await encryptQueuedUserMessageRunParams(
-      {
-        version: 1,
-      },
-      { orgId, userId: ingress.userId },
-    );
-    signal.throwIfAborted();
-
     await persistCanonicalSlackMessage(
       db,
       {
@@ -499,7 +486,6 @@ const persistClaimedCanonicalSlackIngress$ = command(
           userInfoExtras: enriched.userInfoExtras,
         }),
         canonicalAssets,
-        encryptedParams,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
@@ -38,7 +38,6 @@ import {
 import { buildMorningBriefChatMessage } from "./morning-brief-run-prompt";
 import { insertChatEvent } from "./zero-chat-event.service";
 import { touchChatThreadLastMessageAt } from "./zero-chat-event-shared.service";
-import { encryptQueuedUserMessageRunParams } from "./zero-chat-queued-event.service";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { resolveDefaultAgent } from "./zero-email-common.service";
 import { createAutomationChatThread } from "./zero-workflow-user-automation-thread.service";
@@ -288,7 +287,6 @@ async function persistMorningBriefQueueEvent(
     readonly staged: StagedMorningBriefInput;
     readonly chatThreadId: string;
     readonly chatMessage: string;
-    readonly encryptedParams: string;
   },
 ): Promise<void> {
   const { claimed, staged } = args;
@@ -300,7 +298,6 @@ async function persistMorningBriefQueueEvent(
       userMessage: createUserMessageDocument({ text: args.chatMessage }),
       runId: null,
       triggerSource: "workflow-schedule",
-      encryptedParams: args.encryptedParams,
       morningBriefContext: {
         deliveryId: claimed.deliveryId,
         timezone: claimed.timezone,
@@ -367,18 +364,11 @@ const startMorningBriefRun$ = command(
     signal.throwIfAborted();
 
     const chatMessage = buildMorningBriefChatMessage(briefDate);
-    const encryptedParams = await encryptQueuedUserMessageRunParams(
-      { version: 1 },
-      { orgId: row.orgId, userId: row.userId },
-    );
-    signal.throwIfAborted();
-
     await persistMorningBriefQueueEvent(db, {
       claimed,
       staged,
       chatThreadId,
       chatMessage,
-      encryptedParams,
     });
     signal.throwIfAborted();
     await publishChatThreadMessageCreatedSafely(row.userId, chatThreadId);

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -44,7 +44,6 @@ import { insertChatEvent } from "./zero-chat-event.service";
 import { touchChatThreadLastMessageAt } from "./zero-chat-event-shared.service";
 import { createChatEventSourcePart } from "./chat-event-annotation.service";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
-import { encryptQueuedUserMessageRunParams } from "./zero-chat-queued-event.service";
 import { dispatchGithubLabelWorkflowAutomations$ } from "./github-workflow-event.service";
 import {
   dispatchGithubWebhookAutomations$,
@@ -1199,11 +1198,6 @@ async function insertGitHubChatInput(args: {
   readonly currentTime: Date;
 }): Promise<{ readonly chatEventId: string; readonly inserted: boolean }> {
   const issueNumber = args.params.issue.number;
-  const encryptedParams = await encryptQueuedUserMessageRunParams(
-    { version: 1 },
-    { orgId: args.target.orgId, userId: args.params.vm0UserId },
-  );
-
   const chatEventId = uuidv5(
     [
       args.route.installationId,
@@ -1233,7 +1227,6 @@ async function insertGitHubChatInput(args: {
         }),
         runId: null,
         triggerSource: "github",
-        encryptedParams,
         githubContext: {
           repo: args.params.repo,
           subjectNumber: issueNumber,

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -59,7 +59,6 @@ import { touchChatThreadLastMessageAt } from "./zero-chat-event-shared.service";
 import { insertChatEvent } from "./zero-chat-event.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
-import { encryptQueuedUserMessageRunParams } from "./zero-chat-queued-event.service";
 import {
   updateUserModelPreference$,
   userModelPreference,
@@ -1480,15 +1479,6 @@ async function persistAgentPhoneChatMessage(args: {
   });
   args.signal.throwIfAborted();
 
-  const encryptedParams = await encryptQueuedUserMessageRunParams(
-    { version: 1 },
-    {
-      orgId: args.userLink.orgId,
-      userId: args.userLink.vm0UserId,
-    },
-  );
-  args.signal.throwIfAborted();
-
   const chatEventId = agentPhoneChatMessageId({
     event: args.event,
     userLinkId: args.userLink.id,
@@ -1521,7 +1511,6 @@ async function persistAgentPhoneChatMessage(args: {
           userLinkId: args.userLink.id,
           agentphoneAgentId: args.event.agentphoneAgentId,
         },
-        encryptedParams,
         createdAt: currentTime,
       },
       "id",

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -11,7 +11,6 @@ import type {
 import type { ChatTeamsMessageFiles } from "@vm0/db/jsonb-contracts/chat-teams-context";
 import { chatAgentphoneContext } from "@vm0/db/schema/chat-agentphone-context";
 import { chatAutomationContext } from "@vm0/db/schema/chat-automation-context";
-import { chatEventInputParams } from "@vm0/db/schema/chat-event-input-params";
 import {
   chatEventTerminalPredicate,
   chatEvents,
@@ -228,7 +227,6 @@ type InputPromptEvent = ChatEventIdentity &
     readonly eventType: "input.prompt";
     readonly content?: null;
     readonly triggerSource?: TriggerSource;
-    readonly encryptedParams?: string | null;
   };
 
 type InputAutomationEvent = ChatEventIdentity &
@@ -241,7 +239,6 @@ type InputAutomationEvent = ChatEventIdentity &
     readonly workflowAutomationEventPayload?: WorkflowAutomationEventPayload;
     readonly triggerSource: TriggerSource;
     readonly triggerBrief: string | null;
-    readonly encryptedParams?: string | null;
   };
 
 type InputGoalEvent = ChatEventIdentity &
@@ -558,43 +555,6 @@ type NewDisplayContext =
       readonly timezone: string;
       readonly triggeredAt: Date;
     };
-
-function isPendingInputEvent(values: NewChatEvent): boolean {
-  return (
-    (values.eventType === "input.prompt" ||
-      values.eventType === "input.automation" ||
-      values.eventType === "input.goal") &&
-    values.runId === null
-  );
-}
-
-function eventInputParams(
-  values: NewChatEvent,
-): { readonly encryptedParams: string } | undefined {
-  if (
-    !isPendingInputEvent(values) ||
-    !("encryptedParams" in values) ||
-    !values.encryptedParams
-  ) {
-    return undefined;
-  }
-  return { encryptedParams: values.encryptedParams };
-}
-
-async function insertEventInputParams(
-  tx: ChatEventWriteTransaction,
-  eventId: string,
-  values: NewChatEvent,
-): Promise<void> {
-  const params = eventInputParams(values);
-  if (!params) {
-    return;
-  }
-  await tx.insert(chatEventInputParams).values({
-    eventId,
-    encryptedParams: params.encryptedParams,
-  });
-}
 
 function newAutomationDisplayContext(
   eventId: string,
@@ -1109,7 +1069,6 @@ export async function insertChatEvent(
     if (displayContext) {
       await insertDisplayContext(tx, displayContext, inserted.createdAt);
     }
-    await insertEventInputParams(tx, inserted.id, values);
   }
   return rows[0] ?? null;
 }
@@ -1234,7 +1193,6 @@ export async function replaceLoadedChatEvent(
   if (displayContext) {
     await insertDisplayContext(tx, displayContext, inserted.createdAt);
   }
-  await insertEventInputParams(tx, inserted.id, replacement);
   if (options?.preserveAssetRefs !== false) {
     await tx
       .insert(chatEventAssetRefs)
@@ -1255,9 +1213,6 @@ export async function replaceLoadedChatEvent(
       )
       .onConflictDoNothing();
   }
-  await tx
-    .delete(chatEventInputParams)
-    .where(eq(chatEventInputParams.eventId, target.id));
   return inserted;
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -57,7 +57,6 @@ import { touchChatThreadLastMessageAt } from "./zero-chat-event-shared.service";
 import { chatThreadAdmissionBlocked } from "./zero-chat-active-run.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
-import { encryptPersistentSecretsMap } from "./crypto.utils";
 import { noGoalChangeAfterQueueEvent } from "./chat-goal-queue.service";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { resolveArtifactObject$ } from "./artifact-storage.service";
@@ -65,7 +64,6 @@ import { attachCanonicalWebInputAssetsToEvent } from "./canonical-asset.service"
 
 type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
-const USER_MESSAGE_QUEUE_RUN_PARAMS_KEY = "__user_message_queue_run_params__";
 const queuedUserMessageTriggerSourceSchema = z.enum([
   "web",
   "slack",
@@ -76,14 +74,6 @@ const queuedUserMessageTriggerSourceSchema = z.enum([
   "github",
   "workflow-schedule",
 ]);
-
-const queuedUserMessageRunParamsSchema = z.object({
-  version: z.literal(1),
-});
-
-type QueuedUserMessageRunParams = z.infer<
-  typeof queuedUserMessageRunParamsSchema
->;
 
 const queuedChatEvent = alias(chatEvents, "queued_chat_event");
 const queuedChatEventRevoker = alias(chatEvents, "queued_chat_event_revoker");
@@ -174,20 +164,6 @@ export async function lockUserMessageQueueThread(
   threadId: string,
 ): Promise<boolean> {
   return await lockChatQueueThread(db, threadId);
-}
-
-export async function encryptQueuedUserMessageRunParams(
-  params: QueuedUserMessageRunParams,
-  ctx: { readonly orgId: string; readonly userId: string },
-): Promise<string> {
-  const encrypted = await encryptPersistentSecretsMap(
-    { [USER_MESSAGE_QUEUE_RUN_PARAMS_KEY]: JSON.stringify(params) },
-    ctx,
-  );
-  if (!encrypted) {
-    throw new Error("Failed to encrypt queued user message run params");
-  }
-  return encrypted;
 }
 
 export const resolveAttachFileMetadata$ = command(

--- a/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
@@ -71,7 +71,6 @@ import { insertChatEvent } from "./zero-chat-event.service";
 import { createChatEventSourcePart } from "./chat-event-annotation.service";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
-import { encryptQueuedUserMessageRunParams } from "./zero-chat-queued-event.service";
 
 const L = logger("TeamsDispatch");
 const TEAMS_LOGIN_PROMPT_FALLBACK_TEXT =
@@ -1586,15 +1585,6 @@ async function persistTeamsChatMessage(args: {
     threadContext: args.promptContext.text,
     messageFiles: [...args.promptFiles, ...args.promptContext.files],
   });
-  const encryptedParams = await encryptQueuedUserMessageRunParams(
-    { version: 1 },
-    {
-      orgId: args.installation.orgId,
-      userId: args.connection.vm0UserId,
-    },
-  );
-  args.signal.throwIfAborted();
-
   const chatEventId = teamsChatMessageId(args.activity, args.connection.id);
   const inserted = await args.db.transaction(async (tx) => {
     const event = await insertChatEvent(
@@ -1621,7 +1611,6 @@ async function persistTeamsChatMessage(args: {
         }),
         runId: null,
         triggerSource: "teams",
-        encryptedParams,
         teamsContext: launchContext,
         createdAt: currentTime,
       },

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -79,7 +79,6 @@ import { insertChatEvent } from "./zero-chat-event.service";
 import { createChatEventSourcePart } from "./chat-event-annotation.service";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
-import { encryptQueuedUserMessageRunParams } from "./zero-chat-queued-event.service";
 import { telegramIntegrationBotStatus } from "./zero-telegram-data.service";
 import {
   formatTelegramUserDisplayName,
@@ -1788,15 +1787,6 @@ async function persistTelegramChatMessage(args: {
         });
   args.signal.throwIfAborted();
 
-  const encryptedParams = await encryptQueuedUserMessageRunParams(
-    { version: 1 },
-    {
-      orgId: args.source.orgId,
-      userId: args.source.userLink.vm0UserId,
-    },
-  );
-  args.signal.throwIfAborted();
-
   const inserted = await args.source.db.transaction(async (tx) => {
     const event = await insertChatEvent(
       tx,
@@ -1816,7 +1806,6 @@ async function persistTelegramChatMessage(args: {
         }),
         runId: null,
         triggerSource: "telegram",
-        encryptedParams,
         telegramContext: telegramLaunchContext(args),
         createdAt: currentTime,
       },


### PR DESCRIPTION
## Summary

- stop inserting and deleting `chat_event_input_params` rows from chat event writes
- remove queued chat-event parameter encryption and threading from Slack, Feishu, Teams, Telegram, GitHub, AgentPhone, and Morning Brief admissions
- remove the obsolete legacy monitor fixture write and the Morning Brief KMS-failure test that existed only for the retired write path
- retain the `chat_event_input_params` table, schema export, and all migrations for the required deployment-skew interval

## Sequencing

This is PR 2 of the three strictly serialized PRs required by #24576. It started only after reader-removal PR #24615 was released to production and observed. PR 3 (migration-only table drop) must not start until this PR is released and observed.

No changes are made to `user_message`, API contracts, client rendering, `agent_runs.prompt`, or any `chat_*_context` column. The separate `agent_run_queue.encrypted_params` protocol is unchanged.

## Production rollout record

| Step | PR | Production time | Observation |
| --- | --- | --- | --- |
| PR 1: remove readers and rewrite monitor | #24615 | API promoted 2026-08-03T03:55:57Z; release completed 2026-08-03T03:57:39Z via release PR #24599 / run 30782584247 | 2026-08-03T03:56:13Z-04:10:03Z: cleanup cron 15/15 HTTP 200; orphan-queue and stale-drain alerts 0; Axiom queries non-partial with no warnings |
| PR 2: stop writers and retain the table | #24644 | API promoted 2026-08-03T05:36:10Z; release completed 2026-08-03T05:38:47Z via release PR #24641 / run 30785183076 | 2026-08-03T05:36:10Z-05:46:20Z: cleanup cron 10/10 and queue monitor 10/10 HTTP 200; orphan-queue and stale-drain alerts 0; Axiom queries non-partial with no warnings |
| PR 3: drop the table | #24677 | Release PR #24688 merged 2026-08-03T08:26:10Z; production migration ran 08:37:44Z-08:37:46Z; API promoted 08:37:48Z-08:37:51Z; final release attempt completed 08:43:48Z via run 30797383193 | Migration 0808 ran the issue's exact SELECT gates immediately before its same-transaction fail-closed assertion; db:migrate printed Migrations complete, proving the table was empty at deployment and the drop committed. From 08:37:51Z-08:48:47Z, cleanup was 12/12, queue monitor 12/12, and browser reconcile 11/11 HTTP 200; both alert messages and chat_event_input_params log references were 0; Axiom queries were non-partial with no warnings. All production deployment jobs succeeded. Attempt 1 ended failure only because the auxiliary next-release-PR refresh lost its GitHub connection with other side closed; attempt 2 reran that auxiliary job successfully at 08:43:47Z, so the final workflow conclusion is success. The no-input host-worker deploy was skipped. |

## Validation

- `pnpm format`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- PostgreSQL 17 CI image, 8 focused API integration files: 90 tests passed (monitor, Slack, Feishu, Teams, Telegram, GitHub, AgentPhone, Morning Brief)
- static scope audit: no application references to `chatEventInputParams` or `encryptQueuedUserMessageRunParams`; no DB, API-contract, or client diff; table schema retained

Part of #24576.
