### PR TITLE
feat: enable zero image recognition globally

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -222,7 +222,7 @@ describe("auth tokens", () => {
     );
   });
 
-  it("gates image recognition on both the rollout and run eligibility", () => {
+  it("gates image recognition on run eligibility", () => {
     const staffOrgId = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
     const ineligibleToken = generateZeroToken(
       "user_zero",
@@ -236,23 +236,17 @@ describe("auth tokens", () => {
       undefined,
       { imageRecognitionAvailable: true },
     );
-    const rolloutDisabledToken = generateZeroToken(
-      "user_zero",
-      "run_zero",
-      staffOrgId,
-      { [FeatureSwitchKey.ZeroImageRecognition]: false },
-      { imageRecognitionAvailable: true },
-    );
-
     expect(verifyZeroToken(ineligibleToken)?.capabilities).not.toContain(
       "image-recognition:write",
     );
     expect(verifyZeroToken(eligibleToken)?.capabilities).toContain(
       "image-recognition:write",
     );
-    expect(verifyZeroToken(rolloutDisabledToken)?.capabilities).not.toContain(
-      "image-recognition:write",
-    );
+    expect(decodeZeroTokenPayloadForTest(eligibleToken)).toMatchObject({
+      featureSwitchOverrides: {
+        zeroImageRecognition: true,
+      },
+    });
   });
 
   it("gates browser capabilities on both the rollout and thread access", () => {

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -21,6 +21,9 @@ import { singleton } from "../../lib/singleton";
 
 const SANDBOX_TOKEN_PREFIX = "vm0_sandbox_";
 const PAT_TOKEN_PREFIX = "vm0_pat_";
+// Previous runner-bundled Zero CLIs gate `recognize` with this key. Keep the
+// positive token override until those runners have drained after global rollout.
+const LEGACY_IMAGE_RECOGNITION_SWITCH = "zeroImageRecognition";
 // Covers the runner's two-hour execution budget plus claim, startup,
 // finalization, and terminal report time.
 const SANDBOX_TOKEN_TTL_SECONDS = 3 * 60 * 60;
@@ -30,7 +33,6 @@ const CONDITIONAL_CAPABILITIES = [
   ["browser:read", FeatureSwitchKey.ZeroBrowser],
   ["browser:write", FeatureSwitchKey.ZeroBrowser],
   ["connector:write", FeatureSwitchKey.CustomConnectorCliCreate],
-  ["image-recognition:write", FeatureSwitchKey.ZeroImageRecognition],
 ] as const satisfies readonly (readonly [ZeroCapability, FeatureSwitchKey])[];
 
 const AGENT_EXCLUDED_CAPABILITIES = [
@@ -334,6 +336,13 @@ export function generateZeroToken(
       capabilities.push(capability);
     }
   }
+  const featureSwitchOverrides =
+    options?.imageRecognitionAvailable === true
+      ? {
+          ...overrides,
+          [LEGACY_IMAGE_RECOGNITION_SWITCH]: true,
+        }
+      : overrides;
 
   const payload: z.infer<typeof zeroTokenPayloadSchema> = {
     scope: "zero",
@@ -341,7 +350,7 @@ export function generateZeroToken(
     runId,
     orgId,
     capabilities,
-    ...(overrides === undefined ? {} : { featureSwitchOverrides: overrides }),
+    ...(featureSwitchOverrides === undefined ? {} : { featureSwitchOverrides }),
     ...(capabilities.includes("computer-use:write") &&
     options?.computerUseHostId
       ? { computerUseHostId: options.computerUseHostId }

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -21,8 +21,9 @@ import { singleton } from "../../lib/singleton";
 
 const SANDBOX_TOKEN_PREFIX = "vm0_sandbox_";
 const PAT_TOKEN_PREFIX = "vm0_pat_";
-// Previous runner-bundled Zero CLIs gate `recognize` with this key. Keep the
-// positive token override until those runners have drained after global rollout.
+// Pre-rollout TypeScript Zero CLI versions gate `recognize` with this key.
+// Keep the positive token override until those versions can no longer run,
+// including from resumed sandboxes or npm caches.
 const LEGACY_IMAGE_RECOGNITION_SWITCH = "zeroImageRecognition";
 // Covers the runner's two-hour execution budget plus claim, startup,
 // finalization, and terminal report time.

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -6059,10 +6059,9 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     await api.requestCancelRun(actor, sent.body.runId, [200]);
   });
 
-  it("offers image recognition only for enabled image-unsupported models", async () => {
+  it("offers image recognition only for image-unsupported models", async () => {
     const api = createRunsApi(context);
     const chat = createChatFilesBddApi(context);
-    const connectors = createConnectorBddApi(context);
     const unsupportedModel = "deepseek-v4-flash";
     const supportedModel = "claude-sonnet-4-6";
     const unknownModel = "gpt-5.6-sol";
@@ -6128,61 +6127,46 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       };
     }
 
-    const disabledUnsupported = await claimModel(unsupportedModel);
-    const disabledToken = disabledUnsupported.claim.environment?.ZERO_TOKEN;
-    if (!disabledToken) {
-      throw new Error("Expected the disabled run to expose ZERO_TOKEN");
+    const unsupported = await claimModel(unsupportedModel);
+    const unsupportedToken = unsupported.claim.environment?.ZERO_TOKEN;
+    if (!unsupportedToken) {
+      throw new Error(
+        "Expected the unsupported-model run to expose ZERO_TOKEN",
+      );
     }
-    expect(disabledUnsupported.claim.appendSystemPrompt ?? "").not.toContain(
-      "zero recognize",
-    );
-    expect(verifyZeroToken(disabledToken)?.capabilities).not.toContain(
-      "image-recognition:write",
-    );
-    await api.requestCancelRun(actor, disabledUnsupported.runId, [200]);
-
-    await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ZeroImageRecognition]: true,
-    });
-
-    const enabledUnsupported = await claimModel(unsupportedModel);
-    const enabledToken = enabledUnsupported.claim.environment?.ZERO_TOKEN;
-    if (!enabledToken) {
-      throw new Error("Expected the enabled run to expose ZERO_TOKEN");
-    }
-    expect(enabledUnsupported.claim.appendSystemPrompt ?? "").toContain(
+    expect(unsupported.claim.appendSystemPrompt ?? "").toContain(
       'zero recognize --file <image-path> --prompt "<instruction>"',
     );
-    expect(verifyZeroToken(enabledToken)?.capabilities).toContain(
+    expect(verifyZeroToken(unsupportedToken)?.capabilities).toContain(
       "image-recognition:write",
     );
-    await api.requestCancelRun(actor, enabledUnsupported.runId, [200]);
+    await api.requestCancelRun(actor, unsupported.runId, [200]);
 
-    const enabledSupported = await claimModel(supportedModel);
-    const supportedToken = enabledSupported.claim.environment?.ZERO_TOKEN;
+    const supported = await claimModel(supportedModel);
+    const supportedToken = supported.claim.environment?.ZERO_TOKEN;
     if (!supportedToken) {
       throw new Error("Expected the supported-model run to expose ZERO_TOKEN");
     }
-    expect(enabledSupported.claim.appendSystemPrompt ?? "").not.toContain(
+    expect(supported.claim.appendSystemPrompt ?? "").not.toContain(
       "zero recognize",
     );
     expect(verifyZeroToken(supportedToken)?.capabilities).not.toContain(
       "image-recognition:write",
     );
-    await api.requestCancelRun(actor, enabledSupported.runId, [200]);
+    await api.requestCancelRun(actor, supported.runId, [200]);
 
-    const enabledUnknown = await claimModel(unknownModel);
-    const unknownToken = enabledUnknown.claim.environment?.ZERO_TOKEN;
+    const unknown = await claimModel(unknownModel);
+    const unknownToken = unknown.claim.environment?.ZERO_TOKEN;
     if (!unknownToken) {
       throw new Error("Expected the unknown-model run to expose ZERO_TOKEN");
     }
-    expect(enabledUnknown.claim.appendSystemPrompt ?? "").not.toContain(
+    expect(unknown.claim.appendSystemPrompt ?? "").not.toContain(
       "zero recognize",
     );
     expect(verifyZeroToken(unknownToken)?.capabilities).not.toContain(
       "image-recognition:write",
     );
-    await api.requestCancelRun(actor, enabledUnknown.runId, [200]);
+    await api.requestCancelRun(actor, unknown.runId, [200]);
   });
 
   it("injects codex multi-auth provider credentials and proves them via firewall auth", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -93,6 +93,7 @@ describe("/api/zero/feature-switches", () => {
     expect(current.body.supportsCustomModelGateways).toBeTruthy();
     expect(current.body.supportsImageRecognition).toBeTruthy();
     expect(current.body.imageRecognitionRolloutComplete).toBeTruthy();
+    expect(current.body.effectiveSwitches.zeroImageRecognition).toBeTruthy();
     expect(
       current.body.effectiveSwitches[
         FeatureSwitchKey.StructuredPromptInlineTemplates

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -83,6 +83,7 @@ describe("/api/zero/feature-switches", () => {
       ],
     ).toBeTruthy();
     expect(updated.body.supportsImageRecognition).toBeTruthy();
+    expect(updated.body.imageRecognitionRolloutComplete).toBeTruthy();
 
     const current = await accept(client().get({ headers }), [200]);
     expect(current.body.switches).toStrictEqual({
@@ -91,6 +92,7 @@ describe("/api/zero/feature-switches", () => {
     expect(current.body.supportsCustomConnectorOAuth2).toBeTruthy();
     expect(current.body.supportsCustomModelGateways).toBeTruthy();
     expect(current.body.supportsImageRecognition).toBeTruthy();
+    expect(current.body.imageRecognitionRolloutComplete).toBeTruthy();
     expect(
       current.body.effectiveSwitches[
         FeatureSwitchKey.StructuredPromptInlineTemplates

--- a/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
@@ -29,6 +29,7 @@ function featureSwitchResponseBody(params: {
   readonly supportsCustomConnectorOAuth2: boolean;
   readonly supportsCustomModelGateways: boolean;
   readonly supportsImageRecognition: boolean;
+  readonly imageRecognitionRolloutComplete: true;
 }) {
   const effectiveSwitches = getAllFeatureStates({
     orgId: params.orgId,
@@ -46,6 +47,7 @@ function featureSwitchResponseBody(params: {
     supportsCustomConnectorOAuth2: params.supportsCustomConnectorOAuth2,
     supportsCustomModelGateways: params.supportsCustomModelGateways,
     supportsImageRecognition: params.supportsImageRecognition,
+    imageRecognitionRolloutComplete: params.imageRecognitionRolloutComplete,
   };
 }
 
@@ -67,6 +69,7 @@ const getFeatureSwitchesInner$ = computed(async (get): Promise<unknown> => {
       supportsCustomConnectorOAuth2: true,
       supportsCustomModelGateways,
       supportsImageRecognition: true,
+      imageRecognitionRolloutComplete: true,
     }),
   };
 });
@@ -107,6 +110,7 @@ const updateFeatureSwitchesInner$ = command(
         supportsCustomConnectorOAuth2: true,
         supportsCustomModelGateways,
         supportsImageRecognition: true,
+        imageRecognitionRolloutComplete: true,
       }),
     };
   },

--- a/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
@@ -21,6 +21,8 @@ const featureSwitchesAuthOptions = {
   missingOrganizationStatus: 401,
 } as const;
 
+const LEGACY_IMAGE_RECOGNITION_SWITCH = "zeroImageRecognition";
+
 function featureSwitchResponseBody(params: {
   readonly orgId: string;
   readonly userId: string;
@@ -31,14 +33,20 @@ function featureSwitchResponseBody(params: {
   readonly supportsImageRecognition: boolean;
   readonly imageRecognitionRolloutComplete: true;
 }) {
-  const effectiveSwitches = getAllFeatureStates({
+  const registeredEffectiveSwitches = getAllFeatureStates({
     orgId: params.orgId,
     userId: params.userId,
     overrides: params.switches,
   });
-  effectiveSwitches[FeatureSwitchKey.ZeroMailReplyFollowUp] =
-    effectiveSwitches[FeatureSwitchKey.ZeroMailReplyFollowUp] &&
+  registeredEffectiveSwitches[FeatureSwitchKey.ZeroMailReplyFollowUp] =
+    registeredEffectiveSwitches[FeatureSwitchKey.ZeroMailReplyFollowUp] &&
     isZeroMailReplyFollowUpRolloutEnabled();
+  // Pre-rollout Platform bundles still read the removed switch key. Keep the
+  // positive effective value while those bundles can remain open in browsers.
+  const effectiveSwitches = {
+    ...registeredEffectiveSwitches,
+    [LEGACY_IMAGE_RECOGNITION_SWITCH]: true,
+  };
 
   return {
     switches: params.switches,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -70,10 +70,8 @@ import {
 } from "@vm0/core/frameworks";
 import {
   getAllFeatureStates,
-  isFeatureEnabled,
   type FeatureSwitchContext,
 } from "@vm0/core/feature-switch";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { resolveSkillRef, parseGitHubTreeUrl } from "@vm0/core/github-url";
 import {
   getCustomConnectorSkillName,
@@ -7622,15 +7620,10 @@ function prepareRunOutputMetadata(args: {
 
 function isImageRecognitionAvailableForRun(args: {
   readonly includeZeroTokenSecret: boolean | undefined;
-  readonly featureSwitchContext: FeatureSwitchContext;
   readonly selectedModel: string | undefined;
 }): boolean {
   return (
     args.includeZeroTokenSecret === true &&
-    isFeatureEnabled(
-      FeatureSwitchKey.ZeroImageRecognition,
-      args.featureSwitchContext,
-    ) &&
     getModelImageInputSupport(args.selectedModel) === "unsupported"
   );
 }
@@ -7755,7 +7748,6 @@ function prepareRunContext(input: {
         featureSwitchContext: bodyContext.featureSwitchContext,
         imageRecognitionAvailable: isImageRecognitionAvailableForRun({
           includeZeroTokenSecret: args.includeZeroTokenSecret,
-          featureSwitchContext: bodyContext.featureSwitchContext,
           selectedModel:
             runtimeContext.modelProvider?.selectedModel ??
             args.selectedModelOverride,

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -156,7 +156,7 @@ describe("registerZeroCommands", () => {
     vi.stubEnv("ZERO_TOKEN", undefined);
 
     const prog = buildProgram();
-    expect(hiddenCommandNames(prog)).toEqual([]);
+    expect(hiddenCommandNames(prog)).toEqual(["recognize"]);
     expect(registeredCommandNames(prog)).toContain("upgrade");
     expect(registeredCommandNames(prog)).not.toContain("browser");
   });
@@ -202,23 +202,24 @@ describe("registerZeroCommands", () => {
       "scrape",
       "people-search",
       "web-search",
+      "recognize",
       "finance",
       "banking",
       "goal",
     ]);
   });
 
-  it("should keep default-disabled feature commands unregistered with malformed token", () => {
+  it("should hide run-only commands and keep feature commands unregistered with malformed token", () => {
     vi.stubEnv("ZERO_TOKEN", "not-a-valid-token");
 
     const prog = buildProgram();
 
-    expect(hiddenCommandNames(prog)).toEqual([]);
+    expect(hiddenCommandNames(prog)).toEqual(["recognize"]);
     expect(registeredCommandNames(prog)).toContain("upgrade");
     expect(registeredCommandNames(prog)).not.toContain("browser");
   });
 
-  it("should keep default-disabled feature commands unregistered outside zero scope", () => {
+  it("should hide run-only commands and keep feature commands unregistered outside zero scope", () => {
     const token = buildZeroToken({
       scope: "sandbox",
       capabilities: ["agent:read"],
@@ -227,7 +228,7 @@ describe("registerZeroCommands", () => {
 
     const prog = buildProgram();
 
-    expect(hiddenCommandNames(prog)).toEqual([]);
+    expect(hiddenCommandNames(prog)).toEqual(["recognize"]);
     expect(registeredCommandNames(prog)).toContain("upgrade");
     expect(registeredCommandNames(prog)).not.toContain("browser");
   });
@@ -733,9 +734,7 @@ describe("registerZeroCommands", () => {
 
   it("should expose recognition only to eligible Zero runs", () => {
     vi.stubEnv("ZERO_TOKEN", undefined);
-    const noTokenProgram = buildProgram({
-      [FeatureSwitchKey.ZeroImageRecognition]: true,
-    });
+    const noTokenProgram = buildProgram();
     expect(registeredCommandNames(noTokenProgram)).toContain("recognize");
     expect(hiddenCommandNames(noTokenProgram)).toContain("recognize");
 
@@ -744,9 +743,6 @@ describe("registerZeroCommands", () => {
       userId: "user-1",
       orgId: "org-1",
       capabilities: [],
-      featureSwitchOverrides: {
-        [FeatureSwitchKey.ZeroImageRecognition]: true,
-      },
     });
     vi.stubEnv("ZERO_TOKEN", missingCapabilityToken);
     expect(hiddenCommandNames(buildProgram())).toContain("recognize");
@@ -756,9 +752,6 @@ describe("registerZeroCommands", () => {
       userId: "user-1",
       orgId: "org-1",
       capabilities: ["image-recognition:write"],
-      featureSwitchOverrides: {
-        [FeatureSwitchKey.ZeroImageRecognition]: true,
-      },
     });
     vi.stubEnv("ZERO_TOKEN", eligibleToken);
     expect(visibleCommandNames(buildProgram())).toContain("recognize");

--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -48,6 +48,7 @@ describe("zero CLI program", () => {
       "scrape",
       "web-search",
       "people-search",
+      "recognize",
       "finance",
       "banking",
     ];
@@ -72,7 +73,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 39 commands", () => {
-    expect(commandNames).toHaveLength(39);
+  it("should have exactly 40 commands", () => {
+    expect(commandNames).toHaveLength(40);
   });
 });

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -75,7 +75,6 @@ const COMMAND_FEATURE_SWITCH_MAP: Readonly<
   Partial<Record<string, FeatureSwitchKey>>
 > = {
   browser: FeatureSwitchKey.ZeroBrowser,
-  recognize: FeatureSwitchKey.ZeroImageRecognition,
 };
 
 const RUN_ONLY_COMMANDS = new Set(["recognize"]);

--- a/turbo/apps/platform/src/mocks/handlers/api-feature-switches.helpers.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-feature-switches.helpers.ts
@@ -28,6 +28,7 @@ export function setMockFeatureSwitches(
         supportsCustomConnectorOAuth2: true,
         supportsCustomModelGateways: true,
         supportsImageRecognition: true,
+        imageRecognitionRolloutComplete: true,
       });
     }),
   );

--- a/turbo/apps/platform/src/mocks/handlers/api-feature-switches.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-feature-switches.ts
@@ -21,6 +21,8 @@ export const apiFeatureSwitchesHandlers = [
       switches: DEFAULT_SWITCH_OVERRIDES,
       effectiveSwitches: DEFAULT_SWITCH_OVERRIDES,
       supportsCustomConnectorOAuth2: true,
+      supportsImageRecognition: true,
+      imageRecognitionRolloutComplete: true,
     });
   }),
 
@@ -29,6 +31,8 @@ export const apiFeatureSwitchesHandlers = [
       switches: body.switches,
       effectiveSwitches: body.switches,
       supportsCustomConnectorOAuth2: true,
+      supportsImageRecognition: true,
+      imageRecognitionRolloutComplete: true,
     });
   }),
 

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import { detachedSetupPage, setupPage } from "../../__tests__/page-helper.ts";
 import {
   featureSwitch$,
-  zeroImageRecognitionEnabled$,
+  imageRecognitionAvailable$,
 } from "../external/feature-switch.ts";
 import { testContext } from "./test-helpers.ts";
 
@@ -77,16 +77,15 @@ describe("bootstrap feature switch hydration", () => {
     ).toBeFalsy();
   });
 
-  it("keeps image recognition disabled when the API lacks support", async () => {
+  it("keeps image recognition disabled against a pre-rollout API", async () => {
     context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
       return respond(200, {
-        switches: { [FeatureSwitchKey.ZeroImageRecognition]: true },
-        effectiveSwitches: {
-          [FeatureSwitchKey.ZeroImageRecognition]: true,
-        },
+        switches: {},
+        effectiveSwitches: {},
         supportsStructuredInlineTemplates: true,
         supportsCustomConnectorOAuth2: true,
         supportsCustomModelGateways: true,
+        supportsImageRecognition: true,
       });
     });
 
@@ -96,35 +95,31 @@ describe("bootstrap feature switch hydration", () => {
       withoutRender: true,
     });
 
-    expect(context.store.get(zeroImageRecognitionEnabled$)).toBeFalsy();
+    expect(context.store.get(imageRecognitionAvailable$)).toBeFalsy();
   });
 
-  it("waits for current API support before trusting cached image recognition", async () => {
+  it("waits for the current API to confirm global image recognition", async () => {
     context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
       return respond(200, {
-        switches: { [FeatureSwitchKey.ZeroImageRecognition]: true },
-        effectiveSwitches: {
-          [FeatureSwitchKey.ZeroImageRecognition]: true,
-        },
+        switches: {},
+        effectiveSwitches: {},
         supportsStructuredInlineTemplates: true,
         supportsCustomConnectorOAuth2: true,
         supportsCustomModelGateways: true,
         supportsImageRecognition: true,
+        imageRecognitionRolloutComplete: true,
       });
     });
 
     detachedSetupPage({
       context,
       path: "/error",
-      featureSwitches: {
-        [FeatureSwitchKey.ZeroImageRecognition]: true,
-      },
       withoutRender: true,
     });
 
-    expect(context.store.get(zeroImageRecognitionEnabled$)).toBeFalsy();
+    expect(context.store.get(imageRecognitionAvailable$)).toBeFalsy();
     await waitFor(() => {
-      expect(context.store.get(zeroImageRecognitionEnabled$)).toBeTruthy();
+      expect(context.store.get(imageRecognitionAvailable$)).toBeTruthy();
     });
   });
 

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -67,7 +67,7 @@ import {
   codexFastModeEnabled$,
   featureSwitch$,
   zeroBrowserEnabled$,
-  zeroImageRecognitionEnabled$,
+  imageRecognitionAvailable$,
 } from "../external/feature-switch.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { pinnedAgentIds$ } from "../zero-page/zero-pinned-agents.ts";
@@ -2517,7 +2517,7 @@ function createPerformSendMessage(deps: SendMessageDeps) {
                 excludeVisualAttachments:
                   shouldExcludeVisualAttachmentsForModel(
                     request.modelSelection?.selectedModel,
-                    get(zeroImageRecognitionEnabled$),
+                    get(imageRecognitionAvailable$),
                   ),
               },
               signal,
@@ -2675,7 +2675,7 @@ function createQueueMessage(deps: QueueMessageDeps) {
         {
           excludeVisualAttachments: shouldExcludeVisualAttachmentsForModel(
             modelSelection?.selectedModel,
-            get(zeroImageRecognitionEnabled$),
+            get(imageRecognitionAvailable$),
           ),
         },
         signal,

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -38,7 +38,7 @@ import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { userModelPreference$ } from "../external/user-model-preference.ts";
 import {
   featureSwitch$,
-  zeroImageRecognitionEnabled$,
+  imageRecognitionAvailable$,
 } from "../external/feature-switch.ts";
 import { codexFastModeLocalDefault$ } from "../zero-page/codex-fast-local-default.ts";
 import { logger } from "../log.ts";
@@ -507,7 +507,7 @@ const sendNewThreadMessage$ = command(
       {
         excludeVisualAttachments: shouldExcludeVisualAttachmentsForModel(
           resolvedModelSelection.selectedModel,
-          get(zeroImageRecognitionEnabled$),
+          get(imageRecognitionAvailable$),
         ),
       },
       signal,

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -14,7 +14,7 @@ export const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v3";
 
 const { set$: setFeatureSwitchLocalStorage$, get$: featureSwitchCache$ } =
   localStorageSignals(FEATURE_SWITCH_CACHE_KEY);
-const imageRecognitionApiSupported$ = state(false);
+const imageRecognitionGloballyAvailable$ = state(false);
 
 // Pinned to the API backend: feature switches bootstrap before the platform API
 // client is available.
@@ -59,11 +59,8 @@ export const featureSwitch$ = computed((get) => {
   return JSON.parse(raw) as Record<FeatureSwitchKey, boolean>;
 });
 
-export const zeroImageRecognitionEnabled$ = computed((get): boolean => {
-  return (
-    get(imageRecognitionApiSupported$) &&
-    (get(featureSwitch$)[FeatureSwitchKey.ZeroImageRecognition] ?? false)
-  );
+export const imageRecognitionAvailable$ = computed((get): boolean => {
+  return get(imageRecognitionGloballyAvailable$);
 });
 
 export const artifactSidebarInlineOpenEnabled$ = computed((get): boolean => {
@@ -112,7 +109,7 @@ export const customConnectorPermissionsEnabled$ = computed((get): boolean => {
 
 export const reloadFeatureSwitch$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    set(imageRecognitionApiSupported$, false);
+    set(imageRecognitionGloballyAvailable$, false);
     const clerk = await get(clerk$);
     signal.throwIfAborted();
     if (!clerk.user || !clerk.organization) {
@@ -145,14 +142,15 @@ export const reloadFeatureSwitch$ = command(
     if (result.body.supportsCustomModelGateways !== true) {
       combined[FeatureSwitchKey.CustomModelGateways] = false;
     }
-    const supportsImageRecognition =
-      result.body.supportsImageRecognition === true;
-    if (!supportsImageRecognition) {
-      combined[FeatureSwitchKey.ZeroImageRecognition] = false;
-    }
+    // The existing support bit predates global rollout. Requiring the new
+    // marker keeps a new Platform fail-closed while talking to an older API
+    // that still gates recognition by user or organization.
+    const imageRecognitionGloballyAvailable =
+      result.body.supportsImageRecognition === true &&
+      result.body.imageRecognitionRolloutComplete === true;
 
     set(setFeatureSwitchLocalStorage$, JSON.stringify(combined));
-    set(imageRecognitionApiSupported$, supportsImageRecognition);
+    set(imageRecognitionGloballyAvailable$, imageRecognitionGloballyAvailable);
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
@@ -13,7 +13,7 @@ import {
 } from "../chat-page/resolve-draft-attachments.ts";
 import {
   featureSwitch$,
-  zeroImageRecognitionEnabled$,
+  imageRecognitionAvailable$,
 } from "../external/feature-switch.ts";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import type { DraftSignals, ZeroChatAttachment } from "./chat-draft.ts";
@@ -631,7 +631,7 @@ function createComposerSubmissionSignals(
       let hasContent = get(workflowComposer.hasInput$);
       if (!hasContent && attachments.length > 0) {
         const modelSelection = await get(options.modelSelection$);
-        const imageRecognitionEnabled = get(zeroImageRecognitionEnabled$);
+        const imageRecognitionEnabled = get(imageRecognitionAvailable$);
         hasContent = hasVisibleAttachment(
           modelSelection,
           attachments,
@@ -685,7 +685,7 @@ function createComposerSubmissionSignals(
             }
             const modelSelection = await get(options.modelSelection$);
             signal.throwIfAborted();
-            const imageRecognitionEnabled = get(zeroImageRecognitionEnabled$);
+            const imageRecognitionEnabled = get(imageRecognitionAvailable$);
             if (
               !hasVisibleAttachment(
                 modelSelection,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -21,6 +21,7 @@ import { zeroModelPoliciesMainContract } from "@vm0/api-contracts/contracts/zero
 import { zeroBillingStatusContract } from "@vm0/api-contracts/contracts/zero-billing";
 import { zeroUserModelPreferenceContract } from "@vm0/api-contracts/contracts/zero-user-model-preference";
 import { zeroWorkflowsCollectionContract } from "@vm0/api-contracts/contracts/zero-workflows";
+import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { ZERO_RECOGNITION_MAX_FILE_BYTES } from "@vm0/api-contracts/contracts/zero-recognition";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { triggerAblyEvent } from "../../../mocks/ably.ts";
@@ -82,6 +83,16 @@ import {
 beforeEach(() => {
   context.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
 });
+
+function mockPreRolloutImageRecognitionApi(): void {
+  context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
+    return respond(200, {
+      switches: {},
+      effectiveSwitches: {},
+      supportsImageRecognition: true,
+    });
+  });
+}
 
 afterEach(async () => {
   document.documentElement.lang = DEFAULT_LOCALE;
@@ -1902,10 +1913,11 @@ describe("chat composer models", () => {
     });
   });
 
-  it("keeps unsupported visual files out of text-only model sends while accepting text files", async () => {
+  it("keeps unsupported visual files out when the API has not completed rollout", async () => {
     const user = userEvent.setup({ delay: null });
     mockOrgModelRoutes("glm-5.1");
     mockAgent();
+    mockPreRolloutImageRecognitionApi();
     context.mocks.upload.success({
       id: "notes-upload",
       filename: "notes.txt",
@@ -2076,9 +2088,6 @@ describe("chat composer models", () => {
     detachedSetupPage({
       context,
       path: `/agents/${AGENT_ID}/chat`,
-      featureSwitches: {
-        [FeatureSwitchKey.ZeroImageRecognition]: true,
-      },
     });
 
     await expectComposerModel("GLM-5.1");
@@ -2173,9 +2182,6 @@ describe("chat composer models", () => {
     detachedSetupPage({
       context,
       path: `/agents/${AGENT_ID}/chat`,
-      featureSwitches: {
-        [FeatureSwitchKey.ZeroImageRecognition]: true,
-      },
     });
 
     await expectComposerModel("GLM-5.1");
@@ -2213,10 +2219,11 @@ describe("chat composer models", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("hides an accepted visual attachment after switching to a text-only model", async () => {
+  it("hides an accepted visual attachment against a pre-rollout API", async () => {
     const user = userEvent.setup({ delay: null });
     mockOrgModelRoutes("claude-sonnet-4-6");
     mockAgent();
+    mockPreRolloutImageRecognitionApi();
     context.mocks.upload.success({
       id: "visual-model-switch",
       filename: "storyboard.png",
@@ -2270,9 +2277,6 @@ describe("chat composer models", () => {
     detachedSetupPage({
       context,
       path: `/agents/${AGENT_ID}/chat`,
-      featureSwitches: {
-        [FeatureSwitchKey.ZeroImageRecognition]: true,
-      },
     });
 
     await expectComposerModel("Claude Sonnet 4.6");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -574,9 +574,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: AGENT_CHAT_PATH,
-      featureSwitches: {
-        [FeatureSwitchKey.ZeroImageRecognition]: true,
-      },
     });
 
     await waitFor(() => {
@@ -670,9 +667,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ZeroImageRecognition]: true,
-      },
     });
 
     const textarea = await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -767,9 +767,6 @@ describe("chat run queue", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ZeroImageRecognition]: true,
-      },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -156,7 +156,7 @@ import {
   composerUploadPopoverEnabled$,
   composerConnectorPermissionsEnabled$,
   featureSwitch$,
-  zeroImageRecognitionEnabled$,
+  imageRecognitionAvailable$,
 } from "../../signals/external/feature-switch.ts";
 import {
   computerUseHosts$,
@@ -7005,7 +7005,7 @@ function useComposerVisualAttachmentUnsupported(
   signals: ComposerSignals,
 ): VisualAttachmentUnsupportedState | null {
   const modelSelection = useLastResolved(signals.model.modelSelection$) ?? null;
-  const imageRecognitionEnabled = useGet(zeroImageRecognitionEnabled$);
+  const imageRecognitionEnabled = useGet(imageRecognitionAvailable$);
   return getVisualAttachmentUnsupportedState(
     {
       value: modelSelection,
@@ -7318,7 +7318,7 @@ function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
   const setModelSelection = useSet(signals.model.setModelSelection$);
   const configureSelectedModel = useSet(signals.model.configureSelectedModel$);
   const attachments = useGet(signals.draft.attachments$);
-  const imageRecognitionEnabled = useGet(zeroImageRecognitionEnabled$);
+  const imageRecognitionEnabled = useGet(imageRecognitionAvailable$);
   const pageSignal = useGet(pageSignal$);
   const value = modelSelection.state === "hasData" ? modelSelection.data : null;
   const modelPickerLoading = modelSelection.state === "loading";

--- a/turbo/packages/api-contracts/src/contracts/zero-feature-switches.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-feature-switches.ts
@@ -27,6 +27,12 @@ export const featureSwitchesResponseSchema = z.object({
    * Older API deployments omit this field.
    */
   supportsImageRecognition: z.boolean().optional(),
+  /**
+   * Optional handshake indicating managed image recognition is globally
+   * available without a feature switch. Older API deployments omit this field.
+   * Remove after APIs with the pre-rollout semantics are no longer reachable.
+   */
+  imageRecognitionRolloutComplete: z.literal(true).optional(),
 });
 
 export type FeatureSwitchesResponse = z.infer<

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -55,9 +55,6 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.ZeroChatMessaging, {})).toBe(
       false,
     );
-    expect(isFeatureEnabled(FeatureSwitchKey.ZeroImageRecognition, {})).toBe(
-      false,
-    );
     expect(isFeatureEnabled(FeatureSwitchKey.ZeroMailReplyFollowUp, {})).toBe(
       false,
     );
@@ -136,7 +133,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroBrowser]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroChatMessaging]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ZeroImageRecognition]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroMailReplyFollowUp]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(true);
@@ -166,7 +162,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroBrowser]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroChatMessaging]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ZeroImageRecognition]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroMailReplyFollowUp]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -44,7 +44,6 @@ export enum FeatureSwitchKey {
   ZeroDebug = "zeroDebug",
   ZeroBrowser = "zeroBrowser",
   ZeroChatMessaging = "zeroChatMessaging",
-  ZeroImageRecognition = "zeroImageRecognition",
   ZeroMailReplyFollowUp = "zeroMailReplyFollowUp",
   RustZeroCli = "rustZeroCli",
   Banking = "banking",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -475,13 +475,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ZeroImageRecognition]: {
-    maintainer: "liangyou@vm0.ai",
-    description:
-      "Enable managed image recognition for Zero runs whose selected model does not support image input.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.RustZeroCli]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- remove the `zeroImageRecognition` feature switch from core, API eligibility, CLI visibility, and Platform behavior
- make managed recognition available to every eligible Zero run whose selected model explicitly lacks image input support
- keep mixed-version deployments safe with temporary bridges for old Platform bundles and pre-rollout TypeScript CLIs, plus a fail-closed API rollout handshake for new Platform bundles

## Compatibility and exclusions

- The API temporarily reports the removed `zeroImageRecognition` key as enabled in `effectiveSwitches`, so already-loaded pre-rollout Platform bundles keep exposing the globally available capability.
- Models with native image input support or unknown support continue using their existing attachment path.
- Historical database overrides are not migrated or deleted; unregistered feature-switch keys are already ignored.
- The stable `supportsImageRecognition` API capability remains in place.
- Follow-up compatibility removal is tracked in #24997 after old APIs, old Platform bundles, and pre-rollout CLI copies can no longer run, including from resumed sandboxes or npm caches. This PR does not close that issue.

## Validation

- `pnpm format`
- affected core, API contracts, API, CLI, and Platform lint and type checks
- `pnpm knip`
- core feature-switch tests: 213 passed
- API contract tests: 531 passed
- CLI capability visibility tests: 80 passed
- CLI command tree test: 4 passed
- API token and feature-switch route tests: 20 passed
- targeted API run-lifecycle scenario: 1 passed
- focused Platform bootstrap, composer, lifecycle, and queue tests: 96 passed
- post-rebase CLI tests: 84 passed
- post-rebase Platform tests: 50 passed
- post-review feature-switch route tests: 2 passed
- pre-commit hooks: Prettier, Knip, `pnpm check-types`, file-size check, and commitlint
