### PR TITLE
perf(mitm-addon): avoid quadratic x url candidate scanning

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -288,14 +288,15 @@ def classify_includes_bucket(key: str) -> str | None:
 # "could X auto-link this?" boolean, not link indices.  Keep protocol
 # matching case-insensitive and preserve twitter-text-style boundary
 # guards so emails, mentions, hashtags and cashtags do not look like
-# scheme-less URLs.  Candidate extraction stays greedy; classification
-# recognizes a valid TLD at its own boundary before later text can
-# invalidate the URL prefix.
+# scheme-less URLs.  Candidate extraction starts only at Unicode-label
+# boundaries and stays greedy; classification recognizes a valid TLD at
+# its own boundary before later text can invalidate the URL prefix.
 _URL_PRECEDING_CHARS = r"A-Za-z0-9@\uFF20$#\uFF03"
 _URL_WITH_PROTOCOL_RE = re.compile(rf"(?<![{_URL_PRECEDING_CHARS}])https?://", re.IGNORECASE)
 _DOMAIN_CODEPOINT = r"[^\W_]"
 _DOMAIN_CANDIDATE_CHAR = rf"(?:{_DOMAIN_CODEPOINT}|-)"
 _BARE_DOMAIN_CANDIDATE_RE = re.compile(
+    rf"(?<!{_DOMAIN_CODEPOINT})"
     rf"(?<![{_URL_PRECEDING_CHARS}._/-])"
     rf"({_DOMAIN_CANDIDATE_CHAR}+(?:\.{_DOMAIN_CANDIDATE_CHAR}+)+)",
     re.IGNORECASE,

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -646,6 +646,7 @@ def test_tweet_create_with_url_stays_on_with_url_bucket(x_usage, tmp_path, real_
         "Unicode fullwidth mention \uff20éexample.com",
         "Fullwidth tag \uff03twitter.com",
         "Unicode fullwidth tag \uff03éexample.com",
+        "Unicode dot boundary .éexample.com",
         "Plus suffix example.com+tag",
         "Fullwidth terminal plus suffix example.\uff23\uff2f\uff2d+tag",
         "At suffix example.com@user",

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -633,13 +633,19 @@ def test_tweet_create_with_url_stays_on_with_url_bucket(x_usage, tmp_path, real_
     [
         "Email support@example.com",
         "Mention @twitter.com",
+        "Unicode mention @éexample.com",
         "Tag #twitter.com",
+        "Unicode tag #éexample.com",
         "Cash $twitter.com",
+        "Unicode cash $éexample.com",
         "Path /twitter.com",
+        "Unicode path /éexample.com",
         "Archive long.test.tar.bz2",
         "Word abcHTTPS://example.com",
         "Fullwidth mention \uff20twitter.com",
+        "Unicode fullwidth mention \uff20éexample.com",
         "Fullwidth tag \uff03twitter.com",
+        "Unicode fullwidth tag \uff03éexample.com",
         "Plus suffix example.com+tag",
         "Fullwidth terminal plus suffix example.\uff23\uff2f\uff2d+tag",
         "At suffix example.com@user",
@@ -650,6 +656,7 @@ def test_tweet_create_with_url_stays_on_with_url_bucket(x_usage, tmp_path, real_
         "TLD-only prefix com.notatld",
         "Fullwidth unknown \uff26\uff2f\uff2f.notatld",
         "Underscore foo_bar.example.com",
+        "Unicode underscore _éexample.com",
         "Leading hyphen -bad.com",
         "Trailing hyphen bad-.com",
         "Invalid prefix bad-.com.notatld",
@@ -706,6 +713,38 @@ def test_tweet_create_long_dotted_ascii_candidate_skips_idna_normalization(
         p = x_usage.call_and_get_single_billing(flow)
 
     normalize_idna_label.assert_not_called()
+    assert p["category"] == "content.create"
+    assert p["quantity"] == 1
+
+
+def test_tweet_create_long_unicode_label_does_not_restart_candidate_search(
+    x_usage, tmp_path, real_flow
+):
+    """Failed Unicode candidates do not restart inside the same label."""
+    interior_candidate = "éexample.com"
+    assert x_billing._BARE_DOMAIN_CANDIDATE_RE.match(interior_candidate, 1) is None
+
+    text = "é" * 16_000 + "."
+    request_body = json.dumps(
+        {"text": text},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode()
+    assert len(request_body) < REQUEST_BODY_BILLING_INSPECTION_LIMIT
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path="/2/tweets",
+        body=json.dumps({"data": {"id": "1"}}).encode(),
+        status=201,
+        permission="tweet.write",
+        rule="POST /2/tweets",
+    )
+    flow.request.method = "POST"
+    flow.request.content = request_body
+
+    p = x_usage.call_and_get_single_billing(flow)
+
     assert p["category"] == "content.create"
     assert p["quantity"] == 1
 


### PR DESCRIPTION
## Summary

- prevent X bare-domain extraction from restarting inside Unicode labels, making unsuccessful scans linear
- cover the 16,000-character terminal-dot case through the real connector usage flow with a deterministic candidate-start assertion
- classify marker-, punctuation-, path-, and underscore-prefixed Unicode suffixes as non-links, matching the existing boundary contract

## Performance

One cold call per compact JSON body in the same pinned Python 3.14.0 environment:

| Unicode characters before `.` | Body bytes | Before | After |
| ---: | ---: | ---: | ---: |
| 1,000 | 2,012 | 0.017134 s | 0.000121 s |
| 2,000 | 4,012 | 0.073206 s | 0.000166 s |
| 4,000 | 8,012 | 0.293263 s | 0.000301 s |
| 8,000 | 16,012 | 1.145044 s | 0.000716 s |
| 16,000 | 32,012 | 4.627578 s | 0.001326 s |

The benchmark is supporting evidence only; automated coverage asserts the start-position invariant rather than elapsed time.

## Behavior and compatibility

The new start boundary closes an existing leak where inputs such as `@éexample.com` or `.éexample.com` could skip the guarded Unicode character and classify the interior ASCII suffix as a URL. These inputs now follow the existing mention/tag/cashtag/punctuation/underscore/path non-link contract.

Protocol URL detection, candidate contents, greedy multi-label extraction, IDNA and compatibility normalization, IANA TLD classification, valid-prefix handling, request-body limits, and billing payloads are unchanged. This PR adds no API, schema, migration, persisted-state, queue, protocol, dependency, feature-switch, or coordinated-rollout change.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/x_connector_usage/test_writes.py` — 115 passed
- `uv run --no-sync python -m pytest tests/` — 4701 passed, 54 existing warnings

Closes #24850
