### PR TITLE
fix(api): make slack test agent seeding race-safe

### DIFF
--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -207,16 +207,28 @@ async function seedDefaultAgent(
       name: input.name,
       displayName: input.displayName ?? null,
     })
-    .onConflictDoUpdate({
-      target: zeroAgents.id,
-      set: {
-        orgId: input.orgId,
-        owner: input.userId,
-        name: input.name,
-        displayName: input.displayName ?? null,
-        updatedAt: nowDate(),
-      },
-    });
+    // Telegram can seed this shared agent at the same time. Handle either
+    // unique key as the arbiter before updating the canonical compose row.
+    .onConflictDoNothing();
+
+  const [agent] = await db
+    .update(zeroAgents)
+    .set({
+      owner: input.userId,
+      displayName: input.displayName ?? null,
+      updatedAt: nowDate(),
+    })
+    .where(
+      and(
+        eq(zeroAgents.id, composeId),
+        eq(zeroAgents.orgId, input.orgId),
+        eq(zeroAgents.name, input.name),
+      ),
+    )
+    .returning({ id: zeroAgents.id });
+  if (!agent) {
+    throw new Error("Failed to resolve seeded default agent");
+  }
 
   await db.transaction(async (tx) => {
     await ensureStarterCreditGrant(tx, input.orgId);


### PR DESCRIPTION
## Summary

- let either `zero_agents` unique key arbitrate concurrent Slack/Telegram test-agent inserts
- update the canonical compose-backed Slack agent row separately
- fail explicitly if the `id` / `org_id` / `name` invariant cannot be resolved

## Root cause

Turbo merge-group run [30974647552](https://github.com/vm0-ai/vm0/actions/runs/30974647552) failed only in [runner shard 9](https://github.com/vm0-ai/vm0/actions/runs/30974647552/job/92206560077). The Slack round-trip fixture returned HTTP 500 before dispatch. Axiom recorded PostgreSQL error `23505` on `idx_zero_agents_org_name` while Slack used `ON CONFLICT (id) DO UPDATE`.

The shard first seeded Slack successfully, then its test reset/reseed overlapped Telegram setup. Both endpoints intentionally share `e2e-slack-agent`. Under concurrent speculative inserts, Slack handled only the primary-key arbiter while the `(org_id, name)` unique index could still fail. The original PR head and a later merge group both passed the unchanged shard, confirming this is timing-dependent and unrelated to #25145's runner cleanup changes.

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- targeted existing Slack/Telegram race test attempted, but local PostgreSQL was unavailable (`ECONNREFUSED localhost:5432`); PR CI will run it against the test database
