### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -6,7 +6,7 @@ version = 4
 name = "ably-subscriber"
 version = "1.0.10"
 dependencies = [
- "base64 0.23.0",
+ "base64 0.23.1",
  "futures-util",
  "hmac",
  "httpmock",
@@ -602,9 +602,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64-simd"
@@ -1257,7 +1257,7 @@ version = "0.64.2"
 dependencies = [
  "aho-corasick",
  "api-contracts",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "flate2",
@@ -2493,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2612,7 +2612,7 @@ dependencies = [
  "async-trait",
  "aws-sdk-s3",
  "aws-smithy-mocks",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "clap",
@@ -4264,7 +4264,7 @@ version = "0.5.0"
 dependencies = [
  "api-contracts",
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "clap",
  "httpmock",
  "libc",


### PR DESCRIPTION
## Summary

- Update `base64` from 0.23.0 to 0.23.1.
- Update `regex-automata` from 0.4.16 to 0.4.18.
- Keep the change lockfile-only.

## Blocked dependencies

- `generic-array` 0.14.9 remains blocked because `crypto-common` 0.1.7 pins `generic-array` to `=0.14.7`.

## Manual manifest bumps

- None.

## Tests

- `cargo test --workspace --exclude runner`
- `cargo test -p runner` (2,960 passed, 15 ignored; guest inventory: 1 passed)
