### PR TITLE
perf(mitm-addon): stop decoding after json inspection terminates

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -58,9 +58,18 @@ class _BodyDecodeResult(NamedTuple):
 
 _StreamDecodeFeed = Callable[[bytes], None]
 _StreamDecodeFinishError = Callable[[], str | None]
+_StreamDecodeShouldContinue = Callable[[], bool]
 
 
 class StreamDecodeSession(NamedTuple):
+    """Incremental inspection decoder with transport-completion diagnostics.
+
+    ``finish_error`` reports only decoder failures that remain authoritative.
+    When a configured downstream parser permanently stops accepting input, the
+    session intentionally abandons decoding and leaves final error reporting to
+    that parser.
+    """
+
     feed: _StreamDecodeFeed
     finish_error: _StreamDecodeFinishError
 
@@ -91,19 +100,21 @@ def _create_zlib_stream_decode_session(
     *,
     encoding: Literal["gzip", "deflate"],
     max_decoded_chunk: int,
+    should_continue: _StreamDecodeShouldContinue | None,
 ) -> StreamDecodeSession:
     wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
     obj = zlib.decompressobj(wbits)
     compressed_bytes_seen = 0
     decode_error: str | None = None
     decoded_bytes_emitted = 0
+    inspection_stopped = False
     member_in_progress = False
     saw_input = False
 
     def decode(chunk: bytes) -> None:
         nonlocal compressed_bytes_seen, decode_error, decoded_bytes_emitted
-        nonlocal member_in_progress, obj, saw_input
-        if decode_error is not None:
+        nonlocal inspection_stopped, member_in_progress, obj, saw_input
+        if decode_error is not None or inspection_stopped:
             return
         if chunk:
             saw_input = True
