### PR TITLE
fix(platform): keep avatar artifact filter visible while loading

### DIFF
--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx
@@ -169,6 +169,53 @@ describe("artifact catalog page", () => {
     expect(requestedKinds).toStrictEqual(["presentation", "avatar"]);
   });
 
+  it("keeps the avatar filter visible while avatar artifacts load", async () => {
+    const releaseAvatarResponse = context.mocks.deferred<void>();
+    context.mocks.api(
+      artifactCatalogContract.list,
+      async ({ query, respond }) => {
+        if (query.kind === "avatar") {
+          await releaseAvatarResponse.promise;
+          return respond(200, {
+            artifacts: [
+              artifact({ kind: "avatar", title: "avatar-video.mp4" }),
+            ],
+            nextCursor: null,
+            supportedKinds: [...ARTIFACT_CATALOG_KINDS],
+          });
+        }
+        return respond(200, {
+          artifacts: [artifact({ kind: "presentation", title: "launch-deck" })],
+          nextCursor: null,
+          supportedKinds: [...ARTIFACT_CATALOG_KINDS],
+        });
+      },
+    );
+
+    setupArtifactCatalogPage();
+    await findCard("launch-deck");
+
+    const avatarFilter = buttonByLabel("Show avatar artifacts");
+    if (!avatarFilter) {
+      throw new Error("Expected an avatar kind filter");
+    }
+    click(avatarFilter);
+
+    await expect(
+      screen.findByLabelText("Loading artifacts"),
+    ).resolves.toBeInTheDocument();
+    expect(buttonByLabel("Show avatar artifacts")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    await act(async () => {
+      releaseAvatarResponse.resolve();
+      await releaseAvatarResponse.promise;
+    });
+    await findCard("avatar-video.mp4");
+  });
+
   it("localizes the catalog and filters without changing artifact titles", async () => {
     document.documentElement.lang = "pt-BR";
     const requestedKinds: (string | undefined)[] = [];

--- a/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
@@ -13,7 +13,7 @@ import {
   IconWorld,
 } from "@tabler/icons-react";
 import { r2ImageTransformUrl } from "@vm0/core";
-import { useGet, useLoadable, useSet } from "ccstate-react";
+import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import { cn } from "@vm0/ui";
 import { Alert, AlertDescription } from "@vm0/ui/components/ui/alert";
 import { useTranslation } from "react-i18next";
@@ -398,6 +398,7 @@ export function ArtifactCatalogPage() {
   const pageSignal = useGet(pageSignal$);
   const lightboxUrl = useGet(lightboxUrl$);
   const catalog = useLoadable(artifactCatalog$);
+  const lastCatalog = useLastLoadable(artifactCatalog$);
   const artifacts = catalog.state === "hasData" ? catalog.data.artifacts : [];
   const hasMore =
     catalog.state === "hasData" && catalog.data.nextCursor !== null;
@@ -445,8 +446,8 @@ export function ArtifactCatalogPage() {
           <ArtifactCatalogKindFilter
             selectedKind={selectedKind}
             supportedKinds={
-              catalog.state === "hasData"
-                ? catalog.data.supportedKinds
+              lastCatalog.state === "hasData"
+                ? lastCatalog.data.supportedKinds
                 : undefined
             }
             onKindChange={setKind}


### PR DESCRIPTION
## Summary

- retain the last resolved artifact kind capabilities while a filtered catalog request is loading
- prevent the Avatar filter from unmounting and remounting after selection
- cover the pending avatar request state with an integration regression test

## Testing

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api run lint (retry after the initial workspace run hit the default Node heap limit)
- pnpm knip
- pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@vm0/app
- pnpm --filter @vm0/app run check-types
- pnpm --filter api run check-types
- pnpm --filter @vm0/app exec vitest run src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx

Local dev server and browser verification were not run, per repository instructions.