### PR TITLE
refactor(python): centralize content-length parsing

### DIFF
--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -16,6 +16,7 @@ from typing import NoReturn
 from mitmproxy import http
 
 import body_decoding
+import content_length
 import flow_metadata
 from runtime_url_parsing import split_runtime_url
 
@@ -27,8 +28,6 @@ MAX_IN_FLIGHT_REQUESTS = MAX_TOTAL_BYTES // MAX_ENTRY_BYTES
 MAX_WAITERS_PER_KEY = MAX_IN_FLIGHT_REQUESTS
 MAX_TOTAL_WAITERS = MAX_IN_FLIGHT_REQUESTS * 2
 MAX_IN_FLIGHT_WAIT_SECONDS = 10.0
-_MAX_CONTENT_LENGTH_DIGITS = len(str(MAX_ENTRY_BYTES))
-
 _FIREWALL_NAME = "model-provider:codex-oauth-token"
 _CATALOG_HOST = "chatgpt.com"
 _CATALOG_PATH = "/backend-api/codex/models"
@@ -384,20 +383,11 @@ def _json_nesting_is_bounded(document: str) -> bool:
     return True
 
 
-def _content_length(headers: http.Headers) -> int | None:
-    values = headers.get_all("Content-Length")
-    if not values:
-        return None
-    parts = [part.strip() for value in values for part in value.split(",")]
-    if not parts or any(
-        not part.isascii() or not part.isdecimal() or len(part) > _MAX_CONTENT_LENGTH_DIGITS
-        for part in parts
-    ):
-        return -1
-    lengths = {int(part) for part in parts}
-    if len(lengths) != 1:
-        return -1
-    return lengths.pop()
+def _parse_content_length(headers: http.Headers) -> content_length.ContentLengthResult:
+    return content_length.parse(
+        headers.get_all("Content-Length"),
+        max_value=MAX_ENTRY_BYTES,
+    )
 
 
 def _set_telemetry(
@@ -465,11 +455,11 @@ def _request_bypass_reason(
         return "request_body"
     if flow.request.stream:
         return "request_streaming"
-    content_length = _content_length(flow.request.headers)
+    parsed_content_length = _parse_content_length(flow.request.headers)
     if (
         flow.request.headers.get_all("Transfer-Encoding")
-        or content_length == -1
-        or (content_length is not None and content_length > 0)
+        or parsed_content_length.kind in ("invalid", "conflicting", "over_limit")
+        or (parsed_content_length.kind == "valid" and parsed_content_length.value > 0)
     ):
         return "request_framing"
     if any(flow.request.headers.get_all(name) for name in _REQUEST_CONDITIONAL_HEADERS):
@@ -645,8 +635,8 @@ def _response_headers_bypass_reason(
         return "response_vary"
     if _single_usable_etag(response.headers) is None:
         return "response_etag"
-    content_length = _content_length(response.headers)
-    if content_length == -1 or (content_length is not None and content_length > MAX_ENTRY_BYTES):
+    parsed_content_length = _parse_content_length(response.headers)
+    if parsed_content_length.kind not in ("missing", "valid"):
         return "response_size"
     return None
 
@@ -699,18 +689,16 @@ def handle_response_headers(flow: http.HTTPFlow) -> bool:
         _bypass_response(flow, state, bypass_reason)
         return True
 
-    compressed_content_length = _content_length(flow.response.headers)
-    if (
-        compressed_content_length == -1
-        or (compressed_content_length is not None and compressed_content_length > MAX_ENTRY_BYTES)
-        or (
-            compressed_content_length is not None
-            and flow.response.headers.get_all("Transfer-Encoding")
-        )
+    compressed_content_length = _parse_content_length(flow.response.headers)
+    if compressed_content_length.kind not in ("missing", "valid") or (
+        compressed_content_length.kind == "valid"
+        and flow.response.headers.get_all("Transfer-Encoding")
     ):
         _bypass_response(flow, state, "response_size")
         return True
-    state.compressed_content_length = compressed_content_length
+    state.compressed_content_length = (
+        compressed_content_length.value if compressed_content_length.kind == "valid" else None
+    )
     return True
 
 
@@ -778,11 +766,11 @@ def _validated_response_body(
         return "response_size"
 
     body = bytes(state.capture)
-    content_length = _content_length(response.headers)
+    parsed_content_length = _parse_content_length(response.headers)
     if (
         state.upstream_encoding == _IDENTITY_ENCODING
-        and content_length is not None
-        and content_length != len(body)
+        and parsed_content_length.kind == "valid"
+        and parsed_content_length.value != len(body)
     ):
         return "response_body"
     try:

--- a/crates/runner/mitm-addon/src/content_length.py
+++ b/crates/runner/mitm-addon/src/content_length.py
@@ -1,0 +1,76 @@
+"""Bounded parsing for HTTP Content-Length field values."""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+ContentLengthKind = Literal["missing", "valid", "invalid", "conflicting", "over_limit"]
+
+
+@dataclass(frozen=True, slots=True)
+class ContentLengthResult:
+    kind: ContentLengthKind
+    value: int = 0
+
+
+def parse(values: Iterable[str], *, max_value: int) -> ContentLengthResult:
+    """Parse repeated Content-Length fields without converting unbounded integers."""
+    first_value: str | None = None
+    first_start = 0
+    first_end = 0
+    parsed_value = 0
+    over_limit = False
+    limit_digits = len(str(max_value))
+
+    for field_value in values:
+        part_start = 0
+        while True:
+            comma = field_value.find(",", part_start)
+            part_end = len(field_value) if comma == -1 else comma
+
+            while part_start < part_end and field_value[part_start] in (" ", "\t"):
+                part_start += 1
+            while part_end > part_start and field_value[part_end - 1] in (" ", "\t"):
+                part_end -= 1
+            if part_start == part_end:
+                return ContentLengthResult("invalid")
+
+            significant_start = part_start
+            while significant_start < part_end and field_value[significant_start] == "0":
+                significant_start += 1
+            if significant_start == part_end:
+                significant_start -= 1
+
+            for index in range(significant_start, part_end):
+                character = field_value[index]
+                if character < "0" or character > "9":
+                    return ContentLengthResult("invalid")
+
+            if first_value is None:
+                first_value = field_value
+                first_start = significant_start
+                first_end = part_end
+                significant_digits = part_end - significant_start
+                if significant_digits > limit_digits:
+                    parsed_value = max_value + 1
+                    over_limit = True
+                else:
+                    parsed_value = int(field_value[significant_start:part_end])
+                    over_limit = parsed_value > max_value
+            else:
+                significant_digits = part_end - significant_start
+                if significant_digits != first_end - first_start or any(
+                    first_value[first_start + offset] != field_value[significant_start + offset]
+                    for offset in range(significant_digits)
+                ):
+                    return ContentLengthResult("conflicting")
+
+            if comma == -1:
+                break
+            part_start = comma + 1
+
+    if first_value is None:
+        return ContentLengthResult("missing")
+    if over_limit:
+        return ContentLengthResult("over_limit", parsed_value)
+    return ContentLengthResult("valid", parsed_value)

--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -20,7 +20,6 @@ _PROXY_LOG_RESERVED_FIELDS = {"timestamp", "level", "message"}
 
 # Network log size fields are consumed as JavaScript numbers downstream.
 NETWORK_LOG_MAX_SAFE_SIZE = 9_007_199_254_740_991
-NETWORK_LOG_MAX_SAFE_SIZE_DIGITS = len(str(NETWORK_LOG_MAX_SAFE_SIZE))
 
 
 def elapsed_ms(start_time: float | None) -> int:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -26,13 +26,14 @@ from mitmproxy.addonmanager import Loader
 
 # --- Sub-module imports ---
 #
-# auth_base_forwarder/body_capture/connector_diagnostics/connector_intent/matching/registry/
-# response_encoding_negotiation/response_streaming/runner_flush_lifecycle/terminal_usage/
-# upstream_admission/usage/websocket_retention are imported by module (not selective
+# auth_base_forwarder/body_capture/connector_diagnostics/connector_intent/content_length/
+# matching/registry/response_encoding_negotiation/response_streaming/runner_flush_lifecycle/
+# terminal_usage/upstream_admission/usage/websocket_retention are imported by module (not selective
 # `from X import ...`) so that:
 #   1. Cross-module calls read as ``auth_base_forwarder.X(...)`` /
 #      ``body_capture.X(...)`` / ``connector_diagnostics.X(...)`` /
 #      ``connector_intent.X(...)`` /
+#      ``content_length.X(...)`` /
 #      ``matching.X(...)`` / ``registry.X(...)`` / ``response_streaming.X(...)`` /
 #      ``runner_flush_lifecycle.X(...)`` / ``terminal_usage.X(...)`` /
 #      ``upstream_admission.X(...)`` / ``usage.X(...)`` /
@@ -47,6 +48,7 @@ import codex_model_catalog_cache
 import codex_output_timing
 import connector_diagnostics
 import connector_intent
+import content_length
 import flow_metadata
 import flow_metadata_keys as metadata_keys
 import http_local_responses
@@ -91,7 +93,6 @@ from firewall_auth_cache import (
 from firewall_auth_config import auth_config_injects_ordinary_upstream_credentials
 from logging_utils import (
     NETWORK_LOG_MAX_SAFE_SIZE,
-    NETWORK_LOG_MAX_SAFE_SIZE_DIGITS,
     add_firewall_metadata,
     elapsed_ms,
     log_network_entry,
@@ -452,8 +453,11 @@ def _auth_base_body_header_check(
             reason="transfer_encoding",
         )
 
-    raw_content_lengths = flow.request.headers.get_all("Content-Length")
-    if not raw_content_lengths:
+    parsed_content_length = content_length.parse(
+        flow.request.headers.get_all("Content-Length"),
+        max_value=auth_base_forwarder.MAX_AUTH_BASE_REQUEST_BODY_BYTES,
+    )
+    if parsed_content_length.kind == "missing":
         if flow.request.method.upper() not in _AUTH_BASE_BODYLESS_METHODS:
             return _BufferedRequestBodyCheck(
                 kind="length_required",
@@ -468,27 +472,22 @@ def _auth_base_body_header_check(
             return _BufferedRequestBodyCheck(kind="length_required", reason=reason)
         return _BufferedRequestBodyCheck(kind="ok")
 
-    parsed_length: int | None = None
-    for raw_content_length in raw_content_lengths:
-        for part in raw_content_length.split(","):
-            candidate = _parse_auth_base_content_length_part(part)
-            if candidate is None:
-                return _BufferedRequestBodyCheck(
-                    kind="length_required",
-                    reason="invalid_content_length",
-                )
-            if parsed_length is None:
-                parsed_length = candidate
-            elif parsed_length != candidate:
-                return _BufferedRequestBodyCheck(
-                    kind="length_required",
-                    reason="conflicting_content_length",
-                )
-
-    observed_size = parsed_length if parsed_length is not None else 0
-    if observed_size > auth_base_forwarder.MAX_AUTH_BASE_REQUEST_BODY_BYTES:
-        return _BufferedRequestBodyCheck(kind="too_large", observed_size=observed_size)
-    return _BufferedRequestBodyCheck(kind="ok", observed_size=observed_size)
+    if parsed_content_length.kind == "invalid":
+        return _BufferedRequestBodyCheck(
+            kind="length_required",
+            reason="invalid_content_length",
+        )
+    if parsed_content_length.kind == "conflicting":
+        return _BufferedRequestBodyCheck(
+            kind="length_required",
+            reason="conflicting_content_length",
+        )
+    if parsed_content_length.kind == "over_limit":
+        return _BufferedRequestBodyCheck(
+            kind="too_large",
+            observed_size=parsed_content_length.value,
+        )
+    return _BufferedRequestBodyCheck(kind="ok", observed_size=parsed_content_length.value)
 
 
 def _aws_sigv4_body_header_check(
@@ -502,8 +501,11 @@ def _aws_sigv4_body_header_check(
             reason="transfer_encoding",
         )
 
-    raw_content_lengths = flow.request.headers.get_all("Content-Length")
-    if not raw_content_lengths:
+    parsed_content_length = content_length.parse(
+        flow.request.headers.get_all("Content-Length"),
+        max_value=aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES,
+    )
+    if parsed_content_length.kind == "missing":
         if request_end_stream is True:
             return _BufferedRequestBodyCheck(kind="ok")
         reason = (
@@ -513,75 +515,36 @@ def _aws_sigv4_body_header_check(
         )
         return _BufferedRequestBodyCheck(kind="length_required", reason=reason)
 
-    parsed_length: int | None = None
-    for raw_content_length in raw_content_lengths:
-        for part in raw_content_length.split(","):
-            candidate = _parse_limited_content_length_part(
-                part,
-                max_value=aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES,
-            )
-            if candidate is None:
-                return _BufferedRequestBodyCheck(
-                    kind="length_required",
-                    reason="invalid_content_length",
-                )
-            if parsed_length is None:
-                parsed_length = candidate
-            elif parsed_length != candidate:
-                return _BufferedRequestBodyCheck(
-                    kind="length_required",
-                    reason="conflicting_content_length",
-                )
-
-    observed_size = parsed_length if parsed_length is not None else 0
-    if observed_size > aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES:
-        return _BufferedRequestBodyCheck(kind="too_large", observed_size=observed_size)
-    return _BufferedRequestBodyCheck(kind="ok", observed_size=observed_size)
-
-
-def _parse_auth_base_content_length_part(value: str) -> int | None:
-    return _parse_limited_content_length_part(
-        value,
-        max_value=auth_base_forwarder.MAX_AUTH_BASE_REQUEST_BODY_BYTES,
-    )
-
-
-def _parse_limited_content_length_part(value: str, *, max_value: int) -> int | None:
-    value = value.strip(" \t")
-    if not value:
-        return None
-    if not value.isascii() or not value.isdecimal():
-        return None
-    normalized = value.lstrip("0") or "0"
-    limit_text = str(max_value)
-    if len(normalized) > len(limit_text):
-        return max_value + 1
-    return int(normalized)
+    if parsed_content_length.kind == "invalid":
+        return _BufferedRequestBodyCheck(
+            kind="length_required",
+            reason="invalid_content_length",
+        )
+    if parsed_content_length.kind == "conflicting":
+        return _BufferedRequestBodyCheck(
+            kind="length_required",
+            reason="conflicting_content_length",
+        )
+    if parsed_content_length.kind == "over_limit":
+        return _BufferedRequestBodyCheck(
+            kind="too_large",
+            observed_size=parsed_content_length.value,
+        )
+    return _BufferedRequestBodyCheck(kind="ok", observed_size=parsed_content_length.value)
 
 
 def _request_body_fits_stream_buffer(flow: http.HTTPFlow) -> bool:
     if flow.request.headers.get_all("Transfer-Encoding"):
         return False
 
-    raw_content_lengths = flow.request.headers.get_all("Content-Length")
-    if not raw_content_lengths:
-        # requestheaders() does not expose mitmproxy's end_stream flag. Treat
-        # missing Content-Length as unknown length even for GET/HEAD because
-        # HTTP/2 can carry DATA frames after headers without a length header.
-        return False
-
-    parsed_length: int | None = None
-    for raw_content_length in raw_content_lengths:
-        for part in raw_content_length.split(","):
-            candidate = _parse_limited_content_length_part(part, max_value=STREAM_BUFFER_LIMIT)
-            if candidate is None:
-                return False
-            if parsed_length is None:
-                parsed_length = candidate
-            elif parsed_length != candidate:
-                return False
-
-    return (parsed_length or 0) <= STREAM_BUFFER_LIMIT
+    parsed_content_length = content_length.parse(
+        flow.request.headers.get_all("Content-Length"),
+        max_value=STREAM_BUFFER_LIMIT,
+    )
+    # requestheaders() does not expose mitmproxy's end_stream flag. Treat
+    # missing Content-Length as unknown length even for GET/HEAD because
+    # HTTP/2 can carry DATA frames after headers without a length header.
+    return parsed_content_length.kind == "valid"
 
 
 def _restore_request_headers_probe_metadata(
@@ -1416,7 +1379,13 @@ def _response_size(flow: http.HTTPFlow) -> int:
     if streamed_size is not None:
         return streamed_size
 
-    return _content_length_response_size(flow.response.headers.get("content-length"))
+    parsed_content_length = content_length.parse(
+        flow.response.headers.get_all("Content-Length"),
+        max_value=NETWORK_LOG_MAX_SAFE_SIZE,
+    )
+    if parsed_content_length.kind != "valid":
+        return 0
+    return parsed_content_length.value
 
 
 def _request_size(flow: http.HTTPFlow) -> int:
@@ -1424,56 +1393,6 @@ def _request_size(flow: http.HTTPFlow) -> int:
     if streamed_size is not None:
         return streamed_size
     return len(flow.request.raw_content or b"")
-
-
-def _content_length_response_size(content_length: str | None) -> int:
-    if content_length is None:
-        return 0
-
-    response_size: int | None = None
-    start = 0
-    while True:
-        comma = content_length.find(",", start)
-        end = len(content_length) if comma == -1 else comma
-        parsed_size = _single_content_length_response_size(content_length, start, end)
-        if parsed_size is None:
-            return 0
-        if response_size is None:
-            response_size = parsed_size
-        elif response_size != parsed_size:
-            return 0
-        if comma == -1:
-            break
-        start = comma + 1
-
-    return response_size if response_size is not None else 0
-
-
-def _single_content_length_response_size(content_length: str, start: int, end: int) -> int | None:
-    while start < end and content_length[start] in (" ", "\t"):
-        start += 1
-    while end > start and content_length[end - 1] in (" ", "\t"):
-        end -= 1
-    if start == end:
-        return None
-
-    while start < end and content_length[start] == "0":
-        start += 1
-    if start == end:
-        return 0
-
-    significant_start = start
-    if end - significant_start > NETWORK_LOG_MAX_SAFE_SIZE_DIGITS:
-        return None
-    for index in range(significant_start, end):
-        char = content_length[index]
-        if char < "0" or char > "9":
-            return None
-
-    response_size = int(content_length[significant_start:end])
-    if response_size > NETWORK_LOG_MAX_SAFE_SIZE:
-        return None
-    return response_size
 
 
 def _release_terminal_flow_state(

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
@@ -61,6 +61,27 @@ async def test_unbounded_request_content_length_is_rejected_without_parsing(real
     assert flow.request.headers["Accept-Encoding"] == "identity"
 
 
+@pytest.mark.parametrize("content_length", ["\v0", "\f0"], ids=["vertical-tab", "form-feed"])
+async def test_non_ows_request_content_length_bypasses_catalog_cache(
+    real_flow,
+    content_length: str,
+):
+    flow = catalog_flow(
+        real_flow,
+        extra_headers={"Content-Length": content_length},
+    )
+
+    await catalog_cache.prepare_request(flow, request_end_stream=True)
+
+    telemetry: dict[str, object] = {}
+    catalog_cache.add_network_log_fields(flow, telemetry)
+    assert telemetry == {
+        "model_catalog_cache_status": "model_catalog_bypass",
+        "model_catalog_cache_bypass_reason": "request_framing",
+    }
+    assert flow.request.headers["Accept-Encoding"] == "identity"
+
+
 @pytest.mark.parametrize(
     ("method", "request_end_stream", "body", "remove_account", "original_url", "reason"),
     [

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_responses.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_responses.py
@@ -377,6 +377,23 @@ async def test_catalog_responses_with_trailers_are_never_cached(
     catalog_cache.handle_error(retry)
 
 
+async def test_catalog_response_accepts_long_leading_zero_content_length(real_flow):
+    flow = catalog_flow(real_flow, version="leading-zero-content-length")
+    await prepare_miss(flow)
+    flow.response = catalog_response(
+        headers={"Content-Length": "0" * 64 + str(len(CATALOG_BODY))},
+    )
+
+    telemetry = finish_response(flow)
+
+    assert telemetry["model_catalog_cache_status"] == "model_catalog_cold_stored"
+
+    hit = catalog_flow(real_flow, version="leading-zero-content-length")
+    await catalog_cache.prepare_request(hit, request_end_stream=True)
+    assert hit.response is not None
+    assert hit.response.content == CATALOG_BODY
+
+
 @pytest.mark.parametrize(
     ("encoding", "headers", "reason", "expected_encoding"),
     [
@@ -400,6 +417,13 @@ async def test_catalog_responses_with_trailers_are_never_cached(
             "response_size",
             "br",
             id="unbounded-length-integer",
+        ),
+        pytest.param(
+            "br",
+            {"Content-Length": "\v0"},
+            "response_size",
+            "br",
+            id="non-ows-content-length",
         ),
         pytest.param(
             "br",

--- a/crates/runner/mitm-addon/tests/test_content_length.py
+++ b/crates/runner/mitm-addon/tests/test_content_length.py
@@ -1,0 +1,92 @@
+"""Protocol contract for shared Content-Length field parsing."""
+
+import pytest
+from mitmproxy import http
+
+import content_length
+
+_MAX_VALUE = 1000
+
+
+def _header_values(*values: str) -> list[str]:
+    headers = http.Headers([(b"content-length", value.encode("latin-1")) for value in values])
+    return headers.get_all("Content-Length")
+
+
+def test_missing_content_length():
+    assert content_length.parse([], max_value=_MAX_VALUE) == content_length.ContentLengthResult(
+        "missing"
+    )
+
+
+@pytest.mark.parametrize(
+    ("values", "expected_value"),
+    [
+        pytest.param(["42"], 42, id="plain"),
+        pytest.param([" \t42\t "], 42, id="http-optional-whitespace"),
+        pytest.param(["00000000000042"], 42, id="leading-zeros"),
+        pytest.param(["0" * 5000], 0, id="long-zero"),
+        pytest.param(["42, 042"], 42, id="matching-comma-list"),
+        pytest.param(["1000"], 1000, id="exact-limit"),
+    ],
+)
+def test_valid_content_length(values: list[str], expected_value: int):
+    assert content_length.parse(values, max_value=_MAX_VALUE) == (
+        content_length.ContentLengthResult("valid", expected_value)
+    )
+
+
+def test_matching_repeated_content_length_fields():
+    assert content_length.parse(
+        _header_values("00042", "42"),
+        max_value=_MAX_VALUE,
+    ) == content_length.ContentLengthResult("valid", 42)
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param([""], id="empty"),
+        pytest.param(["42,"], id="trailing-empty-part"),
+        pytest.param([",42"], id="leading-empty-part"),
+        pytest.param(["42,,42"], id="interior-empty-part"),
+        pytest.param(["+42"], id="positive-sign"),
+        pytest.param(["-42"], id="negative-sign"),
+        pytest.param(["\u0664\u0662"], id="unicode-digits"),
+        pytest.param(["\v42"], id="vertical-tab"),
+        pytest.param(["\f42"], id="form-feed"),
+    ],
+)
+def test_invalid_content_length(values: list[str]):
+    assert content_length.parse(values, max_value=_MAX_VALUE) == (
+        content_length.ContentLengthResult("invalid")
+    )
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param(["42, 43"], id="comma-list"),
+        pytest.param(_header_values("42", "43"), id="repeated-fields"),
+        pytest.param(["9" * 5000, "8" * 5000], id="distinct-huge-values"),
+    ],
+)
+def test_conflicting_content_length(values: list[str]):
+    assert content_length.parse(values, max_value=_MAX_VALUE) == (
+        content_length.ContentLengthResult("conflicting")
+    )
+
+
+@pytest.mark.parametrize(
+    ("values", "expected_value"),
+    [
+        pytest.param(["1001"], 1001, id="convertible"),
+        pytest.param(["10000"], 1001, id="bounded-payload"),
+        pytest.param(["9" * 5000], 1001, id="very-long"),
+        pytest.param(["9" * 5000, "9" * 5000], 1001, id="matching-huge-values"),
+    ],
+)
+def test_over_limit_content_length(values: list[str], expected_value: int):
+    assert content_length.parse(values, max_value=_MAX_VALUE) == (
+        content_length.ContentLengthResult("over_limit", expected_value)
+    )

--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
@@ -363,6 +363,14 @@ async def test_payload_dependent_sigv4_holds_admission_until_websocket_end(
             auth.AWS_SIGV4_REQUEST_BODY_TOO_LARGE_ERROR,
         ),
         (
+            [("Content-Length", "not-a-number")],
+            auth.AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR,
+        ),
+        (
+            [("Content-Length", "4"), ("Content-Length", "5")],
+            auth.AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR,
+        ),
+        (
             [("Transfer-Encoding", "chunked")],
             auth.AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR,
         ),
@@ -371,7 +379,7 @@ async def test_payload_dependent_sigv4_holds_admission_until_websocket_end(
             auth.AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR,
         ),
     ],
-    ids=["oversized", "chunked", "indeterminate"],
+    ids=["oversized", "invalid", "conflicting", "chunked", "indeterminate"],
 )
 def test_payload_dependent_sigv4_rejects_unbounded_framing_before_auth(
     tmp_path,

--- a/crates/runner/mitm-addon/tests/test_response_handler_logging.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_logging.py
@@ -728,10 +728,6 @@ async def test_early_response_makes_late_request_hook_noop(tmp_path, real_flow, 
     ("content_length", "expected_size"),
     [
         pytest.param("50000", 50000, id="plain"),
-        pytest.param(" 50000\t", 50000, id="optional-whitespace"),
-        pytest.param("10, 10", 10, id="joined-consistent"),
-        pytest.param("00042, 42", 42, id="joined-leading-zero-consistent"),
-        pytest.param("0" * 32 + "42", 42, id="leading-zero-safe-integer"),
     ],
 )
 def test_response_size_uses_content_length_without_stream_state(
@@ -819,24 +815,8 @@ def test_response_size_is_zero_without_stream_state_or_content_length(
 @pytest.mark.parametrize(
     "content_length",
     [
-        pytest.param("", id="empty"),
-        pytest.param(" ", id="space"),
-        pytest.param("\t", id="tab"),
         pytest.param("not-an-int", id="malformed"),
-        pytest.param("-1", id="negative"),
-        pytest.param("+1", id="signed"),
-        pytest.param("1.5", id="fractional"),
-        pytest.param("1e3", id="exponential"),
-        pytest.param("1, 2", id="joined-conflicting"),
-        pytest.param("1,", id="joined-trailing-empty"),
-        pytest.param(",1", id="joined-leading-empty"),
-        pytest.param("10,,10", id="joined-empty-part"),
-        pytest.param("10, abc", id="joined-invalid"),
-        pytest.param("\u0661\u0662", id="unicode-digits"),
         pytest.param("9007199254740992", id="above-max-safe-integer"),
-        pytest.param("0" * 32 + str(1 << 53), id="leading-zero-above-max-safe-integer"),
-        pytest.param("1" * 257, id="too-many-safe-digits"),
-        pytest.param("9" * 4301, id="too-many-digits"),
     ],
 )
 def test_response_size_is_zero_for_invalid_content_length(

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -104,6 +104,7 @@ tests must not resolve a different mitmproxy version from production.
 | `test_addon_configuration.py`                           | Addon option registration and configuration updates                                                                  |
 | `test_builtin_host_policy_contract.py`                  | Cross-stage malformed built-in host policy contracts                                                                 |
 | `test_connection_endpoints.py`                          | Connection endpoint shape validation and IPv6 tuple normalization                                                    |
+| `test_content_length.py`                                | Shared bounded Content-Length field parsing contract                                                                 |
 | `codex_model_catalog_cache_helpers.py`                  | Shared Codex catalog flow, response, and cache lifecycle test builders                                               |
 | `test_codex_model_catalog_cache_coordination.py`        | Codex catalog prefetch, single-flight, wait, cancellation, and active-request capacity behavior                      |
 | `test_codex_model_catalog_cache_hooks.py`               | Codex catalog request admission, firewall hook integration, telemetry, and cleanup                                   |


### PR DESCRIPTION
## Summary

- add one typed, bounded parser for repeated and comma-joined `Content-Length` values
- migrate auth.base, AWS SigV4, request buffering, Codex catalog caching, and response-size logging to the shared contract
- reject non-OWS catalog framing, accept safely normalized leading-zero values, and centralize protocol test coverage

## Scope

- preserves each consumer's Transfer-Encoding, end-stream, size-limit, error, cache, admission, and fallback policy
- leaves capture-log header redaction unchanged
- no schema, persisted data, API, queue, runner protocol, dependency, configuration, migration, or feature-switch changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4601 passed)

Closes #24747
