### PR TITLE
docs(sandbox): document remote exec timeout normalization

### DIFF
--- a/crates/sandbox-fc/src/control/provider.rs
+++ b/crates/sandbox-fc/src/control/provider.rs
@@ -19,6 +19,18 @@ use crate::paths::RuntimePaths;
 /// Firecracker-backed sandbox control.
 ///
 /// Stateless - can be created with zero cost and used immediately.
+///
+/// # Remote exec timeouts
+///
+/// Remote exec requires a positive timeout after normalization to whole
+/// seconds. Fractional seconds are truncated, so 1,500 milliseconds becomes
+/// one second, while a positive duration below one second becomes zero and is
+/// rejected before guest execution. The control server's saturating
+/// seconds-to-milliseconds conversion caps the effective command timeout at
+/// `u32::MAX` milliseconds (about 49.7 days).
+///
+/// The control path adds five seconds to its host-side wait budget. That
+/// overhead does not extend the guest command timeout.
 pub struct FirecrackerControl;
 
 #[async_trait]
@@ -218,6 +230,25 @@ mod tests {
 
         assert_eq!(timeout_secs, 5);
         assert_eq!(control_timeout(timeout_secs), Duration::from_secs(10));
+    }
+
+    #[test]
+    fn positive_subsecond_timeout_becomes_zero_second_request() {
+        let timeout_secs = request_timeout_secs(Duration::from_millis(999));
+
+        assert_eq!(timeout_secs, 0);
+        assert_eq!(
+            control_timeout(timeout_secs),
+            Duration::from_millis(CONTROL_SOCKET_OVERHEAD_MS)
+        );
+    }
+
+    #[test]
+    fn fractional_timeout_truncates_to_whole_seconds() {
+        let timeout_secs = request_timeout_secs(Duration::from_millis(1500));
+
+        assert_eq!(timeout_secs, 1);
+        assert_eq!(control_timeout(timeout_secs), Duration::from_secs(6));
     }
 
     #[test]

--- a/crates/sandbox/src/control.rs
+++ b/crates/sandbox/src/control.rs
@@ -111,8 +111,10 @@ pub trait SandboxControl: Send + Sync {
     /// Execute a command inside a running sandbox using the requested identity
     /// scope.
     ///
-    /// `timeout` is the command timeout; the implementation may add extra
-    /// time for connection overhead.
+    /// `timeout` is the requested command timeout. Implementations may
+    /// normalize it to backend-specific granularity and limits, and may add
+    /// extra time for control or connection overhead. Consult the concrete
+    /// backend's documentation for its normalization rules.
     async fn exec_remote(
         &self,
         target: SandboxControlTarget,


### PR DESCRIPTION
## Summary

- document backend-specific timeout normalization on `SandboxControl::exec_remote`
- document Firecracker's whole-second truncation, sub-second rejection, effective upper bound, and host wait overhead
- add regression coverage for positive sub-second and fractional timeout conversion

## Runtime impact

None. This PR does not change timeout conversion, error behavior, or the control wire protocol.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p sandbox -p sandbox-fc`
- `cargo clippy -p sandbox -p sandbox-fc --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- pre-commit workspace formatting, Clippy, and Rustdoc checks

Closes #25207
