### PR TITLE
test(runner): cover oversized firewall catalog writes

### DIFF
--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -559,6 +559,17 @@ mod tests {
         }
     }
 
+    fn oversized_catalog() -> BuiltinFirewallCatalog {
+        let mut catalog = catalog("github");
+        catalog.catalog_version = "x".repeat(
+            usize::try_from(crate::state_file::BUILTIN_FIREWALL_CATALOG_MAX_BYTES).unwrap(),
+        );
+        catalog
+            .validate_for_api_response()
+            .expect("oversized catalog should remain schema-valid");
+        catalog
+    }
+
     fn catalog_with_auth(auth: serde_json::Value) -> BuiltinFirewallCatalog {
         let mut catalog = catalog("auth-strategy");
         catalog.firewalls.get_mut("auth-strategy").unwrap().apis[0].auth =
@@ -970,6 +981,49 @@ mod tests {
         assert_eq!(cache.catalog_digest, digest());
         assert_eq!(cache.catalog_version, "test-catalog");
         assert_eq!(cache.firewalls["github"].name, "github");
+    }
+
+    #[tokio::test]
+    async fn write_catalog_cache_rejects_oversized_catalog_without_replacing_existing_cache() {
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("builtin-firewall-catalog-cache.json");
+        let lock_path = dir.path().join("builtin-firewall-catalog-cache.json.lock");
+        let expected_error = format!(
+            "builtin firewall catalog cache exceeds {} bytes",
+            crate::state_file::BUILTIN_FIREWALL_CATALOG_MAX_BYTES
+        );
+
+        let error = write_catalog_cache(&cache_path, &lock_path, oversized_catalog())
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains(&expected_error),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !cache_path.exists(),
+            "oversized catalog should not publish a cache file"
+        );
+
+        write_catalog_cache(&cache_path, &lock_path, catalog("github"))
+            .await
+            .unwrap();
+        let before = tokio::fs::read(&cache_path).await.unwrap();
+        let before_ino = std::fs::metadata(&cache_path).unwrap().ino();
+
+        let error = write_catalog_cache(&cache_path, &lock_path, oversized_catalog())
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains(&expected_error),
+            "unexpected error: {error}"
+        );
+        let after = tokio::fs::read(&cache_path).await.unwrap();
+        let after_ino = std::fs::metadata(&cache_path).unwrap().ino();
+        assert_eq!(after, before);
+        assert_eq!(after_ino, before_ino);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add a schema-valid catalog fixture whose serialized cache exceeds the production 16 MiB limit
- verify an oversized catalog cannot create a new cache file
- verify an oversized refresh preserves the bytes and inode of the last valid cache

## Scope

This is test-only coverage of the existing runner publication contract. It does not change runtime behavior, APIs, protocols, cache schemas, Python consumers, persistence, or deployment behavior.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::builtin_firewall_catalog::tests::write_catalog_cache_rejects_oversized_catalog_without_replacing_existing_cache`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`

Closes #25266
