### PR TITLE
perf(python): bound non-streaming x json inspection work

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -102,6 +102,9 @@ def _strip_request_target_query(request_target: str) -> str:
 # exceeding it indicates malformed or hostile upstream data, so the parser
 # discards that row through its terminating newline to protect memory.
 _MAX_NDJSON_LINE_BYTES = LARGE_RESPONSE_DECOMPRESS_LIMIT
+# Bound dense syntax and slow scalar inspection across one non-streaming X JSON
+# response while retaining the selective parser's bulk discarded-string path.
+_MAX_JSON_RESPONSE_WORK_UNITS = 65_536
 # Bound dense syntax and slow scalar inspection while keeping multi-megabyte
 # ordinary discarded strings on the selective parser's bulk-scan path.
 _MAX_NDJSON_ROW_WORK_UNITS = 65_536
@@ -241,6 +244,7 @@ def _create_x_json_selective_extractor() -> JsonSelectiveExtractor:
         array_count_paths={("data",), ("errors",)},
         wildcard_array_count_paths={("includes", "*")},
         object_presence_paths={(), ("data",)},
+        max_work_units=_MAX_JSON_RESPONSE_WORK_UNITS,
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -13,13 +13,18 @@ from mitmproxy.flow import Error
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
-from body_limits import STREAM_BUFFER_LIMIT
+from body_limits import (
+    STREAM_BUFFER_LIMIT,
+    STREAM_DECODE_CHUNK_LIMIT,
+    STREAM_DECODE_EXPANSION_GRACE,
+    STREAM_DECODE_MAX_EXPANSION_RATIO,
+)
 from tests.flow_helpers import response_stream
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.x_flow_helpers import (
     json_body_that_exceeds_integer_digit_limit,
     json_body_that_exceeds_nesting_limit,
-    json_body_that_exceeds_x_ndjson_work_limit,
+    json_body_that_exceeds_x_json_work_limit,
     make_x_pipeline_flow,
     make_x_stream_pipeline_flow,
 )
@@ -119,6 +124,79 @@ class TestXConnectorResponsePipeline:
             f"Streaming decompression skipped: {_STREAM_DECODE_SKIP_REASONS[encoding_case]}"
             in log.debug.call_args[0][0]
         )
+
+    @pytest.mark.parametrize("encoding_case", ["br", "zstd"])
+    def test_full_response_pipeline_bounds_buffered_x_json_fallback_work(
+        self, tmp_path, real_flow, mitm_ctx, encoding_case
+    ):
+        flow = make_x_pipeline_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/search/recent",
+            query="query=vm0",
+            rule="GET /2/tweets/search/recent",
+            content_encoding=encoding_case,
+        )
+        payload = json_body_that_exceeds_x_json_work_limit()
+        compressed = _compress_body(encoding_case, payload)
+        assert len(compressed) < STREAM_BUFFER_LIMIT < len(payload)
+
+        with mitm_ctx():
+            mitm_addon.responseheaders(flow)
+        assert response_stream(flow)(compressed) == compressed
+
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.response(flow)
+            usage.flush_usage_events(trigger="test")
+
+        assert webhook.request_count == 0
+        entries = read_jsonl_entries_after_flush(
+            Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+        )
+        lost_visibility_entries = [
+            entry for entry in entries if "unparseable" in entry["message"].lower()
+        ]
+        assert len(lost_visibility_entries) == 1
+        assert lost_visibility_entries[0]["body_truncated"] is False
+
+    @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
+    def test_full_response_pipeline_bounds_compressed_x_json_work(
+        self, tmp_path, real_flow, encoding_case
+    ):
+        flow = make_x_pipeline_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/search/recent",
+            query="query=vm0",
+            rule="GET /2/tweets/search/recent",
+            content_encoding=encoding_case,
+        )
+        payload = json_body_that_exceeds_x_json_work_limit()
+        compressed = _compress_body(encoding_case, payload)
+        allowed_decoded_bytes = max(
+            STREAM_DECODE_EXPANSION_GRACE,
+            len(compressed) * STREAM_DECODE_MAX_EXPANSION_RATIO,
+        )
+        assert STREAM_DECODE_CHUNK_LIMIT < len(payload) <= allowed_decoded_bytes
+
+        mitm_addon.responseheaders(flow)
+        assert response_stream(flow)(compressed) == compressed
+
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.response(flow)
+            usage.flush_usage_events(trigger="test")
+
+        assert webhook.request_count == 0
+        entries = read_jsonl_entries_after_flush(
+            Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+        )
+        lost_visibility_entries = [
+            entry for entry in entries if "unparseable" in entry["message"].lower()
+        ]
+        assert len(lost_visibility_entries) == 1
+        entry = lost_visibility_entries[0]
+        assert entry["body_truncated"] is False
+        assert entry["parse_error"] == "work limit exceeded"
 
     @pytest.mark.parametrize("encoding_case", ["br", "zstd"])
     def test_responseheaders_unsafe_compressed_x_stream_does_not_leave_parser_state(
@@ -367,7 +445,7 @@ class TestXConnectorResponsePipeline:
             pytest.param(json_body_that_exceeds_nesting_limit(), id="excessive-nesting"),
             pytest.param(json_body_that_exceeds_integer_digit_limit(), id="integer-digit-limit"),
             pytest.param(
-                json_body_that_exceeds_x_ndjson_work_limit(),
+                json_body_that_exceeds_x_json_work_limit(),
                 id="work-limit",
             ),
         ],
