### PR TITLE
test(zero-cli): add typescript-rust differential harness

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -73,6 +73,7 @@ jobs:
       runner-changed: ${{ steps.detect.outputs.runner-changed }}
       nbd-cow-changed: ${{ steps.detect.outputs.nbd-cow-changed }}
       vsock-test-changed: ${{ steps.detect.outputs.vsock-test-changed }}
+      zero-cli-parity-changed: ${{ steps.detect.outputs.zero-cli-parity-changed }}
       crates-runner-consumer-needed: ${{ steps.runner-tests.outputs.crates-runner-consumer-needed }}
       metal-job-ref: ${{ steps.runner-job-ref.outputs.job-ref }}
       runner-image-job-ref: ${{ steps.runner-job-ref.outputs.image-job-ref }}
@@ -119,12 +120,22 @@ jobs:
           check_crate runner
           check_crate nbd-cow
           check_crate vsock-test
+          check_crate zero-cli
 
           # Aggregate: true if any crate or CI config changed
           if grep -q "=true" "$GITHUB_OUTPUT"; then
             echo "any-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "any-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # The executable-only parity lane spans the Rust entry point and the
+          # public TypeScript package artifact. Keep it separate so TypeScript-
+          # only CLI changes do not select unrelated Rust coverage jobs.
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE '^crates/(Cargo\.(toml|lock)|zero-cli/)|^turbo/(apps/cli/|packages/(api-contracts|connectors|core)/|pnpm-lock\.yaml$)|^\.github/workflows/crates\.yml$'; then
+            echo "zero-cli-parity-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "zero-cli-parity-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
           # The api-contracts Rust bindings are generated from selected
@@ -387,6 +398,30 @@ jobs:
             cargo test -p vsock-guest --release --no-default-features \
               --test production_identity -- \
               --ignored --exact production_write_file_identity_matches_sudo_policy
+
+  zero-cli-parity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
+    needs: [detect]
+    if: |
+      needs.detect.outputs.ci-changed == 'true' ||
+      needs.detect.outputs.zero-cli-parity-changed == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+        with:
+          workspaces: crates -> target
+          shared-key: zero-cli-parity
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Run TypeScript-Rust Zero CLI parity cases
+        shell: bash
+        run: crates/zero-cli/tests/parity/run.sh
 
   coverage:
     runs-on: ubuntu-latest-8-cores
@@ -891,6 +926,7 @@ jobs:
       - detect-release
       - detect
       - check
+      - zero-cli-parity
       - coverage
       - api-contracts-rust-bindings
       - runner-firewall-contract-test
@@ -941,6 +977,7 @@ jobs:
 
           # May-skip: only run when relevant crates change
           check_result "check" "${{ needs.check.result }}" "true"
