### PR TITLE
fix(api): purge quiescent threadless agent runs

### DIFF
--- a/turbo/apps/api/src/lib/pg-errors.ts
+++ b/turbo/apps/api/src/lib/pg-errors.ts
@@ -1,0 +1,14 @@
+const PG_FOREIGN_KEY_VIOLATION = "23503";
+
+export function isForeignKeyViolation(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const { cause } = error;
+  if (typeof cause !== "object" || cause === null || !("code" in cause)) {
+    return false;
+  }
+
+  return cause.code === PG_FOREIGN_KEY_VIOLATION;
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1,7 +1,11 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import { createStore } from "ccstate";
-import { cronCompactChatThreadSnapshotsContract } from "@vm0/api-contracts/contracts/cron";
+import {
+  cronCleanupSandboxesContract,
+  cronCompactChatThreadSnapshotsContract,
+} from "@vm0/api-contracts/contracts/cron";
+import { CANCELLATION_RECOVERY_STALE_AFTER_MS } from "@vm0/api-contracts/contracts/runners";
 import {
   chatThreadsContract,
   type ChatEvent,
@@ -10,7 +14,7 @@ import {
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
 import { DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL } from "@vm0/api-contracts/contracts/model-providers";
 import { zeroGoalsContract } from "@vm0/api-contracts/contracts/zero-goals";
-import { describe, expect, it, onTestFinished } from "vitest";
+import { describe, expect, onTestFinished, test as vitestTest } from "vitest";
 
 import { createApp } from "../../../app-factory";
 import { stubTestTimezone } from "../../../__tests__/env-stub";
@@ -31,6 +35,10 @@ import {
   insertChatThreadEventTransactionFixture,
 } from "../../../test-fixtures/chat-thread-events";
 import { installApiTestConnectorCatalog } from "../../../test-fixtures/connector-catalog";
+import {
+  setAgentRunCreatedAtFixture,
+  withThreadlessRunCleanupTestLockFixture,
+} from "../../../test-fixtures/run-deletion";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import {
@@ -92,7 +100,9 @@ const connectorsApi = createConnectorBddApi(context);
 const authOrg = createAuthOrgAgentsBddApi(context);
 const store = createStore();
 const CHAT_THREAD_SNAPSHOT_CRON_SECRET = "chat-thread-snapshot-cron-secret";
+const SANDBOX_CLEANUP_CRON_SECRET = "sandbox-cleanup-cron-secret";
 const DAY_MS = 24 * 60 * 60 * 1000;
+const FORWARD_CLEANUP_TEST_CREATED_AT = "2026-08-03T05:40:26.001Z";
 
 type UserMessage = Extract<
   ChatEvent,
@@ -107,6 +117,26 @@ type UserMessage = Extract<
 >;
 type AssistantMessage = Exclude<ChatEvent, UserMessage>;
 type RunnerClaim = Awaited<ReturnType<typeof api.claimRunnerJob>>;
+
+function it(name: string, test: () => Promise<void>, timeout?: number): void {
+  vitestTest(
+    name,
+    async () => {
+      if (
+        name ===
+        "cancels in-flight runs and cascades schedules when a thread is deleted"
+      ) {
+        await withThreadlessRunCleanupTestLockFixture({
+          signal: context.signal,
+          run: test,
+        });
+        return;
+      }
+      await test();
+    },
+    timeout,
+  );
+}
 
 async function compactChatThreadSnapshots() {
   const client = setupApp({ context })(cronCompactChatThreadSnapshotsContract);
@@ -1338,6 +1368,14 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     const siblingClaim = await claimChatRun(runnerGroup, sibling.runId);
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(sibling.runId, siblingClaim.sandboxHeaders);
+    await setAgentRunCreatedAtFixture(
+      main.runId,
+      new Date(FORWARD_CLEANUP_TEST_CREATED_AT),
+    );
+    await setAgentRunCreatedAtFixture(
+      sibling.runId,
+      new Date(FORWARD_CLEANUP_TEST_CREATED_AT),
+    );
 
     await expect(chat.listActiveChatThreadIds(actor)).resolves.not.toContain(
       sibling.threadId,
@@ -1384,6 +1422,30 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
         }),
       ]),
     );
+
+    // Terminal-only deletion does not have the active fast path. Both roots
+    // become durable cleanup work and are purged only after the quiet window.
+    await chat.deleteThread(actor, sibling.threadId);
+    const cleanupAt = now() + CANCELLATION_RECOVERY_STALE_AFTER_MS;
+    mockEnv("CRON_SECRET", SANDBOX_CLEANUP_CRON_SECRET);
+    mockNow(cleanupAt);
+    onTestFinished(clearMockNow);
+    const cleanup = await accept(
+      setupApp({ context })(cronCleanupSandboxesContract).cleanup({
+        headers: {
+          authorization: `Bearer ${SANDBOX_CLEANUP_CRON_SECRET}`,
+        },
+      }),
+      [200],
+    );
+    expect(cleanup.body.threadlessRuns.discovered).toBeGreaterThanOrEqual(2);
+    expect(cleanup.body.threadlessRuns.deleted).toBeGreaterThanOrEqual(2);
+    await expect(
+      api.requestReadRun(actor, main.runId, [404]),
+    ).resolves.toMatchObject({ status: 404 });
+    await expect(
+      api.requestReadRun(actor, sibling.runId, [404]),
+    ).resolves.toMatchObject({ status: 404 });
 
     await cancelChatRun(actor, other.runId);
   }, 120_000);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -102,7 +102,9 @@ const store = createStore();
 const CHAT_THREAD_SNAPSHOT_CRON_SECRET = "chat-thread-snapshot-cron-secret";
 const SANDBOX_CLEANUP_CRON_SECRET = "sandbox-cleanup-cron-secret";
 const DAY_MS = 24 * 60 * 60 * 1000;
+const FORWARD_CLEANUP_CUTOFF_MS = Date.parse("2026-08-03T05:40:26.000Z");
 const FORWARD_CLEANUP_TEST_CREATED_AT = "2026-08-03T05:40:26.001Z";
+const PRE_FORWARD_CLEANUP_TEST_CREATED_AT = "2026-08-03T05:40:25.999Z";
 
 type UserMessage = Extract<
   ChatEvent,
@@ -1374,7 +1376,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     );
     await setAgentRunCreatedAtFixture(
       sibling.runId,
-      new Date(FORWARD_CLEANUP_TEST_CREATED_AT),
+      new Date(PRE_FORWARD_CLEANUP_TEST_CREATED_AT),
     );
 
     await expect(chat.listActiveChatThreadIds(actor)).resolves.not.toContain(
@@ -1423,9 +1425,21 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       ]),
     );
 
-    // Terminal-only deletion does not have the active fast path. Both roots
-    // become durable cleanup work and are purged only after the quiet window.
+    // Terminal-only deletion does not have the active fast path. The sibling
+    // predates the watermark, so only its matching post-watermark tombstone
+    // admits it to the forward cleanup cohort.
     await chat.deleteThread(actor, sibling.threadId);
+    const siblingDeletion = (await allThreadEvents(actor)).find((event) => {
+      return (
+        event.kind === "deleted" && event.chatThreadId === sibling.threadId
+      );
+    });
+    if (!siblingDeletion) {
+      throw new Error("Expected the sibling deletion tombstone");
+    }
+    expect(Date.parse(siblingDeletion.createdAt)).toBeGreaterThanOrEqual(
+      FORWARD_CLEANUP_CUTOFF_MS,
+    );
     const cleanupAt = now() + CANCELLATION_RECOVERY_STALE_AFTER_MS;
     mockEnv("CRON_SECRET", SANDBOX_CLEANUP_CRON_SECRET);
     mockNow(cleanupAt);

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -33,6 +33,8 @@ import {
   holdAgentRunDeletionFixture,
   holdOrgCreditLockFixture,
   holdRunOutputProjectionLockFixture,
+  insertPendingInlineDeliveryCallbackFixture,
+  readRunCallbackFixture,
   withThreadlessRunCleanupTestLockFixture,
 } from "../../../test-fixtures/run-deletion";
 import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandboxes-state";
@@ -723,6 +725,45 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     );
     expect(response.body.threadlessRuns.discovered).toBeGreaterThanOrEqual(1);
     expect(response.body.threadlessRuns.deleted).toBeGreaterThanOrEqual(1);
+    await expect(findRun(fixture.runId)).resolves.toBeNull();
+  });
+
+  it("terminalizes a stranded inline delivery callback before deleting its run", async () => {
+    mockNow(THREADLESS_TEST_NOW_MS);
+    const fixture = await trackRun(
+      insertRunFixture({
+        status: "completed",
+        createdAt: new Date(THREADLESS_FORWARD_CUTOFF_MS + 1),
+        completedAt: new Date(
+          THREADLESS_TEST_NOW_MS - CANCELLATION_RECOVERY_STALE_AFTER_MS,
+        ),
+        threadless: true,
+      }),
+    );
+    const callbackId = await insertPendingInlineDeliveryCallbackFixture(
+      fixture.runId,
+    );
+    await insertRunnerJobEntry(fixture, new Date(0));
+
+    const waiting = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+    expect(waiting.body.threadlessRuns.discovered).toBeGreaterThanOrEqual(1);
+    expect(waiting.body.threadlessRuns.waiting).toBeGreaterThanOrEqual(1);
+    await expect(findRun(fixture.runId)).resolves.not.toBeNull();
+    await expect(readRunCallbackFixture(callbackId)).resolves.toStrictEqual({
+      status: "failed",
+      lastError: "Chat thread was deleted before inline callback delivery",
+    });
+    await expect(findRunnerJob(fixture.runId)).resolves.toBeNull();
+
+    const deleted = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+    expect(deleted.body.threadlessRuns.discovered).toBeGreaterThanOrEqual(1);
+    expect(deleted.body.threadlessRuns.deleted).toBeGreaterThanOrEqual(1);
     await expect(findRun(fixture.runId)).resolves.toBeNull();
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -2,6 +2,11 @@ import { randomUUID } from "node:crypto";
 
 import { cronCleanupSandboxesContract } from "@vm0/api-contracts/contracts/cron";
 import {
+  triggerSourceSchema,
+  type TriggerSource,
+} from "@vm0/api-contracts/contracts/logs";
+import {
+  CANCELLATION_RECOVERY_STALE_AFTER_MS,
   NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
   runnersNetworkPolicyRefreshContract,
 } from "@vm0/api-contracts/contracts/runners";
@@ -9,24 +14,59 @@ import type {
   TestCronCleanupSandboxesStateActionBody,
   TestCronCleanupSandboxesStateActionResponse,
 } from "@vm0/api-contracts/contracts/test-cron-cleanup-sandboxes-state";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  onTestFinished,
+  test as vitestTest,
+} from "vitest";
 
 import { createApp } from "../../../app-factory";
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockEnv } from "../../../lib/env";
 import { clearMockNow, mockNow } from "../../../lib/time";
+import { generateSandboxToken } from "../../auth/tokens";
+import {
+  holdAgentRunDeletionFixture,
+  holdOrgCreditLockFixture,
+  holdRunOutputProjectionLockFixture,
+  withThreadlessRunCleanupTestLockFixture,
+} from "../../../test-fixtures/run-deletion";
 import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandboxes-state";
 import { createFixtureTracker } from "./helpers/zero-route-test";
+import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 
 const context = testContext();
+const webhooks = createWebhookCallbackApi(context);
 const CRON_SECRET = "test-cron-secret";
 const BUCKET = "test-user-storage-bucket";
 const FIXED_NOW_MS = Date.parse("2000-01-01T00:10:00.000Z");
+const THREADLESS_FORWARD_CUTOFF_MS = Date.parse("2026-08-03T05:40:26.000Z");
+const THREADLESS_TEST_NOW_MS = Date.parse("2026-08-03T06:00:00.000Z");
+const NON_TEST_TRIGGER_SOURCES: readonly TriggerSource[] =
+  triggerSourceSchema.options.filter((source) => {
+    return source !== "test";
+  });
 const CRON_CLEANUP_STATE_ROUTE =
   "/api/test/cron-cleanup-sandboxes-state/action";
 const OFFICIAL_RUNNER_AUTHORIZATION =
   "Bearer vm0_official_abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+function it(name: string, test: () => Promise<void>, timeout?: number): void {
