### PR TITLE
docs(rust): clarify session history diagnostic semantics

### DIFF
--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -137,7 +137,18 @@ pub fn claude_zero_turn_failure_for_config(
     with_cli_observed_exit(diagnostic, cli_result.cli_observed_exit.as_ref().cloned())
 }
 
-/// Return session-history availability for failure diagnostics.
+/// Return the conservative session-history target probe for failure diagnostics.
+///
+/// For Claude Code, an existing nonempty history marker supplies the target.
+/// Otherwise, the target is derived from a nonempty, valid session ID. If
+/// neither source resolves a target, this returns `Missing`; errors reading
+/// either source return `Unknown`.
+///
+/// A resolved target is `Empty` only when metadata identifies a zero-byte
+/// regular file. Any other successful metadata result is `Present`, including
+/// a non-regular target, while `NotFound` maps to `Missing` and other metadata
+/// errors map to `Unknown`. The probe does not open or validate history content.
+/// Codex returns `NotApplicable` because this probe does not apply to it.
 pub fn diagnostic_session_history_status_for_config(
     config: &env::GuestConfig,
     runtime_paths: &paths::GuestPaths,
@@ -150,7 +161,14 @@ pub fn diagnostic_session_history_status_for_config(
     }
 }
 
-/// Return whether a session-history status cannot support a recovery checkpoint.
+/// Return whether the zero-turn path has definitive evidence of no history.
+///
+/// Only `Missing` and `Empty` select the `ClaudeZeroTurnNoHistory` shortcut and
+/// skip recovery checkpointing. A false result, including `Present` or
+/// `Unknown`, does not prove that the target is readable or checkpointable; it
+/// lets the real checkpoint attempt determine the outcome. A later checkpoint
+/// failure is classified as `CheckpointFailed`, while success follows normal
+/// completion.
 pub fn session_history_unavailable(status: SessionHistoryStatus) -> bool {
     matches!(
         status,

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -39,7 +39,7 @@ pub struct FailureDiagnostic {
     pub failure_detail_source: Option<FailureDetailSource>,
     /// Parsed detailed failure reason, when available.
     pub failure_reason: Option<FailureReason>,
-    /// Availability of session history at the time of failure.
+    /// Conservative session-history target probe recorded during failure handling.
     pub session_history_status: SessionHistoryStatus,
     /// Content-safe shape classification for the submitted prompt.
     pub prompt_shape: PromptShape,
@@ -685,17 +685,23 @@ impl AgentFramework {
     }
 }
 
-/// Session-history availability observed during failure handling.
+/// Conservative filesystem-probe result for a session-history target.
+///
+/// When applicable, these states describe whether a producer could resolve a
+/// target and inspect its metadata. They do not prove that the target is
+/// readable or can support a recovery checkpoint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionHistoryStatus {
-    /// Session history file was expected but missing.
+    /// No history target could be resolved, or the resolved target was not found.
     Missing,
-    /// Session history file existed but had no useful content.
+    /// The resolved target was a zero-byte regular file.
     Empty,
-    /// Session history file existed with content.
+    /// Metadata lookup succeeded for any other resolved target.
+    ///
+    /// This does not validate the target's file type, readability, or content.
     Present,
-    /// Session history status could not be determined.
+    /// Target resolution or metadata lookup failed for a reason other than absence.
     Unknown,
     /// Session history is not applicable to the framework or failure mode.
     NotApplicable,

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -39,7 +39,7 @@ pub struct FailureDiagnostic {
     pub failure_detail_source: Option<FailureDetailSource>,
     /// Parsed detailed failure reason, when available.
     pub failure_reason: Option<FailureReason>,
-    /// Conservative session-history target probe recorded during failure handling.
+    /// Conservative session-history target status recorded during failure handling.
     pub session_history_status: SessionHistoryStatus,
     /// Content-safe shape classification for the submitted prompt.
     pub prompt_shape: PromptShape,
@@ -687,9 +687,10 @@ impl AgentFramework {
 
 /// Conservative filesystem-probe result for a session-history target.
 ///
-/// When applicable, these states describe whether a producer could resolve a
-/// target and inspect its metadata. They do not prove that the target is
-/// readable or can support a recovery checkpoint.
+/// When a probe runs, these states describe whether a producer could resolve a
+/// target and inspect its metadata. `Unknown` also covers diagnostics created
+/// before a probe can run. No status proves that the target is readable or can
+/// support a recovery checkpoint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionHistoryStatus {
@@ -701,7 +702,8 @@ pub enum SessionHistoryStatus {
     ///
     /// This does not validate the target's file type, readability, or content.
     Present,
-    /// Target resolution or metadata lookup failed for a reason other than absence.
+    /// No probe result was recorded, or target resolution or metadata lookup
+    /// failed for a reason other than absence.
     Unknown,
     /// Session history is not applicable to the framework or failure mode.
     NotApplicable,


### PR DESCRIPTION
## Summary

- describe session-history diagnostics as conservative target metadata observations
- document every `SessionHistoryStatus` producer branch without implying content validation
- explain the zero-turn no-history shortcut, checkpoint fallthrough, and resulting failure classifications

## Scope

This PR changes Rustdoc only. It does not rename public symbols, change serialized values or schema versions, inspect history content, or alter checkpoint and failure-classification behavior. Existing tests already pin the documented behavior.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml --workspace --all-features --no-deps`
- `git diff --check`
- Lefthook pre-commit and commit-message hooks

Closes #24647
