### PR TITLE
perf(ci): bound checkout history by job needs

### DIFF
--- a/.github/scripts/changed-base-ref.sh
+++ b/.github/scripts/changed-base-ref.sh
@@ -22,7 +22,21 @@ case "$event_name" in
       echo "missing MERGE_GROUP_BASE_SHA for merge_group event" >&2
       exit 2
     fi
-    printf '%s\n' "$MERGE_GROUP_BASE_SHA"
+
+    merge_group_base=$(git rev-parse --verify "${MERGE_GROUP_BASE_SHA}^{commit}" 2>/dev/null) || {
+      echo "MERGE_GROUP_BASE_SHA is not an available commit: ${MERGE_GROUP_BASE_SHA}" >&2
+      exit 2
+    }
+    merge_group_parent=$(git rev-parse --verify HEAD^ 2>/dev/null) || {
+      echo "merge_group HEAD does not have an available parent" >&2
+      exit 2
+    }
+    if [ "$merge_group_base" != "$merge_group_parent" ]; then
+      echo "MERGE_GROUP_BASE_SHA does not match merge_group HEAD parent" >&2
+      exit 2
+    fi
+
+    printf '%s\n' "$merge_group_base"
     ;;
   *)
     printf 'HEAD^\n'

--- a/.github/scripts/tests/changed-base-ref-test.sh
+++ b/.github/scripts/tests/changed-base-ref-test.sh
@@ -46,8 +46,8 @@ git -C "$repo" add turbo/file.ts
 git -C "$repo" commit -q -m "main advance"
 merge_parent=$(git -C "$repo" rev-parse HEAD)
 
+git -C "$repo" switch -q -c pull-merge
 git -C "$repo" merge -q --no-ff feature -m "merge feature"
-merge_ref=$(git -C "$repo" rev-parse HEAD)
 
 actual=$(
   cd "$repo"
@@ -70,6 +70,10 @@ actual=$(
 )
 assert_eq "$actual" "$event_base"
 
+git -C "$repo" switch -q -C merge-group "$merge_parent"
+git -C "$repo" cherry-pick "$feature_head" >/dev/null
+merge_group_head=$(git -C "$repo" rev-parse HEAD)
+
 actual=$(
   cd "$repo"
   run_clean \
@@ -79,14 +83,38 @@ actual=$(
 )
 assert_eq "$actual" "$merge_parent"
 
+missing_base=0000000000000000000000000000000000000000
+if output=$(
+  cd "$repo"
+  run_clean \
+    GITHUB_EVENT_NAME=merge_group \
+    MERGE_GROUP_BASE_SHA="$missing_base" \
+    "$CHANGED_BASE_REF" 2>&1
+); then
+  fail "expected unavailable merge-group base to fail"
+fi
+[[ "$output" == *"MERGE_GROUP_BASE_SHA is not an available commit: $missing_base"* ]] ||
+  fail "unexpected unavailable merge-group base error: $output"
+
+if output=$(
+  cd "$repo"
+  run_clean \
+    GITHUB_EVENT_NAME=merge_group \
+    MERGE_GROUP_BASE_SHA="$event_base" \
+    "$CHANGED_BASE_REF" 2>&1
+); then
+  fail "expected non-parent merge-group base to fail"
+fi
+[[ "$output" == *"MERGE_GROUP_BASE_SHA does not match merge_group HEAD parent"* ]] ||
+  fail "unexpected non-parent merge-group base error: $output"
+
 actual=$(
   cd "$repo"
   run_clean GITHUB_EVENT_NAME=push "$CHANGED_BASE_REF"
 )
 assert_eq "$actual" "HEAD^"
 
-git -C "$repo" switch -q --detach "$merge_ref"
-changed_files=$(git -C "$repo" diff --name-only "$merge_parent" HEAD)
+changed_files=$(git -C "$repo" diff --name-only "$merge_parent" "$merge_group_head")
 assert_eq "$changed_files" "crates/lib.rs"
 
 echo "changed-base-ref-test: ok"

--- a/.github/scripts/tests/checkout-depth-test.sh
+++ b/.github/scripts/tests/checkout-depth-test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+for command in jq yq; do
+  command -v "$command" >/dev/null || fail "$command is required"
+done
+
+actual=$(
+  for workflow in turbo crates runner-image security; do
+    yq -o=json '.' "${REPO_ROOT}/.github/workflows/${workflow}.yml" |
+      jq -r --arg workflow "$workflow" '
+        .jobs
+        | to_entries[]
+        | .key as $job
+        | .value.steps[]?
+        | select((.uses? // "") | startswith("actions/checkout@"))
+        | select(.with["fetch-depth"]? != null)
+        | [$workflow, $job, (.with["fetch-depth"] | tostring)]
+        | @tsv
+      '
+  done | sort
+)
+
+expected=$(
+  printf '%s\n' \
+    $'crates\tdetect\t2' \
+    $'runner-image\tprepare\t2' \
+    $'security\tgitleaks\t${{ github.event_name != '\''pull_request'\'' && 2 || 0 }}' \
+    $'security\tsemgrep\t${{ github.event_name == '\''push'\'' && 1 || 2 }}' \
+    $'turbo\tdetect-turbo-ts-checks\t2' \
+    $'turbo\tfile-size-check\t2' \
+    $'turbo\tlint-eslint\t1' \
+    $'turbo\tprepare\t2' \
+    $'turbo\ttest-migrate\t2' \
+    $'turbo\tvalidate-release-presence\t0' |
+    sort
+)
+
+if [ "$actual" != "$expected" ]; then
+  echo "Expected explicit checkout depths:" >&2
+  echo "$expected" >&2
+  echo "Actual explicit checkout depths:" >&2
+  echo "$actual" >&2
+  fail "checkout depth policy changed"
+fi
+
+echo "checkout-depth-test: ok"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Detect changed crates
         id: detect

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Resolve runner image identity
         id: identity

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -94,7 +94,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ github.event_name == 'push' && 1 || 2 }}
 
       - name: Trust checked out repository
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -231,6 +231,7 @@ jobs:
             .github/scripts/tests/ansible-ssh-control-path-test.sh \
             .github/scripts/tests/check-release-please-component-releases-test.sh \
             .github/scripts/tests/check-workflow-shell-compatibility-test.sh \
