### PR TITLE
perf(python): bound responses http usage inspection

### DIFF
--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -127,7 +127,9 @@ _JSON_PREFILTER_MAX_STRING_BYTES = 1024
 # After this bounded prefix, fall back to the full selective extractor so rare
 # terminal events with late ``type`` fields still report usage.
 _RESPONSES_EVENT_PREFILTER_MAX_BYTES = 4096
-_RESPONSES_WEBSOCKET_MAX_WORK_UNITS = 65_536
+# Bound dense syntax and slow scalar inspection while retaining the selective
+# parser's bulk-scan path for ordinary large content strings.
+_RESPONSES_MAX_WORK_UNITS = 65_536
 _RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR = "work_limit_exceeded"
 
 
@@ -575,7 +577,10 @@ class _OpenAIResponsesSseUsageHandler:
         scalar_fields = (
             _RESPONSES_SSE_SCALAR_FIELDS if include_type else _RESPONSES_SSE_RESPONSE_SCALAR_FIELDS
         )
-        self._extractor = JsonSelectiveExtractor(scalar_fields=scalar_fields)
+        self._extractor = JsonSelectiveExtractor(
+            scalar_fields=scalar_fields,
+            max_work_units=_RESPONSES_MAX_WORK_UNITS,
+        )
         return self._extractor
 
     def _should_include_type_scalar(self) -> bool:
