### PR TITLE
feat(chat): prioritize goal continuation over automation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -16,6 +16,8 @@ import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { mockNow, now, withNowScopeForTest } from "../../../lib/time";
 import {
   createActiveGoalQueueEventFixture,
+  drainChatThreadQueueFixture,
+  pauseGoalQueueTargetFixture,
   readGoalQueueStateFixture,
 } from "../../../test-fixtures/goal-queue";
 import { admitWorkflowAutomationEventFixture } from "../../../test-fixtures/workflow-queue";
@@ -384,7 +386,7 @@ async function expectSweepLeftQueueUntouched(
 }
 
 describe("workflow queue", () => {
-  it("runs a pending workflow event before an older goal continuation on the same thread", async () => {
+  it("keeps a user prompt ahead of a pending goal continuation", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
     const goal = await createActiveGoalQueueEventFixture({
@@ -392,17 +394,144 @@ describe("workflow queue", () => {
       orgId: scenario.orgId,
       userId: scenario.userId,
       agentId: scenario.agentId,
-      objective: "finish after the workflow event",
-      objectiveBrief: "Finish after the workflow event",
+      objective: "continue after the user prompt",
+      objectiveBrief: "Continue after the user prompt",
     });
 
-    const workflowRunId = await expectAcceptedRunId(
-      await postWorkflowWebhook(automation, "workflow wins queue priority"),
-      automation.threadId,
+    const user = await accept(
+      chatEventsClient().send({
+        headers: authHeaders(),
+        body: {
+          agentId: scenario.agentId,
+          threadId: automation.threadId,
+          prompt: "user prompt wins queue priority",
+          userMessage: {
+            version: 1,
+            parts: [{ type: "text", text: "user prompt wins queue priority" }],
+          },
+        },
+      }),
+      [201],
     );
+    if (!user.body.runId) {
+      throw new Error("Expected the user prompt to create a run");
+    }
     const goalQueue = await readGoalQueueStateFixture(automation.threadId);
     expect(goalQueue.runIds).toHaveLength(0);
     expect(goalQueue.eventIds).toContain(goal.eventId);
+
+    await runsApi.requestCancelRun(scenario.actor, user.body.runId, [200]);
+  });
+
+  it("runs a pending goal continuation before a newer workflow event on the same thread", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const goal = await createActiveGoalQueueEventFixture({
+      threadId: automation.threadId,
+      orgId: scenario.orgId,
+      userId: scenario.userId,
+      agentId: scenario.agentId,
+      objective: "finish before the workflow event",
+      objectiveBrief: "Finish before the workflow event",
+    });
+
+    expectAcceptedWithoutRun(
+      await postWorkflowWebhook(automation, "goal wins queue priority"),
+    );
+    const goalQueue = await readGoalQueueStateFixture(automation.threadId);
+    expect(goalQueue.runIds).toHaveLength(1);
+    expect(goalQueue.eventIds).toContain(goal.eventId);
+    await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(0);
+    await expect(
+      pendingWorkflowEvents(automation.threadId),
+    ).resolves.toHaveLength(1);
+
+    const [goalRunId] = goalQueue.runIds;
+    if (!goalRunId) {
+      throw new Error("Expected the goal continuation to create a run");
+    }
+    await runsApi.requestCancelRun(scenario.actor, goalRunId, [200]);
+  });
+
+  it("lets a goal continuation preempt a workflow event during final queue claim", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: scenario.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+
+    const workflowRequest = postWorkflowWebhook(
+      automation,
+      "workflow launch before goal admission",
+    );
+    await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
+
+    const goal = await createActiveGoalQueueEventFixture({
+      threadId: automation.threadId,
+      orgId: scenario.orgId,
+      userId: scenario.userId,
+      agentId: scenario.agentId,
+      objective: "preempt the preparing workflow event",
+      objectiveBrief: "Preempt the preparing workflow event",
+    });
+    const goalDrain = drainChatThreadQueueFixture({
+      threadId: automation.threadId,
+      signal: context.signal,
+    });
+    await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(2);
+
+    admissionLock.release();
+    const [workflowResult] = await Promise.all([workflowRequest, goalDrain]);
+    await admissionLock.done;
+    expectAcceptedWithoutRun(workflowResult);
+
+    const goalQueue = await readGoalQueueStateFixture(automation.threadId);
+    expect(goalQueue.runIds).toHaveLength(1);
+    expect(goalQueue.eventIds).toContain(goal.eventId);
+    await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(0);
+    await expect(
+      pendingWorkflowEvents(automation.threadId),
+    ).resolves.toHaveLength(1);
+
+    const [goalRunId] = goalQueue.runIds;
+    if (!goalRunId) {
+      throw new Error("Expected the preempting goal to create a run");
+    }
+    await runsApi.requestCancelRun(scenario.actor, goalRunId, [200]);
+  });
+
+  it("continues to workflow automation after rejecting a higher-priority invalid goal", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const goal = await createActiveGoalQueueEventFixture({
+      threadId: automation.threadId,
+      orgId: scenario.orgId,
+      userId: scenario.userId,
+      agentId: scenario.agentId,
+      objective: "become invalid before the queue drains",
+      objectiveBrief: "Become invalid before the queue drains",
+    });
+    await pauseGoalQueueTargetFixture(goal.goalId);
+
+    const workflowRunId = await expectAcceptedRunId(
+      await postWorkflowWebhook(automation, "run after invalid goal"),
+      automation.threadId,
+    );
+    const events = await wf.readThreadEvents(automation.threadId);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        eventType: "input.rejected",
+        revokesEventId: goal.eventId,
+        error: "Goal continuation no longer matches the active goal",
+      }),
+    );
+    const goalQueue = await readGoalQueueStateFixture(automation.threadId);
+    expect(goalQueue.runIds).toHaveLength(0);
 
     await runsApi.requestCancelRun(scenario.actor, workflowRunId, [200]);
   });

