### PR TITLE
refactor(platform): trust agent source annotations

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
@@ -510,29 +510,6 @@ describe("user messages", () => {
           },
           createdAt: "2026-08-04T10:00:00Z",
         },
-        {
-          id: "00000000-0000-4000-8000-000000000752",
-          role: "user",
-          content: "Untrusted prompt",
-          runId: "d0000000-0000-4000-a000-000000000752",
-          triggerSource: "web",
-          userMessage: {
-            version: 1,
-            parts: [
-              { type: "text", text: "Untrusted prompt" },
-              {
-                type: "source",
-                kind: "agent",
-                runId: sourceRunId,
-                threadId: sourceThreadId,
-                agentId: sourceAgentId,
-                titleSnapshot: "Hidden source",
-                href: `/chats/${sourceThreadId}#run-${sourceRunId}`,
-              },
-            ],
-          },
-          createdAt: "2026-08-04T10:01:00Z",
-        },
       ],
     });
 
@@ -567,6 +544,5 @@ describe("user messages", () => {
       "data-role",
       "user",
     );
-    expect(screen.queryByText("Hidden source")).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -7588,21 +7588,11 @@ function resolvePagedUserMessageRendering({
 
 function visibleSourceAnnotationPart({
   userMessage,
-  inputEvent,
 }: {
   userMessage: UserMessageDocument | undefined;
-  inputEvent: ChatInputEvent | undefined;
 }) {
   const part = userMessageNonContentPart(userMessage);
-  if (
-    part?.type !== "source" ||
-    (part.kind === "agent" &&
-      (inputEvent?.eventType !== "input.prompt" ||
-        inputEvent.triggerSource !== "agent"))
-  ) {
-    return undefined;
-  }
-  return part;
+  return part?.type === "source" ? part : undefined;
 }
 
 function inputPromptRunAnchor(inputEvent: ChatInputEvent | undefined) {
@@ -7681,7 +7671,6 @@ function PagedUserMessage({
 
   const sourceAnnotationPart = visibleSourceAnnotationPart({
     userMessage,
-    inputEvent,
   });
   return (
     <div


### PR DESCRIPTION
## Summary

- trust `source` parts directly when deciding whether to render source annotations
- remove the redundant `triggerSource` check and the now-unused helper argument
- delete the impossible `triggerSource: "web"` plus `kind: "agent"` test fixture and its hidden-source assertion

## Why

The API derives both the agent source part and `triggerSource: "agent"` from the same `auth.tokenType === "zero"` condition. Re-checking the envelope field in the renderer duplicated a server invariant and treated agent sources differently from the six external source kinds.

## Merge order

This PR was opened after #25097 merged, so it is based on the post-#25097 `main` branch.

## Validation

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-user-messages.test.tsx --maxWorkers=1 --silent=passed-only` (1 file, 5 tests)
- Prettier check for both changed files
- Oxlint and ESLint for both changed files
- `grep -n "triggerSource" turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx` returns no matches

No server, contract, migration, or Morning Brief state changes.

Closes #25158