### PR TITLE
test(vsock-guest): cover pending preservation across resume

### DIFF
--- a/crates/vsock-guest/tests/connection/quiesce.rs
+++ b/crates/vsock-guest/tests/connection/quiesce.rs
@@ -254,7 +254,7 @@ fn malformed_quiesce_resume_payloads_do_not_change_state() {
 }
 
 #[test]
-fn resume_operations_reopens_after_busy_quiesce_with_pending_operation() {
+fn resume_operations_reopens_without_losing_pending_operation() {
     let (handle, mut host_stream) = start_guest_connection();
 
     send_exec_start(
@@ -289,9 +289,18 @@ fn resume_operations_reopens_after_busy_quiesce_with_pending_operation() {
     );
     assert_eq!(reopened.stdout, Some(b"reopened".to_vec()));
 
+    send_quiesce_operations(&mut host_stream, 245);
+    assert_error_contains(&mut host_stream, 245, "guest operations still pending: 1");
+
     send_exec_cancel(&mut host_stream, 241);
     let (_chunks, cancelled) = read_exec_result(&mut host_stream, 241);
     assert_eq!(cancelled.termination, ExecTermination::Cancelled);
+
+    send_quiesce_operations(&mut host_stream, 246);
+    let quiesced = read_message(&mut host_stream);
+    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+    assert_eq!(quiesced.seq, 246);
+    assert!(quiesced.payload.is_empty());
 
     finish_guest_connection(handle, host_stream);
 }


### PR DESCRIPTION
## Summary

- retry quiescing after a busy resume while the original exec remains active
- assert the original pending operation survives a reopened exec completing
- assert quiescing succeeds only after the original exec is cancelled

This PR changes integration coverage only. It does not change guest runtime behavior, protocol contracts, schemas, or deployment compatibility.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-guest --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --test connection quiesce::resume_operations_reopens_without_losing_pending_operation -- --exact`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest`
- mutation check: temporarily clearing `pending` in `OperationState::resume` made the focused test fail at the second quiesce; production code was restored before final validation

Closes #25264
