### PR TITLE
test(guest-agent): reap timed-out subprocesses

### DIFF
--- a/crates/guest-agent/tests/command_output_timeout.rs
+++ b/crates/guest-agent/tests/command_output_timeout.rs
@@ -1,0 +1,70 @@
+//! Timed child output collection must own the child through cleanup.
+
+mod common;
+
+use std::io;
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::process::Command;
+
+const MANAGED_TIMEOUT: Duration = Duration::from_secs(20);
+
+#[tokio::test]
+async fn command_output_timeout_preserves_completed_output()
+-> Result<(), Box<dyn std::error::Error>> {
+    let output = common::command_output_with_timeout(
+        Command::new("/bin/sh")
+            .arg("-c")
+            .arg("printf 'captured stdout'; printf 'captured stderr' >&2; exit 7"),
+        Duration::from_secs(5),
+        "completed child exceeded its budget",
+    )
+    .await?;
+
+    assert_eq!(output.status.code(), Some(7));
+    assert_eq!(output.stdout, b"captured stdout");
+    assert_eq!(output.stderr, b"captured stderr");
+    Ok(())
+}
+
+#[tokio::test]
+async fn command_output_timeout_reaps_child_before_returning()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let pid_file = tmp.path().join("child.pid");
+    let mut command = Command::new("/bin/sh");
+    command
+        .arg("-c")
+        .arg("printf '%s\n' \"$$\" > \"$VM0_TEST_CHILD_PID_FILE\"; exec /bin/sleep 60")
+        .env("VM0_TEST_CHILD_PID_FILE", &pid_file);
+    let execution = tokio::spawn(async move {
+        common::command_output_with_timeout(
+            &mut command,
+            MANAGED_TIMEOUT,
+            "long-lived child exceeded its budget",
+        )
+        .await
+    });
+
+    common::wait_for_path(&pid_file, Duration::from_secs(5)).await?;
+    let pid = std::fs::read_to_string(&pid_file)?.trim().parse::<u32>()?;
+    let process_path = PathBuf::from(format!("/proc/{pid}"));
+    assert!(
+        process_path.exists(),
+        "fixture child must be live before its timeout is advanced"
+    );
+
+    tokio::time::pause();
+    tokio::time::advance(MANAGED_TIMEOUT).await;
+    let join_result = execution.await;
+    tokio::time::resume();
+    let error = join_result?.expect_err("long-lived child should reach its managed timeout");
+
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(error.to_string(), "long-lived child exceeded its budget");
+    assert!(
+        !process_path.exists(),
+        "timed-out child must be reaped before the helper returns"
+    );
+    Ok(())
+}

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -28,6 +28,7 @@ use std::io;
 use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
+use std::process::{Output, Stdio};
 use std::sync::{
     Arc, Mutex,
     atomic::{AtomicU64, AtomicUsize, Ordering},
@@ -37,6 +38,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
+use tokio::process::Command;
 use tokio::sync::{mpsc, oneshot};
 
 pub type SystemLogOverrideGuard = system_log::SystemLogOverrideGuard;
@@ -88,6 +90,66 @@ pub fn unique_temp_path(prefix: &str) -> PathBuf {
         "{prefix}-{}-{timestamp_nanos}-{counter}",
         std::process::id()
     ))
+}
+
+pub async fn command_output_with_timeout(
+    command: &mut Command,
+    timeout: Duration,
+    timeout_context: &str,
+) -> io::Result<Output> {
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()?;
+    let (Some(mut stdout), Some(mut stderr)) = (child.stdout.take(), child.stderr.take()) else {
+        return match child.kill().await {
+            Ok(()) => Err(io::Error::other(
+                "captured child omitted its stdout or stderr pipe",
+            )),
+            Err(error) => Err(io::Error::new(
+                error.kind(),
+                format!(
+                    "captured child omitted its stdout or stderr pipe; failed to terminate and reap child: {error}"
+                ),
+            )),
+        };
+    };
+    let mut stdout_bytes = Vec::new();
+    let mut stderr_bytes = Vec::new();
+
+    let output = {
+        let wait_with_output = async {
+            let (status, stdout_result, stderr_result) = tokio::join!(
+                child.wait(),
+                stdout.read_to_end(&mut stdout_bytes),
+                stderr.read_to_end(&mut stderr_bytes),
+            );
+            let status = status?;
+            stdout_result?;
+            stderr_result?;
+            Ok(Output {
+                status,
+                stdout: stdout_bytes,
+                stderr: stderr_bytes,
+            })
+        };
+        tokio::time::timeout(timeout, wait_with_output).await
+    };
+
+    match output {
+        Ok(output) => output,
+        Err(_) => match child.kill().await {
+            Ok(()) => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                timeout_context.to_string(),
+            )),
+            Err(error) => Err(io::Error::new(
+                error.kind(),
+                format!("{timeout_context}; failed to terminate and reap timed-out child: {error}"),
+            )),
+        },
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/guest-agent/tests/event_delivery_failure_recovery.rs
+++ b/crates/guest-agent/tests/event_delivery_failure_recovery.rs
@@ -134,8 +134,7 @@ async fn run_event_failure_case(
             .json_body(json!({"checkpointId": "event-delivery-recovery-checkpoint"}));
     });
 
