### PR TITLE
feat(contracts): add native zero cli rust bindings

### DIFF
--- a/crates/api-contracts/src/generated/routes.rs
+++ b/crates/api-contracts/src/generated/routes.rs
@@ -6,6 +6,16 @@
 //! Do not edit by hand; regenerate with `cd turbo && pnpm -F @vm0/api-contracts generate:rust`.
 //! Route descriptions are generated from TypeScript contract summaries.
 
+/// Generated route bindings under `build_info`.
+pub mod build_info {
+    /// Get API build information.
+    /// Route contract: `GET /api/build-info`.
+    pub const GET: crate::Route = crate::Route {
+        method: crate::Method::Get,
+        path: "/api/build-info",
+    };
+}
+
 /// Generated route bindings under `runners`.
 pub mod runners {
     /// Generated route bindings under `runners::builtin_firewalls`.
@@ -219,5 +229,28 @@ pub mod webhooks {
                 path: "/api/webhooks/agent/telemetry",
             };
         }
+    }
+}
+
+/// Generated route bindings under `zero`.
+pub mod zero {
+    /// Generated route bindings under `zero::model_policies`.
+    pub mod model_policies {
+        /// List org model-first policies.
+        /// Route contract: `GET /api/zero/model-policies`.
+        pub const LIST: crate::Route = crate::Route {
+            method: crate::Method::Get,
+            path: "/api/zero/model-policies",
+        };
+    }
+
+    /// Generated route bindings under `zero::user_model_preference`.
+    pub mod user_model_preference {
+        /// Get current user's model-first preference.
+        /// Route contract: `GET /api/zero/user-model-preference`.
+        pub const GET: crate::Route = crate::Route {
+            method: crate::Method::Get,
+            path: "/api/zero/user-model-preference",
+        };
     }
 }

--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -4,7 +4,226 @@
 
 //! Generated Rust DTOs for selected `@vm0/api-contracts` request and response bodies.
 //! Do not edit by hand; regenerate with `cd turbo && pnpm -F @vm0/api-contracts generate:rust`.