@@ -135,12 +146,18 @@ def _create_zlib_stream_decode_session(
             except zlib.error as exc:
                 if pending_decoded:
                     feed(bytes(pending_decoded))
+                    if should_continue is not None and not should_continue():
+                        inspection_stopped = True
+                        return
                 decode_error = INVALID_COMPRESSED_BODY
                 _log_streaming_decode_error(encoding, exc)
                 return
             if probing_for_additional_output and decoded:
                 if pending_decoded:
                     feed(bytes(pending_decoded))
+                    if should_continue is not None and not should_continue():
+                        inspection_stopped = True
+                        return
                 decode_error = DECODED_BODY_LIMIT_EXCEEDED
                 return
             if decoded:
@@ -149,10 +166,16 @@ def _create_zlib_stream_decode_session(
                 if len(pending_decoded) == max_decoded_chunk:
                     feed(bytes(pending_decoded))
                     pending_decoded.clear()
+                    if should_continue is not None and not should_continue():
+                        inspection_stopped = True
+                        return
             if obj.eof:
                 if pending_decoded:
                     feed(bytes(pending_decoded))
                     pending_decoded.clear()
+                    if should_continue is not None and not should_continue():
+                        inspection_stopped = True
+                        return
                 # At an exact output boundary, zlib can expose the next member
                 # through both unused_data and unconsumed_tail. Reset before
                 # consulting unconsumed_tail so the next member makes progress.
@@ -164,10 +187,14 @@ def _create_zlib_stream_decode_session(
                 input_cursor.carry(obj.unconsumed_tail)
         if pending_decoded:
             feed(bytes(pending_decoded))
+            if should_continue is not None and not should_continue():
+                inspection_stopped = True
 
     def finish_error() -> str | None:
         if decode_error is not None:
             return decode_error
+        if inspection_stopped:
+            return None
         if saw_input and member_in_progress:
             return INCOMPLETE_COMPRESSED_BODY
         return None
@@ -213,6 +240,7 @@ def create_stream_decode_session(
     feed: _StreamDecodeFeed,
     *,
     max_decoded_chunk: int = STREAM_DECODE_CHUNK_LIMIT,
+    should_continue: _StreamDecodeShouldContinue | None = None,
 ) -> StreamDecodeSession | None:
     """Create a bounded streaming decoder session for usage-parser chunks.
 
@@ -227,6 +255,12 @@ def create_stream_decode_session(
     The returned session exposes ``finish_error()`` so billing paths can reject
     parser state from compressed streams that never reached a valid frame/member
     ending. Best-effort capture paths should continue to use ``decompress_body``.
+
+    ``should_continue`` is an optional permanent-parser capability. It is
+    checked after each decoded delivery. Once false, the session suppresses
+    later parser callbacks and decompression without classifying the abandoned
+    compressed member as incomplete. Recoverable event or line parsers must not
+    supply this capability.
     """
     if max_decoded_chunk <= 0:
         raise ValueError("max_decoded_chunk must be positive")
@@ -234,12 +268,25 @@ def create_stream_decode_session(
     if not can_stream_decode_usage(headers):
         return None
     if not encoding or encoding == "identity":
-        return StreamDecodeSession(feed, _no_stream_decode_error)
+        if should_continue is None:
+            return StreamDecodeSession(feed, _no_stream_decode_error)
+        inspection_stopped = False
+
+        def feed_until_stopped(chunk: bytes) -> None:
+            nonlocal inspection_stopped
+            if inspection_stopped:
+                return
+            feed(chunk)
+            if not should_continue():
+                inspection_stopped = True
+
+        return StreamDecodeSession(feed_until_stopped, _no_stream_decode_error)
     if encoding in ("gzip", "deflate"):
         return _create_zlib_stream_decode_session(
             feed,
             encoding=encoding,
             max_decoded_chunk=max_decoded_chunk,
+            should_continue=should_continue,
         )
     return None
 

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -169,8 +169,14 @@ def release_model_websocket_usage_state(flow: http.HTTPFlow) -> None:
 def _make_response_decode_session(
     feed: _ResponseChunkParser,
     headers: http.Headers,
+    *,
+    should_continue: Callable[[], bool] | None = None,
 ) -> body_decoding.StreamDecodeSession | None:
-    return body_decoding.create_stream_decode_session(headers, feed)
+    return body_decoding.create_stream_decode_session(
+        headers,
+        feed,
+        should_continue=should_continue,
+    )
 
 
 def _make_model_sse_parse_error_logger(
@@ -330,7 +336,11 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
             extractor = usage.create_openai_responses_json_usage_extractor()
         else:
             extractor = usage.create_anthropic_messages_json_usage_extractor()
-        decode_session = _make_response_decode_session(extractor.feed, response.headers)
+        decode_session = _make_response_decode_session(
+            extractor.feed,
+            response.headers,
+            should_continue=extractor.accepts_more_input,
+        )
         if decode_session is None:
             _maybe_log_response_encoding_inspection_risk(flow, response)
             return _ResponseUsageStreamSetup(
@@ -365,7 +375,11 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
         )
     connector_parser = usage.create_connector_response_parser(flow)
     if connector_parser is not None:
-        decode_session = _make_response_decode_session(connector_parser.feed, response.headers)
+        decode_session = _make_response_decode_session(
+            connector_parser.feed,
+            response.headers,
+            should_continue=connector_parser.should_continue,
+        )
         if decode_session is None:
             raise RuntimeError("stream-decodable connector response did not create a decoder")
         if connector_parser.report_on_interruption:

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -246,6 +246,11 @@ class AnthropicMessagesJsonUsageExtractor:
     def feed(self, chunk: bytes) -> None:
         self._extractor.feed(chunk)
 
+    def accepts_more_input(self) -> bool:
+        """Return whether the document parser can still consume input."""
+
+        return self._extractor.accepts_more_input()
+
     def finish(self) -> tuple[dict | None, str | None]:
         result = self._extractor.finish()
         if not result.complete:

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -276,6 +276,15 @@ class JsonSelectiveExtractor:
         self._slow_work_bytes_remaining = 0
         self._discarded_ascii_work_bytes_remaining = 0
 
+    def accepts_more_input(self) -> bool:
+        """Return whether later bytes can still affect this document parser.
+
+        A completed root remains active so trailing data is still validated.
+        Only a permanent parse or configured-bound error stops input.
+        """
+
+        return self._error is None
+
     def feed(self, chunk: bytes) -> None:
         """Consume the next bytes for this JSON document.
 

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -682,6 +682,11 @@ class OpenAIResponsesJsonUsageExtractor:
     def feed(self, chunk: bytes) -> None:
         self._extractor.feed(chunk)
 
+    def accepts_more_input(self) -> bool:
+        """Return whether the document parser can still consume input."""
+
+        return self._extractor.accepts_more_input()
+
     def finish(self) -> tuple[dict | None, str | None]:
         result = self._extractor.finish()
         if not result.complete:

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
@@ -39,9 +39,15 @@ class ConnectorResponseParser(NamedTuple):
     response body completed. It should publish connector-owned unparsed state so
     later fallback parsing does not trust best-effort decoded bytes. This runs
     before an opted-in interrupted response is reported.
+
+    ``should_continue`` is optional and only valid for one-document parsers
+    whose errors are permanent. Response decoding checks it after each parser
+    callback and intentionally stops inspection once it returns false. Event-
+    or line-scoped parsers that recover on later input must leave it unset.
     """
 
     feed: Callable[[bytes], None]
     report_on_interruption: bool
     finish: Callable[[], None] | None = None
     finish_decode_error: Callable[[str], None] | None = None
+    should_continue: Callable[[], bool] | None = None

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -462,6 +462,11 @@ class _XJsonResponseExtractor:
     def feed(self, chunk: bytes) -> None:
         self._extractor.feed(chunk)
 
+    def accepts_more_input(self) -> bool:
+        """Return whether the document parser can still consume input."""
+
+        return self._extractor.accepts_more_input()
+
     def finish(self) -> tuple[dict, str | None]:
         result: dict = {"body_parsed": False, "body_truncated": False}
         extracted = self._extractor.finish()
@@ -533,6 +538,7 @@ def create_response_parser(
         report_on_interruption=False,
         finish=finish_json_state,
         finish_decode_error=finish_json_decode_error,
+        should_continue=extractor.accepts_more_input,
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -246,7 +246,6 @@ class TestStreamDecodeSession:
 
         session.feed(b"[0")
         assert extractor.accepts_more_input() is False
-        assert decoded_callbacks == 1
 
         session.feed(b"]")
         assert decoded_callbacks == 1

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -26,6 +26,7 @@ from tests.body_decode_helpers import (
     pseudo_random_ascii,
     track_brotli_decompressor,
 )
+from usage.json_selective import JsonSelectiveExtractor
 
 _ZLIB_INPUT_BOUND = 1024
 
@@ -51,6 +52,7 @@ def _track_zlib_decompressor(monkeypatch):
     real_factory = zlib.decompressobj
     stats = {
         "calls": 0,
+        "input_bytes": 0,
         "objects": 0,
         "max_input": 0,
         "max_unused_data": 0,
@@ -66,6 +68,7 @@ def _track_zlib_decompressor(monkeypatch):
 
         def decompress(self, chunk, *args, **kwargs):
             stats["calls"] += 1
+            stats["input_bytes"] += len(chunk)
             stats["max_input"] = max(stats["max_input"], len(chunk))
             return self._wrapped.decompress(chunk, *args, **kwargs)
 
@@ -225,6 +228,31 @@ class TestStreamDecodeSession:
         assert chunks == [b"hello"]
         assert session.finish_error() is None
 
+    def test_identity_document_parser_termination_stops_callbacks(self, headers):
+        extractor = JsonSelectiveExtractor(max_work_units=1)
+        decoded_callbacks = 0
+
+        def feed(chunk: bytes) -> None:
+            nonlocal decoded_callbacks
+            decoded_callbacks += 1
+            extractor.feed(chunk)
+
+        session = create_stream_decode_session(
+            headers(),
+            feed,
+            should_continue=extractor.accepts_more_input,
+        )
+        assert session is not None
+
+        session.feed(b"[0")
+        assert extractor.accepts_more_input() is False
+        assert decoded_callbacks == 1
+
+        session.feed(b"]")
+        assert decoded_callbacks == 1
+        assert extractor.finish().error == "work limit exceeded"
+        assert session.finish_error() is None
+
     def test_gzip_high_ratio_output_is_chunked(self, headers):
         plaintext = b"A" * (STREAM_DECODE_CHUNK_LIMIT * 3 + 123)
         chunks: list[bytes] = []
@@ -236,6 +264,55 @@ class TestStreamDecodeSession:
         assert b"".join(chunks) == plaintext
         assert len(chunks) > 1
         assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
+        assert session.finish_error() is None
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_document_parser_termination_stops_zlib_traversal(self, headers, monkeypatch, encoding):
+        dense_array = b"0," * 40_000 + b"0"
+        random_tail = hashlib.shake_256(b"issue-25212-regression").hexdigest(128 * 1024).encode()
+        plaintext = (
+            b'{"padding":['
+            + dense_array
+            + b'],"random":"'
+            + random_tail
+            + b'","bulk":"'
+            + b"A" * (12 * 1024 * 1024)
+            + b'"}'
+        )
+        compressed = _compress_one_shot_body(encoding, plaintext)
+        assert 50 * len(compressed) < len(plaintext) < 100 * len(compressed)
+
+        extractor = JsonSelectiveExtractor(max_work_units=65_536)
+        decoded_callbacks = 0
+        decoded_bytes = 0
+
+        def feed(chunk: bytes) -> None:
+            nonlocal decoded_bytes, decoded_callbacks
+            decoded_callbacks += 1
+            decoded_bytes += len(chunk)
+            extractor.feed(chunk)
+
+        stats = _track_zlib_decompressor(monkeypatch)
+        session = create_stream_decode_session(
+            headers(("Content-Encoding", encoding)),
+            feed,
+            should_continue=extractor.accepts_more_input,
+        )
+        assert session is not None
+        midpoint = len(compressed) // 2
+
+        session.feed(compressed[:midpoint])
+
+        assert extractor.accepts_more_input() is False
+        assert decoded_callbacks < len(plaintext) // STREAM_DECODE_CHUNK_LIMIT // 10
+        assert decoded_bytes < len(plaintext) // 10
+        assert stats["input_bytes"] < len(compressed) // 10
+        counts_after_termination = (decoded_callbacks, decoded_bytes, stats["calls"])
+
+        session.feed(compressed[midpoint:])
+
+        assert (decoded_callbacks, decoded_bytes, stats["calls"]) == counts_after_termination
+        assert extractor.finish().error == "work limit exceeded"
         assert session.finish_error() is None
 
     @pytest.mark.parametrize("encoding", ["gzip", "deflate"])

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
@@ -204,7 +204,14 @@ class TestModelProviderJsonStreaming:
         )
 
         mitm_addon.responseheaders(flow)
-        assert response_stream(flow)(compressed) == compressed
+        callback = response_stream(flow)
+        assert callback(compressed) == compressed
+        corrupt_followup = bytearray(
+            gzip.compress(b"") if encoding_case == "gzip" else zlib.compress(b"")
+        )
+        checksum_offset = -8 if encoding_case == "gzip" else -1
+        corrupt_followup[checksum_offset] ^= 0xFF
+        assert callback(bytes(corrupt_followup)) == bytes(corrupt_followup)
 
         webhook = run_response(flow, self._usage_webhook_api)
 

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -180,7 +180,12 @@ class TestXConnectorResponsePipeline:
         assert STREAM_DECODE_CHUNK_LIMIT < len(payload) <= allowed_decoded_bytes
 
         mitm_addon.responseheaders(flow)
-        assert response_stream(flow)(compressed) == compressed
+        callback = response_stream(flow)
+        assert callback(compressed) == compressed
+        corrupt_followup = bytearray(_compress_body(encoding_case, b""))
+        checksum_offset = -8 if encoding_case == "gzip" else -1
+        corrupt_followup[checksum_offset] ^= 0xFF
+        assert callback(bytes(corrupt_followup)) == bytes(corrupt_followup)
 
         with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)


### PR DESCRIPTION
## Summary

- stop identity, gzip, and deflate inspection after a bounded single-document JSON parser reaches a permanent error
- preserve compressed-stream completion validation while a parser can still accept input, and keep SSE and NDJSON parsers recoverable
- cover the decoder directly and the model-provider and X connector response pipelines, including corrupt trailing compressed members

On the issue reproduction, decoded inspection stopped after 823,193 of 51,030,725 bytes (18 callbacks), avoiding 50,207,532 bytes of decompression and parser work. Forwarded response bytes are unchanged.

## Exclusions

- no changes to JSON parser limits or usage extraction semantics
- no early-stop capability for SSE or NDJSON streams
- no changes to Brotli or Zstandard streaming support

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,789 passed)

Closes #25212