@@ -512,7 +590,7 @@ class TestXConnectorResponsePipeline:
         flow.metadata[metadata_keys.CAPTURE_BODY] = True
 
         mitm_addon.responseheaders(flow)
-        response_stream(flow)(b'{"data":[{"id":"1"},' + b" " * STREAM_BUFFER_LIMIT)
+        response_stream(flow)(b'{"data":[{"id":"1","text":"' + b"x" * STREAM_BUFFER_LIMIT)
         assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
 
         with self._usage_webhook_api() as webhook:
@@ -528,7 +606,7 @@ class TestXConnectorResponsePipeline:
         entry = lost_visibility_entries[0]
         assert entry["level"] == "error"
         assert entry["body_truncated"] is False
-        assert entry["parse_error"] == "incomplete json"
+        assert entry["parse_error"] == "incomplete string"
         assert "connector_response_finish" not in flow.metadata
 
     def test_response_uses_request_hints_for_incremental_x_json_parse_error(

--- a/crates/runner/mitm-addon/tests/test_x_response_parsers.py
+++ b/crates/runner/mitm-addon/tests/test_x_response_parsers.py
@@ -11,7 +11,7 @@ import response_streaming
 from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT, STREAM_BUFFER_LIMIT
 from tests.flow_helpers import response_stream
 from tests.x_flow_helpers import (
-    json_body_that_exceeds_x_ndjson_work_limit,
+    json_body_that_exceeds_x_json_work_limit,
     make_x_response_flow,
 )
 
@@ -132,7 +132,7 @@ class TestNdjsonExtractor:
                 id="dense-array",
             ),
             pytest.param(
-                json_body_that_exceeds_x_ndjson_work_limit(),
+                json_body_that_exceeds_x_json_work_limit(),
                 id="dense-objects",
             ),
         ],
@@ -387,6 +387,52 @@ class TestXJsonFinalize:
 
         response_streaming.finalize_connector_response_state(flow)
         assert flow.metadata[metadata_keys.X_JSON_STATE] == state
