### PR TITLE
perf(sandbox-fc): stream raw exec responses

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2829,7 +2829,6 @@ name = "sandbox-fc"
 version = "0.37.175"
 dependencies = [
  "async-trait",
- "base64 0.23.0",
  "clap",
  "futures-util",
  "guest-contracts",

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-base64.workspace = true
 futures-util.workspace = true
 guest-contracts.workspace = true
 nbd-cow.workspace = true

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -6,17 +6,21 @@
 //!
 //! ## Wire format
 //!
-//! Length-prefixed JSON frames: `[4-byte big-endian length][JSON payload]`.
+//! Length-prefixed frames: `[4-byte big-endian length][payload]`. Requests and
+//! legacy responses use JSON. Negotiated exec responses use a versioned binary
+//! payload so captured stdout and stderr can be transferred without base64.
 //! One request per connection, one response per connection.
 //!
 //! Exec request payloads are [`ExecRequest`]. Termination request payloads are
-//! [`TerminateRequest`]. Responses are serialized as untagged JSON objects.
+//! [`TerminateRequest`]. Public legacy responses are serialized as untagged
+//! JSON objects.
 //!
 //! Termination clients send `{"action":"terminate"}`. A status response is
 //! shaped like `{"status":"accepted"}`; an error response is shaped like
 //! `{"error":"..."}`.
 
 mod client;
+mod exec_response;
 mod protocol;
 mod provider;
 mod resolver;

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -11,9 +11,10 @@
 //! payload so captured stdout and stderr can be transferred without base64.
 //! One request per connection, one response per connection.
 //!
-//! Exec request payloads are [`ExecRequest`]. Termination request payloads are
-//! [`TerminateRequest`]. Public legacy responses are serialized as untagged
-//! JSON objects.
+//! Legacy exec request payloads are [`ExecRequest`]. A negotiated request adds
+//! a private response-format selector after a non-executing capability probe.
+//! Termination request payloads are [`TerminateRequest`]. Public legacy
+//! responses are serialized as untagged JSON objects.
 //!
 //! Termination clients send `{"action":"terminate"}`. A status response is
 //! shaped like `{"status":"accepted"}`; an error response is shaped like

--- a/crates/sandbox-fc/src/control.rs
+++ b/crates/sandbox-fc/src/control.rs
@@ -7,14 +7,9 @@
 //! ## Wire format
 //!
 //! Length-prefixed frames: `[4-byte big-endian length][payload]`. Requests and
-//! legacy responses use JSON. Negotiated exec responses use a versioned binary
+//! termination responses use JSON. Exec responses use a versioned binary
 //! payload so captured stdout and stderr can be transferred without base64.
 //! One request per connection, one response per connection.
-//!
-//! Legacy exec request payloads are [`ExecRequest`]. A negotiated request adds
-//! a private response-format selector after a non-executing capability probe.
-//! Termination request payloads are [`TerminateRequest`]. Public legacy
-//! responses are serialized as untagged JSON objects.
 //!
 //! Termination clients send `{"action":"terminate"}`. A status response is
 //! shaped like `{"status":"accepted"}`; an error response is shaped like
@@ -29,11 +24,8 @@ mod server;
 
 const CONTROL_SOCKET_OVERHEAD_MS: u64 = 5000;
 
-pub use client::{send_exec, send_terminate};
-pub use protocol::{
-    ExecRequest, ExecResponse, TerminateAction, TerminateRequest, TerminateResponse,
-    TerminateStatus,
-};
+pub use client::send_terminate;
+pub use protocol::{TerminateAction, TerminateRequest, TerminateResponse, TerminateStatus};
 pub use provider::FirecrackerControl;
 pub(crate) use server::{
     ControlServerHandle, ProcessTerminationHandle, ProcessTerminationRequest, bind_server,

--- a/crates/sandbox-fc/src/control/client.rs
+++ b/crates/sandbox-fc/src/control/client.rs
@@ -6,9 +6,16 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tokio::net::UnixStream;
 
+use super::exec_response::{ExecResult, RAW_EXEC_RESPONSE_VERSION, read_raw_exec_response};
 use super::protocol::{
-    ExecRequest, ExecResponse, TerminateRequest, TerminateResponse, read_frame, write_frame,
+    CapabilitiesAction, CapabilitiesRequest, CapabilitiesResponse, ExecRequest, ExecResponse,
+    RawExecRequest, TerminateRequest, TerminateResponse, read_frame, write_frame,
 };
+
+pub(super) enum ReceivedExecResponse {
+    Raw(ExecResult),
+    Legacy(ExecResponse),
+}
 
 /// Send an exec request to a control socket and return the wire response.
 ///
@@ -26,6 +33,35 @@ pub async fn send_exec(
     timeout: Duration,
 ) -> io::Result<ExecResponse> {
     send_control_request(sock_path, request, timeout).await
+}
+
+pub(super) async fn send_exec_result(
+    sock_path: &Path,
+    request: &ExecRequest,
+    timeout: Duration,
+) -> io::Result<ReceivedExecResponse> {
+    let deadline = deadline_after(timeout)?;
+    let capabilities: CapabilitiesResponse = send_control_request_until(
+        sock_path,
+        &CapabilitiesRequest {
+            action: CapabilitiesAction::Capabilities,
+        },
+        deadline,
+    )
+    .await?;
+
+    match capabilities {
+        CapabilitiesResponse::Supported {
+            exec_response_raw_version: RAW_EXEC_RESPONSE_VERSION,
+        } => send_raw_exec_request(sock_path, request, deadline)
+            .await
+            .map(ReceivedExecResponse::Raw),
+        CapabilitiesResponse::Supported { .. } | CapabilitiesResponse::Unsupported { .. } => {
+            send_control_request_until(sock_path, request, deadline)
+                .await
+                .map(ReceivedExecResponse::Legacy)
+        }
+    }
 }
 
 /// Send a host-side terminate request to a control socket.
@@ -47,24 +83,56 @@ where
     Response: DeserializeOwned,
 {
     let deadline = deadline_after(timeout)?;
+    send_control_request_until(sock_path, request, deadline).await
+}
 
-    let mut stream = tokio::time::timeout_at(deadline, UnixStream::connect(sock_path))
-        .await
-        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "connect timed out"))??;
-
-    let request_json = serde_json::to_vec(request)
-        .map_err(|e| io::Error::other(format!("serialize request: {e}")))?;
+async fn send_control_request_until<Request, Response>(
+    sock_path: &Path,
+    request: &Request,
+    deadline: tokio::time::Instant,
+) -> io::Result<Response>
+where
+    Request: Serialize,
+    Response: DeserializeOwned,
+{
+    let mut stream = connect_until(sock_path, deadline).await?;
+    let request_json = encode_json_request(request)?;
 
     tokio::time::timeout_at(deadline, async {
         write_frame(&mut stream, &request_json).await?;
         let frame = read_frame(&mut stream).await?;
-        let response: Response = serde_json::from_slice(&frame).map_err(|e| {
+        serde_json::from_slice(&frame).map_err(|e| {
             io::Error::new(io::ErrorKind::InvalidData, format!("invalid response: {e}"))
-        })?;
-        Ok(response)
+        })
     })
     .await
     .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "request timed out"))?
