### PR TITLE
feat(connectors): capture stripe oauth livemode

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -104,7 +104,7 @@ const PRIVATE_VALUE = "SECRET_TOKEN";
 const DEFAULT_API_VERSION = apiPackage.version;
 const ZERO_DIGEST = `sha256:${"0".repeat(64)}`;
 const EXPECTED_CAPABILITY_DIGEST =
-  "sha256:f28faa130eeea8dbc27f816003b6fe162dc1792dd27f5e9173856c5bedb7eea7";
+  "sha256:343b46bc40d126a2c1174e2019f113576669dd79478d66095175824f2eb0b935";
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";

--- a/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
@@ -369,6 +369,7 @@ interface StandardOauthMethodArgs {
   readonly connectorSlug: string;
   readonly prefix: string;
   readonly tokenEnvironmentNames: readonly string[];
+  readonly additionalValues?: Readonly<Record<string, string>>;
   readonly scopes?: readonly string[];
   readonly featureSwitch?: string;
   readonly label?: string;
@@ -384,6 +385,7 @@ function standardOauthMethod(
   const accessTokenRef = secret(accessTokenName);
   const values = {
     accessToken: accessTokenRef,
+    ...args.additionalValues,
     refreshToken: secret(refreshTokenName),
   };
   return providerMethod({
@@ -1497,6 +1499,7 @@ const connectors = [
         connectorSlug: "stripe",
         prefix: "STRIPE",
         tokenEnvironmentNames: ["STRIPE_TOKEN"],
+        additionalValues: { livemode: variable("STRIPE_LIVEMODE") },
         scopes: ["read_write"],
       }),
       manualMethod({

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/stripe.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/stripe.test.ts
@@ -1,0 +1,124 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import type { StaticConfidentialConnectorAuthClient } from "../../../connector-auth-method";
+import type { ConnectorAuthCodeGrantConfig } from "../../../connector-config";
+import { CONNECTOR_AUTH_PROVIDER_METHOD_REGISTRATIONS } from "../../provider-capabilities";
+import { server } from "../../__tests__/test-server";
+import { stripeProvider } from "../stripe/provider";
+import { authCodeGrantFixture } from "./auth-code-grant-fixture";
+
+const TOKEN_URL = "https://connect.stripe.com/oauth/token";
+const ACCOUNT_URL = "https://api.stripe.com/v1/account";
+const AUTH_CODE_GRANT = {
+  ...authCodeGrantFixture(["read_write"]),
+  outputs: {
+    accessToken: "$secrets.STRIPE_ACCESS_TOKEN",
+    livemode: "$vars.STRIPE_LIVEMODE",
+    refreshToken: "$secrets.STRIPE_REFRESH_TOKEN",
+  },
+} satisfies ConnectorAuthCodeGrantConfig;
+const TEST_AUTH_CLIENT = {
+  clientRegistration: "static",
+  clientType: "confidential",
+  clientId: "client-id",
+  clientSecret: "client-secret",
+} satisfies StaticConfidentialConnectorAuthClient;
+
+function exchangeCode() {
+  return stripeProvider.grant.exchangeCode({
+    authCodeGrant: AUTH_CODE_GRANT,
+    authClient: TEST_AUTH_CLIENT,
+    code: "auth-code",
+    redirectUri: "https://example.com/callback",
+  });
+}
+
+describe("connector/providers/stripe", () => {
+  it.each([
+    { livemode: true, output: "true" },
+    { livemode: false, output: "false" },
+  ])(
+    "emits OAuth livemode $livemode as the canonical string",
+    async ({ livemode, output }) => {
+      server.use(
+        http.post(TOKEN_URL, () => {
+          return HttpResponse.json({
+            access_token: "stripe-access-token",
+            livemode,
+            refresh_token: "stripe-refresh-token",
+            scope: "read_write",
+            stripe_user_id: "acct_123",
+          });
+        }),
+        http.get(ACCOUNT_URL, () => {
+          return HttpResponse.json({
+            id: "acct_123",
+            business_profile: { name: "Stripe account" },
+            email: "owner@example.com",
+          });
+        }),
+      );
+
+      await expect(exchangeCode()).resolves.toEqual({
+        outputs: {
+          accessToken: "stripe-access-token",
+          livemode: output,
+          refreshToken: "stripe-refresh-token",
+        },
+        scopes: ["read_write"],
+        userInfo: {
+          id: "acct_123",
+          username: "Stripe account",
+          email: "owner@example.com",
+        },
+      });
+    },
+  );
+
+  it("rejects an OAuth token response without livemode", async () => {
+    server.use(
+      http.post(TOKEN_URL, () => {
+        return HttpResponse.json({
+          access_token: "stripe-access-token",
+          refresh_token: "stripe-refresh-token",
+          stripe_user_id: "acct_123",
+        });
+      }),
+    );
+
+    await expect(exchangeCode()).rejects.toThrow(/livemode/u);
+  });
+
+  it("rejects a non-Boolean OAuth livemode", async () => {
+    server.use(
+      http.post(TOKEN_URL, () => {
+        return HttpResponse.json({
+          access_token: "stripe-access-token",
+          livemode: "true",
+          refresh_token: "stripe-refresh-token",
+          stripe_user_id: "acct_123",
+        });
+      }),
+    );
+
+    await expect(exchangeCode()).rejects.toThrow(/livemode/u);
+  });
+
+  it("declares the exact Stripe OAuth grant outputs", () => {
+    const registration = CONNECTOR_AUTH_PROVIDER_METHOD_REGISTRATIONS.find(
+      (candidate) => {
+        return (
+          candidate.connectorSlug === "stripe" &&
+          candidate.authMethodId === "oauth"
+        );
+      },
+    );
+
+    expect(registration?.contract.grant.outputNames).toEqual([
+      "accessToken",
+      "livemode",
+      "refreshToken",
+    ]);
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/connectors/stripe/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/stripe/oauth.ts
@@ -17,6 +17,7 @@ interface StripeUserInfo {
 
 interface StripeTokenResult {
   accessToken: string;
+  livemode: boolean;
   refreshToken: string | null;
   scopes: string[];
   userInfo: StripeUserInfo;
@@ -78,6 +79,7 @@ export async function exchangeStripeCode(
   const data = z
     .object({
       access_token: z.string().optional(),
+      livemode: z.boolean(),
       refresh_token: z.string().nullable().optional(),
       stripe_user_id: z.string().optional(),
       scope: z.string().optional(),
@@ -104,6 +106,7 @@ export async function exchangeStripeCode(
 
   return {
     accessToken: data.access_token,
+    livemode: data.livemode,
     refreshToken: data.refresh_token ?? null,
     scopes: data.scope ? data.scope.split(" ") : [],
     userInfo,

--- a/turbo/packages/connectors/src/auth-providers/connectors/stripe/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/stripe/provider.ts
@@ -34,6 +34,7 @@ export const stripeProvider: AuthCodeConnectorAuthProvider<"stripe"> = {
       return {
         outputs: {
           accessToken: result.accessToken,
+          livemode: result.livemode ? "true" : "false",
           refreshToken: result.refreshToken,
         },
         scopes: result.scopes,

--- a/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
@@ -1721,7 +1721,7 @@ export const CONNECTOR_AUTH_PROVIDER_METHOD_REGISTRATIONS = [
       grant: {
         kind: "auth-code",
         callbackOrigin: "web",
-        outputNames: ["accessToken", "refreshToken"],
+        outputNames: ["accessToken", "livemode", "refreshToken"],
         startOptionNames: [],
       },
       access: {


### PR DESCRIPTION
## Summary

- parse Stripe OAuth token response `livemode` as a required Boolean
- emit canonical `"true"` or `"false"` provider grant output while preserving `stripe_user_id` identity and refresh behavior
- register the exact executable grant output set and cover true, false, missing, and malformed responses

## Validation

- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors exec vitest run src/auth-providers/connectors/__tests__/stripe.test.ts`
- focused Prettier check for all changed files

## Rollout

This provider contract must be merged and confirmed deployed before vm0-ai/vm0-connectors#98 is merged or published.

Closes #25222
