### PR TITLE
fix(mitm-addon): support leading bom in sse usage streams

### DIFF
--- a/crates/runner/mitm-addon/src/usage/sse.py
+++ b/crates/runner/mitm-addon/src/usage/sse.py
@@ -18,6 +18,7 @@ _CR_BYTE = b"\r"
 _LF_BYTE = b"\n"
 _SPACE = ord(" ")
 _DATA_FIELD_PREFIX = b"data:"
+_UTF8_BOM = b"\xef\xbb\xbf"
 
 # Non-data SSE control lines are expected to be tiny.  Cap malformed lines so
 # an upstream bug cannot grow memory while we wait for a newline.
@@ -71,6 +72,7 @@ class SseUsageScanner:
     This is deliberately not a full EventSource implementation and does not
     return assembled event bodies.  It keeps only bounded control-line state;
     captured ``data`` payload bytes are streamed directly to the handler.
+    One optional UTF-8 byte-order mark is ignored only at stream start.
 
     With ``capture_data_without_event=True``, the first ``data:`` field can
     start a captured event while the current event name is still ``None``.  If a
@@ -101,6 +103,7 @@ class SseUsageScanner:
         self._capture_data_without_event = capture_data_without_event
         self._event_name: str | None = None
         self._line_buf = bytearray()
+        self._at_stream_start = True
         self._state = "line"
         self._discard_event = False
         self._skip_next_lf = False
@@ -133,6 +136,7 @@ class SseUsageScanner:
     def finish(self) -> None:
         """Flush a trailing event when the stream ends without a blank line."""
 
+        self._at_stream_start = False
         if self._state == "data_prefix_space":
             self._start_data_line()
         elif self._state == "line" and self._line_buf:
@@ -153,10 +157,19 @@ class SseUsageScanner:
     def _consume_line(self, chunk: bytes, i: int) -> int:
         byte = chunk[i]
         if _is_line_ending(byte):
+            self._at_stream_start = False
             self._finish_control_line(byte)
             return i + 1
 
         self._line_buf.append(byte)
+        if self._at_stream_start:
+            if _UTF8_BOM.startswith(self._line_buf):
+                if self._line_buf == _UTF8_BOM:
+                    self._line_buf.clear()
+                    self._at_stream_start = False
+                return i + 1
+            self._at_stream_start = False
+
         if self._line_buf == _DATA_FIELD_PREFIX:
             self._line_buf.clear()
             self._state = "data_prefix_space"

--- a/crates/runner/mitm-addon/tests/test_anthropic_messages.py
+++ b/crates/runner/mitm-addon/tests/test_anthropic_messages.py
@@ -225,6 +225,27 @@ class TestAnthropicSseUsageExtractor:
             ("content_block_start", "text"),
         ]
 
+    @pytest.mark.parametrize("prefix", [b"", b"\xef\xbb\xbf"])
+    def test_leading_bom_preserves_eventless_usage_and_diagnostics(self, prefix: bytes):
+        parse_errors: list[tuple[str, str]] = []
+        parse, usage = create_anthropic_messages_sse_usage_extractor(
+            on_parse_error=lambda event, error: parse_errors.append((event, error))
+        )
+
+        parse(
+            prefix + b'data: {"type":"message_start","message":{"id":"msg_bom",'
+            b'"model":"claude-sonnet-4-6","usage":{"input_tokens":9,'
+            b'"output_tokens":1}}}\n\n'
+        )
+
+        assert usage == {
+            "message_id": "msg_bom",
+            "model": "claude-sonnet-4-6",
+            "tokens.input": 9,
+            "tokens.output": 1,
+        }
+        assert parse_errors == []
+
     def test_lifecycle_event_type_mismatch_is_ignored_and_parser_recovers(self):
         parse, usage, lifecycle_events = _create_parser_with_lifecycle_events()
 

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -113,6 +113,26 @@ class TestOpenAIResponsesSseUsageExtractor:
         assert usage["model"] == "gpt-5.4-mini"
         assert usage["tokens.input"] == 3
 
