### PR TITLE
fix: stabilize segmented voice transcription

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
@@ -609,6 +609,41 @@ describe("POST /api/zero/voice-io/*", () => {
     });
   });
 
+  it("retries a transient BytePlus gateway failure once", async () => {
+    const fixture = await seedVoiceFixture({});
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const requestIds: string[] = [];
+    let requestCount = 0;
+    server.use(
+      http.post(BYTEPLUS_ASR_FLASH_URL, ({ request }) => {
+        requestCount += 1;
+        const requestId = request.headers.get("x-api-request-id");
+        if (requestId) {
+          requestIds.push(requestId);
+        }
+        if (requestCount === 1) {
+          return HttpResponse.text("Gateway Timeout", { status: 504 });
+        }
+        return bytePlusSttResponse("hello after retry");
+      }),
+    );
+
+    const app = createVoiceIoTestApp();
+    const response = await app.request("/api/zero/voice-io/stt", {
+      method: "POST",
+      headers: authHeaders(),
+      body: sttForm(sttFile(wavBytes(1))),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({
+      text: "hello after retry",
+    });
+    expect(requestCount).toBe(2);
+    expect(requestIds).toHaveLength(2);
+    expect(new Set(requestIds).size).toBe(2);
+  });
+
   it("accepts BytePlus no-speech responses as empty transcripts", async () => {
     const fixture = await seedVoiceFixture({});
     mocks.clerk.session(fixture.userId, fixture.orgId);
@@ -921,8 +956,10 @@ describe("POST /api/zero/voice-io/*", () => {
       sttDailyDurationKey(),
       FREE_DAILY_DURATION_LIMIT_SECONDS - 3,
     );
+    let requestCount = 0;
     server.use(
       http.post(BYTEPLUS_ASR_FLASH_URL, () => {
+        requestCount += 1;
         return HttpResponse.json(
           { error: { message: "rate limit exceeded" } },
           { status: 429 },
@@ -946,6 +983,7 @@ describe("POST /api/zero/voice-io/*", () => {
       count: 0,
       limit: AUDIO_INPUT_FREE_QUOTA,
     });
+    expect(requestCount).toBe(1);
   });
 
   it("blocks /stt before BytePlus when the daily request limit is exhausted", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
@@ -19,6 +19,7 @@ import {
 } from "../services/zero-voice-io-post.service";
 
 const L = logger("ZeroVoiceIoStt");
+const MAX_CLIENT_DIAGNOSTICS_LOG_LENGTH = 1000;
 
 function logSttUploadInspection(
   file: File,
@@ -32,7 +33,9 @@ function logSttUploadInspection(
     fileName: file.name,
     parsedDurationSeconds,
     clientDiagnostics:
-      typeof clientDiagnostics === "string" ? clientDiagnostics : null,
+      typeof clientDiagnostics === "string"
+        ? clientDiagnostics.slice(0, MAX_CLIENT_DIAGNOSTICS_LOG_LENGTH)
+        : null,
   });
 }
 

--- a/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
+++ b/turbo/apps/api/src/signals/routes/zero-voice-io-stt.ts
@@ -20,6 +20,22 @@ import {
 
 const L = logger("ZeroVoiceIoStt");
 
+function logSttUploadInspection(
+  file: File,
+  parsedDurationSeconds: number | null,
+  formData: FormData,
+): void {
+  const clientDiagnostics = formData.get("clientDiagnostics");
+  L.debug("STT upload inspected", {
+    fileMime: file.type,
+    fileSize: file.size,
+    fileName: file.name,
+    parsedDurationSeconds,
+    clientDiagnostics:
+      typeof clientDiagnostics === "string" ? clientDiagnostics : null,
+  });
+}
+
 const postSttInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const quota = await get(audioInputLifetimeQuota(auth.orgId, auth.userId));
@@ -71,6 +87,7 @@ const postSttInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   const durationSeconds = await getAudioDuration(file);
   signal.throwIfAborted();
+  logSttUploadInspection(file, durationSeconds, formData);
   if (
     durationSeconds !== null &&
     durationSeconds > MAX_STT_REQUEST_DURATION_SECONDS

--- a/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
@@ -108,6 +108,14 @@ interface VoiceInputSttTranscript {
 
 type VoiceInputSttProviderResult = VoiceInputSttTranscript | ErrorResponse;
 
+interface BytePlusSttAttempt {
+  readonly response: Response;
+  readonly requestId: string;
+  readonly providerStatus: string | null;
+  readonly providerDurationMs: number;
+  readonly attempt: number;
+}
+
 interface SttDailyPolicy {
   readonly recordLifetimeUsage: boolean;
   readonly rateKey: string;
@@ -299,6 +307,53 @@ function isBytePlusTranscriptionSuccessStatus(
   );
 }
 
+function isRetryableBytePlusStatus(status: number): boolean {
+  return status === 502 || status === 503 || status === 504;
+}
+
+async function sendBytePlusSttRequest(
+  apiKey: string,
+  requestBody: string,
+  signal: AbortSignal,
+  attempt: number,
+): Promise<BytePlusSttAttempt> {
+  const requestId = randomUUID();
+  const providerRequestStartedAt = performance.now();
+  const response = await fetch(BYTEPLUS_ASR_FLASH_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Api-Key": apiKey,
+      "X-Api-Resource-Id": BYTEPLUS_ASR_RESOURCE_ID,
+      "X-Api-Request-Id": requestId,
+      "X-Api-Sequence": "-1",
+    },
+    body: requestBody,
+    signal,
+  });
+  signal.throwIfAborted();
+
+  const providerStatus = bytePlusTranscriptionStatus(response);
+  const providerDurationMs = Math.round(
+    performance.now() - providerRequestStartedAt,
+  );
+  L.debug("BytePlus STT response received", {
+    requestId,
+    attempt,
+    status: response.status,
+    statusText: response.statusText,
+    providerStatus,
+    providerDurationMs,
+  });
+  return {
+    response,
+    requestId,
+    providerStatus,
+    providerDurationMs,
+    attempt,
+  };
+}
+
 function isBytePlusTranscriptionBody(value: unknown): value is {
   readonly result: {
     readonly text: string;
@@ -352,43 +407,77 @@ export async function transcribeBytePlusVoiceInputFile(
     );
   }
 
-  const requestId = randomUUID();
   const fileBytes = await file.arrayBuffer();
   signal.throwIfAborted();
+  const fileBytesView = new Uint8Array(fileBytes);
+  const audioFormat = bytePlusAudioFormat(file);
+  const audioCodec = bytePlusAudioCodec(file);
+  const hasWebmEbmlHeader =
+    audioFormat === "webm"
+      ? fileBytes.byteLength >= EBML_HEADER.length &&
+        EBML_HEADER.every((byte, index) => {
+          return fileBytesView[index] === byte;
+        })
+      : null;
   const audio: Record<string, unknown> = {
     data: Buffer.from(fileBytes).toString("base64"),
-    format: bytePlusAudioFormat(file),
+    format: audioFormat,
   };
-  const codec = bytePlusAudioCodec(file);
-  if (codec) {
-    audio.codec = codec;
+  if (audioCodec) {
+    audio.codec = audioCodec;
   }
 
-  const bytePlusResponse = await fetch(BYTEPLUS_ASR_FLASH_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-Api-Key": apiKey,
-      "X-Api-Resource-Id": BYTEPLUS_ASR_RESOURCE_ID,
-      "X-Api-Request-Id": requestId,
-      "X-Api-Sequence": "-1",
-    },
-    body: JSON.stringify({
-      audio,
-      request: {
-        model_name: BYTEPLUS_ASR_MODEL,
-        enable_itn: true,
-        enable_punc: true,
-        enable_ddc: true,
-        enable_speaker_info: false,
-        show_utterances: true,
-      },
-    }),
-    signal,
+  L.debug("BytePlus STT request prepared", {
+    fileMime: file.type,
+    fileSize: file.size,
+    fileName: file.name,
+    audioByteLength: fileBytes.byteLength,
+    audioFormat,
+    audioCodec: audioCodec ?? null,
+    hasWebmEbmlHeader,
   });
-  signal.throwIfAborted();
 
-  const providerStatus = bytePlusTranscriptionStatus(bytePlusResponse);
+  const requestBody = JSON.stringify({
+    audio,
+    request: {
+      model_name: BYTEPLUS_ASR_MODEL,
+      enable_itn: true,
+      enable_punc: true,
+      enable_ddc: true,
+      enable_speaker_info: false,
+      show_utterances: true,
+    },
+  });
+  let providerAttempt = await sendBytePlusSttRequest(
+    apiKey,
+    requestBody,
+    signal,
+    1,
+  );
+  if (isRetryableBytePlusStatus(providerAttempt.response.status)) {
+    L.warn("Retrying BytePlus STT after transient response", {
+      requestId: providerAttempt.requestId,
+      status: providerAttempt.response.status,
+      statusText: providerAttempt.response.statusText,
+      providerDurationMs: providerAttempt.providerDurationMs,
+    });
+    await providerAttempt.response.arrayBuffer();
+    signal.throwIfAborted();
+    providerAttempt = await sendBytePlusSttRequest(
+      apiKey,
+      requestBody,
+      signal,
+      2,
+    );
+  }
+
+  const {
+    response: bytePlusResponse,
+    requestId,
+    providerStatus,
+    providerDurationMs,
+    attempt,
+  } = providerAttempt;
   if (
     !bytePlusResponse.ok ||
     !isBytePlusTranscriptionSuccessStatus(providerStatus)
@@ -399,11 +488,13 @@ export async function transcribeBytePlusVoiceInputFile(
       status: bytePlusResponse.status,
       statusText: bytePlusResponse.statusText,
       providerStatus,
+      providerDurationMs,
       responseBody,
       fileMime: file.type,
       fileSize: file.size,
       fileName: file.name,
       requestId,
+      attempt,
     });
     return internalError("Transcription failed");
   }

--- a/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
@@ -575,7 +575,8 @@ function mockAudioContext(signal: AbortSignal): void {
 interface VoiceInputMockOptions {
   readonly audioContextReady?: Promise<void>;
   readonly getUserMediaReady?: Promise<void>;
-  readonly rms?: number | readonly number[];
+  readonly onRecorderStop?: () => void;
+  readonly rms?: number | readonly number[] | (() => number);
 }
 
 function mockVoiceInput(
@@ -608,6 +609,9 @@ function mockVoiceInput(
 
   function nextRms(): number {
     const rms = options.rms;
+    if (typeof rms === "function") {
+      return rms();
+    }
     if (typeof rms === "number") {
       return rms;
     }
@@ -696,6 +700,7 @@ function mockVoiceInput(
       this.state = "inactive";
       this.emitData(true);
       this.dispatchEvent(new Event("stop"));
+      options.onRecorderStop?.();
     }
   }
 

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -39,6 +39,7 @@ const internalVoiceLevel$ = state(0);
 const internalVoiceDetectedDuringRecording$ = state(false);
 const internalVoiceActivityAvailable$ = state(false);
 const internalVoiceActivityCoversRecording$ = state(false);
+const internalRecordingStartedAt$ = state<number | null>(null);
 const internalStream$ = state<MediaStream | null>(null);
 const internalRecorder$ = state<MediaRecorder | null>(null);
 const internalRecordingSession$ = state<VoiceRecordingSession | null>(null);
@@ -425,6 +426,7 @@ const resetState$ = command(({ set }) => {
   set(internalVoiceDetectedDuringRecording$, false);
   set(internalVoiceActivityAvailable$, false);
   set(internalVoiceActivityCoversRecording$, false);
+  set(internalRecordingStartedAt$, null);
   set(internalRecorder$, null);
   set(internalRecordingSession$, null);
   set(internalAudioActivityMonitor$, null);
@@ -440,6 +442,16 @@ const prepareRecordingStart$ = command(({ set }) => {
   set(internalVoiceActivityCoversRecording$, false);
   set(internalRecordingSession$, null);
 });
+
+const startMediaRecorder$ = command(
+  ({ set }, recorder: MediaRecorder): number => {
+    recorder.start();
+    const recordingStartedAt = audioActivityNow();
+    set(internalRecordingStartedAt$, recordingStartedAt);
+    set(internalRecording$, true);
+    return recordingStartedAt;
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Public commands
@@ -477,6 +489,12 @@ interface SttApiFailure {
 type SttApiResult =
   | { readonly ok: true; readonly text: string }
   | ({ readonly ok: false } & SttApiFailure);
+
+interface TranscribeAudioBlobInput {
+  readonly blob: Blob;
+  readonly mimeType: string;
+  readonly captureReason: VoiceSegmentReason;
+}
 
 interface WindowWithWebkitAudioContext extends Window {
   readonly webkitAudioContext?: typeof AudioContext;
@@ -589,14 +607,34 @@ async function stopRecorderAndCaptureData(
 const transcribeAudioBlob$ = command(
   async (
     { get, set },
-    blob: Blob,
-    mimeType: string,
+    input: TranscribeAudioBlobInput,
     signal: AbortSignal,
   ): Promise<SttSegmentResult> => {
+    const { blob, mimeType, captureReason } = input;
     const fetchFn = get(fetch$);
     const formData = new FormData();
     const extension = mimeType.includes("mp4") ? "mp4" : "webm";
+    const recordingStartedAt = get(internalRecordingStartedAt$);
+    const sessionElapsedMs =
+      recordingStartedAt === null
+        ? null
+        : Math.max(0, Math.round(audioActivityNow() - recordingStartedAt));
+    const clientDiagnostics = {
+      captureReason,
+      sessionElapsedMs,
+      sessionVoiceDetected: get(internalVoiceDetectedDuringRecording$),
+      voiceActivityAvailable: get(internalVoiceActivityAvailable$),
+      voiceActivityCoversRecording: get(internalVoiceActivityCoversRecording$),
+    };
+
     formData.append("file", blob, `recording.${extension}`);
+    formData.append("clientDiagnostics", JSON.stringify(clientDiagnostics));
+
+    L.debug("Uploading voice input audio", {
+      blobSize: blob.size,
+      mimeType,
+      ...clientDiagnostics,
+    });
 
     const response = await tapError(
       fetchFn("/api/zero/voice-io/stt", {
@@ -640,8 +678,7 @@ interface VoiceSegmentSessionOptions {
   readonly autoSegment: boolean;
   readonly onSegmentTranscribed: VoiceSegmentTranscribedCallback;
   readonly transcribeBlob: (
-    blob: Blob,
-    mimeType: string,
+    input: TranscribeAudioBlobInput,
     signal: AbortSignal,
   ) => Promise<SttSegmentResult>;
   readonly isVoiceActivityReliable: () => boolean;
@@ -654,13 +691,17 @@ async function uploadCapturedBlob(
   options: VoiceSegmentSessionOptions,
   blob: Blob | null,
   mimeType: string,
+  captureReason: VoiceSegmentReason,
   upload: boolean,
 ): Promise<string> {
   if (!blob || !upload) {
     return "";
   }
 
-  const result = await options.transcribeBlob(blob, mimeType, options.signal);
+  const result = await options.transcribeBlob(
+    { blob, mimeType, captureReason },
+    options.signal,
+  );
   if (!result.ok) {
     if (result.quotaExceeded) {
       options.onQuotaExceeded();
@@ -714,17 +755,38 @@ function createVoiceSegmentTranscriber(
   clearCurrentSegmentVoice: () => void,
 ): VoiceSegmentTranscriber {
   const pendingTranscriptions: Promise<string>[] = [];
+  let uploadQueue: Promise<void> = Promise.resolve();
+
+  const uploadSegment = async (
+    segment: RecordedVoiceSegment,
+    reason: VoiceSegmentReason,
+    upload: boolean,
+  ): Promise<string> => {
+    const previousUpload = uploadQueue;
+    const nextUpload = createDeferredPromise<void>(options.signal);
+    uploadQueue = nextUpload.promise;
+
+    await previousUpload;
+    return await withCleanup(
+      uploadCapturedBlob(
+        options,
+        segment.blob,
+        segment.mimeType,
+        reason,
+        upload,
+      ),
+      () => {
+        nextUpload.resolve(undefined);
+      },
+    );
+  };
+
   const captureAndUploadSegment = async (
     reason: VoiceSegmentReason,
     upload: boolean,
   ): Promise<string> => {
     const segment = await captureSegment(reason, upload);
-    return await uploadCapturedBlob(
-      options,
-      segment.blob,
-      segment.mimeType,
-      upload,
-    );
+    return await uploadSegment(segment, reason, upload);
   };
 
   const enqueueSegment = (
@@ -943,8 +1005,8 @@ export const startRecording$ = command(
       signal,
       autoSegment,
       onSegmentTranscribed,
-      transcribeBlob: async (blob, mimeType, uploadSignal) => {
-        return await set(transcribeAudioBlob$, blob, mimeType, uploadSignal);
+      transcribeBlob: (input, uploadSignal) => {
+        return set(transcribeAudioBlob$, input, uploadSignal);
       },
       isVoiceActivityReliable: () => {
         return voiceActivityReliable;
@@ -972,9 +1034,7 @@ export const startRecording$ = command(
     });
 
     set(internalStarting$, false);
-    recorder.start();
-    const recordingStartedAt = audioActivityNow();
-    set(internalRecording$, true);
+    const recordingStartedAt = set(startMediaRecorder$, recorder);
     set(internalStream$, stream);
     set(internalRecorder$, recorder);
     set(internalRecordingSession$, recordingSession);

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -776,7 +776,9 @@ function createVoiceSegmentTranscriber(
         upload,
       ),
       () => {
-        nextUpload.resolve(undefined);
+        if (!nextUpload.settled()) {
+          nextUpload.resolve(undefined);
+        }
       },
     );
   };

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -1312,6 +1312,12 @@ describe("chat lifecycle", () => {
           screen.getByText("Upgrade or downgrade anytime."),
         ).toBeInTheDocument();
       });
+      await waitFor(() => {
+        expect(screen.queryByLabelText("Stop recording")).toBeNull();
+      });
+      expect(toastError).not.toHaveBeenCalledWith(
+        "Voice transcription failed. Try again.",
+      );
     } finally {
       toastError.mockRestore();
     }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -1008,6 +1008,89 @@ describe("chat lifecycle", () => {
     expect(transcriptionCalls).toBe(1);
   });
 
+  it("uploads voice input segments one at a time", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "voice-input-serialized-segments-thread";
+    const firstRequestStarted = context.mocks.deferred<void>();
+    const releaseFirstRequest = context.mocks.deferred<void>();
+    const speechResumed = context.mocks.deferred<void>();
+    const finalRecorderStopped = context.mocks.deferred<void>();
+    let currentRms = 0.1;
+    let recorderStopCount = 0;
+    let requestCount = 0;
+    let activeRequestCount = 0;
+    let maxActiveRequestCount = 0;
+    context.mocks.browser.voiceInput({
+      onRecorderStop: () => {
+        recorderStopCount += 1;
+        if (recorderStopCount === 2) {
+          finalRecorderStopped.resolve(undefined);
+        }
+      },
+      rms: () => {
+        if (
+          currentRms > 0 &&
+          firstRequestStarted.settled() &&
+          !speechResumed.settled()
+        ) {
+          speechResumed.resolve(undefined);
+        }
+        return currentRms;
+      },
+    });
+    mockChatLifecycle(context, { threadId });
+    context.mocks.api(zeroVoiceIoQuotaContract.get, ({ respond }) => {
+      return respond(200, { allowed: true, count: 0, limit: null });
+    });
+    context.mocks.http.post("*/api/zero/voice-io/stt", async () => {
+      const requestIndex = requestCount;
+      requestCount += 1;
+      activeRequestCount += 1;
+      maxActiveRequestCount = Math.max(
+        maxActiveRequestCount,
+        activeRequestCount,
+      );
+      if (requestIndex === 0) {
+        firstRequestStarted.resolve(undefined);
+        await releaseFirstRequest.promise;
+      }
+      activeRequestCount -= 1;
+      return new Response(
+        JSON.stringify({
+          text: requestIndex === 0 ? "First sentence" : "Second sentence",
+        }),
+        { headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+    const composer = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER);
+    });
+    await user.click(await screen.findByLabelText("Voice input"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
+    });
+
+    currentRms = 0;
+    await firstRequestStarted.promise;
+    currentRms = 0.1;
+    await speechResumed.promise;
+    await user.click(screen.getByLabelText("Stop recording"));
+    await finalRecorderStopped.promise;
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(requestCount).toBe(1);
+
+    releaseFirstRequest.resolve(undefined);
+    await waitFor(() => {
+      expect(composer).toHaveTextContent("First sentence Second sentence");
+      expect(screen.getByLabelText("Voice input")).toBeInTheDocument();
+    });
+    expect(requestCount).toBe(2);
+    expect(maxActiveRequestCount).toBe(1);
+  });
+
   it("automatically stops voice input after extended silence", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "voice-input-auto-stop-thread";


### PR DESCRIPTION
## Summary

- serialize STT uploads within a recording session while allowing recorder rotation to continue
- retry BytePlus STT once for transient 502, 503, and 504 responses using a fresh request ID
- log capture and provider diagnostics for future transcription failures
- add integration coverage for retry behavior and upload serialization

## Why

Silence segmentation can leave an upload in flight when the user stops recording. Overlapping uploads, combined with a transient BytePlus 504, surfaced a misleading transcription failure at stop time.

## Testing

- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace api`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-voice-io-post.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx --maxWorkers=1 --silent=passed-only`
- pre-commit hook (full Turbo Knip and type checks)