### PR TITLE
refactor(python): share provider timing delivery state

### DIFF
--- a/crates/runner/mitm-addon/src/claude_output_timing.py
+++ b/crates/runner/mitm-addon/src/claude_output_timing.py
@@ -17,16 +17,13 @@ See ``tests/test_claude_output_timing.py`` for focused lifecycle coverage.
 
 from __future__ import annotations
 
-import threading
-from collections import OrderedDict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from mitmproxy import http
 
 import flow_metadata
-import usage
-from usage.reporting_context import UsageReportingContext, usage_reporting_context
+import provider_timing_store
 
 FIRST_MESSAGE_START = "claude_proxy_first_message_start"
 FIRST_THINKING_OR_TEXT_BLOCK_START = "claude_proxy_first_thinking_or_text_block_start"
@@ -40,17 +37,17 @@ _LOG_TYPE = "claude_output_timing"
 
 
 @dataclass
-class _RunTimingState:
+class _RunTimingState(provider_timing_store.ProviderTimingState):
     first_message_start_observed: bool = False
     first_thinking_or_text_block_observed: bool = False
     first_text_block_observed: bool = False
-    pending_operations: dict[str, str] = field(default_factory=dict)
-    pending_context: UsageReportingContext | None = None
-    buffered_report: usage.BufferedReportLease | None = None
 
 
-_run_states: OrderedDict[str, _RunTimingState] = OrderedDict()
-_state_lock = threading.Lock()
+_store = provider_timing_store.ProviderTimingStore(
+    state_factory=_RunTimingState,
+    log_type=_LOG_TYPE,
+    max_tracked_runs=_MAX_TRACKED_RUNS,
+)
 
 
 def observe_lifecycle_event(
@@ -71,17 +68,17 @@ def observe_lifecycle_event(
     if not run_id:
         return
 
-    with _state_lock:
-        state = _run_states.get(run_id)
+    with _store.locked():
+        state = _store.get_locked(run_id)
         if event_type == _MESSAGE_START_EVENT:
             if state is None:
-                state = _state_for_run_locked(run_id)
+                state = _store.state_for_run_locked(run_id)
             else:
-                _touch_run_locked(run_id)
+                _store.touch_locked(run_id)
             if not state.first_message_start_observed:
                 state.first_message_start_observed = True
                 state.pending_operations[FIRST_MESSAGE_START] = _observation_time()
-            _admit_pending_locked(flow, run_id, state)
+            _store.admit_pending_locked(flow, run_id, state)
             return
 
         if event_type != _CONTENT_BLOCK_START_EVENT:
@@ -92,9 +89,9 @@ def observe_lifecycle_event(
         if state is None:
             if not is_thinking_or_text:
                 return
-            state = _state_for_run_locked(run_id)
+            state = _store.state_for_run_locked(run_id)
         else:
-            _touch_run_locked(run_id)
+            _store.touch_locked(run_id)
 
         observed_at: str | None = None
         if is_thinking_or_text and not state.first_thinking_or_text_block_observed:
@@ -106,7 +103,7 @@ def observe_lifecycle_event(
                 observed_at = _observation_time()
             state.first_text_block_observed = True
             state.pending_operations[FIRST_TEXT_BLOCK_START] = observed_at
-        _admit_pending_locked(flow, run_id, state)
+        _store.admit_pending_locked(flow, run_id, state)
 
 
 def retry_pending(flow: http.HTTPFlow) -> None:
@@ -114,107 +111,17 @@ def retry_pending(flow: http.HTTPFlow) -> None:
     run_id = flow_metadata.run_id(flow.metadata)
     if not run_id:
         return
-    with _state_lock:
-        state = _run_states.get(run_id)
-        if state is None:
-            return
-        _touch_run_locked(run_id)
-        _admit_pending_locked(flow, run_id, state)
+    _store.retry_pending(flow, run_id)
 
 
 def retry_all_pending() -> None:
     """Retry retained reports until admission capacity is saturated."""
-    with _state_lock:
-        for run_id, state in _run_states.items():
-            if not _admit_retained_locked(run_id, state):
-                return
+    _store.retry_all_pending()
 
 
 def _observation_time() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _state_for_run_locked(run_id: str) -> _RunTimingState:
-    state = _run_states.get(run_id)
-    if state is None:
-        state = _RunTimingState()
-        _run_states[run_id] = state
-        if len(_run_states) > _MAX_TRACKED_RUNS:
-            _, evicted = _run_states.popitem(last=False)
-            _release_buffered_report_locked(evicted)
-        return state
-
-    _touch_run_locked(run_id)
-    return state
-
-
-def _touch_run_locked(run_id: str) -> None:
-    _run_states.move_to_end(run_id)
-
-
-def _admit_pending_locked(
-    flow: http.HTTPFlow,
-    run_id: str,
-    state: _RunTimingState,
-) -> None:
-    if not state.pending_operations:
-        return
-
-    context = usage_reporting_context(flow)
-    if not context.is_complete:
-        return
-    state.pending_context = context
-    if state.buffered_report is None:
-        state.buffered_report = usage.admit_buffered_report()
-    _admit_retained_locked(run_id, state)
-
-
-def _admit_retained_locked(run_id: str, state: _RunTimingState) -> bool:
-    context = state.pending_context
-    if not state.pending_operations or context is None:
-        return True
-    operations = [
-        {
-            "ts": observed_at,
-            "action_type": action_type,
-            "duration_ms": 0,
-            "success": True,
-        }
-        for action_type, observed_at in state.pending_operations.items()
-    ]
-    payload: dict[str, object] = {
-        "runId": run_id,
-        "sandboxOperations": operations,
-    }
-    if not usage.webhook.enqueue_webhook_delivery(
-        context.telemetry_url(),
-        context.sandbox_token,
-        payload,
-        context.proxy_log_path,
-        _LOG_TYPE,
-    ):
-        return False
-
-    lease = state.buffered_report
-    if lease is None:
-        raise RuntimeError("admitted Claude timing report had no buffered owner")
-    state.pending_operations.clear()
-    state.pending_context = None
-    state.buffered_report = None
-    lease.release()
-    return True
-
-
-def _release_buffered_report_locked(state: _RunTimingState) -> None:
-    lease = state.buffered_report
-    if lease is None:
-        return
-    state.buffered_report = None
-    lease.release()
-
-
 def reset_for_tests() -> None:
-    with _state_lock:
-        for state in _run_states.values():
-            _release_buffered_report_locked(state)
-        _run_states.clear()
+    _store.reset()

--- a/crates/runner/mitm-addon/src/codex_output_timing.py
+++ b/crates/runner/mitm-addon/src/codex_output_timing.py
@@ -16,16 +16,13 @@ See ``tests/test_codex_output_timing.py`` for focused lifecycle coverage.
 
 from __future__ import annotations
 
-import threading
-from collections import OrderedDict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from mitmproxy import http
 
 import flow_metadata
-import usage
-from usage.reporting_context import UsageReportingContext, usage_reporting_context
+import provider_timing_store
 
 FIRST_GENERATED_RESPONSE_CREATED = "codex_proxy_first_generated_response_created"
 FIRST_OUTPUT_ITEM_ADDED = "codex_proxy_first_output_item_added"
@@ -42,17 +39,17 @@ _LOG_TYPE = "codex_output_timing"
 
 
 @dataclass
-class _RunTimingState:
+class _RunTimingState(provider_timing_store.ProviderTimingState):
     candidate_response_created_at: str | None = None
     generated_response_selected: bool = False
     first_text_observed: bool = False
-    pending_operations: dict[str, str] = field(default_factory=dict)
-    pending_context: UsageReportingContext | None = None
-    buffered_report: usage.BufferedReportLease | None = None
 
 
-_run_states: OrderedDict[str, _RunTimingState] = OrderedDict()
-_state_lock = threading.Lock()
+_store = provider_timing_store.ProviderTimingStore(
+    state_factory=_RunTimingState,
+    log_type=_LOG_TYPE,
+    max_tracked_runs=_MAX_TRACKED_RUNS,
+)
 
 
 def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
@@ -72,20 +69,20 @@ def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
     if not run_id:
         return
 
-    with _state_lock:
+    with _store.locked():
         if event_type == _RESPONSE_CREATED_EVENT:
-            state = _state_for_run_locked(run_id)
+            state = _store.state_for_run_locked(run_id)
             if not state.generated_response_selected:
                 state.candidate_response_created_at = _observation_time()
-            _admit_pending_locked(flow, run_id, state)
+            _store.admit_pending_locked(flow, run_id, state)
             return
 
-        state = _run_states.get(run_id)
+        state = _store.get_locked(run_id)
         if event_type == _OUTPUT_ITEM_ADDED_EVENT:
             if state is None:
-                state = _state_for_run_locked(run_id)
+                state = _store.state_for_run_locked(run_id)
             else:
-                _touch_run_locked(run_id)
+                _store.touch_locked(run_id)
             if not state.generated_response_selected:
                 state.generated_response_selected = True
                 if state.candidate_response_created_at is not None:
@@ -94,123 +91,37 @@ def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
                     )
                 state.candidate_response_created_at = None
                 state.pending_operations[FIRST_OUTPUT_ITEM_ADDED] = _observation_time()
-                _admit_pending_locked(flow, run_id, state)
+                _store.admit_pending_locked(flow, run_id, state)
             return
 
         if event_type == _OUTPUT_TEXT_DELTA_EVENT:
             if state is None or not state.generated_response_selected:
                 return
-            _touch_run_locked(run_id)
+            _store.touch_locked(run_id)
             if not state.first_text_observed:
                 state.first_text_observed = True
                 state.pending_operations[FIRST_OUTPUT_TEXT_DELTA] = _observation_time()
-                _admit_pending_locked(flow, run_id, state)
+                _store.admit_pending_locked(flow, run_id, state)
             return
 
         if event_type not in _TERMINAL_EVENTS or state is None:
             return
 
-        _touch_run_locked(run_id)
+        _store.touch_locked(run_id)
         if not state.generated_response_selected:
-            removed = _run_states.pop(run_id)
-            _release_buffered_report_locked(removed)
+            _store.discard_locked(run_id)
             return
-        _admit_pending_locked(flow, run_id, state)
+        _store.admit_pending_locked(flow, run_id, state)
 
 
 def retry_all_pending() -> None:
     """Retry retained reports until admission capacity is saturated."""
-    with _state_lock:
-        for run_id, state in _run_states.items():
-            if not _admit_retained_locked(run_id, state):
-                return
+    _store.retry_all_pending()
 
 
 def _observation_time() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _state_for_run_locked(run_id: str) -> _RunTimingState:
-    state = _run_states.get(run_id)
-    if state is None:
-        state = _RunTimingState()
-        _run_states[run_id] = state
-        if len(_run_states) > _MAX_TRACKED_RUNS:
-            _, evicted = _run_states.popitem(last=False)
-            _release_buffered_report_locked(evicted)
-        return state
-
-    _touch_run_locked(run_id)
-    return state
-
-
-def _touch_run_locked(run_id: str) -> None:
-    _run_states.move_to_end(run_id)
-
-
-def _admit_pending_locked(
-    flow: http.HTTPFlow,
-    run_id: str,
-    state: _RunTimingState,
-) -> None:
-    if not state.pending_operations:
-        return
-
-    context = usage_reporting_context(flow)
-    if not context.is_complete:
-        return
-    state.pending_context = context
-    if state.buffered_report is None:
-        state.buffered_report = usage.admit_buffered_report()
-    _admit_retained_locked(run_id, state)
-
-
-def _admit_retained_locked(run_id: str, state: _RunTimingState) -> bool:
-    context = state.pending_context
-    if not state.pending_operations or context is None:
-        return True
-    operations = [
-        {
-            "ts": observed_at,
-            "action_type": action_type,
-            "duration_ms": 0,
-            "success": True,
-        }
-        for action_type, observed_at in state.pending_operations.items()
-    ]
-    payload: dict[str, object] = {
-        "runId": run_id,
-        "sandboxOperations": operations,
-    }
-    if not usage.webhook.enqueue_webhook_delivery(
-        context.telemetry_url(),
-        context.sandbox_token,
-        payload,
-        context.proxy_log_path,
-        _LOG_TYPE,
-    ):
-        return False
-
-    lease = state.buffered_report
-    if lease is None:
-        raise RuntimeError("admitted Codex timing report had no buffered owner")
-    state.pending_operations.clear()
-    state.pending_context = None
-    state.buffered_report = None
-    lease.release()
-    return True
-
-
-def _release_buffered_report_locked(state: _RunTimingState) -> None:
-    lease = state.buffered_report
-    if lease is None:
-        return
-    state.buffered_report = None
-    lease.release()
-
-
 def reset_for_tests() -> None:
-    with _state_lock:
-        for state in _run_states.values():
-            _release_buffered_report_locked(state)
-        _run_states.clear()
+    _store.reset()

--- a/crates/runner/mitm-addon/src/provider_timing_store.py
+++ b/crates/runner/mitm-addon/src/provider_timing_store.py
@@ -1,0 +1,149 @@
+"""Shared run-scoped delivery state for provider-output timing."""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+
+from mitmproxy import http
+
+import usage
+from usage.reporting_context import UsageReportingContext, usage_reporting_context
+
+
+@dataclass
+class ProviderTimingState:
+    """Delivery fields shared by one provider's run-specific timing state."""
+
+    pending_operations: dict[str, str] = field(default_factory=dict)
+    pending_context: UsageReportingContext | None = None
+    buffered_report: usage.BufferedReportLease | None = None
+
+
+class ProviderTimingStore[StateT: ProviderTimingState]:
+    """Own one provider's bounded run state and retained report lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        state_factory: Callable[[], StateT],
+        log_type: str,
+        max_tracked_runs: int,
+    ) -> None:
+        self._state_factory = state_factory
+        self._log_type = log_type
+        self._max_tracked_runs = max_tracked_runs
+        self._run_states: OrderedDict[str, StateT] = OrderedDict()
+        self._lock = threading.Lock()
+
+    @contextmanager
+    def locked(self) -> Iterator[None]:
+        """Serialize provider-specific transitions with store lifecycle work."""
+        with self._lock:
+            yield
+
+    def get_locked(self, run_id: str) -> StateT | None:
+        return self._run_states.get(run_id)
+
+    def state_for_run_locked(self, run_id: str) -> StateT:
+        state = self._run_states.get(run_id)
+        if state is None:
+            state = self._state_factory()
+            self._run_states[run_id] = state
+            if len(self._run_states) > self._max_tracked_runs:
+                _, evicted = self._run_states.popitem(last=False)
+                self._release_buffered_report_locked(evicted)
+            return state
+
+        self.touch_locked(run_id)
+        return state
+
+    def touch_locked(self, run_id: str) -> None:
+        self._run_states.move_to_end(run_id)
+
+    def discard_locked(self, run_id: str) -> None:
+        state = self._run_states.pop(run_id)
+        self._release_buffered_report_locked(state)
+
+    def admit_pending_locked(
+        self,
+        flow: http.HTTPFlow,
+        run_id: str,
+        state: StateT,
+    ) -> None:
+        if not state.pending_operations:
+            return
+
+        context = usage_reporting_context(flow)
+        if not context.is_complete:
+            return
+        state.pending_context = context
+        if state.buffered_report is None:
+            state.buffered_report = usage.admit_buffered_report()
+        self._admit_retained_locked(run_id, state)
+
+    def retry_pending(self, flow: http.HTTPFlow, run_id: str) -> None:
+        with self._lock:
+            state = self._run_states.get(run_id)
+            if state is None:
+                return
+            self.touch_locked(run_id)
+            self.admit_pending_locked(flow, run_id, state)
+
+    def retry_all_pending(self) -> None:
+        """Retry retained reports until admission capacity is saturated."""
+        with self._lock:
+            for run_id, state in self._run_states.items():
+                if not self._admit_retained_locked(run_id, state):
+                    return
+
+    def reset(self) -> None:
+        with self._lock:
+            for state in self._run_states.values():
+                self._release_buffered_report_locked(state)
+            self._run_states.clear()
+
+    def _admit_retained_locked(self, run_id: str, state: StateT) -> bool:
+        context = state.pending_context
+        if not state.pending_operations or context is None:
+            return True
+        operations = [
+            {
+                "ts": observed_at,
+                "action_type": action_type,
+                "duration_ms": 0,
+                "success": True,
+            }
+            for action_type, observed_at in state.pending_operations.items()
+        ]
+        payload: dict[str, object] = {
+            "runId": run_id,
+            "sandboxOperations": operations,
+        }
+        if not usage.webhook.enqueue_webhook_delivery(
+            context.telemetry_url(),
+            context.sandbox_token,
+            payload,
+            context.proxy_log_path,
+            self._log_type,
+        ):
+            return False
+
+        lease = state.buffered_report
+        if lease is None:
+            raise RuntimeError("admitted provider timing report had no buffered owner")
+        state.pending_operations.clear()
+        state.pending_context = None
+        state.buffered_report = None
+        lease.release()
+        return True
+
+    def _release_buffered_report_locked(self, state: StateT) -> None:
+        lease = state.buffered_report
+        if lease is None:
+            return
+        state.buffered_report = None
+        lease.release()

--- a/crates/runner/mitm-addon/tests/test_claude_output_timing.py
+++ b/crates/runner/mitm-addon/tests/test_claude_output_timing.py
@@ -355,7 +355,7 @@ def test_eviction_and_reset_release_retained_buffered_report(
             "enqueue_webhook_delivery",
             return_value=False,
         ),
-        patch.object(claude_output_timing, "_MAX_TRACKED_RUNS", 1),
+        patch.object(claude_output_timing._store, "_max_tracked_runs", 1),
     ):
         first_flow = _claude_sse_flow(real_flow, tmp_path)
         first_flow.metadata[metadata_keys.VM_RUN_ID] = "run-first"
@@ -417,7 +417,7 @@ def test_lru_hit_recency_preserves_recent_buffered_report(
             "enqueue_webhook_delivery",
             side_effect=enqueue_timing_delivery,
         ),
-        patch.object(claude_output_timing, "_MAX_TRACKED_RUNS", 2),
+        patch.object(claude_output_timing._store, "_max_tracked_runs", 2),
     ):
         first_flow = claude_flow("run-a")
         _feed(first_flow, _message_start(include_usage=False))

--- a/crates/runner/mitm-addon/tests/test_codex_output_timing.py
+++ b/crates/runner/mitm-addon/tests/test_codex_output_timing.py
@@ -245,7 +245,7 @@ def test_eviction_and_reset_release_retained_buffered_report(
             "enqueue_webhook_delivery",
             return_value=False,
         ),
-        patch.object(codex_output_timing, "_MAX_TRACKED_RUNS", 1),
+        patch.object(codex_output_timing._store, "_max_tracked_runs", 1),
     ):
         first_flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         first_flow.metadata[metadata_keys.VM_RUN_ID] = "run-first"
@@ -307,7 +307,7 @@ def test_lru_hit_recency_preserves_recent_buffered_report(
             "enqueue_webhook_delivery",
             side_effect=enqueue_timing_delivery,
         ),
-        patch.object(codex_output_timing, "_MAX_TRACKED_RUNS", 2),
+        patch.object(codex_output_timing._store, "_max_tracked_runs", 2),
     ):
         first_flow = codex_flow("run-a")
         _feed_generated_response(first_flow, include_text=False)

--- a/crates/runner/mitm-addon/tests/test_provider_output_timing.py
+++ b/crates/runner/mitm-addon/tests/test_provider_output_timing.py
@@ -1,0 +1,121 @@
+"""Cross-provider integration tests for provider-output timing stores."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from mitmproxy import http
+
+import claude_output_timing
+import codex_output_timing
+import flow_metadata_keys as metadata_keys
+import usage
+from tests.model_provider_flow_helpers import (
+    make_model_provider_sse_flow,
+    make_openai_responses_websocket_flow,
+)
+from tests.pending_helpers import assert_current_pending
+
+
+def test_provider_stores_keep_independent_lru_capacity(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+) -> None:
+    pending_path = tmp_path / "usage-pending"
+    usage.set_pending_path(str(pending_path))
+    delivery_available = False
+    admitted: list[tuple[str, str]] = []
+
+    def enqueue_timing_delivery(
+        _url: str,
+        _sandbox_token: str,
+        payload: dict[str, object],
+        _proxy_log_path: str,
+        log_type: str,
+    ) -> bool:
+        if not delivery_available:
+            return False
+        run_id = payload["runId"]
+        assert isinstance(run_id, str)
+        admitted.append((log_type, run_id))
+        return True
+
+    def claude_flow(run_id: str) -> http.HTTPFlow:
+        flow = make_model_provider_sse_flow(
+            real_flow,
+            tmp_path,
+            host="api.anthropic.com",
+            original_url="https://api.anthropic.com/v1/messages",
+            firewall_name="model-provider:anthropic-api-key",
+            cli_agent_type="claude-code",
+            model_usage_provider="claude-sonnet-4-6",
+        )
+        flow.metadata[metadata_keys.VM_RUN_ID] = run_id
+        return flow
+
+    with (
+        mitm_ctx(api_url="https://api.test"),
+        patch.object(
+            usage.webhook,
+            "enqueue_webhook_delivery",
+            side_effect=enqueue_timing_delivery,
+        ),
+        patch.object(codex_output_timing._store, "_max_tracked_runs", 1),
+        patch.object(claude_output_timing._store, "_max_tracked_runs", 1),
+    ):
+        codex_flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        codex_flow.metadata[metadata_keys.VM_RUN_ID] = "run-shared"
+        codex_output_timing.observe_server_event(codex_flow, "response.created")
+        codex_output_timing.observe_server_event(codex_flow, "response.output_item.added")
+
+        claude_output_timing.observe_lifecycle_event(
+            claude_flow("run-shared"),
+            "message_start",
+            None,
+        )
+
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=2,
+            reports=0,
+            flush_request_id="before-claude-overflow",
+        )
+
+        claude_output_timing.observe_lifecycle_event(
+            claude_flow("run-claude-recent"),
+            "message_start",
+            None,
+        )
+
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=2,
+            reports=0,
+            flush_request_id="after-claude-overflow",
+        )
+
+        delivery_available = True
+        claude_output_timing.retry_all_pending()
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=1,
+            reports=0,
+            flush_request_id="after-claude-retry",
+        )
+
+        codex_output_timing.retry_all_pending()
+
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="after-codex-retry",
+    )
+    assert admitted == [
+        ("claude_output_timing", "run-claude-recent"),
+        ("codex_output_timing", "run-shared"),
+    ]

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -113,7 +113,7 @@ tests must not resolve a different mitmproxy version from production.
 | `test_request_handler_authority_validation.py`          | Request-hook Host/SNI/`:authority` validation and denial effects                                                     |
 | `test_request_handler_builtin_host_policy.py`           | Request-hook runtime built-in host-policy enforcement and compiled-policy reuse                                      |
 | `test_request_handler_connector_admission.py`           | Request-hook connector destination admission, TLS evidence, test-endpoint bypass, and API binding interaction        |
