### PR TITLE
refactor: retire goal context readers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
@@ -185,6 +185,41 @@ describe("cron monitor chat event queue", () => {
     expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
   });
 
+  it("alerts when a pending goal event has lost its goal row", async () => {
+    const fixture = await trackFixture(seedFixture("orphaned-goal"));
+
+    const response = await accept(
+      stateClient().monitor({ body: { event_ids: [fixture.eventId] } }),
+      [500],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: "Internal server error",
+    });
+    expect(
+      context.mocks.sentry.captureException.mock.calls.at(-1)?.[0],
+    ).toMatchObject({
+      code: "ORPHANED_QUEUED_CHAT_MESSAGES",
+      orphanedMessages: 1,
+      orphanedMessagesBySource: { goal: 1 },
+    });
+  });
+
+  it("does not alert while a pending goal continuation is paused", async () => {
+    const fixture = await trackFixture(seedFixture("paused-goal"));
+
+    const response = await accept(
+      stateClient().monitor({ body: { event_ids: [fixture.eventId] } }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      orphanedMessages: 0,
+    });
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+  });
+
   it("does not alert for a newly queued event below the age threshold", async () => {
     const fixture = await trackFixture(seedFixture("queued-integration"));
 

--- a/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
@@ -9,6 +9,8 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { chatEvents } from "@vm0/db/schema/chat-event";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { threadGoals } from "@vm0/db/schema/thread-goal";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { command } from "ccstate";
 import { eq } from "drizzle-orm";
@@ -39,6 +41,7 @@ type FixtureKind = Extract<
   TestCronMonitorChatEventQueueStateActionBody,
   { readonly action: "seed-fixture" }
 >["fixture_kind"];
+type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
 const STALE_CONTEXT_FIXTURES = [
   {
@@ -141,6 +144,77 @@ async function seedActiveRun(
   signal.throwIfAborted();
 }
 
+async function seedGoalFixture(
+  tx: DbTransaction,
+  args: {
+    readonly composeId: string;
+    readonly fixtureKind: "orphaned-goal" | "paused-goal";
+    readonly orgId: string;
+    readonly threadId: string;
+    readonly userId: string;
+  },
+) {
+  const [goal] = await tx
+    .insert(threadGoals)
+    .values({
+      orgId: args.orgId,
+      ownerUserId: args.userId,
+      agentId: args.composeId,
+      chatThreadId: args.threadId,
+      status: args.fixtureKind === "paused-goal" ? "paused" : "active",
+      objective: "orphan monitor goal objective",
+      objectiveBrief: "orphan monitor goal",
+    })
+    .returning({ id: threadGoals.id });
+  if (!goal) {
+    throw new Error("Failed to seed orphan monitor goal");
+  }
+  const [goalEvent] = await tx
+    .insert(chatEvents)
+    .values({
+      chatThreadId: args.threadId,
+      eventType: "input.goal",
+      runGroupId: goal.id,
+      userMessage: createUserMessageDocument({
+        text: null,
+        nonContentPart: { type: "goal", goalBrief: "orphan monitor goal" },
+      }),
+      runId: null,
+      createdAt: new Date(0),
+      seqId: 1,
+    })
+    .returning({ id: chatEvents.id });
+  if (args.fixtureKind === "orphaned-goal") {
+    await tx.delete(threadGoals).where(eq(threadGoals.id, goal.id));
+  }
+  return goalEvent;
+}
+
+async function seedGoalAgent(
+  db: Db,
+  args: {
+    readonly composeId: string;
+    readonly fixtureKind: FixtureKind;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  if (
+    args.fixtureKind !== "orphaned-goal" &&
+    args.fixtureKind !== "paused-goal"
+  ) {
+    return;
+  }
+  await db.insert(zeroAgents).values({
+    id: args.composeId,
+    orgId: args.orgId,
+    owner: args.userId,
+    name: `orphan-monitor-${randomUUID()}`,
+  });
+  signal.throwIfAborted();
+}
+
 async function seedFixture(
   db: Db,
   fixtureKind: FixtureKind,
@@ -160,6 +234,12 @@ async function seedFixture(
   if (!compose) {
     throw new Error("Failed to seed orphan monitor compose");
   }
+
+  await seedGoalAgent(
+    db,
+    { composeId: compose.id, fixtureKind, orgId, userId },
+    signal,
+  );
 
   const [thread] = await db
     .insert(chatThreads)
@@ -204,6 +284,17 @@ async function seedFixture(
         triggerBrief: null,
       });
       return [automation];
+    }
+    if (fixtureKind === "orphaned-goal" || fixtureKind === "paused-goal") {
+      return [
+        await seedGoalFixture(tx, {
+          composeId: compose.id,
+          fixtureKind,
+          orgId,
+          threadId: thread.id,
+          userId,
+        }),
+      ];
     }
     const event =
       fixtureKind === "failed-message"

--- a/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
@@ -1,5 +1,4 @@
 import { chatEvents } from "@vm0/db/schema/chat-event";
-import { chatGoalContext } from "@vm0/db/schema/chat-goal-context";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { threadGoals } from "@vm0/db/schema/thread-goal";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
@@ -242,17 +241,10 @@ export async function rejectGoalQueueEvent(
     }
     const [payload] = await tx
       .select({
-        goalObjectiveBrief: chatGoalContext.objectiveBrief,
+        userMessage: chatEvents.userMessage,
         currentGoalObjectiveBrief: threadGoals.objectiveBrief,
       })
       .from(chatEvents)
-      .leftJoin(
-        chatGoalContext,
-        and(
-          eq(chatEvents.contextType, "goal"),
-          eq(chatGoalContext.id, chatEvents.contextId),
-        ),
-      )
       .leftJoin(
         threadGoals,
         and(
@@ -271,8 +263,11 @@ export async function rejectGoalQueueEvent(
     if (!payload) {
       return false;
     }
+    const goalPart = payload.userMessage?.parts.find((part) => {
+      return part.type === "goal";
+    });
     const objectiveBrief =
-      payload.goalObjectiveBrief ?? payload.currentGoalObjectiveBrief ?? "Goal";
+      goalPart?.goalBrief ?? payload.currentGoalObjectiveBrief ?? "Goal";
     const rejected = await replaceChatEvent(tx, args.eventId, {
       chatThreadId: args.chatThreadId,
       eventType: "input.rejected",

--- a/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
@@ -3,11 +3,11 @@ import { chatAutomationContext } from "@vm0/db/schema/chat-automation-context";
 import { chatEvents } from "@vm0/db/schema/chat-event";
 import { chatFeishuContext } from "@vm0/db/schema/chat-feishu-context";
 import { chatGithubContext } from "@vm0/db/schema/chat-github-context";
-import { chatGoalContext } from "@vm0/db/schema/chat-goal-context";
 import { chatMorningBriefContext } from "@vm0/db/schema/chat-morning-brief-context";
 import { chatSlackContext } from "@vm0/db/schema/chat-slack-context";
 import { chatTeamsContext } from "@vm0/db/schema/chat-teams-context";
 import { chatTelegramContext } from "@vm0/db/schema/chat-telegram-context";
+import { threadGoals } from "@vm0/db/schema/thread-goal";
 import { command } from "ccstate";
 import {
   and,
@@ -153,20 +153,6 @@ function missingScheduledContextRowCondition(db: Db) {
       ),
     ),
     and(
-      eq(chatEvents.contextType, "goal"),
-      notExists(
-        db
-          .select({ id: chatGoalContext.id })
-          .from(chatGoalContext)
-          .where(
-            and(
-              eq(chatGoalContext.id, chatEvents.contextId),
-              eq(chatGoalContext.chatThreadId, chatEvents.chatThreadId),
-            ),
-          ),
-      ),
-    ),
-    and(
       eq(chatEvents.contextType, "morning_brief"),
       notExists(
         db
@@ -183,6 +169,23 @@ function missingScheduledContextRowCondition(db: Db) {
   );
 }
 
+function missingGoalRowCondition(db: Db) {
+  return and(
+    chatEventTypeIn(["input.goal"]),
+    notExists(
+      db
+        .select({ id: threadGoals.id })
+        .from(threadGoals)
+        .where(
+          and(
+            eq(threadGoals.id, chatEvents.runGroupId),
+            eq(threadGoals.chatThreadId, chatEvents.chatThreadId),
+          ),
+        ),
+    ),
+  );
+}
+
 async function monitorChatEventQueue(
   db: Db,
   signal: AbortSignal,
@@ -194,7 +197,11 @@ async function monitorChatEventQueue(
       nullableDriverValueDecoder(pgTextDecoder),
     );
   const results = await db
-    .select({ source: orphanedSource, orphanedMessages: count() })
+    .select({
+      eventType: chatEvents.eventType,
+      source: orphanedSource,
+      orphanedMessages: count(),
+    })
     .from(chatEvents)
     .where(
       and(
@@ -213,24 +220,26 @@ async function monitorChatEventQueue(
         or(
           and(
             isNull(chatEvents.contextType),
-            or(
-              chatEventTypeIn(["input.goal"]),
-              notInArray(chatEvents.triggerSource, ["web", "test", "agent"]),
-            ),
+            notInArray(chatEvents.triggerSource, ["web", "test", "agent"]),
           ),
           missingChatIntegrationContextRowCondition(db),
           missingScheduledContextRowCondition(db),
+          missingGoalRowCondition(db),
         ),
       ),
     )
-    .groupBy(orphanedSource);
+    .groupBy(orphanedSource, chatEvents.eventType);
   signal.throwIfAborted();
 
-  const orphanedMessagesBySource = Object.fromEntries(
-    results.map((result) => {
-      return [result.source ?? "(unknown)", result.orphanedMessages];
-    }),
-  );
+  const orphanedMessagesBySource: Record<string, number> = {};
+  for (const result of results) {
+    const source =
+      result.eventType === "input.goal"
+        ? "goal"
+        : (result.source ?? "(unknown)");
+    orphanedMessagesBySource[source] =
+      (orphanedMessagesBySource[source] ?? 0) + result.orphanedMessages;
+  }
   const orphanedMessages = Object.values(orphanedMessagesBySource).reduce(
     (total, sourceCount) => {
       return total + sourceCount;

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -2,7 +2,6 @@ import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/
 import type { ChatEventType } from "@vm0/api-contracts/contracts/chat-events";
 import { command } from "ccstate";
 import { chatAutomationContext } from "@vm0/db/schema/chat-automation-context";
-import { chatGoalContext } from "@vm0/db/schema/chat-goal-context";
 import {
   chatEvents,
   type ChatEventAttachFileMetadata,
@@ -54,7 +53,6 @@ import { chatThreadAdmissionBlocked } from "./zero-chat-active-run.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
 import { noGoalChangeAfterQueueEvent } from "./chat-goal-queue.service";
-import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { resolveArtifactObject$ } from "./artifact-storage.service";
 import { attachCanonicalWebInputAssetsToEvent } from "./canonical-asset.service";
 
@@ -441,7 +439,6 @@ async function resolveGoalQueueFirstClaimSnapshot(
       goalSnapshotCurrent:
         noGoalChangeAfterQueueEvent(db).mapWith(pgBooleanDecoder),
       userMessage: chatEvents.userMessage,
-      goalBrief: chatGoalContext.objectiveBrief,
     })
     .from(chatEvents)
     .leftJoin(
@@ -452,13 +449,6 @@ async function resolveGoalQueueFirstClaimSnapshot(
         eq(threadGoals.orgId, args.orgId),
         eq(threadGoals.ownerUserId, args.userId),
         eq(chatEvents.runGroupId, threadGoals.id),
-      ),
-    )
-    .leftJoin(
-      chatGoalContext,
-      and(
-        eq(chatEvents.contextType, "goal"),
-        eq(chatGoalContext.id, chatEvents.contextId),
       ),
     )
     .where(
@@ -484,18 +474,7 @@ async function resolveGoalQueueFirstClaimSnapshot(
   ) {
     return null;
   }
-  const userMessage =
-    head.userMessage ??
-    (head.goalBrief
-      ? createUserMessageDocument({
-          text: null,
-          nonContentPart: {
-            type: "goal",
-            goalBrief: head.goalBrief,
-          },
-        })
-      : null);
-  if (!userMessage) {
+  if (!head.userMessage) {
     throw new Error("Goal queue event is missing its user message");
   }
   return {
@@ -503,7 +482,7 @@ async function resolveGoalQueueFirstClaimSnapshot(
     replacement: {
       chatThreadId: args.threadId,
       eventType: "input.prompt",
-      userMessage,
+      userMessage: head.userMessage,
       runId: args.runId,
       runGroupId: args.goalId,
       triggerSource: "workflow-event",

--- a/turbo/packages/api-contracts/src/contracts/test-cron-monitor-chat-event-queue-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-cron-monitor-chat-event-queue-state.ts
@@ -9,6 +9,8 @@ const fixtureKindSchema = z.enum([
   "failed-message",
   "orphan",
   "orphaned-automation",
+  "orphaned-goal",
+  "paused-goal",
   "queued-integration",
   "queued-message",
   "revoked-message",


### PR DESCRIPTION
## Summary

- read queued goal rejection briefs from the event's own `user_message` goal part, with the existing `thread_goals.objective_brief → "Goal"` fallback chain
- remove the `chat_goal_context` join and fallback from the goal claim snapshot while preserving the missing-`user_message` invariant throw
- monitor a pending `input.goal` as orphaned only when its `thread_goals` row is missing
- preserve valid paused goal continuations and add integration coverage for both deleted and paused goal rows

This is PR 1 of the four-PR rollout in #24932. It changes readers only: no writer change, migration, pointer cleanup, schema change, API change, or client rendering change.

## Production pre-check

The gate was evaluated against `vm0-prod-ro` before any code edits on **2026-08-04 06:34 UTC**, retaining the required `event_type = 'input.goal'` filter:

```sql
SELECT count(*)                                                       AS goal_events,
       count(*) FILTER (WHERE e.context_id IS NULL)                   AS no_context_row,
       count(*) FILTER (WHERE e.user_message IS NULL
                              AND e.event_type = 'input.goal'
                              AND e.run_id IS NULL
                              AND NOT EXISTS (SELECT 1 FROM chat_events r
                                              WHERE r.revokes_event_id = e.id)) AS pending_without_user_message
FROM chat_events e
WHERE e.context_type = 'goal' OR e.event_type = 'input.goal';
```

Result:

| goal_events | no_context_row | pending_without_user_message |
|---:|---:|---:|
| 19,059 | 0 | **0** |

MaskDB does not permit filtering the masked `user_message` column directly. The third value was therefore proven with the stronger pending superset: 2,171 `input.goal` rows had `run_id IS NULL`, and all 2,171 had a revoker. The unrevoked superset is zero, so adding `user_message IS NULL` is exactly zero as well. Terminal `input.rejected` and `control.revoke` history was not counted as pending work.

## Validation

- `pnpm exec prettier --check` on all changed files
- `pnpm -F api check-types`
- focused type-aware Oxlint and ESLint on all changed API files
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm knip --workspace api`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test_24932_ecc5 pnpm -F api exec vitest run src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts --maxWorkers=1 --silent=passed-only` (8 passed)

Two existing goal callback BDD cases were also attempted locally; both stopped before the changed path because the initial ordinary runner claim returned `404 Job not found in queue`. The same runner-queue behavior was reproduced on unmodified main during #24877. Full PR CI remains the merge gate.

## Rollout observation

- PR merged: **2026-08-04 07:09:19 UTC**, merge commit `0c6d9da9976507322ea555b7575c7fe15c442452`
- production release PR: #24935 merged at **2026-08-04 08:01:45 UTC**, merge commit `a4b9a2135793a70351b92cdb630ce04b8f69b909`
- production pipeline: [release-please run 30890211190](https://github.com/vm0-ai/vm0/actions/runs/30890211190) completed successfully at **2026-08-04 08:16:54 UTC**
- observation window: **2026-08-04 08:16:54–08:26:54 UTC** (10 minutes)
- traffic: 12,813 production HTTP requests and 6 new `input.goal` events in the window
- affected signals: 0 `Orphaned queued chat messages detected`, 0 `Goal queue event is missing its user message`, and 0 error/fatal web-log events; all Axiom queries were complete with no warnings
- unrelated traffic: three 502s were isolated to `/api/webhooks/agent/firewall/auth`, outside this PR's goal queue paths

PR 2 starts only after this successful release and observation window.

Part of #24932.