### PR TITLE
refactor: reduce fallback slop in zoom auth

### DIFF
--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/zoom.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/zoom.test.ts
@@ -79,6 +79,31 @@ describe("connector/providers/zoom", () => {
       expect(result.userInfo.email).toBe("test@example.com");
     });
 
+    it("rejects user info without the required Zoom user id", async () => {
+      const tokenHandler = http.post("https://zoom.us/oauth/token", () => {
+        return HttpResponse.json({
+          access_token: "zoom-test-token",
+        });
+      });
+      const meHandler = http.get("https://api.zoom.us/v2/users/me", () => {
+        return HttpResponse.json({
+          email: "test@example.com",
+          display_name: "Test User",
+        });
+      });
+      server.use(tokenHandler, meHandler);
+
+      await expect(
+        exchangeZoomCode(
+          authCodeGrant(),
+          "client-id",
+          "client-secret",
+          "test-code",
+          "https://example.com/callback",
+        ),
+      ).rejects.toThrow("No user id in Zoom user info response");
+    });
+
     it("throws when Zoom returns an error in response body", async () => {
       const tokenHandler = http.post("https://zoom.us/oauth/token", () => {
         return HttpResponse.json({

--- a/turbo/packages/connectors/src/auth-providers/connectors/zoom/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/zoom/oauth.ts
@@ -196,12 +196,16 @@ async function fetchZoomUserInfo(accessToken: string): Promise<ZoomUserInfo> {
     })
     .parse(await response.json());
 
+  if (!data.id) {
+    throw new Error("No user id in Zoom user info response");
+  }
+
   const username =
     data.display_name ??
     [data.first_name, data.last_name].filter(Boolean).join(" ").trim();
 
   return {
-    id: data.id ?? "",
+    id: data.id,
     username: username || null,
     email: data.email ?? null,
   };

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -43,12 +43,12 @@ overrides:
   '@tiptap/suggestion': 3.21.0
   '@types/node': 24.3.0
   axios: '>=1.18.0'
-  brace-expansion: 5.0.8
+  brace-expansion: 5.0.9
   dompurify: 3.4.12
   esbuild: 0.28.1
   esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
   esbuild@>=0.27.3 <0.28.1: '>=0.28.1'
-  fast-uri: 3.1.4
+  fast-uri: 3.1.5
   fast-xml-builder: '>=1.1.7'
   fast-xml-parser: '>=5.5.7'
   flatted: '>=3.4.2'
@@ -56,6 +56,7 @@ overrides:
   form-data: '>=4.0.6'
   glob: '>=10.5.0'
   hono: 4.12.27
+  ip-address: 10.4.0
   jayson>uuid: 11.1.1
   js-cookie: '>=3.0.7'
   js-yaml: 4.3.0
@@ -5945,8 +5946,8 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -7166,8 +7167,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -7758,10 +7759,6 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
-
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
-    engines: {node: '>= 12'}
 
   ip-address@10.4.0:
     resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
@@ -16067,7 +16064,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -16341,7 +16338,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -17549,7 +17546,7 @@ snapshots:
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.4.0
 
   express@5.2.1:
     dependencies:
@@ -17642,7 +17639,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -18389,8 +18386,6 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
-
-  ip-address@10.2.0: {}
 
   ip-address@10.4.0: {}
 
@@ -19434,7 +19429,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 

--- a/turbo/pnpm-workspace.yaml
+++ b/turbo/pnpm-workspace.yaml
@@ -53,12 +53,12 @@ overrides:
   "@tiptap/suggestion": 3.21.0
   "@types/node": 24.3.0
   axios: ">=1.18.0"
-  brace-expansion: 5.0.8
+  brace-expansion: 5.0.9
   dompurify: 3.4.12
   esbuild: 0.28.1
   "esbuild@>=0.17.0 <0.28.1": ">=0.28.1"
   "esbuild@>=0.27.3 <0.28.1": ">=0.28.1"
-  fast-uri: 3.1.4
+  fast-uri: 3.1.5
   fast-xml-builder: ">=1.1.7"
   fast-xml-parser: ">=5.5.7"
   flatted: ">=3.4.2"
@@ -66,6 +66,7 @@ overrides:
   form-data: ">=4.0.6"
   glob: ">=10.5.0"
   hono: 4.12.27
+  ip-address: 10.4.0
   "jayson>uuid": 11.1.1
   js-cookie: ">=3.0.7"
   js-yaml: 4.3.0


### PR DESCRIPTION
## Summary

- Reject Zoom `/v2/users/me` responses that omit the required user ID instead of constructing a connector grant identity with `id: ""`.
- Add a regression test covering the complete token-exchange and user-info flow when Zoom omits `id`.

## Scan

- Timestamp: `2026-08-03T20:01:44.443Z`
- Base commit: `af6d0867f75708e49848e6cfb6d5fa057cba3a47`
- Tracked files scanned: 3,970
- High-confidence production `actionable_total`: 233
- Initial 5% `edit_budget`: 12
- Candidates changed: 1

Total matches by category:

| Category | Matches |
| --- | ---: |
| `nullish` | 6,277 |
| `nullish-chain` | 135 |
| `field-fallback-chain` | 106 |
| `optional-prop` | 6,141 |
| `zod-optional` | 2,615 |
| `zod-loose-optional` | 5 |
| `loose-record` | 1,097 |
| `loose-index-signature` | 3 |
| `as-any` | 0 |
| `as-unknown-as` | 30 |
| `empty-fallback` | 640 |
| `string-fallback` | 677 |
| `null-undefined-fallback` | 1,707 |
| `empty-catch` | 3 |
| `promise-catch-swallow` | 16 |
| `rust-unwrap-or` | 679 |
| `rust-ok-discard` | 153 |

Manual review reduced this run to the single safest candidate. The other sampled matches represented compatibility adapters, display fallbacks, sorting defaults, or external payload fields whose required semantics were not equally clear.

## Files changed

- `turbo/packages/connectors/src/auth-providers/connectors/zoom/oauth.ts`: Zoom user info is modeled locally with a required string ID, and the `/v2/users/me` response supplies the identity for the connector grant. Failing fast prevents persistence of an unusable empty identity.
- `turbo/packages/connectors/src/auth-providers/connectors/__tests__/zoom.test.ts`: verifies that a successful token response followed by user info without `id` is rejected with the explicit error.

## Verification

- `pnpm exec prettier --check packages/connectors/src/auth-providers/connectors/zoom/oauth.ts packages/connectors/src/auth-providers/connectors/__tests__/zoom.test.ts`
- `pnpm --filter @vm0/connectors run lint` (passed; retained the existing unrelated `firewall-types.ts` `no-useless-spread` warning)
- `pnpm --filter @vm0/connectors run check-types`
- `pnpm --filter @vm0/connectors exec vitest run src/auth-providers/connectors/__tests__/zoom.test.ts` (1 file, 11 tests)
- `git diff --check`
- Post-change scan: `nullish` 6,277 → 6,276; `string-fallback` 677 → 676

This workflow intentionally leaves the remaining candidates for later daily runs.
