### PR TITLE
feat: upload local cli packages during development

### DIFF
--- a/.github/scripts/tests/deploy-cli-local-test.sh
+++ b/.github/scripts/tests/deploy-cli-local-test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+deploy_script="${repo_root}/scripts/deploy-cli-local.sh"
+build_script="${repo_root}/.github/scripts/build-okou-cli-artifact.sh"
+verify_script="${repo_root}/.github/scripts/verify-okou-cli-artifact.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+test_root="${tmp_dir}/repo"
+mkdir -p \
+  "${test_root}/scripts" \
+  "${test_root}/.github/scripts" \
+  "${test_root}/turbo/apps/cli/dist" \
+  "${test_root}/bin"
+
+ln -s "$deploy_script" "${test_root}/scripts/deploy-cli-local.sh"
+ln -s "$build_script" "${test_root}/.github/scripts/build-okou-cli-artifact.sh"
+ln -s "$verify_script" "${test_root}/.github/scripts/verify-okou-cli-artifact.sh"
+
+cat >"${test_root}/scripts/.env.local" <<'EOF'
+R2_ACCOUNT_ID=test-account
+R2_ACCESS_KEY_ID=wrong-access-key
+R2_SECRET_ACCESS_KEY=wrong-secret-key
+R2_STATIC_ACCESS_KEY_ID=static-access-key
+R2_STATIC_SECRET_ACCESS_KEY=static-secret-key
+EOF
+
+cat >"${test_root}/scripts/cn.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'test.identity\n'
+EOF
+chmod +x "${test_root}/scripts/cn.sh"
+
+cat >"${test_root}/turbo/apps/cli/dist/package.json" <<'EOF'
+{
+  "name": "@vm0/cli",
+  "version": "1.0.0",
+  "bin": { "zero": "zero.js" },
+  "files": ["*.js"]
+}
+EOF
+printf '#!/usr/bin/env node\n' >"${test_root}/turbo/apps/cli/dist/zero.js"
+
+cat >"${test_root}/bin/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n'
+EOF
+
+cat >"${test_root}/bin/pnpm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >"${PNPM_LOG:?}"
+EOF
+
+cat >"${test_root}/bin/aws" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+endpoint=""
+bucket=""
+key=""
+body=""
+content_type=""
+cache_control=""
+while (( $# )); do
+  case "$1" in
+    --endpoint-url) endpoint="$2"; shift 2 ;;
+    --bucket) bucket="$2"; shift 2 ;;
+    --key) key="$2"; shift 2 ;;
+    --body) body="$2"; shift 2 ;;
+    --content-type) content_type="$2"; shift 2 ;;
+    --cache-control) cache_control="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+{
+  printf 'endpoint=%s\n' "$endpoint"
+  printf 'bucket=%s\n' "$bucket"
+  printf 'key=%s\n' "$key"
+  printf 'content_type=%s\n' "$content_type"
+  printf 'cache_control=%s\n' "$cache_control"
+  printf 'access_key=%s\n' "${AWS_ACCESS_KEY_ID:?}"
+  printf 'secret_key=%s\n' "${AWS_SECRET_ACCESS_KEY:?}"
+  printf 'region=%s\n' "${AWS_DEFAULT_REGION:?}"
+} >"${AWS_LOG:?}"
+cp "$body" "${UPLOADED_PACKAGE:?}"
+EOF
+
+chmod +x "${test_root}/bin/git" "${test_root}/bin/pnpm" "${test_root}/bin/aws"
+
+output="$({
+  PATH="${test_root}/bin:${PATH}" \
+    PNPM_LOG="${tmp_dir}/pnpm.log" \
+    AWS_LOG="${tmp_dir}/aws.log" \
+    UPLOADED_PACKAGE="${tmp_dir}/package.tgz" \
+    bash "${test_root}/scripts/deploy-cli-local.sh"
+})"
+
+grep -Fxq -- '--filter @vm0/cli build' "${tmp_dir}/pnpm.log"
+grep -Fxq 'endpoint=https://test-account.r2.cloudflarestorage.com' "${tmp_dir}/aws.log"
+grep -Fxq 'bucket=vm0-static-dev' "${tmp_dir}/aws.log"
+grep -Fxq 'key=okou-cli/local/test.identity/package.tgz' "${tmp_dir}/aws.log"
+grep -Fxq 'content_type=application/gzip' "${tmp_dir}/aws.log"
+grep -Fxq 'cache_control=no-store' "${tmp_dir}/aws.log"
+grep -Fxq 'access_key=static-access-key' "${tmp_dir}/aws.log"
+grep -Fxq 'secret_key=static-secret-key' "${tmp_dir}/aws.log"
+grep -Fxq 'region=auto' "${tmp_dir}/aws.log"
+grep -Fxq 'CLI_PKG_URL=https://static.vm7.io/okou-cli/local/test.identity/package.tgz' <<<"$output"
+
+package_json="$(tar -xOf "${tmp_dir}/package.tgz" package/package.json)"
+jq -e '.name == "@vm0/cli" and .bin.zero == "zero.js"' <<<"$package_json" >/dev/null
+
+echo "deploy-cli-local tests passed"