+    @pytest.mark.parametrize("prefix", [b"", b"\xef\xbb\xbf"])
+    def test_leading_bom_preserves_eventless_usage_and_diagnostics(self, prefix: bytes):
+        parse_errors: list[tuple[str, str]] = []
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_parse_error=lambda event, error: parse_errors.append((event, error))
+        )
+
+        parse(
+            prefix + b'data: {"type":"response.completed","response":{"id":"resp_bom",'
+            b'"model":"gpt-5.6","usage":{"input_tokens":9,"output_tokens":4}}}\n\n'
+        )
+
+        assert usage == {
+            "message_id": "resp_bom",
+            "model": "gpt-5.6",
+            "tokens.input": 9,
+            "tokens.output": 4,
+        }
+        assert parse_errors == []
+
     def test_eventless_unknown_event_type_with_usage_extracts_usage(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(

--- a/crates/runner/mitm-addon/tests/test_sse.py
+++ b/crates/runner/mitm-addon/tests/test_sse.py
@@ -53,6 +53,67 @@ class _FindTrackingBytes(bytes):
 
 
 @pytest.mark.parametrize(
+    "bom_chunks",
+    [
+        pytest.param((b"\xef\xbb\xbf",), id="one-chunk"),
+        pytest.param((b"\xef", b"\xbb\xbf"), id="one-plus-two"),
+        pytest.param((b"\xef\xbb", b"\xbf"), id="two-plus-one"),
+        pytest.param((b"\xef", b"\xbb", b"\xbf"), id="three-chunks"),
+    ],
+)
+def test_ignores_one_leading_utf8_bom_across_chunks(bom_chunks: tuple[bytes, ...]) -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    for chunk in bom_chunks:
+        scanner.feed(chunk)
+    scanner.feed(b"event: target\ndata: ok\n\n")
+
+    assert handler.events == [("target", b"ok")]
+    assert handler.discarded == []
+
+
+@pytest.mark.parametrize("partial_bom", [b"\xef", b"\xef\xbb"])
+def test_preserves_mismatched_partial_bom_at_stream_start(partial_bom: bytes) -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    scanner.feed(partial_bom + b"event: target\ndata: ignored\n\n")
+
+    assert handler.started == []
+    assert handler.events == []
+    assert handler.discarded == []
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        pytest.param(b"\xef\xbb\xbf\xef\xbb\xbf", id="second-bom"),
+        pytest.param(b": comment\n\xef\xbb\xbf", id="later-bom"),
+    ],
+)
+def test_does_not_strip_utf8_bom_after_stream_start(prefix: bytes) -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    scanner.feed(prefix + b"event: target\ndata: ignored\n\n")
+
+    assert handler.started == []
+    assert handler.events == []
+    assert handler.discarded == []
+
+
+def test_preserves_utf8_bom_in_captured_data() -> None:
+    handler = _CaptureHandler({"target"})
+    scanner = SseUsageScanner(handler)
+
+    scanner.feed(b"\xef\xbb\xbfevent: target\ndata: \xef\xbb\xbfpayload\n\n")
+
+    assert handler.events == [("target", b"\xef\xbb\xbfpayload")]
+    assert handler.discarded == []
+
+
+@pytest.mark.parametrize(
     ("preferred_newline", "other_newline"),
     [
         (b"\n", b"\r"),


### PR DESCRIPTION
## Summary

- ignore exactly one UTF-8 BOM at the beginning of an SSE usage stream, including across arbitrary chunk boundaries
- preserve partial mismatches, additional or later BOM bytes, and BOM bytes inside captured data
- verify BOM-free and BOM-prefixed eventless usage parity for both OpenAI Responses and Anthropic Messages extractors

## Scope

The change stays inside the shared Python SSE scanner and its tests. It does not change response decoding, provider selection, APIs, persisted data, migrations, or cross-version protocols.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_sse.py tests/test_openai_responses_sse.py tests/test_anthropic_messages.py` — 133 passed
- `uv run --no-sync python -m pytest tests/` — 4,588 passed

Closes #24687
