### PR TITLE
test(python): cover ssl_insecure upstream binding rejection

### DIFF
--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -346,11 +346,11 @@ def mitm_ctx(tmp_path):
     """Stub ``mitmproxy.ctx.options`` and ``ctx.log`` for a test block.
 
     Returns a context-manager factory: calling ``mitm_ctx(registry_path=...)``
-    patches in a concrete options stub for the addon-specific settings modeled
-    by these tests, plus a ``MagicMock`` log. The log stays on ``MagicMock`` so
-    tests that need to assert on warn/debug calls can do so; ``options`` stays
-    concrete so unexpected attribute access fails instead of silently creating
-    another mock.
+    patches in a concrete options stub for settings consumed by the addon and
+    modeled by these tests, plus a ``MagicMock`` log. The log stays on
+    ``MagicMock`` so tests that need to assert on warn/debug calls can do so;
+    ``options`` stays concrete so unexpected attribute access fails instead of
+    silently creating another mock.
 
     When the caller omits ``registry_path`` the default comes from pytest's
     per-test ``tmp_path`` fixture, so tests never share a /tmp path that

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -320,7 +320,7 @@ def real_tcp_flow():
 
 
 class _StubOptions:
-    """Plain stand-in for addon-specific ``ctx.options`` fields."""
+    """Plain stand-in for ``ctx.options`` fields consumed by the addon."""
 
     def __init__(
         self,
@@ -330,6 +330,7 @@ class _StubOptions:
         builtin_firewall_catalog_cache_path: str,
         client_session_id: str,
         client_version: str,
+        ssl_insecure: bool,
     ) -> None:
         self.vm0_proxy_registry_path = registry_path
         self.vm0_api_url = api_url
@@ -337,6 +338,7 @@ class _StubOptions:
         self.vm0_client_session_id = client_session_id
         self.vm0_client_version = client_version
         self.vm0_usage_flush_interval_seconds = usage.DEFAULT_FLUSH_INTERVAL_SECONDS
+        self.ssl_insecure = ssl_insecure
 
 
 @pytest.fixture
@@ -368,6 +370,7 @@ def mitm_ctx(tmp_path):
         builtin_firewall_catalog_cache_path: str | None = None,
         client_session_id: str = "runner-session-test",
         client_version: str = "runner-version-test",
+        ssl_insecure: bool = False,
     ) -> Iterator[MagicMock]:
         if registry_path is None:
             registry_path = default_registry_path
@@ -379,6 +382,7 @@ def mitm_ctx(tmp_path):
             builtin_firewall_catalog_cache_path=builtin_firewall_catalog_cache_path,
             client_session_id=client_session_id,
             client_version=client_version,
+            ssl_insecure=ssl_insecure,
         )
         log = MagicMock()
         with (

--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_admission.py
@@ -598,7 +598,11 @@ async def test_matching_sni_and_host_allows_test_connector_on_authenticated_api_
     monkeypatch.setenv("VERCEL_AUTOMATION_BYPASS_SECRET", "preview-secret")
 
     with (
-        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        mitm_ctx(
+            registry_path=str(reg_path),
+            api_url="https://api.vm0.ai",
+            ssl_insecure=False,
+        ),
         fake_firewall_headers() as auth_fetch,
     ):
         await mitm_addon.request(flow)
@@ -610,6 +614,51 @@ async def test_matching_sni_and_host_allows_test_connector_on_authenticated_api_
     assert binding.host == "api.vm0.ai"
     assert binding.kinds == frozenset(("connector_auth",))
     assert binding.original_address == ("203.0.113.10", 443)
+
+
+async def test_matching_sni_and_host_blocks_test_connector_with_insecure_upstream_tls(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
+):
+    reg_path = _write_test_oauth_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="203.0.113.10",
+        sni="api.vm0.ai",
+        path="/api/test/oauth-provider/echo",
+        request_headers=headers(
+            ("Host", "api.vm0.ai"),
+            ("x-vm0-test-endpoint-bypass", "preview-secret"),
+        ),
+    )
+    mark_connected_tls_upstream(
+        flow,
+        sni="api.vm0.ai",
+        server_address=("203.0.113.10", 443),
+        peername=("203.0.113.10", 443),
+    )
+    monkeypatch.setenv("VERCEL_AUTOMATION_BYPASS_SECRET", "preview-secret")
+
+    with (
+        mitm_ctx(
+            registry_path=str(reg_path),
+            api_url="https://api.vm0.ai",
+            ssl_insecure=True,
+        ),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_called()
+    assert flow.server_conn.id not in upstream_destination_binding.binding_snapshot_for_tests()
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    body = json.loads(flow.response.content)
+    assert body["error"] == "upstream_destination_unbound"
+    assert body["reason"] == "connector_auth"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "upstream_destination_unbound"
+    assert "Authorization" not in flow.request.headers
 
 
 async def test_test_connector_extends_existing_api_allow_binding(


### PR DESCRIPTION
## Summary

- model mitmproxy's `ssl_insecure` option in the concrete addon test context while preserving the verified-TLS default
- cover the connector request path where otherwise valid TLS metadata must remain unbound when upstream verification is disabled
- assert the full fail-closed outcome: no binding, `upstream_destination_unbound`, no managed-auth fetch, and no credential injection
- make the corresponding verified-TLS success control explicit

## Scope

This PR changes tests only. It does not change production behavior, configuration defaults, dependencies, persisted data, APIs, protocols, or deployment compatibility.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`4567 passed`)
- focused verified/insecure connector admission tests (`2 passed`)
- mutation proof: temporarily bypassing only the production `ssl_insecure` rejection makes the new test fail because managed auth is fetched; restoring the guard makes both focused tests pass
- `lefthook run pre-commit`

Closes #24656
