### PR TITLE
refactor(db): reference migrations by tag and enforce validator expiry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,9 @@ cd turbo && pnpm install && pnpm -F web db:migrate && pnpm build && pnpm test
 - `db:migrate` sets up the local database schema
 - `pnpm build` builds shared packages (e.g. `@vm0/core`)
 
+See [Database Migrations](turbo/packages/db/MIGRATIONS.md) for migration rollout,
+validation, and online SQL patterns.
+
 ### Running the Dev Server
 
 1. Run the preparation script (installs deps, migrates DB):

--- a/turbo/packages/db/MIGRATIONS.md
+++ b/turbo/packages/db/MIGRATIONS.md
@@ -1,0 +1,75 @@
+# Database Migrations
+
+Generate migrations with `pnpm -F @vm0/db db:generate` and verify them with
+`pnpm -F @vm0/db test:migration-consistency`. Do not edit an existing migration
+or snapshot after it has shipped.
+
+## Transition validators
+
+A transition validator protects an expand → contract rollout while old and new
+application versions and data shapes may coexist. Delete one only after all
+three event-based conditions are satisfied:
+
+1. Its target migration has shipped in a production release. Confirm that the
+   production `__drizzle_migrations.created_at` is greater than or equal to the
+   migration's `when` value in `src/migrations/meta/_journal.json`.
+2. The expand → contract cycle it covers is complete. The contract migration is
+   deployed, and no dual-write or dual-read compatibility window remains.
+3. Every invariant it asserts that still applies to the current schema has been
+   promoted to the permanent tier of the migration consistency suite.
+
+There is no time-based retention window. Elapsed time does not determine whether
+a transition validator still protects a live rollout. The squash line advances
+to the last migration in the most recent production release. When that removes a
+referenced migration tag from the journal, the consistency suite fails and the
+expired transition validator must be deleted.
+
+## Migration patterns
+
+[`0811_clear_non_goal_run_groups.sql`](./src/migrations/0811_clear_non_goal_run_groups.sql)
+is the only surviving example of an online backfill migration. It demonstrates:
+
+- the `-- vm0:non-transactional` marker;
+- narrowly relaxing the append-only trigger function and restoring its original
+  body byte-for-byte in the same migration; and
+- batching with `FOR UPDATE ... SKIP LOCKED` and explicit `COMMIT`, without
+  taking a `LOCK TABLE`.
+
+The following patterns no longer have a surviving migration example, so keep the
+complete SQL here.
+
+### Add and validate a constraint online
+
+Add the constraint with `NOT VALID` so PostgreSQL enforces it for new writes
+without first scanning all existing rows. Validate existing rows separately:
+
+```sql
+ALTER TABLE "child_table"
+ADD CONSTRAINT "child_table_parent_id_parent_table_id_fk"
+FOREIGN KEY ("parent_id") REFERENCES "parent_table" ("id")
+NOT VALID;
+--> statement-breakpoint
+ALTER TABLE "child_table"
+VALIDATE CONSTRAINT "child_table_parent_id_parent_table_id_fk";
+```
+
+### Create an index without blocking writes
+
+`CREATE INDEX CONCURRENTLY` cannot run inside a transaction, so the migration
+must use the non-transactional marker:
+
+```sql
+-- vm0:non-transactional
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "table_created_at_idx"
+ON "table" ("created_at");
+```
+
+## Permanent triggers and functions
+
+When a migration adds a trigger or function, update
+`EXPECTED_PERMANENT_TRIGGERS` or `EXPECTED_PERMANENT_FUNCTIONS` in
+`scripts/test-migration-consistency-schema.ts` in the same change. Trigger keys
+include the complete `pg_get_triggerdef` output, and function keys include the
+MD5 of the function body. Changing trigger timing, the function it executes, an
+`UPDATE OF` column list, or a function body therefore makes the permanent
+inventory test fail until the expected inventory is updated.

