### PR TITLE
fix(runner): retain anthropic accounting telemetry

### DIFF
--- a/crates/runner/mitm-addon/src/anthropic_accounting.py
+++ b/crates/runner/mitm-addon/src/anthropic_accounting.py
@@ -1,0 +1,128 @@
+"""Bounded retry ownership for incomplete Anthropic SSE accounting telemetry."""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+from mitmproxy import http
+
+import body_decoding
+import flow_metadata
+import usage
+from usage.reporting_context import usage_reporting_context
+from usage.underbilling import log_usage_underbilling
+
+AnthropicAccountingStatus = Literal[
+    "no_recoverable_usage",
+    "recovered_partial",
+    "recovered_terminal",
+]
+
+_ACTION_TYPES: dict[AnthropicAccountingStatus, str] = {
+    "no_recoverable_usage": "anthropic_sse_incomplete_no_recoverable_usage",
+    "recovered_partial": "anthropic_sse_incomplete_recovered_partial",
+    "recovered_terminal": "anthropic_sse_incomplete_recovered_terminal",
+}
+_LOG_TYPE = "anthropic_sse_accounting"
+_RETENTION_SATURATED_REASON = "anthropic_accounting_retention_saturated"
+
+MAX_RETAINED_REPORTS = usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS
+
+
+@dataclass(frozen=True)
+class _RetainedReport:
+    url: str
+    sandbox_token: str
+    payload: dict[str, object]
+    proxy_log_path: str
+    buffered_report: usage.BufferedReportLease
+
+
+_retained_reports: deque[_RetainedReport] = deque()
+_retained_reports_lock = threading.Lock()
+
+
+def report_incomplete(
+    flow: http.HTTPFlow,
+    accounting_status: AnthropicAccountingStatus,
+) -> None:
+    """Report incomplete accounting or retain it for runner-flush admission."""
+    run_id = flow_metadata.run_id(flow.metadata)
+    context = usage_reporting_context(flow)
+    if not run_id or not context.is_complete:
+        return
+
+    action_type = _ACTION_TYPES[accounting_status]
+    payload: dict[str, object] = {
+        "runId": run_id,
+        "sandboxOperations": [
+            {
+                "ts": datetime.now(UTC).isoformat(),
+                "action_type": action_type,
+                "duration_ms": 0,
+                "success": False,
+                "error": body_decoding.INCOMPLETE_COMPRESSED_BODY,
+            }
+        ],
+    }
+
+    retention_saturated = False
+    with _retained_reports_lock:
+        if len(_retained_reports) >= MAX_RETAINED_REPORTS:
+            _admit_retained_locked()
+        if len(_retained_reports) >= MAX_RETAINED_REPORTS:
+            retention_saturated = True
+        else:
+            _retained_reports.append(
+                _RetainedReport(
+                    url=context.telemetry_url(),
+                    sandbox_token=context.sandbox_token,
+                    payload=payload,
+                    proxy_log_path=context.proxy_log_path,
+                    buffered_report=usage.admit_buffered_report(),
+                )
+            )
+            _admit_retained_locked()
+
+    if retention_saturated:
+        log_usage_underbilling(
+            context.proxy_log_path,
+            "Anthropic incomplete-accounting report could not be retained",
+            _RETENTION_SATURATED_REASON,
+            "risk",
+            action_type=action_type,
+            run_id=run_id,
+            retained_report_capacity=MAX_RETAINED_REPORTS,
+        )
+
+
+def retry_all_pending() -> None:
+    """Retry retained reports in FIFO order until delivery is saturated."""
+    with _retained_reports_lock:
+        _admit_retained_locked()
+
+
+def _admit_retained_locked() -> None:
+    while _retained_reports:
+        report = _retained_reports[0]
+        if not usage.webhook.enqueue_webhook_delivery(
+            report.url,
+            report.sandbox_token,
+            report.payload,
+            report.proxy_log_path,
+            _LOG_TYPE,
+        ):
+            return
+        _retained_reports.popleft()
+        report.buffered_report.release()
+
+
+def reset_for_tests() -> None:
+    """Release retained ownership and reset module state between tests."""
+    with _retained_reports_lock:
+        while _retained_reports:
+            _retained_reports.popleft().buffered_report.release()

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1900,7 +1900,7 @@ def done():
     """Flush pending usage reports and forwarding workers before mitmproxy exits.
 
     The runner flush lifecycle waits for any active SIGUSR1 delivery worker,
-    retries buffered usage and provider-output timing reports, drains accepted
+    retries buffered usage and retained diagnostic reports, drains accepted
     requests, and closes admission before this hook shuts down the usage
     executor. It also performs a final JSONL marker observation and joins the
     marker watcher before the JSONL writer stops. Any retryable usage outcome

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -18,12 +18,12 @@ Lifecycle:
 """
 
 from collections.abc import Callable
