### PR TITLE
perf(python): bound firewall auth fetch admission

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -40,6 +40,7 @@ from aws_sigv4 import (
 from aws_sigv4_body_admission import MAX_AWS_SIGV4_REQUEST_BODY_BYTES
 from firewall_auth_cache import (
     FirewallAuthCacheKey,
+    FirewallAuthFetchSaturatedError,
     InvalidBillableAuthExpiryError,
     get_firewall_headers,
 )
@@ -80,6 +81,7 @@ type OrdinaryUpstreamCredentialsGuard = Callable[[], bool]
 _HTTP_STATUS_CLIENT_ERROR_MIN = 400
 _HTTP_STATUS_SERVER_ERROR_MIN = 500
 AUTH_BASE_FORWARDING_SATURATED_ERROR = "auth_base_forwarding_saturated"
+FIREWALL_AUTH_FETCH_SATURATED_ERROR = "firewall_auth_fetch_saturated"
 AWS_SIGV4_REQUEST_BODY_ADMISSION_SATURATED_ERROR = "aws_sigv4_request_body_admission_saturated"
 AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR = "aws_sigv4_request_body_length_required"
 AWS_SIGV4_REQUEST_BODY_TOO_LARGE_ERROR = "aws_sigv4_request_body_too_large"
@@ -843,6 +845,25 @@ def _set_firewall_auth_resolution_failure(
     exc: Exception,
 ) -> FirewallAuthHandlingResult:
     """Map auth-resolution exceptions to local responses and metadata."""
+    if isinstance(exc, FirewallAuthFetchSaturatedError):
+        flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] = True
+        log_proxy_entry(
+            context.proxy_log_path,
+            "warn",
+            "Firewall auth fetch admission saturated",
+            type="firewall",
+            firewall_base=context.firewall_base,
+        )
+        _set_matched_firewall_failure_response(
+            flow,
+            status=503,
+            action="ALLOW",
+            error_code=FIREWALL_AUTH_FETCH_SATURATED_ERROR,
+            message="Firewall auth is temporarily saturated",
+            permission=context.allow.name,
+        )
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
+
     if isinstance(exc, ConnectorNotConfiguredError):
         log_proxy_entry(
             context.proxy_log_path,

--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -1,4 +1,4 @@
-"""Firewall auth cache state and force-refresh lifecycle."""
+"""Firewall auth cache, fetch admission, and force-refresh lifecycle."""
 
 import asyncio
 import math
@@ -15,6 +15,10 @@ from firewall_auth_client import (
 
 class InvalidBillableAuthExpiryError(Exception):
     """Raised when billable firewall auth succeeds with an invalid cache expiry."""
+
+
+class FirewallAuthFetchSaturatedError(Exception):
+    """Raised when firewall auth fetch admission is saturated."""
 
 
 @dataclass(frozen=True)
@@ -60,6 +64,10 @@ class FirewallAuthStateSnapshotForTests:
 
 
 _auth_state: dict[FirewallAuthCacheKey, _FirewallAuthState] = {}
+MAX_CONCURRENT_FIREWALL_AUTH_FETCHES = 4
+MAX_ADMITTED_FIREWALL_AUTH_FETCHES = 16
+_admitted_firewall_auth_fetches = 0
+_firewall_auth_fetch_semaphore: asyncio.Semaphore | None = None
 
 # Cooldown window for re-marking a force-refresh. Caps amplification at
 # 30 refreshes/hour/key under a persistent non-token 401 loop — safely
@@ -141,7 +149,43 @@ def evict_all_cache_keys() -> None:
 
 def reset_cache_for_tests() -> None:
     """Reset auth cache module state between tests."""
+    global _admitted_firewall_auth_fetches
+    global _firewall_auth_fetch_semaphore
+
     _auth_state.clear()
+    _admitted_firewall_auth_fetches = 0
+    _firewall_auth_fetch_semaphore = None
+
+
+def admitted_firewall_auth_fetches_for_tests() -> int:
+    """Return the current admitted distinct fetch count for tests."""
+    return _admitted_firewall_auth_fetches
+
+
+def _reserve_firewall_auth_fetch() -> None:
+    global _admitted_firewall_auth_fetches
+
+    if _admitted_firewall_auth_fetches >= MAX_ADMITTED_FIREWALL_AUTH_FETCHES:
+        raise FirewallAuthFetchSaturatedError("firewall auth fetch admission is full")
+    _admitted_firewall_auth_fetches += 1
+
+
+def _release_firewall_auth_fetch() -> None:
+    global _admitted_firewall_auth_fetches
+
+    _admitted_firewall_auth_fetches -= 1
+
+
+def _get_firewall_auth_fetch_semaphore() -> asyncio.Semaphore:
+    global _firewall_auth_fetch_semaphore
+
+    semaphore = _firewall_auth_fetch_semaphore
+    if semaphore is None:
+        semaphore = asyncio.Semaphore(
+            MAX_CONCURRENT_FIREWALL_AUTH_FETCHES,
+        )
+        _firewall_auth_fetch_semaphore = semaphore
+    return semaphore
 
 
 def seed_cached_headers_for_tests(
@@ -276,10 +320,11 @@ async def _fetch_and_cache_firewall_headers(
 ) -> dict:
     """Own one shared fetch through completion and update its cache state."""
     try:
-        result = await fetch_firewall_headers(
-            request,
-            force_refresh=force_refresh,
-        )
+        async with _get_firewall_auth_fetch_semaphore():
+            result = await fetch_firewall_headers(
+                request,
+                force_refresh=force_refresh,
+            )
         if request.firewall_billable and not _has_valid_expiry(result.expires_at):
             raise InvalidBillableAuthExpiryError(
                 "Billable firewall auth response did not include a valid cache expiry"
@@ -304,6 +349,7 @@ async def _fetch_and_cache_firewall_headers(
         )
     finally:
         state.in_flight = None
+        _release_firewall_auth_fetch()
 
 
 async def get_firewall_headers(
@@ -333,6 +379,8 @@ async def get_firewall_headers(
         fetch_task = state.in_flight
         created_fetch = fetch_task is None
         if fetch_task is None:
+            _reserve_firewall_auth_fetch()
+
             # Consume the marker before creating the task so only this shared
             # operation can trigger the refresh. Recording before the fetch
             # preserves the intentional failed-refresh cooldown semantics.

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -214,6 +214,142 @@ class TestFirewallHeaderCache:
         }
         assert cached_tokens == {"Bearer token-1", "Bearer token-2"}
 
+    async def test_distinct_fetch_admission_bounds_active_and_waiting_work(self, mitm_ctx):
+        endpoint = FakeAuthEndpoint()
+        release_first = threading.Event()
+        release_second = threading.Event()
+        endpoint.queue_json_response(
+            firewall_auth_success_response(
+                {"Authorization": "Bearer token-1"},
+                expires_at=time.time() + 3600,
+            ),
+            release_event=release_first,
+        )
+        endpoint.queue_json_response(
+            firewall_auth_success_response(
+                {"Authorization": "Bearer token-2"},
+                expires_at=time.time() + 3600,
+            ),
+            release_event=release_second,
+        )
+        endpoint.queue_json_response(
+            firewall_auth_success_response(
+                {"Authorization": "Bearer token-3"},
+                expires_at=time.time() + 3600,
+            )
+        )
+        auth_request = _firewall_auth_request(auth_headers={"Authorization": "template"})
+        first_key = auth_cache_key(api_id="api-1")
+        second_key = auth_cache_key(api_id="api-2")
+        third_key = auth_cache_key(api_id="api-3")
+        mark_force_refresh(third_key)
+
+        tasks: list[asyncio.Task[dict]] = []
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(auth_cache, "MAX_CONCURRENT_FIREWALL_AUTH_FETCHES", 1),
+            patch.object(auth_cache, "MAX_ADMITTED_FIREWALL_AUTH_FETCHES", 2),
+        ):
+            first = asyncio.create_task(auth_cache.get_firewall_headers(first_key, auth_request))
+            tasks.append(first)
+            try:
+                assert await asyncio.to_thread(endpoint.wait_for_request_count, 1)
+
+                follower = asyncio.create_task(
+                    auth_cache.get_firewall_headers(first_key, auth_request)
+                )
+                second = asyncio.create_task(
+                    auth_cache.get_firewall_headers(second_key, auth_request)
+                )
+                tasks.extend((follower, second))
+                await asyncio.sleep(0)
+
+                assert auth_cache.admitted_firewall_auth_fetches_for_tests() == 2
+                assert endpoint.request_count == 1
+                with pytest.raises(auth_cache.FirewallAuthFetchSaturatedError):
+                    await auth_cache.get_firewall_headers(third_key, auth_request)
+                assert endpoint.request_count == 1
+                assert force_refresh_pending(third_key)
+
+                release_first.set()
+                first_result, follower_result = await asyncio.gather(first, follower)
+                assert await asyncio.to_thread(endpoint.wait_for_request_count, 2)
+                assert endpoint.request_count == 2
+
+                release_second.set()
+                second_result = await second
+                assert auth_cache.admitted_firewall_auth_fetches_for_tests() == 0
+
+                third_result = await auth_cache.get_firewall_headers(third_key, auth_request)
+            finally:
+                release_first.set()
+                release_second.set()
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+        assert first_result["headers"] == {"Authorization": "Bearer token-1"}
+        assert first_result["cache_hit"] is False
+        assert follower_result["headers"] == {"Authorization": "Bearer token-1"}
+        assert follower_result["cache_hit"] is True
+        assert second_result["headers"] == {"Authorization": "Bearer token-2"}
+        assert third_result["headers"] == {"Authorization": "Bearer token-3"}
+        assert endpoint.request_count == 3
+        assert endpoint.requests[2].json_body()["forceRefresh"] is True
+        assert not force_refresh_pending(third_key)
+
+    async def test_cancelled_leader_keeps_admission_until_shared_failure(self, mitm_ctx):
+        endpoint = FakeAuthEndpoint()
+        release_failure = threading.Event()
+        endpoint.queue_response(500, body=b"not-json", release_event=release_failure)
+        endpoint.queue_json_response(
+            firewall_auth_success_response(
+                {"Authorization": "Bearer recovered"},
+                expires_at=time.time() + 3600,
+            )
+        )
+        auth_request = _firewall_auth_request(auth_headers={"Authorization": "template"})
+        first_key = auth_cache_key(api_id="api-1")
+        second_key = auth_cache_key(api_id="api-2")
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(auth_cache, "MAX_CONCURRENT_FIREWALL_AUTH_FETCHES", 1),
+            patch.object(auth_cache, "MAX_ADMITTED_FIREWALL_AUTH_FETCHES", 1),
+        ):
+            leader = asyncio.create_task(auth_cache.get_firewall_headers(first_key, auth_request))
+            follower = None
+            try:
+                assert await asyncio.to_thread(endpoint.wait_for_request_count, 1)
+                leader.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await leader
+
+                follower = asyncio.create_task(
+                    auth_cache.get_firewall_headers(first_key, auth_request)
+                )
+                await asyncio.sleep(0)
+                assert auth_cache.admitted_firewall_auth_fetches_for_tests() == 1
+                with pytest.raises(auth_cache.FirewallAuthFetchSaturatedError):
+                    await auth_cache.get_firewall_headers(second_key, auth_request)
+                assert endpoint.request_count == 1
+
+                release_failure.set()
+                with pytest.raises(urllib.error.HTTPError):
+                    await follower
+                assert auth_cache.admitted_firewall_auth_fetches_for_tests() == 0
+
+                recovered = await auth_cache.get_firewall_headers(second_key, auth_request)
+            finally:
+                release_failure.set()
+                tasks = [task for task in (leader, follower) if task is not None]
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+        assert recovered["headers"] == {"Authorization": "Bearer recovered"}
+        assert recovered["cache_hit"] is False
+        assert endpoint.request_count == 2
+        assert auth_cache.admitted_firewall_auth_fetches_for_tests() == 0
+
     async def test_same_run_and_api_with_different_auth_identities_fetch_independently(
         self, mitm_ctx
     ):

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -238,7 +238,7 @@ class TestFirewallHeaderCache:
                 expires_at=time.time() + 3600,
             )
         )
-        auth_request = _firewall_auth_request(auth_headers={"Authorization": "template"})
+        auth_request = firewall_auth_request(auth_headers={"Authorization": "template"})
         first_key = auth_cache_key(api_id="api-1")
         second_key = auth_cache_key(api_id="api-2")
         third_key = auth_cache_key(api_id="api-3")
@@ -256,14 +256,19 @@ class TestFirewallHeaderCache:
             try:
                 assert await asyncio.to_thread(endpoint.wait_for_request_count, 1)
 
-                follower = asyncio.create_task(
-                    auth_cache.get_firewall_headers(first_key, auth_request)
-                )
-                second = asyncio.create_task(
-                    auth_cache.get_firewall_headers(second_key, auth_request)
-                )
+                follower_started = asyncio.Event()
+                second_started = asyncio.Event()
+
+                async def fetch_after_start(
+                    started: asyncio.Event, cache_key: auth_cache.FirewallAuthCacheKey
+                ) -> dict:
+                    started.set()
+                    return await auth_cache.get_firewall_headers(cache_key, auth_request)
+
+                follower = asyncio.create_task(fetch_after_start(follower_started, first_key))
+                second = asyncio.create_task(fetch_after_start(second_started, second_key))
                 tasks.extend((follower, second))
-                await asyncio.sleep(0)
+                await asyncio.gather(follower_started.wait(), second_started.wait())
 
                 assert auth_cache.admitted_firewall_auth_fetches_for_tests() == 2
                 assert endpoint.request_count == 1
@@ -307,7 +312,7 @@ class TestFirewallHeaderCache:
                 expires_at=time.time() + 3600,
             )
         )
