### PR TITLE
docs(python): document network-log target helpers

### DIFF
--- a/crates/runner/mitm-addon/src/http_network_log.py
+++ b/crates/runner/mitm-addon/src/http_network_log.py
@@ -12,6 +12,12 @@ _HTTPS_DEFAULT_PORT = 443
 
 
 def set_target(flow: http.HTTPFlow, *, url: str, host: str, port: int) -> None:
+    """Store the caller-selected network-log identity on the flow.
+
+    Request classification supplies the trusted pre-mutation target, while
+    authority-validation failures supply their diagnostic fallback target.
+    The snapshot remains independent of later changes to ``flow.request``.
+    """
     flow.metadata[metadata_keys.NETWORK_LOG_TARGET] = {
         "url": url,
         "host": host,
@@ -20,6 +26,13 @@ def set_target(flow: http.HTTPFlow, *, url: str, host: str, port: int) -> None:
 
 
 def fallback_host_port(flow: http.HTTPFlow, original_url: str) -> tuple[str, int]:
+    """Return the network-log ``(host, port)`` derived from ``original_url``.
+
+    Use the parsed hostname when present, otherwise the request's pretty host.
+    Preserve an explicit port, including zero; without one, use 443 for HTTPS
+    and 80 for every other scheme. If URL parsing or hostname/port access raises
+    ``ValueError``, fall back to the request's pretty host and port together.
+    """
     try:
         parsed_url = urllib.parse.urlparse(original_url)
         host = parsed_url.hostname or flow.request.pretty_host
@@ -36,11 +49,24 @@ def fallback_host_port(flow: http.HTTPFlow, original_url: str) -> tuple[str, int
 
 
 def set_target_from_url(flow: http.HTTPFlow, url: str) -> None:
+    """Store ``url`` unchanged with its derived network-log host and port.
+
+    A missing hostname uses the request's pretty host. An explicit port is
+    preserved; otherwise HTTPS uses 443 and every other scheme uses 80. A
+    parsing or hostname/port ``ValueError`` falls back to both request fields.
+    This path records authority-validation diagnostic fallback targets.
+    """
     host, port = fallback_host_port(flow, url)
     set_target(flow, url=url, host=host, port=port)
 
 
 def target(flow: http.HTTPFlow) -> tuple[str, str, int]:
+    """Return the required network-log target as ``(url, host, port)``.
+
+    The snapshot must have been stored during request classification or
+    authority validation. This intentionally has no fallback to mutable request
+    state, so missing target metadata or fields propagate ``KeyError``.
+    """
     typed_target = cast(
         dict[str, object],
         flow.metadata[metadata_keys.NETWORK_LOG_TARGET],


### PR DESCRIPTION
## Summary

- document the stored network-log target's caller-established provenance and independence from later request mutation
- describe URL hostname/port derivation, explicit and default ports, and request-field fallback behavior
- make the required `(url, host, port)` tuple and intentional missing-metadata `KeyError` explicit

## Scope

- documentation only; no runtime behavior, metadata shape, API, test, migration, or rollout changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,798 passed)

Closes #25228
