### PR TITLE
refactor(platform): replace native timers with abortable signal timers

### DIFF
--- a/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
+++ b/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
@@ -192,7 +192,9 @@ describe("portable platform runtime environment", () => {
       ),
     ).toBe("https://cdn.vm0.io/artifacts/user_1/artifact_1/report.html");
 
-    runtime.plausible.initPlausible();
+    const plausibleController = new AbortController();
+    await runtime.plausible.initPlausible(plausibleController.signal);
+    plausibleController.abort();
     runtime.plausible.capturePlausibleEvent("runtime_environment_test");
     runtime.posthog.initPostHog();
     runtime.sentry.initSentry();
@@ -239,7 +241,9 @@ describe("portable platform runtime environment", () => {
       ),
     ).toBe("https://cdn.vm7.io/artifacts/user_1/artifact_1/report.html");
 
-    runtime.plausible.initPlausible();
+    const plausibleController = new AbortController();
+    await runtime.plausible.initPlausible(plausibleController.signal);
+    plausibleController.abort();
     runtime.posthog.initPostHog();
     runtime.sentry.initSentry();
 

--- a/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { animationFrame, timeout } from "signal-timers";
 
-import { createDeferredPromise } from "../../signals/utils.ts";
+import { testContext } from "../../signals/__tests__/test-helpers.ts";
+import { createDeferredPromise, resetSignal } from "../../signals/utils.ts";
 import { setupVisualViewportKeyboardState } from "../visual-viewport-keyboard.ts";
 
 const VIEWPORT_SETTLE_WAIT_MS = 75;
