### PR TITLE
docs(guest-init): document cgroup containment bootstrap

### DIFF
--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -3,9 +3,13 @@
 //! The kernel mounts the ext4 rootfs via `root=/dev/vda rw` boot arg and
 //! auto-mounts devtmpfs on `/dev` (`CONFIG_DEVTMPFS_MOUNT=y`).
 //!
-//! This module handles the remaining setup:
-//! 1. Mount virtual filesystems (/proc, /sys)
-//! 2. Configure TCP keepalive and environment variables
+//! This module completes the ordered boot setup:
+//! 1. Mount `/proc`.
+//! 2. Configure TCP keepalive.
+//! 3. Mount `/sys` and initialize cgroup v2 exec process containment.
+//! 4. Mount `/dev/shm`.
+//! 5. Load shared environment variables.
+//! 6. Enter `/root`.
 
 use nix::mount::{MsFlags, mount};
 use std::fs;
@@ -19,14 +23,15 @@ const CGROUP_EVENTS_FILE: &str = "cgroup.events";
 const CGROUP_KILL_FILE: &str = "cgroup.kill";
 const CGROUP_SUBTREE_CONTROL_FILE: &str = "cgroup.subtree_control";
 
-/// Initialize virtual filesystems and environment.
+/// Initialize guest boot filesystems, exec process containment, and environment.
 ///
 /// The kernel has already mounted `/dev/vda` as root (`root=/dev/vda rw`)
 /// and devtmpfs on `/dev` (`CONFIG_DEVTMPFS_MOUNT=y`).
+/// Errors returned here are fatal to PID 1 before it forks `vsock-guest`.
 pub fn init_filesystem() -> Result<(), InitError> {
     eprintln!("[guest-init] Starting filesystem initialization");
 
-    // 1. Mount virtual filesystems
+    // 1. Mount /proc.
     mount(
         Some("proc"),
         "/proc",
@@ -39,7 +44,7 @@ pub fn init_filesystem() -> Result<(), InitError> {
         source: e,
     })?;
 
-    // Configure aggressive TCP keepalive for faster dead connection detection.
+    // 2. Configure aggressive TCP keepalive for faster dead connection detection.
     // Default values (7200s/75s/9 probes = ~2h11m) exceed JOB_TIMEOUT (2h),
     // so dead connections are never detected. These values reduce detection to ~2min.
     for (param, value) in [
@@ -53,6 +58,7 @@ pub fn init_filesystem() -> Result<(), InitError> {
         }
     }
 
+    // 3. Mount /sys and initialize exec process containment.
     mount(
         Some("sys"),
         "/sys",
@@ -67,7 +73,7 @@ pub fn init_filesystem() -> Result<(), InitError> {
 
     initialize_process_containment()?;
 
-    // Mount tmpfs on /dev/shm — required by Chromium for shared memory.
+    // 4. Mount tmpfs on /dev/shm — required by Chromium for shared memory.
     // devtmpfs (CONFIG_DEVTMPFS_MOUNT=y) doesn't create /dev/shm.
     let _ = fs::create_dir_all("/dev/shm");
     mount(
@@ -84,7 +90,7 @@ pub fn init_filesystem() -> Result<(), InitError> {
 
     eprintln!("[guest-init] Virtual filesystems mounted");
 
-    // 2. Load environment variables.
+    // 5. Load environment variables.
     //
     // /etc/environment is baked into the rootfs by customize-rootfs.sh and
     // contains variables shared by ALL users (LANG, NODE_EXTRA_CA_CERTS, …).
@@ -100,7 +106,7 @@ pub fn init_filesystem() -> Result<(), InitError> {
         std::env::set_var("SHELL", "/bin/bash");
     }
 
-    // 3. Change to root home directory (init runs as root;
+    // 6. Change to root home directory (init runs as root;
     // `su - user` will cd to /home/user automatically)
     let _ = std::env::set_current_dir("/root");
 
@@ -143,6 +149,14 @@ impl std::fmt::Display for InitError {
 
 impl std::error::Error for InitError {}
 
+/// Mount cgroup v2 and validate the canonical exec process-containment base.
+///
+/// Cgroup v2 is mounted at `CGROUP_V2_MOUNT_PATH`. The exec base at
+/// `EXEC_CGROUP_BASE_PATH` must expose `cgroup.procs`, `cgroup.events`,
+/// `cgroup.kill`, and `cgroup.subtree_control` as files, with no resource
+/// controllers enabled for its subtree. `vsock-guest` depends on this invariant
+/// for per-exec process cleanup and for validating quiescence before sandbox
+/// reuse.
 fn initialize_process_containment() -> Result<(), InitError> {
     create_dir_all(Path::new(CGROUP_V2_MOUNT_PATH))?;
     mount(

--- a/crates/guest-init/src/main.rs
+++ b/crates/guest-init/src/main.rs
@@ -21,7 +21,8 @@
 //!   they cannot race with each other.
 //!
 //! Startup sequence:
-//! 1. Initialize filesystem (mount /proc, /sys, set env vars)
+//! 1. Initialize guest filesystems, environment, and cgroup v2 exec containment.
+//!    Failure is fatal before `vsock-guest` is forked.
 //! 2. Configure PID 1 signals and block supervised signals
 //! 3. Fork child process
 //! 4. Child (PID 2): restore its inherited signal mask, run vsock-guest
@@ -37,7 +38,7 @@ const SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_secs(1);
 fn main() {
     eprintln!("[guest-init] Starting...");
 
-    // Step 1: Initialize filesystem
+    // Step 1: Initialize guest filesystems, environment, and exec containment.
     if let Err(e) = init::init_filesystem() {
         eprintln!("[guest-init] FATAL: Filesystem init failed: {}", e);
         std::process::exit(1);


### PR DESCRIPTION
## Summary

- align the `guest-init` boot responsibility lists with the implemented startup order
- document the cgroup v2 exec-containment capability contract beside its enforcement
- record that containment failure is fatal before `vsock-guest` starts and that cleanup and reuse quiescence depend on the invariant

## Scope

This changes documentation comments only. Runtime behavior, guest protocols, persisted state, deployment compatibility, and tests are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-init --all-targets --all-features`
- `cargo doc -p guest-init --all-features --no-deps`
- `cargo test -p guest-init --all-features` (22 passed)
- pre-commit workspace Rust formatting, Clippy, and documentation checks

Closes #25141
