### PR TITLE
fix(runner): secure workspace cache publications

### DIFF
--- a/crates/runner/src/workspace_image_cache/fs.rs
+++ b/crates/runner/src/workspace_image_cache/fs.rs
@@ -30,6 +30,25 @@ impl WorkspaceImageCache {
             statvfs_bytes(&path).await
         }
     }
+
+    pub(super) async fn ensure_workspace_cache_entry_dir(
+        &self,
+        cache_key: &str,
+    ) -> RunnerResult<()> {
+        crate::host_file::ensure_dir(
+            self.workspace_image_cache_dir(),
+            crate::host_file::DirMode::Private,
+            "workspace image cache root",
+        )?;
+        let entry_dir = self.workspace_image_cache_entry_dir(cache_key);
+        remove_non_directory_workspace_cache_entry(&entry_dir).await?;
+        crate::host_file::ensure_dir(
+            &entry_dir,
+            crate::host_file::DirMode::Private,
+            "workspace image cache entry",
+        )?;
+        Ok(())
+    }
 }
 
 pub(super) fn is_workspace_tmp_path_name(name: &str) -> bool {
@@ -112,17 +131,12 @@ pub(super) async fn remove_non_directory_workspace_cache_entry(path: &Path) -> R
     Ok(true)
 }
 
