### PR TITLE
fix(runner): guard run controls across sandbox reuse

### DIFF
--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -5,7 +5,9 @@ use std::process::ExitCode;
 use std::time::Duration;
 
 use clap::Args;
-use sandbox::{ExecTermination, RemoteExecResult, SandboxControl, SandboxControlError};
+use sandbox::{
+    ExecTermination, RemoteExecResult, SandboxControl, SandboxControlError, SandboxControlTarget,
+};
 use shell_quote::quote_shell_arg;
 
 use crate::error::{RunnerError, RunnerResult};
@@ -74,13 +76,13 @@ pub struct ExecArgs {
 /// as [`ExitCode::FAILURE`]. Other sandbox-control errors are propagated as
 /// [`RunnerError::Config`].
 pub async fn run_exec(args: ExecArgs, control: &dyn SandboxControl) -> RunnerResult<ExitCode> {
-    // Resolve the target to a sandbox_id string.
-    let sandbox_id = if let Some(ref sid) = args.sandbox {
-        sid.clone()
+    let target = if let Some(ref sid) = args.sandbox {
+        SandboxControlTarget::sandbox(sid)
     } else if let Some(ref rid) = args.run {
         let home = HomePaths::new()?;
         let mappings = run_resolution::collect_active_run_mappings_from_home(&home).await?;
-        run_resolution::resolve_run_to_sandbox(rid, &mappings)?
+        let mapping = run_resolution::resolve_run_mapping(rid, &mappings)?;
+        SandboxControlTarget::run(mapping.run_id, mapping.sandbox_id)
     } else {
         // clap group guarantees one is set — this branch is unreachable.
         return Err(RunnerError::Config(
@@ -97,7 +99,7 @@ pub async fn run_exec(args: ExecArgs, control: &dyn SandboxControl) -> RunnerRes
     let timeout = Duration::from_secs(u64::from(args.timeout));
 
     match control
-        .exec_remote(&sandbox_id, &command, timeout, args.sudo)
+        .exec_remote(target, &command, timeout, args.sudo)
         .await
     {
         Ok(result) => {
@@ -258,7 +260,7 @@ mod tests {
         assert_eq!(
             control.recorded_exec_calls(),
             vec![RemoteExecCall {
-                sandbox_id: "direct-sandbox".to_string(),
+                target: SandboxControlTarget::sandbox("direct-sandbox"),
                 command: "'echo' 'hello world'".to_string(),
                 timeout: Duration::from_secs(47),
                 sudo: true,

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -36,6 +36,8 @@ use target::{
     rediscover_same_target,
 };
 
+const RUN_ORPHAN_FALLBACK_REFUSAL: &str = "run target can no longer be verified after owning-runner control failed; use --sandbox for explicit orphan cleanup";
+
 #[derive(Args)]
 #[command(group = clap::ArgGroup::new("target").required(true))]
 pub struct KillArgs {
@@ -73,10 +75,9 @@ pub async fn run_kill(args: KillArgs, control: &dyn SandboxControl) -> RunnerRes
                 if let Ok(refreshed) = rediscover_same_sandbox_process(&initial.target).await
                     && process::is_orphan(refreshed.target.pid, &refreshed.runner_pids).await
                 {
-                    let outcome = if should_refuse_run_orphan_fallback(&args, is_initial_orphan) {
-                        KillOutcome::RefusedTargetChanged(
-                            "run target is no longer active; refusing orphan fallback for an initially managed sandbox".into(),
-                        )
+                    let outcome = if should_refuse_orphan_fallback(initial.target.run_id.as_deref())
+                    {
+                        KillOutcome::RefusedTargetChanged(RUN_ORPHAN_FALLBACK_REFUSAL.into())
                     } else {
                         kill_current_target(refreshed.target.clone(), true, control).await
                     };
@@ -164,8 +165,8 @@ impl From<OrphanOutcome> for KillOutcome {
     }
 }
 
-fn should_refuse_run_orphan_fallback(args: &KillArgs, is_initial_orphan: bool) -> bool {
-    args.run.is_some() && !is_initial_orphan
+fn should_refuse_orphan_fallback(run_id: Option<&str>) -> bool {
+    run_id.is_some()
 }
 
 async fn kill_current_target(
@@ -188,6 +189,9 @@ async fn retry_as_orphan_if_owner_disappeared(
     let refreshed = match rediscover_same_sandbox_process(expected).await {
         Ok(refreshed) => refreshed,
         Err(error) => {
+            if should_refuse_orphan_fallback(expected.run_id.as_deref()) {
+                return KillOutcome::RefusedTargetChanged(RUN_ORPHAN_FALLBACK_REFUSAL.into());
+            }
             if was_orphan && error.allows_disappeared_orphan_cleanup() {
                 let outcome = orphan::confirmed_disappeared_outcome(expected, was_orphan)
                     .await
@@ -199,6 +203,9 @@ async fn retry_as_orphan_if_owner_disappeared(
     };
     if !process::is_orphan(refreshed.target.pid, &refreshed.runner_pids).await {
         return KillOutcome::RefusedManagedControlFailed(owner_error.to_string());
+    }
+    if should_refuse_orphan_fallback(expected.run_id.as_deref()) {
+        return KillOutcome::RefusedTargetChanged(RUN_ORPHAN_FALLBACK_REFUSAL.into());
     }
 
     KillOutcome::from(orphan::terminate(&refreshed.target).await)
@@ -418,36 +425,13 @@ mod tests {
     }
 
     #[test]
-    fn run_fallback_refuses_initially_managed_target() {
-        let args = KillArgs {
-            run: Some("run".into()),
-            sandbox: None,
-            force: true,
-        };
-
-        assert!(should_refuse_run_orphan_fallback(&args, false));
+    fn run_scoped_target_refuses_orphan_fallback() {
+        assert!(should_refuse_orphan_fallback(Some("run-full-id")));
     }
 
     #[test]
-    fn run_fallback_allows_initial_orphan_target() {
-        let args = KillArgs {
-            run: Some("run".into()),
-            sandbox: None,
-            force: true,
-        };
-
-        assert!(!should_refuse_run_orphan_fallback(&args, true));
-    }
-
-    #[test]
-    fn sandbox_fallback_allows_initially_managed_target() {
-        let args = KillArgs {
-            run: None,
-            sandbox: Some("sbox".into()),
-            force: true,
-        };
-
-        assert!(!should_refuse_run_orphan_fallback(&args, false));
+    fn sandbox_scoped_target_allows_orphan_fallback() {
+        assert!(!should_refuse_orphan_fallback(None));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -36,7 +36,8 @@ use target::{
     rediscover_same_target,
 };
 
-const RUN_ORPHAN_FALLBACK_REFUSAL: &str = "run target can no longer be verified after owning-runner control failed; use --sandbox for explicit orphan cleanup";
+const RUN_ORPHAN_FALLBACK_REFUSAL: &str =
+    "run target can no longer be verified; use --sandbox for explicit orphan cleanup";
 
 #[derive(Args)]
 #[command(group = clap::ArgGroup::new("target").required(true))]
@@ -72,15 +73,18 @@ pub async fn run_kill(args: KillArgs, control: &dyn SandboxControl) -> RunnerRes
         Ok(current) => current,
         Err(error) => {
             if error.allows_disappeared_orphan_cleanup() {
+                if should_refuse_orphan_fallback(initial.target.run_id.as_deref()) {
+                    println!(
+                        "Refused to kill sandbox {} (PID {}) - {RUN_ORPHAN_FALLBACK_REFUSAL}",
+                        initial.target.sandbox_id, initial.target.pid
+                    );
+                    return Ok(ExitCode::FAILURE);
+                }
                 if let Ok(refreshed) = rediscover_same_sandbox_process(&initial.target).await
                     && process::is_orphan(refreshed.target.pid, &refreshed.runner_pids).await
                 {
-                    let outcome = if should_refuse_orphan_fallback(initial.target.run_id.as_deref())
-                    {
-                        KillOutcome::RefusedTargetChanged(RUN_ORPHAN_FALLBACK_REFUSAL.into())
-                    } else {
-                        kill_current_target(refreshed.target.clone(), true, control).await
-                    };
+                    let outcome =
+                        kill_current_target(refreshed.target.clone(), true, control).await;
                     let exit_code =
                         finish_kill_outcome(&initial.target, &refreshed.target, &outcome, control)
                             .await;

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -173,7 +173,7 @@ async fn kill_current_target(
     is_orphan: bool,
     control: &dyn SandboxControl,
 ) -> KillOutcome {
-    match control.kill_remote(&current.sandbox_id).await {
+    match control.kill_remote(current.control_target()).await {
         Ok(RemoteKillResult::RefusedIdle) => KillOutcome::RefusedManagedIdle,
         Ok(result) => KillOutcome::OwnerAccepted(result),
         Err(error) => retry_as_orphan_if_owner_disappeared(&current, error, is_orphan).await,
@@ -404,6 +404,7 @@ async fn confirm() -> bool {
 mod tests {
     use std::path::Path;
 
+    use sandbox::SandboxControlTarget;
     use sandbox_mock::MockSandboxControl;
 
     use super::test_support::make_target;
@@ -460,7 +461,28 @@ mod tests {
             outcome,
             KillOutcome::OwnerAccepted(RemoteKillResult::Accepted)
         ));
-        assert_eq!(control.recorded_kill_ids(), vec!["sbox-123"]);
+        assert_eq!(
+            control.recorded_kill_targets(),
+            vec![SandboxControlTarget::sandbox("sbox-123")]
+        );
+    }
+
+    #[tokio::test]
+    async fn managed_run_target_preserves_full_run_identity() {
+        let control = MockSandboxControl::new("/tmp/test");
+        let mut current = make_target(200, "sbox-123");
+        current.run_id = Some("run-full-id".into());
+
+        let outcome = kill_current_target(current, false, &control).await;
+
+        assert!(matches!(
+            outcome,
+            KillOutcome::OwnerAccepted(RemoteKillResult::Accepted)
+        ));
+        assert_eq!(
+            control.recorded_kill_targets(),
+            vec![SandboxControlTarget::run("run-full-id", "sbox-123")]
+        );
     }
 
     #[tokio::test]
@@ -472,7 +494,10 @@ mod tests {
         let outcome = kill_current_target(current, false, &control).await;
 
         assert!(matches!(outcome, KillOutcome::RefusedManagedIdle));
-        assert_eq!(control.recorded_kill_ids(), vec!["sbox-123"]);
+        assert_eq!(
+            control.recorded_kill_targets(),
+            vec![SandboxControlTarget::sandbox("sbox-123")]
+        );
     }
 
     #[tokio::test]
@@ -486,7 +511,10 @@ mod tests {
             outcome,
             KillOutcome::OwnerAccepted(RemoteKillResult::Accepted)
         ));
-        assert_eq!(control.recorded_kill_ids(), vec!["sbox-123"]);
+        assert_eq!(
+            control.recorded_kill_targets(),
+            vec![SandboxControlTarget::sandbox("sbox-123")]
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/kill/target.rs
+++ b/crates/runner/src/cmd/kill/target.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use sandbox::SandboxControlTarget;
+
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
 use crate::process::{
@@ -53,6 +55,15 @@ impl From<&FirecrackerProcessInfo> for KillTarget {
             base_dir: process.base_dir.clone(),
             identity: process.identity.clone(),
         }
+    }
+}
+
+impl KillTarget {
+    pub(super) fn control_target(&self) -> SandboxControlTarget {
+        self.run_id.as_ref().map_or_else(
+            || SandboxControlTarget::sandbox(&self.sandbox_id),
+            |run_id| SandboxControlTarget::run(run_id, &self.sandbox_id),
+        )
     }
 }
 

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -785,7 +785,7 @@ async fn activate_reserved_idle(
     }
 
     let started_at = Instant::now();
-    let unpark_result = reservation.try_unpark().await;
+    let unpark_result = reservation.try_unpark_for_run(run_id).await;
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleUnpark, started_at);
     match unpark_result {
         IdleUnparkResult::Reused {
@@ -959,7 +959,7 @@ async fn try_reuse_from_pool(
                 }
             }
             let started_at = Instant::now();
-            let unpark_result = entry.try_unpark().await;
+            let unpark_result = entry.try_unpark_for_run(run_id).await;
             pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleUnpark, started_at);
             match unpark_result {
                 IdleUnparkResult::Reused {

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -1054,7 +1054,9 @@ mod tests {
             .await
             .take("sess-restore-plan")
             .expect("parked sandbox should be in idle pool");
-        let IdleUnparkResult::Reused { sandbox, .. } = entry.try_unpark().await else {
+        let IdleUnparkResult::Reused { sandbox, .. } =
+            entry.try_unpark_for_run(RunId::new_v4()).await
+        else {
             panic!("parked sandbox should unpark");
         };
         assert_eq!(sandbox.restored_session_identity(), Some(&identity));
@@ -1098,7 +1100,9 @@ mod tests {
             .await
             .take(session_id)
             .expect("parked sandbox should be in idle pool");
-        let IdleUnparkResult::Reused { sandbox, .. } = entry.try_unpark().await else {
+        let IdleUnparkResult::Reused { sandbox, .. } =
+            entry.try_unpark_for_run(RunId::new_v4()).await
+        else {
             panic!("parked sandbox should unpark");
         };
         assert!(sandbox.restored_session_identity().is_none());

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -1017,6 +1017,12 @@ async fn create_started_sandbox(
         }
     };
 
+    if let Err(error) = sandbox.bind_run_control(&context.run_id.to_string()) {
+        telemetry.record("vm_create", t.elapsed(), false, Some(&error.to_string()));
+        let _ = destroy_sandbox_panic_safe(factory, sandbox).await;
+        return Err(SandboxPrepareError::fatal(error.into()));
+    }
+
     let source_ip = sandbox.source_ip().to_string();
     let proxy_register_started = Instant::now();
     let network_log_session = match register_proxy(config, context, &source_ip).await {

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -70,6 +70,27 @@ async fn execute_inner_happy_path() {
 }
 
 #[tokio::test]
+async fn execute_inner_binds_run_control_before_sandbox_start() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let context = minimal_context();
+    let run_id = context.run_id.to_string();
+
+    let (exit_code, error_msg) =
+        run_new_sandbox_status(&factory, &context, &config, &default_params())
+            .await
+            .unwrap();
+
+    assert_eq!(exit_code, 0);
+    assert!(error_msg.is_none());
+    assert_eq!(overrides.run_control_bind_calls(), vec![run_id.clone()]);
+    assert_eq!(overrides.start_run_control_ids(), vec![Some(run_id)]);
+    assert_proxy_registry_empty(dir.path()).await;
+}
+
+#[tokio::test]
 async fn execute_inner_carries_early_codex_catalog_prefetch_into_agent_run() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/idle_pool.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/idle_pool.rs
@@ -25,7 +25,11 @@ async fn idle_pool_park_and_reuse_cycle() {
     )
     .await;
     assert_eq!(outcome.exit_code(), 0);
-    let sandbox = outcome.sandbox.expect("sandbox alive");
+    let mut sandbox = outcome.sandbox.expect("sandbox alive");
+    assert_eq!(
+        sandbox.park().await.unwrap(),
+        sandbox::SandboxParkOutcome::Reusable
+    );
 
     // Park in idle pool
     let mut pool = IdlePool::new(IdlePoolConfig {
@@ -49,7 +53,10 @@ async fn idle_pool_park_and_reuse_cycle() {
 
     // Execute reuse
     let cancel = tokio_util::sync::CancellationToken::new();
-    let (idle_sandbox, _lease) = match reuse_entry.try_unpark().await {
+    let (idle_sandbox, _lease) = match reuse_entry
+        .try_unpark_for_run(crate::ids::RunId::new_v4())
+        .await
+    {
         crate::idle_pool::IdleUnparkResult::Reused {
             sandbox,
             budget_lease,

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -1480,7 +1480,7 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
     });
     assert!(matches!(pool.park(candidate), ParkResult::Parked));
     let entry = pool.take(&reuse_key).expect("idle entry should exist");
-    let idle_sandbox = match entry.try_unpark().await {
+    let idle_sandbox = match entry.try_unpark_for_run(crate::ids::RunId::new_v4()).await {
         IdleUnparkResult::Reused { sandbox, .. } => *sandbox,
         IdleUnparkResult::Failed { error, .. } => {
             panic!("test idle entry should unpark: {error}");
@@ -1591,7 +1591,7 @@ async fn reusable_idle_sandbox_with_fresh_workspace_promotion(
     });
     assert!(matches!(pool.park(candidate), ParkResult::Parked));
     let entry = pool.take(&reuse_key).expect("idle entry should exist");
-    let idle_sandbox = match entry.try_unpark().await {
+    let idle_sandbox = match entry.try_unpark_for_run(crate::ids::RunId::new_v4()).await {
         IdleUnparkResult::Reused { sandbox, .. } => *sandbox,
         IdleUnparkResult::Failed { error, .. } => {
             panic!("test idle entry should unpark: {error}");

--- a/crates/runner/src/executor/tests/support/config.rs
+++ b/crates/runner/src/executor/tests/support/config.rs
@@ -75,7 +75,7 @@ pub(in crate::executor::tests) fn test_budget_lease() -> crate::resource_budget:
 }
 
 pub(in crate::executor::tests) async fn make_reusable_idle_sandbox(
-    sandbox: Box<dyn Sandbox>,
+    mut sandbox: Box<dyn Sandbox>,
     source_ip: String,
     session_id: &str,
 ) -> (ReusableIdleSandbox, crate::resource_budget::BudgetLease) {
@@ -84,6 +84,10 @@ pub(in crate::executor::tests) async fn make_reusable_idle_sandbox(
         test_support::ParkedIdleCandidateBuilder,
     };
 
+    assert_eq!(
+        sandbox.park().await.unwrap(),
+        sandbox::SandboxParkOutcome::Reusable
+    );
     let mut pool = IdlePool::new(IdlePoolConfig {
         default_timeout: std::time::Duration::from_secs(300),
         max_idle: 0,
@@ -94,7 +98,7 @@ pub(in crate::executor::tests) async fn make_reusable_idle_sandbox(
         .build();
     assert!(matches!(pool.park(candidate), ParkResult::Parked));
     let entry = pool.take(session_id).expect("idle entry should exist");
-    match entry.try_unpark().await {
+    match entry.try_unpark_for_run(crate::ids::RunId::new_v4()).await {
         IdleUnparkResult::Reused {
             sandbox,
             budget_lease,

--- a/crates/runner/src/idle_pool/entry.rs
+++ b/crates/runner/src/idle_pool/entry.rs
@@ -448,14 +448,17 @@ impl IdleEntry {
         now.duration_since(self.parked_at) >= self.idle_timeout
     }
 
-    /// Unpark and consume this idle entry. On failure the entry becomes an
-    /// idle-owned destroy job so callers cannot keep using a partially
-    /// unparked sandbox.
-    pub async fn try_unpark(mut self) -> IdleUnparkResult {
-        match AssertUnwindSafe(self.resources.sandbox.unpark())
-            .catch_unwind()
-            .await
-        {
+    /// Bind the next run identity while parked, then unpark and consume this
+    /// idle entry. On failure the entry becomes an idle-owned destroy job so
+    /// callers cannot keep using a partially unparked sandbox.
+    pub async fn try_unpark_for_run(mut self, run_id: RunId) -> IdleUnparkResult {
+        let activation = async {
+            self.resources
+                .sandbox
+                .bind_run_control(&run_id.to_string())?;
+            self.resources.sandbox.unpark().await
+        };
+        match AssertUnwindSafe(activation).catch_unwind().await {
             Ok(Ok(())) => {
                 let (sandbox, budget_lease) = self.into_reuse_parts();
                 IdleUnparkResult::Reused {
@@ -575,8 +578,8 @@ impl ReservedIdleSandbox {
             .validate_workspace_promotion_identity(cache, working_dir, image_size_bytes)
     }
 
-    pub async fn try_unpark(self) -> IdleUnparkResult {
-        self.entry.try_unpark().await
+    pub async fn try_unpark_for_run(self, run_id: RunId) -> IdleUnparkResult {
+        self.entry.try_unpark_for_run(run_id).await
     }
 
     pub fn into_destroy_job(self) -> IdleDestroyJob {

--- a/crates/runner/src/idle_pool/park_transition_tests.rs
+++ b/crates/runner/src/idle_pool/park_transition_tests.rs
@@ -257,15 +257,24 @@ async fn idle_park_request_success_preserves_reuse_metadata() {
         .reserve_reusable(reuse_key, profile_name, &None)
         .expect("idle entry should be reserved");
 
+    let next_run_id = RunId::new_v4();
     let IdleUnparkResult::Reused {
         sandbox,
         budget_lease,
-    } = reservation.try_unpark().await
+    } = reservation.try_unpark_for_run(next_run_id).await
     else {
         panic!("unpark should succeed");
     };
     let sandbox = *sandbox;
     assert_eq!(sandbox.sandbox_id(), sandbox_id);
+    assert_eq!(
+        overrides.run_control_bind_calls(),
+        vec![next_run_id.to_string()]
+    );
+    assert_eq!(
+        overrides.unpark_run_control_ids(),
+        vec![Some(next_run_id.to_string())]
+    );
     let reused_parts = sandbox.into_parts();
     assert_eq!(reused_parts.source_ip, source_ip);
     assert_eq!(

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -149,6 +149,7 @@ pub(crate) fn resolve_run_mapping(
 
 /// Given a `run_id` prefix, find the unique matching `sandbox_id` from
 /// collected status entries.
+#[cfg(test)]
 pub(crate) fn resolve_run_to_sandbox(
     input: &str,
     mappings: &ActiveRunMappings,

--- a/crates/sandbox-fc/src/control/client.rs
+++ b/crates/sandbox-fc/src/control/client.rs
@@ -83,6 +83,7 @@ mod tests {
         let sock_path = dir.path().join("nonexistent.sock");
 
         let request = ExecRequest {
+            expected_run_id: None,
             command: "echo test".into(),
             timeout_secs: 5,
             sudo: false,
@@ -99,6 +100,7 @@ mod tests {
         let sock_path = dir.path().join("control.sock");
 
         let request = ExecRequest {
+            expected_run_id: None,
             command: "echo test".into(),
             timeout_secs: 5,
             sudo: false,
@@ -131,6 +133,7 @@ mod tests {
 
         let client = tokio::spawn(async move {
             let request = ExecRequest {
+                expected_run_id: None,
                 command: "echo test".into(),
                 timeout_secs: 5,
                 sudo: false,

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -9,6 +9,11 @@ use tokio::net::UnixStream;
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ExecRequest {
+    /// Full run identity that must still own the sandbox at guest admission.
+    ///
+    /// Missing means the caller intentionally selected sandbox scope.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_run_id: Option<String>,
     /// Command text to execute inside the guest.
     pub command: String,
     /// Command timeout in seconds.
@@ -86,8 +91,12 @@ pub enum TerminateAction {
 pub struct TerminateRequest {
     /// Requested host-side control action.
     ///
-    /// Termination clients send `{"action":"terminate"}`.
+    /// Sandbox-scoped termination clients send `{"action":"terminate"}`.
     pub action: TerminateAction,
+    /// Full run identity that must still own the sandbox at termination
+    /// admission. Missing means intentionally sandbox-scoped termination.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_run_id: Option<String>,
 }
 
 /// Result status for a host-side termination request.
@@ -233,6 +242,7 @@ mod tests {
     #[tokio::test]
     async fn protocol_round_trip() {
         let request = ExecRequest {
+            expected_run_id: None,
             command: "echo hello".into(),
             timeout_secs: 10,
             sudo: false,
@@ -241,9 +251,16 @@ mod tests {
 
         // Verify request deserializes correctly.
         let decoded: ExecRequest = serde_json::from_slice(&request_json).unwrap();
+        assert_eq!(decoded.expected_run_id, None);
         assert_eq!(decoded.command, "echo hello");
         assert_eq!(decoded.timeout_secs, 10);
         assert!(!decoded.sudo);
+        assert!(
+            serde_json::from_slice::<serde_json::Value>(&request_json)
+                .unwrap()
+                .get("expected_run_id")
+                .is_none()
+        );
 
         // Verify success response round-trips.
         let response = ExecResponse::Success {
@@ -290,10 +307,26 @@ mod tests {
     }
 
     #[test]
+    fn guarded_exec_request_round_trips_run_identity() {
+        let request = ExecRequest {
+            expected_run_id: Some("run-full-id".into()),
+            command: "true".into(),
+            timeout_secs: 30,
+            sudo: false,
+        };
+
+        let request_json = serde_json::to_value(&request).unwrap();
+        assert_eq!(request_json["expected_run_id"], "run-full-id");
+        let decoded: ExecRequest = serde_json::from_value(request_json).unwrap();
+        assert_eq!(decoded.expected_run_id.as_deref(), Some("run-full-id"));
+    }
+
+    #[test]
     fn exec_request_default_timeout() {
         // timeout_secs has a serde default of 30
         let json = r#"{"command":"echo hi"}"#;
         let req: ExecRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.expected_run_id, None);
         assert_eq!(req.command, "echo hi");
         assert_eq!(req.timeout_secs, 30);
         assert!(!req.sudo);
@@ -497,6 +530,7 @@ mod tests {
     fn terminate_protocol_round_trip() {
         let request = TerminateRequest {
             action: TerminateAction::Terminate,
+            expected_run_id: None,
         };
         let request_json = serde_json::to_value(&request).unwrap();
         assert_eq!(
@@ -508,6 +542,7 @@ mod tests {
 
         let decoded: TerminateRequest = serde_json::from_value(request_json).unwrap();
         assert!(matches!(decoded.action, TerminateAction::Terminate));
+        assert_eq!(decoded.expected_run_id, None);
 
         for (status, status_json) in [
             (TerminateStatus::Accepted, "accepted"),
@@ -548,6 +583,19 @@ mod tests {
     }
 
     #[test]
+    fn guarded_terminate_request_round_trips_run_identity() {
+        let request = TerminateRequest {
+            action: TerminateAction::Terminate,
+            expected_run_id: Some("run-full-id".into()),
+        };
+
+        let request_json = serde_json::to_value(&request).unwrap();
+        assert_eq!(request_json["expected_run_id"], "run-full-id");
+        let decoded: TerminateRequest = serde_json::from_value(request_json).unwrap();
+        assert_eq!(decoded.expected_run_id.as_deref(), Some("run-full-id"));
+    }
+
+    #[test]
     fn terminate_response_rejects_mixed_status_error_shape() {
         let mixed = serde_json::json!({
             "status": "accepted",
@@ -562,6 +610,7 @@ mod tests {
     fn terminate_request_does_not_decode_as_exec_request() {
         let request = TerminateRequest {
             action: TerminateAction::Terminate,
+            expected_run_id: None,
         };
         let request_json = serde_json::to_vec(&request).unwrap();
 

--- a/crates/sandbox-fc/src/control/provider.rs
+++ b/crates/sandbox-fc/src/control/provider.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 use async_trait::async_trait;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
-use sandbox::{RemoteExecResult, RemoteKillResult, SandboxControl, SandboxControlError};
+use sandbox::{
+    RemoteExecResult, RemoteKillResult, SandboxControl, SandboxControlError, SandboxControlTarget,
+};
 
 use super::CONTROL_SOCKET_OVERHEAD_MS;
 use super::client::{send_exec, send_terminate};
@@ -25,11 +27,12 @@ pub struct FirecrackerControl;
 impl SandboxControl for FirecrackerControl {
     async fn exec_remote(
         &self,
-        sandbox_id: &str,
+        target: SandboxControlTarget,
         command: &str,
         timeout: Duration,
         sudo: bool,
     ) -> Result<RemoteExecResult, SandboxControlError> {
+        let sandbox_id = target.sandbox_id();
         if sandbox_id.is_empty() {
             return Err(SandboxControlError::NotFound(
                 "sandbox id must not be empty".into(),
@@ -40,6 +43,7 @@ impl SandboxControl for FirecrackerControl {
 
         let timeout_secs = request_timeout_secs(timeout);
         let request = ExecRequest {
+            expected_run_id: target.expected_run_id().map(str::to_owned),
             command: command.to_owned(),
             timeout_secs,
             sudo,
@@ -59,7 +63,11 @@ impl SandboxControl for FirecrackerControl {
         remote_exec_result_from_response(response)
     }
 
-    async fn kill_remote(&self, sandbox_id: &str) -> Result<RemoteKillResult, SandboxControlError> {
+    async fn kill_remote(
+        &self,
+        target: SandboxControlTarget,
+    ) -> Result<RemoteKillResult, SandboxControlError> {
+        let sandbox_id = target.sandbox_id();
         if sandbox_id.is_empty() {
             return Err(SandboxControlError::NotFound(
                 "sandbox id must not be empty".into(),
@@ -69,6 +77,7 @@ impl SandboxControl for FirecrackerControl {
         let sock_path = resolve_control_socket(sandbox_id)?;
         let request = TerminateRequest {
             action: TerminateAction::Terminate,
+            expected_run_id: target.expected_run_id().map(str::to_owned),
         };
 
         let response = send_terminate(&sock_path, &request, Duration::from_secs(5))
@@ -217,7 +226,12 @@ mod tests {
     async fn exec_remote_empty_id() {
         let control = FirecrackerControl;
         let result = control
-            .exec_remote("", "echo hi", Duration::from_secs(5), false)
+            .exec_remote(
+                SandboxControlTarget::sandbox(""),
+                "echo hi",
+                Duration::from_secs(5),
+                false,
+            )
             .await;
         let Err(e) = result else {
             panic!("expected error");
@@ -228,7 +242,7 @@ mod tests {
     #[tokio::test]
     async fn kill_remote_empty_id() {
         let control = FirecrackerControl;
-        let result = control.kill_remote("").await;
+        let result = control.kill_remote(SandboxControlTarget::sandbox("")).await;
         let Err(e) = result else {
             panic!("expected error");
         };

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -23,12 +23,13 @@ use crate::exec_operation_result::{
     validate_exec_capture_timeout,
 };
 use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
-use crate::park_coordinator::ParkCoordinator;
+use crate::park_coordinator::{ParkCoordinator, RunControlMismatch, TerminateAdmission};
 use crate::runtime_dirs::set_private_runtime_socket_mode;
 
 const RUNNER_EXEC_CAPTURE_LIMIT_BYTES: u32 = 7 * 1024 * 1024;
 const CONTROL_SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 const CONTROL_HANDLER_SHUTDOWN_GRACE: Duration = Duration::from_millis(250);
+const RUN_CONTROL_MISMATCH_ERROR: &str = "run control target is no longer assigned to this sandbox";
 
 /// Cloneable handle used by the control server to ask the process monitor to
 /// terminate the sandbox process group.
@@ -54,9 +55,14 @@ impl ProcessTerminationHandle {
         }
     }
 
-    async fn request_terminate(&self) -> TerminateStatus {
-        if !self.park_coordinator.begin_terminate() {
-            return TerminateStatus::RefusedIdle;
+    async fn request_terminate(
+        &self,
+        expected_run_id: Option<&str>,
+    ) -> Result<TerminateStatus, RunControlMismatch> {
+        match self.park_coordinator.begin_terminate(expected_run_id) {
+            TerminateAdmission::Accepted => {}
+            TerminateAdmission::RefusedIdle => return Ok(TerminateStatus::RefusedIdle),
+            TerminateAdmission::RunControlMismatch => return Err(RunControlMismatch),
         }
 
         let (ack_tx, ack_rx) = oneshot::channel();
@@ -66,10 +72,10 @@ impl ProcessTerminationHandle {
             .await
         {
             Ok(()) => match ack_rx.await {
-                Ok(()) => TerminateStatus::Accepted,
-                Err(_) => TerminateStatus::AlreadyStopped,
+                Ok(()) => Ok(TerminateStatus::Accepted),
+                Err(_) => Ok(TerminateStatus::AlreadyStopped),
             },
-            Err(_) => TerminateStatus::AlreadyStopped,
+            Err(_) => Ok(TerminateStatus::AlreadyStopped),
         }
     }
 }
@@ -408,8 +414,14 @@ async fn terminate(
     termination: &ProcessTerminationHandle,
 ) -> TerminateResponse {
     match request.action {
-        TerminateAction::Terminate => TerminateResponse::Status {
-            status: termination.request_terminate().await,
+        TerminateAction::Terminate => match termination
+            .request_terminate(request.expected_run_id.as_deref())
+            .await
+        {
+            Ok(status) => TerminateResponse::Status { status },
+            Err(RunControlMismatch) => TerminateResponse::Error {
+                error: RUN_CONTROL_MISMATCH_ERROR.into(),
+            },
         },
     }
 }
@@ -437,7 +449,13 @@ async fn execute(request: ExecRequest, guest_operations: &GuestOperationStartGat
         }
     };
 
-    let timeout_ms = request.timeout_secs.saturating_mul(1000);
+    let ExecRequest {
+        expected_run_id,
+        command,
+        timeout_secs,
+        sudo,
+    } = request;
+    let timeout_ms = timeout_secs.saturating_mul(1000);
     let env: &[(&str, &str)] = &[];
 
     if let Err(e) = validate_exec_capture_timeout(timeout_ms) {
@@ -446,19 +464,35 @@ async fn execute(request: ExecRequest, guest_operations: &GuestOperationStartGat
         };
     }
 
+    let write_admission = expected_run_id.map_or_else(vsock_host::FrameWriteObserver::default, {
+        let guest_operations = guest_operations.clone();
+        |expected_run_id| {
+            vsock_host::FrameWriteObserver::new(move || {
+                guest_operations
+                    .ensure_run_control_matches(&expected_run_id)
+                    .map_err(|RunControlMismatch| {
+                        io::Error::new(io::ErrorKind::PermissionDenied, RUN_CONTROL_MISMATCH_ERROR)
+                    })
+            })
+        }
+    });
+
     let result = vsock
-        .exec_operation_capture(vsock_host::ExecCaptureRequest {
-            command: &request.command,
-            timeout_ms,
-            env,
-            sudo: request.sudo,
-            label: "runner-exec",
-            stdout_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
-            stderr_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
-            expected_exit_codes: &[],
-            stdin_bytes: None,
-            wait_timeout: Duration::from_millis(timeout_ms as u64 + CONTROL_SOCKET_OVERHEAD_MS),
-        })
+        .exec_operation_capture_with_write_admission(
+            vsock_host::ExecCaptureRequest {
+                command: &command,
+                timeout_ms,
+                env,
+                sudo,
+                label: "runner-exec",
+                stdout_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
+                stderr_limit_bytes: RUNNER_EXEC_CAPTURE_LIMIT_BYTES,
+                expected_exit_codes: &[],
+                stdin_bytes: None,
+                wait_timeout: Duration::from_millis(timeout_ms as u64 + CONTROL_SOCKET_OVERHEAD_MS),
+            },
+            write_admission,
+        )
         .await
         .and_then(exec_response_from_operation_result);
 

--- a/crates/sandbox-fc/src/control/server/tests.rs
+++ b/crates/sandbox-fc/src/control/server/tests.rs
@@ -111,6 +111,7 @@ fn empty_guest() -> GuestState {
 
 fn exec_request(command: &str) -> ExecRequest {
     ExecRequest {
+        expected_run_id: None,
         command: command.into(),
         timeout_secs: 5,
         sudo: false,
@@ -363,6 +364,7 @@ async fn client_server_terminate_accepted() {
         async move {
             let request = TerminateRequest {
                 action: TerminateAction::Terminate,
+                expected_run_id: None,
             };
             send_terminate(&sock_path, &request, Duration::from_secs(5)).await
         }
@@ -391,6 +393,7 @@ async fn client_server_terminate_already_stopped() {
 
     let request = TerminateRequest {
         action: TerminateAction::Terminate,
+        expected_run_id: None,
     };
     let response = send_terminate(&fixture.sock_path, &request, Duration::from_secs(5))
         .await
@@ -420,6 +423,7 @@ async fn client_server_terminate_refuses_idle_sandbox() {
 
     let request = TerminateRequest {
         action: TerminateAction::Terminate,
+        expected_run_id: None,
     };
     let response = send_terminate(&fixture.sock_path, &request, Duration::from_secs(5))
         .await
@@ -440,6 +444,67 @@ async fn client_server_terminate_refuses_idle_sandbox() {
 }
 
 #[tokio::test]
+async fn stale_run_terminate_is_rejected_after_sandbox_reassignment() {
+    let fixture = ControlServerFixture::new();
+    let coordinator = ParkCoordinator::new();
+    coordinator.bind_run_control("run-a").unwrap();
+    let attempt = coordinator.begin_prepare_park().unwrap();
+    coordinator
+        .complete_prepare_park(&attempt, PrepareParkEvidence::AgentQuiesced)
+        .unwrap();
+    coordinator.mark_parked(&attempt).unwrap();
+    coordinator.bind_run_control("run-b").unwrap();
+    coordinator.reopen_after_unpark().unwrap();
+
+    let (kill_tx, mut kill_rx) = mpsc::channel(1);
+    let termination = ProcessTerminationHandle::with_park_coordinator(kill_tx, coordinator.clone());
+    let mut handle = fixture
+        .bind_with_termination(termination)
+        .unwrap()
+        .spawn(CancellationToken::new());
+
+    let stale_request = TerminateRequest {
+        action: TerminateAction::Terminate,
+        expected_run_id: Some("run-a".into()),
+    };
+    let stale_response = send_terminate(&fixture.sock_path, &stale_request, Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        stale_response,
+        TerminateResponse::Error {
+            error: RUN_CONTROL_MISMATCH_ERROR.into()
+        }
+    );
+    assert!(matches!(
+        kill_rx.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+    assert_eq!(coordinator.state(), CoordinatorState::Open);
+
+    let matching_client = tokio::spawn({
+        let sock_path = fixture.sock_path.clone();
+        async move {
+            let request = TerminateRequest {
+                action: TerminateAction::Terminate,
+                expected_run_id: Some("run-b".into()),
+            };
+            send_terminate(&sock_path, &request, Duration::from_secs(5)).await
+        }
+    });
+    recv_termination_request(&mut kill_rx).await.acknowledge();
+    assert_eq!(
+        matching_client.await.unwrap().unwrap(),
+        TerminateResponse::Status {
+            status: TerminateStatus::Accepted
+        }
+    );
+
+    handle.shutdown().await;
+}
+
+#[tokio::test]
 async fn terminate_response_survives_shutdown_after_request_is_queued() {
     let fixture = ControlServerFixture::new();
     let (kill_tx, mut kill_rx) = mpsc::channel(1);
@@ -454,6 +519,7 @@ async fn terminate_response_survives_shutdown_after_request_is_queued() {
         async move {
             let request = TerminateRequest {
                 action: TerminateAction::Terminate,
+                expected_run_id: None,
             };
             send_terminate(&sock_path, &request, Duration::from_secs(5)).await
         }
@@ -482,7 +548,7 @@ async fn termination_handle_waits_behind_full_channel() {
         .try_send(ProcessTerminationRequest::fire_and_forget())
         .unwrap();
     let termination = ProcessTerminationHandle::new(kill_tx);
-    let terminate_task = tokio::spawn(async move { termination.request_terminate().await });
+    let terminate_task = tokio::spawn(async move { termination.request_terminate(None).await });
 
     let queued_request = recv_termination_request(&mut kill_rx).await;
 
@@ -491,20 +557,20 @@ async fn termination_handle_waits_behind_full_channel() {
     let request = recv_termination_request(&mut kill_rx).await;
     assert!(!terminate_task.is_finished());
     request.acknowledge();
-    assert_eq!(terminate_task.await.unwrap(), TerminateStatus::Accepted);
+    assert_eq!(terminate_task.await.unwrap(), Ok(TerminateStatus::Accepted));
 }
 
 #[tokio::test]
 async fn termination_handle_waits_for_monitor_ack_before_accepting() {
     let (kill_tx, mut kill_rx) = mpsc::channel(1);
     let termination = ProcessTerminationHandle::new(kill_tx);
-    let terminate_task = tokio::spawn(async move { termination.request_terminate().await });
+    let terminate_task = tokio::spawn(async move { termination.request_terminate(None).await });
 
     let request = recv_termination_request(&mut kill_rx).await;
 
     assert!(!terminate_task.is_finished());
     request.acknowledge();
-    assert_eq!(terminate_task.await.unwrap(), TerminateStatus::Accepted);
+    assert_eq!(terminate_task.await.unwrap(), Ok(TerminateStatus::Accepted));
 }
 
 #[tokio::test]
@@ -512,14 +578,14 @@ async fn termination_handle_blocks_future_park_before_queueing_kill() {
     let (kill_tx, mut kill_rx) = mpsc::channel(1);
     let coordinator = ParkCoordinator::new();
     let termination = ProcessTerminationHandle::with_park_coordinator(kill_tx, coordinator.clone());
-    let terminate_task = tokio::spawn(async move { termination.request_terminate().await });
+    let terminate_task = tokio::spawn(async move { termination.request_terminate(None).await });
 
     let request = recv_termination_request(&mut kill_rx).await;
     assert_eq!(coordinator.state(), CoordinatorState::Terminating);
     assert!(coordinator.begin_prepare_park().is_err());
     assert!(!terminate_task.is_finished());
     request.acknowledge();
-    assert_eq!(terminate_task.await.unwrap(), TerminateStatus::Accepted);
+    assert_eq!(terminate_task.await.unwrap(), Ok(TerminateStatus::Accepted));
 }
 
 #[tokio::test]
@@ -528,10 +594,10 @@ async fn termination_handle_accepts_dirty_policy() {
     let coordinator = ParkCoordinator::new();
     coordinator.mark_dirty(DirtyReason::new("transport failed"));
     let termination = ProcessTerminationHandle::with_park_coordinator(kill_tx, coordinator.clone());
-    let terminate_task = tokio::spawn(async move { termination.request_terminate().await });
+    let terminate_task = tokio::spawn(async move { termination.request_terminate(None).await });
 
     recv_termination_request(&mut kill_rx).await.acknowledge();
-    assert_eq!(terminate_task.await.unwrap(), TerminateStatus::Accepted);
+    assert_eq!(terminate_task.await.unwrap(), Ok(TerminateStatus::Accepted));
     assert_eq!(coordinator.state(), CoordinatorState::Terminating);
 }
 
@@ -540,10 +606,10 @@ async fn termination_handle_accepts_ready_for_park_policy() {
     let (kill_tx, mut kill_rx) = mpsc::channel(1);
     let coordinator = ready_for_park_coordinator();
     let termination = ProcessTerminationHandle::with_park_coordinator(kill_tx, coordinator.clone());
-    let terminate_task = tokio::spawn(async move { termination.request_terminate().await });
+    let terminate_task = tokio::spawn(async move { termination.request_terminate(None).await });
 
     recv_termination_request(&mut kill_rx).await.acknowledge();
-    assert_eq!(terminate_task.await.unwrap(), TerminateStatus::Accepted);
+    assert_eq!(terminate_task.await.unwrap(), Ok(TerminateStatus::Accepted));
     assert_eq!(coordinator.state(), CoordinatorState::Terminating);
 }
 
@@ -554,8 +620,8 @@ async fn termination_handle_refuses_when_parked_without_queueing() {
         ProcessTerminationHandle::with_park_coordinator(kill_tx, parked_coordinator());
 
     assert_eq!(
-        termination.request_terminate().await,
-        TerminateStatus::RefusedIdle
+        termination.request_terminate(None).await,
+        Ok(TerminateStatus::RefusedIdle)
     );
     assert_eq!(kill_rx.len(), 0);
 }
@@ -658,6 +724,7 @@ async fn control_server_shutdown_cancels_in_flight_vsock_exec() {
         let sock_path = fixture.sock_path.clone();
         async move {
             let request = ExecRequest {
+                expected_run_id: None,
                 command: "sleep 30".into(),
                 timeout_secs: 30,
                 sudo: false,
@@ -736,6 +803,7 @@ async fn control_exec_rejects_zero_timeout_without_guest_exec() {
             .await;
     let mut handle = fixture.spawn_server();
     let request = ExecRequest {
+        expected_run_id: None,
         command: "echo should-not-run".into(),
         timeout_secs: 0,
         sudo: false,
@@ -790,6 +858,62 @@ async fn control_exec_terminal_guest_error_completes_vsock_operation() {
         .begin_prepare_park()
         .expect("terminal guest error should leave park policy open");
     fixture.coordinator.abort_prepare_park(&attempt).unwrap();
+
+    handle.shutdown().await;
+    fixture.guest_task.abort();
+    let _ = fixture.guest_task.await;
+}
+
+#[tokio::test]
+async fn stale_run_exec_is_rejected_after_sandbox_reassignment() {
+    let fixture = VsockExecFixture::connect(|vsock_base| {
+        mock_guest_errors_exec(vsock_base, "matching run reached guest")
+    })
+    .await;
+    fixture.coordinator.bind_run_control("run-a").unwrap();
+    let attempt = fixture.coordinator.begin_prepare_park().unwrap();
+    let normal_operations_fence = fixture.vsock.try_fence_normal_operations().unwrap();
+    fixture
+        .coordinator
+        .complete_prepare_park(&attempt, PrepareParkEvidence::AgentQuiesced)
+        .unwrap();
+    fixture.coordinator.mark_parked(&attempt).unwrap();
+    fixture.coordinator.bind_run_control("run-b").unwrap();
+    drop(normal_operations_fence);
+    fixture.coordinator.reopen_after_unpark().unwrap();
+    let mut handle = fixture.spawn_server();
+
+    let mut stale_request = exec_request("must-not-reach-guest");
+    stale_request.expected_run_id = Some("run-a".into());
+    let stale_response = send_exec(&fixture.sock_path, &stale_request, Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    match stale_response {
+        ExecResponse::Error { error } => {
+            assert_eq!(error, format!("exec failed: {RUN_CONTROL_MISMATCH_ERROR}"));
+            assert!(!error.contains("run-b"));
+        }
+        ExecResponse::Success { .. } => panic!("stale run exec should fail closed"),
+    }
+    assert_eq!(fixture.coordinator.state(), CoordinatorState::Open);
+    assert!(fixture.vsock.try_fence_normal_operations().is_ok());
+
+    let mut matching_request = exec_request("reach-current-run");
+    matching_request.expected_run_id = Some("run-b".into());
+    let matching_response = send_exec(
+        &fixture.sock_path,
+        &matching_request,
+        Duration::from_secs(5),
+    )
+    .await
+    .unwrap();
+    match matching_response {
+        ExecResponse::Error { error } => {
+            assert!(error.contains("matching run reached guest"), "{error}");
+        }
+        ExecResponse::Success { .. } => panic!("mock guest should reject exec"),
+    }
 
     handle.shutdown().await;
     fixture.guest_task.abort();

--- a/crates/sandbox-fc/src/guest_operations.rs
+++ b/crates/sandbox-fc/src/guest_operations.rs
@@ -8,7 +8,9 @@ use std::sync::Arc;
 
 use vsock_host::VsockHost;
 
-use crate::park_coordinator::{CoordinatorState, OperationStartRejection, ParkCoordinator};
+use crate::park_coordinator::{
+    CoordinatorState, OperationStartRejection, ParkCoordinator, RunControlMismatch,
+};
 use crate::sandbox::SandboxState;
 
 #[derive(Clone)]
@@ -57,6 +59,13 @@ impl GuestOperationStartGate {
         let guest = self.guest.lock().await.as_ref().cloned();
         self.ensure_policy_open()?;
         guest.ok_or(GuestOperationStartError::NoGuest)
+    }
+
+    pub(crate) fn ensure_run_control_matches(
+        &self,
+        expected_run_id: &str,
+    ) -> Result<(), RunControlMismatch> {
+        self.coordinator.ensure_run_control_matches(expected_run_id)
     }
 
     fn ensure_policy_open(&self) -> Result<(), GuestOperationStartError> {

--- a/crates/sandbox-fc/src/park_coordinator.rs
+++ b/crates/sandbox-fc/src/park_coordinator.rs
@@ -31,6 +31,7 @@ impl ParkCoordinator {
             inner: Arc::new(Mutex::new(Inner {
                 state: CoordinatorState::Open,
                 next_attempt_id: 1,
+                active_run_id: None,
             })),
         }
     }
@@ -43,6 +44,34 @@ impl ParkCoordinator {
         match self.inner().state.clone() {
             CoordinatorState::Open => Ok(()),
             state => Err(OperationStartRejection::GateClosed { state }),
+        }
+    }
+
+    /// Bind the full run identity before this assignment can admit controls.
+    pub(crate) fn bind_run_control(&self, run_id: &str) -> Result<(), RunControlBindError> {
+        let mut inner = self.inner();
+        if inner.active_run_id.is_some() {
+            return Err(RunControlBindError::AlreadyBound);
+        }
+
+        match inner.state.clone() {
+            CoordinatorState::Open | CoordinatorState::Parked => {
+                inner.active_run_id = Some(run_id.to_owned());
+                Ok(())
+            }
+            state => Err(RunControlBindError::InvalidState { state }),
+        }
+    }
+
+    /// Verify a guarded control target without revealing the current owner.
+    pub(crate) fn ensure_run_control_matches(
+        &self,
+        expected_run_id: &str,
+    ) -> Result<(), RunControlMismatch> {
+        if self.inner().active_run_id.as_deref() == Some(expected_run_id) {
+            Ok(())
+        } else {
+            Err(RunControlMismatch)
         }
     }
 
@@ -86,6 +115,7 @@ impl ParkCoordinator {
         match inner.state.clone() {
             CoordinatorState::ReadyForPark { attempt_id } if attempt_id == attempt.id => {
                 inner.state = CoordinatorState::Parked;
+                inner.active_run_id = None;
                 Ok(())
             }
             CoordinatorState::Dirty { reason } => Err(PrepareParkError::Dirty { reason }),
@@ -110,14 +140,18 @@ impl ParkCoordinator {
     /// Once this moves the policy to `Terminating`, future or in-flight park
     /// attempts cannot reach `Parked`, so a terminate request cannot race with
     /// the active job finalizer transferring ownership to the idle pool.
-    pub(crate) fn begin_terminate(&self) -> bool {
+    pub(crate) fn begin_terminate(&self, expected_run_id: Option<&str>) -> TerminateAdmission {
         let mut inner = self.inner();
+        if expected_run_id.is_some() && inner.active_run_id.as_deref() != expected_run_id {
+            return TerminateAdmission::RunControlMismatch;
+        }
+
         match inner.state {
-            CoordinatorState::Parked => false,
-            CoordinatorState::Terminating => true,
+            CoordinatorState::Parked => TerminateAdmission::RefusedIdle,
+            CoordinatorState::Terminating => TerminateAdmission::Accepted,
             _ => {
                 inner.state = CoordinatorState::Terminating;
-                true
+                TerminateAdmission::Accepted
             }
         }
     }
@@ -179,6 +213,22 @@ pub(crate) enum OperationStartRejection {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum RunControlBindError {
+    AlreadyBound,
+    InvalidState { state: CoordinatorState },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RunControlMismatch;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TerminateAdmission {
+    Accepted,
+    RefusedIdle,
+    RunControlMismatch,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum PrepareParkError {
     Dirty {
         reason: DirtyReason,
@@ -210,6 +260,7 @@ impl PrepareParkResolution {
 struct Inner {
     state: CoordinatorState,
     next_attempt_id: u64,
+    active_run_id: Option<String>,
 }
 
 impl Inner {
@@ -289,6 +340,62 @@ mod tests {
     }
 
     #[test]
+    fn run_control_assignment_changes_only_at_successful_park_boundary() {
+        let coordinator = ParkCoordinator::new();
+        coordinator.bind_run_control("run-a").unwrap();
+
+        assert_eq!(coordinator.ensure_run_control_matches("run-a"), Ok(()));
+        assert_eq!(
+            coordinator.bind_run_control("run-b"),
+            Err(RunControlBindError::AlreadyBound)
+        );
+
+        let aborted_attempt = begin_attempt(&coordinator);
+        coordinator.abort_prepare_park(&aborted_attempt).unwrap();
+        assert_eq!(coordinator.ensure_run_control_matches("run-a"), Ok(()));
+
+        let failed_coordinator = ParkCoordinator::new();
+        failed_coordinator.bind_run_control("run-a").unwrap();
+        let failed_attempt = begin_attempt(&failed_coordinator);
+        complete_attempt(&failed_coordinator, &failed_attempt);
+        failed_coordinator.mark_dirty(DirtyReason::new("park failed"));
+        assert_eq!(
+            failed_coordinator.ensure_run_control_matches("run-a"),
+            Ok(())
+        );
+
+        let successful_attempt = begin_attempt(&coordinator);
+        complete_attempt(&coordinator, &successful_attempt);
+        coordinator.mark_parked(&successful_attempt).unwrap();
+        assert_eq!(
+            coordinator.ensure_run_control_matches("run-a"),
+            Err(RunControlMismatch)
+        );
+
+        coordinator.bind_run_control("run-b").unwrap();
+        assert_eq!(coordinator.ensure_run_control_matches("run-b"), Ok(()));
+        coordinator.reopen_after_unpark().unwrap();
+        assert_eq!(coordinator.ensure_run_control_matches("run-b"), Ok(()));
+    }
+
+    #[test]
+    fn guarded_terminate_mismatch_does_not_change_coordinator_state() {
+        let coordinator = ParkCoordinator::new();
+        coordinator.bind_run_control("run-b").unwrap();
+
+        assert_eq!(
+            coordinator.begin_terminate(Some("run-a")),
+            TerminateAdmission::RunControlMismatch
+        );
+        assert_eq!(coordinator.state(), CoordinatorState::Open);
+        assert_eq!(
+            coordinator.begin_terminate(Some("run-b")),
+            TerminateAdmission::Accepted
+        );
+        assert_eq!(coordinator.state(), CoordinatorState::Terminating);
+    }
+
+    #[test]
     fn poisoned_mutex_marks_coordinator_dirty() {
         let coordinator = ParkCoordinator::new();
         let poisoned_coordinator = coordinator.clone();
@@ -346,7 +453,10 @@ mod tests {
         );
 
         let terminating = ParkCoordinator::new();
-        assert!(terminating.begin_terminate());
+        assert_eq!(
+            terminating.begin_terminate(None),
+            TerminateAdmission::Accepted
+        );
         assert_eq!(
             terminating.ensure_operation_start_allowed(),
             Err(OperationStartRejection::GateClosed {
@@ -594,8 +704,14 @@ mod tests {
     fn terminate_blocks_future_park_attempts() {
         let coordinator = ParkCoordinator::new();
 
-        assert!(coordinator.begin_terminate());
-        assert!(coordinator.begin_terminate());
+        assert_eq!(
+            coordinator.begin_terminate(None),
+            TerminateAdmission::Accepted
+        );
+        assert_eq!(
+            coordinator.begin_terminate(None),
+            TerminateAdmission::Accepted
+        );
         assert_eq!(coordinator.state(), CoordinatorState::Terminating);
 
         assert_eq!(
@@ -611,7 +727,10 @@ mod tests {
         let coordinator = ParkCoordinator::new();
         let attempt = begin_attempt(&coordinator);
 
-        assert!(coordinator.begin_terminate());
+        assert_eq!(
+            coordinator.begin_terminate(None),
+            TerminateAdmission::Accepted
+        );
         assert_eq!(coordinator.state(), CoordinatorState::Terminating);
 
         assert_eq!(
@@ -629,7 +748,10 @@ mod tests {
         let attempt = begin_attempt(&coordinator);
         complete_attempt(&coordinator, &attempt);
 
-        assert!(coordinator.begin_terminate());
+        assert_eq!(
+            coordinator.begin_terminate(None),
+            TerminateAdmission::Accepted
+        );
         assert_eq!(coordinator.state(), CoordinatorState::Terminating);
         assert_eq!(
             coordinator.mark_parked(&attempt),
@@ -646,7 +768,10 @@ mod tests {
         complete_attempt(&coordinator, &attempt);
         coordinator.mark_parked(&attempt).unwrap();
 
-        assert!(!coordinator.begin_terminate());
+        assert_eq!(
+            coordinator.begin_terminate(None),
+            TerminateAdmission::RefusedIdle
+        );
         assert_eq!(coordinator.state(), CoordinatorState::Parked);
     }
 
@@ -655,7 +780,10 @@ mod tests {
         let coordinator = ParkCoordinator::new();
         coordinator.mark_dirty(DirtyReason::new("transport failed"));
 
-        assert!(coordinator.begin_terminate());
+        assert_eq!(
+            coordinator.begin_terminate(None),
+            TerminateAdmission::Accepted
+        );
         assert_eq!(coordinator.state(), CoordinatorState::Terminating);
     }
 
@@ -663,7 +791,10 @@ mod tests {
     fn dirty_does_not_override_terminating() {
         let coordinator = ParkCoordinator::new();
 
-        assert!(coordinator.begin_terminate());
+        assert_eq!(
+            coordinator.begin_terminate(None),
+            TerminateAdmission::Accepted
+        );
         coordinator.mark_dirty(DirtyReason::new("late park failure"));
 
         assert_eq!(coordinator.state(), CoordinatorState::Terminating);
@@ -686,7 +817,7 @@ mod tests {
             let terminate_barrier = std::sync::Arc::clone(&barrier);
             let terminate_thread = std::thread::spawn(move || {
                 terminate_barrier.wait();
-                terminate_coordinator.begin_terminate()
+                terminate_coordinator.begin_terminate(None)
             });
 
             let prepare_result = prepare_thread
@@ -697,7 +828,7 @@ mod tests {
                 .expect("terminate thread should not panic");
 
             match (prepare_result, terminate_result) {
-                (Ok(attempt), true) => {
+                (Ok(attempt), TerminateAdmission::Accepted) => {
                     assert_eq!(coordinator.state(), CoordinatorState::Terminating);
                     assert_eq!(
                         coordinator
@@ -712,7 +843,7 @@ mod tests {
                     Err(PrepareParkError::InvalidState {
                         state: CoordinatorState::Terminating,
                     }),
-                    true,
+                    TerminateAdmission::Accepted,
                 ) => {
                     assert_eq!(coordinator.state(), CoordinatorState::Terminating);
                 }

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -50,7 +50,7 @@ use crate::leaked_resources::LeakedResources;
 use crate::network::{NetnsInfo, NetnsLease};
 use crate::park_coordinator::{
     CoordinatorState, DirtyReason, OperationStartRejection, ParkAttempt, ParkCoordinator,
-    PrepareParkError, PrepareParkEvidence,
+    PrepareParkError, PrepareParkEvidence, RunControlBindError,
 };
 use crate::paths::{SandboxPaths, SockPaths};
 use crate::process::{ChildExitNotifier, kill_process_group};
@@ -1813,6 +1813,40 @@ impl Sandbox for FirecrackerSandbox {
 
     fn host_process_pid(&self) -> Option<u32> {
         self.process_group_pid
+    }
+
+    fn bind_run_control(&mut self, run_id: &str) -> sandbox::Result<()> {
+        if run_id.is_empty() {
+            return Err(SandboxError::Configuration {
+                message: "run control identity must not be empty".into(),
+            });
+        }
+
+        let sandbox_state = self.current_state();
+        let valid_boundary = (sandbox_state == SandboxState::Created && !self.is_parked)
+            || (sandbox_state == SandboxState::Running && self.is_parked);
+        if !valid_boundary {
+            return Err(SandboxError::InvalidState {
+                context: SandboxInvalidStateContext::Sandbox,
+                state: sandbox_state.to_string(),
+                message: "run control identity must be bound before start or while parked".into(),
+            });
+        }
+
+        self.park_coordinator
+            .bind_run_control(run_id)
+            .map_err(|error| match error {
+                RunControlBindError::AlreadyBound => SandboxError::InvalidState {
+                    context: SandboxInvalidStateContext::Sandbox,
+                    state: format!("{:?}", self.park_coordinator.state()),
+                    message: "run control identity is already bound".into(),
+                },
+                RunControlBindError::InvalidState { state } => SandboxError::InvalidState {
+                    context: SandboxInvalidStateContext::Sandbox,
+                    state: format!("{state:?}"),
+                    message: "run control identity cannot be bound at this lifecycle state".into(),
+                },
+            })
     }
 
     // -- lifecycle --

--- a/crates/sandbox-mock/src/call_records.rs
+++ b/crates/sandbox-mock/src/call_records.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use ::sandbox::{ExecOutputLimits, ProcessControlMode, ProcessOutputMode};
+use ::sandbox::{ExecOutputLimits, ProcessControlMode, ProcessOutputMode, SandboxControlTarget};
 
 /// Behavior override applied to exec calls whose command contains the pattern.
 ///
@@ -22,8 +22,8 @@ pub struct ExecMatcher {
 /// Captured `exec_remote` call fields recorded for test assertions.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RemoteExecCall {
-    /// Sandbox identifier passed to `SandboxControl::exec_remote`.
-    pub sandbox_id: String,
+    /// Identity scope passed to `SandboxControl::exec_remote`.
+    pub target: SandboxControlTarget,
     /// Command string passed to `SandboxControl::exec_remote`.
     pub command: String,
     /// Timeout passed to `SandboxControl::exec_remote`.

--- a/crates/sandbox-mock/src/control.rs
+++ b/crates/sandbox-mock/src/control.rs
@@ -19,7 +19,7 @@ pub struct MockSandboxControl {
     exec_results: Mutex<VecDeque<std::result::Result<RemoteExecResult, SandboxControlError>>>,
     kill_results: Mutex<VecDeque<std::result::Result<RemoteKillResult, SandboxControlError>>>,
     recorded_exec_calls: Mutex<Vec<RemoteExecCall>>,
-    recorded_kill_ids: Mutex<Vec<String>>,
+    recorded_kill_targets: Mutex<Vec<SandboxControlTarget>>,
 }
 
 impl MockSandboxControl {
@@ -37,7 +37,7 @@ impl MockSandboxControl {
             exec_results: Mutex::new(VecDeque::new()),
             kill_results: Mutex::new(VecDeque::new()),
             recorded_exec_calls: Mutex::new(Vec::new()),
-            recorded_kill_ids: Mutex::new(Vec::new()),
+            recorded_kill_targets: Mutex::new(Vec::new()),
         }
     }
 
@@ -71,9 +71,9 @@ impl MockSandboxControl {
         self.kill_results.lock_ignoring_poison().push_back(result);
     }
 
-    /// Return every sandbox id passed to `kill_remote`, in call order.
-    pub fn recorded_kill_ids(&self) -> Vec<String> {
-        self.recorded_kill_ids.lock_ignoring_poison().clone()
+    /// Return every identity scope passed to `kill_remote`, in call order.
+    pub fn recorded_kill_targets(&self) -> Vec<SandboxControlTarget> {
+        self.recorded_kill_targets.lock_ignoring_poison().clone()
     }
 }
 
@@ -81,7 +81,7 @@ impl MockSandboxControl {
 impl SandboxControl for MockSandboxControl {
     async fn exec_remote(
         &self,
-        sandbox_id: &str,
+        target: SandboxControlTarget,
         command: &str,
         timeout: Duration,
         sudo: bool,
@@ -89,7 +89,7 @@ impl SandboxControl for MockSandboxControl {
         self.recorded_exec_calls
             .lock_ignoring_poison()
             .push(RemoteExecCall {
-                sandbox_id: sandbox_id.to_string(),
+                target,
                 command: command.to_string(),
                 timeout,
                 sudo,
@@ -111,11 +111,11 @@ impl SandboxControl for MockSandboxControl {
 
     async fn kill_remote(
         &self,
-        sandbox_id: &str,
+        target: SandboxControlTarget,
     ) -> std::result::Result<RemoteKillResult, SandboxControlError> {
-        self.recorded_kill_ids
+        self.recorded_kill_targets
             .lock_ignoring_poison()
-            .push(sandbox_id.to_string());
+            .push(target);
         self.kill_results
             .lock_ignoring_poison()
             .pop_front()

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -47,6 +47,12 @@ pub(crate) struct FileOverrideState {
 
 #[derive(Default)]
 pub(crate) struct LifecycleOverrideState {
+    /// Full run IDs passed to `bind_run_control`, in call order.
+    pub(crate) run_control_bind_calls: Mutex<Vec<String>>,
+    /// Assignment visible when `start` was entered.
+    pub(crate) start_run_control_ids: Mutex<Vec<Option<String>>>,
+    /// Assignment visible when `unpark` was entered.
+    pub(crate) unpark_run_control_ids: Mutex<Vec<Option<String>>>,
     /// FIFO queue of start results consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
     pub(crate) start_results: Mutex<VecDeque<Result<()>>>,
@@ -395,6 +401,30 @@ impl MockSandboxOverrides {
             .start_results
             .lock_ignoring_poison()
             .push_back(result);
+    }
+
+    /// Return full run identities bound across all mock sandboxes.
+    pub fn run_control_bind_calls(&self) -> Vec<String> {
+        self.lifecycle
+            .run_control_bind_calls
+            .lock_ignoring_poison()
+            .clone()
+    }
+
+    /// Return the assignment visible at each sandbox start.
+    pub fn start_run_control_ids(&self) -> Vec<Option<String>> {
+        self.lifecycle
+            .start_run_control_ids
+            .lock_ignoring_poison()
+            .clone()
+    }
+
+    /// Return the assignment visible at each sandbox unpark.
+    pub fn unpark_run_control_ids(&self) -> Vec<Option<String>> {
+        self.lifecycle
+            .unpark_run_control_ids
+            .lock_ignoring_poison()
+            .clone()
     }
 
     /// Queue a `stop()` result applied to the next factory-created sandbox.

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -32,6 +32,7 @@ use crate::support::{
 pub struct MockSandbox {
     id: String,
     source_ip: String,
+    run_control_id: Option<String>,
     exec_results: Mutex<VecDeque<Result<ExecResult>>>,
     exec_calls: Mutex<Vec<ExecCall>>,
     read_file_results: Mutex<VecDeque<Result<Option<Vec<u8>>>>>,
@@ -72,6 +73,7 @@ impl MockSandbox {
         Self {
             id: id.into(),
             source_ip: "10.0.0.1".into(),
+            run_control_id: None,
             exec_results: Mutex::new(VecDeque::new()),
             exec_calls: Mutex::new(Vec::new()),
             read_file_results: Mutex::new(VecDeque::new()),
@@ -279,10 +281,33 @@ impl Sandbox for MockSandbox {
         &self.source_ip
     }
 
+    fn bind_run_control(&mut self, run_id: &str) -> Result<()> {
+        if self.run_control_id.is_some() {
+            return Err(SandboxError::InvalidState {
+                context: SandboxInvalidStateContext::Sandbox,
+                state: "active".into(),
+                message: "run control identity is already bound".into(),
+            });
+        }
+        self.run_control_id = Some(run_id.to_owned());
+        if let Some(overrides) = &self.overrides {
+            overrides
+                .lifecycle
+                .run_control_bind_calls
+                .lock_ignoring_poison()
+                .push(run_id.to_owned());
+        }
+        Ok(())
+    }
+
     async fn start(&mut self) -> Result<()> {
         let Some(o) = &self.overrides else {
             return Ok(());
         };
+        o.lifecycle
+            .start_run_control_ids
+            .lock_ignoring_poison()
+            .push(self.run_control_id.clone());
         o.lifecycle
             .start_results
             .lock_ignoring_poison()
@@ -308,14 +333,19 @@ impl Sandbox for MockSandbox {
     /// is side-effect-free; tests that need to exercise non-idempotent
     /// scenarios queue explicit results.
     async fn park(&mut self) -> Result<SandboxParkOutcome> {
-        let Some(o) = &self.overrides else {
-            return Ok(SandboxParkOutcome::Reusable);
+        let result = if let Some(o) = &self.overrides {
+            *o.lifecycle.park_calls.lock_ignoring_poison() += 1;
+            wait_lifecycle_gate(&o.lifecycle.park_gate).await;
+            o.lifecycle
+                .park_behaviors
+                .next_result(SandboxParkOutcome::Reusable)
+        } else {
+            Ok(SandboxParkOutcome::Reusable)
         };
-        *o.lifecycle.park_calls.lock_ignoring_poison() += 1;
-        wait_lifecycle_gate(&o.lifecycle.park_gate).await;
-        o.lifecycle
-            .park_behaviors
-            .next_result(SandboxParkOutcome::Reusable)
+        if result.is_ok() {
+            self.run_control_id = None;
+        }
+        result
     }
 
     async fn final_exec_and_park(
@@ -341,6 +371,10 @@ impl Sandbox for MockSandbox {
         let Some(o) = &self.overrides else {
             return Ok(());
         };
+        o.lifecycle
+            .unpark_run_control_ids
+            .lock_ignoring_poison()
+            .push(self.run_control_id.clone());
         *o.lifecycle.unpark_calls.lock_ignoring_poison() += 1;
         o.lifecycle.unpark_behaviors.next_result(())
     }

--- a/crates/sandbox-mock/src/tests/control.rs
+++ b/crates/sandbox-mock/src/tests/control.rs
@@ -4,12 +4,20 @@ use super::*;
 async fn sandbox_control_default_succeeds() {
     let control = MockSandboxControl::new("/tmp/test");
     let result = control
-        .exec_remote("sandbox-1", "echo hi", Duration::from_secs(5), false)
+        .exec_remote(
+            SandboxControlTarget::sandbox("sandbox-1"),
+            "echo hi",
+            Duration::from_secs(5),
+            false,
+        )
         .await
         .unwrap();
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
     assert_eq!(
-        control.kill_remote("sandbox-1").await.unwrap(),
+        control
+            .kill_remote(SandboxControlTarget::sandbox("sandbox-1"))
+            .await
+            .unwrap(),
         RemoteKillResult::Accepted
     );
     assert_eq!(
@@ -22,11 +30,21 @@ async fn sandbox_control_default_succeeds() {
 async fn sandbox_control_records_exec_calls() {
     let control = MockSandboxControl::new("/tmp/test");
     control
-        .exec_remote("sandbox-1", "echo one", Duration::from_secs(5), false)
+        .exec_remote(
+            SandboxControlTarget::sandbox("sandbox-1"),
+            "echo one",
+            Duration::from_secs(5),
+            false,
+        )
         .await
         .unwrap();
     control
-        .exec_remote("sandbox-2", "echo two", Duration::from_secs(7), true)
+        .exec_remote(
+            SandboxControlTarget::run("run-2", "sandbox-2"),
+            "echo two",
+            Duration::from_secs(7),
+            true,
+        )
         .await
         .unwrap();
 
@@ -34,13 +52,13 @@ async fn sandbox_control_records_exec_calls() {
         control.recorded_exec_calls(),
         vec![
             RemoteExecCall {
-                sandbox_id: "sandbox-1".to_string(),
+                target: SandboxControlTarget::sandbox("sandbox-1"),
                 command: "echo one".to_string(),
                 timeout: Duration::from_secs(5),
                 sudo: false,
             },
             RemoteExecCall {
-                sandbox_id: "sandbox-2".to_string(),
+                target: SandboxControlTarget::run("run-2", "sandbox-2"),
                 command: "echo two".to_string(),
                 timeout: Duration::from_secs(7),
                 sudo: true,
@@ -54,14 +72,23 @@ async fn sandbox_control_records_exec_calls() {
 }
 
 #[tokio::test]
-async fn sandbox_control_records_kill_ids() {
+async fn sandbox_control_records_kill_targets() {
     let control = MockSandboxControl::new("/tmp/test");
-    control.kill_remote("sandbox-1").await.unwrap();
-    control.kill_remote("sandbox-2").await.unwrap();
+    control
+        .kill_remote(SandboxControlTarget::sandbox("sandbox-1"))
+        .await
+        .unwrap();
+    control
+        .kill_remote(SandboxControlTarget::run("run-2", "sandbox-2"))
+        .await
+        .unwrap();
 
     assert_eq!(
-        control.recorded_kill_ids(),
-        vec!["sandbox-1".to_string(), "sandbox-2".to_string()],
+        control.recorded_kill_targets(),
+        vec![
+            SandboxControlTarget::sandbox("sandbox-1"),
+            SandboxControlTarget::run("run-2", "sandbox-2"),
+        ],
     );
 }
 
@@ -71,13 +98,23 @@ async fn sandbox_control_queued_results() {
     control.push_exec_remote_result(Err(SandboxControlError::NotFound("gone".into())));
 
     let result = control
-        .exec_remote("sandbox-1", "test", Duration::from_secs(5), false)
+        .exec_remote(
+            SandboxControlTarget::sandbox("sandbox-1"),
+            "test",
+            Duration::from_secs(5),
+            false,
+        )
         .await;
     assert!(result.is_err());
 
     // Falls back to default.
     let result = control
-        .exec_remote("sandbox-1", "test", Duration::from_secs(5), false)
+        .exec_remote(
+            SandboxControlTarget::sandbox("sandbox-1"),
+            "test",
+            Duration::from_secs(5),
+            false,
+        )
         .await
         .unwrap();
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
@@ -88,11 +125,16 @@ async fn sandbox_control_queued_kill_results() {
     let control = MockSandboxControl::new("/tmp/test");
     control.push_kill_remote_result(Err(SandboxControlError::NotFound("gone".into())));
 
-    let result = control.kill_remote("sandbox-1").await;
+    let result = control
+        .kill_remote(SandboxControlTarget::sandbox("sandbox-1"))
+        .await;
     assert!(result.is_err());
 
     assert_eq!(
-        control.kill_remote("sandbox-1").await.unwrap(),
+        control
+            .kill_remote(SandboxControlTarget::sandbox("sandbox-1"))
+            .await
+            .unwrap(),
         RemoteKillResult::Accepted
     );
 }

--- a/crates/sandbox/src/control.rs
+++ b/crates/sandbox/src/control.rs
@@ -5,6 +5,59 @@ use async_trait::async_trait;
 
 use crate::types::ExecTermination;
 
+/// Identity scope for a remote sandbox control operation.
+///
+/// Sandbox-scoped targets intentionally follow the current owner of a sandbox.
+/// Run-scoped targets additionally require the sandbox to still be assigned to
+/// the full run ID resolved by the caller.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SandboxControlTarget {
+    /// Control whichever active workload currently owns this sandbox.
+    Sandbox {
+        /// Sandbox identifier (full UUID or unique prefix).
+        sandbox_id: String,
+    },
+    /// Control this sandbox only while it remains assigned to the expected run.
+    Run {
+        /// Full run identifier resolved before dispatch.
+        run_id: String,
+        /// Sandbox identifier (full UUID or unique prefix).
+        sandbox_id: String,
+    },
+}
+
+impl SandboxControlTarget {
+    /// Construct an explicitly sandbox-scoped target.
+    pub fn sandbox(sandbox_id: impl Into<String>) -> Self {
+        Self::Sandbox {
+            sandbox_id: sandbox_id.into(),
+        }
+    }
+
+    /// Construct a run-scoped target with its full resolved run identity.
+    pub fn run(run_id: impl Into<String>, sandbox_id: impl Into<String>) -> Self {
+        Self::Run {
+            run_id: run_id.into(),
+            sandbox_id: sandbox_id.into(),
+        }
+    }
+
+    /// Return the sandbox identifier used for backend endpoint resolution.
+    pub fn sandbox_id(&self) -> &str {
+        match self {
+            Self::Sandbox { sandbox_id } | Self::Run { sandbox_id, .. } => sandbox_id,
+        }
+    }
+
+    /// Return the expected full run identity for guarded targets.
+    pub fn expected_run_id(&self) -> Option<&str> {
+        match self {
+            Self::Sandbox { .. } => None,
+            Self::Run { run_id, .. } => Some(run_id),
+        }
+    }
+}
+
 /// Result of executing a command inside a running sandbox.
 #[derive(Debug)]
 pub struct RemoteExecResult {
@@ -55,22 +108,24 @@ pub enum SandboxControlError {
 /// without exposing backend-specific types (sockets, paths, wire protocol).
 #[async_trait]
 pub trait SandboxControl: Send + Sync {
-    /// Execute a command inside a running sandbox identified by sandbox ID
-    /// (full UUID or unique prefix).
+    /// Execute a command inside a running sandbox using the requested identity
+    /// scope.
     ///
     /// `timeout` is the command timeout; the implementation may add extra
     /// time for connection overhead.
     async fn exec_remote(
         &self,
-        sandbox_id: &str,
+        target: SandboxControlTarget,
         command: &str,
         timeout: Duration,
         sudo: bool,
     ) -> Result<RemoteExecResult, SandboxControlError>;
 
-    /// Request host-side termination of a running sandbox identified by
-    /// sandbox ID (full UUID or unique prefix).
-    async fn kill_remote(&self, sandbox_id: &str) -> Result<RemoteKillResult, SandboxControlError>;
+    /// Request host-side termination using the requested identity scope.
+    async fn kill_remote(
+        &self,
+        target: SandboxControlTarget,
+    ) -> Result<RemoteKillResult, SandboxControlError>;
 
     /// Return the runtime socket directory for a given sandbox ID.
     ///

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -31,7 +31,9 @@ pub use config::{
     RuntimeConfig, SandboxConfig, SandboxId, SnapshotRef, WorkspaceDriveConfig,
     WorkspaceDriveSeedImage,
 };
-pub use control::{RemoteExecResult, RemoteKillResult, SandboxControl, SandboxControlError};
+pub use control::{
+    RemoteExecResult, RemoteKillResult, SandboxControl, SandboxControlError, SandboxControlTarget,
+};
 pub use error::{
     Result, SandboxError, SandboxGuestDnsReadinessReason, SandboxIdleTransition,
     SandboxInitializationPhase, SandboxInvalidStateContext, SandboxOperation,

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -166,6 +166,17 @@ pub trait Sandbox: Send + Sync + Any {
         None
     }
 
+    /// Bind the opaque full run identity used to guard remote run-scoped
+    /// controls for this sandbox assignment.
+    ///
+    /// Lifecycle owners must call this before a fresh sandbox starts serving
+    /// controls and while a reused sandbox is still parked, before unpark.
+    /// Providers without assignment-aware out-of-process controls may retain
+    /// this no-op implementation.
+    fn bind_run_control(&mut self, _run_id: &str) -> Result<()> {
+        Ok(())
+    }
+
     // -- lifecycle --
 
     /// Boot the guest and make the sandbox ready to serve operations.

--- a/crates/vsock-host/src/exec_operation/frame.rs
+++ b/crates/vsock-host/src/exec_operation/frame.rs
@@ -218,16 +218,22 @@ pub(in crate::exec_operation) async fn write_exec_start_frame(
     payload: &[u8],
     diagnostic: &ExecOperationDiagnostic,
     tracks_normal_operation: bool,
+    write_admission: FrameWriteObserver,
     write_observer: FrameWriteObserver,
 ) -> io::Result<()> {
-    write_frame(
+    write_frame_with_pre_write(
         shared,
         MSG_EXEC_START,
         seq,
         payload,
         Some(diagnostic.frame("start")),
-        tracks_normal_operation.then_some(seq),
-        write_observer,
+        || {
+            write_admission.record_write_start()?;
+            if tracks_normal_operation {
+                mark_exec_operation_possible_guest_write(shared, seq)?;
+            }
+            write_observer.record_write_start()
+        },
     )
     .await
 }

--- a/crates/vsock-host/src/exec_operation/mod.rs
+++ b/crates/vsock-host/src/exec_operation/mod.rs
@@ -23,6 +23,7 @@ pub(crate) use dispatch::dispatch_incoming_frame;
 pub(crate) use handle::ExecOperationCancelOnDropGuard;
 pub(crate) use start::{
     append_diagnostic, exec_operation_capture_on_shared,
+    exec_operation_capture_on_shared_with_write_admission,
     exec_operation_capture_on_shared_with_write_observer,
     exec_operation_capture_with_composite_on_shared_and_observer,
     exec_operation_cleanup_untracked_on_shared_with_write_observer,

--- a/crates/vsock-host/src/exec_operation/start.rs
+++ b/crates/vsock-host/src/exec_operation/start.rs
@@ -73,6 +73,23 @@ async fn start_exec_operation_on_shared_with_tracking(
     tracking: ExecOperationTracking<'_>,
     write_observer: FrameWriteObserver,
 ) -> io::Result<(ExecOperationHandle, Instant)> {
+    start_exec_operation_on_shared_with_tracking_and_admission(
+        shared,
+        request,
+        tracking,
+        FrameWriteObserver::default(),
+        write_observer,
+    )
+    .await
+}
+
+async fn start_exec_operation_on_shared_with_tracking_and_admission(
+    shared: &Arc<Shared>,
+    request: ExecOperationRequest<'_>,
+    tracking: ExecOperationTracking<'_>,
+    write_admission: FrameWriteObserver,
+    write_observer: FrameWriteObserver,
+) -> io::Result<(ExecOperationHandle, Instant)> {
     if request.timeout_ms == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -131,6 +148,7 @@ async fn start_exec_operation_on_shared_with_tracking(
             &payload,
             &diagnostic,
             tracks_normal_operation,
+            write_admission,
             write_observer,
         ),
     )
@@ -251,6 +269,7 @@ where
             &diagnostic,
             tracks_normal_operation,
             FrameWriteObserver::default(),
+            FrameWriteObserver::default(),
         ),
     )
     .await
@@ -361,13 +380,45 @@ pub(crate) async fn exec_operation_capture_on_shared_with_write_observer(
     .await
 }
 
+pub(crate) async fn exec_operation_capture_on_shared_with_write_admission(
+    shared: &Arc<Shared>,
+    request: ExecCaptureRequest<'_>,
+    write_admission: FrameWriteObserver,
+) -> io::Result<ExecOperationResult> {
+    exec_operation_capture_on_shared_with_tracking_and_admission(
+        shared,
+        request,
+        ExecOperationTracking::Tracked,
+        write_admission,
+        FrameWriteObserver::default(),
+    )
+    .await
+}
+
 async fn exec_operation_capture_on_shared_with_tracking(
     shared: &Arc<Shared>,
     request: ExecCaptureRequest<'_>,
     tracking: ExecOperationTracking<'_>,
     write_observer: FrameWriteObserver,
 ) -> io::Result<ExecOperationResult> {
-    let (handle, deadline) = start_exec_operation_on_shared_with_tracking(
+    exec_operation_capture_on_shared_with_tracking_and_admission(
+        shared,
+        request,
+        tracking,
+        FrameWriteObserver::default(),
+        write_observer,
+    )
+    .await
+}
+
+async fn exec_operation_capture_on_shared_with_tracking_and_admission(
+    shared: &Arc<Shared>,
+    request: ExecCaptureRequest<'_>,
+    tracking: ExecOperationTracking<'_>,
+    write_admission: FrameWriteObserver,
+    write_observer: FrameWriteObserver,
+) -> io::Result<ExecOperationResult> {
+    let (handle, deadline) = start_exec_operation_on_shared_with_tracking_and_admission(
         shared,
         ExecOperationRequest {
             timeout_ms: request.timeout_ms,
@@ -387,6 +438,7 @@ async fn exec_operation_capture_on_shared_with_tracking(
             start_write_timeout: request.wait_timeout,
         },
         tracking,
+        write_admission,
         write_observer,
     )
     .await?;

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -350,6 +350,26 @@ impl VsockHost {
         exec_operation::exec_operation_capture_on_shared(&self.shared, request).await
     }
 
+    /// Run a capture-only exec operation with a synchronous admission check at
+    /// the first guest-write boundary.
+    ///
+    /// The normal-operation token is reserved before the admission check runs.
+    /// If the check rejects the request, no frame bytes are written and the
+    /// unused reservation is released without making the connection
+    /// unparkable.
+    pub async fn exec_operation_capture_with_write_admission(
+        &self,
+        request: ExecCaptureRequest<'_>,
+        write_admission: FrameWriteObserver,
+    ) -> io::Result<ExecOperationResult> {
+        exec_operation::exec_operation_capture_on_shared_with_write_admission(
+            &self.shared,
+            request,
+            write_admission,
+        )
+        .await
+    }
+
     /// Atomically reserve one final normal operation and fence every competing
     /// normal operation while running a capture exec.
     ///

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -9,9 +9,9 @@ use vsock_proto::{ExecTermination, MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_START};
 
 use super::super::support::{
     assert_connection_accepts_exec_operation, captured_output_bytes, exec_capture_default,
-    exec_capture_with_write_observer, host_from_stream, is_connected, make_pair, mock_handshake,
-    normal_operation_readiness, operation_count, read_guest_message, send_exec_result,
-    setup_host_and_guest, wait_for_operation_count,
+    exec_capture_with_write_admission, exec_capture_with_write_observer, host_from_stream,
+    is_connected, make_pair, mock_handshake, normal_operation_readiness, operation_count,
+    read_guest_message, send_exec_result, setup_host_and_guest, wait_for_operation_count,
 };
 use super::start_capture_operation;
 use crate::exec_operation as exec_operation_impl;
@@ -350,6 +350,33 @@ async fn exec_write_observer_error_cleans_registration_without_sending_frame() {
     assert_eq!(
         normal_operation_readiness(&host),
         NormalOperationReadiness::NotParkable
+    );
+    assert!(is_connected(&host));
+}
+
+#[tokio::test]
+async fn exec_write_admission_error_releases_unused_reservation_without_sending_frame() {
+    let (host, guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+
+    let err = exec_capture_with_write_admission(
+        &host,
+        capture_request("admission-error"),
+        FrameWriteObserver::new(|| Err(io::Error::other("admission failed"))),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(err.to_string().contains("admission failed"));
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("admission error must not send exec frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after admission error: {err}"),
+    }
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
     );
     assert!(is_connected(&host));
 }

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -233,6 +233,15 @@ pub(crate) async fn exec_capture_with_write_observer(
     .await
 }
 
+pub(crate) async fn exec_capture_with_write_admission(
+    host: &VsockHost,
+    request: ExecCaptureRequest<'_>,
+    write_admission: FrameWriteObserver,
+) -> io::Result<ExecOperationResult> {
+    host.exec_operation_capture_with_write_admission(request, write_admission)
+        .await
+}
+
 pub(crate) fn captured_output_bytes(output: &ExecOwnedCapturedOutput) -> &[u8] {
     match output {
         ExecOwnedCapturedOutput::Captured { bytes, .. } => bytes,


### PR DESCRIPTION
## Summary

- preserve the full run identity when `runner exec --run` and `runner kill --run` resolve a sandbox
- bind each fresh or reused sandbox assignment before it can serve controls
- reject stale run-scoped exec and terminate requests atomically at their guest-write or termination admission boundaries
- fail closed instead of sending an unguarded orphan signal when a run-scoped kill loses its owning runner
- keep direct `--sandbox` controls and explicit orphan cleanup intentionally sandbox-scoped

## Compatibility

- old control clients omit `expected_run_id`, so new servers retain existing sandbox-scoped behavior
- guarded requests sent to an old server fail closed because the old protocol rejects unknown fields
- no guest protocol, public API, database schema, migration, or persisted-data changes

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p sandbox -p sandbox-mock -p vsock-host -p sandbox-fc -p runner --all-targets --all-features`
- `cargo clippy -p sandbox -p sandbox-mock -p vsock-host -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox -p sandbox-mock -p vsock-host -p sandbox-fc -p runner --no-deps --all-features`
- `cargo test -p sandbox -p sandbox-mock -p vsock-host -p sandbox-fc -p runner --all-targets --all-features`
- `cargo test -p runner --bin runner --all-features cmd::kill`

Closes #24821
