### PR TITLE
docs(ably-subscriber): document status event backpressure

### DIFF
--- a/crates/ably-subscriber/src/subscribe.rs
+++ b/crates/ably-subscriber/src/subscribe.rs
@@ -15,7 +15,19 @@ use crate::types::{Error, Event, SubscribeConfig};
 /// best-effort close request, or [`close_and_wait`](Subscription::close_and_wait) when the caller
 /// must observe bounded shutdown completion.
 ///
-/// Messages may be dropped under backpressure if the consumer falls behind.
+/// # Backpressure
+///
+/// All events share a bounded channel. [`Event::Message`] events use non-blocking delivery and may
+/// be dropped when the channel is full. Status events ([`Event::Connected`],
+/// [`Event::Disconnected`], and [`Event::Error`]) instead wait for channel capacity rather than
+/// being dropped because the channel is full.
+///
+/// Keep polling [`next`](Subscription::next) while the subscription is active. A full channel can
+/// delay reconnect until space is available for `Disconnected` and, after reconnect, delay
+/// processing on the new connection until space is available for `Connected`. Calling `close` or
+/// `close_and_wait`, or dropping the subscription, can interrupt a status-event send that is
+/// waiting for capacity. Before waiting to deliver a terminal `Error`, the background task
+/// releases its socket.
 pub struct Subscription {
     rx: mpsc::Receiver<Event>,
     close_tx: Option<oneshot::Sender<CloseRequest>>,
@@ -117,7 +129,9 @@ impl Drop for Subscription {
 /// channel, and returns a [`Subscription`] that yields [`Event`]s.
 ///
 /// The background task automatically handles reconnection, token renewal, and
-/// heartbeat timeout detection.
+/// heartbeat timeout detection. See [`Subscription`] for how a full event channel
+/// can delay reconnect and post-reconnect receive progress until the caller drains
+/// events or closes the subscription.
 pub async fn subscribe(config: SubscribeConfig) -> Result<Subscription, Error> {
     let timing = config.timing.unwrap_or_default();
     let close_timeout = timing.close_timeout;

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -238,6 +238,14 @@ pub struct TimingConfig {
     // -- Backpressure --------------------------------------------------------
     /// Bounded capacity of the internal event channel (mpsc). Values below 1
     /// are treated as 1 because Tokio channels do not support zero capacity.
+    ///
+    /// [`Event::Message`] delivery is non-blocking and may drop messages when
+    /// this channel is full. Delivery of [`Event::Connected`],
+    /// [`Event::Disconnected`], and [`Event::Error`] instead waits for capacity,
+    /// which can delay reconnect and post-reconnect receive progress until the
+    /// caller drains an event or closes or drops the
+    /// [`Subscription`](crate::Subscription). See that type for the complete
+    /// backpressure and close behavior.
     pub event_channel_capacity: usize,
 }
 


### PR DESCRIPTION
## Summary

- document the bounded Ably subscription event channel's two delivery policies
- explain how awaited status events can delay reconnect and post-reconnect receive progress
- document how close/drop interrupts blocked status delivery and how terminal paths release sockets

## Scope

This is a Rustdoc-only change. It does not change runtime behavior, public API signatures, event ordering, buffering, dependencies, data, migrations, or deployment contracts.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p ably-subscriber --all-targets --all-features`
- `cargo doc -p ably-subscriber --all-features --no-deps`
- `cargo test -p ably-subscriber --all-targets --all-features`
- repository pre-commit hooks (`cargo fmt --all`, workspace Clippy, workspace Rustdoc, file-size check)

Closes #25230
