### PR TITLE
fix(mitm-addon): prevent late 401 auth state resurrection

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -81,6 +81,10 @@ def _get_auth_state(cache_key: FirewallAuthCacheKey) -> _FirewallAuthState:
 def request_force_refresh(cache_key: FirewallAuthCacheKey) -> None:
     """Request a forced token refresh on the next /firewall/auth fetch.
 
+    No-op if registry lifecycle handling has already evicted the key. Response
+    hooks may update auth state owned by an active run, but must not recreate
+    ownership for a completed flow.
+
     No-op if a force-refresh marker was consumed within
     ``_FORCE_REFRESH_COOLDOWN_SECS``. The cooldown starts when the marker is
     consumed, before the forced fetch completes, so the same window covers
@@ -104,7 +108,9 @@ def request_force_refresh(cache_key: FirewallAuthCacheKey) -> None:
       Absolute webhook ``expiresAt`` checks remain wall-clock based elsewhere
       in this module.
     """
-    state = _get_auth_state(cache_key)
+    state = _auth_state.get(cache_key)
+    if state is None:
+        return
     now = time.monotonic()
     last_force_refresh_monotonic_at = state.last_force_refresh_monotonic_at
     if (

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -17,6 +17,7 @@ from tests.auth_state_helpers import (
     cached_headers,
     force_refresh_pending,
     has_auth_state,
+    mark_force_refresh,
     require_cached_headers,
     require_last_force_refresh_monotonic_at,
     set_cached_headers,
@@ -99,7 +100,7 @@ class TestFirewallHeaderCache:
         )
         cache_key = auth_cache_key()
         auth_request = _firewall_auth_request(auth_headers={"Authorization": "template"})
-        auth_cache.request_force_refresh(cache_key)
+        mark_force_refresh(cache_key)
         before_fetch = time.monotonic()
 
         with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -594,9 +594,10 @@ class TestGetFirewallHeaders:
         assert require_last_force_refresh_monotonic_at(cache_key) >= before
         assert cached_headers(cache_key) is None
 
-    def test_force_refresh_first_request_is_allowed_without_previous_timestamp(self, headers):
-        """A fresh auth state has no cooldown timestamp, so the first 401 marks."""
+    def test_force_refresh_first_owned_state_is_allowed_without_previous_timestamp(self):
+        """An owned auth state has no cooldown timestamp, so the first 401 marks."""
         cache_key = auth_cache_key()
+        set_cached_headers(cache_key, headers={"Authorization": "Bearer cached-token"})
 
         with patch.object(auth_cache.time, "monotonic", return_value=10.0):
             auth_cache.request_force_refresh(cache_key)

--- a/crates/runner/mitm-addon/tests/test_response_handler_auth_recovery.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_auth_recovery.py
@@ -11,6 +11,7 @@ import firewall_auth_cache as auth_cache
 import flow_metadata_keys as metadata_keys
 import http_network_log
 import mitm_addon
+import registry
 from tests.auth_state_helpers import (
     auth_cache_key,
     auth_state_is_empty,
@@ -22,6 +23,7 @@ from tests.auth_state_helpers import (
 )
 from tests.flow_helpers import header_map
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
+from tests.registry_helpers import write_simple_registry
 
 
 def test_401_firewall_cache_invalidation(real_flow, mitm_ctx, headers):
@@ -125,26 +127,35 @@ def test_invalid_content_length_with_network_log_does_not_block_401_cache_invali
     assert force_refresh_pending(cache_key)
 
 
-def test_401_without_existing_state_marks_force_refresh(real_flow, mitm_ctx, headers):
-    """401 should request a forced refresh even if no cache entry exists yet."""
+def test_late_401_does_not_recreate_registry_evicted_auth_state(tmp_path, real_flow, mitm_ctx):
+    """A response from an evicted run must not reacquire auth-state ownership."""
+    registry_file = tmp_path / "registry.json"
+    write_simple_registry(registry_file, run_id="run-conn-old")
+    registry.load_registry_state(str(registry_file))
+
     flow = real_flow(with_response=False, host="api.github.com")
-    flow.metadata[metadata_keys.VM_RUN_ID] = "run-conn-new"
+    flow.metadata[metadata_keys.VM_RUN_ID] = "run-conn-old"
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.FIREWALL_BASE] = "https://api.github.com"
-    flow.metadata[metadata_keys.FIREWALL_API_ID] = "run-conn-new:0"
+    flow.metadata[metadata_keys.FIREWALL_API_ID] = "run-conn-old:0"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
     flow.response = tutils.tresp(status_code=401, headers=http.Headers())
 
-    cache_key = auth_cache_key(run_id="run-conn-new", api_id="run-conn-new:0")
+    cache_key = auth_cache_key(run_id="run-conn-old", api_id="run-conn-old:0")
     flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] = cache_key
+    set_cached_headers(cache_key, headers={"Authorization": "Bearer old-token"})
+
+    registry_file.write_text('{"updatedAt": 1, "vms": {}}')
+    removed_run_state = registry.load_registry_state(str(registry_file))
     assert not has_auth_state(cache_key)
 
     with mitm_ctx():
         mitm_addon.response(flow)
 
-    assert cached_headers(cache_key) is None
-    assert force_refresh_pending(cache_key)
+    assert not has_auth_state(cache_key)
+    assert registry.load_registry_state(str(registry_file)) is removed_run_state
+    assert not has_auth_state(cache_key)
 
 
 def test_401_within_cooldown_does_not_re_mark(real_flow, mitm_ctx, headers):


### PR DESCRIPTION
## Summary

- keep registry eviction authoritative by making late force-refresh requests update existing auth state only
- cover registry removal, delayed 401 handling, and the unchanged-registry fast path through a real mitmproxy flow and registry file
- make focused cache tests establish ownership explicitly instead of using a terminal response mutation as setup

## Behavior

An HTTP 401 still clears cached headers and requests a forced refresh for an auth key owned by an active run. If registry lifecycle handling has already evicted the key, the completed flow no longer recreates marker-only auth state.

## Exclusions

- no registry hot-path scan or duplicate active-run/generation state
- no API, schema, persisted-state, wire-format, or deployment-order change

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_response_handler_auth_recovery.py tests/test_auth_cache.py tests/test_firewall_auth.py` (201 passed)
- `uv run --no-sync python -m pytest tests/` (4566 passed)

Closes #24648
