### PR TITLE
test(runner): bound local submit rendezvous

### DIFF
--- a/crates/runner/src/cmd/local/submit/tests/completed_cleanup.rs
+++ b/crates/runner/src/cmd/local/submit/tests/completed_cleanup.rs
@@ -1,7 +1,7 @@
 use std::process::ExitCode;
 
-use super::super::{SubmitArgs, run_submit_with_home};
-use super::support::{submit_queue_entry, wait_for_job_and_write_result, write_queue_job_file};
+use super::super::SubmitArgs;
+use super::support::{run_submit_and_write_result, submit_queue_entry, write_queue_job_file};
 use crate::ids::RunId;
 use crate::local_queue;
 use crate::paths::HomePaths;
@@ -12,14 +12,8 @@ async fn submit_returns_failure_for_nonzero_job_response() {
     let home = HomePaths::with_root(dir.path().to_path_buf());
     let group = "test/group";
     let group_dir = home.groups_dir().join(group);
-    let watcher = tokio::spawn(wait_for_job_and_write_result(
-        group_dir.clone(),
-        crate::profile::DEFAULT_PROFILE.to_owned(),
-        42,
-        Some("agent failed".into()),
-    ));
 
-    let code = run_submit_with_home(
+    let (code, request) = run_submit_and_write_result(
         SubmitArgs {
             group: group.into(),
             prompt: "hello".into(),
@@ -34,10 +28,11 @@ async fn submit_returns_failure_for_nonzero_job_response() {
             active_inputs: vec![],
         },
         home,
+        42,
+        Some("agent failed".into()),
     )
     .await
     .unwrap();
-    let request = watcher.await.unwrap();
     let result_path = local_queue::result_path(&group_dir, request.job_id);
 
     assert_eq!(code, ExitCode::FAILURE);

--- a/crates/runner/src/cmd/local/submit/tests/request.rs
+++ b/crates/runner/src/cmd/local/submit/tests/request.rs
@@ -1,7 +1,7 @@
 use std::process::ExitCode;
 
 use super::super::{SubmitArgs, run_submit_with_home};
-use super::support::{submit_args_for_test, wait_for_job_and_write_success};
+use super::support::{run_submit_and_write_success, submit_args_for_test};
 use crate::paths::HomePaths;
 
 #[tokio::test]
@@ -9,13 +9,8 @@ async fn submit_defaults_profile_and_writes_default_partition() {
     let dir = tempfile::tempdir().unwrap();
     let home = HomePaths::with_root(dir.path().to_path_buf());
     let group = "test/group";
-    let group_dir = home.groups_dir().join(group);
-    let watcher = tokio::spawn(wait_for_job_and_write_success(
-        group_dir,
-        crate::profile::DEFAULT_PROFILE.to_owned(),
-    ));
 
-    let code = run_submit_with_home(
+    let (code, request) = run_submit_and_write_success(
         SubmitArgs {
             group: group.into(),
             prompt: "hello".into(),
@@ -33,7 +28,6 @@ async fn submit_defaults_profile_and_writes_default_partition() {
     )
     .await
     .unwrap();
-    let request = watcher.await.unwrap();
 
     assert_eq!(code, ExitCode::SUCCESS);
     assert_eq!(request.prompt, "hello");
@@ -50,13 +44,8 @@ async fn submit_writes_non_default_profile_partition() {
     let home = HomePaths::with_root(dir.path().to_path_buf());
     let group = "test/group";
     let profile = "vm0/large";
-    let group_dir = home.groups_dir().join(group);
-    let watcher = tokio::spawn(wait_for_job_and_write_success(
-        group_dir,
-        profile.to_owned(),
-    ));
 
-    let code = run_submit_with_home(
+    let (code, request) = run_submit_and_write_success(
         SubmitArgs {
             group: group.into(),
             prompt: "hello".into(),
@@ -74,7 +63,6 @@ async fn submit_writes_non_default_profile_partition() {
     )
     .await
     .unwrap();
-    let request = watcher.await.unwrap();
 
     assert_eq!(code, ExitCode::SUCCESS);
     assert_eq!(request.profile.as_deref(), Some(profile));
@@ -85,13 +73,8 @@ async fn submit_serializes_feature_flags_and_identity_fields() {
     let dir = tempfile::tempdir().unwrap();
     let home = HomePaths::with_root(dir.path().to_path_buf());
     let group = "test/group";
-    let group_dir = home.groups_dir().join(group);
-    let watcher = tokio::spawn(wait_for_job_and_write_success(
-        group_dir,
-        crate::profile::DEFAULT_PROFILE.to_owned(),
-    ));
 
-    let code = run_submit_with_home(
+    let (code, request) = run_submit_and_write_success(
         SubmitArgs {
             group: group.into(),
             prompt: "hello".into(),
@@ -109,7 +92,6 @@ async fn submit_serializes_feature_flags_and_identity_fields() {
     )
     .await
     .unwrap();
-    let request = watcher.await.unwrap();
     let flags = request.feature_flags.as_ref().unwrap();
 
     assert_eq!(code, ExitCode::SUCCESS);
@@ -129,13 +111,8 @@ async fn submit_keeps_session_only_job_without_reuse_key() {
     let dir = tempfile::tempdir().unwrap();
     let home = HomePaths::with_root(dir.path().to_path_buf());
     let group = "test/group";
-    let group_dir = home.groups_dir().join(group);
-    let watcher = tokio::spawn(wait_for_job_and_write_success(
-        group_dir,
-        crate::profile::DEFAULT_PROFILE.to_owned(),
-    ));
 
-    let code = run_submit_with_home(
+    let (code, request) = run_submit_and_write_success(
         SubmitArgs {
             group: group.into(),
             prompt: "hello".into(),
@@ -153,7 +130,6 @@ async fn submit_keeps_session_only_job_without_reuse_key() {
     )
     .await
     .unwrap();
-    let request = watcher.await.unwrap();
 
     assert_eq!(code, ExitCode::SUCCESS);
     assert_eq!(request.session_id.as_deref(), Some("sess-123"));
@@ -165,11 +141,6 @@ async fn submit_serializes_env_and_secret_env() {
     let dir = tempfile::tempdir().unwrap();
     let home = HomePaths::with_root(dir.path().to_path_buf());
     let group = "test/group";
-    let group_dir = home.groups_dir().join(group);
-    let watcher = tokio::spawn(wait_for_job_and_write_success(
-        group_dir,
-        crate::profile::DEFAULT_PROFILE.to_owned(),
-    ));
 
     let mut args = submit_args_for_test();
     args.group = group.into();
@@ -186,8 +157,7 @@ async fn submit_serializes_env_and_secret_env() {
         "PRIVATE_KEY=-----BEGIN KEY-----\r\nsecret\r\n-----END KEY-----".into(),
     ];
 
-    let code = run_submit_with_home(args, home).await.unwrap();
-    let request = watcher.await.unwrap();
+    let (code, request) = run_submit_and_write_success(args, home).await.unwrap();
     let environment = request.environment.as_ref().unwrap();
     let secret_environment = request.secret_environment.as_ref().unwrap();
 

--- a/crates/runner/src/cmd/local/submit/tests/support.rs
+++ b/crates/runner/src/cmd/local/submit/tests/support.rs
@@ -1,9 +1,15 @@
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::time::Duration;
 
-use super::super::{SubmitArgs, SubmitQueueEntry};
+use super::super::{SubmitArgs, SubmitQueueEntry, run_submit_with_home};
 use crate::ids::RunId;
 use crate::local_queue::{self, JobRequest, JobResponse};
+use crate::paths::HomePaths;
+
+const TEST_SUBMIT_RENDEZVOUS_TIMEOUT: Duration = Duration::from_secs(5);
+const TEST_SUBMIT_QUEUE_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
 pub(super) fn submit_queue_entry(group_dir: &Path, job_id: RunId) -> SubmitQueueEntry {
     SubmitQueueEntry::for_job(group_dir, crate::profile::DEFAULT_PROFILE, job_id).unwrap()
@@ -20,7 +26,7 @@ pub(super) fn mode(path: &Path) -> u32 {
     std::fs::metadata(path).unwrap().permissions().mode() & 0o777
 }
 
-pub(super) async fn wait_for_job_and_write_result(
+async fn wait_for_job_and_write_result(
     group_dir: std::path::PathBuf,
     profile: String,
     exit_code: i32,
@@ -48,15 +54,88 @@ pub(super) async fn wait_for_job_and_write_result(
             }
         }
 
-        tokio::task::yield_now().await;
+        tokio::time::sleep(TEST_SUBMIT_QUEUE_POLL_INTERVAL).await;
     }
 }
 
-pub(super) async fn wait_for_job_and_write_success(
-    group_dir: std::path::PathBuf,
-    profile: String,
-) -> JobRequest {
-    wait_for_job_and_write_result(group_dir, profile, 0, None).await
+fn observed_queue_entries(group_dir: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut directories = vec![group_dir.to_owned()];
+    let mut entries = Vec::new();
+    while let Some(directory) = directories.pop() {
+        for entry in std::fs::read_dir(directory)? {
+            let entry = entry?;
+            let path = entry.path();
+            if entry.file_type()?.is_dir() {
+                directories.push(path.clone());
+            }
+            entries.push(path.strip_prefix(group_dir).unwrap().to_owned());
+        }
+    }
+    entries.sort();
+    Ok(entries)
+}
+
+async fn run_submit_and_write_result_with_timeout(
+    args: SubmitArgs,
+    home: HomePaths,
+    profile: &str,
+    exit_code: i32,
+    error: Option<String>,
+    timeout: Duration,
+) -> Result<(ExitCode, JobRequest), String> {
+    let group = args.group.clone();
+    let group_dir = home.groups_dir().join(&group);
+    let watched_group_dir = group_dir.clone();
+    let profile = profile.to_owned();
+    let watched_profile = profile.clone();
+    let rendezvous = async move {
+        tokio::try_join!(run_submit_with_home(args, home), async move {
+            Ok::<JobRequest, crate::error::RunnerError>(
+                wait_for_job_and_write_result(watched_group_dir, watched_profile, exit_code, error)
+                    .await,
+            )
+        })
+    };
+
+    match tokio::time::timeout(timeout, rendezvous).await {
+        Ok(Ok(result)) => Ok(result),
+        Ok(Err(error)) => Err(format!(
+            "local submit failed during test rendezvous (group: {group}, profile: {profile}): {error}"
+        )),
+        Err(_) => Err(format!(
+            "local submit test rendezvous timed out after {timeout:?} (group: {group}, profile: {profile}, observed queue entries: {:?})",
+            observed_queue_entries(&group_dir)
+        )),
+    }
+}
+
+pub(super) async fn run_submit_and_write_result(
+    args: SubmitArgs,
+    home: HomePaths,
+    exit_code: i32,
+    error: Option<String>,
+) -> Result<(ExitCode, JobRequest), String> {
+    let profile = args
+        .profile
+        .as_deref()
+        .unwrap_or(crate::profile::DEFAULT_PROFILE)
+        .to_owned();
+    run_submit_and_write_result_with_timeout(
+        args,
+        home,
+        &profile,
+        exit_code,
+        error,
+        TEST_SUBMIT_RENDEZVOUS_TIMEOUT,
+    )
+    .await
+}
+
+pub(super) async fn run_submit_and_write_success(
+    args: SubmitArgs,
+    home: HomePaths,
+) -> Result<(ExitCode, JobRequest), String> {
+    run_submit_and_write_result(args, home, 0, None).await
 }
 
 pub(super) fn submit_args_for_test() -> SubmitArgs {
@@ -73,4 +152,55 @@ pub(super) fn submit_args_for_test() -> SubmitArgs {
         timeout: 1,
         active_inputs: vec![],
     }
+}
+
+#[tokio::test]
+async fn submit_rendezvous_timeout_reports_queue_context() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = HomePaths::with_root(dir.path().to_path_buf());
+    let mut args = submit_args_for_test();
+    args.timeout = super::super::MAX_LOCAL_SUBMIT_TIMEOUT_SECS;
+
+    let result =
+        run_submit_and_write_result_with_timeout(args, home, "vm0/large", 0, None, Duration::ZERO)
+            .await;
+    let error = match result {
+        Ok(_) => panic!("expected local submit test rendezvous to time out"),
+        Err(error) => error,
+    };
+
+    assert!(error.contains("group: test/group"), "got: {error}");
+    assert!(error.contains("profile: vm0/large"), "got: {error}");
+    assert!(error.contains("jobs/vm0/default"), "got: {error}");
+    assert!(error.contains(".job"), "got: {error}");
+}
+
+#[tokio::test]
+async fn submit_rendezvous_surfaces_submit_error_before_deadline() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = HomePaths::with_root(dir.path().to_path_buf());
+    let mut args = submit_args_for_test();
+    args.feature_flags = vec!["missing-equals".to_owned()];
+    args.timeout = super::super::MAX_LOCAL_SUBMIT_TIMEOUT_SECS;
+
+    let result = run_submit_and_write_result_with_timeout(
+        args,
+        home,
+        crate::profile::DEFAULT_PROFILE,
+        0,
+        None,
+        Duration::ZERO,
+    )
+    .await;
+    let error = match result {
+        Ok(_) => panic!("expected local submit validation to fail"),
+        Err(error) => error,
+    };
+
+    assert!(
+        error.contains("local submit failed during test rendezvous"),
+        "got: {error}"
+    );
+    assert!(error.contains("expected key=value"), "got: {error}");
+    assert!(!error.contains("timed out"), "got: {error}");
 }

--- a/crates/runner/src/cmd/local/submit/tests/validation.rs
+++ b/crates/runner/src/cmd/local/submit/tests/validation.rs
@@ -1,7 +1,7 @@
 use std::process::ExitCode;
 
 use super::super::{MAX_LOCAL_SUBMIT_TIMEOUT_SECS, SubmitArgs, run_submit_with_home};
-use super::support::{submit_args_for_test, wait_for_job_and_write_success};
+use super::support::{run_submit_and_write_success, submit_args_for_test};
 use crate::error::RunnerError;
 use crate::local_queue;
 use crate::paths::HomePaths;
@@ -130,17 +130,11 @@ async fn maximum_timeout_is_accepted() {
     let dir = tempfile::tempdir().unwrap();
     let home = HomePaths::with_root(dir.path().to_path_buf());
     let group = "test/group";
-    let group_dir = home.groups_dir().join(group);
     let mut args = submit_args_for_test();
     args.group = group.into();
     args.timeout = MAX_LOCAL_SUBMIT_TIMEOUT_SECS;
-    let watcher = tokio::spawn(wait_for_job_and_write_success(
-        group_dir,
-        crate::profile::DEFAULT_PROFILE.to_owned(),
-    ));
 
-    let code = run_submit_with_home(args, home).await.unwrap();
-    let request = watcher.await.unwrap();
+    let (code, request) = run_submit_and_write_success(args, home).await.unwrap();
 
     assert_eq!(code, ExitCode::SUCCESS);
     assert_eq!(request.prompt, "hello");


### PR DESCRIPTION
## Summary

- bound local-submit test submit/observer rendezvous under one five-second owner without detached Tokio tasks
- report the group, derived profile, and sorted relative queue entries when the test deadline expires
- migrate all seven shared observer callers while preserving the 86,400-second timeout validation
- cover both deadline diagnostics and prompt submit-error propagation with deterministic zero-budget regressions

## Scope

This is test-only. It does not change production local-submit behavior, queue formats, APIs, schemas, migrations, configuration, or deployment contracts.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo test -p runner cmd::local::submit::tests::support`
- `cd crates && cargo test -p runner`
- `cd crates && cargo clippy -p runner --all-targets --all-features`
- `cd crates && cargo doc -p runner --all-features --no-deps`
- `git diff --check`
- `scripts/check-file-size.sh crates/runner/src/cmd/local/submit/tests/support.rs crates/runner/src/cmd/local/submit/tests/request.rs crates/runner/src/cmd/local/submit/tests/validation.rs crates/runner/src/cmd/local/submit/tests/completed_cleanup.rs`

Closes #24712
