### PR TITLE
docs(rust): document exec-control response abandonment

### DIFF
--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -632,6 +632,9 @@ impl SupervisedExecHandle {
     }
 
     /// Send an exec-control request for this supervised operation.
+    ///
+    /// This has the same input, timeout, cancellation, and connection-lifecycle
+    /// contract as [`ExecControlHandle::control`].
     pub async fn control(
         &self,
         message_id: &str,
@@ -751,6 +754,25 @@ impl ExecControlHandle {
     /// Only [`ExecControlOutcome::Delivered`] is returned as an
     /// [`ExecControlAck`]. Guest statuses and guest error responses are
     /// converted into `io::Error` values.
+    ///
+    /// # Response abandonment
+    ///
+    /// If the host response wait expires after the request frame is written,
+    /// or this future is cancelled after the frame may have been written, the
+    /// guest may have received the request without the host retaining proof of
+    /// its response. The connection is then unsafe for later normal operations
+    /// or pooling and must be discarded. A late control result or the
+    /// supervised exec's eventual terminal result does not restore reusability.
+    /// Cancelling this future before the frame may have been written does not
+    /// have this consequence.
+    ///
+    /// A guest-reported [`vsock_proto::ExecControlStatus::SinkTimeout`] is
+    /// different: it is a matched response and does not by itself make the
+    /// connection unsafe. This method converts both that guest status and a
+    /// host response timeout to `io::ErrorKind::TimedOut`. Call
+    /// [`ExecControlHandle::control_with_write_observer`] when the distinction
+    /// matters; it returns matched guest statuses as
+    /// [`ExecControlOutcome::GuestStatus`].
     pub async fn control(
         &self,
         message_id: &str,
@@ -769,10 +791,10 @@ impl ExecControlHandle {
 
     /// Send an exec-control request and return the raw guest outcome.
     ///
-    /// This has the same parameter and timeout contract as
-    /// [`ExecControlHandle::control`], but returns [`ExecControlOutcome`] so
-    /// callers can distinguish delivered requests, non-delivered guest
-    /// statuses, and guest error responses.
+    /// This has the same input, timeout, cancellation, and connection-lifecycle
+    /// contract as [`ExecControlHandle::control`], but returns
+    /// [`ExecControlOutcome`] so callers can distinguish delivered requests,
+    /// non-delivered guest statuses, and guest error responses.
     pub async fn control_with_write_observer(
         &self,
         message_id: &str,

--- a/crates/vsock-host/src/tests/exec_operation/supervised/control.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/control.rs
@@ -327,7 +327,6 @@ async fn supervised_exec_control_cancelled_before_write_remains_reusable() {
     );
 
     drop(writer_guard);
-    tokio::task::yield_now().await;
     assert_no_guest_frame(
         &mut guest,
         "control cancelled before write must not send a frame",

--- a/crates/vsock-host/src/tests/exec_operation/supervised/control.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/control.rs
@@ -7,8 +7,8 @@ use vsock_proto::{
 };
 
 use super::super::super::support::{
-    normal_operation_readiness, operation_count, read_guest_message, send_exec_control_result,
-    send_exec_result,
+    assert_connection_accepts_exec_operation, normal_operation_readiness, operation_count,
+    read_guest_message, send_exec_control_result, send_exec_result,
 };
 use super::support::{
     StartedControlSupervisedExec, StartedSupervisedExec, assert_no_guest_frame,
@@ -295,6 +295,104 @@ async fn supervised_exec_control_guest_error_uses_control_error_fallback() {
     )
     .await;
     handle.wait(Duration::from_secs(5)).await.unwrap();
+}
+
+#[tokio::test]
+async fn supervised_exec_control_cancelled_before_write_remains_reusable() {
+    let StartedControlSupervisedExec {
+        host,
+        mut guest,
+        start,
+        handle,
+        control_handle,
+        ..
+    } = start_control_supervised_exec_fixture("control-cancelled-before-write").await;
+    let start_seq = start.seq();
+    let writer_guard = host.shared.writer.lock().await;
+
+    {
+        let control = control_handle.control("cancelled", b"payload", Duration::from_secs(5));
+        tokio::pin!(control);
+        tokio::select! {
+            result = &mut control => {
+                panic!("control must wait for the held writer lock: {result:?}");
+            }
+            () = tokio::task::yield_now() => {}
+        }
+    }
+
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    drop(writer_guard);
+    tokio::task::yield_now().await;
+    assert_no_guest_frame(
+        &mut guest,
+        "control cancelled before write must not send a frame",
+    );
+    finish_supervised_exec_success(&mut guest, start_seq, handle)
+        .await
+        .unwrap();
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn supervised_exec_control_cancelled_after_write_ignores_late_result() {
+    let StartedControlSupervisedExec {
+        host,
+        mut guest,
+        start,
+        handle,
+        control_handle,
+        control_nonce,
+        ..
+    } = start_control_supervised_exec_fixture("control-cancelled-after-write").await;
+    let start_seq = start.seq();
+
+    let control_task = tokio::spawn(async move {
+        control_handle
+            .control("cancelled", b"payload", Duration::from_secs(5))
+            .await
+    });
+    let control = read_guest_message(&mut guest).await;
+    control_task.abort();
+    assert!(control_task.await.unwrap_err().is_cancelled());
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+
+    send_exec_control_result(
+        &mut guest,
+        control.seq,
+        start_seq,
+        control_nonce,
+        "cancelled",
+        ExecControlStatus::Delivered,
+        "",
+    )
+    .await;
+    send_exec_result(
+        &mut guest,
+        start_seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+        b"",
+    )
+    .await;
+    let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- document the exec-control response-abandonment contract at the canonical public method and link delegating methods to it
- distinguish post-write host timeout or cancellation from matched guest `SinkTimeout`, including the raw-outcome recovery path
- cover pre-write and post-write control cancellation with deterministic real-socket integration tests, including late-result and terminal-result behavior

## Scope

This does not change runtime behavior, public signatures, error values, connection state transitions, or the wire protocol. It documents and locks the existing fail-closed behavior.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-host --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host --all-features` (341 passed)
- pre-commit Rust formatting, workspace Rustdoc, workspace Clippy, file-size, and commit-message hooks

Closes #25177
