### PR TITLE
refactor(sandbox-fc): centralize snapshot spawn construction

### DIFF
--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -51,6 +51,7 @@ mod runtime;
 mod runtime_dirs;
 mod sandbox;
 mod snapshot;
+mod snapshot_mount_namespace;
 mod workspace_drive_image;
 
 pub use api::{ApiClient, ApiError, BalloonStatistics};

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -60,14 +60,12 @@ use crate::process_log::{
     read_process_log_records,
 };
 use crate::runtime_dirs::{prepare_private_runtime_vsock_dir, set_private_runtime_socket_mode};
+use crate::snapshot_mount_namespace::{BindMount, SnapshotMountMode, build_command};
 
 mod snapshot_restore;
 mod state;
 
-use snapshot_restore::{
-    SNAPSHOT_RESTORE_INNER_CMD, UNSHARE_MOUNT_ARGS, ensure_snapshot_drive_bind_target,
-    load_snapshot_and_apply_rate_limits,
-};
+use snapshot_restore::{ensure_snapshot_drive_bind_target, load_snapshot_and_apply_rate_limits};
 pub(crate) use state::SandboxState;
 use state::{
     publish_process_state, publish_watch_state, state_publish_guard, transition_process_state,
@@ -1143,11 +1141,9 @@ impl FirecrackerSandbox {
             "spawning firecracker (snapshot restore)"
         );
 
-        // Use positional args ($1..$9) to avoid shell injection from paths.
-        //
-        // Bind mount targets ($2, $4, $6) are snapshot-level paths shared by
-        // all sandboxes. Each sandbox runs inside `unshare --mount`, so bind
-        // mounts are per-namespace and don't conflict.
+        // Bind mount targets are snapshot-level paths shared by all sandboxes.
+        // Each sandbox runs inside `unshare --mount`, so bind mounts are
+        // per-namespace and don't conflict.
         //
         // IMPORTANT: we must NOT `rm -f` the bind mount target.  The target
         // file is shared across all mount namespaces via the underlying
@@ -1160,19 +1156,19 @@ impl FirecrackerSandbox {
         // namespace (e.g. from a crashed snapshot creation).
         let snapshot_str = snapshot.snapshot_path.display().to_string();
         let memory_str = snapshot.memory_path.display().to_string();
-        let mut command = tokio::process::Command::new("unshare");
-        command
-            .args(UNSHARE_MOUNT_ARGS)
-            .args(["bash", "-c", SNAPSHOT_RESTORE_INNER_CMD, "_"])
-            .arg(self.sock_paths.vsock_dir()) // $1
-            .arg(&snapshot.vsock_bind_dir) // $2
-            .arg(cow_device_path) // $3
-            .arg(&snapshot.drive_bind_path) // $4
-            .arg(&workspace_image_path) // $5
-            .arg(&snapshot.workspace_drive_bind_path) // $6
-            .arg(self.network.name()) // $7
-            .arg(&self.factory_config.binary_path) // $8
-            .arg(&api_sock); // $9
+        let command = build_command(
+            SnapshotMountMode::Restore {
+                vsock: BindMount::new(&self.sock_paths.vsock_dir(), &snapshot.vsock_bind_dir),
+                rootfs: BindMount::new(cow_device_path, &snapshot.drive_bind_path),
+                workspace: BindMount::new(
+                    &workspace_image_path,
+                    &snapshot.workspace_drive_bind_path,
+                ),
+            },
+            self.network.name(),
+            &self.factory_config.binary_path,
+            &api_sock,
+        );
 
         let client = self
             .spawn_and_wait_for_api(command, &api_sock, runtime_cancel, "snapshot restore")

--- a/crates/sandbox-fc/src/sandbox/snapshot_restore.rs
+++ b/crates/sandbox-fc/src/sandbox/snapshot_restore.rs
@@ -10,11 +10,6 @@ use crate::api::ApiClient;
 use crate::config::FirecrackerDeviceRateLimits;
 use crate::factory::InvariantConfig;
 
-/// Bash command run inside `unshare --mount` for snapshot restore.
-/// Positional args are documented at the spawn site.
-pub(super) const SNAPSHOT_RESTORE_INNER_CMD: &str = r#"umount -- "$4" 2>/dev/null; umount -- "$6" 2>/dev/null; mount --bind -- "$1" "$2" && mount --bind -- "$3" "$4" && mount --bind -- "$5" "$6" && exec ip netns exec "$7" "$8" --api-sock "$9""#;
-pub(super) const UNSHARE_MOUNT_ARGS: &[&str] = &["--mount", "--propagation", "private"];
-
 pub(super) async fn load_snapshot_and_apply_rate_limits(
     client: &ApiClient,
     snapshot_path: &str,
@@ -226,46 +221,6 @@ async fn unmount_snapshot_drive_bind_target(path: &Path) -> Result<(), SandboxEr
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn snapshot_restore_inner_cmd_uses_positional_args_without_touch() {
-        assert!(!SNAPSHOT_RESTORE_INNER_CMD.contains("$0"));
-        for arg in ["$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8", "$9"] {
-            let quoted = format!(r#""{arg}""#);
-            assert!(
-                SNAPSHOT_RESTORE_INNER_CMD.contains(&quoted),
-                "expected quoted positional {arg} in inner_cmd: {SNAPSHOT_RESTORE_INNER_CMD}"
-            );
-        }
-        for unexpected in ["$10", "$11"] {
-            assert!(
-                !SNAPSHOT_RESTORE_INNER_CMD.contains(unexpected),
-                "unexpected positional {unexpected} in inner_cmd: {SNAPSHOT_RESTORE_INNER_CMD}"
-            );
-        }
-
-        assert!(
-            SNAPSHOT_RESTORE_INNER_CMD.starts_with(
-                r#"umount -- "$4" 2>/dev/null; umount -- "$6" 2>/dev/null; mount --bind"#
-            ),
-            "inner_cmd must clear stale bind mount before binding: {SNAPSHOT_RESTORE_INNER_CMD}"
-        );
-        assert!(
-            SNAPSHOT_RESTORE_INNER_CMD.contains(
-                r#"&& mount --bind -- "$3" "$4" && mount --bind -- "$5" "$6" && exec ip netns exec"#
-            ),
-            "inner_cmd must bind COW and workspace devices before execing firecracker: {SNAPSHOT_RESTORE_INNER_CMD}"
-        );
-        assert!(
-            !SNAPSHOT_RESTORE_INNER_CMD.contains("touch"),
-            "bind target creation must stay in Rust: {SNAPSHOT_RESTORE_INNER_CMD}"
-        );
-    }
-
-    #[test]
-    fn snapshot_restore_unshare_uses_private_mount_propagation() {
-        assert_eq!(UNSHARE_MOUNT_ARGS, ["--mount", "--propagation", "private"]);
-    }
 
     #[test]
     fn mountinfo_contains_exact_snapshot_drive_bind_target() {

--- a/crates/sandbox-fc/src/snapshot/attempt/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/mod.rs
@@ -348,7 +348,8 @@ impl SnapshotAttempt {
 
         // Spawn Firecracker inside `unshare --mount` so the COW-device bind
         // mount lives in a private mount namespace and dies with the process.
-        // Mirrors the spawn pattern in `sandbox.rs::launch_from_snapshot`.
+        // The shared command builder keeps this mount setup aligned with
+        // snapshot restore.
         if let Err(e) = self.cleanup_resources.process.spawn(SnapshotProcessSpawn {
             cow_device_path: &cow_device_path,
             drive_bind: &drive_bind,

--- a/crates/sandbox-fc/src/snapshot/attempt/process.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/process.rs
@@ -13,11 +13,9 @@ use crate::process_log::{
     PROCESS_LOG_RECORD_MAX_BYTES, PROCESS_LOG_RECORD_TRUNCATED, ProcessLogRecord,
     read_process_log_records,
 };
+use crate::snapshot_mount_namespace::{BindMount, SnapshotMountMode, build_command};
 
 use super::super::SnapshotError;
-
-const SPAWN_INNER_CMD: &str = r#"mount --bind "$1" "$2" && mount --bind "$3" "$4" && exec ip netns exec "$5" "$6" --api-sock "$7""#;
-const UNSHARE_MOUNT_ARGS: &[&str] = &["--mount", "--propagation", "private"];
 
 /// Number of recent stderr lines retained from the spawn chain, used to
 /// surface the underlying cause when the chain (`unshare → bash → ip netns
@@ -85,23 +83,22 @@ impl Default for SnapshotProcess {
 
 impl SnapshotProcess {
     pub(super) fn spawn(&mut self, spawn: SnapshotProcessSpawn<'_>) -> std::io::Result<()> {
-        let mut child = tokio::process::Command::new("unshare")
-            .args(UNSHARE_MOUNT_ARGS)
-            .args(["bash", "-c", SPAWN_INNER_CMD, "_"])
-            .arg(spawn.cow_device_path) // $1
-            .arg(spawn.drive_bind) // $2
-            .arg(spawn.workspace_image) // $3
-            .arg(spawn.workspace_drive_bind) // $4
-            .arg(spawn.network_name) // $5
-            .arg(spawn.binary_path) // $6
-            .arg(spawn.api_sock) // $7
-            .current_dir(spawn.current_dir)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .process_group(0)
-            .kill_on_drop(true)
-            .spawn()?;
+        let mut child = build_command(
+            SnapshotMountMode::Creation {
+                rootfs: BindMount::new(spawn.cow_device_path, spawn.drive_bind),
+                workspace: BindMount::new(spawn.workspace_image, spawn.workspace_drive_bind),
+            },
+            spawn.network_name,
+            spawn.binary_path,
+            spawn.api_sock,
+        )
+        .current_dir(spawn.current_dir)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .process_group(0)
+        .kill_on_drop(true)
+        .spawn()?;
 
         // Stream stdout/stderr lines to tracing (same pattern as sandbox.rs).
         // Stderr is also retained in a bounded ring buffer so that an early
@@ -685,51 +682,5 @@ mod tests {
             &stderr_buf_with_lines(&["noise"]),
         );
         assert!(result.is_ok(), "ok should pass through");
-    }
-
-    /// Structural assertion that the unshare inner_cmd uses positional
-    /// parameters (no path interpolation that could shell-inject) and
-    /// performs the bind-then-exec sequence.
-    ///
-    /// The bind mount must run inside `unshare --mount` so it auto-cleans
-    /// when the FC process dies — see issue #9494. This test guards against
-    /// refactor regressions before the kernel-interaction CI job runs.
-    #[test]
-    fn spawn_inner_cmd_uses_positional_args() {
-        // Only positional args, no $0 or unquoted vars.
-        assert!(!SPAWN_INNER_CMD.contains("$0"));
-        for arg in ["$1", "$2", "$3", "$4", "$5", "$6", "$7"] {
-            let quoted = format!(r#""{arg}""#);
-            assert!(
-                SPAWN_INNER_CMD.contains(&quoted),
-                "expected quoted positional {arg} in inner_cmd: {SPAWN_INNER_CMD}"
-            );
-        }
-        // Strictly 7 positional args — if someone adds a `$8`..`$9` without
-        // updating the spawn site's `.arg(...)` count, the bash call
-        // silently expands to empty strings and fails at runtime.
-        for unexpected in ["$8", "$9"] {
-            assert!(
-                !SPAWN_INNER_CMD.contains(unexpected),
-                "unexpected positional {unexpected} in inner_cmd: {SPAWN_INNER_CMD}"
-            );
-        }
-
-        // Flow: bind the device, then exec into ip netns exec firecracker.
-        // `exec` is critical so signals reach FC directly without an extra
-        // bash layer holding a process slot.
-        assert!(
-            SPAWN_INNER_CMD.starts_with("mount --bind"),
-            "inner_cmd must establish bind mount first: {SPAWN_INNER_CMD}"
-        );
-        assert!(
-            SPAWN_INNER_CMD.contains("&& exec ip netns exec"),
-            "inner_cmd must exec ip netns exec firecracker: {SPAWN_INNER_CMD}"
-        );
-    }
-
-    #[test]
-    fn snapshot_create_unshare_uses_private_mount_propagation() {
-        assert_eq!(UNSHARE_MOUNT_ARGS, ["--mount", "--propagation", "private"]);
     }
 }

--- a/crates/sandbox-fc/src/snapshot_mount_namespace.rs
+++ b/crates/sandbox-fc/src/snapshot_mount_namespace.rs
@@ -1,0 +1,230 @@
+//! Constructs the shared mount-namespace command for snapshot creation and restore.
+//!
+//! Callers retain ownership of process lifecycle, stdio, readiness, diagnostics,
+//! and cleanup after receiving the unspawned command.
+
+use std::path::Path;
+
+use tokio::process::Command;
+
+// The counted sections keep paths in argv while allowing restore to run all
+// stale unmount attempts before either mode starts its ordered bind sequence.
+const INNER_COMMAND: &str = r#"stale_count=$1
+shift
+while [ "$stale_count" -gt 0 ]; do
+    umount -- "$1" 2>/dev/null
+    shift
+    stale_count=$((stale_count - 1))
+done
+bind_count=$1
+shift
+while [ "$bind_count" -gt 0 ]; do
+    mount --bind -- "$1" "$2" || exit
+    shift 2
+    bind_count=$((bind_count - 1))
+done
+exec ip netns exec "$@""#;
+
+pub(crate) struct BindMount<'a> {
+    source: &'a Path,
+    target: &'a Path,
+}
+
+impl<'a> BindMount<'a> {
+    pub(crate) fn new(source: &'a Path, target: &'a Path) -> Self {
+        Self { source, target }
+    }
+}
+
+pub(crate) enum SnapshotMountMode<'a> {
+    Creation {
+        rootfs: BindMount<'a>,
+        workspace: BindMount<'a>,
+    },
+    Restore {
+        vsock: BindMount<'a>,
+        rootfs: BindMount<'a>,
+        workspace: BindMount<'a>,
+    },
+}
+
+pub(crate) fn build_command(
+    mounts: SnapshotMountMode<'_>,
+    network_name: &str,
+    binary_path: &Path,
+    api_sock: &Path,
+) -> Command {
+    let mut command = Command::new("unshare");
+    command.args([
+        "--mount",
+        "--propagation",
+        "private",
+        "bash",
+        "-c",
+        INNER_COMMAND,
+        "_",
+    ]);
+
+    match mounts {
+        SnapshotMountMode::Creation { rootfs, workspace } => {
+            command.args(["0", "2"]);
+            append_bind(&mut command, rootfs);
+            append_bind(&mut command, workspace);
+        }
+        SnapshotMountMode::Restore {
+            vsock,
+            rootfs,
+            workspace,
+        } => {
+            command.arg("2").arg(rootfs.target).arg(workspace.target);
+            command.arg("3");
+            append_bind(&mut command, vsock);
+            append_bind(&mut command, rootfs);
+            append_bind(&mut command, workspace);
+        }
+    }
+
+    command
+        .arg(network_name)
+        .arg(binary_path)
+        .arg("--api-sock")
+        .arg(api_sock);
+    command
+}
+
+fn append_bind(command: &mut Command, bind: BindMount<'_>) {
+    command.arg(bind.source).arg(bind.target);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::{OsStr, OsString};
+
+    use super::*;
+
+    #[test]
+    fn creation_command_owns_private_namespace_bind_order_and_tail() {
+        let command = build_command(
+            SnapshotMountMode::Creation {
+                rootfs: BindMount::new(
+                    Path::new("/dev/root device"),
+                    Path::new("/snapshot/root bind"),
+                ),
+                workspace: BindMount::new(
+                    Path::new("/images/workspace image"),
+                    Path::new("/snapshot/workspace bind"),
+                ),
+            },
+            "snapshot-network",
+            Path::new("/opt/firecracker binary"),
+            Path::new("/run/firecracker api.sock"),
+        );
+
+        assert_eq!(command.as_std().get_program(), OsStr::new("unshare"));
+        assert_eq!(
+            command_args(&command),
+            vec![
+                OsString::from("--mount"),
+                OsString::from("--propagation"),
+                OsString::from("private"),
+                OsString::from("bash"),
+                OsString::from("-c"),
+                OsString::from(INNER_COMMAND),
+                OsString::from("_"),
+                OsString::from("0"),
+                OsString::from("2"),
+                OsString::from("/dev/root device"),
+                OsString::from("/snapshot/root bind"),
+                OsString::from("/images/workspace image"),
+                OsString::from("/snapshot/workspace bind"),
+                OsString::from("snapshot-network"),
+                OsString::from("/opt/firecracker binary"),
+                OsString::from("--api-sock"),
+                OsString::from("/run/firecracker api.sock"),
+            ]
+        );
+    }
+
+    #[test]
+    fn restore_command_cleans_drives_before_ordered_binds_and_tail() {
+        let command = build_command(
+            SnapshotMountMode::Restore {
+                vsock: BindMount::new(
+                    Path::new("/run/sandbox vsock"),
+                    Path::new("/snapshot/vsock bind"),
+                ),
+                rootfs: BindMount::new(
+                    Path::new("/dev/root device"),
+                    Path::new("/snapshot/root bind"),
+                ),
+                workspace: BindMount::new(
+                    Path::new("/images/workspace image"),
+                    Path::new("/snapshot/workspace bind"),
+                ),
+            },
+            "restore-network",
+            Path::new("/opt/firecracker binary"),
+            Path::new("/run/firecracker api.sock"),
+        );
+
+        assert_eq!(command.as_std().get_program(), OsStr::new("unshare"));
+        assert_eq!(
+            command_args(&command),
+            vec![
+                OsString::from("--mount"),
+                OsString::from("--propagation"),
+                OsString::from("private"),
+                OsString::from("bash"),
+                OsString::from("-c"),
+                OsString::from(INNER_COMMAND),
+                OsString::from("_"),
+                OsString::from("2"),
+                OsString::from("/snapshot/root bind"),
+                OsString::from("/snapshot/workspace bind"),
+                OsString::from("3"),
+                OsString::from("/run/sandbox vsock"),
+                OsString::from("/snapshot/vsock bind"),
+                OsString::from("/dev/root device"),
+                OsString::from("/snapshot/root bind"),
+                OsString::from("/images/workspace image"),
+                OsString::from("/snapshot/workspace bind"),
+                OsString::from("restore-network"),
+                OsString::from("/opt/firecracker binary"),
+                OsString::from("--api-sock"),
+                OsString::from("/run/firecracker api.sock"),
+            ]
+        );
+    }
+
+    #[test]
+    fn inner_command_ignores_stale_unmounts_and_stops_on_bind_failure() {
+        let stale_loop = r#"while [ "$stale_count" -gt 0 ]; do
+    umount -- "$1" 2>/dev/null
+    shift
+    stale_count=$((stale_count - 1))
+done"#;
+        let bind_loop = r#"while [ "$bind_count" -gt 0 ]; do
+    mount --bind -- "$1" "$2" || exit
+    shift 2
+    bind_count=$((bind_count - 1))
+done"#;
+
+        let stale_position = INNER_COMMAND.find(stale_loop).unwrap();
+        let bind_position = INNER_COMMAND.find(bind_loop).unwrap();
+        let exec_position = INNER_COMMAND.find("exec ip netns exec \"$@\"").unwrap();
+
+        assert!(stale_position < bind_position);
+        assert!(bind_position < exec_position);
+        assert!(INNER_COMMAND.ends_with("exec ip netns exec \"$@\""));
+        assert!(!INNER_COMMAND.contains("/dev/root device"));
+        assert!(!INNER_COMMAND.contains("/snapshot/root bind"));
+    }
+
+    fn command_args(command: &Command) -> Vec<OsString> {
+        command
+            .as_std()
+            .get_args()
+            .map(OsStr::to_os_string)
+            .collect()
+    }
+}

--- a/crates/sandbox-fc/src/snapshot_mount_namespace.rs
+++ b/crates/sandbox-fc/src/snapshot_mount_namespace.rs
@@ -67,20 +67,18 @@ pub(crate) fn build_command(
 
     match mounts {
         SnapshotMountMode::Creation { rootfs, workspace } => {
-            command.args(["0", "2"]);
-            append_bind(&mut command, rootfs);
-            append_bind(&mut command, workspace);
+            append_sections(&mut command, &[], &[rootfs, workspace]);
         }
         SnapshotMountMode::Restore {
             vsock,
             rootfs,
             workspace,
         } => {
-            command.arg("2").arg(rootfs.target).arg(workspace.target);
-            command.arg("3");
-            append_bind(&mut command, vsock);
-            append_bind(&mut command, rootfs);
-            append_bind(&mut command, workspace);
+            append_sections(
+                &mut command,
+                &[rootfs.target, workspace.target],
+                &[vsock, rootfs, workspace],
+            );
         }
     }
 
@@ -92,13 +90,24 @@ pub(crate) fn build_command(
     command
 }
 
-fn append_bind(command: &mut Command, bind: BindMount<'_>) {
-    command.arg(bind.source).arg(bind.target);
+fn append_sections(command: &mut Command, stale_targets: &[&Path], binds: &[BindMount<'_>]) {
+    command.arg(stale_targets.len().to_string());
+    for target in stale_targets {
+        command.arg(*target);
+    }
+
+    command.arg(binds.len().to_string());
+    for bind in binds {
+        command.arg(bind.source).arg(bind.target);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::ffi::{OsStr, OsString};
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::{Command as StdCommand, Output};
 
     use super::*;
 
@@ -143,6 +152,8 @@ mod tests {
                 OsString::from("/run/firecracker api.sock"),
             ]
         );
+        assert!(!INNER_COMMAND.contains("/dev/root device"));
+        assert!(!INNER_COMMAND.contains("/snapshot/root bind"));
     }
 
     #[test]
@@ -197,27 +208,73 @@ mod tests {
     }
 
     #[test]
-    fn inner_command_ignores_stale_unmounts_and_stops_on_bind_failure() {
-        let stale_loop = r#"while [ "$stale_count" -gt 0 ]; do
-    umount -- "$1" 2>/dev/null
-    shift
-    stale_count=$((stale_count - 1))
-done"#;
-        let bind_loop = r#"while [ "$bind_count" -gt 0 ]; do
-    mount --bind -- "$1" "$2" || exit
-    shift 2
-    bind_count=$((bind_count - 1))
-done"#;
+    fn inner_command_ignores_stale_unmount_failures_and_preserves_order() {
+        let (dir, trace) = fake_host_commands();
+        let output = run_inner_command(
+            dir.path(),
+            &trace,
+            &[
+                "2",
+                "/root target",
+                "/workspace target",
+                "3",
+                "/vsock source",
+                "/vsock target",
+                "/root source",
+                "/root target",
+                "/workspace source",
+                "/workspace target",
+                "network namespace",
+                "/firecracker binary",
+                "--api-sock",
+                "/api socket",
+            ],
+            None,
+        );
 
-        let stale_position = INNER_COMMAND.find(stale_loop).unwrap();
-        let bind_position = INNER_COMMAND.find(bind_loop).unwrap();
-        let exec_position = INNER_COMMAND.find("exec ip netns exec \"$@\"").unwrap();
-
-        assert!(stale_position < bind_position);
-        assert!(bind_position < exec_position);
+        assert!(
+            output.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            fs::read_to_string(trace).unwrap(),
+            "umount </root target>\n\
+umount </workspace target>\n\
+mount </vsock source> </vsock target>\n\
+mount </root source> </root target>\n\
+mount </workspace source> </workspace target>\n\
+ip <netns> <exec> <network namespace> </firecracker binary> <--api-sock> </api socket>\n"
+        );
         assert!(INNER_COMMAND.ends_with("exec ip netns exec \"$@\""));
-        assert!(!INNER_COMMAND.contains("/dev/root device"));
-        assert!(!INNER_COMMAND.contains("/snapshot/root bind"));
+    }
+
+    #[test]
+    fn inner_command_stops_after_first_bind_failure() {
+        let (dir, trace) = fake_host_commands();
+        let output = run_inner_command(
+            dir.path(),
+            &trace,
+            &[
+                "0",
+                "2",
+                "/bad source",
+                "/root target",
+                "/workspace source",
+                "/workspace target",
+                "network",
+                "/firecracker",
+                "--api-sock",
+                "/api",
+            ],
+            Some("/bad source"),
+        );
+
+        assert_eq!(output.status.code(), Some(23));
+        assert_eq!(
+            fs::read_to_string(trace).unwrap(),
+            "mount </bad source> </root target>\n"
+        );
     }
 
     fn command_args(command: &Command) -> Vec<OsString> {
@@ -226,5 +283,63 @@ done"#;
             .get_args()
             .map(OsStr::to_os_string)
             .collect()
+    }
+
+    fn fake_host_commands() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let trace = dir.path().join("trace");
+        write_executable(
+            &dir.path().join("umount"),
+            r#"#!/bin/sh
+printf 'umount <%s>\n' "$2" >> "$TRACE"
+exit 1
+"#,
+        );
+        write_executable(
+            &dir.path().join("mount"),
+            r#"#!/bin/sh
+printf 'mount <%s> <%s>\n' "$3" "$4" >> "$TRACE"
+if [ "$3" = "$FAIL_MOUNT_SOURCE" ]; then
+    exit 23
+fi
+"#,
+        );
+        write_executable(
+            &dir.path().join("ip"),
+            r#"#!/bin/sh
+printf 'ip' >> "$TRACE"
+for arg in "$@"; do
+    printf ' <%s>' "$arg" >> "$TRACE"
+done
+printf '\n' >> "$TRACE"
+"#,
+        );
+        (dir, trace)
+    }
+
+    fn write_executable(path: &Path, contents: &str) {
+        fs::write(path, contents).unwrap();
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).unwrap();
+    }
+
+    fn run_inner_command(
+        command_dir: &Path,
+        trace: &Path,
+        args: &[&str],
+        fail_mount_source: Option<&str>,
+    ) -> Output {
+        let mut command = StdCommand::new("/bin/bash");
+        command
+            .args(["-c", INNER_COMMAND, "_"])
+            .args(args)
+            .env("PATH", command_dir)
+            .env("TRACE", trace)
+            .env_remove("FAIL_MOUNT_SOURCE");
+        if let Some(source) = fail_mount_source {
+            command.env("FAIL_MOUNT_SOURCE", source);
+        }
+        command.output().unwrap()
     }
 }


### PR DESCRIPTION
## Summary

- add one typed mount-namespace command builder for snapshot creation and restore
- derive counted stale-target and bind sections from typed mode data, then preserve the Firecracker exec tail as opaque argv
- route both existing lifecycle owners through the builder and replace their isolated shell-string tests with full command-shape and executable shell-contract coverage

## Scope

- preserves creation and restore working directories, stdio, process groups, child ownership, readiness, diagnostics, and cleanup
- does not change public APIs, runner protocols, configuration, filesystem layout, or persisted snapshot format

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features`
- `cargo doc -p sandbox-fc --all-features --no-deps`
- `cargo test -p sandbox-fc --all-targets --all-features` (812 library tests and 1 integration test passed)
- pre-commit Rust formatting, workspace Clippy, Rustdoc, file-size, and commit-message hooks

Closes #25239
