### PR TITLE
perf(sandbox-fc): reduce balloon settle detection latency

### DIFF
--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -14,6 +14,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use reqwest::Client;
+use sandbox_fc::BALLOON_SETTLE_AXIOM_TARGET;
 use serde_json::{Map, Value};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -171,13 +172,14 @@ pub(crate) struct AxiomLayer {
 }
 
 fn should_ingest(metadata: &Metadata<'_>) -> bool {
-    // Errors and warnings remain the general threshold. One exact INFO target
-    // carries the bounded selected-candidate measurements required before a
-    // successor has an authenticated per-job telemetry owner. DEBUG/TRACE and
-    // all other INFO events stay local-only.
+    // Errors and warnings remain the general threshold. Two exact INFO targets
+    // carry bounded production measurements that have no authenticated
+    // per-job telemetry owner. DEBUG/TRACE and all other INFO events stay
+    // local-only.
     (*metadata.level() <= tracing::Level::WARN && metadata.target() != INTERNAL_TARGET)
         || (*metadata.level() == tracing::Level::INFO
-            && metadata.target() == PRE_PARK_HANDOFF_AXIOM_TARGET)
+            && (metadata.target() == PRE_PARK_HANDOFF_AXIOM_TARGET
+                || metadata.target() == BALLOON_SETTLE_AXIOM_TARGET))
 }
 
 fn ingest_filter() -> FilterFn<fn(&Metadata<'_>) -> bool> {

--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -206,6 +206,14 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
             target: BALLOON_SETTLE_AXIOM_TARGET,
             "balloon target below INFO"
         );
+        tracing::trace!(
+            target: BALLOON_SETTLE_AXIOM_TARGET,
+            "balloon target at TRACE"
+        );
+        tracing::info!(
+            target: "sandbox_fc::balloon_settle::detail",
+            "balloon sibling INFO target"
+        );
     }
 
     guard.shutdown().await;
@@ -246,6 +254,14 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
     assert!(
         !has_event_with_message(&events, "balloon target below INFO"),
         "balloon DEBUG event should not be ingested: {events:#?}",
+    );
+    assert!(
+        !has_event_with_message(&events, "balloon target at TRACE"),
+        "balloon TRACE event should not be ingested: {events:#?}",
+    );
+    assert!(
+        !has_event_with_message(&events, "balloon sibling INFO target"),
+        "only the exact balloon INFO target should be ingested: {events:#?}",
     );
 }
 

--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -12,6 +12,7 @@ use super::{INTERNAL_TARGET, init_from_env_values, init_with_base_url, with_inge
 use httpmock::Method::POST;
 use httpmock::MockServer;
 use httpmock::{HttpMockRequest, HttpMockResponse, Mock};
+use sandbox_fc::BALLOON_SETTLE_AXIOM_TARGET;
 use serde_json::{Value, json};
 use tracing::field::{Field, Visit};
 use tracing::{Event, Subscriber};
@@ -192,6 +193,19 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
             target: PRE_PARK_HANDOFF_AXIOM_TARGET,
             "allowlisted target below INFO"
         );
+        tracing::info!(
+            target: BALLOON_SETTLE_AXIOM_TARGET,
+            measurement = "balloon_settle",
+            outcome = "target_reached",
+            elapsed_ms = 25_u64,
+            sample_count = 2_u64,
+            admission_action = "reuse",
+            "balloon settle completed"
+        );
+        tracing::debug!(
+            target: BALLOON_SETTLE_AXIOM_TARGET,
+            "balloon target below INFO"
+        );
     }
 
     guard.shutdown().await;
@@ -214,6 +228,13 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
     let measurement = event_with_message(&events, "allowlisted measurement");
     assert_eq!(measurement["level"], json!("info"));
     assert_eq!(measurement["outcome"], json!("retained"));
