### PR TITLE
refactor(guest-agent): hydrate codex catalogs structurally

### DIFF
--- a/crates/guest-agent/src/cli/codex_runtime_config.rs
+++ b/crates/guest-agent/src/cli/codex_runtime_config.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 
 use crate::error::AgentError;
 
-const MODEL_CATALOG_FILENAME: &str = "vm0-codex-model-catalog.json";
+const MODEL_CATALOG_FILENAME: &str = "codex-model-catalog.json";
 
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -343,7 +343,7 @@ mod tests {
             overrides.contains(&r#"model_providers.minimax.supports_websockets=false"#.to_string())
         );
         assert!(overrides.contains(
-            &r#"model_catalog_json="/tmp/codex-home/vm0-codex-model-catalog.json""#.to_string()
+            &r#"model_catalog_json="/tmp/codex-home/codex-model-catalog.json""#.to_string()
         ));
     }
 

--- a/crates/guest-agent/src/cli/codex_runtime_config.rs
+++ b/crates/guest-agent/src/cli/codex_runtime_config.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 
 use crate::error::AgentError;
 
-const MODEL_CATALOG_FILENAME: &str = "vm0-model-catalog.json";
+const MODEL_CATALOG_FILENAME: &str = "vm0-codex-model-catalog.json";
 
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -103,15 +103,44 @@ pub(super) fn write_model_catalog(
     let Some(model_catalog) = &config.model_catalog else {
         return Ok(());
     };
-    let model_catalog = if config.provider_id == "vm0-model" {
-        inherit_default_model_instructions(model_catalog, load_bundled_model_catalog()?)?
+    let hydrated_model_catalog = if model_catalog_needs_default_instructions(model_catalog)? {
+        Some(inherit_default_model_instructions(
+            model_catalog,
+            load_bundled_model_catalog()?,
+        )?)
     } else {
-        model_catalog.clone()
+        None
     };
+    let model_catalog = hydrated_model_catalog.as_ref().unwrap_or(model_catalog);
     std::fs::create_dir_all(codex_home)?;
     let path = model_catalog_path(codex_home);
-    write_model_catalog_json_atomic(codex_home, &path, &serde_json::to_vec(&model_catalog)?)?;
+    write_model_catalog_json_atomic(codex_home, &path, &serde_json::to_vec(model_catalog)?)?;
     Ok(())
+}
+
+fn model_catalog_needs_default_instructions(
+    model_catalog: &serde_json::Value,
+) -> Result<bool, AgentError> {
+    let models = model_catalog
+        .get("models")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| AgentError::Execution("invalid Codex model catalog".to_string()))?;
+    let mut needs_default_instructions = false;
+    for model in models {
+        let model = model
+            .as_object()
+            .ok_or_else(|| AgentError::Execution("invalid Codex model entry".to_string()))?;
+        match model.get("base_instructions") {
+            None => needs_default_instructions = true,
+            Some(serde_json::Value::String(_)) => {}
+            Some(_) => {
+                return Err(AgentError::Execution(
+                    "invalid Codex model base_instructions".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(needs_default_instructions)
 }
 
 fn load_bundled_model_catalog() -> Result<BundledModelCatalog, AgentError> {
@@ -149,11 +178,22 @@ fn inherit_default_model_instructions(
         let model = model
             .as_object_mut()
             .ok_or_else(|| AgentError::Execution("invalid Codex model entry".to_string()))?;
+        match model.get("base_instructions") {
+            Some(serde_json::Value::String(_)) => continue,
+            Some(_) => {
+                return Err(AgentError::Execution(
+                    "invalid Codex model base_instructions".to_string(),
+                ));
+            }
+            None => {}
+        }
         model.insert(
             "base_instructions".to_string(),
             serde_json::Value::String(source.base_instructions.clone()),
         );
-        model.insert("model_messages".to_string(), source.model_messages.clone());
+        model
+            .entry("model_messages".to_string())
+            .or_insert_with(|| source.model_messages.clone());
     }
     Ok(hydrated)
 }
@@ -280,7 +320,12 @@ mod tests {
             requires_openai_auth: None,
             wire_api: "responses".to_string(),
             supports_websockets: false,
-            model_catalog: Some(json!({ "models": [{ "slug": "MiniMax-M3" }] })),
+            model_catalog: Some(json!({
+                "models": [{
+                    "slug": "MiniMax-M3",
+                    "base_instructions": ""
+                }]
+            })),
         };
 
         let overrides = startup_config_overrides(Some(&config), codex_home);
@@ -298,7 +343,7 @@ mod tests {
             overrides.contains(&r#"model_providers.minimax.supports_websockets=false"#.to_string())
         );
         assert!(overrides.contains(
-            &r#"model_catalog_json="/tmp/codex-home/vm0-model-catalog.json""#.to_string()
+            &r#"model_catalog_json="/tmp/codex-home/vm0-codex-model-catalog.json""#.to_string()
         ));
     }
 
@@ -401,13 +446,21 @@ mod tests {
             requires_openai_auth: None,
             wire_api: "responses".to_string(),
             supports_websockets: false,
-            model_catalog: Some(json!({ "models": [{ "slug": "MiniMax-M3" }] })),
+            model_catalog: Some(json!({
+                "models": [{
+                    "slug": "MiniMax-M3",
+                    "base_instructions": ""
+                }]
+            })),
         };
 
         write_model_catalog(tmp.path(), &config).unwrap();
 
         let written = std::fs::read_to_string(model_catalog_path(tmp.path())).unwrap();
-        assert_eq!(written, r#"{"models":[{"slug":"MiniMax-M3"}]}"#);
+        assert_eq!(
+            written,
+            r#"{"models":[{"base_instructions":"","slug":"MiniMax-M3"}]}"#
+        );
     }
 
     #[cfg(unix)]
@@ -430,7 +483,12 @@ mod tests {
             requires_openai_auth: None,
             wire_api: "responses".to_string(),
             supports_websockets: false,
-            model_catalog: Some(json!({ "models": [{ "slug": "MiniMax-M3" }] })),
+            model_catalog: Some(json!({
+                "models": [{
+                    "slug": "MiniMax-M3",
+                    "base_instructions": ""
+                }]
+            })),
         };
 
         write_model_catalog(&codex_home, &config).unwrap();
@@ -448,7 +506,10 @@ mod tests {
             "model catalog path should be a regular replacement file, not the old symlink"
         );
         let written = std::fs::read_to_string(model_catalog_path(&codex_home)).unwrap();
-        assert_eq!(written, r#"{"models":[{"slug":"MiniMax-M3"}]}"#);
+        assert_eq!(
+            written,
+            r#"{"models":[{"base_instructions":"","slug":"MiniMax-M3"}]}"#
+        );
     }
 
     #[test]
@@ -456,8 +517,6 @@ mod tests {
         let target = json!({
             "models": [{
                 "slug": "vm0-model",
-                "base_instructions": "",
-                "model_messages": null,
                 "context_window": 1_000_000
             }]
         });
@@ -503,5 +562,90 @@ mod tests {
             "default template"
         );
         assert_eq!(hydrated["models"][0]["context_window"], 1_000_000);
+    }
+
+    #[test]
+    fn inherit_default_model_instructions_only_fills_missing_fields() {
+        let target = json!({
+            "models": [
+                {
+                    "slug": "missing-both",
+                    "context_window": 1_000_000
+                },
+                {
+                    "slug": "explicit-messages",
+                    "model_messages": null
+                },
+                {
+                    "slug": "complete",
+                    "base_instructions": "custom instructions"
+                }
+            ],
+            "unknown_catalog_field": true
+        });
+        let bundled = BundledModelCatalog {
+            models: vec![BundledModel {
+                priority: 1,
+                visibility: "list".to_string(),
+                supported_in_api: true,
+                base_instructions: "default instructions".to_string(),
+                model_messages: json!({ "instructions_template": "default template" }),
+            }],
+        };
+
+        let hydrated = inherit_default_model_instructions(&target, bundled).unwrap();
+
+        assert_eq!(
+            hydrated["models"][0]["base_instructions"],
+            "default instructions"
+        );
+        assert_eq!(
+            hydrated["models"][0]["model_messages"]["instructions_template"],
+            "default template"
+        );
+        assert_eq!(hydrated["models"][0]["context_window"], 1_000_000);
+        assert_eq!(
+            hydrated["models"][1]["base_instructions"],
+            "default instructions"
+        );
+        assert!(hydrated["models"][1]["model_messages"].is_null());
+        assert_eq!(
+            hydrated["models"][2],
+            json!({
+                "slug": "complete",
+                "base_instructions": "custom instructions"
+            })
+        );
+        assert_eq!(hydrated["unknown_catalog_field"], true);
+    }
+
+    #[test]
+    fn write_model_catalog_rejects_non_string_base_instructions_before_replacing_catalog() {
+        let tmp = tempfile::tempdir().unwrap();
+        let catalog_path = model_catalog_path(tmp.path());
+        std::fs::write(&catalog_path, b"existing catalog").unwrap();
+        let config = CodexRuntimeConfig {
+            provider_id: "vm0-model".to_string(),
+            name: "vm0 Model".to_string(),
+            base_url: "https://example.test/v1".to_string(),
+            env_key: "OPENAI_API_KEY".to_string(),
+            http_headers: None,
+            requires_openai_auth: None,
+            wire_api: "responses".to_string(),
+            supports_websockets: false,
+            model_catalog: Some(json!({
+                "models": [{
+                    "slug": "invalid",
+                    "base_instructions": null
+                }]
+            })),
+        };
+
+        let error = write_model_catalog(tmp.path(), &config)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("invalid Codex model base_instructions"));
+        assert_eq!(std::fs::read(&catalog_path).unwrap(), b"existing catalog");
     }
 }

--- a/crates/guest-agent/src/cli/codex_runtime_config.rs
+++ b/crates/guest-agent/src/cli/codex_runtime_config.rs
@@ -516,7 +516,7 @@ mod tests {
     fn inherit_default_model_instructions_uses_highest_priority_visible_model() {
         let target = json!({
             "models": [{
-                "slug": "vm0-model",
+                "slug": "target-model",
                 "context_window": 1_000_000
             }]
         });
@@ -625,8 +625,8 @@ mod tests {
         let catalog_path = model_catalog_path(tmp.path());
         std::fs::write(&catalog_path, b"existing catalog").unwrap();
         let config = CodexRuntimeConfig {
-            provider_id: "vm0-model".to_string(),
-            name: "vm0 Model".to_string(),
+            provider_id: "test-provider".to_string(),
+            name: "Test Provider".to_string(),
             base_url: "https://example.test/v1".to_string(),
             env_key: "OPENAI_API_KEY".to_string(),
             http_headers: None,

--- a/crates/guest-agent/src/cli/codex_runtime_config.rs
+++ b/crates/guest-agent/src/cli/codex_runtime_config.rs
@@ -458,8 +458,13 @@ mod tests {
 
         let written = std::fs::read_to_string(model_catalog_path(tmp.path())).unwrap();
         assert_eq!(
-            written,
-            r#"{"models":[{"base_instructions":"","slug":"MiniMax-M3"}]}"#
+            serde_json::from_str::<serde_json::Value>(&written).unwrap(),
+            json!({
+                "models": [{
+                    "slug": "MiniMax-M3",
+                    "base_instructions": ""
+                }]
+            })
         );
     }
 
@@ -507,8 +512,13 @@ mod tests {
         );
         let written = std::fs::read_to_string(model_catalog_path(&codex_home)).unwrap();
         assert_eq!(
-            written,
-            r#"{"models":[{"base_instructions":"","slug":"MiniMax-M3"}]}"#
+            serde_json::from_str::<serde_json::Value>(&written).unwrap(),
+            json!({
+                "models": [{
+                    "slug": "MiniMax-M3",
+                    "base_instructions": ""
+                }]
+            })
         );
     }
 

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -546,7 +546,7 @@ mod tests {
         let overrides = vec![
             r#"model_provider="minimax""#.to_string(),
             r#"model_providers.minimax.supports_websockets=false"#.to_string(),
-            r#"model_catalog_json="/home/user/.codex/vm0-codex-model-catalog.json""#.to_string(),
+            r#"model_catalog_json="/home/user/.codex/codex-model-catalog.json""#.to_string(),
         ];
         let args = build_codex_args_with_startup_config_for_test("MiniMax-M3", &overrides, "p");
 

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -546,7 +546,7 @@ mod tests {
         let overrides = vec![
             r#"model_provider="minimax""#.to_string(),
             r#"model_providers.minimax.supports_websockets=false"#.to_string(),
-            r#"model_catalog_json="/home/user/.codex/vm0-model-catalog.json""#.to_string(),
+            r#"model_catalog_json="/home/user/.codex/vm0-codex-model-catalog.json""#.to_string(),
         ];
         let args = build_codex_args_with_startup_config_for_test("MiniMax-M3", &overrides, "p");
 

--- a/crates/guest-agent/tests/codex_model_catalog_hydration.rs
+++ b/crates/guest-agent/tests/codex_model_catalog_hydration.rs
@@ -25,12 +25,18 @@ fn incomplete_catalog_inherits_bundled_defaults_before_cli_spawn() -> TestResult
     write_main_codex(&main_codex, &main_marker)?;
 
     let input_catalog = json!({
-        "models": [{
-            "slug": "deepseek-v3.2",
-            "display_name": "DeepSeek V3.2",
-            "context_window": 114_688,
-            "unknown_model_field": { "preserve": true }
-        }],
+        "models": [
+            {
+                "slug": "deepseek-v3.2",
+                "display_name": "DeepSeek V3.2",
+                "context_window": 114_688,
+                "unknown_model_field": { "preserve": true }
+            },
+            {
+                "slug": "deepseek-reasoner",
+                "model_messages": null
+            }
+        ],
         "unknown_catalog_field": "preserve"
     });
     let run_payload_path = write_run_payload(&runtime_dir, input_catalog)?;
@@ -46,8 +52,8 @@ fn incomplete_catalog_inherits_bundled_defaults_before_cli_spawn() -> TestResult
 
     assert_eq!(
         std::fs::read_to_string(&discovery_marker)?,
-        "debug\nmodels\n--bundled\n",
-        "setup should invoke exactly `codex debug models --bundled`"
+        "invocation\ndebug\nmodels\n--bundled\n",
+        "setup should invoke `codex debug models --bundled` exactly once"
     );
     assert!(
         main_marker.exists(),
@@ -68,6 +74,11 @@ fn incomplete_catalog_inherits_bundled_defaults_before_cli_spawn() -> TestResult
         written["models"][0]["unknown_model_field"],
         json!({ "preserve": true })
     );
+    assert_eq!(
+        written["models"][1]["base_instructions"],
+        "default instructions"
+    );
+    assert!(written["models"][1]["model_messages"].is_null());
     assert_eq!(written["unknown_catalog_field"], "preserve");
 
     Ok(())
@@ -161,7 +172,7 @@ fn bundled_discovery_failure_preserves_existing_catalog_and_stops_cli_spawn() ->
     );
     assert_eq!(
         std::fs::read_to_string(&discovery_marker)?,
-        "debug\nmodels\n--bundled\n"
+        "invocation\ndebug\nmodels\n--bundled\n"
     );
     let error_path = guest_contracts::runtime_paths::checkpoint_error_file(&runtime_dir);
     let error = std::fs::read_to_string(error_path)?;
@@ -268,7 +279,8 @@ fn write_successful_discovery_codex(path: &Path, marker: &Path) -> TestResult {
     write_executable(
         path,
         &format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\nprintf '%s' {}\n",
+            "#!/bin/sh\nprintf 'invocation\\n' >> {}\nprintf '%s\\n' \"$@\" >> {}\nprintf '%s' {}\n",
+            quote_shell_arg(&marker),
             quote_shell_arg(&marker),
             quote_shell_arg(&bundled)
         ),
@@ -280,7 +292,8 @@ fn write_failing_discovery_codex(path: &Path, marker: &Path) -> TestResult {
     write_executable(
         path,
         &format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\nexit 42\n",
+            "#!/bin/sh\nprintf 'invocation\\n' >> {}\nprintf '%s\\n' \"$@\" >> {}\nexit 42\n",
+            quote_shell_arg(&marker),
             quote_shell_arg(&marker)
         ),
     )

--- a/crates/guest-agent/tests/codex_model_catalog_hydration.rs
+++ b/crates/guest-agent/tests/codex_model_catalog_hydration.rs
@@ -144,7 +144,7 @@ fn bundled_discovery_failure_preserves_existing_catalog_and_stops_cli_spawn() ->
     let main_marker = tmp.path().join("main-invoked");
     let runtime_dir = tmp.path().join("runtime");
     let codex_home = tmp.path().join(".codex");
-    let catalog_path = codex_home.join("vm0-codex-model-catalog.json");
+    let catalog_path = codex_home.join("codex-model-catalog.json");
     std::fs::create_dir_all(&bin_dir)?;
     std::fs::create_dir_all(&codex_home)?;
     std::fs::write(&catalog_path, b"existing catalog")?;
@@ -206,7 +206,7 @@ fn write_run_payload(
 }
 
 fn read_written_catalog(home: &Path) -> Result<Value, Box<dyn std::error::Error>> {
-    let path = home.join(".codex/vm0-codex-model-catalog.json");
+    let path = home.join(".codex/codex-model-catalog.json");
     Ok(serde_json::from_slice(&std::fs::read(path)?)?)
 }
 

--- a/crates/guest-agent/tests/codex_model_catalog_hydration.rs
+++ b/crates/guest-agent/tests/codex_model_catalog_hydration.rs
@@ -1,0 +1,310 @@
+//! Codex model-catalog hydration must happen before the configured CLI starts.
+
+mod common;
+
+use serde_json::{Value, json};
+use shell_quote::quote_shell_arg;
+use std::path::Path;
+use std::process::{Command, Output};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+#[test]
+fn incomplete_catalog_inherits_bundled_defaults_before_cli_spawn() -> TestResult {
+    common::ensure_canonical_workspace_for_test()?;
+
+    let tmp = tempfile::tempdir()?;
+    let bin_dir = tmp.path().join("bin");
+    let discovery_codex = bin_dir.join("codex");
+    let discovery_marker = tmp.path().join("discovery-args");
+    let main_codex = tmp.path().join("main-codex");
+    let main_marker = tmp.path().join("main-invoked");
+    let runtime_dir = tmp.path().join("runtime");
+    std::fs::create_dir_all(&bin_dir)?;
+    write_successful_discovery_codex(&discovery_codex, &discovery_marker)?;
+    write_main_codex(&main_codex, &main_marker)?;
+
+    let input_catalog = json!({
+        "models": [{
+            "slug": "deepseek-v3.2",
+            "display_name": "DeepSeek V3.2",
+            "context_window": 114_688,
+            "unknown_model_field": { "preserve": true }
+        }],
+        "unknown_catalog_field": "preserve"
+    });
+    let run_payload_path = write_run_payload(&runtime_dir, input_catalog)?;
+
+    let output = run_guest_agent(GuestAgentInvocation {
+        discovery_bin_dir: &bin_dir,
+        main_codex: &main_codex,
+        runtime_dir: &runtime_dir,
+        run_payload_path: &run_payload_path,
+        home: tmp.path(),
+        run_id: "codex-model-catalog-hydration",
+    })?;
+
+    assert_eq!(
+        std::fs::read_to_string(&discovery_marker)?,
+        "debug\nmodels\n--bundled\n",
+        "setup should invoke exactly `codex debug models --bundled`"
+    );
+    assert!(
+        main_marker.exists(),
+        "configured Codex CLI should start after successful hydration: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let written = read_written_catalog(tmp.path())?;
+    assert_eq!(
+        written["models"][0]["base_instructions"],
+        "default instructions"
+    );
+    assert_eq!(
+        written["models"][0]["model_messages"]["instructions_template"],
+        "default template"
+    );
+    assert_eq!(written["models"][0]["context_window"], 114_688);
+    assert_eq!(
+        written["models"][0]["unknown_model_field"],
+        json!({ "preserve": true })
+    );
+    assert_eq!(written["unknown_catalog_field"], "preserve");
+
+    Ok(())
+}
+
+#[test]
+fn complete_catalog_bypasses_bundled_discovery() -> TestResult {
+    common::ensure_canonical_workspace_for_test()?;
+
+    let tmp = tempfile::tempdir()?;
+    let bin_dir = tmp.path().join("bin");
+    let discovery_codex = bin_dir.join("codex");
+    let discovery_marker = tmp.path().join("discovery-invoked");
+    let main_codex = tmp.path().join("main-codex");
+    let main_marker = tmp.path().join("main-invoked");
+    let runtime_dir = tmp.path().join("runtime");
+    std::fs::create_dir_all(&bin_dir)?;
+    write_failing_discovery_codex(&discovery_codex, &discovery_marker)?;
+    write_main_codex(&main_codex, &main_marker)?;
+
+    let input_catalog = json!({
+        "models": [{
+            "slug": "already-complete",
+            "base_instructions": "",
+            "unknown_model_field": true
+        }],
+        "unknown_catalog_field": "preserve"
+    });
+    let run_payload_path = write_run_payload(&runtime_dir, input_catalog.clone())?;
+
+    let output = run_guest_agent(GuestAgentInvocation {
+        discovery_bin_dir: &bin_dir,
+        main_codex: &main_codex,
+        runtime_dir: &runtime_dir,
+        run_payload_path: &run_payload_path,
+        home: tmp.path(),
+        run_id: "codex-complete-model-catalog",
+    })?;
+
+    assert!(
+        !discovery_marker.exists(),
+        "complete catalogs must not invoke bundled discovery"
+    );
+    assert!(
+        main_marker.exists(),
+        "configured Codex CLI should start for a complete catalog: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(read_written_catalog(tmp.path())?, input_catalog);
+
+    Ok(())
+}
+
+#[test]
+fn bundled_discovery_failure_preserves_existing_catalog_and_stops_cli_spawn() -> TestResult {
+    common::ensure_canonical_workspace_for_test()?;
+
+    let tmp = tempfile::tempdir()?;
+    let bin_dir = tmp.path().join("bin");
+    let discovery_codex = bin_dir.join("codex");
+    let discovery_marker = tmp.path().join("discovery-invoked");
+    let main_codex = tmp.path().join("main-codex");
+    let main_marker = tmp.path().join("main-invoked");
+    let runtime_dir = tmp.path().join("runtime");
+    let codex_home = tmp.path().join(".codex");
+    let catalog_path = codex_home.join("vm0-codex-model-catalog.json");
+    std::fs::create_dir_all(&bin_dir)?;
+    std::fs::create_dir_all(&codex_home)?;
+    std::fs::write(&catalog_path, b"existing catalog")?;
+    write_failing_discovery_codex(&discovery_codex, &discovery_marker)?;
+    write_main_codex(&main_codex, &main_marker)?;
+    let run_payload_path = write_run_payload(
+        &runtime_dir,
+        json!({ "models": [{ "slug": "incomplete" }] }),
+    )?;
+
+    let output = run_guest_agent(GuestAgentInvocation {
+        discovery_bin_dir: &bin_dir,
+        main_codex: &main_codex,
+        runtime_dir: &runtime_dir,
+        run_payload_path: &run_payload_path,
+        home: tmp.path(),
+        run_id: "codex-model-catalog-discovery-failure",
+    })?;
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(std::fs::read(&catalog_path)?, b"existing catalog");
+    assert!(
+        !main_marker.exists(),
+        "configured Codex CLI must not start after discovery failure"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&discovery_marker)?,
+        "debug\nmodels\n--bundled\n"
+    );
+    let error_path = guest_contracts::runtime_paths::checkpoint_error_file(&runtime_dir);
+    let error = std::fs::read_to_string(error_path)?;
+    assert!(error.contains("Codex setup failed"));
+    assert!(error.contains("failed to read the bundled Codex model catalog"));
+
+    Ok(())
+}
+
+fn write_run_payload(
+    runtime_dir: &Path,
+    model_catalog: Value,
+) -> Result<std::path::PathBuf, String> {
+    common::write_run_payload_file_for_test(
+        runtime_dir,
+        &guest_contracts::env::RunPayload {
+            prompt: "test model catalog setup".to_string(),
+            codex_runtime_config: json!({
+                "providerId": "deepseek-codex",
+                "name": "DeepSeek Codex",
+                "baseUrl": "https://example.test/v1",
+                "envKey": "OPENAI_API_KEY",
+                "wireApi": "responses",
+                "supportsWebsockets": false,
+                "modelCatalog": model_catalog
+            })
+            .to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )
+}
+
+fn read_written_catalog(home: &Path) -> Result<Value, Box<dyn std::error::Error>> {
+    let path = home.join(".codex/vm0-codex-model-catalog.json");
+    Ok(serde_json::from_slice(&std::fs::read(path)?)?)
+}
+
+struct GuestAgentInvocation<'a> {
+    discovery_bin_dir: &'a Path,
+    main_codex: &'a Path,
+    runtime_dir: &'a Path,
+    run_payload_path: &'a Path,
+    home: &'a Path,
+    run_id: &'a str,
+}
+
+fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::io::Error> {
+    Command::new(env!("CARGO_BIN_EXE_guest-agent"))
+        .env_clear()
+        .env("PATH", args.discovery_bin_dir)
+        .env("CLI_AGENT_TYPE", "codex")
+        .env("USE_MOCK_CODEX", "true")
+        .env("VM0_MOCK_CODEX_PATH", args.main_codex)
+        .env("VM0_RUN_ID", args.run_id)
+        .env(
+            guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
+            args.run_payload_path,
+        )
+        .env("VM0_API_BACKEND_URL", "http://127.0.0.1:1")
+        .env("VM0_API_TOKEN", "")
+        .env("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc")
+        .env("VM0_SANDBOX_REUSE_RESULT", "reused")
+        .env(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            args.runtime_dir,
+        )
+        .env("HOME", args.home)
+        .output()
+}
+
+fn write_successful_discovery_codex(path: &Path, marker: &Path) -> TestResult {
+    let marker = marker.to_string_lossy();
+    let bundled = json!({
+        "models": [
+            {
+                "priority": 0,
+                "visibility": "hide",
+                "supported_in_api": true,
+                "base_instructions": "hidden instructions",
+                "model_messages": null
+            },
+            {
+                "priority": 2,
+                "visibility": "list",
+                "supported_in_api": true,
+                "base_instructions": "lower priority instructions",
+                "model_messages": null
+            },
+            {
+                "priority": 1,
+                "visibility": "list",
+                "supported_in_api": true,
+                "base_instructions": "default instructions",
+                "model_messages": {
+                    "instructions_template": "default template",
+                    "instructions_variables": null,
+                    "approvals": null,
+                    "auto_review": null
+                }
+            }
+        ]
+    })
+    .to_string();
+    write_executable(
+        path,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\nprintf '%s' {}\n",
+            quote_shell_arg(&marker),
+            quote_shell_arg(&bundled)
+        ),
+    )
+}
+
+fn write_failing_discovery_codex(path: &Path, marker: &Path) -> TestResult {
+    let marker = marker.to_string_lossy();
+    write_executable(
+        path,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\nexit 42\n",
+            quote_shell_arg(&marker)
+        ),
+    )
+}
+
+fn write_main_codex(path: &Path, marker: &Path) -> TestResult {
+    let marker = marker.to_string_lossy();
+    write_executable(
+        path,
+        &format!(
+            "#!/bin/sh\nprintf invoked > {}\nexit 0\n",
+            quote_shell_arg(&marker)
+        ),
+    )
+}
+
+fn write_executable(path: &Path, contents: &str) -> TestResult {
+    std::fs::write(path, contents)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut permissions = std::fs::metadata(path)?.permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(path, permissions)?;
+    }
+    Ok(())
+}

--- a/crates/guest-agent/tests/codex_setup_fail_closed.rs
+++ b/crates/guest-agent/tests/codex_setup_fail_closed.rs
@@ -114,7 +114,9 @@ fn codex_setup_rejects_symlinked_home_before_model_catalog_write() -> TestResult
         "guest-agent must not launch Codex after setup fails"
     );
     assert!(
-        !target_codex_home.join("vm0-model-catalog.json").exists(),
+        !target_codex_home
+            .join("vm0-codex-model-catalog.json")
+            .exists(),
         "Codex setup must not write model catalog through symlinked CODEX_HOME"
     );
 

--- a/crates/guest-agent/tests/codex_setup_fail_closed.rs
+++ b/crates/guest-agent/tests/codex_setup_fail_closed.rs
@@ -114,9 +114,7 @@ fn codex_setup_rejects_symlinked_home_before_model_catalog_write() -> TestResult
         "guest-agent must not launch Codex after setup fails"
     );
     assert!(
-        !target_codex_home
-            .join("vm0-codex-model-catalog.json")
-            .exists(),
+        !target_codex_home.join("codex-model-catalog.json").exists(),
         "Codex setup must not write model catalog through symlinked CODEX_HOME"
     );
 


### PR DESCRIPTION
## Summary

- detect incomplete Codex model catalogs from missing `base_instructions` instead of a provider id
- hydrate only incomplete models from one `codex debug models --bundled` call while preserving explicit and unknown fields
- bypass bundled discovery for complete catalogs and fail before replacement when discovery or required-field validation fails
- rename the guest-owned catalog file to `codex-model-catalog.json`

## Compatibility

- the API continues to send `providerId: "vm0-model"` in this slice
- old guests remain compatible with the current API while new guests no longer depend on that provider key
- the catalog filename is an internal guest path passed explicitly through `model_catalog_json`; no persisted-data migration or legacy-path fallback is required
- #24943 must wait for this runner artifact to reach production and previous runners to drain

## Exclusions

- no API contract or provider-id change
- no database, persisted-state, runtime-config capability, provider alias, or rootfs policy change
- no old-sandbox compatibility path

## Validation

- `cargo fmt --check --all`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-agent --no-deps`
- `cargo test -p guest-agent --test codex_model_catalog_hydration`
- `cargo test -p guest-agent --quiet`
- `cargo test -p guest-agent --all-targets --all-features --quiet`
- repository pre-commit Rust formatting, Clippy, documentation, and file-size hooks

Relates to #24942

Parent: #24903
