### PR TITLE
fix(platform): preserve connector access spacing

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1580,7 +1580,7 @@ describe("connectors page", () => {
     await waitFor(() => {
       const card = connectorCardByLabel("GitHub");
       const access = within(card).getByLabelText("Manage GitHub access");
-      expect(access).toHaveTextContent("Used by");
+      expect(access.textContent).toContain("Used by\u00a0Research, Support");
       expect(access).toHaveTextContent("Research, Support");
       expect(access).toHaveTextContent("+2");
       expect(access).not.toHaveTextContent("Growth");

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -779,7 +779,8 @@ function ConnectorAccessButton({
           <span className="shrink-0">
             {t(($) => {
               return $.connectors.catalog.access.usedBy;
-            })}
+            }).trimEnd()}
+            {"\u00a0"}
           </span>
           <span
             className="min-w-0 truncate underline decoration-dotted decoration-muted-foreground/40 underline-offset-2"


### PR DESCRIPTION
## Summary

- preserve visible separation between the connector access label and the first authorized agent name
- normalize translated label suffixes before adding a non-breaking separator
- add a regression assertion for the rendered separator

## Scope

- changes only the built-in connector card access label rendering and its existing page test
- does not change connector authorization behavior, translations, or custom connector cards

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (all packages except the API ESLint step passed; that step reached the default Node heap limit)
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api run lint`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx` (78 tests passed)

## Visual verification

- not run locally because repository instructions prohibit starting a local dev server; the PR preview pipeline can provide browser verification

Closes #24953