+    let balloon = event_with_message(&events, "balloon settle completed");
+    assert_eq!(balloon["level"], json!("info"));
+    assert_eq!(balloon["measurement"], json!("balloon_settle"));
+    assert_eq!(balloon["outcome"], json!("target_reached"));
+    assert_eq!(balloon["elapsed_ms"], json!(25));
+    assert_eq!(balloon["sample_count"], json!(2));
+    assert_eq!(balloon["admission_action"], json!("reuse"));
     assert!(
         !has_event_with_message(&events, "info is below threshold, should not be ingested"),
         "ordinary INFO event should not be ingested: {events:#?}",
@@ -221,6 +242,10 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
     assert!(
         !has_event_with_message(&events, "allowlisted target below INFO"),
         "allowlisted DEBUG event should not be ingested: {events:#?}",
+    );
+    assert!(
+        !has_event_with_message(&events, "balloon target below INFO"),
+        "balloon DEBUG event should not be ingested: {events:#?}",
     );
 }
 

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -74,3 +74,6 @@ pub use sandbox::FirecrackerSandbox;
 pub use snapshot::{
     FirecrackerSnapshotProvider, SNAPSHOT_COMPLETE_MARKER_CONTENT, SnapshotError, create_snapshot,
 };
+
+/// Exact tracing target for the bounded balloon-settlement production summary.
+pub const BALLOON_SETTLE_AXIOM_TARGET: &str = "sandbox_fc::balloon_settle";

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3201,8 +3201,10 @@ fn idle_transition_error(
 
 /// Maximum time to wait for balloon inflation before pausing vCPUs.
 const BALLOON_SETTLE_TIMEOUT: Duration = Duration::from_secs(5);
-/// Poll interval while waiting for balloon inflation.
-const BALLOON_SETTLE_POLL: Duration = Duration::from_millis(500);
+/// Initial poll interval while waiting for balloon inflation.
+const BALLOON_SETTLE_INITIAL_POLL: Duration = Duration::from_millis(25);
+/// Maximum poll interval while waiting for balloon inflation.
+const BALLOON_SETTLE_MAX_POLL: Duration = Duration::from_millis(500);
 /// Upper bound for accepting residual differences between requested and
 /// reported balloon size. Current 4 GiB production profiles commonly settle
 /// with low-hundreds MiB residuals when the guest reports little available
@@ -3395,6 +3397,60 @@ fn park_admission_action(outcome: SandboxParkOutcome) -> &'static str {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+enum BalloonSettleOutcome {
+    SkippedZeroTarget,
+    TargetReached,
+    WithinTolerance,
+    PressureLimited,
+    Deadline,
+    StatsUnavailable,
+}
+
+impl BalloonSettleOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::SkippedZeroTarget => "skipped_zero_target",
+            Self::TargetReached => "target_reached",
+            Self::WithinTolerance => "within_tolerance",
+            Self::PressureLimited => "pressure_limited",
+            Self::Deadline => "deadline",
+            Self::StatsUnavailable => "stats_unavailable",
+        }
+    }
+}
+
+fn emit_balloon_settle_summary(
+    settle_outcome: BalloonSettleOutcome,
+    elapsed_ms: u64,
+    sample_count: u32,
+    park_outcome: SandboxParkOutcome,
+) {
+    info!(
+        target: crate::BALLOON_SETTLE_AXIOM_TARGET,
+        measurement = "balloon_settle",
+        outcome = settle_outcome.as_str(),
+        elapsed_ms,
+        sample_count,
+        admission_action = park_admission_action(park_outcome),
+        "balloon settle completed"
+    );
+}
+
+fn complete_balloon_settle(
+    summary: &BalloonSettleSummary,
+    settle_outcome: BalloonSettleOutcome,
+    park_outcome: SandboxParkOutcome,
+) -> SandboxParkOutcome {
+    emit_balloon_settle_summary(
+        settle_outcome,
+        summary.elapsed_ms(),
+        summary.sample_count,
+        park_outcome,
+    );
+    park_outcome
+}
+
 /// Wait until the guest balloon driver inflates close enough to `target_mib`.
 ///
 /// The guest needs running vCPUs to inflate, so this must be called
@@ -3409,11 +3465,12 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
     let deadline = tokio::time::Instant::now() + BALLOON_SETTLE_TIMEOUT;
     let tolerance_mib = balloon_settle_tolerance_mib(target_mib);
     let mut summary = BalloonSettleSummary::new(target_mib);
