### PR TITLE
refactor(python): share safe state-file reads

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -13,29 +13,18 @@ from mitmproxy import ctx
 import builtin_host_policy
 import connector_template_syntax
 import matching
+import state_file
 from path_security import has_unsafe_path, has_unsafe_url_path
 from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint
 
 MAX_BUILTIN_FIREWALL_CATALOG_BYTES = 16 * 1024 * 1024
-_READ_CHUNK_BYTES = 1024 * 1024
 _CACHE_SCHEMA_VERSION = 1
 _SHA256_HEX_LENGTH = 64
 _RESERVED_PERMISSION_NAMES = frozenset(("all", "__unknown__"))
 _UNTRUSTED_WRITE_BITS = stat.S_IWGRP | stat.S_IWOTH
 
 
-class CatalogFileKey(NamedTuple):
-    """Filesystem identity used to validate catalog cache dependencies.
-
-    Tuple order is `absolute_path`, `st_dev`, `st_ino`, `st_mtime_ns`, then
-    `st_size`. All stat fields in one key come from the same stat result.
-    """
-
-    absolute_path: str
-    st_dev: int
-    st_ino: int
-    st_mtime_ns: int
-    st_size: int
+CatalogFileKey = state_file.StateFileIdentity
 
 
 class CatalogIdentity(NamedTuple):
@@ -201,7 +190,11 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
     state = _state_for_path(path_key)
 
     try:
-        fd, st = _open_cache_for_read(path)
+        opened_file = state_file.open_state_file(
+            path,
+            description="builtin firewall catalog cache",
+            validate_stat=_validate_cache_file_stat,
+        )
     except OSError as exc:
         state.reset(path_key)
         return BuiltinFirewallCatalogSnapshot(
@@ -211,14 +204,8 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
             unavailable_reason=_open_error_unavailable_reason(exc),
         )
 
-    try:
-        key = CatalogFileKey(
-            absolute_path=path_key,
-            st_dev=st.st_dev,
-            st_ino=st.st_ino,
-            st_mtime_ns=st.st_mtime_ns,
-            st_size=st.st_size,
-        )
+    with opened_file:
+        key = opened_file.identity
         if key == state.loaded_key:
             return BuiltinFirewallCatalogSnapshot(key, state.catalog, cache_path=path_key)
         if key == state.failed_key:
@@ -229,7 +216,10 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
                 unavailable_reason=state.failed_reason or "cache_invalid",
             )
         try:
-            catalog = _read_catalog(fd, path, st.st_size, key)
+            catalog = _read_catalog(
+                opened_file.read_bytes(MAX_BUILTIN_FIREWALL_CATALOG_BYTES),
+                key,
+            )
         except (BuiltinFirewallCatalogCacheError, OSError, ValueError, RecursionError) as exc:
             state.failed_key = key
             state.failed_reason = "cache_invalid"
@@ -242,8 +232,6 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
                 cache_path=path_key,
                 unavailable_reason=state.failed_reason,
             )
-    finally:
-        os.close(fd)
 
     state.loaded_key = key
     state.failed_key = None
@@ -255,6 +243,8 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
 def _open_error_unavailable_reason(exc: OSError) -> CatalogUnavailableReason:
     if isinstance(exc, _CatalogCacheOpenError):
         return exc.reason
+    if isinstance(exc, state_file.StateFileNotRegularError):
+        return "cache_not_regular"
     if isinstance(exc, FileNotFoundError):
         return "cache_file_missing"
     if isinstance(exc, PermissionError):
@@ -262,29 +252,12 @@ def _open_error_unavailable_reason(exc: OSError) -> CatalogUnavailableReason:
     return "cache_unavailable"
 
 
-def _open_cache_for_read(path: Path) -> tuple[int, os.stat_result]:
-    flags = os.O_RDONLY
-    for flag_name in ("O_CLOEXEC", "O_NOFOLLOW", "O_NONBLOCK"):
-        flags |= getattr(os, flag_name, 0)
-    fd = os.open(path, flags)
-    try:
-        st = os.fstat(fd)
-    except OSError:
-        os.close(fd)
-        raise
-    if not stat.S_ISREG(st.st_mode):
-        os.close(fd)
-        raise _CatalogCacheOpenError(
-            "cache_not_regular",
-            f"builtin firewall catalog cache is not a regular file: {path}",
-        )
+def _validate_cache_file_stat(path: Path, st: os.stat_result) -> None:
     if not _cache_file_stat_is_trusted(st):
-        os.close(fd)
         raise _CatalogCacheOpenError(
             "cache_untrusted",
             f"builtin firewall catalog cache is not trusted: {path}",
         )
-    return fd, st
 
 
 def _cache_file_stat_is_trusted(st: os.stat_result) -> bool:
@@ -295,38 +268,11 @@ def _cache_file_stat_is_trusted(st: os.stat_result) -> bool:
     )
 
 
-def _read_cache_bytes(fd: int, path: Path, st_size: int) -> bytes:
-    if st_size > MAX_BUILTIN_FIREWALL_CATALOG_BYTES:
-        raise OSError(
-            f"builtin firewall catalog cache {path} exceeds "
-            f"{MAX_BUILTIN_FIREWALL_CATALOG_BYTES} bytes"
-        )
-
-    chunks: list[bytes] = []
-    total = 0
-    while total <= MAX_BUILTIN_FIREWALL_CATALOG_BYTES:
-        to_read = min(_READ_CHUNK_BYTES, MAX_BUILTIN_FIREWALL_CATALOG_BYTES + 1 - total)
-        chunk = os.read(fd, to_read)
-        if not chunk:
-            break
-        chunks.append(chunk)
-        total += len(chunk)
-
-    if total > MAX_BUILTIN_FIREWALL_CATALOG_BYTES:
-        raise OSError(
-            f"builtin firewall catalog cache {path} exceeds "
-            f"{MAX_BUILTIN_FIREWALL_CATALOG_BYTES} bytes"
-        )
-    return b"".join(chunks)
-
-
 def _read_catalog(
-    fd: int,
-    path: Path,
-    st_size: int,
+    raw_bytes: bytes,
     key: CatalogFileKey,
 ) -> BuiltinFirewallCatalog:
