### PR TITLE
fix(python): track f-string formatting failures

### DIFF
--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
@@ -393,6 +393,7 @@ def _is_modeled_implicit_exception_operation(node: ast.AST) -> bool:
             ast.Await,
             ast.BinOp,
             ast.Call,
+            ast.FormattedValue,
             ast.Subscript,
             ast.UnaryOp,
             ast.YieldFrom,

--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
@@ -210,7 +210,9 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
     def visit(self, node: ast.AST) -> None:
         self._record_metadata_merge_key_violations(node)
         super().visit(node)
-        if _is_modeled_implicit_exception_operation(node) and not isinstance(node, ast.Compare):
+        if _is_modeled_implicit_exception_operation(node) and not isinstance(
+            node, (ast.Compare, ast.FormattedValue)
+        ):
             self._record_implicit_exception_aliases()
 
     def _is_metadata_reference(self, node: ast.AST) -> bool:
@@ -800,7 +802,13 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_FormattedValue(self, node: ast.FormattedValue) -> None:
         self._record_metadata_merge_key_violations(node.value)
-        self.generic_visit(node)
+        self.visit(node.value)
+        # Conversion precedes the optional spec; final formatting always follows both.
+        if node.conversion != -1:
+            self._record_implicit_exception_aliases()
+        if node.format_spec is not None:
+            self.visit(node.format_spec)
+        self._record_implicit_exception_aliases()
 
     def visit_Slice(self, node: ast.Slice) -> None:
         self._record_metadata_merge_key_violations(node.lower)

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.base.py.txt
@@ -540,3 +540,34 @@ def true_exhaustive_match_guard_skips_later_cases(flow, manager, value):
                 operation()
         metadata = {}
     return metadata["firewall_name"]
+
+
+def formatted_value_failure_before_rebind(flow, manager, value):
+    metadata = flow.metadata
+    with manager:
+        f"{value}"
+        metadata = {}
+    return metadata["vm_run_id"]
+
+
+def conversion_failure_precedes_format_spec_rebind(flow, manager, value):
+    metadata = flow.metadata
+    with manager:
+        f"{value!r:{(metadata := {})}}"
+        metadata = {}
+    return metadata["firewall_name"]
+
+
+def format_spec_rebind_precedes_formatting_failure(flow, manager, value):
+    metadata = flow.metadata
+    with manager:
+        f"{value:{(metadata := {})}}"
+        metadata = {}
+    return metadata["original_url"]
+
+
+def formatted_value_failure_before_return(flow, manager, value):
+    metadata = flow.metadata
+    with manager:
+        return f"{value}"
+    return metadata["network_log_target"]

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.expected.txt
@@ -33,3 +33,6 @@ implicit_exception_flow.py:389: use metadata_keys.NETWORK_LOG_TARGET for flow.me
 implicit_exception_flow.py:429: use metadata_keys.FIREWALL_PERMISSION for flow.metadata access
 implicit_exception_flow.py:501: use metadata_keys.CONNECTOR_ROUTE_REASON for flow.metadata access
 implicit_exception_flow.py:509: use metadata_keys.CONNECTOR_ROUTE_CANDIDATES for flow.metadata access
+implicit_exception_flow.py:550: use metadata_keys.VM_RUN_ID for flow.metadata access
+implicit_exception_flow.py:558: use metadata_keys.FIREWALL_NAME for flow.metadata access
+implicit_exception_flow.py:573: use metadata_keys.NETWORK_LOG_TARGET for flow.metadata access


### PR DESCRIPTION
## Summary

- classify f-string formatted values as fallible in the shared implicit-exception model
- preserve conversion and final-format failure aliases at their Python evaluation points
- cover ordinary formatting, conversion-before-spec, spec-before-final-format, and terminal-return reachability through the public linter fixture

## Exclusions

- no runtime addon behavior, API, protocol, schema, persisted data, or deployment compatibility changes
- no new internal helper tests or abstractions

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_flow_metadata_key_contract.py` (18 passed)
- `uv run --no-sync python -m pytest tests/` (4729 passed)

Closes #25013
