### PR TITLE
test(vsock-guest): bound connection lifecycle waits

### DIFF
--- a/crates/vsock-guest/tests/connection/reconnect.rs
+++ b/crates/vsock-guest/tests/connection/reconnect.rs
@@ -1,5 +1,4 @@
 use std::io::{self, Write};
-use std::os::fd::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
@@ -11,12 +10,12 @@ use vsock_proto::{
 };
 
 use super::support::{
-    read_and_discard_message, read_message, send_quiesce_operations, unique_socket_path,
+    guest_connection_completion_diagnostic, listener_has_pending_connection, read_guest_ready,
+    read_message, send_quiesce_operations, unique_socket_path, wait_for_guest_connection,
 };
 
 const EXPECTED_RECONNECT_ATTEMPTS: usize = 50;
 const ACCEPT_TIMEOUT: Duration = Duration::from_secs(5);
-const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 type RunReport = Result<(), (io::ErrorKind, String)>;
 
@@ -24,14 +23,14 @@ type RunReport = Result<(), (io::ErrorKind, String)>;
 fn run_exhausts_reconnect_attempts_after_immediate_disconnects() {
     assert_run_exhausts_after_short_lived_connections(
         "reconnect-immediate-disconnect",
-        read_and_discard_message,
+        read_guest_ready,
     );
 }
 
 #[test]
 fn run_exhausts_reconnect_attempts_after_ping_only_disconnects() {
     assert_run_exhausts_after_short_lived_connections("reconnect-ping-only-disconnect", |stream| {
-        read_and_discard_message(stream);
+        read_guest_ready(stream);
 
         let ping = vsock_proto::encode(MSG_PING, 7, &[]).unwrap();
         stream.write_all(&ping).unwrap();
@@ -49,20 +48,14 @@ fn run_resets_reconnect_attempts_after_real_host_work() {
 
     for accepted in 1..EXPECTED_RECONNECT_ATTEMPTS {
         let mut host_stream = accept_run_connection(&listener, &done_rx, accepted);
-        host_stream
-            .set_read_timeout(Some(Duration::from_secs(5)))
-            .unwrap();
-        read_and_discard_message(&mut host_stream);
+        read_guest_ready(&mut host_stream);
         drop(host_stream);
         assert_run_still_running(&done_rx, accepted);
     }
 
     let mut real_work_stream =
         accept_run_connection(&listener, &done_rx, EXPECTED_RECONNECT_ATTEMPTS);
-    real_work_stream
-        .set_read_timeout(Some(Duration::from_secs(5)))
-        .unwrap();
-    read_and_discard_message(&mut real_work_stream);
+    read_guest_ready(&mut real_work_stream);
     send_quiesce_operations(&mut real_work_stream, 9);
     let quiesced = read_message(&mut real_work_stream);
     assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
@@ -71,10 +64,7 @@ fn run_resets_reconnect_attempts_after_real_host_work() {
 
     let mut shutdown_stream =
         accept_run_connection(&listener, &done_rx, EXPECTED_RECONNECT_ATTEMPTS + 1);
-    shutdown_stream
-        .set_read_timeout(Some(Duration::from_secs(5)))
-        .unwrap();
-    read_and_discard_message(&mut shutdown_stream);
+    read_guest_ready(&mut shutdown_stream);
     let shutdown = vsock_proto::encode(MSG_SHUTDOWN, 10, &[]).unwrap();
     shutdown_stream.write_all(&shutdown).unwrap();
     let ack = read_message(&mut shutdown_stream);
@@ -86,7 +76,7 @@ fn run_resets_reconnect_attempts_after_real_host_work() {
     let report = done_rx.recv_timeout(Duration::from_secs(2)).unwrap();
     drop(listener);
     assert_eq!(report, Ok(()));
-    handle.join().unwrap().unwrap();
+    wait_for_guest_connection(handle).unwrap();
 }
 
 fn assert_run_exhausts_after_short_lived_connections(
@@ -100,9 +90,6 @@ fn assert_run_exhausts_after_short_lived_connections(
 
     for accepted in 1..=EXPECTED_RECONNECT_ATTEMPTS {
         let mut host_stream = accept_run_connection(&listener, &done_rx, accepted);
-        host_stream
-            .set_read_timeout(Some(Duration::from_secs(5)))
-            .unwrap();
         handle_connection(&mut host_stream);
         drop(host_stream);
 
@@ -117,15 +104,15 @@ fn assert_run_exhausts_after_short_lived_connections(
             drain_pending_connections(&listener);
             drop(listener);
             let _ = std::fs::remove_file(socket_path.as_str());
-            let result = handle.join().unwrap();
+            let guest_completion = guest_connection_completion_diagnostic(handle);
             panic!(
-                "run() did not exit after {EXPECTED_RECONNECT_ATTEMPTS} short-lived connections: wait_error={error}, result={result:?}"
+                "run() did not exit after {EXPECTED_RECONNECT_ATTEMPTS} short-lived connections: wait_error={error}, guest_completion={guest_completion}"
             );
         }
     };
     drop(listener);
 
-    let error = handle.join().unwrap().expect_err("run() should fail");
+    let error = wait_for_guest_connection(handle).expect_err("run() should fail");
     assert_eq!(
         report,
         Err((io::ErrorKind::ConnectionReset, error.to_string()))
@@ -184,46 +171,6 @@ fn assert_run_still_running(done_rx: &mpsc::Receiver<RunReport>, completed_attem
         }
         Err(mpsc::TryRecvError::Empty) => {}
     }
-}
-
-fn listener_has_pending_connection(
-    listener: &UnixListener,
-    remaining: Duration,
-) -> io::Result<bool> {
-    let timeout = std::cmp::min(remaining, ACCEPT_POLL_INTERVAL)
-        .as_millis()
-        .max(1) as libc::c_int;
-    let mut pollfd = libc::pollfd {
-        fd: listener.as_raw_fd(),
-        events: libc::POLLIN,
-        revents: 0,
-    };
-    // SAFETY: pollfd points to one initialized listener descriptor entry, and
-    // the timeout is a bounded non-negative millisecond value.
-    let result = unsafe { libc::poll(&mut pollfd, 1 as libc::nfds_t, timeout) };
-    if result < 0 {
-        let error = io::Error::last_os_error();
-        if error.kind() == io::ErrorKind::Interrupted {
-            return Ok(false);
-        }
-        return Err(error);
-    }
-    if result == 0 {
-        return Ok(false);
-    }
-    if pollfd.revents & libc::POLLNVAL != 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "listener fd is invalid",
-        ));
-    }
-    if pollfd.revents & (libc::POLLERR | libc::POLLHUP) != 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::BrokenPipe,
-            "listener is no longer accepting connections",
-        ));
-    }
-    Ok(pollfd.revents & libc::POLLIN != 0)
 }
 
 fn drain_pending_connections(listener: &UnixListener) {

--- a/crates/vsock-guest/tests/connection/shutdown.rs
+++ b/crates/vsock-guest/tests/connection/shutdown.rs
@@ -7,8 +7,9 @@ use vsock_guest::run;
 use vsock_proto::{self, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE};
 
 use super::support::{
-    finish_guest_connection, join_guest_connection, read_and_discard_message, read_error_response,
-    read_message, start_guest_connection, unique_socket_path, unique_tmp_path,
+    accept_guest_connection, finish_guest_connection, join_guest_connection, read_error_response,
+    read_guest_ready, read_message, start_guest_connection, unique_socket_path, unique_tmp_path,
+    wait_for_guest_connection,
 };
 
 #[test]
@@ -22,9 +23,9 @@ fn run_exits_after_shutdown_even_when_ack_write_fails() {
     let guest_socket_path = socket_path.as_str().to_owned();
     let handle = thread::spawn(move || run(Some(&guest_socket_path)));
 
-    let (mut host_stream, _) = listener.accept().unwrap();
+    let mut host_stream = accept_guest_connection(&listener);
     drop(listener);
-    read_and_discard_message(&mut host_stream);
+    read_guest_ready(&mut host_stream);
 
     host_stream.shutdown(Shutdown::Read).unwrap();
     let msg = vsock_proto::encode(MSG_SHUTDOWN, 1, &[]).unwrap();
@@ -35,7 +36,7 @@ fn run_exits_after_shutdown_even_when_ack_write_fails() {
     // ACK write fails with EPIPE/BrokenPipe.
     drop(host_stream);
 
-    let result = handle.join().unwrap();
+    let result = wait_for_guest_connection(handle);
     assert!(
         result.is_ok(),
         "shutdown should stop run() cleanly even if ACK write fails: {result:?}",
@@ -58,9 +59,9 @@ fn run_sends_shutdown_ack_and_waits_for_disconnect() {
         result
     });
 
-    let (mut host_stream, _) = listener.accept().unwrap();
+    let mut host_stream = accept_guest_connection(&listener);
     drop(listener);
-    read_and_discard_message(&mut host_stream);
+    read_guest_ready(&mut host_stream);
 
     let msg = vsock_proto::encode(MSG_SHUTDOWN, 42, &[]).unwrap();
     host_stream.write_all(&msg).unwrap();
@@ -79,7 +80,7 @@ fn run_sends_shutdown_ack_and_waits_for_disconnect() {
     done_rx
         .recv_timeout(Duration::from_secs(1))
         .expect("run() should exit after host disconnect");
-    let result = handle.join().unwrap();
+    let result = wait_for_guest_connection(handle);
     assert!(
         result.is_ok(),
         "shutdown should stop run() cleanly: {result:?}"

--- a/crates/vsock-guest/tests/connection/support/connection.rs
+++ b/crates/vsock-guest/tests/connection/support/connection.rs
@@ -1,15 +1,28 @@
-use std::os::unix::net::UnixStream;
+use std::any::Any;
+use std::io;
+use std::os::fd::AsRawFd;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::panic;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use vsock_guest::{
     handle_connection_with_test_process_containment,
     handle_connection_with_test_process_containment_and_exec_drain_deadline,
 };
 
-use super::protocol::read_and_discard_message;
+use super::protocol::read_message_with_context;
+
+const GUEST_CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
+const GUEST_COMPLETION_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const LISTENER_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 pub(crate) type GuestConnectionHandle = thread::JoinHandle<std::io::Result<()>>;
+
+enum GuestConnectionWait {
+    Completed(thread::Result<io::Result<()>>),
+    TimedOut,
+}
 
 pub(crate) fn start_guest_connection() -> (GuestConnectionHandle, UnixStream) {
     start_guest_connection_with_handler(handle_connection_with_test_process_containment)
@@ -29,13 +42,98 @@ pub(crate) fn start_guest_connection_with_exec_drain_deadline(
 fn start_guest_connection_with_handler(
     handler: impl FnOnce(UnixStream) -> std::io::Result<()> + Send + 'static,
 ) -> (GuestConnectionHandle, UnixStream) {
+    start_guest_connection_with_handler_and_timeout(handler, GUEST_CONNECTION_TIMEOUT)
+}
+
+fn start_guest_connection_with_handler_and_timeout(
+    handler: impl FnOnce(UnixStream) -> std::io::Result<()> + Send + 'static,
+    readiness_timeout: Duration,
+) -> (GuestConnectionHandle, UnixStream) {
     let (guest_stream, mut host_stream) = UnixStream::pair().unwrap();
     let handle = thread::spawn(move || handler(guest_stream));
-    read_and_discard_message(&mut host_stream);
-    host_stream
-        .set_read_timeout(Some(Duration::from_secs(5)))
-        .unwrap();
+    read_guest_ready_with_timeout(&mut host_stream, readiness_timeout);
     (handle, host_stream)
+}
+
+pub(crate) fn accept_guest_connection(listener: &UnixListener) -> UnixStream {
+    accept_guest_connection_with_timeout(listener, GUEST_CONNECTION_TIMEOUT).unwrap_or_else(
+        |error| panic!("guest connection readiness failed during listener accept: {error}"),
+    )
+}
+
+fn accept_guest_connection_with_timeout(
+    listener: &UnixListener,
+    timeout: Duration,
+) -> io::Result<UnixStream> {
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .expect("guest connection accept timeout overflowed");
+
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!("listener accept timed out after {timeout:?}"),
+            ));
+        }
+
+        if listener_has_pending_connection(listener, deadline.saturating_duration_since(now))? {
+            return listener.accept().map(|(stream, _)| stream);
+        }
+    }
+}
+
+pub(crate) fn listener_has_pending_connection(
+    listener: &UnixListener,
+    remaining: Duration,
+) -> io::Result<bool> {
+    let timeout = std::cmp::min(remaining, LISTENER_POLL_INTERVAL)
+        .as_millis()
+        .max(1) as libc::c_int;
+    let mut pollfd = libc::pollfd {
+        fd: listener.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    // SAFETY: pollfd points to one initialized listener descriptor entry, and
+    // the timeout is a bounded non-negative millisecond value.
+    let result = unsafe { libc::poll(&mut pollfd, 1 as libc::nfds_t, timeout) };
+    if result < 0 {
+        let error = io::Error::last_os_error();
+        if error.kind() == io::ErrorKind::Interrupted {
+            return Ok(false);
+        }
+        return Err(error);
+    }
+    if result == 0 {
+        return Ok(false);
+    }
+    if pollfd.revents & libc::POLLNVAL != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "listener fd is invalid",
+        ));
+    }
+    if pollfd.revents & (libc::POLLERR | libc::POLLHUP) != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "listener is no longer accepting connections",
+        ));
+    }
+    Ok(pollfd.revents & libc::POLLIN != 0)
+}
+
+pub(crate) fn read_guest_ready(stream: &mut UnixStream) {
+    read_guest_ready_with_timeout(stream, GUEST_CONNECTION_TIMEOUT);
+}
+
+fn read_guest_ready_with_timeout(stream: &mut UnixStream, timeout: Duration) {
+    stream
+        .set_read_timeout(Some(timeout))
+        .expect("set guest connection readiness read timeout");
+    let context = format!("guest connection readiness failed before {timeout:?} deadline");
+    let _ = read_message_with_context(stream, &context);
 }
 
 pub(crate) fn finish_guest_connection(handle: GuestConnectionHandle, host_stream: UnixStream) {
@@ -44,6 +142,233 @@ pub(crate) fn finish_guest_connection(handle: GuestConnectionHandle, host_stream
 }
 
 pub(crate) fn join_guest_connection(handle: GuestConnectionHandle) {
-    let result = handle.join().expect("guest connection thread panicked");
-    result.expect("guest connection handler returned an error");
+    wait_for_guest_connection(handle).expect("guest connection handler returned an error");
+}
+
+pub(crate) fn wait_for_guest_connection(handle: GuestConnectionHandle) -> io::Result<()> {
+    wait_for_guest_connection_with_timeout(handle, GUEST_CONNECTION_TIMEOUT)
+}
+
+fn wait_for_guest_connection_with_timeout(
+    handle: GuestConnectionHandle,
+    timeout: Duration,
+) -> io::Result<()> {
+    match observe_guest_connection_with_timeout(handle, timeout) {
+        GuestConnectionWait::Completed(Ok(result)) => result,
+        GuestConnectionWait::Completed(Err(payload)) => panic::resume_unwind(payload),
+        GuestConnectionWait::TimedOut => {
+            panic!("guest connection teardown timed out after {timeout:?}")
+        }
+    }
+}
+
+pub(crate) fn guest_connection_completion_diagnostic(handle: GuestConnectionHandle) -> String {
+    match observe_guest_connection_with_timeout(handle, GUEST_CONNECTION_TIMEOUT) {
+        GuestConnectionWait::Completed(Ok(result)) => format!("completed with {result:?}"),
+        GuestConnectionWait::Completed(Err(payload)) => {
+            format!(
+                "thread panicked: {}",
+                panic_payload_message(payload.as_ref())
+            )
+        }
+        GuestConnectionWait::TimedOut => {
+            format!("timed out after {GUEST_CONNECTION_TIMEOUT:?}")
+        }
+    }
+}
+
+fn observe_guest_connection_with_timeout(
+    handle: GuestConnectionHandle,
+    timeout: Duration,
+) -> GuestConnectionWait {
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .expect("guest connection teardown timeout overflowed");
+    while !handle.is_finished() {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return GuestConnectionWait::TimedOut;
+        }
+        thread::sleep(std::cmp::min(remaining, GUEST_COMPLETION_POLL_INTERVAL));
+    }
+    GuestConnectionWait::Completed(handle.join())
+}
+
+fn panic_payload_message(payload: &(dyn Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_owned()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "non-string panic payload".to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::AssertUnwindSafe;
+    use std::sync::mpsc;
+
+    use super::*;
+    use crate::support::temp_paths::unique_socket_path;
+
+    const SHORT_TIMEOUT: Duration = Duration::from_millis(20);
+    const WATCHDOG_TIMEOUT: Duration = Duration::from_secs(5);
+
+    #[test]
+    fn guest_ready_timeout_is_bounded() {
+        let (handler_started_tx, handler_started_rx) = mpsc::channel();
+        let (release_handler_tx, release_handler_rx) = mpsc::channel();
+        let (handler_finished_tx, handler_finished_rx) = mpsc::channel();
+        let (observer_finished_tx, observer_finished_rx) = mpsc::channel();
+
+        let observer = thread::spawn(move || {
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                let _ = start_guest_connection_with_handler_and_timeout(
+                    move |_stream| {
+                        handler_started_tx.send(()).expect("report handler start");
+                        release_handler_rx.recv().expect("wait for handler release");
+                        handler_finished_tx
+                            .send(())
+                            .expect("report handler completion");
+                        Ok(())
+                    },
+                    SHORT_TIMEOUT,
+                );
+            }));
+            observer_finished_tx
+                .send(result)
+                .expect("report readiness observer completion");
+        });
+
+        handler_started_rx
+            .recv_timeout(WATCHDOG_TIMEOUT)
+            .expect("handler should reach blocked state");
+        let observed = observer_finished_rx.recv_timeout(WATCHDOG_TIMEOUT);
+        release_handler_tx
+            .send(())
+            .expect("release stalled readiness handler");
+        handler_finished_rx
+            .recv_timeout(WATCHDOG_TIMEOUT)
+            .expect("readiness handler should finish after release");
+        if matches!(&observed, Err(mpsc::RecvTimeoutError::Timeout)) {
+            let _ = observer_finished_rx
+                .recv_timeout(WATCHDOG_TIMEOUT)
+                .expect("readiness observer should finish after handler release");
+        }
+        observer
+            .join()
+            .expect("readiness observer thread should not panic");
+
+        let result = observed.expect("readiness observer exceeded outer watchdog");
+        let payload = result.expect_err("stalled readiness should fail");
+        assert!(
+            panic_payload_message(payload.as_ref()).contains("guest connection readiness"),
+            "readiness timeout should identify its lifecycle phase"
+        );
+    }
+
+    #[test]
+    fn guest_listener_accept_timeout_is_bounded() {
+        let socket_path = unique_socket_path("bounded-listener-accept");
+        let listener = UnixListener::bind(socket_path.as_str()).unwrap();
+        let release_path = socket_path.as_str().to_owned();
+        let (observer_finished_tx, observer_finished_rx) = mpsc::channel();
+
+        let observer = thread::spawn(move || {
+            let result = accept_guest_connection_with_timeout(&listener, SHORT_TIMEOUT).map(drop);
+            observer_finished_tx
+                .send(result)
+                .expect("report listener observer completion");
+        });
+
+        let observed = observer_finished_rx.recv_timeout(WATCHDOG_TIMEOUT);
+        if matches!(&observed, Err(mpsc::RecvTimeoutError::Timeout)) {
+            let _ = UnixStream::connect(release_path);
+            let _ = observer_finished_rx
+                .recv_timeout(WATCHDOG_TIMEOUT)
+                .expect("listener observer should finish after fallback connection");
+        }
+        observer
+            .join()
+            .expect("listener observer thread should not panic");
+
+        let error = observed
+            .expect("listener observer exceeded outer watchdog")
+            .expect_err("listener accept without a connector should time out");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(
+            error.to_string().contains("listener accept"),
+            "listener timeout should identify its lifecycle phase: {error}"
+        );
+    }
+
+    #[test]
+    fn guest_teardown_timeout_is_bounded() {
+        let (guest_started_tx, guest_started_rx) = mpsc::channel();
+        let (release_guest_tx, release_guest_rx) = mpsc::channel();
+        let (guest_finished_tx, guest_finished_rx) = mpsc::channel();
+        let guest = thread::spawn(move || {
+            guest_started_tx.send(()).expect("report guest start");
+            release_guest_rx.recv().expect("wait for guest release");
+            guest_finished_tx.send(()).expect("report guest completion");
+            Ok(())
+        });
+        guest_started_rx
+            .recv_timeout(WATCHDOG_TIMEOUT)
+            .expect("guest should reach blocked state");
+
+        let (observer_finished_tx, observer_finished_rx) = mpsc::channel();
+        let observer = thread::spawn(move || {
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                wait_for_guest_connection_with_timeout(guest, SHORT_TIMEOUT)
+            }));
+            observer_finished_tx
+                .send(result)
+                .expect("report teardown observer completion");
+        });
+
+        let observed = observer_finished_rx.recv_timeout(WATCHDOG_TIMEOUT);
+        release_guest_tx.send(()).expect("release stalled guest");
+        guest_finished_rx
+            .recv_timeout(WATCHDOG_TIMEOUT)
+            .expect("guest should finish after release");
+        if matches!(&observed, Err(mpsc::RecvTimeoutError::Timeout)) {
+            let _ = observer_finished_rx
+                .recv_timeout(WATCHDOG_TIMEOUT)
+                .expect("teardown observer should finish after guest release");
+        }
+        observer
+            .join()
+            .expect("teardown observer thread should not panic");
+
+        let result = observed.expect("teardown observer exceeded outer watchdog");
+        let payload = result.expect_err("stalled guest teardown should fail");
+        assert!(
+            panic_payload_message(payload.as_ref()).contains("guest connection teardown"),
+            "teardown timeout should identify its lifecycle phase"
+        );
+    }
+
+    #[test]
+    fn bounded_guest_completion_preserves_completed_results() {
+        wait_for_guest_connection_with_timeout(thread::spawn(|| Ok(())), WATCHDOG_TIMEOUT)
+            .expect("completed guest should succeed");
+
+        let error = wait_for_guest_connection_with_timeout(
+            thread::spawn(|| Err(io::Error::other("guest error detail"))),
+            WATCHDOG_TIMEOUT,
+        )
+        .expect_err("guest error should be preserved");
+        assert_eq!(error.to_string(), "guest error detail");
+
+        let panic = panic::catch_unwind(|| {
+            wait_for_guest_connection_with_timeout(
+                thread::spawn(|| -> io::Result<()> { panic!("guest panic detail") }),
+                WATCHDOG_TIMEOUT,
+            )
+        })
+        .expect_err("guest panic should be preserved");
+        assert_eq!(panic_payload_message(panic.as_ref()), "guest panic detail");
+    }
 }

