### PR TITLE
refactor(api): stop persisting slack message permalinks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -107,12 +107,10 @@ async function expectClaimedSlackDisplayContext(
   expect(claimedContext).toMatchObject({
     contextType: "slack",
     contextId: expect.any(String),
-    slackPermalink: messagePermalink,
   });
   expect(pendingContext).toMatchObject({
     contextType: "slack",
     contextId: claimedContext?.contextId,
-    slackPermalink: messagePermalink,
   });
 }
 
@@ -1845,7 +1843,6 @@ describe("INT-01: Slack app deep webhook flows", () => {
     ).resolves.toMatchObject({
       contextType: "slack",
       contextId: expect.any(String),
-      slackPermalink: null,
       slackChannelId: channelId,
       slackMessageTs: "2900.000200",
       slackConversationContext: "",

--- a/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
@@ -281,7 +281,6 @@ type ClaimedCanonicalSlackIngress = NonNullable<
 >;
 
 interface CanonicalSlackLaunchContext {
-  readonly messagePermalink: string | null;
   readonly channelId: string;
   readonly messageTs: string;
   readonly conversationContext: string;
@@ -300,7 +299,6 @@ function canonicalSlackLaunchContext(args: {
   readonly routeThreadTs: string;
   readonly messageText: string;
   readonly conversationContext: string;
-  readonly messagePermalink: string | null;
   readonly mentionDisplayNames: Readonly<Record<string, string>>;
   readonly userInfoExtras: {
     readonly slackDisplayName?: string;
@@ -309,7 +307,6 @@ function canonicalSlackLaunchContext(args: {
 }): CanonicalSlackLaunchContext {
   const threadTs = slackPhysicalThreadTs(args.event);
   return {
-    messagePermalink: args.messagePermalink,
     channelId: args.event.channel,
     messageTs: args.event.ts,
     conversationContext: args.conversationContext,
@@ -331,6 +328,7 @@ async function persistCanonicalSlackMessage(
     readonly chatThreadId: string;
     readonly displayContent: string;
     readonly slackContext: CanonicalSlackLaunchContext;
+    readonly messagePermalink: string | null;
     readonly canonicalAssets: readonly CanonicalSlackInputAsset[];
   },
   signal: AbortSignal,
@@ -353,7 +351,7 @@ async function persistCanonicalSlackMessage(
           }),
           nonContentPart: createChatEventSourcePart({
             kind: "slack",
-            messagePermalink: args.slackContext.messagePermalink,
+            messagePermalink: args.messagePermalink,
           }),
         }),
         runId: null,
@@ -476,12 +474,12 @@ const persistClaimedCanonicalSlackIngress$ = command(
         ingress,
         chatThreadId,
         displayContent: enriched.displayContent,
+        messagePermalink,
         slackContext: canonicalSlackLaunchContext({
           event,
           routeThreadTs: ingress.threadTs,
           messageText: messageContent,
           conversationContext: context.executionContext,
-          messagePermalink,
           mentionDisplayNames: enriched.mentionDisplayNames,
           userInfoExtras: enriched.userInfoExtras,
         }),

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -48,7 +48,6 @@ type ChatEventIdentity = Pick<
 type ChatEventDisplayContext =
   | {
       readonly slackContext: {
-        readonly messagePermalink: string | null;
         readonly channelId: string;
         readonly messageTs: string;
         readonly conversationContext: string;
@@ -426,7 +425,6 @@ type NewDisplayContext =
       readonly type: "slack";
       readonly id: string;
       readonly chatThreadId: string;
-      readonly messagePermalink: string | null;
       readonly channelId: string;
       readonly messageTs: string;
       readonly conversationContext: string;
@@ -597,7 +595,6 @@ function newDisplayContext(
       type: "slack",
       id: eventId,
       chatThreadId: values.chatThreadId,
-      messagePermalink: slackContext.messagePermalink,
       channelId: slackContext.channelId,
       messageTs: slackContext.messageTs,
       conversationContext: slackContext.conversationContext,
@@ -807,7 +804,6 @@ async function insertDisplayContext(
     await tx.insert(chatSlackContext).values({
       id: context.id,
       chatThreadId: context.chatThreadId,
-      messagePermalink: context.messagePermalink,
       channelId: context.channelId,
       messageTs: context.messageTs,
       conversationContext: context.conversationContext,

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -63,7 +63,6 @@ interface ChatEventContextFixture {
   readonly workflowName: string | null;
   readonly workflowEventType: string | null;
   readonly workflowEventPayload: JsonObject | null;
-  readonly slackPermalink: string | null;
   readonly slackChannelId: string | null;
   readonly slackMessageTs: string | null;
   readonly slackConversationContext: string | null;
@@ -165,7 +164,6 @@ export async function readChatEventContextFixture(
       workflowName: chatAutomationContext.workflowName,
       workflowEventType: chatAutomationContext.eventType,
       workflowEventPayload: chatAutomationContext.eventPayload,
-      slackPermalink: chatSlackContext.messagePermalink,
       slackChannelId: chatSlackContext.channelId,
       slackMessageTs: chatSlackContext.messageTs,
       slackConversationContext: chatSlackContext.conversationContext,
@@ -273,10 +271,9 @@ const annotationProjectionInputs = [
   {
     text: "slack linked",
     triggerSource: "slack",
+    messagePermalink: "https://vm0.slack.com/archives/C123/p1753257600000100",
     context: {
       slackContext: {
-        messagePermalink:
-          "https://vm0.slack.com/archives/C123/p1753257600000100",
         channelId: "C123",
         messageTs: "1753257600.000100",
         conversationContext: "",
@@ -475,10 +472,10 @@ const annotationProjectionInputs = [
 function annotationProjectionSourcePart(
   input: (typeof annotationProjectionInputs)[number],
 ) {
-  if ("slackContext" in input.context) {
+  if ("messagePermalink" in input) {
     return createChatEventSourcePart({
       kind: "slack",
-      messagePermalink: input.context.slackContext.messagePermalink,
+      messagePermalink: input.messagePermalink,
     });
   }
   if ("feishuContext" in input.context) {
@@ -778,7 +775,6 @@ export async function insertQueuedSlackMissingContextFixture(args: {
       runId: null,
       triggerSource: "slack",
       slackContext: {
-        messagePermalink: null,
         channelId: "C_MONITOR_FAILURE",
         messageTs: "1.000001",
         conversationContext: "",


### PR DESCRIPTION
## Summary

- stop passing `messagePermalink` through the persisted Slack display context
- keep resolving the permalink at ingress and use the in-memory value for the Slack source part
- preserve both linked and link-less source-part behavior without changing claim or delivery data

## Rollout timing

- **PR 1 (this PR):** merged at `2026-08-04T03:16:10Z`; included by ancestry in `api-v1.370.1` (`5419e595`), promoted to production at `2026-08-04T03:30:45Z`, and completed its release pipeline at `2026-08-04T03:32:51Z`
- **PR 2:** open only after the observation below; release in a later, separate production release because its migration runs before API promotion and must not overlap an old API writer

This PR intentionally contains no migration or schema change. `channel_id` and `message_ts` are unchanged.

## Production observation

- observed `2026-08-04T03:30:45Z` through `2026-08-04T03:41:09Z` before starting PR 2
- four Slack integration requests completed with HTTP 200/204; no Slack-related 5xx
- zero production errors matching canonical Slack ingress processing, `message_permalink`, or `chat_slack_context`
- no `/api/zero/slack/events` or Slack `chat_events` arrived in the window, so the gate relies on the completed API promotion plus the clean post-promotion observation rather than claiming a live inbound-message sample
- MaskDB does not expose `chat_slack_context`, so direct production reads of the nullable column were not available

## Validation

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts -t 'deduplicates canonical Slack retries|keeps queued Web and Slack sends on one canonical session' --maxWorkers=1 --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-event-annotations.test.ts --maxWorkers=1 --silent=passed-only`

Part of #24842