-from datetime import UTC, datetime
-from typing import Literal, NamedTuple
+from typing import NamedTuple
 
 from mitmproxy import http
 from wsproto.utilities import generate_accept_token
 
+import anthropic_accounting
 import body_decoding
 import claude_output_timing
 import flow_metadata
@@ -31,7 +31,6 @@ import flow_metadata_keys as metadata_keys
 import usage
 from body_limits import STREAM_BUFFER_LIMIT
 from logging_utils import log_proxy_entry
-from usage.reporting_context import usage_reporting_context
 from usage.underbilling import log_usage_underbilling
 
 _HTTP_STATUS_SWITCHING_PROTOCOLS = 101
@@ -52,19 +51,6 @@ _HTTP_OWS_CHARS = " \t"
 _ANTHROPIC_MESSAGES_SSE_PROTOCOL = "anthropic_messages_sse"
 _ANTHROPIC_USAGE_EVENTS = frozenset(("message_start", "message_delta"))
 _ANTHROPIC_MESSAGE_STOP_EVENT = "message_stop"
-_ANTHROPIC_ACCOUNTING_TELEMETRY_LOG_TYPE = "anthropic_sse_accounting"
-
-_AnthropicAccountingStatus = Literal[
-    "no_recoverable_usage",
-    "recovered_partial",
-    "recovered_terminal",
-]
-
-_ANTHROPIC_ACCOUNTING_ACTION_TYPES: dict[_AnthropicAccountingStatus, str] = {
-    "no_recoverable_usage": "anthropic_sse_incomplete_no_recoverable_usage",
-    "recovered_partial": "anthropic_sse_incomplete_recovered_partial",
-    "recovered_terminal": "anthropic_sse_incomplete_recovered_terminal",
-}
 
 _ResponseChunkParser = Callable[[bytes], None]
 _SseUsageParseErrorLogger = Callable[[str, str], None]
@@ -74,7 +60,7 @@ _AnthropicLifecycleObserver = Callable[[str, str | None], None]
 def _anthropic_incomplete_accounting_status(
     usage_dict: dict,
     accounting_events: set[str],
-) -> _AnthropicAccountingStatus:
+) -> anthropic_accounting.AnthropicAccountingStatus:
     has_recoverable_usage = bool(accounting_events & _ANTHROPIC_USAGE_EVENTS) and (
         usage.has_positive_model_provider_usage(usage_dict)
     )
@@ -83,36 +69,6 @@ def _anthropic_incomplete_accounting_status(
     if _ANTHROPIC_MESSAGE_STOP_EVENT in accounting_events:
         return "recovered_terminal"
     return "recovered_partial"
-
-
-def _report_anthropic_incomplete_accounting(
-    flow: http.HTTPFlow,
-    accounting_status: _AnthropicAccountingStatus,
-) -> None:
-    run_id = flow_metadata.run_id(flow.metadata)
-    context = usage_reporting_context(flow)
-    if not run_id or not context.is_complete:
-        return
-
-    payload: dict[str, object] = {
-        "runId": run_id,
-        "sandboxOperations": [
-            {
-                "ts": datetime.now(UTC).isoformat(),
-                "action_type": _ANTHROPIC_ACCOUNTING_ACTION_TYPES[accounting_status],
-                "duration_ms": 0,
-                "success": False,
-                "error": body_decoding.INCOMPLETE_COMPRESSED_BODY,
-            }
-        ],
-    }
-    usage.webhook.enqueue_webhook_delivery(
-        context.telemetry_url(),
-        context.sandbox_token,
-        payload,
-        context.proxy_log_path,
-        _ANTHROPIC_ACCOUNTING_TELEMETRY_LOG_TYPE,
-    )
 
 
 class CapturedResponseStreamBody(NamedTuple):
@@ -312,7 +268,7 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
                             usage_dict,
                             anthropic_accounting_events,
                         )
