### PR TITLE
fix: preserve avatar picker scroll during pagination

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/avatar-template-picker.ts
+++ b/turbo/apps/platform/src/signals/zero-page/avatar-template-picker.ts
@@ -17,11 +17,13 @@ const AVATAR_TEMPLATE_FILTER_OPTIONS_PAGE_SIZE = 100;
 interface AvatarTemplateCatalogPage {
   readonly avatars: readonly ZeroAvatarVideoAvatar[];
   readonly hasNext: boolean;
+  readonly generation: number;
 }
 
 interface AvatarTemplateVoiceCatalogPage {
   readonly voices: readonly ZeroAvatarVideoVoice[];
   readonly hasNext: boolean;
+  readonly generation: number;
 }
 
 interface AvatarTemplateFilters {
@@ -187,13 +189,21 @@ function createOffsetCatalogPagingSignals<T>(
       set(internalPages$, (pages) => {
         return [...pages, next];
       });
+      await get(catalog$);
+      signal.throwIfAborted();
+      if (get(internalGeneration$) !== generation) {
+        return;
+      }
       set(internalLoadingMore$, false);
     },
   );
   const loadingMore$ = computed((get) => {
     return get(internalLoadingMore$);
   });
-  return { catalog$, reset$, loadMore$, loadingMore$ };
+  const generation$ = computed((get) => {
+    return get(internalGeneration$);
+  });
+  return { catalog$, reset$, loadMore$, loadingMore$, generation$ };
 }
 
 function avatarCatalogQuery(
@@ -269,6 +279,7 @@ function createAvatarTemplateCatalogSignals() {
       return {
         avatars: catalog.items,
         hasNext: catalog.hasNext,
+        generation: get(paging.generation$),
       };
     },
   );
@@ -277,6 +288,7 @@ function createAvatarTemplateCatalogSignals() {
     avatarTemplateFilters$,
     setAvatarTemplateFilters$,
     avatarTemplateCatalogPage$,
+    avatarTemplateCatalogGeneration$: paging.generation$,
     loadMoreAvatarTemplates$: paging.loadMore$,
     avatarTemplatesLoadingMore$: paging.loadingMore$,
   };
@@ -361,6 +373,7 @@ function createAvatarTemplateVoiceCatalogSignals() {
       return {
         voices: catalog.items,
         hasNext: catalog.hasNext,
+        generation: get(paging.generation$),
       };
     },
   );
