### PR TITLE
refactor(runner): rename affinity internals to reuse terminology

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -288,7 +288,7 @@ impl WorkspaceCacheStateSnapshot {
     /// Before the first load, absence has not been established, so every
     /// reuse key might be present. Once loaded, this becomes a membership check
     /// against the stored states. Discovery uses a possible match to request an
-    /// immediate affinity heartbeat after claiming the key.
+    /// immediate reuse-state heartbeat after claiming the key.
     pub(super) fn might_contain_workspace_cache_reuse_key(&self, reuse_key: &str) -> bool {
         let inner = self.lock_inner();
         !inner.workspace_cache_loaded

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -154,7 +154,7 @@ impl CompletionPayload {
 pub(super) struct CompletionReady {
     payload: CompletionPayload,
     budget: BudgetOwnership,
-    session_affinity_changed: bool,
+    reuse_state_changed: bool,
 }
 
 impl CompletionReady {
@@ -162,17 +162,17 @@ impl CompletionReady {
         Self {
             payload,
             budget,
-            session_affinity_changed: false,
+            reuse_state_changed: false,
         }
     }
 
-    pub(super) fn with_session_affinity_changed(mut self) -> Self {
-        self.session_affinity_changed = true;
+    pub(super) fn with_reuse_state_changed(mut self) -> Self {
+        self.reuse_state_changed = true;
         self
     }
 
-    pub(super) fn session_affinity_changed(&self) -> bool {
-        self.session_affinity_changed
+    pub(super) fn reuse_state_changed(&self) -> bool {
+        self.reuse_state_changed
     }
 
     #[cfg(test)]

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -69,7 +69,7 @@ pub(super) struct SpawnContext {
     /// spawn-time mode snapshot.
     pub(super) parking_gate: ParkingGate,
     /// Notifies the main loop to send an immediate heartbeat after reusable
-    /// affinity state changes. This eliminates the up-to-10s blind spot where
+    /// state changes. This eliminates the up-to-10s blind spot where
     /// the server does not know which runner holds a reusable sandbox or
     /// workspace image cache.
     pub(super) reuse_state_notify: Arc<tokio::sync::Notify>,
@@ -355,14 +355,12 @@ impl FinalizationPhase {
         .await;
         let finalization_duration = finalization_started.elapsed();
         let disposition = cleanup_state_after_finalize.disposition();
-        let session_affinity_changed = completion_ready.session_affinity_changed();
+        let reuse_state_changed = completion_ready.reuse_state_changed();
         let (finalization_action, finalization_success, finalization_error) = match disposition {
             RunCleanupDisposition::IdlePoolOwned => {
                 ("runner_host_finalization_reusable_sandbox", true, None)
             }
-            _ if session_affinity_changed => {
-                ("runner_host_finalization_workspace_cache", true, None)
-            }
+            _ if reuse_state_changed => ("runner_host_finalization_workspace_cache", true, None),
             RunCleanupDisposition::DestroyCompleted | RunCleanupDisposition::StatusRemoved => {
                 ("runner_host_finalization_no_resource", true, None)
             }
@@ -435,7 +433,7 @@ impl CompletionPhase {
         // Structural guarantee: claim (in provider) is always paired with complete.
         signal_usage_flush(run_id, &usage_flush_tx);
         let ownership = OwnershipTransitions::new(status.as_ref());
-        let session_affinity_changed = completion_ready.session_affinity_changed();
+        let reuse_state_changed = completion_ready.reuse_state_changed();
         let provider_completion_duration = completion_ready
             .complete_and_release(provider.as_ref(), &ownership, &cleanup_state)
             .await;
@@ -453,7 +451,7 @@ impl CompletionPhase {
                 None,
             );
         }
-        if session_affinity_changed {
+        if reuse_state_changed {
             reuse_state_notify.notify_one();
         }
     }

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -48,12 +48,12 @@ fn local_completed_at() -> String {
     chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
 }
 
-fn mark_session_affinity_refresh(
+fn mark_reuse_state_refresh(
     completion_ready: CompletionReady,
-    session_affinity_changed: bool,
+    reuse_state_changed: bool,
 ) -> CompletionReady {
-    if session_affinity_changed {
-        completion_ready.with_session_affinity_changed()
+    if reuse_state_changed {
+        completion_ready.with_reuse_state_changed()
     } else {
         completion_ready
     }
@@ -188,7 +188,7 @@ pub(super) async fn finalize_sandbox_for_completion(
         .as_ref()
         .map(|promotion| promotion.reuse_key().to_owned());
 
-    let mut session_affinity_changed = false;
+    let mut reuse_state_changed = false;
     let budget = if let Some(reuse_key) = parkable_reuse_key {
         let reuse_key_fingerprint = crate::paths::short_digest(&reuse_key);
         let reuse_kind = reuse_key_kind(&reuse_key);
@@ -256,7 +256,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         destroy_result.workspace_cache_promoted,
                     );
                     record_destroy_result(destroy_result.outcome, destroy_bookkeeping);
-                    return mark_session_affinity_refresh(
+                    return mark_reuse_state_refresh(
                         CompletionReady::new(
                             completion_payload,
                             BudgetOwnership::active(ActiveBudgetLease::from_idle_park_lease(
@@ -300,7 +300,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         &completed_at,
                         destroy_result.workspace_cache_promoted,
                     );
-                    return mark_session_affinity_refresh(
+                    return mark_reuse_state_refresh(
                         CompletionReady::new(completion_payload, destroy_result.budget),
                         workspace_cache_promoted,
                     );
@@ -324,7 +324,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                 destroy_bookkeeping,
             )
             .await;
-            session_affinity_changed |= mark_workspace_cache_snapshot_promoted(
+            reuse_state_changed |= mark_workspace_cache_snapshot_promoted(
                 &workspace_cache_snapshot,
                 Some(&reuse_key),
                 &profile_name,
@@ -350,7 +350,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                 destroy_bookkeeping,
             )
             .await;
-            session_affinity_changed |= mark_workspace_cache_snapshot_promoted(
+            reuse_state_changed |= mark_workspace_cache_snapshot_promoted(
                 &workspace_cache_snapshot,
                 Some(&reuse_key),
                 &profile_name,
@@ -394,7 +394,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                             &completed_at,
                             destroy_result.workspace_cache_promoted,
                         );
-                        return mark_session_affinity_refresh(
+                        return mark_reuse_state_refresh(
                             CompletionReady::new(completion_payload, destroy_result.budget),
                             workspace_cache_promoted,
                         );
@@ -426,7 +426,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         &completed_at,
                         destroy_result.workspace_cache_promoted,
                     );
-                    return mark_session_affinity_refresh(
+                    return mark_reuse_state_refresh(
                         CompletionReady::new(completion_payload, destroy_result.budget),
                         workspace_cache_promoted,
                     );
@@ -463,7 +463,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         ownership
                             .publish_idle_status_after_pool_transfer(snapshot)
                             .await;
-                        session_affinity_changed = true;
+                        reuse_state_changed = true;
                         reuse_state_notify.notify_one();
                         BudgetOwnership::idle_owned()
                     }
@@ -488,7 +488,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         ownership
                             .publish_idle_status_after_pool_transfer(snapshot)
                             .await;
-                        session_affinity_changed = true;
+                        reuse_state_changed = true;
                         reuse_state_notify.notify_one();
                         // The replaced VM was park()ed when it entered the
                         // pool; destroying a parked sandbox is safe — Drop
@@ -520,7 +520,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                             destroy_bookkeeping,
                         )
                         .await;
-                        session_affinity_changed |= mark_workspace_cache_snapshot_promoted(
+                        reuse_state_changed |= mark_workspace_cache_snapshot_promoted(
                             &workspace_cache_snapshot,
                             Some(&reuse_key),
                             &profile_name,
@@ -550,7 +550,7 @@ pub(super) async fn finalize_sandbox_for_completion(
             },
         )
         .await;
-        session_affinity_changed |= mark_workspace_cache_snapshot_promoted(
+        reuse_state_changed |= mark_workspace_cache_snapshot_promoted(
             &workspace_cache_snapshot,
             workspace_promotion_reuse_key.as_deref(),
             &profile_name,
@@ -561,9 +561,9 @@ pub(super) async fn finalize_sandbox_for_completion(
         BudgetOwnership::active(active_lease)
     };
 
-    mark_session_affinity_refresh(
+    mark_reuse_state_refresh(
         CompletionReady::new(completion_payload, budget),
-        session_affinity_changed,
+        reuse_state_changed,
     )
 }
 
@@ -2207,7 +2207,7 @@ mod tests {
             workspace_cache_snapshot
                 .current_held_workspace_states(&active_reuse_keys, None)
                 .is_empty(),
-            "failed post-freeze stop must not advertise session affinity"
+            "failed post-freeze stop must not advertise reusable state"
         );
     }
 

--- a/crates/runner/src/cmd/start/tests/idle_reuse/mod.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/mod.rs
@@ -1,6 +1,6 @@
-mod affinity;
 mod device_limits;
 mod drain;
 mod parking;
+mod same_thread_reuse;
 mod status;
 mod workspace_cache;

--- a/crates/runner/src/cmd/start/tests/idle_reuse/same_thread_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/same_thread_reuse.rs
@@ -8,16 +8,16 @@ use super::super::support::{
 use crate::types::SandboxReuseResult;
 
 // -----------------------------------------------------------------------
-// Test 13: Session affinity reuses idle VM
+// Test 13: Same-thread work reuses an idle VM
 // -----------------------------------------------------------------------
 
 #[tokio::test(start_paused = true)]
-async fn session_affinity_reuses_idle_vm() {
+async fn same_thread_reuses_idle_vm() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
 
-    // Pre-seed: park a VM for session "sess-reuse" with matching profile.
+    // Pre-seed: park a VM for reuse key "sess-reuse" with matching profile.
     let seeded_sandbox_id =
         seed_idle_pool(&idle_pool, &budget, "sess-reuse", "vm0/default", 2, 4096).await;
     assert_eq!(budget.allocated().2, 1, "seeded entry holds budget");

--- a/crates/runner/src/idle_pool/entry.rs
+++ b/crates/runner/src/idle_pool/entry.rs
@@ -36,7 +36,7 @@ pub(super) struct IdleSandboxMetadata {
     /// Local terminal timestamp for this parked sandbox.
     ///
     /// `None` is reserved for synthetic test entries and means the VM is not
-    /// advertised for reuse affinity.
+    /// advertised as reusable.
     pub(super) last_completed_at: Option<String>,
 }
 

--- a/crates/runner/src/provider/local/tests/discovery.rs
+++ b/crates/runner/src/provider/local/tests/discovery.rs
@@ -35,13 +35,13 @@ async fn discover_claim_complete() {
 }
 
 #[tokio::test]
-async fn discover_carries_thread_affinity_before_claim() {
+async fn discover_carries_reuse_metadata_before_claim() {
     let dir = tempfile::tempdir().unwrap();
     let provider = default_provider(dir.path(), CancellationToken::new(), empty_cancel_tokens());
     let job_id = RunId::new_v4();
     let reuse_key = "thread:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 
-    write_job_with_affinity(
+    write_job_with_reuse_metadata(
         dir.path(),
         job_id,
         "continue",
@@ -61,7 +61,7 @@ async fn discover_carries_thread_affinity_before_claim() {
 }
 
 #[tokio::test]
-async fn session_only_job_resumes_without_affinity() {
+async fn session_only_job_resumes_without_reuse_key() {
     let dir = tempfile::tempdir().unwrap();
     let provider = default_provider(dir.path(), CancellationToken::new(), empty_cancel_tokens());
     let job_id = RunId::new_v4();
@@ -80,13 +80,13 @@ async fn session_only_job_resumes_without_affinity() {
 }
 
 #[tokio::test]
-async fn thread_affinity_is_available_before_a_session_exists() {
+async fn reuse_key_is_available_before_a_session_exists() {
     let dir = tempfile::tempdir().unwrap();
     let provider = default_provider(dir.path(), CancellationToken::new(), empty_cancel_tokens());
     let job_id = RunId::new_v4();
     let reuse_key = "thread:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 
-    write_job_with_affinity(dir.path(), job_id, "start warm", Some(reuse_key), None);
+    write_job_with_reuse_metadata(dir.path(), job_id, "start warm", Some(reuse_key), None);
 
     let candidate = provider.discover().await.unwrap();
     assert_eq!(candidate.reuse_key(), Some(reuse_key));

--- a/crates/runner/src/provider/local/tests/support.rs
+++ b/crates/runner/src/provider/local/tests/support.rs
@@ -127,7 +127,7 @@ pub(super) fn write_job_with_session(
     );
 }
 
-pub(super) fn write_job_with_affinity(
+pub(super) fn write_job_with_reuse_metadata(
     dir: &std::path::Path,
     job_id: RunId,
     prompt: &str,

--- a/crates/runner/src/workspace_image_cache/tests/metadata.rs
+++ b/crates/runner/src/workspace_image_cache/tests/metadata.rs
@@ -372,7 +372,7 @@ async fn metadata_validation_rejects_replaced_current_image() {
     assert!(err.to_string().contains("current image identity mismatch"));
     assert!(
         cache.held_workspace_states().await.is_empty(),
-        "stale metadata/current pairs must not be advertised for affinity",
+        "stale metadata/current pairs must not be advertised as reusable workspace caches",
     );
 }
 
@@ -435,7 +435,7 @@ async fn metadata_validation_rejects_symlink_current_image() {
     assert!(err.to_string().contains("current image is not a file"));
     assert!(
         cache.held_workspace_states().await.is_empty(),
-        "symlink current image entries must not be advertised for affinity",
+        "symlink current image entries must not be advertised as reusable workspace caches",
     );
 
     let freed = cache.gc(false).await.unwrap();

--- a/crates/runner/src/workspace_image_cache/tests/state.rs
+++ b/crates/runner/src/workspace_image_cache/tests/state.rs
@@ -494,6 +494,6 @@ async fn held_workspace_states_reject_unsafe_working_dir_metadata() {
 
     assert!(
         cache.held_workspace_states().await.is_empty(),
-        "unsafe working dirs must not be advertised for affinity",
+        "unsafe working dirs must not be advertised as reusable workspace caches",
     );
 }

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -381,7 +381,7 @@ export async function publishRunnerJobNotification(
   runId: string,
   profile: string,
   metadata?: {
-    /** Raw key required for runner-local affinity matching; it stays on the internal runner-group channel. */
+    /** Raw key required for runner-local reuse matching; it stays on the internal runner-group channel. */
     readonly reuseKey: string | null;
     readonly cliAgentSessionId: string | null;
     readonly historyGenerationRunId: string | undefined;

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1105,7 +1105,7 @@ async function sendChatRunMessage(
   return { runId: sent.body.runId, threadId: sent.body.threadId };
 }
 
-interface SameThreadAffinityHeartbeatArgs {
+interface SameThreadReuseHeartbeatArgs {
   readonly admittableProfiles?: string[];
   readonly mode?: "starting" | "running" | "draining" | "stopping";
   readonly reusableSandbox?: {
@@ -1118,7 +1118,7 @@ interface SameThreadAffinityHeartbeatArgs {
   }[];
 }
 
-async function setupSameThreadAffinityScenario(sourceRunnerIdentity?: {
+async function setupSameThreadReuseScenario(sourceRunnerIdentity?: {
   readonly runnerId: string;
   readonly heartbeatGeneration: number;
 }) {
@@ -1129,16 +1129,16 @@ async function setupSameThreadAffinityScenario(sourceRunnerIdentity?: {
 
   const first = await sendChatRunMessage(actor, {
     agentId,
-    prompt: "start affinity-protected session",
+    prompt: "start reuse-preference session",
   });
   const firstClaim = await api.claimRunnerJob(
     first.runId,
     sourceRunnerIdentity ? { runnerIdentity: sourceRunnerIdentity } : {},
   );
-  const cliAgentSessionId = `bdd-affinity-cli-${first.runId}`;
+  const cliAgentSessionId = `bdd-reuse-cli-${first.runId}`;
   const reuseKey = `thread:${first.threadId}`;
-  const affinityRunnerId = randomUUID();
-  const history = `bdd affinity history ${first.runId}`;
+  const reuseRunnerId = randomUUID();
+  const history = `bdd reuse history ${first.runId}`;
   const historyHash = createHash("sha256").update(history).digest("hex");
   mockSessionHistoryBlob(historyHash, history);
   await webhooks.requestAgentCheckpoint(
@@ -1158,21 +1158,21 @@ async function setupSameThreadAffinityScenario(sourceRunnerIdentity?: {
   );
   await flushWaitUntilForTest();
 
-  let affinitySnapshotSequence = 0;
-  function nextAffinitySnapshotSequence(): number {
-    affinitySnapshotSequence += 1;
-    return affinitySnapshotSequence;
+  let reuseSnapshotSequence = 0;
+  function nextReuseSnapshotSequence(): number {
+    reuseSnapshotSequence += 1;
+    return reuseSnapshotSequence;
   }
 
   async function heartbeatHolder(
-    args: SameThreadAffinityHeartbeatArgs,
+    args: SameThreadReuseHeartbeatArgs,
   ): Promise<void> {
     const lastCompletedAt = nowDate().toISOString();
     await api.requestHeartbeatRunner(true, [200], {
-      runnerId: affinityRunnerId,
+      runnerId: reuseRunnerId,
       group: runnerGroup,
       snapshotGeneration: 1,
-      snapshotSequence: nextAffinitySnapshotSequence(),
+      snapshotSequence: nextReuseSnapshotSequence(),
       admittableProfiles: args.admittableProfiles,
       heldSandboxStates: args.reusableSandbox
         ? [
@@ -1208,7 +1208,7 @@ async function setupSameThreadAffinityScenario(sourceRunnerIdentity?: {
       [200],
     );
     if (poll.status !== 200) {
-      throw new Error("Expected affinity poll to return 200");
+      throw new Error("Expected reuse-preference poll to return 200");
     }
     expect(poll.body.job?.runId).toBe(run.runId);
     if (cancelAfterPoll) {
@@ -1231,13 +1231,13 @@ async function setupSameThreadAffinityScenario(sourceRunnerIdentity?: {
 
   return {
     actor,
-    affinityRunnerId,
+    reuseRunnerId,
     agentId,
     api,
     cliAgentSessionId,
     first,
     heartbeatHolder,
-    nextAffinitySnapshotSequence,
+    nextReuseSnapshotSequence,
     pollFollowUp,
     reuseKey,
     runnerGroup,
@@ -3529,7 +3529,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("resumes a CLI session without reuse affinity when no chat thread exists", async () => {
+  it("resumes a CLI session without a reuse key when no chat thread exists", async () => {
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -3619,28 +3619,28 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(completed.status).toBe("completed");
   });
 
-  it("selects same-thread affinity metadata from runner heartbeats", async () => {
+  it("selects same-thread reuse preferences from runner heartbeats", async () => {
     const {
-      affinityRunnerId,
+      reuseRunnerId,
       api,
       cliAgentSessionId,
       first,
       heartbeatHolder,
-      nextAffinitySnapshotSequence,
+      nextReuseSnapshotSequence,
       pollFollowUp,
       reuseKey,
       runnerGroup,
-    } = await setupSameThreadAffinityScenario();
+    } = await setupSameThreadReuseScenario();
 
     function rawHeartbeatBody(
       extra: Record<string, unknown>,
     ): Record<string, unknown> {
       return {
-        runnerId: affinityRunnerId,
+        runnerId: reuseRunnerId,
         runnerName: "bdd-runner",
         group: runnerGroup,
         snapshotGeneration: 1,
-        snapshotSequence: nextAffinitySnapshotSequence(),
+        snapshotSequence: nextReuseSnapshotSequence(),
         totalVcpu: 8,
         totalMemoryMb: 16_384,
         maxConcurrent: 2,
@@ -3707,10 +3707,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(runnerPreference(canonicalHeartbeatHolder.job)).toBeUndefined();
 
     await api.requestHeartbeatRunner(true, [200], {
-      runnerId: affinityRunnerId,
+      runnerId: reuseRunnerId,
       group: runnerGroup,
       snapshotGeneration: 1,
-      snapshotSequence: nextAffinitySnapshotSequence(),
+      snapshotSequence: nextReuseSnapshotSequence(),
       admittableProfiles: ["vm0/default"],
       heldWorkspaceStates: [
         {
@@ -3729,7 +3729,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(workspaceOnlyHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
     expect(runnerPreference(workspaceOnlyHolder.job)).toStrictEqual({
       runnerIdentity: {
-        runnerId: affinityRunnerId,
+        runnerId: reuseRunnerId,
         heartbeatGeneration: 1,
       },
       reason: "matchingReuseKey",
@@ -3814,7 +3814,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
     expect(runnerPreference(differentGenerationHolder.job)).toStrictEqual({
       runnerIdentity: {
-        runnerId: affinityRunnerId,
+        runnerId: reuseRunnerId,
         heartbeatGeneration: 1,
       },
       reason: "matchingReuseKey",
@@ -3833,7 +3833,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
     expect(runnerPreference(exactGenerationHolder.job)).toStrictEqual({
       runnerIdentity: {
-        runnerId: affinityRunnerId,
+        runnerId: reuseRunnerId,
         heartbeatGeneration: 1,
       },
       reason: "exactHistoryGeneration",
@@ -3877,7 +3877,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       heartbeatGeneration: 7,
     };
     const { actor, agentId, api, first, reuseKey, runnerGroup } =
-      await setupSameThreadAffinityScenario(sourceRunnerIdentity);
+      await setupSameThreadReuseScenario(sourceRunnerIdentity);
 
     await api.requestHeartbeatRunner(true, [200], {
       runnerId: sourceRunnerIdentity.runnerId,
@@ -3990,7 +3990,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       heartbeatGeneration: 5,
     };
     const { actor, agentId, api, first, reuseKey, runnerGroup } =
-      await setupSameThreadAffinityScenario(sourceRunnerIdentity);
+      await setupSameThreadReuseScenario(sourceRunnerIdentity);
     await api.requestHeartbeatRunner(true, [200], {
       runnerId: sourceRunnerIdentity.runnerId,
       group: runnerGroup,
@@ -4070,7 +4070,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       heartbeatGeneration: 4,
     };
     const { actor, agentId, api, first, runnerGroup } =
-      await setupSameThreadAffinityScenario(sourceRunnerIdentity);
+      await setupSameThreadReuseScenario(sourceRunnerIdentity);
     await api.requestHeartbeatRunner(true, [200], {
       runnerId: sourceRunnerIdentity.runnerId,
       group: runnerGroup,
@@ -4104,7 +4104,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await flushWaitUntilForTest();
   });
 
-  it("omits same-thread affinity for unavailable holders", async () => {
+  it("omits same-thread reuse preferences for unavailable holders", async () => {
     const {
       actor,
       api,
@@ -4114,7 +4114,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       pollFollowUp,
       waitForCancellation,
       webhooks,
-    } = await setupSameThreadAffinityScenario();
+    } = await setupSameThreadReuseScenario();
 
     await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
@@ -4199,10 +4199,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(runnerPreference(drainingHolder.job)).toBeUndefined();
   });
 
-  it("preserves same-thread affinity timing across queued admission", async () => {
+  it("preserves same-thread reuse-preference timing across queued admission", async () => {
     const {
       actor,
-      affinityRunnerId,
+      reuseRunnerId,
       agentId,
       api,
       cliAgentSessionId,
@@ -4212,7 +4212,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       runnerGroup,
       waitForCancellation,
       webhooks,
-    } = await setupSameThreadAffinityScenario();
+    } = await setupSameThreadReuseScenario();
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -4240,11 +4240,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       ],
     });
     const preferredExactRunner =
-      affinityRunnerId < equivalentExactRunnerId
-        ? { runnerId: affinityRunnerId, heartbeatGeneration: 1 }
+      reuseRunnerId < equivalentExactRunnerId
+        ? { runnerId: reuseRunnerId, heartbeatGeneration: 1 }
         : { runnerId: equivalentExactRunnerId, heartbeatGeneration: 7 };
     if (!actor.orgId) {
-      throw new Error("Expected affinity actor to have an organization");
+      throw new Error("Expected reuse actor to have an organization");
     }
     const requestStartedAt = now();
     const queueInsertedAt = requestStartedAt + 5000;
@@ -4274,7 +4274,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const protectedFollowUpRequest = sendChatRunMessage(actor, {
       agentId,
       threadId: first.threadId,
-      prompt: "continue affinity-protected session",
+      prompt: "continue reuse-preference session",
     });
     cleanupRequests.push(protectedFollowUpRequest);
     await expect
@@ -4307,7 +4307,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       [200],
     );
     if (protectedPoll.status !== 200) {
-      throw new Error("Expected affinity poll to return 200");
+      throw new Error("Expected reuse-preference poll to return 200");
     }
     expect(protectedPoll.body.job?.runId).toBe(protectedFollowUp.runId);
     expect(protectedPoll.body.job?.cliAgentSessionId).toBe(cliAgentSessionId);
@@ -4317,7 +4317,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
 
     const protectedClaim = await api.claimRunnerJob(protectedFollowUp.runId);
-    expect(protectedClaim.prompt).toBe("continue affinity-protected session");
+    expect(protectedClaim.prompt).toBe("continue reuse-preference session");
     expect(protectedClaim.reuseKey).toBe(reuseKey);
     if (typeof protectedClaim.apiStartTime !== "number") {
       throw new Error("Expected the chat run to retain its API start time");
@@ -4395,7 +4395,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       [200],
     );
     if (generationExpiredPoll.status !== 200) {
-      throw new Error("Expected affinity poll to return 200");
+      throw new Error("Expected reuse-preference poll to return 200");
     }
     expect(generationExpiredPoll.body.job?.runId).toBe(
       generationExpiredRun.runId,
@@ -4411,7 +4411,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const expiredFollowUp = await sendChatRunMessage(actor, {
       agentId,
       threadId: first.threadId,
-      prompt: "continue after affinity protection expires",
+      prompt: "continue after reuse-preference protection expires",
     });
     mockNow(now() + 60_000);
     const expiredClaim = await api.requestClaimRunnerJob(
@@ -4420,10 +4420,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       [200],
     );
     if (expiredClaim.status !== 200) {
-      throw new Error("Expected expired affinity claim to succeed");
+      throw new Error("Expected expired reuse-preference claim to succeed");
     }
     expect(expiredClaim.body.prompt).toBe(
-      "continue after affinity protection expires",
+      "continue after reuse-preference protection expires",
     );
     await api.requestCancelRun(actor, expiredFollowUp.runId, [200]);
   });
@@ -4504,13 +4504,13 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       });
     }
 
-    async function expectAffinity(
+    async function expectReusePreference(
       expectedResource: "reusableSandbox" | "workspaceCache" | undefined,
     ): Promise<void> {
       const followUp = await sendChatRunMessage(actor, {
         agentId,
         threadId: first.threadId,
-        prompt: `check ordered heartbeat affinity ${expectedResource ?? "none"}`,
+        prompt: `check ordered heartbeat reuse preference ${expectedResource ?? "none"}`,
       });
       const poll = await api.requestPollRunner(
         true,
@@ -4548,7 +4548,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       sequence: 1,
       resource: undefined,
     });
-    await expectAffinity("reusableSandbox");
+    await expectReusePreference("reusableSandbox");
 
     mockNow(baseTime + 20_000);
     await heartbeat({
@@ -4557,7 +4557,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       resource: "reusableSandbox",
     });
     mockNow(baseTime + 31_000);
-    await expectAffinity(undefined);
+    await expectReusePreference(undefined);
 
     await heartbeat({
       generation: 1,
@@ -4569,7 +4569,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       sequence: 3,
       resource: undefined,
     });
-    await expectAffinity("workspaceCache");
+    await expectReusePreference("workspaceCache");
 
     await heartbeat({
       generation: 2,
@@ -4581,7 +4581,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       sequence: 99,
       resource: "workspaceCache",
     });
-    await expectAffinity(undefined);
+    await expectReusePreference(undefined);
   });
 
   it("prioritizes exact reusable work only for its runner and protection window", async () => {
@@ -4616,14 +4616,14 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
     await flushWaitUntilForTest();
 
-    const affinityRunnerId = randomUUID();
+    const reuseRunnerId = randomUUID();
     const priorityBase = now();
     mockNow(priorityBase);
     onTestFinished(() => {
       clearMockNow();
     });
     await api.requestHeartbeatRunner(true, [200], {
-      runnerId: affinityRunnerId,
+      runnerId: reuseRunnerId,
       group: runnerGroup,
       admittableProfiles: [],
       heldSandboxStates: [
@@ -4654,7 +4654,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(protectedPoll.body.job?.runId).toBe(protectedFollowUp.runId);
     expect(runnerPreference(protectedPoll.body.job)).toMatchObject({
       runnerIdentity: {
-        runnerId: affinityRunnerId,
+        runnerId: reuseRunnerId,
         heartbeatGeneration: 1,
       },
       reason: "exactHistoryGeneration",
@@ -4688,7 +4688,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const reusablePriorityPoll = await api.requestPollRunner(
       true,
       {
-        runnerId: affinityRunnerId,
+        runnerId: reuseRunnerId,
         group: runnerGroup,
         supportedProfiles: ["vm0/default"],
       },
@@ -4700,7 +4700,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(reusablePriorityPoll.body.job?.runId).toBe(newerReusable.runId);
 
     await api.requestHeartbeatRunner(true, [200], {
-      runnerId: affinityRunnerId,
+      runnerId: reuseRunnerId,
       group: runnerGroup,
       admittableProfiles: [],
       heldSandboxStates: [
@@ -4714,7 +4714,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const genericReusablePriorityPoll = await api.requestPollRunner(
       true,
       {
-        runnerId: affinityRunnerId,
+        runnerId: reuseRunnerId,
         group: runnerGroup,
         supportedProfiles: ["vm0/default"],
       },
@@ -4731,7 +4731,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const expiredPriorityPoll = await api.requestPollRunner(
       true,
       {
-        runnerId: affinityRunnerId,
+        runnerId: reuseRunnerId,
         group: runnerGroup,
         supportedProfiles: ["vm0/default"],
       },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -1299,7 +1299,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     );
   });
 
-  it("snapshots thread reuse affinity before a CLI session exists", async () => {
+  it("snapshots thread reuse inputs before a CLI session exists", async () => {
     const runnerGroup = configureCanonicalTelegramRunner();
     const fixture = await trackFixture(
       seedTelegramPostFixture({ linkTelegramUser: true }),
@@ -1360,7 +1360,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       [200],
     );
     if (poll.status !== 200) {
-      throw new Error("Expected the thread-affinity poll to succeed");
+      throw new Error("Expected the same-thread reuse poll to succeed");
     }
     expect(poll.body.job).toMatchObject({
       runId,

--- a/turbo/apps/api/src/signals/services/runner-job-queue-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-job-queue-lifecycle.service.ts
@@ -12,7 +12,7 @@ interface RunnerJobQueueTimestamps {
  * Capture the closest safe persisted approximation of queue availability.
  * The row is committed before notification, so this is insertion time rather
  * than commit, notification, or runner discovery time. The API clock owns the
- * telemetry/affinity boundary, while the database clock owns queue expiry.
+ * telemetry/reuse-preference boundary, while the database clock owns queue expiry.
  */
 export function runnerJobQueueTimestamps(): RunnerJobQueueTimestamps {
   return {


### PR DESCRIPTION
## Summary

- rename runner finalization flags and helpers from session-affinity wording to reusable-state terminology
- rename local-provider, idle-reuse, and API integration fixtures and test descriptions to same-thread reuse or reuse-preference terminology
- rename the idle-reuse `affinity` test module to `same_thread_reuse` and update misleading current-source comments and assertions

## Explicit exclusions

- no runtime behavior, ranking, deadline, admission, resource-selection, API, queue, database, or persisted-data change
- preserve `workspaceAffinityVersion` / `WORKSPACE_AFFINITY_VERSION` as the active workspace-cache compatibility discriminator
- preserve `runner_notification_affinity_lookup` so #24560's production Axiom time series remains continuous

## Validation

- `scripts/prepare.sh`
- `cd crates && cargo fmt --manifest-path Cargo.toml --all --check`
- `cd crates && cargo test --manifest-path Cargo.toml -p runner`
- `cd crates && cargo clippy --manifest-path Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cd crates && cargo doc --manifest-path Cargo.toml -p runner --no-deps`
- `cd turbo && pnpm format`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm knip`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts --maxWorkers=1 --silent=passed-only`
- pre-commit hooks, including repository-wide Turbo type checks and staged Rust format/docs/Clippy checks
- exact source scans for removed legacy identifiers and unintended `affinity` residue

Closes #24828

Parent context: #24355