--- a/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
@@ -47,18 +47,18 @@ export function pendingChatQueueEventCondition(db: ChatQueueReadDb) {
 export function chatQueueEventPriority(): SQL {
   return sql`CASE ${chatEvents.eventType}
     WHEN 'input.prompt' THEN 0
-    WHEN 'input.automation' THEN 1
-    WHEN 'input.goal' THEN 2
+    WHEN 'input.goal' THEN 1
+    WHEN 'input.automation' THEN 2
     ELSE 3
   END`;
 }
 
 /**
  * List one thread's pending queue in its authoritative database order. User
- * input keeps absolute priority over automation input, automation stays ahead
- * of goal continuation, then each class is FIFO by the original event
- * timestamp and id. Keep the sort in PostgreSQL so sub-millisecond timestamp
- * precision matches the final queue-claim queries.
+ * input keeps absolute priority over goal continuation; goal continuation stays
+ * ahead of automation input. Each class is FIFO by the original event timestamp
+ * and id. Keep the sort in PostgreSQL so sub-millisecond timestamp precision
+ * matches the final queue-claim queries.
  */
 export async function listPendingChatQueueEvents(
   db: ChatQueueReadDb,

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -54,7 +54,7 @@ interface DrainChatThreadQueueInput {
 /**
  * The single per-thread scheduler entry: terminal run callbacks, cancel,
  * resume, and the stale sweep all converge here. User messages are attempted
- * first; workflow automation remains second and goal continuation third. Each
+ * first; goal continuation remains second and workflow automation third. Each
  * later drain observes a newly-created active run and stops. The final claims
  * serialize on the same thread row and fold pending events by class priority,
  * then original `created_at` and id.
@@ -80,6 +80,17 @@ export const drainChatThreadQueueForThread$ = command(
       signal,
     );
     signal.throwIfAborted();
+    await set(
+      drainGoalQueueForThread$,
+      {
+        chatThreadId: input.chatThreadId,
+        apiStartTime,
+        dispatchFailedCallbacks: input.dispatchFailedCallbacks,
+        queueItemCreatedBefore: input.queueItemCreatedBefore,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
     const workflowResult = await set(
       drainWorkflowQueueForThread$,
       {
@@ -94,20 +105,7 @@ export const drainChatThreadQueueForThread$ = command(
       signal,
     );
     signal.throwIfAborted();
-    if (workflowResult) {
-      return workflowResult;
-    }
-    await set(
-      drainGoalQueueForThread$,
-      {
-        chatThreadId: input.chatThreadId,
-        apiStartTime,
-        dispatchFailedCallbacks: input.dispatchFailedCallbacks,
-        queueItemCreatedBefore: input.queueItemCreatedBefore,
-      },
-      signal,
-    );
-    return null;
+    return workflowResult;
   },
 );
 

--- a/turbo/apps/api/src/test-fixtures/goal-queue.ts
+++ b/turbo/apps/api/src/test-fixtures/goal-queue.ts
@@ -1,13 +1,16 @@
 import { chatEvents } from "@vm0/db/schema/chat-event";
 import { threadGoals } from "@vm0/db/schema/thread-goal";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { createStore } from "ccstate";
 import { and, eq, isNotNull } from "drizzle-orm";
 
 import { db } from "../lib/db";
+import { dispatchFailedRunCallbacks } from "../signals/services/agent-run-callback.service";
 import {
   admitGoalQueueEvent,
   type GoalQueueAdmission,
 } from "../signals/services/chat-goal-queue.service";
+import { drainChatThreadQueueForThread$ } from "../signals/services/chat-thread-queue-drain.service";
 
 interface GoalQueueAdmissionFixtureArgs {
   readonly threadId: string;
@@ -60,6 +63,35 @@ export async function readGoalQueueStateFixture(threadId: string): Promise<{
       return run.id;
     }),
   };
+}
+
+/** Run the same shared scheduler that follows production goal admission. */
+export async function drainChatThreadQueueFixture(args: {
+  readonly threadId: string;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  await createStore().set(
+    drainChatThreadQueueForThread$,
+    {
+      chatThreadId: args.threadId,
+      dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+    },
+    args.signal,
+  );
+}
+
+/** Invalidate a goal without triggering a separate queue drain. */
+export async function pauseGoalQueueTargetFixture(
+  goalId: string,
+): Promise<void> {
+  const [goal] = await db()
+    .update(threadGoals)
+    .set({ status: "paused" })
+    .where(eq(threadGoals.id, goalId))
+    .returning({ id: threadGoals.id });
+  if (!goal) {
+    throw new Error("Expected the goal queue target fixture");
+  }
 }
 
 /**

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-events.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-events.test.ts
@@ -502,7 +502,7 @@ describe("ChatEvent folds", () => {
     );
   });
 
-  it("folds pending queue events by user priority, original time, and revoke state", () => {
+  it("folds pending queue events by class priority, original time, and revoke state", () => {
     const revoked = revokedChatEventIds(queueFoldFixture);
     expect(isPendingChatQueueEvent(queueFoldFixture[1], revoked)).toBe(true);
     expect(isPendingChatQueueEvent(queueFoldFixture[3], revoked)).toBe(false);
@@ -510,7 +510,7 @@ describe("ChatEvent folds", () => {
       foldPendingChatQueueEvents(queueFoldFixture).map((event) => {
         return event.id;
       }),
-    ).toStrictEqual(["prompt-newer", "automation-oldest", "goal-oldest"]);
+    ).toStrictEqual(["prompt-newer", "goal-oldest", "automation-oldest"]);
   });
 
   it("returns every pending queue event as runnable", () => {
@@ -518,7 +518,7 @@ describe("ChatEvent folds", () => {
       foldRunnableChatQueueEvents(queueFoldFixture).map((event) => {
         return event.id;
       }),
-    ).toStrictEqual(["prompt-newer", "automation-oldest", "goal-oldest"]);
+    ).toStrictEqual(["prompt-newer", "goal-oldest", "automation-oldest"]);
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/chat-events.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-events.ts
@@ -264,7 +264,7 @@ function compareChatQueueEvents(
     if (eventType === "input.prompt") {
       return 0;
     }
-    if (eventType === "input.automation") {
+    if (eventType === "input.goal") {
       return 1;
     }
     return 2;


### PR DESCRIPTION
## Summary

- change the authoritative chat queue priority to `prompt > goal > automation` while preserving FIFO ordering within each class
- drain goal continuation before workflow automation so an invalid goal can be rejected and the same scheduler pass can continue to automation
- align the API contract fold and add regression coverage for prompt precedence, static goal priority, final-claim preemption, and invalid-goal fallthrough

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (API lint rerun with a 3 GiB Node heap after the first local process exhausted its default heap)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/api-contracts exec vitest run src/contracts/__tests__/chat-events.test.ts`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts --maxWorkers=1 -t 'keeps a user prompt|runs a pending goal continuation|lets a goal continuation|continues to workflow automation'`

No database schema or migration changes are required.

Closes #24958
