### PR TITLE
perf(python): bound anthropic json usage inspection

### DIFF
--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -15,6 +15,9 @@ from .model_tokens import ANTHROPIC_USAGE_FIELD_CATEGORIES
 from .sse import SseUsageScanner
 
 _ANTHROPIC_MESSAGES_USAGE_EVENTS = frozenset(("message_start", "message_delta"))
+# Bound dense syntax and slow scalar inspection while retaining the selective
+# parser's bulk-scan path for ordinary large content strings.
+_ANTHROPIC_MESSAGES_MAX_WORK_UNITS = 65_536
 _SseUsageParseErrorCallback = Callable[[str, str], None]
 AnthropicMessagesLifecycleCallback = Callable[[str, str | None], None]
 
@@ -136,7 +139,10 @@ class _AnthropicMessagesSseUsageHandler:
         )
 
     def on_event_start(self, event_name: str | None) -> None:
-        self._extractor = JsonSelectiveExtractor(scalar_fields=_ANTHROPIC_SSE_SCALAR_FIELDS)
+        self._extractor = JsonSelectiveExtractor(
+            scalar_fields=_ANTHROPIC_SSE_SCALAR_FIELDS,
+            max_work_units=_ANTHROPIC_MESSAGES_MAX_WORK_UNITS,
+        )
 
     def on_data(self, chunk: bytes) -> None:
         if self._extractor is not None:
