### PR TITLE
fix(sandbox-fc): wait for progressing balloon reclaim

### DIFF
--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3201,6 +3201,9 @@ fn idle_transition_error(
 
 /// Maximum time to wait for balloon inflation before pausing vCPUs.
 const BALLOON_SETTLE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Additional bounded wait when the balloon is still making progress and the
+/// guest reports enough unused memory to finish reclaiming safely.
+const BALLOON_SETTLE_PROGRESS_GRACE: Duration = Duration::from_secs(5);
 /// Fast-start poll intervals while waiting for balloon inflation.
 const BALLOON_SETTLE_FAST_POLL_INTERVALS: [Duration; 7] = [
     Duration::from_millis(25),
@@ -3238,6 +3241,7 @@ struct BalloonSettleSummary {
     last_observed_target_mib: Option<u32>,
     target_observed: bool,
     first_actual_mib: Option<u32>,
+    previous_actual_mib: Option<u32>,
     last_actual_mib: Option<u32>,
     max_actual_mib: Option<u32>,
     last_deficit_mib: Option<u32>,
@@ -3256,6 +3260,7 @@ impl BalloonSettleSummary {
             last_observed_target_mib: None,
             target_observed: false,
             first_actual_mib: None,
+            previous_actual_mib: None,
             last_actual_mib: None,
             max_actual_mib: None,
             last_deficit_mib: None,
@@ -3273,6 +3278,7 @@ impl BalloonSettleSummary {
         self.last_observed_target_mib = Some(stats.target_mib);
         self.target_observed |= stats.target_mib == self.requested_target_mib;
         self.first_actual_mib.get_or_insert(stats.actual_mib);
+        self.previous_actual_mib = self.last_actual_mib;
         self.last_actual_mib = Some(stats.actual_mib);
         self.max_actual_mib = Some(
             self.max_actual_mib
@@ -3341,6 +3347,31 @@ impl BalloonSettleSummary {
                 .is_some_and(|deficit| deficit >= self.severe_deficit_threshold_mib())
     }
 
+    fn can_extend_for_progress(&self) -> bool {
+        let (
+            Some(previous_actual_mib),
+            Some(last_actual_mib),
+            Some(deficit_mib),
+            Some(free_mib),
+            Some(available_mib),
+        ) = (
+            self.previous_actual_mib,
+            self.last_actual_mib,
+            self.last_deficit_mib,
+            self.reported_free_mib(),
+            self.reported_available_mib(),
+        )
+        else {
+            return false;
+        };
+
+        self.is_severe_deficit()
+            && self.last_observed_target_mib == Some(self.requested_target_mib)
+            && last_actual_mib > previous_actual_mib
+            && free_mib >= i64::from(deficit_mib)
+            && available_mib >= i64::from(deficit_mib) + balloon::PRESSURE_AVAILABLE_MIB
+    }
+
     fn park_outcome(&self) -> SandboxParkOutcome {
         if self.is_severe_deficit() {
             SandboxParkOutcome::NonReusable(SandboxParkNonReusableReason::SevereMemoryRetention)
@@ -3370,6 +3401,7 @@ fn log_balloon_settle_timeout(
     log_id: &str,
     target_mib: u32,
     tolerance_mib: u32,
+    settle_timeout: Duration,
     summary: &BalloonSettleSummary,
     outcome: SandboxParkOutcome,
 ) {
@@ -3394,7 +3426,27 @@ fn log_balloon_settle_timeout(
         reason = summary.reason(),
         admission_action = park_admission_action(outcome),
         "balloon inflate incomplete after {}s, pausing anyway",
-        BALLOON_SETTLE_TIMEOUT.as_secs()
+        settle_timeout.as_secs()
+    );
+}
+
+fn log_balloon_settle_progress_grace(
+    log_id: &str,
+    target_mib: u32,
+    summary: &BalloonSettleSummary,
+) {
+    info!(
+        id = %log_id,
+        actual = ?summary.last_actual_mib,
+        target = target_mib,
+        deficit_mib = ?summary.last_deficit_mib,
+        elapsed_ms = summary.elapsed_ms(),
+        sample_count = summary.sample_count,
+        previous_actual_mib = ?summary.previous_actual_mib,
+        reported_free_mib = ?summary.reported_free_mib(),
+        reported_available_mib = ?summary.reported_available_mib(),
+        grace_ms = duration_ms(BALLOON_SETTLE_PROGRESS_GRACE),
+        "balloon inflation still progressing, extending settle deadline"
     );
 }
 
@@ -3465,20 +3517,37 @@ fn complete_balloon_settle(
 /// **before** pausing. Returns when `actual_mib >= target_mib`, when
 /// the remaining deficit is within [`balloon_settle_tolerance_mib`],
 /// when guest pressure indicates further reclaim is unsafe, or after
-/// [`BALLOON_SETTLE_TIMEOUT`] (partial inflation is better than none). The
-/// returned outcome rejects only the existing severe-deficit classification.
-/// Errors from stats fetching are non-fatal — we log and
-/// proceed to pause.
+/// [`BALLOON_SETTLE_TIMEOUT`]. A severe deficit that is still progressing with
+/// enough unused guest memory gets one bounded
+/// [`BALLOON_SETTLE_PROGRESS_GRACE`]. The returned outcome rejects only the
+/// existing severe-deficit classification. Errors from stats fetching are
+/// non-fatal — we log and proceed to pause.
 async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> SandboxParkOutcome {
-    let deadline = tokio::time::Instant::now() + BALLOON_SETTLE_TIMEOUT;
     let tolerance_mib = balloon_settle_tolerance_mib(target_mib);
     let mut summary = BalloonSettleSummary::new(target_mib);
+    let mut settle_timeout = BALLOON_SETTLE_TIMEOUT;
+    let mut deadline = summary.started_at + settle_timeout;
+    let mut progress_grace_used = false;
     let mut fast_poll_intervals = BALLOON_SETTLE_FAST_POLL_INTERVALS.into_iter();
     loop {
         if tokio::time::Instant::now() >= deadline {
-            let outcome = summary.park_outcome();
-            log_balloon_settle_timeout(log_id, target_mib, tolerance_mib, &summary, outcome);
-            return complete_balloon_settle(&summary, BalloonSettleOutcome::Deadline, outcome);
+            if !progress_grace_used && summary.can_extend_for_progress() {
+                progress_grace_used = true;
+                settle_timeout += BALLOON_SETTLE_PROGRESS_GRACE;
+                deadline = summary.started_at + settle_timeout;
+                log_balloon_settle_progress_grace(log_id, target_mib, &summary);
+            } else {
+                let outcome = summary.park_outcome();
+                log_balloon_settle_timeout(
+                    log_id,
+                    target_mib,
+                    tolerance_mib,
+                    settle_timeout,
+                    &summary,
+                    outcome,
+                );
+                return complete_balloon_settle(&summary, BalloonSettleOutcome::Deadline, outcome);
+            }
         }
 
         match tokio::time::timeout_at(deadline, client.get_balloon_statistics()).await {
@@ -3613,7 +3682,14 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
             }
             Err(_) => {
                 let outcome = summary.park_outcome();
-                log_balloon_settle_timeout(log_id, target_mib, tolerance_mib, &summary, outcome);
+                log_balloon_settle_timeout(
+                    log_id,
+                    target_mib,
+                    tolerance_mib,
+                    settle_timeout,
+                    &summary,
+                    outcome,
+                );
                 return complete_balloon_settle(&summary, BalloonSettleOutcome::Deadline, outcome);
             }
         }

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -3797,6 +3797,55 @@ where
     (output, captured.entries())
 }
 
+async fn advance_balloon_wait_to_progress_grace<F>(
+    mut future: std::pin::Pin<&mut F>,
+    captured: &CapturedEvents,
+) where
+    F: Future<Output = SandboxParkOutcome>,
+{
+    for expected_sample_count in 1..=2 {
+        if expected_sample_count == 2 {
+            tokio::time::advance(BALLOON_SETTLE_FAST_POLL_INTERVALS[0]).await;
+            tokio::time::resume();
+        }
+        loop {
+            let sample_count = captured_message_count(&captured.entries(), "waiting for balloon");
+            if sample_count == expected_sample_count {
+                break;
+            }
+            tokio::select! {
+                outcome = future.as_mut() => {
+                    panic!(
+                        "balloon wait completed after {sample_count} samples, expected {expected_sample_count}; outcome={outcome:?}"
+                    );
+                }
+                () = tokio::task::yield_now() => {}
+            }
+        }
+        if expected_sample_count == 2 {
+            tokio::time::pause();
+        }
+    }
+
+    tokio::time::advance(BALLOON_SETTLE_TIMEOUT).await;
+    tokio::time::resume();
+    loop {
+        if has_captured_event(
+            &captured.entries(),
+            "balloon inflation still progressing, extending settle deadline",
+        ) {
+            tokio::time::pause();
+            return;
+        }
+        tokio::select! {
+            outcome = future.as_mut() => {
+                panic!("balloon wait completed without progress grace; outcome={outcome:?}");
+            }
+            () = tokio::task::yield_now() => {}
+        }
+    }
+}
+
 fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a CapturedEvent {
     events
         .iter()
@@ -4234,6 +4283,122 @@ async fn wait_for_balloon_follows_exact_bounded_poll_schedule() {
         16
     );
     assert_balloon_settle_summary(&captured.entries(), "deadline", 16, "reject_and_destroy");
+}
+
+#[tokio::test]
+async fn wait_for_balloon_extends_deadline_for_recent_safe_progress() {
+    let target_mib = 4096 - balloon::MIN_GUEST_MIB;
+    let initial_stats =
+        MockBalloonStats::new(target_mib, 256).with_memory(mib(3840), mib(3940), mib(3940));
+    let progressing_stats =
+        MockBalloonStats::new(target_mib, 2314).with_memory(mib(2136), mib(2265), mib(3940));
+    let api = MockLifecycleApi::with_stats(
+        std::collections::VecDeque::new(),
+        std::collections::VecDeque::from([
+            MockBalloonStatsReply::Ok(initial_stats),
+            MockBalloonStatsReply::Ok(progressing_stats),
+            MockBalloonStatsReply::Ok(MockBalloonStats::new(target_mib, target_mib)),
+        ]),
+    );
+    let client = ApiClient::new(api.socket_path()).unwrap();
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    tokio::time::pause();
+    let wait = wait_for_balloon(&client, target_mib, "progress-grace");
+    tokio::pin!(wait);
+
+    advance_balloon_wait_to_progress_grace(wait.as_mut(), &captured).await;
+    tokio::time::resume();
+    let outcome = wait.await;
+    drop(guard);
+    let events = captured.entries();
+
+    assert_eq!(outcome, SandboxParkOutcome::Reusable);
+    let event = captured_event(
+        &events,
+        "balloon inflation still progressing, extending settle deadline",
+    );
+    assert_eq!(event.level, Level::INFO);
+    assert_event_field(event, "actual", "Some(2314)");
+    assert_event_field(event, "target", "3584");
+    assert_event_field(event, "deficit_mib", "Some(1270)");
+    assert_event_field(event, "previous_actual_mib", "Some(256)");
+    assert_event_field(event, "reported_free_mib", "Some(2136)");
+    assert_event_field(event, "reported_available_mib", "Some(2265)");
+    assert_event_field(event, "grace_ms", "5000");
+    assert!(!has_captured_event(
+        &events,
+        "balloon inflate incomplete after 5s, pausing anyway"
+    ));
+    assert_balloon_settle_summary(&events, "target_reached", 3, "reuse");
+}
+
+#[tokio::test]
+async fn wait_for_balloon_progress_grace_remains_bounded() {
+    let target_mib = 4096 - balloon::MIN_GUEST_MIB;
+    let initial_stats =
+        MockBalloonStats::new(target_mib, 256).with_memory(mib(3840), mib(3940), mib(3940));
+    let progressing_stats =
+        MockBalloonStats::new(target_mib, 2314).with_memory(mib(2136), mib(2265), mib(3940));
+    let api = MockLifecycleApi::with_stats(
+        std::collections::VecDeque::new(),
+        std::collections::VecDeque::from([
+            MockBalloonStatsReply::Ok(initial_stats),
+            MockBalloonStatsReply::Ok(progressing_stats.clone()),
+            MockBalloonStatsReply::Ok(progressing_stats),
+        ]),
+    );
+    let client = ApiClient::new(api.socket_path()).unwrap();
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    tokio::time::pause();
+    let wait = wait_for_balloon(&client, target_mib, "bounded-progress-grace");
+    tokio::pin!(wait);
+
+    advance_balloon_wait_to_progress_grace(wait.as_mut(), &captured).await;
+    loop {
+        let sample_count = captured_message_count(&captured.entries(), "waiting for balloon");
+        if sample_count == 3 {
+            break;
+        }
+        tokio::select! {
+            outcome = &mut wait => {
+                panic!("balloon wait completed before the grace sample; outcome={outcome:?}");
+            }
+            () = tokio::task::yield_now() => {}
+        }
+    }
+    tokio::time::advance(BALLOON_SETTLE_PROGRESS_GRACE).await;
+    tokio::time::resume();
+    let outcome = wait.await;
+    drop(guard);
+    let events = captured.entries();
+
+    assert_eq!(
+        outcome,
+        SandboxParkOutcome::NonReusable(SandboxParkNonReusableReason::SevereMemoryRetention)
+    );
+    assert_eq!(
+        captured_message_count(
+            &events,
+            "balloon inflation still progressing, extending settle deadline"
+        ),
+        1
+    );
+    let event = captured_event(
+        &events,
+        "balloon inflate incomplete after 10s, pausing anyway",
+    );
+    assert_eq!(event.level, Level::WARN);
+    assert_event_field(event, "actual", "Some(2314)");
+    assert_event_field(event, "deficit_mib", "Some(1270)");
+    assert_event_field(event, "reason", "severe_deficit");
+    assert_event_field(event, "admission_action", "reject_and_destroy");
+    assert_balloon_settle_summary(&events, "deadline", 3, "reject_and_destroy");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- keep the existing five-second balloon settle fast path
- grant one bounded five-second grace period only when the latest sample is still progressing and guest free/available memory can cover the remaining reclaim
- preserve severe-retention rejection when reclaim stalls or the grace expires
- cover the observed CI failure shape and the hard ten-second bound with Firecracker API integration tests

## Root cause

The keep-alive behavior test intermittently lost its VM because balloon inflation was still progressing at the five-second deadline, but the remaining deficit was classified as severe and the parked VM was destroyed. The failing sample had advanced from 256 MiB to 2314 MiB and still reported enough reclaimable guest memory to reach the 3584 MiB target.

## Validation

- cargo fmt --all -- --check
- cargo clippy -p sandbox-fc --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc -p sandbox-fc --all-features --no-deps
- cargo test -p sandbox-fc --all-targets --all-features
- cargo test -p sandbox-fc wait_for_balloon_ after rebasing onto latest main

Observed failure: https://github.com/vm0-ai/vm0/actions/runs/30974896721/job/92207547493