### PR TITLE
refactor(api): add web queued launch loader

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -6679,6 +6679,129 @@ describe("CHAT-02: shared user message queue", () => {
     await cancelChatRun(actor, mockRunId);
   }, 90_000);
 
+  it("uses the claim-time inline-template switch for queued web launch material", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor({
+      orgId: STAFF_ORG_ID,
+    });
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor");
+    }
+    const actorWithOrg = { ...actor, orgId: actor.orgId };
+    await updateFeatureSwitchesForUser(context, actorWithOrg, {
+      [FeatureSwitchKey.StructuredPromptInlineTemplates]: false,
+    });
+
+    const anchor = await sendChatRun(actor, {
+      agentId,
+      prompt: "inline-template switch queue anchor",
+    });
+    const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
+
+    const style = ILLUSTRATION_TEMPLATE_ITEMS[0];
+    if (!style) {
+      throw new Error("Expected a registered illustration style");
+    }
+    const queuedMessageId = randomUUID();
+    const queuedUserMessage: UserMessageDocument = {
+      version: 1,
+      parts: [
+        { type: "text", text: "Restyle with " },
+        {
+          type: "template",
+          titleSnapshot: style.title,
+          template: {
+            type: "illustration",
+            selection: { illustrationStyleId: style.illustrationStyleId },
+          },
+        },
+        { type: "text", text: " at claim" },
+      ],
+    };
+    const queued = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: anchor.threadId,
+        prompt: "legacy queued template projection",
+        userMessage: queuedUserMessage,
+        clientEventId: queuedMessageId,
+      },
+      [201],
+    );
+    expect(queued.body).toMatchObject({ runId: null });
+
+    await updateFeatureSwitchesForUser(context, actorWithOrg, {
+      [FeatureSwitchKey.StructuredPromptInlineTemplates]: true,
+    });
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+
+    const messages = await waitForThreadMessages(
+      actor,
+      anchor.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.revokesEventId === queuedMessageId &&
+            typeof message.runId === "string"
+          );
+        });
+      },
+    );
+    const queuedRunId = userMessages(messages.events).find((message) => {
+      return message.revokesEventId === queuedMessageId;
+    })?.runId;
+    if (!queuedRunId) {
+      throw new Error("Expected the queued template message to auto-send");
+    }
+
+    const run = await api.readRun(actor, queuedRunId);
+    const inlineMarker = `[Template #1: ${style.title} (illustration)]`;
+    expect(run.prompt).toBe(`Restyle with ${inlineMarker} at claim`);
+    const webPrompt = [
+      "# Current Integration\nYou are currently running inside: Web",
+      "You are communicating with the user through the web chat UI.",
+    ].join("\n\n");
+    expect(run.appendSystemPrompt).toContain(webPrompt);
+    expect(run.appendSystemPrompt).toContain("# Inline Templates");
+    expect(run.appendSystemPrompt).toContain(style.illustrationStyleId);
+
+    await expect
+      .poll(() => {
+        const actionTypes = apiDispatchActionTypes(
+          apiDispatchTimingEventsForRun(queuedRunId),
+        );
+        return [
+          "api_dispatch_pre_create_zero_chat_callback_auto_send_build_input",
+          "api_dispatch_pre_create_zero_chat_callback_auto_send_resolve_model_pin",
+          "api_dispatch_pre_create_zero_chat_callback_auto_send_load_session_state",
+        ].every((actionType) => {
+          return actionTypes.has(actionType);
+        });
+      })
+      .toBe(true);
+    const timingEvents = apiDispatchTimingEventsForRun(queuedRunId);
+    expectApiDispatchSpanKind(
+      timingEvents,
+      ["api_dispatch_pre_create_zero_chat_callback_auto_send_build_input"],
+      "top_level",
+    );
+    expectApiDispatchSpanKind(
+      timingEvents,
+      [
+        "api_dispatch_pre_create_zero_chat_callback_auto_send_resolve_model_pin",
+        "api_dispatch_pre_create_zero_chat_callback_auto_send_load_session_state",
+      ],
+      "nested",
+    );
+
+    const queuedClaim = await claimChatRun(runnerGroup, queuedRunId);
+    expect(queuedClaim.claim.prompt).toBe(run.prompt);
+    expect(queuedClaim.claim.appendSystemPrompt).toBe(run.appendSystemPrompt);
+    await cancelChatRun(actor, queuedRunId, queuedClaim.sandboxHeaders);
+  }, 90_000);
+
   it("appends a claimed queued message after messages that are still queued", async () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -13,6 +13,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { upsertOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
+import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import {
   findPendingChatEventByPromptFixture,
   readChatEventContextFixture,
@@ -702,6 +704,73 @@ describe("Teams chat callbacks", () => {
       sandboxToken: queuedClaim.sandboxToken,
       exitCode: 0,
     });
+  });
+
+  it("delivers queued Teams admission failures with launch material", async () => {
+    const teams = await setupConnectedTeamsActor();
+    const teamsApi = teamsApiMocks({
+      serviceUrl: teams.fixture.serviceUrl,
+    });
+    const firstRunId = await dispatchTeamsPersonalRun({
+      fixture: teams.fixture,
+      activityId: "activity-admission-first",
+      text: "hold the Teams admission queue",
+    });
+    const firstClaim = await claimTeamsRun({
+      runnerGroup: teams.runnerGroup,
+      runId: firstRunId,
+    });
+
+    const queuedPrompt = `reject this queued Teams message ${teams.fixture.teamsTenantId}`;
+    const queuedActivityId = "activity-admission-queued";
+    await postTeamsPersonalMessage({
+      fixture: teams.fixture,
+      activityId: queuedActivityId,
+      text: queuedPrompt,
+    });
+    await expect(
+      findPendingChatEventByPromptFixture(queuedPrompt),
+    ).resolves.toMatchObject({ eventId: expect.any(String) });
+
+    await seedOrgMetadata({
+      orgId: teams.fixture.orgId,
+      tier: "pro-suspend",
+      credits: 0,
+    });
+    await upsertOrgPlanEntitlementFixture({
+      orgId: teams.fixture.orgId,
+      status: "suspended",
+      canBuyCredits: true,
+    });
+    clearTeamsApiCalls(teamsApi);
+    await completeSandboxRun({
+      runId: firstRunId,
+      sandboxToken: firstClaim.sandboxToken,
+      exitCode: 0,
+    });
+
+    await expect
+      .poll(() => {
+        return teamsApi.postedActivities.filter((activity) => {
+          return (
+            typeof activity.text === "string" &&
+            activity.text.includes("Add credits")
+          );
+        });
+      })
+      .toStrictEqual([
+        expect.objectContaining({
+          replyToId: queuedActivityId,
+          text: expect.stringContaining("Add credits"),
+        }),
+      ]);
+    expect(
+      (await runsApi.listAgentRuns(teams.actor, { limit: 20 })).runs.filter(
+        (run) => {
+          return run.prompt === queuedPrompt;
+        },
+      ),
+    ).toHaveLength(0);
   });
 
   it("uses installation bot identity when the activity omits it", async () => {

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2696,22 +2696,19 @@ function loadQueuedMessageSessionState(
     "api_dispatch_pre_create_zero_chat_callback_auto_send_load_session_state",
     "nested",
     async () => {
-      const [sessionResolution, featureSwitchContext] = await Promise.all([
-        resolveChatThreadSession({
-          db: args.db,
-          threadId: args.threadId,
-          userId: args.userId,
-          orgId: args.agent.orgId,
-          agentComposeId: args.agent.id,
-          route: {
-            selectedModel: modelRoute.modelPin.selectedModel,
-            modelProvider: modelRoute.effectiveModelProvider ?? null,
-            modelProviderId: modelRoute.modelPin.modelProviderId,
-            cliAgentType: modelRoute.cliAgentType,
-          },
-        }),
-        loadUserFeatureSwitchContext(args.db, args.agent.orgId, args.userId),
-      ]);
+      const sessionResolution = await resolveChatThreadSession({
+        db: args.db,
+        threadId: args.threadId,
+        userId: args.userId,
+        orgId: args.agent.orgId,
+        agentComposeId: args.agent.id,
+        route: {
+          selectedModel: modelRoute.modelPin.selectedModel,
+          modelProvider: modelRoute.effectiveModelProvider ?? null,
+          modelProviderId: modelRoute.modelPin.modelProviderId,
+          cliAgentType: modelRoute.cliAgentType,
+        },
+      });
       const incompleteContext =
         args.queuedMessage.triggerSource === "web"
           ? await loadWebChatIncompleteContext(args.db, args.threadId)
@@ -2719,7 +2716,6 @@ function loadQueuedMessageSessionState(
       return [
         sessionResolution.action === "rotated",
         incompleteContext,
-        featureSwitchContext,
       ] as const;
     },
   );
@@ -2748,6 +2744,7 @@ interface QueuedLaunchLoaderArgs {
   readonly chatThreadId: string;
   readonly orgId: string;
   readonly userId: string;
+  readonly userMessageProjection: ReturnType<typeof projectUserMessage>;
   readonly resolveSignedUrls: (keys: {
     readonly inputKey: string;
     readonly outputKey: string;
@@ -2758,6 +2755,20 @@ type LaunchLoader = (
   db: Db,
   args: QueuedLaunchLoaderArgs,
 ) => Promise<QueuedLaunchMaterial | null>;
+
+/**
+ * Web is the only trigger source with no context table: the user typed the
+ * message, so `chat_events.user_message` *is* the durable original fact rather
+ * than a display copy of something stored elsewhere. This is the one place a
+ * launch loader reads it, and it is deliberate.
+ */
+const loadWebQueuedLaunchMaterial: LaunchLoader = (_db, args) => {
+  return Promise.resolve({
+    prompt: args.userMessageProjection.agentPrompt,
+    appendSystemPrompt: buildWebChatPrompt(),
+    delivery: {},
+  });
+};
 
 type NativeQueuedLaunchMaterial =
   | SlackQueuedLaunchMaterial
@@ -2789,13 +2800,16 @@ function launchLoader<Material extends NativeQueuedLaunchMaterial>(
 }
 
 async function resolveQueuedLaunchMaterial(
-  args: CreateQueuedChatRunInputArgs,
-): Promise<QueuedLaunchMaterial | null> {
+  args: CreateQueuedChatRunInputArgs & {
+    readonly userMessageProjection: ReturnType<typeof projectUserMessage>;
+  },
+): Promise<QueuedLaunchMaterial> {
   const triggerSource = args.queuedMessage.triggerSource;
   let load: LaunchLoader;
   switch (triggerSource) {
     case "web": {
-      return null;
+      load = loadWebQueuedLaunchMaterial;
+      break;
     }
     case "slack": {
       load = launchLoader(loadSlackQueuedLaunchMaterial, (material) => {
@@ -2855,6 +2869,7 @@ async function resolveQueuedLaunchMaterial(
     chatThreadId: args.threadId,
     orgId: args.agent.orgId,
     userId: args.userId,
+    userMessageProjection: args.userMessageProjection,
     resolveSignedUrls: (keys) => {
       return args.resolveMorningBriefSignedUrls(keys, args.signal);
     },
@@ -2866,9 +2881,9 @@ async function resolveQueuedLaunchMaterial(
 }
 
 function queuedIntegrationDeliveries(
-  launchMaterial: QueuedLaunchMaterial | null,
+  launchMaterial: QueuedLaunchMaterial,
 ): QueuedIntegrationDeliveries {
-  return launchMaterial?.delivery ?? {};
+  return launchMaterial.delivery;
 }
 
 function unreachableQueuedTriggerSource(triggerSource: never): never {
@@ -2889,7 +2904,7 @@ function requiredQueuedDelivery<Delivery>(
 
 function queuedMessageAdmissionFailure(
   args: CreateQueuedChatRunInputArgs,
-  launchMaterial: QueuedLaunchMaterial | null,
+  launchMaterial: QueuedLaunchMaterial,
   error: QueuedMessageModelRouteError,
 ): QueuedMessageAdmissionFailure {
   const common = {
@@ -2910,7 +2925,7 @@ function queuedMessageAdmissionFailure(
         kind: "slack_admission_failure",
         ...common,
         slackDelivery: requiredQueuedDelivery(
-          launchMaterial?.delivery.slackDelivery,
+          launchMaterial.delivery.slackDelivery,
           triggerSource,
         ),
       };
@@ -2920,7 +2935,7 @@ function queuedMessageAdmissionFailure(
         kind: "feishu_admission_failure",
         ...common,
         feishuDelivery: requiredQueuedDelivery(
-          launchMaterial?.delivery.feishuDelivery,
+          launchMaterial.delivery.feishuDelivery,
           triggerSource,
         ),
       };
@@ -2930,7 +2945,7 @@ function queuedMessageAdmissionFailure(
         kind: "teams_admission_failure",
         ...common,
         teamsDelivery: requiredQueuedDelivery(
-          launchMaterial?.delivery.teamsDelivery,
+          launchMaterial.delivery.teamsDelivery,
           triggerSource,
         ),
       };
@@ -2940,7 +2955,7 @@ function queuedMessageAdmissionFailure(
         kind: "telegram_admission_failure",
         ...common,
         telegramDelivery: requiredQueuedDelivery(
-          launchMaterial?.delivery.telegramDelivery,
+          launchMaterial.delivery.telegramDelivery,
           triggerSource,
         ),
       };
@@ -2950,7 +2965,7 @@ function queuedMessageAdmissionFailure(
         kind: "agentphone_admission_failure",
         ...common,
         agentphoneDelivery: requiredQueuedDelivery(
-          launchMaterial?.delivery.agentphoneDelivery,
+          launchMaterial.delivery.agentphoneDelivery,
           triggerSource,
         ),
       };
@@ -2960,7 +2975,7 @@ function queuedMessageAdmissionFailure(
         kind: "github_admission_failure",
         ...common,
         githubDelivery: requiredQueuedDelivery(
-          launchMaterial?.delivery.githubDelivery,
+          launchMaterial.delivery.githubDelivery,
           triggerSource,
         ),
       };
@@ -2970,7 +2985,7 @@ function queuedMessageAdmissionFailure(
         kind: "morning_brief_admission_failure",
         ...common,
         morningBriefDelivery: requiredQueuedDelivery(
-          launchMaterial?.delivery.morningBriefDelivery,
+          launchMaterial.delivery.morningBriefDelivery,
           triggerSource,
         ),
         error,
@@ -2983,16 +2998,15 @@ function queuedMessageAdmissionFailure(
 }
 
 function queuedMessagePrompt(args: {
-  readonly launchMaterial: QueuedLaunchMaterial | null;
-  readonly projectedPrompt: string;
+  readonly launchMaterial: QueuedLaunchMaterial;
 }): string {
-  return args.launchMaterial?.prompt ?? args.projectedPrompt;
+  return args.launchMaterial.prompt;
 }
 
 function queuedIntegrationPrompt(args: {
-  readonly launchMaterial: QueuedLaunchMaterial | null;
+  readonly launchMaterial: QueuedLaunchMaterial;
 }): string {
-  return args.launchMaterial?.appendSystemPrompt ?? buildWebChatPrompt();
+  return args.launchMaterial.appendSystemPrompt;
 }
 
 function resolveQueuedMessageGenerationTemplatePrompt(args: {
@@ -3019,7 +3033,11 @@ function resolveQueuedMessageGenerationTemplatePrompt(args: {
   );
 }
 
-async function loadQueuedRunMaterial(args: CreateQueuedChatRunInputArgs) {
+async function loadQueuedRunMaterial(
+  args: CreateQueuedChatRunInputArgs & {
+    readonly userMessageProjection: ReturnType<typeof projectUserMessage>;
+  },
+) {
   return await resolveQueuedLaunchMaterial(args);
 }
 
@@ -3039,26 +3057,38 @@ function queuedUserMessageProjection(
   });
 }
 
-function queuedIntegrationLaunchFields(
-  launchMaterial: QueuedLaunchMaterial | null,
-) {
+function queuedIntegrationLaunchFields(launchMaterial: QueuedLaunchMaterial) {
   return {
     ...queuedIntegrationDeliveries(launchMaterial),
-    userInfoExtras: launchMaterial?.userInfoExtras,
+    userInfoExtras: launchMaterial.userInfoExtras,
   };
 }
 
 async function buildCreateQueuedChatRunInput(
   args: CreateQueuedChatRunInputArgs,
 ): Promise<CreateQueuedChatRunInput | QueuedMessageAdmissionFailure> {
-  const launchMaterial = await loadQueuedRunMaterial(args);
-  const modelRouteResolution = await resolveQueuedMessageModelRoute({
-    db: args.db,
-    threadId: args.threadId,
-    userId: args.userId,
-    orgId: args.agent.orgId,
-    triggerSource: args.queuedMessage.triggerSource,
-    timing: args.timing,
+  const [featureSwitchContext, modelRouteResolution] = await Promise.all([
+    loadUserFeatureSwitchContext(args.db, args.agent.orgId, args.userId),
+    resolveQueuedMessageModelRoute({
+      db: args.db,
+      threadId: args.threadId,
+      userId: args.userId,
+      orgId: args.agent.orgId,
+      triggerSource: args.queuedMessage.triggerSource,
+      timing: args.timing,
+    }),
+  ]);
+  const inlineTemplatesEnabled = isFeatureEnabled(
+    FeatureSwitchKey.StructuredPromptInlineTemplates,
+    featureSwitchContext,
+  );
+  const userMessageProjection = queuedUserMessageProjection(
+    args.queuedMessage.userMessage,
+    inlineTemplatesEnabled,
+  );
+  const launchMaterial = await loadQueuedRunMaterial({
+    ...args,
+    userMessageProjection,
   });
   if ("error" in modelRouteResolution) {
     return queuedMessageAdmissionFailure(
@@ -3069,7 +3099,7 @@ async function buildCreateQueuedChatRunInput(
   }
   const modelRoute = modelRouteResolution.route;
 
-  const [startNewSession, loadedIncompleteContext, featureSwitchContext] =
+  const [startNewSession, loadedIncompleteContext] =
     await loadQueuedMessageSessionState(args, modelRoute);
   const attachFileMetadata = await args.resolveAttachFileMetadata(
     args.userId,
@@ -3077,14 +3107,6 @@ async function buildCreateQueuedChatRunInput(
     args.signal,
   );
   args.signal.throwIfAborted();
-  const inlineTemplatesEnabled = isFeatureEnabled(
-    FeatureSwitchKey.StructuredPromptInlineTemplates,
-    featureSwitchContext,
-  );
-  const userMessageProjection = queuedUserMessageProjection(
-    args.queuedMessage.userMessage,
-    inlineTemplatesEnabled,
-  );
   const incompleteContext = startNewSession ? "" : loadedIncompleteContext;
   const priorContext = await measureChatCallbackPreCreateTiming(
     args.timing,
@@ -3122,7 +3144,6 @@ async function buildCreateQueuedChatRunInput(
   );
   const prompt = queuedMessagePrompt({
     launchMaterial,
-    projectedPrompt: userMessageProjection.agentPrompt,
   });
 
   return {


### PR DESCRIPTION
## Summary

- add an explicit web queued-launch loader backed by the claim-time user message projection
- make queued launch material non-nullable after dispatch, removing the web-only prompt and system-prompt fallbacks
- move the feature-switch lookup out of session loading so it runs in parallel with model-route resolution before launch material is loaded
- cover claim-time inline-template projection and Teams admission-failure delivery

## Root cause

`resolveQueuedLaunchMaterial` used `null` for two contradictory states: web normally had no launch material, while every other source used missing material as a monitored fault. Downstream prompt assembly therefore depended on absence rather than an explicit web launch path.

Web now returns named launch material from `chat_events.user_message` through the claim-time projection, with the source-specific rationale documented at the loader. Missing material has one meaning again: a queue item fault.

## Ordering and timing

The feature-switch lookup only depends on `db`, `orgId`, and `userId`, so it now runs alongside model-route resolution. Launch material still loads before admission-failure handling, preserving Slack/Teams delivery coordinates when model routing fails.

The dependency depth remains three levels:

```
(feature switch || model route) -> launch loader -> session
```

I compared the existing pre-create timing spans:

- `api_dispatch_pre_create_zero_chat_callback_auto_send_build_input` (top-level end-to-end span)
- `api_dispatch_pre_create_zero_chat_callback_auto_send_resolve_model_pin` (nested)
- `api_dispatch_pre_create_zero_chat_callback_auto_send_load_session_state` (nested)

The focused queued-web integration test confirms the same span kinds are emitted. No query was added: the feature-switch query moved from the session-state `Promise.all` into the parallel model-route level, so the serial query depth does not regress.

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint` (passes; existing repository warnings remain)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts src/signals/routes/__tests__/internal-callbacks-teams.test.ts --testNamePattern='derives real-agent preview mode when queued messages are claimed|uses the claim-time inline-template switch for queued web launch material|claims Teams launch material from context|delivers queued Teams admission failures with launch material' --maxWorkers=1` (4 passed)
- `pnpm exec prettier --check apps/api/src/signals/services/internal-chat-run-callback.service.ts apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts`
- `grep -rn "userMessage" apps/api/src/signals/services/*-queued-launch-context.service.ts` (no output)
- `git diff --check`

## Scope

No database, migration, `chat_*_context`, API contract, or client changes. The generation-template path and the web admission-failure case remain unchanged. The seven non-web launch loaders keep the same prompt, system prompt, delivery, and user-info mapping.

Closes #24937