### PR TITLE
perf(runner): measure reserved reuse claims

### DIFF
--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -24,7 +24,7 @@ use tracing_subscriber::filter::{self, FilterFn};
 use tracing_subscriber::layer::{Context, Layer};
 use tracing_subscriber::registry::LookupSpan;
 
-use crate::telemetry::PRE_PARK_HANDOFF_AXIOM_TARGET;
+use crate::telemetry::{PRE_PARK_HANDOFF_AXIOM_TARGET, RESERVED_REUSE_CLAIM_AXIOM_TARGET};
 
 /// Bounded-channel capacity between tracing callers and the dispatcher task.
 /// WARN+ and the selected-candidate measurement events are low-volume, so 1024
@@ -172,13 +172,14 @@ pub(crate) struct AxiomLayer {
 }
 
 fn should_ingest(metadata: &Metadata<'_>) -> bool {
-    // Errors and warnings remain the general threshold. Two exact INFO targets
+    // Errors and warnings remain the general threshold. Three exact INFO targets
     // carry bounded production measurements that have no authenticated
     // per-job telemetry owner. DEBUG/TRACE and all other INFO events stay
     // local-only.
     (*metadata.level() <= tracing::Level::WARN && metadata.target() != INTERNAL_TARGET)
         || (*metadata.level() == tracing::Level::INFO
             && (metadata.target() == PRE_PARK_HANDOFF_AXIOM_TARGET
+                || metadata.target() == RESERVED_REUSE_CLAIM_AXIOM_TARGET
                 || metadata.target() == BALLOON_SETTLE_AXIOM_TARGET))
 }
 

--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -18,7 +18,7 @@ use tracing::field::{Field, Visit};
 use tracing::{Event, Subscriber};
 use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
 
