### PR TITLE
docs(python): document catalog response-header continuation contract

### DIFF
--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -696,7 +696,14 @@ def _bypass_response(
 
 
 def handle_response_headers(flow: http.HTTPFlow) -> bool:
-    """Select pass-through streaming with bounded catalog capture."""
+    """Prepare catalog handling and report whether the caller should continue.
+
+    Return False only for a fresh response served from the local catalog cache; the caller
+    must stop the normal response-header pipeline in that case. Return True for all other flows,
+    including unrelated traffic, cache bypasses, and eligible cold responses, so the caller
+    continues that pipeline. For an eligible cold response, ordinary streaming is installed before
+    wrap_response_stream() composes the bounded catalog capture.
+    """
     state = flow.metadata.get(_FLOW_STATE)
     telemetry = flow.metadata.get(_FLOW_TELEMETRY)
     if isinstance(telemetry, _FlowTelemetry) and telemetry.status == "model_catalog_fresh_hit":

--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -703,6 +703,10 @@ def handle_response_headers(flow: http.HTTPFlow) -> bool:
     including unrelated traffic, cache bypasses, and eligible cold responses, so the hook
     continues that pipeline. For an eligible cold response, ordinary streaming is installed before
     wrap_response_stream() composes the bounded catalog capture.
+
+    ``mitm_addon.responseheaders()`` implements this contract. Focused coverage is
+    ``test_fresh_hit_is_partitioned_and_expiry_never_uses_conditions`` for the stop branch and
+    ``test_request_bypasses_do_not_touch_unrelated_traffic`` for continuation.
     """
     state = flow.metadata.get(_FLOW_STATE)
     telemetry = flow.metadata.get(_FLOW_TELEMETRY)

--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -696,11 +696,11 @@ def _bypass_response(
 
 
 def handle_response_headers(flow: http.HTTPFlow) -> bool:
-    """Prepare catalog handling and report whether the caller should continue.
+    """Prepare catalog handling and tell mitm_addon.responseheaders() whether to continue.
 
-    Return False only for a fresh response served from the local catalog cache; the caller
+    Return False only for a fresh response served from the local catalog cache; the hook
     must stop the normal response-header pipeline in that case. Return True for all other flows,
-    including unrelated traffic, cache bypasses, and eligible cold responses, so the caller
+    including unrelated traffic, cache bypasses, and eligible cold responses, so the hook
     continues that pipeline. For an eligible cold response, ordinary streaming is installed before
     wrap_response_stream() composes the bounded catalog capture.
     """


### PR DESCRIPTION
## Summary

- define the exact continuation semantics of `handle_response_headers()`
- explain why fresh local cache hits stop the response-header pipeline
- document that eligible cold responses install ordinary streaming before catalog capture is composed

## Scope

- documentation only
- no runtime behavior, tests, APIs, data, protocols, or deployment compatibility changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4742 passed)

Closes #25102
