### PR TITLE
fix(chat): open avatar message templates at voice picker

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
+import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroAvatarVideoContract } from "@vm0/api-contracts/contracts/zero-avatar-video";
 import { avatarTemplateStylePresetId } from "@vm0/core/avatar-template";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -8,9 +9,11 @@ import { ILLUSTRATION_TEMPLATE_ITEMS } from "@vm0/core";
 
 import {
   detachedSetupPage,
+  fill,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { findComposerEditor } from "./chat-composer-test-helpers.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
 const context = testContext();
@@ -146,9 +149,17 @@ describe("user messages", () => {
         filterOptions: { languages: ["english"], useCases: [] },
       });
     });
+    let submittedTemplate: GenerationTemplateRequest | undefined;
     mockChatLifecycle(context, {
       threadId,
       threadTitle: "Avatar template reference",
+      onRunCreate(body) {
+        const templatePart = body.userMessage?.parts.find((part) => {
+          return part.type === "template";
+        });
+        submittedTemplate =
+          templatePart?.type === "template" ? templatePart.template : undefined;
+      },
       chatEvents: [
         {
           id: "00000000-0000-4000-8000-000000000749",
@@ -181,6 +192,8 @@ describe("user messages", () => {
     });
 
     await screen.findByLabelText("Template");
+    const editor = await findComposerEditor();
+    await fill(editor, "Reuse this avatar template");
     await user.click(
       await screen.findByLabelText(`Message template ${avatar.name}`),
     );
@@ -195,6 +208,21 @@ describe("user messages", () => {
     expect(
       within(dialog).queryByLabelText(`Select template ${avatar.name}`),
     ).not.toBeInTheDocument();
+
+    await user.click(
+      within(dialog).getByLabelText(`Select voice ${voice.name}`),
+    );
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(
+        screen.getByLabelText(`Preview template ${avatar.name}`),
+      ).toBeInTheDocument();
+    });
+    await user.click(screen.getByLabelText("Send"));
+
+    await waitFor(() => {
+      expect(submittedTemplate).toStrictEqual(template);
+    });
   });
 
   it("renders ordered snapshots with literal Markdown text", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
@@ -1,6 +1,8 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
+import { zeroAvatarVideoContract } from "@vm0/api-contracts/contracts/zero-avatar-video";
+import { avatarTemplateStylePresetId } from "@vm0/core/avatar-template";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { ILLUSTRATION_TEMPLATE_ITEMS } from "@vm0/core";
 
@@ -110,6 +112,89 @@ describe("user messages", () => {
     expect(
       document.querySelector("[data-composer-inline-template]"),
     ).toBeNull();
+  });
+
+  it("opens avatar message templates at the voice picker", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "b0000000-0000-4000-a000-000000000749";
+    const avatar = {
+      id: 81,
+      name: "Ada",
+      coverUrl: "https://example.com/ada.jpg",
+    };
+    const voice = {
+      id: "en-US-ChristopherNeural",
+      name: "Christopher",
+      sampleUrl: "https://example.com/christopher.mp3",
+      language: "English",
+      gender: "male",
+    };
+    const template = {
+      type: "video" as const,
+      selection: {
+        stylePresetId: avatarTemplateStylePresetId(avatar.id),
+        titleSnapshot: avatar.name,
+        previewUrl: avatar.coverUrl,
+        voiceId: voice.id,
+        aspectRatio: "landscape" as const,
+      },
+    };
+    context.mocks.api(zeroAvatarVideoContract.voices, ({ respond }) => {
+      return respond(200, {
+        voices: [voice],
+        hasMore: false,
+        filterOptions: { languages: ["english"], useCases: [] },
+      });
+    });
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Avatar template reference",
+      chatEvents: [
+        {
+          id: "00000000-0000-4000-8000-000000000749",
+          role: "user",
+          content: "Create an avatar video",
+          runId: "d0000000-0000-4000-a000-000000000749",
+          userMessage: {
+            version: 1,
+            parts: [
+              {
+                type: "template",
+                titleSnapshot: avatar.name,
+                template,
+              },
+              { type: "text", text: "Create an avatar video" },
+            ],
+          },
+          createdAt: "2026-08-05T10:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.JoggAiBuiltIn]: true,
+        [FeatureSwitchKey.StructuredPromptInlineTemplates]: true,
+      },
+    });
+
+    await screen.findByLabelText("Template");
+    await user.click(
+      await screen.findByLabelText(`Message template ${avatar.name}`),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    await expect(
+      within(dialog).findByText(`Choose a voice for ${avatar.name}`),
+    ).resolves.toBeInTheDocument();
+    expect(
+      within(dialog).getByLabelText(`Select voice ${voice.name}`),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      within(dialog).queryByLabelText(`Select template ${avatar.name}`),
+    ).not.toBeInTheDocument();
   });
 
   it("renders ordered snapshots with literal Markdown text", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -6860,6 +6860,9 @@ function UserMessageTemplateReference({
   const selectAvatarTemplateForVoice = useSet(
     signals.template.selectAvatarTemplateForVoice$,
   );
+  const setAvatarTemplateFilters = useSet(
+    signals.template.setAvatarTemplateFilters$,
+  );
   return (
     <button
       type="button"
@@ -6878,6 +6881,15 @@ function UserMessageTemplateReference({
       onClick={() => {
         const avatar = avatarTemplateSelection(part.template);
         if (avatar) {
+          setAvatarTemplateFilters({
+            aspectRatio:
+              avatar.aspectRatio === "landscape" ? "landscape" : "portrait",
+            style: undefined,
+            gender: undefined,
+            age: undefined,
+            scene: undefined,
+            ethnicity: undefined,
+          });
           selectAvatarTemplateForVoice({
             id: avatar.avatarId,
             name: avatar.title,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -6857,6 +6857,9 @@ function UserMessageTemplateReference({
   const setTemplatePickerSearch = useSet(
     signals.template.setTemplatePickerSearch$,
   );
+  const selectAvatarTemplateForVoice = useSet(
+    signals.template.selectAvatarTemplateForVoice$,
+  );
   return (
     <button
       type="button"
@@ -6873,6 +6876,14 @@ function UserMessageTemplateReference({
       className={STRUCTURED_INLINE_REFERENCE_CLASS}
       title={`${typeLabel ?? part.template.type} · ${part.titleSnapshot}`}
       onClick={() => {
+        const avatar = avatarTemplateSelection(part.template);
+        if (avatar) {
+          selectAvatarTemplateForVoice({
+            id: avatar.avatarId,
+            name: avatar.title,
+            coverUrl: avatar.previewUrl,
+          });
+        }
         setTemplatePickerCategory(
           templatePickerCategoryForReference(part.template),
         );


### PR DESCRIPTION
## Summary

- open avatar template references from chat messages directly at the voice selection step
- restore the referenced avatar snapshot and selected voice in the picker
- cover the chat-message interaction with a page-level test

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-user-messages.test.tsx`
