### PR TITLE
perf(guest-agent): measure codex startup readiness

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -27,8 +27,8 @@ use super::codex_app_server_events::{
 };
 use super::event_delivery::{EventDeliveryRuntime, EventDeliverySender};
 use super::{
-    AgentExecutionDeadline, CliEventIngestor, CliExecutionResult, CliRuntimeConfig,
-    HeartbeatMonitor, HeartbeatStatus, LOG_TAG, ParsedEventAction, command,
+    AgentExecutionDeadline, CliEventIngestor, CliExecutionControls, CliExecutionResult,
+    CliRuntimeConfig, HeartbeatMonitor, HeartbeatStatus, LOG_TAG, ParsedEventAction, command,
 };
 use crate::active_input::{ActiveInputFrame, ActiveInputWriter};
 use guest_common::{log_info, log_warn};
@@ -60,8 +60,8 @@ struct ThreadIdentity {
     canonical_id: String,
 }
 
-struct EventIngestSink<'a> {
-    ingestor: &'a mut CliEventIngestor,
+struct EventIngestSink<'a, 'startup> {
+    ingestor: &'a mut CliEventIngestor<'startup>,
     output_timing: &'a mut CodexOutputTiming,
     log_file: &'a mut tokio::fs::File,
     masker: &'a SecretMasker,
@@ -145,8 +145,7 @@ pub(super) async fn execute_codex_app_server_for_runtime(
     masker: &SecretMasker,
     mut heartbeat_monitor: HeartbeatMonitor,
     http: HttpClient,
-    active_input: ActiveInputWriter,
-    user_cancellation: CancellationToken,
+    controls: CliExecutionControls<'_>,
     runtime: &CliRuntimeConfig<'_>,
 ) -> Result<CliExecutionResult, AgentError> {
     log_info!(LOG_TAG, "Starting codex app-server execution...");
@@ -159,8 +158,7 @@ pub(super) async fn execute_codex_app_server_for_runtime(
         &mut heartbeat_monitor,
         should_send_events,
         event_delivery.sender(),
-        active_input,
-        user_cancellation,
+        controls,
         runtime,
     )
     .await;
@@ -190,13 +188,17 @@ async fn run_codex_app_server(
     heartbeat_monitor: &mut HeartbeatMonitor,
     should_send_events: bool,
     event_tx: &EventDeliverySender,
-    mut active_input: ActiveInputWriter,
-    user_cancellation: CancellationToken,
+    controls: CliExecutionControls<'_>,
     runtime: &CliRuntimeConfig<'_>,
 ) -> Result<CliExecutionResult, AgentError> {
+    let CliExecutionControls {
+        mut active_input,
+        user_cancellation,
+        codex_startup,
+    } = controls;
     let log_file = guest_contracts::runtime_paths::create_private(runtime.agent_log_file.as_ref())?;
     let mut log_file = tokio::fs::File::from_std(log_file);
-    let mut ingestor = CliEventIngestor::new(runtime);
+    let mut ingestor = CliEventIngestor::new(runtime, codex_startup);
     let mut output_timing = CodexOutputTiming::default();
     let resume_thread_id = resume_thread_id_from_runtime(runtime)?;
     let mut client = CodexAppServerClient::spawn(codex_app_server_config(runtime))
@@ -736,7 +738,7 @@ async fn race_with_heartbeat<T>(
 
 async fn drain_queued_notifications(
     client: &mut CodexAppServerClient,
-    sink: &mut EventIngestSink<'_>,
+    sink: &mut EventIngestSink<'_, '_>,
     active_input: &ActiveInputWriter,
     thread_started_emitted: &mut bool,
     scope: &CodexTurnScope<'_>,
@@ -776,7 +778,7 @@ async fn drain_queued_notifications(
 
 async fn ingest_run_notification(
     notification: ServerNotification,
-    sink: &mut EventIngestSink<'_>,
+    sink: &mut EventIngestSink<'_, '_>,
     active_input: &ActiveInputWriter,
     thread_started_emitted: &mut bool,
     scope: &CodexTurnScope<'_>,
@@ -837,7 +839,7 @@ fn heartbeat_error(result: Result<HeartbeatStatus, oneshot::error::RecvError>) -
 
 async fn ingest_notification(
     notification: ServerNotification,
-    sink: &mut EventIngestSink<'_>,
+    sink: &mut EventIngestSink<'_, '_>,
     thread_started_emitted: bool,
     expected_thread_id: &str,
     active_turn_id: &str,
@@ -977,7 +979,10 @@ fn validate_scope(
     Ok(())
 }
 
-fn record_output_item_start(start: Option<&CodexOutputItemStart>, sink: &mut EventIngestSink<'_>) {
+fn record_output_item_start(
+    start: Option<&CodexOutputItemStart>,
+    sink: &mut EventIngestSink<'_, '_>,
+) {
     if let Some(start) = start {
         sink.output_timing.record(start, sink.ingestor);
     }
@@ -994,7 +999,7 @@ fn event_turn_id(event: &Value) -> Option<&str> {
         .or_else(|| event.pointer("/turn/id").and_then(Value::as_str))
 }
 
-async fn ingest_event(event: Value, sink: &mut EventIngestSink<'_>) -> Result<(), AgentError> {
+async fn ingest_event(event: Value, sink: &mut EventIngestSink<'_, '_>) -> Result<(), AgentError> {
     let raw_line = serde_json::to_vec(&event)?;
     match sink
         .ingestor

--- a/crates/guest-agent/src/cli/codex_startup.rs
+++ b/crates/guest-agent/src/cli/codex_startup.rs
@@ -1,0 +1,46 @@
+//! Exactly-once telemetry for Codex startup through primary turn readiness.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+
+use guest_common::telemetry::record_sandbox_op;
+
+/// Records the complete Codex setup-to-turn-readiness boundary once.
+pub struct CodexStartupTiming {
+    started_at: Instant,
+    completed: AtomicBool,
+}
+
+impl CodexStartupTiming {
+    /// Start a Codex startup observation at the current monotonic time.
+    #[must_use]
+    pub fn start() -> Self {
+        Self {
+            started_at: Instant::now(),
+            completed: AtomicBool::new(false),
+        }
+    }
+
+    /// Complete startup successfully at the time readiness was observed.
+    pub fn record_success_at(&self, observed_at: Instant) {
+        self.record_at(observed_at, true);
+    }
+
+    /// Complete startup as failed at the current monotonic time.
+    pub fn record_failure(&self) {
+        self.record_at(Instant::now(), false);
+    }
+
+    fn record_at(&self, completed_at: Instant, success: bool) {
+        if self.completed.swap(true, Ordering::Relaxed) {
+            return;
+        }
+
+        record_sandbox_op(
+            "codex_startup",
+            completed_at.saturating_duration_since(self.started_at),
+            success,
+            None,
+        );
+    }
+}

--- a/crates/guest-agent/src/cli/framework.rs
+++ b/crates/guest-agent/src/cli/framework.rs
@@ -140,6 +140,11 @@ impl CliFrameworkBehavior {
                 )
             )
     }
+
+    pub(super) fn is_codex_turn_started(self, event: &serde_json::Value) -> bool {
+        matches!(self.framework, env::Framework::Codex)
+            && event.get("type").and_then(serde_json::Value::as_str) == Some("turn.started")
+    }
 }
 
 #[cfg(test)]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -548,14 +548,13 @@ impl<'a> CliEventIngestor<'a> {
         masker: &SecretMasker,
         behavior: CliFrameworkBehavior,
     ) -> Result<ParsedEventAction, AgentError> {
-        let observed_at = Instant::now();
         let is_stream_event =
             event.get("type").and_then(serde_json::Value::as_str) == Some("stream_event");
         if !is_stream_event
             && behavior.is_codex_turn_started(event)
             && let Some(codex_startup) = self.codex_startup
         {
-            codex_startup.record_success_at(observed_at);
+            codex_startup.record_success_at(Instant::now());
         }
         Self::write_raw_line(log_file, raw_line).await;
 

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -24,6 +24,7 @@ mod codex_app_server_backend;
 mod codex_app_server_events;
 mod codex_runtime_config;
 mod codex_setup;
+mod codex_startup;
 mod command;
 mod diagnostics;
 mod event_delivery;
@@ -34,6 +35,7 @@ mod process_group;
 mod termination;
 
 pub use codex_setup::setup_codex_for_config;
+pub use codex_startup::CodexStartupTiming;
 pub use framework::{ClaudeResultStatus, ClaudeResultSummary};
 
 use crate::active_input::{ActiveInputController, ActiveInputWriter, ReplayUserEventAction};
@@ -503,16 +505,17 @@ enum ParsedEventAction {
     Skip,
 }
 
-struct CliEventIngestor {
+struct CliEventIngestor<'a> {
     seq: u32,
     api_start_time: String,
     last_read_event_at: Option<Instant>,
     session_metadata_capture: events::SessionMetadataCapture,
     failure_diagnostic: Option<CliFailureDiagnostic>,
+    codex_startup: Option<&'a CodexStartupTiming>,
 }
 
-impl CliEventIngestor {
-    fn new(runtime: &CliRuntimeConfig<'_>) -> Self {
+impl<'a> CliEventIngestor<'a> {
+    fn new(runtime: &CliRuntimeConfig<'_>, codex_startup: Option<&'a CodexStartupTiming>) -> Self {
         Self {
             seq: 0,
             api_start_time: runtime.api_start_time.to_string(),
@@ -524,6 +527,7 @@ impl CliEventIngestor {
                 runtime.session_history_path_file.as_ref(),
             ),
             failure_diagnostic: None,
+            codex_startup,
         }
     }
 
@@ -544,9 +548,18 @@ impl CliEventIngestor {
         masker: &SecretMasker,
         behavior: CliFrameworkBehavior,
     ) -> Result<ParsedEventAction, AgentError> {
+        let observed_at = Instant::now();
+        let is_stream_event =
+            event.get("type").and_then(serde_json::Value::as_str) == Some("stream_event");
+        if !is_stream_event
+            && behavior.is_codex_turn_started(event)
+            && let Some(codex_startup) = self.codex_startup
+        {
+            codex_startup.record_success_at(observed_at);
+        }
         Self::write_raw_line(log_file, raw_line).await;
 
-        if event.get("type").and_then(serde_json::Value::as_str) == Some("stream_event") {
+        if is_stream_event {
             return Ok(ParsedEventAction::Skip);
         }
         self.last_read_event_at = Some(Instant::now());
@@ -653,7 +666,7 @@ pub async fn execute_cli_with_active_input_for_config_started_at(
         masker,
         heartbeat_monitor,
         http,
-        CliExecutionControls::new(active_input, CancellationToken::new()),
+        CliExecutionControls::new(active_input, CancellationToken::new(), None),
         config,
         paths,
         execution_started_at,
@@ -662,18 +675,24 @@ pub async fn execute_cli_with_active_input_for_config_started_at(
 }
 
 /// Run-scoped controls observed while the inner CLI is executing.
-pub struct CliExecutionControls {
+pub struct CliExecutionControls<'a> {
     active_input: ActiveInputWriter,
     user_cancellation: CancellationToken,
+    codex_startup: Option<&'a CodexStartupTiming>,
 }
 
-impl CliExecutionControls {
-    /// Create controls for active input and explicit user cancellation.
+impl<'a> CliExecutionControls<'a> {
+    /// Create controls for active input, cancellation, and optional Codex startup timing.
     #[must_use]
-    pub fn new(active_input: ActiveInputWriter, user_cancellation: CancellationToken) -> Self {
+    pub fn new(
+        active_input: ActiveInputWriter,
+        user_cancellation: CancellationToken,
+        codex_startup: Option<&'a CodexStartupTiming>,
+    ) -> Self {
         Self {
             active_input,
             user_cancellation,
+            codex_startup,
         }
     }
 }
@@ -683,33 +702,20 @@ pub async fn execute_cli_with_controls_for_config_started_at(
     masker: &SecretMasker,
     heartbeat_monitor: HeartbeatMonitor,
     http: HttpClient,
-    controls: CliExecutionControls,
+    controls: CliExecutionControls<'_>,
     config: &env::GuestConfig,
     paths: &paths::GuestPaths,
     execution_started_at: Instant,
 ) -> Result<CliExecutionResult, AgentError> {
-    let CliExecutionControls {
-        active_input,
-        user_cancellation,
-    } = controls;
     let runtime = CliRuntimeConfig::from_config(config, paths, execution_started_at)?;
-    execute_cli_inner(
-        masker,
-        heartbeat_monitor,
-        http,
-        active_input,
-        user_cancellation,
-        &runtime,
-    )
-    .await
+    execute_cli_inner(masker, heartbeat_monitor, http, controls, &runtime).await
 }
 
 async fn execute_cli_inner(
     masker: &SecretMasker,
     mut heartbeat_monitor: HeartbeatMonitor,
     http: HttpClient,
-    active_input: ActiveInputWriter,
-    user_cancellation: CancellationToken,
+    controls: CliExecutionControls<'_>,
     runtime: &CliRuntimeConfig<'_>,
 ) -> Result<CliExecutionResult, AgentError> {
     if matches!(runtime.framework, env::Framework::Codex) && runtime.use_codex_app_server_backend {
@@ -717,12 +723,17 @@ async fn execute_cli_inner(
             masker,
             heartbeat_monitor,
             http,
-            active_input,
-            user_cancellation,
+            controls,
             runtime,
         )
         .await;
     }
+
+    let CliExecutionControls {
+        active_input,
+        user_cancellation,
+        codex_startup,
+    } = controls;
 
     let behavior = CliFrameworkBehavior::new(runtime.framework);
     let replay_user_messages = active_input.is_enabled();
@@ -939,7 +950,7 @@ async fn execute_cli_inner(
     let mut cli_exit_at: Option<Instant> = None;
     let mut claude_result = None;
     let mut post_result_cleanup_result = None;
-    let mut event_ingestor = CliEventIngestor::new(runtime);
+    let mut event_ingestor = CliEventIngestor::new(runtime, codex_startup);
     let event_result: Result<(), AgentError> = loop {
         tokio::select! {
             () = user_cancellation.cancelled(), if !user_cancellation_handled && cli_status.is_none() => {

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -360,12 +360,18 @@ async fn execute(
     }
     record_sandbox_op("working_dir_setup", wd_start.elapsed(), true, None);
 
+    let codex_startup =
+        matches!(config.framework, env::Framework::Codex).then(cli::CodexStartupTiming::start);
+
     // Codex setup must complete before the CLI starts. On reused sandboxes,
     // continuing after a setup failure can inherit stale auth or runtime state
     // from an earlier run.
     if matches!(config.framework, env::Framework::Codex)
         && let Err(e) = cli::setup_codex_for_config(masker, config).await
     {
+        if let Some(codex_startup) = codex_startup.as_ref() {
+            codex_startup.record_failure();
+        }
         let msg = format!("Codex setup failed: {}", masker.mask_string(&e.to_string()));
         log_error!(LOG_TAG, "{msg}");
         failure_diagnostics::write_guest_error_file(runtime_paths.checkpoint_error_file(), &msg);
@@ -395,6 +401,19 @@ async fn execute(
     let cli_start = Instant::now();
     let mut last_event_sequence = None;
     let mut event_delivery_failure = None;
+    let cli_result = cli::execute_cli_with_controls_for_config_started_at(
+        masker,
+        heartbeat_monitor,
+        http.clone(),
+        cli::CliExecutionControls::new(active_input, cli_cancellation, codex_startup.as_ref()),
+        config,
+        runtime_paths,
+        start,
+    )
+    .await;
+    if let Some(codex_startup) = codex_startup.as_ref() {
+        codex_startup.record_failure();
+    }
     let (
         cli_exit_code,
         mut exit_code,
@@ -402,17 +421,7 @@ async fn execute(
         skip_recovery_checkpoint_for_no_history,
         mut failure_diagnostic,
         cli_execution_succeeded,
-    ) = match cli::execute_cli_with_controls_for_config_started_at(
-        masker,
-        heartbeat_monitor,
-        http.clone(),
-        cli::CliExecutionControls::new(active_input, cli_cancellation),
-        config,
-        runtime_paths,
-        start,
-    )
-    .await
-    {
+    ) = match cli_result {
         Ok(cli_result) => {
             last_event_sequence = cli_result.last_event_sequence;
             if let Some(event_delivery) = cli_result.event_delivery.clone() {

--- a/crates/guest-agent/tests/codex_setup_fail_closed.rs
+++ b/crates/guest-agent/tests/codex_setup_fail_closed.rs
@@ -6,6 +6,7 @@
 mod common;
 
 use guest_contracts::diagnostics::{FailureClass, FailureDiagnostic};
+use serde_json::Value;
 use shell_quote::quote_shell_arg;
 use std::path::Path;
 use std::process::{Command, Output};
@@ -59,6 +60,25 @@ fn codex_setup_failure_exits_before_cli_spawn() -> TestResult {
     let diagnostic_path = guest_contracts::runtime_paths::failure_diagnostic_file(&runtime_dir);
     let diagnostic: FailureDiagnostic = serde_json::from_slice(&std::fs::read(diagnostic_path)?)?;
     assert_eq!(diagnostic.failure_class, FailureClass::CliExecutionError);
+
+    let sandbox_ops_path = guest_contracts::runtime_paths::sandbox_ops_log_file(&runtime_dir);
+    let sandbox_ops = std::fs::read_to_string(sandbox_ops_path)?;
+    let startup = sandbox_ops
+        .lines()
+        .map(serde_json::from_str::<Value>)
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .filter(|operation| {
+            operation.get("action_type").and_then(Value::as_str) == Some("codex_startup")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(startup.len(), 1);
+    let startup = startup
+        .first()
+        .ok_or(std::io::Error::other("missing Codex startup operation"))?;
+    assert_eq!(startup.get("success").and_then(Value::as_bool), Some(false));
+    assert!(startup.get("duration_ms").and_then(Value::as_u64).is_some());
+    assert!(startup.get("error").is_none());
 
     Ok(())
 }

--- a/crates/guest-agent/tests/codex_startup_telemetry.rs
+++ b/crates/guest-agent/tests/codex_startup_telemetry.rs
@@ -1,0 +1,321 @@
+//! Entry-point coverage for Codex startup telemetry.
+
+mod common;
+
+use serde_json::{Value, json};
+use shell_quote::quote_shell_arg;
+use std::path::Path;
+use std::process::{Command, Output};
+
+const CODEX_STARTUP_ACTION: &str = "codex_startup";
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+#[test]
+fn ordinary_codex_records_startup_success_once_at_turn_started() -> TestResult {
+    common::ensure_canonical_workspace_for_test()?;
+
+    let tmp = tempfile::tempdir()?;
+    let codex = tmp.path().join("codex");
+    let runtime_dir = tmp.path().join("runtime");
+    write_jsonl_executable(
+        &codex,
+        &[
+            json!({
+                "type": "thread.started",
+                "thread_id": "00000000-0000-4000-8000-000000000101"
+            }),
+            json!({"type": "turn.started"}),
+            json!({"type": "turn.started"}),
+            json!({
+                "type": "turn.completed",
+                "usage": {"input_tokens": 1, "output_tokens": 1}
+            }),
+        ],
+        false,
+    )?;
+    let run_payload_path = write_run_payload(&runtime_dir, "measure successful startup")?;
+
+    let output = run_guest_agent(GuestAgentInvocation {
+        framework: TestFramework::Codex {
+            binary: &codex,
+            app_server_scenario: None,
+        },
+        runtime_dir: &runtime_dir,
+        run_payload_path: &run_payload_path,
+        home: tmp.path(),
+        run_id: "codex-startup-success",
+    })?;
+
+    assert_guest_success(&output);
+    let operations = read_sandbox_operations(&runtime_dir)?;
+    assert_one_codex_startup(&operations, true)?;
+
+    Ok(())
+}
+
+#[test]
+fn ordinary_codex_exit_before_turn_started_records_startup_failure() -> TestResult {
+    common::ensure_canonical_workspace_for_test()?;
+
+    let tmp = tempfile::tempdir()?;
+    let codex = tmp.path().join("codex");
+    let runtime_dir = tmp.path().join("runtime");
+    write_jsonl_executable(
+        &codex,
+        &[json!({
+            "type": "thread.started",
+            "thread_id": "00000000-0000-4000-8000-000000000102"
+        })],
+        false,
+    )?;
+    let run_payload_path = write_run_payload(&runtime_dir, "measure failed startup")?;
+
+    let output = run_guest_agent(GuestAgentInvocation {
+        framework: TestFramework::Codex {
+            binary: &codex,
+            app_server_scenario: None,
+        },
+        runtime_dir: &runtime_dir,
+        run_payload_path: &run_payload_path,
+        home: tmp.path(),
+        run_id: "codex-startup-before-turn-exit",
+    })?;
+
+    assert_guest_success(&output);
+    let operations = read_sandbox_operations(&runtime_dir)?;
+    assert_one_codex_startup(&operations, false)?;
+
+    Ok(())
+}
+
+#[test]
+fn app_server_records_startup_success_at_primary_turn_started() -> TestResult {
+    common::ensure_canonical_workspace_for_test()?;
+
+    let mock_codex = common::build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    let runtime_dir = tmp.path().join("runtime");
+    let run_payload_path = write_run_payload(&runtime_dir, "measure app-server startup")?;
+
+    let output = run_guest_agent(GuestAgentInvocation {
+        framework: TestFramework::Codex {
+            binary: &mock_codex,
+            app_server_scenario: Some("runtime-turn-complete-without-thread-started"),
+        },
+        runtime_dir: &runtime_dir,
+        run_payload_path: &run_payload_path,
+        home: tmp.path(),
+        run_id: "codex-app-server-startup-success",
+    })?;
+
+    assert_guest_success(&output);
+    let operations = read_sandbox_operations(&runtime_dir)?;
+    assert_one_codex_startup(&operations, true)?;
+
+    Ok(())
+}
+
+#[test]
+fn claude_code_does_not_record_codex_startup() -> TestResult {
+    common::ensure_canonical_workspace_for_test()?;
+
+    let tmp = tempfile::tempdir()?;
+    let claude = tmp.path().join("claude");
+    let runtime_dir = tmp.path().join("runtime");
+    write_jsonl_executable(
+        &claude,
+        &[json!({
+            "type": "result",
+            "subtype": "success",
+            "session_id": "claude-startup-control",
+            "is_error": false,
+            "duration_ms": 1,
+            "num_turns": 1,
+            "result": "done",
+            "total_cost_usd": 0,
+            "usage": {"input_tokens": 1, "output_tokens": 1}
+        })],
+        true,
+    )?;
+    let run_payload_path = write_run_payload(&runtime_dir, "run Claude Code")?;
+
+    let output = run_guest_agent(GuestAgentInvocation {
+        framework: TestFramework::ClaudeCode { binary: &claude },
+        runtime_dir: &runtime_dir,
+        run_payload_path: &run_payload_path,
+        home: tmp.path(),
+        run_id: "claude-startup-control",
+    })?;
+
+    assert_guest_success(&output);
+    let operations = read_sandbox_operations(&runtime_dir)?;
+    assert!(
+        operations.iter().all(|operation| {
+            operation.get("action_type").and_then(Value::as_str) != Some(CODEX_STARTUP_ACTION)
+        }),
+        "Claude Code must not emit Codex startup telemetry: {operations:?}"
+    );
+
+    Ok(())
+}
+
+enum TestFramework<'a> {
+    Codex {
+        binary: &'a Path,
+        app_server_scenario: Option<&'a str>,
+    },
+    ClaudeCode {
+        binary: &'a Path,
+    },
+}
+
+struct GuestAgentInvocation<'a> {
+    framework: TestFramework<'a>,
+    runtime_dir: &'a Path,
+    run_payload_path: &'a Path,
+    home: &'a Path,
+    run_id: &'a str,
+}
+
+fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::io::Error> {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
+    command
+        .env_clear()
+        .env("VM0_RUN_ID", args.run_id)
+        .env(
+            guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
+            args.run_payload_path,
+        )
+        .env("VM0_API_BACKEND_URL", "http://127.0.0.1:1")
+        .env("VM0_API_TOKEN", "")
+        .env("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc")
+        .env("VM0_SANDBOX_REUSE_RESULT", "reused")
+        .env(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            args.runtime_dir,
+        )
+        .env("HOME", args.home);
+
+    match args.framework {
+        TestFramework::Codex {
+            binary,
+            app_server_scenario,
+        } => {
+            command
+                .env("CLI_AGENT_TYPE", "codex")
+                .env("USE_MOCK_CODEX", "true")
+                .env("VM0_MOCK_CODEX_PATH", binary);
+            if let Some(scenario) = app_server_scenario {
+                command
+                    .env("VM0_CODEX_APP_SERVER_BACKEND", "1")
+                    .env("MOCK_CODEX_APP_SERVER_SCENARIO", scenario);
+            }
+        }
+        TestFramework::ClaudeCode { binary } => {
+            command
+                .env("CLI_AGENT_TYPE", "claude-code")
+                .env("USE_MOCK_CLAUDE", "true")
+                .env("VM0_MOCK_CLAUDE_PATH", binary);
+        }
+    }
+
+    command.output()
+}
+
+fn write_run_payload(runtime_dir: &Path, prompt: &str) -> Result<std::path::PathBuf, String> {
+    common::write_run_payload_file_for_test(
+        runtime_dir,
+        &guest_contracts::env::RunPayload {
+            prompt: prompt.to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )
+}
+
+fn write_jsonl_executable(path: &Path, events: &[Value], read_stdin: bool) -> TestResult {
+    let mut script = "#!/bin/sh\n".to_string();
+    if read_stdin {
+        script.push_str("IFS= read -r _prompt || exit 1\n");
+    }
+    for event in events {
+        let line = serde_json::to_string(event)?;
+        script.push_str(&format!(
+            "printf '%s\\n' {}\n",
+            quote_shell_arg(line.as_str())
+        ));
+    }
+    std::fs::write(path, script)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut permissions = std::fs::metadata(path)?.permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(path, permissions)?;
+    }
+    Ok(())
+}
+
+fn read_sandbox_operations(runtime_dir: &Path) -> Result<Vec<Value>, TestError> {
+    let path = guest_contracts::runtime_paths::sandbox_ops_log_file(runtime_dir);
+    let contents = std::fs::read_to_string(path)?;
+    contents
+        .lines()
+        .map(|line| serde_json::from_str(line).map_err(Into::into))
+        .collect()
+}
+
+fn assert_one_codex_startup(operations: &[Value], expected_success: bool) -> TestResult {
+    let startup = operations
+        .iter()
+        .filter(|operation| {
+            operation.get("action_type").and_then(Value::as_str) == Some(CODEX_STARTUP_ACTION)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        startup.len(),
+        1,
+        "unexpected startup operations: {startup:?}"
+    );
+    let operation = startup
+        .first()
+        .ok_or(std::io::Error::other("missing Codex startup operation"))?;
+    assert_eq!(
+        operation.get("success").and_then(Value::as_bool),
+        Some(expected_success)
+    );
+    assert!(
+        operation
+            .get("duration_ms")
+            .and_then(Value::as_u64)
+            .is_some(),
+        "startup operation must contain a numeric duration: {operation}"
+    );
+    assert!(
+        operation.get("ts").and_then(Value::as_str).is_some(),
+        "startup operation must contain a timestamp: {operation}"
+    );
+    assert!(
+        operation.get("error").is_none(),
+        "startup operation must remain content-free: {operation}"
+    );
+    assert_eq!(
+        operation.as_object().map(serde_json::Map::len),
+        Some(4),
+        "startup operation must not add payload fields: {operation}"
+    );
+
+    Ok(())
+}
+
+fn assert_guest_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "guest-agent failed with status {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+type TestError = Box<dyn std::error::Error>;

--- a/crates/guest-agent/tests/codex_startup_telemetry.rs
+++ b/crates/guest-agent/tests/codex_startup_telemetry.rs
@@ -117,6 +117,33 @@ fn app_server_records_startup_success_at_primary_turn_started() -> TestResult {
 }
 
 #[test]
+fn app_server_secondary_turn_started_does_not_complete_startup() -> TestResult {
+    common::ensure_canonical_workspace_for_test()?;
+
+    let mock_codex = common::build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    let runtime_dir = tmp.path().join("runtime");
+    let run_payload_path = write_run_payload(&runtime_dir, "ignore secondary startup")?;
+
+    let output = run_guest_agent(GuestAgentInvocation {
+        framework: TestFramework::Codex {
+            binary: &mock_codex,
+            app_server_scenario: Some("secondary-thread-notifications"),
+        },
+        runtime_dir: &runtime_dir,
+        run_payload_path: &run_payload_path,
+        home: tmp.path(),
+        run_id: "codex-app-server-secondary-startup",
+    })?;
+
+    assert_guest_success(&output);
+    let operations = read_sandbox_operations(&runtime_dir)?;
+    assert_one_codex_startup(&operations, false)?;
+
+    Ok(())
+}
+
+#[test]
 fn claude_code_does_not_record_codex_startup() -> TestResult {
     common::ensure_canonical_workspace_for_test()?;
 

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1102,7 +1102,7 @@ pub async fn execute_cli_with_cancellation_for_runtime(
         masker,
         heartbeat,
         runtime.http.clone(),
-        guest_agent::cli::CliExecutionControls::new(active_input.into_writer(), cancellation),
+        guest_agent::cli::CliExecutionControls::new(active_input.into_writer(), cancellation, None),
         &runtime.config,
         &runtime.paths,
         Instant::now(),


### PR DESCRIPTION
## Summary

- record one exactly-once `codex_startup` operation from Codex setup through the primary `turn.started` event
- cover setup and terminal failures without changing existing execution outcomes, diagnostics, or other telemetry
- add full guest-agent entry coverage for ordinary exec, app-server, setup failure, duplicate readiness, and Claude exclusion

## Scope

- no database schema, migration, public API, persisted state, queue payload, feature switch, synchronous network work, or payload-derived telemetry
- older runner artifacts naturally lack the metric; production analysis uses promotion-bounded cohorts and the eligible working-directory-success denominator

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-agent --no-deps`
- `cargo test -p guest-agent --test codex_startup_telemetry`
- `cargo test -p guest-agent --test codex_setup_fail_closed`
- `cargo test -p guest-agent --test codex_app_server_backend`
- `cargo test -p guest-agent --all-targets --all-features`

Closes #24998

Parent context: #22892
