### PR TITLE
refactor(python): share request-body admission leases

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -27,6 +27,7 @@ from mitmproxy import http
 
 import flow_metadata_keys as metadata_keys
 import public_destination
+import request_body_admission
 from authority_utils import (
     IPV6_VERSION,
     authority_has_empty_port,
@@ -58,6 +59,7 @@ MAX_CONCURRENT_AUTH_BASE_FORWARDS = 4
 MAX_ADMITTED_AUTH_BASE_FORWARDS = 16
 MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES = 128 * 1024 * 1024
 AUTH_BASE_FORWARD_DEADLINE_SECONDS = 30.0
+_NEGATIVE_FORWARD_REQUEST_BODY_SIZE_ERROR = "auth.base forwarding body size cannot be negative"
 _FORWARD_REQUEST_CLEANUP_EXCEPTIONS: tuple[type[BaseException], ...] = (
     Exception,
     asyncio.CancelledError,
@@ -73,9 +75,11 @@ _forward_request_workers: set[threading.Thread] = set()
 _forward_request_workers_lock = threading.Lock()
 _forward_request_pending_futures: set[Future[tuple[int, bytes, http.Headers]]] = set()
 _forward_request_pending_futures_lock = threading.Lock()
-_forward_request_budget_lock = threading.Lock()
-_forward_request_admitted_count = 0
-_forward_request_admitted_body_bytes = 0
+_forward_request_budget = request_body_admission.RequestBodyAdmissionBudget(
+    metadata_key=metadata_keys.AUTH_BASE_FORWARD_ADMISSION,
+    negative_size_message=_NEGATIVE_FORWARD_REQUEST_BODY_SIZE_ERROR,
+    already_attached_message="auth.base forwarding admission is already attached to flow",
+)
 _forward_request_active_handles: set["_ForwardRequestAbortHandle"] = set()
 _forward_request_active_handles_lock = threading.Lock()
 _https_context: ssl.SSLContext | None = None
@@ -168,14 +172,10 @@ def reset_forward_request_state_for_tests() -> None:
     """Reset forwarder worker state between tests."""
     global _dns_resolver
     global _forward_request_accepting
-    global _forward_request_admitted_body_bytes
-    global _forward_request_admitted_count
     global _https_context
 
     shutdown_forward_request_workers(wait=True)
-    with _forward_request_budget_lock:
-        _forward_request_admitted_count = 0
-        _forward_request_admitted_body_bytes = 0
+    _forward_request_budget.reset_for_tests()
     with _https_context_lock:
         _https_context = None
     _dns_resolver = None
@@ -353,16 +353,6 @@ class _ForwardRequestAbortHandle:
         if terminal_state is _ForwardRequestTerminalState.SHUTDOWN_ABORTED:
             raise RuntimeError("auth.base forwarding workers are shut down")
         raise RuntimeError("auth.base forwarding attempt is already completed")
-
-
-class AuthBaseForwardingAdmission:
-    """Opaque reservation for one admitted auth.base forward."""
-
-    __slots__ = ("_body_bytes", "_released")
-
-    def __init__(self, body_bytes: int) -> None:
-        self._body_bytes = body_bytes
-        self._released = False
 
 
 class _ValidatedAddress(NamedTuple):
@@ -732,94 +722,79 @@ def _request_body_size(body: bytes | None) -> int:
     return len(body) if body is not None else 0
 
 
-def reserve_forward_request_admission(body_bytes: int) -> AuthBaseForwardingAdmission:
+def reserve_forward_request_admission(
+    body_bytes: int,
+) -> request_body_admission.RequestBodyAdmissionLease:
     """Reserve aggregate auth.base forwarding capacity before body buffering."""
-    global _forward_request_admitted_body_bytes
-    global _forward_request_admitted_count
-
     if body_bytes < 0:
-        raise ValueError("auth.base forwarding body size cannot be negative")
+        raise ValueError(_NEGATIVE_FORWARD_REQUEST_BODY_SIZE_ERROR)
 
     with _forward_request_lifecycle_lock:
         if not _forward_request_accepting:
             raise RuntimeError("auth.base forwarding workers are shut down")
 
-        with _forward_request_budget_lock:
-            if _forward_request_admitted_count + 1 > MAX_ADMITTED_AUTH_BASE_FORWARDS:
-                raise AuthBaseForwardingSaturatedError("auth.base forwarding admission is full")
-            if (
-                _forward_request_admitted_body_bytes + body_bytes
-                > MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES
-            ):
-                raise AuthBaseForwardingSaturatedError("auth.base forwarding body budget is full")
-
-            _forward_request_admitted_count += 1
-            _forward_request_admitted_body_bytes += body_bytes
-            return AuthBaseForwardingAdmission(body_bytes)
+        try:
+            return _forward_request_budget.reserve(
+                body_bytes,
+                max_admitted_count=MAX_ADMITTED_AUTH_BASE_FORWARDS,
+                max_admitted_body_bytes=MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES,
+            )
+        except request_body_admission.RequestBodyAdmissionCountSaturatedError:
+            raise AuthBaseForwardingSaturatedError(
+                "auth.base forwarding admission is full"
+            ) from None
+        except request_body_admission.RequestBodyAdmissionByteSaturatedError:
+            raise AuthBaseForwardingSaturatedError(
+                "auth.base forwarding body budget is full"
+            ) from None
 
 
 def adjust_forward_request_admission(
-    admission: AuthBaseForwardingAdmission, body_bytes: int
+    admission: request_body_admission.RequestBodyAdmissionLease,
+    body_bytes: int,
 ) -> None:
     """Resize an existing reservation when actual body size differs."""
-    global _forward_request_admitted_body_bytes
-
-    if body_bytes < 0:
-        raise ValueError("auth.base forwarding body size cannot be negative")
-
-    with _forward_request_budget_lock:
-        if admission._released:
-            raise RuntimeError("auth.base forwarding admission is already released")
-        delta = body_bytes - admission._body_bytes
-        if delta > 0 and (
-            _forward_request_admitted_body_bytes + delta > MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES
-        ):
-            raise AuthBaseForwardingSaturatedError("auth.base forwarding body budget is full")
-        _forward_request_admitted_body_bytes += delta
-        admission._body_bytes = body_bytes
+    try:
+        _forward_request_budget.resize(
+            admission,
+            body_bytes,
+            max_admitted_body_bytes=MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES,
+            already_released_message="auth.base forwarding admission is already released",
+        )
+    except request_body_admission.RequestBodyAdmissionByteSaturatedError:
+        raise AuthBaseForwardingSaturatedError("auth.base forwarding body budget is full") from None
 
 
-def release_forward_request_admission(admission: AuthBaseForwardingAdmission) -> None:
+def release_forward_request_admission(
+    admission: request_body_admission.RequestBodyAdmissionLease,
+) -> None:
     """Release aggregate auth.base forwarding capacity exactly once."""
-    global _forward_request_admitted_body_bytes
-    global _forward_request_admitted_count
-
-    with _forward_request_budget_lock:
-        if admission._released:
-            return
-        admission._released = True
-        _forward_request_admitted_count -= 1
-        _forward_request_admitted_body_bytes -= admission._body_bytes
+    _forward_request_budget.release(admission)
 
 
 def attach_forward_request_admission_to_flow(
-    flow: http.HTTPFlow, admission: AuthBaseForwardingAdmission
+    flow: http.HTTPFlow,
+    admission: request_body_admission.RequestBodyAdmissionLease,
 ) -> None:
     """Attach an auth.base forward admission to a flow until ownership is transferred."""
-    if metadata_keys.AUTH_BASE_FORWARD_ADMISSION in flow.metadata:
-        raise RuntimeError("auth.base forwarding admission is already attached to flow")
-    flow.metadata[metadata_keys.AUTH_BASE_FORWARD_ADMISSION] = admission
+    _forward_request_budget.attach_to_flow(flow, admission)
 
 
 def take_forward_request_admission_from_flow(
     flow: http.HTTPFlow,
-) -> AuthBaseForwardingAdmission | None:
+) -> request_body_admission.RequestBodyAdmissionLease | None:
     """Remove an attached auth.base forward admission and transfer ownership."""
-    admission = flow.metadata.pop(metadata_keys.AUTH_BASE_FORWARD_ADMISSION, None)
-    return admission if isinstance(admission, AuthBaseForwardingAdmission) else None
+    return _forward_request_budget.take_from_flow(flow)
 
 
 def release_forward_request_admission_from_flow(flow: http.HTTPFlow) -> None:
     """Release any auth.base forward admission still attached to a flow."""
-    admission = take_forward_request_admission_from_flow(flow)
-    if admission is not None:
-        release_forward_request_admission(admission)
+    _forward_request_budget.release_from_flow(flow)
 
 
 def forward_request_admission_state_for_tests() -> tuple[int, int]:
     """Return current admitted count and body bytes for tests."""
-    with _forward_request_budget_lock:
-        return _forward_request_admitted_count, _forward_request_admitted_body_bytes
+    return _forward_request_budget.state_for_tests()
 
 
 def _is_public_unicast_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
@@ -989,7 +964,7 @@ def _can_submit_forward_request(semaphore: asyncio.Semaphore) -> bool:
 def _release_forward_request_resources(
     loop: asyncio.AbstractEventLoop,
     semaphore: asyncio.Semaphore,
-    admission: AuthBaseForwardingAdmission,
+    admission: request_body_admission.RequestBodyAdmissionLease,
     abort_handle: _ForwardRequestAbortHandle,
     deadline_timer: asyncio.TimerHandle,
     _future: Future[tuple[int, bytes, http.Headers]],
@@ -1159,7 +1134,7 @@ async def forward_request(
     headers: list[tuple[str, str]],
     body: bytes | None,
     *,
-    admission: AuthBaseForwardingAdmission | None = None,
+    admission: request_body_admission.RequestBodyAdmissionLease | None = None,
 ) -> tuple[int, bytes, http.Headers]:
     """Forward an auth.base request within one absolute worker lifetime.
 

--- a/crates/runner/mitm-addon/src/aws_sigv4_body_admission.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4_body_admission.py
@@ -1,10 +1,9 @@
 """Aggregate admission for request bodies retained by AWS SigV4 signing."""
 
-import threading
-
 from mitmproxy import http
 
 import flow_metadata_keys as metadata_keys
+import request_body_admission
 
 # Match the established auth.base buffered-request envelope while keeping the
 # two admission owners independent: auth.base also reserves forwarder capacity.
@@ -12,87 +11,66 @@ MAX_AWS_SIGV4_REQUEST_BODY_BYTES = 32 * 1024 * 1024
 MAX_ADMITTED_AWS_SIGV4_REQUESTS = 16
 MAX_ADMITTED_AWS_SIGV4_REQUEST_BODY_BYTES = 128 * 1024 * 1024
 
-_budget_lock = threading.Lock()
-_admitted_count = 0
-_admitted_body_bytes = 0
-
 
 class AwsSigV4BodyAdmissionSaturatedError(Exception):
     """Raised when the retained SigV4 request-body budget is full."""
 
 
-class AwsSigV4BodyAdmission:
-    """Opaque reservation for one retained SigV4 request body."""
-
-    __slots__ = ("_body_bytes", "_released")
-
-    def __init__(self, body_bytes: int) -> None:
-        self._body_bytes = body_bytes
-        self._released = False
+_budget = request_body_admission.RequestBodyAdmissionBudget(
+    metadata_key=metadata_keys.AWS_SIGV4_BODY_ADMISSION,
+    negative_size_message="AWS SigV4 request body size cannot be negative",
+    already_attached_message="AWS SigV4 request-body admission is already attached",
+)
 
 
-def reserve(body_bytes: int) -> AwsSigV4BodyAdmission:
+def reserve(body_bytes: int) -> request_body_admission.RequestBodyAdmissionLease:
     """Reserve aggregate capacity before mitmproxy buffers a SigV4 body."""
-    global _admitted_body_bytes
-    global _admitted_count
+    try:
+        return _budget.reserve(
+            body_bytes,
+            max_admitted_count=MAX_ADMITTED_AWS_SIGV4_REQUESTS,
+            max_admitted_body_bytes=MAX_ADMITTED_AWS_SIGV4_REQUEST_BODY_BYTES,
+        )
+    except request_body_admission.RequestBodyAdmissionCountSaturatedError:
+        raise AwsSigV4BodyAdmissionSaturatedError(
+            "AWS SigV4 request-body admission is full"
+        ) from None
+    except request_body_admission.RequestBodyAdmissionByteSaturatedError:
+        raise AwsSigV4BodyAdmissionSaturatedError(
+            "AWS SigV4 request-body byte budget is full"
+        ) from None
 
-    if body_bytes < 0:
-        raise ValueError("AWS SigV4 request body size cannot be negative")
 
-    with _budget_lock:
-        if _admitted_count + 1 > MAX_ADMITTED_AWS_SIGV4_REQUESTS:
-            raise AwsSigV4BodyAdmissionSaturatedError("AWS SigV4 request-body admission is full")
-        if _admitted_body_bytes + body_bytes > MAX_ADMITTED_AWS_SIGV4_REQUEST_BODY_BYTES:
-            raise AwsSigV4BodyAdmissionSaturatedError("AWS SigV4 request-body byte budget is full")
-        _admitted_count += 1
-        _admitted_body_bytes += body_bytes
-        return AwsSigV4BodyAdmission(body_bytes)
-
-
-def release(admission: AwsSigV4BodyAdmission) -> None:
+def release(admission: request_body_admission.RequestBodyAdmissionLease) -> None:
     """Release aggregate capacity exactly once."""
-    global _admitted_body_bytes
-    global _admitted_count
-
-    with _budget_lock:
-        if admission._released:
-            return
-        admission._released = True
-        _admitted_count -= 1
-        _admitted_body_bytes -= admission._body_bytes
+    _budget.release(admission)
 
 
-def attach_to_flow(flow: http.HTTPFlow, admission: AwsSigV4BodyAdmission) -> None:
+def attach_to_flow(
+    flow: http.HTTPFlow,
+    admission: request_body_admission.RequestBodyAdmissionLease,
+) -> None:
     """Attach a reservation to its retaining flow."""
-    if metadata_keys.AWS_SIGV4_BODY_ADMISSION in flow.metadata:
-        raise RuntimeError("AWS SigV4 request-body admission is already attached")
-    flow.metadata[metadata_keys.AWS_SIGV4_BODY_ADMISSION] = admission
+    _budget.attach_to_flow(flow, admission)
 
 
-def take_from_flow(flow: http.HTTPFlow) -> AwsSigV4BodyAdmission | None:
+def take_from_flow(
+    flow: http.HTTPFlow,
+) -> request_body_admission.RequestBodyAdmissionLease | None:
     """Remove and return the flow reservation, if present."""
-    admission = flow.metadata.pop(metadata_keys.AWS_SIGV4_BODY_ADMISSION, None)
-    return admission if isinstance(admission, AwsSigV4BodyAdmission) else None
+    return _budget.take_from_flow(flow)
 
 
 def release_from_flow(flow: http.HTTPFlow) -> None:
     """Release any reservation attached to a flow."""
-    admission = take_from_flow(flow)
-    if admission is not None:
-        release(admission)
+    _budget.release_from_flow(flow)
 
 
 def state_for_tests() -> tuple[int, int]:
     """Return admitted flow count and declared bytes for tests."""
-    with _budget_lock:
-        return _admitted_count, _admitted_body_bytes
+    return _budget.state_for_tests()
 
 
 def reset_for_tests() -> None:
     """Reset aggregate admission between tests."""
-    global _admitted_body_bytes
-    global _admitted_count
-
-    with _budget_lock:
-        _admitted_count = 0
-        _admitted_body_bytes = 0
+    _budget.reset_for_tests()

--- a/crates/runner/mitm-addon/src/request_body_admission.py
+++ b/crates/runner/mitm-addon/src/request_body_admission.py
@@ -107,10 +107,13 @@ class RequestBodyAdmissionBudget:
 
     def take_from_flow(self, flow: http.HTTPFlow) -> RequestBodyAdmissionLease | None:
         """Remove and return this budget's flow reservation, if present."""
-        admission = flow.metadata.pop(self._metadata_key, None)
-        if isinstance(admission, RequestBodyAdmissionLease) and admission._budget is self:
-            return admission
-        return None
+        admission = flow.metadata.get(self._metadata_key)
+        if not isinstance(admission, RequestBodyAdmissionLease):
+            flow.metadata.pop(self._metadata_key, None)
+            return None
+        self._require_owner(admission)
+        flow.metadata.pop(self._metadata_key)
+        return admission
 
     def release_from_flow(self, flow: http.HTTPFlow) -> None:
         """Release this budget's reservation attached to a flow."""

--- a/crates/runner/mitm-addon/src/request_body_admission.py
+++ b/crates/runner/mitm-addon/src/request_body_admission.py
@@ -1,0 +1,138 @@
+"""Shared count-and-byte admission for retained request bodies."""
+
+from __future__ import annotations
+
+import threading
+
+from mitmproxy import http
+
+
+class RequestBodyAdmissionCountSaturatedError(Exception):
+    """Raised when an admission budget has no request-count capacity."""
+
+
+class RequestBodyAdmissionByteSaturatedError(Exception):
+    """Raised when an admission budget has no aggregate byte capacity."""
+
+
+class RequestBodyAdmissionLease:
+    """Opaque reservation owned by one request-body admission budget."""
+
+    __slots__ = ("_body_bytes", "_budget", "_released")
+
+    def __init__(self, budget: RequestBodyAdmissionBudget, body_bytes: int) -> None:
+        self._budget = budget
+        self._body_bytes = body_bytes
+        self._released = False
+
+
+class RequestBodyAdmissionBudget:
+    """Own independent count and byte totals for one request-body policy."""
+
+    def __init__(
+        self,
+        *,
+        metadata_key: str,
+        negative_size_message: str,
+        already_attached_message: str,
+    ) -> None:
+        self._metadata_key = metadata_key
+        self._negative_size_message = negative_size_message
+        self._already_attached_message = already_attached_message
+        self._lock = threading.Lock()
+        self._admitted_count = 0
+        self._admitted_body_bytes = 0
+
+    def reserve(
+        self,
+        body_bytes: int,
+        *,
+        max_admitted_count: int,
+        max_admitted_body_bytes: int,
+    ) -> RequestBodyAdmissionLease:
+        """Reserve count and byte capacity atomically."""
+        self._validate_body_size(body_bytes)
+
+        with self._lock:
+            if self._admitted_count + 1 > max_admitted_count:
+                raise RequestBodyAdmissionCountSaturatedError
+            if self._admitted_body_bytes + body_bytes > max_admitted_body_bytes:
+                raise RequestBodyAdmissionByteSaturatedError
+            self._admitted_count += 1
+            self._admitted_body_bytes += body_bytes
+            return RequestBodyAdmissionLease(self, body_bytes)
+
+    def resize(
+        self,
+        admission: RequestBodyAdmissionLease,
+        body_bytes: int,
+        *,
+        max_admitted_body_bytes: int,
+        already_released_message: str,
+    ) -> None:
+        """Resize an existing reservation while preserving aggregate capacity."""
+        self._require_owner(admission)
+        self._validate_body_size(body_bytes)
+
+        with self._lock:
+            if admission._released:
+                raise RuntimeError(already_released_message)
+            delta = body_bytes - admission._body_bytes
+            if delta > 0 and self._admitted_body_bytes + delta > max_admitted_body_bytes:
+                raise RequestBodyAdmissionByteSaturatedError
+            self._admitted_body_bytes += delta
+            admission._body_bytes = body_bytes
+
+    def release(self, admission: RequestBodyAdmissionLease) -> None:
+        """Release aggregate capacity exactly once."""
+        self._require_owner(admission)
+
+        with self._lock:
+            if admission._released:
+                return
+            admission._released = True
+            self._admitted_count -= 1
+            self._admitted_body_bytes -= admission._body_bytes
+
+    def attach_to_flow(
+        self,
+        flow: http.HTTPFlow,
+        admission: RequestBodyAdmissionLease,
+    ) -> None:
+        """Attach a reservation to its retaining flow."""
+        if self._metadata_key in flow.metadata:
+            raise RuntimeError(self._already_attached_message)
+        self._require_owner(admission)
+        flow.metadata[self._metadata_key] = admission
+
+    def take_from_flow(self, flow: http.HTTPFlow) -> RequestBodyAdmissionLease | None:
+        """Remove and return this budget's flow reservation, if present."""
+        admission = flow.metadata.pop(self._metadata_key, None)
+        if isinstance(admission, RequestBodyAdmissionLease) and admission._budget is self:
+            return admission
+        return None
+
+    def release_from_flow(self, flow: http.HTTPFlow) -> None:
+        """Release this budget's reservation attached to a flow."""
+        admission = self.take_from_flow(flow)
+        if admission is not None:
+            self.release(admission)
+
+    def state_for_tests(self) -> tuple[int, int]:
+        """Return admitted count and body bytes for tests."""
+        with self._lock:
+            return self._admitted_count, self._admitted_body_bytes
+
+    def reset_for_tests(self) -> None:
+        """Reset aggregate admission between tests."""
+        with self._lock:
+            self._admitted_count = 0
+            self._admitted_body_bytes = 0
+
+    def _validate_body_size(self, body_bytes: int) -> None:
+        if body_bytes < 0:
+            raise ValueError(self._negative_size_message)
+
+    def _require_owner(self, admission: RequestBodyAdmissionLease) -> None:
+        if admission._budget is not self:
+            raise RuntimeError("request-body admission belongs to another budget")

--- a/crates/runner/mitm-addon/tests/test_request_body_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_body_admission.py
@@ -1,0 +1,206 @@
+"""Resource-safety invariants for shared request-body admission budgets."""
+
+import pytest
+
+import request_body_admission
+
+
+def _budget(metadata_key: str) -> request_body_admission.RequestBodyAdmissionBudget:
+    return request_body_admission.RequestBodyAdmissionBudget(
+        metadata_key=metadata_key,
+        negative_size_message="body size cannot be negative",
+        already_attached_message="admission is already attached",
+    )
+
+
+@pytest.mark.parametrize(
+    ("max_admitted_count", "max_admitted_body_bytes", "error_type"),
+    [
+        (0, 3, request_body_admission.RequestBodyAdmissionCountSaturatedError),
+        (1, 3, request_body_admission.RequestBodyAdmissionByteSaturatedError),
+    ],
+    ids=["count", "body-bytes"],
+)
+def test_reserve_rejects_saturation_without_mutating_state(
+    max_admitted_count: int,
+    max_admitted_body_bytes: int,
+    error_type: type[Exception],
+) -> None:
+    budget = _budget("admission")
+
+    with pytest.raises(error_type):
+        budget.reserve(
+            4,
+            max_admitted_count=max_admitted_count,
+            max_admitted_body_bytes=max_admitted_body_bytes,
+        )
+
+    assert budget.state_for_tests() == (0, 0)
+
+
+def test_negative_sizes_do_not_mutate_state() -> None:
+    budget = _budget("admission")
+
+    with pytest.raises(ValueError, match="body size cannot be negative"):
+        budget.reserve(
+            -1,
+            max_admitted_count=1,
+            max_admitted_body_bytes=4,
+        )
+    assert budget.state_for_tests() == (0, 0)
+
+    lease = budget.reserve(
+        1,
+        max_admitted_count=1,
+        max_admitted_body_bytes=4,
+    )
+    with pytest.raises(ValueError, match="body size cannot be negative"):
+        budget.resize(
+            lease,
+            -1,
+            max_admitted_body_bytes=4,
+            already_released_message="admission is already released",
+        )
+    assert budget.state_for_tests() == (1, 1)
+
+    budget.release(lease)
+
+
+def test_budgets_keep_independent_capacity() -> None:
+    first = _budget("first_admission")
+    second = _budget("second_admission")
+    first_lease = first.reserve(
+        4,
+        max_admitted_count=1,
+        max_admitted_body_bytes=4,
+    )
+
+    with pytest.raises(request_body_admission.RequestBodyAdmissionCountSaturatedError):
+        first.reserve(
+            0,
+            max_admitted_count=1,
+            max_admitted_body_bytes=4,
+        )
+
+    second_lease = second.reserve(
+        4,
+        max_admitted_count=1,
+        max_admitted_body_bytes=4,
+    )
+    assert first.state_for_tests() == (1, 4)
+    assert second.state_for_tests() == (1, 4)
+
+    first.release(first_lease)
+    second.release(second_lease)
+
+
+def test_resize_and_duplicate_release_preserve_accounting() -> None:
+    budget = _budget("admission")
+    lease = budget.reserve(
+        2,
+        max_admitted_count=1,
+        max_admitted_body_bytes=4,
+    )
+
+    budget.resize(
+        lease,
+        4,
+        max_admitted_body_bytes=4,
+        already_released_message="admission is already released",
+    )
+    assert budget.state_for_tests() == (1, 4)
+
+    with pytest.raises(request_body_admission.RequestBodyAdmissionByteSaturatedError):
+        budget.resize(
+            lease,
+            5,
+            max_admitted_body_bytes=4,
+            already_released_message="admission is already released",
+        )
+    assert budget.state_for_tests() == (1, 4)
+
+    budget.resize(
+        lease,
+        1,
+        max_admitted_body_bytes=4,
+        already_released_message="admission is already released",
+    )
+    assert budget.state_for_tests() == (1, 1)
+
+    budget.release(lease)
+    budget.release(lease)
+    assert budget.state_for_tests() == (0, 0)
+
+    with pytest.raises(RuntimeError, match="already released"):
+        budget.resize(
+            lease,
+            0,
+            max_admitted_body_bytes=4,
+            already_released_message="admission is already released",
+        )
+
+
+def test_flow_attachment_transfers_and_releases_once(real_flow) -> None:
+    budget = _budget("admission")
+    flow = real_flow(with_response=False)
+    first = budget.reserve(
+        2,
+        max_admitted_count=2,
+        max_admitted_body_bytes=4,
+    )
+    second = budget.reserve(
+        2,
+        max_admitted_count=2,
+        max_admitted_body_bytes=4,
+    )
+
+    budget.attach_to_flow(flow, first)
+    with pytest.raises(RuntimeError, match="already attached"):
+        budget.attach_to_flow(flow, second)
+    assert budget.state_for_tests() == (2, 4)
+
+    assert budget.take_from_flow(flow) is first
+    assert budget.take_from_flow(flow) is None
+    budget.release(first)
+
+    budget.attach_to_flow(flow, second)
+    budget.release_from_flow(flow)
+    budget.release_from_flow(flow)
+    assert budget.state_for_tests() == (0, 0)
+
+
+def test_budget_rejects_lease_from_another_instance(real_flow) -> None:
+    first = _budget("first_admission")
+    second = _budget("second_admission")
+    flow = real_flow(with_response=False)
+    lease = first.reserve(
+        4,
+        max_admitted_count=1,
+        max_admitted_body_bytes=4,
+    )
+
+    with pytest.raises(RuntimeError, match="another budget"):
+        second.attach_to_flow(flow, lease)
+    with pytest.raises(RuntimeError, match="another budget"):
+        second.release(lease)
+
+    flow.metadata["second_admission"] = lease
+    assert second.take_from_flow(flow) is None
+    assert "second_admission" not in flow.metadata
+    assert first.state_for_tests() == (1, 4)
+    assert second.state_for_tests() == (0, 0)
+
+    first.release(lease)
+
+
+def test_reset_clears_budget_state() -> None:
+    budget = _budget("admission")
+    budget.reserve(
+        4,
+        max_admitted_count=1,
+        max_admitted_body_bytes=4,
+    )
+
+    budget.reset_for_tests()
+
+    assert budget.state_for_tests() == (0, 0)

--- a/crates/runner/mitm-addon/tests/test_request_body_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_body_admission.py
@@ -182,14 +182,23 @@ def test_budget_rejects_lease_from_another_instance(real_flow) -> None:
     with pytest.raises(RuntimeError, match="another budget"):
         second.attach_to_flow(flow, lease)
     with pytest.raises(RuntimeError, match="another budget"):
+        second.resize(
+            lease,
+            1,
+            max_admitted_body_bytes=4,
+            already_released_message="admission is already released",
+        )
+    with pytest.raises(RuntimeError, match="another budget"):
         second.release(lease)
 
     flow.metadata["second_admission"] = lease
-    assert second.take_from_flow(flow) is None
-    assert "second_admission" not in flow.metadata
+    with pytest.raises(RuntimeError, match="another budget"):
+        second.take_from_flow(flow)
+    assert flow.metadata["second_admission"] is lease
     assert first.state_for_tests() == (1, 4)
     assert second.state_for_tests() == (0, 0)
 
+    flow.metadata.pop("second_admission")
     first.release(lease)
 
 


### PR DESCRIPTION
## Summary

- add one shared count-and-byte request-body admission budget and opaque lease
- keep auth.base and AWS SigV4 on independent budget instances with their existing live limits, errors, metadata keys, and release timing
- cover saturation, resize, idempotent release, flow ownership, reset, and cross-instance isolation in focused resource-safety tests

## Scope

This is a process-local Python refactor. Existing auth.base lifecycle gating, semaphore and worker ownership, AWS signing behavior, and request/response/error/WebSocket terminal call sites are unchanged.

No API, runner protocol, queue payload, persisted state, database migration, deployment compatibility shim, or documentation change is included.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_request_body_admission.py`
- focused auth.base, AWS SigV4, framing, and error-handler pytest coverage (189 passed before the final full run)
- `uv run --no-sync python -m pytest -q tests/` (4,599 passed)
- `lefthook run pre-commit`

Closes #24746
