### PR TITLE
fix(runner): enforce shared firewall url contract

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -473,9 +473,9 @@ jobs:
       needs.detect.outputs.ci-changed == 'true' ||
       needs.detect.outputs.runner-firewall-contract-inputs-changed == 'true'
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
           workspaces: crates -> target
           shared-key: runner-firewall-contract

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -66,6 +66,7 @@ jobs:
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
       mitm-addon-test-inputs-changed: ${{ steps.detect.outputs.mitm-addon-test-inputs-changed }}
       mitm-addon-pricing-seed-changed: ${{ steps.detect.outputs.mitm-addon-pricing-seed-changed }}
+      runner-firewall-contract-inputs-changed: ${{ steps.detect.outputs.runner-firewall-contract-inputs-changed }}
       api-contracts-rust-bindings-changed: ${{ steps.detect.outputs.api-contracts-rust-bindings-changed }}
       ably-subscriber-changed: ${{ steps.detect.outputs.ably-subscriber-changed }}
       api-contracts-changed: ${{ steps.detect.outputs.api-contracts-changed }}
@@ -158,6 +159,15 @@ jobs:
             echo "mitm-addon-test-inputs-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "mitm-addon-test-inputs-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # The Rust runner independently validates the shared firewall base
+          # URL contract. Run its focused conformance test when only the
+          # TypeScript-owned corpus changes, without selecting runner images.
+          if git diff --name-only "$BASE_REF" HEAD | grep -qx "turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json"; then
+            echo "runner-firewall-contract-inputs-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "runner-firewall-contract-inputs-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
           # test_x_billing.py checks X connector usage buckets against the
@@ -452,6 +462,28 @@ jobs:
         run: |
           pnpm -F @vm0/api-contracts generate:rust
           git diff --exit-code -- ../crates/api-contracts/src/generated
+
+  runner-firewall-contract-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
+    needs: [detect]
+    if: |
+      needs.detect.outputs.ci-changed == 'true' ||
+      needs.detect.outputs.runner-firewall-contract-inputs-changed == 'true'
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates -> target
+          shared-key: runner-firewall-contract
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Check runner firewall base URL contract
+        working-directory: crates
+        run: cargo test -p runner types::tests::firewall_base_url_validation_matches_shared_contract -- --exact
 
   mitm-addon-test:
     runs-on: ubuntu-latest
@@ -861,6 +893,7 @@ jobs:
       - check
       - coverage
       - api-contracts-rust-bindings
+      - runner-firewall-contract-test
       - mitm-addon-test
       - runner-host-groups
       - runner-build
@@ -910,6 +943,7 @@ jobs:
           check_result "check" "${{ needs.check.result }}" "true"
           check_result "coverage" "${{ needs.coverage.result }}" "true"
           check_result "api-contracts-rust-bindings" "${{ needs.api-contracts-rust-bindings.result }}" "true"
