### PR TITLE
fix(runner): clean up cancelled setup artifact temps

### DIFF
--- a/crates/runner/src/cmd/setup/artifacts.rs
+++ b/crates/runner/src/cmd/setup/artifacts.rs
@@ -210,6 +210,7 @@ mod tests {
     use sha2::{Digest, Sha256};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
     use tokio::task::JoinHandle;
 
     use super::*;
@@ -294,6 +295,50 @@ mod tests {
         (format!("http://{address}/artifact"), task)
     }
 
+    async fn spawn_gated_http_response(
+        response_prefix: Vec<u8>,
+    ) -> (
+        String,
+        oneshot::Receiver<()>,
+        oneshot::Sender<()>,
+        JoinHandle<std::io::Result<()>>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (body_sent_tx, body_sent_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await?;
+            let mut request = [0_u8; 1024];
+            let request_size = stream.read(&mut request).await?;
+            if request_size == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "setup fixture received an empty request",
+                ));
+            }
+            stream.write_all(&response_prefix).await?;
+            body_sent_tx.send(()).map_err(|()| {
+                std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "setup fixture body signal receiver dropped",
+                )
+            })?;
+            release_rx.await.map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "setup fixture release sender dropped",
+                )
+            })
+        });
+        (
+            format!("http://{address}/artifact"),
+            body_sent_rx,
+            release_tx,
+            task,
+        )
+    }
+
     async fn finish_http_response(task: JoinHandle<std::io::Result<()>>) {
         tokio::time::timeout(Duration::from_secs(2), task)
             .await
@@ -321,6 +366,20 @@ mod tests {
             }
         }
         temp_files
+    }
+
+    async fn wait_for_setup_temp_count(root: &Path, expected: usize) -> Vec<PathBuf> {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let temp_files = setup_temp_files(root);
+                if temp_files.len() == expected {
+                    return temp_files;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("setup temp count did not converge")
     }
 
     #[test]
@@ -479,6 +538,55 @@ mod tests {
         download.assert_calls_async(1).await;
         assert_eq!(std::fs::read(&target).unwrap(), content);
         assert_eq!(mode(&target), SETUP_KERNEL_ARTIFACT_MODE);
+    }
+
+    #[tokio::test]
+    async fn cancelling_direct_artifact_download_cleans_temp() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = b"cancelled download".to_vec();
+        let mut response_prefix = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            content.len()
+        )
+        .into_bytes();
+        response_prefix.extend_from_slice(&content[..4]);
+        let (url, body_sent, release, server_task) =
+            spawn_gated_http_response(response_prefix).await;
+        let target = dir.path().join("artifact.bin");
+        let artifact = SetupArtifact {
+            label: "direct",
+            display_name: "direct artifact".to_owned(),
+            target: target.clone(),
+            installed: content_identity(&content),
+            mode: SETUP_KERNEL_ARTIFACT_MODE,
+            url,
+            source: SetupArtifactSource::Direct,
+        };
+        let client = test_client();
+        let install_task =
+            tokio::spawn(async move { install_setup_artifact(&client, artifact).await });
+
+        tokio::time::timeout(Duration::from_secs(2), body_sent)
+            .await
+            .expect("setup fixture did not send the partial body")
+            .expect("setup fixture body signal sender dropped");
+        let temp_files = wait_for_setup_temp_count(dir.path(), 1).await;
+        assert!(
+            temp_files[0]
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .contains(".download.")
+        );
+
+        install_task.abort();
+        let join_error = install_task.await.unwrap_err();
+        assert!(join_error.is_cancelled());
+
+        assert!(wait_for_setup_temp_count(dir.path(), 0).await.is_empty());
+        assert!(!target.exists());
+        release.send(()).unwrap();
+        finish_http_response(server_task).await;
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/setup/mod.rs
+++ b/crates/runner/src/cmd/setup/mod.rs
@@ -49,8 +49,36 @@ const START_SYSTEM_DEPENDENCIES: [&str; 11] = [
 ];
 const OTHER_COMMAND_SYSTEM_DEPENDENCIES: [&str; 3] = ["pgrep", "debootstrap", "flock"];
 
