### PR TITLE
refactor(db): switch to run event sequence number

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-events.ts
@@ -860,7 +860,7 @@ async function getLatestRunsByThreadId(
       userMessage: chatEvents.userMessage,
       attachFiles: chatEvents.attachFiles,
       createdAt: chatEvents.createdAt,
-      sequenceNumber: chatEvents.sequenceNumber,
+      sequenceNumber: chatEvents.runEventSequenceNumber,
       generationTemplate: chatEvents.generationTemplate,
     })
     .from(chatEvents)
@@ -2930,7 +2930,7 @@ async function appendQueueFirstInsufficientCreditsEvents(params: {
       userMessage: queuedMessage.userMessage,
       runId: null,
       error: INSUFFICIENT_CREDITS_MARKER,
-      sequenceNumber: 0,
+      runEventSequenceNumber: 0,
       createdAt: rejectedCreatedAt,
       attachFiles: queuedMessage.attachFiles
         ? [...queuedMessage.attachFiles]
@@ -2943,7 +2943,7 @@ async function appendQueueFirstInsufficientCreditsEvents(params: {
         eventType: "output.error",
         content: params.assistantContent,
         error: INSUFFICIENT_CREDITS_MARKER,
-        sequenceNumber: 1,
+        runEventSequenceNumber: 1,
         createdAt: assistantCreatedAt,
         runId: null,
       });
@@ -3009,7 +3009,7 @@ async function appendInsufficientCreditsEvents(params: {
       userMessage: params.body.userMessage,
       runId: null,
       error: INSUFFICIENT_CREDITS_MARKER,
-      sequenceNumber: 0,
+      runEventSequenceNumber: 0,
       createdAt: userCreatedAt,
       attachFiles: fileIds,
     };
@@ -3043,7 +3043,7 @@ async function appendInsufficientCreditsEvents(params: {
       eventType: "output.error",
       content: assistantContent,
       error: INSUFFICIENT_CREDITS_MARKER,
-      sequenceNumber: 1,
+      runEventSequenceNumber: 1,
       createdAt: assistantCreatedAt,
       runId: null,
     });

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
@@ -225,7 +225,7 @@ function assistantEventItems(
     }
     return [
       {
-        sequenceNumber: event.sequenceNumber,
+        runEventSequenceNumber: event.sequenceNumber,
         content: text,
         runEventId: eventMessageId(event),
       },

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -126,6 +126,7 @@ import {
   insertAssistantEvents$,
   runGroupIdForRun,
   touchChatThreadLastMessageAt,
+  type InsertAssistantEventsInput,
   visibleChatEventCondition,
 } from "./zero-chat-event-shared.service";
 import { insertChatEvent } from "./zero-chat-event.service";
@@ -379,6 +380,27 @@ interface AssistantEventItem {
   readonly content: string;
 }
 
+interface AssistantEventInsertArgs {
+  readonly runId: string;
+  readonly threadId: string;
+  readonly userId: string;
+  readonly items: readonly AssistantEventItem[];
+}
+
+function assistantEventInsertInput(
+  args: AssistantEventInsertArgs,
+): InsertAssistantEventsInput {
+  return {
+    ...args,
+    items: args.items.map((item) => {
+      return {
+        runEventSequenceNumber: item.sequenceNumber,
+        content: item.content,
+      };
+    }),
+  };
+}
+
 function terminalCallbackErrorMessage(
   callbackError: string | null | undefined,
   runError: string | null | undefined,
@@ -448,12 +470,7 @@ interface ChatCallbackDependencies {
     signal: AbortSignal,
   ) => Promise<{ readonly released: number }>;
   readonly insertAssistantItems: (
-    args: {
-      readonly runId: string;
-      readonly threadId: string;
-      readonly userId: string;
-      readonly items: readonly AssistantEventItem[];
-    },
+    args: AssistantEventInsertArgs,
     signal: AbortSignal,
   ) => Promise<void>;
   readonly saveRunSummary: (
@@ -930,22 +947,24 @@ async function latestEventBackedAssistantEvent(
   const [event] = await db
     .select({
       content: chatEvents.content,
-      sequenceNumber: chatEvents.sequenceNumber,
+      sequenceNumber: chatEvents.runEventSequenceNumber,
     })
     .from(chatEvents)
     .where(
       and(
         eq(chatEvents.runId, runId),
         chatEventTypeIn(["output.message"]),
-        isNotNull(chatEvents.sequenceNumber),
+        isNotNull(chatEvents.runEventSequenceNumber),
         isNotNull(chatEvents.content),
         not(sql`${chatEvents.content} ~ '^[[:space:]]*$'`),
         ...(options.maxSequenceNumber === undefined
           ? []
-          : [lte(chatEvents.sequenceNumber, options.maxSequenceNumber)]),
+          : [
+              lte(chatEvents.runEventSequenceNumber, options.maxSequenceNumber),
+            ]),
       ),
     )
-    .orderBy(desc(chatEvents.sequenceNumber))
+    .orderBy(desc(chatEvents.runEventSequenceNumber))
     .limit(1);
 
   if (!event || event.content === null || event.sequenceNumber === null) {
@@ -1079,7 +1098,7 @@ async function recordLastEventToComplete(db: Db, runId: string): Promise<void> {
       and(
         eq(chatEvents.runId, runId),
         chatEventTypeIn(["output.message"]),
-        isNotNull(chatEvents.sequenceNumber),
+        isNotNull(chatEvents.runEventSequenceNumber),
       ),
     );
   if (!event?.lastEventAt) {
@@ -1530,10 +1549,10 @@ async function loadCanonicalDeliveryEvent(
         eq(chatEvents.runId, runId),
         chatEventTypeIn(["output.message"]),
         isNotNull(chatEvents.content),
-        isNotNull(chatEvents.sequenceNumber),
+        isNotNull(chatEvents.runEventSequenceNumber),
       ),
     )
-    .orderBy(desc(chatEvents.sequenceNumber))
+    .orderBy(desc(chatEvents.runEventSequenceNumber))
     .limit(1);
   return event;
 }
@@ -2378,7 +2397,7 @@ async function getLatestRunsByThreadId(
       userMessage: chatEvents.userMessage,
       attachFiles: chatEvents.attachFiles,
       createdAt: chatEvents.createdAt,
-      sequenceNumber: chatEvents.sequenceNumber,
+      sequenceNumber: chatEvents.runEventSequenceNumber,
       generationTemplate: chatEvents.generationTemplate,
     })
     .from(chatEvents)
@@ -4931,7 +4950,11 @@ export async function handleChatInternalCallbackWithoutCcstate(
         );
       },
       insertAssistantItems: async (args, inputSignal) => {
-        await insertAssistantEvents(db, args, inputSignal);
+        await insertAssistantEvents(
+          db,
+          assistantEventInsertInput(args),
+          inputSignal,
+        );
       },
       saveRunSummary: (runId, prompt, resultText, inputSignal) => {
         return saveRunSummary(
@@ -5004,7 +5027,11 @@ const buildChatCallbackDependencies$ = command(
         return set(releaseThreadBrowsersForRun$, args, inputSignal);
       },
       insertAssistantItems: async (args, inputSignal) => {
-        await set(insertAssistantEvents$, args, inputSignal);
+        await set(
+          insertAssistantEvents$,
+          assistantEventInsertInput(args),
+          inputSignal,
+        );
       },
       dispatchChatRunFinishedAutomations: async (event, inputSignal) => {
         // Imported lazily: the dispatcher reaches runWorkflowAutomationNow$,

--- a/turbo/apps/api/src/signals/services/zero-chat-event-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event-shared.service.ts
@@ -67,7 +67,7 @@ export interface InsertAssistantEventsInput {
   readonly threadId: string;
   readonly userId: string;
   readonly items: readonly {
-    readonly sequenceNumber: number;
+    readonly runEventSequenceNumber: number;
     readonly content: string;
     readonly runEventId?: string;
   }[];
@@ -231,7 +231,7 @@ export async function insertAssistantEventsInTransaction(
     (
       item,
     ): item is {
-      readonly sequenceNumber: number;
+      readonly runEventSequenceNumber: number;
       readonly content: string;
       readonly runEventId: string;
     } => {
@@ -257,7 +257,7 @@ export async function insertAssistantEventsInTransaction(
               runGroupId: runContext.runGroupId,
               eventType: "output.message",
               content: item.content,
-              sequenceNumber: item.sequenceNumber,
+              runEventSequenceNumber: item.runEventSequenceNumber,
               runEventId: item.runEventId,
             };
           }),
@@ -277,7 +277,7 @@ export async function insertAssistantEventsInTransaction(
               runGroupId: runContext.runGroupId,
               eventType: "output.message",
               content: item.content,
-              sequenceNumber: item.sequenceNumber,
+              runEventSequenceNumber: item.runEventSequenceNumber,
               runEventId: null,
             };
           }),

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -218,7 +218,7 @@ type ChatEventInputPayload = Pick<
 
 type ChatEventOutputSequence = Pick<
   ChatEventInsert,
-  "sequenceNumber" | "runEventId"
+  "runEventSequenceNumber" | "runEventId"
 >;
 
 type InputPromptEvent = ChatEventIdentity &
@@ -252,7 +252,7 @@ type InputGoalEvent = ChatEventIdentity &
 type InputRejectedEvent = ChatEventIdentity &
   ChatEventDisplayContext &
   ChatEventInputPayload &
-  Pick<ChatEventInsert, "sequenceNumber"> & {
+  Pick<ChatEventInsert, "runEventSequenceNumber"> & {
     readonly eventType: "input.rejected";
     readonly content?: null;
     readonly error: string;
@@ -268,7 +268,7 @@ type OutputMessageEvent = ChatEventIdentity &
   };
 
 type OutputErrorEvent = ChatEventIdentity &
-  Pick<ChatEventInsert, "sequenceNumber"> & {
+  Pick<ChatEventInsert, "runEventSequenceNumber"> & {
     readonly eventType: "output.error";
     readonly content: string | null;
     readonly error: string;
@@ -1094,18 +1094,18 @@ export async function insertChatEvents(
       id: chatEvents.id,
       createdAt: chatEvents.createdAt,
       seqId: chatEvents.seqId,
-      sequenceNumber: chatEvents.sequenceNumber,
+      sequenceNumber: chatEvents.runEventSequenceNumber,
     });
   }
   return await query
     .onConflictDoNothing({
-      target: [chatEvents.runId, chatEvents.sequenceNumber],
+      target: [chatEvents.runId, chatEvents.runEventSequenceNumber],
     })
     .returning({
       id: chatEvents.id,
       createdAt: chatEvents.createdAt,
       seqId: chatEvents.seqId,
-      sequenceNumber: chatEvents.sequenceNumber,
+      sequenceNumber: chatEvents.runEventSequenceNumber,
     });
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
@@ -87,7 +87,7 @@ async function loadThinkingContextMessages(args: {
       content: chatEvents.content,
       userMessage: chatEvents.userMessage,
       createdAt: chatEvents.createdAt,
-      sequenceNumber: chatEvents.sequenceNumber,
+      sequenceNumber: chatEvents.runEventSequenceNumber,
     })
     .from(chatEvents)
     .where(

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -270,7 +270,7 @@ const eventColumns = {
   goalEvent: chatEvents.goalEvent,
   error: chatEvents.error,
   seqId: chatEvents.seqId,
-  sequenceNumber: chatEvents.sequenceNumber,
+  sequenceNumber: chatEvents.runEventSequenceNumber,
   createdAt: chatEvents.createdAt,
   attachFiles: chatEvents.attachFiles,
   generationTemplate: chatEvents.generationTemplate,
@@ -318,7 +318,7 @@ const searchMessageColumns = {
   userMessage: chatEvents.userMessage,
   createdAt: chatEvents.createdAt,
   seqId: chatEvents.seqId,
-  sequenceNumber: chatEvents.sequenceNumber,
+  sequenceNumber: chatEvents.runEventSequenceNumber,
   runId: effectiveChatEventRunId(),
 } as const;
 

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -245,7 +245,7 @@ async function getLatestTitleContextMessages(
       content: chatEvents.content,
       userMessage: chatEvents.userMessage,
       createdAt: chatEvents.createdAt,
-      sequenceNumber: chatEvents.sequenceNumber,
+      sequenceNumber: chatEvents.runEventSequenceNumber,
     })
     .from(chatEvents)
     .leftJoin(agentRuns, eq(agentRuns.id, chatEvents.runId))
@@ -424,7 +424,7 @@ async function getLatestFollowupContextMessages(
       content: chatEvents.content,
       userMessage: chatEvents.userMessage,
       createdAt: chatEvents.createdAt,
-      sequenceNumber: chatEvents.sequenceNumber,
+      sequenceNumber: chatEvents.runEventSequenceNumber,
     })
     .from(chatEvents)
     .where(

--- a/turbo/packages/db/scripts/compare-schemas-normalized.ts
+++ b/turbo/packages/db/scripts/compare-schemas-normalized.ts
@@ -32,14 +32,14 @@ interface ConstraintInfo {
   constraint_def: string;
 }
 
-// PR 1 of the run-event sequence column rollout adds physical storage without
-// declaring it in Drizzle. Remove these allowlists in PR 2 when the runtime
-// schema switches to the canonical property.
+// PR 2 of the run-event sequence column rollout declares the canonical column
+// and index in Drizzle while the legacy objects remain for the draining
+// predecessor and rollback target. Remove these allowlists in PR 3.
 const TRANSITIONAL_RUN_EVENT_SEQUENCE_COLUMNS = new Set([
-  "chat_events.run_event_sequence_number",
+  "chat_events.sequence_number",
 ]);
 const TRANSITIONAL_RUN_EVENT_SEQUENCE_INDEXES = new Set([
-  "chat_events_run_event_seq_unique",
+  "chat_events_run_seq_unique",
 ]);
 
 // Get database URLs from command line args

--- a/turbo/packages/db/scripts/test-migration-consistency-schema.ts
+++ b/turbo/packages/db/scripts/test-migration-consistency-schema.ts
@@ -7786,6 +7786,24 @@ async function validateChatEventPropertyColumnRollout(): Promise<void> {
       await validateRevokesEventIdExpansion(client);
       await validateLastChatEventSeqIdExpansion(client);
       await validateFirstAssistantEventAckExpansion(client);
+      // Keep the historical 0757 mixed-version window intact while adding the
+      // later storage that today's Drizzle schema requires. Applying every
+      // intervening migration would prematurely run the 0768 contraction.
+      const runEventSequenceMigrationSql = await fs.readFile(
+        path.join(MIGRATIONS_DIR, "0807_expand_run_event_sequence_number.sql"),
+        "utf8",
+      );
+      const runEventSequenceMigrationStatements = runEventSequenceMigrationSql
+        .split("--> statement-breakpoint")
+        .map((statement) => {
+          return statement.trim();
+        })
+        .filter((statement) => {
+          return statement.length > 0;
+        });
+      for (const statement of runEventSequenceMigrationStatements) {
+        await client.query(statement);
+      }
       await validateChatEventPropertyColumnRuntimeCutover(client);
       await validateChatEventPropertyColumnContraction(client);
       await validateLegacyChatEventSeqIdAllocatorDrop(client);
@@ -17213,14 +17231,16 @@ const RUN_EVENT_SEQUENCE_NUMBER_PREVIOUS_MIGRATION = 806;
 const RUN_EVENT_SEQUENCE_NUMBER_EXPANSION_MIGRATION = 807;
 
 async function validateRunEventSequenceNumberExpansion(): Promise<void> {
-  console.log("=== Validate populated run event sequence expansion ===\n");
+  console.log(
+    "=== Validate populated run event sequence expansion and runtime cutover ===\n",
+  );
   const testDb = "migration_run_event_sequence_number_test";
   const testDbUrl = createTestDbUrl(testDb);
   const composeId = "00000000-0000-4000-8000-000000080701";
   const threadId = "00000000-0000-4000-8000-000000080702";
   const historicalRunId = "00000000-0000-4000-8000-000000080703";
   const previousApiRunId = "00000000-0000-4000-8000-000000080704";
-  const nextApiRunId = "00000000-0000-4000-8000-000000080705";
+  const currentApiRunId = "00000000-0000-4000-8000-000000080705";
 
   const migrationSql = await fs.readFile(
     path.join(MIGRATIONS_DIR, "0807_expand_run_event_sequence_number.sql"),
@@ -17249,7 +17269,14 @@ async function validateRunEventSequenceNumberExpansion(): Promise<void> {
     path.join(PACKAGE_DIR, "src/schema/chat-event.ts"),
     "utf8",
   );
-  assert.doesNotMatch(schemaSource, /run_event_sequence_number/u);
+  assert.match(
+    schemaSource,
+    /runEventSequenceNumber: integer\("run_event_sequence_number"\)/u,
+  );
+  assert.doesNotMatch(
+    schemaSource,
+    /sequenceNumber: integer\("sequence_number"\)/u,
+  );
 
   await createDatabase(testDb);
   try {
@@ -17313,6 +17340,7 @@ async function validateRunEventSequenceNumberExpansion(): Promise<void> {
         client,
         RUN_EVENT_SEQUENCE_NUMBER_EXPANSION_MIGRATION,
       );
+      const database = drizzle(client);
 
       const historicalRows = await client.query<{
         mismatches: string;
@@ -17348,6 +17376,7 @@ async function validateRunEventSequenceNumberExpansion(): Promise<void> {
             "seq_id"
           )
           VALUES ($1, $2, 'output.message', 7, 10002)
+          ON CONFLICT ("run_id", "sequence_number") DO NOTHING
           RETURNING
             "id",
             "sequence_number" AS "sequenceNumber",
@@ -17366,27 +17395,84 @@ async function validateRunEventSequenceNumberExpansion(): Promise<void> {
         [{ runEventSequenceNumber: 7, sequenceNumber: 7 }],
       );
 
-      const nextApiInsert = await client.query<{
+      const currentApiQuery = database
+        .insert(chatEvents)
+        .values({
+          chatThreadId: threadId,
+          runId: currentApiRunId,
+          eventType: "output.message",
+          runEventSequenceNumber: 9,
+          seqId: 10003,
+        })
+        .onConflictDoNothing({
+          target: [chatEvents.runId, chatEvents.runEventSequenceNumber],
+        })
+        .returning({
+          sequenceNumber: chatEvents.runEventSequenceNumber,
+        });
+      const currentApiSql = currentApiQuery.toSQL();
+      const currentApiExplanation = await client.query<{
+        "QUERY PLAN": unknown;
+      }>(`EXPLAIN (FORMAT JSON) ${currentApiSql.sql}`, currentApiSql.params);
+      function collectConflictArbiterIndexes(
+        value: unknown,
+      ): readonly string[] {
+        if (Array.isArray(value)) {
+          return value.flatMap((item) => {
+            return collectConflictArbiterIndexes(item);
+          });
+        }
+        if (typeof value !== "object" || value === null) {
+          return [];
+        }
+        const record = value as Record<string, unknown>;
+        const directIndexes = record["Conflict Arbiter Indexes"];
+        return [
+          ...(Array.isArray(directIndexes)
+            ? directIndexes.filter((item): item is string => {
+                return typeof item === "string";
+              })
+            : []),
+          ...Object.values(record).flatMap((item) => {
+            return collectConflictArbiterIndexes(item);
+          }),
+        ];
+      }
+      assert.deepEqual(
+        collectConflictArbiterIndexes(
+          currentApiExplanation.rows[0]?.["QUERY PLAN"],
+        ),
+        ["chat_events_run_event_seq_unique"],
+      );
+
+      assert.deepEqual(await currentApiQuery, [{ sequenceNumber: 9 }]);
+      const mirroredRuntimeWrites = await client.query<{
+        legacySequenceNumber: number;
         runEventSequenceNumber: number;
-        sequenceNumber: number;
+        runId: string;
       }>(
         `
-          INSERT INTO "chat_events" (
-            "chat_thread_id",
-            "run_id",
-            "event_type",
-            "run_event_sequence_number",
-            "seq_id"
-          )
-          VALUES ($1, $2, 'output.message', 9, 10003)
-          RETURNING
-            "sequence_number" AS "sequenceNumber",
+          SELECT
+            "run_id" AS "runId",
+            "sequence_number" AS "legacySequenceNumber",
             "run_event_sequence_number" AS "runEventSequenceNumber"
+          FROM "chat_events"
+          WHERE "run_id" IN ($1, $2)
+          ORDER BY "run_id"
         `,
-        [threadId, nextApiRunId],
+        [previousApiRunId, currentApiRunId],
       );
-      assert.deepEqual(nextApiInsert.rows, [
-        { runEventSequenceNumber: 9, sequenceNumber: 9 },
+      assert.deepEqual(mirroredRuntimeWrites.rows, [
+        {
+          legacySequenceNumber: 7,
+          runEventSequenceNumber: 7,
+          runId: previousApiRunId,
+        },
+        {
+          legacySequenceNumber: 9,
+          runEventSequenceNumber: 9,
+          runId: currentApiRunId,
+        },
       ]);
 
       const indexes = await client.query<{
@@ -17477,7 +17563,7 @@ async function validateRunEventSequenceNumberExpansion(): Promise<void> {
           )
           VALUES ($1, $2, 'output.message', 9, 10005)
         `,
-        values: [threadId, nextApiRunId],
+        values: [threadId, currentApiRunId],
       });
       await client.query(`
         CREATE UNIQUE INDEX "chat_events_run_seq_unique"
@@ -17512,7 +17598,7 @@ async function validateRunEventSequenceNumberExpansion(): Promise<void> {
           SET "run_event_sequence_number" = 10
           WHERE "run_id" = $1
         `,
-        values: [nextApiRunId],
+        values: [currentApiRunId],
       });
 
       const rejectFunction = await client.query<{ definition: string }>(`
@@ -17581,7 +17667,12 @@ async function validateRunEventSequenceNumberExpansion(): Promise<void> {
       await assertChatEventsAppendOnlyProtection(client, previousApiEventId);
 
       console.log("   ✅ 10,001 historical rows backfill across batches");
-      console.log("   ✅ Previous and next API inserts mirror both directions");
+      console.log(
+        "   ✅ Draining legacy and current Drizzle inserts coexist with mirrored columns",
+      );
+      console.log(
+        "   ✅ Current targeted ON CONFLICT resolves to chat_events_run_event_seq_unique",
+      );
       console.log("   ✅ Both unique index paths reject duplicates with 23505");
       console.log("   ✅ Strict append-only protection is restored");
       console.log("   ✅ A full non-transactional retry is idempotent\n");

--- a/turbo/packages/db/src/schema/chat-event.ts
+++ b/turbo/packages/db/src/schema/chat-event.ts
@@ -65,9 +65,10 @@ export function chatEventTerminalPredicate(eventType: SQLWrapper): SQL {
  * leaves the queue. Event-backed rows are one row per assistant-visible agent
  * output event; result-only CLI output can be projected from a terminal
  * "result" event. Failed runs append an assistant row carrying the terminal
- * error message. Event-backed rows are keyed by `(run_id, sequence_number)` for
- * idempotent, lock-free inserts from both the event consumer and the callback's
- * final sweep.
+ * error message. `run_event_sequence_number` is the upstream run-event
+ * coordinate used for reconciliation and final-answer selection. The
+ * deterministic primary key derived from `run_event_id` is the first
+ * deduplication guard; `(run_id, run_event_sequence_number)` is a second guard.
  *
  * Terminal-state assistant rows use the `run.completed | run.failed |
  * run.cancelled` event types.
@@ -129,8 +130,14 @@ export const chatEvents = pgTable(
     userMessage: jsonb("user_message").$type<ChatEventUserMessage>(),
     thinking: text("thinking"),
     error: text("error"),
-    sequenceNumber: integer("sequence_number"),
-    runEventId: text("run_event_id"), // Anthropic message ID from event.message.id (e.g. "msg_01abc...")
+    runEventSequenceNumber: integer("run_event_sequence_number"),
+    /**
+     * Upstream run-event ID or a deterministic seed for synthesized rows.
+     * `queue:queued`, `queue:dequeued`, and `thinking:initial` seed stable
+     * primary keys for non-agent rows. `thinking:initial` also distinguishes
+     * our placeholder from real agent thinking stored in the same leaf.
+     */
+    runEventId: text("run_event_id"),
     /** Strictly increasing position within the owning chat thread. */
     seqId: bigint("seq_id", { mode: "number" }).notNull(),
     goalEvent: jsonb("goal_event").$type<ChatEventGoalEvent>(),
@@ -170,9 +177,9 @@ export const chatEvents = pgTable(
         .where(
           sql`${table.runId} IS NULL AND ${table.eventType} IN ('input.prompt', 'input.automation', 'input.goal')`,
         ),
-      uniqueIndex("chat_events_run_seq_unique").on(
+      uniqueIndex("chat_events_run_event_seq_unique").on(
         table.runId,
-        table.sequenceNumber,
+        table.runEventSequenceNumber,
       ),
       uniqueIndex("chat_events_thread_seq_unique").on(
         table.chatThreadId,


### PR DESCRIPTION
## Summary

- rename the Drizzle property to `runEventSequenceNumber` and map it to `run_event_sequence_number`
- switch the declared unique index and targeted `ON CONFLICT` column set to `(run_id, run_event_sequence_number)`
- migrate runtime readers and writers while preserving the wire `sequenceNumber` field as an alias
- correct the `run_event_id` comment to cover upstream IDs and the `queue:queued`, `queue:dequeued`, and `thinking:initial` deterministic sentinels

## Rollout step and compatibility boundary

This is **step 2 (switch) of the three-step rollout** in #24611. Step 1 (#24624, migration 0807) shipped in `db-v1.161.1` at 2026-08-03 04:44 UTC; `gh release list --repo vm0-ai/vm0` confirmed that release before this work began.

This PR has **no migration**. It keeps `sequence_number`, `chat_events_run_seq_unique`, and the 0807 bridge installed for the draining predecessor and rollback target. It does not change `seq_id`, `chat_threads.last_chat_event_seq_id`, `run_event_id`, or the `output.thinking` leaf.

The API-contract `sequenceNumber` field remains unchanged. Runtime projections explicitly map `chatEvents.runEventSequenceNumber` back to `sequenceNumber`, so the wire shape stays byte-identical.

## Conflict-arbiter evidence

The populated-upgrade scenario builds the current Drizzle insert with:

```ts
target: [chatEvents.runId, chatEvents.runEventSequenceNumber]
```

It runs `EXPLAIN (FORMAT JSON)` for that statement and asserts the exact PostgreSQL plan field:

```text
Conflict Arbiter Indexes: chat_events_run_event_seq_unique
```

This is also a `42P10` guard: PostgreSQL must resolve the targeted column list to the new unique index before `EXPLAIN` can return a plan.

## Populated-upgrade evidence

The 0807 scenario now executes both runtime generations on the same expanded database:

- the draining predecessor inserts through `sequence_number` with targeted `ON CONFLICT (run_id, sequence_number)`
- the current Drizzle schema inserts through `run_event_sequence_number` with the new targeted conflict specification
- raw verification proves both inserts leave `sequence_number = run_event_sequence_number`
- both unique indexes continue to reject duplicates independently, append-only protection remains strict, and a full 0807 retry remains idempotent

The older ChatEvent property-cutover scenario also applies the additive 0807 storage before executing today's Drizzle schema, while retaining its historical 0757 mixed-version window and later contraction coverage.

## PR 3 gate

Step 3 must wait until this release is fully deployed and its rollback target has drained. Only then may it run the required production catalog preflight and remove the 0807 bridge/function, `chat_events_run_seq_unique`, and `sequence_number`.

## Post-release verification

- zero `42P10` conflict-target errors
- zero rollout-related `23505` errors
- zero rows where `sequence_number IS DISTINCT FROM run_event_sequence_number`
- zero duplicated `output.message` rows per run

## Verification

- release gate: `gh release list --repo vm0-ai/vm0 --limit 10`
- focused Prettier check for all changed files
- `pnpm -F @vm0/db lint`
- `pnpm -F @vm0/db check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `DATABASE_URL=postgresql://postgres@127.0.0.1:55497/postgres pnpm -F @vm0/db test:migration-consistency`
  - 809 migrations and snapshots on the final rebased branch
  - mixed-version legacy/current writes, exact conflict-arbiter `EXPLAIN`, snapshot accuracy, reset/replay, fresh regeneration, and normalized schema comparison
- `DATABASE_URL=postgresql://postgres@127.0.0.1:55497/postgres pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts src/signals/routes/__tests__/chat-callbacks.bdd.test.ts --maxWorkers=4 --silent=passed-only` (2 files, 88 tests)
- `pnpm knip --workspace @vm0/db --workspace api` reports only the two pre-existing shared JSON string-array exported types; no new finding

The full repository test matrix is left to the PR pipeline.

Refs #24611