+          check_result "runner-firewall-contract-test" "${{ needs.runner-firewall-contract-test.result }}" "true"
           check_result "mitm-addon-test" "${{ needs.mitm-addon-test.result }}" "true"
           check_result "runner-host-groups" "${{ needs.runner-host-groups.result }}" "true"
           check_result "runner-build" "${{ needs.runner-build.result }}" "true"

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2626,6 +2626,7 @@ dependencies = [
  "guest-write-file",
  "hex",
  "httpmock",
+ "idna",
  "libc",
  "nbd-cow",
  "nix",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -70,6 +70,7 @@ futures-util = "0.3"
 hex = "0.4"
 hmac = "0.13.0"
 httpmock = "0.8"
+idna = "1"
 libc = "0.2"
 nix = { version = "0.31", default-features = false }
 proptest = { version = "1", default-features = false, features = ["std"] }

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -33,6 +33,7 @@ flate2 = { workspace = true }
 futures-util = { workspace = true }
 reqwest = { workspace = true }
 hex = { workspace = true }
+idna = { workspace = true }
 libc = { workspace = true }
 sha2 = { workspace = true }
 tar = { workspace = true }

--- a/crates/runner/src/firewall_hostname_policy.rs
+++ b/crates/runner/src/firewall_hostname_policy.rs
@@ -1,0 +1,299 @@
+//! Raw hostname checks for the shared firewall base URL contract.
+//!
+//! URL parsers intentionally canonicalize legacy IPv4 and IDNA spellings. The
+//! firewall contract rejects spellings that hide authority identity, so these
+//! checks run before `url::Url` can discard the original representation.
+
+use unicode_normalization::UnicodeNormalization;
+
+const IDNA_DOT_EQUIVALENTS: [char; 3] = ['\u{3002}', '\u{ff0e}', '\u{ff61}'];
+const IPV4_OCTET_COUNT: usize = 4;
+const IPV4_MAX_OCTET: u16 = 255;
+
+const UNSAFE_UTS46_COLLISION_CHARS: [char; 15] = [
+    '\u{03f2}',
+    '\u{04c0}',
+    '\u{1e9e}',
+    '\u{1806}',
+    '\u{2132}',
+    '\u{2183}',
+    '\u{3164}',
+    '\u{ffa0}',
+    '\u{fffc}',
+    '\u{fffd}',
+    '\u{2f868}',
+    '\u{2f874}',
+    '\u{2f91f}',
+    '\u{2f95f}',
+    '\u{2f9bf}',
+];
+const UNSAFE_UTS46_COLLISION_RANGES: [(u32, u32); 4] = [
+    (0x10a0, 0x10c5),
+    (0x115f, 0x1160),
+    (0x17b4, 0x17b5),
+    (0x2ff0, 0x2ffb),
+];
+const UNSAFE_UTS46_IGNORABLE_RANGES: [(u32, u32); 4] = [
+    (0x034f, 0x034f),
+    (0x180b, 0x180d),
+    (0x180f, 0x180f),
+    (0xfe00, 0xfe0f),
+];
+const UNSAFE_UTS46_SUPPLEMENTARY_IGNORABLE_RANGE: (u32, u32) = (0xe0100, 0xe01ef);
+
+// Unicode 17 assignments from DerivedAge.txt. The shared hostname policy is
+// pinned to Unicode 16, so both direct Unicode and A-label forms must reject
+// characters introduced after that policy boundary.
+// https://www.unicode.org/Public/17.0.0/ucd/DerivedAge.txt
+const UNICODE_17_ASSIGNMENT_RANGES: [(u32, u32); 47] = [
+    (0x088f, 0x088f),
+    (0x0c5c, 0x0c5c),
+    (0x0cdc, 0x0cdc),
+    (0x1acf, 0x1add),
+    (0x1ae0, 0x1aeb),
+    (0x20c1, 0x20c1),
+    (0x2b96, 0x2b96),
+    (0xa7ce, 0xa7cf),
+    (0xa7d2, 0xa7d2),
+    (0xa7d4, 0xa7d4),
+    (0xa7f1, 0xa7f1),
+    (0xfbc3, 0xfbd2),
+    (0xfd90, 0xfd91),
+    (0xfdc8, 0xfdce),
+    (0x10940, 0x10959),
+    (0x10ec5, 0x10ec7),
+    (0x10ed0, 0x10ed8),
+    (0x10efa, 0x10efb),
+    (0x11b60, 0x11b67),
+    (0x11db0, 0x11ddb),
+    (0x11de0, 0x11de9),
+    (0x16ea0, 0x16eb8),
+    (0x16ebb, 0x16ed3),
+    (0x16ff2, 0x16ff6),
+    (0x187f8, 0x187ff),
+    (0x18d09, 0x18d1e),
+    (0x18d80, 0x18df2),
+    (0x1ccfa, 0x1ccfc),
+    (0x1ceba, 0x1ced0),
+    (0x1cee0, 0x1cef0),
+    (0x1e6c0, 0x1e6de),
+    (0x1e6e0, 0x1e6f5),
+    (0x1e6fe, 0x1e6ff),
+    (0x1f6d8, 0x1f6d8),
+    (0x1f777, 0x1f77a),
+    (0x1f8d0, 0x1f8d8),
+    (0x1fa54, 0x1fa57),
+    (0x1fa8a, 0x1fa8a),
+    (0x1fa8e, 0x1fa8e),
+    (0x1fac8, 0x1fac8),
+    (0x1facd, 0x1facd),
+    (0x1faea, 0x1faea),
+    (0x1faef, 0x1faef),
+    (0x1fbfa, 0x1fbfa),
+    (0x2b73a, 0x2b73f),
+    (0x2cea2, 0x2cead),
+    (0x323b0, 0x33479),
+];
+
+pub(crate) fn validate_base_host_for_cache(raw_host: &str) -> Result<(), String> {
+    if raw_host.starts_with('[') && raw_host.ends_with(']') {
+        return Ok(());
+    }
+    if raw_host.is_empty() {
+        return Err("base URL must include a host".to_string());
+    }
+
+    validate_percent_encoding(raw_host)?;
+    let decoded_host = percent_decode(raw_host)
+        .ok_or_else(|| "base URL host has invalid percent encoding".to_string())?;
+    let normalized_host = translate_idna_dots(&decoded_host);
+    let host = normalized_host
+        .strip_suffix('.')
+        .unwrap_or(&normalized_host);
+    if host.is_empty() || host.ends_with('.') || host.split('.').any(str::is_empty) {
+        return Err("base URL host labels must be non-empty".to_string());
+    }
+    if host
+        .chars()
+        .any(|ch| matches!(ch, '*' | ',' | '<' | '>' | '[' | ']' | '^' | '|'))
+    {
+        return Err("base URL host contains forbidden syntax".to_string());
+    }
+
+    validate_canonical_ipv4(&decoded_host, host)?;
+    for label in host.split('.') {
+        validate_hostname_policy_label(label)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn is_ipv4_literal_like(host: &str) -> bool {
+    let labels: Vec<&str> = host.split('.').collect();
+    !labels.is_empty()
+        && labels.len() <= IPV4_OCTET_COUNT
+        && labels.iter().all(|label| {
+            let Some(rest) = label
+                .strip_prefix("0x")
+                .or_else(|| label.strip_prefix("0X"))
+            else {
+                return !label.is_empty() && label.chars().all(|ch| ch.is_ascii_digit());
+            };
+            !rest.is_empty() && rest.chars().all(|ch| ch.is_ascii_hexdigit())
+        })
+}
+
+fn validate_canonical_ipv4(raw_host: &str, normalized_host: &str) -> Result<(), String> {
+    let raw_host = raw_host.strip_suffix('.').unwrap_or(raw_host);
+    if is_ipv4_literal_like(normalized_host)
+        && (raw_host != normalized_host || !is_canonical_ipv4(normalized_host))
+    {
+        return Err("base URL host must use canonical IPv4 address syntax".to_string());
+    }
+    Ok(())
+}
+
+fn is_canonical_ipv4(host: &str) -> bool {
+    let octets: Vec<&str> = host.split('.').collect();
+    octets.len() == IPV4_OCTET_COUNT
+        && octets.iter().all(|octet| {
+            !octet.is_empty()
+                && octet.chars().all(|ch| ch.is_ascii_digit())
+                && (octet.len() == 1 || !octet.starts_with('0'))
+                && octet
+                    .parse::<u16>()
+                    .is_ok_and(|value| value <= IPV4_MAX_OCTET)
+        })
+}
+
+fn validate_percent_encoding(host: &str) -> Result<(), String> {
+    let bytes = host.as_bytes();
+    let mut index = 0;
+    while let Some(&byte) = bytes.get(index) {
+        if byte != b'%' {
+            index += 1;
+            continue;
+        }
+
+        let start = index;
+        while bytes.get(index) == Some(&b'%') {
+            if bytes
+                .get(index + 1)
+                .and_then(|byte| hex_value(*byte))
+                .is_none()
+                || bytes
+                    .get(index + 2)
+                    .and_then(|byte| hex_value(*byte))
+                    .is_none()
+            {
+                return Err("base URL host has invalid percent encoding".to_string());
+            }
+            index += 3;
+        }
+        let decoded = percent_decode(&host[start..index])
+            .ok_or_else(|| "base URL host has invalid percent encoding".to_string())?;
+        if decoded.chars().any(|ch| {
+            ch <= '\u{20}'
+                || ch == '\u{7f}'
+                || matches!(
+                    ch,
+                    '/' | ':' | '?' | '#' | '@' | '\\' | '{' | '}' | ',' | '*'
+                )
+                || ch == '.'
+                || IDNA_DOT_EQUIVALENTS.contains(&ch)
+        }) {
+            return Err("base URL host contains encoded authority syntax".to_string());
+        }
+    }
+    Ok(())
+}
+
+fn validate_hostname_policy_label(label: &str) -> Result<(), String> {
+    if label.chars().any(has_unsafe_uts46_mapping) {
+        return Err("base URL host contains unsafe IDNA compatibility mappings".to_string());
+    }
+    if label.chars().any(is_post_policy_assignment) || alabel_uses_post_policy_assignment(label) {
+        return Err("base URL host exceeds the supported Unicode policy".to_string());
+    }
+    if !label.is_ascii() {
+        let normalized: String = label
+            .nfkd()
+            .collect::<String>()
+            .nfc()
+            .flat_map(char::to_lowercase)
+            .collect();
+        if normalized.is_ascii() {
+            return Err("base URL host contains unsafe IDNA compatibility mappings".to_string());
+        }
+    }
+    Ok(())
+}
+
+fn alabel_uses_post_policy_assignment(label: &str) -> bool {
+    let lower = label.to_ascii_lowercase();
+    let Some(payload) = lower.strip_prefix("xn--") else {
+        return false;
+    };
+    idna::punycode::decode_to_string(payload)
+        .is_some_and(|decoded| decoded.chars().any(is_post_policy_assignment))
+}
+
+fn has_unsafe_uts46_mapping(ch: char) -> bool {
+    let codepoint = u32::from(ch);
+    UNSAFE_UTS46_COLLISION_CHARS.contains(&ch)
+        || codepoint_in_ranges(codepoint, &UNSAFE_UTS46_COLLISION_RANGES)
+        || codepoint_in_ranges(codepoint, &UNSAFE_UTS46_IGNORABLE_RANGES)
+        || codepoint_in_range(codepoint, UNSAFE_UTS46_SUPPLEMENTARY_IGNORABLE_RANGE)
+}
+
+fn is_post_policy_assignment(ch: char) -> bool {
+    codepoint_in_ranges(u32::from(ch), &UNICODE_17_ASSIGNMENT_RANGES)
+}
+
+fn codepoint_in_ranges(codepoint: u32, ranges: &[(u32, u32)]) -> bool {
+    ranges
+        .iter()
+        .any(|range| codepoint_in_range(codepoint, *range))
+}
+
+fn codepoint_in_range(codepoint: u32, (start, end): (u32, u32)) -> bool {
+    start <= codepoint && codepoint <= end
+}
+
+fn translate_idna_dots(host: &str) -> String {
+    host.chars()
+        .map(|ch| {
+            if IDNA_DOT_EQUIVALENTS.contains(&ch) {
+                '.'
+            } else {
+                ch
+            }
+        })
+        .collect()
+}
+
+fn percent_decode(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while let Some(&byte) = bytes.get(index) {
+        if byte != b'%' {
+            decoded.push(byte);
+            index += 1;
+            continue;
+        }
+        let high = hex_value(*bytes.get(index + 1)?)?;
+        let low = hex_value(*bytes.get(index + 2)?)?;
+        decoded.push((high << 4) | low);
+        index += 3;
+    }
+    String::from_utf8(decoded).ok()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -10,6 +10,7 @@ mod dns;
 mod duration;
 mod error;
 mod executor;
+mod firewall_hostname_policy;
 mod group;
 mod helper_exec;
 mod host;

--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -1594,6 +1594,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn invalid_shared_contract_bases_do_not_publish_or_replace_cache() {
+        let invalid_cases =
+            crate::test_fixtures::firewall_base_url_contract::firewall_base_url_validation_cases()
+                .into_iter()
+                .filter(|test_case| !test_case.expected_valid);
+
+        for test_case in invalid_cases {
+            let dir = tempfile::tempdir().unwrap();
+            let cache_path = dir.path().join("builtin-firewall-catalog-cache.json");
+            let lock_path = dir.path().join("builtin-firewall-catalog-cache.json.lock");
+
+            let initial_error =
+                write_catalog_cache(&cache_path, &lock_path, catalog_with_base(&test_case.base))
+                    .await
+                    .unwrap_err();
+            assert!(
+                !cache_path.exists(),
+                "shared case {:?} unexpectedly published an initial cache after {initial_error}",
+                test_case.name
+            );
+
+            write_catalog_cache(&cache_path, &lock_path, catalog("github"))
+                .await
+                .unwrap();
+            let before = tokio::fs::read(&cache_path).await.unwrap();
+
+            let refresh_error =
+                write_catalog_cache(&cache_path, &lock_path, catalog_with_base(&test_case.base))
+                    .await
+                    .unwrap_err();
+            let after = tokio::fs::read(&cache_path).await.unwrap();
+            assert_eq!(
+                after, before,
+                "shared case {:?} replaced the valid cache after {refresh_error}",
+                test_case.name
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn malformed_template_base_catalog_does_not_overwrite_existing_cache() {
         let dir = tempfile::tempdir().unwrap();
         let cache_path = dir.path().join("builtin-firewall-catalog-cache.json");

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -1,3 +1,4 @@
 pub(crate) mod execution_context;
+pub(crate) mod firewall_base_url_contract;
 pub(crate) mod ignored_child;
 pub(crate) mod session_history;

--- a/crates/runner/src/test_fixtures/firewall_base_url_contract.rs
+++ b/crates/runner/src/test_fixtures/firewall_base_url_contract.rs
@@ -1,0 +1,47 @@
+use std::collections::HashSet;
+
+use serde::Deserialize;
+
+const SUPPORTED_HOSTNAME_POLICY: &str = "vm0-uts46-16.0-v1";
+const CONTRACT_JSON: &str = include_str!(
+    "../../../../turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json"
+);
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FirewallBaseUrlValidationContract {
+    hostname_policy: String,
+    base_url_validation_cases: Vec<FirewallBaseUrlValidationCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FirewallBaseUrlValidationCase {
+    pub(crate) name: String,
+    pub(crate) base: String,
+    pub(crate) expected_valid: bool,
+}
+
+pub(crate) fn firewall_base_url_validation_cases() -> Vec<FirewallBaseUrlValidationCase> {
+    let contract: FirewallBaseUrlValidationContract = serde_json::from_str(CONTRACT_JSON)
+        .expect("shared firewall base URL contract should parse");
+    assert_eq!(
+        contract.hostname_policy, SUPPORTED_HOSTNAME_POLICY,
+        "shared firewall hostname policy changed without a runner compatibility review"
+    );
+    assert!(
+        !contract.base_url_validation_cases.is_empty(),
+        "shared firewall base URL contract should contain cases"
+    );
+
+    let mut names = HashSet::new();
+    for test_case in &contract.base_url_validation_cases {
+        assert!(
+            names.insert(test_case.name.as_str()),
+            "shared firewall base URL contract contains duplicate case {:?}",
+            test_case.name
+        );
+    }
+
+    contract.base_url_validation_cases
+}

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -492,8 +492,20 @@ fn validate_firewall_base_for_cache(base: &str) -> Result<(), String> {
         return validate_parameterized_firewall_base_for_cache(base);
     }
     let parsed = url::Url::parse(base).map_err(|_| "base URL is invalid".to_string())?;
+    let authority = raw_url_authority(base)
+        .ok_or_else(|| "base URL must include :// after the scheme".to_string())?;
+    if authority.is_empty() {
+        return Err("base URL must include a host".to_string());
+    }
+    if raw_authority_has_empty_port(base) {
+        return Err("base URL authority must not include an empty port".to_string());
+    }
+    crate::firewall_hostname_policy::validate_base_host_for_cache(raw_host_from_authority(
+        authority,
+    ))?;
+
     let scheme = parsed.scheme();
-    if scheme != "http" && scheme != "https" {
+    if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
         return Err("base URL scheme must be http or https".to_string());
     }
     if parsed.host_str().is_none() {
@@ -566,7 +578,7 @@ fn validate_parameterized_firewall_base_for_cache(base: &str) -> Result<(), Stri
     if scheme.contains('{') || scheme.contains('}') {
         return Err("base URL scheme must not contain parameters".to_string());
     }
-    if scheme != "http" && scheme != "https" {
+    if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
         return Err("base URL scheme must be http or https".to_string());
     }
 
@@ -616,7 +628,9 @@ fn validate_parameterized_firewall_base_host(
     host: &str,
     param_names: &mut HashSet<String>,
 ) -> Result<String, String> {
-    let segments: Vec<&str> = host.split('.').collect();
+    let has_trailing_dot = host.ends_with('.');
+    let host_without_trailing_dot = host.strip_suffix('.').unwrap_or(host);
+    let segments: Vec<&str> = host_without_trailing_dot.split('.').collect();
     if segments.len() < 2 {
         return Err("base URL host must have at least two segments".to_string());
     }
@@ -663,6 +677,9 @@ fn validate_parameterized_firewall_base_host(
     if !has_static_segment {
         return Err("base URL host must have at least one static segment".to_string());
     }
+    if has_trailing_dot {
+        materialized_host.push('.');
+    }
     Ok(materialized_host)
 }
 
@@ -678,6 +695,7 @@ fn validate_parameterized_firewall_base_authority(
     materialized_host: &str,
     port_suffix: &str,
 ) -> Result<(), String> {
+    crate::firewall_hostname_policy::validate_base_host_for_cache(materialized_host)?;
     let syntax_target = format!("{scheme}://{materialized_host}{port_suffix}");
     let parsed = url::Url::parse(&syntax_target)
         .map_err(|_| "parameterized base URL authority is invalid".to_string())?;
@@ -793,7 +811,7 @@ fn validate_host_policy_hostname(value: &str, allow_leading_dot: bool) -> Result
     if host.parse::<IpAddr>().is_ok() {
         return Err("hostPolicy host must not be an IP address".to_string());
     }
-    if is_ipv4_literal_like(host) {
+    if crate::firewall_hostname_policy::is_ipv4_literal_like(host) {
         return Err("hostPolicy host must not look like an IPv4 address".to_string());
     }
     let labels: Vec<&str> = host.split('.').collect();
@@ -801,21 +819,6 @@ fn validate_host_policy_hostname(value: &str, allow_leading_dot: bool) -> Result
         return Err("hostPolicy host must have at least two non-empty labels".to_string());
     }
     Ok(())
-}
-
-fn is_ipv4_literal_like(host: &str) -> bool {
-    let labels: Vec<&str> = host.split('.').collect();
-    !labels.is_empty()
-        && labels.len() <= 4
-        && labels.iter().all(|label| {
-            let Some(rest) = label
-                .strip_prefix("0x")
-                .or_else(|| label.strip_prefix("0X"))
-            else {
-                return !label.is_empty() && label.chars().all(|ch| ch.is_ascii_digit());
-            };
-            !rest.is_empty() && rest.chars().all(|ch| ch.is_ascii_hexdigit())
-        })
 }
 
 /// Auth configuration for a firewall API entry.
@@ -1063,11 +1066,30 @@ fn hex_value(byte: u8) -> Option<u8> {
 }
 
 fn raw_authority_has_empty_port(value: &str) -> bool {
-    let Some(rest) = value.split_once("://").map(|(_, rest)| rest) else {
+    let Some(authority) = raw_url_authority(value) else {
         return false;
     };
+    authority.ends_with(':')
+}
+
+fn raw_url_authority(value: &str) -> Option<&str> {
+    let rest = value.split_once("://").map(|(_, rest)| rest)?;
     let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
-    rest[..authority_end].ends_with(':')
+    Some(&rest[..authority_end])
+}
+
+fn raw_host_from_authority(authority: &str) -> &str {
+    let without_userinfo = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    if without_userinfo.starts_with('[') {
+        return without_userinfo
+            .find(']')
+            .map_or(without_userinfo, |end| &without_userinfo[..=end]);
+    }
+    without_userinfo
+        .rsplit_once(':')
+        .map_or(without_userinfo, |(host, _)| host)
 }
 
 fn raw_url_path(value: &str) -> &str {
@@ -1444,6 +1466,31 @@ impl SandboxReuseResult {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn firewall_base_url_validation_matches_shared_contract() {
+        let mismatches: Vec<String> =
+            crate::test_fixtures::firewall_base_url_contract::firewall_base_url_validation_cases()
+                .into_iter()
+                .filter_map(|test_case| {
+                    let result = validate_firewall_base_for_cache(&test_case.base);
+                    (result.is_ok() != test_case.expected_valid).then(|| {
+                        format!(
+                            "shared case {:?} produced unexpected result for {:?}: {:?}",
+                            test_case.name,
+                            test_case.base,
+                            result.err()
+                        )
+                    })
+                })
+                .collect();
+
+        assert!(
+            mismatches.is_empty(),
+            "firewall base URL contract mismatches:\n{}",
+            mismatches.join("\n")
+        );
+    }
 
     #[test]
     fn raw_url_path_does_not_treat_query_or_fragment_content_as_path() {


### PR DESCRIPTION
## Summary

- make the runner execute all 92 cases in the shared firewall base URL validation contract
- validate raw static and materialized parameterized hostnames before URL parsing can erase unsafe or non-canonical spellings
- prevent every invalid shared-contract base from creating or replacing the builtin firewall cache
- run the focused Rust conformance test when the TypeScript-owned contract corpus changes by itself

## Compatibility and scope

- preserves the existing cache schema and publication format
- adds no database migration, persisted-data rewrite, API/queue shape change, or runner protocol change
- keeps validation at catalog refresh/cache publication, outside request matching and run startup paths

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner types::tests::firewall_base_url_validation_matches_shared_contract -- --exact --nocapture`
- `cargo test -p runner provider::builtin_firewall_catalog::tests::invalid_shared_contract_bases_do_not_publish_or_replace_cache -- --exact --nocapture`
- `cargo test -p runner`
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/crates.yml", encoding="utf-8"))'`
- pre-commit full-workspace Rust formatting, Clippy, and documentation checks

Local workflow shell validation could not run because the development container does not include `shellcheck`; required workflow/action validation remains delegated to CI.

Closes #24783
