### PR TITLE
test(platform): synchronize cached realtime fallback

### DIFF
--- a/turbo/apps/platform/src/mocks/ably.ts
+++ b/turbo/apps/platform/src/mocks/ably.ts
@@ -48,7 +48,13 @@ let hasConnected = false;
 let failedStateChange: FailedStateChange | null = null;
 let connectionClosed = false;
 let nextSubscribeError: Error | null = null;
-const subscribeErrors = new Map<string, Error>();
+const subscribeErrors = new Map<
+  string,
+  {
+    readonly error: Error;
+    readonly observed: ReturnType<typeof createDeferredPromise<void>>;
+  }
+>();
 
 /**
  * Fire all callbacks subscribed to `topic`. Call this from test helpers
@@ -142,8 +148,14 @@ export function rejectNextAblySubscribe(message: string): void {
   nextSubscribeError = new Error(message);
 }
 
-export function rejectAblySubscribe(topic: string, message: string): void {
-  subscribeErrors.set(topic, new Error(message));
+export function rejectAblySubscribe(
+  topic: string,
+  message: string,
+  signal: AbortSignal,
+): Promise<void> {
+  const observed = createDeferredPromise<void>(signal);
+  subscribeErrors.set(topic, { error: new Error(message), observed });
+  return observed.promise;
 }
 
 function invokeAuthCallback(cb: AuthCallback): Promise<AuthCallbackToken> {
@@ -185,10 +197,11 @@ const fakeChannel = {
       throw new Error("Connection closed");
     }
     if (typeof topicOrCallback === "string") {
-      const error = subscribeErrors.get(topicOrCallback);
-      if (error) {
+      const failure = subscribeErrors.get(topicOrCallback);
+      if (failure) {
         subscribeErrors.delete(topicOrCallback);
-        throw error;
+        failure.observed.resolve();
+        throw failure.error;
       }
     }
     if (nextSubscribeError) {

--- a/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
@@ -294,7 +294,9 @@ export function createTestMocks(getSignal: () => AbortSignal) {
       triggerReconnect: triggerAblyReconnect,
       triggerReauth: triggerAblyReauth,
       triggerConnectionClosed: triggerAblyConnectionClosed,
-      rejectSubscribe: rejectAblySubscribe,
+      rejectSubscribe: (topic: string, message: string) => {
+        return rejectAblySubscribe(topic, message, getSignal());
+      },
       rejectNextSubscribe: rejectNextAblySubscribe,
       hasChannelSubscription,
       hasSubscription,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -304,7 +304,7 @@ describe("zero chat thread IndexedDB fallback", () => {
       seqId: 1,
       createdAt: "2026-03-10T00:00:01Z",
     });
-    context.mocks.ably.rejectSubscribe(
+    const realtimeSubscriptionFailed = context.mocks.ably.rejectSubscribe(
       `chatThreadDetailChanged:${THREAD_ID}`,
       "channel attach failed",
     );
@@ -316,6 +316,7 @@ describe("zero chat thread IndexedDB fallback", () => {
 
     try {
       setupChatPage();
+      await realtimeSubscriptionFailed;
 
       await expect(
         screen.findByText("Cached while realtime is unavailable"),


### PR DESCRIPTION
## Summary

- expose a lifecycle-scoped observation promise when the Ably test mock emits a topic-specific subscribe failure
- wait for that failure before asserting the IndexedDB-cached message
- keep the assertion deterministic without adding timeouts, sleeps, or retries

## Failure evidence

- Turbo run 30901661855 failed in test-app shard 4: https://github.com/vm0-ai/vm0/actions/runs/30901661855/job/91967265099
- the first substantive failure was zero-chat-thread-idb.test.tsx: shows cached messages when a realtime subscription fails
- the same test passed in the preceding main run in 1099 ms: https://github.com/vm0-ai/vm0/actions/runs/30900673632/job/91965075749
- the triggering commit only changed guest-agent Rust files, so this is a missing-synchronization test flake rather than a product regression

## Validation

- pnpm format
- NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@vm0/app
- pnpm --filter @vm0/app run check-types
- pnpm --filter api run check-types
- target test file passed 6 consecutive post-fix runs