+            .github/scripts/tests/checkout-depth-test.sh \
             .github/scripts/tests/cloudflare-ssh-command-test.sh \
             .github/scripts/tests/cloudflare-ssh-preconnect-test.sh \
             .github/scripts/tests/cloudflare-ssh-proxy-test.sh \
@@ -259,7 +260,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ github.event_name != 'pull_request' && 2 || 0 }}
 
       - name: Install Gitleaks
         run: |

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -121,7 +121,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Detect Turbo TypeScript check need
         id: detect
@@ -178,7 +178,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Configure Git safe directory
         run: git config --global --add safe.directory /__w/vm0/vm0
@@ -366,7 +366,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Check file sizes
         env:
@@ -408,7 +408,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: ./.github/actions/toolchain-init
       - name: Check DB ownership boundary
         run: .github/scripts/check-db-boundary.sh
@@ -609,7 +609,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - uses: ./.github/actions/toolchain-init
       - name: Prompt for JSONB Contract Changes
         run: |


### PR DESCRIPTION
## Summary

- choose checkout depth from each CI job's actual Git history requirement
- use depth 1 for working-tree-only scans, depth 2 for parent-based checks, and retain full history for pull-request Gitleaks and release-presence validation
- fail clearly when a merge-group base commit is unavailable or does not match the checked-out head, with workflow and resolver regression coverage

## Scope

This PR changes checkout history only. It does not change merge-queue configuration, workflow topology, runner selection, or check decisions.

## Validation

- `bash .github/scripts/tests/changed-base-ref-test.sh`
- `bash .github/scripts/tests/checkout-depth-test.sh`
- all 44 `.github/scripts/tests/*.sh` entry-point tests
- `shellcheck .github/scripts/changed-base-ref.sh .github/scripts/tests/changed-base-ref-test.sh .github/scripts/tests/checkout-depth-test.sh`
- `actionlint`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- `./scripts/check-file-size.sh` for all changed files
- `git diff --check`

Closes #24748
