### PR TITLE
refactor(rust): centralize guest exec terminal budget

### DIFF
--- a/crates/guest-contracts/src/exec_terminal.rs
+++ b/crates/guest-contracts/src/exec_terminal.rs
@@ -1,0 +1,31 @@
+//! Shared guest exec terminal-cleanup budgets.
+
+use std::time::Duration;
+
+/// Graceful wait after signaling contained descendants with `SIGTERM`.
+pub const EXEC_PROCESS_CONTAINMENT_TERM_GRACE: Duration = Duration::from_millis(500);
+
+/// Maximum wait for a contained cgroup to become empty after `cgroup.kill`.
+pub const EXEC_PROCESS_CONTAINMENT_KILL_EMPTY_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Maximum retry window for removing an empty exec cgroup.
+pub const EXEC_PROCESS_CONTAINMENT_REMOVE_TIMEOUT: Duration = Duration::from_millis(250);
+
+/// Maximum time to drain a guest-managed child's stdout/stderr after exit.
+pub const EXEC_OUTPUT_DRAIN_DEADLINE: Duration = Duration::from_secs(5);
+
+/// Maximum configured wait budget before a guest exec terminal result is built.
+///
+/// This conservatively includes the graceful containment path followed by the
+/// output-drain deadline. Forced cancellation and timeout cleanup skip
+/// [`EXEC_PROCESS_CONTAINMENT_TERM_GRACE`]. Scheduling, syscall, drain-poll,
+/// and terminal-frame delivery latency are not part of this configured budget.
+pub const EXEC_TERMINAL_CLEANUP_BUDGET: Duration = EXEC_PROCESS_CONTAINMENT_TERM_GRACE
+    .saturating_add(EXEC_PROCESS_CONTAINMENT_KILL_EMPTY_TIMEOUT)
+    .saturating_add(EXEC_PROCESS_CONTAINMENT_REMOVE_TIMEOUT)
+    .saturating_add(EXEC_OUTPUT_DRAIN_DEADLINE);
+
+const _: () = assert!(
+    EXEC_TERMINAL_CLEANUP_BUDGET.as_millis() == 6_750,
+    "guest exec terminal cleanup budget changed; review runner host grace"
+);

--- a/crates/guest-contracts/src/exec_terminal.rs
+++ b/crates/guest-contracts/src/exec_terminal.rs
@@ -26,6 +26,6 @@ pub const EXEC_TERMINAL_CLEANUP_BUDGET: Duration = EXEC_PROCESS_CONTAINMENT_TERM
     .saturating_add(EXEC_OUTPUT_DRAIN_DEADLINE);
 
 const _: () = assert!(
-    EXEC_TERMINAL_CLEANUP_BUDGET.as_millis() == 6_750,
+    EXEC_TERMINAL_CLEANUP_BUDGET.as_nanos() == 6_750_000_000,
     "guest exec terminal cleanup budget changed; review runner host grace"
 );

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -10,6 +10,7 @@ pub mod codex_thread_id;
 pub mod diagnostics;
 pub mod env;
 pub mod exec_limits;
