### PR TITLE
test(python): cover missing sigv4 signed headers

### DIFF
--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -887,6 +887,23 @@ async def test_header_sigv4_with_duplicate_signed_header_fails_closed(
     assert_sigv4_failed_closed(result, flow, "Malformed AWS signed headers")
 
 
+async def test_header_sigv4_with_missing_signed_header_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    flow = make_sts_header_sigv4_flow(
+        real_flow,
+        headers,
+        signed_headers="host;x-amz-date;x-test",
+    )
+
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+
+    assert_sigv4_failed_closed(result, flow, "AWS signed header is missing")
+
+
 async def test_header_sigv4_without_host_signed_header_fails_closed(
     real_flow,
     headers,
@@ -1086,6 +1103,21 @@ async def test_query_sigv4_with_duplicate_signed_header_fails_closed(
     result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
     assert_sigv4_failed_closed(result, flow, "Malformed AWS signed headers")
+
+
+async def test_query_sigv4_with_missing_signed_header_fails_closed(
+    real_flow,
+    tmp_path,
+    mitm_ctx,
+):
+    flow = make_sts_query_sigv4_flow(
+        real_flow,
+        path=aws_sigv4_presigned_query_path(signed_headers="host;x-test"),
+    )
+
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+
+    assert_sigv4_failed_closed(result, flow, "AWS signed header is missing")
 
 
 async def test_query_sigv4_without_host_signed_header_fails_closed(


### PR DESCRIPTION
## Summary

- cover missing declared custom headers for both SigV4 header authentication and presigned-query authentication
- exercise the real firewall-auth entry point and verify the terminal `502 aws_sigv4_auth_failed` response
- prove both cases fail with `KeyError` when the production missing-header guard is temporarily removed

## Scope

- test-only change in the mitmproxy addon
- no production behavior, shared helper, API, schema, protocol, dependency, migration, compatibility, or documentation changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- focused new tests on the production guard: 2 passed
- focused mutation check with only the guard removed: 2 failed with the expected `KeyError: 'x-test'`
- `uv run --no-sync python -m pytest tests/`: 4568 passed

Closes #24655