@@ -211,7 +217,10 @@ class AnthropicMessagesJsonUsageExtractor:
     """
 
     def __init__(self) -> None:
-        self._extractor = JsonSelectiveExtractor(scalar_fields=_MODEL_JSON_SCALAR_FIELDS)
+        self._extractor = JsonSelectiveExtractor(
+            scalar_fields=_MODEL_JSON_SCALAR_FIELDS,
+            max_work_units=_ANTHROPIC_MESSAGES_MAX_WORK_UNITS,
+        )
 
     def feed(self, chunk: bytes) -> None:
         self._extractor.feed(chunk)

--- a/crates/runner/mitm-addon/tests/test_anthropic_messages.py
+++ b/crates/runner/mitm-addon/tests/test_anthropic_messages.py
@@ -6,6 +6,7 @@ import json
 import pytest
 
 from usage import (
+    create_anthropic_messages_json_usage_extractor,
     create_anthropic_messages_sse_usage_extractor,
     extract_anthropic_messages_usage_with_error_from_json,
 )
@@ -451,6 +452,44 @@ class TestAnthropicSseUsageExtractor:
             "tokens.output": 6,
         }
 
+    def test_work_limit_discards_partial_event_and_recovers(self):
+        parse_errors: list[tuple[str, str]] = []
+        lifecycle_events: list[tuple[str, str | None]] = []
+        parse, usage = create_anthropic_messages_sse_usage_extractor(
+            on_parse_error=lambda event, error: parse_errors.append((event, error)),
+            on_lifecycle_event=lambda event, block_type: lifecycle_events.append(
+                (event, block_type)
+            ),
+        )
+        dense_object_first_line = b",".join([b'"x":0'] * 10_000) + b","
+        dense_object_second_line = b",".join([b'"x":0'] * 10_000)
+
+        parse(
+            b"event: message_start\n"
+            b'data: {"type":"message_start","message":{"id":"msg_partial",'
+            b'"model":"claude-sonnet-4-6","usage":{"input_tokens":7}},'
+            b'"padding":{' + dense_object_first_line + b"\n"
+        )
+        parse(b"data: " + dense_object_second_line + b"}}\n\n")
+
+        assert usage == {}
+        assert lifecycle_events == []
+        assert parse_errors == [("message_start", "work limit exceeded")]
+
+        parse(
+            b"event: message_start\n"
+            b'data: {"type":"message_start","message":{"id":"msg_recovered",'
+            b'"model":"claude-sonnet-4-6","usage":{"input_tokens":9}}}\n\n'
+        )
+
+        assert usage == {
+            "message_id": "msg_recovered",
+            "model": "claude-sonnet-4-6",
+            "tokens.input": 9,
+        }
+        assert lifecycle_events == [("message_start", None)]
+        assert parse_errors == [("message_start", "work limit exceeded")]
+
     def test_empty_usage_dict_not_reported(self):
         """Empty model_provider_usage (SSE ran but no usage found) should not trigger report."""
         parse, usage = create_anthropic_messages_sse_usage_extractor()
@@ -591,6 +630,38 @@ class TestExtractAnthropicUsageWithErrorFromJson:
         assert result is not None
         assert result["tokens.cache_read"] == 50
         assert result["tokens.cache_creation"] == 0
+
+    def test_work_limit_accumulates_across_chunks_without_partial_usage(self):
+        extractor = create_anthropic_messages_json_usage_extractor()
+        dense_array = b",".join([b"0"] * 40_000)
+        extractor.feed(
+            b'{"id":"msg_partial","model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":50,"output_tokens":100},"padding":['
+        )
+        midpoint = len(dense_array) // 2
+        extractor.feed(dense_array[:midpoint])
+        extractor.feed(dense_array[midpoint:])
+        extractor.feed(b"]}")
+
+        assert extractor.finish() == (None, "work limit exceeded")
+
+    def test_large_discarded_ascii_content_stays_within_work_limit(self):
+        body = (
+            b'{"id":"msg_bulk","model":"claude-sonnet-4-6",'
+            b'"content":[{"type":"text","text":"'
+            + b"x" * (3 * 1024 * 1024)
+            + b'"}],"usage":{"input_tokens":50,"output_tokens":100}}'
+        )
+
+        result, error = extract_anthropic_messages_usage_with_error_from_json(body, None)
+
+        assert error is None
+        assert result == {
+            "message_id": "msg_bulk",
+            "model": "claude-sonnet-4-6",
+            "tokens.input": 50,
+            "tokens.output": 100,
+        }
 
     def test_gzip_compressed(self, headers):
         original = b'{"model":"test","usage":{"input_tokens":42}}'

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
@@ -15,6 +15,7 @@ import flow_metadata_keys as metadata_keys
 import mitm_addon
 from body_limits import (
     STREAM_BUFFER_LIMIT,
+    STREAM_DECODE_CHUNK_LIMIT,
     STREAM_DECODE_EXPANSION_GRACE,
     STREAM_DECODE_MAX_EXPANSION_RATIO,
 )
@@ -163,6 +164,54 @@ class TestModelProviderJsonStreaming:
             provider_case,
             cache_write_tokens=cache_write_tokens,
         )
+
+    @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
+    def test_full_pipeline_compressed_anthropic_json_work_limit(
+        self, tmp_path, real_flow, encoding_case
+    ):
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow = model_provider_flow(
+            real_flow,
+            tmp_path,
+            ANTHROPIC_JSON_CASE,
+            proxy_log_path=proxy_log_path,
+        )
+        payload = (
+            b'{"id":"msg_partial","model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":50,"output_tokens":200},"padding":['
+            + b",".join([b"0"] * 40_000)
+            + b"]}"
+        )
+        compressed = gzip.compress(payload) if encoding_case == "gzip" else zlib.compress(payload)
+        allowed_decoded_bytes = max(
+            STREAM_DECODE_EXPANSION_GRACE,
+            len(compressed) * STREAM_DECODE_MAX_EXPANSION_RATIO,
+        )
+        assert STREAM_DECODE_CHUNK_LIMIT < len(payload) <= allowed_decoded_bytes
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map(
+                {"content-type": "application/json", "content-encoding": encoding_case}
+            ),
+        )
+
+        mitm_addon.responseheaders(flow)
+        assert response_stream(flow)(compressed) == compressed
+
+        webhook = run_response(flow, self._usage_webhook_api)
+
+        assert webhook.request_count == 0
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
+        entries = read_jsonl_entries_after_flush(proxy_log_path)
+        usage_warnings = [
+            entry
+            for entry in entries
+            if entry.get("message") == "Model provider JSON usage extraction failed"
+        ]
+        assert len(usage_warnings) == 1
+        assert usage_warnings[0]["level"] == "warn"
+        assert usage_warnings[0]["type"] == "usage_event"
+        assert usage_warnings[0]["error"] == "work limit exceeded"
 
     @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
     def test_full_pipeline_zlib_expansion_limit_preserves_wire_body_and_rejects_usage(


### PR DESCRIPTION
## Summary

- apply a fixed `65_536` work-unit budget to each Anthropic non-SSE JSON document and captured SSE event
- discard partial usage and lifecycle observations on exhaustion while preserving later-event recovery and unchanged response forwarding
- cover dense arrays/objects, multi-line SSE events, large bulk strings, and one-callback gzip/deflate expansion through the real response pipeline

## Scope

- keeps the shared `JsonSelectiveExtractor` default and unrelated consumers unchanged
- adds no API, schema, persisted-state, environment, feature-switch, or decoder-protocol changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_anthropic_messages.py tests/test_model_provider_json_streaming.py tests/test_model_provider_sse_usage.py` (98 passed)
- `uv run --no-sync python -m pytest tests/` (4,708 passed)

Closes #24890
