### PR TITLE
docs(vsock-host): correct write_files guidance

### DIFF
--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -409,10 +409,12 @@ impl VsockHost {
 
     /// Write multiple ordinary files on the guest in one request.
     ///
-    /// Every file uses non-sudo create-parent and truncate semantics. The
-    /// caller must use [`write_file`](Self::write_file) for private, sudo,
-    /// append, or larger individual writes. Empty batches are accepted as a
-    /// no-op to match the higher-level sandbox trait default.
+    /// Every file uses non-sudo create-parent and truncate semantics. Use
+    /// [`write_private_file`](Self::write_private_file) for private runtime
+    /// files and [`write_file`](Self::write_file) for sudo or individual writes
+    /// that exceed the batch content limit. No public [`VsockHost`] write method
+    /// exposes caller-requested append semantics. Empty batches are accepted as
+    /// a no-op to match the higher-level sandbox trait default.
     pub async fn write_files(&self, files: &[WriteFileEntry<'_>]) -> io::Result<()> {
         self.write_files_with_write_observer(files, FrameWriteObserver::default())
             .await


### PR DESCRIPTION
## Summary

- direct private runtime-file callers from `write_files` to `write_private_file`
- keep sudo and oversized individual writes linked to `write_file`
- clarify that no public `VsockHost` write method exposes caller-requested append semantics

## Scope

This is a Rustdoc-only correction. It does not change public signatures, runtime behavior, the host/guest protocol, tests, data, migrations, or rollout requirements.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-host --all-targets --all-features`
- `cargo doc -p vsock-host --all-features --no-deps`
- `cargo test -p vsock-host --all-features` (339 passed)
- repository pre-commit Rustdoc, Clippy, file-size, and commit-message hooks

Closes #25012
