### PR TITLE
fix(python): preserve x fallback counts across empty repeated selectors

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -540,7 +540,7 @@ def _count_bounded_non_empty_comma_segments(value: str, max_count: int) -> int |
         count += 1
         if count > max_count:
             return None
-    return count or None
+    return count
 
 
 def _empty_request_query_fallback_hints() -> dict:
@@ -697,9 +697,6 @@ def _parse_request_query_fallback_hints(original_url: str) -> dict:
                         decoded_value = urllib.parse.unquote_plus(raw_value)
                         if id_count_max is not None:
                             remaining = id_count_max - ids_count
-                            if remaining < 1:
-                                ids_count = 0
-                                break
                             value_count = _count_bounded_non_empty_comma_segments(
                                 decoded_value, remaining
                             )

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
@@ -361,6 +361,78 @@ def test_unparseable_response_accumulates_repeated_id_like_fallback_hints(
     assert p["quantity"] == 3
 
 
+@pytest.mark.parametrize(
+    ("path", "query", "permission", "rule", "expected_category", "expected_quantity"),
+    [
+        (
+            "/2/tweets",
+            "ids=1,2&ids=,,",
+            "tweet.read",
+            "GET /2/tweets",
+            "posts.read",
+            2,
+        ),
+        (
+            "/2/tweets",
+            "ids=,,&ids=1,2",
+            "tweet.read",
+            "GET /2/tweets",
+            "posts.read",
+            2,
+        ),
+        (
+            "/2/users/by",
+            "usernames=a,b&usernames=,,",
+            "users.read",
+            "GET /2/users/by",
+            "user.read",
+            2,
+        ),
+        (
+            "/2/users/by",
+            "usernames=,,&usernames=a,b",
+            "users.read",
+            "GET /2/users/by",
+            "user.read",
+            2,
+        ),
+        (
+            "/2/tweets",
+            f"ids={','.join(str(i) for i in range(100))}&ids=,,",
+            "tweet.read",
+            "GET /2/tweets",
+            "posts.read",
+            100,
+        ),
+    ],
+)
+def test_unparseable_response_preserves_repeated_selector_counts_across_empty_values(
+    x_usage,
+    tmp_path,
+    real_flow,
+    path,
+    query,
+    permission,
+    rule,
+    expected_category,
+    expected_quantity,
+):
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path=path,
+        query=query,
+        body=b"not json",
+        permission=permission,
+        rule=rule,
+    )
+
+    event = x_usage.call_and_get_single_billing(flow)
+
+    assert event["category"] == expected_category
+    assert event["quantity"] == expected_quantity
+
+
 def test_unparseable_response_does_not_treat_semicolon_as_query_separator(
     x_usage, tmp_path, real_flow
 ):
@@ -750,6 +822,12 @@ def test_x_json_parse_error_ignores_id_like_hints_on_irrelevant_paths(
             f"usernames={','.join(f'user{i}' for i in range(101))}",
             "users.read",
             "GET /2/users/by",
+        ),
+        (
+            "/2/tweets",
+            f"ids={','.join(str(i) for i in range(100))}&ids=overflow",
+            "tweet.read",
+            "GET /2/tweets",
         ),
     ],
 )

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
@@ -398,7 +398,7 @@ def test_unparseable_response_accumulates_repeated_id_like_fallback_hints(
         ),
         (
             "/2/tweets",
-            f"ids={','.join(str(i) for i in range(100))}&ids=,,",
+            f"ids={','.join(str(i) for i in range(1, 101))}&ids=,,",
             "tweet.read",
             "GET /2/tweets",
             "posts.read",
@@ -825,7 +825,7 @@ def test_x_json_parse_error_ignores_id_like_hints_on_irrelevant_paths(
         ),
         (
             "/2/tweets",
-            f"ids={','.join(str(i) for i in range(100))}&ids=overflow",
+            f"ids={','.join(str(i) for i in range(1, 101))}&ids=,,&ids=101",
             "tweet.read",
             "GET /2/tweets",
         ),


### PR DESCRIPTION
## Summary

- treat all-empty repeated X `ids` and `usernames` values as zero contributions instead of invalidating valid fallback counts
- let the bounded counter distinguish exact-limit empty values from selector overflow without adding another scan or allocation
- cover both selector orders, exact-limit preservation, and repeated-value overflow through the connector usage entry point

## Scope

- no schema, migration, persisted-data, API, queue payload, runner protocol, configuration, or event-shape changes
- parsed-response billing, endpoint policies, query byte bounds, `max_results`, and the lost-visibility audit path remain unchanged

## Tests

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/x_connector_usage/test_unparseable.py`
- `uv run --no-sync python -m pytest tests/`

Closes #24653
