### PR TITLE
docs(python): clarify binding refresh trust contract

### DIFF
--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -75,6 +75,17 @@ def _connected_verified_tls_destination_endpoint(
     port: int,
     extra_endpoints: tuple[tuple[str, int] | None, ...] = (),
 ) -> tuple[str, int] | None:
+    """Return verified live endpoint evidence for the exact TLS destination.
+
+    After the caller establishes that ``server`` remains connected, a non-``None`` result supplies
+    the remaining evidence for the ``connected_address`` trust precondition of
+    ``upstream_destination_binding.refresh_server_binding_connected_address_if_matching()``. The
+    upstream TLS connection is verified for normalized SNI ``host``, carries certificate evidence
+    without a connection error, and has authoritative connected endpoint evidence for ``port``.
+
+    The fail-closed ``without_verified_tls`` and positive ``after_retargeting`` integration cases
+    in ``tests/test_request_handler_connector_admission.py`` exercise this contract.
+    """
     if bool(getattr(getattr(ctx, "options", object()), "ssl_insecure", False)):
         return None
     if not bool(getattr(server, "tls_established", False)):

--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -230,7 +230,25 @@ def refresh_server_binding_connected_address_if_matching(
     kind: BindingKind,
     connected_address: tuple[str, int],
 ) -> bool:
-    """Replace original_address with a verified connected endpoint if safe."""
+    """Refresh a matching binding from a caller-verified live endpoint.
+
+    ``connected_address`` is a caller-owned trust precondition. Before invoking this helper, the
+    caller must prove through verified upstream TLS and authoritative live-connection evidence that
+    it is the current endpoint for the exact normalized ``destination.host`` and
+    ``destination.port``. The production caller first confirms that the server remains connected,
+    then obtains the TLS identity and exact-port endpoint evidence from
+    ``upstream_admission._connected_verified_tls_destination_endpoint()``.
+
+    This helper only matches the stored binding authority and screens ``connected_address`` with
+    ``connection_endpoints.authoritative_connected_endpoint()``. It does not establish that the
+    server is connected, that TLS authenticated the destination, that the destination owns or
+    authorizes the endpoint, that the endpoint is publicly routable, or that its port corresponds
+    to ``destination.port``. Success replaces ``original_address`` and adds ``kind``, so callers
+    must complete every trust check before invocation.
+
+    The fail-closed ``without_verified_tls`` and positive ``after_retargeting`` integration cases
+    in ``tests/test_request_handler_connector_admission.py`` cover this handoff.
+    """
     server_id = _connection_id(server)
     if server_id is None:
         return False


### PR DESCRIPTION
## Summary

- document that binding refresh requires caller-verified live connection, TLS identity, and exact-port endpoint evidence
- pair the mutation contract with the proof-producing upstream admission helper and focused integration coverage
- keep runtime behavior, signatures, exported names, and deployment contracts unchanged

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_request_handler_connector_admission.py` (27 passed)
- `uv run --no-sync python -m pytest tests/` (4690 passed)

Closes #24819
