### PR TITLE
fix(runner): keep info logs out of axiom

### DIFF
--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -1,4 +1,4 @@
-//! Tracing layer that ships WARN+ and narrowly allowlisted INFO events to Axiom.
+//! Tracing layer that ships WARN+ events to Axiom.
 //!
 //! Disabled at construction when `AXIOM_TOKEN_TELEMETRY` or
 //! `AXIOM_DATASET_SUFFIX` is unset. Dual-write: the existing fmt subscriber
@@ -14,7 +14,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use reqwest::Client;
-use sandbox_fc::BALLOON_SETTLE_AXIOM_TARGET;
 use serde_json::{Map, Value};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -24,12 +23,9 @@ use tracing_subscriber::filter::{self, FilterFn};
 use tracing_subscriber::layer::{Context, Layer};
 use tracing_subscriber::registry::LookupSpan;
 
-use crate::telemetry::{PRE_PARK_HANDOFF_AXIOM_TARGET, RESERVED_REUSE_CLAIM_AXIOM_TARGET};
-
 /// Bounded-channel capacity between tracing callers and the dispatcher task.
-/// WARN+ and the selected-candidate measurement events are low-volume, so 1024
-/// absorbs realistic bursts; overflow is counted + surfaced via stderr rather
-/// than blocking the tracing hot path.
+/// WARN+ events are low-volume, so 1024 absorbs realistic bursts; overflow is
+/// counted + surfaced via stderr rather than blocking the tracing hot path.
 const CHANNEL_CAP: usize = 1024;
 /// Max events per ingest POST. Axiom accepts thousands per batch, but a small
 /// cap keeps POST body size and peak dispatcher memory predictable.
