### PR TITLE
refactor: stop writing goal contexts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1910,14 +1910,14 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     const admittedContext = await readChatEventContextFixture(goalEventId);
     const rejectedContext = await readChatEventContextFixture(rejected.id);
     expect(admittedContext).toMatchObject({
-      contextType: "goal",
-      contextId: expect.any(String),
-      goalObjectiveBrief: objectiveBrief,
+      contextType: null,
+      contextId: null,
+      goalObjectiveBrief: null,
     });
     expect(rejectedContext).toMatchObject({
-      contextType: "goal",
-      contextId: admittedContext?.contextId,
-      goalObjectiveBrief: objectiveBrief,
+      contextType: null,
+      contextId: null,
+      goalObjectiveBrief: null,
     });
     await expect(goalRunIds(first.threadId)).resolves.toHaveLength(0);
   }, 90_000);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -304,14 +304,14 @@ describe("zero goals", () => {
       claimedGoalEvent.id,
     );
     expect(admittedContext).toMatchObject({
-      contextType: "goal",
-      contextId: expect.any(String),
-      goalObjectiveBrief: "bootstrap autonomously",
+      contextType: null,
+      contextId: null,
+      goalObjectiveBrief: null,
     });
     expect(claimedContext).toMatchObject({
-      contextType: "goal",
-      contextId: admittedContext?.contextId,
-      goalObjectiveBrief: "bootstrap autonomously",
+      contextType: null,
+      contextId: null,
+      goalObjectiveBrief: null,
     });
     expect(state.runIds).toHaveLength(1);
 
@@ -388,6 +388,13 @@ describe("zero goals", () => {
       },
       seqId: expect.any(Number),
       createdAt: expect.any(String),
+    });
+    await expect(
+      readChatEventContextFixture(admission.eventId),
+    ).resolves.toMatchObject({
+      contextType: null,
+      contextId: null,
+      goalObjectiveBrief: null,
     });
     await expect(
       chat.getThreadEvent(fixture.actor, fixture.threadId, admission.eventId),

--- a/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
@@ -95,7 +95,6 @@ export async function admitGoalQueueEvent(
           goalBrief: args.objectiveBrief,
         },
       }),
-      goalBrief: args.objectiveBrief,
     });
     if (!inserted) {
       throw new Error("Goal queue event insert returned no row");

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -17,7 +17,6 @@ import {
 } from "@vm0/db/schema/chat-event";
 import { chatFeishuContext } from "@vm0/db/schema/chat-feishu-context";
 import { chatGithubContext } from "@vm0/db/schema/chat-github-context";
-import { chatGoalContext } from "@vm0/db/schema/chat-goal-context";
 import { chatMorningBriefContext } from "@vm0/db/schema/chat-morning-brief-context";
 import { chatSlackContext } from "@vm0/db/schema/chat-slack-context";
 import { chatTeamsContext } from "@vm0/db/schema/chat-teams-context";
@@ -241,7 +240,6 @@ type InputGoalEvent = ChatEventIdentity &
     readonly eventType: "input.goal";
     readonly content?: null;
     readonly runGroupId: string;
-    readonly goalBrief: string;
   };
 
 type InputRejectedEvent = ChatEventIdentity &
