### PR TITLE
perf(guest-agent): bound checkpoint history test fixtures

### DIFF
--- a/crates/guest-agent/src/checkpoint/mod.rs
+++ b/crates/guest-agent/src/checkpoint/mod.rs
@@ -72,6 +72,7 @@ struct CheckpointInputs<'a> {
     run_id: &'a str,
     framework: env::Framework,
     claude_session_pruning_enabled: bool,
+    session_history_limits: session_history::CheckpointSessionHistoryLimits,
     home_dir: &'a str,
     artifact_entries: &'a [env::ArtifactEnv],
     session_id_file: Cow<'a, str>,
@@ -90,6 +91,7 @@ impl<'a> CheckpointInputs<'a> {
                 .get(CLAUDE_SESSION_PRUNING_FEATURE_FLAG)
                 .copied()
                 .unwrap_or(false),
+            session_history_limits: session_history::CheckpointSessionHistoryLimits::Production,
             home_dir: &runtime.config.home_dir,
             artifact_entries: &runtime.config.artifacts,
             session_id_file: Cow::Borrowed(runtime.paths.session_id_file()),
@@ -107,11 +109,43 @@ pub async fn create_checkpoint_for_runtime(runtime: &GuestRuntime) -> Result<(),
     create_checkpoint_with_inputs(&runtime.http, &inputs).await
 }
 
+/// Create a checkpoint with bounded session-history limits for integration tests.
+#[doc(hidden)]
+pub async fn create_checkpoint_for_runtime_with_history_limits_for_test(
+    runtime: &GuestRuntime,
+    candidate_max_bytes: u64,
+    checkpoint_max_bytes: u64,
+) -> Result<(), AgentError> {
+    let mut inputs = CheckpointInputs::from_runtime(runtime);
+    inputs.session_history_limits =
+        session_history::CheckpointSessionHistoryLimits::BoundedForTest {
+            candidate_max_bytes,
+            checkpoint_max_bytes,
+        };
+    create_checkpoint_with_inputs(&runtime.http, &inputs).await
+}
+
 /// Create a best-effort recovery checkpoint using the explicit runtime snapshot.
 pub async fn create_recovery_checkpoint_for_runtime(
     runtime: &GuestRuntime,
 ) -> Result<(), AgentError> {
     let inputs = CheckpointInputs::from_runtime(runtime);
+    create_recovery_checkpoint_with_inputs(&runtime.http, &inputs).await
+}
+
+/// Create a recovery checkpoint with bounded session-history limits for integration tests.
+#[doc(hidden)]
+pub async fn create_recovery_checkpoint_for_runtime_with_history_limits_for_test(
+    runtime: &GuestRuntime,
+    candidate_max_bytes: u64,
+    checkpoint_max_bytes: u64,
+) -> Result<(), AgentError> {
+    let mut inputs = CheckpointInputs::from_runtime(runtime);
+    inputs.session_history_limits =
+        session_history::CheckpointSessionHistoryLimits::BoundedForTest {
+            candidate_max_bytes,
+            checkpoint_max_bytes,
+        };
     create_recovery_checkpoint_with_inputs(&runtime.http, &inputs).await
 }
 
