### PR TITLE
fix(mitm-addon): bound usage webhook dns resolution

### DIFF
--- a/crates/runner/mitm-addon/src/platform_api.py
+++ b/crates/runner/mitm-addon/src/platform_api.py
@@ -32,9 +32,11 @@ class _NoRedirect(urllib.request.HTTPRedirectHandler):
         return None
 
 
-def build_api_opener() -> urllib.request.OpenerDirector:
-    """Build an opener that returns redirects as HTTP errors."""
-    return urllib.request.build_opener(_NoRedirect)
+def build_api_opener(
+    *handlers: urllib.request.BaseHandler,
+) -> urllib.request.OpenerDirector:
+    """Build an opener with caller transports that returns redirects as HTTP errors."""
+    return urllib.request.build_opener(*handlers, _NoRedirect())
 
 
 def configure_client_headers(*, client_session_id: str, client_version: str) -> None:

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -18,9 +18,10 @@ from typing import Literal
 
 import network_log_sanitization
 from logging_utils import log_proxy_entry
-from platform_api import build_api_opener, make_api_request
+from platform_api import make_api_request
 
 from .counters import PendingReportLease, admit_pending_report
+from .webhook_transport import open_request
 
 WebhookDeliveryOutcome = Literal["success", "retryable_failure", "permanent_failure"]
 _DeliveryOutcomeCallback = Callable[[WebhookDeliveryOutcome], None]
@@ -30,9 +31,6 @@ _PERMANENT_FAILURE: WebhookDeliveryOutcome = "permanent_failure"
 _MIN_RETRYABLE_HTTP_STATUS_CODE = 500
 _RETRYABLE_HTTP_STATUS_CODES = {408, 429}
 _WEBHOOK_RETRY_DELAY_SECONDS = 0.5
-
-
-_opener = build_api_opener()
 
 
 def _payload_log_summary(payload: dict) -> dict:
@@ -104,7 +102,7 @@ def _post_webhook(url: str, sandbox_token: str, data: bytes) -> None:
     """POST JSON data to a platform webhook.  Raises on failure."""
     req = make_api_request(url, data, sandbox_token)
     try:
-        with _opener.open(req, timeout=10):
+        with open_request(req):
             pass
     except urllib.error.HTTPError as exc:
         # HTTPError wraps an open socket; context-manage it so the fd is

