### PR TITLE
test(api): isolate pending slack event lookup

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -11,10 +11,7 @@ import { env, mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { installApiTestConnectorCatalog } from "../../../test-fixtures/connector-catalog";
-import {
-  findPendingChatEventByPromptFixture,
-  readChatEventContextFixture,
-} from "../../../test-fixtures/chat-events";
+import { readChatEventContextFixture } from "../../../test-fixtures/chat-events";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise } from "../../utils";
@@ -310,14 +307,6 @@ async function pollSlackRun(runnerGroup: string): Promise<string> {
     runnerGroup,
     "Expected a Slack-triggered run in the runner queue",
   );
-}
-
-async function requirePendingChatEvent(prompt: string) {
-  const event = await findPendingChatEventByPromptFixture(prompt);
-  if (!event) {
-    throw new Error(`Expected queued event for ${prompt}`);
-  }
-  return event;
 }
 
 async function pollQueuedWebAndSlackRuns(args: {
@@ -1832,14 +1821,19 @@ describe("INT-01: Slack app deep webhook flows", () => {
         }),
       ]),
     );
-    const queuedSlackParams = await requirePendingChatEvent(
-      "stay canonical on the same route",
-    );
-    expect(queuedSlackParams).toMatchObject({
-      eventId: expect.any(String),
+    const queuedSlackEvents = state.pending_chat_events.filter((pending) => {
+      return (
+        pending.chatThreadId === canonicalChatThreadId &&
+        pending.triggerSource === "slack"
+      );
     });
+    expect(queuedSlackEvents).toHaveLength(1);
+    const [queuedSlackEvent] = queuedSlackEvents;
+    if (!queuedSlackEvent) {
+      throw new Error("Expected the canonical thread's pending Slack event");
+    }
     await expect(
-      readChatEventContextFixture(queuedSlackParams.eventId),
+      readChatEventContextFixture(queuedSlackEvent.id),
     ).resolves.toMatchObject({
       contextType: "slack",
       contextId: expect.any(String),


### PR DESCRIPTION
## Summary

- select the queued Slack event from the current workspace's scoped pending-event state
- require the current canonical thread and Slack trigger source instead of matching a global fixed prompt
- remove the affected scenario's prompt-only fixture wrapper while preserving its context and session assertions

## Scope

This is a test-only change. It does not modify production behavior, API contracts, database schemas, queue semantics, mocks, timeouts, or deployment compatibility.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts`
- two sequential runs of `pnpm -F api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts --silent=passed-only` (38 tests passed each run without resetting PostgreSQL)
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (183 files, 2645 tests passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `lefthook run pre-commit`

Closes #25021
