### PR TITLE
refactor: remove zero browser feature switch

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -240,51 +240,27 @@ describe("auth tokens", () => {
     expect(verifyZeroToken(eligibleToken)?.capabilities).toContain(
       "image-recognition:write",
     );
-    expect(decodeZeroTokenPayloadForTest(eligibleToken)).not.toHaveProperty(
-      "featureSwitchOverrides",
-    );
   });
 
-  it("gates browser capabilities on both the rollout and thread access", () => {
-    const defaultToken = generateZeroToken(
-      "user_zero",
-      "run_zero",
-      "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
-    );
+  it("gates browser capabilities on thread access", () => {
+    const defaultToken = generateZeroToken("user_zero", "run_zero", "org_zero");
     const enabledToken = generateZeroToken(
       "user_zero",
       "run_zero",
-      "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+      "org_zero",
       undefined,
       { cloudBrowserEnabled: true },
     );
-    const disabledToken = generateZeroToken(
-      "user_zero",
-      "run_zero",
-      "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
-      { [FeatureSwitchKey.ZeroBrowser]: false },
-      { cloudBrowserEnabled: true },
-    );
 
-    for (const token of [defaultToken, disabledToken]) {
-      expect(verifyZeroToken(token)?.capabilities).not.toContain(
-        "browser:read",
-      );
-      expect(verifyZeroToken(token)?.capabilities).not.toContain(
-        "browser:write",
-      );
-    }
+    expect(verifyZeroToken(defaultToken)?.capabilities).not.toContain(
+      "browser:read",
+    );
+    expect(verifyZeroToken(defaultToken)?.capabilities).not.toContain(
+      "browser:write",
+    );
     expect(verifyZeroToken(enabledToken)).toMatchObject({
       cloudBrowserEnabled: true,
       capabilities: expect.arrayContaining(["browser:read", "browser:write"]),
-    });
-    expect(decodeZeroTokenPayloadForTest(disabledToken)).not.toHaveProperty(
-      "cloudBrowserEnabled",
-    );
-    expect(decodeZeroTokenPayloadForTest(disabledToken)).toMatchObject({
-      featureSwitchOverrides: {
-        [FeatureSwitchKey.ZeroBrowser]: false,
-      },
     });
   });
 

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -27,8 +27,6 @@ const SANDBOX_TOKEN_TTL_SECONDS = 3 * 60 * 60;
 
 const CONDITIONAL_CAPABILITIES = [
   ["banking:read", FeatureSwitchKey.Banking],
-  ["browser:read", FeatureSwitchKey.ZeroBrowser],
-  ["browser:write", FeatureSwitchKey.ZeroBrowser],
   ["connector:write", FeatureSwitchKey.CustomConnectorCliCreate],
 ] as const satisfies readonly (readonly [ZeroCapability, FeatureSwitchKey])[];
 
@@ -76,7 +74,6 @@ const zeroTokenPayloadSchema = jwtBaseSchema.extend({
   runId: z.string().min(1),
   orgId: z.string().min(1),
   capabilities: zeroCapabilitiesSchema,
-  featureSwitchOverrides: z.record(z.string(), z.boolean()).optional(),
   computerUseHostId: z.string().uuid().optional(),
   cloudBrowserEnabled: z.literal(true).optional(),
 });
@@ -339,7 +336,6 @@ export function generateZeroToken(
     runId,
     orgId,
     capabilities,
-    ...(overrides === undefined ? {} : { featureSwitchOverrides: overrides }),
     ...(capabilities.includes("computer-use:write") &&
     options?.computerUseHostId
       ? { computerUseHostId: options.computerUseHostId }

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -112,7 +112,6 @@ import {
   setSecretKmsClientForTests,
   type SecretKmsClient,
 } from "../../../lib/secret-kms-client";
-import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 
 /**
  * RUN-01..04 and CHAIN-RUN: successful run dispatch and lifecycle.
@@ -9883,16 +9882,6 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     if (!actor.orgId) {
       throw new Error("Zero runner context requires an organization");
     }
-    await updateFeatureSwitchesForUser(
-      context,
-      {
-        ...actor,
-        orgId: actor.orgId,
-      },
-      {
-        [FeatureSwitchKey.ZeroBrowser]: true,
-      },
-    );
     bdd.acceptAgentStorageWrites();
     api.acceptStorageDownloads();
     api.acceptTelemetryIngest();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -15,7 +15,6 @@ import {
   chatThreadEventsContract,
   chatThreadsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { describe, expect, test as vitestTest } from "vitest";
 import { z } from "zod";
@@ -42,7 +41,6 @@ import {
   setBrowserTabSnapshotAsPreviousApi,
   setComputerUseHostAsPreviousApi,
 } from "./helpers/runtime-state";
-import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -287,9 +285,6 @@ async function reconcileBrowsers() {
 describe("zero browser route", () => {
   it("keeps managed browser access off for a default chat thread", async () => {
     const { runs, chat, actor, agent } = await setupBrowserScenario();
-    await updateFeatureSwitchesForUser(context, actor, {
-      [FeatureSwitchKey.ZeroBrowser]: true,
-    });
     const sent = await chat.requestSendEvent(
       actor,
       {
@@ -325,9 +320,6 @@ describe("zero browser route", () => {
 
   it("advertises managed browser access for an enabled chat thread", async () => {
     const { runs, chat, actor, agent } = await setupBrowserScenario();
-    await updateFeatureSwitchesForUser(context, actor, {
-      [FeatureSwitchKey.ZeroBrowser]: true,
-    });
     const sent = await chat.requestSendEvent(
       actor,
       {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -8,6 +8,7 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
 const LEGACY_MAIL_REPLY_FOLLOW_UP_SWITCH = "zeroMailReplyFollowUp";
+const LEGACY_ZERO_BROWSER_SWITCH = "zeroBrowser";
 
 function client() {
   return setupApp({ context })(zeroFeatureSwitchesContract);
@@ -43,6 +44,35 @@ describe("/api/zero/feature-switches", () => {
     expect(
       previousPlatformSwitches[LEGACY_MAIL_REPLY_FOLLOW_UP_SWITCH],
     ).toBeFalsy();
+  });
+
+  it("keeps the previous Platform Zero Browser switch on", async () => {
+    createZeroRouteMocks(context).clerk.session(
+      "user_legacy_zero_browser_test",
+      "org_legacy_zero_browser_test",
+      "org:member",
+    );
+    const response = await accept(
+      client().get({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const previousPlatformSwitches: Record<string, boolean> = {
+      [LEGACY_ZERO_BROWSER_SWITCH]: false,
+    };
+    for (const key of Object.keys(previousPlatformSwitches)) {
+      const value = response.body.effectiveSwitches[key];
+      if (value !== undefined) {
+        previousPlatformSwitches[key] = value;
+      }
+    }
+
+    expect(
+      response.body.effectiveSwitches[LEGACY_ZERO_BROWSER_SWITCH],
+    ).toBeTruthy();
+    expect(previousPlatformSwitches[LEGACY_ZERO_BROWSER_SWITCH]).toBeTruthy();
   });
 
   it("persists and activates inline templates for a non-staff org", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
@@ -20,6 +20,7 @@ const featureSwitchesAuthOptions = {
 } as const;
 
 const LEGACY_MAIL_REPLY_FOLLOW_UP_SWITCH = "zeroMailReplyFollowUp";
+const LEGACY_ZERO_BROWSER_SWITCH = "zeroBrowser";
 function featureSwitchResponseBody(params: {
   readonly orgId: string;
   readonly userId: string;
@@ -41,6 +42,9 @@ function featureSwitchResponseBody(params: {
   const effectiveSwitches = {
     ...registeredEffectiveSwitches,
     [LEGACY_MAIL_REPLY_FOLLOW_UP_SWITCH]: false,
+    // Platform bundles loaded before the Zero Browser full rollout still
+    // carry this key. Keep them enabled until the old frontend release drains.
+    [LEGACY_ZERO_BROWSER_SWITCH]: true,
   };
 
   return {

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -329,7 +329,6 @@ function buildIntegrationToolsPrompt(
 
 function buildAgentToolsPrompt(args: {
   readonly triggerSource: TriggerSource;
-  readonly zeroBrowserAvailable: boolean;
   readonly cloudBrowserEnabled: boolean | undefined;
   readonly mermaidDiagramsEnabled: boolean;
 }): string {
@@ -343,13 +342,13 @@ function buildAgentToolsPrompt(args: {
     '- Workflow and automation requests use the `workflow-setup` skill first, then follow its guidance. This covers creating, editing, inspecting, running, scheduling, enabling, disabling, copying, or deleting a workflow or automation, and any recurring or event-driven request (for example "every morning", "when a new email arrives", "whenever X happens", "monitor", "remind me", "keep this in sync") even when the user does not say the word "workflow".',
     "- Manage recurring workflow automations: `zero workflow automation --help`. Do NOT use /loop, cron tools (CronCreate, CronList, CronDelete), or ScheduleWakeup — they are not available.",
     "- Browser access: `agent-browser` provides rendered-page inspection and interaction. For one known public URL when you only need page content, prefer `zero scrape <url> --format markdown`; use `agent-browser` when you need browser state, authentication, JavaScript, screenshots, or interaction.",
-    ...(args.zeroBrowserAvailable && args.cloudBrowserEnabled === true
+    ...(args.cloudBrowserEnabled === true
       ? [
           "- Zero Browser and Zero Computer Use are separate surfaces. `zero browser use` creates, reuses, or resumes a remote browser owned by the current chat thread, attaches it to `agent-browser`, and gives the user an authenticated `/browsers/:threadId` live view they can take over. `zero computer-use` drives apps on a desktop host the user connected separately. Running `agent-browser` on its own drives a local browser inside this sandbox: it creates no Zero Browser session and no user-viewable link.",
           "- Zero Browser lifetime: `zero browser use` and `zero browser lease` each extend the session's idle lease by a fixed 10 minutes and report when Zero will reclaim it. The session survives the end of this run, so a later run in the same thread attaches to the same live window and the user can keep working in it. Call `zero browser lease` while a long task keeps the browser idle; a reclaimed session can still resume its saved login profile and reopen its last captured HTTP(S) tab URLs on a best-effort basis.",
         ]
       : []),
-    ...(args.zeroBrowserAvailable && args.cloudBrowserEnabled === false
+    ...(args.cloudBrowserEnabled === false
       ? [
           "- Zero Browser is currently off for this chat thread. When the task needs a user-viewable cloud browser, run `zero connector permission-request browser --permission browser:write`, give the authorization link to the user, and stop this run. Existing run tokens cannot be upgraded; continue in a new run after the user enables it.",
         ]
@@ -453,10 +452,6 @@ function buildAppendSystemPrompt(args: {
     identity,
     buildAgentToolsPrompt({
       triggerSource: args.triggerSource,
-      zeroBrowserAvailable: isFeatureEnabled(
-        FeatureSwitchKey.ZeroBrowser,
-        args.featureSwitchContext,
-      ),
       cloudBrowserEnabled: args.cloudBrowserEnabled,
       mermaidDiagramsEnabled: isFeatureEnabled(
         FeatureSwitchKey.MermaidDiagrams,

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { Command, Help } from "commander";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { buildZeroHelpText, registerZeroCommands } from "../zero";
 import { decodeZeroTokenPayload } from "../lib/api/zero-token";
 
@@ -48,11 +47,9 @@ function buildCommands(): Command[] {
   ];
 }
 
-function buildProgram(
-  featureSwitchOverrides?: Partial<Record<FeatureSwitchKey, boolean>>,
-): Command {
+function buildProgram(): Command {
   const prog = new Command();
-  registerZeroCommands(prog, buildCommands(), featureSwitchOverrides);
+  registerZeroCommands(prog, buildCommands());
   return prog;
 }
 
@@ -92,9 +89,6 @@ describe("decodeZeroTokenPayload", () => {
       orgId: "org-1",
       scope: "zero",
       capabilities: ["agent:read", "connector:read"],
-      featureSwitchOverrides: {
-        [FeatureSwitchKey.ZeroBrowser]: true,
-      },
       iat: 1000,
       exp: 2000,
     });
@@ -105,9 +99,6 @@ describe("decodeZeroTokenPayload", () => {
       orgId: "org-1",
       scope: "zero",
       capabilities: ["agent:read", "connector:read"],
-      featureSwitchOverrides: {
-        [FeatureSwitchKey.ZeroBrowser]: true,
-      },
       iat: 1000,
       exp: 2000,
     });
@@ -155,7 +146,7 @@ describe("registerZeroCommands", () => {
     const prog = buildProgram();
     expect(hiddenCommandNames(prog)).toEqual(["recognize"]);
     expect(registeredCommandNames(prog)).toContain("upgrade");
-    expect(registeredCommandNames(prog)).not.toContain("browser");
+    expect(visibleCommandNames(prog)).toContain("browser");
   });
 
   it("should hide unmapped commands and show capable ones with valid token", () => {
@@ -190,6 +181,7 @@ describe("registerZeroCommands", () => {
       "teams",
       "telegram",
       "phone",
+      "browser",
       "host",
       "maps",
       "weather",
@@ -203,17 +195,17 @@ describe("registerZeroCommands", () => {
     ]);
   });
 
-  it("should hide run-only commands and keep feature commands unregistered with malformed token", () => {
+  it("should hide run-only commands and keep global commands visible with malformed token", () => {
     vi.stubEnv("ZERO_TOKEN", "not-a-valid-token");
 
     const prog = buildProgram();
 
     expect(hiddenCommandNames(prog)).toEqual(["recognize"]);
     expect(registeredCommandNames(prog)).toContain("upgrade");
-    expect(registeredCommandNames(prog)).not.toContain("browser");
+    expect(visibleCommandNames(prog)).toContain("browser");
   });
 
-  it("should hide run-only commands and keep feature commands unregistered outside zero scope", () => {
+  it("should hide run-only commands and keep global commands visible outside zero scope", () => {
     const token = buildZeroToken({
       scope: "sandbox",
       capabilities: ["agent:read"],
@@ -224,7 +216,7 @@ describe("registerZeroCommands", () => {
 
     expect(hiddenCommandNames(prog)).toEqual(["recognize"]);
     expect(registeredCommandNames(prog)).toContain("upgrade");
-    expect(registeredCommandNames(prog)).not.toContain("browser");
+    expect(visibleCommandNames(prog)).toContain("browser");
   });
 
   it("should show globally enabled commands when capabilities array is empty", () => {
@@ -698,28 +690,12 @@ describe("registerZeroCommands", () => {
     expect(buildZeroHelpText()).toContain("Upgrade plan?");
   });
 
-  it("should register browser only when its feature switch and capability are enabled", () => {
-    const disabledToken = buildZeroToken({
-      scope: "zero",
-      userId: "user-1",
-      orgId: "org-1",
-      capabilities: ["browser:read"],
-      featureSwitchOverrides: {
-        [FeatureSwitchKey.ZeroBrowser]: false,
-      },
-    });
-    vi.stubEnv("ZERO_TOKEN", disabledToken);
-
-    expect(registeredCommandNames(buildProgram())).not.toContain("browser");
-
+  it("should expose browser when its capability is enabled", () => {
     const enabledToken = buildZeroToken({
       scope: "zero",
       userId: "user-1",
       orgId: "org-1",
       capabilities: ["browser:read"],
-      featureSwitchOverrides: {
-        [FeatureSwitchKey.ZeroBrowser]: true,
-      },
     });
     vi.stubEnv("ZERO_TOKEN", enabledToken);
 

--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -1,11 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { program, registerZeroCommands } from "../zero";
 
 describe("zero CLI program", () => {
-  registerZeroCommands(program, undefined, {
-    [FeatureSwitchKey.ZeroBrowser]: true,
-  });
+  registerZeroCommands(program);
   const commandNames = program.commands.map((cmd) => {
     return cmd.name();
   });

--- a/turbo/apps/cli/src/lib/api/zero-token.ts
+++ b/turbo/apps/cli/src/lib/api/zero-token.ts
@@ -1,12 +1,9 @@
-import type { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-
 export interface ZeroTokenPayload {
   userId: string;
   runId: string;
   orgId: string;
   scope: string;
   capabilities: string[];
-  featureSwitchOverrides?: Partial<Record<FeatureSwitchKey, boolean>>;
   iat: number;
   exp: number;
 }

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -2,8 +2,6 @@
 // Sentry must be initialized before any other imports
 import "./instrument.js";
 import { Command } from "commander";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { configureGlobalProxyFromEnv } from "./lib/network/proxy.js";
 import {
   decodeZeroTokenPayload,
@@ -71,15 +69,7 @@ const COMMAND_CAPABILITY_MAP: Record<
   banking: "banking:read",
 };
 
-const COMMAND_FEATURE_SWITCH_MAP: Readonly<
-  Partial<Record<string, FeatureSwitchKey>>
-> = {
-  browser: FeatureSwitchKey.ZeroBrowser,
-};
-
 const RUN_ONLY_COMMANDS = new Set(["recognize"]);
-
-type FeatureSwitchOverrides = Partial<Record<FeatureSwitchKey, boolean>>;
 
 const ZERO_COMMAND_DEFINITIONS: readonly ZeroCommandDefinition[] = [
   {
@@ -369,11 +359,7 @@ function buildDefaultCommands(): Command[] {
 function shouldHideCommand(
   name: string,
   payload: ZeroTokenPayload | undefined,
-  featureSwitchOverrides?: FeatureSwitchOverrides,
 ): boolean {
-  if (!isCommandFeatureEnabled(name, payload, featureSwitchOverrides)) {
-    return true;
-  }
   if (!payload) return RUN_ONLY_COMMANDS.has(name);
   const requiredCap = COMMAND_CAPABILITY_MAP[name];
   if (requiredCap === undefined) return true;
@@ -386,30 +372,12 @@ function shouldHideCommand(
   return !payload.capabilities.includes(requiredCap);
 }
 
-function isCommandFeatureEnabled(
-  name: string,
-  payload: ZeroTokenPayload | undefined,
-  featureSwitchOverrides?: FeatureSwitchOverrides,
-): boolean {
-  const featureSwitch = COMMAND_FEATURE_SWITCH_MAP[name];
-  const overrides = featureSwitchOverrides ?? payload?.featureSwitchOverrides;
-  return (
-    !featureSwitch ||
-    isFeatureEnabled(featureSwitch, {
-      userId: payload?.userId,
-      orgId: payload?.orgId,
-      overrides,
-    })
-  );
-}
-
 function addZeroCommand(
   prog: Command,
   cmd: Command,
   payload: ZeroTokenPayload | undefined,
-  featureSwitchOverrides?: FeatureSwitchOverrides,
 ): void {
-  const hidden = shouldHideCommand(cmd.name(), payload, featureSwitchOverrides);
+  const hidden = shouldHideCommand(cmd.name(), payload);
   prog.addCommand(cmd, hidden ? { hidden: true } : {});
 }
 
@@ -457,16 +425,12 @@ function commandExampleIfVisible(
   name: string,
   example: string,
   payload: ZeroTokenPayload | undefined,
-  featureSwitchOverrides?: FeatureSwitchOverrides,
 ): string[] {
-  return shouldHideCommand(name, payload, featureSwitchOverrides)
-    ? []
-    : [example];
+  return shouldHideCommand(name, payload) ? [] : [example];
 }
 
 export function buildZeroHelpText(
   payload: ZeroTokenPayload | undefined = decodeZeroTokenPayload(),
-  featureSwitchOverrides?: FeatureSwitchOverrides,
 ): string {
   const canReadHost = !payload || payload.capabilities.includes("host:read");
   const canWriteHost = !payload || payload.capabilities.includes("host:write");
@@ -482,20 +446,17 @@ export function buildZeroHelpText(
       "upgrade",
       "  Upgrade plan?         zero upgrade pro",
       payload,
-      featureSwitchOverrides,
     ),
     "  Send a Slack message?  zero slack message send --help",
     ...commandExampleIfVisible(
       "feishu",
       "  Send Feishu?          zero feishu message send --help",
       payload,
-      featureSwitchOverrides,
     ),
     ...commandExampleIfVisible(
       "mail",
       "  Link Gmail draft?     zero mail link --help",
       payload,
-      featureSwitchOverrides,
     ),
     "  Send Teams?           zero teams message send --help",
     "  Upload Teams?         zero teams upload-file --help",
@@ -517,7 +478,6 @@ export function buildZeroHelpText(
       "chat",
       '  Rename this chat?     zero chat rename "New title"',
       payload,
-      featureSwitchOverrides,
     ),
     "  Introduce Zero?       zero intro",
     "  List generators?       zero generate --help",
@@ -534,49 +494,41 @@ export function buildZeroHelpText(
       "maps",
       '  Get directions?       zero maps directions --origin "SFO" --destination "Mountain View" --json',
       payload,
-      featureSwitchOverrides,
     ),
     ...commandExampleIfVisible(
       "weather",
       "  Check weather?        zero weather current --lat 39.9042 --lng 116.4074 --json",
       payload,
-      featureSwitchOverrides,
     ),
     ...commandExampleIfVisible(
       "scrape",
       "  Scrape a web page?    zero scrape https://example.com --json",
       payload,
-      featureSwitchOverrides,
     ),
     ...commandExampleIfVisible(
       "web-search",
       '  Search the public web? zero web-search "latest news" --json',
       payload,
-      featureSwitchOverrides,
     ),
     ...commandExampleIfVisible(
       "recognize",
       '  Recognize an image?    zero recognize --file ./image.png --prompt "Describe it"',
       payload,
-      featureSwitchOverrides,
     ),
     ...commandExampleIfVisible(
       "finance",
       "  Get a market quote?   zero finance quote AAPL --json",
       payload,
-      featureSwitchOverrides,
     ),
     ...commandExampleIfVisible(
       "people-search",
       '  Find a professional?   zero people-search "platform engineering leaders" --json',
       payload,
-      featureSwitchOverrides,
     ),
     ...commandExampleIfVisible(
       "banking",
       "  Read bank data?       zero banking accounts --json",
       payload,
-      featureSwitchOverrides,
     ),
     "  Check your identity?   zero whoami",
   ];
@@ -596,16 +548,12 @@ export function buildZeroHelpText(
 export function registerZeroCommands(
   prog: Command,
   commands?: Command[],
-  featureSwitchOverrides?: FeatureSwitchOverrides,
 ): void {
   const token = process.env.ZERO_TOKEN;
   const payload = token ? decodeZeroTokenPayload(token) : undefined;
 
   for (const cmd of commands ?? buildDefaultCommands()) {
-    if (!isCommandFeatureEnabled(cmd.name(), payload, featureSwitchOverrides)) {
-      continue;
-    }
-    addZeroCommand(prog, cmd, payload, featureSwitchOverrides);
+    addZeroCommand(prog, cmd, payload);
   }
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
@@ -17,7 +17,6 @@ import { formatAppNumber } from "../../i18n/format.ts";
 import { i18n } from "../../i18n/index.ts";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
-import { zeroBrowserEnabled$ } from "../external/feature-switch.ts";
 import { pageSignal$ } from "../page-signal.ts";
 import { setAblyPayloadLoop$ } from "../realtime.ts";
 import { onRef, settle, setLoop, withCleanup } from "../utils.ts";
@@ -116,7 +115,7 @@ function createFitWindowSignals(
       aspectRatio: number,
       signal: AbortSignal,
     ): Promise<void> => {
-      if (!get(zeroBrowserEnabled$) || get(fittingWindowState$)) {
+      if (get(fittingWindowState$)) {
         return;
       }
       set(fittingWindowState$, true);
@@ -168,9 +167,6 @@ function createStartBrowserSignals({
 > {
   const startingState$ = state(false);
   const start$ = command(async ({ get, set }, signal: AbortSignal) => {
-    if (!get(zeroBrowserEnabled$)) {
-      return;
-    }
     const eventId = crypto.randomUUID();
     set(startingState$, true);
     if (optimisticEvents) {
@@ -216,9 +212,6 @@ function createCloseBrowserSignals({
   optimisticEvents,
 }: BrowserMutationSignalContext): Pick<BrowserSessionSignals, "close$"> {
   const close$ = command(async ({ get, set }, signal: AbortSignal) => {
-    if (!get(zeroBrowserEnabled$)) {
-      return;
-    }
     const eventId = crypto.randomUUID();
     if (optimisticEvents) {
       await set(
@@ -297,9 +290,6 @@ export function createBrowserSessionSignals(
   );
   const session$ = computed(async (get): Promise<ZeroBrowserSession | null> => {
     get(reloadVersion$);
-    if (!get(zeroBrowserEnabled$)) {
-      return null;
-    }
     const override = get(sessionOverride$);
     return override === undefined
       ? await fetchBrowserSession(
@@ -338,9 +328,6 @@ export function createBrowserSessionSignals(
       async ({ get, set }, _element: HTMLElement, signal: AbortSignal) => {
         await setLoop(
           async () => {
-            if (!get(zeroBrowserEnabled$)) {
-              return true;
-            }
             if (!viewerIsVisible()) {
               return false;
             }

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -67,7 +67,6 @@ import {
   chatThreadSidebarAutoOpenEnabled$,
   codexFastModeEnabled$,
   featureSwitch$,
-  zeroBrowserEnabled$,
   imageRecognitionAvailable$,
 } from "../external/feature-switch.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
@@ -1948,7 +1947,6 @@ function createEventChangeEffects(
       signal.throwIfAborted();
       if (
         !get(chatThreadSidebarAutoOpenEnabled$) ||
-        !get(zeroBrowserEnabled$) ||
         typeof window === "undefined" ||
         !window.matchMedia(CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY).matches
       ) {

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -103,10 +103,6 @@ export const mermaidDiagramsEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.MermaidDiagrams] ?? false;
 });
 
-export const zeroBrowserEnabled$ = computed((get): boolean => {
-  return get(featureSwitch$)[FeatureSwitchKey.ZeroBrowser] ?? false;
-});
-
 export const composerConnectorPermissionsEnabled$ = computed((get): boolean => {
   return (
     get(featureSwitch$)[FeatureSwitchKey.ComposerConnectorPermissions] ?? false

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -2,7 +2,6 @@ import { command, computed, state } from "ccstate";
 import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
 import type { PresentationTemplateItem } from "@vm0/core/presentation-template-items";
 import { localStorageSignals } from "../external/local-storage.ts";
-import { zeroBrowserEnabled$ } from "../external/feature-switch.ts";
 import { jsonParseOr, tapError } from "../utils.ts";
 import type { TemplatePreviewRuntime } from "./template-preview-runtime.ts";
 import {
@@ -36,16 +35,10 @@ const internalNewThreadComputerAccess$ = state<NewThreadComputerAccess | null>(
 export const newThreadComputerAccess$ = computed(
   (get): NewThreadComputerAccess => {
     const selection = get(internalNewThreadComputerAccess$);
-    const cloudBrowserAvailable = get(zeroBrowserEnabled$);
     if (selection === null) {
-      // Cloud browser is the default surface wherever Zero Browser is on.
-      return cloudBrowserAvailable
-        ? { kind: "cloudBrowser" }
-        : { kind: "none" };
+      return { kind: "cloudBrowser" };
     }
-    return selection.kind === "cloudBrowser" && !cloudBrowserAvailable
-      ? { kind: "none" }
-      : selection;
+    return selection;
   },
 );
 

--- a/turbo/apps/platform/src/views/browser-session/__tests__/browser-session-page.test.tsx
+++ b/turbo/apps/platform/src/views/browser-session/__tests__/browser-session-page.test.tsx
@@ -4,7 +4,6 @@ import {
   zeroBrowserContract,
   type ZeroBrowserSession,
 } from "@vm0/api-contracts/contracts/zero-browser";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -75,9 +74,6 @@ describe("browser session page", () => {
       detachedSetupPage({
         context,
         path: `/browsers/${threadId}`,
-        featureSwitches: {
-          [FeatureSwitchKey.ZeroBrowser]: true,
-        },
       });
 
       await expect(screen.findByText(title)).resolves.toBeInTheDocument();
@@ -92,7 +88,6 @@ describe("browser session page", () => {
     detachedSetupPage({
       context,
       path: "/browsers/not-a-thread-id",
-      featureSwitches: { [FeatureSwitchKey.ZeroBrowser]: true },
     });
 
     await expect(
@@ -120,7 +115,6 @@ describe("browser session page", () => {
     detachedSetupPage({
       context,
       path: `/browsers/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ZeroBrowser]: true },
     });
 
     await expect(
@@ -146,7 +140,6 @@ describe("browser session page", () => {
     detachedSetupPage({
       context,
       path: `/browsers/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ZeroBrowser]: true },
     });
 
     await expect(
@@ -176,7 +169,6 @@ describe("browser session page", () => {
     detachedSetupPage({
       context,
       path: `/browsers/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ZeroBrowser]: true },
     });
 
     const frame = await screen.findByTitle("Live browser: booking");
@@ -220,7 +212,6 @@ describe("browser session page", () => {
     detachedSetupPage({
       context,
       path: `/browsers/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ZeroBrowser]: true },
     });
 
     const start = await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -4,7 +4,6 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { describe, expect, it, vi } from "vitest";
 import { zeroVoiceIoQuotaContract } from "@vm0/api-contracts/contracts/zero-voice-io-quota";
 import { zeroComputerUseHostsContract } from "@vm0/api-contracts/contracts/zero-computer-use";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { fill } from "../../../__tests__/page-helper.ts";
 import {
   mockChatLifecycle,
@@ -85,7 +84,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ZeroBrowser]: true },
     });
 
     await waitFor(() => {
@@ -170,7 +168,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ZeroBrowser]: true },
     });
 
     await waitFor(() => {
@@ -212,7 +209,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: AGENT_CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.ZeroBrowser]: true },
     });
 
     await screen.findByPlaceholderText(PLACEHOLDER);
@@ -252,7 +248,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: AGENT_CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.ZeroBrowser]: true },
     });
 
     const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
@@ -285,7 +280,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: AGENT_CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.ZeroBrowser]: true },
     });
 
     const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
@@ -301,38 +295,6 @@ describe("chat lifecycle", () => {
     await user.keyboard("{Escape}");
 
     await sendMessageInUI(user, textarea, "Keep the cloud browser closed");
-
-    await waitFor(() => {
-      expect(sentCloudBrowserEnabled).toBeUndefined();
-    });
-  });
-
-  it("hides Cloud browser from a new chat thread when the feature is disabled", async () => {
-    const user = userEvent.setup({ delay: null });
-    let sentCloudBrowserEnabled: boolean | undefined;
-    mockChatLifecycle(context, {
-      onRunCreate: (body) => {
-        sentCloudBrowserEnabled = body.cloudBrowserEnabled;
-      },
-    });
-    context.mocks.api(zeroComputerUseHostsContract.list, ({ respond }) => {
-      return respond(200, { hosts: [] });
-    });
-
-    detachedSetupPage({ context, path: AGENT_CHAT_PATH });
-
-    const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
-    await user.click(await screen.findByLabelText("Connectors"));
-    expect(screen.getByText("Your computer")).toBeInTheDocument();
-    expect(
-      screen.queryByRole("switch", { name: "Disable Cloud browser" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("switch", { name: "Enable Cloud browser" }),
-    ).not.toBeInTheDocument();
-    await user.keyboard("{Escape}");
-
-    await sendMessageInUI(user, textarea, "No cloud browser here");
 
     await waitFor(() => {
       expect(sentCloudBrowserEnabled).toBeUndefined();
@@ -371,7 +333,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: AGENT_CHAT_PATH,
-      featureSwitches: { [FeatureSwitchKey.ZeroBrowser]: true },
     });
 
     const textarea = await screen.findByPlaceholderText(PLACEHOLDER);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -22,7 +22,6 @@ import {
   type UserPermissionGrantResponse,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse } from "msw";
@@ -3676,7 +3675,6 @@ describe("chat event action cards", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ZeroBrowser]: true },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -159,7 +159,6 @@ function setupArtifactCatalog(
 function setupChatThread({
   artifactFiles = [],
   autoOpenEnabled = false,
-  browserEnabled = true,
   waitForHistoryResponse,
   historyMessages = [],
   messages = [
@@ -191,7 +190,6 @@ function setupChatThread({
 }: {
   artifactFiles?: ChatThreadArtifactFile[];
   autoOpenEnabled?: boolean;
-  browserEnabled?: boolean;
   waitForHistoryResponse?: () => Promise<void>;
   historyMessages?: MockChatEventInput[];
   messages?: MockChatEventInput[];
@@ -280,7 +278,6 @@ function setupChatThread({
     path: THREAD_PATH,
     featureSwitches: {
       [FeatureSwitchKey.ChatThreadSidebarAutoOpen]: autoOpenEnabled,
-      [FeatureSwitchKey.ZeroBrowser]: browserEnabled,
     },
   });
 
@@ -331,14 +328,6 @@ function menuItemByText(text: string): HTMLElement {
 }
 
 describe("thread-owned utility sidebar", () => {
-  it("keeps the browser icon inert until the backend supports thread lifecycle", async () => {
-    setupChatThread({ browserEnabled: false });
-
-    const button = await screen.findByLabelText("Open browser");
-    expect(button).toBeDisabled();
-    expect(button).toHaveAttribute("aria-pressed", "false");
-  });
-
   it("always opens the thread browser from the header", async () => {
     context.mocks.api(zeroBrowserContract.get, ({ params, respond }) => {
       expect(params.threadId).toBe(THREAD_ID);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -126,7 +126,6 @@ function setupChatPage({
     },
     featureSwitches: {
       [FeatureSwitchKey.ChatThreadSidebarAutoOpen]: autoOpenEnabled,
-      [FeatureSwitchKey.ZeroBrowser]: true,
     },
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -264,7 +264,6 @@ interface ComposerComputerUse {
   readonly loading: boolean;
   readonly selectedHostId: string | null;
   readonly onChange: (hostId: string | null) => void;
-  readonly cloudBrowserAvailable: boolean;
   readonly cloudBrowserEnabled: boolean;
   readonly onCloudBrowserChange: (enabled: boolean) => void;
   readonly downloadUrl: string;
@@ -5999,54 +5998,48 @@ function ComputerUseConnectorMenuSection({
   const { t } = useTranslation();
   return (
     <div className="shrink-0 border-t border-border/50 bg-gray-50 p-1 dark:bg-gray-100">
-      {computerUse.cloudBrowserAvailable && (
-        <>
-          <div
-            onClick={() => {
-              computerUse.onCloudBrowserChange(
-                !computerUse.cloudBrowserEnabled,
-              );
-            }}
-            className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-gray-100 dark:hover:bg-gray-200"
-          >
-            <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
-              <IconWorld size={16} stroke={1.5} />
-            </span>
-            <span className="min-w-0 flex-1">
-              <span className="block truncate text-sm text-foreground">
-                {t(($) => {
-                  return $.chat.computerUse.cloudBrowser;
-                })}
-              </span>
-            </span>
-            <span
-              className="flex shrink-0 items-center"
-              onClick={(event) => {
-                event.stopPropagation();
-              }}
-            >
-              <LoadingSwitch
-                checked={computerUse.cloudBrowserEnabled}
-                onCheckedChange={onDomEventFn((enabled) => {
-                  computerUse.onCloudBrowserChange(enabled);
-                })}
-                loading={false}
-                ariaLabel={
-                  computerUse.cloudBrowserEnabled
-                    ? t(($) => {
-                        return $.chat.computerUse.disableCloudBrowser;
-                      })
-                    : t(($) => {
-                        return $.chat.computerUse.enableCloudBrowser;
-                      })
-                }
-                size="sm"
-              />
-            </span>
-          </div>
-          <div className="mx-2 my-1 border-t border-border/50" />
-        </>
-      )}
+      <div
+        onClick={() => {
+          computerUse.onCloudBrowserChange(!computerUse.cloudBrowserEnabled);
+        }}
+        className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-gray-100 dark:hover:bg-gray-200"
+      >
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
+          <IconWorld size={16} stroke={1.5} />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm text-foreground">
+            {t(($) => {
+              return $.chat.computerUse.cloudBrowser;
+            })}
+          </span>
+        </span>
+        <span
+          className="flex shrink-0 items-center"
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+        >
+          <LoadingSwitch
+            checked={computerUse.cloudBrowserEnabled}
+            onCheckedChange={onDomEventFn((enabled) => {
+              computerUse.onCloudBrowserChange(enabled);
+            })}
+            loading={false}
+            ariaLabel={
+              computerUse.cloudBrowserEnabled
+                ? t(($) => {
+                    return $.chat.computerUse.disableCloudBrowser;
+                  })
+                : t(($) => {
+                    return $.chat.computerUse.enableCloudBrowser;
+                  })
+            }
+            size="sm"
+          />
+        </span>
+      </div>
+      <div className="mx-2 my-1 border-t border-border/50" />
       <div className="px-2 pb-1 pt-1 text-xs text-muted-foreground">
         {t(($) => {
           return $.chat.computerUse.yourComputer;
@@ -7712,9 +7705,6 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
     computerUseHosts,
     storedComputerUseHostId,
   );
-  const featureSwitches = useGet(featureSwitch$);
-  const cloudBrowserAvailable =
-    featureSwitches[FeatureSwitchKey.ZeroBrowser] ?? false;
   const composerPageSignal = useGet(pageSignal$);
   const computerUse: ComposerComputerUse = {
     hosts: visibleComputerUseHosts(computerUseHosts, resolvedComputerUseHostId),
@@ -7728,8 +7718,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
         Reason.DomCallback,
       );
     },
-    cloudBrowserAvailable,
-    cloudBrowserEnabled: cloudBrowserAvailable && cloudBrowserEnabled,
+    cloudBrowserEnabled,
     onCloudBrowserChange: (enabled) => {
       detach(
         setCloudBrowserEnabled(enabled, composerPageSignal),

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -488,7 +488,6 @@ function BrowserMenuButton({ thread }: { thread: ChatPanelSignals }) {
   const { t } = useTranslation();
   const sidebarTarget = useGet(thread.sidebar.target$);
   const openBrowserSidebar = useSet(openThreadBrowserSession$);
-  const enabled = useGet(featureSwitch$)[FeatureSwitchKey.ZeroBrowser] ?? false;
 
   const open = sidebarTarget?.type === "browser";
   return (
@@ -497,22 +496,18 @@ function BrowserMenuButton({ thread }: { thread: ChatPanelSignals }) {
         <TooltipTrigger asChild>
           <button
             type="button"
-            disabled={!enabled}
             className={cn(
               "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md transition-colors duration-150",
               open
                 ? "bg-primary/10 text-primary"
                 : "text-muted-foreground/70 hover:bg-accent hover:text-foreground",
-              !enabled && "cursor-not-allowed opacity-50",
             )}
             aria-label={t(($) => {
               return $.chat.thread.openBrowser;
             })}
             aria-pressed={open}
             onClick={() => {
-              if (enabled) {
-                openBrowserSidebar(thread.threadId);
-              }
+              openBrowserSidebar(thread.threadId);
             }}
           >
             <IconWorld size={18} stroke={1.5} />

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -113,7 +113,6 @@ describe("getAllFeatureStates", () => {
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ZeroBrowser]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
@@ -140,7 +139,6 @@ describe("getAllFeatureStates", () => {
       orgId: "org_nonexistent",
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ZeroBrowser]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -39,7 +39,6 @@ export enum FeatureSwitchKey {
   PexelsConnector = "pexelsConnector",
   SpotifyConnector = "spotifyConnector",
   ZeroDebug = "zeroDebug",
-  ZeroBrowser = "zeroBrowser",
   Banking = "banking",
   Lab = "lab",
   NotionWorkflowAutomations = "notionWorkflowAutomations",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -433,13 +433,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ZeroBrowser]: {
-    maintainer: "liangyou@vm0.ai",
-    description:
-      "Enable thread-scoped Cloud browser access in chat and the Zero CLI.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ComposerConnectorPermissions]: {
     maintainer: "ming@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- remove the `ZeroBrowser` feature-switch key and registry entry after the fully rolled-out decision
- make the existing enabled behavior unconditional across the platform, API prompt, token capability calculation, and Zero CLI registration
- retain thread-scoped Cloud Browser authorization and the browser capability boundary

## Rollout decision and archaeology

- Terminal state: `fully-rolled-out`
- Decision basis: explicit request to fully roll out Zero Browser
- Introducing commit: `a56eeac6a74f30fae2fcfb2d69fa8b0840da6764` (`feat(zero): add managed browsers with shared user profiles (#22940)`)
- Parent comparison: the parent had no managed-browser rollout path; the introducing commit added the switch for the CLI entry point while keeping browser APIs and capabilities independent
- Staff rollout: `dc028c3ad8e9b562658189699f22686bae295597` (`feat(zero): enable zero browser for staff organizations (#23050)`)
- Thread/UI expansion: `0699a7935ad6994b00ad97c00a7aeae307dbd4d2` (`feat: add thread-scoped cloud browser access (#23253)`)
- New-chat default: `351f50fa166` made Cloud Browser the default wherever the switch was enabled
- State/guard follow-up: `34def5bba28` sourced browser state from chat events and added rollout guards
- Later refactor: `d6647b76063` retained the same rollout boundary

## Preserved behavior

- New chat threads default to Cloud Browser, and users can still turn it off or select a Computer Use host.
- Browser controls, sidebar opening, session fetch/start/close/fit, viewer keepalive, and auto-open behavior remain available.
- Zero tokens expose `browser:read` and `browser:write` only when the current thread grants Cloud Browser access.
- The Zero CLI still hides browser commands from a valid Zero-scoped token that lacks browser capabilities.
- The agent prompt still distinguishes thread-enabled, thread-disabled, and unspecified Cloud Browser access.
- Browser routes, services, schemas, migrations, provider integration, and thread authorization remain intact.

## Removed rollout behavior

- `FeatureSwitchKey.ZeroBrowser`, its registry entry, and staff-organization targeting
- platform availability signals, disabled UI, and no-op session lifecycle guards
- the CLI feature-switch command map and browser registration gate
- Zero-token `featureSwitchOverrides` transport used by the CLI rollout gate
- switch-specific fixtures and closed-rollout assertions

## Residue and dependency audit

- Second-round searches found no references to `FeatureSwitchKey.ZeroBrowser`, `zeroBrowserEnabled$`, `zeroBrowserAvailable`, `cloudBrowserAvailable`, `COMMAND_FEATURE_SWITCH_MAP`, `isCommandFeatureEnabled`, or the exact `"zeroBrowser"` key.
- Remaining browser capability strings and the “off for this chat thread” prompt are thread-authorization behavior, not rollout-switch behavior.
- `pnpm knip` on the same latest `origin/main`: exit 0 with 44 pre-existing configuration hints.
- `pnpm knip` after cleanup: exit 0 with the same 44 configuration hints and no new unused files, exports, or dependencies.

## Validation

Passed:

- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/zero-cli check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/zero-cli lint`
- `pnpm -F api lint`
- changed platform files: Oxlint, type-aware Oxlint, and ESLint with zero warnings
- 150 targeted tests:
  - core feature switches: 24
  - Zero CLI registration and capability visibility: 84
  - API token capabilities: 18
  - platform browser session/composer/card/sidebar/IDB coverage: 24

Locally blocked by the existing API runner-queue harness:

- `zero-browser.test.ts`: 2 passed, 10 failed; every failure occurs at `claimRunnerJob` with `404 Job not found in queue`
- targeted run-lifecycle prompt test: the same `claimRunnerJob` queue 404
- the same targeted Zero Browser test reproduces unchanged on a clean latest `origin/main` checkout

This PR is draft so the PR pipeline can validate the route/lifecycle coverage that the local runner-queue harness cannot currently execute.
