### PR TITLE
perf(runner): overlap exact reuse restore with claim

### DIFF
--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -257,6 +257,7 @@ mod tests {
             storage_fingerprints: StorageFingerprints::default(),
             restored_session_identity: None,
             history_generation_run_id: None,
+            guest_timezone_intent: crate::guest_timezone::GuestTimezoneIntent::Unknown,
             workspace_image_size_bytes: b"workspace image".len() as u64,
             workspace_promotion: Some(fixture.promotion),
         });

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -484,6 +484,10 @@ pub(super) async fn handle_discovered_job(
         idle_snapshot,
     )
     .await;
+    #[cfg(test)]
+    ctx.spawn_ctx
+        .test_observer
+        .notify_active_run_status_published(run_id);
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::ActiveStatusPublish, started_at);
 
     let job_profile = JobProfile {

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -11,6 +11,7 @@ use std::time::Instant;
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use futures_util::FutureExt;
 use sandbox::SandboxId;
+use tokio::sync::OwnedMutexGuard;
 use tokio::task::JoinSet;
 use tracing::{info, warn};
 
@@ -44,7 +45,9 @@ use crate::lifecycle::RunnerMode;
 use crate::paths::short_digest;
 use crate::provider::{ClaimedJob, JobCandidate, RunnerPreferenceReason};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
-use crate::run_cancellation::{RunCancellationRegistration, RunCancellationRegistry};
+use crate::run_cancellation::{
+    RunCancellationHandle, RunCancellationRegistration, RunCancellationRegistry,
+};
 use crate::status::StatusTracker;
 use crate::types::{
     ExecutionContext, HeldWorkspaceState, SandboxReuseResult, WORKSPACE_AFFINITY_VERSION,
@@ -298,9 +301,16 @@ pub(super) async fn handle_discovered_job(
         claimed.context().reuse_key().map(str::to_owned),
     );
 
-    let (reuse_entry, active_lease, reuse_result, idle_snapshot, needs_reuse_state_refresh) =
-        match resource {
-            AdmittedResource::Fresh(job_lease) => {
+    let (
+        reuse_entry,
+        active_lease,
+        reuse_result,
+        idle_snapshot,
+        needs_reuse_state_refresh,
+        activation_transfer_guard,
+    ) = match resource {
+        AdmittedResource::Fresh(job_lease) => {
+            let (reuse_entry, active_lease, reuse_result, idle_snapshot, refresh) =
                 try_reuse_from_pool(
                     run_id,
                     ReuseAdmissionRequest {
@@ -313,99 +323,136 @@ pub(super) async fn handle_discovered_job(
                     &mut ctx,
                     &mut pre_spawn_timing,
                 )
-                .await
-            }
-            AdmittedResource::Reusable(reservation) => {
-                match activate_reserved_idle(
-                    *reservation,
-                    ReservedActivationRequest {
-                        run_id,
-                        profile_name: &profile_name,
-                        workspace_disk_mb: job_workspace_disk_mb,
-                        context: claimed.context(),
-                    },
-                    &mut ctx,
-                    &mut pre_spawn_timing,
-                )
-                .await
-                {
-                    ReservedActivation::Ready {
-                        reuse_entry,
-                        active_lease,
-                        reuse_result,
-                        idle_snapshot,
-                    } => (
-                        reuse_entry.map(|entry| *entry),
-                        active_lease,
-                        reuse_result,
-                        Some(idle_snapshot),
-                        true,
-                    ),
-                    ReservedActivation::CannotStart {
-                        budget_lease,
-                        reuse_result,
-                        error,
-                    } => {
-                        complete_claimed_without_sandbox(
-                            claimed,
-                            cancellation,
-                            AdmittedResource::Fresh(budget_lease),
-                            job_workspace_disk_mb,
-                            Some(reuse_result),
-                            crate::executor::ExecutionFailure::from_error(error),
-                            &mut ctx,
-                        )
-                        .await;
-                        return DiscoveredJobResult::completed(true);
-                    }
+                .await;
+            (
+                reuse_entry,
+                active_lease,
+                reuse_result,
+                idle_snapshot,
+                refresh,
+                None,
+            )
+        }
+        AdmittedResource::Reusable(reservation) => {
+            match activate_reserved_idle(
+                *reservation,
+                ReservedActivationRequest {
+                    run_id,
+                    profile_name: &profile_name,
+                    workspace_disk_mb: job_workspace_disk_mb,
+                    context: claimed.context(),
+                },
+                &mut ctx,
+                &mut pre_spawn_timing,
+            )
+            .await
+            {
+                ReservedActivation::Ready {
+                    reuse_entry,
+                    active_lease,
+                    reuse_result,
+                    idle_snapshot,
+                } => (
+                    reuse_entry.map(|entry| *entry),
+                    active_lease,
+                    reuse_result,
+                    Some(idle_snapshot),
+                    true,
+                    None,
+                ),
+                ReservedActivation::CannotStart {
+                    budget_lease,
+                    reuse_result,
+                    error,
+                } => {
+                    complete_claimed_without_sandbox(
+                        claimed,
+                        cancellation,
+                        AdmittedResource::Fresh(budget_lease),
+                        job_workspace_disk_mb,
+                        Some(reuse_result),
+                        crate::executor::ExecutionFailure::from_error(error),
+                        &mut ctx,
+                    )
+                    .await;
+                    return DiscoveredJobResult::completed(true);
                 }
             }
-            AdmittedResource::ExactSpeculation(speculation) => {
-                match activate_speculated_exact(
-                    speculation,
-                    ReservedActivationRequest {
-                        run_id,
-                        profile_name: &profile_name,
-                        workspace_disk_mb: job_workspace_disk_mb,
-                        context: claimed.context(),
-                    },
-                    &ctx,
-                    &mut pre_spawn_timing,
-                )
-                .await
-                {
-                    ReservedActivation::Ready {
-                        reuse_entry,
-                        active_lease,
+        }
+        AdmittedResource::ExactSpeculation(speculation) => {
+            let pending = activate_speculated_exact(
+                speculation,
+                ReservedActivationRequest {
+                    run_id,
+                    profile_name: &profile_name,
+                    workspace_disk_mb: job_workspace_disk_mb,
+                    context: claimed.context(),
+                },
+                &ctx,
+                &mut pre_spawn_timing,
+            )
+            .await;
+            match finish_exact_activation(pending, &cancellation.handle(), run_id, &ctx).await {
+                ExactActivation::Ready {
+                    reuse_entry,
+                    active_lease,
+                    reuse_result,
+                    idle_snapshot,
+                    transfer_guard,
+                } => (
+                    reuse_entry.map(|entry| *entry),
+                    active_lease,
+                    reuse_result,
+                    Some(idle_snapshot),
+                    true,
+                    Some(transfer_guard),
+                ),
+                ExactActivation::Cancelled {
+                    resource,
+                    reuse_result,
+                } => {
+                    let run_id = complete_claimed_failure(
+                        claimed,
+                        cancellation,
                         reuse_result,
-                        idle_snapshot,
-                    } => (
-                        reuse_entry.map(|entry| *entry),
-                        active_lease,
-                        reuse_result,
-                        Some(idle_snapshot),
-                        true,
-                    ),
-                    ReservedActivation::CannotStart {
-                        budget_lease,
-                        reuse_result,
-                        error,
-                    } => {
-                        complete_claimed_without_sandbox(
-                            claimed,
-                            cancellation,
-                            AdmittedResource::Fresh(budget_lease),
-                            job_workspace_disk_mb,
-                            Some(reuse_result),
-                            crate::executor::ExecutionFailure::from_error(error),
-                            &mut ctx,
-                        )
-                        .await;
-                        return DiscoveredJobResult::completed(true);
+                        crate::executor::ExecutionFailure::cancelled(),
+                        &ctx,
+                    )
+                    .await;
+                    match resource {
+                        CancelledExactResource::Prepared(sandbox) => {
+                            rollback_exact_speculation_outcome(
+                                ExactSpeculationOutcome::Prepared(sandbox),
+                                run_id,
+                                job_workspace_disk_mb,
+                                &mut ctx,
+                            )
+                            .await;
+                        }
+                        CancelledExactResource::Fresh(budget_lease) => drop(budget_lease),
                     }
+                    return DiscoveredJobResult::completed(true);
+                }
+                ExactActivation::CannotStart {
+                    budget_lease,
+                    reuse_result,
+                    error,
+                } => {
+                    complete_claimed_without_sandbox(
+                        claimed,
+                        cancellation,
+                        AdmittedResource::Fresh(budget_lease),
+                        job_workspace_disk_mb,
+                        Some(reuse_result),
+                        crate::executor::ExecutionFailure::from_error(error),
+                        &mut ctx,
+                    )
+                    .await;
+                    return DiscoveredJobResult::completed(true);
                 }
             }
-        };
+        }
+    };
 
     let session_history_restore_plan =
         build_session_history_restore_plan(SessionHistoryRestorePlanInput {
@@ -464,6 +511,7 @@ pub(super) async fn handle_discovered_job(
         ctx.spawn_ctx,
         ctx.jobs,
     );
+    drop(activation_transfer_guard);
     DiscoveredJobResult::completed(needs_reuse_state_refresh)
 }
 
@@ -1088,7 +1136,16 @@ async fn rollback_exact_speculation(
     workspace_disk_mb: u32,
     ctx: &mut DiscoveredJobContext<'_>,
 ) {
-    let destroy_job = match speculation.outcome {
+    rollback_exact_speculation_outcome(speculation.outcome, run_id, workspace_disk_mb, ctx).await;
+}
+
+async fn rollback_exact_speculation_outcome(
+    outcome: ExactSpeculationOutcome,
+    run_id: RunId,
+    workspace_disk_mb: u32,
+    ctx: &mut DiscoveredJobContext<'_>,
+) {
+    let destroy_job = match outcome {
         ExactSpeculationOutcome::Prepared(sandbox) => {
             match sandbox
                 .repark_for_claim_rollback(run_id, u64::from(workspace_disk_mb) * 1024 * 1024)
@@ -1153,12 +1210,89 @@ enum ReservedActivation {
     },
 }
 
+enum FreshFallbackActivation {
+    Ready {
+        active_lease: BudgetLease,
+        reuse_result: SandboxReuseResult,
+        idle_snapshot: IdlePoolSnapshot,
+    },
+    CannotStart {
+        budget_lease: BudgetLease,
+        reuse_result: SandboxReuseResult,
+        error: String,
+    },
+}
+
+impl From<FreshFallbackActivation> for ReservedActivation {
+    fn from(activation: FreshFallbackActivation) -> Self {
+        match activation {
+            FreshFallbackActivation::Ready {
+                active_lease,
+                reuse_result,
+                idle_snapshot,
+            } => Self::Ready {
+                reuse_entry: None,
+                active_lease,
+                reuse_result,
+                idle_snapshot,
+            },
+            FreshFallbackActivation::CannotStart {
+                budget_lease,
+                reuse_result,
+                error,
+            } => Self::CannotStart {
+                budget_lease,
+                reuse_result,
+                error,
+            },
+        }
+    }
+}
+
+enum PendingExactActivation {
+    Prepared {
+        sandbox: Box<SpeculativeIdleSandbox>,
+        guest_state_prepared: bool,
+    },
+    FreshFallback(FreshFallbackActivation),
+}
+
+impl From<FreshFallbackActivation> for PendingExactActivation {
+    fn from(activation: FreshFallbackActivation) -> Self {
+        Self::FreshFallback(activation)
+    }
+}
+
+enum CancelledExactResource {
+    Prepared(Box<SpeculativeIdleSandbox>),
+    Fresh(BudgetLease),
+}
+
+enum ExactActivation {
+    Ready {
+        reuse_entry: Option<Box<ReusableIdleSandbox>>,
+        active_lease: BudgetLease,
+        reuse_result: SandboxReuseResult,
+        idle_snapshot: IdlePoolSnapshot,
+        transfer_guard: OwnedMutexGuard<()>,
+    },
+    Cancelled {
+        resource: CancelledExactResource,
+        reuse_result: Option<SandboxReuseResult>,
+    },
+    CannotStart {
+        budget_lease: BudgetLease,
+        reuse_result: SandboxReuseResult,
+        error: String,
+    },
+}
+
 async fn activate_speculated_exact(
     speculation: ExactSpeculation,
     request: ReservedActivationRequest<'_>,
     ctx: &DiscoveredJobContext<'_>,
     pre_spawn_timing: &mut RunnerPreSpawnTiming,
-) -> ReservedActivation {
+) -> PendingExactActivation {
     let ReservedActivationRequest {
         run_id,
         profile_name,
@@ -1202,7 +1336,8 @@ async fn activate_speculated_exact(
                 "speculative_exact_reuse_prepare_failed",
                 ctx,
             )
-            .await;
+            .await
+            .into();
         }
     };
 
@@ -1225,7 +1360,8 @@ async fn activate_speculated_exact(
             "speculative_reuse_session_mismatch",
             ctx,
         )
-        .await;
+        .await
+        .into();
     }
 
     if let Some(cache) = ctx.spawn_ctx.exec_config.workspace_cache.as_ref() {
@@ -1254,7 +1390,8 @@ async fn activate_speculated_exact(
                 "speculative_workspace_promotion_mismatch",
                 ctx,
             )
-            .await;
+            .await
+            .into();
         }
     }
 
@@ -1294,7 +1431,8 @@ async fn activate_speculated_exact(
                         "speculative_timezone_correction_failed",
                         ctx,
                     )
-                    .await;
+                    .await
+                    .into();
                 }
                 Err(_) => {
                     speculation_timing.timezone_correction =
@@ -1314,7 +1452,8 @@ async fn activate_speculated_exact(
                         "speculative_timezone_correction_panicked",
                         ctx,
                     )
-                    .await;
+                    .await
+                    .into();
                 }
             }
             true
@@ -1329,18 +1468,78 @@ async fn activate_speculated_exact(
     speculation_timing.timezone_assumption = Some(assumption);
     pre_spawn_timing.record_exact_reuse_speculation(speculation_timing);
 
-    let (reuse_entry, active_lease) = sandbox.commit(guest_state_prepared);
-    info!(
-        run_id = %run_id,
-        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reserved_reuse_key),
-        reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
-        "committing speculatively prepared exact-reuse VM"
-    );
-    ReservedActivation::Ready {
-        reuse_entry: Some(Box::new(reuse_entry)),
-        active_lease,
-        reuse_result: SandboxReuseResult::Reused,
-        idle_snapshot: ctx.idle_pool.lock().await.status_snapshot(),
+    PendingExactActivation::Prepared {
+        sandbox,
+        guest_state_prepared,
+    }
+}
+
+async fn finish_exact_activation(
+    activation: PendingExactActivation,
+    cancellation: &RunCancellationHandle,
+    run_id: RunId,
+    ctx: &DiscoveredJobContext<'_>,
+) -> ExactActivation {
+    match activation {
+        PendingExactActivation::Prepared {
+            sandbox,
+            guest_state_prepared,
+        } => {
+            let transfer_guard = cancellation.transfer_guard().await;
+            if cancellation.is_cancelled() {
+                drop(transfer_guard);
+                return ExactActivation::Cancelled {
+                    resource: CancelledExactResource::Prepared(sandbox),
+                    reuse_result: None,
+                };
+            }
+
+            let reuse_key = sandbox.reuse_key().to_owned();
+            let (reuse_entry, active_lease) = sandbox.commit(guest_state_prepared);
+            info!(
+                run_id = %run_id,
+                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reuse_key),
+                reuse_key_kind = reuse_key_kind(&reuse_key),
+                "committing speculatively prepared exact-reuse VM"
+            );
+            ExactActivation::Ready {
+                reuse_entry: Some(Box::new(reuse_entry)),
+                active_lease,
+                reuse_result: SandboxReuseResult::Reused,
+                idle_snapshot: ctx.idle_pool.lock().await.status_snapshot(),
+                transfer_guard,
+            }
+        }
+        PendingExactActivation::FreshFallback(FreshFallbackActivation::Ready {
+            active_lease,
+            reuse_result,
+            idle_snapshot,
+        }) => {
+            let transfer_guard = cancellation.transfer_guard().await;
+            if cancellation.is_cancelled() {
+                drop(transfer_guard);
+                return ExactActivation::Cancelled {
+                    resource: CancelledExactResource::Fresh(active_lease),
+                    reuse_result: Some(reuse_result),
+                };
+            }
+            ExactActivation::Ready {
+                reuse_entry: None,
+                active_lease,
+                reuse_result,
+                idle_snapshot,
+                transfer_guard,
+            }
+        }
+        PendingExactActivation::FreshFallback(FreshFallbackActivation::CannotStart {
+            budget_lease,
+            reuse_result,
+            error,
+        }) => ExactActivation::CannotStart {
+            budget_lease,
+            reuse_result,
+            error,
+        },
     }
 }
 
@@ -1380,7 +1579,8 @@ async fn activate_reserved_idle(
             "reserved_reuse_session_mismatch",
             ctx,
         )
-        .await;
+        .await
+        .into();
     }
 
     if let Some(cache) = ctx.spawn_ctx.exec_config.workspace_cache.as_ref() {
@@ -1409,7 +1609,8 @@ async fn activate_reserved_idle(
                 "reserved_reuse_workspace_promotion_mismatch",
                 ctx,
             )
-            .await;
+            .await
+            .into();
         }
     }
 
@@ -1450,6 +1651,7 @@ async fn activate_reserved_idle(
                 ctx,
             )
             .await
+            .into()
         }
     }
 }
@@ -1459,16 +1661,15 @@ async fn cleanup_reserved_for_fresh_fallback(
     reuse_result: SandboxReuseResult,
     cleanup_context: &'static str,
     ctx: &DiscoveredJobContext<'_>,
-) -> ReservedActivation {
+) -> FreshFallbackActivation {
     let cleanup = destroy_job.run_retaining_lease(cleanup_context).await;
     match cleanup.outcome {
-        DestroyOutcome::Completed => ReservedActivation::Ready {
-            reuse_entry: None,
+        DestroyOutcome::Completed => FreshFallbackActivation::Ready {
             active_lease: cleanup.budget_lease,
             reuse_result,
             idle_snapshot: ctx.idle_pool.lock().await.status_snapshot(),
         },
-        DestroyOutcome::Uncertain => ReservedActivation::CannotStart {
+        DestroyOutcome::Uncertain => FreshFallbackActivation::CannotStart {
             budget_lease: cleanup.budget_lease,
             reuse_result,
             error: "reserved idle sandbox cleanup was uncertain; fresh replacement was not started"
@@ -1486,6 +1687,17 @@ async fn complete_claimed_without_sandbox(
     failure: crate::executor::ExecutionFailure,
     ctx: &mut DiscoveredJobContext<'_>,
 ) {
+    let run_id = complete_claimed_failure(claimed, cancellation, reuse_result, failure, ctx).await;
+    rollback_admitted_resource(resource, run_id, workspace_disk_mb, ctx).await;
+}
+
+async fn complete_claimed_failure(
+    claimed: ClaimedJob,
+    cancellation: RunCancellationRegistration,
+    reuse_result: Option<SandboxReuseResult>,
+    failure: crate::executor::ExecutionFailure,
+    ctx: &DiscoveredJobContext<'_>,
+) -> RunId {
     let (context, completion_auth, active_input_source) = claimed.into_parts();
     let run_id = context.run_id;
     drop(active_input_source);
@@ -1501,7 +1713,7 @@ async fn complete_claimed_without_sandbox(
         )
         .await;
     cancellation.unregister().await;
-    rollback_admitted_resource(resource, run_id, workspace_disk_mb, ctx).await;
+    run_id
 }
 
 async fn try_reuse_from_pool(

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -1539,11 +1539,22 @@ async fn finish_exact_activation(
             budget_lease,
             reuse_result,
             error,
-        }) => ExactActivation::CannotStart {
-            budget_lease,
-            reuse_result,
-            error,
-        },
+        }) => {
+            let transfer_guard = cancellation.transfer_guard().await;
+            if cancellation.is_cancelled() {
+                drop(transfer_guard);
+                return ExactActivation::Cancelled {
+                    resource: CancelledExactResource::Fresh(budget_lease),
+                    reuse_result: Some(reuse_result),
+                };
+            }
+            drop(transfer_guard);
+            ExactActivation::CannotStart {
+                budget_lease,
+                reuse_result,
+                error,
+            }
+        }
     }
 }
 

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -4,10 +4,12 @@
 //! module owns the body that turns a discovered job into a claimed spawned job.
 
 use std::collections::BTreeMap;
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::Instant;
 
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
+use futures_util::FutureExt;
 use sandbox::SandboxId;
 use tokio::task::JoinSet;
 use tracing::{info, warn};
@@ -27,12 +29,15 @@ use super::pre_park_handoff_observation::{
 };
 use crate::config::ProfileConfig;
 use crate::executor::{
-    RunnerPreSpawnPhase, RunnerPreSpawnTiming, SessionHistoryRestorePlanInput,
-    build_session_history_restore_plan, validate_resume_session_id,
+    ExactReuseSpeculationTiming, RunnerPreSpawnOperationTiming, RunnerPreSpawnPhase,
+    RunnerPreSpawnTiming, SessionHistoryRestorePlanInput, build_session_history_restore_plan,
+    restore_guest_state_with_intent, try_sync_guest_timezone_intent, validate_resume_session_id,
 };
+use crate::guest_timezone::{GuestTimezoneAssumption, GuestTimezoneIntent};
 use crate::idle_pool::{
     DestroyOutcome, IdlePoolSnapshot, IdleUnparkResult, ReservedIdleSandbox,
-    RestoreReservedIdleResult, ReusableIdleSandbox,
+    RestoreReservedIdleResult, ReusableIdleSandbox, SpeculativeIdleSandbox,
+    SpeculativeIdleUnparkResult, SpeculativeReparkResult,
 };
 use crate::ids::RunId;
 use crate::lifecycle::RunnerMode;
@@ -94,12 +99,46 @@ struct LocalAdmission {
 enum LocalAdmissionResource {
     Fresh(BudgetLease),
     Reusable(Box<ReservedIdleSandbox>),
+    ExactSpeculative(Box<ReservedIdleSandbox>),
+}
+
+enum AdmittedResource {
+    Fresh(BudgetLease),
+    Reusable(Box<ReservedIdleSandbox>),
+    ExactSpeculation(ExactSpeculation),
+}
+
+struct ExactSpeculation {
+    outcome: ExactSpeculationOutcome,
+    preparation_started_at: Instant,
+    preparation_completed_at: Instant,
+    claim_started_at: Instant,
+    claim_returned_at: Instant,
+    unpark: RunnerPreSpawnOperationTiming,
+    guest_restore: Option<RunnerPreSpawnOperationTiming>,
+}
+
+struct ExactSpeculationPreparation {
+    outcome: ExactSpeculationOutcome,
+    started_at: Instant,
+    completed_at: Instant,
+    unpark: RunnerPreSpawnOperationTiming,
+    guest_restore: Option<RunnerPreSpawnOperationTiming>,
+}
+
+enum ExactSpeculationOutcome {
+    Prepared(Box<SpeculativeIdleSandbox>),
+    Failed {
+        destroy_job: Box<crate::idle_pool::IdleDestroyJob>,
+        error: String,
+    },
 }
 
 struct AdmittedClaim {
     claimed: ClaimedJob,
-    resource: LocalAdmissionResource,
+    resource: AdmittedResource,
     cancellation: RunCancellationRegistration,
+    claim_returned_at: Instant,
 }
 
 struct PreparedCandidate {
@@ -121,6 +160,16 @@ struct ReuseAdmissionRequest<'a> {
     job_lease: BudgetLease,
 }
 
+struct ClaimAdmissionRequest<'a> {
+    prepared: PreparedCandidate,
+    run_id: RunId,
+    profile_name: &'a str,
+    job_vcpu: u32,
+    job_memory: u32,
+    workspace_disk_mb: u32,
+    device_rate_limits: &'a Option<sandbox::DeviceRateLimits>,
+}
+
 struct ReservedActivationRequest<'a> {
     run_id: RunId,
     profile_name: &'a str,
@@ -136,14 +185,6 @@ impl LocalAdmission {
         } = self;
         cancellation.unregister().await;
         rollback_untracked_resource(resource, ctx).await;
-    }
-
-    fn into_admitted(self, claimed: ClaimedJob) -> AdmittedClaim {
-        AdmittedClaim {
-            claimed,
-            resource: self.resource,
-            cancellation: self.cancellation,
-        }
     }
 }
 
@@ -187,12 +228,15 @@ pub(super) async fn handle_discovered_job(
         PreferencePreparation::Deferred => return DiscoveredJobResult::completed(false),
     };
     let Some(admission) = claim_with_local_admission(
-        prepared,
-        run_id,
-        &profile_name,
-        job_vcpu,
-        job_memory,
-        &device_rate_limits,
+        ClaimAdmissionRequest {
+            prepared,
+            run_id,
+            profile_name: &profile_name,
+            job_vcpu,
+            job_memory,
+            workspace_disk_mb: job_workspace_disk_mb,
+            device_rate_limits: &device_rate_limits,
+        },
         &mut ctx,
     )
     .await
@@ -203,14 +247,42 @@ pub(super) async fn handle_discovered_job(
         claimed,
         resource,
         cancellation,
+        claim_returned_at,
     } = admission;
-    let mut pre_spawn_timing = RunnerPreSpawnTiming::start_after_claim();
+    if cancellation.handle().is_cancelled()
+        && matches!(&resource, AdmittedResource::ExactSpeculation(_))
+    {
+        complete_claimed_without_sandbox(
+            claimed,
+            cancellation,
+            resource,
+            job_workspace_disk_mb,
+            None,
+            crate::executor::ExecutionFailure::cancelled(),
+            &mut ctx,
+        )
+        .await;
+        return DiscoveredJobResult::completed(true);
+    }
+    let mut pre_spawn_timing = RunnerPreSpawnTiming::start_at(claim_returned_at);
     let started_at = Instant::now();
     let resume_session_error = validate_resume_session_id(claimed.context()).err();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::ResumeSessionValidation, started_at);
     if let Some(error) = resume_session_error {
-        let needs_reuse_state_refresh = matches!(&resource, LocalAdmissionResource::Reusable(_));
-        fail_claimed_without_sandbox(claimed, cancellation, resource, None, error, &mut ctx).await;
+        let needs_reuse_state_refresh = matches!(
+            &resource,
+            AdmittedResource::Reusable(_) | AdmittedResource::ExactSpeculation(_)
+        );
+        complete_claimed_without_sandbox(
+            claimed,
+            cancellation,
+            resource,
+            job_workspace_disk_mb,
+            None,
+            crate::executor::ExecutionFailure::from_error(error),
+            &mut ctx,
+        )
+        .await;
         return DiscoveredJobResult::completed(needs_reuse_state_refresh);
     }
     info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
@@ -228,7 +300,7 @@ pub(super) async fn handle_discovered_job(
 
     let (reuse_entry, active_lease, reuse_result, idle_snapshot, needs_reuse_state_refresh) =
         match resource {
-            LocalAdmissionResource::Fresh(job_lease) => {
+            AdmittedResource::Fresh(job_lease) => {
                 try_reuse_from_pool(
                     run_id,
                     ReuseAdmissionRequest {
@@ -243,7 +315,7 @@ pub(super) async fn handle_discovered_job(
                 )
                 .await
             }
-            LocalAdmissionResource::Reusable(reservation) => {
+            AdmittedResource::Reusable(reservation) => {
                 match activate_reserved_idle(
                     *reservation,
                     ReservedActivationRequest {
@@ -274,12 +346,58 @@ pub(super) async fn handle_discovered_job(
                         reuse_result,
                         error,
                     } => {
-                        fail_claimed_without_sandbox(
+                        complete_claimed_without_sandbox(
                             claimed,
                             cancellation,
-                            LocalAdmissionResource::Fresh(budget_lease),
+                            AdmittedResource::Fresh(budget_lease),
+                            job_workspace_disk_mb,
                             Some(reuse_result),
-                            error,
+                            crate::executor::ExecutionFailure::from_error(error),
+                            &mut ctx,
+                        )
+                        .await;
+                        return DiscoveredJobResult::completed(true);
+                    }
+                }
+            }
+            AdmittedResource::ExactSpeculation(speculation) => {
+                match activate_speculated_exact(
+                    speculation,
+                    ReservedActivationRequest {
+                        run_id,
+                        profile_name: &profile_name,
+                        workspace_disk_mb: job_workspace_disk_mb,
+                        context: claimed.context(),
+                    },
+                    &ctx,
+                    &mut pre_spawn_timing,
+                )
+                .await
+                {
+                    ReservedActivation::Ready {
+                        reuse_entry,
+                        active_lease,
+                        reuse_result,
+                        idle_snapshot,
+                    } => (
+                        reuse_entry.map(|entry| *entry),
+                        active_lease,
+                        reuse_result,
+                        Some(idle_snapshot),
+                        true,
+                    ),
+                    ReservedActivation::CannotStart {
+                        budget_lease,
+                        reuse_result,
+                        error,
+                    } => {
+                        complete_claimed_without_sandbox(
+                            claimed,
+                            cancellation,
+                            AdmittedResource::Fresh(budget_lease),
+                            job_workspace_disk_mb,
+                            Some(reuse_result),
+                            crate::executor::ExecutionFailure::from_error(error),
                             &mut ctx,
                         )
                         .await;
@@ -368,14 +486,18 @@ async fn publish_active_run_status(
 }
 
 async fn claim_with_local_admission(
-    prepared: PreparedCandidate,
-    run_id: RunId,
-    profile_name: &str,
-    job_vcpu: u32,
-    job_memory: u32,
-    device_rate_limits: &Option<sandbox::DeviceRateLimits>,
+    request: ClaimAdmissionRequest<'_>,
     ctx: &mut DiscoveredJobContext<'_>,
 ) -> Option<AdmittedClaim> {
+    let ClaimAdmissionRequest {
+        prepared,
+        run_id,
+        profile_name,
+        job_vcpu,
+        job_memory,
+        workspace_disk_mb,
+        device_rate_limits,
+    } = request;
     let PreparedCandidate {
         mut candidate,
         resource,
@@ -470,10 +592,58 @@ async fn claim_with_local_admission(
     let observed_candidate =
         is_selected_finalizing_candidate(&candidate, ctx.runner_id, ctx.heartbeat_generation)
             .then(|| candidate.clone());
-    if matches!(&admission.resource, LocalAdmissionResource::Reusable(_)) {
+    if matches!(
+        &admission.resource,
+        LocalAdmissionResource::Reusable(_) | LocalAdmissionResource::ExactSpeculative(_)
+    ) {
         candidate.mark_reserved_reuse_claim_started();
     }
-    let Some(claimed) = ctx.spawn_ctx.provider.claim(candidate).await else {
+    let LocalAdmission {
+        resource,
+        cancellation,
+    } = admission;
+    let claim_started_at = Instant::now();
+    let (claimed, admitted_resource, claim_returned_at) = match resource {
+        LocalAdmissionResource::Fresh(budget_lease) => {
+            let claimed = ctx.spawn_ctx.provider.claim(candidate).await;
+            (
+                claimed,
+                AdmittedResource::Fresh(budget_lease),
+                Instant::now(),
+            )
+        }
+        LocalAdmissionResource::Reusable(reservation) => {
+            let claimed = ctx.spawn_ctx.provider.claim(candidate).await;
+            (
+                claimed,
+                AdmittedResource::Reusable(reservation),
+                Instant::now(),
+            )
+        }
+        LocalAdmissionResource::ExactSpeculative(reservation) => {
+            let claim = async {
+                let claimed = ctx.spawn_ctx.provider.claim(candidate).await;
+                (claimed, Instant::now())
+            };
+            let preparation = prepare_exact_speculation(*reservation, run_id);
+            let ((claimed, claim_returned_at), preparation) = tokio::join!(claim, preparation);
+            let speculation = ExactSpeculation {
+                outcome: preparation.outcome,
+                preparation_started_at: preparation.started_at,
+                preparation_completed_at: preparation.completed_at,
+                claim_started_at,
+                claim_returned_at,
+                unpark: preparation.unpark,
+                guest_restore: preparation.guest_restore,
+            };
+            (
+                claimed,
+                AdmittedResource::ExactSpeculation(speculation),
+                claim_returned_at,
+            )
+        }
+    };
+    let Some(claimed) = claimed else {
         // None means the job won't run here: either lost the race to another
         // runner, or the provider rejected the job. Release the reservation and
         // cancellation registration so the runner can continue.
@@ -486,7 +656,8 @@ async fn claim_with_local_admission(
                 Some(CandidateReason::ProviderRejected),
             );
         }
-        admission.rollback(ctx).await;
+        cancellation.unregister().await;
+        rollback_admitted_resource(admitted_resource, run_id, workspace_disk_mb, ctx).await;
         return None;
     };
     if claimed.context().run_id != run_id {
@@ -504,7 +675,8 @@ async fn claim_with_local_admission(
             context_run_id = %claimed.context().run_id,
             "provider returned claimed job with mismatched run_id"
         );
-        admission.rollback(ctx).await;
+        cancellation.unregister().await;
+        rollback_admitted_resource(admitted_resource, run_id, workspace_disk_mb, ctx).await;
         return None;
     }
 
@@ -518,7 +690,81 @@ async fn claim_with_local_admission(
         );
     }
 
-    Some(admission.into_admitted(claimed))
+    Some(AdmittedClaim {
+        claimed,
+        resource: admitted_resource,
+        cancellation,
+        claim_returned_at,
+    })
+}
+
+async fn prepare_exact_speculation(
+    reservation: ReservedIdleSandbox,
+    run_id: RunId,
+) -> ExactSpeculationPreparation {
+    let preparation_started_at = Instant::now();
+    let predicted_timezone = reservation.guest_timezone_intent().clone();
+    let unpark_started_at = Instant::now();
+    let unpark_result = reservation.try_unpark_for_speculation(run_id).await;
+    let unpark_duration = unpark_started_at.elapsed();
+    let (outcome, unpark_succeeded, guest_restore) = match unpark_result {
+        SpeculativeIdleUnparkResult::Ready(sandbox) => {
+            let restore_started_at = Instant::now();
+            let restored = AssertUnwindSafe(restore_guest_state_with_intent(
+                sandbox.sandbox(),
+                run_id,
+                &predicted_timezone,
+            ))
+            .catch_unwind()
+            .await;
+            let restore_duration = restore_started_at.elapsed();
+            let (outcome, restore_succeeded) = match restored {
+                Ok(Ok(())) => (ExactSpeculationOutcome::Prepared(sandbox), true),
+                Ok(Err(error)) => (
+                    ExactSpeculationOutcome::Failed {
+                        destroy_job: Box::new(
+                            sandbox.into_destroy_job("speculative_guest_restore_failed"),
+                        ),
+                        error: error.to_string(),
+                    },
+                    false,
+                ),
+                Err(_) => (
+                    ExactSpeculationOutcome::Failed {
+                        destroy_job: Box::new(
+                            sandbox.into_destroy_job("speculative_guest_restore_panicked"),
+                        ),
+                        error: "speculative guest restore panicked".into(),
+                    },
+                    false,
+                ),
+            };
+            (
+                outcome,
+                true,
+                Some(RunnerPreSpawnOperationTiming {
+                    duration: restore_duration,
+                    succeeded: restore_succeeded,
+                }),
+            )
+        }
+        SpeculativeIdleUnparkResult::Failed { destroy_job, error } => (
+            ExactSpeculationOutcome::Failed { destroy_job, error },
+            false,
+            None,
+        ),
+    };
+    let preparation_completed_at = Instant::now();
+    ExactSpeculationPreparation {
+        outcome,
+        started_at: preparation_started_at,
+        completed_at: preparation_completed_at,
+        unpark: RunnerPreSpawnOperationTiming {
+            duration: unpark_duration,
+            succeeded: unpark_succeeded,
+        },
+        guest_restore,
+    }
 }
 
 async fn prepare_preference_candidate(
@@ -567,7 +813,11 @@ async fn prepare_preference_candidate(
             )
             .await
             {
-                return reusable_preparation(candidate, reservation);
+                return if reservation.guest_timezone_intent().is_usable_prediction() {
+                    exact_speculative_preparation(candidate, reservation)
+                } else {
+                    reusable_preparation(candidate, reservation)
+                };
             }
         }
         RunnerPreferenceReason::MatchingReuseKey => {
@@ -653,6 +903,18 @@ fn reusable_preparation(
     PreferencePreparation::Ready(PreparedCandidate {
         candidate,
         resource: Some(LocalAdmissionResource::Reusable(Box::new(reservation))),
+    })
+}
+
+fn exact_speculative_preparation(
+    candidate: JobCandidate,
+    reservation: ReservedIdleSandbox,
+) -> PreferencePreparation {
+    PreferencePreparation::Ready(PreparedCandidate {
+        candidate,
+        resource: Some(LocalAdmissionResource::ExactSpeculative(Box::new(
+            reservation,
+        ))),
     })
 }
 
@@ -782,7 +1044,8 @@ async fn rollback_untracked_resource(
 ) {
     match resource {
         LocalAdmissionResource::Fresh(budget_lease) => drop(budget_lease),
-        LocalAdmissionResource::Reusable(reservation) => {
+        LocalAdmissionResource::Reusable(reservation)
+        | LocalAdmissionResource::ExactSpeculative(reservation) => {
             let (restore_result, snapshot) = {
                 let mut pool = ctx.idle_pool.lock().await;
                 let restore_result = pool.restore_reserved(*reservation);
@@ -802,6 +1065,80 @@ async fn rollback_untracked_resource(
     }
 }
 
+async fn rollback_admitted_resource(
+    resource: AdmittedResource,
+    run_id: RunId,
+    workspace_disk_mb: u32,
+    ctx: &mut DiscoveredJobContext<'_>,
+) {
+    match resource {
+        AdmittedResource::Fresh(budget_lease) => drop(budget_lease),
+        AdmittedResource::Reusable(reservation) => {
+            rollback_untracked_resource(LocalAdmissionResource::Reusable(reservation), ctx).await;
+        }
+        AdmittedResource::ExactSpeculation(speculation) => {
+            rollback_exact_speculation(speculation, run_id, workspace_disk_mb, ctx).await;
+        }
+    }
+}
+
+async fn rollback_exact_speculation(
+    speculation: ExactSpeculation,
+    run_id: RunId,
+    workspace_disk_mb: u32,
+    ctx: &mut DiscoveredJobContext<'_>,
+) {
+    let destroy_job = match speculation.outcome {
+        ExactSpeculationOutcome::Prepared(sandbox) => {
+            match sandbox
+                .repark_for_claim_rollback(run_id, u64::from(workspace_disk_mb) * 1024 * 1024)
+                .await
+            {
+                SpeculativeReparkResult::Reparked(reservation) => {
+                    let (restore_result, snapshot) = {
+                        let mut pool = ctx.idle_pool.lock().await;
+                        let restore_result = pool.restore_reserved(*reservation);
+                        let snapshot = pool.status_snapshot();
+                        (restore_result, snapshot)
+                    };
+                    set_idle_status_snapshot(ctx.status, snapshot).await;
+                    ctx.spawn_ctx.reuse_state_notify.notify_one();
+                    match restore_result {
+                        RestoreReservedIdleResult::Restored => None,
+                        RestoreReservedIdleResult::Rejected(destroy_job) => Some(destroy_job),
+                    }
+                }
+                SpeculativeReparkResult::Destroy {
+                    destroy_job,
+                    reason,
+                    error,
+                } => {
+                    warn!(
+                        run_id = %run_id,
+                        reason,
+                        error,
+                        "speculative exact-reuse rollback could not restore idle ownership"
+                    );
+                    Some(destroy_job)
+                }
+            }
+        }
+        ExactSpeculationOutcome::Failed { destroy_job, error } => {
+            warn!(
+                run_id = %run_id,
+                error,
+                "speculative exact-reuse preparation failed before claim resolved"
+            );
+            Some(destroy_job)
+        }
+    };
+    if let Some(destroy_job) = destroy_job {
+        destroy_idle_jobs_and_wait(vec![*destroy_job], "speculative_exact_reuse_claim_rollback")
+            .await;
+        ctx.spawn_ctx.reuse_state_notify.notify_one();
+    }
+}
+
 enum ReservedActivation {
     Ready {
         reuse_entry: Option<Box<ReusableIdleSandbox>>,
@@ -814,6 +1151,197 @@ enum ReservedActivation {
         reuse_result: SandboxReuseResult,
         error: String,
     },
+}
+
+async fn activate_speculated_exact(
+    speculation: ExactSpeculation,
+    request: ReservedActivationRequest<'_>,
+    ctx: &DiscoveredJobContext<'_>,
+    pre_spawn_timing: &mut RunnerPreSpawnTiming,
+) -> ReservedActivation {
+    let ReservedActivationRequest {
+        run_id,
+        profile_name,
+        workspace_disk_mb,
+        context,
+    } = request;
+    let ExactSpeculation {
+        outcome,
+        preparation_started_at,
+        preparation_completed_at,
+        claim_started_at,
+        claim_returned_at,
+        unpark,
+        guest_restore,
+    } = speculation;
+    let overlap_started_at = preparation_started_at.max(claim_started_at);
+    let overlap_completed_at = preparation_completed_at.min(claim_returned_at);
+    let claim_overlap = overlap_completed_at.saturating_duration_since(overlap_started_at);
+    let post_claim_remainder =
+        preparation_completed_at.saturating_duration_since(claim_returned_at);
+    let mut speculation_timing = ExactReuseSpeculationTiming {
+        unpark,
+        guest_restore,
+        claim_overlap,
+        post_claim_remainder,
+        timezone_correction: None,
+        timezone_assumption: None,
+    };
+    pre_spawn_timing.record_exact_reuse_speculation(speculation_timing);
+    let sandbox = match outcome {
+        ExactSpeculationOutcome::Prepared(sandbox) => sandbox,
+        ExactSpeculationOutcome::Failed { destroy_job, error } => {
+            warn!(
+                run_id = %run_id,
+                error,
+                "speculative exact-reuse preparation failed, destroying before fresh fallback"
+            );
+            return cleanup_reserved_for_fresh_fallback(
+                *destroy_job,
+                SandboxReuseResult::UnparkFailed,
+                "speculative_exact_reuse_prepare_failed",
+                ctx,
+            )
+            .await;
+        }
+    };
+
+    let reserved_reuse_key = sandbox.reuse_key().to_owned();
+    let requested_reuse_key = context.reuse_key();
+    if requested_reuse_key != Some(reserved_reuse_key.as_str()) {
+        warn!(
+            run_id = %run_id,
+            reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reserved_reuse_key),
+            reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
+            "claimed reuse key does not match speculatively prepared idle VM"
+        );
+        return cleanup_reserved_for_fresh_fallback(
+            sandbox.into_destroy_job("speculative_reuse_session_mismatch"),
+            if requested_reuse_key.is_none() {
+                SandboxReuseResult::NoReuseKey
+            } else {
+                SandboxReuseResult::PoolMiss
+            },
+            "speculative_reuse_session_mismatch",
+            ctx,
+        )
+        .await;
+    }
+
+    if let Some(cache) = ctx.spawn_ctx.exec_config.workspace_cache.as_ref() {
+        let started_at = Instant::now();
+        let validation = sandbox.validate_workspace_promotion_identity(
+            cache,
+            CANONICAL_WORKING_DIR,
+            u64::from(workspace_disk_mb) * 1024 * 1024,
+        );
+        pre_spawn_timing.record_phase_elapsed(
+            RunnerPreSpawnPhase::WorkspacePromotionValidation,
+            started_at,
+        );
+        if let Err(mismatch) = validation {
+            warn!(
+                run_id = %run_id,
+                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reserved_reuse_key),
+                reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
+                profile = %profile_name,
+                mismatch = mismatch.as_str(),
+                "workspace promotion identity mismatch after speculative preparation"
+            );
+            return cleanup_reserved_for_fresh_fallback(
+                sandbox.into_destroy_job("speculative_workspace_promotion_mismatch"),
+                SandboxReuseResult::PoolMiss,
+                "speculative_workspace_promotion_mismatch",
+                ctx,
+            )
+            .await;
+        }
+    }
+
+    let claimed_timezone = GuestTimezoneIntent::from_context(context);
+    let assumption = sandbox.guest_timezone_intent().compare(&claimed_timezone);
+    let mut correction_duration = None;
+    let guest_state_prepared = match assumption {
+        GuestTimezoneAssumption::Match => true,
+        GuestTimezoneAssumption::Mismatch => {
+            let correction_started_at = Instant::now();
+            let corrected = AssertUnwindSafe(try_sync_guest_timezone_intent(
+                sandbox.sandbox(),
+                run_id,
+                &claimed_timezone,
+            ))
+            .catch_unwind()
+            .await;
+            correction_duration = Some(correction_started_at.elapsed());
+            match corrected {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    speculation_timing.timezone_correction =
+                        correction_duration.map(|duration| RunnerPreSpawnOperationTiming {
+                            duration,
+                            succeeded: false,
+                        });
+                    speculation_timing.timezone_assumption = Some(assumption);
+                    pre_spawn_timing.record_exact_reuse_speculation(speculation_timing);
+                    warn!(
+                        run_id = %run_id,
+                        error = %error,
+                        "speculative exact-reuse timezone correction transport failed"
+                    );
+                    return cleanup_reserved_for_fresh_fallback(
+                        sandbox.into_destroy_job("speculative_timezone_correction_failed"),
+                        SandboxReuseResult::UnparkFailed,
+                        "speculative_timezone_correction_failed",
+                        ctx,
+                    )
+                    .await;
+                }
+                Err(_) => {
+                    speculation_timing.timezone_correction =
+                        correction_duration.map(|duration| RunnerPreSpawnOperationTiming {
+                            duration,
+                            succeeded: false,
+                        });
+                    speculation_timing.timezone_assumption = Some(assumption);
+                    pre_spawn_timing.record_exact_reuse_speculation(speculation_timing);
+                    warn!(
+                        run_id = %run_id,
+                        "speculative exact-reuse timezone correction panicked"
+                    );
+                    return cleanup_reserved_for_fresh_fallback(
+                        sandbox.into_destroy_job("speculative_timezone_correction_panicked"),
+                        SandboxReuseResult::UnparkFailed,
+                        "speculative_timezone_correction_panicked",
+                        ctx,
+                    )
+                    .await;
+                }
+            }
+            true
+        }
+        GuestTimezoneAssumption::Unknown => false,
+    };
+    speculation_timing.timezone_correction =
+        correction_duration.map(|duration| RunnerPreSpawnOperationTiming {
+            duration,
+            succeeded: true,
+        });
+    speculation_timing.timezone_assumption = Some(assumption);
+    pre_spawn_timing.record_exact_reuse_speculation(speculation_timing);
+
+    let (reuse_entry, active_lease) = sandbox.commit(guest_state_prepared);
+    info!(
+        run_id = %run_id,
+        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reserved_reuse_key),
+        reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
+        "committing speculatively prepared exact-reuse VM"
+    );
+    ReservedActivation::Ready {
+        reuse_entry: Some(Box::new(reuse_entry)),
+        active_lease,
+        reuse_result: SandboxReuseResult::Reused,
+        idle_snapshot: ctx.idle_pool.lock().await.status_snapshot(),
+    }
 }
 
 async fn activate_reserved_idle(
@@ -949,17 +1477,17 @@ async fn cleanup_reserved_for_fresh_fallback(
     }
 }
 
-async fn fail_claimed_without_sandbox(
+async fn complete_claimed_without_sandbox(
     claimed: ClaimedJob,
     cancellation: RunCancellationRegistration,
-    resource: LocalAdmissionResource,
+    resource: AdmittedResource,
+    workspace_disk_mb: u32,
     reuse_result: Option<SandboxReuseResult>,
-    error: String,
+    failure: crate::executor::ExecutionFailure,
     ctx: &mut DiscoveredJobContext<'_>,
 ) {
     let (context, completion_auth, active_input_source) = claimed.into_parts();
     let run_id = context.run_id;
-    let failure = crate::executor::ExecutionFailure::from_error(error);
     drop(active_input_source);
     ctx.spawn_ctx
         .provider
@@ -973,7 +1501,7 @@ async fn fail_claimed_without_sandbox(
         )
         .await;
     cancellation.unregister().await;
-    rollback_untracked_resource(resource, ctx).await;
+    rollback_admitted_resource(resource, run_id, workspace_disk_mb, ctx).await;
 }
 
 async fn try_reuse_from_pool(

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -32,6 +32,7 @@ use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
 use crate::executor::{
     self, ExecutorConfig, RunnerPreSpawnPhase, RunnerPreSpawnTiming, SessionHistoryRestorePlan,
 };
+use crate::guest_timezone::GuestTimezoneIntent;
 use crate::idle_pool::{ParkingGate, ReusableIdleSandbox};
 use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
@@ -242,6 +243,7 @@ struct FinalizationPhase {
     cli_agent_session_id: Option<String>,
     storage_fingerprints: StorageFingerprints,
     device_rate_limits: Option<sandbox::DeviceRateLimits>,
+    guest_timezone_intent: GuestTimezoneIntent,
     factory: SharedFactory,
     idle_pool: SharedIdlePool,
     status: Arc<StatusTracker>,
@@ -276,6 +278,7 @@ impl FinalizationPhase {
             cli_agent_session_id,
             storage_fingerprints,
             device_rate_limits,
+            guest_timezone_intent,
             factory,
             idle_pool,
             status,
@@ -347,6 +350,7 @@ impl FinalizationPhase {
                 workspace_image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,
                 storage_fingerprints,
                 device_rate_limits,
+                guest_timezone_intent,
                 factory,
                 idle_pool,
                 status,
@@ -571,6 +575,7 @@ pub(super) fn spawn_job(
     } else {
         None
     };
+    let guest_timezone_intent = GuestTimezoneIntent::from_context(&context);
     let vcpu = job_profile.vcpu;
     let memory_mb = job_profile.memory_mb;
     let workspace_disk_mb = job_profile.workspace_disk_mb;
@@ -670,6 +675,7 @@ pub(super) fn spawn_job(
         cli_agent_session_id,
         storage_fingerprints,
         device_rate_limits: job_device_rate_limits,
+        guest_timezone_intent,
         factory,
         idle_pool: Arc::clone(&idle_pool),
         status: Arc::clone(&status),
@@ -958,6 +964,7 @@ mod tests {
                 reuse_key: Some(session_id.into()),
                 cli_agent_session_id: Some(session_id.into()),
                 storage_fingerprints: StorageFingerprints::default(),
+                guest_timezone_intent: GuestTimezoneIntent::Unknown,
                 device_rate_limits: None,
                 factory: Arc::new(Box::new(sandbox_mock::MockSandboxFactory::new())),
                 idle_pool: Arc::clone(&self.idle_pool),

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -959,6 +959,7 @@ enum SignalSource {
 enum StartLoopEvent {
     BudgetExhaustedReactorEntered,
     IdleCleanupProcessed { expired_count: usize },
+    ActiveRunStatusPublished { run_id: RunId },
     BeforeIdlePoolOwnershipTransfer { run_id: RunId },
     VmParkedForReuse { run_id: RunId, reuse_key: String },
     UsageFlushRequested,
@@ -1064,6 +1065,26 @@ impl StartLoopTestObserver {
 
     fn notify_before_idle_pool_ownership_transfer(&self, run_id: RunId) {
         self.record(StartLoopEvent::BeforeIdlePoolOwnershipTransfer { run_id });
+    }
+
+    fn notify_active_run_status_published(&self, run_id: RunId) {
+        self.record(StartLoopEvent::ActiveRunStatusPublished { run_id });
+    }
+
+    fn active_run_status_was_published(&self, run_id: RunId) -> bool {
+        self.inner
+            .events
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .iter()
+            .any(|event| {
+                matches!(
+                    event,
+                    StartLoopEvent::ActiveRunStatusPublished {
+                        run_id: observed_run_id
+                    } if *observed_run_id == run_id
+                )
+            })
     }
 
     fn notify_vm_parked_for_reuse(&self, run_id: RunId, reuse_key: String) {

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -26,6 +26,7 @@ use super::ownership::OwnershipTransitions;
 #[cfg(test)]
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
 use crate::executor::{SandboxReuseDisposition, SandboxReuseTerminal};
+use crate::guest_timezone::GuestTimezoneIntent;
 use crate::idle_pool::{
     DestroyOutcome, IdleDestroyPayload, IdleParkActiveParts, IdleParkFailureParts, IdleParkRequest,
     IdleParkRequestParts, ParkResult, ParkingGate,
@@ -166,6 +167,7 @@ pub(super) struct FinalizeContext {
     pub(super) workspace_image_size_bytes: u64,
     pub(super) storage_fingerprints: StorageFingerprints,
     pub(super) device_rate_limits: Option<sandbox::DeviceRateLimits>,
+    pub(super) guest_timezone_intent: GuestTimezoneIntent,
     pub(super) factory: Arc<Box<dyn SandboxFactory>>,
     pub(super) idle_pool: SharedIdlePool,
     pub(super) status: Arc<StatusTracker>,
@@ -249,6 +251,7 @@ async fn finalize_sandbox_for_completion_inner(
         workspace_image_size_bytes,
         storage_fingerprints,
         device_rate_limits,
+        guest_timezone_intent,
         factory,
         idle_pool,
         status,
@@ -336,6 +339,7 @@ async fn finalize_sandbox_for_completion_inner(
                 )
                 | SandboxReuseDisposition::Ineligible(_) => None,
             },
+            guest_timezone_intent,
             workspace_image_size_bytes,
             workspace_promotion,
         });
@@ -1023,6 +1027,7 @@ mod tests {
                 workspace_image_size_bytes: 0,
                 storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
                 device_rate_limits: None,
+                guest_timezone_intent: GuestTimezoneIntent::Unknown,
                 factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
                 idle_pool: Arc::clone(&self.idle_pool),
                 status: Arc::clone(&self.status),
@@ -1231,6 +1236,14 @@ mod tests {
         let network_log_session = fixture.network_log_session().await;
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
+        let mut context = fixture.finalize_context(
+            run_id,
+            sandbox_id,
+            "sess-network-log-park",
+            network_log_session,
+            RunCancellationHandle::new(),
+        );
+        context.guest_timezone_intent = GuestTimezoneIntent::Configured("Asia/Shanghai".into());
 
         let _completion_ready = finalize_sandbox_for_completion(
             Some(Box::new(mock_sandbox_ready_for_idle_reuse(
@@ -1245,13 +1258,7 @@ mod tests {
                 SandboxReuseResult::PoolMiss,
                 CompletionAuth::local(),
             ),
-            fixture.finalize_context(
-                run_id,
-                sandbox_id,
-                "sess-network-log-park",
-                network_log_session,
-                RunCancellationHandle::new(),
-            ),
+            context,
         )
         .await;
 
@@ -1260,6 +1267,10 @@ mod tests {
             let reservation = idle_pool
                 .reserve_reusable_generation("sess-network-log-park", "vm0/default", &None, run_id)
                 .expect("finalized sandbox should be reusable for its generation");
+            assert_eq!(
+                reservation.guest_timezone_intent(),
+                &GuestTimezoneIntent::Configured("Asia/Shanghai".into())
+            );
             assert!(matches!(
                 idle_pool.restore_reserved(reservation),
                 RestoreReservedIdleResult::Restored
@@ -2519,6 +2530,7 @@ mod tests {
             storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
             restored_session_identity: None,
             history_generation_run_id: None,
+            guest_timezone_intent: GuestTimezoneIntent::Unknown,
             workspace_image_size_bytes: b"image".len() as u64,
             workspace_promotion: Some(old_promotion),
         })

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -441,6 +441,78 @@ async fn unavailable_claim_reparks_speculative_sandbox() {
 }
 
 #[tokio::test]
+async fn mismatched_claim_run_id_reparks_speculative_sandbox() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    add_healthy_reuse_preparation_matcher(&overrides);
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: GuestTimezoneIntent::Default,
+            timing: None,
+        },
+    )
+    .await;
+    env.handle.block_claims();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let candidate_run_id = RunId::new_v4();
+    let claimed_run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        candidate_run_id,
+        Some(claimed_context(claimed_run_id, &reuse_key, None)),
+    );
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            candidate_run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+    assert!(
+        env.handle
+            .wait_claim_in_flight(1, Duration::from_secs(5))
+            .await
+    );
+    assert!(
+        overrides
+            .wait_exec_call_count(1, Duration::from_secs(5))
+            .await
+    );
+    env.handle.unblock_claims();
+
+    wait_cancel_token_removed(&env.cancel_tokens, candidate_run_id, Duration::from_secs(5)).await;
+    wait_idle_pool_reuse_keys(&env.idle_pool, &[&reuse_key], Duration::from_secs(5)).await;
+    assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.park_call_count(), 1);
+    assert_eq!(overrides.destroy_call_count(), 0);
+    assert!(overrides.start_process_calls().is_empty());
+    {
+        let completions = env.handle.completions.lock().unwrap();
+        assert!(
+            !completions.iter().any(|completion| {
+                completion.run_id == candidate_run_id || completion.run_id == claimed_run_id
+            }),
+            "mismatched claim must not complete either run"
+        );
+    }
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
 async fn cancellation_during_claim_completes_without_starting_agent_and_reparks() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -741,6 +741,81 @@ async fn cancellation_during_speculative_cleanup_does_not_start_fresh_agent() {
 }
 
 #[tokio::test]
+async fn cancellation_wins_when_speculative_cleanup_is_uncertain() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
+        transition: sandbox::SandboxIdleTransition::Unpark,
+        message: "simulated speculative unpark failure".into(),
+    }));
+    overrides.push_destroy_panic("simulated speculative destroy panic");
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: GuestTimezoneIntent::Default,
+            timing: None,
+        },
+    )
+    .await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(claimed_context(run_id, &reuse_key, None)));
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+
+    destroy_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .unwrap();
+    let cancellation = wait_cancel_handle(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    assert!(cancellation.request_cooperative_user_cancellation().await);
+    destroy_gate.release_one();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("claimed cancellation should win after uncertain speculative cleanup");
+    assert_eq!(completion.error.as_deref(), Some("cancelled by user"));
+    assert_eq!(completion.sandbox_id, None);
+    assert_eq!(
+        completion.reuse_result,
+        Some(SandboxReuseResult::UnparkFailed)
+    );
+    wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    let (_, active_runs) =
+        status_idle_reuse_keys_and_active_runs(&env._temp_dir.path().join("status.json")).await;
+    assert!(active_runs.is_empty());
+    assert!(!env.start_observer.active_run_status_was_published(run_id));
+    assert!(overrides.start_process_calls().is_empty());
+    assert_eq!(overrides.destroy_call_count(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
 async fn closed_parking_gate_destroys_lost_speculation_after_repark() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -579,6 +579,90 @@ async fn cancellation_during_claim_completes_without_starting_agent_and_reparks(
 }
 
 #[tokio::test]
+async fn cancellation_during_timezone_correction_does_not_publish_active_or_start_agent() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let exec_gate = sandbox_mock::MockLifecycleGate::new();
+    overrides.set_exec_lifecycle_gate(exec_gate.clone());
+    add_healthy_reuse_preparation_matcher(&overrides);
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: GuestTimezoneIntent::Configured("Asia/Shanghai".into()),
+            timing: None,
+        },
+    )
+    .await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        run_id,
+        Some(claimed_context(run_id, &reuse_key, Some("Europe/London"))),
+    );
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+
+    exec_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .unwrap();
+    exec_gate.release_one();
+    exec_gate
+        .wait_entered(2, Duration::from_secs(5))
+        .await
+        .unwrap();
+    let cancellation = wait_cancel_handle(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    assert!(cancellation.request_cooperative_user_cancellation().await);
+
+    let (_, active_runs) =
+        status_idle_reuse_keys_and_active_runs(&env._temp_dir.path().join("status.json")).await;
+    assert!(active_runs.is_empty());
+    assert!(overrides.start_process_calls().is_empty());
+
+    exec_gate.release_one();
+    exec_gate
+        .wait_entered(3, Duration::from_secs(5))
+        .await
+        .unwrap();
+    exec_gate.release_one();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("claimed cancellation should be completed");
+    assert_eq!(completion.error.as_deref(), Some("cancelled by user"));
+    assert_eq!(completion.sandbox_id, None);
+    wait_idle_pool_reuse_keys(&env.idle_pool, &[&reuse_key], Duration::from_secs(5)).await;
+    let (_, active_runs) =
+        status_idle_reuse_keys_and_active_runs(&env._temp_dir.path().join("status.json")).await;
+    assert!(active_runs.is_empty());
+    assert!(overrides.start_process_calls().is_empty());
+    assert_eq!(overrides.park_call_count(), 1);
+    assert_eq!(overrides.destroy_call_count(), 0);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
 async fn closed_parking_gate_destroys_lost_speculation_after_repark() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -1,0 +1,818 @@
+use super::super::super::*;
+use super::super::support::{
+    SpeculativeIdleSeedSpec, context_with_session, mock_run_config,
+    seed_idle_pool_with_speculative_timezone, shutdown, status_idle_reuse_keys_and_active_runs,
+    test_profiles, wait_budget_count, wait_cancel_handle, wait_cancel_token_removed,
+    wait_discover_entered, wait_idle_pool_len, wait_idle_pool_reuse_keys,
+};
+use std::sync::Arc;
+
+use crate::guest_timezone::GuestTimezoneIntent;
+use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
+use crate::provider::{JobCandidate, RunnerPreference, RunnerPreferenceReason};
+use crate::types::{ExecutionContext, SandboxReuseResult};
+
+const NON_SELECTED_RUNNER_ID: u128 = 1;
+
+fn exact_generation_candidate(
+    run_id: RunId,
+    reuse_key: &str,
+    history_generation_run_id: RunId,
+) -> JobCandidate {
+    JobCandidate::new(run_id, "vm0/default".into())
+        .with_reuse_key(Some(reuse_key.to_owned()))
+        .with_history_generation_run_id(Some(history_generation_run_id))
+        .with_runner_preference(Some(RunnerPreference::for_test(
+            uuid::Uuid::from_u128(NON_SELECTED_RUNNER_ID),
+            1,
+            RunnerPreferenceReason::ExactHistoryGeneration,
+            std::time::Instant::now() + Duration::from_secs(30),
+        )))
+}
+
+fn claimed_context(run_id: RunId, reuse_key: &str, timezone: Option<&str>) -> ExecutionContext {
+    let mut context = context_with_session(run_id, reuse_key);
+    context.user_timezone = timezone.map(str::to_owned);
+    context
+}
+
+fn guest_restore_commands(overrides: &sandbox_mock::MockSandboxOverrides) -> Vec<String> {
+    overrides
+        .exec_calls()
+        .into_iter()
+        .filter(|call| call.cmd.contains("guest-reseed"))
+        .map(|call| call.cmd)
+        .collect()
+}
+
+fn timezone_correction_commands(overrides: &sandbox_mock::MockSandboxOverrides) -> Vec<String> {
+    overrides
+        .exec_calls()
+        .into_iter()
+        .filter(|call| call.cmd.contains("/etc/timezone") && !call.cmd.contains("guest-reseed"))
+        .map(|call| call.cmd)
+        .collect()
+}
+
+#[tokio::test]
+async fn exact_reuse_restores_guest_while_claim_is_blocked() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    add_healthy_reuse_preparation_matcher(&overrides);
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    let sandbox_id = seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: GuestTimezoneIntent::Configured("Asia/Shanghai".into()),
+            timing: None,
+        },
+    )
+    .await;
+    env.handle.block_claims();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        run_id,
+        Some(claimed_context(run_id, &reuse_key, Some("Asia/Shanghai"))),
+    );
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+
+    assert!(
+        env.handle
+            .wait_claim_in_flight(1, Duration::from_secs(5))
+            .await,
+        "provider claim did not reach its boundary"
+    );
+    assert!(
+        overrides
+            .wait_exec_call_count(1, Duration::from_secs(5))
+            .await,
+        "guest restore did not run while claim was blocked"
+    );
+    let restore_commands = guest_restore_commands(&overrides);
+    assert_eq!(restore_commands.len(), 1);
+    assert!(restore_commands[0].contains("/usr/share/zoneinfo/Asia/Shanghai"));
+    assert_eq!(overrides.unpark_call_count(), 1);
+    assert!(
+        overrides.start_process_calls().is_empty(),
+        "agent process must not start before claim succeeds"
+    );
+    let (idle_reuse_keys, active_runs) =
+        status_idle_reuse_keys_and_active_runs(&env._temp_dir.path().join("status.json")).await;
+    assert!(idle_reuse_keys.is_empty());
+    assert!(
+        active_runs.is_empty(),
+        "speculative sandbox must not be published as active before claim succeeds"
+    );
+
+    env.handle.unblock_claims();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(30))
+        .await
+        .expect("exact-reuse run should complete after claim release");
+    assert_eq!(completion.sandbox_id, Some(sandbox_id));
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    assert_eq!(guest_restore_commands(&overrides).len(), 1);
+    assert!(timezone_correction_commands(&overrides).is_empty());
+
+    shutdown(&env, run_handle).await;
+}
+
+async fn assert_timezone_transition_with(
+    previous: GuestTimezoneIntent,
+    claimed: Option<&str>,
+    expected_restore_zone: &str,
+    expected_correction_zone: Option<&str>,
+    configure: impl FnOnce(&sandbox_mock::MockSandboxOverrides),
+) {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    configure(&overrides);
+    add_healthy_reuse_preparation_matcher(&overrides);
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: previous,
+            timing: None,
+        },
+    )
+    .await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(claimed_context(run_id, &reuse_key, claimed)));
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(30))
+        .await
+        .expect("timezone transition run should complete");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+
+    let restores = guest_restore_commands(&overrides);
+    assert_eq!(restores.len(), 1);
+    assert!(restores[0].contains(&format!("/usr/share/zoneinfo/{expected_restore_zone}")));
+    let corrections = timezone_correction_commands(&overrides);
+    match expected_correction_zone {
+        Some(zone) => {
+            assert_eq!(corrections.len(), 1);
+            assert!(corrections[0].contains(&format!("/usr/share/zoneinfo/{zone}")));
+        }
+        None => assert!(corrections.is_empty()),
+    }
+    assert_eq!(overrides.destroy_call_count(), 0);
+
+    shutdown(&env, run_handle).await;
+}
+
+async fn assert_timezone_transition(
+    previous: GuestTimezoneIntent,
+    claimed: Option<&str>,
+    expected_restore_zone: &str,
+    expected_correction_zone: Option<&str>,
+) {
+    assert_timezone_transition_with(
+        previous,
+        claimed,
+        expected_restore_zone,
+        expected_correction_zone,
+        |_| {},
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn exact_reuse_verifies_configured_and_default_timezone_transitions() {
+    assert_timezone_transition(
+        GuestTimezoneIntent::Configured("Asia/Shanghai".into()),
+        Some("Europe/London"),
+        "Asia/Shanghai",
+        Some("Europe/London"),
+    )
+    .await;
+    assert_timezone_transition(
+        GuestTimezoneIntent::Configured("Asia/Shanghai".into()),
+        None,
+        "Asia/Shanghai",
+        Some("UTC"),
+    )
+    .await;
+    assert_timezone_transition(
+        GuestTimezoneIntent::Default,
+        Some("Asia/Shanghai"),
+        "UTC",
+        Some("Asia/Shanghai"),
+    )
+    .await;
+    assert_timezone_transition(GuestTimezoneIntent::Default, None, "UTC", None).await;
+}
+
+#[tokio::test]
+async fn embedded_timezone_correction_failure_remains_best_effort() {
+    assert_timezone_transition_with(
+        GuestTimezoneIntent::Configured("Asia/Shanghai".into()),
+        Some("Europe/London"),
+        "Asia/Shanghai",
+        Some("Europe/London"),
+        |overrides| {
+            overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
+                pattern: "/usr/share/zoneinfo/Europe/London".into(),
+                exit_code: 1,
+                stdout: Vec::new(),
+                stderr: b"simulated timezone setup failure".to_vec(),
+            });
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn unknown_previous_timezone_keeps_restore_after_claim() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    add_healthy_reuse_preparation_matcher(&overrides);
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: GuestTimezoneIntent::Unknown,
+            timing: None,
+        },
+    )
+    .await;
+    env.handle.block_claims();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        run_id,
+        Some(claimed_context(run_id, &reuse_key, Some("Asia/Shanghai"))),
+    );
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+    assert!(
+        env.handle
+            .wait_claim_in_flight(1, Duration::from_secs(5))
+            .await
+    );
+    assert_eq!(overrides.unpark_call_count(), 0);
+    assert!(overrides.exec_calls().is_empty());
+
+    env.handle.unblock_claims();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(30))
+        .await
+        .expect("unknown prediction should retain ordinary exact reuse");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    assert_eq!(guest_restore_commands(&overrides).len(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn unknown_claimed_timezone_repeats_authoritative_guest_restore() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    add_healthy_reuse_preparation_matcher(&overrides);
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: GuestTimezoneIntent::Configured("Asia/Shanghai".into()),
+            timing: None,
+        },
+    )
+    .await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        run_id,
+        Some(claimed_context(
+            run_id,
+            &reuse_key,
+            Some("invalid timezone"),
+        )),
+    );
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(30))
+        .await
+        .expect("unknown claimed timezone should complete through full restore fallback");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    let restores = guest_restore_commands(&overrides);
+    assert_eq!(restores.len(), 2);
+    assert!(restores[0].contains("/usr/share/zoneinfo/Asia/Shanghai"));
+    assert!(!restores[1].contains("/usr/share/zoneinfo/"));
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn unavailable_claim_reparks_speculative_sandbox() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    add_healthy_reuse_preparation_matcher(&overrides);
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: GuestTimezoneIntent::Default,
+            timing: None,
+        },
+    )
+    .await;
+    env.handle.block_claims();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider.set_claim_result(run_id, None);
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+    assert!(
+        env.handle
+            .wait_claim_in_flight(1, Duration::from_secs(5))
+            .await
+    );
+    assert!(
+        overrides
+            .wait_exec_call_count(1, Duration::from_secs(5))
+            .await
+    );
+    env.handle.unblock_claims();
+
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_idle_pool_reuse_keys(&env.idle_pool, &[&reuse_key], Duration::from_secs(5)).await;
+    assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.park_call_count(), 1);
+    assert_eq!(overrides.destroy_call_count(), 0);
+    assert!(overrides.start_process_calls().is_empty());
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn cancellation_during_claim_completes_without_starting_agent_and_reparks() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    add_healthy_reuse_preparation_matcher(&overrides);
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: GuestTimezoneIntent::Default,
+            timing: None,
+        },
+    )
+    .await;
+    env.handle.block_claims();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(claimed_context(run_id, &reuse_key, None)));
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+    assert!(
+        env.handle
+            .wait_claim_in_flight(1, Duration::from_secs(5))
+            .await
+    );
+    assert!(
+        overrides
+            .wait_exec_call_count(1, Duration::from_secs(5))
+            .await
+    );
+    let cancellation = wait_cancel_handle(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    assert!(cancellation.request_cooperative_user_cancellation().await);
+    env.handle.unblock_claims();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("claimed cancellation should be completed");
+    assert_eq!(completion.error.as_deref(), Some("cancelled by user"));
+    assert_eq!(completion.sandbox_id, None);
+    wait_idle_pool_reuse_keys(&env.idle_pool, &[&reuse_key], Duration::from_secs(5)).await;
+    assert!(overrides.start_process_calls().is_empty());
+    assert_eq!(overrides.park_call_count(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn closed_parking_gate_destroys_lost_speculation_after_repark() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    add_healthy_reuse_preparation_matcher(&overrides);
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: GuestTimezoneIntent::Default,
+            timing: None,
+        },
+    )
+    .await;
+    env.handle.block_claims();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider.set_claim_result(run_id, None);
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+    assert!(
+        env.handle
+            .wait_claim_in_flight(1, Duration::from_secs(5))
+            .await
+    );
+    assert!(
+        overrides
+            .wait_exec_call_count(1, Duration::from_secs(5))
+            .await
+    );
+    assert!(env.parking_gate.soft_drain());
+    env.handle.unblock_claims();
+
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    assert_eq!(overrides.park_call_count(), 1);
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert!(overrides.start_process_calls().is_empty());
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn duplicate_repark_keeps_newer_idle_sandbox_and_destroys_speculation() {
+    let (config, env) = mock_run_config(test_profiles(), 4, 8192, 2);
+    let budget = Arc::clone(&config.capacity.budget);
+    let original_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    add_healthy_reuse_preparation_matcher(&original_overrides);
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &original_overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: GuestTimezoneIntent::Default,
+            timing: None,
+        },
+    )
+    .await;
+    env.handle.block_claims();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider.set_claim_result(run_id, None);
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+    assert!(
+        env.handle
+            .wait_claim_in_flight(1, Duration::from_secs(5))
+            .await
+    );
+    assert!(
+        original_overrides
+            .wait_exec_call_count(1, Duration::from_secs(5))
+            .await
+    );
+
+    let replacement_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let replacement_id = seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &replacement_overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: RunId::new_v4(),
+            guest_timezone_intent: GuestTimezoneIntent::Default,
+            timing: None,
+        },
+    )
+    .await;
+    env.handle.unblock_claims();
+
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_idle_pool_reuse_keys(&env.idle_pool, &[&reuse_key], Duration::from_secs(5)).await;
+    assert_eq!(
+        env.idle_pool.lock().await.status_snapshot().idle_vms[0].sandbox_id,
+        replacement_id
+    );
+    assert_eq!(original_overrides.park_call_count(), 1);
+    assert_eq!(original_overrides.destroy_call_count(), 1);
+    assert_eq!(replacement_overrides.destroy_call_count(), 0);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn repark_failure_destroys_unclaimed_speculation() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_park_result(Err(sandbox::SandboxError::IdleTransition {
+        transition: sandbox::SandboxIdleTransition::Park,
+        message: "simulated speculative repark failure".into(),
+    }));
+    add_healthy_reuse_preparation_matcher(&overrides);
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: GuestTimezoneIntent::Default,
+            timing: None,
+        },
+    )
+    .await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider.set_claim_result(run_id, None);
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    assert_eq!(overrides.park_call_count(), 1);
+    assert_eq!(overrides.destroy_call_count(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+async fn assert_speculation_failure_falls_back_to_fresh(
+    previous: GuestTimezoneIntent,
+    claimed: Option<&str>,
+    configure_failure: impl FnOnce(&sandbox_mock::MockSandboxOverrides),
+) {
+    let (config, env) = mock_run_config(test_profiles(), 4, 8192, 2);
+    let budget = Arc::clone(&config.capacity.budget);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    configure_failure(&overrides);
+    add_healthy_reuse_preparation_matcher(&overrides);
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    let idle_sandbox_id = seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: previous,
+            timing: None,
+        },
+    )
+    .await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(claimed_context(run_id, &reuse_key, claimed)));
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(30))
+        .await
+        .expect("valid claim should use fresh fallback after speculation failure");
+    assert_eq!(
+        completion.reuse_result,
+        Some(SandboxReuseResult::UnparkFailed)
+    );
+    assert_ne!(completion.sandbox_id, Some(idle_sandbox_id));
+    assert_eq!(overrides.destroy_call_count(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn speculative_unpark_failure_destroys_before_fresh_fallback() {
+    assert_speculation_failure_falls_back_to_fresh(
+        GuestTimezoneIntent::Default,
+        None,
+        |overrides| {
+            overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
+                transition: sandbox::SandboxIdleTransition::Unpark,
+                message: "simulated speculative unpark failure".into(),
+            }));
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn speculative_guest_restore_failure_destroys_before_fresh_fallback() {
+    assert_speculation_failure_falls_back_to_fresh(
+        GuestTimezoneIntent::Default,
+        None,
+        |overrides| {
+            overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
+                pattern: "guest-reseed".into(),
+                exit_code: 1,
+                stdout: Vec::new(),
+                stderr: b"guest-reseed failed".to_vec(),
+            });
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn speculative_guest_restore_transport_failure_destroys_before_fresh_fallback() {
+    assert_speculation_failure_falls_back_to_fresh(
+        GuestTimezoneIntent::Default,
+        None,
+        |overrides| {
+            overrides.add_exec_error_matcher(
+                "guest-reseed",
+                sandbox::SandboxError::Operation {
+                    operation: sandbox::SandboxOperation::Exec,
+                    reason: sandbox::SandboxOperationReason::Guest,
+                    message: "simulated guest restore transport failure".into(),
+                },
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn timezone_correction_panic_destroys_before_fresh_fallback() {
+    assert_speculation_failure_falls_back_to_fresh(
+        GuestTimezoneIntent::Configured("Asia/Shanghai".into()),
+        Some("Europe/London"),
+        |overrides| {
+            overrides.add_exec_panic_matcher(
+                "/usr/share/zoneinfo/Europe/London",
+                "simulated timezone correction panic",
+            );
+        },
+    )
+    .await;
+}

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -706,6 +706,7 @@ async fn duplicate_repark_keeps_newer_idle_sandbox_and_destroys_speculation() {
 
     wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
     wait_idle_pool_reuse_keys(&env.idle_pool, &[&reuse_key], Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
     assert_eq!(
         env.idle_pool.lock().await.status_snapshot().idle_vms[0].sandbox_id,
         replacement_id

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -572,6 +572,7 @@ async fn cancellation_during_claim_completes_without_starting_agent_and_reparks(
     assert_eq!(completion.error.as_deref(), Some("cancelled by user"));
     assert_eq!(completion.sandbox_id, None);
     wait_idle_pool_reuse_keys(&env.idle_pool, &[&reuse_key], Duration::from_secs(5)).await;
+    assert!(!env.start_observer.active_run_status_was_published(run_id));
     assert!(overrides.start_process_calls().is_empty());
     assert_eq!(overrides.park_call_count(), 1);
 
@@ -635,6 +636,7 @@ async fn cancellation_during_timezone_correction_does_not_publish_active_or_star
     let (_, active_runs) =
         status_idle_reuse_keys_and_active_runs(&env._temp_dir.path().join("status.json")).await;
     assert!(active_runs.is_empty());
+    assert!(!env.start_observer.active_run_status_was_published(run_id));
     assert!(overrides.start_process_calls().is_empty());
 
     exec_gate.release_one();
@@ -655,6 +657,7 @@ async fn cancellation_during_timezone_correction_does_not_publish_active_or_star
     let (_, active_runs) =
         status_idle_reuse_keys_and_active_runs(&env._temp_dir.path().join("status.json")).await;
     assert!(active_runs.is_empty());
+    assert!(!env.start_observer.active_run_status_was_published(run_id));
     assert!(overrides.start_process_calls().is_empty());
     assert_eq!(overrides.park_call_count(), 1);
     assert_eq!(overrides.destroy_call_count(), 0);
@@ -730,6 +733,7 @@ async fn cancellation_during_speculative_cleanup_does_not_start_fresh_agent() {
     );
     wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
     wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    assert!(!env.start_observer.active_run_status_was_published(run_id));
     assert!(overrides.start_process_calls().is_empty());
     assert_eq!(overrides.destroy_call_count(), 1);
 

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -663,6 +663,80 @@ async fn cancellation_during_timezone_correction_does_not_publish_active_or_star
 }
 
 #[tokio::test]
+async fn cancellation_during_speculative_cleanup_does_not_start_fresh_agent() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
+        transition: sandbox::SandboxIdleTransition::Unpark,
+        message: "simulated speculative unpark failure".into(),
+    }));
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: GuestTimezoneIntent::Default,
+            timing: None,
+        },
+    )
+    .await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(claimed_context(run_id, &reuse_key, None)));
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+
+    destroy_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .unwrap();
+    let cancellation = wait_cancel_handle(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    assert!(cancellation.request_cooperative_user_cancellation().await);
+    let (_, active_runs) =
+        status_idle_reuse_keys_and_active_runs(&env._temp_dir.path().join("status.json")).await;
+    assert!(active_runs.is_empty());
+    assert!(overrides.start_process_calls().is_empty());
+
+    destroy_gate.release_one();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("claimed cancellation should be completed after speculative cleanup");
+    assert_eq!(completion.error.as_deref(), Some("cancelled by user"));
+    assert_eq!(completion.sandbox_id, None);
+    assert_eq!(
+        completion.reuse_result,
+        Some(SandboxReuseResult::UnparkFailed)
+    );
+    wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    assert!(overrides.start_process_calls().is_empty());
+    assert_eq!(overrides.destroy_call_count(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
 async fn closed_parking_gate_destroys_lost_speculation_after_repark() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);

--- a/crates/runner/src/cmd/start/tests/main_loop/mod.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/mod.rs
@@ -1,5 +1,6 @@
 mod admission;
 mod drain_resume;
+mod exact_reuse_speculation;
 mod heartbeat;
 mod job_flow;
 mod shutdown;

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -1,5 +1,6 @@
 use super::super::super::*;
 
+use crate::guest_timezone::GuestTimezoneIntent;
 use crate::idle_pool::{ParkResult, ParkedIdleCandidate, test_support::ParkedIdleCandidateBuilder};
 use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
 use crate::ids::RunId;
@@ -22,6 +23,7 @@ fn make_synthetic_parked_candidate(
 ) -> ParkedIdleCandidate {
     ParkedIdleCandidateBuilder::new(reuse_key, budget_lease)
         .with_profile_name(profile_name)
+        .with_guest_timezone_intent(GuestTimezoneIntent::Unknown)
         .build()
 }
 
@@ -31,6 +33,18 @@ struct IdlePoolSeedSpec<'a> {
     vcpu: u32,
     memory_mb: u32,
     history_generation_run_id: Option<RunId>,
+    guest_timezone_intent: GuestTimezoneIntent,
+    timing: Option<(std::time::Instant, Duration)>,
+}
+
+pub(in super::super) struct SpeculativeIdleSeedSpec<'a> {
+    pub(in super::super) reuse_key: &'a str,
+    pub(in super::super) profile_name: &'a str,
+    pub(in super::super) vcpu: u32,
+    pub(in super::super) memory_mb: u32,
+    pub(in super::super) history_generation_run_id: RunId,
+    pub(in super::super) guest_timezone_intent: GuestTimezoneIntent,
+    pub(in super::super) timing: Option<(std::time::Instant, Duration)>,
 }
 
 /// Pre-populate idle pool with an entry and reserve its budget. Returns
@@ -56,6 +70,8 @@ pub(in super::super) async fn seed_idle_pool(
             vcpu,
             memory_mb,
             history_generation_run_id: None,
+            guest_timezone_intent: GuestTimezoneIntent::Unknown,
+            timing: None,
         },
     )
     .await
@@ -82,6 +98,40 @@ pub(in super::super) async fn seed_idle_pool_with_history_generation(
             vcpu,
             memory_mb,
             history_generation_run_id: Some(history_generation_run_id),
+            guest_timezone_intent: GuestTimezoneIntent::Unknown,
+            timing: None,
+        },
+    )
+    .await
+}
+
+pub(in super::super) async fn seed_idle_pool_with_speculative_timezone(
+    pool: &SharedIdlePool,
+    budget: &Arc<ResourceBudget>,
+    overrides: &Arc<sandbox_mock::MockSandboxOverrides>,
+    spec: SpeculativeIdleSeedSpec<'_>,
+) -> SandboxId {
+    let SpeculativeIdleSeedSpec {
+        reuse_key,
+        profile_name,
+        vcpu,
+        memory_mb,
+        history_generation_run_id,
+        guest_timezone_intent,
+        timing,
+    } = spec;
+    seed_idle_pool_with_overrides_and_generation(
+        pool,
+        budget,
+        overrides,
+        IdlePoolSeedSpec {
+            reuse_key,
+            profile_name,
+            vcpu,
+            memory_mb,
+            history_generation_run_id: Some(history_generation_run_id),
+            guest_timezone_intent,
+            timing,
         },
     )
     .await
@@ -106,6 +156,8 @@ pub(in super::super) async fn seed_idle_pool_with_overrides(
             vcpu,
             memory_mb,
             history_generation_run_id: None,
+            guest_timezone_intent: GuestTimezoneIntent::Unknown,
+            timing: None,
         },
     )
     .await
@@ -123,6 +175,8 @@ async fn seed_idle_pool_with_overrides_and_generation(
         vcpu,
         memory_mb,
         history_generation_run_id,
+        guest_timezone_intent,
+        timing,
     } = spec;
     let runtime = sandbox_mock::MockSandboxRuntime::with_overrides(Arc::clone(overrides));
     let factory = runtime
@@ -158,13 +212,19 @@ async fn seed_idle_pool_with_overrides_and_generation(
         .with_factory(factory_arc)
         .with_sandbox_id(sandbox_id)
         .with_profile_name(profile_name)
+        .with_guest_timezone_intent(guest_timezone_intent)
         .with_last_completed_at(TEST_LAST_COMPLETED_AT);
     let candidate = match history_generation_run_id {
         Some(run_id) => builder.with_history_generation_run_id(run_id).build(),
         None => builder.build(),
     };
     let mut guard = pool.lock().await;
-    let result = guard.park(candidate);
+    let result = match timing {
+        Some((parked_at, idle_timeout)) => {
+            guard.park_at_for_test(candidate, parked_at, idle_timeout)
+        }
+        None => guard.park(candidate),
+    };
     assert!(matches!(result, ParkResult::Parked));
     sandbox_id
 }

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -11,8 +11,9 @@ pub(super) use self::env::{
     two_profiles,
 };
 pub(super) use self::idle_pool::{
-    TestParkedIdleCandidateSpec, WorkspacePromotionSeedSpec, seed_idle_pool,
-    seed_idle_pool_expired, seed_idle_pool_with_history_generation, seed_idle_pool_with_overrides,
+    SpeculativeIdleSeedSpec, TestParkedIdleCandidateSpec, WorkspacePromotionSeedSpec,
+    seed_idle_pool, seed_idle_pool_expired, seed_idle_pool_with_history_generation,
+    seed_idle_pool_with_overrides, seed_idle_pool_with_speculative_timezone,
     seed_idle_pool_with_timing, seed_idle_pool_with_workspace_promotion,
     seed_workspace_cache_state,
 };

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1189,6 +1189,7 @@ pub(super) struct RunControls {
     pub(super) session_history_restore_plan: SessionHistoryRestorePlan,
     pub(super) prepared_storage: Option<crate::storage_cache::PreparedFreshStorage>,
     pub(super) prepared_guest_runtime: Option<PreparedGuestRuntime>,
+    guest_state_prepared: bool,
 }
 
 pub(super) enum PreparedGuestRuntime {
@@ -1281,6 +1282,7 @@ impl RunControls {
             session_history_restore_plan: SessionHistoryRestorePlan::Default,
             prepared_storage: None,
             prepared_guest_runtime: None,
+            guest_state_prepared: false,
         }
     }
 
@@ -1294,6 +1296,11 @@ impl RunControls {
         plan: SessionHistoryRestorePlan,
     ) -> Self {
         self.session_history_restore_plan = plan;
+        self
+    }
+
+    pub(super) fn with_guest_state_prepared(mut self, prepared: bool) -> Self {
+        self.guest_state_prepared = prepared;
         self
     }
 }
@@ -1598,6 +1605,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         session_history_restore_plan,
         mut prepared_storage,
         prepared_guest_runtime,
+        guest_state_prepared,
     } = controls;
     let has_active_input_source = active_input_source.is_some();
     let pre_spawn_started = Instant::now();
@@ -1606,6 +1614,10 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // taking ownership of model-catalog prefetch supervision.
     let prepared_guest_runtime = match prepared_guest_runtime {
         Some(prepared) => prepared,
+        None if guest_state_prepared => PreparedGuestRuntime::Ready(
+            StartedCodexModelCatalogPrefetch::start(sandbox, context, start.reuse_result, &cancel)
+                .await,
+        ),
         None => {
             PreparedGuestRuntime::prepare(
                 sandbox,

--- a/crates/runner/src/executor/guest_state.rs
+++ b/crates/runner/src/executor/guest_state.rs
@@ -3,6 +3,7 @@
 use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, Sandbox};
 
 use super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
+use crate::guest_timezone::{GuestTimezoneIntent, is_shell_safe_name};
 use crate::helper_exec::{
     format_command_output_excerpt, format_helper_exec_failure, helper_exec_succeeded,
     helper_exec_termination_label,
@@ -51,24 +52,7 @@ fn read_host_entropy() -> RunnerResult<Vec<u8>> {
 }
 
 pub(crate) fn is_shell_safe_guest_timezone_name(tz: &str) -> bool {
-    !tz.is_empty()
-        && tz
-            .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || b == b'/' || b == b'_' || b == b'-' || b == b'+')
-}
-
-fn user_timezone(context: &ExecutionContext) -> Option<&str> {
-    let tz = match context.user_timezone.as_deref() {
-        Some(tz) if !tz.is_empty() => tz,
-        _ => return None,
-    };
-    // The value is interpolated into a sudo shell command. This check protects
-    // that boundary; guest zone availability is handled by the command itself.
-    if !is_shell_safe_guest_timezone_name(tz) {
-        tracing::warn!(tz = %tz, "rejected unsafe timezone name");
-        return None;
-    }
-    Some(tz)
+    is_shell_safe_name(tz)
 }
 
 fn timezone_sync_body(tz: &str) -> String {
@@ -140,10 +124,25 @@ pub(crate) async fn restore_guest_state(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
 ) -> RunnerResult<()> {
-    let timezone = user_timezone(context).map(|name| GuestTimezone::BestEffort {
+    let intent = GuestTimezoneIntent::from_context(context);
+    if matches!(intent, GuestTimezoneIntent::Unknown) {
+        tracing::warn!(run_id = %context.run_id, "rejected unsafe timezone name");
+    }
+    let timezone = intent.guest_name().map(|name| GuestTimezone::BestEffort {
         name,
         run_id: context.run_id,
     });
+    restore_guest_state_inner(sandbox, timezone).await
+}
+
+pub(crate) async fn restore_guest_state_with_intent(
+    sandbox: &dyn Sandbox,
+    run_id: RunId,
+    intent: &GuestTimezoneIntent,
+) -> RunnerResult<()> {
+    let timezone = intent
+        .guest_name()
+        .map(|name| GuestTimezone::BestEffort { name, run_id });
     restore_guest_state_inner(sandbox, timezone).await
 }
 
@@ -222,11 +221,37 @@ guest-reseed || {{ status=$?; echo "guest-reseed failed" >&2; exit "$status"; }}
 /// - `/etc/timezone` + `/etc/localtime` — filesystem-level (read by libc)
 /// - `TZ` in `/etc/environment` — inherited by all login shells via PAM
 ///
-/// The agent process also receives `TZ` via the env vars in step 6.
-/// Skipped when no user timezone is configured (falls back to image default UTC).
+/// The agent process also receives `TZ` via its environment. This standalone
+/// helper keeps the fresh non-snapshot path unchanged when no timezone is
+/// configured; full reused-VM restoration applies the explicit UTC default.
 pub(super) async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &ExecutionContext) {
-    let Some(tz) = user_timezone(context) else {
-        return;
+    let intent = GuestTimezoneIntent::from_context(context);
+    match intent {
+        GuestTimezoneIntent::Configured(_) => {
+            sync_guest_timezone_intent(sandbox, context.run_id, &intent).await;
+        }
+        GuestTimezoneIntent::Default => {}
+        GuestTimezoneIntent::Unknown => {
+            tracing::warn!(run_id = %context.run_id, "rejected unsafe timezone name");
+        }
+    }
+}
+
+pub(crate) async fn sync_guest_timezone_intent(
+    sandbox: &dyn Sandbox,
+    run_id: RunId,
+    intent: &GuestTimezoneIntent,
+) {
+    let _ = try_sync_guest_timezone_intent(sandbox, run_id, intent).await;
+}
+
+pub(crate) async fn try_sync_guest_timezone_intent(
+    sandbox: &dyn Sandbox,
+    run_id: RunId,
+    intent: &GuestTimezoneIntent,
+) -> RunnerResult<()> {
+    let Some(tz) = intent.guest_name() else {
+        return Ok(());
     };
     let cmd = timezone_sync_command(tz);
     // Best-effort: don't fail the run if timezone setup fails.
@@ -252,7 +277,7 @@ pub(super) async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &Executi
                 format_command_output_excerpt("stdout", &result.stdout, result.stdout_truncated);
             if let Some(exit_code) = helper_exec_exit_code(&result) {
                 tracing::warn!(
-                    run_id = %context.run_id,
+                    run_id = %run_id,
                     tz = %tz,
                     termination = helper_exec_termination_label(&result),
                     exit_code,
@@ -262,7 +287,7 @@ pub(super) async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &Executi
                 );
             } else {
                 tracing::warn!(
-                    run_id = %context.run_id,
+                    run_id = %run_id,
                     tz = %tz,
                     termination = helper_exec_termination_label(&result),
                     stderr_excerpt = %stderr_excerpt.as_deref().unwrap_or(""),
@@ -273,7 +298,9 @@ pub(super) async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &Executi
         }
         Ok(_) => {}
         Err(e) => {
-            tracing::warn!(run_id = %context.run_id, tz = %tz, error = %e, "failed to set guest timezone");
+            tracing::warn!(run_id = %run_id, tz = %tz, error = %e, "failed to set guest timezone");
+            return Err(e.into());
         }
     }
+    Ok(())
 }

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -46,7 +46,8 @@ mod workspace_session_history_materializer;
 pub(crate) use crate::restored_session_identity::RestoredSessionIdentity;
 pub(crate) use cli_framework::effective_cli_framework;
 pub(crate) use guest_state::{
-    is_shell_safe_guest_timezone_name, restore_guest_state_with_timezone,
+    is_shell_safe_guest_timezone_name, restore_guest_state_with_intent,
+    restore_guest_state_with_timezone, try_sync_guest_timezone_intent,
 };
 pub(crate) use session_history_cpu::SessionHistoryCpuPool;
 pub(crate) use session_history_download::{SessionHistoryMaterializer, SessionHistoryProbe};
@@ -62,7 +63,10 @@ pub(crate) use env::validate_resume_session_id;
 use sandbox_run::{
     NewSandboxHooks, execute_new_sandbox_with_prepared_notifier, execute_reused_sandbox,
 };
-pub(crate) use telemetry::{RunnerPreSpawnPhase, RunnerPreSpawnTiming};
+pub(crate) use telemetry::{
+    ExactReuseSpeculationTiming, RunnerPreSpawnOperationTiming, RunnerPreSpawnPhase,
+    RunnerPreSpawnTiming,
+};
 use telemetry::{RunnerSpawnTiming, record_api_latency, record_reuse_result};
 
 use crate::ids::RunId;
@@ -702,6 +706,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
         storage_fingerprints: prev_storage,
         restored_session_identity: _restored_session_identity,
         workspace_promotion,
+        guest_state_prepared,
     } = idle_sandbox.into_parts();
 
     let resume_session_error = validate_resume_session_id(&context).err();
@@ -787,7 +792,8 @@ pub(crate) async fn execute_job_reuse_with_hooks(
             &mut telemetry,
             RunControls::from_cancellation(cancellation, active_input_source)
                 .with_spawn_timing(spawn_timing)
-                .with_session_history_restore_plan(session_history_restore_plan),
+                .with_session_history_restore_plan(session_history_restore_plan)
+                .with_guest_state_prepared(guest_state_prepared),
         )
         .await;
         outcome.workspace_image = workspace_image;

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -8,6 +8,7 @@ use guest_contracts::epoch_milliseconds::{
 };
 use tracing::warn;
 
+use crate::guest_timezone::GuestTimezoneAssumption;
 use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, SandboxReuseResult};
 use crate::workspace_image_cache::WorkspaceCacheCheckoutResult;
@@ -114,6 +115,23 @@ pub(crate) struct RunnerPreSpawnTiming {
     claim_returned_at: Instant,
     phase_durations: RunnerPreSpawnPhaseDurations,
     task_enqueued_at: Option<Instant>,
+    exact_reuse_speculation: Option<ExactReuseSpeculationTiming>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct RunnerPreSpawnOperationTiming {
+    pub(crate) duration: Duration,
+    pub(crate) succeeded: bool,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct ExactReuseSpeculationTiming {
+    pub(crate) unpark: RunnerPreSpawnOperationTiming,
+    pub(crate) guest_restore: Option<RunnerPreSpawnOperationTiming>,
+    pub(crate) claim_overlap: Duration,
+    pub(crate) post_claim_remainder: Duration,
+    pub(crate) timezone_correction: Option<RunnerPreSpawnOperationTiming>,
+    pub(crate) timezone_assumption: Option<GuestTimezoneAssumption>,
 }
 
 pub(super) struct RunnerSpawnTiming {
@@ -122,12 +140,22 @@ pub(super) struct RunnerSpawnTiming {
 }
 
 impl RunnerPreSpawnTiming {
+    #[cfg(test)]
     pub(crate) fn start_after_claim() -> Self {
+        Self::start_at(Instant::now())
+    }
+
+    pub(crate) fn start_at(claim_returned_at: Instant) -> Self {
         Self {
-            claim_returned_at: Instant::now(),
+            claim_returned_at,
             phase_durations: RunnerPreSpawnPhaseDurations::default(),
             task_enqueued_at: None,
+            exact_reuse_speculation: None,
         }
+    }
+
+    pub(crate) fn record_exact_reuse_speculation(&mut self, timing: ExactReuseSpeculationTiming) {
+        self.exact_reuse_speculation = Some(timing);
     }
 
     pub(crate) fn record_phase(&mut self, phase: RunnerPreSpawnPhase, duration: Duration) {
@@ -159,6 +187,56 @@ impl RunnerPreSpawnTiming {
                 true,
                 None,
             );
+        }
+        if let Some(timing) = self.exact_reuse_speculation.as_ref() {
+            telemetry.record(
+                "runner_exact_reuse_preclaim_unpark",
+                timing.unpark.duration,
+                timing.unpark.succeeded,
+                (!timing.unpark.succeeded).then_some("speculative_unpark_failed"),
+            );
+            if let Some(operation) = timing.guest_restore {
+                telemetry.record(
+                    "runner_exact_reuse_preclaim_guest_restore",
+                    operation.duration,
+                    operation.succeeded,
+                    (!operation.succeeded).then_some("speculative_guest_restore_failed"),
+                );
+            }
+            telemetry.record(
+                "runner_exact_reuse_claim_overlap",
+                timing.claim_overlap,
+                true,
+                None,
+            );
+            telemetry.record(
+                "runner_exact_reuse_postclaim_remainder",
+                timing.post_claim_remainder,
+                true,
+                None,
+            );
+            if let Some(operation) = timing.timezone_correction {
+                telemetry.record(
+                    "runner_exact_reuse_timezone_correction",
+                    operation.duration,
+                    operation.succeeded,
+                    (!operation.succeeded).then_some("speculative_timezone_correction_failed"),
+                );
+            }
+            if let Some(assumption) = timing.timezone_assumption {
+                let action_type = match assumption {
+                    GuestTimezoneAssumption::Match => {
+                        "runner_exact_reuse_timezone_assumption_match"
+                    }
+                    GuestTimezoneAssumption::Mismatch => {
+                        "runner_exact_reuse_timezone_assumption_mismatch"
+                    }
+                    GuestTimezoneAssumption::Unknown => {
+                        "runner_exact_reuse_timezone_assumption_unknown"
+                    }
+                };
+                telemetry.record(action_type, Duration::ZERO, true, None);
+            }
         }
     }
 }

--- a/crates/runner/src/executor/tests/guest_state_tests.rs
+++ b/crates/runner/src/executor/tests/guest_state_tests.rs
@@ -31,6 +31,8 @@ async fn restore_guest_state_combines_clock_sync_and_reseed() {
     assert!(clock_sync_index < reseed_index);
     assert!(calls[0].cmd.contains("guest clock sync failed"));
     assert!(calls[0].cmd.contains("guest-reseed failed"));
+    assert!(calls[0].cmd.contains("/usr/share/zoneinfo/UTC"));
+    assert!(calls[0].cmd.contains("echo 'TZ=UTC' >> /etc/environment"));
     assert!(calls[0].sudo);
     let stdin_bytes = calls[0].stdin_bytes.as_ref().unwrap();
     assert_eq!(stdin_bytes.len(), 256);

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -1462,6 +1462,7 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
         storage_fingerprints: StorageFingerprints::default(),
         restored_session_identity: None,
         history_generation_run_id: None,
+        guest_timezone_intent: crate::guest_timezone::GuestTimezoneIntent::Unknown,
         workspace_image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
         workspace_promotion: Some(promotion),
     })
@@ -1573,6 +1574,7 @@ async fn reusable_idle_sandbox_with_fresh_workspace_promotion(
         storage_fingerprints: StorageFingerprints::default(),
         restored_session_identity: None,
         history_generation_run_id: None,
+        guest_timezone_intent: crate::guest_timezone::GuestTimezoneIntent::Unknown,
         workspace_image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
         workspace_promotion: Some(promotion),
     })

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -15,13 +15,14 @@ use super::super::telemetry::{
     RunnerPreSpawnPhase, elapsed_since_api_start_ms, record_reuse_result,
 };
 use super::super::{
-    ExecutionHooks, NewSandboxDispatch, RunnerPreSpawnTiming, SessionHistoryRestorePlan,
-    execute_job, execute_job_reuse, execute_job_reuse_with_hooks,
-    execute_job_with_prepared_notifier,
+    ExactReuseSpeculationTiming, ExecutionHooks, NewSandboxDispatch, RunnerPreSpawnOperationTiming,
+    RunnerPreSpawnTiming, SessionHistoryRestorePlan, execute_job, execute_job_reuse,
+    execute_job_reuse_with_hooks, execute_job_with_prepared_notifier,
 };
 use super::support::{
     default_params, make_reusable_idle_sandbox, minimal_context, test_executor_config,
 };
+use crate::guest_timezone::GuestTimezoneAssumption;
 use crate::http::{HttpClient, HttpClientConfig};
 use crate::ids::RunId;
 use crate::run_cancellation::RunCancellationSignals;
@@ -482,6 +483,28 @@ fn pre_spawn_timing_with_phases() -> RunnerPreSpawnTiming {
     timing
 }
 
+fn pre_spawn_timing_with_exact_reuse_speculation() -> RunnerPreSpawnTiming {
+    let mut timing = RunnerPreSpawnTiming::start_after_claim();
+    timing.record_exact_reuse_speculation(ExactReuseSpeculationTiming {
+        unpark: RunnerPreSpawnOperationTiming {
+            duration: Duration::from_millis(3),
+            succeeded: true,
+        },
+        guest_restore: Some(RunnerPreSpawnOperationTiming {
+            duration: Duration::from_millis(41),
+            succeeded: true,
+        }),
+        claim_overlap: Duration::from_millis(39),
+        post_claim_remainder: Duration::from_millis(2),
+        timezone_correction: Some(RunnerPreSpawnOperationTiming {
+            duration: Duration::from_millis(5),
+            succeeded: true,
+        }),
+        timezone_assumption: Some(GuestTimezoneAssumption::Mismatch),
+    });
+    timing
+}
+
 #[test]
 fn record_reuse_result_emits_hit_for_reuse() {
     let mut telemetry = new_telemetry();
@@ -661,6 +684,51 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
     assert_lacks_action(&telemetry, "runner_reused_sandbox_prepare");
     assert_lacks_action(&telemetry, "runner_fresh_workspace_image_prepare");
     assert_lacks_action(&telemetry, "runner_guest_state_restore");
+}
+
+#[tokio::test]
+async fn execute_job_records_exact_reuse_speculation_timing() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let factory = ObservedMockSandboxFactory::new();
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (_outcome, telemetry) = execute_job_with_prepared_notifier(
+        &factory,
+        minimal_context(),
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        RunCancellationSignals::hard_only(cancel),
+        ExecutionHooks {
+            sandbox_prepared: None,
+            active_input_source: None,
+            pre_spawn_timing: Some(pre_spawn_timing_with_exact_reuse_speculation()),
+            session_history_restore_plan: SessionHistoryRestorePlan::Default,
+        },
+    )
+    .await;
+
+    for (action, duration_ms) in [
+        ("runner_exact_reuse_preclaim_unpark", 3),
+        ("runner_exact_reuse_preclaim_guest_restore", 41),
+        ("runner_exact_reuse_claim_overlap", 39),
+        ("runner_exact_reuse_postclaim_remainder", 2),
+        ("runner_exact_reuse_timezone_correction", 5),
+    ] {
+        assert_action_success(&telemetry, action, true);
+        assert_action_duration(&telemetry, action, duration_ms);
+    }
+    assert_action_success(
+        &telemetry,
+        "runner_exact_reuse_timezone_assumption_mismatch",
+        true,
+    );
+    assert_lacks_action(&telemetry, "runner_exact_reuse_timezone_assumption_match");
+    assert_lacks_action(&telemetry, "runner_exact_reuse_timezone_assumption_unknown");
 }
 
 #[tokio::test]

--- a/crates/runner/src/guest_timezone.rs
+++ b/crates/runner/src/guest_timezone.rs
@@ -1,0 +1,64 @@
+use crate::types::ExecutionContext;
+
+pub(crate) const DEFAULT_GUEST_TIMEZONE: &str = "UTC";
+
+/// Claimed timezone intent retained with a runner-local idle sandbox.
+///
+/// This records the claim input, not proof that mutable guest files still
+/// contain the requested timezone.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum GuestTimezoneIntent {
+    Configured(String),
+    Default,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum GuestTimezoneAssumption {
+    Match,
+    Mismatch,
+    Unknown,
+}
+
+impl GuestTimezoneIntent {
+    pub(crate) fn from_context(context: &ExecutionContext) -> Self {
+        match context.user_timezone.as_deref() {
+            None | Some("") => Self::Default,
+            Some(timezone) if is_shell_safe_name(timezone) => Self::Configured(timezone.to_owned()),
+            Some(_) => Self::Unknown,
+        }
+    }
+
+    pub(crate) fn guest_name(&self) -> Option<&str> {
+        match self {
+            Self::Configured(timezone) => Some(timezone),
+            Self::Default => Some(DEFAULT_GUEST_TIMEZONE),
+            Self::Unknown => None,
+        }
+    }
+
+    pub(crate) fn is_usable_prediction(&self) -> bool {
+        !matches!(self, Self::Unknown)
+    }
+
+    pub(crate) fn compare(&self, claimed: &Self) -> GuestTimezoneAssumption {
+        if matches!(claimed, Self::Unknown) {
+            GuestTimezoneAssumption::Unknown
+        } else if self == claimed {
+            GuestTimezoneAssumption::Match
+        } else {
+            GuestTimezoneAssumption::Mismatch
+        }
+    }
+}
+
+pub(crate) fn is_shell_safe_name(timezone: &str) -> bool {
+    !timezone.is_empty()
+        && timezone.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || byte == b'/'
+                || byte == b'_'
+                || byte == b'-'
+                || byte == b'+'
+        })
+}

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -16,8 +16,10 @@ pub use entry::{
     IdleDestroyJob, IdleEntry, IdleUnparkResult, ParkedIdleCandidate, RejectedParkedIdleCandidate,
     ReservedIdleSandbox, RestoreReservedIdleResult, ReusableIdleSandbox, ReusableIdleSandboxParts,
 };
+pub(crate) use entry::{SpeculativeIdleSandbox, SpeculativeIdleUnparkResult};
 pub(crate) use park_transition::{
     IdleParkActiveParts, IdleParkFailureParts, IdleParkRequest, IdleParkRequestParts,
+    SpeculativeReparkResult,
 };
 pub(crate) use parking_gate::ParkingGate;
 #[cfg(test)]

--- a/crates/runner/src/idle_pool/entry.rs
+++ b/crates/runner/src/idle_pool/entry.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 use futures_util::FutureExt;
 use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
 
+use crate::guest_timezone::GuestTimezoneIntent;
 use crate::ids::RunId;
 use crate::resource_budget::BudgetLease;
 use crate::restored_session_identity::RestoredSessionIdentity;
@@ -33,6 +34,7 @@ pub(super) struct IdleSandboxMetadata {
     /// was parked. Missing means reuse must fall back to materialize+restore.
     pub(super) restored_session_identity: Option<RestoredSessionIdentity>,
     pub(super) history_generation_run_id: Option<RunId>,
+    pub(super) guest_timezone_intent: GuestTimezoneIntent,
     /// Local terminal timestamp for this parked sandbox.
     ///
     /// `None` is reserved for synthetic test entries and means the VM is not
@@ -60,7 +62,10 @@ pub(super) struct IdleSandboxResources {
 }
 
 impl IdleSandboxResources {
-    fn into_destroy_payload(self, policy: WorkspacePromotionPolicy) -> IdleDestroyPayload {
+    pub(super) fn into_destroy_payload(
+        self,
+        policy: WorkspacePromotionPolicy,
+    ) -> IdleDestroyPayload {
         IdleDestroyPayload {
             resources: self,
             workspace_promotion_policy: policy,
@@ -192,6 +197,7 @@ pub struct ReusableIdleSandbox {
     sandbox: Box<dyn Sandbox>,
     metadata: IdleSandboxMetadata,
     workspace_promotion: Option<WorkspaceImagePromotionContext>,
+    guest_state_prepared: bool,
 }
 
 pub struct ReusableIdleSandboxParts {
@@ -201,6 +207,22 @@ pub struct ReusableIdleSandboxParts {
     pub storage_fingerprints: StorageFingerprints,
     pub restored_session_identity: Option<RestoredSessionIdentity>,
     pub workspace_promotion: Option<WorkspaceImagePromotionContext>,
+    pub guest_state_prepared: bool,
+}
+
+/// An exact-generation idle sandbox that has been unparked for claim-time
+/// preparation but has not yet been committed to a claimed job.
+#[must_use = "speculatively active sandboxes must be committed, re-parked, or destroyed"]
+pub(crate) struct SpeculativeIdleSandbox {
+    pub(super) entry: IdleEntry,
+}
+
+pub(crate) enum SpeculativeIdleUnparkResult {
+    Ready(Box<SpeculativeIdleSandbox>),
+    Failed {
+        destroy_job: Box<IdleDestroyJob>,
+        error: String,
+    },
 }
 
 impl ReusableIdleSandbox {
@@ -217,6 +239,7 @@ impl ReusableIdleSandbox {
             sandbox,
             metadata,
             workspace_promotion,
+            guest_state_prepared,
         } = self;
         let IdleSandboxMetadata {
             reuse_key,
@@ -227,6 +250,7 @@ impl ReusableIdleSandbox {
             storage_fingerprints,
             restored_session_identity,
             history_generation_run_id: _,
+            guest_timezone_intent: _,
             last_completed_at: _,
         } = metadata;
 
@@ -237,6 +261,7 @@ impl ReusableIdleSandbox {
             storage_fingerprints,
             restored_session_identity,
             workspace_promotion,
+            guest_state_prepared,
         }
     }
 }
@@ -495,6 +520,7 @@ impl IdleEntry {
                 sandbox,
                 metadata,
                 workspace_promotion,
+                guest_state_prepared: false,
             },
             budget_lease,
         )
@@ -568,6 +594,10 @@ impl ReservedIdleSandbox {
         self.entry.reuse_key()
     }
 
+    pub(crate) fn guest_timezone_intent(&self) -> &GuestTimezoneIntent {
+        &self.entry.metadata.guest_timezone_intent
+    }
+
     pub fn validate_workspace_promotion_identity(
         &self,
         cache: &WorkspaceImageCache,
@@ -582,6 +612,38 @@ impl ReservedIdleSandbox {
         self.entry.try_unpark_for_run(run_id).await
     }
 
+    pub(crate) async fn try_unpark_for_speculation(
+        mut self,
+        run_id: RunId,
+    ) -> SpeculativeIdleUnparkResult {
+        let activation = async {
+            self.entry
+                .resources
+                .sandbox
+                .bind_run_control(&run_id.to_string())?;
+            self.entry.resources.sandbox.unpark().await
+        };
+        match AssertUnwindSafe(activation).catch_unwind().await {
+            Ok(Ok(())) => SpeculativeIdleUnparkResult::Ready(Box::new(SpeculativeIdleSandbox {
+                entry: self.entry,
+            })),
+            Ok(Err(error)) => SpeculativeIdleUnparkResult::Failed {
+                destroy_job: Box::new(
+                    self.entry.into_destroy_job_abandoning_workspace_promotion(
+                        "speculative_unpark_failed",
+                    ),
+                ),
+                error: error.to_string(),
+            },
+            Err(_) => SpeculativeIdleUnparkResult::Failed {
+                destroy_job: Box::new(self.entry.into_destroy_job_abandoning_workspace_promotion(
+                    "speculative_unpark_panicked",
+                )),
+                error: "sandbox unpark panicked".into(),
+            },
+        }
+    }
+
     pub fn into_destroy_job(self) -> IdleDestroyJob {
         self.entry.into_destroy_job()
     }
@@ -589,5 +651,54 @@ impl ReservedIdleSandbox {
     pub fn into_destroy_job_without_workspace_promotion_for_mismatch(self) -> IdleDestroyJob {
         self.entry
             .into_destroy_job_without_workspace_promotion_for_mismatch()
+    }
+}
+
+impl SpeculativeIdleSandbox {
+    pub(crate) fn sandbox(&self) -> &dyn Sandbox {
+        self.entry.resources.sandbox.as_ref()
+    }
+
+    pub(crate) fn reuse_key(&self) -> &str {
+        self.entry.reuse_key()
+    }
+
+    pub(crate) fn guest_timezone_intent(&self) -> &GuestTimezoneIntent {
+        &self.entry.metadata.guest_timezone_intent
+    }
+
+    pub(crate) fn validate_workspace_promotion_identity(
+        &self,
+        cache: &WorkspaceImageCache,
+        working_dir: &str,
+        image_size_bytes: u64,
+    ) -> Result<(), WorkspaceImagePromotionIdentityMismatch> {
+        self.entry
+            .validate_workspace_promotion_identity(cache, working_dir, image_size_bytes)
+    }
+
+    pub(crate) fn commit(self, guest_state_prepared: bool) -> (ReusableIdleSandbox, BudgetLease) {
+        let Self { entry } = self;
+        let IdleEntry {
+            resources,
+            metadata,
+            budget_lease,
+            ..
+        } = entry;
+        let (sandbox, workspace_promotion) = resources.into_reuse_parts();
+        (
+            ReusableIdleSandbox {
+                sandbox,
+                metadata,
+                workspace_promotion,
+                guest_state_prepared,
+            },
+            budget_lease,
+        )
+    }
+
+    pub(crate) fn into_destroy_job(self, reason: &'static str) -> IdleDestroyJob {
+        self.entry
+            .into_destroy_job_abandoning_workspace_promotion(reason)
     }
 }

--- a/crates/runner/src/idle_pool/park_transition.rs
+++ b/crates/runner/src/idle_pool/park_transition.rs
@@ -8,6 +8,7 @@ use sandbox::{
     SandboxParkNonReusableReason, SandboxParkOutcome,
 };
 
+use crate::guest_timezone::GuestTimezoneIntent;
 use crate::idle_reuse_preparation::IdleReusePreparation;
 use crate::ids::RunId;
 use crate::resource_budget::BudgetLease;
@@ -19,7 +20,9 @@ use crate::workspace_image_cache::{
 use crate::workspace_promotion::abandon_unpublished_workspace_promotion;
 
 use super::entry::{
-    IdleSandboxMetadata, IdleSandboxResources, ParkedIdleCandidate, RejectedParkedIdleCandidate,
+    IdleDestroyJob, IdleEntry, IdleSandboxMetadata, IdleSandboxResources, ParkedIdleCandidate,
+    RejectedParkedIdleCandidate, ReservedIdleSandbox, SpeculativeIdleSandbox,
+    WorkspacePromotionPolicy,
 };
 
 /// One-shot request to transition an active sandbox into same-reuse-key idle
@@ -43,6 +46,7 @@ pub(crate) struct IdleParkRequestParts {
     pub(crate) storage_fingerprints: StorageFingerprints,
     pub(crate) restored_session_identity: Option<RestoredSessionIdentity>,
     pub(crate) history_generation_run_id: Option<RunId>,
+    pub(crate) guest_timezone_intent: GuestTimezoneIntent,
     pub(crate) workspace_image_size_bytes: u64,
     pub(crate) workspace_promotion: Option<WorkspaceImagePromotionContext>,
 }
@@ -96,6 +100,23 @@ pub(crate) enum IdleParkFailureParts {
     },
 }
 
+struct IdleParkTransitionInput {
+    run_id: RunId,
+    resources: IdleSandboxResources,
+    metadata: IdleSandboxMetadata,
+    budget_lease: BudgetLease,
+    workspace_image_size_bytes: u64,
+}
+
+pub(crate) enum SpeculativeReparkResult {
+    Reparked(Box<ReservedIdleSandbox>),
+    Destroy {
+        destroy_job: Box<IdleDestroyJob>,
+        reason: &'static str,
+        error: String,
+    },
+}
+
 impl IdleParkRequest {
     pub(crate) fn new(parts: IdleParkRequestParts) -> Self {
         Self { parts }
@@ -120,7 +141,7 @@ impl IdleParkRequest {
     ) -> Result<IdleParkOutcome, IdleParkFailure> {
         let IdleParkRequestParts {
             run_id,
-            mut sandbox,
+            sandbox,
             factory,
             reuse_key,
             sandbox_id,
@@ -131,14 +152,10 @@ impl IdleParkRequest {
             storage_fingerprints,
             restored_session_identity,
             history_generation_run_id,
+            guest_timezone_intent,
             workspace_image_size_bytes,
             workspace_promotion,
         } = self.parts;
-
-        let retained_runtime_dir = restored_session_identity
-            .as_ref()
-            .and_then(RestoredSessionIdentity::final_metadata_verification)
-            .map(|verification| verification.runtime_dir.to_owned());
 
         let metadata = IdleSandboxMetadata {
             reuse_key,
@@ -149,49 +166,84 @@ impl IdleParkRequest {
             storage_fingerprints,
             restored_session_identity,
             history_generation_run_id,
+            guest_timezone_intent,
             last_completed_at: None,
         };
 
-        if let Some(promotion) = workspace_promotion.as_ref()
-            && let Err(mismatch) =
-                promotion.validate_stored_cache_identity(WorkspaceImagePromotionIdentityRequest {
-                    sandbox_id: metadata.sandbox_id,
-                    profile_name: &metadata.profile_name,
-                    reuse_key: metadata.reuse_key(),
-                    working_dir: CANONICAL_WORKING_DIR,
-                    image_size_bytes: workspace_image_size_bytes,
-                })
-        {
-            tracing::warn!(
-                sandbox_id = %metadata.sandbox_id,
-                profile_name = %metadata.profile_name,
-                mismatch = mismatch.as_str(),
-                "workspace promotion identity mismatch before idle park; destroying without workspace promotion"
-            );
-            abandon_unpublished_workspace_promotion(
-                workspace_promotion,
-                "promotion_identity_mismatch",
-            )
-            .await;
-            return Err(IdleParkFailure {
-                ownership: IdleParkFailureOwnership::Active {
-                    resources: IdleSandboxResources {
-                        sandbox,
-                        factory,
-                        workspace_promotion: None,
-                    },
-                    budget_lease,
+        park_idle_transition(
+            IdleParkTransitionInput {
+                run_id,
+                resources: IdleSandboxResources {
+                    sandbox,
+                    factory,
+                    workspace_promotion,
                 },
-                reason: "promotion_identity_mismatch",
-                error: format!("workspace promotion identity mismatch: {mismatch}"),
-            });
-        }
+                metadata,
+                budget_lease,
+                workspace_image_size_bytes,
+            },
+            observer,
+        )
+        .await
+    }
+}
 
-        let preparation = match IdleReusePreparation::new(
-            sandbox.id(),
-            run_id,
-            retained_runtime_dir.as_deref(),
-        ) {
+async fn park_idle_transition(
+    input: IdleParkTransitionInput,
+    observer: Option<&mut dyn SandboxFinalExecParkObserver>,
+) -> Result<IdleParkOutcome, IdleParkFailure> {
+    let IdleParkTransitionInput {
+        run_id,
+        resources,
+        metadata,
+        budget_lease,
+        workspace_image_size_bytes,
+    } = input;
+    let IdleSandboxResources {
+        mut sandbox,
+        factory,
+        workspace_promotion,
+    } = resources;
+    let retained_runtime_dir = metadata
+        .restored_session_identity
+        .as_ref()
+        .and_then(RestoredSessionIdentity::final_metadata_verification)
+        .map(|verification| verification.runtime_dir.to_owned());
+
+    if let Some(promotion) = workspace_promotion.as_ref()
+        && let Err(mismatch) =
+            promotion.validate_stored_cache_identity(WorkspaceImagePromotionIdentityRequest {
+                sandbox_id: metadata.sandbox_id,
+                profile_name: &metadata.profile_name,
+                reuse_key: metadata.reuse_key(),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: workspace_image_size_bytes,
+            })
+    {
+        tracing::warn!(
+            sandbox_id = %metadata.sandbox_id,
+            profile_name = %metadata.profile_name,
+            mismatch = mismatch.as_str(),
+            "workspace promotion identity mismatch before idle park; destroying without workspace promotion"
+        );
+        abandon_unpublished_workspace_promotion(workspace_promotion, "promotion_identity_mismatch")
+            .await;
+        return Err(IdleParkFailure {
+            ownership: IdleParkFailureOwnership::Active {
+                resources: IdleSandboxResources {
+                    sandbox,
+                    factory,
+                    workspace_promotion: None,
+                },
+                budget_lease,
+            },
+            reason: "promotion_identity_mismatch",
+            error: format!("workspace promotion identity mismatch: {mismatch}"),
+        });
+    }
+
+    let preparation =
+        match IdleReusePreparation::new(sandbox.id(), run_id, retained_runtime_dir.as_deref()) {
             Ok(preparation) => preparation,
             Err(error) => {
                 return Err(IdleParkFailure {
@@ -209,73 +261,131 @@ impl IdleParkRequest {
             }
         };
 
-        let final_exec_and_park = {
-            let request = preparation.exec_request();
-            let transition = match observer {
-                Some(observer) => sandbox.final_exec_and_park_with_observer(
-                    &request,
-                    "idle-reuse-preparation-and-park",
-                    observer,
-                ),
-                None => sandbox.final_exec_and_park(&request, "idle-reuse-preparation-and-park"),
-            };
-            AssertUnwindSafe(transition).catch_unwind().await
+    let final_exec_and_park = {
+        let request = preparation.exec_request();
+        let transition = match observer {
+            Some(observer) => sandbox.final_exec_and_park_with_observer(
+                &request,
+                "idle-reuse-preparation-and-park",
+                observer,
+            ),
+            None => sandbox.final_exec_and_park(&request, "idle-reuse-preparation-and-park"),
         };
-        match final_exec_and_park {
-            Ok(Ok(outcome)) => {
-                let candidate = ParkedIdleCandidate {
-                    resources: IdleSandboxResources {
-                        sandbox,
-                        factory,
-                        workspace_promotion,
+        AssertUnwindSafe(transition).catch_unwind().await
+    };
+    match final_exec_and_park {
+        Ok(Ok(outcome)) => {
+            let candidate = ParkedIdleCandidate {
+                resources: IdleSandboxResources {
+                    sandbox,
+                    factory,
+                    workspace_promotion,
+                },
+                metadata,
+                budget_lease,
+            };
+            if let Err(error) = preparation.validate_result(&outcome.exec_result) {
+                return Err(IdleParkFailure {
+                    ownership: IdleParkFailureOwnership::Parked {
+                        rejected: candidate.into_rejected(),
                     },
-                    metadata,
-                    budget_lease,
-                };
-                if let Err(error) = preparation.validate_result(&outcome.exec_result) {
-                    return Err(IdleParkFailure {
-                        ownership: IdleParkFailureOwnership::Parked {
-                            rejected: candidate.into_rejected(),
-                        },
-                        reason: "reuse_preparation_failed",
-                        error: error.to_string(),
-                    });
-                }
-                Ok(match outcome.park_outcome {
-                    SandboxParkOutcome::Reusable => IdleParkOutcome::Reusable(candidate),
-                    SandboxParkOutcome::NonReusable(reason) => {
-                        IdleParkOutcome::NonReusable { candidate, reason }
-                    }
-                })
+                    reason: "reuse_preparation_failed",
+                    error: error.to_string(),
+                });
             }
-            Ok(Err(e)) => Err(IdleParkFailure {
+            Ok(match outcome.park_outcome {
+                SandboxParkOutcome::Reusable => IdleParkOutcome::Reusable(candidate),
+                SandboxParkOutcome::NonReusable(reason) => {
+                    IdleParkOutcome::NonReusable { candidate, reason }
+                }
+            })
+        }
+        Ok(Err(error)) => Err(IdleParkFailure {
+            ownership: IdleParkFailureOwnership::Active {
+                resources: IdleSandboxResources {
+                    sandbox,
+                    factory,
+                    workspace_promotion,
+                },
+                budget_lease,
+            },
+            reason: "park_failed",
+            error: error.to_string(),
+        }),
+        Err(_) => {
+            // A panic leaves the park transition state uncertain; destroy
+            // the sandbox, but do not publish a workspace cache image.
+            abandon_unpublished_workspace_promotion(workspace_promotion, "park_panicked").await;
+            Err(IdleParkFailure {
                 ownership: IdleParkFailureOwnership::Active {
                     resources: IdleSandboxResources {
                         sandbox,
                         factory,
-                        workspace_promotion,
+                        workspace_promotion: None,
                     },
                     budget_lease,
                 },
-                reason: "park_failed",
-                error: e.to_string(),
-            }),
-            Err(_) => {
-                // A panic leaves the park transition state uncertain; destroy
-                // the sandbox, but do not publish a workspace cache image.
-                abandon_unpublished_workspace_promotion(workspace_promotion, "park_panicked").await;
-                Err(IdleParkFailure {
-                    ownership: IdleParkFailureOwnership::Active {
-                        resources: IdleSandboxResources {
-                            sandbox,
-                            factory,
-                            workspace_promotion: None,
-                        },
+                reason: "park_panicked",
+                error: "sandbox park panicked".into(),
+            })
+        }
+    }
+}
+
+impl SpeculativeIdleSandbox {
+    pub(crate) async fn repark_for_claim_rollback(
+        self,
+        run_id: RunId,
+        workspace_image_size_bytes: u64,
+    ) -> SpeculativeReparkResult {
+        let Self { entry } = self;
+        let IdleEntry {
+            resources,
+            metadata,
+            budget_lease,
+            parked_at,
+            idle_timeout,
+        } = entry;
+        let reuse_key = metadata.reuse_key.clone();
+        let profile_name = metadata.profile_name.clone();
+        match park_idle_transition(
+            IdleParkTransitionInput {
+                run_id,
+                resources,
+                metadata,
+                budget_lease,
+                workspace_image_size_bytes,
+            },
+            None,
+        )
+        .await
+        {
+            Ok(IdleParkOutcome::Reusable(candidate)) => {
+                SpeculativeReparkResult::Reparked(Box::new(ReservedIdleSandbox {
+                    entry: candidate.into_idle_entry(parked_at, idle_timeout),
+                }))
+            }
+            Ok(IdleParkOutcome::NonReusable { candidate, reason }) => {
+                let (payload, budget_lease) = candidate.into_active_destroy_parts();
+                SpeculativeReparkResult::Destroy {
+                    destroy_job: Box::new(IdleDestroyJob {
+                        payload,
                         budget_lease,
-                    },
-                    reason: "park_panicked",
-                    error: "sandbox park panicked".into(),
-                })
+                        reuse_key,
+                        profile_name,
+                    }),
+                    reason: "speculative_repark_non_reusable",
+                    error: format!("re-parked sandbox is not reusable: {}", reason.as_str()),
+                }
+            }
+            Err(failure) => {
+                let (destroy_job, reason, error) =
+                    failure.into_speculative_destroy_job(reuse_key, profile_name);
+                SpeculativeReparkResult::Destroy {
+                    destroy_job: Box::new(destroy_job),
+                    reason,
+                    error,
+                }
             }
         }
     }
@@ -304,6 +414,39 @@ impl IdleParkOutcome {
 }
 
 impl IdleParkFailure {
+    fn into_speculative_destroy_job(
+        self,
+        reuse_key: String,
+        profile_name: String,
+    ) -> (IdleDestroyJob, &'static str, String) {
+        let Self {
+            ownership,
+            reason,
+            error,
+        } = self;
+        let (payload, budget_lease) = match ownership {
+            IdleParkFailureOwnership::Active {
+                resources,
+                budget_lease,
+            } => (
+                resources
+                    .into_destroy_payload(WorkspacePromotionPolicy::AbandonUnpublished(reason)),
+                budget_lease,
+            ),
+            IdleParkFailureOwnership::Parked { rejected } => rejected.into_active_destroy_parts(),
+        };
+        (
+            IdleDestroyJob {
+                payload,
+                budget_lease,
+                reuse_key,
+                profile_name,
+            },
+            reason,
+            error,
+        )
+    }
+
     pub(crate) fn into_parts(self) -> IdleParkFailureParts {
         let Self {
             ownership,

--- a/crates/runner/src/idle_pool/park_transition_tests.rs
+++ b/crates/runner/src/idle_pool/park_transition_tests.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use guest_contracts::reuse_preparation::ReusePreparationRequest;
 use guest_contracts::session_history_identity::{
@@ -64,6 +64,7 @@ async fn make_idle_park_request(
         storage_fingerprints: StorageFingerprints::default(),
         restored_session_identity: None,
         history_generation_run_id: None,
+        guest_timezone_intent: crate::guest_timezone::GuestTimezoneIntent::Unknown,
         workspace_image_size_bytes: 0,
         workspace_promotion: None,
     })
@@ -233,6 +234,7 @@ async fn idle_park_request_success_preserves_reuse_metadata() {
         storage_fingerprints,
         restored_session_identity: Some(restored_session_identity.clone()),
         history_generation_run_id: Some(history_generation_run_id),
+        guest_timezone_intent: crate::guest_timezone::GuestTimezoneIntent::Unknown,
         workspace_image_size_bytes: 0,
         workspace_promotion: None,
     });
@@ -291,6 +293,57 @@ async fn idle_park_request_success_preserves_reuse_metadata() {
     );
     assert_eq!(budget_lease.vcpu(), 2);
     assert_eq!(budget_lease.memory_mb(), 2048);
+}
+
+#[tokio::test]
+async fn speculative_repark_preserves_original_idle_age_and_metadata() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    let history_generation_run_id = RunId::new_v4();
+    let mut request = make_idle_park_request(
+        Arc::clone(&overrides),
+        "session-speculative-repark",
+        make_budget_lease(2, 2048),
+    )
+    .await;
+    request.parts.history_generation_run_id = Some(history_generation_run_id);
+    request.parts.guest_timezone_intent =
+        crate::guest_timezone::GuestTimezoneIntent::Configured("Asia/Shanghai".into());
+    let candidate = match request.park_for_idle().await {
+        Ok(outcome) => outcome.expect_reusable(),
+        Err(_) => panic!("initial park should succeed"),
+    };
+    add_healthy_reuse_preparation_matcher(&overrides);
+
+    let original_parked_at = Instant::now() - Duration::from_secs(120);
+    let original_timeout = Duration::from_secs(300);
+    let reservation = ReservedIdleSandbox {
+        entry: candidate.into_idle_entry(original_parked_at, original_timeout),
+    };
+    let SpeculativeIdleUnparkResult::Ready(speculative) = reservation
+        .try_unpark_for_speculation(RunId::new_v4())
+        .await
+    else {
+        panic!("speculative unpark should succeed");
+    };
+    let SpeculativeReparkResult::Reparked(restored) = speculative
+        .repark_for_claim_rollback(RunId::new_v4(), 0)
+        .await
+    else {
+        panic!("speculative repark should succeed");
+    };
+
+    assert_eq!(restored.entry.parked_at, original_parked_at);
+    assert_eq!(restored.entry.idle_timeout, original_timeout);
+    assert_eq!(
+        restored.entry.metadata.history_generation_run_id,
+        Some(history_generation_run_id)
+    );
+    assert_eq!(
+        restored.guest_timezone_intent(),
+        &crate::guest_timezone::GuestTimezoneIntent::Configured("Asia/Shanghai".into())
+    );
+    assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.park_call_count(), 2);
 }
 
 #[tokio::test]

--- a/crates/runner/src/idle_pool/pool_tests.rs
+++ b/crates/runner/src/idle_pool/pool_tests.rs
@@ -173,6 +173,34 @@ async fn reserved_restore_rejects_after_parking_closes() {
     assert_eq!(pool.len(), 0);
 }
 
+#[tokio::test]
+async fn reserved_restore_rejects_an_entry_with_expired_original_age() {
+    let mut pool = IdlePool::new(pool_config(0));
+    let now = Instant::now();
+    let candidate = make_candidate_for("session-expired-reservation", 2, 2048);
+    assert!(matches!(
+        park_at(
+            &mut pool,
+            "session-expired-reservation",
+            candidate,
+            now - Duration::from_secs(301),
+            Duration::from_secs(300),
+        ),
+        ParkResult::Parked
+    ));
+    let reservation = ReservedIdleSandbox {
+        entry: pool
+            .take("session-expired-reservation")
+            .expect("expired entry should still be available for ownership testing"),
+    };
+
+    let RestoreReservedIdleResult::Rejected(rejected) = pool.restore_reserved(reservation) else {
+        panic!("originally expired reservation must not be restored");
+    };
+    rejected.run().await;
+    assert_eq!(pool.len(), 0);
+}
+
 #[test]
 fn park_uses_candidate_reuse_key_as_pool_key() {
     let mut pool = IdlePool::new(pool_config(0));

--- a/crates/runner/src/idle_pool/test_support.rs
+++ b/crates/runner/src/idle_pool/test_support.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
 use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
+use crate::guest_timezone::GuestTimezoneIntent;
 use crate::ids::RunId;
 use crate::resource_budget::BudgetLease;
 use crate::restored_session_identity::RestoredSessionIdentity;
@@ -28,6 +29,7 @@ pub(crate) struct ParkedIdleCandidateBuilder {
     storage_fingerprints: StorageFingerprints,
     restored_session_identity: Option<RestoredSessionIdentity>,
     history_generation_run_id: Option<RunId>,
+    guest_timezone_intent: GuestTimezoneIntent,
     last_completed_at: Option<String>,
     workspace_promotion: Option<WorkspaceImagePromotionContext>,
 }
@@ -49,6 +51,7 @@ impl ParkedIdleCandidateBuilder {
             storage_fingerprints: StorageFingerprints::default(),
             restored_session_identity: None,
             history_generation_run_id: None,
+            guest_timezone_intent: GuestTimezoneIntent::Unknown,
             last_completed_at: None,
             workspace_promotion: None,
         }
@@ -97,6 +100,14 @@ impl ParkedIdleCandidateBuilder {
         self
     }
 
+    pub(crate) fn with_guest_timezone_intent(
+        mut self,
+        guest_timezone_intent: GuestTimezoneIntent,
+    ) -> Self {
+        self.guest_timezone_intent = guest_timezone_intent;
+        self
+    }
+
     pub(crate) fn with_workspace_promotion(
         mut self,
         workspace_promotion: WorkspaceImagePromotionContext,
@@ -118,6 +129,7 @@ impl ParkedIdleCandidateBuilder {
             storage_fingerprints,
             restored_session_identity,
             history_generation_run_id,
+            guest_timezone_intent,
             last_completed_at,
             workspace_promotion,
         } = self;
@@ -130,6 +142,7 @@ impl ParkedIdleCandidateBuilder {
             storage_fingerprints,
             restored_session_identity,
             history_generation_run_id,
+            guest_timezone_intent,
             last_completed_at,
         };
         ParkedIdleCandidate {

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -12,6 +12,7 @@ mod error;
 mod executor;
 mod firewall_hostname_policy;
 mod group;
+mod guest_timezone;
 mod helper_exec;
 mod host;
 mod host_env;

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -90,6 +90,7 @@ pub struct MockJobProvider {
     /// `wait_completion` so a heartbeat that lands mid-check is still observed.
     heartbeat_notify: Arc<Notify>,
     heartbeat_control: Arc<MockHeartbeatControl>,
+    claim_control: Arc<MockClaimControl>,
 }
 
 /// Test-side handle for driving the mock provider.
@@ -111,6 +112,7 @@ pub struct MockProviderHandle {
     /// See [`MockJobProvider::heartbeat_notify`].
     heartbeat_notify: Arc<Notify>,
     heartbeat_control: Arc<MockHeartbeatControl>,
+    claim_control: Arc<MockClaimControl>,
 }
 
 #[derive(Clone)]
@@ -137,6 +139,14 @@ struct MockHeartbeatControl {
     state_changed: Notify,
 }
 
+#[derive(Default)]
+struct MockClaimControl {
+    blocked: AtomicBool,
+    in_flight: AtomicUsize,
+    release: Notify,
+    state_changed: Notify,
+}
+
 impl MockHeartbeatControl {
     fn enter(&self) -> MockHeartbeatInFlight<'_> {
         let in_flight = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
@@ -155,11 +165,39 @@ impl MockHeartbeatControl {
     }
 }
 
+impl MockClaimControl {
+    fn enter(&self) -> MockClaimInFlight<'_> {
+        self.in_flight.fetch_add(1, Ordering::SeqCst);
+        self.state_changed.notify_waiters();
+        MockClaimInFlight { control: self }
+    }
+
+    fn block(&self) {
+        self.blocked.store(true, Ordering::SeqCst);
+    }
+
+    fn unblock(&self) {
+        self.blocked.store(false, Ordering::SeqCst);
+        self.release.notify_waiters();
+    }
+}
+
 struct MockHeartbeatInFlight<'a> {
     control: &'a MockHeartbeatControl,
 }
 
+struct MockClaimInFlight<'a> {
+    control: &'a MockClaimControl,
+}
+
 impl Drop for MockHeartbeatInFlight<'_> {
+    fn drop(&mut self) {
+        self.control.in_flight.fetch_sub(1, Ordering::SeqCst);
+        self.control.state_changed.notify_waiters();
+    }
+}
+
+impl Drop for MockClaimInFlight<'_> {
     fn drop(&mut self) {
         self.control.in_flight.fetch_sub(1, Ordering::SeqCst);
         self.control.state_changed.notify_waiters();
@@ -258,6 +296,7 @@ impl MockJobProvider {
         let discover_started_count = Arc::new(AtomicUsize::new(0));
         let heartbeat_notify = Arc::new(Notify::new());
         let heartbeat_control = Arc::new(MockHeartbeatControl::default());
+        let claim_control = Arc::new(MockClaimControl::default());
         let provider = Arc::new(Self {
             startup_readiness: Arc::clone(&startup_readiness),
             discovery: Mutex::new(rx),
@@ -275,6 +314,7 @@ impl MockJobProvider {
             discover_started_count: Arc::clone(&discover_started_count),
             heartbeat_notify: Arc::clone(&heartbeat_notify),
             heartbeat_control: Arc::clone(&heartbeat_control),
+            claim_control: Arc::clone(&claim_control),
         });
         let handle = MockProviderHandle {
             startup_readiness,
@@ -290,6 +330,7 @@ impl MockJobProvider {
             discover_started_count,
             heartbeat_notify,
             heartbeat_control,
+            claim_control,
         };
         (provider, handle)
     }
@@ -446,6 +487,35 @@ impl MockProviderHandle {
             .clone()
     }
 
+    pub fn block_claims(&self) {
+        self.claim_control.block();
+    }
+
+    pub fn unblock_claims(&self) {
+        self.claim_control.unblock();
+    }
+
+    pub async fn wait_claim_in_flight(&self, expected: usize, timeout: Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let changed = self.claim_control.state_changed.notified();
+            tokio::pin!(changed);
+            changed.as_mut().enable();
+
+            if self.claim_control.in_flight.load(Ordering::SeqCst) == expected {
+                return true;
+            }
+
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            if tokio::time::timeout(remaining, changed).await.is_err() {
+                return false;
+            }
+        }
+    }
+
     pub fn deferred_poll_deadlines(&self) -> Vec<Instant> {
         self.deferred_poll_deadlines
             .lock()
@@ -528,6 +598,13 @@ impl JobProvider for MockJobProvider {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .push(candidate.clone());
+        let release = self.claim_control.release.notified();
+        tokio::pin!(release);
+        release.as_mut().enable();
+        let _in_flight = self.claim_control.enter();
+        if self.claim_control.blocked.load(Ordering::SeqCst) {
+            release.await;
+        }
         let context = self
             .claim_results
             .lock()

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -12,8 +12,8 @@
 //! For advanced control, create [`MockSandboxOverrides`] and pass it via
 //! [`MockSandboxRuntime::with_overrides`]. This enables pattern-matched exec
 //! results, shared read-file results, shared lifecycle behavior queues, custom
-//! `wait_process` exits, and durable [`MockLifecycleGate`] gates for lifecycle
-//! and cancellation testing.
+//! `wait_process` exits, and durable [`MockLifecycleGate`] gates for exec,
+//! lifecycle, and cancellation testing.
 //!
 //! ```toml
 //! [dev-dependencies]

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -40,6 +40,9 @@ pub(crate) struct ExecOverrideState {
     pub(crate) calls: Mutex<Vec<ExecCall>>,
     /// Wakes tests after an exec call is recorded.
     pub(crate) call_notify: tokio::sync::Notify,
+    /// Optional gate entered after every exec call is recorded but before its
+    /// configured result is selected.
+    pub(crate) lifecycle_gate: Mutex<Option<MockLifecycleGate>>,
 }
 
 #[derive(Default)]
@@ -342,6 +345,11 @@ impl MockSandboxOverrides {
             .wait_process_result_cancellations
             .lock_ignoring_poison()
             .push_back(cancel);
+    }
+
+    /// Block every `exec` call with a durable lifecycle gate after recording it.
+    pub fn set_exec_lifecycle_gate(&self, gate: MockLifecycleGate) {
+        *self.exec.lifecycle_gate.lock_ignoring_poison() = Some(gate);
     }
 
     /// Register a one-shot pattern matcher for an ordinary exited result.

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -17,16 +17,29 @@ pub(crate) struct ExecMatcherResult {
     pub(crate) result: ExecResult,
 }
 
+pub(crate) struct ExecMatcherBehavior {
+    pub(crate) pattern: String,
+    pub(crate) outcome: ExecMatcherOutcome,
+}
+
+pub(crate) enum ExecMatcherOutcome {
+    Return(ExecResult),
+    Error(SandboxError),
+    Panic(String),
+}
+
 #[derive(Default)]
 pub(crate) struct ExecOverrideState {
-    /// Pattern-matched exec results. First matching pattern wins and is
+    /// Pattern-matched exec behaviors. First matching pattern wins and is
     /// consumed (one-shot).
-    pub(crate) matchers: Mutex<Vec<ExecMatcherResult>>,
+    pub(crate) matchers: Mutex<Vec<ExecMatcherBehavior>>,
     /// Pattern-matched exec results that remain available for every matching
     /// call after one-shot matchers have been checked.
     pub(crate) persistent_matchers: Mutex<Vec<ExecMatcherResult>>,
     /// Recorded exec calls across all sandboxes built from this override set.
     pub(crate) calls: Mutex<Vec<ExecCall>>,
+    /// Wakes tests after an exec call is recorded.
+    pub(crate) call_notify: tokio::sync::Notify,
 }
 
 #[derive(Default)]
@@ -340,9 +353,13 @@ impl MockSandboxOverrides {
         self.exec
             .matchers
             .lock_ignoring_poison()
-            .push(ExecMatcherResult {
+            .push(ExecMatcherBehavior {
                 pattern: matcher.pattern,
-                result: ExecResult::new(matcher.exit_code, matcher.stdout, matcher.stderr),
+                outcome: ExecMatcherOutcome::Return(ExecResult::new(
+                    matcher.exit_code,
+                    matcher.stdout,
+                    matcher.stderr,
+                )),
             });
     }
 
@@ -355,17 +372,38 @@ impl MockSandboxOverrides {
         self.exec
             .matchers
             .lock_ignoring_poison()
-            .push(ExecMatcherResult {
+            .push(ExecMatcherBehavior {
                 pattern: pattern.into(),
-                result,
+                outcome: ExecMatcherOutcome::Return(result),
+            });
+    }
+
+    /// Register a one-shot pattern matcher that returns an exec transport error.
+    pub fn add_exec_error_matcher(&self, pattern: impl Into<String>, error: SandboxError) {
+        self.exec
+            .matchers
+            .lock_ignoring_poison()
+            .push(ExecMatcherBehavior {
+                pattern: pattern.into(),
+                outcome: ExecMatcherOutcome::Error(error),
+            });
+    }
+
+    /// Register a one-shot pattern matcher that panics from the exec boundary.
+    pub fn add_exec_panic_matcher(&self, pattern: impl Into<String>, message: impl Into<String>) {
+        self.exec
+            .matchers
+            .lock_ignoring_poison()
+            .push(ExecMatcherBehavior {
+                pattern: pattern.into(),
+                outcome: ExecMatcherOutcome::Panic(message.into()),
             });
     }
 
     /// Register a persistent matcher for an ordinary exited result.
     ///
-    /// One-shot matchers registered with [`Self::add_exec_matcher`] or
-    /// [`Self::add_exec_result_matcher`] take precedence. The persistent
-    /// matcher is not consumed and can serve repeated calls across sandboxes.
+    /// One-shot matchers take precedence. The persistent matcher is not
+    /// consumed and can serve repeated calls across sandboxes.
     pub fn add_persistent_exec_matcher(&self, matcher: ExecMatcher) {
         self.exec
             .persistent_matchers
@@ -383,6 +421,28 @@ impl MockSandboxOverrides {
     /// is captured before exec matchers or queued exec results are consumed.
     pub fn exec_calls(&self) -> Vec<ExecCall> {
         self.exec.calls.lock_ignoring_poison().clone()
+    }
+
+    /// Wait until at least `expected` exec calls have been recorded.
+    pub async fn wait_exec_call_count(&self, expected: usize, timeout: Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let notified = self.exec.call_notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            if self.exec.calls.lock_ignoring_poison().len() >= expected {
+                return true;
+            }
+
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            if tokio::time::timeout(remaining, notified).await.is_err() {
+                return false;
+            }
+        }
     }
 
     /// Return recorded write-file calls across all sandboxes built from this

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -451,6 +451,7 @@ impl Sandbox for MockSandbox {
         if let Some(overrides) = &self.overrides {
             overrides.exec.calls.lock_ignoring_poison().push(call);
             overrides.exec.call_notify.notify_waiters();
+            wait_lifecycle_gate(&overrides.exec.lifecycle_gate).await;
         }
         // Check pattern matchers before the FIFO queue.
         let result = if let Some(overrides) = &self.overrides {

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -14,7 +14,7 @@ use crate::call_records::{
     WaitProcessCall, WriteFileCall, WriteFilesCall,
 };
 use crate::lifecycle::{MockLifecycleGate, wait_lifecycle_gate};
-use crate::overrides::MockSandboxOverrides;
+use crate::overrides::{ExecMatcherOutcome, MockSandboxOverrides};
 use crate::support::{
     LockIgnoringPoison, MOCK_COPY_FILE_MAX_BYTES, validate_mock_copy_host_path,
     validate_mock_exec_env_keys, validate_mock_guest_file_path,
@@ -450,28 +450,39 @@ impl Sandbox for MockSandbox {
         self.exec_calls.lock_ignoring_poison().push(call.clone());
         if let Some(overrides) = &self.overrides {
             overrides.exec.calls.lock_ignoring_poison().push(call);
+            overrides.exec.call_notify.notify_waiters();
         }
         // Check pattern matchers before the FIFO queue.
         let result = if let Some(overrides) = &self.overrides {
-            let mut matchers = overrides.exec.matchers.lock_ignoring_poison();
-            if let Some(idx) = matchers
-                .iter()
-                .position(|m| request.cmd.contains(&m.pattern))
-            {
-                Ok(matchers.remove(idx).result)
-            } else if let Some(matcher) = overrides
-                .exec
-                .persistent_matchers
-                .lock_ignoring_poison()
-                .iter()
-                .find(|matcher| request.cmd.contains(&matcher.pattern))
-            {
-                Ok(clone_exec_result(&matcher.result))
-            } else {
-                self.exec_results
-                    .lock_ignoring_poison()
-                    .pop_front()
-                    .unwrap_or_else(|| Ok(default_exec_result()))
+            let matched = {
+                let mut matchers = overrides.exec.matchers.lock_ignoring_poison();
+                matchers
+                    .iter()
+                    .position(|matcher| request.cmd.contains(&matcher.pattern))
+                    .map(|index| matchers.remove(index).outcome)
+            };
+            match matched {
+                Some(ExecMatcherOutcome::Return(result)) => Ok(result),
+                Some(ExecMatcherOutcome::Error(error)) => Err(error),
+                Some(ExecMatcherOutcome::Panic(message)) => {
+                    std::panic::resume_unwind(Box::new(message))
+                }
+                None => {
+                    if let Some(matcher) = overrides
+                        .exec
+                        .persistent_matchers
+                        .lock_ignoring_poison()
+                        .iter()
+                        .find(|matcher| request.cmd.contains(&matcher.pattern))
+                    {
+                        Ok(clone_exec_result(&matcher.result))
+                    } else {
+                        self.exec_results
+                            .lock_ignoring_poison()
+                            .pop_front()
+                            .unwrap_or_else(|| Ok(default_exec_result()))
+                    }
+                }
             }
         } else {
             self.exec_results

--- a/crates/sandbox-mock/src/tests/exec.rs
+++ b/crates/sandbox-mock/src/tests/exec.rs
@@ -21,6 +21,36 @@ async fn sandbox_default_exec_succeeds() {
 }
 
 #[tokio::test]
+async fn sandbox_exec_lifecycle_gate_blocks_after_recording_call() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    let gate = MockLifecycleGate::new();
+    overrides.set_exec_lifecycle_gate(gate.clone());
+    let sandbox = MockSandbox::with_overrides("gated-exec", Arc::clone(&overrides));
+    let exec = tokio::spawn(async move {
+        sandbox
+            .exec(&ExecRequest {
+                cmd: "echo gated",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                expected_exit_codes: &[],
+                stdin_bytes: None,
+                output_limits: EXEC_OUTPUT_LIMIT_1_MIB,
+            })
+            .await
+    });
+
+    gate.wait_entered(1, Duration::from_secs(5)).await.unwrap();
+    assert_eq!(overrides.exec_calls().len(), 1);
+    assert!(!exec.is_finished());
+    gate.release_one();
+    assert_eq!(
+        exec.await.unwrap().unwrap().termination,
+        ExecTermination::Exited { exit_code: 0 }
+    );
+}
+
+#[tokio::test]
 async fn sandbox_exec_rejects_invalid_env_key_without_recording_call() {
     let sandbox = MockSandbox::new("test-1");
     let result = sandbox


### PR DESCRIPTION
## Summary

- overlap exact-generation sandbox activation and guest-state restoration with the provider claim
- preserve rollback ownership, original idle metadata, expiry, and capacity behavior when the claim does not commit
- verify the claimed timezone before agent startup, correct mismatches, and add phase telemetry for the overlap

## Compatibility

- changes runner-local in-memory lifecycle state only
- does not change API, queue, heartbeat, database, or persisted schemas
- preserves compatibility with independently deployed API and runner versions

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner -p sandbox-mock --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner -p sandbox-mock --all-features --no-deps`
- `cargo test -p sandbox-mock`
- `cargo test -p runner`

Closes #25240

Parent: #24870
