### PR TITLE
fix(ci): clean up closed app preview deployments

### DIFF
--- a/.github/scripts/delete-okou-pages-preview-deployments.sh
+++ b/.github/scripts/delete-okou-pages-preview-deployments.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 3 )); then
+  echo "usage: $0 <account-id> <project-name> <pages-branch>" >&2
+  exit 1
+fi
+
+account_id="$1"
+project_name="$2"
+pages_branch="$3"
+
+: "${account_id:?Cloudflare account ID is required}"
+: "${project_name:?Cloudflare Pages project name is required}"
+: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required}"
+
+if [[ ! "$pages_branch" =~ ^pr-[1-9][0-9]*-app$ ]]; then
+  echo "invalid app preview Pages branch: $pages_branch" >&2
+  exit 1
+fi
+
+api_url="https://api.cloudflare.com/client/v4/accounts/${account_id}/pages/projects/${project_name}/deployments"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+deployment_ids="$tmp_dir/deployment-ids"
+touch "$deployment_ids"
+
+page=1
+total_pages=1
+while (( page <= total_pages )); do
+  response_file="$tmp_dir/page-${page}.json"
+  curl --fail-with-body --silent --show-error \
+    --retry 3 \
+    --retry-all-errors \
+    --retry-delay 1 \
+    "${api_url}?env=preview&page=${page}&per_page=25" \
+    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    --output "$response_file"
+
+  jq -e '.success == true' "$response_file" >/dev/null
+  response_total_pages="$(jq -er '.result_info.total_pages' "$response_file")"
+  if (( response_total_pages > total_pages )); then
+    total_pages="$response_total_pages"
+  fi
+
+  jq -r --arg branch "$pages_branch" '
+    .result[]
+    | select(
+        .environment == "preview"
+        and .deployment_trigger.metadata.branch == $branch
+      )
+    | .id
+  ' "$response_file" >> "$deployment_ids"
+
+  page=$((page + 1))
+done
+
+sort -u "$deployment_ids" -o "$deployment_ids"
+deployment_count="$(wc -l < "$deployment_ids")"
+printf 'Found %s Cloudflare Pages deployment(s) for %s\n' \
+  "$deployment_count" "$pages_branch"
+
+while IFS= read -r deployment_id; do
+  [[ -n "$deployment_id" ]] || continue
+  if [[ ! "$deployment_id" =~ ^[0-9a-f-]+$ ]]; then
+    echo "invalid Cloudflare Pages deployment ID: $deployment_id" >&2
+    exit 1
+  fi
+
+  delete_response="$tmp_dir/delete-${deployment_id}.json"
+  curl --fail-with-body --silent --show-error \
+    --retry 3 \
+    --retry-all-errors \
+    --retry-delay 1 \
+    --request DELETE \
+    "${api_url}/${deployment_id}?force=true" \
+    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    --output "$delete_response"
+  jq -e '.success == true' "$delete_response" >/dev/null
+done < "$deployment_ids"
+
+printf 'Deleted %s Cloudflare Pages deployment(s) for %s\n' \
+  "$deployment_count" "$pages_branch"

--- a/.github/scripts/tests/app-preview-ingress-workflow-test.sh
+++ b/.github/scripts/tests/app-preview-ingress-workflow-test.sh
@@ -50,6 +50,25 @@ legacy_markers.each do |marker|
 end
 
 cleanup_source = File.read(ARGV.fetch(1))
