### PR TITLE
perf(python): rate-limit jsonl append warnings

### DIFF
--- a/crates/runner/mitm-addon/src/jsonl_writer.py
+++ b/crates/runner/mitm-addon/src/jsonl_writer.py
@@ -14,6 +14,7 @@ MAX_PENDING_JSONL_WRITES = 4096
 MAX_PENDING_JSONL_BYTES = 32 * 1024 * 1024
 MAX_JSONL_IOVECS = os.sysconf("SC_IOV_MAX")
 SHUTDOWN_JOIN_TIMEOUT_SECONDS = 1.0
+APPEND_FAILURE_WARNING_INTERVAL_SECONDS = 60.0
 
 
 @dataclass(frozen=True)
@@ -37,6 +38,8 @@ _flush_waiters_by_path: defaultdict[str, int] = defaultdict(int)
 _pending_bytes = 0
 _queued_writes = 0
 _drop_warning_logged = False
+_last_append_failure_at: float | None = None
+_last_append_failure_warning_at: float | None = None
 
 
 def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> None:
@@ -169,6 +172,7 @@ def reset_for_tests() -> None:
     """Reset writer state between tests."""
     global _queue, _worker, _shutdown, _stop_enqueued, _accepted_by_path, _completed_by_path
     global _flush_waiters_by_path, _pending_bytes, _queued_writes, _drop_warning_logged
+    global _last_append_failure_at, _last_append_failure_warning_at
 
     shutdown_writer(timeout=None)
     with _condition:
@@ -182,6 +186,8 @@ def reset_for_tests() -> None:
         _pending_bytes = 0
         _queued_writes = 0
         _drop_warning_logged = False
+        _last_append_failure_at = None
+        _last_append_failure_warning_at = None
         _condition.notify_all()
 
 
@@ -235,14 +241,49 @@ def _write_batch(items: list[object]) -> None:
         if isinstance(item, _WriteItem):
             batches.setdefault(item.log_path, []).append(item)
 
+    append_succeeded = False
+    append_failed = False
     for log_path, path_items in batches.items():
         if not path_items:
             continue
         try:
             _append_lines(log_path, [item.line for item in path_items])
+            append_succeeded = True
         except Exception as exc:
+            append_failed = True
             log_name = path_items[0].log_name