+
+    def test_protocol_shaped_data_array_stays_within_work_limit(self, real_flow):
+        flow = self._billable_x_json_flow(real_flow)
+        data_item = b'{"id":"123456"}'
+        body = b'{"data":[' + b",".join([data_item] * 3_600) + b"]}"
+
+        mitm_addon.responseheaders(flow)
+        assert response_stream(flow)(body) == body
+        response_streaming.finalize_connector_response_state(flow)
+
+        assert flow.metadata[metadata_keys.X_JSON_STATE] == {
+            "body_parsed": True,
+            "body_truncated": False,
+            "response_data_count": 3_600,
+        }
+
+    def test_x_json_work_limit_discards_partial_state_and_next_flow_recovers(self, real_flow):
+        body = json_body_that_exceeds_x_json_work_limit()
+        flow = self._billable_x_json_flow(real_flow)
+        mitm_addon.responseheaders(flow)
+        callback = response_stream(flow)
+        midpoint = len(body) // 2
+
+        assert callback(body[:midpoint]) == body[:midpoint]
+        assert callback(body[midpoint:]) == body[midpoint:]
+        response_streaming.finalize_connector_response_state(flow)
+
+        state = {
+            "body_parsed": False,
+            "body_truncated": False,
+            "parse_error": "work limit exceeded",
+        }
+        assert flow.metadata[metadata_keys.X_JSON_STATE] == state
+        response_streaming.finalize_connector_response_state(flow)
+        assert flow.metadata[metadata_keys.X_JSON_STATE] == state
+
+        next_flow = self._billable_x_json_flow(real_flow)
+        mitm_addon.responseheaders(next_flow)
+        response_stream(next_flow)(b'{"data":[{"id":"after"}]}')
+        response_streaming.finalize_connector_response_state(next_flow)
+
+        assert next_flow.metadata[metadata_keys.X_JSON_STATE] == {
+            "body_parsed": True,
+            "body_truncated": False,
+            "response_data_count": 1,
+        }
 
     def test_forensic_buffer_truncation_does_not_stop_x_json_parser(self, real_flow):
         flow = make_x_response_flow(

--- a/crates/runner/mitm-addon/tests/x_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/x_flow_helpers.py
@@ -14,7 +14,7 @@ from tests.stream_buffer_helpers import set_response_stream_buffer
 RealFlowFactory = Callable[..., http.HTTPFlow]
 _JSON_EXCESSIVE_NESTING_DEPTH = 10_000
 _JSON_INTEGER_DIGIT_LIMIT_DIGITS = 10_000
-_X_NDJSON_DENSE_OBJECT_COUNT = 30_000
+_X_DENSE_OBJECT_COUNT = 30_000
 
 
 def x_original_url(path: str, query: str = "") -> str:
@@ -35,10 +35,10 @@ def json_body_that_exceeds_integer_digit_limit() -> bytes:
     return b'{"n":' + b"1" * _JSON_INTEGER_DIGIT_LIMIT_DIGITS + b"}"
 
 
-def json_body_that_exceeds_x_ndjson_work_limit() -> bytes:
+def json_body_that_exceeds_x_json_work_limit() -> bytes:
     return (
         b'{"data":{"id":"blocked"},"includes":{"users":[{},{},{}]},'
-        b'"matching_rules":[' + b",".join([b"{}"] * _X_NDJSON_DENSE_OBJECT_COUNT) + b"]}"
+        b'"matching_rules":[' + b",".join([b"{}"] * _X_DENSE_OBJECT_COUNT) + b"]}"
     )
 
 


### PR DESCRIPTION
## Summary

- bound non-streaming X JSON structural inspection to 65,536 work units per response document
- apply the same provider-owned policy to incremental parsing and the buffered fallback while preserving X NDJSON's independent per-row lifecycle
- discard partial billing observations on exhaustion, preserve response bytes, and retain the existing one-shot lost-visibility diagnostics and later-flow recovery
- add deterministic integration coverage for ordinary responses, split identity input, gzip/deflate multi-chunk decoding, and Brotli/Zstandard fallback parsing

## Scope

- no shared `JsonSelectiveExtractor` default or response decoder changes
- no API, persisted-state, database, environment, feature-switch, or deployment-order changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_x_response_parsers.py tests/test_x_connector_pipeline.py -q` (75 passed)
- `uv run --no-sync python -m pytest tests/` (4,742 passed)
- `lefthook run pre-commit`

Closes #25104
