### PR TITLE
build(deps): upgrade hono to 4.13.0

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -43,7 +43,7 @@
     "drizzle-orm": "^0.45.2",
     "google-auth-library": "^10.9.0",
     "gpt-tokenizer": "^3.4.0",
-    "hono": "^4.12.34",
+    "hono": "^4.13.0",
     "html-to-text": "^10.0.0",
     "music-metadata": "^11.13.0",
     "pg": "^8.20.0",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -55,7 +55,7 @@ overrides:
   follow-redirects: '>=1.16.0'
   form-data: '>=4.0.6'
   glob: '>=10.5.0'
-  hono: 4.12.34
+  hono: 4.13.0
   ip-address: 10.4.0
   jayson>uuid: 11.1.1
   js-cookie: '>=3.0.7'
@@ -139,10 +139,10 @@ importers:
         version: 3.13.1(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
       '@hono/node-server':
         specifier: ^2.0.10
-        version: 2.0.10(hono@4.12.34)
+        version: 2.0.10(hono@4.13.0)
       '@hono/otel':
         specifier: ^1.1.2
-        version: 1.1.2(hono@4.12.34)
+        version: 1.1.2(hono@4.13.0)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -204,8 +204,8 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
       hono:
-        specifier: 4.12.34
-        version: 4.12.34
+        specifier: 4.13.0
+        version: 4.13.0
       html-to-text:
         specifier: ^10.0.0
         version: 10.0.0
@@ -242,10 +242,10 @@ importers:
     devDependencies:
       '@hono/node-server-v1':
         specifier: npm:@hono/node-server@1.19.14
-        version: '@hono/node-server@1.19.14(hono@4.12.34)'
+        version: '@hono/node-server@1.19.14(hono@4.13.0)'
       '@hono/vite-build':
         specifier: ^1.11.1
-        version: 1.11.1(hono@4.12.34)
+        version: 1.11.1(hono@4.13.0)
       '@opentelemetry/context-async-hooks':
         specifier: 2.7.0
         version: 2.7.0(@opentelemetry/api@1.9.1)
@@ -2092,24 +2092,24 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.34
+      hono: 4.13.0
 
   '@hono/node-server@2.0.10':
     resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: 4.12.34
+      hono: 4.13.0
 
   '@hono/otel@1.1.2':
     resolution: {integrity: sha512-UaBMKPGaQTj4sjvpGqQ+57eolTwMI2znzxV/QBUF99XxhcmqtqaZX95flXpGgWb+lnlinlCy23Y1sZ8+TzzM9A==}
     peerDependencies:
-      hono: 4.12.34
+      hono: 4.13.0
 
   '@hono/vite-build@1.11.1':
     resolution: {integrity: sha512-EQJmFL7G+71MXZQ/mmywNl4qW6DSyjTdC30cq7mlDS451a1/jE86old0M2DCWzNGCO50sv7CzQDYkz4L5dq5VQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.34
+      hono: 4.13.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -7585,8 +7585,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.34:
-    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@2.8.9:
@@ -12288,23 +12288,23 @@ snapshots:
     dependencies:
       graphql: 16.13.2
 
-  '@hono/node-server@1.19.14(hono@4.12.34)':
+  '@hono/node-server@1.19.14(hono@4.13.0)':
     dependencies:
-      hono: 4.12.34
+      hono: 4.13.0
 
-  '@hono/node-server@2.0.10(hono@4.12.34)':
+  '@hono/node-server@2.0.10(hono@4.13.0)':
     dependencies:
-      hono: 4.12.34
+      hono: 4.13.0
 
-  '@hono/otel@1.1.2(hono@4.12.34)':
+  '@hono/otel@1.1.2(hono@4.13.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
-      hono: 4.12.34
+      hono: 4.13.0
 
-  '@hono/vite-build@1.11.1(hono@4.12.34)':
+  '@hono/vite-build@1.11.1(hono@4.13.0)':
     dependencies:
-      hono: 4.12.34
+      hono: 4.13.0
 
   '@humanfs/core@0.19.1': {}
 
@@ -12714,7 +12714,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.34)
+      '@hono/node-server': 1.19.14(hono@4.13.0)
       ajv: 8.20.0
       ajv-formats: 3.0.1
       content-type: 1.0.5
@@ -12724,7 +12724,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.34
+      hono: 4.13.0
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -18194,7 +18194,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.34: {}
+  hono@4.13.0: {}
 
   hosted-git-info@2.8.9: {}
 

--- a/turbo/pnpm-workspace.yaml
+++ b/turbo/pnpm-workspace.yaml
@@ -65,7 +65,7 @@ overrides:
   follow-redirects: ">=1.16.0"
   form-data: ">=4.0.6"
   glob: ">=10.5.0"
-  hono: 4.12.34
+  hono: 4.13.0
   ip-address: 10.4.0
   "jayson>uuid": 11.1.1
   js-cookie: ">=3.0.7"


### PR DESCRIPTION
## Summary

- Upgrade Hono from 4.12.34 to 4.13.0 in the API manifest and the workspace override.
- Regenerate the shared pnpm lockfile so Hono and its peer dependents consistently resolve 4.13.0.
- Pick up the Hono 4.13 performance improvements, HTTP QUERY support, method-not-allowed middleware, and maintenance fixes.

## Context

This supersedes Dependabot PR #24831.

The Dependabot PR only updated the leaf package manifest. The workspace override still pinned Hono to 4.12.34, so its proposed diff would not update the resolved package. This PR aligns the override and lockfile so the upgrade takes effect across the workspace.

## Validation

- `corepack pnpm install --lockfile-only`
- `corepack pnpm install --lockfile-only --frozen-lockfile`
- `git diff --check`
- Full test execution is delegated to the PR pipeline per repository policy.

## Supersedes

- #24831