--- a/.github/scripts/tests/deploy-cli-workflow-test.sh
+++ b/.github/scripts/tests/deploy-cli-workflow-test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+workflow="${repo_root}/.github/workflows/turbo.yml"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+job_block() {
+  local job_name="$1"
+  awk -v job_name="$job_name" '
+    $0 == "  " job_name ":" { in_job = 1 }
+    in_job && $0 ~ /^  [a-zA-Z0-9_-]+:$/ && $0 != "  " job_name ":" { exit }
+    in_job { print }
+  ' "$workflow"
+}
+
+deploy_api="$(job_block deploy-api)"
+deploy_cli="$(job_block deploy-cli)"
+
+grep -Fq '    needs: [prepare]' <<<"$deploy_api" ||
+  fail "deploy-api must depend on prepare"
+if grep -Fq 'deploy-cli' <<<"$deploy_api"; then
+  fail "deploy-api must not wait for deploy-cli"
+fi
+
+expected_package_url="cli-pkg-url: https://static.vm0.io/okou-cli/\${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}/package.tgz"
+package_url_count="$(grep -Fc "$expected_package_url" <<<"$deploy_api" || true)"
+[[ "$package_url_count" == "2" ]] ||
+  fail "API seed and deploy environments must derive the CLI package URL from the artifact SHA"
+
+grep -Fq '      - name: Initialize pnpm cache directory' <<<"$deploy_cli" ||
+  fail "deploy-cli must initialize the pnpm cache directory"
+grep -Fq "        run: mkdir -p \"\$(pnpm store path --silent)\"" <<<"$deploy_cli" ||
+  fail "deploy-cli must create the pnpm store before setup-node saves it"
+
+echo "deploy-cli-workflow tests passed"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -852,7 +852,7 @@ jobs:
       cancel-in-progress: true
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260622
-    needs: [prepare, deploy-cli]
+    needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and anything
     # that needs a live API preview or E2E API token changed.
     # Runs in merge queue too, but skips GitHub Deployment creation (the bobheadxi/deployments action
@@ -904,7 +904,7 @@ jobs:
           web-url: ${{ needs.prepare.outputs.api-preview-url }}
           app-url: ${{ needs.prepare.outputs.app-preview-url }}
           api-backend-url: ${{ needs.prepare.outputs.api-preview-url }}
-          cli-pkg-url: ${{ needs.deploy-cli.outputs.package-url }}
+          cli-pkg-url: https://static.vm0.io/okou-cli/${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}/package.tgz
         env:
           REPO_VARS_JSON: ${{ toJSON(vars) }}
           REPO_SECRETS_JSON: ${{ toJSON(secrets) }}
@@ -1008,7 +1008,7 @@ jobs:
           web-url: ${{ needs.prepare.outputs.api-preview-url }}
           app-url: ${{ needs.prepare.outputs.app-preview-url }}
           api-backend-url: ${{ needs.prepare.outputs.api-preview-url }}
-          cli-pkg-url: ${{ needs.deploy-cli.outputs.package-url }}
+          cli-pkg-url: https://static.vm0.io/okou-cli/${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}/package.tgz
         env:
           REPO_VARS_JSON: ${{ toJSON(vars) }}
           REPO_SECRETS_JSON: ${{ toJSON(secrets) }}
@@ -1969,9 +1969,6 @@ jobs:
   deploy-cli:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    outputs:
