### PR TITLE
docs(python): clarify request stream ownership contract

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -135,18 +135,23 @@ Response streaming
 Request streaming
 -----------------
 - ``REQUEST_STREAM_BUFFER``: capped ``bytearray`` written by
-  ``requestheaders()`` via request streaming setup for stream-safe body
-  capture paths. Read by request body capture and connector billing refinement.
-  Removed by stream cleanup after terminal hooks.
+  ``requestheaders()`` only when this module installs its callback with body
+  capture enabled. A setup attempt that finds an externally owned callable does
+  not create this buffer; repeated vm0 setup preserves the existing buffer. Read
+  by request body capture and connector billing refinement. Removed by stream
+  cleanup after terminal hooks.
 - ``REQUEST_STREAM_BUFFER_STATE``: ``dict`` with at least ``truncated`` and
-  ``total_bytes``. Always written by request streaming setup and read for
-  request size. Capture-enabled paths also write ``REQUEST_STREAM_BUFFER`` and
-  use this state for capture truncation and connector billing refinement.
-  Removed by stream cleanup.
+  ``total_bytes``. Written only when this module installs its callback and read
+  for request size. A setup attempt that finds an externally owned callable does
+  not create this state; repeated vm0 setup preserves existing state.
+  Capture-enabled paths also write ``REQUEST_STREAM_BUFFER`` and use this state
+  for capture truncation and connector billing refinement. Removed by stream
+  cleanup.
 - ``REQUEST_STREAM_COMPLETE``: ``bool`` written by ``request()`` after
-  mitmproxy has delivered the full streamed request body to the addon. Read by
-  connector billing before treating a non-truncated request stream buffer as a
-  complete request body. Removed by stream cleanup.
+  mitmproxy finishes delivering a request whose stream size is tracked by this
+  module. An externally owned stream is not marked complete by this mechanism.
+  Read by connector billing before treating a non-truncated request stream
+  buffer as a complete request body. Removed by stream cleanup.
 
 Model-provider usage
 --------------------

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -149,9 +149,10 @@ Request streaming
   cleanup.
 - ``REQUEST_STREAM_COMPLETE``: ``bool`` written by ``request()`` after
   mitmproxy finishes delivering a request whose stream size is tracked by this
-  module. An externally owned stream is not marked complete by this mechanism.
-  Read by connector billing before treating a non-truncated request stream
-  buffer as a complete request body. Removed by stream cleanup.
+  module. The external-callable no-op path provides no vm0 stream state from
+  which to establish this marker. Read by connector billing before treating a
+  non-truncated request stream buffer as a complete request body. Removed by
+  stream cleanup.
 
 Model-provider usage
 --------------------

--- a/crates/runner/mitm-addon/src/request_streaming.py
+++ b/crates/runner/mitm-addon/src/request_streaming.py
@@ -1,9 +1,14 @@
 """Shared request streaming state for size, capture logging, and X billing.
 
-The callback always counts pass-through bytes. Capture-enabled callers also
-retain a capped prefix consumed by network capture and X connector billing
-refinement. Terminal response and error handling retain the applicable metadata
-through connector usage reporting, then release it.
+When this module installs its pass-through callback, the callback counts every
+chunk. Capture-enabled callers also retain a capped prefix consumed by network
+capture and X connector billing refinement.
+
+Configuration preserves any existing callable stream without composing with it.
+An externally owned callback therefore has no vm0 observation or capture state;
+the size and capture helpers return ``None``. A repeated call for this module's
+callback leaves its existing state intact. Terminal response and error handling
+retain installed metadata through connector usage reporting, then release it.
 """
 
 from typing import NamedTuple
@@ -26,7 +31,13 @@ def configure_request_stream(
     *,
     capture_body: bool = True,
 ) -> None:
-    """Enable request-size observation and optional capped body capture."""
+    """Install vm0 request-size observation and optional capped body capture.
+
+    If the request stream is already callable, preserve it without composition
+    and do not create or reset vm0 request-stream metadata. An external callback
+    therefore has no vm0 size or capture state, while repeated vm0 configuration
+    retains the state installed by the first call.
+    """
     if callable(flow.request.stream):
         return
 

--- a/crates/runner/mitm-addon/src/request_streaming.py
+++ b/crates/runner/mitm-addon/src/request_streaming.py
@@ -5,10 +5,11 @@ chunk. Capture-enabled callers also retain a capped prefix consumed by network
 capture and X connector billing refinement.
 
 Configuration preserves any existing callable stream without composing with it.
-An externally owned callback therefore has no vm0 observation or capture state;
-the size and capture helpers return ``None``. A repeated call for this module's
-callback leaves its existing state intact. Terminal response and error handling
-retain installed metadata through connector usage reporting, then release it.
+When setup first finds an externally owned callback, it creates no vm0
+observation or capture state, so the size and capture helpers return ``None``. A
+repeated call for this module's callback leaves its existing state intact.
+Terminal response and error handling retain installed metadata through connector
+usage reporting, then release it.
 """
 
 from typing import NamedTuple
@@ -35,8 +36,9 @@ def configure_request_stream(
 
     If the request stream is already callable, preserve it without composition
     and do not create or reset vm0 request-stream metadata. An external callback
-    therefore has no vm0 size or capture state, while repeated vm0 configuration
-    retains the state installed by the first call.
+    encountered before vm0 setup therefore leaves no vm0 size or capture state,
+    while repeated vm0 configuration retains the state installed by the first
+    call.
     """
     if callable(flow.request.stream):
         return


### PR DESCRIPTION
## Summary

- document that request stream setup preserves any pre-existing callable without composition
- distinguish externally owned streams with no vm0 metadata from idempotent vm0 reconfiguration
- align request buffer, size state, and completion metadata descriptions with the tested ownership contract

## Scope

This is a documentation-only change. It does not alter request streaming behavior or add new tests; existing production-hook integration tests already cover both callable ownership cases.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4692 passed)
- `git diff --check`
- `lefthook run pre-commit`

Closes #24846
