### PR TITLE
test(runner): remove simulated profile mismatch coverage

### DIFF
--- a/crates/runner/src/executor/tests/sandbox_run_tests/idle_pool.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/idle_pool.rs
@@ -76,27 +76,3 @@ async fn idle_pool_park_and_reuse_cycle() {
     assert_eq!(reuse_outcome.exit_code(), 0);
     assert!(reuse_outcome.sandbox.is_some());
 }
-
-#[tokio::test]
-async fn idle_pool_profile_mismatch_returns_none() {
-    use crate::idle_pool::{IdlePool, IdlePoolConfig, test_support::ParkedIdleCandidateBuilder};
-
-    let mut pool = IdlePool::new(IdlePoolConfig {
-        default_timeout: std::time::Duration::from_secs(300),
-        max_idle: 0,
-    });
-
-    // Park with profile "vm0/default"
-    let entry = ParkedIdleCandidateBuilder::new("test-session", test_budget_lease())
-        .with_mock_sandbox_name("test")
-        .build();
-    let _ = pool.park(entry);
-
-    // Take and verify profile
-    let taken = pool.take("test-session").expect("should find");
-    assert_eq!(taken.profile_name(), "vm0/default");
-
-    // Simulate caller checking profile mismatch
-    let matches_browser = taken.profile_name() == "vm0/browser";
-    assert!(!matches_browser, "should not match different profile");
-}


### PR DESCRIPTION
## Summary

- remove the sandbox-run test that simulated profile mismatch with a local string comparison
- retain the direct idle-pool reservation test and start-loop mismatch lifecycle coverage
- keep the distinct sandbox park, unpark, and reused-execution test unchanged

## Scope

This is test-only cleanup. It does not change runner behavior, APIs, protocols, persisted data, migrations, security boundaries, or deployment compatibility.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-features reusable_reservation_is_exclusive_and_restorable`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-features profile_mismatch_destroys_stale_vm`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-features idle_pool_park_and_reuse_cycle`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`

Closes #25236
