### PR TITLE
test(runner): enforce mitmproxy version contract

### DIFF
--- a/crates/runner/mitm-addon/src/mitmproxy_compat.py
+++ b/crates/runner/mitm-addon/src/mitmproxy_compat.py
@@ -9,9 +9,10 @@ from mitmproxy.proxy.layers.http._hooks import HttpRequestHeadersHook
 
 import websocket_framing
 
-# Keep this synchronized with ``crates/runner/src/deps.rs`` and the Python
-# test dependencies. Re-audit the private imports, generators, and WebSocket
-# extension behavior before accepting another version.
+# The contract test in ``crates/runner/src/deps.rs`` enforces alignment with
+# the runner artifact and Python test dependency. Re-audit the private
+# imports, generators, and WebSocket extension behavior before accepting
+# another version.
 _SUPPORTED_MITMPROXY_VERSION = "12.2.3"
 _SUPPORTED_WSPROTO_VERSION = "1.3.2"
 _BRIDGE_MARKER_ATTRIBUTE = "_vm0_request_end_stream_bridge"

--- a/crates/runner/src/deps.rs
+++ b/crates/runner/src/deps.rs
@@ -2,6 +2,7 @@
 
 pub const FIRECRACKER_VERSION: &str = "v1.15.1";
 pub const KERNEL_VERSION: &str = "6.1.155";
+/// Canonical mitmproxy release for runner artifacts and the embedded add-on.
 pub const MITMPROXY_VERSION: &str = "12.2.3";
 
 // Exact identities for installed artifacts, keyed by arch.
@@ -91,6 +92,16 @@ pub fn mitmdump_url(arch: &str) -> String {
 mod tests {
     use super::*;
 
+    const MITMPROXY_COMPAT_SOURCE: &str = include_str!("../mitm-addon/src/mitmproxy_compat.py");
+    const MITM_ADDON_PYPROJECT: &str = include_str!("../mitm-addon/pyproject.toml");
+
+    fn quoted_values<'a>(source: &'a str, prefix: &str, suffix: &str) -> Vec<&'a str> {
+        source
+            .lines()
+            .filter_map(|line| line.strip_prefix(prefix)?.strip_suffix(suffix))
+            .collect()
+    }
+
     #[test]
     fn strip_patch_version() {
         assert_eq!(FIRECRACKER_MINOR, "v1.15");
@@ -128,5 +139,26 @@ mod tests {
                 "SHA256 should be valid hex: {sha}"
             );
         }
+    }
+
+    #[test]
+    fn mitmproxy_version_contract_matches_python_runtime_and_tests() {
+        let runtime_versions = quoted_values(
+            MITMPROXY_COMPAT_SOURCE,
+            "_SUPPORTED_MITMPROXY_VERSION = \"",
+            "\"",
+        );
+        assert_eq!(
+            runtime_versions.as_slice(),
+            &[MITMPROXY_VERSION],
+            "mitmproxy runtime guard must contain exactly one version matching MITMPROXY_VERSION"
+        );
+
+        let test_versions = quoted_values(MITM_ADDON_PYPROJECT, "    \"mitmproxy==", "\",");
+        assert_eq!(
+            test_versions.as_slice(),
+            &[MITMPROXY_VERSION],
+            "mitmproxy test dependencies must contain exactly one version matching MITMPROXY_VERSION"
+        );
     }
 }

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -93,9 +93,15 @@ one package and the portion of the graph it constrains, use
 with `git diff -- uv.lock`, then run all static checks and the complete test
 suite.
 
-Commit `pyproject.toml` and `uv.lock` together. Keep the mitmproxy constraint
-aligned with the standalone runtime version in `crates/runner/src/deps.rs`;
-tests must not resolve a different mitmproxy version from production.
+Commit `pyproject.toml` and `uv.lock` together. The contract test in
+`crates/runner/src/deps.rs` requires the mitmproxy constraint and add-on runtime
+guard to match the canonical standalone runtime version.
+
+Before changing that version, re-audit the private mitmproxy APIs used by the
+compatibility layer. Update the canonical Rust version together with the
+x86_64 and aarch64 installed/archive sizes and checksums, then update the Python
+constraint and lockfile. Run both the runner and complete add-on validation
+suites before committing the upgrade.
 
 ## Test Files
 


### PR DESCRIPTION
## Summary

- make the runner's `MITMPROXY_VERSION` the explicit canonical release contract
- add an executable contract test that keeps the Python runtime guard and test dependency pin aligned
- document the complete mitmproxy upgrade and private-API re-audit workflow

## Scope

- test and documentation changes only; runtime artifact selection and add-on behavior are unchanged
- no API, protocol, schema, persisted-data, or deployment compatibility changes
- `uv.lock` consistency remains enforced by `uv lock --check`

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-features`
- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/`
- verified the focused contract test fails independently when the Rust version, Python runtime guard, or Python dependency pin drifts

Closes #24822
