### PR TITLE
fix(mitm-addon): revalidate admission after catalog waits

### DIFF
--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -491,21 +491,21 @@ def capture_and_strip_prefetch_marker(flow: http.HTTPFlow) -> None:
         flow.metadata[_PREFETCH_REQUEST] = True
 
 
-async def prepare_request(flow: http.HTTPFlow, *, request_end_stream: bool) -> None:
-    """Serve or prepare one exact authenticated Codex catalog request."""
+async def prepare_request(flow: http.HTTPFlow, *, request_end_stream: bool) -> bool:
+    """Serve or prepare a catalog request and report whether it waited for an owner."""
     if _FLOW_STATE in flow.metadata or _FLOW_TELEMETRY in flow.metadata:
-        return
+        return False
     if flow_metadata.firewall_name(flow.metadata) != _FIREWALL_NAME:
-        return
+        return False
 
     original_url = flow_metadata.original_url(flow.metadata)
     if not _is_catalog_path(original_url):
-        return
+        return False
 
     canonical_url = _catalog_url(original_url)
     if canonical_url is None:
         _set_telemetry(flow, "model_catalog_bypass", bypass_reason="request_url")
-        return
+        return False
 
     bypass_reason = _request_bypass_reason(
         flow,
@@ -513,12 +513,12 @@ async def prepare_request(flow: http.HTTPFlow, *, request_end_stream: bool) -> N
     )
     if bypass_reason is not None:
         _set_telemetry(flow, "model_catalog_bypass", bypass_reason=bypass_reason)
-        return
+        return False
 
     credential_digest = _credential_digest(flow)
     if credential_digest is None:
         _set_telemetry(flow, "model_catalog_bypass", bypass_reason="request_identity")
-        return
+        return False
 
     key = _CacheKey(canonical_url, credential_digest)
     is_prefetch = flow.metadata.get(_PREFETCH_REQUEST) is True
@@ -540,7 +540,7 @@ async def prepare_request(flow: http.HTTPFlow, *, request_end_stream: bool) -> N
                         "completed_consumer" if entry.prefetched and not is_prefetch else None
                     ),
                 )
-                return
+                return wait_deadline is not None
             _remove_entry(key)
         else:
             entry_age_ms = None
@@ -554,7 +554,7 @@ async def prepare_request(flow: http.HTTPFlow, *, request_end_stream: bool) -> N
                     bypass_reason="request_capacity",
                     entry_age_ms=entry_age_ms,
                 )
-                return
+                return wait_deadline is not None
             if wait_deadline is None:
                 wait_deadline = now + MAX_IN_FLIGHT_WAIT_SECONDS
             remaining_wait_seconds = wait_deadline - now
@@ -565,7 +565,7 @@ async def prepare_request(flow: http.HTTPFlow, *, request_end_stream: bool) -> N
                     bypass_reason="request_capacity",
                     entry_age_ms=entry_age_ms,
                 )
-                return
+                return True
             joined_prefetch = in_flight.prefetch_owner and not is_prefetch
             in_flight.waiters += 1
             try:
@@ -580,7 +580,7 @@ async def prepare_request(flow: http.HTTPFlow, *, request_end_stream: bool) -> N
                     bypass_reason="request_capacity",
                     entry_age_ms=entry_age_ms,
                 )
-                return
+                return True
             finally:
                 in_flight.waiters -= 1
             if completed_entry is None:
@@ -597,7 +597,7 @@ async def prepare_request(flow: http.HTTPFlow, *, request_end_stream: bool) -> N
                 entry_age_ms=_age_milliseconds(completed_entry, completed_at),
                 prefetch_role="inflight_consumer" if joined_prefetch else None,
             )
-            return
+            return True
 
         if not _reserve_flow_capacity():
             _set_telemetry(
@@ -606,7 +606,7 @@ async def prepare_request(flow: http.HTTPFlow, *, request_end_stream: bool) -> N
                 bypass_reason="request_capacity",
                 entry_age_ms=entry_age_ms,
             )
-            return
+            return wait_deadline is not None
         in_flight = _InFlight(
             future=asyncio.get_running_loop().create_future(),
             prefetch_owner=is_prefetch,
@@ -621,7 +621,7 @@ async def prepare_request(flow: http.HTTPFlow, *, request_end_stream: bool) -> N
         )
         flow.metadata[_FLOW_STATE] = state
         flow.request.headers["Accept-Encoding"] = _BROTLI_ENCODING