+    let mut poll_interval = BALLOON_SETTLE_INITIAL_POLL;
     loop {
         if tokio::time::Instant::now() >= deadline {
             let outcome = summary.park_outcome();
             log_balloon_settle_timeout(log_id, target_mib, tolerance_mib, &summary, outcome);
-            return outcome;
+            return complete_balloon_settle(&summary, BalloonSettleOutcome::Deadline, outcome);
         }
 
         match tokio::time::timeout_at(deadline, client.get_balloon_statistics()).await {
@@ -3440,7 +3497,11 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                         reported_total_mib = ?summary.reported_total_mib(),
                         "balloon fully inflated, proceeding to pause"
                     );
-                    return SandboxParkOutcome::Reusable;
+                    return complete_balloon_settle(
+                        &summary,
+                        BalloonSettleOutcome::TargetReached,
+                        SandboxParkOutcome::Reusable,
+                    );
                 }
 
                 if deficit_mib <= tolerance_mib {
@@ -3464,7 +3525,11 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                         reported_total_mib = ?summary.reported_total_mib(),
                         "balloon inflated within tolerance, proceeding to pause"
                     );
-                    return SandboxParkOutcome::Reusable;
+                    return complete_balloon_settle(
+                        &summary,
+                        BalloonSettleOutcome::WithinTolerance,
+                        SandboxParkOutcome::Reusable,
+                    );
                 }
 
                 if summary.is_pressure_limited_partial_reclaim(deficit_mib, tolerance_mib) {
@@ -3489,7 +3554,11 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                         reason = BALLOON_PRESSURE_LIMITED_REASON,
                         "balloon pressure-limited partial reclaim, proceeding to pause"
                     );
-                    return SandboxParkOutcome::Reusable;
+                    return complete_balloon_settle(
+                        &summary,
+                        BalloonSettleOutcome::PressureLimited,
+                        SandboxParkOutcome::Reusable,
+                    );
                 }
 
                 trace!(
@@ -3528,22 +3597,27 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                     %e,
                     "balloon stats unavailable, proceeding to pause"
                 );
-                return outcome;
+                return complete_balloon_settle(
+                    &summary,
+                    BalloonSettleOutcome::StatsUnavailable,
+                    outcome,
+                );
             }
             Err(_) => {
                 let outcome = summary.park_outcome();
                 log_balloon_settle_timeout(log_id, target_mib, tolerance_mib, &summary, outcome);
-                return outcome;
+                return complete_balloon_settle(&summary, BalloonSettleOutcome::Deadline, outcome);
             }
         }
 
-        let next_poll = tokio::time::Instant::now() + BALLOON_SETTLE_POLL;
+        let next_poll = tokio::time::Instant::now() + poll_interval;
         tokio::time::sleep_until(if next_poll < deadline {
             next_poll
         } else {
             deadline
         })
         .await;
+        poll_interval = poll_interval.saturating_mul(2).min(BALLOON_SETTLE_MAX_POLL);
     }
 }
 
@@ -3598,6 +3672,12 @@ async fn park_inner(
         // savings.
         wait_for_balloon(&client, target, log_id).await
     } else {
+        emit_balloon_settle_summary(
+            BalloonSettleOutcome::SkippedZeroTarget,
+            0,
+            0,
+            SandboxParkOutcome::Reusable,
+        );
         SandboxParkOutcome::Reusable
     };
 

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -4153,6 +4153,7 @@ async fn wait_for_balloon_caps_adaptive_polling_at_14_samples() {
             stats: MockBalloonStats::new(target_mib, 0),
         })
         .take(14)
+        .chain(std::iter::once(MockBalloonStatsReply::Status(500)))
         .collect(),
     );
     let client = ApiClient::new(api.socket_path()).unwrap();

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -3776,6 +3776,7 @@ where
     let guard = tracing::subscriber::set_default(subscriber);
     tracing::callsite::rebuild_interest_cache();
     tokio::pin!(future);
