### PR TITLE
fix(browser): emit close event on automatic reclamation

### DIFF
--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -304,8 +304,9 @@ the browser lease.
 
 Starting or resuming appends a payload-free `browser.open` chat event; clicking
 the sidebar close button appends a payload-free `browser.close` event without
-stopping the provider instance. Automatic reclamation does not append a chat
-event. The frontend supplies each mutation's event UUID so it can optimistically
+stopping the provider instance. Automatic reclamation for an existing thread
+also appends `browser.close` without inspecting the current sidebar state. The
+frontend supplies each mutation's event UUID so it can optimistically
 project the same event without duplicating it when the server response or
 realtime delivery arrives. Folding these events in order yields the thread's
 browser sidebar state. Opening a thread waits for the authoritative initial

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -27,6 +27,7 @@ import { mockEnv } from "../../../lib/env";
 import { mockNow, withMockNowForTest } from "../../../lib/time";
 import webClientCompatibility from "../../../lib/web-client-compatibility.json";
 import { server } from "../../../mocks/server";
+import { deleteChatThreadRootFixture } from "../../../test-fixtures/chat-thread-deletion";
 import { deleteAgentRunRootFixture } from "../../../test-fixtures/run-deletion";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise } from "../../utils";
@@ -1995,6 +1996,59 @@ describe("zero browser route", () => {
         }),
       }),
     );
+  }, 120_000);
+
+  it("reclaims an active browser after its thread is already deleted", async () => {
+    const { runs, chat, actor, agent } = await setupBrowserScenario();
+    const first = await createClaimedChatRun(
+      chat,
+      runs,
+      actor,
+      agent.agentId,
+      "Open a managed browser",
+    );
+
+    const providerId = randomUUID();
+    acceptBrowserUseCdpSessions([providerId]);
+    let providerStops = 0;
+    server.use(
+      http.post(`${BROWSER_USE_API_URL}/profiles`, async ({ request }) => {
+        const body = z
+          .strictObject({ name: z.string() })
+          .parse(await request.json());
+        return HttpResponse.json(providerProfile(randomUUID(), body.name), {
+          status: 201,
+        });
+      }),
+      http.post(`${BROWSER_USE_API_URL}/browsers`, () => {
+        return HttpResponse.json(providerBrowser(providerId), { status: 201 });
+      }),
+      http.get(`${BROWSER_USE_API_URL}/browsers/:id`, ({ params }) => {
+        return HttpResponse.json(providerBrowser(String(params.id)));
+      }),
+      http.patch(`${BROWSER_USE_API_URL}/browsers/:id`, ({ params }) => {
+        providerStops += 1;
+        return HttpResponse.json(
+          providerBrowser(String(params.id), { status: "stopped" }),
+        );
+      }),
+    );
+
+    await accept(
+      client().use({ headers: first.claim.browserHeaders, body: {} }),
+      [200],
+    );
+
+    await deleteChatThreadRootFixture(first.threadId);
+    const reclaimed = await reconcileBrowsers();
+    expect(reclaimed.body.errors).toBe(0);
+    expect(reclaimed.body.stopped).toBeGreaterThanOrEqual(1);
+    await flushWaitUntilForTest();
+    expect(providerStops).toBeGreaterThanOrEqual(1);
+
+    const retired = await reconcileBrowsers();
+    expect(retired.body).toMatchObject({ checked: 0, stopped: 0, errors: 0 });
+    await deleteAgentRunRootFixture(first.runId);
   }, 120_000);
 
   it("records browser close events for UI actions and automatic reclamation", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -1997,7 +1997,7 @@ describe("zero browser route", () => {
     );
   }, 120_000);
 
