### PR TITLE
perf(sandbox-fc): reduce residual balloon polling gaps

### DIFF
--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3201,8 +3201,16 @@ fn idle_transition_error(
 
 /// Maximum time to wait for balloon inflation before pausing vCPUs.
 const BALLOON_SETTLE_TIMEOUT: Duration = Duration::from_secs(5);
-/// Initial poll interval while waiting for balloon inflation.
-const BALLOON_SETTLE_INITIAL_POLL: Duration = Duration::from_millis(25);
+/// Fast-start poll intervals while waiting for balloon inflation.
+const BALLOON_SETTLE_FAST_POLL_INTERVALS: [Duration; 7] = [
+    Duration::from_millis(25),
+    Duration::from_millis(50),
+    Duration::from_millis(100),
+    Duration::from_millis(100),
+    Duration::from_millis(100),
+    Duration::from_millis(200),
+    Duration::from_millis(200),
+];
 /// Maximum poll interval while waiting for balloon inflation.
 const BALLOON_SETTLE_MAX_POLL: Duration = Duration::from_millis(500);
 /// Upper bound for accepting residual differences between requested and
@@ -3465,7 +3473,7 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
     let deadline = tokio::time::Instant::now() + BALLOON_SETTLE_TIMEOUT;
     let tolerance_mib = balloon_settle_tolerance_mib(target_mib);
     let mut summary = BalloonSettleSummary::new(target_mib);
-    let mut poll_interval = BALLOON_SETTLE_INITIAL_POLL;
+    let mut fast_poll_intervals = BALLOON_SETTLE_FAST_POLL_INTERVALS.into_iter();
     loop {
         if tokio::time::Instant::now() >= deadline {
             let outcome = summary.park_outcome();
@@ -3610,6 +3618,9 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
             }
         }
 
+        let poll_interval = fast_poll_intervals
+            .next()
+            .unwrap_or(BALLOON_SETTLE_MAX_POLL);
         let next_poll = tokio::time::Instant::now() + poll_interval;
         tokio::time::sleep_until(if next_poll < deadline {
             next_poll
@@ -3617,7 +3628,6 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
             deadline
         })
         .await;
-        poll_interval = poll_interval.saturating_mul(2).min(BALLOON_SETTLE_MAX_POLL);
     }
 }
 

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -4141,7 +4141,7 @@ async fn wait_for_balloon_rechecks_after_initial_25_ms_delay() {
 }
 
 #[tokio::test]
-async fn wait_for_balloon_caps_adaptive_polling_at_14_samples() {
+async fn wait_for_balloon_follows_exact_bounded_poll_schedule() {
     let target_mib = 2048 - balloon::MIN_GUEST_MIB;
     let request_entered = Arc::new(Notify::new());
     let response_release = Arc::new(Notify::new());
@@ -4152,7 +4152,7 @@ async fn wait_for_balloon_caps_adaptive_polling_at_14_samples() {
             release: Arc::clone(&response_release),
             stats: MockBalloonStats::new(target_mib, 0),
         })
-        .take(14)
+        .take(16)
         .chain(std::iter::once(MockBalloonStatsReply::Status(500)))
         .collect(),
     );
@@ -4165,7 +4165,7 @@ async fn wait_for_balloon_caps_adaptive_polling_at_14_samples() {
     tokio::pin!(wait);
 
     for (index, delay_ms) in [
-        0_u64, 25, 50, 100, 200, 400, 500, 500, 500, 500, 500, 500, 500, 500,
+        0_u64, 25, 50, 100, 100, 100, 200, 200, 500, 500, 500, 500, 500, 500, 500, 500,
     ]
     .into_iter()
     .enumerate()
@@ -4231,9 +4231,9 @@ async fn wait_for_balloon_caps_adaptive_polling_at_14_samples() {
             .iter()
             .filter(|request| request.method == "GET" && request.path == "/balloon/statistics")
             .count(),
-        14
+        16
     );
-    assert_balloon_settle_summary(&captured.entries(), "deadline", 14, "reject_and_destroy");
+    assert_balloon_settle_summary(&captured.entries(), "deadline", 16, "reject_and_destroy");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- replace exponential balloon-settle polling with the explicit 25/50/100/100/100/200/200 ms fast-start sequence followed by the existing 500 ms tail
- preserve the five-second absolute deadline, response-relative delays, Firecracker request timeout, and all park admission outcomes
- extend the mock Unix-socket integration test to prove the exact 16-sample schedule and request ceiling while retaining the 25 ms two-request success path

## Scope

This PR changes only `sandbox-fc` balloon observation cadence and its integration coverage. It does not change runner scheduling, API or persistence contracts, telemetry transport, idle admission, workspace behavior, or cross-run ownership. Parent #25045 owns the deployed comparison and any later direct-handoff decision.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox-fc --all-features --no-deps`
- `cargo test -p sandbox-fc --all-targets --all-features` (807 unit tests and 1 integration test)
- staged pre-commit checks (workspace Cargo fmt, Clippy, rustdoc, and file-size check)

Closes #25127
Relates to #25045
