### PR TITLE
test(runner): bound snapshot publish cancellation waits

### DIFF
--- a/crates/runner/src/cmd/build/snapshot.rs
+++ b/crates/runner/src/cmd/build/snapshot.rs
@@ -147,8 +147,61 @@ mod tests {
         Arc,
         atomic::{AtomicBool, AtomicU32, Ordering},
     };
+    use std::time::Duration;
 
     use crate::lock;
+
+    const SNAPSHOT_PUBLISH_SCENARIO_TIMEOUT: Duration = Duration::from_secs(5);
+    const SNAPSHOT_PUBLISH_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+    const SNAPSHOT_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+    type SnapshotPublishWaiter = tokio::task::JoinHandle<RunnerResult<sandbox::SnapshotOutput>>;
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum SnapshotLockState {
+        Held,
+        Available,
+        ProbeFailed(String),
+    }
+
+    impl std::fmt::Display for SnapshotLockState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Held => f.write_str("held"),
+                Self::Available => f.write_str("available"),
+                Self::ProbeFailed(error) => write!(f, "probe failed: {error}"),
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct SnapshotPublishPhaseTimeout {
+        phase: &'static str,
+        lock_state: SnapshotLockState,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct SnapshotPublishScenarioTimeout {
+        phase: &'static str,
+        lock_state: SnapshotLockState,
+        cleanup_lock_state: SnapshotLockState,
+    }
+
+    impl std::fmt::Display for SnapshotPublishScenarioTimeout {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(
+                f,
+                "timed out waiting for snapshot publish phase '{}'; snapshot lock was {} before cleanup and {} after cleanup",
+                self.phase, self.lock_state, self.cleanup_lock_state
+            )
+        }
+    }
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum CommitGateBehavior {
+        Release,
+        WithholdForTimeout,
+    }
 
     struct RecordingPendingSnapshotPublish {
         output_dir: PathBuf,
@@ -323,33 +376,146 @@ mod tests {
             .expect("acquire test snapshot lock")
     }
 
-    async fn assert_lock_blocked(lock_path: PathBuf) {
-        let err = lock::try_acquire(lock_path)
-            .await
-            .expect_err("snapshot lock should still be held");
-        assert!(
-            err.to_string().contains("already held"),
-            "unexpected lock error: {err}"
+    async fn snapshot_lock_state(lock_path: &Path) -> SnapshotLockState {
+        match lock::try_acquire_or_busy(lock_path.to_path_buf()).await {
+            Ok(lock::TryLock::Acquired(guard)) => {
+                drop(guard);
+                SnapshotLockState::Available
+            }
+            Ok(lock::TryLock::Busy) => SnapshotLockState::Held,
+            Err(error) => SnapshotLockState::ProbeFailed(error.to_string()),
+        }
+    }
+
+    async fn observe_phase_timeout(
+        phase: &'static str,
+        lock_path: &Path,
+    ) -> SnapshotPublishPhaseTimeout {
+        SnapshotPublishPhaseTimeout {
+            phase,
+            lock_state: snapshot_lock_state(lock_path).await,
+        }
+    }
+
+    async fn wait_for_snapshot_publish_phase(
+        deadline: tokio::time::Instant,
+        phase: &'static str,
+        receiver: tokio::sync::oneshot::Receiver<()>,
+        lock_path: &Path,
+    ) -> Result<(), SnapshotPublishPhaseTimeout> {
+        match tokio::time::timeout_at(deadline, receiver).await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(_)) => panic!("snapshot publish phase '{phase}' closed before signaling"),
+            Err(_) => Err(observe_phase_timeout(phase, lock_path).await),
+        }
+    }
+
+    async fn cancel_snapshot_publish_waiter(
+        deadline: tokio::time::Instant,
+        waiter: &mut Option<SnapshotPublishWaiter>,
+        lock_path: &Path,
+    ) -> Result<(), SnapshotPublishPhaseTimeout> {
+        let result = {
+            let waiter = waiter
+                .as_mut()
+                .expect("snapshot publish waiter should exist");
+            waiter.abort();
+            tokio::time::timeout_at(deadline, waiter).await
+        };
+
+        match result {
+            Ok(Err(error)) if error.is_cancelled() => {
+                waiter.take();
+                Ok(())
+            }
+            Ok(Ok(Ok(_))) => panic!("snapshot publish waiter completed before cancellation"),
+            Ok(Ok(Err(error))) => {
+                panic!("snapshot publish waiter failed before cancellation: {error}")
+            }
+            Ok(Err(error)) => panic!("snapshot publish waiter ended unexpectedly: {error}"),
+            Err(_) => Err(observe_phase_timeout("waiter cancellation", lock_path).await),
+        }
+    }
+
+    async fn assert_lock_blocked(lock_path: &Path) {
+        assert_eq!(
+            snapshot_lock_state(lock_path).await,
+            SnapshotLockState::Held,
+            "snapshot lock should still be held"
         );
     }
 
-    async fn wait_until_lock_available(lock_path: PathBuf) {
-        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+    async fn wait_until_lock_available(
+        deadline: tokio::time::Instant,
+        phase: &'static str,
+        lock_path: &Path,
+    ) -> Result<(), SnapshotPublishPhaseTimeout> {
+        let wait = async {
             loop {
-                match lock::try_acquire(lock_path.clone()).await {
-                    Ok(guard) => {
-                        drop(guard);
-                        break;
+                match snapshot_lock_state(lock_path).await {
+                    SnapshotLockState::Available => break,
+                    SnapshotLockState::Held => {
+                        tokio::time::sleep(SNAPSHOT_LOCK_POLL_INTERVAL).await;
                     }
-                    Err(err) if err.to_string().contains("already held") => {
-                        tokio::task::yield_now().await;
+                    SnapshotLockState::ProbeFailed(error) => {
+                        panic!("failed to probe snapshot lock while waiting for {phase}: {error}")
                     }
-                    Err(err) => panic!("unexpected lock error: {err}"),
                 }
             }
+        };
+
+        match tokio::time::timeout_at(deadline, wait).await {
+            Ok(()) => Ok(()),
+            Err(_) => Err(observe_phase_timeout(phase, lock_path).await),
+        }
+    }
+
+    async fn cleanup_snapshot_lock_state(
+        cleanup_deadline: tokio::time::Instant,
+        lock_path: &Path,
+    ) -> SnapshotLockState {
+        loop {
+            let state = snapshot_lock_state(lock_path).await;
+            match state {
+                SnapshotLockState::Held if tokio::time::Instant::now() < cleanup_deadline => {
+                    let next_poll = (tokio::time::Instant::now() + SNAPSHOT_LOCK_POLL_INTERVAL)
+                        .min(cleanup_deadline);
+                    tokio::time::sleep_until(next_poll).await;
+                }
+                state => return state,
+            }
+        }
+    }
+
+    async fn finish_snapshot_publish_scenario(
+        result: Result<(), SnapshotPublishPhaseTimeout>,
+        waiter: &mut Option<SnapshotPublishWaiter>,
+        commit_release: &mut Option<tokio::sync::oneshot::Sender<()>>,
+        discard_release: &mut Option<tokio::sync::oneshot::Sender<()>>,
+        lock_path: &Path,
+    ) -> Result<(), SnapshotPublishScenarioTimeout> {
+        let Err(timeout) = result else {
+            return Ok(());
+        };
+
+        let cleanup_deadline = tokio::time::Instant::now() + SNAPSHOT_PUBLISH_CLEANUP_TIMEOUT;
+        let waiter = waiter.take();
+        if let Some(waiter) = &waiter {
+            waiter.abort();
+        }
+        drop(commit_release.take());
+        drop(discard_release.take());
+
+        if let Some(waiter) = waiter {
+            let _ = tokio::time::timeout_at(cleanup_deadline, waiter).await;
+        }
+        let cleanup_lock_state = cleanup_snapshot_lock_state(cleanup_deadline, lock_path).await;
+
+        Err(SnapshotPublishScenarioTimeout {
+            phase: timeout.phase,
+            lock_state: timeout.lock_state,
+            cleanup_lock_state,
         })
-        .await
-        .unwrap_or_else(|_| panic!("timed out waiting for snapshot lock to be released"));
     }
 
     #[tokio::test]
@@ -495,8 +661,9 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn shielded_snapshot_publish_keeps_lock_after_waiter_cancelled_until_commit_finishes() {
+    async fn run_commit_cancellation_scenario(
+        gate_behavior: CommitGateBehavior,
+    ) -> Result<(), SnapshotPublishScenarioTimeout> {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("home"));
         let snapshot_hash = "snapshot-hash";
@@ -519,27 +686,62 @@ mod tests {
             discard_done: None,
         };
 
-        let waiter = tokio::spawn(shielded_snapshot_publish(
+        let deadline = tokio::time::Instant::now() + SNAPSHOT_PUBLISH_SCENARIO_TIMEOUT;
+        let mut waiter = Some(tokio::spawn(shielded_snapshot_publish(
             Box::new(pending),
             snapshot_lock,
             snapshot_hash.to_string(),
             snapshot_dir,
-        ));
-        commit_entered_rx.await.expect("commit should start");
-        waiter.abort();
-        assert!(waiter.await.unwrap_err().is_cancelled());
+        )));
+        let mut commit_release_tx = Some(commit_release_tx);
+        let mut discard_release_tx = None;
 
-        assert_lock_blocked(snapshot_lock_path.clone()).await;
+        let result = async {
+            wait_for_snapshot_publish_phase(
+                deadline,
+                "commit entry",
+                commit_entered_rx,
+                &snapshot_lock_path,
+            )
+            .await?;
+            cancel_snapshot_publish_waiter(deadline, &mut waiter, &snapshot_lock_path).await?;
 
-        commit_release_tx
-            .send(())
-            .expect("release commit waiter after cancellation");
-        commit_done_rx.await.expect("commit should finish");
-        wait_until_lock_available(snapshot_lock_path).await;
+            assert_lock_blocked(&snapshot_lock_path).await;
+
+            if gate_behavior == CommitGateBehavior::Release {
+                commit_release_tx
+                    .take()
+                    .expect("commit release gate should exist")
+                    .send(())
+                    .expect("release commit waiter after cancellation");
+            }
+            wait_for_snapshot_publish_phase(
+                deadline,
+                "commit completion",
+                commit_done_rx,
+                &snapshot_lock_path,
+            )
+            .await?;
+            wait_until_lock_available(
+                deadline,
+                "snapshot lock release after commit",
+                &snapshot_lock_path,
+            )
+            .await
+        }
+        .await;
+
+        finish_snapshot_publish_scenario(
+            result,
+            &mut waiter,
+            &mut commit_release_tx,
+            &mut discard_release_tx,
+            &snapshot_lock_path,
+        )
+        .await
     }
 
-    #[tokio::test]
-    async fn shielded_snapshot_publish_keeps_lock_after_waiter_cancelled_until_discard_finishes() {
+    async fn run_discard_cancellation_scenario() -> Result<(), SnapshotPublishScenarioTimeout> {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("home"));
         let snapshot_hash = "snapshot-hash";
@@ -564,28 +766,105 @@ mod tests {
             discard_done: Some(discard_done_tx),
         };
 
-        let waiter = tokio::spawn(shielded_snapshot_publish(
+        let deadline = tokio::time::Instant::now() + SNAPSHOT_PUBLISH_SCENARIO_TIMEOUT;
+        let mut waiter = Some(tokio::spawn(shielded_snapshot_publish(
             Box::new(pending),
             snapshot_lock,
             snapshot_hash.to_string(),
             snapshot_dir,
-        ));
-        commit_entered_rx.await.expect("commit should start");
-        waiter.abort();
-        assert!(waiter.await.unwrap_err().is_cancelled());
+        )));
+        let mut commit_release_tx = Some(commit_release_tx);
+        let mut discard_release_tx = Some(discard_release_tx);
 
-        assert_lock_blocked(snapshot_lock_path.clone()).await;
+        let result = async {
+            wait_for_snapshot_publish_phase(
+                deadline,
+                "commit entry",
+                commit_entered_rx,
+                &snapshot_lock_path,
+            )
+            .await?;
+            cancel_snapshot_publish_waiter(deadline, &mut waiter, &snapshot_lock_path).await?;
 
-        commit_release_tx
-            .send(())
-            .expect("release failing commit after cancellation");
-        discard_entered_rx.await.expect("discard should start");
-        assert_lock_blocked(snapshot_lock_path.clone()).await;
+            assert_lock_blocked(&snapshot_lock_path).await;
 
-        discard_release_tx
-            .send(())
-            .expect("release discard after cancellation");
-        discard_done_rx.await.expect("discard should finish");
-        wait_until_lock_available(snapshot_lock_path).await;
+            commit_release_tx
+                .take()
+                .expect("commit release gate should exist")
+                .send(())
+                .expect("release failing commit after cancellation");
+            wait_for_snapshot_publish_phase(
+                deadline,
+                "discard entry",
+                discard_entered_rx,
+                &snapshot_lock_path,
+            )
+            .await?;
+            assert_lock_blocked(&snapshot_lock_path).await;
+
+            discard_release_tx
+                .take()
+                .expect("discard release gate should exist")
+                .send(())
+                .expect("release discard after cancellation");
+            wait_for_snapshot_publish_phase(
+                deadline,
+                "discard completion",
+                discard_done_rx,
+                &snapshot_lock_path,
+            )
+            .await?;
+            wait_until_lock_available(
+                deadline,
+                "snapshot lock release after discard",
+                &snapshot_lock_path,
+            )
+            .await
+        }
+        .await;
+
+        finish_snapshot_publish_scenario(
+            result,
+            &mut waiter,
+            &mut commit_release_tx,
+            &mut discard_release_tx,
+            &snapshot_lock_path,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn shielded_snapshot_publish_keeps_lock_after_waiter_cancelled_until_commit_finishes() {
+        run_commit_cancellation_scenario(CommitGateBehavior::Release)
+            .await
+            .unwrap_or_else(|error| panic!("{error}"));
+    }
+
+    #[tokio::test]
+    async fn shielded_snapshot_publish_keeps_lock_after_waiter_cancelled_until_discard_finishes() {
+        run_discard_cancellation_scenario()
+            .await
+            .unwrap_or_else(|error| panic!("{error}"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shielded_snapshot_publish_phase_timeout_reports_lock_and_releases_gate() {
+        let started_at = tokio::time::Instant::now();
+        let error = run_commit_cancellation_scenario(CommitGateBehavior::WithholdForTimeout)
+            .await
+            .expect_err("withheld commit should reach the scenario timeout");
+        let elapsed = tokio::time::Instant::now().duration_since(started_at);
+
+        assert_eq!(error.phase, "commit completion");
+        assert_eq!(error.lock_state, SnapshotLockState::Held);
+        assert_eq!(error.cleanup_lock_state, SnapshotLockState::Available);
+        assert!(
+            elapsed >= SNAPSHOT_PUBLISH_SCENARIO_TIMEOUT,
+            "phase timeout returned before the scenario deadline: {elapsed:?}"
+        );
+        assert!(
+            elapsed <= SNAPSHOT_PUBLISH_SCENARIO_TIMEOUT + SNAPSHOT_PUBLISH_CLEANUP_TIMEOUT,
+            "phase timeout cleanup exceeded its local budget: {elapsed:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- bound all snapshot publish commit/discard phase rendezvous with one absolute scenario deadline
- report the stalled phase and snapshot lock state before and after bounded timeout cleanup
- release controlled gates and abort/drain any owned waiter before returning a timeout failure
- add a paused-time regression that withholds commit completion and verifies prompt cleanup

## Scope

- test-only changes in `crates/runner/src/cmd/build/snapshot.rs`
- no production snapshot behavior, lock semantics, API, schema, protocol, persistence, or deployment changes

## Validation

- `cargo test -p runner --bin runner shielded_snapshot_publish -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features` (2960 passed, 15 ignored; `guest_inventory` passed)
- repository pre-commit and commit-message hooks

Closes #24965