-//! These types preserve the TypeScript wire contract for Rust runner and guest-agent code.
+//! These types preserve the TypeScript wire contract for Rust runner, native Zero CLI, and guest-agent code.
+
+/// API build identity returned to native clients.
+pub mod build_info {
+    /// Build identity reported by the current API deployment.
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Response {
+        /// Optional source commit SHA for the API deployment.
+        pub commit_sha: Option<String>,
+        /// Optional release version for the API deployment.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub version: Option<String>,
+    }
+}
+
+/// Model and model-provider discovery DTOs for native clients.
+pub mod models {
+    /// Ownership scope for model-provider credentials.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    pub enum ModelProviderCredentialScope {
+        /// Credentials owned by the organization.
+        #[serde(rename = "org")]
+        Org,
+        /// Credentials owned by the current member.
+        #[serde(rename = "member")]
+        Member,
+    }
+
+    /// Canonical model-provider credential and runtime types.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    pub enum ModelProviderType {
+        /// Model-provider type `claude-code-oauth-token`.
+        #[serde(rename = "claude-code-oauth-token")]
+        ClaudeCodeOauthToken,
+        /// Model-provider type `anthropic-api-key`.
+        #[serde(rename = "anthropic-api-key")]
+        AnthropicApiKey,
+        /// Model-provider type `openrouter-api-key`.
+        #[serde(rename = "openrouter-api-key")]
+        OpenrouterApiKey,
+        /// Model-provider type `moonshot-api-key`.
+        #[serde(rename = "moonshot-api-key")]
+        MoonshotApiKey,
+        /// Model-provider type `minimax-api-key`.
+        #[serde(rename = "minimax-api-key")]
+        MinimaxApiKey,
+        /// Model-provider type `deepseek-api-key`.
+        #[serde(rename = "deepseek-api-key")]
+        DeepseekApiKey,
+        /// Model-provider type `deepseek-codex`.
+        #[serde(rename = "deepseek-codex")]
+        DeepseekCodex,
+        /// Model-provider type `zai-api-key`.
+        #[serde(rename = "zai-api-key")]
+        ZaiApiKey,
+        /// Model-provider type `vercel-ai-gateway`.
+        #[serde(rename = "vercel-ai-gateway")]
+        VercelAiGateway,
+        /// Model-provider type `openrouter-codex`.
+        #[serde(rename = "openrouter-codex")]
+        OpenrouterCodex,
+        /// Model-provider type `vercel-ai-gateway-codex`.
+        #[serde(rename = "vercel-ai-gateway-codex")]
+        VercelAiGatewayCodex,
+        /// Model-provider type `openai-api-key`.
+        #[serde(rename = "openai-api-key")]
+        OpenaiApiKey,
+        /// Model-provider type `codex-oauth-token`.
+        #[serde(rename = "codex-oauth-token")]
+        CodexOauthToken,
+        /// Model-provider type `azure-foundry`.
+        #[serde(rename = "azure-foundry")]
+        AzureFoundry,
+        /// Model-provider type `aws-bedrock`.
+        #[serde(rename = "aws-bedrock")]
+        AwsBedrock,
+        /// Model-provider type `vm0`.
+        #[serde(rename = "vm0")]
+        Vm0,
+    }
+
+    /// Canonical model identifiers accepted for new runs.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    pub enum SupportedRunModel {
+        /// Model identifier `claude-fable-5`.
+        #[serde(rename = "claude-fable-5")]
+        ClaudeFable5,
+        /// Model identifier `claude-opus-5`.
+        #[serde(rename = "claude-opus-5")]
+        ClaudeOpus5,
+        /// Model identifier `gpt-5.6-sol`.
+        #[serde(rename = "gpt-5.6-sol")]
+        Gpt56Sol,
+        /// Model identifier `gpt-5.6-terra`.
+        #[serde(rename = "gpt-5.6-terra")]
+        Gpt56Terra,
+        /// Model identifier `gpt-5.6-luna`.
+        #[serde(rename = "gpt-5.6-luna")]
+        Gpt56Luna,
+        /// Model identifier `gpt-5.5`.
+        #[serde(rename = "gpt-5.5")]
+        Gpt55,
+        /// Model identifier `claude-opus-4-8`.
+        #[serde(rename = "claude-opus-4-8")]
+        ClaudeOpus48,
+        /// Model identifier `claude-opus-4-7`.
+        #[serde(rename = "claude-opus-4-7")]
+        ClaudeOpus47,
+        /// Model identifier `claude-opus-4-6`.
+        #[serde(rename = "claude-opus-4-6")]
+        ClaudeOpus46,
+        /// Model identifier `claude-sonnet-5`.
+        #[serde(rename = "claude-sonnet-5")]
+        ClaudeSonnet5,
+        /// Model identifier `claude-sonnet-4-6`.
+        #[serde(rename = "claude-sonnet-4-6")]
+        ClaudeSonnet46,
+        /// Model identifier `deepseek-v4-pro`.
+        #[serde(rename = "deepseek-v4-pro")]
+        DeepseekV4Pro,
+        /// Model identifier `deepseek-v4-flash`.
+        #[serde(rename = "deepseek-v4-flash")]
+        DeepseekV4Flash,
+        /// Model identifier `kimi-k3`.
+        #[serde(rename = "kimi-k3")]
+        KimiK3,
+        /// Model identifier `kimi-k2.7-code`.
+        #[serde(rename = "kimi-k2.7-code")]
+        KimiK27Code,
+        /// Model identifier `MiniMax-M3`.
+        #[serde(rename = "MiniMax-M3")]
+        MiniMaxM3,
+        /// Model identifier `glm-5.2`.
+        #[serde(rename = "glm-5.2")]
+        Glm52,
+        /// Model identifier `glm-5.1`.
+        #[serde(rename = "glm-5.1")]
+        Glm51,
+        /// Model identifier `mimo-v2.5`.
+        #[serde(rename = "mimo-v2.5")]
+        MimoV25,
+        /// Model identifier `hy3-preview`.
+        #[serde(rename = "hy3-preview")]
+        Hy3Preview,
+    }
+
+    /// Workspace model routing policies visible to native clients.
+    pub mod policies {
+        /// Resolution status for a workspace model route.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        pub enum OrgModelPolicyRouteStatus {
+            /// The model route can resolve a usable provider.
+            #[serde(rename = "valid")]
+            Valid,
+            /// The model route has no usable provider.
+            #[serde(rename = "missing_provider")]
+            MissingProvider,
+            /// The configured model route is invalid.
+            #[serde(rename = "invalid")]
+            Invalid,
+        }
+
+        /// Resolved model routing policy visible to the current user.
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct Policy {
+            /// Stable identifier for the model policy.
+            pub id: String,
+            /// Canonical model selected by the policy.
+            pub model: super::SupportedRunModel,
+            /// Display label for the model.
+            pub model_label: String,
+            /// Whether this policy is the workspace default.
+            pub is_default: bool,
+            /// Provider type selected when no explicit provider is configured.
+            pub default_provider_type: super::ModelProviderType,
+            /// Ownership scope for the provider credentials.
+            pub credential_scope: super::ModelProviderCredentialScope,
+            /// Optional configured model-provider identifier.
+            pub model_provider_id: Option<String>,
+            /// Optional configured model-provider surface identifier.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub model_provider_surface_id: Option<String>,
+            /// Current provider resolution status.
+            pub route_status: OrgModelPolicyRouteStatus,
+            /// Optional explanation when the provider route is unavailable.
+            pub route_status_reason: Option<String>,
+            /// Timestamp when the policy was created.
+            pub created_at: String,
+            /// Timestamp when the policy was last updated.
+            pub updated_at: String,
+        }
+
+        /// Workspace model policies available to the current user.
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct Response {
+            /// Resolved workspace model routing policies.
+            pub policies: Vec<Policy>,
+            /// Optional workspace default model.
+            pub workspace_default_model: Option<super::SupportedRunModel>,
+            /// Optional identifier for the workspace default policy.
+            pub workspace_default_policy_id: Option<String>,
+        }
+    }
+
+    /// Current user's selected model preference.
+    pub mod preference {
+        /// Current user's selected model preference.
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct Response {
+            /// Optional model explicitly selected by the user.
+            pub selected_model: Option<super::SupportedRunModel>,
+            /// Optional timestamp of the last preference update.
+            pub updated_at: Option<String>,
+        }
+    }
+}
 
 /// Runner-facing DTOs generated from TypeScript API contracts.
 pub mod runners {
@@ -51,6 +270,26 @@ pub mod runners {
             /// Whether changed contents are written back to the same Storage.
             #[serde(default, skip_serializing_if = "Option::is_none")]
             pub writeback: Option<bool>,
+        }
+    }
+
+    /// Bundled Zero CLI availability and build identity reported by runners.
+    pub mod zero_cli {
+        /// Bundled Zero CLI availability and non-sensitive build identity reported by a runner.
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct CompatibilityDescriptor {
+            /// Whether the runner embeds the native Zero CLI binary.
+            pub available: bool,
+            /// Optional native Zero CLI crate version.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub version: Option<String>,
+            /// Optional runner build containing the native CLI binary.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub build_id: Option<String>,
+            /// Optional lowercase SHA-256 checksum of the embedded CLI bytes.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub checksum_sha256: Option<String>,
         }
     }
 }

