### PR TITLE
fix(runner): preserve bodyless response content length

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -12,6 +12,7 @@ import urllib.parse
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
+from http import HTTPStatus
 
 from mitmproxy import http
 
@@ -1076,11 +1077,27 @@ async def _apply_url_rewrite(
             for name, value in header_pairs(resp_headers)
             if name.lower() == "content-encoding"
         ]
+        preserve_representation_content_length = status == HTTPStatus.NOT_MODIFIED or (
+            flow.request.method == "HEAD"
+            and status >= HTTPStatus.OK
+            and status != HTTPStatus.NO_CONTENT
+        )
+        representation_content_length: str | None = None
+        if preserve_representation_content_length:
+            content_lengths = resp_headers.get_all("Content-Length")
+            if len(content_lengths) == 1:
+                candidate = content_lengths[0].strip(" \t")
+                if candidate and all("0" <= character <= "9" for character in candidate):
+                    representation_content_length = candidate
         if content_encodings:
             del resp_headers["Content-Encoding"]
         # The forwarder returns representation bytes, but Response.make expects
         # decoded content. Hide the codings while it normalizes response framing.
         flow.response = http.Response.make(status, resp_raw_content, resp_headers)
+        if preserve_representation_content_length:
+            del flow.response.headers["Content-Length"]
+            if representation_content_length is not None:
+                flow.response.headers["Content-Length"] = representation_content_length
         if content_encodings:
             flow.response.headers.set_all("Content-Encoding", content_encodings)
     except ForwardedRequestTooLargeError:

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -1080,7 +1080,7 @@ async def _apply_url_rewrite(
         preserve_representation_content_length = status == HTTPStatus.NOT_MODIFIED or (
             flow.request.method == "HEAD"
             and status >= HTTPStatus.OK
-            and status != HTTPStatus.NO_CONTENT
+            and status not in (HTTPStatus.NO_CONTENT, HTTPStatus.RESET_CONTENT)
         )
         representation_content_length: str | None = None
         if preserve_representation_content_length:

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -192,6 +192,105 @@ class TestAuthBaseUrlRewriteForwarding:
         if decoded_body is not None:
             assert flow.response.content == decoded_body
 
+    @pytest.mark.parametrize(
+        ("method", "status"),
+        [
+            pytest.param("HEAD", 200, id="head"),
+            pytest.param("GET", 304, id="not-modified"),
+        ],
+    )
+    async def test_url_rewrite_preserves_bodyless_representation_content_length(
+        self,
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+        method: str,
+        status: int,
+    ):
+        flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            method=method,
+        )
+
+        with (
+            fake_forwarder_upstream(
+                status=status,
+                body=b"",
+                headers=[("Content-Length", "123")],
+            ),
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
+        assert flow.response is not None
+        assert flow.response.raw_content == b""
+        assert flow.response.headers.get_all("Content-Length") == ["123"]
+
+    @pytest.mark.parametrize(
+        "response_headers",
+        [
+            pytest.param([], id="missing"),
+            pytest.param([("Content-Length", "invalid")], id="malformed"),
+            pytest.param([("Content-Length", "123, 123")], id="comma-list"),
+            pytest.param(
+                [("Content-Length", "123"), ("Content-Length", "123")],
+                id="repeated",
+            ),
+        ],
+    )
+    async def test_url_rewrite_omits_untrusted_bodyless_content_length(
+        self,
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+        response_headers: list[tuple[str, str]],
+    ):
+        flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            method="HEAD",
+        )
+
+        with (
+            fake_forwarder_upstream(status=200, body=b"", headers=response_headers),
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
+        assert flow.response is not None
+        assert flow.response.raw_content == b""
+        assert "Content-Length" not in flow.response.headers
+
+    async def test_url_rewrite_does_not_restore_head_204_content_length(
+        self, real_flow, mitm_ctx, tmp_path
+    ):
+        flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            method="HEAD",
+        )
+
+        with (
+            fake_forwarder_upstream(
+                status=204,
+                body=b"",
+                headers=[("Content-Length", "123")],
+            ),
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
+        assert flow.response is not None
+        assert flow.response.raw_content == b""
+        assert flow.response.headers["Content-Length"] == "0"
+
     async def test_url_rewrite_sends_resolved_auth_headers(
         self, headers, real_flow, mitm_ctx, tmp_path
     ):

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -266,8 +266,15 @@ class TestAuthBaseUrlRewriteForwarding:
         assert flow.response.raw_content == b""
         assert "Content-Length" not in flow.response.headers
 
-    async def test_url_rewrite_does_not_restore_head_204_content_length(
-        self, real_flow, mitm_ctx, tmp_path
+    @pytest.mark.parametrize(
+        "status",
+        [
+            pytest.param(204, id="no-content"),
+            pytest.param(205, id="reset-content"),
+        ],
+    )
+    async def test_url_rewrite_does_not_restore_head_content_length_for_empty_status(
+        self, real_flow, mitm_ctx, tmp_path, status: int
     ):
         flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
             real_flow,
@@ -277,7 +284,7 @@ class TestAuthBaseUrlRewriteForwarding:
 
         with (
             fake_forwarder_upstream(
-                status=204,
+                status=status,
                 body=b"",
                 headers=[("Content-Length", "123")],
             ),


### PR DESCRIPTION
## Summary

- preserve a valid upstream representation `Content-Length` on rewritten `HEAD` and `304` responses
- keep missing, malformed, comma-list, and repeated lengths absent instead of exposing a constructor-generated zero
- retain byte-derived framing for ordinary responses and exclude `204`/`205` from the representation-length exception

No API, schema, persisted-state, queue, or runner protocol changes are included.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,744 passed)

Closes #25111
