### PR TITLE
test(runner): bound network log cancellation waits

### DIFF
--- a/crates/runner/src/dns/log.rs
+++ b/crates/runner/src/dns/log.rs
@@ -874,7 +874,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let (producer, drain_rx) = NetworkLogDrainProducer::channel("dns-test");
         let (mut writer, reader) = tokio::io::duplex(1024);
-        let task = tokio::spawn(tail_reader(
+        let mut task = tokio::spawn(tail_reader(
             tokio::io::BufReader::new(reader),
             manager.clone(),
             cancel.clone(),
@@ -906,10 +906,15 @@ mod tests {
         assert_eq!(parsed["dns_event"], "query");
 
         cancel.cancel();
-        assert!(matches!(
-            task.await.unwrap(),
-            DrainableLineReaderExit::Cancelled
-        ));
+        let exit = match tokio::time::timeout(std::time::Duration::from_secs(1), &mut task).await {
+            Ok(result) => result.unwrap(),
+            Err(_) => {
+                task.abort();
+                let _ = task.await;
+                panic!("timed out waiting for DNS tail reader cancellation");
+            }
+        };
+        assert!(matches!(exit, DrainableLineReaderExit::Cancelled));
         drop(writer);
     }
 }

--- a/crates/runner/src/network_log_drain.rs
+++ b/crates/runner/src/network_log_drain.rs
@@ -698,7 +698,12 @@ mod tests {
         cancel.cancel();
         let (_producer, drain_rx) = NetworkLogDrainProducer::channel("reader-test");
 
-        let exit = run_drainable_line_reader(PendingReader, cancel, drain_rx, |_| async {}).await;
+        let exit = timeout(
+            Duration::from_secs(1),
+            run_drainable_line_reader(PendingReader, cancel, drain_rx, |_| async {}),
+        )
+        .await
+        .expect("timed out waiting for drainable line reader cancellation");
 
         assert!(matches!(exit, DrainableLineReaderExit::Cancelled));
     }


### PR DESCRIPTION
## Summary

- bound the direct drainable line-reader cancellation wait with a one-second local deadline
- bound the spawned DNS tail-reader join and abort plus reap the task before reporting a timeout
- preserve live producer and duplex-writer fixtures so success still proves cancellation rather than channel closure or EOF

Production reader behavior is unchanged; this PR only updates `#[cfg(test)]` lifecycle assertions.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner`
- focused mutation check: temporarily removed the reader cancellation select arm and confirmed both tests failed in about one second with their lifecycle-specific timeout diagnostics, then restored the production code

Closes #25267
