### PR TITLE
refactor(runner): unify runner preference admission

### DIFF
--- a/crates/runner/src/cmd/start/active_reuse_keys.rs
+++ b/crates/runner/src/cmd/start/active_reuse_keys.rs
@@ -27,18 +27,31 @@ pub(super) fn active_reuse_keys(active_reuse_keys: &ActiveReuseKeys) -> HashSet<
     lock_counts(active_reuse_keys).keys().cloned().collect()
 }
 
+pub(super) fn contains_active_reuse_key(
+    active_reuse_keys: &ActiveReuseKeys,
+    reuse_key: &str,
+) -> bool {
+    lock_counts(active_reuse_keys).contains_key(reuse_key)
+}
+
 pub(super) struct ActiveReuseKeyGuard {
     active_reuse_keys: ActiveReuseKeys,
+    reuse_state_notify: Arc<tokio::sync::Notify>,
     reuse_key: Option<String>,
 }
 
 impl ActiveReuseKeyGuard {
-    pub(super) fn new(active_reuse_keys: ActiveReuseKeys, reuse_key: Option<String>) -> Self {
+    pub(super) fn new(
+        active_reuse_keys: ActiveReuseKeys,
+        reuse_state_notify: Arc<tokio::sync::Notify>,
+        reuse_key: Option<String>,
+    ) -> Self {
         if let Some(reuse_key) = reuse_key.as_deref() {
             insert_active_reuse_key(&active_reuse_keys, reuse_key);
         }
         Self {
             active_reuse_keys,
+            reuse_state_notify,
             reuse_key,
         }
     }
@@ -48,6 +61,7 @@ impl ActiveReuseKeyGuard {
             return false;
         };
         remove_active_reuse_key(&self.active_reuse_keys, &reuse_key);
+        self.reuse_state_notify.notify_one();
         true
     }
 }
@@ -56,6 +70,7 @@ impl Drop for ActiveReuseKeyGuard {
     fn drop(&mut self) {
         if let Some(reuse_key) = self.reuse_key.as_deref() {
             remove_active_reuse_key(&self.active_reuse_keys, reuse_key);
+            self.reuse_state_notify.notify_one();
         }
     }
 }