--- a/turbo/packages/db/scripts/test-migration-consistency-schema.ts
+++ b/turbo/packages/db/scripts/test-migration-consistency-schema.ts
@@ -126,9 +126,9 @@ async function resetDatabase(dbUrl: string): Promise<void> {
   });
 }
 
-async function applyMigrationsUpTo(
+async function applyMigrationsUpToTag(
   client: Client,
-  upToIdx: number,
+  upToTag: string,
 ): Promise<void> {
   // Create drizzle migrations table
   await client.query(`
@@ -143,10 +143,18 @@ async function applyMigrationsUpTo(
   const journalPath = path.join(MIGRATIONS_DIR, "meta/_journal.json");
   const journal = JSON.parse(await fs.readFile(journalPath, "utf-8"));
   const entries = journal.entries as Array<{ idx: number; tag: string }>;
+  const upToEntry = entries.find((entry) => {
+    return entry.tag === upToTag;
+  });
+  if (!upToEntry) {
+    throw new Error(
+      `Migration tag "${upToTag}" is absent from meta/_journal.json because that migration has been squashed. This transition validator is expired and should be deleted.`,
+    );
+  }
 
-  // Apply migrations up to the specified index
+  // Apply migrations up to the specified tag
   for (const entry of entries) {
-    if (entry.idx > upToIdx) break;
+    if (entry.idx > upToEntry.idx) break;
 
     const sqlFile = path.join(MIGRATIONS_DIR, `${entry.tag}.sql`);
     const sql = await fs.readFile(sqlFile, "utf-8");
@@ -182,15 +190,15 @@ async function applyMigrationsUpTo(
   }
 }
 
-async function runMigrationsUpTo(
+async function runMigrationsUpToTag(
   dbUrl: string,
-  upToIdx: number,
+  upToTag: string,
 ): Promise<void> {
   const client = new Client({ connectionString: dbUrl });
   await client.connect();
 
   try {
-    await applyMigrationsUpTo(client, upToIdx);
+    await applyMigrationsUpToTag(client, upToTag);
   } finally {
     await client.end();
   }
@@ -1194,6 +1202,19 @@ async function validateSnapshotFiles(): Promise<void> {
   console.log(`   ✅ All ${sqlFiles.length} migrations have snapshots`);
   console.log(`   ✅ Snapshot chain validated (id/prevId references intact)`);
   console.log();
+}
+
+async function validateMigrationTagReferences(): Promise<void> {
+  console.log("=== Phase 0.1: Validate Migration Tag References ===\n");
+
+  const source = await fs.readFile(fileURLToPath(import.meta.url), "utf8");
+  assert.doesNotMatch(
+    source,
+    /\b(?:applyMigrationsUpTo|runMigrationsUpTo)\s*\(/u,
+    "Transition validators must reference migrations by tag, not numeric index",
+  );
+
+  console.log("   ✅ Transition validators reference migrations by tag\n");
 }
 
 async function expectDatabaseError(
@@ -2470,8 +2491,9 @@ async function validateTimestampOrdering(): Promise<void> {
   console.log();
 }
 
-const RUN_EVENT_SEQUENCE_NUMBER_CONTRACTION_PREVIOUS_MIGRATION = 809;
-const RUN_EVENT_SEQUENCE_NUMBER_CONTRACTION_MIGRATION = 810;
+const RUN_EVENT_SEQUENCE_NUMBER_CONTRACTION_PREVIOUS_MIGRATION =
+  "0809_clean_kronos";
+const RUN_EVENT_SEQUENCE_NUMBER_CONTRACTION_MIGRATION = "0810_small_sway";
 
 async function addCurrentChatEventAdditiveStorage(
   client: Client,
@@ -2541,7 +2563,7 @@ async function validateRunEventSequenceNumberRollout(): Promise<void> {
 
   await createDatabase(testDb);
   try {
-    await runMigrationsUpTo(
+    await runMigrationsUpToTag(
       testDbUrl,
       RUN_EVENT_SEQUENCE_NUMBER_CONTRACTION_PREVIOUS_MIGRATION,
     );
@@ -2871,7 +2893,7 @@ async function validateRunEventSequenceNumberRollout(): Promise<void> {
       const strictRejectFunctionDefinition = rejectFunction.rows[0]?.definition;
       assert.ok(strictRejectFunctionDefinition);
 
-      await applyMigrationsUpTo(
+      await applyMigrationsUpToTag(
         client,
         RUN_EVENT_SEQUENCE_NUMBER_CONTRACTION_MIGRATION,
       );
@@ -3071,8 +3093,8 @@ async function validateRunEventSequenceNumberRollout(): Promise<void> {
   }
 }
 
-const GOAL_ONLY_RUN_GROUPS_PREVIOUS_MIGRATION = 810;
-const GOAL_ONLY_RUN_GROUPS_MIGRATION = 811;
+const GOAL_ONLY_RUN_GROUPS_PREVIOUS_MIGRATION = "0810_small_sway";
+const GOAL_ONLY_RUN_GROUPS_MIGRATION = "0811_clear_non_goal_run_groups";
 
 async function validateGoalOnlyRunGroupsCleanup(): Promise<void> {
   console.log("=== Validate goal-only run group cleanup ===\n");
@@ -3114,7 +3136,10 @@ async function validateGoalOnlyRunGroupsCleanup(): Promise<void> {
 
   await createDatabase(testDb);
   try {
-    await runMigrationsUpTo(testDbUrl, GOAL_ONLY_RUN_GROUPS_PREVIOUS_MIGRATION);
+    await runMigrationsUpToTag(
+      testDbUrl,
+      GOAL_ONLY_RUN_GROUPS_PREVIOUS_MIGRATION,
+    );
     const client = new Client({ connectionString: testDbUrl });
     await client.connect();
     try {
@@ -3257,7 +3282,7 @@ async function validateGoalOnlyRunGroupsCleanup(): Promise<void> {
         ],
       );
 
-      await applyMigrationsUpTo(client, GOAL_ONLY_RUN_GROUPS_MIGRATION);
+      await applyMigrationsUpToTag(client, GOAL_ONLY_RUN_GROUPS_MIGRATION);
 
       const runGroups = await client.query<{
         id: string;
@@ -3514,6 +3539,9 @@ async function main(): Promise<void> {
   try {
     // Step 0: Validate snapshot files
     await validateSnapshotFiles();
+
+    // Step 0.1: Validate transition validators use migration tags
+    await validateMigrationTagReferences();
 
     // Step 0.5: Validate timestamp ordering
     await validateTimestampOrdering();


### PR DESCRIPTION
## Summary

- resolve transition-validator migration boundaries through journal tags and fail with actionable squash-expiry guidance when a tag disappears
- convert both surviving transition validators to semantic tag constants and add a Phase 0 guard against numeric helper calls
- document validator deletion criteria, surviving online-backfill guidance, complete online constraint/index SQL patterns, and permanent trigger/function inventory maintenance

## Why

Numeric journal indexes can fall below a future squashed baseline. The old helper would then apply no migrations and fail later while inserting fixtures into an empty database, hiding the stale validator behind an unrelated missing-relation error. Resolving the intended tag through journal entries makes the removed migration and expired validator explicit.

## Validation

- `pnpm -F @vm0/db test:migration-consistency` — passed with the final tag references
- temporary missing-tag check with `0999_nope` — exited 1 and named `0999_nope`, stated that the migration was squashed, and instructed deletion of the expired transition validator; temporary edit reverted
- temporary previous-state check with `0808_baseline` — the complete migration consistency suite passed, confirming the baseline tag is legal; temporary edit reverted
- `pnpm knip` — passed in the repository CI toolchain (`vm0-toolchain:20260622`, Node 22 / pnpm 10.15) with no unused-code findings; only existing configuration hints were reported
- `pnpm -F @vm0/db lint` — passed
- `pnpm -F @vm0/db check-types` — passed
- Prettier check for all changed files — passed

Closes #24676
Refs #24634
