### PR TITLE
perf(guest-agent): measure codex catalog setup

### DIFF
--- a/crates/guest-agent/src/cli/codex_runtime_config.rs
+++ b/crates/guest-agent/src/cli/codex_runtime_config.rs
@@ -108,8 +108,7 @@ pub(super) fn write_model_catalog(
     let Some(model_catalog) = &config.model_catalog else {
         return Ok(());
     };
-    let started_at = Instant::now();
-    let result = (|| {
+    record_catalog_operation(MODEL_CATALOG_PREPARE_ACTION, || {
         let hydrated_model_catalog = if model_catalog_needs_default_instructions(model_catalog)? {
             Some(inherit_default_model_instructions(
                 model_catalog,
@@ -123,14 +122,7 @@ pub(super) fn write_model_catalog(
         let path = model_catalog_path(codex_home);
         write_model_catalog_json_atomic(codex_home, &path, &serde_json::to_vec(model_catalog)?)?;
         Ok(())
-    })();
-    record_sandbox_op(
-        MODEL_CATALOG_PREPARE_ACTION,
-        started_at.elapsed(),
-        result.is_ok(),
-        None,
-    );
-    result
+    })
 }
 
 fn model_catalog_needs_default_instructions(
@@ -159,8 +151,7 @@ fn model_catalog_needs_default_instructions(
 }
 
 fn load_bundled_model_catalog() -> Result<BundledModelCatalog, AgentError> {
-    let started_at = Instant::now();
-    let result = (|| {
+    record_catalog_operation(MODEL_CATALOG_BUNDLED_LOAD_ACTION, || {
         let output = Command::new("codex")
             .args(["debug", "models", "--bundled"])
             .output()?;
@@ -170,13 +161,16 @@ fn load_bundled_model_catalog() -> Result<BundledModelCatalog, AgentError> {
             ));
         }
         Ok(serde_json::from_slice(&output.stdout)?)
-    })();
-    record_sandbox_op(
-        MODEL_CATALOG_BUNDLED_LOAD_ACTION,
-        started_at.elapsed(),
-        result.is_ok(),
-        None,
-    );
+    })
+}
+
+fn record_catalog_operation<T>(
+    action_type: &str,
+    operation: impl FnOnce() -> Result<T, AgentError>,
+) -> Result<T, AgentError> {
+    let started_at = Instant::now();
+    let result = operation();
+    record_sandbox_op(action_type, started_at.elapsed(), result.is_ok(), None);
     result
 }
 

--- a/crates/guest-agent/src/cli/codex_runtime_config.rs
+++ b/crates/guest-agent/src/cli/codex_runtime_config.rs
@@ -6,10 +6,15 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Instant;
+
+use guest_common::telemetry::record_sandbox_op;
 
 use crate::error::AgentError;
 
 const MODEL_CATALOG_FILENAME: &str = "codex-model-catalog.json";
+const MODEL_CATALOG_PREPARE_ACTION: &str = "codex_model_catalog_prepare";
+const MODEL_CATALOG_BUNDLED_LOAD_ACTION: &str = "codex_model_catalog_bundled_load";
 
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -103,19 +108,29 @@ pub(super) fn write_model_catalog(
     let Some(model_catalog) = &config.model_catalog else {
         return Ok(());
     };
-    let hydrated_model_catalog = if model_catalog_needs_default_instructions(model_catalog)? {
-        Some(inherit_default_model_instructions(
-            model_catalog,
-            load_bundled_model_catalog()?,
-        )?)
-    } else {
-        None
-    };
-    let model_catalog = hydrated_model_catalog.as_ref().unwrap_or(model_catalog);
-    std::fs::create_dir_all(codex_home)?;
-    let path = model_catalog_path(codex_home);
-    write_model_catalog_json_atomic(codex_home, &path, &serde_json::to_vec(model_catalog)?)?;
-    Ok(())
+    let started_at = Instant::now();
+    let result = (|| {
+        let hydrated_model_catalog = if model_catalog_needs_default_instructions(model_catalog)? {
+            Some(inherit_default_model_instructions(
+                model_catalog,
+                load_bundled_model_catalog()?,
+            )?)
+        } else {
+            None
+        };
+        let model_catalog = hydrated_model_catalog.as_ref().unwrap_or(model_catalog);
+        std::fs::create_dir_all(codex_home)?;
+        let path = model_catalog_path(codex_home);
+        write_model_catalog_json_atomic(codex_home, &path, &serde_json::to_vec(model_catalog)?)?;
+        Ok(())
+    })();
+    record_sandbox_op(
+        MODEL_CATALOG_PREPARE_ACTION,
+        started_at.elapsed(),
+        result.is_ok(),
+        None,
+    );
+    result
 }
 
 fn model_catalog_needs_default_instructions(
@@ -144,15 +159,25 @@ fn model_catalog_needs_default_instructions(
 }
 
 fn load_bundled_model_catalog() -> Result<BundledModelCatalog, AgentError> {
-    let output = Command::new("codex")
-        .args(["debug", "models", "--bundled"])
-        .output()?;
-    if !output.status.success() {
-        return Err(AgentError::Execution(
-            "failed to read the bundled Codex model catalog".to_string(),
-        ));
-    }
-    Ok(serde_json::from_slice(&output.stdout)?)
+    let started_at = Instant::now();
+    let result = (|| {
+        let output = Command::new("codex")
+            .args(["debug", "models", "--bundled"])
+            .output()?;
+        if !output.status.success() {
+            return Err(AgentError::Execution(
+                "failed to read the bundled Codex model catalog".to_string(),
+            ));
+        }
+        Ok(serde_json::from_slice(&output.stdout)?)
+    })();
+    record_sandbox_op(
+        MODEL_CATALOG_BUNDLED_LOAD_ACTION,
+        started_at.elapsed(),
+        result.is_ok(),
+        None,
+    );
+    result
 }
 
 fn inherit_default_model_instructions(

--- a/crates/guest-agent/tests/codex_model_catalog_hydration.rs
+++ b/crates/guest-agent/tests/codex_model_catalog_hydration.rs
@@ -7,7 +7,11 @@ use shell_quote::quote_shell_arg;
 use std::path::Path;
 use std::process::{Command, Output};
 
-type TestResult = Result<(), Box<dyn std::error::Error>>;
+type TestError = Box<dyn std::error::Error>;
+type TestResult = Result<(), TestError>;
+
+const MODEL_CATALOG_PREPARE_ACTION: &str = "codex_model_catalog_prepare";
+const MODEL_CATALOG_BUNDLED_LOAD_ACTION: &str = "codex_model_catalog_bundled_load";
 
 #[test]
 fn incomplete_catalog_inherits_bundled_defaults_before_cli_spawn() -> TestResult {
@@ -80,6 +84,16 @@ fn incomplete_catalog_inherits_bundled_defaults_before_cli_spawn() -> TestResult
     );
     assert!(written["models"][1]["model_messages"].is_null());
     assert_eq!(written["unknown_catalog_field"], "preserve");
+    let operations = read_catalog_operations(&runtime_dir)?;
+    assert_eq!(operations.len(), 2);
+    let prepare = single_catalog_operation(&operations, MODEL_CATALOG_PREPARE_ACTION)?;
+    let bundled_load = single_catalog_operation(&operations, MODEL_CATALOG_BUNDLED_LOAD_ACTION)?;
+    assert_catalog_operation_result(prepare, true);
+    assert_catalog_operation_result(bundled_load, true);
+    assert!(
+        operation_duration_ms(prepare)? >= operation_duration_ms(bundled_load)?,
+        "total catalog preparation must contain bundled loading: {operations:?}"
+    );
 
     Ok(())
 }
@@ -128,6 +142,19 @@ fn complete_catalog_bypasses_bundled_discovery() -> TestResult {
         String::from_utf8_lossy(&output.stderr)
     );
     assert_eq!(read_written_catalog(tmp.path())?, input_catalog);
+    let operations = read_catalog_operations(&runtime_dir)?;
+    assert_eq!(operations.len(), 1);
+    assert_catalog_operation_result(
+        single_catalog_operation(&operations, MODEL_CATALOG_PREPARE_ACTION)?,
+        true,
+    );
+    assert!(
+        operations.iter().all(|operation| {
+            operation.get("action_type").and_then(Value::as_str)
+                != Some(MODEL_CATALOG_BUNDLED_LOAD_ACTION)
+        }),
+        "complete catalogs must not emit bundled-load telemetry: {operations:?}"
+    );
 
     Ok(())
 }
@@ -178,6 +205,16 @@ fn bundled_discovery_failure_preserves_existing_catalog_and_stops_cli_spawn() ->
     let error = std::fs::read_to_string(error_path)?;
     assert!(error.contains("Codex setup failed"));
     assert!(error.contains("failed to read the bundled Codex model catalog"));
+    let operations = read_catalog_operations(&runtime_dir)?;
+    assert_eq!(operations.len(), 2);
+    let prepare = single_catalog_operation(&operations, MODEL_CATALOG_PREPARE_ACTION)?;
+    let bundled_load = single_catalog_operation(&operations, MODEL_CATALOG_BUNDLED_LOAD_ACTION)?;
+    assert_catalog_operation_result(prepare, false);
+    assert_catalog_operation_result(bundled_load, false);
+    assert!(
+        operation_duration_ms(prepare)? >= operation_duration_ms(bundled_load)?,
+        "failed total catalog preparation must contain bundled loading: {operations:?}"
+    );
 
     Ok(())
 }
@@ -208,6 +245,67 @@ fn write_run_payload(
 fn read_written_catalog(home: &Path) -> Result<Value, Box<dyn std::error::Error>> {
     let path = home.join(".codex/codex-model-catalog.json");
     Ok(serde_json::from_slice(&std::fs::read(path)?)?)
+}
+
+fn read_catalog_operations(runtime_dir: &Path) -> Result<Vec<Value>, TestError> {
+    let path = guest_contracts::runtime_paths::sandbox_ops_log_file(runtime_dir);
+    let mut operations = Vec::new();
+    for line in std::fs::read_to_string(path)?.lines() {
+        let operation: Value = serde_json::from_str(line)?;
+        let action_type = operation.get("action_type").and_then(Value::as_str);
+        if action_type == Some(MODEL_CATALOG_PREPARE_ACTION)
+            || action_type == Some(MODEL_CATALOG_BUNDLED_LOAD_ACTION)
+        {
+            operations.push(operation);
+        }
+    }
+    Ok(operations)
+}
+
+fn single_catalog_operation<'a>(
+    operations: &'a [Value],
+    action_type: &str,
+) -> Result<&'a Value, TestError> {
+    let mut matching = operations.iter().filter(|operation| {
+        operation.get("action_type").and_then(Value::as_str) == Some(action_type)
+    });
+    let operation = matching.next().ok_or_else(|| {
+        std::io::Error::other(format!("missing {action_type} operation: {operations:?}"))
+    })?;
+    if matching.next().is_some() {
+        return Err(std::io::Error::other(format!(
+            "duplicate {action_type} operation: {operations:?}"
+        ))
+        .into());
+    }
+    Ok(operation)
+}
+
+fn assert_catalog_operation_result(operation: &Value, expected_success: bool) {
+    assert_eq!(
+        operation.get("success").and_then(Value::as_bool),
+        Some(expected_success)
+    );
+    assert!(
+        operation
+            .get("duration_ms")
+            .and_then(Value::as_u64)
+            .is_some(),
+        "operation must include duration_ms: {operation:?}"
+    );
+    assert!(
+        operation.get("error").is_none(),
+        "catalog timing must not emit an error dimension: {operation:?}"
+    );
+}
+
+fn operation_duration_ms(operation: &Value) -> Result<u64, TestError> {
+    operation
+        .get("duration_ms")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| {
+            std::io::Error::other("catalog operation duration must be an unsigned integer").into()
+        })
 }
 
 struct GuestAgentInvocation<'a> {


### PR DESCRIPTION
## Summary

- record total Codex model catalog preparation latency and success in guest sandbox telemetry
- record the nested bundled-catalog load only when an incomplete catalog requires hydration
- verify operation count, nesting, success, and failure through the existing guest-agent entry-point integration tests

## Scope

- uses the existing best-effort sandbox-operation JSONL transport
- preserves catalog validation, hydration, command count, atomic writes, and propagated errors
- does not add API, schema, database, runner protocol, dashboard, or feature-switch changes

## Validation

- `cargo fmt --check --all`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-agent --no-deps`
- `cargo test -p guest-agent --test codex_model_catalog_hydration`
- `cargo test -p guest-agent --all-targets --all-features`

Closes #24979

Parent context: #24903
