### PR TITLE
perf(vsock): encode exec results into one frame buffer

### DIFF
--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -52,8 +52,11 @@ use std::time::{Duration, Instant};
 use vsock_proto::{
     self, ExecCapturedOutput, ExecControlNonce, ExecControlPolicy, ExecLifecyclePolicy,
     ExecOutputPolicy, ExecOutputStream, ExecTermination, ExecTimeoutPolicy, MSG_ERROR,
-    MSG_EXEC_RESULT, MSG_EXEC_STARTED,
+    MSG_EXEC_STARTED,
 };
+
+#[cfg(test)]
+use vsock_proto::MSG_EXEC_RESULT;
 
 use crate::drain::{BoundedDrainResult, BoundedStreamConfig, drain_bounded_cancellable};
 use crate::error::to_io_error;
@@ -1547,7 +1550,10 @@ fn send_exec_result_after_lock<F>(
 where
     F: FnOnce(),
 {
-    let payload = vsock_proto::encode_exec_result(
+    let mut encoded = Vec::new();
+    vsock_proto::encode_exec_result_frame_into(
+        &mut encoded,
+        frame.seq,
         frame.termination,
         frame.duration_ms,
         frame.stdout,
@@ -1555,7 +1561,6 @@ where
         frame.diagnostic,
     )
     .map_err(to_io_error)?;
-    let encoded = vsock_proto::encode(MSG_EXEC_RESULT, frame.seq, &payload).map_err(to_io_error)?;
     writer.write_frame_after_lock(&encoded, after_lock)
 }
 

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -168,8 +168,8 @@ pub use payloads::exec_operation::{
     decode_exec_control, decode_exec_control_result, decode_exec_output, decode_exec_result,
     decode_exec_start, decode_exec_started, encode_exec_cancel, encode_exec_control,
     encode_exec_control_result, encode_exec_output, encode_exec_output_frame_into,
-    encode_exec_result, encode_exec_start, encode_exec_start_with_expected_exit_codes,
-    encode_exec_started,
+    encode_exec_result, encode_exec_result_frame_into, encode_exec_start,
+    encode_exec_start_with_expected_exit_codes, encode_exec_started,
 };
 pub use payloads::write_file::{
     WriteFileBatchEntry, decode_write_file, decode_write_file_result, decode_write_files,

--- a/crates/vsock-proto/src/payloads/exec_operation.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation.rs
@@ -15,6 +15,7 @@ pub use output::{
 };
 pub use result::{
     DecodedExecResult, ExecCapturedOutput, ExecTermination, decode_exec_result, encode_exec_result,
+    encode_exec_result_frame_into,
 };
 pub use start::{
     DecodedExecStart, ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy,

--- a/crates/vsock-proto/src/payloads/exec_operation/result.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/result.rs
@@ -1,9 +1,10 @@
 use crate::error::ProtocolError;
+use crate::frame::encode_into;
 use crate::read::{
     checked_payload_len_add, ensure_payload_fits_message, ensure_u16_len, ensure_u32_len,
     expect_consumed, read_i32, read_slice, read_str, read_u8, read_u16, read_u32,
 };
-use crate::wire::EXEC_CAPTURED_OUTPUT_FLAG_TRUNCATED;
+use crate::wire::{EXEC_CAPTURED_OUTPUT_FLAG_TRUNCATED, MSG_EXEC_RESULT};
 
 pub(super) const EXEC_TERMINATION_EXITED: u8 = 0x00;
 pub(super) const EXEC_TERMINATION_TIMED_OUT: u8 = 0x01;
@@ -115,16 +116,13 @@ fn append_exec_operation_captured_output(p: &mut Vec<u8>, output: ExecCapturedOu
     }
 }
 
-/// Encode exec_result payload.
-pub fn encode_exec_result(
+fn validate_exec_result_payload(
     termination: ExecTermination,
-    duration_ms: u32,
     stdout: ExecCapturedOutput<'_>,
     stderr: ExecCapturedOutput<'_>,
     diagnostic: &str,
-) -> Result<Vec<u8>, ProtocolError> {
-    let diagnostic_bytes = diagnostic.as_bytes();
-    let diagnostic_len = ensure_u16_len("diagnostic", diagnostic_bytes.len())?;
+) -> Result<(u16, usize), ProtocolError> {
+    let diagnostic_len = ensure_u16_len("diagnostic", diagnostic.len())?;
     let stdout_len = exec_operation_captured_output_encoded_len(stdout, "stdout")?;
     let stderr_len = exec_operation_captured_output_encoded_len(stderr, "stderr")?;
 
@@ -133,18 +131,82 @@ pub fn encode_exec_result(
     payload_len = checked_payload_len_add(payload_len, stdout_len)?;
     payload_len = checked_payload_len_add(payload_len, stderr_len)?;
     payload_len = checked_payload_len_add(payload_len, 2)?;
-    payload_len = checked_payload_len_add(payload_len, diagnostic_bytes.len())?;
+    payload_len = checked_payload_len_add(payload_len, diagnostic.len())?;
     ensure_payload_fits_message(payload_len)?;
 
-    let mut p = Vec::with_capacity(payload_len);
-    append_exec_termination(&mut p, termination);
+    Ok((diagnostic_len, payload_len))
+}
+
+fn append_exec_result_payload(
+    p: &mut Vec<u8>,
+    termination: ExecTermination,
+    duration_ms: u32,
+    stdout: ExecCapturedOutput<'_>,
+    stderr: ExecCapturedOutput<'_>,
+    diagnostic: &str,
+    diagnostic_len: u16,
+) {
+    append_exec_termination(p, termination);
     p.extend_from_slice(&duration_ms.to_be_bytes());
-    append_exec_operation_captured_output(&mut p, stdout);
-    append_exec_operation_captured_output(&mut p, stderr);
+    append_exec_operation_captured_output(p, stdout);
+    append_exec_operation_captured_output(p, stderr);
     p.extend_from_slice(&diagnostic_len.to_be_bytes());
-    p.extend_from_slice(diagnostic_bytes);
+    p.extend_from_slice(diagnostic.as_bytes());
+}
+
+/// Encode exec_result payload.
+pub fn encode_exec_result(
+    termination: ExecTermination,
+    duration_ms: u32,
+    stdout: ExecCapturedOutput<'_>,
+    stderr: ExecCapturedOutput<'_>,
+    diagnostic: &str,
+) -> Result<Vec<u8>, ProtocolError> {
+    let (diagnostic_len, payload_len) =
+        validate_exec_result_payload(termination, stdout, stderr, diagnostic)?;
+
+    let mut p = Vec::with_capacity(payload_len);
+    append_exec_result_payload(
+        &mut p,
+        termination,
+        duration_ms,
+        stdout,
+        stderr,
+        diagnostic,
+        diagnostic_len,
+    );
     debug_assert_eq!(p.len(), payload_len);
     Ok(p)
+}
+
+/// Encode a full exec_result frame into `frame`.
+///
+/// The resulting frame uses the same bytes as
+/// `encode(MSG_EXEC_RESULT, seq, &encode_exec_result(...))` without allocating
+/// separate payload and frame vectors.
+pub fn encode_exec_result_frame_into(
+    frame: &mut Vec<u8>,
+    seq: u32,
+    termination: ExecTermination,
+    duration_ms: u32,
+    stdout: ExecCapturedOutput<'_>,
+    stderr: ExecCapturedOutput<'_>,
+    diagnostic: &str,
+) -> Result<(), ProtocolError> {
+    frame.clear();
+    let (diagnostic_len, payload_len) =
+        validate_exec_result_payload(termination, stdout, stderr, diagnostic)?;
+    encode_into(frame, MSG_EXEC_RESULT, seq, payload_len, |frame| {
+        append_exec_result_payload(
+            frame,
+            termination,
+            duration_ms,
+            stdout,
+            stderr,
+            diagnostic,
+            diagnostic_len,
+        );
+    })
 }
 
 fn decode_exec_termination(

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/exec_result.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/exec_result.rs
@@ -68,6 +68,29 @@ fn exec_result_frame_into_matches_composed_encoding() {
 }
 
 #[test]
+fn exec_result_frame_into_rejects_too_long_diagnostic() {
+    let diagnostic = "x".repeat(u16::MAX as usize + 1);
+    let mut frame = b"stale frame bytes".to_vec();
+
+    let err = encode_exec_result_frame_into(
+        &mut frame,
+        42,
+        ExecTermination::WaitFailed,
+        1234,
+        ExecCapturedOutput::Discarded,
+        ExecCapturedOutput::Discarded,
+        &diagnostic,
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ProtocolError::PayloadTooLarge("diagnostic", size) if size == diagnostic.len()
+    ));
+    assert!(frame.is_empty());
+}
+
+#[test]
 fn exec_result_roundtrip_timed_out_with_diagnostic() {
     let payload = encode_exec_result(
         ExecTermination::TimedOut,

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/exec_result.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/exec_result.rs
@@ -1,5 +1,6 @@
 use super::super::*;
 use super::shared::{ExecResultLayout, set_byte_at};
+use crate::{MSG_EXEC_RESULT, encode};
 
 #[test]
 fn exec_result_roundtrip_exited_with_captured_outputs() {
@@ -36,6 +37,36 @@ fn exec_result_roundtrip_exited_with_captured_outputs() {
         }
     );
 }
+
+#[test]
+fn exec_result_frame_into_matches_composed_encoding() {
+    let termination = ExecTermination::Exited { exit_code: -9 };
+    let stdout = ExecCapturedOutput::Captured {
+        bytes: b"stdout",
+        truncated: false,
+    };
+    let stderr = ExecCapturedOutput::Captured {
+        bytes: b"stderr",
+        truncated: true,
+    };
+    let payload = encode_exec_result(termination, 1234, stdout, stderr, "diagnostic").unwrap();
+    let expected = encode(MSG_EXEC_RESULT, 42, &payload).unwrap();
+    let mut frame = b"stale frame bytes".to_vec();
+
+    encode_exec_result_frame_into(
+        &mut frame,
+        42,
+        termination,
+        1234,
+        stdout,
+        stderr,
+        "diagnostic",
+    )
+    .unwrap();
+
+    assert_eq!(frame, expected);
+}
+
 #[test]
 fn exec_result_roundtrip_timed_out_with_diagnostic() {
     let payload = encode_exec_result(

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/exec_result_properties.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/exec_result_properties.rs
@@ -1,6 +1,7 @@
 use super::super::*;
 use super::shared::{ExecResultLayout, set_byte_at, write_u16_at, write_u32_at};
 use crate::wire::MAX_PAYLOAD_SIZE;
+use crate::{HEADER_SIZE, MAX_MESSAGE_SIZE, MSG_EXEC_RESULT, encode};
 use proptest::prelude::*;
 use proptest::test_runner::{Config as ProptestConfig, RngSeed, TestCaseResult};
 
@@ -358,6 +359,20 @@ fn exec_result_roundtrips_structural_and_scalar_boundaries() {
                     let payload =
                         encode_exec_result(termination, duration_ms, stdout, stderr, "边界")
                             .unwrap();
+                    let expected_frame = encode(MSG_EXEC_RESULT, 42, &payload).unwrap();
+                    let mut frame = Vec::new();
+                    encode_exec_result_frame_into(
+                        &mut frame,
+                        42,
+                        termination,
+                        duration_ms,
+                        stdout,
+                        stderr,
+                        "边界",
+                    )
+                    .unwrap();
+
+                    assert_eq!(frame, expected_frame);
                     assert_eq!(
                         decode_exec_result(&payload).unwrap(),
                         DecodedExecResult {
@@ -432,4 +447,61 @@ fn exec_result_roundtrips_max_payload_length() {
             diagnostic: "",
         }
     );
+
+    let expected_frame = encode(MSG_EXEC_RESULT, 42, &payload).unwrap();
+    drop(payload);
+    let mut frame = Vec::new();
+    encode_exec_result_frame_into(
+        &mut frame,
+        42,
+        ExecTermination::Cancelled,
+        0,
+        ExecCapturedOutput::Captured {
+            bytes: &stdout,
+            truncated: true,
+        },
+        ExecCapturedOutput::Discarded,
+        "",
+    )
+    .unwrap();
+
+    assert_eq!(frame.len(), HEADER_SIZE + MAX_MESSAGE_SIZE);
+    assert_eq!(frame, expected_frame);
+}
+
+#[test]
+fn exec_result_frame_rejects_one_byte_over_max_payload() {
+    let empty_payload = encode_exec_result(
+        ExecTermination::Cancelled,
+        0,
+        ExecCapturedOutput::Captured {
+            bytes: &[],
+            truncated: true,
+        },
+        ExecCapturedOutput::Discarded,
+        "",
+    )
+    .unwrap();
+    let stdout = vec![0xA5; MAX_PAYLOAD_SIZE - empty_payload.len() + 1];
+    let mut frame = b"stale frame bytes".to_vec();
+
+    let err = encode_exec_result_frame_into(
+        &mut frame,
+        42,
+        ExecTermination::Cancelled,
+        0,
+        ExecCapturedOutput::Captured {
+            bytes: &stdout,
+            truncated: true,
+        },
+        ExecCapturedOutput::Discarded,
+        "",
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ProtocolError::MessageTooLarge(size) if size == MAX_MESSAGE_SIZE + 1
+    ));
+    assert!(frame.is_empty());
 }


### PR DESCRIPTION
## Summary

- add an exec-result full-frame encoder that shares validation and payload appending with the existing payload encoder
- encode guest terminal results directly into one frame buffer while preserving writer-lock and completion ordering
- verify byte equivalence across all result variants, the exact frame limit, and one-byte-over rejection

## Scope

- preserves the existing public payload encoder and on-wire protocol
- does not change host-side result ownership or add vectored I/O
- does not change schemas, configuration, persisted state, or rollout behavior

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p vsock-proto`
- `cargo test -p vsock-guest --all-features`
- `cargo clippy -p vsock-proto -p vsock-guest --all-targets --all-features`
- `cargo clippy -p vsock-guest --release --no-default-features --all-targets`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p vsock-proto -p vsock-guest --all-features --no-deps`
- pre-commit workspace Rust formatting, Clippy, documentation, and file-size checks

Closes #24744
