### PR TITLE
test(e2e): use google for browser network probe

### DIFF
--- a/e2e/tests/03-runner/t59-browser-user-agent-network-log.bats
+++ b/e2e/tests/03-runner/t59-browser-user-agent-network-log.bats
@@ -27,7 +27,7 @@ teardown_file() {
 
 @test "t59-0: browser User-Agent marker appears in network logs" {
     run run_compose_fixture "$AGENT_NAME" \
-        "curl -sS -o /dev/null -w 'BROWSER_STATUS=%{http_code}\n' -A 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36' https://example.com"
+        "curl -sS -o /dev/null -w 'BROWSER_STATUS=%{http_code}\n' -A 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36' https://www.google.com"
 
     assert_success
     assert_output --partial "BROWSER_STATUS=200"
@@ -38,5 +38,5 @@ teardown_file() {
         return 1
     }
 
-    wait_for_log "$RUN_ID" --network -- "example.com" "[browser]"
+    wait_for_log "$RUN_ID" --network -- "www.google.com" "[browser]"
 }


### PR DESCRIPTION
## Summary

- replace `example.com` in the browser User-Agent network-log E2E with the established `www.google.com` runner TLS probe
- preserve the HTTP 200 and `[browser]` network-log assertions

## Scope

This is a test-only target change. It does not alter runner behavior, network policy, proxy handling, or production code. The deployed runner E2E path is exercised by PR CI.

## Validation

- `e2e/test/libs/bats/bin/bats -c e2e/tests/03-runner/t59-browser-user-agent-network-log.bats`
- `curl -sS -o /dev/null -w 'BROWSER_STATUS=%{http_code}\\n' -A 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36' https://www.google.com`
- `git diff --check`
- pre-commit file-size check
- commit message lint
