### PR TITLE
perf(api): align runner claim timing boundaries

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -158,6 +158,10 @@ const EXPECTED_ZERO_RUN_DISALLOWED_TOOLS = [
   "Skill(loop)",
   "Skill(loop *)",
 ] as const;
+const CLAIM_ROUTE_PARENT_TIMING_ACTION_TYPES = [
+  "claim_route_request_to_transition_start",
+  "claim_route_request_to_response_ready",
+] as const;
 const CLAIM_ROUTE_TOP_LEVEL_TIMING_ACTION_TYPES = [
   "claim_route_request_prepare",
   "claim_route_lookup_authorization",
@@ -179,6 +183,7 @@ const CLAIM_ROUTE_TRANSITION_TIMING_ACTION_TYPES = [
   "claim_route_transition_execute",
 ] as const;
 const CLAIM_ROUTE_TIMING_ACTION_TYPES = [
+  ...CLAIM_ROUTE_PARENT_TIMING_ACTION_TYPES,
   ...CLAIM_ROUTE_TOP_LEVEL_TIMING_ACTION_TYPES,
   ...CLAIM_ROUTE_TRANSITION_TIMING_ACTION_TYPES,
 ] as const;
@@ -3089,6 +3094,18 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const running = await api.readRun(actor, run.runId);
     expect(running.status).toBe("running");
     expect(running.startedAt).toBeDefined();
+    for (const actionType of CLAIM_ROUTE_PARENT_TIMING_ACTION_TYPES) {
+      expect(
+        singleSandboxOperationEvent(
+          claimRouteTimingEventsForRun(run.runId),
+          actionType,
+        ),
+      ).toStrictEqual(
+        expect.objectContaining({
+          span_kind: "parent",
+        }),
+      );
+    }
 
     const laterClaim = await api.requestClaimRunnerJob(true, run.runId, [404]);
     expectApiError(laterClaim.body);
@@ -10222,6 +10239,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       [500],
     );
     expect(failedClaim.status).toBe(500);
+    expect(claimRouteTimingEventsForRun(resumed.runId)).toHaveLength(0);
 
     await api.requestCancelRun(actor, resumed.runId, [200]);
   });
@@ -10293,6 +10311,17 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     for (const actionType of CLAIM_ROUTE_PREPARED_PATH_OMITTED_ACTION_TYPES) {
       expect(observedClaimRouteActionTypes).not.toContain(actionType);
     }
