### PR TITLE
perf(guest-agent): use statx for reuse identity

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1273,6 +1273,7 @@ dependencies = [
  "pin-project-lite",
  "process-control-ipc",
  "reqwest",
+ "rustix",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -76,6 +76,7 @@ proptest = { version = "1", default-features = false, features = ["std"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 rmp-serde = "1"
 rmpv = "1"
+rustix = { version = "1", features = ["fs", "linux_4_11"] }
 sentry = { version = "0.49", default-features = false }
 serde = "1"
 serde_json = "1"

--- a/crates/guest-agent/Cargo.toml
+++ b/crates/guest-agent/Cargo.toml
@@ -19,6 +19,7 @@ http-body = "1"
 libc.workspace = true
 pin-project-lite = "0.2"
 reqwest = { workspace = true }
+rustix.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 hex.workspace = true

--- a/crates/guest-agent/src/nofollow_fs.rs
+++ b/crates/guest-agent/src/nofollow_fs.rs
@@ -16,7 +16,7 @@ use std::fs::{self, File, OpenOptions};
 #[cfg(target_os = "linux")]
 use std::io;
 #[cfg(target_os = "linux")]
-use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+use std::os::fd::{AsRawFd, FromRawFd};
 #[cfg(target_os = "linux")]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(target_os = "linux")]
@@ -25,10 +25,13 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 #[cfg(target_os = "linux")]
+use rustix::fs::{AtFlags, StatxFlags};
+
+#[cfg(target_os = "linux")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct FileIdentity {
-    device: libc::dev_t,
-    inode: libc::ino_t,
+    device: (u32, u32),
+    inode: u64,
     mount_id: u64,
 }
 
@@ -155,40 +158,18 @@ impl Dir {
 
 #[cfg(target_os = "linux")]
 fn file_identity(file: &File) -> io::Result<FileIdentity> {
-    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
-    // SAFETY: `stat` points to writable memory and `file` owns a live
-    // descriptor for the duration of the call.
-    let result = unsafe { libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) };
-    if result != 0 {
-        return Err(io::Error::last_os_error());
+    let mask = StatxFlags::INO | StatxFlags::MNT_ID;
+    let stat = rustix::fs::statx(file, c"", AtFlags::EMPTY_PATH, mask)?;
+    if !StatxFlags::from_bits_retain(stat.stx_mask).contains(mask) {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "filesystem identity is unavailable",
+        ));
     }
-    // SAFETY: successful `fstat` initialized the full structure.
-    let stat = unsafe { stat.assume_init() };
-    let mount_id = mount_id_for_fd(file.as_raw_fd())?;
     Ok(FileIdentity {
-        device: stat.st_dev,
-        inode: stat.st_ino,
-        mount_id,
-    })
-}
-
-#[cfg(target_os = "linux")]
-fn mount_id_for_fd(fd: RawFd) -> io::Result<u64> {
-    let fdinfo = fs::read_to_string(format!("/proc/self/fdinfo/{fd}"))?;
-    let value = fdinfo
-        .lines()
-        .find_map(|line| line.strip_prefix("mnt_id:"))
-        .ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Unsupported,
-                "filesystem mount identity is unavailable",
-            )
-        })?;
-    value.trim().parse().map_err(|error| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("invalid filesystem mount identity: {error}"),
-        )
+        device: (stat.stx_dev_major, stat.stx_dev_minor),
+        inode: stat.stx_ino,
+        mount_id: stat.stx_mnt_id,
     })
 }
 


### PR DESCRIPTION
## Summary

- replace per-entry `fstat` plus `/proc/self/fdinfo` parsing with one descriptor-based `statx` call
- request and validate inode and mount identity while preserving the existing device, inode, and mount equality checks
- use the safe `rustix` API so the implementation builds for both production musl targets without maintaining a raw syscall ABI

## Scope

- no runner protocol, API, persisted-state, or deployment compatibility changes
- no fallback to `/proc/self/fdinfo`; filesystems that cannot return the required identity fail reuse preparation closed
- directory traversal and same-device bind-mount rejection behavior remain unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --all-features`
- `cargo build --locked --release --target x86_64-unknown-linux-musl -p guest-agent`
- `cargo build --locked --release --target aarch64-unknown-linux-musl -p guest-agent`

Closes #24780
