### PR TITLE
test(runner): cover timezone file fallback

### DIFF
--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -70,14 +70,14 @@ pub struct SubmitArgs {
     active_inputs: Vec<String>,
 }
 
-/// Detect the system timezone from the `TZ` env var or `/etc/timezone`.
-fn detect_system_timezone() -> Option<String> {
+/// Detect the system timezone from the `TZ` env var or a timezone file.
+fn detect_system_timezone(timezone_file: &Path) -> Option<String> {
     if let Ok(tz) = std::env::var("TZ")
         && !tz.is_empty()
     {
         return Some(tz);
     }
-    std::fs::read_to_string("/etc/timezone")
+    std::fs::read_to_string(timezone_file)
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
@@ -398,7 +398,7 @@ impl SubmitPlan {
             vars: None,
             environment,
             secret_environment,
-            user_timezone: detect_system_timezone(),
+            user_timezone: detect_system_timezone(Path::new("/etc/timezone")),
             profile: Some(profile.clone()),
             reuse_key: chat_thread_id.map(|thread_id| format!("thread:{thread_id}")),
             session_id,

--- a/crates/runner/src/cmd/local/submit/tests/timezone.rs
+++ b/crates/runner/src/cmd/local/submit/tests/timezone.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::time::Duration;
 
 use super::super::detect_system_timezone;
@@ -6,26 +7,67 @@ use crate::test_fixtures::ignored_child::{
 };
 
 const TIMEZONE_CHILD_SCENARIO: &str = "VM0_RUNNER_TIMEZONE_TEST_SCENARIO";
+const TIMEZONE_CHILD_FILE: &str = "VM0_RUNNER_TIMEZONE_TEST_FILE";
 const TIMEZONE_CHILD_TEST: &str =
     "cmd::local::submit::tests::timezone::detect_system_timezone_child";
 const TIMEZONE_FROM_ENV_SCENARIO: &str = "from-env";
 const TIMEZONE_EMPTY_ENV_SCENARIO: &str = "empty-env";
+const TIMEZONE_ABSENT_ENV_SCENARIO: &str = "absent-env";
+const TIMEZONE_WHITESPACE_FILE_SCENARIO: &str = "whitespace-file";
+const TIMEZONE_MISSING_FILE_SCENARIO: &str = "missing-file";
 
 #[tokio::test]
 async fn detect_system_timezone_from_env() {
-    run_timezone_child(TIMEZONE_FROM_ENV_SCENARIO, "America/New_York").await;
+    run_timezone_child(
+        TIMEZONE_FROM_ENV_SCENARIO,
+        Some("America/New_York"),
+        Some("Asia/Shanghai\n"),
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn detect_system_timezone_empty_env() {
-    run_timezone_child(TIMEZONE_EMPTY_ENV_SCENARIO, "").await;
+    run_timezone_child(
+        TIMEZONE_EMPTY_ENV_SCENARIO,
+        Some(""),
+        Some("  Asia/Shanghai \n"),
+    )
+    .await;
 }
 
-async fn run_timezone_child(scenario: &'static str, timezone: &'static str) {
+#[tokio::test]
+async fn detect_system_timezone_absent_env() {
+    run_timezone_child(TIMEZONE_ABSENT_ENV_SCENARIO, None, Some("\nEtc/UTC\n")).await;
+}
+
+#[tokio::test]
+async fn detect_system_timezone_whitespace_file() {
+    run_timezone_child(TIMEZONE_WHITESPACE_FILE_SCENARIO, None, Some(" \n\t")).await;
+}
+
+#[tokio::test]
+async fn detect_system_timezone_missing_file() {
+    run_timezone_child(TIMEZONE_MISSING_FILE_SCENARIO, None, None).await;
+}
+
+async fn run_timezone_child(
+    scenario: &'static str,
+    timezone: Option<&str>,
+    timezone_file_content: Option<&str>,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let timezone_file = dir.path().join("timezone");
+    if let Some(content) = timezone_file_content {
+        std::fs::write(&timezone_file, content).unwrap();
+    }
+    let timezone_file = timezone_file
+        .to_str()
+        .expect("temporary timezone path must be UTF-8");
     run_ignored_child_test(
         TIMEZONE_CHILD_TEST,
         (TIMEZONE_CHILD_SCENARIO, scenario),
-        &[("TZ", Some(timezone))],
+        &[("TZ", timezone), (TIMEZONE_CHILD_FILE, Some(timezone_file))],
         Duration::from_secs(5),
     )
     .await;
@@ -40,17 +82,31 @@ fn detect_system_timezone_child() {
     if !ignored_child_test_env_guard_enabled((TIMEZONE_CHILD_SCENARIO, &scenario)) {
         return;
     }
+    let timezone_file = std::env::var(TIMEZONE_CHILD_FILE)
+        .expect("timezone child file must be supplied by the parent test");
+    let timezone_file = Path::new(&timezone_file);
 
     match scenario.as_str() {
         TIMEZONE_FROM_ENV_SCENARIO => {
             assert_eq!(
-                detect_system_timezone(),
+                detect_system_timezone(timezone_file),
                 Some("America/New_York".to_string())
             );
         }
         TIMEZONE_EMPTY_ENV_SCENARIO => {
-            // Empty TZ falls through to /etc/timezone.
-            assert_ne!(detect_system_timezone(), Some("".to_string()));
+            assert_eq!(
+                detect_system_timezone(timezone_file),
+                Some("Asia/Shanghai".to_string())
+            );
+        }
+        TIMEZONE_ABSENT_ENV_SCENARIO => {
+            assert_eq!(
+                detect_system_timezone(timezone_file),
+                Some("Etc/UTC".to_string())
+            );
+        }
+        TIMEZONE_WHITESPACE_FILE_SCENARIO | TIMEZONE_MISSING_FILE_SCENARIO => {
+            assert_eq!(detect_system_timezone(timezone_file), None);
         }
         other => panic!("unknown timezone test scenario: {other}"),
     }

--- a/crates/runner/src/cmd/local/submit/tests/timezone.rs
+++ b/crates/runner/src/cmd/local/submit/tests/timezone.rs
@@ -16,6 +16,8 @@ const TIMEZONE_ABSENT_ENV_SCENARIO: &str = "absent-env";
 const TIMEZONE_WHITESPACE_FILE_SCENARIO: &str = "whitespace-file";
 const TIMEZONE_MISSING_FILE_SCENARIO: &str = "missing-file";
 
+// `/etc/timezone` cannot be varied through the local-submit interface without changing host
+// state. The ignored child isolates `TZ` while this internal seam reads a real temporary file.
 #[tokio::test]
 async fn detect_system_timezone_from_env() {
     run_timezone_child(


### PR DESCRIPTION
## Summary

- parameterize the private local timezone detector with its fallback file path while keeping the production call fixed to `/etc/timezone`
- replace the host-dependent empty-`TZ` assertion with deterministic ignored-child scenarios backed by real temporary files
- cover non-empty `TZ` precedence, empty and absent `TZ` fallback, trimmed file values, whitespace-only files, and file read failure

## Scope

Production timezone semantics are unchanged. This PR adds no public API, serialized payload, persisted state, feature switch, hidden environment override, guest policy, or deployment change.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner detect_system_timezone -- --nocapture`
- `cargo test -p runner --all-targets --all-features` (2966 passed, 15 ignored)
- `lefthook run pre-commit` (workspace Rust format, Clippy, docs, and file-size checks)
- mutation check: temporarily bypassing the fallback read made the exact empty- and absent-`TZ` fallback scenarios fail; restoring it returned the focused suite to green

Closes #25180
