### PR TITLE
fix(platform): wait for voice input before sending

### DIFF
--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -44,6 +44,8 @@ const internalStream$ = state<MediaStream | null>(null);
 const internalRecorder$ = state<MediaRecorder | null>(null);
 const internalRecordingSession$ = state<VoiceRecordingSession | null>(null);
 const internalAudioActivityMonitor$ = state<AudioActivityMonitor | null>(null);
+const internalStartingPromise$ =
+  state<Promise<VoiceRecordingStartup | null> | null>(null);
 const internalStopAndTranscribePromise$ = state<Promise<void> | null>(null);
 const audioInputQuotaReload$ = state(0);
 
@@ -123,6 +125,11 @@ function transcriptionFailedMessage(): string {
   });
 }
 
+function reportMicStartFailure(error: unknown): void {
+  L.error("Microphone start failed", error);
+  toast.error(microphoneAccessDeniedMessage());
+}
+
 function microphoneAccessDeniedMessage(): string {
   return i18n.t(($) => {
     return $.chat.voice.microphoneAccessDenied;
@@ -142,6 +149,12 @@ interface VoiceRecordingSession {
   readonly handleActivity: (activity: VoiceActivity) => void;
   readonly startSilenceTimeout: () => void;
   readonly stopAndTranscribe: (signal: AbortSignal) => Promise<void>;
+}
+
+interface VoiceRecordingStartup {
+  readonly stream: MediaStream;
+  readonly session: VoiceRecordingSession;
+  readonly recordingStartedAt: number;
 }
 
 interface AudioActivityTracker {
@@ -431,6 +444,7 @@ const resetState$ = command(({ set }) => {
   set(internalRecorder$, null);
   set(internalRecordingSession$, null);
   set(internalAudioActivityMonitor$, null);
+  set(internalStartingPromise$, null);
   set(internalStopAndTranscribePromise$, null);
   set(internalStream$, null);
 });
@@ -977,66 +991,74 @@ export const startRecording$ = command(
     );
     set(prepareRecordingStart$);
 
-    await waitForBrowserPaint(signal);
-    signal.throwIfAborted();
-
-    const stream = await tapError(openMedia(signal), (error) => {
-      L.error("Microphone start failed", error);
-      toast.error(microphoneAccessDeniedMessage());
-    });
-    if (stream === undefined) {
-      set(internalStarting$, false);
-      return;
-    }
-    if (!stream) {
-      set(internalStarting$, false);
-      return;
-    }
-
-    const recorder = createMediaRecorder(stream);
     let audioActivityMonitor: AudioActivityMonitor | null = null;
     let voiceActivityReliable = false;
     let longSilenceStop: ReturnType<typeof createDeferredPromise<void>> | null =
       null;
-    const recordingSession = createVoiceSegmentSession({
-      initialRecorder: recorder,
-      stream,
-      signal,
-      autoSegment,
-      onSegmentTranscribed,
-      transcribeBlob: (input, uploadSignal) => {
-        return set(transcribeAudioBlob$, input, uploadSignal);
-      },
-      isVoiceActivityReliable: () => {
-        return voiceActivityReliable;
-      },
-      onLongSilence: () => {
-        if (longSilenceStop && !longSilenceStop.settled()) {
-          longSilenceStop.resolve(undefined);
+    const starting = withCleanup(
+      (async (): Promise<VoiceRecordingStartup | null> => {
+        await waitForBrowserPaint(signal);
+        signal.throwIfAborted();
+
+        const stream = await tapError(openMedia(signal), reportMicStartFailure);
+        if (!stream) {
+          return null;
+        }
+
+        const recorder = createMediaRecorder(stream);
+        const recordingSession = createVoiceSegmentSession({
+          initialRecorder: recorder,
+          stream,
+          signal,
+          autoSegment,
+          onSegmentTranscribed,
+          transcribeBlob: (input, uploadSignal) => {
+            return set(transcribeAudioBlob$, input, uploadSignal);
+          },
+          isVoiceActivityReliable: () => {
+            return voiceActivityReliable;
+          },
+          onLongSilence: () => {
+            if (longSilenceStop && !longSilenceStop.settled()) {
+              longSilenceStop.resolve(undefined);
+            }
+          },
+          onQuotaExceeded: () => {
+            set(resetRecord$);
+          },
+          onRecorderChanged: (nextRecorder) => {
+            set(internalRecorder$, nextRecorder);
+          },
+        });
+
+        signal.addEventListener("abort", () => {
+          recordingSession.cancel();
+          if (audioActivityMonitor) {
+            stopAudioActivityMonitor(audioActivityMonitor);
+          }
+          stopAllTracks(stream);
+          set(resetState$);
+        });
+
+        const recordingStartedAt = set(startMediaRecorder$, recorder);
+        set(internalStream$, stream);
+        set(internalRecorder$, recorder);
+        set(internalRecordingSession$, recordingSession);
+        return { stream, session: recordingSession, recordingStartedAt };
+      })(),
+      () => {
+        if (get(internalStartingPromise$) === starting) {
+          set(internalStartingPromise$, null);
+          set(internalStarting$, false);
         }
       },
-      onQuotaExceeded: () => {
-        set(resetRecord$);
-      },
-      onRecorderChanged: (nextRecorder) => {
-        set(internalRecorder$, nextRecorder);
-      },
-    });
-
-    signal.addEventListener("abort", () => {
-      recordingSession.cancel();
-      if (audioActivityMonitor) {
-        stopAudioActivityMonitor(audioActivityMonitor);
-      }
-      stopAllTracks(stream);
-      set(resetState$);
-    });
-
-    set(internalStarting$, false);
-    const recordingStartedAt = set(startMediaRecorder$, recorder);
-    set(internalStream$, stream);
-    set(internalRecorder$, recorder);
-    set(internalRecordingSession$, recordingSession);
+    );
+    set(internalStartingPromise$, starting);
+    const startup = await starting;
+    if (!startup) {
+      return;
+    }
+    const { stream, session: recordingSession, recordingStartedAt } = startup;
     const startedAudioActivityMonitor = await tapError(
       startAudioActivityMonitor(
         stream,
@@ -1086,6 +1108,13 @@ export const stopAndTranscribe$ = command(
     if (activeCompletion) {
       await activeCompletion;
       signal.throwIfAborted();
+      return;
+    }
+    const starting = get(internalStartingPromise$);
+    if (starting) {
+      await starting;
+      signal.throwIfAborted();
+      await set(stopAndTranscribe$, signal);
       return;
     }
     if (!get(internalRecording$)) {

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -44,6 +44,7 @@ const internalStream$ = state<MediaStream | null>(null);
 const internalRecorder$ = state<MediaRecorder | null>(null);
 const internalRecordingSession$ = state<VoiceRecordingSession | null>(null);
 const internalAudioActivityMonitor$ = state<AudioActivityMonitor | null>(null);
+const internalStopAndTranscribePromise$ = state<Promise<void> | null>(null);
 const audioInputQuotaReload$ = state(0);
 
 // ---------------------------------------------------------------------------
@@ -140,7 +141,7 @@ interface VoiceRecordingSession {
   readonly cancel: () => void;
   readonly handleActivity: (activity: VoiceActivity) => void;
   readonly startSilenceTimeout: () => void;
-  readonly stopAndTranscribe: (signal: AbortSignal) => Promise<string>;
+  readonly stopAndTranscribe: (signal: AbortSignal) => Promise<void>;
 }
 
 interface AudioActivityTracker {
@@ -430,6 +431,7 @@ const resetState$ = command(({ set }) => {
   set(internalRecorder$, null);
   set(internalRecordingSession$, null);
   set(internalAudioActivityMonitor$, null);
+  set(internalStopAndTranscribePromise$, null);
   set(internalStream$, null);
 });
 
@@ -940,17 +942,12 @@ function createVoiceSegmentSession(
     startSilenceTimeout(): void {
       silenceTimer.start();
     },
-    async stopAndTranscribe(stopSignal: AbortSignal): Promise<string> {
+    async stopAndTranscribe(stopSignal: AbortSignal): Promise<void> {
       stopped = true;
       silenceTimer.clear();
-      const finalText = await transcriber.enqueueSegment(
-        "stop",
-        shouldUploadStopSegment(),
-        false,
-      );
+      await transcriber.enqueueSegment("stop", shouldUploadStopSegment(), true);
       stopSignal.throwIfAborted();
       await transcriber.waitForPending();
-      return finalText;
     },
   };
 }
@@ -1079,43 +1076,52 @@ export const startRecording$ = command(
 
     await longSilenceStop.promise;
     signal.throwIfAborted();
-    const text = await set(stopAndTranscribe$, signal);
-    if (text) {
-      onSegmentTranscribed(text);
-    }
+    await set(stopAndTranscribe$, signal);
   },
 );
 
 export const stopAndTranscribe$ = command(
-  async ({ get, set }, signal: AbortSignal): Promise<string> => {
-    if (!get(internalRecording$)) {
-      return "";
-    }
-
-    const recorder = get(internalRecorder$);
-    const session = get(internalRecordingSession$);
-    const audioActivityMonitor = get(internalAudioActivityMonitor$);
-    if (audioActivityMonitor) {
-      stopAudioActivityMonitor(audioActivityMonitor);
-      await closeAudioContextQuietly(audioActivityMonitor.audioContext);
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const activeCompletion = get(internalStopAndTranscribePromise$);
+    if (activeCompletion) {
+      await activeCompletion;
       signal.throwIfAborted();
-      set(internalAudioActivityMonitor$, null);
-      set(internalSpeechDetected$, false);
-      set(internalVoiceLevel$, 0);
+      return;
+    }
+    if (!get(internalRecording$)) {
+      return;
     }
 
-    if (!session) {
-      if (recorder && recorder.state !== "inactive") {
-        recorder.stop();
-      }
-      set(resetRecord$);
-      return "";
-    }
+    const completion = withCleanup(
+      (async () => {
+        const recorder = get(internalRecorder$);
+        const session = get(internalRecordingSession$);
+        const audioActivityMonitor = get(internalAudioActivityMonitor$);
+        if (audioActivityMonitor) {
+          stopAudioActivityMonitor(audioActivityMonitor);
+          await closeAudioContextQuietly(audioActivityMonitor.audioContext);
+          signal.throwIfAborted();
+          set(internalAudioActivityMonitor$, null);
+          set(internalSpeechDetected$, false);
+          set(internalVoiceLevel$, 0);
+        }
 
-    set(internalRecording$, false);
-    set(internalTranscribing$, true);
-    return await withCleanup(session.stopAndTranscribe(signal), () => {
-      set(resetRecord$);
-    });
+        if (!session) {
+          if (recorder && recorder.state !== "inactive") {
+            recorder.stop();
+          }
+          return;
+        }
+
+        set(internalRecording$, false);
+        set(internalTranscribing$, true);
+        await session.stopAndTranscribe(signal);
+      })(),
+      () => {
+        set(resetRecord$);
+      },
+    );
+    set(internalStopAndTranscribePromise$, completion);
+    await completion;
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -1017,6 +1017,63 @@ describe("chat lifecycle", () => {
     }
   });
 
+  it("waits for voice input to finish starting before sending", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "b0000000-0000-4000-a000-000000000779";
+    const microphoneReady = context.mocks.deferred<void>();
+    const submissionRequested = context.mocks.deferred<void>();
+    const sentPrompts: string[] = [];
+    context.mocks.browser.voiceInput({
+      getUserMediaReady: microphoneReady.promise,
+      rms: 0.1,
+    });
+    mockChatLifecycle(context, {
+      threadId,
+      onRunCreate: (body) => {
+        if (body.prompt !== undefined) {
+          sentPrompts.push(body.prompt);
+        }
+        submissionRequested.resolve(undefined);
+      },
+    });
+    context.mocks.http.post("*/api/zero/voice-io/stt", () => {
+      return new Response(JSON.stringify({ text: "startup voice input" }), {
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    try {
+      detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+      const composer = await waitFor(() => {
+        return screen.getByPlaceholderText(PLACEHOLDER);
+      });
+      await fill(composer, "Typed introduction");
+      await user.click(await screen.findByLabelText("Voice input"));
+      await waitFor(() => {
+        expect(screen.getByLabelText("Starting voice input")).toBeDisabled();
+      });
+
+      await user.click(screen.getByLabelText("Send"));
+
+      expect(submissionRequested.settled()).toBeFalsy();
+      microphoneReady.resolve(undefined);
+
+      await waitFor(() => {
+        expect(sentPrompts).toHaveLength(1);
+      });
+      expect(sentPrompts[0]).toContain("Typed introduction");
+      expect(sentPrompts[0]).toContain("startup voice input");
+      await waitFor(() => {
+        expect(screen.getByLabelText("Voice input")).toBeInTheDocument();
+      });
+    } finally {
+      if (!microphoneReady.settled()) {
+        microphoneReady.resolve(undefined);
+      }
+    }
+  });
+
   it("transcribes a voice input segment after silence while recording", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "voice-input-segment-thread";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -940,6 +940,83 @@ describe("chat lifecycle", () => {
     }
   });
 
+  it("waits for active voice input before sending", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "b0000000-0000-4000-a000-000000000778";
+    const transcriptionRequested = context.mocks.deferred<void>();
+    const transcriptionReady = context.mocks.deferred<void>();
+    const submissionRequested = context.mocks.deferred<void>();
+    const sentPrompts: string[] = [];
+    context.mocks.browser.voiceInput({ rms: 0.1 });
+    mockChatLifecycle(context, {
+      threadId,
+      onRunCreate: (body) => {
+        if (body.prompt !== undefined) {
+          sentPrompts.push(body.prompt);
+        }
+        submissionRequested.resolve(undefined);
+      },
+    });
+    context.mocks.http.post("*/api/zero/voice-io/stt", async () => {
+      transcriptionRequested.resolve(undefined);
+      await transcriptionReady.promise;
+      return new Response(JSON.stringify({ text: "completed voice input" }), {
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    try {
+      detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+      const composer = await waitFor(() => {
+        return screen.getByPlaceholderText(PLACEHOLDER);
+      });
+      await fill(composer, "Typed introduction");
+      const sendButton = screen.getByLabelText("Send");
+      await waitFor(() => {
+        expect(sendButton).toBeEnabled();
+      });
+      await user.click(await screen.findByLabelText("Voice input"));
+      await waitFor(() => {
+        expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
+      });
+
+      const firstRequest = Promise.race([
+        (async () => {
+          await transcriptionRequested.promise;
+          return "transcription" as const;
+        })(),
+        (async () => {
+          await submissionRequested.promise;
+          return "submission" as const;
+        })(),
+      ]);
+      await user.click(sendButton);
+
+      await expect(firstRequest).resolves.toBe("transcription");
+      expect(sentPrompts).toStrictEqual([]);
+
+      await user.click(screen.getByLabelText("Send"));
+      expect(submissionRequested.settled()).toBeFalsy();
+
+      transcriptionReady.resolve(undefined);
+
+      await waitFor(() => {
+        expect(sentPrompts).toHaveLength(1);
+      });
+      expect(sentPrompts[0]).toContain("Typed introduction");
+      expect(sentPrompts[0]).toContain("completed voice input");
+      expect(sentPrompts[0]?.match(/completed voice input/g)).toHaveLength(1);
+      await waitFor(() => {
+        expect(screen.getByLabelText("Voice input")).toBeInTheDocument();
+      });
+    } finally {
+      if (!transcriptionReady.settled()) {
+        transcriptionReady.resolve(undefined);
+      }
+    }
+  });
+
   it("transcribes a voice input segment after silence while recording", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "voice-input-segment-thread";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -6667,15 +6667,7 @@ function MicButton({ signals }: { signals: ComposerSignals }) {
       return;
     }
     if (recording) {
-      detach(
-        (async () => {
-          const text = await stopAndTranscribe(signal);
-          if (text) {
-            onTranscribed(text);
-          }
-        })(),
-        Reason.DomCallback,
-      );
+      detach(stopAndTranscribe(signal), Reason.DomCallback);
       return;
     }
     if (!quota) {
@@ -7049,11 +7041,13 @@ function useComposerPrimaryAction(
 function startComposerSubmission({
   action,
   activate,
+  completeVoiceInput,
   ensurePushSubscription,
   signal,
 }: {
   action: ComposerPrimaryAction;
   activate: (signal: AbortSignal) => Promise<boolean>;
+  completeVoiceInput: (signal: AbortSignal) => Promise<void>;
   ensurePushSubscription: (signal: AbortSignal) => Promise<void>;
   signal: AbortSignal;
 }): void {
@@ -7063,7 +7057,13 @@ function startComposerSubmission({
   if (action === "send") {
     detach(ensurePushSubscription(signal), Reason.DomCallback);
   }
-  detach(activate(signal), Reason.DomCallback);
+  detach(
+    (async () => {
+      await completeVoiceInput(signal);
+      await activate(signal);
+    })(),
+    Reason.DomCallback,
+  );
 }
 
 function useComposerFileUpload(
@@ -7110,6 +7110,7 @@ function ComposerInputSlot({ signals }: { signals: ComposerSignals }) {
   const templatePicker = useComposerTemplatePicker(signals);
   const primaryAction = useComposerPrimaryAction(signals);
   const submitCurrentInput = useSet(signals.submission.submitCurrentInput$);
+  const completeVoiceInput = useSet(stopAndTranscribe$);
   const ensurePushSubscription = useSet(ensurePushSubscription$);
   const rootSignal = useGet(rootSignal$);
   const sendModeLoadable = useLastLoadable(sendMode$);
@@ -7168,6 +7169,7 @@ function ComposerInputSlot({ signals }: { signals: ComposerSignals }) {
       activate: (signal) => {
         return submitCurrentInput(primaryAction, signal);
       },
+      completeVoiceInput,
       ensurePushSubscription,
       signal: rootSignal,
     });
@@ -7252,6 +7254,7 @@ function ComposerSendControl({ signals }: { signals: ComposerSignals }) {
   const activatePrimaryAction = useSet(
     signals.submission.activatePrimaryAction$,
   );
+  const completeVoiceInput = useSet(stopAndTranscribe$);
   const ensurePushSubscription = useSet(ensurePushSubscription$);
   const rootSignal = useGet(rootSignal$);
   const activate = () => {
@@ -7264,6 +7267,7 @@ function ComposerSendControl({ signals }: { signals: ComposerSignals }) {
       activate: (signal) => {
         return activatePrimaryAction(action, signal);
       },
+      completeVoiceInput,
       ensurePushSubscription,
       signal: rootSignal,
     });


### PR DESCRIPTION
## Summary

- stop active voice input and wait for all pending transcription before reading the composer for send or queue
- share the in-flight voice completion so overlapping send/stop actions wait for the same result and append the final transcript once
- add a page-level regression test that proves transcription starts before submission and blocks submission until completion

## Testing

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx --maxWorkers=1 --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run --maxWorkers=4 --silent=passed-only` (122 files, 1368 tests)
- pre-commit full-repository Knip and TypeScript checks

Fixes #24378
