### PR TITLE
feat(platform): auto-fit browser viewport when sidebar opens

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
@@ -12,6 +12,7 @@ import {
   type Computed,
   type State,
 } from "ccstate";
+import { animationFrame } from "signal-timers";
 
 import { formatAppNumber } from "../../i18n/format.ts";
 import { i18n } from "../../i18n/index.ts";
@@ -21,7 +22,13 @@ import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
 import { zeroBrowserEnabled$ } from "../external/feature-switch.ts";
 import { pageSignal$ } from "../page-signal.ts";
 import { setAblyPayloadLoop$ } from "../realtime.ts";
-import { onRef, settle, setLoop, withCleanup } from "../utils.ts";
+import {
+  createDeferredPromise,
+  onRef,
+  settle,
+  setLoop,
+  withCleanup,
+} from "../utils.ts";
 import { parseTrustedPlatformActionUrl } from "./platform-action-url.ts";
 
 // One heartbeat per minute keeps a viewed browser comfortably inside its
@@ -43,7 +50,11 @@ export interface BrowserSessionSignals extends BrowserSessionDescriptor {
   readonly reloadPanel$: Command<void, []>;
   readonly start$: Command<Promise<void>, [AbortSignal]>;
   readonly stop$: Command<Promise<void>, [AbortSignal]>;
-  readonly fitWindow$: Command<Promise<void>, [number, AbortSignal]>;
+  readonly fitViewport$: Command<Promise<void>, [HTMLElement, AbortSignal]>;
+  readonly autoFitViewportRef$: Command<
+    (() => void) | undefined,
+    [HTMLElement | null]
+  >;
   readonly subscribe$: Command<Promise<void>, [AbortSignal]>;
   // Attach to the visible panel container: the lease heartbeat lives exactly as
   // long as that element is mounted.
@@ -107,10 +118,75 @@ async function fetchBrowserSession(
   return response.status === 200 ? response.body.browser : null;
 }
 
+function isActiveSidebarSizeTransition(animation: Animation): boolean {
+  if (!("transitionProperty" in animation)) {
+    return false;
+  }
+  const property = animation.transitionProperty;
+  return (
+    (property === "flex-basis" || property === "width") &&
+    animation.playState !== "finished" &&
+    animation.playState !== "idle"
+  );
+}
+
+function waitForBrowserSidebarLayout(
+  viewport: HTMLElement,
+  signal: AbortSignal,
+): Promise<void> {
+  const sidebarPane = viewport.closest<HTMLElement>(
+    "[data-chat-thread-sidebar-pane]",
+  );
+  if (!sidebarPane) {
+    throw new Error("Browser viewport is outside the thread sidebar pane");
+  }
+  const pane = sidebarPane;
+
+  const ready = createDeferredPromise<void>(signal);
+  function cleanup(): void {
+    pane.removeEventListener("transitionend", handleTransitionSettled);
+    pane.removeEventListener("transitioncancel", handleTransitionSettled);
+    signal.removeEventListener("abort", cleanup);
+  }
+  function finish(): void {
+    cleanup();
+    if (!ready.settled()) {
+      ready.resolve(undefined);
+    }
+  }
+  function handleTransitionSettled(event: TransitionEvent): void {
+    if (
+      event.target === pane &&
+      (event.propertyName === "flex-basis" || event.propertyName === "width")
+    ) {
+      finish();
+    }
+  }
+
+  pane.addEventListener("transitionend", handleTransitionSettled);
+  pane.addEventListener("transitioncancel", handleTransitionSettled);
+  signal.addEventListener("abort", cleanup, { once: true });
+  animationFrame(
+    () => {
+      const animations =
+        typeof pane.getAnimations === "function" ? pane.getAnimations() : [];
+      if (!animations.some(isActiveSidebarSizeTransition)) {
+        finish();
+      }
+    },
+    { signal },
+  );
+  return ready.promise;
+}
+
 function createFitWindowSignals(
   descriptor: BrowserSessionDescriptor,
+  session$: BrowserSessionSignals["session$"],
   sessionOverride$: State<ZeroBrowserSession | null | undefined>,
-): Pick<BrowserSessionSignals, "fittingWindow$" | "fitWindow$"> {
+): Pick<
+  BrowserSessionSignals,
+  "autoFitViewportRef$" | "fittingWindow$" | "fitViewport$"
+> {
   const fittingWindowState$ = state(false);
   const fitWindow$ = command(
     async (
@@ -144,11 +220,51 @@ function createFitWindowSignals(
       }
     },
   );
+  const fitViewport$ = command(
+    async (
+      { get, set },
+      viewport: HTMLElement,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      const session = await get(session$);
+      signal.throwIfAborted();
+      if (
+        session?.status !== "active" ||
+        session.liveUrl === null ||
+        session.screen?.resizable !== true
+      ) {
+        return;
+      }
+      const { width, height } = viewport.getBoundingClientRect();
+      if (
+        !Number.isFinite(width) ||
+        !Number.isFinite(height) ||
+        width <= 0 ||
+        height <= 0
+      ) {
+        return;
+      }
+      await set(fitWindow$, width / height, signal);
+    },
+  );
+  const autoFitViewportRef$ = onRef(
+    command(
+      async (
+        { set },
+        viewport: HTMLElement,
+        signal: AbortSignal,
+      ): Promise<void> => {
+        await waitForBrowserSidebarLayout(viewport, signal);
+        await set(fitViewport$, viewport, signal);
+      },
+    ),
+  );
   return {
+    autoFitViewportRef$,
     fittingWindow$: computed((get) => {
       return get(fittingWindowState$);
     }),
-    fitWindow$,
+    fitViewport$,
   };
 }
 
@@ -352,10 +468,8 @@ export function createBrowserSessionSignals(
     });
   });
 
