### PR TITLE
fix(api): keep queued admission delivery independent of realtime

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -3391,9 +3391,13 @@ describe("CHAT-02: drain-time admission failure", () => {
       canBuyCredits: true,
     });
     context.mocks.ably.publish.mockClear();
+    context.mocks.ably.publish.mockRejectedValue(
+      new Error("Injected queued Web admission realtime failure"),
+    );
 
     await completeChatRunOk(anchor.runId, anchorHeaders);
     await flushWaitUntilForTest();
+    context.mocks.ably.publish.mockResolvedValue(undefined);
     const terminal = await waitForThreadMessages(
       actor,
       anchor.threadId,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -3104,7 +3104,7 @@ describe("Feishu integration", () => {
     await runsApi.heartbeatRunner(runnerGroup);
     const firstClaim = await runsApi.claimRunnerJob(firstRun.id);
 
-    const queuedPrompt = "reject this queued Feishu message after credit loss";
+    const queuedPrompt = `reject this queued Feishu message after credit loss ${randomUUID()}`;
     const queuedMessageId = `om_${randomUUID()}`;
     const queuedPayload = directMessage(appId, queuedPrompt, "ou_feishu_user", {
       messageId: queuedMessageId,
@@ -3133,6 +3133,9 @@ describe("Feishu integration", () => {
     });
     outboundMessages = [];
     context.mocks.ably.publish.mockClear();
+    context.mocks.ably.publish.mockRejectedValue(
+      new Error("Injected queued Feishu admission realtime failure"),
+    );
     await completeRunSession({
       runId: firstRun.id,
       sandboxToken: firstClaim.sandboxToken,
@@ -3140,6 +3143,7 @@ describe("Feishu integration", () => {
       history: `bdd Feishu admission history ${firstRun.id}`,
       assistantText: "First Feishu task completed",
     });
+    context.mocks.ably.publish.mockResolvedValue(undefined);
 
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
     const threadEvents = await accept(
@@ -3282,8 +3286,7 @@ describe("Feishu integration", () => {
       failedDeliveryAnchor.id,
     );
 
-    const failedDeliveryPrompt =
-      "persist this queued Feishu failure before delivery fails";
+    const failedDeliveryPrompt = `persist this queued Feishu failure before delivery fails ${randomUUID()}`;
     const failedDeliveryMessageId = `om_${randomUUID()}`;
     await postEvent(
       callbackUrl,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -54,9 +54,7 @@ import {
   publishChatThreadDetailChangedSafely,
   publishChatThreadMessageCreatedSafely,
   publishChatThreadRunCreatedSafely,
-  publishThreadListChanged,
   publishThreadListChangedSafely,
-  publishUserSignal,
 } from "../external/realtime";
 import {
   recordSandboxOperation,
@@ -3246,6 +3244,17 @@ function recordQueuedMessageAdmissionFailure(
   });
 }
 
+async function publishQueuedAdmissionFailureInvalidations(args: {
+  readonly userId: string;
+  readonly threadId: string;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  await publishChatThreadMessageCreatedSafely(args.userId, args.threadId);
+  args.signal.throwIfAborted();
+  await publishThreadListChangedSafely(args.userId);
+  args.signal.throwIfAborted();
+}
+
 async function handleWebQueuedMessageAdmissionFailure(args: {
   readonly db: Db;
   readonly failure: WebQueuedMessageAdmissionFailure;
@@ -3275,11 +3284,11 @@ async function handleWebQueuedMessageAdmissionFailure(args: {
   }
 
   recordQueuedMessageAdmissionFailure(args.failure);
-  await publishUserSignal(
-    [args.failure.userId],
-    `chatThreadMessageCreated:${args.failure.threadId}`,
-  );
-  await publishThreadListChanged(args.failure.userId);
+  await publishQueuedAdmissionFailureInvalidations({
+    userId: args.failure.userId,
+    threadId: args.failure.threadId,
+    signal: args.signal,
+  });
 }
 
 async function handleFeishuQueuedMessageAdmissionFailure(args: {
@@ -3313,12 +3322,11 @@ async function handleFeishuQueuedMessageAdmissionFailure(args: {
   }
 
   recordQueuedMessageAdmissionFailure(args.failure);
-  await publishUserSignal(
-    [args.failure.userId],
-    `chatThreadMessageCreated:${args.failure.threadId}`,
-  );
-  await publishThreadListChanged(args.failure.userId);
-  args.signal.throwIfAborted();
+  await publishQueuedAdmissionFailureInvalidations({
+    userId: args.failure.userId,
+    threadId: args.failure.threadId,
+    signal: args.signal,
+  });
   await tapError(
     args.deliver(
       {
@@ -3378,12 +3386,11 @@ async function handleSlackQueuedMessageAdmissionFailure(args: {
   }
 
   recordQueuedMessageAdmissionFailure(args.failure);
-  await publishUserSignal(
-    [args.failure.userId],
-    `chatThreadMessageCreated:${args.failure.threadId}`,
-  );
-  await publishThreadListChanged(args.failure.userId);
-  args.signal.throwIfAborted();
+  await publishQueuedAdmissionFailureInvalidations({
+    userId: args.failure.userId,
+    threadId: args.failure.threadId,
+    signal: args.signal,
+  });
   await tapError(
     args.deliver(
       {
@@ -3439,12 +3446,11 @@ async function handleTeamsQueuedMessageAdmissionFailure(args: {
   }
 
   recordQueuedMessageAdmissionFailure(args.failure);
-  await publishUserSignal(
-    [args.failure.userId],
-    `chatThreadMessageCreated:${args.failure.threadId}`,
-  );
-  await publishThreadListChanged(args.failure.userId);
-  args.signal.throwIfAborted();
+  await publishQueuedAdmissionFailureInvalidations({
+    userId: args.failure.userId,
+    threadId: args.failure.threadId,
+    signal: args.signal,
+  });
   await tapError(
     args.deliver(
       {
@@ -3496,12 +3502,11 @@ async function handleTelegramQueuedMessageAdmissionFailure(args: {
   }
 
   recordQueuedMessageAdmissionFailure(args.failure);
-  await publishUserSignal(
-    [args.failure.userId],
-    `chatThreadMessageCreated:${args.failure.threadId}`,
-  );
-  await publishThreadListChanged(args.failure.userId);
-  args.signal.throwIfAborted();
+  await publishQueuedAdmissionFailureInvalidations({
+    userId: args.failure.userId,
+    threadId: args.failure.threadId,
+    signal: args.signal,
+  });
   await tapError(
     args.deliver(
       {
@@ -3553,12 +3558,11 @@ async function handleAgentPhoneQueuedMessageAdmissionFailure(args: {
   }
 
   recordQueuedMessageAdmissionFailure(args.failure);
-  await publishUserSignal(
-    [args.failure.userId],
-    `chatThreadMessageCreated:${args.failure.threadId}`,
-  );
-  await publishThreadListChanged(args.failure.userId);
-  args.signal.throwIfAborted();
+  await publishQueuedAdmissionFailureInvalidations({
+    userId: args.failure.userId,
+    threadId: args.failure.threadId,
+    signal: args.signal,
+  });
   await tapError(
     args.deliver(
       {
@@ -3610,12 +3614,11 @@ async function handleGitHubQueuedMessageAdmissionFailure(args: {
   }
 
   recordQueuedMessageAdmissionFailure(args.failure);
-  await publishUserSignal(
-    [args.failure.userId],
-    `chatThreadMessageCreated:${args.failure.threadId}`,
-  );
-  await publishThreadListChanged(args.failure.userId);
-  args.signal.throwIfAborted();
+  await publishQueuedAdmissionFailureInvalidations({
+    userId: args.failure.userId,
+    threadId: args.failure.threadId,
+    signal: args.signal,
+  });
   await tapError(
     args.deliver(
       {
@@ -3685,11 +3688,11 @@ async function handleMorningBriefQueuedMessageAdmissionFailure(args: {
   }
 
   recordQueuedMessageAdmissionFailure(args.failure);
-  await publishUserSignal(
-    [args.failure.userId],
-    `chatThreadMessageCreated:${args.failure.threadId}`,
-  );
-  await publishThreadListChanged(args.failure.userId);
+  await publishQueuedAdmissionFailureInvalidations({
+    userId: args.failure.userId,
+    threadId: args.failure.threadId,
+    signal: args.signal,
+  });
 }
 
 async function handleQueuedMessageAdmissionFailure(args: {


### PR DESCRIPTION
Follow-up to #24625.

Addresses the P1 follow-up from [review 4841229165](https://github.com/vm0-ai/vm0/pull/24643#pullrequestreview-4841229165).

## Summary

- route every queued admission failure post-commit message and thread invalidation through the existing safe realtime publishers
- preserve AbortSignal propagation while allowing ordinary Ably failures to remain observable without blocking channel delivery
- cover Web terminalization and Feishu exactly-once error delivery plus thinking-reaction cleanup when Ably rejects

## Testing

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts -t "terminalizes a queued Web message when credits are lost before drain"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feishu-integration.test.ts -t "terminalizes and delivers a queued Feishu admission failure exactly once"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t "blocks admission for model-first sends through visible chat messages"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts -t "rejects a Morning Brief admission failure and keeps the thread drainable"`