### PR TITLE
feat(chat): enable chat steering for staff org

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -128,6 +128,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ZeroBrowser]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ChatSteer]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PwaChatKeyboardGestures]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadSidebarAutoOpen]).toBe(
       true,
@@ -157,6 +158,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(
       false,
     );
+    expect(otherOrgStates[FeatureSwitchKey.ChatSteer]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PwaChatKeyboardGestures]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -370,6 +370,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Steer pending chat prompts into active runs and render them inline.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.PwaChatKeyboardGestures]: {
     maintainer: "bingjie@vm0.ai",


### PR DESCRIPTION
## Summary

- enable `chatSteer` for the staff organization while keeping it disabled by default
- cover staff and non-staff organization states in the feature rollout matrix test

## Verification

- `npx --yes prettier@3.8.1 --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (24 tests passed)
