### PR TITLE
feat: name new workspaces after their creator

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -493,6 +493,8 @@
       "workspaceSwitcher": {
         "create": "Arbeitsbereich erstellen",
         "creating": "Wird erstellt…",
+        "defaultName": "Arbeitsbereich von {{name}}",
+        "defaultNameFallback": "Mein Arbeitsbereich",
         "join": "Beitreten",
         "joining": "Beitritt läuft…",
         "organizationFallback": "Organisation",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -493,6 +493,8 @@
       "workspaceSwitcher": {
         "create": "Create workspace",
         "creating": "Creating…",
+        "defaultName": "{{name}}'s Workspace",
+        "defaultNameFallback": "My Workspace",
         "join": "Join",
         "joining": "Joining…",
         "organizationFallback": "Organization",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -507,6 +507,8 @@
       "workspaceSwitcher": {
         "create": "Crear espacio de trabajo",
         "creating": "Creando…",
+        "defaultName": "Espacio de trabajo de {{name}}",
+        "defaultNameFallback": "Mi espacio de trabajo",
         "join": "Unirse",
         "joining": "Uniéndose...",
         "organizationFallback": "Organización",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -507,6 +507,8 @@
       "workspaceSwitcher": {
         "create": "Créer un espace de travail",
         "creating": "Création…",
+        "defaultName": "Espace de travail de {{name}}",
+        "defaultNameFallback": "Mon espace de travail",
         "join": "Rejoindre",
         "joining": "Rejoindre…",
         "organizationFallback": "Organisation",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -493,6 +493,8 @@
       "workspaceSwitcher": {
         "create": "वर्कस्पेस बनाएं",
         "creating": "बनाया जा रहा है...",
+        "defaultName": "{{name}} का वर्कस्पेस",
+        "defaultNameFallback": "मेरा वर्कस्पेस",
         "join": "जोड़ना",
         "joining": "शामिल हो रहे हैं...",
         "organizationFallback": "संगठन",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -493,6 +493,8 @@
       "workspaceSwitcher": {
         "create": "Buat ruang kerja",
         "creating": "Membuat…",
+        "defaultName": "Ruang kerja {{name}}",
+        "defaultNameFallback": "Ruang kerja saya",
         "join": "Gabung",
         "joining": "Bergabung…",
         "organizationFallback": "Organisasi",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -507,6 +507,8 @@
       "workspaceSwitcher": {
         "create": "Crea area di lavoro",
         "creating": "Creazione…",
+        "defaultName": "Area di lavoro di {{name}}",
+        "defaultNameFallback": "La mia area di lavoro",
         "join": "Partecipa",
         "joining": "Partecipazione…",
         "organizationFallback": "Organizzazione",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -493,6 +493,8 @@
       "workspaceSwitcher": {
         "create": "ワークスペースの作成",
         "creating": "作成中…",
+        "defaultName": "{{name}}のワークスペース",
+        "defaultNameFallback": "マイワークスペース",
         "join": "参加する",
         "joining": "参加中…",
         "organizationFallback": "組織",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -493,6 +493,8 @@
       "workspaceSwitcher": {
         "create": "워크스페이스 만들기",
         "creating": "만드는 중…",
+        "defaultName": "{{name}}의 워크스페이스",
+        "defaultNameFallback": "내 워크스페이스",
         "join": "참여",
         "joining": "참여 중…",
         "organizationFallback": "조직",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -507,6 +507,8 @@
       "workspaceSwitcher": {
         "create": "Criar espaço de trabalho",
         "creating": "Criando…",
+        "defaultName": "Espaço de trabalho de {{name}}",
+        "defaultNameFallback": "Meu espaço de trabalho",
         "join": "Entrar",
         "joining": "Entrando…",
         "organizationFallback": "Organização",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
@@ -159,6 +159,7 @@ describe("zero org switcher", () => {
       user: {
         id: "test-user-123",
         fullName: "Alex Rivera",
+        firstName: "Alex",
         email: "alex.rivera@example.test",
         createOrganizationEnabled: true,
       },
@@ -199,8 +200,8 @@ describe("zero org switcher", () => {
 
     await waitFor(() => {
       expect(mockedClerk.createOrganization).toHaveBeenCalledWith({
-        name: expect.stringMatching(/^workspace-/u),
-        slug: expect.stringMatching(/^workspace-/u),
+        name: "Alex's Workspace",
+        slug: expect.stringMatching(/^alex-[0-9a-f]{8}$/u),
       });
       expect(mockedClerk.setActive).toHaveBeenCalledWith({
         organization: "new-org-id",

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -125,6 +125,45 @@ function InvitationRow({
   );
 }
 
+/**
+ * The name a new workspace is titled after: the creator's first name, else
+ * their full name, else the local part of their email. `null` when Clerk
+ * exposes none of them, in which case the workspace gets a generic name.
+ */
+function workspaceOwnerName(user: {
+  firstName?: string | null;
+  fullName?: string | null;
+  primaryEmailAddress?: { emailAddress: string } | null;
+}): string | null {
+  const firstName = user.firstName?.trim();
+  if (firstName) {
+    return firstName;
+  }
+  const fullName = user.fullName?.trim();
+  if (fullName) {
+    return fullName;
+  }
+  const emailLocalPart = user.primaryEmailAddress?.emailAddress
+    .split("@")[0]
+    ?.trim();
+  return emailLocalPart || null;
+}
+
+/**
+ * Clerk slugs allow lowercase alphanumerics and hyphens only, so scripts it
+ * cannot represent (CJK, for example) collapse to an empty prefix and fall
+ * back to "workspace". The random suffix keeps the slug unique.
+ */
+function workspaceSlug(ownerName: string | null): string {
+  const prefix = (ownerName ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    .slice(0, 24)
+    .replace(/-+$/gu, "");
+  return `${prefix || "workspace"}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
 function CreateWorkspaceItem() {
   const clerkLoadable = useLastLoadable(clerk$);
   const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
@@ -137,10 +176,22 @@ function CreateWorkspaceItem() {
       return;
     }
     setCreating(true);
-    const slug = `workspace-${crypto.randomUUID().slice(0, 8)}`;
+    const ownerName = clerk.user ? workspaceOwnerName(clerk.user) : null;
+    const name =
+      ownerName === null
+        ? t(($) => {
+            return $.appShell.sidebar.workspaceSwitcher.defaultNameFallback;
+          })
+        : t(
+            ($) => {
+              return $.appShell.sidebar.workspaceSwitcher.defaultName;
+            },
+            { name: ownerName },
+          );
+    const slug = workspaceSlug(ownerName);
     await bestEffort(
       (async () => {
-        const org = await clerk.createOrganization({ name: slug, slug });
+        const org = await clerk.createOrganization({ name, slug });
         await clerk.setActive({ organization: org.id });
       })(),
     );


### PR DESCRIPTION
## Problem

Workspaces created from the org switcher were named `workspace-<8 random hex>` — the name and the slug were the same random string, so the sidebar, the switcher menu and the switcher header all showed an unreadable label.


## Change

Name the workspace after its creator instead:

| source (first available) | example name | example slug |
| --- | --- | --- |
| `user.firstName` | `Molly's Workspace` | `molly-59044cb8` |
| `user.fullName` | `Alex Rivera's Workspace` | `alex-rivera-59044cb8` |
| email local part | `ming's Workspace` | `ming-59044cb8` |
| none of the above | `My Workspace` | `workspace-59044cb8` |

- The name is localized in all 10 locales (`{{name}}'s Workspace` / `My Workspace`), so a Japanese user gets `Molly のワークスペース`.
- The slug keeps a random 8-hex suffix, so uniqueness is unchanged and no retry-on-conflict handling is needed. Names that cannot be slugified (CJK, for example) fall back to the `workspace-` prefix, matching today's behaviour.

## Scope note

This only covers workspaces created from the in-app **Create workspace** button. The workspace a user gets at sign-up is created by Clerk's auto-create-organization and is already named `<Name>'s organization` (or `My Organization` when Clerk has no first name) — changing that is a separate Clerk-side decision.

## Test

- `zero-org-switcher.test.tsx` now asserts the creator-derived name and slug.
- `pnpm -F @vm0/app run lint`, `check-types`, and the org-switcher test suite pass locally; `pnpm knip` output is unchanged from `main`.
