### PR TITLE
fix(mitm-addon): reject truncated auth.base responses

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -720,6 +720,9 @@ def _read_response_body(resp) -> bytes:
     body = resp.read(MAX_AUTH_BASE_RESPONSE_BODY_BYTES + 1)
     if len(body) > MAX_AUTH_BASE_RESPONSE_BODY_BYTES:
         raise ForwardedResponseTooLargeError("Forwarded auth.base response body too large")
+    remaining = resp.length
+    if remaining is not None and remaining > 0:
+        raise http_client.IncompleteRead(body, remaining)
     return body
 
 

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder_protocol.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder_protocol.py
@@ -269,6 +269,24 @@ class TestAuthBaseForwarderResponseBodyLimit:
         assert upstream.socket.response_file is not None
         assert upstream.socket.response_file.read_sizes == [5]
 
+    async def test_accepts_complete_fixed_length_body_at_limit(self):
+        with (
+            patch.object(forwarder, "MAX_AUTH_BASE_RESPONSE_BODY_BYTES", 4),
+            fake_forwarder_upstream(
+                body=b"1234",
+                headers=[("Content-Length", "4")],
+            ),
+        ):
+            status, body, _headers = await forwarder.forward_request(
+                "https://example.com",
+                "GET",
+                [],
+                None,
+            )
+
+        assert status == 200
+        assert body == b"1234"
+
     async def test_rejects_body_over_limit_and_closes_resources(self):
         with (
             patch.object(forwarder, "MAX_AUTH_BASE_RESPONSE_BODY_BYTES", 4),
@@ -281,6 +299,47 @@ class TestAuthBaseForwarderResponseBodyLimit:
         assert upstream.socket.response_file.read_sizes == [5]
         assert upstream.socket.response_file.closed
         assert upstream.socket.closed
+
+    async def test_rejects_truncated_fixed_length_body_and_closes_resources(self):
+        with (
+            patch.object(forwarder, "MAX_AUTH_BASE_RESPONSE_BODY_BYTES", 4),
+            fake_forwarder_upstream(
+                body=b"123",
+                headers=[("Content-Length", "4")],
+            ) as upstream,
+            pytest.raises(http_client.IncompleteRead) as exc_info,
+        ):
+            await forwarder.forward_request("https://example.com", "GET", [], None)
+
+        assert exc_info.value.partial == b"123"
+        assert exc_info.value.expected == 1
+        assert upstream.socket.response_file is not None
+        assert upstream.socket.response_file.closed
+        assert upstream.socket.closed
+
+    @pytest.mark.parametrize(
+        ("method", "status"),
+        [
+            pytest.param("HEAD", 200, id="head"),
+            pytest.param("GET", 204, id="no-content"),
+            pytest.param("GET", 304, id="not-modified"),
+        ],
+    )
+    async def test_accepts_no_body_semantics_with_content_length(self, method: str, status: int):
+        with fake_forwarder_upstream(
+            status=status,
+            body=b"",
+            headers=[("Content-Length", "4")],
+        ):
+            response_status, body, _headers = await forwarder.forward_request(
+                "https://example.com",
+                method,
+                [],
+                None,
+            )
+
+        assert response_status == status
+        assert body == b""
 
 
 class TestAuthBaseForwarderRequestBodyLimit:

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
@@ -165,6 +165,78 @@ class TestAuthBaseUrlRewriteSafety:
         assert "super-secret-token" not in log_text
         assert "real-token" not in log_text
 
+    async def test_truncated_upstream_response_returns_502_without_partial_body(
+        self, headers, real_flow, mitm_ctx, tmp_path
+    ):
+        partial_body = b'{"secret":"partial-upstream-secret"}'
+        flow, allow, vm_info, token_meta = make_safety_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            path="/hook?client=visible",
+            request_headers=headers(
+                ("Host", "firewall-placeholder.vm3.ai"),
+                ("Authorization", "Bearer agent"),
+            ),
+            resolved_base="https://real.example.com/webhook/super-secret-token",
+            token_overrides={
+                "headers": {
+                    "Authorization": "Bearer real-token",
+                    "X-Custom": "injected-value",
+                },
+                "query": {"api_key": "resolved-key"},
+                "resolved_secrets": ["WEBHOOK", "API_KEY"],
+                "refreshed_connectors": ["discord"],
+                "refreshed_secrets": ["WEBHOOK"],
+                "cache_hit": False,
+            },
+        )
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
+
+        with (
+            fake_forwarder_upstream(
+                body=partial_body,
+                headers=[("Content-Length", str(len(partial_body) + 5))],
+            ) as upstream,
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+        assert upstream.socket.response_file is not None
+        assert upstream.socket.response_file.closed
+        assert upstream.socket.closed
+
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        response_body = json.loads(flow.response.content)
+        assert response_body["error"] == "url_rewrite_forward_failed"
+        assert response_body["message"] == "Failed to forward request to upstream"
+        assert partial_body not in flow.response.content
+
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "url_rewrite_forward_failed"
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
+        assert metadata_keys.AUTH_RESOLVED_SECRETS not in flow.metadata
+        assert metadata_keys.AUTH_REFRESHED_CONNECTORS not in flow.metadata
+        assert metadata_keys.AUTH_REFRESHED_SECRETS not in flow.metadata
+        assert metadata_keys.AUTH_CACHE_HIT not in flow.metadata
+
+        assert flow.request.headers["Authorization"] == "Bearer agent"
+        assert flow.request.path == "/hook?client=visible"
+        assert "X-Custom" not in flow.request.headers
+        assert "api_key" not in flow.request.query
+        assert flow.request.query["client"] == "visible"
+
+        log_text = await asyncio.to_thread(read_jsonl_text_after_flush, proxy_log_path)
+        assert "URL rewrite forward failed" in log_text
+        assert "IncompleteRead" in log_text
+        assert "Firewall URL rewrite:" not in log_text
+        assert "partial-upstream-secret" not in log_text
+        assert "super-secret-token" not in log_text
+        assert "real-token" not in log_text
+
     async def test_resolved_base_http_fails_closed_without_forwarding(
         self, headers, real_flow, mitm_ctx, tmp_path
     ):


### PR DESCRIPTION
## Summary

- reject fixed-length auth.base responses that reach EOF before their declared `Content-Length`
- preserve the existing bounded-read cap, over-limit error precedence, and valid close-delimited, chunked, and no-body semantics
- cover the real HTTP parser and observable firewall handler failure path so partial upstream bytes cannot appear as a successful sandbox response

## Scope

This keeps the existing `url_rewrite_forward_failed` 502 contract. It does not add a new public error code, change the response-size limit, precheck upstream declarations, or redesign the auth.base transport.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_auth_base_forwarder_protocol.py tests/test_firewall_rewrite_safety.py` (57 passed)
- `uv run --no-sync python -m pytest tests/` (4599 passed)

Closes #24750
