### PR TITLE
perf(python): offload sigv4 body hashing

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -32,8 +32,10 @@ from auth_base_forwarder import (
     take_forward_request_admission_from_flow,
 )
 from aws_sigv4 import (
+    AwsSigV4BodyHash,
     AwsSigV4Credentials,
     AwsSigV4SigningError,
+    hash_request_body,
     request_requires_body_for_signing,
     sign_request,
 )
@@ -440,6 +442,8 @@ def _request_path_query(flow: http.HTTPFlow) -> str:
 def _sign_flow_request_with_aws_sigv4(
     flow: http.HTTPFlow,
     credentials: AwsSigV4Credentials,
+    *,
+    precomputed_body_hash: AwsSigV4BodyHash | None = None,
 ) -> None:
     signed_url, signed_headers = sign_request(
         method=flow.request.method,
@@ -447,11 +451,45 @@ def _sign_flow_request_with_aws_sigv4(
         headers=header_pairs(flow.request.headers),
         body=flow.request.raw_content,
         credentials=credentials,
+        precomputed_body_hash=precomputed_body_hash,
     )
     flow.request.url = signed_url
     flow.request.headers = http.Headers(
         [(name.encode(), value.encode()) for name, value in signed_headers]
     )
+
+
+async def _precompute_aws_sigv4_body_hash(
+    flow: http.HTTPFlow,
+    *,
+    context: _FirewallAuthContext,
+    token_meta: dict,
+) -> AwsSigV4BodyHash | None:
+    if context.auth_request.auth_base is not None or context.auth_request.auth_aws_sigv4 is None:
+        return None
+    if not isinstance(token_meta.get("aws_sigv4"), AwsSigV4Credentials):
+        return None
+    if not aws_sigv4_request_requires_body_for_signing(flow):
+        return None
+
+    hash_future = asyncio.get_running_loop().run_in_executor(
+        None,
+        hash_request_body,
+        flow.request.raw_content,
+    )
+    try:
+        return await asyncio.shield(hash_future)
+    except asyncio.CancelledError:
+        while not hash_future.done():
+            try:
+                await asyncio.shield(hash_future)
+            except asyncio.CancelledError:
+                continue
+            except Exception:
+                break
+        if not hash_future.cancelled():
+            hash_future.exception()
+        raise
 
 
 def _set_url_rewrite_forward_failed(
@@ -1088,6 +1126,7 @@ async def _apply_resolved_firewall_auth(
     context: _FirewallAuthContext,
     token_meta: dict,
     auth_base_client_headers: list[tuple[str, str]] | None,
+    aws_sigv4_body_hash: AwsSigV4BodyHash | None,
 ) -> FirewallAuthHandlingResult:
     """Apply resolved firewall auth and return request ownership outcome."""
     headers = token_meta["headers"]
@@ -1144,7 +1183,11 @@ async def _apply_resolved_firewall_auth(
                 ValueError("resolved AWS SigV4 credentials are missing"),
             )
         try:
-            _sign_flow_request_with_aws_sigv4(flow, aws_sigv4)
+            _sign_flow_request_with_aws_sigv4(
+                flow,
+                aws_sigv4,
+                precomputed_body_hash=aws_sigv4_body_hash,
+            )
         except AwsSigV4SigningError as e:
             _set_matched_firewall_failure_response(
                 flow,
@@ -1256,6 +1299,12 @@ async def handle_firewall_request(
         else:
             token_meta = _empty_firewall_auth_metadata()
 
+        aws_sigv4_body_hash = await _precompute_aws_sigv4_body_hash(
+            flow,
+            context=context,
+            token_meta=token_meta,
+        )
+
         if (
             context.auth_request.auth_base is None
             and auth_config_injects_ordinary_upstream_credentials(
@@ -1273,6 +1322,7 @@ async def handle_firewall_request(
             context=context,
             token_meta=token_meta,
             auth_base_client_headers=auth_base_client_headers,
+            aws_sigv4_body_hash=aws_sigv4_body_hash,
         )
         if auth_result is FirewallAuthHandlingResult.LOCAL_RESPONSE:
             return _finish_firewall_auth_result(flow, auth_result)

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -20,6 +20,7 @@ import re
 import urllib.parse
 from dataclasses import dataclass
 from enum import Enum
+from typing import NewType
 
 from http_header_syntax import has_forbidden_header_value_control, is_http_header_name
 from runtime_url_parsing import split_runtime_url
@@ -59,6 +60,8 @@ _RAW_WHITESPACE_CHARS = frozenset(" \t\n\r\f\v")
 _ASCII_CONTROL_MAX = 0x1F
 _ASCII_DELETE = 0x7F
 _DEFAULT_PORTS = {"http": 80, "https": 443}
+
+AwsSigV4BodyHash = NewType("AwsSigV4BodyHash", str)
 
 
 class AwsSigV4SigningError(Exception):
@@ -115,6 +118,7 @@ def sign_request(
     headers: list[tuple[str, str]],
     body: bytes | None,
     credentials: AwsSigV4Credentials,
+    precomputed_body_hash: AwsSigV4BodyHash | None = None,
 ) -> tuple[str, list[tuple[str, str]]]:
     """Return a URL/header pair re-signed with real AWS credentials.
 
@@ -136,6 +140,9 @@ def sign_request(
     S3-family services keep S3 canonical URI behavior. For presigned S3
     requests without an explicit ``x-amz-content-sha256`` header, the payload
     hash is ``UNSIGNED-PAYLOAD``.
+
+    When supplied, ``precomputed_body_hash`` must be the SHA-256 digest of
+    ``body``. It is ignored when the request declares a supported payload hash.
     """
     _validate_credentials(credentials)
     _validate_headers(headers)
@@ -154,6 +161,7 @@ def sign_request(
             credentials=credentials,
             context=context,
             is_s3=is_s3,
+            precomputed_body_hash=precomputed_body_hash,
         )
     return _sign_header_request(
         method=method,
@@ -163,7 +171,13 @@ def sign_request(
         credentials=credentials,
         context=context,
         is_s3=is_s3,
+        precomputed_body_hash=precomputed_body_hash,
     )
+
+
+def hash_request_body(body: bytes | None) -> AwsSigV4BodyHash:
+    """Return the SHA-256 digest used by payload-dependent SigV4 signing."""
+    return AwsSigV4BodyHash(hashlib.sha256(body or b"").hexdigest())
 
 
 def request_requires_body_for_signing(
@@ -358,8 +372,9 @@ def _sign_header_request(
     credentials: AwsSigV4Credentials,
     context: _SigningContext,
     is_s3: bool,
+    precomputed_body_hash: AwsSigV4BodyHash | None,
 ) -> tuple[str, list[tuple[str, str]]]:
-    payload_hash = _payload_hash(headers, body)
+    payload_hash = _payload_hash(headers, body, precomputed_body_hash)
     clean_headers = _without_headers(headers, {"authorization", "x-amz-security-token"})
     clean_headers = _upsert_header(clean_headers, "host", _host_header_value(url))
     clean_headers = _upsert_header(clean_headers, "x-amz-date", context.amz_date)
@@ -412,11 +427,12 @@ def _sign_query_request(
     credentials: AwsSigV4Credentials,
     context: _SigningContext,
     is_s3: bool,
+    precomputed_body_hash: AwsSigV4BodyHash | None,
 ) -> tuple[str, list[tuple[str, str]]]:
     clean_headers = _without_headers(headers, {"authorization", "x-amz-security-token"})
     clean_headers = _upsert_header(clean_headers, "host", _host_header_value(url))
     signed_headers = frozenset(set(context.signed_headers) | {"host"})
-    payload_hash = _query_payload_hash(headers, body, is_s3)
+    payload_hash = _query_payload_hash(headers, body, is_s3, precomputed_body_hash)
     unsigned_url = _replace_query_signing_params(
         url,
         credentials=credentials,
@@ -529,20 +545,33 @@ def _normalize_header_value(value: str) -> str:
     return " ".join(value.strip().split())
 
 
-def _payload_hash(headers: list[tuple[str, str]], body: bytes | None) -> str:
+def _payload_hash(
+    headers: list[tuple[str, str]],
+    body: bytes | None,
+    precomputed_body_hash: AwsSigV4BodyHash | None,
+) -> str:
     header_value = _content_hash_header_value(headers)
     if header_value is not None:
         return header_value
-    return hashlib.sha256(body or b"").hexdigest()
+    if precomputed_body_hash is not None:
+        return precomputed_body_hash
+    return hash_request_body(body)
 
 
-def _query_payload_hash(headers: list[tuple[str, str]], body: bytes | None, is_s3: bool) -> str:
+def _query_payload_hash(
+    headers: list[tuple[str, str]],
+    body: bytes | None,
+    is_s3: bool,
+    precomputed_body_hash: AwsSigV4BodyHash | None,
+) -> str:
     header_value = _content_hash_header_value(headers)
     if header_value is not None:
         return header_value
     if is_s3:
         return _UNSIGNED_PAYLOAD
-    return hashlib.sha256(body or b"").hexdigest()
+    if precomputed_body_hash is not None:
+        return precomputed_body_hash
+    return hash_request_body(body)
 
 
 def _content_hash_header_value(headers: list[tuple[str, str]]) -> str | None:

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -9,6 +9,7 @@ import runtime_url_parsing
 from aws_sigv4 import (
     AwsSigV4Credentials,
     AwsSigV4SigningError,
+    hash_request_body,
     request_requires_body_for_signing,
     sign_request,
 )
@@ -320,6 +321,46 @@ def test_presigned_query_preserves_ordinary_pairs() -> None:
         "&X-Amz-SignedHeaders=host"
         "&X-Amz-Signature=9245f52c735ed2e7286981a0013837d6c69b227b74cee0a9611b3f0257fc1c68"
     )
+
+
+@pytest.mark.parametrize(
+    ("url", "headers"),
+    [
+        pytest.param(
+            f"https://{STS_HOST}/",
+            _header_auth_headers(),
+            id="header",
+        ),
+        pytest.param(
+            _presigned_url(STS_HOST),
+            [("Host", STS_HOST)],
+            id="presigned",
+        ),
+    ],
+)
+def test_precomputed_body_hash_matches_direct_body_signing(
+    url: str,
+    headers: list[tuple[str, str]],
+) -> None:
+    body = b"expected body"
+    expected = sign_request(
+        method="POST",
+        url=url,
+        headers=headers,
+        body=body,
+        credentials=_credentials(),
+    )
+
+    actual = sign_request(
+        method="POST",
+        url=url,
+        headers=headers,
+        body=b"body ignored by the precomputed path",
+        credentials=_credentials(),
+        precomputed_body_hash=hash_request_body(body),
+    )
+
+    assert actual == expected
 
 
 @pytest.mark.parametrize("amz_date", _INVALID_SEMANTIC_SIGV4_TIMESTAMPS)
@@ -749,6 +790,7 @@ def test_header_auth_content_hash_controls_aws_reference_signature(
         headers=_aws_s3_header_auth_headers(header_value),
         body=body,
         credentials=_aws_s3_example_credentials(),
+        precomputed_body_hash=hash_request_body(b"ignored precomputed body"),
     )
 
     authorization = {name.lower(): value for name, value in headers}["authorization"]
@@ -772,6 +814,7 @@ def test_header_auth_unsigned_payload_controls_reference_signature(
         headers=_aws_s3_header_auth_headers(header_value),
         body=body,
         credentials=_aws_s3_example_credentials(),
+        precomputed_body_hash=hash_request_body(b"ignored precomputed body"),
     )
 
     authorization = {name.lower(): value for name, value in headers}["authorization"]
@@ -804,6 +847,7 @@ def test_presigned_s3_unsigned_payload_matches_aws_reference_signature() -> None
         headers=[("Host", _AWS_S3_EXAMPLE_HOST)],
         body=None,
         credentials=_aws_s3_example_credentials(),
+        precomputed_body_hash=hash_request_body(b"ignored precomputed body"),
     )
 
     query = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(signed_url).query))

--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
@@ -70,7 +70,7 @@ async def _wait_for_hash_start(
         if started_task in done and started_task.result():
             return
         if request_task in done:
-            await request_task
+            _ = await request_task
             raise AssertionError("request finished before SigV4 body hashing started")
         raise AssertionError("SigV4 body hashing did not start before timeout")
     finally:
@@ -385,7 +385,7 @@ async def test_payload_dependent_sigv4_hashing_allows_event_loop_progress(
             assert not request_task.done()
 
             hasher.release.set()
-            await request_task
+            _ = await request_task
 
             assert (
                 f"Credential={RESOLVED_AWS_ACCESS_KEY_ID}/" in flow.request.headers["authorization"]
@@ -441,7 +441,7 @@ async def test_payload_dependent_sigv4_cancellation_waits_for_hash_completion(
 
             hasher.release.set()
             with pytest.raises(asyncio.CancelledError):
-                await request_task
+                _ = await request_task
         finally:
             hasher.release.set()
             await cancel_pending_task(request_task)
@@ -482,7 +482,7 @@ async def test_payload_dependent_sigv4_revalidates_upstream_after_hashing(
             flow.server_conn.state = connection.ConnectionState.CLOSED
             mitm_addon.server_disconnected(SimpleNamespace(server=flow.server_conn))
             hasher.release.set()
-            await request_task
+            _ = await request_task
 
             assert flow.response is not None
             assert flow.response.status_code == 403

--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
@@ -3,6 +3,7 @@
 import asyncio
 import hashlib
 import json
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -16,6 +17,7 @@ import aws_sigv4_body_admission
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import request_streaming
+from aws_sigv4 import AwsSigV4BodyHash, hash_request_body
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.aws_sigv4_helpers import (
     RESOLVED_AWS_ACCESS_KEY_ID,
@@ -36,6 +38,43 @@ from tests.upstream_connection_helpers import mark_connected_tls_upstream
 
 _CLIENT_IP = "10.200.0.5"
 _AWS_PERMISSION = "aws-request"
+_HASH_WAIT_TIMEOUT_SECONDS = 2.0
+
+
+class _ControlledBodyHasher:
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self.started = asyncio.Event()
+        self.release = threading.Event()
+        self.thread_id: int | None = None
+        self._loop = loop
+
+    def __call__(self, body: bytes | None) -> AwsSigV4BodyHash:
+        self.thread_id = threading.get_ident()
+        self._loop.call_soon_threadsafe(self.started.set)
+        if not self.release.wait(timeout=_HASH_WAIT_TIMEOUT_SECONDS):
+            raise AssertionError("controlled SigV4 body hash was not released before timeout")
+        return hash_request_body(body)
+
+
+async def _wait_for_hash_start(
+    hasher: _ControlledBodyHasher,
+    request_task: asyncio.Task[None],
+) -> None:
+    started_task = asyncio.create_task(hasher.started.wait())
+    try:
+        done, _pending = await asyncio.wait(
+            (started_task, request_task),
+            return_when=asyncio.FIRST_COMPLETED,
+            timeout=_HASH_WAIT_TIMEOUT_SECONDS,
+        )
+        if started_task in done and started_task.result():
+            return
+        if request_task in done:
+            await request_task
+            raise AssertionError("request finished before SigV4 body hashing started")
+        raise AssertionError("SigV4 body hashing did not start before timeout")
+    finally:
+        await cancel_pending_task(started_task)
 
 
 def _resolved_token_meta() -> dict[str, object]:
@@ -139,6 +178,11 @@ async def test_payload_independent_sigv4_signs_before_streaming(
     with (
         mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
         patch.object(auth, "get_firewall_headers", get_headers),
+        patch.object(
+            auth,
+            "hash_request_body",
+            side_effect=AssertionError("body-independent signing submitted a body hash"),
+        ),
     ):
         await await_requestheaders_result(mitm_addon.requestheaders(flow))
 
@@ -300,6 +344,160 @@ async def test_payload_dependent_sigv4_holds_admission_until_terminal_cleanup(
     get_headers.assert_awaited_once()
     assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
     assert metadata_keys.AWS_SIGV4_BODY_ADMISSION not in flow.metadata
+
+
+async def test_payload_dependent_sigv4_hashing_allows_event_loop_progress(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    body = b"body"
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        body=body,
+        content_length=str(len(body)),
+    )
+    get_headers = AsyncMock(return_value=_resolved_token_meta())
+    event_loop_thread_id = threading.get_ident()
+    hasher = _ControlledBodyHasher(asyncio.get_running_loop())
+    request_task: asyncio.Task[None] | None = None
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+        patch.object(auth, "hash_request_body", hasher),
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+        request_task = asyncio.create_task(mitm_addon.request(flow))
+        try:
+            await _wait_for_hash_start(hasher, request_task)
+
+            assert hasher.thread_id is not None
+            assert hasher.thread_id != event_loop_thread_id
+            assert not request_task.done()
+            assert RESOLVED_AWS_ACCESS_KEY_ID not in flow.request.headers["authorization"]
+
+            progressed = asyncio.create_task(asyncio.sleep(0, result=True))
+            assert await progressed is True
+            assert not request_task.done()
+
+            hasher.release.set()
+            await request_task
+
+            assert (
+                f"Credential={RESOLVED_AWS_ACCESS_KEY_ID}/" in flow.request.headers["authorization"]
+            )
+            assert aws_sigv4_body_admission.state_for_tests() == (1, len(body))
+
+            flow.response = http.Response.make(200, b"ok")
+            mitm_addon.response(flow)
+        finally:
+            hasher.release.set()
+            await cancel_pending_task(request_task)
+
+    get_headers.assert_awaited_once()
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+
+
+async def test_payload_dependent_sigv4_cancellation_waits_for_hash_completion(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    body = b"body"
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        body=body,
+        content_length=str(len(body)),
+    )
+    get_headers = AsyncMock(return_value=_resolved_token_meta())
+    hasher = _ControlledBodyHasher(asyncio.get_running_loop())
+    request_task: asyncio.Task[None] | None = None
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+        patch.object(auth, "hash_request_body", hasher),
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+        request_task = asyncio.create_task(mitm_addon.request(flow))
+        try:
+            await _wait_for_hash_start(hasher, request_task)
+
+            request_task.cancel()
+            await asyncio.sleep(0)
+            assert not request_task.done()
+            request_task.cancel()
+            await asyncio.sleep(0)
+            assert not request_task.done()
+            assert aws_sigv4_body_admission.state_for_tests() == (1, len(body))
+            assert metadata_keys.AWS_SIGV4_BODY_ADMISSION in flow.metadata
+
+            hasher.release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await request_task
+        finally:
+            hasher.release.set()
+            await cancel_pending_task(request_task)
+
+    get_headers.assert_awaited_once()
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+    assert metadata_keys.AWS_SIGV4_BODY_ADMISSION not in flow.metadata
+
+
+async def test_payload_dependent_sigv4_revalidates_upstream_after_hashing(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    body = b"body"
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        body=body,
+        content_length=str(len(body)),
+    )
+    get_headers = AsyncMock(return_value=_resolved_token_meta())
+    hasher = _ControlledBodyHasher(asyncio.get_running_loop())
+    request_task: asyncio.Task[None] | None = None
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+        patch.object(auth, "hash_request_body", hasher),
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+        request_task = asyncio.create_task(mitm_addon.request(flow))
+        try:
+            await _wait_for_hash_start(hasher, request_task)
+
+            flow.server_conn.state = connection.ConnectionState.CLOSED
+            mitm_addon.server_disconnected(SimpleNamespace(server=flow.server_conn))
+            hasher.release.set()
+            await request_task
+
+            assert flow.response is not None
+            assert flow.response.status_code == 403
+            assert flow.response.content is not None
+            assert json.loads(flow.response.content)["error"] == "upstream_destination_unbound"
+            assert RESOLVED_AWS_ACCESS_KEY_ID not in flow.request.headers["authorization"]
+            assert aws_sigv4_body_admission.state_for_tests() == (1, len(body))
+
+            mitm_addon.response(flow)
+        finally:
+            hasher.release.set()
+            await cancel_pending_task(request_task)
+
+    get_headers.assert_awaited_once()
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
 
 
 async def test_payload_dependent_sigv4_holds_admission_until_websocket_end(


### PR DESCRIPTION
## Summary

- hash payload-dependent AWS SigV4 request bodies in the event loop's default executor
- join the hash worker before propagating cancellation so the retained-body admission lease cannot be released early
- keep destination revalidation and all credential/request mutation on the event-loop thread
- preserve the worker-free body-independent streaming path and existing SigV4 hash precedence

## Safety and scope

The worker receives only the immutable `bytes | None` request body. Resolved credentials, URLs, headers, and mitmproxy flow objects remain on the event-loop thread. Hashing completes before the existing final upstream credential guard, so a connection or host-policy change during the new await still fails closed before credentials are committed.

This does not change APIs, schemas, persisted state, configuration, admission limits, or runner protocols. It does not introduce a dedicated executor; the existing 16-flow / 128 MiB SigV4 body admission remains the producer bound.

## Benchmark

Local microbenchmark on the repository-pinned Python 3.14.0 runtime. The direct signer used a valid STS header-auth placeholder, one warm-up, and nine samples per size:

| Body | Current `main` median / max | This branch direct signer median / max |
| ---: | ---: | ---: |
| 1 MiB | 0.399 / 4.532 ms | 0.399 / 0.441 ms |
| 8 MiB | 3.127 / 3.347 ms | 2.801 / 3.113 ms |
| 32 MiB | 11.614 / 12.014 ms | 11.185 / 11.370 ms |

The synchronous primitive remains proportional to body size. A seven-sample async comparison used four concurrent 32 MiB bodies, a warmed default executor, and a 1 ms event-loop heartbeat:

| Path | Batch total median | Heartbeat gap median | Heartbeat gap max |
| --- | ---: | ---: | ---: |
| synchronous signing | 40.840 ms | 40.873 ms | 43.094 ms |
| executor hash + precomputed signing | 11.727 ms | 4.457 ms | 5.382 ms |

The batch total reflects parallel hashing on this machine; the intended result is the reduction in shared event-loop occupancy. The benchmark was run from `crates/runner/mitm-addon` with `PYTHONPATH=src uv run --no-sync python` and exercised `sign_request()`, `hash_request_body()`, `loop.run_in_executor(None, ...)`, and an `asyncio.sleep(0.001)` heartbeat under the production 4 x 32 MiB aggregate envelope.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4708 passed)
- `lefthook run pre-commit`

Closes #24889
