### PR TITLE
perf(guest-agent): bound artifact checkpoint manifests

### DIFF
--- a/crates/api-contracts/src/generated/constants.rs
+++ b/crates/api-contracts/src/generated/constants.rs
@@ -160,3 +160,14 @@ pub mod runners {
         pub const CANONICAL_WORKING_DIR: &str = "/home/user/workspace";
     }
 }
+
+/// Storage manifest contract constants shared by TypeScript and Rust.
+pub mod storages {
+    /// Maximum file entries accepted in a storage manifest.
+    /// Guest artifact checkpointing and TypeScript storage webhook validation use this shared limit.
+    pub const STORAGE_MANIFEST_MAX_FILES: u64 = 50000;
+
+    /// Maximum cumulative UTF-8 path bytes accepted in a storage manifest.
+    /// Guest artifact checkpointing and TypeScript storage webhook validation use this shared limit.
+    pub const STORAGE_MANIFEST_MAX_PATH_BYTES: u64 = 8388608;
+}

--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -1,6 +1,10 @@
 use super::FileEntry;
 #[cfg(target_os = "linux")]
 use crate::nofollow_fs::Dir;
+#[cfg(target_os = "linux")]
+use api_contracts::generated::constants::storages::{
+    STORAGE_MANIFEST_MAX_FILES, STORAGE_MANIFEST_MAX_PATH_BYTES,
+};
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use guest_common::log_warn;
@@ -16,10 +20,11 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 #[cfg(target_os = "linux")]
 pub(super) fn collect_file_metadata(dir_path: &str) -> Result<Vec<FileEntry>, ArchiveError> {
     let mut files = Vec::new();
+    let mut path_bytes = 0;
     let root_path = Path::new(dir_path);
     let root = open_artifact_root(root_path)?;
     let entries = read_artifact_root(&root, root_path)?;
-    walk_entries(&root, "", entries, &mut files)?;
+    walk_entries(&root, "", entries, &mut files, &mut path_bytes)?;
     Ok(files)
 }
 
@@ -31,12 +36,17 @@ pub(super) fn collect_file_metadata(dir_path: &str) -> Result<Vec<FileEntry>, Ar
 }
 
 #[cfg(target_os = "linux")]