--- a/crates/api-contracts/tests/routes.rs
+++ b/crates/api-contracts/tests/routes.rs
@@ -41,6 +41,20 @@ fn exposes_generated_runner_route_constants() {
 }
 
 #[test]
+fn exposes_native_zero_cli_read_only_routes() {
+    let build_info = routes::build_info::GET;
+    let model_policies = routes::zero::model_policies::LIST;
+    let model_preference = routes::zero::user_model_preference::GET;
+
+    assert_eq!(build_info.method, Method::Get);
+    assert_eq!(build_info.path, "/api/build-info");
+    assert_eq!(model_policies.method, Method::Get);
+    assert_eq!(model_policies.path, "/api/zero/model-policies");
+    assert_eq!(model_preference.method, Method::Get);
+    assert_eq!(model_preference.path, "/api/zero/user-model-preference");
+}
+
+#[test]
 fn generated_routes_build_urls_from_base_api_url() {
     let route = routes::webhooks::agent::telemetry::SEND;
 

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -1,5 +1,9 @@
 use api_contracts::generated::types::{
-    runners::storage as runner_storage,
+    build_info,
+    models::{
+        ModelProviderCredentialScope, ModelProviderType, SupportedRunModel, policies, preference,
+    },
+    runners::{storage as runner_storage, zero_cli},
     webhooks::agent::{
         checkpoints,
         storages::{FileEntryWithHash, commit, prepare},
@@ -268,4 +272,90 @@ fn generated_storage_mount_entry_preserves_canonical_shape() {
         mount.missing_root_policy,
         Some(runner_storage::ArtifactEntryMissingRootPolicy::PreserveParentVersion)
     );
+}
+
+#[test]
+fn generated_model_policy_response_preserves_typed_discovery_fields() {
+    let response: policies::Response = serde_json::from_value(json!({
+        "policies": [{
+            "id": "00000000-0000-4000-8000-000000000001",
+            "model": "gpt-5.6-sol",
+            "modelLabel": "GPT 5.6 Sol",
+            "isDefault": true,
+            "defaultProviderType": "codex-oauth-token",
+            "credentialScope": "member",
+            "modelProviderId": null,
+            "routeStatus": "valid",
+            "routeStatusReason": null,
+            "createdAt": "2026-08-04T00:00:00.000Z",
+            "updatedAt": "2026-08-04T00:00:00.000Z"
+        }],
+        "workspaceDefaultModel": "gpt-5.6-sol",
+        "workspaceDefaultPolicyId": "00000000-0000-4000-8000-000000000001"
+    }))
+    .unwrap();
+
+    assert_eq!(response.policies[0].model, SupportedRunModel::Gpt56Sol);
+    assert_eq!(
+        response.policies[0].default_provider_type,
+        ModelProviderType::CodexOauthToken
+    );
+    assert_eq!(
+        response.policies[0].credential_scope,
+        ModelProviderCredentialScope::Member
+    );
+    assert_eq!(
+        response.policies[0].route_status,
+        policies::OrgModelPolicyRouteStatus::Valid
+    );
+    assert!(response.policies[0].model_provider_surface_id.is_none());
+    assert_eq!(
+        response.workspace_default_model,
+        Some(SupportedRunModel::Gpt56Sol)
+    );
+}
+
+#[test]
+fn generated_selected_model_and_build_identity_responses_accept_absent_values() {
+    let selected: preference::Response = serde_json::from_value(json!({
+        "selectedModel": null,
+        "updatedAt": null
+    }))
+    .unwrap();
+    let identity: build_info::Response = serde_json::from_value(json!({
+        "commitSha": null
+    }))
+    .unwrap();
+
+    assert!(selected.selected_model.is_none());
+    assert!(selected.updated_at.is_none());
+    assert!(identity.commit_sha.is_none());
+    assert!(identity.version.is_none());
+}
+
+#[test]
+fn generated_zero_cli_compatibility_descriptor_omits_unavailable_metadata() {
+    let unavailable: zero_cli::CompatibilityDescriptor =
+        serde_json::from_value(json!({ "available": false })).unwrap();
+    assert_eq!(
+        serde_json::to_value(unavailable).unwrap(),
+        json!({ "available": false })
+    );
+
+    let available: zero_cli::CompatibilityDescriptor = serde_json::from_value(json!({
+        "available": true,
+        "version": "1.2.3",
+        "buildId": "runner-rs@1.2.3",
+        "checksumSha256": "a".repeat(64),
+        "token": "must-not-survive",
+        "commandArguments": ["secret"]
+    }))
+    .unwrap();
+    let value = serde_json::to_value(available).unwrap();
+
+    assert_eq!(value["version"], "1.2.3");
+    assert_eq!(value["buildId"], "runner-rs@1.2.3");
+    assert_eq!(value["checksumSha256"], "a".repeat(64));
+    assert!(value.get("token").is_none());
+    assert!(value.get("commandArguments").is_none());
 }

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -47,8 +47,11 @@ zstd = { workspace = true, features = ["zstdmt"] }
 vsock-proto = { workspace = true }
 
 [build-dependencies]
+hex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
+zero-cli = { workspace = true }
 
 # These dev-dependencies exist solely for release-please version tracking:
 # cargo-workspace plugin includes dev-dependencies in its dependency graph,
@@ -66,7 +69,6 @@ guest-mock-claude = { workspace = true }
 guest-mock-codex = { workspace = true }
 guest-reseed = { workspace = true }
 guest-write-file = { workspace = true }
-zero-cli = { workspace = true }
 httpmock = { workspace = true }
 sandbox-mock = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -69,6 +69,7 @@ guest-mock-claude = { workspace = true }
 guest-mock-codex = { workspace = true }
 guest-reseed = { workspace = true }
 guest-write-file = { workspace = true }
+zero-cli = { workspace = true }
 httpmock = { workspace = true }
 sandbox-mock = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/runner/build.rs
+++ b/crates/runner/build.rs
@@ -6,8 +6,10 @@ use std::path::{Path, PathBuf};
 use std::{env, fs};
 
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 
 const GUEST_BINARIES_FILE: &str = "guest-binaries.json";
+const ZERO_CLI_BINARY: &str = "zero-cli";
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -92,6 +94,16 @@ fn main() {
                 .unwrap_or_else(|| panic!("non-UTF-8 path: {}", abs.display()));
             println!("cargo::rustc-env={}={abs_str}", guest.bundled_env);
             println!("cargo::rerun-if-changed={abs_str}");
+            if guest.binary == ZERO_CLI_BINARY {
+                let bytes = fs::read(&abs)
+                    .unwrap_or_else(|e| panic!("read bundled Zero CLI {}: {e}", abs.display()));
+                let checksum = hex::encode(Sha256::digest(bytes));
+                println!(
+                    "cargo::rustc-env=BUNDLED_ZERO_CLI_VERSION={}",
+                    zero_cli::VERSION
+                );
+                println!("cargo::rustc-env=BUNDLED_ZERO_CLI_SHA256={checksum}");
+            }
         }
     }
 }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -13,6 +13,7 @@ use api_contracts::generated::{
         NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE, RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
     },
     routes,
