### PR TITLE
refactor(db): finalize run event sequence contraction

### DIFF
--- a/turbo/packages/db/scripts/compare-schemas-normalized.ts
+++ b/turbo/packages/db/scripts/compare-schemas-normalized.ts
@@ -32,16 +32,6 @@ interface ConstraintInfo {
   constraint_def: string;
 }
 
-// PR 2 of the run-event sequence column rollout declares the canonical column
-// and index in Drizzle while the legacy objects remain for the draining
-// predecessor and rollback target. Remove these allowlists in PR 3.
-const TRANSITIONAL_RUN_EVENT_SEQUENCE_COLUMNS = new Set([
-  "chat_events.sequence_number",
-]);
-const TRANSITIONAL_RUN_EVENT_SEQUENCE_INDEXES = new Set([
-  "chat_events_run_seq_unique",
-]);
-
 // Get database URLs from command line args
 const db1Url = process.argv[2];
 const db2Url = process.argv[3];
@@ -70,11 +60,7 @@ async function getTableColumns(client: Client): Promise<TableColumn[]> {
       AND t.table_type = 'BASE TABLE'
     ORDER BY c.table_name, c.column_name
   `);
-  return result.rows.filter((column) => {
-    return !TRANSITIONAL_RUN_EVENT_SEQUENCE_COLUMNS.has(
-      `${column.table_name}.${column.column_name}`,
-    );
-  });
+  return result.rows;
 }
 
 async function getIndexes(client: Client): Promise<IndexInfo[]> {
@@ -87,9 +73,7 @@ async function getIndexes(client: Client): Promise<IndexInfo[]> {
     WHERE schemaname = 'public'
     ORDER BY tablename, indexname
   `);
