### PR TITLE
refactor: remove r2ZeroCli feature switch

### DIFF
--- a/e2e/tests/03-runner/t58-mock-claude-echo-jsonl.bats
+++ b/e2e/tests/03-runner/t58-mock-claude-echo-jsonl.bats
@@ -6,14 +6,6 @@
 
 load '../../helpers/setup'
 
-set_r2_zero_cli() {
-    local enabled="$1"
-    e2e_api_curl "/api/zero/feature-switches" \
-        -X POST \
-        -d "{\"switches\":{\"r2ZeroCli\":${enabled}}}" \
-        >/dev/null
-}
-
 setup_file() {
     export AGENT_NAME="e2e-t58-$(date +%s%3N)-$RANDOM"
     export TEST_DIR="$(mktemp -d)"
@@ -40,7 +32,6 @@ EOF
 }
 
 teardown_file() {
-    set_r2_zero_cli false || true
     if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
         rm -rf "$TEST_DIR"
     fi
@@ -76,13 +67,9 @@ EOF
 }
 
 @test "t58-2: CLI_PKG_URL reaches the runner guest" {
-    set_r2_zero_cli true
-
     run run_compose_fixture \
         "$AGENT_NAME" \
         'test -n "$CLI_PKG_URL" && printf "CLI_PKG_URL=%s" "$CLI_PKG_URL"'
-
-    set_r2_zero_cli false
 
     assert_success
     assert_output --regexp 'CLI_PKG_URL=https://static\.vm0\.io/okou-cli/[0-9a-f]{40}/package\.tgz'

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9852,47 +9852,22 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 });
 
 describe("RUN-01: zero runner context, queue promotion, and skills", () => {
-  it("selects npm, R2, and runner-bundled Zero CLI distributions by feature switch precedence", async () => {
+  it("selects R2 and runner-bundled Zero CLI distributions by feature switch precedence", async () => {
     const api = createRunsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     if (!actor.orgId) {
       throw new Error("Zero CLI selection requires an organization");
     }
 
-    const npmRun = await api.createRun(actor, {
-      agentId,
-      prompt: "use the default Zero CLI",
-      modelProvider: "anthropic-api-key",
-    });
-    await api.heartbeatRunner(runnerGroup);
-    const npmClaim = await api.claimRunnerJob(npmRun.runId);
-    expect(npmClaim.appendSystemPrompt ?? "").toContain(
-      "Run commands with: `npx -p @vm0/cli zero <command>`",
-    );
-    expect(npmClaim.appendSystemPrompt ?? "").not.toContain(
-      "Run commands with: `zero-cli <command>`",
-    );
-    expect(npmClaim.environment?.CLI_PKG_URL).toBeUndefined();
-    await api.requestCancelRun(actor, npmRun.runId, [200]);
-
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.R2ZeroCli]: true },
-    );
-
     const r2Run = await api.createRun(actor, {
       agentId,
-      prompt: "use the R2 Zero CLI package",
+      prompt: "use the default Zero CLI",
       modelProvider: "anthropic-api-key",
     });
     await api.heartbeatRunner(runnerGroup);
     const r2Claim = await api.claimRunnerJob(r2Run.runId);
     expect(r2Claim.appendSystemPrompt ?? "").toContain(
       `Run commands with: \`npx --yes --package="\${CLI_PKG_URL}" zero <command>\``,
-    );
-    expect(r2Claim.appendSystemPrompt ?? "").not.toContain(
-      "Run commands with: `npx -p @vm0/cli zero <command>`",
     );
     expect(r2Claim.appendSystemPrompt ?? "").not.toContain(
       "Run commands with: `zero-cli <command>`",
@@ -9920,9 +9895,6 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     );
     expect(rustClaim.appendSystemPrompt ?? "").not.toContain(
       `Run commands with: \`npx --yes --package="\${CLI_PKG_URL}" zero <command>\``,
-    );
-    expect(rustClaim.appendSystemPrompt ?? "").not.toContain(
-      "Run commands with: `npx -p @vm0/cli zero <command>`",
     );
     expect(rustClaim.environment?.CLI_PKG_URL).toBeUndefined();
     await api.requestCancelRun(actor, rustRun.runId, [200]);
@@ -10166,7 +10138,9 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     );
     expect(claim.disallowedTools).not.toContain("WebFetch");
     expect(claim.environment?.ZERO_APP_URL).toBe(appUrl);
-    expect(claim.environment?.CLI_PKG_URL).toBeUndefined();
+    expect(claim.environment?.CLI_PKG_URL).toBe(
+      "https://static.vm0.io/okou-cli/test-commit/package.tgz",
+    );
     expect(claim.environment?.VM0_APP_URL).toBeUndefined();
     expect(claim.environment?.APP_URL).toBeUndefined();
     expect(claim.environment?.ZERO_AGENT_ID).toBe(agent.agentId);

--- a/turbo/apps/api/src/signals/routes/__tests__/test-agent-runs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-agent-runs.test.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 
 import { testAgentRunsContract } from "@vm0/api-contracts/contracts/test-agent-runs";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { createApp } from "../../../app-factory";
 import { accept, testContext } from "../../../__tests__/test-context";
@@ -11,7 +10,6 @@ import { generateSandboxToken } from "../../auth/tokens";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createRunReadsApi } from "./helpers/api-bdd-run-reads";
 import { createRunsApi } from "./helpers/api-bdd-runs";
-import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -84,14 +82,6 @@ describe("POST /api/test/agent-runs", () => {
       "https://static.vm0.io/okou-cli/direct-run-test/package.tgz",
     );
     const { actor, composeId, runnerGroup } = await seedDirectRunActor();
-    if (!actor.orgId) {
-      throw new Error("Expected an organization-scoped test actor");
-    }
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.R2ZeroCli]: true },
-    );
 
     const response = await accept(
       client().create({

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -5233,11 +5233,10 @@ async function buildStoredExecutionContextDraft(args: {
       connectorVars: args.connectorContext.vars,
     }),
     ...args.extraEnvironment,
-    ...(isFeatureEnabled(
-      FeatureSwitchKey.R2ZeroCli,
+    ...(!isFeatureEnabled(
+      FeatureSwitchKey.RustZeroCli,
       args.featureSwitchContext,
-    ) &&
-    !isFeatureEnabled(FeatureSwitchKey.RustZeroCli, args.featureSwitchContext)
+    )
       ? { CLI_PKG_URL: env("CLI_PKG_URL") }
       : {}),
   };

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -333,13 +333,10 @@ function buildAgentToolsPrompt(args: {
   readonly cloudBrowserEnabled: boolean | undefined;
   readonly mermaidDiagramsEnabled: boolean;
   readonly rustZeroCliEnabled: boolean;
-  readonly r2ZeroCliEnabled: boolean;
 }): string {
   const zeroCliCommand = args.rustZeroCliEnabled
     ? "zero-cli"
-    : args.r2ZeroCliEnabled
-      ? `npx --yes --package="\${CLI_PKG_URL}" zero`
-      : "npx -p @vm0/cli zero";
+    : `npx --yes --package="\${CLI_PKG_URL}" zero`;
   return [
     "# Agent Tools",
     `You have access to the Zero CLI. Run commands with: \`${zeroCliCommand} <command>\``,
@@ -470,10 +467,6 @@ function buildAppendSystemPrompt(args: {
       ),
       rustZeroCliEnabled: isFeatureEnabled(
         FeatureSwitchKey.RustZeroCli,
-        args.featureSwitchContext,
-      ),
-      r2ZeroCliEnabled: isFeatureEnabled(
-        FeatureSwitchKey.R2ZeroCli,
         args.featureSwitchContext,
       ),
     }),

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -52,7 +52,6 @@ describe("isFeatureEnabled", () => {
       isFeatureEnabled(FeatureSwitchKey.ChatThreadSidebarAutoOpen, {}),
     ).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.RustZeroCli, {})).toBe(false);
-    expect(isFeatureEnabled(FeatureSwitchKey.R2ZeroCli, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.JoggAiBuiltIn, {})).toBe(false);
   });
 

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -44,7 +44,6 @@ export enum FeatureSwitchKey {
   ZeroDebug = "zeroDebug",
   ZeroBrowser = "zeroBrowser",
   RustZeroCli = "rustZeroCli",
-  R2ZeroCli = "r2ZeroCli",
   Banking = "banking",
   Lab = "lab",
   NotionWorkflowAutomations = "notionWorkflowAutomations",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -468,12 +468,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Use the runner-bundled Rust zero-cli entry point for Zero CLI commands.",
     enabled: false,
   },
-  [FeatureSwitchKey.R2ZeroCli]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Use the commit-addressed R2 npm tarball for Zero CLI commands instead of the published @vm0/cli package.",
-    enabled: false,
-  },
   [FeatureSwitchKey.ComposerConnectorPermissions]: {
     maintainer: "ming@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- permanently select the commit-addressed R2 npm tarball for non-Rust Zero CLI runs
- inject `CLI_PKG_URL` without consulting `r2ZeroCli`
- remove the terminal feature-switch key, registry entry, test overrides, and off-path assertions
- retain the R2 artifact producer and the existing npm compatibility publication after auditing their consumers

## Terminal state

- Switch: `r2ZeroCli`
- State: `fully-rolled-out`
- Basis: Ethan requested the full rollout after successfully exercising `npx --yes --package="${CLI_PKG_URL}" zero --help` on 2026-08-05.
- Introducing commit: `4201a475d596ad7f97d2f3777dcc9c34f1037050` (`feat: deploy commit-addressed cli packages to r2`, #25072)

The introducing patch added the commit-addressed artifact pipeline and gated only runtime selection/injection. Its parent used `npx -p @vm0/cli zero`; the fully rolled-out branch uses the R2 tarball command and injects the matching URL. The independent `rustZeroCli` switch remains higher priority on current `main`, so Rust-enabled runs continue to advertise `zero-cli` and omit the otherwise-unused package URL.

## Publishing dependency audit

The publishing paths are intentionally retained:

- `.github/workflows/turbo.yml`'s `deploy-cli` job is the producer of `static.vm0.io/okou-cli/<sha>/package.tgz`, which the fully rolled-out runtime now requires. Removing it would break every new non-Rust run.
- `.github/workflows/release-please.yml`'s `publish-npm` job still serves the bundled Rust CLI's missing-`CLI_PKG_URL` fallback and the production E2B CLI template, which installs `@vm0/cli` directly. It also preserves compatibility for public npm consumers outside the repository.
- The npm job authenticates through GitHub OIDC. The `npm` environment currently has no dedicated Actions variables or secrets to remove.
- `R2_STATIC_ACCESS_KEY_ID`, `R2_STATIC_SECRET_ACCESS_KEY`, `R2_STATIC_BUCKET_NAME`, and `R2_ACCOUNT_ID` are shared with app deployment, release deployment, rollback, runner-image, and local CLI tooling. They are not cleanup-only configuration and were not deleted.

Open PR #25169 removes the separate native Rust CLI rollout and touches several of the same files. There is no terminal-state conflict: if #25169 lands first, this PR should be rebased so the permanent R2 path becomes unconditional. The npm publication still has the E2B/public compatibility consumers described above.

## Search and orphan cleanup

- Direct identifiers searched: `r2ZeroCli`, `R2ZeroCli`
- Variant sweep: `r2-zero-cli`, `r2_zero_cli`, `R2_ZERO_CLI`
- Related terms reviewed: `CLI_PKG_URL`, `okou-cli`, `npx -p @vm0/cli zero`, `publish-npm`, `npm publish`, and the R2 Actions credentials
- No switch identifier or discarded API prompt remains.
- Expected retained npm references are the Rust fallback and the E2B template; expected retained R2 references implement the permanent behavior.
- Knip baseline: exit 0 with 44 existing configuration hints.
- Knip after cleanup and after rebasing onto latest `main`: exit 0 with the same 44 hints and no new unused files, exports, types, or dependencies.

## Tests changed

- removed the feature-off npm case and the `r2ZeroCli` true/false matrix from the API lifecycle scenario
- kept direct assertions for the permanent R2 behavior and the independent Rust precedence behavior
- removed the feature-switch override from direct test runs
- removed the E2E switch mutator/teardown while retaining the guest-visible `CLI_PKG_URL` assertion
- removed the terminal switch's core registry assertion

## Validation

- `pnpm exec prettier --check` on all changed TypeScript files
- `git diff --check`
- `pnpm --filter @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (24 passed), rerun after rebase
- `pnpm --filter @vm0/core lint`
- targeted plain/type-aware Oxlint and ESLint on the four changed API files (passed; only pre-existing warnings elsewhere in the large lifecycle test file)
- `pnpm --filter @vm0/core check-types`
- `pnpm --filter api check-types`
- `pnpm knip` before and after cleanup, plus after rebase
- full identifier and related-consumer searches described above

## Local validation limits

- `pnpm --filter api exec vitest run src/signals/routes/__tests__/test-agent-runs.test.ts` was blocked before test execution because no local PostgreSQL server is available (`ECONNREFUSED ::1:5432` / `127.0.0.1:5432`; 4 tests skipped). The lifecycle scenario has the same database dependency, so it was not redundantly retried.
- full API workspace lint reached only existing Vitest-rule warnings and then exhausted the local Node heap (exit 134). The narrower lint over every changed API file passed.
- Bats is not installed locally, so the retained runner E2E assertion is delegated to the PR pipeline.

The PR is draft so the standard pipeline can supply the blocked database, full-workspace lint, and runner E2E coverage.
