### PR TITLE
test(nbd-cow): cover dropped create attempt cooldown

### DIFF
--- a/crates/nbd-cow/src/device/create.rs
+++ b/crates/nbd-cow/src/device/create.rs
@@ -827,7 +827,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_attempt_guard_drop_aborts_dispatch_task() {
+    async fn create_attempt_guard_drop_aborts_dispatch_and_preserves_lease_cooldown() {
         struct DropNotify(Option<tokio::sync::oneshot::Sender<()>>);
 
         impl Drop for DropNotify {
@@ -839,11 +839,25 @@ mod tests {
         }
 
         let lock_dir = tempfile::tempdir().expect("tempdir");
-        let pool = pool::DevicePoolHandle::new(pool::DevicePoolConfig::default());
-        let mut guard = CreateAttemptGuard::new(
-            pool.clone(),
-            pool::DeviceLease::new_for_test(3, lock_dir.path()),
+        let pool = pool::DevicePoolHandle::new_one_device_for_test(
+            pool::DevicePoolConfig {
+                cooldown: Duration::MAX,
+            },
+            lock_dir.path(),
         );
+        let acquisition = tokio::time::timeout(Duration::from_secs(1), pool.acquire())
+            .await
+            .expect("pool acquire timed out")
+            .expect("pool acquire failed");
+        let (lease, _, _) = acquisition.into_parts();
+        let device_index = lease.index();
+        let snapshot = tokio::time::timeout(Duration::from_secs(1), pool.snapshot())
+            .await
+            .expect("initial pool snapshot timed out");
+        assert!(snapshot.in_flight.contains(&device_index));
+        assert!(snapshot.cooldown.is_empty());
+
+        let mut guard = CreateAttemptGuard::new(pool.clone(), lease);
         let token = guard.shutdown_token();
         let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel();
         let (started_tx, started_rx) = tokio::sync::oneshot::channel();
@@ -854,13 +868,42 @@ mod tests {
             token.cancelled().await;
         }));
 
-        started_rx.await.unwrap();
+        tokio::time::timeout(Duration::from_secs(1), started_rx)
+            .await
+            .expect("dispatch task startup timed out")
+            .expect("dispatch task exited before startup notification");
         drop(guard);
 
-        tokio::time::timeout(std::time::Duration::from_secs(1), dropped_rx)
+        tokio::time::timeout(Duration::from_secs(1), dropped_rx)
             .await
-            .unwrap()
-            .unwrap();
-        pool.cleanup().await;
+            .expect("dispatch task teardown timed out")
+            .expect("dispatch task dropped without notification");
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let snapshot = pool.snapshot().await;
+                if !snapshot.in_flight.contains(&device_index)
+                    && snapshot.cooldown == vec![device_index]
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropped create attempt did not reach cooldown");
+        assert!(
+            crate::device_lock::try_acquire_device_claim_in(device_index, lock_dir.path())
+                .expect("lock probe")
+                .is_none()
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), pool.cleanup())
+            .await
+            .expect("pool cleanup timed out");
+        assert!(
+            crate::device_lock::try_acquire_device_claim_in(device_index, lock_dir.path())
+                .expect("lock probe")
+                .is_some()
+        );
     }
 }

--- a/crates/nbd-cow/src/pool/actor.rs
+++ b/crates/nbd-cow/src/pool/actor.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use std::path::Path;
 use std::time::Instant;
 
 use crate::device_lock::NbdDeviceClaim;
@@ -112,6 +114,16 @@ impl DevicePoolHandle {
     /// that backs the returned handle and all of its clones.
     pub fn new(config: DevicePoolConfig) -> Self {
         Self::from_pool(DevicePool::new(config))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_one_device_for_test(config: DevicePoolConfig, lock_dir: &Path) -> Self {
+        Self::from_pool(DevicePool::new_with_options(
+            config,
+            1,
+            lock_dir.to_path_buf(),
+            |_| true,
+        ))
     }
 
     #[cfg(test)]
@@ -254,7 +266,7 @@ impl DevicePoolHandle {
     }
 
     #[cfg(test)]
-    pub(super) async fn snapshot(&self) -> DevicePoolSnapshot {
+    pub(crate) async fn snapshot(&self) -> DevicePoolSnapshot {
         let (respond_to, response) = oneshot::channel();
         self.commands
             .send(DevicePoolCommand::Snapshot { respond_to })

--- a/crates/nbd-cow/src/pool/state.rs
+++ b/crates/nbd-cow/src/pool/state.rs
@@ -74,9 +74,9 @@ impl Default for DevicePoolConfig {
 
 #[cfg(test)]
 #[derive(Debug)]
-pub(super) struct DevicePoolSnapshot {
-    pub(super) cooldown: Vec<u32>,
-    pub(super) in_flight: HashSet<u32>,
+pub(crate) struct DevicePoolSnapshot {
+    pub(crate) cooldown: Vec<u32>,
+    pub(crate) in_flight: HashSet<u32>,
     pub(super) waiting_acquires: usize,
 }
 


### PR DESCRIPTION
## Summary

- acquire the create-attempt lease through a deterministic one-device pool actor so the test starts from real in-flight state
- extend the guard-drop coverage to assert dispatch teardown, in-flight-to-cooldown transition, cooperative lock retention, and cleanup release
- expose only the required pool constructor and snapshot state under `cfg(test)`

## Scope

- test-only change; production pool and create behavior are unchanged
- no API, protocol, persisted data, migration, dependency, documentation, or rollout changes
- assertions intentionally protect cooldown and lock behavior rather than distinguishing clean and uncertain internal action labels, which currently share the same cooldown transition

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow device::create::tests::create_attempt_guard_drop_aborts_dispatch_and_preserves_lease_cooldown -- --exact`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p nbd-cow --all-features --no-deps`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- pre-commit hooks: workspace Cargo formatting, documentation, Clippy, file-size check, and commitlint

Closes #24650
