### PR TITLE
feat: roll out the pwa chat keyboard gestures switch to all users

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -18,6 +18,9 @@ describe("isFeatureEnabled", () => {
       true,
     );
     expect(isFeatureEnabled(FeatureSwitchKey.TeamsIntegration, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.PwaChatKeyboardGestures, {})).toBe(
+      true,
+    );
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -117,7 +120,6 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.ChatSteer]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.PwaChatKeyboardGestures]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadSidebarAutoOpen]).toBe(
       true,
     );
@@ -147,9 +149,6 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.ChatSteer]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.PwaChatKeyboardGestures]).toBe(
-      false,
-    );
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadSidebarAutoOpen]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -368,8 +368,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "bingjie@vm0.ai",
     description:
       "Keep the PWA chat composer pinned above the software keyboard and support swipe-to-dismiss gestures.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ChatThreadSidebarAutoOpen]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

Full rollout of the `pwaChatKeyboardGestures` feature switch. It was gated to the staff org; it is now globally enabled for everyone.

The switch keeps the PWA chat composer pinned above the software keyboard and enables swipe-to-dismiss gestures. Behavior is still additionally guarded at the call sites by `isStandalonePwa()`, so nothing changes for browser-tab users — only for users running Zero as an installed PWA.

## Changes

- `turbo/packages/core/src/feature-switch.ts` — `enabled: true`, drop the `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` gate.
- `turbo/packages/core/src/__tests__/feature-switch.test.ts` — move the switch out of the staff-org rollout matrix and into the globally-enabled assertions, matching how other fully rolled-out switches (`teamsIntegration`, `customConnectorCliCreate`) are covered.

## Test plan

- CI: `packages/core` feature-switch tests cover the new global state.
- `zero-page/__tests__/chat-lifecycle.test.tsx` parameterizes the switch value, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)