### PR TITLE
fix(runner): arm sigint before publishing local jobs

### DIFF
--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -12,6 +12,7 @@ use std::process::ExitCode;
 use std::time::Duration;
 
 use clap::Args;
+use tokio::signal::unix::{Signal, SignalKind, signal};
 use uuid::Uuid;
 
 use crate::active_input::{ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES, active_input_payload_len};
@@ -650,7 +651,7 @@ impl SubmitPlan {
         ActiveInputProducer::start(self.queue.clone(), std::mem::take(&mut self.active_inputs))
     }
 
-    async fn wait_for_result(&self) -> RunnerResult<SubmitOutcome> {
+    async fn wait_for_result(&self, sigint: &mut Signal) -> RunnerResult<SubmitOutcome> {
         let started_at = tokio::time::Instant::now();
 
         loop {
@@ -672,16 +673,16 @@ impl SubmitPlan {
             let remaining = self.timeout.saturating_sub(elapsed);
             tokio::select! {
                 () = tokio::time::sleep(std::cmp::min(POLL_INTERVAL, remaining)) => {}
-                _ = tokio::signal::ctrl_c() => {
+                _ = sigint.recv() => {
                     eprintln!("interrupted — requesting cancel for {}", self.queue.job_id);
                     let _ = local_queue::write_private_marker(&self.queue.cancel, "local cancel marker");
-                    return Ok(self.wait_for_cancel_grace().await);
+                    return Ok(self.wait_for_cancel_grace(sigint).await);
                 }
             }
         }
     }
 
-    async fn wait_for_cancel_grace(&self) -> SubmitOutcome {
+    async fn wait_for_cancel_grace(&self, sigint: &mut Signal) -> SubmitOutcome {
         let grace = tokio::time::Instant::now() + CANCEL_GRACE;
         loop {
             if let Some(buf) = try_read_result(&self.queue.result) {
@@ -696,7 +697,7 @@ impl SubmitPlan {
             }
             tokio::select! {
                 () = tokio::time::sleep(POLL_INTERVAL) => {}
-                _ = tokio::signal::ctrl_c() => {
+                _ = sigint.recv() => {
                     eprintln!("second interrupt, exiting immediately");
                     self.abandon("local submit interrupted before job completed");
                     return SubmitOutcome::Cancelled;
@@ -732,9 +733,13 @@ pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
 
 async fn run_submit_with_home(args: SubmitArgs, home: HomePaths) -> RunnerResult<ExitCode> {
     let mut plan = SubmitPlan::from_args(args, home)?;
+    let mut sigint = signal(SignalKind::interrupt())
+        .map_err(|e| RunnerError::Internal(format!("register local submit SIGINT handler: {e}")))?;
     plan.write_job_file()?;
+    #[cfg(test)]
+    tests::post_publish_test_checkpoint();
     let producer = plan.start_active_input_producer();
-    let outcome = plan.wait_for_result().await;
+    let outcome = plan.wait_for_result(&mut sigint).await;
     if let Some(producer) = producer {
         producer.stop().await;
     }

--- a/crates/runner/src/cmd/local/submit/tests/interrupt.rs
+++ b/crates/runner/src/cmd/local/submit/tests/interrupt.rs
@@ -1,0 +1,105 @@
+use std::ffi::OsStr;
+use std::process::ExitCode;
+use std::time::Duration;
+
+use super::super::run_submit_with_home;
+use super::support::submit_args_for_test;
+use crate::ids::RunId;
+use crate::local_queue::{self, JobRequest, JobResponse};
+use crate::paths::HomePaths;
+use crate::test_fixtures::ignored_child::{
+    ignored_child_test_env_guard_enabled, run_ignored_child_test,
+};
+
+const INTERRUPT_CHILD_ENV: &str = "VM0_RUNNER_LOCAL_SUBMIT_INTERRUPT_TEST";
+const INTERRUPT_CHILD_VALUE: &str = "after-job-publication";
+const INTERRUPT_CHILD_TEST: &str =
+    "cmd::local::submit::tests::interrupt::sigint_after_job_publication_uses_cancel_cleanup_child";
+
+pub(super) fn post_publish_test_checkpoint() {
+    if std::env::var_os(INTERRUPT_CHILD_ENV).as_deref() != Some(OsStr::new(INTERRUPT_CHILD_VALUE)) {
+        return;
+    }
+
+    nix::sys::signal::kill(nix::unistd::Pid::this(), nix::sys::signal::Signal::SIGINT)
+        .expect("send SIGINT after local job publication");
+}
+
+#[tokio::test]
+async fn sigint_after_job_publication_uses_cancel_cleanup() {
+    run_ignored_child_test(
+        INTERRUPT_CHILD_TEST,
+        (INTERRUPT_CHILD_ENV, INTERRUPT_CHILD_VALUE),
+        &[],
+        Duration::from_secs(5),
+    )
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "spawned by sigint_after_job_publication_uses_cancel_cleanup"]
+async fn sigint_after_job_publication_uses_cancel_cleanup_child() {
+    if !ignored_child_test_env_guard_enabled((INTERRUPT_CHILD_ENV, INTERRUPT_CHILD_VALUE)) {
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = HomePaths::with_root(dir.path().to_path_buf());
+    let group_dir = home.groups_dir().join("test/group");
+    let profile = crate::profile::DEFAULT_PROFILE.to_owned();
+    let runner = tokio::spawn(wait_for_cancel_and_write_failure(
+        group_dir.clone(),
+        profile.clone(),
+    ));
+
+    let exit = run_submit_with_home(submit_args_for_test(), home)
+        .await
+        .unwrap();
+    let job_id = runner.await.unwrap();
+
+    assert_eq!(exit, ExitCode::FAILURE);
+    assert!(
+        !local_queue::job_path(&group_dir, &profile, job_id)
+            .unwrap()
+            .exists(),
+        "interrupted submit must not leave an executable job"
+    );
+    assert!(!local_queue::cancel_path(&group_dir, job_id).exists());
+    assert!(!local_queue::claim_path(&group_dir, job_id).exists());
+    assert!(!local_queue::result_path(&group_dir, job_id).exists());
+}
+
+async fn wait_for_cancel_and_write_failure(
+    group_dir: std::path::PathBuf,
+    profile: String,
+) -> RunId {
+    let job_dir = local_queue::profile_jobs_dir(&group_dir, &profile).unwrap();
+    let request = loop {
+        if let Ok(entries) = std::fs::read_dir(&job_dir) {
+            let request = entries.filter_map(Result::ok).find_map(|entry| {
+                let path = entry.path();
+                (path.extension().and_then(|ext| ext.to_str()) == Some("job")).then(|| {
+                    serde_json::from_slice::<JobRequest>(&std::fs::read(path).unwrap()).unwrap()
+                })
+            });
+            if let Some(request) = request {
+                break request;
+            }
+        }
+        tokio::task::yield_now().await;
+    };
+
+    let cancel_path = local_queue::cancel_path(&group_dir, request.job_id);
+    while !local_queue::marker_file_exists(&cancel_path, "local cancel marker").unwrap() {
+        tokio::task::yield_now().await;
+    }
+
+    let result = JobResponse {
+        run_id: request.job_id,
+        exit_code: 1,
+        error: Some("cancelled by test runner".to_owned()),
+    };
+    let result_path = local_queue::result_path(&group_dir, request.job_id);
+    std::fs::write(result_path, serde_json::to_vec(&result).unwrap()).unwrap();
+    request.job_id
+}

--- a/crates/runner/src/cmd/local/submit/tests/mod.rs
+++ b/crates/runner/src/cmd/local/submit/tests/mod.rs
@@ -1,9 +1,14 @@
 mod abandoned_cleanup;
 mod active_inputs;
 mod completed_cleanup;
+mod interrupt;
 mod queue_publication;
 mod request;
 mod result_markers;
 mod support;
 mod timezone;
 mod validation;
+
+pub(super) fn post_publish_test_checkpoint() {
+    interrupt::post_publish_test_checkpoint();
+}


### PR DESCRIPTION
## Summary

- synchronously register and retain the local-submit Unix SIGINT stream before publishing the executable `.job`
- reuse the retained stream for the existing first-interrupt cancel flow and second-interrupt abandonment flow
- add a deterministic child-process regression that sends SIGINT after publication but before result polling and verifies queue cleanup

## Scope

- no API, queue protocol, serialized payload, schema, migration, or persisted-data changes
- no changes to `runner start` or other command signal semantics

Closes #24649

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::local::submit::tests::interrupt::sigint_after_job_publication_uses_cancel_cleanup -- --nocapture`
- 20 consecutive focused regression runs
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::local::submit::tests` (61 passed, 2 ignored)
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features` (2,920 passed, 15 ignored; guest inventory 1 passed)
- staged Rust pre-commit hooks (`cargo-fmt`, `cargo-doc`, `cargo-clippy`, file-size check, commitlint)
