### PR TITLE
perf(runner): split codex agent and upstream latency

### DIFF
--- a/crates/runner/mitm-addon/src/codex_output_timing.py
+++ b/crates/runner/mitm-addon/src/codex_output_timing.py
@@ -1,4 +1,4 @@
-"""Run-scoped, content-free provider-output timing for default Codex runs.
+"""Run-scoped, content-free provider request/output timing for Codex runs.
 
 State is keyed by ``run_id``, not WebSocket flow, so first-milestone selection
 spans provider responses, tool turns, and Responses WebSocket reconnections.
@@ -24,10 +24,14 @@ from mitmproxy import http
 import flow_metadata
 import provider_timing_store
 
+FIRST_GENERATED_RESPONSE_CREATE_SENT = "codex_proxy_first_generated_response_create_sent"
 FIRST_GENERATED_RESPONSE_CREATED = "codex_proxy_first_generated_response_created"
 FIRST_OUTPUT_ITEM_ADDED = "codex_proxy_first_output_item_added"
 FIRST_OUTPUT_TEXT_DELTA = "codex_proxy_first_output_text_delta"
+FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE = "codex_proxy_first_text_in_first_generated_response"
+FIRST_TEXT_IN_LATER_GENERATED_RESPONSE = "codex_proxy_first_text_in_later_generated_response"
 
+_RESPONSE_CREATE_EVENT = "response.create"
 _RESPONSE_CREATED_EVENT = "response.created"
 _OUTPUT_ITEM_ADDED_EVENT = "response.output_item.added"
 _OUTPUT_TEXT_DELTA_EVENT = "response.output_text.delta"
@@ -40,9 +44,11 @@ _LOG_TYPE = "codex_output_timing"
 
 @dataclass
 class _RunTimingState(provider_timing_store.ProviderTimingState):
+    candidate_response_create_sent_at: str | None = None
     candidate_response_created_at: str | None = None
     generated_response_selected: bool = False
     first_text_observed: bool = False
