### PR TITLE
refactor: retire zero run trigger agent provenance

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 
+import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
 import {
   ILLUSTRATION_TEMPLATE_ITEMS,
@@ -13,6 +14,7 @@ import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
   chatEventsContract,
   chatThreadEventsContract,
+  chatThreadsContract,
   type AttachFile,
   type ChatRunOptionsRequest,
   type ChatThreadEvent,
@@ -58,6 +60,7 @@ import { createFirewallApi, secretTemplate } from "./helpers/api-bdd-firewall";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+import { readAgentRunState$ } from "./helpers/agent-run-callback";
 import { chatEventDisplayText } from "./helpers/chat-event";
 import {
   clearThreadSessionBinding,
@@ -111,6 +114,7 @@ const connectors = createConnectorBddApi(context);
 const cu = createComputerUseBddApi(context);
 const misc = createMiscRoutesApi(context);
 const routeMocks = createZeroRouteMocks(context);
+const runStateStore = createStore();
 const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 const CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET = "zero web upload-file -f <path>";
 const API_DISPATCH_ZERO_WEB_CHAT_PRE_CREATE_ACTION_TYPES = [
@@ -790,6 +794,10 @@ function modelProviderConnectionsByIdClient() {
 
 function chatEventsClient() {
   return setupApp({ context })(chatEventsContract);
+}
+
+function chatThreadsClient() {
+  return setupApp({ context })(chatThreadsContract);
 }
 
 function chatThreadEventsClient() {
@@ -6018,6 +6026,145 @@ describe("CHAT-02: queued attachments on auto-send", () => {
     );
     expect(followUp.prompt).toContain(`[ID] ${secondFileId}`);
     await cancelChatRun(actor, promoted.runId);
+  }, 90_000);
+});
+
+describe("CHAT-02: run-scoped Zero-token chat launches", () => {
+  it("keeps immediate and queued runs web-scoped without agent provenance", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    if (!actor.orgId) {
+      throw new Error("Expected an organization-scoped chat actor");
+    }
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const caller = await sendChatRun(actor, {
+      agentId,
+      prompt: "launch chat work from this run",
+    });
+    const zeroToken = api.zeroTokenForRunWithCapabilities(actor, caller.runId, [
+      "chat-thread:read",
+      "chat-thread:write",
+      "chat-event:read",
+      "chat-event:write",
+    ]);
+
+    const createdThread = await accept(
+      chatThreadsClient().create({
+        headers: { authorization: `Bearer ${zeroToken}` },
+        body: { agentId, title: "Run-scoped handoff" },
+      }),
+      [201],
+    );
+    const immediate = await requestSendEventWithBearer(
+      zeroToken,
+      {
+        agentId,
+        threadId: createdThread.body.id,
+        prompt: "immediate run-scoped handoff",
+      },
+      [201],
+    );
+    if (immediate.status !== 201) {
+      throw new Error("Expected the run-scoped handoff request to succeed");
+    }
+    if (!immediate.body.runId) {
+      throw new Error("Expected the run-scoped handoff to launch immediately");
+    }
+
+    await expect(
+      api.readRun(actor, immediate.body.runId),
+    ).resolves.toMatchObject({
+      runId: immediate.body.runId,
+      prompt: "immediate run-scoped handoff",
+    });
+    // Neither callback internals nor retired provenance are public API fields.
+    // The test-only state route is the only boundary that can prove their
+    // absence without importing database schemas or production services.
+    const immediateState = await runStateStore.set(
+      readAgentRunState$,
+      {
+        orgId: actor.orgId,
+        userId: actor.userId,
+        runId: immediate.body.runId,
+      },
+      context.signal,
+    );
+    expect(immediateState.zero_run).toMatchObject({
+      triggerSource: "web",
+      triggerAgentId: null,
+    });
+    expect(
+      immediateState.callbacks.map((callback) => {
+        return callback.internalKind;
+      }),
+    ).toStrictEqual(["chat"]);
+
+    const queuedEventId = randomUUID();
+    const queued = await requestSendEventWithBearer(
+      zeroToken,
+      {
+        agentId,
+        clientEventId: queuedEventId,
+        threadId: createdThread.body.id,
+        prompt: "queued run-scoped handoff",
+      },
+      [201],
+    );
+    if (queued.status !== 201) {
+      throw new Error("Expected the queued run-scoped request to succeed");
+    }
+    expect(queued.body.runId).toBeNull();
+
+    await cancelChatRun(actor, immediate.body.runId);
+    const promotedMessages = await waitForThreadMessages(
+      actor,
+      createdThread.body.id,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.revokesEventId === queuedEventId &&
+            message.runId !== undefined
+          );
+        });
+      },
+    );
+    const promoted = userMessages(promotedMessages.events).find(
+      (message): message is PromptMessage => {
+        return (
+          message.eventType === "input.prompt" &&
+          message.revokesEventId === queuedEventId
+        );
+      },
+    );
+    if (!promoted?.runId) {
+      throw new Error("Expected the queued run-scoped handoff to promote");
+    }
+
+    await expect(api.readRun(actor, promoted.runId)).resolves.toMatchObject({
+      runId: promoted.runId,
+      prompt: "queued run-scoped handoff",
+    });
+    const promotedState = await runStateStore.set(
+      readAgentRunState$,
+      {
+        orgId: actor.orgId,
+        userId: actor.userId,
+        runId: promoted.runId,
+      },
+      context.signal,
+    );
+    expect(promotedState.zero_run).toMatchObject({
+      triggerSource: "web",
+      triggerAgentId: null,
+    });
+    expect(
+      promotedState.callbacks.map((callback) => {
+        return callback.internalKind;
+      }),
+    ).toStrictEqual(["chat"]);
+
+    await cancelChatRun(actor, promoted.runId);
+    await cancelChatRun(actor, caller.runId);
   }, 90_000);
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/agent-run-callback.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/agent-run-callback.ts
@@ -26,11 +26,18 @@ const agentRunCallbackSnapshotSchema = z.object({
   lastError: z.string().nullable(),
 });
 
