### PR TITLE
docs(python): document tcp start fail-closed contract

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1935,7 +1935,11 @@ def done():
 
 
 def tcp_start(flow: tcp.TCPFlow) -> None:
-    """Track TCP connection start time and look up VM info."""
+    """Apply ``tcp_logging.start()``'s canonical registry-admission contract.
+
+    The delegated contract includes its no-op outcomes and fail-closed flow killing before TCP
+    logging metadata is installed.
+    """
     tcp_logging.start(flow, registry_path=get_registry_path())
 
 

--- a/crates/runner/mitm-addon/src/tcp_logging.py
+++ b/crates/runner/mitm-addon/src/tcp_logging.py
@@ -20,7 +20,16 @@ _TCP_RESPONSE_SIZE = "_tcp_response_size"
 
 
 def start(flow: tcp.TCPFlow, *, registry_path: str) -> None:
-    """Track TCP connection start time and look up VM info."""
+    """Apply registry admission and install TCP logging metadata for a valid VM.
+
+    Outcomes:
+    - A missing client peer address is a no-op.
+    - An unregistered client is a no-op.
+    - An unavailable registry calls ``flow.kill()`` without installing TCP logging metadata.
+    - An invalid VM entry calls ``flow.kill()`` without installing TCP logging metadata.
+    - A valid registered VM installs the run ID, network and proxy log paths, and
+      ``TCP_START_MONOTONIC``.
+    """
     client_ip = flow.client_conn.peername[0] if flow.client_conn.peername else None
     if not client_ip:
         return


### PR DESCRIPTION
## Summary

- document the complete TCP start outcome matrix on the canonical `tcp_logging.start()` behavior owner
- keep the exported `mitm_addon.tcp_start()` hook aligned through an explicit fail-closed contract reference
- distinguish no-op lookup outcomes from registry and VM validation failures that kill the flow before metadata installation

## Scope

- documentation only
- no runtime, registry, metadata lifecycle, API, protocol, persistence, or deployment behavior changes
- no new tests because the existing `TestTcpStart` entry-point coverage already exercises all five documented outcomes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`4801 passed`)

Closes #25259