+    tokio::time::pause();
 
     loop {
         if has_captured_event(&captured.entries(), "waiting for balloon") {
@@ -3789,7 +3790,6 @@ where
         }
     }
 
-    tokio::time::pause();
     tokio::time::advance(BALLOON_SETTLE_TIMEOUT).await;
     tokio::time::resume();
     let output = future.await;
@@ -4092,6 +4092,7 @@ async fn wait_for_balloon_rechecks_after_initial_25_ms_delay() {
     let subscriber = tracing_subscriber::registry().with(captured.clone());
     let guard = tracing::subscriber::set_default(subscriber);
     tracing::callsite::rebuild_interest_cache();
+    tokio::time::pause();
     let wait = wait_for_balloon(&client, target_mib, "fast-start");
     tokio::pin!(wait);
 
@@ -4116,7 +4117,6 @@ async fn wait_for_balloon_rechecks_after_initial_25_ms_delay() {
         1
     );
 
-    tokio::time::pause();
     tokio::time::advance(Duration::from_millis(24)).await;
     assert!(
         api.drain_requests().is_empty(),
@@ -4143,11 +4143,17 @@ async fn wait_for_balloon_rechecks_after_initial_25_ms_delay() {
 #[tokio::test]
 async fn wait_for_balloon_caps_adaptive_polling_at_14_samples() {
     let target_mib = 2048 - balloon::MIN_GUEST_MIB;
+    let request_entered = Arc::new(Notify::new());
+    let response_release = Arc::new(Notify::new());
     let mut api = MockLifecycleApi::with_stats(
         std::collections::VecDeque::new(),
-        std::collections::VecDeque::from([MockBalloonStatsReply::Ok(MockBalloonStats::new(
-            target_mib, 0,
-        ))]),
+        std::iter::repeat_with(|| MockBalloonStatsReply::GatedOk {
+            entered: Arc::clone(&request_entered),
+            release: Arc::clone(&response_release),
+            stats: MockBalloonStats::new(target_mib, 0),
+        })
+        .take(14)
+        .collect(),
     );
     let client = ApiClient::new(api.socket_path()).unwrap();
     let captured = CapturedEvents::default();
@@ -4157,40 +4163,42 @@ async fn wait_for_balloon_caps_adaptive_polling_at_14_samples() {
     let wait = wait_for_balloon(&client, target_mib, "bounded-schedule");
     tokio::pin!(wait);
 
-    loop {
-        let sample_count = captured_message_count(&captured.entries(), "waiting for balloon");
-        if sample_count == 1 {
-            break;
-        }
-        tokio::select! {
-            outcome = &mut wait => {
-                panic!("balloon wait completed before the first deficient sample: {outcome:?}");
-            }
-            () = tokio::task::yield_now() => {}
-        }
-    }
-
-    tokio::time::pause();
     for (index, delay_ms) in [
-        25_u64, 50, 100, 200, 400, 500, 500, 500, 500, 500, 500, 500, 500,
+        0_u64, 25, 50, 100, 200, 400, 500, 500, 500, 500, 500, 500, 500, 500,
     ]
     .into_iter()
     .enumerate()
     {
-        tokio::time::advance(Duration::from_millis(delay_ms - 1)).await;
-        assert!(
-            futures_util::poll!(wait.as_mut()).is_pending(),
-            "balloon wait completed before the scheduled sample {}",
-            index + 2
-        );
-        assert_eq!(
-            captured_message_count(&captured.entries(), "waiting for balloon"),
-            index + 1,
-            "statistics GET began before the scheduled delay of {delay_ms} ms"
-        );
-        tokio::time::advance(Duration::from_millis(1)).await;
-        tokio::time::resume();
-        let expected_sample_count = index + 2;
+        if delay_ms > 0 {
+            tokio::time::advance(Duration::from_millis(delay_ms - 1)).await;
+            assert!(
+                futures_util::poll!(wait.as_mut()).is_pending(),
+                "balloon wait completed before scheduled sample {}",
+                index + 1
+            );
+            assert_eq!(
+                captured_message_count(&captured.entries(), "waiting for balloon"),
+                index,
+                "statistics GET began before the scheduled delay of {delay_ms} ms"
+            );
+            tokio::time::advance(Duration::from_millis(1)).await;
+            tokio::time::resume();
+        }
+        loop {
+            tokio::select! {
+                () = request_entered.notified() => break,
+                outcome = &mut wait => {
+                    panic!(
+                        "balloon wait completed before statistics request {}; outcome={outcome:?}",
+                        index + 1
+                    );
+                }
+                () = tokio::task::yield_now() => {}
+            }
+        }
+        tokio::time::pause();
+        response_release.notify_one();
+        let expected_sample_count = index + 1;
         loop {
             let sample_count = captured_message_count(&captured.entries(), "waiting for balloon");
             if sample_count == expected_sample_count {
@@ -4205,7 +4213,6 @@ async fn wait_for_balloon_caps_adaptive_polling_at_14_samples() {
                 () = tokio::task::yield_now() => {}
             }
         }
-        tokio::time::pause();
     }
 
     tokio::time::advance(BALLOON_SETTLE_TIMEOUT).await;

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -3821,6 +3821,65 @@ fn assert_event_field(event: &CapturedEvent, field: &str, expected: &str) {
     assert_eq!(actual, expected, "field {field} mismatch; event={event:#?}");
 }
 
+fn captured_message_count(events: &[CapturedEvent], message: &str) -> usize {
+    events
+        .iter()
+        .filter(|event| {
+            event
+                .fields
+                .get("message")
+                .is_some_and(|actual| actual == message)
+        })
+        .count()
+}
+
+fn assert_balloon_settle_summary(
+    events: &[CapturedEvent],
+    outcome: &str,
+    sample_count: u32,
+    admission_action: &str,
+) {
+    let summaries: Vec<_> = events
+        .iter()
+        .filter(|event| {
+            event
+                .fields
+                .get("message")
+                .is_some_and(|message| message == "balloon settle completed")
+        })
+        .collect();
+    assert_eq!(
+        summaries.len(),
+        1,
+        "expected exactly one balloon settle summary; events={events:#?}"
+    );
+
+    let summary = summaries[0];
+    assert_eq!(summary.level, Level::INFO);
+    assert_eq!(
+        summary
+            .fields
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        [
+            "admission_action",
+            "elapsed_ms",
+            "measurement",
+            "message",
+            "outcome",
+            "sample_count",
+        ],
+        "canonical summary must remain bounded and identifier-free"
+    );
+    assert_event_field(summary, "measurement", "balloon_settle");
+    assert_event_field(summary, "outcome", outcome);
+    assert_event_field(summary, "sample_count", &sample_count.to_string());
+    assert_event_field(summary, "admission_action", admission_action);
+    assert_eq!(summary.field_kinds.get("elapsed_ms"), Some(&"u64"));
+    assert_eq!(summary.field_kinds.get("sample_count"), Some(&"u64"));
+}
+
 #[test]
 fn exec_capture_request_preserves_stable_operation_label() {
     let stdin = [1, 2, 3];
@@ -4019,6 +4078,157 @@ fn balloon_statistics(target_mib: u32, actual_mib: u32) -> BalloonStatistics {
 }
 
 #[tokio::test]
+async fn wait_for_balloon_rechecks_after_initial_25_ms_delay() {
+    let target_mib = 2048 - balloon::MIN_GUEST_MIB;
+    let mut api = MockLifecycleApi::with_stats(
+        std::collections::VecDeque::new(),
+        std::collections::VecDeque::from([
+            MockBalloonStatsReply::Ok(MockBalloonStats::new(target_mib, 0)),
+            MockBalloonStatsReply::Ok(MockBalloonStats::new(target_mib, target_mib)),
+        ]),
+    );
+    let client = ApiClient::new(api.socket_path()).unwrap();
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    let wait = wait_for_balloon(&client, target_mib, "fast-start");
+    tokio::pin!(wait);
+
+    loop {
+        if captured_message_count(&captured.entries(), "waiting for balloon") == 1 {
+            break;
+        }
+        tokio::select! {
+            outcome = &mut wait => {
+                panic!("balloon wait completed before the first deficient sample: {outcome:?}");
+            }
+            () = tokio::task::yield_now() => {}
+        }
+    }
+
+    let mut requests = api.drain_requests();
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| request.method == "GET" && request.path == "/balloon/statistics")
+            .count(),
+        1
+    );
+
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_millis(24)).await;
+    assert!(
+        api.drain_requests().is_empty(),
+        "the second statistics GET must not begin before 25 ms"
+    );
+
+    tokio::time::advance(Duration::from_millis(1)).await;
+    tokio::time::resume();
+    let outcome = wait.await;
+    drop(guard);
+
+    assert_eq!(outcome, SandboxParkOutcome::Reusable);
+    requests.extend(api.drain_requests());
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| request.method == "GET" && request.path == "/balloon/statistics")
+            .count(),
+        2
+    );
+    assert_balloon_settle_summary(&captured.entries(), "target_reached", 2, "reuse");
+}
+
+#[tokio::test]
+async fn wait_for_balloon_caps_adaptive_polling_at_14_samples() {
+    let target_mib = 2048 - balloon::MIN_GUEST_MIB;
+    let mut api = MockLifecycleApi::with_stats(
+        std::collections::VecDeque::new(),
+        std::collections::VecDeque::from([MockBalloonStatsReply::Ok(MockBalloonStats::new(
+            target_mib, 0,
+        ))]),
+    );
+    let client = ApiClient::new(api.socket_path()).unwrap();
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    let wait = wait_for_balloon(&client, target_mib, "bounded-schedule");
+    tokio::pin!(wait);
+
+    loop {
+        let sample_count = captured_message_count(&captured.entries(), "waiting for balloon");
+        if sample_count == 1 {
+            break;
+        }
+        tokio::select! {
+            outcome = &mut wait => {
+                panic!("balloon wait completed before the first deficient sample: {outcome:?}");
+            }
+            () = tokio::task::yield_now() => {}
+        }
+    }
+
+    tokio::time::pause();
+    for (index, delay_ms) in [
+        25_u64, 50, 100, 200, 400, 500, 500, 500, 500, 500, 500, 500, 500,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        tokio::time::advance(Duration::from_millis(delay_ms - 1)).await;
+        assert!(
+            futures_util::poll!(wait.as_mut()).is_pending(),
+            "balloon wait completed before the scheduled sample {}",
+            index + 2
+        );
+        assert_eq!(
+            captured_message_count(&captured.entries(), "waiting for balloon"),
+            index + 1,
+            "statistics GET began before the scheduled delay of {delay_ms} ms"
+        );
+        tokio::time::advance(Duration::from_millis(1)).await;
+        tokio::time::resume();
+        let expected_sample_count = index + 2;
+        loop {
+            let sample_count = captured_message_count(&captured.entries(), "waiting for balloon");
+            if sample_count == expected_sample_count {
+                break;
+            }
+            tokio::select! {
+                outcome = &mut wait => {
+                    panic!(
+                        "balloon wait completed after {sample_count} samples, expected {expected_sample_count}; outcome={outcome:?}"
+                    );
+                }
+                () = tokio::task::yield_now() => {}
+            }
+        }
+        tokio::time::pause();
+    }
+
+    tokio::time::advance(BALLOON_SETTLE_TIMEOUT).await;
+    tokio::time::resume();
+    let outcome = wait.await;
+    drop(guard);
+
+    assert_eq!(
+        outcome,
+        SandboxParkOutcome::NonReusable(SandboxParkNonReusableReason::SevereMemoryRetention)
+    );
+    let requests = api.drain_requests();
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| request.method == "GET" && request.path == "/balloon/statistics")
+            .count(),
+        14
+    );
+    assert_balloon_settle_summary(&captured.entries(), "deadline", 14, "reject_and_destroy");
+}
+
+#[tokio::test]
 async fn wait_for_balloon_near_target_logs_summary_without_timeout() {
     let target_mib = 4096 - balloon::MIN_GUEST_MIB;
     let api = MockLifecycleApi::with_stats(
@@ -4053,6 +4263,7 @@ async fn wait_for_balloon_near_target_logs_summary_without_timeout() {
     assert_event_field(event, "first_actual_mib", "Some(3545)");
     assert_event_field(event, "max_actual_mib", "Some(3545)");
     assert_event_field(event, "actual_delta_mib", "Some(0)");
+    assert_balloon_settle_summary(&events, "within_tolerance", 1, "reuse");
 }
 
 #[tokio::test]
@@ -4087,6 +4298,7 @@ async fn wait_for_balloon_timeout_logs_actual_stalled_reason() {
     assert_event_field(event, "actual_delta_mib", "Some(0)");
     assert_event_field(event, "reason", "actual_stalled");
     assert_event_field(event, "admission_action", "reuse");
+    assert_balloon_settle_summary(&events, "deadline", 1, "reuse");
 }
 
 #[tokio::test]
@@ -4121,6 +4333,7 @@ async fn wait_for_balloon_accepts_pressure_limited_partial_reclaim() {
     assert_event_field(event, "reported_free_mib", "Some(64)");
     assert_event_field(event, "reported_available_mib", "Some(128)");
     assert_event_field(event, "reason", "pressure_limited_partial_reclaim");
+    assert_balloon_settle_summary(&events, "pressure_limited", 1, "reuse");
 }
 
 #[test]
@@ -4208,6 +4421,7 @@ async fn wait_for_balloon_timeout_logs_target_not_observed_reason() {
     assert_event_field(event, "target_observed", "false");
     assert_event_field(event, "observed_target_mib", "Some(1024)");
     assert_event_field(event, "reason", "target_not_observed");
+    assert_balloon_settle_summary(&events, "deadline", 1, "reuse");
 }
 
 #[tokio::test]
@@ -4254,6 +4468,7 @@ async fn wait_for_balloon_stats_poll_is_bounded_by_settle_timeout() {
     assert_event_field(event, "reason", "stats_unavailable");
     assert_event_field(event, "actual", "None");
     assert_event_field(event, "deficit_mib", "None");
+    assert_balloon_settle_summary(&events, "deadline", 0, "reuse");
 }
 
 #[tokio::test]
@@ -4285,6 +4500,7 @@ async fn wait_for_balloon_timeout_logs_severe_deficit_and_memory_stats() {
     assert_event_field(event, "reported_total_mib", "Some(2048)");
     assert_event_field(event, "reason", "severe_deficit");
     assert_event_field(event, "admission_action", "reject_and_destroy");
+    assert_balloon_settle_summary(&events, "deadline", 1, "reject_and_destroy");
 }
 
 #[tokio::test]
@@ -4313,6 +4529,7 @@ async fn park_pauses_when_balloon_stats_are_unavailable() {
     assert_event_field(event, "deficit_mib", "None");
     assert_event_field(event, "sample_count", "0");
     assert_event_field(event, "reason", "stats_unavailable");
+    assert_balloon_settle_summary(&events, "stats_unavailable", 0, "reuse");
 
     let reqs = api.drain_requests();
     let ps = patches(&reqs);
@@ -4556,15 +4773,15 @@ async fn park_small_vm_skips_balloon_but_pauses_vcpus() {
     let mut controller = Some(original_controller);
     let mut is_parked = false;
 
-    park_inner(
+    let (result, events) = capture_async_log_events(park_inner(
         &mut is_parked,
         512,
         &mut controller,
         api.socket_path(),
         "test-park-small",
-    )
-    .await
-    .unwrap();
+    ))
+    .await;
+    result.unwrap();
 
     assert!(is_parked, "is_parked should be set");
     let still_there = controller.as_ref().expect("controller must be preserved");
@@ -4579,6 +4796,7 @@ async fn park_small_vm_skips_balloon_but_pauses_vcpus() {
     assert_eq!(ps.len(), 1, "expected only vm pause, no balloon PATCH");
     assert_eq!(ps[0].path, "/vm");
     assert!(ps[0].body.contains("Paused"));
+    assert_balloon_settle_summary(&events, "skipped_zero_target", 0, "reuse");
 }
 
 #[tokio::test]
@@ -4890,13 +5108,13 @@ async fn park_balloon_failure_leaves_flag_false() {
     let mut controller = Some(test_balloon_controller());
     let mut is_parked = false;
 
-    let result = park_inner(
+    let (result, events) = capture_async_log_events(park_inner(
         &mut is_parked,
         2048,
         &mut controller,
         api.socket_path(),
         "test-park-fail",
-    )
+    ))
     .await;
 
     assert_idle_transition(result, SandboxIdleTransition::Park);
@@ -4907,6 +5125,10 @@ async fn park_balloon_failure_leaves_flag_false() {
     let ps = patches(&reqs);
     assert_eq!(ps.len(), 1, "only balloon inflate should be attempted");
     assert_eq!(ps[0].path, "/balloon");
+    assert!(
+        !has_captured_event(&events, "balloon settle completed"),
+        "PATCH failure occurs before settlement and must not emit a completed summary"
+    );
 
     // A follow-up unpark must be a clean no-op because is_parked is false.
     let (_state_tx, state_rx) = watch::channel(SandboxState::Running);
@@ -5038,13 +5260,13 @@ async fn park_pause_http_400_propagates_as_idle_transition() {
     let mut controller = Some(test_balloon_controller());
     let mut is_parked = false;
 
-    let result = park_inner(
+    let (result, events) = capture_async_log_events(park_inner(
         &mut is_parked,
         2048,
         &mut controller,
         api.socket_path(),
         "pause-fail",
-    )
+    ))
     .await;
 
     assert_idle_transition_message(
@@ -5061,6 +5283,7 @@ async fn park_pause_http_400_propagates_as_idle_transition() {
     assert_eq!(ps.len(), 2);
     assert_eq!(ps[0].path, "/balloon");
     assert_eq!(ps[1].path, "/vm");
+    assert_balloon_settle_summary(&events, "stats_unavailable", 1, "reject_and_destroy");
 }
 
 #[tokio::test]
@@ -5424,13 +5647,13 @@ async fn park_small_vm_pause_failure_preserves_controller() {
     let mut controller = Some(original_controller);
     let mut is_parked = false;
 
-    let result = park_inner(
+    let (result, events) = capture_async_log_events(park_inner(
         &mut is_parked,
         512,
         &mut controller,
         api.socket_path(),
         "small-fail",
-    )
+    ))
     .await;
 
     assert_idle_transition(result, SandboxIdleTransition::Park);
@@ -5443,4 +5666,5 @@ async fn park_small_vm_pause_failure_preserves_controller() {
         original_id,
         "controller must not be replaced or aborted"
     );
+    assert_balloon_settle_summary(&events, "skipped_zero_target", 0, "reuse");
 }


### PR DESCRIPTION
## Summary

- replace the fixed 500 ms Firecracker balloon-settle sleep with a 25/50/100/200/400 ms fast
  start capped at 500 ms under the existing five-second deadline
- emit one identifier-free terminal balloon summary through an exact INFO target in the runner's
  existing bounded, non-blocking Axiom layer
- cover the exact cadence, 14-request upper bound, all settle classifications, zero-target skip,
  PATCH/pause boundaries, and Axiom filtering/serialization

## Compatibility

- preserves balloon targets, tolerances, pressure handling, severe-retention rejection, and the
  absolute request/sleep deadline
- preserves balloon-before-pause ordering and keeps a completed settle summary distinct from a
  later pause failure
- changes no API, guest, Poll, Ably, claim, runner preference, database, persisted state, idle
  admission, workspace, ownership, or fallback contract
- old and new runners can overlap because each sandbox remains process-owned and returns the same
  park outcome contract

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox-fc -p runner --all-features --no-deps`
- `cargo test -p sandbox-fc --all-targets --all-features`
- `cargo test -p runner --bin runner --all-features`
- `lefthook run pre-commit`

Closes #25065

Parent: #25045
