### PR TITLE
refactor(platform): remove legacy permission agent reload

### DIFF
--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -13,7 +13,7 @@ import {
 import { zeroClient$ } from "../api-client.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { accept } from "../../lib/accept.ts";
-import { agentById, currentAgentId$, reloadAgentById$ } from "../agent.ts";
+import { agentById, currentAgentId$ } from "../agent.ts";
 import { firewallPermissionMetadataByConnector } from "../firewall-permission-metadata.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { retryTransientLoad } from "../utils.ts";
@@ -62,10 +62,7 @@ export const permissionAllowExpiresIn$ = computed((get) => {
 // Agent data
 // ---------------------------------------------------------------------------
 
-const internalAgentReload$ = state(0);
-
 export const permissionAllowAgent$ = computed((get) => {
-  get(internalAgentReload$);
   const agentId = get(permissionAllowAgentId$);
   if (!agentId) {
     return null;
@@ -223,10 +220,6 @@ export const applyUserPermissionGrants$ = command(
     set(internalUserPermissionGrantsReload$, (prev) => {
       return prev + 1;
     });
-    set(internalAgentReload$, (prev) => {
-      return prev + 1;
-    });
-    set(reloadAgentById$);
     return result.body;
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -9,6 +9,7 @@ import {
   zeroBrowserContract,
   type ZeroBrowserSession,
 } from "@vm0/api-contracts/contracts/zero-browser";
+import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroMailContract } from "@vm0/api-contracts/contracts/zero-mail";
 import {
   zeroConnectorCatalogContract,
@@ -34,7 +35,7 @@ import {
 import { isoFromNowMs, mockNow } from "../../../__tests__/time.ts";
 import { triggerAblyEvent, hasSubscription } from "../../../mocks/ably.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { mockChatLifecycle } from "./chat-test-helpers.ts";
+import { PLACEHOLDER, mockChatLifecycle } from "./chat-test-helpers.ts";
 
 const context = testContext();
 
@@ -3208,10 +3209,54 @@ describe("chat event action cards", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("keeps permission success visible while permission grants reload", async () => {
+  it("keeps permission success and composer connectors visible while grants reload", async () => {
     mockNow();
     const user = userEvent.setup({ delay: null });
+    const threadId = "b0000000-0000-4000-a000-000000000991";
     const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=gmail&permission=messages.write&action=allow&expiresIn=1h`;
+    let holdAgentResponse = false;
+    context.mocks.api(
+      zeroAgentsByIdContract.get,
+      async ({ deferred, params, respond }) => {
+        if (holdAgentResponse) {
+          const agentDeferred = deferred<void>();
+          await agentDeferred.promise;
+        }
+        return respond(200, {
+          agentId: params.id,
+          ownerId: "test-user-123",
+          description: null,
+          displayName: "Zero",
+          sound: null,
+          avatarUrl: null,
+          modelProviderId: null,
+          selectedModel: null,
+          preferPersonalProvider: false,
+        });
+      },
+    );
+    context.mocks.data.connectors([
+      connectedConnector({
+        slug: "gmail",
+        authMethod: "oauth",
+        externalEmail: "sender@example.com",
+      }),
+    ]);
+    mockConnectorCatalogStatus([
+      publicConnectorStatusItem({
+        slug: "gmail",
+        label: "Gmail",
+        connected: true,
+        connectionStatus: "connected",
+        connection: {
+          authMethod: "oauth",
+          externalUsername: null,
+          externalEmail: "sender@example.com",
+          reconnectReason: null,
+        },
+      }),
+    ]);
+    mockAgentConnectorAuthorizations(["gmail"]);
     let listRequests = 0;
     let storedGrants: UserPermissionGrantResponse[] = [];
     let resolveReload: () => void = () => {
@@ -3257,7 +3302,7 @@ describe("chat event action cards", () => {
     );
 
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-permission-save-reload`,
+      threadId,
       threadTitle: "Permission save reload",
       chatEvents: [
         {
@@ -3279,10 +3324,20 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-permission-save-reload`,
+      path: `/chats/${threadId}`,
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
+    const composerEditor = await screen.findByPlaceholderText(PLACEHOLDER);
+    const composer = composerEditor.closest(".zero-composer");
+    if (!(composer instanceof HTMLElement)) {
+      throw new Error("Composer element not found");
+    }
+    await user.click(within(composer).getByLabelText("Connectors"));
+    const gmailConnector = await screen.findByText("Gmail");
+    expect(gmailConnector).toBeInTheDocument();
+
+    holdAgentResponse = true;
     await confirmPermissionAction(user, permissionCard);
 
     await waitFor(() => {
@@ -3294,6 +3349,8 @@ describe("chat event action cards", () => {
     expect(
       within(permissionCard).queryByText("Checking permission status..."),
     ).not.toBeInTheDocument();
+    await user.click(within(composer).getByLabelText("Connectors"));
+    expect(screen.getByText("Gmail")).toBeInTheDocument();
 
     resolveReload();
     await waitFor(() => {


### PR DESCRIPTION
## Summary

- remove the legacy permission-specific agent invalidation and global agent reload after permission grants are saved
- keep the permission-grant invalidation used for local refresh and Ably cross-client synchronization
- cover the chat action-card flow so the composer connector list stays populated while permission grants reload

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (the API package was rerun with a 4 GiB Node heap after the default local heap OOM)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-event-action-cards.test.tsx` (35 tests)
