### PR TITLE
test(firewall): cover specificity decision contract

### DIFF
--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -1040,6 +1040,94 @@
       }
     },
     {
+      "name": "plus greedy blocked permission wins over star greedy allowed permission",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "files.star",
+                  "rules": ["GET /files/{rest*}"]
+                },
+                {
+                  "name": "files.plus",
+                  "rules": ["GET /files/{rest+}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": [],
+          "deny": ["files.plus"],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/files/readme"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com",
+        "relativePath": "/files/readme",
+        "reason": "permission_denied",
+        "permissions": ["files.plus"]
+      }
+    },
+    {
+      "name": "two-code-point literal block wins over one-code-point emoji literal allow",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "files.emoji",
+                  "rules": ["GET /files/😀{id}"]
+                },
+                {
+                  "name": "files.ascii",
+                  "rules": ["GET /files/{id}ab"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": [],
+          "deny": ["files.ascii"],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/files/😀xab"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com",
+        "relativePath": "/files/😀xab",
+        "reason": "permission_denied",
+        "permissions": ["files.ascii"]
+      }
+    },
+    {
       "name": "unknown endpoint follows deny policy",
       "firewalls": [
         {


### PR DESCRIPTION
## Summary

- add shared final-decision coverage for `+` greedy precedence over `*` greedy precedence
- add shared final-decision coverage for Unicode code-point literal specificity
- exercise both the TypeScript decision matcher and the indexed Python production matcher without changing runtime code

## Exclusions

- no production matcher changes
- no duplicate Python-only fixtures or removal of existing TypeScript diagnostics
- no API, protocol, persistence, dependency, migration, or rollout changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,803 passed)
- `pnpm exec prettier --check packages/connectors/src/__tests__/firewall-semantics-contract.json`
- `pnpm -F @vm0/connectors test` (896 passed)
- `pnpm knip`
- `git diff --check`
- `./scripts/check-file-size.sh turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json`
- independent Python mutations confirmed that each new case fails when its intended specificity coordinate is neutralized

Closes #25263