@@ -88,7 +103,11 @@ mod tests {
     #[test]
     fn active_reuse_key_guard_registers_and_unregisters_initial_key() {
         let registry = new_active_reuse_keys();
-        let guard = ActiveReuseKeyGuard::new(Arc::clone(&registry), Some("thread:thread-2".into()));
+        let guard = ActiveReuseKeyGuard::new(
+            Arc::clone(&registry),
+            Arc::new(tokio::sync::Notify::new()),
+            Some("thread:thread-2".into()),
+        );
 
         assert!(active_reuse_keys(&registry).contains("thread:thread-2"));
 

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -582,7 +582,10 @@ async fn defer_preference_candidate(
         retained = retain,
         "runner preference has no qualifying local resource, deferring claim"
     );
-    ctx.spawn_ctx.provider.defer_poll_after(delay).await;
+    ctx.spawn_ctx
+        .provider
+        .defer_poll_until(preference.deadline())
+        .await;
     if retain {
         PreferencePreparation::Pending(candidate)
     } else {

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -109,12 +109,6 @@ enum PreferencePreparation {
     Deferred,
 }
 
-enum ClaimAdmissionOutcome {
-    Admitted(Box<AdmittedClaim>),
-    Pending(Box<JobCandidate>),
-    NotAdmitted,
-}
-
 struct ReuseAdmissionRequest<'a> {
     profile_name: &'a str,
     device_rate_limits: &'a Option<sandbox::DeviceRateLimits>,
@@ -172,8 +166,24 @@ pub(super) async fn handle_discovered_job(
         return DiscoveredJobResult::completed(false);
     };
 
-    let admission = claim_with_local_admission(
+    let prepared = match prepare_preference_candidate(
         candidate,
+        &profile_name,
+        job_vcpu,
+        job_memory,
+        &device_rate_limits,
+        &ctx,
+    )
+    .await
+    {
+        PreferencePreparation::Ready(prepared) => prepared,
+        PreferencePreparation::Pending(candidate) => {
+            return DiscoveredJobResult::pending(candidate);
+        }
+        PreferencePreparation::Deferred => return DiscoveredJobResult::completed(false),
+    };
+    let Some(admission) = claim_with_local_admission(
+        prepared,
         run_id,
         &profile_name,
         job_vcpu,
@@ -181,15 +191,9 @@ pub(super) async fn handle_discovered_job(
         &device_rate_limits,
         &mut ctx,
     )
-    .await;
-    let admission = match admission {
-        ClaimAdmissionOutcome::Admitted(admission) => *admission,
-        ClaimAdmissionOutcome::Pending(candidate) => {
-            return DiscoveredJobResult::pending(*candidate);
-        }
-        ClaimAdmissionOutcome::NotAdmitted => {
-            return DiscoveredJobResult::completed(false);
-        }
+    .await
+    else {
+        return DiscoveredJobResult::completed(false);
     };
     let AdmittedClaim {
         claimed,
@@ -360,52 +364,35 @@ async fn publish_active_run_status(
 }
 
 async fn claim_with_local_admission(
-    candidate: JobCandidate,
+    prepared: PreparedCandidate,
     run_id: RunId,
     profile_name: &str,
     job_vcpu: u32,
     job_memory: u32,
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     ctx: &mut DiscoveredJobContext<'_>,
-) -> ClaimAdmissionOutcome {
+) -> Option<AdmittedClaim> {
     let PreparedCandidate {
         mut candidate,
         resource,
-    } = match prepare_preference_candidate(
-        candidate,
-        profile_name,
-        job_vcpu,
-        job_memory,
-        device_rate_limits,
-        ctx,
-    )
-    .await
-    {
-        PreferencePreparation::Ready(prepared) => prepared,
-        PreferencePreparation::Pending(candidate) => {
-            return ClaimAdmissionOutcome::Pending(Box::new(candidate));
-        }
-        PreferencePreparation::Deferred => return ClaimAdmissionOutcome::NotAdmitted,
-    };
+    } = prepared;
     candidate.mark_local_admission_started();
 
     // Reserve either the exact reusable sandbox or fresh capacity before
     // claiming so a losing claim can restore all local ownership.
     let resource = match resource {
         Some(resource) => resource,
-        None => match acquire_local_admission_resource(
-            &candidate,
-            profile_name,
-            job_vcpu,
-            job_memory,
-            device_rate_limits,
-            ctx,
-        )
-        .await
-        {
-            Some(resource) => resource,
-            None => return ClaimAdmissionOutcome::NotAdmitted,
-        },
+        None => {
+            acquire_local_admission_resource(
+                &candidate,
+                profile_name,
+                job_vcpu,
+                job_memory,
+                device_rate_limits,
+                ctx,
+            )
+            .await?
+        }
     };
     // Register cancellation before claiming so provider-side cancel channels
     // (Ably supervisor for ApiProvider, `.cancel` scan for LocalProvider) can
@@ -415,7 +402,7 @@ async fn claim_with_local_admission(
         Ok(registration) => registration,
         Err(_) => {
             rollback_untracked_resource(resource, ctx).await;
-            return ClaimAdmissionOutcome::NotAdmitted;
+            return None;
         }
     };
 
@@ -432,18 +419,18 @@ async fn claim_with_local_admission(
         RunnerMode::Running => {}
         RunnerMode::Starting => {
             admission.rollback(ctx).await;
-            return ClaimAdmissionOutcome::NotAdmitted;
+            return None;
         }
         RunnerMode::Draining => {
             admission.rollback(ctx).await;
-            return ClaimAdmissionOutcome::NotAdmitted;
+            return None;
         }
         RunnerMode::Stopping => {
             admission.cancellation.request_hard_cancellation().await;
         }
         RunnerMode::Stopped => {
             admission.rollback(ctx).await;
-            return ClaimAdmissionOutcome::NotAdmitted;
+            return None;
         }
     }
     // claim() runs in the branch handler: non-interruptible, so a valid
@@ -453,7 +440,7 @@ async fn claim_with_local_admission(
         // runner, or the provider rejected the job. Release the reservation and
         // cancellation registration so the runner can continue.
         admission.rollback(ctx).await;
-        return ClaimAdmissionOutcome::NotAdmitted;
+        return None;
     };
     if claimed.context().run_id != run_id {
         warn!(
@@ -462,10 +449,10 @@ async fn claim_with_local_admission(
             "provider returned claimed job with mismatched run_id"
         );
         admission.rollback(ctx).await;
-        return ClaimAdmissionOutcome::NotAdmitted;
+        return None;
     }
 
-    ClaimAdmissionOutcome::Admitted(Box::new(admission.into_admitted(claimed)))
+    Some(admission.into_admitted(claimed))
 }
 
 async fn prepare_preference_candidate(

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -12,7 +12,7 @@ use sandbox::SandboxId;
 use tokio::task::JoinSet;
 use tracing::{info, warn};
 
-use super::active_reuse_keys::ActiveReuseKeyGuard;
+use super::active_reuse_keys::{ActiveReuseKeyGuard, contains_active_reuse_key};
 use super::factory_lifecycle::SharedFactory;
 use super::idle_lifecycle::{
     SharedIdlePool, add_preparing_run_with_idle_status_snapshot,
@@ -33,13 +33,13 @@ use crate::idle_pool::{
 use crate::ids::RunId;
 use crate::lifecycle::RunnerMode;
 use crate::paths::short_digest;
-use crate::provider::{ClaimedJob, JobCandidate};
+use crate::provider::{ClaimedJob, JobCandidate, RunnerPreferenceReason};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::run_cancellation::{RunCancellationRegistration, RunCancellationRegistry};
 use crate::status::StatusTracker;
 use crate::types::{
-    ExecutionContext, HeldWorkspaceState, SandboxReuseResult, SessionAffinityResource,
-    WORKSPACE_AFFINITY_VERSION, reuse_key_kind,
+    ExecutionContext, HeldWorkspaceState, SandboxReuseResult, WORKSPACE_AFFINITY_VERSION,
+    reuse_key_kind,
 };
 
 pub(super) struct DiscoveredJob {
@@ -47,6 +47,8 @@ pub(super) struct DiscoveredJob {
 }
 
 pub(super) struct DiscoveredJobContext<'a> {
+    pub(super) runner_id: &'a str,
+    pub(super) heartbeat_generation: u64,
     pub(super) profiles: &'a BTreeMap<String, ProfileConfig>,
     pub(super) factories: &'a BTreeMap<String, (SharedFactory, bool)>,
     pub(super) budget: &'a Arc<ResourceBudget>,
@@ -57,6 +59,27 @@ pub(super) struct DiscoveredJobContext<'a> {
     pub(super) spawn_ctx: &'a SpawnContext,
     pub(super) destroy_tasks: &'a mut JoinSet<bool>,
     pub(super) jobs: &'a mut JoinSet<RunCancellationRegistration>,
+}
+
+pub(super) struct DiscoveredJobResult {
+    pub(super) needs_reuse_state_refresh: bool,
+    pub(super) pending_candidate: Option<JobCandidate>,
+}
+
+impl DiscoveredJobResult {
+    fn completed(needs_reuse_state_refresh: bool) -> Self {
+        Self {
+            needs_reuse_state_refresh,
+            pending_candidate: None,
+        }
+    }
+
+    fn pending(candidate: JobCandidate) -> Self {
+        Self {
+            needs_reuse_state_refresh: false,
+            pending_candidate: Some(candidate),
+        }
+    }
 }
 
 struct LocalAdmission {
@@ -75,9 +98,21 @@ struct AdmittedClaim {
     cancellation: RunCancellationRegistration,
 }
 
-struct PreparedAffinityCandidate {
+struct PreparedCandidate {
     candidate: JobCandidate,
     resource: Option<LocalAdmissionResource>,
+}
+
+enum PreferencePreparation {
+    Ready(PreparedCandidate),
+    Pending(JobCandidate),
+    Deferred,
+}
+
+enum ClaimAdmissionOutcome {
+    Admitted(Box<AdmittedClaim>),
+    Pending(Box<JobCandidate>),
+    NotAdmitted,
 }
 
 struct ReuseAdmissionRequest<'a> {
@@ -117,7 +152,7 @@ impl LocalAdmission {
 pub(super) async fn handle_discovered_job(
     job: DiscoveredJob,
     mut ctx: DiscoveredJobContext<'_>,
-) -> bool {
+) -> DiscoveredJobResult {
     let DiscoveredJob { mut candidate } = job;
     candidate.mark_main_loop_handling_started();
     let run_id = candidate.run_id();
@@ -125,7 +160,7 @@ pub(super) async fn handle_discovered_job(
     // Look up profile config for resource requirements.
     let Some(profile_config) = ctx.profiles.get(&profile_name) else {
         warn!(run_id = %run_id, profile = %profile_name, "unknown profile, skipping");
-        return false;
+        return DiscoveredJobResult::completed(false);
     };
     let job_vcpu = profile_config.vcpu;
     let job_memory = profile_config.memory_mb;
@@ -134,10 +169,10 @@ pub(super) async fn handle_discovered_job(
     // Look up factory for this profile.
     let Some((factory, restore_guest_state)) = ctx.factories.get(&profile_name) else {
         warn!(run_id = %run_id, profile = %profile_name, "no factory for profile, skipping");
-        return false;
+        return DiscoveredJobResult::completed(false);
     };
 
-    let Some(admission) = claim_with_local_admission(
+    let admission = claim_with_local_admission(
         candidate,
         run_id,
         &profile_name,
@@ -146,9 +181,15 @@ pub(super) async fn handle_discovered_job(
         &device_rate_limits,
         &mut ctx,
     )
-    .await
-    else {
-        return false;
+    .await;
+    let admission = match admission {
+        ClaimAdmissionOutcome::Admitted(admission) => *admission,
+        ClaimAdmissionOutcome::Pending(candidate) => {
+            return DiscoveredJobResult::pending(*candidate);
+        }
+        ClaimAdmissionOutcome::NotAdmitted => {
+            return DiscoveredJobResult::completed(false);
+        }
     };
     let AdmittedClaim {
         claimed,
@@ -160,24 +201,24 @@ pub(super) async fn handle_discovered_job(
     let resume_session_error = validate_resume_session_id(claimed.context()).err();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::ResumeSessionValidation, started_at);
     if let Some(error) = resume_session_error {
-        let needs_session_affinity_refresh =
-            matches!(&resource, LocalAdmissionResource::Reusable(_));
+        let needs_reuse_state_refresh = matches!(&resource, LocalAdmissionResource::Reusable(_));
         fail_claimed_without_sandbox(claimed, cancellation, resource, None, error, &mut ctx).await;
-        return needs_session_affinity_refresh;
+        return DiscoveredJobResult::completed(needs_reuse_state_refresh);
     }
     info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
     let started_at = Instant::now();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::DeviceRateLimits, started_at);
 
-    // Hide the claimed reuse key from heartbeat affinity before unpark or
-    // fallback cleanup can yield. Otherwise a concurrent heartbeat could
-    // briefly advertise stale workspace-cache affinity for an active run.
+    // Hide the claimed reuse key from heartbeats before unpark or fallback
+    // cleanup can yield. Otherwise a concurrent heartbeat could briefly
+    // advertise stale workspace-cache state for an active run.
     let active_reuse_key_guard = ActiveReuseKeyGuard::new(
         ctx.spawn_ctx.active_reuse_keys.clone(),
+        Arc::clone(&ctx.spawn_ctx.reuse_state_notify),
         claimed.context().reuse_key().map(str::to_owned),
     );
 
-    let (reuse_entry, active_lease, reuse_result, idle_snapshot, needs_session_affinity_refresh) =
+    let (reuse_entry, active_lease, reuse_result, idle_snapshot, needs_reuse_state_refresh) =
         match resource {
             LocalAdmissionResource::Fresh(job_lease) => {
                 try_reuse_from_pool(
@@ -234,7 +275,7 @@ pub(super) async fn handle_discovered_job(
                             &mut ctx,
                         )
                         .await;
-                        return true;
+                        return DiscoveredJobResult::completed(true);
                     }
                 }
             }
@@ -297,7 +338,7 @@ pub(super) async fn handle_discovered_job(
         ctx.spawn_ctx,
         ctx.jobs,
     );
-    needs_session_affinity_refresh
+    DiscoveredJobResult::completed(needs_reuse_state_refresh)
 }
 
 async fn publish_active_run_status(
@@ -326,11 +367,11 @@ async fn claim_with_local_admission(
     job_memory: u32,
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     ctx: &mut DiscoveredJobContext<'_>,
-) -> Option<AdmittedClaim> {
-    let PreparedAffinityCandidate {
+) -> ClaimAdmissionOutcome {
+    let PreparedCandidate {
         mut candidate,
         resource,
-    } = prepare_affinity_protected_candidate(
+    } = match prepare_preference_candidate(
         candidate,
         profile_name,
         job_vcpu,
@@ -338,24 +379,33 @@ async fn claim_with_local_admission(
         device_rate_limits,
         ctx,
     )
-    .await?;
+    .await
+    {
+        PreferencePreparation::Ready(prepared) => prepared,
+        PreferencePreparation::Pending(candidate) => {
+            return ClaimAdmissionOutcome::Pending(Box::new(candidate));
+        }
+        PreferencePreparation::Deferred => return ClaimAdmissionOutcome::NotAdmitted,
+    };
     candidate.mark_local_admission_started();
 
     // Reserve either the exact reusable sandbox or fresh capacity before
     // claiming so a losing claim can restore all local ownership.
     let resource = match resource {
         Some(resource) => resource,
-        None => {
-            acquire_local_admission_resource(
-                &candidate,
-                profile_name,
-                job_vcpu,
-                job_memory,
-                device_rate_limits,
-                ctx,
-            )
-            .await?
-        }
+        None => match acquire_local_admission_resource(
+            &candidate,
+            profile_name,
+            job_vcpu,
+            job_memory,
+            device_rate_limits,
+            ctx,
+        )
+        .await
+        {
+            Some(resource) => resource,
+            None => return ClaimAdmissionOutcome::NotAdmitted,
+        },
     };
     // Register cancellation before claiming so provider-side cancel channels
     // (Ably supervisor for ApiProvider, `.cancel` scan for LocalProvider) can
@@ -365,7 +415,7 @@ async fn claim_with_local_admission(
         Ok(registration) => registration,
         Err(_) => {
             rollback_untracked_resource(resource, ctx).await;
-            return None;
+            return ClaimAdmissionOutcome::NotAdmitted;
         }
     };
 
@@ -382,18 +432,18 @@ async fn claim_with_local_admission(
         RunnerMode::Running => {}
         RunnerMode::Starting => {
             admission.rollback(ctx).await;
-            return None;
+            return ClaimAdmissionOutcome::NotAdmitted;
         }
         RunnerMode::Draining => {
             admission.rollback(ctx).await;
-            return None;
+            return ClaimAdmissionOutcome::NotAdmitted;
         }
         RunnerMode::Stopping => {
             admission.cancellation.request_hard_cancellation().await;
         }
         RunnerMode::Stopped => {
             admission.rollback(ctx).await;
-            return None;
+            return ClaimAdmissionOutcome::NotAdmitted;
         }
     }
     // claim() runs in the branch handler: non-interruptible, so a valid
@@ -403,7 +453,7 @@ async fn claim_with_local_admission(
         // runner, or the provider rejected the job. Release the reservation and
         // cancellation registration so the runner can continue.
         admission.rollback(ctx).await;
-        return None;
+        return ClaimAdmissionOutcome::NotAdmitted;
     };
     if claimed.context().run_id != run_id {
         warn!(
@@ -412,95 +462,52 @@ async fn claim_with_local_admission(
             "provider returned claimed job with mismatched run_id"
         );
         admission.rollback(ctx).await;
-        return None;
+        return ClaimAdmissionOutcome::NotAdmitted;
     }
 
-    Some(admission.into_admitted(claimed))
+    ClaimAdmissionOutcome::Admitted(Box::new(admission.into_admitted(claimed)))
 }
 
-async fn prepare_affinity_protected_candidate(
+async fn prepare_preference_candidate(
     candidate: JobCandidate,
     profile_name: &str,
     job_vcpu: u32,
     job_memory: u32,
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     ctx: &DiscoveredJobContext<'_>,
-) -> Option<PreparedAffinityCandidate> {
-    if candidate.is_history_generation_affinity_protected()
-        && let (Some(reuse_key), Some(history_generation_run_id)) = (
-            candidate.reuse_key().map(str::to_owned),
-            candidate.history_generation_run_id(),
-        )
-    {
-        if let Some(reservation) = reserve_reusable_idle(
-            &reuse_key,
-            profile_name,
-            device_rate_limits,
-            Some(history_generation_run_id),
-            ctx,
-        )
-        .await
-        {
-            return Some(PreparedAffinityCandidate {
-                candidate,
-                resource: Some(LocalAdmissionResource::Reusable(Box::new(reservation))),
-            });
-        }
-
-        let delay = candidate
-            .history_generation_affinity_protection_remaining()
-            .unwrap_or_default();
-        let reuse_key_fingerprint = diagnostic_reuse_key_fingerprint(&reuse_key);
-        info!(
-            run_id = %candidate.run_id(),
-            reuse_key_fingerprint = %reuse_key_fingerprint,
-            reuse_key_kind = reuse_key_kind(&reuse_key),
-            delay_ms = delay.as_millis(),
-            "exact session-history generation protected by another runner, deferring claim"
-        );
-        ctx.spawn_ctx.provider.defer_poll_after(delay).await;
-        return None;
-    }
-
-    if !candidate.is_affinity_protected() {
-        return Some(PreparedAffinityCandidate {
-            candidate,
-            resource: None,
-        });
+) -> PreferencePreparation {
+    let Some(preference) = candidate.runner_preference().cloned() else {
+        return ordinary_preparation(candidate);
+    };
+    if preference.is_expired() {
+        return ordinary_preparation(candidate.without_runner_preference());
     }
     let Some(reuse_key) = candidate.reuse_key().map(str::to_owned) else {
-        let delay = candidate
-            .affinity_protection_remaining()
-            .unwrap_or_default();
-        info!(
-            run_id = %candidate.run_id(),
-            has_cli_agent_session_id = candidate.cli_agent_session_id().is_some(),
-            delay_ms = delay.as_millis(),
-            "affinity-protected candidate missing session metadata, deferring claim"
-        );
-        ctx.spawn_ctx.provider.defer_poll_after(delay).await;
-        return None;
+        return ordinary_preparation(candidate.without_runner_preference());
     };
 
-    match candidate.session_affinity_resource() {
-        Some(SessionAffinityResource::ReusableSandbox) => {
-            if let Some(reservation) =
-                reserve_reusable_idle(&reuse_key, profile_name, device_rate_limits, None, ctx).await
+    match preference.reason() {
+        RunnerPreferenceReason::ExactHistoryGeneration => {
+            let Some(history_generation_run_id) = candidate.history_generation_run_id() else {
+                return ordinary_preparation(candidate.without_runner_preference());
+            };
+            if let Some(reservation) = reserve_reusable_idle(
+                &reuse_key,
+                profile_name,
+                device_rate_limits,
+                Some(history_generation_run_id),
+                ctx,
+            )
+            .await
             {
-                return Some(PreparedAffinityCandidate {
-                    candidate,
-                    resource: Some(LocalAdmissionResource::Reusable(Box::new(reservation))),
-                });
+                return reusable_preparation(candidate, reservation);
             }
         }
-        Some(SessionAffinityResource::WorkspaceCache) => {
+        RunnerPreferenceReason::MatchingReuseKey => {
             if let Some(reservation) =
                 reserve_reusable_idle(&reuse_key, profile_name, device_rate_limits, None, ctx).await
             {
-                return Some(PreparedAffinityCandidate {
-                    candidate,
-                    resource: Some(LocalAdmissionResource::Reusable(Box::new(reservation))),
-                });
+                return reusable_preparation(candidate, reservation);
             }
 
             let held_workspace_states = current_local_held_workspace_states(ctx);
@@ -516,28 +523,84 @@ async fn prepare_affinity_protected_candidate(
                 && let Some(lease) =
                     ResourceBudget::try_reserve_lease(ctx.budget, job_vcpu, job_memory)
             {
-                return Some(PreparedAffinityCandidate {
+                return PreferencePreparation::Ready(PreparedCandidate {
                     candidate,
                     resource: Some(LocalAdmissionResource::Fresh(lease)),
                 });
             }
         }
-        None => {}
+        RunnerPreferenceReason::FinalizingPredecessor => {
+            let Some(history_generation_run_id) = candidate.history_generation_run_id() else {
+                return ordinary_preparation(candidate.without_runner_preference());
+            };
+            if let Some(reservation) = reserve_reusable_idle(
+                &reuse_key,
+                profile_name,
+                device_rate_limits,
+                Some(history_generation_run_id),
+                ctx,
+            )
+            .await
+            {
+                return reusable_preparation(candidate, reservation);
+            }
+
+            if preference.targets(ctx.runner_id, ctx.heartbeat_generation) {
+                if !contains_active_reuse_key(&ctx.spawn_ctx.active_reuse_keys, &reuse_key) {
+                    return ordinary_preparation(candidate.without_runner_preference());
+                }
+                return defer_preference_candidate(candidate, &preference, &reuse_key, ctx, true)
+                    .await;
+            }
+        }
     }
 
-    let delay = candidate
-        .affinity_protection_remaining()
-        .unwrap_or_default();
-    let reuse_key_fingerprint = diagnostic_reuse_key_fingerprint(&reuse_key);
+    defer_preference_candidate(candidate, &preference, &reuse_key, ctx, false).await
+}
+
+fn ordinary_preparation(candidate: JobCandidate) -> PreferencePreparation {
+    PreferencePreparation::Ready(PreparedCandidate {
+        candidate,
+        resource: None,
+    })
+}
+
+fn reusable_preparation(
+    candidate: JobCandidate,
+    reservation: ReservedIdleSandbox,
+) -> PreferencePreparation {
+    PreferencePreparation::Ready(PreparedCandidate {
+        candidate,
+        resource: Some(LocalAdmissionResource::Reusable(Box::new(reservation))),
+    })
+}
+
+async fn defer_preference_candidate(
+    candidate: JobCandidate,
+    preference: &crate::provider::RunnerPreference,
+    reuse_key: &str,
+    ctx: &DiscoveredJobContext<'_>,
+    retain: bool,
+) -> PreferencePreparation {
+    if preference.is_expired() {
+        return ordinary_preparation(candidate.without_runner_preference());
+    }
+    let delay = preference.remaining();
     info!(
         run_id = %candidate.run_id(),
-        reuse_key_fingerprint = %reuse_key_fingerprint,
-        reuse_key_kind = reuse_key_kind(&reuse_key),
+        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
+        reuse_key_kind = reuse_key_kind(reuse_key),
+        preference_reason = ?preference.reason(),
         delay_ms = delay.as_millis(),
-        "same-reuse-key affinity protected by another runner, deferring claim"
+        retained = retain,
+        "runner preference has no qualifying local resource, deferring claim"
     );
     ctx.spawn_ctx.provider.defer_poll_after(delay).await;
-    None
+    if retain {
+        PreferencePreparation::Pending(candidate)
+    } else {
+        PreferencePreparation::Deferred
+    }
 }
 
 fn diagnostic_reuse_key_fingerprint(reuse_key: &str) -> String {
@@ -578,7 +641,7 @@ async fn acquire_local_admission_resource(
                 "reclaiming expired idle VMs for candidate admission"
             );
             destroy_idle_jobs_and_wait(expired, "candidate_admission_expired").await;
-            ctx.spawn_ctx.park_notify.notify_one();
+            ctx.spawn_ctx.reuse_state_notify.notify_one();
             continue;
         }
 
@@ -593,7 +656,7 @@ async fn acquire_local_admission_resource(
             "evicting idle VM for candidate admission"
         );
         destroy_idle_jobs_and_wait(vec![evicted], "candidate_admission_oldest").await;
-        ctx.spawn_ctx.park_notify.notify_one();
+        ctx.spawn_ctx.reuse_state_notify.notify_one();
     }
 }
 
@@ -642,7 +705,7 @@ async fn rollback_untracked_resource(
                     *destroy_job,
                     "reserved_idle_rollback_rejected",
                 );
-                ctx.spawn_ctx.park_notify.notify_one();
+                ctx.spawn_ctx.reuse_state_notify.notify_one();
             }
         }
     }
@@ -865,7 +928,7 @@ async fn try_reuse_from_pool(
             .might_contain_workspace_cache_reuse_key(reuse_key);
     pre_spawn_timing
         .record_phase_elapsed(RunnerPreSpawnPhase::WorkspaceCacheStateLookup, started_at);
-    let needs_session_affinity_refresh = took_idle_session || claimed_workspace_cache_reuse_key;
+    let needs_reuse_state_refresh = took_idle_session || claimed_workspace_cache_reuse_key;
     match taken {
         Some(entry)
             if entry.profile_name() == profile_name
@@ -901,7 +964,7 @@ async fn try_reuse_from_pool(
                         job_lease,
                         SandboxReuseResult::PoolMiss,
                         snapshot,
-                        needs_session_affinity_refresh,
+                        needs_reuse_state_refresh,
                     );
                 }
             }
@@ -928,7 +991,7 @@ async fn try_reuse_from_pool(
                         budget_lease,
                         SandboxReuseResult::Reused,
                         snapshot,
-                        needs_session_affinity_refresh,
+                        needs_reuse_state_refresh,
                     )
                 }
                 IdleUnparkResult::Failed { destroy_job, error } => {
@@ -945,7 +1008,7 @@ async fn try_reuse_from_pool(
                         job_lease,
                         SandboxReuseResult::UnparkFailed,
                         snapshot,
-                        needs_session_affinity_refresh,
+                        needs_reuse_state_refresh,
                     )
                 }
             }
@@ -968,7 +1031,7 @@ async fn try_reuse_from_pool(
                 job_lease,
                 SandboxReuseResult::DeviceLimitMismatch,
                 snapshot,
-                needs_session_affinity_refresh,
+                needs_reuse_state_refresh,
             )
         }
         Some(stale) => {
@@ -990,7 +1053,7 @@ async fn try_reuse_from_pool(
                 job_lease,
                 SandboxReuseResult::ProfileMismatch,
                 snapshot,
-                needs_session_affinity_refresh,
+                needs_reuse_state_refresh,
             )
         }
         None => {
@@ -1005,7 +1068,7 @@ async fn try_reuse_from_pool(
                 job_lease,
                 SandboxReuseResult::PoolMiss,
                 None,
-                needs_session_affinity_refresh,
+                needs_reuse_state_refresh,
             )
         }
     }

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -72,7 +72,7 @@ pub(super) struct SpawnContext {
     /// affinity state changes. This eliminates the up-to-10s blind spot where
     /// the server does not know which runner holds a reusable sandbox or
     /// workspace image cache.
-    pub(super) park_notify: Arc<tokio::sync::Notify>,
+    pub(super) reuse_state_notify: Arc<tokio::sync::Notify>,
     /// Best-effort signal for the main loop to ask mitmproxy to flush usage.
     pub(super) usage_flush_tx: mpsc::Sender<()>,
     pub(super) active_reuse_keys: ActiveReuseKeys,
@@ -242,7 +242,7 @@ struct FinalizationPhase {
     factory: SharedFactory,
     idle_pool: SharedIdlePool,
     status: Arc<StatusTracker>,
-    park_notify: Arc<tokio::sync::Notify>,
+    reuse_state_notify: Arc<tokio::sync::Notify>,
     workspace_cache_snapshot: WorkspaceCacheStateSnapshot,
     parking_gate: ParkingGate,
     network_log_drain: NetworkLogDrainCoordinator,
@@ -276,7 +276,7 @@ impl FinalizationPhase {
             factory,
             idle_pool,
             status,
-            park_notify,
+            reuse_state_notify,
             workspace_cache_snapshot,
             parking_gate,
             network_log_drain,
@@ -339,7 +339,7 @@ impl FinalizationPhase {
                 factory,
                 idle_pool,
                 status,
-                park_notify,
+                reuse_state_notify,
                 workspace_cache_snapshot,
                 parking_gate,
                 network_log_drain,
@@ -415,7 +415,7 @@ struct CompletionPhase {
     provider: Arc<dyn JobProvider>,
     status: Arc<StatusTracker>,
     usage_flush_tx: mpsc::Sender<()>,
-    park_notify: Arc<tokio::sync::Notify>,
+    reuse_state_notify: Arc<tokio::sync::Notify>,
     active_reuse_key_guard: ActiveReuseKeyGuard,
     cleanup_state: RunCleanupState,
 }
@@ -427,7 +427,7 @@ impl CompletionPhase {
             provider,
             status,
             usage_flush_tx,
-            park_notify,
+            reuse_state_notify,
             active_reuse_key_guard,
             cleanup_state,
         } = self;
@@ -454,7 +454,7 @@ impl CompletionPhase {
             );
         }
         if session_affinity_changed {
-            park_notify.notify_one();
+            reuse_state_notify.notify_one();
         }
     }
 }
@@ -581,7 +581,7 @@ pub(super) fn spawn_job(
     let exec_config = Arc::clone(&ctx.exec_config);
     let status = Arc::clone(&ctx.status);
     let idle_pool = Arc::clone(&ctx.idle_pool);
-    let park_notify = Arc::clone(&ctx.park_notify);
+    let reuse_state_notify = Arc::clone(&ctx.reuse_state_notify);
     let workspace_cache_snapshot = ctx.workspace_cache_snapshot.clone();
     let usage_flush_tx = ctx.usage_flush_tx.clone();
     let parking_gate = ctx.parking_gate.clone();
@@ -655,7 +655,7 @@ pub(super) fn spawn_job(
         factory,
         idle_pool: Arc::clone(&idle_pool),
         status: Arc::clone(&status),
-        park_notify: Arc::clone(&park_notify),
+        reuse_state_notify: Arc::clone(&reuse_state_notify),
         workspace_cache_snapshot,
         parking_gate,
         network_log_drain: exec_config.network_log_drain.clone(),
@@ -701,7 +701,7 @@ pub(super) fn spawn_job(
                 provider,
                 status,
                 usage_flush_tx,
-                park_notify,
+                reuse_state_notify,
                 active_reuse_key_guard,
                 cleanup_state: cleanup_state_for_body,
             }
@@ -873,7 +873,7 @@ mod tests {
         status: Arc<StatusTracker>,
         idle_pool: SharedIdlePool,
         parking_gate: ParkingGate,
-        park_notify: Arc<tokio::sync::Notify>,
+        reuse_state_notify: Arc<tokio::sync::Notify>,
     }
 
     impl FinalizationTelemetryFixture {
@@ -900,7 +900,7 @@ mod tests {
                 status,
                 idle_pool,
                 parking_gate,
-                park_notify: Arc::new(tokio::sync::Notify::new()),
+                reuse_state_notify: Arc::new(tokio::sync::Notify::new()),
             }
         }
 
@@ -927,7 +927,7 @@ mod tests {
                 factory: Arc::new(Box::new(sandbox_mock::MockSandboxFactory::new())),
                 idle_pool: Arc::clone(&self.idle_pool),
                 status: Arc::clone(&self.status),
-                park_notify: Arc::clone(&self.park_notify),
+                reuse_state_notify: Arc::clone(&self.reuse_state_notify),
                 workspace_cache_snapshot: WorkspaceCacheStateSnapshot::new(),
                 parking_gate: self.parking_gate.clone(),
                 network_log_drain: NetworkLogDrainCoordinator::noop(),
@@ -1151,13 +1151,20 @@ mod tests {
             ))
             .await;
         assert!(
-            fixture.park_notify.notified().now_or_never().is_some(),
+            fixture
+                .reuse_state_notify
+                .notified()
+                .now_or_never()
+                .is_some(),
             "finalizer should send the early park refresh"
         );
 
         let active_reuse_keys = super::super::active_reuse_keys::new_active_reuse_keys();
-        let active_reuse_key_guard =
-            ActiveReuseKeyGuard::new(Arc::clone(&active_reuse_keys), Some(session_id.to_owned()));
+        let active_reuse_key_guard = ActiveReuseKeyGuard::new(
+            Arc::clone(&active_reuse_keys),
+            Arc::clone(&fixture.reuse_state_notify),
+            Some(session_id.to_owned()),
+        );
         let (usage_flush_tx, _usage_flush_rx) = mpsc::channel(1);
 
         CompletionPhase {
@@ -1165,7 +1172,7 @@ mod tests {
             provider: Arc::new(NoopCompletionProvider),
             status: Arc::clone(&fixture.status),
             usage_flush_tx,
-            park_notify: Arc::clone(&fixture.park_notify),
+            reuse_state_notify: Arc::clone(&fixture.reuse_state_notify),
             active_reuse_key_guard,
             cleanup_state: RunCleanupState::new(),
         }
@@ -1180,7 +1187,11 @@ mod tests {
             "completion should release the active reuse-key guard before notifying"
         );
         assert!(
-            fixture.park_notify.notified().now_or_never().is_some(),
+            fixture
+                .reuse_state_notify
+                .notified()
+                .now_or_never()
+                .is_some(),
             "completion should send a post-guard-release refresh"
         );
     }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -64,8 +64,8 @@ use crate::network_log_manager::NetworkLogManager;
 use crate::paths::{HomePaths, LogPaths, RunnerPaths, touch_mtime};
 use crate::prefetch;
 use crate::provider::{
-    ApiProvider, ApiProviderConfig, BuiltinFirewallCatalogCachePaths, JobProvider, LocalProvider,
-    NetworkPolicyRefreshHandle,
+    ApiProvider, ApiProviderConfig, BuiltinFirewallCatalogCachePaths, JobCandidate, JobProvider,
+    LocalProvider, NetworkPolicyRefreshHandle,
 };
 use crate::proxy;
 use crate::resource_budget::ResourceBudget;
@@ -89,7 +89,7 @@ mod ownership;
 mod sandbox_finalization;
 mod signals;
 
-use active_reuse_keys::new_active_reuse_keys;
+use active_reuse_keys::{ActiveReuseKeys, new_active_reuse_keys};
 use factory_lifecycle::{shutdown_factory_instances, shutdown_runtime, start_factories};
 use heartbeat::{
     HEARTBEAT_PERIOD, HeartbeatContext, HeartbeatContextInit, HeartbeatController,
@@ -115,6 +115,44 @@ use signals::{
 };
 
 const READY_DIRECT_CANDIDATE_DRAIN_LIMIT: usize = 8;
+
+fn candidate_for_admission(
+    candidate: JobCandidate,
+    pending_candidate: &mut Option<JobCandidate>,
+) -> JobCandidate {
+    if let Some(pending) =
+        pending_candidate.take_if(|pending| pending.run_id() == candidate.run_id())
+    {
+        info!(
+            run_id = %candidate.run_id(),
+            "duplicate finalizing candidate rechecks retained admission state"
+        );
+        pending
+    } else {
+        candidate
+    }
+}
+
+fn retain_finalizing_candidate(
+    pending_candidate: &mut Option<JobCandidate>,
+    candidate: JobCandidate,
+) {
+    if pending_candidate.is_none() {
+        *pending_candidate = Some(candidate);
+    } else {
+        info!(
+            run_id = %candidate.run_id(),
+            "finalizing candidate not retained because the pending slot is occupied"
+        );
+    }
+}
+
+async fn sleep_until_optional_instant(deadline: Option<Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline.into()).await,
+        None => std::future::pending().await,
+    }
+}
 
 struct TeardownTimer {
     start: Instant,
@@ -717,6 +755,8 @@ async fn run_start_with_home(
         )
         .await?;
 
+    let active_reuse_keys = new_active_reuse_keys();
+    let reuse_state_notify = Arc::new(tokio::sync::Notify::new());
     let config = RunConfig {
         runner: RunnerInfo {
             id: runner_id,
@@ -743,6 +783,8 @@ async fn run_start_with_home(
             idle_pool,
             parking_gate,
             status,
+            active_reuse_keys,
+            reuse_state_notify,
         },
         provider: ProviderState {
             provider,
@@ -829,6 +871,8 @@ struct RunnerSharedState {
     idle_pool: SharedIdlePool,
     parking_gate: ParkingGate,
     status: Arc<StatusTracker>,
+    active_reuse_keys: ActiveReuseKeys,
+    reuse_state_notify: Arc<tokio::sync::Notify>,
 }
 
 struct ProviderState {
@@ -1340,12 +1384,12 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // Main loop
     // -----------------------------------------------------------------------
     // Notification channel: spawned jobs signal the main loop to send an
-    // immediate heartbeat after session affinity state changes, so the server
+    // immediate heartbeat after reusable state changes, so the server
     // learns about a held reusable sandbox or workspace image cache without
     // waiting for the next 10-second tick.
-    let park_notify = Arc::new(tokio::sync::Notify::new());
+    let reuse_state_notify = Arc::clone(&shared.reuse_state_notify);
     let orphaned_active_runs = OrphanedActiveRuns::new();
-    let active_reuse_keys = new_active_reuse_keys();
+    let active_reuse_keys = shared.active_reuse_keys.clone();
     let workspace_cache_snapshot = WorkspaceCacheStateSnapshot::new();
     let mut orphan_reap_tick = tokio::time::interval_at(
         tokio::time::Instant::now() + Duration::from_secs(10),
@@ -1389,7 +1433,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         status: Arc::clone(&shared.status),
         orphaned_active_runs: orphaned_active_runs.clone(),
         parking_gate: shared.parking_gate.clone(),
-        park_notify: Arc::clone(&park_notify),
+        reuse_state_notify: Arc::clone(&reuse_state_notify),
         usage_flush_tx,
         active_reuse_keys: active_reuse_keys.clone(),
         workspace_cache_snapshot,
@@ -1400,12 +1444,16 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         test_observer: test_hooks.test_observer.clone(),
     };
     let mut draining_idle_pool_drained = false;
+    let mut pending_finalizing_candidate = None;
     let mut terminal_error = None;
     loop {
         let mode = *mode_rx.borrow_and_update();
         if mode != current_mode {
             current_mode = mode;
             shared.status.set_mode(mode).await;
+        }
+        if mode != RunnerMode::Running {
+            pending_finalizing_candidate = None;
         }
         match mode {
             RunnerMode::Starting => {}
@@ -1458,7 +1506,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         "reclaiming expired idle VMs for resource pressure"
                     );
                     if destroy_idle_jobs_and_wait(expired, "budget_pressure_expired").await {
-                        park_notify.notify_one();
+                        reuse_state_notify.notify_one();
                     }
                     continue;
                 }
@@ -1475,6 +1523,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             test_hooks.test_observer.notify_budget_exhausted_reactor();
         }
         let heartbeat_sending = heartbeat.is_sending();
+        let pending_finalizing_deadline = pending_finalizing_candidate
+            .as_ref()
+            .and_then(JobCandidate::runner_preference)
+            .map(crate::provider::RunnerPreference::deadline);
         tokio::select! {
             // Job discovery via provider (Ably wakeups + HTTP poll).
             // The future is pinned outside the loop so heartbeat/cleanup
@@ -1483,9 +1535,15 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 let Some(candidate) = discovered else { break };
                 // Future completed — create a new one for the next discovery.
                 discover_fut = Box::pin(provider_state.provider.discover());
-                let mut needs_session_affinity_refresh = handle_discovered_job(
+                let candidate = candidate_for_admission(
+                    candidate,
+                    &mut pending_finalizing_candidate,
+                );
+                let result = handle_discovered_job(
                     DiscoveredJob { candidate },
                     DiscoveredJobContext {
+                        runner_id: &runner.id,
+                        heartbeat_generation: runner.heartbeat_generation,
                         profiles: &runner.profiles,
                         factories: &factories,
                         budget: &capacity.budget,
@@ -1498,6 +1556,14 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         jobs: &mut jobs,
                     },
                 ).await;
+                let mut needs_reuse_state_refresh =
+                    result.needs_reuse_state_refresh;
+                if let Some(candidate) = result.pending_candidate {
+                    retain_finalizing_candidate(
+                        &mut pending_finalizing_candidate,
+                        candidate,
+                    );
+                }
                 let mut drained_ready_candidates = 0;
                 while drained_ready_candidates < READY_DIRECT_CANDIDATE_DRAIN_LIMIT {
                     let live_mode = *mode_rx.borrow();
@@ -1515,9 +1581,15 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         break;
                     };
                     drained_ready_candidates += 1;
-                    let candidate_needs_session_affinity_refresh = handle_discovered_job(
+                    let candidate = candidate_for_admission(
+                        candidate,
+                        &mut pending_finalizing_candidate,
+                    );
+                    let result = handle_discovered_job(
                         DiscoveredJob { candidate },
                         DiscoveredJobContext {
+                            runner_id: &runner.id,
+                            heartbeat_generation: runner.heartbeat_generation,
                             profiles: &runner.profiles,
                             factories: &factories,
                             budget: &capacity.budget,
@@ -1530,16 +1602,22 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                             jobs: &mut jobs,
                         },
                     ).await;
-                    needs_session_affinity_refresh |= candidate_needs_session_affinity_refresh;
+                    needs_reuse_state_refresh |= result.needs_reuse_state_refresh;
+                    if let Some(candidate) = result.pending_candidate {
+                        retain_finalizing_candidate(
+                            &mut pending_finalizing_candidate,
+                            candidate,
+                        );
+                    }
                 }
                 let live_mode = *mode_rx.borrow();
-                if needs_session_affinity_refresh
+                if needs_reuse_state_refresh
                     && matches!(live_mode, RunnerMode::Running | RunnerMode::Draining)
                 {
                     info!(
                         source = "direct_candidate_batch",
                         drained_ready_candidates,
-                        "session affinity state triggered immediate heartbeat"
+                        "reusable state triggered immediate heartbeat"
                     );
                     heartbeat.request(live_mode)?;
                 }
@@ -1667,7 +1745,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             // Reap completed destroy tasks
             Some(result) = destroy_tasks.join_next(), if !destroy_tasks.is_empty() => {
                 match result {
-                    Ok(true) => park_notify.notify_one(),
+                    Ok(true) => reuse_state_notify.notify_one(),
                     Ok(false) => {}
                     Err(e) => warn!(error = %e, "destroy task panicked"),
                 }
@@ -1707,10 +1785,71 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 let live_mode = *mode_rx.borrow();
                 heartbeat.request(live_mode)?;
             }
-            // Immediate heartbeat after session affinity state changes —
-            // eliminates the up-to-10s blind spot for affinity routing.
-            _ = park_notify.notified(), if matches!(mode, RunnerMode::Running | RunnerMode::Draining) => {
+            _ = sleep_until_optional_instant(pending_finalizing_deadline),
+                if pending_finalizing_candidate.is_some() && mode == RunnerMode::Running =>
+            {
+                let Some(candidate) = pending_finalizing_candidate.take() else {
+                    continue;
+                };
+                let candidate = candidate.without_runner_preference();
+                let result = handle_discovered_job(
+                    DiscoveredJob { candidate },
+                    DiscoveredJobContext {
+                        runner_id: &runner.id,
+                        heartbeat_generation: runner.heartbeat_generation,
+                        profiles: &runner.profiles,
+                        factories: &factories,
+                        budget: &capacity.budget,
+                        idle_pool: &shared.idle_pool,
+                        status: &shared.status,
+                        mode_rx: &mode_rx,
+                        cancel_tokens: &provider_state.cancel_tokens,
+                        spawn_ctx: &spawn_ctx,
+                        destroy_tasks: &mut destroy_tasks,
+                        jobs: &mut jobs,
+                    },
+                ).await;
+                if let Some(candidate) = result.pending_candidate {
+                    retain_finalizing_candidate(
+                        &mut pending_finalizing_candidate,
+                        candidate,
+                    );
+                }
+                if result.needs_reuse_state_refresh {
+                    heartbeat.request(*mode_rx.borrow())?;
+                }
+            }
+            // Immediate heartbeat after reusable state changes eliminates the
+            // up-to-10s blind spot for reuse-aware routing.
+            _ = reuse_state_notify.notified(), if matches!(mode, RunnerMode::Running | RunnerMode::Draining) => {
                 let live_mode = *mode_rx.borrow();
+                if live_mode == RunnerMode::Running
+                    && let Some(candidate) = pending_finalizing_candidate.take()
+                {
+                    let result = handle_discovered_job(
+                        DiscoveredJob { candidate },
+                        DiscoveredJobContext {
+                            runner_id: &runner.id,
+                            heartbeat_generation: runner.heartbeat_generation,
+                            profiles: &runner.profiles,
+                            factories: &factories,
+                            budget: &capacity.budget,
+                            idle_pool: &shared.idle_pool,
+                            status: &shared.status,
+                            mode_rx: &mode_rx,
+                            cancel_tokens: &provider_state.cancel_tokens,
+                            spawn_ctx: &spawn_ctx,
+                            destroy_tasks: &mut destroy_tasks,
+                            jobs: &mut jobs,
+                        },
+                    ).await;
+                    if let Some(candidate) = result.pending_candidate {
+                        retain_finalizing_candidate(
+                            &mut pending_finalizing_candidate,
+                            candidate,
+                        );
+                    }
+                }
                 let source = match live_mode {
                     RunnerMode::Running if can_discover => "main",
                     RunnerMode::Running => "budget_exhausted",
@@ -1720,7 +1859,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     }
                 };
                 if matches!(live_mode, RunnerMode::Running | RunnerMode::Draining) {
-                    info!(source, "session affinity state triggered immediate heartbeat");
+                    info!(source, "reusable state triggered immediate heartbeat");
                     heartbeat.request(live_mode)?;
                 }
             }

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -96,7 +96,7 @@ pub(super) struct FinalizeContext {
     pub(super) factory: Arc<Box<dyn SandboxFactory>>,
     pub(super) idle_pool: SharedIdlePool,
     pub(super) status: Arc<StatusTracker>,
-    pub(super) park_notify: Arc<tokio::sync::Notify>,
+    pub(super) reuse_state_notify: Arc<tokio::sync::Notify>,
     pub(super) workspace_cache_snapshot: WorkspaceCacheStateSnapshot,
     pub(super) parking_gate: ParkingGate,
     pub(super) network_log_drain: NetworkLogDrainCoordinator,
@@ -136,7 +136,7 @@ pub(super) async fn finalize_sandbox_for_completion(
         factory,
         idle_pool,
         status,
-        park_notify,
+        reuse_state_notify,
         workspace_cache_snapshot,
         parking_gate,
         network_log_drain,
@@ -457,7 +457,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                             .publish_idle_status_after_pool_transfer(snapshot)
                             .await;
                         session_affinity_changed = true;
-                        park_notify.notify_one();
+                        reuse_state_notify.notify_one();
                         BudgetOwnership::idle_owned()
                     }
                     ParkResult::Replaced(evicted) => {
@@ -482,13 +482,13 @@ pub(super) async fn finalize_sandbox_for_completion(
                             .publish_idle_status_after_pool_transfer(snapshot)
                             .await;
                         session_affinity_changed = true;
-                        park_notify.notify_one();
+                        reuse_state_notify.notify_one();
                         // The replaced VM was park()ed when it entered the
                         // pool; destroying a parked sandbox is safe — Drop
                         // aborts any leftover handles and the FC process is
                         // killed regardless of balloon state.
                         if destroy_idle_jobs_and_wait(vec![evicted], "park_replaced").await {
-                            park_notify.notify_one();
+                            reuse_state_notify.notify_one();
                         }
                         BudgetOwnership::idle_owned()
                     }
@@ -865,7 +865,7 @@ mod tests {
                 factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
                 idle_pool: Arc::clone(&self.idle_pool),
                 status: Arc::clone(&self.status),
-                park_notify: Arc::new(tokio::sync::Notify::new()),
+                reuse_state_notify: Arc::new(tokio::sync::Notify::new()),
                 workspace_cache_snapshot: WorkspaceCacheStateSnapshot::new(),
                 parking_gate: self.parking_gate.clone(),
                 network_log_drain: NetworkLogDrainCoordinator::noop(),
@@ -2354,7 +2354,7 @@ mod tests {
             ParkResult::Parked
         ));
 
-        let park_notify = Arc::new(tokio::sync::Notify::new());
+        let reuse_state_notify = Arc::new(tokio::sync::Notify::new());
         let (_budget, lease) = test_budget_lease();
         let network_log_session = fixture.network_log_session().await;
         let new_run_id = RunId::new_v4();
@@ -2366,7 +2366,7 @@ mod tests {
             network_log_session,
             RunCancellationHandle::new(),
         );
-        context.park_notify = Arc::clone(&park_notify);
+        context.reuse_state_notify = Arc::clone(&reuse_state_notify);
 
         let finalize_task = tokio::spawn(finalize_sandbox_for_completion(
             Some(Box::new(mock_sandbox_ready_for_idle_reuse(
@@ -2389,14 +2389,14 @@ mod tests {
             .await
             .expect("replaced idle destroy should reach destroy gate");
         assert!(
-            park_notify.notified().now_or_never().is_some(),
+            reuse_state_notify.notified().now_or_never().is_some(),
             "newly parked replacement should notify before replaced destroy finishes"
         );
 
         destroy_gate.release_one();
         let _completion_ready = finalize_task.await.expect("finalizer task should join");
         assert!(
-            park_notify.notified().now_or_never().is_some(),
+            reuse_state_notify.notified().now_or_never().is_some(),
             "replaced idle workspace cache promotion should notify after destroy"
         );
         assert!(

--- a/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
@@ -5,18 +5,11 @@ use super::super::support::{
     wait_budget_count, wait_idle_pool_len, wait_status_idle_empty_with_active_run,
 };
 
-use crate::types::{SandboxReuseResult, SessionAffinityResource};
-
-const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
+use crate::types::SandboxReuseResult;
 
 fn reusable_candidate(run_id: RunId, session_id: &str) -> crate::provider::JobCandidate {
     crate::provider::JobCandidate::new(run_id, "vm0/default".into())
-        .with_affinity_metadata(
-            Some(session_id.to_string()),
-            Some(session_id.to_string()),
-            Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
-        )
-        .with_session_affinity_resource(Some(SessionAffinityResource::ReusableSandbox))
+        .with_reuse_key(Some(session_id.to_string()))
 }
 
 /// When the runner takes a sandbox out of the idle pool for reuse and

--- a/crates/runner/src/cmd/start/tests/idle_reuse/affinity.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/affinity.rs
@@ -122,11 +122,7 @@ async fn invalid_reserved_resume_session_fails_before_reuse() {
         .discover_tx
         .send(
             crate::provider::JobCandidate::new(run_id, "vm0/default".into())
-                .with_affinity_metadata(
-                    Some(reuse_key.to_string()),
-                    Some(invalid_session_id.to_string()),
-                    None,
-                ),
+                .with_reuse_key(Some(reuse_key.to_string())),
         )
         .unwrap();
 

--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -7,24 +7,16 @@ use super::super::support::{
 };
 
 use crate::paths::RunnerPaths;
-use crate::types::{SandboxReuseResult, SessionAffinityResource};
+use crate::types::SandboxReuseResult;
 use crate::workspace_image_cache::WorkspaceImageCache;
-
-const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
 
 fn reusable_candidate(
     run_id: RunId,
     profile_name: &str,
     reuse_key: &str,
-    provider_session_id: &str,
 ) -> crate::provider::JobCandidate {
     crate::provider::JobCandidate::new(run_id, profile_name.to_string())
-        .with_affinity_metadata(
-            Some(reuse_key.to_string()),
-            Some(provider_session_id.to_string()),
-            Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
-        )
-        .with_session_affinity_resource(Some(SessionAffinityResource::ReusableSandbox))
+        .with_reuse_key(Some(reuse_key.to_string()))
 }
 
 async fn wait_heartbeat_with_workspace_after(
@@ -215,12 +207,7 @@ async fn workspace_promotion_mismatch_destroys_stale_idle_vm_and_fresh_creates()
     env.provider.set_claim_result(run_id, Some(context));
     env.handle
         .discover_tx
-        .send(reusable_candidate(
-            run_id,
-            "vm0/default",
-            reuse_key,
-            provider_session_id,
-        ))
+        .send(reusable_candidate(run_id, "vm0/default", reuse_key))
         .unwrap();
 
     let completion = env

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -1,59 +1,111 @@
 use super::super::super::*;
 use super::super::support::{
-    assert_run_exits_within, context_with_session, minimal_context, mock_run_config,
-    mock_run_config_with_overrides, push_job, seed_idle_pool,
+    TEST_HEARTBEAT_GENERATION, TEST_RUNNER_ID, assert_run_exits_within, context_with_session,
+    minimal_context, mock_run_config, mock_run_config_with_overrides, push_job, seed_idle_pool,
     seed_idle_pool_with_history_generation, seed_idle_pool_with_overrides,
     seed_workspace_cache_state, shutdown, test_profiles, wait_budget_count, wait_cancel_token,
     wait_cancel_token_removed, wait_discover_entered,
 };
-use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use std::sync::Arc;
 
+use super::super::super::active_reuse_keys::ActiveReuseKeyGuard;
 use crate::paths::RunnerPaths;
-use crate::types::{SandboxReuseResult, SessionAffinityResource};
+use crate::provider::{RunnerPreference, RunnerPreferenceReason};
+use crate::types::SandboxReuseResult;
 use crate::workspace_image_cache::WorkspaceImageCache;
 
-const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
+const NON_SELECTED_RUNNER_ID: u128 = 1;
 
-fn affinity_protected_candidate(run_id: RunId, session_id: &str) -> crate::provider::JobCandidate {
-    crate::provider::JobCandidate::new(run_id, "vm0/default".into()).with_affinity_metadata(
-        Some(session_id.to_string()),
-        Some(session_id.to_string()),
-        Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
+fn preferred_candidate(
+    run_id: RunId,
+    reuse_key: Option<&str>,
+    reason: RunnerPreferenceReason,
+) -> crate::provider::JobCandidate {
+    preferred_candidate_until(
+        run_id,
+        reuse_key,
+        reason,
+        std::time::Instant::now() + Duration::from_secs(30),
     )
 }
 
-fn reusable_affinity_protected_candidate(
+fn preferred_candidate_until(
     run_id: RunId,
-    session_id: &str,
+    reuse_key: Option<&str>,
+    reason: RunnerPreferenceReason,
+    deadline: std::time::Instant,
 ) -> crate::provider::JobCandidate {
-    affinity_protected_candidate(run_id, session_id)
-        .with_session_affinity_resource(Some(SessionAffinityResource::ReusableSandbox))
+    crate::provider::JobCandidate::new(run_id, "vm0/default".into())
+        .with_reuse_key(reuse_key.map(str::to_owned))
+        .with_runner_preference(Some(RunnerPreference::for_test(
+            uuid::Uuid::from_u128(NON_SELECTED_RUNNER_ID),
+            1,
+            reason,
+            deadline,
+        )))
 }
 
-fn workspace_affinity_protected_candidate(
-    run_id: RunId,
-    session_id: &str,
-) -> crate::provider::JobCandidate {
-    affinity_protected_candidate(run_id, session_id)
-        .with_session_affinity_resource(Some(SessionAffinityResource::WorkspaceCache))
+fn matching_preference_candidate(run_id: RunId, session_id: &str) -> crate::provider::JobCandidate {
+    preferred_candidate(
+        run_id,
+        Some(session_id),
+        RunnerPreferenceReason::MatchingReuseKey,
+    )
 }
 
-fn generation_affinity_protected_candidate(
+fn exact_generation_preference_candidate(
     run_id: RunId,
     session_id: &str,
     target_generation_run_id: RunId,
 ) -> crate::provider::JobCandidate {
+    preferred_candidate(
+        run_id,
+        Some(session_id),
+        RunnerPreferenceReason::ExactHistoryGeneration,
+    )
+    .with_history_generation_run_id(Some(target_generation_run_id))
+}
+
+fn finalizing_candidate(
+    run_id: RunId,
+    reuse_key: &str,
+    history_generation_run_id: RunId,
+    runner_id: &str,
+    heartbeat_generation: u64,
+) -> crate::provider::JobCandidate {
+    finalizing_candidate_until(
+        run_id,
+        reuse_key,
+        history_generation_run_id,
+        runner_id,
+        heartbeat_generation,
+        std::time::Instant::now() + Duration::from_secs(30),
+    )
+}
+
+fn finalizing_candidate_until(
+    run_id: RunId,
+    reuse_key: &str,
+    history_generation_run_id: RunId,
+    runner_id: &str,
+    heartbeat_generation: u64,
+    deadline: std::time::Instant,
+) -> crate::provider::JobCandidate {
     crate::provider::JobCandidate::new(run_id, "vm0/default".into())
-        .with_affinity_metadata(
-            Some(session_id.to_string()),
-            Some(session_id.to_string()),
-            Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
-        )
-        .with_history_generation_run_id(Some(target_generation_run_id))
-        .with_history_generation_affinity_protected_until(Some(
-            FUTURE_AFFINITY_PROTECTED_UNTIL.to_string(),
-        ))
+        .with_reuse_key(Some(reuse_key.to_owned()))
+        .with_history_generation_run_id(Some(history_generation_run_id))
+        .with_runner_preference(Some(RunnerPreference::for_test(
+            runner_id.parse().unwrap(),
+            heartbeat_generation,
+            RunnerPreferenceReason::FinalizingPredecessor,
+            deadline,
+        )))
+}
+
+fn context_with_reuse_key(run_id: RunId, reuse_key: &str) -> crate::types::ExecutionContext {
+    let mut context = minimal_context(run_id);
+    context.reuse_key = Some(reuse_key.to_owned());
+    context
 }
 
 /// TOCTOU regression: soft drain can arrive after the main loop has selected
@@ -287,7 +339,7 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
     env.provider.set_claim_result(conflict_run_id, None);
     env.handle
         .discover_tx
-        .send(generation_affinity_protected_candidate(
+        .send(exact_generation_preference_candidate(
             conflict_run_id,
             session_id,
             reserved_generation_run_id,
@@ -315,7 +367,7 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
     env.handle
         .discover_tx
         .send(
-            reusable_affinity_protected_candidate(followup_run_id, session_id)
+            matching_preference_candidate(followup_run_id, session_id)
                 .with_history_generation_run_id(Some(followup_target_generation_run_id)),
         )
         .unwrap();
@@ -329,7 +381,7 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn reusable_affinity_reservation_is_restored_after_claim_conflict() {
+async fn matching_preference_reservation_is_restored_after_claim_conflict() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);
     let idle_pool = Arc::clone(&env.idle_pool);
@@ -342,7 +394,7 @@ async fn reusable_affinity_reservation_is_restored_after_claim_conflict() {
     env.provider.set_claim_result(run_id, None);
     env.handle
         .discover_tx
-        .send(reusable_affinity_protected_candidate(run_id, session_id))
+        .send(matching_preference_candidate(run_id, session_id))
         .unwrap();
 
     wait_discover_entered(&env, Duration::from_secs(5)).await;
@@ -382,7 +434,7 @@ async fn reusable_claim_without_generation_target_reuses_sandbox() {
         .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
     env.handle
         .discover_tx
-        .send(reusable_affinity_protected_candidate(run_id, session_id))
+        .send(matching_preference_candidate(run_id, session_id))
         .unwrap();
 
     let completion = env
@@ -397,8 +449,8 @@ async fn reusable_claim_without_generation_target_reuses_sandbox() {
         .find(|candidate| candidate.run_id() == run_id)
         .expect("missing-target reusable candidate should reach claim");
     assert_eq!(
-        candidate.session_affinity_resource(),
-        Some(SessionAffinityResource::ReusableSandbox)
+        candidate.runner_preference().map(RunnerPreference::reason),
+        Some(RunnerPreferenceReason::MatchingReuseKey)
     );
 
     shutdown(&env, run_handle).await;
@@ -430,7 +482,7 @@ async fn generation_protected_different_idle_sandbox_defers_before_claim() {
         .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
     env.handle
         .discover_tx
-        .send(generation_affinity_protected_candidate(
+        .send(exact_generation_preference_candidate(
             run_id,
             session_id,
             target_generation_run_id,
@@ -458,7 +510,7 @@ async fn generation_protected_different_idle_sandbox_defers_before_claim() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn affinity_protected_candidate_without_local_session_defers_before_claim() {
+async fn matching_preference_without_local_resource_defers_before_claim() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
@@ -472,7 +524,7 @@ async fn affinity_protected_candidate_without_local_session_defers_before_claim(
     );
     env.handle
         .discover_tx
-        .send(reusable_affinity_protected_candidate(
+        .send(matching_preference_candidate(
             run_id,
             "sess-owned-elsewhere",
         ))
@@ -489,14 +541,351 @@ async fn affinity_protected_candidate_without_local_session_defers_before_claim(
     assert_eq!(
         env.handle.deferred_poll_delays().len(),
         1,
-        "runner should schedule a follow-up poll after the affinity protection expires"
+        "runner should schedule a follow-up poll after the preference expires"
     );
 
     shutdown(&env, run_handle).await;
 }
 
+#[tokio::test]
+async fn selected_finalizing_candidate_keeps_reactor_live_and_claims_after_key_release() {
+    let (config, env) = mock_run_config(test_profiles(), 4, 8192, 2);
+    let reuse_key = "thread:pending-finalization";
+    let history_generation_run_id = RunId::new_v4();
+    let predecessor_guard = ActiveReuseKeyGuard::new(
+        env.active_reuse_keys.clone(),
+        Arc::clone(&env.reuse_state_notify),
+        Some(reuse_key.to_owned()),
+    );
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let pending_run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        pending_run_id,
+        Some(context_with_reuse_key(pending_run_id, reuse_key)),
+    );
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate(
+            pending_run_id,
+            reuse_key,
+            history_generation_run_id,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+        ))
+        .unwrap();
+
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    assert!(
+        env.handle.claim_candidates().is_empty(),
+        "selected finalizing candidate should remain unclaimed while the key is active"
+    );
+
+    let unrelated_run_id = RunId::new_v4();
+    push_job(
+        &env,
+        unrelated_run_id,
+        "vm0/default",
+        Some(minimal_context(unrelated_run_id)),
+    );
+    assert!(
+        env.handle
+            .wait_completion(unrelated_run_id, Duration::from_secs(5))
+            .await
+            .is_some(),
+        "unrelated work should continue while a finalizing candidate is pending"
+    );
+
+    drop(predecessor_guard);
+    assert!(
+        env.handle
+            .wait_completion(pending_run_id, Duration::from_secs(5))
+            .await
+            .is_some(),
+        "active-key release without a reusable resource should wake ordinary admission"
+    );
+    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn selected_finalizing_candidate_claims_exact_resource_on_reuse_state_wakeup() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let reuse_key = "thread:pending-exact-resource";
+    let history_generation_run_id = RunId::new_v4();
+    let predecessor_guard = ActiveReuseKeyGuard::new(
+        env.active_reuse_keys.clone(),
+        Arc::clone(&env.reuse_state_notify),
+        Some(reuse_key.to_owned()),
+    );
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate(
+            run_id,
+            reuse_key,
+            history_generation_run_id,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    seed_idle_pool_with_history_generation(
+        &env.idle_pool,
+        &budget,
+        reuse_key,
+        "vm0/default",
+        2,
+        4096,
+        history_generation_run_id,
+    )
+    .await;
+    env.reuse_state_notify.notify_one();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("exact resource state should wake the retained candidate");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    drop(predecessor_guard);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn non_selected_finalizing_candidate_is_not_retained() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let reuse_key = "thread:non-selected-finalization";
+    let predecessor_guard = ActiveReuseKeyGuard::new(
+        env.active_reuse_keys.clone(),
+        Arc::clone(&env.reuse_state_notify),
+        Some(reuse_key.to_owned()),
+    );
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate(
+            run_id,
+            reuse_key,
+            RunId::new_v4(),
+            &uuid::Uuid::from_u128(NON_SELECTED_RUNNER_ID).to_string(),
+            1,
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    drop(predecessor_guard);
+    tokio::task::yield_now().await;
+    assert!(env.handle.claim_candidates().is_empty());
+    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
 #[tokio::test(start_paused = true)]
-async fn affinity_protected_candidate_without_session_metadata_defers_before_claim() {
+async fn same_run_duplicate_does_not_renew_pending_finalizing_deadline() {
+    let (config, env) = mock_run_config(test_profiles(), 4, 8192, 2);
+    let reuse_key = "thread:pending-duplicate";
+    let history_generation_run_id = RunId::new_v4();
+    let predecessor_guard = ActiveReuseKeyGuard::new(
+        env.active_reuse_keys.clone(),
+        Arc::clone(&env.reuse_state_notify),
+        Some(reuse_key.to_owned()),
+    );
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
+    let original_deadline = std::time::Instant::now() + Duration::from_millis(100);
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate_until(
+            run_id,
+            reuse_key,
+            history_generation_run_id,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+            original_deadline,
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate_until(
+            run_id,
+            reuse_key,
+            history_generation_run_id,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+            std::time::Instant::now() + Duration::from_secs(30),
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    assert!(env.handle.claim_candidates().is_empty());
+
+    tokio::time::advance(Duration::from_millis(101)).await;
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await;
+    assert!(
+        completion.is_some(),
+        "the original deadline should enter ordinary admission despite a later duplicate"
+    );
+    let claimed = env
+        .handle
+        .claim_candidates()
+        .into_iter()
+        .find(|candidate| candidate.run_id() == run_id)
+        .expect("expired pending candidate should reach claim");
+    assert!(
+        claimed.runner_preference().is_none(),
+        "expiry should clear the advisory preference before ordinary admission"
+    );
+
+    drop(predecessor_guard);
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn pending_slot_overflow_does_not_retain_a_distinct_candidate() {
+    let (config, env) = mock_run_config(test_profiles(), 6, 12288, 3);
+    let first_reuse_key = "thread:pending-slot-first";
+    let second_reuse_key = "thread:pending-slot-second";
+    let first_guard = ActiveReuseKeyGuard::new(
+        env.active_reuse_keys.clone(),
+        Arc::clone(&env.reuse_state_notify),
+        Some(first_reuse_key.to_owned()),
+    );
+    let second_guard = ActiveReuseKeyGuard::new(
+        env.active_reuse_keys.clone(),
+        Arc::clone(&env.reuse_state_notify),
+        Some(second_reuse_key.to_owned()),
+    );
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let first_run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        first_run_id,
+        Some(context_with_reuse_key(first_run_id, first_reuse_key)),
+    );
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate(
+            first_run_id,
+            first_reuse_key,
+            RunId::new_v4(),
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let second_run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        second_run_id,
+        Some(context_with_reuse_key(second_run_id, second_reuse_key)),
+    );
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate(
+            second_run_id,
+            second_reuse_key,
+            RunId::new_v4(),
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    drop(second_guard);
+    tokio::task::yield_now().await;
+    assert!(
+        !env.handle
+            .claim_candidates()
+            .iter()
+            .any(|candidate| candidate.run_id() == second_run_id),
+        "a distinct overflow candidate should rely on durable provider fallback"
+    );
+
+    drop(first_guard);
+    assert!(
+        env.handle
+            .wait_completion(first_run_id, Duration::from_secs(5))
+            .await
+            .is_some(),
+        "the original pending slot should still wake and claim"
+    );
+    assert!(
+        !env.handle
+            .claim_candidates()
+            .iter()
+            .any(|candidate| candidate.run_id() == second_run_id)
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn drain_discards_pending_finalizing_candidate_without_claiming() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let reuse_key = "thread:pending-drain";
+    let predecessor_guard = ActiveReuseKeyGuard::new(
+        env.active_reuse_keys.clone(),
+        Arc::clone(&env.reuse_state_notify),
+        Some(reuse_key.to_owned()),
+    );
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate(
+            run_id,
+            reuse_key,
+            RunId::new_v4(),
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    env.drain();
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "drain should discard process-local pending admission and exit",
+    )
+    .await;
+    assert!(env.handle.claim_candidates().is_empty());
+
+    drop(predecessor_guard);
+}
+
+#[tokio::test(start_paused = true)]
+async fn preference_without_reuse_key_uses_ordinary_admission() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
@@ -508,31 +897,29 @@ async fn affinity_protected_candidate_without_session_metadata_defers_before_cla
         .set_claim_result(run_id, Some(minimal_context(run_id)));
     env.handle
         .discover_tx
-        .send(
-            crate::provider::JobCandidate::new(run_id, "vm0/default".into())
-                .with_affinity_metadata(
-                    None,
-                    None,
-                    Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
-                )
-                .with_session_affinity_resource(Some(SessionAffinityResource::ReusableSandbox)),
-        )
+        .send(preferred_candidate(
+            run_id,
+            None,
+            RunnerPreferenceReason::MatchingReuseKey,
+        ))
         .unwrap();
 
-    wait_discover_entered(&env, Duration::from_secs(5)).await;
-    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
-    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await;
     assert!(
-        env.handle.claim_candidates().is_empty(),
-        "a protected candidate without session metadata must not reach claim"
+        completion.is_some(),
+        "incomplete preference metadata is advisory"
     );
-    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
+    assert!(env.handle.deferred_poll_delays().is_empty());
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
 
     shutdown(&env, run_handle).await;
 }
 
 #[tokio::test(start_paused = true)]
-async fn affinity_protected_candidate_without_resource_defers_even_when_session_is_local() {
+async fn matching_preference_uses_actual_local_sandbox_without_resource_class() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);
     let idle_pool = Arc::clone(&env.idle_pool);
@@ -547,26 +934,22 @@ async fn affinity_protected_candidate_without_resource_defers_even_when_session_
         .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
     env.handle
         .discover_tx
-        .send(affinity_protected_candidate(run_id, session_id))
+        .send(matching_preference_candidate(run_id, session_id))
         .unwrap();
 
-    wait_discover_entered(&env, Duration::from_secs(5)).await;
-    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
-    assert!(
-        env.handle.claim_candidates().is_empty(),
-        "a protected candidate without a typed resource must not use legacy local admission"
-    );
-    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
-    assert_eq!(
-        idle_pool.lock().await.held_reuse_keys(),
-        vec![session_id.to_string()]
-    );
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("actual compatible sandbox should satisfy matching preference");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    assert!(env.handle.deferred_poll_delays().is_empty());
 
     shutdown(&env, run_handle).await;
 }
 
 #[tokio::test(start_paused = true)]
-async fn ready_direct_drain_continues_after_affinity_defer() {
+async fn ready_direct_drain_continues_after_preference_defer() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let run_handle = tokio::spawn(run(config));
 
@@ -585,7 +968,7 @@ async fn ready_direct_drain_continues_after_affinity_defer() {
     env.provider
         .set_claim_result(followup_run_id, Some(minimal_context(followup_run_id)));
     env.handle
-        .push_ready_candidate(affinity_protected_candidate(
+        .push_ready_candidate(matching_preference_candidate(
             protected_run_id,
             "sess-owned-elsewhere",
         ));
@@ -742,11 +1125,13 @@ async fn expired_generation_protection_preserves_local_session_claim() {
     env.handle
         .discover_tx
         .send(
-            workspace_affinity_protected_candidate(run_id, "sess-held-local")
-                .with_history_generation_run_id(Some(RunId::new_v4()))
-                .with_history_generation_affinity_protected_until(Some(
-                    "2000-01-01T00:00:00Z".to_string(),
-                )),
+            preferred_candidate_until(
+                run_id,
+                Some("sess-held-local"),
+                RunnerPreferenceReason::ExactHistoryGeneration,
+                std::time::Instant::now() - Duration::from_secs(1),
+            )
+            .with_history_generation_run_id(Some(RunId::new_v4())),
         )
         .unwrap();
 
@@ -776,7 +1161,7 @@ async fn expired_generation_protection_preserves_local_session_claim() {
 }
 
 #[tokio::test]
-async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspace() {
+async fn exact_preference_defers_for_cache_then_matching_preference_claims_it() {
     let reuse_key = "thread:cache-local";
     let provider_session_id = "provider-session-cache-local";
     let image_size_bytes = 1024 * 1024;
@@ -797,18 +1182,6 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
         image_size_bytes,
     )
     .await;
-    let cache_key = crate::paths::scoped_workspace_image_cache_key(
-        &config.runner.group,
-        "vm0/default",
-        reuse_key,
-        CANONICAL_WORKING_DIR,
-        image_size_bytes,
-    );
-    let cache_entry_dir = config
-        .paths
-        .home
-        .workspace_image_cache_dir()
-        .join(cache_key);
     Arc::get_mut(&mut config.exec_config)
         .unwrap()
         .workspace_cache = Some(workspace_cache);
@@ -816,36 +1189,15 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
 
     wait_discover_entered(&env, Duration::from_secs(2)).await;
 
-    let reusable_protected_run_id = RunId::new_v4();
-    let mut reusable_context = context_with_session(reusable_protected_run_id, provider_session_id);
-    reusable_context.reuse_key = Some(reuse_key.into());
+    let exact_run_id = RunId::new_v4();
+    let mut exact_context = context_with_session(exact_run_id, provider_session_id);
+    exact_context.reuse_key = Some(reuse_key.into());
     env.provider
-        .set_claim_result(reusable_protected_run_id, Some(reusable_context));
+        .set_claim_result(exact_run_id, Some(exact_context));
     env.handle
         .discover_tx
-        .send(reusable_affinity_protected_candidate(
-            reusable_protected_run_id,
-            reuse_key,
-        ))
-        .unwrap();
-    wait_discover_entered(&env, Duration::from_secs(5)).await;
-    assert!(
-        env.handle.claim_candidates().is_empty(),
-        "workspace-only state must not satisfy reusable-sandbox selection"
-    );
-    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
-
-    tokio::fs::remove_dir_all(&cache_entry_dir).await.unwrap();
-    let generation_protected_run_id = RunId::new_v4();
-    let mut generation_context =
-        context_with_session(generation_protected_run_id, provider_session_id);
-    generation_context.reuse_key = Some(reuse_key.into());
-    env.provider
-        .set_claim_result(generation_protected_run_id, Some(generation_context));
-    env.handle
-        .discover_tx
-        .send(generation_affinity_protected_candidate(
-            generation_protected_run_id,
+        .send(exact_generation_preference_candidate(
+            exact_run_id,
             reuse_key,
             RunId::new_v4(),
         ))
@@ -853,9 +1205,9 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     assert!(
         env.handle.claim_candidates().is_empty(),
-        "workspace-cache state and fresh capacity must not impersonate an exact reusable generation"
+        "workspace-cache state must not impersonate an exact reusable generation"
     );
-    assert_eq!(env.handle.deferred_poll_delays().len(), 2);
+    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
 
     let run_id = RunId::new_v4();
     let mut workspace_context = context_with_session(run_id, provider_session_id);
@@ -864,10 +1216,7 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
         .set_claim_result(run_id, Some(workspace_context));
     env.handle
         .discover_tx
-        .send(
-            workspace_affinity_protected_candidate(run_id, reuse_key)
-                .with_history_generation_run_id(Some(RunId::new_v4())),
-        )
+        .send(matching_preference_candidate(run_id, reuse_key))
         .unwrap();
 
     let completion = env
@@ -879,18 +1228,9 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
         "runner should claim from the startup workspace-cache snapshot even if a later scan would miss"
     );
 
-    let claim_candidates = env.handle.claim_candidates();
-    let claimed_candidate = claim_candidates
-        .iter()
-        .find(|candidate| candidate.run_id() == run_id)
-        .expect("claim should record the protected candidate");
-    assert_eq!(
-        claimed_candidate.session_affinity_resource(),
-        Some(SessionAffinityResource::WorkspaceCache)
-    );
     assert_eq!(
         env.handle.deferred_poll_delays().len(),
-        2,
+        1,
         "the workspace-selected candidate should not add another deferral"
     );
 
@@ -943,13 +1283,13 @@ async fn saturated_cache_only_holder_defers_before_reclaiming_unrelated_idle() {
     env.provider.set_claim_result(run_id, Some(context));
     env.handle
         .discover_tx
-        .send(workspace_affinity_protected_candidate(run_id, reuse_key))
+        .send(matching_preference_candidate(run_id, reuse_key))
         .unwrap();
 
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     assert!(
         env.handle.claim_candidates().is_empty(),
-        "cache-only affinity must not bypass exhausted fresh admission"
+        "a cache-only preference must not bypass exhausted fresh admission"
     );
     assert_eq!(
         env.handle.deferred_poll_delays().len(),
@@ -959,7 +1299,7 @@ async fn saturated_cache_only_holder_defers_before_reclaiming_unrelated_idle() {
     assert_eq!(
         idle_pool.lock().await.held_reuse_keys(),
         vec!["sess-unrelated-idle".to_string()],
-        "affinity deferral must happen before candidate-aware reclamation"
+        "preference deferral must happen before candidate-aware reclamation"
     );
     assert_eq!(budget.allocated(), (2, 4096, 1));
 
@@ -967,7 +1307,7 @@ async fn saturated_cache_only_holder_defers_before_reclaiming_unrelated_idle() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn ready_direct_drain_batches_session_affinity_heartbeat() {
+async fn ready_direct_drain_batches_reuse_state_heartbeat() {
     let wait_gate = sandbox_mock::MockLifecycleGate::new();
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
@@ -1040,7 +1380,7 @@ async fn ready_direct_drain_batches_session_affinity_heartbeat() {
     assert_eq!(
         env.handle.heartbeat_count(),
         heartbeat_count + 1,
-        "direct-candidate drain should batch session-affinity refresh into one heartbeat"
+        "direct-candidate drain should batch reuse-state refresh into one heartbeat"
     );
 
     let claimed_run_ids: std::collections::HashSet<RunId> = env
@@ -1142,12 +1482,12 @@ async fn duplicate_discovery_deduplicated() {
     let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
     wait_discover_entered(&env, Duration::from_secs(5)).await;
 
-    // Push the same run_id again with reusable affinity. The duplicate first
+    // Push the same run_id again with a matching-reuse preference. The duplicate first
     // owns the idle reservation, then must restore it when the cancellation
     // registry reports that the original run already owns local admission.
     env.handle
         .discover_tx
-        .send(reusable_affinity_protected_candidate(run_id, session_id))
+        .send(matching_preference_candidate(run_id, session_id))
         .unwrap();
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     assert_eq!(

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -494,7 +494,7 @@ async fn generation_protected_different_idle_sandbox_defers_before_claim() {
         env.handle.claim_candidates().is_empty(),
         "a different reusable generation must not reach claim during exact protection"
     );
-    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
+    assert_eq!(env.handle.deferred_poll_deadlines().len(), 1);
     let pool = idle_pool.lock().await;
     assert_eq!(pool.held_reuse_keys(), vec![session_id.to_string()]);
     assert_eq!(
@@ -539,7 +539,7 @@ async fn matching_preference_without_local_resource_defers_before_claim() {
         "runner must not claim a protected same-reuse-key candidate without local reusable state"
     );
     assert_eq!(
-        env.handle.deferred_poll_delays().len(),
+        env.handle.deferred_poll_deadlines().len(),
         1,
         "runner should schedule a follow-up poll after the preference expires"
     );
@@ -605,7 +605,7 @@ async fn selected_finalizing_candidate_keeps_reactor_live_and_claims_after_key_r
             .is_some(),
         "active-key release without a reusable resource should wake ordinary admission"
     );
-    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
+    assert_eq!(env.handle.deferred_poll_deadlines().len(), 1);
 
     shutdown(&env, run_handle).await;
 }
@@ -692,7 +692,7 @@ async fn non_selected_finalizing_candidate_is_not_retained() {
     drop(predecessor_guard);
     tokio::task::yield_now().await;
     assert!(env.handle.claim_candidates().is_empty());
-    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
+    assert_eq!(env.handle.deferred_poll_deadlines().len(), 1);
 
     shutdown(&env, run_handle).await;
 }
@@ -740,6 +740,11 @@ async fn same_run_duplicate_does_not_renew_pending_finalizing_deadline() {
         .unwrap();
     wait_discover_entered(&env, Duration::from_secs(2)).await;
     assert!(env.handle.claim_candidates().is_empty());
+    assert_eq!(
+        env.handle.deferred_poll_deadlines(),
+        vec![original_deadline, original_deadline],
+        "duplicate rechecks must forward the original absolute deadline"
+    );
 
     tokio::time::advance(Duration::from_millis(101)).await;
     let completion = env
@@ -912,7 +917,7 @@ async fn preference_without_reuse_key_uses_ordinary_admission() {
         completion.is_some(),
         "incomplete preference metadata is advisory"
     );
-    assert!(env.handle.deferred_poll_delays().is_empty());
+    assert!(env.handle.deferred_poll_deadlines().is_empty());
     wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
 
     shutdown(&env, run_handle).await;
@@ -943,7 +948,7 @@ async fn matching_preference_uses_actual_local_sandbox_without_resource_class() 
         .await
         .expect("actual compatible sandbox should satisfy matching preference");
     assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
-    assert!(env.handle.deferred_poll_delays().is_empty());
+    assert!(env.handle.deferred_poll_deadlines().is_empty());
 
     shutdown(&env, run_handle).await;
 }
@@ -1023,7 +1028,7 @@ async fn ready_direct_drain_continues_after_preference_defer() {
         "protected ready candidate should be deferred before claim"
     );
     assert_eq!(
-        env.handle.deferred_poll_delays().len(),
+        env.handle.deferred_poll_deadlines().len(),
         1,
         "protected ready candidate should schedule one follow-up poll"
     );
@@ -1153,7 +1158,7 @@ async fn expired_generation_protection_preserves_local_session_claim() {
             .is_some()
     );
     assert!(
-        env.handle.deferred_poll_delays().is_empty(),
+        env.handle.deferred_poll_deadlines().is_empty(),
         "runner holding the protected session should not defer the claim"
     );
 
@@ -1207,7 +1212,7 @@ async fn exact_preference_defers_for_cache_then_matching_preference_claims_it() 
         env.handle.claim_candidates().is_empty(),
         "workspace-cache state must not impersonate an exact reusable generation"
     );
-    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
+    assert_eq!(env.handle.deferred_poll_deadlines().len(), 1);
 
     let run_id = RunId::new_v4();
     let mut workspace_context = context_with_session(run_id, provider_session_id);
@@ -1229,7 +1234,7 @@ async fn exact_preference_defers_for_cache_then_matching_preference_claims_it() 
     );
 
     assert_eq!(
-        env.handle.deferred_poll_delays().len(),
+        env.handle.deferred_poll_deadlines().len(),
         1,
         "the workspace-selected candidate should not add another deferral"
     );
@@ -1292,7 +1297,7 @@ async fn saturated_cache_only_holder_defers_before_reclaiming_unrelated_idle() {
         "a cache-only preference must not bypass exhausted fresh admission"
     );
     assert_eq!(
-        env.handle.deferred_poll_delays().len(),
+        env.handle.deferred_poll_deadlines().len(),
         1,
         "workspace-selected work should defer when fresh budget is unavailable"
     );

--- a/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
@@ -505,7 +505,7 @@ async fn heartbeat_tick_defers_past_first_select_poll() {
     wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     // `minimal_context` → no reuse key → completion path does not trigger
-    // `park_notify`, so any heartbeat observed here came from the
+    // `reuse_state_notify`, so any heartbeat observed here came from the
     // interval tick (the path we want to prove did NOT fire).
     let run_id = RunId::new_v4();
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -10,6 +10,9 @@ use crate::provider::mock::{MockJobProvider, MockProviderHandle};
 use crate::run_cancellation::RunCancellationRegistry;
 use sandbox_mock::MockSandboxRuntime;
 
+pub(in super::super) const TEST_RUNNER_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+pub(in super::super) const TEST_HEARTBEAT_GENERATION: u64 = 7;
+
 pub(in super::super) fn test_profiles() -> BTreeMap<String, config::ProfileConfig> {
     let mut m = BTreeMap::new();
     m.insert(
@@ -31,6 +34,8 @@ pub(in super::super) struct MockRunEnv {
     pub(in super::super) handle: MockProviderHandle,
     pub(in super::super) provider: Arc<MockJobProvider>,
     pub(in super::super) idle_pool: SharedIdlePool,
+    pub(in super::super) active_reuse_keys: ActiveReuseKeys,
+    pub(in super::super) reuse_state_notify: Arc<tokio::sync::Notify>,
     pub(in super::super) lifecycle: LifecycleController,
     pub(in super::super) parking_gate: ParkingGate,
     pub(in super::super) start_observer: StartLoopTestObserver,
@@ -198,13 +203,15 @@ fn build_mock_run_config_with_runtime(
             },
             parking_gate.clone(),
         )));
+    let active_reuse_keys = new_active_reuse_keys();
+    let reuse_state_notify = Arc::new(tokio::sync::Notify::new());
 
     let config = RunConfig {
         runner: RunnerInfo {
-            id: "test-runner".into(),
+            id: TEST_RUNNER_ID.into(),
             name: "test".into(),
             group: "test-group".into(),
-            heartbeat_generation: 7,
+            heartbeat_generation: TEST_HEARTBEAT_GENERATION,
             profiles,
         },
         paths: RunPaths {
@@ -238,6 +245,8 @@ fn build_mock_run_config_with_runtime(
                 None,
                 None,
             )),
+            active_reuse_keys: active_reuse_keys.clone(),
+            reuse_state_notify: Arc::clone(&reuse_state_notify),
         },
         provider: ProviderState {
             provider,
@@ -295,6 +304,8 @@ fn build_mock_run_config_with_runtime(
         handle,
         provider: provider_ref,
         idle_pool,
+        active_reuse_keys,
+        reuse_state_notify,
         lifecycle: lifecycle.clone(),
         parking_gate,
         start_observer,

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -5,9 +5,10 @@ mod status;
 mod wait;
 
 pub(super) use self::env::{
-    MockRunEnv, mock_run_config, mock_run_config_with_api_url, mock_run_config_with_delay,
-    mock_run_config_with_overrides, mock_run_config_with_overrides_and_api_url,
-    mock_run_config_with_runtime, test_profiles, two_profiles,
+    MockRunEnv, TEST_HEARTBEAT_GENERATION, TEST_RUNNER_ID, mock_run_config,
+    mock_run_config_with_api_url, mock_run_config_with_delay, mock_run_config_with_overrides,
+    mock_run_config_with_overrides_and_api_url, mock_run_config_with_runtime, test_profiles,
+    two_profiles,
 };
 pub(super) use self::idle_pool::{
     TestParkedIdleCandidateSpec, WorkspacePromotionSeedSpec, seed_idle_pool,

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -14,15 +14,12 @@ pub(crate) struct LocalDiscoveredJob {
     pub(crate) profile_name: String,
     pub(crate) job_path: PathBuf,
     pub(crate) reuse_key: Option<String>,
-    pub(crate) cli_agent_session_id: Option<String>,
 }
 
 #[derive(serde::Deserialize)]
 struct LocalDiscoveryMetadata {
     #[serde(default)]
     reuse_key: Option<String>,
-    #[serde(default)]
-    session_id: Option<String>,
 }
 
 pub(crate) enum LocalClaimResult {
@@ -197,16 +194,12 @@ impl LocalQueue {
                         .and_then(|bytes| {
                             serde_json::from_slice::<LocalDiscoveryMetadata>(&bytes).ok()
                         });
-                let (reuse_key, cli_agent_session_id) = match metadata {
-                    Some(metadata) => (metadata.reuse_key, metadata.session_id),
-                    None => (None, None),
-                };
+                let reuse_key = metadata.and_then(|metadata| metadata.reuse_key);
                 return Some(LocalDiscoveredJob {
                     run_id: candidate.run_id,
                     profile_name: profile.clone(),
                     job_path: candidate.path,
                     reuse_key,
-                    cli_agent_session_id,
                 });
             }
         }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -31,6 +31,7 @@ use super::builtin_firewall_catalog::{
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
+    parse_runner_preference,
 };
 use crate::active_input::{ActiveInputAblyNotifications, ActiveInputSource};
 use crate::duration::duration_ms;
@@ -47,9 +48,17 @@ use sandbox::SandboxId;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct ClaimRequestBody {
+struct ClaimRequestBody<'a> {
     active_input: bool,
+    runner_identity: ClaimRunnerIdentity<'a>,
     telemetry: ClaimRequestTelemetry,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ClaimRunnerIdentity<'a> {
+    runner_id: &'a str,
+    heartbeat_generation: u64,
 }
 
 #[derive(Serialize)]
@@ -577,25 +586,24 @@ impl JobProvider for ApiProvider {
                     }
                     let run_id = job.run_id;
                     let reuse_key = job.reuse_key().map(str::to_owned);
-                    let cli_agent_session_id = job.cli_agent_session_id;
                     let history_generation_run_id = job.history_generation_run_id;
-                    let history_generation_affinity_protected_until =
-                        job.history_generation_affinity_protected_until;
-                    let affinity_protected_until = job.affinity_protected_until;
-                    let session_affinity_resource = job.session_affinity_resource;
+                    let runner_preference = match parse_runner_preference(job.runner_preference) {
+                        Ok(runner_preference) => runner_preference,
+                        Err(error) => {
+                            warn!(
+                                run_id = %run_id,
+                                error = %error,
+                                "poll: invalid runner preference, using ordinary admission"
+                            );
+                            None
+                        }
+                    };
                     let profile = job.experimental_profile;
                     info!(run_id = %run_id, %profile, poll_reason = ?reason, "poll: job found");
                     let mut candidate = JobCandidate::new(run_id, profile)
-                        .with_affinity_metadata(
-                            reuse_key,
-                            cli_agent_session_id,
-                            affinity_protected_until,
-                        )
-                        .with_session_affinity_resource(session_affinity_resource)
+                        .with_reuse_key(reuse_key)
                         .with_history_generation_run_id(history_generation_run_id)
-                        .with_history_generation_affinity_protected_until(
-                            history_generation_affinity_protected_until,
-                        )
+                        .with_runner_preference(runner_preference)
                         .with_discovery_source(JobDiscoverySource::Poll)
                         .with_poll_reason(poll_reason_value(reason))
                         .with_poll_timing(poll_due_started_at.elapsed(), http_request_elapsed);
@@ -635,7 +643,11 @@ impl JobProvider for ApiProvider {
 
     async fn claim(&self, candidate: JobCandidate) -> Option<ClaimedJob> {
         let run_id = candidate.run_id();
-        match self.api.claim(&candidate).await {
+        match self
+            .api
+            .claim(&candidate, &self.runner_id, self.heartbeat_generation)
+            .await
+        {
             Ok(Some(ctx)) => {
                 let active_input_source = if ctx.active_input == Some(true) {
                     if ctx.active_input_ably == Some(true) {
@@ -992,9 +1004,11 @@ impl ApiClient {
     async fn claim(
         &self,
         candidate: &JobCandidate,
+        runner_id: &str,
+        heartbeat_generation: u64,
     ) -> Result<Option<ExecutionContext>, ClaimApiError> {
         let run_id = candidate.run_id();
-        let body = claim_request_body(candidate);
+        let body = claim_request_body(candidate, runner_id, heartbeat_generation);
         let run_id = run_id.to_string();
         let resp = send_api(
             self.http
@@ -1058,6 +1072,15 @@ impl ApiClient {
                 text: entry.text,
             })
             .collect())
+    }
+
+    #[cfg(test)]
+    async fn claim_for_test(
+        &self,
+        candidate: &JobCandidate,
+    ) -> Result<Option<ExecutionContext>, ClaimApiError> {
+        self.claim(candidate, "550e8400-e29b-41d4-a716-446655440000", 7)
+            .await
     }
 
     /// Report job completion. Uses the per-job **sandbox token** for auth.
@@ -1179,7 +1202,11 @@ impl ApiClient {
     }
 }
 
-fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
+fn claim_request_body<'a>(
+    candidate: &JobCandidate,
+    runner_id: &'a str,
+    heartbeat_generation: u64,
+) -> ClaimRequestBody<'a> {
     let is_ably_candidate = candidate.discovery_source() == Some(JobDiscoverySource::Ably);
     let (
         direct_candidate_notification_to_enqueue_ms,
@@ -1207,6 +1234,10 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
 
     ClaimRequestBody {
         active_input: true,
+        runner_identity: ClaimRunnerIdentity {
+            runner_id,
+            heartbeat_generation,
+        },
         telemetry: ClaimRequestTelemetry {
             discovery_source: candidate.discovery_source().map(JobDiscoverySource::as_str),
             job_discovered_to_claim_request_ms: claim_telemetry_duration_ms(
@@ -1563,11 +1594,18 @@ mod tests {
     use uuid::Uuid;
 
     use crate::http::HttpClientConfig;
+    use crate::provider::RunnerPreferenceReason;
 
     const RUNNER_CLAIM_RESPONSE_FIXTURE: &str = include_str!(
         "../../../../turbo/packages/api-contracts/src/contracts/__tests__/fixtures/runner-claim-response.json"
     );
     const RUNNER_CLAIM_RESPONSE_FIXTURE_RUN_ID: &str = "00000000-0000-4000-8000-000000020985";
+    const TEST_RUNNER_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+    const TEST_HEARTBEAT_GENERATION: u64 = 7;
+
+    fn claim_request_body_for_test(candidate: &JobCandidate) -> ClaimRequestBody<'_> {
+        claim_request_body(candidate, TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION)
+    }
 
     fn api_client_for_server(server: &MockServer) -> ApiClient {
         ApiClient::new(
@@ -2131,8 +2169,6 @@ mod tests {
     #[test]
     fn claim_request_body_serializes_runner_timing() {
         let now = std::time::Instant::now();
-        let target_generation_run_id: RunId =
-            "00000000-0000-0000-0000-000000000099".parse().unwrap();
         let candidate = JobCandidate::new_with_timing_for_test(
             RunId::nil(),
             crate::profile::DEFAULT_PROFILE.to_string(),
@@ -2140,16 +2176,17 @@ mod tests {
             Some(now.checked_sub(Duration::from_millis(7)).unwrap()),
         )
         .with_discovery_source(JobDiscoverySource::Poll)
-        .with_session_affinity_resource(Some(
-            crate::types::SessionAffinityResource::ReusableSandbox,
-        ))
-        .with_history_generation_run_id(Some(target_generation_run_id))
         .with_poll_reason("deferred")
         .with_poll_timing(Duration::from_millis(19), Duration::from_millis(11));
 
-        let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
+        let body = serde_json::to_value(claim_request_body_for_test(&candidate)).unwrap();
 
         assert_eq!(body["activeInput"], true);
+        assert_eq!(body["runnerIdentity"]["runnerId"], TEST_RUNNER_ID);
+        assert_eq!(
+            body["runnerIdentity"]["heartbeatGeneration"],
+            TEST_HEARTBEAT_GENERATION
+        );
         assert_eq!(body["telemetry"]["discoverySource"], "poll");
         assert!(
             body["telemetry"]["jobDiscoveredToClaimRequestMs"]
@@ -2171,11 +2208,7 @@ mod tests {
                 .is_none()
         );
         assert!(body["telemetry"].get("localAdmissionResource").is_none());
-        assert!(
-            !body
-                .to_string()
-                .contains(&target_generation_run_id.to_string())
-        );
+        assert!(body.get("runnerPreference").is_none());
         assert!(!body.to_string().contains("rawSizeBytes"));
         assert!(!body.to_string().contains("sessionId"));
         assert!(!body.to_string().contains("historyHash"));
@@ -2197,7 +2230,7 @@ mod tests {
         candidate.mark_main_loop_handling_started();
         candidate.mark_local_admission_started();
 
-        let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
+        let body = serde_json::to_value(claim_request_body_for_test(&candidate)).unwrap();
 
         assert_eq!(body["telemetry"]["discoverySource"], "ably");
         assert_eq!(
@@ -2230,7 +2263,7 @@ mod tests {
         candidate.mark_main_loop_handling_started();
         candidate.mark_local_admission_started();
 
-        let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
+        let body = serde_json::to_value(claim_request_body_for_test(&candidate)).unwrap();
 
         assert_eq!(body["telemetry"]["discoverySource"], "poll");
         assert!(
@@ -2264,7 +2297,7 @@ mod tests {
                     Duration::from_millis(CLAIM_TELEMETRY_DURATION_MS_MAX + 1),
                 );
 
-        let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
+        let body = serde_json::to_value(claim_request_body_for_test(&candidate)).unwrap();
 
         assert_eq!(
             body["telemetry"]["pollDueToJobDiscoveredMs"],
@@ -2286,7 +2319,7 @@ mod tests {
             None,
         );
 
-        let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
+        let body = serde_json::to_value(claim_request_body_for_test(&candidate)).unwrap();
 
         assert!(
             body["telemetry"]["jobDiscoveredToClaimRequestMs"]
@@ -2330,7 +2363,7 @@ mod tests {
             JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
                 .with_discovery_source(JobDiscoverySource::Ably);
 
-        let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
+        let body = serde_json::to_value(claim_request_body_for_test(&candidate)).unwrap();
 
         assert_eq!(body["telemetry"]["discoverySource"], "ably");
         assert!(body["telemetry"].get("pollDueToJobDiscoveredMs").is_none());
@@ -2436,23 +2469,66 @@ mod tests {
 
         assert_eq!(discovered.run_id(), run_id);
         assert_eq!(discovered.profile_name(), "vm0/large");
-        assert_eq!(discovered.cli_agent_session_id(), Some("sess-poll"));
         assert_eq!(
             discovered.history_generation_run_id(),
             Some(history_generation_run_id)
         );
-        assert!(discovered.is_affinity_protected());
-        assert!(discovered.is_history_generation_affinity_protected());
+        let preference = discovered
+            .runner_preference()
+            .expect("canonical preference should be parsed");
         assert_eq!(
-            discovered.session_affinity_resource(),
-            Some(crate::types::SessionAffinityResource::ReusableSandbox)
+            preference.reason(),
+            RunnerPreferenceReason::ExactHistoryGeneration
         );
+        assert!(preference.targets("00000000-0000-0000-0000-000000000005", 7));
         assert_eq!(
             discovered.discovery_source(),
             Some(JobDiscoverySource::Poll)
         );
         assert!(discovered.poll_due_to_job_discovered_elapsed().is_some());
         assert!(discovered.poll_http_request_elapsed().is_some());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn discover_preserves_poll_job_with_malformed_optional_preference() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::new_v4();
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(routes::runners::poll::POLL.path);
+                then.status(200).json_body(serde_json::json!({
+                    "job": {
+                        "runId": run_id,
+                        "experimentalProfile": "vm0/default",
+                        "reuseKey": "thread:malformed-preference",
+                        "runnerPreference": {
+                            "runnerIdentity": {
+                                "runnerId": TEST_RUNNER_ID,
+                                "heartbeatGeneration": 0
+                            },
+                            "reason": "matchingReuseKey",
+                            "expiresAt": "2999-01-01T00:00:00.000Z"
+                        }
+                    }
+                }));
+            })
+            .await;
+        let provider = api_provider_for_test_with_supported_profiles(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+            vec!["vm0/default".to_string()],
+        );
+
+        let candidate = tokio::time::timeout(Duration::from_secs(1), provider.discover())
+            .await
+            .expect("discover should preserve the job")
+            .expect("job candidate");
+
+        assert_eq!(candidate.run_id(), run_id);
+        assert_eq!(candidate.reuse_key(), Some("thread:malformed-preference"));
+        assert!(candidate.runner_preference().is_none());
         mock.assert_async().await;
     }
 
@@ -3235,7 +3311,7 @@ mod tests {
         let api = api_client_for_server(&server);
 
         let candidate = JobCandidate::new(run_id, crate::profile::DEFAULT_PROFILE.to_string());
-        let outcome = api.claim(&candidate).await.unwrap();
+        let outcome = api.claim_for_test(&candidate).await.unwrap();
 
         assert!(outcome.is_none());
         mock.assert_async().await;
@@ -3255,7 +3331,7 @@ mod tests {
         let api = api_client_for_server(&server);
 
         let candidate = JobCandidate::new(run_id, crate::profile::DEFAULT_PROFILE.to_string());
-        let error = api.claim(&candidate).await.unwrap_err();
+        let error = api.claim_for_test(&candidate).await.unwrap_err();
 
         let ClaimApiError::Request(error) = error else {
             panic!("expected ClaimApiError::Request");
@@ -3288,7 +3364,7 @@ mod tests {
         let api = api_client_for_server(&server);
 
         let err = api
-            .claim(&JobCandidate::new(
+            .claim_for_test(&JobCandidate::new(
                 run_id,
                 crate::profile::DEFAULT_PROFILE.to_string(),
             ))
@@ -3337,7 +3413,7 @@ mod tests {
         let api = api_client_for_server(&server);
 
         let err = api
-            .claim(&JobCandidate::new(
+            .claim_for_test(&JobCandidate::new(
                 run_id,
                 crate::profile::DEFAULT_PROFILE.to_string(),
             ))
@@ -3386,7 +3462,7 @@ mod tests {
         let api = api_client_for_server(&server);
 
         let err = api
-            .claim(&JobCandidate::new(
+            .claim_for_test(&JobCandidate::new(
                 run_id,
                 crate::profile::DEFAULT_PROFILE.to_string(),
             ))
@@ -3445,7 +3521,7 @@ mod tests {
         let api = api_client_for_server(&server);
 
         let err = api
-            .claim(&JobCandidate::new(
+            .claim_for_test(&JobCandidate::new(
                 run_id,
                 crate::profile::DEFAULT_PROFILE.to_string(),
             ))
@@ -3493,7 +3569,7 @@ mod tests {
         let api = api_client_for_server(&server);
 
         let err = api
-            .claim(&JobCandidate::new(
+            .claim_for_test(&JobCandidate::new(
                 run_id,
                 crate::profile::DEFAULT_PROFILE.to_string(),
             ))
@@ -3758,7 +3834,17 @@ mod tests {
         let claim_path = format!("/api/runners/jobs/{run_id}/claim");
         let claim_mock = server
             .mock_async(|when, then| {
-                when.method(POST).path(claim_path.as_str());
+                when.method(POST)
+                    .path(claim_path.as_str())
+                    .json_body_includes(
+                        serde_json::json!({
+                            "runnerIdentity": {
+                                "runnerId": TEST_RUNNER_ID,
+                                "heartbeatGeneration": TEST_HEARTBEAT_GENERATION,
+                            }
+                        })
+                        .to_string(),
+                    );
                 then.status(200).json_body(serde_json::json!({
                     "runId": run_id,
                     "prompt": "previous response",

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -717,8 +717,10 @@ impl JobProvider for ApiProvider {
         }
     }
 
-    async fn defer_poll_after(&self, delay: Duration) {
-        self.poll_wakeups.request_deferred_poll_after(delay).await;
+    async fn defer_poll_until(&self, deadline: Instant) {
+        self.poll_wakeups
+            .request_deferred_poll_until(deadline)
+            .await;
     }
 
     async fn shutdown(&self) {

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -27,12 +27,12 @@ use super::api_direct_candidates::{
     DirectJobCandidate,
 };
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
+use super::{RunnerPreference, parse_runner_preference};
 use crate::active_input::ActiveInputAblyNotifications;
 use crate::duration::duration_ms;
 use crate::ids::RunId;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::run_cancellation::RunCancellationRegistry;
-use crate::types::SessionAffinityResource;
 
 const ABLY_BACKOFF_INITIAL: Duration = Duration::from_secs(5);
 const ABLY_BACKOFF_MAX: Duration = Duration::from_secs(60);
@@ -716,21 +716,14 @@ async fn handle_ably_message_with_network_policy_refresh(
                     "ably: job notification, queueing direct candidate"
                 );
                 JobNotificationAction::Direct(
-                    DirectJobCandidate::new_with_affinity_metadata(
+                    DirectJobCandidate::new_with_routing_metadata(
                         notif.run_id,
                         profile.to_owned(),
                         notification_received_at,
                         notif.reuse_key.map(str::to_owned),
-                        notif.cli_agent_session_id.map(str::to_owned),
-                        notif.affinity_protected_until.map(str::to_owned),
+                        notif.runner_preference,
                     )
-                    .with_history_generation_run_id(notif.history_generation_run_id)
-                    .with_session_affinity_resource(notif.session_affinity_resource)
-                    .with_history_generation_affinity_protected_until(
-                        notif
-                            .history_generation_affinity_protected_until
-                            .map(str::to_owned),
-                    ),
+                    .with_history_generation_run_id(notif.history_generation_run_id),
                 )
             } else {
                 info!(
@@ -771,11 +764,8 @@ struct JobNotification<'a> {
     run_id: RunId,
     profile: Option<&'a str>,
     reuse_key: Option<&'a str>,
-    cli_agent_session_id: Option<&'a str>,
-    session_affinity_resource: Option<SessionAffinityResource>,
     history_generation_run_id: Option<RunId>,
-    history_generation_affinity_protected_until: Option<&'a str>,
-    affinity_protected_until: Option<&'a str>,
+    runner_preference: Option<RunnerPreference>,
 }
 
 struct NetworkPolicyRefreshNotification {
@@ -960,40 +950,9 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
         .get("profile")
         .and_then(|v| v.as_str())
         .filter(|value| !value.is_empty());
-    let cli_agent_session_id = msg
-        .data
-        .get("cliAgentSessionId")
-        .and_then(|v| v.as_str())
-        .filter(|value| !value.is_empty());
     let reuse_key = msg
         .data
         .get("reuseKey")
-        .and_then(|v| v.as_str())
-        .filter(|value| !value.is_empty());
-    let affinity_protected_until = msg
-        .data
-        .get("affinityProtectedUntil")
-        .and_then(|v| v.as_str())
-        .filter(|value| !value.is_empty());
-    let session_affinity_resource = match msg.data.get("sessionAffinityResource") {
-        Some(value) if value.as_str() == Some("reusableSandbox") => {
-            Some(SessionAffinityResource::ReusableSandbox)
-        }
-        Some(value) if value.as_str() == Some("workspaceCache") => {
-            Some(SessionAffinityResource::WorkspaceCache)
-        }
-        Some(value) => {
-            warn!(
-                value = %value,
-                "ably: invalid session affinity resource, ignoring job notification"
-            );
-            return None;
-        }
-        None => None,
-    };
-    let history_generation_affinity_protected_until = msg
-        .data
-        .get("historyGenerationAffinityProtectedUntil")
         .and_then(|v| v.as_str())
         .filter(|value| !value.is_empty());
     let history_generation_run_id = msg
@@ -1001,15 +960,24 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
         .get("historyGenerationRunId")
         .and_then(|v| v.as_str())
         .and_then(|value| value.parse().ok());
+    let runner_preference = match parse_runner_preference(msg.data.get("runnerPreference").cloned())
+    {
+        Ok(runner_preference) => runner_preference,
+        Err(error) => {
+            warn!(
+                run_id = %run_id,
+                error = %error,
+                "ably: invalid runner preference, using ordinary admission"
+            );
+            None
+        }
+    };
     Some(JobNotification {
         run_id,
         profile,
         reuse_key,
-        cli_agent_session_id,
-        session_affinity_resource,
         history_generation_run_id,
-        history_generation_affinity_protected_until,
-        affinity_protected_until,
+        runner_preference,
     })
 }
 
@@ -1157,6 +1125,7 @@ impl AblyDisconnectState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider::RunnerPreferenceReason;
 
     fn make_message(name: Option<&str>, data: serde_json::Value) -> ably_subscriber::Message {
         ably_subscriber::Message {
@@ -1934,13 +1903,8 @@ mod tests {
             serde_json::json!({
                 "runId": "00000000-0000-0000-0000-000000000001",
                 "profile": "vm0/default",
-                "cliAgentSessionId": "sess-ably",
                 "reuseKey": "thread:chat-thread",
                 "historyGenerationRunId": "00000000-0000-0000-0000-000000000098",
-                "historyGenerationAffinityProtectedUntil": "2999-01-01T00:00:00.000Z",
-                "affinityProtectedUntil": "2999-01-01T00:00:00.000Z",
-                "sessionAffinityResource": "workspaceCache",
-                // Old runners must ignore the additive preference during rollout.
                 "runnerPreference": {
                     "runnerIdentity": {
                         "runnerId": "00000000-0000-0000-0000-000000000005",
@@ -1962,19 +1926,60 @@ mod tests {
         assert_eq!(candidate.profile_name(), "vm0/default");
         let candidate = candidate.into_job_candidate();
         assert_eq!(candidate.reuse_key(), Some("thread:chat-thread"));
-        assert_eq!(candidate.cli_agent_session_id(), Some("sess-ably"));
         assert_eq!(
             candidate.history_generation_run_id(),
             Some("00000000-0000-0000-0000-000000000098".parse().unwrap())
         );
-        assert!(candidate.is_affinity_protected());
-        assert!(candidate.is_history_generation_affinity_protected());
+        let preference = candidate
+            .runner_preference()
+            .expect("canonical preference should be parsed");
         assert_eq!(
-            candidate.session_affinity_resource(),
-            Some(SessionAffinityResource::WorkspaceCache)
+            preference.reason(),
+            RunnerPreferenceReason::MatchingReuseKey
         );
+        assert!(preference.targets("00000000-0000-0000-0000-000000000005", 7));
         assert_no_direct_candidate(&direct_candidates).await;
         assert!(!wakeups.snapshot().await.poll_now);
+    }
+
+    #[tokio::test]
+    async fn malformed_optional_preference_preserves_direct_candidate() {
+        let tokens = RunCancellationRegistry::new();
+        let wakeups = PollWakeups::new(true);
+        let direct_candidates = direct_candidate_inbox();
+        let profiles = default_profiles();
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000011",
+                "profile": "vm0/default",
+                "reuseKey": "thread:malformed-preference",
+                "runnerPreference": {
+                    "runnerIdentity": {
+                        "runnerId": "00000000-0000-0000-0000-000000000005",
+                        "heartbeatGeneration": 7
+                    },
+                    "reason": "futureReason",
+                    "expiresAt": "2999-01-01T00:00:00.000Z"
+                }
+            }),
+        );
+
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
+
+        let candidate = pop_direct_candidate(&direct_candidates)
+            .await
+            .into_job_candidate();
+        assert_eq!(candidate.reuse_key(), Some("thread:malformed-preference"));
+        assert!(candidate.runner_preference().is_none());
+        assert_no_direct_candidate(&direct_candidates).await;
     }
 
     #[tokio::test]
@@ -2264,20 +2269,6 @@ mod tests {
             .await
             .expect("dropping supervisor should cancel the task")
             .unwrap();
-    }
-
-    #[test]
-    fn parse_job_notification_rejects_unknown_session_affinity_resource() {
-        let msg = make_message(
-            Some("job"),
-            serde_json::json!({
-                "runId": "00000000-0000-0000-0000-000000000001",
-                "profile": "vm0/default",
-                "sessionAffinityResource": "futureResource"
-            }),
-        );
-
-        assert!(parse_job_notification(&msg).is_none());
     }
 
     #[test]

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -174,6 +174,12 @@ impl PollWakeups {
             .await;
     }
 
+    pub(super) async fn request_deferred_poll_until(&self, deadline: StdInstant) {
+        let now = tokio::time::Instant::now();
+        self.request_deferred_poll_capped_at(deadline.into(), now + DEFERRED_POLL_MAX)
+            .await;
+    }
+
     async fn request_deferred_poll_capped_at(
         &self,
         at: tokio::time::Instant,
@@ -1491,6 +1497,19 @@ mod tests {
 
         tokio::time::sleep_until(extended_deadline).await;
         assert_eq!(poll_reason(wait.await.unwrap()), Some(PollReason::Deferred));
+    }
+
+    #[tokio::test]
+    async fn deferred_poll_until_preserves_absolute_deadline() {
+        let wakeups = PollWakeups::new(true);
+        let deadline = StdInstant::now() + Duration::from_secs(2);
+
+        wakeups.request_deferred_poll_until(deadline).await;
+
+        assert_eq!(
+            wakeups.snapshot().await.deferred_poll_at,
+            Some(deadline.into())
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/runner/src/provider/api_direct_candidates.rs
+++ b/crates/runner/src/provider/api_direct_candidates.rs
@@ -6,9 +6,8 @@ use tokio::sync::{Mutex, Notify};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-use super::{JobCandidate, JobDiscoverySource};
+use super::{JobCandidate, JobDiscoverySource, RunnerPreference};
 use crate::ids::RunId;
-use crate::types::SessionAffinityResource;
 
 pub(super) const DIRECT_CANDIDATE_STALE_AFTER: Duration = Duration::from_secs(60);
 
@@ -19,11 +18,8 @@ pub(super) struct DirectJobCandidate {
     discovered_at: StdInstant,
     enqueued_at: Option<StdInstant>,
     reuse_key: Option<String>,
-    cli_agent_session_id: Option<String>,
-    session_affinity_resource: Option<SessionAffinityResource>,
     history_generation_run_id: Option<RunId>,
-    history_generation_affinity_protected_until: Option<String>,
-    affinity_protected_until: Option<String>,
+    runner_preference: Option<RunnerPreference>,
 }
 
 impl DirectJobCandidate {
@@ -38,7 +34,7 @@ impl DirectJobCandidate {
         profile_name: String,
         discovered_at: StdInstant,
     ) -> Self {
-        Self::new_with_affinity_metadata(run_id, profile_name, discovered_at, None, None, None)
+        Self::new_with_routing_metadata(run_id, profile_name, discovered_at, None, None)
     }
 
     #[cfg(test)]
@@ -49,18 +45,17 @@ impl DirectJobCandidate {
         enqueued_at: StdInstant,
     ) -> Self {
         let mut candidate =
-            Self::new_with_affinity_metadata(run_id, profile_name, discovered_at, None, None, None);
+            Self::new_with_routing_metadata(run_id, profile_name, discovered_at, None, None);
         candidate.enqueued_at = Some(enqueued_at);
         candidate
     }
 
-    pub(super) fn new_with_affinity_metadata(
+    pub(super) fn new_with_routing_metadata(
         run_id: RunId,
         profile_name: String,
         discovered_at: StdInstant,
         reuse_key: Option<String>,
-        cli_agent_session_id: Option<String>,
-        affinity_protected_until: Option<String>,
+        runner_preference: Option<RunnerPreference>,
     ) -> Self {
         Self {
             run_id,
@@ -68,11 +63,8 @@ impl DirectJobCandidate {
             discovered_at,
             enqueued_at: None,
             reuse_key,
-            cli_agent_session_id,
-            session_affinity_resource: None,
             history_generation_run_id: None,
-            history_generation_affinity_protected_until: None,
-            affinity_protected_until,
+            runner_preference,
         }
     }
 
@@ -108,22 +100,6 @@ impl DirectJobCandidate {
         self
     }
 
-    pub(super) fn with_session_affinity_resource(
-        mut self,
-        resource: Option<SessionAffinityResource>,
-    ) -> Self {
-        self.session_affinity_resource = resource;
-        self
-    }
-
-    pub(super) fn with_history_generation_affinity_protected_until(
-        mut self,
-        protected_until: Option<String>,
-    ) -> Self {
-        self.history_generation_affinity_protected_until = protected_until;
-        self
-    }
-
     pub(super) fn into_job_candidate(self) -> JobCandidate {
         let dequeued_at = StdInstant::now();
         let notification_to_enqueue_elapsed = self
@@ -133,16 +109,9 @@ impl DirectJobCandidate {
             .enqueued_at
             .map(|enqueued_at| dequeued_at.saturating_duration_since(enqueued_at));
         JobCandidate::new_with_discovered_at(self.run_id, self.profile_name, self.discovered_at)
-            .with_affinity_metadata(
-                self.reuse_key,
-                self.cli_agent_session_id,
-                self.affinity_protected_until,
-            )
-            .with_session_affinity_resource(self.session_affinity_resource)
+            .with_reuse_key(self.reuse_key)
             .with_history_generation_run_id(self.history_generation_run_id)
-            .with_history_generation_affinity_protected_until(
-                self.history_generation_affinity_protected_until,
-            )
+            .with_runner_preference(self.runner_preference)
             .with_discovery_source(JobDiscoverySource::Ably)
             .with_direct_candidate_timing(notification_to_enqueue_elapsed, inbox_wait_elapsed)
     }
@@ -157,30 +126,18 @@ impl DirectJobCandidate {
             );
             return;
         }
-        if candidate.reuse_key.is_some() {
-            self.reuse_key = candidate.reuse_key;
+        let preserve_existing = matches!(
+            (&self.runner_preference, &candidate.runner_preference),
+            (Some(existing), Some(candidate))
+                if existing.reason() == candidate.reason()
+                    && existing.deadline() < candidate.deadline()
+        );
+        if preserve_existing {
+            return;
         }
-        if candidate.cli_agent_session_id.is_some() {
-            self.cli_agent_session_id = candidate.cli_agent_session_id;
-        }
-        if candidate.affinity_protected_until.is_some() {
-            self.affinity_protected_until = candidate.affinity_protected_until;
-        }
-        if self.session_affinity_resource.is_none()
-            || candidate.session_affinity_resource == Some(SessionAffinityResource::ReusableSandbox)
-        {
-            self.session_affinity_resource = candidate.session_affinity_resource;
-        }
-        if candidate
-            .history_generation_affinity_protected_until
-            .is_some()
-        {
-            self.history_generation_affinity_protected_until =
-                candidate.history_generation_affinity_protected_until;
-        }
-        if candidate.history_generation_run_id.is_some() {
-            self.history_generation_run_id = candidate.history_generation_run_id;
-        }
+        self.reuse_key = candidate.reuse_key;
+        self.history_generation_run_id = candidate.history_generation_run_id;
+        self.runner_preference = candidate.runner_preference;
     }
 }
 
@@ -432,6 +389,14 @@ mod tests {
         DirectCandidateInbox::new(capacity, stale_after)
     }
 
+    fn runner_preference(
+        runner_id: u128,
+        reason: super::super::RunnerPreferenceReason,
+        deadline: StdInstant,
+    ) -> RunnerPreference {
+        RunnerPreference::for_test(uuid::Uuid::from_u128(runner_id), 7, reason, deadline)
+    }
+
     fn candidate_with_enqueued_at(run_id: RunId, enqueued_at: StdInstant) -> DirectJobCandidate {
         let mut candidate = DirectJobCandidate::new_with_discovered_at(
             run_id,
@@ -450,18 +415,19 @@ mod tests {
         let history_generation_run_id = run_id(2);
         let run_id = run_id(1);
 
+        let first_deadline = StdInstant::now() + Duration::from_secs(5);
         let inserted = inbox
-            .push(
-                DirectJobCandidate::new_with_affinity_metadata(
-                    run_id,
-                    "vm0/default".to_string(),
-                    first_discovered_at,
-                    Some("session:sess-1".to_string()),
-                    Some("sess-1".to_string()),
-                    None,
-                )
-                .with_session_affinity_resource(Some(SessionAffinityResource::WorkspaceCache)),
-            )
+            .push(DirectJobCandidate::new_with_routing_metadata(
+                run_id,
+                "vm0/default".to_string(),
+                first_discovered_at,
+                Some("session:sess-1".to_string()),
+                Some(runner_preference(
+                    10,
+                    super::super::RunnerPreferenceReason::MatchingReuseKey,
+                    first_deadline,
+                )),
+            ))
             .await;
         assert_eq!(
             inserted.snapshot(),
@@ -471,21 +437,21 @@ mod tests {
             }
         );
 
+        let exact_deadline = StdInstant::now() + Duration::from_secs(8);
         let updated = inbox
             .push(
-                DirectJobCandidate::new_with_affinity_metadata(
+                DirectJobCandidate::new_with_routing_metadata(
                     run_id,
                     "vm0/default".to_string(),
                     second_discovered_at,
-                    None,
-                    None,
-                    Some("2999-01-01T00:00:00.000Z".to_string()),
+                    Some("session:sess-2".to_string()),
+                    Some(runner_preference(
+                        20,
+                        super::super::RunnerPreferenceReason::ExactHistoryGeneration,
+                        exact_deadline,
+                    )),
                 )
-                .with_history_generation_run_id(Some(history_generation_run_id))
-                .with_history_generation_affinity_protected_until(Some(
-                    "2999-01-01T00:00:00.000Z".to_string(),
-                ))
-                .with_session_affinity_resource(Some(SessionAffinityResource::ReusableSandbox)),
+                .with_history_generation_run_id(Some(history_generation_run_id)),
             )
             .await;
         assert!(matches!(
@@ -499,21 +465,21 @@ mod tests {
             }
         ));
 
-        let downgraded = inbox
-            .push(
-                DirectJobCandidate::new_with_affinity_metadata(
-                    run_id,
-                    "vm0/default".to_string(),
-                    second_discovered_at,
-                    None,
-                    None,
-                    None,
-                )
-                .with_session_affinity_resource(Some(SessionAffinityResource::WorkspaceCache)),
-            )
+        let renewed = inbox
+            .push(DirectJobCandidate::new_with_routing_metadata(
+                run_id,
+                "vm0/default".to_string(),
+                second_discovered_at,
+                Some("session:must-not-renew".to_string()),
+                Some(runner_preference(
+                    30,
+                    super::super::RunnerPreferenceReason::ExactHistoryGeneration,
+                    StdInstant::now() + Duration::from_secs(30),
+                )),
+            ))
             .await;
         assert!(matches!(
-            downgraded,
+            renewed,
             DirectCandidateInsertOutcome::Updated { .. }
         ));
 
@@ -521,17 +487,20 @@ mod tests {
         assert_eq!(candidate.discovered_at(), first_discovered_at);
         assert!(candidate.enqueued_at().is_some());
         let candidate = candidate.into_job_candidate();
-        assert_eq!(candidate.cli_agent_session_id(), Some("sess-1"));
+        assert_eq!(candidate.reuse_key(), Some("session:sess-2"));
         assert_eq!(
             candidate.history_generation_run_id(),
             Some(history_generation_run_id)
         );
-        assert!(candidate.is_affinity_protected());
-        assert!(candidate.is_history_generation_affinity_protected());
+        let preference = candidate
+            .runner_preference()
+            .expect("updated canonical preference");
         assert_eq!(
-            candidate.session_affinity_resource(),
-            Some(SessionAffinityResource::ReusableSandbox)
+            preference.reason(),
+            super::super::RunnerPreferenceReason::ExactHistoryGeneration
         );
+        assert_eq!(preference.deadline(), exact_deadline);
+        assert!(preference.targets(&uuid::Uuid::from_u128(20).to_string(), 7));
         assert!(
             candidate
                 .direct_candidate_notification_to_enqueue_elapsed()
@@ -539,6 +508,47 @@ mod tests {
         );
         assert!(candidate.direct_candidate_inbox_wait_elapsed().is_some());
         assert!(inbox.try_pop().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn duplicate_without_preference_clears_the_previous_routing_snapshot() {
+        let inbox = direct_candidate_inbox(1);
+        let candidate_run_id = run_id(3);
+        inbox
+            .push(
+                DirectJobCandidate::new_with_routing_metadata(
+                    candidate_run_id,
+                    "vm0/default".to_string(),
+                    StdInstant::now(),
+                    Some("session:stale".to_string()),
+                    Some(runner_preference(
+                        10,
+                        super::super::RunnerPreferenceReason::ExactHistoryGeneration,
+                        StdInstant::now() + Duration::from_secs(5),
+                    )),
+                )
+                .with_history_generation_run_id(Some(run_id(4))),
+            )
+            .await;
+
+        inbox
+            .push(DirectJobCandidate::new_with_routing_metadata(
+                candidate_run_id,
+                "vm0/default".to_string(),
+                StdInstant::now(),
+                None,
+                None,
+            ))
+            .await;
+
+        let candidate = inbox
+            .try_pop()
+            .await
+            .expect("updated direct candidate")
+            .into_job_candidate();
+        assert!(candidate.reuse_key().is_none());
+        assert!(candidate.history_generation_run_id().is_none());
+        assert!(candidate.runner_preference().is_none());
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/local/mod.rs
+++ b/crates/runner/src/provider/local/mod.rs
@@ -113,7 +113,7 @@ fn job_candidate_from_discovered(discovered: LocalDiscoveredJob) -> JobCandidate
         discovered.profile_name,
         discovered.job_path,
     )
-    .with_affinity_metadata(discovered.reuse_key, discovered.cli_agent_session_id, None)
+    .with_reuse_key(discovered.reuse_key)
 }
 
 #[async_trait::async_trait]

--- a/crates/runner/src/provider/local/tests/discovery.rs
+++ b/crates/runner/src/provider/local/tests/discovery.rs
@@ -35,7 +35,7 @@ async fn discover_claim_complete() {
 }
 
 #[tokio::test]
-async fn discover_carries_thread_affinity_and_session_before_claim() {
+async fn discover_carries_thread_affinity_before_claim() {
     let dir = tempfile::tempdir().unwrap();
     let provider = default_provider(dir.path(), CancellationToken::new(), empty_cancel_tokens());
     let job_id = RunId::new_v4();
@@ -50,7 +50,6 @@ async fn discover_carries_thread_affinity_and_session_before_claim() {
     );
 
     let candidate = provider.discover().await.unwrap();
-    assert_eq!(candidate.cli_agent_session_id(), Some("session-123"));
     assert_eq!(candidate.reuse_key(), Some(reuse_key));
 
     let claimed = provider.claim(candidate).await.unwrap();
@@ -70,7 +69,6 @@ async fn session_only_job_resumes_without_affinity() {
     write_job_with_session(dir.path(), job_id, "continue cold", "session-123");
 
     let candidate = provider.discover().await.unwrap();
-    assert_eq!(candidate.cli_agent_session_id(), Some("session-123"));
     assert_eq!(candidate.reuse_key(), None);
 
     let claimed = provider.claim(candidate).await.unwrap();
@@ -91,7 +89,6 @@ async fn thread_affinity_is_available_before_a_session_exists() {
     write_job_with_affinity(dir.path(), job_id, "start warm", Some(reuse_key), None);
 
     let candidate = provider.discover().await.unwrap();
-    assert_eq!(candidate.cli_agent_session_id(), None);
     assert_eq!(candidate.reuse_key(), Some(reuse_key));
 
     let claimed = provider.claim(candidate).await.unwrap();

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -19,7 +19,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use tokio::sync::{Mutex, Notify, mpsc};
@@ -63,7 +63,7 @@ pub struct MockJobProvider {
     claim_candidates: Arc<StdMutex<Vec<JobCandidate>>>,
     completions: Arc<StdMutex<Vec<Completion>>>,
     heartbeats: Arc<StdMutex<Vec<HeartbeatState>>>,
-    deferred_poll_delays: Arc<StdMutex<Vec<Duration>>>,
+    deferred_poll_deadlines: Arc<StdMutex<Vec<Instant>>>,
     cancel: CancellationToken,
     /// Fired each time `discover()` has reached its inner `select!` await
     /// point (lock + optional `poll_delay` complete, about to park on
@@ -100,7 +100,7 @@ pub struct MockProviderHandle {
     claim_candidates: Arc<StdMutex<Vec<JobCandidate>>>,
     pub completions: Arc<StdMutex<Vec<Completion>>>,
     pub heartbeats: Arc<StdMutex<Vec<HeartbeatState>>>,
-    deferred_poll_delays: Arc<StdMutex<Vec<Duration>>>,
+    deferred_poll_deadlines: Arc<StdMutex<Vec<Instant>>>,
     /// See [`Self::wait_discover_entered`].
     discover_entered: Arc<Notify>,
     /// See [`MockJobProvider::completion_notify`].
@@ -250,7 +250,7 @@ impl MockJobProvider {
         let claim_candidates = Arc::new(StdMutex::new(Vec::new()));
         let completions = Arc::new(StdMutex::new(Vec::new()));
         let heartbeats = Arc::new(StdMutex::new(Vec::new()));
-        let deferred_poll_delays = Arc::new(StdMutex::new(Vec::new()));
+        let deferred_poll_deadlines = Arc::new(StdMutex::new(Vec::new()));
         let startup_readiness = Arc::new(MockStartupReadiness::default());
         let discover_entered = Arc::new(Notify::new());
         let completion_notify = Arc::new(Notify::new());
@@ -267,7 +267,7 @@ impl MockJobProvider {
             claim_candidates: Arc::clone(&claim_candidates),
             completions: Arc::clone(&completions),
             heartbeats: Arc::clone(&heartbeats),
-            deferred_poll_delays: Arc::clone(&deferred_poll_delays),
+            deferred_poll_deadlines: Arc::clone(&deferred_poll_deadlines),
             cancel,
             discover_entered: Arc::clone(&discover_entered),
             completion_notify: Arc::clone(&completion_notify),
@@ -283,7 +283,7 @@ impl MockJobProvider {
             claim_candidates,
             completions,
             heartbeats,
-            deferred_poll_delays,
+            deferred_poll_deadlines,
             discover_entered,
             completion_notify,
             discover_poll_started,
@@ -446,8 +446,8 @@ impl MockProviderHandle {
             .clone()
     }
 
-    pub fn deferred_poll_delays(&self) -> Vec<Duration> {
-        self.deferred_poll_delays
+    pub fn deferred_poll_deadlines(&self) -> Vec<Instant> {
+        self.deferred_poll_deadlines
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .clone()
@@ -593,11 +593,11 @@ impl JobProvider for MockJobProvider {
         }
     }
 
-    async fn defer_poll_after(&self, delay: Duration) {
-        self.deferred_poll_delays
+    async fn defer_poll_until(&self, deadline: Instant) {
+        self.deferred_poll_deadlines
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .push(delay);
+            .push(deadline);
     }
 
     /// Acquire the discovery Mutex to preserve the shutdown deadlock regression shape.

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -21,15 +21,126 @@ pub(crate) use network_policy_refresh::{
     NetworkPolicyRefreshHandle, NetworkPolicyRefreshRegistration,
 };
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, FixedOffset, Utc};
 use sandbox::SandboxId;
+use serde::{Deserialize, Deserializer, de::Error as _};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
+use uuid::Uuid;
 
 use crate::active_input::ActiveInputSource;
 use crate::error::RunnerResult;
 use crate::ids::RunId;
-use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult, SessionAffinityResource};
+use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
+
+const JAVASCRIPT_MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum RunnerPreferenceReason {
+    ExactHistoryGeneration,
+    MatchingReuseKey,
+    FinalizingPredecessor,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct RunnerProcessIdentity {
+    runner_id: Uuid,
+    #[serde(deserialize_with = "deserialize_heartbeat_generation")]
+    heartbeat_generation: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RunnerPreferencePayload {
+    runner_identity: RunnerProcessIdentity,
+    reason: RunnerPreferenceReason,
+    expires_at: DateTime<FixedOffset>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct RunnerPreference {
+    runner_identity: RunnerProcessIdentity,
+    reason: RunnerPreferenceReason,
+    deadline: Instant,
+}
+
+impl RunnerPreference {
+    pub(crate) fn reason(&self) -> RunnerPreferenceReason {
+        self.reason
+    }
+
+    pub(crate) fn deadline(&self) -> Instant {
+        self.deadline
+    }
+
+    pub(crate) fn remaining(&self) -> Duration {
+        self.deadline.saturating_duration_since(Instant::now())
+    }
+
+    pub(crate) fn is_expired(&self) -> bool {
+        self.deadline <= Instant::now()
+    }
+
+    pub(crate) fn targets(&self, runner_id: &str, heartbeat_generation: u64) -> bool {
+        runner_id
+            .parse::<Uuid>()
+            .is_ok_and(|runner_id| runner_id == self.runner_identity.runner_id)
+            && heartbeat_generation == self.runner_identity.heartbeat_generation
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        runner_id: Uuid,
+        heartbeat_generation: u64,
+        reason: RunnerPreferenceReason,
+        deadline: Instant,
+    ) -> Self {
+        Self {
+            runner_identity: RunnerProcessIdentity {
+                runner_id,
+                heartbeat_generation,
+            },
+            reason,
+            deadline,
+        }
+    }
+}
+
+pub(crate) fn parse_runner_preference(
+    value: Option<serde_json::Value>,
+) -> Result<Option<RunnerPreference>, serde_json::Error> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let payload: RunnerPreferencePayload = serde_json::from_value(value)?;
+    let now = Instant::now();
+    let remaining = (payload.expires_at.with_timezone(&Utc) - Utc::now())
+        .to_std()
+        .unwrap_or_default();
+    let deadline = now
+        .checked_add(remaining)
+        .ok_or_else(|| serde_json::Error::custom("runner preference expiry is out of range"))?;
+    Ok(Some(RunnerPreference {
+        runner_identity: payload.runner_identity,
+        reason: payload.reason,
+        deadline,
+    }))
+}
+
+fn deserialize_heartbeat_generation<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = u64::deserialize(deserializer)?;
+    if value == 0 || value > JAVASCRIPT_MAX_SAFE_INTEGER {
+        return Err(D::Error::custom(
+            "heartbeat generation must be a positive JavaScript safe integer",
+        ));
+    }
+    Ok(value)
+}
 
 /// Low-cardinality source that first discovered a job candidate.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -66,11 +177,8 @@ pub struct JobCandidate {
     poll_due_to_job_discovered_elapsed: Option<Duration>,
     poll_http_request_elapsed: Option<Duration>,
     reuse_key: Option<String>,
-    cli_agent_session_id: Option<String>,
-    session_affinity_resource: Option<SessionAffinityResource>,
     history_generation_run_id: Option<RunId>,
-    history_generation_affinity_protected_until: Option<DateTime<Utc>>,
-    affinity_protected_until: Option<DateTime<Utc>>,
+    runner_preference: Option<RunnerPreference>,
 }
 
 impl JobCandidate {
@@ -100,11 +208,8 @@ impl JobCandidate {
             poll_due_to_job_discovered_elapsed: None,
             poll_http_request_elapsed: None,
             reuse_key: None,
-            cli_agent_session_id: None,
-            session_affinity_resource: None,
             history_generation_run_id: None,
-            history_generation_affinity_protected_until: None,
-            affinity_protected_until: None,
+            runner_preference: None,
         }
     }
 
@@ -190,63 +295,33 @@ impl JobCandidate {
         self.poll_http_request_elapsed
     }
 
-    pub(crate) fn cli_agent_session_id(&self) -> Option<&str> {
-        self.cli_agent_session_id.as_deref()
-    }
-
     pub(crate) fn reuse_key(&self) -> Option<&str> {
         self.reuse_key.as_deref()
-    }
-
-    pub(crate) fn session_affinity_resource(&self) -> Option<SessionAffinityResource> {
-        self.session_affinity_resource
     }
 
     pub(crate) fn history_generation_run_id(&self) -> Option<RunId> {
         self.history_generation_run_id
     }
 
-    pub(crate) fn affinity_protection_remaining(&self) -> Option<Duration> {
-        protection_remaining(self.affinity_protected_until)
+    pub(crate) fn runner_preference(&self) -> Option<&RunnerPreference> {
+        self.runner_preference.as_ref()
     }
 
-    pub(crate) fn is_affinity_protected(&self) -> bool {
-        self.affinity_protection_remaining()
-            .is_some_and(|remaining| !remaining.is_zero())
-    }
-
-    pub(crate) fn history_generation_affinity_protection_remaining(&self) -> Option<Duration> {
-        let generation_remaining =
-            protection_remaining(self.history_generation_affinity_protected_until)?;
-        let session_remaining = self.affinity_protection_remaining()?;
-        Some(generation_remaining.min(session_remaining))
-    }
-
-    pub(crate) fn is_history_generation_affinity_protected(&self) -> bool {
-        self.history_generation_affinity_protection_remaining()
-            .is_some_and(|remaining| !remaining.is_zero())
-    }
-
-    pub(crate) fn with_affinity_metadata(
-        mut self,
-        reuse_key: Option<String>,
-        cli_agent_session_id: Option<String>,
-        affinity_protected_until: Option<String>,
-    ) -> Self {
-        self.reuse_key = reuse_key.filter(|reuse_key| !reuse_key.is_empty());
-        self.cli_agent_session_id =
-            cli_agent_session_id.filter(|session_id| !session_id.is_empty());
-        self.affinity_protected_until = affinity_protected_until
-            .as_deref()
-            .and_then(parse_affinity_protected_until);
+    pub(crate) fn without_runner_preference(mut self) -> Self {
+        self.runner_preference = None;
         self
     }
 
-    pub(crate) fn with_session_affinity_resource(
+    pub(crate) fn with_reuse_key(mut self, reuse_key: Option<String>) -> Self {
+        self.reuse_key = reuse_key.filter(|reuse_key| !reuse_key.is_empty());
+        self
+    }
+
+    pub(crate) fn with_runner_preference(
         mut self,
-        resource: Option<SessionAffinityResource>,
+        runner_preference: Option<RunnerPreference>,
     ) -> Self {
-        self.session_affinity_resource = resource;
+        self.runner_preference = runner_preference;
         self
     }
 
@@ -255,16 +330,6 @@ impl JobCandidate {
         history_generation_run_id: Option<RunId>,
     ) -> Self {
         self.history_generation_run_id = history_generation_run_id;
-        self
-    }
-
-    pub(crate) fn with_history_generation_affinity_protected_until(
-        mut self,
-        protected_until: Option<String>,
-    ) -> Self {
-        self.history_generation_affinity_protected_until = protected_until
-            .as_deref()
-            .and_then(parse_affinity_protected_until);
         self
     }
 
@@ -310,21 +375,6 @@ impl JobCandidate {
             ..Self::new_with_discovered_at(run_id, profile_name, discovered_at)
         }
     }
-}
-
-fn parse_affinity_protected_until(value: &str) -> Option<DateTime<Utc>> {
-    DateTime::parse_from_rfc3339(value)
-        .ok()
-        .map(|parsed| parsed.with_timezone(&Utc))
-}
-
-fn protection_remaining(protected_until: Option<DateTime<Utc>>) -> Option<Duration> {
-    let protected_until = protected_until?;
-    let now = Utc::now();
-    if protected_until <= now {
-        return None;
-    }
-    (protected_until - now).to_std().ok()
 }
 
 /// Job claim result with the context and auth required for terminal completion.
@@ -596,26 +646,5 @@ mod tests {
         assert_eq!(context.run_id, run_id);
         assert!(active_input_source.is_none());
         assert!(completion_auth.matches_sandbox_token_for_test(run_id, "sandbox-token"));
-    }
-
-    #[test]
-    fn history_generation_affinity_never_outlives_session_affinity() {
-        let expired_session = JobCandidate::new(RunId::nil(), "vm0/default".into())
-            .with_affinity_metadata(
-                Some("session:sess-deadline".into()),
-                Some("sess-deadline".into()),
-                Some("2000-01-01T00:00:00Z".into()),
-            )
-            .with_history_generation_affinity_protected_until(Some("2999-01-01T00:00:00Z".into()));
-        assert!(!expired_session.is_history_generation_affinity_protected());
-
-        let active_session = JobCandidate::new(RunId::nil(), "vm0/default".into())
-            .with_affinity_metadata(
-                Some("session:sess-deadline".into()),
-                Some("sess-deadline".into()),
-                Some("2999-01-01T00:00:01Z".into()),
-            )
-            .with_history_generation_affinity_protected_until(Some("2999-01-01T00:00:00Z".into()));
-        assert!(active_session.is_history_generation_affinity_protected());
     }
 }

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -594,10 +594,10 @@ pub trait JobProvider: Send + Sync {
     /// the future to enforce single-flight and lifecycle ordering.
     async fn heartbeat(&self, state: &HeartbeatState);
 
-    /// Delay the next API-backed poll until a protected same-reuse-key job can
-    /// fall back to normal compatible-runner claiming.
+    /// Defer the next API-backed poll until the immutable preference deadline
+    /// allows normal compatible-runner claiming.
     /// Default no-op — only relevant for API-backed providers.
-    async fn defer_poll_after(&self, _delay: Duration) {}
+    async fn defer_poll_until(&self, _deadline: Instant) {}
 
     /// Release discovery resources (subscriptions, background tasks).
     ///

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -35,17 +35,11 @@ pub struct Job {
     pub run_id: RunId,
     pub experimental_profile: String,
     #[serde(default)]
-    pub cli_agent_session_id: Option<String>,
-    #[serde(default)]
     pub reuse_key: Option<String>,
     #[serde(default)]
     pub history_generation_run_id: Option<RunId>,
     #[serde(default)]
-    pub history_generation_affinity_protected_until: Option<String>,
-    #[serde(default)]
-    pub affinity_protected_until: Option<String>,
-    #[serde(default)]
-    pub session_affinity_resource: Option<SessionAffinityResource>,
+    pub runner_preference: Option<serde_json::Value>,
 }
 
 pub(crate) fn reuse_key_kind(reuse_key: &str) -> &'static str {
@@ -60,13 +54,6 @@ impl Job {
     pub(crate) fn reuse_key(&self) -> Option<&str> {
         self.reuse_key.as_deref()
     }
-}
-
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub enum SessionAffinityResource {
-    ReusableSandbox,
-    WorkspaceCache,
 }
 
 // ---------------------------------------------------------------------------
@@ -1476,7 +1463,14 @@ mod tests {
                 "runId": "550e8400-e29b-41d4-a716-446655440000",
                 "experimentalProfile": "browser",
                 "cliAgentSessionId": "legacy-session",
-                "sessionAffinityResource": "workspaceCache"
+                "runnerPreference": {
+                    "runnerIdentity": {
+                        "runnerId": "b85bb257-21c1-4b8f-8676-a4051f35b7b0",
+                        "heartbeatGeneration": 7
+                    },
+                    "reason": "matchingReuseKey",
+                    "expiresAt": "2026-08-03T12:00:00.000Z"
+                }
             }
         });
         let resp: PollResponse = serde_json::from_value(json).unwrap();
@@ -1488,10 +1482,7 @@ mod tests {
                 .unwrap()
         );
         assert_eq!(job.experimental_profile, "browser");
-        assert_eq!(
-            job.session_affinity_resource,
-            Some(SessionAffinityResource::WorkspaceCache)
-        );
+        assert!(job.runner_preference.is_some());
         assert!(job.reuse_key().is_none());
     }
 


### PR DESCRIPTION
## Summary

- consume the canonical strict `runnerPreference` object from Poll and Ably, preserve jobs with malformed optional metadata as ordinary admission, and send the current runner ID/generation on official claims
- replace the legacy affinity deadline/resource branches with one actual-local-resource admission policy for exact generation, matching reuse key, and finalizing predecessor preferences
- retain at most one selected finalizing candidate in the main loop, re-evaluate it on reusable-state changes or its immutable monotonic deadline, and keep unrelated work progressing
- update direct-candidate deduplication atomically so duplicate delivery cannot synthesize routing metadata or extend a same-reason deadline
- preserve the original absolute preference deadline across the provider boundary so scheduling delay cannot renew the HTTP Poll fallback window

## Compatibility and scope

- no database, persisted-state, queue-schema, or API schema changes
- an older API without `runnerPreference` continues through ordinary admission
- current API dual delivery keeps older runners compatible; `finalizingPredecessor` remains dormant until #24560
- the claim body preserves the newly added `activeInput: true` capability alongside `runnerIdentity`

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner provider::api_direct_candidates::tests` (7 passed)
- `cargo test -p runner provider::api_ably_supervisor::tests` (39 passed)
- `cargo test -p runner provider::api::tests` (58 passed)
- `cargo test -p runner cmd::start::tests::main_loop::admission` (25 passed)
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` (2940 passed, 15 ignored; guest inventory passed)

Closes #24559

Parent context: #24355
