### PR TITLE
test(vsock-guest): bound production identity guest teardown

### DIFF
--- a/crates/vsock-guest/tests/production_identity.rs
+++ b/crates/vsock-guest/tests/production_identity.rs
@@ -2,11 +2,12 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 use std::os::unix::net::UnixStream;
+use std::panic;
 use std::path::{Path, PathBuf};
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use vsock_proto::{MSG_ERROR, MSG_READY, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, RawMessage};
 
@@ -15,6 +16,8 @@ const SANDBOX_GID: u32 = 42_420;
 const SANDBOX_SUPPLEMENTARY_GID: u32 = 42_421;
 const SANDBOX_HOME: &str = "/home/user";
 const PRIVILEGED_REPORT_DIR: &str = "/root";
+const GUEST_CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
+const GUEST_COMPLETION_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 #[derive(Debug, Eq, PartialEq)]
 struct Identity {
@@ -104,7 +107,7 @@ fn require_production_configuration() {
 fn start_guest_connection() -> (JoinHandle<std::io::Result<()>>, UnixStream) {
     let (guest_stream, mut host_stream) = UnixStream::pair().expect("create Unix stream pair");
     host_stream
-        .set_read_timeout(Some(Duration::from_secs(5)))
+        .set_read_timeout(Some(GUEST_CONNECTION_TIMEOUT))
         .expect("set host read timeout");
     let handle = thread::spawn(move || vsock_guest::handle_connection(guest_stream));
 
@@ -115,10 +118,29 @@ fn start_guest_connection() -> (JoinHandle<std::io::Result<()>>, UnixStream) {
 }
 
 fn join_guest_connection(handle: JoinHandle<std::io::Result<()>>) {
-    handle
-        .join()
-        .expect("guest connection thread panicked")
+    wait_for_guest_connection_with_timeout(handle, GUEST_CONNECTION_TIMEOUT)
         .expect("guest connection returned an error");
+}
+
+fn wait_for_guest_connection_with_timeout(
+    handle: JoinHandle<io::Result<()>>,
+    timeout: Duration,
+) -> io::Result<()> {
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .expect("production identity guest teardown timeout overflowed");
+    while !handle.is_finished() {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            panic!("production identity guest teardown timed out after {timeout:?}");
+        }
+        thread::sleep(std::cmp::min(remaining, GUEST_COMPLETION_POLL_INTERVAL));
+    }
+
+    match handle.join() {
+        Ok(result) => result,
+        Err(payload) => panic::resume_unwind(payload),
+    }
 }
 
 fn send_write_file(stream: &mut UnixStream, sequence: u32, path: &str, sudo: bool) {
@@ -219,4 +241,95 @@ fn current_groups() -> BTreeSet<u32> {
     // SAFETY: This process identity getter has no preconditions.
     groups.insert(unsafe { libc::getegid() });
     groups
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+    use std::panic::AssertUnwindSafe;
+    use std::sync::mpsc;
+
+    use super::*;
+
+    const SHORT_TIMEOUT: Duration = Duration::from_millis(20);
+    const WATCHDOG_TIMEOUT: Duration = Duration::from_secs(5);
+
+    #[test]
+    fn guest_teardown_timeout_is_bounded() {
+        let (guest_started_tx, guest_started_rx) = mpsc::channel();
+        let (release_guest_tx, release_guest_rx) = mpsc::channel();
+        let (guest_finished_tx, guest_finished_rx) = mpsc::channel();
+        let guest = thread::spawn(move || {
+            guest_started_tx.send(()).expect("report guest start");
+            release_guest_rx.recv().expect("wait for guest release");
+            guest_finished_tx.send(()).expect("report guest completion");
+            Ok(())
+        });
+        guest_started_rx
+            .recv_timeout(WATCHDOG_TIMEOUT)
+            .expect("guest should reach blocked state");
+
+        let (observer_finished_tx, observer_finished_rx) = mpsc::channel();
+        let observer = thread::spawn(move || {
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                wait_for_guest_connection_with_timeout(guest, SHORT_TIMEOUT)
+            }));
+            observer_finished_tx
+                .send(result)
+                .expect("report teardown observer completion");
+        });
+
+        let observed = observer_finished_rx.recv_timeout(WATCHDOG_TIMEOUT);
+        release_guest_tx.send(()).expect("release stalled guest");
+        guest_finished_rx
+            .recv_timeout(WATCHDOG_TIMEOUT)
+            .expect("guest should finish after release");
+        if matches!(&observed, Err(mpsc::RecvTimeoutError::Timeout)) {
+            let _ = observer_finished_rx
+                .recv_timeout(WATCHDOG_TIMEOUT)
+                .expect("teardown observer should finish after guest release");
+        }
+        observer
+            .join()
+            .expect("teardown observer thread should not panic");
+
+        let result = observed.expect("teardown observer exceeded outer watchdog");
+        let payload = result.expect_err("stalled guest teardown should fail");
+        assert!(
+            panic_payload_message(payload.as_ref()).contains("production identity guest teardown"),
+            "teardown timeout should identify its lifecycle phase"
+        );
+    }
+
+    #[test]
+    fn bounded_guest_completion_preserves_completed_results() {
+        wait_for_guest_connection_with_timeout(thread::spawn(|| Ok(())), WATCHDOG_TIMEOUT)
+            .expect("completed guest should succeed");
+
+        let error = wait_for_guest_connection_with_timeout(
+            thread::spawn(|| Err(io::Error::other("guest error detail"))),
+            WATCHDOG_TIMEOUT,
+        )
+        .expect_err("guest error should be preserved");
+        assert_eq!(error.to_string(), "guest error detail");
+
+        let panic = panic::catch_unwind(|| {
+            wait_for_guest_connection_with_timeout(
+                thread::spawn(|| -> io::Result<()> { panic!("guest panic detail") }),
+                WATCHDOG_TIMEOUT,
+            )
+        })
+        .expect_err("guest panic should be preserved");
+        assert_eq!(panic_payload_message(panic.as_ref()), "guest panic detail");
+    }
+
+    fn panic_payload_message(payload: &(dyn Any + Send)) -> &str {
+        if let Some(message) = payload.downcast_ref::<&str>() {
+            message
+        } else if let Some(message) = payload.downcast_ref::<String>() {
+            message.as_str()
+        } else {
+            "non-string panic payload"
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- bound the production identity guest thread with a five-second teardown deadline after host disconnect
- preserve completed handler I/O errors and original thread panic payloads while reporting timeout separately
- add synchronized timeout coverage plus completed success, error, and panic regressions

## Scope

This is limited to `crates/vsock-guest/tests/production_identity.rs`. It keeps the privileged identity assertions, protocol flow, public production handler, report cleanup, release/no-default-feature path, and CI configuration unchanged.

It does not change production behavior, APIs, protocols, dependencies, schemas, persisted data, migrations, feature switches, deployment compatibility, rollout, or job timeouts.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vsock-guest --test production_identity` (2 passed, 1 privileged test ignored)
- `tests::guest_teardown_timeout_is_bounded` repeated 25 times
- `cargo test -p vsock-guest --release --no-default-features --test production_identity` (2 passed, 1 privileged test ignored)
- `cargo test -p vsock-guest` (222 passed, 1 privileged test ignored)
- `cargo clippy -p vsock-guest --all-targets --all-features -- -D warnings`
- `cargo clippy -p vsock-guest --release --no-default-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p vsock-guest --all-features --no-deps`
- affected-file Lefthook pre-commit checks and commit message lint
- `git diff --check`

The ignored privileged identity assertion requires CI's existing root account and helper setup.

Closes #25019
