### PR TITLE
refactor: reduce fallback slop in meta ads

### DIFF
--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/meta-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/meta-ads.test.ts
@@ -111,6 +111,40 @@ describe("connector/providers/meta-ads", () => {
       expect(result.userInfo.email).toBe("test@example.com");
     });
 
+    it("throws when Meta Ads user info omits the user id", async () => {
+      const shortLivedHandler = http.post(TOKEN_URL, () => {
+        return HttpResponse.json({
+          access_token: "short-lived-token",
+          token_type: "bearer",
+          expires_in: 3600,
+        });
+      });
+      const longLivedHandler = http.get(TOKEN_URL, () => {
+        return HttpResponse.json({
+          access_token: "long-lived-token",
+          token_type: "bearer",
+          expires_in: 5184000,
+        });
+      });
+      const userHandler = http.get(USER_URL, () => {
+        return HttpResponse.json({
+          name: "Test User",
+          email: "test@example.com",
+        });
+      });
+      server.use(shortLivedHandler, longLivedHandler, userHandler);
+
+      await expect(
+        exchangeMetaAdsCode(
+          authCodeGrant(),
+          "client-id",
+          "client-secret",
+          "test-code",
+          "https://example.com/callback",
+        ),
+      ).rejects.toThrow("No user id in Meta Ads user info response");
+    });
+
     it("throws when token endpoint returns an error", async () => {
       const handler = http.post(TOKEN_URL, () => {
         return HttpResponse.json(

--- a/turbo/packages/connectors/src/auth-providers/connectors/meta-ads/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/meta-ads/oauth.ts
@@ -204,8 +204,12 @@ async function fetchMetaAdsUserInfo(
     })
     .parse(await response.json());
 
+  if (!data.id) {
+    throw new Error("No user id in Meta Ads user info response");
+  }
+
   return {
-    id: data.id ?? "",
+    id: data.id,
     username: data.name ?? null,
     email: data.email ?? null,
   };


### PR DESCRIPTION
## Summary

Reject Meta Ads `/me` responses that omit the required user ID instead of creating a connector grant identity with `id: ""`.

## Scan

- Scan timestamp: `2026-08-04T20:02:35.836Z`
- Base commit: `926523f492ab51186ae8703d6cc541268aa52d57`
- Files scanned: 3,969
- Total matches: 20,312
- `actionable_total`: 232 high-confidence production candidates
- `edit_budget`: 12 (`ceil(232 * 0.05)`)
- Candidates changed: 1

### Matches by category

| Category | Matches |
| --- | ---: |
| `nullish` | 6,263 |
| `nullish-chain` | 135 |
| `field-fallback-chain` | 105 |
| `optional-prop` | 6,141 |
| `zod-optional` | 2,637 |
| `zod-loose-optional` | 5 |
| `loose-record` | 1,096 |
| `loose-index-signature` | 3 |
| `as-any` | 0 |
| `as-unknown-as` | 30 |
| `empty-fallback` | 638 |
| `string-fallback` | 689 |
| `null-undefined-fallback` | 1,696 |
| `empty-catch` | 3 |
| `promise-catch-swallow` | 16 |
| `rust-unwrap-or` | 692 |
| `rust-ok-discard` | 163 |

## Changes

- `turbo/packages/connectors/src/auth-providers/connectors/meta-ads/oauth.ts`: fail with a clear error when the Graph `/me` payload omits `id`. The connector grant identity requires a real provider user ID, so an empty string cannot represent a valid identity.
- `turbo/packages/connectors/src/auth-providers/connectors/__tests__/meta-ads.test.ts`: cover the complete OAuth exchange and assert that a missing `/me` ID is rejected.

The remaining candidates are intentionally left for later daily runs. Many of the highest-scoring remaining matches are deliberate multi-source compatibility fallbacks, presentation fallbacks, arbitrary JSON contracts, or test-only cleanup paths and need separate semantic review.

## Verification

- `pnpm prettier --check packages/connectors/src/auth-providers/connectors/meta-ads/oauth.ts packages/connectors/src/auth-providers/connectors/__tests__/meta-ads.test.ts`
- `pnpm --filter @vm0/connectors lint`
- `pnpm --filter @vm0/connectors check-types`
- `pnpm --filter @vm0/connectors exec vitest run src/auth-providers/connectors/__tests__/meta-ads.test.ts` (10 tests passed)
- `git diff --check`
- Pre-commit hooks: Prettier, Knip, full workspace typecheck (12/12), and file-size check
- Commit message hook: commitlint
