### PR TITLE
refactor: remove the unreachable automation user_message fallback at claim

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -17,10 +17,6 @@ import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { morningBriefDeliveries } from "@vm0/db/schema/morning-brief";
 import { threadGoals } from "@vm0/db/schema/thread-goal";
 import {
-  zeroWorkflowAutomations,
-  zeroWorkflows,
-} from "@vm0/db/schema/zero-workflow";
-import {
   and,
   asc,
   eq,
@@ -387,10 +383,7 @@ async function resolveWorkflowQueueFirstClaimSnapshot(
       ...queueFirstReplacementTargetFields,
       automationId: chatAutomationContext.automationId,
       triggerSource: chatEvents.triggerSource,
-      triggerBrief: chatAutomationContext.triggerBrief,
       userMessage: chatEvents.userMessage,
-      workflowId: zeroWorkflows.id,
-      workflowName: zeroWorkflows.name,
     })
     .from(chatEvents)
     .leftJoin(
@@ -399,14 +392,6 @@ async function resolveWorkflowQueueFirstClaimSnapshot(
         eq(chatEvents.contextType, "automation"),
         eq(chatAutomationContext.id, chatEvents.contextId),
       ),
-    )
-    .leftJoin(
-      zeroWorkflowAutomations,
-      eq(zeroWorkflowAutomations.id, chatAutomationContext.automationId),
-    )
-    .leftJoin(
-      zeroWorkflows,
-      eq(zeroWorkflows.id, zeroWorkflowAutomations.workflowId),
     )
     .where(
       and(
@@ -429,24 +414,7 @@ async function resolveWorkflowQueueFirstClaimSnapshot(
   ) {
     return null;
   }
-  const userMessage =
-    head.userMessage ??
-    (head.workflowName === null
-      ? null
-      : createUserMessageDocument({
-          text: null,
-          nonContentPart: {
-            type: "automation",
-            workflowName: head.workflowName,
-            ...(head.workflowId === null
-              ? {}
-              : { workflowId: head.workflowId }),
-            ...(head.triggerBrief === null
-              ? {}
-              : { automationBrief: head.triggerBrief }),
-          },
-        }));
-  if (!userMessage) {
+  if (!head.userMessage) {
     throw new Error("Workflow queue event is missing its user message");
   }
   return {
@@ -454,7 +422,7 @@ async function resolveWorkflowQueueFirstClaimSnapshot(
     replacement: {
       chatThreadId: args.threadId,
       eventType: "input.prompt",
-      userMessage,
+      userMessage: head.userMessage,
       runId: args.runId,
       ...(head.triggerSource ? { triggerSource: head.triggerSource } : {}),
     },


### PR DESCRIPTION
## Summary

- remove the unreachable workflow-queue claim fallback that rebuilt an automation `user_message` from live workflow state
- remove the fallback-only `zero_workflow_automations` and `zero_workflows` joins, selected fields, and imports
- keep the `chat_automation_context` join and automation identity check
- keep the missing-`user_message` invariant throw so queue monitoring can surface violations

This is a read-only contraction: no schema migration, column change, data cleanup, API change, or client rendering change.

## Validation

- `pnpm exec prettier --write apps/api/src/signals/services/zero-chat-queued-event.service.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts --maxWorkers=1 --silent=passed-only -t "keeps claimed automation context after the automation is deleted|rejects only the failed webhook trigger and accepts the next event"` (2 passed)
- PR CI passed, including `lint-knip` (the full `pnpm knip` check), formatting, types, all eight API test shards, app/CLI tests, CLI E2E, and security gates

The broader two-file local automation queue run encountered the existing runner-queue `404 Job not found in queue` behavior in 10 cases; the same representative failure reproduces on unmodified `origin/main`. The rejection path and 12 other cases passed locally, and the complete PR CI test matrix passed.

## Pre-merge production verification

Verified against `vm0-prod-ro` at **2026-08-04 04:36:26 UTC** with the required event-type filter:

```sql
SELECT count(*) AS pending_automation
FROM chat_events e
WHERE e.event_type = 'input.automation'
  AND e.run_id IS NULL
  AND NOT EXISTS (
    SELECT 1
    FROM chat_events r
    WHERE r.revokes_event_id = e.id
  );
```

Result: **`pending_automation = 0`**.

The read-only verification found 781 matching `input.automation` / null-run candidates, all 781 referenced by a revoker, leaving zero pending automation inputs. Terminal `input.rejected` and `control.revoke` rows were not counted.

Closes #24877