### PR TITLE
fix(runner): require benchmark guest timezone

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -52,11 +52,11 @@ fn parse_env_args(env: &[String]) -> RunnerResult<Vec<(String, String)>> {
 }
 
 fn validate_timezone_arg(timezone: &str) -> RunnerResult<()> {
-    if !timezone.is_empty() && executor::is_valid_guest_timezone_name(timezone) {
+    if executor::is_shell_safe_guest_timezone_name(timezone) {
         return Ok(());
     }
     Err(RunnerError::Config(format!(
-        "invalid --timezone {timezone:?}: expected a non-empty IANA timezone name"
+        "invalid --timezone {timezone:?}: expected a non-empty guest zoneinfo name containing only ASCII letters, digits, '/', '_', '-', or '+'"
     )))
 }
 
@@ -73,7 +73,7 @@ pub struct BenchmarkArgs {
     /// Environment variables to pass (KEY=VALUE), can be repeated
     #[arg(long, short)]
     env: Vec<String>,
-    /// System timezone to configure in the VM before running the command
+    /// Guest zoneinfo name to configure; benchmark fails if unavailable in the VM
     #[arg(long, default_value = DEFAULT_BENCHMARK_TIMEZONE)]
     timezone: String,
     /// Run the command as root (sudo)
@@ -488,7 +488,23 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use async_trait::async_trait;
+    use clap::CommandFactory;
     use sandbox::{Sandbox, SandboxError, SandboxInitializationPhase};
+
+    #[test]
+    fn benchmark_help_describes_required_guest_zoneinfo() {
+        let mut command = crate::Cli::command();
+        let help = command
+            .find_subcommand_mut("benchmark")
+            .expect("runner CLI should expose benchmark")
+            .render_help()
+            .to_string();
+        let normalized_help = help.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        assert!(normalized_help.contains(
+            "Guest zoneinfo name to configure; benchmark fails if unavailable in the VM"
+        ));
+    }
 
     #[test]
     fn parse_env_args_accepts_key_value_pairs() {
@@ -566,12 +582,13 @@ mod tests {
     }
 
     #[test]
-    fn validate_timezone_arg_accepts_default_and_common_names() {
+    fn validate_timezone_arg_accepts_shell_safe_zoneinfo_name_shapes() {
         for timezone in [
             DEFAULT_BENCHMARK_TIMEZONE,
             "Asia/Shanghai",
             "Etc/GMT+1",
             "America/Argentina/Buenos_Aires",
+            "Mars/Olympus",
         ] {
             validate_timezone_arg(timezone).unwrap();
         }
@@ -581,10 +598,14 @@ mod tests {
     fn validate_timezone_arg_rejects_empty_and_shell_metacharacters() {
         for timezone in ["", "UTC;id", "America/New York", "UTC'", "$(date)"] {
             let err = validate_timezone_arg(timezone).unwrap_err();
+            let message = err.to_string();
             assert!(
-                err.to_string().contains("invalid --timezone"),
+                message.contains("invalid --timezone")
+                    && message.contains("non-empty guest zoneinfo name")
+                    && message.contains("ASCII letters"),
                 "timezone {timezone:?} produced unexpected error: {err}"
             );
+            assert!(!message.contains("IANA"), "got: {message}");
         }
     }
 

--- a/crates/runner/src/executor/guest_state.rs
+++ b/crates/runner/src/executor/guest_state.rs
@@ -12,11 +12,12 @@ use crate::types::ExecutionContext;
 
 const ENTROPY_SIZE: usize = 256;
 const TIMEZONE_SYNC_FAILED_MARKER: &str = "guest timezone sync failed";
+const TIMEZONE_UNAVAILABLE_MARKER: &str = "guest timezone unavailable";
 
 #[derive(Clone, Copy)]
-struct GuestTimezone<'a> {
-    name: &'a str,
-    run_id: Option<RunId>,
+enum GuestTimezone<'a> {
+    BestEffort { name: &'a str, run_id: RunId },
+    Required { name: &'a str },
 }
 
 fn helper_exec_exit_code(result: &sandbox::ExecResult) -> Option<i32> {
@@ -49,9 +50,11 @@ fn read_host_entropy() -> RunnerResult<Vec<u8>> {
     Ok(entropy)
 }
 
-pub(crate) fn is_valid_guest_timezone_name(tz: &str) -> bool {
-    tz.bytes()
-        .all(|b| b.is_ascii_alphanumeric() || b == b'/' || b == b'_' || b == b'-' || b == b'+')
+pub(crate) fn is_shell_safe_guest_timezone_name(tz: &str) -> bool {
+    !tz.is_empty()
+        && tz
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'/' || b == b'_' || b == b'-' || b == b'+')
 }
 
 fn user_timezone(context: &ExecutionContext) -> Option<&str> {
@@ -59,11 +62,10 @@ fn user_timezone(context: &ExecutionContext) -> Option<&str> {
         Some(tz) if !tz.is_empty() => tz,
         _ => return None,
     };
-    // Strict validation: timezone names are like "Asia/Shanghai" or "UTC".
-    // Only allow alphanumeric, '/', '_', '-', '+'.  This prevents shell
-    // injection since the value is interpolated into a sudo shell command.
-    if !is_valid_guest_timezone_name(tz) {
-        tracing::warn!(tz = %tz, "rejected invalid timezone name");
+    // The value is interpolated into a sudo shell command. This check protects
+    // that boundary; guest zone availability is handled by the command itself.
+    if !is_shell_safe_guest_timezone_name(tz) {
+        tracing::warn!(tz = %tz, "rejected unsafe timezone name");
         return None;
     }
     Some(tz)
@@ -90,12 +92,23 @@ fn timezone_sync_best_effort_command(tz: &str) -> String {
     )
 }
 
-fn log_embedded_timezone_failure(run_id: Option<RunId>, tz: &str, result: &sandbox::ExecResult) {
-    if !result
+fn timezone_sync_required_command(tz: &str) -> String {
+    let body = timezone_sync_body(tz);
+    format!(
+        "test -f /usr/share/zoneinfo/{tz} || {{ echo \"{TIMEZONE_UNAVAILABLE_MARKER}\" >&2; exit 1; }}\n\
+         {{ {body}; }} || {{ status=$?; echo \"{TIMEZONE_SYNC_FAILED_MARKER}\" >&2; exit \"$status\"; }}"
+    )
+}
+
+fn stderr_contains_marker(result: &sandbox::ExecResult, marker: &str) -> bool {
+    result
         .stderr
-        .windows(TIMEZONE_SYNC_FAILED_MARKER.len())
-        .any(|window| window == TIMEZONE_SYNC_FAILED_MARKER.as_bytes())
-    {
+        .windows(marker.len())
+        .any(|window| window == marker.as_bytes())
+}
+
+fn log_embedded_timezone_failure(run_id: RunId, tz: &str, result: &sandbox::ExecResult) {
+    if !stderr_contains_marker(result, TIMEZONE_SYNC_FAILED_MARKER) {
         return;
     }
 
@@ -103,24 +116,14 @@ fn log_embedded_timezone_failure(run_id: Option<RunId>, tz: &str, result: &sandb
         format_command_output_excerpt("stderr", &result.stderr, result.stderr_truncated);
     let stdout_excerpt =
         format_command_output_excerpt("stdout", &result.stdout, result.stdout_truncated);
-    if let Some(run_id) = run_id {
-        tracing::warn!(
-            run_id = %run_id,
-            tz = %tz,
-            termination = helper_exec_termination_label(result),
-            stderr_excerpt = %stderr_excerpt.as_deref().unwrap_or(""),
-            stdout_excerpt = %stdout_excerpt.as_deref().unwrap_or(""),
-            "failed to set guest timezone"
-        );
-    } else {
-        tracing::warn!(
-            tz = %tz,
-            termination = helper_exec_termination_label(result),
-            stderr_excerpt = %stderr_excerpt.as_deref().unwrap_or(""),
-            stdout_excerpt = %stdout_excerpt.as_deref().unwrap_or(""),
-            "failed to set guest timezone"
-        );
-    }
+    tracing::warn!(
+        run_id = %run_id,
+        tz = %tz,
+        termination = helper_exec_termination_label(result),
+        stderr_excerpt = %stderr_excerpt.as_deref().unwrap_or(""),
+        stdout_excerpt = %stdout_excerpt.as_deref().unwrap_or(""),
+        "failed to set guest timezone"
+    );
 }
 
 /// Restores snapshot-sensitive guest state in one exec before the agent starts.
@@ -137,9 +140,9 @@ pub(crate) async fn restore_guest_state(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
 ) -> RunnerResult<()> {
-    let timezone = user_timezone(context).map(|name| GuestTimezone {
+    let timezone = user_timezone(context).map(|name| GuestTimezone::BestEffort {
         name,
-        run_id: Some(context.run_id),
+        run_id: context.run_id,
     });
     restore_guest_state_inner(sandbox, timezone).await
 }
@@ -148,19 +151,12 @@ pub(crate) async fn restore_guest_state_with_timezone(
     sandbox: &dyn Sandbox,
     timezone: &str,
 ) -> RunnerResult<()> {
-    if timezone.is_empty() || !is_valid_guest_timezone_name(timezone) {
+    if !is_shell_safe_guest_timezone_name(timezone) {
         return Err(RunnerError::Config(format!(
-            "invalid timezone {timezone:?}: expected a non-empty IANA timezone name"
+            "invalid timezone {timezone:?}: expected a non-empty guest zoneinfo name containing only ASCII letters, digits, '/', '_', '-', or '+'"
         )));
     }
-    restore_guest_state_inner(
-        sandbox,
-        Some(GuestTimezone {
-            name: timezone,
-            run_id: None,
-        }),
-    )
-    .await
+    restore_guest_state_inner(sandbox, Some(GuestTimezone::Required { name: timezone })).await
 }
 
 async fn restore_guest_state_inner(
@@ -175,7 +171,14 @@ guest-reseed || {{ status=$?; echo "guest-reseed failed" >&2; exit "$status"; }}
     );
     if let Some(timezone) = timezone {
         cmd.push('\n');
-        cmd.push_str(&timezone_sync_best_effort_command(timezone.name));
+        match timezone {
+            GuestTimezone::BestEffort { name, .. } => {
+                cmd.push_str(&timezone_sync_best_effort_command(name));
+            }
+            GuestTimezone::Required { name } => {
+                cmd.push_str(&timezone_sync_required_command(name));
+            }
+        }
     }
     let result = sandbox
         .exec_with_diagnostic_label(
@@ -192,14 +195,21 @@ guest-reseed || {{ status=$?; echo "guest-reseed failed" >&2; exit "$status"; }}
         )
         .await?;
 
+    if let Some(GuestTimezone::Required { name }) = timezone
+        && stderr_contains_marker(&result, TIMEZONE_UNAVAILABLE_MARKER)
+    {
+        return Err(RunnerError::Config(format!(
+            "guest timezone {name:?} is unavailable: /usr/share/zoneinfo/{name} is not a file"
+        )));
+    }
     if !helper_exec_succeeded(&result) {
         return Err(RunnerError::Internal(format_helper_exec_failure(
             "guest state restore",
             &result,
         )));
     }
-    if let Some(timezone) = timezone {
-        log_embedded_timezone_failure(timezone.run_id, timezone.name, &result);
+    if let Some(GuestTimezone::BestEffort { name, run_id }) = timezone {
+        log_embedded_timezone_failure(run_id, name, &result);
     }
 
     Ok(())

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -45,7 +45,9 @@ mod workspace_session_history_materializer;
 
 pub(crate) use crate::restored_session_identity::RestoredSessionIdentity;
 pub(crate) use cli_framework::effective_cli_framework;
-pub(crate) use guest_state::{is_valid_guest_timezone_name, restore_guest_state_with_timezone};
+pub(crate) use guest_state::{
+    is_shell_safe_guest_timezone_name, restore_guest_state_with_timezone,
+};
 pub(crate) use session_history_cpu::SessionHistoryCpuPool;
 pub(crate) use session_history_download::{SessionHistoryMaterializer, SessionHistoryProbe};
 pub(crate) use session_history_restore_plan::{

--- a/crates/runner/src/executor/tests/guest_state_tests.rs
+++ b/crates/runner/src/executor/tests/guest_state_tests.rs
@@ -7,6 +7,7 @@ use super::super::guest_state::{
     restore_guest_state, restore_guest_state_with_timezone, sync_guest_timezone,
 };
 use super::support::{CapturedEvent, CapturedEvents, minimal_context, sandbox_exec_error};
+use crate::error::RunnerError;
 use crate::ids::RunId;
 use crate::types::ExecutionContext;
 
@@ -72,7 +73,7 @@ async fn restore_guest_state_folds_timezone_sync_into_restore_exec() {
 }
 
 #[tokio::test]
-async fn restore_guest_state_with_explicit_timezone_folds_sync_into_restore_exec() {
+async fn restore_guest_state_with_explicit_timezone_requires_zone_in_restore_exec() {
     let sandbox = MockSandbox::new("test");
 
     restore_guest_state_with_timezone(&sandbox, "UTC")
@@ -85,11 +86,54 @@ async fn restore_guest_state_with_explicit_timezone_folds_sync_into_restore_exec
     assert!(command.contains("date -s \"@"));
     assert!(command.contains("guest-reseed"));
     assert!(
-        command.contains("if test -f /usr/share/zoneinfo/UTC; then { echo 'UTC' > /etc/timezone"),
+        command.contains(
+            "test -f /usr/share/zoneinfo/UTC || { echo \"guest timezone unavailable\" >&2; exit 1; }"
+        ),
         "unexpected command: {command}"
     );
     assert!(command.contains("echo 'TZ=UTC' >> /etc/environment"));
     assert!(command.contains("guest timezone sync failed"));
+    assert!(command.contains("exit \"$status\""));
+}
+
+#[tokio::test]
+async fn restore_guest_state_with_explicit_timezone_reports_unavailable_zone() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        1,
+        Vec::new(),
+        b"guest timezone unavailable".to_vec(),
+    )));
+
+    let result = restore_guest_state_with_timezone(&sandbox, "Mars/Olympus").await;
+
+    match result {
+        Err(RunnerError::Config(message)) => {
+            assert!(message.contains("guest timezone \"Mars/Olympus\" is unavailable"));
+            assert!(message.contains("/usr/share/zoneinfo/Mars/Olympus"));
+        }
+        other => panic!("expected unavailable-zone config error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn restore_guest_state_with_explicit_timezone_fails_when_application_fails() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        2,
+        Vec::new(),
+        b"ln failed\nguest timezone sync failed".to_vec(),
+    )));
+
+    let result = restore_guest_state_with_timezone(&sandbox, "UTC").await;
+
+    match result {
+        Err(RunnerError::Internal(message)) => {
+            assert!(message.contains("guest state restore failed (exit code 2)"));
+            assert!(message.contains("guest timezone sync failed"));
+        }
+        other => panic!("expected guest restore failure, got: {other:?}"),
+    }
 }
 
 #[tokio::test]
@@ -100,7 +144,9 @@ async fn restore_guest_state_with_explicit_timezone_rejects_invalid_timezone_bef
 
     let message = result.unwrap_err().to_string();
     assert!(
-        message.contains("invalid timezone"),
+        message.contains("invalid timezone")
+            && message.contains("non-empty guest zoneinfo name")
+            && !message.contains("IANA"),
         "unexpected error: {message}"
     );
     assert!(sandbox.exec_calls().is_empty());


### PR DESCRIPTION
## Summary

- require the explicit benchmark timezone to exist and apply successfully inside the guest
- keep normal agent timezone restoration best-effort while sharing the existing restore exec
- describe host validation as shell-safe zoneinfo syntax instead of IANA validation
- document unavailable-zone failure in `runner benchmark --help`

## Behavior

`runner benchmark --timezone <name>` now fails before the benchmark command runs when the selected VM does not contain `/usr/share/zoneinfo/<name>`. A missing zone is reported as a configuration error; a zone that exists but cannot be applied uses the existing guest-restore diagnostic path.

This does not change normal agent timezone behavior, add a guest exec, or modify API, persisted-state, database, or cross-version contracts.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner cmd::benchmark::tests`
- `cargo test -p runner executor::tests::guest_state_tests`
- `cargo test -p runner` (2967 passed, 15 ignored)
- pre-commit Rust formatting, Clippy, rustdoc, file-size, and commit-message checks

Closes #25178