+cleanup = YAML.load_file(ARGV.fetch(1))
+expected_cleanup_group = "pr-${{ github.event.pull_request.number }}"
+unless cleanup.fetch("concurrency").fetch("group") == expected_cleanup_group
+  raise "cleanup must cancel the matching PR Turbo run before deleting Pages deployments"
+end
+
+pages_cleanup = cleanup.fetch("jobs").fetch("cleanup-app-pages-deployments")
+pages_cleanup_steps = pages_cleanup.fetch("steps")
+pages_cleanup_step = pages_cleanup_steps.find do |step|
+  step["name"] == "Delete Cloudflare Pages app preview deployments"
+end
+raise "missing app Pages deployment cleanup step" unless pages_cleanup_step
+unless pages_cleanup_step.fetch("run").include?("delete-okou-pages-preview-deployments.sh")
+  raise "app Pages cleanup must use the audited deletion script"
+end
+unless pages_cleanup_step.fetch("env").fetch("PAGES_BRANCH") == "pr-${{ github.event.pull_request.number }}-app"
+  raise "app Pages cleanup branch must derive only from the closed PR number"
+end
+
 legacy_cleanup_markers = [
   "cleanup-okou-pages-domain",
   "cleanup-legacy-preview-www",

--- a/.github/scripts/tests/delete-okou-pages-preview-deployments-test.sh
+++ b/.github/scripts/tests/delete-okou-pages-preview-deployments-test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+script="${repo_root}/.github/scripts/delete-okou-pages-preview-deployments.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+mock_curl="$tmp_dir/bin/curl"
+request_log="$tmp_dir/requests"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'method=GET' \
+  'output_file=' \
+  'url=' \
+  'while (( $# > 0 )); do' \
+  '  case "$1" in' \
+  '    --request) method="$2"; shift 2 ;;' \
+  '    --output) output_file="$2"; shift 2 ;;' \
+  '    --retry|--retry-delay|-H) shift 2 ;;' \
+  '    --fail-with-body|--silent|--show-error|--retry-all-errors) shift ;;' \
+  '    https://*) url="$1"; shift ;;' \
+  '    *) echo "unexpected curl argument: $1" >&2; exit 1 ;;' \
+  '  esac' \
+  'done' \
+  'printf "%s\t%s\n" "$method" "$url" >> "$REQUEST_LOG"' \
+  'case "$method:$url" in' \
+  '  GET:*"page=1"*)' \
+  '    printf "%s\n" '\''{"success":true,"result":[{"id":"a1111111-1111-1111-1111-111111111111","environment":"preview","deployment_trigger":{"metadata":{"branch":"pr-42-app"}}},{"id":"b2222222-2222-2222-2222-222222222222","environment":"preview","deployment_trigger":{"metadata":{"branch":"pr-41-app"}}}],"result_info":{"total_pages":2}}'\'' > "$output_file"' \
+  '    ;;' \
+  '  GET:*"page=2"*)' \
+  '    printf "%s\n" '\''{"success":true,"result":[{"id":"c3333333-3333-3333-3333-333333333333","environment":"preview","deployment_trigger":{"metadata":{"branch":"pr-42-app"}}}],"result_info":{"total_pages":2}}'\'' > "$output_file"' \
+  '    ;;' \
+  '  DELETE:*/deployments/a1111111-1111-1111-1111-111111111111\?force=true)' \
+  '    printf "%s\n" '\''{"success":true,"result":null}'\'' > "$output_file"' \
+  '    ;;' \
+  '  DELETE:*/deployments/c3333333-3333-3333-3333-333333333333\?force=true)' \
+  '    printf "%s\n" '\''{"success":true,"result":null}'\'' > "$output_file"' \
+  '    ;;' \
+  '  *) echo "unexpected request: $method $url" >&2; exit 1 ;;' \
+  'esac' > "$mock_curl"
+chmod +x "$mock_curl"
+
+export CLOUDFLARE_API_TOKEN="test-token"
+export PATH="$tmp_dir/bin:$PATH"
+export REQUEST_LOG="$request_log"
+
+output="$tmp_dir/output"
+bash "$script" account-id okou-app pr-42-app > "$output"
+
+grep -Fxq 'Found 2 Cloudflare Pages deployment(s) for pr-42-app' "$output"
+grep -Fxq 'Deleted 2 Cloudflare Pages deployment(s) for pr-42-app' "$output"
+test "$(grep -c '^GET' "$request_log")" -eq 2
+test "$(grep -c '^DELETE' "$request_log")" -eq 2
+grep -Fq '/deployments/a1111111-1111-1111-1111-111111111111?force=true' "$request_log"
+grep -Fq '/deployments/c3333333-3333-3333-3333-333333333333?force=true' "$request_log"
+if grep -Fq 'b2222222-2222-2222-2222-222222222222?force=true' "$request_log"; then
+  echo "deleted a deployment from another branch" >&2
+  exit 1
+fi
+
+if bash "$script" account-id okou-app staging-app >/dev/null 2>&1; then
+  echo "accepted a non-PR Pages branch" >&2
+  exit 1
+fi
+
+echo "delete-okou-pages-preview-deployments tests passed"

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -5,10 +5,33 @@ on:
     types: [closed]
 
 concurrency:
-  group: ${{ github.head_ref || github.ref }}
+  group: pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
+  cleanup-app-pages-deployments:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Delete Cloudflare Pages app preview deployments
+        env:
+          CF_PAGES_PROJECT_NAME: ${{ vars.CF_PAGES_PROJECT_NAME }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CF_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
+          PAGES_BRANCH: pr-${{ github.event.pull_request.number }}-app
+        run: |
+          bash .github/scripts/delete-okou-pages-preview-deployments.sh \
+            "$CLOUDFLARE_ACCOUNT_ID" \
+            "$CF_PAGES_PROJECT_NAME" \
+            "$PAGES_BRANCH"
+
   cleanup-runner:
     # Skip for release-please PRs (only version bumps and changelogs)
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"


### PR DESCRIPTION
## Summary

- delete all Cloudflare Pages deployments for an app preview branch when its PR closes
- derive the deletion target only from the closed PR number and reject non-PR branches
- share the `pr-N` concurrency group with Turbo so cleanup cancels an in-flight PR run before deleting resources
- keep production and staging Pages deployments outside the cleanup path

## Verification

- `bash -n .github/scripts/delete-okou-pages-preview-deployments.sh .github/scripts/tests/delete-okou-pages-preview-deployments-test.sh .github/scripts/tests/app-preview-ingress-workflow-test.sh`
- `bash .github/scripts/tests/delete-okou-pages-preview-deployments-test.sh`
- `bash .github/scripts/tests/app-preview-ingress-workflow-test.sh`
- `git diff --check`
- Shellcheck is deferred to the PR `Workflow Lint` job because it is not installed in the local runtime.
