### PR TITLE
fix(mitm-addon): make json work accounting chunk-independent

### DIFF
--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -623,13 +623,7 @@ class JsonSelectiveExtractor:
             self._error = "missing string parser state"
             return i
         work_limited = self.max_work_units is not None
-        if (
-            state.raw is None
-            and not state.escape
-            and not state.unicode_remaining
-            and not state.utf8_remaining
-            and _is_discarded_ascii_string_byte(chunk[i])
-        ):
+        if _can_bulk_skip_discarded_string_byte(state, chunk[i]):
             end = self._discarded_ascii_work_span_end(len(chunk), i) if work_limited else len(chunk)
             if self._error:
                 return i
@@ -649,6 +643,8 @@ class JsonSelectiveExtractor:
         start = i
         try:
             while i < end:
+                if _can_bulk_skip_discarded_string_byte(state, chunk[i]):
+                    break
                 b = chunk[i]
                 i += 1
 
@@ -980,6 +976,16 @@ def _is_json_value_start(b: int) -> bool:
 
 def _is_discarded_ascii_string_byte(b: int) -> bool:
     return _JSON_CONTROL_CHAR_MAX <= b < _UTF8_ONE_BYTE_MAX and b not in b'"\\'
+
+
+def _can_bulk_skip_discarded_string_byte(state: _StringState, b: int) -> bool:
+    return (
+        state.raw is None
+        and not state.escape
+        and not state.unicode_remaining
+        and not state.utf8_remaining
+        and _is_discarded_ascii_string_byte(b)
+    )
 
 
 def _validate_extractor_config(

--- a/crates/runner/mitm-addon/tests/test_json_selective_strings.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_strings.py
@@ -139,7 +139,7 @@ def test_lone_surrogate_key_does_not_abort_later_selected_fields():
     assert result.values == {("usage", "input_tokens"): 7}
 
 
-def test_bulk_skips_large_unselected_string_without_storing_value():
+def test_bulk_skips_large_unselected_string_after_escape_without_storing_value():
     bytewise_accept_calls = 0
     accept_string_byte_code = JsonSelectiveExtractor._accept_string_byte.__code__
 
@@ -154,7 +154,7 @@ def test_bulk_skips_large_unselected_string_without_storing_value():
         scalar_fields={("usage", "input_tokens"): ScalarField("int")}
     )
     large_text = b"x" * (2 * 1024 * 1024)
-    payload = b'{"content":[{"text":"' + large_text + b'"}],"usage":{"input_tokens":7}}'
+    payload = b'{"content":[{"text":"prefix\\n' + large_text + b'"}],"usage":{"input_tokens":7}}'
 
     chunk_size = 64 * 1024
     previous_profile = sys.getprofile()

--- a/crates/runner/mitm-addon/tests/test_json_selective_work_limit.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_work_limit.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from usage.json_selective import JsonSelectiveExtractor
+from usage.json_selective import JsonSelectiveExtractor, ScalarField
 
 
 @pytest.mark.parametrize(
@@ -36,6 +36,35 @@ def test_work_limit_is_exact_and_chunk_independent(
         assert extractor.finish().complete is True
 
         limited = JsonSelectiveExtractor(max_work_units=exact_work_units - 1)
+        for offset in range(0, len(payload), chunk_size):
+            limited.feed(payload[offset : offset + chunk_size])
+        result = limited.finish()
+
+        assert result.complete is False
+        assert result.error == "work limit exceeded"
+        assert result.values == {}
+        assert result.array_counts == {}
+        assert result.wildcard_array_counts == {}
+        assert result.object_present == set()
+
+
+def test_discarded_string_work_limit_is_chunk_independent_after_escape():
+    payload = b'{"' + b"k" * 26 + b'":"q\\"s\\\\"}'
+
+    for chunk_size in (1, 2, 3, 7, len(payload)):
+        extractor = JsonSelectiveExtractor(
+            scalar_fields={("target",): ScalarField("int")},
+            max_work_units=7,
+        )
+        for offset in range(0, len(payload), chunk_size):
+            extractor.feed(payload[offset : offset + chunk_size])
+
+        assert extractor.finish().complete is True
+
+        limited = JsonSelectiveExtractor(
+            scalar_fields={("target",): ScalarField("int")},
+            max_work_units=6,
+        )
         for offset in range(0, len(payload), chunk_size):
             limited.feed(payload[offset : offset + chunk_size])
         result = limited.finish()

--- a/crates/runner/mitm-addon/tests/test_x_response_parsers.py
+++ b/crates/runner/mitm-addon/tests/test_x_response_parsers.py
@@ -403,6 +403,37 @@ class TestXJsonFinalize:
             "response_data_count": 3_600,
         }
 
+    @pytest.mark.parametrize(
+        "chunk_size",
+        [
+            pytest.param(2, id="two-byte"),
+            pytest.param(None, id="whole-body"),
+        ],
+    )
+    def test_escaped_discarded_strings_stay_within_work_limit_across_chunks(
+        self,
+        real_flow,
+        chunk_size,
+    ):
+        discarded_property = b',"' + b"k" * 26 + b'":"q\\"s\\\\"'
+        body = b'{"data":[{"id":"1"}]' + discarded_property * 13_104 + b"}   "
+        assert len(body) == 497_976
+        resolved_chunk_size = len(body) if chunk_size is None else chunk_size
+        flow = self._billable_x_json_flow(real_flow)
+
+        mitm_addon.responseheaders(flow)
+        callback = response_stream(flow)
+        for offset in range(0, len(body), resolved_chunk_size):
+            chunk = body[offset : offset + resolved_chunk_size]
+            assert callback(chunk) == chunk
+        response_streaming.finalize_connector_response_state(flow)
+
+        assert flow.metadata[metadata_keys.X_JSON_STATE] == {
+            "body_parsed": True,
+            "body_truncated": False,
+            "response_data_count": 1,
+        }
+
     def test_x_json_work_limit_discards_partial_state_and_next_flow_recovers(self, real_flow):
         body = json_body_that_exceeds_x_json_work_limit()
         flow = self._billable_x_json_flow(real_flow)


### PR DESCRIPTION
## Summary

- re-evaluate discarded-ASCII bulk-scan eligibility after slow string state transitions, independent of response chunk boundaries
- preserve existing slow and bulk work tariffs while making bounded extraction deterministic and restoring the unlimited bulk path after escapes
- cover the exact parser budget, the unlimited profiling contract, and the production X 65,536-unit response boundary

## Compatibility

- no API, schema, persisted-data, migration, protocol, or work-limit changes
- JSON validation and extraction results remain unchanged except that valid coalesced inputs now receive the same work accounting as identical fragmented inputs

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_json_selective_work_limit.py tests/test_json_selective_strings.py tests/test_x_response_parsers.py` (95 passed)
- `uv run --no-sync python -m pytest tests/` (4,765 passed)

Closes #25192
