### PR TITLE
fix(platform): render mermaid diagrams only once their fence closes

### DIFF
--- a/turbo/apps/platform/src/lib/rehype-mermaid.ts
+++ b/turbo/apps/platform/src/lib/rehype-mermaid.ts
@@ -14,13 +14,23 @@
  */
 
 const MERMAID_BLOCK_CLASS = "mermaid-block";
+const FENCE_OPENING = /^ {0,3}(`{3,}|~{3,})/;
+
+interface HastPoint {
+  readonly offset?: number;
+}
 
 interface HastNode {
   readonly type: string;
   readonly tagName?: string;
   readonly value?: string;
   readonly properties?: Record<string, unknown>;
+  readonly position?: { readonly start: HastPoint; readonly end: HastPoint };
   children?: HastNode[];
+}
+
+interface MarkdownFile {
+  readonly value?: unknown;
 }
 
 function collectText(node: HastNode): string {
@@ -56,6 +66,36 @@ function mermaidCodeElement(node: HastNode): HastNode | undefined {
   return code;
 }
 
+/**
+ * A streaming assistant message reaches this plugin mid-fence, and markdown
+ * parses an unterminated fence as a code block, so the diagram source would be
+ * a fragment that changes with every chunk. Only the closing delimiter tells a
+ * finished diagram from one that is still arriving; without position data
+ * (no source available) the block is treated as finished, as before.
+ */
+function isClosedFence(node: HastNode, source: string): boolean {
+  const start = node.position?.start.offset;
+  const end = node.position?.end.offset;
+  if (start === undefined || end === undefined) {
+    return true;
+  }
+  const lines = source.slice(start, end).trimEnd().split("\n");
+  const opening = FENCE_OPENING.exec(lines[0] ?? "")?.[1];
+  const closing = lines.length > 1 ? lines[lines.length - 1] : undefined;
+  if (opening === undefined || closing === undefined) {
+    return true;
+  }
+  // CommonMark: the closing delimiter is the same character, at least as long
+  // as the opening one, and carries nothing else.
+  const trimmed = closing.replace(/^ {0,3}/, "");
+  return (
+    trimmed.length >= opening.length &&
+    [...trimmed].every((character) => {
+      return character === opening[0];
+    })
+  );
+}
+
 function mermaidBlockNode(code: string): HastNode {
   return {
     type: "element",
@@ -68,7 +108,7 @@ function mermaidBlockNode(code: string): HastNode {
   };
 }
 
-function replaceMermaidBlocks(node: HastNode): void {
+function replaceMermaidBlocks(node: HastNode, source: string): void {
   const children = node.children;
   if (!children) {
     return;
@@ -76,15 +116,22 @@ function replaceMermaidBlocks(node: HastNode): void {
   for (const [index, child] of children.entries()) {
     const code = mermaidCodeElement(child);
     if (code) {
-      children[index] = mermaidBlockNode(collectText(code).replace(/\n$/, ""));
+      if (isClosedFence(child, source)) {
+        children[index] = mermaidBlockNode(
+          collectText(code).replace(/\n$/, ""),
+        );
+      }
       continue;
     }
-    replaceMermaidBlocks(child);
+    replaceMermaidBlocks(child, source);
   }
 }
 
 export function rehypeMermaid() {
-  return (tree: HastNode): void => {
-    replaceMermaidBlocks(tree);
+  return (tree: HastNode, file: MarkdownFile): void => {
+    replaceMermaidBlocks(
+      tree,
+      typeof file.value === "string" ? file.value : "",
+    );
   };
 }

--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -261,6 +261,39 @@ describe("assistant markdown", () => {
     expect(screen.getByTestId("thread-sidebar-artifacts")).toBeInTheDocument();
   });
 
+  it("leaves a streaming mermaid fence as code until it closes", async () => {
+    mockThread("```mermaid\nflowchart TD\n  A --> B");
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-markdown",
+      featureSwitches: { [FeatureSwitchKey.MermaidDiagrams]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        document.querySelector("code.language-mermaid"),
+      ).toBeInTheDocument();
+    });
+    expect(document.querySelector(".mermaid-block")).toBeNull();
+  });
+
+  it("renders a closed mermaid fence that ends the message", async () => {
+    mockThread("Here is the flow:\n\n```mermaid\nflowchart TD\n  A --> B\n```");
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-markdown",
+      featureSwitches: { [FeatureSwitchKey.MermaidDiagrams]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-testid="mermaid-svg"]'),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("keeps the source visible when a mermaid diagram cannot be parsed", async () => {
     mockThread("```mermaid\nthis is not a diagram\n```");
 


### PR DESCRIPTION
Independent of #24651 / #24658 (different files); the three together are the mermaid autoscroll fix.

## Problem

Markdown parses an unterminated fence as a code block, so as soon as an assistant message streams ` ```mermaid `, `rehypeMermaid` turns it into a mermaid block — with a fragment as its source.

The canvas is keyed by `${theme}:${code}`, so every streamed chunk is a new key:

1. React remounts the canvas, `onRef` aborts the render in flight;
2. status resets to `rendering`, so the block collapses to its 2rem placeholder;
3. the half-written source fails `mermaid.parse`, status becomes `error`, and the fallback renders the source as a tall `<pre>`;
4. the next chunk collapses it back.

So the block oscillates between two heights on every chunk of a diagram, and each chunk pays for a full mermaid parse of a fragment that cannot render.

## Change

Convert a fence only once its closing delimiter has arrived, decided from the source the plugin already receives as the unified `VFile` plus the node's position: the last line of the block must be the same delimiter character, at least as long as the opening run, and carry nothing else (CommonMark's closing rule). No position data — no source — keeps the previous behavior.

While a diagram streams it therefore stays an ordinary code block, whose height grows in step with the text around it (autoscroll follows that fine). When the fence closes, the source it renders from is final, so the canvas mounts once and renders once.

This also removes the reason to key the canvas by source: with a stable source the existing key is stable, so no change is needed there.

## Tests

Two integration tests in `markdown.test.tsx`:

- an unterminated fence stays `code.language-mermaid` and produces no `.mermaid-block` (fails on `main`);
- a closed fence that ends the message still renders — the case a naive "is this the end of the source" check would break.

Existing mermaid tests (theme switching, lightbox, invalid syntax, feature switch off) pass unchanged.

## Note on what remains

A diagram still appears after its message finishes, which is a one-time height change that the per-event scroll commit cannot see. #24658 is what follows that growth back to the bottom.