### PR TITLE
test(api): isolate usage rollup fixture from cron

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-runs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-runs.test.ts
@@ -789,6 +789,9 @@ describe("GET /api/zero/usage/runs", () => {
       throw new Error("Expected an org-scoped actor");
     }
     const firstRunAt = new Date(nowDate());
+    // Keep these rows outside the wall-clock compaction window used by
+    // parallel cron tests until this test explicitly materializes them.
+    firstRunAt.setUTCDate(firstRunAt.getUTCDate() + 1);
     firstRunAt.setUTCHours(8, 0, 0, 0);
     mockNow(firstRunAt);
     await postUsageAllowanceInvoicePaid(context.signal, {


### PR DESCRIPTION
## Summary

- keep the mixed raw/hourly usage fixture outside the wall-clock compaction cutoff
- prevent parallel compaction cron tests from materializing its raw events first
- preserve the existing explicit raw-to-hourly transition assertions

## Root cause

The test pinned its first processed events to 08:00 UTC on the current day. After 10:00 UTC those events are older than the production compaction cutoff, so a parallel global compaction test can move them to hourly storage before the test calls its explicit materialization helper. The helper then correctly returns 0 instead of the expected 2.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-runs.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-runs.test.ts src/signals/routes/__tests__/cron-compact-usage-events.test.ts --maxWorkers=2 --sequence.shuffle`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit hooks