-  it("reuses one thread browser and records open-close UI lifecycle events", async () => {
+  it("records browser close events for UI actions and automatic reclamation", async () => {
     const { routeMocks, runs, chat, actor, agent } =
       await setupBrowserScenario();
     const first = await createClaimedChatRun(
@@ -2055,6 +2055,17 @@ describe("zero browser route", () => {
       [200],
     );
 
+    routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const beforeReclaimCloseEventId = randomUUID();
+    await accept(
+      client().close({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { threadId: first.threadId },
+        body: { eventId: beforeReclaimCloseEventId },
+      }),
+      [200],
+    );
+
     mockNow(STARTED_AT_MS + 11 * MINUTE_MS);
     const reclaimed = await reconcileBrowsers();
     expect(reclaimed.body).toMatchObject({
@@ -2075,7 +2086,6 @@ describe("zero browser route", () => {
     });
     expect(providerCreates).toBe(2);
 
-    routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
     const noOpEventId = randomUUID();
     const alreadyActive = await accept(
       client().open({
@@ -2138,6 +2148,16 @@ describe("zero browser route", () => {
       {
         id: firstStart.body.lifecycleEventId,
         eventType: "browser.open",
+        content: null,
+      },
+      {
+        id: beforeReclaimCloseEventId,
+        eventType: "browser.close",
+        content: null,
+      },
+      {
+        id: expect.any(String),
+        eventType: "browser.close",
         content: null,
       },
       {

--- a/turbo/apps/api/src/signals/services/zero-browser.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-browser.service.ts
@@ -3103,6 +3103,7 @@ const reconcileBrowserInstance$ = command(
       reason,
       signal,
       {
+        emitCloseEvent: row.chatThreadId !== null,
         stopProvider,
       },
     );

--- a/turbo/apps/api/src/signals/services/zero-browser.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-browser.service.ts
@@ -580,6 +580,7 @@ async function stopActiveBrowserInstance(
   reason: ZeroBrowserSuspensionReason,
   signal: AbortSignal,
   options: {
+    readonly emitCloseEvent?: boolean;
     readonly stopProvider: boolean;
     readonly saveTabSnapshot?: boolean;
   } = { stopProvider: true },
@@ -621,7 +622,23 @@ async function stopActiveBrowserInstance(
         updatedAt: nowDate(),
       })
       .where(eq(browserSessions.chatThreadId, target.chatThreadId));
-    return true;
+    if (options.emitCloseEvent === false) {
+      return { eventSeqId: null };
+    }
+    const event = await insertChatEvent(
+      tx,
+      {
+        id: randomUUID(),
+        chatThreadId: target.chatThreadId,
+        eventType: "browser.close",
+        content: null,
+      },
+      "id",
+    );
+    if (!event) {
+      throw new Error("Failed to persist managed browser close event");
+    }
+    return { eventSeqId: event.seqId };
   });
   if (stopped && options.stopProvider) {
     stopProviderSessionLater(target.providerSessionId);
@@ -633,6 +650,13 @@ async function stopActiveBrowserInstance(
   await publishBrowserSessionChangedSafely(target.userId, {
     threadId: target.chatThreadId,
   });
+  if (stopped.eventSeqId !== null) {
+    await publishChatThreadMessageCreatedSafely(
+      target.userId,
+      target.chatThreadId,
+      stopped.eventSeqId,
+    );
+  }
   signal.throwIfAborted();
   return true;
 }
@@ -2301,7 +2325,7 @@ export const stopZeroBrowserForThreadCompatibility$ = command(
           },
           "user",
           signal,
-          { stopProvider: true },
+          { emitCloseEvent: false, stopProvider: true },
         );
       } else {
         await suspendBrowserWithoutActiveInstance(db, browser, "user", signal);
@@ -2680,6 +2704,7 @@ export const stopThreadZeroBrowsers$ = command(
     for (const target of active) {
       if (
         await stopActiveBrowserInstance(db, target, "reconcile", signal, {
+          emitCloseEvent: false,
           stopProvider: false,
           saveTabSnapshot: false,
         })

--- a/turbo/apps/api/src/test-fixtures/chat-thread-deletion.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-thread-deletion.ts
@@ -1,0 +1,15 @@
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { eq } from "drizzle-orm";
+
+import { db } from "../lib/db";
+
+/**
+ * Deletes the thread root without running route side effects. Production APIs
+ * cannot pause after the durable delete but before browser cleanup, so this
+ * fixture constructs that crash window for reconciler coverage.
+ */
+export async function deleteChatThreadRootFixture(
+  chatThreadId: string,
+): Promise<void> {
+  await db().delete(chatThreads).where(eq(chatThreads.id, chatThreadId));
+}


### PR DESCRIPTION
## Summary

- append a payload-free `browser.close` event when the backend automatically reclaims an active browser for an existing thread
- publish the corresponding realtime chat event without inspecting the current sidebar projection
- avoid duplicate close events for the legacy `/stop` compatibility path and deleted-thread cleanup
- update the browser lifecycle documentation and API integration coverage

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-browser.test.ts -t "records browser close events for UI actions and automatic reclamation"`
