### PR TITLE
feat(api): publish canonical runner reuse preference

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -2291,7 +2291,16 @@ mod tests {
                         "historyGenerationRunId": history_generation_run_id,
                         "historyGenerationAffinityProtectedUntil": "2999-01-01T00:00:00.000Z",
                         "affinityProtectedUntil": "2999-01-01T00:00:00.000Z",
-                        "sessionAffinityResource": "reusableSandbox"
+                        "sessionAffinityResource": "reusableSandbox",
+                        // Old runners must ignore the additive preference during rollout.
+                        "runnerPreference": {
+                            "runnerIdentity": {
+                                "runnerId": "00000000-0000-0000-0000-000000000005",
+                                "heartbeatGeneration": 7
+                            },
+                            "reason": "exactHistoryGeneration",
+                            "expiresAt": "2999-01-01T00:00:00.000Z"
+                        }
                     }
                 }));
             })

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -1896,7 +1896,16 @@ mod tests {
                 "historyGenerationRunId": "00000000-0000-0000-0000-000000000098",
                 "historyGenerationAffinityProtectedUntil": "2999-01-01T00:00:00.000Z",
                 "affinityProtectedUntil": "2999-01-01T00:00:00.000Z",
-                "sessionAffinityResource": "workspaceCache"
+                "sessionAffinityResource": "workspaceCache",
+                // Old runners must ignore the additive preference during rollout.
+                "runnerPreference": {
+                    "runnerIdentity": {
+                        "runnerId": "00000000-0000-0000-0000-000000000005",
+                        "heartbeatGeneration": 7
+                    },
+                    "reason": "matchingReuseKey",
+                    "expiresAt": "2999-01-01T00:00:00.000Z"
+                }
             }),
         );
 

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -4,7 +4,10 @@ import type {
   BrowserSessionChangedPayload,
   ConnectorChangedPayload,
 } from "@vm0/api-contracts/contracts/realtime";
-import type { SessionAffinityResource } from "@vm0/api-contracts/contracts/runners";
+import type {
+  RunnerPreference,
+  SessionAffinityResource,
+} from "@vm0/api-contracts/contracts/runners";
 import type { ZeroBuiltInGenerationRealtimeSubscription } from "@vm0/api-contracts/contracts/zero-built-in-generation";
 
 import { env } from "../../lib/env";
@@ -379,6 +382,7 @@ export async function publishRunnerJobNotification(
     readonly affinityProtectedUntil: string | null;
     readonly sessionAffinityResource: SessionAffinityResource | null;
     readonly historyGenerationRunId: string | undefined;
+    readonly runnerPreference: RunnerPreference | null;
   },
 ): Promise<boolean> {
   const published = await tapError(
@@ -405,6 +409,9 @@ export async function publishRunnerJobNotification(
           : {}),
         ...(metadata?.historyGenerationRunId
           ? { historyGenerationRunId: metadata.historyGenerationRunId }
+          : {}),
+        ...(metadata?.runnerPreference
+          ? { runnerPreference: metadata.runnerPreference }
           : {}),
       });
       L.debug(`Published job ${runId} to runner-group:${group} (broadcast)`);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -145,6 +145,12 @@ function sessionAffinityResource(
   return job?.sessionAffinityResource;
 }
 