-fn walk_dir(current: &Dir, relative: &str, out: &mut Vec<FileEntry>) -> Result<(), ArchiveError> {
+fn walk_dir(
+    current: &Dir,
+    relative: &str,
+    out: &mut Vec<FileEntry>,
+    path_bytes: &mut u64,
+) -> Result<(), ArchiveError> {
     let entries = match current.read_dir() {
         Ok(e) => e,
         Err(_) => return Ok(()),
     };
-    walk_entries(current, relative, entries, out)
+    walk_entries(current, relative, entries, out, path_bytes)
 }
 
 #[cfg(target_os = "linux")]
@@ -45,6 +55,7 @@ fn walk_entries(
     relative: &str,
     entries: fs::ReadDir,
     out: &mut Vec<FileEntry>,
+    path_bytes: &mut u64,
 ) -> Result<(), ArchiveError> {
     for entry in entries.flatten() {
         let name = entry.file_name();
@@ -59,7 +70,7 @@ fn walk_entries(
         if try_directory && let Ok(dir) = current.open_child_dir(&name) {
             let name_str = artifact_path_component(&name, relative)?;
             let rel = relative_artifact_path(relative, name_str);
-            walk_dir(&dir, &rel, out)?;
+            walk_dir(&dir, &rel, out, path_bytes)?;
             continue;
         }
         if !try_file {
@@ -77,12 +88,30 @@ fn walk_entries(
         }
         let name_str = artifact_path_component(&name, relative)?;
         let rel = relative_artifact_path(relative, name_str);
+        let observed_files = u64::try_from(out.len())
+            .unwrap_or(u64::MAX)
+            .saturating_add(1);
+        let observed_path_bytes =
+            path_bytes.saturating_add(u64::try_from(rel.len()).unwrap_or(u64::MAX));
+        if observed_files > STORAGE_MANIFEST_MAX_FILES
+            || observed_path_bytes > STORAGE_MANIFEST_MAX_PATH_BYTES
+        {
+            return Err(ArchiveError::ManifestLimitExceeded {
+                observed_files,
+                max_files: STORAGE_MANIFEST_MAX_FILES,
+                observed_path_bytes,
+                max_path_bytes: STORAGE_MANIFEST_MAX_PATH_BYTES,
+            });
+        }
         match compute_file_hash_from_reader(file) {
-            Ok((hash, size)) => out.push(FileEntry {
-                path: rel,
-                hash,
-                size,
-            }),
+            Ok((hash, size)) => {
+                *path_bytes = observed_path_bytes;
+                out.push(FileEntry {
+                    path: rel,
+                    hash,
+                    size,
+                });
+            }
             Err(e) => {
                 log_warn!(LOG_TAG, "Could not process file {rel}: {e}");
             }
@@ -159,6 +188,15 @@ pub(super) enum ArchiveError {
         "artifact path component is not valid UTF-8 under {parent:?}: {component}; artifact paths must be valid UTF-8"
     )]
     NonUtf8PathComponent { parent: String, component: String },
+    #[error(
+        "artifact checkpoint manifest limit exceeded: candidate files {observed_files}/{max_files}, candidate UTF-8 path bytes {observed_path_bytes}/{max_path_bytes}"
+    )]
+    ManifestLimitExceeded {
+        observed_files: u64,
+        max_files: u64,
+        observed_path_bytes: u64,
+        max_path_bytes: u64,
+    },
     #[error("failed to create archive output {}: {source}", path.display())]
     CreateOutput { path: PathBuf, source: io::Error },
     #[error("invalid archive path {path:?}: path must be relative and stay within the artifact")]

--- a/crates/guest-agent/src/checkpoint/artifact.rs
+++ b/crates/guest-agent/src/checkpoint/artifact.rs
@@ -488,6 +488,10 @@ mod tests {
                 .path("/api/webhooks/agent/storages/commit");
             then.status(200).json_body(json!({"unreachable": true}));
         });
+        let upload = server.mock(|when, then| {
+            when.method(PUT);
+            then.status(200);
+        });
         let http = HttpClient::with_api_config(
             server.base_url(),
             "test-token",
@@ -524,6 +528,7 @@ mod tests {
             "got: {count_message}"
         );
         prepare.assert_calls(0);
+        upload.assert_calls(0);
         commit.assert_calls(0);
 
         let telemetry_entries = std::fs::read_to_string(&telemetry_path)

--- a/crates/guest-agent/src/checkpoint/artifact.rs
+++ b/crates/guest-agent/src/checkpoint/artifact.rs
@@ -243,6 +243,21 @@ mod tests {
 
     const REQUEST_OVERLAP_TIMEOUT: Duration = Duration::from_secs(5);
 
+    struct SandboxOpsOverrideGuard;
+
+    impl SandboxOpsOverrideGuard {
+        fn set(path: &std::path::Path) -> Self {
+            guest_common::telemetry::set_sandbox_ops_log_file(path);
+            Self
+        }
+    }
+
+    impl Drop for SandboxOpsOverrideGuard {
+        fn drop(&mut self) {
+            guest_common::telemetry::clear_sandbox_ops_log_file();
+        }
+    }
+
     async fn start_artifact_checkpoint_test_server(
         artifact_count: usize,
     ) -> (String, tokio::task::JoinHandle<Vec<String>>) {
@@ -392,6 +407,10 @@ mod tests {
                 .path("/api/webhooks/agent/storages/commit");
             then.status(200).json_body(json!({"unreachable": true}));
         });
+        let upload = server.mock(|when, then| {
+            when.method(PUT);
+            then.status(200);
+        });
         let http = HttpClient::with_api_config(
             server.base_url(),
             "test-token",
@@ -419,7 +438,137 @@ mod tests {
             "got: {err}"
         );
         prepare.assert_calls(0);
+        upload.assert_calls(0);
         commit.assert_calls(0);
+    }
+
+    #[tokio::test]
+    async fn artifact_snapshot_enforces_manifest_boundaries_before_storage_api_calls() {
+        use api_contracts::generated::constants::storages::{
+            STORAGE_MANIFEST_MAX_FILES, STORAGE_MANIFEST_MAX_PATH_BYTES,
+        };
+
+        let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
+        guest_common::log::clear_system_log_file();
+
+        let dir = tempfile::tempdir().unwrap();
+        let first_prefix = "a".repeat(200);
+        let second_prefix = "b".repeat(200);
+        let mount = dir
+            .path()
+            .join(first_prefix)
+            .join(second_prefix)
+            .join("files");
+        std::fs::create_dir_all(&mount).unwrap();
+        let max_files = usize::try_from(STORAGE_MANIFEST_MAX_FILES).unwrap();
+        for index in 0..max_files {
+            std::fs::File::create(mount.join(format!("{index:05}"))).unwrap();
+        }
+
+        let exact_files = vas::walk_files_for_checkpoint(mount.to_str().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(exact_files.len(), max_files);
+        drop(exact_files);
+
+        let over_limit_path = mount.join("over-limit");
+        std::fs::File::create(&over_limit_path).unwrap();
+
+        let telemetry_dir = tempfile::tempdir().unwrap();
+        let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
+        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+        let server = MockServer::start();
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let http = HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
+        .unwrap();
+        let entries = vec![env::ArtifactEnv {
+            name: "workspace".to_string(),
+            mount_path: mount.to_string_lossy().into_owned(),
+            storage_id: "storage-id".to_string(),
+            version_id: "parent-version".to_string(),
+            missing_root_policy: None,
+        }];
+
+        let count_error = snapshot_artifact_entries(&http, "test-run", &entries)
+            .await
+            .unwrap_err();
+        let count_message = count_error.to_string();
+        assert!(
+            count_message.contains(&format!(
+                "candidate files {}/{STORAGE_MANIFEST_MAX_FILES}",
+                STORAGE_MANIFEST_MAX_FILES + 1
+            )),
+            "got: {count_message}"
+        );
+        assert!(
+            count_message.contains("candidate UTF-8 path bytes"),
+            "got: {count_message}"
+        );
+        assert!(
+            count_message.contains(&format!("/{STORAGE_MANIFEST_MAX_PATH_BYTES}")),
+            "got: {count_message}"
+        );
+        prepare.assert_calls(0);
+        commit.assert_calls(0);
+
+        let telemetry_entries = std::fs::read_to_string(&telemetry_path)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        let failure = telemetry_entries
+            .iter()
+            .find(|entry| {
+                entry.get("action_type").and_then(serde_json::Value::as_str)
+                    == Some("artifact_hash_compute")
+                    && entry.get("success").and_then(serde_json::Value::as_bool) == Some(false)
+            })
+            .expect("failed artifact_hash_compute telemetry entry");
+        assert_eq!(
+            failure.get("error").and_then(serde_json::Value::as_str),
+            Some(
+                count_message
+                    .strip_prefix("checkpoint: ")
+                    .unwrap_or(&count_message)
+            )
+        );
+
+        std::fs::remove_file(over_limit_path).unwrap();
+        let path_error = vas::walk_files_for_checkpoint(dir.path().to_str().unwrap())
+            .await
+            .unwrap_err()
+            .into_agent_error();
+        let path_message = path_error.to_string();
+        assert!(
+            path_message.contains("candidate UTF-8 path bytes"),
+            "got: {path_message}"
+        );
+        assert!(
+            path_message.contains(&format!("/{STORAGE_MANIFEST_MAX_PATH_BYTES}")),
+            "got: {path_message}"
+        );
+        assert!(
+            !path_message.contains(&format!(
+                "candidate files {}/{STORAGE_MANIFEST_MAX_FILES}",
+                STORAGE_MANIFEST_MAX_FILES + 1
+            )),
+            "path-byte limit must fail before the file-count limit: {path_message}"
+        );
     }
 
     #[tokio::test]

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -1,7 +1,63 @@
 import { describe, expect, it } from "vitest";
 
 import { SESSION_HISTORY_DOWNLOAD_SOURCE_CONFIGURED_PUBLIC_ENDPOINT } from "../runners";
-import { webhookTelemetryContract } from "../webhooks";
+import {
+  STORAGE_MANIFEST_MAX_FILES,
+  STORAGE_MANIFEST_MAX_PATH_BYTES,
+  storageManifestFilesSchema,
+} from "../storages";
+import {
+  webhookStoragesCommitContract,
+  webhookStoragesPrepareContract,
+  webhookTelemetryContract,
+} from "../webhooks";
+
+const storageId = "00000000-0000-4000-8000-000000000000";
+const manifestHash = "a".repeat(64);
+
+function manifestFile(path: string) {
+  return { path, hash: manifestHash, size: 0 };
+}
+
+describe("storage webhook manifest limits", () => {
+  it("accepts the exact file-count boundary and rejects one more file", () => {
+    const exactFiles = Array.from(
+      { length: STORAGE_MANIFEST_MAX_FILES },
+      (_, index) => {
+        return manifestFile(`f-${index}`);
+      },
+    );
+    const overFiles = [...exactFiles, manifestFile("over-limit")];
+
+    expect(storageManifestFilesSchema.safeParse(exactFiles).success).toBe(true);
+    expect(
+      webhookStoragesPrepareContract.prepare.body.safeParse({
+        runId: "run-id",
+        storageId,
+        files: overFiles,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts the exact path-byte boundary and rejects one more byte", () => {
+    const exactFiles = [
+      manifestFile("é".repeat(STORAGE_MANIFEST_MAX_PATH_BYTES / 2)),
+    ];
+    const overFiles = [
+      manifestFile(`${"é".repeat(STORAGE_MANIFEST_MAX_PATH_BYTES / 2)}a`),
+    ];
+
+    expect(storageManifestFilesSchema.safeParse(exactFiles).success).toBe(true);
+    expect(
+      webhookStoragesCommitContract.commit.body.safeParse({
+        runId: "run-id",
+        storageId,
+        versionId: manifestHash,
+        files: overFiles,
+      }).success,
+    ).toBe(false);
+  });
+});
 
 describe("webhook telemetry contract", () => {
   it("accepts known session history download sources", () => {

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -186,7 +186,10 @@ export {
 } from "./zero-user-model-preference";
 export {
   MAX_FILE_SIZE_BYTES,
+  STORAGE_MANIFEST_MAX_FILES,
+  STORAGE_MANIFEST_MAX_PATH_BYTES,
   fileEntryWithHashSchema,
+  storageManifestFilesSchema,
   storageChangesSchema,
   presignedUploadSchema,
 } from "./storages";

--- a/turbo/packages/api-contracts/src/contracts/storages.ts
+++ b/turbo/packages/api-contracts/src/contracts/storages.ts
@@ -41,6 +41,11 @@ export const storageManifestFilesSchema = z
   )
   .refine(
     (files) => {
+      // The array check already rejects this case. Avoid another linear pass
+      // over an arbitrarily oversized request just to report a second issue.
+      if (files.length > STORAGE_MANIFEST_MAX_FILES) {
+        return true;
+      }
       let pathBytes = 0;
       for (const file of files) {
         pathBytes += storageManifestPathEncoder.encode(file.path).byteLength;

--- a/turbo/packages/api-contracts/src/contracts/storages.ts
+++ b/turbo/packages/api-contracts/src/contracts/storages.ts
@@ -6,6 +6,16 @@ import { z } from "zod";
 export const MAX_FILE_SIZE_BYTES = 104_857_600;
 
 /**
+ * Maximum file entries accepted in a storage manifest.
+ */
+export const STORAGE_MANIFEST_MAX_FILES = 50_000;
+
+/**
+ * Maximum cumulative UTF-8 path bytes accepted in a storage manifest.
+ */
+export const STORAGE_MANIFEST_MAX_PATH_BYTES = 8 * 1024 * 1024;
+
+/**
  * File entry with hash for content-addressable storage.
  */
 export const fileEntryWithHashSchema = z.object({
@@ -17,6 +27,33 @@ export const fileEntryWithHashSchema = z.object({
     .min(0, "Size must be non-negative")
     .max(MAX_FILE_SIZE_BYTES, "File size exceeds 100MB limit"),
 });
+
+const storageManifestPathEncoder = new TextEncoder();
+
+/**
+ * Bounded file entries for storage prepare and commit manifests.
+ */
+export const storageManifestFilesSchema = z
+  .array(fileEntryWithHashSchema)
+  .max(
+    STORAGE_MANIFEST_MAX_FILES,
+    `Storage manifest exceeds ${STORAGE_MANIFEST_MAX_FILES} files`,
+  )
+  .refine(
+    (files) => {
+      let pathBytes = 0;
+      for (const file of files) {
+        pathBytes += storageManifestPathEncoder.encode(file.path).byteLength;
+        if (pathBytes > STORAGE_MANIFEST_MAX_PATH_BYTES) {
+          return false;
+        }
+      }
+      return true;
+    },
+    {
+      message: `Storage manifest paths exceed ${STORAGE_MANIFEST_MAX_PATH_BYTES} UTF-8 bytes`,
+    },
+  );
 
 /**
  * Incremental changes for partial uploads.

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -11,9 +11,9 @@ import {
 } from "./runners";
 import { eventSequenceNumberSchema, networkLogEntrySchema } from "./runs";
 import {
-  fileEntryWithHashSchema,
-  storageChangesSchema,
   presignedUploadSchema,
+  storageChangesSchema,
+  storageManifestFilesSchema,
 } from "./storages";
 
 const c = initContract();
@@ -725,7 +725,7 @@ export const webhookStoragesPrepareContract = c.router({
        * mounts.
        */
       storageId: z.string().uuid(),
-      files: z.array(fileEntryWithHashSchema),
+      files: storageManifestFilesSchema,
       parentVersionId: z.string().optional(),
       force: z.boolean().optional(),
       baseVersion: z.string().optional(),
@@ -772,7 +772,7 @@ export const webhookStoragesCommitContract = c.router({
       storageId: z.string().uuid(),
       versionId: z.string().min(1, "Version ID is required"),
       parentVersionId: z.string().optional(),
-      files: z.array(fileEntryWithHashSchema),
+      files: storageManifestFilesSchema,
       message: z.string().optional(),
     }),
     responses: {

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
@@ -41,6 +41,10 @@ import {
   SESSION_HISTORY_ENCODING_ZSTD,
   SESSION_HISTORY_GZIP_MIN_BYTES,
 } from "../../contracts/runners";
+import {
+  STORAGE_MANIFEST_MAX_FILES,
+  STORAGE_MANIFEST_MAX_PATH_BYTES,
+} from "../../contracts/storages";
 
 const codexOauthPlaceholders =
   MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"].placeholders!;
@@ -53,6 +57,15 @@ const canonicalGuestHomeDirDoc = [
 const canonicalWorkingDirDoc = [
   "Canonical working directory path expected inside runner guests.",
   "Rust and TypeScript components use this shared contract value when building runner commands and paths.",
+] as const;
+
+const storageManifestMaxFilesDoc = [
+  "Maximum file entries accepted in a storage manifest.",
+  "Guest artifact checkpointing and TypeScript storage webhook validation use this shared limit.",
+] as const;
+const storageManifestMaxPathBytesDoc = [
+  "Maximum cumulative UTF-8 path bytes accepted in a storage manifest.",
+  "Guest artifact checkpointing and TypeScript storage webhook validation use this shared limit.",
 ] as const;
 
 const resumeSessionHistoryMaxBytesDoc = [
@@ -279,6 +292,18 @@ const expectedBindings = [
     rustDoc: canonicalWorkingDirDoc,
   },
   {
+    rustModulePath: ["storages"],
+    rustConstName: "STORAGE_MANIFEST_MAX_FILES",
+    value: rustU64(STORAGE_MANIFEST_MAX_FILES),
+    rustDoc: storageManifestMaxFilesDoc,
+  },
+  {
+    rustModulePath: ["storages"],
+    rustConstName: "STORAGE_MANIFEST_MAX_PATH_BYTES",
+    value: rustU64(STORAGE_MANIFEST_MAX_PATH_BYTES),
+    rustDoc: storageManifestMaxPathBytesDoc,
+  },
+  {
     rustModulePath: ["codex_oauth_token", "placeholders"],
     rustConstName: "CHATGPT_ACCESS_TOKEN",
     value: rustString(codexOauthPlaceholders.CHATGPT_ACCESS_TOKEN),
@@ -405,6 +430,7 @@ describe("Rust constant bindings", () => {
     expect(firstRender).toContain("pub mod model_provider_env {");
     expect(firstRender).toContain("pub mod client {");
     expect(firstRender).toContain("pub mod runners {");
+    expect(firstRender).toContain("pub mod storages {");
     expect(firstRender).toContain("pub mod placeholders {");
     expect(firstRender).toContain("pub mod headers {");
     expect(firstRender).toContain(
@@ -478,6 +504,12 @@ describe("Rust constant bindings", () => {
     );
     expect(firstRender).toContain(
       `pub const SESSION_HISTORY_GZIP_MIN_BYTES: u64 = ${SESSION_HISTORY_GZIP_MIN_BYTES};`,
+    );
+    expect(firstRender).toContain(
+      `pub const STORAGE_MANIFEST_MAX_FILES: u64 = ${STORAGE_MANIFEST_MAX_FILES};`,
+    );
+    expect(firstRender).toContain(
+      `pub const STORAGE_MANIFEST_MAX_PATH_BYTES: u64 = ${STORAGE_MANIFEST_MAX_PATH_BYTES};`,
     );
     expect(firstRender).toContain(
       `pub const CLIENT_VERSION_HEADER: &str = "${CLIENT_VERSION_HEADER}";`,

--- a/turbo/packages/api-contracts/src/rust-bindings/constants.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/constants.ts
@@ -30,6 +30,10 @@ import {
   SESSION_HISTORY_ENCODING_ZSTD,
   SESSION_HISTORY_GZIP_MIN_BYTES,
 } from "../contracts/runners";
+import {
+  STORAGE_MANIFEST_MAX_FILES,
+  STORAGE_MANIFEST_MAX_PATH_BYTES,
+} from "../contracts/storages";
 
 export type RustConstantValue =
   | {
@@ -86,6 +90,7 @@ const modelProviderEnvPlaceholderModule = [
 const clientHeadersModule = ["client", "headers"] as const;
 const clientTypesModule = ["client", "types"] as const;
 const runnerPathsModule = ["runners", "paths"] as const;
+const storagesModule = ["storages"] as const;
 
 export const rustConstantRootDoc = [
   "Generated Rust constants for `@vm0/api-contracts`.",
@@ -147,6 +152,12 @@ export const rustConstantModuleDocs = [
     rustModulePath: runnerPathsModule,
     rustDoc: [
       "Runner and guest filesystem path constants shared across Rust and TypeScript.",
+    ],
+  },
+  {
+    rustModulePath: storagesModule,
+    rustDoc: [
+      "Storage manifest contract constants shared by TypeScript and Rust.",
     ],
   },
 ] satisfies readonly RustConstantModuleDoc[];
@@ -381,6 +392,24 @@ export const rustConstantBindings = [
     rustDoc: [
       "Canonical working directory path expected inside runner guests.",
       "Rust and TypeScript components use this shared contract value when building runner commands and paths.",
+    ],
+  },
+  {
+    rustModulePath: storagesModule,
+    rustConstName: "STORAGE_MANIFEST_MAX_FILES",
+    value: rustU64(STORAGE_MANIFEST_MAX_FILES),
+    rustDoc: [
+      "Maximum file entries accepted in a storage manifest.",
+      "Guest artifact checkpointing and TypeScript storage webhook validation use this shared limit.",
+    ],
+  },
+  {
+    rustModulePath: storagesModule,
+    rustConstName: "STORAGE_MANIFEST_MAX_PATH_BYTES",
+    value: rustU64(STORAGE_MANIFEST_MAX_PATH_BYTES),
+    rustDoc: [
+      "Maximum cumulative UTF-8 path bytes accepted in a storage manifest.",
+      "Guest artifact checkpointing and TypeScript storage webhook validation use this shared limit.",
     ],
   },
   ...codexOauthPlaceholderNames.map((name) => {


### PR DESCRIPTION
## Summary

- define shared storage manifest limits of 50,000 files and 8 MiB of cumulative UTF-8 path bytes
- reject oversized artifact checkpoint manifests incrementally in the guest before hashing or retaining the crossing entry
- enforce the same limits on storage prepare and commit webhook contracts and generate the values into Rust
- cover exact and over-limit boundaries, pre-request rejection, and existing failure telemetry

## Compatibility

Within-limit manifests keep the existing wire shape and behavior. An older guest can still call the new API, where oversized manifests are rejected by contract validation; a new guest rejects the same manifests locally when paired with an older API. This intentionally tightens acceptance for pathological manifests without adding persisted state, protocol fields, migrations, or a feature flag.

## Validation

- `pnpm -F @vm0/api-contracts generate:rust`
- `pnpm -F @vm0/api-contracts test` (529 tests)
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm knip --workspace @vm0/api-contracts`
- runtime API schema generation and compatibility check against `runtime-api-schema-prod`
- `cargo fmt --all --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent --all-targets --all-features`
- `cargo clippy -p api-contracts --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p api-contracts --all-features --no-deps`
- `cargo test -p api-contracts --all-targets --all-features`
- repository pre-commit hooks, including full Knip, TypeScript type checks, Rust workspace Clippy, and Rust workspace docs

Closes #24879
