### PR TITLE
fix(sandbox-fc): verify conntrack reset outcomes

### DIFF
--- a/crates/sandbox-fc/src/command.rs
+++ b/crates/sandbox-fc/src/command.rs
@@ -19,6 +19,7 @@ const PIPE_READ_CHUNK_BYTES: usize = 8192;
 #[error("command failed: {command}\n{detail}")]
 pub struct CommandError {
     pub command: String,
+    pub exit_code: Option<i32>,
     pub detail: String,
 }
 
@@ -180,6 +181,7 @@ pub async fn exec_with_timeout(
         .await
         .map_err(|e| CommandError {
             command: cmd_display.clone(),
+            exit_code: None,
             detail: e.to_string(),
         })?;
 
@@ -190,6 +192,7 @@ pub async fn exec_with_timeout(
         let stderr = output.stderr.to_lossy_trimmed_string();
         Err(CommandError {
             command: cmd_display,
+            exit_code: output.status.code(),
             detail: stderr,
         })
     }
@@ -209,6 +212,7 @@ pub async fn exec_status_with_timeout(
             .await
             .map_err(|e| CommandError {
                 command: cmd_display.clone(),
+                exit_code: None,
                 detail: e.to_string(),
             })?;
 
@@ -218,6 +222,7 @@ pub async fn exec_status_with_timeout(
         let stderr = output.stderr.to_lossy_trimmed_string();
         Err(CommandError {
             command: cmd_display,
+            exit_code: output.status.code(),
             detail: stderr,
         })
     }
@@ -760,6 +765,7 @@ mod tests {
             "command was: {}",
             err.command
         );
+        assert_eq!(err.exit_code, Some(1));
     }
 
     #[tokio::test]
@@ -888,6 +894,7 @@ mod tests {
         .unwrap_err();
 
         assert!(err.detail.contains("status-failed"), "err was: {err}");
+        assert_eq!(err.exit_code, Some(7));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/network/pool/firewall.rs
+++ b/crates/sandbox-fc/src/network/pool/firewall.rs
@@ -601,6 +601,7 @@ async fn run_firewall_restore(
         Err(error) => {
             return Err(CommandError {
                 command: command.to_string(),
+                exit_code: None,
                 detail: format!("failed to create firewall restore input: {error}"),
             });
         }
@@ -608,12 +609,14 @@ async fn run_firewall_restore(
     if let Err(error) = file.write_all(payload.as_bytes()) {
         return Err(CommandError {
             command: command.to_string(),
+            exit_code: None,
             detail: format!("failed to write firewall restore input: {error}"),
         });
     }
     let Some(path) = file.path().to_str() else {
         return Err(CommandError {
             command: command.to_string(),
+            exit_code: None,
             detail: format!(
                 "firewall restore input path is not UTF-8: {}",
                 file.path().display()

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -4,7 +4,8 @@ use std::future::Future;
 use std::os::fd::AsRawFd;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(test)]
+use std::sync::atomic::Ordering;
 #[cfg(test)]
 use std::time::Duration;
 
@@ -13,7 +14,7 @@ use nix::fcntl::{Flock, FlockArg};
 use tracing::{error, info, warn};
 
 use crate::command::{
-    IgnoredCommandOutcome, exec_ignore_errors_with_timeout, exec_status_with_timeout,
+    CommandError, IgnoredCommandOutcome, exec_ignore_errors_with_timeout, exec_status_with_timeout,
     exec_with_timeout,
 };
 use crate::guest_dns_netfilter_trace::{
@@ -40,7 +41,8 @@ use super::types::{NamespaceDeleteOutcome, NetnsInfo};
 // 10-second waves leave room inside the runner's 300-second systemd stop
 // budget for firewall cleanup and the other teardown phases.
 const NAMESPACE_DELETE_CONCURRENCY: usize = 16;
-static CONNTRACK_NOT_FOUND_LOGGED: AtomicBool = AtomicBool::new(false);
+const CONNTRACK_ZERO_DELETE_PREFIX: &str = "conntrack v";
+const CONNTRACK_ZERO_DELETE_SUFFIX: &str = " (conntrack-tools): 0 flow entries have been deleted.";
 
 /// Peer-side device name inside namespaces (fixed).
 const PEER_DEVICE: &str = "veth0";
@@ -463,18 +465,10 @@ async fn flush_conntrack(peer_ip: &str) -> ConntrackFlushOutcome {
     let src_args = ["-D", "-s", peer_ip];
     let dst_args = ["-D", "-d", peer_ip];
     let (src, dst) = tokio::join!(
-        exec_ignore_errors_with_timeout("conntrack", &src_args, HOST_NETWORK_COMMAND_TIMEOUT),
-        exec_ignore_errors_with_timeout("conntrack", &dst_args, HOST_NETWORK_COMMAND_TIMEOUT),
+        exec_status_with_timeout("conntrack", &src_args, HOST_NETWORK_COMMAND_TIMEOUT),
+        exec_status_with_timeout("conntrack", &dst_args, HOST_NETWORK_COMMAND_TIMEOUT),
     );
-    if conntrack_flush_is_trusted(src, dst) {
-        if conntrack_command_missing(src, dst)
-            && !CONNTRACK_NOT_FOUND_LOGGED.swap(true, Ordering::Relaxed)
-        {
-            warn!(
-                peer_ip,
-                "conntrack command not found; proceeding without conntrack reset"
-            );
-        }
+    if conntrack_flush_is_trusted(&src, &dst) {
         ConntrackFlushOutcome::Trusted
     } else {
         warn!(
@@ -487,19 +481,30 @@ async fn flush_conntrack(peer_ip: &str) -> ConntrackFlushOutcome {
     }
 }
 
-fn conntrack_flush_is_trusted(src: IgnoredCommandOutcome, dst: IgnoredCommandOutcome) -> bool {
-    (src.completed_without_timeout() && dst.completed_without_timeout())
-        || conntrack_command_missing(src, dst)
+fn conntrack_flush_is_trusted(
+    src: &std::result::Result<(), CommandError>,
+    dst: &std::result::Result<(), CommandError>,
+) -> bool {
+    conntrack_delete_is_trusted(src) && conntrack_delete_is_trusted(dst)
 }
 
-fn conntrack_command_missing(src: IgnoredCommandOutcome, dst: IgnoredCommandOutcome) -> bool {
-    matches!(
-        (src, dst),
-        (
-            IgnoredCommandOutcome::NotFound,
-            IgnoredCommandOutcome::NotFound
-        )
-    )
+/// `conntrack -D` exits 1 both when no flows match and for operational errors.
+/// Only its standard zero-delete summary proves the former case.
+fn conntrack_delete_is_trusted(result: &std::result::Result<(), CommandError>) -> bool {
+    let Err(error) = result else {
+        return true;
+    };
+    if error.exit_code != Some(1) {
+        return false;
+    }
+    let Some(version) = error
+        .detail
+        .strip_prefix(CONNTRACK_ZERO_DELETE_PREFIX)
+        .and_then(|detail| detail.strip_suffix(CONNTRACK_ZERO_DELETE_SUFFIX))
+    else {
+        return false;
+    };
+    !version.is_empty() && !version.chars().any(char::is_whitespace)
 }
 
 // ---------------------------------------------------------------------------
@@ -1062,51 +1067,94 @@ mod tests {
         }
     }
 
-    #[test]
-    fn conntrack_flush_trusts_completed_deletes() {
-        assert!(conntrack_flush_is_trusted(
-            IgnoredCommandOutcome::Success,
-            IgnoredCommandOutcome::NonZero
-        ));
+    #[tokio::test]
+    async fn conntrack_flush_trusts_success_and_verified_zero_delete() {
+        let success = exec_status_with_timeout("true", &[], Duration::from_secs(1)).await;
+        let zero_delete = exec_status_with_timeout(
+            "sh",
+            &[
+                "-c",
+                "printf '%s\\n' 'conntrack v1.4.8 (conntrack-tools): 0 flow entries have been deleted.' >&2; exit 1",
+            ],
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert!(conntrack_delete_is_trusted(&success));
+        assert!(conntrack_delete_is_trusted(&zero_delete));
+        assert!(conntrack_flush_is_trusted(&success, &zero_delete));
+        assert!(conntrack_flush_is_trusted(&zero_delete, &success));
     }
 
-    #[test]
-    fn conntrack_flush_trusts_missing_optional_command() {
-        assert!(conntrack_flush_is_trusted(
-            IgnoredCommandOutcome::NotFound,
-            IgnoredCommandOutcome::NotFound
-        ));
-    }
+    #[tokio::test]
+    async fn conntrack_flush_rejects_command_failures_and_invalid_invocations() {
+        let command_failure = exec_status_with_timeout(
+            "sh",
+            &["-c", "printf 'permission denied\\n' >&2; exit 1"],
+            Duration::from_secs(1),
+        )
+        .await;
+        let invalid_invocation = exec_status_with_timeout(
+            "sh",
+            &[
+                "-c",
+                "printf '%s\\n' 'conntrack v1.4.8 (conntrack-tools): 0 flow entries have been deleted.' >&2; exit 2",
+            ],
+            Duration::from_secs(1),
+        )
+        .await;
 
-    #[test]
-    fn conntrack_flush_does_not_trust_timeout_or_partial_missing_command() {
+        assert!(!conntrack_delete_is_trusted(&command_failure));
+        assert!(!conntrack_delete_is_trusted(&invalid_invocation));
         assert!(!conntrack_flush_is_trusted(
-            IgnoredCommandOutcome::Timeout,
-            IgnoredCommandOutcome::Success
-        ));
-        assert!(!conntrack_flush_is_trusted(
-            IgnoredCommandOutcome::NotFound,
-            IgnoredCommandOutcome::Success
+            &command_failure,
+            &invalid_invocation
         ));
     }
 
+    #[tokio::test]
+    async fn conntrack_flush_rejects_missing_command_timeout_and_partial_success() {
+        let success = exec_status_with_timeout("true", &[], Duration::from_secs(1)).await;
+        let missing = exec_status_with_timeout(
+            "vm0-definitely-missing-conntrack-command",
+            &[],
+            Duration::from_millis(50),
+        )
+        .await;
+        let timeout =
+            exec_status_with_timeout("sh", &["-c", "sleep 2"], Duration::from_millis(50)).await;
+
+        assert!(!conntrack_delete_is_trusted(&missing));
+        assert!(!conntrack_delete_is_trusted(&timeout));
+        assert!(!conntrack_flush_is_trusted(&success, &missing));
+        assert!(!conntrack_flush_is_trusted(&timeout, &success));
+    }
+
     #[test]
-    fn conntrack_flush_does_not_trust_uncertain_command_failures() {
-        for outcome in [
-            IgnoredCommandOutcome::SpawnError,
-            IgnoredCommandOutcome::WaitError,
-            IgnoredCommandOutcome::PipeError,
-            IgnoredCommandOutcome::OutputTooLarge,
-        ] {
-            assert!(
-                !conntrack_flush_is_trusted(outcome, IgnoredCommandOutcome::Success),
-                "trusted left-side outcome: {outcome:?}"
-            );
-            assert!(
-                !conntrack_flush_is_trusted(IgnoredCommandOutcome::Success, outcome),
-                "trusted right-side outcome: {outcome:?}"
-            );
-        }
+    fn conntrack_zero_delete_requires_exact_single_line_diagnostic() {
+        let misleading_prefix = Err(CommandError {
+            command: "conntrack -D -s 10.0.0.2".to_string(),
+            exit_code: Some(1),
+            detail: "not-conntrack v1.4.8 (conntrack-tools): 0 flow entries have been deleted."
+                .to_string(),
+        });
+        let multiline = Err(CommandError {
+            command: "conntrack -D -s 10.0.0.2".to_string(),
+            exit_code: Some(1),
+            detail:
+                "warning\nconntrack v1.4.8 (conntrack-tools): 0 flow entries have been deleted."
+                    .to_string(),
+        });
+        let truncated = Err(CommandError {
+            command: "conntrack -D -s 10.0.0.2".to_string(),
+            exit_code: Some(1),
+            detail: "conntrack v1.4.8 (conntrack-tools): 0 flow entries have been deleted.\n[output truncated]"
+                .to_string(),
+        });
+
+        assert!(!conntrack_delete_is_trusted(&misleading_prefix));
+        assert!(!conntrack_delete_is_trusted(&multiline));
+        assert!(!conntrack_delete_is_trusted(&truncated));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -65,6 +65,7 @@ const NETWORK_COMMANDS: &[&str] = &[
     "iptables",
     "iptables-save",
     "iptables-restore",
+    "conntrack",
     "sysctl",
 ];
 const DNS_INPUT_FILTER_COMMANDS: &[&str] = &["ip6tables", "ip6tables-save", "ip6tables-restore"];
@@ -551,6 +552,7 @@ mod tests {
                 "iptables",
                 "iptables-save",
                 "iptables-restore",
+                "conntrack",
                 "sysctl",
                 "mkfs.ext4"
             ]
@@ -569,6 +571,7 @@ mod tests {
                 "iptables",
                 "iptables-save",
                 "iptables-restore",
+                "conntrack",
                 "sysctl",
                 "cp",
                 "mkfs.ext4",
@@ -592,6 +595,7 @@ mod tests {
                 "iptables",
                 "iptables-save",
                 "iptables-restore",
+                "conntrack",
                 "sysctl",
                 "mkfs.ext4",
                 "unshare",
@@ -619,7 +623,7 @@ mod tests {
     }
 
     #[test]
-    fn conntrack_is_optional_not_hard_required() {
+    fn conntrack_is_required_for_network_modes() {
         let snapshot = snapshot_config();
         let modes = [
             PrerequisiteMode::FactoryFresh,
@@ -629,7 +633,7 @@ mod tests {
 
         for mode in modes {
             let commands = required_commands(&mode);
-            assert!(!commands.contains(&"conntrack"), "mode: {mode:?}");
+            assert!(commands.contains(&"conntrack"), "mode: {mode:?}");
         }
     }
 
@@ -642,6 +646,7 @@ mod tests {
                 "iptables",
                 "iptables-save",
                 "iptables-restore",
+                "conntrack",
                 "sysctl"
             ]
         );
@@ -652,6 +657,7 @@ mod tests {
                 "iptables",
                 "iptables-save",
                 "iptables-restore",
+                "conntrack",
                 "sysctl",
                 "ip6tables",
                 "ip6tables-save",


### PR DESCRIPTION
## Summary

- fail closed when either peer-scoped conntrack delete cannot be verified
- accept only successful deletion or the standard exit-1 zero-delete result from conntrack-tools
- require `conntrack` during runner network prerequisite validation
- retain bounded per-direction failure evidence and cover the command boundary without privileged tests

## Problem

The namespace pool previously trusted every ordinary non-zero `conntrack -D` exit and even a missing executable. Because peer IPs are reused across sandbox attachments, an actual permission, tool, or netlink failure could leave stale state while the namespace was admitted or requeued.

Upstream conntrack-tools also returns exit 1 when a delete matches zero flows, so treating every non-zero result as unsafe would reject clean namespaces.

## Change

`CommandError` now retains the ordinary child exit code alongside its existing bounded stderr. The conntrack path uses the bounded status runner and trusts each source/destination delete only when it:

- exits successfully; or
- exits 1 with exactly one standard `conntrack v... (conntrack-tools): 0 flow entries have been deleted.` diagnostic line.

Both directions must be trusted. Missing commands, timeouts, other exit-1 errors, invalid invocations, truncated diagnostics, and partial success remain untrusted. Existing namespace state transitions already delete/reject an untrusted new namespace and avoid requeueing an untrusted released namespace.

`conntrack` is now part of the shared network prerequisite group, so incorrectly provisioned hosts fail before sandbox work rather than repeatedly during namespace admission.

## Compatibility

This is internal to the runner artifact. It does not change APIs, schemas, persisted state, queue payloads, frontend behavior, or runner/backend and runner/guest protocols.

The intended availability trade-off is fail-closed: a host missing conntrack or a future unsupported diagnostic format will fail prerequisite validation or namespace reset instead of weakening cross-run isolation. Privileged metal CI is the deployment gate for the host dependency.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc --all-features --no-deps`
- focused conntrack tests: 9 passed
- focused command tests: 22 passed
- focused prerequisite tests: 29 passed
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`: 803 unit tests and 1 integration test passed
- repository staged-file hooks: workspace Rust formatting, Clippy, rustdoc, and file-size checks passed

Closes #24902
