### PR TITLE
fix: fold completed work by user phase

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -12,6 +12,7 @@ import { click } from "../../../__tests__/page-helper.ts";
 import { initializeI18n } from "../../../i18n/index.ts";
 import { DEFAULT_LOCALE } from "../../../i18n/resources.ts";
 import { mockChatLifecycle, mockSubagentThread } from "./chat-test-helpers.ts";
+import type { MockChatEventInput } from "./chat-event-test-helpers.ts";
 import {
   billingStatus,
   buildModelPolicy,
@@ -849,190 +850,172 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("keeps every steered user message outside completed work", async () => {
-    const threadId = "thread-work-folding-steered-users";
-    const runId = "run-work-folding-steered-users";
-    mockChatLifecycle(context, {
-      threadId,
-      chatEvents: [
+  it.each([
+    {
+      name: "splits one completed run into folds at user boundaries",
+      caseId: "two-folds",
+      sequence: ["U1", "A2", "A3", "A4", "U2", "A5", "A6", "A7", "A8"],
+      visibleOrder: [
+        "U1",
+        "Worked for 30s",
+        "A4",
+        "U2",
+        "Worked for 40s",
+        "A8",
+      ],
+      usageAssistant: "A8",
+      folds: [
         {
-          role: "user",
-          content: "Prepare the launch plan",
-          runId,
-          createdAt: "2026-08-04T10:00:00Z",
+          label: "Worked for 30s",
+          hidden: ["A2", "A3"],
+          final: "A4",
         },
         {
-          role: "assistant",
-          content: "Reviewing the launch notes.",
-          runId,
-          createdAt: "2026-08-04T10:00:10Z",
-        },
-        {
-          role: "user",
-          content: "Also include the rollback steps",
-          runId,
-          createdAt: "2026-08-04T10:00:20Z",
-        },
-        {
-          role: "user",
-          content: "Keep the rollback checklist concise",
-          runId,
-          createdAt: "2026-08-04T10:00:25Z",
-        },
-        {
-          role: "assistant",
-          content: "Adding the rollback steps.",
-          runId,
-          createdAt: "2026-08-04T10:00:30Z",
-        },
-        {
-          role: "assistant",
-          content: "The launch and rollback plan is ready.",
-          runId,
-          runLifecycleEvent: "completed",
-          createdAt: "2026-08-04T10:00:40Z",
+          label: "Worked for 40s",
+          hidden: ["A5", "A6", "A7"],
+          final: "A8",
         },
       ],
-    });
-
-    detachedSetupPage({
-      context,
-      path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ChatSteer]: true },
-    });
-
-    const expandButton = await screen.findByLabelText("Expand work history");
-    const messageContainer = expandButton.closest(
-      "[data-message-container]",
-    ) as HTMLElement | null;
-    expect(messageContainer).not.toBeNull();
-    expect(screen.getAllByText("Prepare the launch plan")).toHaveLength(1);
-    expect(screen.getAllByText("Also include the rollback steps")).toHaveLength(
-      1,
-    );
-    expect(
-      screen.getAllByText("Keep the rollback checklist concise"),
-    ).toHaveLength(1);
-    expect(screen.queryByText("Reviewing the launch notes.")).toBeNull();
-    expect(screen.queryByText("Adding the rollback steps.")).toBeNull();
-    expectTextBefore(
-      messageContainer!,
-      "Prepare the launch plan",
-      "Also include the rollback steps",
-    );
-    expectTextBefore(
-      messageContainer!,
-      "Also include the rollback steps",
-      "Keep the rollback checklist concise",
-    );
-    expectTextBefore(
-      messageContainer!,
-      "Keep the rollback checklist concise",
-      "Worked for 40s",
-    );
-    expectTextBefore(
-      messageContainer!,
-      "Worked for 40s",
-      "The launch and rollback plan is ready.",
-    );
-
-    click(expandButton);
-    await waitFor(() => {
-      expect(
-        screen.getByText("Reviewing the launch notes."),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText("Adding the rollback steps."),
-      ).toBeInTheDocument();
-      expect(screen.getAllByText("Prepare the launch plan")).toHaveLength(1);
-      expect(
-        screen.getAllByText("Also include the rollback steps"),
-      ).toHaveLength(1);
-      expect(
-        screen.getAllByText("Keep the rollback checklist concise"),
-      ).toHaveLength(1);
-    });
-  });
-
-  it("keeps a trailing steered user message outside completed work", async () => {
-    const threadId = "thread-work-folding-trailing-steered-user";
-    const runId = "run-work-folding-trailing-steered-user";
-    mockChatLifecycle(context, {
-      threadId,
-      chatEvents: [
+    },
+    {
+      name: "keeps one assistant before a trailing user unfolded",
+      caseId: "single-assistant-before-user",
+      sequence: ["U1", "A2", "U2"],
+      visibleOrder: ["U1", "A2", "U2"],
+      usageAssistant: "A2",
+      folds: [],
+    },
+    {
+      name: "folds earlier assistant work before a trailing user",
+      caseId: "fold-before-user",
+      sequence: ["U1", "A2", "A3", "U2"],
+      visibleOrder: ["U1", "Worked for 20s", "A3", "U2"],
+      usageAssistant: "A3",
+      folds: [
         {
-          role: "user",
-          content: "Prepare the launch plan",
-          runId,
-          createdAt: "2026-08-04T10:00:00Z",
+          label: "Worked for 20s",
+          hidden: ["A2"],
+          final: "A3",
         },
-        {
-          role: "assistant",
-          content: "Reviewing the launch notes.",
-          runId,
-          createdAt: "2026-08-04T10:00:10Z",
+      ],
+    },
+    {
+      name: "keeps one assistant in each user phase unfolded",
+      caseId: "single-assistant-per-phase",
+      sequence: ["U1", "A2", "U2", "A3"],
+      visibleOrder: ["U1", "A2", "U2", "A3"],
+      usageAssistant: "A3",
+      folds: [],
+    },
+  ])(
+    "$name",
+    async ({ caseId, sequence, visibleOrder, usageAssistant, folds }) => {
+      const threadId = `thread-work-folding-${caseId}`;
+      const runId = `run-work-folding-${caseId}`;
+      const chatEvents: MockChatEventInput[] = sequence.map(
+        (content, index) => {
+          const createdAt = new Date(
+            Date.UTC(2026, 7, 5, 10, 0, index * 10),
+          ).toISOString();
+          if (content.startsWith("U")) {
+            return { role: "user", content, runId, createdAt };
+          }
+          return {
+            role: "assistant",
+            content,
+            runId,
+            createdAt,
+            ...(index === sequence.length - 1
+              ? { runLifecycleEvent: "completed" as const }
+              : {}),
+          };
         },
-        {
-          role: "assistant",
-          content: "The launch plan is ready.",
-          runId,
-          createdAt: "2026-08-04T10:00:20Z",
-        },
-        {
-          role: "user",
-          content: "Also include the rollback steps",
-          runId,
-          createdAt: "2026-08-04T10:00:30Z",
-        },
-        {
+      );
+      if (sequence.at(-1)?.startsWith("U")) {
+        chatEvents.push({
           role: "assistant",
           content: null,
           runId,
           runLifecycleEvent: "completed",
-          createdAt: "2026-08-04T10:00:40Z",
+          createdAt: new Date(
+            Date.UTC(2026, 7, 5, 10, 0, sequence.length * 10),
+          ).toISOString(),
+        });
+      }
+      chatEvents.push({
+        role: "assistant",
+        content: null,
+        runId,
+        usage: {
+          version: 1,
+          totalCredits: 12,
+          settledAt: new Date(
+            Date.UTC(2026, 7, 5, 10, 0, sequence.length * 10 + 1),
+          ).toISOString(),
+          breakdown: [],
         },
-      ],
-    });
+        createdAt: new Date(
+          Date.UTC(2026, 7, 5, 10, 0, sequence.length * 10 + 1),
+        ).toISOString(),
+      });
+      mockChatLifecycle(context, { threadId, chatEvents });
 
-    detachedSetupPage({
-      context,
-      path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ChatSteer]: true },
-    });
+      detachedSetupPage({
+        context,
+        path: `/chats/${threadId}`,
+        featureSwitches: { [FeatureSwitchKey.ChatSteer]: true },
+      });
 
-    const expandButton = await screen.findByLabelText("Expand work history");
-    const messageContainer = expandButton.closest(
-      "[data-message-container]",
-    ) as HTMLElement | null;
-    expect(messageContainer).not.toBeNull();
-    expect(screen.queryByText("Reviewing the launch notes.")).toBeNull();
-    expectTextBefore(
-      messageContainer!,
-      "Prepare the launch plan",
-      "Also include the rollback steps",
-    );
-    expectTextBefore(
-      messageContainer!,
-      "Also include the rollback steps",
-      "Worked for 40s",
-    );
-    expectTextBefore(
-      messageContainer!,
-      "Worked for 40s",
-      "The launch plan is ready.",
-    );
+      await screen.findByText(visibleOrder[0]!);
+      const expandButtons = screen.queryAllByLabelText("Expand work history");
+      expect(expandButtons).toHaveLength(folds.length);
+      for (const [index, fold] of folds.entries()) {
+        const expandButton = expandButtons[index]!;
+        expect(expandButton).toHaveTextContent(fold.label);
+        const assistantGroup = expandButton.closest(
+          '[data-role="assistant"]',
+        ) as HTMLElement | null;
+        expect(assistantGroup).not.toBeNull();
+        expect(
+          within(assistantGroup!).getByText(fold.final),
+        ).toBeInTheDocument();
+        for (const hidden of fold.hidden) {
+          expect(within(assistantGroup!).queryByText(hidden)).toBeNull();
+        }
+      }
+      for (let index = 1; index < visibleOrder.length; index++) {
+        expectTextBefore(
+          document.body,
+          visibleOrder[index - 1]!,
+          visibleOrder[index]!,
+        );
+      }
+      for (const [index, fold] of folds.entries()) {
+        const expandButton = expandButtons[index]!;
+        const assistantGroup = expandButton.closest(
+          '[data-role="assistant"]',
+        ) as HTMLElement;
+        click(expandButton);
+        await waitFor(() => {
+          for (const hidden of fold.hidden) {
+            expect(
+              within(assistantGroup).getByText(hidden),
+            ).toBeInTheDocument();
+          }
+        });
+      }
 
-    click(expandButton);
-    await waitFor(() => {
+      const usageButtons = screen.queryAllByLabelText("Credit usage 12");
+      expect(usageButtons).toHaveLength(1);
+      const usageAssistantGroup = usageButtons[0]!.closest(
+        '[data-role="assistant"]',
+      ) as HTMLElement | null;
+      expect(usageAssistantGroup).not.toBeNull();
       expect(
-        screen.getByText("Reviewing the launch notes."),
+        within(usageAssistantGroup!).getByText(usageAssistant),
       ).toBeInTheDocument();
-      expect(screen.getAllByText("Prepare the launch plan")).toHaveLength(1);
-      expect(
-        screen.getAllByText("Also include the rollback steps"),
-      ).toHaveLength(1);
-    });
-  });
+    },
+  );
 
   it("keeps the legacy trailing-user layout when chat steer is disabled", async () => {
     const threadId = "thread-work-folding-trailing-user-disabled";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2997,12 +2997,31 @@ function attachUsageToCompletedWorkGroups(
   groups: readonly ChatEventGroup[],
   usageByRunId: ReadonlyMap<string, ChatEventUsagePayload>,
 ): ChatEventGroup[] {
-  return groups.map((group) => {
+  const lastAssistantGroupIndexByRunId = new Map<string, number>();
+  for (const [index, group] of groups.entries()) {
+    if (
+      group.role !== "assistant" ||
+      !group.events.some(isRenderableAssistantEvent)
+    ) {
+      continue;
+    }
+    const runId = firstRunIdForEvents(group.events);
+    if (runId !== undefined) {
+      lastAssistantGroupIndexByRunId.set(runId, index);
+    }
+  }
+  return groups.map((group, index) => {
     if (group.role !== "assistant") {
       return group;
     }
     const runId = firstRunIdForEvents(group.events);
-    const usage = runId === undefined ? undefined : usageByRunId.get(runId);
+    if (
+      runId === undefined ||
+      lastAssistantGroupIndexByRunId.get(runId) !== index
+    ) {
+      return group;
+    }
+    const usage = usageByRunId.get(runId);
     return usage === undefined ? group : { ...group, usage };
   });
 }
@@ -3036,6 +3055,118 @@ function terminatedRunIdsForCompletedWork(
   return terminatedChatRunIds(events);
 }
 
+function splitCompletedWorkEventsAtUsers(
+  events: readonly EnrichedChatEvent[],
+): EnrichedChatEvent[][] {
+  const phases: EnrichedChatEvent[][] = [];
+  let phase: EnrichedChatEvent[] = [];
+  for (const event of events) {
+    if (
+      phase.length > 0 &&
+      chatEventCompatibilityRole(event.eventType) === "user"
+    ) {
+      phases.push(phase);
+      phase = [];
+    }
+    phase.push(event);
+  }
+  if (phase.length > 0) {
+    phases.push(phase);
+  }
+  return phases;
+}
+
+function lastCompletedWorkEventIndex(
+  events: readonly EnrichedChatEvent[],
+  predicate: (event: EnrichedChatEvent) => boolean,
+): number {
+  for (let index = events.length - 1; index >= 0; index--) {
+    if (predicate(events[index]!)) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function completedWorkFinalEventIndex(
+  events: readonly EnrichedChatEvent[],
+): number {
+  const primaryResultIndex = lastCompletedWorkEventIndex(
+    events,
+    isPrimaryAssistantResultEvent,
+  );
+  return primaryResultIndex >= 0
+    ? primaryResultIndex
+    : lastCompletedWorkEventIndex(events, isRenderableAssistantEvent);
+}
+
+function canFoldCompletedWorkTrailingEvent(
+  event: EnrichedChatEvent,
+  chatSteerEnabled: boolean,
+): boolean {
+  const role = chatEventCompatibilityRole(event.eventType);
+  if (chatSteerEnabled && role === "user") {
+    return true;
+  }
+  return (
+    role === "assistant" &&
+    (!isRenderableAssistantEvent(event) || event.eventType === "run.completed")
+  );
+}
+
+interface CompletedWorkPhaseFolding {
+  visibleEvents: readonly EnrichedChatEvent[];
+  fold: CompletedWorkFold | null;
+}
+
+function foldCompletedWorkPhase(
+  runId: string,
+  events: readonly EnrichedChatEvent[],
+  chatSteerEnabled: boolean,
+): CompletedWorkPhaseFolding {
+  const finalEventIndex = completedWorkFinalEventIndex(events);
+  const finalEvent =
+    finalEventIndex >= 0 ? events[finalEventIndex]! : undefined;
+  const precedingEvents =
+    finalEventIndex > 0 ? events.slice(0, finalEventIndex) : [];
+  const hiddenEvents = precedingEvents.filter((event) => {
+    return (
+      chatEventCompatibilityRole(event.eventType) !== "user" &&
+      !isThinkingOnlyAssistantEvent(event)
+    );
+  });
+  const userEvents = (chatSteerEnabled ? events : precedingEvents).filter(
+    (event) => {
+      return chatEventCompatibilityRole(event.eventType) === "user";
+    },
+  );
+  const trailingEvents =
+    finalEventIndex >= 0 ? events.slice(finalEventIndex + 1) : [];
+  const trailingEventsCanFold = trailingEvents.every((event) => {
+    return canFoldCompletedWorkTrailingEvent(event, chatSteerEnabled);
+  });
+  if (
+    finalEvent === undefined ||
+    hiddenEvents.length === 0 ||
+    !trailingEventsCanFold
+  ) {
+    return { visibleEvents: events, fold: null };
+  }
+  return {
+    visibleEvents: [
+      ...userEvents,
+      finalEvent,
+      ...trailingEvents.filter(isRenderableAssistantEvent),
+    ],
+    fold: {
+      key: `${runId}:${finalEvent.id}`,
+      finalEventId: finalEvent.id,
+      hiddenGroups: groupEventsByRole(hiddenEvents),
+      labelGroups: groupEventsByRole(events),
+    },
+  };
+}
+
 function buildCompletedWorkFolding(
   groups: readonly ChatEventGroup[],
   chatSteerEnabled: boolean,
@@ -3047,6 +3178,7 @@ function buildCompletedWorkFolding(
   const terminatedRunIds = terminatedRunIdsForCompletedWork(events);
   const visibleEvents: EnrichedChatEvent[] = [];
   const folds: CompletedWorkFold[] = [];
+  let hasCompletedWorkPhaseBoundary = false;
 
   for (let index = 0; index < events.length; ) {
     const runId = events[index]!.runId;
@@ -3068,70 +3200,28 @@ function buildCompletedWorkFolding(
       continue;
     }
 
-    let finalEventIndex = -1;
-    for (let offset = runEvents.length - 1; offset >= 0; offset--) {
-      if (isPrimaryAssistantResultEvent(runEvents[offset]!)) {
-        finalEventIndex = offset;
-        break;
-      }
+    const completedWorkEventGroups = chatSteerEnabled
+      ? splitCompletedWorkEventsAtUsers(runEvents)
+      : [runEvents];
+    if (completedWorkEventGroups.length > 1) {
+      hasCompletedWorkPhaseBoundary = true;
     }
-    if (finalEventIndex < 0) {
-      for (let offset = runEvents.length - 1; offset >= 0; offset--) {
-        if (isRenderableAssistantEvent(runEvents[offset]!)) {
-          finalEventIndex = offset;
-          break;
-        }
+    for (const completedWorkEvents of completedWorkEventGroups) {
+      const phaseFolding = foldCompletedWorkPhase(
+        runId,
+        completedWorkEvents,
+        chatSteerEnabled,
+      );
+      visibleEvents.push(...phaseFolding.visibleEvents);
+      if (phaseFolding.fold !== null) {
+        folds.push(phaseFolding.fold);
       }
-    }
-    const finalEvent =
-      finalEventIndex >= 0 ? runEvents[finalEventIndex]! : undefined;
-    const precedingEvents =
-      finalEventIndex > 0 ? runEvents.slice(0, finalEventIndex) : [];
-    const hiddenEvents = precedingEvents.filter((event) => {
-      return (
-        chatEventCompatibilityRole(event.eventType) !== "user" &&
-        !isThinkingOnlyAssistantEvent(event)
-      );
-    });
-    const userEvents = (chatSteerEnabled ? runEvents : precedingEvents).filter(
-      (event) => {
-        return chatEventCompatibilityRole(event.eventType) === "user";
-      },
-    );
-    const trailingEvents =
-      finalEventIndex >= 0 ? runEvents.slice(finalEventIndex + 1) : [];
-    const trailingEventsCanFold = trailingEvents.every((event) => {
-      const role = chatEventCompatibilityRole(event.eventType);
-      return (
-        (chatSteerEnabled && role === "user") ||
-        (role === "assistant" &&
-          (!isRenderableAssistantEvent(event) ||
-            event.eventType === "run.completed"))
-      );
-    });
-    const visibleTrailingEvents = trailingEvents.filter((event) => {
-      return isRenderableAssistantEvent(event);
-    });
-    if (
-      finalEvent !== undefined &&
-      hiddenEvents.length > 0 &&
-      trailingEventsCanFold
-    ) {
-      visibleEvents.push(...userEvents, finalEvent, ...visibleTrailingEvents);
-      folds.push({
-        key: `${runId}:${finalEvent.id}`,
-        finalEventId: finalEvent.id,
-        hiddenGroups: groupEventsByRole(hiddenEvents),
-        labelGroups: groupEventsByRole(runEvents),
-      });
-    } else {
-      visibleEvents.push(...runEvents);
     }
 
     index = endIndex;
   }
 
-  if (folds.length === 0) {
+  if (folds.length === 0 && !hasCompletedWorkPhaseBoundary) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

- split completed ChatSteer runs into user-delimited phases
- fold intermediate assistant work within each phase while preserving the phase's final response
- attach run usage only to the final renderable assistant group
- cover the four requested message sequences, independent fold expansion, ordering, and usage ownership

## Verification

- `pnpm --filter @vm0/app run lint`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-run-results.test.tsx` (40 passed)

## Notes

- `pnpm knip` still reports the pre-existing unused root `e2b` devDependency; this PR does not modify `package.json`.