+    types::runners::zero_cli::CompatibilityDescriptor,
 };
 use reqwest::{Response, StatusCode};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
@@ -49,6 +50,7 @@ use sandbox::SandboxId;
 struct ClaimRequestBody<'a> {
     runner_identity: ClaimRunnerIdentity<'a>,
     telemetry: ClaimRequestTelemetry,
+    zero_cli: CompatibilityDescriptor,
 }
 
 #[derive(Serialize)]
@@ -1180,6 +1182,27 @@ fn claim_request_body<'a>(
                 .map(claim_telemetry_duration_ms),
             poll_reason: candidate.poll_reason().map(String::from),
         },
+        zero_cli: bundled_zero_cli_compatibility(),
+    }
+}
+
+fn bundled_zero_cli_compatibility() -> CompatibilityDescriptor {
+    match (
+        option_env!("BUNDLED_ZERO_CLI_VERSION"),
+        option_env!("BUNDLED_ZERO_CLI_SHA256"),
+    ) {
+        (Some(version), Some(checksum_sha256)) => CompatibilityDescriptor {
+            available: true,
+            version: Some(version.to_owned()),
+            build_id: Some(concat!("runner-rs@", env!("CARGO_PKG_VERSION")).to_owned()),
+            checksum_sha256: Some(checksum_sha256.to_owned()),
+        },
+        _ => CompatibilityDescriptor {
+            available: false,
+            version: None,
+            build_id: None,
+            checksum_sha256: None,
+        },
     }
 }
 
@@ -2085,6 +2108,26 @@ mod tests {
         assert_eq!(body["telemetry"]["pollDueToJobDiscoveredMs"], 19);
         assert_eq!(body["telemetry"]["pollHttpRequestMs"], 11);
         assert_eq!(body["telemetry"]["pollReason"], "deferred");
+        match (
+            option_env!("BUNDLED_ZERO_CLI_VERSION"),
+            option_env!("BUNDLED_ZERO_CLI_SHA256"),
+        ) {
+            (Some(version), Some(checksum_sha256)) => {
+                assert_eq!(body["zeroCli"]["available"], true);
+                assert_eq!(body["zeroCli"]["version"], version);
+                assert_eq!(
+                    body["zeroCli"]["buildId"],
+                    concat!("runner-rs@", env!("CARGO_PKG_VERSION"))
+                );
+                assert_eq!(body["zeroCli"]["checksumSha256"], checksum_sha256);
+            }
+            _ => {
+                assert_eq!(body["zeroCli"]["available"], false);
+                assert!(body["zeroCli"].get("version").is_none());
+                assert!(body["zeroCli"].get("buildId").is_none());
+                assert!(body["zeroCli"].get("checksumSha256").is_none());
+            }
+        }
         assert!(body.get("runnerPreference").is_none());
         assert!(!body.to_string().contains("rawSizeBytes"));
         assert!(!body.to_string().contains("sessionId"));
@@ -2092,6 +2135,8 @@ mod tests {
         assert!(!body.to_string().contains("cacheKey"));
         assert!(!body.to_string().contains("path"));
         assert!(body.get("capabilities").is_none());
+        assert!(!body.to_string().contains("commandArguments"));
+        assert!(!body.to_string().contains("token"));
     }
 
     #[test]

--- a/crates/zero-cli/src/lib.rs
+++ b/crates/zero-cli/src/lib.rs
@@ -2,3 +2,6 @@
 //!
 //! The CLI implementation lives in the binary target. This library target
 //! allows runner to depend on the crate for release-please version tracking.
+
+/// Version of the native Zero CLI binary built from this crate.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -987,6 +987,53 @@ describe("runner claim request contract", () => {
 
     expect(body.telemetry).toEqual({});
   });