@@ -172,15 +168,7 @@ pub(crate) struct AxiomLayer {
 }
 
 fn should_ingest(metadata: &Metadata<'_>) -> bool {
-    // Errors and warnings remain the general threshold. Three exact INFO targets
-    // carry bounded production measurements that have no authenticated
-    // per-job telemetry owner. DEBUG/TRACE and all other INFO events stay
-    // local-only.
-    (*metadata.level() <= tracing::Level::WARN && metadata.target() != INTERNAL_TARGET)
-        || (*metadata.level() == tracing::Level::INFO
-            && (metadata.target() == PRE_PARK_HANDOFF_AXIOM_TARGET
-                || metadata.target() == RESERVED_REUSE_CLAIM_AXIOM_TARGET
-                || metadata.target() == BALLOON_SETTLE_AXIOM_TARGET))
+    *metadata.level() <= tracing::Level::WARN && metadata.target() != INTERNAL_TARGET
 }
 
 fn ingest_filter() -> FilterFn<fn(&Metadata<'_>) -> bool> {

--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -12,13 +12,10 @@ use super::{INTERNAL_TARGET, init_from_env_values, init_with_base_url, with_inge
 use httpmock::Method::POST;
 use httpmock::MockServer;
 use httpmock::{HttpMockRequest, HttpMockResponse, Mock};
-use sandbox_fc::BALLOON_SETTLE_AXIOM_TARGET;
 use serde_json::{Value, json};
 use tracing::field::{Field, Visit};
 use tracing::{Event, Subscriber};
 use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
-
-use crate::telemetry::{PRE_PARK_HANDOFF_AXIOM_TARGET, RESERVED_REUSE_CLAIM_AXIOM_TARGET};
 
 #[derive(Clone, Debug)]
 struct RecordedEvent {
@@ -185,16 +182,12 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
         tracing::error!(code = 42, "a failure");
         tracing::info!("info is below threshold, should not be ingested");
         tracing::info!(
-            target: PRE_PARK_HANDOFF_AXIOM_TARGET,
+            target: "runner::pre_park_successor_handoff",
             outcome = "retained",
-            "allowlisted measurement"
-        );
-        tracing::debug!(
-            target: PRE_PARK_HANDOFF_AXIOM_TARGET,
-            "allowlisted target below INFO"
+            "pre-park INFO measurement"
         );
         tracing::info!(
-            target: RESERVED_REUSE_CLAIM_AXIOM_TARGET,
+            target: "runner::reserved_reuse_claim",
             measurement = "reserved_reuse_claim",
             outcome = "claimed",
             run_id = "00000000-0000-0000-0000-000000000001",
@@ -203,34 +196,14 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
             timezone_state = "absent",
             "reserved reusable claim observed"
         );
-        tracing::debug!(
-            target: RESERVED_REUSE_CLAIM_AXIOM_TARGET,
-            "reserved reuse target below INFO"
-        );
         tracing::info!(
-            target: "runner::reserved_reuse_claim::detail",
-            "reserved reuse sibling INFO target"
-        );
-        tracing::info!(
-            target: BALLOON_SETTLE_AXIOM_TARGET,
+            target: "sandbox_fc::balloon_settle",
             measurement = "balloon_settle",
             outcome = "target_reached",
             elapsed_ms = 25_u64,
             sample_count = 2_u64,
             admission_action = "reuse",
             "balloon settle completed"
-        );
-        tracing::debug!(
-            target: BALLOON_SETTLE_AXIOM_TARGET,
-            "balloon target below INFO"
-        );
-        tracing::trace!(
-            target: BALLOON_SETTLE_AXIOM_TARGET,
-            "balloon target at TRACE"
-        );
-        tracing::info!(
-            target: "sandbox_fc::balloon_settle::detail",
-            "balloon sibling INFO target"
         );
     }
 
@@ -251,51 +224,17 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
     assert_eq!(failure["service"], json!("runner"));
     assert_eq!(failure["level"], json!("error"));
     assert_eq!(failure["code"], json!(42));
-    let measurement = event_with_message(&events, "allowlisted measurement");
-    assert_eq!(measurement["level"], json!("info"));
-    assert_eq!(measurement["outcome"], json!("retained"));
-    let reserved_reuse = event_with_message(&events, "reserved reusable claim observed");
-    assert_eq!(reserved_reuse["level"], json!("info"));
-    assert_eq!(reserved_reuse["measurement"], json!("reserved_reuse_claim"));
-    assert_eq!(reserved_reuse["outcome"], json!("claimed"));
-    assert_eq!(reserved_reuse["duration_ms"], json!(42));
-    assert_eq!(reserved_reuse["preference_reason"], json!("none"));
-    assert_eq!(reserved_reuse["timezone_state"], json!("absent"));
-    let balloon = event_with_message(&events, "balloon settle completed");
-    assert_eq!(balloon["level"], json!("info"));
-    assert_eq!(balloon["measurement"], json!("balloon_settle"));
-    assert_eq!(balloon["outcome"], json!("target_reached"));
-    assert_eq!(balloon["elapsed_ms"], json!(25));
-    assert_eq!(balloon["sample_count"], json!(2));
-    assert_eq!(balloon["admission_action"], json!("reuse"));
-    assert!(
-        !has_event_with_message(&events, "info is below threshold, should not be ingested"),
-        "ordinary INFO event should not be ingested: {events:#?}",
-    );
-    assert!(
-        !has_event_with_message(&events, "allowlisted target below INFO"),
-        "allowlisted DEBUG event should not be ingested: {events:#?}",
-    );
-    assert!(
-        !has_event_with_message(&events, "reserved reuse target below INFO"),
-        "reserved-reuse DEBUG event should not be ingested: {events:#?}",
-    );
-    assert!(
-        !has_event_with_message(&events, "reserved reuse sibling INFO target"),
-        "reserved-reuse sibling INFO event should not be ingested: {events:#?}",
-    );
-    assert!(
-        !has_event_with_message(&events, "balloon target below INFO"),
-        "balloon DEBUG event should not be ingested: {events:#?}",
-    );
-    assert!(
-        !has_event_with_message(&events, "balloon target at TRACE"),
-        "balloon TRACE event should not be ingested: {events:#?}",
-    );
-    assert!(
-        !has_event_with_message(&events, "balloon sibling INFO target"),
-        "only the exact balloon INFO target should be ingested: {events:#?}",
-    );
+    for message in [
+        "info is below threshold, should not be ingested",
+        "pre-park INFO measurement",
+        "reserved reusable claim observed",
+        "balloon settle completed",
+    ] {
+        assert!(
+            !has_event_with_message(&events, message),
+            "INFO event should not be ingested: {events:#?}",
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/runner/src/cmd/start/pre_park_handoff_observation.rs
+++ b/crates/runner/src/cmd/start/pre_park_handoff_observation.rs
@@ -1,5 +1,6 @@
 use crate::provider::{JobCandidate, RunnerPreferenceReason};
-use crate::telemetry::PRE_PARK_HANDOFF_AXIOM_TARGET;
+
+const TRACING_TARGET: &str = "runner::pre_park_successor_handoff";
 
 #[derive(Clone, Copy)]
 pub(super) enum CandidateOutcome {
@@ -67,7 +68,7 @@ pub(super) fn record_candidate_observation(
     let successor_run_id = candidate.run_id();
     match (candidate.history_generation_run_id(), reason) {
         (Some(predecessor_run_id), Some(reason)) => tracing::info!(
-            target: PRE_PARK_HANDOFF_AXIOM_TARGET,
+            target: TRACING_TARGET,
             measurement = "pre_park_successor_handoff",
             outcome = outcome.as_str(),
             reason = reason.as_str(),
@@ -78,7 +79,7 @@ pub(super) fn record_candidate_observation(
             "pre-park successor handoff candidate observed"
         ),
         (Some(predecessor_run_id), None) => tracing::info!(
-            target: PRE_PARK_HANDOFF_AXIOM_TARGET,
+            target: TRACING_TARGET,
             measurement = "pre_park_successor_handoff",
             outcome = outcome.as_str(),
             predecessor_run_id = %predecessor_run_id,
@@ -88,7 +89,7 @@ pub(super) fn record_candidate_observation(
             "pre-park successor handoff candidate observed"
         ),
         (None, Some(reason)) => tracing::info!(
-            target: PRE_PARK_HANDOFF_AXIOM_TARGET,
+            target: TRACING_TARGET,
             measurement = "pre_park_successor_handoff",
             outcome = outcome.as_str(),
             reason = reason.as_str(),
@@ -98,7 +99,7 @@ pub(super) fn record_candidate_observation(
             "pre-park successor handoff candidate observed"
         ),
         (None, None) => tracing::info!(
-            target: PRE_PARK_HANDOFF_AXIOM_TARGET,
+            target: TRACING_TARGET,
             measurement = "pre_park_successor_handoff",
             outcome = outcome.as_str(),
             successor_run_id = %successor_run_id,

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -40,7 +40,6 @@ use crate::error::{ApiStatusError, RunnerError, RunnerResult};
 use crate::http::{ApiRequestBuilder, HttpClient};
 use crate::ids::RunId;
 use crate::run_cancellation::RunCancellationRegistry;
-use crate::telemetry::RESERVED_REUSE_CLAIM_AXIOM_TARGET;
 use crate::types::{
     CompleteRequest, ExecutionContext, HeartbeatState, Job, NetworkPolicyRefreshBatchResponse,
     PollResponse, SandboxReuseResult,
@@ -48,6 +47,7 @@ use crate::types::{
 use sandbox::SandboxId;
 
 const CHAT_STEER_FEATURE_FLAG: &str = "chatSteer";
+const RESERVED_REUSE_CLAIM_TRACING_TARGET: &str = "runner::reserved_reuse_claim";
 
 fn chat_steer_enabled(
     reuse_key: Option<&str>,
@@ -198,7 +198,7 @@ fn record_reserved_reuse_claim_observation(
 
     match outcome {
         ReservedReuseClaimOutcome::Claimed { timezone_state } => tracing::info!(
-            target: RESERVED_REUSE_CLAIM_AXIOM_TARGET,
+            target: RESERVED_REUSE_CLAIM_TRACING_TARGET,
             measurement = "reserved_reuse_claim",
             outcome = "claimed",
             run_id = %run_id,
@@ -211,7 +211,7 @@ fn record_reserved_reuse_claim_observation(
             "reserved reusable claim observed"
         ),
         ReservedReuseClaimOutcome::Unavailable => tracing::info!(
-            target: RESERVED_REUSE_CLAIM_AXIOM_TARGET,
+            target: RESERVED_REUSE_CLAIM_TRACING_TARGET,
             measurement = "reserved_reuse_claim",
             outcome = "unavailable",
             run_id = %run_id,
@@ -223,7 +223,7 @@ fn record_reserved_reuse_claim_observation(
             "reserved reusable claim observed"
         ),
         ReservedReuseClaimOutcome::ProviderFailure { class } => tracing::info!(
-            target: RESERVED_REUSE_CLAIM_AXIOM_TARGET,
+            target: RESERVED_REUSE_CLAIM_TRACING_TARGET,
             measurement = "reserved_reuse_claim",
             outcome = "provider_failure",
             failure_class = class.as_str(),
@@ -236,7 +236,7 @@ fn record_reserved_reuse_claim_observation(
             "reserved reusable claim observed"
         ),
         ReservedReuseClaimOutcome::ResponseRunIdMismatch => tracing::info!(
-            target: RESERVED_REUSE_CLAIM_AXIOM_TARGET,
+            target: RESERVED_REUSE_CLAIM_TRACING_TARGET,
             measurement = "reserved_reuse_claim",
             outcome = "response_run_id_mismatch",
             run_id = %run_id,

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -24,14 +24,6 @@ const FLUSH_THRESHOLD: Duration = Duration::from_secs(30);
 /// Timeout for telemetry HTTP requests (shorter than default API timeout).
 const TELEMETRY_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Exact tracing target whose selected-candidate INFO events are admitted to
-/// the production Axiom log layer.
-pub(crate) const PRE_PARK_HANDOFF_AXIOM_TARGET: &str = "runner::pre_park_successor_handoff";
-
-/// Exact tracing target whose reserved-reuse claim INFO events are admitted
-/// to the production Axiom log layer.
-pub(crate) const RESERVED_REUSE_CLAIM_AXIOM_TARGET: &str = "runner::reserved_reuse_claim";
-
 /// Per-job telemetry collector. Buffers sandbox operations and flushes them
 /// periodically (auto on 30 s threshold) and at job end.
 ///

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -74,6 +74,3 @@ pub use sandbox::FirecrackerSandbox;
 pub use snapshot::{
     FirecrackerSnapshotProvider, SNAPSHOT_COMPLETE_MARKER_CONTENT, SnapshotError, create_snapshot,
 };
-
-/// Exact tracing target for the bounded balloon-settlement production summary.
-pub const BALLOON_SETTLE_AXIOM_TARGET: &str = "sandbox_fc::balloon_settle";

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3427,7 +3427,7 @@ fn emit_balloon_settle_summary(
     park_outcome: SandboxParkOutcome,
 ) {
     info!(
-        target: crate::BALLOON_SETTLE_AXIOM_TARGET,
+        target: "sandbox_fc::balloon_settle",
         measurement = "balloon_settle",
         outcome = settle_outcome.as_str(),
         elapsed_ms,


### PR DESCRIPTION
## Summary

- restrict the runner Axiom tracing sink to WARN and ERROR events
- keep performance INFO observations local and remove their Axiom-specific target coupling
- cover ordinary INFO and every formerly allowlisted INFO target as negative ingest cases

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p runner -p sandbox-fc --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner -p sandbox-fc --all-features --no-deps`
- `cargo test -p runner -p sandbox-fc --all-targets --all-features`