### PR TITLE
perf(api): attribute runner-claim baseline database latency

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -770,6 +770,9 @@ function expectClaimRouteResponseTimingActions(args: {
     );
     expect(event?.duration_ms).toStrictEqual(expect.any(Number));
     expect(Number(event?.duration_ms)).toBeGreaterThanOrEqual(0);
+    if (actionType !== "claim_route_response_network_policy_refresh") {
+      expect(event).not.toHaveProperty("policy_refresh_path");
+    }
     for (const forbiddenKey of FORBIDDEN_CLAIM_ROUTE_TIMING_KEYS) {
       expect(event).not.toHaveProperty(forbiddenKey);
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -770,9 +770,9 @@ function expectClaimRouteResponseTimingActions(args: {
     );
     expect(event?.duration_ms).toStrictEqual(expect.any(Number));
     expect(Number(event?.duration_ms)).toBeGreaterThanOrEqual(0);
-    if (actionType !== "claim_route_response_network_policy_refresh") {
-      expect(event).not.toHaveProperty("policy_refresh_path");
-    }
+    expect(Object.hasOwn(event ?? {}, "policy_refresh_path")).toBe(
+      actionType === "claim_route_response_network_policy_refresh",
+    );
     for (const forbiddenKey of FORBIDDEN_CLAIM_ROUTE_TIMING_KEYS) {
       expect(event).not.toHaveProperty(forbiddenKey);
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -164,6 +164,7 @@ const CLAIM_ROUTE_PREPARED_PATH_OMITTED_ACTION_TYPES = [
 const CLAIM_ROUTE_RESPONSE_TIMING_ACTION_TYPES = [
   "claim_route_response_resume_session",
   "claim_route_response_network_policy_refresh",
+  "claim_route_response_network_policy_refresh_baseline_database",
 ] as const;
 type ClaimRouteResponseTimingActionType =
   (typeof CLAIM_ROUTE_RESPONSE_TIMING_ACTION_TYPES)[number];
@@ -9083,6 +9084,21 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       expect(claim.networkPolicies?.slack?.deny).toContain("chat:write");
       expect(claim).not.toHaveProperty("connectorPermissionBaseline");
       expectClaimNetworkPolicyRefreshPath(run.runId, fallbackCase.path);
+      expectClaimRouteResponseTimingActions({
+        runId: run.runId,
+        expectedActionTypes:
+          fallbackCase.mode === "catalog-mismatch"
+            ? [
+                "claim_route_response_network_policy_refresh",
+                "claim_route_response_network_policy_refresh_baseline_database",
+              ]
+            : ["claim_route_response_network_policy_refresh"],
+        forbiddenValues: [
+          `fallback ${fallbackCase.mode}`,
+          "slack",
+          claim.sandboxToken,
+        ],
+      });
       await api.requestCancelRun(actor, run.runId, [200]);
     }
   });
@@ -9201,7 +9217,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const granted = grantedContext.policy;
     expectClaimRouteResponseTimingActions({
       runId: grantedContext.claim.runId,
-      expectedActionTypes: ["claim_route_response_network_policy_refresh"],
+      expectedActionTypes: [
+        "claim_route_response_network_policy_refresh",
+        "claim_route_response_network_policy_refresh_baseline_database",
+      ],
       forbiddenValues: [
         "granted permissions",
         "slack",
@@ -9568,6 +9587,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       expectedActionTypes: [
         "claim_route_response_resume_session",
         "claim_route_response_network_policy_refresh",
+        "claim_route_response_network_policy_refresh_baseline_database",
       ],
       forbiddenValues: [
         firstPrompt,

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -176,6 +176,7 @@ type ClaimRouteTimingActionType =
   | "claim_route_secret_materialization"
   | "claim_route_response_assembly"
   | "claim_route_response_network_policy_refresh"
+  | "claim_route_response_network_policy_refresh_baseline_database"
   | "claim_route_response_resume_session"
   | "claim_route_transition_running"
   | "claim_route_transition_execute";
@@ -1359,6 +1360,13 @@ async function refreshClaimNetworkPolicies(args: {
         args.db,
         scope,
         baseline,
+        async <T>(operation: () => Promise<T>): Promise<T> => {
+          return await args.timing.measure(
+            "claim_route_response_network_policy_refresh_baseline_database",
+            "nested",
+            operation,
+          );
+        },
       );
       if (resolution.kind === "incompatible") {
         return await fullRefresh("full_incompatible_baseline");

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -105,6 +105,10 @@ type BaselineNetworkPolicyRefreshResolution =
     }
   | { readonly kind: "incompatible" };
 
+type BaselineNetworkPolicyDatabaseMeasure = <T>(
+  operation: () => Promise<T>,
+) => Promise<T>;
+
 interface UserPermissionGrantBaseScope {
   readonly orgId: string;
   readonly userId: string;
@@ -454,6 +458,7 @@ export async function resolveActiveNetworkPolicyRefreshesFromBaseline(
   db: ReadonlyDb,
   scope: UserPermissionGrantScope,
   baseline: StoredConnectorPermissionBaseline,
+  measureDatabase: BaselineNetworkPolicyDatabaseMeasure,
   checkedAt: Date = nowDate(),
 ): Promise<BaselineNetworkPolicyRefreshResolution> {
   const connectorSlugs = Object.keys(baseline.connectors);
@@ -469,52 +474,54 @@ export async function resolveActiveNetworkPolicyRefreshesFromBaseline(
     return { kind: "incompatible" };
   }
 
-  const rows = await db
-    .select({
-      identity: {
-        schemaVersion: connectorCatalogActiveSnapshot.schemaVersion,
-        catalogVersion: connectorCatalogActiveSnapshot.catalogVersion,
-        catalogDigest: connectorCatalogActiveSnapshot.catalogDigest,
-      },
-      grant: {
-        connectorSlug: userPermissionGrants.connectorSlug,
-        permission: userPermissionGrants.permission,
-        action: userPermissionGrants.action,
-        expiresAt: userPermissionGrants.expiresAt,
-      },
-    })
-    .from(connectorCatalogActiveSnapshot)
-    .innerJoin(
-      connectorCatalogCompatibilityEvaluation,
-      connectorCatalogIdentityJoin(),
-    )
-    .leftJoin(
-      userPermissionGrants,
-      and(
-        eq(userPermissionGrants.orgId, scope.orgId),
-        eq(userPermissionGrants.userId, scope.userId),
-        eq(userPermissionGrants.agentId, scope.agentId),
-        inArray(userPermissionGrants.connectorSlug, connectorSlugs),
-        activeUserPermissionGrantCondition(checkedAt),
-      ),
-    )
-    .where(
-      and(
-        eq(connectorCatalogActiveSnapshot.sourceId, current.sourceId),
-        eq(
-          connectorCatalogActiveSnapshot.schemaVersion,
-          SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+  const rows = await measureDatabase(async () => {
+    return await db
+      .select({
+        identity: {
+          schemaVersion: connectorCatalogActiveSnapshot.schemaVersion,
+          catalogVersion: connectorCatalogActiveSnapshot.catalogVersion,
+          catalogDigest: connectorCatalogActiveSnapshot.catalogDigest,
+        },
+        grant: {
+          connectorSlug: userPermissionGrants.connectorSlug,
+          permission: userPermissionGrants.permission,
+          action: userPermissionGrants.action,
+          expiresAt: userPermissionGrants.expiresAt,
+        },
+      })
+      .from(connectorCatalogActiveSnapshot)
+      .innerJoin(
+        connectorCatalogCompatibilityEvaluation,
+        connectorCatalogIdentityJoin(),
+      )
+      .leftJoin(
+        userPermissionGrants,
+        and(
+          eq(userPermissionGrants.orgId, scope.orgId),
+          eq(userPermissionGrants.userId, scope.userId),
+          eq(userPermissionGrants.agentId, scope.agentId),
+          inArray(userPermissionGrants.connectorSlug, connectorSlugs),
+          activeUserPermissionGrantCondition(checkedAt),
         ),
-        eq(
-          connectorCatalogCompatibilityEvaluation.executableCapabilityDigest,
-          current.capabilityDigest,
+      )
+      .where(
+        and(
+          eq(connectorCatalogActiveSnapshot.sourceId, current.sourceId),
+          eq(
+            connectorCatalogActiveSnapshot.schemaVersion,
+            SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+          ),
+          eq(
+            connectorCatalogCompatibilityEvaluation.executableCapabilityDigest,
+            current.capabilityDigest,
+          ),
         ),
-      ),
-    )
-    .orderBy(
-      asc(userPermissionGrants.connectorSlug),
-      asc(userPermissionGrants.permission),
-    );
+      )
+      .orderBy(
+        asc(userPermissionGrants.connectorSlug),
+        asc(userPermissionGrants.permission),
+      );
+  });
 
   const first = rows[0];
   if (


### PR DESCRIPTION
## Summary

- emit `claim_route_response_network_policy_refresh_baseline_database` as a fixed nested runner-claim timing
- measure exactly the existing compatible-baseline identity/current-grant database await while preserving all policy and fallback behavior
- cover compatible, empty, query-before-fallback, resume-concurrent, and telemetry privacy boundaries through the existing API integration suite

## Scope

This PR adds internal API telemetry only. It does not change the query shape, permission freshness, catalog fallback, claim ordering, database schema, persisted state, API or runner contracts, queue payloads, runner code, or feature switches.

#24915 remains open for the stable post-deployment attribution report that joins this child to its policy parent by `run_id`.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --silent=passed-only` (143 passed)
- repository pre-commit hooks, including full Turbo Knip and type checks

Relates to #24915

Parent context: #24868
