### PR TITLE
test(guest-agent): bound telemetry final-shutdown waits

### DIFF
--- a/crates/guest-agent/tests/integration/telemetry.rs
+++ b/crates/guest-agent/tests/integration/telemetry.rs
@@ -218,9 +218,11 @@ async fn final_flush_and_shutdown_uploads_log_emitted_immediately_before_it() {
     );
 
     guest_common::log_warn!("sandbox:guest-agent", "{marker}");
-    telemetry
-        .final_flush_and_shutdown()
+    tokio::time::timeout(Duration::from_secs(5), telemetry.final_flush_and_shutdown())
         .await
+        .expect(
+            "final telemetry upload and uploader task termination should complete within 5 seconds",
+        )
         .expect("final flush and shutdown should upload just-emitted log");
     drop(system_log_guard);
 

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -44,7 +44,14 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
         Arc::clone(&masker),
         http.clone(),
     );
-    telemetry.final_flush_and_shutdown().await?;
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        telemetry.final_flush_and_shutdown(),
+    )
+    .await
+    .expect(
+        "no-API final-flush reply and uploader task termination should complete within 5 seconds",
+    )?;
 
     let shutdown = CancellationToken::new();
     let heartbeat = tokio::spawn(guest_agent::heartbeat::heartbeat_loop_for_run(


### PR DESCRIPTION
## Summary

- bound both telemetry final-shutdown integration paths with a five-second test-only deadline
- report whether the no-API reply/termination or API upload/termination lifecycle stopped making progress
- preserve the existing no-network and exactly-once final-tail upload assertions

## Scope

- test code only
- no production telemetry timeout, cancellation, protocol, schema, configuration, or documentation changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent --test no_api_mode no_api_mode_drains_background_webhook_users_without_network_client -- --exact`
- `cargo test -p guest-agent --test integration telemetry::final_flush_and_shutdown_uploads_log_emitted_immediately_before_it -- --exact`
- `cargo test -p guest-agent --all-targets --all-features`
- mutation check: temporarily removed the no-API final-shutdown loop exit and confirmed the target test failed in 5.01 seconds with the new lifecycle diagnostic, then restored the production source
- repository pre-commit hooks

Closes #24906
