### PR TITLE
fix(api): stop null trigger sources from skipping orphan checks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
@@ -116,11 +116,48 @@ describe("cron monitor chat event queue", () => {
     expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
   });
 
+  it("alerts for a pointerless prompt with a null trigger source", async () => {
+    const fixture = await trackFixture(seedFixture("orphan"));
+
+    const response = await accept(
+      stateClient().monitor({ body: { event_ids: [fixture.eventId] } }),
+      [500],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: "Internal server error",
+    });
+    expect(
+      context.mocks.sentry.captureException.mock.calls.at(-1)?.[0],
+    ).toMatchObject({
+      code: "ORPHANED_QUEUED_CHAT_MESSAGES",
+      orphanedMessages: 1,
+      orphanedMessagesBySource: { "(unknown)": 1 },
+    });
+  });
+
+  it("does not alert for pointerless web, test, or agent prompts", async () => {
+    const fixture = await trackFixture(seedFixture("orphan"));
+
+    const response = await accept(
+      stateClient().monitor({
+        body: { event_ids: fixture.eventIds.slice(1, 4) },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      orphanedMessages: 0,
+    });
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+  });
+
   it("raises a grouped alert for every source with a missing context row", async () => {
     const fixture = await trackFixture(seedFixture("orphan"));
 
     const response = await accept(
-      stateClient().monitor({ body: { event_ids: [...fixture.eventIds] } }),
+      stateClient().monitor({ body: { event_ids: fixture.eventIds.slice(4) } }),
       [500],
     );
 
@@ -205,7 +242,7 @@ describe("cron monitor chat event queue", () => {
     });
   });
 
-  it("does not alert while a pending goal continuation is paused", async () => {
+  it("does not alert for a paused goal continuation without a context pointer", async () => {
     const fixture = await trackFixture(seedFixture("paused-goal"));
 
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
@@ -45,6 +45,26 @@ type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
 const STALE_CONTEXT_FIXTURES = [
   {
+    contextType: null,
+    eventType: "input.prompt",
+    triggerSource: null,
+  },
+  {
+    contextType: null,
+    eventType: "input.prompt",
+    triggerSource: "web",
+  },
+  {
+    contextType: null,
+    eventType: "input.prompt",
+    triggerSource: "test",
+  },
+  {
+    contextType: null,
+    eventType: "input.prompt",
+    triggerSource: "agent",
+  },
+  {
     contextType: "slack",
     eventType: "input.prompt",
     triggerSource: "slack",
@@ -266,7 +286,7 @@ async function seedFixture(
             return {
               ...baseEvent,
               ...fixture,
-              contextId: randomUUID(),
+              contextId: fixture.contextType === null ? null : randomUUID(),
               createdAt: new Date(0),
               seqId: index + 1,
             };

--- a/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
@@ -16,6 +16,7 @@ import {
   inArray,
   isNull,
   lt,
+  not,
   notExists,
   notInArray,
   or,
@@ -220,7 +221,11 @@ async function monitorChatEventQueue(
         or(
           and(
             isNull(chatEvents.contextType),
-            notInArray(chatEvents.triggerSource, ["web", "test", "agent"]),
+            not(chatEventTypeIn(["input.goal"])),
+            or(
+              isNull(chatEvents.triggerSource),
+              notInArray(chatEvents.triggerSource, ["web", "test", "agent"]),
+            ),
           ),
           missingChatIntegrationContextRowCondition(db),
           missingScheduledContextRowCondition(db),


### PR DESCRIPTION
## Summary

- make the missing-context-pointer monitor branch treat a null `trigger_source` as requiring validation
- exempt `input.goal` from the missing-pointer branch while preserving the `thread_goals` existence check
- cover null, `web`, `test`, `agent`, and pointerless goal cases without changing the nine-source grouped alert

## Root cause

`trigger_source NOT IN ('web', 'test', 'agent')` evaluates to null when `trigger_source` is null, so PostgreSQL drops an otherwise orphaned pointerless event from the monitor count.

The condition now follows the invariant from #24948: non-goal events with no context pointer are checked when the trigger source is null or outside the exempt source set.

## Coordination with #24932

This PR lands after #24932 PR 1 (#24939). The branch was rebased onto main after #24939 merged and retains its `missingGoalRowCondition` check against `thread_goals`.

Both properties remain live:

- a null `trigger_source` cannot skip the missing-pointer check
- `input.goal` is exempt from the missing-pointer check and is validated against `thread_goals` instead

## Scope

No migration, schema change, API contract change, or client change.

## Validation

- `pnpm exec prettier --write` on all changed files
- `pnpm -F api lint`
- `pnpm -F api check-types`
- focused type-aware Oxlint and ESLint on all changed API files after the final edit
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm knip --workspace api`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test_24948_c733 pnpm -F api exec vitest run src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts --maxWorkers=1 --silent=passed-only` (10 passed)

Fixes #24948.