### PR TITLE
fix(api): use active subscription billing periods

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2715,6 +2715,73 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
     });
   });
 
+  it("reads the usage allowance subscription period for a forever Custom plan", async () => {
+    const bdd = createBddApi(context);
+    const billing = createBillingMediaApi(context);
+    const actor = bdd.user();
+    const orgId = orgOf(actor);
+    const suffix = randomUUID().slice(0, 8);
+    const customerId = `cus_bdd_custom_allowance_${suffix}`;
+    const allowanceStartsAtUnix = epochSeconds(-1);
+    const allowanceEndsAtUnix = epochSeconds(29);
+    api.configureStripeBillingEnv();
+    context.mocks.stripe.subscriptions.list.mockResolvedValue({ data: [] });
+    await completeOnboardingWithoutCredits(actor);
+
+    await api.postStripeEvent(
+      stripeEvent({
+        type: "invoice.paid",
+        object: {
+          id: `in_bdd_atom_custom_forever_${suffix}`,
+          customer: customerId,
+          metadata: {
+            type: "atom_grant",
+            purpose: "atom_grant",
+            source: "atom_entitlement",
+            orgId,
+            tier: "custom",
+            duration: "forever",
+          },
+          parent: null,
+          lines: {
+            data: [
+              {
+                id: `il_bdd_atom_custom_forever_${suffix}`,
+                quantity: 1,
+                price: { id: "price_bdd_atom_grant" },
+                period: {
+                  start: epochSeconds(0),
+                  end: epochSeconds(30),
+                },
+                parent: { type: "invoice_item_details" },
+              },
+            ],
+          },
+        },
+      }),
+      [200],
+    );
+
+    await postUsageAllowanceInvoicePaid(context.signal, {
+      orgId,
+      userId: actor.userId,
+      customerId,
+      subscriptionId: `sub_bdd_custom_allowance_${suffix}`,
+      effectiveAt: new Date(allowanceStartsAtUnix * 1000),
+      expiresAt: new Date(allowanceEndsAtUnix * 1000),
+      shortWindowSeconds: 5 * 60 * 60,
+      shortWindowUnits: 625_000,
+      weeklyWindowSeconds: 7 * 86_400,
+      weeklyWindowUnits: 5_000_000,
+    });
+
+    expect((await billing.readBillingStatus(actor)).tier).toBe("custom");
+    expect((await billing.readUsageMembers(actor)).body.period).toStrictEqual({
+      start: isoOf(allowanceStartsAtUnix),
+      end: isoOf(allowanceEndsAtUnix),
+    });
+  });
+
   it("rejects lower Atom grants after a Custom grant without canceling subscriptions", async () => {
     const bdd = createBddApi(context);
     const billing = createBillingMediaApi(context);

--- a/turbo/apps/api/src/signals/services/zero-org-billing-period.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-billing-period.service.ts
@@ -1,7 +1,8 @@
 import { command } from "ccstate";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgPlanEntitlements } from "@vm0/db/schema/org-plan-entitlement";
-import { eq } from "drizzle-orm";
+import { orgUsageAllowanceEntitlements } from "@vm0/db/schema/org-usage-allowance";
+import { and, eq, gt, inArray, isNotNull, lte } from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
@@ -9,10 +10,35 @@ import { nowDate } from "../external/time";
 import { logger } from "../../lib/log";
 
 const L = logger("OrgBillingPeriod");
+const ACTIVE_USAGE_ALLOWANCE_STATUSES = [
+  "active",
+  "manual_active",
+  "trialing",
+  "past_due",
+  "unpaid",
+] as const;
 
 interface OrgBillingPeriod {
   readonly start: Date;
   readonly end: Date;
+}
+
+function resolveUsageAllowancePeriod(
+  row:
+    | {
+        readonly allowancePeriodStart: Date | null;
+        readonly allowancePeriodEnd: Date | null;
+      }
+    | undefined,
+): OrgBillingPeriod | null {
+  if (!row?.allowancePeriodStart || !row.allowancePeriodEnd) {
+    return null;
+  }
+
+  return {
+    start: row.allowancePeriodStart,
+    end: row.allowancePeriodEnd,
+  };
 }
 
 interface StoredBillingPeriod {
@@ -41,8 +67,10 @@ function resolveStoredBillingPeriod(args: {
 /**
  * Resolve an org's current billing period `{ start, end }`.
  *
- * Reads the exact period stored in `orgPlanEntitlements` first, including
- * non-monthly Custom plan grants. Falls back to
+ * Reads the exact period stored for an active usage-allowance subscription
+ * first because that subscription owns the credit-usage billing cycle across
+ * plan tiers. Falls back to `orgPlanEntitlements`, including non-monthly
+ * Custom plan grants, and then to
  * `orgMetadata.currentPeriodEnd`; if missing or expired AND a
  * `stripeSubscriptionId` exists, retrieves the Stripe subscription and writes
  * the refreshed value back to orgMetadata. This API service owns the runtime
@@ -68,9 +96,12 @@ export const getOrgBillingPeriod$ = command(
     signal: AbortSignal,
   ): Promise<OrgBillingPeriod | null> => {
     const writeDb = set(writeDb$);
+    const now = nowDate();
 
     const [orgRow] = await writeDb
       .select({
+        allowancePeriodStart: orgUsageAllowanceEntitlements.effectiveAt,
+        allowancePeriodEnd: orgUsageAllowanceEntitlements.expiresAt,
         planPeriodStart: orgPlanEntitlements.currentPeriodStart,
         planPeriodEnd: orgPlanEntitlements.currentPeriodEnd,
         currentPeriodEnd: orgMetadata.currentPeriodEnd,
@@ -81,9 +112,32 @@ export const getOrgBillingPeriod$ = command(
         orgPlanEntitlements,
         eq(orgPlanEntitlements.orgId, orgMetadata.orgId),
       )
+      .leftJoin(
+        orgUsageAllowanceEntitlements,
+        and(
+          eq(orgUsageAllowanceEntitlements.orgId, orgMetadata.orgId),
+          inArray(orgUsageAllowanceEntitlements.status, [
+            ...ACTIVE_USAGE_ALLOWANCE_STATUSES,
+          ]),
+          isNotNull(orgUsageAllowanceEntitlements.stripeSubscriptionId),
+          lte(orgUsageAllowanceEntitlements.effectiveAt, now),
+          gt(orgUsageAllowanceEntitlements.expiresAt, now),
+        ),
+      )
       .where(eq(orgMetadata.orgId, orgId))
       .limit(1);
     signal.throwIfAborted();
+
+    const allowancePeriod = resolveUsageAllowancePeriod(orgRow);
+    if (allowancePeriod) {
+      L.debug("billing period resolved", {
+        orgId,
+        source: "usage_allowance",
+        periodStart: allowancePeriod.start,
+        periodEnd: allowancePeriod.end,
+      });
+      return allowancePeriod;
+    }
 
     const storedPeriod = resolveStoredBillingPeriod({
       planStart: orgRow?.planPeriodStart ?? null,
@@ -92,7 +146,6 @@ export const getOrgBillingPeriod$ = command(
     });
     let periodStart = storedPeriod.start;
     let periodEnd = storedPeriod.end;
-    const now = nowDate();
 
     if ((!periodEnd || periodEnd < now) && orgRow?.stripeSubscriptionId) {
       if (periodEnd && periodEnd < now) {


### PR DESCRIPTION
## Summary

- prefer the active Stripe-backed usage-allowance subscription period for credit usage across plan tiers
- retain plan-entitlement and legacy subscription periods as fallbacks when no active usage subscription exists
- cover a forever Custom plan with a monthly usage-allowance subscription through public webhook and usage APIs

## Testing

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres pnpm --filter api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts -t "reads the usage allowance subscription period for a forever Custom plan"`
