### PR TITLE
test(e2e): shorten real llm prompts

### DIFF
--- a/.github/scripts/runner-behavior-local-claude-active-input-smoke.sh
+++ b/.github/scripts/runner-behavior-local-claude-active-input-smoke.sh
@@ -64,7 +64,7 @@ sudo "$BIN_DIR/runner" service start \
   --config "$RUNNER_DIR/runner.yaml" \
   --local
 
-PROMPT='This is a CI smoke test for Claude Code active input. The initial prompt token is ci-initial-5k2. Before your final answer, run Bash command `sleep 1` so two follow-up user messages can arrive, each containing one token. After the command and after reading both follow-up messages, reply with exactly RESULT=ci-initial-5k2+FIRST+SECOND, replacing FIRST and SECOND with the exact text of the first and second follow-up messages. If either follow-up message is missing, reply exactly RESULT=missing. Do not include any other text.'
+PROMPT='Run `sleep 1` with Bash, then read both follow-up messages. Reply only RESULT=ci-initial-5k2+FIRST+SECOND, replacing FIRST and SECOND with their exact text in order. If either is missing, reply only RESULT=missing.'
 EXPECTED_RESULT='RESULT=ci-initial-5k2+ci-active-one-7f3+ci-active-two-9q4'
 
 echo "--- Submitting active-input smoke job ---"

--- a/.github/scripts/runner-behavior-local-codex-active-input-smoke.sh
+++ b/.github/scripts/runner-behavior-local-codex-active-input-smoke.sh
@@ -64,7 +64,7 @@ sudo "$BIN_DIR/runner" service start \
   --config "$RUNNER_DIR/runner.yaml" \
   --local
 
-PROMPT='This is a CI smoke test for Codex active input. The initial prompt token is codex-initial-8m6. Before your final answer, run shell command `sleep 1` so two follow-up user messages can arrive, each containing one token. After the command and after reading both follow-up messages, reply with exactly RESULT=codex-initial-8m6+FIRST+SECOND, replacing FIRST and SECOND with the exact text of the first and second follow-up messages. If either follow-up message is missing, reply exactly RESULT=missing. Do not include any other text.'
+PROMPT='Run `sleep 1`, then read both follow-up messages. Reply only RESULT=codex-initial-8m6+FIRST+SECOND, replacing FIRST and SECOND with their exact text in order. If either is missing, reply only RESULT=missing.'
 EXPECTED_RESULT='RESULT=codex-initial-8m6+codex-active-one-2p9+codex-active-two-6v1'
 
 echo "--- Submitting Codex active-input smoke job ---"