-| `test_request_handler_api_admission.py`                 | Request-hook platform API auto-allow, port scoping, registry gate, and destination binding                            |
+| `test_request_handler_api_admission.py`                 | Request-hook platform API auto-allow, port scoping, registry gate, and destination binding                           |
 | `test_request_handler_tls_admission.py`                 | Request-hook connection-scoped TLS admission revalidation and cleanup                                                |
 | `test_request_handler_registry_admission.py`            | Request-hook proxy-registry availability and VM entry admission                                                      |
 | `test_request_handler_firewall_dispatch.py`             | Core firewall dispatch, permission blocks, malformed config/policy handling, block responses, and unsafe-path blocks |
@@ -209,6 +209,7 @@ tests must not resolve a different mitmproxy version from production.
 | `test_model_provider_websocket_lifecycle.py`            | Model provider WebSocket HTTP upgrade and terminal usage lifecycle                                                   |
 | `test_codex_output_timing.py`                           | Default Codex provider-output timing observations over WebSocket                                                     |
 | `test_claude_output_timing.py`                          | Claude Code provider-output lifecycle timing over Anthropic SSE                                                      |
+| `test_provider_output_timing.py`                        | Cross-provider output-timing store capacity and lifecycle independence                                               |
 | `test_websocket_retention.py`                           | Registered WebSocket message retention and cleanup                                                                   |
 | `test_model_provider_websocket_metadata.py`             | Model provider WebSocket usage metadata parsing                                                                      |
 | `test_model_provider_usage.py`                          | Model provider usage reporter                                                                                        |


### PR DESCRIPTION
## Summary

- extract the duplicated run-scoped timing delivery lifecycle into a shared generic store
- keep Claude and Codex event selection in their provider modules with independent locks, LRUs, capacities, and log types
- preserve thin provider retry/reset wrappers for explicit runner flush and test cleanup ordering
- add cross-provider integration coverage proving one provider's LRU eviction does not release the other's retained work

## Compatibility and exclusions

- no provider milestone, timestamp, payload, or content-retention behavior changes
- no unified cross-provider store, dynamic registry, or shared contention point
- no database schema, persisted data, API route, queue payload, runner protocol, or rollout migration changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4576 passed)
- focused provider timing and runner flush integration tests (43 passed)
- `pnpm prettier --check ../docs/testing/mitm-addon-testing.md`
- `git diff --check`
- `pnpm --dir turbo exec lefthook run pre-commit`

Closes #24707
