### PR TITLE
refactor: reduce fallback slop in connector identities

### DIFF
--- a/turbo/packages/connectors/src/auth-providers/__tests__/grant-result.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/__tests__/grant-result.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { requireConnectorGrantUserId } from "../grant-result";
+
+describe("requireConnectorGrantUserId", () => {
+  it("returns a present user id", () => {
+    expect(requireConnectorGrantUserId("user-123", "Test Provider")).toBe(
+      "user-123",
+    );
+  });
+
+  it("rejects missing and empty user ids", () => {
+    for (const id of [undefined, null, ""]) {
+      expect(() => {
+        requireConnectorGrantUserId(id, "Test Provider");
+      }).toThrow("No user id in Test Provider user info response");
+    }
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/connectors/canva/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/canva/oauth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connector-config";
+import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
 
 const CANVA_TOKEN_URL = "https://api.canva.com/rest/v1/oauth/token";
@@ -234,7 +235,10 @@ async function fetchCanvaUserInfo(accessToken: string): Promise<CanvaUserInfo> {
     })
     .parse(await meResponse.json());
 
-  const userId = meData.team_user?.user_id ?? "";
+  const userId = requireConnectorGrantUserId(
+    meData.team_user?.user_id,
+    "Canva",
+  );
 
   // Fetch display name from profile endpoint (requires profile:read scope)
   let displayName: string | null = null;

--- a/turbo/packages/connectors/src/auth-providers/connectors/deel/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/deel/oauth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connector-config";
+import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
 
 const DEEL_TOKEN_URL = "https://app.deel.com/oauth2/tokens";
@@ -261,7 +262,7 @@ async function fetchDeelUserInfo(
   const email = person?.emails?.[0]?.value ?? null;
 
   return {
-    id: person?.id ?? "",
+    id: requireConnectorGrantUserId(person?.id, "Deel"),
     username: name || null,
     email,
   };

--- a/turbo/packages/connectors/src/auth-providers/connectors/docusign/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/docusign/oauth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connector-config";
+import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
 
 const DOCUSIGN_TOKEN_URL = "https://account-d.docusign.com/oauth/token";
@@ -235,7 +236,7 @@ async function fetchDocuSignUserInfo(
     .parse(await response.json());
 
   return {
-    id: data.sub ?? "",
+    id: requireConnectorGrantUserId(data.sub, "DocuSign"),
     username: data.name ?? null,
     email: data.email ?? null,
   };

--- a/turbo/packages/connectors/src/auth-providers/connectors/dropbox/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/dropbox/oauth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connector-config";
+import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
 
 const DROPBOX_TOKEN_URL = "https://api.dropboxapi.com/oauth2/token";
@@ -194,7 +195,7 @@ async function fetchDropboxUserInfo(
     .parse(await response.json());
 
   return {
-    id: data.account_id ?? "",
+    id: requireConnectorGrantUserId(data.account_id, "Dropbox"),
     username: data.name?.display_name ?? null,
     email: data.email ?? null,
   };

--- a/turbo/packages/connectors/src/auth-providers/connectors/garmin-connect/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/garmin-connect/oauth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connector-config";
+import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
 
 const GARMIN_CONNECT_TOKEN_URL =
@@ -230,7 +231,7 @@ async function fetchGarminConnectUserId(
     .parse(await response.json());
 
   return {
-    id: data.userId ?? "",
+    id: requireConnectorGrantUserId(data.userId, "Garmin Connect"),
     username: data.displayName ?? null,
     email: null,
   };

--- a/turbo/packages/connectors/src/auth-providers/connectors/gmail/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/gmail/oauth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connector-config";
+import { requireConnectorGrantUserId } from "../../grant-result";
 import { buildGoogleAuthorizationUrl } from "../../oauth/google";
 import { throwOAuthError } from "../../oauth/error";
 
@@ -126,7 +127,7 @@ async function fetchGmailUserInfo(accessToken: string): Promise<GmailUserInfo> {
     .parse(await response.json());
 
   return {
-    id: data.emailAddress ?? "",
+    id: requireConnectorGrantUserId(data.emailAddress, "Gmail"),
     email: data.emailAddress ?? null,
     name: data.emailAddress ?? null,
   };

--- a/turbo/packages/connectors/src/auth-providers/connectors/gumroad/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/gumroad/oauth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connector-config";
+import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
 
 const GUMROAD_TOKEN_URL = "https://gumroad.com/oauth/token";
@@ -178,7 +179,7 @@ async function fetchGumroadUserInfo(
     .parse(await response.json());
 
   return {
-    id: data.user?.id ?? "",
+    id: requireConnectorGrantUserId(data.user?.id, "Gumroad"),
     username: data.user?.name ?? null,
     email: data.user?.email ?? null,
   };

--- a/turbo/packages/connectors/src/auth-providers/connectors/mailchimp/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/mailchimp/oauth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connector-config";
+import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
 
 const MAILCHIMP_TOKEN_URL = "https://login.mailchimp.com/oauth2/token";
@@ -136,7 +137,7 @@ async function fetchMailchimpMetadata(accessToken: string): Promise<{
   return {
     apiEndpoint: data.api_endpoint ?? "",
     userInfo: {
-      id: data.user_id?.toString() ?? "",
+      id: requireConnectorGrantUserId(data.user_id?.toString(), "Mailchimp"),
       username: data.login?.login_name ?? data.accountname ?? null,
       email: data.login?.login_email ?? null,
     },

--- a/turbo/packages/connectors/src/auth-providers/connectors/mercury/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/mercury/oauth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connector-config";
+import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
 
 const MERCURY_ENDPOINTS = {
@@ -256,7 +257,7 @@ async function fetchMercuryUserInfo(
   const firstAccount = data.accounts?.[0];
 
   return {
-    id: firstAccount?.id ?? "",
+    id: requireConnectorGrantUserId(firstAccount?.id, "Mercury"),
     username: firstAccount?.name ?? firstAccount?.legalBusinessName ?? null,
     email: null,
   };

--- a/turbo/packages/connectors/src/auth-providers/connectors/supabase/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/supabase/oauth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connector-config";
+import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
 
 const SUPABASE_TOKEN_URL = "https://api.supabase.com/v1/oauth/token";
@@ -241,7 +242,7 @@ async function fetchSupabaseUserInfo(
   const org = data[0];
 
   return {
-    id: org?.id ?? "",
+    id: requireConnectorGrantUserId(org?.id, "Supabase"),
     username: org?.name ?? null,
     email: null,
   };

--- a/turbo/packages/connectors/src/auth-providers/connectors/todoist/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/todoist/oauth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connector-config";
+import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
 
 const TODOIST_TOKEN_URL = "https://todoist.com/oauth/access_token";
@@ -122,7 +123,7 @@ async function fetchTodoistUserInfo(accessToken: string): Promise<{
     .parse(await response.json());
 
   return {
-    id: data.id ?? "",
+    id: requireConnectorGrantUserId(data.id, "Todoist"),
     username: data.full_name ?? null,
     email: data.email ?? null,
   };

--- a/turbo/packages/connectors/src/auth-providers/connectors/xero/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/xero/oauth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connector-config";
+import { requireConnectorGrantUserId } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
 
 const XERO_TOKEN_URL = "https://identity.xero.com/connect/token";
@@ -187,7 +188,7 @@ async function fetchXeroUserInfo(accessToken: string): Promise<XeroUserInfo> {
     .parse(await response.json());
 
   return {
-    id: data.sub ?? "",
+    id: requireConnectorGrantUserId(data.sub, "Xero"),
     username: data.name ?? null,
     email: data.email ?? null,
   };

--- a/turbo/packages/connectors/src/auth-providers/grant-result.ts
+++ b/turbo/packages/connectors/src/auth-providers/grant-result.ts
@@ -10,6 +10,16 @@ export interface ConnectorAuthProviderGrantUserInfo {
   readonly email: string | null;
 }
 
+export function requireConnectorGrantUserId(
+  id: string | null | undefined,
+  providerName: string,
+): string {
+  if (!id) {
+    throw new Error(`No user id in ${providerName} user info response`);
+  }
+  return id;
+}
+
 export type ConnectorAuthProviderGrantOutputValues = Readonly<
   Record<string, string | null | undefined>
 >;


### PR DESCRIPTION
## Summary

Reject missing external identity IDs across 12 OAuth connector grant paths instead of fabricating `id: ""` and persisting an empty connector `externalId`.

The scanner conservatively labels external API adapters as medium confidence. Manual review promoted this repeated pattern because every changed endpoint supplies the identity used by `ConnectorAuthProviderGrantUserInfo.id`, and the API persists that value directly as the connector connection's `externalId`.

## Scan

- Timestamp: `2026-08-04T23:48:27.031Z`
- Base commit: `619d3727ebdd6858d7a627e5f9b8cbe330b554d1`
- Files scanned: 3,969
- Total matches: 20,310
- Raw actionable matches: 4,415
- High-confidence production actionable (`actionable_total`): 232
- Minimum 5% batch (`minimum_change_count`): 12
- Candidates changed: 12
- Post-change raw actionable matches: 4,403
- Remaining scanner high-confidence production candidates: 232; these 12 external-adapter matches were manually elevated after contract review, while the scanner intentionally keeps that category medium confidence.

### Matches by category

| Category | Matches |
| --- | ---: |
| nullish | 6,262 |
| nullish-chain | 135 |
| field-fallback-chain | 105 |
| optional-prop | 6,141 |
| zod-optional | 2,637 |
| zod-loose-optional | 5 |
| loose-record | 1,096 |
| loose-index-signature | 3 |
| as-any | 0 |
| as-unknown-as | 30 |
| empty-fallback | 638 |
| string-fallback | 688 |
| null-undefined-fallback | 1,696 |
| empty-catch | 3 |
| promise-catch-swallow | 16 |
| rust-unwrap-or | 692 |
| rust-ok-discard | 163 |

## What changed and why it was slop

Added `requireConnectorGrantUserId`, then replaced 12 empty-string identity fallbacks in:

- Canva
- Deel
- DocuSign
- Dropbox
- Garmin Connect
- Gmail
- Gumroad
- Mailchimp
- Mercury
- Supabase
- Todoist
- Xero

Previously, a successful token response followed by a malformed or incomplete identity response could still produce a connector grant with `userInfo.id === ""`. That empty value was then stored as the connector's external identity. This hid a broken provider contract, made unrelated invalid grants indistinguishable, and allowed authorization to appear successful without a usable external account identity.

The shared guard now throws a provider-specific error before the grant can be persisted. It rejects `undefined`, `null`, and empty strings while returning valid IDs unchanged.

## Why the batch is safe

- `ConnectorAuthProviderGrantUserInfo` requires an identity `id: string`.
- The API copies that ID directly into `connectors.externalId` during connector upsert.
- Each changed value comes from the provider endpoint or token field already designated by that connector as its grant identity; no alternate optional profile field was made required.
- Successful OAuth behavior is unchanged when the provider returns the identity.
- A shared regression test covers valid, missing, null, and empty IDs.
- Existing Gumroad and Mercury OAuth suites exercise representative successful flows after adopting the guard.

## Verification

- Prettier on all changed files.
- `pnpm --filter @vm0/connectors lint` passed. It reported one unrelated existing `unicorn(no-useless-spread)` warning in `src/firewall-types.ts`.
- `pnpm --filter @vm0/connectors check-types` passed.
- Targeted Vitest: shared grant-result, Gumroad, and Mercury suites — 3 files, 19 tests passed.
- `git diff --check` passed.
- Pre-commit hooks passed: Prettier, Knip, full workspace typecheck (12/12 tasks), and file-size checks.
- Commitlint passed.
- Post-change scanner reconciliation: `string-fallback` 688 → 676 and raw actionable matches 4,415 → 4,403, exactly 12 fewer.

The remaining candidates are intentionally left for later daily runs.
