### PR TITLE
test(ably-subscriber): bound reconnect state waits

### DIFF
--- a/crates/ably-subscriber/tests/integration/heartbeat_timeouts.rs
+++ b/crates/ably-subscriber/tests/integration/heartbeat_timeouts.rs
@@ -294,13 +294,11 @@ async fn reconnect_timeout_retries_until_suspended() {
 
         // For reconnect attempts: accept TCP but never complete WebSocket
         // handshake — forces reconnect_timeout to fire (not "connection refused").
-        let Ok((mut held_connection, _)) = ws.listener.accept().await else {
-            return;
-        };
-        while let Ok((tcp, _)) = ws.listener.accept().await {
-            held_connection = tcp;
+        let mut held_connection = None;
+        loop {
+            let (tcp, _) = ws.listener.accept().await.unwrap();
+            drop(held_connection.replace(tcp));
         }
-        drop(held_connection);
     });
 
     let mut timing = TimingConfig::default();

--- a/crates/ably-subscriber/tests/integration/heartbeat_timeouts.rs
+++ b/crates/ably-subscriber/tests/integration/heartbeat_timeouts.rs
@@ -4,6 +4,7 @@ use ably_subscriber::{Event, TimingConfig, subscribe};
 use futures_util::{SinkExt, StreamExt};
 use httpmock::prelude::*;
 use std::time::Duration;
+use tokio::time::Instant;
 use tokio_tungstenite::tungstenite;
 
 #[tokio::test]
