### PR TITLE
perf(python): skip no-op auth.base query tokenization

### DIFF
--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -379,6 +379,9 @@ def _merge_rewrite_query(
     orig_query: str,
     resolved_query: dict[str, str] | None,
 ) -> str:
+    if not base_query and not resolved_query:
+        return orig_query
+
     base_pairs = _split_query_pairs(base_query)
     orig_pairs = _split_query_pairs(orig_query)
     auth_keys = set(resolved_query or {})

--- a/crates/runner/mitm-addon/tests/test_url_utils.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils.py
@@ -1,8 +1,15 @@
 """Tests for URL reconstruction and rewrite utilities."""
 
+from collections.abc import Iterator
+
 import pytest
 
 import url_utils
+
+
+class _FailOnIterationQuery(str):
+    def __iter__(self) -> Iterator[str]:
+        raise AssertionError("original query must not be tokenized without trusted query sources")
 
 
 class TestBuildRewriteUrl:
@@ -174,6 +181,33 @@ class TestBuildRewriteUrl:
             "",
         )
         assert url == "https://example.com/hook"
+
+    @pytest.mark.parametrize(
+        "resolved_query",
+        [
+            pytest.param(None, id="absent"),
+            pytest.param({}, id="empty"),
+        ],
+    )
+    def test_query_free_trusted_sources_do_not_tokenize_original_query(
+        self,
+        resolved_query: dict[str, str] | None,
+    ):
+        query = _FailOnIterationQuery(
+            "blank=&;duplicate=first&&duplicate=second;encoded=%E8%AF%B7%E6%B1%82&unicode=请求"
+        )
+
+        url = url_utils.build_rewrite_url(
+            "https://example.com/hook",
+            "/",
+            query,
+            resolved_query,
+        )
+
+        assert url == (
+            "https://example.com/hook?blank=&;duplicate=first&&duplicate=second;"
+            "encoded=%E8%AF%B7%E6%B1%82&unicode=%E8%AF%B7%E6%B1%82"
+        )
 
     def test_base_query_allows_raw_at_sign(self):
         url = url_utils.build_rewrite_url(


### PR DESCRIPTION
## Summary

- return the original request query directly when neither trusted auth-base source contributes query data
- keep resolved-base validation, final URL quoting, and every trusted-query precedence path unchanged
- add deterministic entry-point coverage for absent and empty resolved auth query shapes without timing thresholds or internal mocks

## Scope

This PR changes only the mitmproxy addon's auth-base query composition identity case and its regression coverage. It does not change query limits, connector behavior, APIs, persisted data, dependencies, configuration, or deployment protocols.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_url_utils.py tests/test_auth_query_injection.py tests/test_firewall_rewrite_success.py tests/test_firewall_rewrite_forwarding.py tests/test_firewall_rewrite_safety.py -q` (181 passed)
- `uv run --no-sync python -m pytest tests/` (4577 passed)

Closes #24686