-    let output = tokio::time::timeout(
-        Duration::from_secs(20),
+    let output = common::command_output_with_timeout(
         Command::new(env!("CARGO_BIN_EXE_guest-agent"))
             .env_clear()
             .env("VM0_TEST_DISABLE_HTTP_RETRY_DELAY", "1")
@@ -164,11 +163,11 @@ async fn run_event_failure_case(
             .env(
                 guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
                 &runtime_dir,
-            )
-            .output(),
+            ),
+        Duration::from_secs(20),
+        "guest-agent exceeded its finalization budget",
     )
-    .await
-    .map_err(|_| io::Error::other("guest-agent exceeded its finalization budget"))??;
+    .await?;
 
     assert!(events.calls_async().await >= 3);
     prepare.assert_calls_async(1).await;

--- a/crates/guest-agent/tests/execution_timeout_recovery.rs
+++ b/crates/guest-agent/tests/execution_timeout_recovery.rs
@@ -85,8 +85,7 @@ async fn execution_timeout_checkpoints_the_resumable_session_before_exit()
             .json_body(json!({"checkpointId": "execution-timeout-recovery-checkpoint"}));
     });
 
-    let output = tokio::time::timeout(
-        Duration::from_secs(20),
+    let output = common::command_output_with_timeout(
         Command::new(env!("CARGO_BIN_EXE_guest-agent"))
             .env_clear()
             .env(
@@ -119,11 +118,11 @@ async fn execution_timeout_checkpoints_the_resumable_session_before_exit()
             .env(
                 guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
                 &runtime_dir,
-            )
-            .output(),
+            ),
+        Duration::from_secs(20),
+        "guest-agent did not finish within its finalization budget",
     )
-    .await
-    .expect("guest-agent did not finish within its finalization budget")?;
+    .await?;
 
     assert_eq!(
         output.status.code(),

--- a/crates/guest-agent/tests/user_cancellation_recovery.rs
+++ b/crates/guest-agent/tests/user_cancellation_recovery.rs
@@ -178,8 +178,7 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
         read_response(&mut stream)
     });
 
-    let output = tokio::time::timeout(
-        Duration::from_secs(20),
+    let output = common::command_output_with_timeout(
         Command::new(env!("CARGO_BIN_EXE_guest-agent"))
             .env_clear()
             .env(
@@ -216,16 +215,11 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
                 guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
                 &runtime_dir,
             )
-            .env(process_control_ipc::BOOTSTRAP_ENV, &endpoint)
-            .output(),
+            .env(process_control_ipc::BOOTSTRAP_ENV, &endpoint),
+        Duration::from_secs(20),
+        "guest-agent did not finish within its finalization budget",
     )
-    .await
-    .map_err(|_| {
-        std::io::Error::new(
-            std::io::ErrorKind::TimedOut,
-            "guest-agent did not finish within its finalization budget",
-        )
-    })??;
+    .await?;
     let response = control.await??;
 
     assert_eq!(response.message_id, "cancel-running-cli");


### PR DESCRIPTION
## Summary

- own timed guest-agent test subprocesses through explicit termination and reaping
- preserve concurrent stdout and stderr capture on normal completion
- add readiness-gated virtual-time coverage proving timeout cleanup completes before return

## Scope and compatibility

- changes guest-agent integration-test infrastructure only
- does not change production runtime behavior, APIs, protocols, schemas, persistence, migrations, rollout, or deployment compatibility
- terminates the directly spawned child; process-group cleanup is outside this issue

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent --no-deps --all-features`
- `cargo test -p guest-agent --test command_output_timeout --all-features -- --nocapture`
- timeout cleanup regression repeated 20 times
- `cargo test -p guest-agent --all-features --test event_delivery_failure_recovery --test execution_timeout_recovery --test user_cancellation_recovery -- --nocapture`
- `cargo test -p guest-agent --all-targets --all-features`
- `git diff --check`

Closes #24742