+
+  it("accepts an optional non-sensitive bundled Zero CLI descriptor", () => {
+    const body = runnersJobClaimContract.claim.body.parse({
+      zeroCli: {
+        available: true,
+        version: "1.2.3",
+        buildId: "runner-rs@1.2.3",
+        checksumSha256: "a".repeat(64),
+        token: "must-not-survive",
+        commandArguments: ["secret"],
+      },
+    });
+
+    expect(body).toEqual({
+      zeroCli: {
+        available: true,
+        version: "1.2.3",
+        buildId: "runner-rs@1.2.3",
+        checksumSha256: "a".repeat(64),
+      },
+    });
+  });
+
+  it("keeps old and new runner claim generations compatible", () => {
+    const previousClaimBodySchema = runnersJobClaimContract.claim.body.omit({
+      zeroCli: true,
+    });
+    const newRunnerBody = {
+      zeroCli: {
+        available: false,
+      },
+    };
+
+    expect(runnersJobClaimContract.claim.body.parse({})).toEqual({});
+    expect(previousClaimBodySchema.parse(newRunnerBody)).toEqual({});
+  });
+
+  it("rejects malformed bundled Zero CLI checksums", () => {
+    expect(
+      runnersJobClaimContract.claim.body.safeParse({
+        zeroCli: {
+          available: true,
+          checksumSha256: "not-a-sha256",
+        },
+      }).success,
+    ).toBe(false);
+  });
 });
 
 describe("runner poll request contract", () => {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -132,6 +132,20 @@ const runnerClaimTelemetrySchema = z
   })
   .catch({});
 