+          check_result "zero-cli-parity" "${{ needs.zero-cli-parity.result }}" "true"
           check_result "coverage" "${{ needs.coverage.result }}" "true"
           check_result "api-contracts-rust-bindings" "${{ needs.api-contracts-rust-bindings.result }}" "true"
           check_result "runner-firewall-contract-test" "${{ needs.runner-firewall-contract-test.result }}" "true"

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -4247,7 +4247,12 @@ dependencies = [
 name = "zero-cli"
 version = "0.1.0"
 dependencies = [
+ "clap",
+ "nix",
+ "serde",
+ "serde_json",
  "tempfile",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/zero-cli/Cargo.toml
+++ b/crates/zero-cli/Cargo.toml
@@ -5,7 +5,12 @@ edition.workspace = true
 description = "Runner-bundled native entry point for the Zero CLI"
 
 [dev-dependencies]
+clap = { workspace = true, features = ["derive"] }
+nix = { workspace = true, features = ["term"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tempfile.workspace = true
+uuid = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/zero-cli/examples/parity.rs
+++ b/crates/zero-cli/examples/parity.rs
@@ -1,0 +1,202 @@
+#[path = "parity/compare.rs"]
+mod compare;
+#[path = "parity/execution.rs"]
+mod execution;
+#[path = "parity/http.rs"]
+mod http;
+#[path = "parity/model.rs"]
+mod model;
+
+use std::env;
+use std::ffi::OsStr;
+use std::fmt::{self, Display};
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+use clap::Parser;
+
+use compare::compare_observations;
+use execution::{Implementation, observe};
+use model::load_cases;
+
+const NPX_TARGET_ENV: &str = "ZERO_CLI_PARITY_NPX_TARGET";
+
+type Result<T> = std::result::Result<T, HarnessError>;
+
+#[derive(Debug)]
+struct HarnessError(String);
+
+impl HarnessError {
+    fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl Display for HarnessError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for HarnessError {}
+
+#[derive(Debug, Parser)]
+#[command(about = "Compare the TypeScript and Rust Zero CLI executables")]
+struct Arguments {
+    /// Public TypeScript Zero CLI executable (the built dist/zero.js artifact).
+    #[arg(long)]
+    typescript: PathBuf,
+
+    /// Runner-bundled Rust zero-cli executable.
+    #[arg(long)]
+    rust: PathBuf,
+
+    /// Directory containing version 1 JSON parity cases.
+    #[arg(
+        long,
+        default_value = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/parity/v1/cases"
+        )
+    )]
+    cases: PathBuf,
+}
+
+fn main() -> ExitCode {
+    if executable_name().is_some_and(|name| name == OsStr::new("npx")) {
+        return run_npx_shim();
+    }
+
+    match run(Arguments::parse()) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn executable_name() -> Option<std::ffi::OsString> {
+    env::args_os()
+        .next()
+        .and_then(|path| Path::new(&path).file_name().map(OsStr::to_os_string))
+}
+
+fn run_npx_shim() -> ExitCode {
+    match exec_typescript_from_npx() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("zero-cli parity npx shim: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn exec_typescript_from_npx() -> Result<()> {
+    let target = env::var_os(NPX_TARGET_ENV)
+        .ok_or_else(|| HarnessError::new(format!("{NPX_TARGET_ENV} is not set")))?;
+    let mut arguments = env::args_os().skip(1);
+
+    for expected in ["-p", "@vm0/cli", "zero"] {
+        let actual = arguments
+            .next()
+            .ok_or_else(|| HarnessError::new(format!("missing expected argument {expected:?}")))?;
+        if actual != OsStr::new(expected) {
+            return Err(HarnessError::new(format!(
+                "expected argument {expected:?}, received {actual:?}"
+            )));
+        }
+    }
+
+    let error = Command::new(target).args(arguments).exec();
+    Err(HarnessError::new(format!(
+        "failed to execute TypeScript Zero CLI: {error}"
+    )))
+}
+
+fn run(arguments: Arguments) -> Result<()> {
+    let typescript = canonical_executable(&arguments.typescript, "TypeScript")?;
+    let rust = canonical_executable(&arguments.rust, "Rust")?;
+    let harness_executable = env::current_exe().map_err(|error| {
+        HarnessError::new(format!("resolve parity harness executable: {error}"))
+    })?;
+    let cases = load_cases(&arguments.cases)?;
+    let mut failures = Vec::new();
+
+    for loaded in cases {
+        let typescript_observation = observe(
+            Implementation::Typescript,
+            &typescript,
+            &typescript,
+            &harness_executable,
+            &loaded.case,
+        );
+        let rust_observation = observe(
+            Implementation::Rust,
+            &rust,
+            &typescript,
+            &harness_executable,
+            &loaded.case,
+        );
+
+        match (typescript_observation, rust_observation) {
+            (Ok(typescript_observation), Ok(rust_observation)) => {
+                if let Some(report) =
+                    compare_observations(&loaded.case, &typescript_observation, &rust_observation)
+                {
+                    failures.push(report);
+                } else {
+                    println!("PASS {} ({})", loaded.case.name, loaded.path.display());
+                }
+            }
+            (typescript_result, rust_result) => {
+                let mut report = format!(
+                    "case {:?} failed before comparison ({})",
+                    loaded.case.name,
+                    loaded.path.display()
+                );
+                if let Err(error) = typescript_result {
+                    report.push_str(&format!("\n  TypeScript: {error}"));
+                }
+                if let Err(error) = rust_result {
+                    report.push_str(&format!("\n  Rust: {error}"));
+                }
+                failures.push(report);
+            }
+        }
+    }
+
+    if failures.is_empty() {
+        println!("All Zero CLI parity cases passed");
+        return Ok(());
+    }
+
+    Err(HarnessError::new(format!(
+        "{} Zero CLI parity case(s) failed\n\n{}",
+        failures.len(),
+        failures.join("\n\n")
+    )))
+}
+
+fn canonical_executable(path: &Path, implementation: &str) -> Result<PathBuf> {
+    let canonical = path.canonicalize().map_err(|error| {
+        HarnessError::new(format!(
+            "resolve {implementation} executable {}: {error}",
+            path.display()
+        ))
+    })?;
+    let metadata = canonical.metadata().map_err(|error| {
+        HarnessError::new(format!(
+            "inspect {implementation} executable {}: {error}",
+            canonical.display()
+        ))
+    })?;
+    if !metadata.is_file() {
+        return Err(HarnessError::new(format!(
+            "{implementation} executable is not a file: {}",
+            canonical.display()
+        )));
+    }
+    Ok(canonical)
+}

--- a/crates/zero-cli/examples/parity/compare.rs
+++ b/crates/zero-cli/examples/parity/compare.rs
@@ -1,0 +1,577 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use uuid::Uuid;
+
+use crate::model::{
+    Case, FilesystemEntry, FilesystemEntryKind, Normalization, Observation, RuntimeValue,
+    RuntimeValues, TextTarget,
+};
+use crate::{HarnessError, Result};
+
+const DIAGNOSTIC_CONTEXT_BEFORE: usize = 48;
+const DIAGNOSTIC_CONTEXT_AFTER: usize = 160;
+
+pub fn normalize_observation(
+    observation: &mut Observation,
+    case: &Case,
+    runtime_values: &RuntimeValues,
+) -> Result<()> {
+    for normalization in &case.normalizations {
+        if let Normalization::RuntimeValue { value, targets } = normalization {
+            normalize_runtime_value(observation, *value, targets, runtime_values)?;
+        }
+    }
+
+    let uuid_headers = case
+        .normalizations
+        .iter()
+        .filter_map(|normalization| match normalization {
+            Normalization::UuidHttpHeader { header } => Some(header.as_str()),
+            Normalization::RuntimeValue { .. } => None,
+        })
+        .collect::<BTreeSet<_>>();
+    normalize_uuid_headers(observation, &uuid_headers)
+}
+
+fn normalize_runtime_value(
+    observation: &mut Observation,
+    value: RuntimeValue,
+    targets: &BTreeSet<TextTarget>,
+    runtime_values: &RuntimeValues,
+) -> Result<()> {
+    let (source, replacement) = match value {
+        RuntimeValue::WorkspacePath => (&runtime_values.workspace_path, "<WORKSPACE>"),
+        RuntimeValue::MockHttpUrl => (&runtime_values.mock_http_url, "<MOCK_HTTP_URL>"),
+        RuntimeValue::HomePath => (&runtime_values.home_path, "<HOME>"),
+        RuntimeValue::TempPath => (&runtime_values.temp_path, "<TEMP>"),
+    };
+    if source.is_empty() {
+        return Err(HarnessError::new(format!(
+            "runtime value {value:?} is empty"
+        )));
+    }
+
+    let source = source.as_bytes();
+    let replacement = replacement.as_bytes();
+    let mut replacements = 0_usize;
+    if targets.contains(&TextTarget::Stdout) {
+        replacements += replace_bytes(&mut observation.stdout, source, replacement);
+    }
+    if targets.contains(&TextTarget::Stderr) {
+        replacements += replace_bytes(&mut observation.stderr, source, replacement);
+    }
+    if targets.contains(&TextTarget::HttpRequestBody) {
+        for request in &mut observation.requests {
+            replacements += replace_bytes(&mut request.body, source, replacement);
+        }
+    }
+    if targets.contains(&TextTarget::FilesystemFileContent) {
+        for entry in &mut observation.filesystem {
+            if let FilesystemEntryKind::File(content) = &mut entry.kind {
+                replacements += replace_bytes(content, source, replacement);
+            }
+        }
+    }
+    if replacements == 0 {
+        return Err(HarnessError::new(format!(
+            "runtime-value normalization {value:?} did not match any declared target"
+        )));
+    }
+    Ok(())
+}
+
+fn normalize_uuid_headers(
+    observation: &mut Observation,
+    header_names: &BTreeSet<&str>,
+) -> Result<()> {
+    if header_names.is_empty() {
+        return Ok(());
+    }
+    let mut identities: BTreeMap<Uuid, Vec<u8>> = BTreeMap::new();
+    let mut matched_headers = BTreeSet::new();
+    for request in &mut observation.requests {
+        for (name, value) in &mut request.headers {
+            if !header_names.contains(name.as_str()) {
+                continue;
+            }
+            matched_headers.insert(name.clone());
+            let text = std::str::from_utf8(value).map_err(|error| {
+                HarnessError::new(format!(
+                    "UUID header {name:?} is not UTF-8 and cannot be normalized: {error}"
+                ))
+            })?;
+            let uuid = Uuid::parse_str(text).map_err(|error| {
+                HarnessError::new(format!(
+                    "UUID header {name:?} has invalid value {text:?}: {error}"
+                ))
+            })?;
+            let next_identity = identities.len() + 1;
+            let normalized = identities
+                .entry(uuid)
+                .or_insert_with(|| format!("<UUID:{next_identity}>").into_bytes());
+            *value = normalized.clone();
+        }
+    }
+
+    for header in header_names {
+        if !matched_headers.contains(*header) {
+            return Err(HarnessError::new(format!(
+                "UUID normalization header {header:?} was not present in any request"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn replace_bytes(value: &mut Vec<u8>, source: &[u8], replacement: &[u8]) -> usize {
+    let Some(first_match) = find_bytes(value, source) else {
+        return 0;
+    };
+    let mut result = Vec::with_capacity(value.len());
+    let mut cursor = 0_usize;
+    let mut next_match = Some(first_match);
+    let mut replacements = 0_usize;
+    while let Some(position) = next_match {
+        if let Some(prefix) = value.get(cursor..position) {
+            result.extend_from_slice(prefix);
+        }
+        result.extend_from_slice(replacement);
+        replacements += 1;
+        cursor = position.saturating_add(source.len());
+        next_match = value
+            .get(cursor..)
+            .and_then(|remaining| find_bytes(remaining, source))
+            .map(|offset| cursor.saturating_add(offset));
+    }
+    if let Some(suffix) = value.get(cursor..) {
+        result.extend_from_slice(suffix);
+    }
+    *value = result;
+    replacements
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+pub fn compare_observations(
+    case: &Case,
+    typescript: &Observation,
+    rust: &Observation,
+) -> Option<String> {
+    let mut mismatches = Vec::new();
+    compare_bytes(
+        "stdout",
+        &typescript.stdout,
+        &rust.stdout,
+        false,
+        &mut mismatches,
+    );
+    compare_bytes(
+        "stderr",
+        &typescript.stderr,
+        &rust.stderr,
+        false,
+        &mut mismatches,
+    );
+    compare_value(
+        "exit.code",
+        typescript.termination.code,
+        rust.termination.code,
+        &mut mismatches,
+    );
+    compare_value(
+        "exit.signal",
+        typescript.termination.signal,
+        rust.termination.signal,
+        &mut mismatches,
+    );
+    compare_requests(&typescript.requests, &rust.requests, &mut mismatches);
+    compare_filesystem(&typescript.filesystem, &rust.filesystem, &mut mismatches);
+
+    if mismatches.is_empty() {
+        return None;
+    }
+    let numbered = mismatches
+        .iter()
+        .enumerate()
+        .map(|(index, mismatch)| format!("  {}. {mismatch}", index + 1))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Some(format!(
+        "case {:?} (schema v{}): {}\n{} parity mismatch(es):\n{}",
+        case.name,
+        case.schema_version,
+        case.description,
+        mismatches.len(),
+        numbered
+    ))
+}
+
+fn compare_requests(
+    typescript: &[crate::model::RequestObservation],
+    rust: &[crate::model::RequestObservation],
+    mismatches: &mut Vec<String>,
+) {
+    compare_value(
+        "http.requestCount",
+        typescript.len(),
+        rust.len(),
+        mismatches,
+    );
+    for (index, (typescript_request, rust_request)) in typescript.iter().zip(rust).enumerate() {
+        compare_value(
+            &format!("http[{index}].method"),
+            &typescript_request.method,
+            &rust_request.method,
+            mismatches,
+        );
+        compare_value(
+            &format!("http[{index}].path"),
+            &typescript_request.path,
+            &rust_request.path,
+            mismatches,
+        );
+        compare_value(
+            &format!("http[{index}].query"),
+            &typescript_request.query,
+            &rust_request.query,
+            mismatches,
+        );
+        compare_bytes(
+            &format!("http[{index}].body"),
+            &typescript_request.body,
+            &rust_request.body,
+            false,
+            mismatches,
+        );
+
+        let header_names = typescript_request
+            .headers
+            .keys()
+            .chain(rust_request.headers.keys())
+            .collect::<BTreeSet<_>>();
+        for header_name in header_names {
+            let label = format!("http[{index}].headers[{header_name:?}]");
+            let typescript_value = typescript_request.headers.get(header_name);
+            let rust_value = rust_request.headers.get(header_name);
+            compare_optional_bytes(
+                &label,
+                typescript_value,
+                rust_value,
+                header_name.eq_ignore_ascii_case("authorization"),
+                mismatches,
+            );
+        }
+    }
+}
+
+fn compare_filesystem(
+    typescript: &[FilesystemEntry],
+    rust: &[FilesystemEntry],
+    mismatches: &mut Vec<String>,
+) {
+    let typescript_by_path = typescript
+        .iter()
+        .map(|entry| (entry.path.as_str(), entry))
+        .collect::<BTreeMap<_, _>>();
+    let rust_by_path = rust
+        .iter()
+        .map(|entry| (entry.path.as_str(), entry))
+        .collect::<BTreeMap<_, _>>();
+    let paths = typescript_by_path
+        .keys()
+        .chain(rust_by_path.keys())
+        .copied()
+        .collect::<BTreeSet<_>>();
+    for path in paths {
+        let typescript_entry = typescript_by_path.get(path).copied();
+        let rust_entry = rust_by_path.get(path).copied();
+        match (typescript_entry, rust_entry) {
+            (Some(typescript_entry), Some(rust_entry)) => {
+                compare_value(
+                    &format!("filesystem[{path:?}].mode"),
+                    format!("{:04o}", typescript_entry.mode),
+                    format!("{:04o}", rust_entry.mode),
+                    mismatches,
+                );
+                compare_value(
+                    &format!("filesystem[{path:?}].kind"),
+                    filesystem_kind_name(&typescript_entry.kind),
+                    filesystem_kind_name(&rust_entry.kind),
+                    mismatches,
+                );
+                match (&typescript_entry.kind, &rust_entry.kind) {
+                    (
+                        FilesystemEntryKind::File(typescript_content),
+                        FilesystemEntryKind::File(rust_content),
+                    ) => compare_bytes(
+                        &format!("filesystem[{path:?}].content"),
+                        typescript_content,
+                        rust_content,
+                        false,
+                        mismatches,
+                    ),
+                    (
+                        FilesystemEntryKind::Symlink(typescript_target),
+                        FilesystemEntryKind::Symlink(rust_target),
+                    ) => compare_value(
+                        &format!("filesystem[{path:?}].target"),
+                        typescript_target,
+                        rust_target,
+                        mismatches,
+                    ),
+                    _ => {}
+                }
+            }
+            (Some(entry), None) => mismatches.push(format!(
+                "filesystem[{path:?}] exists only for TypeScript ({}, mode {:04o})",
+                filesystem_kind_name(&entry.kind),
+                entry.mode
+            )),
+            (None, Some(entry)) => mismatches.push(format!(
+                "filesystem[{path:?}] exists only for Rust ({}, mode {:04o})",
+                filesystem_kind_name(&entry.kind),
+                entry.mode
+            )),
+            (None, None) => {}
+        }
+    }
+}
+
+fn filesystem_kind_name(kind: &FilesystemEntryKind) -> &'static str {
+    match kind {
+        FilesystemEntryKind::File(_) => "file",
+        FilesystemEntryKind::Directory => "directory",
+        FilesystemEntryKind::Symlink(_) => "symlink",
+    }
+}
+
+fn compare_value<T: std::fmt::Debug + PartialEq>(
+    label: &str,
+    typescript: T,
+    rust: T,
+    mismatches: &mut Vec<String>,
+) {
+    if typescript != rust {
+        mismatches.push(format!(
+            "{label} differs\n       TypeScript: {typescript:?}\n       Rust:       {rust:?}"
+        ));
+    }
+}
+
+fn compare_optional_bytes(
+    label: &str,
+    typescript: Option<&Vec<u8>>,
+    rust: Option<&Vec<u8>>,
+    sensitive: bool,
+    mismatches: &mut Vec<String>,
+) {
+    match (typescript, rust) {
+        (Some(typescript), Some(rust)) => {
+            compare_bytes(label, typescript, rust, sensitive, mismatches);
+        }
+        (Some(typescript), None) => mismatches.push(format!(
+            "{label} differs\n       TypeScript: {}\n       Rust:       <missing>",
+            render_value(typescript, sensitive)
+        )),
+        (None, Some(rust)) => mismatches.push(format!(
+            "{label} differs\n       TypeScript: <missing>\n       Rust:       {}",
+            render_value(rust, sensitive)
+        )),
+        (None, None) => {}
+    }
+}
+
+fn compare_bytes(
+    label: &str,
+    typescript: &[u8],
+    rust: &[u8],
+    sensitive: bool,
+    mismatches: &mut Vec<String>,
+) {
+    if typescript == rust {
+        return;
+    }
+    let difference = typescript
+        .iter()
+        .zip(rust)
+        .position(|(left, right)| left != right)
+        .unwrap_or_else(|| typescript.len().min(rust.len()));
+    mismatches.push(format!(
+        "{label} differs at byte {difference} (TypeScript {} bytes, Rust {} bytes)\n       TypeScript: {}\n       Rust:       {}",
+        typescript.len(),
+        rust.len(),
+        render_context(typescript, difference, sensitive),
+        render_context(rust, difference, sensitive)
+    ));
+}
+
+fn render_value(value: &[u8], sensitive: bool) -> String {
+    if sensitive {
+        return format!("<redacted, {} bytes>", value.len());
+    }
+    render_bytes(value)
+}
+
+fn render_context(value: &[u8], difference: usize, sensitive: bool) -> String {
+    if sensitive {
+        return format!("<redacted, {} bytes>", value.len());
+    }
+    let start = difference.saturating_sub(DIAGNOSTIC_CONTEXT_BEFORE);
+    let end = value
+        .len()
+        .min(difference.saturating_add(DIAGNOSTIC_CONTEXT_AFTER));
+    let context = value.get(start..end).unwrap_or_default();
+    let prefix = if start > 0 { "..." } else { "" };
+    let suffix = if end < value.len() { "..." } else { "" };
+    format!("{prefix}{}{suffix}", render_bytes(context))
+}
+
+fn render_bytes(value: &[u8]) -> String {
+    match std::str::from_utf8(value) {
+        Ok(text) => format!("{text:?}"),
+        Err(_) => format!(
+            "0x{}",
+            value
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<String>()
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    use crate::model::{Filesystem, MockHttp, RequestObservation, TerminalMode, Termination};
+
+    use super::*;
+
+    #[test]
+    fn intentional_mismatches_name_each_parity_dimension() {
+        let case = test_case(Vec::new());
+        let typescript = Observation {
+            stdout: b"alpha\n".to_vec(),
+            stderr: Vec::new(),
+            termination: Termination {
+                code: Some(0),
+                signal: None,
+            },
+            requests: vec![RequestObservation {
+                method: "GET".to_owned(),
+                path: "/left".to_owned(),
+                query: String::new(),
+                body: Vec::new(),
+                headers: BTreeMap::new(),
+            }],
+            filesystem: vec![FilesystemEntry {
+                path: "result.txt".to_owned(),
+                mode: 0o644,
+                kind: FilesystemEntryKind::File(b"left".to_vec()),
+            }],
+        };
+        let rust = Observation {
+            stdout: b"alpHa\n".to_vec(),
+            stderr: b"rust error\n".to_vec(),
+            termination: Termination {
+                code: Some(2),
+                signal: None,
+            },
+            requests: vec![RequestObservation {
+                method: "POST".to_owned(),
+                path: "/right".to_owned(),
+                query: String::new(),
+                body: Vec::new(),
+                headers: BTreeMap::new(),
+            }],
+            filesystem: vec![FilesystemEntry {
+                path: "result.txt".to_owned(),
+                mode: 0o600,
+                kind: FilesystemEntryKind::File(b"right".to_vec()),
+            }],
+        };
+
+        let report = compare_observations(&case, &typescript, &rust).unwrap();
+
+        assert!(report.contains("case \"diagnostic\" (schema v1)"));
+        assert!(report.contains("stdout differs at byte 3"));
+        assert!(report.contains("stderr differs"));
+        assert!(report.contains("exit.code differs"));
+        assert!(report.contains("http[0].method differs"));
+        assert!(report.contains("http[0].path differs"));
+        assert!(report.contains("filesystem[\"result.txt\"].mode differs"));
+        assert!(report.contains("filesystem[\"result.txt\"].content differs"));
+    }
+
+    #[test]
+    fn declared_runtime_and_uuid_values_are_normalized_narrowly() {
+        let case = test_case(vec![
+            Normalization::RuntimeValue {
+                value: RuntimeValue::MockHttpUrl,
+                targets: BTreeSet::from([TextTarget::Stdout]),
+            },
+            Normalization::UuidHttpHeader {
+                header: "x-request-id".to_owned(),
+            },
+        ]);
+        let mut observation = Observation {
+            stdout: b"API: http://127.0.0.1:32123\n".to_vec(),
+            stderr: Vec::new(),
+            termination: Termination {
+                code: Some(0),
+                signal: None,
+            },
+            requests: vec![RequestObservation {
+                method: "GET".to_owned(),
+                path: "/".to_owned(),
+                query: String::new(),
+                body: Vec::new(),
+                headers: BTreeMap::from([(
+                    "x-request-id".to_owned(),
+                    b"00000000-0000-4000-8000-000000000001".to_vec(),
+                )]),
+            }],
+            filesystem: Vec::new(),
+        };
+        let runtime_values = RuntimeValues {
+            workspace_path: "/tmp/workspace".to_owned(),
+            mock_http_url: "http://127.0.0.1:32123".to_owned(),
+            home_path: "/tmp/home".to_owned(),
+            temp_path: "/tmp/tmp".to_owned(),
+        };
+
+        normalize_observation(&mut observation, &case, &runtime_values).unwrap();
+
+        assert_eq!(observation.stdout, b"API: <MOCK_HTTP_URL>\n");
+        assert_eq!(observation.requests[0].headers["x-request-id"], b"<UUID:1>");
+    }
+
+    fn test_case(normalizations: Vec<Normalization>) -> Case {
+        Case {
+            schema: "../schema.json".to_owned(),
+            schema_version: 1,
+            name: "diagnostic".to_owned(),
+            description: "intentional mismatch".to_owned(),
+            argv: Vec::new(),
+            environment: BTreeMap::new(),
+            stdin: String::new(),
+            working_directory: PathBuf::from("."),
+            terminal_mode: TerminalMode::Pipe,
+            timeout_ms: 1_000,
+            mock_http: MockHttp {
+                capture_headers: vec!["x-request-id".to_owned()],
+                exchanges: Vec::new(),
+            },
+            filesystem: Filesystem { seed: Vec::new() },
+            normalizations,
+        }
+    }
+}

--- a/crates/zero-cli/examples/parity/execution.rs
+++ b/crates/zero-cli/examples/parity/execution.rs
@@ -591,8 +591,39 @@ fn display_path(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+    use std::process::Command;
 
     use super::*;
+
+    #[test]
+    fn pty_execution_connects_all_standard_streams_to_terminals() {
+        if cfg!(target_os = "linux") && !Path::new("/dev/pts").is_dir() {
+            eprintln!("PTY integration probe skipped: /dev/pts is unavailable");
+            return;
+        }
+
+        let mut command = Command::new("/bin/sh");
+        command.arg("-c").arg(
+            r#"
+stdin_mode=pipe
+stdout_mode=pipe
+stderr_mode=pipe
+[ -t 0 ] && stdin_mode=tty
+[ -t 1 ] && stdout_mode=tty
+[ -t 2 ] && stderr_mode=tty
+IFS= read -r payload
+printf 'stdin=%s;stdout=%s;input=%s' "$stdin_mode" "$stdout_mode" "$payload"
+printf 'stderr=%s' "$stderr_mode" >&2
+"#,
+        );
+
+        let output = run_pty(command, b"fixture-input\n", 2_000).unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"stdin=tty;stdout=tty;input=fixture-input");
+        assert_eq!(output.stderr, b"stderr=tty");
+    }
 
     #[test]
     fn filesystem_snapshot_records_content_modes_and_links() {

--- a/crates/zero-cli/examples/parity/execution.rs
+++ b/crates/zero-cli/examples/parity/execution.rs
@@ -1,0 +1,640 @@
+use std::env;
+use std::fs::{self, File};
+use std::io::{self, Read, Write};
+use std::os::unix::fs::{PermissionsExt, symlink};
+use std::os::unix::process::ExitStatusExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use nix::errno::Errno;
+use nix::pty::{Winsize, openpty};
+use tempfile::{Builder, TempDir};
+
+use crate::compare::normalize_observation;
+use crate::http::MockServer;
+use crate::model::{
+    Case, FilesystemEntry, FilesystemEntryKind, Observation, RuntimeValues, SeedEntry,
+    TerminalMode, Termination,
+};
+use crate::{HarnessError, NPX_TARGET_ENV, Result};
+
+const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const PTY_COLUMNS: u16 = 100;
+const PTY_ROWS: u16 = 30;
+
+#[derive(Clone, Copy, Debug)]
+pub enum Implementation {
+    Typescript,
+    Rust,
+}
+
+impl Implementation {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Typescript => "TypeScript",
+            Self::Rust => "Rust",
+        }
+    }
+
+    fn temp_prefix(self) -> &'static str {
+        match self {
+            Self::Typescript => "zero-cli-parity-typescript-",
+            Self::Rust => "zero-cli-parity-rust-",
+        }
+    }
+}
+
+struct IsolatedRuntime {
+    _root: TempDir,
+    workspace: PathBuf,
+    home: PathBuf,
+    temp: PathBuf,
+    bin: PathBuf,
+}
+
+struct ProcessOutput {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    status: ExitStatus,
+}
+
+pub fn observe(
+    implementation: Implementation,
+    executable: &Path,
+    typescript_executable: &Path,
+    harness_executable: &Path,
+    case: &Case,
+) -> Result<Observation> {
+    let runtime = IsolatedRuntime::new(implementation, harness_executable, case)?;
+    let server = MockServer::start(&case.mock_http)?;
+    let runtime_values = RuntimeValues {
+        workspace_path: display_path(&runtime.workspace),
+        mock_http_url: server.url().to_owned(),
+        home_path: display_path(&runtime.home),
+        temp_path: display_path(&runtime.temp),
+    };
+    let command = build_command(
+        executable,
+        typescript_executable,
+        &runtime,
+        &runtime_values,
+        case,
+    )?;
+    let process_result = run_process(command, case);
+    let http_result = server.finish();
+    let process = process_result.map_err(|error| {
+        HarnessError::new(format!(
+            "{} execution failed: {error}",
+            implementation.label()
+        ))
+    })?;
+    let requests = http_result.map_err(|error| {
+        HarnessError::new(format!(
+            "{} mock HTTP service failed: {error}",
+            implementation.label()
+        ))
+    })?;
+    validate_http_exchanges(implementation, case, &requests)?;
+
+    let filesystem = snapshot_filesystem(&runtime.workspace).map_err(|error| {
+        HarnessError::new(format!(
+            "snapshot {} case filesystem: {error}",
+            implementation.label()
+        ))
+    })?;
+    let mut observation = Observation {
+        stdout: process.stdout,
+        stderr: process.stderr,
+        termination: Termination {
+            code: process.status.code(),
+            signal: process.status.signal(),
+        },
+        requests,
+        filesystem,
+    };
+    normalize_observation(&mut observation, case, &runtime_values).map_err(|error| {
+        HarnessError::new(format!(
+            "normalize {} observation: {error}",
+            implementation.label()
+        ))
+    })?;
+    Ok(observation)
+}
+
+impl IsolatedRuntime {
+    fn new(implementation: Implementation, harness_executable: &Path, case: &Case) -> Result<Self> {
+        let root = Builder::new()
+            .prefix(implementation.temp_prefix())
+            .tempdir()
+            .map_err(|error| HarnessError::new(format!("create isolated runtime: {error}")))?;
+        let workspace = root.path().join("workspace");
+        let home = root.path().join("home");
+        let temp = root.path().join("tmp");
+        let bin = root.path().join("bin");
+        for directory in [&workspace, &home, &temp, &bin] {
+            fs::create_dir_all(directory).map_err(|error| {
+                HarnessError::new(format!(
+                    "create isolated directory {}: {error}",
+                    directory.display()
+                ))
+            })?;
+        }
+        symlink(harness_executable, bin.join("npx"))
+            .map_err(|error| HarnessError::new(format!("create isolated npx shim: {error}")))?;
+        materialize_filesystem(&workspace, &case.filesystem.seed)?;
+        let working_directory = workspace.join(&case.working_directory);
+        fs::create_dir_all(&working_directory).map_err(|error| {
+            HarnessError::new(format!(
+                "create case working directory {}: {error}",
+                working_directory.display()
+            ))
+        })?;
+
+        Ok(Self {
+            _root: root,
+            workspace,
+            home,
+            temp,
+            bin,
+        })
+    }
+}
+
+fn build_command(
+    executable: &Path,
+    typescript_executable: &Path,
+    runtime: &IsolatedRuntime,
+    runtime_values: &RuntimeValues,
+    case: &Case,
+) -> Result<Command> {
+    let inherited_path =
+        env::var_os("PATH").ok_or_else(|| HarnessError::new("host PATH is unavailable"))?;
+    let mut path_entries = vec![runtime.bin.clone()];
+    path_entries.extend(env::split_paths(&inherited_path));
+    let isolated_path = env::join_paths(path_entries)
+        .map_err(|error| HarnessError::new(format!("construct isolated PATH: {error}")))?;
+
+    let mut command = Command::new(executable);
+    command
+        .args(&case.argv)
+        .current_dir(runtime.workspace.join(&case.working_directory))
+        .env_clear()
+        .env("HOME", &runtime.home)
+        .env("LANG", "C.UTF-8")
+        .env("LC_ALL", "C.UTF-8")
+        .env("PATH", isolated_path)
+        .env("TMPDIR", &runtime.temp)
+        .env("TZ", "UTC")
+        .env("VM0_API_BACKEND_URL", &runtime_values.mock_http_url)
+        .env("XDG_CACHE_HOME", runtime.home.join(".cache"))
+        .env(NPX_TARGET_ENV, typescript_executable);
+
+    match case.terminal_mode {
+        TerminalMode::Pipe => {
+            command.env("NO_COLOR", "1").env("TERM", "dumb");
+        }
+        TerminalMode::Pty => {
+            command.env("TERM", "xterm-256color");
+        }
+    }
+
+    for (key, value) in &case.environment {
+        command.env(key, expand_runtime_placeholders(value, runtime_values));
+    }
+    Ok(command)
+}
+
+fn expand_runtime_placeholders(value: &str, runtime_values: &RuntimeValues) -> String {
+    value
+        .replace("${WORKSPACE}", &runtime_values.workspace_path)
+        .replace("${MOCK_HTTP_URL}", &runtime_values.mock_http_url)
+        .replace("${HOME}", &runtime_values.home_path)
+        .replace("${TEMP}", &runtime_values.temp_path)
+}
+
+fn run_process(command: Command, case: &Case) -> Result<ProcessOutput> {
+    match case.terminal_mode {
+        TerminalMode::Pipe => run_piped(command, case.stdin.as_bytes(), case.timeout_ms),
+        TerminalMode::Pty => run_pty(command, case.stdin.as_bytes(), case.timeout_ms),
+    }
+}
+
+fn run_piped(mut command: Command, stdin: &[u8], timeout_ms: u64) -> Result<ProcessOutput> {
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|error| HarnessError::new(format!("spawn process: {error}")))?;
+    drop(command);
+
+    let child_stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| HarnessError::new("piped child stdin was not created"))?;
+    let child_stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| HarnessError::new("piped child stdout was not created"))?;
+    let child_stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| HarnessError::new("piped child stderr was not created"))?;
+
+    let stdin_thread = spawn_stdin_writer(child_stdin, stdin.to_vec(), false);
+    let stdout_thread = spawn_reader(child_stdout, false);
+    let stderr_thread = spawn_reader(child_stderr, false);
+    let status = wait_with_timeout(&mut child, timeout_ms)?;
+    join_stdin_writer(stdin_thread)?;
+    let stdout = join_reader(stdout_thread, "stdout")?;
+    let stderr = join_reader(stderr_thread, "stderr")?;
+    Ok(ProcessOutput {
+        stdout,
+        stderr,
+        status,
+    })
+}
+
+fn run_pty(mut command: Command, stdin: &[u8], timeout_ms: u64) -> Result<ProcessOutput> {
+    let winsize = Winsize {
+        ws_row: PTY_ROWS,
+        ws_col: PTY_COLUMNS,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let stdin_pty = openpty(Some(&winsize), None)
+        .map_err(|error| HarnessError::new(format!("open stdin PTY: {error}")))?;
+    let stdout_pty = openpty(Some(&winsize), None)
+        .map_err(|error| HarnessError::new(format!("open stdout PTY: {error}")))?;
+    let stderr_pty = openpty(Some(&winsize), None)
+        .map_err(|error| HarnessError::new(format!("open stderr PTY: {error}")))?;
+
+    command
+        .stdin(Stdio::from(File::from(stdin_pty.slave)))
+        .stdout(Stdio::from(File::from(stdout_pty.slave)))
+        .stderr(Stdio::from(File::from(stderr_pty.slave)));
+    let mut child = command
+        .spawn()
+        .map_err(|error| HarnessError::new(format!("spawn PTY process: {error}")))?;
+    drop(command);
+
+    let stdin_thread = spawn_stdin_writer(File::from(stdin_pty.master), stdin.to_vec(), true);
+    let stdout_thread = spawn_reader(File::from(stdout_pty.master), true);
+    let stderr_thread = spawn_reader(File::from(stderr_pty.master), true);
+    let status = wait_with_timeout(&mut child, timeout_ms)?;
+    join_stdin_writer(stdin_thread)?;
+    let stdout = join_reader(stdout_thread, "stdout")?;
+    let stderr = join_reader(stderr_thread, "stderr")?;
+    Ok(ProcessOutput {
+        stdout,
+        stderr,
+        status,
+    })
+}
+
+fn spawn_stdin_writer<W: Write + Send + 'static>(
+    mut writer: W,
+    stdin: Vec<u8>,
+    send_end_of_transmission: bool,
+) -> JoinHandle<io::Result<()>> {
+    thread::spawn(move || {
+        match writer.write_all(&stdin) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::BrokenPipe => return Ok(()),
+            Err(error) => return Err(error),
+        }
+        if send_end_of_transmission {
+            match writer.write_all(&[4]) {
+                Ok(()) => {}
+                Err(error) if is_closed_stream_error(&error) => return Ok(()),
+                Err(error) => return Err(error),
+            }
+        }
+        writer.flush()
+    })
+}
+
+fn join_stdin_writer(thread: JoinHandle<io::Result<()>>) -> Result<()> {
+    thread
+        .join()
+        .map_err(|_| HarnessError::new("stdin writer thread panicked"))?
+        .map_err(|error| HarnessError::new(format!("write child stdin: {error}")))
+}
+
+fn spawn_reader<R: Read + Send + 'static>(
+    mut reader: R,
+    pty: bool,
+) -> JoinHandle<io::Result<Vec<u8>>> {
+    thread::spawn(move || {
+        let mut output = Vec::new();
+        let mut buffer = [0_u8; 8192];
+        loop {
+            match reader.read(&mut buffer) {
+                Ok(0) => return Ok(output),
+                Ok(read) => {
+                    if let Some(bytes) = buffer.get(..read) {
+                        output.extend_from_slice(bytes);
+                    }
+                }
+                Err(error) if pty && is_closed_stream_error(&error) => return Ok(output),
+                Err(error) => return Err(error),
+            }
+        }
+    })
+}
+
+fn join_reader(thread: JoinHandle<io::Result<Vec<u8>>>, stream: &str) -> Result<Vec<u8>> {
+    thread
+        .join()
+        .map_err(|_| HarnessError::new(format!("{stream} reader thread panicked")))?
+        .map_err(|error| HarnessError::new(format!("read child {stream}: {error}")))
+}
+
+fn is_closed_stream_error(error: &io::Error) -> bool {
+    error.kind() == io::ErrorKind::BrokenPipe || error.raw_os_error() == Some(Errno::EIO as i32)
+}
+
+fn wait_with_timeout(child: &mut Child, timeout_ms: u64) -> Result<ExitStatus> {
+    let timeout = Duration::from_millis(timeout_ms);
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or_else(|| HarnessError::new("process timeout exceeds supported duration"))?;
+    loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|error| HarnessError::new(format!("wait for process: {error}")))?
+        {
+            return Ok(status);
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            child
+                .kill()
+                .map_err(|error| HarnessError::new(format!("kill timed-out process: {error}")))?;
+            child
+                .wait()
+                .map_err(|error| HarnessError::new(format!("reap timed-out process: {error}")))?;
+            return Err(HarnessError::new(format!(
+                "process exceeded fixture timeout of {timeout_ms} ms"
+            )));
+        }
+        thread::sleep(PROCESS_POLL_INTERVAL.min(deadline.saturating_duration_since(now)));
+    }
+}
+
+fn materialize_filesystem(workspace: &Path, entries: &[SeedEntry]) -> Result<()> {
+    for entry in entries {
+        let path = workspace.join(entry.path());
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                HarnessError::new(format!(
+                    "create filesystem fixture parent {}: {error}",
+                    parent.display()
+                ))
+            })?;
+        }
+        match entry {
+            SeedEntry::File { content, .. } => {
+                fs::write(&path, content).map_err(|error| {
+                    HarnessError::new(format!(
+                        "write filesystem fixture {}: {error}",
+                        path.display()
+                    ))
+                })?;
+            }
+            SeedEntry::Directory { .. } => {
+                fs::create_dir_all(&path).map_err(|error| {
+                    HarnessError::new(format!(
+                        "create filesystem fixture directory {}: {error}",
+                        path.display()
+                    ))
+                })?;
+            }
+            SeedEntry::Symlink { target, .. } => {
+                symlink(target, &path).map_err(|error| {
+                    HarnessError::new(format!(
+                        "create filesystem fixture symlink {}: {error}",
+                        path.display()
+                    ))
+                })?;
+            }
+        }
+    }
+
+    for entry in entries {
+        let path = workspace.join(entry.path());
+        match entry {
+            SeedEntry::File { mode, .. } | SeedEntry::Directory { mode, .. } => {
+                fs::set_permissions(&path, fs::Permissions::from_mode(*mode)).map_err(|error| {
+                    HarnessError::new(format!(
+                        "set filesystem fixture mode on {}: {error}",
+                        path.display()
+                    ))
+                })?;
+            }
+            SeedEntry::Symlink { .. } => {}
+        }
+    }
+    Ok(())
+}
+
+fn snapshot_filesystem(workspace: &Path) -> Result<Vec<FilesystemEntry>> {
+    let mut entries = Vec::new();
+    snapshot_directory(workspace, workspace, &mut entries)?;
+    entries.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(entries)
+}
+
+fn snapshot_directory(
+    workspace: &Path,
+    directory: &Path,
+    entries: &mut Vec<FilesystemEntry>,
+) -> Result<()> {
+    let children = fs::read_dir(directory).map_err(|error| {
+        HarnessError::new(format!(
+            "read workspace directory {}: {error}",
+            directory.display()
+        ))
+    })?;
+    let mut paths = children
+        .map(|entry| {
+            entry
+                .map(|entry| entry.path())
+                .map_err(|error| HarnessError::new(format!("read workspace entry: {error}")))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    paths.sort();
+
+    for path in paths {
+        let metadata = fs::symlink_metadata(&path).map_err(|error| {
+            HarnessError::new(format!(
+                "inspect workspace entry {}: {error}",
+                path.display()
+            ))
+        })?;
+        let relative = path.strip_prefix(workspace).map_err(|error| {
+            HarnessError::new(format!(
+                "resolve workspace-relative path {}: {error}",
+                path.display()
+            ))
+        })?;
+        let relative = relative.to_str().ok_or_else(|| {
+            HarnessError::new(format!(
+                "workspace entry is not valid UTF-8: {}",
+                relative.display()
+            ))
+        })?;
+        let mode = metadata.permissions().mode() & 0o7777;
+        let file_type = metadata.file_type();
+        let kind = if file_type.is_file() {
+            FilesystemEntryKind::File(fs::read(&path).map_err(|error| {
+                HarnessError::new(format!("read workspace file {}: {error}", path.display()))
+            })?)
+        } else if file_type.is_dir() {
+            FilesystemEntryKind::Directory
+        } else if file_type.is_symlink() {
+            let target = fs::read_link(&path).map_err(|error| {
+                HarnessError::new(format!(
+                    "read workspace symlink {}: {error}",
+                    path.display()
+                ))
+            })?;
+            FilesystemEntryKind::Symlink(target.to_string_lossy().into_owned())
+        } else {
+            return Err(HarnessError::new(format!(
+                "unsupported workspace entry type: {}",
+                path.display()
+            )));
+        };
+        entries.push(FilesystemEntry {
+            path: relative.to_owned(),
+            mode,
+            kind,
+        });
+        if file_type.is_dir() {
+            snapshot_directory(workspace, &path, entries)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_http_exchanges(
+    implementation: Implementation,
+    case: &Case,
+    requests: &[crate::model::RequestObservation],
+) -> Result<()> {
+    let mut mismatches = Vec::new();
+    if requests.len() != case.mock_http.exchanges.len() {
+        mismatches.push(format!(
+            "request count: expected {}, observed {}",
+            case.mock_http.exchanges.len(),
+            requests.len()
+        ));
+    }
+
+    for (index, (exchange, request)) in case.mock_http.exchanges.iter().zip(requests).enumerate() {
+        let expected = &exchange.request;
+        if request.method != expected.method {
+            mismatches.push(format!(
+                "request {index} method: expected {:?}, observed {:?}",
+                expected.method, request.method
+            ));
+        }
+        if request.path != expected.path {
+            mismatches.push(format!(
+                "request {index} path: expected {:?}, observed {:?}",
+                expected.path, request.path
+            ));
+        }
+        if request.query != expected.query {
+            mismatches.push(format!(
+                "request {index} query: expected {:?}, observed {:?}",
+                expected.query, request.query
+            ));
+        }
+        if request.body != expected.body.as_bytes() {
+            mismatches.push(format!(
+                "request {index} body: expected {:?}, observed {}",
+                expected.body,
+                render_bytes(&request.body)
+            ));
+        }
+    }
+
+    if mismatches.is_empty() {
+        return Ok(());
+    }
+    Err(HarnessError::new(format!(
+        "{} fixture HTTP contract mismatch:\n    {}",
+        implementation.label(),
+        mismatches.join("\n    ")
+    )))
+}
+
+fn render_bytes(bytes: &[u8]) -> String {
+    match std::str::from_utf8(bytes) {
+        Ok(value) => format!("{value:?}"),
+        Err(_) => bytes
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>(),
+    }
+}
+
+fn display_path(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    #[test]
+    fn filesystem_snapshot_records_content_modes_and_links() {
+        let root = tempfile::tempdir().unwrap();
+        let workspace = root.path().join("workspace");
+        fs::create_dir(&workspace).unwrap();
+        let entries = vec![
+            SeedEntry::Directory {
+                path: PathBuf::from("nested"),
+                mode: 0o750,
+            },
+            SeedEntry::File {
+                path: PathBuf::from("nested/value.txt"),
+                content: "value".to_owned(),
+                mode: 0o640,
+            },
+            SeedEntry::Symlink {
+                path: PathBuf::from("link"),
+                target: PathBuf::from("nested/value.txt"),
+            },
+        ];
+        materialize_filesystem(&workspace, &entries).unwrap();
+
+        let snapshot = snapshot_filesystem(&workspace).unwrap();
+
+        assert_eq!(snapshot.len(), 3);
+        assert!(snapshot.iter().any(|entry| {
+            entry.path == "nested/value.txt"
+                && entry.mode == 0o640
+                && entry.kind == FilesystemEntryKind::File(b"value".to_vec())
+        }));
+        assert!(snapshot.iter().any(|entry| {
+            entry.path == "link"
+                && entry.kind == FilesystemEntryKind::Symlink("nested/value.txt".to_owned())
+        }));
+        assert_eq!(
+            fs::metadata(workspace.join("nested"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o7777,
+            0o750
+        );
+    }
+}

--- a/crates/zero-cli/examples/parity/http.rs
+++ b/crates/zero-cli/examples/parity/http.rs
@@ -1,0 +1,384 @@
+use std::collections::BTreeMap;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::mpsc::{self, Sender};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use crate::model::{HttpExchange, MockHttp, MockResponse, RequestObservation};
+use crate::{HarnessError, Result};
+
+const MAX_HEADER_BYTES: usize = 64 * 1024;
+const MAX_BODY_BYTES: usize = 8 * 1024 * 1024;
+const STREAM_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub struct MockServer {
+    address: SocketAddr,
+    stop: Option<Sender<()>>,
+    thread: Option<JoinHandle<Result<Vec<RequestObservation>>>>,
+}
+
+impl MockServer {
+    pub fn start(specification: &MockHttp) -> Result<Self> {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).map_err(|error| {
+            HarnessError::new(format!("bind isolated mock HTTP service: {error}"))
+        })?;
+        let address = listener.local_addr().map_err(|error| {
+            HarnessError::new(format!("resolve mock HTTP service address: {error}"))
+        })?;
+        let (stop_sender, stop_receiver) = mpsc::channel();
+        let specification = specification.clone();
+        let thread = thread::spawn(move || {
+            let mut requests = Vec::new();
+            let mut errors = Vec::new();
+            loop {
+                let (mut stream, _) = listener.accept().map_err(|error| {
+                    HarnessError::new(format!("accept mock HTTP connection: {error}"))
+                })?;
+                if stop_receiver.try_recv().is_ok() {
+                    break;
+                }
+                let exchange = specification.exchanges.get(requests.len());
+                match handle_connection(&mut stream, &specification.capture_headers, exchange) {
+                    Ok(request) => requests.push(request),
+                    Err(error) => {
+                        errors.push(error.to_string());
+                        let _ = write_response(
+                            &mut stream,
+                            &MockResponse {
+                                status: 500,
+                                headers: BTreeMap::from([(
+                                    "content-type".to_owned(),
+                                    "text/plain; charset=utf-8".to_owned(),
+                                )]),
+                                body: "parity mock HTTP service failed".to_owned(),
+                            },
+                        );
+                    }
+                }
+            }
+            if errors.is_empty() {
+                Ok(requests)
+            } else {
+                Err(HarnessError::new(errors.join("; ")))
+            }
+        });
+
+        Ok(Self {
+            address,
+            stop: Some(stop_sender),
+            thread: Some(thread),
+        })
+    }
+
+    pub fn url(&self) -> String {
+        format!("http://{}", self.address)
+    }
+
+    pub fn finish(mut self) -> Result<Vec<RequestObservation>> {
+        self.stop_thread()
+    }
+
+    fn stop_thread(&mut self) -> Result<Vec<RequestObservation>> {
+        let stop = self
+            .stop
+            .take()
+            .ok_or_else(|| HarnessError::new("mock HTTP service was already stopped"))?;
+        stop.send(()).map_err(|error| {
+            HarnessError::new(format!("signal mock HTTP service shutdown: {error}"))
+        })?;
+        TcpStream::connect(self.address).map_err(|error| {
+            HarnessError::new(format!("wake mock HTTP service for shutdown: {error}"))
+        })?;
+        let thread = self
+            .thread
+            .take()
+            .ok_or_else(|| HarnessError::new("mock HTTP service thread is unavailable"))?;
+        thread
+            .join()
+            .map_err(|_| HarnessError::new("mock HTTP service thread panicked"))?
+    }
+}
+
+impl Drop for MockServer {
+    fn drop(&mut self) {
+        if let Some(stop) = self.stop.take() {
+            let _ = stop.send(());
+            let _ = TcpStream::connect(self.address);
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn handle_connection(
+    stream: &mut TcpStream,
+    capture_headers: &[String],
+    exchange: Option<&HttpExchange>,
+) -> Result<RequestObservation> {
+    stream
+        .set_read_timeout(Some(STREAM_TIMEOUT))
+        .map_err(|error| HarnessError::new(format!("set mock HTTP read timeout: {error}")))?;
+    stream
+        .set_write_timeout(Some(STREAM_TIMEOUT))
+        .map_err(|error| HarnessError::new(format!("set mock HTTP write timeout: {error}")))?;
+    let request = read_request(stream, capture_headers)?;
+    let response =
+        exchange.map_or_else(unexpected_request_response, |value| value.response.clone());
+    write_response(stream, &response)?;
+    Ok(request)
+}
+
+fn read_request(stream: &mut TcpStream, capture_headers: &[String]) -> Result<RequestObservation> {
+    let mut received = Vec::new();
+    let header_end = loop {
+        if let Some(position) = find_bytes(&received, b"\r\n\r\n") {
+            break position + 4;
+        }
+        if received.len() >= MAX_HEADER_BYTES {
+            return Err(HarnessError::new(format!(
+                "mock HTTP request headers exceed {MAX_HEADER_BYTES} bytes"
+            )));
+        }
+        let mut buffer = [0_u8; 8192];
+        let read = stream
+            .read(&mut buffer)
+            .map_err(|error| HarnessError::new(format!("read mock HTTP request: {error}")))?;
+        if read == 0 {
+            return Err(HarnessError::new(
+                "mock HTTP client closed before completing request headers",
+            ));
+        }
+        let bytes = buffer
+            .get(..read)
+            .ok_or_else(|| HarnessError::new("invalid mock HTTP read length"))?;
+        received.extend_from_slice(bytes);
+    };
+
+    let header_bytes = received
+        .get(..header_end.saturating_sub(4))
+        .ok_or_else(|| HarnessError::new("invalid mock HTTP header boundary"))?;
+    let header_text = String::from_utf8(header_bytes.to_vec())
+        .map_err(|error| HarnessError::new(format!("mock HTTP headers are not UTF-8: {error}")))?;
+    let mut lines = header_text.split("\r\n");
+    let request_line = lines
+        .next()
+        .ok_or_else(|| HarnessError::new("mock HTTP request line is missing"))?;
+    let mut request_parts = request_line.split_ascii_whitespace();
+    let method = request_parts
+        .next()
+        .ok_or_else(|| HarnessError::new("mock HTTP method is missing"))?
+        .to_owned();
+    let target = request_parts
+        .next()
+        .ok_or_else(|| HarnessError::new("mock HTTP request target is missing"))?
+        .to_owned();
+    let version = request_parts
+        .next()
+        .ok_or_else(|| HarnessError::new("mock HTTP version is missing"))?;
+    if request_parts.next().is_some() || !version.starts_with("HTTP/1.") {
+        return Err(HarnessError::new(format!(
+            "unsupported mock HTTP request line {request_line:?}"
+        )));
+    }
+
+    let mut headers: BTreeMap<String, Vec<Vec<u8>>> = BTreeMap::new();
+    for line in lines {
+        let (name, value) = line
+            .split_once(':')
+            .ok_or_else(|| HarnessError::new(format!("invalid mock HTTP header line {line:?}")))?;
+        let name = name.trim().to_ascii_lowercase();
+        let value = value.trim().as_bytes().to_vec();
+        headers.entry(name).or_default().push(value);
+    }
+
+    if headers
+        .get("transfer-encoding")
+        .is_some_and(|values| !values.is_empty())
+    {
+        return Err(HarnessError::new(
+            "chunked mock HTTP request bodies are not supported by schema v1",
+        ));
+    }
+    let content_length = parse_content_length(&headers)?;
+    if content_length > MAX_BODY_BYTES {
+        return Err(HarnessError::new(format!(
+            "mock HTTP request body exceeds {MAX_BODY_BYTES} bytes"
+        )));
+    }
+    while received.len().saturating_sub(header_end) < content_length {
+        let remaining = content_length.saturating_sub(received.len().saturating_sub(header_end));
+        let mut buffer = vec![0_u8; remaining.min(8192)];
+        stream
+            .read_exact(&mut buffer)
+            .map_err(|error| HarnessError::new(format!("read mock HTTP body: {error}")))?;
+        received.extend_from_slice(&buffer);
+    }
+    let body_end = header_end
+        .checked_add(content_length)
+        .ok_or_else(|| HarnessError::new("mock HTTP body boundary overflow"))?;
+    let body = received
+        .get(header_end..body_end)
+        .ok_or_else(|| HarnessError::new("invalid mock HTTP body boundary"))?
+        .to_vec();
+
+    let mut captured_headers = BTreeMap::new();
+    for name in capture_headers {
+        if let Some(values) = headers.get(name) {
+            captured_headers.insert(name.clone(), join_header_values(values));
+        }
+    }
+    let (path, query) = target
+        .split_once('?')
+        .map_or((target.as_str(), ""), |(path, query)| (path, query));
+    Ok(RequestObservation {
+        method,
+        path: path.to_owned(),
+        query: query.to_owned(),
+        body,
+        headers: captured_headers,
+    })
+}
+
+fn parse_content_length(headers: &BTreeMap<String, Vec<Vec<u8>>>) -> Result<usize> {
+    let Some(values) = headers.get("content-length") else {
+        return Ok(0);
+    };
+    if values.len() != 1 {
+        return Err(HarnessError::new(
+            "mock HTTP request has multiple Content-Length headers",
+        ));
+    }
+    let value = values
+        .first()
+        .ok_or_else(|| HarnessError::new("mock HTTP Content-Length value is missing"))?;
+    let value = std::str::from_utf8(value).map_err(|error| {
+        HarnessError::new(format!("mock HTTP Content-Length is not UTF-8: {error}"))
+    })?;
+    value.parse::<usize>().map_err(|error| {
+        HarnessError::new(format!(
+            "invalid mock HTTP Content-Length {value:?}: {error}"
+        ))
+    })
+}
+
+fn join_header_values(values: &[Vec<u8>]) -> Vec<u8> {
+    let capacity = values.iter().map(Vec::len).sum::<usize>()
+        + values.len().saturating_sub(1).saturating_mul(2);
+    let mut joined = Vec::with_capacity(capacity);
+    for (index, value) in values.iter().enumerate() {
+        if index > 0 {
+            joined.extend_from_slice(b", ");
+        }
+        joined.extend_from_slice(value);
+    }
+    joined
+}
+
+fn write_response(stream: &mut TcpStream, response: &MockResponse) -> Result<()> {
+    let body = response.body.as_bytes();
+    write!(
+        stream,
+        "HTTP/1.1 {} {}\r\nConnection: close\r\nContent-Length: {}\r\n",
+        response.status,
+        reason_phrase(response.status),
+        body.len()
+    )
+    .map_err(|error| HarnessError::new(format!("write mock HTTP status: {error}")))?;
+    for (name, value) in &response.headers {
+        write!(stream, "{name}: {value}\r\n").map_err(|error| {
+            HarnessError::new(format!("write mock HTTP response header: {error}"))
+        })?;
+    }
+    stream
+        .write_all(b"\r\n")
+        .and_then(|()| stream.write_all(body))
+        .and_then(|()| stream.flush())
+        .map_err(|error| HarnessError::new(format!("write mock HTTP response body: {error}")))
+}
+
+fn unexpected_request_response() -> MockResponse {
+    MockResponse {
+        status: 500,
+        headers: BTreeMap::from([(
+            "content-type".to_owned(),
+            "application/json".to_owned(),
+        )]),
+        body: r#"{"error":{"code":"UNEXPECTED_PARITY_REQUEST","message":"No fixture response is configured"}}"#
+            .to_owned(),
+    }
+}
+
+fn reason_phrase(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        201 => "Created",
+        202 => "Accepted",
+        204 => "No Content",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        403 => "Forbidden",
+        404 => "Not Found",
+        409 => "Conflict",
+        422 => "Unprocessable Content",
+        429 => "Too Many Requests",
+        500 => "Internal Server Error",
+        502 => "Bad Gateway",
+        503 => "Service Unavailable",
+        504 => "Gateway Timeout",
+        _ => "Fixture Response",
+    }
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn captures_selected_request_dimensions_and_returns_fixture_response() {
+        let specification = MockHttp {
+            capture_headers: vec!["x-test".to_owned()],
+            exchanges: vec![HttpExchange {
+                request: crate::model::ExpectedRequest {
+                    method: "POST".to_owned(),
+                    path: "/resource".to_owned(),
+                    query: "a=1".to_owned(),
+                    body: "payload".to_owned(),
+                },
+                response: MockResponse {
+                    status: 201,
+                    headers: BTreeMap::from([("content-type".to_owned(), "text/plain".to_owned())]),
+                    body: "created".to_owned(),
+                },
+            }],
+        };
+        let server = MockServer::start(&specification).unwrap();
+        let mut stream = TcpStream::connect(server.address).unwrap();
+        stream
+            .write_all(
+                b"POST /resource?a=1 HTTP/1.1\r\nHost: local\r\nX-Test: value\r\nContent-Length: 7\r\n\r\npayload",
+            )
+            .unwrap();
+        let mut response = String::new();
+        stream.read_to_string(&mut response).unwrap();
+        let requests = server.finish().unwrap();
+
+        assert!(response.starts_with("HTTP/1.1 201 Created\r\n"));
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, "POST");
+        assert_eq!(requests[0].path, "/resource");
+        assert_eq!(requests[0].query, "a=1");
+        assert_eq!(requests[0].body, b"payload");
+        assert_eq!(requests[0].headers["x-test"], b"value");
+    }
+}

--- a/crates/zero-cli/examples/parity/http.rs
+++ b/crates/zero-cli/examples/parity/http.rs
@@ -12,6 +12,8 @@ const MAX_HEADER_BYTES: usize = 64 * 1024;
 const MAX_BODY_BYTES: usize = 8 * 1024 * 1024;
 const STREAM_TIMEOUT: Duration = Duration::from_secs(5);
 
+type HeaderValues = BTreeMap<String, Vec<Vec<u8>>>;
+
 pub struct MockServer {
     address: SocketAddr,
     stop: Option<Sender<()>>,
@@ -131,6 +133,23 @@ fn handle_connection(
 }
 
 fn read_request(stream: &mut TcpStream, capture_headers: &[String]) -> Result<RequestObservation> {
+    let (mut received, header_end) = read_request_head(stream)?;
+    let (method, target, headers) = parse_request_head(&received, header_end)?;
+    let body = read_request_body(stream, &mut received, header_end, &headers)?;
+    let captured_headers = capture_request_headers(&headers, capture_headers);
+    let (path, query) = target
+        .split_once('?')
+        .map_or((target.as_str(), ""), |(path, query)| (path, query));
+    Ok(RequestObservation {
+        method,
+        path: path.to_owned(),
+        query: query.to_owned(),
+        body,
+        headers: captured_headers,
+    })
+}
+
+fn read_request_head(stream: &mut TcpStream) -> Result<(Vec<u8>, usize)> {
     let mut received = Vec::new();
     let header_end = loop {
         if let Some(position) = find_bytes(&received, b"\r\n\r\n") {
@@ -155,7 +174,13 @@ fn read_request(stream: &mut TcpStream, capture_headers: &[String]) -> Result<Re
             .ok_or_else(|| HarnessError::new("invalid mock HTTP read length"))?;
         received.extend_from_slice(bytes);
     };
+    Ok((received, header_end))
+}
 
+fn parse_request_head(
+    received: &[u8],
+    header_end: usize,
+) -> Result<(String, String, HeaderValues)> {
     let header_bytes = received
         .get(..header_end.saturating_sub(4))
         .ok_or_else(|| HarnessError::new("invalid mock HTTP header boundary"))?;
@@ -183,7 +208,7 @@ fn read_request(stream: &mut TcpStream, capture_headers: &[String]) -> Result<Re
         )));
     }
 
-    let mut headers: BTreeMap<String, Vec<Vec<u8>>> = BTreeMap::new();
+    let mut headers = HeaderValues::new();
     for line in lines {
         let (name, value) = line
             .split_once(':')
@@ -192,7 +217,15 @@ fn read_request(stream: &mut TcpStream, capture_headers: &[String]) -> Result<Re
         let value = value.trim().as_bytes().to_vec();
         headers.entry(name).or_default().push(value);
     }
+    Ok((method, target, headers))
+}
 
+fn read_request_body(
+    stream: &mut TcpStream,
+    received: &mut Vec<u8>,
+    header_end: usize,
+    headers: &HeaderValues,
+) -> Result<Vec<u8>> {
     if headers
         .get("transfer-encoding")
         .is_some_and(|values| !values.is_empty())
@@ -201,7 +234,7 @@ fn read_request(stream: &mut TcpStream, capture_headers: &[String]) -> Result<Re
             "chunked mock HTTP request bodies are not supported by schema v1",
         ));
     }
-    let content_length = parse_content_length(&headers)?;
+    let content_length = parse_content_length(headers)?;
     if content_length > MAX_BODY_BYTES {
         return Err(HarnessError::new(format!(
             "mock HTTP request body exceeds {MAX_BODY_BYTES} bytes"
@@ -222,26 +255,23 @@ fn read_request(stream: &mut TcpStream, capture_headers: &[String]) -> Result<Re
         .get(header_end..body_end)
         .ok_or_else(|| HarnessError::new("invalid mock HTTP body boundary"))?
         .to_vec();
+    Ok(body)
+}
 
+fn capture_request_headers(
+    headers: &HeaderValues,
+    capture_headers: &[String],
+) -> BTreeMap<String, Vec<u8>> {
     let mut captured_headers = BTreeMap::new();
     for name in capture_headers {
         if let Some(values) = headers.get(name) {
             captured_headers.insert(name.clone(), join_header_values(values));
         }
     }
-    let (path, query) = target
-        .split_once('?')
-        .map_or((target.as_str(), ""), |(path, query)| (path, query));
-    Ok(RequestObservation {
-        method,
-        path: path.to_owned(),
-        query: query.to_owned(),
-        body,
-        headers: captured_headers,
-    })
+    captured_headers
 }
 
-fn parse_content_length(headers: &BTreeMap<String, Vec<Vec<u8>>>) -> Result<usize> {
+fn parse_content_length(headers: &HeaderValues) -> Result<usize> {
     let Some(values) = headers.get("content-length") else {
         return Ok(0);
     };

--- a/crates/zero-cli/examples/parity/model.rs
+++ b/crates/zero-cli/examples/parity/model.rs
@@ -1,0 +1,477 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::{HarnessError, Result};
+
+const CASE_SCHEMA_REFERENCE: &str = "../schema.json";
+const CASE_SCHEMA_VERSION: u32 = 1;
+const RESERVED_ENVIRONMENT_KEYS: [&str; 8] = [
+    "HOME",
+    "NO_COLOR",
+    "PATH",
+    "TERM",
+    "TMPDIR",
+    "VM0_API_BACKEND_URL",
+    "XDG_CACHE_HOME",
+    "ZERO_CLI_PARITY_NPX_TARGET",
+];
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Case {
+    #[serde(rename = "$schema")]
+    pub schema: String,
+    pub schema_version: u32,
+    pub name: String,
+    pub description: String,
+    pub argv: Vec<String>,
+    pub environment: BTreeMap<String, String>,
+    pub stdin: String,
+    pub working_directory: PathBuf,
+    pub terminal_mode: TerminalMode,
+    pub timeout_ms: u64,
+    pub mock_http: MockHttp,
+    pub filesystem: Filesystem,
+    pub normalizations: Vec<Normalization>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TerminalMode {
+    Pipe,
+    Pty,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MockHttp {
+    pub capture_headers: Vec<String>,
+    pub exchanges: Vec<HttpExchange>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HttpExchange {
+    pub request: ExpectedRequest,
+    pub response: MockResponse,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ExpectedRequest {
+    pub method: String,
+    pub path: String,
+    pub query: String,
+    pub body: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MockResponse {
+    pub status: u16,
+    pub headers: BTreeMap<String, String>,
+    pub body: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Filesystem {
+    pub seed: Vec<SeedEntry>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum SeedEntry {
+    File {
+        path: PathBuf,
+        content: String,
+        mode: u32,
+    },
+    Directory {
+        path: PathBuf,
+        mode: u32,
+    },
+    Symlink {
+        path: PathBuf,
+        target: PathBuf,
+    },
+}
+
+impl SeedEntry {
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::File { path, .. } | Self::Directory { path, .. } | Self::Symlink { path, .. } => {
+                path
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum Normalization {
+    RuntimeValue {
+        value: RuntimeValue,
+        targets: BTreeSet<TextTarget>,
+    },
+    UuidHttpHeader {
+        header: String,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RuntimeValue {
+    WorkspacePath,
+    MockHttpUrl,
+    HomePath,
+    TempPath,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
+#[serde(rename_all = "kebab-case")]
+pub enum TextTarget {
+    Stdout,
+    Stderr,
+    HttpRequestBody,
+    FilesystemFileContent,
+}
+
+#[derive(Debug)]
+pub struct LoadedCase {
+    pub path: PathBuf,
+    pub case: Case,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Observation {
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub termination: Termination,
+    pub requests: Vec<RequestObservation>,
+    pub filesystem: Vec<FilesystemEntry>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Termination {
+    pub code: Option<i32>,
+    pub signal: Option<i32>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RequestObservation {
+    pub method: String,
+    pub path: String,
+    pub query: String,
+    pub body: Vec<u8>,
+    pub headers: BTreeMap<String, Vec<u8>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FilesystemEntry {
+    pub path: String,
+    pub mode: u32,
+    pub kind: FilesystemEntryKind,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FilesystemEntryKind {
+    File(Vec<u8>),
+    Directory,
+    Symlink(String),
+}
+
+#[derive(Clone, Debug)]
+pub struct RuntimeValues {
+    pub workspace_path: String,
+    pub mock_http_url: String,
+    pub home_path: String,
+    pub temp_path: String,
+}
+
+pub fn load_cases(directory: &Path) -> Result<Vec<LoadedCase>> {
+    let mut paths = Vec::new();
+    collect_case_paths(directory, &mut paths)?;
+    paths.sort();
+    if paths.is_empty() {
+        return Err(HarnessError::new(format!(
+            "no JSON parity cases found under {}",
+            directory.display()
+        )));
+    }
+
+    let mut names = BTreeSet::new();
+    let mut cases = Vec::with_capacity(paths.len());
+    for path in paths {
+        let content = fs::read_to_string(&path).map_err(|error| {
+            HarnessError::new(format!("read parity case {}: {error}", path.display()))
+        })?;
+        let case: Case = serde_json::from_str(&content).map_err(|error| {
+            HarnessError::new(format!("parse parity case {}: {error}", path.display()))
+        })?;
+        validate_case(&case, &path)?;
+        if !names.insert(case.name.clone()) {
+            return Err(HarnessError::new(format!(
+                "duplicate parity case name {:?} at {}",
+                case.name,
+                path.display()
+            )));
+        }
+        cases.push(LoadedCase { path, case });
+    }
+    Ok(cases)
+}
+
+fn collect_case_paths(directory: &Path, paths: &mut Vec<PathBuf>) -> Result<()> {
+    let entries = fs::read_dir(directory).map_err(|error| {
+        HarnessError::new(format!(
+            "read parity case directory {}: {error}",
+            directory.display()
+        ))
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            HarnessError::new(format!(
+                "read entry in parity case directory {}: {error}",
+                directory.display()
+            ))
+        })?;
+        let file_type = entry.file_type().map_err(|error| {
+            HarnessError::new(format!(
+                "inspect parity case path {}: {error}",
+                entry.path().display()
+            ))
+        })?;
+        if file_type.is_dir() {
+            collect_case_paths(&entry.path(), paths)?;
+        } else if entry.path().extension() == Some(OsStr::new("json")) {
+            paths.push(entry.path());
+        }
+    }
+    Ok(())
+}
+
+use std::ffi::OsStr;
+
+fn validate_case(case: &Case, path: &Path) -> Result<()> {
+    if case.schema != CASE_SCHEMA_REFERENCE || case.schema_version != CASE_SCHEMA_VERSION {
+        return Err(HarnessError::new(format!(
+            "{} must use schema reference {CASE_SCHEMA_REFERENCE:?} and schema version {CASE_SCHEMA_VERSION}",
+            path.display()
+        )));
+    }
+    if case.name.trim().is_empty() || case.description.trim().is_empty() {
+        return Err(HarnessError::new(format!(
+            "{} must have a non-empty name and description",
+            path.display()
+        )));
+    }
+    if case.timeout_ms == 0 {
+        return Err(HarnessError::new(format!(
+            "{} timeoutMs must be greater than zero",
+            path.display()
+        )));
+    }
+    validate_relative_path(&case.working_directory, true, "workingDirectory", path)?;
+
+    for (key, value) in &case.environment {
+        if key.is_empty() || key.contains('=') || key.contains('\0') {
+            return Err(HarnessError::new(format!(
+                "{} contains invalid environment key {key:?}",
+                path.display()
+            )));
+        }
+        if RESERVED_ENVIRONMENT_KEYS.contains(&key.as_str()) {
+            return Err(HarnessError::new(format!(
+                "{} may not override harness-owned environment key {key}",
+                path.display()
+            )));
+        }
+        if value.contains('\0') {
+            return Err(HarnessError::new(format!(
+                "{} environment value for {key:?} contains a NUL byte",
+                path.display()
+            )));
+        }
+    }
+
+    let mut seed_paths = BTreeSet::new();
+    for entry in &case.filesystem.seed {
+        validate_relative_path(entry.path(), false, "filesystem seed path", path)?;
+        if !seed_paths.insert(entry.path().to_path_buf()) {
+            return Err(HarnessError::new(format!(
+                "{} contains duplicate filesystem seed path {}",
+                path.display(),
+                entry.path().display()
+            )));
+        }
+        match entry {
+            SeedEntry::File { mode, .. } | SeedEntry::Directory { mode, .. } => {
+                if *mode > 0o7777 {
+                    return Err(HarnessError::new(format!(
+                        "{} contains invalid filesystem mode {mode}",
+                        path.display()
+                    )));
+                }
+            }
+            SeedEntry::Symlink { target, .. } => {
+                validate_relative_path(target, false, "symlink target", path)?;
+            }
+        }
+    }
+
+    let capture_headers = case
+        .mock_http
+        .capture_headers
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    if capture_headers.len() != case.mock_http.capture_headers.len() {
+        return Err(HarnessError::new(format!(
+            "{} contains duplicate captureHeaders",
+            path.display()
+        )));
+    }
+    for header in &case.mock_http.capture_headers {
+        if !is_http_token(header) || header.bytes().any(|byte| byte.is_ascii_uppercase()) {
+            return Err(HarnessError::new(format!(
+                "{} capture header {header:?} must be non-empty lowercase ASCII",
+                path.display()
+            )));
+        }
+    }
+
+    for exchange in &case.mock_http.exchanges {
+        let request = &exchange.request;
+        if request.method.is_empty()
+            || request.method.bytes().any(|byte| byte.is_ascii_lowercase())
+            || !request.path.starts_with('/')
+            || request.query.starts_with('?')
+        {
+            return Err(HarnessError::new(format!(
+                "{} contains an invalid mock HTTP request definition",
+                path.display()
+            )));
+        }
+        if !(100..=599).contains(&exchange.response.status) {
+            return Err(HarnessError::new(format!(
+                "{} contains invalid mock HTTP status {}",
+                path.display(),
+                exchange.response.status
+            )));
+        }
+        for header in exchange.response.headers.keys() {
+            if !is_http_token(header) {
+                return Err(HarnessError::new(format!(
+                    "{} contains invalid mock response header name {header:?}",
+                    path.display()
+                )));
+            }
+            if header.eq_ignore_ascii_case("content-length")
+                || header.eq_ignore_ascii_case("connection")
+            {
+                return Err(HarnessError::new(format!(
+                    "{} mock response must not set harness-owned header {header:?}",
+                    path.display()
+                )));
+            }
+        }
+        for (header, value) in &exchange.response.headers {
+            if value.contains('\r') || value.contains('\n') {
+                return Err(HarnessError::new(format!(
+                    "{} mock response header {header:?} contains a line break",
+                    path.display()
+                )));
+            }
+        }
+    }
+
+    for normalization in &case.normalizations {
+        match normalization {
+            Normalization::RuntimeValue { targets, .. } if targets.is_empty() => {
+                return Err(HarnessError::new(format!(
+                    "{} runtime-value normalization must name at least one target",
+                    path.display()
+                )));
+            }
+            Normalization::UuidHttpHeader { header }
+                if !capture_headers.contains(header.as_str()) =>
+            {
+                return Err(HarnessError::new(format!(
+                    "{} UUID normalization header {header:?} is not listed in captureHeaders",
+                    path.display()
+                )));
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn is_http_token(value: &str) -> bool {
+    !value.is_empty()
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(
+                    byte,
+                    b'!' | b'#'
+                        | b'$'
+                        | b'%'
+                        | b'&'
+                        | b'\''
+                        | b'*'
+                        | b'+'
+                        | b'-'
+                        | b'.'
+                        | b'^'
+                        | b'_'
+                        | b'`'
+                        | b'|'
+                        | b'~'
+                )
+        })
+}
+
+fn validate_relative_path(
+    value: &Path,
+    allow_current_directory: bool,
+    field: &str,
+    case_path: &Path,
+) -> Result<()> {
+    if value.as_os_str().is_empty() || value.is_absolute() {
+        return Err(HarnessError::new(format!(
+            "{} {field} must be a non-empty relative path",
+            case_path.display()
+        )));
+    }
+    let mut normal_components = 0_usize;
+    for component in value.components() {
+        match component {
+            Component::Normal(_) => normal_components += 1,
+            Component::CurDir if allow_current_directory => {}
+            Component::CurDir => {
+                return Err(HarnessError::new(format!(
+                    "{} {field} must not contain a current-directory component",
+                    case_path.display()
+                )));
+            }
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(HarnessError::new(format!(
+                    "{} {field} must stay inside the case workspace",
+                    case_path.display()
+                )));
+            }
+        }
+    }
+    if normal_components == 0 && !allow_current_directory {
+        return Err(HarnessError::new(format!(
+            "{} {field} must name a workspace entry",
+            case_path.display()
+        )));
+    }
+    Ok(())
+}

--- a/crates/zero-cli/examples/parity/model.rs
+++ b/crates/zero-cli/examples/parity/model.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 
@@ -254,9 +255,16 @@ fn collect_case_paths(directory: &Path, paths: &mut Vec<PathBuf>) -> Result<()> 
     Ok(())
 }
 
-use std::ffi::OsStr;
-
 fn validate_case(case: &Case, path: &Path) -> Result<()> {
+    validate_case_metadata(case, path)?;
+    validate_relative_path(&case.working_directory, true, "workingDirectory", path)?;
+    validate_environment(&case.environment, path)?;
+    validate_filesystem(&case.filesystem, path)?;
+    let capture_headers = validate_mock_http(&case.mock_http, path)?;
+    validate_normalizations(&case.normalizations, &capture_headers, path)
+}
+
+fn validate_case_metadata(case: &Case, path: &Path) -> Result<()> {
     if case.schema != CASE_SCHEMA_REFERENCE || case.schema_version != CASE_SCHEMA_VERSION {
         return Err(HarnessError::new(format!(
             "{} must use schema reference {CASE_SCHEMA_REFERENCE:?} and schema version {CASE_SCHEMA_VERSION}",
@@ -275,9 +283,11 @@ fn validate_case(case: &Case, path: &Path) -> Result<()> {
             path.display()
         )));
     }
-    validate_relative_path(&case.working_directory, true, "workingDirectory", path)?;
+    Ok(())
+}
 
-    for (key, value) in &case.environment {
+fn validate_environment(environment: &BTreeMap<String, String>, path: &Path) -> Result<()> {
+    for (key, value) in environment {
         if key.is_empty() || key.contains('=') || key.contains('\0') {
             return Err(HarnessError::new(format!(
                 "{} contains invalid environment key {key:?}",
@@ -297,9 +307,12 @@ fn validate_case(case: &Case, path: &Path) -> Result<()> {
             )));
         }
     }
+    Ok(())
+}
 
+fn validate_filesystem(filesystem: &Filesystem, path: &Path) -> Result<()> {
     let mut seed_paths = BTreeSet::new();
-    for entry in &case.filesystem.seed {
+    for entry in &filesystem.seed {
         validate_relative_path(entry.path(), false, "filesystem seed path", path)?;
         if !seed_paths.insert(entry.path().to_path_buf()) {
             return Err(HarnessError::new(format!(
@@ -322,20 +335,22 @@ fn validate_case(case: &Case, path: &Path) -> Result<()> {
             }
         }
     }
+    Ok(())
+}
 
-    let capture_headers = case
-        .mock_http
+fn validate_mock_http(mock_http: &MockHttp, path: &Path) -> Result<BTreeSet<String>> {
+    let capture_headers = mock_http
         .capture_headers
         .iter()
-        .map(String::as_str)
+        .cloned()
         .collect::<BTreeSet<_>>();
-    if capture_headers.len() != case.mock_http.capture_headers.len() {
+    if capture_headers.len() != mock_http.capture_headers.len() {
         return Err(HarnessError::new(format!(
             "{} contains duplicate captureHeaders",
             path.display()
         )));
     }
-    for header in &case.mock_http.capture_headers {
+    for header in &mock_http.capture_headers {
         if !is_http_token(header) || header.bytes().any(|byte| byte.is_ascii_uppercase()) {
             return Err(HarnessError::new(format!(
                 "{} capture header {header:?} must be non-empty lowercase ASCII",
@@ -344,52 +359,62 @@ fn validate_case(case: &Case, path: &Path) -> Result<()> {
         }
     }
 
-    for exchange in &case.mock_http.exchanges {
-        let request = &exchange.request;
-        if request.method.is_empty()
-            || request.method.bytes().any(|byte| byte.is_ascii_lowercase())
-            || !request.path.starts_with('/')
-            || request.query.starts_with('?')
-        {
+    for exchange in &mock_http.exchanges {
+        validate_http_exchange(exchange, path)?;
+    }
+    Ok(capture_headers)
+}
+
+fn validate_http_exchange(exchange: &HttpExchange, path: &Path) -> Result<()> {
+    let request = &exchange.request;
+    if request.method.is_empty()
+        || request.method.bytes().any(|byte| byte.is_ascii_lowercase())
+        || !request.path.starts_with('/')
+        || request.query.starts_with('?')
+    {
+        return Err(HarnessError::new(format!(
+            "{} contains an invalid mock HTTP request definition",
+            path.display()
+        )));
+    }
+    if !(100..=599).contains(&exchange.response.status) {
+        return Err(HarnessError::new(format!(
+            "{} contains invalid mock HTTP status {}",
+            path.display(),
+            exchange.response.status
+        )));
+    }
+    for (header, value) in &exchange.response.headers {
+        if !is_http_token(header) {
             return Err(HarnessError::new(format!(
-                "{} contains an invalid mock HTTP request definition",
+                "{} contains invalid mock response header name {header:?}",
                 path.display()
             )));
         }
-        if !(100..=599).contains(&exchange.response.status) {
+        if header.eq_ignore_ascii_case("content-length")
+            || header.eq_ignore_ascii_case("connection")
+        {
             return Err(HarnessError::new(format!(
-                "{} contains invalid mock HTTP status {}",
-                path.display(),
-                exchange.response.status
+                "{} mock response must not set harness-owned header {header:?}",
+                path.display()
             )));
         }
-        for header in exchange.response.headers.keys() {
-            if !is_http_token(header) {
-                return Err(HarnessError::new(format!(
-                    "{} contains invalid mock response header name {header:?}",
-                    path.display()
-                )));
-            }
-            if header.eq_ignore_ascii_case("content-length")
-                || header.eq_ignore_ascii_case("connection")
-            {
-                return Err(HarnessError::new(format!(
-                    "{} mock response must not set harness-owned header {header:?}",
-                    path.display()
-                )));
-            }
-        }
-        for (header, value) in &exchange.response.headers {
-            if value.contains('\r') || value.contains('\n') {
-                return Err(HarnessError::new(format!(
-                    "{} mock response header {header:?} contains a line break",
-                    path.display()
-                )));
-            }
+        if value.contains('\r') || value.contains('\n') {
+            return Err(HarnessError::new(format!(
+                "{} mock response header {header:?} contains a line break",
+                path.display()
+            )));
         }
     }
+    Ok(())
+}
 
-    for normalization in &case.normalizations {
+fn validate_normalizations(
+    normalizations: &[Normalization],
+    capture_headers: &BTreeSet<String>,
+    path: &Path,
+) -> Result<()> {
+    for normalization in normalizations {
         match normalization {
             Normalization::RuntimeValue { targets, .. } if targets.is_empty() => {
                 return Err(HarnessError::new(format!(
@@ -408,7 +433,6 @@ fn validate_case(case: &Case, path: &Path) -> Result<()> {
             _ => {}
         }
     }
-
     Ok(())
 }
 

--- a/crates/zero-cli/tests/parity/README.md
+++ b/crates/zero-cli/tests/parity/README.md
@@ -10,6 +10,10 @@ The command builds the public TypeScript package artifact, builds the
 runner-bundled `zero-cli`, runs the harness self-tests, and then executes every
 case under `v1/cases/` against both executables.
 
+The checked-in help cases exercise both `pipe` and `pty`. A focused harness
+self-test also verifies that PTY stdin, stdout, and stderr independently report
+TTY status while preserving separate output capture.
+
 ## Execution boundary
 
 Each implementation runs as a child process with the same fixture-defined

--- a/crates/zero-cli/tests/parity/README.md
+++ b/crates/zero-cli/tests/parity/README.md
@@ -1,0 +1,84 @@
+# Zero CLI differential parity harness
+
+Run the complete local suite from the repository root:
+
+```bash
+crates/zero-cli/tests/parity/run.sh
+```
+
+The command builds the public TypeScript package artifact, builds the
+runner-bundled `zero-cli`, runs the harness self-tests, and then executes every
+case under `v1/cases/` against both executables.
+
+## Execution boundary
+
+Each implementation runs as a child process with the same fixture-defined
+arguments, environment, stdin, relative working directory, timeout, and
+terminal mode. `pipe` uses ordinary non-TTY streams. `pty` gives stdin, stdout,
+and stderr separate fixed-size pseudoterminals so both streams remain
+independently observable while reporting TTY status.
+
+Every implementation receives its own temporary root containing:
+
+- an independently materialized workspace;
+- isolated home, temporary, and cache directories;
+- a fresh mock HTTP server bound to loopback; and
+- an `npx` shim that preserves the Rust proxy's public process boundary while
+  executing the same built TypeScript package artifact without a registry
+  download.
+
+The harness does not import TypeScript functions or Rust implementation
+modules. `--typescript`, `--rust`, and `--cases` accept alternate executable and
+case paths, so generated inventory cases can use the same boundary later.
+
+## Version 1 case schema
+
+`v1/schema.json` is the authoritative JSON Schema. A case declares:
+
+- `argv`, `environment`, `stdin`, `workingDirectory`, `terminalMode`, and
+  `timeoutMs`;
+- ordered mock HTTP exchanges, including the exact expected method, raw path,
+  raw query, and request body plus the response to return;
+- the request headers to capture for differential comparison;
+- real filesystem seed entries (file, directory, or symlink) and Unix modes;
+  and
+- any narrowly scoped normalizations.
+
+The complete workspace tree is snapshotted after each execution. Snapshots
+compare relative paths, entry type, Unix permission bits, file bytes, and
+symlink targets. Filesystem timestamps and temporary-root names are never part
+of the observation.
+
+## Compared parity dimensions
+
+Comparison is exact by default across:
+
+- stdout and stderr bytes;
+- exit code and terminating signal;
+- ordered HTTP method, path, raw query, body bytes, and selected headers; and
+- the post-execution filesystem snapshot.
+
+Mock exchanges are also checked against their expected request shape before
+the TypeScript-versus-Rust comparison, so two equally incorrect requests do not
+silently pass a fixture.
+
+Mismatch output names the case and dimension, reports the first differing byte
+with bounded context, and lists per-request and per-path differences. Values of
+the `authorization` header are compared but redacted from diagnostics.
+Fixtures must use synthetic credentials and payload data; never place a real
+token or secret in a case.
+
+## Narrow normalization
+
+Schema v1 supports only two explicit normalization forms:
+
+- `runtime-value` replaces one harness-generated value (workspace, mock URL,
+  home, or temporary path) in named text-bearing dimensions. A declaration
+  fails if it does not match anything.
+- `uuid-http-header` validates UUID-valued captured headers and replaces them
+  with stable identity-preserving placeholders. A declaration fails if the
+  header is absent or not a UUID.
+
+There is no general regular-expression, whitespace, ANSI, ordering, or JSON
+normalization. Add a normalizer only when a case demonstrates an unavoidable
+nondeterministic value.

--- a/crates/zero-cli/tests/parity/run.sh
+++ b/crates/zero-cli/tests/parity/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/../../../.." && pwd)
+typescript_bin="$repo_root/turbo/apps/cli/dist/zero.js"
+rust_bin="$repo_root/crates/target/debug/zero-cli"
+cases_dir="$script_dir/v1/cases"
+
+pnpm --dir "$repo_root/turbo" --filter @vm0/cli build
+chmod +x "$typescript_bin"
+
+cargo build --manifest-path "$repo_root/crates/Cargo.toml" -p zero-cli --bin zero-cli
+cargo test --manifest-path "$repo_root/crates/Cargo.toml" -p zero-cli --example parity
+cargo run --manifest-path "$repo_root/crates/Cargo.toml" -p zero-cli --example parity -- \
+  --typescript "$typescript_bin" \
+  --rust "$rust_bin" \
+  --cases "$cases_dir"

--- a/crates/zero-cli/tests/parity/v1/cases/help-pipe.json
+++ b/crates/zero-cli/tests/parity/v1/cases/help-pipe.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../schema.json",
+  "schemaVersion": 1,
+  "name": "help-pipe",
+  "description": "top-level help through non-TTY streams",
+  "argv": ["--help"],
+  "environment": {},
+  "stdin": "",
+  "workingDirectory": ".",
+  "terminalMode": "pipe",
+  "timeoutMs": 10000,
+  "mockHttp": {
+    "captureHeaders": [],
+    "exchanges": []
+  },
+  "filesystem": {
+    "seed": [
+      {
+        "kind": "file",
+        "path": "input/unchanged.txt",
+        "content": "seeded fixture\n",
+        "mode": 420
+      }
+    ]
+  },
+  "normalizations": []
+}

--- a/crates/zero-cli/tests/parity/v1/cases/help-pty.json
+++ b/crates/zero-cli/tests/parity/v1/cases/help-pty.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../schema.json",
+  "schemaVersion": 1,
+  "name": "help-pty",
+  "description": "top-level help through fixed-size TTY streams",
+  "argv": ["--help"],
+  "environment": {},
+  "stdin": "",
+  "workingDirectory": ".",
+  "terminalMode": "pty",
+  "timeoutMs": 10000,
+  "mockHttp": {
+    "captureHeaders": [],
+    "exchanges": []
+  },
+  "filesystem": {
+    "seed": []
+  },
+  "normalizations": []
+}

--- a/crates/zero-cli/tests/parity/v1/cases/http-error.json
+++ b/crates/zero-cli/tests/parity/v1/cases/http-error.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "../schema.json",
+  "schemaVersion": 1,
+  "name": "http-error",
+  "description": "HTTP request construction and API error process forwarding",
+  "argv": ["model", "ls"],
+  "environment": {
+    "ZERO_TOKEN": "parity-test-token"
+  },
+  "stdin": "",
+  "workingDirectory": ".",
+  "terminalMode": "pipe",
+  "timeoutMs": 10000,
+  "mockHttp": {
+    "captureHeaders": [
+      "authorization",
+      "x-client-request-id",
+      "x-client-session-id",
+      "x-client-type",
+      "x-client-version"
+    ],
+    "exchanges": [
+      {
+        "request": {
+          "method": "GET",
+          "path": "/api/zero/model-policies",
+          "query": "",
+          "body": ""
+        },
+        "response": {
+          "status": 500,
+          "headers": {
+            "content-type": "application/json"
+          },
+          "body": "{\"error\":{\"code\":\"PARITY_FIXTURE_ERROR\",\"message\":\"fixture failure\"}}"
+        }
+      }
+    ]
+  },
+  "filesystem": {
+    "seed": []
+  },
+  "normalizations": [
+    {
+      "kind": "uuid-http-header",
+      "header": "x-client-session-id"
+    },
+    {
+      "kind": "uuid-http-header",
+      "header": "x-client-request-id"
+    }
+  ]
+}

--- a/crates/zero-cli/tests/parity/v1/cases/intro.json
+++ b/crates/zero-cli/tests/parity/v1/cases/intro.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../schema.json",
+  "schemaVersion": 1,
+  "name": "intro",
+  "description": "agent-facing Zero introduction output",
+  "argv": ["intro"],
+  "environment": {},
+  "stdin": "",
+  "workingDirectory": ".",
+  "terminalMode": "pipe",
+  "timeoutMs": 10000,
+  "mockHttp": {
+    "captureHeaders": [],
+    "exchanges": []
+  },
+  "filesystem": {
+    "seed": []
+  },
+  "normalizations": []
+}

--- a/crates/zero-cli/tests/parity/v1/cases/unknown-command.json
+++ b/crates/zero-cli/tests/parity/v1/cases/unknown-command.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../schema.json",
+  "schemaVersion": 1,
+  "name": "unknown-command",
+  "description": "unknown command stderr and non-zero process status",
+  "argv": ["parity-command-that-does-not-exist"],
+  "environment": {},
+  "stdin": "ignored input\n",
+  "workingDirectory": ".",
+  "terminalMode": "pipe",
+  "timeoutMs": 10000,
+  "mockHttp": {
+    "captureHeaders": [],
+    "exchanges": []
+  },
+  "filesystem": {
+    "seed": []
+  },
+  "normalizations": []
+}

--- a/crates/zero-cli/tests/parity/v1/cases/variable-set-body.json
+++ b/crates/zero-cli/tests/parity/v1/cases/variable-set-body.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "../schema.json",
+  "schemaVersion": 1,
+  "name": "variable-set-body",
+  "description": "JSON request body, content headers, and successful process output",
+  "argv": [
+    "variable",
+    "set",
+    "PARITY_VALUE",
+    "two words",
+    "--description",
+    "fixture description"
+  ],
+  "environment": {
+    "ZERO_TOKEN": "parity-test-token"
+  },
+  "stdin": "",
+  "workingDirectory": ".",
+  "terminalMode": "pipe",
+  "timeoutMs": 10000,
+  "mockHttp": {
+    "captureHeaders": [
+      "authorization",
+      "content-type",
+      "x-client-request-id",
+      "x-client-session-id",
+      "x-client-type",
+      "x-client-version"
+    ],
+    "exchanges": [
+      {
+        "request": {
+          "method": "POST",
+          "path": "/api/zero/variables",
+          "query": "",
+          "body": "{\"name\":\"PARITY_VALUE\",\"value\":\"two words\",\"description\":\"fixture description\"}"
+        },
+        "response": {
+          "status": 201,
+          "headers": {
+            "content-type": "application/json"
+          },
+          "body": "{\"id\":\"00000000-0000-4000-8000-000000000001\",\"name\":\"PARITY_VALUE\",\"value\":\"two words\",\"description\":\"fixture description\",\"createdAt\":\"2026-01-01T00:00:00.000Z\",\"updatedAt\":\"2026-01-01T00:00:00.000Z\"}"
+        }
+      }
+    ]
+  },
+  "filesystem": {
+    "seed": []
+  },
+  "normalizations": [
+    {
+      "kind": "uuid-http-header",
+      "header": "x-client-session-id"
+    },
+    {
+      "kind": "uuid-http-header",
+      "header": "x-client-request-id"
+    }
+  ]
+}

--- a/crates/zero-cli/tests/parity/v1/cases/whoami-runtime-url.json
+++ b/crates/zero-cli/tests/parity/v1/cases/whoami-runtime-url.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../schema.json",
+  "schemaVersion": 1,
+  "name": "whoami-runtime-url",
+  "description": "local identity output with an isolated runtime API origin",
+  "argv": ["whoami"],
+  "environment": {},
+  "stdin": "",
+  "workingDirectory": ".",
+  "terminalMode": "pipe",
+  "timeoutMs": 10000,
+  "mockHttp": {
+    "captureHeaders": [],
+    "exchanges": []
+  },
+  "filesystem": {
+    "seed": []
+  },
+  "normalizations": [
+    {
+      "kind": "runtime-value",
+      "value": "mock-http-url",
+      "targets": ["stdout"]
+    }
+  ]
+}

--- a/crates/zero-cli/tests/parity/v1/schema.json
+++ b/crates/zero-cli/tests/parity/v1/schema.json
@@ -1,0 +1,286 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vm0.ai/schemas/zero-cli-parity-case-v1.json",
+  "title": "Zero CLI parity case v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schemaVersion",
+    "name",
+    "description",
+    "argv",
+    "environment",
+    "stdin",
+    "workingDirectory",
+    "terminalMode",
+    "timeoutMs",
+    "mockHttp",
+    "filesystem",
+    "normalizations"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "../schema.json"
+    },
+    "schemaVersion": {
+      "const": 1
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "argv": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "stdin": {
+      "type": "string"
+    },
+    "workingDirectory": {
+      "type": "string",
+      "minLength": 1
+    },
+    "terminalMode": {
+      "enum": ["pipe", "pty"]
+    },
+    "timeoutMs": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "mockHttp": {
+      "$ref": "#/$defs/mockHttp"
+    },
+    "filesystem": {
+      "$ref": "#/$defs/filesystem"
+    },
+    "normalizations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/normalization"
+      }
+    }
+  },
+  "$defs": {
+    "mockHttp": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["captureHeaders", "exchanges"],
+      "properties": {
+        "captureHeaders": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9!#$%&'*+.^_`|~-]+$"
+          }
+        },
+        "exchanges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/httpExchange"
+          }
+        }
+      }
+    },
+    "httpExchange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["request", "response"],
+      "properties": {
+        "request": {
+          "$ref": "#/$defs/expectedRequest"
+        },
+        "response": {
+          "$ref": "#/$defs/mockResponse"
+        }
+      }
+    },
+    "expectedRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["method", "path", "query", "body"],
+      "properties": {
+        "method": {
+          "type": "string",
+          "pattern": "^[A-Z]+$"
+        },
+        "path": {
+          "type": "string",
+          "pattern": "^/"
+        },
+        "query": {
+          "type": "string",
+          "pattern": "^[^?].*$|^$"
+        },
+        "body": {
+          "type": "string"
+        }
+      }
+    },
+    "mockResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "headers", "body"],
+      "properties": {
+        "status": {
+          "type": "integer",
+          "minimum": 100,
+          "maximum": 599
+        },
+        "headers": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^[A-Za-z0-9!#$%&'*+.^_`|~-]+$"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "pattern": "^[^\\r\\n]*$"
+          }
+        },
+        "body": {
+          "type": "string"
+        }
+      }
+    },
+    "filesystem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["seed"],
+      "properties": {
+        "seed": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/seedEntry"
+          }
+        }
+      }
+    },
+    "seedEntry": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "path", "content", "mode"],
+          "properties": {
+            "kind": {
+              "const": "file"
+            },
+            "path": {
+              "$ref": "#/$defs/relativePath"
+            },
+            "content": {
+              "type": "string"
+            },
+            "mode": {
+              "$ref": "#/$defs/unixMode"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "path", "mode"],
+          "properties": {
+            "kind": {
+              "const": "directory"
+            },
+            "path": {
+              "$ref": "#/$defs/relativePath"
+            },
+            "mode": {
+              "$ref": "#/$defs/unixMode"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "path", "target"],
+          "properties": {
+            "kind": {
+              "const": "symlink"
+            },
+            "path": {
+              "$ref": "#/$defs/relativePath"
+            },
+            "target": {
+              "$ref": "#/$defs/relativePath"
+            }
+          }
+        }
+      ]
+    },
+    "relativePath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+    },
+    "unixMode": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 4095
+    },
+    "normalization": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "value", "targets"],
+          "properties": {
+            "kind": {
+              "const": "runtime-value"
+            },
+            "value": {
+              "enum": [
+                "workspace-path",
+                "mock-http-url",
+                "home-path",
+                "temp-path"
+              ]
+            },
+            "targets": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "enum": [
+                  "stdout",
+                  "stderr",
+                  "http-request-body",
+                  "filesystem-file-content"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "header"],
+          "properties": {
+            "kind": {
+              "const": "uuid-http-header"
+            },
+            "header": {
+              "type": "string",
+              "pattern": "^[a-z0-9!#$%&'*+.^_`|~-]+$"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add an executable-only differential harness for the built TypeScript `zero` package artifact and runner-bundled Rust `zero-cli`
- give every implementation an isolated but equivalent environment with independent mock HTTP, workspace, home, cache, temporary directories, and terminal plumbing
- add version 1 JSON fixtures and schema for argv, environment, stdin, working directory, terminal mode, ordered HTTP exchanges, filesystem seeds, and explicit normalization
- compare stdout, stderr, exit code/signal, ordered HTTP method/path/query/body/selected headers, and post-run filesystem type/mode/content/symlink state
- add bounded CI mismatch diagnostics, self-tests for intentional mismatches, and a targeted cross-language parity job

The harness uses only public executable boundaries. The isolated `npx` shim preserves the current Rust proxy path while executing the same built TypeScript package artifact without registry downloads. No CLI production behavior, native business command, rollout selection, runtime module, or generated contract changes are included.

## Fixture schema

Schema v1 lives at `crates/zero-cli/tests/parity/v1/schema.json`; hand-authored cases live under `v1/cases`. The harness also accepts `--cases`, `--typescript`, and `--rust`, so later generated surface-inventory cases can use the same implementation-independent format.

Exact comparison is the default. The only v1 normalizers are declared runtime-value replacement on named text dimensions and validated UUID replacement for named captured HTTP headers. Unused, missing, or invalid normalization declarations fail the case.

## Initial cases

- top-level help
- unknown command stderr/status with piped stdin
- `intro`
- `whoami` with isolated-origin normalization
- model-list API error forwarding with request/header capture
- variable-set success with exact JSON request body and response handling

## Validation

- `cargo fmt --all -- --check`
- `bash -n crates/zero-cli/tests/parity/run.sh`
- workflow YAML and fixture JSON parsing
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo clippy -p zero-cli --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p zero-cli --all-features --no-deps`
- `cargo test -p zero-cli --all-targets --all-features` (existing proxy test plus 4 harness self-tests)
- `crates/zero-cli/tests/parity/run.sh` (TypeScript package build plus all 6 differential cases)

Closes #24971
Part of #24878
Foundation: #24907
