### PR TITLE
feat(api): prefer finalizing predecessor and remove legacy affinity

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -2203,13 +2203,6 @@ mod tests {
         assert_eq!(body["telemetry"]["pollDueToJobDiscoveredMs"], 19);
         assert_eq!(body["telemetry"]["pollHttpRequestMs"], 11);
         assert_eq!(body["telemetry"]["pollReason"], "deferred");
-        assert!(body["telemetry"].get("sessionAffinityResource").is_none());
-        assert!(
-            body["telemetry"]
-                .get("sessionAffinityLocalResource")
-                .is_none()
-        );
-        assert!(body["telemetry"].get("localAdmissionResource").is_none());
         assert!(body.get("runnerPreference").is_none());
         assert!(!body.to_string().contains("rawSizeBytes"));
         assert!(!body.to_string().contains("sessionId"));
@@ -2336,7 +2329,6 @@ mod tests {
         assert!(body["telemetry"].get("pollDueToJobDiscoveredMs").is_none());
         assert!(body["telemetry"].get("pollHttpRequestMs").is_none());
         assert!(body["telemetry"].get("pollReason").is_none());
-        assert!(body["telemetry"].get("sessionAffinityResource").is_none());
         assert!(
             body["telemetry"]
                 .get("directCandidateNotificationToEnqueueMs")
@@ -2441,10 +2433,6 @@ mod tests {
                         "experimentalProfile": "vm0/large",
                         "cliAgentSessionId": "sess-poll",
                         "historyGenerationRunId": history_generation_run_id,
-                        "historyGenerationAffinityProtectedUntil": "2999-01-01T00:00:00.000Z",
-                        "affinityProtectedUntil": "2999-01-01T00:00:00.000Z",
-                        "sessionAffinityResource": "reusableSandbox",
-                        // Old runners must ignore the additive preference during rollout.
                         "runnerPreference": {
                             "runnerIdentity": {
                                 "runnerId": "00000000-0000-0000-0000-000000000005",

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -4,10 +4,7 @@ import type {
   BrowserSessionChangedPayload,
   ConnectorChangedPayload,
 } from "@vm0/api-contracts/contracts/realtime";
-import type {
-  RunnerPreference,
-  SessionAffinityResource,
-} from "@vm0/api-contracts/contracts/runners";
+import type { RunnerPreference } from "@vm0/api-contracts/contracts/runners";
 import type { ZeroBuiltInGenerationRealtimeSubscription } from "@vm0/api-contracts/contracts/zero-built-in-generation";
 
 import { env } from "../../lib/env";
@@ -387,9 +384,6 @@ export async function publishRunnerJobNotification(
     /** Raw key required for runner-local affinity matching; it stays on the internal runner-group channel. */
     readonly reuseKey: string | null;
     readonly cliAgentSessionId: string | null;
-    readonly historyGenerationAffinityProtectedUntil: string | null;
-    readonly affinityProtectedUntil: string | null;
-    readonly sessionAffinityResource: SessionAffinityResource | null;
     readonly historyGenerationRunId: string | undefined;
     readonly runnerPreference: RunnerPreference | null;
   },
@@ -403,18 +397,6 @@ export async function publishRunnerJobNotification(
         ...(metadata?.reuseKey ? { reuseKey: metadata.reuseKey } : {}),
         ...(metadata?.cliAgentSessionId
           ? { cliAgentSessionId: metadata.cliAgentSessionId }
-          : {}),
-        ...(metadata?.affinityProtectedUntil
-          ? { affinityProtectedUntil: metadata.affinityProtectedUntil }
-          : {}),
-        ...(metadata?.sessionAffinityResource
-          ? { sessionAffinityResource: metadata.sessionAffinityResource }
-          : {}),
-        ...(metadata?.historyGenerationAffinityProtectedUntil
-          ? {
-              historyGenerationAffinityProtectedUntil:
-                metadata.historyGenerationAffinityProtectedUntil,
-            }
           : {}),
         ...(metadata?.historyGenerationRunId
           ? { historyGenerationRunId: metadata.historyGenerationRunId }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -269,6 +269,10 @@ function runnerHeartbeatBody(
 }
 
 export function createRunsApi(context: TestContext) {
+  const defaultRunnerIdentity = {
+    runnerId: randomUUID(),
+    heartbeatGeneration: 1,
+  };
   const applyUserPermissionGrantRequestBody = (
     body: {
       readonly agentId: string;
@@ -488,7 +492,7 @@ export function createRunsApi(context: TestContext) {
         runApp(context)(runnersJobClaimContract).claim({
           headers: runnerHeaders(true),
           params: { id: runId },
-          body,
+          body: { runnerIdentity: defaultRunnerIdentity, ...body },
         }),
         [200],
       );
@@ -1184,7 +1188,7 @@ export function createRunsApi(context: TestContext) {
         runApp(context)(runnersJobClaimContract).claim({
           headers: runnerHeaders(validAuth),
           params: { id: runId },
-          body,
+          body: { runnerIdentity: defaultRunnerIdentity, ...body },
         }),
         statuses,
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -127,24 +127,6 @@ const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 const ASSISTANT_EVENT_ID_NAMESPACE = "bfec4fb6-d5b8-43e4-a72a-9f58f87d7e01";
 const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
 
-function sessionAffinityProtectedUntil(
-  job: RunnerJob | null | undefined,
-): string | null {
-  return job?.affinityProtectedUntil ?? null;
-}
-
-function historyGenerationAffinityProtectedUntil(
-  job: RunnerJob | null | undefined,
-): string | null {
-  return job?.historyGenerationAffinityProtectedUntil ?? null;
-}
-
-function sessionAffinityResource(
-  job: RunnerJob | null | undefined,
-): RunnerJob["sessionAffinityResource"] {
-  return job?.sessionAffinityResource;
-}
-
 function runnerPreference(
   job: RunnerJob | null | undefined,
 ): RunnerJob["runnerPreference"] {
@@ -1136,7 +1118,10 @@ interface SameThreadAffinityHeartbeatArgs {
   }[];
 }
 
-async function setupSameThreadAffinityScenario() {
+async function setupSameThreadAffinityScenario(sourceRunnerIdentity?: {
+  readonly runnerId: string;
+  readonly heartbeatGeneration: number;
+}) {
   const api = createRunsApi(context);
   const chat = createChatFilesBddApi(context);
   const webhooks = createWebhookCallbackApi(context);
@@ -1146,7 +1131,10 @@ async function setupSameThreadAffinityScenario() {
     agentId,
     prompt: "start affinity-protected session",
   });
-  const firstClaim = await api.claimRunnerJob(first.runId);
+  const firstClaim = await api.claimRunnerJob(
+    first.runId,
+    sourceRunnerIdentity ? { runnerIdentity: sourceRunnerIdentity } : {},
+  );
   const cliAgentSessionId = `bdd-affinity-cli-${first.runId}`;
   const reuseKey = `thread:${first.threadId}`;
   const affinityRunnerId = randomUUID();
@@ -3254,7 +3242,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, run.runId, [200]);
   });
 
-  it("leaves claim ownership null when an official runner omits rollout identity", async () => {
+  it("rejects an official runner claim without process identity", async () => {
     const api = createRunsApi(context);
     const { actor, agentId } = await entitledRunActor();
     const run = await api.createRun(actor, {
@@ -3263,12 +3251,18 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       modelProvider: "anthropic-api-key",
     });
 
-    await api.claimRunnerJob(run.runId);
-
-    await expect(readRunClaimOwner(context, run.runId)).resolves.toStrictEqual({
-      runner_id: null,
-      heartbeat_generation: null,
+    const rejected = await api.requestRawClaimRunnerJob(
+      true,
+      run.runId,
+      [400],
+      {},
+    );
+    expectApiError(rejected.body);
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "pending",
     });
+
+    await api.claimRunnerJob(run.runId);
     await api.requestCancelRun(actor, run.runId, [200]);
   });
 
@@ -3465,6 +3459,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       first.runId,
       [200],
       {
+        runnerIdentity: {
+          runnerId: randomUUID(),
+          heartbeatGeneration: 1,
+        },
         telemetry: {
           pollReason: "future-runner-reason",
           jobDiscoveredToClaimRequestMs: -1,
@@ -3584,7 +3582,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(poll.body.job?.runId).toBe(resumed.runId);
     expect(poll.body.job?.cliAgentSessionId).toBe(cliAgentSessionId);
     expect(poll.body.job?.reuseKey).toBeNull();
-    expect(sessionAffinityProtectedUntil(poll.body.job)).toBeNull();
     expect(runnerPreference(poll.body.job)).toBeUndefined();
 
     const resumedClaim = await api.claimRunnerJob(resumed.runId);
@@ -3707,15 +3704,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       cliAgentSessionId,
     );
     expect(canonicalHeartbeatHolder.job?.reuseKey).toBe(reuseKey);
-    expect(
-      sessionAffinityProtectedUntil(canonicalHeartbeatHolder.job),
-    ).toBeNull();
-    expect(
-      historyGenerationAffinityProtectedUntil(canonicalHeartbeatHolder.job),
-    ).toBeNull();
-    expect(
-      sessionAffinityResource(canonicalHeartbeatHolder.job),
-    ).toBeUndefined();
     expect(runnerPreference(canonicalHeartbeatHolder.job)).toBeUndefined();
 
     await api.requestHeartbeatRunner(true, [200], {
@@ -3738,9 +3726,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const workspaceOnlyHolder = await pollFollowUp(
       "continue with a workspace-only holder",
     );
-    expect(sessionAffinityResource(workspaceOnlyHolder.job)).toBe(
-      "workspaceCache",
-    );
     expect(workspaceOnlyHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
     expect(runnerPreference(workspaceOnlyHolder.job)).toStrictEqual({
       runnerIdentity: {
@@ -3748,7 +3733,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         heartbeatGeneration: 1,
       },
       reason: "matchingReuseKey",
-      expiresAt: sessionAffinityProtectedUntil(workspaceOnlyHolder.job),
+      expiresAt: expect.any(String),
     });
     await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
@@ -3759,12 +3744,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const capableWorkspaceHolder = await pollFollowUp(
       "continue with a capable workspace holder",
     );
-    expect(
-      sessionAffinityProtectedUntil(capableWorkspaceHolder.job),
-    ).toStrictEqual(expect.any(String));
-    expect(sessionAffinityResource(capableWorkspaceHolder.job)).toBe(
-      "workspaceCache",
-    );
+    expect(runnerPreference(capableWorkspaceHolder.job)).toMatchObject({
+      reason: "matchingReuseKey",
+    });
 
     const reusableRunnerId = randomUUID();
     await api.requestHeartbeatRunner(true, [200], {
@@ -3784,16 +3766,13 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const reusableOverWorkspace = await pollFollowUp(
       "prefer a reusable holder over a capable workspace holder",
     );
-    expect(sessionAffinityResource(reusableOverWorkspace.job)).toBe(
-      "reusableSandbox",
-    );
     const reusablePreference = {
       runnerIdentity: {
         runnerId: reusableRunnerId,
         heartbeatGeneration: 1,
       },
       reason: "matchingReuseKey" as const,
-      expiresAt: sessionAffinityProtectedUntil(reusableOverWorkspace.job),
+      expiresAt: expect.any(String),
     };
     expect(runnerPreference(reusableOverWorkspace.job)).toStrictEqual(
       reusablePreference,
@@ -3802,7 +3781,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "job",
       expect.objectContaining({
         runId: reusableOverWorkspace.run.runId,
-        sessionAffinityResource: "reusableSandbox",
         runnerPreference: reusablePreference,
       }),
     );
@@ -3822,12 +3800,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const mismatchedCapableWorkspace = await pollFollowUp(
       "continue with a mismatched capable workspace",
     );
-    expect(
-      sessionAffinityProtectedUntil(mismatchedCapableWorkspace.job),
-    ).toBeNull();
-    expect(
-      sessionAffinityResource(mismatchedCapableWorkspace.job),
-    ).toBeUndefined();
     expect(runnerPreference(mismatchedCapableWorkspace.job)).toBeUndefined();
 
     await heartbeatHolder({
@@ -3840,22 +3812,13 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const differentGenerationHolder = await pollFollowUp(
       "continue with a different reusable generation",
     );
-    expect(
-      sessionAffinityProtectedUntil(differentGenerationHolder.job),
-    ).toStrictEqual(expect.any(String));
-    expect(sessionAffinityResource(differentGenerationHolder.job)).toBe(
-      "reusableSandbox",
-    );
-    expect(
-      historyGenerationAffinityProtectedUntil(differentGenerationHolder.job),
-    ).toBeNull();
     expect(runnerPreference(differentGenerationHolder.job)).toStrictEqual({
       runnerIdentity: {
         runnerId: affinityRunnerId,
         heartbeatGeneration: 1,
       },
       reason: "matchingReuseKey",
-      expiresAt: sessionAffinityProtectedUntil(differentGenerationHolder.job),
+      expiresAt: expect.any(String),
     });
 
     await heartbeatHolder({
@@ -3868,34 +3831,23 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const exactGenerationHolder = await pollFollowUp(
       "continue with exact reusable generation",
     );
-    expect(
-      sessionAffinityProtectedUntil(exactGenerationHolder.job),
-    ).toStrictEqual(expect.any(String));
-    expect(
-      historyGenerationAffinityProtectedUntil(exactGenerationHolder.job),
-    ).toStrictEqual(expect.any(String));
-    expect(sessionAffinityResource(exactGenerationHolder.job)).toBe(
-      "reusableSandbox",
-    );
     expect(runnerPreference(exactGenerationHolder.job)).toStrictEqual({
       runnerIdentity: {
         runnerId: affinityRunnerId,
         heartbeatGeneration: 1,
       },
       reason: "exactHistoryGeneration",
-      expiresAt: historyGenerationAffinityProtectedUntil(
-        exactGenerationHolder.job,
-      ),
+      expiresAt: expect.any(String),
     });
 
-    for (const { runId, resource } of [
+    for (const { runId, resolution } of [
       {
         runId: reusableOverWorkspace.run.runId,
-        resource: "reusableSandbox",
+        resolution: "matching_reusable_sandbox",
       },
       {
         runId: capableWorkspaceHolder.run.runId,
-        resource: "workspaceCache",
+        resolution: "matching_workspace_cache",
       },
     ]) {
       for (const actionType of [
@@ -3906,12 +3858,250 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         expect(events).toHaveLength(1);
         expect(events[0]).toStrictEqual(
           expect.objectContaining({
-            session_affinity_resource: resource,
+            runner_preference_resolution: resolution,
             reuse_key_kind: "thread",
           }),
         );
       }
     }
+  });
+
+  it("prefers the live finalizing source before generic reuse without renewing its deadline", async () => {
+    const sourceCompletedAt = now();
+    mockNow(sourceCompletedAt);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    const sourceRunnerIdentity = {
+      runnerId: randomUUID(),
+      heartbeatGeneration: 7,
+    };
+    const { actor, agentId, api, first, reuseKey, runnerGroup } =
+      await setupSameThreadAffinityScenario(sourceRunnerIdentity);
+
+    await api.requestHeartbeatRunner(true, [200], {
+      runnerId: sourceRunnerIdentity.runnerId,
+      group: runnerGroup,
+      snapshotGeneration: sourceRunnerIdentity.heartbeatGeneration,
+      snapshotSequence: 1,
+      admittableProfiles: [],
+    });
+    const genericRunnerId = randomUUID();
+    await api.requestHeartbeatRunner(true, [200], {
+      runnerId: genericRunnerId,
+      group: runnerGroup,
+      snapshotGeneration: 3,
+      snapshotSequence: 1,
+      admittableProfiles: [],
+      heldSandboxStates: [
+        {
+          reuseKey,
+          lastCompletedAt: nowDate().toISOString(),
+          reusableSandbox: { profile: "vm0/default" },
+        },
+      ],
+    });
+
+    const successorCreatedAt = sourceCompletedAt + 100;
+    mockNow(successorCreatedAt);
+    context.mocks.ably.publish.mockClear();
+    const successor = await sendChatRunMessage(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "continue while the exact source is finalizing",
+    });
+    const finalizingPreference = {
+      runnerIdentity: sourceRunnerIdentity,
+      reason: "finalizingPredecessor" as const,
+      expiresAt: new Date(sourceCompletedAt + 1500).toISOString(),
+    };
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "job",
+      expect.objectContaining({
+        runId: successor.runId,
+        reuseKey,
+        historyGenerationRunId: first.runId,
+        runnerPreference: finalizingPreference,
+      }),
+    );
+
+    const sourcePoll = await api.requestPollRunner(
+      true,
+      {
+        runnerId: sourceRunnerIdentity.runnerId,
+        group: runnerGroup,
+        supportedProfiles: ["vm0/default"],
+      },
+      [200],
+    );
+    if (sourcePoll.status !== 200) {
+      throw new Error("Expected finalizing predecessor poll to succeed");
+    }
+    expect(sourcePoll.body.job?.runId).toBe(successor.runId);
+    expect(runnerPreference(sourcePoll.body.job)).toStrictEqual(
+      finalizingPreference,
+    );
+    expect(
+      sandboxOperationEventsForRunByAction(
+        successor.runId,
+        "runner_notification_affinity_lookup",
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        runner_preference_resolution: "finalizing_predecessor",
+      }),
+    );
+
+    mockNow(sourceCompletedAt + 1601);
+    const genericPoll = await api.requestPollRunner(
+      true,
+      {
+        runnerId: genericRunnerId,
+        group: runnerGroup,
+        supportedProfiles: ["vm0/default"],
+      },
+      [200],
+    );
+    if (genericPoll.status !== 200) {
+      throw new Error("Expected generic fallback poll to succeed");
+    }
+    expect(genericPoll.body.job?.runId).toBe(successor.runId);
+    expect(runnerPreference(genericPoll.body.job)).toStrictEqual({
+      runnerIdentity: {
+        runnerId: genericRunnerId,
+        heartbeatGeneration: 3,
+      },
+      reason: "matchingReuseKey",
+      expiresAt: new Date(successorCreatedAt + 2000).toISOString(),
+    });
+
+    await api.requestCancelRun(actor, successor.runId, [200]);
+    await flushWaitUntilForTest();
+  });
+
+  it("prefers advertised exact history over the finalizing source", async () => {
+    const sourceCompletedAt = now();
+    mockNow(sourceCompletedAt);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    const sourceRunnerIdentity = {
+      runnerId: randomUUID(),
+      heartbeatGeneration: 5,
+    };
+    const { actor, agentId, api, first, reuseKey, runnerGroup } =
+      await setupSameThreadAffinityScenario(sourceRunnerIdentity);
+    await api.requestHeartbeatRunner(true, [200], {
+      runnerId: sourceRunnerIdentity.runnerId,
+      group: runnerGroup,
+      snapshotGeneration: sourceRunnerIdentity.heartbeatGeneration,
+      snapshotSequence: 1,
+      admittableProfiles: [],
+    });
+    const exactRunnerIdentity = {
+      runnerId: randomUUID(),
+      heartbeatGeneration: 9,
+    };
+    await api.requestHeartbeatRunner(true, [200], {
+      runnerId: exactRunnerIdentity.runnerId,
+      group: runnerGroup,
+      snapshotGeneration: exactRunnerIdentity.heartbeatGeneration,
+      snapshotSequence: 1,
+      admittableProfiles: [],
+      heldSandboxStates: [
+        {
+          reuseKey,
+          lastCompletedAt: nowDate().toISOString(),
+          reusableSandbox: {
+            profile: "vm0/default",
+            historyGenerationRunId: first.runId,
+          },
+        },
+      ],
+    });
+
+    const successorCreatedAt = sourceCompletedAt + 100;
+    mockNow(successorCreatedAt);
+    context.mocks.ably.publish.mockClear();
+    const successor = await sendChatRunMessage(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "continue with exact history already advertised",
+    });
+    const exactPreference = {
+      runnerIdentity: exactRunnerIdentity,
+      reason: "exactHistoryGeneration" as const,
+      expiresAt: new Date(successorCreatedAt + 500).toISOString(),
+    };
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "job",
+      expect.objectContaining({
+        runId: successor.runId,
+        runnerPreference: exactPreference,
+      }),
+    );
+    const poll = await api.requestPollRunner(
+      true,
+      {
+        runnerId: exactRunnerIdentity.runnerId,
+        group: runnerGroup,
+        supportedProfiles: ["vm0/default"],
+      },
+      [200],
+    );
+    if (poll.status !== 200) {
+      throw new Error("Expected exact-history poll to succeed");
+    }
+    expect(poll.body.job?.runId).toBe(successor.runId);
+    expect(runnerPreference(poll.body.job)).toStrictEqual(exactPreference);
+
+    await api.requestCancelRun(actor, successor.runId, [200]);
+    await flushWaitUntilForTest();
+  });
+
+  it("does not prefer a predecessor after its runner generation restarts", async () => {
+    const sourceCompletedAt = now();
+    mockNow(sourceCompletedAt);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    const sourceRunnerIdentity = {
+      runnerId: randomUUID(),
+      heartbeatGeneration: 4,
+    };
+    const { actor, agentId, api, first, runnerGroup } =
+      await setupSameThreadAffinityScenario(sourceRunnerIdentity);
+    await api.requestHeartbeatRunner(true, [200], {
+      runnerId: sourceRunnerIdentity.runnerId,
+      group: runnerGroup,
+      snapshotGeneration: sourceRunnerIdentity.heartbeatGeneration + 1,
+      snapshotSequence: 1,
+      admittableProfiles: [],
+    });
+
+    mockNow(sourceCompletedAt + 100);
+    const successor = await sendChatRunMessage(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "continue after the source process restarted",
+    });
+    const poll = await api.requestPollRunner(
+      true,
+      {
+        runnerId: sourceRunnerIdentity.runnerId,
+        group: runnerGroup,
+        supportedProfiles: ["vm0/default"],
+      },
+      [200],
+    );
+    if (poll.status !== 200) {
+      throw new Error("Expected restarted-source poll to succeed");
+    }
+    expect(poll.body.job?.runId).toBe(successor.runId);
+    expect(runnerPreference(poll.body.job)).toBeUndefined();
+
+    await api.requestCancelRun(actor, successor.runId, [200]);
+    await flushWaitUntilForTest();
   });
 
   it("omits same-thread affinity for unavailable holders", async () => {
@@ -3934,7 +4124,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue while holder is starting",
     );
     expect(startingHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(sessionAffinityProtectedUntil(startingHolder.job)).toBeNull();
     expect(runnerPreference(startingHolder.job)).toBeUndefined();
 
     await heartbeatHolder({
@@ -3945,7 +4134,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       false,
     );
     expect(unavailableHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(sessionAffinityProtectedUntil(unavailableHolder.job)).toBeNull();
     expect(runnerPreference(unavailableHolder.job)).toBeUndefined();
     const unavailableClaim = await api.claimRunnerJob(
       unavailableHolder.run.runId,
@@ -3979,8 +4167,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue after holder heartbeat is stale",
     );
     expect(staleHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(sessionAffinityProtectedUntil(staleHolder.job)).toBeNull();
-    expect(historyGenerationAffinityProtectedUntil(staleHolder.job)).toBeNull();
     expect(runnerPreference(staleHolder.job)).toBeUndefined();
 
     await heartbeatHolder({
@@ -3996,12 +4182,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(profileIncompatibleHolder.job?.cliAgentSessionId).toBe(
       cliAgentSessionId,
     );
-    expect(
-      sessionAffinityProtectedUntil(profileIncompatibleHolder.job),
-    ).toBeNull();
-    expect(
-      historyGenerationAffinityProtectedUntil(profileIncompatibleHolder.job),
-    ).toBeNull();
     expect(runnerPreference(profileIncompatibleHolder.job)).toBeUndefined();
 
     await heartbeatHolder({
@@ -4016,10 +4196,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue while holder is draining",
     );
     expect(drainingHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(sessionAffinityProtectedUntil(drainingHolder.job)).toBeNull();
-    expect(
-      historyGenerationAffinityProtectedUntil(drainingHolder.job),
-    ).toBeNull();
     expect(runnerPreference(drainingHolder.job)).toBeUndefined();
   });
 
@@ -4111,11 +4287,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         runId: protectedFollowUp.runId,
         reuseKey,
         historyGenerationRunId: first.runId,
-        affinityProtectedUntil: new Date(queueInsertedAt + 2000).toISOString(),
-        sessionAffinityResource: "reusableSandbox",
-        historyGenerationAffinityProtectedUntil: new Date(
-          queueInsertedAt + 500,
-        ).toISOString(),
         runnerPreference: exactRunnerPreference,
       }),
     );
@@ -4131,15 +4302,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(protectedPoll.body.job?.runId).toBe(protectedFollowUp.runId);
     expect(protectedPoll.body.job?.cliAgentSessionId).toBe(cliAgentSessionId);
     expect(protectedPoll.body.job?.reuseKey).toBe(reuseKey);
-    expect(sessionAffinityProtectedUntil(protectedPoll.body.job)).toBe(
-      new Date(queueInsertedAt + 2000).toISOString(),
-    );
-    expect(
-      historyGenerationAffinityProtectedUntil(protectedPoll.body.job),
-    ).toBe(new Date(queueInsertedAt + 500).toISOString());
-    expect(sessionAffinityResource(protectedPoll.body.job)).toBe(
-      "reusableSandbox",
-    );
     expect(runnerPreference(protectedPoll.body.job)).toStrictEqual(
       exactRunnerPreference,
     );
@@ -4192,9 +4354,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           runner_group: runnerGroup,
           profile: "vm0/default",
           notification_target: "broadcast",
-          session_affinity: "protected",
-          session_affinity_resource: "reusableSandbox",
-          history_generation_affinity: "protected",
+          runner_preference_resolution: "exact_history_generation",
           reuse_key_kind: "thread",
         }),
       );
@@ -4229,12 +4389,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     }
     expect(generationExpiredPoll.body.job?.runId).toBe(
       generationExpiredRun.runId,
-    );
-    expect(
-      historyGenerationAffinityProtectedUntil(generationExpiredPoll.body.job),
-    ).toBeNull();
-    expect(sessionAffinityProtectedUntil(generationExpiredPoll.body.job)).toBe(
-      new Date(generationExpiredAt + 2000).toISOString(),
     );
     expect(runnerPreference(generationExpiredPoll.body.job)).toStrictEqual({
       runnerIdentity: preferredExactRunner,
@@ -4306,7 +4460,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     async function heartbeat(args: {
       readonly generation: number;
       readonly sequence: number;
-      readonly resource: RunnerJob["sessionAffinityResource"];
+      readonly resource: "reusableSandbox" | "workspaceCache" | undefined;
     }): Promise<void> {
       const lastCompletedAt = nowDate().toISOString();
       await api.requestHeartbeatRunner(true, [200], {
@@ -4341,7 +4495,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     }
 
     async function expectAffinity(
-      expectedResource: RunnerJob["sessionAffinityResource"],
+      expectedResource: "reusableSandbox" | "workspaceCache" | undefined,
     ): Promise<void> {
       const followUp = await sendChatRunMessage(actor, {
         agentId,
@@ -4358,11 +4512,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       }
       expect(poll.body.job?.runId).toBe(followUp.runId);
       if (expectedResource) {
-        expect(sessionAffinityProtectedUntil(poll.body.job)).not.toBeNull();
+        expect(runnerPreference(poll.body.job)).toMatchObject({
+          runnerIdentity: {
+            runnerId,
+            heartbeatGeneration: 1,
+          },
+          reason: "matchingReuseKey",
+          expiresAt: expect.any(String),
+        });
       } else {
-        expect(sessionAffinityProtectedUntil(poll.body.job)).toBeNull();
+        expect(runnerPreference(poll.body.job)).toBeUndefined();
       }
-      expect(sessionAffinityResource(poll.body.job)).toBe(expectedResource);
       await api.requestCancelRun(actor, followUp.runId, [200]);
       await flushWaitUntilForTest();
     }
@@ -4482,12 +4642,14 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected reusable-holder poll to return 200");
     }
     expect(protectedPoll.body.job?.runId).toBe(protectedFollowUp.runId);
-    expect(protectedPoll.body.job?.affinityProtectedUntil).toStrictEqual(
-      expect.any(String),
-    );
-    expect(protectedPoll.body.job?.sessionAffinityResource).toBe(
-      "reusableSandbox",
-    );
+    expect(runnerPreference(protectedPoll.body.job)).toMatchObject({
+      runnerIdentity: {
+        runnerId: affinityRunnerId,
+        heartbeatGeneration: 1,
+      },
+      reason: "exactHistoryGeneration",
+      expiresAt: expect.any(String),
+    });
     await api.requestCancelRun(actor, protectedFollowUp.runId, [200]);
     await flushWaitUntilForTest();
 
@@ -4662,9 +4824,13 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected workspace-priority poll to return 200");
     }
     expect(workspacePoll.body.job?.runId).toBe(newerWorkspace.runId);
-    expect(workspacePoll.body.job?.sessionAffinityResource).toBe(
-      "workspaceCache",
-    );
+    expect(runnerPreference(workspacePoll.body.job)).toMatchObject({
+      runnerIdentity: {
+        runnerId: workspaceRunnerId,
+        heartbeatGeneration: 1,
+      },
+      reason: "matchingReuseKey",
+    });
 
     await api.requestCancelRun(actor, newerWorkspace.runId, [200]);
     await api.requestCancelRun(actor, olderGeneric.runId, [200]);
@@ -4950,9 +5116,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
           runner_group: runnerGroup,
           profile: "vm0/default",
           notification_target: "broadcast",
-          session_affinity: "no_session",
-          session_affinity_resource: "none",
-          history_generation_affinity: "no_session",
+          runner_preference_resolution: "no_reuse_key",
           reuse_key_kind: "none",
         }),
       );
@@ -10323,28 +10487,6 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       });
       await api.requestCancelRun(actor, created.body.runId, [200]);
     }
-  });
-
-  it("accepts previous runner telemetry", async () => {
-    const api = createRunsApi(context);
-    const { actor, agentId } = await entitledRunActor();
-
-    const run = await api.createRun(actor, {
-      agentId,
-      prompt: "accept previous runner generation relationship",
-      modelProvider: "anthropic-api-key",
-    });
-    const claim = await api.requestRawClaimRunnerJob(true, run.runId, [200], {
-      telemetry: {
-        sessionAffinityResource: "workspaceCache",
-        sessionAffinityLocalResource: "workspaceCache",
-        localAdmissionResource: "fresh",
-        sessionHistoryGenerationRelationship: "different",
-      },
-    });
-    expect(claim.status).toBe(200);
-
-    await api.requestCancelRun(actor, run.runId, [200]);
   });
 
   it("returns 500 when claim response construction fails", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -1366,8 +1366,14 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       runId,
       cliAgentSessionId: null,
       reuseKey,
-      sessionAffinityResource: "reusableSandbox",
-      affinityProtectedUntil: expect.any(String),
+      runnerPreference: {
+        runnerIdentity: {
+          runnerId,
+          heartbeatGeneration: 1,
+        },
+        reason: "matchingReuseKey",
+        expiresAt: expect.any(String),
+      },
     });
     for (const actionType of [
       "runner_notification_queue_to_entry",

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -103,10 +103,10 @@ import {
   tryNormalizeSessionHistoryBlobEncoding,
 } from "../services/session-history-blobs";
 import {
+  type RunnerPreferenceResolutionOutcome,
   runnerReuseKeyTelemetryKind,
   runnerReusePreferenceLookupError,
   runnerReusePreferencePollPriority,
-  runnerReusePreferenceTelemetryResource,
   resolveRunnerReusePreference,
 } from "../services/runner-reuse-preference";
 import type { RouteEntry } from "../route-entry";
@@ -536,9 +536,7 @@ function recordPollTimingMetrics(args: {
   readonly profile: string;
   readonly authType: RunnerAuthContext["type"];
   readonly pollReason: string | undefined;
-  readonly sessionAffinity: string;
-  readonly sessionAffinityResource: string;
-  readonly historyGenerationAffinity: string;
+  readonly runnerPreferenceResolution: RunnerPreferenceResolutionOutcome;
   readonly reuseKeyKind: "thread" | "session" | "none";
   readonly queueCreatedAtMs: number;
   readonly pollRequestStartedAtMs: number;
@@ -550,9 +548,7 @@ function recordPollTimingMetrics(args: {
     runner_group: args.runnerGroup,
     profile: args.profile,
     auth_type: args.authType,
-    session_affinity: args.sessionAffinity,
-    session_affinity_resource: args.sessionAffinityResource,
-    history_generation_affinity: args.historyGenerationAffinity,
+    runner_preference_resolution: args.runnerPreferenceResolution,
     reuse_key_kind: args.reuseKeyKind,
   };
   if (args.pollReason) {
@@ -733,10 +729,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     profile: pendingJob.profile,
     authType: auth.type,
     pollReason: body.data.telemetry?.pollReason,
-    sessionAffinity: reusePreference.status,
-    sessionAffinityResource:
-      runnerReusePreferenceTelemetryResource(reusePreference),
-    historyGenerationAffinity: reusePreference.historyGenerationStatus,
+    runnerPreferenceResolution: reusePreference.outcome,
     reuseKeyKind: runnerReuseKeyTelemetryKind(pendingJob.reuseKey),
     queueCreatedAtMs: pendingJob.createdAt.getTime(),
     pollRequestStartedAtMs,
@@ -758,12 +751,6 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         cliAgentSessionId: pendingJob.cliAgentSessionId,
         reuseKey: pendingJob.reuseKey,
         historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
-        historyGenerationAffinityProtectedUntil:
-          reusePreference.historyGenerationProtectedUntil?.toISOString() ??
-          null,
-        affinityProtectedUntil:
-          reusePreference.protectedUntil?.toISOString() ?? null,
-        sessionAffinityResource: reusePreference.resource ?? undefined,
         runnerPreference: reusePreference.runnerPreference ?? undefined,
       },
     },
@@ -2390,6 +2377,9 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   signal.throwIfAborted();
   if (!body.ok) {
     return body.response;
+  }
+  if (auth.type === "official-runner" && !body.data.runnerIdentity) {
+    return badRequestMessage("Official runner claim requires runnerIdentity");
   }
 
   const runId = get(pathParamsOf(runnersJobClaimContract.claim)).id;

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -6,7 +6,6 @@ import type { Db } from "../external/db";
 import {
   runnerReuseKeyTelemetryKind,
   runnerReusePreferenceLookupError,
-  runnerReusePreferenceTelemetryResource,
   resolveRunnerReusePreference,
 } from "./runner-reuse-preference";
 import { tapError } from "../utils";
@@ -61,11 +60,6 @@ export async function notifyRunnerJob(
     {
       reuseKey: args.reuseKey,
       cliAgentSessionId: args.cliAgentSessionId,
-      historyGenerationAffinityProtectedUntil:
-        reusePreference.historyGenerationProtectedUntil?.toISOString() ?? null,
-      affinityProtectedUntil:
-        reusePreference.protectedUntil?.toISOString() ?? null,
-      sessionAffinityResource: reusePreference.resource,
       historyGenerationRunId: args.historyGenerationRunId,
       runnerPreference: reusePreference.runnerPreference,
     },
@@ -76,10 +70,7 @@ export async function notifyRunnerJob(
     runner_group: args.runnerGroup,
     profile: args.profile,
     notification_target: "broadcast",
-    session_affinity: reusePreference.status,
-    session_affinity_resource:
-      runnerReusePreferenceTelemetryResource(reusePreference),
-    history_generation_affinity: reusePreference.historyGenerationStatus,
+    runner_preference_resolution: reusePreference.outcome,
     reuse_key_kind: runnerReuseKeyTelemetryKind(args.reuseKey),
   };
   // Queue-relative actions are cumulative boundaries. Preference lookup and

--- a/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
+++ b/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
@@ -1,7 +1,5 @@
-import type {
-  RunnerPreference,
-  SessionAffinityResource,
-} from "@vm0/api-contracts/contracts/runners";
+import type { RunnerPreference } from "@vm0/api-contracts/contracts/runners";
+import { agentRuns } from "@vm0/db/schema/agent-run";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
 import {
@@ -18,6 +16,7 @@ import {
   type SQL,
   type SQLWrapper,
 } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 
 import { pgBooleanDecoder } from "../../lib/db-structured-result";
 import type { Db } from "../external/db";
@@ -27,7 +26,10 @@ const RUNNER_EXACT_HISTORY_PROTECTION_MS = Math.min(
   500,
   RUNNER_REUSE_PROTECTION_MS,
 );
+const RUNNER_FINALIZING_PREDECESSOR_PROTECTION_MS = 1500;
 const RUNNER_REUSE_HOLDER_FRESH_MS = 30_000;
+
+const finalizingSourceRun = alias(agentRuns, "finalizing_source_run");
 
 function runnerReuseHolderFreshAfter(currentDate: Date): Date {
   return new Date(currentDate.getTime() - RUNNER_REUSE_HOLDER_FRESH_MS);
@@ -95,7 +97,64 @@ function runnerStateHas(args: {
           ...(args.runnerId ? [eq(runnerState.runnerId, args.runnerId)] : []),
           eq(runnerState.mode, "running"),
           gt(runnerState.lastSeenAt, args.freshAfter),
+          gt(runnerState.heartbeatGeneration, 0),
           args.resourceCondition,
+        ),
+      ),
+  );
+}
+
+function finalizingPredecessorCondition(args: {
+  readonly runnerGroup: string;
+  readonly completedAfter: Date;
+}): SQL | undefined {
+  // admittableProfiles is remaining capacity, so it may be empty while this
+  // process is still finalizing. Poll and Ably recipients enforce static
+  // profile support before admitting the advisory preference.
+  return and(
+    eq(finalizingSourceRun.status, "completed"),
+    gt(finalizingSourceRun.completedAt, args.completedAfter),
+    eq(finalizingSourceRun.runnerGroup, args.runnerGroup),
+    isNotNull(finalizingSourceRun.runnerId),
+    isNotNull(finalizingSourceRun.runnerHeartbeatGeneration),
+    eq(runnerState.runnerId, finalizingSourceRun.runnerId),
+    eq(
+      runnerState.heartbeatGeneration,
+      finalizingSourceRun.runnerHeartbeatGeneration,
+    ),
+  );
+}
+
+function runnerStateHasFinalizingPredecessor(args: {
+  readonly db: Pick<Db, "select">;
+  readonly runnerId?: string;
+  readonly runnerGroup: string;
+  readonly historyGenerationRunId: SQLWrapper;
+  readonly freshAfter: Date;
+  readonly completedAfter: Date;
+}): SQL {
+  return exists(
+    args.db
+      .select({ runnerId: runnerState.runnerId })
+      .from(runnerState)
+      .innerJoin(
+        finalizingSourceRun,
+        eq(
+          sql`${finalizingSourceRun.id}::text`,
+          sql`cast(${args.historyGenerationRunId} as text)`,
+        ),
+      )
+      .where(
+        and(
+          eq(runnerState.runnerGroup, args.runnerGroup),
+          ...(args.runnerId ? [eq(runnerState.runnerId, args.runnerId)] : []),
+          eq(runnerState.mode, "running"),
+          gt(runnerState.lastSeenAt, args.freshAfter),
+          gt(runnerState.heartbeatGeneration, 0),
+          finalizingPredecessorCondition({
+            runnerGroup: args.runnerGroup,
+            completedAfter: args.completedAfter,
+          }),
         ),
       ),
   );
@@ -117,6 +176,9 @@ export function runnerReusePreferencePollPriority(args: {
   );
   const generationProtectedAfter = new Date(
     args.currentDate.getTime() - RUNNER_EXACT_HISTORY_PROTECTION_MS,
+  );
+  const finalizingCompletedAfter = new Date(
+    args.currentDate.getTime() - RUNNER_FINALIZING_PREDECESSOR_PROTECTION_MS,
   );
   const freshAfter = runnerReuseHolderFreshAfter(args.currentDate);
   const targetGenerationRunId = sql`${runnerJobQueue.executionContext}->'resumeSession'->>'historyGenerationRunId'`;
@@ -152,6 +214,21 @@ export function runnerReusePreferencePollPriority(args: {
   const hasLocalReusable = local(reusableCondition);
   const hasGlobalWorkspace = global(workspaceCondition);
   const hasLocalWorkspace = local(workspaceCondition);
+  const hasGlobalFinalizingPredecessor = runnerStateHasFinalizingPredecessor({
+    db: args.db,
+    runnerGroup: args.runnerGroup,
+    historyGenerationRunId: targetGenerationRunId,
+    freshAfter,
+    completedAfter: finalizingCompletedAfter,
+  });
+  const hasLocalFinalizingPredecessor = runnerStateHasFinalizingPredecessor({
+    db: args.db,
+    runnerId: args.runnerId,
+    runnerGroup: args.runnerGroup,
+    historyGenerationRunId: targetGenerationRunId,
+    freshAfter,
+    completedAfter: finalizingCompletedAfter,
+  });
   return sql`CASE
     WHEN ${and(
       gt(runnerJobQueue.createdAt, generationProtectedAfter),
@@ -159,7 +236,17 @@ export function runnerReusePreferencePollPriority(args: {
       isNotNull(targetGenerationRunId),
       hasGlobalExact,
     )}
-    THEN CASE WHEN ${hasLocalExact} THEN 5 ELSE 0 END
+    THEN CASE WHEN ${hasLocalExact} THEN 7 ELSE 0 END
+    WHEN ${and(
+      isNotNull(runnerJobQueue.reuseKey),
+      isNotNull(targetGenerationRunId),
+      hasGlobalFinalizingPredecessor,
+    )}
+    THEN CASE
+      WHEN ${hasLocalExact} THEN 6
+      WHEN ${hasLocalFinalizingPredecessor} THEN 5
+      ELSE 0
+    END
     WHEN ${and(
       gt(runnerJobQueue.createdAt, protectedAfter),
       isNotNull(runnerJobQueue.reuseKey),
@@ -180,49 +267,34 @@ export function runnerReusePreferencePollPriority(args: {
   END`;
 }
 
-type RunnerReusePreferenceStatus =
-  | "no_session"
+export type RunnerPreferenceResolutionOutcome =
+  | "exact_history_generation"
+  | "finalizing_predecessor"
+  | "matching_reusable_sandbox"
+  | "matching_workspace_cache"
+  | "no_reuse_key"
   | "expired"
-  | "protected"
   | "no_viable_holder"
   | "lookup_error";
 
-type RunnerHistoryGenerationPreferenceStatus =
-  | "no_session"
-  | "no_target"
-  | "expired"
-  | "protected"
-  | "no_exact_holder"
-  | "lookup_error";
-
-type CurrentRunnerPreference = Omit<RunnerPreference, "reason"> & {
-  readonly reason: Exclude<RunnerPreference["reason"], "finalizingPredecessor">;
-};
-
 interface RunnerReusePreferenceResolution {
-  readonly runnerPreference: CurrentRunnerPreference | null;
-  readonly protectedUntil: Date | null;
-  readonly status: RunnerReusePreferenceStatus;
-  readonly resource: SessionAffinityResource | null;
-  readonly historyGenerationProtectedUntil: Date | null;
-  readonly historyGenerationStatus: RunnerHistoryGenerationPreferenceStatus;
+  readonly runnerPreference: RunnerPreference | null;
+  readonly outcome: RunnerPreferenceResolutionOutcome;
 }
 
 export function runnerReusePreferenceLookupError(): RunnerReusePreferenceResolution {
   return {
     runnerPreference: null,
-    protectedUntil: null,
-    status: "lookup_error",
-    resource: null,
-    historyGenerationProtectedUntil: null,
-    historyGenerationStatus: "lookup_error",
+    outcome: "lookup_error",
   };
 }
 
 interface RunnerReuseHolder {
   readonly runnerIdentity: RunnerPreference["runnerIdentity"];
-  readonly resource: SessionAffinityResource;
   readonly hasExactHistoryGeneration: boolean;
+  readonly isFinalizingPredecessor: boolean;
+  readonly hasReusableSandbox: boolean;
+  readonly sourceCompletedAt: Date | null;
 }
 
 async function selectRunnerReuseHolder(args: {
@@ -233,15 +305,21 @@ async function selectRunnerReuseHolder(args: {
   readonly historyGenerationRunId: string | undefined;
   readonly freshAfter: Date;
   readonly shouldLookUpExactGeneration: boolean;
+  readonly shouldLookUpGenericReuse: boolean;
+  readonly finalizingCompletedAfter: Date;
 }): Promise<RunnerReuseHolder | null> {
-  const reusableCondition = reusableSandboxCondition({
-    reuseKey: sql.param(args.reuseKey),
-    profile: sql.param(args.profile),
-  });
-  const workspaceCondition = capableWorkspaceCondition({
-    reuseKey: sql.param(args.reuseKey),
-    profile: sql.param(args.profile),
-  });
+  const reusableCondition = args.shouldLookUpGenericReuse
+    ? reusableSandboxCondition({
+        reuseKey: sql.param(args.reuseKey),
+        profile: sql.param(args.profile),
+      })
+    : sql`false`;
+  const workspaceCondition = args.shouldLookUpGenericReuse
+    ? capableWorkspaceCondition({
+        reuseKey: sql.param(args.reuseKey),
+        profile: sql.param(args.profile),
+      })
+    : sql`false`;
   const exactGenerationCondition =
     args.shouldLookUpExactGeneration &&
     args.historyGenerationRunId !== undefined
@@ -251,8 +329,16 @@ async function selectRunnerReuseHolder(args: {
           historyGenerationRunId: sql.param(args.historyGenerationRunId),
         })
       : sql`false`;
+  const finalizingCondition =
+    (args.historyGenerationRunId
+      ? finalizingPredecessorCondition({
+          runnerGroup: args.runnerGroup,
+          completedAfter: args.finalizingCompletedAfter,
+        })
+      : undefined) ?? sql`false`;
   const resourceRank = sql`CASE
-    WHEN ${exactGenerationCondition} THEN 3
+    WHEN ${exactGenerationCondition} THEN 4
+    WHEN ${finalizingCondition} THEN 3
     WHEN ${reusableCondition} THEN 2
     WHEN ${workspaceCondition} THEN 1
     ELSE 0
@@ -264,16 +350,31 @@ async function selectRunnerReuseHolder(args: {
       hasExactHistoryGeneration: sql`${exactGenerationCondition}`.mapWith(
         pgBooleanDecoder,
       ),
+      isFinalizingPredecessor: sql`${finalizingCondition}`.mapWith(
+        pgBooleanDecoder,
+      ),
       hasReusableSandbox: sql`${reusableCondition}`.mapWith(pgBooleanDecoder),
+      sourceCompletedAt: finalizingSourceRun.completedAt,
     })
     .from(runnerState)
+    .leftJoin(
+      finalizingSourceRun,
+      args.historyGenerationRunId
+        ? eq(finalizingSourceRun.id, args.historyGenerationRunId)
+        : sql`false`,
+    )
     .where(
       and(
         eq(runnerState.runnerGroup, args.runnerGroup),
         eq(runnerState.mode, "running"),
         gt(runnerState.lastSeenAt, args.freshAfter),
         gt(runnerState.heartbeatGeneration, 0),
-        or(exactGenerationCondition, reusableCondition, workspaceCondition),
+        or(
+          exactGenerationCondition,
+          finalizingCondition,
+          reusableCondition,
+          workspaceCondition,
+        ),
       ),
     )
     .orderBy(desc(resourceRank), asc(runnerState.runnerId))
@@ -287,8 +388,10 @@ async function selectRunnerReuseHolder(args: {
       runnerId: holder.runnerId,
       heartbeatGeneration: holder.heartbeatGeneration,
     },
-    resource: holder.hasReusableSandbox ? "reusableSandbox" : "workspaceCache",
     hasExactHistoryGeneration: holder.hasExactHistoryGeneration,
+    isFinalizingPredecessor: holder.isFinalizingPredecessor,
+    hasReusableSandbox: holder.hasReusableSandbox,
+    sourceCompletedAt: holder.sourceCompletedAt,
   };
 }
 
@@ -304,36 +407,29 @@ export async function resolveRunnerReusePreference(args: {
   if (!args.reuseKey) {
     return {
       runnerPreference: null,
-      protectedUntil: null,
-      status: "no_session",
-      resource: null,
-      historyGenerationProtectedUntil: null,
-      historyGenerationStatus: "no_session",
+      outcome: "no_reuse_key",
     };
   }
-  const protectedUntil = new Date(
+  const matchingReuseExpiresAt = new Date(
     args.createdAt.getTime() + RUNNER_REUSE_PROTECTION_MS,
   );
-  const historyGenerationProtectedUntil = args.historyGenerationRunId
+  const exactHistoryExpiresAt = args.historyGenerationRunId
     ? new Date(args.createdAt.getTime() + RUNNER_EXACT_HISTORY_PROTECTION_MS)
     : null;
-  if (protectedUntil <= args.currentDate) {
+  const shouldLookUpGenericReuse = matchingReuseExpiresAt > args.currentDate;
+  if (!shouldLookUpGenericReuse && !args.historyGenerationRunId) {
     return {
       runnerPreference: null,
-      protectedUntil: null,
-      status: "expired",
-      resource: null,
-      historyGenerationProtectedUntil: null,
-      historyGenerationStatus: args.historyGenerationRunId
-        ? "expired"
-        : "no_target",
+      outcome: "expired",
     };
   }
 
   const freshAfter = runnerReuseHolderFreshAfter(args.currentDate);
   const shouldLookUpExactGeneration =
-    historyGenerationProtectedUntil !== null &&
-    historyGenerationProtectedUntil > args.currentDate;
+    exactHistoryExpiresAt !== null && exactHistoryExpiresAt > args.currentDate;
+  const finalizingCompletedAfter = new Date(
+    args.currentDate.getTime() - RUNNER_FINALIZING_PREDECESSOR_PROTECTION_MS,
+  );
   const holder = await selectRunnerReuseHolder({
     db: args.db,
     runnerGroup: args.runnerGroup,
@@ -342,55 +438,58 @@ export async function resolveRunnerReusePreference(args: {
     historyGenerationRunId: args.historyGenerationRunId,
     freshAfter,
     shouldLookUpExactGeneration,
+    shouldLookUpGenericReuse,
+    finalizingCompletedAfter,
   });
-  const historyGenerationStatus: RunnerHistoryGenerationPreferenceStatus =
-    !args.historyGenerationRunId
-      ? "no_target"
-      : !shouldLookUpExactGeneration
-        ? "expired"
-        : holder?.hasExactHistoryGeneration
-          ? "protected"
-          : "no_exact_holder";
 
   if (!holder) {
     return {
       runnerPreference: null,
-      protectedUntil: null,
-      status: "no_viable_holder",
-      resource: null,
-      historyGenerationProtectedUntil: null,
-      historyGenerationStatus,
+      outcome: shouldLookUpGenericReuse ? "no_viable_holder" : "expired",
     };
   }
 
-  const hasExactHistoryGeneration =
-    holder.hasExactHistoryGeneration &&
-    historyGenerationProtectedUntil !== null;
+  if (holder.hasExactHistoryGeneration) {
+    if (!exactHistoryExpiresAt) {
+      throw new Error("Exact history preference is missing its deadline");
+    }
+    return {
+      runnerPreference: {
+        runnerIdentity: holder.runnerIdentity,
+        reason: "exactHistoryGeneration",
+        expiresAt: exactHistoryExpiresAt.toISOString(),
+      },
+      outcome: "exact_history_generation",
+    };
+  }
+
+  if (holder.isFinalizingPredecessor) {
+    if (!holder.sourceCompletedAt) {
+      throw new Error("Finalizing predecessor is missing its completion time");
+    }
+    return {
+      runnerPreference: {
+        runnerIdentity: holder.runnerIdentity,
+        reason: "finalizingPredecessor",
+        expiresAt: new Date(
+          holder.sourceCompletedAt.getTime() +
+            RUNNER_FINALIZING_PREDECESSOR_PROTECTION_MS,
+        ).toISOString(),
+      },
+      outcome: "finalizing_predecessor",
+    };
+  }
 
   return {
     runnerPreference: {
       runnerIdentity: holder.runnerIdentity,
-      reason: hasExactHistoryGeneration
-        ? "exactHistoryGeneration"
-        : "matchingReuseKey",
-      expiresAt: hasExactHistoryGeneration
-        ? historyGenerationProtectedUntil.toISOString()
-        : protectedUntil.toISOString(),
+      reason: "matchingReuseKey",
+      expiresAt: matchingReuseExpiresAt.toISOString(),
     },
-    protectedUntil,
-    status: "protected",
-    resource: holder.resource,
-    historyGenerationProtectedUntil: hasExactHistoryGeneration
-      ? historyGenerationProtectedUntil
-      : null,
-    historyGenerationStatus,
+    outcome: holder.hasReusableSandbox
+      ? "matching_reusable_sandbox"
+      : "matching_workspace_cache",
   };
-}
-
-export function runnerReusePreferenceTelemetryResource(
-  resolution: RunnerReusePreferenceResolution,
-): "reusableSandbox" | "workspaceCache" | "none" {
-  return resolution.resource ?? "none";
 }
 
 export function runnerReuseKeyTelemetryKind(

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -471,7 +471,6 @@ describe("runner resume session contract", () => {
   });
 
   it("keeps generation metadata in stable discovery and reusable shapes", () => {
-    const historyGenerationAffinityProtectedUntil = "2026-07-15T00:00:00.500Z";
     const storedResumeSession = {
       sessionId: "sess-123",
       historyGenerationRunId,
@@ -501,14 +500,8 @@ describe("runner resume session contract", () => {
       vars: null,
       experimentalProfile: "vm0/default",
       historyGenerationRunId,
-      historyGenerationAffinityProtectedUntil,
-      sessionAffinityResource: "reusableSandbox",
     });
     expect(job.historyGenerationRunId).toBe(historyGenerationRunId);
-    expect(job.historyGenerationAffinityProtectedUntil).toBe(
-      historyGenerationAffinityProtectedUntil,
-    );
-    expect(job.sessionAffinityResource).toBe("reusableSandbox");
 
     const heldSandboxState = heldSandboxStateSchema.parse({
       reuseKey: "thread:22222222-2222-4222-8222-222222222223",
@@ -537,7 +530,7 @@ describe("runner resume session contract", () => {
     ]);
   });
 
-  it("keeps job generation-affinity additions optional", () => {
+  it("keeps the canonical runner preference optional", () => {
     const job = jobSchema.parse({
       runId: "22222222-2222-4222-8222-222222222222",
       prompt: "continue",
@@ -545,10 +538,7 @@ describe("runner resume session contract", () => {
       agentComposeVersionId: null,
       vars: null,
       experimentalProfile: "vm0/default",
-      historyGenerationAffinityProtectedUntil: null,
     });
-    expect(job.historyGenerationAffinityProtectedUntil).toBeNull();
-    expect(job.sessionAffinityResource).toBeUndefined();
     expect(job.runnerPreference).toBeUndefined();
   });
 
@@ -1029,19 +1019,6 @@ describe("runner claim request contract", () => {
     });
 
     expect(result.success).toBe(true);
-  });
-
-  it("accepts and strips previous runner telemetry", () => {
-    const body = runnersJobClaimContract.claim.body.parse({
-      telemetry: {
-        sessionAffinityResource: "workspaceCache",
-        sessionAffinityLocalResource: "workspaceCache",
-        localAdmissionResource: "fresh",
-        sessionHistoryGenerationRelationship: "fresh",
-      },
-    });
-
-    expect(body.telemetry).toEqual({});
   });
 
   it("discards malformed diagnostic telemetry", () => {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -83,11 +83,6 @@ export const runnerClaimPollReasonSchema = z.enum([
   "fast",
 ]);
 
-export const sessionAffinityResourceSchema = z.enum([
-  "reusableSandbox",
-  "workspaceCache",
-]);
-
 const runnerHeartbeatGenerationSchema = z
   .number()
   .int()
@@ -299,17 +294,6 @@ export const jobSchema = z.object({
   cliAgentSessionId: z.string().nullable().optional(),
   reuseKey: z.string().nullable().optional(),
   historyGenerationRunId: z.uuid().optional(),
-  historyGenerationAffinityProtectedUntil: z
-    .string()
-    .datetime({ offset: true })
-    .nullable()
-    .optional(),
-  affinityProtectedUntil: z
-    .string()
-    .datetime({ offset: true })
-    .nullable()
-    .optional(),
-  sessionAffinityResource: sessionAffinityResourceSchema.optional(),
   runnerPreference: runnerPreferenceSchema.optional(),
 });
 
@@ -925,7 +909,4 @@ export type SessionHistoryDownloadSource = z.infer<
 >;
 export type SessionHistorySizeBucket = z.infer<
   typeof sessionHistorySizeBucketSchema
->;
-export type SessionAffinityResource = z.infer<
-  typeof sessionAffinityResourceSchema
 >;


### PR DESCRIPTION
## Summary

- resolve one canonical runner preference from a single ranked live-state query: advertised exact history, the still-live finalizing source process, generic reusable sandbox, then compatible workspace cache
- give the finalizing predecessor an immutable `completedAt + 1,500 ms` deadline and mirror the same ordering in Poll selection
- require exact process identity for official runner claims while preserving identity-free non-official claims
- remove the temporary affinity fields and legacy telemetry dimensions from Poll, Ably, contracts, fixtures, and API tests

## Deployment compatibility

- no database migration or persisted JSON schema change
- runner v0.153.1 is already deployed and understands every canonical `runnerPreference` reason while sending claim identity
- runner-local profile support, resource proof, reserve-before-claim, and claim CAS remain authoritative
- direct sandbox/workspace transfer, persisted predecessor state, and production benefit validation are intentionally excluded

## Validation

- `cd turbo && pnpm -F @vm0/db db:migrate`
- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @vm0/api-contracts lint`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F @vm0/api-contracts check-types`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm knip`
- `cd turbo && pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts --silent=passed-only`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts --maxWorkers=1 --silent=passed-only`
- `cd crates && cargo fmt --manifest-path Cargo.toml --all --check`
- `cd crates && cargo clippy --manifest-path Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cd crates && cargo doc --manifest-path Cargo.toml -p runner --no-deps`
- `cd crates && cargo test --manifest-path Cargo.toml -p runner provider::api::tests::discover_returns_http_poll_job_after_wakeup`
- pre-commit hooks, including repository-wide Turbo type checks and staged Rust checks

Refs #24560

Parent context: #24355
