### PR TITLE
test(sandbox-fc): pin leak cleaner cow workspace safety

### DIFF
--- a/crates/sandbox-fc/src/factory/leak_cleaner.rs
+++ b/crates/sandbox-fc/src/factory/leak_cleaner.rs
@@ -244,18 +244,17 @@ mod tests {
         }
     }
 
-    async fn cleanup_paths_after_cow_outcome(
-        cow_cleanup_outcome: CowCleanupOutcome,
+    async fn leaked_resource_with_paths(
         delete_workspace: bool,
-    ) -> tempfile::TempDir {
+    ) -> (tempfile::TempDir, LeakedResources) {
         let tmp = tempfile::tempdir().unwrap();
         let sock_dir = tmp.path().join("sock");
         let workspace = tmp.path().join("workspace");
         tokio::fs::create_dir_all(&sock_dir).await.unwrap();
         tokio::fs::create_dir_all(&workspace).await.unwrap();
-        let netns_pool = NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test());
 
-        cleanup_leaked_resource_after_cow_cleanup(
+        (
+            tmp,
             LeakedResources {
                 sandbox_id: "sandbox".into(),
                 cow_device: None,
@@ -264,19 +263,15 @@ mod tests {
                 workspace,
                 delete_workspace,
             },
-            &netns_pool,
-            cow_cleanup_outcome,
         )
-        .await;
-
-        tmp
     }
 
     #[tokio::test]
     async fn safe_cow_cleanup_deletes_workspace() {
-        let tmp =
-            cleanup_paths_after_cow_outcome(CowCleanupOutcome::BackingFilesSafeToDelete, true)
-                .await;
+        let (tmp, leaked) = leaked_resource_with_paths(true).await;
+        let netns_pool = NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test());
+
+        cleanup_leaked_resource(leaked, &netns_pool).await;
 
         assert!(!tmp.path().join("sock").exists());
         assert!(!tmp.path().join("workspace").exists());
@@ -284,9 +279,13 @@ mod tests {
 
     #[tokio::test]
     async fn unsafe_cow_cleanup_preserves_workspace() {
-        let tmp = cleanup_paths_after_cow_outcome(
+        let (tmp, leaked) = leaked_resource_with_paths(true).await;
+        let netns_pool = NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test());
+
+        cleanup_leaked_resource_after_cow_cleanup(
+            leaked,
+            &netns_pool,
             CowCleanupOutcome::DeviceMayStillReferenceBackingFiles,
-            true,
         )
         .await;
 
@@ -296,9 +295,15 @@ mod tests {
 
     #[tokio::test]
     async fn disabled_workspace_deletion_preserves_workspace_after_safe_cow_cleanup() {
-        let tmp =
-            cleanup_paths_after_cow_outcome(CowCleanupOutcome::BackingFilesSafeToDelete, false)
-                .await;
+        let (tmp, leaked) = leaked_resource_with_paths(false).await;
+        let netns_pool = NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test());
+
+        cleanup_leaked_resource_after_cow_cleanup(
+            leaked,
+            &netns_pool,
+            CowCleanupOutcome::BackingFilesSafeToDelete,
+        )
+        .await;
 
         assert!(!tmp.path().join("sock").exists());
         assert!(tmp.path().join("workspace").exists());

--- a/crates/sandbox-fc/src/factory/leak_cleaner.rs
+++ b/crates/sandbox-fc/src/factory/leak_cleaner.rs
@@ -185,12 +185,20 @@ async fn wait_for_leak_cleaner_shutdown(
     shutdown
 }
 
-async fn cleanup_leaked_resource(leaked: LeakedResources, netns_pool: &NetnsPoolHandle) {
-    let cow_cleanup_outcome = match leaked.cow_device {
+async fn cleanup_leaked_resource(mut leaked: LeakedResources, netns_pool: &NetnsPoolHandle) {
+    let cow_cleanup_outcome = match leaked.cow_device.take() {
         Some(cow_device) => destroy_cow_device_with_retries(&leaked.sandbox_id, cow_device).await,
         None => CowCleanupOutcome::BackingFilesSafeToDelete,
     };
 
+    cleanup_leaked_resource_after_cow_cleanup(leaked, netns_pool, cow_cleanup_outcome).await;
+}
+
+async fn cleanup_leaked_resource_after_cow_cleanup(
+    leaked: LeakedResources,
+    netns_pool: &NetnsPoolHandle,
+    cow_cleanup_outcome: CowCleanupOutcome,
+) {
     if let Some(network) = leaked.network {
         let mut network = Some(network);
         let outcome = netns_pool.release(&mut network).await;
@@ -236,8 +244,10 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn cleanup_leaked_resource_respects_workspace_preservation() {
+    async fn cleanup_paths_after_cow_outcome(
+        cow_cleanup_outcome: CowCleanupOutcome,
+        delete_workspace: bool,
+    ) -> tempfile::TempDir {
         let tmp = tempfile::tempdir().unwrap();
         let sock_dir = tmp.path().join("sock");
         let workspace = tmp.path().join("workspace");
@@ -245,21 +255,53 @@ mod tests {
         tokio::fs::create_dir_all(&workspace).await.unwrap();
         let netns_pool = NetnsPoolHandle::new_for_test(NetnsPool::inactive_for_test());
 
-        cleanup_leaked_resource(
+        cleanup_leaked_resource_after_cow_cleanup(
             LeakedResources {
                 sandbox_id: "sandbox".into(),
                 cow_device: None,
                 network: None,
-                sock_dir: sock_dir.clone(),
-                workspace: workspace.clone(),
-                delete_workspace: false,
+                sock_dir,
+                workspace,
+                delete_workspace,
             },
             &netns_pool,
+            cow_cleanup_outcome,
         )
         .await;
 
-        assert!(!sock_dir.exists());
-        assert!(workspace.exists());
+        tmp
+    }
+
+    #[tokio::test]
+    async fn safe_cow_cleanup_deletes_workspace() {
+        let tmp =
+            cleanup_paths_after_cow_outcome(CowCleanupOutcome::BackingFilesSafeToDelete, true)
+                .await;
+
+        assert!(!tmp.path().join("sock").exists());
+        assert!(!tmp.path().join("workspace").exists());
+    }
+
+    #[tokio::test]
+    async fn unsafe_cow_cleanup_preserves_workspace() {
+        let tmp = cleanup_paths_after_cow_outcome(
+            CowCleanupOutcome::DeviceMayStillReferenceBackingFiles,
+            true,
+        )
+        .await;
+
+        assert!(!tmp.path().join("sock").exists());
+        assert!(tmp.path().join("workspace").exists());
+    }
+
+    #[tokio::test]
+    async fn disabled_workspace_deletion_preserves_workspace_after_safe_cow_cleanup() {
+        let tmp =
+            cleanup_paths_after_cow_outcome(CowCleanupOutcome::BackingFilesSafeToDelete, false)
+                .await;
+
+        assert!(!tmp.path().join("sock").exists());
+        assert!(tmp.path().join("workspace").exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- split the leak cleaner's existing post-COW phase from device teardown so resolved COW safety outcomes can exercise the production filesystem path deterministically
- cover safe/deletable, unsafe/deletable, and safe/preserved workspace behavior with real temporary directories
- verify socket-directory cleanup for every outcome without requiring a privileged NBD device

## Scope

- no COW classification, retry, cleanup ordering, logging, API, protocol, schema, or persisted-data behavior changes

## Validation

- `cargo test -p sandbox-fc factory::leak_cleaner::tests`
- `cargo test -p sandbox-fc`
- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features`
- `cargo doc -p sandbox-fc --all-features --no-deps`
- pre-commit Rust formatting, Clippy, documentation, and file-size checks

Closes #24824
