### PR TITLE
fix(api): accept joggai webhook project ids

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-avatar-video.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-avatar-video.test.ts
@@ -459,10 +459,8 @@ describe("JoggAI built-in avatar video routes", () => {
       event: "generated_avatar_video_success",
       timestamp: 1_700_000_000,
       data: {
-        video_id: "jogg-video-123",
-        status: "completed",
+        project_id: "jogg-video-123",
         video_url: GENERATED_VIDEO_URL,
-        cover_url: "https://res.jogg.ai/avatar-video.jpg",
         duration: 121,
       },
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-avatar-video.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-avatar-video.test.ts
@@ -373,6 +373,38 @@ describe("JoggAI built-in avatar video routes", () => {
     expect(voiceBody.hasMore).toBeFalsy();
   });
 
+  it("accepts JoggAI's documented webhook video ID", async () => {
+    const webhookBody = JSON.stringify({
+      event_id: "event-documented-video-id",
+      event: "generated_avatar_video_success",
+      timestamp: 1_700_000_000,
+      data: {
+        video_id: "jogg-documented-video",
+        status: "completed",
+        video_url: GENERATED_VIDEO_URL,
+        cover_url: "https://res.jogg.ai/avatar-video.jpg",
+        duration: 30,
+      },
+    });
+    const signature = createHmac("sha256", JOGGAI_WEBHOOK_SECRET)
+      .update(webhookBody)
+      .digest("hex");
+
+    const response = await createAvatarVideoTestApp().request(
+      "/api/webhooks/built-in-generations/joggai",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-webhook-signature": signature,
+        },
+        body: webhookBody,
+      },
+    );
+
+    expect(response.status).toBe(200);
+  });
+
   it("stores a run-scoped talking-avatar video in the avatar catalog", async () => {
     const fixture = await seedAvatarVideoFixture();
     const { composeId } = await store.set(

--- a/turbo/apps/api/src/signals/services/zero-avatar-video.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-avatar-video.service.ts
@@ -629,7 +629,9 @@ export function parseJoggAiWebhookPayload(
   }
   const event = optionalString(value.event);
   const status = optionalString(value.data.status)?.toLowerCase();
-  const videoId = optionalString(value.data.project_id);
+  const videoId =
+    optionalString(value.data.project_id) ??
+    optionalString(value.data.video_id);
   if (!videoId) {
     return badRequest("JoggAI webhook did not include a video ID");
   }

--- a/turbo/apps/api/src/signals/services/zero-avatar-video.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-avatar-video.service.ts
@@ -629,7 +629,9 @@ export function parseJoggAiWebhookPayload(
   }
   const event = optionalString(value.event);
   const status = optionalString(value.data.status)?.toLowerCase();
-  const videoId = optionalString(value.data.video_id);
+  const videoId =
+    optionalString(value.data.video_id) ??
+    optionalString(value.data.project_id);
   if (!videoId) {
     return badRequest("JoggAI webhook did not include a video ID");
   }

--- a/turbo/apps/api/src/signals/services/zero-avatar-video.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-avatar-video.service.ts
@@ -629,9 +629,7 @@ export function parseJoggAiWebhookPayload(
   }
   const event = optionalString(value.event);
   const status = optionalString(value.data.status)?.toLowerCase();
-  const videoId =
-    optionalString(value.data.video_id) ??
-    optionalString(value.data.project_id);
+  const videoId = optionalString(value.data.project_id);
   if (!videoId) {
     return badRequest("JoggAI webhook did not include a video ID");
   }


### PR DESCRIPTION
## Summary

- use JoggAI webhook `project_id` as the generated video identifier
- keep the create-video response handling unchanged because that endpoint returns `video_id`
- cover the observed success webhook shape where `status` and `cover_url` are omitted
- verify webhook processing still completes generation, billing, and artifact persistence

## Testing

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-avatar-video.test.ts --maxWorkers=1`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`