-            _warn(f"Failed to write {log_name} log: {type(exc).__name__}: {exc}")
+            _report_append_failure(log_name, exc)
+
+    if append_succeeded and not append_failed:
+        _report_append_recovery()
+
+
+def _report_append_failure(log_name: str, exc: Exception) -> None:
+    global _last_append_failure_at, _last_append_failure_warning_at
+
+    now = time.monotonic()
+    _last_append_failure_at = now
+    if (
+        _last_append_failure_warning_at is not None
+        and now - _last_append_failure_warning_at < APPEND_FAILURE_WARNING_INTERVAL_SECONDS
+    ):
+        return
+
+    _last_append_failure_warning_at = now
+    _warn(f"Failed to write {log_name} log: {type(exc).__name__}: {exc}")
+
+
+def _report_append_recovery() -> None:
+    global _last_append_failure_at, _last_append_failure_warning_at
+
+    if _last_append_failure_at is None:
+        return
+    if time.monotonic() - _last_append_failure_at < APPEND_FAILURE_WARNING_INTERVAL_SECONDS:
+        return
+
+    _last_append_failure_at = None
+    _last_append_failure_warning_at = None
+    _warn("JSONL log writes recovered")
 
 
 def _append_lines(log_path: str, lines: list[bytes]) -> None:

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -98,6 +98,69 @@ def test_writer_warns_and_retires_batch_when_writev_returns_zero(tmp_path, mitm_
     assert (tmp_path / "network.jsonl").read_bytes() == b""
 
 
+def test_writer_rate_limits_append_failures_until_stable_recovery(tmp_path, mitm_ctx):
+    missing_dir = tmp_path / "missing"
+    failing_path = missing_dir / "network.jsonl"
+    first_failing_path = tmp_path / "missing-0" / "network.jsonl"
+    healthy_path = tmp_path / "healthy.jsonl"
+    now = 0.0
+
+    def monotonic() -> float:
+        return now
+
+    def write_and_flush(path: str, line: bytes) -> None:
+        jsonl_writer.write_jsonl_line(path, line, "network")
+        assert jsonl_writer.flush_log_path(path)
+
+    with (
+        patch.object(jsonl_writer.time, "monotonic", side_effect=monotonic),
+        mitm_ctx() as log,
+    ):
+        for index in range(1000):
+            path = tmp_path / f"missing-{index}" / "network.jsonl"
+            write_and_flush(str(path), b"{}\n")
+
+        assert log.warn.call_count == 1
+
+        now = 59.0
+        write_and_flush(str(healthy_path), b"healthy-before-interval\n")
+        assert log.warn.call_count == 1
+
+        now = 60.0
+        write_and_flush(str(failing_path), b"{}\n")
+        assert log.warn.call_count == 2
+
+        now = 119.0
+        write_and_flush(str(healthy_path), b"healthy-before-recovery\n")
+        assert log.warn.call_count == 2
+
+        missing_dir.mkdir()
+        now = 120.0
+        write_and_flush(str(failing_path), b"recovered\n")
+        assert failing_path.read_bytes() == b"recovered\n"
+        assert log.warn.call_args_list[2].args == ("JSONL log writes recovered",)
+
+        failing_path.unlink()
+        missing_dir.rmdir()
+        write_and_flush(str(failing_path), b"{}\n")
+
+    assert log.warn.call_count == 4
+    for warning_index, expected_path in (
+        (0, first_failing_path),
+        (1, failing_path),
+        (3, failing_path),
+    ):
+        warning = log.warn.call_args_list[warning_index].args[0]
+        assert warning.startswith("Failed to write network log: FileNotFoundError: ")
+        assert str(expected_path) in warning
+    assert healthy_path.read_bytes() == b"healthy-before-interval\nhealthy-before-recovery\n"
+    assert jsonl_writer._pending_bytes == 0
+    assert jsonl_writer._queued_writes == 0
+    assert not jsonl_writer._accepted_by_path
+    assert not jsonl_writer._completed_by_path
+    assert not jsonl_writer._flush_waiters_by_path
+
+
 def test_writer_publishes_backlog_completion_once_per_batch(tmp_path):
     class ObservedCondition:
         def __init__(self) -> None:

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -161,6 +161,72 @@ def test_writer_rate_limits_append_failures_until_stable_recovery(tmp_path, mitm
     assert not jsonl_writer._flush_waiters_by_path
 
 
+def test_writer_does_not_recover_from_mixed_path_batch(tmp_path, mitm_ctx):
+    initial_failure_path = tmp_path / "initial-missing" / "network.jsonl"
+    gate_path = tmp_path / "gate.jsonl"
+    healthy_path = tmp_path / "healthy.jsonl"
+    mixed_failure_path = tmp_path / "mixed-missing" / "network.jsonl"
+    gate_started = threading.Event()
+    release_gate = threading.Event()
+    mixed_batch_started = threading.Event()
+    release_mixed_batch = threading.Event()
+    original_append_lines = jsonl_writer._append_lines
+    now = 0.0
+
+    def monotonic() -> float:
+        return now
+
+    def write_and_flush(path: str, line: bytes) -> None:
+        jsonl_writer.write_jsonl_line(path, line, "network")
+        assert jsonl_writer.flush_log_path(path)
+
+    def append_lines(path: str, lines: list[bytes]) -> None:
+        if path == str(gate_path):
+            gate_started.set()
+            release_gate.wait()
+        elif path == str(healthy_path):
+            mixed_batch_started.set()
+            release_mixed_batch.wait()
+        original_append_lines(path, lines)
+
+    with (
+        patch.object(jsonl_writer.time, "monotonic", side_effect=monotonic),
+        mitm_ctx() as log,
+    ):
+        write_and_flush(str(initial_failure_path), b"{}\n")
+        assert log.warn.call_count == 1
+
+        now = 59.0
+        with patch.object(jsonl_writer, "_append_lines", side_effect=append_lines):
+            try:
+                jsonl_writer.write_jsonl_line(str(gate_path), b"gate\n", "network")
+                assert gate_started.wait(timeout=1)
+
+                jsonl_writer.write_jsonl_line(str(healthy_path), b"healthy\n", "network")
+                jsonl_writer.write_jsonl_line(str(mixed_failure_path), b"{}\n", "network")
+                release_gate.set()
+                assert mixed_batch_started.wait(timeout=1)
+
+                now = 60.0
+                release_mixed_batch.set()
+                assert jsonl_writer.flush_log_path(str(healthy_path))
+                assert jsonl_writer.flush_log_path(str(mixed_failure_path))
+            finally:
+                release_gate.set()
+                release_mixed_batch.set()
+
+        assert gate_path.read_bytes() == b"gate\n"
+        assert healthy_path.read_bytes() == b"healthy\n"
+        assert log.warn.call_count == 2
+        mixed_failure_warning = log.warn.call_args_list[1].args[0]
+        assert mixed_failure_warning.startswith("Failed to write network log: FileNotFoundError: ")
+        assert str(mixed_failure_path) in mixed_failure_warning
+
+        now = 120.0
+        write_and_flush(str(healthy_path), b"recovered\n")
+        assert log.warn.call_args_list[2].args == ("JSONL log writes recovered",)
+
+
 def test_writer_publishes_backlog_completion_once_per_batch(tmp_path):
     class ObservedCondition:
         def __init__(self) -> None:

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -170,7 +170,8 @@ def test_writer_does_not_recover_from_mixed_path_batch(tmp_path, mitm_ctx):
     release_gate = threading.Event()
     mixed_batch_started = threading.Event()
     release_mixed_batch = threading.Event()
-    original_append_lines = jsonl_writer._append_lines
+    original_writev = jsonl_writer.os.writev
+    writev_calls = 0
     now = 0.0
 
     def monotonic() -> float:
@@ -180,14 +181,17 @@ def test_writer_does_not_recover_from_mixed_path_batch(tmp_path, mitm_ctx):
         jsonl_writer.write_jsonl_line(path, line, "network")
         assert jsonl_writer.flush_log_path(path)
 
-    def append_lines(path: str, lines: list[bytes]) -> None:
-        if path == str(gate_path):
+    def writev(fd: int, buffers: list[bytes | memoryview]) -> int:
+        nonlocal writev_calls
+
+        writev_calls += 1
+        if writev_calls == 1:
             gate_started.set()
             release_gate.wait()
-        elif path == str(healthy_path):
+        elif writev_calls == 2:
             mixed_batch_started.set()
             release_mixed_batch.wait()
-        original_append_lines(path, lines)
+        return original_writev(fd, buffers)
 
     with (
         patch.object(jsonl_writer.time, "monotonic", side_effect=monotonic),
@@ -197,7 +201,7 @@ def test_writer_does_not_recover_from_mixed_path_batch(tmp_path, mitm_ctx):
         assert log.warn.call_count == 1
 
         now = 59.0
-        with patch.object(jsonl_writer, "_append_lines", side_effect=append_lines):
+        with patch.object(jsonl_writer.os, "writev", side_effect=writev):
             try:
                 jsonl_writer.write_jsonl_line(str(gate_path), b"gate\n", "network")
                 assert gate_started.wait(timeout=1)


### PR DESCRIPTION
## Summary

- cap JSONL append-failure diagnostics at the first warning plus one per 60-second monotonic interval
- report recovery only after a nonempty all-success batch follows a full failure-free interval, then re-arm immediate reporting
- cover 1,000 separately drained real-filesystem failures across distinct paths, mixed success/failure batches, periodic reporting, stable recovery, and post-recovery failure

## Scope

- preserves failed-write retirement, queue admission, flush, shutdown, and JSONL output behavior
- no API, schema, migration, dependency, persisted format, runner protocol, feature switch, or rollout change

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_jsonl_writer.py -q` (12 passed)
- `uv run --no-sync python -m pytest tests/ -q` (4692 passed)
- `lefthook run pre-commit`

Closes #24820