--- a/e2e/helpers/audit-sandbox.bash
+++ b/e2e/helpers/audit-sandbox.bash
@@ -33,13 +33,12 @@ audit_chatgpt_oauth_sandbox_via_agent() {
     # Single quotes prevent shell expansion in the agent's literal Bash call.
     local prompt
     prompt=$(cat <<EOF
-Run this exact Bash command and include its output between '---AUDIT-START---' and '---AUDIT-END---' markers in your response. Do not modify the command, do not add commentary inside the markers:
-
+Run this command:
 bash $artifact_path '${CHATGPT_AUDIT_FORBIDDEN_ACCESS_TOKEN}' '${CHATGPT_AUDIT_FORBIDDEN_REFRESH_TOKEN}' '${CHATGPT_AUDIT_FORBIDDEN_ACCOUNT_ID}' '${CHATGPT_AUDIT_FORBIDDEN_ID_TOKEN}'
 
-After running, output exactly:
+Reply only, replacing <stdout> with the command's exact stdout:
 ---AUDIT-START---
-<paste the entire stdout above between the markers, on a single line>
+<stdout>
 ---AUDIT-END---
 EOF
 )

--- a/e2e/tests/03-runner/t-codex-real-smoke.bats
+++ b/e2e/tests/03-runner/t-codex-real-smoke.bats
@@ -62,7 +62,7 @@ ensure_openai_model_provider() {
     ensure_openai_model_provider
 
     run run_compose_fixture "$AGENT_NAME" \
-        "Run 'codex --version' with the shell tool and include the exact output" \
+        "Run \`codex --version\` with shell; return its output." \
         '{"modelProviderType":"openai-api-key","realAgentInPreview":true}'
 
     assert_success
@@ -74,7 +74,7 @@ ensure_openai_model_provider() {
     ensure_openai_model_provider
 
     run run_compose_fixture "$AGENT_NAME" \
-        "Compute 123+456 and reply with exactly: RESULT=<answer>" \
+        "123+456. Reply only RESULT=<answer>." \
         '{"modelProviderType":"openai-api-key","realAgentInPreview":true}'
 
     assert_success

--- a/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
+++ b/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
@@ -102,7 +102,7 @@ teardown_file() {
     # LAST_THREAD_ID / LAST_RUN_ID would arrive empty. The helper returns
     # non-zero on failure, which fails the test naturally.
     run_codex_chat_with_capacity_retry "$AGENT_ID" \
-        "Compute 123+456 and reply with exactly: RESULT=<answer>" \
+        "123+456. Reply only RESULT=<answer>." \
         "gpt-5.5"
 
     # Assert: real codex produced the expected sentinel. The selected model's
@@ -115,7 +115,7 @@ teardown_file() {
 
 @test "t-codex-zero-byok-smoke-2: gpt-5.6-luna via zero web layer" {
     run_codex_chat_with_capacity_retry "$AGENT_ID" \
-        "Compute 234+567 and reply with exactly: LUNA_RESULT=<answer>" \
+        "234+567. Reply only LUNA_RESULT=<answer>." \
         "gpt-5.6-luna"
 
     [[ "$LAST_MSG_CONTENT" == *"LUNA_RESULT=801"* ]] \

--- a/e2e/tests/03-runner/t27-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/t27-real-claude-smoke.bats
@@ -113,7 +113,7 @@ ensure_anthropic_model_provider() {
 
     # Run claude --version inside the sandbox to confirm which binary is installed
     run run_compose_fixture "$AGENT_NAME" \
-        "Run 'claude --version' with the Bash tool and include the exact output" \
+        "Run \`claude --version\` with Bash; return its output." \
         '{"modelProviderType":"anthropic-api-key","realAgentInPreview":true}'
 
     assert_success
@@ -131,7 +131,7 @@ ensure_anthropic_model_provider() {
     ensure_anthropic_model_provider
 
     run run_compose_fixture "$AGENT_NAME" \
-        "Compute 123+456 and reply with exactly: RESULT=<answer>" \
+        "123+456. Reply only RESULT=<answer>." \
         '{"modelProviderType":"anthropic-api-key","realAgentInPreview":true}'
 
     assert_success
@@ -152,11 +152,11 @@ ensure_anthropic_model_provider() {
     ensure_anthropic_model_provider
 
     run run_compose_fixture "${AGENT_NAME}-flags" \
-        "Compute 789+101 and follow the required final response format." \
+        "789+101. Follow the required response format." \
         '{
             "modelProviderType":"anthropic-api-key",
             "realAgentInPreview":true,
-            "appendSystemPrompt":"In your final response, output exactly two lines and no extra text. Line 1: RESULT=<answer>. Line 2: SIGNATURE=smoke-test.",
+            "appendSystemPrompt":"Reply only:\nRESULT=<answer>\nSIGNATURE=smoke-test",
             "disallowedTools":["CronCreate","CronList","CronDelete"]
         }'
 
@@ -184,7 +184,7 @@ ensure_anthropic_model_provider() {
     local settings='{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo SETTINGS_HOOK_OK > /tmp/hook_sentinel.txt"}]}]}}'
 
     run run_compose_fixture "${AGENT_NAME}-settings" \
-        "Step 1: run 'echo hello'. Step 2: run 'cat /tmp/hook_sentinel.txt'. Include the exact output of step 2 in your response." \
+        "Use Bash: echo hello; cat /tmp/hook_sentinel.txt. Return the cat output." \
         "$(jq -nc --arg settings "$settings" \
             '{
                 modelProviderType: "anthropic-api-key",

--- a/e2e/tests/03-runner/t53-test-oauth-connector.bats
+++ b/e2e/tests/03-runner/t53-test-oauth-connector.bats
@@ -221,6 +221,10 @@ append_test_oauth_bypass_headers() {
     fi
 }
 
+test_oauth_echo_prompt() {
+    printf '%s' "printf ECHO_BODY=; curl -sS -w '\nECHO_STATUS=%{http_code}\n' -H 'x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}' -H 'x-vm0-test-endpoint-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}' '${TEST_OAUTH_PROVIDER_URL}/api/test/oauth-provider/echo'"
+}
+
 header_location() {
     local header_file="$1"
     grep -i '^location:' "$header_file" | head -n1 | sed -E 's/^[Ll]ocation:[[:space:]]*//; s/\r$//'
@@ -333,7 +337,7 @@ EOF
     # without depending on Next external rewrites to preserve preview guard
     # headers. The web-to-api rewrite is covered by web rewrite tests.
     run run_zero_agent_via_chat "$COMPOSE_ID" \
-        "STATUS=\$(curl -s -o /tmp/echo-body -w '%{http_code}' -H 'x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}' -H 'x-vm0-test-endpoint-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}' '${TEST_OAUTH_PROVIDER_URL}/api/test/oauth-provider/echo') && echo \"ECHO_STATUS=\$STATUS\" && echo \"ECHO_BODY=\$(cat /tmp/echo-body)\""
+        "$(test_oauth_echo_prompt)"
 
     echo "$output"
     assert_success
@@ -408,7 +412,7 @@ EOF
     assert_success
 
     run run_zero_agent_via_chat "$COMPOSE_ID" \
-        "STATUS=\$(curl -s -o /tmp/echo-body -w '%{http_code}' -H 'x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}' -H 'x-vm0-test-endpoint-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}' '${TEST_OAUTH_PROVIDER_URL}/api/test/oauth-provider/echo') && echo \"ECHO_STATUS=\$STATUS\" && echo \"ECHO_BODY=\$(cat /tmp/echo-body)\""
+        "$(test_oauth_echo_prompt)"
 
     echo "$output"
     assert_success

--- a/e2e/tests/03-runner/t54-codex-oauth-sandbox.bats
+++ b/e2e/tests/03-runner/t54-codex-oauth-sandbox.bats
@@ -99,7 +99,7 @@ teardown_file() {
 # (per plan phase Q1 decision: A2 — synthetic + MSW for CI).
 @test "t54-1: codex agent run completes with codex-oauth provider" {
     run run_compose_fixture "$AGENT_NAME" \
-        "Reply with exactly RESULT=579" \
+        "Reply only RESULT=579" \
         '{"modelProviderType":"codex-oauth-token"}'
 
     assert_success
@@ -180,7 +180,7 @@ teardown_file() {
     seed_codex_oauth_via_authjson "$raw_json"
 
     run run_compose_fixture "$AGENT_NAME" \
-        "Reply with exactly RESULT=579" \
+        "Reply only RESULT=579" \
         '{"modelProviderType":"codex-oauth-token"}'
 
     assert_success
@@ -240,9 +240,8 @@ teardown_file() {
     fi
 
     run run_compose_fixture "$AGENT_NAME" \
-        "Run this exact Bash command and include its output:
-curl -sS -m 10 -o /tmp/curl-out.txt -w 'HTTP_CODE=%{http_code} EXIT=%{exitcode}' https://auth.openai.com/oauth/token; echo
-cat /tmp/curl-out.txt 2>/dev/null || echo 'NO_RESPONSE_BODY'" \
+        "Use Bash; return its output:
+curl -sS -m 10 -o /tmp/r -w 'HTTP_CODE=%{http_code} EXIT=%{exitcode}\n' https://auth.openai.com/oauth/token; cat /tmp/r 2>/dev/null || echo NO_BODY" \
         '{"modelProviderType":"codex-oauth-token","realAgentInPreview":true}'
 
     assert_success

--- a/e2e/tests/03-runner/t54-codex-oauth-sandbox.bats
+++ b/e2e/tests/03-runner/t54-codex-oauth-sandbox.bats
@@ -241,7 +241,7 @@ teardown_file() {
 
     run run_compose_fixture "$AGENT_NAME" \
         "Use Bash; return its output:
-curl -sS -m 10 -o /tmp/r -w 'HTTP_CODE=%{http_code} EXIT=%{exitcode}\n' https://auth.openai.com/oauth/token; cat /tmp/r 2>/dev/null || echo NO_BODY" \
+curl -sS -m 10 -w '\nHTTP_CODE=%{http_code} EXIT=%{exitcode}\n' https://auth.openai.com/oauth/token || true" \
         '{"modelProviderType":"codex-oauth-token","realAgentInPreview":true}'
 
     assert_success

--- a/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
+++ b/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
@@ -76,7 +76,7 @@ teardown_file() {
 
 @test "t54-0: BYOK provider — firewall not billable" {
     run run_compose_fixture "$RUN_AGENT_NAME" \
-        "Reply with exactly: DONE" \
+        "Reply only DONE" \
         '{"modelProviderType":"anthropic-api-key","realAgentInPreview":true}'
 
     echo "$output"
@@ -98,7 +98,7 @@ teardown_file() {
 @test "t54-1: vm0 meta-provider — firewall billable" {
     zero_chat_run_with_model \
         "$AGENT_ID" \
-        "Reply with exactly: DONE" \
+        "Reply only DONE" \
         "claude-sonnet-4-6" \
         true
     THREAD_IDS="$THREAD_IDS $LAST_THREAD_ID"


### PR DESCRIPTION
## Summary

- shorten prompts used by real Claude and Codex E2E smoke tests while preserving their existing behavioral assertions
- reduce active-input and sandbox-audit instructions to the minimum required model behavior
- reuse a compact OAuth echo command and remove firewall-probe temp-file I/O without weakening the response-body, status, or deny assertions

## Scope

- test and CI prompt text only
- no production runtime, API, schema, persisted data, or deployment contract changes

## Validation

- `bash -n .github/scripts/runner-behavior-local-codex-active-input-smoke.sh .github/scripts/runner-behavior-local-claude-active-input-smoke.sh e2e/helpers/audit-sandbox.bash`
- `e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/t27-real-claude-smoke.bats e2e/tests/03-runner/t-codex-real-smoke.bats e2e/tests/03-runner/t-codex-zero-byok-smoke.bats e2e/tests/03-runner/t53-test-oauth-connector.bats e2e/tests/03-runner/t54-codex-oauth-sandbox.bats e2e/tests/03-runner/t54-vm0-billable-firewall.bats` (17 tests parsed)
- generated OAuth echo prompt validated with `bash -n`
- `git diff --check`
- pre-commit file-size hook and commit message lint

Real-model execution is intentionally left to CI because it requires preview infrastructure, runner capacity, and model-provider secrets.