+}
+
+async fn send_raw_exec_request(
+    sock_path: &Path,
+    request: &ExecRequest,
+    deadline: tokio::time::Instant,
+) -> io::Result<ExecResult> {
+    let mut stream = connect_until(sock_path, deadline).await?;
+    let request_json = encode_json_request(&RawExecRequest::from(request))?;
+
+    tokio::time::timeout_at(deadline, async {
+        write_frame(&mut stream, &request_json).await?;
+        read_raw_exec_response(&mut stream).await
+    })
+    .await
+    .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "request timed out"))?
+}
+
+async fn connect_until(sock_path: &Path, deadline: tokio::time::Instant) -> io::Result<UnixStream> {
+    tokio::time::timeout_at(deadline, UnixStream::connect(sock_path))
+        .await
+        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "connect timed out"))?
+}
+
+fn encode_json_request(request: &impl Serialize) -> io::Result<Vec<u8>> {
+    serde_json::to_vec(request).map_err(|e| io::Error::other(format!("serialize request: {e}")))
 }
 
 fn deadline_after(timeout: Duration) -> io::Result<tokio::time::Instant> {
@@ -76,6 +144,11 @@ fn deadline_after(timeout: Duration) -> io::Result<tokio::time::Instant> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use sandbox::ExecTermination;
+    use tokio::net::UnixListener;
 
     #[tokio::test]
     async fn send_exec_missing_socket_returns_not_found() {
@@ -111,9 +184,76 @@ mod tests {
         assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
     }
 
+    #[tokio::test]
+    async fn negotiated_exec_falls_back_before_sending_command_to_legacy_server() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let server = tokio::spawn(async move {
+            let (mut probe_stream, _) = listener.accept().await.unwrap();
+            let probe_json = read_frame(&mut probe_stream).await.unwrap();
+            let probe: CapabilitiesRequest = serde_json::from_slice(&probe_json).unwrap();
+            assert_eq!(probe.action, CapabilitiesAction::Capabilities);
+            assert!(serde_json::from_slice::<ExecRequest>(&probe_json).is_err());
+            let unsupported = serde_json::to_vec(&ExecResponse::Error {
+                error: "invalid request: unknown field `action`".into(),
+            })
+            .unwrap();
+            write_frame(&mut probe_stream, &unsupported).await.unwrap();
+
+            let (mut exec_stream, _) = listener.accept().await.unwrap();
+            let exec_json = read_frame(&mut exec_stream).await.unwrap();
+            let json: serde_json::Value = serde_json::from_slice(&exec_json).unwrap();
+            assert!(json.get("response_format").is_none());
+            let exec: ExecRequest = serde_json::from_slice(&exec_json).unwrap();
+            assert_eq!(exec.command, "printf legacy");
+            let response = serde_json::to_vec(&ExecResponse::Success {
+                termination: ExecTermination::Exited { exit_code: 7 },
+                stdout: BASE64.encode(b"legacy out"),
+                stderr: BASE64.encode(b"legacy err"),
+                stdout_truncated: true,
+                stderr_truncated: false,
+                diagnostic: "legacy diagnostic".into(),
+            })
+            .unwrap();
+            write_frame(&mut exec_stream, &response).await.unwrap();
+        });
+
+        let response = send_exec_result(
+            &sock_path,
+            &ExecRequest {
+                expected_run_id: None,
+                command: "printf legacy".into(),
+                timeout_secs: 5,
+                sudo: false,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        let ReceivedExecResponse::Legacy(ExecResponse::Success {
+            termination,
+            stdout,
+            stderr,
+            stdout_truncated,
+            stderr_truncated,
+            diagnostic,
+        }) = response
+        else {
+            panic!("legacy server should return the legacy response shape");
+        };
+        assert_eq!(termination, ExecTermination::Exited { exit_code: 7 });
+        assert_eq!(BASE64.decode(stdout).unwrap(), b"legacy out");
+        assert_eq!(BASE64.decode(stderr).unwrap(), b"legacy err");
+        assert!(stdout_truncated);
+        assert!(!stderr_truncated);
+        assert_eq!(diagnostic, "legacy diagnostic");
+        server.await.unwrap();
+    }
+
     #[tokio::test(start_paused = true)]
     async fn send_exec_times_out_waiting_for_response() {
-        use tokio::net::UnixListener;
         use tokio::sync::oneshot;
 
         let dir = tempfile::tempdir().unwrap();

--- a/crates/sandbox-fc/src/control/client.rs
+++ b/crates/sandbox-fc/src/control/client.rs
@@ -67,12 +67,10 @@ fn deadline_after(timeout: Duration) -> io::Result<tokio::time::Instant> {
 mod tests {
     use super::*;
 
-    use super::super::protocol::ExecResponseFormat;
     use tokio::net::UnixListener;
 
     fn exec_request(command: &str) -> ExecRequest {
         ExecRequest {
-            response_format: ExecResponseFormat::RawV1,
             expected_run_id: None,
             command: command.into(),
             timeout_secs: 5,

--- a/crates/sandbox-fc/src/control/client.rs
+++ b/crates/sandbox-fc/src/control/client.rs
@@ -3,65 +3,27 @@ use std::path::Path;
 use std::time::Duration;
 
 use serde::Serialize;
-use serde::de::DeserializeOwned;
 use tokio::net::UnixStream;
 
-use super::exec_response::{ExecResult, RAW_EXEC_RESPONSE_VERSION, read_raw_exec_response};
-use super::protocol::{
-    CapabilitiesAction, CapabilitiesRequest, CapabilitiesResponse, ExecRequest, ExecResponse,
-    RawExecRequest, TerminateRequest, TerminateResponse, read_frame, write_frame,
-};
+use super::exec_response::{ExecResult, read_raw_exec_response};
+use super::protocol::{ExecRequest, TerminateRequest, TerminateResponse, read_frame, write_frame};
 
-pub(super) enum ReceivedExecResponse {
-    Raw(ExecResult),
-    Legacy(ExecResponse),
-}
-
-/// Send an exec request to a control socket and return the wire response.
-///
-/// Used by `runner exec` to communicate with a running sandbox.
-///
-/// The returned [`ExecResponse::Success`] still contains base64-encoded stdout
-/// and stderr. Use `FirecrackerControl::exec_remote` when the caller wants
-/// decoded byte buffers.
-///
-/// Returns [`io::ErrorKind::InvalidInput`] when `timeout` cannot be represented
-/// as a Tokio deadline.
-pub async fn send_exec(
+/// Send an exec request to a control socket and read its raw response.
+pub(super) async fn send_exec(
     sock_path: &Path,
     request: &ExecRequest,
     timeout: Duration,
-) -> io::Result<ExecResponse> {
-    send_control_request(sock_path, request, timeout).await
-}
-
-pub(super) async fn send_exec_result(
-    sock_path: &Path,
-    request: &ExecRequest,
-    timeout: Duration,
-) -> io::Result<ReceivedExecResponse> {
+) -> io::Result<ExecResult> {
     let deadline = deadline_after(timeout)?;
-    let capabilities: CapabilitiesResponse = send_control_request_until(
-        sock_path,
-        &CapabilitiesRequest {
-            action: CapabilitiesAction::Capabilities,
-        },
-        deadline,
-    )
-    .await?;
+    let mut stream = connect_until(sock_path, deadline).await?;
+    let request_json = encode_json_request(request)?;
 
-    match capabilities {
-        CapabilitiesResponse::Supported {
-            exec_response_raw_version: RAW_EXEC_RESPONSE_VERSION,
-        } => send_raw_exec_request(sock_path, request, deadline)
-            .await
-            .map(ReceivedExecResponse::Raw),
-        CapabilitiesResponse::Supported { .. } | CapabilitiesResponse::Unsupported { .. } => {
-            send_control_request_until(sock_path, request, deadline)
-                .await
-                .map(ReceivedExecResponse::Legacy)
-        }
-    }
+    tokio::time::timeout_at(deadline, async {
+        write_frame(&mut stream, &request_json).await?;
+        read_raw_exec_response(&mut stream).await
+    })
+    .await
+    .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "request timed out"))?
 }
 
 /// Send a host-side terminate request to a control socket.
@@ -70,31 +32,7 @@ pub async fn send_terminate(
     request: &TerminateRequest,
     timeout: Duration,
 ) -> io::Result<TerminateResponse> {
-    send_control_request(sock_path, request, timeout).await
-}
-
-async fn send_control_request<Request, Response>(
-    sock_path: &Path,
-    request: &Request,
-    timeout: Duration,
-) -> io::Result<Response>
-where
-    Request: Serialize,
-    Response: DeserializeOwned,
-{
     let deadline = deadline_after(timeout)?;
-    send_control_request_until(sock_path, request, deadline).await
-}
-
-async fn send_control_request_until<Request, Response>(
-    sock_path: &Path,
-    request: &Request,
-    deadline: tokio::time::Instant,
-) -> io::Result<Response>
-where
-    Request: Serialize,
-    Response: DeserializeOwned,
-{
     let mut stream = connect_until(sock_path, deadline).await?;
     let request_json = encode_json_request(request)?;
 
@@ -104,22 +42,6 @@ where
         serde_json::from_slice(&frame).map_err(|e| {
             io::Error::new(io::ErrorKind::InvalidData, format!("invalid response: {e}"))
         })
-    })
-    .await
-    .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "request timed out"))?
-}
-
-async fn send_raw_exec_request(
-    sock_path: &Path,
-    request: &ExecRequest,
-    deadline: tokio::time::Instant,
-) -> io::Result<ExecResult> {
-    let mut stream = connect_until(sock_path, deadline).await?;
-    let request_json = encode_json_request(&RawExecRequest::from(request))?;
-
-    tokio::time::timeout_at(deadline, async {
-        write_frame(&mut stream, &request_json).await?;
-        read_raw_exec_response(&mut stream).await
     })
     .await
     .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "request timed out"))?
@@ -145,24 +67,30 @@ fn deadline_after(timeout: Duration) -> io::Result<tokio::time::Instant> {
 mod tests {
     use super::*;
 
-    use base64::Engine;
-    use base64::engine::general_purpose::STANDARD as BASE64;
-    use sandbox::ExecTermination;
+    use super::super::protocol::ExecResponseFormat;
     use tokio::net::UnixListener;
+
+    fn exec_request(command: &str) -> ExecRequest {
+        ExecRequest {
+            response_format: ExecResponseFormat::RawV1,
+            expected_run_id: None,
+            command: command.into(),
+            timeout_secs: 5,
+            sudo: false,
+        }
+    }
 
     #[tokio::test]
     async fn send_exec_missing_socket_returns_not_found() {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("nonexistent.sock");
 
-        let request = ExecRequest {
-            expected_run_id: None,
-            command: "echo test".into(),
-            timeout_secs: 5,
-            sudo: false,
-        };
-
-        let result = send_exec(&sock_path, &request, Duration::from_millis(100)).await;
+        let result = send_exec(
+            &sock_path,
+            &exec_request("echo test"),
+            Duration::from_millis(100),
+        )
+        .await;
         let error = result.unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::NotFound);
     }
@@ -172,96 +100,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
 
-        let request = ExecRequest {
-            expected_run_id: None,
-            command: "echo test".into(),
-            timeout_secs: 5,
-            sudo: false,
-        };
-
-        let result = send_exec(&sock_path, &request, Duration::MAX).await;
+        let result = send_exec(&sock_path, &exec_request("echo test"), Duration::MAX).await;
         let error = result.unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
-    }
-
-    async fn assert_negotiated_exec_uses_legacy_response(capabilities: CapabilitiesResponse) {
-        let dir = tempfile::tempdir().unwrap();
-        let sock_path = dir.path().join("control.sock");
-        let listener = UnixListener::bind(&sock_path).unwrap();
-        let server = tokio::spawn(async move {
-            let (mut probe_stream, _) = listener.accept().await.unwrap();
-            let probe_json = read_frame(&mut probe_stream).await.unwrap();
-            let probe: CapabilitiesRequest = serde_json::from_slice(&probe_json).unwrap();
-            assert_eq!(probe.action, CapabilitiesAction::Capabilities);
-            assert!(serde_json::from_slice::<ExecRequest>(&probe_json).is_err());
-            let capabilities = serde_json::to_vec(&capabilities).unwrap();
-            write_frame(&mut probe_stream, &capabilities).await.unwrap();
-
-            let (mut exec_stream, _) = listener.accept().await.unwrap();
-            let exec_json = read_frame(&mut exec_stream).await.unwrap();
-            let json: serde_json::Value = serde_json::from_slice(&exec_json).unwrap();
-            assert!(json.get("response_format").is_none());
-            let exec: ExecRequest = serde_json::from_slice(&exec_json).unwrap();
-            assert_eq!(exec.command, "printf legacy");
-            let response = serde_json::to_vec(&ExecResponse::Success {
-                termination: ExecTermination::Exited { exit_code: 7 },
-                stdout: BASE64.encode(b"legacy out"),
-                stderr: BASE64.encode(b"legacy err"),
-                stdout_truncated: true,
-                stderr_truncated: false,
-                diagnostic: "legacy diagnostic".into(),
-            })
-            .unwrap();
-            write_frame(&mut exec_stream, &response).await.unwrap();
-        });
-
-        let response = send_exec_result(
-            &sock_path,
-            &ExecRequest {
-                expected_run_id: None,
-                command: "printf legacy".into(),
-                timeout_secs: 5,
-                sudo: false,
-            },
-            Duration::from_secs(5),
-        )
-        .await
-        .unwrap();
-
-        let ReceivedExecResponse::Legacy(ExecResponse::Success {
-            termination,
-            stdout,
-            stderr,
-            stdout_truncated,
-            stderr_truncated,
-            diagnostic,
-        }) = response
-        else {
-            panic!("legacy server should return the legacy response shape");
-        };
-        assert_eq!(termination, ExecTermination::Exited { exit_code: 7 });
-        assert_eq!(BASE64.decode(stdout).unwrap(), b"legacy out");
-        assert_eq!(BASE64.decode(stderr).unwrap(), b"legacy err");
-        assert!(stdout_truncated);
-        assert!(!stderr_truncated);
-        assert_eq!(diagnostic, "legacy diagnostic");
-        server.await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn negotiated_exec_falls_back_before_sending_command_to_legacy_server() {
-        assert_negotiated_exec_uses_legacy_response(CapabilitiesResponse::Unsupported {
-            error: "invalid request: unknown field `action`".into(),
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn negotiated_exec_falls_back_from_unknown_raw_version() {
-        assert_negotiated_exec_uses_legacy_response(CapabilitiesResponse::Supported {
-            exec_response_raw_version: RAW_EXEC_RESPONSE_VERSION + 1,
-        })
-        .await;
     }
 
     #[tokio::test(start_paused = true)]
@@ -284,13 +125,12 @@ mod tests {
         });
 
         let client = tokio::spawn(async move {
-            let request = ExecRequest {
-                expected_run_id: None,
-                command: "echo test".into(),
-                timeout_secs: 5,
-                sudo: false,
-            };
-            send_exec(&sock_path, &request, Duration::from_secs(5)).await
+            send_exec(
+                &sock_path,
+                &exec_request("echo test"),
+                Duration::from_secs(5),
+            )
+            .await
         });
 
         request_seen_rx.await.unwrap();

--- a/crates/sandbox-fc/src/control/client.rs
+++ b/crates/sandbox-fc/src/control/client.rs
@@ -184,8 +184,7 @@ mod tests {
         assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
     }
 
-    #[tokio::test]
-    async fn negotiated_exec_falls_back_before_sending_command_to_legacy_server() {
+    async fn assert_negotiated_exec_uses_legacy_response(capabilities: CapabilitiesResponse) {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
         let listener = UnixListener::bind(&sock_path).unwrap();
@@ -195,11 +194,8 @@ mod tests {
             let probe: CapabilitiesRequest = serde_json::from_slice(&probe_json).unwrap();
             assert_eq!(probe.action, CapabilitiesAction::Capabilities);
             assert!(serde_json::from_slice::<ExecRequest>(&probe_json).is_err());
-            let unsupported = serde_json::to_vec(&ExecResponse::Error {
-                error: "invalid request: unknown field `action`".into(),
-            })
-            .unwrap();
-            write_frame(&mut probe_stream, &unsupported).await.unwrap();
+            let capabilities = serde_json::to_vec(&capabilities).unwrap();
+            write_frame(&mut probe_stream, &capabilities).await.unwrap();
 
             let (mut exec_stream, _) = listener.accept().await.unwrap();
             let exec_json = read_frame(&mut exec_stream).await.unwrap();
@@ -250,6 +246,22 @@ mod tests {
         assert!(!stderr_truncated);
         assert_eq!(diagnostic, "legacy diagnostic");
         server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn negotiated_exec_falls_back_before_sending_command_to_legacy_server() {
+        assert_negotiated_exec_uses_legacy_response(CapabilitiesResponse::Unsupported {
+            error: "invalid request: unknown field `action`".into(),
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn negotiated_exec_falls_back_from_unknown_raw_version() {
+        assert_negotiated_exec_uses_legacy_response(CapabilitiesResponse::Supported {
+            exec_response_raw_version: RAW_EXEC_RESPONSE_VERSION + 1,
+        })
+        .await;
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/sandbox-fc/src/control/exec_response.rs
+++ b/crates/sandbox-fc/src/control/exec_response.rs
@@ -1,4 +1,4 @@
-//! Versioned binary responses for negotiated control-socket exec requests.
+//! Versioned binary responses for control-socket exec requests.
 //!
 //! Every payload starts with `VM0E`, a version byte, and a kind byte. A success
 //! then carries a structured termination, truncation flags, three big-endian

--- a/crates/sandbox-fc/src/control/exec_response.rs
+++ b/crates/sandbox-fc/src/control/exec_response.rs
@@ -1,0 +1,476 @@
+//! Versioned binary responses for negotiated control-socket exec requests.
+//!
+//! Every payload starts with `VM0E`, a version byte, and a kind byte. A success
+//! then carries a structured termination, truncation flags, three big-endian
+//! lengths, and contiguous stdout, stderr, and UTF-8 diagnostic bytes. An error
+//! carries one big-endian length followed by its UTF-8 message.
+
+use std::io;
+
+use sandbox::ExecTermination;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+
+use super::protocol::{read_frame_payload_len, write_frame_payload_len};
+
+pub(super) const RAW_EXEC_RESPONSE_VERSION: u8 = 1;
+
+const RAW_EXEC_MAGIC: [u8; 4] = *b"VM0E";
+const RAW_EXEC_KIND_SUCCESS: u8 = 0;
+const RAW_EXEC_KIND_ERROR: u8 = 1;
+
+const TERMINATION_EXITED: u8 = 0;
+const TERMINATION_TIMED_OUT: u8 = 1;
+const TERMINATION_CANCELLED: u8 = 2;
+const TERMINATION_START_FAILED: u8 = 3;
+const TERMINATION_WAIT_FAILED: u8 = 4;
+
+const FLAG_STDOUT_TRUNCATED: u8 = 1 << 0;
+const FLAG_STDERR_TRUNCATED: u8 = 1 << 1;
+const KNOWN_FLAGS: u8 = FLAG_STDOUT_TRUNCATED | FLAG_STDERR_TRUNCATED;
+
+const COMMON_HEADER_LEN: usize = RAW_EXEC_MAGIC.len() + 1 + 1;
+const SUCCESS_LENGTH_FIELDS_LEN: usize = 4 + 4 + 4;
+const ERROR_LENGTH_FIELD_LEN: usize = 4;
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) enum ExecResult {
+    Success {
+        termination: ExecTermination,
+        stdout: Vec<u8>,
+        stderr: Vec<u8>,
+        stdout_truncated: bool,
+        stderr_truncated: bool,
+        diagnostic: String,
+    },
+    Error {
+        error: String,
+    },
+}
+
+pub(super) async fn write_raw_exec_response(
+    stream: &mut UnixStream,
+    response: &ExecResult,
+) -> io::Result<()> {
+    match response {
+        ExecResult::Success {
+            termination,
+            stdout,
+            stderr,
+            stdout_truncated,
+            stderr_truncated,
+            diagnostic,
+        } => {
+            let stdout_len = wire_len("stdout", stdout.len())?;
+            let stderr_len = wire_len("stderr", stderr.len())?;
+            let diagnostic_len = wire_len("diagnostic", diagnostic.len())?;
+            let header_len = COMMON_HEADER_LEN
+                .checked_add(termination_wire_len(*termination))
+                .and_then(|len| len.checked_add(1 + SUCCESS_LENGTH_FIELDS_LEN))
+                .ok_or_else(|| invalid_data("raw exec success header length overflowed"))?;
+            let payload_len =
+                checked_payload_len(header_len, &[stdout.len(), stderr.len(), diagnostic.len()])?;
+
+            let mut header = Vec::with_capacity(header_len);
+            append_common_header(&mut header, RAW_EXEC_KIND_SUCCESS);
+            append_termination(&mut header, *termination);
+            header.push(
+                (u8::from(*stdout_truncated) * FLAG_STDOUT_TRUNCATED)
+                    | (u8::from(*stderr_truncated) * FLAG_STDERR_TRUNCATED),
+            );
+            header.extend_from_slice(&stdout_len.to_be_bytes());
+            header.extend_from_slice(&stderr_len.to_be_bytes());
+            header.extend_from_slice(&diagnostic_len.to_be_bytes());
+
+            write_frame_payload_len(stream, payload_len).await?;
+            stream.write_all(&header).await?;
+            stream.write_all(stdout).await?;
+            stream.write_all(stderr).await?;
+            stream.write_all(diagnostic.as_bytes()).await?;
+        }
+        ExecResult::Error { error } => {
+            let error_len = wire_len("error", error.len())?;
+            let header_len = COMMON_HEADER_LEN + ERROR_LENGTH_FIELD_LEN;
+            let payload_len = checked_payload_len(header_len, &[error.len()])?;
+
+            let mut header = Vec::with_capacity(header_len);
+            append_common_header(&mut header, RAW_EXEC_KIND_ERROR);
+            header.extend_from_slice(&error_len.to_be_bytes());
+
+            write_frame_payload_len(stream, payload_len).await?;
+            stream.write_all(&header).await?;
+            stream.write_all(error.as_bytes()).await?;
+        }
+    }
+
+    stream.flush().await
+}
+
+pub(super) async fn read_raw_exec_response(stream: &mut UnixStream) -> io::Result<ExecResult> {
+    let payload_len = read_frame_payload_len(stream).await?;
+    let mut reader = RawFrameReader::new(stream, payload_len);
+
+    let magic = reader.read_array::<4>().await?;
+    if magic != RAW_EXEC_MAGIC {
+        return Err(invalid_data("invalid raw exec response magic"));
+    }
+
+    let version = reader.read_u8().await?;
+    if version != RAW_EXEC_RESPONSE_VERSION {
+        return Err(invalid_data(format!(
+            "unsupported raw exec response version: {version}"
+        )));
+    }
+
+    match reader.read_u8().await? {
+        RAW_EXEC_KIND_SUCCESS => read_raw_success(&mut reader).await,
+        RAW_EXEC_KIND_ERROR => read_raw_error(&mut reader).await,
+        kind => Err(invalid_data(format!(
+            "unknown raw exec response kind: {kind}"
+        ))),
+    }
+}
+
+async fn read_raw_success(reader: &mut RawFrameReader<'_>) -> io::Result<ExecResult> {
+    let termination = read_termination(reader).await?;
+    let flags = reader.read_u8().await?;
+    if flags & !KNOWN_FLAGS != 0 {
+        return Err(invalid_data(format!(
+            "unknown raw exec response flags: {flags:#04x}"
+        )));
+    }
+
+    let stdout_len = reader.read_u32().await? as usize;
+    let stderr_len = reader.read_u32().await? as usize;
+    let diagnostic_len = reader.read_u32().await? as usize;
+    let body_len = checked_payload_len(0, &[stdout_len, stderr_len, diagnostic_len])?;
+    if reader.remaining() != body_len {
+        return Err(invalid_data(format!(
+            "raw exec success lengths declare {body_len} bytes with {} bytes remaining",
+            reader.remaining()
+        )));
+    }
+
+    let stdout = reader.read_vec(stdout_len).await?;
+    let stderr = reader.read_vec(stderr_len).await?;
+    let diagnostic = String::from_utf8(reader.read_vec(diagnostic_len).await?)
+        .map_err(|error| invalid_data(format!("raw exec diagnostic is not UTF-8: {error}")))?;
+
+    Ok(ExecResult::Success {
+        termination,
+        stdout,
+        stderr,
+        stdout_truncated: flags & FLAG_STDOUT_TRUNCATED != 0,
+        stderr_truncated: flags & FLAG_STDERR_TRUNCATED != 0,
+        diagnostic,
+    })
+}
+
+async fn read_raw_error(reader: &mut RawFrameReader<'_>) -> io::Result<ExecResult> {
+    let error_len = reader.read_u32().await? as usize;
+    if reader.remaining() != error_len {
+        return Err(invalid_data(format!(
+            "raw exec error length declares {error_len} bytes with {} bytes remaining",
+            reader.remaining()
+        )));
+    }
+
+    let error = String::from_utf8(reader.read_vec(error_len).await?)
+        .map_err(|error| invalid_data(format!("raw exec error is not UTF-8: {error}")))?;
+    Ok(ExecResult::Error { error })
+}
+
+async fn read_termination(reader: &mut RawFrameReader<'_>) -> io::Result<ExecTermination> {
+    match reader.read_u8().await? {
+        TERMINATION_EXITED => Ok(ExecTermination::Exited {
+            exit_code: i32::from_be_bytes(reader.read_array::<4>().await?),
+        }),
+        TERMINATION_TIMED_OUT => Ok(ExecTermination::TimedOut),
+        TERMINATION_CANCELLED => Ok(ExecTermination::Cancelled),
+        TERMINATION_START_FAILED => Ok(ExecTermination::StartFailed),
+        TERMINATION_WAIT_FAILED => Ok(ExecTermination::WaitFailed),
+        termination => Err(invalid_data(format!(
+            "unknown raw exec termination: {termination}"
+        ))),
+    }
+}
+
+fn append_common_header(header: &mut Vec<u8>, kind: u8) {
+    header.extend_from_slice(&RAW_EXEC_MAGIC);
+    header.push(RAW_EXEC_RESPONSE_VERSION);
+    header.push(kind);
+}
+
+fn termination_wire_len(termination: ExecTermination) -> usize {
+    match termination {
+        ExecTermination::Exited { .. } => 5,
+        ExecTermination::TimedOut
+        | ExecTermination::Cancelled
+        | ExecTermination::StartFailed
+        | ExecTermination::WaitFailed => 1,
+    }
+}
+
+fn append_termination(header: &mut Vec<u8>, termination: ExecTermination) {
+    match termination {
+        ExecTermination::Exited { exit_code } => {
+            header.push(TERMINATION_EXITED);
+            header.extend_from_slice(&exit_code.to_be_bytes());
+        }
+        ExecTermination::TimedOut => header.push(TERMINATION_TIMED_OUT),
+        ExecTermination::Cancelled => header.push(TERMINATION_CANCELLED),
+        ExecTermination::StartFailed => header.push(TERMINATION_START_FAILED),
+        ExecTermination::WaitFailed => header.push(TERMINATION_WAIT_FAILED),
+    }
+}
+
+fn wire_len(field: &'static str, len: usize) -> io::Result<u32> {
+    u32::try_from(len)
+        .map_err(|_| invalid_data(format!("raw exec {field} is too large: {len} bytes")))
+}
+
+fn checked_payload_len(header_len: usize, fields: &[usize]) -> io::Result<usize> {
+    fields.iter().try_fold(header_len, |len, field_len| {
+        len.checked_add(*field_len)
+            .ok_or_else(|| invalid_data("raw exec response length overflowed"))
+    })
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+struct RawFrameReader<'a> {
+    stream: &'a mut UnixStream,
+    remaining: usize,
+}
+
+impl<'a> RawFrameReader<'a> {
+    fn new(stream: &'a mut UnixStream, remaining: usize) -> Self {
+        Self { stream, remaining }
+    }
+
+    fn remaining(&self) -> usize {
+        self.remaining
+    }
+
+    async fn read_u8(&mut self) -> io::Result<u8> {
+        Ok(self.read_array::<1>().await?[0])
+    }
+
+    async fn read_u32(&mut self) -> io::Result<u32> {
+        Ok(u32::from_be_bytes(self.read_array::<4>().await?))
+    }
+
+    async fn read_array<const N: usize>(&mut self) -> io::Result<[u8; N]> {
+        self.reserve(N)?;
+        let mut bytes = [0; N];
+        self.stream.read_exact(&mut bytes).await?;
+        Ok(bytes)
+    }
+
+    async fn read_vec(&mut self, len: usize) -> io::Result<Vec<u8>> {
+        self.reserve(len)?;
+        let mut bytes = vec![0; len];
+        self.stream.read_exact(&mut bytes).await?;
+        Ok(bytes)
+    }
+
+    fn reserve(&mut self, len: usize) -> io::Result<()> {
+        self.remaining = self.remaining.checked_sub(len).ok_or_else(|| {
+            invalid_data(format!(
+                "raw exec response needs {len} bytes with only {} remaining",
+                self.remaining
+            ))
+        })?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::protocol::MAX_FRAME_PAYLOAD_SIZE;
+    use super::*;
+
+    async fn round_trip(response: ExecResult) {
+        let (mut reader, mut writer) = UnixStream::pair().unwrap();
+        let write = tokio::spawn(async move {
+            write_raw_exec_response(&mut writer, &response)
+                .await
+                .unwrap();
+            response
+        });
+
+        let decoded = read_raw_exec_response(&mut reader).await.unwrap();
+        let expected = write.await.unwrap();
+        assert_eq!(decoded, expected);
+    }
+
+    async fn encoded_payload(response: ExecResult) -> Vec<u8> {
+        let (mut reader, mut writer) = UnixStream::pair().unwrap();
+        let write = tokio::spawn(async move {
+            write_raw_exec_response(&mut writer, &response)
+                .await
+                .unwrap();
+        });
+
+        let len = reader.read_u32().await.unwrap() as usize;
+        let mut payload = vec![0; len];
+        reader.read_exact(&mut payload).await.unwrap();
+        write.await.unwrap();
+        payload
+    }
+
+    async fn decode_payload(payload: &[u8]) -> io::Result<ExecResult> {
+        let (mut reader, mut writer) = UnixStream::pair().unwrap();
+        let payload = payload.to_vec();
+        let write = tokio::spawn(async move {
+            writer.write_u32(payload.len() as u32).await.unwrap();
+            writer.write_all(&payload).await.unwrap();
+        });
+
+        let result = read_raw_exec_response(&mut reader).await;
+        write.await.unwrap();
+        result
+    }
+
+    fn success_payload() -> Vec<u8> {
+        let mut payload = Vec::new();
+        append_common_header(&mut payload, RAW_EXEC_KIND_SUCCESS);
+        append_termination(&mut payload, ExecTermination::Exited { exit_code: 7 });
+        payload.push(FLAG_STDOUT_TRUNCATED);
+        payload.extend_from_slice(&3u32.to_be_bytes());
+        payload.extend_from_slice(&2u32.to_be_bytes());
+        payload.extend_from_slice(&4u32.to_be_bytes());
+        payload.extend_from_slice(b"out");
+        payload.extend_from_slice(b"er");
+        payload.extend_from_slice(b"diag");
+        payload
+    }
+
+    #[tokio::test]
+    async fn raw_exec_success_round_trips_all_terminal_shapes() {
+        for termination in [
+            ExecTermination::Exited { exit_code: -17 },
+            ExecTermination::TimedOut,
+            ExecTermination::Cancelled,
+            ExecTermination::StartFailed,
+            ExecTermination::WaitFailed,
+        ] {
+            round_trip(ExecResult::Success {
+                termination,
+                stdout: vec![0, 0xff, b'\n'],
+                stderr: b"stderr".to_vec(),
+                stdout_truncated: true,
+                stderr_truncated: true,
+                diagnostic: "diagnostic 边界".into(),
+            })
+            .await;
+        }
+    }
+
+    #[tokio::test]
+    async fn raw_exec_error_round_trips() {
+        round_trip(ExecResult::Error {
+            error: "sandbox unavailable 边界".into(),
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn maximum_control_capture_avoids_base64_wire_expansion() {
+        const STREAM_LEN: usize = 7 * 1024 * 1024;
+        let payload = encoded_payload(ExecResult::Success {
+            termination: ExecTermination::Exited { exit_code: 0 },
+            stdout: vec![b'o'; STREAM_LEN],
+            stderr: vec![b'e'; STREAM_LEN],
+            stdout_truncated: true,
+            stderr_truncated: true,
+            diagnostic: String::new(),
+        })
+        .await;
+
+        assert_eq!(payload.len(), 24 + 2 * STREAM_LEN);
+        let base64_len = 2 * STREAM_LEN.div_ceil(3) * 4;
+        assert!(payload.len() < base64_len);
+        assert_eq!(base64_len - payload.len(), 4_893_336);
+    }
+
+    #[tokio::test]
+    async fn raw_exec_reader_rejects_invalid_header_fields() {
+        let valid = success_payload();
+        for (offset, value, expected) in [
+            (0, b'X', "magic"),
+            (4, RAW_EXEC_RESPONSE_VERSION + 1, "version"),
+            (5, 0xff, "kind"),
+            (6, 0xff, "termination"),
+            (11, 0x80, "flags"),
+        ] {
+            let mut malformed = valid.clone();
+            malformed[offset] = value;
+            let error = decode_payload(&malformed).await.unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+            assert!(error.to_string().contains(expected), "{error}");
+        }
+    }
+
+    #[tokio::test]
+    async fn raw_exec_reader_rejects_inconsistent_lengths_and_trailing_bytes() {
+        let mut inconsistent = success_payload();
+        inconsistent[12..16].copy_from_slice(&4u32.to_be_bytes());
+        let error = decode_payload(&inconsistent).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("lengths declare"));
+
+        let mut trailing = success_payload();
+        trailing.push(0);
+        let error = decode_payload(&trailing).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("lengths declare"));
+    }
+
+    #[tokio::test]
+    async fn raw_exec_reader_rejects_invalid_utf8() {
+        let mut success = success_payload();
+        *success.last_mut().unwrap() = 0xff;
+        let error = decode_payload(&success).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("diagnostic is not UTF-8"));
+
+        let mut error_payload = Vec::new();
+        append_common_header(&mut error_payload, RAW_EXEC_KIND_ERROR);
+        error_payload.extend_from_slice(&1u32.to_be_bytes());
+        error_payload.push(0xff);
+        let error = decode_payload(&error_payload).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("error is not UTF-8"));
+    }
+
+    #[tokio::test]
+    async fn raw_exec_reader_preserves_truncated_transport_error() {
+        let payload = success_payload();
+        let declared_len = payload.len();
+        let (mut reader, mut writer) = UnixStream::pair().unwrap();
+        let write = tokio::spawn(async move {
+            writer.write_u32(declared_len as u32).await.unwrap();
+            writer
+                .write_all(&payload[..payload.len() - 1])
+                .await
+                .unwrap();
+        });
+
+        let error = read_raw_exec_response(&mut reader).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
+        write.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn raw_exec_reader_rejects_oversized_frame_before_payload_read() {
+        let (mut reader, mut writer) = UnixStream::pair().unwrap();
+        writer.write_u32(MAX_FRAME_PAYLOAD_SIZE + 1).await.unwrap();
+
+        let error = read_raw_exec_response(&mut reader).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("frame too large"));
+    }
+}

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -1,6 +1,5 @@
 use std::io;
 
-use sandbox::ExecTermination;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
@@ -8,167 +7,39 @@ use tokio::net::UnixStream;
 /// Request from a `runner exec` client.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct ExecRequest {
+pub(super) struct ExecRequest {
+    /// Required wire marker for the raw exec response protocol.
+    pub(super) response_format: ExecResponseFormat,
     /// Full run identity that must still own the sandbox at guest admission.
     ///
     /// Missing means the caller intentionally selected sandbox scope.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub expected_run_id: Option<String>,
+    pub(super) expected_run_id: Option<String>,
     /// Command text to execute inside the guest.
-    pub command: String,
+    pub(super) command: String,
     /// Command timeout in seconds.
     ///
     /// When this field is omitted during JSON deserialization, it defaults to
     /// 30 seconds.
     #[serde(default = "default_timeout")]
-    pub timeout_secs: u32,
+    pub(super) timeout_secs: u32,
     /// Whether to request sudo execution inside the guest.
     ///
     /// When this field is omitted during JSON deserialization, it defaults to
     /// `false`. The guest command runner decides how sudo is applied.
     #[serde(default)]
-    pub sudo: bool,
+    pub(super) sudo: bool,
 }
 
 fn default_timeout() -> u32 {
     30
 }
 
-/// Request that probes control-server capabilities without executing a command.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub(super) struct CapabilitiesRequest {
-    pub(super) action: CapabilitiesAction,
-}
-
-/// Non-executing control action used for protocol negotiation.
+/// Exec response representation required by the control protocol.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub(super) enum CapabilitiesAction {
-    Capabilities,
-}
-
-/// Response to a control capability probe.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
-pub(super) enum CapabilitiesResponse {
-    Supported { exec_response_raw_version: u8 },
-    Unsupported { error: String },
-}
-
-/// Exec response representation selected by a negotiated request.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
 pub(super) enum ExecResponseFormat {
-    #[default]
-    JsonBase64,
     RawV1,
-}
-
-/// Server-side exec request shape that also accepts a negotiated response format.
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub(super) struct WireExecRequest {
-    #[serde(default)]
-    pub(super) expected_run_id: Option<String>,
-    pub(super) command: String,
-    #[serde(default = "default_timeout")]
-    pub(super) timeout_secs: u32,
-    #[serde(default)]
-    pub(super) sudo: bool,
-    #[serde(default)]
-    pub(super) response_format: ExecResponseFormat,
-}
-
-impl WireExecRequest {
-    pub(super) fn into_request(self) -> (ExecRequest, ExecResponseFormat) {
-        let Self {
-            expected_run_id,
-            command,
-            timeout_secs,
-            sudo,
-            response_format,
-        } = self;
-        (
-            ExecRequest {
-                expected_run_id,
-                command,
-                timeout_secs,
-                sudo,
-            },
-            response_format,
-        )
-    }
-}
-
-/// Borrowed exec request that explicitly selects raw response version 1.
-#[derive(Debug, Serialize)]
-pub(super) struct RawExecRequest<'a> {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) expected_run_id: Option<&'a str>,
-    pub(super) command: &'a str,
-    pub(super) timeout_secs: u32,
-    pub(super) sudo: bool,
-    pub(super) response_format: ExecResponseFormat,
-}
-
-impl<'a> From<&'a ExecRequest> for RawExecRequest<'a> {
-    fn from(request: &'a ExecRequest) -> Self {
-        let ExecRequest {
-            expected_run_id,
-            command,
-            timeout_secs,
-            sudo,
-        } = request;
-        Self {
-            expected_run_id: expected_run_id.as_deref(),
-            command,
-            timeout_secs: *timeout_secs,
-            sudo: *sudo,
-            response_format: ExecResponseFormat::RawV1,
-        }
-    }
-}
-
-/// Response to a `runner exec` client.
-///
-/// This enum is serialized without a tag. Clients should distinguish variants
-/// by shape: a command result response contains command result fields, while an
-/// error response contains only an `error` string.
-/// Unknown fields are rejected so mixed success/error shapes fail closed.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
-pub enum ExecResponse {
-    /// Command execution produced a captured result.
-    Success {
-        /// Structured terminal state returned by the guest command runner.
-        termination: ExecTermination,
-        /// Base64-encoded captured stdout bytes.
-        ///
-        /// This is not plain UTF-8 text. `FirecrackerControl::exec_remote`
-        /// decodes it before returning `sandbox::RemoteExecResult`.
-        stdout: String,
-        /// Base64-encoded captured stderr bytes.
-        ///
-        /// This is not plain UTF-8 text. `FirecrackerControl::exec_remote`
-        /// decodes it before returning `sandbox::RemoteExecResult`.
-        stderr: String,
-        /// Whether stdout was cut at the capture limit.
-        ///
-        /// Truncation is independent of the command exit code.
-        stdout_truncated: bool,
-        /// Whether stderr was cut at the capture limit.
-        ///
-        /// Truncation is independent of the command exit code.
-        stderr_truncated: bool,
-        /// Guest-provided terminal diagnostic text.
-        diagnostic: String,
-    },
-    /// Request failed before a command result could be returned.
-    Error {
-        /// Human-readable error message for operators and clients.
-        error: String,
-    },
 }
 
 /// Host-side control action requested over the local control socket.
@@ -291,9 +162,6 @@ pub(super) async fn write_frame_payload_len(stream: &mut UnixStream, len: usize)
 mod tests {
     use super::*;
 
-    use super::super::exec_response::RAW_EXEC_RESPONSE_VERSION;
-    use base64::Engine;
-    use base64::engine::general_purpose::STANDARD as BASE64;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{UnixListener, UnixStream};
 
@@ -348,8 +216,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn protocol_round_trip() {
+    async fn exec_request_round_trip() {
         let request = ExecRequest {
+            response_format: ExecResponseFormat::RawV1,
             expected_run_id: None,
             command: "echo hello".into(),
             timeout_secs: 10,
@@ -363,60 +232,19 @@ mod tests {
         assert_eq!(decoded.command, "echo hello");
         assert_eq!(decoded.timeout_secs, 10);
         assert!(!decoded.sudo);
+        assert_eq!(decoded.response_format, ExecResponseFormat::RawV1);
         assert!(
             serde_json::from_slice::<serde_json::Value>(&request_json)
                 .unwrap()
                 .get("expected_run_id")
                 .is_none()
         );
-
-        // Verify success response round-trips.
-        let response = ExecResponse::Success {
-            termination: ExecTermination::Exited { exit_code: 0 },
-            stdout: BASE64.encode(b"hello\n"),
-            stderr: BASE64.encode(b""),
-            stdout_truncated: false,
-            stderr_truncated: false,
-            diagnostic: "terminal diagnostic".into(),
-        };
-        let response_json = serde_json::to_vec(&response).unwrap();
-        let decoded: ExecResponse = serde_json::from_slice(&response_json).unwrap();
-        match decoded {
-            ExecResponse::Success {
-                termination,
-                stdout,
-                stderr,
-                stdout_truncated,
-                stderr_truncated,
-                diagnostic,
-            } => {
-                assert_eq!(termination, ExecTermination::Exited { exit_code: 0 });
-                assert_eq!(BASE64.decode(stdout).unwrap(), b"hello\n");
-                assert_eq!(BASE64.decode(stderr).unwrap(), b"");
-                assert!(!stdout_truncated);
-                assert!(!stderr_truncated);
-                assert_eq!(diagnostic, "terminal diagnostic");
-            }
-            ExecResponse::Error { .. } => panic!("expected success"),
-        }
-
-        // Verify error response round-trips.
-        let response = ExecResponse::Error {
-            error: "sandbox not running".into(),
-        };
-        let response_json = serde_json::to_vec(&response).unwrap();
-        let decoded: ExecResponse = serde_json::from_slice(&response_json).unwrap();
-        match decoded {
-            ExecResponse::Error { error } => {
-                assert_eq!(error, "sandbox not running");
-            }
-            ExecResponse::Success { .. } => panic!("expected error"),
-        }
     }
 
     #[test]
     fn guarded_exec_request_round_trips_run_identity() {
         let request = ExecRequest {
+            response_format: ExecResponseFormat::RawV1,
             expected_run_id: Some("run-full-id".into()),
             command: "true".into(),
             timeout_secs: 30,
@@ -432,17 +260,18 @@ mod tests {
     #[test]
     fn exec_request_default_timeout() {
         // timeout_secs has a serde default of 30
-        let json = r#"{"command":"echo hi"}"#;
+        let json = r#"{"response_format":"raw_v1","command":"echo hi"}"#;
         let req: ExecRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.expected_run_id, None);
         assert_eq!(req.command, "echo hi");
         assert_eq!(req.timeout_secs, 30);
         assert!(!req.sudo);
+        assert_eq!(req.response_format, ExecResponseFormat::RawV1);
     }
 
     #[test]
     fn exec_request_with_sudo() {
-        let json = r#"{"command":"apt install curl","timeout_secs":60,"sudo":true}"#;
+        let json = r#"{"response_format":"raw_v1","command":"apt install curl","timeout_secs":60,"sudo":true}"#;
         let req: ExecRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.command, "apt install curl");
         assert_eq!(req.timeout_secs, 60);
@@ -450,240 +279,14 @@ mod tests {
     }
 
     #[test]
-    fn wire_exec_request_preserves_legacy_defaults() {
-        let request: WireExecRequest = serde_json::from_str(r#"{"command":"echo hi"}"#).unwrap();
-        let (request, response_format) = request.into_request();
-
-        assert_eq!(request.expected_run_id, None);
-        assert_eq!(request.command, "echo hi");
-        assert_eq!(request.timeout_secs, 30);
-        assert!(!request.sudo);
-        assert_eq!(response_format, ExecResponseFormat::JsonBase64);
-    }
-
-    #[test]
-    fn raw_exec_request_explicitly_selects_raw_v1() {
-        let request = ExecRequest {
-            expected_run_id: Some("run-full-id".into()),
-            command: "printf raw".into(),
-            timeout_secs: 17,
-            sudo: true,
-        };
-        let json = serde_json::to_value(RawExecRequest::from(&request)).unwrap();
-
-        assert_eq!(json["expected_run_id"], "run-full-id");
-        assert_eq!(json["command"], "printf raw");
-        assert_eq!(json["timeout_secs"], 17);
-        assert_eq!(json["sudo"], true);
-        assert_eq!(json["response_format"], "raw_v1");
-
-        let decoded: WireExecRequest = serde_json::from_value(json).unwrap();
-        let (decoded, response_format) = decoded.into_request();
-        assert_eq!(decoded.expected_run_id.as_deref(), Some("run-full-id"));
-        assert_eq!(decoded.command, "printf raw");
-        assert_eq!(response_format, ExecResponseFormat::RawV1);
-    }
-
-    #[test]
-    fn capabilities_response_accepts_additive_fields() {
-        let response: CapabilitiesResponse = serde_json::from_value(serde_json::json!({
-            "exec_response_raw_version": RAW_EXEC_RESPONSE_VERSION,
-            "terminate_version": 1,
-        }))
-        .unwrap();
-
-        let CapabilitiesResponse::Supported {
-            exec_response_raw_version,
-        } = response
-        else {
-            panic!("explicit raw version should remain supported with additive fields");
-        };
-        assert_eq!(exec_response_raw_version, RAW_EXEC_RESPONSE_VERSION);
-    }
-
-    #[test]
-    fn exec_response_success_serialization() {
-        let resp = ExecResponse::Success {
-            termination: ExecTermination::Exited { exit_code: 0 },
-            stdout: BASE64.encode(b"output\n"),
-            stderr: BASE64.encode(b""),
-            stdout_truncated: false,
-            stderr_truncated: false,
-            diagnostic: "diagnostic".into(),
-        };
-        let json = serde_json::to_value(&resp).unwrap();
-        // Untagged enum: no "type" field, just the fields directly
-        assert_eq!(json["termination"]["kind"], "exited");
-        assert_eq!(json["termination"]["exit_code"], 0);
-        assert!(json.get("exit_code").is_none());
-        assert!(json.get("stdout").is_some());
-        assert!(json.get("stderr").is_some());
-        assert_eq!(json["diagnostic"], "diagnostic");
-        assert!(json.get("error").is_none());
-    }
-
-    #[test]
-    fn exec_response_success_serializes_non_exited_termination() {
-        for (termination, expected_kind) in [
-            (ExecTermination::TimedOut, "timed_out"),
-            (ExecTermination::Cancelled, "cancelled"),
-            (ExecTermination::StartFailed, "start_failed"),
-            (ExecTermination::WaitFailed, "wait_failed"),
-        ] {
-            let resp = ExecResponse::Success {
-                termination,
-                stdout: BASE64.encode(b""),
-                stderr: BASE64.encode(b""),
-                stdout_truncated: false,
-                stderr_truncated: false,
-                diagnostic: String::new(),
-            };
-            let json = serde_json::to_value(&resp).unwrap();
-            assert_eq!(json["termination"]["kind"], expected_kind);
-            assert!(json["termination"].get("exit_code").is_none());
-            let decoded: ExecResponse = serde_json::from_value(json).unwrap();
-            match decoded {
-                ExecResponse::Success {
-                    termination: decoded,
-                    ..
-                } => assert_eq!(decoded, termination),
-                ExecResponse::Error { .. } => panic!("expected success"),
-            }
-        }
-    }
-
-    #[test]
-    fn exec_response_rejects_legacy_exit_code_success_shape() {
-        let legacy = serde_json::json!({
-            "exit_code": 0,
-            "stdout": BASE64.encode(b""),
-            "stderr": BASE64.encode(b""),
-            "stdout_truncated": false,
-            "stderr_truncated": false
-        });
-
-        let result = serde_json::from_value::<ExecResponse>(legacy);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn exec_response_rejects_mixed_success_error_shape() {
-        let mixed = serde_json::json!({
-            "termination": {
-                "kind": "exited",
-                "exit_code": 0,
-            },
-            "stdout": BASE64.encode(b""),
-            "stderr": BASE64.encode(b""),
-            "stdout_truncated": false,
-            "stderr_truncated": false,
-            "diagnostic": "",
-            "error": "sandbox not running",
-        });
-
-        let result = serde_json::from_value::<ExecResponse>(mixed);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn exec_response_rejects_non_exited_termination_with_exit_code() {
-        for exit_code in [serde_json::json!(124), serde_json::Value::Null] {
-            let malformed = serde_json::json!({
-                "termination": {
-                    "kind": "timed_out",
-                    "exit_code": exit_code,
-                },
-                "stdout": BASE64.encode(b""),
-                "stderr": BASE64.encode(b""),
-                "stdout_truncated": false,
-                "stderr_truncated": false,
-                "diagnostic": "",
-            });
-
-            let result = serde_json::from_value::<ExecResponse>(malformed);
-            assert!(result.is_err());
-        }
-    }
-
-    #[test]
-    fn exec_response_rejects_exited_termination_without_exit_code() {
-        for termination in [
-            serde_json::json!({
-                "kind": "exited",
-            }),
-            serde_json::json!({
-                "kind": "exited",
-                "exit_code": null,
-            }),
-        ] {
-            let malformed = serde_json::json!({
-                "termination": termination,
-                "stdout": BASE64.encode(b""),
-                "stderr": BASE64.encode(b""),
-                "stdout_truncated": false,
-                "stderr_truncated": false,
-                "diagnostic": "",
-            });
-
-            let result = serde_json::from_value::<ExecResponse>(malformed);
-            assert!(result.is_err());
-        }
-    }
-
-    #[test]
-    fn exec_response_rejects_termination_unknown_field() {
-        let malformed = serde_json::json!({
-            "termination": {
-                "kind": "exited",
-                "exit_code": 0,
-                "signal": 9,
-            },
-            "stdout": BASE64.encode(b""),
-            "stderr": BASE64.encode(b""),
-            "stdout_truncated": false,
-            "stderr_truncated": false,
-            "diagnostic": "",
-        });
-
-        let result = serde_json::from_value::<ExecResponse>(malformed);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn exec_response_rejects_invalid_termination_kind_shapes() {
-        for termination in [
-            r#"{"exit_code":0}"#,
-            r#"{"kind":"unknown","exit_code":0}"#,
-            r#"{"kind":"exited","kind":"timed_out","exit_code":0}"#,
-            r#"{"kind":"exited","exit_code":0,"exit_code":1}"#,
-        ] {
-            let malformed = format!(
-                r#"{{
-                    "termination": {termination},
-                    "stdout": "{}",
-                    "stderr": "{}",
-                    "stdout_truncated": false,
-                    "stderr_truncated": false,
-                    "diagnostic": ""
-                }}"#,
-                BASE64.encode(b""),
-                BASE64.encode(b"")
-            );
-
-            let result = serde_json::from_str::<ExecResponse>(&malformed);
-            assert!(result.is_err());
-        }
-    }
-
-    #[test]
-    fn exec_response_error_serialization() {
-        let resp = ExecResponse::Error {
-            error: "sandbox not running".into(),
-        };
-        let json = serde_json::to_value(&resp).unwrap();
-        assert_eq!(json["error"], "sandbox not running");
-        assert!(json.get("termination").is_none());
-        assert!(json.get("exit_code").is_none());
+    fn exec_request_requires_raw_response_format() {
+        assert!(serde_json::from_str::<ExecRequest>(r#"{"command":"echo hi"}"#).is_err());
+        assert!(
+            serde_json::from_str::<ExecRequest>(
+                r#"{"response_format":"raw_v2","command":"echo hi"}"#,
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -50,7 +50,7 @@ pub(super) enum CapabilitiesAction {
 
 /// Response to a control capability probe.
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 pub(super) enum CapabilitiesResponse {
     Supported { exec_response_raw_version: u8 },
     Unsupported { error: String },
@@ -114,11 +114,17 @@ pub(super) struct RawExecRequest<'a> {
 
 impl<'a> From<&'a ExecRequest> for RawExecRequest<'a> {
     fn from(request: &'a ExecRequest) -> Self {
+        let ExecRequest {
+            expected_run_id,
+            command,
+            timeout_secs,
+            sudo,
+        } = request;
         Self {
-            expected_run_id: request.expected_run_id.as_deref(),
-            command: &request.command,
-            timeout_secs: request.timeout_secs,
-            sudo: request.sudo,
+            expected_run_id: expected_run_id.as_deref(),
+            command,
+            timeout_secs: *timeout_secs,
+            sudo: *sudo,
             response_format: ExecResponseFormat::RawV1,
         }
     }
@@ -285,6 +291,7 @@ pub(super) async fn write_frame_payload_len(stream: &mut UnixStream, len: usize)
 mod tests {
     use super::*;
 
+    use super::super::exec_response::RAW_EXEC_RESPONSE_VERSION;
     use base64::Engine;
     use base64::engine::general_purpose::STANDARD as BASE64;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -475,6 +482,23 @@ mod tests {
         assert_eq!(decoded.expected_run_id.as_deref(), Some("run-full-id"));
         assert_eq!(decoded.command, "printf raw");
         assert_eq!(response_format, ExecResponseFormat::RawV1);
+    }
+
+    #[test]
+    fn capabilities_response_accepts_additive_fields() {
+        let response: CapabilitiesResponse = serde_json::from_value(serde_json::json!({
+            "exec_response_raw_version": RAW_EXEC_RESPONSE_VERSION,
+            "terminate_version": 1,
+        }))
+        .unwrap();
+
+        let CapabilitiesResponse::Supported {
+            exec_response_raw_version,
+        } = response
+        else {
+            panic!("explicit raw version should remain supported with additive fields");
+        };
+        assert_eq!(exec_response_raw_version, RAW_EXEC_RESPONSE_VERSION);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -34,6 +34,96 @@ fn default_timeout() -> u32 {
     30
 }
 
+/// Request that probes control-server capabilities without executing a command.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct CapabilitiesRequest {
+    pub(super) action: CapabilitiesAction,
+}
+
+/// Non-executing control action used for protocol negotiation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum CapabilitiesAction {
+    Capabilities,
+}
+
+/// Response to a control capability probe.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged, deny_unknown_fields)]
+pub(super) enum CapabilitiesResponse {
+    Supported { exec_response_raw_version: u8 },
+    Unsupported { error: String },
+}
+
+/// Exec response representation selected by a negotiated request.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum ExecResponseFormat {
+    #[default]
+    JsonBase64,
+    RawV1,
+}
+
+/// Server-side exec request shape that also accepts a negotiated response format.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct WireExecRequest {
+    #[serde(default)]
+    pub(super) expected_run_id: Option<String>,
+    pub(super) command: String,
+    #[serde(default = "default_timeout")]
+    pub(super) timeout_secs: u32,
+    #[serde(default)]
+    pub(super) sudo: bool,
+    #[serde(default)]
+    pub(super) response_format: ExecResponseFormat,
+}
+
+impl WireExecRequest {
+    pub(super) fn into_request(self) -> (ExecRequest, ExecResponseFormat) {
+        let Self {
+            expected_run_id,
+            command,
+            timeout_secs,
+            sudo,
+            response_format,
+        } = self;
+        (
+            ExecRequest {
+                expected_run_id,
+                command,
+                timeout_secs,
+                sudo,
+            },
+            response_format,
+        )
+    }
+}
+
+/// Borrowed exec request that explicitly selects raw response version 1.
+#[derive(Debug, Serialize)]
+pub(super) struct RawExecRequest<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) expected_run_id: Option<&'a str>,
+    pub(super) command: &'a str,
+    pub(super) timeout_secs: u32,
+    pub(super) sudo: bool,
+    pub(super) response_format: ExecResponseFormat,
+}
+
+impl<'a> From<&'a ExecRequest> for RawExecRequest<'a> {
+    fn from(request: &'a ExecRequest) -> Self {
+        Self {
+            expected_run_id: request.expected_run_id.as_deref(),
+            command: &request.command,
+            timeout_secs: request.timeout_secs,
+            sudo: request.sudo,
+            response_format: ExecResponseFormat::RawV1,
+        }
+    }
+}
+
 /// Response to a `runner exec` client.
 ///
 /// This enum is serialized without a tag. Clients should distinguish variants
@@ -146,7 +236,7 @@ pub enum TerminateResponse {
 }
 
 /// Maximum frame payload size: 64 MiB, excluding the 4-byte length prefix.
-const MAX_FRAME_PAYLOAD_SIZE: u32 = 64 * 1024 * 1024;
+pub(super) const MAX_FRAME_PAYLOAD_SIZE: u32 = 64 * 1024 * 1024;
 
 fn frame_payload_len_error(len: usize) -> io::Error {
     io::Error::new(
@@ -155,7 +245,7 @@ fn frame_payload_len_error(len: usize) -> io::Error {
     )
 }
 
-fn validate_frame_payload_len(len: usize) -> io::Result<u32> {
+pub(super) fn validate_frame_payload_len(len: usize) -> io::Result<u32> {
     if len > MAX_FRAME_PAYLOAD_SIZE as usize {
         return Err(frame_payload_len_error(len));
     }
@@ -165,19 +255,30 @@ fn validate_frame_payload_len(len: usize) -> io::Result<u32> {
 
 /// Read a length-prefixed frame from the stream.
 pub(super) async fn read_frame(stream: &mut UnixStream) -> io::Result<Vec<u8>> {
-    let len = validate_frame_payload_len(stream.read_u32().await? as usize)?;
-    let mut buf = vec![0u8; len as usize];
+    let len = read_frame_payload_len(stream).await?;
+    let mut buf = vec![0u8; len];
     stream.read_exact(&mut buf).await?;
     Ok(buf)
 }
 
+/// Read and validate a frame payload length without allocating its payload.
+pub(super) async fn read_frame_payload_len(stream: &mut UnixStream) -> io::Result<usize> {
+    let len = stream.read_u32().await? as usize;
+    validate_frame_payload_len(len)?;
+    Ok(len)
+}
+
 /// Write a length-prefixed frame to the stream.
 pub(super) async fn write_frame(stream: &mut UnixStream, data: &[u8]) -> io::Result<()> {
-    let len = validate_frame_payload_len(data.len())?;
-    stream.write_u32(len).await?;
+    write_frame_payload_len(stream, data.len()).await?;
     stream.write_all(data).await?;
     stream.flush().await?;
     Ok(())
+}
+
+/// Validate and write a frame payload length without requiring a contiguous payload.
+pub(super) async fn write_frame_payload_len(stream: &mut UnixStream, len: usize) -> io::Result<()> {
+    stream.write_u32(validate_frame_payload_len(len)?).await
 }
 
 #[cfg(test)]
@@ -339,6 +440,41 @@ mod tests {
         assert_eq!(req.command, "apt install curl");
         assert_eq!(req.timeout_secs, 60);
         assert!(req.sudo);
+    }
+
+    #[test]
+    fn wire_exec_request_preserves_legacy_defaults() {
+        let request: WireExecRequest = serde_json::from_str(r#"{"command":"echo hi"}"#).unwrap();
+        let (request, response_format) = request.into_request();
+
+        assert_eq!(request.expected_run_id, None);
+        assert_eq!(request.command, "echo hi");
+        assert_eq!(request.timeout_secs, 30);
+        assert!(!request.sudo);
+        assert_eq!(response_format, ExecResponseFormat::JsonBase64);
+    }
+
+    #[test]
+    fn raw_exec_request_explicitly_selects_raw_v1() {
+        let request = ExecRequest {
+            expected_run_id: Some("run-full-id".into()),
+            command: "printf raw".into(),
+            timeout_secs: 17,
+            sudo: true,
+        };
+        let json = serde_json::to_value(RawExecRequest::from(&request)).unwrap();
+
+        assert_eq!(json["expected_run_id"], "run-full-id");
+        assert_eq!(json["command"], "printf raw");
+        assert_eq!(json["timeout_secs"], 17);
+        assert_eq!(json["sudo"], true);
+        assert_eq!(json["response_format"], "raw_v1");
+
+        let decoded: WireExecRequest = serde_json::from_value(json).unwrap();
+        let (decoded, response_format) = decoded.into_request();
+        assert_eq!(decoded.expected_run_id.as_deref(), Some("run-full-id"));
+        assert_eq!(decoded.command, "printf raw");
+        assert_eq!(response_format, ExecResponseFormat::RawV1);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -8,8 +8,6 @@ use tokio::net::UnixStream;
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct ExecRequest {
-    /// Required wire marker for the raw exec response protocol.
-    pub(super) response_format: ExecResponseFormat,
     /// Full run identity that must still own the sandbox at guest admission.
     ///
     /// Missing means the caller intentionally selected sandbox scope.
@@ -33,13 +31,6 @@ pub(super) struct ExecRequest {
 
 fn default_timeout() -> u32 {
     30
-}
-
-/// Exec response representation required by the control protocol.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub(super) enum ExecResponseFormat {
-    RawV1,
 }
 
 /// Host-side control action requested over the local control socket.
@@ -218,7 +209,6 @@ mod tests {
     #[tokio::test]
     async fn exec_request_round_trip() {
         let request = ExecRequest {
-            response_format: ExecResponseFormat::RawV1,
             expected_run_id: None,
             command: "echo hello".into(),
             timeout_secs: 10,
@@ -232,7 +222,6 @@ mod tests {
         assert_eq!(decoded.command, "echo hello");
         assert_eq!(decoded.timeout_secs, 10);
         assert!(!decoded.sudo);
-        assert_eq!(decoded.response_format, ExecResponseFormat::RawV1);
         assert!(
             serde_json::from_slice::<serde_json::Value>(&request_json)
                 .unwrap()
@@ -244,7 +233,6 @@ mod tests {
     #[test]
     fn guarded_exec_request_round_trips_run_identity() {
         let request = ExecRequest {
-            response_format: ExecResponseFormat::RawV1,
             expected_run_id: Some("run-full-id".into()),
             command: "true".into(),
             timeout_secs: 30,
@@ -260,33 +248,21 @@ mod tests {
     #[test]
     fn exec_request_default_timeout() {
         // timeout_secs has a serde default of 30
-        let json = r#"{"response_format":"raw_v1","command":"echo hi"}"#;
+        let json = r#"{"command":"echo hi"}"#;
         let req: ExecRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.expected_run_id, None);
         assert_eq!(req.command, "echo hi");
         assert_eq!(req.timeout_secs, 30);
         assert!(!req.sudo);
-        assert_eq!(req.response_format, ExecResponseFormat::RawV1);
     }
 
     #[test]
     fn exec_request_with_sudo() {
-        let json = r#"{"response_format":"raw_v1","command":"apt install curl","timeout_secs":60,"sudo":true}"#;
+        let json = r#"{"command":"apt install curl","timeout_secs":60,"sudo":true}"#;
         let req: ExecRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.command, "apt install curl");
         assert_eq!(req.timeout_secs, 60);
         assert!(req.sudo);
-    }
-
-    #[test]
-    fn exec_request_requires_raw_response_format() {
-        assert!(serde_json::from_str::<ExecRequest>(r#"{"command":"echo hi"}"#).is_err());
-        assert!(
-            serde_json::from_str::<ExecRequest>(
-                r#"{"response_format":"raw_v2","command":"echo hi"}"#,
-            )
-            .is_err()
-        );
     }
 
     #[test]

--- a/crates/sandbox-fc/src/control/provider.rs
+++ b/crates/sandbox-fc/src/control/provider.rs
@@ -3,17 +3,15 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD as BASE64;
 use sandbox::{
     RemoteExecResult, RemoteKillResult, SandboxControl, SandboxControlError, SandboxControlTarget,
 };
 
 use super::CONTROL_SOCKET_OVERHEAD_MS;
-use super::client::{ReceivedExecResponse, send_exec_result, send_terminate};
+use super::client::{send_exec, send_terminate};
 use super::exec_response::ExecResult;
 use super::protocol::{
-    ExecRequest, ExecResponse, TerminateAction, TerminateRequest, TerminateResponse,
+    ExecRequest, ExecResponseFormat, TerminateAction, TerminateRequest, TerminateResponse,
     TerminateStatus,
 };
 use super::resolver::resolve_control_socket;
@@ -44,6 +42,7 @@ impl SandboxControl for FirecrackerControl {
 
         let timeout_secs = request_timeout_secs(timeout);
         let request = ExecRequest {
+            response_format: ExecResponseFormat::RawV1,
             expected_run_id: target.expected_run_id().map(str::to_owned),
             command: command.to_owned(),
             timeout_secs,
@@ -51,7 +50,7 @@ impl SandboxControl for FirecrackerControl {
         };
 
         // Add 5 seconds for control socket overhead beyond the command timeout.
-        let response = send_exec_result(&sock_path, &request, control_timeout(timeout_secs))
+        let response = send_exec(&sock_path, &request, control_timeout(timeout_secs))
             .await
             .map_err(|e| {
                 if e.kind() == io::ErrorKind::InvalidInput {
@@ -61,10 +60,7 @@ impl SandboxControl for FirecrackerControl {
                 }
             })?;
 
-        match response {
-            ReceivedExecResponse::Raw(result) => remote_exec_result_from_result(result),
-            ReceivedExecResponse::Legacy(response) => remote_exec_result_from_response(response),
-        }
+        remote_exec_result_from_result(response)
     }
 
     async fn kill_remote(
@@ -113,39 +109,6 @@ impl SandboxControl for FirecrackerControl {
     }
 }
 
-fn remote_exec_result_from_response(
-    response: ExecResponse,
-) -> Result<RemoteExecResult, SandboxControlError> {
-    let result = match response {
-        ExecResponse::Success {
-            termination,
-            stdout,
-            stderr,
-            stdout_truncated,
-            stderr_truncated,
-            diagnostic,
-        } => {
-            let stdout_bytes = BASE64
-                .decode(&stdout)
-                .map_err(|e| SandboxControlError::Connection(format!("decode stdout: {e}")))?;
-            let stderr_bytes = BASE64
-                .decode(&stderr)
-                .map_err(|e| SandboxControlError::Connection(format!("decode stderr: {e}")))?;
-            ExecResult::Success {
-                termination,
-                stdout: stdout_bytes,
-                stderr: stderr_bytes,
-                diagnostic,
-                stdout_truncated,
-                stderr_truncated,
-            }
-        }
-        ExecResponse::Error { error } => ExecResult::Error { error },
-    };
-
-    remote_exec_result_from_result(result)
-}
-
 fn remote_exec_result_from_result(
     result: ExecResult,
 ) -> Result<RemoteExecResult, SandboxControlError> {
@@ -186,11 +149,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn remote_exec_response_success_decodes_structured_result() {
-        let result = remote_exec_result_from_response(ExecResponse::Success {
+    fn remote_exec_result_maps_structured_result() {
+        let result = remote_exec_result_from_result(ExecResult::Success {
             termination: ExecTermination::Exited { exit_code: 7 },
-            stdout: BASE64.encode(b"out"),
-            stderr: BASE64.encode(b"err"),
+            stdout: b"out".to_vec(),
+            stderr: b"err".to_vec(),
             stdout_truncated: true,
             stderr_truncated: false,
             diagnostic: "diagnostic".into(),
@@ -206,42 +169,8 @@ mod tests {
     }
 
     #[test]
-    fn remote_exec_response_invalid_base64_is_connection_error() {
-        let result = remote_exec_result_from_response(ExecResponse::Success {
-            termination: ExecTermination::Exited { exit_code: 0 },
-            stdout: "not base64".into(),
-            stderr: BASE64.encode(b""),
-            stdout_truncated: false,
-            stderr_truncated: false,
-            diagnostic: String::new(),
-        });
-
-        let Err(SandboxControlError::Connection(message)) = result else {
-            panic!("expected connection error");
-        };
-        assert!(message.contains("decode stdout"));
-    }
-
-    #[test]
-    fn remote_exec_response_invalid_stderr_base64_is_connection_error() {
-        let result = remote_exec_result_from_response(ExecResponse::Success {
-            termination: ExecTermination::Exited { exit_code: 0 },
-            stdout: BASE64.encode(b""),
-            stderr: "not base64".into(),
-            stdout_truncated: false,
-            stderr_truncated: false,
-            diagnostic: String::new(),
-        });
-
-        let Err(SandboxControlError::Connection(message)) = result else {
-            panic!("expected connection error");
-        };
-        assert!(message.contains("decode stderr"));
-    }
-
-    #[test]
-    fn remote_exec_response_error_maps_to_remote_error() {
-        let result = remote_exec_result_from_response(ExecResponse::Error {
+    fn remote_exec_result_error_maps_to_remote_error() {
+        let result = remote_exec_result_from_result(ExecResult::Error {
             error: "sandbox not running".into(),
         });
 

--- a/crates/sandbox-fc/src/control/provider.rs
+++ b/crates/sandbox-fc/src/control/provider.rs
@@ -11,8 +11,7 @@ use super::CONTROL_SOCKET_OVERHEAD_MS;
 use super::client::{send_exec, send_terminate};
 use super::exec_response::ExecResult;
 use super::protocol::{
-    ExecRequest, ExecResponseFormat, TerminateAction, TerminateRequest, TerminateResponse,
-    TerminateStatus,
+    ExecRequest, TerminateAction, TerminateRequest, TerminateResponse, TerminateStatus,
 };
 use super::resolver::resolve_control_socket;
 use crate::paths::RuntimePaths;
@@ -42,7 +41,6 @@ impl SandboxControl for FirecrackerControl {
 
         let timeout_secs = request_timeout_secs(timeout);
         let request = ExecRequest {
-            response_format: ExecResponseFormat::RawV1,
             expected_run_id: target.expected_run_id().map(str::to_owned),
             command: command.to_owned(),
             timeout_secs,

--- a/crates/sandbox-fc/src/control/provider.rs
+++ b/crates/sandbox-fc/src/control/provider.rs
@@ -10,7 +10,8 @@ use sandbox::{
 };
 
 use super::CONTROL_SOCKET_OVERHEAD_MS;
-use super::client::{send_exec, send_terminate};
+use super::client::{ReceivedExecResponse, send_exec_result, send_terminate};
+use super::exec_response::ExecResult;
 use super::protocol::{
     ExecRequest, ExecResponse, TerminateAction, TerminateRequest, TerminateResponse,
     TerminateStatus,
@@ -50,7 +51,7 @@ impl SandboxControl for FirecrackerControl {
         };
 
         // Add 5 seconds for control socket overhead beyond the command timeout.
-        let response = send_exec(&sock_path, &request, control_timeout(timeout_secs))
+        let response = send_exec_result(&sock_path, &request, control_timeout(timeout_secs))
             .await
             .map_err(|e| {
                 if e.kind() == io::ErrorKind::InvalidInput {
@@ -60,7 +61,10 @@ impl SandboxControl for FirecrackerControl {
                 }
             })?;
 
-        remote_exec_result_from_response(response)
+        match response {
+            ReceivedExecResponse::Raw(result) => remote_exec_result_from_result(result),
+            ReceivedExecResponse::Legacy(response) => remote_exec_result_from_response(response),
+        }
     }
 
     async fn kill_remote(
@@ -112,7 +116,7 @@ impl SandboxControl for FirecrackerControl {
 fn remote_exec_result_from_response(
     response: ExecResponse,
 ) -> Result<RemoteExecResult, SandboxControlError> {
-    match response {
+    let result = match response {
         ExecResponse::Success {
             termination,
             stdout,
@@ -127,16 +131,41 @@ fn remote_exec_result_from_response(
             let stderr_bytes = BASE64
                 .decode(&stderr)
                 .map_err(|e| SandboxControlError::Connection(format!("decode stderr: {e}")))?;
-            Ok(RemoteExecResult {
+            ExecResult::Success {
                 termination,
                 stdout: stdout_bytes,
                 stderr: stderr_bytes,
                 diagnostic,
                 stdout_truncated,
                 stderr_truncated,
-            })
+            }
         }
-        ExecResponse::Error { error } => Err(SandboxControlError::Remote(error)),
+        ExecResponse::Error { error } => ExecResult::Error { error },
+    };
+
+    remote_exec_result_from_result(result)
+}
+
+fn remote_exec_result_from_result(
+    result: ExecResult,
+) -> Result<RemoteExecResult, SandboxControlError> {
+    match result {
+        ExecResult::Success {
+            termination,
+            stdout,
+            stderr,
+            stdout_truncated,
+            stderr_truncated,
+            diagnostic,
+        } => Ok(RemoteExecResult {
+            termination,
+            stdout,
+            stderr,
+            diagnostic,
+            stdout_truncated,
+            stderr_truncated,
+        }),
+        ExecResult::Error { error } => Err(SandboxControlError::Remote(error)),
     }
 }
 

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -14,8 +14,8 @@ use tracing::{info, warn};
 use super::CONTROL_SOCKET_OVERHEAD_MS;
 use super::exec_response::{ExecResult, write_raw_exec_response};
 use super::protocol::{
-    ExecRequest, ExecResponseFormat, TerminateAction, TerminateRequest, TerminateResponse,
-    TerminateStatus, read_frame, write_frame,
+    ExecRequest, TerminateAction, TerminateRequest, TerminateResponse, TerminateStatus, read_frame,
+    write_frame,
 };
 use crate::exec_operation_result::{
     captured_exec_output_bytes, exec_termination_from_vsock_termination, reject_stream_overflow,
@@ -448,7 +448,6 @@ async fn execute(request: ExecRequest, guest_operations: &GuestOperationStartGat
     };
 
     let ExecRequest {
-        response_format: ExecResponseFormat::RawV1,
         expected_run_id,
         command,
         timeout_secs,

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -4,8 +4,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::Serialize;
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{mpsc, oneshot};
@@ -14,11 +12,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use super::CONTROL_SOCKET_OVERHEAD_MS;
-use super::exec_response::{ExecResult, RAW_EXEC_RESPONSE_VERSION, write_raw_exec_response};
+use super::exec_response::{ExecResult, write_raw_exec_response};
 use super::protocol::{
-    CapabilitiesRequest, CapabilitiesResponse, ExecRequest, ExecResponse, ExecResponseFormat,
-    TerminateAction, TerminateRequest, TerminateResponse, TerminateStatus, WireExecRequest,
-    read_frame, write_frame,
+    ExecRequest, ExecResponseFormat, TerminateAction, TerminateRequest, TerminateResponse,
+    TerminateStatus, read_frame, write_frame,
 };
 use crate::exec_operation_result::{
     captured_exec_output_bytes, exec_termination_from_vsock_termination, reject_stream_overflow,
@@ -385,53 +382,26 @@ async fn handle_connection(
         result = read_frame(&mut stream) => result?,
     };
 
-    if serde_json::from_slice::<CapabilitiesRequest>(&frame).is_ok() {
-        return write_json_frame(
-            &mut stream,
-            &CapabilitiesResponse::Supported {
-                exec_response_raw_version: RAW_EXEC_RESPONSE_VERSION,
-            },
-        )
-        .await;
-    }
-
     if let Ok(request) = serde_json::from_slice::<TerminateRequest>(&frame) {
         let response = terminate(request, &termination).await;
         return write_json_frame(&mut stream, &response).await;
     }
 
-    let (response, response_format) = match serde_json::from_slice::<WireExecRequest>(&frame) {
-        Ok(request) => {
-            let (request, response_format) = request.into_request();
-            let response = tokio::select! {
-                biased;
-                () = shutdown.cancelled() => return Ok(()),
-                response = execute(request, &guest_operations) => response,
-            };
-            (response, response_format)
-        }
-        Err(e) => (
-            ExecResult::Error {
-                error: format!("invalid request: {e}"),
-            },
-            ExecResponseFormat::JsonBase64,
-        ),
-    };
-
-    match response_format {
-        ExecResponseFormat::JsonBase64 => {
-            let response_json = encode_json_frame(&legacy_response_from_result(response))?;
-            tokio::select! {
-                biased;
-                () = shutdown.cancelled() => return Ok(()),
-                result = write_frame(&mut stream, &response_json) => result?,
-            }
-        }
-        ExecResponseFormat::RawV1 => tokio::select! {
+    let response = match serde_json::from_slice::<ExecRequest>(&frame) {
+        Ok(request) => tokio::select! {
             biased;
             () = shutdown.cancelled() => return Ok(()),
-            result = write_raw_exec_response(&mut stream, &response) => result?,
+            response = execute(request, &guest_operations) => response,
         },
+        Err(e) => ExecResult::Error {
+            error: format!("invalid request: {e}"),
+        },
+    };
+
+    tokio::select! {
+        biased;
+        () = shutdown.cancelled() => return Ok(()),
+        result = write_raw_exec_response(&mut stream, &response) => result?,
     }
 
     Ok(())
@@ -478,6 +448,7 @@ async fn execute(request: ExecRequest, guest_operations: &GuestOperationStartGat
     };
 
     let ExecRequest {
+        response_format: ExecResponseFormat::RawV1,
         expected_run_id,
         command,
         timeout_secs,
@@ -556,27 +527,6 @@ fn exec_result_from_operation_result(
         stderr_truncated,
         diagnostic,
     })
-}
-
-fn legacy_response_from_result(result: ExecResult) -> ExecResponse {
-    match result {
-        ExecResult::Success {
-            termination,
-            stdout,
-            stderr,
-            stdout_truncated,
-            stderr_truncated,
-            diagnostic,
-        } => ExecResponse::Success {
-            termination,
-            stdout: BASE64.encode(stdout),
-            stderr: BASE64.encode(stderr),
-            stdout_truncated,
-            stderr_truncated,
-            diagnostic,
-        },
-        ExecResult::Error { error } => ExecResponse::Error { error },
-    }
 }
 
 fn control_start_error(error: GuestOperationStartError) -> String {

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -14,9 +14,11 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use super::CONTROL_SOCKET_OVERHEAD_MS;
+use super::exec_response::{ExecResult, RAW_EXEC_RESPONSE_VERSION, write_raw_exec_response};
 use super::protocol::{
-    ExecRequest, ExecResponse, TerminateAction, TerminateRequest, TerminateResponse,
-    TerminateStatus, read_frame, write_frame,
+    CapabilitiesRequest, CapabilitiesResponse, ExecRequest, ExecResponse, ExecResponseFormat,
+    TerminateAction, TerminateRequest, TerminateResponse, TerminateStatus, WireExecRequest,
+    read_frame, write_frame,
 };
 use crate::exec_operation_result::{
     captured_exec_output_bytes, exec_termination_from_vsock_termination, reject_stream_overflow,
@@ -383,27 +385,53 @@ async fn handle_connection(
         result = read_frame(&mut stream) => result?,
     };
 
+    if serde_json::from_slice::<CapabilitiesRequest>(&frame).is_ok() {
+        return write_json_frame(
+            &mut stream,
+            &CapabilitiesResponse::Supported {
+                exec_response_raw_version: RAW_EXEC_RESPONSE_VERSION,
+            },
+        )
+        .await;
+    }
+
     if let Ok(request) = serde_json::from_slice::<TerminateRequest>(&frame) {
         let response = terminate(request, &termination).await;
         return write_json_frame(&mut stream, &response).await;
     }
 
-    let response = match serde_json::from_slice::<ExecRequest>(&frame) {
-        Ok(request) => tokio::select! {
-            biased;
-            () = shutdown.cancelled() => return Ok(()),
-            response = execute(request, &guest_operations) => response,
-        },
-        Err(e) => ExecResponse::Error {
-            error: format!("invalid request: {e}"),
-        },
+    let (response, response_format) = match serde_json::from_slice::<WireExecRequest>(&frame) {
+        Ok(request) => {
+            let (request, response_format) = request.into_request();
+            let response = tokio::select! {
+                biased;
+                () = shutdown.cancelled() => return Ok(()),
+                response = execute(request, &guest_operations) => response,
+            };
+            (response, response_format)
+        }
+        Err(e) => (
+            ExecResult::Error {
+                error: format!("invalid request: {e}"),
+            },
+            ExecResponseFormat::JsonBase64,
+        ),
     };
 
-    let response_json = encode_json_frame(&response)?;
-    tokio::select! {
-        biased;
-        () = shutdown.cancelled() => return Ok(()),
-        result = write_frame(&mut stream, &response_json) => result?,
+    match response_format {
+        ExecResponseFormat::JsonBase64 => {
+            let response_json = encode_json_frame(&legacy_response_from_result(response))?;
+            tokio::select! {
+                biased;
+                () = shutdown.cancelled() => return Ok(()),
+                result = write_frame(&mut stream, &response_json) => result?,
+            }
+        }
+        ExecResponseFormat::RawV1 => tokio::select! {
+            biased;
+            () = shutdown.cancelled() => return Ok(()),
+            result = write_raw_exec_response(&mut stream, &response) => result?,
+        },
     }
 
     Ok(())
@@ -439,11 +467,11 @@ fn encode_json_frame<Response: Serialize>(response: &Response) -> io::Result<Vec
 }
 
 /// Execute an [`ExecRequest`] through the sandbox operation start gate.
-async fn execute(request: ExecRequest, guest_operations: &GuestOperationStartGate) -> ExecResponse {
+async fn execute(request: ExecRequest, guest_operations: &GuestOperationStartGate) -> ExecResult {
     let vsock = match guest_operations.begin_control_operation().await {
         Ok(vsock) => vsock,
         Err(error) => {
-            return ExecResponse::Error {
+            return ExecResult::Error {
                 error: control_start_error(error),
             };
         }
@@ -459,7 +487,7 @@ async fn execute(request: ExecRequest, guest_operations: &GuestOperationStartGat
     let env: &[(&str, &str)] = &[];
 
     if let Err(e) = validate_exec_capture_timeout(timeout_ms) {
-        return ExecResponse::Error {
+        return ExecResult::Error {
             error: format!("exec failed: {e}"),
         };
     }
@@ -494,19 +522,19 @@ async fn execute(request: ExecRequest, guest_operations: &GuestOperationStartGat
             write_admission,
         )
         .await
-        .and_then(exec_response_from_operation_result);
+        .and_then(exec_result_from_operation_result);
 
     match result {
         Ok(response) => response,
-        Err(e) => ExecResponse::Error {
+        Err(e) => ExecResult::Error {
             error: format!("exec failed: {e}"),
         },
     }
 }
 
-fn exec_response_from_operation_result(
+fn exec_result_from_operation_result(
     result: vsock_host::ExecOperationResult,
-) -> io::Result<ExecResponse> {
+) -> io::Result<ExecResult> {
     reject_stream_overflow(&result)?;
 
     let vsock_host::ExecOperationResult {
@@ -520,14 +548,35 @@ fn exec_response_from_operation_result(
     let (stdout, stdout_truncated) = captured_exec_output_bytes("stdout", stdout)?;
     let (stderr, stderr_truncated) = captured_exec_output_bytes("stderr", stderr)?;
 
-    Ok(ExecResponse::Success {
+    Ok(ExecResult::Success {
         termination: exec_termination_from_vsock_termination(termination),
-        stdout: BASE64.encode(stdout),
-        stderr: BASE64.encode(stderr),
+        stdout,
+        stderr,
         stdout_truncated,
         stderr_truncated,
         diagnostic,
     })
+}
+
+fn legacy_response_from_result(result: ExecResult) -> ExecResponse {
+    match result {
+        ExecResult::Success {
+            termination,
+            stdout,
+            stderr,
+            stdout_truncated,
+            stderr_truncated,
+            diagnostic,
+        } => ExecResponse::Success {
+            termination,
+            stdout: BASE64.encode(stdout),
+            stderr: BASE64.encode(stderr),
+            stdout_truncated,
+            stderr_truncated,
+            diagnostic,
+        },
+        ExecResult::Error { error } => ExecResponse::Error { error },
+    }
 }
 
 fn control_start_error(error: GuestOperationStartError) -> String {

--- a/crates/sandbox-fc/src/control/server/tests.rs
+++ b/crates/sandbox-fc/src/control/server/tests.rs
@@ -14,7 +14,6 @@ use vsock_proto::{
 };
 
 use crate::control::client::send_exec;
-use crate::control::exec_response::read_raw_exec_response;
 use crate::control::{
     TerminateAction, TerminateRequest, TerminateResponse, TerminateStatus, send_terminate,
 };
@@ -114,7 +113,6 @@ fn empty_guest() -> GuestState {
 
 fn exec_request(command: &str) -> ExecRequest {
     ExecRequest {
-        response_format: ExecResponseFormat::RawV1,
         expected_run_id: None,
         command: command.into(),
         timeout_secs: 5,
@@ -370,39 +368,6 @@ async fn client_receives_raw_server_error() {
     };
     assert!(error.contains("not running"), "unexpected error: {error}");
     handle.shutdown().await;
-}
-
-#[tokio::test]
-async fn legacy_exec_request_is_rejected_before_guest_execution() {
-    let (exec_seen_tx, mut exec_seen_rx) = oneshot::channel();
-    let fixture =
-        VsockExecFixture::connect(|vsock_base| mock_guest_records_exec(vsock_base, exec_seen_tx))
-            .await;
-    let mut handle = fixture.spawn_server();
-    let mut stream = UnixStream::connect(&fixture.sock_path).await.unwrap();
-    let legacy_request = serde_json::json!({
-        "command": "must-not-run",
-        "timeout_secs": 5,
-        "sudo": false,
-    });
-
-    write_frame(&mut stream, &serde_json::to_vec(&legacy_request).unwrap())
-        .await
-        .unwrap();
-    let response = read_raw_exec_response(&mut stream).await.unwrap();
-
-    let ExecResult::Error { error } = response else {
-        panic!("legacy request should return a raw protocol error");
-    };
-    assert!(
-        error.contains("response_format"),
-        "unexpected error: {error}"
-    );
-    assert!(matches!(exec_seen_rx.try_recv(), Err(TryRecvError::Empty)));
-
-    handle.shutdown().await;
-    fixture.guest_task.abort();
-    let _ = fixture.guest_task.await;
 }
 
 // Terminate protocol behavior.
@@ -832,7 +797,6 @@ async fn control_server_shutdown_cancels_in_flight_vsock_exec() {
         let sock_path = fixture.sock_path.clone();
         async move {
             let request = ExecRequest {
-                response_format: ExecResponseFormat::RawV1,
                 expected_run_id: None,
                 command: "sleep 30".into(),
                 timeout_secs: 30,
@@ -912,7 +876,6 @@ async fn control_exec_rejects_zero_timeout_without_guest_exec() {
             .await;
     let mut handle = fixture.spawn_server();
     let request = ExecRequest {
-        response_format: ExecResponseFormat::RawV1,
         expected_run_id: None,
         command: "echo should-not-run".into(),
         timeout_secs: 0,

--- a/crates/sandbox-fc/src/control/server/tests.rs
+++ b/crates/sandbox-fc/src/control/server/tests.rs
@@ -13,10 +13,10 @@ use vsock_proto::{
     RawMessage,
 };
 
-use crate::control::client::{ReceivedExecResponse, send_exec_result};
+use crate::control::client::send_exec;
+use crate::control::exec_response::read_raw_exec_response;
 use crate::control::{
-    ExecRequest, ExecResponse, TerminateAction, TerminateRequest, TerminateResponse,
-    TerminateStatus, send_exec, send_terminate,
+    TerminateAction, TerminateRequest, TerminateResponse, TerminateStatus, send_terminate,
 };
 use crate::park_coordinator::{
     CoordinatorState, DirtyReason, ParkCoordinator, PrepareParkEvidence,
@@ -114,6 +114,7 @@ fn empty_guest() -> GuestState {
 
 fn exec_request(command: &str) -> ExecRequest {
     ExecRequest {
+        response_format: ExecResponseFormat::RawV1,
         expected_run_id: None,
         command: command.into(),
         timeout_secs: 5,
@@ -342,21 +343,21 @@ async fn client_server_no_guest() {
         .unwrap();
 
     match response {
-        ExecResponse::Error { error } => {
+        ExecResult::Error { error } => {
             assert!(error.contains("not running"), "unexpected error: {error}");
         }
-        ExecResponse::Success { .. } => panic!("expected error when guest is None"),
+        ExecResult::Success { .. } => panic!("expected error when guest is None"),
     }
 
     handle.shutdown().await;
 }
 
 #[tokio::test]
-async fn negotiated_client_receives_raw_server_error() {
+async fn client_receives_raw_server_error() {
     let fixture = ControlServerFixture::new();
     let mut handle = fixture.spawn_default(CancellationToken::new());
 
-    let response = send_exec_result(
+    let response = send_exec(
         &fixture.sock_path,
         &exec_request("ps aux"),
         Duration::from_secs(5),
@@ -364,11 +365,44 @@ async fn negotiated_client_receives_raw_server_error() {
     .await
     .unwrap();
 
-    let ReceivedExecResponse::Raw(ExecResult::Error { error }) = response else {
-        panic!("new server should return a negotiated raw error");
+    let ExecResult::Error { error } = response else {
+        panic!("server should return a raw error");
     };
     assert!(error.contains("not running"), "unexpected error: {error}");
     handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn legacy_exec_request_is_rejected_before_guest_execution() {
+    let (exec_seen_tx, mut exec_seen_rx) = oneshot::channel();
+    let fixture =
+        VsockExecFixture::connect(|vsock_base| mock_guest_records_exec(vsock_base, exec_seen_tx))
+            .await;
+    let mut handle = fixture.spawn_server();
+    let mut stream = UnixStream::connect(&fixture.sock_path).await.unwrap();
+    let legacy_request = serde_json::json!({
+        "command": "must-not-run",
+        "timeout_secs": 5,
+        "sudo": false,
+    });
+
+    write_frame(&mut stream, &serde_json::to_vec(&legacy_request).unwrap())
+        .await
+        .unwrap();
+    let response = read_raw_exec_response(&mut stream).await.unwrap();
+
+    let ExecResult::Error { error } = response else {
+        panic!("legacy request should return a raw protocol error");
+    };
+    assert!(
+        error.contains("response_format"),
+        "unexpected error: {error}"
+    );
+    assert!(matches!(exec_seen_rx.try_recv(), Err(TryRecvError::Empty)));
+
+    handle.shutdown().await;
+    fixture.guest_task.abort();
+    let _ = fixture.guest_task.await;
 }
 
 // Terminate protocol behavior.
@@ -737,7 +771,7 @@ async fn control_server_shutdown_cancels_pending_connection() {
 // Vsock-backed control exec lifecycle.
 
 #[tokio::test]
-async fn negotiated_control_exec_streams_both_capture_limits() {
+async fn control_exec_streams_both_capture_limits() {
     const CAPTURE_LIMIT: usize = 7 * 1024 * 1024;
     let stdout = vec![0xa5; CAPTURE_LIMIT];
     let stderr = vec![0x5a; CAPTURE_LIMIT];
@@ -754,7 +788,7 @@ async fn negotiated_control_exec_streams_both_capture_limits() {
     .await;
     let mut handle = fixture.spawn_server();
 
-    let response = send_exec_result(
+    let response = send_exec(
         &fixture.sock_path,
         &exec_request("produce-boundary-output"),
         Duration::from_secs(5),
@@ -762,16 +796,16 @@ async fn negotiated_control_exec_streams_both_capture_limits() {
     .await
     .unwrap();
 
-    let ReceivedExecResponse::Raw(ExecResult::Success {
+    let ExecResult::Success {
         termination,
         stdout,
         stderr,
         stdout_truncated,
         stderr_truncated,
         diagnostic,
-    }) = response
+    } = response
     else {
-        panic!("new client and server should negotiate a raw success response");
+        panic!("server should return a raw success response");
     };
     assert_eq!(termination, ExecTermination::Exited { exit_code: 23 });
     assert_eq!(stdout.len(), CAPTURE_LIMIT);
@@ -798,6 +832,7 @@ async fn control_server_shutdown_cancels_in_flight_vsock_exec() {
         let sock_path = fixture.sock_path.clone();
         async move {
             let request = ExecRequest {
+                response_format: ExecResponseFormat::RawV1,
                 expected_run_id: None,
                 command: "sleep 30".into(),
                 timeout_secs: 30,
@@ -850,13 +885,13 @@ async fn control_exec_rejects_when_policy_gate_is_closing() {
         .unwrap();
 
     match response {
-        ExecResponse::Error { error } => {
+        ExecResult::Error { error } => {
             assert!(
                 error.contains("operation gate closed"),
                 "unexpected error: {error}"
             );
         }
-        ExecResponse::Success { .. } => panic!("expected gate-closed error"),
+        ExecResult::Success { .. } => panic!("expected gate-closed error"),
     }
     assert!(
         matches!(exec_seen_rx.try_recv(), Err(TryRecvError::Empty)),
@@ -877,6 +912,7 @@ async fn control_exec_rejects_zero_timeout_without_guest_exec() {
             .await;
     let mut handle = fixture.spawn_server();
     let request = ExecRequest {
+        response_format: ExecResponseFormat::RawV1,
         expected_run_id: None,
         command: "echo should-not-run".into(),
         timeout_secs: 0,
@@ -887,13 +923,13 @@ async fn control_exec_rejects_zero_timeout_without_guest_exec() {
         .unwrap();
 
     match response {
-        ExecResponse::Error { error } => {
+        ExecResult::Error { error } => {
             assert_eq!(
                 error,
                 "exec failed: exec requires a positive timeout; use supervised exec for unbounded commands"
             );
         }
-        ExecResponse::Success { .. } => panic!("expected zero-timeout validation error"),
+        ExecResult::Success { .. } => panic!("expected zero-timeout validation error"),
     }
     assert!(
         matches!(exec_seen_rx.try_recv(), Err(TryRecvError::Empty)),
@@ -918,13 +954,13 @@ async fn control_exec_terminal_guest_error_completes_vsock_operation() {
         .unwrap();
 
     match response {
-        ExecResponse::Error { error } => {
+        ExecResult::Error { error } => {
             assert!(
                 error.contains("guest refused exec"),
                 "unexpected error: {error}"
             );
         }
-        ExecResponse::Success { .. } => panic!("expected guest error"),
+        ExecResult::Success { .. } => panic!("expected guest error"),
     }
     assert!(fixture.vsock.try_fence_normal_operations().is_ok());
     let attempt = fixture
@@ -964,11 +1000,11 @@ async fn stale_run_exec_is_rejected_after_sandbox_reassignment() {
         .unwrap();
 
     match stale_response {
-        ExecResponse::Error { error } => {
+        ExecResult::Error { error } => {
             assert_eq!(error, format!("exec failed: {RUN_CONTROL_MISMATCH_ERROR}"));
             assert!(!error.contains("run-b"));
         }
-        ExecResponse::Success { .. } => panic!("stale run exec should fail closed"),
+        ExecResult::Success { .. } => panic!("stale run exec should fail closed"),
     }
     assert_eq!(fixture.coordinator.state(), CoordinatorState::Open);
     assert!(fixture.vsock.try_fence_normal_operations().is_ok());
@@ -983,10 +1019,10 @@ async fn stale_run_exec_is_rejected_after_sandbox_reassignment() {
     .await
     .unwrap();
     match matching_response {
-        ExecResponse::Error { error } => {
+        ExecResult::Error { error } => {
             assert!(error.contains("matching run reached guest"), "{error}");
         }
-        ExecResponse::Success { .. } => panic!("mock guest should reject exec"),
+        ExecResult::Success { .. } => panic!("mock guest should reject exec"),
     }
 
     handle.shutdown().await;
@@ -1011,10 +1047,10 @@ async fn control_exec_transport_error_makes_vsock_not_parkable() {
         .unwrap()
         .unwrap();
     match response {
-        ExecResponse::Error { error } => {
+        ExecResult::Error { error } => {
             assert!(error.contains("exec failed"), "unexpected error: {error}");
         }
-        ExecResponse::Success { .. } => panic!("expected transport error"),
+        ExecResult::Success { .. } => panic!("expected transport error"),
     }
     assert_eq!(fixture.coordinator.state(), CoordinatorState::Open);
     assert!(

--- a/crates/sandbox-fc/src/control/server/tests.rs
+++ b/crates/sandbox-fc/src/control/server/tests.rs
@@ -3,14 +3,17 @@ use super::*;
 use std::future::Future;
 use std::os::unix::fs::PermissionsExt;
 
-use base64::Engine;
 use sandbox::ExecTermination;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::oneshot::error::TryRecvError;
 use tokio::sync::{mpsc, oneshot};
 use vsock_host::{ExecOwnedCapturedOutput, NormalOperationFenceRejection, VsockHost};
-use vsock_proto::{Decoder, MSG_ERROR, MSG_EXEC_START, MSG_PING, MSG_PONG, MSG_READY, RawMessage};
+use vsock_proto::{
+    Decoder, ExecCapturedOutput, MSG_ERROR, MSG_EXEC_START, MSG_PING, MSG_PONG, MSG_READY,
+    RawMessage,
+};
 
+use crate::control::client::{ReceivedExecResponse, send_exec_result};
 use crate::control::{
     ExecRequest, ExecResponse, TerminateAction, TerminateRequest, TerminateResponse,
     TerminateStatus, send_exec, send_terminate,
@@ -141,10 +144,10 @@ fn control_exec_result(
 }
 
 fn expect_exec_success(
-    response: ExecResponse,
+    response: ExecResult,
 ) -> (ExecTermination, Vec<u8>, Vec<u8>, bool, bool, String) {
     match response {
-        ExecResponse::Success {
+        ExecResult::Success {
             termination,
             stdout,
             stderr,
@@ -153,13 +156,13 @@ fn expect_exec_success(
             diagnostic,
         } => (
             termination,
-            BASE64.decode(stdout).expect("stdout should decode"),
-            BASE64.decode(stderr).expect("stderr should decode"),
+            stdout,
+            stderr,
             stdout_truncated,
             stderr_truncated,
             diagnostic,
         ),
-        ExecResponse::Error { error } => panic!("expected success response, got error: {error}"),
+        ExecResult::Error { error } => panic!("expected success response, got error: {error}"),
     }
 }
 
@@ -214,7 +217,7 @@ async fn bind_server_sets_private_socket_mode() {
 
 #[test]
 fn control_exec_result_preserves_ordinary_exit_state() {
-    let response = exec_response_from_operation_result(control_exec_result(
+    let response = exec_result_from_operation_result(control_exec_result(
         vsock_proto::ExecTermination::Exited { exit_code: 7 },
         b"out".to_vec(),
         b"err".to_vec(),
@@ -260,7 +263,7 @@ fn control_exec_result_preserves_structured_terminal_state() {
             b"stderr clue".to_vec(),
         ),
     ] {
-        let response = exec_response_from_operation_result(control_exec_result(
+        let response = exec_result_from_operation_result(control_exec_result(
             termination,
             Vec::new(),
             expected_stderr.clone(),
@@ -277,7 +280,7 @@ fn control_exec_result_preserves_structured_terminal_state() {
 
 #[test]
 fn control_exec_result_rejects_invalid_capture_state() {
-    let overflow = exec_response_from_operation_result(vsock_host::ExecOperationResult {
+    let overflow = exec_result_from_operation_result(vsock_host::ExecOperationResult {
         stream_overflowed: true,
         ..control_exec_result(
             vsock_proto::ExecTermination::Exited { exit_code: 0 },
@@ -290,7 +293,7 @@ fn control_exec_result_rejects_invalid_capture_state() {
     assert_eq!(overflow.kind(), io::ErrorKind::InvalidData);
     assert!(overflow.to_string().contains("overflowed a stream queue"));
 
-    let stdout_discarded = exec_response_from_operation_result(vsock_host::ExecOperationResult {
+    let stdout_discarded = exec_result_from_operation_result(vsock_host::ExecOperationResult {
         stdout: ExecOwnedCapturedOutput::Discarded,
         ..control_exec_result(
             vsock_proto::ExecTermination::Exited { exit_code: 0 },
@@ -303,7 +306,7 @@ fn control_exec_result_rejects_invalid_capture_state() {
     assert_eq!(stdout_discarded.kind(), io::ErrorKind::InvalidData);
     assert!(stdout_discarded.to_string().contains("discarded stdout"));
 
-    let stderr_discarded = exec_response_from_operation_result(vsock_host::ExecOperationResult {
+    let stderr_discarded = exec_result_from_operation_result(vsock_host::ExecOperationResult {
         stderr: ExecOwnedCapturedOutput::Discarded,
         ..control_exec_result(
             vsock_proto::ExecTermination::Exited { exit_code: 0 },
@@ -345,6 +348,26 @@ async fn client_server_no_guest() {
         ExecResponse::Success { .. } => panic!("expected error when guest is None"),
     }
 
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn negotiated_client_receives_raw_server_error() {
+    let fixture = ControlServerFixture::new();
+    let mut handle = fixture.spawn_default(CancellationToken::new());
+
+    let response = send_exec_result(
+        &fixture.sock_path,
+        &exec_request("ps aux"),
+        Duration::from_secs(5),
+    )
+    .await
+    .unwrap();
+
+    let ReceivedExecResponse::Raw(ExecResult::Error { error }) = response else {
+        panic!("new server should return a negotiated raw error");
+    };
+    assert!(error.contains("not running"), "unexpected error: {error}");
     handle.shutdown().await;
 }
 
@@ -714,6 +737,57 @@ async fn control_server_shutdown_cancels_pending_connection() {
 // Vsock-backed control exec lifecycle.
 
 #[tokio::test]
+async fn negotiated_control_exec_streams_both_capture_limits() {
+    const CAPTURE_LIMIT: usize = 7 * 1024 * 1024;
+    let stdout = vec![0xa5; CAPTURE_LIMIT];
+    let stderr = vec![0x5a; CAPTURE_LIMIT];
+    let fixture = VsockExecFixture::connect(move |vsock_base| {
+        mock_guest_returns_exec(
+            vsock_base,
+            stdout,
+            stderr,
+            true,
+            false,
+            "boundary diagnostic",
+        )
+    })
+    .await;
+    let mut handle = fixture.spawn_server();
+
+    let response = send_exec_result(
+        &fixture.sock_path,
+        &exec_request("produce-boundary-output"),
+        Duration::from_secs(5),
+    )
+    .await
+    .unwrap();
+
+    let ReceivedExecResponse::Raw(ExecResult::Success {
+        termination,
+        stdout,
+        stderr,
+        stdout_truncated,
+        stderr_truncated,
+        diagnostic,
+    }) = response
+    else {
+        panic!("new client and server should negotiate a raw success response");
+    };
+    assert_eq!(termination, ExecTermination::Exited { exit_code: 23 });
+    assert_eq!(stdout.len(), CAPTURE_LIMIT);
+    assert!(stdout.iter().all(|byte| *byte == 0xa5));
+    assert_eq!(stderr.len(), CAPTURE_LIMIT);
+    assert!(stderr.iter().all(|byte| *byte == 0x5a));
+    assert!(stdout_truncated);
+    assert!(!stderr_truncated);
+    assert_eq!(diagnostic, "boundary diagnostic");
+
+    handle.shutdown().await;
+    fixture.guest_task.abort();
+    let _ = fixture.guest_task.await;
+}
+
+#[tokio::test]
 async fn control_server_shutdown_cancels_in_flight_vsock_exec() {
     let (exec_seen_tx, exec_seen_rx) = oneshot::channel();
     let fixture =
@@ -1047,6 +1121,55 @@ async fn mock_guest_errors_exec(vsock_base: PathBuf, error: &'static str) {
             let frame = vsock_proto::encode(MSG_ERROR, message.seq, &payload).unwrap();
             stream.write_all(&frame).await.unwrap();
             std::future::pending::<()>().await;
+        }
+    }
+}
+
+async fn mock_guest_returns_exec(
+    vsock_base: PathBuf,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    stdout_truncated: bool,
+    stderr_truncated: bool,
+    diagnostic: &'static str,
+) {
+    let listener_path = PathBuf::from(format!(
+        "{}_{}",
+        vsock_base.display(),
+        vsock_proto::VSOCK_PORT
+    ));
+    wait_for_socket_exists(&listener_path).await;
+
+    let mut stream = UnixStream::connect(&listener_path).await.unwrap();
+    let mut decoder = Decoder::new();
+    mock_vsock_handshake(&mut stream, &mut decoder).await;
+
+    loop {
+        let message = read_vsock_message(&mut stream, &mut decoder).await;
+        if message.msg_type == MSG_EXEC_START {
+            let mut frame = Vec::new();
+            vsock_proto::encode_exec_result_frame_into(
+                &mut frame,
+                message.seq,
+                vsock_proto::ExecTermination::Exited { exit_code: 23 },
+                10,
+                ExecCapturedOutput::Captured {
+                    bytes: &stdout,
+                    truncated: stdout_truncated,
+                },
+                ExecCapturedOutput::Captured {
+                    bytes: &stderr,
+                    truncated: stderr_truncated,
+                },
+                diagnostic,
+            )
+            .unwrap();
+            stream.write_all(&frame).await.unwrap();
+            drop(frame);
+            drop(stdout);
+            drop(stderr);
+            std::future::pending::<()>().await;
+            return;
         }
     }
 }


### PR DESCRIPTION
## Summary

- replace successful and error `runner exec` control responses with a single versioned raw protocol
- stream captured stdout and stderr directly across one control-socket connection without base64 or a complete response buffer
- keep the existing JSON exec request shape and make raw v1 the only response representation
- remove capability probing, format markers, JSON/base64 exec responses, fallback handling, and the unused direct `base64` dependency
- validate raw frame versions, tags, flags, lengths, UTF-8 fields, truncation, and the 64 MiB frame limit

## Protocol

- exec requests remain length-prefixed JSON with `command`, `timeout_secs`, `sudo`, and optional `expected_run_id`
- the server always returns a raw v1 success or error frame
- there is no negotiation, request-side response selector, legacy exec response, or fallback path
- terminate requests and responses remain unchanged JSON

This only changes the local `runner exec` debugging/CI control protocol. It does not change normal runner execution, the sandbox trait, runner CLI behavior, guest/vsock protocol, backend APIs, configuration, database schema, migrations, or persisted data.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p sandbox-fc --all-features --no-deps`
- `cargo test -p sandbox-fc --all-features` (803 passed)
- `cargo test -p runner --bin runner` (2948 passed, 15 ignored)
- repository pre-commit hooks

Closes #24900
