### PR TITLE
test(rust): bound vsock stream-closure assertions

### DIFF
--- a/crates/vsock-host/src/tests/exec_operation/lifecycle.rs
+++ b/crates/vsock-host/src/tests/exec_operation/lifecycle.rs
@@ -10,7 +10,7 @@ use super::super::support::{
     normal_operation_readiness, operation_count, read_guest_message, send_exec_output,
     send_exec_result, setup_host_and_guest,
 };
-use super::start_capture_operation;
+use super::{assert_stream_closed, start_capture_operation};
 use crate::{
     ExecOperationRequest, ExecOwnedCapturedOutput, ExecStreamRequest,
     operation_tracker::NormalOperationReadiness,
@@ -83,7 +83,7 @@ async fn exec_operation_connection_close_wakes_result_and_stream() {
     drop(guest);
     let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
-    assert!(rx.recv().await.is_none());
+    assert_stream_closed(&mut rx, "connection close");
     assert_eq!(
         normal_operation_readiness(&host),
         NormalOperationReadiness::NotParkable
@@ -154,7 +154,7 @@ async fn host_drop_closes_active_exec_result_and_stream() {
         .unwrap()
         .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
-    assert!(rx.recv().await.is_none());
+    assert_stream_closed(&mut rx, "host drop");
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/exec_operation/mod.rs
+++ b/crates/vsock-host/src/tests/exec_operation/mod.rs
@@ -1,8 +1,21 @@
 use std::time::Duration;
 
+use tokio::sync::mpsc::{self, error::TryRecvError};
 use vsock_proto::ExecOutputPolicy;
 
-use crate::{ExecOperationHandle, ExecOperationRequest};
+use crate::{ExecOperationHandle, ExecOperationRequest, ExecOutputEvent};
+
+fn assert_stream_closed(receiver: &mut mpsc::Receiver<ExecOutputEvent>, scenario: &str) {
+    match receiver.try_recv() {
+        Err(TryRecvError::Disconnected) => {}
+        Err(TryRecvError::Empty) => {
+            panic!("{scenario}: stream sender remained open after terminal state")
+        }
+        Ok(event) => {
+            panic!("{scenario}: expected stream closure, received unexpected event: {event:?}")
+        }
+    }
+}
 
 async fn start_capture_operation(host: &crate::VsockHost, command: &str) -> ExecOperationHandle {
     host.start_exec_operation(ExecOperationRequest {

--- a/crates/vsock-host/src/tests/exec_operation/stream.rs
+++ b/crates/vsock-host/src/tests/exec_operation/stream.rs
@@ -12,6 +12,7 @@ use super::super::support::{
     assert_connection_accepts_exec_operation, is_connected, operation_count, read_guest_message,
     send_discarded_exec_result, send_exec_output, send_exec_result, setup_host_and_guest,
 };
+use super::assert_stream_closed;
 use crate::{
     ConnectionState, ExecOperationRequest, ExecStreamRequest, exec_operation as exec_operation_impl,
 };
@@ -444,7 +445,7 @@ async fn exec_operation_stream_dispatches_stdout_stderr_and_closes_on_result() {
     .await;
     let result = handle.wait(Duration::from_secs(5)).await.unwrap();
     assert!(!result.stream_overflowed);
-    assert!(rx.recv().await.is_none());
+    assert_stream_closed(&mut rx, "stdout and stderr result");
 }
 
 #[tokio::test]
@@ -483,7 +484,7 @@ async fn exec_operation_stream_handles_output_and_result_from_one_write() {
     let result = handle.wait(Duration::from_secs(5)).await.unwrap();
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
     assert!(!result.stream_overflowed);
-    assert!(rx.recv().await.is_none());
+    assert_stream_closed(&mut rx, "coalesced output and result");
 }
 
 #[tokio::test]
@@ -529,7 +530,7 @@ async fn exec_operation_stream_handles_output_and_pending_response_from_one_writ
     let result = handle.wait(Duration::from_secs(5)).await.unwrap();
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
     assert!(!result.stream_overflowed);
-    assert!(rx.recv().await.is_none());
+    assert_stream_closed(&mut rx, "pending response and result");
 }
 
 #[tokio::test]
@@ -625,13 +626,13 @@ async fn exec_operation_stream_full_channel_closes_stream_and_marks_result() {
     )
     .await;
 
+    let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+    assert!(result.stream_overflowed);
+
     let first = rx.recv().await.unwrap();
     assert_eq!(first.output_seq, 0);
     assert_eq!(first.chunk, b"first");
-    assert!(rx.recv().await.is_none());
-
-    let result = handle.wait(Duration::from_secs(5)).await.unwrap();
-    assert!(result.stream_overflowed);
+    assert_stream_closed(&mut rx, "stream queue overflow");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add an exec-operation test helper that immediately distinguishes a disconnected stream, a retained sender, and unexpected buffered output
- replace six unbounded terminal stream-closure receives after proven lifecycle barriers
- await the queue-overflow result before draining output, proving terminal delivery while the bounded stream queue remains full

## Scope

- test-only; no production lifecycle, timeout, protocol, API, schema, dependency, persisted state, generated artifact, or deployment change
- preserve the existing async deadline for teardown-before-copy, where reader-loop frame processing has not yet completed
- preserve output ordering, truncation, overflow, readiness, result, operation-state, and connection-state assertions

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host --lib 'tests::exec_operation::lifecycle::'`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host --lib 'tests::exec_operation::stream::'`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p vsock-host --all-features --no-deps`
- queue-overflow exact test repeated 100 times
- path-selected `lefthook run pre-commit`
- `git diff --check`

Closes #24885
