### PR TITLE
refactor(api): stop projecting chat event trigger source

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -589,7 +589,9 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
       phoneEvents.events.some((event) => {
         return (
           event.eventType === "input.prompt" &&
-          event.triggerSource === "agentphone"
+          event.userMessage.parts.some((part) => {
+            return part.type === "source" && part.kind === "agentphone";
+          })
         );
       }),
     ).toBeTruthy();

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -7052,7 +7052,6 @@ describe("CHAT-02: shared user message queue", () => {
     );
     expect(firstInput).toMatchObject({
       eventType: "input.prompt",
-      triggerSource: "agent",
       userMessage: {
         version: 1,
         parts: [

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-agent-run-rollout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-agent-run-rollout.test.ts
@@ -231,7 +231,6 @@ async function runPreAgentRunContextRouteProbe(
   });
   expect(delegatedEvent).toMatchObject({
     eventType: "input.prompt",
-    triggerSource: "agent",
     userMessage: {
       version: 1,
       parts: [{ type: "text", text: "pre-migration delegated prompt" }],

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
@@ -18,6 +18,7 @@ import { deleteAgentRunRootFixture } from "../../../test-fixtures/run-deletion";
 import type { ApiTestUser } from "./helpers/api-bdd";
 import { mockGmailConnectorOAuth } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
+import { createRunReadsApi } from "./helpers/api-bdd-run-reads";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
@@ -33,6 +34,7 @@ const store = createStore();
 const mocks = createZeroRouteMocks(context);
 const wf = createWorkflowsBddApi(context);
 const runsApi = createRunsApi(context);
+const runReadsApi = createRunReadsApi(context);
 const webhooksApi = createWebhookCallbackApi(context);
 const chatFilesApi = createChatFilesBddApi(context);
 const computerUseApi = createComputerUseBddApi(context);
@@ -165,7 +167,6 @@ async function executeDueWorkflowAutomations(
 interface WorkflowRunMessage {
   readonly runId: string;
   readonly runGroupId?: string;
-  readonly triggerSource: string | undefined;
   readonly triggerBrief: string | null | undefined;
   readonly workflowId: string | undefined;
   readonly workflowName: string;
@@ -194,7 +195,6 @@ async function workflowRunMessages(
         ...(message.runGroupId === undefined
           ? {}
           : { runGroupId: message.runGroupId }),
-        triggerSource: message.triggerSource,
         triggerBrief: automationPart.automationBrief,
         workflowId: automationPart.workflowId,
         workflowName: automationPart.workflowName,
@@ -430,7 +430,13 @@ describe("zero workflow automation scheduler", () => {
 
     const run = await onlyWorkflowRunMessage(threadId);
     expect(run.runGroupId).toBeUndefined();
-    expect(run.triggerSource).toBe("workflow-schedule");
+    const logs = await runReadsApi.requestListLogs(scenario.actor, {}, [200]);
+    expect(logs.body.data).toContainEqual(
+      expect.objectContaining({
+        id: run.runId,
+        triggerSource: "workflow-schedule",
+      }),
+    );
     expect(run.triggerBrief).toMatch(
       new RegExp(
         `^${friendlyTriggeredAtPattern(
@@ -810,7 +816,6 @@ describe("zero workflow automation scheduler", () => {
     expect(historicalRuns).toStrictEqual([
       {
         runId: run.runId,
-        triggerSource: "workflow-schedule",
         triggerBrief: run.triggerBrief,
         workflowId: scenario.workflowId,
         workflowName: WORKFLOW_NAME,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-controls.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-controls.test.ts
@@ -283,6 +283,7 @@ describe("workflow automation queue controls", () => {
     );
     expect(initial.body.running?.runId).toBe(runningRunId);
     expect(initial.body.pending).toHaveLength(3);
+    expect(initial.body.pending[0]).not.toHaveProperty("triggerSource");
     expect(initial.body.pausedAt).toBeNull();
     expect(initial.body.pauseReason).toBeNull();
 

--- a/turbo/apps/api/src/signals/routes/zero-workflow-queue.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflow-queue.ts
@@ -53,7 +53,6 @@ async function workflowQueueResponse(
         return {
           id: event.id,
           automationId: event.automationId,
-          triggerSource: event.triggerSource,
           triggerBrief: event.triggerBrief,
           createdAt: event.createdAt.toISOString(),
         };

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -19,10 +19,6 @@ import {
   persistedAttachmentSchema,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import {
-  triggerSourceSchema,
-  type TriggerSource,
-} from "@vm0/api-contracts/contracts/logs";
-import {
   modelProviderCredentialScopeSchema,
   modelProviderTypeSchema,
   type ModelProviderCredentialScope,
@@ -109,9 +105,6 @@ import {
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import { cancellationRecoveryPendingForThread } from "./zero-chat-active-run.service";
 
-const nullableTriggerSourceDecoder = nullableDriverValueDecoder(
-  zodEnumDriverValueDecoder(triggerSourceSchema),
-);
 const nullableTextDecoder = nullableDriverValueDecoder(pgTextDecoder);
 const matchedChatEvent = alias(chatEvents, "matched_chat_event");
 const hostedRunUploadedFiles = alias(runUploadedFiles, "hosted_files");
@@ -126,7 +119,6 @@ type ChatEventRow = {
   readonly thinking: string | null;
   readonly runId: string | null;
   readonly runGroupId: string | null;
-  readonly triggerSource: TriggerSource | null;
   readonly isGoalRun: boolean;
   readonly usagePayload: ChatEventUsagePayload | null;
   readonly runEventId: string | null;
@@ -282,9 +274,6 @@ const eventColumns = {
 function chatEventMetadataSubquery(db: Pick<Db, "select">) {
   return db
     .select({
-      runTriggerSource: sql`${zeroRuns.triggerSource}`
-        .mapWith(nullableTriggerSourceDecoder)
-        .as("run_trigger_source"),
       goalId: zeroRuns.goalId,
     })
     .from(zeroRuns)
@@ -298,12 +287,6 @@ function selectChatEventsWithMetadata(db: Pick<Db, "select">) {
   return db
     .select({
       ...eventColumns,
-      triggerSource: sql`COALESCE(
-        ${chatEvents.triggerSource},
-        ${metadata.runTriggerSource}
-      )`
-        .mapWith(nullableTriggerSourceDecoder)
-        .as("trigger_source"),
       isGoalRun: isNotNull(metadata.goalId).mapWith(pgBooleanDecoder),
     })
     .from(chatEvents)
@@ -626,7 +609,6 @@ function baseChatEventFromRow(row: ChatEventRow, content: string | null) {
     content,
     runId: row.runId ?? undefined,
     runGroupId: row.runGroupId ?? undefined,
-    triggerSource: row.triggerSource ?? undefined,
     isGoalRun: row.isGoalRun || undefined,
     runEventId: row.runEventId ?? undefined,
     revokesEventId: row.revokesEventId ?? undefined,
@@ -664,11 +646,6 @@ const chatEventBuilders = {
       eventType: "input.automation",
       content: null,
       userMessage: row.userMessage ?? undefined,
-      triggerSource: requiredChatEventField(
-        row.triggerSource,
-        row.eventType,
-        "triggerSource",
-      ),
     };
   },
   "input.goal": (row, event) => {

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/queued.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/queued.test.ts
@@ -79,7 +79,6 @@ describe("zero chat queued command", () => {
                 threadId: THREAD_ID,
                 eventType: "input.automation",
                 content: null,
-                triggerSource: "workflow-event",
                 userMessage: {
                   version: 1,
                   parts: [

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-test-helpers.ts
@@ -79,7 +79,6 @@ function baseEvent(
     content,
     runId: message.runId,
     runGroupId: message.runGroupId,
-    triggerSource: message.triggerSource,
     isGoalRun: message.isGoalRun,
     runEventId: message.runEventId,
     revokesEventId: message.revokesEventId,
@@ -131,7 +130,6 @@ const mockChatEventOverrides = {
   "input.automation": (message, id) => {
     return {
       content: null,
-      triggerSource: message.triggerSource ?? "workflow-event",
       userMessage:
         message.userMessage ??
         ({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -133,7 +133,6 @@ describe("chat lifecycle", () => {
           role: "user",
           content: "Check the production rollout",
           runId: "run-slack-origin",
-          triggerSource: "slack",
           userMessage: {
             version: 1,
             parts: [
@@ -155,7 +154,6 @@ describe("chat lifecycle", () => {
           role: "user",
           content: "This source link was unavailable",
           runId: "run-slack-origin-without-link",
-          triggerSource: "slack",
           userMessage: {
             version: 1,
             parts: [
@@ -200,7 +198,6 @@ describe("chat lifecycle", () => {
           role: "user",
           content: "Check the Feishu conversation",
           runId: "run-feishu-origin",
-          triggerSource: "feishu",
           userMessage: {
             version: 1,
             parts: [
@@ -222,7 +219,6 @@ describe("chat lifecycle", () => {
           role: "user",
           content: "This source link was unavailable",
           runId: "run-feishu-origin-without-link",
-          triggerSource: "feishu",
           userMessage: {
             version: 1,
             parts: [

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -192,7 +192,6 @@ function mockCancellationRecoveryQueue(options?: {
               id: `${THREAD_ID}-queued-automation`,
               eventType: "input.automation" as const,
               content: null,
-              triggerSource: "workflow-event" as const,
               userMessage: {
                 version: 1 as const,
                 parts: [
@@ -258,7 +257,6 @@ describe("chat run queue", () => {
           id: `${THREAD_ID}-pending-automation`,
           eventType: "input.automation",
           content: null,
-          triggerSource: "workflow-event",
           userMessage: {
             version: 1,
             parts: [

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
@@ -501,7 +501,6 @@ describe("user messages", () => {
           role: "user",
           content: "Delegated prompt",
           runId: targetRunId,
-          triggerSource: "agent",
           userMessage: {
             version: 1,
             parts: [

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -1098,7 +1098,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           content: workflowPrompt,
           runId: "f0000001-0000-4000-a000-00000000073c",
           runGroupId,
-          triggerSource: "workflow-event",
           userMessage: workflowUserMessage,
           createdAt: "2026-06-09T10:00:00Z",
         },
@@ -1108,7 +1107,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           content: "First workflow result",
           runId: "f0000001-0000-4000-a000-00000000073c",
           runGroupId,
-          triggerSource: "workflow-event",
           createdAt: "2026-06-09T10:00:30Z",
         },
         {
@@ -1117,7 +1115,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           content: workflowPrompt,
           runId: "f0000001-0000-4000-a000-00000000073d",
           runGroupId,
-          triggerSource: "workflow-event",
           userMessage: workflowUserMessage,
           createdAt: "2026-06-09T10:02:00Z",
         },
@@ -1127,7 +1124,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           content: "Latest workflow result",
           runId: "f0000001-0000-4000-a000-00000000073d",
           runGroupId,
-          triggerSource: "workflow-event",
           runLifecycleEvent: "completed",
           createdAt: "2026-06-09T10:02:30Z",
         },
@@ -1176,7 +1172,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           content: workflowPrompt,
           runId: "f0000001-0000-4000-a000-00000000074c",
           runGroupId,
-          triggerSource: "workflow-event",
           userMessage: workflowUserMessage,
           createdAt: "2026-06-09T10:00:00Z",
         },
@@ -1186,7 +1181,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           content: "First workflow result",
           runId: "f0000001-0000-4000-a000-00000000074c",
           runGroupId,
-          triggerSource: "workflow-event",
           runLifecycleEvent: "completed",
           createdAt: "2026-06-09T10:00:30Z",
         },
@@ -1196,7 +1190,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           content: workflowPrompt,
           runId: "f0000001-0000-4000-a000-00000000074d",
           runGroupId,
-          triggerSource: "workflow-event",
           userMessage: workflowUserMessage,
           createdAt: "2026-06-09T10:02:00Z",
         },
@@ -1207,7 +1200,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           error: "Run cancelled",
           runId: "f0000001-0000-4000-a000-00000000074d",
           runGroupId,
-          triggerSource: "workflow-event",
           runLifecycleEvent: "cancelled",
           createdAt: "2026-06-09T10:02:30Z",
         },
@@ -1257,7 +1249,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           eventType: "input.automation",
           content: null,
           runId: "f0000001-0000-4000-a000-00000000083c",
-          triggerSource: "workflow-event",
           userMessage: {
             version: 1,
             parts: [
@@ -1276,7 +1267,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           role: "assistant",
           content: "Workflow result",
           runId: "f0000001-0000-4000-a000-00000000083c",
-          triggerSource: "workflow-event",
           createdAt: "2026-06-09T10:00:30Z",
         },
       ],
@@ -1313,7 +1303,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           eventType: "input.automation",
           content: null,
           runId: "f0000001-0000-4000-a000-00000000084c",
-          triggerSource: "workflow-event",
           userMessage: {
             version: 1,
             parts: [
@@ -1360,7 +1349,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           eventType: "input.automation",
           content: null,
           runId: "f0000001-0000-4000-a000-00000000085c",
-          triggerSource: "workflow-event",
           userMessage: {
             version: 1,
             parts: [
@@ -1403,7 +1391,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           id: "msg-claimed-automation",
           eventType: "input.automation",
           content: null,
-          triggerSource: "workflow-event",
           userMessage: {
             version: 1,
             parts: [
@@ -1421,7 +1408,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           id: "msg-pending-automation",
           eventType: "input.automation",
           content: null,
-          triggerSource: "workflow-event",
           userMessage: {
             version: 1,
             parts: [

--- a/turbo/apps/platform/src/views/zero-page/__tests__/workflow-queue-panel.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/workflow-queue-panel.test.tsx
@@ -78,7 +78,6 @@ function setupWorkflowQueuePage({
         id: EVENT_ID_1,
         eventType: "input.automation",
         content: null,
-        triggerSource: "workflow-event",
         userMessage: {
           version: 1,
           parts: [{ type: "automation", workflowName: "customer-followup" }],
@@ -90,7 +89,6 @@ function setupWorkflowQueuePage({
         id: EVENT_ID_2,
         eventType: "input.automation",
         content: null,
-        triggerSource: "workflow-event",
         userMessage: {
           version: 1,
           parts: [

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-events.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-events.test.ts
@@ -55,7 +55,6 @@ const chatEvents = [
         },
       ],
     },
-    triggerSource: "workflow-event",
     createdAt: "2026-07-23T00:00:01.000Z",
   },
   {
@@ -88,7 +87,6 @@ const chatEvents = [
       ],
     },
     error: "Insufficient credits",
-    triggerSource: "workflow-event",
     createdAt: CREATED_AT,
   },
   {
@@ -309,6 +307,12 @@ describe("ChatEvent catalog", () => {
       chatEventSchema.safeParse({
         ...automation,
         encryptedParams: "must-stay-server-side",
+      }).success,
+    ).toBe(false);
+    expect(
+      chatEventSchema.safeParse({
+        ...automation,
+        triggerSource: "workflow-event",
       }).success,
     ).toBe(false);
     const goal = chatEvents[2];

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -6,7 +6,6 @@ import { requireUserMessageForDraftAttachments } from "./draft-user-message";
 import { hostedArtifactKindSchema } from "./zero-host";
 import { runStatusSchema } from "./runs";
 import { zeroGoalEventSchema } from "./zero-goals";
-import { triggerSourceSchema } from "./logs";
 import { supportedRunModelSchema } from "./model-providers";
 import {
   avatarVideoAspectRatioSchema,
@@ -494,7 +493,6 @@ const chatEventBaseSchema = z.object({
   content: z.string().nullable(),
   runId: z.string().optional(),
   runGroupId: z.string().optional(),
-  triggerSource: triggerSourceSchema.optional(),
   isGoalRun: z.boolean().optional(),
   runEventId: z.string().optional(),
   revokesEventId: z.string().optional(),
@@ -537,7 +535,6 @@ const inputAutomationEventSchema = chatEventBaseSchema
     eventType: z.literal("input.automation"),
     content: z.null(),
     userMessage: userMessageDocumentSchema.optional(),
-    triggerSource: triggerSourceSchema,
   })
   .strict();
 
@@ -550,7 +547,6 @@ const inputGoalEventSchema = chatEventBaseSchema
     // the user-facing document and stream ordering contract.
     runId: z.never().optional(),
     runGroupId: z.never().optional(),
-    triggerSource: z.never().optional(),
     isGoalRun: z.never().optional(),
     runEventId: z.never().optional(),
     revokesEventId: z.never().optional(),

--- a/turbo/packages/api-contracts/src/contracts/zero-workflow-queue.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflow-queue.ts
@@ -10,7 +10,6 @@ const eventIdParams = z.object({ id: z.string().uuid() });
 export const workflowQueueEventSchema = z.object({
   id: z.string(),
   automationId: z.string(),
-  triggerSource: z.string(),
   triggerBrief: z.string().nullable(),
   createdAt: z.string(),
 });


### PR DESCRIPTION
## Summary

- remove `triggerSource` from the canonical chat event and legacy workflow queue API contracts
- stop projecting `chat_events.trigger_source` through those responses while preserving the internal column, queue dispatch, and goal metadata subquery
- update contract consumers and integration coverage to use the remaining public message/log surfaces

## Validation

- affected Turbo workspace type checks and lint
- targeted contract, API, platform, and CLI Vitest suites
- Prettier checks for all changed files
- `pnpm knip` in the CI Linux toolchain image
- acceptance greps for remaining internal `chatEvents.triggerSource` reads and unchanged platform/CLI logs consumers

Closes #25270
