### PR TITLE
fix(python): preserve auth base representation lengths

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -80,6 +80,9 @@ class FirewallHeaderPhaseAuthResult(Enum):
 type OrdinaryUpstreamCredentialsGuard = Callable[[], bool]
 
 
+_HTTP_STATUS_INFORMATIONAL_MIN = 100
+_HTTP_STATUS_SUCCESS_MIN = 200
+_HTTP_STATUS_NO_CONTENT = 204
 _HTTP_STATUS_NOT_MODIFIED = 304
 _HTTP_STATUS_CLIENT_ERROR_MIN = 400
 _HTTP_STATUS_SERVER_ERROR_MIN = 500
@@ -1072,8 +1075,12 @@ async def _apply_url_rewrite(
             req_body,
             admission=admission,
         )
-        preserves_representation_length = (
-            flow.request.method == "HEAD" or status == _HTTP_STATUS_NOT_MODIFIED
+        is_head_representation = flow.request.method == "HEAD" and not (
+            _HTTP_STATUS_INFORMATIONAL_MIN <= status < _HTTP_STATUS_SUCCESS_MIN
+            or status == _HTTP_STATUS_NO_CONTENT
+        )
+        preserves_representation_length = is_head_representation or (
+            flow.request.method == "GET" and status == _HTTP_STATUS_NOT_MODIFIED
         )
         representation_content_length: str | None = None
         if preserves_representation_length:

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -83,6 +83,7 @@ type OrdinaryUpstreamCredentialsGuard = Callable[[], bool]
 _HTTP_STATUS_INFORMATIONAL_MIN = 100
 _HTTP_STATUS_SUCCESS_MIN = 200
 _HTTP_STATUS_NO_CONTENT = 204
+_HTTP_STATUS_RESET_CONTENT = 205
 _HTTP_STATUS_NOT_MODIFIED = 304
 _HTTP_STATUS_CLIENT_ERROR_MIN = 400
 _HTTP_STATUS_SERVER_ERROR_MIN = 500
@@ -1077,7 +1078,7 @@ async def _apply_url_rewrite(
         )
         is_head_representation = flow.request.method == "HEAD" and not (
             _HTTP_STATUS_INFORMATIONAL_MIN <= status < _HTTP_STATUS_SUCCESS_MIN
-            or status == _HTTP_STATUS_NO_CONTENT
+            or status in (_HTTP_STATUS_NO_CONTENT, _HTTP_STATUS_RESET_CONTENT)
         )
         preserves_representation_length = is_head_representation or (
             flow.request.method == "GET" and status == _HTTP_STATUS_NOT_MODIFIED

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -80,6 +80,7 @@ class FirewallHeaderPhaseAuthResult(Enum):
 type OrdinaryUpstreamCredentialsGuard = Callable[[], bool]
 
 
+_HTTP_STATUS_NOT_MODIFIED = 304
 _HTTP_STATUS_CLIENT_ERROR_MIN = 400
 _HTTP_STATUS_SERVER_ERROR_MIN = 500
 AUTH_BASE_FORWARDING_SATURATED_ERROR = "auth_base_forwarding_saturated"
@@ -1071,6 +1072,16 @@ async def _apply_url_rewrite(
             req_body,
             admission=admission,
         )
+        preserves_representation_length = (
+            flow.request.method == "HEAD" or status == _HTTP_STATUS_NOT_MODIFIED
+        )
+        representation_content_length: str | None = None
+        if preserves_representation_length:
+            content_lengths = resp_headers.get_all("Content-Length")
+            if len(content_lengths) == 1:
+                candidate = content_lengths[0].strip(" \t")
+                if candidate.isascii() and candidate.isdigit():
+                    representation_content_length = candidate
         content_encodings = [
             value
             for name, value in header_pairs(resp_headers)
@@ -1081,6 +1092,10 @@ async def _apply_url_rewrite(
         # The forwarder returns representation bytes, but Response.make expects
         # decoded content. Hide the codings while it normalizes response framing.
         flow.response = http.Response.make(status, resp_raw_content, resp_headers)
+        if preserves_representation_length:
+            del flow.response.headers["Content-Length"]
+            if representation_content_length is not None:
+                flow.response.headers["Content-Length"] = representation_content_length
         if content_encodings:
             flow.response.headers.set_all("Content-Encoding", content_encodings)
     except ForwardedRequestTooLargeError:

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -244,6 +244,32 @@ class TestAuthBaseUrlRewriteForwarding:
         assert flow.response.raw_content == b""
         assert flow.response.headers.get_all("Content-Length") == expected_content_lengths
 
+    async def test_url_rewrite_does_not_restore_content_length_for_head_204(
+        self, real_flow, mitm_ctx, tmp_path
+    ):
+        flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            method="HEAD",
+        )
+
+        with (
+            fake_forwarder_upstream(
+                status=204,
+                body=b"",
+                headers=[("Content-Length", "123")],
+            ),
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
+        assert flow.response is not None
+        assert flow.response.status_code == 204
+        assert flow.response.raw_content == b""
+        assert flow.response.headers.get_all("Content-Length") == ["0"]
+
     async def test_url_rewrite_sends_resolved_auth_headers(
         self, headers, real_flow, mitm_ctx, tmp_path
     ):

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -192,6 +192,58 @@ class TestAuthBaseUrlRewriteForwarding:
         if decoded_body is not None:
             assert flow.response.content == decoded_body
 
+    @pytest.mark.parametrize(
+        ("method", "status"),
+        [
+            pytest.param("HEAD", 200, id="head"),
+            pytest.param("GET", 304, id="not-modified"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("response_headers", "expected_content_lengths"),
+        [
+            pytest.param(
+                [("Content-Length", "123")],
+                ["123"],
+                id="representation-length",
+            ),
+            pytest.param([], [], id="absent"),
+            pytest.param(
+                [("Content-Length", "123"), ("Content-Length", "124")],
+                [],
+                id="conflicting",
+            ),
+        ],
+    )
+    async def test_url_rewrite_preserves_bodyless_response_content_length(
+        self,
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+        method: str,
+        status: int,
+        response_headers: list[tuple[str, str]],
+        expected_content_lengths: list[str],
+    ):
+        flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            method=method,
+        )
+
+        with (
+            fake_forwarder_upstream(status=status, body=b"", headers=response_headers),
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
+        assert flow.response is not None
+        assert flow.response.status_code == status
+        assert flow.response.raw_content == b""
+        assert flow.response.headers.get_all("Content-Length") == expected_content_lengths
+
     async def test_url_rewrite_sends_resolved_auth_headers(
         self, headers, real_flow, mitm_ctx, tmp_path
     ):

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -213,6 +213,13 @@ class TestAuthBaseUrlRewriteForwarding:
                 [],
                 id="conflicting",
             ),
+            pytest.param([("Content-Length", "invalid")], [], id="malformed"),
+            pytest.param([("Content-Length", "123, 123")], [], id="comma-list"),
+            pytest.param(
+                [("Content-Length", "123"), ("Content-Length", "123")],
+                [],
+                id="repeated",
+            ),
         ],
     )
     async def test_url_rewrite_preserves_bodyless_response_content_length(
@@ -244,8 +251,15 @@ class TestAuthBaseUrlRewriteForwarding:
         assert flow.response.raw_content == b""
         assert flow.response.headers.get_all("Content-Length") == expected_content_lengths
 
-    async def test_url_rewrite_does_not_restore_content_length_for_head_204(
-        self, real_flow, mitm_ctx, tmp_path
+    @pytest.mark.parametrize(
+        "status",
+        [
+            pytest.param(204, id="no-content"),
+            pytest.param(205, id="reset-content"),
+        ],
+    )
+    async def test_url_rewrite_does_not_restore_content_length_for_empty_head_status(
+        self, real_flow, mitm_ctx, tmp_path, status: int
     ):
         flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
             real_flow,
@@ -255,7 +269,7 @@ class TestAuthBaseUrlRewriteForwarding:
 
         with (
             fake_forwarder_upstream(
-                status=204,
+                status=status,
                 body=b"",
                 headers=[("Content-Length", "123")],
             ),
@@ -266,7 +280,7 @@ class TestAuthBaseUrlRewriteForwarding:
 
         assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
         assert flow.response is not None
-        assert flow.response.status_code == 204
+        assert flow.response.status_code == status
         assert flow.response.raw_content == b""
         assert flow.response.headers.get_all("Content-Length") == ["0"]
 


### PR DESCRIPTION
## Summary

- preserve valid upstream representation `Content-Length` on bodyless `HEAD` and `304` auth rewrites
- keep an omitted, malformed, comma-list, repeated, or conflicting representation length absent instead of generating or forwarding unsafe metadata
- cover the final rewritten `HTTPFlow` for valid, absent, ambiguous, and prohibited lengths

## Scope

- ordinary response framing still comes from the buffered bytes through `http.Response.make`
- existing encoded-response and hop-by-hop-header behavior is unchanged
- `1xx`, `204`, and `205` responses are explicitly excluded from the `HEAD` representation-length exception
- this does not otherwise change adjacent bodyless-status, informational, or successful `CONNECT` framing behavior

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`4756 passed`)

Closes #25111
