### PR TITLE
refactor(api): remove image recognition rollout compatibility

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -242,11 +242,9 @@ describe("auth tokens", () => {
     expect(verifyZeroToken(eligibleToken)?.capabilities).toContain(
       "image-recognition:write",
     );
-    expect(decodeZeroTokenPayloadForTest(eligibleToken)).toMatchObject({
-      featureSwitchOverrides: {
-        zeroImageRecognition: true,
-      },
-    });
+    expect(decodeZeroTokenPayloadForTest(eligibleToken)).not.toHaveProperty(
+      "featureSwitchOverrides",
+    );
   });
 
   it("gates browser capabilities on both the rollout and thread access", () => {

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -21,10 +21,6 @@ import { singleton } from "../../lib/singleton";
 
 const SANDBOX_TOKEN_PREFIX = "vm0_sandbox_";
 const PAT_TOKEN_PREFIX = "vm0_pat_";
-// Pre-rollout TypeScript Zero CLI versions gate `recognize` with this key.
-// Keep the positive token override until those versions can no longer run,
-// including from resumed sandboxes or npm caches.
-const LEGACY_IMAGE_RECOGNITION_SWITCH = "zeroImageRecognition";
 // Covers the runner's two-hour execution budget plus claim, startup,
 // finalization, and terminal report time.
 const SANDBOX_TOKEN_TTL_SECONDS = 3 * 60 * 60;
@@ -337,21 +333,13 @@ export function generateZeroToken(
       capabilities.push(capability);
     }
   }
-  const featureSwitchOverrides =
-    options?.imageRecognitionAvailable === true
-      ? {
-          ...overrides,
-          [LEGACY_IMAGE_RECOGNITION_SWITCH]: true,
-        }
-      : overrides;
-
   const payload: z.infer<typeof zeroTokenPayloadSchema> = {
     scope: "zero",
     userId,
     runId,
     orgId,
     capabilities,
-    ...(featureSwitchOverrides === undefined ? {} : { featureSwitchOverrides }),
+    ...(overrides === undefined ? {} : { featureSwitchOverrides: overrides }),
     ...(capabilities.includes("computer-use:write") &&
     options?.computerUseHostId
       ? { computerUseHostId: options.computerUseHostId }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -73,7 +73,6 @@ describe("/api/zero/feature-switches", () => {
       ],
     ).toBeTruthy();
     expect(updated.body.supportsImageRecognition).toBeTruthy();
-    expect(updated.body.imageRecognitionRolloutComplete).toBeTruthy();
     expect(updated.body.supportsAvatarTemplates).toBeTruthy();
 
     const current = await accept(client().get({ headers }), [200]);
@@ -83,8 +82,6 @@ describe("/api/zero/feature-switches", () => {
     expect(current.body.supportsCustomConnectorOAuth2).toBeTruthy();
     expect(current.body.supportsCustomModelGateways).toBeTruthy();
     expect(current.body.supportsImageRecognition).toBeTruthy();
-    expect(current.body.imageRecognitionRolloutComplete).toBeTruthy();
-    expect(current.body.effectiveSwitches.zeroImageRecognition).toBeTruthy();
     expect(current.body.supportsAvatarTemplates).toBeTruthy();
     expect(
       current.body.effectiveSwitches[

--- a/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
@@ -19,9 +19,7 @@ const featureSwitchesAuthOptions = {
   missingOrganizationStatus: 401,
 } as const;
 
-const LEGACY_IMAGE_RECOGNITION_SWITCH = "zeroImageRecognition";
 const LEGACY_MAIL_REPLY_FOLLOW_UP_SWITCH = "zeroMailReplyFollowUp";
-
 function featureSwitchResponseBody(params: {
   readonly orgId: string;
   readonly userId: string;
@@ -30,7 +28,6 @@ function featureSwitchResponseBody(params: {
   readonly supportsCustomConnectorOAuth2: boolean;
   readonly supportsCustomModelGateways: boolean;
   readonly supportsImageRecognition: boolean;
-  readonly imageRecognitionRolloutComplete: true;
   readonly supportsAvatarTemplates: boolean;
 }) {
   const registeredEffectiveSwitches = getAllFeatureStates({
@@ -44,7 +41,6 @@ function featureSwitchResponseBody(params: {
   const effectiveSwitches = {
     ...registeredEffectiveSwitches,
     [LEGACY_MAIL_REPLY_FOLLOW_UP_SWITCH]: false,
-    [LEGACY_IMAGE_RECOGNITION_SWITCH]: true,
   };
 
   return {
@@ -54,7 +50,6 @@ function featureSwitchResponseBody(params: {
     supportsCustomConnectorOAuth2: params.supportsCustomConnectorOAuth2,
     supportsCustomModelGateways: params.supportsCustomModelGateways,
     supportsImageRecognition: params.supportsImageRecognition,
-    imageRecognitionRolloutComplete: params.imageRecognitionRolloutComplete,
     supportsAvatarTemplates: params.supportsAvatarTemplates,
   };
 }
@@ -77,7 +72,6 @@ const getFeatureSwitchesInner$ = computed(async (get): Promise<unknown> => {
       supportsCustomConnectorOAuth2: true,
       supportsCustomModelGateways,
       supportsImageRecognition: true,
-      imageRecognitionRolloutComplete: true,
       supportsAvatarTemplates: true,
     }),
   };
@@ -119,7 +113,6 @@ const updateFeatureSwitchesInner$ = command(
         supportsCustomConnectorOAuth2: true,
         supportsCustomModelGateways,
         supportsImageRecognition: true,
-        imageRecognitionRolloutComplete: true,
         supportsAvatarTemplates: true,
       }),
     };

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts
@@ -99,31 +99,6 @@ describe("bootstrap feature switch hydration", () => {
     expect(context.store.get(imageRecognitionAvailable$)).toBeTruthy();
   });
 
-  it("accepts image recognition when the temporary marker is present", async () => {
-    context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
-      return respond(200, {
-        switches: {},
-        effectiveSwitches: {},
-        supportsStructuredInlineTemplates: true,
-        supportsCustomConnectorOAuth2: true,
-        supportsCustomModelGateways: true,
-        supportsImageRecognition: true,
-        imageRecognitionRolloutComplete: true,
-      });
-    });
-
-    detachedSetupPage({
-      context,
-      path: "/error",
-      withoutRender: true,
-    });
-
-    expect(context.store.get(imageRecognitionAvailable$)).toBeFalsy();
-    await waitFor(() => {
-      expect(context.store.get(imageRecognitionAvailable$)).toBeTruthy();
-    });
-  });
-
   it("keeps image recognition unavailable when the API omits support", async () => {
     context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
       return respond(200, {
@@ -132,7 +107,6 @@ describe("bootstrap feature switch hydration", () => {
         supportsStructuredInlineTemplates: true,
         supportsCustomConnectorOAuth2: true,
         supportsCustomModelGateways: true,
-        imageRecognitionRolloutComplete: true,
       });
     });
 
@@ -154,7 +128,6 @@ describe("bootstrap feature switch hydration", () => {
         supportsCustomConnectorOAuth2: true,
         supportsCustomModelGateways: true,
         supportsImageRecognition: false,
-        imageRecognitionRolloutComplete: true,
       });
     });
 

--- a/turbo/packages/api-contracts/src/contracts/zero-feature-switches.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-feature-switches.ts
@@ -28,12 +28,6 @@ export const featureSwitchesResponseSchema = z.object({
    */
   supportsImageRecognition: z.boolean().optional(),
   /**
-   * Optional handshake indicating managed image recognition is globally
-   * available without a feature switch. Older API deployments omit this field.
-   * Remove after APIs with the pre-rollout semantics are no longer reachable.
-   */
-  imageRecognitionRolloutComplete: z.literal(true).optional(),
-  /**
    * Optional capability handshake for API-backed avatar templates.
    * Older API deployments omit this field.
    */


### PR DESCRIPTION
## Summary

- remove the temporary image-recognition rollout marker and raw legacy switch from the feature-switch contract and API responses
- stop injecting the legacy image-recognition feature-switch override into Zero tokens while preserving `image-recognition:write` eligibility
- delete rollout-only Platform fixtures and retain true, false, and omitted stable-capability coverage
- keep the global App minimum supported version and middleware tests unchanged

## Deployment compatibility

- `app-v0.680.0` is already deployed and reads only `supportsImageRecognition`
- an already-loaded marker-dependent `0.679.2` page may keep image recognition unavailable until reload; its request and unrelated API use continue to work
- the global App floor remains `0.670.1`, avoiding a broad HTTP 426 force-upgrade for this cleanup
- pre-rollout TypeScript CLI copies are retired; the native CLI fallback resolves the current npm CLI
- stable capability, model input eligibility, pricing, and general feature-switch token overrides are unchanged
- no database schema, migration, or persisted-data change is included

## Validation

Current head:

- Prettier check on affected files
- `pnpm -F api exec vitest run src/__tests__/app-factory.test.ts src/signals/auth/__tests__/tokens.test.ts src/signals/routes/__tests__/zero-feature-switches.test.ts --silent=passed-only` (65 passed)
- `pnpm -F @vm0/app exec vitest run src/signals/__tests__/bootstrap-feature-switch.test.ts --silent=passed-only` (9 passed)
- pre-commit repository-wide TypeScript checks and Knip
- exact tracked-source search for retired identifiers
- no net diff in `web-client-compatibility.json` or its app-factory compatibility tests

Equivalent earlier implementation:

- complete Platform suite (123 files, 1,395 tests passed)
- CLI capability visibility suite (80 passed)
- complete API-contracts suite (26 files, 538 tests passed)
- affected-workspace lint and type checks

The complete API suite could not be validated locally because the container has unrelated pre-existing database schema drift. Focused affected API tests pass, no database files are changed, and CI remains the clean-environment full-suite gate.

Closes #25037

Parent: #24997