+function runnerPreference(
+  job: RunnerJob | null | undefined,
+): RunnerJob["runnerPreference"] {
+  return job?.runnerPreference;
+}
+
 const CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET = "zero web upload-file -f <path>";
 const API_DISPATCH_ATOMIC_PERSISTENCE_ACTION_TYPES = [
   "api_dispatch_persist_atomic_launch",
@@ -3562,6 +3568,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(poll.body.job?.cliAgentSessionId).toBe(cliAgentSessionId);
     expect(poll.body.job?.reuseKey).toBeNull();
     expect(sessionAffinityProtectedUntil(poll.body.job)).toBeNull();
+    expect(runnerPreference(poll.body.job)).toBeUndefined();
 
     const resumedClaim = await api.claimRunnerJob(resumed.runId);
     expect(resumedClaim.reuseKey).toBeNull();
@@ -3692,6 +3699,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(
       sessionAffinityResource(canonicalHeartbeatHolder.job),
     ).toBeUndefined();
+    expect(runnerPreference(canonicalHeartbeatHolder.job)).toBeUndefined();
 
     await api.requestHeartbeatRunner(true, [200], {
       runnerId: affinityRunnerId,
@@ -3717,6 +3725,14 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "workspaceCache",
     );
     expect(workspaceOnlyHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
+    expect(runnerPreference(workspaceOnlyHolder.job)).toStrictEqual({
+      runnerIdentity: {
+        runnerId: affinityRunnerId,
+        heartbeatGeneration: 1,
+      },
+      reason: "matchingReuseKey",
+      expiresAt: sessionAffinityProtectedUntil(workspaceOnlyHolder.job),
+    });
     await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
       workspaceCaches: [
@@ -3754,11 +3770,23 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(sessionAffinityResource(reusableOverWorkspace.job)).toBe(
       "reusableSandbox",
     );
+    const reusablePreference = {
+      runnerIdentity: {
+        runnerId: reusableRunnerId,
+        heartbeatGeneration: 1,
+      },
+      reason: "matchingReuseKey" as const,
+      expiresAt: sessionAffinityProtectedUntil(reusableOverWorkspace.job),
+    };
+    expect(runnerPreference(reusableOverWorkspace.job)).toStrictEqual(
+      reusablePreference,
+    );
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "job",
       expect.objectContaining({
         runId: reusableOverWorkspace.run.runId,
         sessionAffinityResource: "reusableSandbox",
+        runnerPreference: reusablePreference,
       }),
     );
     await api.requestHeartbeatRunner(true, [200], {
@@ -3783,6 +3811,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(
       sessionAffinityResource(mismatchedCapableWorkspace.job),
     ).toBeUndefined();
+    expect(runnerPreference(mismatchedCapableWorkspace.job)).toBeUndefined();
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -3803,6 +3832,14 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(
       historyGenerationAffinityProtectedUntil(differentGenerationHolder.job),
     ).toBeNull();
+    expect(runnerPreference(differentGenerationHolder.job)).toStrictEqual({
+      runnerIdentity: {
+        runnerId: affinityRunnerId,
+        heartbeatGeneration: 1,
+      },
+      reason: "matchingReuseKey",
+      expiresAt: sessionAffinityProtectedUntil(differentGenerationHolder.job),
+    });
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -3823,6 +3860,16 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(sessionAffinityResource(exactGenerationHolder.job)).toBe(
       "reusableSandbox",
     );
+    expect(runnerPreference(exactGenerationHolder.job)).toStrictEqual({
+      runnerIdentity: {
+        runnerId: affinityRunnerId,
+        heartbeatGeneration: 1,
+      },
+      reason: "exactHistoryGeneration",
+      expiresAt: historyGenerationAffinityProtectedUntil(
+        exactGenerationHolder.job,
+      ),
+    });
 
     for (const { runId, resource } of [
       {
@@ -3871,6 +3918,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
     expect(startingHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
     expect(sessionAffinityProtectedUntil(startingHolder.job)).toBeNull();
+    expect(runnerPreference(startingHolder.job)).toBeUndefined();
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -3881,6 +3929,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
     expect(unavailableHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
     expect(sessionAffinityProtectedUntil(unavailableHolder.job)).toBeNull();
+    expect(runnerPreference(unavailableHolder.job)).toBeUndefined();
     const unavailableClaim = await api.claimRunnerJob(
       unavailableHolder.run.runId,
     );
@@ -3915,6 +3964,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(staleHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
     expect(sessionAffinityProtectedUntil(staleHolder.job)).toBeNull();
     expect(historyGenerationAffinityProtectedUntil(staleHolder.job)).toBeNull();
+    expect(runnerPreference(staleHolder.job)).toBeUndefined();
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -3935,6 +3985,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(
       historyGenerationAffinityProtectedUntil(profileIncompatibleHolder.job),
     ).toBeNull();
+    expect(runnerPreference(profileIncompatibleHolder.job)).toBeUndefined();
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -3952,11 +4003,13 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(
       historyGenerationAffinityProtectedUntil(drainingHolder.job),
     ).toBeNull();
+    expect(runnerPreference(drainingHolder.job)).toBeUndefined();
   });
 
   it("preserves same-thread affinity timing across queued admission", async () => {
     const {
       actor,
+      affinityRunnerId,
       agentId,
       api,
       cliAgentSessionId,
@@ -3975,6 +4028,28 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         historyGenerationRunId: first.runId,
       },
     });
+    const equivalentExactRunnerId = randomUUID();
+    await api.requestHeartbeatRunner(true, [200], {
+      runnerId: equivalentExactRunnerId,
+      group: runnerGroup,
+      snapshotGeneration: 7,
+      snapshotSequence: 1,
+      admittableProfiles: [],
+      heldSandboxStates: [
+        {
+          reuseKey,
+          lastCompletedAt: nowDate().toISOString(),
+          reusableSandbox: {
+            profile: "vm0/default",
+            historyGenerationRunId: first.runId,
+          },
+        },
+      ],
+    });
+    const preferredExactRunner =
+      affinityRunnerId < equivalentExactRunnerId
+        ? { runnerId: affinityRunnerId, heartbeatGeneration: 1 }
+        : { runnerId: equivalentExactRunnerId, heartbeatGeneration: 7 };
     if (!actor.orgId) {
       throw new Error("Expected affinity actor to have an organization");
     }
@@ -4008,6 +4083,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await releaseOrgAdmissionLock(context);
     await admissionLockRequest;
     const protectedFollowUp = await protectedFollowUpRequest;
+    const exactRunnerPreference = {
+      runnerIdentity: preferredExactRunner,
+      reason: "exactHistoryGeneration" as const,
+      expiresAt: new Date(queueInsertedAt + 500).toISOString(),
+    };
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "job",
       expect.objectContaining({
@@ -4019,6 +4099,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         historyGenerationAffinityProtectedUntil: new Date(
           queueInsertedAt + 500,
         ).toISOString(),
+        runnerPreference: exactRunnerPreference,
       }),
     );
 
@@ -4041,6 +4122,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     ).toBe(new Date(queueInsertedAt + 500).toISOString());
     expect(sessionAffinityResource(protectedPoll.body.job)).toBe(
       "reusableSandbox",
+    );
+    expect(runnerPreference(protectedPoll.body.job)).toStrictEqual(
+      exactRunnerPreference,
     );
 
     const protectedClaim = await api.claimRunnerJob(protectedFollowUp.runId);
@@ -4135,6 +4219,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(sessionAffinityProtectedUntil(generationExpiredPoll.body.job)).toBe(
       new Date(generationExpiredAt + 2000).toISOString(),
     );
+    expect(runnerPreference(generationExpiredPoll.body.job)).toStrictEqual({
+      runnerIdentity: preferredExactRunner,
+      reason: "matchingReuseKey",
+      expiresAt: new Date(generationExpiredAt + 2000).toISOString(),
+    });
     await api.requestCancelRun(actor, generationExpiredRun.runId, [200]);
     await flushWaitUntilForTest();
 

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -95,11 +95,11 @@ import {
 } from "../services/session-history-blobs";
 import {
   runnerReuseKeyTelemetryKind,
-  runnerSessionAffinityPollPriority,
-  runnerSessionAffinityLookupError,
-  runnerSessionAffinityProtection,
-  runnerSessionAffinityTelemetryResource,
-} from "../services/runner-session-affinity";
+  runnerReusePreferenceLookupError,
+  runnerReusePreferencePollPriority,
+  runnerReusePreferenceTelemetryResource,
+  resolveRunnerReusePreference,
+} from "../services/runner-reuse-preference";
 import type { RouteEntry } from "../route-entry";
 import { settle, tapError } from "../utils";
 
@@ -595,7 +595,7 @@ function runnerPollPriorityOrder(
   }
   return [
     desc(
-      runnerSessionAffinityPollPriority({
+      runnerReusePreferencePollPriority({
         db,
         runnerId: args.runnerId,
         runnerGroup: args.runnerGroup,
@@ -603,6 +603,32 @@ function runnerPollPriorityOrder(
       }),
     ),
   ];
+}
+
+async function resolvePollRunnerReusePreference(
+  db: Pick<Db, "select">,
+  args: {
+    readonly runId: string;
+    readonly runnerGroup: string;
+    readonly profile: string;
+    readonly reuseKey: string | null;
+    readonly historyGenerationRunId: string | undefined;
+    readonly createdAt: Date;
+    readonly currentDate: Date;
+  },
+) {
+  const resolution = await tapError(
+    resolveRunnerReusePreference({ db, ...args }),
+    (error) => {
+      L.warn("Failed to resolve runner reuse preference for poll response", {
+        runId: args.runId,
+        runnerGroup: args.runnerGroup,
+        profile: args.profile,
+        error,
+      });
+    },
+  );
+  return resolution ?? runnerReusePreferenceLookupError();
 }
 
 const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
@@ -644,7 +670,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const db = set(writeDb$);
   const pendingJobLookupStartedAtMs = now();
   const currentDate = nowDate();
-  const sessionAffinityPriorityOrder = runnerPollPriorityOrder(db, {
+  const reusePreferencePriorityOrder = runnerPollPriorityOrder(db, {
     runnerId: body.data.runnerId,
     runnerGroup: group,
     currentDate,
@@ -669,7 +695,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     .innerJoin(agentRuns, eq(runnerJobQueue.runId, agentRuns.id))
     .where(and(...whereConditions))
     .orderBy(
-      ...sessionAffinityPriorityOrder,
+      ...reusePreferencePriorityOrder,
       runnerJobQueue.createdAt,
       runnerJobQueue.runId,
     )
@@ -680,26 +706,15 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!pendingJob) {
     return { status: 200 as const, body: { job: null } };
   }
-  const affinity =
-    (await tapError(
-      runnerSessionAffinityProtection({
-        db,
-        runnerGroup: group,
-        profile: pendingJob.profile,
-        reuseKey: pendingJob.reuseKey,
-        historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
-        createdAt: pendingJob.createdAt,
-        currentDate,
-      }),
-      (error) => {
-        L.warn("Failed to resolve runner session affinity for poll response", {
-          runId: pendingJob.runId,
-          runnerGroup: group,
-          profile: pendingJob.profile,
-          error,
-        });
-      },
-    )) ?? runnerSessionAffinityLookupError();
+  const reusePreference = await resolvePollRunnerReusePreference(db, {
+    runId: pendingJob.runId,
+    runnerGroup: group,
+    profile: pendingJob.profile,
+    reuseKey: pendingJob.reuseKey,
+    historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
+    createdAt: pendingJob.createdAt,
+    currentDate,
+  });
   signal.throwIfAborted();
   recordPollTimingMetrics({
     runId: pendingJob.runId,
@@ -707,9 +722,10 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     profile: pendingJob.profile,
     authType: auth.type,
     pollReason: body.data.telemetry?.pollReason,
-    sessionAffinity: affinity.status,
-    sessionAffinityResource: runnerSessionAffinityTelemetryResource(affinity),
-    historyGenerationAffinity: affinity.historyGenerationStatus,
+    sessionAffinity: reusePreference.status,
+    sessionAffinityResource:
+      runnerReusePreferenceTelemetryResource(reusePreference),
+    historyGenerationAffinity: reusePreference.historyGenerationStatus,
     reuseKeyKind: runnerReuseKeyTelemetryKind(pendingJob.reuseKey),
     queueCreatedAtMs: pendingJob.createdAt.getTime(),
     pollRequestStartedAtMs,
@@ -732,9 +748,12 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         reuseKey: pendingJob.reuseKey,
         historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
         historyGenerationAffinityProtectedUntil:
-          affinity.historyGenerationProtectedUntil?.toISOString() ?? null,
-        affinityProtectedUntil: affinity.protectedUntil?.toISOString() ?? null,
-        sessionAffinityResource: affinity.resource ?? undefined,
+          reusePreference.historyGenerationProtectedUntil?.toISOString() ??
+          null,
+        affinityProtectedUntil:
+          reusePreference.protectedUntil?.toISOString() ?? null,
+        sessionAffinityResource: reusePreference.resource ?? undefined,
+        runnerPreference: reusePreference.runnerPreference ?? undefined,
       },
     },
   };

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -5,10 +5,10 @@ import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
 import {
   runnerReuseKeyTelemetryKind,
-  runnerSessionAffinityLookupError,
-  runnerSessionAffinityProtection,
-  runnerSessionAffinityTelemetryResource,
-} from "./runner-session-affinity";
+  runnerReusePreferenceLookupError,
+  runnerReusePreferenceTelemetryResource,
+  resolveRunnerReusePreference,
+} from "./runner-reuse-preference";
 import { tapError } from "../utils";
 
 const L = logger("RunnerDispatch");
@@ -27,10 +27,10 @@ export async function notifyRunnerJob(
 ): Promise<boolean> {
   const notificationEnteredAt = now();
   const currentDate = new Date(notificationEnteredAt);
-  let affinityLookupSucceeded = true;
-  const affinity =
+  let preferenceLookupSucceeded = true;
+  const reusePreference =
     (await tapError(
-      runnerSessionAffinityProtection({
+      resolveRunnerReusePreference({
         db,
         runnerGroup: args.runnerGroup,
         profile: args.profile,
@@ -40,9 +40,9 @@ export async function notifyRunnerJob(
         currentDate,
       }),
       (error) => {
-        affinityLookupSucceeded = false;
+        preferenceLookupSucceeded = false;
         L.warn(
-          "Failed to resolve runner session affinity for job notification",
+          "Failed to resolve runner reuse preference for job notification",
           {
             runId: args.runId,
             runnerGroup: args.runnerGroup,
@@ -51,8 +51,8 @@ export async function notifyRunnerJob(
           },
         );
       },
-    )) ?? runnerSessionAffinityLookupError();
-  const affinityFinishedAt = now();
+    )) ?? runnerReusePreferenceLookupError();
+  const preferenceFinishedAt = now();
   const publishStartedAt = now();
   const published = await publishRunnerJobNotification(
     args.runnerGroup,
@@ -62,10 +62,12 @@ export async function notifyRunnerJob(
       reuseKey: args.reuseKey,
       cliAgentSessionId: args.cliAgentSessionId,
       historyGenerationAffinityProtectedUntil:
-        affinity.historyGenerationProtectedUntil?.toISOString() ?? null,
-      affinityProtectedUntil: affinity.protectedUntil?.toISOString() ?? null,
-      sessionAffinityResource: affinity.resource,
+        reusePreference.historyGenerationProtectedUntil?.toISOString() ?? null,
+      affinityProtectedUntil:
+        reusePreference.protectedUntil?.toISOString() ?? null,
+      sessionAffinityResource: reusePreference.resource,
       historyGenerationRunId: args.historyGenerationRunId,
+      runnerPreference: reusePreference.runnerPreference,
     },
   );
   const publishFinishedAt = now();
@@ -74,13 +76,14 @@ export async function notifyRunnerJob(
     runner_group: args.runnerGroup,
     profile: args.profile,
     notification_target: "broadcast",
-    session_affinity: affinity.status,
-    session_affinity_resource: runnerSessionAffinityTelemetryResource(affinity),
-    history_generation_affinity: affinity.historyGenerationStatus,
+    session_affinity: reusePreference.status,
+    session_affinity_resource:
+      runnerReusePreferenceTelemetryResource(reusePreference),
+    history_generation_affinity: reusePreference.historyGenerationStatus,
     reuse_key_kind: runnerReuseKeyTelemetryKind(args.reuseKey),
   };
-  // Queue-relative actions are cumulative boundaries. Affinity and publish
-  // durations are nested children and must not be added to those boundaries.
+  // Queue-relative actions are cumulative boundaries. Preference lookup and
+  // publish durations are nested children and must not be added to them.
   recordSandboxOperations([
     {
       sandboxType: "runner",
@@ -93,8 +96,8 @@ export async function notifyRunnerJob(
     {
       sandboxType: "runner",
       actionType: "runner_notification_affinity_lookup",
-      durationMs: Math.max(0, affinityFinishedAt - notificationEnteredAt),
-      success: affinityLookupSucceeded,
+      durationMs: Math.max(0, preferenceFinishedAt - notificationEnteredAt),
+      success: preferenceLookupSucceeded,
       runId: args.runId,
       dimensions,
     },

--- a/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
+++ b/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
@@ -101,6 +101,11 @@ function runnerStateHas(args: {
   );
 }
 
+/**
+ * Poll ordering runs before a job is selected, so any runner with qualifying
+ * local reuse may prioritize the job independently of the globally selected
+ * preference identity.
+ */
 export function runnerReusePreferencePollPriority(args: {
   readonly db: Pick<Db, "select">;
   readonly runnerId: string;

--- a/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
+++ b/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
@@ -1,13 +1,19 @@
-import type { SessionAffinityResource } from "@vm0/api-contracts/contracts/runners";
+import type {
+  RunnerPreference,
+  SessionAffinityResource,
+} from "@vm0/api-contracts/contracts/runners";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
 import {
   and,
   arrayContains,
+  asc,
+  desc,
   eq,
   exists,
   gt,
   isNotNull,
+  or,
   sql,
   type SQL,
   type SQLWrapper,
@@ -16,17 +22,15 @@ import {
 import { pgBooleanDecoder } from "../../lib/db-structured-result";
 import type { Db } from "../external/db";
 
-const RUNNER_SESSION_AFFINITY_PROTECTION_MS = 2000;
-const RUNNER_HISTORY_GENERATION_AFFINITY_PROTECTION_MS = Math.min(
+const RUNNER_REUSE_PROTECTION_MS = 2000;
+const RUNNER_EXACT_HISTORY_PROTECTION_MS = Math.min(
   500,
-  RUNNER_SESSION_AFFINITY_PROTECTION_MS,
+  RUNNER_REUSE_PROTECTION_MS,
 );
-const RUNNER_SESSION_AFFINITY_HOLDER_FRESH_MS = 30_000;
+const RUNNER_REUSE_HOLDER_FRESH_MS = 30_000;
 
-function runnerSessionAffinityHolderFreshAfter(currentDate: Date): Date {
-  return new Date(
-    currentDate.getTime() - RUNNER_SESSION_AFFINITY_HOLDER_FRESH_MS,
-  );
+function runnerReuseHolderFreshAfter(currentDate: Date): Date {
+  return new Date(currentDate.getTime() - RUNNER_REUSE_HOLDER_FRESH_MS);
 }
 
 function reusableSandboxCondition(args: {
@@ -97,20 +101,19 @@ function runnerStateHas(args: {
   );
 }
 
-export function runnerSessionAffinityPollPriority(args: {
+export function runnerReusePreferencePollPriority(args: {
   readonly db: Pick<Db, "select">;
   readonly runnerId: string;
   readonly runnerGroup: string;
   readonly currentDate: Date;
 }): SQL {
   const protectedAfter = new Date(
-    args.currentDate.getTime() - RUNNER_SESSION_AFFINITY_PROTECTION_MS,
+    args.currentDate.getTime() - RUNNER_REUSE_PROTECTION_MS,
   );
   const generationProtectedAfter = new Date(
-    args.currentDate.getTime() -
-      RUNNER_HISTORY_GENERATION_AFFINITY_PROTECTION_MS,
+    args.currentDate.getTime() - RUNNER_EXACT_HISTORY_PROTECTION_MS,
   );
-  const freshAfter = runnerSessionAffinityHolderFreshAfter(args.currentDate);
+  const freshAfter = runnerReuseHolderFreshAfter(args.currentDate);
   const targetGenerationRunId = sql`${runnerJobQueue.executionContext}->'resumeSession'->>'historyGenerationRunId'`;
   const reuseKey = runnerJobQueue.reuseKey;
   const profile = runnerJobQueue.profile;
@@ -172,22 +175,14 @@ export function runnerSessionAffinityPollPriority(args: {
   END`;
 }
 
-type RunnerSessionAffinityStatus =
+type RunnerReusePreferenceStatus =
   | "no_session"
   | "expired"
   | "protected"
   | "no_viable_holder"
   | "lookup_error";
 
-interface RunnerSessionAffinityProtection {
-  readonly protectedUntil: Date | null;
-  readonly status: RunnerSessionAffinityStatus;
-  readonly resource: SessionAffinityResource | null;
-  readonly historyGenerationProtectedUntil: Date | null;
-  readonly historyGenerationStatus: RunnerHistoryGenerationAffinityStatus;
-}
-
-type RunnerHistoryGenerationAffinityStatus =
+type RunnerHistoryGenerationPreferenceStatus =
   | "no_session"
   | "no_target"
   | "expired"
@@ -195,8 +190,22 @@ type RunnerHistoryGenerationAffinityStatus =
   | "no_exact_holder"
   | "lookup_error";
 
-export function runnerSessionAffinityLookupError(): RunnerSessionAffinityProtection {
+type CurrentRunnerPreference = Omit<RunnerPreference, "reason"> & {
+  readonly reason: Exclude<RunnerPreference["reason"], "finalizingPredecessor">;
+};
+
+interface RunnerReusePreferenceResolution {
+  readonly runnerPreference: CurrentRunnerPreference | null;
+  readonly protectedUntil: Date | null;
+  readonly status: RunnerReusePreferenceStatus;
+  readonly resource: SessionAffinityResource | null;
+  readonly historyGenerationProtectedUntil: Date | null;
+  readonly historyGenerationStatus: RunnerHistoryGenerationPreferenceStatus;
+}
+
+export function runnerReusePreferenceLookupError(): RunnerReusePreferenceResolution {
   return {
+    runnerPreference: null,
     protectedUntil: null,
     status: "lookup_error",
     resource: null,
@@ -205,36 +214,13 @@ export function runnerSessionAffinityLookupError(): RunnerSessionAffinityProtect
   };
 }
 
-function affinityProtectedUntil(
-  reuseKey: string | null,
-  createdAt: Date,
-): Date | null {
-  if (!reuseKey) {
-    return null;
-  }
-  return new Date(createdAt.getTime() + RUNNER_SESSION_AFFINITY_PROTECTION_MS);
+interface RunnerReuseHolder {
+  readonly runnerIdentity: RunnerPreference["runnerIdentity"];
+  readonly resource: SessionAffinityResource;
+  readonly hasExactHistoryGeneration: boolean;
 }
 
-function historyGenerationAffinityProtectedUntil(args: {
-  readonly reuseKey: string | null;
-  readonly historyGenerationRunId: string | undefined;
-  readonly createdAt: Date;
-}): Date | null {
-  if (!args.reuseKey || !args.historyGenerationRunId) {
-    return null;
-  }
-  return new Date(
-    args.createdAt.getTime() + RUNNER_HISTORY_GENERATION_AFFINITY_PROTECTION_MS,
-  );
-}
-
-interface RunnerSessionAffinityHolders {
-  readonly hasSessionHolder: boolean;
-  readonly hasExactGenerationHolder: boolean;
-  readonly resource: SessionAffinityResource | null;
-}
-
-async function runnerSessionAffinityHolders(args: {
+async function selectRunnerReuseHolder(args: {
   readonly db: Pick<Db, "select">;
   readonly runnerGroup: string;
   readonly profile: string;
@@ -242,7 +228,7 @@ async function runnerSessionAffinityHolders(args: {
   readonly historyGenerationRunId: string | undefined;
   readonly freshAfter: Date;
   readonly shouldLookUpExactGeneration: boolean;
-}): Promise<RunnerSessionAffinityHolders> {
+}): Promise<RunnerReuseHolder | null> {
   const reusableCondition = reusableSandboxCondition({
     reuseKey: sql.param(args.reuseKey),
     profile: sql.param(args.profile),
@@ -260,20 +246,20 @@ async function runnerSessionAffinityHolders(args: {
           historyGenerationRunId: sql.param(args.historyGenerationRunId),
         })
       : sql`false`;
-  const [holders] = await args.db
+  const resourceRank = sql`CASE
+    WHEN ${exactGenerationCondition} THEN 3
+    WHEN ${reusableCondition} THEN 2
+    WHEN ${workspaceCondition} THEN 1
+    ELSE 0
+  END`;
+  const [holder] = await args.db
     .select({
-      hasReusableHolder:
-        sql`coalesce(bool_or(${reusableCondition}), false)`.mapWith(
-          pgBooleanDecoder,
-        ),
-      hasWorkspaceHolder:
-        sql`coalesce(bool_or(${workspaceCondition}), false)`.mapWith(
-          pgBooleanDecoder,
-        ),
-      hasExactGenerationHolder:
-        sql`coalesce(bool_or(${exactGenerationCondition}), false)`.mapWith(
-          pgBooleanDecoder,
-        ),
+      runnerId: runnerState.runnerId,
+      heartbeatGeneration: runnerState.heartbeatGeneration,
+      hasExactHistoryGeneration: sql`${exactGenerationCondition}`.mapWith(
+        pgBooleanDecoder,
+      ),
+      hasReusableSandbox: sql`${reusableCondition}`.mapWith(pgBooleanDecoder),
     })
     .from(runnerState)
     .where(
@@ -281,23 +267,27 @@ async function runnerSessionAffinityHolders(args: {
         eq(runnerState.runnerGroup, args.runnerGroup),
         eq(runnerState.mode, "running"),
         gt(runnerState.lastSeenAt, args.freshAfter),
+        gt(runnerState.heartbeatGeneration, 0),
+        or(exactGenerationCondition, reusableCondition, workspaceCondition),
       ),
-    );
+    )
+    .orderBy(desc(resourceRank), asc(runnerState.runnerId))
+    .limit(1);
 
-  const hasReusableHolder = holders?.hasReusableHolder ?? false;
-  const hasWorkspaceHolder = holders?.hasWorkspaceHolder ?? false;
+  if (!holder) {
+    return null;
+  }
   return {
-    hasSessionHolder: hasReusableHolder || hasWorkspaceHolder,
-    hasExactGenerationHolder: holders?.hasExactGenerationHolder ?? false,
-    resource: hasReusableHolder
-      ? "reusableSandbox"
-      : hasWorkspaceHolder
-        ? "workspaceCache"
-        : null,
+    runnerIdentity: {
+      runnerId: holder.runnerId,
+      heartbeatGeneration: holder.heartbeatGeneration,
+    },
+    resource: holder.hasReusableSandbox ? "reusableSandbox" : "workspaceCache",
+    hasExactHistoryGeneration: holder.hasExactHistoryGeneration,
   };
 }
 
-export async function runnerSessionAffinityProtection(args: {
+export async function resolveRunnerReusePreference(args: {
   readonly db: Pick<Db, "select">;
   readonly runnerGroup: string;
   readonly profile: string;
@@ -305,12 +295,10 @@ export async function runnerSessionAffinityProtection(args: {
   readonly historyGenerationRunId: string | undefined;
   readonly createdAt: Date;
   readonly currentDate: Date;
-}): Promise<RunnerSessionAffinityProtection> {
-  const protectedUntil = affinityProtectedUntil(args.reuseKey, args.createdAt);
-  const historyGenerationProtectedUntil =
-    historyGenerationAffinityProtectedUntil(args);
+}): Promise<RunnerReusePreferenceResolution> {
   if (!args.reuseKey) {
     return {
+      runnerPreference: null,
       protectedUntil: null,
       status: "no_session",
       resource: null,
@@ -318,8 +306,15 @@ export async function runnerSessionAffinityProtection(args: {
       historyGenerationStatus: "no_session",
     };
   }
-  if (!protectedUntil || protectedUntil <= args.currentDate) {
+  const protectedUntil = new Date(
+    args.createdAt.getTime() + RUNNER_REUSE_PROTECTION_MS,
+  );
+  const historyGenerationProtectedUntil = args.historyGenerationRunId
+    ? new Date(args.createdAt.getTime() + RUNNER_EXACT_HISTORY_PROTECTION_MS)
+    : null;
+  if (protectedUntil <= args.currentDate) {
     return {
+      runnerPreference: null,
       protectedUntil: null,
       status: "expired",
       resource: null,
@@ -330,11 +325,11 @@ export async function runnerSessionAffinityProtection(args: {
     };
   }
 
-  const freshAfter = runnerSessionAffinityHolderFreshAfter(args.currentDate);
+  const freshAfter = runnerReuseHolderFreshAfter(args.currentDate);
   const shouldLookUpExactGeneration =
     historyGenerationProtectedUntil !== null &&
     historyGenerationProtectedUntil > args.currentDate;
-  const holders = await runnerSessionAffinityHolders({
+  const holder = await selectRunnerReuseHolder({
     db: args.db,
     runnerGroup: args.runnerGroup,
     profile: args.profile,
@@ -343,30 +338,54 @@ export async function runnerSessionAffinityProtection(args: {
     freshAfter,
     shouldLookUpExactGeneration,
   });
-  const historyGenerationStatus: RunnerHistoryGenerationAffinityStatus =
+  const historyGenerationStatus: RunnerHistoryGenerationPreferenceStatus =
     !args.historyGenerationRunId
       ? "no_target"
       : !shouldLookUpExactGeneration
         ? "expired"
-        : holders.hasExactGenerationHolder
+        : holder?.hasExactHistoryGeneration
           ? "protected"
           : "no_exact_holder";
 
+  if (!holder) {
+    return {
+      runnerPreference: null,
+      protectedUntil: null,
+      status: "no_viable_holder",
+      resource: null,
+      historyGenerationProtectedUntil: null,
+      historyGenerationStatus,
+    };
+  }
+
+  const hasExactHistoryGeneration =
+    holder.hasExactHistoryGeneration &&
+    historyGenerationProtectedUntil !== null;
+
   return {
-    protectedUntil: holders.hasSessionHolder ? protectedUntil : null,
-    status: holders.hasSessionHolder ? "protected" : "no_viable_holder",
-    resource: holders.resource,
-    historyGenerationProtectedUntil: holders.hasExactGenerationHolder
+    runnerPreference: {
+      runnerIdentity: holder.runnerIdentity,
+      reason: hasExactHistoryGeneration
+        ? "exactHistoryGeneration"
+        : "matchingReuseKey",
+      expiresAt: hasExactHistoryGeneration
+        ? historyGenerationProtectedUntil.toISOString()
+        : protectedUntil.toISOString(),
+    },
+    protectedUntil,
+    status: "protected",
+    resource: holder.resource,
+    historyGenerationProtectedUntil: hasExactHistoryGeneration
       ? historyGenerationProtectedUntil
       : null,
     historyGenerationStatus,
   };
 }
 
-export function runnerSessionAffinityTelemetryResource(
-  affinity: RunnerSessionAffinityProtection,
+export function runnerReusePreferenceTelemetryResource(
+  resolution: RunnerReusePreferenceResolution,
 ): "reusableSandbox" | "workspaceCache" | "none" {
-  return affinity.resource ?? "none";
+  return resolution.resource ?? "none";
 }
 
 export function runnerReuseKeyTelemetryKind(

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -565,6 +565,16 @@ describe("runner resume session contract", () => {
         runnerPreference: {
           ...runnerPreference,
           reason: "matchingReuseKey",
+          resource: "reusableSandbox",
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      jobSchema.safeParse({
+        ...jobInput,
+        runnerPreference: {
+          ...runnerPreference,
+          reason: "matchingReuseKey",
           runnerIdentity: {
             ...runnerPreference.runnerIdentity,
             resource: "reusableSandbox",

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -515,44 +515,60 @@ describe("runner resume session contract", () => {
     });
     expect(job.historyGenerationAffinityProtectedUntil).toBeNull();
     expect(job.sessionAffinityResource).toBeUndefined();
-    expect(job.predecessorRunnerAffinity).toBeUndefined();
+    expect(job.runnerPreference).toBeUndefined();
   });
 
-  it("accepts a complete dormant predecessor runner affinity", () => {
-    const predecessorRunnerAffinity = {
-      sourceRunId: "11111111-1111-4111-8111-111111111111",
-      runnerId: "22222222-2222-4222-8222-222222222222",
-      heartbeatGeneration: 7,
+  it("accepts one strict optional runner preference", () => {
+    const runnerPreference = {
+      runnerIdentity: {
+        runnerId: "22222222-2222-4222-8222-222222222222",
+        heartbeatGeneration: 7,
+      },
       expiresAt: "2026-08-03T00:00:01.000Z",
     };
-    const job = jobSchema.parse({
+    const jobInput = {
       runId: "33333333-3333-4333-8333-333333333333",
       prompt: "continue",
       appendSystemPrompt: null,
       agentComposeVersionId: null,
       vars: null,
       experimentalProfile: "vm0/default",
-      predecessorRunnerAffinity,
-    });
+    };
 
-    expect(job.predecessorRunnerAffinity).toStrictEqual(
-      predecessorRunnerAffinity,
-    );
+    for (const reason of [
+      "exactHistoryGeneration",
+      "matchingReuseKey",
+      "finalizingPredecessor",
+    ] as const) {
+      const job = jobSchema.parse({
+        ...jobInput,
+        runnerPreference: { ...runnerPreference, reason },
+      });
+      expect(job.runnerPreference).toStrictEqual({
+        ...runnerPreference,
+        reason,
+      });
+    }
     expect(
       jobSchema.safeParse({
-        ...job,
-        predecessorRunnerAffinity: {
-          ...predecessorRunnerAffinity,
+        ...jobInput,
+        runnerPreference: {
+          ...runnerPreference,
+          reason: "matchingReuseKey",
           expiresAt: undefined,
         },
       }).success,
     ).toBe(false);
     expect(
       jobSchema.safeParse({
-        ...job,
-        predecessorRunnerAffinity: {
-          ...predecessorRunnerAffinity,
-          resource: "reusableSandbox",
+        ...jobInput,
+        runnerPreference: {
+          ...runnerPreference,
+          reason: "matchingReuseKey",
+          runnerIdentity: {
+            ...runnerPreference.runnerIdentity,
+            resource: "reusableSandbox",
+          },
         },
       }).success,
     ).toBe(false);

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -101,9 +101,14 @@ const runnerProcessIdentitySchema = z
   })
   .strict();
 
-export const predecessorRunnerAffinitySchema = runnerProcessIdentitySchema
-  .extend({
-    sourceRunId: z.uuid(),
+export const runnerPreferenceSchema = z
+  .object({
+    runnerIdentity: runnerProcessIdentitySchema,
+    reason: z.enum([
+      "exactHistoryGeneration",
+      "matchingReuseKey",
+      "finalizingPredecessor",
+    ]),
     expiresAt: z.string().datetime({ offset: true }),
   })
   .strict();
@@ -301,7 +306,7 @@ export const jobSchema = z.object({
     .nullable()
     .optional(),
   sessionAffinityResource: sessionAffinityResourceSchema.optional(),
-  predecessorRunnerAffinity: predecessorRunnerAffinitySchema.optional(),
+  runnerPreference: runnerPreferenceSchema.optional(),
 });
 
 const heldWorkspaceCacheSchema = z.object({
@@ -849,6 +854,7 @@ export type RunnersHeartbeatContract = typeof runnersHeartbeatContract;
 export type RunnersBuiltinFirewallsResolveContract =
   typeof runnersBuiltinFirewallsResolveContract;
 export type Job = z.infer<typeof jobSchema>;
+export type RunnerPreference = z.infer<typeof runnerPreferenceSchema>;
 export type HeldSandboxState = z.infer<typeof heldSandboxStateSchema>;
 export type HeldWorkspaceState = z.infer<typeof heldWorkspaceStateSchema>;
 export type ExecutionContext = z.infer<typeof executionContextSchema>;

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -101,6 +101,10 @@ const runnerProcessIdentitySchema = z
   })
   .strict();
 
+/**
+ * Advisory cross-runner coordination, not an exclusive assignment. A runner
+ * with an equivalent compatible local resource remains eligible to claim.
+ */
 export const runnerPreferenceSchema = z
   .object({
     runnerIdentity: runnerProcessIdentitySchema,


### PR DESCRIPTION
## Summary

- add one strict optional `runnerPreference` contract with runner identity, reason, and immutable expiry
- replace aggregate session-affinity lookup with one deterministic ranked holder selection shared by Poll and Ably delivery
- preserve the three consumed legacy affinity fields and existing telemetry as projections during the staged runner rollout
- remove the dormant predecessor-affinity schema and old service terminology
- add mixed-version Poll and Ably tests proving current Rust runners ignore the additive preference

## Compatibility and scope

- old runners can ignore the additive preference and continue reading legacy fields
- this producer emits `exactHistoryGeneration` and `matchingReuseKey`; it does not yet emit `finalizingPredecessor`
- no database, runner consumer, claim, sandbox lifecycle, or workspace lifecycle behavior changes

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm knip`
- pre-commit full Turbo typecheck
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --bin runner --all-features`

Closes #24683

Relates to #24355