### PR TITLE
docs(mitm-addon): document catalog wait revalidation

### DIFF
--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -482,7 +482,19 @@ def capture_and_strip_prefetch_marker(flow: http.HTTPFlow) -> None:
 
 
 async def prepare_request(flow: http.HTTPFlow, *, request_end_stream: bool) -> bool:
-    """Serve or prepare a catalog request and report whether it waited for an owner."""
+    """Serve or prepare a catalog request and report whether it crossed a wait.
+
+    ``True`` means the request waited for at least one in-flight owner. The wait may
+    end through owner success, failure or release, timeout, invalidation, or
+    replacement, and the waiter may subsequently become the replacement owner. A
+    local cache response does not continue upstream. Otherwise, a caller that may
+    inject ordinary upstream credentials must revalidate the current upstream
+    continuation before proceeding after a ``True`` result.
+
+    ``mitm_addon._prepare_codex_catalog_request_with_upstream_revalidation()``
+    implements this contract. Its focused lifecycle coverage is
+    ``test_catalog_wait_revalidates_only_provider_continuation``.
+    """
     if _FLOW_STATE in flow.metadata or _FLOW_TELEMETRY in flow.metadata:
         return False
     if flow_metadata.firewall_name(flow.metadata) != _FIREWALL_NAME:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1085,7 +1085,16 @@ async def _prepare_codex_catalog_request_with_upstream_revalidation(
     require_connected: bool,
     request_end_stream: bool,
 ) -> None:
-    """Prepare a local catalog response or revalidate provider continuation."""
+    """Coordinate catalog preparation with post-wait provider revalidation.
+
+    A successful local cache response never continues to the provider. When
+    ``prepare_request()`` reports that this flow waited and no local response exists,
+    the suspension may have invalidated its connector binding, public destination,
+    or host-policy assumptions, so ordinary credential-bearing continuation is
+    revalidated before proceeding. See
+    ``test_catalog_wait_revalidates_only_provider_continuation`` for owner failure,
+    timeout, and local-response coverage across both request hooks.
+    """
     waited_for_in_flight = await codex_model_catalog_cache.prepare_request(
         flow,
         request_end_stream=request_end_stream,


### PR DESCRIPTION
## Summary

- document that a `prepare_request()` result of `True` means the request crossed at least one single-flight wait
- describe owner completion, failure/release, timeout, invalidation, and replacement outcomes
- document the fail-closed revalidation required before credential-bearing upstream continuation
- link the cache contract to its coordinating helper and focused hook-level integration test

## Scope

Documentation only. This PR does not change runtime behavior, the boolean interface, persisted data, protocols, or tests.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_codex_model_catalog_cache_hooks.py -k test_catalog_wait_revalidates_only_provider_continuation` (6 passed)
- `uv run --no-sync python -m pytest tests/` (4629 passed)

Closes #24776