@@ -532,12 +530,6 @@ type NewDisplayContext =
       readonly triggerBrief: string | null;
     }
   | {
-      readonly type: "goal";
-      readonly id: string;
-      readonly chatThreadId: string;
-      readonly objectiveBrief: string;
-    }
-  | {
       readonly type: "morning_brief";
       readonly id: string;
       readonly chatThreadId: string;
@@ -669,16 +661,6 @@ function newDisplayContext(
   const automationContext = newAutomationDisplayContext(eventId, values);
   if (automationContext !== undefined) {
     return automationContext;
-  }
-
-  const goalBrief = "goalBrief" in values ? values.goalBrief : undefined;
-  if (goalBrief !== undefined) {
-    return {
-      type: "goal",
-      id: eventId,
-      chatThreadId: values.chatThreadId,
-      objectiveBrief: goalBrief,
-    };
   }
 
   return undefined;
@@ -894,12 +876,6 @@ async function insertDisplayContext(
   if (context.type === "morning_brief") {
     return insertMorningBriefContext(tx, context, createdAt);
   }
-  await tx.insert(chatGoalContext).values({
-    id: context.id,
-    chatThreadId: context.chatThreadId,
-    objectiveBrief: context.objectiveBrief,
-    createdAt,
-  });
 }
 
 function persistedChatEventValues(
@@ -908,12 +884,8 @@ function persistedChatEventValues(
     Pick<ChatEventInsert, "id" | "contextType" | "contextId">
   >,
 ): PersistedChatEvent {
-  const { goalBrief: _goalBrief, ...persistedValues } = {
-    goalBrief: undefined,
-    ...values,
-  };
   return {
-    ...persistedValues,
+    ...values,
     ...overrides,
     ...(values.eventType === "input.prompt" ||
     values.eventType === "input.rejected" ||


### PR DESCRIPTION
## Summary

- stop passing the duplicate `goalBrief` writer-only field when admitting `input.goal`
- remove the goal display-context variant and its `chat_goal_context` insert
- leave the goal brief frozen in `user_message.parts[]`, while new goal events and their replacement events carry `context_type = context_id = NULL`
- update entry-point integration coverage for admission, normal claim, and rejection

This is PR 2 of the four-PR rollout in #24932. It changes writers only. It contains no migration, historical pointer cleanup, schema deletion, reader change, API change, or client rendering change.

## Validation

- `pnpm exec prettier --check` on all changed files
- `pnpm -F api check-types`
- focused basic and type-aware Oxlint on all changed files
- focused ESLint on all changed files with zero warnings
- `pnpm knip --workspace api`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test_24932_ecc5 pnpm -F api exec vitest run src/signals/routes/__tests__/zero-goals.test.ts -t "returns an unclaimed input.goal event without its server-side queue fields" --maxWorkers=1 --silent=passed-only` (passed)
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test_24932_ecc5 pnpm -F api exec vitest run src/signals/routes/__tests__/zero-goals.test.ts -t "bootstraps a provisioned goal thread through a claimed input.goal event" --maxWorkers=1 --silent=passed-only` (passed)

The focused rejection test was attempted locally, but stopped before the changed path because the initial ordinary runner claim returned `404 Job not found in queue` at `claimChatRunJob`. This is the same local runner-queue condition recorded on PR 1 and on unmodified main during #24877. Full PR CI passed.

## Rollout observation

- PR merged: **2026-08-04 08:58:08 UTC**, merge commit `74e53cf246cacdf0c5eaabba449782a95c509927`
- production release PR: #24975 merged at **2026-08-04 09:13:17 UTC**, merge commit `12d4a8904d97cb517921464f04858001f0040c1f`
- production pipeline: [release-please run 30895361175](https://github.com/vm0-ai/vm0/actions/runs/30895361175) completed successfully at **2026-08-04 09:28:34 UTC**
- observation window: **2026-08-04 09:28:34–09:38:34 UTC** (10 minutes)
- writer gate: 21 new `input.goal` rows; all 21 had `context_type IS NULL` and all 21 had `context_id IS NULL`
- context-row gate: `chat_goal_context` stayed at **16,983** rows from start to finish; 0 rows were created during the window
- live PR 3 input: **19,249** historical `chat_events.context_type = 'goal'` pointers remain, including terminal rows that inherited the pointer
- traffic: 15,213 production HTTP requests; the only 5xx was one unrelated `/api/zero/scrape` request
- affected signals: 0 `Orphaned queued chat messages detected` and 0 `Goal queue event is missing its user message`; Axiom queries were complete with no warnings
- unrelated errors: three runner errors correlated to ordinary web runs with `run_group_id = NULL`, not goal continuations

PR 3 starts only after this successful release and observation window.

Part of #24932.