-        return
+        return wait_deadline is not None
 
 
 def _response_headers_bypass_reason(

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1036,8 +1036,11 @@ async def _try_firewall_request_stream_from_headers(
     try:
         request_classification.cache_classification(flow, classification)
         flow.metadata[_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS] = True
-        await codex_model_catalog_cache.prepare_request(
+        await _prepare_codex_catalog_request_with_upstream_revalidation(
             flow,
+            allow,
+            admitted_server=admitted_server,
+            require_connected=require_connected,
             request_end_stream=request_end_stream is True,
         )
         if flow.response is None:
@@ -1109,6 +1112,32 @@ def _revalidate_ordinary_upstream_credentials_for_request(
         return False
 
     return True
+
+
+async def _prepare_codex_catalog_request_with_upstream_revalidation(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+    *,
+    admitted_server: connection.Server,
+    require_connected: bool,
+    request_end_stream: bool,
+) -> None:
+    """Prepare a local catalog response or revalidate provider continuation."""
+    waited_for_in_flight = await codex_model_catalog_cache.prepare_request(
+        flow,
+        request_end_stream=request_end_stream,
+    )
+    if (
+        waited_for_in_flight
+        and flow.response is None
+        and _firewall_allow_injects_ordinary_upstream_credentials(allow)
+    ):
+        _revalidate_ordinary_upstream_credentials_for_request(
+            flow,
+            allow,
+            admitted_server=admitted_server,
+            require_connected=require_connected,
+        )
 
 
 def _unhandled_request_classification(classification: NoReturn) -> NoReturn:
@@ -1267,8 +1296,11 @@ async def request(flow: http.HTTPFlow) -> None:
                 auth_base_forwarder.release_forward_request_admission_from_flow(flow)
                 terminal_usage.release_tracked_flow(flow)
             elif auth_result is FirewallAuthHandlingResult.CONTINUE_UPSTREAM:
-                await codex_model_catalog_cache.prepare_request(
+                await _prepare_codex_catalog_request_with_upstream_revalidation(
                     flow,
+                    allow,
+                    admitted_server=admitted_server,
+                    require_connected=require_connected,
                     request_end_stream=True,
                 )
             return

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
@@ -3,13 +3,18 @@
 import asyncio
 import json
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Literal
 
 import pytest
+from mitmproxy import connection
+from mitmproxy.flow import Error
 
 import codex_model_catalog_cache as catalog_cache
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import request_classification
+import upstream_destination_binding
 import usage
 from tests.codex_model_catalog_cache_helpers import (
     CATALOG_BODY,
@@ -24,6 +29,7 @@ from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.pending_helpers import assert_pending
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 from tests.requestheaders_helpers import await_requestheaders_result
+from tests.upstream_connection_helpers import mark_connected_tls_upstream
 
 
 async def test_request_bypasses_do_not_touch_unrelated_traffic(real_flow):
@@ -217,6 +223,131 @@ async def test_both_firewall_auth_paths_prepare_catalog_cache(
     assert header_flow.response.content == CATALOG_BODY
     assert header_flow.response.stream is False
     assert "X-VM0-Codex-Model-Catalog-Prefetch" not in header_flow.request.headers
+
+
+@pytest.mark.parametrize("entry_point", ["request", "requestheaders"])
+@pytest.mark.parametrize("owner_result", ["failure", "timeout", "local-response"])
+async def test_catalog_wait_revalidates_only_provider_continuation(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    monkeypatch: pytest.MonkeyPatch,
+    entry_point: Literal["request", "requestheaders"],
+    owner_result: Literal["failure", "timeout", "local-response"],
+):
+    if owner_result == "timeout":
+        monkeypatch.setattr(catalog_cache, "MAX_IN_FLIGHT_WAIT_SECONDS", 0.1)
+
+    resolved_headers = {
+        "Authorization": "Bearer resolved-token",
+        "ChatGPT-Account-ID": "resolved-account",
+    }
+    owner = catalog_flow(
+        real_flow,
+        auth_value="resolved-token",
+        account="resolved-account",
+    )
+    await prepare_miss(owner)
+
+    registry_path = _write_codex_registry(
+        tmp_path,
+        capture=entry_point == "requestheaders",
+        billable=True,
+    )
+    follower_headers = {
+        "Host": "chatgpt.com",
+        "Accept-Encoding": "identity",
+    }
+    if entry_point == "request":
+        follower_headers["Content-Length"] = "0"
+    follower = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="chatgpt.com",
+        method="GET",
+        path="/backend-api/codex/models?client_version=0.145.0",
+        request_headers=header_map(follower_headers),
+    )
+    follower.metadata["_vm0_request_end_stream"] = True
+    mark_connected_tls_upstream(
+        follower,
+        sni="chatgpt.com",
+        server_address=("203.0.113.10", 443),
+        peername=("203.0.113.10", 443),
+    )
+
+    follower_task: asyncio.Task[None] | None = None
+    try:
+        with (
+            mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers(headers=resolved_headers),
+        ):
+            if entry_point == "request":
+                follower_task = asyncio.create_task(mitm_addon.request(follower))
+            else:
+                follower_task = asyncio.create_task(
+                    await_requestheaders_result(mitm_addon.requestheaders(follower))
+                )
+
+            await asyncio.sleep(0)
+            assert not follower_task.done()
+            assert follower.request.headers["Authorization"] == "Bearer resolved-token"
+            assert follower.request.headers["ChatGPT-Account-ID"] == "resolved-account"
+            assert follower.metadata["_usage_flow_tracked"] is True
+            assert (
+                follower.server_conn.id in upstream_destination_binding.binding_snapshot_for_tests()
+            )
+
+            follower.server_conn.state = connection.ConnectionState.CLOSED
+            mitm_addon.server_disconnected(SimpleNamespace(server=follower.server_conn))
+            assert (
+                follower.server_conn.id
+                not in upstream_destination_binding.binding_snapshot_for_tests()
+            )
+
+            if owner_result == "failure":
+                owner.error = Error("upstream reset")
+                catalog_cache.handle_error(owner)
+            elif owner_result == "local-response":
+                owner.response = catalog_response(encoding="br")
+                finish_response(owner)
+
+            await follower_task
+            if entry_point == "requestheaders":
+                await mitm_addon.request(follower)
+
+            assert follower.response is not None
+            if owner_result != "local-response":
+                assert follower.response.status_code == 403
+                assert (
+                    follower.metadata[metadata_keys.FIREWALL_ERROR]
+                    == "upstream_destination_unbound"
+                )
+                assert metadata_keys.REQUEST_STREAM_BUFFER not in follower.metadata
+                assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in follower.metadata
+            else:
+                assert follower.response.status_code == 200
+                assert follower.response.content == CATALOG_BODY
+                assert follower.metadata.get(metadata_keys.FIREWALL_ERROR) is None
+
+            mitm_addon.responseheaders(follower)
+            mitm_addon.response(follower)
+    finally:
+        if follower_task is not None:
+            if not follower_task.done():
+                follower_task.cancel()
+            _ = await asyncio.gather(follower_task, return_exceptions=True)
+        catalog_cache.handle_error(owner)
+        if follower.metadata.get("_usage_flow_tracked"):
+            mitm_addon.response(follower)
+
+    assert "_usage_flow_tracked" not in follower.metadata
+    assert "_codex_model_catalog_cache_state" not in follower.metadata
+    assert "_codex_model_catalog_cache_telemetry" not in follower.metadata
+    assert mitm_addon._FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS not in follower.metadata
+    assert metadata_keys.REQUEST_STREAM_BUFFER not in follower.metadata
+    assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in follower.metadata
 
 
 async def test_cancelled_requestheaders_catalog_follower_releases_usage_tracking(


### PR DESCRIPTION
## Summary

- report when Codex catalog preparation actually waited for an in-flight owner
- revalidate the original upstream admission only when that wait still leads to provider continuation
- cover normal and stream-safe auth paths across owner failure, timeout, and local-response outcomes

## Scope

This changes only the runner MITM addon's internal catalog/auth orchestration. Local catalog responses remain usable after a disconnect, and non-catalog, fresh-hit, initial-owner, and pre-join bypass paths retain their existing policy work. There are no API, protocol, migration, persisted-state, registry-schema, guest-interface, documentation, or rollout changes.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_codex_model_catalog_cache_hooks.py -k catalog_wait_revalidates_only_provider_continuation` (6 passed)
- `uv run --no-sync python -m pytest -q tests/test_request_handler_connector_admission.py tests/test_request_headers_connector_admission.py tests/test_request_handler_public_destination.py tests/test_request_handler_usage_tracking.py` (134 passed)
- `uv run --no-sync python -m pytest -q tests/` (4599 passed)

Closes #24751
