### PR TITLE
fix(chat): show every message attachment above the bubble

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -222,7 +222,7 @@ describe("user messages", () => {
       return element as HTMLElement;
     });
     expect(userMessageElement.textContent).toBe(
-      "Start Archived source with PDForiginal-report.pdf, then " +
+      "Start Archived source with , then " +
         "TXTdeleted-notes.txt.\n" +
         "Use **literal** <span>.",
     );
@@ -244,17 +244,26 @@ describe("user messages", () => {
       image.compareDocumentPosition(userMessageElement) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+    // Resolved files leave the bubble too, so they show the live filename
+    // rather than the snapshot the message was written with.
+    const pdf = screen.getByLabelText(
+      "Open pdf preview for renamed-report.pdf",
+    );
     expect(
-      userMessageElement.querySelector(
-        'button[aria-label="Open pdf preview for original-report.pdf"]',
+      within(screen.getByTestId("message-file-attachments")).getByLabelText(
+        "Open pdf preview for renamed-report.pdf",
       ),
-    ).toBeInTheDocument();
+    ).toBe(pdf);
+    expect(
+      pdf.compareDocumentPosition(userMessageElement) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(screen.getByLabelText("File deleted-notes.txt")).toBeInTheDocument();
     expect(
       screen.queryByText("Legacy structured body should stay hidden"),
     ).not.toBeInTheDocument();
     expect(screen.queryByText("Retired template")).not.toBeInTheDocument();
-    expect(screen.queryByText("renamed-report.pdf")).not.toBeInTheDocument();
+    expect(screen.queryByText("original-report.pdf")).not.toBeInTheDocument();
 
     const literalMarkdown = await screen.findByText(
       "Canonical **bold** remains",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1136,7 +1136,7 @@ describe("zero attachment chips", () => {
     expect(screen.getByText("this is the screencast")).toBeInTheDocument();
   });
 
-  it("shows user video attachments before the text bubble and keeps file chips inline", async () => {
+  it("shows user attachments above the text bubble with media and file chips on separate rows", async () => {
     const videoUrl = "https://cdn.vm7.io/artifacts/test/elevated/clip.mp4";
     const docUrl = "https://cdn.vm7.io/artifacts/test/elevated/README.md";
     mockChatLifecycle(context, {
@@ -1178,12 +1178,25 @@ describe("zero attachment chips", () => {
 
     expect(textBubble).not.toBeNull();
     expect(videoPreview.closest(".zero-chat-bubble-user")).toBeNull();
+    expect(docChip.closest(".zero-chat-bubble-user")).toBeNull();
     expect(
       videoPreview.compareDocumentPosition(textBubble!) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-    expect(docChip.closest(".zero-chat-bubble-user")).toBe(textBubble);
-    expect(docChip.parentElement).toHaveClass("mx-1");
+    expect(
+      docChip.compareDocumentPosition(textBubble!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      within(screen.getByTestId("message-media-attachments")).getByLabelText(
+        "Preview clip.mp4",
+      ),
+    ).toBe(videoPreview);
+    expect(
+      within(screen.getByTestId("message-file-attachments")).getByLabelText(
+        "Open markdown preview for README.md",
+      ),
+    ).toBe(docChip);
   });
 
   it("opens persisted canonical audio, video, and document attachments", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -6354,6 +6354,143 @@ function AttachmentMaterializationState({
   );
 }
 
+// Images and videos render as thumbnails, every other attachment as a chip.
+// The two shapes never share a row, so they are grouped before rendering.
+function isMediaAttachment(attachment: ResolvedMessageAttachment): boolean {
+  return attachment.isImage || attachment.kind === "video";
+}
+
+function MessageAttachment({
+  attachment: a,
+  onImageClick,
+}: {
+  attachment: ResolvedMessageAttachment;
+  onImageClick: (url: string) => void;
+}) {
+  const { t } = useTranslation();
+  const openVideoLightbox = useSet(openAttachmentVideoLightbox$);
+
+  if (a.assetRef && a.assetRef.materialization.status !== "ready") {
+    return <AttachmentMaterializationState attachment={a} />;
+  }
+  if (a.isImage) {
+    return (
+      <ChatImagePreviewLink
+        alt={a.filename}
+        ariaLabel={t(
+          ($) => {
+            return $.chat.attachments.previewFile;
+          },
+          {
+            filename: a.filename,
+          },
+        )}
+        imageClassName="block h-full w-full object-contain"
+        linkClassName={CHAT_INLINE_IMAGE_PREVIEW_CLASS}
+        onPreview={() => {
+          onImageClick(a.url);
+        }}
+        placeholderClassName="h-full w-full"
+        url={a.url}
+      />
+    );
+  }
+  if (a.kind === "video") {
+    return (
+      <ChatVideoPreviewButton
+        ariaLabel={t(
+          ($) => {
+            return $.chat.attachments.previewFile;
+          },
+          {
+            filename: a.filename,
+          },
+        )}
+        buttonClassName={CHAT_INLINE_VIDEO_ATTACHMENT_PREVIEW_CLASS}
+        filename={a.filename}
+        onPreview={() => {
+          openVideoLightbox({
+            url: a.url,
+            filename: a.filename,
+          });
+        }}
+        posterClassName="h-full w-full"
+        url={a.url}
+        videoClassName="h-full w-full object-contain"
+      />
+    );
+  }
+  if (
+    a.kind === "markdown" ||
+    a.kind === "text" ||
+    a.kind === "json" ||
+    a.kind === "csv" ||
+    a.kind === "pdf" ||
+    a.kind === "html"
+  ) {
+    return (
+      <PreviewableFileAttachmentChip
+        filename={a.filename}
+        url={a.url}
+        kind={a.kind}
+        text$={a.text$}
+      />
+    );
+  }
+  if (a.kind === "audio") {
+    return (
+      <PreviewableAudioAttachmentChip
+        filename={a.filename}
+        url={a.url}
+        contentType={a.contentType}
+      />
+    );
+  }
+  return (
+    <FileAttachmentChip
+      filename={a.filename}
+      url={a.url}
+      contentType={a.contentType}
+    />
+  );
+}
+
+function UserMessageAttachmentRow({
+  align,
+  attachments,
+  onImageClick,
+  testId,
+}: {
+  align: "start" | "end";
+  attachments: ResolvedMessageAttachment[];
+  onImageClick: (url: string) => void;
+  testId: string;
+}) {
+  if (attachments.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap gap-2",
+        align === "start" ? "justify-start" : "justify-end",
+      )}
+      data-testid={testId}
+    >
+      {attachments.map((a) => {
+        return (
+          <MessageAttachment
+            key={a.id ?? a.url}
+            attachment={a}
+            onImageClick={onImageClick}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
 function UserMessageAttachments({
   attachments,
   onImageClick,
@@ -6363,9 +6500,6 @@ function UserMessageAttachments({
   onImageClick: (url: string) => void;
   align?: "start" | "end";
 }) {
-  const { t } = useTranslation();
-  const openVideoLightbox = useSet(openAttachmentVideoLightbox$);
-
   if (attachments.length === 0) {
     return null;
   }
@@ -6373,105 +6507,24 @@ function UserMessageAttachments({
   return (
     <div
       className={cn(
-        "flex max-w-[85%] flex-wrap gap-2",
-        align === "start" ? "mt-2 justify-start" : "mb-2 justify-end self-end",
+        "flex max-w-[85%] flex-col gap-2",
+        align === "start" ? "mt-2 items-start" : "mb-2 items-end self-end",
       )}
     >
-      {attachments.map((a) => {
-        if (a.assetRef && a.assetRef.materialization.status !== "ready") {
-          return (
-            <AttachmentMaterializationState
-              key={a.id ?? a.url}
-              attachment={a}
-            />
-          );
-        }
-        if (a.isImage) {
-          return (
-            <ChatImagePreviewLink
-              key={a.url}
-              alt={a.filename}
-              ariaLabel={t(
-                ($) => {
-                  return $.chat.attachments.previewFile;
-                },
-                {
-                  filename: a.filename,
-                },
-              )}
-              imageClassName="block h-full w-full object-contain"
-              linkClassName={CHAT_INLINE_IMAGE_PREVIEW_CLASS}
-              onPreview={() => {
-                onImageClick(a.url);
-              }}
-              placeholderClassName="h-full w-full"
-              url={a.url}
-            />
-          );
-        }
-        if (a.kind === "video") {
-          return (
-            <ChatVideoPreviewButton
-              key={a.url}
-              ariaLabel={t(
-                ($) => {
-                  return $.chat.attachments.previewFile;
-                },
-                {
-                  filename: a.filename,
-                },
-              )}
-              buttonClassName={CHAT_INLINE_VIDEO_ATTACHMENT_PREVIEW_CLASS}
-              filename={a.filename}
-              onPreview={() => {
-                openVideoLightbox({
-                  url: a.url,
-                  filename: a.filename,
-                });
-              }}
-              posterClassName="h-full w-full"
-              url={a.url}
-              videoClassName="h-full w-full object-contain"
-            />
-          );
-        }
-        if (
-          a.kind === "markdown" ||
-          a.kind === "text" ||
-          a.kind === "json" ||
-          a.kind === "csv" ||
-          a.kind === "pdf" ||
-          a.kind === "html"
-        ) {
-          return (
-            <PreviewableFileAttachmentChip
-              key={a.url}
-              filename={a.filename}
-              url={a.url}
-              kind={a.kind}
-              text$={a.text$}
-            />
-          );
-        }
-        if (a.kind === "audio") {
-          return (
-            <PreviewableAudioAttachmentChip
-              key={a.url}
-              filename={a.filename}
-              url={a.url}
-              contentType={a.contentType}
-            />
-          );
-        }
-        return (
-          <FileAttachmentChip
-            key={a.url}
-            filename={a.filename}
-            url={a.url}
-            contentType={a.contentType}
-          />
-        );
-      })}
+      <UserMessageAttachmentRow
+        align={align}
+        attachments={attachments.filter(isMediaAttachment)}
+        onImageClick={onImageClick}
+        testId="message-media-attachments"
+      />
+      <UserMessageAttachmentRow
+        align={align}
+        attachments={attachments.filter((a) => {
+          return !isMediaAttachment(a);
+        })}
+        onImageClick={onImageClick}
+        testId="message-file-attachments"
+      />
     </div>
   );
 }
@@ -7391,16 +7444,14 @@ function UserMessageContent({
   agentReferenceSignalsForId: ChatPanelSignals["agentReferenceSignalsForId"];
   composerSignals: ComposerSignals;
 }) {
-  // Images and videos read as media, so they sit above the bubble as
-  // thumbnails instead of interrupting the sentence they were dropped into.
-  const mediaAttachments = attachments.filter((attachment) => {
-    return (
-      attachment.id !== null &&
-      (attachment.isImage || attachment.kind === "video")
-    );
+  // Attachments read as their own object, so they all sit above the bubble
+  // instead of interrupting the sentence they were dropped into. Attachments
+  // without an id cannot be matched to a document part, so they stay inline.
+  const elevatedAttachments = attachments.filter((attachment) => {
+    return attachment.id !== null;
   });
-  const mediaAttachmentIds = new Set(
-    mediaAttachments.flatMap((attachment) => {
+  const elevatedFileIds = new Set(
+    elevatedAttachments.flatMap((attachment) => {
       return attachment.id ? [attachment.id] : [];
     }),
   );
@@ -7412,11 +7463,7 @@ function UserMessageContent({
   const hasBody = document.parts.some((part) => {
     return (
       !isUserMessageNonContentPart(part) &&
-      !isElevatedUserMessagePart(
-        part,
-        mediaAttachmentIds,
-        inlineTemplatesEnabled,
-      )
+      !isElevatedUserMessagePart(part, elevatedFileIds, inlineTemplatesEnabled)
     );
   });
 
@@ -7436,7 +7483,7 @@ function UserMessageContent({
         </div>
       ) : null}
       <UserMessageAttachments
-        attachments={mediaAttachments}
+        attachments={elevatedAttachments}
         onImageClick={onImageClick}
       />
       {hasBody ? (
@@ -7445,7 +7492,7 @@ function UserMessageContent({
             <UserMessageView
               document={document}
               attachments={referenceAttachments}
-              elevatedFileIds={mediaAttachmentIds}
+              elevatedFileIds={elevatedFileIds}
               inlineTemplatesEnabled={inlineTemplatesEnabled}
               agentReferenceSignalsForId={agentReferenceSignalsForId}
               composerSignals={composerSignals}


### PR DESCRIPTION
## Problem

Attachment placement in a sent message was inconsistent: images and videos were elevated above the message bubble, while PDFs, docs, audio, and other files stayed inline inside the bubble text. One message could therefore show its attachments in two different places (reported in Slack).

## Change

Per the team decision (all attachments above the bubble, previewable media and file chips on separate rows):

- `UserMessageContent` now elevates every resolved attachment out of the bubble, not just images and videos. Attachments that cannot be matched to a document part (no id) still render inline, as before.
- `UserMessageAttachments` renders two rows: media thumbnails first, file chips below. Each row is skipped when empty, so single-type messages look unchanged.
- Extracted the per-attachment branch into `MessageAttachment` so both rows share one renderer.

## Note

Elevated file attachments now show the attachment's current filename instead of the filename snapshot captured when the message was written — the same behavior images and videos already had.

## Testing

- `pnpm -F @vm0/app exec vitest run` for `zero-attachment-chips`, `chat-user-messages`, `chat-user-message-writing`, `chat-run-results`, `chat-lifecycle`, `chat-workflows-and-goals`, `chat-inline-feedback`
- `pnpm -F @vm0/app run lint`, `pnpm -F @vm0/app run check-types`
- Not verified in a browser locally; please eyeball the PR preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)