### PR TITLE
test(runner): verify workspace cache after idle take

### DIFF
--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -1,13 +1,14 @@
 use super::super::super::*;
 use super::super::support::{
     WorkspacePromotionSeedSpec, context_with_session, mock_run_config,
-    mock_run_config_with_overrides, push_job, seed_idle_pool,
+    mock_run_config_with_overrides, push_job, seed_idle_pool_with_overrides,
     seed_idle_pool_with_workspace_promotion, shutdown, test_profiles, wait_budget_count,
     wait_discover_entered, wait_idle_pool_reuse_keys,
 };
 
+use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
 use crate::paths::RunnerPaths;
-use crate::types::SandboxReuseResult;
+use crate::types::{SandboxReuseResult, WORKSPACE_AFFINITY_VERSION, WorkspaceCacheCapability};
 use crate::workspace_image_cache::WorkspaceImageCache;
 
 fn reusable_candidate(
@@ -23,6 +24,7 @@ async fn wait_heartbeat_with_workspace_after(
     handle: &crate::provider::mock::MockProviderHandle,
     mut cursor: usize,
     reuse_key: &str,
+    expected_workspace: &WorkspaceCacheCapability,
     timeout: Duration,
 ) -> bool {
     let deadline = tokio::time::Instant::now() + timeout;
@@ -30,10 +32,10 @@ async fn wait_heartbeat_with_workspace_after(
         {
             let heartbeats = handle.heartbeats.lock().unwrap_or_else(|e| e.into_inner());
             if heartbeats[cursor..].iter().any(|state| {
-                state
-                    .held_workspace_states
-                    .iter()
-                    .any(|state| state.reuse_key == reuse_key)
+                state.held_workspace_states.iter().any(|state| {
+                    state.reuse_key == reuse_key
+                        && state.workspace_caches.contains(expected_workspace)
+                })
             }) {
                 return true;
             }
@@ -75,6 +77,10 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
     let run_id = RunId::new_v4();
     let provider_session_id = "provider-session-cache-heartbeat";
     let reuse_key = "thread:cache-heartbeat";
+    let expected_workspace = WorkspaceCacheCapability {
+        profile: "vm0/default".to_string(),
+        workspace_affinity_version: WORKSPACE_AFFINITY_VERSION,
+    };
     let mut ctx = context_with_session(run_id, provider_session_id);
     ctx.reuse_key = Some(reuse_key.into());
     push_job(&env, run_id, "vm0/default", Some(ctx));
@@ -116,6 +122,7 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
             &env.handle,
             before,
             reuse_key,
+            &expected_workspace,
             Duration::from_secs(5),
         )
         .await,
@@ -238,6 +245,10 @@ async fn reuse_take_preserves_cached_workspace_snapshot_state() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
     overrides.push_wait_process_exit(sandbox::ProcessExit::new(1, 1, Vec::new(), Vec::new()));
+    let reuse_wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let reuse_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    add_healthy_reuse_preparation_matcher(&reuse_overrides);
+    reuse_overrides.set_wait_process_lifecycle_gate(reuse_wait_gate.clone());
 
     let mut profiles = test_profiles();
     profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
@@ -255,11 +266,24 @@ async fn reuse_take_preserves_cached_workspace_snapshot_state() {
         .unwrap()
         .workspace_cache = Some(workspace_cache.clone());
 
-    seed_idle_pool(&idle_pool, &budget, "sess-refresh", "vm0/default", 2, 4096).await;
+    seed_idle_pool_with_overrides(
+        &idle_pool,
+        &budget,
+        &reuse_overrides,
+        "sess-refresh",
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
 
     let run_handle = tokio::spawn(run(config));
     wait_discover_entered(&env, Duration::from_secs(5)).await;
-    let heartbeat_count = env.handle.heartbeat_count();
+    let promotion_heartbeat_count = env.handle.heartbeat_count();
+    let expected_workspace = WorkspaceCacheCapability {
+        profile: "vm0/default".to_string(),
+        workspace_affinity_version: WORKSPACE_AFFINITY_VERSION,
+    };
 
     let cache_run_id = RunId::new_v4();
     push_job(
@@ -296,11 +320,17 @@ async fn reuse_take_preserves_cached_workspace_snapshot_state() {
         .expect("cache seed job should complete");
     assert_eq!(cache_completion.exit_code, 1);
     assert!(
-        env.handle
-            .wait_heartbeat_past(heartbeat_count, Duration::from_secs(5))
-            .await,
-        "workspace cache promotion should refresh the workspace snapshot before claim"
+        wait_heartbeat_with_workspace_after(
+            &env.handle,
+            promotion_heartbeat_count,
+            "sess-cached",
+            &expected_workspace,
+            Duration::from_secs(5),
+        )
+        .await,
+        "workspace cache promotion should advertise the expected workspace before claim"
     );
+    let reuse_heartbeat_count = env.handle.heartbeat_count();
     let run_id = RunId::new_v4();
     push_job(
         &env,
@@ -308,6 +338,23 @@ async fn reuse_take_preserves_cached_workspace_snapshot_state() {
         "vm0/default",
         Some(context_with_session(run_id, "sess-refresh")),
     );
+    reuse_wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("reused wait_process should enter before the post-take heartbeat assertion");
+    assert!(
+        wait_heartbeat_with_workspace_after(
+            &env.handle,
+            reuse_heartbeat_count,
+            "sess-cached",
+            &expected_workspace,
+            Duration::from_secs(5),
+        )
+        .await,
+        "idle take should preserve the unrelated cached workspace in the immediate heartbeat"
+    );
+    reuse_overrides.clear_wait_process_lifecycle_gate();
+    reuse_wait_gate.release_one();
 
     let completion = env
         .handle

--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -25,17 +25,25 @@ async fn wait_heartbeat_with_workspace_after(
     mut cursor: usize,
     reuse_key: &str,
     expected_workspace: &WorkspaceCacheCapability,
+    absent_sandbox_reuse_key: Option<&str>,
     timeout: Duration,
 ) -> bool {
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
         {
             let heartbeats = handle.heartbeats.lock().unwrap_or_else(|e| e.into_inner());
-            if heartbeats[cursor..].iter().any(|state| {
-                state.held_workspace_states.iter().any(|state| {
+            if heartbeats[cursor..].iter().any(|heartbeat| {
+                let has_expected_workspace = heartbeat.held_workspace_states.iter().any(|state| {
                     state.reuse_key == reuse_key
                         && state.workspace_caches.contains(expected_workspace)
-                })
+                });
+                let omits_claimed_sandbox = absent_sandbox_reuse_key.is_none_or(|reuse_key| {
+                    heartbeat
+                        .held_sandbox_states
+                        .iter()
+                        .all(|state| state.reuse_key != reuse_key)
+                });
+                has_expected_workspace && omits_claimed_sandbox
             }) {
                 return true;
             }
@@ -123,6 +131,7 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
             before,
             reuse_key,
             &expected_workspace,
+            None,
             Duration::from_secs(5),
         )
         .await,
@@ -325,6 +334,7 @@ async fn reuse_take_preserves_cached_workspace_snapshot_state() {
             promotion_heartbeat_count,
             "sess-cached",
             &expected_workspace,
+            None,
             Duration::from_secs(5),
         )
         .await,
@@ -348,6 +358,7 @@ async fn reuse_take_preserves_cached_workspace_snapshot_state() {
             reuse_heartbeat_count,
             "sess-cached",
             &expected_workspace,
+            Some("sess-refresh"),
             Duration::from_secs(5),
         )
         .await,


### PR DESCRIPTION
## Summary

- require runner heartbeat tests to match the exact workspace cache profile and affinity version
- hold the reused sandbox active while asserting one immediate post-take heartbeat retains the unrelated workspace cache and no longer advertises the claimed idle sandbox
- preserve the existing successful reuse and idle-pool re-park coverage

## Scope

This is a test-only change. It does not modify runner heartbeat behavior, sandbox reuse behavior, APIs, protocols, persisted state, cache formats, or deployment compatibility.

## Validation

- `cargo test -p runner cmd::start::tests::idle_reuse::workspace_cache::reuse_take_preserves_cached_workspace_snapshot_state -- --exact --nocapture`
- focused target test repeated 20 times on the current head
- temporary negative heartbeat-filter mutation confirmed the active post-take assertion fails, then was reverted
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --no-deps --all-features`
- `cargo test -p runner --all-targets --all-features` (2945 passed, 15 ignored)
- repository pre-commit and commit-message hooks

Closes #24884