-                        _report_anthropic_incomplete_accounting(
+                        anthropic_accounting.report_incomplete(
                             flow,
                             accounting_status,
                         )

--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -11,6 +11,7 @@ from typing import Literal
 
 from mitmproxy import ctx
 
+import anthropic_accounting
 import claude_output_timing
 import codex_output_timing
 import logging_utils
@@ -216,8 +217,9 @@ def _flush_usage_for_runner_request() -> None:
 
 
 def _flush_delivery_work(*, trigger: _DeliveryFlushTrigger) -> None:
-    """Admit billing work before retained diagnostic timing reports."""
+    """Admit billing work before retained diagnostic reports."""
     usage.flush_usage_events(trigger=trigger)
+    anthropic_accounting.retry_all_pending()
     claude_output_timing.retry_all_pending()
     codex_output_timing.retry_all_pending()
 

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -17,13 +17,13 @@ The stable facade covers:
   used by the runner's usage-flush and shutdown protocol.
 
 Production consumers use this package facade for proxy hooks and response
-processing, runner flush lifecycle and terminal reporting, and Claude/Codex
-provider-output timing.
+processing, runner flush lifecycle and terminal reporting, and retained
+diagnostic telemetry.
 Tests should exercise public hook, provider, and lifecycle paths at their
 observable boundaries: runner-visible pending state and in-flight accounting,
 plus the local HTTP webhook boundary. Avoid patching private transport internals.
 Delivery admission tests may target the production ``usage.webhook`` enqueue
-boundary used by buffered usage and provider-output timing; retry and transport
+boundary used by buffered usage and diagnostic telemetry; retry and transport
 helpers remain private.
 """
 

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -25,6 +25,7 @@ import pytest
 from mitmproxy import http, tcp
 from mitmproxy.test import tflow, tutils
 
+import anthropic_accounting
 import auth
 import auth_base_forwarder
 import aws_sigv4_body_admission
@@ -69,6 +70,7 @@ def _reset_module_state() -> Iterator[None]:
     platform_api.configure_client_headers(client_session_id="", client_version="")
     clear_auth_state()
     _usage_connectors._unregistered_handler_warned.clear()
+    anthropic_accounting.reset_for_tests()
     claude_output_timing.reset_for_tests()
     codex_model_catalog_cache.reset_for_tests()
     codex_output_timing.reset_for_tests()
@@ -79,6 +81,7 @@ def _reset_module_state() -> Iterator[None]:
     yield
     runner_flush_lifecycle.reset_runner_usage_flush_state_for_tests()
     usage.reset_usage_buffer_for_tests()
+    anthropic_accounting.reset_for_tests()
     claude_output_timing.reset_for_tests()
     codex_model_catalog_cache.reset_for_tests()
     codex_output_timing.reset_for_tests()

--- a/crates/runner/mitm-addon/tests/pending_helpers.py
+++ b/crates/runner/mitm-addon/tests/pending_helpers.py
@@ -26,7 +26,7 @@ def assert_pending(
     flows, including billable model-provider and connector flows plus
     non-billable observable model-provider flows.  ``buffered`` is the number
     of unadmitted addon work units, including usage source events and retained
-    provider timing reports, and ``reports`` is the number of pending webhook
+    diagnostic reports, and ``reports`` is the number of pending webhook
     report deliveries.
 
     When ``flush_request_id`` is provided, the snapshot must include a matching

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -7,12 +7,14 @@ import zlib
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
+from unittest.mock import patch
 
 import brotli
 import pytest
 from mitmproxy import http
 from mitmproxy.flow import Error
 
+import anthropic_accounting
 import body_decoding
 import flow_metadata_keys as metadata_keys
 import mitm_addon
@@ -23,10 +25,17 @@ from tests.jsonl_log_helpers import (
     read_jsonl_entries_after_flush,
 )
 from tests.model_provider_flow_helpers import make_model_provider_sse_flow
+from tests.pending_helpers import assert_current_pending, assert_pending
+from tests.usage_buffer_helpers import event as usage_event
 from tests.usage_helpers import (
     CapturedWebhookRequest,
     UsageWebhookServer,
     compact_observation_quantities,
+)
+from tests.webhook_test_helpers import (
+    QueuedUsageExecutor,
+    install_runner_usage_flush_request,
+    request_runner_usage_flush,
 )
 
 _TELEMETRY_PATH = "/api/webhooks/agent/telemetry"
@@ -90,6 +99,24 @@ def _compress_zlib_sse(body: bytes, encoding: str) -> bytes:
         return gzip.compress(body)
     assert encoding == "deflate"
     return zlib.compress(body)
+
+
+def _feed_incomplete_anthropic_sse_without_recoverable_usage(
+    flow: http.HTTPFlow,
+    *,
+    encoding: str = "gzip",
+) -> None:
+    assert flow.response is not None
+    flow.response.headers["content-encoding"] = encoding
+    plaintext = (
+        b"event: message_start\n"
+        b'data: {"type":"message_start","message":{"model":"claude-sonnet-4-6",'
+        b'"usage":{"input_tokens":0,"output_tokens":0}}}\n\n'
+        b"event: message_stop\n"
+        b'data: {"type":"message_stop"}\n\n'
+    )
+    mitm_addon.responseheaders(flow)
+    response_stream(flow)(_compress_zlib_sse(plaintext, encoding)[:-1])
 
 
 def _anthropic_accounting_requests(
@@ -454,18 +481,10 @@ class TestModelProviderSseUsage:
         self, tmp_path, real_flow, encoding
     ):
         flow = _anthropic_messages_sse_flow(tmp_path, real_flow)
-        assert flow.response is not None
-        flow.response.headers["content-encoding"] = encoding
-        plaintext = (
-            b"event: message_start\n"
-            b'data: {"type":"message_start","message":{"model":"claude-sonnet-4-6",'
-            b'"usage":{"input_tokens":0,"output_tokens":0}}}\n\n'
-            b"event: message_stop\n"
-            b'data: {"type":"message_stop"}\n\n'
+        _feed_incomplete_anthropic_sse_without_recoverable_usage(
+            flow,
+            encoding=encoding,
         )
-
-        mitm_addon.responseheaders(flow)
-        response_stream(flow)(_compress_zlib_sse(plaintext, encoding)[:-1])
         webhook = self._run_response(flow)
 
         assert webhook.usage_events() == []
@@ -478,6 +497,180 @@ class TestModelProviderSseUsage:
             event="compressed_body",
             error=body_decoding.INCOMPLETE_COMPRESSED_BODY,
         )
+
+    def test_saturated_incomplete_anthropic_accounting_retries_through_runner_flush(
+        self,
+        tmp_path: Path,
+        real_flow,
+        mitm_ctx,
+        usage_webhook_server: UsageWebhookServer,
+    ) -> None:
+        flow = _anthropic_messages_sse_flow(tmp_path, real_flow)
+        executor = QueuedUsageExecutor()
+        pending_path = install_runner_usage_flush_request(tmp_path)
+
+        with (
+            mitm_ctx(api_url=usage_webhook_server.api_url),
+            patch.object(usage.webhook, "usage_executor", executor),
+        ):
+            for index in range(usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS):
+                assert usage.webhook.enqueue_webhook_delivery(
+                    usage_webhook_server.url("/filler"),
+                    "tok-xyz",
+                    {"runId": f"filler-{index}", "events": []},
+                    str(tmp_path / "filler.jsonl"),
+                    "usage_event",
+                )
+
+            _feed_incomplete_anthropic_sse_without_recoverable_usage(flow)
+            mitm_addon.response(flow)
+            retained_at = datetime.now(UTC)
+
+            assert _anthropic_accounting_requests(usage_webhook_server) == []
+            assert_current_pending(
+                pending_path,
+                flows=0,
+                buffered=1,
+                reports=usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS,
+            )
+
+            assert (
+                usage.buffer_usage_events(
+                    usage_webhook_server.url("/usage-priority"),
+                    "tok-xyz",
+                    "usage-priority",
+                    [usage_event(source_key="usage-priority")],
+                    str(tmp_path / "proxy.jsonl"),
+                )
+                == 1
+            )
+            request_runner_usage_flush()
+            assert_pending(
+                pending_path,
+                flows=0,
+                buffered=2,
+                reports=usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS,
+                flush_request_id="request-1",
+            )
+
+            executor.run_next()
+            request_runner_usage_flush()
+            assert_pending(
+                pending_path,
+                flows=0,
+                buffered=2,
+                reports=usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS,
+                flush_request_id="request-1",
+            )
+
+            executor.run_last()
+            request_runner_usage_flush()
+            assert_pending(
+                pending_path,
+                flows=0,
+                buffered=0,
+                reports=usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS,
+                flush_request_id="request-1",
+            )
+
+            executor.run_all()
+            request_runner_usage_flush()
+            assert_pending(
+                pending_path,
+                flows=0,
+                buffered=0,
+                reports=0,
+                flush_request_id="request-1",
+            )
+            request_runner_usage_flush()
+
+        [request] = _anthropic_accounting_requests(usage_webhook_server)
+        assert request.json_body()["runId"] == "00000000-0000-0000-0000-000000025133"
+        [operation] = _anthropic_accounting_operations(usage_webhook_server)
+        assert operation["action_type"] == "anthropic_sse_incomplete_no_recoverable_usage"
+        assert datetime.fromisoformat(str(operation["ts"])) <= retained_at
+        assert [
+            captured.path
+            for captured in usage_webhook_server.requests
+            if captured.path != "/filler"
+        ] == ["/usage-priority", _TELEMETRY_PATH]
+        assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+
+    def test_incomplete_anthropic_accounting_retention_overflow_is_action_specific(
+        self,
+        tmp_path: Path,
+        real_flow,
+        mitm_ctx,
+        usage_webhook_server: UsageWebhookServer,
+    ) -> None:
+        first_flow = _anthropic_messages_sse_flow(tmp_path, real_flow)
+        first_flow.metadata[metadata_keys.VM_RUN_ID] = "run-retained"
+        overflow_flow = _anthropic_messages_sse_flow(tmp_path, real_flow)
+        overflow_flow.metadata[metadata_keys.VM_RUN_ID] = "run-overflow"
+        executor = QueuedUsageExecutor()
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
+
+        with (
+            mitm_ctx(api_url=usage_webhook_server.api_url),
+            patch.object(usage.webhook, "usage_executor", executor),
+            patch.object(anthropic_accounting, "MAX_RETAINED_REPORTS", 1),
+        ):
+            for index in range(usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS):
+                assert usage.webhook.enqueue_webhook_delivery(
+                    usage_webhook_server.url("/filler"),
+                    "tok-xyz",
+                    {"runId": f"filler-{index}", "events": []},
+                    str(tmp_path / "filler.jsonl"),
+                    "usage_event",
+                )
+
+            _feed_incomplete_anthropic_sse_without_recoverable_usage(first_flow)
+            mitm_addon.response(first_flow)
+            _feed_incomplete_anthropic_sse_without_recoverable_usage(overflow_flow)
+            mitm_addon.response(overflow_flow)
+
+            assert_current_pending(
+                pending_path,
+                flows=0,
+                buffered=1,
+                reports=usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS,
+            )
+            overflow_entries = [
+                entry
+                for entry in read_jsonl_entries_after_flush(
+                    Path(overflow_flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+                )
+                if entry.get("reason") == "anthropic_accounting_retention_saturated"
+            ]
+            [overflow_entry] = overflow_entries
+            assert overflow_entry["type"] == "usage_underbilling"
+            assert overflow_entry["underbilling_class"] == "risk"
+            assert overflow_entry["component"] == "mitm_addon"
+            assert overflow_entry["action_type"] == (
+                "anthropic_sse_incomplete_no_recoverable_usage"
+            )
+            assert overflow_entry["run_id"] == "run-overflow"
+            assert overflow_entry["retained_report_capacity"] == 1
+            assert "tok-xyz" not in json.dumps(overflow_entry)
+
+            anthropic_accounting.reset_for_tests()
+            assert_current_pending(
+                pending_path,
+                flows=0,
+                buffered=0,
+                reports=usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS,
+            )
+            executor.run_all()
+
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+        )
+        assert _anthropic_accounting_requests(usage_webhook_server) == []
+        assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
 
     def test_full_pipeline_incomplete_compressed_anthropic_sse_does_not_flush_fragment(
         self, tmp_path, real_flow


### PR DESCRIPTION
## Summary

- retain incomplete Anthropic SSE accounting telemetry when webhook admission is saturated
- expose retained reports through the runner-visible buffered counter and retry them after billing work during repeated runner flushes
- bound retention to one delivery queue, emit an action-specific underbilling signal on overflow, and preserve FIFO/exactly-once ownership transfer
- cover saturation, billing priority, eventual delivery, overflow privacy, reset, and counter cleanup through real addon hooks

## Scope

- no API, database schema, persisted format, runner protocol, deployment configuration, or compatibility shim changes
- no timer, background thread, or synchronous network retry added to the response hook

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_model_provider_sse_usage.py` (40 passed)
- `uv run --no-sync python -m pytest tests/` (4797 passed)

Closes #25232