@@ -276,7 +277,7 @@ async fn reconnect_timeout_retries_until_suspended() {
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
-    tokio::spawn(async move {
+    let server_task = tokio::spawn(async move {
         // First connection succeeds, then drop
         let conn = ws
             .accept_and_handshake_with_opts(
@@ -293,13 +294,9 @@ async fn reconnect_timeout_retries_until_suspended() {
 
         // For reconnect attempts: accept TCP but never complete WebSocket
         // handshake — forces reconnect_timeout to fire (not "connection refused").
+        let mut held_connections = Vec::new();
         while let Ok((tcp, _)) = ws.listener.accept().await {
-            tokio::spawn(async move {
-                let _hold = tcp;
-                // Keep the TCP connection open without completing the
-                // WebSocket handshake so reconnect_timeout fires.
-                std::future::pending::<()>().await;
-            });
+            held_connections.push(tcp);
         }
     });
 
@@ -323,20 +320,34 @@ async fn reconnect_timeout_retries_until_suspended() {
     // Each reconnect attempt hangs → reconnect_timeout fires → retry. Matching
     // ably-js, retries do not exhaust; once connection_state_ttl expires, the
     // connection enters suspended retry.
-    loop {
-        let event = expect_event(&mut sub, "suspended transition")
-            .await
-            .unwrap();
-        match event {
+    let suspended_transition = expect_event_matching_before(
+        async || sub.next().await,
+        Instant::now() + RECONNECT_EVENT_TIMEOUT,
+        "Disconnected reason containing connection state expired",
+        |event| match event {
             Event::Disconnected { reason }
                 if reason
                     .as_deref()
                     .is_some_and(|reason| reason.contains("connection state expired")) =>
             {
-                break;
+                Ok(true)
             }
-            Event::Disconnected { .. } => {}
-            other => panic!("expected Disconnected while retrying, got {other:?}"),
+            Event::Disconnected { .. } => Ok(false),
+            other => Err(format!(
+                "expected Disconnected while retrying, got {other:?}"
+            )),
+        },
+    )
+    .await;
+    sub.close();
+    let cleanup = abort_server_task(server_task, "mock server").await;
+
+    match (suspended_transition, cleanup) {
+        (Ok(_), Ok(())) => {}
+        (Ok(_), Err(cleanup_error)) => panic!("{cleanup_error}"),
+        (Err(error), Ok(())) => panic!("{error}"),
+        (Err(error), Err(cleanup_error)) => {
+            panic!("{error}; cleanup failed: {cleanup_error}")
         }
     }
 }

--- a/crates/ably-subscriber/tests/integration/heartbeat_timeouts.rs
+++ b/crates/ably-subscriber/tests/integration/heartbeat_timeouts.rs
@@ -294,10 +294,13 @@ async fn reconnect_timeout_retries_until_suspended() {
 
         // For reconnect attempts: accept TCP but never complete WebSocket
         // handshake — forces reconnect_timeout to fire (not "connection refused").
-        let mut held_connections = Vec::new();
+        let Ok((mut held_connection, _)) = ws.listener.accept().await else {
+            return;
+        };
         while let Ok((tcp, _)) = ws.listener.accept().await {
-            held_connections.push(tcp);
+            held_connection = tcp;
         }
+        drop(held_connection);
     });
 
     let mut timing = TimingConfig::default();

--- a/crates/ably-subscriber/tests/integration/reconnect.rs
+++ b/crates/ably-subscriber/tests/integration/reconnect.rs
@@ -6,6 +6,7 @@ use ably_subscriber::{Event, TimingConfig, subscribe};
 use futures_util::{SinkExt, StreamExt};
 use httpmock::prelude::*;
 use std::time::Duration;
+use tokio::time::Instant;
 use tokio_tungstenite::tungstenite;
 
 #[tokio::test]
@@ -738,7 +739,7 @@ async fn retry_enters_suspended_after_connection_state_ttl() {
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
-    tokio::spawn(async move {
+    let server_task = tokio::spawn(async move {
         // First connection: handshake then drop
         let conn = ws
             .accept_and_handshake_with_opts(
@@ -772,25 +773,30 @@ async fn retry_enters_suspended_after_connection_state_ttl() {
         matches!(event, Event::Disconnected { .. }),
         "expected Disconnected, got {event:?}"
     );
+    join_server_task(server_task, "mock server").await.unwrap();
 
     // ably-js does not exhaust reconnect attempts. Once the connection state
     // TTL expires, it moves to suspended retry and keeps trying fresh connects.
-    loop {
-        let event = expect_event(&mut sub, "suspended transition")
-            .await
-            .unwrap();
-        match event {
+    expect_event_matching_before(
+        async || sub.next().await,
+        Instant::now() + RECONNECT_EVENT_TIMEOUT,
+        "Disconnected reason containing connection state expired",
+        |event| match event {
             Event::Disconnected { reason }
                 if reason
                     .as_deref()
                     .is_some_and(|reason| reason.contains("connection state expired")) =>
             {
-                break;
+                Ok(true)
             }
-            Event::Disconnected { .. } => {}
-            other => panic!("expected Disconnected while retrying, got {other:?}"),
-        }
-    }
+            Event::Disconnected { .. } => Ok(false),
+            other => Err(format!(
+                "expected Disconnected while retrying, got {other:?}"
+            )),
+        },
+    )
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
@@ -817,19 +823,23 @@ async fn suspended_retry_reconnect_attach_uses_resume_without_serial() {
         drop(conn);
 
         let mut suspended_seen_rx = suspended_seen_rx;
-        loop {
-            tokio::select! {
-                biased;
-                result = &mut suspended_seen_rx => {
-                    result.unwrap();
-                    break;
-                }
-                accept_result = ws.listener.accept() => {
-                    let (tcp, _) = accept_result.unwrap();
-                    drop(tcp);
+        tokio::time::timeout(RECONNECT_EVENT_TIMEOUT, async {
+            loop {
+                tokio::select! {
+                    biased;
+                    result = &mut suspended_seen_rx => {
+                        result.unwrap();
+                        break;
+                    }
+                    accept_result = ws.listener.accept() => {
+                        let (tcp, _) = accept_result.unwrap();
+                        drop(tcp);
+                    }
                 }
             }
-        }
+        })
+        .await
+        .expect("timed out waiting for suspended transition signal");
 
         let mut conn2 = tokio::time::timeout(Duration::from_secs(5), async {
             loop {
@@ -901,21 +911,33 @@ async fn suspended_retry_reconnect_attach_uses_resume_without_serial() {
 
     expect_connected(&mut sub, "Connected event").await.unwrap();
 
-    loop {
-        let event = expect_event(&mut sub, "suspended retry transition")
-            .await
-            .unwrap();
-        match event {
+    let suspended_transition = expect_event_matching_before(
+        async || sub.next().await,
+        Instant::now() + RECONNECT_EVENT_TIMEOUT,
+        "Disconnected reason containing connection state expired",
+        |event| match event {
             Event::Disconnected { reason }
                 if reason
                     .as_deref()
                     .is_some_and(|reason| reason.contains("connection state expired")) =>
             {
-                suspended_seen_tx.send(()).unwrap();
-                break;
+                Ok(true)
             }
-            Event::Disconnected { .. } => {}
-            other => panic!("expected Disconnected while retrying, got {other:?}"),
+            Event::Disconnected { .. } => Ok(false),
+            other => Err(format!(
+                "expected Disconnected while retrying, got {other:?}"
+            )),
+        },
+    )
+    .await;
+    match suspended_transition {
+        Ok(_) => suspended_seen_tx.send(()).unwrap(),
+        Err(error) => {
+            sub.close();
+            if let Err(cleanup_error) = abort_server_task(server_task, "mock server").await {
+                panic!("{error}; cleanup failed: {cleanup_error}");
+            }
+            panic!("{error}");
         }
     }
 
@@ -1004,15 +1026,23 @@ async fn non_positive_ttl_keeps_default_resume_window() {
     let event = expect_event(&mut sub, "Disconnected").await.unwrap();
     assert!(matches!(event, Event::Disconnected { .. }));
 
-    loop {
-        let event = expect_event_with_timeout(&mut sub, RECONNECT_EVENT_TIMEOUT, "Connected")
-            .await
-            .unwrap();
-        match event {
-            Event::Connected => break,
-            Event::Disconnected { .. } => {}
-            other => panic!("expected Connected, got {other:?}"),
+    let connected = expect_event_matching_before(
+        async || sub.next().await,
+        Instant::now() + RECONNECT_EVENT_TIMEOUT,
+        "Connected",
+        |event| match event {
+            Event::Connected => Ok(true),
+            Event::Disconnected { .. } => Ok(false),
+            other => Err(format!("expected Connected, got {other:?}")),
+        },
+    )
+    .await;
+    if let Err(error) = connected {
+        sub.close();
+        if let Err(cleanup_error) = abort_server_task(server_task, "mock server").await {
+            panic!("{error}; cleanup failed: {cleanup_error}");
         }
+        panic!("{error}");
     }
 
     // Message after reconnect proves the subscription is still alive.

--- a/crates/ably-subscriber/tests/integration/support/events.rs
+++ b/crates/ably-subscriber/tests/integration/support/events.rs
@@ -1,9 +1,14 @@
+use std::collections::VecDeque;
+use std::ops::AsyncFnMut;
 use std::time::Duration;
 
 use ably_subscriber::{Event, Subscription};
 use tokio::task::JoinHandle;
+use tokio::time::Instant;
 
 use super::TEST_IO_TIMEOUT;
+
+const EVENT_DIAGNOSTIC_LIMIT: usize = 8;
 
 pub(crate) async fn expect_event_with_timeout(
     sub: &mut Subscription,
@@ -19,6 +24,78 @@ pub(crate) async fn expect_event_with_timeout(
 
 pub(crate) async fn expect_event(sub: &mut Subscription, context: &str) -> Result<Event, String> {
     expect_event_with_timeout(sub, TEST_IO_TIMEOUT, context).await
+}
+
+pub(crate) async fn expect_event_matching_before(
+    mut next_event: impl AsyncFnMut() -> Option<Event>,
+    deadline: Instant,
+    expected: &str,
+    mut classify: impl FnMut(&Event) -> Result<bool, String>,
+) -> Result<Event, String> {
+    let mut event_count = 0;
+    let mut recent_events = VecDeque::with_capacity(EVENT_DIAGNOSTIC_LIMIT);
+    let result = tokio::time::timeout_at(deadline, async {
+        loop {
+            let event = next_event()
+                .await
+                .ok_or_else(|| format!("subscription ended while waiting for {expected}"))?;
+            event_count += 1;
+            if recent_events.len() == EVENT_DIAGNOSTIC_LIMIT {
+                recent_events.pop_front();
+            }
+            recent_events.push_back(format!("{event:?}"));
+
+            if classify(&event)? {
+                return Ok::<Event, String>(event);
+            }
+        }
+    })
+    .await;
+
+    match result {
+        Ok(Ok(event)) => Ok(event),
+        Ok(Err(error)) => Err(format!(
+            "{error} after {event_count} event(s); recent events: {recent_events:?}"
+        )),
+        Err(_) => Err(format!(
+            "timed out waiting for {expected} after {event_count} event(s); recent events: {recent_events:?}"
+        )),
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn event_match_deadline_is_not_reset_by_nonterminal_events() {
+    let expected = "Connected";
+    let mut nonterminal_count = 0;
+    let error = expect_event_matching_before(
+        async || {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            Some(Event::Disconnected {
+                reason: Some("retrying".to_string()),
+            })
+        },
+        Instant::now() + Duration::from_secs(1),
+        expected,
+        |event| match event {
+            Event::Connected => Ok(true),
+            Event::Disconnected { .. } => {
+                nonterminal_count += 1;
+                Ok(false)
+            }
+            other => Err(format!("expected Connected, got {other:?}")),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(
+        nonterminal_count > 1,
+        "expected repeated nonterminal events, got {nonterminal_count}"
+    );
+    assert!(error.contains(&format!("timed out waiting for {expected}")));
+    assert!(error.contains(&format!("after {nonterminal_count} event(s)")));
+    assert!(error.contains("Disconnected"));
+    assert!(error.contains("retrying"));
 }
 
 pub(crate) async fn expect_connected(sub: &mut Subscription, context: &str) -> Result<(), String> {
@@ -57,6 +134,15 @@ pub(crate) async fn join_server_task(
             let _ = task.await;
             Err(format!("timed out waiting for {context} task"))
         }
+    }
+}
+
+pub(crate) async fn abort_server_task(task: JoinHandle<()>, context: &str) -> Result<(), String> {
+    task.abort();
+    match task.await {
+        Ok(()) => Ok(()),
+        Err(error) if error.is_cancelled() => Ok(()),
+        Err(error) => Err(format!("{context} task panicked: {error}")),
     }
 }
 

--- a/crates/ably-subscriber/tests/integration/support/mod.rs
+++ b/crates/ably-subscriber/tests/integration/support/mod.rs
@@ -15,8 +15,9 @@ pub(crate) use config::{
     test_config_with_timing,
 };
 pub(crate) use events::{
-    assert_value_stable_for, expect_connected, expect_event, expect_event_with_timeout,
-    expect_subscription_closed, join_server_task, wait_for_test_observation,
+    abort_server_task, assert_value_stable_for, expect_connected, expect_event,
+    expect_event_matching_before, expect_event_with_timeout, expect_subscription_closed,
+    join_server_task, wait_for_test_observation,
 };
 pub(crate) use protocol::{
     assert_attach_resume, expect_protocol_msg, now_ms, send_message,


### PR DESCRIPTION
## Summary

- add an aggregate-deadline event observer with bounded state/reason diagnostics
- bound all four Ably reconnect-state loops and the pre-suspended server accept loop
- retain, close, abort, and await owned mock-server work on scenario failure
- cover repeated nonterminal events deterministically with paused Tokio time

## Scope

This changes only the `ably-subscriber` integration-test harness. Production subscriber behavior, timing defaults, public APIs, protocols, dependencies, and deployment artifacts are unchanged.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p ably-subscriber --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber --test integration --quiet` (10 consecutive runs)
- repository pre-commit and commit-message hooks

Closes #24964
