### PR TITLE
test(vsock-guest): cover exec-control registration rollback

### DIFF
--- a/crates/vsock-guest/src/exec_control/tests/registry.rs
+++ b/crates/vsock-guest/src/exec_control/tests/registry.rs
@@ -158,6 +158,37 @@ fn duplicate_control_sink_sequence_is_rejected_without_rebinding_endpoint() {
     first.guard.release();
 }
 #[test]
+fn failed_control_sink_registration_rolls_back_active_sequence() {
+    let seq = 21;
+    let nonce = unique_test_nonce(21);
+    let endpoint = process_control_ipc::endpoint_name(seq, &nonce);
+    let occupied_listener = process_control_ipc::bind_abstract_listener(&endpoint).unwrap();
+    let registry = ExecControlRegistry::default();
+
+    let error = match registry.register(seq, nonce, true) {
+        Ok(_) => panic!("expected occupied control sink endpoint to reject registration"),
+        Err(error) => error,
+    };
+
+    assert_eq!(error.kind(), io::ErrorKind::AddrInUse);
+    let (status, diagnostic) = resolve_error(&registry, seq, nonce);
+    assert_eq!(status, ExecControlStatus::Inactive);
+    assert_eq!(diagnostic, "exec operation is not active");
+
+    drop(occupied_listener);
+    let registration = registry.register(seq, nonce, true).unwrap();
+    assert_eq!(
+        registration.bootstrap_endpoint.as_deref(),
+        Some(endpoint.as_str())
+    );
+    assert!(registry.resolve(seq, nonce).is_ok());
+
+    drop(registration);
+    let (status, diagnostic) = resolve_error(&registry, seq, nonce);
+    assert_eq!(status, ExecControlStatus::Inactive);
+    assert_eq!(diagnostic, "exec operation is not active");
+}
+#[test]
 fn control_sink_registration_exports_bootstrap_endpoint() {
     let nonce = unique_test_nonce(7);
     let registry = ExecControlRegistry::default();


### PR DESCRIPTION
## Summary

- exercise the real exec-control sink bind failure after registry insertion by occupying the exact Linux abstract endpoint
- verify failed registration rolls the operation back to `Inactive` and permits the identical sink-backed registration after the conflict is released
- preserve production behavior and all existing registry lifecycle coverage

## Scope

- test-only change in `vsock-guest`
- no production, protocol, API, dependency, persistence, generated-code, or deployment changes

## Validation

- focused regression passed 20 consecutive runs
- mutation check confirmed the regression fails when `self.remove(seq)` is temporarily removed
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p vsock-guest --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features`
- repository Rust pre-commit and commit-message hooks

Closes #25016