-        auth_request = _firewall_auth_request(auth_headers={"Authorization": "template"})
+        auth_request = firewall_auth_request(auth_headers={"Authorization": "template"})
         first_key = auth_cache_key(api_id="api-1")
         second_key = auth_cache_key(api_id="api-2")
 
@@ -325,10 +330,14 @@ class TestFirewallHeaderCache:
                 with pytest.raises(asyncio.CancelledError):
                     await leader
 
-                follower = asyncio.create_task(
-                    auth_cache.get_firewall_headers(first_key, auth_request)
-                )
-                await asyncio.sleep(0)
+                follower_started = asyncio.Event()
+
+                async def follow_shared_fetch() -> dict:
+                    follower_started.set()
+                    return await auth_cache.get_firewall_headers(first_key, auth_request)
+
+                follower = asyncio.create_task(follow_shared_fetch())
+                await follower_started.wait()
                 assert auth_cache.admitted_firewall_auth_fetches_for_tests() == 1
                 with pytest.raises(auth_cache.FirewallAuthFetchSaturatedError):
                     await auth_cache.get_firewall_headers(second_key, auth_request)

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
@@ -14,7 +14,7 @@ import firewall_auth_client as auth_client
 import flow_metadata_keys as metadata_keys
 import matching
 import platform_api
