### PR TITLE
fix(auth): retain organization across mobile token refresh

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/auth-org-switch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-org-switch.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  emitMockedClerkEvent,
+  mockedClerk,
+  mockOrganization,
+} from "../../__tests__/mock-auth.ts";
+import { setupPage } from "../../__tests__/page-helper.ts";
+import { testContext } from "./test-helpers.ts";
+
+const context = testContext();
+
+describe("organization auth lifecycle", () => {
+  it("keeps the active organization through a transient Clerk refresh", async () => {
+    window.location.href = "http://localhost/error";
+
+    await setupPage({
+      context,
+      path: "/error",
+      org: {
+        activeOrg: { id: "org_A", name: "Org A" },
+        memberships: [{ id: "org_A" }],
+      },
+      withoutRender: true,
+    });
+    mockedClerk.sessionGetToken.mockClear();
+
+    mockOrganization({
+      activeOrg: null,
+      memberships: [{ id: "org_A" }],
+    });
+    emitMockedClerkEvent();
+
+    expect(sessionStorage.getItem("clerk-active-org-id")).toBe("org_A");
+
+    mockOrganization({
+      activeOrg: { id: "org_A", name: "Org A" },
+      memberships: [{ id: "org_A" }],
+    });
+    emitMockedClerkEvent();
+
+    expect(mockedClerk.sessionGetToken).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe("/error");
+  });
+});

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -447,20 +447,15 @@ export const watchOrgSwitch$ = command(async ({ get }, signal: AbortSignal) => {
   const unsubscribe = clerk.addListener(
     onDomEventFn(async () => {
       const newOrgId = clerk.organization?.id ?? undefined;
-      if (newOrgId === prevOrgId) {
+      // On mobile, Clerk can transiently clear clerk.organization to
+      // undefined during a background token refresh before restoring it on
+      // the next event. Keep the previous concrete org so that restoration
+      // is recognized as unchanged rather than as an org switch.
+      if (!newOrgId || newOrgId === prevOrgId) {
         return;
       }
       prevOrgId = newOrgId;
       persistOrgId(newOrgId);
-      // On mobile, Clerk can transiently clear clerk.organization to
-      // undefined during a background token refresh before restoring it on
-      // the next event. Guard against that by only reloading when the
-      // session is landing on a concrete org (org_A→org_B or
-      // undefined→org_A). An org disappearing to undefined is treated as a
-      // transient state; the listener will fire again with the real org_id.
-      if (!newOrgId) {
-        return;
-      }
 
       await bestEffort(
         (async () => {


### PR DESCRIPTION
## Summary

- retain the last concrete Clerk organization when a mobile background refresh briefly clears it
- prevent the same organization restoration from being treated as a real switch and triggering a hard reload
- cover the full org_A -> undefined -> org_A sequence through the production bootstrap path

## Context

The guard introduced in #11570 returned for an undefined organization only after updating prevOrgId and clearing session storage. When Clerk restored the original organization on its next event, watchOrgSwitch$ saw undefined -> org_A and reloaded the page.

This moves the existing empty-organization guard before those mutations. Genuine org_A -> org_B switches and first undefined -> org_A selections retain their existing behavior. No timers, retries, or additional lifecycle listeners are introduced.

## Verification

- pnpm exec prettier --write apps/platform/src/signals/auth.ts apps/platform/src/signals/__tests__/auth-org-switch.test.ts
- pnpm -F @vm0/app exec vitest run src/signals/__tests__/auth-org-switch.test.ts
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm knip --workspace @vm0/app