### PR TITLE
fix(ci): discard runner benchmark response body

### DIFF
--- a/.github/scripts/runner-behavior-benchmark.sh
+++ b/.github/scripts/runner-behavior-benchmark.sh
@@ -22,7 +22,7 @@ echo "=== Running benchmark (default) ==="
 ssh "$REMOTE" "sudo ${BIN_DIR}/runner benchmark \
   --config ${RUNNER_DIR}/runner.yaml \
   --profile vm0/default \
-  'curl -sf --max-time 10 https://www.vm0.ai'"
+  'curl -sf --max-time 10 --output /dev/null https://www.vm0.ai'"
 
 echo "=== Running benchmark (browser automation) ==="
 # Retry once — snapshot restore can trigger transient Chromium


### PR DESCRIPTION
## Summary

- discard the default runner benchmark's HTTP response body after validating the request
- preserve curl's fail-fast behavior and 10-second request timeout
- avoid streaming a large homepage through the Cloudflare SSH command channel

## Scope

This does not change the browser automation benchmark or the shared SSH transport behavior.

## Validation

- `bash -n .github/scripts/runner-behavior-benchmark.sh`
- entry-point command construction test with a fake `ssh` executable
- `curl -sf --max-time 10 --output /dev/null https://www.vm0.ai`
- pre-commit file-size check
- commit message validation
