### PR TITLE
perf(python): enforce firewall auth fetch deadline

### DIFF
--- a/crates/runner/mitm-addon/pyproject.toml
+++ b/crates/runner/mitm-addon/pyproject.toml
@@ -11,6 +11,8 @@ dev = [
 ]
 test = [
     "Brotli>=1.2.0",
+    "cryptography==48.0.1",
+    "h11==0.16.0",
     "h2>=4.3.0",
     "pytest>=7.0",
     "pytest-asyncio>=0.23",

--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -62,6 +62,10 @@ class FirewallAuthDeadlineExceededError(Exception):
     """Raised when one /firewall/auth request exceeds its total lifetime."""
 
 
+class FirewallAuthProtocolError(Exception):
+    """Raised when the platform returns malformed HTTP without exposing its bytes."""
+
+
 class FirewallAuthApiError(Exception):
     """Raised when /firewall/auth returns a structured error envelope."""
 
@@ -802,6 +806,8 @@ async def fetch_firewall_headers(
                 "Firewall auth fetch deadline exceeded"
             ) from None
         raise
+    except h11.ProtocolError:
+        raise FirewallAuthProtocolError("Firewall auth HTTP protocol error") from None
 
     if not _HTTP_STATUS_SUCCESS_MIN <= response.status < _HTTP_STATUS_REDIRECTION_MIN:
         _raise_firewall_auth_http_error(response, url)

--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -92,6 +92,12 @@ class _ResolvedAddress(NamedTuple):
     port: int
 
 
+class _ConnectedStream(NamedTuple):
+    reader: asyncio.StreamReader
+    writer: asyncio.StreamWriter
+    socket: socket.socket
+
+
 @dataclass(frozen=True)
 class _ConnectionPlan:
     origin_scheme: str
@@ -336,7 +342,7 @@ def _abort_socket(sock: socket.socket) -> None:
 
 async def _open_connected_stream(
     addresses: tuple[_ResolvedAddress, ...],
-) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+) -> _ConnectedStream:
     loop = asyncio.get_running_loop()
     last_error: OSError | None = None
     for address in addresses:
