### PR TITLE
fix: persist automation trigger prompts in chat events

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/chat-event.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/chat-event.ts
@@ -20,7 +20,11 @@ export function chatEventAutomationPart(
 export function chatEventDisplayText(event: ChatEvent): string | null {
   switch (event.eventType) {
     case "input.prompt":
+    case "input.automation":
     case "input.rejected": {
+      if (!event.userMessage) {
+        return null;
+      }
       return event.userMessage.parts
         .flatMap((part) => {
           return part.type === "text" ? [part.text] : [];

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
@@ -15,6 +15,10 @@ import type { ApiTestUser } from "./helpers/api-bdd";
 import { createGithubBddApi } from "./helpers/api-bdd-github";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
+import {
+  chatEventAutomationPart,
+  chatEventDisplayText,
+} from "./helpers/chat-event";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -634,7 +638,7 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     mockOptionalEnv("GITHUB_APP_WEBHOOK_SECRET", GITHUB_WEBHOOK_SECRET);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
-    await accept(
+    const created = await accept(
       automationsClient().create({
         headers: authHeaders(),
         params: { workflowId },
@@ -657,6 +661,9 @@ describe("POST /api/webhooks/github for workflow automations", () => {
       }),
       [201],
     );
+    if (!created.body.chatThreadId) {
+      throw new Error("Expected the automation to have a chat thread");
+    }
 
     const ignored = await postGithubWebhook({
       event: "workflow_run",
@@ -689,6 +696,26 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     if (!runId || listedRuns.runs.length !== 1) {
       throw new Error("Expected a GitHub workflow run automation");
     }
+    const displayPrompt = `/${WORKFLOW_NAME}\nTrigger: GitHub Actions workflow "Turbo" completed with conclusion "failure" (run 555 attempt 2, GitHub webhook delivery ${deliveryId}).`;
+    const events = await wf.readThreadEvents(created.body.chatThreadId);
+    const admittedEvent = events.find((event) => {
+      return event.eventType === "input.automation";
+    });
+    const claimedEvent = events.find((event) => {
+      return event.eventType === "input.prompt" && event.runId === runId;
+    });
+    if (
+      admittedEvent?.eventType !== "input.automation" ||
+      claimedEvent?.eventType !== "input.prompt"
+    ) {
+      throw new Error("Expected admitted and claimed workflow chat events");
+    }
+    expect(
+      chatEventAutomationPart(admittedEvent)?.automationBrief,
+    ).toBeUndefined();
+    expect(chatEventDisplayText(admittedEvent)).toBe(displayPrompt);
+    expect(claimedEvent.userMessage).toStrictEqual(admittedEvent.userMessage);
+    expect(chatEventDisplayText(claimedEvent)).toBe(displayPrompt);
     const claim = await runsApi.claimRunnerJob(runId);
     const zeroToken = claim.environment?.ZERO_TOKEN;
     if (!zeroToken) {
@@ -697,6 +724,7 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     expect(verifyZeroToken(zeroToken)?.capabilities).toContain(
       "goal:user-control:write",
     );
+    expect(claim.prompt).toBe(displayPrompt);
     expect(claim.appendSystemPrompt).toContain(
       'GitHub Actions workflow "Turbo" completed with conclusion "failure"',
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -845,6 +845,10 @@ describe("workflow queue", () => {
     if (admittedTriggerBrief === undefined) {
       throw new Error("Expected the admitted schedule tick trigger brief");
     }
+    const admittedDisplayPrompt = `/${WORKFLOW_NAME}\nTrigger: schedule fired at ${new Date(
+      firedAt,
+    ).toISOString()} (cron "0 9 * * *" in UTC).`;
+    expect(chatEventDisplayText(pendingTick)).toBe(admittedDisplayPrompt);
     const pendingContext = await readChatEventContextFixture(pendingTick.id);
     expect(pendingContext).toMatchObject({
       contextType: "automation",
@@ -872,9 +876,11 @@ describe("workflow queue", () => {
     ).find((event) => {
       return event.eventType === "input.prompt" && event.runId === runIds[1];
     });
-    if (!claimedTick) {
+    if (claimedTick?.eventType !== "input.prompt") {
       throw new Error("Expected the schedule tick to be claimed");
     }
+    expect(claimedTick.userMessage).toStrictEqual(pendingTick.userMessage);
+    expect(chatEventDisplayText(claimedTick)).toBe(admittedDisplayPrompt);
     expect(chatEventAutomationPart(claimedTick)?.automationBrief).toBe(
       admittedTriggerBrief,
     );
@@ -889,11 +895,7 @@ describe("workflow queue", () => {
 
     await runsApi.heartbeatRunner(scenario.runnerGroup);
     const claim = await runsApi.claimRunnerJob(runIds[1]!);
-    expect(claim.prompt).toBe(
-      `/${WORKFLOW_NAME}\nTrigger: schedule fired at ${new Date(
-        firedAt,
-      ).toISOString()} (cron "0 9 * * *" in UTC).`,
-    );
+    expect(claim.prompt).toBe(admittedDisplayPrompt);
     expect(claim.prompt).not.toContain(new Date(drainedAt).toISOString());
     expect(claim.appendSystemPrompt).toContain(
       `"firedAt": "${new Date(firedAt).toISOString()}"`,
@@ -1216,44 +1218,32 @@ describe("workflow queue", () => {
       }),
       [200],
     );
-    expect(failedEvents.body.events).toStrictEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          eventType: "input.rejected",
-          error: expect.any(String),
-          userMessage: {
-            version: 1,
-            parts: [
-              {
-                type: "automation",
-                workflowName: WORKFLOW_NAME,
-                workflowId: scenario.workflowId,
-              },
-            ],
-          },
-        }),
-      ]),
-    );
     const rejectedEvent = failedEvents.body.events.find((event) => {
       return event.eventType === "input.rejected";
     });
-    expect(rejectedEvent).toStrictEqual(
-      expect.objectContaining({
-        userMessage: {
-          version: 1,
-          parts: [
-            {
-              type: "automation",
-              workflowName: WORKFLOW_NAME,
-              workflowId: scenario.workflowId,
-            },
-          ],
-        },
-      }),
-    );
     if (!rejectedEvent?.revokesEventId) {
       throw new Error("Expected the rejected event to revoke its queue input");
     }
+    expect(rejectedEvent.error).toStrictEqual(expect.any(String));
+    expect(chatEventAutomationPart(rejectedEvent)).toStrictEqual({
+      type: "automation",
+      workflowName: WORKFLOW_NAME,
+      workflowId: scenario.workflowId,
+    });
+    const rejectedDisplayPrompt = chatEventDisplayText(rejectedEvent);
+    expect(rejectedDisplayPrompt).toMatch(
+      new RegExp(
+        `^/${WORKFLOW_NAME}\\nTrigger: signed workflow webhook received an HTTP POST at 2026-07-25T12:00:00.000Z \\(delivery .+\\)\\.$`,
+      ),
+    );
+    const admittedEvent = failedEvents.body.events.find((event) => {
+      return event.id === rejectedEvent.revokesEventId;
+    });
+    if (admittedEvent?.eventType !== "input.automation") {
+      throw new Error("Expected the rejected event's admitted queue input");
+    }
+    expect(rejectedEvent.userMessage).toStrictEqual(admittedEvent.userMessage);
+    expect(chatEventDisplayText(admittedEvent)).toBe(rejectedDisplayPrompt);
     await runsApi.ensureOrgModelProvider(scenario.actor);
     const runId = await expectAcceptedRunId(
       await postWorkflowWebhook(automation, "next trigger"),

--- a/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
@@ -108,6 +108,7 @@ export type PersistWorkflowQueueSourceTransition = (
 interface WorkflowQueueAdmissionArgs {
   readonly automation: typeof zeroWorkflowAutomations.$inferSelect;
   readonly workflowName: string;
+  readonly displayPrompt: string;
   readonly workflowAutomationEventType?: WorkflowAutomationEventType;
   readonly workflowAutomationEventPayload?: WorkflowAutomationEventPayload;
   readonly chatThreadId: string;
@@ -142,7 +143,7 @@ async function attemptWorkflowQueueAdmission(
       eventType: "input.automation",
       content: null,
       userMessage: createUserMessageDocument({
-        text: null,
+        text: args.displayPrompt,
         nonContentPart: {
           type: "automation",
           workflowName: args.workflowName,

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -8,7 +8,10 @@ import {
   ApiDispatchTimingCollector,
   measureApiDispatchTiming,
 } from "./api-dispatch-timing.service";
-import { persistedWorkflowAutomationEventPayload } from "./workflow-automation-context.service";
+import {
+  persistedWorkflowAutomationEventPayload,
+  workflowAutomationPrompt,
+} from "./workflow-automation-context.service";
 import type {
   RunWorkflowAutomationNowArgs,
   RunWorkflowAutomationResult,
@@ -44,6 +47,7 @@ export const runWorkflowAutomationNow$ = command(
         return await admitWorkflowAutomationEvent(db, {
           automation,
           workflowName: args.automationContext.workflowName,
+          displayPrompt: workflowAutomationPrompt(args.automationContext),
           workflowAutomationEventType: args.automationContext.eventType,
           workflowAutomationEventPayload:
             persistedWorkflowAutomationEventPayload(

--- a/turbo/apps/api/src/test-fixtures/workflow-queue.ts
+++ b/turbo/apps/api/src/test-fixtures/workflow-queue.ts
@@ -6,7 +6,11 @@ import { eq } from "drizzle-orm";
 
 import { db } from "../lib/db";
 import { admitWorkflowAutomationEvent } from "../signals/services/workflow-chat-event-queue.service";
-import { persistedWorkflowAutomationEventPayload } from "../signals/services/workflow-automation-context.service";
+import {
+  persistedWorkflowAutomationEventPayload,
+  storedWorkflowAutomationContext,
+  workflowAutomationPrompt,
+} from "../signals/services/workflow-automation-context.service";
 
 interface WorkflowAutomationEventFixtureArgs {
   readonly automationId: string;
@@ -33,15 +37,23 @@ export async function admitWorkflowAutomationEventFixture(
   if (!row) {
     throw new Error("Expected the workflow automation to exist");
   }
+  const eventPayload = {
+    receivedAt: "2026-08-01T12:00:00.000Z",
+    deliveryId: args.triggerBrief,
+  } as const;
+  const automationContext = storedWorkflowAutomationContext({
+    workflowName: row.workflowName,
+    eventType: "webhook-received",
+    eventPayload,
+  });
 
   const admission = await admitWorkflowAutomationEvent(db(), {
     automation: row.automation,
     workflowName: row.workflowName,
+    displayPrompt: workflowAutomationPrompt(automationContext),
     workflowAutomationEventType: "webhook-received",
-    workflowAutomationEventPayload: persistedWorkflowAutomationEventPayload({
-      receivedAt: "2026-08-01T12:00:00.000Z",
-      deliveryId: args.triggerBrief,
-    }),
+    workflowAutomationEventPayload:
+      persistedWorkflowAutomationEventPayload(eventPayload),
     chatThreadId: args.chatThreadId,
     triggerSource: "workflow-event",
     triggerBrief: args.triggerBrief,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -1244,7 +1244,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
     });
   });
 
-  it("renders workflow automation user messages with the workflow title and brief", async () => {
+  it("keeps rendering legacy workflow automation briefs without text", async () => {
     const threadId = "thread-workflow-user-message-marker";
     const workflowPrompt = "/daily-workflow";
 
@@ -1297,6 +1297,99 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
       ).not.toBeInTheDocument();
       expect(screen.queryByText(workflowPrompt)).not.toBeInTheDocument();
     });
+  });
+
+  it("renders the persisted workflow prompt instead of its brief", async () => {
+    const threadId = "thread-workflow-user-message-prompt";
+    const workflowPrompt =
+      '/daily-workflow\nTrigger: Gmail applied label "todo" to message msg-123.';
+
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Workflow user message prompt",
+      chatEvents: [
+        {
+          id: "msg-workflow-prompt-user",
+          eventType: "input.automation",
+          content: null,
+          runId: "f0000001-0000-4000-a000-00000000084c",
+          triggerSource: "workflow-event",
+          userMessage: {
+            version: 1,
+            parts: [
+              { type: "text", text: workflowPrompt },
+              {
+                type: "automation",
+                workflowName: "Daily workflow",
+                workflowId: "f0000001-0000-4000-a000-000000000841",
+                automationBrief: "Gmail label applied",
+              },
+            ],
+          },
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+    });
+
+    const annotation = await screen.findByLabelText("Workflow Daily workflow");
+    const userTurn = annotation.closest('[data-role="user"]');
+    expect(userTurn).not.toBeNull();
+    expect(userTurn).toHaveTextContent("/daily-workflow");
+    expect(userTurn).toHaveTextContent(
+      'Trigger: Gmail applied label "todo" to message msg-123.',
+    );
+    expect(userTurn).not.toHaveTextContent("Gmail label applied");
+  });
+
+  it("renders persisted workflow prompts without a trigger brief", async () => {
+    const threadId = "thread-workflow-user-message-no-brief";
+    const workflowPrompt =
+      '/turbo-flaky-test-repair\nTrigger: GitHub Actions workflow "Turbo" completed with conclusion "failure".';
+
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Workflow user message without brief",
+      chatEvents: [
+        {
+          id: "msg-workflow-no-brief-user",
+          eventType: "input.automation",
+          content: null,
+          runId: "f0000001-0000-4000-a000-00000000085c",
+          triggerSource: "workflow-event",
+          userMessage: {
+            version: 1,
+            parts: [
+              { type: "text", text: workflowPrompt },
+              {
+                type: "automation",
+                workflowName: "turbo-flaky-test-repair",
+              },
+            ],
+          },
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+    });
+
+    const annotation = await screen.findByLabelText(
+      "Workflow turbo-flaky-test-repair",
+    );
+    const userTurn = annotation.closest('[data-role="user"]');
+    expect(userTurn).not.toBeNull();
+    expect(userTurn).toHaveTextContent("/turbo-flaky-test-repair");
+    expect(userTurn).toHaveTextContent(
+      'Trigger: GitHub Actions workflow "Turbo" completed with conclusion "failure".',
+    );
   });
 
   it("renders a pending automation only as an automation event", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -7472,7 +7472,9 @@ function WorkflowUserMessage({
     t(($) => {
       return $.chat.templates.categories.workflow;
     });
-  const workflowBody = part.automationBrief?.trim();
+  const workflowBody =
+    messageDocumentToDisplayText(event.userMessage)?.trim() ||
+    part.automationBrief?.trim();
   const bubbleClassName =
     "zero-chat-bubble-user rounded-xl max-w-[85%] text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere] overflow-hidden whitespace-pre-wrap transition-colors duration-150";
   const body = workflowBody ? (


### PR DESCRIPTION
## Summary

- snapshot each newly admitted automation trigger prompt in `chat_events.user_message`
- preserve the same immutable user message through claimed and rejected queue transitions while keeping runner prompt derivation independent
- render the event-owned prompt in chat, with `automationBrief` retained as a fallback for legacy events

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- API, app, and remaining workspace type checks
- focused API admission, rejection, and FIFO tests
- focused platform workflow-message rendering tests

Fixes #25170
