### PR TITLE
docs(runner): clarify sandbox finalization ownership

### DIFF
--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -112,9 +112,10 @@ pub(super) struct FinalizeContext {
 /// Finalizes ownership of a sandbox returned by the executor.
 ///
 /// `None` requires no sandbox lifecycle action. For `Some`, idle parking is
-/// attempted only after a zero exit code, no cancellation, an open parking
-/// gate, and an available reuse key. Otherwise, or whenever parking cannot
-/// complete, the sandbox is stopped and destroyed.
+/// considered only when the exit code is zero, cancellation is not active, the
+/// parking gate is open, and a reuse key is available. Otherwise, or if
+/// cancellation wins before ownership transfer or parking cannot complete, the
+/// sandbox is stopped and destroyed.
 pub(super) async fn finalize_sandbox_for_completion(
     sandbox: Option<Box<dyn Sandbox>>,
     active_lease: ActiveBudgetLease,

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -109,6 +109,12 @@ pub(super) struct FinalizeContext {
     pub(super) test_observer: StartLoopTestObserver,
 }
 
+/// Finalizes ownership of a sandbox returned by the executor.
+///
+/// `None` requires no sandbox lifecycle action. For `Some`, idle parking is
+/// attempted only after a zero exit code, no cancellation, an open parking
+/// gate, and an available reuse key. Otherwise, or whenever parking cannot
+/// complete, the sandbox is stopped and destroyed.
 pub(super) async fn finalize_sandbox_for_completion(
     sandbox: Option<Box<dyn Sandbox>>,
     active_lease: ActiveBudgetLease,

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -9,10 +9,12 @@
 //! kept-alive idle VM.
 //!
 //! Both paths return `ExecuteOutcome` plus a pending `JobTelemetry`
-//! buffer. When `ExecuteOutcome::sandbox` is `Some`, the sandbox is still alive
-//! and the caller decides whether to park it for reuse or destroy it. The
-//! caller also flushes telemetry after firing `provider.complete`, so the
-//! user-visible completion signal is not blocked on best-effort uploads.
+//! buffer. When `ExecuteOutcome::sandbox` is `Some`, the executor transfers
+//! ownership of a still-live sandbox that the caller must finalize through the
+//! runner's park-or-destroy path. Presence alone does not mean the sandbox can
+//! be parked. The caller also flushes telemetry after firing
+//! `provider.complete`, so the user-visible completion signal is not blocked on
+//! best-effort uploads.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -236,12 +238,20 @@ impl ExecutionHooks {
     }
 }
 
-/// Outcome of a job execution, including the sandbox for possible reuse.
+/// Outcome of a job execution and ownership of any sandbox still alive afterward.
 pub struct ExecuteOutcome {
     pub failure: Option<ExecutionFailure>,
-    /// The sandbox after execution. `Some` when the sandbox is still alive
-    /// and eligible for keep-alive parking. `None` when execution failed
-    /// during create/start (sandbox was destroyed inline).
+    /// Sandbox ownership after execution.
+    ///
+    /// `Some` transfers a still-live sandbox to the caller for finalization; it
+    /// does not imply the sandbox is eligible for reuse. Finalization may
+    /// attempt parking only after a zero exit code, no cancellation, an open
+    /// parking gate, and an available reuse key. A failed or rejected park
+    /// attempt still destroys the sandbox.
+    ///
+    /// `None` means no live sandbox ownership is returned, either because no
+    /// sandbox was created or because executor-side cleanup already consumed
+    /// it.
     pub sandbox: Option<Box<dyn Sandbox>>,
     pub source_ip: String,
     pub network_log_session: Option<NetworkLogSession>,

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -244,10 +244,10 @@ pub struct ExecuteOutcome {
     /// Sandbox ownership after execution.
     ///
     /// `Some` transfers a still-live sandbox to the caller for finalization; it
-    /// does not imply the sandbox is eligible for reuse. Finalization may
-    /// attempt parking only after a zero exit code, no cancellation, an open
-    /// parking gate, and an available reuse key. A failed or rejected park
-    /// attempt still destroys the sandbox.
+    /// does not imply the sandbox is eligible for reuse. Finalization considers
+    /// parking only when the exit code is zero, cancellation is not active, the
+    /// parking gate is open, and a reuse key is available. Cancellation before
+    /// ownership transfer or an unsuccessful park still destroys the sandbox.
     ///
     /// `None` means no live sandbox ownership is returned, either because no
     /// sandbox was created or because executor-side cleanup already consumed

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1378,9 +1378,10 @@ async fn execute_job_nonzero_exit_still_returns_sandbox() {
     )
     .await;
 
-    // Sandbox should be alive regardless of exit code (caller decides fate)
+    // The executor returns sandbox ownership even though finalization must
+    // destroy it after a non-zero exit.
     assert!(
         outcome.sandbox.is_some(),
-        "sandbox must be returned for caller to stop+destroy or park"
+        "sandbox must be returned for caller finalization"
     );
 }


### PR DESCRIPTION
## Summary

- clarify that `ExecuteOutcome::sandbox` transfers ownership of a still-live sandbox for finalization rather than proving reuse eligibility
- document the zero-exit, cancellation, parking-gate, and reuse-key inputs to the park-or-destroy decision
- define the finalizer's behavior for absent sandboxes and unsuccessful park attempts
- align the existing non-zero-exit test wording with the same finalization contract

## Scope

- documentation only; no runtime, protocol, persistence, or deployment behavior changes
- no new tests because existing runner integration tests already cover the documented `Some`, `None`, park, and destroy paths

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --bin runner execute_job_nonzero_exit_still_returns_sandbox`
- repository pre-commit and commit-message hooks

Closes #24775
