### PR TITLE
perf(runner): retain healthy failed and cancelled sandboxes

### DIFF
--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -211,6 +211,7 @@ impl ExecutorInvocation {
                 ExecutorPhaseOutcome {
                     outcome: executor::ExecuteOutcome {
                         failure: Some(failure),
+                        sandbox_reuse_disposition: executor::SandboxReuseDisposition::default(),
                         sandbox: None,
                         source_ip: String::new(),
                         network_log_session: None,
@@ -295,6 +296,7 @@ impl FinalizationPhase {
         } = executor_result;
         let executor::ExecuteOutcome {
             failure: _,
+            sandbox_reuse_disposition,
             sandbox,
             source_ip,
             network_log_session,
@@ -344,6 +346,7 @@ impl FinalizationPhase {
                 parking_gate,
                 network_log_drain,
                 exit_code,
+                sandbox_reuse_disposition,
                 cancel,
                 cleanup_state,
                 #[cfg(test)]
@@ -356,6 +359,14 @@ impl FinalizationPhase {
         let finalization_duration = finalization_started.elapsed();
         let disposition = cleanup_state_after_finalize.disposition();
         let reuse_state_changed = completion_ready.reuse_state_changed();
+        if had_sandbox {
+            telemetry.record(
+                sandbox_reuse_disposition.telemetry_action(),
+                Duration::ZERO,
+                true,
+                None,
+            );
+        }
         let (finalization_action, finalization_success, finalization_error) = match disposition {
             RunCleanupDisposition::IdlePoolOwned => {
                 ("runner_host_finalization_reusable_sandbox", true, None)
@@ -517,10 +528,10 @@ impl DeferredUploadPhase {
 /// If `reuse_entry` is `Some`, the job reuses an existing idle sandbox.
 /// Otherwise it creates a new one via the factory.
 ///
-/// A sandbox is considered for idle parking only after a successful, uncancelled
-/// execution while parking is open and a reuse key is available. Park failure,
-/// cancellation before idle-pool transfer, or pool rejection falls back to
-/// destruction.
+/// A sandbox is considered for idle parking only after execution supplies a
+/// positive reuse disposition while parking is open, no hard cancellation is
+/// active, and a reuse key is available. Park failure, hard cancellation before
+/// idle-pool transfer, or pool rejection falls back to destruction.
 ///
 /// The completion state returned by finalization carries
 /// [`BudgetOwnership`](super::job_lifecycle::BudgetOwnership). Non-accepted paths
@@ -945,6 +956,9 @@ mod tests {
         ExecutorPhaseOutcome {
             outcome: executor::ExecuteOutcome {
                 failure: None,
+                sandbox_reuse_disposition: executor::SandboxReuseDisposition::Eligible(
+                    executor::SandboxReuseTerminal::Success,
+                ),
                 sandbox: Some(Box::new(mock_sandbox_ready_for_idle_reuse(sandbox_name))),
                 source_ip: "10.0.0.1".into(),
                 network_log_session: None,
@@ -962,6 +976,7 @@ mod tests {
         ExecutorPhaseOutcome {
             outcome: executor::ExecuteOutcome {
                 failure: None,
+                sandbox_reuse_disposition: executor::SandboxReuseDisposition::default(),
                 sandbox: None,
                 source_ip: String::new(),
                 network_log_session: None,
@@ -1040,6 +1055,10 @@ mod tests {
         assert_telemetry_action(
             &finalized.telemetry,
             "runner_host_finalization_reusable_sandbox",
+        );
+        assert_telemetry_action(
+            &finalized.telemetry,
+            "runner_terminal_sandbox_reuse_eligible_success",
         );
         assert_telemetry_action(&finalized.telemetry, "session_history_identity_parked");
         assert_eq!(

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -221,6 +221,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                 SandboxReuseDisposition::Eligible(SandboxReuseTerminal::Success) => Some(run_id),
                 SandboxReuseDisposition::Eligible(
                     SandboxReuseTerminal::NonzeroExit
+                    | SandboxReuseTerminal::ExecutionTimeout
                     | SandboxReuseTerminal::CooperativeCancellation,
                 )
                 | SandboxReuseDisposition::Ineligible(_) => None,

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -22,6 +22,7 @@ use super::job_lifecycle::{
 use super::ownership::OwnershipTransitions;
 #[cfg(test)]
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
+use crate::executor::{SandboxReuseDisposition, SandboxReuseTerminal};
 use crate::idle_pool::{
     DestroyOutcome, IdleDestroyPayload, IdleParkActiveParts, IdleParkFailureParts, IdleParkRequest,
     IdleParkRequestParts, ParkResult, ParkingGate,
@@ -101,6 +102,7 @@ pub(super) struct FinalizeContext {
     pub(super) parking_gate: ParkingGate,
     pub(super) network_log_drain: NetworkLogDrainCoordinator,
     pub(super) exit_code: i32,
+    pub(super) sandbox_reuse_disposition: SandboxReuseDisposition,
     pub(super) cancel: RunCancellationHandle,
     pub(super) cleanup_state: RunCleanupState,
     #[cfg(test)]
@@ -112,10 +114,10 @@ pub(super) struct FinalizeContext {
 /// Finalizes ownership of a sandbox returned by the executor.
 ///
 /// `None` requires no sandbox lifecycle action. For `Some`, idle parking is
-/// considered only when the exit code is zero, cancellation is not active, the
-/// parking gate is open, and a reuse key is available. Otherwise, or if
-/// cancellation wins before ownership transfer or parking cannot complete, the
-/// sandbox is stopped and destroyed.
+/// considered only when execution supplied positive reuse evidence, hard
+/// cancellation is not active, the parking gate is open, and a reuse key is
+/// available. Otherwise, or if hard cancellation wins before ownership
+/// transfer or parking cannot complete, the sandbox is stopped and destroyed.
 pub(super) async fn finalize_sandbox_for_completion(
     sandbox: Option<Box<dyn Sandbox>>,
     active_lease: ActiveBudgetLease,
@@ -148,6 +150,7 @@ pub(super) async fn finalize_sandbox_for_completion(
         parking_gate,
         network_log_drain,
         exit_code,
+        sandbox_reuse_disposition,
         cancel,
         cleanup_state,
         #[cfg(test)]
@@ -164,16 +167,23 @@ pub(super) async fn finalize_sandbox_for_completion(
         outer_job_panic,
     };
     let cancelled = cancel.is_cancelled();
+    let hard_cancelled = cancel.is_hard_cancelled();
     let terminal_status = workspace_terminal_status(exit_code, cancelled);
     let completed_at = local_completed_at();
     let resolved_cli_agent_session_id = cli_agent_session_id
         .as_deref()
         .or(discovered_cli_agent_session_id.as_deref());
-    let parkable_reuse_key = if exit_code == 0 && !cancelled && parking_gate.is_open() {
-        reuse_key.clone()
-    } else {
-        None
-    };
+    info!(
+        run_id = %run_id,
+        sandbox_reuse_disposition = sandbox_reuse_disposition.as_str(),
+        "evaluating terminal sandbox reuse"
+    );
+    let parkable_reuse_key =
+        if sandbox_reuse_disposition.is_eligible() && !hard_cancelled && parking_gate.is_open() {
+            reuse_key.clone()
+        } else {
+            None
+        };
     let workspace_promotion = workspace_image.and_then(|workspace_image| {
         workspace_image.into_promotion_context(WorkspaceImagePromotionRequest {
             run_id,
@@ -207,7 +217,14 @@ pub(super) async fn finalize_sandbox_for_completion(
             source_ip,
             storage_fingerprints,
             restored_session_identity,
-            history_generation_run_id: Some(run_id),
+            history_generation_run_id: match sandbox_reuse_disposition {
+                SandboxReuseDisposition::Eligible(SandboxReuseTerminal::Success) => Some(run_id),
+                SandboxReuseDisposition::Eligible(
+                    SandboxReuseTerminal::NonzeroExit
+                    | SandboxReuseTerminal::CooperativeCancellation,
+                )
+                | SandboxReuseDisposition::Ineligible(_) => None,
+            },
             workspace_image_size_bytes,
             workspace_promotion,
         });
@@ -308,19 +325,19 @@ pub(super) async fn finalize_sandbox_for_completion(
             },
         };
         let (candidate, non_reusable_reason) = park_outcome.into_parts();
-        if cancel.is_cancelled() {
+        if cancel.is_hard_cancelled() {
             let (payload, budget_lease) = candidate.into_active_destroy_parts();
             close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
             info!(
                 run_id = %run_id,
                 reuse_key_fingerprint = %reuse_key_fingerprint,
                 reuse_key_kind = reuse_kind,
-                "job cancelled while parking, destroying VM"
+                "job hard-cancelled while parking, destroying VM"
             );
             let destroy_result = destroy_active_owned_idle_payload(
                 payload,
                 budget_lease,
-                "cancelled",
+                "hard_cancellation",
                 destroy_bookkeeping,
             )
             .await;
@@ -364,26 +381,26 @@ pub(super) async fn finalize_sandbox_for_completion(
             test_observer.notify_before_idle_pool_ownership_transfer(run_id);
             loop {
                 let mut pool = idle_pool.lock().await;
-                // Let cancellation win while finalization is still waiting for
-                // the pool lock. Once the pool lock is held, only enter the
+                // Let hard cancellation win while finalization is still waiting
+                // for the pool lock. Once the pool lock is held, only enter the
                 // final transfer boundary if the per-run gate is immediately
                 // available; otherwise release the pool lock before waiting.
                 let Some(transfer_guard) = cancel.try_transfer_guard() else {
                     drop(pool);
                     let transfer_guard = cancel.transfer_guard().await;
-                    if cancel.is_cancelled() {
+                    if cancel.is_hard_cancelled() {
                         info!(
                             run_id = %run_id,
                             reuse_key_fingerprint = %reuse_key_fingerprint,
                             reuse_key_kind = reuse_kind,
-                            "job cancelled before idle pool ownership transfer, destroying VM"
+                            "job hard-cancelled before idle pool ownership transfer, destroying VM"
                         );
                         drop(transfer_guard);
                         let (payload, budget_lease) = candidate.into_active_destroy_parts();
                         let destroy_result = destroy_active_owned_idle_payload(
                             payload,
                             budget_lease,
-                            "cancelled",
+                            "hard_cancellation",
                             destroy_bookkeeping,
                         )
                         .await;
@@ -402,12 +419,12 @@ pub(super) async fn finalize_sandbox_for_completion(
                     drop(transfer_guard);
                     continue;
                 };
-                if cancel.is_cancelled() {
+                if cancel.is_hard_cancelled() {
                     info!(
                         run_id = %run_id,
                         reuse_key_fingerprint = %reuse_key_fingerprint,
                         reuse_key_kind = reuse_kind,
-                        "job cancelled before idle pool ownership transfer, destroying VM"
+                        "job hard-cancelled before idle pool ownership transfer, destroying VM"
                     );
                     drop(transfer_guard);
                     drop(pool);
@@ -415,7 +432,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                     let destroy_result = destroy_active_owned_idle_payload(
                         payload,
                         budget_lease,
-                        "cancelled",
+                        "hard_cancellation",
                         destroy_bookkeeping,
                     )
                     .await;
@@ -534,7 +551,11 @@ pub(super) async fn finalize_sandbox_for_completion(
         }
     } else {
         // No parkable reuse key — stop + destroy.
-        let cleanup_reason = active_cleanup_reason(exit_code, cancelled, parking_gate.is_open());
+        let cleanup_reason = active_cleanup_reason(
+            sandbox_reuse_disposition,
+            hard_cancelled,
+            parking_gate.is_open(),
+        );
         let destroy_result = stop_and_destroy_sandbox(
             sandbox,
             &**factory,
@@ -622,11 +643,18 @@ async fn close_network_log_session(
     }
 }
 
-fn active_cleanup_reason(exit_code: i32, cancelled: bool, parking_open: bool) -> &'static str {
-    if cancelled {
-        "cancelled"
-    } else if exit_code != 0 {
-        "nonzero_exit"
+fn active_cleanup_reason(
+    sandbox_reuse_disposition: SandboxReuseDisposition,
+    hard_cancelled: bool,
+    parking_open: bool,
+) -> &'static str {
+    if hard_cancelled {
+        "hard_cancellation"
+    } else if matches!(
+        sandbox_reuse_disposition,
+        SandboxReuseDisposition::Ineligible(_)
+    ) {
+        sandbox_reuse_disposition.as_str()
     } else if !parking_open {
         "parking_closed"
     } else {
@@ -877,6 +905,9 @@ mod tests {
                 parking_gate: self.parking_gate.clone(),
                 network_log_drain: NetworkLogDrainCoordinator::noop(),
                 exit_code: 0,
+                sandbox_reuse_disposition: SandboxReuseDisposition::Eligible(
+                    SandboxReuseTerminal::Success,
+                ),
                 cancel,
                 cleanup_state: RunCleanupState::new(),
                 outer_job_panic: None,
@@ -1779,6 +1810,14 @@ mod tests {
         context.discovered_cli_agent_session_id = None;
         context.restored_session_identity = None;
         context.exit_code = 1;
+        context.sandbox_reuse_disposition = if cancelled {
+            SandboxReuseDisposition::Eligible(SandboxReuseTerminal::CooperativeCancellation)
+        } else {
+            SandboxReuseDisposition::Eligible(SandboxReuseTerminal::NonzeroExit)
+        };
+        if !cancelled {
+            assert!(context.parking_gate.soft_drain());
+        }
         context.workspace_image = Some(workspace_image);
         context.workspace_image_size_bytes = b"image".len() as u64;
 
@@ -2016,6 +2055,9 @@ mod tests {
         context.cli_agent_session_id = None;
         context.discovered_cli_agent_session_id = None;
         context.exit_code = 1;
+        context.sandbox_reuse_disposition =
+            SandboxReuseDisposition::Eligible(SandboxReuseTerminal::NonzeroExit);
+        assert!(context.parking_gate.soft_drain());
         context.workspace_image = Some(workspace_image);
         context.workspace_image_size_bytes = b"image".len() as u64;
         let workspace_cache_snapshot = context.workspace_cache_snapshot.clone();
@@ -2100,6 +2142,9 @@ mod tests {
         context.cli_agent_session_id = None;
         context.discovered_cli_agent_session_id = None;
         context.exit_code = 1;
+        context.sandbox_reuse_disposition =
+            SandboxReuseDisposition::Eligible(SandboxReuseTerminal::NonzeroExit);
+        assert!(context.parking_gate.soft_drain());
         context.workspace_image = Some(workspace_image);
         context.workspace_image_size_bytes = b"image".len() as u64;
         let workspace_cache_snapshot = context.workspace_cache_snapshot.clone();
@@ -2177,6 +2222,9 @@ mod tests {
         );
         context.factory = factory;
         context.exit_code = 1;
+        context.sandbox_reuse_disposition =
+            SandboxReuseDisposition::Eligible(SandboxReuseTerminal::NonzeroExit);
+        assert!(context.parking_gate.soft_drain());
         context.workspace_image = Some(workspace_image);
         context.workspace_image_size_bytes = b"image".len() as u64;
         let workspace_cache_snapshot = context.workspace_cache_snapshot.clone();
@@ -2458,6 +2506,65 @@ mod tests {
                 .await,
             "cancelled destroyed sandbox must not retain network-log attribution",
         );
+    }
+
+    #[tokio::test]
+    async fn finalizer_preserves_verified_success_metadata_after_late_cooperative_cancel() {
+        let (_budget, lease) = test_budget_lease();
+        let fixture = FinalizeTestFixture::new().await;
+        let network_log_session = fixture.network_log_session().await;
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let session_id = "sess-late-cooperative-cancel";
+        let cancel = RunCancellationHandle::new();
+        cancel.request_cooperative_user_cancellation().await;
+        let cleanup_state = RunCleanupState::new();
+        let identity = RestoredSessionIdentity::claude_code_for_test("verified-history");
+        let mut context =
+            fixture.finalize_context(run_id, sandbox_id, session_id, network_log_session, cancel);
+        context.exit_code = 137;
+        context.restored_session_identity = Some(identity.clone());
+        context.cleanup_state = cleanup_state.clone();
+
+        let _completion_ready = finalize_sandbox_for_completion(
+            Some(Box::new(mock_sandbox_ready_for_idle_reuse(
+                "late-cooperative-cancel",
+            ))),
+            ActiveBudgetLease::new(lease),
+            CompletionPayload::new(
+                run_id,
+                137,
+                Some("cancelled by user".into()),
+                sandbox_id,
+                SandboxReuseResult::PoolMiss,
+                CompletionAuth::local(),
+            ),
+            context,
+        )
+        .await;
+
+        assert_eq!(
+            cleanup_state.disposition(),
+            RunCleanupDisposition::IdlePoolOwned,
+        );
+        let held = fixture.idle_pool.lock().await.held_sandbox_states();
+        assert_eq!(held.len(), 1);
+        assert_eq!(
+            held[0].reusable_sandbox.history_generation_run_id,
+            Some(run_id),
+        );
+        let entry = fixture
+            .idle_pool
+            .lock()
+            .await
+            .take(session_id)
+            .expect("late-cancelled successful sandbox should be parked");
+        let crate::idle_pool::IdleUnparkResult::Reused { sandbox, .. } =
+            entry.try_unpark_for_run(RunId::new_v4()).await
+        else {
+            panic!("late-cancelled successful sandbox should unpark");
+        };
+        assert_eq!(sandbox.restored_session_identity(), Some(&identity));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
@@ -5,6 +5,10 @@ use super::super::support::{
     wait_cancel_token_removed, wait_idle_pool_reuse_keys,
 };
 use crate::types::SandboxReuseResult;
+use guest_contracts::diagnostics::{
+    AgentFramework, CliTerminationDiagnostic, CliTerminationReason, FailureClass,
+    FailureDiagnostic, PromptMetadata,
+};
 
 #[tokio::test(start_paused = true)]
 async fn active_destroy_panic_still_reports_completion_and_releases_budget() {
@@ -75,6 +79,90 @@ async fn nonzero_job_parks_and_successor_reuses_sandbox() {
         held[0].reusable_sandbox.history_generation_run_id, None,
         "failed execution must not advertise an exact history generation",
     );
+
+    let successor_run_id = RunId::new_v4();
+    push_job(
+        &env,
+        successor_run_id,
+        "vm0/default",
+        Some(context_with_session(successor_run_id, reuse_key)),
+    );
+
+    let successor = env
+        .handle
+        .wait_completion(successor_run_id, Duration::from_secs(5))
+        .await
+        .expect("successor should complete");
+    assert_eq!(successor.exit_code, 0);
+    assert_eq!(successor.reuse_result, Some(SandboxReuseResult::Reused));
+    assert_eq!(successor.sandbox_id, Some(sandbox_id));
+    wait_idle_pool_reuse_keys(&idle_pool, &[reuse_key], Duration::from_secs(5)).await;
+    assert_eq!(budget.allocated().2, 1);
+    assert_eq!(overrides.park_call_count(), 2);
+    assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.destroy_call_count(), 0);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn confirmed_execution_timeout_parks_and_successor_reuses_sandbox() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_wait_process_exit(sandbox::ProcessExit::new(
+        1,
+        guest_contracts::diagnostics::AGENT_EXECUTION_TIMEOUT_EXIT_CODE,
+        Vec::new(),
+        Vec::new(),
+    ));
+    let diagnostic = FailureDiagnostic::new(
+        FailureClass::CliExecutionError,
+        AgentFramework::ClaudeCode,
+        PromptMetadata::from_prompt("continue until the execution deadline"),
+    )
+    .with_cli_exit_code(143)
+    .with_cli_termination(CliTerminationDiagnostic::new(
+        CliTerminationReason::ExecutionTimeout,
+    ));
+    overrides.push_read_file_result(Ok(Some(serde_json::to_vec(&diagnostic).unwrap())));
+    overrides.push_read_file_result(Ok(Some(b"Agent execution timed out".to_vec())));
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 4, 8192, 4, Arc::clone(&overrides));
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let run_handle = tokio::spawn(run(config));
+    let reuse_key = "sess-execution-timeout";
+
+    let timed_out_run_id = RunId::new_v4();
+    push_job(
+        &env,
+        timed_out_run_id,
+        "vm0/default",
+        Some(context_with_session(timed_out_run_id, reuse_key)),
+    );
+
+    let timed_out = env
+        .handle
+        .wait_completion(timed_out_run_id, Duration::from_secs(5))
+        .await
+        .expect("timed-out job should complete");
+    assert_eq!(
+        timed_out.exit_code,
+        guest_contracts::diagnostics::AGENT_EXECUTION_TIMEOUT_EXIT_CODE,
+    );
+    assert_eq!(
+        timed_out.error.as_deref(),
+        Some("Agent execution timed out")
+    );
+    let sandbox_id = timed_out
+        .sandbox_id
+        .expect("timed-out run should own a sandbox");
+    wait_idle_pool_reuse_keys(&idle_pool, &[reuse_key], Duration::from_secs(5)).await;
+    assert_eq!(budget.allocated().2, 1);
+    assert_eq!(overrides.park_call_count(), 1);
+    assert_eq!(overrides.destroy_call_count(), 0);
+    let held = idle_pool.lock().await.held_sandbox_states();
+    assert_eq!(held.len(), 1);
+    assert_eq!(held[0].reusable_sandbox.history_generation_run_id, None);
 
     let successor_run_id = RunId::new_v4();
     push_job(

--- a/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
@@ -2,8 +2,9 @@ use super::super::super::*;
 use super::super::support::{
     context_with_session, minimal_context, mock_run_config_with_overrides, push_job, shutdown,
     status_idle_reuse_keys_and_active_runs, test_profiles, wait_budget_count, wait_cancel_handle,
-    wait_cancel_token_removed,
+    wait_cancel_token_removed, wait_idle_pool_reuse_keys,
 };
+use crate::types::SandboxReuseResult;
 
 #[tokio::test(start_paused = true)]
 async fn active_destroy_panic_still_reports_completion_and_releases_budget() {
@@ -33,44 +34,154 @@ async fn active_destroy_panic_still_reports_completion_and_releases_budget() {
     shutdown(&env, run_handle).await;
 }
 
-/// Test 20: Failed job with session context is not parked.
-///
-/// When `wait_process` returns a non-zero exit code, `spawn_job()` skips
-/// parking (because `exit_code == 0` is false) and destroys the sandbox.
+/// Test 20: A healthy non-zero process exit remains failed but retains its VM.
 #[tokio::test(start_paused = true)]
-async fn failed_job_with_session_not_parked() {
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_code(
-        1,
-    ));
-    let (config, env) = mock_run_config_with_overrides(test_profiles(), 4, 8192, 4, overrides);
+async fn nonzero_job_parks_and_successor_reuses_sandbox() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_wait_process_exit(sandbox::ProcessExit::new(1, 1, Vec::new(), Vec::new()));
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 4, 8192, 4, Arc::clone(&overrides));
     let budget = Arc::clone(&config.capacity.budget);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let run_handle = tokio::spawn(run(config));
+    let reuse_key = "sess-fail";
 
-    let run_id = RunId::new_v4();
+    let failed_run_id = RunId::new_v4();
     push_job(
         &env,
-        run_id,
+        failed_run_id,
         "vm0/default",
-        Some(context_with_session(run_id, "sess-fail")),
+        Some(context_with_session(failed_run_id, reuse_key)),
     );
 
-    let c = env
+    let failed = env
         .handle
-        .wait_completion(run_id, Duration::from_secs(5))
-        .await;
-    assert!(c.is_some(), "job should complete");
-    assert_eq!(c.unwrap().exit_code, 1);
+        .wait_completion(failed_run_id, Duration::from_secs(5))
+        .await
+        .expect("non-zero job should complete");
+    assert_eq!(failed.exit_code, 1);
+    let sandbox_id = failed.sandbox_id.expect("failed run should own a sandbox");
+    wait_idle_pool_reuse_keys(&idle_pool, &[reuse_key], Duration::from_secs(5)).await;
+    assert_eq!(
+        budget.allocated().2,
+        1,
+        "parked VM should retain its budget"
+    );
+    assert_eq!(overrides.park_call_count(), 1);
+    assert_eq!(overrides.destroy_call_count(), 0);
+    let held = idle_pool.lock().await.held_sandbox_states();
+    assert_eq!(held.len(), 1);
+    assert_eq!(
+        held[0].reusable_sandbox.history_generation_run_id, None,
+        "failed execution must not advertise an exact history generation",
+    );
 
-    wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
-    assert_eq!(idle_pool.lock().await.len(), 0, "failed job must not park");
+    let successor_run_id = RunId::new_v4();
+    push_job(
+        &env,
+        successor_run_id,
+        "vm0/default",
+        Some(context_with_session(successor_run_id, reuse_key)),
+    );
+
+    let successor = env
+        .handle
+        .wait_completion(successor_run_id, Duration::from_secs(5))
+        .await
+        .expect("successor should complete");
+    assert_eq!(successor.exit_code, 0);
+    assert_eq!(successor.reuse_result, Some(SandboxReuseResult::Reused));
+    assert_eq!(successor.sandbox_id, Some(sandbox_id));
+    wait_idle_pool_reuse_keys(&idle_pool, &[reuse_key], Duration::from_secs(5)).await;
+    assert_eq!(budget.allocated().2, 1);
+    assert_eq!(overrides.park_call_count(), 2);
+    assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.destroy_call_count(), 0);
 
     shutdown(&env, run_handle).await;
 }
 
-/// Test 21: A cancelled job is destroyed instead of parked.
 #[tokio::test(start_paused = true)]
-async fn cancelled_job_not_parked() {
+async fn cooperative_cancellation_parks_and_successor_reuses_sandbox() {
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 4, 8192, 4, Arc::clone(&overrides));
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let cancel_tokens = config.provider.cancel_tokens.clone();
+    let run_handle = tokio::spawn(run(config));
+    let reuse_key = "sess-cooperative-cancel";
+
+    let cancelled_run_id = RunId::new_v4();
+    push_job(
+        &env,
+        cancelled_run_id,
+        "vm0/default",
+        Some(context_with_session(cancelled_run_id, reuse_key)),
+    );
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("source run should enter process wait");
+    let cancel_handle =
+        wait_cancel_handle(&cancel_tokens, cancelled_run_id, Duration::from_secs(5)).await;
+    cancel_handle.request_cooperative_user_cancellation().await;
+    assert!(
+        overrides
+            .wait_for_process_control_calls(1, Duration::from_secs(5))
+            .await,
+        "cooperative cancellation should reach the guest control channel",
+    );
+    overrides.clear_wait_process_lifecycle_gate();
+    wait_gate.release_one();
+
+    let cancelled = env
+        .handle
+        .wait_completion(cancelled_run_id, Duration::from_secs(5))
+        .await
+        .expect("cooperatively cancelled run should complete");
+    assert_eq!(cancelled.exit_code, 137);
+    assert_eq!(cancelled.error.as_deref(), Some("cancelled by user"));
+    let sandbox_id = cancelled
+        .sandbox_id
+        .expect("cancelled run should own a sandbox");
+    wait_idle_pool_reuse_keys(&idle_pool, &[reuse_key], Duration::from_secs(5)).await;
+    assert_eq!(budget.allocated().2, 1);
+    assert_eq!(overrides.park_call_count(), 1);
+    assert_eq!(overrides.destroy_call_count(), 0);
+    let held = idle_pool.lock().await.held_sandbox_states();
+    assert_eq!(held.len(), 1);
+    assert_eq!(held[0].reusable_sandbox.history_generation_run_id, None);
+
+    let successor_run_id = RunId::new_v4();
+    push_job(
+        &env,
+        successor_run_id,
+        "vm0/default",
+        Some(context_with_session(successor_run_id, reuse_key)),
+    );
+    let successor = env
+        .handle
+        .wait_completion(successor_run_id, Duration::from_secs(5))
+        .await
+        .expect("successor should complete");
+    assert_eq!(successor.exit_code, 0);
+    assert_eq!(successor.reuse_result, Some(SandboxReuseResult::Reused));
+    assert_eq!(successor.sandbox_id, Some(sandbox_id));
+    wait_idle_pool_reuse_keys(&idle_pool, &[reuse_key], Duration::from_secs(5)).await;
+    assert_eq!(budget.allocated().2, 1);
+    assert_eq!(overrides.park_call_count(), 2);
+    assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.destroy_call_count(), 0);
+
+    shutdown(&env, run_handle).await;
+}
+
+/// Test 21: A hard-cancelled job is destroyed instead of parked.
+#[tokio::test(start_paused = true)]
+async fn hard_cancelled_job_not_parked() {
     let wait_gate = sandbox_mock::MockLifecycleGate::new();
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     overrides.set_wait_process_lifecycle_gate(wait_gate.clone());

--- a/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
@@ -299,16 +299,19 @@ async fn hard_cancelled_job_not_parked() {
         .handle
         .wait_completion(run_id, Duration::from_secs(5))
         .await;
-    assert!(c.is_some(), "cancelled job should still complete");
+    assert!(c.is_some(), "hard-cancelled job should still complete");
     let c = c.unwrap();
-    assert_eq!(c.exit_code, 137, "cancellation yields synthetic SIGKILL");
+    assert_eq!(
+        c.exit_code, 137,
+        "hard cancellation yields synthetic SIGKILL"
+    );
     assert_eq!(c.error.as_deref(), Some("cancelled by user"));
 
     wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
     assert_eq!(
         idle_pool.lock().await.len(),
         0,
-        "cancelled job must not park"
+        "hard-cancelled job must not park"
     );
     assert_eq!(overrides.start_process_calls().len(), 1);
     assert_eq!(overrides.park_call_count(), 0);

--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -123,7 +123,7 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
     assert_eq!(
         env.idle_pool.lock().await.len(),
         0,
-        "nonzero job should not park a VM",
+        "soft-drained parking gate should prevent VM parking",
     );
 
     assert!(

--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -111,6 +111,7 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
     file.set_len(16 * 1024 * 1024).await.unwrap();
     drop(file);
 
+    assert!(env.parking_gate.soft_drain());
     overrides.clear_wait_process_lifecycle_gate();
     wait_gate.release_one();
     let completion = env
@@ -137,6 +138,7 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
         .await,
         "immediate heartbeat should advertise the promoted workspace cache",
     );
+    assert!(env.parking_gate.open_after_soft_drain());
 
     let second_gate = sandbox_mock::MockLifecycleGate::new();
     overrides.set_wait_process_lifecycle_gate(second_gate.clone());
@@ -320,6 +322,7 @@ async fn reuse_take_preserves_cached_workspace_snapshot_state() {
     file.set_len(16 * 1024 * 1024).await.unwrap();
     drop(file);
 
+    assert!(env.parking_gate.soft_drain());
     overrides.clear_wait_process_lifecycle_gate();
     wait_gate.release_one();
     let cache_completion = env
@@ -340,6 +343,7 @@ async fn reuse_take_preserves_cached_workspace_snapshot_state() {
         .await,
         "workspace cache promotion should advertise the expected workspace before claim"
     );
+    assert!(env.parking_gate.open_after_soft_drain());
     let reuse_heartbeat_count = env.handle.heartbeat_count();
     let run_id = RunId::new_v4();
     push_job(

--- a/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
@@ -165,6 +165,7 @@ async fn telemetry_flush_classifies_workspace_cache_finalization() {
     let file = tokio::fs::File::create(active_image).await.unwrap();
     file.set_len(16 * 1024 * 1024).await.unwrap();
     drop(file);
+    assert!(env.parking_gate.soft_drain());
     overrides.clear_wait_process_lifecycle_gate();
     wait_gate.release_one();
 

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -60,7 +60,8 @@ use super::workspace_session_history_materializer::{
 use super::{
     EXIT_SIGKILL, EXIT_SIGNAL_KILL, ExecutionFailure, ExecutorConfig, JOB_TIMEOUT,
     JOB_TIMEOUT_EXIT_CODE, ResourceFailureDiagnostics, ResourceFailureKind, RunnerError,
-    RunnerResult, SandboxReuseResult, SessionHistoryRestoreFallback, SessionHistoryRestorePlan,
+    RunnerResult, SandboxReuseDisposition, SandboxReuseRejection, SandboxReuseResult,
+    SandboxReuseTerminal, SessionHistoryRestoreFallback, SessionHistoryRestorePlan,
     USER_ENV_FILE_ENV_KEY, agent_exit_failure_message, guest_runtime_dir, guest_runtime_path,
     job_supervisor_timeout, job_terminal_wait_timeout, normalize_failure_exit_code,
 };
@@ -685,19 +686,12 @@ pub(super) struct ProcessCancelTimeouts {
 
 pub(super) struct AgentExecutionResult {
     pub(super) failure: Option<ExecutionFailure>,
+    pub(super) sandbox_reuse_disposition: SandboxReuseDisposition,
     pub(super) stdout_stream_diagnostics: AgentStdoutStreamDiagnostics,
     pub(super) reusable_session_identity: Option<RestoredSessionIdentity>,
 }
 
 impl AgentExecutionResult {
-    pub(super) fn success() -> Self {
-        Self {
-            failure: None,
-            stdout_stream_diagnostics: AgentStdoutStreamDiagnostics::default(),
-            reusable_session_identity: None,
-        }
-    }
-
     pub(super) fn failure(
         exit_code: i32,
         error: impl Into<String>,
@@ -705,6 +699,7 @@ impl AgentExecutionResult {
     ) -> Self {
         Self {
             failure: Some(ExecutionFailure::new(exit_code, error, diagnostic)),
+            sandbox_reuse_disposition: SandboxReuseDisposition::default(),
             stdout_stream_diagnostics: AgentStdoutStreamDiagnostics::default(),
             reusable_session_identity: None,
         }
@@ -717,6 +712,7 @@ impl AgentExecutionResult {
     pub(super) fn cancelled() -> Self {
         Self {
             failure: Some(ExecutionFailure::cancelled()),
+            sandbox_reuse_disposition: SandboxReuseDisposition::default(),
             stdout_stream_diagnostics: AgentStdoutStreamDiagnostics::default(),
             reusable_session_identity: None,
         }
@@ -730,18 +726,14 @@ impl AgentExecutionResult {
         self
     }
 
-    pub(super) fn with_reusable_session_identity(
-        mut self,
-        reusable_session_identity: Option<RestoredSessionIdentity>,
-    ) -> Self {
-        self.reusable_session_identity = reusable_session_identity;
-        self
-    }
-
     pub(super) fn with_resource_diagnostics(
         mut self,
         resource_diagnostics: Option<ResourceFailureDiagnostics>,
     ) -> Self {
+        if resource_diagnostics.is_some_and(|diagnostics| diagnostics.failure_kind.is_some()) {
+            self.sandbox_reuse_disposition =
+                SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ResourceFailure);
+        }
         if let Some(failure) = self.failure.take() {
             self.failure = Some(failure.with_resource_diagnostics(resource_diagnostics));
         }
@@ -750,6 +742,8 @@ impl AgentExecutionResult {
 
     #[must_use]
     pub(super) fn with_resource_failure_kind(mut self, kind: ResourceFailureKind) -> Self {
+        self.sandbox_reuse_disposition =
+            SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ResourceFailure);
         if let Some(failure) = self.failure.take() {
             self.failure = Some(failure.with_resource_diagnostics(Some(
                 ResourceFailureDiagnostics::from_failure_kind(kind),
@@ -1079,6 +1073,42 @@ fn diagnostic_is_agent_execution_timeout(diagnostic: Option<&FailureDiagnostic>)
     diagnostic
         .and_then(|diagnostic| diagnostic.cli_termination.as_ref())
         .is_some_and(|termination| termination.reason == CliTerminationReason::ExecutionTimeout)
+}
+
+fn sandbox_reuse_disposition_for_process_exit(
+    exit: &sandbox::ProcessExit,
+    cancellation: CancellationDisposition,
+    failure: Option<&ExecutionFailure>,
+) -> SandboxReuseDisposition {
+    if cancellation == CancellationDisposition::HardFallback {
+        return SandboxReuseDisposition::Ineligible(SandboxReuseRejection::HardCancellation);
+    }
+    if failure.is_some_and(|failure| {
+        failure
+            .resource_diagnostics
+            .is_some_and(|diagnostics| diagnostics.failure_kind.is_some())
+    }) {
+        return SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ResourceFailure);
+    }
+    if failure.is_some_and(|failure| {
+        matches!(
+            failure.kind,
+            super::ExecutionFailureKind::RunnerJobTimeout { .. }
+        )
+    }) {
+        return SandboxReuseDisposition::Ineligible(SandboxReuseRejection::RunnerJobTimeout);
+    }
+
+    let ExecTermination::Exited { exit_code } = exit.termination else {
+        return SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ExecutionUncertain);
+    };
+    if cancellation == CancellationDisposition::Cooperative {
+        SandboxReuseDisposition::Eligible(SandboxReuseTerminal::CooperativeCancellation)
+    } else if exit_code == 0 {
+        SandboxReuseDisposition::Eligible(SandboxReuseTerminal::Success)
+    } else {
+        SandboxReuseDisposition::Eligible(SandboxReuseTerminal::NonzeroExit)
+    }
 }
 
 fn process_exit_oom_candidate(exit: &sandbox::ProcessExit) -> bool {
@@ -2317,6 +2347,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                         t.elapsed(),
                         None,
                     )),
+                    sandbox_reuse_disposition: SandboxReuseDisposition::Ineligible(
+                        SandboxReuseRejection::RunnerJobTimeout,
+                    ),
                     stdout_stream_diagnostics: stdout_stream_diagnostics_on_wait_error,
                     reusable_session_identity: None,
                 });
@@ -2556,15 +2589,21 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         None
     };
 
+    let sandbox_reuse_disposition =
+        sandbox_reuse_disposition_for_process_exit(&exit, cancellation, failure.as_ref());
     let agent_result = match failure {
         Some(failure) => AgentExecutionResult {
             failure: Some(failure),
+            sandbox_reuse_disposition,
             stdout_stream_diagnostics,
             reusable_session_identity: None,
         },
-        None => AgentExecutionResult::success()
-            .with_stdout_stream_diagnostics(stdout_stream_diagnostics)
-            .with_reusable_session_identity(reusable_session_identity),
+        None => AgentExecutionResult {
+            failure: None,
+            sandbox_reuse_disposition,
+            stdout_stream_diagnostics,
+            reusable_session_identity,
+        },
     };
     telemetry.record(
         "agent_execute",

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1090,20 +1090,27 @@ fn sandbox_reuse_disposition_for_process_exit(
     }) {
         return SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ResourceFailure);
     }
-    if failure.is_some_and(|failure| {
+    // A guest-agent execution deadline is reusable only when the provider
+    // observed the guest-agent itself exit. A provider-level timeout does not
+    // carry the same process-termination evidence.
+    let exit_code = match exit.termination {
+        ExecTermination::Exited { exit_code } => exit_code,
+        ExecTermination::TimedOut => {
+            return SandboxReuseDisposition::Ineligible(SandboxReuseRejection::UnconfirmedTimeout);
+        }
+        ExecTermination::Cancelled | ExecTermination::StartFailed | ExecTermination::WaitFailed => {
+            return SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ExecutionUncertain);
+        }
+    };
+    if cancellation == CancellationDisposition::Cooperative {
+        SandboxReuseDisposition::Eligible(SandboxReuseTerminal::CooperativeCancellation)
+    } else if failure.is_some_and(|failure| {
         matches!(
             failure.kind,
             super::ExecutionFailureKind::RunnerJobTimeout { .. }
         )
     }) {
-        return SandboxReuseDisposition::Ineligible(SandboxReuseRejection::RunnerJobTimeout);
-    }
-
-    let ExecTermination::Exited { exit_code } = exit.termination else {
-        return SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ExecutionUncertain);
-    };
-    if cancellation == CancellationDisposition::Cooperative {
-        SandboxReuseDisposition::Eligible(SandboxReuseTerminal::CooperativeCancellation)
+        SandboxReuseDisposition::Eligible(SandboxReuseTerminal::ExecutionTimeout)
     } else if exit_code == 0 {
         SandboxReuseDisposition::Eligible(SandboxReuseTerminal::Success)
     } else {
@@ -2348,7 +2355,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                         None,
                     )),
                     sandbox_reuse_disposition: SandboxReuseDisposition::Ineligible(
-                        SandboxReuseRejection::RunnerJobTimeout,
+                        SandboxReuseRejection::UnconfirmedTimeout,
                     ),
                     stdout_stream_diagnostics: stdout_stream_diagnostics_on_wait_error,
                     reusable_session_identity: None,

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -238,16 +238,99 @@ impl ExecutionHooks {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SandboxReuseDisposition {
+    Eligible(SandboxReuseTerminal),
+    Ineligible(SandboxReuseRejection),
+}
+
+impl SandboxReuseDisposition {
+    #[must_use]
+    pub(crate) fn is_eligible(self) -> bool {
+        matches!(self, Self::Eligible(_))
+    }
+
+    #[must_use]
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Eligible(SandboxReuseTerminal::Success) => "eligible_success",
+            Self::Eligible(SandboxReuseTerminal::NonzeroExit) => "eligible_nonzero_exit",
+            Self::Eligible(SandboxReuseTerminal::CooperativeCancellation) => {
+                "eligible_cooperative_cancellation"
+            }
+            Self::Ineligible(SandboxReuseRejection::ExecutionUncertain) => "execution_uncertain",
+            Self::Ineligible(SandboxReuseRejection::HardCancellation) => "hard_cancellation",
+            Self::Ineligible(SandboxReuseRejection::RunnerJobTimeout) => "runner_job_timeout",
+            Self::Ineligible(SandboxReuseRejection::ResourceFailure) => "resource_failure",
+            Self::Ineligible(SandboxReuseRejection::PostJobCleanupFailure) => {
+                "post_job_cleanup_failure"
+            }
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn telemetry_action(self) -> &'static str {
+        match self {
+            Self::Eligible(SandboxReuseTerminal::Success) => {
+                "runner_terminal_sandbox_reuse_eligible_success"
+            }
+            Self::Eligible(SandboxReuseTerminal::NonzeroExit) => {
+                "runner_terminal_sandbox_reuse_eligible_nonzero_exit"
+            }
+            Self::Eligible(SandboxReuseTerminal::CooperativeCancellation) => {
+                "runner_terminal_sandbox_reuse_eligible_cooperative_cancellation"
+            }
+            Self::Ineligible(SandboxReuseRejection::ExecutionUncertain) => {
+                "runner_terminal_sandbox_reuse_rejected_execution_uncertain"
+            }
+            Self::Ineligible(SandboxReuseRejection::HardCancellation) => {
+                "runner_terminal_sandbox_reuse_rejected_hard_cancellation"
+            }
+            Self::Ineligible(SandboxReuseRejection::RunnerJobTimeout) => {
+                "runner_terminal_sandbox_reuse_rejected_runner_job_timeout"
+            }
+            Self::Ineligible(SandboxReuseRejection::ResourceFailure) => {
+                "runner_terminal_sandbox_reuse_rejected_resource_failure"
+            }
+            Self::Ineligible(SandboxReuseRejection::PostJobCleanupFailure) => {
+                "runner_terminal_sandbox_reuse_rejected_post_job_cleanup_failure"
+            }
+        }
+    }
+}
+
+impl Default for SandboxReuseDisposition {
+    fn default() -> Self {
+        Self::Ineligible(SandboxReuseRejection::ExecutionUncertain)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SandboxReuseTerminal {
+    Success,
+    NonzeroExit,
+    CooperativeCancellation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SandboxReuseRejection {
+    ExecutionUncertain,
+    HardCancellation,
+    RunnerJobTimeout,
+    ResourceFailure,
+    PostJobCleanupFailure,
+}
+
 /// Outcome of a job execution and ownership of any sandbox still alive afterward.
 pub struct ExecuteOutcome {
     pub failure: Option<ExecutionFailure>,
+    pub(crate) sandbox_reuse_disposition: SandboxReuseDisposition,
     /// Sandbox ownership after execution.
     ///
     /// `Some` transfers a still-live sandbox to the caller for finalization; it
-    /// does not imply the sandbox is eligible for reuse. Finalization considers
-    /// parking only when the exit code is zero, cancellation is not active, the
-    /// parking gate is open, and a reuse key is available. Cancellation before
-    /// ownership transfer or an unsuccessful park still destroys the sandbox.
+    /// does not imply the sandbox is eligible for reuse. Finalization consumes
+    /// `sandbox_reuse_disposition` and still enforces hard cancellation, the
+    /// parking gate, a reuse key, reuse preparation, and ownership transfer.
     ///
     /// `None` means no live sandbox ownership is returned, either because no
     /// sandbox was created or because executor-side cleanup already consumed
@@ -272,6 +355,7 @@ impl ExecuteOutcome {
     ) -> Self {
         Self {
             failure: Some(failure),
+            sandbox_reuse_disposition: SandboxReuseDisposition::default(),
             sandbox: Some(sandbox),
             source_ip,
             network_log_session: None,
@@ -507,6 +591,7 @@ pub(crate) async fn execute_job_with_prepared_notifier(
     ) {
         ExecuteOutcome {
             failure: Some(ExecutionFailure::from_error(error)),
+            sandbox_reuse_disposition: SandboxReuseDisposition::default(),
             sandbox: None,
             source_ip: String::new(),
             network_log_session: None,
@@ -534,6 +619,7 @@ pub(crate) async fn execute_job_with_prepared_notifier(
             Ok(outcome) => outcome,
             Err(e) => ExecuteOutcome {
                 failure: Some(ExecutionFailure::from_error(e.to_string())),
+                sandbox_reuse_disposition: SandboxReuseDisposition::default(),
                 sandbox: None,
                 source_ip: String::new(),
                 network_log_session: None,

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -255,12 +255,13 @@ impl SandboxReuseDisposition {
         match self {
             Self::Eligible(SandboxReuseTerminal::Success) => "eligible_success",
             Self::Eligible(SandboxReuseTerminal::NonzeroExit) => "eligible_nonzero_exit",
+            Self::Eligible(SandboxReuseTerminal::ExecutionTimeout) => "eligible_execution_timeout",
             Self::Eligible(SandboxReuseTerminal::CooperativeCancellation) => {
                 "eligible_cooperative_cancellation"
             }
             Self::Ineligible(SandboxReuseRejection::ExecutionUncertain) => "execution_uncertain",
             Self::Ineligible(SandboxReuseRejection::HardCancellation) => "hard_cancellation",
-            Self::Ineligible(SandboxReuseRejection::RunnerJobTimeout) => "runner_job_timeout",
+            Self::Ineligible(SandboxReuseRejection::UnconfirmedTimeout) => "unconfirmed_timeout",
             Self::Ineligible(SandboxReuseRejection::ResourceFailure) => "resource_failure",
             Self::Ineligible(SandboxReuseRejection::PostJobCleanupFailure) => {
                 "post_job_cleanup_failure"
@@ -277,6 +278,9 @@ impl SandboxReuseDisposition {
             Self::Eligible(SandboxReuseTerminal::NonzeroExit) => {
                 "runner_terminal_sandbox_reuse_eligible_nonzero_exit"
             }
+            Self::Eligible(SandboxReuseTerminal::ExecutionTimeout) => {
+                "runner_terminal_sandbox_reuse_eligible_execution_timeout"
+            }
             Self::Eligible(SandboxReuseTerminal::CooperativeCancellation) => {
                 "runner_terminal_sandbox_reuse_eligible_cooperative_cancellation"
             }
@@ -286,8 +290,8 @@ impl SandboxReuseDisposition {
             Self::Ineligible(SandboxReuseRejection::HardCancellation) => {
                 "runner_terminal_sandbox_reuse_rejected_hard_cancellation"
             }
-            Self::Ineligible(SandboxReuseRejection::RunnerJobTimeout) => {
-                "runner_terminal_sandbox_reuse_rejected_runner_job_timeout"
+            Self::Ineligible(SandboxReuseRejection::UnconfirmedTimeout) => {
+                "runner_terminal_sandbox_reuse_rejected_unconfirmed_timeout"
             }
             Self::Ineligible(SandboxReuseRejection::ResourceFailure) => {
                 "runner_terminal_sandbox_reuse_rejected_resource_failure"
@@ -309,6 +313,7 @@ impl Default for SandboxReuseDisposition {
 pub(crate) enum SandboxReuseTerminal {
     Success,
     NonzeroExit,
+    ExecutionTimeout,
     CooperativeCancellation,
 }
 
@@ -316,7 +321,7 @@ pub(crate) enum SandboxReuseTerminal {
 pub(crate) enum SandboxReuseRejection {
     ExecutionUncertain,
     HardCancellation,
-    RunnerJobTimeout,
+    UnconfirmedTimeout,
     ResourceFailure,
     PostJobCleanupFailure,
 }

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -34,7 +34,8 @@ use super::workspace_session_history_materializer::WorkspaceSessionHistoryMateri
 use super::{
     ExecuteOutcome, ExecutionFailure, ExecutorConfig, JobParams, NewSandboxDispatch,
     PROCESS_CANCEL_TIMEOUTS, RunnerError, RunnerResult, SandboxPreparedNotifier,
-    SandboxReuseResult, SessionHistoryMaterializer, SessionHistoryRestorePlan,
+    SandboxReuseDisposition, SandboxReuseRejection, SandboxReuseResult, SessionHistoryMaterializer,
+    SessionHistoryRestorePlan,
 };
 use crate::dns::{DnsReadinessLogObservation, inspect_readiness_log_segment};
 use crate::duration::duration_ms;
@@ -1289,6 +1290,7 @@ pub(super) async fn execute_reused_sandbox(
             );
             return ExecuteOutcome {
                 failure: Some(ExecutionFailure::from_error(e.to_string())),
+                sandbox_reuse_disposition: SandboxReuseDisposition::default(),
                 sandbox: Some(sandbox),
                 source_ip,
                 network_log_session: None,
@@ -1426,6 +1428,8 @@ pub(super) async fn execute_prepared_sandbox_run_with_process_cancel_timeouts(
                 "post-job proxy cleanup failed: {e}"
             )));
         }
+        agent_result.sandbox_reuse_disposition =
+            SandboxReuseDisposition::Ineligible(SandboxReuseRejection::PostJobCleanupFailure);
     }
 
     // Read the CLI-generated session ID after a first-run execution.
@@ -1447,6 +1451,7 @@ pub(super) async fn execute_prepared_sandbox_run_with_process_cancel_timeouts(
 
     ExecuteOutcome {
         failure: agent_result.failure,
+        sandbox_reuse_disposition: agent_result.sandbox_reuse_disposition,
         sandbox: Some(sandbox),
         source_ip,
         network_log_session: Some(network_log_session),

--- a/crates/runner/src/executor/tests/agent_run_tests/cancellation.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/cancellation.rs
@@ -23,8 +23,9 @@ use crate::executor::tests::support::{
     spawn_run_in_sandbox_test_with_timeouts, test_executor_config, test_telemetry,
 };
 use crate::executor::{
-    EXIT_SIGKILL, PROCESS_CANCEL_TIMEOUTS, PROCESS_CANCEL_WRITE_TIMEOUT,
-    SessionHistoryMaterializer, SessionHistoryRestorePlan, effective_cli_framework,
+    EXIT_SIGKILL, PROCESS_CANCEL_TIMEOUTS, PROCESS_CANCEL_WRITE_TIMEOUT, SandboxReuseDisposition,
+    SandboxReuseRejection, SandboxReuseTerminal, SessionHistoryMaterializer,
+    SessionHistoryRestorePlan, effective_cli_framework,
 };
 use crate::run_cancellation::RunCancellationHandle;
 use crate::types::{
@@ -450,6 +451,10 @@ async fn run_in_sandbox_cancels_guest_process_and_waits_for_terminal_status() {
         Some(EXIT_SIGKILL)
     );
     assert_eq!(
+        result.sandbox_reuse_disposition,
+        SandboxReuseDisposition::Ineligible(SandboxReuseRejection::HardCancellation),
+    );
+    assert_eq!(
         result.stdout_stream_diagnostics,
         AgentStdoutStreamDiagnostics {
             bytes_written: 14,
@@ -509,6 +514,10 @@ async fn run_in_sandbox_requests_cooperative_user_cancellation() {
     assert_eq!(
         result.failure.as_ref().map(|failure| failure.exit_code),
         Some(EXIT_SIGKILL)
+    );
+    assert_eq!(
+        result.sandbox_reuse_disposition,
+        SandboxReuseDisposition::Eligible(SandboxReuseTerminal::CooperativeCancellation),
     );
 }
 
@@ -732,6 +741,10 @@ async fn hard_cancellation_preempts_cooperative_recovery() {
     assert_eq!(
         result.failure.as_ref().map(|failure| failure.exit_code),
         Some(EXIT_SIGKILL)
+    );
+    assert_eq!(
+        result.sandbox_reuse_disposition,
+        SandboxReuseDisposition::Ineligible(SandboxReuseRejection::HardCancellation),
     );
 }
 

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -544,7 +544,7 @@ async fn execute_inner_marks_stdout_incomplete_on_wait_process_error() {
     }
     assert_eq!(
         outcome.sandbox_reuse_disposition,
-        SandboxReuseDisposition::Ineligible(SandboxReuseRejection::RunnerJobTimeout),
+        SandboxReuseDisposition::Ineligible(SandboxReuseRejection::UnconfirmedTimeout),
     );
     assert!(
         outcome.sandbox.is_some(),
@@ -729,7 +729,7 @@ async fn execute_inner_guest_process_timeout_marks_failure_kind() {
     }
     assert_eq!(
         outcome.sandbox_reuse_disposition,
-        SandboxReuseDisposition::Ineligible(SandboxReuseRejection::RunnerJobTimeout),
+        SandboxReuseDisposition::Ineligible(SandboxReuseRejection::UnconfirmedTimeout),
     );
 }
 
@@ -878,6 +878,10 @@ async fn execute_inner_structured_guest_execution_timeout_marks_failure_kind() {
         }
         ExecutionFailureKind::Generic => panic!("expected runner job timeout failure kind"),
     }
+    assert_eq!(
+        outcome.sandbox_reuse_disposition,
+        SandboxReuseDisposition::Eligible(SandboxReuseTerminal::ExecutionTimeout),
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::executor::{SandboxReuseDisposition, SandboxReuseRejection, SandboxReuseTerminal};
 use guest_contracts::diagnostics::{
     EventDeliveryAcceptanceOutcome, EventDeliveryAttemptFailureKind,
     EventDeliveryCompletedAttemptDiagnostic, EventDeliveryDiagnostic,
@@ -211,6 +212,10 @@ async fn execute_inner_appends_stream_limit_marker_after_oom_rewrite() {
     let failure = outcome.failure.as_ref().expect("expected OOM failure");
     assert_eq!(outcome.exit_code(), 1);
     assert_eq!(failure.error.as_str(), "Agent process killed by OOM killer");
+    assert_eq!(
+        outcome.sandbox_reuse_disposition,
+        SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ResourceFailure),
+    );
     assert_eq!(
         failure
             .resource_diagnostics
@@ -537,6 +542,10 @@ async fn execute_inner_marks_stdout_incomplete_on_wait_process_error() {
         }
         ExecutionFailureKind::Generic => panic!("expected runner job timeout failure kind"),
     }
+    assert_eq!(
+        outcome.sandbox_reuse_disposition,
+        SandboxReuseDisposition::Ineligible(SandboxReuseRejection::RunnerJobTimeout),
+    );
     assert!(
         outcome.sandbox.is_some(),
         "sandbox must be returned on post-start execution failure"
@@ -649,6 +658,10 @@ async fn execute_inner_non_exited_zero_code_is_failure() {
     assert_eq!(failure.exit_code, 1);
     assert_eq!(failure.error, "Agent exited with code 1");
     assert_eq!(failure.kind, ExecutionFailureKind::Generic);
+    assert_eq!(
+        outcome.sandbox_reuse_disposition,
+        SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ExecutionUncertain),
+    );
     assert!(outcome.discovered_cli_agent_session_id.is_none());
     assert!(
         overrides
@@ -714,6 +727,10 @@ async fn execute_inner_guest_process_timeout_marks_failure_kind() {
         }
         ExecutionFailureKind::Generic => panic!("expected runner job timeout failure kind"),
     }
+    assert_eq!(
+        outcome.sandbox_reuse_disposition,
+        SandboxReuseDisposition::Ineligible(SandboxReuseRejection::RunnerJobTimeout),
+    );
 }
 
 #[tokio::test]
@@ -1268,6 +1285,10 @@ async fn execute_inner_nonzero_records_agent_execute_error() {
     .unwrap();
 
     assert_eq!(outcome.exit_code(), 7);
+    assert_eq!(
+        outcome.sandbox_reuse_disposition,
+        SandboxReuseDisposition::Eligible(SandboxReuseTerminal::NonzeroExit),
+    );
     let ops = telemetry.pending_ops_snapshot();
     let agent_execute = ops
         .iter()

--- a/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::executor::{SandboxReuseDisposition, SandboxReuseRejection};
 
 fn capture_proxy_register_events(action: impl FnOnce()) -> Vec<CapturedEvent> {
     let captured = CapturedEvents::default();
@@ -210,4 +211,8 @@ async fn execute_inner_proxy_unregister_failure_marks_successful_run_failed() {
     assert!(outcome.sandbox.is_some());
     assert!(outcome.network_log_session.is_some());
     assert!(outcome.discovered_cli_agent_session_id.is_none());
+    assert_eq!(
+        outcome.sandbox_reuse_disposition,
+        SandboxReuseDisposition::Ineligible(SandboxReuseRejection::PostJobCleanupFailure),
+    );
 }

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -63,9 +63,9 @@ pub struct IdlePoolSnapshot {
 
 /// Pool of idle sandboxes keyed by reuse key.
 ///
-/// After a job completes successfully, its sandbox can be parked here
-/// instead of being destroyed. A subsequent job for the same reuse key
-/// can reuse the parked sandbox, skipping VM creation and startup.
+/// After a job reaches a terminal state that is proven reusable, its sandbox
+/// can be parked here instead of being destroyed. A subsequent job for the same
+/// reuse key can reuse the parked sandbox, skipping VM creation and startup.
 pub struct IdlePool {
     entries: HashMap<String, IdleEntry>,
     config: IdlePoolConfig,

--- a/crates/runner/src/run_cancellation.rs
+++ b/crates/runner/src/run_cancellation.rs
@@ -173,6 +173,10 @@ impl RunCancellationHandle {
         self.inner.token.is_cancelled()
     }
 
+    pub(crate) fn is_hard_cancelled(&self) -> bool {
+        self.inner.hard_token.is_cancelled()
+    }
+
     pub(crate) fn signals(&self) -> RunCancellationSignals {
         RunCancellationSignals {
             any: self.inner.token.clone(),
@@ -305,10 +309,12 @@ mod tests {
         assert!(signals.any().is_cancelled());
         assert!(signals.cooperative_user().is_cancelled());
         assert!(!signals.hard().is_cancelled());
+        assert!(!handle.is_hard_cancelled());
 
         assert!(handle.request_hard_cancellation().await);
         assert!(!handle.request_hard_cancellation().await);
         assert!(signals.hard().is_cancelled());
+        assert!(handle.is_hard_cancelled());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- carry a fail-closed, typed sandbox reuse disposition from process execution through post-job cleanup into finalization
- retain structurally healthy sandboxes after ordinary non-zero exits, confirmed GuestAgent execution timeouts, and confirmed cooperative cancellations without changing failed, timed-out, or cancelled run results
- distinguish a GuestAgent that exits after its execution deadline from provider/supervisor timeouts that lack confirmed process termination
- preserve hard-cancellation revocation, reuse preparation, pool admission, workspace-cache fallback, and conservative session/history metadata
- add deterministic two-run coverage for failed, timed-out, and cancelled sandbox reuse plus negative coverage for unconfirmed timeout, uncertain termination, resource failure, cleanup failure, and hard cancellation

## Safety

- unknown execution state defaults to destruction
- provider/supervisor timeout without `ExecTermination::Exited`, hard cancellation, OOM/resource evidence, and post-job cleanup failure remain ineligible for reuse
- `prepare-for-reuse` and the existing parking/transfer gates remain authoritative
- failed, timed-out, and cooperatively cancelled sandboxes publish neither reusable session identity nor exact history generation; verified successful metadata survives only a late cooperative cancellation

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --no-deps --all-features`
- `cargo test -q -p runner --all-targets --all-features` (2,948 runner tests passed, 15 ignored; guest inventory passed)

## Exclusions

- no database schema or persisted application data changes
- no public API, queue payload, guest protocol, runner-selection, or remote workspace persistence changes

Closes #24834

Parent context: #23452