--- a/crates/runner/mitm-addon/src/usage/webhook_transport.py
+++ b/crates/runner/mitm-addon/src/usage/webhook_transport.py
@@ -1,0 +1,473 @@
+"""Deadline-aware urllib transport for usage webhook attempts."""
+
+import asyncio
+import errno
+import functools
+import http.client as http_client
+import ipaddress
+import socket
+import ssl
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from concurrent.futures import Future
+from contextlib import suppress
+from enum import Enum, auto
+from types import TracebackType
+from typing import NamedTuple, Protocol, Self
+
+import mitmproxy_rs
+
+from platform_api import build_api_opener
+
+ATTEMPT_DEADLINE_SECONDS = 10.0
+_DEFAULT_HTTP_PORT = 80
+_DEFAULT_HTTPS_PORT = 443
+_IPV6_VERSION = 6
+_https_context: ssl.SSLContext | None = None
+_https_context_lock = threading.Lock()
+
+
+class UsageWebhookDeadlineExceededError(TimeoutError):
+    """Raised when one usage webhook attempt exceeds its total lifetime."""
+
+
+class _AddressResolver(Protocol):
+    async def lookup_ip(self, host: str) -> list[str]:
+        raise NotImplementedError
+
+
+class _OpenResponse(Protocol):
+    def close(self) -> None:
+        raise NotImplementedError
+
+    def __enter__(self) -> Self:
+        raise NotImplementedError
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        raise NotImplementedError
+
+
+class _ResolvedAddress(NamedTuple):
+    family: socket.AddressFamily
+    host: str
+    port: int
+
+
+class _AttemptTerminalState(Enum):
+    COMPLETED = auto()
+    DEADLINE_EXPIRED = auto()
+
+
+type _SocketAddress = tuple[str, int] | tuple[str, int, int, int]
+
+
+def _abort_socket(sock: socket.socket) -> None:
+    with suppress(Exception):
+        sock.shutdown(socket.SHUT_RDWR)
+    with suppress(Exception):
+        sock.close()
+
+
+class _AttemptHandle:
+    """Serialize deadline expiry, socket ownership, and attempt completion."""
+
+    __slots__ = ("_deadline", "_lock", "_socket", "_terminal_state")
+
+    def __init__(self, deadline: float) -> None:
+        self._deadline = deadline
+        self._lock = threading.Lock()
+        self._socket: socket.socket | None = None
+        self._terminal_state: _AttemptTerminalState | None = None
+
+    def remaining_seconds(self) -> float:
+        self.raise_if_expired()
+        remaining = self._deadline - time.monotonic()
+        if remaining <= 0:
+            self.expire()
+            self.raise_if_expired()
+        return remaining
+
+    def register_socket(self, sock: socket.socket) -> None:
+        with self._lock:
+            if self._terminal_state is None:
+                self._socket = sock
+                return
+        _abort_socket(sock)
+        self.raise_if_expired()
+        raise RuntimeError("usage webhook attempt is already completed")
+
+    def replace_socket(self, current: socket.socket, replacement: socket.socket) -> None:
+        with self._lock:
+            if self._terminal_state is None and self._socket is current:
+                self._socket = replacement
+                return
+            terminal_state = self._terminal_state
+        _abort_socket(replacement)
+        if terminal_state is _AttemptTerminalState.DEADLINE_EXPIRED:
+            self.raise_if_expired()
+        raise RuntimeError("usage webhook socket ownership changed unexpectedly")
+
+    def clear_socket(self, sock: socket.socket) -> None:
+        with self._lock:
+            if self._socket is sock:
+                self._socket = None
+
+    def expire(self) -> bool:
+        sock: socket.socket | None = None
+        with self._lock:
+            if self._terminal_state is not None:
+                return False
+            self._terminal_state = _AttemptTerminalState.DEADLINE_EXPIRED
+            sock = self._socket
+            self._socket = None
+        if sock is not None:
+            _abort_socket(sock)
+        return True
+
+    def finish(self) -> bool:
+        sock: socket.socket | None = None
+        with self._lock:
+            if self._terminal_state is None:
+                if time.monotonic() >= self._deadline:
+                    self._terminal_state = _AttemptTerminalState.DEADLINE_EXPIRED
+                    sock = self._socket
+                else:
+                    self._terminal_state = _AttemptTerminalState.COMPLETED
+                self._socket = None
+            expired = self._terminal_state is _AttemptTerminalState.DEADLINE_EXPIRED
+        if sock is not None:
+            _abort_socket(sock)
+        return expired
+
+    def raise_if_expired(self) -> None:
+        with self._lock:
+            expired = self._terminal_state is _AttemptTerminalState.DEADLINE_EXPIRED
+        if expired:
+            raise UsageWebhookDeadlineExceededError("usage webhook attempt deadline exceeded")
+
+
+def _socket_address(address: _ResolvedAddress) -> _SocketAddress:
+    if address.family == socket.AF_INET6:
+        return address.host, address.port, 0, 0
+    return address.host, address.port
+
+
+async def _lookup_ip(host: str, handle: _AttemptHandle) -> list[str]:
+    resolver: _AddressResolver = mitmproxy_rs.dns.DnsResolver()
+    async with asyncio.timeout(handle.remaining_seconds()):
+        return await resolver.lookup_ip(host)
+
+
+def _lookup_ip_in_bridge(host: str, handle: _AttemptHandle) -> list[str]:
+    result: Future[list[str]] = Future()
+
+    def run_lookup() -> None:
+        try:
+            resolved = asyncio.run(_lookup_ip(host, handle))
+        except BaseException as exc:
+            result.set_exception(exc)
+        else:
+            result.set_result(resolved)
+
+    thread = threading.Thread(
+        target=run_lookup,
+        name="usage-webhook-dns",
+        daemon=True,
+    )
+    thread.start()
+    try:
+        try:
+            return result.result(timeout=handle.remaining_seconds())
+        except TimeoutError:
+            if not result.done():
+                handle.expire()
+            handle.raise_if_expired()
+            raise
+    finally:
+        thread.join()
+
+
+def _resolve_host(host: str, handle: _AttemptHandle) -> list[str]:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(_lookup_ip(host, handle))
+    return _lookup_ip_in_bridge(host, handle)
+
+
+def _resolve_addresses(
+    host: str, port: int, handle: _AttemptHandle
+) -> tuple[_ResolvedAddress, ...]:
+    try:
+        literal_address = ipaddress.ip_address(host)
+    except ValueError:
+        resolved_hosts = _resolve_host(host, handle)
+    else:
+        resolved_hosts = [literal_address.compressed]
+
+    handle.raise_if_expired()
+    seen: set[str] = set()
+    addresses: list[_ResolvedAddress] = []
+    for resolved_host in resolved_hosts:
+        address = ipaddress.ip_address(resolved_host)
+        normalized_host = address.compressed
+        if normalized_host in seen:
+            continue
+        seen.add(normalized_host)
+        family = socket.AF_INET6 if address.version == _IPV6_VERSION else socket.AF_INET
+        addresses.append(_ResolvedAddress(family, normalized_host, port))
+    if not addresses:
+        raise OSError("usage webhook host did not resolve")
+    return tuple(addresses)
+
+
+def _connect_socket(
+    host: str,
+    port: int,
+    source_address: tuple[str, int] | None,
+    handle: _AttemptHandle,
+) -> socket.socket:
+    addresses = _resolve_addresses(host, port, handle)
+    last_error: OSError | None = None
+    for address in addresses:
+        handle.raise_if_expired()
+        sock = socket.socket(address.family, socket.SOCK_STREAM)
+        try:
+            handle.register_socket(sock)
+            sock.settimeout(handle.remaining_seconds())
+            if source_address is not None:
+                sock.bind(source_address)
+            sock.connect(_socket_address(address))
+            try:
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            except OSError as exc:
+                if exc.errno != errno.ENOPROTOOPT:
+                    raise
+            handle.raise_if_expired()
+        except OSError as exc:
+            last_error = exc
+            handle.clear_socket(sock)
+            _abort_socket(sock)
+            handle.raise_if_expired()
+            continue
+        except Exception:
+            handle.clear_socket(sock)
+            _abort_socket(sock)
+            raise
+        return sock
+    if last_error is not None:
+        raise last_error
+    raise OSError("usage webhook resolver returned no connection address")
+
+
+def _get_https_context() -> ssl.SSLContext:
+    global _https_context
+
+    context = _https_context
+    if context is not None:
+        return context
+    with _https_context_lock:
+        context = _https_context
+        if context is None:
+            context = ssl.create_default_context()
+            context.set_alpn_protocols(["http/1.1"])
+            if context.post_handshake_auth is not None:
+                context.post_handshake_auth = True
+            _https_context = context
+        return context
+
+
+class _DeadlineHTTPConnection(http_client.HTTPConnection):
+    default_port = _DEFAULT_HTTP_PORT
+    _tunnel: Callable[[], None]
+    _tunnel_host: str | None
+
+    def __init__(
+        self,
+        host: str,
+        port: int | None = None,
+        *,
+        timeout: float | None = ATTEMPT_DEADLINE_SECONDS,
+        source_address: tuple[str, int] | None = None,
+        blocksize: int = 8192,
+        attempt_handle: _AttemptHandle,
+    ) -> None:
+        super().__init__(
+            host,
+            port=port,
+            timeout=timeout,
+            source_address=source_address,
+            blocksize=blocksize,
+        )
+        self._attempt_handle = attempt_handle
+        self._source_address = source_address
+
+    def connect(self) -> None:
+        sys.audit("http.client.connect", self, self.host, self.port)
+        self.sock = _connect_socket(
+            self.host,
+            self.port,
+            self._source_address,
+            self._attempt_handle,
+        )
+        if self._tunnel_host:
+            self.sock.settimeout(self._attempt_handle.remaining_seconds())
+            self._tunnel()
+
+    def close(self) -> None:
+        sock = self.sock
+        try:
+            super().close()
+        finally:
+            if sock is not None:
+                self._attempt_handle.clear_socket(sock)
+
+
+class _DeadlineHTTPSConnection(http_client.HTTPSConnection):
+    default_port = _DEFAULT_HTTPS_PORT
+    _tunnel: Callable[[], None]
+    _tunnel_host: str | None
+
+    def __init__(
+        self,
+        host: str,
+        port: int | None = None,
+        *,
+        timeout: float | None = ATTEMPT_DEADLINE_SECONDS,
+        source_address: tuple[str, int] | None = None,
+        context: ssl.SSLContext | None = None,
+        blocksize: int = 8192,
+        attempt_handle: _AttemptHandle,
+    ) -> None:
+        ssl_context = context if context is not None else _get_https_context()
+        super().__init__(
+            host,
+            port=port,
+            timeout=timeout,
+            source_address=source_address,
+            context=ssl_context,
+            blocksize=blocksize,
+        )
+        self._attempt_handle = attempt_handle
+        self._source_address = source_address
+        self._ssl_context = ssl_context
+
+    def connect(self) -> None:
+        sys.audit("http.client.connect", self, self.host, self.port)
+        raw_sock = _connect_socket(
+            self.host,
+            self.port,
+            self._source_address,
+            self._attempt_handle,
+        )
+        self.sock = raw_sock
+        try:
+            if self._tunnel_host:
+                raw_sock.settimeout(self._attempt_handle.remaining_seconds())
+                self._tunnel()
+                server_hostname = self._tunnel_host
+            else:
+                server_hostname = self.host
+            wrapped_sock = self._ssl_context.wrap_socket(
+                raw_sock,
+                server_hostname=server_hostname,
+                do_handshake_on_connect=False,
+            )
+            if wrapped_sock is not raw_sock:
+                self._attempt_handle.replace_socket(raw_sock, wrapped_sock)
+            self.sock = wrapped_sock
+            wrapped_sock.settimeout(self._attempt_handle.remaining_seconds())
+            wrapped_sock.do_handshake()
+            self._attempt_handle.raise_if_expired()
+        except Exception:
+            sock = self.sock
+            self.sock = None
+            if sock is not None:
+                self._attempt_handle.clear_socket(sock)
+                _abort_socket(sock)
+            raise
+
+    def close(self) -> None:
+        sock = self.sock
+        try:
+            super().close()
+        finally:
+            if sock is not None:
+                self._attempt_handle.clear_socket(sock)
+
+
+class _DeadlineHTTPHandler(urllib.request.HTTPHandler):
+    def __init__(self, attempt_handle: _AttemptHandle) -> None:
+        super().__init__()
+        self._connection_factory = functools.partial(
+            _DeadlineHTTPConnection,
+            attempt_handle=attempt_handle,
+        )
+
+    def http_open(self, req: urllib.request.Request) -> _OpenResponse:
+        return self.do_open(self._connection_factory, req)
+
+
+class _DeadlineHTTPSHandler(urllib.request.HTTPSHandler):
+    def __init__(self, attempt_handle: _AttemptHandle) -> None:
+        context = _get_https_context()
+        super().__init__(context=context)
+        self._ssl_context = context
+        self._connection_factory = functools.partial(
+            _DeadlineHTTPSConnection,
+            attempt_handle=attempt_handle,
+        )
+
+    def https_open(self, req: urllib.request.Request) -> _OpenResponse:
+        return self.do_open(self._connection_factory, req, context=self._ssl_context)
+
+
+def _stop_deadline_timer(timer: threading.Timer) -> None:
+    timer.cancel()
+    timer.join()
+
+
+def open_request(request: urllib.request.Request) -> _OpenResponse:
+    """Open one usage webhook request within one absolute attempt deadline."""
+    deadline = time.monotonic() + ATTEMPT_DEADLINE_SECONDS
+    handle = _AttemptHandle(deadline)
+    timer = threading.Timer(ATTEMPT_DEADLINE_SECONDS, handle.expire)
+    timer.name = "usage-webhook-deadline"
+    timer.daemon = True
+    timer.start()
+    try:
+        opener = build_api_opener(
+            _DeadlineHTTPHandler(handle),
+            _DeadlineHTTPSHandler(handle),
+        )
+        response = opener.open(request, timeout=ATTEMPT_DEADLINE_SECONDS)
+    except Exception as exc:
+        expired = handle.finish()
+        _stop_deadline_timer(timer)
+        if expired:
+            if isinstance(exc, urllib.error.HTTPError):
+                exc.close()
+            raise UsageWebhookDeadlineExceededError(
+                "usage webhook attempt deadline exceeded"
+            ) from exc
+        raise
+    except BaseException:
+        handle.finish()
+        _stop_deadline_timer(timer)
+        raise
+
+    expired = handle.finish()
+    _stop_deadline_timer(timer)
+    if expired:
+        response.close()
+        raise UsageWebhookDeadlineExceededError("usage webhook attempt deadline exceeded")
+    return response

