### PR TITLE
refactor(rust): centralize epoch-millisecond validation

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -26,6 +26,7 @@
 //! legacy JSONL and failure-diagnostic shapes rather than preserving their raw
 //! app-server representation.
 
+use guest_contracts::epoch_milliseconds::is_plausible_epoch_milliseconds;
 use serde_json::{Map, Value, json};
 
 use super::codex_app_server::ServerNotification;
@@ -54,7 +55,6 @@ pub(super) const IGNORED_NOTIFICATION_METHODS: &[&str] = &[
 
 const MAX_GENERIC_COLLECTION_ITEMS: usize = 16;
 const MAX_GENERIC_OBJECT_FIELDS: usize = 24;
-const MIN_EPOCH_MS_TIMESTAMP: u64 = 1_000_000_000_000;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum CodexOutputItemKind {
@@ -180,7 +180,7 @@ pub(super) fn codex_output_item_start(
         .get("startedAtMs")
         .ok_or_else(|| missing_field(&notification.method, "startedAtMs"))?
         .as_u64()
-        .filter(|value| *value >= MIN_EPOCH_MS_TIMESTAMP)
+        .filter(|value| is_plausible_epoch_milliseconds(*value))
         .ok_or_else(|| invalid_field_for_method(&notification.method, "startedAtMs"))?;
 
     Ok(Some(CodexOutputItemStart {

--- a/crates/guest-agent/src/timing.rs
+++ b/crates/guest-agent/src/timing.rs
@@ -2,11 +2,11 @@
 
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
+use guest_contracts::epoch_milliseconds::is_plausible_epoch_milliseconds;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
-const MIN_EPOCH_MS_TIMESTAMP: u64 = 1_000_000_000_000;
 static INVALID_API_START_TIME_WARNED: AtomicBool = AtomicBool::new(false);
 
 /// Record an E2E duration from an already captured API start timestamp.
@@ -49,7 +49,7 @@ fn e2e_duration_from_api_start(api_start: &str, now_ms: u64) -> Option<Duration>
 
 fn parse_api_start_time_ms(api_start: &str) -> Option<u64> {
     let api_start_ms = api_start.parse::<u64>().ok()?;
-    if api_start_ms < MIN_EPOCH_MS_TIMESTAMP {
+    if !is_plausible_epoch_milliseconds(api_start_ms) {
         return None;
     }
 

--- a/crates/guest-contracts/src/epoch_milliseconds.rs
+++ b/crates/guest-contracts/src/epoch_milliseconds.rs
@@ -1,0 +1,13 @@
+//! Shared plausibility contract for Unix epoch-millisecond timestamps.
+//!
+//! The minimum distinguishes millisecond-shaped timestamps from contemporary
+//! Unix epoch seconds. This contract intentionally does not restrict how far a
+//! timestamp may be in the future.
+
+/// Inclusive minimum for a plausible Unix epoch-millisecond timestamp.
+pub const MIN_PLAUSIBLE_EPOCH_MILLISECONDS: u64 = 1_000_000_000_000;
+
+/// Return whether a value is a plausible Unix epoch-millisecond timestamp.
+pub fn is_plausible_epoch_milliseconds(timestamp: u64) -> bool {
+    timestamp >= MIN_PLAUSIBLE_EPOCH_MILLISECONDS
+}

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cli_agent_session_id;
 pub mod codex_thread_id;
 pub mod diagnostics;
 pub mod env;
+pub mod epoch_milliseconds;
 pub mod exec_limits;
 pub mod exec_terminal;
 pub mod process_containment;

--- a/crates/guest-contracts/tests/epoch_milliseconds.rs
+++ b/crates/guest-contracts/tests/epoch_milliseconds.rs
@@ -1,0 +1,27 @@
+use guest_contracts::epoch_milliseconds::{
+    MIN_PLAUSIBLE_EPOCH_MILLISECONDS, is_plausible_epoch_milliseconds,
+};
+
+#[test]
+fn accepts_minimum_and_future_values() {
+    for timestamp in [
+        MIN_PLAUSIBLE_EPOCH_MILLISECONDS,
+        1_700_000_000_000,
+        u64::MAX,
+    ] {
+        assert!(
+            is_plausible_epoch_milliseconds(timestamp),
+            "expected acceptance for {timestamp}"
+        );
+    }
+}
+
+#[test]
+fn rejects_values_below_minimum() {
+    for timestamp in [0, 1_700_000_000, MIN_PLAUSIBLE_EPOCH_MILLISECONDS - 1] {
+        assert!(
+            !is_plausible_epoch_milliseconds(timestamp),
+            "expected rejection for {timestamp}"
+        );
+    }
+}

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -128,7 +128,6 @@ fn job_supervisor_timeout() -> Duration {
 fn job_terminal_wait_timeout() -> Duration {
     job_supervisor_timeout() + JOB_TERMINAL_GRACE_TIMEOUT
 }
-const MIN_EPOCH_MS_TIMESTAMP: u64 = 1_000_000_000_000;
 const BOOTSTRAP_SENSITIVE_ENV_KEYS: &[&str] = &[
     "BASH_ENV",
     "ENV",

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -3,9 +3,11 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
+use guest_contracts::epoch_milliseconds::{
+    MIN_PLAUSIBLE_EPOCH_MILLISECONDS, is_plausible_epoch_milliseconds,
+};
 use tracing::warn;
 
-use super::MIN_EPOCH_MS_TIMESTAMP;
 use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, SandboxReuseResult};
 use crate::workspace_image_cache::WorkspaceCacheCheckoutResult;
@@ -260,14 +262,14 @@ pub(super) fn warn_invalid_api_start_time_once(
     warn!(
         run_id = %context.run_id,
         api_start_ms,
-        min_epoch_ms_timestamp = MIN_EPOCH_MS_TIMESTAMP,
+        min_epoch_ms_timestamp = MIN_PLAUSIBLE_EPOCH_MILLISECONDS,
         action_type,
         "skipping API latency telemetry for invalid epoch-ms start timestamp"
     );
 }
 
 pub(super) fn elapsed_since_api_start_ms(api_start_ms: u64, now_ms: u64) -> Option<Duration> {
-    if api_start_ms < MIN_EPOCH_MS_TIMESTAMP {
+    if !is_plausible_epoch_milliseconds(api_start_ms) {
         return None;
     }
 


### PR DESCRIPTION
## Summary

- add a shared epoch-millisecond plausibility contract in `guest-contracts`
- use the shared predicate for runner API latency, guest E2E timing, and Codex output timing
- cover the inclusive minimum, seconds-shaped rejection, and future-value acceptance through the public contract API

## Behavior and compatibility

- preserves the existing `1_000_000_000_000` inclusive boundary
- preserves future timestamp acceptance and saturating elapsed-duration behavior
- preserves guest parsing and warnings, Codex filtering and method-specific errors, and the runner's structured warning field
- changes no public payload, environment variable, telemetry name, TypeScript contract, schema, migration, feature switch, or deployment order

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p runner -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p runner -p guest-agent --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts -p runner -p guest-agent --all-targets --all-features`
- repository pre-commit hooks

Closes #25143