-  const { fittingWindow$, fitWindow$ } = createFitWindowSignals(
-    descriptor,
-    sessionOverride$,
-  );
+  const { autoFitViewportRef$, fittingWindow$, fitViewport$ } =
+    createFitWindowSignals(descriptor, session$, sessionOverride$);
   const mutationContext: BrowserMutationSignalContext = {
     descriptor,
     session$,
@@ -423,10 +537,11 @@ export function createBrowserSessionSignals(
     panelSession$: session$,
     ...startSignals,
     ...stopSignals,
+    autoFitViewportRef$,
     fittingWindow$,
     reload$,
     reloadPanel$: reload$,
-    fitWindow$,
+    fitViewport$,
     ...subscriptionSignals,
     keepAliveRef$,
   };

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -753,10 +753,19 @@ describe("thread-owned utility sidebar", () => {
     expect(screen.queryByTestId("artifact-sidebar")).not.toBeInTheDocument();
   });
 
-  it("auto-opens the thread browser while its latest lifecycle event is started", async () => {
+  it("fits the live browser once per sidebar opening and keeps manual fit", async () => {
     const liveUrl = "https://live.browser-use.com/?wss=auto-open-browser";
     const requestStarted = context.mocks.deferred<void>();
     const releaseResponse = context.mocks.deferred<void>();
+    let viewportRect = DOMRect.fromRect({ width: 720, height: 900 });
+    const getBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        return Object.hasOwn(this.dataset, "browserSessionViewport")
+          ? viewportRect
+          : getBoundingClientRect.call(this);
+      },
+    );
     const browser = browserSession({
       name: "Auto-open browser",
       liveUrl,
@@ -818,34 +827,38 @@ describe("thread-owned utility sidebar", () => {
     const frame = await screen.findByTitle("Live browser: Auto-open browser");
     expect(frame).toHaveAttribute("src", liveUrl);
     expect(frame.closest("[data-browser-session-sidebar]")).not.toBeNull();
-    expect(resizeAspectRatios).toStrictEqual([]);
-
-    const viewport = frame.closest("[data-browser-session-viewport]");
-    if (!(viewport instanceof HTMLDivElement)) {
-      throw new Error("Expected a live browser viewport");
-    }
-    vi.spyOn(viewport, "getBoundingClientRect").mockReturnValue(
-      DOMRect.fromRect({
-        width: 720,
-        height: 900,
-      }),
-    );
     const fitWindow = queryAllByRoleFast("button").find((button) => {
       return button.getAttribute("aria-label") === "Fit browser to window";
     });
     if (!(fitWindow instanceof HTMLButtonElement)) {
       throw new Error("Expected the fit browser button");
     }
-    expect(fitWindow).toBeEnabled();
+    await waitFor(() => {
+      expect(resizeAspectRatios).toStrictEqual([0.8]);
+      expect(fitWindow).toBeEnabled();
+    });
+
+    viewportRect = DOMRect.fromRect({ width: 900, height: 600 });
     click(fitWindow);
 
     await waitFor(() => {
       expect(leaseRequests).toBeGreaterThan(0);
-      expect(resizeAspectRatios).toStrictEqual([0.8]);
+      expect(resizeAspectRatios).toStrictEqual([0.8, 1.5]);
       expect(fitWindow).toBeEnabled();
       expect(
         screen.getByTitle("Live browser: Auto-open browser"),
       ).toHaveAttribute("src", liveUrl);
+    });
+
+    click(screen.getByLabelText("Close live browser"));
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Live browser")).not.toBeInTheDocument();
+    });
+
+    viewportRect = DOMRect.fromRect({ width: 600, height: 1000 });
+    click(screen.getByLabelText("Open browser"));
+    await waitFor(() => {
+      expect(resizeAspectRatios).toStrictEqual([0.8, 1.5, 0.6]);
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/browser-session-panel.tsx
+++ b/turbo/apps/platform/src/views/zero-page/browser-session-panel.tsx
@@ -185,6 +185,7 @@ export function BrowserSessionPanel({
 }: BrowserSessionPanelProps) {
   const { t } = useTranslation();
   const sessionLoadable = useLastLoadable(signals.panelSession$);
+  const autoFitViewportRef = useSet(signals.autoFitViewportRef$);
   const keepAliveRef = useSet(signals.keepAliveRef$);
   const start = useSet(signals.start$);
   const starting = useGet(signals.starting$);
@@ -262,6 +263,7 @@ export function BrowserSessionPanel({
     <PanelFrame panelRef={keepAliveRef}>
       {containLiveFrame ? (
         <div
+          ref={autoFitViewportRef}
           data-browser-session-viewport
           style={{ containerType: "size" }}
           className="flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-muted/20"

--- a/turbo/apps/platform/src/views/zero-page/browser-session-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/browser-session-sidebar.tsx
@@ -23,7 +23,7 @@ export function BrowserSessionSidebar({
   onClose,
 }: BrowserSessionSidebarProps) {
   const { t } = useTranslation();
-  const fitWindow = useSet(signals.fitWindow$);
+  const fitViewport = useSet(signals.fitViewport$);
   const fittingWindow = useGet(signals.fittingWindow$);
   const stop = useSet(signals.stop$);
   const stopping = useGet(signals.stopping$);
@@ -50,17 +50,8 @@ export function BrowserSessionSidebar({
     if (!liveViewport) {
       return;
     }
-    const { width, height } = liveViewport.getBoundingClientRect();
-    if (
-      !Number.isFinite(width) ||
-      !Number.isFinite(height) ||
-      width <= 0 ||
-      height <= 0
-    ) {
-      return;
-    }
     detach(
-      fitWindow(width / height, pageSignal),
+      fitViewport(liveViewport, pageSignal),
       Reason.DomCallback,
       "fit browser to sidebar window",
     );

--- a/turbo/apps/platform/src/views/zero-page/chat-thread-sidebar-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-thread-sidebar-shell.tsx
@@ -98,6 +98,7 @@ export function ChatThreadSidebarShell({
       </div>
       {open && <ChatThreadSidebarResizeHandle />}
       <div
+        data-chat-thread-sidebar-pane
         data-testid="chat-thread-sidebar-pane"
         className={cn(
           "flex min-h-0 min-w-0 overflow-hidden",


### PR DESCRIPTION
## Summary

- fit the managed browser to the live sidebar viewport once whenever the Browser sidebar opens
- wait for the sidebar width transition to settle before measuring the viewport
- reuse the same viewport-based resize path for the existing manual Fit action
- cover auto-open, manual Fit, close, and reopen behavior without continuous resizing

## Verification

- `pnpm format`
- `pnpm turbo run lint` (all non-API workspaces passed; the API process hit the default local heap limit)
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api run lint`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/thread-sidebar.test.tsx` (20 tests passed)

Local browser verification was not run because the repository instructions prohibit starting a local dev server unless explicitly requested; the PR pipeline will run the broader checks.
