### PR TITLE
refactor(runner): centralize guest dns probe signature

### DIFF
--- a/crates/runner/src/cmd/build/hashes.rs
+++ b/crates/runner/src/cmd/build/hashes.rs
@@ -1,12 +1,13 @@
+use std::net::Ipv4Addr;
 use std::path::Path;
 
+use sandbox_fc::DNS_PROBE_RESOLVER_IPV4;
 use sha2::{Digest, Sha256};
 
 use crate::ca;
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
 
-use super::ROOTFS_DNS_NAMESERVER;
 use super::scripts::{CUSTOMIZE_SCRIPT, TEMPLATE_BUILD_SCRIPT};
 
 /// Bump to invalidate all shared template images in R2.
@@ -61,10 +62,11 @@ pub(super) fn compute_template_hash(rootfs_disk_mb: u32) -> String {
 ///
 /// This hash is what runner configs use. It includes the shared template hash plus
 /// every rootfs-only input that changes the bootable rootfs content.
-pub(super) async fn compute_rootfs_hash(
+async fn compute_rootfs_hash(
     template_hash: &str,
     guest_bins: &[(&Path, &str)],
     ca_fingerprint: &str,
+    dns_nameserver: Ipv4Addr,
     rootfs_disk_mb: u32,
 ) -> RunnerResult<String> {
     let mut hasher = Sha256::new();
@@ -80,7 +82,8 @@ pub(super) async fn compute_rootfs_hash(
     hasher.update(b"ca_fingerprint:");
     hasher.update(ca_fingerprint.as_bytes());
     hasher.update(b"dns_nameserver:");
-    hasher.update(ROOTFS_DNS_NAMESERVER.as_bytes());
+    let dns_nameserver = dns_nameserver.to_string();
+    hasher.update(dns_nameserver.as_bytes());
 
     for (src, dest) in guest_bins {
         let content = tokio::fs::read(src)
@@ -101,8 +104,14 @@ pub(super) async fn compute_rootfs_build_hashes(
     rootfs_disk_mb: u32,
 ) -> RunnerResult<RootfsBuildHashes> {
     let template_hash = compute_template_hash(rootfs_disk_mb);
-    let rootfs_hash =
-        compute_rootfs_hash(&template_hash, guest_bins, ca_fingerprint, rootfs_disk_mb).await?;
+    let rootfs_hash = compute_rootfs_hash(
+        &template_hash,
+        guest_bins,
+        ca_fingerprint,
+        DNS_PROBE_RESOLVER_IPV4,
+        rootfs_disk_mb,
+    )
+    .await?;
 
     Ok(RootfsBuildHashes {
         template_hash,
@@ -185,12 +194,24 @@ mod tests {
         tokio::fs::write(&bin, b"binary-content").await.unwrap();
         let bins: &[(&Path, &str)] = &[(&bin, "/usr/local/bin/guest-agent")];
 
-        let h1 = compute_rootfs_hash("template-hash", bins, "ca-fingerprint", 16384)
-            .await
-            .unwrap();
-        let h2 = compute_rootfs_hash("template-hash", bins, "ca-fingerprint", 16384)
-            .await
-            .unwrap();
+        let h1 = compute_rootfs_hash(
+            "template-hash",
+            bins,
+            "ca-fingerprint",
+            DNS_PROBE_RESOLVER_IPV4,
+            16384,
+        )
+        .await
+        .unwrap();
+        let h2 = compute_rootfs_hash(
+            "template-hash",
+            bins,
+            "ca-fingerprint",
+            DNS_PROBE_RESOLVER_IPV4,
+            16384,
+        )
+        .await
+        .unwrap();
         assert_eq!(h1, h2);
         assert_eq!(h1.len(), 64); // SHA-256 hex
     }
@@ -240,6 +261,7 @@ mod tests {
             "template-a",
             &[(&bin_a, "/usr/local/bin/guest-agent")],
             "ca-a",
+            DNS_PROBE_RESOLVER_IPV4,
             16384,
         )
         .await
@@ -249,6 +271,7 @@ mod tests {
             "template-a",
             &[(&bin_b, "/usr/local/bin/guest-agent")],
             "ca-a",
+            DNS_PROBE_RESOLVER_IPV4,
             16384,
         )
         .await
@@ -262,6 +285,7 @@ mod tests {
             "template-a",
             &[(&bin_a, "/usr/local/bin/guest-agent")],
             "ca-a",
+            DNS_PROBE_RESOLVER_IPV4,
             32768,
         )
         .await
@@ -272,6 +296,7 @@ mod tests {
             "template-a",
             &[(&bin_a, "/usr/local/bin/guest-download")],
             "ca-a",
+            DNS_PROBE_RESOLVER_IPV4,
             16384,
         )
         .await
@@ -282,6 +307,7 @@ mod tests {
             "template-a",
             &[(&bin_a, "/usr/local/bin/guest-agent")],
             "ca-b",
+            DNS_PROBE_RESOLVER_IPV4,
             16384,
         )
         .await
@@ -292,11 +318,23 @@ mod tests {
             "template-b",
             &[(&bin_a, "/usr/local/bin/guest-agent")],
             "ca-a",
+            DNS_PROBE_RESOLVER_IPV4,
             16384,
         )
         .await
         .unwrap();
         assert_ne!(base, different_template, "hash must change with template");
+
+        let different_dns = compute_rootfs_hash(
+            "template-a",
+            &[(&bin_a, "/usr/local/bin/guest-agent")],
+            "ca-a",
+            Ipv4Addr::new(1, 1, 1, 1),
+            16384,
+        )
+        .await
+        .unwrap();
+        assert_ne!(base, different_dns, "hash must change with DNS nameserver");
     }
 
     #[test]

--- a/crates/runner/src/cmd/build/mod.rs
+++ b/crates/runner/src/cmd/build/mod.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use clap::Args;
 use nix::fcntl::Flock;
 use sandbox::SnapshotProvider;
+use sandbox_fc::DNS_PROBE_RESOLVER_IPV4;
 
 use crate::ca;
 use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
@@ -29,7 +30,6 @@ use local_publish::LocalFilePublish;
 use scripts::{RootfsScripts, rootfs_script_command, run_rootfs_script};
 use sizes::file_sizes;
 
-const ROOTFS_DNS_NAMESERVER: &str = "8.8.8.8";
 const TEMPLATE_FILE: &str = "template.ext4";
 const TEMPLATE_DOWNLOAD_FILE: &str = "downloaded-template.ext4";
 const TEMPLATE_WARM_DIR_PREFIX: &str = "template-warm-";
@@ -1091,7 +1091,7 @@ async fn customize_rootfs_staging(
         .arg("--ca-dir")
         .arg(&ca_dir)
         .arg("--dns-nameserver")
-        .arg(ROOTFS_DNS_NAMESERVER);
+        .arg(DNS_PROBE_RESOLVER_IPV4.to_string());
     for guest in input.guests.iter() {
         cmd.arg("--guest")
             .arg(&guest.path)

--- a/crates/sandbox-fc/src/guest_dns_netfilter_trace.rs
+++ b/crates/sandbox-fc/src/guest_dns_netfilter_trace.rs
@@ -600,28 +600,25 @@ impl TracePacket {
 
     fn readiness_header(
         &self,
-        namespace: &str,
-        host_device: &str,
-        peer_ip: &str,
-        source_port: Option<u16>,
+        target: GuestDnsNetfilterTraceCaptureTarget<'_>,
+        probe_resolver: &str,
+        probe_destination_port: &str,
     ) -> Option<&TracePacketHeader> {
-        let resolver = DNS_PROBE_RESOLVER_IPV4.to_string();
-        let destination_port = DNS_PROBE_DESTINATION_PORT.to_string();
         let traces_udp_readiness_rule = self.steps.iter().any(|step| {
             step.table == "raw"
                 && step.chain == "PREROUTING"
                 && step.rule.as_deref().is_some_and(|rule| {
                     rule_has_option_value(rule, "-p", "udp")
-                        && rule_has_option_value(rule, "--dport", &destination_port)
+                        && rule_has_option_value(rule, "--dport", probe_destination_port)
                         && rule_has_exact_packet_length(rule, GUEST_DNS_PROBE_PACKET_BYTES)
-                        && rule_has_option_value(rule, "--comment", namespace)
+                        && rule_has_option_value(rule, "--comment", target.namespace)
                         && rule_has_option_value(rule, "-j", "TRACE")
                 })
         });
         self.headers.iter().find(|header| {
-            header.input.as_deref() == Some(host_device)
-                && header.source.as_deref() == Some(peer_ip)
-                && header.destination.as_deref() == Some(resolver.as_str())
+            header.input.as_deref() == Some(target.host_device)
+                && header.source.as_deref() == Some(target.peer_ip)
+                && header.destination.as_deref() == Some(probe_resolver)
                 && header.length == Some(GUEST_DNS_PROBE_PACKET_BYTES)
                 && (header
                     .protocol
@@ -629,25 +626,23 @@ impl TracePacket {
                     .is_some_and(|protocol| protocol.eq_ignore_ascii_case("udp"))
                     || traces_udp_readiness_rule)
                 && header.destination_port == Some(DNS_PROBE_DESTINATION_PORT)
-                && source_port.is_none_or(|source_port| header.source_port == Some(source_port))
+                && target
+                    .source_port
+                    .is_none_or(|source_port| header.source_port == Some(source_port))
         })
     }
 
     fn report(
         &self,
-        namespace: &str,
-        host_device: &str,
-        peer_ip: &str,
-        source_port: Option<u16>,
-        dns_port: u16,
+        target: GuestDnsNetfilterTraceCaptureTarget<'_>,
+        probe_resolver: &str,
+        probe_destination_port: &str,
     ) -> Option<TracePacketReport> {
         let original_header = self
-            .readiness_header(namespace, host_device, peer_ip, source_port)?
+            .readiness_header(target, probe_resolver, probe_destination_port)?
             .clone();
-        let dns_port_value = dns_port;
-        let dns_port = dns_port.to_string();
-        let probe_destination_port = DNS_PROBE_DESTINATION_PORT.to_string();
-        let resolver = DNS_PROBE_RESOLVER_IPV4.to_string();
+        let dns_port_value = target.dns_port;
+        let dns_port = target.dns_port.to_string();
         let nat_prerouting_reached = self
             .steps
             .iter()
@@ -657,8 +652,8 @@ impl TracePacket {
                 && step.chain == "PREROUTING"
                 && step.rule.as_deref().is_some_and(|rule| {
                     rule_has_option_value(rule, "-p", "udp")
-                        && rule_has_option_value(rule, "--dport", &probe_destination_port)
-                        && rule_has_option_value(rule, "--comment", namespace)
+                        && rule_has_option_value(rule, "--dport", probe_destination_port)
+                        && rule_has_option_value(rule, "--comment", target.namespace)
                         && rule_has_option_value(rule, "-j", "REDIRECT")
                         && (rule_has_option_value(rule, "--to-port", &dns_port)
                             || rule_has_option_value(rule, "--to-ports", &dns_port))
@@ -668,9 +663,9 @@ impl TracePacket {
             .headers
             .iter()
             .find(|header| {
-                header.input.as_deref() == Some(host_device)
-                    && header.source.as_deref() == Some(peer_ip)
-                    && header.destination.as_deref() != Some(resolver.as_str())
+                header.input.as_deref() == Some(target.host_device)
+                    && header.source.as_deref() == Some(target.peer_ip)
+                    && header.destination.as_deref() != Some(probe_resolver)
                     && header.destination_port == Some(dns_port_value)
             })
             .cloned();
@@ -682,8 +677,8 @@ impl TracePacket {
             .steps
             .iter()
             .any(|step| step.table == "filter" && step.chain == "INPUT");
-        let pool_input_comment =
-            parse_netns_name(namespace).map(|name| make_pool_dns_filter_comment(name.pool_index));
+        let pool_input_comment = parse_netns_name(target.namespace)
+            .map(|name| make_pool_dns_filter_comment(name.pool_index));
         let pool_input_rule_reached = self.steps.iter().any(|step| {
             step.table == "filter"
                 && step.chain == "INPUT"
@@ -1137,6 +1132,8 @@ impl GuestDnsNetfilterTraceReader {
         cursor: GuestDnsNetfilterTraceCursor,
         target: GuestDnsNetfilterTraceCaptureTarget<'_>,
     ) -> GuestDnsNetfilterTraceReport {
+        let probe_resolver = DNS_PROBE_RESOLVER_IPV4.to_string();
+        let probe_destination_port = DNS_PROBE_DESTINATION_PORT.to_string();
         let state = lock_state(&self.state);
         if cursor.monitor_id != state.monitor_id {
             return GuestDnsNetfilterTraceReport {
@@ -1156,15 +1153,7 @@ impl GuestDnsNetfilterTraceReader {
             .packets
             .iter()
             .filter(|packet| packet.sequence > cursor.sequence)
-            .filter_map(|packet| {
-                packet.report(
-                    target.namespace,
-                    target.host_device,
-                    target.peer_ip,
-                    target.source_port,
-                    target.dns_port,
-                )
-            })
+            .filter_map(|packet| packet.report(target, &probe_resolver, &probe_destination_port))
             .collect::<Vec<_>>();
         let matched_packets = matches.len();
         let first_reported = matched_packets.saturating_sub(MAX_REPORTED_PACKETS);

--- a/crates/sandbox-fc/src/guest_dns_netfilter_trace.rs
+++ b/crates/sandbox-fc/src/guest_dns_netfilter_trace.rs
@@ -105,9 +105,10 @@ use tokio::time::{Duration, Instant, timeout, timeout_at};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-use crate::guest_dns_readiness::{
-    GUEST_DNS_READINESS_MAX_ATTEMPTS, GUEST_DNS_READINESS_PACKET_BYTES,
+use crate::guest_dns_probe::{
+    DNS_PROBE_DESTINATION_PORT, DNS_PROBE_RESOLVER_IPV4, GUEST_DNS_PROBE_PACKET_BYTES,
 };
+use crate::guest_dns_readiness::GUEST_DNS_READINESS_MAX_ATTEMPTS;
 use crate::network::{make_pool_dns_filter_comment, parse_netns_name};
 
 const MAX_PACKETS: usize = 256;
@@ -121,7 +122,6 @@ const MAX_REPORTED_PACKETS: usize = GUEST_DNS_READINESS_MAX_ATTEMPTS as usize;
 const MONITOR_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 const TRACE_CAPTURE_WAIT: Duration = Duration::from_millis(250);
 const READ_CHUNK_BYTES: usize = 4 * 1_024;
-const READINESS_DNS_IPV4: &str = "8.8.8.8";
 
 static NEXT_MONITOR_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -605,13 +605,15 @@ impl TracePacket {
         peer_ip: &str,
         source_port: Option<u16>,
     ) -> Option<&TracePacketHeader> {
+        let resolver = DNS_PROBE_RESOLVER_IPV4.to_string();
+        let destination_port = DNS_PROBE_DESTINATION_PORT.to_string();
         let traces_udp_readiness_rule = self.steps.iter().any(|step| {
             step.table == "raw"
                 && step.chain == "PREROUTING"
                 && step.rule.as_deref().is_some_and(|rule| {
                     rule_has_option_value(rule, "-p", "udp")
-                        && rule_has_option_value(rule, "--dport", "53")
-                        && rule_has_exact_packet_length(rule, GUEST_DNS_READINESS_PACKET_BYTES)
+                        && rule_has_option_value(rule, "--dport", &destination_port)
+                        && rule_has_exact_packet_length(rule, GUEST_DNS_PROBE_PACKET_BYTES)
                         && rule_has_option_value(rule, "--comment", namespace)
                         && rule_has_option_value(rule, "-j", "TRACE")
                 })
@@ -619,14 +621,14 @@ impl TracePacket {
         self.headers.iter().find(|header| {
             header.input.as_deref() == Some(host_device)
                 && header.source.as_deref() == Some(peer_ip)
-                && header.destination.as_deref() == Some(READINESS_DNS_IPV4)
-                && header.length == Some(GUEST_DNS_READINESS_PACKET_BYTES)
+                && header.destination.as_deref() == Some(resolver.as_str())
+                && header.length == Some(GUEST_DNS_PROBE_PACKET_BYTES)
                 && (header
                     .protocol
                     .as_deref()
                     .is_some_and(|protocol| protocol.eq_ignore_ascii_case("udp"))
                     || traces_udp_readiness_rule)
-                && header.destination_port == Some(53)
+                && header.destination_port == Some(DNS_PROBE_DESTINATION_PORT)
                 && source_port.is_none_or(|source_port| header.source_port == Some(source_port))
         })
     }
@@ -644,6 +646,8 @@ impl TracePacket {
             .clone();
         let dns_port_value = dns_port;
         let dns_port = dns_port.to_string();
+        let probe_destination_port = DNS_PROBE_DESTINATION_PORT.to_string();
+        let resolver = DNS_PROBE_RESOLVER_IPV4.to_string();
         let nat_prerouting_reached = self
             .steps
             .iter()
@@ -653,7 +657,7 @@ impl TracePacket {
                 && step.chain == "PREROUTING"
                 && step.rule.as_deref().is_some_and(|rule| {
                     rule_has_option_value(rule, "-p", "udp")
-                        && rule_has_option_value(rule, "--dport", "53")
+                        && rule_has_option_value(rule, "--dport", &probe_destination_port)
                         && rule_has_option_value(rule, "--comment", namespace)
                         && rule_has_option_value(rule, "-j", "REDIRECT")
                         && (rule_has_option_value(rule, "--to-port", &dns_port)
@@ -666,7 +670,7 @@ impl TracePacket {
             .find(|header| {
                 header.input.as_deref() == Some(host_device)
                     && header.source.as_deref() == Some(peer_ip)
-                    && header.destination.as_deref() != Some(READINESS_DNS_IPV4)
+                    && header.destination.as_deref() != Some(resolver.as_str())
                     && header.destination_port == Some(dns_port_value)
             })
             .cloned();

--- a/crates/sandbox-fc/src/guest_dns_network_evidence.rs
+++ b/crates/sandbox-fc/src/guest_dns_network_evidence.rs
@@ -87,7 +87,7 @@ use crate::guest_dns_netfilter_trace::{
     GuestDnsNetfilterTraceAttachment, GuestDnsNetfilterTraceCaptureTarget,
     GuestDnsNetfilterTraceCursor, GuestDnsNetfilterTraceReport,
 };
-use crate::guest_dns_readiness::GUEST_DNS_READINESS_PACKET_BYTES;
+use crate::guest_dns_probe::GUEST_DNS_PROBE_PACKET_BYTES;
 
 const BASELINE_COMMAND_TIMEOUT: Duration = Duration::from_millis(250);
 const PEER_DEVICE: &str = "veth0";
@@ -613,7 +613,7 @@ fn correlate(
             Some(deltas),
         );
     }
-    if deltas.namespace_masquerade.bytes != expected_packets * GUEST_DNS_READINESS_PACKET_BYTES {
+    if deltas.namespace_masquerade.bytes != expected_packets * GUEST_DNS_PROBE_PACKET_BYTES {
         return EvidenceCorrelation::inconclusive(
             EvidenceReason::MasqueradeByteMismatch,
             Some(deltas),
@@ -677,7 +677,7 @@ fn observe_counters(
 
     let expected_packets = u64::from(readiness_attempts);
     let exact_namespace_masquerade = if deltas.namespace_masquerade.packets == expected_packets
-        && deltas.namespace_masquerade.bytes == expected_packets * GUEST_DNS_READINESS_PACKET_BYTES
+        && deltas.namespace_masquerade.bytes == expected_packets * GUEST_DNS_PROBE_PACKET_BYTES
     {
         CounterObservationStatus::Observed
     } else {

--- a/crates/sandbox-fc/src/guest_dns_probe.rs
+++ b/crates/sandbox-fc/src/guest_dns_probe.rs
@@ -1,0 +1,35 @@
+//! Fixed identity shared by guest DNS emission, readiness, and failure diagnostics.
+
+use std::net::Ipv4Addr;
+
+const DNS_HEADER_BYTES: usize = 12;
+const DNS_QNAME_OVERHEAD_BYTES: usize = 2;
+const DNS_QUESTION_TRAILER_BYTES: usize = 4;
+const IPV4_HEADER_BYTES: usize = 20;
+const UDP_HEADER_BYTES: usize = 8;
+
+/// Local-only hostname used to validate a namespace's DNS redirect path.
+pub const DNS_READINESS_HOSTNAME: &str = "vm0-readiness.invalid";
+
+/// Local-only hostname reserved for post-failure namespace diagnostics.
+pub const DNS_DIAGNOSTIC_HOSTNAME: &str = "vm0-vethprobe.invalid";
+
+/// TEST-NET address returned for the readiness and diagnostic hostnames.
+pub const DNS_READINESS_IPV4: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 1);
+
+/// Dummy external resolver written to guest configuration and intercepted by the DNS proxy.
+pub const DNS_PROBE_RESOLVER_IPV4: Ipv4Addr = Ipv4Addr::new(8, 8, 8, 8);
+pub(crate) const DNS_PROBE_DESTINATION_PORT: u16 = 53;
+/// Fixed diagnostic port outside Linux's default ephemeral range, used to correlate one query.
+pub(crate) const DNS_DIAGNOSTIC_SOURCE_PORT: u16 = 30_053;
+
+pub(crate) const GUEST_DNS_PROBE_QUERY_BYTES: usize = dns_a_query_bytes(DNS_READINESS_HOSTNAME);
+/// IPv4 packet size of either fixed UDP DNS A query.
+pub(crate) const GUEST_DNS_PROBE_PACKET_BYTES: u64 =
+    (IPV4_HEADER_BYTES + UDP_HEADER_BYTES + GUEST_DNS_PROBE_QUERY_BYTES) as u64;
+
+const _: () = assert!(dns_a_query_bytes(DNS_DIAGNOSTIC_HOSTNAME) == GUEST_DNS_PROBE_QUERY_BYTES);
+
+const fn dns_a_query_bytes(hostname: &str) -> usize {
+    DNS_HEADER_BYTES + hostname.len() + DNS_QNAME_OVERHEAD_BYTES + DNS_QUESTION_TRAILER_BYTES
+}

--- a/crates/sandbox-fc/src/guest_dns_readiness.rs
+++ b/crates/sandbox-fc/src/guest_dns_readiness.rs
@@ -7,7 +7,7 @@ use tokio::time::{Instant, timeout_at};
 use vsock_host::{ExecOperationRequest, ExecOperationResult, ExecOwnedCapturedOutput, VsockHost};
 use vsock_proto::{ExecOutputPolicy, ExecTermination};
 
-use crate::network::{DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4};
+use crate::guest_dns_probe::{DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4};
 
 const RESOLVER_ENV: &[(&str, &str)] = &[("RES_OPTIONS", "attempts:1 timeout:1")];
 const LABEL: &str = "guest-dns-readiness";
@@ -20,8 +20,6 @@ const STDERR_LIMIT_BYTES: u32 = 512;
 const EXPECTED_TRANSIENT_EXIT_CODES: &[i32] = &[2];
 
 pub(crate) const GUEST_DNS_READINESS_MAX_ATTEMPTS: u16 = 3;
-/// IPv4 packet size of the fixed `vm0-readiness.invalid` UDP A query.
-pub(crate) const GUEST_DNS_READINESS_PACKET_BYTES: u64 = 67;
 
 const PRODUCTION_POLICY: ReadinessPolicy = ReadinessPolicy {
     total_timeout: Duration::from_secs(7),

--- a/crates/sandbox-fc/src/guest_dns_veth_handoff_diagnostic.rs
+++ b/crates/sandbox-fc/src/guest_dns_veth_handoff_diagnostic.rs
@@ -10,19 +10,18 @@ use crate::guest_dns_netfilter_trace::{
     GuestDnsNetfilterTraceAttachment, GuestDnsNetfilterTraceCaptureTarget,
     GuestDnsNetfilterTraceReport,
 };
-use crate::guest_dns_readiness::GUEST_DNS_READINESS_PACKET_BYTES;
-use crate::network::{
-    DNS_DIAGNOSTIC_SOURCE_PORT, DNS_READINESS_RESOLVER_IPV4, DnsDiagnosticProbeReport,
-    probe_namespace_dns_diagnostic,
+use crate::guest_dns_probe::{
+    DNS_DIAGNOSTIC_SOURCE_PORT, DNS_PROBE_DESTINATION_PORT, DNS_PROBE_RESOLVER_IPV4,
+    GUEST_DNS_PROBE_PACKET_BYTES,
 };
+use crate::network::{DnsDiagnosticProbeReport, probe_namespace_dns_diagnostic};
 
 const PEER_DEVICE: &str = "veth0";
-const DNS_PORT: u16 = 53;
 // TC egress accounts the Ethernet header still present before veth transmit;
 // TC ingress runs after eth_type_trans has removed that header.
 const ETHERNET_HEADER_BYTES: u64 = 14;
-const NAMESPACE_EGRESS_PACKET_BYTES: u64 = GUEST_DNS_READINESS_PACKET_BYTES + ETHERNET_HEADER_BYTES;
-const ROOT_INGRESS_PACKET_BYTES: u64 = GUEST_DNS_READINESS_PACKET_BYTES;
+const NAMESPACE_EGRESS_PACKET_BYTES: u64 = GUEST_DNS_PROBE_PACKET_BYTES + ETHERNET_HEADER_BYTES;
+const ROOT_INGRESS_PACKET_BYTES: u64 = GUEST_DNS_PROBE_PACKET_BYTES;
 const TC_COMMAND_TIMEOUT: Duration = Duration::from_millis(500);
 const PROBE_TIMEOUT: Duration = Duration::from_millis(500);
 const FILTER_PRIORITY_BASE: u16 = 49_152;
@@ -648,13 +647,13 @@ fn filter_add_args(
         "src_ip".to_string(),
         format!("{peer_ip}/32"),
         "dst_ip".to_string(),
-        format!("{DNS_READINESS_RESOLVER_IPV4}/32"),
+        format!("{DNS_PROBE_RESOLVER_IPV4}/32"),
         "ip_proto".to_string(),
         "udp".to_string(),
         "src_port".to_string(),
         DNS_DIAGNOSTIC_SOURCE_PORT.to_string(),
         "dst_port".to_string(),
-        DNS_PORT.to_string(),
+        DNS_PROBE_DESTINATION_PORT.to_string(),
         "action".to_string(),
         "gact".to_string(),
         "continue".to_string(),

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -36,6 +36,7 @@ mod factory;
 mod guest_dns_failure_diagnostics;
 mod guest_dns_netfilter_trace;
 mod guest_dns_network_evidence;
+mod guest_dns_probe;
 mod guest_dns_readiness;
 mod guest_dns_veth_handoff_diagnostic;
 mod guest_operations;
@@ -59,9 +60,11 @@ pub use config::{
 };
 pub use control::FirecrackerControl;
 pub use factory::{PREWARM_SCRIPT, config_hash};
+pub use guest_dns_probe::{
+    DNS_DIAGNOSTIC_HOSTNAME, DNS_PROBE_RESOLVER_IPV4, DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4,
+};
 pub use network::{
-    DNS_DIAGNOSTIC_HOSTNAME, DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4, NetnsInfo, NetnsLease,
-    NetnsPool, NetnsPoolConfig, ParsedNetnsName, parse_netns_name,
+    NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, ParsedNetnsName, parse_netns_name,
 };
 pub use paths::{
     FactoryPaths, LockPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths,

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -9,8 +9,4 @@ pub use pool::{
     NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, ParsedNetnsName, parse_netns_name,
 };
 pub(crate) use pool::{NetnsPoolHandle, make_pool_dns_filter_comment};
-pub use readiness::{DNS_DIAGNOSTIC_HOSTNAME, DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4};
-pub(crate) use readiness::{
-    DNS_DIAGNOSTIC_SOURCE_PORT, DNS_READINESS_RESOLVER_IPV4, DnsDiagnosticProbeReport,
-    probe_namespace_dns_diagnostic,
-};
+pub(crate) use readiness::{DnsDiagnosticProbeReport, probe_namespace_dns_diagnostic};

--- a/crates/sandbox-fc/src/network/pool/firewall.rs
+++ b/crates/sandbox-fc/src/network/pool/firewall.rs
@@ -4,7 +4,9 @@ use std::io::Write;
 use tracing::{info, warn};
 
 use crate::command::{CommandError, exec_status_with_timeout, exec_with_timeout};
-use crate::guest_dns_readiness::GUEST_DNS_READINESS_PACKET_BYTES;
+use crate::guest_dns_probe::{
+    DNS_PROBE_DESTINATION_PORT, DNS_PROBE_RESOLVER_IPV4, GUEST_DNS_PROBE_PACKET_BYTES,
+};
 
 use super::super::error::{NetworkError, Result};
 use super::HOST_NETWORK_COMMAND_TIMEOUT;
@@ -13,8 +15,6 @@ use super::naming::{
     make_pool_dns_filter_comment, parse_netns_name,
 };
 use super::types::NamespaceDeleteOutcome;
-
-const GUEST_DNS_READINESS_IPV4: &str = "8.8.8.8/32";
 
 /// Configuration for one namespace's host firewall transaction.
 #[derive(Clone, Copy)]
@@ -318,10 +318,10 @@ fn namespace_guest_dns_trace_restore_tables(
         table: "raw",
         rules: vec![
             format!(
-                "-I PREROUTING 1 -i {host_device} -s {peer} -d {GUEST_DNS_READINESS_IPV4} -p udp --dport 53 -m length --length {GUEST_DNS_READINESS_PACKET_BYTES} -m comment --comment {name} -j TRACE"
+                "-I PREROUTING 1 -i {host_device} -s {peer} -d {DNS_PROBE_RESOLVER_IPV4}/32 -p udp --dport {DNS_PROBE_DESTINATION_PORT} -m length --length {GUEST_DNS_PROBE_PACKET_BYTES} -m comment --comment {name} -j TRACE"
             ),
             format!(
-                "-I PREROUTING 1 -i {host_device} -s {peer} -d {GUEST_DNS_READINESS_IPV4} -p tcp --dport 53 -m comment --comment {name} -j TRACE"
+                "-I PREROUTING 1 -i {host_device} -s {peer} -d {DNS_PROBE_RESOLVER_IPV4}/32 -p tcp --dport {DNS_PROBE_DESTINATION_PORT} -m comment --comment {name} -j TRACE"
             ),
         ],
     }]

--- a/crates/sandbox-fc/src/network/readiness.rs
+++ b/crates/sandbox-fc/src/network/readiness.rs
@@ -16,21 +16,10 @@ use tracing::{info, warn};
 use serde::Serialize;
 
 use crate::duration::duration_ms;
-
-/// Local-only hostname used to validate a namespace's DNS redirect path.
-pub const DNS_READINESS_HOSTNAME: &str = "vm0-readiness.invalid";
-
-/// Local-only hostname reserved for post-failure namespace diagnostics.
-pub const DNS_DIAGNOSTIC_HOSTNAME: &str = "vm0-vethprobe.invalid";
-
-/// TEST-NET address returned for the readiness and diagnostic hostnames.
-pub const DNS_READINESS_IPV4: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 1);
-
-pub(crate) const DNS_READINESS_RESOLVER_IPV4: Ipv4Addr = Ipv4Addr::new(8, 8, 8, 8);
-/// Fixed diagnostic port outside Linux's default ephemeral range, used to correlate one query.
-pub(crate) const DNS_DIAGNOSTIC_SOURCE_PORT: u16 = 30_053;
-
-const _: () = assert!(DNS_DIAGNOSTIC_HOSTNAME.len() == DNS_READINESS_HOSTNAME.len());
+use crate::guest_dns_probe::{
+    DNS_DIAGNOSTIC_HOSTNAME, DNS_DIAGNOSTIC_SOURCE_PORT, DNS_PROBE_DESTINATION_PORT,
+    DNS_PROBE_RESOLVER_IPV4, DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4,
+};
 
 pub(super) const DNS_READINESS_OPERATION_TIMEOUT: Duration = Duration::from_secs(3);
 
@@ -38,7 +27,6 @@ pub(super) type DnsReadinessFuture =
     Pin<Box<dyn Future<Output = Result<u16, DnsReadinessError>> + Send>>;
 pub(super) type DnsReadinessProbe = Arc<dyn Fn(String) -> DnsReadinessFuture + Send + Sync>;
 
-const DNS_PORT: u16 = 53;
 const DNS_RESPONSE_MAX_BYTES: usize = 512;
 const DNS_QUERY_FLAGS_RECURSION_DESIRED: u16 = 0x0100;
 const DNS_RESPONSE_FLAG: u16 = 0x8000;
@@ -342,7 +330,7 @@ fn probe_namespace_dns_diagnostic_blocking(
     }
 
     let mut report = probe_dns_endpoint_once(
-        SocketAddrV4::new(DNS_READINESS_RESOLVER_IPV4, DNS_PORT),
+        SocketAddrV4::new(DNS_PROBE_RESOLVER_IPV4, DNS_PROBE_DESTINATION_PORT),
         DNS_DIAGNOSTIC_SOURCE_PORT,
         probe_timeout,
         DNS_DIAGNOSTIC_HOSTNAME,
@@ -455,7 +443,7 @@ fn probe_namespace_dns_blocking(
         .map_err(|errno| DnsReadinessError::errno(DnsReadinessStage::EnterNamespace, errno))?;
 
     let result = probe_dns_endpoint(
-        SocketAddrV4::new(DNS_READINESS_IPV4, DNS_PORT),
+        SocketAddrV4::new(DNS_READINESS_IPV4, DNS_PROBE_DESTINATION_PORT),
         probe_timeout,
         hostname,
     );
@@ -678,6 +666,10 @@ mod tests {
     fn query_uses_readiness_name_and_a_record() {
         let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
 
+        assert_eq!(
+            query.len(),
+            crate::guest_dns_probe::GUEST_DNS_PROBE_QUERY_BYTES
+        );
         assert_eq!(query.get(..2).unwrap(), &0x1234_u16.to_be_bytes());
         assert_eq!(
             query.get(2..4).unwrap(),
@@ -695,6 +687,10 @@ mod tests {
     fn diagnostic_query_uses_distinct_fixed_name() {
         let query = build_dns_query(0x1234, DNS_DIAGNOSTIC_HOSTNAME).unwrap();
 
+        assert_eq!(
+            query.len(),
+            crate::guest_dns_probe::GUEST_DNS_PROBE_QUERY_BYTES
+        );
         assert!(
             query
                 .windows("vm0-vethprobe".len())


### PR DESCRIPTION
## Summary

- define one compile-time guest DNS probe identity in `sandbox-fc`, including hostnames, resolver, ports, expected answer, and packet size derived from the fixed query
- use that identity when runner writes and hashes the guest resolver and when `sandbox-fc` matches readiness traffic across firewall, trace, counter, and veth diagnostics
- preserve the current rootfs contents, hash input bytes, and wire behavior; dnsmasq upstream resolvers and the unrelated default-route sentinel remain separate

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox-fc -p runner --all-features --no-deps`
- `cargo test -p sandbox-fc -p runner --all-targets --all-features`

Closes #24901
