### PR TITLE
fix(guest-agent): use process-owned mock build locks

### DIFF
--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -642,63 +642,55 @@ fn build_and_locate_mock_package(package: &str, binary: &str) -> Result<PathBuf,
     let fingerprint = mock_fingerprint(&package_dir, profile_dir_name)?;
     let marker = target_dir.join(format!(".vm0-{package}-{profile_dir_name}.fingerprint"));
     let lock = target_dir.join(format!(".vm0-{package}-{profile_dir_name}.lock"));
+    let _lock = acquire_mock_build_lock(&lock)?;
 
-    while std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&lock)
-        .is_err()
-    {
-        if std::fs::metadata(&lock)
-            .and_then(|metadata| metadata.modified())
-            .ok()
-            .and_then(|modified| modified.elapsed().ok())
-            .is_some_and(|age| age > Duration::from_secs(600))
-        {
-            let _ = std::fs::remove_file(&lock);
-            continue;
-        }
-        std::thread::sleep(Duration::from_millis(25));
+    if mock.exists() && std::fs::read_to_string(&marker).ok().as_deref() == Some(&fingerprint) {
+        return Ok(mock);
     }
 
-    let result = (|| {
-        if mock.exists() && std::fs::read_to_string(&marker).ok().as_deref() == Some(&fingerprint) {
-            return Ok(mock.clone());
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(["build", "-p", package, "--quiet"])
+        .arg("--target-dir")
+        .arg(target_dir);
+    // Cargo profile → output dir mapping:
+    //   --release            → target_dir/release
+    //   --profile <name>     → target_dir/<name>
+    //   (default / dev)      → target_dir/debug
+    // So pick the flag that lands the artifact beside our test binary.
+    match profile_dir_name {
+        "debug" => {}
+        "release" => {
+            cmd.arg("--release");
         }
+        other => {
+            cmd.args(["--profile", other]);
+        }
+    }
 
-        let mut cmd = std::process::Command::new("cargo");
-        cmd.args(["build", "-p", package, "--quiet"])
-            .arg("--target-dir")
-            .arg(target_dir);
-        // Cargo profile → output dir mapping:
-        //   --release            → target_dir/release
-        //   --profile <name>     → target_dir/<name>
-        //   (default / dev)      → target_dir/debug
-        // So pick the flag that lands the artifact beside our test binary.
-        match profile_dir_name {
-            "debug" => {}
-            "release" => {
-                cmd.arg("--release");
-            }
-            other => {
-                cmd.args(["--profile", other]);
-            }
-        }
+    let status = cmd
+        .status()
+        .map_err(|e| format!("invoke cargo build: {e}"))?;
+    if !status.success() {
+        return Err(format!("cargo build -p {package} failed"));
+    }
+    if !mock.exists() {
+        return Err(format!("mock binary not found at {}", mock.display()));
+    }
+    std::fs::write(&marker, fingerprint).map_err(|e| format!("write mock fingerprint: {e}"))?;
+    Ok(mock)
+}
 
-        let status = cmd
-            .status()
-            .map_err(|e| format!("invoke cargo build: {e}"))?;
-        if !status.success() {
-            return Err(format!("cargo build -p {package} failed"));
-        }
-        if !mock.exists() {
-            return Err(format!("mock binary not found at {}", mock.display()));
-        }
-        std::fs::write(&marker, fingerprint).map_err(|e| format!("write mock fingerprint: {e}"))?;
-        Ok(mock.clone())
-    })();
-    let _ = std::fs::remove_file(lock);
-    result
+pub fn acquire_mock_build_lock(lock: &Path) -> Result<std::fs::File, String> {
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(lock)
+        .map_err(|e| format!("open mock build lock {}: {e}", lock.display()))?;
+    file.lock()
+        .map_err(|e| format!("lock mock build file {}: {e}", lock.display()))?;
+    Ok(file)
 }
 
 fn mock_fingerprint(package_dir: &Path, profile: &str) -> Result<String, String> {

--- a/crates/guest-agent/tests/mock_build_lock.rs
+++ b/crates/guest-agent/tests/mock_build_lock.rs
@@ -2,7 +2,6 @@
 
 mod common;
 
-use std::ffi::OsStr;
 use std::fs::{OpenOptions, TryLockError};
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
@@ -11,7 +10,7 @@ use std::time::Duration;
 use tokio::process::{Child, Command};
 
 const TEST_NAME: &str = "mock_build_lock_recovers_after_holder_exit";
-const MODE_ENV: &str = "VM0_MOCK_BUILD_LOCK_TEST_MODE";
+const HOLDER_ENV: &str = "VM0_MOCK_BUILD_LOCK_TEST_HOLDER";
 const LOCK_PATH_ENV: &str = "VM0_MOCK_BUILD_LOCK_TEST_PATH";
 const STARTED_PATH_ENV: &str = "VM0_MOCK_BUILD_LOCK_TEST_STARTED_PATH";
 const READY_PATH_ENV: &str = "VM0_MOCK_BUILD_LOCK_TEST_READY_PATH";
@@ -23,8 +22,12 @@ struct HolderProcess {
 
 impl HolderProcess {
     fn spawn(lock: &Path, started: &Path, ready: &Path) -> io::Result<Self> {
-        let mut command = child_command("holder", lock)?;
-        let child = command
+        let child = Command::new(std::env::current_exe()?)
+            .arg("--exact")
+            .arg(TEST_NAME)
+            .arg("--nocapture")
+            .env(HOLDER_ENV, "1")
+            .env(LOCK_PATH_ENV, lock)
             .env(STARTED_PATH_ENV, started)
             .env(READY_PATH_ENV, ready)
             .stdin(Stdio::piped())
@@ -58,8 +61,8 @@ impl HolderProcess {
 
 #[tokio::test]
 async fn mock_build_lock_recovers_after_holder_exit() -> Result<(), Box<dyn std::error::Error>> {
-    if let Some(mode) = std::env::var_os(MODE_ENV) {
-        run_child_mode(&mode)?;
+    if std::env::var_os(HOLDER_ENV).is_some() {
+        run_holder(&required_path(LOCK_PATH_ENV)?)?;
         return Ok(());
     }
 
@@ -99,28 +102,6 @@ async fn mock_build_lock_recovers_after_holder_exit() -> Result<(), Box<dyn std:
     assert!(lock.is_file(), "lock pathname should remain stable");
 
     Ok(())
-}
-
-fn child_command(mode: &str, lock: &Path) -> io::Result<Command> {
-    let mut command = Command::new(std::env::current_exe()?);
-    command
-        .arg("--exact")
-        .arg(TEST_NAME)
-        .arg("--nocapture")
-        .env(MODE_ENV, mode)
-        .env(LOCK_PATH_ENV, lock);
-    Ok(command)
-}
-
-fn run_child_mode(mode: &OsStr) -> io::Result<()> {
-    let lock = required_path(LOCK_PATH_ENV)?;
-    if mode == OsStr::new("holder") {
-        return run_holder(&lock);
-    }
-    Err(io::Error::new(
-        io::ErrorKind::InvalidInput,
-        format!("unknown mock build lock child mode: {mode:?}"),
-    ))
 }
 
 fn run_holder(lock: &Path) -> io::Result<()> {

--- a/crates/guest-agent/tests/mock_build_lock.rs
+++ b/crates/guest-agent/tests/mock_build_lock.rs
@@ -1,0 +1,170 @@
+//! Cross-process coverage for the mock-package build lock shared by guest-agent tests.
+
+mod common;
+
+use std::ffi::OsStr;
+use std::fs::{OpenOptions, TryLockError};
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::process::{ExitStatus, Stdio};
+use std::time::Duration;
+use tokio::process::{Child, Command};
+
+const TEST_NAME: &str = "mock_build_lock_recovers_after_holder_exit";
+const MODE_ENV: &str = "VM0_MOCK_BUILD_LOCK_TEST_MODE";
+const LOCK_PATH_ENV: &str = "VM0_MOCK_BUILD_LOCK_TEST_PATH";
+const STARTED_PATH_ENV: &str = "VM0_MOCK_BUILD_LOCK_TEST_STARTED_PATH";
+const READY_PATH_ENV: &str = "VM0_MOCK_BUILD_LOCK_TEST_READY_PATH";
+const PROCESS_TIMEOUT: Duration = Duration::from_secs(5);
+
+struct HolderProcess {
+    child: Child,
+}
+
+impl HolderProcess {
+    fn spawn(lock: &Path, started: &Path, ready: &Path) -> io::Result<Self> {
+        let mut command = child_command("holder", lock)?;
+        let child = command
+            .env(STARTED_PATH_ENV, started)
+            .env(READY_PATH_ENV, ready)
+            .stdin(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()?;
+        Ok(Self { child })
+    }
+
+    async fn crash(&mut self) -> io::Result<()> {
+        self.child.start_kill()?;
+        let status = wait_for_exit(&mut self.child, "crashed holder").await?;
+        if status.success() {
+            return Err(io::Error::other(format!(
+                "crashed holder exited successfully: {status}"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn release(&mut self) -> io::Result<()> {
+        drop(self.child.stdin.take());
+        let status = wait_for_exit(&mut self.child, "released holder").await?;
+        if !status.success() {
+            return Err(io::Error::other(format!(
+                "released holder failed: {status}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn mock_build_lock_recovers_after_holder_exit() -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(mode) = std::env::var_os(MODE_ENV) {
+        run_child_mode(&mode)?;
+        return Ok(());
+    }
+
+    let temp = tempfile::tempdir()?;
+    let lock = temp.path().join("mock-build.lock");
+    let first_started = temp.path().join("first-started");
+    let first_ready = temp.path().join("first-ready");
+    let successor_started = temp.path().join("successor-started");
+    let successor_ready = temp.path().join("successor-ready");
+
+    let mut first = HolderProcess::spawn(&lock, &first_started, &first_ready)?;
+    common::wait_for_path(&first_ready, PROCESS_TIMEOUT).await?;
+    assert!(
+        !lock_is_available(&lock)?,
+        "first holder should exclude the parent process"
+    );
+
+    let mut successor = HolderProcess::spawn(&lock, &successor_started, &successor_ready)?;
+    common::wait_for_path(&successor_started, PROCESS_TIMEOUT).await?;
+    assert!(
+        !lock_is_available(&lock)?,
+        "first holder should remain exclusive while successor waits"
+    );
+
+    first.crash().await?;
+    common::wait_for_path(&successor_ready, PROCESS_TIMEOUT).await?;
+    assert!(
+        !lock_is_available(&lock)?,
+        "successor should exclude the parent process"
+    );
+
+    successor.release().await?;
+    assert!(
+        lock_is_available(&lock)?,
+        "released successor should make the lock available"
+    );
+    assert!(lock.is_file(), "lock pathname should remain stable");
+
+    Ok(())
+}
+
+fn child_command(mode: &str, lock: &Path) -> io::Result<Command> {
+    let mut command = Command::new(std::env::current_exe()?);
+    command
+        .arg("--exact")
+        .arg(TEST_NAME)
+        .arg("--nocapture")
+        .env(MODE_ENV, mode)
+        .env(LOCK_PATH_ENV, lock);
+    Ok(command)
+}
+
+fn run_child_mode(mode: &OsStr) -> io::Result<()> {
+    let lock = required_path(LOCK_PATH_ENV)?;
+    if mode == OsStr::new("holder") {
+        return run_holder(&lock);
+    }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("unknown mock build lock child mode: {mode:?}"),
+    ))
+}
+
+fn run_holder(lock: &Path) -> io::Result<()> {
+    let started = required_path(STARTED_PATH_ENV)?;
+    let ready = required_path(READY_PATH_ENV)?;
+    std::fs::write(started, b"started")?;
+    let _lock = common::acquire_mock_build_lock(lock).map_err(io::Error::other)?;
+    std::fs::write(ready, b"ready")?;
+
+    let mut input = Vec::new();
+    io::stdin().read_to_end(&mut input)?;
+    Ok(())
+}
+
+fn lock_is_available(lock: &Path) -> io::Result<bool> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(lock)?;
+    match file.try_lock() {
+        Ok(()) => Ok(true),
+        Err(TryLockError::WouldBlock) => Ok(false),
+        Err(TryLockError::Error(error)) => Err(error),
+    }
+}
+
+fn required_path(key: &str) -> io::Result<PathBuf> {
+    std::env::var_os(key).map(PathBuf::from).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("missing child path environment variable {key}"),
+        )
+    })
+}
+
+async fn wait_for_exit(child: &mut Child, context: &str) -> io::Result<ExitStatus> {
+    tokio::time::timeout(PROCESS_TIMEOUT, child.wait())
+        .await
+        .map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!("timed out waiting for {context}"),
+            )
+        })?
+}


### PR DESCRIPTION
## Summary

- replace pathname-based mock build lock ownership with a persistent, descriptor-owned OS file lock
- hold the lock across cache validation, mock compilation, and fingerprint publication so process exit releases ownership safely
- add cross-process integration coverage for a waiting successor taking over after the current holder crashes

## Scope

- test infrastructure only
- no production runtime, schema, dependency, configuration, or documentation changes

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p guest-agent --test mock_build_lock --quiet` (20 consecutive runs)
- `cargo clippy -p guest-agent --all-targets --all-features`
- `cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent --all-targets --all-features --quiet`
- repository pre-commit hooks

Closes #24777
