### PR TITLE
chore(cli): remove stale ngrok bundling exception

### DIFF
--- a/turbo/apps/cli/tsup.config.ts
+++ b/turbo/apps/cli/tsup.config.ts
@@ -27,14 +27,6 @@ export default defineConfig({
       "const require = __createRequire(import.meta.url);",
     ].join("\n"),
   },
-  // @ngrok/ngrok contains platform-specific native binaries (.node) that
-  // cannot be bundled by esbuild — must remain external.
-  // All other dependencies live in devDependencies and are bundled by tsup.
-  // @sentry/node was previously external due to ImportInTheMiddle ESM loader
-  // hook issues, but that was fixed upstream in sentry-javascript v8.8.0
-  // (see getsentry/sentry-javascript#12009). It is now in devDependencies
-  // and bundled like everything else.
-  external: ["@ngrok/ngrok"],
   // Resolve packages from the CLI's node_modules when bundling workspace deps
   // (e.g. @vm0/core imports zod, which lives in apps/cli/node_modules)
   esbuildOptions(options) {


### PR DESCRIPTION
## Summary

- remove the obsolete `@ngrok/ngrok` external from the Zero CLI tsup config
- remove the outdated comments describing the former native-module exception

## Verification

- `pnpm exec prettier --check apps/cli/tsup.config.ts`
- `pnpm --filter @vm0/zero-cli lint`
- `pnpm --filter @vm0/zero-cli check-types`
- `pnpm --filter @vm0/zero-cli build`
- built and verified the CLI artifact; dependency fields remain empty and emitted JavaScript contains no `@ngrok/ngrok` reference