+const context = testContext();
+const resetViewportSettleSignal$ = resetSignal();
 const originalMatchMediaDescriptor = Object.getOwnPropertyDescriptor(
   window,
   "matchMedia",
@@ -85,12 +89,19 @@ function focusComposer(inExistingThread: boolean): {
 }
 
 function waitForViewportSettle(): Promise<void> {
-  const settled = createDeferredPromise<void>(AbortSignal.any([]));
-  window.setTimeout(() => {
-    window.requestAnimationFrame(() => {
-      settled.resolve();
-    });
-  }, VIEWPORT_SETTLE_WAIT_MS);
+  const settled = createDeferredPromise<void>(context.signal);
+  timeout(
+    () => {
+      animationFrame(
+        () => {
+          settled.resolve();
+        },
+        { signal: context.signal },
+      );
+    },
+    VIEWPORT_SETTLE_WAIT_MS,
+    { signal: context.signal },
+  );
   return settled.promise;
 }
 
@@ -104,7 +115,9 @@ async function resizeAndSettle(
 }
 
 function startViewportKeyboardState(): () => void {
-  const cleanup = setupVisualViewportKeyboardState();
+  const cleanup = setupVisualViewportKeyboardState(context.signal, () => {
+    return context.store.set(resetViewportSettleSignal$, context.signal);
+  });
   onTestFinished(cleanup);
   return cleanup;
 }

--- a/turbo/apps/platform/src/lib/plausible.ts
+++ b/turbo/apps/platform/src/lib/plausible.ts
@@ -1,3 +1,4 @@
+import { delay } from "signal-timers";
 import { resolvePlatformRuntimeConfig } from "./platform-host.ts";
 
 type PlausibleEventProps = Record<string, string | number | boolean>;
@@ -70,17 +71,38 @@ function loadPlausible(): void {
   document.head.appendChild(script);
 }
 
-export function initPlausible(): void {
+export async function initPlausible(signal: AbortSignal): Promise<void> {
   if (window.__vm0PlausibleLoadScheduled || !plausibleScriptUrl()) {
     return;
   }
+  signal.throwIfAborted();
   window.__vm0PlausibleLoadScheduled = true;
 
   if (typeof window.requestIdleCallback === "function") {
-    window.requestIdleCallback(loadPlausible, { timeout: 3000 });
+    const idleLoad: { callbackId?: number; pending: boolean } = {
+      pending: true,
+    };
+    const cancelLoad = () => {
+      if (idleLoad.callbackId !== undefined) {
+        window.cancelIdleCallback(idleLoad.callbackId);
+      }
+    };
+    idleLoad.callbackId = window.requestIdleCallback(
+      () => {
+        idleLoad.pending = false;
+        signal.removeEventListener("abort", cancelLoad);
+        loadPlausible();
+      },
+      { timeout: 3000 },
+    );
+    if (idleLoad.pending) {
+      signal.addEventListener("abort", cancelLoad, { once: true });
+    }
     return;
   }
-  window.setTimeout(loadPlausible, 100);
+  await delay(100, { signal });
+  signal.throwIfAborted();
+  loadPlausible();
 }
 
 export function capturePlausibleEvent(

--- a/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
+++ b/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
@@ -1,3 +1,6 @@
+import { delay } from "signal-timers";
+import { detach, Reason } from "../signals/utils.ts";
+
 const KEYBOARD_SHRINK_RATIO = 0.15;
 const MIN_KEYBOARD_SHRINK_PX = 120;
 const LAYOUT_VIEWPORT_CHANGE_TOLERANCE_PX = 8;
@@ -226,7 +229,11 @@ function updateKeyboardViewportState(
   setKeyboardOpen(readKeyboardOcclusion(state.baselineHeight, viewport));
 }
 
-export function setupVisualViewportKeyboardState(): () => void {
+export function setupVisualViewportKeyboardState(
+  signal: AbortSignal,
+  resetSettledSignal: () => AbortSignal,
+): () => void {
+  signal.throwIfAborted();
   const viewport = window.visualViewport;
 
   if (!viewport) {
@@ -243,13 +250,23 @@ export function setupVisualViewportKeyboardState(): () => void {
   };
   let scheduledFrameId: number | null = null;
   let revealFrameId: number | null = null;
-  let settledTimerId: number | null = null;
+  let settledTimerSignal: AbortSignal | null = null;
 
   const cancelSettledUpdate = () => {
-    if (settledTimerId !== null) {
-      window.clearTimeout(settledTimerId);
-      settledTimerId = null;
+    if (settledTimerSignal) {
+      resetSettledSignal();
+      settledTimerSignal = null;
     }
+  };
+
+  const commitSettledUpdate = async (settledSignal: AbortSignal) => {
+    await delay(VIEWPORT_SETTLE_DELAY_MS, { signal: settledSignal });
+    settledSignal.throwIfAborted();
+    if (settledTimerSignal !== settledSignal) {
+      return;
+    }
+    settledTimerSignal = null;
+    update(true);
   };
 
   const update = (commitOpening: boolean) => {
@@ -288,10 +305,13 @@ export function setupVisualViewportKeyboardState(): () => void {
     // The short trailing read also prevents the first stale resize sample from
     // moving the page before the native focus pan has settled.
     cancelSettledUpdate();
-    settledTimerId = window.setTimeout(() => {
-      settledTimerId = null;
-      update(true);
-    }, VIEWPORT_SETTLE_DELAY_MS);
+    const settledSignal = resetSettledSignal();
+    settledTimerSignal = settledSignal;
+    detach(
+      commitSettledUpdate(settledSignal),
+      Reason.DomCallback,
+      "visual viewport settle",
+    );
   };
 
   const scheduleBaselineReset = () => {
@@ -319,7 +339,13 @@ export function setupVisualViewportKeyboardState(): () => void {
   document.addEventListener("focusout", scheduleUpdate);
   update(false);
 
-  return () => {
+  let cleanedUp = false;
+  const cleanup = () => {
+    if (cleanedUp) {
+      return;
+    }
+    cleanedUp = true;
+    signal.removeEventListener("abort", cleanup);
     viewport.removeEventListener("resize", scheduleUpdate);
     viewport.removeEventListener("scroll", scheduleUpdate);
     window.removeEventListener("orientationchange", scheduleBaselineReset);
@@ -334,4 +360,6 @@ export function setupVisualViewportKeyboardState(): () => void {
     cancelSettledUpdate();
     setKeyboardClosed();
   };
+  signal.addEventListener("abort", cleanup, { once: true });
+  return cleanup;
 }

--- a/turbo/apps/platform/src/main.ts
+++ b/turbo/apps/platform/src/main.ts
@@ -8,16 +8,17 @@ import { createRoot } from "react-dom/client";
 import { createStore } from "ccstate";
 import { bootstrap$ } from "./signals/bootstrap.ts";
 import { setLogErrorHandler } from "./signals/log.ts";
-import { detach, Reason } from "./signals/utils.ts";
+import { detach, Reason, resetSignal } from "./signals/utils.ts";
 import { setupRouter } from "./views/main.tsx";
 
 // (no-op Platform release marker refreshed again on 2026-07-31)
 
+const resetRootSignal$ = resetSignal();
+const resetViewportSettleSignal$ = resetSignal();
+
 // Initialize Sentry before bootstrap so errors during startup are captured
 initSentry();
 initPostHog();
-initPlausible();
-setupVisualViewportKeyboardState();
 
 setLogErrorHandler((loggerName, args) => {
   const error = args.find((a): a is Error => {
@@ -37,7 +38,20 @@ setLogErrorHandler((loggerName, args) => {
 
 async function main() {
   const store = createStore();
-  const rootSignal = AbortSignal.any([]);
+  const rootSignal = store.set(resetRootSignal$);
+  window.addEventListener(
+    "pagehide",
+    (event) => {
+      if (!event.persisted) {
+        store.set(resetRootSignal$);
+      }
+    },
+    { signal: rootSignal },
+  );
+  detach(initPlausible(rootSignal), Reason.Entrance, "initPlausible");
+  setupVisualViewportKeyboardState(rootSignal, () => {
+    return store.set(resetViewportSettleSignal$, rootSignal);
+  });
 
   await store.set(
     bootstrap$,

--- a/turbo/apps/platform/src/mocks/msw-contract.ts
+++ b/turbo/apps/platform/src/mocks/msw-contract.ts
@@ -20,6 +20,7 @@ import type {
   ServerInferResponses,
 } from "@vm0/api-contracts/contracts/trpc-contract";
 import { http, HttpResponse, type HttpHandler, type PathParams } from "msw";
+import { delay } from "signal-timers";
 import { createDeferredPromise } from "../signals/utils.ts";
 
 export interface SignalContextLike {
@@ -77,20 +78,7 @@ async function withSignal<T>(
 }
 
 function delayWithSignal(ms: number, signal: AbortSignal): Promise<void> {
-  if (signal.aborted) {
-    return Promise.reject(getAbortReason(signal));
-  }
-  return new Promise<void>((resolve, reject) => {
-    const timer = window.setTimeout(() => {
-      signal.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-    const onAbort = () => {
-      window.clearTimeout(timer);
-      reject(getAbortReason(signal));
-    };
-    signal.addEventListener("abort", onAbort, { once: true });
-  });
+  return delay(ms, { signal });
 }
 
 function neverWithSignal(signal: AbortSignal): Promise<never> {

--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -1,5 +1,5 @@
 import { command, computed, state } from "ccstate";
-import { isAbortError, onRef, resetSignal, setLoop } from "./utils.ts";
+import { completeOnLocalAbort, onRef, resetSignal, setLoop } from "./utils.ts";
 import { getAvatarPresets } from "../views/zero-page/zero-avatars.ts";
 import { captureFirstSkeletonHide$ } from "../lib/posthog.ts";
 import { i18n } from "../i18n/index.ts";
@@ -153,22 +153,18 @@ export const startSkeletonCycling$ = command(
     // The local reset is the normal completion path when the page becomes
     // ready. Parent cancellation still belongs to the command caller and must
     // propagate through bootstrap.
-    // eslint-disable-next-line no-restricted-syntax
-    try {
-      await setLoop(
+    await completeOnLocalAbort(
+      setLoop(
         () => {
           set(cycleSkeletonCopy$);
           return ++cycles >= MAX_SKELETON_CYCLES;
         },
         4000,
         loopSignal,
-      );
-    } catch (error) {
-      parentSignal.throwIfAborted();
-      if (!loopSignal.aborted || !isAbortError(error)) {
-        throw error;
-      }
-    }
+      ),
+      loopSignal,
+      parentSignal,
+    );
   },
 );
 

--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -1,5 +1,5 @@
 import { command, computed, state } from "ccstate";
-import { onRef, resetSignal, setLoop } from "./utils.ts";
+import { isAbortError, onRef, resetSignal, setLoop } from "./utils.ts";
 import { getAvatarPresets } from "../views/zero-page/zero-avatars.ts";
 import { captureFirstSkeletonHide$ } from "../lib/posthog.ts";
 import { i18n } from "../i18n/index.ts";
@@ -149,14 +149,26 @@ const MAX_SKELETON_CYCLES = 3;
 export const startSkeletonCycling$ = command(
   async ({ set }, parentSignal: AbortSignal) => {
     let cycles = 0;
-    await setLoop(
-      () => {
-        set(cycleSkeletonCopy$);
-        return ++cycles >= MAX_SKELETON_CYCLES;
-      },
-      4000,
-      set(resetSkeletonCycling$, parentSignal),
-    );
+    const loopSignal = set(resetSkeletonCycling$, parentSignal);
+    // The local reset is the normal completion path when the page becomes
+    // ready. Parent cancellation still belongs to the command caller and must
+    // propagate through bootstrap.
+    // eslint-disable-next-line no-restricted-syntax
+    try {
+      await setLoop(
+        () => {
+          set(cycleSkeletonCopy$);
+          return ++cycles >= MAX_SKELETON_CYCLES;
+        },
+        4000,
+        loopSignal,
+      );
+    } catch (error) {
+      parentSignal.throwIfAborted();
+      if (!loopSignal.aborted || !isAbortError(error)) {
+        throw error;
+      }
+    }
   },
 );
 

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -1,4 +1,5 @@
 import { command, type Command } from "ccstate";
+import { timeout } from "signal-timers";
 import { createElement } from "react";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { setupClerk$, watchOrgSwitch$ } from "./auth.ts";
@@ -440,11 +441,18 @@ const setupFeatureSwitches$ = command(async ({ set }, signal: AbortSignal) => {
   await set(syncLocalePreference$, signal);
 });
 
-function showSuccessToastAfterMount(message: string): void {
+function showSuccessToastAfterMount(
+  message: string,
+  signal: AbortSignal,
+): void {
   const showToast = () => {
-    window.setTimeout(() => {
-      toast.success(message);
-    }, 0);
+    timeout(
+      () => {
+        toast.success(message);
+      },
+      0,
+      { signal },
+    );
   };
 
   if (document.readyState === "complete") {
@@ -452,10 +460,10 @@ function showSuccessToastAfterMount(message: string): void {
     return;
   }
 
-  window.addEventListener("load", showToast, { once: true });
+  window.addEventListener("load", showToast, { once: true, signal });
 }
 
-const handleBillingRedirect$ = command(({ set }) => {
+const handleBillingRedirect$ = command(({ set }, signal: AbortSignal) => {
   const url = new URL(window.location.href);
   const billing = url.searchParams.get("billing");
   const credits = url.searchParams.get("credits");
@@ -487,6 +495,7 @@ const handleBillingRedirect$ = command(({ set }) => {
         },
         { plan: label },
       ),
+      signal,
     );
     set(reloadBillingStatus$);
   }
@@ -496,6 +505,7 @@ const handleBillingRedirect$ = command(({ set }) => {
       i18n.t(($) => {
         return $.billing.toasts.creditsAdded;
       }),
+      signal,
     );
     set(reloadBillingStatus$);
   }
@@ -505,6 +515,7 @@ const handleBillingRedirect$ = command(({ set }) => {
       i18n.t(($) => {
         return $.billing.toasts.concurrencyAdded;
       }),
+      signal,
     );
     set(reloadBillingStatus$);
   }
@@ -541,7 +552,7 @@ export const bootstrap$ = command(
 
     render();
 
-    set(handleBillingRedirect$);
+    set(handleBillingRedirect$, signal);
     set(handleSlackRedirect$);
 
     await Promise.all([

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -6,7 +6,7 @@ import {
   type Computed,
   type State,
 } from "ccstate";
-import { delay } from "signal-timers";
+import { delay, timeout } from "signal-timers";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { IN_VITEST } from "../../env.ts";
 import { i18n } from "../../i18n/index.ts";
@@ -740,7 +740,7 @@ function createThreadUIState() {
 
   // Copy state with 2s auto-clear
   const internalCopiedId$ = state<string | null>(null);
-  const internalCopiedTimerId$ = state<number | null>(null);
+  const resetCopiedSignal$ = resetSignal();
 
   const copiedEventId$ = computed((get) => {
     return get(internalCopiedId$);
@@ -758,16 +758,22 @@ function createThreadUIState() {
       if (!ok) {
         return;
       }
-      const existingTimerId = get(internalCopiedTimerId$);
-      if (existingTimerId !== null) {
-        window.clearTimeout(existingTimerId);
-      }
+      const copiedSignal = set(resetCopiedSignal$, signal);
       set(internalCopiedId$, eventId);
-      const timerId = window.setTimeout(() => {
-        set(internalCopiedId$, null);
-        set(internalCopiedTimerId$, null);
-      }, 2000);
-      set(internalCopiedTimerId$, timerId);
+      const clearCopiedId = () => {
+        if (get(internalCopiedId$) === eventId) {
+          set(internalCopiedId$, null);
+        }
+      };
+      copiedSignal.addEventListener("abort", clearCopiedId, { once: true });
+      timeout(
+        () => {
+          copiedSignal.removeEventListener("abort", clearCopiedId);
+          clearCopiedId();
+        },
+        2000,
+        { signal: copiedSignal },
+      );
     },
   );
 

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -1,5 +1,5 @@
 import { command, state, type Command } from "ccstate";
-import { delay } from "signal-timers";
+import { delay, timeout } from "signal-timers";
 import { IN_VITEST } from "../env.ts";
 import { logger } from "./log.ts";
 
@@ -358,9 +358,7 @@ async function waitForFibonacciRetry(
   signal: AbortSignal,
 ): Promise<void> {
   const delayMs = fibonacciRetryDelayMs(retryIndex);
-  await (IN_VITEST
-    ? delay(0, { signal: AbortSignal.any([]) })
-    : delay(delayMs, { signal }));
+  await (IN_VITEST ? waitForNextMacrotask(signal) : delay(delayMs, { signal }));
   signal.throwIfAborted();
 }
 
@@ -433,14 +431,12 @@ export async function setLoop(
         return;
       }
       fibIndex = 0;
-      // In VITEST, yield to the macrotask queue via setTimeout so React can
-      // flush renders between iterations. Using Promise.resolve() only queues
-      // a microtask, which starves React's render cycle. We avoid
-      // delay(0, { signal }) because signal-timers' Promise.race leaves an
-      // abandoned promiseFromSignal that rejects as an unhandled rejection
-      // when the abort signal fires during afterEach cleanup.
+      // In VITEST, yield to the macrotask queue so React can flush renders
+      // between iterations. Using Promise.resolve() only queues a microtask,
+      // which starves React's render cycle. The callback timer avoids
+      // signal-timers' delay Promise.race while still honoring the loop signal.
       await (IN_VITEST
-        ? delay(0, { signal: AbortSignal.any([]) })
+        ? waitForNextMacrotask(signal)
         : delay(interval, { signal }));
     } catch (error) {
       throwIfAbort(error);
@@ -462,6 +458,20 @@ export async function setLoop(
       fibIndex++;
     }
   }
+}
+
+function waitForNextMacrotask(signal: AbortSignal): Promise<void> {
+  const deferred = createDeferredPromise<void>(signal);
+  if (!signal.aborted) {
+    timeout(
+      () => {
+        deferred.resolve(undefined);
+      },
+      0,
+      { signal },
+    );
+  }
+  return deferred.promise;
 }
 
 export function resetSignal(): Command<AbortSignal, AbortSignal[]> {

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -134,6 +134,23 @@ export const isAbortError = (error: unknown): boolean => {
   return false;
 };
 
+/**
+ * Treat cancellation by a nested lifecycle as successful completion while
+ * preserving parent cancellation and unrelated failures.
+ */
+export function completeOnLocalAbort(
+  completion: Promise<void>,
+  localSignal: AbortSignal,
+  parentSignal: AbortSignal,
+): Promise<void> {
+  return completion.then(undefined, (error) => {
+    parentSignal.throwIfAborted();
+    if (!localSignal.aborted || !isAbortError(error)) {
+      throw error;
+    }
+  });
+}
+
 function throwIfNotAbort(e: unknown) {
   if (!isAbortError(e)) {
     throw e;

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import { timeout } from "signal-timers";
 import {
   zeroVoiceIoQuotaContract,
   type AudioInputQuotaResponse,
@@ -27,6 +28,7 @@ import { i18n } from "../../i18n/index.ts";
 const L = logger("VoiceIO:STT");
 
 const resetRecord$ = resetSignal();
+const resetVoiceSilenceTimer$ = resetSignal();
 // ---------------------------------------------------------------------------
 // Internal state
 // ---------------------------------------------------------------------------
@@ -200,6 +202,7 @@ interface VoiceSilenceTimer {
 }
 
 interface VoiceSilenceTimerOptions {
+  readonly resetTimerSignal: () => AbortSignal;
   readonly isStopped: () => boolean;
   readonly markStopped: () => void;
   readonly isVoiceActivityReliable: () => boolean;
@@ -698,6 +701,7 @@ interface VoiceSegmentSessionOptions {
     signal: AbortSignal,
   ) => Promise<SttSegmentResult>;
   readonly isVoiceActivityReliable: () => boolean;
+  readonly resetSilenceTimerSignal: () => AbortSignal;
   readonly onLongSilence: () => void;
   readonly onQuotaExceeded: () => void;
   readonly onRecorderChanged: (recorder: MediaRecorder) => void;
@@ -863,12 +867,12 @@ function createVoiceSegmentTranscriber(
 function createVoiceSilenceTimer(
   options: VoiceSilenceTimerOptions,
 ): VoiceSilenceTimer {
-  let timerId: number | null = null;
+  let timerSignal: AbortSignal | null = null;
 
   const clear = (): void => {
-    if (timerId !== null) {
-      window.clearTimeout(timerId);
-      timerId = null;
+    if (timerSignal) {
+      options.resetTimerSignal();
+      timerSignal = null;
     }
   };
 
@@ -877,14 +881,23 @@ function createVoiceSilenceTimer(
     if (options.isStopped() || !options.isVoiceActivityReliable()) {
       return;
     }
-    timerId = window.setTimeout(() => {
-      timerId = null;
-      if (options.isStopped() || !options.isVoiceActivityReliable()) {
-        return;
-      }
-      options.markStopped();
-      options.onLongSilence();
-    }, VOICE_ACTIVITY_AUTO_STOP_MS);
+    const signal = options.resetTimerSignal();
+    timerSignal = signal;
+    timeout(
+      () => {
+        if (timerSignal !== signal) {
+          return;
+        }
+        timerSignal = null;
+        if (options.isStopped() || !options.isVoiceActivityReliable()) {
+          return;
+        }
+        options.markStopped();
+        options.onLongSilence();
+      },
+      VOICE_ACTIVITY_AUTO_STOP_MS,
+      { signal },
+    );
   };
 
   return { clear, start };
@@ -921,6 +934,7 @@ function createVoiceSegmentSession(
   };
 
   const silenceTimer = createVoiceSilenceTimer({
+    resetTimerSignal: options.resetSilenceTimerSignal,
     isStopped: () => {
       return stopped;
     },
@@ -1017,6 +1031,9 @@ export const startRecording$ = command(
           },
           isVoiceActivityReliable: () => {
             return voiceActivityReliable;
+          },
+          resetSilenceTimerSignal: () => {
+            return set(resetVoiceSilenceTimer$, signal);
           },
           onLongSilence: () => {
             if (longSilenceStop && !longSilenceStop.settled()) {

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -132,6 +132,10 @@ function reportMicStartFailure(error: unknown): void {
   toast.error(microphoneAccessDeniedMessage());
 }
 
+function reportAudioActivityMonitorStartFailure(error: unknown): void {
+  L.error("Audio activity monitor start failed", error);
+}
+
 function microphoneAccessDeniedMessage(): string {
   return i18n.t(($) => {
     return $.chat.voice.microphoneAccessDenied;
@@ -1007,7 +1011,7 @@ export const startRecording$ = command(
 
     let audioActivityMonitor: AudioActivityMonitor | null = null;
     let voiceActivityReliable = false;
-    let longSilenceStop: ReturnType<typeof createDeferredPromise<void>> | null =
+    let silenceStop: ReturnType<typeof createDeferredPromise<void>> | null =
       null;
     const starting = withCleanup(
       (async (): Promise<VoiceRecordingStartup | null> => {
@@ -1036,8 +1040,8 @@ export const startRecording$ = command(
             return set(resetVoiceSilenceTimer$, signal);
           },
           onLongSilence: () => {
-            if (longSilenceStop && !longSilenceStop.settled()) {
-              longSilenceStop.resolve(undefined);
+            if (silenceStop && !silenceStop.settled()) {
+              silenceStop.resolve(undefined);
             }
           },
           onQuotaExceeded: () => {
@@ -1089,9 +1093,7 @@ export const startRecording$ = command(
         },
         signal,
       ),
-      (error) => {
-        L.error("Audio activity monitor start failed", error);
-      },
+      reportAudioActivityMonitorStartFailure,
     );
     signal.throwIfAborted();
     if (startedAudioActivityMonitor === undefined) {
@@ -1107,13 +1109,13 @@ export const startRecording$ = command(
     set(internalVoiceActivityAvailable$, audioActivityMonitor !== null);
     set(internalVoiceActivityCoversRecording$, voiceActivityReliable);
     if (voiceActivityReliable) {
-      longSilenceStop = createDeferredPromise<void>(signal);
+      silenceStop = createDeferredPromise<void>(signal);
       recordingSession.startSilenceTimeout();
     } else {
       return;
     }
 
-    await longSilenceStop.promise;
+    await silenceStop.promise;
     signal.throwIfAborted();
     await set(stopAndTranscribe$, signal);
   },

--- a/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import { timeout } from "signal-timers";
 import { openArtifactInOpenSidebar$ } from "../chat-page/thread-sidebar-coordinator.ts";
 import {
   createTextPreviewComputed,
@@ -6,7 +7,7 @@ import {
   type TextPreviewComputed,
   type TextPreviewKind,
 } from "../text-preview.ts";
-import { onRef } from "../utils.ts";
+import { onRef, resetSignal } from "../utils.ts";
 
 // ---------------------------------------------------------------------------
 // Lightbox state — tracks which attachment is open in the global preview UI
@@ -90,6 +91,7 @@ const internalLightboxState$ = state<AttachmentLightboxState | null>(null);
 const internalLightboxDialogVisible$ = state(false);
 const internalLightboxDialogFullscreen$ = state(false);
 const internalLightboxDialogCloseToken$ = state(0);
+const resetLightboxDialogCloseSignal$ = resetSignal();
 
 export const lightboxUrl$ = computed((get) => {
   return get(internalLightboxState$);
@@ -121,14 +123,21 @@ const closeLightboxForDialogExitToken$ = command(
   },
 );
 
-export const closeLightboxWithDialogExit$ = command(({ get, set }) => {
-  const token = get(internalLightboxDialogCloseToken$) + 1;
-  set(internalLightboxDialogCloseToken$, token);
-  set(internalLightboxDialogVisible$, false);
-  window.setTimeout(() => {
-    set(closeLightboxForDialogExitToken$, token);
-  }, LIGHTBOX_DIALOG_EXIT_DURATION_MS);
-});
+export const closeLightboxWithDialogExit$ = command(
+  ({ get, set }, signal: AbortSignal) => {
+    const closeSignal = set(resetLightboxDialogCloseSignal$, signal);
+    const token = get(internalLightboxDialogCloseToken$) + 1;
+    set(internalLightboxDialogCloseToken$, token);
+    set(internalLightboxDialogVisible$, false);
+    timeout(
+      () => {
+        set(closeLightboxForDialogExitToken$, token);
+      },
+      LIGHTBOX_DIALOG_EXIT_DURATION_MS,
+      { signal: closeSignal },
+    );
+  },
+);
 
 /**
  * An open artifact sidebar owns every artifact click that could live in it, so
@@ -284,7 +293,7 @@ const closeLightboxOnEscape$ = command(
           e.preventDefault();
           e.stopPropagation();
           e.stopImmediatePropagation();
-          set(closeLightboxWithDialogExit$);
+          set(closeLightboxWithDialogExit$, signal);
         }
       },
       { capture: true, signal },

--- a/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import { timeout } from "signal-timers";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   zeroIntegrationsTelegramContract,
@@ -11,6 +12,7 @@ import { accept } from "../../lib/accept.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { writeToClipboard } from "./clipboard.ts";
 import { i18n } from "../../i18n/index.ts";
+import { resetSignal } from "../utils.ts";
 
 export type TelegramAddSetupStep = "token" | "domain" | "privacy" | "create";
 export type TelegramSetupCheckTarget = "token" | "domain" | "privacy";
@@ -39,7 +41,7 @@ const internalTelegramAddSetupState$ = state<TelegramAddSetupState>(
   initialTelegramAddSetupState(),
 );
 const internalTelegramCopiedValue$ = state<string | null>(null);
-const internalTelegramCopyTimeoutId$ = state<number | null>(null);
+const resetTelegramCopySignal$ = resetSignal();
 const internalTelegramFailedAvatarKeys$ = state<Record<string, boolean>>({});
 const internalTelegramSavingBotId$ = state<string | null>(null);
 const internalTelegramUnlinkingBotId$ = state<string | null>(null);
@@ -202,17 +204,22 @@ export const copyTelegramValue$ = command(
       return;
     }
 
-    const existingTimeoutId = get(internalTelegramCopyTimeoutId$);
-    if (existingTimeoutId !== null) {
-      window.clearTimeout(existingTimeoutId);
-    }
-
+    const copySignal = set(resetTelegramCopySignal$, signal);
     set(internalTelegramCopiedValue$, value);
-    const timeoutId = window.setTimeout(() => {
-      set(internalTelegramCopiedValue$, null);
-      set(internalTelegramCopyTimeoutId$, null);
-    }, 1500);
-    set(internalTelegramCopyTimeoutId$, timeoutId);
+    const clearCopiedValue = () => {
+      if (get(internalTelegramCopiedValue$) === value) {
+        set(internalTelegramCopiedValue$, null);
+      }
+    };
+    copySignal.addEventListener("abort", clearCopiedValue, { once: true });
+    timeout(
+      () => {
+        copySignal.removeEventListener("abort", clearCopiedValue);
+        clearCopiedValue();
+      },
+      1500,
+      { signal: copySignal },
+    );
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -1,4 +1,5 @@
 import type { MouseEvent } from "react";
+import { timeout } from "signal-timers";
 import {
   useGet,
   useSet,
@@ -813,16 +814,29 @@ function ChatThreadsSkeleton() {
   );
 }
 
-function markPointerFocus(viewport: HTMLElement) {
+function markPointerFocus(viewport: HTMLElement, signal: AbortSignal) {
+  signal.throwIfAborted();
   const token = Math.random().toString(36);
   viewport.dataset.sidebarPointerFocusToken = token;
-  viewport.ownerDocument.defaultView?.setTimeout(() => {
+  const clearPointerFocus = () => {
     if (viewport.dataset.sidebarPointerFocusToken !== token) {
       return;
     }
 
     delete viewport.dataset.sidebarPointerFocusToken;
-  }, 350);
+  };
+  const clearPointerFocusOnAbort = () => {
+    clearPointerFocus();
+  };
+  signal.addEventListener("abort", clearPointerFocusOnAbort, { once: true });
+  timeout(
+    () => {
+      signal.removeEventListener("abort", clearPointerFocusOnAbort);
+      clearPointerFocus();
+    },
+    350,
+    { signal },
+  );
 }
 
 function consumePointerFocus(viewport: HTMLElement) {
@@ -947,7 +961,7 @@ function ExpandedChatThreadsContent() {
       data-testid="sidebar-scroll-area"
       tabIndex={currentMainThreadId ? 0 : undefined}
       onPointerDownCapture={(event) => {
-        markPointerFocus(event.currentTarget);
+        markPointerFocus(event.currentTarget, pageSignal);
       }}
       onFocus={(event) => {
         if (event.target !== event.currentTarget) {

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -26,6 +26,7 @@ import type {
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ZeroChatAttachment } from "../../signals/zero-page/chat-draft";
 import type { ChatPanelSignals } from "../../signals/chat-page/chat-panel-signals.ts";
+import { rootSignal$ } from "../../signals/root-signal.ts";
 import {
   currentLeftThread$,
   currentRightThread$,
@@ -1115,6 +1116,7 @@ function ArtifactPreviewDialogActions({
   preview: AttachmentLightboxState;
 }) {
   const { t } = useTranslation();
+  const rootSignal = useGet(rootSignal$);
   const closeLightboxWithDialogExit = useSet(closeLightboxWithDialogExit$);
   const openArtifactSidebarPreview = useSet(openThreadArtifactSplitView$);
   const resetZoomableImageCanvasZoom = useSet(resetZoomableImageCanvasZoom$);
@@ -1139,7 +1141,7 @@ function ArtifactPreviewDialogActions({
       );
     }
     openArtifactSidebarPreview(preview.url);
-    closeLightboxWithDialogExit();
+    closeLightboxWithDialogExit(rootSignal);
   };
   return (
     <div className="flex shrink-0 items-center gap-1">
@@ -1179,7 +1181,7 @@ function ArtifactPreviewDialogActions({
           return $.artifacts.actions.close;
         })}
         onClick={() => {
-          closeLightboxWithDialogExit();
+          closeLightboxWithDialogExit(rootSignal);
         }}
       >
         <IconX size={18} stroke={1.8} />
@@ -1198,6 +1200,7 @@ function ArtifactPreviewDialogContent({
   preview: AttachmentLightboxState;
 }) {
   const { t } = useTranslation();
+  const rootSignal = useGet(rootSignal$);
   const dialogRef = useSet(lightboxDialogRef$);
   const closeLightboxWithDialogExit = useSet(closeLightboxWithDialogExit$);
   const filename = artifact?.filename ?? artifactDialogFilename(preview);
@@ -1206,7 +1209,7 @@ function ArtifactPreviewDialogContent({
   const fullscreen = useGet(lightboxDialogFullscreen$);
 
   const closeWithAnimation = () => {
-    closeLightboxWithDialogExit();
+    closeLightboxWithDialogExit(rootSignal);
   };
 
   const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## Summary

- replace the remaining native `setTimeout`/`clearTimeout` usage in Platform source and tests with `signal-timers`
- bind one-shot work to real root, page, recording, dialog, or test lifecycle signals; use `resetSignal` for restartable timers
- replace the never-aborting app root placeholder with a page-owned root signal and preserve parent-vs-local abort semantics for the skeleton loop
- keep copied-state, viewport settle, lightbox exit, voice silence, bootstrap toast, telemetry load, sidebar focus, and mock delays cancellable

## Verification

- `pnpm --filter @vm0/app run lint`
- `pnpm knip`
- full `pnpm check-types` via the pre-commit hook
- 29 targeted Vitest cases covering viewport settle, runtime telemetry, voice silence, attachment close, Telegram copy, chat copy, bootstrap cancellation, and sidebar focus
- native timer scan across `turbo/apps/platform/src` returns no matches
