### PR TITLE
feat(platform): follow chat content growth back to the tail

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -56,10 +56,12 @@ function scrollAnchorForEvent(
   container: HTMLElement,
   eventId: string,
 ): HTMLElement | null {
-  return (
-    scrollAnchors(container).find((anchor) => {
-      return anchor.getAttribute(SCROLL_ANCHOR_ATTRIBUTE) === eventId;
-    }) ?? null
+  // Selected by attribute rather than scanned out of `scrollAnchors`: a reader
+  // holding an anchor restores on every frame the thread grows, and collecting
+  // every anchor in the thread first would walk the whole history before each
+  // paint.
+  return container.querySelector<HTMLElement>(
+    `[${SCROLL_ANCHOR_ATTRIBUTE}="${eventId}"]`,
   );
 }
 
@@ -278,9 +280,12 @@ function createScrollNavigationSignals(
     set(scrollToBottom$);
   });
 
-  // Viewport and composer resizes settle over a frame, so their restore waits
-  // for the next one. The flag coalesces repeated notifications into a single
-  // restore.
+  // The viewport and the composer settle their layout over a frame, so their
+  // restore waits for the next one and the flag folds repeated notifications
+  // into a single run. Resizing the viewport also reflows the message box, so
+  // the content observer restores inside the frame as well and this pass then
+  // runs once more against the settled layout; both write the same position,
+  // which makes the repeat invisible.
   const scheduleRestoreAfterResize$ = command(
     ({ set }, signal: AbortSignal) => {
       if (!runtime.initialized || runtime.resizeScheduled) {
@@ -302,6 +307,9 @@ function createScrollNavigationSignals(
   // callbacks run after layout and before paint, so a scroll written here is
   // part of that frame; waiting for the next one would paint the grown content
   // at the old offset first, which reads as a flash before the view snaps back.
+  // Deliberately outside `resizeScheduled`: sharing that flag would fold this
+  // restore into the deferred pass, which is the frame of delay it exists to
+  // avoid.
   const restoreAfterContentResize$ = command(({ set }) => {
     if (!runtime.initialized) {
       return;
@@ -479,6 +487,11 @@ function createScrollContainerOnRef(
  * scroll was committed — a diagram that finishes rendering, an image that
  * finishes loading — is invisible to the container observer and leaves the
  * thread stranded above the bottom.
+ *
+ * `observe` delivers once on its own. Both refs belong to the same thread and
+ * bind together, so that delivery either arrives before the thread is
+ * initialized and is dropped, or arrives in the frame the render commit already
+ * scrolled and re-applies the position the thread is holding.
  */
 function createScrollContentOnRef(
   threadId: string,

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -22,6 +22,10 @@ interface ChatThreadScrollSignals {
     (() => void) | undefined,
     [HTMLElement | null]
   >;
+  readonly scrollContentOnRef$: Command<
+    (() => void) | undefined,
+    [HTMLElement | null]
+  >;
   readonly threadScrollPosition$: Computed<ThreadScrollPosition | null>;
   readonly awayFromBottom$: Computed<boolean>;
   readonly autoScroll$: Command<
@@ -274,6 +278,43 @@ function createScrollNavigationSignals(
     set(scrollToBottom$);
   });
 
+  // Coalesced across the container and content observers: a resize that changes
+  // both boxes still restores once.
+  const scheduleRestoreAfterResize$ = command(
+    ({ set }, signal: AbortSignal) => {
+      if (!runtime.initialized || runtime.resizeScheduled) {
+        return;
+      }
+      runtime.resizeScheduled = true;
+      L.debug("resize scroll restore scheduled", { threadId });
+      animationFrame(
+        () => {
+          runtime.resizeScheduled = false;
+          set(restoreAfterResize$);
+        },
+        { signal },
+      );
+    },
+  );
+
+  return {
+    scrollTo$,
+    scrollToBottom$,
+    scrollToTop$,
+    scheduleRestoreAfterResize$,
+  };
+}
+
+/**
+ * Commits the scroll that belongs to a rendered batch of events: one frame
+ * after the events change, either back to the bottom or onto the anchor the
+ * reader is holding.
+ */
+function createRenderScrollSignals(
+  threadId: string,
+  scroll: InternalScrollSignals,
+  runtime: ScrollRuntime,
+) {
   const commitScrollAfterRender$ = command(
     ({ get }, request: ScrollAfterRenderRequest): void => {
       if (request.revision !== runtime.latestRenderRequestRevision) {
@@ -344,13 +385,7 @@ function createScrollNavigationSignals(
     },
   );
 
-  return {
-    scrollTo$,
-    scrollToBottom$,
-    scrollToTop$,
-    restoreAfterResize$,
-    autoScroll$,
-  };
+  return { autoScroll$ };
 }
 
 type ScrollNavigationSignals = ReturnType<typeof createScrollNavigationSignals>;
@@ -386,18 +421,7 @@ function createScrollContainerOnRef(
         set(scroll.syncThreadScrollPosition$, container, !programmatic);
       };
       const scheduleRestoreAfterResize = () => {
-        if (!runtime.initialized || runtime.resizeScheduled) {
-          return;
-        }
-        runtime.resizeScheduled = true;
-        L.debug("resize scroll restore scheduled", { threadId });
-        animationFrame(
-          () => {
-            runtime.resizeScheduled = false;
-            set(navigation.restoreAfterResize$);
-          },
-          { signal },
-        );
+        set(navigation.scheduleRestoreAfterResize$, signal);
       };
       const resizeObserver = new ResizeObserver(scheduleRestoreAfterResize);
 
@@ -435,6 +459,36 @@ function createScrollContainerOnRef(
   );
 }
 
+/**
+ * Observes the element that holds the messages. The container's own box only
+ * changes with the viewport or the composer, so content that arrives after its
+ * scroll was committed — a diagram that finishes rendering, an image that
+ * finishes loading — is invisible to the container observer and leaves the
+ * thread stranded above the bottom.
+ */
+function createScrollContentOnRef(
+  threadId: string,
+  navigation: ScrollNavigationSignals,
+) {
+  return onRef(
+    command(({ set }, content: HTMLElement, signal: AbortSignal) => {
+      L.debug("content bound", { threadId });
+      const resizeObserver = new ResizeObserver(() => {
+        set(navigation.scheduleRestoreAfterResize$, signal);
+      });
+      resizeObserver.observe(content);
+      signal.addEventListener(
+        "abort",
+        () => {
+          resizeObserver.disconnect();
+          L.debug("content unbound", { threadId });
+        },
+        { once: true },
+      );
+    }),
+  );
+}
+
 export function createChatThreadScrollSignals(
   threadId: string,
 ): ChatThreadScrollSignals {
@@ -446,18 +500,21 @@ export function createChatThreadScrollSignals(
   };
   const scroll = createInternalScrollSignals(threadId);
   const navigation = createScrollNavigationSignals(threadId, scroll, runtime);
+  const render = createRenderScrollSignals(threadId, scroll, runtime);
   const scrollContainerOnRef$ = createScrollContainerOnRef(
     threadId,
     scroll,
     navigation,
     runtime,
   );
+  const scrollContentOnRef$ = createScrollContentOnRef(threadId, navigation);
 
   return {
     scrollContainerOnRef$,
+    scrollContentOnRef$,
     threadScrollPosition$: scroll.threadScrollPosition$,
     awayFromBottom$: scroll.awayFromBottom$,
-    autoScroll$: navigation.autoScroll$,
+    autoScroll$: render.autoScroll$,
     scrollTo$: navigation.scrollTo$,
     scrollToTop$: navigation.scrollToTop$,
     scrollToBottom$: navigation.scrollToBottom$,

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -139,10 +139,11 @@ interface ScrollRuntime {
   initialized: boolean;
   resizeScheduled: boolean;
   latestRenderRequestRevision: number;
-  // Offset this module last wrote to the container, cleared by the next scroll
-  // event. Scroll events are delivered asynchronously, so content rendered in
-  // between (an async diagram, a late image) can make that event measure as
-  // "not at the bottom" and park the thread on an anchor nobody chose.
+  // Offset this module last wrote to the container, cleared once the container
+  // reports a different one. Scroll events are delivered asynchronously, so
+  // content rendered in between (an async diagram, a late image) can make that
+  // event measure as "not at the bottom" and park the thread on an anchor
+  // nobody chose.
   programmaticScrollTop: number | null;
 }
 
@@ -439,7 +440,13 @@ function createScrollContainerOnRef(
         }
         const programmatic =
           runtime.programmaticScrollTop === container.scrollTop;
-        runtime.programmaticScrollTop = null;
+        if (!programmatic) {
+          // The container has left the offset this module wrote, so the reader
+          // moved it. Until that happens the offset is still ours no matter how
+          // many events describe it, and content growing every frame delivers
+          // more of them than the restores that wrote them.
+          runtime.programmaticScrollTop = null;
+        }
         set(scroll.syncThreadScrollPosition$, container, !programmatic);
       };
       const scheduleRestoreAfterResize = () => {

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -278,8 +278,9 @@ function createScrollNavigationSignals(
     set(scrollToBottom$);
   });
 
-  // Coalesced across the container and content observers: a resize that changes
-  // both boxes still restores once.
+  // Viewport and composer resizes settle over a frame, so their restore waits
+  // for the next one. The flag coalesces repeated notifications into a single
+  // restore.
   const scheduleRestoreAfterResize$ = command(
     ({ set }, signal: AbortSignal) => {
       if (!runtime.initialized || runtime.resizeScheduled) {
@@ -297,11 +298,24 @@ function createScrollNavigationSignals(
     },
   );
 
+  // Content growth restores in the same frame that produced it. ResizeObserver
+  // callbacks run after layout and before paint, so a scroll written here is
+  // part of that frame; waiting for the next one would paint the grown content
+  // at the old offset first, which reads as a flash before the view snaps back.
+  const restoreAfterContentResize$ = command(({ set }) => {
+    if (!runtime.initialized) {
+      return;
+    }
+    L.debug("content resize scroll restore", { threadId });
+    set(restoreAfterResize$);
+  });
+
   return {
     scrollTo$,
     scrollToBottom$,
     scrollToTop$,
     scheduleRestoreAfterResize$,
+    restoreAfterContentResize$,
   };
 }
 
@@ -474,7 +488,7 @@ function createScrollContentOnRef(
     command(({ set }, content: HTMLElement, signal: AbortSignal) => {
       L.debug("content bound", { threadId });
       const resizeObserver = new ResizeObserver(() => {
-        set(navigation.scheduleRestoreAfterResize$, signal);
+        set(navigation.restoreAfterContentResize$);
       });
       resizeObserver.observe(content);
       signal.addEventListener(

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -76,16 +76,15 @@ function applyScrollTop(
   runtime.programmaticScrollTop = container.scrollTop;
 }
 
+/** Returns false when the anchored event is not in the DOM. */
 function scrollToPosition(
   runtime: ScrollRuntime,
   container: HTMLElement,
   position: ThreadScrollPosition,
-): void {
+): boolean {
   const target = scrollAnchorForEvent(container, position.targetEventId);
   if (!target) {
-    throw new Error(
-      `Chat scroll target is not rendered: ${position.targetEventId}`,
-    );
+    return false;
   }
   const currentViewportOffsetTop =
     target.getBoundingClientRect().top - container.getBoundingClientRect().top;
@@ -94,6 +93,7 @@ function scrollToPosition(
     container,
     container.scrollTop + currentViewportOffsetTop - position.viewportOffsetTop,
   );
+  return true;
 }
 
 function firstVisibleScrollAnchor(container: HTMLElement): HTMLElement | null {
@@ -243,7 +243,11 @@ function createScrollNavigationSignals(
     if (!container) {
       throw new Error("Chat scroll container is not mounted");
     }
-    scrollToPosition(runtime, container, position);
+    if (!scrollToPosition(runtime, container, position)) {
+      throw new Error(
+        `Chat scroll target is not rendered: ${position.targetEventId}`,
+      );
+    }
     runtime.initialized = true;
   });
 
@@ -269,15 +273,24 @@ function createScrollNavigationSignals(
 
   const restoreAfterResize$ = command(({ get, set }) => {
     const position = get(scroll.threadScrollPosition$);
+    const container = get(scroll.scrollContainer$);
     L.debug("resize scroll restore", {
       threadId,
       targetEventId: position?.targetEventId ?? null,
       viewportOffsetTop: position?.viewportOffsetTop ?? null,
     });
-    if (position) {
-      set(scrollTo$, position);
+    if (!container) {
+      throw new Error("Chat scroll container is not mounted");
+    }
+    if (position && scrollToPosition(runtime, container, position)) {
+      runtime.initialized = true;
       return;
     }
+    // Either the thread is following the tail, or the event it anchors to has
+    // left the DOM — a queued message moves into the thinking indicator, which
+    // renders no anchor. Holding a position nothing renders would freeze the
+    // thread where it stands and every later resize would try again, so the
+    // thread goes back to following the tail.
     set(scrollToBottom$);
   });
 
@@ -339,7 +352,7 @@ function createRenderScrollSignals(
   runtime: ScrollRuntime,
 ) {
   const commitScrollAfterRender$ = command(
-    ({ get }, request: ScrollAfterRenderRequest): void => {
+    ({ get, set }, request: ScrollAfterRenderRequest): void => {
       if (request.revision !== runtime.latestRenderRequestRevision) {
         L.debug("stale render scroll ignored", {
           revision: request.revision,
@@ -362,9 +375,16 @@ function createRenderScrollSignals(
         });
         return;
       }
-      if (request.position) {
-        scrollToPosition(runtime, container, request.position);
-      } else {
+      if (
+        !request.position ||
+        !scrollToPosition(runtime, container, request.position)
+      ) {
+        // The batch either follows the tail, or it carries a position whose
+        // event this render does not show: sending while a run is active
+        // queues the message, and a queued message moves into the thinking
+        // indicator, which renders no anchor. Nothing can hold that position,
+        // so the thread follows the tail rather than staying put.
+        set(scroll.clearThreadScrollPosition$);
         applyScrollTop(runtime, container, container.scrollHeight);
       }
       runtime.initialized = true;

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -111,6 +111,7 @@ export interface ChatThreadSignals {
     (() => void) | undefined,
     [HTMLElement | null]
   >;
+  scrollContentOnRef$: Command<(() => void) | undefined, [HTMLElement | null]>;
   threadScrollPosition$: Computed<ThreadScrollPosition | null>;
   scrollTo$: Command<void, [ThreadScrollPosition]>;
   scrollToBottom$: Command<void, []>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -4394,6 +4394,7 @@ export function createChatThreadSignals(
     ...messageActions,
     ...assistantErrorRecovery,
     scrollContainerOnRef$: events.scroll.scrollContainerOnRef$,
+    scrollContentOnRef$: events.scroll.scrollContentOnRef$,
     threadScrollPosition$: events.scroll.threadScrollPosition$,
     awayFromBottom$: events.scroll.awayFromBottom$,
     scrollTo$: events.scroll.scrollTo$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
@@ -470,6 +470,7 @@ function mockLateGrowingThread({
 }): {
   readonly publishAppendedEvents: () => Promise<void>;
   readonly growContent: (extraScrollHeight: number) => void;
+  readonly growContentAbove: (extraScrollHeight: number) => void;
 } {
   const { publishAppendedEvents } = mockLiveThread({
     threadId,
@@ -477,6 +478,7 @@ function mockLateGrowingThread({
     appendedEvents: simpleUserEvents(threadId, prefix, 9).slice(8),
   });
   let extraScrollHeight = 0;
+  let eventTopShift = 0;
   installChatLayout(
     new Map([
       [
@@ -496,7 +498,7 @@ function mockLateGrowingThread({
           eventRect: (eventId) => {
             const index = Number(eventId.split("-").at(-1));
             return Number.isFinite(index)
-              ? { top: index * 100, height: 80 }
+              ? { top: index * 100 + eventTopShift, height: 80 }
               : undefined;
           },
         },
@@ -507,6 +509,12 @@ function mockLateGrowingThread({
     publishAppendedEvents,
     growContent: (nextExtraScrollHeight: number) => {
       extraScrollHeight = nextExtraScrollHeight;
+    },
+    // Content that grows above the reader — a diagram rendering in history —
+    // pushes every message down by the same amount.
+    growContentAbove: (nextExtraScrollHeight: number) => {
+      extraScrollHeight = nextExtraScrollHeight;
+      eventTopShift = nextExtraScrollHeight;
     },
   };
 }
@@ -755,6 +763,76 @@ describe("chat scroll position", () => {
         container.scrollHeight - container.clientHeight,
       );
       expect(document.querySelector("[data-scroll-to-bottom]")).toBeNull();
+    });
+  });
+
+  it("follows the tail when content finishes rendering after the tail scroll", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000811";
+    const { growContent } = mockLateGrowingThread({
+      threadId,
+      prefix: "content-growth",
+    });
+    const resizeObserver = installResizeObserver();
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const container = await waitFor(() => {
+      expect(screen.getByText("content-growth message 7")).toBeInTheDocument();
+      const current = chatScrollContainer();
+      expect(current.scrollTop).toBe(700);
+      return current;
+    });
+    const messageContainer = container.querySelector(
+      "[data-message-container]",
+    );
+    if (!messageContainer) {
+      throw new Error("Chat message container not found");
+    }
+    expect(resizeObserver.isObserved(messageContainer)).toBeTruthy();
+
+    // A diagram finishes rendering well after its message was committed. Only
+    // the content box changes, so the container observer never sees it.
+    growContent(400);
+    resizeObserver.trigger(messageContainer);
+
+    await waitFor(() => {
+      expect(container.scrollTop).toBe(
+        container.scrollHeight - container.clientHeight,
+      );
+    });
+  });
+
+  it("keeps the visible anchor when content above the reader grows", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000812";
+    const { growContentAbove } = mockLateGrowingThread({
+      threadId,
+      prefix: "grow-above",
+    });
+    const resizeObserver = installResizeObserver();
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const container = await waitFor(() => {
+      expect(screen.getByText("grow-above message 7")).toBeInTheDocument();
+      const current = chatScrollContainer();
+      expect(current.scrollTop).toBe(700);
+      return current;
+    });
+    const messageContainer = container.querySelector(
+      "[data-message-container]",
+    );
+    if (!messageContainer) {
+      throw new Error("Chat message container not found");
+    }
+    scrollTo(container, 420);
+    expect(viewportOffsetTop("grow-above-4")).toBe(-20);
+
+    growContentAbove(400);
+    resizeObserver.trigger(messageContainer);
+
+    await waitFor(() => {
+      expect(viewportOffsetTop("grow-above-4")).toBe(-20);
+      expect(container.scrollTop).toBe(820);
     });
   });
 
@@ -1404,7 +1482,7 @@ describe("chat scroll position", () => {
       throw new Error("Chat message container not found");
     }
     expect(resizeObserver.isObserved(container)).toBeTruthy();
-    expect(resizeObserver.isObserved(messageContainer)).toBeFalsy();
+    expect(resizeObserver.isObserved(messageContainer)).toBeTruthy();
     scrollTo(container, 420);
     expect(viewportOffsetTop("resize-preserve-4")).toBe(-20);
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
@@ -795,11 +795,13 @@ describe("chat scroll position", () => {
     growContent(400);
     resizeObserver.trigger(messageContainer);
 
-    await waitFor(() => {
-      expect(container.scrollTop).toBe(
-        container.scrollHeight - container.clientHeight,
-      );
-    });
+    // Asserted synchronously: the restore must happen inside the observer
+    // callback, which the browser runs before painting the frame that grew the
+    // content. Waiting for the next frame would paint the grown content at the
+    // old offset first, which the reader sees as a flash.
+    expect(container.scrollTop).toBe(
+      container.scrollHeight - container.clientHeight,
+    );
   });
 
   it("keeps the visible anchor when content above the reader grows", async () => {
@@ -830,10 +832,8 @@ describe("chat scroll position", () => {
     growContentAbove(400);
     resizeObserver.trigger(messageContainer);
 
-    await waitFor(() => {
-      expect(viewportOffsetTop("grow-above-4")).toBe(-20);
-      expect(container.scrollTop).toBe(820);
-    });
+    expect(viewportOffsetTop("grow-above-4")).toBe(-20);
+    expect(container.scrollTop).toBe(820);
   });
 
   it("keeps following the tail when a nested scroller scrolls after late content growth", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
@@ -844,6 +844,55 @@ describe("chat scroll position", () => {
     );
   });
 
+  it("follows the tail when the anchored event stops being rendered", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000816";
+    const { growContent } = mockLateGrowingThread({
+      threadId,
+      prefix: "anchor-gone",
+    });
+    const resizeObserver = installResizeObserver();
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const container = await waitFor(() => {
+      expect(screen.getByText("anchor-gone message 7")).toBeInTheDocument();
+      const current = chatScrollContainer();
+      expect(current.scrollTop).toBe(700);
+      return current;
+    });
+    const messageContainer = container.querySelector(
+      "[data-message-container]",
+    );
+    if (!messageContainer) {
+      throw new Error("Chat message container not found");
+    }
+
+    container.scrollTop = 300;
+    fireEvent.scroll(container);
+    await waitFor(() => {
+      expect(document.querySelector("[data-scroll-to-bottom]")).not.toBeNull();
+    });
+
+    // Sending while a run is active queues the message, and a queued message
+    // moves into the thinking indicator, which renders no anchor. The position
+    // the thread is holding then points at nothing.
+    for (const anchor of Array.from(
+      container.querySelectorAll("[data-chat-scroll-anchor-event-id]"),
+    )) {
+      anchor.remove();
+    }
+
+    growContent(400);
+    resizeObserver.trigger(messageContainer);
+
+    expect(container.scrollTop).toBe(
+      container.scrollHeight - container.clientHeight,
+    );
+    await waitFor(() => {
+      expect(document.querySelector("[data-scroll-to-bottom]")).toBeNull();
+    });
+  });
+
   it("keeps the visible anchor when content above the reader grows", async () => {
     const threadId = "b0000000-0000-4000-a000-000000000812";
     const { growContentAbove } = mockLateGrowingThread({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
@@ -804,6 +804,46 @@ describe("chat scroll position", () => {
     );
   });
 
+  it("keeps following the tail when growing content delivers a second scroll event", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000815";
+    const { growContent } = mockLateGrowingThread({
+      threadId,
+      prefix: "second-scroll",
+    });
+    const resizeObserver = installResizeObserver();
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const container = await waitFor(() => {
+      expect(screen.getByText("second-scroll message 7")).toBeInTheDocument();
+      const current = chatScrollContainer();
+      expect(current.scrollTop).toBe(700);
+      return current;
+    });
+    const messageContainer = container.querySelector(
+      "[data-message-container]",
+    );
+    if (!messageContainer) {
+      throw new Error("Chat message container not found");
+    }
+
+    // Content that keeps growing restores once per frame, and every restore
+    // leaves a scroll event behind. The reader has not touched the thread, so
+    // none of those events may park it — including a second one that arrives
+    // before the next restore writes a new offset.
+    growContent(400);
+    resizeObserver.trigger(messageContainer);
+    fireEvent.scroll(container);
+    growContent(800);
+    fireEvent.scroll(container);
+
+    expect(document.querySelector("[data-scroll-to-bottom]")).toBeNull();
+    resizeObserver.trigger(messageContainer);
+    expect(container.scrollTop).toBe(
+      container.scrollHeight - container.clientHeight,
+    );
+  });
+
   it("keeps the visible anchor when content above the reader grows", async () => {
     const threadId = "b0000000-0000-4000-a000-000000000812";
     const { growContentAbove } = mockLateGrowingThread({

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2639,10 +2639,12 @@ function ChatThreadEmptyState({ thread }: { thread: ChatThreadSignals }) {
 function ChatThreadEventsMain({ thread }: { thread: ChatThreadSignals }) {
   const renderedGroupsReady =
     useLastResolved(thread.visibleRenderedChatGroupsReady$) ?? false;
+  const scrollContentOnRef = useSet(thread.scrollContentOnRef$);
 
   return (
     <main className={CHAT_THREAD_CONTENT_MAIN_CLASS}>
       <div
+        ref={scrollContentOnRef}
         data-message-container
         className="w-full max-w-[900px] mx-auto flex flex-col gap-6 pb-4 overflow-visible"
         style={{ visibility: renderedGroupsReady ? "visible" : "hidden" }}


### PR DESCRIPTION
Stacked on #24651 — review that one first; this PR retargets to `main` automatically once it merges.

## Problem

`createChatThreadScrollSignals` observes the scroll container itself. A scroll container's box changes with the viewport and the composer, never with the messages inside it, so the only thing that scrolls the thread to the bottom is the per-event commit in `autoScroll$`, one animation frame after the events change.

Anything that grows **after** that frame is therefore never followed:

- a mermaid diagram (#24290) renders asynchronously — dynamic `import("mermaid")`, `parse`, `render` — and at commit time it is still a 2rem placeholder;
- an image that loads late, a font that settles, an artifact card that expands.

Growing `scrollHeight` fires no scroll event, so `threadScrollPosition$` stays `null`, `awayFromBottom$` stays `false`, and the floating scroll-to-bottom button stays hidden while the reader sits several hundred pixels above the newest message. It self-heals on the next streamed event and comes back whenever a diagram settles after the last event of a run.

The same gap moves a reader who is holding an anchor: the container has `[overflow-anchor:none]`, so content growing above the viewport drifts their view instead of being compensated (a test added here measures 400px of drift on `main`).

## Change

- Bind the message container (`[data-message-container]`) to a new `scrollContentOnRef$` and observe it. `onRef` handles rebinding, so unlike `container.firstElementChild` this cannot end up observing a detached node.
- Route it into the existing `restoreAfterResize$`, which already does the right thing on both branches: hold the anchor when the reader has one, return to the bottom when they do not.
- `scheduleRestoreAfterResize$` becomes a command shared by both observers, so they still coalesce into one restore per frame through `runtime.resizeScheduled`.
- `commitScrollAfterRender$` / `autoScroll$` move into `createRenderScrollSignals` unchanged — the navigation factory otherwise exceeds `max-lines-per-function`.

## Tests

Two integration tests, both failing on the parent branch:

- content finishing its render after the tail scroll must bring the view back to the bottom;
- content growing above a reader who is holding an anchor must keep that anchor at the same viewport offset (fails with 380 instead of -20 without the observer).
- a second scroll event arriving for content that is still growing must not park the thread (fails by rendering the scroll-to-bottom button, which is what the reader sees when the tail stops following).

The existing resize test's assertion that the message container is *not* observed is inverted, since observing it is the point of this change. Chat scroll, history-navigation, lifecycle and IndexedDB suites pass (86 tests).

## Notes

- Restoring every frame changed the lifetime the programmatic-scroll marker from #24651 needs. It was consumed by the first scroll event that read it, which held while restores were rare; content growing during a run restores each frame and each restore leaves an event behind, so a later event describing the same offset found the marker spent, measured taller content and parked the thread. The marker now clears only once the container reports a different offset.

- The restore now runs at most once per frame while streaming; with an anchor held it selects that anchor by attribute and measures two rects. Collecting every anchor in the thread first, which the old restore did, is a full-history walk before every paint once this path is hot, so `scrollAnchorForEvent` selects directly.
- The same-frame restore was checked in Chrome on a preview of this branch, not only in the mocked observer: a second `ResizeObserver` registered after the app's one — so it runs later in the same delivery, after the restore and before paint — read a bottom gap of `0` for a 424px growth. The jsdom assertions pin that the code does not defer; this pins that the browser has not painted yet when it runs.
- `observe` delivers once by itself when the content ref binds. Both refs belong to the same thread and bind together, so that delivery either lands before the thread is initialized and is dropped by the `initialized` guard, or lands in the frame whose render commit already scrolled and re-applies the position the thread holds.
- The throw both earlier PRs deferred is reachable, and this is the PR that reaches it. The render window, `buildRunGroupFolding` and `completedWorkExpandedKeysForScrollTarget` keep the anchored event mounted, but `splitQueuedEventsForThinkingIndicator` does not: sending while a run is active queues the message and moves it out of the rendered groups into the thinking indicator, which renders no anchor. The restore then threw out of the ResizeObserver callback and out of the render commit, so nothing scrolled and every later resize retried the same restore — the thread froze above the fold with the scroll-to-bottom button showing. A position naming an event nothing renders cannot be held, so both paths clear it and follow the tail. `scrollTo$` still throws, where an unrendered target is a real invariant violation.


