### PR TITLE
refactor(runner): centralize network log process lifecycle

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -57,7 +57,7 @@ use crate::host;
 use crate::http::{HttpClient, HttpClientConfig};
 use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkingGate};
 use crate::kmsg_log;
-use crate::lifecycle::RunnerMode;
+use crate::lifecycle::{LifecycleController, RunnerMode};
 use crate::lock;
 use crate::network_log_drain::{DrainableLineReaderExit, NetworkLogDrainCoordinator};
 use crate::network_log_manager::NetworkLogManager;
@@ -1206,6 +1206,89 @@ fn maybe_panic_outer_job(
     }
 }
 
+#[derive(Clone, Copy)]
+enum RequiredNetworkLogComponent {
+    Kmsg,
+    Dns,
+}
+
+impl RequiredNetworkLogComponent {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Kmsg => "kmsg",
+            Self::Dns => "dns",
+        }
+    }
+
+    fn stop_source(self) -> &'static str {
+        match self {
+            Self::Kmsg => "kmsg-monitor",
+            Self::Dns => "dns-monitor",
+        }
+    }
+
+    fn terminal_message(
+        self,
+        result: &Result<DrainableLineReaderExit, tokio::task::JoinError>,
+    ) -> String {
+        match self {
+            Self::Kmsg => match result {
+                Ok(exit) => format!("kmsg monitor exited unexpectedly: {exit:?}"),
+                Err(error) => format!("kmsg monitor task failed: {error}"),
+            },
+            Self::Dns => match result {
+                Ok(DrainableLineReaderExit::Cancelled) => {
+                    "dns monitor exited unexpectedly: Cancelled".to_string()
+                }
+                Ok(DrainableLineReaderExit::DrainChannelClosed) => {
+                    "dns monitor exited unexpectedly: DrainChannelClosed".to_string()
+                }
+                Ok(DrainableLineReaderExit::Eof { during_drain }) => {
+                    format!(
+                        "dns monitor exited unexpectedly: Eof {{ during_drain: {during_drain} }}"
+                    )
+                }
+                Ok(DrainableLineReaderExit::ReadError {
+                    during_drain,
+                    error,
+                }) => {
+                    format!(
+                        "dns monitor exited unexpectedly: ReadError {{ during_drain: {during_drain}, error: {error} }}"
+                    )
+                }
+                Err(error) => format!("dns monitor task failed: {error}"),
+            },
+        }
+    }
+}
+
+async fn handle_required_network_log_completion(
+    component: RequiredNetworkLogComponent,
+    result: Result<DrainableLineReaderExit, tokio::task::JoinError>,
+    reap_child: impl std::future::Future<Output = ()>,
+    cancel: &CancellationToken,
+    cancel_tokens: &RunCancellationRegistry,
+    lifecycle: &LifecycleController,
+) -> Option<RunnerError> {
+    let mode = lifecycle.current_mode();
+    let terminal_error = if matches!(mode, RunnerMode::Stopping | RunnerMode::Stopped) {
+        None
+    } else {
+        let message = component.terminal_message(&result);
+        error!(
+            component = component.label(),
+            ?mode,
+            result = ?result,
+            "required runner component exited"
+        );
+        handle_stopping_signal(component.stop_source(), cancel, cancel_tokens, lifecycle).await;
+        Some(RunnerError::Internal(message))
+    };
+
+    reap_child.await;
+    terminal_error
+}
+
 async fn run(config: RunConfig) -> RunnerResult<()> {
     let RunConfig {
         runner,
@@ -1648,68 +1731,28 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 ).await;
             }
             result = kmsg_handle.wait() => {
-                let mode = lifecycle.current_mode();
-                if !matches!(mode, RunnerMode::Stopping | RunnerMode::Stopped) {
-                    let message = match &result {
-                        Ok(exit) => format!("kmsg monitor exited unexpectedly: {exit:?}"),
-                        Err(error) => format!("kmsg monitor task failed: {error}"),
-                    };
-                    error!(
-                        component = "kmsg",
-                        ?mode,
-                        result = ?result,
-                        "required runner component exited"
-                    );
-                    terminal_error = Some(RunnerError::Internal(message));
-                    handle_stopping_signal(
-                        "kmsg-monitor",
-                        &provider_state.cancel,
-                        &provider_state.cancel_tokens,
-                        &lifecycle,
-                    ).await;
+                if let Some(error) = handle_required_network_log_completion(
+                    RequiredNetworkLogComponent::Kmsg,
+                    result,
+                    kmsg_handle.kill_and_reap_child(),
+                    &provider_state.cancel,
+                    &provider_state.cancel_tokens,
+                    &lifecycle,
+                ).await {
+                    terminal_error = Some(error);
                 }
-                kmsg_handle.kill_and_reap_child().await;
             }
             result = dns_handle.wait() => {
-                let mode = lifecycle.current_mode();
-                if !matches!(mode, RunnerMode::Stopping | RunnerMode::Stopped) {
-                    let message = match &result {
-                        Ok(DrainableLineReaderExit::Cancelled) => {
-                            "dns monitor exited unexpectedly: Cancelled".to_string()
-                        }
-                        Ok(DrainableLineReaderExit::DrainChannelClosed) => {
-                            "dns monitor exited unexpectedly: DrainChannelClosed".to_string()
-                        }
-                        Ok(DrainableLineReaderExit::Eof { during_drain }) => {
-                            format!(
-                                "dns monitor exited unexpectedly: Eof {{ during_drain: {during_drain} }}"
-                            )
-                        }
-                        Ok(DrainableLineReaderExit::ReadError {
-                            during_drain,
-                            error,
-                        }) => {
-                            format!(
-                                "dns monitor exited unexpectedly: ReadError {{ during_drain: {during_drain}, error: {error} }}"
-                            )
-                        }
-                        Err(error) => format!("dns monitor task failed: {error}"),
-                    };
-                    error!(
-                        component = "dns",
-                        ?mode,
-                        result = ?result,
-                        "required runner component exited"
-                    );
-                    terminal_error = Some(RunnerError::Internal(message));
-                    handle_stopping_signal(
-                        "dns-monitor",
-                        &provider_state.cancel,
-                        &provider_state.cancel_tokens,
-                        &lifecycle,
-                    ).await;
+                if let Some(error) = handle_required_network_log_completion(
+                    RequiredNetworkLogComponent::Dns,
+                    result,
+                    dns_handle.kill_and_reap_child(),
+                    &provider_state.cancel,
+                    &provider_state.cancel_tokens,
+                    &lifecycle,
+                ).await {
+                    terminal_error = Some(error);
                 }
-                dns_handle.kill_and_reap_child().await;
             }
             // Reap completed jobs promptly in all live modes. Without this,
             // normal Running mode can retain completed JoinSet entries and

--- a/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
@@ -93,10 +93,38 @@ async fn shutdown_drains_memory_prefetch_before_stopped() {
     wait_status_mode(&status_path, "stopped", Duration::from_secs(5)).await;
 }
 
-#[tokio::test]
-async fn kmsg_stdout_eof_stops_runner_and_reaps_child_before_teardown() {
+#[derive(Clone, Copy)]
+enum NetworkLogTestComponent {
+    Kmsg,
+    Dns,
+}
+
+impl NetworkLogTestComponent {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Kmsg => "kmsg",
+            Self::Dns => "dns",
+        }
+    }
+
+    fn eof_error_prefix(self) -> &'static str {
+        match self {
+            Self::Kmsg => "kmsg monitor exited unexpectedly: Eof",
+            Self::Dns => "dns monitor exited unexpectedly: Eof",
+        }
+    }
+
+    async fn install(self, config: &mut RunConfig) -> (tokio::process::ChildStdin, u32, u64) {
+        match self {
+            Self::Kmsg => install_controllable_kmsg(config).await,
+            Self::Dns => install_controllable_dns(config).await,
+        }
+    }
+}
+
+async fn assert_network_log_eof_stops_runner(component: NetworkLogTestComponent) {
     let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let (stdin, pid, starttime) = install_controllable_kmsg(&mut config).await;
+    let (stdin, pid, starttime) = component.install(&mut config).await;
     env.handle.block_heartbeats();
     let run_handle = tokio::spawn(run(config));
 
@@ -107,23 +135,27 @@ async fn kmsg_stdout_eof_stops_runner_and_reaps_child_before_teardown() {
         env.handle
             .wait_heartbeat_in_flight(1, Duration::from_secs(2))
             .await,
-        "kmsg EOF should drive runner teardown",
+        "{} EOF should drive runner teardown",
+        component.label(),
     );
     assert!(
         !run_handle.is_finished(),
         "blocked final heartbeat should hold teardown open",
     );
-    assert_child_reaped("kmsg", pid, starttime).await;
-    assert!(env.cancel.is_cancelled(), "kmsg EOF should stop discovery");
+    assert_child_reaped(component.label(), pid, starttime).await;
+    assert!(
+        env.cancel.is_cancelled(),
+        "{} EOF should stop discovery",
+        component.label(),
+    );
 
     env.handle.unblock_heartbeats();
-    assert_run_error_contains(run_handle, "Eof").await;
+    assert_run_error_contains(run_handle, component.eof_error_prefix()).await;
 }
 