-  return result.rows.filter((index) => {
-    return !TRANSITIONAL_RUN_EVENT_SEQUENCE_INDEXES.has(index.index_name);
-  });
+  return result.rows;
 }
 
 async function getConstraints(client: Client): Promise<ConstraintInfo[]> {

--- a/turbo/packages/db/scripts/test-migration-consistency-schema.ts
+++ b/turbo/packages/db/scripts/test-migration-consistency-schema.ts
@@ -17818,6 +17818,7 @@ async function validateRunnerSandboxStatePersistence(): Promise<void> {
 
 const RUN_EVENT_SEQUENCE_NUMBER_PREVIOUS_MIGRATION = 806;
 const RUN_EVENT_SEQUENCE_NUMBER_EXPANSION_MIGRATION = 807;
+const RUN_EVENT_SEQUENCE_NUMBER_CONTRACTION_MIGRATION = 810;
 
 async function addCurrentChatEventAdditiveStorage(
   client: Client,
@@ -17828,9 +17829,9 @@ async function addCurrentChatEventAdditiveStorage(
   `);
 }
 
-async function validateRunEventSequenceNumberExpansion(): Promise<void> {
+async function validateRunEventSequenceNumberRollout(): Promise<void> {
   console.log(
-    "=== Validate populated run event sequence expansion and runtime cutover ===\n",
+    "=== Validate populated run event sequence expand, switch, and contract rollout ===\n",
   );
   const testDb = "migration_run_event_sequence_number_test";
   const testDbUrl = createTestDbUrl(testDb);
@@ -17839,6 +17840,7 @@ async function validateRunEventSequenceNumberExpansion(): Promise<void> {
   const historicalRunId = "00000000-0000-4000-8000-000000080703";
   const previousApiRunId = "00000000-0000-4000-8000-000000080704";
   const currentApiRunId = "00000000-0000-4000-8000-000000080705";
+  const contractedRunId = "00000000-0000-4000-8000-000000080706";
 
   const migrationSql = await fs.readFile(
     path.join(MIGRATIONS_DIR, "0807_expand_run_event_sequence_number.sql"),
@@ -17862,6 +17864,37 @@ async function validateRunEventSequenceNumberExpansion(): Promise<void> {
   assert.match(migrationSql, /\bLIMIT 10000\b/u);
   assert.match(migrationSql, /\bFOR UPDATE SKIP LOCKED\b/u);
   assert.match(migrationSql, /\bCOMMIT\b/u);
+
+  const contractionSql = await fs.readFile(
+    path.join(MIGRATIONS_DIR, "0810_small_sway.sql"),
+    "utf8",
+  );
+  assert.ok(contractionSql.startsWith(NON_TRANSACTIONAL_MIGRATION_MARKER));
+  assert.equal(
+    (
+      contractionSql.match(
+        /DROP INDEX CONCURRENTLY IF EXISTS "chat_events_run_seq_unique"/gu,
+      ) ?? []
+    ).length,
+    1,
+  );
+  assert.match(
+    contractionSql,
+    /DROP TRIGGER IF EXISTS "bridge_chat_event_run_event_sequence_number_0807"/u,
+  );
+  assert.match(
+    contractionSql,
+    /DROP FUNCTION IF EXISTS "bridge_chat_event_run_event_sequence_number_0807"\(\)/u,
+  );
+  assert.match(contractionSql, /DROP COLUMN IF EXISTS "sequence_number"/u);
+  assert.doesNotMatch(
+    contractionSql,
+    /CREATE OR REPLACE FUNCTION "reject_chat_event_source_update"/u,
+  );
+  assert.doesNotMatch(
+    contractionSql,
+    /"seq_id"|"last_chat_event_seq_id"|"run_event_id"|"chat_events_run_event_seq_unique"/u,
+  );
 
   const schemaSource = await fs.readFile(
     path.join(PACKAGE_DIR, "src/schema/chat-event.ts"),
@@ -18209,6 +18242,8 @@ async function validateRunEventSequenceNumberExpansion(): Promise<void> {
         rejectFunction.rows[0]?.definition ?? "",
         /run_event_sequence_number/u,
       );
+      const strictRejectFunctionDefinition = rejectFunction.rows[0]?.definition;
+      assert.ok(strictRejectFunctionDefinition);
 
       const migrationStatements = migrationSql
         .split("--> statement-breakpoint")
@@ -18265,6 +18300,180 @@ async function validateRunEventSequenceNumberExpansion(): Promise<void> {
       ]);
       await assertChatEventsAppendOnlyProtection(client, previousApiEventId);
 
+      await applyMigrationsUpTo(
+        client,
+        RUN_EVENT_SEQUENCE_NUMBER_CONTRACTION_MIGRATION,
+      );
+
+      const preservedRows = await client.query<{
+        maximumSequence: number;
+        minimumSequence: number;
+        rows: string;
+      }>(
+        `
+          SELECT
+            count(*)::text AS "rows",
+            min("run_event_sequence_number") AS "minimumSequence",
+            max("run_event_sequence_number") AS "maximumSequence"
+          FROM "chat_events"
+          WHERE "run_id" = $1
+        `,
+        [historicalRunId],
+      );
+      assert.deepEqual(preservedRows.rows, [
+        {
+          maximumSequence: 10001,
+          minimumSequence: 1,
+          rows: "10001",
+        },
+      ]);
+
+      const switchedRows = await client.query<{
+        runEventSequenceNumber: number;
+        runId: string;
+      }>(
+        `
+          SELECT
+            "run_id" AS "runId",
+            "run_event_sequence_number" AS "runEventSequenceNumber"
+          FROM "chat_events"
+          WHERE "run_id" IN ($1, $2)
+          ORDER BY "run_id"
+        `,
+        [previousApiRunId, currentApiRunId],
+      );
+      assert.deepEqual(switchedRows.rows, [
+        {
+          runEventSequenceNumber: 7,
+          runId: previousApiRunId,
+        },
+        {
+          runEventSequenceNumber: 9,
+          runId: currentApiRunId,
+        },
+      ]);
+
+      const contractedInsert = await database
+        .insert(chatEvents)
+        .values({
+          chatThreadId: threadId,
+          runId: contractedRunId,
+          eventType: "output.message",
+          runEventSequenceNumber: 11,
+          seqId: 10007,
+        })
+        .returning({
+          id: chatEvents.id,
+          sequenceNumber: chatEvents.runEventSequenceNumber,
+        });
+      assert.equal(contractedInsert.length, 1);
+      assert.equal(contractedInsert[0]?.sequenceNumber, 11);
+      const contractedEventId = contractedInsert[0]?.id;
+      assert.ok(contractedEventId);
+
+      await expectDatabaseError(client, {
+        code: "23505",
+        messageIncludes: "chat_events_run_event_seq_unique",
+        query: `
+          INSERT INTO "chat_events" (
+            "chat_thread_id",
+            "run_id",
+            "event_type",
+            "run_event_sequence_number",
+            "seq_id"
+          )
+          VALUES ($1, $2, 'output.message', 11, 10008)
+        `,
+        values: [threadId, contractedRunId],
+      });
+      await assertChatEventsAppendOnlyProtection(client, contractedEventId);
+
+      const contractionStatements = contractionSql
+        .split("--> statement-breakpoint")
+        .map((statement) => {
+          return statement.trim();
+        })
+        .filter((statement) => {
+          return statement.length > 0;
+        });
+      for (const statement of contractionStatements) {
+        await client.query(statement);
+      }
+
+      const contractedCatalog = await client.query<{
+        backfillProcedurePresent: boolean;
+        bridgeFunctionPresent: boolean;
+        bridgeTriggerPresent: boolean;
+        canonicalIndexValid: boolean;
+        legacyColumnPresent: boolean;
+        legacyIndexPresent: boolean;
+        rejectTriggerEnabled: string;
+      }>(`
+        SELECT
+          EXISTS (
+            SELECT 1
+            FROM "information_schema"."columns"
+            WHERE "table_schema" = 'public'
+              AND "table_name" = 'chat_events'
+              AND "column_name" = 'sequence_number'
+          ) AS "legacyColumnPresent",
+          to_regclass('public.chat_events_run_seq_unique') IS NOT NULL
+            AS "legacyIndexPresent",
+          EXISTS (
+            SELECT 1
+            FROM "pg_index"
+            WHERE "indexrelid" =
+              'public.chat_events_run_event_seq_unique'::regclass
+              AND "indisunique"
+              AND "indisvalid"
+          ) AS "canonicalIndexValid",
+          to_regprocedure(
+            'public.bridge_chat_event_run_event_sequence_number_0807()'
+          ) IS NOT NULL AS "bridgeFunctionPresent",
+          to_regprocedure(
+            'public.backfill_chat_event_run_event_sequence_number_0807()'
+          ) IS NOT NULL AS "backfillProcedurePresent",
+          EXISTS (
+            SELECT 1
+            FROM "pg_trigger"
+            WHERE "tgrelid" = 'public.chat_events'::regclass
+              AND "tgname" =
+                'bridge_chat_event_run_event_sequence_number_0807'
+              AND NOT "tgisinternal"
+          ) AS "bridgeTriggerPresent",
+          (
+            SELECT "tgenabled"::text
+            FROM "pg_trigger"
+            WHERE "tgrelid" = 'public.chat_events'::regclass
+              AND "tgname" = 'chat_events_reject_update'
+              AND NOT "tgisinternal"
+          ) AS "rejectTriggerEnabled"
+      `);
+      assert.deepEqual(contractedCatalog.rows, [
+        {
+          backfillProcedurePresent: false,
+          bridgeFunctionPresent: false,
+          bridgeTriggerPresent: false,
+          canonicalIndexValid: true,
+          legacyColumnPresent: false,
+          legacyIndexPresent: false,
+          rejectTriggerEnabled: "O",
+        },
+      ]);
+
+      const preservedRejectFunction = await client.query<{
+        definition: string;
+      }>(`
+        SELECT pg_get_functiondef(
+          'public.reject_chat_event_source_update()'::regprocedure
+        ) AS "definition"
+      `);
+      assert.equal(
+        preservedRejectFunction.rows[0]?.definition,
+        strictRejectFunctionDefinition,
+      );
+      await assertChatEventsAppendOnlyProtection(client, contractedEventId);
+
       console.log("   ✅ 10,001 historical rows backfill across batches");
       console.log(
         "   ✅ Draining legacy and current Drizzle inserts coexist with mirrored columns",
@@ -18274,7 +18483,15 @@ async function validateRunEventSequenceNumberExpansion(): Promise<void> {
       );
       console.log("   ✅ Both unique index paths reject duplicates with 23505");
       console.log("   ✅ Strict append-only protection is restored");
-      console.log("   ✅ A full non-transactional retry is idempotent\n");
+      console.log(
+        "   ✅ Contract preserves canonical rows and new writes while the canonical index independently rejects duplicates",
+      );
+      console.log(
+        "   ✅ Legacy column, index, bridge, and backfill procedure are absent",
+      );
+      console.log(
+        "   ✅ Full expansion and contraction non-transactional retries are idempotent\n",
+      );
     } finally {
       await client.end();
     }
@@ -18415,7 +18632,7 @@ async function main(): Promise<void> {
     await validateChatEventRunLifecycleContraction();
     await validateChatEventLowTrafficIndexes();
     await validateChatEventRevokeIndex();
-    await validateRunEventSequenceNumberExpansion();
+    await validateRunEventSequenceNumberRollout();
     await validateOrgPlanEntitlementBackfill();
     await validateModelObservationContractCleanup();
     await validateChatEventTypeBackfillAndContract();


### PR DESCRIPTION
## Summary

- finish step 3 (contract) of the three-step `chat_events.sequence_number` rollout in #24611
- recognize the contraction SQL that landed on `main` in #24768 as migration `0810_small_sway.sql` while this PR was waiting for the successor release gate
- remove the normalized-schema transitional column/index allowlists
- extend the populated-upgrade scenario through the 0810 contraction, full retry, canonical reads/writes, independent canonical uniqueness, strict append-only protection, and legacy-object removal

No duplicate migration is added: after #24768 merged, a new 0811 copy would be an idempotent no-op. The wire contract is unchanged. API `sequenceNumber` continues to map from `runEventSequenceNumber`; this PR does not touch `seq_id`, `chat_threads.last_chat_event_seq_id`, `run_event_id`, `chat_events_run_event_seq_unique`, or `output.thinking`.

## Main convergence

The original branch contained the focused PR 3 migration. During merge-queue admission, #24768 merged first and migration 0810 performed the same bridge trigger/function, legacy concurrent-index, and legacy-column contraction together with its active-input expansion. The branch was rebased, the redundant 0811 migration and snapshot were removed, and the PR now supplies the missing schema-comparison cleanup and contract coverage against the migration that is actually on `main`.

## Successor release gate

Satisfied on 2026-08-03:

- #24741 merged at 11:07:57 UTC as `ef55bfbcdf1362bd9a5f2efe4707af62faff52e2`
- `api-v1.367.0` and `db-v1.162.0` were published from that exact commit
- release-please run 30808303010 completed successfully; `promote-api-production`, `deploy-api-schema`, app/runner promotion, and the rollback dashboard all succeeded
- a complete 15-minute `vm0-web-logs-prod` query examined 37,041 events with zero `42703` messages naming `sequence_number` and zero `23505` messages
- MaskDB reported 1,055,122 `chat_events`, with matching non-null counts of 751,054 for both legacy and canonical sequence columns; the newest 100 non-null canonical rows had zero value mismatches

This establishes a production rollback target newer than `api-v1.366.1` / `db-v1.161.2`, so rollback cannot restore the old writer and old targeted `ON CONFLICT` columns.

## PostgreSQL catalog preflight

The preflight used two read-only layers before implementation:

1. Production MaskDB metadata for `vm0-prod-ro` confirmed the pre-contract live state: `chat_events` contained both `sequence_number` and `run_event_sequence_number`, `chat_events_run_seq_unique` was exactly the unique `(run_id, sequence_number)` index, and `chat_events_run_event_seq_unique` was the valid canonical unique `(run_id, run_event_sequence_number)` index.
2. The complete pre-contract migration chain through 0809 was replayed into the CI-pinned PostgreSQL 17.10 image and its system catalogs were queried directly. The only persisted objects referencing the legacy identifier were the expected 0807 bridge function and trigger. There were zero other functions/procedures, triggers, views, materialized views, rules, column defaults, generated expressions, or policies. `backfill_chat_event_run_event_sequence_number_0807()` was absent, and the only catalog dependency of the legacy column was `chat_events_run_seq_unique`.
3. After #24768 landed, the exact current-main chain through 0810 was replayed again. The legacy column/index/bridge were absent, the backfill procedure remained absent, and the catalog scan returned zero functions/procedures, triggers, views, materialized views, rules, defaults, generated expressions, or policies referencing `sequence_number`.

MaskDB intentionally does not expose `pg_proc`, `pg_trigger`, or the other system catalogs (`pg_proc` metadata access returned 404), so the live production schema/index metadata and direct PostgreSQL catalog replays are recorded separately rather than presenting a replay as a live production system-catalog query.

The preflight also confirmed that `chat_events_reject_update` is enabled and uses the strict unconditional append-only function. Its definition hash remained `c18eb36ad2253a3b2e9c346bccfd2d00` across the pre-contract and current-main replays. Migration 0810 does not redefine that shared function, and the populated-upgrade scenario proves exact definition preservation and strict rejection behavior.

## Migration safety

The contraction SQL now on `main` in migration 0810 retains the required safety shape:

- `-- vm0:non-transactional` keeps `CONCURRENTLY` outside a transaction
- the bridge trigger and function use `IF EXISTS`
- the legacy index uses `DROP INDEX CONCURRENTLY IF EXISTS` on the highest-write table
- the legacy column uses `DROP COLUMN IF EXISTS`
- a full successful migration replay converges without changing canonical state
- `chat_events_run_event_seq_unique` remains valid and independently rejects duplicates with `23505`
- `chat_events_reject_update` remains enabled, behaviorally strict, and definition-identical across contraction

This PR removes the temporary normalized-schema exceptions only after the populated migration proves the physical database and canonical schema now converge.

## Validation

Passed locally on the rebased current-main chain:

- focused Prettier check and `git diff --check`
- `pnpm -F @vm0/db lint`
- `pnpm -F @vm0/db check-types`
- `DATABASE_URL=postgresql://postgres@127.0.0.1:55511/postgres pnpm -F @vm0/db test:migration-consistency`
  - 811 migrations and snapshots
  - populated run-event sequence expand/switch/0810-contract scenario
  - 10,001 historical rows survive with canonical sequence values intact
  - canonical Drizzle reads/writes and independent `23505` enforcement
  - strict append-only protection and exact function-definition preservation
  - old column/index/bridge/backfill procedure absence and full retry
  - latest snapshot 810 accuracy, consecutive reset/replay, fresh regeneration, and normalized schema comparison
- final branch diff contains only the normalized-schema allowlist cleanup and populated contract coverage

Before the #24768 convergence, the focused ChatEvent Vitest file also passed (1 file, 2 tests). No full local Vitest suite or dev server was run; the PR pipeline owns the full matrix.

## Post-release verification before merge

- [x] #24741 merged and the `api-v1.367.0` / `db-v1.162.0` production release completed successfully
- [x] zero PostgreSQL `42703` errors naming `chat_events.sequence_number`
- [x] zero rollout-related PostgreSQL `23505` errors
- [x] MaskDB confirmed canonical `run_event_sequence_number` data remains intact

## Post-contract verification

- confirm production metadata no longer exposes `sequence_number` or `chat_events_run_seq_unique`
- confirm `chat_events_run_event_seq_unique` remains valid
- confirm the bridge objects are absent and `chat_events_reject_update` remains enabled
- continue monitoring for zero `42703` references to the old column and zero `23505` regressions

Closes #24611
