### PR TITLE
fix(guest-agent): include file modes in artifact identity

### DIFF
--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -15,8 +15,9 @@ use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+const ARTIFACT_FILE_IDENTITY_V2_DOMAIN: &[u8] = b"vm0-artifact-file-identity-v2\0";
 
-/// Walk directory and compute SHA-256 for each file, skipping `.git` and `.vm0`.
+/// Walk directory and compute byte-and-mode identity for each file, skipping `.git` and `.vm0`.
 #[cfg(target_os = "linux")]
 pub(super) fn collect_file_metadata(dir_path: &str) -> Result<Vec<FileEntry>, ArchiveError> {
     let mut files = Vec::new();
@@ -103,7 +104,7 @@ fn walk_entries(
                 max_path_bytes: STORAGE_MANIFEST_MAX_PATH_BYTES,
             });
         }
-        match compute_file_hash_from_reader(file) {
+        match compute_file_identity_from_reader(file, archive_mode(&metadata)) {
             Ok((hash, size)) => {
                 *path_bytes = observed_path_bytes;
                 out.push(FileEntry {
@@ -151,12 +152,24 @@ fn artifact_path_component<'a>(
 }
 
 #[cfg(test)]
-fn compute_file_hash(path: &Path) -> Result<(String, u64), std::io::Error> {
-    compute_file_hash_from_reader(std::fs::File::open(path)?)
+fn compute_file_identity(path: &Path) -> Result<(String, u64), std::io::Error> {
+    let file = File::open(path)?;
+    let metadata = file.metadata()?;
+    compute_file_identity_from_reader(file, archive_mode(&metadata))
 }
 
-fn compute_file_hash_from_reader(mut reader: impl Read) -> Result<(String, u64), std::io::Error> {
+fn artifact_file_identity_hasher(mode: u32) -> Sha256 {
     let mut hasher = Sha256::new();
+    hasher.update(ARTIFACT_FILE_IDENTITY_V2_DOMAIN);
+    hasher.update(mode.to_be_bytes());
+    hasher
+}
+
+fn compute_file_identity_from_reader(
+    mut reader: impl Read,
+    mode: u32,
+) -> Result<(String, u64), std::io::Error> {
+    let mut hasher = artifact_file_identity_hasher(mode);
     let mut buf = [0u8; 8192];
     let mut total = 0u64;
     loop {
@@ -214,9 +227,9 @@ pub(super) enum ArchiveError {
         actual: u64,
     },
     #[error(
-        "archive file {path:?} content changed after manifest collection: expected sha256 {expected}, got {actual}"
+        "archive file {path:?} identity changed after manifest collection: expected {expected}, got {actual}"
     )]
-    HashMismatch {
+    IdentityMismatch {
         path: String,
         expected: String,
         actual: String,
@@ -290,7 +303,7 @@ pub(super) fn create_archive(
 /// root/child path opening used for archive creation, then verifies that
 /// manifest paths are still non-empty relative paths with no root, prefix, `.`,
 /// or `..` components, entries are still regular files, and file size plus
-/// SHA-256 still match the pre-walked manifest.
+/// byte-and-mode identity still match the pre-walked manifest.
 /// Empty manifests still validate readable artifact-root access through the
 /// no-follow root-opening path.
 ///
@@ -349,7 +362,7 @@ fn consume_verified_archive_file(
     consume: impl FnOnce(&Metadata, &mut ArchiveFileReader<File>) -> Result<(), ArchiveError>,
 ) -> Result<(), ArchiveError> {
     let (file, metadata) = open_manifest_file(root, entry)?;
-    let mut reader = ArchiveFileReader::new(file, entry.size);
+    let mut reader = ArchiveFileReader::new(file, entry.size, archive_mode(&metadata));
     consume(&metadata, &mut reader)?;
 
     let actual_hash = reader
@@ -359,7 +372,7 @@ fn consume_verified_archive_file(
             source,
         })?;
     if actual_hash != entry.hash {
-        return Err(ArchiveError::HashMismatch {
+        return Err(ArchiveError::IdentityMismatch {
             path: entry.path.clone(),
             expected: entry.hash.clone(),
             actual: actual_hash,
@@ -471,11 +484,11 @@ struct ArchiveFileReader<R> {
 }
 
 impl<R> ArchiveFileReader<R> {
-    fn new(inner: R, size: u64) -> Self {
+    fn new(inner: R, size: u64, mode: u32) -> Self {
         Self {
             inner,
             remaining: size,
-            hasher: Sha256::new(),
+            hasher: artifact_file_identity_hasher(mode),
         }
     }
 
@@ -1004,12 +1017,12 @@ mod tests {
         let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
         std::fs::write(root.join("target.txt"), "after!").unwrap();
 
-        assert_archive_inputs_rejected(root, &files, &["target.txt", "content changed"]).unwrap();
+        assert_archive_inputs_rejected(root, &files, &["target.txt", "identity changed"]).unwrap();
     }
 
     #[test]
     fn archive_reader_rejects_extra_bytes_after_declared_size() {
-        let mut reader = ArchiveFileReader::new(Cursor::new(b"abcdef".as_slice()), 3);
+        let mut reader = ArchiveFileReader::new(Cursor::new(b"abcdef".as_slice()), 3, 0o644);
         let mut archived = Vec::new();
 
         io::copy(&mut reader, &mut archived).unwrap();
@@ -1226,32 +1239,32 @@ mod tests {
     }
 
     #[test]
-    fn compute_file_hash_known_value() {
+    fn compute_file_identity_known_value() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.txt");
         std::fs::write(&path, "hello world").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
-        let (hash, size) = compute_file_hash(&path).unwrap();
+        let (hash, size) = compute_file_identity(&path).unwrap();
         assert_eq!(size, 11);
-        // SHA-256 of "hello world"
         assert_eq!(
             hash,
-            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+            "6f69406f7b21e3d9a7e458aa935c68b71b7cf42f65bca5026410573e351a9da8"
         );
     }
 
     #[test]
-    fn compute_file_hash_empty_file() {
+    fn compute_file_identity_empty_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("empty.txt");
         std::fs::write(&path, "").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
-        let (hash, size) = compute_file_hash(&path).unwrap();
+        let (hash, size) = compute_file_identity(&path).unwrap();
         assert_eq!(size, 0);
-        // SHA-256 of empty string
         assert_eq!(
             hash,
-            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            "8c3d521e5e864a97dade01f390d422ac29653fb3d03624893971fcedd4bc0dff"
         );
     }
 

--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -1,4 +1,4 @@
-//! VAS artifact upload — SHA-256 hashing, tar.gz creation, S3 presigned upload.
+//! VAS artifact upload — file byte-and-mode identity, tar.gz creation, S3 presigned upload.
 //!
 //! Flow (caller first walks the mount via [`walk_files_for_checkpoint`], then
 //! invokes [`create_snapshot`] with the pre-walked file list):
@@ -35,6 +35,7 @@ pub(crate) struct FileEntry {
     /// UTF-8 relative protocol path used in prepare/commit payloads, manifests,
     /// and archive creation. Do not derive this from lossy filesystem conversion.
     pub(crate) path: String,
+    /// Opaque identity for the file bytes and Unix mode persisted in the archive.
     pub(crate) hash: String,
     pub(crate) size: u64,
 }
@@ -156,7 +157,7 @@ impl WalkFilesError {
 pub(crate) async fn walk_files_for_checkpoint(
     mount_path: &str,
 ) -> Result<Vec<FileEntry>, WalkFilesError> {
-    log_info!(LOG_TAG, "Computing file hashes...");
+    log_info!(LOG_TAG, "Computing file identities...");
     let hash_start = std::time::Instant::now();
     let mount = mount_path.to_string();
     let files_result =

--- a/crates/guest-agent/src/checkpoint/artifact.rs
+++ b/crates/guest-agent/src/checkpoint/artifact.rs
@@ -88,10 +88,10 @@ async fn snapshot_artifact_plan(
             ));
         }
     };
-    // Skip the VAS round-trips when the mount is byte-identical to what
-    // was originally mounted. `version_id` in VAS *is* the content hash
-    // (same SHA-256 the web producer emits), so an equality check on the
-    // locally-recomputed hash is sufficient — no extra metadata needed.
+    // Skip the VAS round-trips when the mount has the same file bytes and Unix
+    // modes as the version that was originally mounted. `version_id` in VAS is
+    // the deterministic storage identity, so an equality check on the locally
+    // recomputed value is sufficient.
     // See #10967 for the ~3.9s-per-checkpoint motivation.
     let skip_check_start = std::time::Instant::now();
     let content_hash_start = std::time::Instant::now();

--- a/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
+++ b/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
@@ -5,19 +5,34 @@ use guest_agent::run_context::GuestRuntime;
 use httpmock::prelude::*;
 use serde_json::json;
 use sha2::{Digest, Sha256};
+#[cfg(target_os = "linux")]
+use std::io::Cursor;
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+#[cfg(target_os = "linux")]
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 const RUN_ID: &str = "artifact-checkpoint-content-hash";
 const STORAGE_ID: &str = "01234567-89ab-cdef-0123-456789abcdef";
+const ARTIFACT_FILE_IDENTITY_V2_DOMAIN: &[u8] = b"vm0-artifact-file-identity-v2\0";
 
 fn sha256_hex(bytes: impl AsRef<[u8]>) -> String {
     hex::encode(Sha256::digest(bytes.as_ref()))
 }
 
-fn content_hash_for_single_file(storage_id: &str, path: &str, content: &str) -> String {
-    let file_hash = sha256_hex(content.as_bytes());
-    sha256_hex(format!("storage:{storage_id}\n{path}:{file_hash}"))
+fn artifact_file_identity(mode: u32, content: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(ARTIFACT_FILE_IDENTITY_V2_DOMAIN);
+    hasher.update(mode.to_be_bytes());
+    hasher.update(content);
+    hex::encode(hasher.finalize())
+}
+
+fn version_id_for_single_file(storage_id: &str, path: &str, mode: u32, content: &[u8]) -> String {
+    let file_identity = artifact_file_identity(mode, content);
+    sha256_hex(format!("storage:{storage_id}\n{path}:{file_identity}"))
 }
 
 fn checkpoint_request_has_artifact_snapshot(
@@ -111,14 +126,17 @@ fn test_runtime(
     })
 }
 
+#[cfg(target_os = "linux")]
 #[tokio::test(flavor = "current_thread")]
 async fn unchanged_artifact_checkpoint_records_content_hash_timing()
 -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
     let mount_path = temp_dir.path().join("workspace");
     std::fs::create_dir(&mount_path)?;
-    std::fs::write(mount_path.join("a.txt"), "hello")?;
-    let version_id = content_hash_for_single_file(STORAGE_ID, "a.txt", "hello");
+    let file_path = mount_path.join("a.txt");
+    std::fs::write(&file_path, "hello")?;
+    std::fs::set_permissions(&file_path, std::fs::Permissions::from_mode(0o644))?;
+    let version_id = version_id_for_single_file(STORAGE_ID, "a.txt", 0o644, b"hello");
 
     let server = MockServer::start();
     let runtime = test_runtime(
@@ -182,6 +200,179 @@ async fn unchanged_artifact_checkpoint_records_content_hash_timing()
     let sandbox_ops = std::fs::read_to_string(runtime.paths.sandbox_ops_file())?;
     assert!(sandbox_ops.contains(r#""action_type":"artifact_content_hash_compute""#));
     assert!(sandbox_ops.contains(r#""action_type":"artifact_snapshot_skipped""#));
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test(flavor = "current_thread")]
+async fn permission_only_change_creates_restorable_artifact_version()
+-> Result<(), Box<dyn std::error::Error>> {
+    const SCRIPT: &[u8] = b"#!/bin/sh\necho ok\n";
+
+    let temp_dir = tempfile::tempdir()?;
+    let mount_path = temp_dir.path().join("workspace");
+    std::fs::create_dir(&mount_path)?;
+    let script_path = mount_path.join("script.sh");
+    std::fs::write(&script_path, SCRIPT)?;
+    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o644))?;
+
+    let mounted_version = version_id_for_single_file(STORAGE_ID, "script.sh", 0o644, SCRIPT);
+    let checkpoint_version = version_id_for_single_file(STORAGE_ID, "script.sh", 0o755, SCRIPT);
+    let checkpoint_file_identity = artifact_file_identity(0o755, SCRIPT);
+    assert_ne!(mounted_version, checkpoint_version);
+
+    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))?;
+
+    let server = MockServer::start();
+    let runtime = test_runtime(
+        temp_dir.path(),
+        &mount_path,
+        &mounted_version,
+        &server.base_url(),
+    )?;
+    let history_path = temp_dir.path().join("history.jsonl");
+    std::fs::write(&history_path, r#"{"type":"system"}"#)?;
+    guest_agent::paths::write_private(runtime.paths.session_id_file(), "session-mode-change")?;
+    guest_agent::paths::write_private(
+        runtime.paths.session_history_path_file(),
+        history_path.to_string_lossy().as_ref(),
+    )?;
+
+    let history_prepare = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(format!(r#"{{"runId":"{RUN_ID}"}}"#));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"existing": true}));
+    });
+
+    let archive_url = server.url("/uploads/artifact.tar.gz");
+    let manifest_url = server.url("/uploads/manifest.json");
+    let prepare_files = json!([{
+        "path": "script.sh",
+        "hash": checkpoint_file_identity,
+        "size": SCRIPT.len() as u64,
+    }]);
+    let prepare_version = checkpoint_version.clone();
+    let prepare_parent = mounted_version.clone();
+    let storage_prepare = server.mock(move |when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/storages/prepare")
+            .json_body(json!({
+                "runId": RUN_ID,
+                "storageId": STORAGE_ID,
+                "files": prepare_files,
+                "parentVersionId": prepare_parent,
+            }));
+        then.status(200).json_body(json!({
+            "versionId": prepare_version,
+            "existing": false,
+            "uploads": {
+                "archive": {
+                    "key": "artifact-key",
+                    "presignedUrl": archive_url,
+                },
+                "manifest": {
+                    "key": "manifest-key",
+                    "presignedUrl": manifest_url,
+                },
+            },
+        }));
+    });
+
+    let uploaded_archive = Arc::new(Mutex::new(None::<Vec<u8>>));
+    let uploaded_archive_for_mock = Arc::clone(&uploaded_archive);
+    let archive_upload = server.mock(move |when, then| {
+        when.method(PUT)
+            .path("/uploads/artifact.tar.gz")
+            .header("Content-Type", "application/gzip");
+        then.respond_with(move |req| {
+            *uploaded_archive_for_mock
+                .lock()
+                .expect("uploaded archive lock should not be poisoned") =
+                Some(req.body_ref().to_vec());
+            HttpMockResponse::builder().status(200).build()
+        });
+    });
+    let manifest_upload = server.mock(|when, then| {
+        when.method(PUT)
+            .path("/uploads/manifest.json")
+            .header("Content-Type", "application/json");
+        then.status(200);
+    });
+
+    let commit_files = json!([{
+        "path": "script.sh",
+        "hash": artifact_file_identity(0o755, SCRIPT),
+        "size": SCRIPT.len() as u64,
+    }]);
+    let commit_version = checkpoint_version.clone();
+    let commit_parent = mounted_version.clone();
+    let commit_response_version = checkpoint_version.clone();
+    let storage_commit = server.mock(move |when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/storages/commit")
+            .json_body(json!({
+                "runId": RUN_ID,
+                "storageId": STORAGE_ID,
+                "versionId": commit_version,
+                "parentVersionId": commit_parent,
+                "files": commit_files,
+                "message": format!("Checkpoint from run {RUN_ID}"),
+            }));
+        then.status(200).json_body(json!({
+            "success": true,
+            "versionId": commit_response_version,
+            "storageName": "workspace",
+            "size": SCRIPT.len() as u64,
+            "fileCount": 1,
+        }));
+    });
+
+    let expected_version = checkpoint_version.clone();
+    let expected_mount_path = mount_path.to_string_lossy().into_owned();
+    let checkpoint = server.mock(move |when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .is_true(move |req| {
+                checkpoint_request_has_artifact_snapshot(
+                    req,
+                    &expected_version,
+                    &expected_mount_path,
+                )
+            });
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "checkpoint-with-mode-change"}));
+    });
+
+    guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime).await?;
+
+    history_prepare.assert_calls_async(1).await;
+    storage_prepare.assert_calls_async(1).await;
+    archive_upload.assert_calls_async(1).await;
+    manifest_upload.assert_calls_async(1).await;
+    storage_commit.assert_calls_async(1).await;
+    checkpoint.assert_calls_async(1).await;
+
+    let archive_bytes = uploaded_archive
+        .lock()
+        .map_err(|_| std::io::Error::other("uploaded archive lock was poisoned"))?
+        .clone()
+        .ok_or_else(|| std::io::Error::other("artifact archive was not uploaded"))?;
+    let restore_path = temp_dir.path().join("restored");
+    std::fs::create_dir(&restore_path)?;
+    let decoder = flate2::read::GzDecoder::new(Cursor::new(archive_bytes));
+    tar::Archive::new(decoder).unpack(&restore_path)?;
+
+    let restored_script = restore_path.join("script.sh");
+    assert_eq!(std::fs::read(&restored_script)?, SCRIPT);
+    assert_eq!(
+        std::fs::metadata(&restored_script)?.permissions().mode() & 0o7777,
+        0o755
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- version guest artifact file identity over a domain tag, archived Unix mode, and file bytes
- recompute the same identity during archive creation and deduplicated snapshot validation
- cover a `0644` to `0755` checkpoint through upload, commit, extraction, and restored-mode verification
- retain the unchanged-artifact checkpoint fast path

## Compatibility

The prepare/commit and manifest shapes are unchanged. APIs continue to aggregate the opaque 64-character file identity, so old guest/new API and new guest/old API combinations remain accepted. Existing artifacts stay readable; each non-empty artifact receives one new version on its first checkpoint from the upgraded guest, then deduplicates normally.

## Exclusions

- no API, generated-contract, database, or storage-path changes
- no global storage-root or manifest-v2 redesign
- no historical artifact migration or cleanup

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-agent --no-deps`
- `cargo test -p guest-agent --test artifact_checkpoint_content_hash`
- `cargo test -p guest-agent`
- repository pre-commit hooks, including workspace Rust docs and Clippy

Closes #24893
