### PR TITLE
feat: fully enable artifact versioning switches

### DIFF
--- a/turbo/apps/api/src/lib/file-url.ts
+++ b/turbo/apps/api/src/lib/file-url.ts
@@ -65,17 +65,6 @@ export function isArtifactKeyV2(key: string): boolean {
   return /^artifacts\/[0-9a-z]{10}\.[^/]+$/u.test(key);
 }
 
-/**
- * Build the permanent URL for an uploaded attachment.
- */
-export function buildFileUrl(
-  userId: string,
-  id: string,
-  filename: string,
-): string {
-  return `${publicArtifactsBaseUrl()}/${buildArtifactKey(userId, id, filename)}`;
-}
-
 export function buildFileUrlFromKey(key: string): string {
   return `${publicArtifactsBaseUrl()}/${key.replace(/^\/+/, "")}`;
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -237,6 +237,7 @@ async function createHostedArtifact(args: {
   readonly threadId: string;
   readonly fileId: string;
   readonly url: string;
+  readonly aliasUrl: string;
   readonly deploymentId: string;
   readonly bearer: string;
 }> {
@@ -255,13 +256,17 @@ async function createHostedArtifact(args: {
     spaFallback: false,
     files: [hostedTextFile("/index.html", `<main>${args.site}</main>`)],
   });
+  if (!prepared.artifactUrl) {
+    throw new Error("Expected a versioned hosted artifact URL");
+  }
   await chat.completeHostedSiteWithBearer(bearer, prepared.deploymentId);
   await completeChatRunOk(run.runId, sandboxHeaders);
   return {
     runId: run.runId,
     threadId: run.threadId,
-    fileId: prepared.url,
-    url: prepared.url,
+    fileId: prepared.deploymentId,
+    url: prepared.artifactUrl,
+    aliasUrl: prepared.url,
     deploymentId: prepared.deploymentId,
     bearer,
   };
@@ -486,7 +491,9 @@ describe("video Artifact previews", () => {
     const previewedArtifact = response.artifacts.find((item) => {
       return item.fileId === videoArtifact.fileId;
     });
-    expect(previewedArtifact?.previewImageUrl).toMatch(/\/poster-v2\.jpg$/);
+    expect(previewedArtifact?.previewImageUrl).toMatch(
+      /\/artifacts\/[0-9a-z]{10}\.jpg$/u,
+    );
   }, 180_000);
 
   it("leaves video preview empty when media frame extraction fails", async () => {
@@ -613,8 +620,8 @@ describe("GET /api/zero/artifacts", () => {
         expect.objectContaining({
           threadId: run.threadId,
           runId: run.runId,
-          fileId: prepared.url,
-          url: prepared.url,
+          fileId: prepared.deploymentId,
+          url: prepared.artifactUrl,
           size: hostedFile.size,
           updatedAt: expect.any(String),
           artifactKind: "hosted-site",
@@ -631,7 +638,7 @@ describe("GET /api/zero/artifacts", () => {
       ]),
     );
     const hostedArtifact = response.artifacts.find((artifact) => {
-      return artifact.fileId === prepared.url;
+      return artifact.fileId === prepared.deploymentId;
     });
     expect(hostedArtifact).not.toHaveProperty("previewImageUrl");
     expect(
@@ -773,7 +780,7 @@ describe("GET /api/zero/artifacts", () => {
       expect.arrayContaining([
         expect.objectContaining({
           url: artifact.url,
-          aliasUrl: artifact.url,
+          aliasUrl: artifact.aliasUrl,
           previewImageUrl: firstArtifact?.previewImageUrl,
         }),
       ]),

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
@@ -288,6 +288,7 @@ describe("CHAT-02 chat messages and visible validation", () => {
     });
     const uploadId = randomUUID();
     const clientEventId = randomUUID();
+    api.mockCompletedUploadObject(actor, uploadId, "launch-plan.txt", 24);
     const expectedUserMessage: UserMessageDocument = {
       version: 1,
       parts: [
@@ -810,9 +811,12 @@ describe("FILE-01 uploads, storage, and host APIs", () => {
         ),
       ],
     });
-    expect(prepared.publicSlug).toMatch(
-      new RegExp(`^${site}-[a-f0-9]{8}-release-01$`),
-    );
+    expect(prepared).toMatchObject({
+      publicSlug: site,
+      aliasUrl: prepared.url,
+      deploymentVersion: 1,
+      artifactUrl: expect.stringContaining(`dpl-${prepared.deploymentId}.`),
+    });
     expect(prepared.uploads).toHaveLength(2);
 
     const otherActor = bdd.user();
@@ -829,12 +833,17 @@ describe("FILE-01 uploads, storage, and host APIs", () => {
       actor,
       prepared.deploymentId,
     );
-    expect(completed).toStrictEqual({
+    expect(completed).toMatchObject({
       siteId: prepared.siteId,
       deploymentId: prepared.deploymentId,
       publicSlug: prepared.publicSlug,
       url: prepared.url,
       status: "ready",
+      deploymentVersion: 1,
+      artifactUrl: prepared.artifactUrl,
+      aliasUrl: prepared.url,
+      isActive: true,
+      activeDeploymentVersion: 1,
     });
 
     const invalid = await api.requestPrepareHostedSite(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2983,7 +2983,8 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
     expect(hostedGroup?.files).toHaveLength(1);
     expect(hostedGroup?.files[0]).toMatchObject({
       artifactKind: "hosted-site",
-      url: prepared.url,
+      url: prepared.artifactUrl,
+      aliasUrl: prepared.url,
       contentType: "text/html",
     });
     const plainGroup = artifacts.runs.find((group) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
@@ -344,6 +344,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     api.captureHostedSitesS3();
 
     const legacyActor = bdd.user();
+    await setHostedArtifactVersions(legacyActor, false);
     const occupied = await api.prepareHostedSite(legacyActor, {
       site: `bdd-alias-owner-${randomUUID().slice(0, 8)}`,
       slugSuffix: "fixed",
@@ -393,6 +394,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     const bdd = createBddApi(context);
     const api = createHostMapsBddApi(context);
     const actor = bdd.user();
+    await setHostedArtifactVersions(actor, false);
     // First test in the file: install the S3 boundary explicitly before any
     // host call (mock defaults only arrive in afterEach resets).
     const capture = api.captureHostedSitesS3();
@@ -988,7 +990,8 @@ describe("CHAIN-BILLING-MEDIA/FILE-01: run-scoped zero-token attribution", () =>
       spaFallback: false,
       files: [hostedTextFile("/index.html", "<main>run artifact</main>")],
     });
-    expectHostedSitePublicSlug(prepared.publicSlug, site, "run-01");
+    expect(prepared.publicSlug).toBe(site);
+    expect(prepared.deploymentVersion).toBe(1);
 
     const completed = await api.completeHostedSite(
       bearer,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-artifacts-image-edit-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-artifacts-image-edit-snapshot.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import { artifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
 
-import { buildFileUrl } from "../../../lib/file-url";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { createBddApi } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
@@ -36,7 +35,7 @@ async function seedVisibleImage(): Promise<{
     agentId: agent.agentId,
     title: "Image editing",
   });
-  await chat.requestSendEvent(
+  const sent = await chat.requestSendEvent(
     actor,
     {
       agentId: agent.agentId,
@@ -53,12 +52,22 @@ async function seedVisibleImage(): Promise<{
     },
     [201],
   );
+  if (sent.status !== 201) {
+    throw new Error("Expected image attachment message to be created");
+  }
+  const events = await chat.listThreadEvents(actor, sent.body.threadId);
+  const attachment = events.events.find((event) => {
+    return event.eventType === "input.prompt";
+  })?.attachFiles?.[0];
+  if (!attachment) {
+    throw new Error("Expected image attachment to be visible in thread events");
+  }
   if (!actor.orgId) {
     throw new Error("Expected the seeded actor to belong to an org");
   }
 
   return {
-    artifactUrl: buildFileUrl(actor.userId, IMAGE_FILE_ID, IMAGE_FILENAME),
+    artifactUrl: attachment.url,
     orgId: actor.orgId,
     userId: actor.userId,
   };

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
@@ -1,6 +1,10 @@
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 
+import {
+  PutObjectCommand,
+  type PutObjectCommandInput,
+} from "@aws-sdk/client-s3";
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
 
@@ -155,17 +159,18 @@ function currentSecond(): number {
   return Math.floor(now() / 1000);
 }
 
-function commandInput(command: unknown): Record<string, unknown> {
-  if (
-    typeof command === "object" &&
-    command !== null &&
-    "input" in command &&
-    typeof command.input === "object" &&
-    command.input !== null
-  ) {
-    return command.input as Record<string, unknown>;
+function putObjectInput(): PutObjectCommandInput {
+  const command = context.mocks.s3.send.mock.calls
+    .map(([candidate]) => {
+      return candidate;
+    })
+    .find((candidate): candidate is PutObjectCommand => {
+      return candidate instanceof PutObjectCommand;
+    });
+  if (!command) {
+    throw new Error("Expected generated image to be uploaded to S3");
   }
-  return {};
+  return command.input;
 }
 
 // Reads the org credit balance through the product billing surface so charge
@@ -954,17 +959,16 @@ describe("POST /api/zero/image-io/generate", () => {
     const filename = String(body.filename);
     const url = String(body.url);
     expect(filename).toBe(`image-${fileId.slice(0, 8)}.webp`);
-    expect(url).toBe(
-      `https://cdn.vm7.io/artifacts/${encodeURIComponent(
-        fixture.userId,
-      )}/${fileId}/${filename}`,
-    );
 
-    const putInput = commandInput(context.mocks.s3.send.mock.calls[0]?.[0]);
+    const putInput = putObjectInput();
     expect(putInput.Bucket).toBe(TEST_BUCKET);
-    expect(putInput.Key).toBe(
-      `artifacts/${fixture.userId}/${fileId}/${filename}`,
-    );
+    expect(putInput.Key).toMatch(/^artifacts\/[0-9a-z]{10}\.webp$/u);
+    expect(url).toBe(`https://cdn.vm7.io/${String(putInput.Key)}`);
+    expect(putInput.Metadata).toStrictEqual({
+      "artifact-id": fileId,
+      filename: encodeURIComponent(filename),
+      "user-id": encodeURIComponent(fixture.userId),
+    });
     expect(putInput.ContentType).toBe("image/webp");
     const putBody = putInput.Body;
     expect(Buffer.isBuffer(putBody)).toBeTruthy();
@@ -1222,10 +1226,13 @@ describe("POST /api/zero/image-io/generate", () => {
     }
     const fileId = String(body.id);
     const filename = String(body.filename);
-    const putInput = commandInput(context.mocks.s3.send.mock.calls[0]?.[0]);
-    expect(putInput.Key).toBe(
-      `artifacts/${fixture.userId}/${fileId}/${filename}`,
-    );
+    const putInput = putObjectInput();
+    expect(putInput.Key).toMatch(/^artifacts\/[0-9a-z]{10}\.jpg$/u);
+    expect(putInput.Metadata).toStrictEqual({
+      "artifact-id": fileId,
+      filename: encodeURIComponent(filename),
+      "user-id": encodeURIComponent(fixture.userId),
+    });
     expect(putInput.ContentType).toBe("image/jpeg");
 
     // The megapixel category/quantity are asserted in the result body above;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
@@ -1123,7 +1123,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
       objectStore.puts.some((put) => {
         return (
           put.bucket === "test-user-artifacts" &&
-          put.key.endsWith("/poster-v2.jpg") &&
+          /^artifacts\/[0-9a-z]{10}\.jpg$/u.test(put.key) &&
           put.contentType === "image/jpeg"
         );
       }),
@@ -1132,7 +1132,9 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
     const videoArtifact = artifacts.artifacts.find((artifact) => {
       return artifact.fileId === fileId;
     });
-    expect(videoArtifact?.previewImageUrl).toMatch(/\/poster-v2\.jpg$/);
+    expect(videoArtifact?.previewImageUrl).toMatch(
+      /\/artifacts\/[0-9a-z]{10}\.jpg$/u,
+    );
   });
 
   it("does not record a run association for ordinary clerk session auth", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-multipart.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-multipart.test.ts
@@ -1,6 +1,13 @@
 import { randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
 
+import {
+  AbortMultipartUploadCommand,
+  CompleteMultipartUploadCommand,
+  CreateMultipartUploadCommand,
+  ListObjectsV2Command,
+  ListPartsCommand,
+} from "@aws-sdk/client-s3";
 import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -23,7 +30,10 @@ describe("multipart user artifact uploads", () => {
     const orgId = `org_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
     context.mocks.s3.send.mockImplementation((command: unknown) => {
-      if (command?.constructor.name === "CreateMultipartUploadCommand") {
+      if (command instanceof ListObjectsV2Command) {
+        return Promise.resolve({ Contents: [] });
+      }
+      if (command instanceof CreateMultipartUploadCommand) {
         return Promise.resolve({ UploadId: "multipart-upload-1" });
       }
       return Promise.resolve({});
@@ -74,10 +84,24 @@ describe("multipart user artifact uploads", () => {
         ],
       },
     });
-    expect(context.mocks.s3.send.mock.calls[0]?.[0]).toMatchObject({
-      input: {
-        Bucket: "test-user-artifacts",
-        ContentType: "video/mp4",
+    expect(response.body.url).toMatch(
+      /^https:\/\/cdn\.vm7\.io\/artifacts\/[0-9a-z]{10}\.mp4$/u,
+    );
+    const createCommand = context.mocks.s3.send.mock.calls
+      .map(([command]) => {
+        return command;
+      })
+      .find((command): command is CreateMultipartUploadCommand => {
+        return command instanceof CreateMultipartUploadCommand;
+      });
+    expect(createCommand?.input).toMatchObject({
+      Bucket: "test-user-artifacts",
+      Key: expect.stringMatching(/^artifacts\/[0-9a-z]{10}\.mp4$/u),
+      ContentType: "video/mp4",
+      Metadata: {
+        "artifact-id": response.body.id,
+        filename: "recording.mp4",
+        "user-id": encodeURIComponent(userId),
       },
     });
   });
@@ -86,6 +110,7 @@ describe("multipart user artifact uploads", () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
+    mocks.s3.listObjects([]);
 
     const response = await accept(
       apiClient().prepare({
@@ -102,6 +127,14 @@ describe("multipart user artifact uploads", () => {
 
     expect(response.body).toMatchObject({
       uploadUrl: "https://r2.example.com/upload?sig=test",
+      url: expect.stringMatching(
+        /^https:\/\/cdn\.vm7\.io\/artifacts\/[0-9a-z]{10}\.mp4$/u,
+      ),
+      uploadHeaders: {
+        "x-amz-meta-artifact-id": response.body.id,
+        "x-amz-meta-filename": "small.mp4",
+        "x-amz-meta-user-id": encodeURIComponent(userId),
+      },
     });
     expect(response.body).not.toHaveProperty("multipart");
   });
@@ -119,7 +152,10 @@ describe("multipart user artifact uploads", () => {
     };
     mocks.clerk.session(userId, orgId);
     context.mocks.s3.send.mockImplementation((command: unknown) => {
-      if (command?.constructor.name === "CreateMultipartUploadCommand") {
+      if (command instanceof ListObjectsV2Command) {
+        return Promise.resolve({ Contents: [] });
+      }
+      if (command instanceof CreateMultipartUploadCommand) {
         controller.abort(abortError);
         return Promise.resolve({ UploadId: "multipart-upload-cancelled" });
       }
@@ -139,12 +175,18 @@ describe("multipart user artifact uploads", () => {
     });
 
     expect(response.status).toBe(500);
-    expect(context.mocks.s3.send).toHaveBeenCalledTimes(2);
-    expect(context.mocks.s3.send.mock.calls[1]?.[0]).toMatchObject({
-      input: {
-        Bucket: "test-user-artifacts",
-        UploadId: "multipart-upload-cancelled",
-      },
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(3);
+    const abortCommand = context.mocks.s3.send.mock.calls
+      .map(([command]) => {
+        return command;
+      })
+      .find((command): command is AbortMultipartUploadCommand => {
+        return command instanceof AbortMultipartUploadCommand;
+      });
+    expect(abortCommand?.input).toMatchObject({
+      Bucket: "test-user-artifacts",
+      Key: expect.stringMatching(/^artifacts\/[0-9a-z]{10}\.mp4$/u),
+      UploadId: "multipart-upload-cancelled",
     });
   });
 
@@ -153,7 +195,7 @@ describe("multipart user artifact uploads", () => {
     const orgId = `org_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
     context.mocks.s3.send.mockImplementation((command: unknown) => {
-      if (command?.constructor.name === "ListPartsCommand") {
+      if (command instanceof ListPartsCommand) {
         return Promise.resolve({
           Parts: [
             { PartNumber: 1, ETag: '"etag-1"' },
@@ -179,18 +221,26 @@ describe("multipart user artifact uploads", () => {
 
     expect(response.body).toStrictEqual({
       id: "3a513aef-a376-49c4-8f15-61f7e8e40526",
-      url: `https://cdn.vm7.io/artifacts/${userId}/3a513aef-a376-49c4-8f15-61f7e8e40526/my_recording.mp4`,
+      url: expect.stringMatching(
+        /^https:\/\/cdn\.vm7\.io\/artifacts\/[0-9a-z]{10}\.mp4$/u,
+      ),
     });
-    expect(context.mocks.s3.send.mock.calls[1]?.[0]).toMatchObject({
-      input: {
-        Bucket: "test-user-artifacts",
-        UploadId: "multipart-upload-1",
-        MultipartUpload: {
-          Parts: [
-            { PartNumber: 1, ETag: '"etag-1"' },
-            { PartNumber: 2, ETag: '"etag-2"' },
-          ],
-        },
+    const completeCommand = context.mocks.s3.send.mock.calls
+      .map(([command]) => {
+        return command;
+      })
+      .find((command): command is CompleteMultipartUploadCommand => {
+        return command instanceof CompleteMultipartUploadCommand;
+      });
+    expect(completeCommand?.input).toMatchObject({
+      Bucket: "test-user-artifacts",
+      Key: expect.stringMatching(/^artifacts\/[0-9a-z]{10}\.mp4$/u),
+      UploadId: "multipart-upload-1",
+      MultipartUpload: {
+        Parts: [
+          { PartNumber: 1, ETag: '"etag-1"' },
+          { PartNumber: 2, ETag: '"etag-2"' },
+        ],
       },
     });
   });
@@ -241,12 +291,17 @@ describe("multipart user artifact uploads", () => {
     expect(response.body).toStrictEqual({
       id: "ba428dc9-af58-4785-b45f-bbed9633ecde",
     });
-    expect(context.mocks.s3.send.mock.calls[0]?.[0]).toMatchObject({
-      input: {
-        Bucket: "test-user-artifacts",
-        Key: `artifacts/${userId}/ba428dc9-af58-4785-b45f-bbed9633ecde/my_recording.mp4`,
-        UploadId: "multipart-upload-3",
-      },
+    const abortCommand = context.mocks.s3.send.mock.calls
+      .map(([command]) => {
+        return command;
+      })
+      .find((command): command is AbortMultipartUploadCommand => {
+        return command instanceof AbortMultipartUploadCommand;
+      });
+    expect(abortCommand?.input).toMatchObject({
+      Bucket: "test-user-artifacts",
+      Key: expect.stringMatching(/^artifacts\/[0-9a-z]{10}\.mp4$/u),
+      UploadId: "multipart-upload-3",
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts
@@ -1,6 +1,10 @@
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 
+import {
+  PutObjectCommand,
+  type PutObjectCommandInput,
+} from "@aws-sdk/client-s3";
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
@@ -169,17 +173,18 @@ function currentSecond(): number {
   return Math.floor(now() / 1000);
 }
 
-function commandInput(command: unknown): Record<string, unknown> {
-  if (
-    typeof command === "object" &&
-    command !== null &&
-    "input" in command &&
-    typeof command.input === "object" &&
-    command.input !== null
-  ) {
-    return command.input as Record<string, unknown>;
+function putObjectInput(): PutObjectCommandInput {
+  const command = context.mocks.s3.send.mock.calls
+    .map(([candidate]) => {
+      return candidate;
+    })
+    .find((candidate): candidate is PutObjectCommand => {
+      return candidate instanceof PutObjectCommand;
+    });
+  if (!command) {
+    throw new Error("Expected generated video to be uploaded to S3");
   }
-  return {};
+  return command.input;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -786,17 +791,16 @@ describe("POST /api/zero/video-io/generate", () => {
     const filename = String(body.filename);
     const url = String(body.url);
     expect(filename).toBe(`video-${fileId.slice(0, 8)}.mp4`);
-    expect(url).toBe(
-      `https://cdn.vm7.io/artifacts/${encodeURIComponent(
-        fixture.userId,
-      )}/${fileId}/${filename}`,
-    );
 
-    const putInput = commandInput(context.mocks.s3.send.mock.calls[0]?.[0]);
+    const putInput = putObjectInput();
     expect(putInput.Bucket).toBe(TEST_BUCKET);
-    expect(putInput.Key).toBe(
-      `artifacts/${fixture.userId}/${fileId}/${filename}`,
-    );
+    expect(putInput.Key).toMatch(/^artifacts\/[0-9a-z]{10}\.mp4$/u);
+    expect(url).toBe(`https://cdn.vm7.io/${String(putInput.Key)}`);
+    expect(putInput.Metadata).toStrictEqual({
+      "artifact-id": fileId,
+      filename: encodeURIComponent(filename),
+      "user-id": encodeURIComponent(fixture.userId),
+    });
     expect(putInput.ContentType).toBe("video/mp4");
     const putBody = putInput.Body;
     expect(Buffer.isBuffer(putBody)).toBeTruthy();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
@@ -1,6 +1,10 @@
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 
+import {
+  PutObjectCommand,
+  type PutObjectCommandInput,
+} from "@aws-sdk/client-s3";
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
@@ -85,17 +89,18 @@ function sttDailyDurationKey(date: Date = currentDate()): string {
   return `${DAILY_DURATION_KEY_PREFIX}_${date.toISOString().slice(0, 10)}`;
 }
 
-function commandInput(command: unknown): Record<string, unknown> {
-  if (
-    typeof command === "object" &&
-    command !== null &&
-    "input" in command &&
-    typeof command.input === "object" &&
-    command.input !== null
-  ) {
-    return command.input as Record<string, unknown>;
+function putObjectInput(): PutObjectCommandInput {
+  const command = context.mocks.s3.send.mock.calls
+    .map(([candidate]) => {
+      return candidate;
+    })
+    .find((candidate): candidate is PutObjectCommand => {
+      return candidate instanceof PutObjectCommand;
+    });
+  if (!command) {
+    throw new Error("Expected generated speech to be uploaded to S3");
   }
-  return {};
+  return command.input;
 }
 
 function writeAscii(bytes: Uint8Array, offset: number, value: string): void {
@@ -1246,20 +1251,26 @@ describe("POST /api/zero/voice-io/*", () => {
         typeof body === "object" &&
         body !== null &&
         "id" in body &&
-        "filename" in body
+        "filename" in body &&
+        "url" in body
       )
     ) {
       throw new Error("Expected speech response id and filename");
     }
     const fileId = String(body.id);
     const filename = String(body.filename);
+    const url = String(body.url);
     expect(filename).toBe(`voice-${fileId.slice(0, 8)}.wav`);
 
-    const putInput = commandInput(context.mocks.s3.send.mock.calls[0]?.[0]);
+    const putInput = putObjectInput();
     expect(putInput.Bucket).toBe(TEST_BUCKET);
-    expect(putInput.Key).toBe(
-      `artifacts/${fixture.userId}/${fileId}/${filename}`,
-    );
+    expect(putInput.Key).toMatch(/^artifacts\/[0-9a-z]{10}\.wav$/u);
+    expect(url).toBe(`https://cdn.vm7.io/${String(putInput.Key)}`);
+    expect(putInput.Metadata).toStrictEqual({
+      "artifact-id": fileId,
+      filename: encodeURIComponent(filename),
+      "user-id": encodeURIComponent(fixture.userId),
+    });
     expect(putInput.ContentType).toBe(SPEECH_CONTENT_TYPE);
     const putBody = putInput.Body;
     expect(Buffer.isBuffer(putBody)).toBeTruthy();

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -23,6 +23,10 @@ describe("isFeatureEnabled", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.CustomConnectorPermissions, {}),
     ).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.ArtifactKeyV2, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.HostedArtifactVersions, {})).toBe(
+      true,
+    );
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -141,7 +145,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadSidebarAutoOpen]).toBe(
       true,
     );
-    expect(staffOrgStates[FeatureSwitchKey.ArtifactKeyV2]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.ArtifactKeyV2]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.HostedArtifactVersions]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.HtmlResourceIndex]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
@@ -175,7 +179,8 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadSidebarAutoOpen]).toBe(
       false,
     );
-    expect(otherOrgStates[FeatureSwitchKey.ArtifactKeyV2]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ArtifactKeyV2]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.HostedArtifactVersions]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.HtmlResourceIndex]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -434,14 +434,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "yuma@vm0.ai",
     description:
       "Store new user artifacts under flat, ten-character hashed public keys.",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.HostedArtifactVersions]: {
     maintainer: "yuma@vm0.ai",
     description:
       "Create immutable hosted artifact versions behind stable site aliases.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.HtmlResourceIndex]: {
     maintainer: "bingjie@vm0.ai",


### PR DESCRIPTION
## Summary

- enable `ArtifactKeyV2` for all users
- enable `HostedArtifactVersions` for all users and remove the redundant staff-only allowlist
- update API integration coverage for versioned hosted deployments and flat hashed artifact keys
- remove the now-unused legacy file URL helper

## Testing

- pre-commit: Prettier, full Knip, full Turbo type checking
- `pnpm -F @vm0/core test`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run --maxWorkers=1 --silent=passed-only` (181 files, 2607 tests)
- post-rebase affected API suite (10 files, 150 tests)