### PR TITLE
fix(platform): separate cloud browser from your computer in connector menu

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -202,6 +202,39 @@ describe("chat lifecycle", () => {
     );
   });
 
+  it("keeps Cloud browser out of the Your computer group", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockChatLifecycle(context);
+    context.mocks.api(zeroComputerUseHostsContract.list, ({ respond }) => {
+      return respond(200, { hosts: [] });
+    });
+
+    detachedSetupPage({
+      context,
+      path: AGENT_CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.ZeroBrowser]: true },
+    });
+
+    await screen.findByPlaceholderText(PLACEHOLDER);
+    await user.click(await screen.findByLabelText("Connectors"));
+
+    const cloudBrowserSwitch = await screen.findByRole("switch", {
+      name: "Disable Cloud browser",
+    });
+    expect(screen.getByText("No online computers")).toBeInTheDocument();
+
+    // Cloud browser is a Zero-hosted remote browser, not one of the user's own
+    // machines, so its toggle must stay above the "Your computer" heading
+    // instead of being listed under it. That heading labels the rows after it
+    // rather than wrapping them, so document order is the only page-visible
+    // expression of the grouping.
+    expect(
+      cloudBrowserSwitch.compareDocumentPosition(
+        screen.getByText("Your computer"),
+      ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("creates a new chat thread with Cloud browser on by default", async () => {
     const user = userEvent.setup({ delay: null });
     let sentCloudBrowserEnabled: boolean | undefined;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -5898,59 +5898,64 @@ function ComputerUseConnectorMenuSection({
   const { t } = useTranslation();
   return (
     <div className="shrink-0 border-t border-border/50 bg-gray-50 p-1 dark:bg-gray-100">
+      {computerUse.cloudBrowserAvailable && (
+        <>
+          <div
+            onClick={() => {
+              computerUse.onCloudBrowserChange(
+                !computerUse.cloudBrowserEnabled,
+              );
+            }}
+            className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-gray-100 dark:hover:bg-gray-200"
+          >
+            <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
+              <IconWorld size={16} stroke={1.5} />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm text-foreground">
+                {t(($) => {
+                  return $.chat.computerUse.cloudBrowser;
+                })}
+              </span>
+            </span>
+            <span
+              className="flex shrink-0 items-center"
+              onClick={(event) => {
+                event.stopPropagation();
+              }}
+            >
+              <LoadingSwitch
+                checked={computerUse.cloudBrowserEnabled}
+                onCheckedChange={onDomEventFn((enabled) => {
+                  computerUse.onCloudBrowserChange(enabled);
+                })}
+                loading={false}
+                ariaLabel={
+                  computerUse.cloudBrowserEnabled
+                    ? t(($) => {
+                        return $.chat.computerUse.disableCloudBrowser;
+                      })
+                    : t(($) => {
+                        return $.chat.computerUse.enableCloudBrowser;
+                      })
+                }
+                size="sm"
+              />
+            </span>
+          </div>
+          <div className="mx-2 my-1 border-t border-border/50" />
+        </>
+      )}
       <div className="px-2 pb-1 pt-1 text-xs text-muted-foreground">
         {t(($) => {
           return $.chat.computerUse.yourComputer;
         })}
       </div>
-      {computerUse.cloudBrowserAvailable && (
-        <div
-          onClick={() => {
-            computerUse.onCloudBrowserChange(!computerUse.cloudBrowserEnabled);
-          }}
-          className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 transition-colors hover:bg-gray-100 dark:hover:bg-gray-200"
-        >
-          <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
-            <IconWorld size={16} stroke={1.5} />
-          </span>
-          <span className="min-w-0 flex-1">
-            <span className="block truncate text-sm text-foreground">
-              {t(($) => {
-                return $.chat.computerUse.cloudBrowser;
-              })}
-            </span>
-          </span>
-          <span
-            className="flex shrink-0 items-center"
-            onClick={(event) => {
-              event.stopPropagation();
-            }}
-          >
-            <LoadingSwitch
-              checked={computerUse.cloudBrowserEnabled}
-              onCheckedChange={onDomEventFn((enabled) => {
-                computerUse.onCloudBrowserChange(enabled);
-              })}
-              loading={false}
-              ariaLabel={
-                computerUse.cloudBrowserEnabled
-                  ? t(($) => {
-                      return $.chat.computerUse.disableCloudBrowser;
-                    })
-                  : t(($) => {
-                      return $.chat.computerUse.enableCloudBrowser;
-                    })
-              }
-              size="sm"
-            />
-          </span>
-        </div>
-      )}
       {computerUse.loading ? (
         <div className="flex flex-col animate-pulse">
           {Array.from({ length: 2 }, (_, i) => {
             return (
-              <div key={i} className="flex items-center gap-2 px-2 py-2">
+              <div key={i} className="flex items-center gap-2 px-2 py-1.5">
                 <span className="h-4 w-4 shrink-0 rounded bg-muted/50" />
                 <span className="h-3.5 w-24 rounded bg-muted/50 flex-1" />
                 <span className="h-3 w-6 rounded-full bg-muted/50" />
@@ -5960,7 +5965,7 @@ function ComputerUseConnectorMenuSection({
         </div>
       ) : computerUse.hosts.length > 0 ? (
         <div
-          className="flex max-h-[108px] flex-col overflow-y-auto"
+          className="flex max-h-[96px] flex-col overflow-y-auto"
           role="group"
           aria-label={t(($) => {
             return $.chat.computerUse.hosts;
@@ -5974,7 +5979,7 @@ function ComputerUseConnectorMenuSection({
                 onClick={() => {
                   computerUse.onChange(checked ? null : host.id);
                 }}
-                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 transition-colors hover:bg-gray-100 dark:hover:bg-gray-200"
+                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-gray-100 dark:hover:bg-gray-200"
               >
                 <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
                   <IconDeviceDesktop size={16} stroke={1.5} />
@@ -6030,7 +6035,7 @@ function ComputerUseConnectorMenuSection({
           })}
         </div>
       ) : (
-        <div className="flex items-center gap-2 px-2 py-2 text-sm text-muted-foreground">
+        <div className="flex items-center gap-2 px-2 py-1.5 text-sm text-muted-foreground">
           <IconDeviceDesktop
             size={16}
             stroke={1.5}
@@ -6044,7 +6049,7 @@ function ComputerUseConnectorMenuSection({
       <PopoverClose asChild>
         <button
           type="button"
-          className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm text-foreground transition-colors hover:bg-gray-100 dark:hover:bg-gray-200"
+          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-gray-100 dark:hover:bg-gray-200"
           onClick={onOpenDownloadDialog}
         >
           <IconPlug


### PR DESCRIPTION
## Problem

In the chat composer's connector menu, the **Cloud browser** toggle was rendered inside the `Your computer` group, alongside the Computer Use host list and *Connect my computer*.

Cloud browser is a Zero-hosted remote browser — it does not run on the user's machine. Grouping the two under one label is a category error, and it produces a self-contradictory empty state: Cloud browser can be **on** while the same group reads *No online computers*.

## Change

`ComputerUseConnectorMenuSection` (`turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx`):

- Cloud browser is now its own row at the top of the footer, followed by a divider.
- `Your computer` now labels only real machines (host list / empty state / *Connect my computer*).
- Section rows tighten from `py-2` to `py-1.5`, and the host list max height goes `108px` → `96px`, so the added divider does not grow the menu.
- No copy or i18n changes — the Cloud browser row is self-evident and needs no caption of its own.

## Before / After

![Before and after](https://cdn.vm0.io/artifacts/ghuz5welmr.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)