### PR TITLE
perf(runner): move codex catalog validation off event loop

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -446,7 +446,11 @@ def _decompress_brotli_bounded(data: bytes, max_output: int) -> bytes:
 
 
 def _decompress_zlib_json_usage_body(
-    data: bytes, encoding: Literal["gzip", "deflate"], max_output: int
+    data: bytes,
+    encoding: Literal["gzip", "deflate"],
+    max_output: int,
+    *,
+    log_errors: bool,
 ) -> tuple[bytes, str | None]:
     if max_output <= 0:
         return b"", DECODED_BODY_LIMIT_EXCEEDED if data else None
@@ -465,9 +469,10 @@ def _decompress_zlib_json_usage_body(
             try:
                 decoded = obj.decompress(member_data, max_length=remaining_output + 1)
             except zlib.error as exc:
-                with contextlib.suppress(AttributeError):
-                    # ctx.log unavailable outside mitmproxy runtime
-                    ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
+                if log_errors:
+                    with contextlib.suppress(AttributeError):
+                        # ctx.log unavailable outside mitmproxy runtime
+                        ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
                 return b"", INVALID_COMPRESSED_BODY
 
             if len(decoded) > remaining_output:
@@ -523,7 +528,12 @@ def _validate_complete_zstd_frames(data: bytes, max_output: int) -> str | None:
     return None
 
 
-def _decompress_zstd_json_usage_body(data: bytes, max_output: int) -> tuple[bytes, str | None]:
+def _decompress_zstd_json_usage_body(
+    data: bytes,
+    max_output: int,
+    *,
+    log_errors: bool,
+) -> tuple[bytes, str | None]:
     if max_output <= 0:
         return b"", DECODED_BODY_LIMIT_EXCEEDED if data else None
 
@@ -533,9 +543,10 @@ def _decompress_zstd_json_usage_body(data: bytes, max_output: int) -> tuple[byte
             # Force validation of any trailing frame without accumulating it.
             extra = reader.read(1)
     except zstandard.ZstdError as exc:
-        with contextlib.suppress(AttributeError):
-            # ctx.log unavailable outside mitmproxy runtime
-            ctx.log.debug(f"Decompression failed (zstd): {exc}")
+        if log_errors:
+            with contextlib.suppress(AttributeError):
+                # ctx.log unavailable outside mitmproxy runtime
+                ctx.log.debug(f"Decompression failed (zstd): {exc}")
         return b"", INVALID_COMPRESSED_BODY
 
     if extra:
@@ -544,10 +555,19 @@ def _decompress_zstd_json_usage_body(data: bytes, max_output: int) -> tuple[byte
 
 
 def _decode_supported_body_with_complete_status(
-    data: bytes, encoding: str, max_output: int
+    data: bytes,
+    encoding: str,
+    max_output: int,
+    *,
+    log_errors: bool = True,
 ) -> tuple[bytes, str | None]:
     if encoding in ("gzip", "deflate"):
-        return _decompress_zlib_json_usage_body(data, encoding, max_output)
+        return _decompress_zlib_json_usage_body(
+            data,
+            encoding,
+            max_output,
+            log_errors=log_errors,
+        )
     if encoding == "br":
         try:
             body, finished, limited = _decompress_brotli_bounded_with_status(
@@ -556,9 +576,10 @@ def _decode_supported_body_with_complete_status(
                 validate_complete_input=True,
             )
         except brotli.error as exc:
-            with contextlib.suppress(AttributeError):
-                # ctx.log unavailable outside mitmproxy runtime
-                ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
+            if log_errors:
+                with contextlib.suppress(AttributeError):
+                    # ctx.log unavailable outside mitmproxy runtime
+                    ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
             return b"", INVALID_COMPRESSED_BODY
         if limited:
             return body, DECODED_BODY_LIMIT_EXCEEDED
@@ -566,7 +587,7 @@ def _decode_supported_body_with_complete_status(
             return body, INCOMPLETE_COMPRESSED_BODY
         return body, None
     if encoding == "zstd":
-        return _decompress_zstd_json_usage_body(data, max_output)
+        return _decompress_zstd_json_usage_body(data, max_output, log_errors=log_errors)
     raise ValueError(f"unsupported content encoding: {encoding}")
 
 
@@ -596,7 +617,11 @@ def decode_request_body_for_network_log_capture(
 
 
 def decompress_json_usage_body(
-    data: bytes, headers: http.Headers, max_output: int = LARGE_RESPONSE_DECOMPRESS_LIMIT
+    data: bytes,
+    headers: http.Headers,
+    max_output: int = LARGE_RESPONSE_DECOMPRESS_LIMIT,
+    *,
+    log_errors: bool = True,
 ) -> tuple[bytes, str | None]:
     """Decompress a JSON usage response body with an observable empty-prefix error.
 
@@ -605,10 +630,18 @@ def decompress_json_usage_body(
     from stream metadata. JSON usage fallback only has the final buffer, so it
     needs to distinguish a valid compressed empty response from an incomplete
     compressed frame that produced no JSON bytes.
+
+    Set ``log_errors`` to ``False`` when decoding on a worker thread where the
+    mitmproxy logging context must not be accessed.
     """
     encoding = headers.get("content-encoding", "").strip().lower()
     if encoding in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS:
-        return _decode_supported_body_with_complete_status(data, encoding, max_output)
+        return _decode_supported_body_with_complete_status(
+            data,
+            encoding,
+            max_output,
+            log_errors=log_errors,
+        )
     if encoding and encoding != "identity" and data:
         return b"", "unsupported content encoding"
     return decompress_body(data, headers, max_output=max_output), None

--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -9,7 +9,7 @@ import secrets
 import time
 import urllib.parse
 from collections import OrderedDict
-from collections.abc import Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
 from typing import NoReturn
 
@@ -79,6 +79,23 @@ class _CacheEntry:
     prefetched: bool
 
 
+@dataclass(frozen=True)
+class _ResponseValidationSnapshot:
+    status_code: int
+    header_fields: tuple[tuple[bytes, bytes], ...] = field(repr=False)
+    has_trailers: bool
+    body: bytes = field(repr=False)
+    upstream_encoding: str | None
+    compressed_content_length: int | None
+
+
+@dataclass(frozen=True)
+class _ValidatedResponse:
+    body: bytes = field(repr=False)
+    content_type: str
+    etag: str = field(repr=False)
+
+
 @dataclass
 class _FlowTelemetry:
     status: str
@@ -121,6 +138,8 @@ _in_flight: dict[_CacheKey, _InFlight] = {}
 _owned_body_bytes = 0
 _active_flow_states = 0
 _process_hmac_key = secrets.token_bytes(32)
+_validation_loop: asyncio.AbstractEventLoop | None = None
+_validation_semaphore: asyncio.Semaphore | None = None
 
 
 def _bounded_milliseconds(seconds: float) -> int:
@@ -627,27 +646,28 @@ async def prepare_request(flow: http.HTTPFlow, *, request_end_stream: bool) -> b
 
 
 def _response_headers_bypass_reason(
-    response: http.Response,
+    status_code: int,
+    headers: http.Headers,
     *,
     allow_brotli: bool = False,
 ) -> str | None:
-    if response.status_code != _HTTP_STATUS_OK:
+    if status_code != _HTTP_STATUS_OK:
         return "response_status"
-    encoding = _single_content_encoding(response.headers)
+    encoding = _single_content_encoding(headers)
     if encoding != _IDENTITY_ENCODING and not (allow_brotli and encoding == _BROTLI_ENCODING):
         return "response_encoding"
-    content_type = response.headers.get("Content-Type", "")
+    content_type = headers.get("Content-Type", "")
     if len(content_type.encode()) > _MAX_CONTENT_TYPE_BYTES or not _content_type_is_json(
         content_type
     ):
         return "response_content_type"
-    if _response_cache_control_is_unsafe(response.headers):
+    if _response_cache_control_is_unsafe(headers):
         return "response_cache_control"
-    if response.headers.get_all("Vary"):
+    if headers.get_all("Vary"):
         return "response_vary"
-    if _single_usable_etag(response.headers) is None:
+    if _single_usable_etag(headers) is None:
         return "response_etag"
-    parsed_content_length = _parse_content_length(response.headers)
+    parsed_content_length = _parse_content_length(headers)
     if parsed_content_length.kind not in ("missing", "valid"):
         return "response_size"
     return None
@@ -687,7 +707,10 @@ def handle_response_headers(flow: http.HTTPFlow) -> bool:
     encoding = _single_content_encoding(flow.response.headers)
     if encoding == _IDENTITY_ENCODING:
         state.upstream_encoding = _IDENTITY_ENCODING
-        bypass_reason = _response_headers_bypass_reason(flow.response)
+        bypass_reason = _response_headers_bypass_reason(
+            flow.response.status_code,
+            flow.response.headers,
+        )
         if bypass_reason is not None:
             _bypass_response(flow, state, bypass_reason)
         return True
@@ -696,7 +719,11 @@ def handle_response_headers(flow: http.HTTPFlow) -> bool:
         return True
 
     state.upstream_encoding = _BROTLI_ENCODING
-    bypass_reason = _response_headers_bypass_reason(flow.response, allow_brotli=True)
+    bypass_reason = _response_headers_bypass_reason(
+        flow.response.status_code,
+        flow.response.headers,
+        allow_brotli=True,
+    )
     if bypass_reason is not None:
         _bypass_response(flow, state, bypass_reason)
         return True
@@ -722,7 +749,8 @@ def wrap_response_stream(flow: http.HTTPFlow) -> None:
         or state.finalized
         or flow.response is None
         or _response_headers_bypass_reason(
-            flow.response,
+            flow.response.status_code,
+            flow.response.headers,
             allow_brotli=state.upstream_encoding == _BROTLI_ENCODING,
         )
         is not None
@@ -762,25 +790,41 @@ def _unwrap_response_stream(flow: http.HTTPFlow, state: _FlowState) -> None:
     state.downstream_stream = None
 
 
-def _validated_response_body(
-    response: http.Response,
-    state: _FlowState,
-) -> tuple[bytes, str, str] | str:
+def _validate_response_snapshot(
+    snapshot: _ResponseValidationSnapshot,
+) -> _ValidatedResponse | str:
+    headers = http.Headers(snapshot.header_fields)
+    body = snapshot.body
+    if snapshot.upstream_encoding == _BROTLI_ENCODING:
+        if (
+            snapshot.compressed_content_length is not None
+            and len(body) != snapshot.compressed_content_length
+        ) or snapshot.has_trailers:
+            return "response_body"
+        body, decode_error = body_decoding.decompress_json_usage_body(
+            body,
+            headers,
+            max_output=MAX_ENTRY_BYTES,
+            log_errors=False,
+        )
+        if decode_error == body_decoding.DECODED_BODY_LIMIT_EXCEEDED:
+            return "response_size"
+        if decode_error is not None:
+            return "response_encoding"
+
     bypass_reason = _response_headers_bypass_reason(
-        response,
-        allow_brotli=state.upstream_encoding == _BROTLI_ENCODING,
+        snapshot.status_code,
+        headers,
+        allow_brotli=snapshot.upstream_encoding == _BROTLI_ENCODING,
     )
     if bypass_reason is not None:
         return bypass_reason
-    if response.trailers:
+    if snapshot.has_trailers:
         return "response_body"
-    if state.capture is None or state.capture_overflow:
-        return "response_size"
 
-    body = bytes(state.capture)
-    parsed_content_length = _parse_content_length(response.headers)
+    parsed_content_length = _parse_content_length(headers)
     if (
-        state.upstream_encoding == _IDENTITY_ENCODING
+        snapshot.upstream_encoding == _IDENTITY_ENCODING
         and parsed_content_length.kind == "valid"
         and parsed_content_length.value != len(body)
     ):
@@ -801,89 +845,113 @@ def _validated_response_body(
         return "response_json"
     if not isinstance(payload, dict) or not isinstance(payload.get("models"), list):
         return "response_shape"
-    content_type = response.headers.get("Content-Type", "")
-    etag = _single_usable_etag(response.headers)
+    content_type = headers.get("Content-Type", "")
+    etag = _single_usable_etag(headers)
     if etag is None:
         return "response_etag"
-    return body, content_type, etag
+    return _ValidatedResponse(body=body, content_type=content_type, etag=etag)
 
 
-def _decode_captured_brotli_response(
-    response: http.Response,
+def _validation_semaphore_for_running_loop() -> asyncio.Semaphore:
+    global _validation_loop, _validation_semaphore
+    loop = asyncio.get_running_loop()
+    if _validation_loop is not loop or _validation_semaphore is None:
+        _validation_loop = loop
+        _validation_semaphore = asyncio.Semaphore(1)
+    return _validation_semaphore
+
+
+async def _validate_response_off_loop(
+    snapshot: _ResponseValidationSnapshot,
+) -> tuple[_ValidatedResponse | str, asyncio.CancelledError | None]:
+    semaphore = _validation_semaphore_for_running_loop()
+    async with semaphore:
+        loop = asyncio.get_running_loop()
+        validation = loop.run_in_executor(None, _validate_response_snapshot, snapshot)
+        cancellation: asyncio.CancelledError | None = None
+        while True:
+            try:
+                result = await asyncio.shield(validation)
+                return result, cancellation
+            except asyncio.CancelledError as error:
+                if cancellation is None:
+                    cancellation = error
+
+
+async def _finalize_response_snapshot(
+    flow: http.HTTPFlow,
     state: _FlowState,
-) -> str | None:
-    if state.upstream_encoding != _BROTLI_ENCODING:
-        return None
-    if state.capture is None or state.capture_overflow:
-        return "response_size"
-    compressed = bytes(state.capture)
-    if (
-        state.compressed_content_length is not None
-        and len(compressed) != state.compressed_content_length
-    ) or response.trailers:
-        return "response_body"
+    snapshot: _ResponseValidationSnapshot,
+) -> None:
+    try:
+        validated, cancellation = await _validate_response_off_loop(snapshot)
+        completed_at = time.monotonic()
+        if isinstance(validated, str):
+            _set_not_stored(flow, state, validated, now=completed_at)
+        else:
+            observed_etag = state.in_flight.observed_etag
+            if state.key in _entries or (
+                observed_etag is not None and observed_etag != validated.etag
+            ):
+                _set_not_stored(flow, state, "concurrent_change", now=completed_at)
+            else:
+                entry = _CacheEntry(
+                    body=validated.body,
+                    content_type=validated.content_type,
+                    etag=validated.etag,
+                    validated_at=completed_at,
+                    prefetched=state.prefetch_owner,
+                )
+                evictions = _replace_entry(state.key, entry)
+                _publish_result(state, entry)
+                _set_telemetry(
+                    flow,
+                    "model_catalog_cold_stored",
+                    entry_age_ms=state.entry_age_ms,
+                    validation_latency_ms=_bounded_milliseconds(
+                        completed_at - state.request_started_at
+                    ),
+                    eviction_count=evictions,
+                    upstream_encoding=state.upstream_encoding,
+                    prefetch_role="producer" if state.prefetch_owner else None,
+                )
+        if cancellation is not None:
+            raise cancellation
+    finally:
+        _release_flow_capacity(state)
 
-    decoded, decode_error = body_decoding.decompress_json_usage_body(
-        compressed,
-        response.headers,
-        max_output=MAX_ENTRY_BYTES,
-    )
-    if decode_error == body_decoding.DECODED_BODY_LIMIT_EXCEEDED:
-        return "response_size"
-    if decode_error is not None:
-        return "response_encoding"
 
-    state.capture = bytearray(decoded)
-    return None
-
-
-def finalize_response(flow: http.HTTPFlow) -> None:
-    """Normalize, validate, and install one complete catalog response."""
+def finalize_response(flow: http.HTTPFlow) -> Awaitable[None] | None:
+    """Start validation for one complete catalog response when eligible."""
     state = flow.metadata.get(_FLOW_STATE)
     if not isinstance(state, _FlowState) or state.finalized:
-        return
+        return None
     state.finalized = True
     try:
         _unwrap_response_stream(flow, state)
-        now = time.monotonic()
         response = flow.response
         if response is None:
-            _set_not_stored(flow, state, "response_missing", now=now)
-            return
-        decode_failure = _decode_captured_brotli_response(response, state)
-        if decode_failure is not None:
-            _set_not_stored(flow, state, decode_failure, now=now)
-            return
-        validated = _validated_response_body(response, state)
-        if isinstance(validated, str):
-            _set_not_stored(flow, state, validated, now=now)
-            return
-        body, content_type, etag = validated
-        observed_etag = state.in_flight.observed_etag
-        if state.key in _entries or (observed_etag is not None and observed_etag != etag):
-            _set_not_stored(flow, state, "concurrent_change", now=now)
-            return
-
-        entry = _CacheEntry(
+            _set_not_stored(flow, state, "response_missing")
+            _release_flow_capacity(state)
+            return None
+        if state.capture is None or state.capture_overflow:
+            _set_not_stored(flow, state, "response_size")
+            _release_flow_capacity(state)
+            return None
+        body = bytes(state.capture)
+        state.capture = None
+        snapshot = _ResponseValidationSnapshot(
+            status_code=response.status_code,
+            header_fields=tuple(response.headers.fields),
+            has_trailers=bool(response.trailers),
             body=body,
-            content_type=content_type,
-            etag=etag,
-            validated_at=now,
-            prefetched=state.prefetch_owner,
-        )
-        evictions = _replace_entry(state.key, entry)
-        _publish_result(state, entry)
-        _set_telemetry(
-            flow,
-            "model_catalog_cold_stored",
-            entry_age_ms=state.entry_age_ms,
-            validation_latency_ms=_bounded_milliseconds(now - state.request_started_at),
-            eviction_count=evictions,
             upstream_encoding=state.upstream_encoding,
-            prefetch_role="producer" if state.prefetch_owner else None,
+            compressed_content_length=state.compressed_content_length,
         )
-    finally:
+    except BaseException:
         _release_flow_capacity(state)
+        raise
+    return _finalize_response_snapshot(flow, state, snapshot)
 
 
 def handle_error(flow: http.HTTPFlow) -> None:
@@ -978,6 +1046,7 @@ def release_flow_state(flow: http.HTTPFlow) -> None:
 def reset_for_tests() -> None:
     """Reset process cache ownership between tests."""
     global _active_flow_states, _owned_body_bytes, _process_hmac_key
+    global _validation_loop, _validation_semaphore
     for in_flight in _in_flight.values():
         if not in_flight.future.done():
             in_flight.future.set_result(None)
@@ -986,3 +1055,5 @@ def reset_for_tests() -> None:
     _owned_body_bytes = 0
     _active_flow_states = 0
     _process_hmac_key = secrets.token_bytes(32)
+    _validation_loop = None
+    _validation_semaphore = None

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1630,10 +1630,38 @@ def websocket_end(flow: http.HTTPFlow) -> None:
         _release_terminal_flow_state(flow, release_tracking=True)
 
 
-def response(flow: http.HTTPFlow) -> None:
+def response(flow: http.HTTPFlow) -> Awaitable[None] | None:
+    try:
+        continuation = _handle_response(flow)
+    except BaseException:
+        _release_terminal_flow_state(
+            flow,
+            release_tracking=True,
+            release_aws_sigv4_body_admission=flow.websocket is None,
+        )
+        raise
+    if continuation is not None:
+        return _complete_response(flow, continuation)
+
     release_tracking = True
     try:
-        _handle_response(flow)
+        release_tracking = not response_streaming.is_model_websocket_usage_enabled(flow)
+    finally:
+        _release_terminal_flow_state(
+            flow,
+            release_tracking=release_tracking,
+            release_aws_sigv4_body_admission=flow.websocket is None,
+        )
+    return None
+
+
+async def _complete_response(
+    flow: http.HTTPFlow,
+    continuation: Awaitable[None],
+) -> None:
+    release_tracking = True
+    try:
+        await continuation
         release_tracking = not response_streaming.is_model_websocket_usage_enabled(flow)
     finally:
         _release_terminal_flow_state(
@@ -1643,7 +1671,7 @@ def response(flow: http.HTTPFlow) -> None:
         )
 
 
-def _handle_response(flow: http.HTTPFlow) -> None:
+def _handle_response(flow: http.HTTPFlow) -> Awaitable[None] | None:
     """
     Handle response and log network activity.
     """
@@ -1654,14 +1682,60 @@ def _handle_response(flow: http.HTTPFlow) -> None:
     if not run_id:
         # Unregistered VM: the request handler returned before populating
         # metadata, so none of this handler's work applies.
-        return
+        return None
 
     latency_ms = elapsed_ms(start_time)
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
     firewall_action = flow_metadata.firewall_action(flow.metadata)
 
     connector_diagnostics.maybe_replace_response(flow, original_url=original_url)
-    codex_model_catalog_cache.finalize_response(flow)
+    validation = codex_model_catalog_cache.finalize_response(flow)
+    if validation is not None:
+        return _finish_response_after_catalog_validation(
+            flow,
+            validation,
+            run_id=run_id,
+            latency_ms=latency_ms,
+            original_url=original_url,
+            firewall_action=firewall_action,
+        )
+    _finish_response_handling(
+        flow,
+        run_id=run_id,
+        latency_ms=latency_ms,
+        original_url=original_url,
+        firewall_action=firewall_action,
+    )
+    return None
+
+
+async def _finish_response_after_catalog_validation(
+    flow: http.HTTPFlow,
+    validation: Awaitable[None],
+    *,
+    run_id: str,
+    latency_ms: int,
+    original_url: str,
+    firewall_action: str,
+) -> None:
+    await validation
+    _finish_response_handling(
+        flow,
+        run_id=run_id,
+        latency_ms=latency_ms,
+        original_url=original_url,
+        firewall_action=firewall_action,
+    )
+
+
+def _finish_response_handling(
+    flow: http.HTTPFlow,
+    *,
+    run_id: str,
+    latency_ms: int,
+    original_url: str,
+    firewall_action: str,
+) -> None:
 
     request_size = _request_size(flow)
     stream_buf = flow.metadata.get(metadata_keys.STREAM_BUFFER)

--- a/crates/runner/mitm-addon/tests/codex_model_catalog_cache_helpers.py
+++ b/crates/runner/mitm-addon/tests/codex_model_catalog_cache_helpers.py
@@ -138,7 +138,7 @@ async def prepare_miss(flow: http.HTTPFlow) -> None:
     assert "If-None-Match" not in flow.request.headers
 
 
-def finish_response(flow: http.HTTPFlow) -> dict[str, object]:
+async def finish_response(flow: http.HTTPFlow) -> dict[str, object]:
     assert flow.response is not None
     wire_body = flow.response.raw_content or b""
     mitm_addon.responseheaders(flow)
@@ -147,7 +147,9 @@ def finish_response(flow: http.HTTPFlow) -> dict[str, object]:
         split = len(wire_body) // 2
         assert stream(wire_body[:split]) == wire_body[:split]
         assert stream(wire_body[split:]) == wire_body[split:]
-    catalog_cache.finalize_response(flow)
+    finalization = catalog_cache.finalize_response(flow)
+    if finalization is not None:
+        await finalization
     telemetry: dict[str, object] = {}
     catalog_cache.add_network_log_fields(flow, telemetry)
     return telemetry
@@ -162,4 +164,4 @@ async def install_catalog(
 ) -> dict[str, object]:
     await prepare_miss(flow)
     flow.response = catalog_response(body=body, etag=etag, encoding=encoding)
-    return finish_response(flow)
+    return await finish_response(flow)

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_async_validation.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_async_validation.py
@@ -1,0 +1,321 @@
+"""Integration coverage for asynchronous Codex catalog validation ownership."""
+
+import asyncio
+import json
+import threading
+from collections.abc import Awaitable, Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import ParamSpec, TypeVar
+
+import pytest
+from mitmproxy import http
+
+import codex_model_catalog_cache as catalog_cache
+import mitm_addon
+from tests.codex_model_catalog_cache_helpers import (
+    catalog_flow,
+    catalog_response,
+    prepare_miss,
+)
+from tests.flow_helpers import response_stream
+
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
+_FlowFactory = Callable[..., http.HTTPFlow]
+
+
+class _ControlledValidationExecutor(ThreadPoolExecutor):
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        super().__init__(max_workers=4, thread_name_prefix="catalog-validation-test")
+        self._loop = loop
+        self._release = threading.Event()
+        self._lock = threading.Lock()
+        self._submission_count = 0
+        self._active_count = 0
+        self.max_active_count = 0
+        self.worker_thread_ids: set[int] = set()
+        self.started = asyncio.Event()
+
+    @property
+    def submission_count(self) -> int:
+        with self._lock:
+            return self._submission_count
+
+    def release_workers(self) -> None:
+        self._release.set()
+
+    def submit(
+        self,
+        fn: Callable[_P, _T],
+        /,
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> Future[_T]:
+        with self._lock:
+            self._submission_count += 1
+
+        def controlled_call() -> _T:
+            with self._lock:
+                self._active_count += 1
+                self.max_active_count = max(self.max_active_count, self._active_count)
+                self.worker_thread_ids.add(threading.get_ident())
+            self._loop.call_soon_threadsafe(self.started.set)
+            self._release.wait()
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                with self._lock:
+                    self._active_count -= 1
+
+        return super().submit(controlled_call)
+
+
+def _dense_catalog_body(label: str) -> bytes:
+    item = json.dumps(
+        {"slug": label, "display_name": "Dense model"},
+        separators=(",", ":"),
+    ).encode()
+    prefix = b'{"models":['
+    suffix = b"]}"
+    item_count = (catalog_cache.MAX_ENTRY_BYTES - len(prefix) - len(suffix) + 1) // (len(item) + 1)
+    body = prefix + b",".join([item] * item_count) + suffix
+    assert len(body) <= catalog_cache.MAX_ENTRY_BYTES
+    assert len(body) >= catalog_cache.MAX_ENTRY_BYTES * 9 // 10
+    return body
+
+
+async def _start_catalog_response(
+    real_flow: _FlowFactory,
+    *,
+    version: str,
+    body: bytes,
+) -> tuple[http.HTTPFlow, Awaitable[None]]:
+    flow = catalog_flow(real_flow, version=version)
+    await prepare_miss(flow)
+    flow.response = catalog_response(body=body, encoding="identity")
+    mitm_addon.responseheaders(flow)
+    assert callable(flow.response.stream)
+    assert response_stream(flow)(body) == body
+    continuation = mitm_addon.response(flow)
+    assert continuation is not None
+    return flow, continuation
+
+
+async def _release_tasks(
+    executor: _ControlledValidationExecutor,
+    tasks: list[asyncio.Task[None]],
+) -> None:
+    executor.release_workers()
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def _await_continuation(continuation: Awaitable[None]) -> None:
+    await continuation
+
+
+def _replace_default_executor(
+    loop: asyncio.AbstractEventLoop,
+    executor: _ControlledValidationExecutor,
+) -> None:
+    loop.set_default_executor(
+        ThreadPoolExecutor(max_workers=1, thread_name_prefix="post-catalog-test")
+    )
+    executor.shutdown(wait=True)
+
+
+def test_non_catalog_response_hook_stays_synchronous(real_flow: _FlowFactory) -> None:
+    assert mitm_addon.response(real_flow()) is None
+
+
+async def test_dense_catalog_validations_are_serialized_off_event_loop(
+    real_flow: _FlowFactory,
+    mitm_ctx,
+) -> None:
+    loop = asyncio.get_running_loop()
+    loop_thread_id = threading.get_ident()
+    executor = _ControlledValidationExecutor(loop)
+    loop.set_default_executor(executor)
+    tasks: list[asyncio.Task[None]] = []
+    first_body = _dense_catalog_body("first")
+    second_body = _dense_catalog_body("second")
+
+    try:
+        with mitm_ctx():
+            try:
+                _, first_continuation = await _start_catalog_response(
+                    real_flow,
+                    version="off-loop-first",
+                    body=first_body,
+                )
+                first_task = asyncio.create_task(_await_continuation(first_continuation))
+                tasks.append(first_task)
+                await asyncio.wait_for(executor.started.wait(), timeout=1)
+
+                progressed = asyncio.Event()
+                loop.call_soon(progressed.set)
+                await asyncio.wait_for(progressed.wait(), timeout=1)
+                assert not first_task.done()
+                assert executor.worker_thread_ids
+                assert loop_thread_id not in executor.worker_thread_ids
+
+                _, second_continuation = await _start_catalog_response(
+                    real_flow,
+                    version="off-loop-second",
+                    body=second_body,
+                )
+                second_task = asyncio.create_task(_await_continuation(second_continuation))
+                tasks.append(second_task)
+                await asyncio.sleep(0)
+                assert not second_task.done()
+                assert executor.submission_count == 1
+
+                executor.release_workers()
+                await asyncio.gather(*tasks)
+            finally:
+                await _release_tasks(executor, tasks)
+
+        assert executor.submission_count == 2
+        assert executor.max_active_count == 1
+        for version, expected_body in (
+            ("off-loop-first", first_body),
+            ("off-loop-second", second_body),
+        ):
+            hit = catalog_flow(real_flow, version=version)
+            await catalog_cache.prepare_request(hit, request_end_stream=True)
+            assert hit.response is not None
+            assert hit.response.content == expected_body
+            catalog_cache.release_flow_state(hit)
+    finally:
+        _replace_default_executor(loop, executor)
+
+
+async def test_catalog_validation_cancellation_preserves_atomic_ownership(
+    real_flow: _FlowFactory,
+    mitm_ctx,
+) -> None:
+    loop = asyncio.get_running_loop()
+    executor = _ControlledValidationExecutor(loop)
+    loop.set_default_executor(executor)
+    tasks: list[asyncio.Task[None]] = []
+    admitted_body = _dense_catalog_body("admitted")
+    waiting_body = _dense_catalog_body("waiting")
+
+    try:
+        with mitm_ctx():
+            try:
+                admitted_flow, admitted_continuation = await _start_catalog_response(
+                    real_flow,
+                    version="cancel-admitted",
+                    body=admitted_body,
+                )
+                admitted_task = asyncio.create_task(_await_continuation(admitted_continuation))
+                tasks.append(admitted_task)
+                await asyncio.wait_for(executor.started.wait(), timeout=1)
+
+                waiting_flow, waiting_continuation = await _start_catalog_response(
+                    real_flow,
+                    version="cancel-waiting",
+                    body=waiting_body,
+                )
+                waiting_task = asyncio.create_task(_await_continuation(waiting_continuation))
+                tasks.append(waiting_task)
+                await asyncio.sleep(0)
+                assert executor.submission_count == 1
+
+                follower = catalog_flow(real_flow, version="cancel-waiting")
+                follower_prepare = asyncio.create_task(
+                    catalog_cache.prepare_request(follower, request_end_stream=True)
+                )
+                await asyncio.sleep(0)
+                assert not follower_prepare.done()
+
+                waiting_task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await waiting_task
+                await asyncio.wait_for(follower_prepare, timeout=1)
+                assert follower.response is None
+                assert follower.request.headers["Accept-Encoding"] == "br"
+                assert executor.submission_count == 1
+                catalog_cache.handle_error(follower)
+
+                admitted_task.cancel()
+                await asyncio.sleep(0)
+                admitted_task.cancel()
+                await asyncio.sleep(0)
+                assert not admitted_task.done()
+
+                executor.release_workers()
+                with pytest.raises(asyncio.CancelledError):
+                    await admitted_task
+            finally:
+                await _release_tasks(executor, tasks)
+
+        assert "_codex_model_catalog_cache_state" not in admitted_flow.metadata
+        assert "_codex_model_catalog_cache_state" not in waiting_flow.metadata
+
+        admitted_hit = catalog_flow(real_flow, version="cancel-admitted")
+        await catalog_cache.prepare_request(admitted_hit, request_end_stream=True)
+        assert admitted_hit.response is not None
+        assert admitted_hit.response.content == admitted_body
+        catalog_cache.release_flow_state(admitted_hit)
+
+        missing_hit = catalog_flow(real_flow, version="cancel-waiting")
+        await prepare_miss(missing_hit)
+        catalog_cache.handle_error(missing_hit)
+
+        owners = [
+            catalog_flow(real_flow, version=f"post-cancel-capacity-{index}")
+            for index in range(catalog_cache.MAX_IN_FLIGHT_REQUESTS)
+        ]
+        for owner in owners:
+            await prepare_miss(owner)
+        overflow = catalog_flow(real_flow, version="post-cancel-capacity-overflow")
+        await catalog_cache.prepare_request(overflow, request_end_stream=True)
+        assert overflow.response is None
+        assert overflow.request.headers["Accept-Encoding"] == "identity"
+        overflow_telemetry: dict[str, object] = {}
+        catalog_cache.add_network_log_fields(overflow, overflow_telemetry)
+        assert overflow_telemetry == {
+            "model_catalog_cache_status": "model_catalog_bypass",
+            "model_catalog_cache_bypass_reason": "request_capacity",
+        }
+        for owner in owners:
+            catalog_cache.handle_error(owner)
+    finally:
+        _replace_default_executor(loop, executor)
+
+
+async def test_executor_submission_failure_releases_catalog_owner(
+    real_flow: _FlowFactory,
+    mitm_ctx,
+) -> None:
+    loop = asyncio.get_running_loop()
+    failed_executor = ThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix="failed-catalog-test",
+    )
+    loop.set_default_executor(failed_executor)
+    failed_executor.shutdown(wait=True)
+
+    try:
+        with mitm_ctx():
+            flow, continuation = await _start_catalog_response(
+                real_flow,
+                version="executor-failure",
+                body=b'{"models":[]}',
+            )
+            with pytest.raises(RuntimeError):
+                await continuation
+
+        assert "_codex_model_catalog_cache_state" not in flow.metadata
+        retry = catalog_flow(real_flow, version="executor-failure")
+        await prepare_miss(retry)
+        catalog_cache.handle_error(retry)
+    finally:
+        loop.set_default_executor(
+            ThreadPoolExecutor(max_workers=1, thread_name_prefix="post-catalog-failure-test")
+        )

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_coordination.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_coordination.py
@@ -32,7 +32,9 @@ async def test_singleflight_delivers_owner_response_to_follower(real_flow):
 
     first_body = b'{"models":[{"slug":"first"}]}'
     first.response = catalog_response(body=first_body, encoding="br")
-    assert finish_response(first)["model_catalog_cache_status"] == "model_catalog_cold_stored"
+    assert (await finish_response(first))["model_catalog_cache_status"] == (
+        "model_catalog_cold_stored"
+    )
     await second_prepare
     assert second.response is not None
     assert second.response.content == first_body
@@ -64,7 +66,7 @@ async def test_prefetch_marker_is_stripped_and_roles_distinguish_consumers(real_
     assert not consumer_prepare.done()
 
     prefetch.response = catalog_response(encoding="br")
-    prefetch_telemetry = finish_response(prefetch)
+    prefetch_telemetry = await finish_response(prefetch)
     assert prefetch_telemetry["model_catalog_prefetch_role"] == "producer"
 
     await consumer_prepare
@@ -182,7 +184,7 @@ async def test_cancelled_follower_does_not_cancel_singleflight_owner(real_flow):
     assert not surviving_prepare.done()
 
     owner.response = catalog_response(encoding="br")
-    finish_response(owner)
+    await finish_response(owner)
     await surviving_prepare
     assert surviving_follower.response is not None
     assert surviving_follower.response.content == CATALOG_BODY
@@ -206,7 +208,7 @@ async def test_singleflight_wait_is_bounded_without_canceling_owner(real_flow):
     }
 
     owner.response = catalog_response(encoding="br")
-    finish_response(owner)
+    await finish_response(owner)
     hit = catalog_flow(real_flow, version="bounded-wait")
     await catalog_cache.prepare_request(hit, request_end_stream=True)
     assert hit.response is not None
@@ -253,7 +255,7 @@ async def test_singleflight_rechecks_entry_after_etag_invalidation(real_flow):
     assert not follower_prepare.done()
 
     owner.response = catalog_response(encoding="br")
-    finish_response(owner)
+    await finish_response(owner)
     invalidation = responses_flow(real_flow, etag='"catalog-v2"')
     mitm_addon.responseheaders(invalidation)
 
@@ -290,7 +292,7 @@ async def test_etag_signal_supersedes_in_flight_owner_and_releases_follower(real
         etag='"catalog-v2"',
         encoding="br",
     )
-    assert finish_response(matching_owner)["model_catalog_cache_status"] == (
+    assert (await finish_response(matching_owner))["model_catalog_cache_status"] == (
         "model_catalog_cold_stored"
     )
 
@@ -300,12 +302,12 @@ async def test_etag_signal_supersedes_in_flight_owner_and_releases_follower(real
         etag='"catalog-v1"',
         encoding="br",
     )
-    assert finish_response(isolated_owner)["model_catalog_cache_status"] == (
+    assert (await finish_response(isolated_owner))["model_catalog_cache_status"] == (
         "model_catalog_cold_stored"
     )
 
     superseded_owner.response = catalog_response(etag='"catalog-v1"', encoding="br")
-    superseded_telemetry = finish_response(superseded_owner)
+    superseded_telemetry = await finish_response(superseded_owner)
     await asyncio.wait_for(follower_prepare, timeout=0.1)
 
     validation_latency = superseded_telemetry.pop("model_catalog_cache_validation_latency_ms")
@@ -325,7 +327,9 @@ async def test_etag_signal_supersedes_in_flight_owner_and_releases_follower(real
         etag='"catalog-v2"',
         encoding="br",
     )
-    assert finish_response(follower)["model_catalog_cache_status"] == ("model_catalog_cold_stored")
+    assert (await finish_response(follower))["model_catalog_cache_status"] == (
+        "model_catalog_cold_stored"
+    )
 
     expected_hits = (
         (catalog_flow(real_flow, version="superseded-owner"), replacement_body),

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
@@ -213,7 +213,7 @@ async def test_both_firewall_auth_paths_prepare_catalog_cache(
     assert request_flow.request.headers["Accept-Encoding"] == "br"
     assert "X-VM0-Codex-Model-Catalog-Prefetch" not in request_flow.request.headers
     request_flow.response = catalog_response(encoding="br")
-    request_telemetry = finish_response(request_flow)
+    request_telemetry = await finish_response(request_flow)
     assert request_telemetry["model_catalog_prefetch_role"] == "producer"
 
     header_registry = _write_codex_registry(tmp_path, capture=True)
@@ -332,7 +332,7 @@ async def test_catalog_wait_revalidates_only_provider_continuation(
                 catalog_cache.handle_error(owner)
             elif owner_result == "local-response":
                 owner.response = catalog_response(encoding="br")
-                finish_response(owner)
+                await finish_response(owner)
 
             await follower_task
             if entry_point == "requestheaders":
@@ -460,7 +460,9 @@ async def test_network_log_contains_bounded_encoding_telemetry_and_cleanup(
     assert response_stream(flow)(compressed_body) == compressed_body
 
     with mitm_ctx():
-        mitm_addon.response(flow)
+        continuation = mitm_addon.response(flow)
+        assert continuation is not None
+        await continuation
 
     [entry] = read_jsonl_entries_after_flush(tmp_path / "network.jsonl")
     assert entry["model_catalog_cache_status"] == "model_catalog_cold_stored"

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_responses.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_responses.py
@@ -35,7 +35,9 @@ async def test_brotli_miss_without_length_is_cached_and_passed_through(real_flow
     assert "Content-Length" not in brotli_flow.response.headers
     assert response_stream(brotli_flow)(compressed_body) == compressed_body
 
-    catalog_cache.finalize_response(brotli_flow)
+    finalization = catalog_cache.finalize_response(brotli_flow)
+    assert finalization is not None
+    await finalization
     assert brotli_flow.response.status_code == 200
     assert brotli_flow.response.raw_content == compressed_body
     assert brotli_flow.response.headers["Content-Encoding"] == "br"
@@ -77,7 +79,7 @@ async def test_set_cookie_is_not_replayed_from_cached_brotli_response(real_flow)
     )
     del cold.response.headers["Content-Length"]
 
-    telemetry = finish_response(cold)
+    telemetry = await finish_response(cold)
 
     assert telemetry["model_catalog_cache_status"] == "model_catalog_cold_stored"
     assert cold.response.headers["Set-Cookie"] == "catalog_session=opaque; Secure"
@@ -196,7 +198,7 @@ async def test_invalid_identity_responses_pass_through_without_installing(
     original_status = response.status_code
     original_body = response.raw_content
 
-    telemetry = finish_response(flow)
+    telemetry = await finish_response(flow)
     validation_latency = telemetry.pop("model_catalog_cache_validation_latency_ms")
 
     assert flow.response.status_code == original_status
@@ -297,7 +299,9 @@ async def test_invalid_streamed_brotli_passes_through_without_installing(
     assert flow.response.status_code == 200
     assert callable(flow.response.stream)
     assert response_stream(flow)(wire_body) == wire_body
-    catalog_cache.finalize_response(flow)
+    finalization = catalog_cache.finalize_response(flow)
+    assert finalization is not None
+    await finalization
 
     assert flow.response.status_code == 200
     assert flow.response.raw_content == wire_body
@@ -341,7 +345,7 @@ async def test_brotli_cache_policy_bypasses_body_validation(
     )
     wire_body = flow.response.raw_content
 
-    telemetry = finish_response(flow)
+    telemetry = await finish_response(flow)
 
     assert flow.response.status_code == 200
     assert flow.response.raw_content == wire_body
@@ -363,7 +367,7 @@ async def test_catalog_responses_with_trailers_are_never_cached(
     flow.response = catalog_response(encoding=encoding)
     flow.response.trailers = header_map({"Digest": "sha-256=:opaque:"})
 
-    telemetry = finish_response(flow)
+    telemetry = await finish_response(flow)
 
     assert telemetry["model_catalog_cache_status"] == "model_catalog_cold_not_stored"
     assert telemetry["model_catalog_cache_bypass_reason"] == "response_body"
@@ -384,7 +388,7 @@ async def test_catalog_response_accepts_long_leading_zero_content_length(real_fl
         headers={"Content-Length": "0" * 64 + str(len(CATALOG_BODY))},
     )
 
-    telemetry = finish_response(flow)
+    telemetry = await finish_response(flow)
 
     assert telemetry["model_catalog_cache_status"] == "model_catalog_cold_stored"
 
@@ -468,7 +472,9 @@ async def test_unsafe_encoded_headers_pass_through_without_caching(
     assert callable(flow.response.stream)
     wire_body = response.raw_content or b""
     assert response_stream(flow)(wire_body) == wire_body
-    catalog_cache.finalize_response(flow)
+    finalization = catalog_cache.finalize_response(flow)
+    if finalization is not None:
+        await finalization
     assert flow.response.status_code == 200
     assert flow.response.raw_content == wire_body
     telemetry: dict[str, object] = {}

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
@@ -50,6 +50,7 @@ from tests.aws_sigv4_helpers import (
     aws_sigv4_authorization,
     resolved_aws_sigv4_credentials,
 )
+from tests.codex_model_catalog_cache_helpers import catalog_flow
 from tests.firewall_aws_sigv4_helpers import aws_api_entry
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
@@ -360,7 +361,9 @@ async def test_http2_fresh_catalog_hit_completes_without_provider_connection(
     )
     mitm_addon.responseheaders(seed_flow)
     assert response_stream(seed_flow)(catalog_body) == catalog_body
-    codex_model_catalog_cache.finalize_response(seed_flow)
+    finalization = codex_model_catalog_cache.finalize_response(seed_flow)
+    assert finalization is not None
+    await finalization
     codex_model_catalog_cache.release_flow_state(seed_flow)
     response_streaming.release_response_stream_state(seed_flow)
 
@@ -499,6 +502,7 @@ async def _catalog_http_stream(
 
 async def test_http2_brotli_catalog_is_streamed_unchanged_while_cached(
     tmp_path: Path,
+    real_flow,
 ) -> None:
     catalog_path = "/backend-api/codex/models?client_version=0.145.0"
     catalog_body = b'{"models":[{"slug":"gpt-test"}]}'
@@ -568,6 +572,17 @@ async def test_http2_brotli_catalog_is_streamed_unchanged_while_cached(
         assert flow.response.status_code == 200
         assert flow.response.headers["Content-Encoding"] == "br"
         assert flow.response.headers["Content-Length"] == str(len(compressed_body))
+
+        cache_hit = catalog_flow(
+            real_flow,
+            version="0.145.0",
+            auth_value="resolved-access",
+            account="resolved-account",
+        )
+        await codex_model_catalog_cache.prepare_request(cache_hit, request_end_stream=True)
+        assert cache_hit.response is not None
+        assert cache_hit.response.content == catalog_body
+        codex_model_catalog_cache.release_flow_state(cache_hit)
 
         after_response = list(stream.handle_event(events.HookCompleted(response_hook, None)))
 


### PR DESCRIPTION
## Summary

- move complete Codex model catalog validation to the default executor so dense cold catalogs no longer monopolize the mitmproxy event loop
- serialize catalog validation at one worker while keeping cache mutation, ETag compare-and-set, publication, telemetry, and cleanup on the event-loop thread
- preserve the synchronous response-hook fast path for ordinary traffic and retain atomic ownership across cancellation and executor failures
- keep worker validation free of mitmproxy logging-context access

## Scope

This changes only the runner Python mitm addon and its integration tests. It does not change database state, API contracts, queue payloads, guest protocols, persisted data, or deployment compatibility requirements.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,733 passed)
- focused cache, body-decoding, cancellation, and real mitmproxy HTTP/2 integration suites
- `git diff --check`

Closes #25015