-pub(super) async fn ensure_workspace_cache_entry_dir(path: &Path) -> RunnerResult<()> {
-    remove_non_directory_workspace_cache_entry(path).await?;
-    fs::create_dir_all(path).await?;
-    let metadata = fs::symlink_metadata(path).await?;
-    if metadata.is_dir() {
-        return Ok(());
-    }
-    Err(RunnerError::Internal(format!(
-        "workspace image cache entry is not a directory: {}",
-        path.display()
-    )))
+pub(super) fn secure_workspace_cache_publication_file(path: &Path) -> RunnerResult<()> {
+    crate::host_file::validate_private_file_destination(
+        path,
+        "workspace image cache publication file",
+    )?;
+    Ok(())
 }
 
 pub(super) fn has_copy_headroom(stats: FsStats, budget: CacheBudget, allocated_bytes: u64) -> bool {

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -20,8 +20,9 @@ use crate::types::{
 
 use super::entry::is_cache_key_name;
 use super::fs::{
-    allocated_bytes, ensure_workspace_cache_entry_dir, has_copy_headroom, local_timestamp,
-    remove_non_directory_workspace_cache_entry, remove_workspace_cache_path_if_exists, sparse_copy,
+    allocated_bytes, has_copy_headroom, local_timestamp,
+    remove_non_directory_workspace_cache_entry, remove_workspace_cache_path_if_exists,
+    secure_workspace_cache_publication_file, sparse_copy,
 };
 use super::metadata::{
     WorkspaceCacheMetadata, WorkspaceCacheState as WorkspaceCacheEntryState,
@@ -821,7 +822,9 @@ impl WorkspaceImageCache {
             );
             return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
         }
-        ensure_workspace_cache_entry_dir(&cache_dir).await?;
+        self.ensure_workspace_cache_entry_dir(input.cache_key)
+            .await?;
+        secure_workspace_cache_publication_file(input.active_image)?;
         let tmp = self.workspace_image_cache_tmp_image(input.cache_key, input.run_id);
         let _ = remove_workspace_cache_path_if_exists(&tmp).await;
         let rename_started = Instant::now();
@@ -867,6 +870,10 @@ impl WorkspaceImageCache {
                 return Err(e.into());
             }
         };
+        if let Err(e) = secure_workspace_cache_publication_file(&tmp) {
+            let _ = remove_workspace_cache_path_if_exists(&tmp).await;
+            return Err(e);
+        }
         let tmp_metadata = match fs::symlink_metadata(&tmp).await {
             Ok(metadata) => metadata,
             Err(e) => {
@@ -1242,6 +1249,19 @@ impl WorkspaceImagePromotionContext {
                 }
             }
         };
+        if let Err(e) = self
+            .cache
+            .ensure_workspace_cache_entry_dir(&self.cache_key)
+            .await
+        {
+            info!(
+                run_id = %self.run_id,
+                cache_key = self.cache_key,
+                error = %e,
+                "workspace image cache sidecar staging skipped: cache entry permission setup failed"
+            );
+            return None;
+        }
         Some(WorkspaceSessionHistorySidecarEntryGuard {
             cache: self.cache.clone(),
             cache_key: self.cache_key.clone(),

--- a/crates/runner/src/workspace_image_cache/metadata.rs
+++ b/crates/runner/src/workspace_image_cache/metadata.rs
@@ -10,7 +10,7 @@ use crate::ids::RunId;
 use crate::storage_fingerprints::StorageFingerprints;
 
 use super::fs::{
-    allocated_bytes, ensure_workspace_cache_entry_dir, remove_workspace_cache_path_if_exists,
+    allocated_bytes, remove_workspace_cache_path_if_exists, secure_workspace_cache_publication_file,
 };
 use super::types::WorkspaceCacheTerminalStatus;
 use super::{CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceImageCache};
@@ -141,15 +141,17 @@ impl WorkspaceImageCache {
     ) -> RunnerResult<()> {
         let metadata_path = self.workspace_image_cache_metadata(cache_key);
         let tmp = metadata_path.with_file_name(format!("metadata.json.tmp.{run_id}"));
-        if let Some(parent) = metadata_path.parent() {
-            ensure_workspace_cache_entry_dir(parent).await?;
-        }
+        self.ensure_workspace_cache_entry_dir(cache_key).await?;
         let bytes = serde_json::to_vec_pretty(&metadata)
             .map_err(|e| RunnerError::Internal(format!("serialize workspace metadata: {e}")))?;
         let _ = remove_workspace_cache_path_if_exists(&tmp).await;
         if let Err(e) = fs::write(&tmp, bytes).await {
             let _ = remove_workspace_cache_path_if_exists(&tmp).await;
             return Err(e.into());
+        }
+        if let Err(e) = secure_workspace_cache_publication_file(&tmp) {
+            let _ = remove_workspace_cache_path_if_exists(&tmp).await;
+            return Err(e);
         }
         if let Err(e) = fs::rename(&tmp, &metadata_path).await {
             let _ = remove_workspace_cache_path_if_exists(&tmp).await;

--- a/crates/runner/src/workspace_image_cache/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/sidecar.rs
@@ -56,7 +56,7 @@ use crate::ids::RunId;
 use crate::restored_session_identity::{RestoredSessionIdentity, RestoredSessionIdentityFields};
 
 use super::fs::{
-    ensure_workspace_cache_entry_dir, remove_workspace_cache_path_if_exists,
+    remove_workspace_cache_path_if_exists, secure_workspace_cache_publication_file,
     workspace_cache_existing_path_allocated_bytes,
 };
 use super::metadata::WorkspaceImageFileIdentity;
@@ -301,6 +301,7 @@ impl WorkspaceImageCache {
         paths: &CacheEntryPaths,
         source: &WorkspaceSessionHistorySidecarPromotionSource,
     ) -> RunnerResult<()> {
+        self.ensure_workspace_cache_entry_dir(cache_key).await?;
         let tmp_metadata = fs::symlink_metadata(&source.tmp_path).await?;
         if !tmp_metadata.is_file()
             || tmp_metadata.len() != source.encoded_size
@@ -309,6 +310,10 @@ impl WorkspaceImageCache {
         {
             let _ = remove_workspace_cache_path_if_exists(&source.tmp_path).await;
             return Ok(());
+        }
+        if let Err(e) = secure_workspace_cache_publication_file(&source.tmp_path) {
+            let _ = remove_workspace_cache_path_if_exists(&source.tmp_path).await;
+            return Err(e);
         }
         let previous_metadata = self
             .read_session_history_sidecar_metadata(paths.session_history_sidecar_metadata())
@@ -321,7 +326,6 @@ impl WorkspaceImageCache {
             let _ = remove_workspace_cache_path_if_exists(&source.tmp_path).await;
             return Ok(());
         };
-        ensure_workspace_cache_entry_dir(paths.entry_dir()).await?;
         let tmp_metadata_path = self.workspace_image_cache_tmp_sidecar_metadata(cache_key, run_id);
         let sidecar_metadata_path = paths.session_history_sidecar_metadata();
         let sidecar_body_path = paths.entry_dir().join(body_slot.file_name());
@@ -333,6 +337,11 @@ impl WorkspaceImageCache {
             let _ = remove_workspace_cache_path_if_exists(&tmp_metadata_path).await;
             let _ = remove_workspace_cache_path_if_exists(&source.tmp_path).await;
             return Err(e.into());
+        }
+        if let Err(e) = secure_workspace_cache_publication_file(&tmp_metadata_path) {
+            let _ = remove_workspace_cache_path_if_exists(&tmp_metadata_path).await;
+            let _ = remove_workspace_cache_path_if_exists(&source.tmp_path).await;
+            return Err(e);
         }
         if let Err(e) = fs::rename(&source.tmp_path, &sidecar_body_path).await {
             let _ = remove_workspace_cache_path_if_exists(&tmp_metadata_path).await;

--- a/crates/runner/src/workspace_image_cache/tests/promotion.rs
+++ b/crates/runner/src/workspace_image_cache/tests/promotion.rs
@@ -1,4 +1,8 @@
-use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::Path;
+use std::time::Duration;
+
+use nix::sys::stat::Mode;
 
 use tokio::fs;
 
@@ -16,7 +20,35 @@ use super::support::{
 use crate::error::RunnerError;
 use crate::ids::RunId;
 use crate::paths::{RunnerPaths, workspace_image_cache_key};
+use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::storage_fingerprints::StorageFingerprints;
+use crate::test_fixtures::ignored_child::{
+    ignored_child_test_env_guard_enabled, run_ignored_child_test,
+};
+
+const PERMISSIVE_UMASK_CHILD_ENV: &str = "VM0_RUN_WORKSPACE_CACHE_PERMISSIVE_UMASK_TEST";
+
+fn mode(path: &Path) -> u32 {
+    std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+}
+
+struct UmaskGuard {
+    original: Mode,
+}
+
+impl UmaskGuard {
+    fn set(mask: Mode) -> Self {
+        Self {
+            original: nix::sys::stat::umask(mask),
+        }
+    }
+}
+
+impl Drop for UmaskGuard {
+    fn drop(&mut self) {
+        nix::sys::stat::umask(self.original);
+    }
+}
 
 async fn cross_filesystem_cache(
     fs_stats: FsStats,
@@ -429,6 +461,86 @@ async fn consumed_cache_hit_promotion_moves_active_image_back_to_cache() {
 }
 
 #[tokio::test]
+async fn promotion_enforces_private_permissions_under_permissive_umask() {
+    run_ignored_child_test(
+        "workspace_image_cache::tests::promotion::promotion_enforces_private_permissions_under_permissive_umask_child",
+        (PERMISSIVE_UMASK_CHILD_ENV, "1"),
+        &[],
+        Duration::from_secs(60),
+    )
+    .await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn promotion_enforces_private_permissions_under_permissive_umask_child() {
+    if !ignored_child_test_env_guard_enabled((PERMISSIVE_UMASK_CHILD_ENV, "1")) {
+        return;
+    }
+
+    let _umask = UmaskGuard::set(Mode::from_bits_truncate(0o022));
+    let (_dir, paths, cache) = local_cache().await;
+    let run_id = RunId::new_v4();
+    let sandbox_id = sandbox::SandboxId::new_v4();
+    let reuse_key = "sess-private-permissions";
+    let image = b"private workspace image";
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                reuse_key: Some(reuse_key),
+                working_dir: "/workspace",
+                image_size_bytes: image.len() as u64,
+            },
+            workspace_drive_required: false,
+        })
+        .await;
+    let active_image = paths.active_workspace_image(&sandbox_id);
+    fs::create_dir_all(active_image.parent().unwrap())
+        .await
+        .unwrap();
+    fs::write(&active_image, image).await.unwrap();
+    fs::set_permissions(&active_image, std::fs::Permissions::from_mode(0o644))
+        .await
+        .unwrap();
+    let active_metadata = fs::metadata(&active_image).await.unwrap();
+    let active_identity = (active_metadata.dev(), active_metadata.ino());
+
+    assert!(
+        lease
+            .promote(
+                run_id,
+                WorkspaceCacheTerminalStatus::Success,
+                "2026-05-02T00:00:00.000Z".into(),
+                &StorageFingerprints::default(),
+            )
+            .await
+            .unwrap()
+    );
+
+    let cache_key = cache.scoped_cache_key(
+        TEST_PROFILE_NAME,
+        reuse_key,
+        "/workspace",
+        image.len() as u64,
+    );
+    let entry_dir = cache.workspace_image_cache_entry_dir(&cache_key);
+    let current = cache.workspace_image_cache_current_image(&cache_key);
+    let metadata = cache.workspace_image_cache_metadata(&cache_key);
+    let current_metadata = fs::metadata(&current).await.unwrap();
+    assert_eq!(
+        active_identity,
+        (current_metadata.dev(), current_metadata.ino())
+    );
+    assert_eq!(mode(cache.workspace_image_cache_dir()), 0o700);
+    assert_eq!(mode(&entry_dir), 0o700);
+    assert_eq!(mode(&current), 0o600);
+    assert_eq!(mode(&metadata), 0o600);
+}
+
+#[tokio::test]
 async fn cross_filesystem_promotion_falls_back_to_sparse_copy() {
     let (_runner_dir, _cache_dir, paths, cache) = cross_filesystem_cache(FsStats {
         total_bytes: TEST_FS_TOTAL_BYTES,
@@ -458,6 +570,9 @@ async fn cross_filesystem_promotion_falls_back_to_sparse_copy() {
         .await
         .unwrap();
     fs::write(&active_image, &image).await.unwrap();
+    fs::set_permissions(&active_image, std::fs::Permissions::from_mode(0o644))
+        .await
+        .unwrap();
 
     assert!(
         lease
@@ -486,6 +601,120 @@ async fn cross_filesystem_promotion_falls_back_to_sparse_copy() {
     assert_ne!(
         fs::metadata(&active_image).await.unwrap().dev(),
         fs::metadata(&current).await.unwrap().dev()
+    );
+    assert_eq!(mode(cache.workspace_image_cache_dir()), 0o700);
+    assert_eq!(
+        mode(&cache.workspace_image_cache_entry_dir(&cache_key)),
+        0o700
+    );
+    assert_eq!(mode(&current), 0o600);
+    assert_eq!(
+        mode(&cache.workspace_image_cache_metadata(&cache_key)),
+        0o600
+    );
+}
+
+#[tokio::test]
+async fn promotion_rejects_group_writable_image_without_publishing_metadata() {
+    let (_dir, paths, cache) = local_cache().await;
+    let run_id = RunId::new_v4();
+    let sandbox_id = sandbox::SandboxId::new_v4();
+    let reuse_key = "sess-group-writable-image";
+    let image = b"unsafe workspace image";
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                reuse_key: Some(reuse_key),
+                working_dir: "/workspace",
+                image_size_bytes: image.len() as u64,
+            },
+            workspace_drive_required: false,
+        })
+        .await;
+    let active_image = paths.active_workspace_image(&sandbox_id);
+    fs::create_dir_all(active_image.parent().unwrap())
+        .await
+        .unwrap();
+    fs::write(&active_image, image).await.unwrap();
+    fs::set_permissions(&active_image, std::fs::Permissions::from_mode(0o660))
+        .await
+        .unwrap();
+
+    let error = lease
+        .promote(
+            run_id,
+            WorkspaceCacheTerminalStatus::Success,
+            "2026-05-02T00:00:00.000Z".into(),
+            &StorageFingerprints::default(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("group/other writable"));
+    assert!(active_image.exists());
+    let cache_key = cache.scoped_cache_key(
+        TEST_PROFILE_NAME,
+        reuse_key,
+        "/workspace",
+        image.len() as u64,
+    );
+    assert!(
+        !cache
+            .workspace_image_cache_current_image(&cache_key)
+            .exists()
+    );
+    assert!(!cache.workspace_image_cache_metadata(&cache_key).exists());
+}
+
+#[tokio::test]
+async fn sidecar_staging_guard_secures_cache_directories_before_copy() {
+    let (_dir, _paths, cache) = local_cache().await;
+    let run_id = RunId::new_v4();
+    let sandbox_id = sandbox::SandboxId::new_v4();
+    let reuse_key = "sess-sidecar-staging-permissions";
+    let image_size_bytes = 4096;
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                reuse_key: Some(reuse_key),
+                working_dir: "/workspace",
+                image_size_bytes,
+            },
+            workspace_drive_required: false,
+        })
+        .await;
+    let restored_session_identity = RestoredSessionIdentity::claude_code_for_test("history-hash");
+    let promotion = lease
+        .into_promotion_context(WorkspaceImagePromotionRequest {
+            run_id,
+            sandbox_id,
+            restored_session_identity: Some(&restored_session_identity),
+            terminal_status: WorkspaceCacheTerminalStatus::Success,
+            completed_at: "2026-05-02T00:00:00.000Z".into(),
+            storage_fingerprints: StorageFingerprints::default(),
+        })
+        .unwrap();
+
+    let guard = promotion
+        .try_acquire_session_history_sidecar_entry_guard()
+        .await
+        .unwrap();
+    let cache_key =
+        cache.scoped_cache_key(TEST_PROFILE_NAME, reuse_key, "/workspace", image_size_bytes);
+    assert_eq!(mode(cache.workspace_image_cache_dir()), 0o700);
+    assert_eq!(
+        mode(&cache.workspace_image_cache_entry_dir(&cache_key)),
+        0o700
+    );
+    assert_eq!(
+        guard.session_history_sidecar_tmp_path(),
+        cache.workspace_image_cache_tmp_sidecar(&cache_key, run_id)
     );
 }
 

--- a/crates/runner/src/workspace_image_cache/tests/promotion.rs
+++ b/crates/runner/src/workspace_image_cache/tests/promotion.rs
@@ -20,7 +20,6 @@ use super::support::{
 use crate::error::RunnerError;
 use crate::ids::RunId;
 use crate::paths::{RunnerPaths, workspace_image_cache_key};
-use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::test_fixtures::ignored_child::{
     ignored_child_test_env_guard_enabled, run_ignored_child_test,
@@ -667,55 +666,6 @@ async fn promotion_rejects_group_writable_image_without_publishing_metadata() {
             .exists()
     );
     assert!(!cache.workspace_image_cache_metadata(&cache_key).exists());
-}
-
-#[tokio::test]
-async fn sidecar_staging_guard_secures_cache_directories_before_copy() {
-    let (_dir, _paths, cache) = local_cache().await;
-    let run_id = RunId::new_v4();
-    let sandbox_id = sandbox::SandboxId::new_v4();
-    let reuse_key = "sess-sidecar-staging-permissions";
-    let image_size_bytes = 4096;
-    let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
-            identity: WorkspaceImageLeaseIdentity {
-                run_id,
-                sandbox_id,
-                profile_name: TEST_PROFILE_NAME,
-                reuse_key: Some(reuse_key),
-                working_dir: "/workspace",
-                image_size_bytes,
-            },
-            workspace_drive_required: false,
-        })
-        .await;
-    let restored_session_identity = RestoredSessionIdentity::claude_code_for_test("history-hash");
-    let promotion = lease
-        .into_promotion_context(WorkspaceImagePromotionRequest {
-            run_id,
-            sandbox_id,
-            restored_session_identity: Some(&restored_session_identity),
-            terminal_status: WorkspaceCacheTerminalStatus::Success,
-            completed_at: "2026-05-02T00:00:00.000Z".into(),
-            storage_fingerprints: StorageFingerprints::default(),
-        })
-        .unwrap();
-
-    let guard = promotion
-        .try_acquire_session_history_sidecar_entry_guard()
-        .await
-        .unwrap();
-    let cache_key =
-        cache.scoped_cache_key(TEST_PROFILE_NAME, reuse_key, "/workspace", image_size_bytes);
-    assert_eq!(mode(cache.workspace_image_cache_dir()), 0o700);
-    assert_eq!(
-        mode(&cache.workspace_image_cache_entry_dir(&cache_key)),
-        0o700
-    );
-    assert_eq!(
-        guard.session_history_sidecar_tmp_path(),
-        cache.workspace_image_cache_tmp_sidecar(&cache_key, run_id)
-    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/workspace_image_cache/tests/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/tests/sidecar.rs
@@ -1,4 +1,5 @@
-use std::os::unix::fs::symlink;
+use std::os::unix::fs::{PermissionsExt, symlink};
+use std::path::Path;
 
 use api_contracts::generated::constants::runners::{
     RESUME_SESSION_HISTORY_MAX_BYTES, paths::CANONICAL_WORKING_DIR,
@@ -21,6 +22,10 @@ use crate::paths::RunnerPaths;
 use crate::restored_session_identity::{RestoredSessionFramework, RestoredSessionIdentity};
 use crate::types::ResumeSessionHistoryRefKind;
 
+fn mode(path: &Path) -> u32 {
+    std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+}
+
 fn test_restored_session_identity(session_id: &str, history: &[u8]) -> RestoredSessionIdentity {
     RestoredSessionIdentity::new(
         RestoredSessionFramework::ClaudeCode,
@@ -40,6 +45,9 @@ async fn publish_test_session_history_sidecar(
 ) -> RestoredSessionIdentity {
     let tmp_path = cache.workspace_image_cache_tmp_sidecar(cache_key, run_id);
     fs::write(&tmp_path, history).await.unwrap();
+    fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o644))
+        .await
+        .unwrap();
     let identity = test_restored_session_identity(session_id, history);
     let source = WorkspaceSessionHistorySidecarPromotionSource {
         tmp_path,
@@ -98,7 +106,105 @@ async fn session_history_sidecar_publish_and_probe_hit() {
         WorkspaceSessionHistorySidecarRepresentation::Raw
     );
     assert_eq!(sidecar.encoded_size, history.len() as u64);
-    assert_eq!(fs::read(sidecar.path).await.unwrap(), history);
+    assert_eq!(fs::read(&sidecar.path).await.unwrap(), history);
+    assert_eq!(mode(cache.workspace_image_cache_dir()), 0o700);
+    assert_eq!(
+        mode(&cache.workspace_image_cache_entry_dir(&cache_key)),
+        0o700
+    );
+    assert_eq!(mode(&metadata_path), 0o600);
+    assert_eq!(mode(&sidecar.path), 0o600);
+}
+
+#[tokio::test]
+async fn session_history_sidecar_rejects_group_writable_source() {
+    let (_dir, paths, cache) = local_cache().await;
+    let run_id = RunId::new_v4();
+    let session_id = "sess-sidecar-group-writable";
+    let history = br#"{"type":"message","content":"unsafe"}"#;
+    let cache_key = write_current_cache_entry(
+        &cache,
+        run_id,
+        session_id,
+        CANONICAL_WORKING_DIR,
+        "2026-05-01T00:00:00.000Z",
+        "2026-05-01T00:00:00.000Z",
+    )
+    .await;
+    let tmp_path = cache.workspace_image_cache_tmp_sidecar(&cache_key, run_id);
+    fs::write(&tmp_path, history).await.unwrap();
+    fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o660))
+        .await
+        .unwrap();
+    let source = WorkspaceSessionHistorySidecarPromotionSource {
+        tmp_path: tmp_path.clone(),
+        representation: WorkspaceSessionHistorySidecarRepresentation::Raw,
+        encoded_size: history.len() as u64,
+        restored_session_identity: test_restored_session_identity(session_id, history),
+    };
+
+    let error = cache
+        .publish_session_history_sidecar(
+            &cache_key,
+            run_id,
+            WorkspaceSessionHistorySidecarPublication::Replace(&source),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("group/other writable"));
+    assert!(!tmp_path.exists());
+    assert!(
+        !paths
+            .workspace_image_cache_entry_dir(&cache_key)
+            .join("session-history.metadata.json")
+            .exists()
+    );
+}
+
+#[tokio::test]
+async fn session_history_sidecar_does_not_publish_non_regular_source() {
+    let (dir, paths, cache) = local_cache().await;
+    let run_id = RunId::new_v4();
+    let session_id = "sess-sidecar-symlink-source";
+    let history = br#"{"type":"message","content":"outside"}"#;
+    let cache_key = write_current_cache_entry(
+        &cache,
+        run_id,
+        session_id,
+        CANONICAL_WORKING_DIR,
+        "2026-05-01T00:00:00.000Z",
+        "2026-05-01T00:00:00.000Z",
+    )
+    .await;
+    let outside = dir.path().join("outside-session-history");
+    fs::write(&outside, history).await.unwrap();
+    let tmp_path = cache.workspace_image_cache_tmp_sidecar(&cache_key, run_id);
+    symlink(&outside, &tmp_path).unwrap();
+    let source = WorkspaceSessionHistorySidecarPromotionSource {
+        tmp_path: tmp_path.clone(),
+        representation: WorkspaceSessionHistorySidecarRepresentation::Raw,
+        encoded_size: history.len() as u64,
+        restored_session_identity: test_restored_session_identity(session_id, history),
+    };
+
+    cache
+        .publish_session_history_sidecar(
+            &cache_key,
+            run_id,
+            WorkspaceSessionHistorySidecarPublication::Replace(&source),
+        )
+        .await
+        .unwrap();
+
+    assert!(!tmp_path.exists());
+    assert_eq!(fs::read(&outside).await.unwrap(), history);
+    assert!(
+        !paths
+            .workspace_image_cache_entry_dir(&cache_key)
+            .join("session-history.metadata.json")
+            .exists()
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -1,6 +1,8 @@
 use super::test_support::{TEST_WORKSPACE_IMAGE_SIZE_BYTES, WorkspacePromotionFixture};
 use super::*;
 
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -27,6 +29,10 @@ use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::workspace_image_cache::{
     WorkspaceCacheCheckoutResult, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
 };
+
+fn mode(path: &Path) -> u32 {
+    std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+}
 
 async fn mock_sandbox_with_overrides(
     sandbox_id: SandboxId,
@@ -398,6 +404,38 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
     assert_eq!(tokio::fs::read(sidecar.path).await.unwrap(), history);
 }
 
+#[tokio::test]
+async fn active_workspace_permission_failure_skips_cache_publication() {
+    let fixture = WorkspacePromotionFixture::new("sess-active-permission-failure").await;
+    let paths = crate::paths::RunnerPaths::new(fixture._dir.path().join("runner"));
+    let active_image = paths.active_workspace_image(&fixture.sandbox_id);
+    tokio::fs::set_permissions(&active_image, std::fs::Permissions::from_mode(0o660))
+        .await
+        .unwrap();
+    let cache = fixture.cache.clone();
+    let reuse_key = fixture.reuse_key.clone();
+    let sandbox = MockSandbox::new(fixture.sandbox_id.to_string());
+
+    let (promoted, events) = capture_promotion_events(prepare_and_publish_workspace_image(
+        &sandbox,
+        fixture.promotion,
+    ))
+    .await;
+
+    assert!(!promoted);
+    let event = captured_event(&events, "workspace image cache promotion failed");
+    assert!(
+        event
+            .fields
+            .get("error")
+            .is_some_and(|error| error.contains("group/other writable"))
+    );
+    assert_eq!(
+        WorkspacePromotionFixture::checkout_result(&cache, &reuse_key).await,
+        WorkspaceCacheCheckoutResult::Miss
+    );
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn active_workspace_promotion_keeps_history_read_failure_warning() {
     let reuse_key = "thread:active-sidecar-read-failure";
@@ -468,6 +506,9 @@ async fn session_history_sidecar_staging_is_protected_from_gc() {
                 let entry_dir = tmp_path.parent().unwrap();
                 assert!(tmp_path.is_file());
                 assert!(entry_dir.is_dir());
+                assert_eq!(mode(entry_dir.parent().unwrap()), 0o700);
+                assert_eq!(mode(entry_dir), 0o700);
+                assert_eq!(mode(tmp_path), 0o600);
 
                 let freed = cache.gc(false).await.unwrap();
 


### PR DESCRIPTION
## Summary

- enforce `0700` on workspace cache roots and publication entries through the existing descriptor-based host filesystem policy
- validate and tighten workspace images, metadata, and session-history sidecars to owner-owned regular `0600` files before publication
- secure sidecar entry directories before guest-copy staging and keep permission failures on the existing best-effort cache path
- cover permissive umask, rename and cross-filesystem copy, sidecar staging/publication, and unsafe source rejection

## Explicit exclusions

- no eager migration, recursive scan, or cleanup of untouched legacy cache artifacts
- no process-wide umask change
- no database schema, persisted cache format, API, or runner protocol change

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --bin runner workspace_image_cache`
- `cargo test -p runner --bin runner`

Closes #25209