-      artifact-sha: ${{ steps.artifact.outputs.sha }}
-      package-url: ${{ steps.artifact.outputs.package-url }}
     concurrency:
       group: deploy-cli-${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       cancel-in-progress: false
@@ -2006,6 +2003,8 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: turbo/pnpm-lock.yaml
+      - name: Initialize pnpm cache directory
+        run: mkdir -p "$(pnpm store path --silent)"
       - name: Configure git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
@@ -2034,7 +2033,6 @@ jobs:
           {
             echo "sha=$sha"
             echo "prefix=$prefix"
-            echo "package-url=${CLI_STATIC_BASE_URL}/${prefix}/package.tgz"
           } >> "$GITHUB_OUTPUT"
 
       - name: Check for existing artifact

--- a/scripts/.env.local.tpl
+++ b/scripts/.env.local.tpl
@@ -18,6 +18,11 @@ R2_ACCOUNT_ID=op://Development/cloudflare/R2_ACCOUNT_ID
 R2_ACCESS_KEY_ID=op://Development/cloudflare/R2_ACCESS_KEY_ID
 R2_SECRET_ACCESS_KEY=op://Development/cloudflare/R2_SECRET_ACCESS_KEY
 R2_USER_STORAGES_BUCKET_NAME=op://Development/cloudflare/R2_USER_STORAGES_BUCKET_NAME
+
+# R2 static assets for local CLI uploads
+R2_STATIC_ACCESS_KEY_ID=op://Development/cloudflare/R2_STATIC_ACCESS_KEY_ID
+R2_STATIC_SECRET_ACCESS_KEY=op://Development/cloudflare/R2_STATIC_SECRET_ACCESS_KEY
+
 R2_USER_ARTIFACTS_BUCKET_NAME=user-artifact-dev
 R2_USER_ARTIFACTS_ACCESS_KEY_ID=op://Development/cloudflare/R2_USER_ARTIFACTS_ACCESS_KEY_ID
 R2_USER_ARTIFACTS_SECRET_ACCESS_KEY=op://Development/cloudflare/R2_USER_ARTIFACTS_SECRET_ACCESS_KEY

--- a/scripts/deploy-cli-local.sh
+++ b/scripts/deploy-cli-local.sh
@@ -22,8 +22,8 @@ source "$ENV_FILE"
 set +a
 
 : "${R2_ACCOUNT_ID:?R2_ACCOUNT_ID is required in scripts/.env.local}"
-: "${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID is required in scripts/.env.local}"
-: "${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY is required in scripts/.env.local}"
+: "${R2_STATIC_ACCESS_KEY_ID:?R2_STATIC_ACCESS_KEY_ID is required in scripts/.env.local}"
+: "${R2_STATIC_SECRET_ACCESS_KEY:?R2_STATIC_SECRET_ACCESS_KEY is required in scripts/.env.local}"
 
 identity="$("$SCRIPT_DIR/cn.sh" -u)"
 if [[ ! "$identity" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
@@ -46,8 +46,8 @@ commit_sha="$(git -C "$PROJECT_ROOT" rev-parse HEAD)"
 
 object_key="okou-cli/local/${identity}/package.tgz"
 r2_endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
-AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID" \
-AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY" \
+AWS_ACCESS_KEY_ID="$R2_STATIC_ACCESS_KEY_ID" \
+AWS_SECRET_ACCESS_KEY="$R2_STATIC_SECRET_ACCESS_KEY" \
 AWS_DEFAULT_REGION=auto \
   aws s3api put-object \
     --endpoint-url "$r2_endpoint" \

--- a/turbo/apps/cli/tsup.config.ts
+++ b/turbo/apps/cli/tsup.config.ts
@@ -49,6 +49,11 @@ export default defineConfig({
   },
   onSuccess: isWatchMode
     ? async () => {
+        console.log("Uploading Zero CLI for local runners...");
+        execSync("pnpm --workspace-root deploy-cli:local", {
+          stdio: "inherit",
+        });
+        console.log("Zero CLI uploaded for local runners");
         console.log("Installing Zero CLI globally...");
         execSync("sudo npm link --local", { cwd: "dist", stdio: "inherit" });
         console.log("Zero CLI installed globally");


### PR DESCRIPTION
## Summary

- upload the local CLI package to the identity-scoped R2 URL after successful dev watch builds
- use the dedicated R2 static credentials and cover the local upload contract
- decouple `deploy-api` from `deploy-cli` by deriving `CLI_PKG_URL` from the event commit SHA
- initialize the pnpm cache directory when an existing CLI artifact skips dependency installation

## Testing

- `pnpm --filter @vm0/cli lint`
- `pnpm --filter @vm0/cli check-types`
- `pnpm --filter @vm0/cli test`
- `pnpm knip --workspace @vm0/cli`
- Actionlint and workflow shell compatibility checks
- Shellcheck and the new local deploy/workflow regression tests
- real `pnpm deploy-cli:local` upload and CDN package verification
- full pre-commit checks, including repository Knip and TypeScript checks
