### PR TITLE
test(sandbox-fc): guard prewarm process-group safety

### DIFF
--- a/crates/sandbox-fc/tests/prewarm_script.rs
+++ b/crates/sandbox-fc/tests/prewarm_script.rs
@@ -1,0 +1,75 @@
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use sandbox_fc::PREWARM_SCRIPT;
+
+const CLAUDE_COMMAND: &str = r#"#!/bin/sh
+printf '%s\n' CLAUDE >> "$PREWARM_TRACE"
+exit "$CLAUDE_EXIT"
+"#;
+
+const CODEX_COMMAND: &str = r#"#!/bin/sh
+printf '%s\n' CODEX >> "$PREWARM_TRACE"
+exit "$CODEX_EXIT"
+"#;
+
+const SU_COMMAND: &str = r#"#!/bin/sh
+printf '%s\n' su >> "$PREWARM_TRACE"
+exit 97
+"#;
+
+type TestResult<T> = Result<T, Box<dyn Error>>;
+
+fn write_executable(path: &Path, contents: &str) -> io::Result<()> {
+    fs::write(path, contents)?;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+}
+
+fn run_prewarm(claude_exit: u8, codex_exit: u8) -> TestResult<(Output, String)> {
+    let temp = tempfile::tempdir()?;
+    let trace = temp.path().join("trace");
+    write_executable(&temp.path().join("claude"), CLAUDE_COMMAND)?;
+    write_executable(&temp.path().join("codex"), CODEX_COMMAND)?;
+    write_executable(&temp.path().join("su"), SU_COMMAND)?;
+
+    let output = Command::new("/bin/sh")
+        .arg("-c")
+        .arg(PREWARM_SCRIPT)
+        .env_clear()
+        .env("PATH", temp.path())
+        .env("PREWARM_TRACE", &trace)
+        .env("CLAUDE_EXIT", claude_exit.to_string())
+        .env("CODEX_EXIT", codex_exit.to_string())
+        .output()?;
+    let trace = fs::read_to_string(trace)?;
+
+    Ok((output, trace))
+}
+
+#[test]
+fn prewarm_script_preserves_process_group_and_failure_isolation() -> TestResult<()> {
+    assert!(
+        !PREWARM_SCRIPT.contains("su "),
+        "PREWARM_SCRIPT must not switch users; the guest exec layer owns the user-shell wrapper"
+    );
+
+    for (claude_exit, codex_exit) in [(7, 0), (0, 9), (7, 9)] {
+        let (output, trace) = run_prewarm(claude_exit, codex_exit)?;
+
+        assert!(
+            output.status.success(),
+            "prewarm failed for claude={claude_exit}, codex={codex_exit}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            trace, "CLAUDE\nCODEX\n",
+            "both framework warmups must run without a nested user-shell wrapper"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- add a public-entry `sandbox-fc` integration test for the snapshot prewarm script
- reject nested `su` user switching and trace real shell execution through boundary fake commands
- verify Claude-only, Codex-only, and simultaneous failures remain isolated while both warmups run

## Scope

- test-only; `PREWARM_SCRIPT`, snapshot hashes, dependencies, and runtime behavior are unchanged
- no API, protocol, persisted-data, migration, or deployment compatibility changes

## Validation

- `cargo test -p sandbox-fc --test prewarm_script`
- temporarily restored the pre-#3265 double-wrapped script and confirmed the focused test fails on the nested user-shell assertion; restored the production constant afterward
- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features`
- `cargo doc -p sandbox-fc --all-features --no-deps`
- `cargo test -p sandbox-fc --all-features` (793 existing tests and 1 new integration test passed)

Closes #24711
