### PR TITLE
test(guest-agent): revalidate cached mocks per cargo session

### DIFF
--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -21,8 +21,8 @@ mod system_log;
 
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use serde_json::{Value, json};
-use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::future::Future;
 use std::io;
 use std::os::fd::{AsFd, AsRawFd, OwnedFd};
@@ -597,8 +597,8 @@ pub fn ensure_canonical_workspace_for_test() -> Result<(), String> {
     Ok(())
 }
 
-/// Build the mock binary (idempotent when up to date) and resolve its
-/// filesystem path.
+/// Build the mock binary once per verified Cargo test invocation and resolve
+/// its filesystem path.
 ///
 /// The subprocess `cargo build` must land the artifact in the same
 /// `target/` directory + profile that the enclosing `cargo test` uses,
@@ -626,6 +626,28 @@ fn build_and_locate_mock_package(package: &str, binary: &str) -> Result<PathBuf,
         .parent()
         .and_then(|p| p.parent())
         .ok_or_else(|| "target/<profile> dir".to_string())?;
+    let workspace_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .ok_or_else(|| "guest-agent workspace directory".to_string())?;
+
+    let build_session = cargo_build_session_id();
+    build_and_locate_mock_package_in_workspace(
+        workspace_dir,
+        target_profile_dir,
+        package,
+        binary,
+        build_session.as_deref(),
+    )
+}
+
+/// Build a mock package in an explicit workspace and cache it for one Cargo build session.
+pub fn build_and_locate_mock_package_in_workspace(
+    workspace_dir: &Path,
+    target_profile_dir: &Path,
+    package: &str,
+    binary: &str,
+    build_session: Option<&str>,
+) -> Result<PathBuf, String> {
     let target_dir = target_profile_dir
         .parent()
         .ok_or_else(|| "target dir".to_string())?;
@@ -633,25 +655,34 @@ fn build_and_locate_mock_package(package: &str, binary: &str) -> Result<PathBuf,
         .file_name()
         .and_then(|n| n.to_str())
         .ok_or_else(|| "profile dir name".to_string())?;
-
     let mock = target_profile_dir.join(binary);
-    let workspace_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .ok_or_else(|| "guest-agent workspace directory".to_string())?;
-    let package_dir = workspace_dir.join(package);
-    let fingerprint = mock_fingerprint(&package_dir, profile_dir_name)?;
-    let marker = target_dir.join(format!(".vm0-{package}-{profile_dir_name}.fingerprint"));
+    let marker = target_dir.join(format!(".vm0-{package}-{profile_dir_name}.build-session"));
     let lock = target_dir.join(format!(".vm0-{package}-{profile_dir_name}.lock"));
     let _lock = acquire_mock_build_lock(&lock)?;
 
-    if mock.exists() && std::fs::read_to_string(&marker).ok().as_deref() == Some(&fingerprint) {
+    if mock.exists()
+        && build_session.is_some()
+        && std::fs::read_to_string(&marker).ok().as_deref() == build_session
+    {
         return Ok(mock);
+    }
+
+    match std::fs::remove_file(&marker) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(format!(
+                "remove mock build session {}: {error}",
+                marker.display()
+            ));
+        }
     }
 
     let mut cmd = std::process::Command::new("cargo");
     cmd.args(["build", "-p", package, "--quiet"])
         .arg("--target-dir")
-        .arg(target_dir);
+        .arg(target_dir)
+        .current_dir(workspace_dir);
     // Cargo profile → output dir mapping:
     //   --release            → target_dir/release
     //   --profile <name>     → target_dir/<name>
@@ -676,7 +707,10 @@ fn build_and_locate_mock_package(package: &str, binary: &str) -> Result<PathBuf,
     if !mock.exists() {
         return Err(format!("mock binary not found at {}", mock.display()));
     }
-    std::fs::write(&marker, fingerprint).map_err(|e| format!("write mock fingerprint: {e}"))?;
+    if let Some(build_session) = build_session {
+        std::fs::write(&marker, build_session)
+            .map_err(|e| format!("write mock build session: {e}"))?;
+    }
     Ok(mock)
 }
 
@@ -693,39 +727,35 @@ pub fn acquire_mock_build_lock(lock: &Path) -> Result<std::fs::File, String> {
     Ok(file)
 }
 