@@ -656,7 +661,10 @@ class OpenAIResponsesJsonUsageExtractor:
     """
 
     def __init__(self) -> None:
-        self._extractor = JsonSelectiveExtractor(scalar_fields=_RESPONSES_RESPONSE_SCALAR_FIELDS)
+        self._extractor = JsonSelectiveExtractor(
+            scalar_fields=_RESPONSES_RESPONSE_SCALAR_FIELDS,
+            max_work_units=_RESPONSES_MAX_WORK_UNITS,
+        )
 
     def feed(self, chunk: bytes) -> None:
         self._extractor.feed(chunk)
@@ -739,7 +747,7 @@ def extract_openai_responses_usage_from_event(
     )
     extractor = JsonSelectiveExtractor(
         scalar_fields=scalar_fields,
-        max_work_units=_RESPONSES_WEBSOCKET_MAX_WORK_UNITS,
+        max_work_units=_RESPONSES_MAX_WORK_UNITS,
     )
     extractor.feed(event._body)
     result = extractor.finish()

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
@@ -165,23 +165,31 @@ class TestModelProviderJsonStreaming:
             cache_write_tokens=cache_write_tokens,
         )
 
+    @pytest.mark.parametrize(
+        "provider_case",
+        MODEL_PROVIDER_JSON_CASES,
+        ids=model_provider_json_case_id,
+    )
     @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
-    def test_full_pipeline_compressed_anthropic_json_work_limit(
-        self, tmp_path, real_flow, encoding_case
+    def test_full_pipeline_compressed_model_json_work_limit(
+        self, tmp_path, real_flow, provider_case, encoding_case
     ):
         proxy_log_path = tmp_path / "proxy.jsonl"
         flow = model_provider_flow(
             real_flow,
             tmp_path,
-            ANTHROPIC_JSON_CASE,
+            provider_case,
             proxy_log_path=proxy_log_path,
         )
-        payload = (
-            b'{"id":"msg_partial","model":"claude-sonnet-4-6",'
-            b'"usage":{"input_tokens":50,"output_tokens":200},"padding":['
-            + b",".join([b"0"] * 40_000)
-            + b"]}"
-        )
+        payload = json.dumps(
+            {
+                "id": provider_case.message_id,
+                "model": provider_case.model,
+                "usage": {"input_tokens": 50, "output_tokens": 200},
+                "padding": [0] * 40_000,
+            },
+            separators=(",", ":"),
+        ).encode()
         compressed = gzip.compress(payload) if encoding_case == "gzip" else zlib.compress(payload)
         allowed_decoded_bytes = max(
             STREAM_DECODE_EXPANSION_GRACE,

--- a/crates/runner/mitm-addon/tests/test_openai_responses_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_json.py
@@ -5,7 +5,10 @@ import json
 
 import pytest
 
-from usage import extract_openai_responses_usage_with_error_from_json
+from usage import (
+    create_openai_responses_json_usage_extractor,
+    extract_openai_responses_usage_with_error_from_json,
+)
 
 
 class TestExtractOpenAIResponsesUsageWithErrorFromJson:
@@ -206,3 +209,37 @@ class TestExtractOpenAIResponsesUsageWithErrorFromJson:
             "tokens.output": 9,
             "tokens.cache_read": 6,
         }
+
+    def test_protocol_shaped_output_with_many_items_stays_within_work_limit(self):
+        output_item = (
+            b'{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}'
+        )
+        body = (
+            b'{"id":"resp_many","model":"gpt-5.6-sol","output":['
+            + b",".join([output_item] * 700)
+            + b'],"usage":{"input_tokens":20,"output_tokens":9}}'
+        )
+
+        result, error = extract_openai_responses_usage_with_error_from_json(body, None)
+
+        assert error is None
+        assert result == {
+            "message_id": "resp_many",
+            "model": "gpt-5.6-sol",
+            "tokens.input": 20,
+            "tokens.output": 9,
+        }
+
+    def test_work_limit_accumulates_across_chunks_without_partial_usage(self):
+        extractor = create_openai_responses_json_usage_extractor()
+        dense_array = b",".join([b"0"] * 40_000)
+        extractor.feed(
+            b'{"id":"resp_partial","model":"gpt-5.6-sol",'
+            b'"usage":{"input_tokens":20,"output_tokens":9},"padding":['
+        )
+        midpoint = len(dense_array) // 2
+        extractor.feed(dense_array[:midpoint])
+        extractor.feed(dense_array[midpoint:])
+        extractor.feed(b"]}")
+
+        assert extractor.finish() == (None, "work limit exceeded")

--- a/crates/runner/mitm-addon/tests/test_openai_responses_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_json.py
@@ -230,7 +230,7 @@ class TestExtractOpenAIResponsesUsageWithErrorFromJson:
             "tokens.output": 9,
         }
 
-    def test_work_limit_accumulates_across_chunks_without_partial_usage(self):
+    def test_work_limit_discards_partial_document_and_next_extractor_recovers(self):
         extractor = create_openai_responses_json_usage_extractor()
         dense_array = b",".join([b"0"] * 40_000)
         extractor.feed(
@@ -243,3 +243,19 @@ class TestExtractOpenAIResponsesUsageWithErrorFromJson:
         extractor.feed(b"]}")
 
         assert extractor.finish() == (None, "work limit exceeded")
+
+        next_extractor = create_openai_responses_json_usage_extractor()
+        next_extractor.feed(
+            b'{"id":"resp_recovered","model":"gpt-5.6-sol",'
+            b'"usage":{"input_tokens":8,"output_tokens":3}}'
+        )
+
+        assert next_extractor.finish() == (
+            {
+                "message_id": "resp_recovered",
+                "model": "gpt-5.6-sol",
+                "tokens.input": 8,
+                "tokens.output": 3,
+            },
+            None,
+        )

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -74,6 +74,39 @@ class TestOpenAIResponsesSseUsageExtractor:
             "tokens.output": 0,
         }
 
+    def test_work_limit_discards_partial_event_and_recovers(self):
+        parse_errors: list[tuple[str, str]] = []
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_parse_error=lambda event, error: parse_errors.append((event, error))
+        )
+        dense_array = b",".join([b"0"] * 40_000)
+        midpoint = len(dense_array) // 2
+
+        parse(
+            b"event: response.completed\n"
+            b'data: {"type":"response.completed","response":{"id":"resp_partial",'
+            b'"model":"gpt-5.6-sol","usage":{"input_tokens":20,"output_tokens":9}},'
+            b'"padding":[' + dense_array[:midpoint] + b"\n"
+        )
+        parse(b"data: " + dense_array[midpoint:] + b"]}\n\n")
+
+        assert usage == {}
+        assert parse_errors == [("response.completed", "work limit exceeded")]
+
+        parse(
+            b"event: response.completed\n"
+            b'data: {"type":"response.completed","response":{"id":"resp_recovered",'
+            b'"model":"gpt-5.6-sol","usage":{"input_tokens":8,"output_tokens":3}}}\n\n'
+        )
+
+        assert usage == {
+            "message_id": "resp_recovered",
+            "model": "gpt-5.6-sol",
+            "tokens.input": 8,
+            "tokens.output": 3,
+        }
+        assert parse_errors == [("response.completed", "work limit exceeded")]
+
     def test_ignores_response_in_progress(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(


### PR DESCRIPTION
## Summary

- apply the existing 65,536-unit selective JSON work budget to OpenAI Responses HTTP SSE events and non-SSE documents
- use one transport-neutral Responses policy while preserving the existing WebSocket allowance and the shared parser's unlimited default
- discard partial usage on exhaustion, retain existing diagnostics and byte-for-byte response forwarding, and recover with a fresh budget for later SSE events and flows
- cover protocol-shaped success, dense cross-chunk exhaustion, SSE multi-`data:` recovery, and gzip/deflate response-stream behavior

## Behavior and compatibility

The parser budget is owned by the existing document/event extractor, so response chunking and streaming decompression cannot reset it. Documented non-usage SSE events still bypass the full extractor, and large discarded ASCII output continues through the bulk-scan path.

This is runner-local. It does not change APIs, database schema or persisted data, queue payloads, environment variables, feature switches, deployment ordering, or decoder cancellation/offload behavior.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_openai_responses_json.py tests/test_openai_responses_sse.py tests/test_model_provider_json_streaming.py` (92 passed)
- `uv run --no-sync python -m pytest tests/` (4718 passed)

Closes #24967