+export const runnerZeroCliCompatibilitySchema = z.object({
+  available: z.boolean(),
+  version: z.string().min(1).optional(),
+  buildId: z.string().min(1).optional(),
+  checksumSha256: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/u)
+    .optional(),
+});
+
+export type RunnerZeroCliCompatibility = z.infer<
+  typeof runnerZeroCliCompatibilitySchema
+>;
+
 const runnerPollTelemetrySchema = z
   .object({
     pollReason: runnerClaimPollReasonSchema.optional(),
@@ -704,6 +718,7 @@ export const runnersJobClaimContract = c.router({
     body: z.object({
       runnerIdentity: runnerProcessIdentitySchema.optional(),
       telemetry: runnerClaimTelemetrySchema.optional(),
+      zeroCli: runnerZeroCliCompatibilitySchema.optional(),
     }),
     responses: {
       200: executionContextSchema,

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/generated.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/generated.test.ts
@@ -1,0 +1,55 @@
+import { readFile } from "node:fs/promises";
+
+import {
+  renderGeneratedMod,
+  renderRustConstants,
+  renderRustRoutes,
+  renderRustTypes,
+} from "../generate";
+import { rustConstantBindings } from "../constants";
+import { rustRouteBindings } from "../routes";
+import { rustTypeBindings } from "../types";
+
+const generatedDirectory = new URL(
+  "../../../../../../crates/api-contracts/src/generated/",
+  import.meta.url,
+);
+
+const generatedFiles = [
+  {
+    filename: "constants.rs",
+    render: () => {
+      return renderRustConstants(rustConstantBindings);
+    },
+  },
+  {
+    filename: "routes.rs",
+    render: () => {
+      return renderRustRoutes(rustRouteBindings);
+    },
+  },
+  {
+    filename: "types.rs",
+    render: () => {
+      return renderRustTypes(rustTypeBindings);
+    },
+  },
+  {
+    filename: "mod.rs",
+    render: renderGeneratedMod,
+  },
+] as const;
+
+describe("generated Rust API contracts", () => {
+  it.each(generatedFiles)(
+    "keeps committed $filename synchronized with the TypeScript registry",
+    async ({ filename, render }) => {
+      const committed = await readFile(
+        new URL(filename, generatedDirectory),
+        "utf8",
+      );
+
+      expect(committed).toBe(render());
+    },
+  );
+});

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/routes.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/routes.test.ts
@@ -3,6 +3,24 @@ import { type RustRouteBinding, rustRouteBindings } from "../routes";
 
 const expectedBindings = [
   {
+    method: "GET",
+    path: "/api/build-info",
+    rustModulePath: ["build_info"],
+    rustConstName: "GET",
+  },
+  {
+    method: "GET",
+    path: "/api/zero/model-policies",
+    rustModulePath: ["zero", "model_policies"],
+    rustConstName: "LIST",
+  },
+  {
+    method: "GET",
+    path: "/api/zero/user-model-preference",
+    rustModulePath: ["zero", "user_model_preference"],
+    rustConstName: "GET",
+  },
+  {
     method: "POST",
     path: "/api/runners/poll",
     rustModulePath: ["runners", "poll"],
@@ -133,7 +151,9 @@ describe("Rust route bindings", () => {
 
     expect(secondRender).toBe(firstRender);
     for (const binding of expectedBindings) {
-      expect(firstRender).toContain("crate::Method::Post");
+      const methodVariant =
+        binding.method === "GET" ? "crate::Method::Get" : "crate::Method::Post";
+      expect(firstRender).toContain(methodVariant);
       expect(firstRender).toContain(`"${binding.path}"`);
     }
   });

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -20,6 +20,46 @@ import {
 
 const expectedBindings = [
   {
+    rustModulePath: ["build_info"],
+    rustTypeName: "Response",
+    direction: "response",
+  },
+  {
+    rustModulePath: ["models"],
+    rustTypeName: "ModelProviderCredentialScope",
+    direction: "response",
+  },
+  {
+    rustModulePath: ["models"],
+    rustTypeName: "ModelProviderType",
+    direction: "response",
+  },
+  {
+    rustModulePath: ["models"],
+    rustTypeName: "SupportedRunModel",
+    direction: "response",
+  },
+  {
+    rustModulePath: ["models", "policies"],
+    rustTypeName: "OrgModelPolicyRouteStatus",
+    direction: "response",
+  },
+  {
+    rustModulePath: ["models", "policies"],
+    rustTypeName: "Policy",
+    direction: "response",
+  },
+  {
+    rustModulePath: ["models", "policies"],
+    rustTypeName: "Response",
+    direction: "response",
+  },
+  {
+    rustModulePath: ["models", "preference"],
+    rustTypeName: "Response",
+    direction: "response",
+  },
+  {
     rustModulePath: ["runners", "storage"],
     rustTypeName: "ArtifactEntryMissingRootPolicy",
     direction: "response",
@@ -28,6 +68,11 @@ const expectedBindings = [
     rustModulePath: ["runners", "storage"],
     rustTypeName: "StorageMountEntry",
     direction: "response",
+  },
+  {
+    rustModulePath: ["runners", "zero_cli"],
+    rustTypeName: "CompatibilityDescriptor",
+    direction: "request",
   },
   {
     rustModulePath: ["webhooks", "agent", "checkpoints"],
@@ -226,6 +271,18 @@ describe("Rust type bindings", () => {
     expect(firstRender.match(/pub archive_size: Option<u64>,/g)).toHaveLength(
       1,
     );
+    expect(firstRender).toContain("pub enum SupportedRunModel {");
+    expect(firstRender).toContain("Gpt56Sol,");
+    expect(firstRender).toContain("pub enum ModelProviderType {");
+    expect(firstRender).toContain("CodexOauthToken,");
+    expect(firstRender).toContain("pub struct Policy {");
+    expect(firstRender).toContain("pub policies: Vec<Policy>,");
+    expect(firstRender).toContain(
+      "pub workspace_default_model: Option<super::SupportedRunModel>,",
+    );
+    expect(firstRender).toContain("pub struct CompatibilityDescriptor {");
+    expect(firstRender).toContain("pub available: bool,");
+    expect(firstRender).toContain("pub checksum_sha256: Option<String>,");
   });
 
   it("keeps canonical Storage mount override aligned with its schema", () => {

--- a/turbo/packages/api-contracts/src/rust-bindings/routes.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/routes.ts
@@ -1,3 +1,4 @@
+import { buildInfoContract } from "../contracts/build-info";
 import { runnerRealtimeTokenContract } from "../contracts/realtime";
 import {
   runnersNetworkPolicyRefreshContract,
@@ -16,6 +17,8 @@ import {
   webhookStoragesPrepareContract,
   webhookTelemetryContract,
 } from "../contracts/webhooks";
+import { zeroModelPoliciesMainContract } from "../contracts/zero-model-policies";
+import { zeroUserModelPreferenceContract } from "../contracts/zero-user-model-preference";
 
 export interface RouteLike {
   readonly method?: unknown;
@@ -30,6 +33,21 @@ export interface RustRouteBinding {
 }
 
 export const rustRouteBindings = [
+  {
+    route: buildInfoContract.get,
+    rustModulePath: ["build_info"],
+    rustConstName: "GET",
+  },
+  {
+    route: zeroModelPoliciesMainContract.list,
+    rustModulePath: ["zero", "model_policies"],
+    rustConstName: "LIST",
+  },
+  {
+    route: zeroUserModelPreferenceContract.get,
+    rustModulePath: ["zero", "user_model_preference"],
+    rustConstName: "GET",
+  },
   {
     route: runnersPollContract.poll,
     rustModulePath: ["runners", "poll"],

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -1,6 +1,18 @@
 import type { z } from "zod";
+import { buildInfoResponseSchema } from "../contracts/build-info";
+import { MODEL_PROVIDER_TYPE_IDS } from "../contracts/model-provider-types";
+import { SUPPORTED_RUN_MODELS } from "../contracts/model-price-tiers";
+import {
+  modelProviderCredentialScopeSchema,
+  modelProviderTypeSchema,
+  orgModelPoliciesResponseSchema,
+  orgModelPolicySchema,
+  orgModelPolicyRouteStatusSchema,
+  supportedRunModelSchema,
+} from "../contracts/model-providers";
 import {
   artifactMissingRootPolicySchema,
+  runnerZeroCliCompatibilitySchema,
   storageMountEntrySchema,
 } from "../contracts/runners";
 import { fileEntryWithHashSchema } from "../contracts/storages";
@@ -9,6 +21,7 @@ import {
   webhookStoragesCommitContract,
   webhookStoragesPrepareContract,
 } from "../contracts/webhooks";
+import { userModelPreferenceResponseSchema } from "../contracts/zero-user-model-preference";
 
 export interface RustTypeBinding {
   readonly schema: z.ZodType;
@@ -34,10 +47,26 @@ export interface RustTypeModuleDoc {
 export const rustTypeRootDoc = [
   "Generated Rust DTOs for selected `@vm0/api-contracts` request and response bodies.",
   "Do not edit by hand; regenerate with `cd turbo && pnpm -F @vm0/api-contracts generate:rust`.",
-  "These types preserve the TypeScript wire contract for Rust runner and guest-agent code.",
+  "These types preserve the TypeScript wire contract for Rust runner, native Zero CLI, and guest-agent code.",
 ] as const;
 
 export const rustTypeModuleDocs = [
+  {
+    rustModulePath: ["build_info"],
+    rustDoc: ["API build identity returned to native clients."],
+  },
+  {
+    rustModulePath: ["models"],
+    rustDoc: ["Model and model-provider discovery DTOs for native clients."],
+  },
+  {
+    rustModulePath: ["models", "policies"],
+    rustDoc: ["Workspace model routing policies visible to native clients."],
+  },
+  {
+    rustModulePath: ["models", "preference"],
+    rustDoc: ["Current user's selected model preference."],
+  },
   {
     rustModulePath: ["runners"],
     rustDoc: ["Runner-facing DTOs generated from TypeScript API contracts."],
@@ -46,6 +75,12 @@ export const rustTypeModuleDocs = [
     rustModulePath: ["runners", "storage"],
     rustDoc: [
       "Storage manifest DTOs used by runners to mount volumes and artifacts.",
+    ],
+  },
+  {
+    rustModulePath: ["runners", "zero_cli"],
+    rustDoc: [
+      "Bundled Zero CLI availability and build identity reported by runners.",
     ],
   },
   {
@@ -76,7 +111,198 @@ export const rustTypeModuleDocs = [
   },
 ] satisfies readonly RustTypeModuleDoc[];
 
+function enumVariantDocs(
+  values: readonly string[],
+  subject: string,
+): Readonly<Record<string, readonly string[]>> {
+  return Object.fromEntries(
+    values.map((value) => {
+      return [value, [`${subject} \`${value}\`.`]];
+    }),
+  );
+}
+
 export const rustTypeBindings = [
+  {
+    schema: buildInfoResponseSchema,
+    rustModulePath: ["build_info"],
+    rustTypeName: "Response",
+    direction: "response",
+    declarations: [
+      {
+        rustTypeName: "Response",
+        rustDoc: ["Build identity reported by the current API deployment."],
+        fields: {
+          commitSha: ["Optional source commit SHA for the API deployment."],
+          version: ["Optional release version for the API deployment."],
+        },
+      },
+    ],
+  },
+  {
+    schema: supportedRunModelSchema,
+    rustModulePath: ["models"],
+    rustTypeName: "SupportedRunModel",
+    direction: "response",
+    declarations: [
+      {
+        rustTypeName: "SupportedRunModel",
+        rustDoc: ["Canonical model identifiers accepted for new runs."],
+        variants: enumVariantDocs(SUPPORTED_RUN_MODELS, "Model identifier"),
+      },
+    ],
+  },
+  {
+    schema: modelProviderTypeSchema,
+    rustModulePath: ["models"],
+    rustTypeName: "ModelProviderType",
+    direction: "response",
+    declarations: [
+      {
+        rustTypeName: "ModelProviderType",
+        rustDoc: ["Canonical model-provider credential and runtime types."],
+        variants: enumVariantDocs(
+          MODEL_PROVIDER_TYPE_IDS,
+          "Model-provider type",
+        ),
+      },
+    ],
+  },
+  {
+    schema: modelProviderCredentialScopeSchema,
+    rustModulePath: ["models"],
+    rustTypeName: "ModelProviderCredentialScope",
+    direction: "response",
+    declarations: [
+      {
+        rustTypeName: "ModelProviderCredentialScope",
+        rustDoc: ["Ownership scope for model-provider credentials."],
+        variants: {
+          org: ["Credentials owned by the organization."],
+          member: ["Credentials owned by the current member."],
+        },
+      },
+    ],
+  },
+  {
+    schema: orgModelPolicyRouteStatusSchema,
+    rustModulePath: ["models", "policies"],
+    rustTypeName: "OrgModelPolicyRouteStatus",
+    direction: "response",
+    declarations: [
+      {
+        rustTypeName: "OrgModelPolicyRouteStatus",
+        rustDoc: ["Resolution status for a workspace model route."],
+        variants: {
+          valid: ["The model route can resolve a usable provider."],
+          missing_provider: ["The model route has no usable provider."],
+          invalid: ["The configured model route is invalid."],
+        },
+      },
+    ],
+  },
+  {
+    schema: orgModelPolicySchema,
+    rustModulePath: ["models", "policies"],
+    rustTypeName: "Policy",
+    direction: "response",
+    fieldTypeOverrides: {
+      model: "super::SupportedRunModel",
+      defaultProviderType: "super::ModelProviderType",
+      credentialScope: "super::ModelProviderCredentialScope",
+      routeStatus: "OrgModelPolicyRouteStatus",
+    },
+    declarations: [
+      {
+        rustTypeName: "Policy",
+        rustDoc: ["Resolved model routing policy visible to the current user."],
+        fields: {
+          id: ["Stable identifier for the model policy."],
+          model: ["Canonical model selected by the policy."],
+          modelLabel: ["Display label for the model."],
+          isDefault: ["Whether this policy is the workspace default."],
+          defaultProviderType: [
+            "Provider type selected when no explicit provider is configured.",
+          ],
+          credentialScope: ["Ownership scope for the provider credentials."],
+          modelProviderId: ["Optional configured model-provider identifier."],
+          modelProviderSurfaceId: [
+            "Optional configured model-provider surface identifier.",
+          ],
+          routeStatus: ["Current provider resolution status."],
+          routeStatusReason: [
+            "Optional explanation when the provider route is unavailable.",
+          ],
+          createdAt: ["Timestamp when the policy was created."],
+          updatedAt: ["Timestamp when the policy was last updated."],
+        },
+      },
+    ],
+  },
+  {
+    schema: orgModelPoliciesResponseSchema,
+    rustModulePath: ["models", "policies"],
+    rustTypeName: "Response",
+    direction: "response",
+    fieldTypeOverrides: {
+      policies: "Vec<Policy>",
+      workspaceDefaultModel: "Option<super::SupportedRunModel>",
+    },
+    declarations: [
+      {
+        rustTypeName: "Response",
+        rustDoc: ["Workspace model policies available to the current user."],
+        fields: {
+          policies: ["Resolved workspace model routing policies."],
+          workspaceDefaultModel: ["Optional workspace default model."],
+          workspaceDefaultPolicyId: [
+            "Optional identifier for the workspace default policy.",
+          ],
+        },
+      },
+    ],
+  },
+  {
+    schema: userModelPreferenceResponseSchema,
+    rustModulePath: ["models", "preference"],
+    rustTypeName: "Response",
+    direction: "response",
+    fieldTypeOverrides: {
+      selectedModel: "Option<super::SupportedRunModel>",
+    },
+    declarations: [
+      {
+        rustTypeName: "Response",
+        rustDoc: ["Current user's selected model preference."],
+        fields: {
+          selectedModel: ["Optional model explicitly selected by the user."],
+          updatedAt: ["Optional timestamp of the last preference update."],
+        },
+      },
+    ],
+  },
+  {
+    schema: runnerZeroCliCompatibilitySchema,
+    rustModulePath: ["runners", "zero_cli"],
+    rustTypeName: "CompatibilityDescriptor",
+    direction: "request",
+    declarations: [
+      {
+        rustTypeName: "CompatibilityDescriptor",
+        rustDoc: [
+          "Bundled Zero CLI availability and non-sensitive build identity reported by a runner.",
+        ],
+        fields: {
+          available: ["Whether the runner embeds the native Zero CLI binary."],
+          version: ["Optional native Zero CLI crate version."],
+          buildId: ["Optional runner build containing the native CLI binary."],
+          checksumSha256: [
+            "Optional lowercase SHA-256 checksum of the embedded CLI bytes.",
+          ],
+        },
+      },
+    ],
+  },
   {
     schema: artifactMissingRootPolicySchema,
     rustModulePath: ["runners", "storage"],


### PR DESCRIPTION
## Summary

- Generate Rust bindings for API build identity, model policies, selected model preference, supported models, provider types, credential scopes, and route status enums from the TypeScript registries.
- Add a committed-output consistency test covering generated routes, DTOs/enums, constants, and module declarations. The existing canonical CLI client header constants remain the single source of truth.
- Report an optional zeroCli compatibility descriptor during runner claims with availability, native CLI version, runner build ID, and SHA-256 of the embedded CLI bytes.

## Compatibility

- Old runner to new API: zeroCli is optional, so omitted descriptors remain valid.
- New runner to old API: the additive claim field is ignored by the previous Zod object reader; this pairing is covered explicitly.
- Unbundled runners report only available: false; version, build ID, and checksum remain optional.
- The descriptor contains no command arguments or tokens, and both TypeScript and Rust contract tests verify unknown sensitive fields are excluded.
- The rollout switch and selected CLI behavior remain unchanged.

## Validation

- pnpm -F @vm0/api-contracts generate:rust
- pnpm -F @vm0/api-contracts exec vitest run src/rust-bindings/__tests__ src/contracts/__tests__/runners.test.ts src/contracts/__tests__/build-info.test.ts (128 tests)
- pnpm -F @vm0/api-contracts lint
- pnpm -F @vm0/api-contracts check-types
- pnpm knip --workspace @vm0/api-contracts
- runtime API compatibility lint against runtime-api-schema-prod/current.json
- cargo test -p api-contracts (22 integration tests)
- cargo test -p zero-cli (npm proxy behavior unchanged)
- cargo fmt --all -- --check
- cargo clippy for api-contracts, zero-cli, and runner with all targets
- cargo doc for api-contracts, zero-cli, and runner with warnings denied
- CARGO_BUILD_JOBS=1 cargo check -p runner --tests
- Simulated bundled runner build verified zero-cli version 0.2.0 and an exact embedded-byte SHA-256 match.

The focused runner test binary was attempted twice locally, including with CARGO_BUILD_JOBS=1, but rustc was killed by the host during final linking with SIGKILL and no compiler diagnostic. The runner production and test targets type-check cleanly, and runner Clippy passes all targets; CI can execute the linked test on its larger runner.

Closes #24970