### PR TITLE
test(guest-download): bound binary subprocesses

### DIFF
--- a/crates/guest-download/tests/integration/binary_logging/manifest_input.rs
+++ b/crates/guest-download/tests/integration/binary_logging/manifest_input.rs
@@ -1,6 +1,6 @@
 use super::{
     BinaryLoggingFixture, assert_default_zero_task_attribution,
-    assert_single_download_total_success,
+    assert_single_download_total_success, process,
 };
 use crate::support::{manifest_json, write_manifest};
 
@@ -55,12 +55,7 @@ fn binary_path_mode_rejects_extra_args_before_telemetry() {
     let fixture = BinaryLoggingFixture::new("path-extra-arg").unwrap();
     let manifest_path = write_manifest(&fixture.dir, &[], None).unwrap();
 
-    let output = fixture
-        .command()
-        .arg(&manifest_path)
-        .arg("--ignored")
-        .output()
-        .unwrap();
+    let output = process::run(fixture.command().arg(&manifest_path).arg("--ignored")).unwrap();
 
     assert!(!output.status.success());
     let content = fixture.read_system_log().unwrap();
@@ -75,12 +70,7 @@ fn binary_path_mode_rejects_extra_args_before_telemetry() {
 fn binary_manifest_stdin_rejects_extra_args_before_telemetry() {
     let fixture = BinaryLoggingFixture::new("stdin-extra-arg").unwrap();
 
-    let output = fixture
-        .command()
-        .arg("--manifest-stdin")
-        .arg("--ignored")
-        .output()
-        .unwrap();
+    let output = process::run(fixture.command().arg("--manifest-stdin").arg("--ignored")).unwrap();
 
     assert!(!output.status.success());
     let content = fixture.read_system_log().unwrap();
@@ -138,7 +128,7 @@ fn binary_writes_system_log_on_manifest_read_failure() {
 fn binary_without_manifest_path_logs_usage() {
     let fixture = BinaryLoggingFixture::new("missing-arg").unwrap();
 
-    let output = fixture.command().output().unwrap();
+    let output = process::run(&mut fixture.command()).unwrap();
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/crates/guest-download/tests/integration/binary_logging/mod.rs
+++ b/crates/guest-download/tests/integration/binary_logging/mod.rs
@@ -1,13 +1,14 @@
 use crate::support::unique_run_id;
 use serde_json::Value;
 use std::ffi::OsStr;
-use std::io::{self, Write as _};
+use std::io;
 use std::path::PathBuf;
-use std::process::{Command, Output, Stdio};
+use std::process::{Command, Output};
 use tempfile::TempDir;
 
 mod attribution;
 mod manifest_input;
+mod process;
 mod redaction;
 mod runtime_paths;
 
@@ -55,21 +56,22 @@ impl BinaryLoggingFixture {
     }
 
     pub(super) fn run_manifest_path(&self, manifest_path: impl AsRef<OsStr>) -> io::Result<Output> {
-        self.command().arg(manifest_path).output()
+        self.spawn_manifest_path(manifest_path)?.wait()
+    }
+
+    pub(in crate::binary_logging) fn spawn_manifest_path(
+        &self,
+        manifest_path: impl AsRef<OsStr>,
+    ) -> io::Result<process::CommandExecution> {
+        process::CommandExecution::spawn(self.command().arg(manifest_path), None)
     }
 
     pub(super) fn run_manifest_stdin(&self, manifest_json: &[u8]) -> io::Result<Output> {
-        let mut command = self.command();
-        let mut child = command
-            .arg("--manifest-stdin")
-            .stdin(Stdio::piped())
-            .spawn()?;
-        child
-            .stdin
-            .as_mut()
-            .ok_or_else(|| io::Error::other("guest-download stdin unavailable"))?
-            .write_all(manifest_json)?;
-        child.wait_with_output()
+        process::CommandExecution::spawn(
+            self.command().arg("--manifest-stdin"),
+            Some(manifest_json),
+        )?
+        .wait()
     }
 
     pub(super) fn read_system_log(&self) -> io::Result<String> {

--- a/crates/guest-download/tests/integration/binary_logging/process.rs
+++ b/crates/guest-download/tests/integration/binary_logging/process.rs
@@ -1,0 +1,177 @@
+use std::fs::File;
+use std::io::{self, Read as _, Seek as _, Write as _};
+use std::process::{Child, Command, ExitStatus, Output, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+const RUN_TIMEOUT: Duration = Duration::from_secs(10);
+const CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+const CHILD_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(1);
+
+pub(super) struct CommandExecution {
+    child: Option<Child>,
+    stdout: File,
+    stderr: File,
+}
+
+impl CommandExecution {
+    pub(super) fn spawn(command: &mut Command, stdin: Option<&[u8]>) -> io::Result<Self> {
+        let stdout = tempfile::tempfile()?;
+        let stderr = tempfile::tempfile()?;
+        command
+            .stdin(stdin_file(stdin)?)
+            .stdout(Stdio::from(stdout.try_clone()?))
+            .stderr(Stdio::from(stderr.try_clone()?));
+
+        Ok(Self {
+            child: Some(command.spawn()?),
+            stdout,
+            stderr,
+        })
+    }
+
+    #[cfg(unix)]
+    pub(super) fn id(&self) -> io::Result<u32> {
+        self.child
+            .as_ref()
+            .map(Child::id)
+            .ok_or_else(|| io::Error::other("command execution lost its child"))
+    }
+
+    pub(super) fn wait(self) -> io::Result<Output> {
+        self.wait_with_timeout(RUN_TIMEOUT)
+    }
+
+    pub(super) fn wait_with_timeout(mut self, timeout: Duration) -> io::Result<Output> {
+        let mut child = self
+            .child
+            .take()
+            .ok_or_else(|| io::Error::other("command execution lost its child"))?;
+        let deadline = Instant::now() + timeout;
+
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => return self.read_output(status),
+                Ok(None) => {}
+                Err(error) => {
+                    let cleanup = terminate_and_reap(child);
+                    let diagnostics = self.read_diagnostics();
+                    return Err(io::Error::other(format!(
+                        "failed to observe guest-download completion: {error}; cleanup: {cleanup}; \
+                         {diagnostics}"
+                    )));
+                }
+            }
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            std::thread::sleep(remaining.min(CHILD_WAIT_POLL_INTERVAL));
+        }
+
+        let cleanup = terminate_and_reap(child);
+        let diagnostics = self.read_diagnostics();
+        Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!(
+                "guest-download timed out after {timeout:?}; cleanup: {cleanup}; {diagnostics}"
+            ),
+        ))
+    }
+
+    fn read_output(&mut self, status: ExitStatus) -> io::Result<Output> {
+        let (stdout, stderr) = self.read_streams()?;
+        Ok(Output {
+            status,
+            stdout,
+            stderr,
+        })
+    }
+
+    fn read_diagnostics(&mut self) -> String {
+        match self.read_streams() {
+            Ok((stdout, stderr)) => format!(
+                "stdout={:?}; stderr={:?}",
+                String::from_utf8_lossy(&stdout),
+                String::from_utf8_lossy(&stderr)
+            ),
+            Err(error) => format!("failed to read captured output: {error}"),
+        }
+    }
+
+    fn read_streams(&mut self) -> io::Result<(Vec<u8>, Vec<u8>)> {
+        Ok((
+            read_captured_stream(&mut self.stdout, "stdout")?,
+            read_captured_stream(&mut self.stderr, "stderr")?,
+        ))
+    }
+}
+
+impl Drop for CommandExecution {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.take() {
+            let _ = terminate_and_reap(child);
+        }
+    }
+}
+
+pub(super) fn run(command: &mut Command) -> io::Result<Output> {
+    CommandExecution::spawn(command, None)?.wait()
+}
+
+fn stdin_file(stdin: Option<&[u8]>) -> io::Result<Stdio> {
+    let Some(stdin) = stdin else {
+        return Ok(Stdio::null());
+    };
+
+    let mut file = tempfile::tempfile()?;
+    file.write_all(stdin)?;
+    file.rewind()?;
+    Ok(Stdio::from(file))
+}
+
+fn read_captured_stream(file: &mut File, name: &str) -> io::Result<Vec<u8>> {
+    file.rewind()
+        .map_err(|error| io::Error::new(error.kind(), format!("rewind {name}: {error}")))?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|error| io::Error::new(error.kind(), format!("read {name}: {error}")))?;
+    Ok(bytes)
+}
+
+fn terminate_and_reap(mut child: Child) -> String {
+    let kill = match child.kill() {
+        Ok(()) => "signal sent".to_owned(),
+        Err(error) => format!("failed: {error}"),
+    };
+    let reap = match reap_child_with_timeout(child, CLEANUP_TIMEOUT) {
+        Ok(status) => format!("completed with {status}"),
+        Err(error) => format!("failed: {error}"),
+    };
+    format!("kill={kill}, reap={reap}")
+}
+
+fn reap_child_with_timeout(mut child: Child, timeout: Duration) -> Result<ExitStatus, String> {
+    let (status_tx, status_rx) = mpsc::channel();
+    let reaper = std::thread::spawn(move || {
+        let _ = status_tx.send(child.wait());
+    });
+
+    match status_rx.recv_timeout(timeout) {
+        Ok(status) => {
+            reaper
+                .join()
+                .map_err(|_| "child reaper panicked".to_owned())?;
+            status.map_err(|error| format!("wait failed: {error}"))
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            drop(reaper);
+            Err(format!("child was not reaped within {timeout:?}"))
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            drop(reaper);
+            Err("child reaper exited without a status".to_owned())
+        }
+    }
+}

--- a/crates/guest-download/tests/integration/binary_logging/redaction.rs
+++ b/crates/guest-download/tests/integration/binary_logging/redaction.rs
@@ -3,12 +3,18 @@ use crate::support::{
     assert_does_not_contain_any, create_tar_gz, read_http_request_path, write_manifest,
 };
 use httpmock::prelude::*;
-use std::io::{self, Write as _};
-use std::net::{TcpListener, TcpStream};
+use std::io;
+use std::net::TcpListener;
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
+use std::time::{Duration, Instant};
 
 const EXPECTED_RETRY_ATTEMPTS: usize = 3;
-const SERVER_STOP_PATH: &str = "/__stop";
+const SERVER_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const SERVER_STREAM_READ_TIMEOUT: Duration = Duration::from_secs(1);
+const SERVER_START_TIMEOUT: Duration = Duration::from_secs(5);
+const SERVER_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+const SERVER_JOIN_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
 fn validate_attempt_warning(
     log_name: &str,
@@ -54,32 +60,136 @@ fn validate_attempt_warnings(
     Ok(())
 }
 
-fn start_connection_drop_server() -> io::Result<(String, thread::JoinHandle<io::Result<usize>>)> {
-    let listener = TcpListener::bind("127.0.0.1:0")?;
-    let base_url = format!("http://{}", listener.local_addr()?);
-    let handle = thread::spawn(move || {
-        let mut accepted = 0;
-        loop {
-            let (mut stream, _) = listener.accept()?;
-            if read_http_request_path(&mut stream)? == SERVER_STOP_PATH {
-                return Ok(accepted);
-            }
-            accepted += 1;
-        }
-    });
-
-    Ok((base_url, handle))
+#[derive(Clone, Copy)]
+enum ConnectionBehavior {
+    Drop,
+    Hold,
 }
 
-fn stop_connection_drop_server(base_url: &str) -> io::Result<()> {
-    let address = base_url
-        .strip_prefix("http://")
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid server URL"))?;
-    let mut stream = TcpStream::connect(address)?;
-    stream.write_all(
-        format!("GET {SERVER_STOP_PATH} HTTP/1.1\r\nhost: localhost\r\nconnection: close\r\n\r\n")
-            .as_bytes(),
-    )
+struct ConnectionDropServer {
+    base_url: String,
+    stop_tx: Sender<()>,
+    request_started_rx: Receiver<()>,
+    handle: Option<thread::JoinHandle<io::Result<usize>>>,
+}
+
+impl ConnectionDropServer {
+    fn start() -> io::Result<Self> {
+        Self::start_with_behavior(ConnectionBehavior::Drop)
+    }
+
+    fn start_holding() -> io::Result<Self> {
+        Self::start_with_behavior(ConnectionBehavior::Hold)
+    }
+
+    fn start_with_behavior(behavior: ConnectionBehavior) -> io::Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        listener.set_nonblocking(true)?;
+        let base_url = format!("http://{}", listener.local_addr()?);
+        let (stop_tx, stop_rx) = mpsc::channel();
+        let (request_started_tx, request_started_rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            serve_dropped_connections(listener, stop_rx, request_started_tx, behavior)
+        });
+
+        Ok(Self {
+            base_url,
+            stop_tx,
+            request_started_rx,
+            handle: Some(handle),
+        })
+    }
+
+    fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    fn wait_for_request(&self) -> io::Result<()> {
+        match self.request_started_rx.recv_timeout(SERVER_START_TIMEOUT) {
+            Ok(()) => Ok(()),
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!(
+                    "connection-drop server received no request within {SERVER_START_TIMEOUT:?}"
+                ),
+            )),
+            Err(mpsc::RecvTimeoutError::Disconnected) => Err(io::Error::other(
+                "connection-drop server exited before receiving a request",
+            )),
+        }
+    }
+
+    fn finish(mut self) -> io::Result<usize> {
+        self.shutdown()
+    }
+
+    fn shutdown(&mut self) -> io::Result<usize> {
+        let handle = self
+            .handle
+            .take()
+            .ok_or_else(|| io::Error::other("connection-drop server lost its thread"))?;
+        let _ = self.stop_tx.send(());
+        let deadline = Instant::now() + SERVER_CLEANUP_TIMEOUT;
+        while !handle.is_finished() {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!(
+                        "connection-drop server did not stop within {SERVER_CLEANUP_TIMEOUT:?}"
+                    ),
+                ));
+            }
+            thread::sleep(remaining.min(SERVER_JOIN_POLL_INTERVAL));
+        }
+
+        handle
+            .join()
+            .map_err(|_| io::Error::other("connection-drop server panicked"))?
+    }
+}
+
+impl Drop for ConnectionDropServer {
+    fn drop(&mut self) {
+        if self.handle.is_some() {
+            let _ = self.shutdown();
+        }
+    }
+}
+
+fn serve_dropped_connections(
+    listener: TcpListener,
+    stop_rx: Receiver<()>,
+    request_started_tx: Sender<()>,
+    behavior: ConnectionBehavior,
+) -> io::Result<usize> {
+    let mut accepted = 0;
+    loop {
+        match stop_rx.try_recv() {
+            Ok(()) | Err(mpsc::TryRecvError::Disconnected) => return Ok(accepted),
+            Err(mpsc::TryRecvError::Empty) => {}
+        }
+
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                stream.set_read_timeout(Some(SERVER_STREAM_READ_TIMEOUT))?;
+                read_http_request_path(&mut stream)?;
+                accepted += 1;
+                let _ = request_started_tx.send(());
+                if matches!(behavior, ConnectionBehavior::Hold) {
+                    let _ = stop_rx.recv();
+                    return Ok(accepted);
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                match stop_rx.recv_timeout(SERVER_POLL_INTERVAL) {
+                    Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => return Ok(accepted),
+                    Err(mpsc::RecvTimeoutError::Timeout) => {}
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
 }
 
 #[test]
@@ -295,7 +405,8 @@ fn binary_classifies_system_resolver_failure_without_logging_url() {
 
 #[test]
 fn binary_classifies_connection_drop_without_logging_url() {
-    let (base_url, server_handle) = start_connection_drop_server().unwrap();
+    let server = ConnectionDropServer::start().unwrap();
+    let base_url = server.base_url().to_owned();
     let fixture = BinaryLoggingFixture::new("connection-drop-secret-url").unwrap();
     let mount = fixture.dir.path().join("mount");
     let url = format!(
@@ -305,8 +416,7 @@ fn binary_classifies_connection_drop_without_logging_url() {
         write_manifest(&fixture.dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
     let output = fixture.run_manifest_path(&manifest).unwrap();
-    stop_connection_drop_server(&base_url).unwrap();
-    let accepted = server_handle.join().unwrap().unwrap();
+    let accepted = server.finish().unwrap();
 
     assert!(!output.status.success());
     assert_eq!(accepted, EXPECTED_RETRY_ATTEMPTS);
@@ -347,6 +457,43 @@ fn binary_classifies_connection_drop_without_logging_url() {
         "missing classified storage_download entry: {ops_log_content}"
     );
     assert_download_total_success_present(&ops, false);
+}
+
+#[cfg(unix)]
+#[test]
+fn binary_timeout_terminates_child_and_connection_responder() {
+    let server = ConnectionDropServer::start_holding().unwrap();
+    let fixture = BinaryLoggingFixture::new("held-connection-timeout").unwrap();
+    let mount = fixture.dir.path().join("mount");
+    let url = format!("{}/held.tar.gz", server.base_url());
+    let manifest =
+        write_manifest(&fixture.dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+    let execution = fixture.spawn_manifest_path(&manifest).unwrap();
+    let child_id = execution.id().unwrap();
+
+    server.wait_for_request().unwrap();
+    let error = execution.wait_with_timeout(Duration::ZERO).unwrap_err();
+    let accepted = server.finish().unwrap();
+
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    let message = error.to_string();
+    assert!(message.contains("guest-download timed out after 0ns"));
+    assert!(message.contains("kill=signal sent"));
+    assert!(message.contains("reap=completed with"));
+    assert!(message.contains("stdout="));
+    assert!(message.contains("stderr="));
+    assert!(message.contains("[INFO] [sandbox:download] Downloading 1 items"));
+    assert_eq!(accepted, 1);
+    let child_id = libc::pid_t::try_from(child_id).unwrap();
+    let mut status = 0;
+    // SAFETY: `child_id` came from the directly owned child, and the lifecycle
+    // helper returned only after reaping it. WNOHANG verifies no status remains.
+    let result = unsafe { libc::waitpid(child_id, &mut status, libc::WNOHANG) };
+    assert_eq!(result, -1);
+    assert_eq!(
+        io::Error::last_os_error().raw_os_error(),
+        Some(libc::ECHILD)
+    );
 }
 
 #[test]

--- a/crates/guest-download/tests/integration/binary_logging/runtime_paths.rs
+++ b/crates/guest-download/tests/integration/binary_logging/runtime_paths.rs
@@ -1,6 +1,6 @@
 use super::{
     BinaryLoggingFixture, RuntimeLogPaths, assert_default_zero_task_attribution,
-    assert_single_download_total_success, guest_download_command,
+    assert_single_download_total_success, guest_download_command, process,
 };
 use crate::support::{unique_run_id, write_manifest};
 
@@ -37,11 +37,12 @@ fn binary_fails_without_run_id_for_runtime_log_setup() {
     let dir = tempfile::tempdir().unwrap();
     let manifest_path = write_manifest(&dir, &[], None).unwrap();
 
-    let output = guest_download_command()
-        .arg(&manifest_path)
-        .env_remove("VM0_RUN_ID")
-        .output()
-        .unwrap();
+    let output = process::run(
+        guest_download_command()
+            .arg(&manifest_path)
+            .env_remove("VM0_RUN_ID"),
+    )
+    .unwrap();
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -56,11 +57,12 @@ fn binary_fails_with_empty_run_id_for_runtime_log_setup() {
     let dir = tempfile::tempdir().unwrap();
     let manifest_path = write_manifest(&dir, &[], None).unwrap();
 
-    let output = guest_download_command()
-        .arg(&manifest_path)
-        .env("VM0_RUN_ID", "")
-        .output()
-        .unwrap();
+    let output = process::run(
+        guest_download_command()
+            .arg(&manifest_path)
+            .env("VM0_RUN_ID", ""),
+    )
+    .unwrap();
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -76,15 +78,16 @@ fn binary_fails_with_relative_runtime_dir_for_runtime_log_setup() {
     let manifest_path = write_manifest(&dir, &[], None).unwrap();
     let run_id = unique_run_id("relative-runtime-dir");
 
-    let output = guest_download_command()
-        .arg(&manifest_path)
-        .env("VM0_RUN_ID", run_id)
-        .env(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-            "relative-runtime-dir",
-        )
-        .output()
-        .unwrap();
+    let output = process::run(
+        guest_download_command()
+            .arg(&manifest_path)
+            .env("VM0_RUN_ID", run_id)
+            .env(
+                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                "relative-runtime-dir",
+            ),
+    )
+    .unwrap();
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -101,12 +104,13 @@ fn binary_fails_with_invalid_run_id_for_runtime_log_setup() {
     let dir = tempfile::tempdir().unwrap();
     let manifest_path = write_manifest(&dir, &[], None).unwrap();
 
-    let output = guest_download_command()
-        .arg(&manifest_path)
-        .env("VM0_RUN_ID", "invalid/run/id")
-        .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
-        .output()
-        .unwrap();
+    let output = process::run(
+        guest_download_command()
+            .arg(&manifest_path)
+            .env("VM0_RUN_ID", "invalid/run/id")
+            .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV),
+    )
+    .unwrap();
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -124,15 +128,16 @@ fn binary_uses_absolute_runtime_dir_without_validating_run_id_as_path_segment() 
     let manifest_path = write_manifest(&dir, &[], None).unwrap();
     let logs = RuntimeLogPaths::new(&dir);
 
-    let output = guest_download_command()
-        .arg(&manifest_path)
-        .env("VM0_RUN_ID", "ignored/when/runtime-dir/is-set")
-        .env(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-            &logs.runtime_dir,
-        )
-        .output()
-        .unwrap();
+    let output = process::run(
+        guest_download_command()
+            .arg(&manifest_path)
+            .env("VM0_RUN_ID", "ignored/when/runtime-dir/is-set")
+            .env(
+                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                &logs.runtime_dir,
+            ),
+    )
+    .unwrap();
 
     assert!(
         output.status.success(),
@@ -152,13 +157,14 @@ fn binary_fails_without_home_or_runtime_dir_for_runtime_log_setup() {
     let manifest_path = write_manifest(&dir, &[], None).unwrap();
     let run_id = unique_run_id("missing-home");
 
-    let output = guest_download_command()
-        .arg(&manifest_path)
-        .env("VM0_RUN_ID", run_id)
-        .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
-        .env_remove("HOME")
-        .output()
-        .unwrap();
+    let output = process::run(
+        guest_download_command()
+            .arg(&manifest_path)
+            .env("VM0_RUN_ID", run_id)
+            .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
+            .env_remove("HOME"),
+    )
+    .unwrap();
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);


### PR DESCRIPTION
## Summary

- route every binary-logging `guest-download` invocation through a 10-second owned-child deadline
- preserve stdin and captured output with anonymous files while bounding kill and reap cleanup
- make the connection-drop responder unconditionally stoppable and add a real blocked-child regression

## Scope

This is test-harness-only. It does not change production download behavior, dependencies, protocols,
workflows, or CI job timeouts.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-download --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-download --all-features --no-deps`
- new timeout/responder regression repeated 10 times
- `cargo test -p guest-download --test integration binary_logging:: --quiet`
- `cargo test -p guest-download --all-targets --all-features --quiet`

Closes #25018
