### PR TITLE
perf(mitm-addon): bound x billing gzip member input

### DIFF
--- a/crates/runner/mitm-addon/src/billing_body.py
+++ b/crates/runner/mitm-addon/src/billing_body.py
@@ -1,7 +1,6 @@
 """Request body decoding policy for connector billing inspection."""
 
 import zlib
-from typing import Literal
 
 from mitmproxy import http
 
@@ -9,39 +8,47 @@ from body_limits import REQUEST_BODY_BILLING_INSPECTION_LIMIT
 from zlib_input import ZlibInputCursor
 
 
-def _decode_zlib_request_body_for_billing(
-    data: bytes, encoding: Literal["gzip", "deflate"], max_output: int
-) -> bytes | None:
-    """Decode every gzip member or one deflate stream under one output cap."""
-    wbits_options = (
-        (16 + zlib.MAX_WBITS,) if encoding == "gzip" else (zlib.MAX_WBITS, -zlib.MAX_WBITS)
-    )
-    for wbits in wbits_options:
-        input_cursor = ZlibInputCursor(data)
-        decoded = bytearray()
-        obj = zlib.decompressobj(wbits)
-        while input_cursor:
-            input_chunk = input_cursor.take()
-            try:
-                decoded.extend(
-                    obj.decompress(
-                        input_chunk,
-                        max_length=max_output - len(decoded) + 1,
-                    )
+def _decode_gzip_request_body_for_billing(data: bytes, max_output: int) -> bytes | None:
+    """Decode every gzip member under one output cap."""
+    input_cursor = ZlibInputCursor(data)
+    decoded = bytearray()
+    wbits = 16 + zlib.MAX_WBITS
+    obj = zlib.decompressobj(wbits)
+    while input_cursor:
+        input_chunk = input_cursor.take()
+        try:
+            decoded.extend(
+                obj.decompress(
+                    input_chunk,
+                    max_length=max_output - len(decoded) + 1,
                 )
-            except zlib.error:
-                break
-            if len(decoded) > max_output:
-                return None
-            if obj.eof:
-                input_cursor.carry(obj.unused_data)
-                if not input_cursor:
-                    return bytes(decoded)
-                if encoding != "gzip":
-                    break
-                obj = zlib.decompressobj(wbits)
-            elif obj.unconsumed_tail:
-                input_cursor.carry(obj.unconsumed_tail)
+            )
+        except zlib.error:
+            return None
+        if len(decoded) > max_output:
+            return None
+        if obj.eof:
+            input_cursor.carry(obj.unused_data)
+            if not input_cursor:
+                return bytes(decoded)
+            obj = zlib.decompressobj(wbits)
+        elif obj.unconsumed_tail:
+            input_cursor.carry(obj.unconsumed_tail)
+    return None
+
+
+def _decode_deflate_request_body_for_billing(data: bytes, max_output: int) -> bytes | None:
+    """Decode one zlib-wrapped or raw deflate stream under one output cap."""
+    for wbits in (zlib.MAX_WBITS, -zlib.MAX_WBITS):
+        obj = zlib.decompressobj(wbits)
+        try:
+            decoded = obj.decompress(data, max_length=max_output + 1)
+        except zlib.error:
+            continue
+        if len(decoded) > max_output:
+            return None
+        if obj.eof and not obj.unused_data:
+            return decoded
     return None
 
 
@@ -69,7 +76,7 @@ def decode_request_body_for_billing(
     if not encoding or encoding == "identity":
         return raw_content if len(raw_content) <= max_decoded else None
     if encoding == "gzip":
-        return _decode_zlib_request_body_for_billing(raw_content, "gzip", max_decoded)
+        return _decode_gzip_request_body_for_billing(raw_content, max_decoded)
     if encoding == "deflate":
-        return _decode_zlib_request_body_for_billing(raw_content, "deflate", max_decoded)
+        return _decode_deflate_request_body_for_billing(raw_content, max_decoded)
     return None

--- a/crates/runner/mitm-addon/src/billing_body.py
+++ b/crates/runner/mitm-addon/src/billing_body.py
@@ -6,6 +6,7 @@ from typing import Literal
 from mitmproxy import http
 
 from body_limits import REQUEST_BODY_BILLING_INSPECTION_LIMIT
+from zlib_input import ZlibInputCursor
 
 
 def _decode_zlib_request_body_for_billing(
@@ -16,14 +17,15 @@ def _decode_zlib_request_body_for_billing(
         (16 + zlib.MAX_WBITS,) if encoding == "gzip" else (zlib.MAX_WBITS, -zlib.MAX_WBITS)
     )
     for wbits in wbits_options:
-        remaining = data
+        input_cursor = ZlibInputCursor(data)
         decoded = bytearray()
-        while remaining:
-            obj = zlib.decompressobj(wbits)
+        obj = zlib.decompressobj(wbits)
+        while input_cursor:
+            input_chunk = input_cursor.take()
             try:
                 decoded.extend(
                     obj.decompress(
-                        remaining,
+                        input_chunk,
                         max_length=max_output - len(decoded) + 1,
                     )
                 )
@@ -31,13 +33,15 @@ def _decode_zlib_request_body_for_billing(
                 break
             if len(decoded) > max_output:
                 return None
-            if not obj.eof:
-                break
-            remaining = obj.unused_data
-            if not remaining:
-                return bytes(decoded)
-            if encoding != "gzip":
-                break
+            if obj.eof:
+                input_cursor.carry(obj.unused_data)
+                if not input_cursor:
+                    return bytes(decoded)
+                if encoding != "gzip":
+                    break
+                obj = zlib.decompressobj(wbits)
+            elif obj.unconsumed_tail:
+                input_cursor.carry(obj.unconsumed_tail)
     return None
 
 

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -24,6 +24,7 @@ from body_limits import (
     STREAM_DECODE_EXPANSION_GRACE,
     STREAM_DECODE_MAX_EXPANSION_RATIO,
 )
+from zlib_input import ZlibInputCursor
 
 # Brotli 1.2's output_buffer_limit is a soft allocation threshold, not a hard
 # returned-byte cap. Keep small compressed inputs on tiny chunks as a second
@@ -32,11 +33,6 @@ from body_limits import (
 _BROTLI_DECOMPRESS_MIN_INPUT_CHUNK_SIZE = 16
 _BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE = 1024
 _BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS = 64
-# Bound how much following compressed input zlib can copy into unused_data at
-# a member boundary. This is larger than zstd validation chunks because zlib's
-# max_length already bounds decoded output and ordinary inputs benefit from
-# fewer Python-to-C calls.
-_ZLIB_DECOMPRESS_INPUT_CHUNK_SIZE = 1024
 # zstd's Python decompression object has no zlib-style max_length argument.
 # Keep validation input chunks small so the discarded decoded output is bounded.
 _ZSTD_VALIDATE_INPUT_CHUNK_SIZE = 32
@@ -67,32 +63,6 @@ _StreamDecodeFinishError = Callable[[], str | None]
 class StreamDecodeSession(NamedTuple):
     feed: _StreamDecodeFeed
     finish_error: _StreamDecodeFinishError
-
-
-class _ZlibInputCursor:
-    """Advance source bytes once while prioritizing bounded decompressor tails."""
-
-    def __init__(self, data: bytes) -> None:
-        self._source = memoryview(data)
-        self._source_offset = 0
-        self._pending_input = b""
-
-    def __bool__(self) -> bool:
-        return self._source_offset < len(self._source) or bool(self._pending_input)
-
-    def take(self) -> bytes | memoryview:
-        if self._pending_input:
-            chunk = self._pending_input
-            self._pending_input = b""
-            return chunk
-        chunk = self._source[
-            self._source_offset : self._source_offset + _ZLIB_DECOMPRESS_INPUT_CHUNK_SIZE
-        ]
-        self._source_offset += len(chunk)
-        return chunk
-
-    def carry(self, data: bytes) -> None:
-        self._pending_input = data
 
 
 def _log_streaming_decode_error(encoding_label: str, exc: Exception) -> None:
@@ -138,7 +108,7 @@ def _create_zlib_stream_decode_session(
         if chunk:
             saw_input = True
             compressed_bytes_seen += len(chunk)
-        input_cursor = _ZlibInputCursor(chunk)
+        input_cursor = ZlibInputCursor(chunk)
         # Input slicing can make zlib return partial parser chunks. Coalesce
         # only within this callback and member so existing delivery boundaries
         # and the max_decoded_chunk contract remain intact.
@@ -323,7 +293,7 @@ def _decompress_zlib_best_effort_bounded(
         return _BodyDecodeResult(b"", False)
 
     wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
-    input_cursor = _ZlibInputCursor(data)
+    input_cursor = ZlibInputCursor(data)
     out = bytearray()
     # A full-input zlib call exposes no partial output when that member raises.
     # Commit each member only at EOF so bounded slicing preserves that policy.
@@ -456,7 +426,7 @@ def _decompress_zlib_json_usage_body(
         return b"", DECODED_BODY_LIMIT_EXCEEDED if data else None
 
     wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
-    input_cursor = _ZlibInputCursor(data)
+    input_cursor = ZlibInputCursor(data)
     out = bytearray()
 
     while input_cursor:

--- a/crates/runner/mitm-addon/src/zlib_input.py
+++ b/crates/runner/mitm-addon/src/zlib_input.py
@@ -1,0 +1,29 @@
+"""Bounded compressed-input traversal for zlib decoders."""
+
+_ZLIB_DECOMPRESS_INPUT_CHUNK_SIZE = 1024
+
+
+class ZlibInputCursor:
+    """Advance source bytes once while prioritizing bounded decompressor tails."""
+
+    def __init__(self, data: bytes) -> None:
+        self._source = memoryview(data)
+        self._source_offset = 0
+        self._pending_input = b""
+
+    def __bool__(self) -> bool:
+        return self._source_offset < len(self._source) or bool(self._pending_input)
+
+    def take(self) -> bytes | memoryview:
+        if self._pending_input:
+            chunk = self._pending_input
+            self._pending_input = b""
+            return chunk
+        chunk = self._source[
+            self._source_offset : self._source_offset + _ZLIB_DECOMPRESS_INPUT_CHUNK_SIZE
+        ]
+        self._source_offset += len(chunk)
+        return chunk
+
+    def carry(self, data: bytes) -> None:
+        self._pending_input = data

--- a/crates/runner/mitm-addon/src/zlib_input.py
+++ b/crates/runner/mitm-addon/src/zlib_input.py
@@ -1,5 +1,8 @@
 """Bounded compressed-input traversal for zlib decoders."""
 
+# Bound how much following compressed input zlib can copy into a member tail.
+# One KiB prevents full-body tails while keeping a 64 KiB source to at most
+# 64 fresh source slices.
 _ZLIB_DECOMPRESS_INPUT_CHUNK_SIZE = 1024
 
 

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -24,6 +24,7 @@ _PLAIN_TEXT_TWEET_BODY = b'{"text":"hello world"}'
 _GZIP_WBITS = 16 + zlib.MAX_WBITS
 _ZLIB_DEFLATE_WBITS = zlib.MAX_WBITS
 _RAW_DEFLATE_WBITS = -zlib.MAX_WBITS
+_ZLIB_INPUT_BOUND = 1024
 
 
 def _gzip_members(*payloads: bytes) -> bytes:
@@ -196,6 +197,73 @@ def test_tweet_create_compressed_plain_text_downgrades_to_content_create(
     p = x_usage.call_and_get_single_billing(flow)
     assert p["category"] == "content.create"
     assert p["quantity"] == 1
+
+
+def test_tweet_create_many_gzip_members_use_bounded_input(x_usage, tmp_path, real_flow):
+    empty_member = _gzip_members(b"")
+    request_body = _GZIP_TWEET_BODY + empty_member * (
+        (REQUEST_BODY_BILLING_INSPECTION_LIMIT - len(_GZIP_TWEET_BODY)) // len(empty_member)
+    )
+    assert (
+        REQUEST_BODY_BILLING_INSPECTION_LIMIT - len(empty_member)
+        < len(request_body)
+        <= REQUEST_BODY_BILLING_INSPECTION_LIMIT
+    )
+
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path="/2/tweets",
+        body=json.dumps({"data": {"id": "1"}}).encode(),
+        status=201,
+        permission="tweet.write",
+        rule="POST /2/tweets",
+        request_body=request_body,
+        request_encoding="gzip",
+    )
+    flow.request.method = "POST"
+
+    real_factory = zlib.decompressobj
+    stats = {"calls": 0, "max_input": 0, "max_unused_data": 0}
+
+    class NonConcatenableUnusedData(bytes):
+        def __add__(self, _other: object) -> bytes:
+            raise TypeError("zlib unused data must not be concatenated")
+
+    class TrackingDecompressionObj:
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+
+        def decompress(self, chunk, *args, **kwargs):
+            stats["calls"] += 1
+            stats["max_input"] = max(stats["max_input"], len(chunk))
+            return self._wrapped.decompress(chunk, *args, **kwargs)
+
+        @property
+        def eof(self):
+            return self._wrapped.eof
+
+        @property
+        def unused_data(self):
+            unused_data = NonConcatenableUnusedData(self._wrapped.unused_data)
+            stats["max_unused_data"] = max(stats["max_unused_data"], len(unused_data))
+            return unused_data
+
+        @property
+        def unconsumed_tail(self):
+            return self._wrapped.unconsumed_tail
+
+    def factory(*args, **kwargs):
+        return TrackingDecompressionObj(real_factory(*args, **kwargs))
+
+    with patch("billing_body.zlib.decompressobj", factory):
+        p = x_usage.call_and_get_single_billing(flow)
+
+    assert p["category"] == "content.create"
+    assert p["quantity"] == 1
+    assert stats["calls"] > 0
+    assert stats["max_input"] <= _ZLIB_INPUT_BOUND
+    assert stats["max_unused_data"] <= _ZLIB_INPUT_BOUND
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- extract the proven 1 KiB zlib input cursor into a policy-neutral internal module shared by body decoding and billing
- feed X billing gzip members through bounded source chunks and carried tails while preserving the global decoded cap and fail-closed semantics
- cover a near-64 KiB, many-member gzip body through the real X billing entry point with structural input and `unused_data` bounds

## Behavior And Compatibility

- preserves multi-member gzip, single-stream zlib/raw deflate, exact-limit, overflow, incomplete-member, and trailing-input behavior
- keeps billing function signatures, categories, usage events, APIs, queues, and persisted data unchanged
- changes no database, feature switch, deployment workflow, generated artifact, or user-facing documentation
- old and new runners produce the same billing result during rollout; the new runner avoids excess synchronous decompression work

## Structural Result

For the 65,522-byte reproduction body:

- cumulative compressed input submitted to zlib: 107,289,022 bytes to 1,740,302 bytes
- maximum single decompressor input: 65,522 bytes to 1,024 bytes
- maximum `unused_data`: 65,480 bytes to 1,022 bytes
- decoded JSON and X billing category remain unchanged

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/x_connector_usage/test_writes.py` (116 passed)
- `uv run --no-sync python -m pytest tests/test_body_decoding.py` (102 passed)
- `uv run --no-sync python -m pytest tests/` (4,763 passed)
- `git diff --check`

Closes #25191
