### PR TITLE
feat(core): enable custom connector features globally

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -179,19 +179,19 @@ describe("auth tokens", () => {
     );
   });
 
-  it("gates custom connector writes behind the CLI create feature switch", () => {
+  it("grants custom connector writes by default and honors a disabled override", () => {
     const defaultToken = generateZeroToken("user_zero", "run_zero", "org_zero");
-    const enabledToken = generateZeroToken(
+    const disabledToken = generateZeroToken(
       "user_zero",
       "run_zero",
       "org_zero",
-      { [FeatureSwitchKey.CustomConnectorCliCreate]: true },
+      { [FeatureSwitchKey.CustomConnectorCliCreate]: false },
     );
 
-    expect(verifyZeroToken(defaultToken)?.capabilities).not.toContain(
+    expect(verifyZeroToken(defaultToken)?.capabilities).toContain(
       "connector:write",
     );
-    expect(verifyZeroToken(enabledToken)?.capabilities).toContain(
+    expect(verifyZeroToken(disabledToken)?.capabilities).not.toContain(
       "connector:write",
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -1554,6 +1554,9 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       },
     };
 
+    await connectorsApi.updateFeatureSwitches(admin, {
+      [FeatureSwitchKey.CustomConnectorOAuth2]: false,
+    });
     const disabled = await connectorsApi.requestCreateCustomConnector(
       admin,
       connectorBody,
@@ -1597,6 +1600,9 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     });
     expectNoVisibleSecret(created, clientSecret);
 
+    await connectorsApi.updateFeatureSwitches(member, {
+      [FeatureSwitchKey.CustomConnectorCliCreate]: false,
+    });
     const disabledAgentAuthorization =
       await connectorsApi.requestStartCustomConnectorOAuth2(
         member,
@@ -1937,6 +1943,9 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       queryInjections: created.queryInjections,
       authMode: created.authMode,
     };
+    await connectorsApi.updateFeatureSwitches(admin, {
+      [FeatureSwitchKey.CustomConnectorOAuth2]: false,
+    });
     const disabledUpdate = await connectorsApi.requestUpdateCustomConnector(
       admin,
       created.id,
@@ -2050,7 +2059,9 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     }
     mockClerkMembership(context, admin, "org:admin");
     const runId = randomUUID();
-    const readonlyToken = generateZeroToken(admin.userId, runId, admin.orgId);
+    const readonlyToken = generateZeroToken(admin.userId, runId, admin.orgId, {
+      [FeatureSwitchKey.CustomConnectorCliCreate]: false,
+    });
     const connectorsClient = setupApp({ context })(
       zeroCustomConnectorsContract,
     );
@@ -2089,6 +2100,9 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
 
     const writeToken = generateZeroToken(admin.userId, runId, admin.orgId, {
       [FeatureSwitchKey.CustomConnectorCliCreate]: true,
+    });
+    await connectorsApi.updateFeatureSwitches(admin, {
+      [FeatureSwitchKey.CustomConnectorCliCreate]: false,
     });
     const gated = await accept(
       connectorsClient.create({
@@ -2174,6 +2188,9 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       authMode: "manual",
     });
 
+    await connectorsApi.updateFeatureSwitches(admin, {
+      [FeatureSwitchKey.CustomConnectorCliCreate]: false,
+    });
     const disabled = await connectorsApi.requestSetCustomConnectorValues(
       admin,
       created.id,

--- a/turbo/apps/platform/src/mocks/handlers/api-feature-switches.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-feature-switches.ts
@@ -20,6 +20,7 @@ export const apiFeatureSwitchesHandlers = [
     return respond(200, {
       switches: DEFAULT_SWITCH_OVERRIDES,
       effectiveSwitches: DEFAULT_SWITCH_OVERRIDES,
+      supportsCustomConnectorOAuth2: true,
     });
   }),
 
@@ -27,6 +28,7 @@ export const apiFeatureSwitchesHandlers = [
     return respond(200, {
       switches: body.switches,
       effectiveSwitches: body.switches,
+      supportsCustomConnectorOAuth2: true,
     });
   }),
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -3602,9 +3602,7 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.CustomConnectorOAuth2]: true,
-      },
+      featureSwitches: {},
     });
 
     click(await screen.findByText("Custom"));
@@ -3857,7 +3855,13 @@ describe("connectors page", () => {
       teamAgent(supportAgentId, "Support"),
     ]);
 
-    detachedSetupPage({ context, path: "/connectors" });
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: {
+        [FeatureSwitchKey.CustomConnectorOAuth2]: false,
+      },
+    });
 
     click(await screen.findByText("Custom"));
 

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -14,6 +14,15 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.VideoArtifactPosters, {})).toBe(
       true,
     );
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.CustomConnectorCliCreate, {}),
+    ).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.CustomConnectorOAuth2, {})).toBe(
+      true,
+    );
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.CustomConnectorPermissions, {}),
+    ).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -501,22 +501,19 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "liangyou@vm0.ai",
     description:
       "Allow Zero CLI agents to create and configure custom connectors directly.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.CustomConnectorOAuth2]: {
     maintainer: "liangyou@vm0.ai",
     description:
       "Allow org admins to add OAuth 2.0 authentication to custom connectors.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.CustomConnectorPermissions]: {
     maintainer: "yuma@vm0.ai",
     description:
       "Allow users to manage agent permission grants for custom connectors.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
 };
 


### PR DESCRIPTION
## Summary

- enable CLI custom connector creation for all users
- enable OAuth 2.0 custom connectors for all users
- enable custom connector permission management for all users
- update rollout tests and align the platform feature-switch mock with OAuth 2.0 API support

## Testing

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- 85 affected core and API tests
- 169 affected platform tests

The full Vitest run reached 7,922 passing tests. All rollout-related failures were fixed and passed in isolated reruns; two unrelated chat-event tests remained blocked by stale Stripe customer state for the fixed staff organization in the local development database.
