### PR TITLE
test(api): stabilize browser screenshot cleanup retry

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -29,6 +29,7 @@ import webClientCompatibility from "../../../lib/web-client-compatibility.json";
 import { server } from "../../../mocks/server";
 import { deleteAgentRunRootFixture } from "../../../test-fixtures/run-deletion";
 import { flushWaitUntilForTest } from "../../context/wait-until";
+import { createDeferredPromise } from "../../utils";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
@@ -1718,9 +1719,25 @@ describe("zero browser route", () => {
         );
       }),
     );
+    const releaseSecondScreenshotUpload = createDeferredPromise<void>(
+      context.signal,
+    );
+    const releaseThirdScreenshotUpload = createDeferredPromise<void>(
+      context.signal,
+    );
+    let screenshotUploadCount = 0;
     let failNextScreenshotDelete = true;
     context.mocks.s3.send.mockImplementation((command: unknown) => {
       const input = commandInput(command);
+      if (input.ContentType === "image/webp") {
+        screenshotUploadCount += 1;
+        if (screenshotUploadCount === 2) {
+          return releaseSecondScreenshotUpload.promise;
+        }
+        if (screenshotUploadCount === 3) {
+          return releaseThirdScreenshotUpload.promise;
+        }
+      }
       if ("Delete" in input && failNextScreenshotDelete) {
         failNextScreenshotDelete = false;
         return Promise.reject(new Error("transient screenshot delete failure"));
@@ -1847,6 +1864,7 @@ describe("zero browser route", () => {
     expect(secondReconcile.body).toMatchObject({
       errors: 0,
     });
+    releaseSecondScreenshotUpload.resolve(undefined);
     await flushWaitUntilForTest();
 
     const afterSecondCapture = await accept(
@@ -1930,6 +1948,7 @@ describe("zero browser route", () => {
         );
       }),
     ).toHaveLength(2);
+    releaseThirdScreenshotUpload.resolve(undefined);
     await flushWaitUntilForTest();
 
     const afterThirdCapture = await accept(


### PR DESCRIPTION
## Summary

- Make the managed-browser screenshot cleanup retry test deterministic by holding the second and third mocked S3 uploads until the active reconciliation pass returns.
- Preserve the production reconciliation behavior while ensuring the test's explicit retry pass owns the queued deletion assertion.

## Failure evidence

- [Turbo job 91938251263](https://github.com/vm0-ai/vm0/actions/runs/30892676375/job/91938251263) intermittently observed two deletion attempts where the test expected one.
- The background screenshot capture and the same reconciliation request's queued-deletion scan can validly run in either order, so the old intermediate call-count assertion depended on task scheduling.

## Scope

- Test synchronization only; no production code, API, schema, or deployment behavior changes.
- Supersedes #24951's test fix without carrying its unrelated Cloudflare Pages changes.

## Validation

- `pnpm prettier --check apps/api/src/signals/routes/__tests__/zero-browser.test.ts`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `DATABASE_URL=<fresh temporary database> pnpm -F api exec vitest run src/signals/routes/__tests__/zero-browser.test.ts --silent=passed-only` (11 passed)
- The formerly flaky test passed 10 consecutive isolated runs without Vitest retries.
- Pre-commit hooks: full-repository Knip, full-repository type checks, file-size check, and commitlint.