+    for (const actionType of CLAIM_ROUTE_PARENT_TIMING_ACTION_TYPES) {
+      const events = claimRouteTimingEvents.filter((event) => {
+        return event.op_type === actionType;
+      });
+      expect(events).toHaveLength(1);
+      expect(events[0]).toStrictEqual(
+        expect.objectContaining({
+          span_kind: "parent",
+        }),
+      );
+    }
     for (const actionType of CLAIM_ROUTE_TOP_LEVEL_TIMING_ACTION_TYPES) {
       const events = claimRouteTimingEvents.filter((event) => {
         return event.op_type === actionType;
@@ -10331,7 +10360,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       );
       expect(event.duration_ms).toStrictEqual(expect.any(Number));
       expect(Number(event.duration_ms)).toBeGreaterThanOrEqual(0);
-      expect(["top_level", "nested"]).toContain(event.span_kind);
+      expect(["parent", "top_level", "nested"]).toContain(event.span_kind);
       expect(event).not.toHaveProperty("fallback_reason");
       for (const forbiddenKey of FORBIDDEN_CLAIM_ROUTE_TIMING_KEYS) {
         expect(event).not.toHaveProperty(forbiddenKey);

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -160,7 +160,7 @@ function isResumeSessionHistoryLoadError(
   return error instanceof ResumeSessionHistoryLoadError;
 }
 
-type ClaimRouteTimingSpanKind = "top_level" | "nested";
+type ClaimRouteTimingSpanKind = "parent" | "top_level" | "nested";
 type ClaimNetworkPolicyRefreshPath =
   | "baseline"
   | "baseline_empty"
@@ -168,6 +168,8 @@ type ClaimNetworkPolicyRefreshPath =
   | "full_invalid_baseline"
   | "full_incompatible_baseline";
 type ClaimRouteTimingActionType =
+  | "claim_route_request_to_transition_start"
+  | "claim_route_request_to_response_ready"
   | "claim_route_request_prepare"
   | "claim_route_lookup_authorization"
   | "claim_route_context_parse"
@@ -1886,6 +1888,8 @@ function scheduleSuccessfulClaimSideEffects(args: {
     ),
     claimRequestToRunningMs: Math.max(
       0,
+      // This historical state boundary ends at PostgreSQL's in-transaction
+      // claimedAt, not at an application-clock route parent.
       args.claimResult.claimedAt.getTime() - args.claimRequestStartedAtMs,
     ),
     jobDiscoveredToClaimRequestMs:
@@ -2285,6 +2289,11 @@ const claimAuthorizedJob$ = command(
     }
     signal.throwIfAborted();
 
+    claimRouteTiming.recordElapsed(
+      "claim_route_request_to_transition_start",
+      "parent",
+      args.claimRequestStartedAtMs,
+    );
     const claimResult = await claimRouteTiming.measure(
       "claim_route_transition_running",
       "top_level",
@@ -2303,6 +2312,12 @@ const claimAuthorizedJob$ = command(
       return claimTransitionErrorResponse(claimResult);
     }
 
+    const response = { status: 200 as const, body: responseBodyResult.value };
+    claimRouteTiming.recordElapsed(
+      "claim_route_request_to_response_ready",
+      "parent",
+      args.claimRequestStartedAtMs,
+    );
     scheduleSuccessfulClaimSideEffects({
       jobWithRun,
       authType: args.authType,
@@ -2313,7 +2328,7 @@ const claimAuthorizedJob$ = command(
       claimRouteTiming,
     });
 
-    return { status: 200 as const, body: responseBodyResult.value };
+    return response;
   },
 );
 


### PR DESCRIPTION
## Summary

- add fixed application-clock parents from runner claim entry to transition start and response readiness
- classify cumulative actions with `span_kind: parent` so they cannot be mistaken for disjoint top-level phases
- preserve the historical PostgreSQL `claimedAt` boundary and every existing claim timing
- cover successful, failed response-build, and competing claim requests through the real API route and PostgreSQL

## Problem

The existing `claim_request_to_running` metric starts on the API application clock but ends at PostgreSQL's in-transaction `claimedAt`. `claim_route_transition_running` instead measures the complete application-observed transaction, including result decoding, validation, commit, and return after that database timestamp.

Subtracting the current application route phases from the mixed-clock historical boundary can therefore produce negative or misleading residuals. The recent request-matched difference is an attribution target, not a promised latency saving.

## Changes

Successful claims now emit two additive fixed actions:

- `claim_route_request_to_transition_start`: handler entry through successful claim response-body construction, ending immediately before the running transition
- `claim_route_request_to_response_ready`: the same entry through construction of the successful route result, ending before successful side effects are scheduled and before route return

Both use the existing collector and dimensions with `span_kind: parent`. Every record is finalized before the existing asynchronous successful-claim drain is scheduled. Failed response construction and losing concurrent claims retain the existing behavior of emitting no successful timing set.

`claim_request_to_running`, `claim_route_transition_running`, and `claim_route_transition_execute` retain their calculations and boundaries. The source now documents that the first action ends at the in-database timestamp rather than at an application parent.

For a complete successful run-matched set, production can derive:

- pre-transition unassigned time from the transition-start parent minus entered disjoint top-level phases
- transaction wrapper time from transition running minus transition execute
- post-transition response preparation from response-ready minus transition-start minus transition running

The historical database boundary remains a separate comparison and is not subtracted from application-clock parents.

## Scope and compatibility

- no claim authorization, expiry, CAS, ownership, queue deletion, response, permission freshness, resume validation, abort, cancellation, or error behavior change
- no schema, migration, persisted-state, public API, frontend, queue, runner, or GuestAgent protocol change
- no dynamic or sensitive telemetry fields and no high-cardinality dimension
- old and new API instances can overlap because the records are additive and runners do not consume them
- rollback removes only the two new action series and their fixed classification
- framework serialization, network transit, and runner response receipt remain outside this route-local boundary and require separate evidence before follow-up telemetry

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t 'returns 500 when claim response construction fails|dispatches, scopes, and claims runs through CLI PATs|allows exactly one concurrent runner claim'` (3 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (139 passed)
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api build`
- `pnpm knip --workspace api`
- pre-commit full Knip and Turbo type checks

## Post-deploy gate

Wait for one stable API revision and report complete-set count plus request-matched p50/p95/p99 for the two parents, existing route children, same-clock residuals, transaction-minus-SQL time, historical claim boundaries, `api_to_spawn`, and failures. Create behavior-changing work only if one avoidable owner is material.

Closes #24638

Parent context: #24203
