### PR TITLE
perf: measure pre-park successor handoff

### DIFF
--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -1,4 +1,4 @@
-//! Tracing layer that ships WARN+ events to Axiom.
+//! Tracing layer that ships WARN+ and narrowly allowlisted INFO events to Axiom.
 //!
 //! Disabled at construction when `AXIOM_TOKEN_TELEMETRY` or
 //! `AXIOM_DATASET_SUFFIX` is unset. Dual-write: the existing fmt subscriber
@@ -23,9 +23,12 @@ use tracing_subscriber::filter::{self, FilterFn};
 use tracing_subscriber::layer::{Context, Layer};
 use tracing_subscriber::registry::LookupSpan;
 
+use crate::telemetry::PRE_PARK_HANDOFF_AXIOM_TARGET;
+
 /// Bounded-channel capacity between tracing callers and the dispatcher task.
-/// WARN+ events are rare, so 1024 absorbs realistic bursts; overflow is
-/// counted + surfaced via stderr rather than blocking the tracing hot path.
+/// WARN+ and the selected-candidate measurement events are low-volume, so 1024
+/// absorbs realistic bursts; overflow is counted + surfaced via stderr rather
+/// than blocking the tracing hot path.
 const CHANNEL_CAP: usize = 1024;
 /// Max events per ingest POST. Axiom accepts thousands per batch, but a small
 /// cap keeps POST body size and peak dispatcher memory predictable.