-from tests.auth_endpoint_helpers import firewall_auth_success_response
+from tests.auth_endpoint_helpers import FakeAuthEndpoint, firewall_auth_success_response
 from tests.auth_state_helpers import cached_headers
 from tests.aws_sigv4_helpers import (
     DEFAULT_SIGV4_TIMESTAMP,
@@ -652,6 +652,52 @@ class TestHandleFirewallRequest:
             await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is False
+
+    async def test_fetch_admission_saturation_returns_redacted_503(
+        self, real_flow, mitm_ctx, tmp_path
+    ):
+        encrypted_secrets = "encrypted-sensitive-payload"
+        sandbox_token = "sensitive-sandbox-token"
+        flow = _firewall_flow(real_flow)
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
+        endpoint = FakeAuthEndpoint()
+        api_entry = _api_entry()
+        vm_info = _vm_info(
+            tmp_path,
+            encrypted_secrets=encrypted_secrets,
+            sandbox_marker=sandbox_token,
+        )
+        allow = _allow(api_entry)
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(auth_cache, "MAX_ADMITTED_FIREWALL_AUTH_FETCHES", 0),
+        ):
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+        assert endpoint.request_count == 0
+        assert flow.response is not None
+        assert flow.response.status_code == 503
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert (
+            flow.metadata[metadata_keys.FIREWALL_ERROR] == auth.FIREWALL_AUTH_FETCH_SATURATED_ERROR
+        )
+        assert flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] is True
+        assert "Authorization" not in flow.request.headers
+        body = json.loads(flow.response.content)
+        assert body == {
+            "error": "firewall_auth_fetch_saturated",
+            "message": "Firewall auth is temporarily saturated",
+            "permission": "github",
+            "base": "https://api.github.com",
+        }
+        log_text = await asyncio.to_thread(read_jsonl_text_after_flush, proxy_log_path)
+        assert "Firewall auth fetch admission saturated" in log_text
+        assert encrypted_secrets not in log_text
+        assert sandbox_token not in log_text
 
     async def test_failure_returns_502(self, real_flow, headers, mitm_ctx, tmp_path):
         flow = _firewall_flow(real_flow)


### PR DESCRIPTION
## Summary

- cap firewall-auth work at 16 admitted distinct cache misses and 4 active client submissions
- charge capacity to the per-key shared fetch so same-key followers continue to coalesce
- reject excess keys before `asyncio.to_thread()` with a redacted HTTP 503 diagnostic
- preserve force-refresh state across saturation and release capacity after success, failure, or waiter cancellation

## Scope

This PR keeps the existing `urllib` client and global default executor. It does not implement the per-fetch absolute deadline tracked by #24713 and does not add a dedicated worker pool, runtime configuration, feature switch, schema change, persisted state, protocol change, migration, or cleanup task.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`4578 passed`)

Closes #24714
