### PR TITLE
docs(runner): document fail-closed run prefix resolution

### DIFF
--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -85,11 +85,16 @@ pub(crate) async fn collect_active_run_mappings_from_home(
     Ok(collect_active_run_mappings(&runners).await)
 }
 
-/// Given a `run_id` prefix, find the unique matching active run from collected
+/// Given a full `run_id` or prefix, find the matching active run from collected
 /// status entries.
 ///
-/// Returns the full `run_id` and `sandbox_id` on unique match. Errors on empty
-/// or ambiguous.
+/// A unique exact match is accepted even when some trusted live runner status
+/// files were unreadable. A non-exact prefix is accepted only when it uniquely
+/// identifies a collected mapping and every trusted live runner status file was
+/// readable.
+///
+/// Returns an error for empty input, no matches, ambiguous matches, or a
+/// non-exact match when the runner-status scan was incomplete.
 /// When no match is found and some runners were unreadable, the error
 /// message includes a diagnostic hint so the operator knows why.
 pub(crate) fn resolve_run_mapping(
@@ -147,8 +152,8 @@ pub(crate) fn resolve_run_mapping(
     }
 }
 
-/// Given a `run_id` prefix, find the unique matching `sandbox_id` from
-/// collected status entries.
+/// Resolve a full `run_id` or prefix to a `sandbox_id` using the same exact-ID,
+/// prefix-uniqueness, and incomplete-scan rules as [`resolve_run_mapping`].
 #[cfg(test)]
 pub(crate) fn resolve_run_to_sandbox(
     input: &str,


### PR DESCRIPTION
## Summary

- document that exact collected run IDs remain resolvable when trusted runner status files are unreadable
- clarify that non-exact prefixes require a unique match and a complete trusted runner-status scan
- keep the test-only sandbox resolver helper aligned with the primary resolver contract

## Scope

Documentation only. This PR does not change resolution behavior, error messages, types, CLI behavior, or tests; focused tests already cover both the fail-closed prefix case and the exact-ID exception.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner run_resolution`
- repository pre-commit and commit-message hooks

Closes #24898