@@ -365,17 +371,18 @@ async def _open_connected_stream(
         except BaseException:
             _abort_socket(sock)
             raise
-        return reader, writer
+        return _ConnectedStream(reader, writer, sock)
 
     if last_error is None:
         raise OSError("Firewall auth connection failed")
     raise last_error
 
 
-async def _abort_writer(writer: asyncio.StreamWriter) -> None:
-    writer.transport.abort()
-    with suppress(OSError):
-        await writer.wait_closed()
+def _abort_stream(stream: _ConnectedStream) -> None:
+    try:
+        stream.writer.transport.abort()
+    finally:
+        _abort_socket(stream.socket)
 
 
 async def _read_proxy_connect_status(reader: asyncio.StreamReader) -> int:
@@ -415,21 +422,21 @@ async def _establish_proxy_tunnel(
         raise OSError(f"Firewall auth HTTP proxy CONNECT failed with status {status}")
 
 
-async def _open_stream(plan: _ConnectionPlan) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+async def _open_stream(plan: _ConnectionPlan) -> _ConnectedStream:
     addresses = await _resolve_addresses(plan.connect_host, plan.connect_port)
-    reader, writer = await _open_connected_stream(addresses)
+    stream = await _open_connected_stream(addresses)
     try:
         if plan.use_proxy_tunnel:
-            await _establish_proxy_tunnel(writer, reader, plan)
+            await _establish_proxy_tunnel(stream.writer, stream.reader, plan)
         if plan.origin_scheme == "https":
-            await writer.start_tls(
+            await stream.writer.start_tls(
                 _get_https_context(),
                 server_hostname=plan.origin_host,
             )
     except BaseException:
-        await _abort_writer(writer)
+        _abort_stream(stream)
         raise
-    return reader, writer
+    return stream
 
 
 def _request_headers(
@@ -513,13 +520,13 @@ async def _perform_http_request(
     plan: _ConnectionPlan,
     body: bytes,
 ) -> _HttpResponse:
-    reader, writer = await _open_stream(plan)
+    stream = await _open_stream(plan)
     connection = h11.Connection(
         h11.CLIENT,
         max_incomplete_event_size=_MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES,
     )
     try:
-        writer.write(
+        stream.writer.write(
             connection.send(
                 h11.Request(
                     method=req.get_method(),
@@ -528,16 +535,17 @@ async def _perform_http_request(
                 )
             )
         )
-        writer.write(connection.send(h11.Data(data=body)))
-        writer.write(connection.send(h11.EndOfMessage()))
-        await writer.drain()
-        response = await _read_http_response(reader, connection)
-        writer.close()
+        stream.writer.write(connection.send(h11.Data(data=body)))
+        stream.writer.write(connection.send(h11.EndOfMessage()))
+        await stream.writer.drain()
+        response = await _read_http_response(stream.reader, connection)
+        stream.writer.close()
         with suppress(OSError):
-            await writer.wait_closed()
+            await stream.writer.wait_closed()
+        stream.socket.close()
         return response
     except BaseException:
-        await _abort_writer(writer)
+        _abort_stream(stream)
         raise
 
 

--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -337,7 +337,8 @@ async def _resolve_addresses(host: str, port: int) -> tuple[_ResolvedAddress, ..
 def _abort_socket(sock: socket.socket) -> None:
     with suppress(OSError):
         sock.shutdown(socket.SHUT_RDWR)
-    sock.close()
+    with suppress(OSError):
+        sock.close()
 
 
 async def _open_connected_stream(

--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -1,16 +1,39 @@
 """Client and response parsing for the runner firewall auth endpoint."""
 
 import asyncio
+import base64
+import errno
+import io
+import ipaddress
 import json
 import math
+import socket
+import ssl
 import urllib.error
+import urllib.parse
+import urllib.request
+from contextlib import suppress
 from dataclasses import dataclass, field
-from typing import Protocol
+from email.message import Message
+from typing import NamedTuple, Protocol
+
+import h11
+import mitmproxy_rs
 
 import platform_api
 from aws_sigv4 import AwsSigV4Credentials
 
 MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES = 256 * 1024
+FIREWALL_AUTH_FETCH_DEADLINE_SECONDS = 10.0
+_MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES = 64 * 1024
+_DEFAULT_HTTP_PORT = 80
+_DEFAULT_HTTPS_PORT = 443
+_IPV6_VERSION = 6
+_HTTP_STATUS_LINE_MIN_PARTS = 2
+_HTTP_STATUS_INFORMATIONAL_MIN = 100
+_HTTP_STATUS_SUCCESS_MIN = 200
+_HTTP_STATUS_REDIRECTION_MIN = 300
+_HTTP_STATUS_SWITCHING_PROTOCOLS = 101
 _STRUCTURED_FIREWALL_AUTH_ERROR_CODES = frozenset(
     {
         "FORBIDDEN",
@@ -19,7 +42,8 @@ _STRUCTURED_FIREWALL_AUTH_ERROR_CODES = frozenset(
     }
 )
 _FIREWALL_AUTH_FAILURE_REASONS = frozenset({"upstream_provider", "reconnect_required"})
-_opener = platform_api.build_api_opener()
+_dns_resolver: "_AddressResolver | None" = None
+_https_context: ssl.SSLContext | None = None
 
 
 class ConnectorNotConfiguredError(Exception):
@@ -32,6 +56,10 @@ class InsufficientCreditsError(Exception):
 
 class FirewallAuthResponseTooLargeError(Exception):
     """Raised when /firewall/auth returns a response body above the local cap."""
+
+
+class FirewallAuthDeadlineExceededError(Exception):
+    """Raised when one /firewall/auth request exceeds its total lifetime."""
 
 
 class FirewallAuthApiError(Exception):
@@ -53,9 +81,35 @@ class FirewallAuthApiError(Exception):
         self.failure_reason = failure_reason
 
 
-class _ResponseBodyReader(Protocol):
-    def read(self, n: int = -1) -> bytes:
+class _AddressResolver(Protocol):
+    async def lookup_ip(self, host: str) -> list[str]:
         raise NotImplementedError
+
+
+class _ResolvedAddress(NamedTuple):
+    family: socket.AddressFamily
+    host: str
+    port: int
+
+
+@dataclass(frozen=True)
+class _ConnectionPlan:
+    origin_scheme: str
+    origin_host: str
+    origin_authority: str
+    connect_host: str
+    connect_port: int
+    request_target: str
+    use_proxy_tunnel: bool = False
+    proxy_authorization: str | None = field(default=None, repr=False)
+
+
+@dataclass(frozen=True)
+class _HttpResponse:
+    status: int
+    reason: str
+    headers: Message
+    body: bytes
 
 
 @dataclass(frozen=True)
@@ -119,11 +173,370 @@ class FirewallAuthSuccess:
     refreshed_secrets: list[str] = field(default_factory=list)
 
 
-def _read_firewall_auth_response_body(resp: _ResponseBodyReader) -> bytes:
-    body = resp.read(MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES + 1)
-    if len(body) > MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES:
-        raise FirewallAuthResponseTooLargeError("Firewall auth response body too large")
-    return body
+def reset_transport_state_for_tests() -> None:
+    """Reset lazily created network state between event-loop tests."""
+    global _dns_resolver
+    global _https_context
+
+    _dns_resolver = None
+    _https_context = None
+
+
+def _get_dns_resolver() -> _AddressResolver:
+    global _dns_resolver
+
+    resolver = _dns_resolver
+    if resolver is None:
+        resolver = mitmproxy_rs.dns.DnsResolver()
+        _dns_resolver = resolver
+    return resolver
+
+
+def _get_https_context() -> ssl.SSLContext:
+    global _https_context
+
+    context = _https_context
+    if context is None:
+        context = ssl.create_default_context()
+        context.set_alpn_protocols(["http/1.1"])
+        _https_context = context
+    return context
+
+
+def _normalized_host(host: str) -> str:
+    try:
+        return ipaddress.ip_address(host).compressed
+    except ValueError:
+        return host.encode("idna").decode("ascii")
+
+
+def _format_authority(host: str, port: int, *, include_port: bool) -> str:
+    rendered_host = f"[{host}]" if ":" in host else host
+    return f"{rendered_host}:{port}" if include_port else rendered_host
+
+
+def _parsed_port(parsed: urllib.parse.SplitResult, default_port: int, *, subject: str) -> int:
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError(f"Invalid {subject} port") from exc
+    return default_port if port is None else port
+
+
+def _proxy_authorization(parsed: urllib.parse.SplitResult) -> str | None:
+    if parsed.username is None:
+        return None
+    username = urllib.parse.unquote(parsed.username)
+    password = urllib.parse.unquote(parsed.password or "")
+    encoded = base64.b64encode(f"{username}:{password}".encode()).decode("ascii")
+    return f"Basic {encoded}"
+
+
+def _proxy_plan(
+    *,
+    scheme: str,
+    origin_authority: str,
+) -> tuple[str, int, str | None] | None:
+    if urllib.request.proxy_bypass(origin_authority):
+        return None
+
+    configured_proxy = urllib.request.getproxies().get(scheme)
+    if not configured_proxy:
+        return None
+    proxy_url = configured_proxy if "://" in configured_proxy else f"http://{configured_proxy}"
+    parsed = urllib.parse.urlsplit(proxy_url)
+    if parsed.scheme.lower() != "http":
+        raise ValueError("Firewall auth supports only HTTP environment proxies")
+    if parsed.hostname is None:
+        raise ValueError("Invalid firewall auth HTTP proxy URL")
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        raise ValueError("Invalid firewall auth HTTP proxy URL")
+    return (
+        _normalized_host(parsed.hostname),
+        _parsed_port(parsed, _DEFAULT_HTTP_PORT, subject="firewall auth HTTP proxy"),
+        _proxy_authorization(parsed),
+    )
+
+
+def _build_connection_plan(req: urllib.request.Request) -> _ConnectionPlan:
+    parsed = urllib.parse.urlsplit(req.full_url)
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"} or parsed.hostname is None:
+        raise ValueError("Platform API URL must be an absolute http(s) URL")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("Platform API URL must not contain user information")
+
+    default_port = _DEFAULT_HTTPS_PORT if scheme == "https" else _DEFAULT_HTTP_PORT
+    origin_host = _normalized_host(parsed.hostname)
+    origin_port = _parsed_port(parsed, default_port, subject="platform API")
+    origin_authority = _format_authority(
+        origin_host,
+        origin_port,
+        include_port=parsed.port is not None,
+    )
+    path = parsed.path or "/"
+    origin_target = f"{path}?{parsed.query}" if parsed.query else path
+    proxy = _proxy_plan(scheme=scheme, origin_authority=origin_authority)
+    if proxy is None:
+        return _ConnectionPlan(
+            origin_scheme=scheme,
+            origin_host=origin_host,
+            origin_authority=origin_authority,
+            connect_host=origin_host,
+            connect_port=origin_port,
+            request_target=origin_target,
+        )
+
+    proxy_host, proxy_port, proxy_authorization = proxy
+    request_target = (
+        urllib.parse.urlunsplit((scheme, origin_authority, path, parsed.query, ""))
+        if scheme == "http"
+        else origin_target
+    )
+    return _ConnectionPlan(
+        origin_scheme=scheme,
+        origin_host=origin_host,
+        origin_authority=origin_authority,
+        connect_host=proxy_host,
+        connect_port=proxy_port,
+        request_target=request_target,
+        use_proxy_tunnel=scheme == "https",
+        proxy_authorization=proxy_authorization,
+    )
+
+
+async def _resolve_addresses(host: str, port: int) -> tuple[_ResolvedAddress, ...]:
+    try:
+        literal_address = ipaddress.ip_address(host)
+    except ValueError:
+        resolved_hosts = await _get_dns_resolver().lookup_ip(host)
+    else:
+        resolved_hosts = [literal_address.compressed]
+
+    addresses: list[_ResolvedAddress] = []
+    seen: set[str] = set()
+    for resolved_host in resolved_hosts:
+        address = ipaddress.ip_address(resolved_host)
+        normalized = address.compressed
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        family = socket.AF_INET6 if address.version == _IPV6_VERSION else socket.AF_INET
+        addresses.append(_ResolvedAddress(family, normalized, port))
+    if not addresses:
+        raise socket.gaierror(socket.EAI_NONAME, "Firewall auth host did not resolve")
+    return tuple(addresses)
+
+
+def _abort_socket(sock: socket.socket) -> None:
+    with suppress(OSError):
+        sock.shutdown(socket.SHUT_RDWR)
+    sock.close()
+
+
+async def _open_connected_stream(
+    addresses: tuple[_ResolvedAddress, ...],
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    loop = asyncio.get_running_loop()
+    last_error: OSError | None = None
+    for address in addresses:
+        sock = socket.socket(address.family, socket.SOCK_STREAM)
+        sock.setblocking(False)
+        try:
+            socket_address: tuple[str, int] | tuple[str, int, int, int]
+            if address.family == socket.AF_INET6:
+                socket_address = (address.host, address.port, 0, 0)
+            else:
+                socket_address = (address.host, address.port)
+            await loop.sock_connect(sock, socket_address)
+            try:
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            except OSError as exc:
+                if exc.errno != errno.ENOPROTOOPT:
+                    raise
+            reader, writer = await asyncio.open_connection(
+                sock=sock,
+                limit=_MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES,
+            )
+        except OSError as exc:
+            last_error = exc
+            _abort_socket(sock)
+            continue
+        except BaseException:
+            _abort_socket(sock)
+            raise
+        return reader, writer
+
+    if last_error is None:
+        raise OSError("Firewall auth connection failed")
+    raise last_error
+
+
+def _abort_writer(writer: asyncio.StreamWriter) -> None:
+    writer.transport.abort()
+
+
+async def _read_proxy_connect_status(reader: asyncio.StreamReader) -> int:
+    total_header_bytes = 0
+    while True:
+        header_block = await reader.readuntil(b"\r\n\r\n")
+        total_header_bytes += len(header_block)
+        if total_header_bytes > _MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES:
+            raise ValueError("Firewall auth HTTP proxy response headers too large")
+        status_line = header_block.split(b"\r\n", 1)[0]
+        parts = status_line.split(b" ", 2)
+        if len(parts) < _HTTP_STATUS_LINE_MIN_PARTS or not parts[0].startswith(b"HTTP/"):
+            raise ValueError("Invalid firewall auth HTTP proxy response")
+        try:
+            status = int(parts[1])
+        except ValueError as exc:
+            raise ValueError("Invalid firewall auth HTTP proxy response") from exc
+        if not _HTTP_STATUS_INFORMATIONAL_MIN <= status < _HTTP_STATUS_SUCCESS_MIN:
+            return status
+
+
+async def _establish_proxy_tunnel(
+    writer: asyncio.StreamWriter,
+    reader: asyncio.StreamReader,
+    plan: _ConnectionPlan,
+) -> None:
+    lines = [
+        f"CONNECT {plan.origin_authority} HTTP/1.1",
+        f"Host: {plan.origin_authority}",
+    ]
+    if plan.proxy_authorization is not None:
+        lines.append(f"Proxy-Authorization: {plan.proxy_authorization}")
+    writer.write(("\r\n".join(lines) + "\r\n\r\n").encode("latin-1"))
+    await writer.drain()
+    status = await _read_proxy_connect_status(reader)
+    if not _HTTP_STATUS_SUCCESS_MIN <= status < _HTTP_STATUS_REDIRECTION_MIN:
+        raise OSError(f"Firewall auth HTTP proxy CONNECT failed with status {status}")
+
+
+async def _open_stream(plan: _ConnectionPlan) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    addresses = await _resolve_addresses(plan.connect_host, plan.connect_port)
+    reader, writer = await _open_connected_stream(addresses)
+    try:
+        if plan.use_proxy_tunnel:
+            await _establish_proxy_tunnel(writer, reader, plan)
+        if plan.origin_scheme == "https":
+            await writer.start_tls(
+                _get_https_context(),
+                server_hostname=plan.origin_host,
+            )
+    except BaseException:
+        _abort_writer(writer)
+        raise
+    return reader, writer
+
+
+def _request_headers(
+    req: urllib.request.Request,
+    plan: _ConnectionPlan,
+    body: bytes,
+) -> list[tuple[bytes, bytes]]:
+    excluded_headers = {"connection", "content-length", "host", "proxy-authorization"}
+    headers = [
+        (name.encode("ascii"), value.encode("latin-1"))
+        for name, value in req.header_items()
+        if name.lower() not in excluded_headers
+    ]
+    headers.extend(
+        (
+            (b"Host", plan.origin_authority.encode("ascii")),
+            (b"Content-Length", str(len(body)).encode("ascii")),
+            (b"Connection", b"close"),
+        )
+    )
+    if plan.proxy_authorization is not None and not plan.use_proxy_tunnel:
+        headers.append((b"Proxy-Authorization", plan.proxy_authorization.encode("latin-1")))
+    return headers
+
+
+def _response_headers(event: h11.Response | h11.InformationalResponse) -> Message:
+    headers = Message()
+    for name, value in event.headers:
+        headers.add_header(name.decode("ascii"), value.decode("latin-1"))
+    return headers
+
+
+async def _read_http_response(
+    reader: asyncio.StreamReader,
+    connection: h11.Connection,
+) -> _HttpResponse:
+    response_event: h11.Response | h11.InformationalResponse | None = None
+    body = bytearray()
+    while True:
+        event = connection.next_event()
+        if event is h11.NEED_DATA:
+            connection.receive_data(await reader.read(64 * 1024))
+            continue
+        if event is h11.PAUSED:
+            raise h11.RemoteProtocolError("Unexpected HTTP protocol switch")
+        if isinstance(event, h11.InformationalResponse):
+            if event.status_code == _HTTP_STATUS_SWITCHING_PROTOCOLS:
+                return _HttpResponse(
+                    event.status_code,
+                    event.reason.decode("latin-1"),
+                    _response_headers(event),
+                    b"",
+                )
+            continue
+        if isinstance(event, h11.Response):
+            response_event = event
+            continue
+        if isinstance(event, h11.Data):
+            if response_event is None:
+                raise h11.RemoteProtocolError("Received HTTP response body before headers")
+            if len(body) + len(event.data) > MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES:
+                raise FirewallAuthResponseTooLargeError("Firewall auth response body too large")
+            body.extend(event.data)
+            continue
+        if isinstance(event, h11.EndOfMessage):
+            if response_event is None:
+                raise h11.RemoteProtocolError("Received HTTP response without headers")
+            return _HttpResponse(
+                response_event.status_code,
+                response_event.reason.decode("latin-1"),
+                _response_headers(response_event),
+                bytes(body),
+            )
+        if isinstance(event, h11.ConnectionClosed):
+            raise h11.RemoteProtocolError("HTTP connection closed before response completed")
+        raise h11.RemoteProtocolError("Unexpected HTTP response event")
+
+
+async def _perform_http_request(
+    req: urllib.request.Request,
+    plan: _ConnectionPlan,
+    body: bytes,
+) -> _HttpResponse:
+    reader, writer = await _open_stream(plan)
+    connection = h11.Connection(
+        h11.CLIENT,
+        max_incomplete_event_size=_MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES,
+    )
+    try:
+        writer.write(
+            connection.send(
+                h11.Request(
+                    method=req.get_method(),
+                    target=plan.request_target,
+                    headers=_request_headers(req, plan, body),
+                )
+            )
+        )
+        writer.write(connection.send(h11.Data(data=body)))
+        writer.write(connection.send(h11.EndOfMessage()))
+        await writer.drain()
+        response = await _read_http_response(reader, connection)
+        writer.close()
+        with suppress(OSError):
+            await writer.wait_closed()
+        return response
+    except BaseException:
+        _abort_writer(writer)
+        raise
 
 
 def _firewall_auth_api_error_from_envelope(
@@ -303,51 +716,36 @@ def _parse_firewall_auth_success(
     )
 
 
-def _fetch_firewall_headers_sync(
-    request: FirewallAuthRequest,
-    api_url: str,
-    *,
-    force_refresh: bool = False,
-) -> FirewallAuthSuccess:
-    """Synchronous helper — runs in a thread to avoid blocking the event loop.
-
-    api_url is resolved by the async caller (fetch_firewall_headers) while
-    still on the event loop, so this function never touches ctx.options.
-    """
-    url = f"{api_url}/api/webhooks/agent/firewall/auth"
-    data = json.dumps(request.to_body(force_refresh=force_refresh)).encode()
-    req = platform_api.make_api_request(url, data, request.sandbox_token)
+def _raise_firewall_auth_http_error(response: _HttpResponse, url: str) -> None:
+    error = urllib.error.HTTPError(
+        url,
+        response.status,
+        response.reason,
+        response.headers,
+        io.BytesIO(response.body),
+    )
     try:
-        # nosemgrep: dynamic-urllib-use-detected
-        with _opener.open(req, timeout=10) as resp:
-            decoded: object = json.loads(_read_firewall_auth_response_body(resp))
-            return _parse_firewall_auth_success(decoded, request)
-    except urllib.error.HTTPError as e:
-        # HTTPError wraps an open socket; `with e` closes on every exit
-        # path to avoid FD exhaustion under sustained cache-miss load (#10475).
-        with e:
-            try:
-                error_body = json.loads(_read_firewall_auth_response_body(e))
-            except (UnicodeDecodeError, json.JSONDecodeError, OSError):
-                raise e from None
-            if not isinstance(error_body, dict):
-                raise e from None
-            error_info = error_body.get("error")
-            if not isinstance(error_info, dict):
-                raise e from None
-            error_message = error_info.get("message")
-            if error_info.get("code") == "CONNECTOR_NOT_CONFIGURED":
-                raise ConnectorNotConfiguredError(
-                    error_message if isinstance(error_message, str) else "Connector not configured",
-                ) from None
-            if error_info.get("code") == "INSUFFICIENT_CREDITS":
-                raise InsufficientCreditsError(
-                    error_message if isinstance(error_message, str) else "Insufficient credits",
-                ) from None
-            api_error = _firewall_auth_api_error_from_envelope(e.code, error_info)
-            if api_error is None:
-                raise e from None
-            raise api_error from None
+        error_body: object = json.loads(response.body)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise error from None
+    if not isinstance(error_body, dict):
+        raise error from None
+    error_info = error_body.get("error")
+    if not isinstance(error_info, dict):
+        raise error from None
+    error_message = error_info.get("message")
+    if error_info.get("code") == "CONNECTOR_NOT_CONFIGURED":
+        raise ConnectorNotConfiguredError(
+            error_message if isinstance(error_message, str) else "Connector not configured",
+        ) from None
+    if error_info.get("code") == "INSUFFICIENT_CREDITS":
+        raise InsufficientCreditsError(
+            error_message if isinstance(error_message, str) else "Insufficient credits",
+        ) from None
+    api_error = _firewall_auth_api_error_from_envelope(response.status, error_info)
+    if api_error is None:
+        raise error from None
+    raise api_error from None
 
 
 async def fetch_firewall_headers(
@@ -375,12 +773,26 @@ async def fetch_firewall_headers(
     When force_refresh is True, the endpoint refreshes access tokens regardless
     of DB tokenExpiresAt — used after the upstream returns 401 (#9860).
 
-    Uses asyncio.to_thread to avoid blocking mitmproxy's event loop.
+    One monotonic deadline covers cancellable DNS, connect, TLS, request write,
+    response headers, and the bounded response body.
     """
     api_url = platform_api.get_api_url()
-    return await asyncio.to_thread(
-        _fetch_firewall_headers_sync,
-        request,
-        api_url,
-        force_refresh=force_refresh,
-    )
+    url = f"{api_url}/api/webhooks/agent/firewall/auth"
+    body = json.dumps(request.to_body(force_refresh=force_refresh)).encode()
+    req = platform_api.make_api_request(url, body, request.sandbox_token)
+    plan = _build_connection_plan(req)
+    timeout = asyncio.timeout(FIREWALL_AUTH_FETCH_DEADLINE_SECONDS)
+    try:
+        async with timeout:
+            response = await _perform_http_request(req, plan, body)
+    except TimeoutError:
+        if timeout.expired():
+            raise FirewallAuthDeadlineExceededError(
+                "Firewall auth fetch deadline exceeded"
+            ) from None
+        raise
+
+    if not _HTTP_STATUS_SUCCESS_MIN <= response.status < _HTTP_STATUS_REDIRECTION_MIN:
+        _raise_firewall_auth_http_error(response, url)
+    decoded: object = json.loads(response.body)
+    return _parse_firewall_auth_success(decoded, request)

--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -372,8 +372,10 @@ async def _open_connected_stream(
     raise last_error
 
 
-def _abort_writer(writer: asyncio.StreamWriter) -> None:
+async def _abort_writer(writer: asyncio.StreamWriter) -> None:
     writer.transport.abort()
+    with suppress(OSError):
+        await writer.wait_closed()
 
 
 async def _read_proxy_connect_status(reader: asyncio.StreamReader) -> int:
@@ -425,7 +427,7 @@ async def _open_stream(plan: _ConnectionPlan) -> tuple[asyncio.StreamReader, asy
                 server_hostname=plan.origin_host,
             )
     except BaseException:
-        _abort_writer(writer)
+        await _abort_writer(writer)
         raise
     return reader, writer
 
@@ -535,7 +537,7 @@ async def _perform_http_request(
             await writer.wait_closed()
         return response
     except BaseException:
-        _abort_writer(writer)
+        await _abort_writer(writer)
         raise
 
 

--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -62,10 +62,6 @@ class FirewallAuthDeadlineExceededError(Exception):
     """Raised when one /firewall/auth request exceeds its total lifetime."""
 
 
-class FirewallAuthProtocolError(Exception):
-    """Raised when the platform returns malformed HTTP without exposing its bytes."""
-
-
 class FirewallAuthApiError(Exception):
     """Raised when /firewall/auth returns a structured error envelope."""
 
@@ -807,7 +803,7 @@ async def fetch_firewall_headers(
             ) from None
         raise
     except h11.ProtocolError:
-        raise FirewallAuthProtocolError("Firewall auth HTTP protocol error") from None
+        raise ValueError("Firewall auth HTTP protocol error") from None
 
     if not _HTTP_STATUS_SUCCESS_MIN <= response.status < _HTTP_STATUS_REDIRECTION_MIN:
         _raise_firewall_auth_http_error(response, url)

--- a/crates/runner/mitm-addon/src/platform_api.py
+++ b/crates/runner/mitm-addon/src/platform_api.py
@@ -53,8 +53,9 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
 
     Centralises User-Agent, Authorization, Content-Type, and the optional
     Vercel bypass header so that callers cannot accidentally omit them. The
-    credentials are unredirected as defense in depth; callers must still use
-    :func:`build_api_opener` so redirects fail before contacting another URL.
+    credentials are unredirected as defense in depth; callers must still reject
+    redirects, using :func:`build_api_opener` or an equivalent transport policy,
+    before contacting another URL.
     """
     parsed_url = urllib.parse.urlsplit(url)
     if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:

--- a/crates/runner/mitm-addon/src/platform_api.py
+++ b/crates/runner/mitm-addon/src/platform_api.py
@@ -38,7 +38,7 @@ def build_api_opener() -> urllib.request.OpenerDirector:
 
 
 def configure_client_headers(*, client_session_id: str, client_version: str) -> None:
-    """Snapshot runner-provided client header values for worker-thread requests."""
+    """Snapshot runner-provided client header values for platform API requests."""
     global _CLIENT_HEADERS
     _CLIENT_HEADERS = (client_session_id, client_version)
 

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -32,6 +32,7 @@ import builtin_connector_diagnostics
 import claude_output_timing
 import codex_model_catalog_cache
 import codex_output_timing
+import firewall_auth_client
 import logging_utils
 import mitm_addon
 import platform_api
@@ -58,6 +59,7 @@ def _reset_module_state() -> Iterator[None]:
     reset them around each case to avoid cross-test callbacks.
     """
     auth_base_forwarder.reset_forward_request_state_for_tests()
+    firewall_auth_client.reset_transport_state_for_tests()
     aws_sigv4_body_admission.reset_for_tests()
     builtin_connector_diagnostics.reset_cache_for_tests()
     registry.reset_cache_for_tests()
@@ -82,6 +84,7 @@ def _reset_module_state() -> Iterator[None]:
     codex_output_timing.reset_for_tests()
     logging_utils.reset_log_writer_for_tests()
     auth_base_forwarder.reset_forward_request_state_for_tests()
+    firewall_auth_client.reset_transport_state_for_tests()
     aws_sigv4_body_admission.reset_for_tests()
     builtin_connector_diagnostics.reset_cache_for_tests()
     upstream_destination_binding.reset_for_tests()

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -78,7 +78,7 @@ class TestFirewallHeaderCache:
         assert require_cached_headers(cache_key).headers == {"Authorization": "Bearer token"}
 
     async def test_cancelled_force_refresh_leader_keeps_shared_fetch(self, mitm_ctx):
-        """A cancelled leader must leave its threaded forced fetch available to a waiter."""
+        """A cancelled leader must leave its shared forced fetch available to a waiter."""
         endpoint = FakeAuthEndpoint()
         release_response = threading.Event()
         endpoint.queue_json_response(
@@ -410,7 +410,7 @@ class TestGetFirewallHeaders:
 
         assert headers["headers"] == fresh_headers
         assert headers["cache_hit"] is False
-        # fetch_firewall_headers wraps urllib; pins the TTL-expiry→re-fetch contract (#9991).
+        # Pin the TTL-expiry-to-refetch contract independently of the client transport.
         mock_fetch.assert_called_once()
         # Verify cache was updated with new entry
         assert require_cached_headers(cache_key).headers == fresh_headers

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -1117,7 +1117,7 @@ class TestFirewallAuthAsyncTransport:
             with (
                 mitm_ctx(api_url=f"http://127.0.0.1:{port}"),
                 patch.object(platform_api, "VERCEL_BYPASS", ""),
-                pytest.raises(auth_client.FirewallAuthProtocolError) as exc_info,
+                pytest.raises(ValueError, match=r"^Firewall auth HTTP protocol error$") as exc_info,
             ):
                 await auth_client.fetch_firewall_headers(firewall_auth_request())
 

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -1,14 +1,25 @@
 """Integration tests for the firewall auth client and response protocol."""
 
-import io
+import asyncio
+import base64
+import datetime
 import json
+import os
+import ssl
 import time
 import urllib.error
 import uuid
-from email.message import Message
-from unittest.mock import MagicMock, patch
+from collections.abc import AsyncIterator, Callable, Coroutine
+from contextlib import asynccontextmanager, suppress
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 
 import firewall_auth_cache as auth_cache
 import firewall_auth_client as auth_client
@@ -21,20 +32,148 @@ from tests.firewall_auth_helpers import firewall_auth_request
 _MALFORMED_SUCCESS_PREFIX = "Firewall auth endpoint returned malformed success response"
 
 
-def _http_error(url: str, status: int, reason: str, body: bytes) -> urllib.error.HTTPError:
-    return urllib.error.HTTPError(url, status, reason, Message(), io.BytesIO(body))
+@dataclass(frozen=True)
+class _RawHttpRequest:
+    method: str
+    target: str
+    headers: dict[str, str]
+    body: bytes
 
 
-def _raw_response(body: bytes) -> MagicMock:
-    mock_resp = MagicMock()
-    mock_resp.__enter__.return_value = mock_resp
-    mock_resp.read.return_value = body
-    return mock_resp
+type _TestServerHandler = Callable[
+    [asyncio.StreamReader, asyncio.StreamWriter], Coroutine[object, object, None]
+]
 
 
-class _UnreadableHttpErrorBody(io.BytesIO):
-    def read(self, size: int = -1) -> bytes:
-        raise OSError("body read failed")
+@asynccontextmanager
+async def _run_test_server(
+    handler: _TestServerHandler,
+    *,
+    ssl_context: ssl.SSLContext | None = None,
+) -> AsyncIterator[int]:
+    client_tasks: set[asyncio.Task[None]] = set()
+
+    def client_connected(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        client_tasks.add(asyncio.create_task(handler(reader, writer)))
+
+    server = await asyncio.start_server(
+        client_connected,
+        "127.0.0.1",
+        0,
+        ssl=ssl_context,
+    )
+    assert server.sockets
+    socket_address = server.sockets[0].getsockname()
+    port = socket_address[1]
+    assert isinstance(port, int)
+    try:
+        yield port
+    finally:
+        server.close()
+        await server.wait_closed()
+        for task in client_tasks:
+            if not task.done():
+                task.cancel()
+        if client_tasks:
+            results = await asyncio.gather(*client_tasks, return_exceptions=True)
+            for result in results:
+                if isinstance(result, BaseException) and not isinstance(
+                    result, asyncio.CancelledError
+                ):
+                    raise result
+
+
+async def _read_raw_http_request(reader: asyncio.StreamReader) -> _RawHttpRequest:
+    header_block = await reader.readuntil(b"\r\n\r\n")
+    lines = header_block[:-4].split(b"\r\n")
+    method, target, _version = lines[0].decode("ascii").split(" ", 2)
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        name, value = line.split(b":", 1)
+        headers[name.decode("ascii").lower()] = value.decode("latin-1").strip()
+    content_length = int(headers.get("content-length", "0"))
+    body = await reader.readexactly(content_length)
+    return _RawHttpRequest(method, target, headers, body)
+
+
+async def _close_test_writer(writer: asyncio.StreamWriter) -> None:
+    writer.close()
+    with suppress(OSError):
+        await writer.wait_closed()
+
+
+async def _write_success_response(
+    writer: asyncio.StreamWriter,
+    *,
+    headers: dict[str, str] | None = None,
+) -> None:
+    body = json.dumps(firewall_auth_success_response(headers or {})).encode()
+    writer.write(
+        b"HTTP/1.1 200 OK\r\n"
+        + f"Content-Length: {len(body)}\r\n".encode("ascii")
+        + b"Content-Type: application/json\r\nConnection: close\r\n\r\n"
+        + body
+    )
+    await writer.drain()
+    await _close_test_writer(writer)
+
+
+async def _trickle_until_peer_disconnect(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    peer_closed: asyncio.Event,
+) -> None:
+    peer_eof = asyncio.create_task(reader.read())
+    try:
+        while not peer_eof.done():
+            writer.write(b" ")
+            await writer.drain()
+            await asyncio.sleep(0.02)
+        remaining_request_body = await peer_eof
+        assert remaining_request_body == b""
+    except ConnectionResetError:
+        pass
+    finally:
+        if not peer_eof.done():
+            peer_eof.cancel()
+            with suppress(asyncio.CancelledError):
+                await peer_eof
+        await _close_test_writer(writer)
+    peer_closed.set()
+
+
+def _create_tls_contexts(tmp_path: Path) -> tuple[ssl.SSLContext, ssl.SSLContext]:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    now = datetime.datetime.now(datetime.UTC)
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName("localhost")]), critical=False)
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(private_key, hashes.SHA256())
+    )
+    certificate_path = tmp_path / "localhost-cert.pem"
+    private_key_path = tmp_path / "localhost-key.pem"
+    certificate_path.write_bytes(certificate.public_bytes(serialization.Encoding.PEM))
+    private_key_path.write_bytes(
+        private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+    )
+
+    server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    server_context.load_cert_chain(certificate_path, private_key_path)
+    client_context = ssl.create_default_context(cafile=str(certificate_path))
+    client_context.set_alpn_protocols(["http/1.1"])
+    return server_context, client_context
 
 
 class TestFetchFirewallHeaders:
@@ -560,15 +699,12 @@ class TestFetchFirewallHeaders:
         assert request.headers["x-vercel-protection-bypass"] == "secret-bypass-value"
         assert target.requests == ()
 
-    async def test_invalid_api_url_raises_before_open(self):
+    async def test_invalid_api_url_raises_before_network_io(self):
         with (
             patch.object(platform_api, "get_api_url", return_value="file:///etc/passwd"),
-            patch("firewall_auth_client._opener.open") as mock_open,
             pytest.raises(ValueError, match="absolute http"),
         ):
             await auth_client.fetch_firewall_headers(firewall_auth_request())
-
-        mock_open.assert_not_called()
 
     async def test_424_connector_not_configured_raises_custom_error(self, mitm_ctx):
         """Auth endpoint 424 CONNECTOR_NOT_CONFIGURED raises ConnectorNotConfiguredError."""
@@ -910,170 +1046,370 @@ class TestFirewallAuthSuccessParser:
             auth_client._parse_firewall_auth_success(body, firewall_auth_request())
 
 
-class TestFirewallAuthResponseBodyReader:
-    def test_response_at_body_limit_is_accepted(self):
-        response_body = json.dumps({"headers": {}}).encode()
-        mock_resp = _raw_response(response_body)
-
-        with patch.object(auth_client, "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES", len(response_body)):
-            assert auth_client._read_firewall_auth_response_body(mock_resp) == response_body
-
-        mock_resp.read.assert_called_once_with(len(response_body) + 1)
-
-    def test_response_over_body_limit_raises(self):
-        response_body = json.dumps({"headers": {}}).encode()
-        mock_resp = _raw_response(response_body)
-
-        with (
-            patch.object(
-                auth_client, "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES", len(response_body) - 1
-            ),
-            pytest.raises(
-                auth_client.FirewallAuthResponseTooLargeError,
-                match="Firewall auth response body too large",
-            ),
-        ):
-            auth_client._read_firewall_auth_response_body(mock_resp)
-
-        mock_resp.read.assert_called_once_with(len(response_body))
-
-
-class TestFetchFirewallHeadersResourceBoundary:
-    def test_closes_response_on_success(self, mitm_ctx):
-        """Success path must close the HTTP response — FD leak guard (#10475)."""
-        mock_resp = MagicMock()
-        mock_resp.__enter__.return_value = mock_resp
-        mock_resp.read.return_value = json.dumps(firewall_auth_success_response({})).encode()
-
-        with (
-            mitm_ctx(),
-            patch("platform_api.urllib.request.Request"),
-            patch("firewall_auth_client._opener.open", return_value=mock_resp),
-            patch.object(platform_api, "VERCEL_BYPASS", ""),
-        ):
-            auth_client._fetch_firewall_headers_sync(firewall_auth_request(), "https://api.vm0.ai")
-
-        mock_resp.__exit__.assert_called_once()  # urllib external boundary (#9991)
-
-    def test_closes_http_error_response_when_body_is_unreadable(self, mitm_ctx):
-        http_error = urllib.error.HTTPError(
-            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
-            400,
-            "Bad Request",
-            Message(),
-            _UnreadableHttpErrorBody(),
-        )
-        http_error.close = MagicMock()
-
-        with (
-            mitm_ctx(),
-            patch("platform_api.urllib.request.Request"),
-            patch("firewall_auth_client._opener.open", side_effect=http_error),
-            patch.object(platform_api, "VERCEL_BYPASS", ""),
-            pytest.raises(urllib.error.HTTPError) as exc_info,
-        ):
-            auth_client._fetch_firewall_headers_sync(firewall_auth_request(), "https://api.vm0.ai")
-
-        assert exc_info.value is http_error
-        http_error.close.assert_called_once()
-
-    def test_closes_http_error_response_when_body_has_invalid_utf8(self, mitm_ctx):
-        http_error = _http_error(
-            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
-            400,
-            "Bad Request",
-            b"\xff",
-        )
-        http_error.close = MagicMock()
-
-        with (
-            mitm_ctx(),
-            patch("platform_api.urllib.request.Request"),
-            patch("firewall_auth_client._opener.open", side_effect=http_error),
-            patch.object(platform_api, "VERCEL_BYPASS", ""),
-            pytest.raises(urllib.error.HTTPError) as exc_info,
-        ):
-            auth_client._fetch_firewall_headers_sync(firewall_auth_request(), "https://api.vm0.ai")
-
-        assert exc_info.value is http_error
-        assert exc_info.value.code == 400
-        http_error.close.assert_called_once()
-
-    def test_closes_http_error_response_when_body_is_too_large(self, mitm_ctx):
-        error_body = json.dumps(
-            {
-                "error": {
-                    "message": "Access token expired and refresh failed for: notion.",
-                    "code": "TOKEN_REFRESH_FAILED",
-                }
-            }
-        ).encode()
-        http_error = _http_error(
-            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
-            502,
-            "Bad Gateway",
-            error_body,
-        )
-        http_error.close = MagicMock()
-
-        with (
-            mitm_ctx(),
-            patch.object(
-                auth_client,
-                "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
-                len(error_body) - 1,
-            ),
-            patch("platform_api.urllib.request.Request"),
-            patch("firewall_auth_client._opener.open", side_effect=http_error),
-            patch.object(platform_api, "VERCEL_BYPASS", ""),
-            pytest.raises(
-                auth_client.FirewallAuthResponseTooLargeError,
-                match="Firewall auth response body too large",
-            ),
-        ):
-            auth_client._fetch_firewall_headers_sync(firewall_auth_request(), "https://api.vm0.ai")
-
-        http_error.close.assert_called_once()
-
+class TestFirewallAuthAsyncTransport:
     @pytest.mark.parametrize(
-        ("error_body", "expected_exception"),
+        "framing",
         [
-            (
-                json.dumps(
-                    {
-                        "error": {
-                            "message": "Access token expired and refresh failed for: notion.",
-                            "code": "TOKEN_REFRESH_FAILED",
-                        }
-                    }
-                ).encode(),
-                auth_client.FirewallAuthApiError,
-            ),
-            (b"{}", urllib.error.HTTPError),
+            pytest.param("chunked", id="chunked"),
+            pytest.param("eof", id="eof-delimited"),
+            pytest.param("informational", id="informational-before-content-length"),
         ],
     )
-    def test_closes_http_error_response(
+    async def test_accepts_http_11_response_framing(self, framing: str, mitm_ctx):
+        response_body = json.dumps(firewall_auth_success_response({})).encode()
+        requests: list[_RawHttpRequest] = []
+
+        async def handle_client(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            requests.append(await _read_raw_http_request(reader))
+            if framing == "chunked":
+                midpoint = len(response_body) // 2
+                chunks = (response_body[:midpoint], response_body[midpoint:])
+                encoded_chunks = b"".join(
+                    f"{len(chunk):x}\r\n".encode("ascii") + chunk + b"\r\n" for chunk in chunks
+                )
+                response = (
+                    b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n"
+                    b"Connection: close\r\n\r\n" + encoded_chunks + b"0\r\n\r\n"
+                )
+            elif framing == "eof":
+                response = b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n" + response_body
+            else:
+                response = (
+                    b"HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\n"
+                    + f"Content-Length: {len(response_body)}\r\n".encode("ascii")
+                    + b"Connection: close\r\n\r\n"
+                    + response_body
+                )
+            writer.write(response)
+            await writer.drain()
+            await _close_test_writer(writer)
+
+        async with _run_test_server(handle_client) as port:
+            with (
+                mitm_ctx(api_url=f"http://127.0.0.1:{port}"),
+                patch.object(platform_api, "VERCEL_BYPASS", ""),
+            ):
+                result = await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+        assert result.payload.headers == {}
+        assert len(requests) == 1
+        assert requests[0].method == "POST"
+        assert requests[0].target == "/api/webhooks/agent/firewall/auth"
+
+    async def test_total_deadline_aborts_a_trickling_response(self, mitm_ctx):
+        request_received = asyncio.Event()
+        peer_closed = asyncio.Event()
+
+        async def handle_client(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            await _read_raw_http_request(reader)
+            request_received.set()
+            writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 1000000\r\nConnection: close\r\n\r\n")
+            await writer.drain()
+            await _trickle_until_peer_disconnect(reader, writer, peer_closed)
+
+        async with _run_test_server(handle_client) as port:
+            with (
+                mitm_ctx(api_url=f"http://127.0.0.1:{port}"),
+                patch.object(auth_client, "FIREWALL_AUTH_FETCH_DEADLINE_SECONDS", 0.5),
+                patch.object(platform_api, "VERCEL_BYPASS", ""),
+                pytest.raises(auth_client.FirewallAuthDeadlineExceededError) as exc_info,
+            ):
+                await auth_client.fetch_firewall_headers(
+                    firewall_auth_request(
+                        encrypted_secrets="sensitive-encrypted-secrets",
+                        sandbox_auth="sensitive-sandbox-token",
+                    )
+                )
+
+            await asyncio.wait_for(request_received.wait(), timeout=2.0)
+            await asyncio.wait_for(peer_closed.wait(), timeout=2.0)
+
+        assert str(exc_info.value) == "Firewall auth fetch deadline exceeded"
+        assert "sensitive-encrypted-secrets" not in str(exc_info.value)
+        assert "sensitive-sandbox-token" not in str(exc_info.value)
+
+    async def test_total_deadline_aborts_a_stalled_tls_handshake(self, mitm_ctx):
+        handshake_started = asyncio.Event()
+        peer_closed = asyncio.Event()
+
+        async def handle_client(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            await reader.readexactly(1)
+            handshake_started.set()
+            try:
+                while await reader.read(64 * 1024):
+                    pass
+            except ConnectionResetError:
+                pass
+            peer_closed.set()
+            await _close_test_writer(writer)
+
+        proxy_environment = {
+            "http_proxy": "",
+            "HTTP_PROXY": "",
+            "https_proxy": "",
+            "HTTPS_PROXY": "",
+            "all_proxy": "",
+            "ALL_PROXY": "",
+            "no_proxy": "",
+            "NO_PROXY": "",
+        }
+        async with _run_test_server(handle_client) as port:
+            with (
+                patch.dict(os.environ, proxy_environment),
+                mitm_ctx(api_url=f"https://127.0.0.1:{port}"),
+                patch.object(auth_client, "FIREWALL_AUTH_FETCH_DEADLINE_SECONDS", 0.5),
+                pytest.raises(auth_client.FirewallAuthDeadlineExceededError),
+            ):
+                await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+            await asyncio.wait_for(handshake_started.wait(), timeout=2.0)
+            await asyncio.wait_for(peer_closed.wait(), timeout=2.0)
+
+    async def test_total_deadline_cancels_dns_lookup_before_connect(self, mitm_ctx):
+        class BlockingResolver:
+            def __init__(self) -> None:
+                self.started = asyncio.Event()
+                self.cancelled = asyncio.Event()
+
+            async def lookup_ip(self, host: str) -> list[str]:
+                assert host == "firewall-auth.invalid"
+                self.started.set()
+                try:
+                    await asyncio.Future()
+                except asyncio.CancelledError:
+                    self.cancelled.set()
+                    raise
+                raise AssertionError("unreachable")
+
+        resolver = BlockingResolver()
+        proxy_environment = {
+            "http_proxy": "",
+            "HTTP_PROXY": "",
+            "https_proxy": "",
+            "HTTPS_PROXY": "",
+            "all_proxy": "",
+            "ALL_PROXY": "",
+            "no_proxy": "",
+            "NO_PROXY": "",
+        }
+        with (
+            patch.dict(os.environ, proxy_environment),
+            patch.object(auth_client, "_dns_resolver", resolver),
+            patch.object(auth_client, "FIREWALL_AUTH_FETCH_DEADLINE_SECONDS", 0.05),
+            mitm_ctx(api_url="http://firewall-auth.invalid"),
+            pytest.raises(auth_client.FirewallAuthDeadlineExceededError),
+        ):
+            await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+        assert resolver.started.is_set()
+        assert resolver.cancelled.is_set()
+
+    async def test_shared_deadline_failure_releases_key_and_does_not_block_other_key(
         self,
         mitm_ctx,
-        error_body: bytes,
-        expected_exception: type[Exception],
     ):
-        """HTTPError path must close the underlying socket — FD leak guard (#10475)."""
-        http_error = _http_error(
-            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
-            400,
-            "Bad Request",
-            error_body,
+        requests: list[_RawHttpRequest] = []
+        first_request_received = asyncio.Event()
+        first_peer_closed = asyncio.Event()
+
+        async def handle_client(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            requests.append(await _read_raw_http_request(reader))
+            request_number = len(requests)
+            if request_number != 1:
+                await _write_success_response(writer)
+                return
+
+            first_request_received.set()
+            writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 1000000\r\nConnection: close\r\n\r\n")
+            await writer.drain()
+            await _trickle_until_peer_disconnect(reader, writer, first_peer_closed)
+
+        shared_key = auth_cache_key(api_id="shared")
+        unrelated_key = auth_cache_key(api_id="unrelated")
+        request = firewall_auth_request()
+        async with _run_test_server(handle_client) as port:
+            with (
+                mitm_ctx(api_url=f"http://127.0.0.1:{port}"),
+                patch.object(auth_client, "FIREWALL_AUTH_FETCH_DEADLINE_SECONDS", 0.5),
+                patch.object(platform_api, "VERCEL_BYPASS", ""),
+            ):
+                leader = asyncio.create_task(auth_cache.get_firewall_headers(shared_key, request))
+                await asyncio.wait_for(first_request_received.wait(), timeout=2.0)
+                followers = [
+                    asyncio.create_task(auth_cache.get_firewall_headers(shared_key, request))
+                    for _ in range(2)
+                ]
+                unrelated = await auth_cache.get_firewall_headers(unrelated_key, request)
+                shared_results = await asyncio.gather(
+                    leader,
+                    *followers,
+                    return_exceptions=True,
+                )
+                await asyncio.wait_for(first_peer_closed.wait(), timeout=2.0)
+                retry = await auth_cache.get_firewall_headers(shared_key, request)
+
+        assert unrelated["headers"] == {}
+        assert unrelated["cache_hit"] is False
+        assert all(
+            isinstance(result, auth_client.FirewallAuthDeadlineExceededError)
+            for result in shared_results
         )
-        http_error.close = MagicMock()
+        assert len({id(result) for result in shared_results}) == 1
+        assert retry["headers"] == {}
+        assert retry["cache_hit"] is False
+        assert len(requests) == 3
 
-        with (
-            mitm_ctx(),
-            patch("platform_api.urllib.request.Request"),
-            patch("firewall_auth_client._opener.open", side_effect=http_error),
-            patch.object(platform_api, "VERCEL_BYPASS", ""),
-            pytest.raises(expected_exception),
-        ):
-            auth_client._fetch_firewall_headers_sync(firewall_auth_request(), "https://api.vm0.ai")
+    async def test_http_environment_proxy_uses_absolute_form_and_proxy_credentials(
+        self,
+        mitm_ctx,
+    ):
+        proxy = FakeAuthEndpoint()
+        proxy.queue_json_response(firewall_auth_success_response({}))
 
-        http_error.close.assert_called_once()  # urllib external boundary (#9991)
+        with proxy.run():
+            proxy_url = proxy.api_url.replace(
+                "http://",
+                "http://proxy-user:proxy-password@",
+                1,
+            )
+            proxy_environment = {
+                "http_proxy": proxy_url,
+                "HTTP_PROXY": "",
+                "all_proxy": "",
+                "ALL_PROXY": "",
+                "no_proxy": "",
+                "NO_PROXY": "",
+            }
+            with (
+                patch.dict(os.environ, proxy_environment),
+                mitm_ctx(api_url="http://platform.example:8123"),
+                patch.object(platform_api, "VERCEL_BYPASS", ""),
+            ):
+                result = await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+        expected_proxy_authorization = "Basic " + base64.b64encode(
+            b"proxy-user:proxy-password"
+        ).decode("ascii")
+        assert result.payload.headers == {}
+        assert proxy.request_count == 1
+        assert proxy.requests[0].path == (
+            "http://platform.example:8123/api/webhooks/agent/firewall/auth"
+        )
+        assert proxy.requests[0].headers["host"] == "platform.example:8123"
+        assert proxy.requests[0].headers["proxy-authorization"] == expected_proxy_authorization
+        assert proxy.requests[0].headers["authorization"] == "Bearer tok-xyz"
+
+    async def test_no_proxy_bypasses_environment_proxy(self, mitm_ctx):
+        origin = FakeAuthEndpoint()
+        proxy = FakeAuthEndpoint()
+        origin.queue_json_response(firewall_auth_success_response({}))
+
+        with origin.run(), proxy.run():
+            proxy_environment = {
+                "http_proxy": proxy.api_url,
+                "HTTP_PROXY": "",
+                "all_proxy": "",
+                "ALL_PROXY": "",
+                "no_proxy": "127.0.0.1",
+                "NO_PROXY": "127.0.0.1",
+            }
+            with (
+                patch.dict(os.environ, proxy_environment),
+                mitm_ctx(api_url=origin.api_url),
+                patch.object(platform_api, "VERCEL_BYPASS", ""),
+            ):
+                await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+        assert origin.request_count == 1
+        assert proxy.request_count == 0
+
+    async def test_https_proxy_connect_preserves_origin_tls_and_isolates_credentials(
+        self,
+        mitm_ctx,
+        tmp_path: Path,
+    ):
+        server_context, client_context = _create_tls_contexts(tmp_path)
+        origin_requests: list[_RawHttpRequest] = []
+        proxy_requests: list[_RawHttpRequest] = []
+
+        async def handle_origin(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            origin_requests.append(await _read_raw_http_request(reader))
+            await _write_success_response(writer)
+
+        async with _run_test_server(handle_origin, ssl_context=server_context) as origin_port:
+
+            async def handle_proxy(
+                client_reader: asyncio.StreamReader,
+                client_writer: asyncio.StreamWriter,
+            ) -> None:
+                proxy_requests.append(await _read_raw_http_request(client_reader))
+                origin_reader, origin_writer = await asyncio.open_connection(
+                    "127.0.0.1",
+                    origin_port,
+                )
+                client_writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                await client_writer.drain()
+
+                async def relay(
+                    reader: asyncio.StreamReader,
+                    writer: asyncio.StreamWriter,
+                ) -> None:
+                    while data := await reader.read(64 * 1024):
+                        writer.write(data)
+                        await writer.drain()
+
+                try:
+                    await asyncio.gather(
+                        relay(client_reader, origin_writer),
+                        relay(origin_reader, client_writer),
+                    )
+                finally:
+                    await _close_test_writer(origin_writer)
+                    await _close_test_writer(client_writer)
+
+            async with _run_test_server(handle_proxy) as proxy_port:
+                proxy_url = f"http://proxy-user:proxy-password@127.0.0.1:{proxy_port}"
+                proxy_environment = {
+                    "https_proxy": proxy_url,
+                    "HTTPS_PROXY": "",
+                    "all_proxy": "",
+                    "ALL_PROXY": "",
+                    "no_proxy": "",
+                    "NO_PROXY": "",
+                }
+                with (
+                    patch.dict(os.environ, proxy_environment),
+                    patch.object(auth_client, "_https_context", client_context),
+                    patch.object(platform_api, "VERCEL_BYPASS", ""),
+                    mitm_ctx(api_url=f"https://localhost:{origin_port}"),
+                ):
+                    result = await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+        expected_proxy_authorization = "Basic " + base64.b64encode(
+            b"proxy-user:proxy-password"
+        ).decode("ascii")
+        assert result.payload.headers == {}
+        assert len(proxy_requests) == 1
+        assert proxy_requests[0].method == "CONNECT"
+        assert proxy_requests[0].target == f"localhost:{origin_port}"
+        assert proxy_requests[0].headers["proxy-authorization"] == expected_proxy_authorization
+        assert len(origin_requests) == 1
+        assert origin_requests[0].target == "/api/webhooks/agent/firewall/auth"
+        assert origin_requests[0].headers["authorization"] == "Bearer tok-xyz"
+        assert "proxy-authorization" not in origin_requests[0].headers
+

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -125,14 +125,13 @@ async def _trickle_until_peer_disconnect(
 ) -> None:
     peer_eof = asyncio.create_task(reader.read())
     try:
-        while not peer_eof.done():
-            writer.write(b" ")
-            await writer.drain()
-            await asyncio.sleep(0.02)
-        remaining_request_body = await peer_eof
-        assert remaining_request_body == b""
-    except ConnectionResetError:
-        pass
+        with suppress(ConnectionResetError):
+            while not peer_eof.done():
+                writer.write(b" ")
+                await writer.drain()
+                await asyncio.sleep(0.02)
+            remaining_request_body = await peer_eof
+            assert remaining_request_body == b""
     finally:
         if not peer_eof.done():
             peer_eof.cancel()
@@ -1144,11 +1143,9 @@ class TestFirewallAuthAsyncTransport:
         ) -> None:
             await reader.readexactly(1)
             handshake_started.set()
-            try:
+            with suppress(ConnectionResetError):
                 while await reader.read(64 * 1024):
                     pass
-            except ConnectionResetError:
-                pass
             peer_closed.set()
             await _close_test_writer(writer)
 

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -1098,6 +1098,32 @@ class TestFirewallAuthAsyncTransport:
         assert requests[0].method == "POST"
         assert requests[0].target == "/api/webhooks/agent/firewall/auth"
 
+    async def test_protocol_error_does_not_expose_response_bytes(self, mitm_ctx):
+        sensitive_response_bytes = b"sensitive-resolved-auth-value"
+
+        async def handle_client(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            await _read_raw_http_request(reader)
+            writer.write(
+                b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n"
+                b"Connection: close\r\n\r\n" + sensitive_response_bytes + b"\r\n"
+            )
+            await writer.drain()
+            await _close_test_writer(writer)
+
+        async with _run_test_server(handle_client) as port:
+            with (
+                mitm_ctx(api_url=f"http://127.0.0.1:{port}"),
+                patch.object(platform_api, "VERCEL_BYPASS", ""),
+                pytest.raises(auth_client.FirewallAuthProtocolError) as exc_info,
+            ):
+                await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+        assert str(exc_info.value) == "Firewall auth HTTP protocol error"
+        assert sensitive_response_bytes.decode() not in str(exc_info.value)
+
     async def test_total_deadline_aborts_a_trickling_response(self, mitm_ctx):
         request_received = asyncio.Event()
         peer_closed = asyncio.Event()

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -1412,4 +1412,3 @@ class TestFirewallAuthAsyncTransport:
         assert origin_requests[0].target == "/api/webhooks/agent/firewall/auth"
         assert origin_requests[0].headers["authorization"] == "Bearer tok-xyz"
         assert "proxy-authorization" not in origin_requests[0].headers
-

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
@@ -2,8 +2,9 @@
 
 import asyncio
 import json
+import os
 import urllib.error
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -14,7 +15,7 @@ import firewall_auth_client as auth_client
 import flow_metadata_keys as metadata_keys
 import matching
 import platform_api
-from tests.auth_endpoint_helpers import firewall_auth_success_response
+from tests.auth_endpoint_helpers import FakeAuthEndpoint, firewall_auth_success_response
 from tests.auth_state_helpers import cached_headers
 from tests.aws_sigv4_helpers import (
     DEFAULT_SIGV4_TIMESTAMP,
@@ -39,13 +40,6 @@ _MISSING_FIELD = object()
 
 def _fail_if_ordinary_upstream_credentials_are_revalidated() -> bool:
     raise AssertionError("ordinary upstream credential guard must not run")
-
-
-def _json_response(body: object) -> MagicMock:
-    mock_resp = MagicMock()
-    mock_resp.__enter__.return_value = mock_resp
-    mock_resp.read.return_value = json.dumps(body).encode()
-    return mock_resp
 
 
 def _allow(
@@ -713,9 +707,25 @@ class TestHandleFirewallRequest:
         vm_info = _vm_info(tmp_path)
         allow = _allow(api_entry)
 
+        class FailingResolver:
+            async def lookup_ip(self, host: str) -> list[str]:
+                assert host == "auth-endpoint.invalid"
+                raise network_error
+
+        proxy_environment = {
+            "http_proxy": "",
+            "HTTP_PROXY": "",
+            "https_proxy": "",
+            "HTTPS_PROXY": "",
+            "all_proxy": "",
+            "ALL_PROXY": "",
+            "no_proxy": "",
+            "NO_PROXY": "",
+        }
         with (
-            patch("firewall_auth_client._opener.open", side_effect=network_error),
-            mitm_ctx(),
+            patch.dict(os.environ, proxy_environment),
+            patch.object(auth_client, "_dns_resolver", FailingResolver()),
+            mitm_ctx(api_url="http://auth-endpoint.invalid"),
         ):
             await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
@@ -746,14 +756,12 @@ class TestHandleFirewallRequest:
         )
         vm_info = _vm_info(tmp_path)
         allow = _allow(api_entry)
-        mock_resp = MagicMock()
-        mock_resp.__enter__.return_value = mock_resp
-        mock_resp.__exit__.return_value = False
-        mock_resp.read.return_value = b"not-json"
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_response(200, body=b"not-json")
 
         with (
-            patch("firewall_auth_client._opener.open", return_value=mock_resp),
-            mitm_ctx(),
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
         ):
             await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
@@ -770,7 +778,6 @@ class TestHandleFirewallRequest:
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
         assert "connectors" not in body
-        mock_resp.__exit__.assert_called_once()
 
     @pytest.mark.parametrize(
         ("field_name", "invalid_value", "expected_reason"),
@@ -918,11 +925,12 @@ class TestHandleFirewallRequest:
             response.pop(field_name)
         else:
             response[field_name] = invalid_value
-        mock_resp = _json_response(response)
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response(response)
 
         with (
-            patch("firewall_auth_client._opener.open", return_value=mock_resp),
-            mitm_ctx(),
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
         ):
             result = await handle_firewall_request_without_upstream_admission(
                 flow,
@@ -944,7 +952,6 @@ class TestHandleFirewallRequest:
         assert body["message"] == (
             f"Failed to resolve auth headers: {_MALFORMED_SUCCESS_PREFIX}: {expected_reason}"
         )
-        mock_resp.__exit__.assert_called_once()
 
     async def test_strategy_inconsistent_success_returns_502_without_auth_mutation(
         self,
@@ -962,16 +969,15 @@ class TestHandleFirewallRequest:
         )
         vm_info = _vm_info(tmp_path)
         allow = _allow(api_entry)
-        mock_resp = _json_response(
-            firewall_auth_success_response({"Authorization": "Bearer resolved"})
-            | {
-                "query": {"api_key": "resolved-key"},
-            }
-        )
+        response = firewall_auth_success_response({"Authorization": "Bearer resolved"}) | {
+            "query": {"api_key": "resolved-key"},
+        }
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response(response)
 
         with (
-            patch("firewall_auth_client._opener.open", return_value=mock_resp),
-            mitm_ctx(),
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
         ):
             result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
@@ -1001,18 +1007,17 @@ class TestHandleFirewallRequest:
         vm_info = _vm_info(tmp_path)
         allow = _allow(api_entry)
         response_body = json.dumps({"headers": {"Authorization": "Bearer tok"}}).encode()
-        mock_resp = MagicMock()
-        mock_resp.__enter__.return_value = mock_resp
-        mock_resp.read.return_value = response_body
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_response(200, body=response_body)
 
         with (
+            endpoint.run(),
             patch.object(
                 auth_client,
                 "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
                 len(response_body) - 1,
             ),
-            patch("firewall_auth_client._opener.open", return_value=mock_resp),
-            mitm_ctx(),
+            mitm_ctx(api_url=endpoint.api_url),
         ):
             await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
@@ -1030,7 +1035,6 @@ class TestHandleFirewallRequest:
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
         assert "connectors" not in body
-        mock_resp.__exit__.assert_called_once()
 
     async def test_malformed_json_success_response_returns_502_without_auth_mutation(
         self,
@@ -1047,11 +1051,12 @@ class TestHandleFirewallRequest:
         )
         vm_info = _vm_info(tmp_path)
         allow = _allow(api_entry)
-        mock_resp = _json_response({"headers": []})
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response({"headers": []})
 
         with (
-            patch("firewall_auth_client._opener.open", return_value=mock_resp),
-            mitm_ctx(),
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
         ):
             await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
@@ -1069,7 +1074,6 @@ class TestHandleFirewallRequest:
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
         assert "connectors" not in body
-        mock_resp.__exit__.assert_called_once()
 
     async def test_structured_api_error_is_preserved(self, real_flow, mitm_ctx, tmp_path):
         flow = _firewall_flow(real_flow)

--- a/crates/runner/mitm-addon/uv.lock
+++ b/crates/runner/mitm-addon/uv.lock
@@ -562,6 +562,8 @@ source = { virtual = "." }
 dev = [
     { name = "basedpyright" },
     { name = "brotli" },
+    { name = "cryptography" },
+    { name = "h11" },
     { name = "h2" },
     { name = "mitmproxy" },
     { name = "pytest" },
@@ -572,6 +574,8 @@ dev = [
 ]
 test = [
     { name = "brotli" },
+    { name = "cryptography" },
+    { name = "h11" },
     { name = "h2" },
     { name = "mitmproxy" },
     { name = "pytest" },
@@ -586,6 +590,8 @@ test = [
 dev = [
     { name = "basedpyright", specifier = ">=1.39" },
     { name = "brotli", specifier = ">=1.2.0" },
+    { name = "cryptography", specifier = "==48.0.1" },
+    { name = "h11", specifier = "==0.16.0" },
     { name = "h2", specifier = ">=4.3.0" },
     { name = "mitmproxy", specifier = "==12.2.3" },
     { name = "pytest", specifier = ">=7.0" },
@@ -596,6 +602,8 @@ dev = [
 ]
 test = [
     { name = "brotli", specifier = ">=1.2.0" },
+    { name = "cryptography", specifier = "==48.0.1" },
+    { name = "h11", specifier = "==0.16.0" },
     { name = "h2", specifier = ">=4.3.0" },
     { name = "mitmproxy", specifier = "==12.2.3" },
     { name = "pytest", specifier = ">=7.0" },


### PR DESCRIPTION
## Summary

- replace the firewall auth `urllib` worker-thread fetch with a fully asynchronous HTTP/1.1 transport
- enforce one 10-second monotonic deadline across DNS, connect, proxy CONNECT, TLS, request write, response headers, and the bounded response body
- preserve direct HTTP/HTTPS, environment proxy and `no_proxy` routing, redirect rejection, structured API errors, and response limits
- abort owned sockets before timeout or cancellation reaches the shared auth-cache task, including during a stalled TLS handshake
- map malformed HTTP protocol failures to a static error so peer-controlled response bytes cannot enter logs or sandbox responses

## Tests

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync pytest tests/test_firewall_auth_client.py -q` (81 passed)
- `uv run --no-sync pytest tests/test_firewall_auth_client.py -q -k 'total_deadline or shared_deadline_failure'` (4 passed, repeated 5 times)
- `uv run --no-sync python -m pytest tests/` (4,594 passed)
- repository pre-commit hooks for the changed Python files

## Compatibility

- no API, runner protocol, queue payload, schema, persisted-state, migration, configuration, or feature-switch change
- usage webhook delivery remains out of scope because it owns a separate bounded executor, retry, and shutdown lifecycle
- h11 and the cancellable Rust DNS resolver are already supplied by the release-locked mitmproxy runtime

Closes #24713