-#[tokio::test]
-async fn kmsg_stdout_read_error_stops_runner_and_kills_child() {
+async fn assert_network_log_read_error_stops_runner(component: NetworkLogTestComponent) {
     let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let (mut stdin, pid, starttime) = install_controllable_kmsg(&mut config).await;
+    let (mut stdin, pid, starttime) = component.install(&mut config).await;
     env.handle.block_heartbeats();
     let run_handle = tokio::spawn(run(config));
 
@@ -135,84 +167,59 @@ async fn kmsg_stdout_read_error_stops_runner_and_kills_child() {
         env.handle
             .wait_heartbeat_in_flight(1, Duration::from_secs(2))
             .await,
-        "kmsg read error should drive runner teardown",
+        "{} read error should drive runner teardown",
+        component.label(),
     );
-    assert_child_reaped("kmsg", pid, starttime).await;
+    assert_child_reaped(component.label(), pid, starttime).await;
+    assert!(
+        env.cancel.is_cancelled(),
+        "{} read error should stop discovery",
+        component.label(),
+    );
 
     env.handle.unblock_heartbeats();
     assert_run_error_contains(run_handle, "ReadError").await;
 }
 
-#[tokio::test]
-async fn normal_shutdown_cancels_kmsg_and_reaps_child_without_error() {
+async fn assert_normal_shutdown_reaps_network_log_child(component: NetworkLogTestComponent) {
     let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let (_stdin, pid, starttime) = install_controllable_kmsg(&mut config).await;
+    let (_stdin, pid, starttime) = component.install(&mut config).await;
     let run_handle = tokio::spawn(run(config));
 
     wait_discover_entered(&env, Duration::from_secs(2)).await;
     env.trigger_stopping().await;
 
-    assert_run_exits_within(
-        run_handle,
-        Duration::from_secs(3),
-        "normal hard shutdown should stop the kmsg monitor",
-    )
-    .await;
-    assert_child_reaped("kmsg", pid, starttime).await;
+    let timeout_message = format!(
+        "normal hard shutdown should stop the {} monitor",
+        component.label(),
+    );
+    assert_run_exits_within(run_handle, Duration::from_secs(3), &timeout_message).await;
+    assert_child_reaped(component.label(), pid, starttime).await;
+}
+
+#[tokio::test]
+async fn kmsg_stdout_eof_stops_runner_and_reaps_child_before_teardown() {
+    assert_network_log_eof_stops_runner(NetworkLogTestComponent::Kmsg).await;
+}
+
+#[tokio::test]
+async fn kmsg_stdout_read_error_stops_runner_and_kills_child() {
+    assert_network_log_read_error_stops_runner(NetworkLogTestComponent::Kmsg).await;
+}
+
+#[tokio::test]
+async fn normal_shutdown_cancels_kmsg_and_reaps_child_without_error() {
+    assert_normal_shutdown_reaps_network_log_child(NetworkLogTestComponent::Kmsg).await;
 }
 
 #[tokio::test]
 async fn dns_stderr_eof_stops_runner_and_reaps_child_before_teardown() {
-    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let (stdin, pid, starttime) = install_controllable_dns(&mut config).await;
-    env.handle.block_heartbeats();
-    let run_handle = tokio::spawn(run(config));
-
-    wait_discover_entered(&env, Duration::from_secs(2)).await;
-    drop(stdin);
-
-    assert!(
-        env.handle
-            .wait_heartbeat_in_flight(1, Duration::from_secs(2))
-            .await,
-        "dns EOF should drive runner teardown",
-    );
-    assert!(
-        !run_handle.is_finished(),
-        "blocked final heartbeat should hold teardown open",
-    );
-    assert_child_reaped("dns", pid, starttime).await;
-    assert!(env.cancel.is_cancelled(), "dns EOF should stop discovery");
-
-    env.handle.unblock_heartbeats();
-    assert_run_error_contains(run_handle, "dns monitor exited unexpectedly: Eof").await;
+    assert_network_log_eof_stops_runner(NetworkLogTestComponent::Dns).await;
 }
 
 #[tokio::test]
 async fn dns_stderr_read_error_stops_runner_and_kills_child() {
-    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let (mut stdin, pid, starttime) = install_controllable_dns(&mut config).await;
-    env.handle.block_heartbeats();
-    let run_handle = tokio::spawn(run(config));
-
-    wait_discover_entered(&env, Duration::from_secs(2)).await;
-    stdin.write_all(&[0xff, b'\n']).await.unwrap();
-    stdin.flush().await.unwrap();
-
-    assert!(
-        env.handle
-            .wait_heartbeat_in_flight(1, Duration::from_secs(2))
-            .await,
-        "dns read error should drive runner teardown",
-    );
-    assert_child_reaped("dns", pid, starttime).await;
-    assert!(
-        env.cancel.is_cancelled(),
-        "dns read error should stop discovery",
-    );
-
-    env.handle.unblock_heartbeats();
-    assert_run_error_contains(run_handle, "ReadError").await;
+    assert_network_log_read_error_stops_runner(NetworkLogTestComponent::Dns).await;
 }
 
 #[tokio::test]
@@ -280,20 +287,7 @@ async fn dns_monitor_task_panic_stops_runner_and_cancels_active_job() {
 
 #[tokio::test]
 async fn normal_shutdown_cancels_dns_and_reaps_child_without_error() {
-    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let (_stdin, pid, starttime) = install_controllable_dns(&mut config).await;
-    let run_handle = tokio::spawn(run(config));
-
-    wait_discover_entered(&env, Duration::from_secs(2)).await;
-    env.trigger_stopping().await;
-
-    assert_run_exits_within(
-        run_handle,
-        Duration::from_secs(3),
-        "normal hard shutdown should stop the dns monitor",
-    )
-    .await;
-    assert_child_reaped("dns", pid, starttime).await;
+    assert_normal_shutdown_reaps_network_log_child(NetworkLogTestComponent::Dns).await;
 }
 
 /// SIGTERM while a job is in flight: per-job cancellation fires, the

--- a/crates/runner/src/dns/proxy.rs
+++ b/crates/runner/src/dns/proxy.rs
@@ -8,16 +8,13 @@ use sandbox_fc::{DNS_DIAGNOSTIC_HOSTNAME, DNS_READINESS_HOSTNAME, DNS_READINESS_
 
 use super::log::tail_stderr;
 use super::port::DnsPortReservation;
-use crate::child_cleanup::kill_and_reap_child_on_drop;
 use crate::network_log_drain::{DrainableLineReaderExit, NetworkLogDrainProducer};
 use crate::network_log_manager::NetworkLogManager;
+use crate::network_log_process::NetworkLogProcess;
 
 /// Handle to the dnsmasq process and its log monitor.
 pub struct DnsProxy {
-    cancel: CancellationToken,
-    task: Option<tokio::task::JoinHandle<DrainableLineReaderExit>>,
-    child: Option<tokio::process::Child>,
-    drain: NetworkLogDrainProducer,
+    process: NetworkLogProcess,
     port: u16,
 }
 
@@ -25,34 +22,17 @@ impl DnsProxy {
     /// Await the log monitor task, or pend forever after its completion has
     /// already been consumed.
     pub(crate) async fn wait(&mut self) -> Result<DrainableLineReaderExit, tokio::task::JoinError> {
-        let result = match self.task.as_mut() {
-            Some(task) => task.await,
-            None => std::future::pending().await,
-        };
-        self.task = None;
-        result
+        self.process.wait().await
     }
 
     /// Kill dnsmasq when necessary and wait for it to be reaped.
     pub(crate) async fn kill_and_reap_child(&mut self) {
-        let child_reaped = if let Some(ref mut child) = self.child {
-            let _ = child.start_kill();
-            child.wait().await.is_ok()
-        } else {
-            false
-        };
-        if child_reaped {
-            self.child = None;
-        }
+        self.process.kill_and_reap_child().await;
     }
 
     /// Stop the DNS proxy and wait for cleanup.
-    pub async fn stop(mut self) {
-        self.cancel.cancel();
-        self.kill_and_reap_child().await;
-        if let Some(task) = self.task.take() {
-            let _ = task.await;
-        }
+    pub async fn stop(self) {
+        self.process.stop().await;
         info!("dns proxy stopped");
     }
 
@@ -66,34 +46,14 @@ impl DnsProxy {
     /// `NetworkLogDrainCoordinator` uses this to ask the dnsmasq stderr reader
     /// task to drain complete log rows already visible to that task.
     pub(crate) fn drain_producer(&self) -> NetworkLogDrainProducer {
-        self.drain.clone()
+        self.process.drain_producer()
     }
 
     /// Create a noop handle for testing. No `dnsmasq` process is spawned.
     #[cfg(test)]
     pub fn noop() -> Self {
-        let cancel = CancellationToken::new();
-        let token = cancel.clone();
-        let (drain, mut drain_rx) = NetworkLogDrainProducer::channel("dns");
         Self {
-            cancel,
-            task: Some(tokio::spawn(async move {
-                loop {
-                    tokio::select! {
-                        _ = token.cancelled() => {
-                            return DrainableLineReaderExit::Cancelled;
-                        }
-                        request = drain_rx.recv() => {
-                            let Some(request) = request else {
-                                return DrainableLineReaderExit::DrainChannelClosed;
-                            };
-                            request.ack();
-                        }
-                    }
-                }
-            })),
-            child: None,
-            drain,
+            process: NetworkLogProcess::noop("dnsmasq", "dns"),
             port: 0,
         }
     }
@@ -115,10 +75,7 @@ impl DnsProxy {
         let task = tokio::spawn(tail_stderr(stderr, network_log_manager, token, drain_rx));
 
         Ok(Self {
-            cancel,
-            task: Some(task),
-            child: Some(child),
-            drain,
+            process: NetworkLogProcess::new("dnsmasq", cancel, task, child, drain),
             port,
         })
     }
@@ -136,55 +93,9 @@ impl DnsProxy {
     pub(crate) async fn replace_monitor_with_panic_trigger_for_test(
         &mut self,
     ) -> std::sync::Arc<tokio::sync::Notify> {
-        let task = self.task.take().expect("DNS monitor task should exist");
-        task.abort();
-        let error = task
+        self.process
+            .replace_monitor_with_panic_trigger_for_test("dns")
             .await
-            .expect_err("aborted DNS monitor task should return a join error");
-        assert!(
-            error.is_cancelled(),
-            "aborted DNS monitor task should be cancelled: {error}",
-        );
-
-        let token = self.cancel.clone();
-        let trigger = std::sync::Arc::new(tokio::sync::Notify::new());
-        let task_trigger = std::sync::Arc::clone(&trigger);
-        let (drain, mut drain_rx) = NetworkLogDrainProducer::channel("dns");
-        self.drain = drain;
-        self.task = Some(tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    _ = token.cancelled() => {
-                        return DrainableLineReaderExit::Cancelled;
-                    }
-                    request = drain_rx.recv() => {
-                        let Some(request) = request else {
-                            return DrainableLineReaderExit::DrainChannelClosed;
-                        };
-                        request.ack();
-                    }
-                    _ = task_trigger.notified() => {
-                        panic!("simulated DNS monitor task panic");
-                    }
-                }
-            }
-        }));
-        trigger
-    }
-}
-
-impl Drop for DnsProxy {
-    /// Kill dnsmasq and abort the log task if `stop()` was never called.
-    ///
-    /// Prevents orphaned dnsmasq processes when shutdown misses the explicit
-    /// async `stop()` path. The cleanup helper also reaps children that already
-    /// exited before drop.
-    fn drop(&mut self) {
-        kill_and_reap_child_on_drop("dnsmasq", &mut self.child);
-        self.cancel.cancel();
-        if let Some(task) = &self.task {
-            task.abort();
-        }
     }
 }
 

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -14,12 +14,12 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use crate::child_cleanup::kill_and_reap_child_on_drop;
 use crate::network_log_drain::{
     DrainableLineReaderExit, NetworkLogDrainProducer, NetworkLogDrainRequest,
     run_drainable_line_reader,
 };
 use crate::network_log_manager::NetworkLogManager;
+use crate::network_log_process::NetworkLogProcess;
 
 /// Prefix used in iptables `--log-prefix` to identify our log lines.
 const LOG_PREFIX: &str = "VM0:";
@@ -27,10 +27,7 @@ const LOG_PREFIX: &str = "VM0:";
 /// Handle to the background kmsg monitor. Call [`KmsgHandle::stop`] during
 /// shutdown to cancel the async task and kill the `dmesg -w` child process.
 pub struct KmsgHandle {
-    cancel: CancellationToken,
-    task: Option<tokio::task::JoinHandle<DrainableLineReaderExit>>,
-    child: Option<tokio::process::Child>,
-    drain: NetworkLogDrainProducer,
+    process: NetworkLogProcess,
 }
 
 impl KmsgHandle {
@@ -40,62 +37,25 @@ impl KmsgHandle {
     /// Keeping the task in the handle lets the runner reactor select on it
     /// without taking ownership unless it actually completes.
     pub(crate) async fn wait(&mut self) -> Result<DrainableLineReaderExit, tokio::task::JoinError> {
-        let result = match self.task.as_mut() {
-            Some(task) => task.await,
-            None => std::future::pending().await,
-        };
-        self.task = None;
-        result
+        self.process.wait().await
     }
 
     /// Kill the dmesg child when necessary and wait for it to be reaped.
     pub(crate) async fn kill_and_reap_child(&mut self) {
-        let child_reaped = if let Some(ref mut child) = self.child {
-            let _ = child.start_kill();
-            child.wait().await.is_ok()
-        } else {
-            false
-        };
-        if child_reaped {
-            self.child = None;
-        }
+        self.process.kill_and_reap_child().await;
     }
 
     /// Stop the kmsg monitor and wait for cleanup.
-    pub async fn stop(mut self) {
-        self.cancel.cancel();
-        self.kill_and_reap_child().await;
-        if let Some(task) = self.task.take() {
-            let _ = task.await;
-        }
+    pub async fn stop(self) {
+        self.process.stop().await;
         info!("kmsg monitor stopped");
     }
 
     /// Create a noop handle for testing. No `dmesg` process is spawned.
     #[cfg(test)]
     pub fn noop() -> Self {
-        let cancel = CancellationToken::new();
-        let token = cancel.clone();
-        let (drain, mut drain_rx) = NetworkLogDrainProducer::channel("kmsg");
         Self {
-            cancel,
-            task: Some(tokio::spawn(async move {
-                loop {
-                    tokio::select! {
-                        _ = token.cancelled() => {
-                            return DrainableLineReaderExit::Cancelled;
-                        }
-                        request = drain_rx.recv() => {
-                            let Some(request) = request else {
-                                return DrainableLineReaderExit::DrainChannelClosed;
-                            };
-                            request.ack();
-                        }
-                    }
-                }
-            })),
-            child: None,
-            drain,
+            process: NetworkLogProcess::noop("dmesg", "kmsg"),
         }
     }
 
@@ -104,22 +64,7 @@ impl KmsgHandle {
     /// `NetworkLogDrainCoordinator` uses this to ask the `dmesg -w` reader
     /// task to drain complete log rows already visible to that task.
     pub(crate) fn drain_producer(&self) -> NetworkLogDrainProducer {
-        self.drain.clone()
-    }
-}
-
-impl Drop for KmsgHandle {
-    /// Kill dmesg and abort the log task if `stop()` was never called.
-    ///
-    /// Prevents a leaked `dmesg -w` process when shutdown misses the explicit
-    /// async `stop()` path. The cleanup helper also reaps children that already
-    /// exited before drop.
-    fn drop(&mut self) {
-        kill_and_reap_child_on_drop("dmesg", &mut self.child);
-        self.cancel.cancel();
-        if let Some(task) = &self.task {
-            task.abort();
-        }
+        self.process.drain_producer()
     }
 }
 
@@ -175,10 +120,7 @@ impl KmsgHandle {
 
         let task = tokio::spawn(run_loop(network_log_manager, token, stdout, drain_rx));
         Ok(Self {
-            cancel,
-            task: Some(task),
-            child: Some(child),
-            drain,
+            process: NetworkLogProcess::new("dmesg", cancel, task, child, drain),
         })
     }
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -30,6 +30,7 @@ mod lock;
 mod log_file;
 mod network_log_drain;
 mod network_log_manager;
+mod network_log_process;
 mod network_logs;
 mod paths;
 mod prefetch;

--- a/crates/runner/src/network_log_process.rs
+++ b/crates/runner/src/network_log_process.rs
@@ -1,0 +1,192 @@
+use tokio_util::sync::CancellationToken;
+
+use crate::child_cleanup::kill_and_reap_child_on_drop;
+use crate::network_log_drain::{DrainableLineReaderExit, NetworkLogDrainProducer};
+
+/// Owns the common post-spawn lifecycle of a required network-log process.
+pub(crate) struct NetworkLogProcess {
+    child_label: &'static str,
+    cancel: CancellationToken,
+    task: Option<tokio::task::JoinHandle<DrainableLineReaderExit>>,
+    child: Option<tokio::process::Child>,
+    drain: NetworkLogDrainProducer,
+}
+
+impl NetworkLogProcess {
+    pub(crate) fn new(
+        child_label: &'static str,
+        cancel: CancellationToken,
+        task: tokio::task::JoinHandle<DrainableLineReaderExit>,
+        child: tokio::process::Child,
+        drain: NetworkLogDrainProducer,
+    ) -> Self {
+        Self {
+            child_label,
+            cancel,
+            task: Some(task),
+            child: Some(child),
+            drain,
+        }
+    }
+
+    /// Await the monitor task, or pend forever after its completion has
+    /// already been consumed.
+    ///
+    /// Keeping the task in the owner lets the runner reactor select on it
+    /// without taking ownership unless it actually completes.
+    pub(crate) async fn wait(&mut self) -> Result<DrainableLineReaderExit, tokio::task::JoinError> {
+        let result = match self.task.as_mut() {
+            Some(task) => task.await,
+            None => std::future::pending().await,
+        };
+        self.task = None;
+        result
+    }
+
+    /// Kill the child when necessary and wait for it to be reaped.
+    pub(crate) async fn kill_and_reap_child(&mut self) {
+        let child_reaped = if let Some(ref mut child) = self.child {
+            let _ = child.start_kill();
+            child.wait().await.is_ok()
+        } else {
+            false
+        };
+        if child_reaped {
+            self.child = None;
+        }
+    }
+
+    /// Cancel the monitor task and wait for the child and task to finish.
+    pub(crate) async fn stop(mut self) {
+        self.cancel.cancel();
+        self.kill_and_reap_child().await;
+        if let Some(task) = self.task.take() {
+            let _ = task.await;
+        }
+    }
+
+    pub(crate) fn drain_producer(&self) -> NetworkLogDrainProducer {
+        self.drain.clone()
+    }
+
+    /// Create a lifecycle owner without a child process for runner tests.
+    #[cfg(test)]
+    pub(crate) fn noop(child_label: &'static str, drain_source: &'static str) -> Self {
+        let cancel = CancellationToken::new();
+        let token = cancel.clone();
+        let (drain, mut drain_rx) = NetworkLogDrainProducer::channel(drain_source);
+        Self {
+            child_label,
+            cancel,
+            task: Some(tokio::spawn(async move {
+                loop {
+                    tokio::select! {
+                        _ = token.cancelled() => {
+                            return DrainableLineReaderExit::Cancelled;
+                        }
+                        request = drain_rx.recv() => {
+                            let Some(request) = request else {
+                                return DrainableLineReaderExit::DrainChannelClosed;
+                            };
+                            request.ack();
+                        }
+                    }
+                }
+            })),
+            child: None,
+            drain,
+        }
+    }
+
+    /// Replace the monitor with a task that panics when triggered.
+    #[cfg(test)]
+    pub(crate) async fn replace_monitor_with_panic_trigger_for_test(
+        &mut self,
+        drain_source: &'static str,
+    ) -> std::sync::Arc<tokio::sync::Notify> {
+        let task = self.task.take().expect("monitor task should exist");
+        task.abort();
+        let error = task
+            .await
+            .expect_err("aborted monitor task should return a join error");
+        assert!(
+            error.is_cancelled(),
+            "aborted monitor task should be cancelled: {error}",
+        );
+
+        let token = self.cancel.clone();
+        let trigger = std::sync::Arc::new(tokio::sync::Notify::new());
+        let task_trigger = std::sync::Arc::clone(&trigger);
+        let (drain, mut drain_rx) = NetworkLogDrainProducer::channel(drain_source);
+        self.drain = drain;
+        self.task = Some(tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = token.cancelled() => {
+                        return DrainableLineReaderExit::Cancelled;
+                    }
+                    request = drain_rx.recv() => {
+                        let Some(request) = request else {
+                            return DrainableLineReaderExit::DrainChannelClosed;
+                        };
+                        request.ack();
+                    }
+                    _ = task_trigger.notified() => {
+                        panic!("simulated network-log monitor task panic");
+                    }
+                }
+            }
+        }));
+        trigger
+    }
+}
+
+impl Drop for NetworkLogProcess {
+    fn drop(&mut self) {
+        kill_and_reap_child_on_drop(self.child_label, &mut self.child);
+        self.cancel.cancel();
+        if let Some(task) = &self.task {
+            task.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(target_os = "linux")]
+mod tests {
+    use super::*;
+    use crate::process::read_process_stat;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn drop_reaps_owned_child() {
+        let child = tokio::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .unwrap();
+        let pid = child.id().unwrap();
+        let starttime = read_process_stat(pid).await.unwrap().starttime;
+        let cancel = CancellationToken::new();
+        let task_cancel = cancel.clone();
+        let task = tokio::spawn(async move {
+            task_cancel.cancelled().await;
+            DrainableLineReaderExit::Cancelled
+        });
+        let (drain, _drain_rx) = NetworkLogDrainProducer::channel("drop-test");
+        let process = NetworkLogProcess::new("drop-test", cancel, task, child, drain);
+
+        drop(process);
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let observed_starttime = read_process_stat(pid).await.map(|stat| stat.starttime);
+                if observed_starttime != Some(starttime) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("dropped network-log process should reap its child");
+    }
+}


### PR DESCRIPTION
## Summary

- extract a shared owner for required network-log child, monitor task, cancellation, and drain lifecycle
- centralize required Kmsg and DNS completion classification, hard-stop, and prompt reap while preserving independent waits
- share lifecycle contract tests and cover abnormal owner drop with a real child process

## Behavior and compatibility

- no behavior change is intended; existing startup logic, diagnostics, and teardown ordering are preserved
- no API, protocol, schema, configuration, persisted-state, or generated-artifact changes

## Explicit exclusions

- no generic process supervisor
- no restart policy
- no shared startup abstraction

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner network_log_process`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::main_loop::shutdown`
- `cargo test --manifest-path crates/Cargo.toml -p runner network_log_drain`
- `cargo test --manifest-path crates/Cargo.toml -p runner kmsg_log::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner dns::`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `git diff --check`

Closes #24851