@@ -168,10 +171,13 @@ pub(crate) struct AxiomLayer {
 }
 
 fn should_ingest(metadata: &Metadata<'_>) -> bool {
-    // Fixed WARN+ threshold. Errors and warnings only; INFO/DEBUG stay out
-    // of Axiom to keep ingest volume predictable. INTERNAL_TARGET is for
-    // this layer's own diagnostics, which should remain local-only.
-    *metadata.level() <= tracing::Level::WARN && metadata.target() != INTERNAL_TARGET
+    // Errors and warnings remain the general threshold. One exact INFO target
+    // carries the bounded selected-candidate measurements required before a
+    // successor has an authenticated per-job telemetry owner. DEBUG/TRACE and
+    // all other INFO events stay local-only.
+    (*metadata.level() <= tracing::Level::WARN && metadata.target() != INTERNAL_TARGET)
+        || (*metadata.level() == tracing::Level::INFO
+            && metadata.target() == PRE_PARK_HANDOFF_AXIOM_TARGET)
 }
 
 fn ingest_filter() -> FilterFn<fn(&Metadata<'_>) -> bool> {

--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -17,6 +17,8 @@ use tracing::field::{Field, Visit};
 use tracing::{Event, Subscriber};
 use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
 
+use crate::telemetry::PRE_PARK_HANDOFF_AXIOM_TARGET;
+
 #[derive(Clone, Debug)]
 struct RecordedEvent {
     level: tracing::Level,
@@ -181,6 +183,15 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
         tracing::warn!(foo = "bar", "a warning");
         tracing::error!(code = 42, "a failure");
         tracing::info!("info is below threshold, should not be ingested");
+        tracing::info!(
+            target: PRE_PARK_HANDOFF_AXIOM_TARGET,
+            outcome = "retained",
+            "allowlisted measurement"
+        );
+        tracing::debug!(
+            target: PRE_PARK_HANDOFF_AXIOM_TARGET,
+            "allowlisted target below INFO"
+        );
     }
 
     guard.shutdown().await;
@@ -200,9 +211,16 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
     assert_eq!(failure["service"], json!("runner"));
     assert_eq!(failure["level"], json!("error"));
     assert_eq!(failure["code"], json!(42));
+    let measurement = event_with_message(&events, "allowlisted measurement");
+    assert_eq!(measurement["level"], json!("info"));
+    assert_eq!(measurement["outcome"], json!("retained"));
     assert!(
-        !events.iter().any(|event| event["level"] == json!("info")),
-        "INFO event should not be ingested: {events:#?}",
+        !has_event_with_message(&events, "info is below threshold, should not be ingested"),
+        "ordinary INFO event should not be ingested: {events:#?}",
+    );
+    assert!(
+        !has_event_with_message(&events, "allowlisted target below INFO"),
+        "allowlisted DEBUG event should not be ingested: {events:#?}",
     );
 }
 

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -21,6 +21,10 @@ use super::idle_lifecycle::{
     spawn_idle_destroy_job,
 };
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
+use super::pre_park_handoff_observation::{
+    CandidateOutcome, CandidateReason, is_selected_finalizing_candidate,
+    record_candidate_observation,
+};
 use crate::config::ProfileConfig;
 use crate::executor::{
     RunnerPreSpawnPhase, RunnerPreSpawnTiming, SessionHistoryRestorePlanInput,
@@ -401,6 +405,13 @@ async fn claim_with_local_admission(
     let cancellation = match ctx.cancel_tokens.register(run_id).await {
         Ok(registration) => registration,
         Err(_) => {
+            record_candidate_observation(
+                &candidate,
+                ctx.runner_id,
+                ctx.heartbeat_generation,
+                CandidateOutcome::ClaimLost,
+                Some(CandidateReason::CancellationRegistrationConflict),
+            );
             rollback_untracked_resource(resource, ctx).await;
             return None;
         }
@@ -418,10 +429,24 @@ async fn claim_with_local_admission(
     match mode {
         RunnerMode::Running => {}
         RunnerMode::Starting => {
+            record_candidate_observation(
+                &candidate,
+                ctx.runner_id,
+                ctx.heartbeat_generation,
+                CandidateOutcome::Cancelled,
+                Some(CandidateReason::RunnerModeChanged),
+            );
             admission.rollback(ctx).await;
             return None;
         }
         RunnerMode::Draining => {
+            record_candidate_observation(
+                &candidate,
+                ctx.runner_id,
+                ctx.heartbeat_generation,
+                CandidateOutcome::Cancelled,
+                Some(CandidateReason::RunnerModeChanged),
+            );
             admission.rollback(ctx).await;
             return None;
         }
@@ -429,20 +454,48 @@ async fn claim_with_local_admission(
             admission.cancellation.request_hard_cancellation().await;
         }
         RunnerMode::Stopped => {
+            record_candidate_observation(
+                &candidate,
+                ctx.runner_id,
+                ctx.heartbeat_generation,
+                CandidateOutcome::Cancelled,
+                Some(CandidateReason::RunnerModeChanged),
+            );
             admission.rollback(ctx).await;
             return None;
         }
     }
     // claim() runs in the branch handler: non-interruptible, so a valid
     // successful claim is always paired with complete().
+    let observed_candidate =
+        is_selected_finalizing_candidate(&candidate, ctx.runner_id, ctx.heartbeat_generation)
+            .then(|| candidate.clone());
     let Some(claimed) = ctx.spawn_ctx.provider.claim(candidate).await else {
         // None means the job won't run here: either lost the race to another
         // runner, or the provider rejected the job. Release the reservation and
         // cancellation registration so the runner can continue.
+        if let Some(candidate) = observed_candidate.as_ref() {
+            record_candidate_observation(
+                candidate,
+                ctx.runner_id,
+                ctx.heartbeat_generation,
+                CandidateOutcome::ClaimLost,
+                Some(CandidateReason::ProviderRejected),
+            );
+        }
         admission.rollback(ctx).await;
         return None;
     };
     if claimed.context().run_id != run_id {
+        if let Some(candidate) = observed_candidate.as_ref() {
+            record_candidate_observation(
+                candidate,
+                ctx.runner_id,
+                ctx.heartbeat_generation,
+                CandidateOutcome::ClaimLost,
+                Some(CandidateReason::ProviderRunIdMismatch),
+            );
+        }
         warn!(
             run_id = %run_id,
             context_run_id = %claimed.context().run_id,
@@ -450,6 +503,16 @@ async fn claim_with_local_admission(
         );
         admission.rollback(ctx).await;
         return None;
+    }
+
+    if let Some(candidate) = observed_candidate.as_ref() {
+        record_candidate_observation(
+            candidate,
+            ctx.runner_id,
+            ctx.heartbeat_generation,
+            CandidateOutcome::Claimed,
+            None,
+        );
     }
 
     Some(admission.into_admitted(claimed))
@@ -467,9 +530,23 @@ async fn prepare_preference_candidate(
         return ordinary_preparation(candidate);
     };
     if preference.is_expired() {
+        record_candidate_observation(
+            &candidate,
+            ctx.runner_id,
+            ctx.heartbeat_generation,
+            CandidateOutcome::Expired,
+            None,
+        );
         return ordinary_preparation(candidate.without_runner_preference());
     }
     let Some(reuse_key) = candidate.reuse_key().map(str::to_owned) else {
+        record_candidate_observation(
+            &candidate,
+            ctx.runner_id,
+            ctx.heartbeat_generation,
+            CandidateOutcome::Mismatched,
+            Some(CandidateReason::MissingReuseKey),
+        );
         return ordinary_preparation(candidate.without_runner_preference());
     };
 
@@ -518,6 +595,13 @@ async fn prepare_preference_candidate(
         }
         RunnerPreferenceReason::FinalizingPredecessor => {
             let Some(history_generation_run_id) = candidate.history_generation_run_id() else {
+                record_candidate_observation(
+                    &candidate,
+                    ctx.runner_id,
+                    ctx.heartbeat_generation,
+                    CandidateOutcome::Mismatched,
+                    Some(CandidateReason::MissingHistoryGeneration),
+                );
                 return ordinary_preparation(candidate.without_runner_preference());
             };
             if let Some(reservation) = reserve_reusable_idle(
@@ -534,6 +618,13 @@ async fn prepare_preference_candidate(
 
             if preference.targets(ctx.runner_id, ctx.heartbeat_generation) {
                 if !contains_active_reuse_key(&ctx.spawn_ctx.active_reuse_keys, &reuse_key) {
+                    record_candidate_observation(
+                        &candidate,
+                        ctx.runner_id,
+                        ctx.heartbeat_generation,
+                        CandidateOutcome::Mismatched,
+                        Some(CandidateReason::InactivePredecessor),
+                    );
                     return ordinary_preparation(candidate.without_runner_preference());
                 }
                 return defer_preference_candidate(candidate, &preference, &reuse_key, ctx, true)
@@ -570,6 +661,13 @@ async fn defer_preference_candidate(
     retain: bool,
 ) -> PreferencePreparation {
     if preference.is_expired() {
+        record_candidate_observation(
+            &candidate,
+            ctx.runner_id,
+            ctx.heartbeat_generation,
+            CandidateOutcome::Expired,
+            None,
+        );
         return ordinary_preparation(candidate.without_runner_preference());
     }
     let delay = preference.remaining();

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -24,7 +24,9 @@ use super::job_lifecycle::{
 use super::job_terminal_log::log_terminal_job_outcome;
 use super::orphan_reap::OrphanedActiveRuns;
 use super::ownership::{OwnershipTransitions, RunSandbox};
-use super::sandbox_finalization::{FinalizeContext, finalize_sandbox_for_completion};
+use super::sandbox_finalization::{
+    FinalizeContext, finalize_sandbox_for_completion_with_telemetry,
+};
 #[cfg(test)]
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
 use crate::executor::{
@@ -320,10 +322,17 @@ impl FinalizationPhase {
         // `sandbox.park()` is in flight. Pass the live handle so finalization
         // can synchronize the final idle-pool ownership transfer.
         let finalization_started = Instant::now();
-        let completion_ready = finalize_sandbox_for_completion(
+        telemetry.record(
+            "runner_host_finalization_started",
+            Duration::ZERO,
+            true,
+            None,
+        );
+        let completion_ready = finalize_sandbox_for_completion_with_telemetry(
             sandbox,
             ActiveBudgetLease::new(active_lease),
             completion_payload,
+            &mut telemetry,
             FinalizeContext {
                 run_id,
                 sandbox_id,
@@ -523,7 +532,7 @@ impl DeferredUploadPhase {
 /// The provider has already claimed the job and the caller has reserved
 /// resources in the budget. The spawned task runs the executor, reports
 /// completion through the provider, and delegates the post-executor
-/// park-or-destroy decision to [`finalize_sandbox_for_completion`].
+/// park-or-destroy decision to [`finalize_sandbox_for_completion_with_telemetry`].
 ///
 /// If `reuse_entry` is `Some`, the job reuses an existing idle sandbox.
 /// Otherwise it creates a new one via the factory.
@@ -877,6 +886,23 @@ mod tests {
         );
     }
 
+    fn assert_failed_telemetry_action(telemetry: &JobTelemetry, action: &str, error: &str) {
+        let ops = telemetry.pending_ops_snapshot();
+        assert!(
+            ops.iter()
+                .any(|op| op.0 == action && !op.1 && op.2.as_deref() == Some(error)),
+            "expected failed telemetry action {action} with {error}, got: {ops:?}"
+        );
+    }
+
+    fn assert_no_telemetry_action(telemetry: &JobTelemetry, action: &str) {
+        let ops = telemetry.pending_ops_snapshot();
+        assert!(
+            ops.iter().all(|op| op.0 != action),
+            "unexpected telemetry action {action}, got: {ops:?}"
+        );
+    }
+
     struct FinalizationTelemetryFixture {
         _dir: tempfile::TempDir,
         status: Arc<StatusTracker>,
@@ -953,13 +979,25 @@ mod tests {
         sandbox_name: &str,
         restored_session_identity: Option<RestoredSessionIdentity>,
     ) -> ExecutorPhaseOutcome {
+        executor_phase_outcome_with_sandbox(
+            run_id,
+            Box::new(mock_sandbox_ready_for_idle_reuse(sandbox_name)),
+            restored_session_identity,
+        )
+    }
+
+    fn executor_phase_outcome_with_sandbox(
+        run_id: RunId,
+        sandbox: Box<dyn sandbox::Sandbox>,
+        restored_session_identity: Option<RestoredSessionIdentity>,
+    ) -> ExecutorPhaseOutcome {
         ExecutorPhaseOutcome {
             outcome: executor::ExecuteOutcome {
                 failure: None,
                 sandbox_reuse_disposition: executor::SandboxReuseDisposition::Eligible(
                     executor::SandboxReuseTerminal::Success,
                 ),
-                sandbox: Some(Box::new(mock_sandbox_ready_for_idle_reuse(sandbox_name))),
+                sandbox: Some(sandbox),
                 source_ip: "10.0.0.1".into(),
                 network_log_session: None,
                 workspace_image: None,
@@ -1060,6 +1098,14 @@ mod tests {
             &finalized.telemetry,
             "runner_terminal_sandbox_reuse_eligible_success",
         );
+        for action in [
+            "runner_host_finalization_started",
+            "runner_host_reuse_preparation",
+            "runner_host_physical_park",
+            "runner_host_idle_publication",
+        ] {
+            assert_telemetry_action(&finalized.telemetry, action);
+        }
         assert_telemetry_action(&finalized.telemetry, "session_history_identity_parked");
         assert_eq!(
             cleanup_state.disposition(),
@@ -1143,6 +1189,87 @@ mod tests {
             .finalize(executor_phase_outcome_without_sandbox(run_id))
             .await;
 
+        assert_telemetry_action(&finalized.telemetry, "runner_host_finalization_no_resource");
+    }
+
+    #[tokio::test]
+    async fn finalization_records_reuse_preparation_failure_without_physical_park() {
+        let fixture = FinalizationTelemetryFixture::new().await;
+        let (_budget, lease) = test_budget_lease();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let cleanup_state = RunCleanupState::new();
+        let sandbox = sandbox_mock::MockSandbox::new("reuse-preparation-failed");
+        sandbox.push_exec_result(Err(sandbox::SandboxError::Operation {
+            operation: sandbox::SandboxOperation::Exec,
+            reason: sandbox::SandboxOperationReason::Guest,
+            message: "reuse preparation disconnected".into(),
+        }));
+        let finalization = fixture.finalization_phase(
+            run_id,
+            sandbox_id,
+            "sess-reuse-preparation-failed",
+            lease,
+            cleanup_state,
+        );
+
+        let finalized = finalization
+            .finalize(executor_phase_outcome_with_sandbox(
+                run_id,
+                Box::new(sandbox),
+                None,
+            ))
+            .await;
+
+        assert_failed_telemetry_action(
+            &finalized.telemetry,
+            "runner_host_reuse_preparation",
+            "reuse preparation failed",
+        );
+        assert_no_telemetry_action(&finalized.telemetry, "runner_host_physical_park");
+        assert_no_telemetry_action(&finalized.telemetry, "runner_host_idle_publication");
+        assert_telemetry_action(&finalized.telemetry, "runner_host_finalization_no_resource");
+    }
+
+    #[tokio::test]
+    async fn finalization_records_physical_park_failure_after_reuse_preparation() {
+        let fixture = FinalizationTelemetryFixture::new().await;
+        let (_budget, lease) = test_budget_lease();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let cleanup_state = RunCleanupState::new();
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher(&overrides);
+        overrides.push_park_result(Err(sandbox::SandboxError::IdleTransition {
+            transition: sandbox::SandboxIdleTransition::Park,
+            message: "physical park failed".into(),
+        }));
+        let finalization = fixture.finalization_phase(
+            run_id,
+            sandbox_id,
+            "sess-physical-park-failed",
+            lease,
+            cleanup_state,
+        );
+
+        let finalized = finalization
+            .finalize(executor_phase_outcome_with_sandbox(
+                run_id,
+                Box::new(sandbox_mock::MockSandbox::with_overrides(
+                    "physical-park-failed",
+                    overrides,
+                )),
+                None,
+            ))
+            .await;
+
+        assert_telemetry_action(&finalized.telemetry, "runner_host_reuse_preparation");
+        assert_failed_telemetry_action(
+            &finalized.telemetry,
+            "runner_host_physical_park",
+            "physical park failed",
+        );
+        assert_no_telemetry_action(&finalized.telemetry, "runner_host_idle_publication");
         assert_telemetry_action(&finalized.telemetry, "runner_host_finalization_no_resource");
     }
 

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -1126,6 +1126,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cooperative_cancellation_reuse_does_not_record_hard_cancellation_marker() {
+        let fixture = FinalizationTelemetryFixture::new().await;
+        let (_budget, lease) = test_budget_lease();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let session_id = "sess-cooperative-cancellation";
+        let cleanup_state = RunCleanupState::new();
+        let finalization = fixture.finalization_phase(
+            run_id,
+            sandbox_id,
+            session_id,
+            lease,
+            cleanup_state.clone(),
+        );
+        finalization
+            .cancel
+            .request_cooperative_user_cancellation()
+            .await;
+        let mut executor_result = executor_phase_outcome(run_id, "cooperative-cancellation", None);
+        executor_result.outcome.sandbox_reuse_disposition =
+            executor::SandboxReuseDisposition::Eligible(
+                executor::SandboxReuseTerminal::CooperativeCancellation,
+            );
+
+        let finalized = finalization.finalize(executor_result).await;
+
+        assert_telemetry_action(
+            &finalized.telemetry,
+            "runner_host_finalization_reusable_sandbox",
+        );
+        assert_telemetry_action(
+            &finalized.telemetry,
+            "runner_terminal_sandbox_reuse_eligible_cooperative_cancellation",
+        );
+        assert_no_telemetry_action(&finalized.telemetry, "runner_host_finalization_cancelled");
+        assert_eq!(
+            cleanup_state.disposition(),
+            RunCleanupDisposition::IdlePoolOwned,
+        );
+        assert!(fixture.idle_pool.lock().await.take(session_id).is_some());
+    }
+
+    #[tokio::test]
     async fn finalization_records_identity_park_missing_when_parked_without_restored_identity() {
         let fixture = FinalizationTelemetryFixture::new().await;
         let (_budget, lease) = test_budget_lease();

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -1169,6 +1169,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn hard_cancellation_records_finalization_cancellation_marker() {
+        let fixture = FinalizationTelemetryFixture::new().await;
+        let (_budget, lease) = test_budget_lease();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let cleanup_state = RunCleanupState::new();
+        let finalization = fixture.finalization_phase(
+            run_id,
+            sandbox_id,
+            "sess-hard-cancellation",
+            lease,
+            cleanup_state.clone(),
+        );
+        finalization.cancel.request_hard_cancellation().await;
+        let mut executor_result = executor_phase_outcome(run_id, "hard-cancellation", None);
+        executor_result.outcome.sandbox_reuse_disposition =
+            executor::SandboxReuseDisposition::Ineligible(
+                executor::SandboxReuseRejection::HardCancellation,
+            );
+
+        let finalized = finalization.finalize(executor_result).await;
+
+        assert_failed_telemetry_action(
+            &finalized.telemetry,
+            "runner_host_finalization_cancelled",
+            "cancelled",
+        );
+        assert_telemetry_action(
+            &finalized.telemetry,
+            "runner_terminal_sandbox_reuse_rejected_hard_cancellation",
+        );
+        assert_telemetry_action(&finalized.telemetry, "runner_host_finalization_no_resource");
+        assert_no_telemetry_action(&finalized.telemetry, "runner_host_reuse_preparation");
+        assert_no_telemetry_action(&finalized.telemetry, "runner_host_physical_park");
+        assert_no_telemetry_action(&finalized.telemetry, "runner_host_idle_publication");
+        assert_eq!(
+            cleanup_state.disposition(),
+            RunCleanupDisposition::DestroyCompleted,
+        );
+    }
+
+    #[tokio::test]
     async fn finalization_records_identity_park_missing_when_parked_without_restored_identity() {
         let fixture = FinalizationTelemetryFixture::new().await;
         let (_budget, lease) = test_budget_lease();

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -86,6 +86,7 @@ mod job_terminal_log;
 mod mitm_restart;
 mod orphan_reap;
 mod ownership;
+mod pre_park_handoff_observation;
 mod sandbox_finalization;
 mod signals;
 
@@ -110,6 +111,9 @@ use mitm_restart::{
 use orphan_reap::{
     OrphanReapMode, OrphanReapProcessDiscovery, OrphanedActiveRuns, reap_orphaned_active_runs,
 };
+use pre_park_handoff_observation::{
+    CandidateOutcome, CandidateReason, record_candidate_observation,
+};
 use signals::{
     EarlySignals, SignalController, SignalHandlerTask, handle_stopping_signal, recv_handler_task,
 };
@@ -119,7 +123,16 @@ const READY_DIRECT_CANDIDATE_DRAIN_LIMIT: usize = 8;
 fn candidate_for_admission(
     candidate: JobCandidate,
     pending_candidate: &mut Option<JobCandidate>,
+    runner_id: &str,
+    heartbeat_generation: u64,
 ) -> JobCandidate {
+    record_candidate_observation(
+        &candidate,
+        runner_id,
+        heartbeat_generation,
+        CandidateOutcome::Received,
+        None,
+    );
     if let Some(pending) =
         pending_candidate.take_if(|pending| pending.run_id() == candidate.run_id())
     {
@@ -136,10 +149,26 @@ fn candidate_for_admission(
 fn retain_finalizing_candidate(
     pending_candidate: &mut Option<JobCandidate>,
     candidate: JobCandidate,
+    runner_id: &str,
+    heartbeat_generation: u64,
 ) {
     if pending_candidate.is_none() {
+        record_candidate_observation(
+            &candidate,
+            runner_id,
+            heartbeat_generation,
+            CandidateOutcome::Retained,
+            None,
+        );
         *pending_candidate = Some(candidate);
     } else {
+        record_candidate_observation(
+            &candidate,
+            runner_id,
+            heartbeat_generation,
+            CandidateOutcome::SlotOccupied,
+            None,
+        );
         info!(
             run_id = %candidate.run_id(),
             "finalizing candidate not retained because the pending slot is occupied"
@@ -1535,8 +1564,16 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             current_mode = mode;
             shared.status.set_mode(mode).await;
         }
-        if mode != RunnerMode::Running {
-            pending_finalizing_candidate = None;
+        if mode != RunnerMode::Running
+            && let Some(candidate) = pending_finalizing_candidate.take()
+        {
+            record_candidate_observation(
+                &candidate,
+                &runner.id,
+                runner.heartbeat_generation,
+                CandidateOutcome::Cancelled,
+                Some(CandidateReason::RunnerModeChanged),
+            );
         }
         match mode {
             RunnerMode::Starting => {}
@@ -1621,6 +1658,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 let candidate = candidate_for_admission(
                     candidate,
                     &mut pending_finalizing_candidate,
+                    &runner.id,
+                    runner.heartbeat_generation,
                 );
                 let result = handle_discovered_job(
                     DiscoveredJob { candidate },
@@ -1645,6 +1684,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     retain_finalizing_candidate(
                         &mut pending_finalizing_candidate,
                         candidate,
+                        &runner.id,
+                        runner.heartbeat_generation,
                     );
                 }
                 let mut drained_ready_candidates = 0;
@@ -1667,6 +1708,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     let candidate = candidate_for_admission(
                         candidate,
                         &mut pending_finalizing_candidate,
+                        &runner.id,
+                        runner.heartbeat_generation,
                     );
                     let result = handle_discovered_job(
                         DiscoveredJob { candidate },
@@ -1690,6 +1733,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         retain_finalizing_candidate(
                             &mut pending_finalizing_candidate,
                             candidate,
+                            &runner.id,
+                            runner.heartbeat_generation,
                         );
                     }
                 }
@@ -1834,6 +1879,13 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 let Some(candidate) = pending_finalizing_candidate.take() else {
                     continue;
                 };
+                record_candidate_observation(
+                    &candidate,
+                    &runner.id,
+                    runner.heartbeat_generation,
+                    CandidateOutcome::Expired,
+                    None,
+                );
                 let candidate = candidate.without_runner_preference();
                 let result = handle_discovered_job(
                     DiscoveredJob { candidate },
@@ -1856,6 +1908,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     retain_finalizing_candidate(
                         &mut pending_finalizing_candidate,
                         candidate,
+                        &runner.id,
+                        runner.heartbeat_generation,
                     );
                 }
                 if result.needs_reuse_state_refresh {
@@ -1890,6 +1944,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         retain_finalizing_candidate(
                             &mut pending_finalizing_candidate,
                             candidate,
+                            &runner.id,
+                            runner.heartbeat_generation,
                         );
                     }
                 }

--- a/crates/runner/src/cmd/start/pre_park_handoff_observation.rs
+++ b/crates/runner/src/cmd/start/pre_park_handoff_observation.rs
@@ -1,0 +1,121 @@
+use crate::provider::{JobCandidate, RunnerPreferenceReason};
+use crate::telemetry::PRE_PARK_HANDOFF_AXIOM_TARGET;
+
+#[derive(Clone, Copy)]
+pub(super) enum CandidateOutcome {
+    Received,
+    Retained,
+    SlotOccupied,
+    Expired,
+    Cancelled,
+    Mismatched,
+    ClaimLost,
+    Claimed,
+}
+
+impl CandidateOutcome {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Received => "received",
+            Self::Retained => "retained",
+            Self::SlotOccupied => "slot_occupied",
+            Self::Expired => "expired",
+            Self::Cancelled => "cancelled",
+            Self::Mismatched => "mismatched",
+            Self::ClaimLost => "claim_lost",
+            Self::Claimed => "claimed",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum CandidateReason {
+    MissingReuseKey,
+    MissingHistoryGeneration,
+    InactivePredecessor,
+    RunnerModeChanged,
+    CancellationRegistrationConflict,
+    ProviderRejected,
+    ProviderRunIdMismatch,
+}
+
+impl CandidateReason {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::MissingReuseKey => "missing_reuse_key",
+            Self::MissingHistoryGeneration => "missing_history_generation",
+            Self::InactivePredecessor => "inactive_predecessor",
+            Self::RunnerModeChanged => "runner_mode_changed",
+            Self::CancellationRegistrationConflict => "cancellation_registration_conflict",
+            Self::ProviderRejected => "provider_rejected",
+            Self::ProviderRunIdMismatch => "provider_run_id_mismatch",
+        }
+    }
+}
+
+pub(super) fn record_candidate_observation(
+    candidate: &JobCandidate,
+    runner_id: &str,
+    heartbeat_generation: u64,
+    outcome: CandidateOutcome,
+    reason: Option<CandidateReason>,
+) {
+    if !is_selected_finalizing_candidate(candidate, runner_id, heartbeat_generation) {
+        return;
+    }
+
+    let successor_run_id = candidate.run_id();
+    match (candidate.history_generation_run_id(), reason) {
+        (Some(predecessor_run_id), Some(reason)) => tracing::info!(
+            target: PRE_PARK_HANDOFF_AXIOM_TARGET,
+            measurement = "pre_park_successor_handoff",
+            outcome = outcome.as_str(),
+            reason = reason.as_str(),
+            predecessor_run_id = %predecessor_run_id,
+            successor_run_id = %successor_run_id,
+            runner_id,
+            heartbeat_generation,
+            "pre-park successor handoff candidate observed"
+        ),
+        (Some(predecessor_run_id), None) => tracing::info!(
+            target: PRE_PARK_HANDOFF_AXIOM_TARGET,
+            measurement = "pre_park_successor_handoff",
+            outcome = outcome.as_str(),
+            predecessor_run_id = %predecessor_run_id,
+            successor_run_id = %successor_run_id,
+            runner_id,
+            heartbeat_generation,
+            "pre-park successor handoff candidate observed"
+        ),
+        (None, Some(reason)) => tracing::info!(
+            target: PRE_PARK_HANDOFF_AXIOM_TARGET,
+            measurement = "pre_park_successor_handoff",
+            outcome = outcome.as_str(),
+            reason = reason.as_str(),
+            successor_run_id = %successor_run_id,
+            runner_id,
+            heartbeat_generation,
+            "pre-park successor handoff candidate observed"
+        ),
+        (None, None) => tracing::info!(
+            target: PRE_PARK_HANDOFF_AXIOM_TARGET,
+            measurement = "pre_park_successor_handoff",
+            outcome = outcome.as_str(),
+            successor_run_id = %successor_run_id,
+            runner_id,
+            heartbeat_generation,
+            "pre-park successor handoff candidate observed"
+        ),
+    }
+}
+
+pub(super) fn is_selected_finalizing_candidate(
+    candidate: &JobCandidate,
+    runner_id: &str,
+    heartbeat_generation: u64,
+) -> bool {
+    candidate.runner_preference().is_some_and(|preference| {
+        preference.reason() == RunnerPreferenceReason::FinalizingPredecessor
+            && preference.targets(runner_id, heartbeat_generation)
+    })
+}

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -6,10 +6,13 @@
 
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use chrono::SecondsFormat;
 use futures_util::FutureExt;
-use sandbox::{Sandbox, SandboxFactory, SandboxId};
+use sandbox::{
+    Sandbox, SandboxFactory, SandboxFinalExecParkObserver, SandboxFinalExecParkStage, SandboxId,
+};
 use tracing::{info, warn};
 
 use super::heartbeat::WorkspaceCacheStateSnapshot;
@@ -37,6 +40,7 @@ use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::run_cancellation::RunCancellationHandle;
 use crate::status::StatusTracker;
 use crate::storage_fingerprints::StorageFingerprints;
+use crate::telemetry::JobTelemetry;
 use crate::types::reuse_key_kind;
 use crate::types::{HeldWorkspaceState, WORKSPACE_AFFINITY_VERSION, WorkspaceCacheCapability};
 use crate::workspace_image_cache::{
@@ -44,6 +48,74 @@ use crate::workspace_image_cache::{
     WorkspaceImagePromotionRequest,
 };
 use crate::workspace_promotion::prepare_workspace_image_from_active_sandbox;
+
+struct FinalizationTelemetry<'a> {
+    telemetry: Option<&'a mut JobTelemetry>,
+    physical_park_completed_at: Option<Instant>,
+}
+
+impl<'a> FinalizationTelemetry<'a> {
+    fn new(telemetry: &'a mut JobTelemetry) -> Self {
+        Self {
+            telemetry: Some(telemetry),
+            physical_park_completed_at: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn disabled() -> Self {
+        Self {
+            telemetry: None,
+            physical_park_completed_at: None,
+        }
+    }
+
+    fn record_idle_publication(&mut self, success: bool, error: Option<&'static str>) {
+        let Some(started_at) = self.physical_park_completed_at else {
+            return;
+        };
+        if let Some(telemetry) = self.telemetry.as_deref_mut() {
+            telemetry.record(
+                "runner_host_idle_publication",
+                started_at.elapsed(),
+                success,
+                error,
+            );
+        }
+    }
+
+    fn record_outcome(&mut self, action_type: &'static str, error: &'static str) {
+        if let Some(telemetry) = self.telemetry.as_deref_mut() {
+            telemetry.record(action_type, Duration::ZERO, false, Some(error));
+        }
+    }
+}
+
+impl SandboxFinalExecParkObserver for FinalizationTelemetry<'_> {
+    fn record_stage(
+        &mut self,
+        stage: SandboxFinalExecParkStage,
+        duration: Duration,
+        success: bool,
+    ) {
+        let (action_type, error) = match stage {
+            SandboxFinalExecParkStage::ReusePreparation => (
+                "runner_host_reuse_preparation",
+                (!success).then_some("reuse preparation failed"),
+            ),
+            SandboxFinalExecParkStage::PhysicalPark => (
+                "runner_host_physical_park",
+                (!success).then_some("physical park failed"),
+            ),
+        };
+        if let Some(telemetry) = self.telemetry.as_deref_mut() {
+            telemetry.record(action_type, duration, success, error);
+        }
+        if stage == SandboxFinalExecParkStage::PhysicalPark && success {
+            self.physical_park_completed_at = Some(Instant::now());
+        }
+    }
+}
 
 fn local_completed_at() -> String {
     chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
@@ -118,10 +190,45 @@ pub(super) struct FinalizeContext {
 /// cancellation is not active, the parking gate is open, and a reuse key is
 /// available. Otherwise, or if hard cancellation wins before ownership
 /// transfer or parking cannot complete, the sandbox is stopped and destroyed.
-pub(super) async fn finalize_sandbox_for_completion(
+pub(super) async fn finalize_sandbox_for_completion_with_telemetry(
     sandbox: Option<Box<dyn Sandbox>>,
     active_lease: ActiveBudgetLease,
     completion_payload: CompletionPayload,
+    telemetry: &mut JobTelemetry,
+    ctx: FinalizeContext,
+) -> CompletionReady {
+    finalize_sandbox_for_completion_inner(
+        sandbox,
+        active_lease,
+        completion_payload,
+        FinalizationTelemetry::new(telemetry),
+        ctx,
+    )
+    .await
+}
+
+#[cfg(test)]
+async fn finalize_sandbox_for_completion(
+    sandbox: Option<Box<dyn Sandbox>>,
+    active_lease: ActiveBudgetLease,
+    completion_payload: CompletionPayload,
+    ctx: FinalizeContext,
+) -> CompletionReady {
+    finalize_sandbox_for_completion_inner(
+        sandbox,
+        active_lease,
+        completion_payload,
+        FinalizationTelemetry::disabled(),
+        ctx,
+    )
+    .await
+}
+
+async fn finalize_sandbox_for_completion_inner(
+    sandbox: Option<Box<dyn Sandbox>>,
+    active_lease: ActiveBudgetLease,
+    completion_payload: CompletionPayload,
+    mut telemetry: FinalizationTelemetry<'_>,
     ctx: FinalizeContext,
 ) -> CompletionReady {
     let Some(sandbox) = sandbox else {
@@ -168,6 +275,9 @@ pub(super) async fn finalize_sandbox_for_completion(
     };
     let cancelled = cancel.is_cancelled();
     let hard_cancelled = cancel.is_hard_cancelled();
+    if cancelled {
+        telemetry.record_outcome("runner_host_finalization_cancelled", "cancelled");
+    }
     let terminal_status = workspace_terminal_status(exit_code, cancelled);
     let completed_at = local_completed_at();
     let resolved_cli_agent_session_id = cli_agent_session_id
@@ -229,7 +339,10 @@ pub(super) async fn finalize_sandbox_for_completion(
             workspace_image_size_bytes,
             workspace_promotion,
         });
-        let park_outcome = match park_request.park_for_idle().await {
+        let park_outcome = match park_request
+            .park_for_idle_with_observer(&mut telemetry)
+            .await
+        {
             Ok(outcome) => outcome,
             Err(failure) => match failure.into_parts() {
                 IdleParkFailureParts::Active {
@@ -237,6 +350,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                     reason,
                     error,
                 } => {
+                    telemetry.record_idle_publication(false, Some(reason));
                     let IdleParkActiveParts {
                         sandbox,
                         factory: failure_factory,
@@ -289,6 +403,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                     reason,
                     error,
                 } => {
+                    telemetry.record_idle_publication(false, Some(reason));
                     warn!(
                         run_id = %run_id,
                         reuse_key_fingerprint = %reuse_key_fingerprint,
@@ -327,6 +442,8 @@ pub(super) async fn finalize_sandbox_for_completion(
         };
         let (candidate, non_reusable_reason) = park_outcome.into_parts();
         if cancel.is_hard_cancelled() {
+            telemetry.record_outcome("runner_host_finalization_cancelled", "cancelled");
+            telemetry.record_idle_publication(false, Some("cancelled"));
             let (payload, budget_lease) = candidate.into_active_destroy_parts();
             close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
             info!(
@@ -351,6 +468,7 @@ pub(super) async fn finalize_sandbox_for_completion(
             );
             destroy_result.budget
         } else if let Some(reason) = non_reusable_reason {
+            telemetry.record_idle_publication(false, Some("non_reusable"));
             close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
             info!(
                 run_id = %run_id,
@@ -390,6 +508,8 @@ pub(super) async fn finalize_sandbox_for_completion(
                     drop(pool);
                     let transfer_guard = cancel.transfer_guard().await;
                     if cancel.is_hard_cancelled() {
+                        telemetry.record_outcome("runner_host_finalization_cancelled", "cancelled");
+                        telemetry.record_idle_publication(false, Some("cancelled"));
                         info!(
                             run_id = %run_id,
                             reuse_key_fingerprint = %reuse_key_fingerprint,
@@ -421,6 +541,8 @@ pub(super) async fn finalize_sandbox_for_completion(
                     continue;
                 };
                 if cancel.is_hard_cancelled() {
+                    telemetry.record_outcome("runner_host_finalization_cancelled", "cancelled");
+                    telemetry.record_idle_publication(false, Some("cancelled"));
                     info!(
                         run_id = %run_id,
                         reuse_key_fingerprint = %reuse_key_fingerprint,
@@ -482,6 +604,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                             .publish_idle_status_after_pool_transfer(snapshot)
                             .await;
                         reuse_state_changed = true;
+                        telemetry.record_idle_publication(true, None);
                         reuse_state_notify.notify_one();
                         BudgetOwnership::idle_owned()
                     }
@@ -507,6 +630,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                             .publish_idle_status_after_pool_transfer(snapshot)
                             .await;
                         reuse_state_changed = true;
+                        telemetry.record_idle_publication(true, None);
                         reuse_state_notify.notify_one();
                         // The replaced VM was park()ed when it entered the
                         // pool; destroying a parked sandbox is safe — Drop
@@ -518,6 +642,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         BudgetOwnership::idle_owned()
                     }
                     ParkResult::Rejected(rejected) => {
+                        telemetry.record_idle_publication(false, Some("idle_pool_rejected"));
                         info!(
                             run_id = %run_id,
                             reuse_key_fingerprint = %reuse_key_fingerprint,

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -275,7 +275,7 @@ async fn finalize_sandbox_for_completion_inner(
     };
     let cancelled = cancel.is_cancelled();
     let hard_cancelled = cancel.is_hard_cancelled();
-    if cancelled {
+    if hard_cancelled {
         telemetry.record_outcome("runner_host_finalization_cancelled", "cancelled");
     }
     let terminal_status = workspace_terminal_status(exit_code, cancelled);

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -13,8 +13,47 @@ use crate::paths::RunnerPaths;
 use crate::provider::{RunnerPreference, RunnerPreferenceReason};
 use crate::types::SandboxReuseResult;
 use crate::workspace_image_cache::WorkspaceImageCache;
+use tracing::instrument::WithSubscriber;
+use tracing_subscriber::prelude::*;
+use tracing_test_support::CapturedEvents;
 
 const NON_SELECTED_RUNNER_ID: u128 = 1;
+
+fn spawn_run_with_candidate_observations(
+    config: RunConfig,
+) -> (tokio::task::JoinHandle<RunnerResult<()>>, CapturedEvents) {
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    (
+        tokio::spawn(run(config).with_subscriber(subscriber)),
+        captured,
+    )
+}
+
+fn assert_candidate_observation(
+    captured: &CapturedEvents,
+    successor_run_id: RunId,
+    predecessor_run_id: RunId,
+    outcome: &str,
+) {
+    let successor_run_id = successor_run_id.to_string();
+    let predecessor_run_id = predecessor_run_id.to_string();
+    let heartbeat_generation = TEST_HEARTBEAT_GENERATION.to_string();
+    assert!(
+        captured.entries().iter().any(|event| {
+            event.level == tracing::Level::INFO
+                && event.fields.get("measurement").map(String::as_str)
+                    == Some("pre_park_successor_handoff")
+                && event.fields.get("successor_run_id") == Some(&successor_run_id)
+                && event.fields.get("predecessor_run_id") == Some(&predecessor_run_id)
+                && event.fields.get("runner_id").map(String::as_str) == Some(TEST_RUNNER_ID)
+                && event.fields.get("heartbeat_generation") == Some(&heartbeat_generation)
+                && event.fields.get("outcome").map(String::as_str) == Some(outcome)
+        }),
+        "missing {outcome} candidate observation for {successor_run_id}; events={:#?}",
+        captured.entries()
+    );
+}
 
 fn preferred_candidate(
     run_id: RunId,
@@ -621,7 +660,7 @@ async fn selected_finalizing_candidate_claims_exact_resource_on_reuse_state_wake
         Arc::clone(&env.reuse_state_notify),
         Some(reuse_key.to_owned()),
     );
-    let run_handle = tokio::spawn(run(config));
+    let (run_handle, captured) = spawn_run_with_candidate_observations(config);
     wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     let run_id = RunId::new_v4();
@@ -657,7 +696,54 @@ async fn selected_finalizing_candidate_claims_exact_resource_on_reuse_state_wake
         .await
         .expect("exact resource state should wake the retained candidate");
     assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    for outcome in ["received", "retained", "claimed"] {
+        assert_candidate_observation(&captured, run_id, history_generation_run_id, outcome);
+    }
     drop(predecessor_guard);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn selected_finalizing_candidate_records_claim_loss_and_restores_exact_resource() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let reuse_key = "thread:finalizing-claim-loss";
+    let history_generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_history_generation(
+        &env.idle_pool,
+        &budget,
+        reuse_key,
+        "vm0/default",
+        2,
+        4096,
+        history_generation_run_id,
+    )
+    .await;
+    let (run_handle, captured) = spawn_run_with_candidate_observations(config);
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider.set_claim_result(run_id, None);
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate(
+            run_id,
+            reuse_key,
+            history_generation_run_id,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+        ))
+        .unwrap();
+
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    assert_candidate_observation(&captured, run_id, history_generation_run_id, "claim_lost");
+    assert_eq!(
+        env.idle_pool.lock().await.held_reuse_keys(),
+        vec![reuse_key.to_string()],
+        "lost claim should restore the exact reusable resource"
+    );
 
     shutdown(&env, run_handle).await;
 }
@@ -707,7 +793,7 @@ async fn same_run_duplicate_does_not_renew_pending_finalizing_deadline() {
         Arc::clone(&env.reuse_state_notify),
         Some(reuse_key.to_owned()),
     );
-    let run_handle = tokio::spawn(run(config));
+    let (run_handle, captured) = spawn_run_with_candidate_observations(config);
     wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     let run_id = RunId::new_v4();
@@ -765,6 +851,7 @@ async fn same_run_duplicate_does_not_renew_pending_finalizing_deadline() {
         claimed.runner_preference().is_none(),
         "expiry should clear the advisory preference before ordinary admission"
     );
+    assert_candidate_observation(&captured, run_id, history_generation_run_id, "expired");
 
     drop(predecessor_guard);
     shutdown(&env, run_handle).await;
@@ -785,7 +872,7 @@ async fn pending_slot_overflow_does_not_retain_a_distinct_candidate() {
         Arc::clone(&env.reuse_state_notify),
         Some(second_reuse_key.to_owned()),
     );
-    let run_handle = tokio::spawn(run(config));
+    let (run_handle, captured) = spawn_run_with_candidate_observations(config);
     wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     let first_run_id = RunId::new_v4();
@@ -806,6 +893,7 @@ async fn pending_slot_overflow_does_not_retain_a_distinct_candidate() {
     wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     let second_run_id = RunId::new_v4();
+    let second_history_generation_run_id = RunId::new_v4();
     env.provider.set_claim_result(
         second_run_id,
         Some(context_with_reuse_key(second_run_id, second_reuse_key)),
@@ -815,7 +903,7 @@ async fn pending_slot_overflow_does_not_retain_a_distinct_candidate() {
         .send(finalizing_candidate(
             second_run_id,
             second_reuse_key,
-            RunId::new_v4(),
+            second_history_generation_run_id,
             TEST_RUNNER_ID,
             TEST_HEARTBEAT_GENERATION,
         ))
@@ -846,6 +934,12 @@ async fn pending_slot_overflow_does_not_retain_a_distinct_candidate() {
             .iter()
             .any(|candidate| candidate.run_id() == second_run_id)
     );
+    assert_candidate_observation(
+        &captured,
+        second_run_id,
+        second_history_generation_run_id,
+        "slot_occupied",
+    );
 
     shutdown(&env, run_handle).await;
 }
@@ -859,10 +953,11 @@ async fn drain_discards_pending_finalizing_candidate_without_claiming() {
         Arc::clone(&env.reuse_state_notify),
         Some(reuse_key.to_owned()),
     );
-    let run_handle = tokio::spawn(run(config));
+    let (run_handle, captured) = spawn_run_with_candidate_observations(config);
     wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     let run_id = RunId::new_v4();
+    let history_generation_run_id = RunId::new_v4();
     env.provider
         .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
     env.handle
@@ -870,7 +965,7 @@ async fn drain_discards_pending_finalizing_candidate_without_claiming() {
         .send(finalizing_candidate(
             run_id,
             reuse_key,
-            RunId::new_v4(),
+            history_generation_run_id,
             TEST_RUNNER_ID,
             TEST_HEARTBEAT_GENERATION,
         ))
@@ -885,6 +980,7 @@ async fn drain_discards_pending_finalizing_candidate_without_claiming() {
     )
     .await;
     assert!(env.handle.claim_candidates().is_empty());
+    assert_candidate_observation(&captured, run_id, history_generation_run_id, "cancelled");
 
     drop(predecessor_guard);
 }

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -1020,6 +1020,52 @@ async fn preference_without_reuse_key_uses_ordinary_admission() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn selected_finalizing_candidate_without_reuse_key_records_mismatch() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let (run_handle, captured) = spawn_run_with_candidate_observations(config);
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    let history_generation_run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(minimal_context(run_id)));
+    env.handle
+        .discover_tx
+        .send(
+            crate::provider::JobCandidate::new(run_id, "vm0/default".into())
+                .with_history_generation_run_id(Some(history_generation_run_id))
+                .with_runner_preference(Some(RunnerPreference::for_test(
+                    TEST_RUNNER_ID.parse().unwrap(),
+                    TEST_HEARTBEAT_GENERATION,
+                    RunnerPreferenceReason::FinalizingPredecessor,
+                    std::time::Instant::now() + Duration::from_secs(30),
+                ))),
+        )
+        .unwrap();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await;
+    assert!(
+        completion.is_some(),
+        "missing reuse metadata should preserve ordinary admission"
+    );
+    assert_candidate_observation(&captured, run_id, history_generation_run_id, "mismatched");
+    let successor_run_id = run_id.to_string();
+    assert!(
+        captured.entries().iter().any(|event| {
+            event.fields.get("successor_run_id") == Some(&successor_run_id)
+                && event.fields.get("reason").map(String::as_str) == Some("missing_reuse_key")
+        }),
+        "mismatch observation should identify the bounded missing-reuse-key reason; events={:#?}",
+        captured.entries()
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
 async fn matching_preference_uses_actual_local_sandbox_without_resource_class() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);

--- a/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
@@ -24,6 +24,10 @@ async fn telemetry_flush_includes_start_loop_claim_phase_spans() {
                 .body_includes("runner_claim_active_status_publish")
                 .body_includes("runner_claim_spawn_job_setup")
                 .body_includes("runner_claim_task_schedule_wait")
+                .body_includes("runner_host_finalization_started")
+                .body_includes("runner_host_reuse_preparation")
+                .body_includes("runner_host_physical_park")
+                .body_includes("runner_host_idle_publication")
                 .body_includes("runner_host_finalization_reusable_sandbox")
                 .body_includes("runner_host_completion_fallback")
                 .body_includes("runner_active_reuse_key_released");

--- a/crates/runner/src/idle_pool/park_transition.rs
+++ b/crates/runner/src/idle_pool/park_transition.rs
@@ -24,7 +24,7 @@ use super::entry::{
 
 /// One-shot request to transition an active sandbox into same-reuse-key idle
 /// ownership.
-#[must_use = "idle park requests own active sandbox and budget; call park_for_idle"]
+#[must_use = "idle park requests own active sandbox and budget; call a park_for_idle method"]
 pub(crate) struct IdleParkRequest {
     pub(super) parts: IdleParkRequestParts,
 }

--- a/crates/runner/src/idle_pool/park_transition.rs
+++ b/crates/runner/src/idle_pool/park_transition.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use futures_util::FutureExt;
 use sandbox::{
-    DeviceRateLimits, Sandbox, SandboxFactory, SandboxId, SandboxParkNonReusableReason,
-    SandboxParkOutcome,
+    DeviceRateLimits, Sandbox, SandboxFactory, SandboxFinalExecParkObserver, SandboxId,
+    SandboxParkNonReusableReason, SandboxParkOutcome,
 };
 
 use crate::idle_reuse_preparation::IdleReusePreparation;
@@ -101,7 +101,23 @@ impl IdleParkRequest {
         Self { parts }
     }
 
+    #[cfg(test)]
     pub(crate) async fn park_for_idle(self) -> Result<IdleParkOutcome, IdleParkFailure> {
+        self.park_for_idle_with_optional_observer(None).await
+    }
+
+    pub(crate) async fn park_for_idle_with_observer(
+        self,
+        observer: &mut dyn SandboxFinalExecParkObserver,
+    ) -> Result<IdleParkOutcome, IdleParkFailure> {
+        self.park_for_idle_with_optional_observer(Some(observer))
+            .await
+    }
+
+    async fn park_for_idle_with_optional_observer(
+        self,
+        observer: Option<&mut dyn SandboxFinalExecParkObserver>,
+    ) -> Result<IdleParkOutcome, IdleParkFailure> {
         let IdleParkRequestParts {
             run_id,
             mut sandbox,
@@ -195,11 +211,15 @@ impl IdleParkRequest {
 
         let final_exec_and_park = {
             let request = preparation.exec_request();
-            AssertUnwindSafe(
-                sandbox.final_exec_and_park(&request, "idle-reuse-preparation-and-park"),
-            )
-            .catch_unwind()
-            .await
+            let transition = match observer {
+                Some(observer) => sandbox.final_exec_and_park_with_observer(
+                    &request,
+                    "idle-reuse-preparation-and-park",
+                    observer,
+                ),
+                None => sandbox.final_exec_and_park(&request, "idle-reuse-preparation-and-park"),
+            };
+            AssertUnwindSafe(transition).catch_unwind().await
         };
         match final_exec_and_park {
             Ok(Ok(outcome)) => {

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -24,6 +24,10 @@ const FLUSH_THRESHOLD: Duration = Duration::from_secs(30);
 /// Timeout for telemetry HTTP requests (shorter than default API timeout).
 const TELEMETRY_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Exact tracing target whose selected-candidate INFO events are admitted to
+/// the production Axiom log layer.
+pub(crate) const PRE_PARK_HANDOFF_AXIOM_TARGET: &str = "runner::pre_park_successor_handoff";
+
 /// Per-job telemetry collector. Buffers sandbox operations and flushes them
 /// periodically (auto on 30 s threshold) and at job end.
 ///

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -11,9 +11,10 @@ use sandbox::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessCancelHandle,
     GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter, ProcessControlAck,
     ProcessControlMode, ProcessExit, ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxConfig,
-    SandboxError, SandboxFinalExecParkOutcome, SandboxIdleTransition, SandboxInvalidStateContext,
-    SandboxOperation, SandboxOperationReason, SandboxParkNonReusableReason, SandboxParkOutcome,
-    SandboxStartObserver, SandboxStartStage, StartProcessRequest, WriteFileEntry,
+    SandboxError, SandboxFinalExecParkObserver, SandboxFinalExecParkOutcome,
+    SandboxFinalExecParkStage, SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation,
+    SandboxOperationReason, SandboxParkNonReusableReason, SandboxParkOutcome, SandboxStartObserver,
+    SandboxStartStage, StartProcessRequest, WriteFileEntry,
 };
 use tokio::io::AsyncRead;
 use tokio::sync::{mpsc, watch};
@@ -99,6 +100,22 @@ impl<'a> SandboxStartTiming<'a> {
     }
 
     fn record(&mut self, stage: SandboxStartStage, started: Instant, success: bool) {
+        if let Some(observer) = self.observer.as_deref_mut() {
+            observer.record_stage(stage, started.elapsed(), success);
+        }
+    }
+}
+
+struct SandboxFinalExecParkTiming<'a> {
+    observer: Option<&'a mut dyn SandboxFinalExecParkObserver>,
+}
+
+impl<'a> SandboxFinalExecParkTiming<'a> {
+    fn new(observer: Option<&'a mut dyn SandboxFinalExecParkObserver>) -> Self {
+        Self { observer }
+    }
+
+    fn record(&mut self, stage: SandboxFinalExecParkStage, started: Instant, success: bool) {
         if let Some(observer) = self.observer.as_deref_mut() {
             observer.record_stage(stage, started.elapsed(), success);
         }
@@ -1799,6 +1816,94 @@ fn exec_capture_request<'a>(
     }
 }
 
+impl FirecrackerSandbox {
+    async fn final_exec_and_park_with_optional_observer(
+        &mut self,
+        request: &ExecRequest<'_>,
+        diagnostic_label: &'static str,
+        observer: Option<&mut dyn SandboxFinalExecParkObserver>,
+    ) -> sandbox::Result<SandboxFinalExecParkOutcome> {
+        if self.is_parked {
+            return Err(idle_transition_error(
+                SandboxIdleTransition::Park,
+                "final guest exec cannot run on an already parked sandbox",
+            ));
+        }
+
+        let operation = SandboxOperation::Exec;
+        Self::validate_exec_env_keys(operation, request.env)?;
+        let timeout_ms = request.timeout_ms();
+        validate_exec_capture_timeout(timeout_ms)
+            .map_err(|error| Self::operation_error(operation, error, self.has_backend_crashed()))?;
+
+        let coordinator = self.park_coordinator.clone();
+        let guest = Arc::clone(&self.guest);
+        let final_exec_guest = Arc::clone(&guest);
+        let id = self.id.clone();
+        let api_sock = self.sock_paths.api_sock();
+        let final_exec_request = exec_capture_request(request, timeout_ms, diagnostic_label);
+        let (normal_operations_fence, park_outcome, exec_result) =
+            park_with_ready_for_park_and_preparation_with_observer(
+                &id,
+                &coordinator,
+                observer,
+                || async move {
+                    let guest =
+                        final_exec_guest
+                            .lock()
+                            .await
+                            .as_ref()
+                            .cloned()
+                            .ok_or_else(|| {
+                                ParkNormalOperationFenceError::GuestUnavailable(io::Error::new(
+                                    io::ErrorKind::NotConnected,
+                                    "guest connection missing during final park operation",
+                                ))
+                            })?;
+                    let (result, fence) = guest
+                        .exec_operation_capture_with_fence(final_exec_request)
+                        .await
+                        .map_err(|error| match error {
+                            FencedExecError::FenceRejected(error) => {
+                                ParkNormalOperationFenceError::Rejected(error)
+                            }
+                            FencedExecError::Operation(error) => {
+                                ParkNormalOperationFenceError::FinalOperation(error)
+                            }
+                        })?;
+                    let result = exec_result_from_operation_result(result)
+                        .map_err(ParkNormalOperationFenceError::FinalOperation)?;
+                    Ok((fence, result))
+                },
+                || async move {
+                    let guest = guest.lock().await.as_ref().cloned().ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::NotConnected,
+                            "guest connection missing during park quiesce",
+                        )
+                    })?;
+                    guest.quiesce_operations(GUEST_PARK_LIFECYCLE_TIMEOUT).await
+                },
+                || {
+                    park_inner(
+                        &mut self.is_parked,
+                        self.config.resources.memory_mb,
+                        self.runtime.balloon_mut(),
+                        &api_sock,
+                        &id,
+                    )
+                },
+            )
+            .await?;
+        self.park_fence = Some(normal_operations_fence);
+        self.park_outcome = Some(park_outcome);
+        Ok(SandboxFinalExecParkOutcome {
+            exec_result,
+            park_outcome,
+        })
+    }
+}
+
 #[async_trait]
 impl Sandbox for FirecrackerSandbox {
     // -- identity --
@@ -2049,83 +2154,18 @@ impl Sandbox for FirecrackerSandbox {
         request: &ExecRequest<'_>,
         diagnostic_label: &'static str,
     ) -> sandbox::Result<SandboxFinalExecParkOutcome> {
-        if self.is_parked {
-            return Err(idle_transition_error(
-                SandboxIdleTransition::Park,
-                "final guest exec cannot run on an already parked sandbox",
-            ));
-        }
+        self.final_exec_and_park_with_optional_observer(request, diagnostic_label, None)
+            .await
+    }
 
-        let operation = SandboxOperation::Exec;
-        Self::validate_exec_env_keys(operation, request.env)?;
-        let timeout_ms = request.timeout_ms();
-        validate_exec_capture_timeout(timeout_ms)
-            .map_err(|error| Self::operation_error(operation, error, self.has_backend_crashed()))?;
-
-        let coordinator = self.park_coordinator.clone();
-        let guest = Arc::clone(&self.guest);
-        let final_exec_guest = Arc::clone(&guest);
-        let id = self.id.clone();
-        let api_sock = self.sock_paths.api_sock();
-        let final_exec_request = exec_capture_request(request, timeout_ms, diagnostic_label);
-        let (normal_operations_fence, park_outcome, exec_result) =
-            park_with_ready_for_park_and_preparation(
-                &id,
-                &coordinator,
-                || async move {
-                    let guest =
-                        final_exec_guest
-                            .lock()
-                            .await
-                            .as_ref()
-                            .cloned()
-                            .ok_or_else(|| {
-                                ParkNormalOperationFenceError::GuestUnavailable(io::Error::new(
-                                    io::ErrorKind::NotConnected,
-                                    "guest connection missing during final park operation",
-                                ))
-                            })?;
-                    let (result, fence) = guest
-                        .exec_operation_capture_with_fence(final_exec_request)
-                        .await
-                        .map_err(|error| match error {
-                            FencedExecError::FenceRejected(error) => {
-                                ParkNormalOperationFenceError::Rejected(error)
-                            }
-                            FencedExecError::Operation(error) => {
-                                ParkNormalOperationFenceError::FinalOperation(error)
-                            }
-                        })?;
-                    let result = exec_result_from_operation_result(result)
-                        .map_err(ParkNormalOperationFenceError::FinalOperation)?;
-                    Ok((fence, result))
-                },
-                || async move {
-                    let guest = guest.lock().await.as_ref().cloned().ok_or_else(|| {
-                        io::Error::new(
-                            io::ErrorKind::NotConnected,
-                            "guest connection missing during park quiesce",
-                        )
-                    })?;
-                    guest.quiesce_operations(GUEST_PARK_LIFECYCLE_TIMEOUT).await
-                },
-                || {
-                    park_inner(
-                        &mut self.is_parked,
-                        self.config.resources.memory_mb,
-                        self.runtime.balloon_mut(),
-                        &api_sock,
-                        &id,
-                    )
-                },
-            )
-            .await?;
-        self.park_fence = Some(normal_operations_fence);
-        self.park_outcome = Some(park_outcome);
-        Ok(SandboxFinalExecParkOutcome {
-            exec_result,
-            park_outcome,
-        })
+    async fn final_exec_and_park_with_observer(
+        &mut self,
+        request: &ExecRequest<'_>,
+        diagnostic_label: &'static str,
+        observer: &mut dyn SandboxFinalExecParkObserver,
+    ) -> sandbox::Result<SandboxFinalExecParkOutcome> {
+        self.final_exec_and_park_with_optional_observer(request, diagnostic_label, Some(observer))
+            .await
     }
 
     async fn unpark(&mut self) -> sandbox::Result<()> {
@@ -2651,6 +2691,45 @@ where
     P: FnOnce() -> PF,
     PF: Future<Output = sandbox::Result<Outcome>>,
 {
+    park_with_ready_for_park_and_preparation_with_observer(
+        log_id,
+        coordinator,
+        None,
+        fence_and_prepare,
+        quiesce_guest,
+        park_firecracker,
+    )
+    .await
+}
+
+async fn park_with_ready_for_park_and_preparation_with_observer<
+    Fence,
+    Outcome,
+    Preparation,
+    F,
+    FF,
+    Q,
+    QF,
+    P,
+    PF,
+>(
+    log_id: &str,
+    coordinator: &ParkCoordinator,
+    observer: Option<&mut dyn SandboxFinalExecParkObserver>,
+    fence_and_prepare: F,
+    quiesce_guest: Q,
+    park_firecracker: P,
+) -> sandbox::Result<(Fence, Outcome, Preparation)>
+where
+    F: FnOnce() -> FF,
+    FF: Future<Output = Result<(Fence, Preparation), ParkNormalOperationFenceError>>,
+    Q: FnOnce() -> QF,
+    QF: Future<Output = io::Result<()>>,
+    P: FnOnce() -> PF,
+    PF: Future<Output = sandbox::Result<Outcome>>,
+{
+    let mut timing = SandboxFinalExecParkTiming::new(observer);
+    let preparation_started = Instant::now();
     info!(
         id = %log_id,
         transition = "park",
@@ -2679,6 +2758,11 @@ where
                 error = %error_message,
                 "sandbox park lifecycle prepare rejected"
             );
+            timing.record(
+                SandboxFinalExecParkStage::ReusePreparation,
+                preparation_started,
+                false,
+            );
             return Err(prepare_park_error(SandboxIdleTransition::Park, error));
         }
     };
@@ -2703,6 +2787,11 @@ where
                 reason_kind = "busy",
                 "sandbox park lifecycle normal-operation fence rejected"
             );
+            timing.record(
+                SandboxFinalExecParkStage::ReusePreparation,
+                preparation_started,
+                false,
+            );
             return Err(idle_transition_error(
                 SandboxIdleTransition::Park,
                 "normal operations busy while preparing park",
@@ -2722,6 +2811,11 @@ where
                 "sandbox park lifecycle normal-operation fence failed"
             );
             guard.mark_dirty(message.clone());
+            timing.record(
+                SandboxFinalExecParkStage::ReusePreparation,
+                preparation_started,
+                false,
+            );
             return Err(idle_transition_error(SandboxIdleTransition::Park, message));
         }
         Err(ParkNormalOperationFenceError::GuestUnavailable(error)) => {
@@ -2735,6 +2829,11 @@ where
                 "sandbox park lifecycle normal-operation fence failed"
             );
             guard.mark_dirty(message.clone());
+            timing.record(
+                SandboxFinalExecParkStage::ReusePreparation,
+                preparation_started,
+                false,
+            );
             return Err(idle_transition_error(SandboxIdleTransition::Park, message));
         }
         Err(ParkNormalOperationFenceError::FinalOperation(error)) => {
@@ -2748,6 +2847,11 @@ where
                 "sandbox park lifecycle final guest operation failed"
             );
             guard.mark_dirty(message.clone());
+            timing.record(
+                SandboxFinalExecParkStage::ReusePreparation,
+                preparation_started,
+                false,
+            );
             return Err(idle_transition_error(SandboxIdleTransition::Park, message));
         }
     };
@@ -2770,6 +2874,11 @@ where
             "sandbox park lifecycle guest quiesce failed"
         );
         guard.mark_dirty(message.clone());
+        timing.record(
+            SandboxFinalExecParkStage::ReusePreparation,
+            preparation_started,
+            false,
+        );
         return Err(idle_transition_error(SandboxIdleTransition::Park, message));
     }
 
@@ -2789,17 +2898,35 @@ where
             "sandbox park lifecycle failed to enter ReadyForPark"
         );
         guard.mark_dirty(message.clone());
+        timing.record(
+            SandboxFinalExecParkStage::ReusePreparation,
+            preparation_started,
+            false,
+        );
         return Err(idle_transition_error(SandboxIdleTransition::Park, message));
     }
 
+    timing.record(
+        SandboxFinalExecParkStage::ReusePreparation,
+        preparation_started,
+        true,
+    );
     info!(
         id = %log_id,
         transition = "park",
         phase = "ready_for_park",
         "sandbox park lifecycle ReadyForPark reached"
     );
+    let physical_park_started = Instant::now();
     let outcome = match park_firecracker().await {
-        Ok(outcome) => outcome,
+        Ok(outcome) => {
+            timing.record(
+                SandboxFinalExecParkStage::PhysicalPark,
+                physical_park_started,
+                true,
+            );
+            outcome
+        }
         Err(error) => {
             warn!(
                 id = %log_id,
@@ -2812,6 +2939,11 @@ where
             guard.mark_dirty(format!(
                 "Firecracker park failed after ReadyForPark: {error}"
             ));
+            timing.record(
+                SandboxFinalExecParkStage::PhysicalPark,
+                physical_park_started,
+                false,
+            );
             return Err(error);
         }
     };

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -17,6 +17,22 @@ use vsock_proto::{
 
 struct TestNormalOperationFence;
 
+#[derive(Default)]
+struct RecordingFinalExecParkObserver {
+    records: Vec<(SandboxFinalExecParkStage, bool)>,
+}
+
+impl SandboxFinalExecParkObserver for RecordingFinalExecParkObserver {
+    fn record_stage(
+        &mut self,
+        stage: SandboxFinalExecParkStage,
+        _duration: Duration,
+        success: bool,
+    ) {
+        self.records.push((stage, success));
+    }
+}
+
 async fn park_with_ready_for_park<Q, QF, P, PF>(
     log_id: &str,
     coordinator: &ParkCoordinator,
@@ -967,6 +983,87 @@ async fn final_preparation_transport_failure_marks_dirty_without_quiesce_or_paus
         coordinator.state(),
         CoordinatorState::Dirty { .. }
     ));
+}
+
+#[tokio::test]
+async fn final_exec_park_observer_reports_completed_stages_in_order() {
+    let coordinator = ParkCoordinator::new();
+    let mut observer = RecordingFinalExecParkObserver::default();
+
+    super::park_with_ready_for_park_and_preparation_with_observer(
+        "test-sandbox",
+        &coordinator,
+        Some(&mut observer),
+        || async { Ok((TestNormalOperationFence, "prepared")) },
+        || async { Ok(()) },
+        || async { Ok(SandboxParkOutcome::Reusable) },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        observer.records,
+        vec![
+            (SandboxFinalExecParkStage::ReusePreparation, true),
+            (SandboxFinalExecParkStage::PhysicalPark, true),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn final_exec_park_observer_reports_preparation_failure_only() {
+    let coordinator = ParkCoordinator::new();
+    let mut observer = RecordingFinalExecParkObserver::default();
+
+    let result = super::park_with_ready_for_park_and_preparation_with_observer(
+        "test-sandbox",
+        &coordinator,
+        Some(&mut observer),
+        || async {
+            Err::<(TestNormalOperationFence, ()), _>(ParkNormalOperationFenceError::FinalOperation(
+                io::Error::new(io::ErrorKind::ConnectionReset, "final exec disconnected"),
+            ))
+        },
+        || async { Ok(()) },
+        || async { Ok(SandboxParkOutcome::Reusable) },
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert_eq!(
+        observer.records,
+        vec![(SandboxFinalExecParkStage::ReusePreparation, false)]
+    );
+}
+
+#[tokio::test]
+async fn final_exec_park_observer_reports_physical_park_failure() {
+    let coordinator = ParkCoordinator::new();
+    let mut observer = RecordingFinalExecParkObserver::default();
+
+    let result = super::park_with_ready_for_park_and_preparation_with_observer(
+        "test-sandbox",
+        &coordinator,
+        Some(&mut observer),
+        || async { Ok((TestNormalOperationFence, ())) },
+        || async { Ok(()) },
+        || async {
+            Err::<SandboxParkOutcome, _>(idle_transition_error(
+                SandboxIdleTransition::Park,
+                "physical park failed",
+            ))
+        },
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert_eq!(
+        observer.records,
+        vec![
+            (SandboxFinalExecParkStage::ReusePreparation, true),
+            (SandboxFinalExecParkStage::PhysicalPark, false),
+        ]
+    );
 }
 
 #[tokio::test]

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use ::sandbox::*;
 use async_trait::async_trait;
@@ -357,6 +357,59 @@ impl Sandbox for MockSandbox {
             .exec_with_diagnostic_label(request, diagnostic_label)
             .await?;
         let park_outcome = self.park().await?;
+        Ok(SandboxFinalExecParkOutcome {
+            exec_result,
+            park_outcome,
+        })
+    }
+
+    async fn final_exec_and_park_with_observer(
+        &mut self,
+        request: &ExecRequest<'_>,
+        diagnostic_label: &'static str,
+        observer: &mut dyn SandboxFinalExecParkObserver,
+    ) -> Result<SandboxFinalExecParkOutcome> {
+        let preparation_started = Instant::now();
+        let exec_result = match self
+            .exec_with_diagnostic_label(request, diagnostic_label)
+            .await
+        {
+            Ok(exec_result) => {
+                observer.record_stage(
+                    SandboxFinalExecParkStage::ReusePreparation,
+                    preparation_started.elapsed(),
+                    true,
+                );
+                exec_result
+            }
+            Err(error) => {
+                observer.record_stage(
+                    SandboxFinalExecParkStage::ReusePreparation,
+                    preparation_started.elapsed(),
+                    false,
+                );
+                return Err(error);
+            }
+        };
+        let physical_park_started = Instant::now();
+        let park_outcome = match self.park().await {
+            Ok(park_outcome) => {
+                observer.record_stage(
+                    SandboxFinalExecParkStage::PhysicalPark,
+                    physical_park_started.elapsed(),
+                    true,
+                );
+                park_outcome
+            }
+            Err(error) => {
+                observer.record_stage(
+                    SandboxFinalExecParkStage::PhysicalPark,
+                    physical_park_started.elapsed(),
+                    false,
+                );
+                return Err(error);
+            }
+        };
         Ok(SandboxFinalExecParkOutcome {
             exec_result,
             park_outcome,

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -45,8 +45,8 @@ pub use factory::{
 };
 pub use runtime::{RuntimeProvider, SandboxRuntime};
 pub use sandbox::{
-    Sandbox, SandboxFinalExecParkOutcome, SandboxParkNonReusableReason, SandboxParkOutcome,
-    SandboxStartObserver, SandboxStartStage,
+    Sandbox, SandboxFinalExecParkObserver, SandboxFinalExecParkOutcome, SandboxFinalExecParkStage,
+    SandboxParkNonReusableReason, SandboxParkOutcome, SandboxStartObserver, SandboxStartStage,
 };
 pub use snapshot::{
     PendingSnapshotPublish, SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider,

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -107,6 +107,27 @@ pub trait SandboxStartObserver: Send {
     fn record_stage(&mut self, stage: SandboxStartStage, duration: Duration, success: bool);
 }
 
+/// Fixed low-cardinality stages of the final reuse preparation and park path.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxFinalExecParkStage {
+    /// Fences normal operations, runs the final guest preparation, and reaches
+    /// the provider's safe pre-park boundary.
+    ReusePreparation,
+    /// Commits the provider-specific physical park after preparation succeeds.
+    PhysicalPark,
+}
+
+/// Receives optional final preparation and physical-park timing records.
+///
+/// Callbacks describe completed stages only and are informational: they never
+/// own lifecycle transitions, cleanup, or cancellation. A cancelled attempt
+/// can therefore omit the stage that was in progress. Implementations using
+/// the default observer-aware method report no stages.
+pub trait SandboxFinalExecParkObserver: Send {
+    /// Records one completed final-exec/park stage.
+    fn record_stage(&mut self, stage: SandboxFinalExecParkStage, duration: Duration, success: bool);
+}
+
 /// A process-isolation environment that runs guest workloads for the runner.
 ///
 /// Implementations are created by a [`SandboxFactory`](crate::SandboxFactory)
@@ -283,6 +304,20 @@ pub trait Sandbox: Send + Sync + Any {
             message: "final guest exec during park is not supported by this sandbox provider"
                 .to_string(),
         })
+    }
+
+    /// Run the final guest preparation and park while reporting provider stages.
+    ///
+    /// This has the same lifecycle and error contract as
+    /// [`final_exec_and_park`](Self::final_exec_and_park). The default method
+    /// preserves provider behavior and emits no callbacks.
+    async fn final_exec_and_park_with_observer(
+        &mut self,
+        request: &ExecRequest<'_>,
+        diagnostic_label: &'static str,
+        _observer: &mut dyn SandboxFinalExecParkObserver,
+    ) -> Result<SandboxFinalExecParkOutcome> {
+        self.final_exec_and_park(request, diagnostic_label).await
     }
 
     /// Transition the sandbox back to the active state.

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -123,6 +123,10 @@ pub enum SandboxFinalExecParkStage {
 /// own lifecycle transitions, cleanup, or cancellation. A cancelled attempt
 /// can therefore omit the stage that was in progress. Implementations using
 /// the default observer-aware method report no stages.
+///
+/// An overriding implementation reports each applicable stage at most once.
+/// `PhysicalPark` is reported only after a successful `ReusePreparation`;
+/// either failed stage ends the sequence.
 pub trait SandboxFinalExecParkObserver: Send {
     /// Records one completed final-exec/park stage.
     fn record_stage(&mut self, stage: SandboxFinalExecParkStage, duration: Duration, success: bool);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3945,16 +3945,19 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(runnerPreference(sourcePoll.body.job)).toStrictEqual(
       finalizingPreference,
     );
-    expect(
-      sandboxOperationEventsForRunByAction(
-        successor.runId,
-        "runner_notification_affinity_lookup",
-      ),
-    ).toContainEqual(
-      expect.objectContaining({
-        runner_preference_resolution: "finalizing_predecessor",
-      }),
-    );
+    for (const actionType of [
+      "runner_notification_affinity_lookup",
+      "runner_poll_pending_job_lookup",
+    ]) {
+      expect(
+        sandboxOperationEventsForRunByAction(successor.runId, actionType),
+      ).toContainEqual(
+        expect.objectContaining({
+          runner_preference_resolution: "finalizing_predecessor",
+          history_generation_run_id: first.runId,
+        }),
+      );
+    }
 
     mockNow(sourceCompletedAt + 1601);
     const genericPoll = await api.requestPollRunner(
@@ -4370,9 +4373,18 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           notification_target: "broadcast",
           runner_preference_resolution: "exact_history_generation",
           reuse_key_kind: "thread",
+          history_generation_run_id: first.runId,
         }),
       );
     }
+    expect(
+      sandboxOperationEventsForRunByAction(
+        protectedFollowUp.runId,
+        "api_to_claim_request",
+      ),
+    ).toContainEqual(
+      expect.objectContaining({ history_generation_run_id: first.runId }),
+    );
     await api.requestCancelRun(actor, protectedFollowUp.runId, [200]);
     await webhooks.requestAgentComplete(
       {
@@ -5134,7 +5146,14 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
           reuse_key_kind: "none",
         }),
       );
+      expect(events[0]).not.toHaveProperty("history_generation_run_id");
     }
+    expect(
+      sandboxOperationEventsForRunByAction(
+        third.runId,
+        "api_to_claim_request",
+      )[0],
+    ).not.toHaveProperty("history_generation_run_id");
     await expect(readFakeKmsDecryptCallCount(context)).resolves.toBe(
       decryptCountBeforeClaim,
     );

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -77,6 +77,7 @@ import {
 import { generateSandboxToken } from "../auth/tokens";
 import { decryptPersistentSecretsMap } from "../services/crypto.utils";
 import { dispatchCompleteSideEffects$ } from "../services/agent-webhook-complete.service";
+import { historyGenerationRunIdForStoredExecutionContext } from "../services/agent-run-queue-payload.service";
 import { loadConnectorRuntimeSnapshot } from "../services/connector-catalog-runtime.service";
 import { loadConnectorRunnerFirewallCatalog } from "../services/connector-runner-firewall-catalog.service";
 import {
@@ -530,6 +531,7 @@ function recordPollTimingMetrics(args: {
   readonly pollReason: string | undefined;
   readonly runnerPreferenceResolution: RunnerPreferenceResolutionOutcome;
   readonly reuseKeyKind: "thread" | "session" | "none";
+  readonly historyGenerationRunId: string | undefined;
   readonly queueCreatedAtMs: number;
   readonly pollRequestStartedAtMs: number;
   readonly pendingJobLookupStartedAtMs: number;
@@ -545,6 +547,9 @@ function recordPollTimingMetrics(args: {
   };
   if (args.pollReason) {
     dimensions.poll_reason = args.pollReason;
+  }
+  if (args.historyGenerationRunId) {
+    dimensions.history_generation_run_id = args.historyGenerationRunId;
   }
 
   recordSandboxOperations([
@@ -723,6 +728,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     pollReason: body.data.telemetry?.pollReason,
     runnerPreferenceResolution: reusePreference.outcome,
     reuseKeyKind: runnerReuseKeyTelemetryKind(pendingJob.reuseKey),
+    historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
     queueCreatedAtMs: pendingJob.createdAt.getTime(),
     pollRequestStartedAtMs,
     pendingJobLookupStartedAtMs,
@@ -1920,6 +1926,9 @@ function scheduleSuccessfulClaimSideEffects(args: {
     pollDueToJobDiscoveredMs: args.telemetry?.pollDueToJobDiscoveredMs,
     pollHttpRequestMs: args.telemetry?.pollHttpRequestMs,
     pollReason: args.telemetry?.pollReason,
+    historyGenerationRunId: historyGenerationRunIdForStoredExecutionContext(
+      args.storedContext,
+    ),
     claimRouteTiming: args.claimRouteTiming,
   });
 }
@@ -1945,6 +1954,7 @@ function scheduleClaimSucceededSideEffects(args: {
   readonly pollDueToJobDiscoveredMs: number | undefined;
   readonly pollHttpRequestMs: number | undefined;
   readonly pollReason: string | undefined;
+  readonly historyGenerationRunId: string | undefined;
   readonly claimRouteTiming: ClaimRouteTimingCollector;
 }): void {
   waitUntil(
@@ -1980,6 +1990,7 @@ interface ClaimTimingMetricArgs {
   readonly pollDueToJobDiscoveredMs: number | undefined;
   readonly pollHttpRequestMs: number | undefined;
   readonly pollReason: string | undefined;
+  readonly historyGenerationRunId: string | undefined;
   readonly claimRouteTiming: ClaimRouteTimingCollector;
 }
 
@@ -2073,6 +2084,9 @@ function claimTimingDimensions(
   }
   if (args.pollReason) {
     dimensions.poll_reason = args.pollReason;
+  }
+  if (args.historyGenerationRunId) {
+    dimensions.history_generation_run_id = args.historyGenerationRunId;
   }
   return dimensions;
 }

--- a/turbo/apps/api/src/signals/services/agent-run-queue-payload.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-queue-payload.service.ts
@@ -41,7 +41,7 @@ interface CompatibleQueuedRunnerJobPayload extends Omit<
   readonly executionContext: CompatibleStoredExecutionContext;
 }
 
-function historyGenerationRunId(
+export function historyGenerationRunIdForStoredExecutionContext(
   executionContext: Pick<StoredExecutionContext, "resumeSession">,
 ): string | undefined {
   const resumeSession = executionContext.resumeSession;
@@ -95,7 +95,7 @@ export async function decryptQueuedRunnerJobPayload(
     profile: wirePayload.profile,
     cliAgentSessionId: wirePayload.sessionId,
     reuseKey: wirePayload.reuseKey ?? null,
-    historyGenerationRunId: historyGenerationRunId(
+    historyGenerationRunId: historyGenerationRunIdForStoredExecutionContext(
       wirePayload.executionContext,
     ),
     executionContext: wirePayload.executionContext,
@@ -115,7 +115,9 @@ export function queuedRunnerJobPayload(args: {
     profile: args.profile,
     cliAgentSessionId: args.cliAgentSessionId,
     reuseKey: args.reuseKey,
-    historyGenerationRunId: historyGenerationRunId(args.executionContext),
+    historyGenerationRunId: historyGenerationRunIdForStoredExecutionContext(
+      args.executionContext,
+    ),
     executionContext: args.executionContext,
   };
 }

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -66,13 +66,16 @@ export async function notifyRunnerJob(
   );
   const publishFinishedAt = now();
 
-  const dimensions = {
+  const dimensions: Record<string, string> = {
     runner_group: args.runnerGroup,
     profile: args.profile,
     notification_target: "broadcast",
     runner_preference_resolution: reusePreference.outcome,
     reuse_key_kind: runnerReuseKeyTelemetryKind(args.reuseKey),
   };
+  if (args.historyGenerationRunId) {
+    dimensions.history_generation_run_id = args.historyGenerationRunId;
+  }
   // Queue-relative actions are cumulative boundaries. Preference lookup and
   // publish durations are nested children and must not be added to them.
   recordSandboxOperations([


### PR DESCRIPTION
## Summary

- emit production-ingested, bounded observations for selected `finalizingPredecessor` candidate receipt, retention, expiry, cancellation, mismatch, claim loss, and claim success
- expose behavior-neutral reuse-preparation and physical-park stage callbacks, then record predecessor finalization and idle-publication timing through existing job telemetry
- add the already-known history-generation run ID to API notification, poll, and claim telemetry dimensions for exact predecessor/successor correlation

## Scope

- measurement only: no execution protocol, queue payload, database, timeout, admission, claim, sandbox lifecycle, or resource-ownership behavior changes
- ordinary runner INFO logs remain excluded from Axiom; only one exact low-volume measurement target is allowlisted through the existing bounded non-blocking dispatcher
- existing finalization, claim, reuse, and unpark action names remain authoritative and unchanged
- #24891 remains open after merge for the production measurement report and the go/no-go decision for #24873

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-targets --all-features -- -D warnings`
- `cd crates && cargo doc -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-features --no-deps`
- `cd crates && cargo test -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-features`
- `cd turbo && pnpm exec prettier --check apps/api/src/signals/routes/runners.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts apps/api/src/signals/services/agent-run-queue-payload.service.ts apps/api/src/signals/services/runner-dispatch.service.ts`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `cd turbo && pnpm knip --workspace api`
- pre-commit hooks: full Turbo Knip/type checking plus Rust format, docs, and Clippy

Relates to #24891

Parent context: #24873
