### PR TITLE
refactor(python): share runner flush marker envelope parsing

### DIFF
--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -14,6 +14,7 @@ from mitmproxy import ctx
 import claude_output_timing
 import codex_output_timing
 import logging_utils
+import runner_flush_request
 import usage
 
 _RunnerFlushPhase = Literal["running", "draining", "closed"]
@@ -250,24 +251,19 @@ def _flush_jsonl_for_runner_request() -> None:
 
 def _read_jsonl_flush_request() -> tuple[str, str] | None:
     marker_path = Path(__file__).resolve().parent / _JSONL_FLUSH_REQUEST_FILE
-    try:
-        marker = json.loads(marker_path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+    request = runner_flush_request.read_runner_flush_request(
+        marker_path,
+        get_usage_state_id=usage.current_usage_state_id,
+    )
+    if request is None:
         return None
-
-    if not isinstance(marker, dict):
-        return None
-    if marker.get("usageStateId") != usage.current_usage_state_id():
-        return None
-    flush_request_id = marker.get("flushRequestId")
+    flush_request_id = request.flush_request_id
     if (
-        not isinstance(flush_request_id, str)
-        or not flush_request_id
-        or not _is_safe_jsonl_flush_request_id(flush_request_id)
+        not _is_safe_jsonl_flush_request_id(flush_request_id)
         or flush_request_id == _last_jsonl_flush_request_id
     ):
         return None
-    log_path = marker.get("path")
+    log_path = request.marker.get("path")
     if not isinstance(log_path, str) or not log_path:
         return None
     return log_path, flush_request_id

--- a/crates/runner/mitm-addon/src/runner_flush_request.py
+++ b/crates/runner/mitm-addon/src/runner_flush_request.py
@@ -1,0 +1,32 @@
+"""Common runner flush request marker envelope parsing."""
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import NamedTuple
+
+
+class RunnerFlushRequest(NamedTuple):
+    marker: dict[str, object]
+    flush_request_id: str
+
+
+def read_runner_flush_request(
+    marker_path: Path,
+    *,
+    get_usage_state_id: Callable[[], str],
+) -> RunnerFlushRequest | None:
+    """Read a runner flush request for the expected addon generation."""
+    try:
+        marker: object = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(marker, dict):
+        return None
+    if marker.get("usageStateId") != get_usage_state_id():
+        return None
+    flush_request_id = marker.get("flushRequestId")
+    if not isinstance(flush_request_id, str) or not flush_request_id:
+        return None
+    return RunnerFlushRequest(marker=marker, flush_request_id=flush_request_id)

--- a/crates/runner/mitm-addon/src/usage/counters.py
+++ b/crates/runner/mitm-addon/src/usage/counters.py
@@ -19,6 +19,8 @@ from typing import Any
 
 from mitmproxy import ctx
 
+import runner_flush_request
+
 _counter_lock = threading.Lock()
 _pending_write_lock = threading.Lock()
 _in_flight_flows = 0
@@ -106,19 +108,13 @@ def read_usage_flush_request_id() -> str | None:
         return None
 
     marker_path = Path(pending_path).with_name(_FLUSH_REQUEST_FILE)
-    try:
-        marker = json.loads(marker_path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+    request = runner_flush_request.read_runner_flush_request(
+        marker_path,
+        get_usage_state_id=lambda: usage_state_id,
+    )
+    if request is None:
         return None
-
-    if not isinstance(marker, dict):
-        return None
-    if marker.get("usageStateId") != usage_state_id:
-        return None
-    flush_request_id = marker.get("flushRequestId")
-    if not isinstance(flush_request_id, str) or not flush_request_id:
-        return None
-    return flush_request_id
+    return request.flush_request_id
 
 
 def _write_pending_state(pending_path: str, state: dict[str, Any]) -> None:

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -3,8 +3,6 @@
 import json
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 import flow_metadata_keys as metadata_keys
 import usage
 from tests.pending_helpers import assert_current_pending, assert_pending
@@ -240,12 +238,6 @@ class TestUsagePendingCounter:
 
         assert usage.read_usage_flush_request_id() is None
 
-    def test_read_usage_flush_request_id_returns_none_when_marker_missing(self, tmp_path):
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
-
-        assert usage.read_usage_flush_request_id() is None
-
     def test_read_usage_flush_request_id_accepts_matching_marker(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
@@ -260,52 +252,6 @@ class TestUsagePendingCounter:
         )
 
         assert usage.read_usage_flush_request_id() == "request-1"
-
-    def test_read_usage_flush_request_id_rejects_stale_marker(self, tmp_path):
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
-        (tmp_path / "usage-flush-request").write_text(
-            json.dumps(
-                {
-                    "usageStateId": "old-state",
-                    "flushRequestId": "request-1",
-                    "requestedAtMs": 1_770_000_000_000,
-                }
-            )
-        )
-
-        assert usage.read_usage_flush_request_id() is None
-
-    def test_read_usage_flush_request_id_ignores_invalid_marker(self, tmp_path):
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
-        (tmp_path / "usage-flush-request").write_text("not-json")
-
-        assert usage.read_usage_flush_request_id() is None
-
-    def test_read_usage_flush_request_id_ignores_invalid_utf8_marker(self, tmp_path):
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
-        (tmp_path / "usage-flush-request").write_bytes(b"\xff")
-
-        assert usage.read_usage_flush_request_id() is None
-
-    @pytest.mark.parametrize(
-        "marker",
-        [
-            [],
-            {},
-            {"usageStateId": "runner-state"},
-            {"usageStateId": "runner-state", "flushRequestId": ""},
-            {"usageStateId": "runner-state", "flushRequestId": 123},
-        ],
-    )
-    def test_read_usage_flush_request_id_rejects_invalid_marker_shape(self, tmp_path, marker):
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
-        (tmp_path / "usage-flush-request").write_text(json.dumps(marker))
-
-        assert usage.read_usage_flush_request_id() is None
 
     def test_decrement_underflow_stays_non_negative_and_logs_once_per_counter(self, tmp_path):
         pending_path = tmp_path / "usage-pending"

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -201,6 +201,84 @@ class _InstrumentedFlushOwnerLock:
 class TestRunnerUsageFlushSignal:
     """Tests for runner-triggered usage buffer flush requests."""
 
+    @pytest.mark.parametrize("consumer", ["usage", "jsonl"])
+    @pytest.mark.parametrize(
+        ("marker_bytes", "marker_is_directory"),
+        [
+            pytest.param(None, False, id="missing"),
+            pytest.param(None, True, id="unreadable"),
+            pytest.param(b"\xff", False, id="invalid-utf8"),
+            pytest.param(b"not-json", False, id="invalid-json"),
+            pytest.param(b"[]", False, id="non-object"),
+            pytest.param(
+                json.dumps(
+                    {
+                        "usageStateId": "previous-runner-state",
+                        "flushRequestId": "request-1",
+                    }
+                ).encode(),
+                False,
+                id="stale-generation",
+            ),
+            pytest.param(
+                json.dumps({"usageStateId": _RUNNER_USAGE_STATE_ID}).encode(),
+                False,
+                id="missing-request-id",
+            ),
+            pytest.param(
+                json.dumps(
+                    {
+                        "usageStateId": _RUNNER_USAGE_STATE_ID,
+                        "flushRequestId": "",
+                    }
+                ).encode(),
+                False,
+                id="empty-request-id",
+            ),
+            pytest.param(
+                json.dumps(
+                    {
+                        "usageStateId": _RUNNER_USAGE_STATE_ID,
+                        "flushRequestId": 123,
+                    }
+                ).encode(),
+                False,
+                id="non-string-request-id",
+            ),
+        ],
+    )
+    def test_flush_request_consumers_ignore_malformed_envelope(
+        self,
+        runner_usage_flush_files: RunnerUsageFlushFiles,
+        consumer: str,
+        marker_bytes: bytes | None,
+        marker_is_directory: bool,
+    ) -> None:
+        marker_path = (
+            runner_usage_flush_files.usage_flush_request_path
+            if consumer == "usage"
+            else runner_usage_flush_files.jsonl_flush_request_path
+        )
+        if marker_is_directory:
+            marker_path.mkdir()
+        elif marker_bytes is not None:
+            marker_path.write_bytes(marker_bytes)
+
+        if consumer == "usage":
+            assert usage.read_usage_flush_request_id() is None
+            return
+
+        with (
+            patch.object(
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
+            ),
+            patch.object(logging_utils, "flush_log_path") as flush_log_path,
+        ):
+            runner_flush_lifecycle._flush_jsonl_for_runner_request()
+
+        flush_log_path.assert_not_called()
+        assert not runner_usage_flush_files.jsonl_flush_state_path.exists()
+
     def test_real_signal_during_request_consumption_drains_acknowledgement(
         self, tmp_path: Path
     ) -> None:
@@ -470,32 +548,30 @@ class TestRunnerUsageFlushSignal:
             "pending": 0,
         }
 
-    def test_jsonl_flush_request_rejects_unsafe_request_id(
-        self, runner_usage_flush_files: RunnerUsageFlushFiles
-    ):
-        runner_usage_flush_files.write_jsonl_flush_request(flush_request_id="../jsonl-request-1")
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            pytest.param("flushRequestId", "../jsonl-request-1", id="unsafe-request-id"),
+            pytest.param("path", "", id="empty-path"),
+            pytest.param("path", 123, id="non-string-path"),
+        ],
+    )
+    def test_jsonl_flush_request_rejects_protocol_specific_fields(
+        self,
+        runner_usage_flush_files: RunnerUsageFlushFiles,
+        field: str,
+        value: object,
+    ) -> None:
+        runner_usage_flush_files.write_jsonl_flush_request()
+        marker = json.loads(runner_usage_flush_files.jsonl_flush_request_path.read_text())
+        marker[field] = value
+        runner_usage_flush_files.jsonl_flush_request_path.write_text(json.dumps(marker))
 
         with (
             patch.object(logging_utils, "flush_log_path") as flush_log_path,
             running_jsonl_flush_worker(runner_usage_flush_files),
         ):
             pass