+    later_response_before_text: bool = False
 
 
 _store = provider_timing_store.ProviderTimingStore(
@@ -50,6 +56,33 @@ _store = provider_timing_store.ProviderTimingStore(
     log_type=_LOG_TYPE,
     max_tracked_runs=_MAX_TRACKED_RUNS,
 )
+
+
+def observe_client_event(
+    flow: http.HTTPFlow,
+    event_type: str | None,
+    received_at: float,
+) -> None:
+    """Advance one run's timing state from a received client Responses event."""
+    if event_type != _RESPONSE_CREATE_EVENT:
+        return
+
+    run_id = flow_metadata.run_id(flow.metadata)
+    if not run_id:
+        return
+
+    with _store.locked():
+        state = _store.state_for_run_locked(run_id)
+        if state.generated_response_selected:
+            if not state.first_text_observed:
+                state.later_response_before_text = True
+            _store.admit_pending_locked(flow, run_id, state)
+            return
+
+        state.candidate_response_create_sent_at = datetime.fromtimestamp(
+            received_at, UTC
+        ).isoformat()
+        state.candidate_response_created_at = None
 
 
 def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
@@ -74,6 +107,8 @@ def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
             state = _store.state_for_run_locked(run_id)
             if not state.generated_response_selected:
                 state.candidate_response_created_at = _observation_time()
+            elif not state.first_text_observed:
+                state.later_response_before_text = True
             _store.admit_pending_locked(flow, run_id, state)
             return
 
@@ -85,10 +120,15 @@ def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
                 _store.touch_locked(run_id)
             if not state.generated_response_selected:
                 state.generated_response_selected = True
+                if state.candidate_response_create_sent_at is not None:
+                    state.pending_operations[FIRST_GENERATED_RESPONSE_CREATE_SENT] = (
+                        state.candidate_response_create_sent_at
+                    )
                 if state.candidate_response_created_at is not None:
                     state.pending_operations[FIRST_GENERATED_RESPONSE_CREATED] = (
                         state.candidate_response_created_at
                     )
+                state.candidate_response_create_sent_at = None
                 state.candidate_response_created_at = None
                 state.pending_operations[FIRST_OUTPUT_ITEM_ADDED] = _observation_time()
                 _store.admit_pending_locked(flow, run_id, state)
@@ -100,7 +140,14 @@ def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
             _store.touch_locked(run_id)
             if not state.first_text_observed:
                 state.first_text_observed = True
-                state.pending_operations[FIRST_OUTPUT_TEXT_DELTA] = _observation_time()
+                observed_at = _observation_time()
+                state.pending_operations[FIRST_OUTPUT_TEXT_DELTA] = observed_at
+                text_path = (
+                    FIRST_TEXT_IN_LATER_GENERATED_RESPONSE
+                    if state.later_response_before_text
+                    else FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE
+                )
+                state.pending_operations[text_path] = observed_at
                 _store.admit_pending_locked(flow, run_id, state)
             return
 
@@ -111,6 +158,8 @@ def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
         if not state.generated_response_selected:
             _store.discard_locked(run_id)
             return
+        if not state.first_text_observed:
+            state.later_response_before_text = True
         _store.admit_pending_locked(flow, run_id, state)
 
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1559,12 +1559,13 @@ def websocket_message(flow: http.HTTPFlow) -> None:
     if not response_streaming.is_model_websocket_usage_enabled(flow):
         return
     uses_openai_responses = response_streaming.uses_openai_responses_usage_protocol(flow)
-    body = message.content.encode() if isinstance(message.content, str) else message.content
     if getattr(message, "from_client", False):
         if uses_openai_responses:
+            body = message.content.encode() if isinstance(message.content, str) else message.content
             event_type = usage.inspect_openai_responses_event_type_json(body)
             codex_output_timing.observe_client_event(flow, event_type, message.timestamp)
         return
+    body = message.content.encode() if isinstance(message.content, str) else message.content
     event = usage.inspect_openai_responses_event_json(body)
     if uses_openai_responses:
         codex_output_timing.observe_server_event(flow, event.event_type)

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1548,7 +1548,7 @@ def responseheaders(flow: http.HTTPFlow) -> None:
 
 
 def websocket_message(flow: http.HTTPFlow) -> None:
-    """Bound registered WebSocket history and feed model-provider usage."""
+    """Bound WebSocket history and observe model-provider protocol events."""
     if not flow.websocket or not flow.websocket.messages:
         return
     if not flow_metadata.run_id(flow.metadata):
@@ -1558,11 +1558,15 @@ def websocket_message(flow: http.HTTPFlow) -> None:
     websocket_retention.schedule_message_trim(flow)
     if not response_streaming.is_model_websocket_usage_enabled(flow):
         return
-    if getattr(message, "from_client", False):
-        return
+    uses_openai_responses = response_streaming.uses_openai_responses_usage_protocol(flow)
     body = message.content.encode() if isinstance(message.content, str) else message.content
+    if getattr(message, "from_client", False):
+        if uses_openai_responses:
+            event_type = usage.inspect_openai_responses_event_type_json(body)
+            codex_output_timing.observe_client_event(flow, event_type, message.timestamp)
+        return
     event = usage.inspect_openai_responses_event_json(body)
-    if response_streaming.uses_openai_responses_usage_protocol(flow):
+    if uses_openai_responses:
         codex_output_timing.observe_server_event(flow, event.event_type)
     response_streaming.feed_model_websocket_usage(flow, event)
 

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -61,6 +61,7 @@ from .openai_responses import (
     extract_openai_responses_usage_from_event,
     extract_openai_responses_usage_with_error_from_json,
     inspect_openai_responses_event_json,
+    inspect_openai_responses_event_type_json,
     merge_openai_responses_usage_result,
 )
 from .providers.connectors import (
@@ -104,6 +105,7 @@ __all__ = [
     "has_positive_model_provider_usage",
     "increment_in_flight_flows",
     "inspect_openai_responses_event_json",
+    "inspect_openai_responses_event_type_json",
     "is_model_provider_usage_observable",
     "merge_openai_responses_usage_result",
     "needs_connector_response_buffer_fallback",

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -11,10 +11,11 @@ model-provider usage billing:
   ``mitm_addon.py`` fallback used by legacy/test flows without
   response-streaming parser state.
 - Single-frame WebSocket event JSON via
-  ``inspect_openai_responses_event_json`` and
+  ``inspect_openai_responses_event_type_json``,
+  ``inspect_openai_responses_event_json``, and
   ``extract_openai_responses_usage_from_event``, consumed by
-  ``mitm_addon.py`` and ``response_streaming.py`` for Responses events received
-  over upgrades.
+  ``mitm_addon.py`` and ``response_streaming.py`` for client event-type timing
+  and server usage events received over upgrades.
 - Per-event usage aggregation via ``merge_openai_responses_usage_result``,
   used by ``response_streaming.py`` to fold terminal SSE and WebSocket event
   usage into a per-flow accumulator.
@@ -184,12 +185,16 @@ def inspect_openai_responses_event_json(body: bytes) -> OpenAIResponsesEvent:
     usage inspection.
     """
     result = _probe_responses_event_type(body)
-    event_type = result.value if result.status == "found" and result.value is not None else None
     return OpenAIResponsesEvent(
-        event_type=event_type,
+        event_type=_observed_responses_event_type(result),
         _body=body,
         _classification=_classify_responses_event_type_result(result),
     )
+
+
+def inspect_openai_responses_event_type_json(body: bytes) -> str | None:
+    """Probe one Responses frame for its top-level ``type`` without retaining it."""
+    return _observed_responses_event_type(_probe_responses_event_type(body))
 
 
 def _probe_responses_event_type(body: bytes) -> TopLevelStringFieldProbeResult:
@@ -199,6 +204,10 @@ def _probe_responses_event_type(body: bytes) -> TopLevelStringFieldProbeResult:
         max_depth=_JSON_PREFILTER_MAX_DEPTH,
         max_string_bytes=_JSON_PREFILTER_MAX_STRING_BYTES,
     )
+
+
+def _observed_responses_event_type(result: TopLevelStringFieldProbeResult) -> str | None:
+    return result.value if result.status == "found" and result.value is not None else None
 
 
 def _classify_responses_event_type(body: bytes) -> _ResponsesEventTypeClassification:

--- a/crates/runner/mitm-addon/tests/test_codex_output_timing.py
+++ b/crates/runner/mitm-addon/tests/test_codex_output_timing.py
@@ -1,4 +1,4 @@
-"""Tests for default Codex provider-output timing observations."""
+"""Tests for default Codex provider request/output timing observations."""
 
 import json
 import sys
@@ -32,9 +32,12 @@ from tests.webhook_test_helpers import (
 from usage import json_probe
 
 _TELEMETRY_PATH = "/api/webhooks/agent/telemetry"
+_FIRST_GENERATED_RESPONSE_CREATE_SENT = "codex_proxy_first_generated_response_create_sent"
 _FIRST_GENERATED_RESPONSE_CREATED = "codex_proxy_first_generated_response_created"
 _FIRST_OUTPUT_ITEM_ADDED = "codex_proxy_first_output_item_added"
 _FIRST_OUTPUT_TEXT_DELTA = "codex_proxy_first_output_text_delta"
+_FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE = "codex_proxy_first_text_in_first_generated_response"
+_FIRST_TEXT_IN_LATER_GENERATED_RESPONSE = "codex_proxy_first_text_in_later_generated_response"
 
 
 @pytest.fixture(autouse=True)
@@ -70,12 +73,31 @@ def _operations(requests: list[CapturedWebhookRequest]) -> list[dict[str, object
     return operations
 
 
+def _feed_client_event(
+    flow: http.HTTPFlow,
+    event: bytes,
+    *,
+    received_at: float | None = None,
+) -> None:
+    set_websocket_message(flow, from_client=True, content=event)
+    assert flow.websocket is not None
+    if received_at is not None:
+        flow.websocket.messages[-1].timestamp = received_at
+    mitm_addon.websocket_message(flow)
+
+
 def _feed_generated_response(
     flow: http.HTTPFlow,
     *,
     include_text: bool = True,
     secret: str | None = None,
+    request_received_at: float | None = None,
 ) -> None:
+    _feed_client_event(
+        flow,
+        _event("response.create", secret=secret),
+        received_at=request_received_at,
+    )
     feed_websocket_server_message(flow, _event("response.created", secret=secret))
     feed_websocket_server_message(flow, _event("response.output_item.added", secret=secret))
     if include_text:
@@ -92,30 +114,39 @@ def test_default_codex_excludes_prewarm_and_reports_content_free_milestones(
     flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
     proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
     secret = "provider-secret-that-must-not-be-reported"
+    generated_request_received_at = 1_700_000_000.125
 
     with mitm_ctx(api_url=usage_webhook_server.api_url):
         mitm_addon.responseheaders(flow)
+        _feed_client_event(flow, _event("response.create", secret=secret))
         feed_websocket_server_message(flow, _event("response.created", secret=secret))
         feed_websocket_server_message(flow, _event("response.completed", secret=secret))
         assert _timing_requests(usage_webhook_server) == []
 
-        _feed_generated_response(flow, secret=secret)
+        _feed_generated_response(
+            flow,
+            secret=secret,
+            request_received_at=generated_request_received_at,
+        )
 
     requests = _timing_requests(usage_webhook_server)
     assert len(requests) == 2
-    assert [len(request.json_body()["sandboxOperations"]) for request in requests] == [2, 1]
+    assert [len(request.json_body()["sandboxOperations"]) for request in requests] == [3, 2]
     assert all(request.header("authorization") == "Bearer tok-xyz" for request in requests)
 
     operations = _operations(requests)
     assert [operation["action_type"] for operation in operations] == [
+        _FIRST_GENERATED_RESPONSE_CREATE_SENT,
         _FIRST_GENERATED_RESPONSE_CREATED,
         _FIRST_OUTPUT_ITEM_ADDED,
         _FIRST_OUTPUT_TEXT_DELTA,
+        _FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE,
     ]
     assert all(operation["duration_ms"] == 0 for operation in operations)
     assert all(operation["success"] is True for operation in operations)
     timestamps = [datetime.fromisoformat(str(operation["ts"])) for operation in operations]
     assert timestamps == sorted(timestamps)
+    assert timestamps[0] == datetime.fromtimestamp(generated_request_received_at, UTC)
     assert all(request.json_body()["runId"] == "run-abc-123" for request in requests)
 
     serialized_requests = b"".join(request.body for request in requests)
@@ -157,17 +188,26 @@ def test_tool_turns_reconnects_and_reused_sandboxes_preserve_run_boundaries(
         assert isinstance(run_id, str)
         operations_by_run.setdefault(run_id, []).extend(_operations([request]))
 
-    expected_actions = [
+    first_run_actions = [
+        _FIRST_GENERATED_RESPONSE_CREATE_SENT,
         _FIRST_GENERATED_RESPONSE_CREATED,
         _FIRST_OUTPUT_ITEM_ADDED,
         _FIRST_OUTPUT_TEXT_DELTA,
+        _FIRST_TEXT_IN_LATER_GENERATED_RESPONSE,
+    ]
+    direct_run_actions = [
+        _FIRST_GENERATED_RESPONSE_CREATE_SENT,
+        _FIRST_GENERATED_RESPONSE_CREATED,
+        _FIRST_OUTPUT_ITEM_ADDED,
+        _FIRST_OUTPUT_TEXT_DELTA,
+        _FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE,
     ]
     assert {
         run_id: [operation["action_type"] for operation in operations]
         for run_id, operations in operations_by_run.items()
     } == {
-        "run-abc-123": expected_actions,
-        "run-reused-sandbox": expected_actions,
+        "run-abc-123": first_run_actions,
+        "run-reused-sandbox": direct_run_actions,
     }
 
 
@@ -189,6 +229,9 @@ def test_irrelevant_websocket_messages_do_not_report_timings(
             content=_event("response.output_item.added"),
         )
         mitm_addon.websocket_message(flow)
+        _feed_client_event(flow, b'{"type":')
+        _feed_client_event(flow, _event("future.client-event"))
+        _feed_client_event(flow, _event("response.create"))
         feed_websocket_server_message(flow, b'{"type":')
         feed_websocket_server_message(flow, _event("future.unknown"))
         feed_websocket_server_message(flow, _event("response.output_text.delta"))
@@ -204,10 +247,17 @@ def test_irrelevant_websocket_messages_do_not_report_timings(
     assert _timing_requests(usage_webhook_server) == []
 
 
-def test_server_websocket_event_type_is_probed_once(
+@pytest.mark.parametrize(
+    ("from_client", "event_type"),
+    [(True, "response.create"), (False, "response.output_text.delta")],
+)
+def test_websocket_event_type_is_probed_once(
     tmp_path: Path,
     real_flow,
     mitm_ctx,
+    *,
+    from_client: bool,
+    event_type: str,
 ) -> None:
     flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
     probe_code = json_probe.probe_top_level_string_field.__code__
@@ -223,7 +273,12 @@ def test_server_websocket_event_type_is_probed_once(
         mitm_addon.responseheaders(flow)
         sys.setprofile(count_probe)
         try:
-            feed_websocket_server_message(flow, _event("response.output_text.delta"))
+            set_websocket_message(
+                flow,
+                from_client=from_client,
+                content=_event(event_type),
+            )
+            mitm_addon.websocket_message(flow)
         finally:
             sys.setprofile(previous_profile)
 
@@ -411,13 +466,17 @@ def test_repeated_runner_flush_retries_saturated_timing_after_websocket_end(
     [request] = _timing_requests(usage_webhook_server)
     operations = _operations([request])
     assert [operation["action_type"] for operation in operations] == [
+        _FIRST_GENERATED_RESPONSE_CREATE_SENT,
         _FIRST_GENERATED_RESPONSE_CREATED,
         _FIRST_OUTPUT_ITEM_ADDED,
         _FIRST_OUTPUT_TEXT_DELTA,
+        _FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE,
     ]
-    created_at = datetime.fromisoformat(str(operations[0]["ts"]))
-    output_at = datetime.fromisoformat(str(operations[1]["ts"]))
-    text_at = datetime.fromisoformat(str(operations[2]["ts"]))
-    assert created_at <= output_at <= text_at <= first_flush_started_at
+    sent_at = datetime.fromisoformat(str(operations[0]["ts"]))
+    created_at = datetime.fromisoformat(str(operations[1]["ts"]))
+    output_at = datetime.fromisoformat(str(operations[2]["ts"]))
+    text_at = datetime.fromisoformat(str(operations[3]["ts"]))
+    path_at = datetime.fromisoformat(str(operations[4]["ts"]))
+    assert sent_at <= created_at <= output_at <= text_at == path_at <= first_flush_started_at
     assert secret.encode() not in request.body
     assert usage.webhook.pending_delivery_payload_count_for_tests() == 0


### PR DESCRIPTION
## Summary

- observe the received timestamp of client Codex `response.create` frames without retaining request payloads
- promote the first client request only after its sequential response produces output, preserving prewarm and retry exclusion
- label first text as occurring in the first generated response or a later generated response for unambiguous latency cohorts
- preserve the existing bounded run-state and asynchronous telemetry delivery contracts

## Behavior

The new fixed timing operations are:

- `codex_proxy_first_generated_response_create_sent`
- `codex_proxy_first_text_in_first_generated_response`
- `codex_proxy_first_text_in_later_generated_response`

The existing `response.created`, output-item, first-text, usage, and top-level product metrics keep their semantics. The change does not add a database migration, public API, feature switch, persisted state, runner protocol, or queue payload.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,796 passed)

Closes #25227

Parent context: #22892
