### PR TITLE
fix(python): revalidate buffered requests before dispatch

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -811,7 +811,6 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
             except BaseException:
                 auth_base_forwarder.release_forward_request_admission(admission)
                 raise
-            request_classification.cache_classification(flow, classification)
             return None
 
         if _firewall_allow_uses_aws_sigv4(allow):
@@ -928,7 +927,6 @@ def _admit_buffered_aws_sigv4_request(
     except BaseException:
         aws_sigv4_body_admission.release(admission)
         raise
-    request_classification.cache_classification(flow, classification)
 
 
 async def _try_firewall_request_stream_from_headers(
@@ -1145,6 +1143,10 @@ async def request(flow: http.HTTPFlow) -> None:
             flow.metadata[metadata_keys.REQUEST_STREAM_COMPLETE] = True
 
         classification = _request_classification_for_flow(flow)
+        if classification.kind != "firewall_allow" or not _firewall_allow_auth_base(
+            classification.firewall_allow
+        ):
+            auth_base_forwarder.release_forward_request_admission_from_flow(flow)
         if classification.kind != "firewall_allow" or not _firewall_allow_uses_aws_sigv4(
             classification.firewall_allow
         ):
@@ -1194,7 +1196,6 @@ async def request(flow: http.HTTPFlow) -> None:
             _set_firewall_block_response(flow, classification.firewall_block)
             return
         if classification.kind == "public_destination_denied":
-            auth_base_forwarder.release_forward_request_admission_from_flow(flow)
             terminal_usage.release_tracked_flow(flow)
             _block_public_destination_denied(flow, classification.public_destination_denial)
             return

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -2,10 +2,11 @@
 
 This module owns the classification result consumed by both `requestheaders()`
 and `request()`. The header hook may classify as a probe before mitmproxy has
-buffered the request body. When that header-phase decision must be reused by
-the request hook, it caches the classification on the current flow. When the
-header hook only probed to decide whether it can handle the request early, it
-restores the metadata touched by that probe path before falling through.
+buffered the request body. It caches the classification only when header-phase
+authorization is complete and mitmproxy may start upstream streaming before the
+request hook. Body-admission paths keep their admission state separately so the
+request hook classifies them against current registry state before upstream
+dispatch.
 
 The request hook consumes a cached classification when present, otherwise it
 performs a fresh classification. Cached classifications are scoped to a single
@@ -217,9 +218,10 @@ RequestClassification = (
 def cache_classification(flow: http.HTTPFlow, classification: RequestClassification) -> None:
     """Cache a header-phase classification for request-phase reuse.
 
-    Callers should cache only when the request hook must continue from the same
-    classification decision, such as request streaming or header-phase auth
-    setup. Terminal and early-response paths must pop the cached value.
+    Callers must cache only after header-phase authorization is complete and
+    mitmproxy may start upstream streaming before the request hook. Reserving
+    buffered body admission alone does not authorize reuse. Terminal and
+    early-response paths must pop the cached value.
     """
 
     flow.metadata[REQUEST_CLASSIFICATION_METADATA_KEY] = classification

--- a/crates/runner/mitm-addon/tests/test_request_handler_auth_base_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_auth_base_body.py
@@ -11,6 +11,7 @@ import auth
 import auth_base_forwarder
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import request_classification
 import upstream_destination_binding
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
@@ -472,6 +473,49 @@ async def test_auth_base_requestheaders_admission_released_after_success(
     assert flow.response.status_code == 202
     assert flow.response.content == b"accepted"
     assert flow.server_conn.id in upstream_destination_binding.binding_snapshot_for_tests()
+    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+
+
+async def test_auth_base_buffered_request_revalidates_registry_before_auth(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_auth_base_firewall_registry(tmp_path)
+    declared_size = mitm_addon.STREAM_BUFFER_LIMIT + 1
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            ("X-Client", "original"),
+            ("Content-Length", str(declared_size)),
+        ),
+        request_body=b"body",
+    )
+    original_headers = tuple(flow.request.headers.fields)
+    get_headers = AsyncMock()
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+        assert auth_base_forwarder.forward_request_admission_state_for_tests() == (
+            1,
+            declared_size,
+        )
+        assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
+
+        reg_path.unlink()
+        await mitm_addon.request(flow)
+
+    get_headers.assert_not_awaited()
+    assert flow.response is not None
+    assert flow.response.status_code == 503
+    assert json.loads(flow.response.content)["error"] == "registry_unavailable"
+    assert tuple(flow.request.headers.fields) == original_headers
     assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
 
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
@@ -16,6 +16,7 @@ import auth
 import aws_sigv4_body_admission
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import request_classification
 import request_streaming
 from aws_sigv4 import AwsSigV4BodyHash, hash_request_body
 from body_limits import STREAM_BUFFER_LIMIT
@@ -344,6 +345,48 @@ async def test_payload_dependent_sigv4_holds_admission_until_terminal_cleanup(
     get_headers.assert_awaited_once()
     assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
     assert metadata_keys.AWS_SIGV4_BODY_ADMISSION not in flow.metadata
+
+
+async def test_payload_dependent_sigv4_revalidates_network_policy_before_auth(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    body = b"body"
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        body=body,
+        content_length=str(len(body)),
+    )
+    original_authorization = flow.request.headers["authorization"]
+    get_headers = AsyncMock(return_value=_resolved_token_meta())
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+        assert aws_sigv4_body_admission.state_for_tests() == (1, len(body))
+        assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
+
+        registry_payload = json.loads(registry_path.read_text())
+        policy = registry_payload["vms"][_CLIENT_IP]["networkPolicies"]["aws"]
+        policy["allow"] = []
+        policy["deny"] = [_AWS_PERMISSION]
+        registry_payload["updatedAt"] = 1
+        registry_path.write_text(json.dumps(registry_payload))
+
+        await mitm_addon.request(flow)
+
+    get_headers.assert_not_awaited()
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert json.loads(flow.response.content)["reason"] == "permission_denied"
+    assert flow.request.headers["authorization"] == original_authorization
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
 
 
 async def test_payload_dependent_sigv4_hashing_allows_event_loop_progress(

--- a/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
@@ -1262,7 +1262,7 @@ async def test_public_destination_request_phase_blocks_unresolved_hostname_witho
     )
 
 
-async def test_public_destination_revalidates_cached_auth_base_classification(
+async def test_public_destination_reclassifies_buffered_auth_base_request(
     tmp_path, real_flow, mitm_ctx, headers
 ):
     reg_path = _write_public_destination_firewall_registry(
@@ -1279,7 +1279,7 @@ async def test_public_destination_revalidates_cached_auth_base_classification(
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
         assert mitm_addon.requestheaders(flow) is None
-        assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY in flow.metadata
+        assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
         assert auth_base_forwarder.forward_request_admission_state_for_tests() == (
             1,
             mitm_addon.STREAM_BUFFER_LIMIT + 1,
@@ -1302,7 +1302,7 @@ async def test_public_destination_revalidates_cached_auth_base_classification(
     assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
 
 
-async def test_public_destination_revalidates_cached_auth_base_hostname_classification(
+async def test_public_destination_reclassifies_buffered_auth_base_hostname_request(
     tmp_path, real_flow, mitm_ctx, headers
 ):
     reg_path = _write_public_destination_firewall_registry(
@@ -1319,7 +1319,7 @@ async def test_public_destination_revalidates_cached_auth_base_hostname_classifi
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
         assert mitm_addon.requestheaders(flow) is None
-        assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY in flow.metadata
+        assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
         assert auth_base_forwarder.forward_request_admission_state_for_tests() == (
             1,
             mitm_addon.STREAM_BUFFER_LIMIT + 1,


### PR DESCRIPTION
## Summary

- stop treating buffered `auth.base` and payload-dependent AWS SigV4 admission as cached authorization
- reclassify those requests against current registry, TLS, VM, firewall, and network-policy state before upstream dispatch
- preserve header-authorized stream caches and release incompatible buffered admission immediately
- cover registry removal, same-run policy revocation, credential non-resolution, and `publicDestination` behavior with hook-level integration tests

## Why

Mitmproxy invokes `request()` before sending a buffered request upstream, but the previous classification cache bypassed the current registry at that gate. A stopped/replaced run or an in-place network-policy revocation could therefore continue into auth or forwarding under the old header-phase allow.

The change removes the unused buffered classification cache rather than adding cache provenance. Existing admission leases still retain bounded-body ownership, while the canonical classifier supplies current authorization. Classification caching remains unchanged for requests authorized in `requestheaders()` that mitmproxy may already be streaming before `request()` runs.

## Compatibility

No database schema, persisted data, API, queue payload, runner protocol, browser contract, generated contract, migration, or feature switch changes.

## Validation

- `uv lock --check`
- `uv sync --locked`
- focused affected pytest suite: 195 passed
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/`: 4,715 passed

Closes #24927
