### PR TITLE
test(api): stabilize multi-step chat timeouts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-chat.test.ts
@@ -564,5 +564,5 @@ describe("GitHub canonical chat threads", () => {
         subjectNumber,
       }),
     ]);
-  });
+  }, 30_000);
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-controls.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-controls.test.ts
@@ -388,7 +388,7 @@ describe("workflow automation queue controls", () => {
     expect(runIds).toHaveLength(2);
     await completeRunThroughSandbox(scenario, runIds[1]!);
     await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(2);
-  });
+  }, 30_000);
 
   it("queues manual Run now behind the active run and existing backlog", async () => {
     const scenario = await setup();


### PR DESCRIPTION
## Summary

- give the two multi-stage chat integration scenarios a 30-second per-test timeout
- keep the 5-second default for the rest of the API test suite

## Root cause

The failing API shard was under transient contention: aggregate test time rose from 78.70 seconds in a successful run to 129.89 seconds in the failed run. A neighboring GitHub chat scenario that already has a 30-second budget rose from 2.607 seconds to 9.422 seconds, while both affected scenarios hit the default timeout at almost exactly 5 seconds. Logs show their workflows were still making progress rather than deadlocking.

Failed job: https://github.com/vm0-ai/vm0/actions/runs/30801878005/job/91648267342

## Validation

- Prettier check for both changed files
- API lint
- API type check
- API-scoped and full Knip
- CI-equivalent API shard 3 with coverage: 23 files and 400 tests passed
- Lefthook pre-commit and commit message checks