### PR TITLE
perf(nbd-cow): decode bitmaps in chunks

### DIFF
--- a/crates/nbd-cow/src/cow/bitmap.rs
+++ b/crates/nbd-cow/src/cow/bitmap.rs
@@ -1,5 +1,5 @@
 use std::fs::{File, OpenOptions};
-use std::io::{BufReader, Read, Write};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 use bitvec::prelude::*;
@@ -11,9 +11,9 @@ const _: () = assert!(
     std::mem::size_of::<usize>() == 8,
     "nbd-cow requires a 64-bit target"
 );
-const BITMAP_WRITE_CHUNK_BYTES: usize = 64 * 1024;
-const _: () = assert!(BITMAP_WRITE_CHUNK_BYTES.is_multiple_of(8));
-const BITMAP_WORDS_PER_WRITE_CHUNK: usize = BITMAP_WRITE_CHUNK_BYTES / 8;
+const BITMAP_CHUNK_BYTES: usize = 64 * 1024;
+const _: () = assert!(BITMAP_CHUNK_BYTES.is_multiple_of(8));
+const BITMAP_WORDS_PER_CHUNK: usize = BITMAP_CHUNK_BYTES / 8;
 
 /// Save the dirty bitmap to a file.
 ///
@@ -77,7 +77,7 @@ fn write_bitmap_words<W: Write>(writer: &mut W, raw: &[usize]) -> std::io::Resul
         return Ok(());
     }
 
-    let words_per_chunk = raw.len().min(BITMAP_WORDS_PER_WRITE_CHUNK);
+    let words_per_chunk = raw.len().min(BITMAP_WORDS_PER_CHUNK);
     let mut chunk = Vec::with_capacity(words_per_chunk * 8);
 
     for words in raw.chunks(words_per_chunk) {
@@ -96,16 +96,15 @@ fn write_bitmap_words<W: Write>(writer: &mut W, raw: &[usize]) -> std::io::Resul
 /// Returns an error if the block count doesn't match `expected_blocks`
 /// or if the file is truncated.
 pub(super) fn load_bitmap(path: &Path, expected_blocks: usize) -> Result<BitVec> {
-    let file = File::open(path)?;
+    let mut file = File::open(path)?;
     let file_len = file.metadata()?.len();
     if file_len < 8 {
         return Err(NbdCowError::Io(std::io::Error::other(
             "bitmap file too short for header",
         )));
     }
-    let mut reader = BufReader::new(file);
     let mut header = [0u8; 8];
-    reader.read_exact(&mut header)?;
+    file.read_exact(&mut header)?;
     let num_blocks = u64::from_le_bytes(header) as usize;
     if num_blocks != expected_blocks {
         return Err(NbdCowError::Io(std::io::Error::other(format!(
@@ -126,10 +125,26 @@ pub(super) fn load_bitmap(path: &Path, expected_blocks: usize) -> Result<BitVec>
             "bitmap word allocation failed: {e}"
         )))
     })?;
-    for _ in 0..expected_words {
-        let mut word_bytes = [0u8; 8];
-        reader.read_exact(&mut word_bytes)?;
-        words.push(u64::from_le_bytes(word_bytes) as usize);
+
+    let chunk_len = expected_data_len.min(BITMAP_CHUNK_BYTES);
+    let mut chunk = Vec::new();
+    chunk.try_reserve_exact(chunk_len).map_err(|e| {
+        NbdCowError::Io(std::io::Error::other(format!(
+            "bitmap read buffer allocation failed: {e}"
+        )))
+    })?;
+    chunk.resize(chunk_len, 0);
+
+    for start in (0..expected_words).step_by(BITMAP_WORDS_PER_CHUNK) {
+        let words_in_chunk = (expected_words - start).min(BITMAP_WORDS_PER_CHUNK);
+        let bytes_in_chunk = words_in_chunk * 8;
+        chunk.truncate(bytes_in_chunk);
+        file.read_exact(&mut chunk)?;
+        words.extend(chunk.chunks_exact(8).map(|word_bytes| {
+            let mut word = [0u8; 8];
+            word.copy_from_slice(word_bytes);
+            u64::from_le_bytes(word) as usize
+        }));
     }
     let mut bv = BitVec::from_vec(words);
     bv.truncate(num_blocks);

--- a/crates/nbd-cow/src/cow/tests.rs
+++ b/crates/nbd-cow/src/cow/tests.rs
@@ -443,7 +443,7 @@ fn bitmap_save_uses_documented_file_layout() {
 }
 
 #[test]
-fn bitmap_save_preserves_large_file_layout() {
+fn bitmap_large_round_trip_preserves_file_layout() {
     const WORDS_PER_64K_PAYLOAD: usize = 64 * 1024 / 8;
     const WORDS: usize = WORDS_PER_64K_PAYLOAD + 2;
     const BLOCKS: usize = WORDS * 64;
@@ -462,6 +462,9 @@ fn bitmap_save_preserves_large_file_layout() {
     assert_eq!(bitmap_word(&data, 0), 1);
     assert_eq!(bitmap_word(&data, WORDS_PER_64K_PAYLOAD), 1);
     assert_eq!(bitmap_word(&data, WORDS - 1), 1u64 << 63);
+
+    let loaded = bitmap::load_bitmap(bitmap_file.path(), BLOCKS).unwrap();
+    assert_eq!(loaded, dirty);
 }
 
 fn bitmap_word(data: &[u8], word_index: usize) -> u64 {


### PR DESCRIPTION
## Summary

- decode COW bitmap payloads in bounded 64 KiB chunks instead of issuing one buffered read per 64-bit word
- share the existing serialization chunk size while preserving the bitmap format, little-endian conversion, validation errors, and accepted trailing bytes
- extend the existing 64 KiB-plus-tail bitmap test through the real load path and compare the complete restored bitmap

## Scope

This PR changes only the `nbd-cow` decoder and its behavior coverage. It does not remove the separate duplicate bitmap validation/load in snapshot-backed COW pool preparation, change public APIs, or alter persisted data.

At the 1 TiB device limit, the 32 MiB bitmap payload now requires at most 512 chunk reads instead of 4,194,304 word-sized reads. Auxiliary decode storage is bounded at 64 KiB and allocated fallibly; no unsafe code or dependency is added.

## Benchmark

One-off optimized harness on this development container:

- Rust: `rustc 1.97.0 (2d8144b78 2026-07-07)`
- Build: `rustc -O --edition=2024`
- Input: one page-cached 32 MiB bitmap payload
- Sampling: 3 warmups, then 40 alternating samples per loop shape; decoded vectors passed through `std::hint::black_box`

| Decoder | Mean | Median | Minimum |
| --- | ---: | ---: | ---: |
| 8-byte `BufReader` loop | 17.240 ms | 17.167 ms | 16.722 ms |
| 64 KiB direct chunks | 8.333 ms | 8.357 ms | 7.828 ms |

Median speedup: **2.05x**. Absolute timings are environment-specific; automated tests assert behavior rather than wall-clock performance.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p nbd-cow --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow --all-features`
- pre-commit workspace Rust formatting, documentation, Clippy, file-size, and commit-message checks

Closes #24708
