### PR TITLE
docs(python): document tls clienthello admission states

### DIFF
--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -321,10 +321,10 @@ def handle_tls_clienthello(
     """Apply the MITM admission decision for a TLS ClientHello.
 
     With no client peer IP, leave the interception decision unchanged. Valid registry VMs stay
-    intercepted, may prebind a privileged upstream, and record ``valid_registry_vm`` with run and
-    SNI identity when the connection can be keyed. Invalid entries and unavailable registry
-    lookups also stay intercepted, recording ``invalid_registry_vm`` and
-    ``registry_unavailable`` respectively, so the request hook can fail closed.
+    intercepted and may prebind a privileged upstream. Invalid VM entries and unavailable registry
+    lookups also stay intercepted, preserving the request hook's fail-closed path. When the
+    connection can be keyed, these outcomes record ``valid_registry_vm`` with run and SNI identity,
+    ``invalid_registry_vm``, or ``registry_unavailable`` respectively.
 
     Only a client IP positively absent from a successfully loaded registry clears prior admission
     state and switches to passthrough. TLS admission is connection identity evidence for later

--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -318,10 +318,18 @@ def handle_tls_clienthello(
     registry_path: str,
     api_url: str,
 ) -> None:
-    """
-    Handle TLS ClientHello — decide whether to MITM intercept.
-    All registered VMs use MITM mode for HTTP-level filtering and logging.
-    Unregistered IPs are passed through without interception.
+    """Apply the MITM admission decision for a TLS ClientHello.
+
+    With no client peer IP, leave the interception decision unchanged. Valid registry VMs stay
+    intercepted, may prebind a privileged upstream, and record ``valid_registry_vm`` with run and
+    SNI identity when the connection can be keyed. Invalid entries and unavailable registry
+    lookups also stay intercepted, recording ``invalid_registry_vm`` and
+    ``registry_unavailable`` respectively, so the request hook can fail closed.
+
+    Only a client IP positively absent from a successfully loaded registry clears prior admission
+    state and switches to passthrough. TLS admission is connection identity evidence for later
+    classification, not cached authorization; current request-time registry state remains
+    authoritative for enforcement.
     """
     client_ip = data.context.client.peername[0] if data.context.client.peername else None
     if not client_ip:


### PR DESCRIPTION
## Summary

- document every TLS ClientHello registry admission outcome at the public hook
- clarify that invalid and unavailable states remain intercepted to preserve fail-closed request handling
- distinguish connection identity evidence from current request-time authorization
- keep runtime behavior unchanged

## Validation

- `cd crates/runner/mitm-addon && uv lock --check`
- `cd crates/runner/mitm-addon && uv sync --locked`
- `cd crates/runner/mitm-addon && uv run --no-sync ruff format --check .`
- `cd crates/runner/mitm-addon && uv run --no-sync ruff check .`
- `cd crates/runner/mitm-addon && uv run --no-sync basedpyright -p .`
- `cd crates/runner/mitm-addon && uv run --no-sync python -m pytest tests/` (4574 passed)

Closes #24685