+pub mod exec_terminal;
 pub mod process_containment;
 pub mod reuse_preparation;
 pub mod runtime_paths;

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -92,11 +92,11 @@ const PROCESS_CANCEL_TERMINAL_HOST_SLACK: Duration = Duration::from_millis(1_250
 const PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT: Duration =
     EXEC_TERMINAL_CLEANUP_BUDGET.saturating_add(PROCESS_CANCEL_TERMINAL_HOST_SLACK);
 const _: () = assert!(
-    JOB_TERMINAL_GRACE_TIMEOUT.as_millis() == 10_000,
+    JOB_TERMINAL_GRACE_TIMEOUT.as_nanos() == 10_000_000_000,
     "job terminal grace changed; review guest cleanup and host slack"
 );
 const _: () = assert!(
-    PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT.as_millis() == 8_000,
+    PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT.as_nanos() == 8_000_000_000,
     "process cancellation terminal grace changed; review guest cleanup and host slack"
 );
 const PROCESS_CANCEL_TIMEOUTS: ProcessCancelTimeouts = ProcessCancelTimeouts {

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -69,6 +69,7 @@ use api_contracts::generated::constants::runners::{
     RUNNER_CANCELLATION_RECOVERY_GRACE_MS,
     paths::{CANONICAL_GUEST_HOME_DIR, CANONICAL_WORKING_DIR},
 };
+use guest_contracts::exec_terminal::EXEC_TERMINAL_CLEANUP_BUDGET;
 
 /// Maximum guest-side runtime budget for a single agent process (2 hours).
 const JOB_TIMEOUT: Duration = Duration::from_secs(7200);
@@ -79,20 +80,25 @@ const JOB_TIMEOUT_EXIT_CODE: i32 = guest_contracts::diagnostics::AGENT_EXECUTION
 /// plus a full presigned-upload timeout without letting an unavailable backend
 /// hold runner capacity indefinitely.
 const JOB_FINALIZATION_GRACE_TIMEOUT: Duration = Duration::from_secs(90);
-/// Extra time for the host to receive guest timeout terminal proof.
-///
-/// The sandbox supervisor receives the execution budget plus finalization
-/// grace. This additional host grace covers vsock-guest's bounded
-/// supervised-process cleanup, its 5s stdout/stderr drain deadline, and normal
-/// scheduling overhead before it sends terminal proof.
-const JOB_TERMINAL_GRACE_TIMEOUT: Duration = Duration::from_secs(10);
+/// Host-owned allowance beyond guest terminal cleanup for scheduling,
+/// observation, and terminal proof delivery after the supervisor timeout.
+const JOB_TERMINAL_HOST_SLACK: Duration = Duration::from_millis(3_250);
+const JOB_TERMINAL_GRACE_TIMEOUT: Duration =
+    EXEC_TERMINAL_CLEANUP_BUDGET.saturating_add(JOB_TERMINAL_HOST_SLACK);
 /// Maximum time to spend writing a guest control or cancellation frame.
 const PROCESS_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
-/// Grace period for the guest to report a terminal status after cancel is sent.
-/// This covers vsock-guest's bounded supervised-process cleanup (500ms TERM
-/// grace, 1s cgroup.kill empty wait, and 250ms cgroup removal), its 5s
-/// stdout/stderr drain deadline, and normal scheduling overhead.
-const PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT: Duration = Duration::from_secs(8);
+/// Host-owned allowance beyond guest terminal cleanup after cancel is sent.
+const PROCESS_CANCEL_TERMINAL_HOST_SLACK: Duration = Duration::from_millis(1_250);
+const PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT: Duration =
+    EXEC_TERMINAL_CLEANUP_BUDGET.saturating_add(PROCESS_CANCEL_TERMINAL_HOST_SLACK);
+const _: () = assert!(
+    JOB_TERMINAL_GRACE_TIMEOUT.as_millis() == 10_000,
+    "job terminal grace changed; review guest cleanup and host slack"
+);
+const _: () = assert!(
+    PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT.as_millis() == 8_000,
+    "process cancellation terminal grace changed; review guest cleanup and host slack"
+);
 const PROCESS_CANCEL_TIMEOUTS: ProcessCancelTimeouts = ProcessCancelTimeouts {
     write: PROCESS_CANCEL_WRITE_TIMEOUT,
     terminal_grace: PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT,

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use guest_contracts::exec_terminal::EXEC_OUTPUT_DRAIN_DEADLINE;
 use vsock_proto::{
     self, BorrowedRawMessage, DecodeWithError, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL, MSG_EXEC_START,
     MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_QUIESCE_OPERATIONS, MSG_READY,
@@ -24,7 +25,6 @@ use crate::handlers::{
 use crate::log::log;
 use crate::process_containment::{ProcessContainmentMode, verify_exec_process_containment_empty};
 use crate::quiesce::{AcquireOperationError, OperationGuard, OperationState, QuiesceResult};
-use crate::wait::DRAIN_DEADLINE;
 use crate::writer::GuestWriter;
 
 // Vsock constants (only used on Linux)
@@ -596,7 +596,7 @@ fn handle_connection_with_mode(
     handle_connection_with_mode_and_exec_drain_deadline(
         stream,
         process_containment_mode,
-        DRAIN_DEADLINE,
+        EXEC_OUTPUT_DRAIN_DEADLINE,
     )
 }
 
@@ -785,7 +785,11 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                 .map_err(unstable_connection_failure)
                 .and_then(|stream| {
                     log("INFO", "Connected");
-                    handle_connection_with_outcome(stream, process_containment_mode, DRAIN_DEADLINE)
+                    handle_connection_with_outcome(
+                        stream,
+                        process_containment_mode,
+                        EXEC_OUTPUT_DRAIN_DEADLINE,
+                    )
                 })
         } else {
             log("INFO", "Connecting to host (CID=2)...");
@@ -793,7 +797,11 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                 .map_err(unstable_connection_failure)
                 .and_then(|stream| {
                     log("INFO", "Connected");
-                    handle_connection_with_outcome(stream, process_containment_mode, DRAIN_DEADLINE)
+                    handle_connection_with_outcome(
+                        stream,
+                        process_containment_mode,
+                        EXEC_OUTPUT_DRAIN_DEADLINE,
+                    )
                 })
         };
 

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -49,6 +49,8 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
+#[cfg(test)]
+use guest_contracts::exec_terminal::EXEC_OUTPUT_DRAIN_DEADLINE;
 use vsock_proto::{
     self, ExecCapturedOutput, ExecControlNonce, ExecControlPolicy, ExecLifecyclePolicy,
     ExecOutputPolicy, ExecOutputStream, ExecTermination, ExecTimeoutPolicy, MSG_ERROR,
@@ -1720,7 +1722,7 @@ mod tests {
             exec_control_guard: None,
             exec_control_bootstrap_endpoint: None,
             process_containment_mode: ProcessContainmentMode::BuildConfigured,
-            drain_deadline: crate::wait::DRAIN_DEADLINE,
+            drain_deadline: EXEC_OUTPUT_DRAIN_DEADLINE,
         }
     }
 

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 
+use guest_contracts::exec_terminal::EXEC_OUTPUT_DRAIN_DEADLINE;
 use vsock_proto::{
     self, BorrowedRawMessage, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_WRITE_FILE_RESULT,
     MSG_WRITE_FILES_RESULT,
@@ -19,8 +20,7 @@ use crate::shutdown::handle_shutdown;
 use crate::threading::{SystemThreadSpawner, ThreadSpawner, spawn_scoped_named};
 use crate::user::apply_write_file_identity;
 use crate::wait::{
-    DRAIN_DEADLINE, WaitOutcome, await_drain_deadline,
-    wait_with_kill_timeout_or_connection_cancelled,
+    WaitOutcome, await_drain_deadline, wait_with_kill_timeout_or_connection_cancelled,
 };
 
 const THREAD_WRITE_STDERR: &str = "vsock-write-stderr";
@@ -176,7 +176,7 @@ where
             Err(e) => {
                 cancel.store(true, std::sync::atomic::Ordering::Release);
                 kill_and_reap_child(child);
-                let _ = await_drain_deadline(&done_rx, 1, &cancel, DRAIN_DEADLINE);
+                let _ = await_drain_deadline(&done_rx, 1, &cancel, EXEC_OUTPUT_DRAIN_DEADLINE);
                 let _ = stderr_handle.join();
                 return (false, format!("Failed to spawn stdin writer thread: {e}"));
             }
@@ -198,7 +198,7 @@ where
             Err(panic) => std::panic::resume_unwind(panic),
         };
 
-        let _ = await_drain_deadline(&done_rx, 1, &cancel, DRAIN_DEADLINE);
+        let _ = await_drain_deadline(&done_rx, 1, &cancel, EXEC_OUTPUT_DRAIN_DEADLINE);
         let stderr = stderr_handle.join().unwrap_or_default();
 
         match outcome {

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -9,6 +9,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use guest_contracts::exec_terminal::{
+    EXEC_PROCESS_CONTAINMENT_KILL_EMPTY_TIMEOUT, EXEC_PROCESS_CONTAINMENT_REMOVE_TIMEOUT,
+    EXEC_PROCESS_CONTAINMENT_TERM_GRACE,
+};
 use guest_contracts::process_containment::{EXEC_CGROUP_BASE_PATH, EXEC_CGROUP_NAME_PREFIX};
 
 use crate::log::log;
@@ -17,9 +21,6 @@ const CGROUP_EVENTS_FILE: &str = "cgroup.events";
 const CGROUP_KILL_FILE: &str = "cgroup.kill";
 const CGROUP_PROCS_FILE: &str = "cgroup.procs";
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
-const TERM_GRACE: Duration = Duration::from_millis(500);
-const KILL_EMPTY_TIMEOUT: Duration = Duration::from_secs(1);
-const REMOVE_TIMEOUT: Duration = Duration::from_millis(250);
 
 static NEXT_CGROUP_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -307,7 +308,7 @@ fn cleanup_cgroup(
             }
         }
 
-        if let Err(error) = wait_until_empty(group_path, TERM_GRACE) {
+        if let Err(error) = wait_until_empty(group_path, EXEC_PROCESS_CONTAINMENT_TERM_GRACE) {
             log(
                 "WARN",
                 &format!(
@@ -337,7 +338,7 @@ fn cleanup_cgroup(
         fs::write(group_path.join(CGROUP_KILL_FILE), b"1")
             .map_err(|error| ProcessContainmentError::new("write cgroup.kill", error))?;
         cgroup_kill_used = true;
-        if !wait_until_empty(group_path, KILL_EMPTY_TIMEOUT)? {
+        if !wait_until_empty(group_path, EXEC_PROCESS_CONTAINMENT_KILL_EMPTY_TIMEOUT)? {
             return Err(ProcessContainmentError::new(
                 "wait for cgroup.kill",
                 io::Error::new(
@@ -521,7 +522,7 @@ fn wait_until_empty(group_path: &Path, timeout: Duration) -> Result<bool, Proces
 }
 
 fn remove_empty_cgroup(group_path: &Path) -> Result<(), ProcessContainmentError> {
-    let deadline = Instant::now() + REMOVE_TIMEOUT;
+    let deadline = Instant::now() + EXEC_PROCESS_CONTAINMENT_REMOVE_TIMEOUT;
     loop {
         match fs::remove_dir(group_path) {
             Ok(()) => return Ok(()),

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -8,11 +8,6 @@ use std::time::{Duration, Instant};
 use crate::process::{kill_and_reap_child, kill_owned_child_process_group, process_signal_pid};
 use crate::threading::spawn_scoped_named;
 
-/// After the child process exits, continue draining stdout/stderr for this
-/// many seconds. If EOF is not received within this deadline, proceed to
-/// the terminal exec result anyway to prevent indefinite hangs when orphaned
-/// child processes hold pipe fds open.
-pub(crate) const DRAIN_DEADLINE: Duration = Duration::from_secs(5);
 const WAIT_CANCEL_POLL_INTERVAL_MS: u64 = 50;
 const THREAD_WAIT_OBSERVER: &str = "vsock-wait-observer";
 

--- a/crates/vsock-guest/tests/connection/exec_cancel_cleanup.rs
+++ b/crates/vsock-guest/tests/connection/exec_cancel_cleanup.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use guest_contracts::exec_terminal::EXEC_OUTPUT_DRAIN_DEADLINE;
 use vsock_proto::{
     self, ExecControlPolicy, ExecOutputPolicy, ExecOutputStream, ExecTermination,
     ExecTimeoutPolicy, MSG_ERROR, MSG_EXEC_CANCEL,
@@ -272,7 +273,9 @@ fn exec_operation_returns_when_orphaned_grandchild_holds_stdout() {
     let (handle, mut host_stream) =
         start_guest_connection_with_exec_drain_deadline(Duration::from_millis(500));
     host_stream
-        .set_read_timeout(Some(Duration::from_secs(DRAIN_DEADLINE_SECS + 5)))
+        .set_read_timeout(Some(
+            EXEC_OUTPUT_DRAIN_DEADLINE.saturating_add(Duration::from_secs(5)),
+        ))
         .unwrap();
     let orphan = OrphanProcessGuard::new("orphan-exec-operation-sleep");
     let command = orphan_sleep_command("orphan-exec-operation", orphan.pid_path());
@@ -296,7 +299,7 @@ fn exec_operation_returns_when_orphaned_grandchild_holds_stdout() {
         String::from_utf8_lossy(&stdout),
     );
     assert!(
-        elapsed < Duration::from_secs(DRAIN_DEADLINE_SECS),
+        elapsed < EXEC_OUTPUT_DRAIN_DEADLINE,
         "test exec result should arrive before the production drain deadline, took {elapsed:?}",
     );
 

--- a/crates/vsock-guest/tests/connection/exec_output.rs
+++ b/crates/vsock-guest/tests/connection/exec_output.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use guest_contracts::exec_terminal::EXEC_OUTPUT_DRAIN_DEADLINE;
 use vsock_proto::{ExecOutputPolicy, ExecOutputStream, ExecTermination};
 
 use super::exec_helpers::{EXEC_OPERATION_TIMEOUT_TEST_MS, read_exec_stdout_output};
@@ -354,7 +355,7 @@ fn exec_operation_captures_grandchild_output_before_drain_deadline() {
         "stderr-early\nstderr-late\n"
     );
     assert!(
-        elapsed < Duration::from_secs(DRAIN_DEADLINE_SECS),
+        elapsed < EXEC_OUTPUT_DRAIN_DEADLINE,
         "late output should be captured before drain deadline, took {elapsed:?}",
     );
 

--- a/crates/vsock-guest/tests/connection/exec_stdin.rs
+++ b/crates/vsock-guest/tests/connection/exec_stdin.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use guest_contracts::exec_terminal::EXEC_OUTPUT_DRAIN_DEADLINE;
 use vsock_proto::{
     self, ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy, ExecStartEncodeRequest,
     ExecTermination, ExecTimeoutPolicy,
@@ -129,7 +130,7 @@ fn exec_operation_returns_when_grandchild_holds_stdin_without_reading() {
     assert_eq!(result.stderr, Some(Vec::new()));
     assert!(result.diagnostic.is_empty());
     assert!(
-        elapsed < Duration::from_secs(DRAIN_DEADLINE_SECS),
+        elapsed < EXEC_OUTPUT_DRAIN_DEADLINE,
         "exec result should not wait for an inherited stdin pipe, took {elapsed:?}",
     );
     finish_guest_connection(handle, host_stream);

--- a/crates/vsock-guest/tests/connection/support/exec.rs
+++ b/crates/vsock-guest/tests/connection/support/exec.rs
@@ -5,7 +5,6 @@ use vsock_proto::{
     MSG_EXEC_CANCEL, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START,
 };
 
-pub(crate) const DRAIN_DEADLINE_SECS: u64 = 5;
 pub(crate) const LONG_RUNNING_EXEC_TIMEOUT_MS: u32 = 60_000;
 pub(crate) const LARGE_ENV_COMMAND: &str =
     "printf '%s:%s:%s:%s:%s\\n' \"$SMALL\" \"${#BIG_A}\" \"${#BIG_B}\" \"${#BIG_C}\" \"${#BIG_D}\"";

--- a/crates/vsock-guest/tests/connection/support/mod.rs
+++ b/crates/vsock-guest/tests/connection/support/mod.rs
@@ -11,10 +11,9 @@ pub(crate) use connection::{
     wait_for_guest_connection,
 };
 pub(crate) use exec::{
-    DRAIN_DEADLINE_SECS, LARGE_ENV_COMMAND, LONG_RUNNING_EXEC_TIMEOUT_MS, assert_large_env_stdout,
-    large_env_entries, large_env_values, read_exec_output_chunk, read_exec_result,
-    send_exec_cancel, send_exec_start, send_exec_start_request, send_exec_start_with_env,
-    stderr_data, stdout_data,
+    LARGE_ENV_COMMAND, LONG_RUNNING_EXEC_TIMEOUT_MS, assert_large_env_stdout, large_env_entries,
+    large_env_values, read_exec_output_chunk, read_exec_result, send_exec_cancel, send_exec_start,
+    send_exec_start_request, send_exec_start_with_env, stderr_data, stdout_data,
 };
 pub(crate) use process::{
     OrphanProcessGuard, ProcessGroupFileGuard, orphan_sleep_command, pid_alive, wait_for_pid_exit,


### PR DESCRIPTION
## Summary

- define guest exec containment and output-drain durations once in `guest-contracts` and derive a conservative 6.75-second terminal cleanup budget
- make `vsock-guest` runtime code and integration tests consume the shared component values
- derive runner cancellation and job-terminal grace from the shared guest budget plus explicit host slack, with compile-time invariants preserving the existing 8-second and 10-second behavior

## Compatibility

- no API, database, queue, persisted-state, or vsock protocol changes
- no runtime timeout changes
- drain polling, containment polling, terminal frame delivery, and cancellation write behavior remain unchanged

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo check -p guest-contracts -p vsock-guest -p runner --all-targets --all-features`
- `cd crates && cargo test --quiet -p guest-contracts -p vsock-guest -p runner --all-targets --all-features`
- `cd crates && cargo clippy -p guest-contracts -p vsock-guest -p runner --all-targets --all-features -- -D warnings`
- `cd crates && RUSTDOCFLAGS='-D warnings' cargo doc -p guest-contracts -p vsock-guest -p runner --no-deps --all-features`

Closes #24972
