### PR TITLE
test(runner): assert drain reader acknowledgement

### DIFF
--- a/crates/runner/src/network_log_drain.rs
+++ b/crates/runner/src/network_log_drain.rs
@@ -495,10 +495,11 @@ mod tests {
 
         writer.write_all(b"first\n").await.unwrap();
 
-        producer
+        let outcome = producer
             .drain(drain_context(path), Duration::from_secs(1))
             .await;
 
+        assert_eq!(outcome, NetworkLogDrainOutcome::Acknowledged);
         assert_eq!(handled.lock().unwrap().as_slice(), ["first"]);
 
         cancel.cancel();


### PR DESCRIPTION
## Summary

- capture the drain result in the real duplex-backed line-reader test
- require the ready-line barrier to complete with `NetworkLogDrainOutcome::Acknowledged`
- preserve the handled-line ordering assertion and bounded reader cleanup

## Scope

This changes test coverage only. It does not modify production behavior, timeouts, protocols, persistence, or consumer-specific DNS and kernel-log tests.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner network_log_drain::tests::drainable_line_reader_processes_ready_line_before_ack -- --exact`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`

Closes #24749
