### PR TITLE
refactor: remove zero browser legacy switch response

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -8,7 +8,6 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
 const LEGACY_MAIL_REPLY_FOLLOW_UP_SWITCH = "zeroMailReplyFollowUp";
-const LEGACY_ZERO_BROWSER_SWITCH = "zeroBrowser";
 
 function client() {
   return setupApp({ context })(zeroFeatureSwitchesContract);
@@ -44,35 +43,6 @@ describe("/api/zero/feature-switches", () => {
     expect(
       previousPlatformSwitches[LEGACY_MAIL_REPLY_FOLLOW_UP_SWITCH],
     ).toBeFalsy();
-  });
-
-  it("keeps the previous Platform Zero Browser switch on", async () => {
-    createZeroRouteMocks(context).clerk.session(
-      "user_legacy_zero_browser_test",
-      "org_legacy_zero_browser_test",
-      "org:member",
-    );
-    const response = await accept(
-      client().get({
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    const previousPlatformSwitches: Record<string, boolean> = {
-      [LEGACY_ZERO_BROWSER_SWITCH]: false,
-    };
-    for (const key of Object.keys(previousPlatformSwitches)) {
-      const value = response.body.effectiveSwitches[key];
-      if (value !== undefined) {
-        previousPlatformSwitches[key] = value;
-      }
-    }
-
-    expect(
-      response.body.effectiveSwitches[LEGACY_ZERO_BROWSER_SWITCH],
-    ).toBeTruthy();
-    expect(previousPlatformSwitches[LEGACY_ZERO_BROWSER_SWITCH]).toBeTruthy();
   });
 
   it("persists and activates inline templates for a non-staff org", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
@@ -20,7 +20,6 @@ const featureSwitchesAuthOptions = {
 } as const;
 
 const LEGACY_MAIL_REPLY_FOLLOW_UP_SWITCH = "zeroMailReplyFollowUp";
-const LEGACY_ZERO_BROWSER_SWITCH = "zeroBrowser";
 function featureSwitchResponseBody(params: {
   readonly orgId: string;
   readonly userId: string;
@@ -42,9 +41,6 @@ function featureSwitchResponseBody(params: {
   const effectiveSwitches = {
     ...registeredEffectiveSwitches,
     [LEGACY_MAIL_REPLY_FOLLOW_UP_SWITCH]: false,
-    // Platform bundles loaded before the Zero Browser full rollout still
-    // carry this key. Keep them enabled until the old frontend release drains.
-    [LEGACY_ZERO_BROWSER_SWITCH]: true,
   };
 
   return {


### PR DESCRIPTION
## Summary

- remove the legacy `effectiveSwitches.zeroBrowser = true` response shim
- remove the compatibility-only API route test for old Platform bundles
- keep the fully rolled-out Zero Browser product behavior unchanged

## Feature-switch decision

- Terminal state: `fully-rolled-out`
- Decision basis: Zero Browser was fully rolled out in #25289, and the follow-up user decision explicitly rejects retaining the old-bundle compatibility response.
- Original feature introduction: `a56eeac6a7` (`feat(zero): add managed browsers with shared user profiles`)
- Registry/key cleanup: #25289
- Compatibility shim introduction: `252c2a0096`

## History and behavior audit

The remaining two-file diff was introduced solely by `252c2a0096`. This PR removes those exact compatibility additions: the dynamic legacy response key and the test that simulated a previous Platform bundle. It does not revert the Browser implementation or any of the unconditional behavior retained by #25289.

Broader searches for `ZeroBrowser`, `zeroBrowser`, `zero-browser`, and `zero_browser` still find the permanent Browser contracts, API services, CLI commands, and Platform UI. Those are product implementation rather than feature-switch remnants and remain intentionally.

Exact follow-up searches for `LEGACY_ZERO_BROWSER_SWITCH`, `legacy_zero_browser`, `previous Platform Zero Browser`, and the serialized `"zeroBrowser"` key under the feature-switch route and core registry return no matches.

## Knip

- Baseline: `pnpm knip` passed with 44 existing configuration hints.
- After cleanup: `pnpm knip` passed with the same 44 configuration hints and no cleanup-related orphaned code.

## Tests and validation

- `pnpm exec prettier --write apps/api/src/signals/routes/zero-feature-switches.ts apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts`
- `git diff --check`
- `pnpm --filter api lint`
- `pnpm --filter api check-types`
- Lefthook pre-commit: Prettier, Knip, and full `check-types` (12/12) passed
- Targeted route test attempted: `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-feature-switches.test.ts`
  - blocked before test execution because the local PostgreSQL service was unavailable (`ECONNREFUSED ::1:5432` / `127.0.0.1:5432`)

The PR pipeline should run the route test with its database service and complete the remaining repository checks.