-struct ProducedSetupArtifact {
+#[derive(Debug)]
+struct SetupTempPath {
     path: PathBuf,
+    active: bool,
+}
+
+impl SetupTempPath {
+    fn new(path: PathBuf) -> Self {
+        Self { path, active: true }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn disarm(&mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for SetupTempPath {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+struct ProducedSetupArtifact {
+    temp_path: SetupTempPath,
     file: File,
     sha256: String,
 }
@@ -380,7 +408,7 @@ fn setup_dir_open_flags() -> OFlag {
     OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC
 }
 
-fn create_setup_temp_file(target: &Path, kind: &str) -> RunnerResult<(PathBuf, File)> {
+fn create_setup_temp_file(target: &Path, kind: &str) -> RunnerResult<(SetupTempPath, File)> {
     let parent = file_parent(target);
     ensure_setup_shared_dir(parent)?;
     let file_name = target.file_name().ok_or_else(|| {
@@ -402,8 +430,9 @@ fn create_setup_temp_file(target: &Path, kind: &str) -> RunnerResult<(PathBuf, F
 
         match open_setup_temp_file_at(&tmp_path) {
             Ok(file) => {
-                secure_setup_temp_file(&file, &tmp_path)?;
-                return Ok((tmp_path, file));
+                let temp_path = SetupTempPath::new(tmp_path);
+                secure_setup_temp_file(&file, temp_path.path())?;
+                return Ok((temp_path, file));
             }
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(error) => {
@@ -422,7 +451,7 @@ fn create_setup_temp_file(target: &Path, kind: &str) -> RunnerResult<(PathBuf, F
 }
 
 #[cfg(test)]
-fn create_setup_temp_file_at(path: &Path) -> RunnerResult<File> {
+fn create_setup_temp_file_at(path: &Path) -> RunnerResult<(SetupTempPath, File)> {
     ensure_setup_shared_dir(file_parent(path))?;
     let file = open_setup_temp_file_at(path).map_err(|e| {
         RunnerError::Internal(format!(
@@ -430,8 +459,9 @@ fn create_setup_temp_file_at(path: &Path) -> RunnerResult<File> {
             path.display()
         ))
     })?;
-    secure_setup_temp_file(&file, path)?;
-    Ok(file)
+    let temp_path = SetupTempPath::new(path.to_owned());
+    secure_setup_temp_file(&file, temp_path.path())?;
+    Ok((temp_path, file))
 }
 
 fn open_setup_temp_file_at(path: &Path) -> std::io::Result<File> {
@@ -472,41 +502,63 @@ fn secure_setup_temp_file(file: &File, path: &Path) -> RunnerResult<()> {
 }
 
 fn install_produced_artifact(
-    artifact: ProducedSetupArtifact,
+    mut artifact: ProducedSetupArtifact,
     target: &Path,
     mode: u32,
 ) -> RunnerResult<()> {
-    let produced_stat = setup_file_stat(&artifact.file, &artifact.path, "produced setup artifact")?;
-    validate_trusted_regular_setup_file(&produced_stat, &artifact.path, "produced setup artifact")?;
+    let produced_stat = setup_file_stat(
+        &artifact.file,
+        artifact.temp_path.path(),
+        "produced setup artifact",
+    )?;
+    validate_trusted_regular_setup_file(
+        &produced_stat,
+        artifact.temp_path.path(),
+        "produced setup artifact",
+    )?;
     if (produced_stat.st_mode & GROUP_OR_OTHER_WRITE_BITS) != 0 {
         return Err(RunnerError::Internal(format!(
             "{} is group/other writable",
-            artifact.path.display()
+            artifact.temp_path.path().display()
         )));
     }
 
-    let temp_path_file = open_setup_file_for_identity(&artifact.path, "produced setup artifact")?;
-    let temp_path_stat =
-        setup_file_stat(&temp_path_file, &artifact.path, "produced setup artifact")?;
+    let temp_path_file =
+        open_setup_file_for_identity(artifact.temp_path.path(), "produced setup artifact")?;
+    let temp_path_stat = setup_file_stat(
+        &temp_path_file,
+        artifact.temp_path.path(),
+        "produced setup artifact",
+    )?;
     validate_same_setup_file_identity(
         &produced_stat,
         &temp_path_stat,
-        &artifact.path,
+        artifact.temp_path.path(),
         "produced setup artifact",
     )?;
 
     chmod_fd(
         &artifact.file,
-        &artifact.path,
+        artifact.temp_path.path(),
         mode,
         "produced setup artifact",
     )?;
-    let chmod_stat = setup_file_stat(&artifact.file, &artifact.path, "produced setup artifact")?;
-    validate_setup_artifact_mode(&chmod_stat, &artifact.path, mode, "produced setup artifact")?;
+    let chmod_stat = setup_file_stat(
+        &artifact.file,
+        artifact.temp_path.path(),
+        "produced setup artifact",
+    )?;
+    validate_setup_artifact_mode(
+        &chmod_stat,
+        artifact.temp_path.path(),
+        mode,
+        "produced setup artifact",
+    )?;
     drop(temp_path_file);
 
-    std::fs::rename(&artifact.path, target)
+    std::fs::rename(artifact.temp_path.path(), target)
         .map_err(|e| RunnerError::Internal(format!("rename to {}: {e}", target.display())))?;
+    artifact.temp_path.disarm();
 
     let target_file = open_setup_file_for_identity(target, "installed setup artifact")?;
     let target_stat = setup_file_stat(&target_file, target, "installed setup artifact")?;
@@ -790,7 +842,7 @@ async fn stream_to_file(
     Ok((file.into_std().await, hex::encode(hasher.finalize())))
 }
 
-/// Download a URL to a temp file. Cleans up on failure.
+/// Download a URL to an owned temp file that cleans itself up until installed.
 async fn download_to_temp(
     client: &reqwest::Client,
     url: &str,
@@ -821,35 +873,24 @@ async fn download_to_temp(
         )));
     }
 
-    let (tmp_path, file) = create_setup_temp_file(target, kind)?;
-    let result = async {
-        let (file, sha256) = stream_to_file(
-            response,
-            tokio::fs::File::from_std(file),
-            &tmp_path,
-            expected,
-            label,
-        )
-        .await?;
-        verify_sha256(&sha256, &expected.sha256, &format!("{label} source"))?;
-        Ok((file, sha256))
-    }
-    .await;
-
-    match result {
-        Ok((file, sha256)) => Ok(ProducedSetupArtifact {
-            path: tmp_path,
-            file,
-            sha256,
-        }),
-        Err(error) => {
-            let _ = tokio::fs::remove_file(&tmp_path).await;
-            Err(error)
-        }
-    }
+    let (temp_path, file) = create_setup_temp_file(target, kind)?;
+    let (file, sha256) = stream_to_file(
+        response,
+        tokio::fs::File::from_std(file),
+        temp_path.path(),
+        expected,
+        label,
+    )
+    .await?;
+    verify_sha256(&sha256, &expected.sha256, &format!("{label} source"))?;
+    Ok(ProducedSetupArtifact {
+        temp_path,
+        file,
+        sha256,
+    })
 }
 
-/// Download a tarball, extract a named entry. Cleans up tarball after extraction.
+/// Download an owned tarball and extract a named entry into another owned temp.
 async fn download_and_extract(
     client: &reqwest::Client,
     url: &str,
@@ -859,131 +900,124 @@ async fn download_and_extract(
     archive_identity: &SetupArtifactIdentity,
     installed_identity: &SetupArtifactIdentity,
 ) -> RunnerResult<ProducedSetupArtifact> {
-    let ProducedSetupArtifact {
-        path: tarball_path,
-        file: tarball_file,
-        sha256: _,
-    } = download_to_temp(client, url, target, "tarball", label, archive_identity).await?;
-
-    let result = extract_tar_entry(
-        tarball_file,
-        &tarball_path,
-        target,
-        entry_name,
-        label,
-        installed_identity,
-    )
-    .await;
-    let _ = tokio::fs::remove_file(&tarball_path).await;
-    result
+    let archive = download_to_temp(client, url, target, "tarball", label, archive_identity).await?;
+    extract_tar_entry(archive, target, entry_name, label, installed_identity).await
 }
 
 /// Extract a named entry from a gzipped tarball, writing to tmp_path.
 /// Matches by file_name (last path component).
 async fn extract_tar_entry(
-    mut tarball_file: File,
-    tarball_path: &Path,
+    archive: ProducedSetupArtifact,
     target: &Path,
     entry_name: &str,
     label: &str,
     installed_identity: &SetupArtifactIdentity,
 ) -> RunnerResult<ProducedSetupArtifact> {
-    let tarball = tarball_path.to_owned();
     let target = target.to_owned();
     let entry_name = entry_name.to_owned();
     let label = label.to_owned();
     let expected_size = installed_identity.size;
 
     tokio::task::spawn_blocking(move || {
-        tarball_file.seek(SeekFrom::Start(0)).map_err(|e| {
-            RunnerError::Internal(format!("seek verified tarball {}: {e}", tarball.display()))
-        })?;
-        let decoder = flate2::read::GzDecoder::new(tarball_file);
-        let mut archive = tar::Archive::new(decoder);
-
-        let entries = archive
-            .entries()
-            .map_err(|e| RunnerError::Internal(format!("read tarball entries: {e}")))?;
-
-        for entry in entries {
-            let mut entry =
-                entry.map_err(|e| RunnerError::Internal(format!("read tarball entry: {e}")))?;
-
-            let path = entry
-                .path()
-                .map_err(|e| RunnerError::Internal(format!("read entry path: {e}")))?;
-
-            let file_name = path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or_default();
-
-            if file_name == entry_name {
-                let declared_size = entry.size();
-                if declared_size != expected_size {
-                    return Err(RunnerError::Internal(format!(
-                        "{label} entry size mismatch: expected {expected_size} bytes, got {declared_size} bytes"
-                    )));
-                }
-
-                let (tmp, mut out) = create_setup_temp_file(&target, "extract")?;
-                let result = (|| {
-                    let mut hasher = Sha256::new();
-                    let mut buf = [0u8; 64 * 1024];
-                    let mut observed_size = 0_u64;
-                    loop {
-                        let n = entry
-                            .read(&mut buf)
-                            .map_err(|e| RunnerError::Internal(format!("read tar entry: {e}")))?;
-                        if n == 0 {
-                            if observed_size != expected_size {
-                                return Err(RunnerError::Internal(format!(
-                                    "{label} entry size mismatch: expected {expected_size} bytes, got {observed_size} bytes"
-                                )));
-                            }
-                            std::io::Write::flush(&mut out)
-                                .map_err(|e| RunnerError::Internal(format!("flush binary: {e}")))?;
-                            return Ok(hex::encode(hasher.finalize()));
-                        }
-                        let chunk = buf.get(..n).ok_or_else(|| {
-                            RunnerError::Internal("read returned invalid length".into())
-                        })?;
-                        let chunk_size = u64::try_from(chunk.len()).map_err(|e| {
-                            RunnerError::Internal(format!("measure {label} tar entry chunk: {e}"))
-                        })?;
-                        let next_size = observed_size.checked_add(chunk_size).ok_or_else(|| {
-                            RunnerError::Internal(format!(
-                                "{label} entry size overflow while extracting"
-                            ))
-                        })?;
-                        if next_size > expected_size {
-                            return Err(RunnerError::Internal(format!(
-                                "{label} entry exceeds expected size of {expected_size} bytes (read at least {next_size} bytes)"
-                            )));
-                        }
-                        hasher.update(chunk);
-                        std::io::Write::write_all(&mut out, chunk)
-                            .map_err(|e| RunnerError::Internal(format!("write binary: {e}")))?;
-                        observed_size = next_size;
-                    }
-                })();
-                if result.is_err() {
-                    let _ = std::fs::remove_file(&tmp);
-                }
-                return result.map(|sha256| ProducedSetupArtifact {
-                    path: tmp,
-                    file: out,
-                    sha256,
-                });
-            }
-        }
-
-        Err(RunnerError::Internal(format!(
-            "'{entry_name}' not found in tarball"
-        )))
+        extract_tar_entry_blocking(archive, &target, &entry_name, &label, expected_size)
     })
     .await
     .map_err(|e| RunnerError::Internal(format!("extract task failed: {e}")))?
+}
+
+fn extract_tar_entry_blocking(
+    archive: ProducedSetupArtifact,
+    target: &Path,
+    entry_name: &str,
+    label: &str,
+    expected_size: u64,
+) -> RunnerResult<ProducedSetupArtifact> {
+    let ProducedSetupArtifact {
+        temp_path: archive_path,
+        mut file,
+        sha256: _,
+    } = archive;
+    file.seek(SeekFrom::Start(0)).map_err(|e| {
+        RunnerError::Internal(format!(
+            "seek verified tarball {}: {e}",
+            archive_path.path().display()
+        ))
+    })?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+
+    let entries = archive
+        .entries()
+        .map_err(|e| RunnerError::Internal(format!("read tarball entries: {e}")))?;
+
+    for entry in entries {
+        let mut entry =
+            entry.map_err(|e| RunnerError::Internal(format!("read tarball entry: {e}")))?;
+
+        let path = entry
+            .path()
+            .map_err(|e| RunnerError::Internal(format!("read entry path: {e}")))?;
+
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+
+        if file_name == entry_name {
+            let declared_size = entry.size();
+            if declared_size != expected_size {
+                return Err(RunnerError::Internal(format!(
+                    "{label} entry size mismatch: expected {expected_size} bytes, got {declared_size} bytes"
+                )));
+            }
+
+            let (temp_path, mut out) = create_setup_temp_file(target, "extract")?;
+            let mut hasher = Sha256::new();
+            let mut buf = [0u8; 64 * 1024];
+            let mut observed_size = 0_u64;
+            loop {
+                let n = entry
+                    .read(&mut buf)
+                    .map_err(|e| RunnerError::Internal(format!("read tar entry: {e}")))?;
+                if n == 0 {
+                    if observed_size != expected_size {
+                        return Err(RunnerError::Internal(format!(
+                            "{label} entry size mismatch: expected {expected_size} bytes, got {observed_size} bytes"
+                        )));
+                    }
+                    std::io::Write::flush(&mut out)
+                        .map_err(|e| RunnerError::Internal(format!("flush binary: {e}")))?;
+                    return Ok(ProducedSetupArtifact {
+                        temp_path,
+                        file: out,
+                        sha256: hex::encode(hasher.finalize()),
+                    });
+                }
+                let chunk = buf
+                    .get(..n)
+                    .ok_or_else(|| RunnerError::Internal("read returned invalid length".into()))?;
+                let chunk_size = u64::try_from(chunk.len()).map_err(|e| {
+                    RunnerError::Internal(format!("measure {label} tar entry chunk: {e}"))
+                })?;
+                let next_size = observed_size.checked_add(chunk_size).ok_or_else(|| {
+                    RunnerError::Internal(format!("{label} entry size overflow while extracting"))
+                })?;
+                if next_size > expected_size {
+                    return Err(RunnerError::Internal(format!(
+                        "{label} entry exceeds expected size of {expected_size} bytes (read at least {next_size} bytes)"
+                    )));
+                }
+                hasher.update(chunk);
+                std::io::Write::write_all(&mut out, chunk)
+                    .map_err(|e| RunnerError::Internal(format!("write binary: {e}")))?;
+                observed_size = next_size;
+            }
+        }
+    }
+
+    Err(RunnerError::Internal(format!(
+        "'{entry_name}' not found in tarball"
+    )))
 }
 
 /// Verify SHA256, set permissions through the produced fd, and atomically rename to target.
@@ -996,9 +1030,13 @@ async fn verify_and_install(
     mode: u32,
 ) -> RunnerResult<()> {
     let verification = (|| {
-        let stat = setup_file_stat(&artifact.file, &artifact.path, "produced setup artifact")?;
+        let stat = setup_file_stat(
+            &artifact.file,
+            artifact.temp_path.path(),
+            "produced setup artifact",
+        )?;
         let actual_size =
-            setup_artifact_file_size(&stat, &artifact.path, "produced setup artifact")?;
+            setup_artifact_file_size(&stat, artifact.temp_path.path(), "produced setup artifact")?;
         if actual_size != expected.size {
             return Err(RunnerError::Internal(format!(
                 "{label} size mismatch: expected {} bytes, got {actual_size} bytes",
@@ -1007,10 +1045,7 @@ async fn verify_and_install(
         }
         verify_sha256(&artifact.sha256, &expected.sha256, label)
     })();
-    if let Err(e) = verification {
-        let _ = tokio::fs::remove_file(&artifact.path).await;
-        return Err(e);
-    }
+    verification?;
 
     match atomic_install_produced(artifact, target, mode).await {
         Ok(()) => Ok(()),
@@ -1028,23 +1063,16 @@ async fn verify_and_install(
     }
 }
 
-/// Prepare a produced artifact through its fd, then atomically rename. Cleans up temp on failure.
+/// Prepare a produced artifact through its fd, then atomically rename and disarm cleanup.
 async fn atomic_install_produced(
     artifact: ProducedSetupArtifact,
     target: &Path,
     mode: u32,
 ) -> RunnerResult<()> {
-    let tmp_path = artifact.path.clone();
     let target = target.to_owned();
-    let result =
-        tokio::task::spawn_blocking(move || install_produced_artifact(artifact, &target, mode))
-            .await
-            .map_err(|e| RunnerError::Internal(format!("install task failed: {e}")))?;
-
-    if result.is_err() {
-        let _ = tokio::fs::remove_file(&tmp_path).await;
-    }
-    result
+    tokio::task::spawn_blocking(move || install_produced_artifact(artifact, &target, mode))
+        .await
+        .map_err(|e| RunnerError::Internal(format!("install task failed: {e}")))?
 }
 
 #[allow(clippy::unreachable)] // arch validated by check_architecture
@@ -1154,17 +1182,18 @@ mod tests {
     use super::*;
     use std::os::unix::fs::{PermissionsExt, symlink};
     use std::os::unix::net::UnixListener;
+    use std::sync::mpsc;
 
     fn mode(path: &Path) -> u32 {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
     }
 
     fn produced_artifact(path: &Path, content: &[u8]) -> ProducedSetupArtifact {
-        let mut file = create_setup_temp_file_at(path).unwrap();
+        let (temp_path, mut file) = create_setup_temp_file_at(path).unwrap();
         std::io::Write::write_all(&mut file, content).unwrap();
         std::io::Write::flush(&mut file).unwrap();
         ProducedSetupArtifact {
-            path: path.to_owned(),
+            temp_path,
             file,
             sha256: hex::encode(Sha256::digest(content)),
         }
@@ -1175,6 +1204,44 @@ mod tests {
             size: u64::try_from(content.len()).unwrap(),
             sha256: hex::encode(Sha256::digest(content)),
         }
+    }
+
+    fn tarball_with_entry(entry_name: &str, content: &[u8]) -> Vec<u8> {
+        let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, entry_name, content)
+            .unwrap();
+        builder.into_inner().unwrap().finish().unwrap()
+    }
+
+    fn setup_temp_files(root: &Path) -> Vec<PathBuf> {
+        std::fs::read_dir(root)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| {
+                path.file_name()
+                    .is_some_and(|name| name.to_string_lossy().ends_with(".tmp"))
+            })
+            .collect()
+    }
+
+    async fn wait_for_setup_temp_count(root: &Path, expected: usize) -> Vec<PathBuf> {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let temp_files = setup_temp_files(root);
+                if temp_files.len() == expected {
+                    return temp_files;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("setup temp count did not converge")
     }
 
     #[test]
@@ -1309,10 +1376,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(".artifact.tmp");
 
-        let file = create_setup_temp_file_at(&path).unwrap();
+        let (temp_path, file) = create_setup_temp_file_at(&path).unwrap();
         drop(file);
 
+        assert!(path.exists());
         assert_eq!(mode(&path), SETUP_TEMP_ARTIFACT_MODE);
+        drop(temp_path);
+        assert!(!path.exists());
     }
 
     #[test]
@@ -1570,6 +1640,122 @@ mod tests {
                 .unwrap_err();
 
         assert!(error.to_string().contains("mode"));
+    }
+
+    #[tokio::test]
+    async fn detached_blocking_extraction_cleans_owned_temps() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = b"extracted content";
+        let tarball = tarball_with_entry("tool", content);
+        let archive_path = dir.path().join(".tool.tarball.test.tmp");
+        let target = dir.path().join("tool");
+        let archive = produced_artifact(&archive_path, &tarball);
+        let expected_size = u64::try_from(content.len()).unwrap();
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_extract_tx, release_extract_rx) = mpsc::channel();
+        let (output_ready_tx, output_ready_rx) = tokio::sync::oneshot::channel();
+        let (release_return_tx, release_return_rx) = mpsc::channel();
+        let blocking_target = target.clone();
+        let extraction_task = tokio::spawn(async move {
+            tokio::task::spawn_blocking(move || {
+                entered_tx.send(()).unwrap();
+                release_extract_rx.recv().unwrap();
+                let result = extract_tar_entry_blocking(
+                    archive,
+                    &blocking_target,
+                    "tool",
+                    "test",
+                    expected_size,
+                );
+                output_ready_tx.send(()).unwrap();
+                release_return_rx.recv().unwrap();
+                result
+            })
+            .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(2), entered_rx)
+            .await
+            .expect("blocking extraction did not start")
+            .expect("blocking extraction start sender dropped");
+        assert!(archive_path.exists());
+        assert_eq!(setup_temp_files(dir.path()), vec![archive_path.clone()]);
+
+        extraction_task.abort();
+        let join_error = match extraction_task.await {
+            Err(error) => error,
+            Ok(_) => panic!("extraction task completed before cancellation"),
+        };
+        assert!(join_error.is_cancelled());
+        release_extract_tx.send(()).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), output_ready_rx)
+            .await
+            .expect("detached extraction did not produce output")
+            .expect("detached extraction output sender dropped");
+        assert!(!archive_path.exists());
+        let extracted_temps = wait_for_setup_temp_count(dir.path(), 1).await;
+        assert!(
+            extracted_temps[0]
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .contains(".extract.")
+        );
+        assert!(!target.exists());
+
+        release_return_tx.send(()).unwrap();
+        assert!(wait_for_setup_temp_count(dir.path(), 0).await.is_empty());
+        assert!(!target.exists());
+    }
+
+    #[tokio::test]
+    async fn detached_blocking_install_failure_cleans_owned_temp() {
+        let dir = tempfile::tempdir().unwrap();
+        let temp_path = dir.path().join(".tool.install.test.tmp");
+        let target = dir.path().join("target");
+        std::fs::create_dir(&target).unwrap();
+        let artifact = produced_artifact(&temp_path, b"content");
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
+        let blocking_target = target.clone();
+        let install_task = tokio::spawn(async move {
+            tokio::task::spawn_blocking(move || {
+                entered_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                let result = install_produced_artifact(
+                    artifact,
+                    &blocking_target,
+                    SETUP_EXECUTABLE_ARTIFACT_MODE,
+                );
+                finished_tx.send(result.is_err()).unwrap();
+                result
+            })
+            .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(2), entered_rx)
+            .await
+            .expect("blocking install did not start")
+            .expect("blocking install start sender dropped");
+        assert!(temp_path.exists());
+
+        install_task.abort();
+        let join_error = match install_task.await {
+            Err(error) => error,
+            Ok(_) => panic!("install task completed before cancellation"),
+        };
+        assert!(join_error.is_cancelled());
+        release_tx.send(()).unwrap();
+
+        let failed = tokio::time::timeout(Duration::from_secs(2), finished_rx)
+            .await
+            .expect("detached blocking install did not finish")
+            .expect("detached blocking install result sender dropped");
+        assert!(failed);
+        assert!(wait_for_setup_temp_count(dir.path(), 0).await.is_empty());
+        assert!(target.is_dir());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- own setup artifact temporary paths with a drop guard until the final rename succeeds
- carry temporary-file ownership through direct downloads, archive extraction, and blocking installation work
- cover cancellation during direct downloads and detached blocking extraction/install work

## Exclusions

- does not scan for or remove temporary files left by older runner processes
- does not attempt cleanup after an uncatchable process kill or host crash
- does not change APIs, schemas, protocols, dependencies, or persisted data

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::setup`
- setup test suite repeated 10 times
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`

Closes #25113