-
-        flush_log_path.assert_not_called()
-        assert not runner_usage_flush_files.jsonl_flush_state_path.exists()
-
-    def test_jsonl_flush_request_ignores_invalid_utf8_marker(
-        self, runner_usage_flush_files: RunnerUsageFlushFiles
-    ):
-        runner_usage_flush_files.jsonl_flush_request_path.write_bytes(b"\xff")
-
-        with (
-            patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
-            ),
-            patch.object(logging_utils, "flush_log_path") as flush_log_path,
-        ):
-            runner_flush_lifecycle._flush_jsonl_for_runner_request()
 
         flush_log_path.assert_not_called()
         assert not runner_usage_flush_files.jsonl_flush_state_path.exists()
@@ -698,23 +774,6 @@ class TestRunnerUsageFlushSignal:
             (str(first_path),),
             (str(second_path),),
         ]
-
-    def test_jsonl_watcher_rejects_previous_usage_generation(
-        self, runner_usage_flush_files: RunnerUsageFlushFiles
-    ):
-        runner_usage_flush_files.write_jsonl_flush_request()
-        marker = json.loads(runner_usage_flush_files.jsonl_flush_request_path.read_text())
-        marker["usageStateId"] = "previous-runner-state"
-        runner_usage_flush_files.jsonl_flush_request_path.write_text(json.dumps(marker))
-
-        with (
-            patch.object(logging_utils, "flush_log_path") as flush_log_path,
-            running_jsonl_flush_worker(runner_usage_flush_files),
-        ):
-            pass
-
-        flush_log_path.assert_not_called()
-        assert not runner_usage_flush_files.jsonl_flush_state_path.exists()
 
     def test_jsonl_watcher_final_observation_processes_published_marker(
         self, runner_usage_flush_files: RunnerUsageFlushFiles

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -269,12 +269,10 @@ class TestRunnerUsageFlushSignal:
             return
 
         with (
-            patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
-            ),
             patch.object(logging_utils, "flush_log_path") as flush_log_path,
+            running_jsonl_flush_worker(runner_usage_flush_files),
         ):
-            runner_flush_lifecycle._flush_jsonl_for_runner_request()
+            pass
 
         flush_log_path.assert_not_called()
         assert not runner_usage_flush_files.jsonl_flush_state_path.exists()


### PR DESCRIPTION
## Summary

- centralize the shared runner flush marker UTF-8, JSON object, generation, and request ID checks in one Python module
- keep usage marker path selection and JSONL safe-ID, duplicate, path, lifecycle, and acknowledgement behavior in their existing owners
- consolidate malformed-envelope integration coverage across both consumers and retain focused protocol-specific regressions

## Compatibility

- no request or acknowledgement filenames, JSON fields, accepted values, polling, timeout, logging, or state-machine behavior changed
- no API, database, migration, feature switch, or rollout work is required

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4772 passed)

Closes #25206