-fn mock_fingerprint(package_dir: &Path, profile: &str) -> Result<String, String> {
-    let mut files = Vec::new();
-    collect_files(package_dir, &mut files)?;
-    files.sort();
-    let mut hasher = Sha256::new();
-    hasher.update(profile.as_bytes());
-    for path in files {
-        hasher.update(
-            path.strip_prefix(package_dir)
-                .unwrap_or(&path)
-                .to_string_lossy()
-                .as_bytes(),
-        );
-        hasher.update(std::fs::read(&path).map_err(|e| format!("read mock source: {e}"))?);
+/// Resolve a reusable session only for tests launched directly by Cargo on Linux.
+fn cargo_build_session_id() -> Option<String> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    let parent_pid = status
+        .lines()
+        .find_map(|line| line.strip_prefix("PPid:"))?
+        .trim()
+        .parse::<u32>()
+        .ok()?;
+    let parent_exe = std::fs::read_link(format!("/proc/{parent_pid}/exe")).ok()?;
+    if parent_exe.file_name()? != OsStr::new("cargo") {
+        return None;
     }
-    Ok(hex::encode(hasher.finalize()))
-}
 
-fn collect_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<(), String> {
-    for entry in std::fs::read_dir(dir).map_err(|e| format!("read mock package: {e}"))? {
-        let path = entry
-            .map_err(|e| format!("read mock package entry: {e}"))?
-            .path();
-        if path.file_name().is_some_and(|name| name == "target") {
-            continue;
-        }
-        if path.is_dir() {
-            collect_files(&path, files)?;
-        } else {
-            files.push(path);
-        }
+    let parent_stat = std::fs::read_to_string(format!("/proc/{parent_pid}/stat")).ok()?;
+    let fields_after_command = parent_stat.get(parent_stat.rfind(')')? + 1..)?;
+    // `starttime` is field 22, or field 20 after the PID and parenthesized command.
+    let parent_start_time = fields_after_command
+        .split_whitespace()
+        .nth(19)?
+        .parse::<u64>()
+        .ok()?;
+    let boot_id = std::fs::read_to_string("/proc/sys/kernel/random/boot_id").ok()?;
+    let boot_id = boot_id.trim();
+    if boot_id.is_empty() {
+        return None;
     }
-    Ok(())
+
+    Some(format!("{boot_id}:{parent_pid}:{parent_start_time}"))
 }
 
 /// Test-specific values for the experimental Codex app-server backend env.

--- a/crates/guest-agent/tests/mock_build_session.rs
+++ b/crates/guest-agent/tests/mock_build_session.rs
@@ -1,0 +1,171 @@
+//! Integration coverage for Cargo-session-scoped guest mock reuse.
+
+mod common;
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const WORKSPACE_WITH_CONTRACT_ONE: &str = r#"
+[workspace]
+resolver = "3"
+members = ["mock", "contract-one", "contract-two"]
+
+[workspace.dependencies]
+contract = { package = "contract-one", path = "contract-one" }
+"#;
+
+const WORKSPACE_WITH_CONTRACT_TWO: &str = r#"
+[workspace]
+resolver = "3"
+members = ["mock", "contract-one", "contract-two"]
+
+[workspace.dependencies]
+contract = { package = "contract-two", path = "contract-two" }
+"#;
+
+const MOCK_MANIFEST: &str = r#"
+[package]
+name = "mock-package"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+contract.workspace = true
+"#;
+
+const MOCK_SOURCE: &str = r#"
+fn main() {
+    println!("{}", contract::value());
+}
+"#;
+
+const CONTRACT_ONE_MANIFEST: &str = r#"
+[package]
+name = "contract-one"
+version = "0.1.0"
+edition = "2024"
+"#;
+
+const CONTRACT_TWO_MANIFEST: &str = r#"
+[package]
+name = "contract-two"
+version = "0.1.0"
+edition = "2024"
+"#;
+
+#[test]
+fn mock_build_session_revalidates_dependency_inputs() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path();
+    let mock_dir = workspace.join("mock");
+    let contract_one_dir = workspace.join("contract-one");
+    let contract_two_dir = workspace.join("contract-two");
+    fs::create_dir_all(mock_dir.join("src"))?;
+    fs::create_dir_all(contract_one_dir.join("src"))?;
+    fs::create_dir_all(contract_two_dir.join("src"))?;
+
+    let workspace_manifest = workspace.join("Cargo.toml");
+    let mock_manifest = mock_dir.join("Cargo.toml");
+    let mock_source = mock_dir.join("src/main.rs");
+    fs::write(&workspace_manifest, WORKSPACE_WITH_CONTRACT_ONE)?;
+    fs::write(&mock_manifest, MOCK_MANIFEST)?;
+    fs::write(&mock_source, MOCK_SOURCE)?;
+    fs::write(contract_one_dir.join("Cargo.toml"), CONTRACT_ONE_MANIFEST)?;
+    fs::write(
+        contract_one_dir.join("src/lib.rs"),
+        "pub fn value() -> &'static str { \"one\" }\n",
+    )?;
+    fs::write(contract_two_dir.join("Cargo.toml"), CONTRACT_TWO_MANIFEST)?;
+    fs::write(
+        contract_two_dir.join("src/lib.rs"),
+        "pub fn value() -> &'static str { \"two\" }\n",
+    )?;
+
+    let original_mock_manifest = fs::read(&mock_manifest)?;
+    let original_mock_source = fs::read(&mock_source)?;
+    let target_profile_dir = workspace.join("target/debug");
+    fs::create_dir(workspace.join("target"))?;
+
+    let mock = build_mock(workspace, &target_profile_dir, Some("session-one"))?;
+    assert_eq!(run_mock(&mock)?, "one");
+    let session_marker = workspace.join("target/.vm0-mock-package-debug.build-session");
+    assert_eq!(fs::read_to_string(&session_marker)?, "session-one");
+
+    // Hide the manifest so any unexpected second Cargo invocation fails.
+    let hidden_workspace_manifest = workspace.join("Cargo.toml.hidden");
+    fs::rename(&workspace_manifest, &hidden_workspace_manifest)?;
+    let reuse_result = build_mock(workspace, &target_profile_dir, Some("session-one"));
+    fs::rename(&hidden_workspace_manifest, &workspace_manifest)?;
+    let reused = reuse_result?;
+    assert_eq!(reused, mock);
+
+    fs::write(
+        contract_one_dir.join("src/lib.rs"),
+        "pub fn value() -> &'static str { \"one-updated\" }\n",
+    )?;
+    let rebuilt = build_mock(workspace, &target_profile_dir, Some("session-two"))?;
+    assert_eq!(run_mock(&rebuilt)?, "one-updated");
+
+    fs::write(&workspace_manifest, WORKSPACE_WITH_CONTRACT_TWO)?;
+    let remapped = build_mock(workspace, &target_profile_dir, Some("session-three"))?;
+    assert_eq!(run_mock(&remapped)?, "two");
+
+    let lock_path = workspace.join("Cargo.lock");
+    let valid_lock = fs::read_to_string(&lock_path)?;
+    let valid_contract = "name = \"contract-two\"\nversion = \"0.1.0\"";
+    let invalid_contract = "name = \"contract-two\"\nversion = \"9.9.9\"";
+    let invalid_lock = valid_lock.replacen(valid_contract, invalid_contract, 1);
+    assert_ne!(
+        invalid_lock, valid_lock,
+        "lockfile fixture should be changed"
+    );
+    fs::write(&lock_path, invalid_lock)?;
+    let lock_revalidated = build_mock(workspace, &target_profile_dir, Some("session-four"))?;
+    assert_eq!(run_mock(&lock_revalidated)?, "two");
+    let repaired_lock = fs::read_to_string(&lock_path)?;
+    assert!(repaired_lock.contains(valid_contract));
+    assert!(!repaired_lock.contains(invalid_contract));
+
+    fs::write(
+        contract_two_dir.join("src/lib.rs"),
+        "pub fn value() -> &'static str { \"two-updated\" }\n",
+    )?;
+    let uncached = build_mock(workspace, &target_profile_dir, None)?;
+    assert_eq!(run_mock(&uncached)?, "two-updated");
+    assert!(!session_marker.exists());
+
+    assert_eq!(fs::read(&mock_manifest)?, original_mock_manifest);
+    assert_eq!(fs::read(&mock_source)?, original_mock_source);
+    Ok(())
+}
+
+fn build_mock(
+    workspace: &Path,
+    target_profile_dir: &Path,
+    build_session: Option<&str>,
+) -> io::Result<PathBuf> {
+    common::build_and_locate_mock_package_in_workspace(
+        workspace,
+        target_profile_dir,
+        "mock-package",
+        "mock-package",
+        build_session,
+    )
+    .map_err(io::Error::other)
+}
+
+fn run_mock(mock: &Path) -> io::Result<String> {
+    let output = Command::new(mock).output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "mock exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    String::from_utf8(output.stdout)
+        .map(|stdout| stdout.trim().to_owned())
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}


### PR DESCRIPTION
## Summary

- scope guest mock artifact reuse to one verified parent Cargo invocation
- let the first mock request in each new Cargo invocation run Cargo's complete freshness check while retaining the existing per-package lock
- add an integration test with a real temporary workspace covering dependency source, workspace mapping, lockfile, same-session reuse, and unverified-launcher behavior

## Scope

- test infrastructure only
- no production runtime, API, schema, protocol, workflow, or documentation changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent --all-targets --all-features`
- `cargo test -p guest-agent --test mock_build_session`
- verified one nested guest mock build is shared across two integration-test binaries in one Cargo invocation

Closes #24910