-const agentRunCallbacksResponseSchema = z.object({
+const agentRunStateResponseSchema = z.object({
+  zero_run: z
+    .object({
+      triggerSource: z.string().nullable(),
+      triggerAgentId: z.string().nullable(),
+    })
+    .nullable(),
   callbacks: z.array(agentRunCallbackSnapshotSchema),
 });
 
 type AgentRunCallbackSnapshot = z.infer<typeof agentRunCallbackSnapshotSchema>;
+type AgentRunStateSnapshot = z.infer<typeof agentRunStateResponseSchema>;
 
 interface ReadAgentRunCallbacksBaseOptions {
   readonly orgId: string;
@@ -104,12 +111,12 @@ export const seedAgentRunCallback$ = command(
   },
 );
 
-export const readAgentRunCallbacks$ = command(
+export const readAgentRunState$ = command(
   async (
     _,
     options: ReadAgentRunCallbacksOptions,
     signal: AbortSignal,
-  ): Promise<readonly AgentRunCallbackSnapshot[]> => {
+  ): Promise<AgentRunStateSnapshot> => {
     const response = await requestTelegramState(
       signal,
       TELEGRAM_STATE_ACTION_ROUTE,
@@ -126,10 +133,21 @@ export const readAgentRunCallbacks$ = command(
       },
     );
     signal.throwIfAborted();
-    expectOk(response, "readAgentRunCallbacks$");
+    expectOk(response, "readAgentRunState$");
     signal.throwIfAborted();
     const body = await readJson<unknown>(response);
     signal.throwIfAborted();
-    return agentRunCallbacksResponseSchema.parse(body).callbacks;
+    return agentRunStateResponseSchema.parse(body);
+  },
+);
+
+export const readAgentRunCallbacks$ = command(
+  async (
+    { set },
+    options: ReadAgentRunCallbacksOptions,
+    signal: AbortSignal,
+  ): Promise<readonly AgentRunCallbackSnapshot[]> => {
+    const state = await set(readAgentRunState$, options, signal);
+    return state.callbacks;
   },
 );

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -3534,6 +3534,42 @@ describe("RUN-04/OPS-01: zero run logs", () => {
     expect(sinceFilteredIds).not.toContain(beforeBoundaryRun.runId);
   });
 
+  it("preserves historical agent-source logs without provenance", async () => {
+    const actor = await entitledActor();
+    const compose = await createClaudeCompose(actor, "historical-agent-log");
+    const historicalAgentRun = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "historical agent-source run",
+      triggerSource: "agent",
+    });
+    await api.requestCancelRun(actor, historicalAgentRun.runId, [200]);
+
+    const listed = await reads.requestListLogs(actor, {}, [200]);
+    if (listed.status !== 200) {
+      throw new Error("Expected the historical agent-source log list");
+    }
+    expect(
+      listed.body.data.find((entry) => {
+        return entry.id === historicalAgentRun.runId;
+      }),
+    ).toMatchObject({
+      triggerSource: "agent",
+      triggerAgentName: null,
+    });
+    expect(listed.body.filters.sources).toContain("agent");
+
+    const detail = await reads.requestReadLogById(
+      actor,
+      historicalAgentRun.runId,
+      [200],
+    );
+    expect(detail.body).toMatchObject({
+      id: historicalAgentRun.runId,
+      triggerSource: "agent",
+      triggerAgentName: null,
+    });
+  });
+
   it("resolves zero log agent identity from the run session when compose versions are shared", async () => {
     const misc = createMiscRoutesApi(context);
     const authOrg = createAuthOrgAgentsBddApi(context);

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -1182,6 +1182,7 @@ async function getTelegramPostRunStateForAction(
       .select({
         id: zeroRuns.id,
         triggerSource: zeroRuns.triggerSource,
+        triggerAgentId: zeroRuns.triggerAgentId,
         chatThreadId: zeroRuns.chatThreadId,
         modelProvider: zeroRuns.modelProvider,
         selectedModel: zeroRuns.selectedModel,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -402,7 +402,6 @@ interface PreparedAdditionalVolumes {
 }
 
 interface ZeroRunMetadata {
-  readonly triggerAgentId?: string;
   // Run provenance for workflow schedule automations.
   readonly workflowAutomationId?: string;
   readonly triggerBrief?: string;
@@ -5146,7 +5145,6 @@ function launchZeroRunValues(
     triggerBrief: metadata.triggerBrief ?? null,
     runGroupId: metadata.goalId ?? null,
     goalId: metadata.goalId ?? null,
-    triggerAgentId: metadata.triggerAgentId ?? null,
     ...(args.zeroRunModelPin ?? zeroRunModelProviderValues(args.modelProvider)),
     chatThreadId: args.chatThreadId ?? null,
     apiStartedAt: args.status === "queued" ? null : new Date(args.apiStartTime),

--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -22,7 +22,6 @@ import { agentSessions } from "@vm0/db/schema/agent-session";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { conversations } from "@vm0/db/schema/conversation";
-import { alias } from "drizzle-orm/pg-core";
 import {
   and,
   count,
@@ -44,8 +43,6 @@ import { now } from "../../lib/time";
 import { runContextCliAgentType } from "./run-context-framework.service";
 
 type ServiceDb = Pick<Db, "select" | "selectDistinct">;
-
-const triggerAgentAlias = alias(zeroAgents, "trigger_agent");
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 const AXIOM_RUN_ID_FILTER_CHUNK_SIZE = 500;
@@ -197,7 +194,6 @@ export function zeroLogsList(
           composeName: agentComposes.name,
           composeContent: agentComposeVersions.content,
           displayName: zeroAgents.displayName,
-          triggerAgentName: triggerAgentAlias.displayName,
           cliAgentSessionId: conversations.cliAgentSessionId,
         })
         .from(agentRuns)
@@ -212,10 +208,6 @@ export function zeroLogsList(
           eq(agentSessions.agentComposeId, agentComposes.id),
         )
         .leftJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
-        .leftJoin(
-          triggerAgentAlias,
-          eq(zeroRuns.triggerAgentId, triggerAgentAlias.id),
-        )
         .leftJoin(conversations, eq(agentRuns.id, conversations.runId))
         .where(whereClause)
         .orderBy(desc(agentRuns.createdAt), desc(agentRuns.id))
@@ -243,7 +235,7 @@ export function zeroLogsList(
           displayName: run.displayName ?? null,
           framework: extractFramework(run.composeContent),
           triggerSource: normalizeTriggerSource(run.triggerSource),
-          triggerAgentName: run.triggerAgentName ?? null,
+          triggerAgentName: null,
           status: run.status as LogStatus,
           prompt: run.prompt,
           createdAt: run.createdAt.toISOString(),
@@ -397,7 +389,6 @@ export function zeroLogDetail(
         agentId: zeroAgents.id,
         agentDisplayName: zeroAgents.displayName,
         triggerSource: zeroRuns.triggerSource,
-        triggerAgentName: triggerAgentAlias.displayName,
         modelProvider: zeroRuns.modelProvider,
         selectedModel: zeroRuns.selectedModel,
       })
@@ -409,10 +400,6 @@ export function zeroLogDetail(
       )
       .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
       .leftJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
-      .leftJoin(
-        triggerAgentAlias,
-        eq(zeroRuns.triggerAgentId, triggerAgentAlias.id),
-      )
       .where(
         and(
           eq(agentRuns.id, params.runId),
@@ -432,7 +419,6 @@ export function zeroLogDetail(
       agentId,
       agentDisplayName,
       triggerSource,
-      triggerAgentName,
       modelProvider,
       selectedModel,
     } = result;
@@ -452,7 +438,7 @@ export function zeroLogDetail(
       modelProvider: modelProvider ?? null,
       selectedModel: selectedModel ?? null,
       triggerSource: normalizeTriggerSource(triggerSource),
-      triggerAgentName: triggerAgentName ?? null,
+      triggerAgentName: null,
       status: run.status as LogStatus,
       prompt: run.prompt,
       appendSystemPrompt: run.appendSystemPrompt ?? null,

--- a/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
@@ -4,8 +4,6 @@ import type {
   FirewallPermissionGrant,
   FirewallPermissionGrantAction,
 } from "@vm0/connectors/firewall-metadata/policy";
-import { agentRuns } from "@vm0/db/schema/agent-run";
-import { agentSessions } from "@vm0/db/schema/agent-session";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { userConnectors } from "@vm0/db/schema/user-connector";
@@ -49,7 +47,6 @@ const bootstrapMetadataRowKindSchema = z.enum([
   "builtin_connector",
   "custom_connector",
   "permission_grant",
-  "trigger_agent",
 ]);
 type BootstrapMetadataRowKind = z.output<typeof bootstrapMetadataRowKindSchema>;
 const bootstrapMetadataRowKindDecoder = zodEnumDriverValueDecoder(
@@ -110,14 +107,12 @@ export interface ZeroRunBootstrapContext extends AgentConnectorScope {
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly workflows: readonly RunWorkflowRef[];
   readonly permissionGrants: readonly FirewallPermissionGrant[];
-  readonly triggerAgentId: string | undefined;
 }
 
 interface ZeroRunBootstrapSnapshotArgs {
   readonly userId: string;
   readonly orgId: string;
   readonly agentId: string;
-  readonly triggerRunId: string | undefined;
   readonly checkedAt: Date;
 }
 
@@ -146,25 +141,6 @@ function emptyBootstrapMetadataFields() {
       .mapWith(nullableCustomConnectorPermissionNamesDecoder)
       .as("permission_names"),
   };
-}
-
-function zeroRunTriggerAgentMetadataQuery(
-  db: ReadonlyDb,
-  triggerRunId: string | undefined,
-) {
-  return db
-    .select({
-      kind: sql`'trigger_agent'`
-        .mapWith(bootstrapMetadataRowKindDecoder)
-        .as("kind"),
-      ...emptyBootstrapMetadataFields(),
-      id: sql`${agentSessions.agentComposeId}::text`
-        .mapWith(nullableTextDecoder)
-        .as("id"),
-    })
-    .from(agentRuns)
-    .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
-    .where(triggerRunId ? eq(agentRuns.id, triggerRunId) : sql`FALSE`);
 }
 
 function zeroRunCustomConnectorMetadataQuery(
@@ -296,18 +272,12 @@ async function queryZeroRunBootstrapMetadataSnapshot(
         activeUserPermissionGrantCondition(args.checkedAt),
       ),
     );
-  const triggerAgentQuery = zeroRunTriggerAgentMetadataQuery(
-    db,
-    args.triggerRunId,
-  );
-
   return await unionAll(
     userInfoQuery,
     featureSwitchQuery,
     builtinConnectorQuery,
     customConnectorQuery,
     permissionGrantQuery,
-    triggerAgentQuery,
   );
 }
 
@@ -363,7 +333,6 @@ export function materializeZeroRunBootstrapContext(
   const connectorRows: AgentConnectorSlugRow[] = [];
   const customConnectorRows: AgentCustomConnectorRow[] = [];
   const permissionGrants: FirewallPermissionGrant[] = [];
-  let triggerAgentId: string | undefined;
 
   for (const row of rows.metadataRows) {
     switch (row.kind) {
@@ -417,13 +386,6 @@ export function materializeZeroRunBootstrapContext(
         });
         break;
       }
-      case "trigger_agent": {
-        if (row.id === null) {
-          throw new Error("Invalid Zero bootstrap metadata trigger agent row");
-        }
-        triggerAgentId = row.id;
-        break;
-      }
     }
   }
 
@@ -452,6 +414,5 @@ export function materializeZeroRunBootstrapContext(
     ...connectorScope,
     workflows: workflowsForRunFromRows(rows.workflowRows, args.userId),
     permissionGrants,
-    triggerAgentId,
   };
 }

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -1,5 +1,3 @@
-import { randomBytes } from "node:crypto";
-
 import { PLAN_UPGRADE_CLI_HINT } from "@vm0/api-contracts/contracts/errors";
 import { CANONICAL_WORKING_DIR } from "@vm0/api-contracts/contracts/runners";
 import { zeroRunCreateBodySchema } from "@vm0/api-contracts/contracts/zero-runs";
@@ -139,7 +137,6 @@ interface InternalRunCallback {
 type RunCallback = HttpRunCallback | InternalRunCallback;
 
 interface ZeroRunMetadata {
-  readonly triggerAgentId?: string;
   readonly workflowAutomationId?: string;
   readonly triggerBrief?: string;
   readonly goalId?: string;
@@ -223,10 +220,6 @@ function forbidden(message: string) {
       },
     },
   };
-}
-
-function generateCallbackSecret(): string {
-  return randomBytes(32).toString("hex");
 }
 
 function buildAgentIdentityPrompt(agent: ZeroAgentRunRecord): string | null {
@@ -637,14 +630,11 @@ function createRunBody(args: {
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly userInfo: UserInfo;
   readonly permissionPolicies: FirewallPolicies | null | undefined;
-  readonly triggerAgentId: string | undefined;
   readonly triggerSource: TriggerSource | undefined;
   readonly appendSystemPrompt: string | undefined;
   readonly cloudBrowserEnabled: boolean | undefined;
 }) {
-  const triggerSource =
-    args.triggerSource ??
-    (args.triggerAgentId ? ("agent" as const) : ("web" as const));
+  const triggerSource = args.triggerSource ?? "web";
   const baseAppendSystemPrompt = buildAppendSystemPrompt({
     agent: args.agent,
     featureSwitchContext: args.featureSwitchContext,
@@ -673,18 +663,6 @@ function createRunBody(args: {
     disallowedTools: [...DISALLOWED_TOOLS],
     vars: { ZERO_AGENT_ID: args.agent.id },
   };
-}
-
-function callbacksForAutomationAgent(triggerAgentId: string | undefined) {
-  return triggerAgentId
-    ? [
-        {
-          internalKind: "agent" as const,
-          secret: generateCallbackSecret(),
-          payload: { triggerAgentId },
-        },
-      ]
-    : undefined;
 }
 
 function measureZeroPreCreate<T>(
@@ -739,7 +717,6 @@ async function loadZeroRunPostAuthorizationContext(
     readonly userId: string;
     readonly orgId: string;
     readonly agentId: string;
-    readonly triggerRunId: string | undefined;
     readonly apiStartTime: number;
     readonly timing: ApiDispatchTimingCollector;
   },
@@ -754,7 +731,6 @@ async function loadZeroRunPostAuthorizationContext(
         userId: args.userId,
         orgId: args.orgId,
         agentId: args.agentId,
-        triggerRunId: args.triggerRunId,
         checkedAt: new Date(args.apiStartTime),
       });
       measuredSnapshotRows = loadedRows;
@@ -820,7 +796,6 @@ function buildZeroCreateAgentRunArgs(args: {
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly userInfo: UserInfo;
   readonly runPermissionPolicies: FirewallPolicies | null | undefined;
-  readonly triggerAgentId: string | undefined;
   readonly workflows: readonly RunWorkflowRef[];
   readonly allowedConnectorSlugs: readonly ConnectorSlug[];
   readonly allowedCustomConnectorIds: readonly string[];
@@ -841,7 +816,6 @@ function buildZeroCreateAgentRunArgs(args: {
       featureSwitchContext: args.featureSwitchContext,
       userInfo: { ...args.userInfo, ...command.userInfoExtras },
       permissionPolicies: args.runPermissionPolicies,
-      triggerAgentId: args.triggerAgentId,
       triggerSource: command.triggerSource,
       appendSystemPrompt: command.appendSystemPrompt,
       cloudBrowserEnabled: args.cloudBrowserEnabled,
@@ -860,10 +834,7 @@ function buildZeroCreateAgentRunArgs(args: {
       chatThreadId: command.chatThreadId,
       codexServiceTier: command.codexServiceTier,
     }),
-    callbacks: [
-      ...(callbacksForAutomationAgent(args.triggerAgentId) ?? []),
-      ...(command.callbacks ?? []),
-    ],
+    callbacks: command.callbacks,
     includeZeroTokenSecret: true,
     zeroTokenComputerUseHostId: command.computerUseHostId,
     zeroTokenCloudBrowserEnabled: args.cloudBrowserEnabled,
@@ -877,10 +848,7 @@ function buildZeroCreateAgentRunArgs(args: {
       source: "zero_agent",
     },
     validateEnvironmentReferences: false,
-    zeroRunMetadata: {
-      ...command.zeroRunMetadata,
-      triggerAgentId: args.triggerAgentId,
-    },
+    zeroRunMetadata: command.zeroRunMetadata,
     dispatchFailedCallbacks: command.dispatchFailedCallbacks,
     ...(command.zeroRunModelPin
       ? { zeroRunModelPin: command.zeroRunModelPin }
@@ -911,7 +879,6 @@ interface ZeroRunAfterPreCreate {
   readonly timing: ApiDispatchTimingCollector;
   readonly cloudBrowserEnabled: boolean | undefined;
   readonly command: AnyCreateZeroRunCommandArgs;
-  readonly triggerAgentId: string | undefined;
   readonly threadSessionResolution?: ChatThreadSessionResolution;
 }
 
@@ -1070,10 +1037,6 @@ const createZeroRunInternal$ = command(
       return forbidden("Only the private agent owner can run this agent");
     }
 
-    const triggerRunId =
-      args.auth.tokenType === "sandbox" || args.auth.tokenType === "zero"
-        ? args.auth.runId
-        : undefined;
     const {
       userInfo,
       featureSwitchContext,
@@ -1083,14 +1046,12 @@ const createZeroRunInternal$ = command(
       workflows,
       runPermissionPolicies,
       connectorCatalogSnapshot,
-      triggerAgentId,
     } = await loadZeroRunPostAuthorizationContext(
       db,
       {
         userId: args.auth.userId,
         orgId: args.auth.orgId,
         agentId: agent.id,
-        triggerRunId,
         apiStartTime: args.apiStartTime,
         timing,
       },
@@ -1106,7 +1067,6 @@ const createZeroRunInternal$ = command(
         featureSwitchContext,
         runPermissionPolicies,
         connectorCatalogSnapshot,
-        triggerAgentId,
         workflows,
         allowedConnectorSlugs,
         allowedCustomConnectorIds,

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-page-routing.test.ts
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-page-routing.test.ts
@@ -196,7 +196,7 @@ describe("activity page routing", () => {
     },
   );
 
-  it("identifies delegated activity with the parent agent source", async () => {
+  it("shows historical agent activity with the generic source label", async () => {
     context.mocks.data.composesList([
       {
         id: "c0000000-0000-4000-a000-000000000001",
@@ -219,7 +219,7 @@ describe("activity page routing", () => {
             framework: "claude-code",
             status: "completed",
             triggerSource: "agent",
-            triggerAgentName: "Parent Bot",
+            triggerAgentName: null,
             prompt: "Test prompt",
             createdAt: "2026-03-10T15:00:00Z",
             startedAt: "2026-03-10T15:00:01Z",
@@ -234,7 +234,7 @@ describe("activity page routing", () => {
     detachedSetupPage({ context, path: "/activities" });
 
     await waitFor(() => {
-      expect(screen.getByText("Agent (Parent Bot)")).toBeInTheDocument();
+      expect(screen.getByText("Agent")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

- remove caller-run trigger-agent bootstrap metadata and all runtime triggerAgentId threading
- default unspecified Zero run trigger sources to web and stop creating new internal agent callbacks
- stop Activity queries from reading trigger_agent_id while preserving the triggerAgentName response shape as null
- add targeted coverage for run-scoped Zero-token chat launches and historical Agent activity

## Rollout compatibility

- keeps zero_runs.trigger_agent_id in the Drizzle schema and physical database
- keeps the internal agent callback discriminator, dispatcher, handler, progress, and no-ccstate compatibility paths
- keeps the triggerAgentName API and platform contract until the follow-up cleanup release
- keeps the historical triggerSource agent enum value and generic Agent label

## Validation

- pnpm format
- pnpm -F api lint
- pnpm -F api check-types
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm knip --workspace api --workspace @vm0/app
- targeted API regression: run-scoped Zero-token immediate and queued chat launches
- targeted API regression: historical agent-source log list/detail
- targeted platform regression: generic Agent activity label

A pre-existing callback compatibility test that claims a queued runner job reproduces a local environment 404 on latest main; the same file's other four tests pass, and this PR leaves that compatibility path unchanged. CI remains authoritative for the standard queue environment.

Refs #24917