--- a/crates/vsock-guest/tests/connection/support/mod.rs
+++ b/crates/vsock-guest/tests/connection/support/mod.rs
@@ -5,8 +5,10 @@ mod protocol;
 mod temp_paths;
 
 pub(crate) use connection::{
-    finish_guest_connection, join_guest_connection, start_guest_connection,
-    start_guest_connection_with_exec_drain_deadline,
+    accept_guest_connection, finish_guest_connection, guest_connection_completion_diagnostic,
+    join_guest_connection, listener_has_pending_connection, read_guest_ready,
+    start_guest_connection, start_guest_connection_with_exec_drain_deadline,
+    wait_for_guest_connection,
 };
 pub(crate) use exec::{
     DRAIN_DEADLINE_SECS, LARGE_ENV_COMMAND, LONG_RUNNING_EXEC_TIMEOUT_MS, assert_large_env_stdout,
@@ -18,7 +20,7 @@ pub(crate) use process::{
     OrphanProcessGuard, ProcessGroupFileGuard, orphan_sleep_command, pid_alive, wait_for_pid_exit,
 };
 pub(crate) use protocol::{
-    assert_ping_pong, read_and_discard_message, read_error_response, read_message,
-    send_control_payload, send_quiesce_operations, send_resume_operations,
+    assert_ping_pong, read_error_response, read_message, send_control_payload,
+    send_quiesce_operations, send_resume_operations,
 };
 pub(crate) use temp_paths::{unique_pid_path, unique_socket_path, unique_tmp_path};

--- a/crates/vsock-guest/tests/connection/support/protocol.rs
+++ b/crates/vsock-guest/tests/connection/support/protocol.rs
@@ -5,24 +5,34 @@ use vsock_proto::{
 };
 
 pub(crate) fn read_message(stream: &mut impl Read) -> vsock_proto::RawMessage {
+    read_message_with_context(stream, "read message")
+}
+
+pub(super) fn read_message_with_context(
+    stream: &mut impl Read,
+    context: &str,
+) -> vsock_proto::RawMessage {
     let mut hdr = [0u8; 4];
-    stream.read_exact(&mut hdr).unwrap();
+    stream
+        .read_exact(&mut hdr)
+        .unwrap_or_else(|error| panic!("{context}: failed to read frame header: {error}"));
     let body_len = u32::from_be_bytes(hdr) as usize;
     let mut body = vec![0u8; body_len];
-    stream.read_exact(&mut body).unwrap();
+    stream
+        .read_exact(&mut body)
+        .unwrap_or_else(|error| panic!("{context}: failed to read frame body: {error}"));
 
     let mut full = Vec::with_capacity(4 + body_len);
     full.extend_from_slice(&hdr);
     full.extend_from_slice(&body);
     let mut decoder = vsock_proto::Decoder::new();
-    let msgs = decoder.decode(&full).unwrap();
-    assert_eq!(msgs.len(), 1);
-    msgs.into_iter().next().unwrap()
-}
-
-/// Read one framed message from the stream and discard it.
-pub(crate) fn read_and_discard_message(stream: &mut impl Read) {
-    let _ = read_message(stream);
+    let msgs = decoder
+        .decode(&full)
+        .unwrap_or_else(|error| panic!("{context}: failed to decode frame: {error}"));
+    assert_eq!(msgs.len(), 1, "{context}: expected one decoded frame");
+    msgs.into_iter()
+        .next()
+        .unwrap_or_else(|| panic!("{context}: decoded frame is missing"))
 }
 
 pub(crate) fn read_error_response(stream: &mut impl Read, seq: u32) -> String {


### PR DESCRIPTION
## Summary

- bound shared paired-stream readiness before the first ready-frame read and preserve phase-specific diagnostics
- centralize bounded guest-thread completion while retaining completed `io::Error` results and original panic payloads
- reuse the existing absolute-deadline listener polling for raw shutdown and reconnect scenarios, including reconnect failure cleanup
- add synchronized watchdog regressions for listener accept, ready-frame, teardown, and completed-result behavior

## Scope

This changes only the `vsock-guest` connection integration-test harness and its shutdown/reconnect scenarios. It does not change production guest behavior, the vsock protocol, dependencies, Cargo metadata, CI configuration, APIs, schemas, persisted data, migrations, feature switches, or deployment compatibility.

Stable Rust cannot terminate an arbitrary stalled thread, so a teardown timeout detaches the guest on an already-failing test path. Each synthetic regression explicitly releases its stall and waits for cleanup before asserting.

## Validation

- `cargo test -p vsock-guest --test connection` (70 passed)
- `cargo test -p vsock-guest` (220 passed, 1 existing ignored production-identity test)
- each accept/readiness/teardown timeout regression repeated 25 times in the foreground
- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-guest --all-targets --all-features -- -D warnings`
- `cargo clippy -p vsock-guest --release --no-default-features --all-targets -- -D warnings`
- `cargo doc -p vsock-guest --all-features --no-deps`
- repository pre-commit hooks for the five changed Rust files (workspace fmt, Clippy, rustdoc, and file-size checks)
- commit message lint

Closes #24785
