### PR TITLE
refactor(api-contracts): rename deepseek codex provider key

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -2465,7 +2465,10 @@ describe("CHAT-02: model-first provider policies", () => {
       prompt: "run with DeepSeek Responses",
       model: "deepseek-v4-flash",
     });
-    const { claim } = await claimChatRun(runnerGroup, run.runId);
+    const { claim, sandboxHeaders } = await claimChatRun(
+      runnerGroup,
+      run.runId,
+    );
     const environment = claimEnvironment(claim);
 
     expect(claim.cliAgentType).toBe("codex");
@@ -2476,7 +2479,7 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(environment.OPENAI_MODEL).toBe("deepseek-v4-flash");
     expect(environment.ANTHROPIC_MODEL).toBeUndefined();
     expect(claim.codexRuntimeConfig).toMatchObject({
-      providerId: "vm0-model",
+      providerId: "deepseek-codex",
       name: "DeepSeek",
       baseUrl: "https://api.deepseek.com",
       envKey: "OPENAI_API_KEY",
@@ -2493,7 +2496,33 @@ describe("CHAT-02: model-first provider policies", () => {
       },
     });
 
-    await cancelChatRun(actor, run.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(run.runId, sandboxHeaders, {
+      cliAgentType: "codex",
+    });
+
+    const followUp = await sendChatRun(actor, {
+      agentId,
+      threadId: run.threadId,
+      prompt: "continue with DeepSeek Responses",
+    });
+    const { claim: followUpClaim } = await claimChatRun(
+      runnerGroup,
+      followUp.runId,
+    );
+    const followUpEnvironment = claimEnvironment(followUpClaim);
+    expect(followUpClaim.cliAgentType).toBe("codex");
+    expect(followUpClaim.resumeSession?.sessionId).toBe(`bdd-cli-${run.runId}`);
+    expect(followUpClaim.codexRuntimeConfig?.providerId).toBe("deepseek-codex");
+    expect(followUpEnvironment.OPENAI_API_KEY).toBe(
+      modelProviderSecretPlaceholder("deepseek-codex", "DEEPSEEK_API_KEY"),
+    );
+    expect(followUpEnvironment.OPENAI_BASE_URL).toBe(
+      "https://api.deepseek.com",
+    );
+    expect(followUpEnvironment.OPENAI_MODEL).toBe("deepseek-v4-flash");
+
+    await cancelChatRun(actor, followUp.runId);
   });
 
   it("resolves an unchanged existing thread without waiting for its row lock", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -6033,7 +6033,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     });
     expect(claim.environment).not.toHaveProperty("ANTHROPIC_MODEL");
     expect(claim.codexRuntimeConfig).toMatchObject({
-      providerId: "vm0-model",
+      providerId: "deepseek-codex",
       name: "DeepSeek",
       baseUrl: "https://api.deepseek.com",
       envKey: "OPENAI_API_KEY",

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -1053,7 +1053,7 @@ describe("deepseek-codex Responses provider", () => {
 
   it("configures the VM0-owned DeepSeek Responses model catalog", () => {
     expect(getModelProviderCodexRuntimeConfig("deepseek-codex")).toMatchObject({
-      providerId: "vm0-model",
+      providerId: "deepseek-codex",
       name: "DeepSeek",
       baseUrl: "https://api.deepseek.com",
       envKey: "OPENAI_API_KEY",

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -88,7 +88,7 @@ const MODEL_PROVIDER_CODEX_RUNTIME_CONFIGS: Partial<
   Record<ModelProviderType, ModelProviderCodexRuntimeConfig>
 > = {
   "deepseek-codex": {
-    providerId: "vm0-model",
+    providerId: "deepseek-codex",
     name: "DeepSeek",
     baseUrl: "https://api.deepseek.com",
     envKey: "OPENAI_API_KEY",


### PR DESCRIPTION
## Summary

- rename the active DeepSeek Codex runtime provider key from `vm0-model` to `deepseek-codex`
- keep direct and VM0-managed DeepSeek claims aligned through the shared runtime-config registry
- extend the direct DeepSeek route integration through checkpoint, completion, session continuation, and claim so the resumed run proves it receives both the prior Codex session and the current provider key

## Scope

This changes only the opaque Codex provider namespace and its direct contract/API expectations. The provider type, model mapping, credentials, DeepSeek URL, Responses wire behavior, catalog contents, pricing, usage identity, and firewall routing are unchanged.

There is no runtime-config shape change, guest compatibility branch, database schema change, persisted-data migration, R2 transition, or backfill. Execution contexts created before deployment keep `vm0-model`; newly created contexts use `deepseek-codex`.

## Deployment compatibility

The reader-first prerequisite from #24957 is released in guest-agent v0.63.5 / Runner v0.155.1 and is active on both production hosts. Older deployed Runner services are draining and cannot claim new payloads.

A rollback that re-admits Runner older than v0.155.1 while this API writer still serves is not compatible: the old guest does not structurally complete the DeepSeek catalog under the new key. A rollback crossing this boundary must make the API compatible before old Runner admission, restore #24957, or roll forward.

## Validation

- `pnpm exec prettier --check packages/api-contracts/src/contracts/model-providers.ts packages/api-contracts/src/contracts/__tests__/model-providers.test.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts` (183 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/chat-events.bdd.test.ts --maxWorkers=1` (210 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t "routes DeepSeek V4 Flash through the native Responses adapter" --maxWorkers=1` (final focused continuation check passed)
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace @vm0/api-contracts --workspace api`
- pre-commit hooks: Prettier, repository Knip, full Turbo type checking, file-size check, and commitlint

Closes #24943

Parent context: #24903
