### PR TITLE
fix(sandbox-fc): stabilize root veth mac identity

### DIFF
--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -505,6 +505,37 @@ RUNNER_VETH_PREFIX=${RUNNER_POOL_PREFIX/vm0-ns-/vm0-ve-}
 ATTACKER_IF=${ATTACKER_NS/vm0-ns-/vm0-ve-}
 VICTIM_IF=${VICTIM_NS/vm0-ns-/vm0-ve-}
 
+ATTACKER_POOL_HEX=${ATTACKER_NS#vm0-ns-}
+ATTACKER_POOL_HEX=${ATTACKER_POOL_HEX%-*}
+ATTACKER_NAMESPACE_HEX=${ATTACKER_NS##*-}
+ATTACKER_EXPECTED_ROOT_MAC="02:56:4d:${ATTACKER_POOL_HEX}:${ATTACKER_NAMESPACE_HEX}:01"
+ATTACKER_UDEV_PROPERTIES=""
+for _ in $(seq 1 100); do
+  ATTACKER_UDEV_PROPERTIES=$(sudo udevadm info --query=property \
+    --path="/sys/class/net/${ATTACKER_IF}" 2>/dev/null || true)
+  if printf '%s\n' "$ATTACKER_UDEV_PROPERTIES" \
+    | grep -F -- "ID_NET_LINK_FILE=" >/dev/null; then
+    break
+  fi
+  sleep 0.05
+done
+ATTACKER_LINK_FILE=$(printf '%s\n' "$ATTACKER_UDEV_PROPERTIES" \
+  | sed -n 's/^ID_NET_LINK_FILE=//p' \
+  | head -n 1)
+[ -n "$ATTACKER_LINK_FILE" ] \
+  || fail "udev did not record link processing for $ATTACKER_IF"
+ATTACKER_ROOT_MAC=$(sudo ip -j link show dev "$ATTACKER_IF" \
+  | jq -r '.[0].address // empty') \
+  || fail "failed to read root veth MAC: $ATTACKER_IF"
+[ "$ATTACKER_ROOT_MAC" = "$ATTACKER_EXPECTED_ROOT_MAC" ] \
+  || fail "root veth MAC changed after udev processing: device=$ATTACKER_IF link_file=$ATTACKER_LINK_FILE expected=$ATTACKER_EXPECTED_ROOT_MAC actual=$ATTACKER_ROOT_MAC"
+ATTACKER_ROOT_ADDR_ASSIGN_TYPE=$(sudo cat \
+  "/sys/class/net/${ATTACKER_IF}/addr_assign_type") \
+  || fail "failed to read root veth address assignment type: $ATTACKER_IF"
+[ "$ATTACKER_ROOT_ADDR_ASSIGN_TYPE" = 3 ] \
+  || fail "root veth MAC is not userspace-set: device=$ATTACKER_IF addr_assign_type=$ATTACKER_ROOT_ADDR_ASSIGN_TYPE"
+echo "PASS: root veth MAC remains stable after udev processing"
+
 ATTACKER_PROXY_RULE=$(printf '%s\n' "$PROXY_RULES" \
   | grep -F -- "$ATTACKER_NS" \
   | head -n 1 || true)

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -177,6 +177,7 @@ async fn create_netns_with_tap(
 async fn setup_veth_pair(
     name: &str,
     host_device: &str,
+    host_mac: &str,
     host_ip: &str,
     peer_ip: &str,
 ) -> Result<()> {
@@ -186,6 +187,8 @@ async fn setup_veth_pair(
         "link",
         "add",
         host_device,
+        "address",
+        host_mac,
         "type",
         "veth",
         "peer",
@@ -605,6 +608,7 @@ pub(super) async fn create_single_namespace(
     let ns_idx_str = format_hex_index(ns_index);
     let ns_name = make_ns_name(&pool_idx_str, &ns_idx_str);
     let host_device = make_host_device(&pool_idx_str, &ns_idx_str);
+    let host_mac = format!("02:56:4d:{pool_idx_str}:{ns_idx_str}:01");
     let (host_ip, peer_ip) = generate_veth_ip_pair(pool_index, ns_index);
 
     info!(name = %ns_name, proxy = proxy_port.is_some(), "creating namespace");
@@ -613,6 +617,7 @@ pub(super) async fn create_single_namespace(
     let result = create_namespace_inner(
         &ns_name,
         &host_device,
+        &host_mac,
         &host_ip,
         &peer_ip,
         sn,
@@ -668,6 +673,7 @@ pub(super) async fn create_single_namespace(
 async fn create_namespace_inner(
     name: &str,
     host_device: &str,
+    host_mac: &str,
     host_ip: &str,
     peer_ip: &str,
     sn: &GuestNetwork,
@@ -675,7 +681,7 @@ async fn create_namespace_inner(
 ) -> Result<()> {
     let gw_with_prefix = format!("{}/{}", sn.gateway_ip, sn.prefix_len);
     create_netns_with_tap(name, sn.tap_name, sn.tap_mac, &gw_with_prefix).await?;
-    setup_veth_pair(name, host_device, host_ip, peer_ip).await?;
+    setup_veth_pair(name, host_device, host_mac, host_ip, peer_ip).await?;
     setup_namespace_routing(name, host_ip, sn.gateway_ip, sn.prefix_len).await?;
     apply_namespace_rules(name, host_device, peer_ip, firewall_config).await?;
 

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -608,6 +608,8 @@ pub(super) async fn create_single_namespace(
     let ns_idx_str = format_hex_index(ns_index);
     let ns_name = make_ns_name(&pool_idx_str, &ns_idx_str);
     let host_device = make_host_device(&pool_idx_str, &ns_idx_str);
+    // Pool and namespace bytes keep the root-veth MAC unique on this host.
+    // Supplying it in RTM_NEWLINK prevents a later udev rewrite after neighbor learning.
     let host_mac = format!("02:56:4d:{pool_idx_str}:{ns_idx_str}:01");
     let (host_ip, peer_ip) = generate_veth_ip_pair(pool_index, ns_index);
 


### PR DESCRIPTION
## Summary

- assign every root-side runner veth a deterministic locally administered MAC in the existing link-create request
- keep the namespace-side veth kernel-generated and add no runtime udev wait, retry, or host configuration
- verify on metal that udev has processed the root link without changing the runner-owned MAC before exercising the existing DNS path

## Exclusions

- no API, schema, queue, snapshot, persisted-state, or deployment protocol changes
- no host `.link` rule, neighbor repair, timeout increase, or additional readiness retry

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox-fc --all-features --no-deps`
- `cargo test -p sandbox-fc --all-targets --all-features`
- `bash -n .github/scripts/runner-behavior-exec.sh`
- `shellcheck .github/scripts/runner-behavior-exec.sh`

The Crates metal lane provides the authoritative systemd-udev integration validation.

Closes #25068