+  vitestTest(
+    name,
+    async () => {
+      await withThreadlessRunCleanupTestLockFixture({
+        signal: context.signal,
+        run: test,
+      });
+    },
+    timeout,
+  );
+}
 
 interface RunFixture {
   readonly runId: string;
@@ -34,6 +74,7 @@ interface RunFixture {
   readonly composeId: string;
   readonly versionId: string;
   readonly orgId: string;
+  readonly userId: string;
 }
 
 interface ExportJobFixture {
@@ -49,6 +90,21 @@ interface QueueMarkerRevoker {
   readonly id: string;
   readonly revokesEventId: string;
   readonly runEventId: string | null;
+}
+
+interface RunOwnershipFixture {
+  readonly usageEventId: string;
+  readonly uploadedFileId: string;
+  readonly fileArtifactId: string;
+  readonly browserSessionId: string;
+  readonly generationJobId: string;
+  readonly hostedSiteId: string;
+  readonly hostedDeploymentId: string;
+  readonly hostedArtifactId: string;
+}
+
+interface ChatThreadFixture {
+  readonly threadId: string;
 }
 
 function apiClient() {
@@ -130,7 +186,14 @@ function nullableString(value: unknown): string | null {
 }
 
 async function cleanupRunFixture(fixture: RunFixture): Promise<void> {
-  await postCronCleanupState({ action: "delete-run", run_id: fixture.runId });
+  await postCronCleanupState({
+    action: "delete-run",
+    run_id: fixture.runId,
+    session_id: fixture.sessionId,
+    compose_id: fixture.composeId,
+    version_id: fixture.versionId,
+    org_id: fixture.orgId,
+  });
 }
 
 async function cleanupExportJobFixture(
@@ -142,11 +205,50 @@ async function cleanupExportJobFixture(
   });
 }
 
+function ownershipActionFields(
+  fixture: RunOwnershipFixture,
+): Record<string, string> {
+  return {
+    usage_event_id: fixture.usageEventId,
+    uploaded_file_id: fixture.uploadedFileId,
+    file_artifact_id: fixture.fileArtifactId,
+    browser_session_id: fixture.browserSessionId,
+    generation_job_id: fixture.generationJobId,
+    hosted_site_id: fixture.hostedSiteId,
+    hosted_deployment_id: fixture.hostedDeploymentId,
+    hosted_artifact_id: fixture.hostedArtifactId,
+  };
+}
+
+async function cleanupRunOwnershipFixture(
+  fixture: RunOwnershipFixture,
+): Promise<void> {
+  await postCronCleanupState({
+    action: "delete-run-ownership",
+    ...ownershipActionFields(fixture),
+  });
+}
+
+async function cleanupChatThreadFixture(
+  fixture: ChatThreadFixture,
+): Promise<void> {
+  await postCronCleanupState({
+    action: "delete-run-thread",
+    thread_id: fixture.threadId,
+  });
+}
+
 async function insertRunFixture(args?: {
   readonly status?: string;
   readonly composeName?: string;
   readonly createdAt?: Date;
   readonly lastHeartbeatAt?: Date | null;
+  readonly completedAt?: Date | null;
+  readonly cancellationRecoveryCompleted?: boolean;
+  readonly threadless?: boolean;
+  readonly triggerSource?: TriggerSource;
+  readonly userId?: string;
+  readonly orgId?: string;
 }): Promise<RunFixture> {
   const response = await postCronCleanupState({
     action: "seed-run",
@@ -157,6 +259,15 @@ async function insertRunFixture(args?: {
       args?.lastHeartbeatAt === undefined
         ? undefined
         : (args.lastHeartbeatAt?.toISOString() ?? null),
+    completed_at:
+      args?.completedAt === undefined
+        ? undefined
+        : (args.completedAt?.toISOString() ?? null),
+    cancellation_recovery_completed: args?.cancellationRecoveryCompleted,
+    threadless: args?.threadless,
+    trigger_source: args?.triggerSource,
+    user_id: args?.userId,
+    org_id: args?.orgId,
   });
   return {
     runId: stringField(response, "run_id"),
@@ -164,6 +275,7 @@ async function insertRunFixture(args?: {
     composeId: stringField(response, "compose_id"),
     versionId: stringField(response, "version_id"),
     orgId: stringField(response, "org_id"),
+    userId: stringField(response, "user_id"),
   };
 }
 
@@ -179,6 +291,44 @@ async function insertQueueEntry(
     run_id: fixture.runId,
     expires_at: expiresAt.toISOString(),
     encrypted_params: options?.encryptedParams,
+  });
+}
+
+async function insertRunOwnership(
+  fixture: RunFixture,
+): Promise<RunOwnershipFixture> {
+  const response = await postCronCleanupState({
+    action: "seed-run-ownership",
+    run_id: fixture.runId,
+  });
+  return {
+    usageEventId: stringField(response, "usage_event_id"),
+    uploadedFileId: stringField(response, "uploaded_file_id"),
+    fileArtifactId: stringField(response, "file_artifact_id"),
+    browserSessionId: stringField(response, "browser_session_id"),
+    generationJobId: stringField(response, "generation_job_id"),
+    hostedSiteId: stringField(response, "hosted_site_id"),
+    hostedDeploymentId: stringField(response, "hosted_deployment_id"),
+    hostedArtifactId: stringField(response, "hosted_artifact_id"),
+  };
+}
+
+async function attachRunThread(
+  fixture: RunFixture,
+): Promise<ChatThreadFixture> {
+  const response = await postCronCleanupState({
+    action: "attach-run-thread",
+    run_id: fixture.runId,
+  });
+  return { threadId: stringField(response, "thread_id") };
+}
+
+async function findRunOwnership(
+  fixture: RunOwnershipFixture,
+): Promise<TestCronCleanupSandboxesStateActionResponse> {
+  return await postCronCleanupState({
+    action: "get-run-ownership",
+    ...ownershipActionFields(fixture),
   });
 }
 
@@ -328,6 +478,12 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
   const trackExportJob = createFixtureTracker<ExportJobFixture>(
     cleanupExportJobFixture,
   );
+  const trackRunOwnership = createFixtureTracker<RunOwnershipFixture>(
+    cleanupRunOwnershipFixture,
+  );
+  const trackChatThread = createFixtureTracker<ChatThreadFixture>(
+    cleanupChatThreadFixture,
+  );
 
   beforeEach(() => {
     mockEnv("CRON_SECRET", CRON_SECRET);
@@ -374,7 +530,435 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       results: [],
       exportJobsCleaned: 0,
       exportJobsStuck: 0,
+      threadlessRuns: {
+        discovered: expect.any(Number),
+        cancelled: expect.any(Number),
+        waiting: expect.any(Number),
+        deleted: expect.any(Number),
+        failed: expect.any(Number),
+        errors: expect.any(Array),
+      },
     });
+  });
+
+  it("leaves the audited pre-forward threadless cohort discoverable", async () => {
+    mockNow(THREADLESS_TEST_NOW_MS);
+    const fixture = await trackRun(
+      insertRunFixture({
+        status: "completed",
+        createdAt: new Date(THREADLESS_FORWARD_CUTOFF_MS - 1),
+        completedAt: new Date(
+          THREADLESS_TEST_NOW_MS - CANCELLATION_RECOVERY_STALE_AFTER_MS,
+        ),
+        threadless: true,
+      }),
+    );
+
+    await accept(apiClient().cleanup({ headers: cronHeaders() }), [200]);
+
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "completed",
+    });
+  });
+
+  it("ignores preview-only test fixture runs without bypassing non-test runs", async () => {
+    mockNow(THREADLESS_TEST_NOW_MS);
+    const fixture = await trackRun(
+      insertRunFixture({
+        status: "completed",
+        createdAt: new Date(THREADLESS_FORWARD_CUTOFF_MS + 1),
+        completedAt: new Date(
+          THREADLESS_TEST_NOW_MS - CANCELLATION_RECOVERY_STALE_AFTER_MS,
+        ),
+        threadless: true,
+        triggerSource: "test",
+      }),
+    );
+
+    await accept(apiClient().cleanup({ headers: cronHeaders() }), [200]);
+
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "completed",
+    });
+  });
+
+  it("processes every non-test trigger source when the run is threadless", async () => {
+    mockNow(THREADLESS_TEST_NOW_MS);
+    const fixtures: RunFixture[] = [];
+    for (const triggerSource of NON_TEST_TRIGGER_SOURCES) {
+      fixtures.push(
+        await trackRun(
+          insertRunFixture({
+            status: "completed",
+            createdAt: new Date(THREADLESS_FORWARD_CUTOFF_MS + 1),
+            completedAt: new Date(
+              THREADLESS_TEST_NOW_MS - CANCELLATION_RECOVERY_STALE_AFTER_MS,
+            ),
+            threadless: true,
+            triggerSource,
+          }),
+        ),
+      );
+    }
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.threadlessRuns.discovered).toBeGreaterThanOrEqual(
+      NON_TEST_TRIGGER_SOURCES.length,
+    );
+    expect(response.body.threadlessRuns.deleted).toBeGreaterThanOrEqual(
+      NON_TEST_TRIGGER_SOURCES.length,
+    );
+    for (const fixture of fixtures) {
+      await expect(findRun(fixture.runId)).resolves.toBeNull();
+    }
+  });
+
+  it("waits through the quiet window and deletes at its exact boundary", async () => {
+    const completedAt = new Date(THREADLESS_TEST_NOW_MS);
+    mockNow(completedAt.getTime() + CANCELLATION_RECOVERY_STALE_AFTER_MS - 1);
+    const fixture = await trackRun(
+      insertRunFixture({
+        status: "completed",
+        createdAt: new Date(THREADLESS_FORWARD_CUTOFF_MS + 1),
+        completedAt,
+        threadless: true,
+      }),
+    );
+
+    const waitingResponse = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+    expect(
+      waitingResponse.body.threadlessRuns.discovered,
+    ).toBeGreaterThanOrEqual(1);
+    expect(waitingResponse.body.threadlessRuns.waiting).toBeGreaterThanOrEqual(
+      1,
+    );
+    await expect(findRun(fixture.runId)).resolves.not.toBeNull();
+
+    mockNow(completedAt.getTime() + CANCELLATION_RECOVERY_STALE_AFTER_MS);
+    const deletedResponse = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+    expect(
+      deletedResponse.body.threadlessRuns.discovered,
+    ).toBeGreaterThanOrEqual(1);
+    expect(deletedResponse.body.threadlessRuns.deleted).toBeGreaterThanOrEqual(
+      1,
+    );
+    await expect(findRun(fixture.runId)).resolves.toBeNull();
+  });
+
+  it("hard-cancels an active threadless run without deleting it in the same pass", async () => {
+    mockNow(THREADLESS_TEST_NOW_MS);
+    const fixture = await trackRun(
+      insertRunFixture({
+        status: "running",
+        createdAt: new Date(THREADLESS_TEST_NOW_MS - 60_000),
+        lastHeartbeatAt: new Date(THREADLESS_TEST_NOW_MS - 60_000),
+        threadless: true,
+      }),
+    );
+
+    const cancelledResponse = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+    expect(
+      cancelledResponse.body.threadlessRuns.discovered,
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      cancelledResponse.body.threadlessRuns.cancelled,
+    ).toBeGreaterThanOrEqual(1);
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "cancelled",
+    });
+
+    mockNow(THREADLESS_TEST_NOW_MS + CANCELLATION_RECOVERY_STALE_AFTER_MS);
+    const deletedResponse = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+    expect(
+      deletedResponse.body.threadlessRuns.discovered,
+    ).toBeGreaterThanOrEqual(1);
+    expect(deletedResponse.body.threadlessRuns.deleted).toBeGreaterThanOrEqual(
+      1,
+    );
+    await expect(findRun(fixture.runId)).resolves.toBeNull();
+  });
+
+  it("redrives expired unresolved cancellation recovery before deletion", async () => {
+    mockNow(THREADLESS_TEST_NOW_MS);
+    const fixture = await trackRun(
+      insertRunFixture({
+        status: "cancelled",
+        createdAt: new Date(THREADLESS_FORWARD_CUTOFF_MS + 1),
+        completedAt: new Date(
+          THREADLESS_TEST_NOW_MS - CANCELLATION_RECOVERY_STALE_AFTER_MS + 1,
+        ),
+        cancellationRecoveryCompleted: false,
+        threadless: true,
+      }),
+    );
+
+    const waiting = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+    expect(waiting.body.threadlessRuns.discovered).toBeGreaterThanOrEqual(1);
+    expect(waiting.body.threadlessRuns.waiting).toBeGreaterThanOrEqual(1);
+    await expect(findRun(fixture.runId)).resolves.not.toBeNull();
+
+    mockNow(THREADLESS_TEST_NOW_MS + 1);
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+    expect(response.body.threadlessRuns.discovered).toBeGreaterThanOrEqual(1);
+    expect(response.body.threadlessRuns.deleted).toBeGreaterThanOrEqual(1);
+    await expect(findRun(fixture.runId)).resolves.toBeNull();
+  });
+
+  it("cascades run-owned artifacts while preserving independent ownership", async () => {
+    mockNow(THREADLESS_TEST_NOW_MS);
+    const fixture = await trackRun(
+      insertRunFixture({
+        status: "completed",
+        createdAt: new Date(THREADLESS_FORWARD_CUTOFF_MS + 1),
+        completedAt: new Date(
+          THREADLESS_TEST_NOW_MS - CANCELLATION_RECOVERY_STALE_AFTER_MS,
+        ),
+        threadless: true,
+      }),
+    );
+    const ownership = await trackRunOwnership(insertRunOwnership(fixture));
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.threadlessRuns.discovered).toBeGreaterThanOrEqual(1);
+    expect(response.body.threadlessRuns.deleted).toBeGreaterThanOrEqual(1);
+    const state = await findRunOwnership(ownership);
+    expect(recordField(state, "uploaded_file")).toBeNull();
+    expect(recordField(state, "file_artifact")).toBeNull();
+    expect(recordField(state, "usage_event")).toMatchObject({
+      runId: null,
+      status: "processed",
+      creditsCharged: 9,
+    });
+    expect(recordField(state, "browser_session")).toMatchObject({
+      id: ownership.browserSessionId,
+      runId: null,
+    });
+    expect(recordField(state, "generation_job")).toMatchObject({
+      id: ownership.generationJobId,
+      runId: null,
+    });
+    expect(recordField(state, "hosted_site")).toMatchObject({
+      id: ownership.hostedSiteId,
+      createdFromRunId: fixture.runId,
+    });
+    expect(recordField(state, "hosted_deployment")).toMatchObject({
+      id: ownership.hostedDeploymentId,
+      runId: fixture.runId,
+    });
+    expect(recordField(state, "hosted_artifact")).toStrictEqual({
+      id: ownership.hostedArtifactId,
+    });
+  });
+
+  it("processes only the oldest bounded batch of threadless runs", async () => {
+    mockNow(THREADLESS_TEST_NOW_MS);
+    const userId = `user-${randomUUID()}`;
+    const orgId = `org-${randomUUID()}`;
+    const fixtures = await Promise.all(
+      Array.from({ length: 21 }, async (_, index) => {
+        return await trackRun(
+          insertRunFixture({
+            status: "completed",
+            createdAt: new Date(THREADLESS_FORWARD_CUTOFF_MS + index + 1),
+            completedAt: new Date(
+              THREADLESS_TEST_NOW_MS - CANCELLATION_RECOVERY_STALE_AFTER_MS,
+            ),
+            threadless: true,
+            userId,
+            orgId,
+          }),
+        );
+      }),
+    );
+
+    const firstResponse = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+    expect(firstResponse.body.threadlessRuns).toMatchObject({
+      discovered: 20,
+      deleted: 20,
+      failed: 0,
+    });
+    await expect(findRun(fixtures[20]!.runId)).resolves.not.toBeNull();
+
+    const secondResponse = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+    expect(
+      secondResponse.body.threadlessRuns.discovered,
+    ).toBeGreaterThanOrEqual(1);
+    expect(secondResponse.body.threadlessRuns.deleted).toBeGreaterThanOrEqual(
+      1,
+    );
+    await expect(findRun(fixtures[20]!.runId)).resolves.toBeNull();
+  });
+
+  it("acknowledges an event projection that loses the root-delete race", async () => {
+    mockNow(THREADLESS_TEST_NOW_MS);
+    const fixture = await trackRun(
+      insertRunFixture({
+        status: "completed",
+        createdAt: new Date(THREADLESS_FORWARD_CUTOFF_MS + 1),
+        completedAt: new Date(
+          THREADLESS_TEST_NOW_MS - CANCELLATION_RECOVERY_STALE_AFTER_MS,
+        ),
+        threadless: true,
+      }),
+    );
+    const held = await holdRunOutputProjectionLockFixture({
+      runId: fixture.runId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      held.release();
+      await held.done;
+    });
+    const headers = {
+      authorization: `Bearer ${generateSandboxToken(
+        fixture.userId,
+        fixture.runId,
+        fixture.orgId,
+      )}`,
+    };
+    const eventRequest = webhooks.requestAgentEvents(
+      {
+        runId: fixture.runId,
+        events: [
+          {
+            type: "assistant",
+            sequenceNumber: 0,
+            message: {
+              id: `msg_${randomUUID()}`,
+              content: [{ type: "text", text: "late output" }],
+            },
+          },
+        ],
+      },
+      headers,
+      [200],
+    );
+    await expect.poll(held.blockedWaiterCount).toBeGreaterThan(0);
+
+    const cleanup = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+    expect(cleanup.body.threadlessRuns.discovered).toBeGreaterThanOrEqual(1);
+    expect(cleanup.body.threadlessRuns.deleted).toBeGreaterThanOrEqual(1);
+    held.release();
+    await held.done;
+    const eventResponse = await eventRequest;
+    expect(eventResponse).toMatchObject({
+      status: 200,
+      body: { received: 1, firstSequence: 0, lastSequence: 0 },
+    });
+  });
+
+  it("skips deletion when the threadless state changes before the write transaction", async () => {
+    mockNow(THREADLESS_TEST_NOW_MS);
+    const fixture = await trackRun(
+      insertRunFixture({
+        status: "completed",
+        createdAt: new Date(THREADLESS_FORWARD_CUTOFF_MS + 1),
+        completedAt: new Date(
+          THREADLESS_TEST_NOW_MS - CANCELLATION_RECOVERY_STALE_AFTER_MS,
+        ),
+        threadless: true,
+      }),
+    );
+    const held = await holdOrgCreditLockFixture({
+      orgId: fixture.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      held.release();
+      await held.done;
+    });
+    const cleanupRequest = apiClient().cleanup({ headers: cronHeaders() });
+    await expect.poll(held.blockedWaiterCount).toBeGreaterThan(0);
+
+    await trackChatThread(attachRunThread(fixture));
+    held.release();
+    await held.done;
+    const cleanup = await accept(cleanupRequest, [200]);
+    expect(cleanup.body.threadlessRuns.discovered).toBeGreaterThanOrEqual(1);
+    expect(cleanup.body.threadlessRuns.waiting).toBeGreaterThanOrEqual(1);
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "completed",
+    });
+  });
+
+  it("acknowledges completion when root deletion wins the row-lock race", async () => {
+    mockNow(THREADLESS_TEST_NOW_MS);
+    const fixture = await trackRun(
+      insertRunFixture({
+        status: "running",
+        createdAt: new Date(THREADLESS_FORWARD_CUTOFF_MS + 1),
+        threadless: true,
+      }),
+    );
+    const held = await holdAgentRunDeletionFixture({
+      runId: fixture.runId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      held.release();
+      await held.done;
+    });
+    const headers = {
+      authorization: `Bearer ${generateSandboxToken(
+        fixture.userId,
+        fixture.runId,
+        fixture.orgId,
+      )}`,
+    };
+    const completionRequest = webhooks.requestAgentComplete(
+      {
+        runId: fixture.runId,
+        exitCode: 1,
+        error: "late runner failure",
+      },
+      headers,
+      [200],
+    );
+    await expect.poll(held.blockedWaiterCount).toBeGreaterThan(0);
+
+    held.release();
+    await held.done;
+    const completion = await completionRequest;
+    expect(completion).toMatchObject({
+      status: 200,
+      body: { success: true, status: "failed" },
+    });
+    await expect(findRun(fixture.runId)).resolves.toBeNull();
   });
 
   it("does not cleanup a recent pending run", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1268,7 +1268,7 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
     expect(redirectTargetRequests).toBe(0);
   });
 
