### PR TITLE
fix(platform): scope browser cards to chat threads

### DIFF
--- a/turbo/apps/platform/src/signals/browser-session/browser-session-page-setup.ts
+++ b/turbo/apps/platform/src/signals/browser-session/browser-session-page-setup.ts
@@ -20,7 +20,7 @@ export const setupBrowserSessionPage$ = command(
     const descriptor = parseBrowserSessionUrl(`/browsers/${threadId}`);
     set(
       setBrowserSessionPageSignals$,
-      descriptor ? createBrowserSessionSignals(descriptor) : null,
+      descriptor ? createBrowserSessionSignals(descriptor.threadId) : null,
     );
     set(updatePage$, createElement(BrowserSessionPage), "minimal");
     set(

--- a/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
@@ -22,10 +22,6 @@ import { zeroBrowserEnabled$ } from "../external/feature-switch.ts";
 import { pageSignal$ } from "../page-signal.ts";
 import { setAblyPayloadLoop$ } from "../realtime.ts";
 import { onRef, settle, setLoop, withCleanup } from "../utils.ts";
-import {
-  getOrCreateCardSignals,
-  registeredCardSignals,
-} from "./card-signal-map.ts";
 import { parseTrustedPlatformActionUrl } from "./platform-action-url.ts";
 
 // One heartbeat per minute keeps a viewed browser comfortably inside its
@@ -34,9 +30,7 @@ const LEASE_HEARTBEAT_INTERVAL_MS = 60_000;
 
 export interface BrowserSessionDescriptor {
   readonly threadId: string;
-  readonly originalUrl: string;
   readonly href: string;
-  readonly fallbackMarkdown: string;
 }
 
 export interface BrowserSessionSignals extends BrowserSessionDescriptor {
@@ -50,6 +44,7 @@ export interface BrowserSessionSignals extends BrowserSessionDescriptor {
   readonly start$: Command<Promise<void>, [AbortSignal]>;
   readonly stop$: Command<Promise<void>, [AbortSignal]>;
   readonly fitWindow$: Command<Promise<void>, [number, AbortSignal]>;
+  readonly subscribe$: Command<Promise<void>, [AbortSignal]>;
   // Attach to the visible panel container: the lease heartbeat lives exactly as
   // long as that element is mounted.
   readonly keepAliveRef$: Command<
@@ -71,16 +66,8 @@ export interface BrowserLifecycleOptimisticEvents {
   >;
 }
 
-export interface BrowserSessionCardSignalsRegistry {
-  readonly browser: BrowserSessionSignals;
-  register(descriptor: BrowserSessionDescriptor): BrowserSessionSignals;
-  resolve(resourceKey: string): BrowserSessionSignals;
-  readonly subscribe$: Command<Promise<void>, [AbortSignal]>;
-}
-
 export function parseBrowserSessionUrl(
   value: string,
-  fallbackMarkdown: string = value,
 ): BrowserSessionDescriptor | null {
   const url = parseTrustedPlatformActionUrl(value);
   if (!url) {
@@ -95,9 +82,7 @@ export function parseBrowserSessionUrl(
   }
   return {
     threadId,
-    originalUrl: value,
     href: `/browsers/${threadId}`,
-    fallbackMarkdown,
   };
 }
 
@@ -298,10 +283,50 @@ function createStopBrowserSignals({
   };
 }
 
-export function createBrowserSessionSignals(
+function createBrowserSessionSubscriptionSignals(
   descriptor: BrowserSessionDescriptor,
+  reload$: BrowserSessionSignals["reload$"],
+): Pick<BrowserSessionSignals, "subscribe$"> {
+  const reloadBrowserSession$ = command(
+    ({ set }, _signal: AbortSignal): boolean => {
+      set(reload$);
+      return false;
+    },
+  );
+  const onBrowserSessionChanged$ = command(
+    ({ set }, payload: unknown, _signal: AbortSignal): boolean => {
+      const parsed = browserSessionChangedPayloadSchema.safeParse(payload);
+      if (parsed.success && parsed.data.threadId === descriptor.threadId) {
+        set(reload$);
+      }
+      return false;
+    },
+  );
+  const subscribe$ = command(
+    async ({ set }, signal: AbortSignal): Promise<void> => {
+      await set(
+        setAblyPayloadLoop$,
+        {
+          topic: "browserSessionChanged",
+          loopCommand$: onBrowserSessionChanged$,
+          catchUpCommand$: reloadBrowserSession$,
+          options: { runOnSubscribe: true },
+        },
+        signal,
+      );
+    },
+  );
+  return { subscribe$ };
+}
+
+export function createBrowserSessionSignals(
+  threadId: string,
   optimisticEvents?: BrowserLifecycleOptimisticEvents,
 ): BrowserSessionSignals {
+  const descriptor: BrowserSessionDescriptor = {
+    threadId,
+    href: `/browsers/${threadId}`,
+  };
   const reloadVersion$ = state(0);
   const sessionOverride$ = state<ZeroBrowserSession | null | undefined>(
     undefined,
@@ -340,6 +365,10 @@ export function createBrowserSessionSignals(
   };
   const startSignals = createStartBrowserSignals(mutationContext);
   const stopSignals = createStopBrowserSignals(mutationContext);
+  const subscriptionSignals = createBrowserSessionSubscriptionSignals(
+    descriptor,
+    reload$,
+  );
 
   const keepAliveRef$ = onRef(
     command(
@@ -398,6 +427,7 @@ export function createBrowserSessionSignals(
     reload$,
     reloadPanel$: reload$,
     fitWindow$,
+    ...subscriptionSignals,
     keepAliveRef$,
   };
 }
@@ -416,78 +446,4 @@ export function browserSessionReclaimHint(
         },
       )
     : null;
-}
-
-export function createBrowserSessionCardSignalsRegistry(
-  threadId: string,
-  optimisticEvents?: BrowserLifecycleOptimisticEvents,
-): BrowserSessionCardSignalsRegistry {
-  const signalsByResourceKey = new Map<string, BrowserSessionSignals>();
-  const signalsByThreadId = new Map<string, BrowserSessionSignals>();
-  const browser = createBrowserSessionSignals(
-    {
-      threadId,
-      originalUrl: `/browsers/${threadId}`,
-      href: `/browsers/${threadId}`,
-      fallbackMarkdown: `/browsers/${threadId}`,
-    },
-    optimisticEvents,
-  );
-  signalsByThreadId.set(threadId, browser);
-  const reloadAll$ = command(({ set }, _signal: AbortSignal): boolean => {
-    for (const signals of signalsByThreadId.values()) {
-      set(signals.reload$);
-    }
-    return false;
-  });
-  const onBrowserSessionChanged$ = command(
-    ({ set }, payload: unknown, _signal: AbortSignal): boolean => {
-      const parsed = browserSessionChangedPayloadSchema.safeParse(payload);
-      if (!parsed.success) {
-        return false;
-      }
-      const signals = signalsByThreadId.get(parsed.data.threadId);
-      if (signals) {
-        set(signals.reload$);
-      }
-      return false;
-    },
-  );
-  const subscribe$ = command(
-    async ({ set }, signal: AbortSignal): Promise<void> => {
-      await set(
-        setAblyPayloadLoop$,
-        {
-          topic: "browserSessionChanged",
-          loopCommand$: onBrowserSessionChanged$,
-          catchUpCommand$: reloadAll$,
-          options: { runOnSubscribe: true },
-        },
-        signal,
-      );
-    },
-  );
-  return {
-    browser,
-    register(descriptor) {
-      const shared = getOrCreateCardSignals(
-        signalsByThreadId,
-        descriptor.threadId,
-        () => {
-          return createBrowserSessionSignals(descriptor, optimisticEvents);
-        },
-      );
-      return getOrCreateCardSignals(
-        signalsByResourceKey,
-        descriptor.fallbackMarkdown,
-        () => {
-          return { ...shared, ...descriptor };
-        },
-      );
-    },
-    resolve(resourceKey) {
-      return registeredCardSignals(signalsByResourceKey, resourceKey);
-    },
-    subscribe$,
-  };
 }

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-body-blocks.ts
@@ -25,9 +25,13 @@ function chatEventBodyContent(event: ChatEvent): string {
   return event.content?.trim() ?? "";
 }
 
-export function parseChatEventBodyBlocks(event: ChatEvent): ParsedBodyBlock[] {
+export function parseChatEventBodyBlocks(
+  event: ChatEvent,
+  threadId: string,
+): ParsedBodyBlock[] {
   const content = chatEventBodyContent(event);
   return parseBodyBlocks(content, {
     previews: chatEventCompatibilityRole(event.eventType) === "assistant",
+    browserThreadId: threadId,
   }).blocks;
 }

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -179,9 +179,9 @@ import {
   type MailDraftSignals,
 } from "./mail-draft.ts";
 import {
-  createBrowserSessionCardSignalsRegistry,
+  createBrowserSessionSignals,
   type BrowserLifecycleOptimisticEvents,
-  type BrowserSessionCardSignalsRegistry,
+  type BrowserSessionSignals,
 } from "./browser-session-block.ts";
 import { createChatThreadContainerSignals } from "./chat-thread-container.ts";
 import { createAssistantErrorRecoverySignals } from "./assistant-error-recovery.ts";
@@ -1172,6 +1172,7 @@ function registerEventAgentReferences(
 }
 
 function registerChatEvent(
+  threadId: string,
   event: PersistedChatEvent,
   registerBodyBlocks: BodyBlocksRenderer,
   artifactCardSignals: ArtifactCardSignalsRegistry,
@@ -1181,17 +1182,19 @@ function registerChatEvent(
   registerEventAgentReferences(event, agentReferenceSignals);
   const blocks = skipsEventBodyRendering(event)
     ? []
-    : registerBodyBlocks(parseChatEventBodyBlocks(event));
+    : registerBodyBlocks(parseChatEventBodyBlocks(event, threadId));
   return { event, blocks };
 }
 
 function registerPersistentEvents({
+  threadId,
   persistentEvents,
   events,
   registerBodyBlocks,
   artifactCardSignals,
   agentReferenceSignals,
 }: {
+  threadId: string;
   persistentEvents: readonly RegisteredChatEvent[];
   events: readonly PersistedChatEvent[];
   registerBodyBlocks: BodyBlocksRenderer;
@@ -1215,6 +1218,7 @@ function registerPersistentEvents({
   }
   return events.map((event) => {
     return registerChatEvent(
+      threadId,
       event,
       registerBodyBlocks,
       artifactCardSignals,
@@ -1842,7 +1846,7 @@ interface BodyBlockRegistries {
   readonly mailDraftCardSignals: ReturnType<
     typeof createMailDraftCardSignalsRegistry
   >;
-  readonly browserSessionCardSignals: BrowserSessionCardSignalsRegistry;
+  readonly browserSessionSignals: BrowserSessionSignals;
 }
 
 function createBodyBlocksRenderer({
@@ -1853,7 +1857,7 @@ function createBodyBlocksRenderer({
   computerUseAuthorizationCardSignals,
   planUpgradeCardSignals,
   mailDraftCardSignals,
-  browserSessionCardSignals,
+  browserSessionSignals,
 }: BodyBlockRegistries): (
   resolution: "register" | "resolve",
 ) => BodyBlocksRenderer {
@@ -1942,10 +1946,7 @@ function createBodyBlocksRenderer({
             return {
               type: block.type,
               resourceKey: block.resourceKey,
-              signals:
-                resolution === "register"
-                  ? browserSessionCardSignals.register(block.descriptor)
-                  : browserSessionCardSignals.resolve(block.resourceKey),
+              signals: browserSessionSignals,
             };
           }
         }
@@ -1981,6 +1982,7 @@ function createIndexedDbEventCacheSignals({
       if (result.value.length > 0) {
         const registeredEvents = result.value.map((event) => {
           return registerChatEvent(
+            threadId,
             event,
             registerBodyBlocks,
             artifactCardSignals,
@@ -2024,7 +2026,7 @@ function createPagedEventResources(
   initialOptimisticEntries: readonly OptimisticChatEventEntry[],
 ) {
   const mailDraftCardSignals = createMailDraftCardSignalsRegistry(threadId);
-  const browserSessionCardSignals = createBrowserSessionCardSignalsRegistry(
+  const browserSessionSignals = createBrowserSessionSignals(
     threadId,
     browserLifecycleOptimisticEvents,
   );
@@ -2041,7 +2043,7 @@ function createPagedEventResources(
       createComputerUseAuthorizationCardSignalsRegistry(),
     planUpgradeCardSignals: createPlanUpgradeCardSignalsRegistry(),
     mailDraftCardSignals,
-    browserSessionCardSignals,
+    browserSessionSignals,
   });
   const registerBodyBlocks = bodyBlocksRenderer("register");
   const registerOptimisticEventResources = (
@@ -2060,8 +2062,8 @@ function createPagedEventResources(
     mailDraftCardSignals,
     publicSignals: {
       reloadMailDrafts$: mailDraftCardSignals.reload$,
-      browserSessionSignals: browserSessionCardSignals.browser,
-      subscribeBrowserSessions$: browserSessionCardSignals.subscribe$,
+      browserSessionSignals,
+      subscribeBrowserSessions$: browserSessionSignals.subscribe$,
       artifactSignalsForUrl: (url: string): ArtifactSignals | undefined => {
         return artifactCardSignals.find(url);
       },
@@ -2369,6 +2371,7 @@ function createPagedEvents(
       }
       const scrollPosition = get(effects.scroll.threadScrollPosition$);
       const registeredEvents = registerPersistentEvents({
+        threadId,
         persistentEvents: get(persistentChatEvents$),
         events,
         registerBodyBlocks: resources.registerBodyBlocks,

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-events.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-events.ts
@@ -22,7 +22,7 @@ export function createOptimisticChatEventEntry(
 ): OptimisticChatEventEntry {
   return {
     ...input,
-    parsedBodyBlocks: parseChatEventBodyBlocks(input.event),
+    parsedBodyBlocks: parseChatEventBodyBlocks(input.event, input.threadId),
   };
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -158,6 +158,11 @@ type OpenMarkdownFence = {
   lines: string[];
 };
 
+interface ParseBodyBlocksOptions {
+  readonly previews?: boolean;
+  readonly browserThreadId?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -752,7 +757,10 @@ function extractActionUrlFromLine(line: string): string | null {
   return urls.length === 1 ? urls[0]! : null;
 }
 
-function createActionBlockFromLine(line: string): Extract<
+function createActionBlockFromLine(
+  line: string,
+  browserThreadId: string | undefined,
+): Extract<
   ParsedBodyBlock,
   {
     type:
@@ -824,11 +832,11 @@ function createActionBlockFromLine(line: string): Extract<
     };
   }
 
-  const browserSession = parseBrowserSessionUrl(url, line);
-  if (browserSession) {
+  const browserSession = parseBrowserSessionUrl(url);
+  if (browserSession && browserSession.threadId === browserThreadId) {
     return {
       type: "browser-session",
-      resourceKey: browserSession.fallbackMarkdown,
+      resourceKey: browserSession.href,
       descriptor: browserSession,
     };
   }
@@ -946,7 +954,7 @@ function markdownTableRowIndexes(lines: string[]): Set<number> {
 
 export function parseBodyBlocks(
   content: string,
-  options: { previews?: boolean } = {},
+  options: ParseBodyBlocksOptions = {},
 ): {
   cleanContent: string;
   blocks: ParsedBodyBlock[];
@@ -1016,7 +1024,9 @@ export function parseBodyBlocks(
       continue;
     }
 
-    const actionBlock = previews ? createActionBlockFromLine(line) : null;
+    const actionBlock = previews
+      ? createActionBlockFromLine(line, options.browserThreadId)
+      : null;
     if (actionBlock) {
       if (actionBlock.type === "connector-action") {
         const retainedMarkdown = retainedConnectorActionMarkdown(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -3874,9 +3874,10 @@ describe("chat event action cards", () => {
     });
   });
 
-  it("renders trusted browser links as preview cards and reuses the screenshot when paused", async () => {
+  it("renders current-thread browser links as cards and keeps other browser links", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "c0000000-0000-4000-a000-000000000080";
+    const otherThreadId = "c0000000-0000-4000-a000-000000000079";
     const liveUrl =
       "https://live.browser-use.com/?wss=test-browser-session-token";
     const screenshotUrl =
@@ -3909,6 +3910,7 @@ describe("chat event action cards", () => {
     });
 
     const untrustedUrl = `https://evil.example.test/browsers/${threadId}`;
+    const otherThreadUrl = `https://app.vm0.ai/browsers/${otherThreadId}`;
     mockChatLifecycle(context, {
       threadId,
       threadTitle: "Managed browser card",
@@ -3919,6 +3921,7 @@ describe("chat event action cards", () => {
           content: [
             `https://app.vm0.ai/browsers/${threadId}`,
             `[Open browser](/browsers/${threadId})`,
+            `[Other thread browser](${otherThreadUrl})`,
             `[Untrusted browser](${untrustedUrl})`,
           ].join("\n"),
           runId: "c0000000-0000-4000-a000-000000000085",
@@ -4030,6 +4033,11 @@ describe("chat event action cards", () => {
         resumedLiveUrl,
       );
     });
+    expect(
+      queryAllByRoleFast("link").find((link) => {
+        return link.textContent === "Other thread browser";
+      }),
+    ).toHaveAttribute("href", otherThreadUrl);
     expect(
       queryAllByRoleFast("link").find((link) => {
         return link.textContent === "Untrusted browser";


### PR DESCRIPTION
## Summary

- create one managed-browser signal graph for each chat thread signals object
- attach every current-thread browser card occurrence and the thread sidebar to that shared graph
- keep browser links for other chat threads as ordinary links and remove the obsolete fallback-keyed registry

## User impact

Repeated browser cards in one chat thread now always reflect the same browser state. A copied browser link for another chat thread remains a normal link instead of rendering a card for that other thread.

## Verification

- `pnpm exec prettier --check <changed files>`
- `pnpm exec oxlint <changed files>`
- `pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json <changed files>`
- `pnpm exec eslint <changed files> --max-warnings 0`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-event-action-cards.test.tsx -t "renders current-thread browser links as cards and keeps other browser links" --maxWorkers=1`
