### PR TITLE
fix(storage): expand artifact commit compatibility for canonical ids

### DIFF
--- a/crates/guest-agent/src/content_hash.rs
+++ b/crates/guest-agent/src/content_hash.rs
@@ -8,7 +8,7 @@
 //!
 //! The two implementations must stay byte-identical. The inline `#[cfg(test)]`
 //! suite below hardcodes fixture vectors for the Rust port; changes here must
-//! be checked against TS `computeContentHashFromHashes`.
+//! be checked against TS `computeContentHashV1FromHashes`.
 
 use sha2::{Digest, Sha256};
 
@@ -97,7 +97,7 @@ fn formatted_entry_sort_key(entry: ContentHashEntry<'_>) -> Vec<u16> {
 mod tests {
     use super::*;
 
-    // Fixtures below must stay aligned with TS `computeContentHashFromHashes` at
+    // Fixtures below must stay aligned with TS `computeContentHashV1FromHashes` at
     // `turbo/apps/api/src/signals/services/storage-content-hash.service.ts`.
     const STORAGE_A: &str = "01234567-89ab-cdef-0123-456789abcdef";
     const STORAGE_B: &str = "ffffffff-ffff-ffff-ffff-ffffffffffff";

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-storages.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-storages.ts
@@ -14,6 +14,7 @@ type StorageFixtureOwner = "organization" | "user";
 interface BddStoragePrepareBody {
   readonly storageName: string;
   readonly storageOwner: StorageFixtureOwner;
+  readonly storageId?: string;
   readonly files: readonly BddStorageFileEntry[];
   readonly force?: boolean;
   readonly baseVersion?: string;
@@ -36,6 +37,11 @@ interface BddStorageDownloadQuery {
   readonly name: string;
   readonly owner: StorageFixtureOwner;
   readonly version?: string;
+}
+
+interface BddStorageDeleteBody {
+  readonly name: string;
+  readonly owner: StorageFixtureOwner;
 }
 
 function requireOrgId(actor: ApiTestUser): string {
@@ -108,6 +114,7 @@ export function createStoragesBddApi(context: TestContext) {
         userId: actor.userId,
         storageName: body.storageName,
         storageOwner: body.storageOwner,
+        storageId: body.storageId,
         files: fixtureFiles(body.files),
         force: body.force,
         baseVersion: body.baseVersion,
@@ -168,6 +175,16 @@ export function createStoragesBddApi(context: TestContext) {
         throw new Error("Storage download action returned no result");
       }
       return response.download;
+    },
+
+    async deleteStorage(actor: ApiTestUser, body: BddStorageDeleteBody) {
+      await postAction(context, {
+        action: "delete",
+        orgId: requireOrgId(actor),
+        userId: actor.userId,
+        storageName: body.name,
+        storageOwner: body.owner,
+      });
     },
   };
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/storage-content-hash.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/storage-content-hash.bdd.test.ts
@@ -1,0 +1,125 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, it, onTestFinished } from "vitest";
+
+import { testContext } from "../../../__tests__/test-context";
+import contentHashContract from "../../../test-fixtures/storage-content-hash-contract.json";
+import { createBddApi } from "./helpers/api-bdd";
+import { createStoragesBddApi } from "./helpers/api-bdd-storages";
+
+const context = testContext();
+const STORAGE_NAME = "content-hash-contract";
+
+interface ContractFile {
+  readonly path?: string;
+  readonly pathUtf16?: readonly number[];
+  readonly content: string;
+  readonly hash: string;
+  readonly size: number;
+}
+
+function materializePath(file: ContractFile): string {
+  if (file.path !== undefined) {
+    return file.path;
+  }
+  if (file.pathUtf16 === undefined) {
+    throw new Error("Content hash fixture file has no path representation");
+  }
+  return String.fromCharCode(...file.pathUtf16);
+}
+
+function materializeFiles(files: readonly ContractFile[]) {
+  return files.map((file) => {
+    expect(createHash("sha256").update(file.content).digest("hex")).toBe(
+      file.hash,
+    );
+    expect(Buffer.byteLength(file.content)).toBe(file.size);
+    return {
+      path: materializePath(file),
+      hash: file.hash,
+      size: file.size,
+    };
+  });
+}
+
+function contractCase(name: string) {
+  const found = contentHashContract.cases.find((entry) => {
+    return entry.name === name;
+  });
+  if (!found) {
+    throw new Error(`Missing content hash contract case: ${name}`);
+  }
+  return found;
+}
+
+describe("storage content hash contract", () => {
+  it("keeps prepare on v1 while commit accepts canonical v2", async () => {
+    const bdd = createBddApi(context);
+    const storages = createStoragesBddApi(context);
+    const actor = bdd.user({
+      userId: "user_storage_content_hash_contract",
+      orgId: "org_storage_content_hash_contract",
+    });
+    const storageIdentity: {
+      readonly name: string;
+      readonly owner: "user";
+    } = { name: STORAGE_NAME, owner: "user" };
+
+    await storages.deleteStorage(actor, storageIdentity);
+    onTestFinished(async () => {
+      await storages.deleteStorage(actor, storageIdentity);
+    });
+    storages.mockStoragePresignedUrls();
+    storages.mockStorageObjectsExist();
+
+    for (const entry of contentHashContract.cases) {
+      const files = materializeFiles(entry.files);
+      const prepared = await storages.prepareStorage(actor, {
+        storageName: STORAGE_NAME,
+        storageOwner: "user",
+        storageId: contentHashContract.storageId,
+        files,
+        force: true,
+      });
+      expect(prepared.versionId).toBe(entry.expectedV1);
+
+      const committed = await storages.commitStorage(actor, {
+        storageName: STORAGE_NAME,
+        storageOwner: "user",
+        versionId: entry.expectedV2,
+        files,
+      });
+      expect(committed).toMatchObject({
+        success: true,
+        versionId: entry.expectedV2,
+        headVersionId: entry.expectedV2,
+        storageName: STORAGE_NAME,
+        size: files.reduce((sum, file) => {
+          return sum + file.size;
+        }, 0),
+        fileCount: files.length,
+      });
+    }
+
+    const twoFiles = contractCase("collision-two-files");
+    const reversed = contractCase("reversed-order");
+    const newlinePath = contractCase("collision-newline-path");
+    expect(twoFiles.expectedV1).toBe(newlinePath.expectedV1);
+    expect(twoFiles.expectedV2).not.toBe(newlinePath.expectedV2);
+    expect(twoFiles.expectedV2).toBe(reversed.expectedV2);
+
+    const replacement = contractCase("replacement-character-path");
+    const loneSurrogate = contractCase("lone-surrogate-path");
+    expect(replacement.expectedV1).toBe(loneSurrogate.expectedV1);
+    expect(replacement.expectedV2).not.toBe(loneSurrogate.expectedV2);
+
+    await expect(
+      storages.commitStorage(actor, {
+        storageName: STORAGE_NAME,
+        storageOwner: "user",
+        versionId: "f".repeat(64),
+        files: materializeFiles(contractCase("single").files),
+      }),
+    ).rejects.toThrow("Storage state action commit failed with 400");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/test-storage-fixture.ts
+++ b/turbo/apps/api/src/signals/routes/test-storage-fixture.ts
@@ -46,6 +46,7 @@ async function findOrCreateFixtureStorageId(args: {
   readonly userId: string;
   readonly name: string;
   readonly owner: "organization" | "user";
+  readonly storageId?: string;
 }) {
   const userId = fixtureOwner(args.userId, args.owner);
   const [existing] = await args.db
@@ -63,7 +64,12 @@ async function findOrCreateFixtureStorageId(args: {
     return existing.id;
   }
 
-  const location = newStorageS3Location(args.orgId);
+  const location = args.storageId
+    ? {
+        storageId: args.storageId,
+        s3Prefix: `${args.orgId}/${args.storageId}`,
+      }
+    : newStorageS3Location(args.orgId);
   const [storage] = await args.db
     .insert(storages)
     .values({
@@ -122,6 +128,7 @@ async function prepareStorageState(
     userId: body.userId,
     name: body.storageName,
     owner: body.storageOwner,
+    storageId: body.storageId,
   });
   signal.throwIfAborted();
   const response = await set(
@@ -302,6 +309,24 @@ async function downloadStorageState(
   });
 }
 
+async function deleteStorageState(
+  db: Db,
+  body: StorageStateAction<"delete">,
+  signal: AbortSignal,
+) {
+  await db
+    .delete(storages)
+    .where(
+      and(
+        eq(storages.orgId, body.orgId),
+        eq(storages.userId, fixtureOwner(body.userId, body.storageOwner)),
+        eq(storages.name, body.storageName),
+      ),
+    );
+  signal.throwIfAborted();
+  return actionOk();
+}
+
 const prepare$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!isTestEndpointAllowed(get(request$))) {
     return testEndpointNotFoundResponse();
@@ -395,6 +420,9 @@ const action$ = command(async ({ get, set }, signal: AbortSignal) => {
     }
     case "download": {
       return await downloadStorageState(db, bodyResult.data, signal);
+    }
+    case "delete": {
+      return await deleteStorageState(db, bodyResult.data, signal);
     }
   }
 });

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -45,7 +45,7 @@ import {
   type ApiDispatchTimingDimensions,
   type ApiDispatchTimingDimensionsInput,
 } from "./api-dispatch-timing.service";
-import { computeContentHashFromHashes } from "./storage-content-hash.service";
+import { computeContentHashV1FromHashes } from "./storage-content-hash.service";
 import { newStorageS3Location } from "./storage-s3-prefix.utils";
 
 type ComputedGetter = <T>(computedValue: Computed<T>) => T;
@@ -1395,7 +1395,7 @@ async function initializeEmptyArtifactStorage(
   storage: ArtifactStorageRow,
 ): Promise<void> {
   args.stats?.recordArtifactEnsureMissingHeadVersion();
-  const versionId = computeContentHashFromHashes(storage.id, []);
+  const versionId = computeContentHashV1FromHashes(storage.id, []);
   const s3Key = `${storage.s3Prefix}/${versionId}`;
   const initializedHead = await insertInitialArtifactVersion({
     db: args.db,

--- a/turbo/apps/api/src/signals/services/storage-content-hash.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-content-hash.service.ts
@@ -40,7 +40,7 @@ function encodeUint32(value: number): Buffer {
   return encoded;
 }
 
-function encodeUtf16Be(value: string): Buffer {
+function encodeCountedUtf16Be(value: string): Buffer {
   const encoded = Buffer.allocUnsafe(4 + value.length * 2);
   encoded.writeUInt32BE(value.length);
   for (let index = 0; index < value.length; index += 1) {
@@ -62,6 +62,8 @@ function compareUtf16(left: string, right: string): number {
 /**
  * Canonical v2 artifact content identity. The guest-agent peer lands in #24803.
  *
+ * The frame contains the fixed domain and version, a counted storage ID, the
+ * file count, then counted path/hash pairs sorted by those two fields.
  * Strings are counted and encoded as UTF-16BE code units so every JavaScript
  * string, including lone surrogates, has a distinct representation.
  */
@@ -71,7 +73,7 @@ export function computeContentHashV2FromHashes(
 ): string {
   const contentHash = createHash("sha256");
   contentHash.update(CONTENT_HASH_V2_DOMAIN);
-  contentHash.update(encodeUtf16Be(storageId));
+  contentHash.update(encodeCountedUtf16Be(storageId));
   contentHash.update(encodeUint32(files.length));
 
   const sortedFiles = [...files].sort((left, right) => {
@@ -80,8 +82,8 @@ export function computeContentHashV2FromHashes(
     );
   });
   for (const file of sortedFiles) {
-    contentHash.update(encodeUtf16Be(file.path));
-    contentHash.update(encodeUtf16Be(file.hash));
+    contentHash.update(encodeCountedUtf16Be(file.path));
+    contentHash.update(encodeCountedUtf16Be(file.hash));
   }
 
   return contentHash.digest("hex");

--- a/turbo/apps/api/src/signals/services/storage-content-hash.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-content-hash.service.ts
@@ -1,5 +1,10 @@
 import { createHash } from "node:crypto";
 
+const CONTENT_HASH_V2_DOMAIN = Buffer.concat([
+  Buffer.from("vm0-storage-content-hash", "ascii"),
+  Buffer.from([0, 2]),
+]);
+
 export interface FileEntryWithHash {
   readonly path: string;
   readonly hash: string;
@@ -10,7 +15,7 @@ export function hashFileContent(content: Buffer): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
-export function computeContentHashFromHashes(
+export function computeContentHashV1FromHashes(
   storageId: string,
   files: readonly FileEntryWithHash[],
 ): string {
@@ -27,4 +32,57 @@ export function computeContentHashFromHashes(
   return createHash("sha256")
     .update(`storage:${storageId}\n${entries.join("\n")}`)
     .digest("hex");
+}
+
+function encodeUint32(value: number): Buffer {
+  const encoded = Buffer.allocUnsafe(4);
+  encoded.writeUInt32BE(value);
+  return encoded;
+}
+
+function encodeUtf16Be(value: string): Buffer {
+  const encoded = Buffer.allocUnsafe(4 + value.length * 2);
+  encoded.writeUInt32BE(value.length);
+  for (let index = 0; index < value.length; index += 1) {
+    encoded.writeUInt16BE(value.charCodeAt(index), 4 + index * 2);
+  }
+  return encoded;
+}
+
+function compareUtf16(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * Canonical v2 artifact content identity. The guest-agent peer lands in #24803.
+ *
+ * Strings are counted and encoded as UTF-16BE code units so every JavaScript
+ * string, including lone surrogates, has a distinct representation.
+ */
+export function computeContentHashV2FromHashes(
+  storageId: string,
+  files: readonly FileEntryWithHash[],
+): string {
+  const contentHash = createHash("sha256");
+  contentHash.update(CONTENT_HASH_V2_DOMAIN);
+  contentHash.update(encodeUtf16Be(storageId));
+  contentHash.update(encodeUint32(files.length));
+
+  const sortedFiles = [...files].sort((left, right) => {
+    return (
+      compareUtf16(left.path, right.path) || compareUtf16(left.hash, right.hash)
+    );
+  });
+  for (const file of sortedFiles) {
+    contentHash.update(encodeUtf16Be(file.path));
+    contentHash.update(encodeUtf16Be(file.hash));
+  }
+
+  return contentHash.digest("hex");
 }

--- a/turbo/apps/api/src/signals/services/storage-volume-upload.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-volume-upload.service.ts
@@ -15,7 +15,7 @@ import { writeDb$ } from "../external/db";
 import { putS3Object, verifyS3FilesExist } from "../external/s3";
 import { onRejection, safeSync } from "../utils";
 import {
-  computeContentHashFromHashes,
+  computeContentHashV1FromHashes,
   hashFileContent,
   type FileEntryWithHash,
 } from "./storage-content-hash.service";
@@ -215,7 +215,7 @@ const uploadVolumeServerSideInner$ = command(
         size: file.size,
       };
     });
-    const versionId = computeContentHashFromHashes(storage.id, fileEntries);
+    const versionId = computeContentHashV1FromHashes(storage.id, fileEntries);
     // On upsert conflict the row keeps its original prefix, which can differ
     // from the freshly generated one — always key objects off the stored value.
     const s3Key = `${storage.s3Prefix}/${versionId}`;

--- a/turbo/apps/api/src/signals/services/storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-write.service.ts
@@ -21,7 +21,8 @@ import {
 } from "../external/s3";
 import { tapError } from "../utils";
 import {
-  computeContentHashFromHashes,
+  computeContentHashV1FromHashes,
+  computeContentHashV2FromHashes,
   type FileEntryWithHash,
 } from "./storage-content-hash.service";
 
@@ -781,7 +782,7 @@ export const prepareStorageUploadForStorage$ = command(
       }),
     );
     signal.throwIfAborted();
-    const versionId = computeContentHashFromHashes(storage.id, mergedFiles);
+    const versionId = computeContentHashV1FromHashes(storage.id, mergedFiles);
 
     const existingReusable = await get(
       existingStorageVersionIsReusable({
@@ -827,11 +828,15 @@ export const commitStorageUploadForStorage$ = command(
       return notFound("Storage not found");
     }
 
-    const computedVersionId = computeContentHashFromHashes(
+    const computedVersionIdV1 = computeContentHashV1FromHashes(
       storage.id,
       args.files,
     );
-    if (computedVersionId !== args.versionId) {
+    // Temporary rollout compatibility. Remove v1 acceptance in #24805.
+    if (
+      computedVersionIdV1 !== args.versionId &&
+      computeContentHashV2FromHashes(storage.id, args.files) !== args.versionId
+    ) {
       return badRequestMessage("Version ID mismatch - files may have changed");
     }
 

--- a/turbo/apps/api/src/test-fixtures/storage-content-hash-contract.json
+++ b/turbo/apps/api/src/test-fixtures/storage-content-hash-contract.json
@@ -1,0 +1,136 @@
+{
+  "storageId": "01234567-89ab-4def-8123-456789abcdef",
+  "cases": [
+    {
+      "name": "empty",
+      "guestCompatible": true,
+      "files": [],
+      "expectedV1": "dad50c584b1d55c08ceae9741dccb32232d59c87a7fad0765e840e3e39039a10",
+      "expectedV2": "2995f54ead37d25eb72fea78b2c040b201fd13098adff745067cde9e4997b8ba"
+    },
+    {
+      "name": "single",
+      "guestCompatible": true,
+      "files": [
+        {
+          "path": "alpha.txt",
+          "content": "alpha",
+          "hash": "8ed3f6ad685b959ead7022518e1af76cd816f8e8ec7ccdda1ed4018e8f2223f8",
+          "size": 5
+        }
+      ],
+      "expectedV1": "fa155f94b3d8ce29a6f549bfc3f39e28c129ef7df106e754c0dbd04f74d37d60",
+      "expectedV2": "b0edb5119cadd34b10489a9dfa2767e682156b270e6a03396c85df6a1b9b1fdb"
+    },
+    {
+      "name": "collision-two-files",
+      "guestCompatible": true,
+      "files": [
+        {
+          "path": "a",
+          "content": "first",
+          "hash": "a7937b64b8caa58f03721bb6bacf5c78cb235febe0e70b1b84cd99541461a08e",
+          "size": 5
+        },
+        {
+          "path": "b",
+          "content": "second",
+          "hash": "16367aacb67a4a017c8da8ab95682ccb390863780f7114dda0a0e0c55644c7c4",
+          "size": 6
+        }
+      ],
+      "expectedV1": "7b1322a2b8008240b3c874a996c8df5a134487ac3bfb7d54d6e9b7c0a30f9e8a",
+      "expectedV2": "678518119d309bdaaff13ed2e3140eaa7ed51ea4ef30e90bc099a0067a8f0b6a"
+    },
+    {
+      "name": "reversed-order",
+      "guestCompatible": true,
+      "files": [
+        {
+          "path": "b",
+          "content": "second",
+          "hash": "16367aacb67a4a017c8da8ab95682ccb390863780f7114dda0a0e0c55644c7c4",
+          "size": 6
+        },
+        {
+          "path": "a",
+          "content": "first",
+          "hash": "a7937b64b8caa58f03721bb6bacf5c78cb235febe0e70b1b84cd99541461a08e",
+          "size": 5
+        }
+      ],
+      "expectedV1": "7b1322a2b8008240b3c874a996c8df5a134487ac3bfb7d54d6e9b7c0a30f9e8a",
+      "expectedV2": "678518119d309bdaaff13ed2e3140eaa7ed51ea4ef30e90bc099a0067a8f0b6a"
+    },
+    {
+      "name": "collision-newline-path",
+      "guestCompatible": true,
+      "files": [
+        {
+          "path": "a:a7937b64b8caa58f03721bb6bacf5c78cb235febe0e70b1b84cd99541461a08e\nb",
+          "content": "second",
+          "hash": "16367aacb67a4a017c8da8ab95682ccb390863780f7114dda0a0e0c55644c7c4",
+          "size": 6
+        }
+      ],
+      "expectedV1": "7b1322a2b8008240b3c874a996c8df5a134487ac3bfb7d54d6e9b7c0a30f9e8a",
+      "expectedV2": "917771f85b12715d90368cbde150351d07ac43b8706c6fd3d6979b23b5ed832b"
+    },
+    {
+      "name": "colon-path",
+      "guestCompatible": true,
+      "files": [
+        {
+          "path": "dir:name.txt",
+          "content": "colon",
+          "hash": "70bdae49483e37d0af32b9744687346938f38f56e5c3486b4638795180082bbe",
+          "size": 5
+        }
+      ],
+      "expectedV1": "a28254cf5af7c1780a7dbb92f6a31075532bd33c73baa8d7cd179064892abb12",
+      "expectedV2": "03444e74fb5c088c39a5c6ba4811f9c07cb22c8c9a1bdf80704c30ce0902a4ae"
+    },
+    {
+      "name": "non-bmp-path",
+      "guestCompatible": true,
+      "files": [
+        {
+          "path": "emoji-😀.txt",
+          "content": "emoji",
+          "hash": "4030f0c0b99ba5e189b6fe295448a8ca31ca589a55930175de18032545c11501",
+          "size": 5
+        }
+      ],
+      "expectedV1": "58e32f6b7152c981f14e788ff688323a6ab08403e5f2e1162538b0b00940f0fb",
+      "expectedV2": "34fe5711394b5647f475cabe0af2cfc42270f31280c095ae054ab1ffc082a4ee"
+    },
+    {
+      "name": "replacement-character-path",
+      "guestCompatible": true,
+      "files": [
+        {
+          "path": "�.txt",
+          "content": "unicode",
+          "hash": "2fcf76a4c3c75b1fb5288d83d62dd114dc556d16fba206ab35d38bfe294a2857",
+          "size": 7
+        }
+      ],
+      "expectedV1": "4495b97f31999caca64d527823616fcc734fb91a95d3773dd90eed678bc86c22",
+      "expectedV2": "1426d80f42f6c4dcd00475f98f73dd27ebaccb75087718af812f77104e178a9c"
+    },
+    {
+      "name": "lone-surrogate-path",
+      "guestCompatible": false,
+      "files": [
+        {
+          "pathUtf16": [55296, 46, 116, 120, 116],
+          "content": "unicode",
+          "hash": "2fcf76a4c3c75b1fb5288d83d62dd114dc556d16fba206ab35d38bfe294a2857",
+          "size": 7
+        }
+      ],
+      "expectedV1": "4495b97f31999caca64d527823616fcc734fb91a95d3773dd90eed678bc86c22",
+      "expectedV2": "f3dd21791090d4060c313d35000309cf55ceb86d189397d3b2eb24216ad0e0ab"
+    }
+  ]
+}

--- a/turbo/packages/api-contracts/src/contracts/test-storage-fixture.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-storage-fixture.ts
@@ -52,6 +52,7 @@ export const testStorageStateActionBodySchema = z.discriminatedUnion("action", [
     userId: z.string(),
     storageName: z.string().min(1),
     storageOwner: storageOwnerSchema,
+    storageId: z.uuid().optional(),
     files: z.array(fileEntryWithHashSchema),
     force: z.boolean().optional(),
     baseVersion: z.string().optional(),
@@ -80,6 +81,13 @@ export const testStorageStateActionBodySchema = z.discriminatedUnion("action", [
     storageName: z.string().min(1),
     storageOwner: storageOwnerSchema,
     versionId: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal("delete"),
+    orgId: z.string(),
+    userId: z.string(),
+    storageName: z.string().min(1),
+    storageOwner: storageOwnerSchema,
   }),
 ]);
 


### PR DESCRIPTION
## Summary

- add an unambiguous, versioned UTF-16BE artifact content identity alongside the current v1 identity
- keep every storage producer on v1 while allowing commit to validate either v1 or v2, with lazy v2 computation for legacy commits
- add portable literal compatibility vectors and route-level coverage through the real storage service and database boundary

## Rollout

This is the expand-only deployment stage. It does not switch API or guest producers, change database schema, alter public contracts, or change generated Rust bindings. Verify this API revision in production before #24803 starts producing v2 IDs; #24805 removes temporary v1 commit acceptance after the migration and drain gate.

## Validation

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/storage-content-hash.bdd.test.ts`
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (183 files, 2628 tests)
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts exec vitest run` (25 files, 532 tests)
- `pnpm -F @vm0/api-contracts generate:rust` with zero generated diff
- `pnpm knip --workspace api --workspace @vm0/api-contracts`
- `cargo fmt -p guest-agent -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-agent --no-deps --all-features`
- `cargo test -p guest-agent --all-features`

Closes #24802

Parent: #24781
