### PR TITLE
refactor: stop showing org slugs and drop dead slug payloads

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -363,7 +363,11 @@ describe("ORG-01 and ORG-02", () => {
     const orgs = await api.listOrgs(admin);
     expect(
       orgs.orgs.some((candidate) => {
-        return candidate.slug === nextSlug && candidate.role === "admin";
+        return (
+          candidate.id === admin.orgId &&
+          candidate.name === "BDD Org Updated" &&
+          candidate.role === "admin"
+        );
       }),
     ).toBeTruthy();
 
@@ -400,6 +404,7 @@ describe("ORG-01 and ORG-02", () => {
       membershipRequests: [{ id: requestId, actor: requester }],
     });
     const members = await api.listMembers(admin);
+    expect(members.name).toBe("BDD Org Updated");
     expect(members.role).toBe("admin");
     expect(
       members.members.some((candidate) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
@@ -169,7 +169,6 @@ describe("GET /api/zero/integrations/slack", () => {
     expect(response.body.isInstalled).toBeTruthy();
     expect(response.body.workspaceName).toBe("Test Workspace");
     expect(response.body.defaultAgentName).toBe("Slack Bot");
-    expect(response.body.agentOrgSlug).toBe("test-org-slug");
     // Admin + connected: scope fields should be present (botScopes null → mismatch)
     expect(response.body).toHaveProperty("scopeMismatch");
     expect(response.body).toHaveProperty("reinstallUrl");
@@ -243,7 +242,6 @@ describe("GET /api/zero/integrations/slack", () => {
     // Not connected: workspace/environment fields should NOT be present
     expect(response.body).not.toHaveProperty("workspaceName");
     expect(response.body).not.toHaveProperty("defaultAgentName");
-    expect(response.body).not.toHaveProperty("agentOrgSlug");
     expect(response.body).not.toHaveProperty("environment");
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-connect.test.ts
@@ -323,7 +323,6 @@ describe("GET /api/zero/integrations/teams/connect", () => {
       teamId: fixture.teamsTeamId,
       teamName: fixture.teamsTeamName,
       defaultAgentName: null,
-      agentOrgSlug: null,
       environment: {
         requiredSecrets: [],
         requiredVars: [],

--- a/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-slack.ts
@@ -182,7 +182,6 @@ const getSlackStatusInner$ = computed(async (get) => {
     ? {
         workspaceName: status.workspaceName,
         defaultAgentName: status.defaultAgentName,
-        agentOrgSlug: status.agentOrgSlug,
         environment: await get(getSlackEnvironment$),
       }
     : {

--- a/turbo/apps/api/src/signals/services/zero-org-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-data.service.ts
@@ -564,11 +564,11 @@ export function zeroOrgList(
     return {
       orgs: memberships.data.map((membership) => {
         return {
-          slug: membership.organization.slug,
+          id: membership.organization.id,
+          name: membership.organization.name,
           role: mapClerkOrgRole(membership.role),
         };
       }),
-      active: undefined,
     };
   });
 }
@@ -774,7 +774,7 @@ export function zeroOrgMembersList(
     }
 
     return {
-      slug: org.slug ?? args.orgId,
+      name: org.name,
       role: args.callerRole,
       members: memberList,
       pendingInvitations,

--- a/turbo/apps/api/src/signals/services/zero-slack-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-data.service.ts
@@ -2,7 +2,6 @@ import { computed, type Computed } from "ccstate";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
-import { orgCache } from "@vm0/db/schema/org-cache";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { and, eq } from "drizzle-orm";
 
@@ -82,7 +81,6 @@ interface SlackOrgStatusResult {
   readonly installUrl: string | null;
   readonly connectUrl: string | null;
   readonly defaultAgentName: string | null;
-  readonly agentOrgSlug: string | null;
   readonly scopeMismatch: boolean | null;
   readonly reinstallUrl: string | null;
 }
@@ -103,21 +101,13 @@ export function zeroSlackOrgStatus(args: {
 
     const isAdmin = args.orgRole === "admin";
     let defaultAgentName: string | null = null;
-    let agentOrgSlug: string | null = null;
 
     if (installation) {
-      const [[orgMeta], [orgCacheRow]] = await Promise.all([
-        db
-          .select({ defaultAgentId: orgMetadata.defaultAgentId })
-          .from(orgMetadata)
-          .where(eq(orgMetadata.orgId, args.orgId))
-          .limit(1),
-        db
-          .select({ slug: orgCache.slug })
-          .from(orgCache)
-          .where(eq(orgCache.orgId, args.orgId))
-          .limit(1),
-      ]);
+      const [orgMeta] = await db
+        .select({ defaultAgentId: orgMetadata.defaultAgentId })
+        .from(orgMetadata)
+        .where(eq(orgMetadata.orgId, args.orgId))
+        .limit(1);
 
       if (orgMeta?.defaultAgentId) {
         const [agent] = await db
@@ -129,10 +119,6 @@ export function zeroSlackOrgStatus(args: {
           .where(eq(zeroAgents.id, orgMeta.defaultAgentId))
           .limit(1);
         defaultAgentName = agent?.displayName ?? agent?.name ?? null;
-      }
-
-      if (orgCacheRow?.slug) {
-        agentOrgSlug = orgCacheRow.slug;
       }
     }
 
@@ -169,7 +155,6 @@ export function zeroSlackOrgStatus(args: {
         installUrl,
         connectUrl: null,
         defaultAgentName,
-        agentOrgSlug,
         scopeMismatch: null,
         reinstallUrl: null,
       };
@@ -204,7 +189,6 @@ export function zeroSlackOrgStatus(args: {
         installUrl: null,
         connectUrl,
         defaultAgentName,
-        agentOrgSlug,
         ...scopeFields,
       };
     }
@@ -219,7 +203,6 @@ export function zeroSlackOrgStatus(args: {
       installUrl: null,
       connectUrl: null,
       defaultAgentName,
-      agentOrgSlug,
       ...scopeFields,
     };
   });

--- a/turbo/apps/api/src/signals/services/zero-teams-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-connect.service.ts
@@ -5,7 +5,6 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
-import { orgCache } from "@vm0/db/schema/org-cache";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { teamsOrgConnections } from "@vm0/db/schema/teams-org-connection";
@@ -400,7 +399,6 @@ type ConnectorProvidedBindings = Parameters<
 
 interface ConnectedTeamsStatusFields {
   readonly defaultAgentName: string | null;
-  readonly agentOrgSlug: string | null;
   readonly environment: TeamsEnvironment;
 }
 
@@ -415,7 +413,6 @@ interface TeamsConnectStatus {
   readonly teamId?: string | null;
   readonly teamName?: string | null;
   readonly defaultAgentName?: string | null;
-  readonly agentOrgSlug?: string | null;
   readonly permissionMismatch?: boolean | null;
   readonly reinstallUrl?: string | null;
   readonly environment?: TeamsEnvironment;
@@ -428,18 +425,6 @@ function emptyTeamsEnvironment(): TeamsEnvironment {
     missingSecrets: [],
     missingVars: [],
   };
-}
-
-async function getTeamsAgentOrgSlug(
-  db: ReadonlyDb,
-  orgId: string,
-): Promise<string | null> {
-  const [orgCacheRow] = await db
-    .select({ slug: orgCache.slug })
-    .from(orgCache)
-    .where(eq(orgCache.orgId, orgId))
-    .limit(1);
-  return orgCacheRow?.slug ?? null;
 }
 
 async function resolveTeamsEnvironment(args: {
@@ -531,15 +516,11 @@ async function resolveConnectedStatusFields(args: {
     args.userId,
     args.orgId,
   );
-  const [agentOrgSlug, environment] = await Promise.all([
-    getTeamsAgentOrgSlug(args.db, args.orgId),
-    resolveTeamsEnvironment(args),
-  ]);
+  const environment = await resolveTeamsEnvironment(args);
   return {
     defaultAgentName: composeId
       ? ((await getTeamsAgentName(args.db, composeId)) ?? null)
       : null,
-    agentOrgSlug,
     environment,
   };
 }
@@ -643,7 +624,6 @@ function activeTeamsStatus(args: {
   }
   return {
     ...status,
-    agentOrgSlug: args.connectedFields.agentOrgSlug,
     environment: args.connectedFields.environment,
   };
 }

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/list.test.ts
@@ -40,10 +40,9 @@ describe("zero org list command", () => {
       http.get("http://localhost:3000/api/zero/org/list", () => {
         return HttpResponse.json({
           orgs: [
-            { slug: "personal-user", role: "admin" },
-            { slug: "my-org", role: "admin" },
+            { id: "org-personal", name: "Personal User", role: "admin" },
+            { id: "my-org", name: "My Org", role: "admin" },
           ],
-          active: undefined,
         });
       }),
     );
@@ -51,9 +50,9 @@ describe("zero org list command", () => {
     await listCommand.parseAsync(["node", "cli"]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("personal-user");
+    expect(logCalls).toContain("Personal User");
     expect(logCalls).toContain("admin");
-    expect(logCalls).toContain("my-org");
+    expect(logCalls).toContain("My Org");
   });
 
   it("should mark current organization", async () => {
@@ -61,10 +60,9 @@ describe("zero org list command", () => {
       http.get("http://localhost:3000/api/zero/org/list", () => {
         return HttpResponse.json({
           orgs: [
-            { slug: "personal-user", role: "admin" },
-            { slug: "my-org", role: "admin" },
+            { id: "org-personal", name: "Personal User", role: "admin" },
+            { id: "my-org", name: "My Org", role: "admin" },
           ],
-          active: undefined,
         });
       }),
     );
@@ -72,7 +70,8 @@ describe("zero org list command", () => {
     await listCommand.parseAsync(["node", "cli"]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("current");
+    expect(logCalls).toContain("* My Org (admin) \u2190 current");
+    expect(logCalls).not.toContain("* Personal User");
   });
 
   it("should handle API error", async () => {

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/members.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/members.test.ts
@@ -23,7 +23,7 @@ describe("zero org members command", () => {
     server.use(
       http.get("http://localhost:3000/api/zero/org/members", () => {
         return HttpResponse.json({
-          slug: "my-org",
+          name: "My Org",
           role: "admin",
           createdAt: "2024-01-01T00:00:00Z",
           members: [
@@ -38,7 +38,7 @@ describe("zero org members command", () => {
     await membersCommand.parseAsync(["node", "cli"]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("my-org");
+    expect(logCalls).toContain("My Org");
     expect(logCalls).toContain("admin@example.com");
     expect(logCalls).toContain("member@example.com");
   });

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/status.test.ts
@@ -29,6 +29,8 @@ describe("zero org status command", () => {
         return HttpResponse.json({
           id: "test-id",
           slug: "testuser",
+          name: "Test Workspace",
+          tier: "pro",
           createdAt: "2024-01-01T00:00:00Z",
           updatedAt: "2024-01-01T00:00:00Z",
         });
@@ -41,8 +43,9 @@ describe("zero org status command", () => {
       expect.stringContaining("Organization Information"),
     );
     expect(mockConsoleLog).toHaveBeenCalledWith(
-      expect.stringContaining("testuser"),
+      expect.stringContaining("Test Workspace"),
     );
+    expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining("pro"));
   });
 
   it("should show helpful message when user has no organization", async () => {

--- a/turbo/apps/cli/src/commands/zero/org/list.ts
+++ b/turbo/apps/cli/src/commands/zero/org/list.ts
@@ -14,11 +14,11 @@ export const listCommand = new Command()
 
       console.log(chalk.bold("Available organizations:"));
       for (const org of result.orgs) {
-        const isCurrent = org.slug === activeOrg;
+        const isCurrent = org.id === activeOrg;
         const marker = isCurrent ? chalk.green("* ") : "  ";
         const roleLabel = org.role ? ` (${org.role})` : "";
         const currentLabel = isCurrent ? chalk.dim(" ← current") : "";
-        console.log(`${marker}${org.slug}${roleLabel}${currentLabel}`);
+        console.log(`${marker}${org.name}${roleLabel}${currentLabel}`);
       }
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/org/members.ts
+++ b/turbo/apps/cli/src/commands/zero/org/members.ts
@@ -10,7 +10,7 @@ export const membersCommand = new Command()
     withErrorHandler(async () => {
       const status = await getZeroOrgMembers();
 
-      console.log(chalk.bold(`Organization: ${status.slug}`));
+      console.log(chalk.bold(`Organization: ${status.name}`));
       console.log(`  Role: ${status.role}`);
       console.log(
         `  Created: ${new Date(status.createdAt).toLocaleDateString()}`,

--- a/turbo/apps/cli/src/commands/zero/org/status.ts
+++ b/turbo/apps/cli/src/commands/zero/org/status.ts
@@ -13,7 +13,10 @@ export const statusCommand = new Command()
         const org = await getZeroOrg();
 
         console.log(chalk.bold("Organization Information:"));
-        console.log(`  Slug: ${chalk.green(org.slug)}`);
+        console.log(`  Name: ${chalk.green(org.name)}`);
+        if (org.tier) {
+          console.log(`  Tier: ${org.tier}`);
+        }
       } catch (error) {
         if (error instanceof ApiRequestError && error.status === 404) {
           throw new Error("No organization configured", {

--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-slack-org.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-slack-org.ts
@@ -10,7 +10,6 @@ let mockSlackOrgData: SlackOrgStatus = {
   isInstalled: true,
   workspaceName: "Test Org Workspace",
   isAdmin: true,
-  agentOrgSlug: "test-org",
   environment: {
     requiredSecrets: [],
     requiredVars: [],
@@ -25,7 +24,6 @@ export function resetMockSlackOrgIntegration(): void {
     isInstalled: true,
     workspaceName: "Test Org Workspace",
     isAdmin: true,
-    agentOrgSlug: "test-org",
     environment: {
       requiredSecrets: [],
       requiredVars: [],

--- a/turbo/apps/platform/src/mocks/handlers/api-org-members.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-org-members.ts
@@ -7,7 +7,7 @@ import type { OrgMembersResponse } from "@vm0/api-contracts/contracts/org-member
 import { mockApi } from "../msw-contract.ts";
 
 let mockOrgMembersResponse: OrgMembersResponse = {
-  slug: "user-12345678",
+  name: "User Workspace",
   role: "admin",
   members: [],
   pendingInvitations: [],
@@ -23,7 +23,7 @@ export function setMockOrgMembers(
 
 export function resetMockOrgMembers(): void {
   mockOrgMembersResponse = {
-    slug: "user-12345678",
+    name: "User Workspace",
     role: "admin",
     members: [],
     pendingInvitations: [],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
@@ -55,7 +55,7 @@ describe("organization general settings", () => {
     await openGeneralTab();
 
     await waitFor(() => {
-      expect(screen.getByRole("img", { name: "old-slug" })).toHaveAttribute(
+      expect(screen.getByRole("img", { name: "Old Name" })).toHaveAttribute(
         "src",
         logoUrl,
       );
@@ -147,7 +147,7 @@ describe("organization general settings", () => {
     await openGeneralTab();
 
     await waitFor(() => {
-      expect(screen.getByRole("img", { name: "acme" })).toHaveAttribute(
+      expect(screen.getByRole("img", { name: "Acme" })).toHaveAttribute(
         "src",
         initialLogoUrl,
       );
@@ -166,7 +166,7 @@ describe("organization general settings", () => {
 
     await waitFor(() => {
       expect(capturedLogoName).toBe("workspace-logo.png");
-      expect(screen.getByRole("img", { name: "acme" })).toHaveAttribute(
+      expect(screen.getByRole("img", { name: "Acme" })).toHaveAttribute(
         "src",
         uploadedLogoUrl,
       );
@@ -195,7 +195,7 @@ describe("organization general settings", () => {
       new File(["first"], "first-logo.png", { type: "image/png" }),
     );
     await waitFor(() => {
-      expect(screen.getByRole("img", { name: "acme" })).toHaveAttribute(
+      expect(screen.getByRole("img", { name: "Acme" })).toHaveAttribute(
         "src",
         "blob:mock-image-2",
       );
@@ -206,7 +206,7 @@ describe("organization general settings", () => {
       new File(["second"], "second-logo.png", { type: "image/png" }),
     );
     await waitFor(() => {
-      expect(screen.getByRole("img", { name: "acme" })).toHaveAttribute(
+      expect(screen.getByRole("img", { name: "Acme" })).toHaveAttribute(
         "src",
         "blob:mock-image-4",
       );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-members-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-members-tab.test.tsx
@@ -56,7 +56,7 @@ function menuItemByText(text: string): HTMLElement {
 
 function mockMembersStory(): void {
   let response: OrgMembersResponse = {
-    slug: "test-org",
+    name: "Test Org",
     role: "admin",
     createdAt: "2026-01-01T00:00:00Z",
     members: [

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
@@ -30,7 +30,7 @@ function expectedAllowanceResetText(value: string): string {
 
 function mockUsageStory(): void {
   const orgMembers: OrgMembersResponse = {
-    slug: "test-org",
+    name: "Test Org",
     role: "admin",
     createdAt: "2026-01-01T00:00:00Z",
     members: [

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
@@ -38,7 +38,7 @@ async function openDialog(
     role,
   });
   context.mocks.data.orgMembers({
-    slug: "test-org",
+    name: "Test Org",
     role,
     members: [],
     pendingInvitations: [],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -62,7 +62,6 @@ function mockSlackAPI(overrides: Partial<SlackOrgStatus> = {}): void {
     reinstallUrl: null,
     scopeMismatch: false,
     workspaceName: null,
-    agentOrgSlug: null,
     environment: {
       requiredSecrets: [],
       requiredVars: [],

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
@@ -219,7 +219,7 @@ function ProfileSection({
                 <img
                   src={(pendingLogoPreview ?? logoUrl)!}
                   alt={
-                    org.slug ??
+                    org.name ||
                     t(($) => {
                       return $.settings.workspace.profile.logo.fallbackAlt;
                     })

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -20,7 +20,6 @@ import {
   onDomEventFn,
   Reason,
 } from "../../signals/utils.ts";
-import { org$ } from "../../signals/org.ts";
 import {
   userInvitations$,
   refreshUserInvitations$,
@@ -220,7 +219,6 @@ function OtherMembershipsList() {
 
 function OrgDropdownContent() {
   const clerkLoadable = useLastLoadable(clerk$);
-  const orgData = useLastResolved(org$);
   const pendingInvitations = useLastResolved(userInvitations$);
   const currentOrg = useLastResolved(currentOrgInfo$);
   const { t } = useTranslation();
@@ -231,7 +229,6 @@ function OrgDropdownContent() {
     t(($) => {
       return $.appShell.sidebar.workspaceSwitcher.organizationFallback;
     });
-  const orgSlug = orgData?.slug;
   const memberships = clerk?.user?.organizationMemberships ?? [];
   const currentOrgId = clerk?.organization?.id;
 
@@ -259,11 +256,6 @@ function OrgDropdownContent() {
           <p className="text-sm font-semibold leading-tight truncate text-foreground">
             {orgName}
           </p>
-          {orgSlug && (
-            <p className="text-xs text-muted-foreground truncate mt-0.5">
-              {orgSlug}
-            </p>
-          )}
         </div>
       </div>
 

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -602,7 +602,6 @@ export {
   MODEL_PROVIDER_FIREWALL_CONFIGS,
   getModelProviderFirewall,
   // VM0 managed provider
-  VM0_ORG_SLUG,
   VM0_MODEL_TO_PROVIDER,
   VM0_MODEL_ALIAS_TO_MODEL,
   getVm0ConcreteProviderType,

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -99,11 +99,6 @@ const MODEL_PROVIDER_CODEX_RUNTIME_CONFIGS: Partial<
   },
 };
 
-/**
- * The org slug authorized to use the VM0 managed provider.
- */
-export const VM0_ORG_SLUG = "vm0";
-
 export const DEFAULT_ORG_MODEL_POLICY_MODELS = [
   "claude-fable-5",
   "claude-opus-5",

--- a/turbo/packages/api-contracts/src/contracts/org-list.ts
+++ b/turbo/packages/api-contracts/src/contracts/org-list.ts
@@ -4,7 +4,8 @@ import { z } from "zod";
  * Org list item schema
  */
 export const orgListItemSchema = z.object({
-  slug: z.string(),
+  id: z.string(),
+  name: z.string(),
   role: z.string(),
 });
 export type OrgListItem = z.infer<typeof orgListItemSchema>;
@@ -14,6 +15,5 @@ export type OrgListItem = z.infer<typeof orgListItemSchema>;
  */
 export const orgListResponseSchema = z.object({
   orgs: z.array(orgListItemSchema),
-  active: z.string().optional(),
 });
 export type OrgListResponse = z.infer<typeof orgListResponseSchema>;

--- a/turbo/packages/api-contracts/src/contracts/org-members.ts
+++ b/turbo/packages/api-contracts/src/contracts/org-members.ts
@@ -69,7 +69,7 @@ export type MembershipRequestAction = z.infer<
  * Org members response schema (status + members list)
  */
 export const orgMembersResponseSchema = z.object({
-  slug: z.string(),
+  name: z.string(),
   role: orgRoleSchema,
   members: z.array(orgMemberSchema),
   pendingInvitations: z.array(orgPendingInvitationSchema).optional(),

--- a/turbo/packages/api-contracts/src/contracts/zero-integrations-slack.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-integrations-slack.ts
@@ -19,7 +19,6 @@ const slackOrgStatusSchema = z.object({
   installUrl: z.string().nullable().optional(),
   connectUrl: z.string().nullable().optional(),
   defaultAgentName: z.string().nullable().optional(),
-  agentOrgSlug: z.string().nullable().optional(),
   environment: slackEnvironmentSchema.optional(),
   /** True when the installation's granted scopes are outdated (admin-only). */
   scopeMismatch: z.boolean().optional(),

--- a/turbo/packages/api-contracts/src/contracts/zero-teams-connect.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-teams-connect.ts
@@ -25,7 +25,6 @@ const teamsConnectStatusSchema = z.object({
   teamId: nullableStringSchema.optional(),
   teamName: nullableStringSchema.optional(),
   defaultAgentName: nullableStringSchema.optional(),
-  agentOrgSlug: nullableStringSchema.optional(),
   permissionMismatch: z.boolean().optional(),
   reinstallUrl: nullableStringSchema.optional(),
   environment: teamsEnvironmentSchema.optional(),

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -158,7 +158,6 @@ export {
   getSecretNamesForAuthMethod,
   MODEL_PROVIDER_FIREWALL_CONFIGS,
   getModelProviderFirewall,
-  VM0_ORG_SLUG,
   VM0_MODEL_TO_PROVIDER,
   getVm0ConcreteProviderType,
   getVm0Vendor,


### PR DESCRIPTION
Closes #24993. Step 3 of #24990.

## What changes

Nothing acts on the org slug any more, but it was still printed to users and several payloads still carried it for no consumer at all. This removes both.

**Web**
- `zero-org-switcher.tsx`: removed the subtitle line under the workspace name. There is nothing meaningful left to show once the slug is gone — the workspace name is already the line above it.
- `org-general-tab.tsx`: the workspace logo `alt` now uses `org.name`, falling back to the existing i18n string when the name is empty.

**Contracts**
- `orgListItemSchema` → `{ id, name, role }`; `orgListResponseSchema` drops `active`.
- `orgMembersResponseSchema.slug` → `name`.
- `agentOrgSlug` deleted from the Slack and Teams status schemas.
- `VM0_ORG_SLUG` deleted along with its two barrel re-exports. Its comment claimed it authorized the VM0 managed provider, but authorization goes by provider type and tier; the re-exports are why knip never flagged it.

**API**
- `zeroOrgList` returns `id`/`name` from the Clerk membership and no longer returns `active`.
- `zeroOrgMembersList` returns `org.name`.
- `zero-slack-data.service.ts` drops `agentOrgSlug` and the `org_cache` lookup that only fed it; the surrounding `Promise.all` collapses to a single query.
- `zero-teams-connect.service.ts` drops `getTeamsAgentOrgSlug` and every `agentOrgSlug` field.

**CLI**
- `zero org status` prints the workspace name and tier.
- `zero org list` prints the name and marks the active workspace with `org.id === await getActiveOrg()`.
- `zero org members` prints the workspace name.

## The `zero org list` marker was broken

`zero org list` compared `org.slug === activeOrg`, but `getActiveOrg()` returns an **orgId**, and the server hardcoded `active: undefined`. The "current org" marker was structurally unable to light up. Rather than keep `active` as a second, redundant source of the same truth, the response drops it and the CLI decides from the token's orgId — so the marker now works for the first time. `list.test.ts` asserts the marker lands on the token's org and not on the other one.

## Compatibility note

An **old** CLI talking to the new API will print `undefined` for the org identity in `zero org list` and `zero org members`, since it reads the removed `slug`. This is cosmetic and limited to those two commands; no web, desktop, or runner code path reads either field, so stale browser tabs are unaffected. Flagging it because the repo's deployment-compatibility rule asks for old/new combinations to be considered — the epic's design deliberately replaces the field rather than dual-writing it.

## Non-goals honored

`orgResponseSchema.slug`, the `org_cache.slug` write path, and the column/index are untouched — that is step 4 of #24990, to be written after this merges. Connector, hosted-site, workflow, and generation-template slugs and the `vm0/<image>` namespace are untouched.

## Verification

- `pnpm check-types`, `pnpm knip`, `pnpm format` clean.
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/org` — 17 files, 71 tests passed.
- Platform: `settings-dialog`, `org-members-tab`, `org-usage-tab`, `zero-works-page` — 4 files, 58 tests passed.
- eslint clean on every changed file. The `api` workspace's full lint task was OOM-killed (exit 137) in the sandbox, not a lint failure; leaving it to CI.
- API integration tests need Postgres, which is unavailable here — relying on PR CI.
- `grep -rn "VM0_ORG_SLUG\|agentOrgSlug"` returns nothing repo-wide.

## Merge order

Merge **after** #24991, #24992, and #24817, then rebase. As of opening, none of the three has merged.