-use crate::telemetry::PRE_PARK_HANDOFF_AXIOM_TARGET;
+use crate::telemetry::{PRE_PARK_HANDOFF_AXIOM_TARGET, RESERVED_REUSE_CLAIM_AXIOM_TARGET};
 
 #[derive(Clone, Debug)]
 struct RecordedEvent {
@@ -194,6 +194,24 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
             "allowlisted target below INFO"
         );
         tracing::info!(
+            target: RESERVED_REUSE_CLAIM_AXIOM_TARGET,
+            measurement = "reserved_reuse_claim",
+            outcome = "claimed",
+            run_id = "00000000-0000-0000-0000-000000000001",
+            duration_ms = 42_u64,
+            preference_reason = "none",
+            timezone_state = "absent",
+            "reserved reusable claim observed"
+        );
+        tracing::debug!(
+            target: RESERVED_REUSE_CLAIM_AXIOM_TARGET,
+            "reserved reuse target below INFO"
+        );
+        tracing::info!(
+            target: "runner::reserved_reuse_claim::detail",
+            "reserved reuse sibling INFO target"
+        );
+        tracing::info!(
             target: BALLOON_SETTLE_AXIOM_TARGET,
             measurement = "balloon_settle",
             outcome = "target_reached",
@@ -236,6 +254,13 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
     let measurement = event_with_message(&events, "allowlisted measurement");
     assert_eq!(measurement["level"], json!("info"));
     assert_eq!(measurement["outcome"], json!("retained"));
+    let reserved_reuse = event_with_message(&events, "reserved reusable claim observed");
+    assert_eq!(reserved_reuse["level"], json!("info"));
+    assert_eq!(reserved_reuse["measurement"], json!("reserved_reuse_claim"));
+    assert_eq!(reserved_reuse["outcome"], json!("claimed"));
+    assert_eq!(reserved_reuse["duration_ms"], json!(42));
+    assert_eq!(reserved_reuse["preference_reason"], json!("none"));
+    assert_eq!(reserved_reuse["timezone_state"], json!("absent"));
     let balloon = event_with_message(&events, "balloon settle completed");
     assert_eq!(balloon["level"], json!("info"));
     assert_eq!(balloon["measurement"], json!("balloon_settle"));
@@ -250,6 +275,14 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
     assert!(
         !has_event_with_message(&events, "allowlisted target below INFO"),
         "allowlisted DEBUG event should not be ingested: {events:#?}",
+    );
+    assert!(
+        !has_event_with_message(&events, "reserved reuse target below INFO"),
+        "reserved-reuse DEBUG event should not be ingested: {events:#?}",
+    );
+    assert!(
+        !has_event_with_message(&events, "reserved reuse sibling INFO target"),
+        "reserved-reuse sibling INFO event should not be ingested: {events:#?}",
     );
     assert!(
         !has_event_with_message(&events, "balloon target below INFO"),

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -470,6 +470,9 @@ async fn claim_with_local_admission(
     let observed_candidate =
         is_selected_finalizing_candidate(&candidate, ctx.runner_id, ctx.heartbeat_generation)
             .then(|| candidate.clone());
+    if matches!(&admission.resource, LocalAdmissionResource::Reusable(_)) {
+        candidate.mark_reserved_reuse_claim_started();
+    }
     let Some(claimed) = ctx.spawn_ctx.provider.claim(candidate).await else {
         // None means the job won't run here: either lost the race to another
         // runner, or the provider rejected the job. Release the reservation and

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -147,6 +147,14 @@ fn context_with_reuse_key(run_id: RunId, reuse_key: &str) -> crate::types::Execu
     context
 }
 
+fn reserved_reuse_claim_preference(
+    candidate: &crate::provider::JobCandidate,
+) -> Option<&'static str> {
+    candidate
+        .reserved_reuse_claim_observation()
+        .map(crate::provider::ReservedReuseClaimObservation::preference_reason)
+}
+
 /// TOCTOU regression: soft drain can arrive after the main loop has selected
 /// a discovered candidate but before claim. The candidate is still unowned at
 /// that point, so Draining must roll back local admission and skip claim.
@@ -281,6 +289,17 @@ async fn claim_failure_rolls_back_budget() {
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     wait_cancel_token_removed(&env.cancel_tokens, run_id_1, Duration::from_secs(5)).await;
     assert_eq!(budget.allocated().2, 0);
+    let fresh_candidate = env
+        .handle
+        .claim_candidates()
+        .into_iter()
+        .find(|candidate| candidate.run_id() == run_id_1)
+        .expect("fresh candidate should reach the provider claim");
+    assert_eq!(
+        reserved_reuse_claim_preference(&fresh_candidate),
+        None,
+        "fresh admission must stay outside the reserved-reuse claim cohort"
+    );
     // Second job: claim succeeds — budget should have been freed.
     let run_id_2 = RunId::new_v4();
     push_job(
@@ -416,6 +435,23 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
         .await
         .expect("restored idle reservation should serve the next claim");
     assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    let claim_candidates = env.handle.claim_candidates();
+    let exact_candidate = claim_candidates
+        .iter()
+        .find(|candidate| candidate.run_id() == conflict_run_id)
+        .expect("exact candidate should reach the provider claim");
+    assert_eq!(
+        reserved_reuse_claim_preference(exact_candidate),
+        Some("exact_history_generation")
+    );
+    let matching_candidate = claim_candidates
+        .iter()
+        .find(|candidate| candidate.run_id() == followup_run_id)
+        .expect("matching candidate should reach the provider claim");
+    assert_eq!(
+        reserved_reuse_claim_preference(matching_candidate),
+        Some("matching_reuse_key")
+    );
     shutdown(&env, run_handle).await;
 }
 
@@ -444,6 +480,41 @@ async fn matching_preference_reservation_is_restored_after_claim_conflict() {
         "lost claim should restore the generic reusable reservation"
     );
     assert_eq!(budget.allocated(), (2, 4096, 1));
+
+    let ordinary_run_id = RunId::new_v4();
+    env.provider.set_claim_result(ordinary_run_id, None);
+    env.handle
+        .discover_tx
+        .send(
+            crate::provider::JobCandidate::new(ordinary_run_id, "vm0/default".into())
+                .with_reuse_key(Some(session_id.to_owned())),
+        )
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    wait_cancel_token_removed(&env.cancel_tokens, ordinary_run_id, Duration::from_secs(5)).await;
+
+    let claim_candidates = env.handle.claim_candidates();
+    let matching_candidate = claim_candidates
+        .iter()
+        .find(|candidate| candidate.run_id() == run_id)
+        .expect("matching candidate should reach the provider claim");
+    assert_eq!(
+        reserved_reuse_claim_preference(matching_candidate),
+        Some("matching_reuse_key")
+    );
+    let ordinary_candidate = claim_candidates
+        .iter()
+        .find(|candidate| candidate.run_id() == ordinary_run_id)
+        .expect("ordinary reuse-key candidate should reach the provider claim");
+    assert_eq!(
+        reserved_reuse_claim_preference(ordinary_candidate),
+        Some("none")
+    );
+    assert_eq!(
+        idle_pool.lock().await.held_reuse_keys(),
+        vec![session_id.to_string()],
+        "ordinary lost claim should also restore the reusable reservation"
+    );
 
     shutdown(&env, run_handle).await;
 }
@@ -739,6 +810,16 @@ async fn selected_finalizing_candidate_records_claim_loss_and_restores_exact_res
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
     assert_candidate_observation(&captured, run_id, history_generation_run_id, "claim_lost");
+    let claimed_candidate = env
+        .handle
+        .claim_candidates()
+        .into_iter()
+        .find(|candidate| candidate.run_id() == run_id)
+        .expect("finalizing candidate should reach the provider claim");
+    assert_eq!(
+        reserved_reuse_claim_preference(&claimed_candidate),
+        Some("finalizing_predecessor")
+    );
     assert_eq!(
         env.idle_pool.lock().await.held_reuse_keys(),
         vec![reuse_key.to_string()],

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -32,7 +32,7 @@ use super::builtin_firewall_catalog::{
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
-    parse_runner_preference,
+    ReservedReuseClaimObservation, parse_runner_preference,
 };
 use crate::active_input::{ActiveInputNotifications, ActiveInputSource};
 use crate::duration::duration_ms;
@@ -40,6 +40,7 @@ use crate::error::{ApiStatusError, RunnerError, RunnerResult};
 use crate::http::{ApiRequestBuilder, HttpClient};
 use crate::ids::RunId;
 use crate::run_cancellation::RunCancellationRegistry;
+use crate::telemetry::RESERVED_REUSE_CLAIM_AXIOM_TARGET;
 use crate::types::{
     CompleteRequest, ExecutionContext, HeartbeatState, Job, NetworkPolicyRefreshBatchResponse,
     PollResponse, SandboxReuseResult,
@@ -173,6 +174,80 @@ struct ClaimFailureDecision {
     status: Option<StatusCode>,
     transport_kind: Option<&'static str>,
     response_run_id: Option<RunId>,
+}
+
+enum ReservedReuseClaimOutcome {
+    Claimed { timezone_state: &'static str },
+    Unavailable,
+    ProviderFailure { class: ClaimFailureClass },
+    ResponseRunIdMismatch,
+}
+
+fn record_reserved_reuse_claim_observation(
+    observation: Option<ReservedReuseClaimObservation>,
+    run_id: RunId,
+    runner_id: &str,
+    heartbeat_generation: u64,
+    outcome: ReservedReuseClaimOutcome,
+) {
+    let Some(observation) = observation else {
+        return;
+    };
+    let duration_ms = duration_ms(observation.elapsed());
+    let preference_reason = observation.preference_reason();
+
+    match outcome {
+        ReservedReuseClaimOutcome::Claimed { timezone_state } => tracing::info!(
+            target: RESERVED_REUSE_CLAIM_AXIOM_TARGET,
+            measurement = "reserved_reuse_claim",
+            outcome = "claimed",
+            run_id = %run_id,
+            runner_id,
+            heartbeat_generation,
+            runner_version = env!("CARGO_PKG_VERSION"),
+            duration_ms,
+            preference_reason,
+            timezone_state,
+            "reserved reusable claim observed"
+        ),
+        ReservedReuseClaimOutcome::Unavailable => tracing::info!(
+            target: RESERVED_REUSE_CLAIM_AXIOM_TARGET,
+            measurement = "reserved_reuse_claim",
+            outcome = "unavailable",
+            run_id = %run_id,
+            runner_id,
+            heartbeat_generation,
+            runner_version = env!("CARGO_PKG_VERSION"),
+            duration_ms,
+            preference_reason,
+            "reserved reusable claim observed"
+        ),
+        ReservedReuseClaimOutcome::ProviderFailure { class } => tracing::info!(
+            target: RESERVED_REUSE_CLAIM_AXIOM_TARGET,
+            measurement = "reserved_reuse_claim",
+            outcome = "provider_failure",
+            failure_class = class.as_str(),
+            run_id = %run_id,
+            runner_id,
+            heartbeat_generation,
+            runner_version = env!("CARGO_PKG_VERSION"),
+            duration_ms,
+            preference_reason,
+            "reserved reusable claim observed"
+        ),
+        ReservedReuseClaimOutcome::ResponseRunIdMismatch => tracing::info!(
+            target: RESERVED_REUSE_CLAIM_AXIOM_TARGET,
+            measurement = "reserved_reuse_claim",
+            outcome = "response_run_id_mismatch",
+            run_id = %run_id,
+            runner_id,
+            heartbeat_generation,
+            runner_version = env!("CARGO_PKG_VERSION"),
+            duration_ms,
+            preference_reason,
+            "reserved reusable claim observed"
+        ),
+    }
 }
 
 const CLAIM_TELEMETRY_DURATION_MS_MAX: u64 = 9_007_199_254_740_991;
@@ -642,6 +717,7 @@ impl JobProvider for ApiProvider {
 
     async fn claim(&self, candidate: JobCandidate) -> Option<ClaimedJob> {
         let run_id = candidate.run_id();
+        let reserved_reuse_observation = candidate.reserved_reuse_claim_observation();
         match self
             .api
             .claim(&candidate, &self.runner_id, self.heartbeat_generation)
@@ -666,6 +742,13 @@ impl JobProvider for ApiProvider {
                 } {
                     Ok(claimed) => claimed,
                     Err(error) => {
+                        record_reserved_reuse_claim_observation(
+                            reserved_reuse_observation,
+                            run_id,
+                            &self.runner_id,
+                            self.heartbeat_generation,
+                            ReservedReuseClaimOutcome::ResponseRunIdMismatch,
+                        );
                         self.record_claim_failure(
                             run_id,
                             ClaimFailureDecision {
@@ -680,6 +763,19 @@ impl JobProvider for ApiProvider {
                         return None;
                     }
                 };
+                record_reserved_reuse_claim_observation(
+                    reserved_reuse_observation,
+                    run_id,
+                    &self.runner_id,
+                    self.heartbeat_generation,
+                    ReservedReuseClaimOutcome::Claimed {
+                        timezone_state: if claimed.context().user_timezone.is_some() {
+                            "present"
+                        } else {
+                            "absent"
+                        },
+                    },
+                );
                 self.claim_cooldowns.remove(run_id).await;
                 info!(
                     run_id = %run_id,
@@ -690,14 +786,30 @@ impl JobProvider for ApiProvider {
                 Some(claimed)
             }
             Ok(None) => {
+                record_reserved_reuse_claim_observation(
+                    reserved_reuse_observation,
+                    run_id,
+                    &self.runner_id,
+                    self.heartbeat_generation,
+                    ReservedReuseClaimOutcome::Unavailable,
+                );
                 self.claim_cooldowns.remove(run_id).await;
                 info!(run_id = %run_id, "job unavailable, skipping");
                 self.poll_wakeups.request_immediate_poll().await;
                 None
             }
             Err(e) => {
-                self.record_claim_failure(run_id, classify_claim_failure(&e))
-                    .await;
+                let decision = classify_claim_failure(&e);
+                record_reserved_reuse_claim_observation(
+                    reserved_reuse_observation,
+                    run_id,
+                    &self.runner_id,
+                    self.heartbeat_generation,
+                    ReservedReuseClaimOutcome::ProviderFailure {
+                        class: decision.class,
+                    },
+                );
+                self.record_claim_failure(run_id, decision).await;
                 None
             }
         }
@@ -1637,7 +1749,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::http::HttpClientConfig;
-    use crate::provider::RunnerPreferenceReason;
+    use crate::provider::{RunnerPreference, RunnerPreferenceReason};
 
     const RUNNER_CLAIM_RESPONSE_FIXTURE: &str = include_str!(
         "../../../../turbo/packages/api-contracts/src/contracts/__tests__/fixtures/runner-claim-response.json"
@@ -1929,6 +2041,80 @@ mod tests {
             .get(field)
             .map(String::as_str)
             .unwrap_or_else(|| panic!("missing field {field}; event={event:#?}"))
+    }
+
+    fn marked_reusable_candidate(
+        run_id: RunId,
+        preference_reason: Option<RunnerPreferenceReason>,
+    ) -> JobCandidate {
+        let mut candidate = JobCandidate::new(run_id, crate::profile::DEFAULT_PROFILE.to_string())
+            .with_runner_preference(preference_reason.map(|reason| {
+                RunnerPreference::for_test(
+                    TEST_RUNNER_ID.parse().unwrap(),
+                    TEST_HEARTBEAT_GENERATION,
+                    reason,
+                    Instant::now() + Duration::from_secs(30),
+                )
+            }));
+        candidate.mark_reserved_reuse_claim_started();
+        candidate
+    }
+
+    fn reserved_reuse_claim_event(events: &[CapturedEvent]) -> &CapturedEvent {
+        let matching: Vec<_> = events
+            .iter()
+            .filter(|event| {
+                event
+                    .fields
+                    .get("message")
+                    .is_some_and(|message| message == "reserved reusable claim observed")
+            })
+            .collect();
+        assert_eq!(
+            matching.len(),
+            1,
+            "marked claim should emit exactly one observation; events={events:#?}"
+        );
+        matching[0]
+    }
+
+    fn assert_reserved_reuse_claim_event<'a>(
+        events: &'a [CapturedEvent],
+        run_id: RunId,
+        outcome: &str,
+        preference_reason: &str,
+    ) -> &'a CapturedEvent {
+        let event = reserved_reuse_claim_event(events);
+        assert_eq!(event.level, Level::INFO);
+        assert_eq!(event_field(event, "measurement"), "reserved_reuse_claim");
+        assert_eq!(event_field(event, "outcome"), outcome);
+        assert_eq!(event_field(event, "run_id"), run_id.to_string());
+        assert_eq!(event_field(event, "runner_id"), TEST_RUNNER_ID);
+        assert_eq!(
+            event_field(event, "heartbeat_generation"),
+            TEST_HEARTBEAT_GENERATION.to_string()
+        );
+        assert_eq!(
+            event_field(event, "runner_version"),
+            env!("CARGO_PKG_VERSION")
+        );
+        assert_eq!(event_field(event, "preference_reason"), preference_reason);
+        event_field(event, "duration_ms")
+            .parse::<u64>()
+            .expect("claim duration should be an integer number of milliseconds");
+        event
+    }
+
+    fn assert_no_reserved_reuse_claim_event(events: &[CapturedEvent]) {
+        assert!(
+            events.iter().all(|event| {
+                event
+                    .fields
+                    .get("message")
+                    .is_none_or(|message| message != "reserved reusable claim observed")
+            }),
+            "unmarked claim must not emit a reserved-reuse observation; events={events:#?}"
+        );
     }
 
     fn heartbeat_state_for_test() -> HeartbeatState {
@@ -2778,11 +2964,12 @@ mod tests {
         )
         .await;
 
-        let direct = tokio::time::timeout(Duration::from_secs(1), provider.discover())
+        let mut direct = tokio::time::timeout(Duration::from_secs(1), provider.discover())
             .await
             .expect("discover should receive direct candidate")
             .unwrap();
         assert_eq!(direct.discovery_source(), Some(JobDiscoverySource::Ably));
+        direct.mark_reserved_reuse_claim_started();
         let (claim, events) = capture_api_provider_events(provider.claim(direct)).await;
         assert!(claim.is_none());
         let event = captured_event(&events, "claim failed, candidate cooling down");
@@ -2794,6 +2981,16 @@ mod tests {
         assert!(
             !format!("{event:#?}").contains("sensitive-claim-rejection-body"),
             "claim failure event must not contain the response body"
+        );
+        let observation =
+            assert_reserved_reuse_claim_event(&events, rejected_run_id, "provider_failure", "none");
+        assert_eq!(
+            event_field(observation, "failure_class"),
+            "http_deterministic"
+        );
+        assert!(
+            !format!("{observation:#?}").contains("sensitive-claim-rejection-body"),
+            "claim observation must not contain the response body"
         );
 
         let next = tokio::time::timeout(Duration::from_secs(1), provider.discover())
@@ -2863,8 +3060,14 @@ mod tests {
         )
         .await;
 
-        let unavailable = provider.discover().await.unwrap();
-        assert!(provider.claim(unavailable).await.is_none());
+        let mut unavailable = provider.discover().await.unwrap();
+        unavailable.mark_reserved_reuse_claim_started();
+        let (claim, events) = capture_api_provider_events(provider.claim(unavailable)).await;
+        assert!(claim.is_none());
+        let observation =
+            assert_reserved_reuse_claim_event(&events, unavailable_run_id, "unavailable", "none");
+        assert!(!observation.fields.contains_key("failure_class"));
+        assert!(!observation.fields.contains_key("timezone_state"));
         let next = tokio::time::timeout(Duration::from_secs(1), provider.discover())
             .await
             .expect("unavailable claim should promptly poll the backlog")
@@ -3738,13 +3941,10 @@ mod tests {
             Arc::new(PollWakeups::new(false)),
         );
 
-        let claimed = provider
-            .claim(JobCandidate::new(
-                run_id,
-                crate::profile::DEFAULT_PROFILE.to_string(),
-            ))
-            .await
-            .expect("shared current claim response should decode");
+        let candidate =
+            marked_reusable_candidate(run_id, Some(RunnerPreferenceReason::ExactHistoryGeneration));
+        let (claimed, events) = capture_api_provider_events(provider.claim(candidate)).await;
+        let claimed = claimed.expect("shared current claim response should decode");
         let context = claimed.context();
 
         assert_eq!(context.run_id, run_id);
@@ -3787,6 +3987,17 @@ mod tests {
         assert_eq!(
             context.codex_runtime_config.as_ref().unwrap().provider_id,
             "fixture_provider"
+        );
+        let event = assert_reserved_reuse_claim_event(
+            &events,
+            run_id,
+            "claimed",
+            "exact_history_generation",
+        );
+        assert_eq!(event_field(event, "timezone_state"), "present");
+        assert!(
+            !format!("{event:#?}").contains("UTC"),
+            "claim observation must not contain the raw timezone"
         );
         claim_mock.assert_calls_async(1).await;
     }
@@ -3887,18 +4098,18 @@ mod tests {
             Arc::new(PollWakeups::new(false)),
         );
 
-        let claimed = provider
-            .claim(JobCandidate::new(
-                run_id,
-                crate::profile::DEFAULT_PROFILE.to_string(),
-            ))
-            .await
-            .expect("previous minimal claim response should remain compatible");
+        let (claimed, events) = capture_api_provider_events(provider.claim(JobCandidate::new(
+            run_id,
+            crate::profile::DEFAULT_PROFILE.to_string(),
+        )))
+        .await;
+        let claimed = claimed.expect("previous minimal claim response should remain compatible");
         let context = claimed.context();
 
         assert_eq!(context.prompt, "previous response");
         assert!(context.append_system_prompt.is_none());
         assert!(context.billable_firewalls.is_empty());
+        assert_no_reserved_reuse_claim_event(&events);
         claim_mock.assert_calls_async(1).await;
     }
 
@@ -3996,11 +4207,8 @@ mod tests {
             Arc::new(PollWakeups::new(false)),
         );
 
-        let (claimed, events) = capture_api_provider_events(provider.claim(JobCandidate::new(
-            run_id,
-            crate::profile::DEFAULT_PROFILE.to_string(),
-        )))
-        .await;
+        let candidate = marked_reusable_candidate(run_id, None);
+        let (claimed, events) = capture_api_provider_events(provider.claim(candidate)).await;
 
         assert!(claimed.is_none());
         let event = captured_event(&events, "claim failed, candidate cooling down");
@@ -4010,6 +4218,10 @@ mod tests {
             context_run_id.to_string()
         );
         assert_eq!(event_field(event, "retry_after_ms"), "30000");
+        let observation =
+            assert_reserved_reuse_claim_event(&events, run_id, "response_run_id_mismatch", "none");
+        assert!(!observation.fields.contains_key("failure_class"));
+        assert!(!observation.fields.contains_key("timezone_state"));
         claim_mock.assert_calls_async(1).await;
     }
 
@@ -4044,11 +4256,8 @@ mod tests {
             Arc::new(PollWakeups::new(false)),
         );
 
-        let (claimed, events) = capture_api_provider_events(provider.claim(JobCandidate::new(
-            run_id,
-            crate::profile::DEFAULT_PROFILE.to_string(),
-        )))
-        .await;
+        let candidate = marked_reusable_candidate(run_id, None);
+        let (claimed, events) = capture_api_provider_events(provider.claim(candidate)).await;
         let claimed = claimed.expect("claim should succeed");
         let event = captured_event(&events, "job claimed");
         assert_eq!(
@@ -4056,6 +4265,8 @@ mod tests {
             "550e8400-e29b-41d4-a716-446655440000"
         );
         assert_eq!(event_field(event, "heartbeat_generation"), "7");
+        let observation = assert_reserved_reuse_claim_event(&events, run_id, "claimed", "none");
+        assert_eq!(event_field(observation, "timezone_state"), "absent");
         let (context, completion_auth, active_input_source) = claimed.into_parts();
         assert_eq!(context.sandbox_token, "claim-sandbox-token");
         assert!(active_input_source.is_none());

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -43,6 +43,16 @@ pub(crate) enum RunnerPreferenceReason {
     FinalizingPredecessor,
 }
 
+impl RunnerPreferenceReason {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::ExactHistoryGeneration => "exact_history_generation",
+            Self::MatchingReuseKey => "matching_reuse_key",
+            Self::FinalizingPredecessor => "finalizing_predecessor",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(crate) struct RunnerProcessIdentity {
@@ -149,6 +159,23 @@ pub(crate) enum JobDiscoverySource {
     Poll,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ReservedReuseClaimObservation {
+    started_at: Instant,
+    preference_reason: Option<RunnerPreferenceReason>,
+}
+
+impl ReservedReuseClaimObservation {
+    pub(crate) fn elapsed(self) -> Duration {
+        self.started_at.elapsed()
+    }
+
+    pub(crate) fn preference_reason(self) -> &'static str {
+        self.preference_reason
+            .map_or("none", RunnerPreferenceReason::as_str)
+    }
+}
+
 impl JobDiscoverySource {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
@@ -179,6 +206,7 @@ pub struct JobCandidate {
     reuse_key: Option<String>,
     history_generation_run_id: Option<RunId>,
     runner_preference: Option<RunnerPreference>,
+    reserved_reuse_claim_observation: Option<ReservedReuseClaimObservation>,
 }
 
 impl JobCandidate {
@@ -210,6 +238,7 @@ impl JobCandidate {
             reuse_key: None,
             history_generation_run_id: None,
             runner_preference: None,
+            reserved_reuse_claim_observation: None,
         }
     }
 
@@ -305,6 +334,17 @@ impl JobCandidate {
 
     pub(crate) fn runner_preference(&self) -> Option<&RunnerPreference> {
         self.runner_preference.as_ref()
+    }
+
+    pub(crate) fn mark_reserved_reuse_claim_started(&mut self) {
+        self.reserved_reuse_claim_observation = Some(ReservedReuseClaimObservation {
+            started_at: Instant::now(),
+            preference_reason: self.runner_preference().map(RunnerPreference::reason),
+        });
+    }
+
+    pub(crate) fn reserved_reuse_claim_observation(&self) -> Option<ReservedReuseClaimObservation> {
+        self.reserved_reuse_claim_observation
     }
 
     pub(crate) fn without_runner_preference(mut self) -> Self {

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -28,6 +28,10 @@ const TELEMETRY_TIMEOUT: Duration = Duration::from_secs(5);
 /// the production Axiom log layer.
 pub(crate) const PRE_PARK_HANDOFF_AXIOM_TARGET: &str = "runner::pre_park_successor_handoff";
 
+/// Exact tracing target whose reserved-reuse claim INFO events are admitted
+/// to the production Axiom log layer.
+pub(crate) const RESERVED_REUSE_CLAIM_AXIOM_TARGET: &str = "runner::reserved_reuse_claim";
+
 /// Per-job telemetry collector. Buffers sandbox operations and flushes them
 /// periodically (auto on 30 s threshold) and at job end.
 ///


### PR DESCRIPTION
## Summary

- mark API claims that start while runner admission owns a reserved reusable idle sandbox
- emit one bounded runner-side Axiom observation for claimed, unavailable, provider-failure, and
  response run-ID mismatch outcomes
- record full runner-observed claim duration, effective preference reason, runner version, and
  timezone presence without logging raw reuse or timezone values
- allowlist only the exact new INFO target and cover admission, real HTTP, and Axiom transport paths

## Scope

This is instrumentation only. It does not unpark or mutate a sandbox before claim, change claim or
cancellation ownership, alter rollback/activation behavior, or change any database, persisted
state, API, heartbeat, queue, or sandbox-token schema.

#25075 remains open after this PR so the production cohort can be collected and the go/no-go
recommendation can be posted to parent #24870.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` (2959 passed, 0 failed; 15 ignored)
- repository pre-commit and commit-message hooks

Relates to #25075
Parent context: #24870