@@ -346,6 +380,7 @@ mod tests {
             run_id: "checkpoint-missing-mount",
             framework: env::Framework::ClaudeCode,
             claude_session_pruning_enabled: false,
+            session_history_limits: session_history::CheckpointSessionHistoryLimits::Production,
             home_dir: &home_dir,
             artifact_entries: &entries,
             session_id_file: guest_paths.session_id_file().into(),
@@ -440,6 +475,7 @@ mod tests {
             run_id: "checkpoint-codex-zstd-reuse",
             framework: env::Framework::Codex,
             claude_session_pruning_enabled: false,
+            session_history_limits: session_history::CheckpointSessionHistoryLimits::Production,
             home_dir: &home_dir,
             artifact_entries: &[],
             session_id_file: guest_paths.session_id_file().into(),

--- a/crates/guest-agent/src/checkpoint/session_history.rs
+++ b/crates/guest-agent/src/checkpoint/session_history.rs
@@ -19,7 +19,8 @@ use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
 use guest_session_prune::{
     ClaudeHistorySelection, CodexHistorySelection, select_claude_compact_generation,
-    select_codex_compact_generation,
+    select_claude_compact_generation_with_candidate_limit_for_test,
+    select_codex_compact_generation, select_codex_compact_generation_with_candidate_limit_for_test,
 };
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -29,6 +30,63 @@ use std::time::Duration;
 
 const SESSION_HISTORY_ZSTD_LEVEL: i32 = 3;
 const SESSION_HISTORY_COMPRESSION_MIN_BYTES: usize = SESSION_HISTORY_GZIP_MIN_BYTES as usize;
+
+#[derive(Clone, Copy)]
+pub(super) enum CheckpointSessionHistoryLimits {
+    Production,
+    BoundedForTest {
+        candidate_max_bytes: u64,
+        checkpoint_max_bytes: u64,
+    },
+}
+
+impl CheckpointSessionHistoryLimits {
+    fn checkpoint_max_bytes(self) -> u64 {
+        match self {
+            Self::Production => RESUME_SESSION_HISTORY_MAX_BYTES,
+            Self::BoundedForTest {
+                checkpoint_max_bytes,
+                ..
+            } => checkpoint_max_bytes,
+        }
+    }
+
+    fn select_claude(
+        self,
+        source_path: &str,
+        expected_session_id: &str,
+    ) -> std::io::Result<ClaudeHistorySelection> {
+        match self {
+            Self::Production => select_claude_compact_generation(source_path, expected_session_id),
+            Self::BoundedForTest {
+                candidate_max_bytes,
+                ..
+            } => select_claude_compact_generation_with_candidate_limit_for_test(
+                source_path,
+                expected_session_id,
+                candidate_max_bytes,
+            ),
+        }
+    }
+
+    fn select_codex(
+        self,
+        source: &mut std::fs::File,
+        expected_thread_id: &str,
+    ) -> std::io::Result<CodexHistorySelection> {
+        match self {
+            Self::Production => select_codex_compact_generation(source, expected_thread_id),
+            Self::BoundedForTest {
+                candidate_max_bytes,
+                ..
+            } => select_codex_compact_generation_with_candidate_limit_for_test(
+                source,
+                expected_thread_id,
+                candidate_max_bytes,
+            ),
+        }
+    }
+}
 
 enum SessionHistoryUploadBody {
     Identity(Vec<u8>),
@@ -199,6 +257,7 @@ pub(super) struct CheckpointSessionHistoryInputs {
     mode: CheckpointMode,
     framework: env::Framework,
     claude_session_pruning_enabled: bool,
+    limits: CheckpointSessionHistoryLimits,
     home_dir: String,
     session_id_file: String,
     session_history_path_file: String,
@@ -210,6 +269,7 @@ impl CheckpointSessionHistoryInputs {
             mode,
             framework: inputs.framework,
             claude_session_pruning_enabled: inputs.claude_session_pruning_enabled,
+            limits: inputs.session_history_limits,
             home_dir: inputs.home_dir.to_string(),
             session_id_file: inputs.session_id_file.to_string(),
             session_history_path_file: inputs.session_history_path_file.to_string(),
@@ -357,6 +417,7 @@ fn prepare_session_history(
     mode: CheckpointMode,
     framework: env::Framework,
     claude_session_pruning_enabled: bool,
+    limits: CheckpointSessionHistoryLimits,
     cli_agent_session_id: &str,
     history_marker_payload: &str,
     history_read_start: std::time::Instant,
@@ -367,7 +428,7 @@ fn prepare_session_history(
         && !history::is_codex_marker(history_marker_payload)
     {
         let prune_start = std::time::Instant::now();
-        match select_claude_compact_generation(history_marker_payload, cli_agent_session_id) {
+        match limits.select_claude(history_marker_payload, cli_agent_session_id) {
             Ok(ClaudeHistorySelection::Candidate(candidate)) => {
                 let source_size = candidate.source_size();
                 let candidate_size = candidate.candidate_size();
@@ -423,7 +484,7 @@ fn prepare_session_history(
         match history::resolve_codex_session_history_from_payload(history_marker_payload) {
             Ok(mut source) => {
                 if let Some(file) = source.plain_file_mut() {
-                    match select_codex_compact_generation(file, cli_agent_session_id) {
+                    match limits.select_codex(file, cli_agent_session_id) {
                         Ok(CodexHistorySelection::Candidate(candidate)) => {
                             let source_size = candidate.source_size();
                             let candidate_size = candidate.candidate_size();
@@ -502,14 +563,15 @@ fn prepare_session_history(
         }
     }
 
+    let checkpoint_max_bytes = limits.checkpoint_max_bytes();
     let source_result = resolved_codex_history.map_or_else(
         || {
             history::read_session_history_checkpoint_source_from_payload_bounded(
                 history_marker_payload,
-                RESUME_SESSION_HISTORY_MAX_BYTES,
+                checkpoint_max_bytes,
             )
         },
-        |source| source.into_checkpoint_source_bounded(RESUME_SESSION_HISTORY_MAX_BYTES),
+        |source| source.into_checkpoint_source_bounded(checkpoint_max_bytes),
     );
     let source = match source_result {
         Ok(source) => source,
@@ -527,7 +589,12 @@ fn prepare_session_history(
             prepare_raw_session_history(mode, history_read_start, history_bytes)
         }
         history::SessionHistoryCheckpointSource::CodexZstd { encoded } => {
-            prepare_reused_zstd_session_history(mode, history_read_start, encoded)
+            prepare_reused_zstd_session_history(
+                mode,
+                history_read_start,
+                encoded,
+                checkpoint_max_bytes,
+            )
         }
     }
 }
@@ -604,13 +671,13 @@ fn prepare_reused_zstd_session_history(
     mode: CheckpointMode,
     history_read_start: std::time::Instant,
     zstd_bytes: Vec<u8>,
+    checkpoint_max_bytes: u64,
 ) -> Result<PreparedSessionHistory, AgentError> {
-    let analysis = analyze_zstd_session_history(
-        &zstd_bytes,
-        RESUME_SESSION_HISTORY_MAX_BYTES,
-        mode.validate_history(),
-    )
-    .map_err(|e| fail_preserving_error(mode, "session_history_read", history_read_start, e))?;
+    let analysis =
+        analyze_zstd_session_history(&zstd_bytes, checkpoint_max_bytes, mode.validate_history())
+            .map_err(|e| {
+                fail_preserving_error(mode, "session_history_read", history_read_start, e)
+            })?;
 
     if let Some(msg) = &analysis.invalid_utf8 {
         if mode.validate_history() {
@@ -770,6 +837,7 @@ fn prepare_checkpoint_session_history(
         mode,
         framework,
         claude_session_pruning_enabled,
+        limits,
         home_dir,
         session_id_file,
         session_history_path_file,
@@ -833,6 +901,7 @@ fn prepare_checkpoint_session_history(
         mode,
         framework,
         claude_session_pruning_enabled,
+        limits,
         &cli_agent_session_id,
         &history_marker_payload,
         history_read_start,

--- a/crates/guest-agent/tests/integration/checkpoint/recovery.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/recovery.rs
@@ -137,6 +137,30 @@ async fn recovery_checkpoint_does_not_prune_eligible_codex_history() {
     assert!(!std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists());
     prepare_mock.assert_calls_async(0).await;
     checkpoint_mock.assert_calls_async(0).await;
+
+    let source_history = std::fs::read(&history_path).unwrap();
+    let encoded_history = zstd_session_history_for_test(&source_history).unwrap();
+    let encoded_history_path = history_path.with_extension("jsonl.zst");
+    std::fs::write(&encoded_history_path, &encoded_history).unwrap();
+    std::fs::remove_file(&history_path).unwrap();
+
+    let error = create_bounded_recovery_checkpoint(&runtime)
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("Session history exceeds maximum size"),
+        "recovery checkpoint must apply the bounded hard limit to reused Codex zstd: {error}"
+    );
+    assert_eq!(
+        std::fs::read(&encoded_history_path).unwrap(),
+        encoded_history
+    );
+    assert!(!std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists());
+    prepare_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(0).await;
 }
 
 async fn assert_recovery_checkpoint_derives_claude_history_marker(

--- a/crates/guest-agent/tests/integration/checkpoint/recovery.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/recovery.rs
@@ -84,7 +84,7 @@ async fn recovery_checkpoint_does_not_prune_eligible_claude_history() {
         then.status(200);
     });
 
-    let error = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(&runtime)
+    let error = create_bounded_recovery_checkpoint(&runtime)
         .await
         .unwrap_err();
 
@@ -123,7 +123,7 @@ async fn recovery_checkpoint_does_not_prune_eligible_codex_history() {
         then.status(200);
     });
 
-    let error = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(&runtime)
+    let error = create_bounded_recovery_checkpoint(&runtime)
         .await
         .unwrap_err();
 

--- a/crates/guest-agent/tests/integration/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/success.rs
@@ -145,9 +145,7 @@ async fn success_checkpoint_preserves_oversized_claude_history_when_pruning_disa
             .json_body(json!({"checkpointId": "checkpoint-unpruned-claude"}));
     });
 
-    guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime)
-        .await
-        .unwrap();
+    create_bounded_checkpoint(&runtime).await.unwrap();
 
     prepare_mock.assert_calls_async(1).await;
     checkpoint_mock.assert_calls_async(1).await;
@@ -271,9 +269,7 @@ async fn success_checkpoint_reconciles_claude_compact_generation_after_commit() 
         });
     });
 
-    guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime)
-        .await
-        .unwrap();
+    create_bounded_checkpoint(&runtime).await.unwrap();
 
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(1).await;
@@ -362,9 +358,7 @@ async fn success_checkpoint_reconciles_codex_compact_generation_after_commit() {
         });
     });
 
-    guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime)
-        .await
-        .unwrap();
+    create_bounded_checkpoint(&runtime).await.unwrap();
 
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(1).await;
@@ -432,9 +426,7 @@ async fn success_checkpoint_omits_identity_when_live_history_replacement_fails()
         });
     });
 
-    guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime)
-        .await
-        .unwrap();
+    create_bounded_checkpoint(&runtime).await.unwrap();
 
     prepare_mock.assert_calls_async(1).await;
     checkpoint_mock.assert_calls_async(1).await;
@@ -476,9 +468,7 @@ async fn success_checkpoint_keeps_live_history_when_compact_commit_fails() {
             .json_body(json!({}));
     });
 
-    let error = guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime)
-        .await
-        .unwrap_err();
+    let error = create_bounded_checkpoint(&runtime).await.unwrap_err();
 
     assert!(
         error

--- a/crates/guest-agent/tests/integration/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/success.rs
@@ -486,7 +486,8 @@ async fn success_checkpoint_uploads_non_utf8_session_history() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
-    let runtime = runtime_from_process_env().unwrap();
+    let mut runtime = runtime_from_process_env().unwrap();
+    set_claude_session_pruning(&mut runtime, true);
     let _files_guard = SessionCheckpointFilesGuard::new();
     let history = b"{\"type\":\"system\"}\nnon-utf8:\xC3(\n".to_vec();
     let _history_dir = write_literal_session_history("success-non-utf8-session", &history).unwrap();

--- a/crates/guest-agent/tests/integration/checkpoint/support.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/support.rs
@@ -9,9 +9,34 @@ use std::{
 };
 
 pub(super) const LARGE_SESSION_HISTORY_SIZE_BYTES: usize = 1024 * 1024 + 1;
+pub(super) const CHECKPOINT_TEST_CANDIDATE_MAX_BYTES: u64 =
+    api_contracts::generated::constants::runners::SESSION_HISTORY_GZIP_MIN_BYTES;
+pub(super) const CHECKPOINT_TEST_MAX_BYTES: u64 = CHECKPOINT_TEST_CANDIDATE_MAX_BYTES * 2;
 
 pub(super) fn runtime_from_process_env() -> Result<guest_agent::run_context::GuestRuntime, String> {
     guest_agent::run_context::GuestRuntime::from_process_env()
+}
+
+pub(super) async fn create_bounded_checkpoint(
+    runtime: &guest_agent::run_context::GuestRuntime,
+) -> Result<(), guest_agent::error::AgentError> {
+    guest_agent::checkpoint::create_checkpoint_for_runtime_with_history_limits_for_test(
+        runtime,
+        CHECKPOINT_TEST_CANDIDATE_MAX_BYTES,
+        CHECKPOINT_TEST_MAX_BYTES,
+    )
+    .await
+}
+
+pub(super) async fn create_bounded_recovery_checkpoint(
+    runtime: &guest_agent::run_context::GuestRuntime,
+) -> Result<(), guest_agent::error::AgentError> {
+    guest_agent::checkpoint::create_recovery_checkpoint_for_runtime_with_history_limits_for_test(
+        runtime,
+        CHECKPOINT_TEST_CANDIDATE_MAX_BYTES,
+        CHECKPOINT_TEST_MAX_BYTES,
+    )
+    .await
 }
 
 pub(super) fn set_claude_session_pruning(
@@ -154,7 +179,7 @@ pub(super) fn write_prunable_claude_history(
     let mut history_file =
         std::fs::File::create(&history_path).map_err(|error| format!("create history: {error}"))?;
     history_file
-        .set_len(guest_session_prune::CLAUDE_COMPACT_GENERATION_MAX_BYTES + 1)
+        .set_len(CHECKPOINT_TEST_CANDIDATE_MAX_BYTES + 1)
         .map_err(|error| format!("size history: {error}"))?;
     history_file
         .seek(SeekFrom::End(0))
@@ -290,7 +315,7 @@ pub(super) fn write_prunable_codex_history(
         .write_all(&canonical)
         .map_err(|error| format!("write canonical Codex history: {error}"))?;
     history_file
-        .set_len(api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES + 1)
+        .set_len(CHECKPOINT_TEST_MAX_BYTES + 1)
         .map_err(|error| format!("size Codex history: {error}"))?;
     history_file
         .seek(SeekFrom::End(0))

--- a/crates/guest-session-prune/src/codex.rs
+++ b/crates/guest-session-prune/src/codex.rs
@@ -267,6 +267,24 @@ pub fn select_codex_compact_generation(
     select_with_limits_and_hook(source, expected_thread_id, PRODUCTION_LIMITS, || {})
 }
 
+/// Select a Codex compact generation with a bounded integration-test window.
+#[doc(hidden)]
+pub fn select_codex_compact_generation_with_candidate_limit_for_test(
+    source: &mut File,
+    expected_thread_id: &str,
+    candidate_max_bytes: u64,
+) -> io::Result<CodexHistorySelection> {
+    select_with_limits_and_hook(
+        source,
+        expected_thread_id,
+        SelectionLimits {
+            candidate_max_bytes,
+            ..PRODUCTION_LIMITS
+        },
+        || {},
+    )
+}
+
 fn select_with_limits_and_hook(
     source: &mut File,
     expected_thread_id: &str,

--- a/crates/guest-session-prune/src/lib.rs
+++ b/crates/guest-session-prune/src/lib.rs
@@ -17,6 +17,7 @@ use uuid::Uuid;
 pub use codex::{
     CODEX_COMPACT_GENERATION_MAX_BYTES, CODEX_JSONL_RECORD_MAX_BYTES, CodexHistoryCandidate,
     CodexHistoryIneligibleReason, CodexHistorySelection, select_codex_compact_generation,
+    select_codex_compact_generation_with_candidate_limit_for_test,
 };
 
 /// Maximum decoded size of an accepted Claude compact generation.
@@ -291,6 +292,24 @@ pub fn select_claude_compact_generation(
         source_path.as_ref(),
         expected_session_id,
         SelectionLimits::PRODUCTION,
+        || {},
+    )
+}
+
+/// Select a Claude compact generation with a bounded integration-test window.
+#[doc(hidden)]
+pub fn select_claude_compact_generation_with_candidate_limit_for_test(
+    source_path: impl AsRef<Path>,
+    expected_session_id: &str,
+    candidate_max_bytes: u64,
+) -> io::Result<ClaudeHistorySelection> {
+    select_with_limits_and_hook(
+        source_path.as_ref(),
+        expected_session_id,
+        SelectionLimits {
+            candidate_max_bytes,
+            ..SelectionLimits::PRODUCTION
+        },
         || {},
     )
 }


### PR DESCRIPTION
## Summary

- add doc-hidden, per-call bounded selector and checkpoint entry points for integration tests
- reduce seven repeated checkpoint fixtures from production-scale 64-128 MiB histories to 64-128 KiB histories
- preserve the existing public production-boundary tests and all checkpoint lifecycle assertions

## Scope

Production selector guards, checkpoint size limits, runtime behavior, configuration, protocols, and persisted data are unchanged. Only explicitly named integration-test entry points can construct the private bounded limit policy.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p guest-session-prune`
- `cargo test -p guest-agent --test integration checkpoint:: -- --test-threads=1`
- `cargo test -p guest-agent`
- `cargo clippy -p guest-session-prune -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-session-prune -p guest-agent --all-features --no-deps`
- `cargo llvm-cov --no-report -p guest-agent --test integration -- checkpoint:: --test-threads=1`

The focused coverage run retained all 27 checkpoint tests and completed the test phase in 1.33 seconds, down from the 2.29-second current-main baseline (about 42% faster). Compilation time was measured separately.

Closes #24652
