### PR TITLE
fix: hide rejected goal continuations from chat

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -44,14 +44,21 @@ import {
 } from "./chat-lifecycle-test-helpers.ts";
 
 describe("chat lifecycle", () => {
-  it("renders a rejected goal continuation as a goal artifact without exposing its machine reason", async () => {
+  it("does not render a rejected goal continuation after an assistant response", async () => {
     const threadId = "thread-rejected-goal-artifact";
     const objectiveBrief = "Keep the launch moving";
     const machineReason = "internal provider credential id abc123 is invalid";
+    const assistantResponse = "The active goal has been stopped.";
     mockChatLifecycle(context, {
       threadId,
       threadTitle: "Rejected goal artifact",
       chatEvents: [
+        {
+          id: "msg-assistant-response",
+          role: "assistant",
+          content: assistantResponse,
+          createdAt: "2026-07-29T10:00:00Z",
+        },
         {
           id: "msg-rejected-goal",
           role: "user",
@@ -62,25 +69,19 @@ describe("chat lifecycle", () => {
             parts: [{ type: "goal", goalBrief: objectiveBrief }],
           },
           error: machineReason,
-          createdAt: "2026-07-29T10:00:00Z",
+          createdAt: "2026-07-29T10:00:01Z",
         },
       ],
     });
 
     detachedSetupPage({ context, path: `/chats/${threadId}` });
 
-    await waitFor(() => {
-      expect(screen.getByLabelText("Goal")).toBeInTheDocument();
-      expect(screen.getByText(objectiveBrief)).toBeInTheDocument();
-    });
+    const renderedAssistantResponse =
+      await screen.findByText(assistantResponse);
+    expect(renderedAssistantResponse).toBeInTheDocument();
+    expect(screen.queryByLabelText("Goal")).not.toBeInTheDocument();
+    expect(screen.queryByText(objectiveBrief)).not.toBeInTheDocument();
     expect(screen.queryByText(machineReason)).not.toBeInTheDocument();
-    const goalArtifact = screen
-      .getByText(objectiveBrief)
-      .closest('[data-role="user"]');
-    if (!(goalArtifact instanceof HTMLElement)) {
-      throw new Error("Expected the rejected goal artifact");
-    }
-    expect(within(goalArtifact).getByLabelText("Goal")).toBeInTheDocument();
   });
 
   it("opens run logs from assistant message actions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3328,10 +3328,21 @@ function runGroupFoldGoalLabel(fold: RunGroupFold): string {
         .toLocaleLowerCase(i18n.resolvedLanguage);
 }
 
+function isRejectedGoalUserMessage(event: EnrichedChatEvent): boolean {
+  return (
+    event.eventType === "input.rejected" &&
+    eventNonContentPart(event)?.type === "goal"
+  );
+}
+
 function isGoalUserMessage(
   event: EnrichedChatEvent,
 ): event is EnrichedChatEvent & ChatInputEvent {
-  return isInputChatEvent(event) && eventNonContentPart(event)?.type === "goal";
+  return (
+    isInputChatEvent(event) &&
+    !isRejectedGoalUserMessage(event) &&
+    eventNonContentPart(event)?.type === "goal"
+  );
 }
 
 function isGoalRunGroupFold(fold: RunGroupFold): boolean {
@@ -7467,6 +7478,10 @@ function PagedUserMessage({
       Reason.DomCallback,
     );
   };
+
+  if (isRejectedGoalUserMessage(event)) {
+    return null;
+  }
 
   if (isWorkflowUserMessage(event)) {
     return <WorkflowUserMessage event={event} />;


### PR DESCRIPTION
## Summary

- hide rejected goal continuation events instead of rendering them as user-authored Goal messages
- exclude rejected goal continuations from goal run-group classification
- cover the observed ordering where a rejected continuation arrives after the final assistant response

## Why

Rejected goal continuations are internal queue cleanup events and do not create a run. Rendering them as Goal cards makes a stopped goal look like a new user message after the assistant has already finished.

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged TypeScript checks for non-API packages, Platform, and API
- targeted Platform Vitest: rejected goal hidden and normal archived goal history still rendered (2 passed)

## Local test note

The full 28-test Platform file was attempted first, but its Vitest worker repeatedly restarted under the local 4 GB memory limit. The focused regression and adjacent normal-goal coverage pass; the PR pipeline will run the broader suite.
