### PR TITLE
fix(python): revalidate firewall authorization after auth waits

### DIFF
--- a/crates/runner/mitm-addon/src/http_local_responses.py
+++ b/crates/runner/mitm-addon/src/http_local_responses.py
@@ -18,6 +18,7 @@ from url_utils import AuthorityValidationError
 
 _BUILTIN_HOST_POLICY_DENIED_ERROR: Final = "builtin_host_policy_denied"
 _AMBIGUOUS_CONNECTOR_ROUTE_ERROR: Final = "ambiguous_connector_route"
+_FIREWALL_AUTHORIZATION_CHANGED_ERROR: Final = "firewall_authorization_changed"
 _STALE_TLS_ADMISSION_ERROR: Final = "stale_tls_admission"
 _UPSTREAM_DESTINATION_UNBOUND_ERROR: Final = "upstream_destination_unbound"
 _HTTP_STATUS_CONFLICT = 409
@@ -126,6 +127,39 @@ def block_stale_tls_admission(flow: http.HTTPFlow, *, reason: str) -> None:
                     "proxy registry VM"
                 ),
                 "reason": reason,
+            }
+        ).encode(),
+        {"Content-Type": "application/json"},
+    )
+
+
+def block_firewall_authorization_changed(
+    flow: http.HTTPFlow,
+    *,
+    current_decision: str,
+) -> None:
+    proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
+    log_proxy_entry(
+        proxy_log_path,
+        "warn",
+        "Request blocked: firewall authorization changed while credentials were resolving",
+        type="firewall_authorization",
+        current_decision=current_decision,
+    )
+    flow_metadata.set_firewall_decision(
+        flow.metadata,
+        "BLOCK",
+        error=_FIREWALL_AUTHORIZATION_CHANGED_ERROR,
+    )
+    flow.response = http.Response.make(
+        _HTTP_STATUS_CONFLICT,
+        json.dumps(
+            {
+                "error": _FIREWALL_AUTHORIZATION_CHANGED_ERROR,
+                "message": (
+                    "Request blocked: firewall authorization changed while credentials "
+                    "were resolving"
+                ),
             }
         ).encode(),
         {"Content-Type": "application/json"},

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -114,6 +114,26 @@ _HTTP_OWS_CHARS = " \t"
 # _REQUEST_HEADERS_TERMINATED is a flow-local sentinel for request() early exit.
 _REQUEST_HEADERS_TERMINATED = "_request_headers_terminated"
 _FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS = "_firewall_auth_applied_in_requestheaders"
+_STALE_FIREWALL_AUTHORIZATION_METADATA_KEYS = (
+    metadata_keys.FIREWALL_BASE,
+    metadata_keys.FIREWALL_API_ID,
+    metadata_keys.FIREWALL_AUTH_CACHE_KEY,
+    metadata_keys.FIREWALL_NAME,
+    metadata_keys.FIREWALL_PERMISSION,
+    metadata_keys.FIREWALL_RULE_MATCH,
+    metadata_keys.FIREWALL_PARAMS,
+    metadata_keys.FIREWALL_BILLABLE,
+    metadata_keys.FIREWALL_ACTION,
+    metadata_keys.FIREWALL_ERROR,
+    metadata_keys.CONNECTOR_ROUTE_REASON,
+    metadata_keys.CONNECTOR_ROUTE_CANDIDATES,
+    metadata_keys.AUTH_RESOLVED_SECRETS,
+    metadata_keys.AUTH_REFRESHED_CONNECTORS,
+    metadata_keys.AUTH_REFRESHED_SECRETS,
+    metadata_keys.AUTH_CACHE_HIT,
+    metadata_keys.AUTH_URL_REWRITE,
+    metadata_keys.MODEL_USAGE_PROVIDER,
+)
 
 _AUTH_BASE_BODYLESS_METHODS = frozenset(("GET", "HEAD"))
 _HTTP_RESPONSE_BODYLESS_METHODS = frozenset(("CONNECT", "HEAD"))
@@ -619,6 +639,17 @@ def _block_stale_tls_admission(flow: http.HTTPFlow, *, reason: str) -> None:
     http_local_responses.block_stale_tls_admission(flow, reason=reason)
 
 
+def _block_firewall_authorization_changed(
+    flow: http.HTTPFlow,
+    *,
+    current_decision: str,
+) -> None:
+    http_local_responses.block_firewall_authorization_changed(
+        flow,
+        current_decision=current_decision,
+    )
+
+
 def _block_upstream_destination_unbound(
     flow: http.HTTPFlow,
     *,
@@ -966,6 +997,7 @@ async def _try_firewall_request_stream_from_headers(
 
     _maybe_normalize_accept_encoding_for_body_inspection(flow, allow, vm_info)
     _start_request_timing(flow)
+    expected_run_id = flow_metadata.run_id(flow.metadata)
     admitted_server = flow.server_conn
     require_connected = flow.server_conn.connected
     try:
@@ -974,12 +1006,13 @@ async def _try_firewall_request_stream_from_headers(
             allow,
             vm_info,
             revalidate_ordinary_upstream_credentials=lambda: (
-                _has_current_direct_connector_auth_binding(
+                _ordinary_upstream_credentials_are_current_for_requestheaders(
                     flow,
+                    allow,
+                    expected_run_id=expected_run_id,
                     admitted_server=admitted_server,
                     require_connected=require_connected,
                 )
-                and _builtin_host_policy_error_for_firewall_allow(flow, allow) is None
             ),
         )
     except (asyncio.CancelledError, Exception):
@@ -1000,6 +1033,7 @@ async def _try_firewall_request_stream_from_headers(
         await _prepare_codex_catalog_request_with_upstream_revalidation(
             flow,
             allow,
+            expected_run_id=expected_run_id,
             admitted_server=admitted_server,
             require_connected=require_connected,
             request_end_stream=request_end_stream is True,
@@ -1044,6 +1078,7 @@ def _revalidate_ordinary_upstream_credentials_for_request(
     flow: http.HTTPFlow,
     allow: matching.FirewallAllow,
     *,
+    expected_run_id: str,
     admitted_server: connection.Server,
     require_connected: bool,
 ) -> bool:
@@ -1055,19 +1090,24 @@ def _revalidate_ordinary_upstream_credentials_for_request(
         _block_upstream_destination_unbound(flow, reason="connector_auth")
         return False
 
-    public_destination_denial = request_classification.current_public_destination_denial(
-        flow,
-        allow,
+    current_classification = _current_firewall_authorization_classification(flow)
+    current_allow = _equivalent_current_firewall_allow(
+        current_classification,
+        expected_allow=allow,
+        expected_run_id=expected_run_id,
     )
-    if public_destination_denial is not None:
-        _block_public_destination_denied(flow, public_destination_denial)
+    if current_allow is None:
+        _block_current_firewall_authorization(flow, current_classification)
         return False
 
-    host_policy_error = _builtin_host_policy_error_for_firewall_allow(flow, allow)
+    host_policy_error = _builtin_host_policy_error_for_firewall_allow(
+        flow,
+        current_allow.firewall_allow,
+    )
     if host_policy_error is not None:
         _block_builtin_host_policy_denied(
             flow,
-            allow=allow,
+            allow=current_allow.firewall_allow,
             error=host_policy_error,
         )
         return False
@@ -1075,10 +1115,111 @@ def _revalidate_ordinary_upstream_credentials_for_request(
     return True
 
 
+def _current_firewall_authorization_classification(
+    flow: http.HTTPFlow,
+) -> request_classification.RequestClassification:
+    preserved_probe_metadata = {
+        key: flow.metadata[key]
+        for key in (
+            metadata_keys.HTTP_REQUEST_START_MONOTONIC,
+            metadata_keys.WEBSOCKET_UPGRADE_REQUEST,
+        )
+        if key in flow.metadata
+    }
+    request_classification.restore_request_headers_probe_metadata(
+        flow,
+        preserved_probe_metadata,
+    )
+    return _classify_request_for_flow(flow)
+
+
+def _equivalent_current_firewall_allow(
+    classification: request_classification.RequestClassification,
+    *,
+    expected_allow: matching.FirewallAllow,
+    expected_run_id: str,
+) -> request_classification.FirewallAllow | None:
+    if not isinstance(classification, request_classification.FirewallAllow):
+        return None
+    current_run_id = classification.vm_info.get("runId")
+    if current_run_id != expected_run_id:
+        return None
+    if classification.firewall_allow != expected_allow:
+        return None
+    return classification
+
+
+def _ordinary_upstream_credentials_are_current_for_requestheaders(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+    *,
+    expected_run_id: str,
+    admitted_server: connection.Server,
+    require_connected: bool,
+) -> bool:
+    if not _has_current_direct_connector_auth_binding(
+        flow,
+        admitted_server=admitted_server,
+        require_connected=require_connected,
+    ):
+        return False
+    current_classification = _current_firewall_authorization_classification(flow)
+    current_allow = _equivalent_current_firewall_allow(
+        current_classification,
+        expected_allow=allow,
+        expected_run_id=expected_run_id,
+    )
+    return current_allow is not None and (
+        _builtin_host_policy_error_for_firewall_allow(
+            flow,
+            current_allow.firewall_allow,
+        )
+        is None
+    )
+
+
+def _clear_stale_firewall_authorization_metadata(flow: http.HTTPFlow) -> None:
+    for key in _STALE_FIREWALL_AUTHORIZATION_METADATA_KEYS:
+        flow.metadata.pop(key, None)
+
+
+def _block_current_firewall_authorization(
+    flow: http.HTTPFlow,
+    classification: request_classification.RequestClassification,
+) -> None:
+    _clear_stale_firewall_authorization_metadata(flow)
+    if classification.kind == "registry_unavailable":
+        _block_registry_unavailable(flow, classification.registry_unavailable)
+        return
+    if classification.kind == "stale_tls_admission":
+        _block_stale_tls_admission(flow, reason=classification.stale_tls_reason)
+        return
+    if classification.kind == "invalid_registry_vm":
+        _block_invalid_registry_vm(flow, classification.invalid_vm)
+        return
+    if classification.kind == "authority_denied":
+        _block_authority_validation_error(flow, classification.authority_error)
+        return
+    if classification.kind == "firewall_ambiguous":
+        _set_firewall_ambiguous_response(flow, classification.firewall_ambiguous)
+        return
+    if classification.kind == "firewall_block":
+        _set_firewall_block_response(flow, classification.firewall_block)
+        return
+    if classification.kind == "public_destination_denied":
+        _block_public_destination_denied(flow, classification.public_destination_denial)
+        return
+    _block_firewall_authorization_changed(
+        flow,
+        current_decision=classification.kind,
+    )
+
+
 async def _prepare_codex_catalog_request_with_upstream_revalidation(
     flow: http.HTTPFlow,
     allow: matching.FirewallAllow,
     *,
+    expected_run_id: str,
     admitted_server: connection.Server,
     require_connected: bool,
     request_end_stream: bool,
@@ -1087,9 +1228,9 @@ async def _prepare_codex_catalog_request_with_upstream_revalidation(
 
     A successful local cache response never continues to the provider. When
     ``prepare_request()`` reports that this flow waited and no local response exists,
-    the suspension may have invalidated its connector binding, public destination,
-    or host-policy assumptions, so ordinary credential-bearing continuation is
-    revalidated before proceeding. See
+    the suspension may have invalidated its connector binding, registry-backed
+    firewall authorization, destination, or host-policy assumptions, so ordinary
+    credential-bearing continuation is revalidated before proceeding. See
     ``test_catalog_wait_revalidates_only_provider_continuation`` for owner failure,
     timeout, and local-response coverage across both request hooks.
     """
@@ -1105,6 +1246,7 @@ async def _prepare_codex_catalog_request_with_upstream_revalidation(
         _revalidate_ordinary_upstream_credentials_for_request(
             flow,
             allow,
+            expected_run_id=expected_run_id,
             admitted_server=admitted_server,
             require_connected=require_connected,
         )
@@ -1247,6 +1389,7 @@ async def request(flow: http.HTTPFlow) -> None:
                 is_billable_firewall(allow.name, vm_info),
                 _is_model_provider_usage_observable(allow.name, vm_info),
             )
+            expected_run_id = flow_metadata.run_id(flow.metadata)
             admitted_server = flow.server_conn
             require_connected = flow.server_conn.connected
             auth_result = await handle_firewall_request(
@@ -1257,6 +1400,7 @@ async def request(flow: http.HTTPFlow) -> None:
                     _revalidate_ordinary_upstream_credentials_for_request(
                         flow,
                         allow,
+                        expected_run_id=expected_run_id,
                         admitted_server=admitted_server,
                         require_connected=require_connected,
                     )
@@ -1272,6 +1416,7 @@ async def request(flow: http.HTTPFlow) -> None:
                 await _prepare_codex_catalog_request_with_upstream_revalidation(
                     flow,
                     allow,
+                    expected_run_id=expected_run_id,
                     admitted_server=admitted_server,
                     require_connected=require_connected,
                     request_end_stream=True,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -971,8 +971,15 @@ async def _try_firewall_request_stream_from_headers(
 ) -> None:
     allow = classification.firewall_allow
     vm_info = classification.vm_info
+    request_headers_snapshot = http.Headers(flow.request.headers.fields)
+    request_url_snapshot = flow.request.url
+
+    def restore_request_state() -> None:
+        flow.request.url = request_url_snapshot
+        flow.request.headers = http.Headers(request_headers_snapshot.fields)
 
     def fall_back() -> None:
+        restore_request_state()
         if aws_sigv4_buffered_fallback is None:
             _restore_request_headers_probe_metadata(flow, metadata_snapshot)
             return
@@ -1016,6 +1023,7 @@ async def _try_firewall_request_stream_from_headers(
             ),
         )
     except (asyncio.CancelledError, Exception):
+        restore_request_state()
         _restore_request_headers_probe_metadata(flow, metadata_snapshot)
         raise
     if result is not FirewallHeaderPhaseAuthResult.APPLIED:
@@ -1042,6 +1050,7 @@ async def _try_firewall_request_stream_from_headers(
             request_streaming.configure_request_stream(flow, capture_body=capture_body)
     except (asyncio.CancelledError, Exception):
         _release_terminal_flow_state(flow, release_tracking=True)
+        restore_request_state()
         _restore_request_headers_probe_metadata(flow, metadata_snapshot)
         raise
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
@@ -251,7 +251,7 @@ async def test_registry_change_during_auth_blocks_old_authorization(
             await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
             _mutate_registry(registry_path, tmp_path, registry_mutation)
             release_auth_resolution.set()
-            await hook_task
+            await asyncio.gather(hook_task)
         finally:
             release_auth_resolution.set()
             await cancel_pending_task(hook_task)
@@ -327,7 +327,7 @@ async def test_unrelated_same_run_policy_change_keeps_equivalent_authorization(
                 vm_info=_registry_vm(tmp_path, allow_unrelated_orgs=True),
             )
             release_auth_resolution.set()
-            await hook_task
+            await asyncio.gather(hook_task)
         finally:
             release_auth_resolution.set()
             await cancel_pending_task(hook_task)
@@ -381,7 +381,7 @@ async def test_different_same_run_allow_decision_fails_closed_without_old_creden
                 ),
             )
             release_auth_resolution.set()
-            await request_task
+            await asyncio.gather(request_task)
         finally:
             release_auth_resolution.set()
             await cancel_pending_task(request_task)

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
@@ -1,0 +1,397 @@
+"""Registry authorization revalidation across firewall-auth waits."""
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Literal, cast
+from unittest.mock import AsyncMock
+
+import pytest
+from mitmproxy import http, tls
+
+import auth
+import connector_intent
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+import request_classification
+from body_limits import STREAM_BUFFER_LIMIT
+from tests.firewall_helpers import cancel_pending_task
+from tests.request_handler_helpers import _single_firewall_vm, _write_registry
+from tests.requestheaders_helpers import _assert_no_request_stream, await_requestheaders_result
+from tests.upstream_connection_helpers import mark_connected_tls_upstream
+
+type HookPhase = Literal["request", "requestheaders"]
+type RegistryMutation = Literal["remove", "replace_run", "revoke_permission"]
+
+_CLIENT_IP = "10.200.0.5"
+_ORIGINAL_RUN_ID = "run-before-auth-wait"
+_RESOLVED_AUTHORIZATION = "Bearer resolved-for-old-authorization"
+
+
+def _registry_vm(
+    tmp_path: Path,
+    *,
+    run_id: str = _ORIGINAL_RUN_ID,
+    allow_repos: bool = True,
+    allow_unrelated_orgs: bool = False,
+) -> dict[str, object]:
+    allowed_permissions = ["repos-write"] if allow_repos else []
+    denied_permissions = [] if allow_repos else ["repos-write"]
+    if allow_unrelated_orgs:
+        allowed_permissions.append("orgs-write")
+    else:
+        denied_permissions.append("orgs-write")
+    return _single_firewall_vm(
+        tmp_path,
+        run_id=run_id,
+        api_entry={
+            "base": "https://api.github.com",
+            "auth": {
+                "headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"},
+                "query": {"managed": "${{ secrets.GITHUB_TOKEN }}"},
+            },
+            "permissions": [
+                {"name": "repos-write", "rules": ["POST /repos/{path+}"]},
+                {"name": "orgs-write", "rules": ["POST /orgs/{path+}"]},
+            ],
+        },
+        network_policy={
+            "allow": allowed_permissions,
+            "deny": denied_permissions,
+            "ask": [],
+            "unknownPolicy": "deny",
+        },
+        billable_firewalls=["github"],
+        vm_fields={"captureNetworkBodies": True},
+    )
+
+
+def _switchable_permission_vm(
+    tmp_path: Path,
+    *,
+    allowed_permission: str,
+) -> dict[str, object]:
+    permissions = ("repos-primary", "repos-secondary")
+    denied_permission = next(
+        permission for permission in permissions if permission != allowed_permission
+    )
+    return _single_firewall_vm(
+        tmp_path,
+        run_id=_ORIGINAL_RUN_ID,
+        api_entry={
+            "base": "https://api.github.com",
+            "auth": {
+                "headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"},
+                "query": {"managed": "${{ secrets.GITHUB_TOKEN }}"},
+            },
+            "permissions": [
+                {"name": permission, "rules": ["POST /repos/{path+}"]} for permission in permissions
+            ],
+        },
+        network_policy={
+            "allow": [allowed_permission],
+            "deny": [denied_permission],
+            "ask": [],
+            "unknownPolicy": "deny",
+        },
+        billable_firewalls=["github"],
+        vm_fields={"captureNetworkBodies": True},
+    )
+
+
+def _publish_registry(registry_path: Path, *, vm_info: dict[str, object] | None) -> None:
+    """Publish a complete registry snapshot with the runner's atomic-replace shape."""
+    next_path = registry_path.with_name("registry.next.json")
+    vms = {} if vm_info is None else {_CLIENT_IP: vm_info}
+    next_path.write_text(json.dumps({"vms": vms}), encoding="utf-8")
+    next_path.replace(registry_path)
+
+
+def _mutate_registry(
+    registry_path: Path,
+    tmp_path: Path,
+    mutation: RegistryMutation,
+) -> None:
+    if mutation == "remove":
+        _publish_registry(registry_path, vm_info=None)
+        return
+    if mutation == "replace_run":
+        _publish_registry(
+            registry_path,
+            vm_info=_registry_vm(tmp_path, run_id="run-replacement-after-auth-wait"),
+        )
+        return
+    _publish_registry(
+        registry_path,
+        vm_info=_registry_vm(tmp_path, allow_repos=False),
+    )
+
+
+def _firewall_flow(real_flow, make_tls_data) -> tuple[http.HTTPFlow, tls.ClientHelloData]:
+    flow = real_flow(
+        with_response=False,
+        client_ip=_CLIENT_IP,
+        host="api.github.com",
+        sni="api.github.com",
+        method="POST",
+        path="/repos/octocat/hello?client=visible",
+        request_headers=http.Headers(
+            (
+                (b"Host", b"api.github.com"),
+                (b"Content-Length", str(STREAM_BUFFER_LIMIT + 1).encode()),
+            )
+        ),
+    )
+    client_id = "client-firewall-auth-revalidation"
+    flow.client_conn.id = client_id
+    upstream_endpoint = ("172.66.0.243", 443)
+    mark_connected_tls_upstream(
+        flow,
+        sni="api.github.com",
+        server_address=upstream_endpoint,
+        peername=upstream_endpoint,
+    )
+    tls_data = make_tls_data(
+        client_ip=_CLIENT_IP,
+        sni="api.github.com",
+        client_id=client_id,
+        server_address=upstream_endpoint,
+        server_peername=upstream_endpoint,
+        server_connected=True,
+        server_id=flow.server_conn.id,
+    )
+    return flow, cast(tls.ClientHelloData, tls_data)
+
+
+def _resolved_firewall_auth() -> dict[str, object]:
+    return {
+        "headers": {"Authorization": _RESOLVED_AUTHORIZATION},
+        "query": {"managed": "resolved-for-old-authorization"},
+        "resolved_secrets": ["GITHUB_TOKEN"],
+        "refreshed_connectors": [],
+        "refreshed_secrets": [],
+        "cache_hit": False,
+    }
+
+
+def _assert_current_denial(flow: http.HTTPFlow, mutation: RegistryMutation) -> None:
+    assert flow.response is not None
+    assert flow.response.content is not None
+    body = json.loads(flow.response.content)
+    if mutation == "remove":
+        assert flow.response.status_code == 503
+        assert body["error"] == "stale_tls_admission"
+        assert body["reason"] == "registry_entry_missing"
+        assert metadata_keys.VM_RUN_ID not in flow.metadata
+    elif mutation == "replace_run":
+        assert flow.response.status_code == 503
+        assert body["error"] == "stale_tls_admission"
+        assert body["reason"] == "run_id_mismatch"
+        assert metadata_keys.VM_RUN_ID not in flow.metadata
+    else:
+        assert flow.response.status_code == 403
+        assert body["error"] == "permission_denied"
+        assert body["reason"] == "permission_denied"
+        assert body["permissions"] == ["repos-write"]
+        assert flow.metadata[metadata_keys.VM_RUN_ID] == _ORIGINAL_RUN_ID
+
+    assert flow.metadata.get(metadata_keys.FIREWALL_AUTH_CACHE_KEY) is None
+    assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
+    assert "_usage_flow_tracked" not in flow.metadata
+
+
+@pytest.mark.parametrize("hook_phase", ["request", "requestheaders"])
+@pytest.mark.parametrize(
+    "registry_mutation",
+    ["remove", "replace_run", "revoke_permission"],
+)
+async def test_registry_change_during_auth_blocks_old_authorization(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+    monkeypatch,
+    hook_phase: HookPhase,
+    registry_mutation: RegistryMutation,
+):
+    registry_path = _write_registry(
+        tmp_path,
+        client_ip=_CLIENT_IP,
+        vm_info=_registry_vm(tmp_path),
+    )
+    flow, tls_data = _firewall_flow(real_flow, make_tls_data)
+    flow.metadata["preexisting"] = "keep"
+    original_metadata = dict(flow.metadata)
+    original_headers = flow.request.headers.fields
+    original_path = flow.request.path
+    auth_resolution_entered = asyncio.Event()
+    release_auth_resolution = asyncio.Event()
+
+    async def resolve_auth(*_args, **_kwargs):
+        auth_resolution_entered.set()
+        await release_auth_resolution.wait()
+        return _resolved_firewall_auth()
+
+    auth_fetch = AsyncMock(side_effect=resolve_auth)
+    monkeypatch.setattr(auth, "get_firewall_headers", auth_fetch)
+
+    hook_task: asyncio.Task[None] | None = None
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        if hook_phase == "request":
+            hook_task = asyncio.create_task(mitm_addon.request(flow))
+        else:
+            hook_task = asyncio.create_task(
+                await_requestheaders_result(mitm_addon.requestheaders(flow))
+            )
+        try:
+            await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
+            _mutate_registry(registry_path, tmp_path, registry_mutation)
+            release_auth_resolution.set()
+            await hook_task
+        finally:
+            release_auth_resolution.set()
+            await cancel_pending_task(hook_task)
+
+        if hook_phase == "requestheaders":
+            assert flow.response is None
+            assert flow.error is None
+            restored_metadata = {
+                key: value
+                for key, value in flow.metadata.items()
+                if key not in connector_intent.REQUEST_HEADERS_PROBE_METADATA_KEYS
+            }
+            assert restored_metadata == original_metadata
+            assert connector_intent.from_flow(flow) == connector_intent.ABSENT
+            assert flow.request.headers.fields == original_headers
+            assert flow.request.path == original_path
+            assert mitm_addon._FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS not in flow.metadata
+            _assert_no_request_stream(flow)
+
+            await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.request.headers.fields == original_headers
+    assert flow.request.path == original_path
+    assert flow.request.headers.get("Authorization") is None
+    _assert_current_denial(flow, registry_mutation)
+
+
+@pytest.mark.parametrize("hook_phase", ["request", "requestheaders"])
+async def test_unrelated_same_run_policy_change_keeps_equivalent_authorization(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+    monkeypatch,
+    hook_phase: HookPhase,
+):
+    registry_path = _write_registry(
+        tmp_path,
+        client_ip=_CLIENT_IP,
+        vm_info=_registry_vm(tmp_path),
+    )
+    flow, tls_data = _firewall_flow(real_flow, make_tls_data)
+    auth_resolution_entered = asyncio.Event()
+    release_auth_resolution = asyncio.Event()
+
+    async def resolve_auth(*_args, **_kwargs):
+        auth_resolution_entered.set()
+        await release_auth_resolution.wait()
+        return _resolved_firewall_auth()
+
+    auth_fetch = AsyncMock(side_effect=resolve_auth)
+    monkeypatch.setattr(auth, "get_firewall_headers", auth_fetch)
+
+    hook_task: asyncio.Task[None] | None = None
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        if hook_phase == "request":
+            hook_task = asyncio.create_task(mitm_addon.request(flow))
+        else:
+            hook_task = asyncio.create_task(
+                await_requestheaders_result(mitm_addon.requestheaders(flow))
+            )
+        try:
+            await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
+            _publish_registry(
+                registry_path,
+                vm_info=_registry_vm(tmp_path, allow_unrelated_orgs=True),
+            )
+            release_auth_resolution.set()
+            await hook_task
+        finally:
+            release_auth_resolution.set()
+            await cancel_pending_task(hook_task)
+
+        if hook_phase == "requestheaders":
+            await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == _RESOLVED_AUTHORIZATION
+    assert flow.request.query["managed"] == "resolved-for-old-authorization"
+    assert flow.metadata[metadata_keys.VM_RUN_ID] == _ORIGINAL_RUN_ID
+
+
+async def test_different_same_run_allow_decision_fails_closed_without_old_credentials(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+    monkeypatch,
+):
+    registry_path = _write_registry(
+        tmp_path,
+        client_ip=_CLIENT_IP,
+        vm_info=_switchable_permission_vm(tmp_path, allowed_permission="repos-primary"),
+    )
+    flow, tls_data = _firewall_flow(real_flow, make_tls_data)
+    original_headers = flow.request.headers.fields
+    original_path = flow.request.path
+    auth_resolution_entered = asyncio.Event()
+    release_auth_resolution = asyncio.Event()
+
+    async def resolve_auth(*_args, **_kwargs):
+        auth_resolution_entered.set()
+        await release_auth_resolution.wait()
+        return _resolved_firewall_auth()
+
+    auth_fetch = AsyncMock(side_effect=resolve_auth)
+    monkeypatch.setattr(auth, "get_firewall_headers", auth_fetch)
+
+    request_task: asyncio.Task[None] | None = None
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        request_task = asyncio.create_task(mitm_addon.request(flow))
+        try:
+            await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
+            _publish_registry(
+                registry_path,
+                vm_info=_switchable_permission_vm(
+                    tmp_path,
+                    allowed_permission="repos-secondary",
+                ),
+            )
+            release_auth_resolution.set()
+            await request_task
+        finally:
+            release_auth_resolution.set()
+            await cancel_pending_task(request_task)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.request.headers.fields == original_headers
+    assert flow.request.path == original_path
+    assert flow.response is not None
+    assert flow.response.status_code == 409
+    assert flow.response.content is not None
+    assert json.loads(flow.response.content) == {
+        "error": "firewall_authorization_changed",
+        "message": (
+            "Request blocked: firewall authorization changed while credentials were resolving"
+        ),
+    }
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "firewall_authorization_changed"
+    assert flow.metadata.get(metadata_keys.FIREWALL_AUTH_CACHE_KEY) is None
+    assert "_usage_flow_tracked" not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
@@ -24,6 +24,7 @@ type HookPhase = Literal["request", "requestheaders"]
 type RegistryMutation = Literal["remove", "replace_run", "revoke_permission"]
 
 _CLIENT_IP = "10.200.0.5"
+_FIREWALL_NAME = "model-provider:test"
 _ORIGINAL_RUN_ID = "run-before-auth-wait"
 _RESOLVED_AUTHORIZATION = "Bearer resolved-for-old-authorization"
 
@@ -44,6 +45,7 @@ def _registry_vm(
     return _single_firewall_vm(
         tmp_path,
         run_id=run_id,
+        firewall_name=_FIREWALL_NAME,
         api_entry={
             "base": "https://api.github.com",
             "auth": {
@@ -61,8 +63,8 @@ def _registry_vm(
             "ask": [],
             "unknownPolicy": "deny",
         },
-        billable_firewalls=["github"],
-        vm_fields={"captureNetworkBodies": True},
+        billable_firewalls=[_FIREWALL_NAME],
+        vm_fields={"captureNetworkBodies": True, "modelUsageProvider": "test"},
     )
 
 
@@ -78,6 +80,7 @@ def _switchable_permission_vm(
     return _single_firewall_vm(
         tmp_path,
         run_id=_ORIGINAL_RUN_ID,
+        firewall_name=_FIREWALL_NAME,
         api_entry={
             "base": "https://api.github.com",
             "auth": {
@@ -94,8 +97,8 @@ def _switchable_permission_vm(
             "ask": [],
             "unknownPolicy": "deny",
         },
-        billable_firewalls=["github"],
-        vm_fields={"captureNetworkBodies": True},
+        billable_firewalls=[_FIREWALL_NAME],
+        vm_fields={"captureNetworkBodies": True, "modelUsageProvider": "test"},
     )
 
 
@@ -271,7 +274,12 @@ async def test_registry_change_during_auth_blocks_old_authorization(
             await mitm_addon.request(flow)
 
     auth_fetch.assert_awaited_once()
-    assert flow.request.headers.fields == original_headers
+    if hook_phase == "requestheaders":
+        assert flow.request.headers.fields == original_headers
+    else:
+        assert flow.request.headers.get("Host") == "api.github.com"
+        assert flow.request.headers.get("Content-Length") == str(STREAM_BUFFER_LIMIT + 1)
+        assert flow.request.headers.get("Accept-Encoding") == "identity"
     assert flow.request.path == original_path
     assert flow.request.headers.get("Authorization") is None
     _assert_current_denial(flow, registry_mutation)
@@ -347,7 +355,6 @@ async def test_different_same_run_allow_decision_fails_closed_without_old_creden
         vm_info=_switchable_permission_vm(tmp_path, allowed_permission="repos-primary"),
     )
     flow, tls_data = _firewall_flow(real_flow, make_tls_data)
-    original_headers = flow.request.headers.fields
     original_path = flow.request.path
     auth_resolution_entered = asyncio.Event()
     release_auth_resolution = asyncio.Event()
@@ -380,7 +387,9 @@ async def test_different_same_run_allow_decision_fails_closed_without_old_creden
             await cancel_pending_task(request_task)
 
     auth_fetch.assert_awaited_once()
-    assert flow.request.headers.fields == original_headers
+    assert flow.request.headers.get("Host") == "api.github.com"
+    assert flow.request.headers.get("Content-Length") == str(STREAM_BUFFER_LIMIT + 1)
+    assert flow.request.headers.get("Accept-Encoding") == "identity"
     assert flow.request.path == original_path
     assert flow.response is not None
     assert flow.response.status_code == 409

--- a/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
@@ -823,7 +823,9 @@ async def test_firewall_allow_small_bounded_body_retargets_unconnected_upstream(
 
         await mitm_addon.request(flow)
 
-    assert validated_flows == [flow, flow]
+    # Header prebinding, request dispatch, and the post-auth authorization guard
+    # each validate the current trusted authority before credential mutation.
+    assert validated_flows == [flow, flow, flow]
     auth_fetch.assert_awaited_once()
     assert flow.response is None
     assert flow.request.headers["Authorization"] == "Bearer resolved"

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -125,6 +125,7 @@ suites before committing the upgrade.
 | `test_request_handler_registry_admission.py`            | Request-hook proxy-registry availability and VM entry admission                                                      |
 | `test_request_handler_firewall_dispatch.py`             | Core firewall dispatch, permission blocks, malformed config/policy handling, block responses, and unsafe-path blocks |
 | `test_request_handler_firewall_auth.py`                 | Request-hook firewall auth identity, credential guards, upstream-binding lifetime, and cancellation                  |
+| `test_request_handler_firewall_auth_revalidation.py`    | Registry authorization revalidation across request and requestheaders firewall-auth waits                            |
 | `test_request_handler_public_destination.py`            | Request-hook public destination validation and revalidation                                                          |
 | `test_request_handler_connector_diagnostics.py`         | Request-hook connector diagnostics and inactive built-in connector diagnostics                                       |
 | `test_request_handler_auth_base_body.py`                | Request-hook auth-base body admission and cleanup                                                                    |


### PR DESCRIPTION
## Summary

- reclassify credential-bearing firewall requests from the current proxy registry after asynchronous auth resolution
- require the same run and equivalent firewall allow decision before applying resolved header, query, or SigV4 credentials
- preserve response-free `requestheaders()` fallback while returning canonical current denials from `request()`
- cover registry removal, run reassignment, same-run permission changes, and unrelated-policy updates through both public hooks

## Scope

- no runner protocol, proxy-registry schema, persisted state, API, or migration changes
- the separate cached-classification boundary between `requestheaders()` and `request()` is already addressed on main by #24966

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- focused post-rebase integration suite (186 passed)
- `uv run --no-sync python -m pytest tests/` (4,724 passed)

Closes #24925