-  it("rejects an event batch when its required DB run is missing", async () => {
+  it("acknowledges an event batch when its required DB run is missing", async () => {
     const runId = randomUUID();
     const headers = api.sandboxWebhookHeaders({ runId });
     let requestCount = 0;
@@ -1287,12 +1287,12 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
         events: [{ type: "system", sequenceNumber: 0 }],
       },
       headers,
-      [503],
+      [200],
     );
-    expectApiError(response.body);
-    expect(response.body.error).toStrictEqual({
-      code: "EVENT_DELIVERY_UNAVAILABLE",
-      message: "Agent event delivery is temporarily unavailable",
+    expect(response.body).toStrictEqual({
+      received: 1,
+      firstSequence: 0,
+      lastSequence: 0,
     });
     await flushWaitUntilForTest();
     expect(requestCount).toBe(0);
@@ -1704,7 +1704,7 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
 });
 
 describe("WHCB-06: sandbox agent artifact webhook boundaries", () => {
-  it("rejects malformed, mismatched, and missing-run sandbox artifact reports", async () => {
+  it("handles malformed, mismatched, and missing-run sandbox artifact reports", async () => {
     const runId = randomUUID();
     const hash = "a".repeat(64);
     const headers = api.sandboxWebhookHeaders({ runId });
@@ -1738,10 +1738,13 @@ describe("WHCB-06: sandbox agent artifact webhook boundaries", () => {
         events: [{ type: "system", sequenceNumber: 0 }],
       },
       headers,
-      [503],
+      [200],
     );
-    expectApiError(missingEventsRun.body);
-    expect(missingEventsRun.body.error.code).toBe("EVENT_DELIVERY_UNAVAILABLE");
+    expect(missingEventsRun.body).toStrictEqual({
+      received: 1,
+      firstSequence: 0,
+      lastSequence: 0,
+    });
 
     const malformedComplete = await api.requestAgentCompleteUnchecked(
       { runId },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -21,6 +21,7 @@ import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockEnv } from "../../../lib/env";
 import { mockNow, withMockNowForTest } from "../../../lib/time";
 import { server } from "../../../mocks/server";
+import { deleteAgentRunRootFixture } from "../../../test-fixtures/run-deletion";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
@@ -821,6 +822,7 @@ describe("zero browser route", () => {
 
     // Thread deletion releases both local slots and requests provider cleanup
     // without waiting for Browser Use.
+    mockNow(Date.parse("2026-08-03T06:00:00.000Z"));
     await chat.deleteThread(actor, first.threadId);
     await chat.deleteThread(actor, other.threadId);
     await flushWaitUntilForTest();
@@ -835,6 +837,13 @@ describe("zero browser route", () => {
         return profileId === profileIds[1];
       }),
     ).toHaveLength(1);
+
+    // Root deletion preserves browser ownership, so the existing
+    // missing-thread reconciler remains the sole durable provider teardown
+    // path. Delete only this test's roots: the production sweep is global and
+    // is covered by the cleanup route integration tests.
+    await deleteAgentRunRootFixture(first.runId);
+    await deleteAgentRunRootFixture(other.runId);
     const reconciled = await reconcileBrowsers();
     expect(reconciled.body).toMatchObject({
       checked: 1,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-complete.test.ts
@@ -7,6 +7,7 @@ import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { testContext } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
+import { deleteAgentRunFixture } from "../../../test-fixtures/chat-events";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import {
   createBddApi,
@@ -264,6 +265,25 @@ describe("POST /api/zero/uploads/complete", () => {
     );
 
     expect(second.body).toStrictEqual(first.body);
+  });
+
+  it("acknowledges a late upload after its run root was deleted", async () => {
+    const fixture = await createRunUploadFixture();
+    const fileId = randomUUID();
+    addUploadObject(fixture, fileId, "late.txt", 11);
+    await deleteAgentRunFixture({ runId: fixture.runId });
+
+    const response = await chat.completeUploadWithBearer(
+      fixture.bearer,
+      { id: fileId },
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id: fileId,
+      filename: "late.txt",
+      size: 11,
+    });
   });
 
   it("returns 404 when the uploaded object cannot be found", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
@@ -13,6 +13,7 @@ import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
 import { mockEnv } from "../../../lib/env";
 import { mockNow, now } from "../../../lib/time";
+import { deleteAgentRunRootFixture } from "../../../test-fixtures/run-deletion";
 import type { ApiTestUser } from "./helpers/api-bdd";
 import { mockGmailConnectorOAuth } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
@@ -689,6 +690,50 @@ describe("zero workflow automation scheduler", () => {
       throw new Error("Expected the loop automation to be rescheduled");
     }
     expect(Date.parse(read.nextRunAt)).toBeGreaterThanOrEqual(before + 290_000);
+    await disableAutomation(automation.automationId);
+  });
+
+  it("recreates workflow thread and run after cleanup leaves lastRunId dangling", async () => {
+    const scenario = await setup();
+    const automation = await createDueLoopAutomation(scenario, 60);
+
+    await executeDueWorkflowAutomations(automation.automationId);
+    const firstRun = await onlyWorkflowRunMessage(automation.threadId);
+    await completeRunThroughSandbox(scenario, firstRun.runId, 0);
+    await expect
+      .poll(async () => {
+        return (await wf.readAutomation(automation.automationId)).nextRunAt;
+      })
+      .not.toBeNull();
+
+    await chatFilesApi.deleteThread(scenario.actor, automation.threadId);
+    await expect(
+      wf.readAutomation(automation.automationId),
+    ).resolves.toMatchObject({ chatThreadId: null });
+
+    // The cleanup route's global sweep is covered separately. Delete exactly
+    // this root so the regression stays focused on the deliberately dangling
+    // lastRunId reader and replacement-thread behavior.
+    await deleteAgentRunRootFixture(firstRun.runId);
+    await expect(
+      runsApi.requestReadRun(scenario.actor, firstRun.runId, [404]),
+    ).resolves.toMatchObject({ status: 404 });
+
+    const dangling = await wf.readAutomation(automation.automationId);
+    if (!dangling.nextRunAt) {
+      throw new Error("Expected the loop automation to remain scheduled");
+    }
+    mockNow(Date.parse(dangling.nextRunAt));
+    await executeDueWorkflowAutomations(automation.automationId);
+    const continued = await wf.readAutomation(automation.automationId);
+    if (!continued.chatThreadId) {
+      throw new Error("Expected the next firing to recreate its chat thread");
+    }
+    expect(continued.chatThreadId).not.toBe(automation.threadId);
+    const secondRun = await onlyWorkflowRunMessage(continued.chatThreadId);
+    expect(secondRun.runId).not.toBe(firstRun.runId);
+
+    await completeRunThroughSandbox(scenario, secondRun.runId, 1);
     await disableAutomation(automation.automationId);
   });
 

--- a/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
@@ -4,10 +4,14 @@ import {
   type TestCronCleanupSandboxesStateActionBody,
   testCronCleanupSandboxesStateContract,
 } from "@vm0/api-contracts/contracts/test-cron-cleanup-sandboxes-state";
+import { triggerSourceSchema } from "@vm0/api-contracts/contracts/logs";
 import {
   agentComposeVersions,
   agentComposes,
 } from "@vm0/db/schema/agent-compose";
+import { artifacts } from "@vm0/db/schema/artifact";
+import { browserSessions } from "@vm0/db/schema/browser-session";
+import { builtInGenerationJobs } from "@vm0/db/schema/built-in-generation-job";
 import { agentRunCustomConnectorAuthRefs } from "@vm0/db/schema/agent-run-custom-connector-auth-ref";
 import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -16,13 +20,18 @@ import { chatEvents } from "@vm0/db/schema/chat-event";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { exportJobs } from "@vm0/db/schema/export-job";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { hostedDeployments, hostedSites } from "@vm0/db/schema/hosted-site";
+import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { command } from "ccstate";
 import { and, eq, inArray, notExists } from "drizzle-orm";
 
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import { writeDb$, type Db } from "../external/db";
+import { nowDate } from "../../lib/time";
 import type { RouteEntry } from "../route-entry";
 import { insertChatEvent } from "../services/zero-chat-event.service";
 import {
@@ -88,6 +97,14 @@ function readNullableDate(
   return readDate(body, key) ?? undefined;
 }
 
+function readOptionalBoolean(
+  body: Record<string, unknown>,
+  key: string,
+): boolean | undefined {
+  const value = body[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
 function versionId(): string {
   return createHash("sha256").update(randomUUID()).digest("hex");
 }
@@ -97,6 +114,13 @@ async function seedRunForAction(
   body: Record<string, unknown>,
   signal: AbortSignal,
 ) {
+  const triggerSource = triggerSourceSchema.safeParse(
+    readOptionalString(body, "trigger_source") ?? "web",
+  );
+  if (!triggerSource.success) {
+    return actionBadRequest("trigger_source is invalid");
+  }
+
   const userId = readOptionalString(body, "user_id") ?? `user-${randomUUID()}`;
   const orgId = readOptionalString(body, "org_id") ?? `org-${randomUUID()}`;
   const composeName =
@@ -124,11 +148,14 @@ async function seedRunForAction(
     .where(eq(agentComposes.id, compose.id));
   signal.throwIfAborted();
 
-  await db.insert(orgMetadata).values({
-    orgId,
-    tier: "free",
-    credits: 10_000,
-  });
+  await db
+    .insert(orgMetadata)
+    .values({
+      orgId,
+      tier: "free",
+      credits: 10_000,
+    })
+    .onConflictDoNothing();
   signal.throwIfAborted();
 
   const [session] = await db
@@ -152,12 +179,24 @@ async function seedRunForAction(
       sandboxId:
         readOptionalString(body, "sandbox_id") ?? `sandbox-${randomUUID()}`,
       createdAt: readDate(body, "created_at") ?? undefined,
+      completedAt: readNullableDate(body, "completed_at"),
       lastHeartbeatAt: readNullableDate(body, "last_heartbeat_at"),
+      cancellationRecoveryCompleted: readOptionalBoolean(
+        body,
+        "cancellation_recovery_completed",
+      ),
     })
     .returning({ id: agentRuns.id });
   signal.throwIfAborted();
   if (!run) {
     return actionBadRequest("failed to seed run");
+  }
+
+  if (readOptionalBoolean(body, "threadless") === true) {
+    await db
+      .insert(zeroRuns)
+      .values({ id: run.id, triggerSource: triggerSource.data });
+    signal.throwIfAborted();
   }
 
   return actionOk({
@@ -166,6 +205,7 @@ async function seedRunForAction(
     compose_id: compose.id,
     version_id: agentComposeVersionId,
     org_id: orgId,
+    user_id: userId,
   });
 }
 
@@ -228,24 +268,331 @@ async function deleteRunForAction(
   signal.throwIfAborted();
   await db.delete(agentRuns).where(eq(agentRuns.id, runId));
   signal.throwIfAborted();
-  if (run) {
-    await db.delete(agentSessions).where(eq(agentSessions.id, run.sessionId));
+  const sessionId = run?.sessionId ?? readString(body, "session_id");
+  const version = run?.versionId ?? readString(body, "version_id");
+  const owningOrgId = run?.orgId ?? readString(body, "org_id");
+  const composeId = session?.composeId ?? readString(body, "compose_id");
+  if (sessionId) {
+    await db.delete(agentSessions).where(eq(agentSessions.id, sessionId));
     signal.throwIfAborted();
-    if (run.versionId) {
+    if (version) {
       await db
         .delete(agentComposeVersions)
-        .where(eq(agentComposeVersions.id, run.versionId));
+        .where(eq(agentComposeVersions.id, version));
       signal.throwIfAborted();
     }
-    if (session) {
-      await db
-        .delete(agentComposes)
-        .where(eq(agentComposes.id, session.composeId));
+    if (composeId) {
+      await db.delete(agentComposes).where(eq(agentComposes.id, composeId));
       signal.throwIfAborted();
     }
-    await db.delete(orgMetadata).where(eq(orgMetadata.orgId, run.orgId));
+  }
+  if (owningOrgId) {
+    await db.delete(orgMetadata).where(eq(orgMetadata.orgId, owningOrgId));
     signal.throwIfAborted();
   }
+  return actionOk();
+}
+
+async function seedHostedPublication(
+  db: Db,
+  run: { readonly id: string; readonly orgId: string; readonly userId: string },
+  uploadedFile: { readonly id: string; readonly createdAt: Date },
+  signal: AbortSignal,
+): Promise<{
+  readonly hostedSiteId: string;
+  readonly hostedDeploymentId: string;
+  readonly hostedArtifactId: string;
+}> {
+  const hostedSiteId = randomUUID();
+  const hostedDeploymentId = randomUUID();
+  const publicSlug = `cleanup-${randomUUID()}`;
+  await db.insert(hostedSites).values({
+    id: hostedSiteId,
+    orgId: run.orgId,
+    userId: run.userId,
+    slug: publicSlug,
+    publicSlug,
+    createdFromRunId: run.id,
+  });
+  signal.throwIfAborted();
+  await db.insert(hostedDeployments).values({
+    id: hostedDeploymentId,
+    siteId: hostedSiteId,
+    orgId: run.orgId,
+    userId: run.userId,
+    runId: run.id,
+    status: "ready",
+    deploymentVersion: 1,
+    artifactUrl: `https://storage.example/${hostedDeploymentId}.zip`,
+    r2Prefix: `hosted/${hostedDeploymentId}`,
+    manifest: {
+      version: 1,
+      deploymentId: hostedDeploymentId,
+      siteId: hostedSiteId,
+      publicSlug,
+      deploymentVersion: 1,
+      createdAt: nowDate().toISOString(),
+      artifactKind: "hosted-site",
+      spaFallback: false,
+      files: {},
+    },
+    manifestHash: "a".repeat(64),
+    contentHash: "b".repeat(64),
+    fileCount: 0,
+    sizeBytes: 0,
+    url: `https://${publicSlug}.sites.example`,
+    readyAt: nowDate(),
+  });
+  signal.throwIfAborted();
+  const hostedArtifactId = randomUUID();
+  await db.insert(artifacts).values({
+    id: hostedArtifactId,
+    orgId: run.orgId,
+    authorUserId: run.userId,
+    kind: "hosted-site",
+    entityId: hostedSiteId,
+    logicalKey: `site:${hostedSiteId}`,
+    projectionFileId: uploadedFile.id,
+    projectionCreatedAt: uploadedFile.createdAt,
+    title: publicSlug,
+  });
+  signal.throwIfAborted();
+
+  return { hostedSiteId, hostedDeploymentId, hostedArtifactId };
+}
+
+async function seedRunOwnershipForAction(
+  db: Db,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+) {
+  const runId = readString(body, "run_id");
+  if (!runId) {
+    return actionBadRequest("run_id is required");
+  }
+  const [run] = await db
+    .select({
+      id: agentRuns.id,
+      userId: agentRuns.userId,
+      orgId: agentRuns.orgId,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+  signal.throwIfAborted();
+  if (!run) {
+    return actionBadRequest("run not found");
+  }
+
+  const usageEventId = randomUUID();
+  await db.insert(usageEvent).values({
+    id: usageEventId,
+    runId,
+    idempotencyKey: randomUUID(),
+    orgId: run.orgId,
+    userId: run.userId,
+    kind: "model",
+    provider: "cleanup-test",
+    category: "tokens.input",
+    quantity: 1,
+    grossCredits: 9,
+    status: "pending",
+  });
+  signal.throwIfAborted();
+
+  const [uploadedFile] = await db
+    .insert(runUploadedFiles)
+    .values({
+      runId,
+      source: "web",
+      externalId: randomUUID(),
+      userId: run.userId,
+      orgId: run.orgId,
+      filename: "cleanup-owned.txt",
+      contentType: "text/plain",
+      sizeBytes: 7,
+      url: `https://storage.example/${randomUUID()}`,
+      metadata: {},
+    })
+    .returning({
+      id: runUploadedFiles.id,
+      createdAt: runUploadedFiles.createdAt,
+    });
+  signal.throwIfAborted();
+  if (!uploadedFile) {
+    return actionBadRequest("failed to seed uploaded file");
+  }
+  const fileArtifactId = randomUUID();
+  await db.insert(artifacts).values({
+    id: fileArtifactId,
+    orgId: run.orgId,
+    authorUserId: run.userId,
+    kind: "file",
+    entityId: uploadedFile.id,
+    logicalKey: `file:${uploadedFile.id}`,
+    projectionFileId: uploadedFile.id,
+    projectionCreatedAt: uploadedFile.createdAt,
+    title: "cleanup-owned.txt",
+  });
+  signal.throwIfAborted();
+
+  const browserSessionId = randomUUID();
+  await db.insert(browserSessions).values({
+    id: browserSessionId,
+    chatThreadId: randomUUID(),
+    runId,
+    orgId: run.orgId,
+    userId: run.userId,
+    name: "cleanup-browser",
+    status: "suspended",
+    timeoutMinutes: 30,
+  });
+  signal.throwIfAborted();
+
+  const generationJobId = randomUUID();
+  await db.insert(builtInGenerationJobs).values({
+    id: generationJobId,
+    type: "image",
+    status: "completed",
+    orgId: run.orgId,
+    userId: run.userId,
+    runId,
+    request: {},
+  });
+  signal.throwIfAborted();
+
+  const { hostedSiteId, hostedDeploymentId, hostedArtifactId } =
+    await seedHostedPublication(db, run, uploadedFile, signal);
+
+  return actionOk({
+    usage_event_id: usageEventId,
+    uploaded_file_id: uploadedFile.id,
+    file_artifact_id: fileArtifactId,
+    browser_session_id: browserSessionId,
+    generation_job_id: generationJobId,
+    hosted_site_id: hostedSiteId,
+    hosted_deployment_id: hostedDeploymentId,
+    hosted_artifact_id: hostedArtifactId,
+  });
+}
+
+async function getRunOwnershipForAction(
+  db: Db,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+) {
+  const usageEventId = readString(body, "usage_event_id");
+  const uploadedFileId = readString(body, "uploaded_file_id");
+  const fileArtifactId = readString(body, "file_artifact_id");
+  const browserSessionId = readString(body, "browser_session_id");
+  const generationJobId = readString(body, "generation_job_id");
+  const hostedSiteId = readString(body, "hosted_site_id");
+  const hostedDeploymentId = readString(body, "hosted_deployment_id");
+  const hostedArtifactId = readString(body, "hosted_artifact_id");
+  if (
+    !usageEventId ||
+    !uploadedFileId ||
+    !fileArtifactId ||
+    !browserSessionId ||
+    !generationJobId ||
+    !hostedSiteId ||
+    !hostedDeploymentId ||
+    !hostedArtifactId
+  ) {
+    return actionBadRequest("ownership ids are required");
+  }
+
+  const [usage] = await db
+    .select({
+      runId: usageEvent.runId,
+      status: usageEvent.status,
+      creditsCharged: usageEvent.creditsCharged,
+    })
+    .from(usageEvent)
+    .where(eq(usageEvent.id, usageEventId));
+  const [uploadedFile] = await db
+    .select({ id: runUploadedFiles.id })
+    .from(runUploadedFiles)
+    .where(eq(runUploadedFiles.id, uploadedFileId));
+  const [fileArtifact] = await db
+    .select({ id: artifacts.id })
+    .from(artifacts)
+    .where(eq(artifacts.id, fileArtifactId));
+  const [browserSession] = await db
+    .select({ id: browserSessions.id, runId: browserSessions.runId })
+    .from(browserSessions)
+    .where(eq(browserSessions.id, browserSessionId));
+  const [generationJob] = await db
+    .select({
+      id: builtInGenerationJobs.id,
+      runId: builtInGenerationJobs.runId,
+    })
+    .from(builtInGenerationJobs)
+    .where(eq(builtInGenerationJobs.id, generationJobId));
+  const [hostedSite] = await db
+    .select({
+      id: hostedSites.id,
+      createdFromRunId: hostedSites.createdFromRunId,
+    })
+    .from(hostedSites)
+    .where(eq(hostedSites.id, hostedSiteId));
+  const [hostedDeployment] = await db
+    .select({ id: hostedDeployments.id, runId: hostedDeployments.runId })
+    .from(hostedDeployments)
+    .where(eq(hostedDeployments.id, hostedDeploymentId));
+  const [hostedArtifact] = await db
+    .select({ id: artifacts.id })
+    .from(artifacts)
+    .where(eq(artifacts.id, hostedArtifactId));
+  signal.throwIfAborted();
+
+  return actionOk({
+    usage_event: usage ?? null,
+    uploaded_file: uploadedFile ?? null,
+    file_artifact: fileArtifact ?? null,
+    browser_session: browserSession ?? null,
+    generation_job: generationJob ?? null,
+    hosted_site: hostedSite ?? null,
+    hosted_deployment: hostedDeployment ?? null,
+    hosted_artifact: hostedArtifact ?? null,
+  });
+}
+
+async function deleteRunOwnershipForAction(
+  db: Db,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+) {
+  const ids = [
+    readString(body, "file_artifact_id"),
+    readString(body, "hosted_artifact_id"),
+  ].filter((id): id is string => {
+    return id !== null;
+  });
+  if (ids.length > 0) {
+    await db.delete(artifacts).where(inArray(artifacts.id, ids));
+  }
+  const usageEventId = readString(body, "usage_event_id");
+  if (usageEventId) {
+    await db.delete(usageEvent).where(eq(usageEvent.id, usageEventId));
+  }
+  const browserSessionId = readString(body, "browser_session_id");
+  if (browserSessionId) {
+    await db
+      .delete(browserSessions)
+      .where(eq(browserSessions.id, browserSessionId));
+  }
+  const generationJobId = readString(body, "generation_job_id");
+  if (generationJobId) {
+    await db
+      .delete(builtInGenerationJobs)
+      .where(eq(builtInGenerationJobs.id, generationJobId));
+  }
+  const hostedSiteId = readString(body, "hosted_site_id");
+  if (hostedSiteId) {
+    await db.delete(hostedSites).where(eq(hostedSites.id, hostedSiteId));
+  }
+  signal.throwIfAborted();
   return actionOk();
 }
 
@@ -393,6 +740,62 @@ async function seedQueueMarkerForAction(
     return actionBadRequest("failed to seed queue marker");
   }
   return actionOk({ marker_id: marker.id, thread_id: thread.id });
+}
+
+async function attachRunThreadForAction(
+  db: Db,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+) {
+  const runId = readString(body, "run_id");
+  if (!runId) {
+    return actionBadRequest("run_id is required");
+  }
+  const [run] = await db
+    .select({ userId: agentRuns.userId, sessionId: agentRuns.sessionId })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId));
+  if (!run) {
+    return actionBadRequest("run not found");
+  }
+  const [session] = await db
+    .select({ composeId: agentSessions.agentComposeId })
+    .from(agentSessions)
+    .where(eq(agentSessions.id, run.sessionId));
+  if (!session) {
+    return actionBadRequest("session not found");
+  }
+  const [thread] = await db
+    .insert(chatThreads)
+    .values({
+      userId: run.userId,
+      agentComposeId: session.composeId,
+      title: "concurrent cleanup recheck",
+    })
+    .returning({ id: chatThreads.id });
+  if (!thread) {
+    return actionBadRequest("failed to seed chat thread");
+  }
+  await db
+    .update(zeroRuns)
+    .set({ chatThreadId: thread.id })
+    .where(eq(zeroRuns.id, runId));
+  signal.throwIfAborted();
+  return actionOk({ thread_id: thread.id });
+}
+
+async function deleteRunThreadForAction(
+  db: Db,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+) {
+  const threadId = readString(body, "thread_id");
+  if (!threadId) {
+    return actionBadRequest("thread_id is required");
+  }
+  await db.delete(chatThreads).where(eq(chatThreads.id, threadId));
+  signal.throwIfAborted();
+  return actionOk();
 }
 
 async function seedExportJobForAction(
@@ -556,7 +959,11 @@ async function getExportJobForAction(
 
 const cronCleanupSandboxesActionHandlers = {
   "seed-run": seedRunForAction,
+  "seed-run-ownership": seedRunOwnershipForAction,
+  "attach-run-thread": attachRunThreadForAction,
   "delete-run": deleteRunForAction,
+  "delete-run-ownership": deleteRunOwnershipForAction,
+  "delete-run-thread": deleteRunThreadForAction,
   "seed-runner-job": seedRunnerJobForAction,
   "seed-custom-connector-auth-ref": seedCustomConnectorAuthRefForAction,
   "seed-queue-entry": seedQueueEntryForAction,
@@ -564,6 +971,7 @@ const cronCleanupSandboxesActionHandlers = {
   "seed-export-job": seedExportJobForAction,
   "delete-export-job": deleteExportJobForAction,
   "get-run": getRunForAction,
+  "get-run-ownership": getRunOwnershipForAction,
   "get-runner-job": getRunnerJobForAction,
   "get-custom-connector-auth-ref": getCustomConnectorAuthRefForAction,
   "get-queue-entry": getQueueEntryForAction,

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-checkpoints.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-checkpoints.ts
@@ -5,6 +5,7 @@ import {
 } from "@vm0/api-contracts/contracts/webhooks";
 
 import { notFound } from "../../lib/error";
+import { isForeignKeyViolation } from "../../lib/pg-errors";
 import { authorization$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
@@ -17,21 +18,6 @@ import {
   getSandboxAuthForRun,
   unauthorizedRunMismatch,
 } from "./agent-webhook-auth";
-
-const PG_FOREIGN_KEY_VIOLATION = "23503";
-
-function isForeignKeyViolation(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-
-  const { cause } = error;
-  if (typeof cause !== "object" || cause === null || !("code" in cause)) {
-    return false;
-  }
-
-  return cause.code === PG_FOREIGN_KEY_VIOLATION;
-}
 
 const createBody$ = bodyResultOf(webhookCheckpointsContract.create);
 const createCheckpoint$ = command(async ({ get, set }, signal: AbortSignal) => {

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -17,6 +17,7 @@ import {
 
 import { notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
+import { isForeignKeyViolation } from "../../lib/pg-errors";
 import { nowDate } from "../../lib/time";
 import { authorization$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
@@ -37,7 +38,6 @@ import { usageUnderbillingFields } from "../usage-underbilling";
 const SANDBOX_TELEMETRY_SYSTEM_DATASET = "sandbox-telemetry-system";
 const SANDBOX_TELEMETRY_METRICS_DATASET = "sandbox-telemetry-metrics";
 const SANDBOX_TELEMETRY_NETWORK_DATASET = "sandbox-telemetry-network";
-const PG_FOREIGN_KEY_VIOLATION = "23503";
 const MODEL_USAGE_KIND = "model";
 const TELEMETRY_INGEST_TIMEOUT_MS = 10_000;
 
@@ -115,19 +115,6 @@ function sandboxOperationDimensions(
       ? { session_history_download_source: op.session_history_download_source }
       : {}),
   };
-}
-
-function isForeignKeyViolation(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-
-  const { cause } = error;
-  if (typeof cause !== "object" || cause === null || !("code" in cause)) {
-    return false;
-  }
-
-  return cause.code === PG_FOREIGN_KEY_VIOLATION;
 }
 
 const heartbeatBody$ = bodyResultOf(webhookHeartbeatContract.send);

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack-upload-init.ts
@@ -11,7 +11,7 @@ import {
 import { MAX_SLACK_FILE_SIZE_BYTES } from "../external/slack-file-fetcher";
 import { prepareCanonicalPublishedAsset$ } from "../services/canonical-asset.service";
 import { zeroSlackOrgInstallation } from "../services/zero-slack-data.service";
-import { badRequestMessage } from "../../lib/error";
+import { badRequestMessage, notFound } from "../../lib/error";
 import { isAllowedUploadType } from "../../lib/uploads-constants";
 import type { RouteEntry } from "../route-entry";
 
@@ -81,6 +81,9 @@ const initInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       },
       signal,
     );
+    if (!prepared) {
+      return notFound("Agent run not found");
+    }
     return {
       status: 200 as const,
       body: {

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -2,7 +2,7 @@ import { command } from "ccstate";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
-import { and, eq, isNull, notInArray, or } from "drizzle-orm";
+import { and, eq, inArray, isNull, notInArray, or } from "drizzle-orm";
 
 import { env, optionalEnv } from "../../lib/env";
 import { computeHmacSignature } from "../../lib/event-consumer/hmac";
@@ -39,6 +39,17 @@ import {
 import { continueGoalIfIdle$ } from "./zero-goal-continuation.service";
 
 const L = logger("AgentRunCallback");
+
+const INLINE_ONLY_INTEGRATION_DELIVERY_CALLBACK_KINDS = [
+  "slack:chat",
+  "feishu:chat",
+  "teams:chat",
+  "telegram:chat",
+  "github:chat",
+  "slack:org",
+] as const;
+const DELETED_THREAD_INLINE_CALLBACK_ERROR =
+  "Chat thread was deleted before inline callback delivery";
 
 interface CallbackRecord {
   readonly id: string;
@@ -309,12 +320,7 @@ async function dispatchRunCallbacks(
         or(
           isNull(agentRunCallbacks.internalKind),
           notInArray(agentRunCallbacks.internalKind, [
-            "slack:chat",
-            "feishu:chat",
-            "teams:chat",
-            "telegram:chat",
-            "github:chat",
-            "slack:org",
+            ...INLINE_ONLY_INTEGRATION_DELIVERY_CALLBACK_KINDS,
           ]),
         ),
       ),
@@ -342,6 +348,27 @@ export async function dispatchFailedRunCallbacks(
   error: string,
 ): Promise<void> {
   await dispatchRunCallbacks(db, runId, "failed", undefined, error);
+}
+
+export async function failPendingInlineOnlyDeliveryCallbacksForDeletedThread(
+  db: Db,
+  runId: string,
+): Promise<void> {
+  await db
+    .update(agentRunCallbacks)
+    .set({
+      status: "failed",
+      lastError: DELETED_THREAD_INLINE_CALLBACK_ERROR,
+    })
+    .where(
+      and(
+        eq(agentRunCallbacks.runId, runId),
+        eq(agentRunCallbacks.status, "pending"),
+        inArray(agentRunCallbacks.internalKind, [
+          ...INLINE_ONLY_INTEGRATION_DELIVERY_CALLBACK_KINDS,
+        ]),
+      ),
+    );
 }
 
 export const dispatchRunCallbacks$ = command(
@@ -396,12 +423,7 @@ export const dispatchRunCallbacks$ = command(
           or(
             isNull(agentRunCallbacks.internalKind),
             notInArray(agentRunCallbacks.internalKind, [
-              "slack:chat",
-              "feishu:chat",
-              "teams:chat",
-              "telegram:chat",
-              "github:chat",
-              "slack:org",
+              ...INLINE_ONLY_INTEGRATION_DELIVERY_CALLBACK_KINDS,
             ]),
           ),
         ),

--- a/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../lib/event-consumer/verify";
 import { eventDeliveryUnavailable } from "../../lib/error";
 import { logger } from "../../lib/log";
+import { isForeignKeyViolation } from "../../lib/pg-errors";
 import { now } from "../../lib/time";
 import type { SandboxAuth } from "../../types/auth";
 import { publishRunChangedForUserSafely } from "../external/realtime";
@@ -217,6 +218,21 @@ export const receiveAgentEvents$ = command(
     );
     signal.throwIfAborted();
     if (!projectionResult.ok) {
+      if (isForeignKeyViolation(projectionResult.error)) {
+        L.debug("Ignored events for deleted run", {
+          runId: payload.runId,
+          ...range,
+        });
+        return {
+          response: {
+            status: 200 as const,
+            body: {
+              received: payload.events.length,
+              ...range,
+            },
+          },
+        };
+      }
       L.error("Required database run output projection failed", {
         runId: payload.runId,
         ...range,

--- a/turbo/apps/api/src/signals/services/canonical-asset.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-asset.service.ts
@@ -16,6 +16,7 @@ import type { SlackFile } from "../../lib/slack-webhook-context";
 import { env } from "../../lib/env";
 import { buildFileUrlFromKey, isArtifactKeyV2 } from "../../lib/file-url";
 import { inferMimetype } from "../../lib/mimetype";
+import { isForeignKeyViolation } from "../../lib/pg-errors";
 import { isAllowedUploadType } from "../../lib/uploads-constants";
 import { type Db, writeDb$ } from "../external/db";
 import {
@@ -30,7 +31,7 @@ import {
   s3MetadataHeaders,
   s3ObjectHead,
 } from "../external/s3";
-import { settleIncludingAbort } from "../utils";
+import { settle, settleIncludingAbort } from "../utils";
 import {
   allocateArtifactObject$,
   artifactObjectMetadata,
@@ -840,7 +841,7 @@ async function ensureCanonicalSlackDelivery(
   db: Db,
   assetId: string,
   args: PrepareCanonicalPublishedAssetArgs,
-): Promise<void> {
+): Promise<boolean> {
   await db
     .insert(canonicalAssetDeliveries)
     .values({
@@ -869,7 +870,7 @@ async function ensureCanonicalSlackDelivery(
     )
     .limit(1);
   if (!delivery) {
-    throw new Error("Canonical Slack delivery is missing");
+    return false;
   }
   if (
     delivery.destination.channelId !== args.destination.channelId ||
@@ -881,6 +882,7 @@ async function ensureCanonicalSlackDelivery(
       "Upload operation identity was reused for another Slack destination",
     );
   }
+  return true;
 }
 
 export const prepareCanonicalPublishedAsset$ = command(
@@ -888,7 +890,7 @@ export const prepareCanonicalPublishedAsset$ = command(
     { get, set },
     args: PrepareCanonicalPublishedAssetArgs,
     signal: AbortSignal,
-  ): Promise<PreparedCanonicalPublishedAsset> => {
+  ): Promise<PreparedCanonicalPublishedAsset | null> => {
     const db = set(writeDb$);
     const scope = `run:${args.runId}`;
     const source = await sourceForRun(db, args.runId, "slack", signal);
@@ -899,7 +901,7 @@ export const prepareCanonicalPublishedAsset$ = command(
       .limit(1);
     signal.throwIfAborted();
     if (!run) {
-      throw new Error("Canonical publication run does not exist");
+      return null;
     }
 
     const artifact = await set(
@@ -912,14 +914,35 @@ export const prepareCanonicalPublishedAsset$ = command(
       },
       signal,
     );
-    const asset = await ensureCanonicalPublishedAsset(db, args, artifact, {
-      scope,
-      source,
-      chatThreadId: run.chatThreadId,
-    });
+    const assetResult = await settle(
+      ensureCanonicalPublishedAsset(db, args, artifact, {
+        scope,
+        source,
+        chatThreadId: run.chatThreadId,
+      }),
+      signal,
+    );
+    if (!assetResult.ok) {
+      if (isForeignKeyViolation(assetResult.error)) {
+        return null;
+      }
+      throw assetResult.error;
+    }
+    const asset = assetResult.value;
     signal.throwIfAborted();
-    await ensureCanonicalSlackDelivery(db, asset.id, args);
-    signal.throwIfAborted();
+    const deliveryResult = await settle(
+      ensureCanonicalSlackDelivery(db, asset.id, args),
+      signal,
+    );
+    if (!deliveryResult.ok) {
+      if (isForeignKeyViolation(deliveryResult.error)) {
+        return null;
+      }
+      throw deliveryResult.error;
+    }
+    if (!deliveryResult.value) {
+      return null;
+    }
     const storageKey = asset.storageKey;
     if (!storageKey) {
       throw new Error("Canonical publication storage key is missing");

--- a/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
@@ -32,6 +32,10 @@ import type { QueueMarkerRevokeNotification } from "./zero-chat-queue-marker.ser
 import { drainStaleCanonicalSlackIngress$ } from "./canonical-slack-ingress-processor.service";
 import { drainStaleCanonicalFeishuIngress$ } from "./canonical-feishu-ingress-processor.service";
 import { retryPendingFeishuConnectWelcomes$ } from "./zero-feishu-welcome.service";
+import {
+  cleanupThreadlessRuns$,
+  type ThreadlessRunCleanupResult,
+} from "./threadless-run-cleanup.service";
 
 const L = logger("CronCleanupSandboxes");
 
@@ -55,6 +59,7 @@ interface CleanupSandboxesResult {
   readonly results: readonly CleanupResult[];
   readonly exportJobsCleaned: number;
   readonly exportJobsStuck: number;
+  readonly threadlessRuns: ThreadlessRunCleanupResult;
 }
 
 interface StaleRun {
@@ -533,6 +538,12 @@ export const cleanupSandboxes$ = command(
       return isExpiredRun(run, cutoffs);
     });
 
+    // Run before generic queue maintenance so an active threadless run always
+    // takes the hard-cancel path and can never become terminal and be deleted
+    // within the same maintenance pass.
+    const threadlessRuns = await set(cleanupThreadlessRuns$, signal);
+    signal.throwIfAborted();
+
     const expiredQueueResult = await set(cleanupExpiredQueueEntries$, signal);
     signal.throwIfAborted();
     const queuedOrphanResult = await set(
@@ -619,6 +630,7 @@ export const cleanupSandboxes$ = command(
       results,
       exportJobsCleaned,
       exportJobsStuck,
+      threadlessRuns,
     };
   },
 );

--- a/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
+++ b/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
@@ -8,7 +8,10 @@ import {
 } from "@vm0/db/schema/run-uploaded-file";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 
+import { logger } from "../../lib/log";
+import { isForeignKeyViolation } from "../../lib/pg-errors";
 import { type Db, writeDb$ } from "../external/db";
+import { settle } from "../utils";
 import { syncArtifactCatalogForFile$ } from "./artifact-catalog.service";
 import { publishArtifactsChangedForRun } from "./artifact-realtime.service";
 import {
@@ -80,6 +83,24 @@ interface RecordedUploadedFile {
   readonly previewImageUrl: string | null;
 }
 
+const L = logger("RunUploadedFiles");
+
+async function recordRunUploadedFileWrite(
+  write: Promise<readonly RecordedUploadedFile[]>,
+  runId: string,
+  signal: AbortSignal,
+): Promise<RecordedUploadedFile | undefined> {
+  const result = await settle(write, signal);
+  if (result.ok) {
+    return result.value[0];
+  }
+  if (!isForeignKeyViolation(result.error)) {
+    throw result.error;
+  }
+  L.debug("Ignored uploaded-file association for deleted run", { runId });
+  return undefined;
+}
+
 function videoArtifactPreviewArgs(
   args: {
     readonly runId: string;
@@ -134,7 +155,7 @@ export const recordHostedSiteArtifact$ = command(
         ? `${args.publicSlug}.html`
         : `${args.site}-v${args.deploymentVersion}.html`;
 
-    const [row] = await writeDb
+    const write = writeDb
       .insert(runUploadedFiles)
       .values({
         runId: args.runId,
@@ -207,11 +228,16 @@ export const recordHostedSiteArtifact$ = command(
         id: runUploadedFiles.id,
         previewImageUrl: runUploadedFiles.previewImageUrl,
       });
+    const row = await recordRunUploadedFileWrite(write, args.runId, signal);
     signal.throwIfAborted();
 
-    await set(syncArtifactCatalogForFile$, row?.id, signal);
+    if (!row) {
+      return null;
+    }
+
+    await set(syncArtifactCatalogForFile$, row.id, signal);
     await publishArtifactsChangedForRun(writeDb, args.runId, signal);
-    return row ?? null;
+    return row;
   },
 );
 
@@ -241,7 +267,7 @@ export const recordWebUploadedFile$ = command(
       s3Key: args.s3Key,
     };
 
-    const [row] = await writeDb
+    const write = writeDb
       .insert(runUploadedFiles)
       .values({
         runId: args.runId,
@@ -276,9 +302,14 @@ export const recordWebUploadedFile$ = command(
         id: runUploadedFiles.id,
         previewImageUrl: runUploadedFiles.previewImageUrl,
       });
+    const row = await recordRunUploadedFileWrite(write, args.runId, signal);
     signal.throwIfAborted();
 
-    await set(syncArtifactCatalogForFile$, row?.id, signal);
+    if (!row) {
+      return;
+    }
+
+    await set(syncArtifactCatalogForFile$, row.id, signal);
     await publishArtifactsChangedForRun(writeDb, args.runId, signal);
     set(
       scheduleVideoArtifactPreviewRender$,
@@ -330,7 +361,7 @@ export const recordTelegramUploadedFile$ = command(
     const writeDb = set(writeDb$);
     const source = await sourceForRun(writeDb, args.runId, "telegram", signal);
 
-    const [row] = await writeDb
+    const write = writeDb
       .insert(runUploadedFiles)
       .values({
         runId: args.runId,
@@ -365,9 +396,14 @@ export const recordTelegramUploadedFile$ = command(
         id: runUploadedFiles.id,
         previewImageUrl: runUploadedFiles.previewImageUrl,
       });
+    const row = await recordRunUploadedFileWrite(write, args.runId, signal);
     signal.throwIfAborted();
 
-    await set(syncArtifactCatalogForFile$, row?.id, signal);
+    if (!row) {
+      return;
+    }
+
+    await set(syncArtifactCatalogForFile$, row.id, signal);
     await publishArtifactsChangedForRun(writeDb, args.runId, signal);
     set(
       scheduleVideoArtifactPreviewRender$,
@@ -457,7 +493,7 @@ export const recordGithubUploadedFile$ = command(
     const writeDb = set(writeDb$);
     const source = await sourceForRun(writeDb, args.runId, "github", signal);
 
-    const [row] = await writeDb
+    const write = writeDb
       .insert(runUploadedFiles)
       .values({
         runId: args.runId,
@@ -492,9 +528,14 @@ export const recordGithubUploadedFile$ = command(
         id: runUploadedFiles.id,
         previewImageUrl: runUploadedFiles.previewImageUrl,
       });
+    const row = await recordRunUploadedFileWrite(write, args.runId, signal);
     signal.throwIfAborted();
 
-    await set(syncArtifactCatalogForFile$, row?.id, signal);
+    if (!row) {
+      return;
+    }
+
+    await set(syncArtifactCatalogForFile$, row.id, signal);
     await publishArtifactsChangedForRun(writeDb, args.runId, signal);
     set(
       scheduleVideoArtifactPreviewRender$,
@@ -524,7 +565,7 @@ export const recordFeishuUploadedFile$ = command(
     const writeDb = set(writeDb$);
     const source = await sourceForRun(writeDb, args.runId, "feishu", signal);
 
-    const [row] = await writeDb
+    const write = writeDb
       .insert(runUploadedFiles)
       .values({
         runId: args.runId,
@@ -559,9 +600,14 @@ export const recordFeishuUploadedFile$ = command(
         id: runUploadedFiles.id,
         previewImageUrl: runUploadedFiles.previewImageUrl,
       });
+    const row = await recordRunUploadedFileWrite(write, args.runId, signal);
     signal.throwIfAborted();
 
-    await set(syncArtifactCatalogForFile$, row?.id, signal);
+    if (!row) {
+      return;
+    }
+
+    await set(syncArtifactCatalogForFile$, row.id, signal);
     await publishArtifactsChangedForRun(writeDb, args.runId, signal);
     set(
       scheduleVideoArtifactPreviewRender$,
@@ -591,7 +637,7 @@ export const recordTeamsUploadedFile$ = command(
     const writeDb = set(writeDb$);
     const source = await sourceForRun(writeDb, args.runId, "teams", signal);
 
-    const [row] = await writeDb
+    const write = writeDb
       .insert(runUploadedFiles)
       .values({
         runId: args.runId,
@@ -626,9 +672,14 @@ export const recordTeamsUploadedFile$ = command(
         id: runUploadedFiles.id,
         previewImageUrl: runUploadedFiles.previewImageUrl,
       });
+    const row = await recordRunUploadedFileWrite(write, args.runId, signal);
     signal.throwIfAborted();
 
-    await set(syncArtifactCatalogForFile$, row?.id, signal);
+    if (!row) {
+      return;
+    }
+
+    await set(syncArtifactCatalogForFile$, row.id, signal);
     await publishArtifactsChangedForRun(writeDb, args.runId, signal);
     set(
       scheduleVideoArtifactPreviewRender$,
@@ -669,7 +720,7 @@ export const recordAgentPhoneUploadedFile$ = command(
       signal,
     );
 
-    const [row] = await writeDb
+    const write = writeDb
       .insert(runUploadedFiles)
       .values({
         runId: args.runId,
@@ -704,9 +755,14 @@ export const recordAgentPhoneUploadedFile$ = command(
         id: runUploadedFiles.id,
         previewImageUrl: runUploadedFiles.previewImageUrl,
       });
+    const row = await recordRunUploadedFileWrite(write, args.runId, signal);
     signal.throwIfAborted();
 
-    await set(syncArtifactCatalogForFile$, row?.id, signal);
+    if (!row) {
+      return;
+    }
+
+    await set(syncArtifactCatalogForFile$, row.id, signal);
     await publishArtifactsChangedForRun(writeDb, args.runId, signal);
     set(
       scheduleVideoArtifactPreviewRender$,
@@ -747,7 +803,7 @@ export const recordSlackUploadedFile$ = command(
     const writeDb = set(writeDb$);
     const source = await sourceForRun(writeDb, args.runId, "slack", signal);
 
-    const [row] = await writeDb
+    const write = writeDb
       .insert(runUploadedFiles)
       .values({
         runId: args.runId,
@@ -782,9 +838,14 @@ export const recordSlackUploadedFile$ = command(
         id: runUploadedFiles.id,
         previewImageUrl: runUploadedFiles.previewImageUrl,
       });
+    const row = await recordRunUploadedFileWrite(write, args.runId, signal);
     signal.throwIfAborted();
 
-    await set(syncArtifactCatalogForFile$, row?.id, signal);
+    if (!row) {
+      return;
+    }
+
+    await set(syncArtifactCatalogForFile$, row.id, signal);
     await publishArtifactsChangedForRun(writeDb, args.runId, signal);
     set(
       scheduleVideoArtifactPreviewRender$,

--- a/turbo/apps/api/src/signals/services/threadless-run-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/threadless-run-cleanup.service.ts
@@ -1,0 +1,378 @@
+import { CANCELLATION_RECOVERY_STALE_AFTER_MS } from "@vm0/api-contracts/contracts/runners";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { chatThreadEvents } from "@vm0/db/schema/chat-thread-event";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { command } from "ccstate";
+import {
+  and,
+  asc,
+  eq,
+  exists,
+  gte,
+  inArray,
+  isNull,
+  ne,
+  or,
+  sql,
+} from "drizzle-orm";
+
+import { logger } from "../../lib/log";
+import { nowDate } from "../external/time";
+import { writeDb$, type Db } from "../external/db";
+import { settle } from "../utils";
+import { dispatchCompleteSideEffects$ } from "./agent-webhook-complete.service";
+import {
+  cancelRun$,
+  dispatchCancelSideEffects$,
+} from "./zero-run-cancel.service";
+import { drainOrgQueue$ } from "./zero-run-queue.service";
+
+const L = logger("ThreadlessRunCleanup");
+
+const ACTIVE_RUN_STATUSES = ["queued", "pending", "running"] as const;
+const TERMINAL_RUN_STATUSES = [
+  "completed",
+  "failed",
+  "cancelled",
+  "timeout",
+] as const;
+
+const THREADLESS_RUN_SWEEP_LIMIT = 20;
+
+// The audited legacy cohort predates this issue. It must remain untouched until
+// a separately gated data migration. Newer runs are unambiguously forward
+// lifecycle rows. Older runs enter the forward cohort only when their durable
+// chat callback can be matched to a post-cutoff thread-deletion tombstone.
+const THREADLESS_RUN_FORWARD_CUTOFF_ISO = "2026-08-03T05:40:26.000Z";
+
+interface ThreadlessRunCandidate {
+  readonly runId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly status: string;
+  readonly error: string | null;
+  readonly completedAt: Date | null;
+  readonly cancellationRecoveryCompleted: boolean | null;
+}
+
+interface ThreadlessRunCleanupError {
+  readonly runId: string;
+  readonly error: string;
+}
+
+export interface ThreadlessRunCleanupResult {
+  readonly discovered: number;
+  readonly cancelled: number;
+  readonly waiting: number;
+  readonly deleted: number;
+  readonly failed: number;
+  readonly errors: readonly ThreadlessRunCleanupError[];
+}
+
+function isActiveStatus(status: string): boolean {
+  return (ACTIVE_RUN_STATUSES as readonly string[]).includes(status);
+}
+
+function isTerminalStatus(status: string): boolean {
+  return (TERMINAL_RUN_STATUSES as readonly string[]).includes(status);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function terminalError(candidate: ThreadlessRunCandidate): string | undefined {
+  if (candidate.status === "completed") {
+    return undefined;
+  }
+  if (candidate.error) {
+    return candidate.error;
+  }
+  if (candidate.status === "cancelled") {
+    return "Run cancelled";
+  }
+  if (candidate.status === "timeout") {
+    return "Run timed out";
+  }
+  return "Run failed";
+}
+
+async function loadThreadlessRunCandidates(
+  db: Db,
+): Promise<readonly ThreadlessRunCandidate[]> {
+  const forwardCutoff = new Date(THREADLESS_RUN_FORWARD_CUTOFF_ISO);
+  return await db
+    .select({
+      runId: agentRuns.id,
+      orgId: agentRuns.orgId,
+      userId: agentRuns.userId,
+      status: agentRuns.status,
+      error: agentRuns.error,
+      completedAt: agentRuns.completedAt,
+      cancellationRecoveryCompleted: agentRuns.cancellationRecoveryCompleted,
+    })
+    .from(zeroRuns)
+    .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+    .where(
+      and(
+        isNull(zeroRuns.chatThreadId),
+        ne(zeroRuns.triggerSource, "test"),
+        inArray(agentRuns.status, [
+          ...ACTIVE_RUN_STATUSES,
+          ...TERMINAL_RUN_STATUSES,
+        ]),
+        or(
+          gte(agentRuns.createdAt, forwardCutoff),
+          exists(
+            db
+              .select({ id: chatThreadEvents.id })
+              .from(agentRunCallbacks)
+              .innerJoin(
+                chatThreadEvents,
+                and(
+                  eq(chatThreadEvents.userId, agentRuns.userId),
+                  eq(chatThreadEvents.orgId, agentRuns.orgId),
+                  eq(chatThreadEvents.kind, "deleted"),
+                  gte(chatThreadEvents.createdAt, forwardCutoff),
+                  eq(
+                    sql`${agentRunCallbacks.payload}->>'threadId'`,
+                    sql`${chatThreadEvents.chatThreadId}::text`,
+                  ),
+                ),
+              )
+              .where(
+                and(
+                  eq(agentRunCallbacks.runId, agentRuns.id),
+                  eq(agentRunCallbacks.internalKind, "chat"),
+                ),
+              ),
+          ),
+        ),
+      ),
+    )
+    .orderBy(asc(agentRuns.createdAt), asc(agentRuns.id))
+    .limit(THREADLESS_RUN_SWEEP_LIMIT);
+}
+
+function quietWindowElapsed(
+  candidate: ThreadlessRunCandidate,
+  quietBefore: Date,
+): boolean {
+  return candidate.completedAt !== null && candidate.completedAt <= quietBefore;
+}
+
+async function hasDeletionBlocker(
+  db: Pick<Db, "select">,
+  runId: string,
+): Promise<boolean> {
+  const [pendingCallback] = await db
+    .select({ id: agentRunCallbacks.id })
+    .from(agentRunCallbacks)
+    .where(
+      and(
+        eq(agentRunCallbacks.runId, runId),
+        eq(agentRunCallbacks.status, "pending"),
+      ),
+    )
+    .limit(1);
+  if (pendingCallback) {
+    return true;
+  }
+
+  const [queuedRun] = await db
+    .select({ runId: agentRunQueue.runId })
+    .from(agentRunQueue)
+    .where(eq(agentRunQueue.runId, runId))
+    .limit(1);
+  if (queuedRun) {
+    return true;
+  }
+
+  const [runnerJob] = await db
+    .select({ runId: runnerJobQueue.runId })
+    .from(runnerJobQueue)
+    .where(eq(runnerJobQueue.runId, runId))
+    .limit(1);
+  if (runnerJob) {
+    return true;
+  }
+
+  const [pendingUsage] = await db
+    .select({ id: usageEvent.id })
+    .from(usageEvent)
+    .where(and(eq(usageEvent.runId, runId), eq(usageEvent.status, "pending")))
+    .limit(1);
+  return pendingUsage !== undefined;
+}
+
+async function deleteIfStillEligible(
+  db: Db,
+  candidate: ThreadlessRunCandidate,
+  quietBefore: Date,
+): Promise<boolean> {
+  return await db.transaction(async (tx) => {
+    const [current] = await tx
+      .select({
+        status: agentRuns.status,
+        completedAt: agentRuns.completedAt,
+        cancellationRecoveryCompleted: agentRuns.cancellationRecoveryCompleted,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, candidate.runId))
+      .for("update");
+    if (
+      !current ||
+      current.status !== candidate.status ||
+      current.completedAt?.getTime() !== candidate.completedAt?.getTime() ||
+      current.cancellationRecoveryCompleted !==
+        candidate.cancellationRecoveryCompleted ||
+      !isTerminalStatus(current.status) ||
+      current.completedAt === null ||
+      current.completedAt > quietBefore
+    ) {
+      return false;
+    }
+
+    const [zeroRun] = await tx
+      .select({ chatThreadId: zeroRuns.chatThreadId })
+      .from(zeroRuns)
+      .where(eq(zeroRuns.id, candidate.runId))
+      .limit(1);
+    if (!zeroRun || zeroRun.chatThreadId !== null) {
+      return false;
+    }
+
+    if (await hasDeletionBlocker(tx, candidate.runId)) {
+      return false;
+    }
+
+    const [deleted] = await tx
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, candidate.runId))
+      .returning({ id: agentRuns.id });
+    return deleted !== undefined;
+  });
+}
+
+async function redriveTerminalLifecycle(
+  set: Parameters<Parameters<typeof command>[0]>[0]["set"],
+  candidate: ThreadlessRunCandidate,
+  signal: AbortSignal,
+): Promise<void> {
+  if (candidate.status === "cancelled") {
+    const cancelResult = await set(
+      cancelRun$,
+      {
+        runId: candidate.runId,
+        userId: candidate.userId,
+        orgId: candidate.orgId,
+        runnerCancellationMode: "hard",
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    if ("alreadyCancelled" in cancelResult) {
+      await set(dispatchCancelSideEffects$, cancelResult, signal);
+      signal.throwIfAborted();
+    }
+  }
+
+  const error = terminalError(candidate);
+  await set(
+    dispatchCompleteSideEffects$,
+    {
+      kind: "terminal",
+      runId: candidate.runId,
+      orgId: candidate.orgId,
+      status: candidate.status === "completed" ? "completed" : "failed",
+      ...(error === undefined ? {} : { error }),
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  // dispatchCompleteSideEffects$ treats queue publication as best effort for
+  // normal webhooks. Deletion requires a strict durable reconciliation pass.
+  await set(drainOrgQueue$, { orgId: candidate.orgId }, signal);
+  signal.throwIfAborted();
+}
+
+export const cleanupThreadlessRuns$ = command(
+  async ({ set }, signal: AbortSignal): Promise<ThreadlessRunCleanupResult> => {
+    const db = set(writeDb$);
+    const candidates = await loadThreadlessRunCandidates(db);
+    signal.throwIfAborted();
+
+    let cancelled = 0;
+    let waiting = 0;
+    let deleted = 0;
+    const errors: ThreadlessRunCleanupError[] = [];
+    const quietBefore = new Date(
+      nowDate().getTime() - CANCELLATION_RECOVERY_STALE_AFTER_MS,
+    );
+
+    for (const candidate of candidates) {
+      const result = await settle(
+        (async () => {
+          if (isActiveStatus(candidate.status)) {
+            const cancelResult = await set(
+              cancelRun$,
+              {
+                runId: candidate.runId,
+                userId: candidate.userId,
+                orgId: candidate.orgId,
+                runnerCancellationMode: "hard",
+              },
+              signal,
+            );
+            signal.throwIfAborted();
+            if (!("alreadyCancelled" in cancelResult)) {
+              waiting++;
+              return;
+            }
+            await set(dispatchCancelSideEffects$, cancelResult, signal);
+            signal.throwIfAborted();
+            cancelled++;
+            return;
+          }
+
+          if (!quietWindowElapsed(candidate, quietBefore)) {
+            waiting++;
+            return;
+          }
+
+          await redriveTerminalLifecycle(set, candidate, signal);
+          if (await deleteIfStillEligible(db, candidate, quietBefore)) {
+            deleted++;
+          } else {
+            waiting++;
+          }
+        })(),
+        signal,
+      );
+      if (!result.ok) {
+        errors.push({
+          runId: candidate.runId,
+          error: errorMessage(result.error),
+        });
+      }
+    }
+
+    const cleanupResult = {
+      discovered: candidates.length,
+      cancelled,
+      waiting,
+      deleted,
+      failed: errors.length,
+      errors,
+    };
+    if (candidates.length > 0) {
+      L.debug("Threadless run cleanup completed", cleanupResult);
+    }
+    return cleanupResult;
+  },
+);

--- a/turbo/apps/api/src/signals/services/threadless-run-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/threadless-run-cleanup.service.ts
@@ -24,6 +24,7 @@ import { logger } from "../../lib/log";
 import { nowDate } from "../external/time";
 import { writeDb$, type Db } from "../external/db";
 import { settle } from "../utils";
+import { failPendingInlineOnlyDeliveryCallbacksForDeletedThread } from "./agent-run-callback.service";
 import { dispatchCompleteSideEffects$ } from "./agent-webhook-complete.service";
 import {
   cancelRun$,
@@ -260,6 +261,7 @@ async function deleteIfStillEligible(
 
 async function redriveTerminalLifecycle(
   set: Parameters<Parameters<typeof command>[0]>[0]["set"],
+  db: Db,
   candidate: ThreadlessRunCandidate,
   signal: AbortSignal,
 ): Promise<void> {
@@ -292,6 +294,12 @@ async function redriveTerminalLifecycle(
       ...(error === undefined ? {} : { error }),
     },
     signal,
+  );
+  signal.throwIfAborted();
+
+  await failPendingInlineOnlyDeliveryCallbacksForDeletedThread(
+    db,
+    candidate.runId,
   );
   signal.throwIfAborted();
 
@@ -345,7 +353,7 @@ export const cleanupThreadlessRuns$ = command(
             return;
           }
 
-          await redriveTerminalLifecycle(set, candidate, signal);
+          await redriveTerminalLifecycle(set, db, candidate, signal);
           if (await deleteIfStillEligible(db, candidate, quietBefore)) {
             deleted++;
           } else {

--- a/turbo/apps/api/src/test-fixtures/run-deletion.ts
+++ b/turbo/apps/api/src/test-fixtures/run-deletion.ts
@@ -1,3 +1,4 @@
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { count, eq, sql } from "drizzle-orm";
 import { z } from "zod";
@@ -94,6 +95,33 @@ export async function setAgentRunCreatedAtFixture(
     .update(agentRuns)
     .set({ createdAt })
     .where(eq(agentRuns.id, runId));
+}
+
+export async function insertPendingInlineDeliveryCallbackFixture(
+  runId: string,
+): Promise<string> {
+  const [callback] = await db()
+    .insert(agentRunCallbacks)
+    .values({ runId, internalKind: "slack:chat", payload: {} })
+    .returning({ id: agentRunCallbacks.id });
+  if (!callback) {
+    throw new Error("Expected the inline delivery callback to be inserted");
+  }
+  return callback.id;
+}
+
+export async function readRunCallbackFixture(callbackId: string): Promise<{
+  readonly status: string;
+  readonly lastError: string | null;
+} | null> {
+  const [callback] = await db()
+    .select({
+      status: agentRunCallbacks.status,
+      lastError: agentRunCallbacks.lastError,
+    })
+    .from(agentRunCallbacks)
+    .where(eq(agentRunCallbacks.id, callbackId));
+  return callback ?? null;
 }
 
 /** Holds the production event projection lock until the test releases it. */

--- a/turbo/apps/api/src/test-fixtures/run-deletion.ts
+++ b/turbo/apps/api/src/test-fixtures/run-deletion.ts
@@ -1,0 +1,219 @@
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { count, eq, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { db } from "../lib/db";
+import { executeRawRows } from "../lib/db-raw-rows";
+import { createDeferredPromise, settleIncludingAbort } from "../signals/utils";
+
+const databasePidRowSchema = z.object({ pid: z.int() });
+const waiterCountRowSchema = z.object({ waiterCount: z.int() });
+
+async function directBlockedWaiterCount(holderPid: number): Promise<number> {
+  const rows = await executeRawRows(
+    db(),
+    sql`
+      SELECT ${count()}::int AS "waiterCount"
+      FROM pg_stat_activity AS activity
+      WHERE ${holderPid} = ANY(pg_blocking_pids(activity.pid))
+    `,
+    waiterCountRowSchema,
+  );
+  return rows[0]?.waiterCount ?? 0;
+}
+
+interface HeldDatabaseBoundary {
+  readonly release: () => void;
+  readonly done: Promise<void>;
+  readonly blockedWaiterCount: () => Promise<number>;
+}
+
+/** Serializes integration tests that invoke the global threadless-run sweep. */
+async function holdThreadlessRunCleanupTestLockFixture(args: {
+  readonly signal: AbortSignal;
+}): Promise<HeldDatabaseBoundary> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const pidRows = await executeRawRows(
+      tx,
+      sql`SELECT pg_backend_pid() AS "pid"`,
+      databasePidRowSchema,
+    );
+    const pid = pidRows[0]?.pid;
+    if (!pid) {
+      throw new Error("Expected the cleanup test lock holder pid");
+    }
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtextextended('threadless-run-cleanup-integration-test', 0))`,
+    );
+    started.resolve(pid);
+    await released.promise;
+  });
+  const pid = await started.promise;
+  return {
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+    done,
+    blockedWaiterCount: async () => {
+      return await directBlockedWaiterCount(pid);
+    },
+  };
+}
+
+export async function withThreadlessRunCleanupTestLockFixture<T>(args: {
+  readonly signal: AbortSignal;
+  readonly run: () => Promise<T>;
+}): Promise<T> {
+  const lock = await holdThreadlessRunCleanupTestLockFixture({
+    signal: args.signal,
+  });
+  const result = await settleIncludingAbort(args.run());
+  lock.release();
+  await lock.done;
+  if (!result.ok) {
+    throw result.error;
+  }
+  return result.value;
+}
+
+/** Deletes one run root without invoking a global maintenance sweep. */
+export async function deleteAgentRunRootFixture(runId: string): Promise<void> {
+  await db().delete(agentRuns).where(eq(agentRuns.id, runId));
+}
+
+/** Moves a run to a deterministic position in an oldest-first test sweep. */
+export async function setAgentRunCreatedAtFixture(
+  runId: string,
+  createdAt: Date,
+): Promise<void> {
+  await db()
+    .update(agentRuns)
+    .set({ createdAt })
+    .where(eq(agentRuns.id, runId));
+}
+
+/** Holds the production event projection lock until the test releases it. */
+export async function holdRunOutputProjectionLockFixture(args: {
+  readonly runId: string;
+  readonly signal: AbortSignal;
+}): Promise<HeldDatabaseBoundary> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const projectionLockKey = `run_output_projection:${args.runId}`;
+  const done = db().transaction(async (tx) => {
+    const pidRows = await executeRawRows(
+      tx,
+      sql`SELECT pg_backend_pid() AS "pid"`,
+      databasePidRowSchema,
+    );
+    const pid = pidRows[0]?.pid;
+    if (!pid) {
+      throw new Error("Expected the projection lock holder pid");
+    }
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtextextended(${projectionLockKey}, 0))`,
+    );
+    started.resolve(pid);
+    await released.promise;
+  });
+  const pid = await started.promise;
+  return {
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+    done,
+    blockedWaiterCount: async () => {
+      return await directBlockedWaiterCount(pid);
+    },
+  };
+}
+
+/** Holds the same per-org credit reconciliation lock as terminal side effects. */
+export async function holdOrgCreditLockFixture(args: {
+  readonly orgId: string;
+  readonly signal: AbortSignal;
+}): Promise<HeldDatabaseBoundary> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const pidRows = await executeRawRows(
+      tx,
+      sql`SELECT pg_backend_pid() AS "pid"`,
+      databasePidRowSchema,
+    );
+    const pid = pidRows[0]?.pid;
+    if (!pid) {
+      throw new Error("Expected the credit lock holder pid");
+    }
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext('credit_' || ${args.orgId}))`,
+    );
+    started.resolve(pid);
+    await released.promise;
+  });
+  const pid = await started.promise;
+  return {
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+    done,
+    blockedWaiterCount: async () => {
+      return await directBlockedWaiterCount(pid);
+    },
+  };
+}
+
+/**
+ * Locks one root, then deletes it in the holding transaction when released.
+ * This lets a route test deterministically put a runner write behind the root
+ * delete without adding product-only synchronization.
+ */
+export async function holdAgentRunDeletionFixture(args: {
+  readonly runId: string;
+  readonly signal: AbortSignal;
+}): Promise<HeldDatabaseBoundary> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const pidRows = await executeRawRows(
+      tx,
+      sql`SELECT pg_backend_pid() AS "pid"`,
+      databasePidRowSchema,
+    );
+    const pid = pidRows[0]?.pid;
+    if (!pid) {
+      throw new Error("Expected the run deletion holder pid");
+    }
+    const [run] = await tx
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, args.runId))
+      .for("update");
+    if (!run) {
+      throw new Error("Expected the run root to exist before deletion");
+    }
+    started.resolve(pid);
+    await released.promise;
+    await tx.delete(agentRuns).where(eq(agentRuns.id, args.runId));
+  });
+  const pid = await started.promise;
+  return {
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+    done,
+    blockedWaiterCount: async () => {
+      return await directBlockedWaiterCount(pid);
+    },
+  };
+}

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -25,6 +25,19 @@ const cleanupResponseSchema = z.object({
   results: z.array(cleanupResultSchema),
   exportJobsCleaned: z.number(),
   exportJobsStuck: z.number(),
+  threadlessRuns: z.object({
+    discovered: z.number().int().nonnegative(),
+    cancelled: z.number().int().nonnegative(),
+    waiting: z.number().int().nonnegative(),
+    deleted: z.number().int().nonnegative(),
+    failed: z.number().int().nonnegative(),
+    errors: z.array(
+      z.object({
+        runId: z.string().uuid(),
+        error: z.string(),
+      }),
+    ),
+  }),
 });
 
 /**

--- a/turbo/packages/api-contracts/src/contracts/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-cron-cleanup-sandboxes-state.ts
@@ -8,7 +8,11 @@ export const testCronCleanupSandboxesStateActionBodySchema = z
   .object({
     action: z.enum([
       "seed-run",
+      "seed-run-ownership",
+      "attach-run-thread",
       "delete-run",
+      "delete-run-ownership",
+      "delete-run-thread",
       "seed-runner-job",
       "seed-custom-connector-auth-ref",
       "seed-queue-entry",
@@ -16,6 +20,7 @@ export const testCronCleanupSandboxesStateActionBodySchema = z
       "seed-export-job",
       "delete-export-job",
       "get-run",
+      "get-run-ownership",
       "get-runner-job",
       "get-custom-connector-auth-ref",
       "get-queue-entry",


### PR DESCRIPTION
## Summary

- add a bounded, oldest-first threadless-run reconciler to the existing minute `cron-cleanup-sandboxes` maintenance path
- exclude only persisted `trigger_source = 'test'` preview/E2E fixtures from the selector; every non-test threadless run remains cleanup work, with no environment-based bypass
- hard-cancel active candidates without same-pass deletion, redrive durable terminal side effects after the 120-second recovery window, and re-check every delete condition while holding the root write lock
- terminalize pending inline-only integration delivery callbacks when their chat thread is gone so a crash before delivery cannot block root deletion forever
- delete the `agent_runs` root so established cascades and `SET NULL` ownership rules remove run-owned children while preserving billing, generation, browser, workflow, and hosted-publication state
- harden event materialization, uploaded-file association, checkpoints, usage telemetry, and canonical Slack publication against late root-delete races without exposing PostgreSQL `23503` as 5xx
- cover cancellation recovery, bounded drain, exact quiet-window boundaries, callback crash recovery, both forward-watermark selector branches, concurrent writes/state changes, ownership preservation, browser reconciliation, and workflow continuation with deterministic integration tests

The audited 20,176-row legacy cohort remains outside this forward sweep. The selector uses the issue-created forward watermark (`2026-08-03T05:40:26Z`); older roots enter only when an existing chat callback matches a deletion tombstone after that watermark. This PR adds no schema, cleanup queue, prefix deletion, or data migration.

Parent epic: https://github.com/vm0-ai/vm0/issues/24358

Closes #24670

## Validation

- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm knip --workspace api`
- cleanup integration file: 33 passed
- focused deleted-thread callback and pre-watermark tombstone selector regressions: 2 passed
- focused thread/upload/workflow cleanup regressions: 4 passed
- browser ownership and reconciliation integration file: 11 passed
- webhook callback and late-event integration file: 44 passed
- canonical Slack upload init/complete files: 21 passed

No full local Vitest suite or development server was run.

## Production rollout gate

After deployment, wait for pre-change API instances to drain and for at least the 120-second cancellation-recovery window. Then verify the structured `discovered/cancelled/waiting/deleted/failed` output and zero error backlog, confirm new threadless rows converge, check production telemetry for no new run-owned FK `23503` or webhook 5xx class, and sample billing plus hosted publications. Only after that gate should a separate child issue define and delete the legacy cohort with a fixed pre-deployment cutoff.