### PR TITLE
fix(platform): scale mermaid diagrams to fit their box

### DIFF
--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -1,9 +1,7 @@
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
-
 import { describe, expect, it } from "vitest";
 
 import indexHtml from "../../../../index.html?raw";
+import { readGlobalCss } from "./global-css.ts";
 
 function getViewportDirectives(): string[] {
   const match = /<meta\s+name="viewport"\s+content="([^"]+)"/.exec(indexHtml);
@@ -12,20 +10,6 @@ function getViewportDirectives(): string[] {
       return directive.trim();
     }) ?? []
   );
-}
-
-function readGlobalCss(): string {
-  const candidates = [
-    join(process.cwd(), "src/views/css/index.css"),
-    join(process.cwd(), "apps/platform/src/views/css/index.css"),
-  ];
-  const path = candidates.find((candidate) => {
-    return existsSync(candidate);
-  });
-  if (path === undefined) {
-    throw new Error("Unable to locate platform global CSS");
-  }
-  return readFileSync(path, "utf8");
 }
 
 describe("platform entrypoint safe area behavior", () => {

--- a/turbo/apps/platform/src/views/css/__tests__/global-css.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/global-css.ts
@@ -1,0 +1,32 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Reads the platform's global stylesheet as text. Tests run in happy-dom, which
+ * applies no CSS and performs no layout, so a rule can only be asserted from its
+ * own source. The path depends on whether vitest was started from the workspace
+ * or from the turbo root.
+ */
+export function readGlobalCss(): string {
+  const candidates = [
+    join(process.cwd(), "src/views/css/index.css"),
+    join(process.cwd(), "apps/platform/src/views/css/index.css"),
+  ];
+  const path = candidates.find((candidate) => {
+    return existsSync(candidate);
+  });
+  if (path === undefined) {
+    throw new Error("Unable to locate platform global CSS");
+  }
+  return readFileSync(path, "utf8");
+}
+
+/** Returns the declarations of the rule introduced by `selector`. */
+export function readCssRule(css: string, selector: string): string {
+  const start = css.indexOf(`${selector} {`);
+  if (start === -1) {
+    throw new Error(`Unable to locate CSS rule for ${selector}`);
+  }
+  const end = css.indexOf("}", start);
+  return css.slice(start, end);
+}

--- a/turbo/apps/platform/src/views/css/__tests__/mermaid-diagram-fit.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/mermaid-diagram-fit.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { readCssRule, readGlobalCss } from "./global-css.ts";
+
+const BOX_SELECTOR = ".wmde-markdown .mermaid-diagram-expand";
+const IMAGE_SELECTOR = ".wmde-markdown .mermaid-diagram-image";
+const INSET_CHILDREN_SELECTOR = `${IMAGE_SELECTOR},\n.wmde-markdown .mermaid-diagram-pending`;
+
+function readPixels(rule: string, pattern: RegExp): number {
+  const match = pattern.exec(rule);
+  if (!match?.[1]) {
+    throw new Error(`Unable to read ${String(pattern)} from ${rule}`);
+  }
+  return Number(match[1]);
+}
+
+describe("mermaid diagram box", () => {
+  it("scales a diagram of any ratio into the box instead of clipping it", () => {
+    const image = readCssRule(readGlobalCss(), IMAGE_SELECTOR);
+
+    // `object-fit` only letterboxes a diagram once the image has a box to fit
+    // into. An absolutely positioned <img> sized `auto` is laid out at its own
+    // intrinsic size and ignores the opposite insets, so dropping either of
+    // these declarations leaves a tall diagram running past the box and a wide
+    // one anchored to the top edge.
+    expect(image).toMatch(/width:\s*calc\(100% - \d+px\);/);
+    expect(image).toMatch(/height:\s*calc\(100% - \d+px\);/);
+    expect(image).toMatch(/object-fit:\s*contain;/);
+  });
+
+  it("keeps the fitted size in step with the box padding", () => {
+    const globalCss = readGlobalCss();
+    const padding = readPixels(
+      readCssRule(globalCss, BOX_SELECTOR),
+      /padding:\s*(\d+)px;/,
+    );
+    const inset = readPixels(
+      readCssRule(globalCss, INSET_CHILDREN_SELECTOR),
+      /inset:\s*(\d+)px;/,
+    );
+    const removedFromSize = readPixels(
+      readCssRule(globalCss, IMAGE_SELECTOR),
+      /width:\s*calc\(100% - (\d+)px\);/,
+    );
+
+    // The image is placed against the padding box, so its size has to give back
+    // the padding on both edges itself. A padding change that misses the `calc`
+    // would push the diagram back out of the box.
+    expect(inset).toBe(padding);
+    expect(removedFromSize).toBe(padding * 2);
+  });
+
+  it("reserves the same box for every diagram before it renders", () => {
+    const globalCss = readGlobalCss();
+    const box = readCssRule(globalCss, BOX_SELECTOR);
+
+    expect(box).toMatch(/max-width:\s*420px;/);
+    expect(box).toMatch(/aspect-ratio:\s*4 \/ 3;/);
+    expect(box).toMatch(/overflow:\s*hidden;/);
+    expect(readCssRule(globalCss, INSET_CHILDREN_SELECTOR)).toMatch(
+      /position:\s*absolute;/,
+    );
+  });
+});

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -1104,6 +1104,13 @@ body {
 }
 
 .wmde-markdown .mermaid-diagram-image {
+  /* An absolutely positioned <img> whose width and height are `auto` is laid
+     out at its own intrinsic size, so `inset` alone leaves the diagram at
+     lightbox scale and `object-fit` has nothing to fit into. The size is
+     therefore stated: `calc` rather than `100%`, since a percentage resolves
+     against the padding box, which the box's own padding would not clear. */
+  width: calc(100% - 16px);
+  height: calc(100% - 16px);
   object-fit: contain;
   /* github-markdown-css paints every image on an opaque canvas colour, which
      would cover the box behind the letterboxed diagram. */


### PR DESCRIPTION
## Problem

Mermaid diagrams are not scaled into their box. The `<img>` fills the box's width and keeps its own aspect ratio vertically, so a tall flowchart runs past the bottom of the 4:3 frame and is cut off by `overflow: hidden`.

## Cause

`.mermaid-diagram-image` positions the image absolutely with `inset: 8px` and relies on `object-fit: contain`, but never states a width or height. An absolutely positioned replaced element whose `width` and `height` are `auto` is laid out at its intrinsic size (here bounded only by the markdown theme's `img { max-width: 100% }`), and the `bottom`/`right` insets are ignored. The image box therefore already matches the diagram's aspect ratio and `object-fit` has nothing to fit into.

Diagrams are serialized at `LIGHTBOX_SVG_WIDTH = 1600` so the lightbox can open them at full size, which makes the overflow large.

## Fix

State the image's size so the inset rectangle becomes the fit box. `calc(100% - 16px)` rather than `100%`, because a percentage on an absolutely positioned child resolves against the padding box, which the box's own 8px padding would not clear.

## Verification

Reproduced the layout in a browser with the shipped rules and a 1600x4000 SVG, measuring the rendered image against its box:

| | image | box height | contained |
| --- | --- | --- | --- |
| before | 418 x 1045 | 315 | no, clipped |
| after | 402 x 297 | 315 | yes, letterboxed |

The existing mermaid tests run in jsdom with mermaid mocked, so they assert markup rather than layout and could not catch this.

## Note

Diagrams now fit, but a strongly vertical flowchart is letterboxed into a 420x315 frame and its labels end up small. Changing that means letting the frame follow the diagram's own ratio, which trades away the reserved-height behaviour that keeps a thread from shifting while a diagram renders. Left as is here; happy to follow up if we want the frame to adapt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
