### PR TITLE
fix(billing): limit receipt download concurrency

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-invoices.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-invoices.test.ts
@@ -9,6 +9,7 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
 import { mockListStripeInvoices } from "../../external/stripe-client";
+import { createDeferredPromise } from "../../utils";
 import {
   deleteInvoicesOrg$,
   seedInvoicesOrg$,
@@ -241,6 +242,163 @@ describe("GET /api/zero/billing/invoices", () => {
     expect(archive.readAsText("receipt-INV-JULY-002.pdf")).toBe(
       "second receipt",
     );
+  });
+
+  it("limits concurrent receipt downloads and retries transient failures", async () => {
+    const customerId = `cus-bounded-${randomUUID().slice(0, 8)}`;
+    const fixture = await track(
+      store.set(
+        seedInvoicesOrg$,
+        {
+          stripeCustomerId: customerId,
+          stripeSubscriptionId: `sub-bounded-${randomUUID().slice(0, 8)}`,
+          subscriptionStatus: "active",
+          tier: "pro",
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const invoices = Array.from({ length: 11 }, (_, index) => {
+      const suffix = String(index + 1).padStart(3, "0");
+      return {
+        id: `inv_bounded_${suffix}`,
+        number: `INV-BOUNDED-${suffix}`,
+        created: Date.UTC(2026, 6, 10) / 1000,
+        amount_paid: 2000,
+        status: "paid",
+        hosted_invoice_url: `https://stripe.test/invoice/inv_bounded_${suffix}`,
+        invoice_pdf: `https://stripe.test/receipts/inv_bounded_${suffix}`,
+      };
+    });
+    mockListStripeInvoices(() => {
+      return Promise.resolve(invoices);
+    });
+
+    const firstWaveStarted = createDeferredPromise<void>(context.signal);
+    const releaseFirstWave = createDeferredPromise<void>(context.signal);
+    let firstWaveRequests = 0;
+    let activeDownloads = 0;
+    let maxActiveDownloads = 0;
+    let transientAttempts = 0;
+    server.use(
+      http.get(
+        "https://stripe.test/receipts/:invoiceId",
+        async ({ params }) => {
+          activeDownloads += 1;
+          maxActiveDownloads = Math.max(maxActiveDownloads, activeDownloads);
+          firstWaveRequests += 1;
+          if (firstWaveRequests <= 10) {
+            if (firstWaveRequests === 10) {
+              firstWaveStarted.resolve(undefined);
+            }
+            await releaseFirstWave.promise;
+          }
+
+          const invoiceId = String(params.invoiceId);
+          let response: Response;
+          if (invoiceId === "inv_bounded_002") {
+            transientAttempts += 1;
+            if (transientAttempts === 1) {
+              response = new HttpResponse(null, { status: 429 });
+            } else if (transientAttempts === 2) {
+              response = new HttpResponse(null, { status: 503 });
+            } else {
+              response = new HttpResponse(`receipt for ${invoiceId}`, {
+                headers: { "Content-Type": "application/pdf" },
+              });
+            }
+          } else {
+            response = new HttpResponse(`receipt for ${invoiceId}`, {
+              headers: { "Content-Type": "application/pdf" },
+            });
+          }
+          activeDownloads -= 1;
+          return response;
+        },
+      ),
+    );
+
+    const client = setupApp({ context })(zeroBillingInvoicesContract);
+    const responsePromise = accept(
+      client.downloadReceipts({
+        headers: { authorization: "Bearer clerk-session" },
+        query: { startMonth: "2026-07", endMonth: "2026-07" },
+      }),
+      [200],
+    );
+    await firstWaveStarted.promise;
+    const nextTurn = createDeferredPromise<void>(context.signal);
+    setImmediate(() => {
+      nextTurn.resolve(undefined);
+    });
+    await nextTurn.promise;
+    releaseFirstWave.resolve(undefined);
+    const response = await responsePromise;
+
+    expect(maxActiveDownloads).toBe(10);
+    expect(transientAttempts).toBe(3);
+    const archive = new AdmZip(Buffer.from(await response.body.arrayBuffer()));
+    expect(archive.getEntries()).toHaveLength(11);
+    expect(archive.readAsText("receipt-INV-BOUNDED-002.pdf")).toBe(
+      "receipt for inv_bounded_002",
+    );
+  });
+
+  it("returns 502 after transient receipt retries are exhausted", async () => {
+    const customerId = `cus-failed-receipt-${randomUUID().slice(0, 8)}`;
+    const fixture = await track(
+      store.set(
+        seedInvoicesOrg$,
+        {
+          stripeCustomerId: customerId,
+          stripeSubscriptionId: `sub-failed-receipt-${randomUUID().slice(0, 8)}`,
+          subscriptionStatus: "active",
+          tier: "pro",
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    mockListStripeInvoices(() => {
+      return Promise.resolve([
+        {
+          id: "inv_failed_receipt",
+          number: "INV-FAILED-RECEIPT",
+          created: Date.UTC(2026, 6, 10) / 1000,
+          amount_paid: 2000,
+          status: "paid",
+          hosted_invoice_url: "https://stripe.test/invoice/inv_failed_receipt",
+          invoice_pdf: "https://stripe.test/receipts/inv_failed_receipt",
+        },
+      ]);
+    });
+    let attempts = 0;
+    server.use(
+      http.get("https://stripe.test/receipts/inv_failed_receipt", () => {
+        attempts += 1;
+        return new HttpResponse(null, { status: 503 });
+      }),
+    );
+
+    const client = setupApp({ context })(zeroBillingInvoicesContract);
+    const response = await accept(
+      client.downloadReceipts({
+        headers: { authorization: "Bearer clerk-session" },
+        query: { startMonth: "2026-07", endMonth: "2026-07" },
+      }),
+      [502],
+    );
+
+    expect(attempts).toBe(3);
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Failed to download receipts from Stripe",
+        code: "BAD_GATEWAY",
+      },
+    });
   });
 
   it("returns an empty list when the org has no Stripe customer", async () => {

--- a/turbo/apps/api/src/signals/services/zero-billing-invoices.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-invoices.service.ts
@@ -3,6 +3,7 @@ import { command, computed, type Computed } from "ccstate";
 import type { BillingInvoicesResponse } from "@vm0/api-contracts/contracts/zero-billing";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { eq } from "drizzle-orm";
+import { delay } from "signal-timers";
 
 import { db$ } from "../external/db";
 import { listStripeInvoices } from "../external/stripe-client";
@@ -28,6 +29,16 @@ interface ReceiptEntry {
   readonly content: Buffer;
 }
 
+interface ReceiptDownload {
+  readonly id: string;
+  readonly number: string | null;
+  readonly url: string;
+}
+
+const RECEIPT_DOWNLOAD_CONCURRENCY = 10;
+const RECEIPT_DOWNLOAD_ATTEMPTS = 3;
+const RECEIPT_DOWNLOAD_RETRY_BASE_DELAY_MS = 500;
+
 function monthlyRange(
   startMonth: string,
   endMonth: string,
@@ -48,6 +59,71 @@ function monthlyRange(
 function receiptFilename(invoiceNumber: string | null, id: string): string {
   const reference = (invoiceNumber ?? id).replace(/[^a-zA-Z0-9._-]+/gu, "-");
   return `receipt-${reference}.pdf`;
+}
+
+async function downloadReceipt(
+  receipt: ReceiptDownload,
+  signal: AbortSignal,
+): Promise<ReceiptEntry | null> {
+  for (let attempt = 0; attempt < RECEIPT_DOWNLOAD_ATTEMPTS; attempt += 1) {
+    const response = await tapError(fetch(receipt.url, { signal }));
+    signal.throwIfAborted();
+    if (!response) {
+      return null;
+    }
+
+    const content = await tapError(response.arrayBuffer());
+    signal.throwIfAborted();
+    if (response.ok) {
+      if (!content) {
+        return null;
+      }
+      return {
+        path: receiptFilename(receipt.number, receipt.id),
+        content: Buffer.from(content),
+      };
+    }
+
+    const retryable = response.status === 429 || response.status >= 500;
+    const hasAnotherAttempt = attempt + 1 < RECEIPT_DOWNLOAD_ATTEMPTS;
+    if (!retryable || !hasAnotherAttempt) {
+      return null;
+    }
+    await delay(RECEIPT_DOWNLOAD_RETRY_BASE_DELAY_MS * 2 ** attempt, {
+      signal,
+    });
+  }
+  return null;
+}
+
+async function downloadReceipts(
+  receipts: readonly ReceiptDownload[],
+  signal: AbortSignal,
+): Promise<readonly (ReceiptEntry | null)[]> {
+  const downloaded: (ReceiptEntry | null | undefined)[] = Array.from({
+    length: receipts.length,
+  });
+  const workerCount = Math.min(RECEIPT_DOWNLOAD_CONCURRENCY, receipts.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async (_, workerIndex) => {
+      for (
+        let receiptIndex = workerIndex;
+        receiptIndex < receipts.length;
+        receiptIndex += workerCount
+      ) {
+        const receipt = receipts[receiptIndex];
+        if (!receipt) {
+          return;
+        }
+        downloaded[receiptIndex] = await downloadReceipt(receipt, signal);
+      }
+    }),
+  );
+
+  return downloaded.map((entry) => {
+    return entry ?? null;
+  });
 }
 
 async function assembleReceiptArchive(
@@ -157,30 +233,23 @@ export const downloadZeroOrgReceiptArchive$ = command(
       monthlyRange(args.startMonth, args.endMonth),
     );
     signal.throwIfAborted();
-    const receipts = invoices.filter((invoice) => {
-      return invoice.invoice_pdf !== null;
+    const receipts = invoices.flatMap((invoice): readonly ReceiptDownload[] => {
+      if (!invoice.invoice_pdf) {
+        return [];
+      }
+      return [
+        {
+          id: invoice.id,
+          number: invoice.number,
+          url: invoice.invoice_pdf,
+        },
+      ];
     });
     if (receipts.length === 0) {
       return { kind: "not_found" };
     }
 
-    const downloaded = await Promise.all(
-      receipts.map(async (invoice) => {
-        const url = invoice.invoice_pdf;
-        if (!url) {
-          return null;
-        }
-        const response = await tapError(fetch(url, { signal }));
-        signal.throwIfAborted();
-        if (!response?.ok) {
-          return null;
-        }
-        return {
-          path: receiptFilename(invoice.number, invoice.id),
-          content: Buffer.from(await response.arrayBuffer()),
-        };
-      }),
-    );
+    const downloaded = await downloadReceipts(receipts, signal);
     signal.throwIfAborted();
     if (
       downloaded.some((entry) => {


### PR DESCRIPTION
## Summary

- cap Stripe receipt PDF downloads at 10 concurrent requests
- retry HTTP 429 and 5xx responses twice with exponential backoff before preserving the existing 502 behavior
- add route integration coverage for the concurrency cap, transient recovery, and exhausted retries

## Context

Monthly archives with many receipts used an unbounded `Promise.all`, causing Stripe's file service to rate-limit part of the batch and fail the entire ZIP download.

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api lint`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-billing-invoices.test.ts` (9 passed)