-    raw = json.loads(_read_cache_bytes(fd, path, st_size).decode("utf-8"))
+    raw = json.loads(raw_bytes.decode("utf-8"))
     if not isinstance(raw, dict):
         raise BuiltinFirewallCatalogCacheError("catalog cache must be an object")
 

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -1,8 +1,6 @@
 """Proxy registry loading and VM lookup cache."""
 
 import json
-import os
-import stat
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -11,6 +9,7 @@ from mitmproxy import ctx
 
 import matching
 import registry_firewalls
+import state_file
 from firewall_auth_cache import evict_all_cache_keys, evict_stale_cache_keys
 
 VmContext = tuple[
@@ -18,15 +17,8 @@ VmContext = tuple[
     matching.CompiledFirewallSet | None,
     matching.CompiledNetworkPolicies,
 ]
-type _RegistryFileKey = tuple[
-    str,
-    int,
-    int,
-    int,
-    int,
-]
+type _RegistryFileKey = state_file.StateFileIdentity
 MAX_REGISTRY_BYTES = 16 * 1024 * 1024
-_READ_CHUNK_BYTES = 1024 * 1024
 
 
 class _RegistryFormatError(ValueError):
@@ -306,43 +298,8 @@ def _classify_registry_vms(
     )
 
 
-def _open_registry_for_read(path: Path) -> tuple[int, os.stat_result]:
-    flags = os.O_RDONLY
-    for flag_name in ("O_CLOEXEC", "O_NOFOLLOW", "O_NONBLOCK"):
-        flags |= getattr(os, flag_name, 0)
-    fd = os.open(path, flags)
-    try:
-        st = os.fstat(fd)
-    except OSError:
-        os.close(fd)
-        raise
-    if not stat.S_ISREG(st.st_mode):
-        os.close(fd)
-        raise OSError(f"proxy registry is not a regular file: {path}")
-    return fd, st
-
-
-def _read_registry_bytes(fd: int, path: Path, st_size: int) -> bytes:
-    if st_size > MAX_REGISTRY_BYTES:
-        raise OSError(f"proxy registry {path} exceeds {MAX_REGISTRY_BYTES} bytes")
-
-    chunks: list[bytes] = []
-    total = 0
-    while total <= MAX_REGISTRY_BYTES:
-        to_read = min(_READ_CHUNK_BYTES, MAX_REGISTRY_BYTES + 1 - total)
-        chunk = os.read(fd, to_read)
-        if not chunk:
-            break
-        chunks.append(chunk)
-        total += len(chunk)
-
-    if total > MAX_REGISTRY_BYTES:
-        raise OSError(f"proxy registry {path} exceeds {MAX_REGISTRY_BYTES} bytes")
-    return b"".join(chunks)
-
-
-def _read_registry_vms(fd: int, path: Path, st_size: int) -> dict:
-    raw_registry = json.loads(_read_registry_bytes(fd, path, st_size).decode("utf-8"))
+def _read_registry_vms(raw_bytes: bytes) -> dict:
+    raw_registry = json.loads(raw_bytes.decode("utf-8"))
     if not isinstance(raw_registry, dict):
         raise _RegistryFormatError("proxy registry must be an object")
     raw_vms = raw_registry.get("vms", {})
@@ -383,7 +340,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
     builtin_catalog_cache_path = _builtin_firewall_catalog_cache_path()
 
     try:
-        fd, st = _open_registry_for_read(path)
+        opened_file = state_file.open_state_file(path, description="proxy registry")
     except OSError as e:
         message = str(e)
         if not state.stat_error_logged:
@@ -391,14 +348,8 @@ def load_registry_state(registry_path: str) -> RegistryState:
             ctx.log.warn(f"Failed to stat proxy registry: {message}")
         return _mark_unavailable(state, reason="stat_failed", message=message)
 
-    try:
-        key = (
-            path_key,
-            st.st_dev,
-            st.st_ino,
-            st.st_mtime_ns,
-            st.st_size,
-        )
+    with opened_file:
+        key = opened_file.identity
         loaded_catalog_snapshot = state.snapshot.builtin_firewall_catalog_snapshot
         if key == state.snapshot.loaded_key and (
             loaded_catalog_snapshot is None
@@ -417,7 +368,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
             )
 
         try:
-            raw_registry = _read_registry_vms(fd, path, st.st_size)
+            raw_registry = _read_registry_vms(opened_file.read_bytes(MAX_REGISTRY_BYTES))
         except OSError as e:
             message = str(e)
             state.failed_key = None
@@ -431,8 +382,6 @@ def load_registry_state(registry_path: str) -> RegistryState:
             state.read_error_key = None
             ctx.log.warn(f"Failed to parse proxy registry: {message}")
             return _mark_unavailable(state, reason="parse_failed", message=message)
-    finally:
-        os.close(fd)
 
     (
         new_registry,

--- a/crates/runner/mitm-addon/src/state_file.py
+++ b/crates/runner/mitm-addon/src/state_file.py
@@ -30,7 +30,7 @@ class StateFileNotRegularError(OSError):
 class OpenedStateFile:
     """Validated state-file descriptor owned by a context manager."""
 
-    fd: int
+    _fd: int
     path: Path
     description: str
     identity: StateFileIdentity
@@ -39,7 +39,7 @@ class OpenedStateFile:
         return self
 
     def __exit__(self, *_args: object) -> None:
-        os.close(self.fd)
+        os.close(self._fd)
 
     def read_bytes(self, max_bytes: int) -> bytes:
         """Read at most `max_bytes`, probing one extra byte for size drift."""
@@ -50,7 +50,7 @@ class OpenedStateFile:
         total = 0
         while total <= max_bytes:
             to_read = min(_READ_CHUNK_BYTES, max_bytes + 1 - total)
-            chunk = os.read(self.fd, to_read)
+            chunk = os.read(self._fd, to_read)
             if not chunk:
                 break
             chunks.append(chunk)
@@ -75,7 +75,7 @@ def open_state_file(
     try:
         st = _validate_opened_file(fd, path, description, validate_stat)
         return OpenedStateFile(
-            fd=fd,
+            _fd=fd,
             path=path,
             description=description,
             identity=StateFileIdentity(

--- a/crates/runner/mitm-addon/src/state_file.py
+++ b/crates/runner/mitm-addon/src/state_file.py
@@ -74,22 +74,21 @@ def open_state_file(
     fd = os.open(path, flags)
     try:
         st = _validate_opened_file(fd, path, description, validate_stat)
+        return OpenedStateFile(
+            fd=fd,
+            path=path,
+            description=description,
+            identity=StateFileIdentity(
+                absolute_path=str(path.absolute()),
+                st_dev=st.st_dev,
+                st_ino=st.st_ino,
+                st_mtime_ns=st.st_mtime_ns,
+                st_size=st.st_size,
+            ),
+        )
     except BaseException:
         os.close(fd)
         raise
-
-    return OpenedStateFile(
-        fd=fd,
-        path=path,
-        description=description,
-        identity=StateFileIdentity(
-            absolute_path=str(path.absolute()),
-            st_dev=st.st_dev,
-            st_ino=st.st_ino,
-            st_mtime_ns=st.st_mtime_ns,
-            st_size=st.st_size,
-        ),
-    )
 
 
 def _validate_opened_file(

--- a/crates/runner/mitm-addon/src/state_file.py
+++ b/crates/runner/mitm-addon/src/state_file.py
@@ -1,0 +1,106 @@
+"""Safe bounded reads for runner-owned state files."""
+
+import os
+import stat
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NamedTuple, Self
+
+_READ_CHUNK_BYTES = 1024 * 1024
+
+type StatValidator = Callable[[Path, os.stat_result], None]
+
+
+class StateFileIdentity(NamedTuple):
+    """Identity of the descriptor opened for a state-file read."""
+
+    absolute_path: str
+    st_dev: int
+    st_ino: int
+    st_mtime_ns: int
+    st_size: int
+
+
+class StateFileNotRegularError(OSError):
+    """The opened state-file path does not identify a regular file."""
+
+
+@dataclass(frozen=True)
+class OpenedStateFile:
+    """Validated state-file descriptor owned by a context manager."""
+
+    fd: int
+    path: Path
+    description: str
+    identity: StateFileIdentity
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        os.close(self.fd)
+
+    def read_bytes(self, max_bytes: int) -> bytes:
+        """Read at most `max_bytes`, probing one extra byte for size drift."""
+        if self.identity.st_size > max_bytes:
+            raise OSError(f"{self.description} {self.path} exceeds {max_bytes} bytes")
+
+        chunks: list[bytes] = []
+        total = 0
+        while total <= max_bytes:
+            to_read = min(_READ_CHUNK_BYTES, max_bytes + 1 - total)
+            chunk = os.read(self.fd, to_read)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+
+        if total > max_bytes:
+            raise OSError(f"{self.description} {self.path} exceeds {max_bytes} bytes")
+        return b"".join(chunks)
+
+
+def open_state_file(
+    path: Path,
+    *,
+    description: str,
+    validate_stat: StatValidator | None = None,
+) -> OpenedStateFile:
+    """Open and validate a state file, closing it if setup fails."""
+    flags = os.O_RDONLY
+    for flag_name in ("O_CLOEXEC", "O_NOFOLLOW", "O_NONBLOCK"):
+        flags |= getattr(os, flag_name, 0)
+    fd = os.open(path, flags)
+    try:
+        st = _validate_opened_file(fd, path, description, validate_stat)
+    except BaseException:
+        os.close(fd)
+        raise
+
+    return OpenedStateFile(
+        fd=fd,
+        path=path,
+        description=description,
+        identity=StateFileIdentity(
+            absolute_path=str(path.absolute()),
+            st_dev=st.st_dev,
+            st_ino=st.st_ino,
+            st_mtime_ns=st.st_mtime_ns,
+            st_size=st.st_size,
+        ),
+    )
+
+
+def _validate_opened_file(
+    fd: int,
+    path: Path,
+    description: str,
+    validate_stat: StatValidator | None,
+) -> os.stat_result:
+    st = os.fstat(fd)
+    if not stat.S_ISREG(st.st_mode):
+        raise StateFileNotRegularError(f"{description} is not a regular file: {path}")
+    if validate_stat is not None:
+        validate_stat(path, st)
+    return st

--- a/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
@@ -1,6 +1,7 @@
 """Integration tests for server-catalog connector diagnostic lifecycles."""
 
 import json
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -235,7 +236,12 @@ async def test_repeated_preferred_catalog_does_not_reopen_cache(
     registry_path = _builtin_shared_registry(tmp_path)
     first_flow = _flow(real_flow, host="unmatched.example.com")
     second_flow = _flow(real_flow, host="unmatched.example.com")
-    original_open_state_file = state_file.open_state_file
+    original_os_open = state_file.os.open
+    opened_paths: list[Path] = []
+
+    def record_open(path: Path, flags: int) -> int:
+        opened_paths.append(path)
+        return original_os_open(path, flags)
 
     with (
         mitm_ctx(
@@ -243,10 +249,10 @@ async def test_repeated_preferred_catalog_does_not_reopen_cache(
             builtin_firewall_catalog_cache_path=str(cache_path),
         ),
         patch.object(
-            state_file,
-            "open_state_file",
-            wraps=original_open_state_file,
-        ) as open_state_file,
+            state_file.os,
+            "open",
+            side_effect=record_open,
+        ),
     ):
         await mitm_addon.request(first_flow)
         await mitm_addon.request(second_flow)
@@ -257,12 +263,9 @@ async def test_repeated_preferred_catalog_does_not_reopen_cache(
         for value in flow.metadata.values()
         if isinstance(value, builtin_connector_diagnostics.DiagnosticCatalogSnapshot)
     ]
-    catalog_open_calls = [
-        call for call in open_state_file.call_args_list if call.args[0] == cache_path
-    ]
     assert first_flow.response is None
     assert second_flow.response is None
-    assert len(catalog_open_calls) == 1
+    assert opened_paths.count(cache_path) == 1
     assert len(pinned_snapshots) == 2
     assert pinned_snapshots[0] is pinned_snapshots[1]
     assert pinned_snapshots[0].catalog_identity is not None

--- a/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
@@ -8,10 +8,10 @@ from mitmproxy.flow import Error
 from mitmproxy.test import tutils
 
 import builtin_connector_diagnostics
-import builtin_firewall_cache
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import request_classification
+import state_file
 from tests.connector_diagnostic_helpers import (
     record_connector_diagnostic_requestheaders_context,
     write_connector_diagnostic_catalog_cache,
@@ -235,7 +235,7 @@ async def test_repeated_preferred_catalog_does_not_reopen_cache(
     registry_path = _builtin_shared_registry(tmp_path)
     first_flow = _flow(real_flow, host="unmatched.example.com")
     second_flow = _flow(real_flow, host="unmatched.example.com")
-    original_open_cache_for_read = builtin_firewall_cache._open_cache_for_read
+    original_open_state_file = state_file.open_state_file
 
     with (
         mitm_ctx(
@@ -243,10 +243,10 @@ async def test_repeated_preferred_catalog_does_not_reopen_cache(
             builtin_firewall_catalog_cache_path=str(cache_path),
         ),
         patch.object(
-            builtin_firewall_cache,
-            "_open_cache_for_read",
-            wraps=original_open_cache_for_read,
-        ) as open_cache_for_read,
+            state_file,
+            "open_state_file",
+            wraps=original_open_state_file,
+        ) as open_state_file,
     ):
         await mitm_addon.request(first_flow)
         await mitm_addon.request(second_flow)
@@ -257,9 +257,12 @@ async def test_repeated_preferred_catalog_does_not_reopen_cache(
         for value in flow.metadata.values()
         if isinstance(value, builtin_connector_diagnostics.DiagnosticCatalogSnapshot)
     ]
+    catalog_open_calls = [
+        call for call in open_state_file.call_args_list if call.args[0] == cache_path
+    ]
     assert first_flow.response is None
     assert second_flow.response is None
-    assert open_cache_for_read.call_count == 1
+    assert len(catalog_open_calls) == 1
     assert len(pinned_snapshots) == 2
     assert pinned_snapshots[0] is pinned_snapshots[1]
     assert pinned_snapshots[0].catalog_identity is not None

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_validation.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_validation.py
@@ -1,6 +1,5 @@
 """Tests for built-in registry catalog payload and trust validation."""
 
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -8,6 +7,7 @@ import pytest
 import builtin_connector_diagnostics
 import builtin_firewall_cache
 import registry
+import state_file
 from tests.registry_builtin_helpers import (
     cache_firewall,
     write_catalog_cache,
@@ -69,44 +69,29 @@ def _assert_cache_firewall_is_invalid(
 
 
 class TestRegistryBuiltinCatalogValidation:
-    def test_runner_catalog_cache_accepts_exact_size_limit(self, tmp_path):
+    def test_runner_catalog_cache_fstat_failure_reports_unavailable(self, tmp_path):
         cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
-        write_catalog_cache(
-            cache_path,
-            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            version="catalog-a",
-            firewalls={"fallback": cache_firewall("fallback", "https://cache.example.com")},
-        )
-        exact_size = cache_path.stat().st_size
-
-        with patch.object(
-            builtin_firewall_cache,
-            "MAX_BUILTIN_FIREWALL_CATALOG_BYTES",
-            exact_size,
-        ):
-            snapshot = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
-
-        assert snapshot.catalog is not None
-        assert snapshot.catalog.firewalls["fallback"]["name"] == "fallback"
-        assert snapshot.unavailable_reason is None
-
-    def test_runner_catalog_cache_fstat_failure_closes_opened_descriptor(self):
-        cache_path = Path("builtin-firewall-catalog-cache.json")
-        opened_fd = 42
+        cache_path.write_text("{}")
         error = OSError("fstat failed")
 
-        with (
-            patch.object(builtin_firewall_cache.os, "open", return_value=opened_fd),
-            patch.object(builtin_firewall_cache.os, "fstat", side_effect=error),
-            patch.object(builtin_firewall_cache.os, "close") as close,
-        ):
+        with patch.object(state_file.os, "fstat", side_effect=error):
             snapshot = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
 
         assert snapshot.dependency_file_key is None
         assert snapshot.catalog is None
         assert snapshot.cache_path == str(cache_path.absolute())
         assert snapshot.unavailable_reason == "cache_unavailable"
-        close.assert_called_once_with(opened_fd)
+
+    def test_runner_catalog_cache_directory_reports_not_regular(self, tmp_path):
+        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+        cache_path.mkdir()
+
+        snapshot = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+
+        assert snapshot.dependency_file_key is None
+        assert snapshot.catalog is None
+        assert snapshot.cache_path == str(cache_path.absolute())
+        assert snapshot.unavailable_reason == "cache_not_regular"
 
     def test_runner_catalog_cache_rejects_initial_oversize_before_parsing(self, tmp_path, mitm_ctx):
         cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
@@ -135,31 +120,6 @@ class TestRegistryBuiltinCatalogValidation:
 
         assert snapshot.dependency_file_key is not None
         assert snapshot.dependency_file_key.st_size == actual_size
-        assert snapshot.catalog is None
-        assert snapshot.unavailable_reason == "cache_invalid"
-        assert spy.call_count == 0
-
-    def test_runner_catalog_cache_rejects_underreported_size_before_parsing(self, mitm_ctx):
-        cache_path = Path("/proc/self/status")
-        assert cache_path.stat().st_size == 0
-
-        with (
-            mitm_ctx(),
-            patch.object(
-                builtin_firewall_cache,
-                "MAX_BUILTIN_FIREWALL_CATALOG_BYTES",
-                1,
-            ),
-            patch.object(
-                builtin_firewall_cache.json,
-                "loads",
-                wraps=builtin_firewall_cache.json.loads,
-            ) as spy,
-        ):
-            snapshot = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
-
-        assert snapshot.dependency_file_key is not None
-        assert snapshot.dependency_file_key.st_size == 0
         assert snapshot.catalog is None
         assert snapshot.unavailable_reason == "cache_invalid"
         assert spy.call_count == 0

--- a/crates/runner/mitm-addon/tests/test_registry_loading.py
+++ b/crates/runner/mitm-addon/tests/test_registry_loading.py
@@ -2,19 +2,16 @@
 
 import json
 import os
-import queue
-from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 import registry
+import state_file
 from tests.registry_helpers import (
     pin_mtime,
     write_simple_registry,
 )
-from tests.thread_helpers import ThreadUnderTest
 
 
 class TestLoadRegistry:
@@ -23,15 +20,6 @@ class TestLoadRegistry:
 
         assert "10.200.0.1" in result
         assert result["10.200.0.1"]["runId"] == "run-abc-123"
-
-    def test_loads_valid_registry_at_exact_size_limit(self, registry_file):
-        exact_size = registry_file.stat().st_size
-
-        with patch.object(registry, "MAX_REGISTRY_BYTES", exact_size):
-            state = registry.load_registry_state(str(registry_file))
-
-        assert not isinstance(state, registry.RegistryUnavailable)
-        assert state.vms["10.200.0.1"]["runId"] == "run-abc-123"
 
     def test_classifies_invalid_registered_vm_entries(self, tmp_path):
         path = tmp_path / "registry.json"
@@ -80,21 +68,6 @@ class TestLoadRegistry:
 
         assert result == {}
         assert isinstance(state, registry.RegistryUnavailable)
-
-    def test_fstat_failure_closes_opened_descriptor(self):
-        opened_fd = 42
-        error = OSError("fstat failed")
-
-        with (
-            patch.object(registry.os, "open", return_value=opened_fd),
-            patch.object(registry.os, "fstat", side_effect=error),
-            patch.object(registry.os, "close") as close,
-            pytest.raises(OSError, match="fstat failed") as exc_info,
-        ):
-            registry._open_registry_for_read(Path("registry.json"))
-
-        assert exc_info.value is error
-        close.assert_called_once_with(opened_fd)
 
     def test_cache_returns_same_on_unchanged(self, registry_file):
         result1 = registry.load_registry(str(registry_file))
@@ -220,20 +193,6 @@ class TestLoadRegistry:
         assert log.warn.call_count == 1
         assert "Failed to stat" in log.warn.call_args_list[0].args[0]
 
-    def test_symlink_registry_is_unavailable_without_following_target(self, tmp_path):
-        path = tmp_path / "registry.json"
-        target = tmp_path / "outside-registry.json"
-        write_simple_registry(target, run_id="outside-run")
-        path.symlink_to(target)
-
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
-            result = registry.load_registry(str(path))
-            state = registry.load_registry_state(str(path))
-
-        assert result == {}
-        assert isinstance(state, registry.RegistryUnavailable)
-        assert state.reason == "stat_failed"
-
     def test_symlink_after_success_does_not_return_previous_snapshot(
         self,
         registry_file,
@@ -249,37 +208,6 @@ class TestLoadRegistry:
         with patch.object(registry.ctx, "log", MagicMock(), create=True):
             result = registry.load_registry(str(registry_file))
             state = registry.load_registry_state(str(registry_file))
-
-        assert result == {}
-        assert isinstance(state, registry.RegistryUnavailable)
-        assert state.reason == "stat_failed"
-
-    def test_fifo_registry_is_unavailable_without_blocking(self, tmp_path):
-        path = tmp_path / "registry.json"
-        os.mkfifo(path)
-        results = queue.Queue()
-        log = MagicMock()
-
-        def load_state():
-            with patch.object(registry.ctx, "log", log, create=True):
-                results.put(registry.load_registry_state(str(path)))
-
-        thread = ThreadUnderTest(target=load_state, daemon=True)
-        thread.start()
-        thread.join_and_raise(1)
-
-        assert not thread.is_alive(), "registry load blocked on FIFO"
-        state = results.get_nowait()
-        assert isinstance(state, registry.RegistryUnavailable)
-        assert state.reason == "stat_failed"
-
-    def test_directory_registry_is_unavailable(self, tmp_path):
-        path = tmp_path / "registry.json"
-        path.mkdir()
-
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
-            result = registry.load_registry(str(path))
-            state = registry.load_registry_state(str(path))
 
         assert result == {}
         assert isinstance(state, registry.RegistryUnavailable)
@@ -302,22 +230,6 @@ class TestLoadRegistry:
         assert spy.call_count == 0
         assert log.warn.call_count == 1
         assert "exceeds" in log.warn.call_args_list[0].args[0]
-
-    def test_underreported_registry_is_unavailable_before_parsing(self):
-        path = Path("/proc/self/status")
-        assert path.stat().st_size == 0
-        log = MagicMock()
-
-        with (
-            patch.object(registry.ctx, "log", log, create=True),
-            patch.object(registry, "MAX_REGISTRY_BYTES", 1),
-            patch.object(registry.json, "loads", wraps=registry.json.loads) as spy,
-        ):
-            state = registry.load_registry_state(str(path))
-
-        assert isinstance(state, registry.RegistryUnavailable)
-        assert state.reason == "read_failed"
-        assert spy.call_count == 0
 
     def test_parse_failure_logs_once_and_does_not_reparse(self, tmp_path):
         """Parse failure on a fixed file: key match short-circuits re-parse."""
@@ -475,7 +387,7 @@ class TestLoadRegistry:
         log = MagicMock()
         with (
             patch.object(registry.ctx, "log", log, create=True),
-            patch.object(registry.os, "read", side_effect=read_with_one_failure) as spy,
+            patch.object(state_file.os, "read", side_effect=read_with_one_failure) as spy,
         ):
             failed = registry.load_registry(str(registry_file))
             recovered = registry.load_registry(str(registry_file))
@@ -488,47 +400,36 @@ class TestLoadRegistry:
 
     def test_read_failure_clears_previous_failed_key(self, tmp_path):
         path = tmp_path / "registry.json"
-        path.write_text("{}")
-        first_key = SimpleNamespace(st_dev=1, st_ino=1, st_mtime_ns=100, st_size=10)
-        second_key = SimpleNamespace(st_dev=1, st_ino=1, st_mtime_ns=200, st_size=20)
         valid_registry = {"vms": {"10.0.0.1": {"runId": "r1"}}}
-        read_results = iter(
-            [
-                b"{ broken",
-                b"",
-                OSError("read failed"),
-                json.dumps(valid_registry).encode(),
-                b"",
-            ]
-        )
-
-        stats = iter([first_key, second_key, first_key])
-
-        def open_with_fake_stat(_path):
-            return os.open(path, os.O_RDONLY), next(stats)
-
-        def read_parse_fail_then_read_fail_then_recover(_fd, _count):
-            result = next(read_results)
-            if isinstance(result, OSError):
-                raise result
-            return result
+        valid_bytes = json.dumps(valid_registry, separators=(",", ":")).encode()
+        path.write_bytes(b"{" + b" " * (len(valid_bytes) - 1))
+        first_stat = path.stat()
 
         log = MagicMock()
-        with (
-            patch.object(registry.ctx, "log", log, create=True),
-            patch.object(registry, "_open_registry_for_read", side_effect=open_with_fake_stat),
-            patch.object(
-                registry.os,
-                "read",
-                side_effect=read_parse_fail_then_read_fail_then_recover,
-            ) as spy,
-        ):
+        with patch.object(registry.ctx, "log", log, create=True):
             assert registry.load_registry(str(path)) == {}
-            assert registry.load_registry(str(path)) == {}
+
+            path.write_bytes(b"x" * (len(valid_bytes) + 1))
+            with patch.object(state_file.os, "read", side_effect=OSError("read failed")):
+                assert registry.load_registry(str(path)) == {}
+
+            path.write_bytes(valid_bytes)
+            os.utime(path, ns=(first_stat.st_atime_ns, first_stat.st_mtime_ns))
+            recovered_stat = path.stat()
+            assert (
+                recovered_stat.st_dev,
+                recovered_stat.st_ino,
+                recovered_stat.st_mtime_ns,
+                recovered_stat.st_size,
+            ) == (
+                first_stat.st_dev,
+                first_stat.st_ino,
+                first_stat.st_mtime_ns,
+                first_stat.st_size,
+            )
             recovered = registry.load_registry(str(path))
 
         assert recovered == {"10.0.0.1": {"runId": "r1"}}
-        assert spy.call_count == 5
         assert log.warn.call_count == 2
         assert "Failed to parse" in log.warn.call_args_list[0].args[0]
         assert "Failed to read" in log.warn.call_args_list[1].args[0]

--- a/crates/runner/mitm-addon/tests/test_state_file.py
+++ b/crates/runner/mitm-addon/tests/test_state_file.py
@@ -143,3 +143,25 @@ def test_stat_validator_failure_closes_opened_descriptor(tmp_path):
 
     assert len(opened_fds) == 1
     _assert_descriptor_closed(opened_fds[0])
+
+
+def test_identity_setup_failure_closes_opened_descriptor(tmp_path):
+    path = tmp_path / "state.json"
+    path.write_text("{}")
+    opened_fds: list[int] = []
+    real_open = os.open
+
+    def record_open(open_path: Path, flags: int) -> int:
+        fd = real_open(open_path, flags)
+        opened_fds.append(fd)
+        return fd
+
+    with (
+        patch.object(state_file.os, "open", side_effect=record_open),
+        patch.object(state_file.Path, "absolute", side_effect=OSError("absolute failed")),
+        pytest.raises(OSError, match="absolute failed"),
+    ):
+        state_file.open_state_file(path, description="test state")
+
+    assert len(opened_fds) == 1
+    _assert_descriptor_closed(opened_fds[0])

--- a/crates/runner/mitm-addon/tests/test_state_file.py
+++ b/crates/runner/mitm-addon/tests/test_state_file.py
@@ -2,6 +2,7 @@
 
 import errno
 import os
+from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import patch
 
@@ -18,13 +19,31 @@ def _assert_descriptor_closed(fd: int) -> None:
     assert exc_info.value.errno == errno.EBADF
 
 
-def test_reads_exact_limit_from_opened_identity_and_closes(tmp_path):
+@pytest.fixture
+def opened_fds() -> Iterator[list[int]]:
+    descriptors: list[int] = []
+    real_open = os.open
+
+    def record_open(open_path: Path, flags: int) -> int:
+        fd = real_open(open_path, flags)
+        descriptors.append(fd)
+        return fd
+
+    with patch.object(state_file.os, "open", side_effect=record_open):
+        yield descriptors
+
+
+def test_reads_exact_limit_from_opened_identity_and_closes(
+    tmp_path: Path,
+    opened_fds: list[int],
+) -> None:
     path = tmp_path / "state.json"
     payload = b"state"
     path.write_bytes(payload)
 
     with state_file.open_state_file(path, description="test state") as opened_file:
-        fd = opened_file.fd
+        assert len(opened_fds) == 1
+        fd = opened_fds[0]
         st = os.fstat(fd)
 
         assert opened_file.identity == state_file.StateFileIdentity(
@@ -40,7 +59,7 @@ def test_reads_exact_limit_from_opened_identity_and_closes(tmp_path):
     _assert_descriptor_closed(fd)
 
 
-def test_rejects_initially_oversized_file(tmp_path):
+def test_rejects_initially_oversized_file(tmp_path: Path) -> None:
     path = tmp_path / "state.json"
     path.write_bytes(b"too large")
 
@@ -51,7 +70,7 @@ def test_rejects_initially_oversized_file(tmp_path):
         opened_file.read_bytes(3)
 
 
-def test_rejects_bytes_beyond_underreported_size():
+def test_rejects_bytes_beyond_underreported_size() -> None:
     path = Path("/proc/self/status")
     assert path.stat().st_size == 0
 
@@ -62,7 +81,7 @@ def test_rejects_bytes_beyond_underreported_size():
         opened_file.read_bytes(1)
 
 
-def test_rejects_symlink_without_following_target(tmp_path):
+def test_rejects_symlink_without_following_target(tmp_path: Path) -> None:
     target = tmp_path / "target.json"
     target.write_text("{}")
     path = tmp_path / "state.json"
@@ -72,7 +91,7 @@ def test_rejects_symlink_without_following_target(tmp_path):
         state_file.open_state_file(path, description="test state")
 
 
-def test_rejects_fifo_without_blocking(tmp_path):
+def test_rejects_fifo_without_blocking(tmp_path: Path) -> None:
     path = tmp_path / "state.json"
     os.mkfifo(path)
 
@@ -87,7 +106,7 @@ def test_rejects_fifo_without_blocking(tmp_path):
     assert not thread.is_alive(), "state-file open blocked on FIFO"
 
 
-def test_rejects_directory(tmp_path):
+def test_rejects_directory(tmp_path: Path) -> None:
     path = tmp_path / "state.json"
     path.mkdir()
 
@@ -95,19 +114,14 @@ def test_rejects_directory(tmp_path):
         state_file.open_state_file(path, description="test state")
 
 
-def test_fstat_failure_closes_opened_descriptor(tmp_path):
+def test_fstat_failure_closes_opened_descriptor(
+    tmp_path: Path,
+    opened_fds: list[int],
+) -> None:
     path = tmp_path / "state.json"
     path.write_text("{}")
-    opened_fds: list[int] = []
-    real_open = os.open
-
-    def record_open(open_path: Path, flags: int) -> int:
-        fd = real_open(open_path, flags)
-        opened_fds.append(fd)
-        return fd
 
     with (
-        patch.object(state_file.os, "open", side_effect=record_open),
         patch.object(state_file.os, "fstat", side_effect=OSError("fstat failed")),
         pytest.raises(OSError, match="fstat failed"),
     ):
@@ -117,22 +131,17 @@ def test_fstat_failure_closes_opened_descriptor(tmp_path):
     _assert_descriptor_closed(opened_fds[0])
 
 
-def test_stat_validator_failure_closes_opened_descriptor(tmp_path):
+def test_stat_validator_failure_closes_opened_descriptor(
+    tmp_path: Path,
+    opened_fds: list[int],
+) -> None:
     path = tmp_path / "state.json"
     path.write_text("{}")
-    opened_fds: list[int] = []
-    real_open = os.open
-
-    def record_open(open_path: Path, flags: int) -> int:
-        fd = real_open(open_path, flags)
-        opened_fds.append(fd)
-        return fd
 
     def reject_stat(_path: Path, _st: os.stat_result) -> None:
         raise PermissionError("untrusted")
 
     with (
-        patch.object(state_file.os, "open", side_effect=record_open),
         pytest.raises(PermissionError, match="untrusted"),
     ):
         state_file.open_state_file(
@@ -145,19 +154,14 @@ def test_stat_validator_failure_closes_opened_descriptor(tmp_path):
     _assert_descriptor_closed(opened_fds[0])
 
 
-def test_identity_setup_failure_closes_opened_descriptor(tmp_path):
+def test_identity_setup_failure_closes_opened_descriptor(
+    tmp_path: Path,
+    opened_fds: list[int],
+) -> None:
     path = tmp_path / "state.json"
     path.write_text("{}")
-    opened_fds: list[int] = []
-    real_open = os.open
-
-    def record_open(open_path: Path, flags: int) -> int:
-        fd = real_open(open_path, flags)
-        opened_fds.append(fd)
-        return fd
 
     with (
-        patch.object(state_file.os, "open", side_effect=record_open),
         patch.object(state_file.Path, "absolute", side_effect=OSError("absolute failed")),
         pytest.raises(OSError, match="absolute failed"),
     ):

--- a/crates/runner/mitm-addon/tests/test_state_file.py
+++ b/crates/runner/mitm-addon/tests/test_state_file.py
@@ -1,0 +1,145 @@
+"""Filesystem integration contracts for safe state-file reads."""
+
+import errno
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import state_file
+from tests.thread_helpers import ThreadUnderTest
+
+
+def _assert_descriptor_closed(fd: int) -> None:
+    with pytest.raises(OSError, match="Bad file descriptor") as exc_info:
+        os.fstat(fd)
+
+    assert exc_info.value.errno == errno.EBADF
+
+
+def test_reads_exact_limit_from_opened_identity_and_closes(tmp_path):
+    path = tmp_path / "state.json"
+    payload = b"state"
+    path.write_bytes(payload)
+
+    with state_file.open_state_file(path, description="test state") as opened_file:
+        fd = opened_file.fd
+        st = os.fstat(fd)
+
+        assert opened_file.identity == state_file.StateFileIdentity(
+            absolute_path=str(path.absolute()),
+            st_dev=st.st_dev,
+            st_ino=st.st_ino,
+            st_mtime_ns=st.st_mtime_ns,
+            st_size=st.st_size,
+        )
+        assert opened_file.read_bytes(len(payload)) == payload
+        assert not os.get_inheritable(fd)
+
+    _assert_descriptor_closed(fd)
+
+
+def test_rejects_initially_oversized_file(tmp_path):
+    path = tmp_path / "state.json"
+    path.write_bytes(b"too large")
+
+    with (
+        state_file.open_state_file(path, description="test state") as opened_file,
+        pytest.raises(OSError, match=r"test state .* exceeds 3 bytes"),
+    ):
+        opened_file.read_bytes(3)
+
+
+def test_rejects_bytes_beyond_underreported_size():
+    path = Path("/proc/self/status")
+    assert path.stat().st_size == 0
+
+    with (
+        state_file.open_state_file(path, description="test state") as opened_file,
+        pytest.raises(OSError, match=r"test state .* exceeds 1 bytes"),
+    ):
+        opened_file.read_bytes(1)
+
+
+def test_rejects_symlink_without_following_target(tmp_path):
+    target = tmp_path / "target.json"
+    target.write_text("{}")
+    path = tmp_path / "state.json"
+    path.symlink_to(target)
+
+    with pytest.raises(OSError, match="symbolic links"):
+        state_file.open_state_file(path, description="test state")
+
+
+def test_rejects_fifo_without_blocking(tmp_path):
+    path = tmp_path / "state.json"
+    os.mkfifo(path)
+
+    def open_fifo() -> None:
+        with pytest.raises(state_file.StateFileNotRegularError):
+            state_file.open_state_file(path, description="test state")
+
+    thread = ThreadUnderTest(target=open_fifo, daemon=True)
+    thread.start()
+    thread.join_and_raise(1)
+
+    assert not thread.is_alive(), "state-file open blocked on FIFO"
+
+
+def test_rejects_directory(tmp_path):
+    path = tmp_path / "state.json"
+    path.mkdir()
+
+    with pytest.raises(state_file.StateFileNotRegularError):
+        state_file.open_state_file(path, description="test state")
+
+
+def test_fstat_failure_closes_opened_descriptor(tmp_path):
+    path = tmp_path / "state.json"
+    path.write_text("{}")
+    opened_fds: list[int] = []
+    real_open = os.open
+
+    def record_open(open_path: Path, flags: int) -> int:
+        fd = real_open(open_path, flags)
+        opened_fds.append(fd)
+        return fd
+
+    with (
+        patch.object(state_file.os, "open", side_effect=record_open),
+        patch.object(state_file.os, "fstat", side_effect=OSError("fstat failed")),
+        pytest.raises(OSError, match="fstat failed"),
+    ):
+        state_file.open_state_file(path, description="test state")
+
+    assert len(opened_fds) == 1
+    _assert_descriptor_closed(opened_fds[0])
+
+
+def test_stat_validator_failure_closes_opened_descriptor(tmp_path):
+    path = tmp_path / "state.json"
+    path.write_text("{}")
+    opened_fds: list[int] = []
+    real_open = os.open
+
+    def record_open(open_path: Path, flags: int) -> int:
+        fd = real_open(open_path, flags)
+        opened_fds.append(fd)
+        return fd
+
+    def reject_stat(_path: Path, _st: os.stat_result) -> None:
+        raise PermissionError("untrusted")
+
+    with (
+        patch.object(state_file.os, "open", side_effect=record_open),
+        pytest.raises(PermissionError, match="untrusted"),
+    ):
+        state_file.open_state_file(
+            path,
+            description="test state",
+            validate_stat=reject_stat,
+        )
+
+    assert len(opened_fds) == 1
+    _assert_descriptor_closed(opened_fds[0])

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -145,6 +145,7 @@ suites before committing the upgrade.
 | `test_runner_usage_flush_signal.py`                     | Runner-triggered usage and JSONL flush requests                                                                      |
 | `test_tls_clienthello_hook.py`                          | TLS clienthello admission behavior                                                                                   |
 | `test_tcp_hooks.py`                                     | TCP start, logging, message drain, end, and error hooks                                                              |
+| `test_state_file.py`                                    | Shared safe-open, descriptor identity, bounded-read, and cleanup contracts                                            |
 | `test_registry_loading.py`                              | Registry loading, parsing, unavailable-state, and cache behavior                                                     |
 | `test_registry_auth_cache_eviction.py`                  | Registry-driven auth-cache ownership and eviction behavior                                                           |
 | `test_registry_context.py`                              | VM lookup and public compiled context API behavior                                                                   |


### PR DESCRIPTION
## Summary

- add one context-managed Python boundary for safe state-file open, descriptor identity, bounded reads, and cleanup
- migrate proxy registry and builtin firewall catalog loading while preserving their cache, trust, error-classification, and fail-closed behavior
- consolidate common filesystem regressions into a real-filesystem contract and retain caller-specific lifecycle coverage

## Explicit exclusions

- no registry or catalog file-format changes
- no changes to cache keys, size limits, retry/memoization behavior, warnings, or unavailable reasons
- no changes to the path-only builtin catalog invalidation probe or its owner/mode trust policy
- no API, persisted-data, protocol, dependency, rollout, or deployment changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_state_file.py tests/test_registry_loading.py tests/test_registry_builtin_catalog_validation.py tests/test_registry_builtin_snapshot.py tests/test_registry_builtin_core_cache.py tests/test_connector_diagnostic_catalog_lifecycle.py -q` (96 passed)
- `uv run --no-sync python -m pytest tests/ -q` (4694 passed)

Closes #24847
