### PR TITLE
fix(platform): keep chat autoscroll following the tail after late growth

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -59,7 +59,19 @@ function scrollAnchorForEvent(
   );
 }
 
+function applyScrollTop(
+  runtime: ScrollRuntime,
+  container: HTMLElement,
+  scrollTop: number,
+): void {
+  container.scrollTop = scrollTop;
+  // Remember where this module left the container. The browser clamps the
+  // assignment, so read the offset back instead of trusting the requested one.
+  runtime.programmaticScrollTop = container.scrollTop;
+}
+
 function scrollToPosition(
+  runtime: ScrollRuntime,
   container: HTMLElement,
   position: ThreadScrollPosition,
 ): void {
@@ -71,7 +83,11 @@ function scrollToPosition(
   }
   const currentViewportOffsetTop =
     target.getBoundingClientRect().top - container.getBoundingClientRect().top;
-  container.scrollTop += currentViewportOffsetTop - position.viewportOffsetTop;
+  applyScrollTop(
+    runtime,
+    container,
+    container.scrollTop + currentViewportOffsetTop - position.viewportOffsetTop,
+  );
 }
 
 function firstVisibleScrollAnchor(container: HTMLElement): HTMLElement | null {
@@ -117,6 +133,11 @@ interface ScrollRuntime {
   initialized: boolean;
   resizeScheduled: boolean;
   latestRenderRequestRevision: number;
+  // Offset this module last wrote to the container, cleared by the next scroll
+  // event. Scroll events are delivered asynchronously, so content rendered in
+  // between (an async diagram, a late image) can make that event measure as
+  // "not at the bottom" and park the thread on an anchor nobody chose.
+  programmaticScrollTop: number | null;
 }
 
 function createInternalScrollSignals(threadId: string) {
@@ -152,10 +173,17 @@ function createInternalScrollSignals(threadId: string) {
     set(threadScrollPositions$, next);
   });
   const syncThreadScrollPosition$ = command(
-    ({ set }, container: HTMLElement) => {
+    ({ set }, container: HTMLElement, capturePosition: boolean) => {
       if (isAtBottom(container)) {
         set(clearThreadScrollPosition$);
         L.debug("scroll position cleared at bottom", {
+          threadId,
+          scrollTop: container.scrollTop,
+        });
+        return;
+      }
+      if (!capturePosition) {
+        L.debug("programmatic scroll position ignored", {
           threadId,
           scrollTop: container.scrollTop,
         });
@@ -208,7 +236,7 @@ function createScrollNavigationSignals(
     if (!container) {
       throw new Error("Chat scroll container is not mounted");
     }
-    scrollToPosition(container, position);
+    scrollToPosition(runtime, container, position);
     runtime.initialized = true;
   });
 
@@ -218,7 +246,7 @@ function createScrollNavigationSignals(
       throw new Error("Chat scroll container is not mounted");
     }
     set(scroll.clearThreadScrollPosition$);
-    container.scrollTop = container.scrollHeight;
+    applyScrollTop(runtime, container, container.scrollHeight);
     runtime.initialized = true;
   });
 
@@ -227,9 +255,9 @@ function createScrollNavigationSignals(
     if (!container) {
       throw new Error("Chat scroll container is not mounted");
     }
-    container.scrollTop = 0;
+    applyScrollTop(runtime, container, 0);
     runtime.initialized = true;
-    set(scroll.syncThreadScrollPosition$, container);
+    set(scroll.syncThreadScrollPosition$, container, true);
   });
 
   const restoreAfterResize$ = command(({ get, set }) => {
@@ -271,9 +299,9 @@ function createScrollNavigationSignals(
         return;
       }
       if (request.position) {
-        scrollToPosition(container, request.position);
+        scrollToPosition(runtime, container, request.position);
       } else {
-        container.scrollTop = container.scrollHeight;
+        applyScrollTop(runtime, container, container.scrollHeight);
       }
       runtime.initialized = true;
       L.debug("render scroll committed", {
@@ -341,12 +369,21 @@ function createScrollContainerOnRef(
         initialized: runtime.initialized,
       });
 
-      const handleScroll = () => {
+      const handleScroll = (event: Event) => {
         if (!runtime.initialized) {
           L.debug("pre-initialization scroll ignored", { threadId });
           return;
         }
-        set(scroll.syncThreadScrollPosition$, container);
+        if (event.target !== container) {
+          // The listener runs in the capture phase, so nested scrollers (wide
+          // diagrams, code blocks, tables) deliver their scroll events here
+          // too. Where they sit says nothing about where the thread sits.
+          return;
+        }
+        const programmatic =
+          runtime.programmaticScrollTop === container.scrollTop;
+        runtime.programmaticScrollTop = null;
+        set(scroll.syncThreadScrollPosition$, container, !programmatic);
       };
       const scheduleRestoreAfterResize = () => {
         if (!runtime.initialized || runtime.resizeScheduled) {
@@ -389,6 +426,7 @@ function createScrollContainerOnRef(
           );
           set(scroll.clearScrollContainer$, container);
           runtime.initialized = false;
+          runtime.programmaticScrollTop = null;
           L.debug("container unbound", { threadId });
         },
         { once: true },
@@ -404,6 +442,7 @@ export function createChatThreadScrollSignals(
     initialized: false,
     resizeScheduled: false,
     latestRenderRequestRevision: 0,
+    programmaticScrollTop: null,
   };
   const scroll = createInternalScrollSignals(threadId);
   const navigation = createScrollNavigationSignals(threadId, scroll, runtime);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
@@ -461,6 +461,56 @@ function mockLiveThread({
   };
 }
 
+function mockLateGrowingThread({
+  threadId,
+  prefix,
+}: {
+  readonly threadId: string;
+  readonly prefix: string;
+}): {
+  readonly publishAppendedEvents: () => Promise<void>;
+  readonly growContent: (extraScrollHeight: number) => void;
+} {
+  const { publishAppendedEvents } = mockLiveThread({
+    threadId,
+    initialEvents: simpleUserEvents(threadId, prefix, 8),
+    appendedEvents: simpleUserEvents(threadId, prefix, 9).slice(8),
+  });
+  let extraScrollHeight = 0;
+  installChatLayout(
+    new Map([
+      [
+        threadId,
+        {
+          clientHeight: () => {
+            return 300;
+          },
+          scrollHeight: () => {
+            const rendered = document.body.textContent?.includes(
+              `${prefix} message 8`,
+            )
+              ? 1100
+              : 1000;
+            return rendered + extraScrollHeight;
+          },
+          eventRect: (eventId) => {
+            const index = Number(eventId.split("-").at(-1));
+            return Number.isFinite(index)
+              ? { top: index * 100, height: 80 }
+              : undefined;
+          },
+        },
+      ],
+    ]),
+  );
+  return {
+    publishAppendedEvents,
+    growContent: (nextExtraScrollHeight: number) => {
+      extraScrollHeight = nextExtraScrollHeight;
+    },
+  };
+}
+
 function mockBackfilledHistoryScroll({
   threadId,
   finalScrollHeight,
@@ -673,6 +723,81 @@ describe("chat scroll position", () => {
     await waitFor(() => {
       expect(screen.getByText("tail-follow message 8")).toBeInTheDocument();
       expect(container.scrollTop).toBe(800);
+    });
+  });
+
+  it("keeps following the tail when late content growth delivers the tail scroll event", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000809";
+    const { publishAppendedEvents, growContent } = mockLateGrowingThread({
+      threadId,
+      prefix: "late-growth",
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const container = await waitFor(() => {
+      expect(screen.getByText("late-growth message 7")).toBeInTheDocument();
+      const current = chatScrollContainer();
+      expect(current.scrollTop).toBe(700);
+      return current;
+    });
+
+    // A diagram finishes rendering after the tail scroll was written, so the
+    // browser delivers that scroll event against taller content.
+    growContent(400);
+    fireEvent.scroll(container);
+
+    await publishAppendedEvents();
+
+    await waitFor(() => {
+      expect(screen.getByText("late-growth message 8")).toBeInTheDocument();
+      expect(container.scrollTop).toBe(
+        container.scrollHeight - container.clientHeight,
+      );
+      expect(document.querySelector("[data-scroll-to-bottom]")).toBeNull();
+    });
+  });
+
+  it("keeps following the tail when a nested scroller scrolls after late content growth", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000810";
+    const { publishAppendedEvents, growContent } = mockLateGrowingThread({
+      threadId,
+      prefix: "nested-scroll",
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const container = await waitFor(() => {
+      expect(screen.getByText("nested-scroll message 7")).toBeInTheDocument();
+      const current = chatScrollContainer();
+      expect(current.scrollTop).toBe(700);
+      return current;
+    });
+    // Reading history and returning to the bottom leaves the thread following
+    // the tail again.
+    scrollTo(container, 420);
+    scrollTo(container, 700);
+
+    growContent(400);
+    const messageContainer = container.querySelector(
+      "[data-message-container]",
+    );
+    if (!messageContainer) {
+      throw new Error("Chat message container not found");
+    }
+    // Panning a wide diagram or table sideways scrolls a nested container. The
+    // capture-phase listener sees that event, but it says nothing about where
+    // the thread itself sits.
+    fireEvent.scroll(messageContainer);
+
+    await publishAppendedEvents();
+
+    await waitFor(() => {
+      expect(screen.getByText("nested-scroll message 8")).toBeInTheDocument();
+      expect(container.scrollTop).toBe(
+        container.scrollHeight - container.clientHeight,
+      );
+      expect(document.querySelector("[data-scroll-to-bottom]")).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Problem

A chat thread's scroll state is one value: `threadScrollPosition$` — `null` means "follow the tail", an anchored position means "hold this message here". It is written from a single judgement, taken inside the container's `scroll` handler: *is the viewport at the bottom right now?* Nothing records **who** caused the scroll.

That is fine until content grows after the scroll was written. Scroll events are delivered asynchronously, so this interleaving is reachable:

1. A new event arrives; `commitScrollAfterRender$` writes `scrollTop = scrollHeight` on the next animation frame.
2. Before the browser delivers that scroll event, an async-rendered mermaid diagram (or a late image) makes the content taller.
3. The handler runs, measures "not at the bottom", and captures a position.

From then on the thread holds that anchor instead of following the tail, and because the same value drives `awayFromBottom$`, the floating scroll-to-bottom button is hidden — the reader is left below the fold with no way back except scrolling manually. Mermaid diagrams (#24290) are the first chat content that grows asynchronously; markdown images already reserve a fixed box, and KaTeX and code blocks lay out synchronously.

The same handler is registered with `capture: true`, so scroll events from nested scrollers reach it as well. Panning a wide diagram, code block or table sideways therefore runs the same judgement against the thread's own geometry.

## Change

- Record the offset every programmatic scroll leaves behind (`applyScrollTop` reads it back, because the browser clamps the assignment) and skip position capture for the scroll event that write queues.
- Ignore scroll events whose target is not the scroll container.
- Clearing the position at the bottom stays unconditional, so a reader who drags back to the bottom always resumes following the tail.

No change to the shape of the state, to the anchor model, or to history navigation.

## Tests

Two integration tests in `chat-scroll-position.test.tsx`, both of which fail on `main` (they stop at `scrollTop` 700 instead of 1200):

- late content growth delivering the tail scroll event must not park the thread;
- a nested scroller's scroll event after late growth must not park the thread — this one is reached with the programmatic marker already cleared, so only the target check can catch it.

Existing chat scroll, history-navigation, lifecycle and IndexedDB suites pass unchanged (84 tests).

## Scope note

The deep dive that produced this change also proposed making `scrollToPosition` non-throwing on the resize-restore path. It is **not** included: the render window (`Math.min(requestedStartIndex, targetStartIndex)`), `buildRunGroupFolding` and `completedWorkExpandedKeysForScrollTarget` all keep the anchored event rendered, so no test can reach that throw today, and adding an untested guard would be defensive programming against a state the app currently prevents. It is revisited in the follow-up that observes content size, where the restore path becomes hot.

## Follow-ups

- Observe content size so late growth actually re-pins the tail (this PR only stops the state from being corrupted by it).
- Stop rendering mermaid fences while they stream, and key the canvas by block position instead of full source.