### PR TITLE
test(api): split canonical slack status lifecycle

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -1976,6 +1976,123 @@ describe("INT-01: Slack app deep webhook flows", () => {
         ),
       }),
     );
+    await completeSlackTriggeredRun({
+      runId: run2Id,
+      sandboxToken: claim2.sandboxToken,
+      cliAgentType: claim2.cliAgentType,
+      assistantText: "Canonical Slack answer two",
+    });
+    await flushWaitUntilAndAssert(() => {
+      expect(context.mocks.slack.chat.postMessage).toHaveBeenCalledOnce();
+      expect(context.mocks.slack.chat.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: channelId,
+          thread_ts: threadTs,
+          text: "Canonical Slack answer two",
+        }),
+      );
+    });
+    expect(firstAssistantEventsForRun(run2Id)).toHaveLength(1);
+    expect(
+      (await chat.listThreadEvents(actor, canonicalChatThreadId)).events,
+    ).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "output.message",
+          content: "Canonical Slack answer two",
+        }),
+      ]),
+    );
+    const run2 = await runs.readRun(actor, run2Id);
+    expect(run2.result?.agentSessionId).toBe(slackSessionId);
+    expect(run2.result?.agentSessionId).toBe(webSessionId);
+  });
+
+  it("keeps canonical Slack status stable across failed delivery and cancellation", async () => {
+    const actor = bdd.user();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    const runnerGroup = runs.configureRunnerGroup();
+    integrations.configureSlackAppMocks();
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+    if (!actor.orgId) {
+      throw new Error("Expected canonical Slack actor to belong to an org");
+    }
+    const orgId = actor.orgId;
+    const slackUserId = uniqueSlackUserId();
+    const { teamId, botUserId } = await integrations.installSlackWorkspace(
+      actor,
+      {
+        installerSlackUserId: slackUserId,
+      },
+    );
+    const channelId = "C_BDD_CANONICAL_STATUS";
+    const threadTs = "2902.000100";
+    const event = {
+      type: "app_mention",
+      user: slackUserId,
+      text: "<@" + botUserId + "> establish the canonical status route",
+      ts: threadTs,
+      channel: channelId,
+      channel_type: "channel",
+    };
+    const eventBody = JSON.stringify({
+      type: "event_callback",
+      team_id: teamId,
+      event_id: `EvBDD${randomUUID().replace(/-/g, "")}`,
+      event,
+    });
+    await integrations.requestSlackEvent(
+      eventBody,
+      integrations.signedSlackIngressHeaders(eventBody),
+      [200],
+    );
+    await flushWaitUntilForTest();
+
+    const state = await integrations.readSlackTestState(teamId);
+    const canonicalChatThreadId = state.chat_thread_routes[0]?.chatThreadId;
+    if (!canonicalChatThreadId) {
+      throw new Error("Expected canonical Slack status route to own a thread");
+    }
+    const run1Id = await pollSlackRun(runnerGroup);
+    const claim1 = await runs.claimRunnerJob(run1Id);
+    const queuedEventBody = JSON.stringify({
+      type: "event_callback",
+      team_id: teamId,
+      event_id: `EvBDD${randomUUID().replace(/-/g, "")}`,
+      event: {
+        ...event,
+        text: "fail this canonical Slack delivery",
+        ts: "2902.000200",
+        thread_ts: threadTs,
+      },
+    });
+    await integrations.requestSlackEvent(
+      queuedEventBody,
+      integrations.signedSlackIngressHeaders(queuedEventBody),
+      [200],
+    );
+    await flushWaitUntilForTest();
+    await completeSlackTriggeredRun({
+      runId: run1Id,
+      sandboxToken: claim1.sandboxToken,
+      cliAgentType: claim1.cliAgentType,
+      assistantText: "Canonical Slack seed answer",
+    });
+    await flushWaitUntilForTest();
+    const run1 = await runs.readRun(actor, run1Id);
+    const slackSessionId = run1.result?.agentSessionId;
+    if (!slackSessionId) {
+      throw new Error(
+        "Expected the canonical Slack seed run to save a session",
+      );
+    }
+
+    const run2Id = await pollSlackRun(runnerGroup);
+    const claim2 = await runs.claimRunnerJob(run2Id);
+    expect(claim2.resumeSession?.sessionId).toBe(`bdd-slack-cli-${run1Id}`);
+    context.mocks.slack.chat.postMessage.mockClear();
     context.mocks.slack.chat.postMessage.mockRejectedValueOnce(
       new DOMException("Slack delivery aborted", "AbortError"),
     );
@@ -2112,7 +2229,6 @@ describe("INT-01: Slack app deep webhook flows", () => {
     );
     const run2 = await runs.readRun(actor, run2Id);
     expect(run2.result?.agentSessionId).toBe(slackSessionId);
-    expect(run2.result?.agentSessionId).toBe(webSessionId);
   });
 
   it("keeps Slack DM sessions scoped to the selected agent", async () => {


### PR DESCRIPTION
## Summary

- split canonical Web/Slack session reuse from failed-delivery status and cancellation behavior
- seed the failed-delivery/status scenario independently so each behavior owns its existing 5-second test budget
- preserve the session, callback, status-overlap, telemetry, output-message, and cancellation assertions
- leave production behavior and the global test timeout unchanged

## Trigger

- Turbo run: https://github.com/vm0-ai/vm0/actions/runs/30793848264
- event: `merge_group`
- failing SHA: `bd48371260806d12b4be98c86b3392dbb2502609`
- queued PR: #24704
- first substantive failure: `test-api (4)`, `integrations.bdd.test.ts > keeps queued Web and Slack sends on one canonical session`

## Root cause

Classification: test-budget exhaustion under CI shard contention.

The test passed on the same PR head and adjacent successful runs in 1,429-1,774 ms, then took 5,141 ms and hit the global 5-second timeout. The containing file grew from 15,646-21,461 ms in those passing runs to 27,602 ms, while neighboring tests also took roughly 2-3x longer. In the failing log, the first canonical run completion took about 3.4 seconds between its permalink warning and run-summary output, versus about 0.35 seconds in a passing run.

The queued PR does not change this test or its canonical Slack/Web session implementation, and its pull-request Turbo run passed the same API shard. Aggregate gate failure was downstream, not causal.

## Fix

The queued Web/Slack session test now completes its second Slack run successfully and finishes after verifying delivery, output projection, and canonical session reuse. Failed callback delivery, overlapping terminal/thinking status updates, and cancellation now run from an independently seeded canonical Slack route in a separate test.

This gives the independent behaviors separate timeout budgets without retries, sleeps, timeout increases, or weakened assertions.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts`
- `pnpm -F api exec eslint src/signals/routes/__tests__/integrations.bdd.test.ts`
- `pnpm -F api check-types`
- pre-commit hooks: Prettier, Knip, all-package type checks, and file-size check
- `git diff --check`

Targeted Vitest execution could not start because the local API test environment could not connect to PostgreSQL on `localhost:5432`; all tests were skipped during suite initialization. No database or development server was started. The PR `test-api (4)` shard will provide runtime validation for both isolated scenarios.
