### PR TITLE
feat: lift video attachments above the user message bubble

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1136,6 +1136,56 @@ describe("zero attachment chips", () => {
     expect(screen.getByText("this is the screencast")).toBeInTheDocument();
   });
 
+  it("shows user video attachments before the text bubble and keeps file chips inline", async () => {
+    const videoUrl = "https://cdn.vm7.io/artifacts/test/elevated/clip.mp4";
+    const docUrl = "https://cdn.vm7.io/artifacts/test/elevated/README.md";
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatEvents: [
+        {
+          id: "msg-video-then-text",
+          role: "user",
+          content: "Watch this clip",
+          attachFiles: [
+            {
+              id: "attachment-clip",
+              filename: "clip.mp4",
+              contentType: "video/mp4",
+              size: 4096,
+              url: videoUrl,
+            },
+            {
+              id: "attachment-readme",
+              filename: "README.md",
+              contentType: "text/markdown",
+              size: 512,
+              url: docUrl,
+            },
+          ],
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    const videoPreview = await screen.findByLabelText("Preview clip.mp4");
+    const text = await screen.findByText("Watch this clip");
+    const textBubble = text.closest(".zero-chat-bubble-user");
+    const docChip = screen.getByLabelText(
+      "Open markdown preview for README.md",
+    );
+
+    expect(textBubble).not.toBeNull();
+    expect(videoPreview.closest(".zero-chat-bubble-user")).toBeNull();
+    expect(
+      videoPreview.compareDocumentPosition(textBubble!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(docChip.closest(".zero-chat-bubble-user")).toBe(textBubble);
+    expect(docChip.parentElement).toHaveClass("mx-1");
+  });
+
   it("opens persisted canonical audio, video, and document attachments", async () => {
     const audioUrl =
       "https://cdn.vm7.io/artifacts/test/attachment-audio/briefing.mp3";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -6584,6 +6584,9 @@ const STRUCTURED_REFERENCE_CHIP_CLASS =
   "inline-flex max-w-[240px] items-center gap-1 rounded-md border " +
   "border-foreground/15 bg-background/80 px-1.5 py-0.5 align-middle " +
   "text-xs font-medium";
+// File chips carry their own border, so they need more breathing room from the
+// surrounding sentence than a borderless inline mention does.
+const INLINE_FILE_REFERENCE_SPACING_CLASS = "mx-1";
 const STRUCTURED_INLINE_REFERENCE_CLASS =
   "relative -top-px mx-0.5 inline-flex h-7 max-w-[240px] items-center " +
   "gap-1.5 rounded-md bg-orange-500/10 px-2 align-middle text-[13px] " +
@@ -6745,7 +6748,13 @@ function UserMessageFileReference({
         />
       );
     }
-    return <span className="inline-flex align-middle">{reference}</span>;
+    return (
+      <span
+        className={`${INLINE_FILE_REFERENCE_SPACING_CLASS} inline-flex align-middle`}
+      >
+        {reference}
+      </span>
+    );
   }
   return (
     <span
@@ -6757,7 +6766,7 @@ function UserMessageFileReference({
           filename: part.filenameSnapshot,
         },
       )}
-      className={`${STRUCTURED_REFERENCE_CHIP_CLASS} h-7`}
+      className={`${STRUCTURED_REFERENCE_CHIP_CLASS} ${INLINE_FILE_REFERENCE_SPACING_CLASS} h-7`}
       title={part.filenameSnapshot}
     >
       <FilePreviewIcon
@@ -7179,11 +7188,16 @@ function UserMessageContent({
   agentReferenceSignalsForId: ChatThreadSignals["agentReferenceSignalsForId"];
   composerSignals: ComposerSignals;
 }) {
-  const imageAttachments = attachments.filter((attachment) => {
-    return attachment.id !== null && attachment.isImage;
+  // Images and videos read as media, so they sit above the bubble as
+  // thumbnails instead of interrupting the sentence they were dropped into.
+  const mediaAttachments = attachments.filter((attachment) => {
+    return (
+      attachment.id !== null &&
+      (attachment.isImage || attachment.kind === "video")
+    );
   });
-  const imageAttachmentIds = new Set(
-    imageAttachments.flatMap((attachment) => {
+  const mediaAttachmentIds = new Set(
+    mediaAttachments.flatMap((attachment) => {
       return attachment.id ? [attachment.id] : [];
     }),
   );
@@ -7197,7 +7211,7 @@ function UserMessageContent({
       !isUserMessageNonContentPart(part) &&
       !isElevatedUserMessagePart(
         part,
-        imageAttachmentIds,
+        mediaAttachmentIds,
         inlineTemplatesEnabled,
       )
     );
@@ -7219,7 +7233,7 @@ function UserMessageContent({
         </div>
       ) : null}
       <UserMessageAttachments
-        attachments={imageAttachments}
+        attachments={mediaAttachments}
         onImageClick={onImageClick}
       />
       {hasBody ? (
@@ -7228,7 +7242,7 @@ function UserMessageContent({
             <UserMessageView
               document={document}
               attachments={referenceAttachments}
-              elevatedFileIds={imageAttachmentIds}
+              elevatedFileIds={mediaAttachmentIds}
               inlineTemplatesEnabled={inlineTemplatesEnabled}
               agentReferenceSignalsForId={agentReferenceSignalsForId}
               composerSignals={composerSignals}


### PR DESCRIPTION
## What

Closes #24875

In a user message, video attachments now render as thumbnails above the bubble, exactly like images. Non-media files keep their inline chip, but get horizontal spacing from the surrounding text.

Before, a message with an image and a video split its media across two places: the image was elevated above the bubble, while the video sat inline in the middle of the sentence. Inline file chips also butted straight up against adjacent words.

## Changes

- `UserMessageContent` elevates images **and** videos (`mediaAttachments`), and marks both as elevated parts so they are dropped from the inline body. `UserMessageAttachments` already rendered videos at the same 50px thumbnail size, so no new visual treatment was needed.
- Inline file chips (`UserMessageFileReference`) get `mx-1` on both sides — half the 8px gap used between elevated attachments, and a little more than the 2px used by borderless inline mentions, since these chips carry their own border.

## Testing

- New integration test in `zero-attachment-chips.test.tsx` asserts the video preview sits outside and before the text bubble while the markdown chip stays inside it with the spacing class. Verified it fails on unmodified code.
- `pnpm -F @vm0/app check-types`, `pnpm -F @vm0/app lint`, and the chat/attachment test files in `src/views/zero-page/__tests__` pass locally.

Not verified in a browser — no dev server was available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
