### PR TITLE
fix(runner): distinguish r2 body transport failures

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2627,6 +2627,7 @@ dependencies = [
  "guest-reseed",
  "guest-write-file",
  "hex",
+ "http-body 1.1.0",
  "httpmock",
  "idna",
  "libc",

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -72,6 +72,7 @@ guest-reseed = { workspace = true }
 guest-write-file = { workspace = true }
 zero-cli = { workspace = true }
 httpmock = { workspace = true }
+http-body = "1"
 sandbox-mock = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tracing-test-support.workspace = true

--- a/crates/runner/src/cmd/build/tests/fixtures.rs
+++ b/crates/runner/src/cmd/build/tests/fixtures.rs
@@ -3,6 +3,8 @@ use super::*;
 use aws_smithy_mocks::{Rule, RuleMode, mock, mock_client};
 use std::sync::Arc;
 
+use crate::test_fixtures::http_body::byte_stream_with_error_after;
+
 pub(super) const TEST_TEMPLATE_DISK_BYTES: u64 = 128 * 1024 * 1024;
 
 #[derive(clap::Parser)]
@@ -209,6 +211,30 @@ pub(super) fn template_get_rule(body: Vec<u8>) -> Rule {
         .then_output(move || {
             GetObjectOutput::builder()
                 .body(ByteStream::from((*body_for_closure).clone()))
+                .build()
+        })
+}
+
+pub(super) fn template_get_body_error_rule(body: Vec<u8>) -> Rule {
+    use aws_sdk_s3::Client;
+    use aws_sdk_s3::operation::get_object::GetObjectOutput;
+
+    let body = Arc::new(body);
+    let body_for_closure = Arc::clone(&body);
+    mock!(Client::get_object)
+        .match_requests(|req| {
+            req.bucket() == Some("test-bucket")
+                && req.key() == Some("runner-templates/test-template-hash.tar.zst")
+        })
+        .then_output(move || {
+            GetObjectOutput::builder()
+                .body(byte_stream_with_error_after(
+                    (*body_for_closure).clone(),
+                    std::io::Error::new(
+                        std::io::ErrorKind::ConnectionReset,
+                        "injected R2 body transport failure",
+                    ),
+                ))
                 .build()
         })
 }

--- a/crates/runner/src/cmd/build/tests/template_cache.rs
+++ b/crates/runner/src/cmd/build/tests/template_cache.rs
@@ -101,6 +101,42 @@ async fn full_image_download_request_failure_falls_back_to_local_build() {
 }
 
 #[tokio::test]
+async fn full_image_body_read_failure_uses_deduplicated_fallback() {
+    use aws_sdk_s3::Client;
+    use aws_sdk_s3::operation::head_object::HeadObjectOutput;
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
+    let rootfs = RootfsPaths::new(&home, "r2-body-read-fallback-rootfs");
+    let archive = template_archive_bytes(b"downloaded-template").await;
+    let get = template_get_body_error_rule(archive[..archive.len() / 2].to_vec());
+    let head = mock!(Client::head_object).then_output(|| HeadObjectOutput::builder().build());
+    let cache = mock_r2_cache(&[&get, &head]);
+    let input = template_input(&home, TemplateCache::BestEffort(&cache));
+    let (_scripts, work_dir) = fake_rootfs_scripts().await;
+    let attempt_dir = rootfs.dir().join("attempt.tmp");
+    let staging = rootfs.rootfs_staging();
+
+    materialize_template_from_r2_or_build(
+        &input,
+        &attempt_dir,
+        &work_dir,
+        TemplateMaterializationTarget::RootfsStaging(&staging),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(tokio::fs::read(&staging).await.unwrap(), b"built-template");
+    assert!(work_dir.join("build-template-called").exists());
+    assert_eq!(get.num_calls(), 1);
+    assert_eq!(
+        head.num_calls(),
+        1,
+        "request failure must use deduplicated upload instead of force-overwriting R2"
+    );
+}
+
+#[tokio::test]
 async fn full_image_upload_failure_is_nonfatal_after_cache_miss() {
     use aws_sdk_s3::Client;
 

--- a/crates/runner/src/r2_cache/download.rs
+++ b/crates/runner/src/r2_cache/download.rs
@@ -1,6 +1,14 @@
-use std::path::{Path, PathBuf};
+use std::{
+    error::Error as _,
+    io,
+    path::{Path, PathBuf},
+    pin::Pin,
+    sync::{Arc, OnceLock},
+    task::{Context, Poll},
+};
 
 use aws_sdk_s3::error::SdkError;
+use tokio::io::{AsyncRead, ReadBuf};
 
 use super::{
     R2DownloadError, R2Error, R2ImageCache,
@@ -91,7 +99,7 @@ impl R2ImageCache {
             .await
             .map_err(|e| R2DownloadError::Local(R2Error::Io(e)))?;
 
-        let body_reader = resp.body.into_async_read();
+        let (body_reader, body_read_failure) = TrackedBodyReader::new(resp.body.into_async_read());
 
         if let Err(e) = tokio::fs::create_dir_all(&staging).await {
             return Err(finish_file_staging_error(
@@ -105,9 +113,12 @@ impl R2ImageCache {
             unpack_template_into_staging(body_reader, &staging, expected_template_bytes, limits)
                 .await
         {
-            let error = match error {
-                TemplateUnpackError::Invalid(error) => R2DownloadError::InvalidObject(error),
-                TemplateUnpackError::Local(error) => R2DownloadError::Local(error),
+            let error = match body_read_failure.request_error(key) {
+                Some(error) => error,
+                None => match error {
+                    TemplateUnpackError::Invalid(error) => R2DownloadError::InvalidObject(error),
+                    TemplateUnpackError::Local(error) => R2DownloadError::Local(error),
+                },
             };
             return Err(finish_file_staging_error(&staging, error).await);
         }
@@ -166,6 +177,70 @@ impl R2ImageCache {
 
         Ok(true)
     }
+}
+
+#[derive(Clone, Default)]
+struct BodyReadFailure {
+    diagnostic: Arc<OnceLock<String>>,
+}
+
+impl BodyReadFailure {
+    fn record(&self, error: &io::Error) {
+        self.diagnostic.get_or_init(|| error_diagnostic(error));
+    }
+
+    fn request_error(&self, key: &str) -> Option<R2DownloadError> {
+        self.diagnostic.get().map(|diagnostic| {
+            R2DownloadError::Request(R2Error::S3(format!(
+                "get_object {key} body read: {diagnostic}"
+            )))
+        })
+    }
+}
+
+struct TrackedBodyReader<R> {
+    inner: R,
+    failure: BodyReadFailure,
+}
+
+impl<R> TrackedBodyReader<R> {
+    fn new(inner: R) -> (Self, BodyReadFailure) {
+        let failure = BodyReadFailure::default();
+        (
+            Self {
+                inner,
+                failure: failure.clone(),
+            },
+            failure,
+        )
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for TrackedBodyReader<R> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match Pin::new(&mut self.inner).poll_read(cx, buffer) {
+            Poll::Ready(Err(error)) => {
+                self.failure.record(&error);
+                Poll::Ready(Err(error))
+            }
+            result => result,
+        }
+    }
+}
+
+fn error_diagnostic(error: &io::Error) -> String {
+    let mut diagnostic = error.to_string();
+    let mut source = error.source();
+    while let Some(error) = source {
+        diagnostic.push_str(": ");
+        diagnostic.push_str(&error.to_string());
+        source = error.source();
+    }
+    diagnostic
 }
 
 pub(super) fn file_staging_dir(destination: &Path) -> PathBuf {

--- a/crates/runner/src/r2_cache/tests/download.rs
+++ b/crates/runner/src/r2_cache/tests/download.rs
@@ -6,9 +6,10 @@ use super::super::{
 use super::fixtures::{
     archive_limits, archive_with_type, deterministic_bytes, empty_template_archive,
     excessive_sparse_metadata_archive, get_object_body, get_object_body_for_key,
-    get_object_body_with_content_length, mock_cache, nested_template_archive,
-    production_template_archive, regular_template_archive, sparse_template_archive,
-    template_archive_with_extra, template_archive_with_trailing_decompressed_data, zstd_bytes,
+    get_object_body_then_error, get_object_body_with_content_length, mock_cache,
+    nested_template_archive, production_template_archive, regular_template_archive,
+    sparse_template_archive, template_archive_with_extra,
+    template_archive_with_trailing_decompressed_data, zstd_bytes,
 };
 use aws_smithy_mocks::mock;
 
@@ -156,6 +157,36 @@ async fn request_failure_remains_distinct_from_invalid_object() {
     assert!(matches!(error, R2DownloadError::Request(_)));
     assert!(!destination.exists());
     assert!(!file_staging_dir(&destination).exists());
+}
+
+#[tokio::test]
+async fn body_read_failure_is_request_but_same_prefix_clean_eof_is_invalid() {
+    const BODY_ERROR: &str = "injected R2 body transport failure";
+
+    let archive = regular_template_archive(b"hello");
+    let prefix = archive[..archive.len() / 2].to_vec();
+    let get = get_object_body_then_error(prefix.clone(), BODY_ERROR);
+    let cache = mock_cache("test-bucket", &[&get]);
+    let dst = tempfile::tempdir().unwrap();
+    let destination = dst.path().join("template.ext4");
+    tokio::fs::write(&destination, b"existing-rootfs")
+        .await
+        .unwrap();
+
+    let error = cache
+        .try_download_template_to_file("hash", &destination, SMALL_TEMPLATE_BYTES)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, R2DownloadError::Request(_)));
+    assert!(error.to_string().contains(BODY_ERROR));
+    assert_eq!(
+        tokio::fs::read(&destination).await.unwrap(),
+        b"existing-rootfs"
+    );
+    assert!(!file_staging_dir(&destination).exists());
+
+    assert_invalid_preserves_destination(get_object_body(prefix), SMALL_TEMPLATE_BYTES).await;
 }
 
 #[tokio::test]

--- a/crates/runner/src/r2_cache/tests/fixtures.rs
+++ b/crates/runner/src/r2_cache/tests/fixtures.rs
@@ -11,6 +11,8 @@ use super::super::{
 };
 use aws_smithy_mocks::{Rule, RuleMode, mock, mock_client};
 
+use crate::test_fixtures::http_body::byte_stream_with_error_after;
+
 pub(super) fn mock_cache(bucket: &str, rules: &[&Rule]) -> R2ImageCache {
     let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, rules);
     R2ImageCache::with_client(client, bucket.to_string())
@@ -186,6 +188,24 @@ pub(super) fn archive_limits(expected_template_bytes: u64) -> TemplateArchiveLim
 
 pub(super) fn get_object_body(bytes: Vec<u8>) -> Rule {
     get_object_body_with_content_length(bytes, None)
+}
+
+pub(super) fn get_object_body_then_error(bytes: Vec<u8>, message: &'static str) -> Rule {
+    use std::sync::Arc;
+
+    use aws_sdk_s3::Client;
+    use aws_sdk_s3::operation::get_object::GetObjectOutput;
+
+    let body = Arc::new(bytes);
+    let body_for_closure = Arc::clone(&body);
+    mock!(Client::get_object).then_output(move || {
+        GetObjectOutput::builder()
+            .body(byte_stream_with_error_after(
+                (*body_for_closure).clone(),
+                std::io::Error::new(std::io::ErrorKind::ConnectionReset, message),
+            ))
+            .build()
+    })
 }
 
 pub(super) fn get_object_body_with_content_length(

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -1,4 +1,5 @@
 pub(crate) mod execution_context;
 pub(crate) mod firewall_base_url_contract;
+pub(crate) mod http_body;
 pub(crate) mod ignored_child;
 pub(crate) mod session_history;

--- a/crates/runner/src/test_fixtures/http_body.rs
+++ b/crates/runner/src/test_fixtures/http_body.rs
@@ -1,0 +1,39 @@
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use aws_sdk_s3::primitives::ByteStream;
+use bytes::Bytes;
+use http_body::{Body, Frame};
+
+pub(crate) fn byte_stream_with_error_after(bytes: Vec<u8>, error: io::Error) -> ByteStream {
+    ByteStream::from_body_1_x(BodyThenError {
+        bytes: Some(Bytes::from(bytes)),
+        error: Some(error),
+    })
+}
+
+struct BodyThenError {
+    bytes: Option<Bytes>,
+    error: Option<io::Error>,
+}
+
+impl Body for BodyThenError {
+    type Data = Bytes;
+    type Error = io::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        if let Some(bytes) = self.bytes.take() {
+            return Poll::Ready(Some(Ok(Frame::data(bytes))));
+        }
+        if let Some(error) = self.error.take() {
+            return Poll::Ready(Some(Err(error)));
+        }
+        Poll::Ready(None)
+    }
+}


### PR DESCRIPTION
## Summary

- preserve the underlying response-body read error through archive decoding
- classify explicit mid-body R2 transport failures as request failures while keeping clean-EOF corruption as invalid object data
- add deterministic download and build integration coverage, including deduplicated upload fallback behavior

## Exclusions

- no API, protocol, schema, migration, or persisted-data changes
- no retry-policy, buffering, or archive-limit changes

## Testing

- `cargo test --manifest-path crates/Cargo.toml -p runner r2_cache::tests::download`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::build::tests::template_cache`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`

Closes #25106
