### PR TITLE
fix(python): keep connector diagnostics bodyless for head

### DIFF
--- a/crates/runner/mitm-addon/src/connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/connector_diagnostics.py
@@ -22,7 +22,7 @@ Lifecycle:
 - ``responseheaders()`` offers eligible 401/403 responses to
   ``install_response_stream_if_needed()`` before installing general response
   streaming. A diagnostic stream suppresses the upstream body and emits its
-  replacement body once.
+  replacement content once, except that HEAD remains bodyless.
 - ``response()`` completes streamed replacement or handles buffered 401/403
   replacement before network logging. ``error()`` may synthesize a diagnostic
   response unless response headers already installed a replacement.
@@ -158,6 +158,7 @@ def maybe_make_local_response(
 
     Return ``True`` only after installing a local HTTP 424 response, recording
     failure/timing/firewall metadata, and emitting the diagnostic proxy entry.
+    HEAD keeps the same diagnostic status and metadata without response content.
     The caller must treat that response as terminal for request dispatch.
     """
     if _is_browser_diagnostic_skip(flow):
@@ -171,10 +172,10 @@ def maybe_make_local_response(
     flow_metadata.start_request_timing(flow.metadata)
     _set_failure_metadata(flow, candidate)
     flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
-    flow.response = http.Response.make(
-        _HTTP_STATUS_FAILED_DEPENDENCY,
-        _response_body(candidate, upstream_status=0),
-        {"Content-Type": "application/json"},
+    flow.response = _make_local_response(
+        flow,
+        candidate,
+        upstream_status=0,
     )
     _log_proxy_entry(
         flow,
@@ -205,7 +206,8 @@ def maybe_make_firewall_allow_local_response(
     local response.
 
     Return ``True`` only after installing and logging a local HTTP 424 response
-    and recording the selected candidate and ownership metadata. The caller
+    and recording the selected candidate and ownership metadata. HEAD keeps the
+    same diagnostic status and metadata without response content. The caller
     must stop normal request dispatch on ``True``.
     """
     if _is_browser_diagnostic_skip(flow):
@@ -245,10 +247,10 @@ def maybe_make_firewall_allow_local_response(
     flow.metadata[_CONNECTOR_DIAGNOSTIC_OWNERSHIP_CANDIDATES] = resolution.candidate_connector_slugs
     flow.metadata[_CONNECTOR_DIAGNOSTIC_OWNERSHIP_HINT_STATUS] = resolution.hint_status
     flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
-    flow.response = http.Response.make(
-        _HTTP_STATUS_FAILED_DEPENDENCY,
-        _response_body(candidate, upstream_status=0),
-        {"Content-Type": "application/json"},
+    flow.response = _make_local_response(
+        flow,
+        candidate,
+        upstream_status=0,
     )
     _log_proxy_entry(
         flow,
@@ -262,9 +264,10 @@ def install_response_stream_if_needed(flow: http.HTTPFlow) -> bool:
     """Install diagnostic replacement during the response-header phase.
 
     ``responseheaders()`` must call this before general response streaming. For
-    an eligible unauthenticated 401/403, it replaces the response body and its
-    framing headers, caches the diagnostic body, and installs a callback that
-    discards upstream chunks and emits that body once at end-of-stream.
+    an eligible unauthenticated 401/403, it replaces the response content and
+    framing headers, caches the diagnostic content, and installs a callback that
+    discards upstream chunks and emits that content once at end-of-stream. HEAD
+    caches and emits empty content without a Content-Length field.
 
     Return ``True`` only when this module owns ``flow.response.stream``; the
     caller must then skip installing another stream callback. ``False`` means no
@@ -341,9 +344,11 @@ def maybe_replace_response(
         if isinstance(body, bytes) and not flow.metadata.get(
             _CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT
         ):
-            flow.response.content = body
-            flow.response.headers["Content-Type"] = "application/json"
-            flow.response.headers["Content-Length"] = str(len(body))
+            _apply_diagnostic_response_content(
+                flow.response,
+                body,
+                omit_content_length=_is_head_request(flow),
+            )
         _log_proxy_entry(
             flow,
             original_url=original_url,
@@ -389,7 +394,8 @@ def maybe_make_error_response(
     already installed diagnostic replacement, it does not create or log another
     diagnostic and clears trailers when a response exists. Otherwise an
     eligible non-browser request without auth material receives a local HTTP 424
-    response with upstream status zero and one diagnostic proxy entry.
+    response with upstream status zero and one diagnostic proxy entry. HEAD keeps
+    that response bodyless.
     """
     if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS):
         if flow.response is not None:
@@ -403,10 +409,10 @@ def maybe_make_error_response(
     if _request_has_auth_material(flow, candidate, original_url):
         return
     _set_failure_metadata(flow, candidate)
-    flow.response = http.Response.make(
-        _HTTP_STATUS_FAILED_DEPENDENCY,
-        _response_body(candidate, upstream_status=0),
-        {"Content-Type": "application/json"},
+    flow.response = _make_local_response(
+        flow,
+        candidate,
+        upstream_status=0,
     )
     _log_proxy_entry(
         flow,
@@ -627,6 +633,55 @@ def _response_body(
     return json.dumps(body, separators=(",", ":")).encode()
 
 
+def _is_head_request(flow: http.HTTPFlow) -> bool:
+    return flow.request.method.upper() == "HEAD"
+
+
+def _set_diagnostic_response_content(
+    flow: http.HTTPFlow,
+    response: http.Response,
+    candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
+    *,
+    upstream_status: int,
+) -> bytes:
+    bodyless = _is_head_request(flow)
+    content = b"" if bodyless else _response_body(candidate, upstream_status=upstream_status)
+    _apply_diagnostic_response_content(
+        response,
+        content,
+        omit_content_length=bodyless,
+    )
+    return content
+
+
+def _apply_diagnostic_response_content(
+    response: http.Response,
+    content: bytes,
+    *,
+    omit_content_length: bool,
+) -> None:
+    response.content = content
+    response.headers["Content-Type"] = "application/json"
+    if omit_content_length:
+        del response.headers["Content-Length"]
+
+
+def _make_local_response(
+    flow: http.HTTPFlow,
+    candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
+    *,
+    upstream_status: int,
+) -> http.Response:
+    response = http.Response.make(_HTTP_STATUS_FAILED_DEPENDENCY)
+    _set_diagnostic_response_content(
+        flow,
+        response,
+        candidate,
+        upstream_status=upstream_status,
+    )
+    return response
+
+
 def _message(
     candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
 ) -> str:
@@ -714,14 +769,12 @@ def _replace_response_content(
         if header in flow.response.headers:
             del flow.response.headers[header]
     flow.response.trailers = None
-    body = _response_body(
+    return _set_diagnostic_response_content(
+        flow,
+        flow.response,
         candidate,
         upstream_status=upstream_status,
     )
-    flow.response.content = body
-    flow.response.headers["Content-Type"] = "application/json"
-    flow.response.headers["Content-Length"] = str(len(body))
-    return body
 
 
 def _log_proxy_entry(

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -150,6 +150,39 @@ class TestErrorHandler:
         assert proxy_entries[0]["upstream_status"] == 0
         assert proxy_entries[1]["type"] == "connection_error"
 
+    async def test_head_connector_candidate_error_gets_bodyless_diagnostic(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        reg_path = write_connector_diagnostic_capture_registry(tmp_path)
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="fal.run",
+            path="/fal-ai/nano-banana-pro",
+            method="HEAD",
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            record_connector_diagnostic_requestheaders_context(flow)
+            flow.error = Error("connection reset by peer")
+            mitm_addon.error(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 424
+        assert flow.response.raw_content == b""
+        assert flow.response.headers["Content-Type"] == "application/json"
+        assert flow.response.headers.get_all("Content-Length") == []
+        assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG] == "fal"
+        [network_entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert network_entry["response_size"] == 0
+        assert network_entry["error"] == "connection reset by peer"
+        assert "response_body" not in network_entry
+        [connector_entry, connection_entry] = read_jsonl_entries_after_flush(
+            tmp_path / "proxy.jsonl"
+        )
+        assert connector_entry["type"] == "connector_diagnostic"
+        assert connection_entry["type"] == "connection_error"
+
     def test_streamed_connector_candidate_error_before_request_gets_diagnostic(
         self, tmp_path, real_flow, mitm_ctx
     ):

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
@@ -51,6 +51,10 @@ from tests.aws_sigv4_helpers import (
     resolved_aws_sigv4_credentials,
 )
 from tests.codex_model_catalog_cache_helpers import catalog_flow
+from tests.connector_diagnostic_helpers import (
+    record_connector_diagnostic_requestheaders_context,
+    write_connector_diagnostic_capture_registry,
+)
 from tests.firewall_aws_sigv4_helpers import aws_api_entry
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
@@ -498,6 +502,94 @@ async def _catalog_http_stream(
     stream.client_state = stream.state_done
     stream.server_state = stream.state_wait_for_response_headers
     return stream, flow
+
+
+async def test_head_connector_diagnostic_emits_no_response_data(
+    tmp_path: Path,
+    real_flow,
+) -> None:
+    registry_path = write_connector_diagnostic_capture_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip=_CLIENT_IP,
+        host="fal.run",
+        path="/fal-ai/nano-banana-pro",
+        method="HEAD",
+    )
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+    ):
+        addon_context.options.update(
+            vm0_api_url="https://api.vm0.ai",
+            vm0_builtin_firewall_catalog_cache_path=str(
+                tmp_path / "builtin-firewall-catalog-cache.json"
+            ),
+            vm0_proxy_registry_path=str(registry_path),
+        )
+        record_connector_diagnostic_requestheaders_context(flow)
+        _, http_layer = _start_http_layer(
+            addon_context,
+            alpn=b"h2",
+            host="fal.run",
+        )
+        stream = HttpStream(http_layer.context.fork(), 1)
+        list(stream.handle_event(events.Start()))
+        stream.flow = flow
+        flow.live = True
+        stream.client_state = stream.state_done
+        stream.server_state = stream.state_wait_for_response_headers
+
+        upstream_response = tutils.tresp(
+            status_code=401,
+            headers=header_map(
+                {
+                    "Content-Length": "8",
+                    "Content-Type": "text/plain",
+                }
+            ),
+            content=b"",
+        )
+        response_header_commands = list(
+            stream.handle_event(ResponseHeaders(1, upstream_response, end_stream=True))
+        )
+        response_headers_hook = next(
+            command
+            for command in response_header_commands
+            if isinstance(command, HttpResponseHeadersHook)
+        )
+        await addon_context.master.addons.invoke_addon(
+            mitm_addon,
+            response_headers_hook,
+        )
+        after_headers = list(stream.handle_event(events.HookCompleted(response_headers_hook, None)))
+
+        end_commands = list(stream.handle_event(ResponseEndOfMessage(1)))
+        response_hook = next(
+            command for command in end_commands if isinstance(command, HttpResponseHook)
+        )
+        await addon_context.master.addons.invoke_addon(mitm_addon, response_hook)
+        after_response = list(stream.handle_event(events.HookCompleted(response_hook, None)))
+
+    assert flow.response is not None
+    assert flow.response.status_code == 401
+    assert flow.response.raw_content == b""
+    assert flow.response.headers["Content-Type"] == "application/json"
+    assert flow.response.headers.get_all("Content-Length") == []
+    client_events = [
+        command.event
+        for command in [*after_headers, *end_commands, *after_response]
+        if isinstance(command, SendHttp)
+    ]
+    assert any(
+        isinstance(event, ResponseHeaders)
+        and event.response.status_code == 401
+        and event.end_stream
+        for event in client_events
+    )
+    assert not any(isinstance(event, ResponseData) for event in client_events)
+    assert any(isinstance(event, ResponseEndOfMessage) for event in client_events)
 
 
 async def test_http2_brotli_catalog_is_streamed_unchanged_while_cached(

--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
@@ -10,6 +10,7 @@ import request_classification
 import request_streaming
 import upstream_destination_binding
 from tests.connector_diagnostic_helpers import (
+    write_connector_diagnostic_capture_registry,
     write_connector_diagnostic_catalog_cache,
     write_shared_base_diagnostic_catalog,
 )
@@ -136,6 +137,52 @@ async def test_shared_base_unknown_endpoint_diagnoses_inactive_sibling_before_au
     assert proxy_log_entry["ownership_reason"] == "route_owner"
     assert proxy_log_entry["ownership_candidates"] == ["active-shared", "inactive-shared"]
     assert proxy_log_entry["ownership_hint_status"] == "ignored"
+
+
+async def test_shared_base_head_diagnostic_is_bodyless(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    write_shared_base_diagnostic_catalog(
+        tmp_path,
+        active_permissions=[{"name": "active-read", "rules": ["GET /active"]}],
+        inactive_permissions=[{"name": "inactive-read", "rules": ["HEAD /inactive"]}],
+    )
+    reg_path = _write_shared_base_active_firewall_registry(
+        tmp_path,
+        vm_fields={"captureNetworkBodies": True},
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path="/inactive",
+        method="HEAD",
+        request_headers=headers(
+            ("Host", "shared.example.com"),
+            ("X-VM0-Connector-Intent", "inactive-shared"),
+        ),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer active"}) as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+        mitm_addon.response(flow)
+
+    auth_fetch.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 424
+    assert flow.response.raw_content == b""
+    assert flow.response.headers["Content-Type"] == "application/json"
+    assert flow.response.headers.get_all("Content-Length") == []
+    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG] == "inactive-shared"
+    [network_entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+    assert network_entry["response_size"] == 0
+    assert "response_body" not in network_entry
+    [connector_entry, http_error_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert connector_entry["type"] == "connector_diagnostic"
+    assert http_error_entry["type"] == "http_error"
 
 
 async def test_shared_base_connector_intent_diagnoses_inside_candidate_set_before_auth(
@@ -391,6 +438,36 @@ async def test_inactive_builtin_connector_url_without_auth_gets_local_diagnostic
     assert proxy_entry["upstream_status"] == 0
     assert http_error_entry["type"] == "http_error"
     assert http_error_entry["status"] == 424
+
+
+async def test_inactive_builtin_connector_head_diagnostic_is_bodyless(
+    tmp_path, real_flow, mitm_ctx
+):
+    reg_path = write_connector_diagnostic_capture_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="fal.run",
+        path="/fal-ai/nano-banana-pro",
+        method="HEAD",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+        mitm_addon.response(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 424
+    assert flow.response.raw_content == b""
+    assert flow.response.headers["Content-Type"] == "application/json"
+    assert flow.response.headers.get_all("Content-Length") == []
+    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG] == "fal"
+    [network_entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+    assert network_entry["response_size"] == 0
+    assert "response_body" not in network_entry
+    [connector_entry, http_error_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert connector_entry["type"] == "connector_diagnostic"
+    assert http_error_entry["type"] == "http_error"
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
@@ -89,6 +89,47 @@ async def test_replaces_unauthenticated_connector_401_body(tmp_path, real_flow, 
     assert proxy_entry["upstream_status"] == 401
 
 
+async def test_replaces_buffered_head_401_with_bodyless_diagnostic(tmp_path, real_flow, mitm_ctx):
+    reg_path = write_connector_diagnostic_capture_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="fal.run",
+        path="/fal-ai/nano-banana-pro",
+        method="HEAD",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        record_connector_diagnostic_requestheaders_context(flow)
+        flow.response = tutils.tresp(
+            status_code=401,
+            headers=header_map(
+                {
+                    "content-encoding": "gzip",
+                    "content-length": "8",
+                    "content-type": "text/plain",
+                    "transfer-encoding": "chunked",
+                }
+            ),
+            content=b"upstream",
+        )
+        mitm_addon.response(flow)
+
+    assert flow.response.status_code == 401
+    assert flow.response.raw_content == b""
+    assert flow.response.headers["Content-Type"] == "application/json"
+    assert flow.response.headers.get_all("Content-Length") == []
+    assert "Content-Encoding" not in flow.response.headers
+    assert "Transfer-Encoding" not in flow.response.headers
+    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG] == "fal"
+    [network_entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+    assert network_entry["response_size"] == 0
+    assert "response_body" not in network_entry
+    [connector_entry, http_error_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert connector_entry["type"] == "connector_diagnostic"
+    assert http_error_entry["type"] == "http_error"
+
+
 async def test_active_shared_base_owner_preserves_ordinary_allow_401(tmp_path, real_flow, mitm_ctx):
     write_shared_base_diagnostic_catalog(
         tmp_path,
@@ -305,6 +346,45 @@ async def test_restores_connector_diagnostic_body_when_headers_end_stream(
     [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
     assert entry["response_size"] == len(content)
     assert json.loads(entry["response_body"])["error"] == "connector_not_configured_for_run"
+
+
+async def test_head_response_stream_emits_no_diagnostic_body(tmp_path, real_flow, mitm_ctx):
+    reg_path = write_connector_diagnostic_capture_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="fal.run",
+        path="/fal-ai/nano-banana-pro",
+        method="HEAD",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        record_connector_diagnostic_requestheaders_context(flow)
+        flow.response = tutils.tresp(
+            status_code=401,
+            headers=header_map(
+                {
+                    "content-length": "8",
+                    "content-type": "text/plain",
+                    "transfer-encoding": "chunked",
+                }
+            ),
+            content=b"upstream",
+        )
+        mitm_addon.responseheaders(flow)
+        stream = response_stream(flow)
+        assert stream(b"unexpected upstream body") == ()
+        assert stream(b"") == b""
+        mitm_addon.response(flow)
+
+    assert flow.response.status_code == 401
+    assert flow.response.raw_content == b""
+    assert flow.response.headers["Content-Type"] == "application/json"
+    assert flow.response.headers.get_all("Content-Length") == []
+    assert "Transfer-Encoding" not in flow.response.headers
+    [network_entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+    assert network_entry["response_size"] == 0
+    assert "response_body" not in network_entry
 
 
 async def test_streams_connector_401_when_user_auth_is_present(


### PR DESCRIPTION
## Summary

- keep every connector-diagnostic response bodyless for `HEAD`, including ordinary local 424, shared-base local 424, upstream 401/403 replacement, and upstream-error 424 paths
- centralize diagnostic response content application so responseheaders streaming, end-stream restoration, buffered responses, and local responses share the same framing
- omit `Content-Length` for bodyless diagnostics while preserving status, JSON content type, diagnostic metadata, and proxy logging
- add real-hook integration coverage plus a pinned mitmproxy state-machine regression that asserts no client-facing `ResponseData`

## Scope

- non-HEAD diagnostic JSON and upstream-body suppression remain unchanged
- no connector matching, eligibility, status, schema, persistence, API, queue, or runner protocol changes
- no migration, feature switch, or coordinated rollout is required

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,762 passed)

Closes #25147