--- a/crates/runner/mitm-addon/src/usage/webhook_transport.py
+++ b/crates/runner/mitm-addon/src/usage/webhook_transport.py
@@ -1,21 +1,16 @@
-"""Deadline-aware urllib transport for usage webhook attempts."""
+"""Urllib transport with bounded DNS resolution for usage webhooks."""
 
 import asyncio
 import errno
-import functools
 import http.client as http_client
 import ipaddress
 import socket
 import ssl
 import sys
-import threading
-import time
-import urllib.error
 import urllib.request
 from collections.abc import Callable
-from concurrent.futures import Future
-from contextlib import suppress
-from enum import Enum, auto
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
 from types import TracebackType
 from typing import NamedTuple, Protocol, Self
 
@@ -23,16 +18,8 @@ import mitmproxy_rs
 
 from platform_api import build_api_opener
 
-ATTEMPT_DEADLINE_SECONDS = 10.0
-_DEFAULT_HTTP_PORT = 80
-_DEFAULT_HTTPS_PORT = 443
+WEBHOOK_OPERATION_TIMEOUT_SECONDS = 10.0
 _IPV6_VERSION = 6
-_https_context: ssl.SSLContext | None = None
-_https_context_lock = threading.Lock()
-
-
-class UsageWebhookDeadlineExceededError(TimeoutError):
-    """Raised when one usage webhook attempt exceeds its total lifetime."""
 
 
 class _AddressResolver(Protocol):
@@ -62,97 +49,7 @@ class _ResolvedAddress(NamedTuple):
     port: int
 
 
-class _AttemptTerminalState(Enum):
-    COMPLETED = auto()
-    DEADLINE_EXPIRED = auto()
-
-
 type _SocketAddress = tuple[str, int] | tuple[str, int, int, int]
-
-
-def _abort_socket(sock: socket.socket) -> None:
-    with suppress(Exception):
-        sock.shutdown(socket.SHUT_RDWR)
-    with suppress(Exception):
-        sock.close()
-
-
-class _AttemptHandle:
-    """Serialize deadline expiry, socket ownership, and attempt completion."""
-
-    __slots__ = ("_deadline", "_lock", "_socket", "_terminal_state")
-
-    def __init__(self, deadline: float) -> None:
-        self._deadline = deadline
-        self._lock = threading.Lock()
-        self._socket: socket.socket | None = None
-        self._terminal_state: _AttemptTerminalState | None = None
-
-    def remaining_seconds(self) -> float:
-        self.raise_if_expired()
-        remaining = self._deadline - time.monotonic()
-        if remaining <= 0:
-            self.expire()
-            self.raise_if_expired()
-        return remaining
-
-    def register_socket(self, sock: socket.socket) -> None:
-        with self._lock:
-            if self._terminal_state is None:
-                self._socket = sock
-                return
-        _abort_socket(sock)
-        self.raise_if_expired()
-        raise RuntimeError("usage webhook attempt is already completed")
-
-    def replace_socket(self, current: socket.socket, replacement: socket.socket) -> None:
-        with self._lock:
-            if self._terminal_state is None and self._socket is current:
-                self._socket = replacement
-                return
-            terminal_state = self._terminal_state
-        _abort_socket(replacement)
-        if terminal_state is _AttemptTerminalState.DEADLINE_EXPIRED:
-            self.raise_if_expired()
-        raise RuntimeError("usage webhook socket ownership changed unexpectedly")
-
-    def clear_socket(self, sock: socket.socket) -> None:
-        with self._lock:
-            if self._socket is sock:
-                self._socket = None
-
-    def expire(self) -> bool:
-        sock: socket.socket | None = None
-        with self._lock:
-            if self._terminal_state is not None:
-                return False
-            self._terminal_state = _AttemptTerminalState.DEADLINE_EXPIRED
-            sock = self._socket
-            self._socket = None
-        if sock is not None:
-            _abort_socket(sock)
-        return True
-
-    def finish(self) -> bool:
-        sock: socket.socket | None = None
-        with self._lock:
-            if self._terminal_state is None:
-                if time.monotonic() >= self._deadline:
-                    self._terminal_state = _AttemptTerminalState.DEADLINE_EXPIRED
-                    sock = self._socket
-                else:
-                    self._terminal_state = _AttemptTerminalState.COMPLETED
-                self._socket = None
-            expired = self._terminal_state is _AttemptTerminalState.DEADLINE_EXPIRED
-        if sock is not None:
-            _abort_socket(sock)
-        return expired
-
-    def raise_if_expired(self) -> None:
-        with self._lock:
-            expired = self._terminal_state is _AttemptTerminalState.DEADLINE_EXPIRED
-        if expired:
-            raise UsageWebhookDeadlineExceededError("usage webhook attempt deadline exceeded")
 
 
 def _socket_address(address: _ResolvedAddress) -> _SocketAddress:
@@ -161,60 +58,37 @@ def _socket_address(address: _ResolvedAddress) -> _SocketAddress:
     return address.host, address.port
 
 
-async def _lookup_ip(host: str, handle: _AttemptHandle) -> list[str]:
+async def _lookup_ip(host: str, timeout_seconds: float | None) -> list[str]:
     resolver: _AddressResolver = mitmproxy_rs.dns.DnsResolver()
-    async with asyncio.timeout(handle.remaining_seconds()):
+    async with asyncio.timeout(timeout_seconds):
         return await resolver.lookup_ip(host)
 
 
-def _lookup_ip_in_bridge(host: str, handle: _AttemptHandle) -> list[str]:
-    result: Future[list[str]] = Future()
-
-    def run_lookup() -> None:
-        try:
-            resolved = asyncio.run(_lookup_ip(host, handle))
-        except BaseException as exc:
-            result.set_exception(exc)
-        else:
-            result.set_result(resolved)
-
-    thread = threading.Thread(
-        target=run_lookup,
-        name="usage-webhook-dns",
-        daemon=True,
-    )
-    thread.start()
-    try:
-        try:
-            return result.result(timeout=handle.remaining_seconds())
-        except TimeoutError:
-            if not result.done():
-                handle.expire()
-            handle.raise_if_expired()
-            raise
-    finally:
-        thread.join()
+def _lookup_ip_in_bridge(host: str, timeout: float | None) -> list[str]:
+    with ThreadPoolExecutor(max_workers=1, thread_name_prefix="usage-webhook-dns") as executor:
+        return executor.submit(asyncio.run, _lookup_ip(host, timeout)).result()
 
 
-def _resolve_host(host: str, handle: _AttemptHandle) -> list[str]:
+def _resolve_host(host: str, timeout: float | None) -> list[str]:
     try:
         asyncio.get_running_loop()
     except RuntimeError:
-        return asyncio.run(_lookup_ip(host, handle))
-    return _lookup_ip_in_bridge(host, handle)
+        return asyncio.run(_lookup_ip(host, timeout))
+    return _lookup_ip_in_bridge(host, timeout)
 
 
 def _resolve_addresses(
-    host: str, port: int, handle: _AttemptHandle
+    host: str,
+    port: int,
+    timeout: float | None,
 ) -> tuple[_ResolvedAddress, ...]:
     try:
         literal_address = ipaddress.ip_address(host)
     except ValueError:
