### PR TITLE
fix(attribution): carry ga4 client ids into checkout

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/ad-attribution.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/ad-attribution.test.ts
@@ -4,7 +4,7 @@ import { getStoredAdAttributionMetadata } from "../bootstrap/ad-attribution.ts";
 
 const STORED_AD_ATTRIBUTION_KEY = "vm0.adAttribution";
 
-describe("GA4 client ID attribution", () => {
+describe("ga4 client id attribution", () => {
   afterEach(() => {
     window.sessionStorage.removeItem(STORED_AD_ATTRIBUTION_KEY);
   });
@@ -25,7 +25,7 @@ describe("GA4 client ID attribution", () => {
         window.sessionStorage,
         "_ga=GA1.1.123456789.987654321",
       ),
-    ).toEqual({
+    ).toStrictEqual({
       source_type: "paid",
       gclid: "click-123",
       gclid_present: "true",
@@ -41,7 +41,7 @@ describe("GA4 client ID attribution", () => {
         window.sessionStorage,
         "_ga=GA1.1.123456789.987654321",
       ),
-    ).toEqual({ ga_client_id: "123456789.987654321" });
+    ).toStrictEqual({ ga_client_id: "123456789.987654321" });
   });
 
   it("ignores malformed analytics cookies", () => {

--- a/turbo/apps/platform/src/signals/__tests__/ad-attribution.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/ad-attribution.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getStoredAdAttributionMetadata } from "../bootstrap/ad-attribution.ts";
+
+const STORED_AD_ATTRIBUTION_KEY = "vm0.adAttribution";
+
+describe("GA4 client ID attribution", () => {
+  afterEach(() => {
+    window.sessionStorage.removeItem(STORED_AD_ATTRIBUTION_KEY);
+  });
+
+  it("extracts the GA4 client ID from the shared _ga cookie", () => {
+    window.sessionStorage.setItem(
+      STORED_AD_ATTRIBUTION_KEY,
+      new URLSearchParams({
+        source_type: "paid",
+        gclid: "click-123",
+        utm_source: "google",
+        utm_medium: "cpc",
+      }).toString(),
+    );
+
+    expect(
+      getStoredAdAttributionMetadata(
+        window.sessionStorage,
+        "_ga=GA1.1.123456789.987654321",
+      ),
+    ).toEqual({
+      source_type: "paid",
+      gclid: "click-123",
+      gclid_present: "true",
+      utm_source: "google",
+      utm_medium: "cpc",
+      ga_client_id: "123456789.987654321",
+    });
+  });
+
+  it("returns the GA4 client ID even when no ad click was stored", () => {
+    expect(
+      getStoredAdAttributionMetadata(
+        window.sessionStorage,
+        "_ga=GA1.1.123456789.987654321",
+      ),
+    ).toEqual({ ga_client_id: "123456789.987654321" });
+  });
+
+  it("ignores malformed analytics cookies", () => {
+    expect(
+      getStoredAdAttributionMetadata(
+        window.sessionStorage,
+        "_ga=not-a-ga-cookie",
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/turbo/apps/platform/src/signals/bootstrap/ad-attribution.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/ad-attribution.ts
@@ -8,6 +8,8 @@ import {
 const AD_ATTRIBUTION_SOURCE_PARAM = "vm0_source";
 
 const STORED_AD_ATTRIBUTION_KEY = "vm0.adAttribution";
+const GOOGLE_ANALYTICS_CLIENT_ID_COOKIE = "_ga";
+const GOOGLE_ANALYTICS_CLIENT_ID_METADATA_PARAM = "ga_client_id";
 
 const AD_ATTRIBUTION_PARAMS = [
   "source_type",
@@ -99,6 +101,23 @@ function readCookie(name: string, cookieString: string): string | null {
   return null;
 }
 
+function googleAnalyticsClientIdFromCookie(
+  cookieString: string,
+): string | undefined {
+  const value = readCookie(GOOGLE_ANALYTICS_CLIENT_ID_COOKIE, cookieString);
+  if (!value) {
+    return undefined;
+  }
+
+  const parts = value.split(".");
+  if (parts.length < 4 || !/^GA\d+$/.test(parts[0] ?? "")) {
+    return undefined;
+  }
+
+  const clientId = parts.slice(2).join(".");
+  return /^\d+\.\d+$/.test(clientId) ? clientId : undefined;
+}
+
 // First-touch attribution forwarded across the www.vm0.ai -> app.vm0.ai hop in
 // the shared .vm0.ai cookie. A satellite on another registrable domain cannot
 // read this cookie, so its URL params remain the handoff mechanism and are
@@ -165,17 +184,14 @@ export function applyStoredAdAttribution(
 
 export function getStoredAdAttributionMetadata(
   storage: Storage | null = getSessionStorage(),
+  cookieString: string = getCookieString(),
 ): AdAttributionMetadata | undefined {
   if (!storage) {
     return undefined;
   }
 
   const stored = storage.getItem(STORED_AD_ATTRIBUTION_KEY);
-  if (!stored) {
-    return undefined;
-  }
-
-  const attributionParams = new URLSearchParams(stored);
+  const attributionParams = new URLSearchParams(stored ?? "");
   const metadata: AdAttributionMetadata = {};
 
   const sourceType = attributionParams.get("source_type");
@@ -196,6 +212,11 @@ export function getStoredAdAttributionMetadata(
       metadata[clickIdParam] = value;
       metadata[metadataParam] = "true";
     }
+  }
+
+  const gaClientId = googleAnalyticsClientIdFromCookie(cookieString);
+  if (gaClientId) {
+    metadata[GOOGLE_ANALYTICS_CLIENT_ID_METADATA_PARAM] = gaClientId;
   }
 
   return Object.keys(metadata).length > 0 ? metadata : undefined;

--- a/turbo/packages/api-contracts/src/contracts/zero-attribution.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-attribution.ts
@@ -41,6 +41,11 @@ export const adAttributionMetadataSchema = z
     gclid: z.string().min(1).max(200).optional(),
     gbraid: z.string().min(1).max(200).optional(),
     wbraid: z.string().min(1).max(200).optional(),
+    // GA4's browser client ID is read from the first-party _ga cookie. It is
+    // carried separately from ad click IDs so server-side GA4 events can be
+    // joined back to the browser session without treating every visitor as a
+    // Google Ads conversion.
+    ga_client_id: z.string().min(1).max(100).optional(),
     gclid_present: z.literal("true").optional(),
     gbraid_present: z.literal("true").optional(),
     wbraid_present: z.literal("true").optional(),


### PR DESCRIPTION
## Summary
- extract the GA4 browser client ID from the shared `_ga` cookie
- carry `ga_client_id` through signup attribution and Stripe checkout metadata
- add focused coverage for paid, direct, and malformed-cookie cases

This completes the client-side half of the existing marketing webhook GA4 `trial_start` and `purchase` path. It does not create fake conversions or change Google Ads settings.

## Verification
- platform attribution tests: passed
- signup attribution tests: passed
- API contracts type checks: passed
- platform production and test type checks: passed