@@ -370,6 +383,7 @@ function createAvatarTemplateVoiceCatalogSignals() {
     setAvatarTemplateVoiceFilters$,
     avatarTemplateVoiceFilterOptions$,
     avatarTemplateVoiceCatalogPage$,
+    avatarTemplateVoiceCatalogGeneration$: paging.generation$,
     loadMoreAvatarTemplateVoices$: paging.loadMore$,
     avatarTemplateVoicesLoadingMore$: paging.loadingMore$,
     resetAvatarTemplateVoiceCatalog$: paging.reset$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -717,6 +717,10 @@ describe("chat composer templates", () => {
       const selectAvatar = await within(dialog).findByLabelText(
         "Select template Ada",
       );
+      expect(within(dialog).getByLabelText("Select template Avatar 1")).toBe(
+        firstCard,
+      );
+      expect(avatarScroll.scrollTop).toBe(500);
       const adaPreview = selectAvatar.querySelector(
         "[data-avatar-template-preview]",
       );
@@ -790,6 +794,9 @@ describe("chat composer templates", () => {
       if (!(voiceScroll instanceof HTMLElement)) {
         throw new Error("Voice catalog scroll area not found");
       }
+      const firstVoiceCard = within(dialog).getByLabelText(
+        "Select voice Christopher",
+      );
       Object.defineProperties(voiceScroll, {
         scrollHeight: { configurable: true, value: 1200 },
         clientHeight: { configurable: true, value: 500 },
@@ -799,6 +806,10 @@ describe("chat composer templates", () => {
       await within(dialog).findByText("Loading");
       voicePageTwoReady.resolve();
       await within(dialog).findByLabelText("Select voice Ava");
+      expect(within(dialog).getByLabelText("Select voice Christopher")).toBe(
+        firstVoiceCard,
+      );
+      expect(voiceScroll.scrollTop).toBe(500);
       const voicePreview = within(dialog).getByLabelText(
         "Preview voice Christopher",
       );

--- a/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
@@ -27,7 +27,7 @@ import {
   Skeleton,
   cn,
 } from "@vm0/ui";
-import { useGet, useLoadable, useSet } from "ccstate-react";
+import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import type {
   KeyboardEvent as ReactKeyboardEvent,
   MouseEvent as ReactMouseEvent,
@@ -960,8 +960,20 @@ function AvatarVoicePickerContent({
 }) {
   const { t } = useTranslation();
   const catalog = useLoadable(signals.template.avatarTemplateVoiceCatalogPage$);
+  const lastCatalog = useLastResolved(
+    signals.template.avatarTemplateVoiceCatalogPage$,
+  );
+  const generation = useGet(
+    signals.template.avatarTemplateVoiceCatalogGeneration$,
+  );
   const loadMore = useSet(signals.template.loadMoreAvatarTemplateVoices$);
   const loadingMore = useGet(signals.template.avatarTemplateVoicesLoadingMore$);
+  const visibleCatalog =
+    catalog.state === "hasData"
+      ? catalog.data
+      : lastCatalog?.generation === generation
+        ? lastCatalog
+        : undefined;
   const pageSignal = useGet(pageSignal$);
   const selectedVoiceId =
     value?.type === "video" ? value.selection.voiceId : undefined;
@@ -1024,13 +1036,13 @@ function AvatarVoicePickerContent({
             className="min-h-0 flex-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
             onScroll={handleVoiceScroll}
           >
-            {catalog.state === "loading" ? (
-              <AvatarVoiceSkeletonGrid />
-            ) : catalog.state === "hasError" ? (
+            {catalog.state === "hasError" ? (
               <AvatarTemplateEmpty error />
-            ) : catalog.data.voices.length > 0 ? (
+            ) : visibleCatalog === undefined ? (
+              <AvatarVoiceSkeletonGrid />
+            ) : visibleCatalog.voices.length > 0 ? (
               <div className="grid grid-cols-1 gap-2.5">
-                {catalog.data.voices.map((voice) => {
+                {visibleCatalog.voices.map((voice) => {
                   return (
                     <AvatarVoiceCard
                       key={voice.id}
@@ -1064,9 +1076,19 @@ function AvatarCatalogPickerContent({
   readonly onUse: (avatar: ZeroAvatarVideoAvatar) => void;
 }) {
   const catalog = useLoadable(signals.template.avatarTemplateCatalogPage$);
+  const lastCatalog = useLastResolved(
+    signals.template.avatarTemplateCatalogPage$,
+  );
+  const generation = useGet(signals.template.avatarTemplateCatalogGeneration$);
   const filters = useGet(signals.template.avatarTemplateFilters$);
   const loadMore = useSet(signals.template.loadMoreAvatarTemplates$);
   const loadingMore = useGet(signals.template.avatarTemplatesLoadingMore$);
+  const visibleCatalog =
+    catalog.state === "hasData"
+      ? catalog.data
+      : lastCatalog?.generation === generation
+        ? lastCatalog
+        : undefined;
   const pageSignal = useGet(pageSignal$);
   const handleAvatarScroll = (event: ReactUIEvent<HTMLElement>) => {
     if (catalog.state !== "hasData" || !catalog.data.hasNext) {
@@ -1088,13 +1110,13 @@ function AvatarCatalogPickerContent({
       onScroll={handleAvatarScroll}
     >
       <AvatarCatalogFilters signals={signals} />
-      {catalog.state === "loading" ? (
-        <AvatarTemplateSkeletonGrid aspectRatio={filters.aspectRatio} />
-      ) : catalog.state === "hasError" ? (
+      {catalog.state === "hasError" ? (
         <AvatarTemplateEmpty error />
+      ) : visibleCatalog === undefined ? (
+        <AvatarTemplateSkeletonGrid aspectRatio={filters.aspectRatio} />
       ) : (
         <>
-          {catalog.data.avatars.length > 0 ? (
+          {visibleCatalog.avatars.length > 0 ? (
             <div
               className={cn(
                 "grid gap-4",
@@ -1103,7 +1125,7 @@ function AvatarCatalogPickerContent({
                   : "grid-cols-1 sm:grid-cols-2 xl:grid-cols-3",
               )}
             >
-              {catalog.data.avatars.map((avatar) => {
+              {visibleCatalog.avatars.map((avatar) => {
                 return (
                   <AvatarTemplateCard
                     key={avatar.id}


### PR DESCRIPTION
## Summary

- keep existing avatar and voice cards mounted while loading the next catalog page
- distinguish pagination refreshes from filter refreshes so filters still show skeletons
- add regression coverage for card identity and scroll position preservation

## Testing

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx --maxWorkers=1`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- pre-commit full Turbo type checks and Knip