-        resolved_hosts = _resolve_host(host, handle)
+        resolved_hosts = _resolve_host(host, timeout)
     else:
         resolved_hosts = [literal_address.compressed]
 
-    handle.raise_if_expired()
     seen: set[str] = set()
     addresses: list[_ResolvedAddress] = []
     for resolved_host in resolved_hosts:
@@ -233,241 +107,90 @@ def _resolve_addresses(
 def _connect_socket(
     host: str,
     port: int,
+    timeout: float | None,
     source_address: tuple[str, int] | None,
-    handle: _AttemptHandle,
 ) -> socket.socket:
-    addresses = _resolve_addresses(host, port, handle)
+    addresses = _resolve_addresses(host, port, timeout)
     last_error: OSError | None = None
     for address in addresses:
-        handle.raise_if_expired()
-        sock = socket.socket(address.family, socket.SOCK_STREAM)
-        try:
-            handle.register_socket(sock)
-            sock.settimeout(handle.remaining_seconds())
-            if source_address is not None:
-                sock.bind(source_address)
-            sock.connect(_socket_address(address))
+        with ExitStack() as cleanup:
+            sock = socket.socket(address.family, socket.SOCK_STREAM)
+            cleanup.callback(sock.close)
             try:
-                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                sock.settimeout(timeout)
+                if source_address is not None:
+                    sock.bind(source_address)
+                sock.connect(_socket_address(address))
+                try:
+                    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                except OSError as exc:
+                    if exc.errno != errno.ENOPROTOOPT:
+                        raise
             except OSError as exc:
-                if exc.errno != errno.ENOPROTOOPT:
-                    raise
-            handle.raise_if_expired()
-        except OSError as exc:
-            last_error = exc
-            handle.clear_socket(sock)
-            _abort_socket(sock)
-            handle.raise_if_expired()
-            continue
-        except Exception:
-            handle.clear_socket(sock)
-            _abort_socket(sock)
-            raise
-        return sock
+                last_error = exc
+                continue
+            cleanup.pop_all()
+            return sock
     if last_error is not None:
         raise last_error
     raise OSError("usage webhook resolver returned no connection address")
 
 
-def _get_https_context() -> ssl.SSLContext:
-    global _https_context
-
-    context = _https_context
-    if context is not None:
-        return context
-    with _https_context_lock:
-        context = _https_context
-        if context is None:
-            context = ssl.create_default_context()
-            context.set_alpn_protocols(["http/1.1"])
-            if context.post_handshake_auth is not None:
-                context.post_handshake_auth = True
-            _https_context = context
-        return context
-
-
-class _DeadlineHTTPConnection(http_client.HTTPConnection):
-    default_port = _DEFAULT_HTTP_PORT
+class _ResolvedHTTPConnection(http_client.HTTPConnection):
+    source_address: tuple[str, int] | None
     _tunnel: Callable[[], None]
     _tunnel_host: str | None
-
-    def __init__(
-        self,
-        host: str,
-        port: int | None = None,
-        *,
-        timeout: float | None = ATTEMPT_DEADLINE_SECONDS,
-        source_address: tuple[str, int] | None = None,
-        blocksize: int = 8192,
-        attempt_handle: _AttemptHandle,
-    ) -> None:
-        super().__init__(
-            host,
-            port=port,
-            timeout=timeout,
-            source_address=source_address,
-            blocksize=blocksize,
-        )
-        self._attempt_handle = attempt_handle
-        self._source_address = source_address
 
     def connect(self) -> None:
         sys.audit("http.client.connect", self, self.host, self.port)
         self.sock = _connect_socket(
             self.host,
             self.port,
-            self._source_address,
-            self._attempt_handle,
+            self.timeout,
+            self.source_address,
         )
         if self._tunnel_host:
-            self.sock.settimeout(self._attempt_handle.remaining_seconds())
             self._tunnel()
 
-    def close(self) -> None:
-        sock = self.sock
-        try:
-            super().close()
-        finally:
-            if sock is not None:
-                self._attempt_handle.clear_socket(sock)
 
-
-class _DeadlineHTTPSConnection(http_client.HTTPSConnection):
-    default_port = _DEFAULT_HTTPS_PORT
+class _ResolvedHTTPSConnection(http_client.HTTPSConnection):
+    source_address: tuple[str, int] | None
+    _context: ssl.SSLContext
     _tunnel: Callable[[], None]
     _tunnel_host: str | None
 
-    def __init__(
-        self,
-        host: str,
-        port: int | None = None,
-        *,
-        timeout: float | None = ATTEMPT_DEADLINE_SECONDS,
-        source_address: tuple[str, int] | None = None,
-        context: ssl.SSLContext | None = None,
-        blocksize: int = 8192,
-        attempt_handle: _AttemptHandle,
-    ) -> None:
-        ssl_context = context if context is not None else _get_https_context()
-        super().__init__(
-            host,
-            port=port,
-            timeout=timeout,
-            source_address=source_address,
-            context=ssl_context,
-            blocksize=blocksize,
-        )
-        self._attempt_handle = attempt_handle
-        self._source_address = source_address
-        self._ssl_context = ssl_context
-
     def connect(self) -> None:
         sys.audit("http.client.connect", self, self.host, self.port)
-        raw_sock = _connect_socket(
+        self.sock = _connect_socket(
             self.host,
             self.port,
-            self._source_address,
-            self._attempt_handle,
+            self.timeout,
+            self.source_address,
         )
-        self.sock = raw_sock
-        try:
-            if self._tunnel_host:
-                raw_sock.settimeout(self._attempt_handle.remaining_seconds())
-                self._tunnel()
-                server_hostname = self._tunnel_host
-            else:
-                server_hostname = self.host
-            wrapped_sock = self._ssl_context.wrap_socket(
-                raw_sock,
-                server_hostname=server_hostname,
-                do_handshake_on_connect=False,
-            )
-            if wrapped_sock is not raw_sock:
-                self._attempt_handle.replace_socket(raw_sock, wrapped_sock)
-            self.sock = wrapped_sock
-            wrapped_sock.settimeout(self._attempt_handle.remaining_seconds())
-            wrapped_sock.do_handshake()
-            self._attempt_handle.raise_if_expired()
-        except Exception:
-            sock = self.sock
-            self.sock = None
-            if sock is not None:
-                self._attempt_handle.clear_socket(sock)
-                _abort_socket(sock)
-            raise
-
-    def close(self) -> None:
-        sock = self.sock
-        try:
-            super().close()
-        finally:
-            if sock is not None:
-                self._attempt_handle.clear_socket(sock)
-
-
-class _DeadlineHTTPHandler(urllib.request.HTTPHandler):
-    def __init__(self, attempt_handle: _AttemptHandle) -> None:
-        super().__init__()
-        self._connection_factory = functools.partial(
-            _DeadlineHTTPConnection,
-            attempt_handle=attempt_handle,
+        if self._tunnel_host:
+            self._tunnel()
+            server_hostname = self._tunnel_host
+        else:
+            server_hostname = self.host
+        self.sock = self._context.wrap_socket(
+            self.sock,
+            server_hostname=server_hostname,
         )
 
+
+class _ResolvedHTTPHandler(urllib.request.HTTPHandler):
     def http_open(self, req: urllib.request.Request) -> _OpenResponse:
-        return self.do_open(self._connection_factory, req)
+        return self.do_open(_ResolvedHTTPConnection, req)
 
 
-class _DeadlineHTTPSHandler(urllib.request.HTTPSHandler):
-    def __init__(self, attempt_handle: _AttemptHandle) -> None:
-        context = _get_https_context()
-        super().__init__(context=context)
-        self._ssl_context = context
-        self._connection_factory = functools.partial(
-            _DeadlineHTTPSConnection,
-            attempt_handle=attempt_handle,
-        )
+class _ResolvedHTTPSHandler(urllib.request.HTTPSHandler):
+    _context: ssl.SSLContext | None
 
     def https_open(self, req: urllib.request.Request) -> _OpenResponse:
-        return self.do_open(self._connection_factory, req, context=self._ssl_context)
-
-
-def _stop_deadline_timer(timer: threading.Timer) -> None:
-    timer.cancel()
-    timer.join()
+        return self.do_open(_ResolvedHTTPSConnection, req, context=self._context)
 
 
 def open_request(request: urllib.request.Request) -> _OpenResponse:
-    """Open one usage webhook request within one absolute attempt deadline."""
-    deadline = time.monotonic() + ATTEMPT_DEADLINE_SECONDS
-    handle = _AttemptHandle(deadline)
-    timer = threading.Timer(ATTEMPT_DEADLINE_SECONDS, handle.expire)
-    timer.name = "usage-webhook-deadline"
-    timer.daemon = True
-    timer.start()
-    try:
-        opener = build_api_opener(
-            _DeadlineHTTPHandler(handle),
-            _DeadlineHTTPSHandler(handle),
-        )
-        response = opener.open(request, timeout=ATTEMPT_DEADLINE_SECONDS)
-    except Exception as exc:
-        expired = handle.finish()
-        _stop_deadline_timer(timer)
-        if expired:
-            if isinstance(exc, urllib.error.HTTPError):
-                exc.close()
-            raise UsageWebhookDeadlineExceededError(
-                "usage webhook attempt deadline exceeded"
-            ) from exc
-        raise
-    except BaseException:
-        handle.finish()
-        _stop_deadline_timer(timer)
-        raise
-
-    expired = handle.finish()
-    _stop_deadline_timer(timer)
-    if expired:
-        response.close()
-        raise UsageWebhookDeadlineExceededError("usage webhook attempt deadline exceeded")
-    return response
+    """Open one usage webhook request with bounded DNS resolution."""
+    opener = build_api_opener(_ResolvedHTTPHandler(), _ResolvedHTTPSHandler())
+    return opener.open(request, timeout=WEBHOOK_OPERATION_TIMEOUT_SECONDS)

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -1,7 +1,9 @@
 """Tests for usage-buffer retry and overlapping flush behavior."""
 
+import asyncio
 import contextlib
 import json
+import time
 import urllib.request
 from unittest.mock import patch
 
@@ -9,6 +11,7 @@ import pytest
 
 import usage
 import usage.buffer as usage_buffer
+import usage.webhook_transport as webhook_transport
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 from tests.pending_helpers import assert_current_pending, assert_pending
 from tests.usage_buffer_helpers import (
@@ -654,6 +657,80 @@ def test_timeout_delivery_failure_retains_batch_and_retries_with_same_key(
         assert usage.flush_usage_events(trigger="test") == 0
         assert mock_open.call_count == 3
         mock_sleep.assert_called_once_with(0.5)
+
+
+def test_dns_deadline_retains_batch_and_releases_delivery_ownership(
+    tmp_path,
+    sync_usage_executor,
+    usage_webhook_server,
+):
+    pending_path = tmp_path / "usage-pending"
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    webhook_url = usage_webhook_server.url("/usage").replace("127.0.0.1", "usage-webhook.invalid")
+
+    class BlockingResolver:
+        blocked = True
+        calls = 0
+        cancellations = 0
+
+        async def lookup_ip(self, host: str) -> list[str]:
+            assert host == "usage-webhook.invalid"
+            type(self).calls += 1
+            if not type(self).blocked:
+                return ["127.0.0.1"]
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                type(self).cancellations += 1
+                raise
+            raise AssertionError("blocked resolver unexpectedly completed")
+
+    usage.set_pending_path(str(pending_path))
+    usage.buffer_usage_events(
+        webhook_url,
+        "token-a",
+        "run-1",
+        [event(source_key="source-1", quantity=10)],
+        str(proxy_log_path),
+    )
+
+    with (
+        patch.object(webhook_transport, "ATTEMPT_DEADLINE_SECONDS", 0.05),
+        patch.object(webhook_transport.mitmproxy_rs.dns, "DnsResolver", BlockingResolver),
+        patch.object(usage.webhook.time, "sleep") as mock_sleep,
+    ):
+        started_at = time.monotonic()
+        assert usage.flush_usage_events(trigger="test") == 1
+        assert time.monotonic() - started_at < 1.0
+
+        assert BlockingResolver.calls == 2
+        assert BlockingResolver.cancellations == 2
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=1,
+            reports=0,
+            flush_request_id="dns-deadline-retained",
+        )
+        assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+
+        BlockingResolver.blocked = False
+        assert usage.flush_usage_events(trigger="test") == 1
+
+    assert usage_webhook_server.request_count == 1
+    body = usage_webhook_server.requests[0].json_body()
+    assert body["runId"] == "run-1"
+    assert body["events"][0]["quantity"] == 10
+    assert BlockingResolver.calls == 3
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="dns-deadline-drained",
+    )
+    assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+    mock_sleep.assert_called_once_with(0.5)
 
 
 def test_partial_delivery_failure_retains_only_failed_batch_with_same_key(

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -659,7 +659,7 @@ def test_timeout_delivery_failure_retains_batch_and_retries_with_same_key(
         mock_sleep.assert_called_once_with(0.5)
 
 
-def test_dns_deadline_retains_batch_and_releases_delivery_ownership(
+def test_dns_timeout_retains_batch_and_releases_delivery_ownership(
     tmp_path,
     sync_usage_executor,
     usage_webhook_server,
@@ -695,7 +695,7 @@ def test_dns_deadline_retains_batch_and_releases_delivery_ownership(
     )
 
     with (
-        patch.object(webhook_transport, "ATTEMPT_DEADLINE_SECONDS", 0.05),
+        patch.object(webhook_transport, "WEBHOOK_OPERATION_TIMEOUT_SECONDS", 0.05),
         patch.object(webhook_transport.mitmproxy_rs.dns, "DnsResolver", BlockingResolver),
         patch.object(usage.webhook.time, "sleep") as mock_sleep,
     ):
@@ -710,7 +710,7 @@ def test_dns_deadline_retains_batch_and_releases_delivery_ownership(
             flows=0,
             buffered=1,
             reports=0,
-            flush_request_id="dns-deadline-retained",
+            flush_request_id="dns-timeout-retained",
         )
         assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
 
@@ -727,7 +727,7 @@ def test_dns_deadline_retains_batch_and_releases_delivery_ownership(
         flows=0,
         buffered=0,
         reports=0,
-        flush_request_id="dns-deadline-drained",
+        flush_request_id="dns-timeout-drained",
     )
     assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
     mock_sleep.assert_called_once_with(0.5)

--- a/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
@@ -1,24 +1,29 @@
 """Tests for usage webhook HTTP delivery behavior."""
 
 import json
+import socket
+import ssl
+import threading
 import time
 import urllib.error
 import urllib.request
 import uuid
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 import flow_metadata_keys as metadata_keys
 import platform_api
 import usage
+import usage.webhook_transport as webhook_transport
 from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
     read_jsonl_entries_after_flush,
     read_jsonl_text_after_flush,
 )
 from tests.pending_helpers import assert_current_pending
+from tests.thread_helpers import ThreadUnderTest
 from tests.webhook_test_helpers import (
     SANITIZED_WEBHOOK_URL,
     SENSITIVE_WEBHOOK_URL,
@@ -211,6 +216,158 @@ def test_retries_on_failure(tmp_path, real_flow, sync_usage_executor, usage_webh
         _report_and_flush_model_usage(flow)
 
     assert webhook.request_count == 2
+    mock_sleep.assert_called_once_with(0.5)
+
+
+def test_response_header_deadline_aborts_both_attempts(
+    tmp_path,
+    sync_usage_executor,
+    usage_webhook_server,
+):
+    pending_path = tmp_path / "usage-pending"
+    proxy_log = tmp_path / "proxy.jsonl"
+    release_headers = threading.Event()
+    delivery_outcomes: list[str] = []
+    usage.set_pending_path(str(pending_path))
+    usage_webhook_server.queue_response(204, release_event=release_headers)
+    usage_webhook_server.queue_response(204, release_event=release_headers)
+
+    def deliver() -> None:
+        assert usage.webhook.enqueue_webhook_delivery(
+            usage_webhook_server.url("/usage"),
+            "tok",
+            {"runId": "run-1", "events": []},
+            str(proxy_log),
+            "usage_event",
+            delivery_outcome_callback=delivery_outcomes.append,
+        )
+
+    try:
+        with (
+            patch.object(webhook_transport, "ATTEMPT_DEADLINE_SECONDS", 0.05),
+            patch.object(usage.webhook.time, "sleep") as mock_sleep,
+        ):
+            delivery_thread = ThreadUnderTest(target=deliver, name="blocked-usage-webhook")
+            delivery_thread.start()
+            assert usage_webhook_server.wait_for_request_count(2, timeout=1.0)
+            delivery_thread.join_and_raise(timeout=1.0)
+
+        assert not release_headers.is_set()
+        assert usage_webhook_server.request_count == 2
+        assert delivery_outcomes == ["retryable_failure"]
+        assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+        assert not any(
+            thread.name == "usage-webhook-deadline" and thread.is_alive()
+            for thread in threading.enumerate()
+        )
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="response-deadline",
+        )
+        mock_sleep.assert_called_once_with(0.5)
+    finally:
+        release_headers.set()
+
+
+def test_https_deadline_connects_to_resolved_ip_and_aborts_owned_tls_socket(
+    tmp_path,
+    sync_usage_executor,
+):
+    proxy_log = tmp_path / "proxy.jsonl"
+    delivery_outcomes: list[str] = []
+    resolver_calls: list[str] = []
+    raw_sockets = [MagicMock(), MagicMock()]
+    raw_socket_iterator = iter(raw_sockets)
+    real_socket = socket.socket
+    tls_sockets: list[MagicMock] = []
+    server_hostnames: list[str] = []
+    tls_context = MagicMock(spec=ssl.SSLContext)
+    tls_context.post_handshake_auth = False
+
+    class PublicResolver:
+        async def lookup_ip(self, host: str) -> list[str]:
+            resolver_calls.append(host)
+            return ["203.0.113.10"]
+
+    def wrap_socket(
+        raw_socket: MagicMock,
+        *,
+        server_hostname: str,
+        do_handshake_on_connect: bool,
+    ) -> MagicMock:
+        assert raw_socket in raw_sockets
+        assert not do_handshake_on_connect
+        server_hostnames.append(server_hostname)
+        aborted = threading.Event()
+        tls_socket = MagicMock()
+
+        def block_handshake() -> None:
+            assert aborted.wait(timeout=1.0)
+            raise OSError("TLS handshake aborted")
+
+        tls_socket.do_handshake.side_effect = block_handshake
+        tls_socket.shutdown.side_effect = lambda _how: aborted.set()
+        tls_socket.close.side_effect = aborted.set
+        tls_sockets.append(tls_socket)
+        return tls_socket
+
+    tls_context.wrap_socket.side_effect = wrap_socket
+
+    def create_socket(
+        family: int = -1,
+        socket_type: int = -1,
+        protocol: int = -1,
+        file_descriptor: int | None = None,
+    ) -> socket.socket | MagicMock:
+        if (
+            family == socket.AF_INET
+            and socket_type == socket.SOCK_STREAM
+            and protocol == -1
+            and file_descriptor is None
+        ):
+            return next(raw_socket_iterator)
+        if file_descriptor is None:
+            return real_socket(family, socket_type, protocol)
+        return real_socket(family, socket_type, protocol, file_descriptor)
+
+    with (
+        patch.object(webhook_transport, "ATTEMPT_DEADLINE_SECONDS", 0.05),
+        patch.object(webhook_transport, "_https_context", None),
+        patch.object(webhook_transport.ssl, "create_default_context", return_value=tls_context),
+        patch.object(webhook_transport.mitmproxy_rs.dns, "DnsResolver", PublicResolver),
+        patch.object(webhook_transport.socket, "socket", side_effect=create_socket),
+        patch.object(webhook_transport.urllib.request, "getproxies", return_value={}),
+        patch.object(usage.webhook.time, "sleep") as mock_sleep,
+    ):
+        assert usage.webhook.enqueue_webhook_delivery(
+            "https://webhook.example.test/usage",
+            "tok",
+            {"runId": "run-1", "events": []},
+            str(proxy_log),
+            "usage_event",
+            delivery_outcome_callback=delivery_outcomes.append,
+        )
+        sync_usage_executor.shutdown(wait=True)
+
+    assert resolver_calls == ["webhook.example.test", "webhook.example.test"]
+    for raw_socket in raw_sockets:
+        raw_socket.connect.assert_called_once_with(("203.0.113.10", 443))
+        raw_socket.setsockopt.assert_called_once_with(
+            socket.IPPROTO_TCP,
+            socket.TCP_NODELAY,
+            1,
+        )
+    assert server_hostnames == ["webhook.example.test", "webhook.example.test"]
+    assert len(tls_sockets) == 2
+    for tls_socket in tls_sockets:
+        tls_socket.shutdown.assert_called_with(socket.SHUT_RDWR)
+        assert tls_socket.close.called
+    tls_context.set_alpn_protocols.assert_called_once_with(["http/1.1"])
+    assert tls_context.post_handshake_auth is True
+    assert delivery_outcomes == ["retryable_failure"]
     mock_sleep.assert_called_once_with(0.5)
 
 
@@ -537,4 +694,37 @@ def test_falls_back_to_sync_after_shutdown(
     assert body["events"][0]["category"] == "tokens.input"
     assert_current_pending(
         pending_path, flows=0, buffered=0, reports=0, flush_request_id="sync-fallback"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_fallback_resolves_hostname_from_active_event_loop(
+    tmp_path,
+    fresh_usage_executor,
+    usage_webhook_server,
+):
+    proxy_log = tmp_path / "proxy.jsonl"
+    resolver_threads: list[str] = []
+
+    class LocalResolver:
+        async def lookup_ip(self, host: str) -> list[str]:
+            assert host == "usage-webhook.invalid"
+            resolver_threads.append(threading.current_thread().name)
+            return ["127.0.0.1"]
+
+    fresh_usage_executor.shutdown(wait=True)
+    webhook_url = usage_webhook_server.url("/usage").replace("127.0.0.1", "usage-webhook.invalid")
+    with patch.object(webhook_transport.mitmproxy_rs.dns, "DnsResolver", LocalResolver):
+        assert usage.webhook.enqueue_webhook_delivery(
+            webhook_url,
+            "tok",
+            {"runId": "run-1", "events": []},
+            str(proxy_log),
+            "usage_event",
+        )
+
+    assert usage_webhook_server.request_count == 1
+    assert resolver_threads == ["usage-webhook-dns"]
+    assert not any(
+        thread.name == "usage-webhook-dns" and thread.is_alive() for thread in threading.enumerate()
     )

--- a/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
@@ -283,9 +283,8 @@ def test_https_deadline_connects_to_resolved_ip_and_aborts_owned_tls_socket(
     raw_socket_iterator = iter(raw_sockets)
     real_socket = socket.socket
     tls_sockets: list[MagicMock] = []
+    tls_contexts: list[ssl.SSLContext] = []
     server_hostnames: list[str] = []
-    tls_context = MagicMock(spec=ssl.SSLContext)
-    tls_context.post_handshake_auth = False
 
     class PublicResolver:
         async def lookup_ip(self, host: str) -> list[str]:
@@ -293,6 +292,7 @@ def test_https_deadline_connects_to_resolved_ip_and_aborts_owned_tls_socket(
             return ["203.0.113.10"]
 
     def wrap_socket(
+        context: ssl.SSLContext,
         raw_socket: MagicMock,
         *,
         server_hostname: str,
@@ -300,6 +300,7 @@ def test_https_deadline_connects_to_resolved_ip_and_aborts_owned_tls_socket(
     ) -> MagicMock:
         assert raw_socket in raw_sockets
         assert not do_handshake_on_connect
+        tls_contexts.append(context)
         server_hostnames.append(server_hostname)
         aborted = threading.Event()
         tls_socket = MagicMock()
@@ -313,8 +314,6 @@ def test_https_deadline_connects_to_resolved_ip_and_aborts_owned_tls_socket(
         tls_socket.close.side_effect = aborted.set
         tls_sockets.append(tls_socket)
         return tls_socket
-
-    tls_context.wrap_socket.side_effect = wrap_socket
 
     def create_socket(
         family: int = -1,
@@ -335,8 +334,7 @@ def test_https_deadline_connects_to_resolved_ip_and_aborts_owned_tls_socket(
 
     with (
         patch.object(webhook_transport, "ATTEMPT_DEADLINE_SECONDS", 0.05),
-        patch.object(webhook_transport, "_https_context", None),
-        patch.object(webhook_transport.ssl, "create_default_context", return_value=tls_context),
+        patch.object(ssl.SSLContext, "wrap_socket", autospec=True, side_effect=wrap_socket),
         patch.object(webhook_transport.mitmproxy_rs.dns, "DnsResolver", PublicResolver),
         patch.object(webhook_transport.socket, "socket", side_effect=create_socket),
         patch.object(webhook_transport.urllib.request, "getproxies", return_value={}),
@@ -365,8 +363,12 @@ def test_https_deadline_connects_to_resolved_ip_and_aborts_owned_tls_socket(
     for tls_socket in tls_sockets:
         tls_socket.shutdown.assert_called_with(socket.SHUT_RDWR)
         assert tls_socket.close.called
-    tls_context.set_alpn_protocols.assert_called_once_with(["http/1.1"])
-    assert tls_context.post_handshake_auth is True
+    assert len(tls_contexts) == 2
+    assert len({id(context) for context in tls_contexts}) == 1
+    for context in tls_contexts:
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+        assert context.post_handshake_auth is True
     assert delivery_outcomes == ["retryable_failure"]
     mock_sleep.assert_called_once_with(0.5)
 

--- a/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
@@ -1,5 +1,6 @@
 """Tests for usage webhook HTTP delivery behavior."""
 
+import io
 import json
 import socket
 import ssl
@@ -272,7 +273,7 @@ def test_response_header_deadline_aborts_both_attempts(
         release_headers.set()
 
 
-def test_https_deadline_connects_to_resolved_ip_and_aborts_owned_tls_socket(
+def test_https_proxy_deadline_preserves_target_tls_identity_and_aborts_tls_socket(
     tmp_path,
     sync_usage_executor,
 ):
@@ -285,6 +286,10 @@ def test_https_deadline_connects_to_resolved_ip_and_aborts_owned_tls_socket(
     tls_sockets: list[MagicMock] = []
     tls_contexts: list[ssl.SSLContext] = []
     server_hostnames: list[str] = []
+    for raw_socket in raw_sockets:
+        raw_socket.makefile.return_value = io.BytesIO(
+            b"HTTP/1.0 200 Connection established\r\n\r\n"
+        )
 
     class PublicResolver:
         async def lookup_ip(self, host: str) -> list[str]:
@@ -337,7 +342,12 @@ def test_https_deadline_connects_to_resolved_ip_and_aborts_owned_tls_socket(
         patch.object(ssl.SSLContext, "wrap_socket", autospec=True, side_effect=wrap_socket),
         patch.object(webhook_transport.mitmproxy_rs.dns, "DnsResolver", PublicResolver),
         patch.object(webhook_transport.socket, "socket", side_effect=create_socket),
-        patch.object(webhook_transport.urllib.request, "getproxies", return_value={}),
+        patch.object(
+            webhook_transport.urllib.request,
+            "getproxies",
+            return_value={"https": "http://proxy.example.test:8443"},
+        ),
+        patch.object(webhook_transport.urllib.request, "proxy_bypass", return_value=False),
         patch.object(usage.webhook.time, "sleep") as mock_sleep,
     ):
         assert usage.webhook.enqueue_webhook_delivery(
@@ -350,14 +360,18 @@ def test_https_deadline_connects_to_resolved_ip_and_aborts_owned_tls_socket(
         )
         sync_usage_executor.shutdown(wait=True)
 
-    assert resolver_calls == ["webhook.example.test", "webhook.example.test"]
+    assert resolver_calls == ["proxy.example.test", "proxy.example.test"]
     for raw_socket in raw_sockets:
-        raw_socket.connect.assert_called_once_with(("203.0.113.10", 443))
+        raw_socket.connect.assert_called_once_with(("203.0.113.10", 8443))
         raw_socket.setsockopt.assert_called_once_with(
             socket.IPPROTO_TCP,
             socket.TCP_NODELAY,
             1,
         )
+        request_bytes = b"".join(call.args[0] for call in raw_socket.sendall.call_args_list)
+        request_line = request_bytes.split(b"\r\n", 1)[0]
+        assert request_line.startswith(b"CONNECT webhook.example.test:443 HTTP/1.")
+        assert b"Host: webhook.example.test:443\r\n" in request_bytes
     assert server_hostnames == ["webhook.example.test", "webhook.example.test"]
     assert len(tls_sockets) == 2
     for tls_socket in tls_sockets:

--- a/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
@@ -24,7 +24,6 @@ from tests.jsonl_log_helpers import (
     read_jsonl_text_after_flush,
 )
 from tests.pending_helpers import assert_current_pending
-from tests.thread_helpers import ThreadUnderTest
 from tests.webhook_test_helpers import (
     SANITIZED_WEBHOOK_URL,
     SENSITIVE_WEBHOOK_URL,
@@ -220,76 +219,38 @@ def test_retries_on_failure(tmp_path, real_flow, sync_usage_executor, usage_webh
     mock_sleep.assert_called_once_with(0.5)
 
 
-def test_response_header_deadline_aborts_both_attempts(
+@pytest.mark.parametrize(
+    ("proxies", "connection_host", "connection_port", "uses_connect"),
+    [
+        ({}, "webhook.example.test", 443, False),
+        (
+            {"https": "http://proxy.example.test:8443"},
+            "proxy.example.test",
+            8443,
+            True,
+        ),
+    ],
+)
+def test_https_preserves_connection_and_target_identity(
     tmp_path,
     sync_usage_executor,
-    usage_webhook_server,
-):
-    pending_path = tmp_path / "usage-pending"
-    proxy_log = tmp_path / "proxy.jsonl"
-    release_headers = threading.Event()
-    delivery_outcomes: list[str] = []
-    usage.set_pending_path(str(pending_path))
-    usage_webhook_server.queue_response(204, release_event=release_headers)
-    usage_webhook_server.queue_response(204, release_event=release_headers)
-
-    def deliver() -> None:
-        assert usage.webhook.enqueue_webhook_delivery(
-            usage_webhook_server.url("/usage"),
-            "tok",
-            {"runId": "run-1", "events": []},
-            str(proxy_log),
-            "usage_event",
-            delivery_outcome_callback=delivery_outcomes.append,
-        )
-
-    try:
-        with (
-            patch.object(webhook_transport, "ATTEMPT_DEADLINE_SECONDS", 0.05),
-            patch.object(usage.webhook.time, "sleep") as mock_sleep,
-        ):
-            delivery_thread = ThreadUnderTest(target=deliver, name="blocked-usage-webhook")
-            delivery_thread.start()
-            assert usage_webhook_server.wait_for_request_count(2, timeout=1.0)
-            delivery_thread.join_and_raise(timeout=1.0)
-
-        assert not release_headers.is_set()
-        assert usage_webhook_server.request_count == 2
-        assert delivery_outcomes == ["retryable_failure"]
-        assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
-        assert not any(
-            thread.name == "usage-webhook-deadline" and thread.is_alive()
-            for thread in threading.enumerate()
-        )
-        assert_current_pending(
-            pending_path,
-            flows=0,
-            buffered=0,
-            reports=0,
-            flush_request_id="response-deadline",
-        )
-        mock_sleep.assert_called_once_with(0.5)
-    finally:
-        release_headers.set()
-
-
-def test_https_proxy_deadline_preserves_target_tls_identity_and_aborts_tls_socket(
-    tmp_path,
-    sync_usage_executor,
+    proxies: dict[str, str],
+    connection_host: str,
+    connection_port: int,
+    uses_connect: bool,
 ):
     proxy_log = tmp_path / "proxy.jsonl"
     delivery_outcomes: list[str] = []
     resolver_calls: list[str] = []
-    raw_sockets = [MagicMock(), MagicMock()]
-    raw_socket_iterator = iter(raw_sockets)
+    raw_socket = MagicMock()
     real_socket = socket.socket
-    tls_sockets: list[MagicMock] = []
+    tls_socket = MagicMock()
     tls_contexts: list[ssl.SSLContext] = []
     server_hostnames: list[str] = []
-    for raw_socket in raw_sockets:
-        raw_socket.makefile.return_value = io.BytesIO(
-            b"HTTP/1.0 200 Connection established\r\n\r\n"
-        )
+    raw_socket.makefile.return_value = io.BytesIO(b"HTTP/1.0 200 Connection established\r\n\r\n")
+    tls_socket.makefile.return_value = io.BytesIO(
+        b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n"
+    )
 
     class PublicResolver:
         async def lookup_ip(self, host: str) -> list[str]:
@@ -298,26 +259,13 @@ def test_https_proxy_deadline_preserves_target_tls_identity_and_aborts_tls_socke
 
     def wrap_socket(
         context: ssl.SSLContext,
-        raw_socket: MagicMock,
+        socket_to_wrap: MagicMock,
         *,
         server_hostname: str,
-        do_handshake_on_connect: bool,
     ) -> MagicMock:
-        assert raw_socket in raw_sockets
-        assert not do_handshake_on_connect
+        assert socket_to_wrap is raw_socket
         tls_contexts.append(context)
         server_hostnames.append(server_hostname)
-        aborted = threading.Event()
-        tls_socket = MagicMock()
-
-        def block_handshake() -> None:
-            assert aborted.wait(timeout=1.0)
-            raise OSError("TLS handshake aborted")
-
-        tls_socket.do_handshake.side_effect = block_handshake
-        tls_socket.shutdown.side_effect = lambda _how: aborted.set()
-        tls_socket.close.side_effect = aborted.set
-        tls_sockets.append(tls_socket)
         return tls_socket
 
     def create_socket(
@@ -332,23 +280,21 @@ def test_https_proxy_deadline_preserves_target_tls_identity_and_aborts_tls_socke
             and protocol == -1
             and file_descriptor is None
         ):
-            return next(raw_socket_iterator)
+            return raw_socket
         if file_descriptor is None:
             return real_socket(family, socket_type, protocol)
         return real_socket(family, socket_type, protocol, file_descriptor)
 
     with (
-        patch.object(webhook_transport, "ATTEMPT_DEADLINE_SECONDS", 0.05),
         patch.object(ssl.SSLContext, "wrap_socket", autospec=True, side_effect=wrap_socket),
         patch.object(webhook_transport.mitmproxy_rs.dns, "DnsResolver", PublicResolver),
         patch.object(webhook_transport.socket, "socket", side_effect=create_socket),
         patch.object(
             webhook_transport.urllib.request,
             "getproxies",
-            return_value={"https": "http://proxy.example.test:8443"},
+            return_value=proxies,
         ),
         patch.object(webhook_transport.urllib.request, "proxy_bypass", return_value=False),
-        patch.object(usage.webhook.time, "sleep") as mock_sleep,
     ):
         assert usage.webhook.enqueue_webhook_delivery(
             "https://webhook.example.test/usage",
@@ -360,31 +306,32 @@ def test_https_proxy_deadline_preserves_target_tls_identity_and_aborts_tls_socke
         )
         sync_usage_executor.shutdown(wait=True)
 
-    assert resolver_calls == ["proxy.example.test", "proxy.example.test"]
-    for raw_socket in raw_sockets:
-        raw_socket.connect.assert_called_once_with(("203.0.113.10", 8443))
-        raw_socket.setsockopt.assert_called_once_with(
-            socket.IPPROTO_TCP,
-            socket.TCP_NODELAY,
-            1,
-        )
-        request_bytes = b"".join(call.args[0] for call in raw_socket.sendall.call_args_list)
-        request_line = request_bytes.split(b"\r\n", 1)[0]
-        assert request_line.startswith(b"CONNECT webhook.example.test:443 HTTP/1.")
-        assert b"Host: webhook.example.test:443\r\n" in request_bytes
-    assert server_hostnames == ["webhook.example.test", "webhook.example.test"]
-    assert len(tls_sockets) == 2
-    for tls_socket in tls_sockets:
-        tls_socket.shutdown.assert_called_with(socket.SHUT_RDWR)
-        assert tls_socket.close.called
-    assert len(tls_contexts) == 2
-    assert len({id(context) for context in tls_contexts}) == 1
+    assert resolver_calls == [connection_host]
+    raw_socket.connect.assert_called_once_with(("203.0.113.10", connection_port))
+    raw_socket.settimeout.assert_called_once_with(10.0)
+    raw_socket.setsockopt.assert_called_once_with(
+        socket.IPPROTO_TCP,
+        socket.TCP_NODELAY,
+        1,
+    )
+    connect_bytes = b"".join(call.args[0] for call in raw_socket.sendall.call_args_list)
+    if uses_connect:
+        connect_line = connect_bytes.split(b"\r\n", 1)[0]
+        assert connect_line.startswith(b"CONNECT webhook.example.test:443 HTTP/1.")
+        assert b"Host: webhook.example.test:443\r\n" in connect_bytes
+    else:
+        assert connect_bytes == b""
+    assert server_hostnames == ["webhook.example.test"]
+    request_bytes = b"".join(call.args[0] for call in tls_socket.sendall.call_args_list)
+    assert request_bytes.startswith(b"POST /usage HTTP/1.1\r\n")
+    assert b"Host: webhook.example.test\r\n" in request_bytes
+    assert len(tls_contexts) == 1
     for context in tls_contexts:
         assert context.verify_mode == ssl.CERT_REQUIRED
         assert context.check_hostname is True
         assert context.post_handshake_auth is True
-    assert delivery_outcomes == ["retryable_failure"]
-    mock_sleep.assert_called_once_with(0.5)
+    assert tls_socket.close.called
+    assert delivery_outcomes == ["success"]
 
 
 def test_gives_up_after_retry_budget(tmp_path, real_flow, sync_usage_executor, usage_webhook_api):
@@ -740,7 +687,9 @@ async def test_sync_fallback_resolves_hostname_from_active_event_loop(
         )
 
     assert usage_webhook_server.request_count == 1
-    assert resolver_threads == ["usage-webhook-dns"]
+    assert len(resolver_threads) == 1
+    assert resolver_threads[0].startswith("usage-webhook-dns")
     assert not any(
-        thread.name == "usage-webhook-dns" and thread.is_alive() for thread in threading.enumerate()
+        thread.name.startswith("usage-webhook-dns") and thread.is_alive()
+        for thread in threading.enumerate()
     )


### PR DESCRIPTION
## Summary

- bound usage webhook DNS lookup with the cancelable resolver already shipped in the standalone mitmproxy runtime
- connect to resolved numeric IPv4/IPv6 addresses while preserving the original direct or proxied destination for HTTP `Host`, CONNECT, TLS SNI, and certificate verification
- preserve the existing retry, retained payload/idempotency, redirect rejection, credentials, HTTP status classification, and urllib socket-timeout behavior

## Scope

- this fixes the demonstrated DNS stall; TCP, proxy CONNECT, TLS, send, and response reads retain urllib's per-operation timeout semantics rather than sharing one aggregate wall-clock deadline
- no API, schema, migration, queue payload, persisted-state, dependency, feature-switch, or auth-base forwarding changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_usage_buffer_flush_failures.py tests/test_webhook_http_delivery.py tests/test_done_hook.py` (50 passed)
- `uv run --no-sync python -m pytest tests/` (4,594 passed)

Closes #24718
