### PR TITLE
refactor(api): own connector auth-method feature switches

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -2057,14 +2057,14 @@ describe("connector catalog valid lifecycle", () => {
       manual: true,
     });
     const hidden = publicAuthMethod({
-      id: "api",
+      id: "oauth",
       grantKind: "manual",
       manual: true,
     });
     hidden.visible = false;
     const release = buildRelease({
       version: "2026-07-15.external-request-filters",
-      connectorSlug: "bentoml",
+      connectorSlug: "cal-com",
       mutateCatalog: (artifact) => {
         setArtifactAuthMethods(artifact, [gated, visible, hidden]);
       },
@@ -2083,7 +2083,7 @@ describe("connector catalog valid lifecycle", () => {
             revoke: "none",
           }),
           manualPrivateAuthMethod({
-            id: "api",
+            id: "oauth",
             prefix: "HIDDEN",
             access: "static",
             revoke: "none",
@@ -2114,7 +2114,7 @@ describe("connector catalog valid lifecycle", () => {
       featureClient.update({
         headers,
         body: {
-          switches: { [FeatureSwitchKey.BentomlConnector]: true },
+          switches: { [FeatureSwitchKey.CalComConnector]: true },
         },
       }),
       [200],

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -2051,7 +2051,6 @@ describe("connector catalog valid lifecycle", () => {
       grantKind: "manual",
       manual: true,
     });
-    gated.featureSwitch = "awsConnector";
     const visible = publicAuthMethod({
       id: "cli",
       grantKind: "manual",
@@ -2065,6 +2064,7 @@ describe("connector catalog valid lifecycle", () => {
     hidden.visible = false;
     const release = buildRelease({
       version: "2026-07-15.external-request-filters",
+      connectorSlug: "bentoml",
       mutateCatalog: (artifact) => {
         setArtifactAuthMethods(artifact, [gated, visible, hidden]);
       },
@@ -2114,7 +2114,7 @@ describe("connector catalog valid lifecycle", () => {
       featureClient.update({
         headers,
         body: {
-          switches: { [FeatureSwitchKey.AwsConnector]: true },
+          switches: { [FeatureSwitchKey.BentomlConnector]: true },
         },
       }),
       [200],
@@ -2127,23 +2127,28 @@ describe("connector catalog valid lifecycle", () => {
     ).toStrictEqual(["api-token", "cli"]);
     await accept(featureClient.delete({ headers }), [200]);
 
-    const unsupported = buildRelease({
-      version: "2026-07-15.external-all-incompatible",
+    const graduated = buildRelease({
+      version: "2026-07-15.external-graduated-switch",
       mutateCatalog: (artifact) => {
         const method = firstRecord(
           firstRecord(artifact.connectors, "connectors").authMethods,
           "authMethods",
         );
-        method.featureSwitch = "futureConnectorSwitch";
+        method.featureSwitch = "retiredConnectorSwitch";
       },
     });
-    serveObjects(catalogObjects([release, unsupported], unsupported));
+    serveObjects(catalogObjects([release, graduated], graduated));
     await syncCatalog();
-    const allFiltered = await accept(catalogClient.list({ headers }), [200]);
-    expect(allFiltered.body).toStrictEqual({
-      connectors: [],
-      categoryMetadata: { categories: [], groups: [] },
-    });
+    const graduatedVisible = await accept(
+      catalogClient.list({ headers }),
+      [200],
+    );
+    expect(graduatedVisible.body.connectors).toMatchObject([
+      {
+        slug: "external-test",
+        authMethods: [{ id: "api-token" }],
+      },
+    ]);
   });
 
   it("executes an external manual grant with catalog-owned storage", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -840,6 +840,11 @@ describe("GET /api/zero/connector-catalog", () => {
     );
 
     assertPublicConnectorCatalogHasNoPrivateFields(response.body);
+    expect(
+      response.body.connector.authMethods.map((method) => {
+        return method.id;
+      }),
+    ).toStrictEqual(["oauth", "api"]);
     const apiMethod = response.body.connector.authMethods.find((method) => {
       return method.id === "api";
     });

--- a/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
+++ b/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
@@ -1,0 +1,61 @@
+import type {
+  ConnectorAuthMethodId,
+  ConnectorSlug,
+} from "@vm0/api-contracts/contracts/connector-identity";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+
+/**
+ * vm0 owns rollout associations. Deploy an association before publishing a
+ * method that should be gated, and remove it when its switch graduates.
+ */
+const FEATURE_SWITCH_BY_AUTH_METHOD = Object.freeze<
+  Record<string, FeatureSwitchKey | undefined>
+>({
+  "ahrefs\0oauth": FeatureSwitchKey.AhrefsConnector,
+  "aws\0cli": FeatureSwitchKey.AwsConnector,
+  "bentoml\0api-token": FeatureSwitchKey.BentomlConnector,
+  "bill\0api-token": FeatureSwitchKey.BillConnector,
+  "box\0oauth": FeatureSwitchKey.BoxConnector,
+  "cal-com\0api-token": FeatureSwitchKey.CalComConnector,
+  "cal-com\0oauth": FeatureSwitchKey.CalComConnector,
+  "canva\0oauth": FeatureSwitchKey.CanvaConnector,
+  "close\0oauth": FeatureSwitchKey.CloseConnector,
+  "copper\0oauth": FeatureSwitchKey.CopperConnector,
+  "datadog\0oauth": FeatureSwitchKey.DatadogConnector,
+  "deel\0oauth": FeatureSwitchKey.DeelConnector,
+  "docusign\0oauth": FeatureSwitchKey.DocuSignConnector,
+  "dropbox\0oauth": FeatureSwitchKey.DropboxConnector,
+  "expensify\0api-token": FeatureSwitchKey.ExpensifyConnector,
+  "figma\0oauth": FeatureSwitchKey.FigmaConnector,
+  "garmin-connect\0oauth": FeatureSwitchKey.GarminConnectConnector,
+  "mailchimp\0oauth": FeatureSwitchKey.MailchimpConnector,
+  "mercury\0oauth": FeatureSwitchKey.MercuryConnector,
+  "meta-ads\0oauth": FeatureSwitchKey.MetaAdsConnector,
+  "neon\0oauth": FeatureSwitchKey.NeonConnector,
+  "netsuite\0api-token": FeatureSwitchKey.NetSuiteConnector,
+  "paypal\0api-token": FeatureSwitchKey.PayPalConnector,
+  "pexels\0api-token": FeatureSwitchKey.PexelsConnector,
+  "posthog\0oauth": FeatureSwitchKey.PosthogConnector,
+  "quickbooks\0oauth": FeatureSwitchKey.QuickBooksConnector,
+  "ramp\0api-token": FeatureSwitchKey.RampConnector,
+  "reddit\0oauth": FeatureSwitchKey.RedditConnector,
+  "spotify\0oauth": FeatureSwitchKey.SpotifyConnector,
+  "supabase\0oauth": FeatureSwitchKey.SupabaseConnector,
+  "test-oauth\0api": FeatureSwitchKey.TestOauthConnector,
+  "test-oauth\0api-token": FeatureSwitchKey.TestOauthConnector,
+  "test-oauth\0oauth": FeatureSwitchKey.TestOauthConnector,
+  "test-oauth-device\0api": FeatureSwitchKey.TestOauthConnector,
+  "test-oauth-device\0oauth": FeatureSwitchKey.TestOauthConnector,
+  "tiktok-ads\0oauth": FeatureSwitchKey.TikTokAdsConnector,
+  "webflow\0oauth": FeatureSwitchKey.WebflowConnector,
+  "workday\0api-token": FeatureSwitchKey.WorkdayConnector,
+  "zapier\0api-token": FeatureSwitchKey.ZapierConnector,
+  "zoom\0oauth": FeatureSwitchKey.ZoomConnector,
+});
+
+export function connectorAuthMethodFeatureSwitch(
+  connectorSlug: ConnectorSlug,
+  authMethodId: ConnectorAuthMethodId,
+): FeatureSwitchKey | undefined {
+  return FEATURE_SWITCH_BY_AUTH_METHOD[`${connectorSlug}\0${authMethodId}`];
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -15,7 +15,6 @@ import type {
   PublicConnectorCatalogStatusItem,
   PublicConnectorCatalogStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
   connectorCatalogActiveSnapshot,
   connectorCatalogCompatibilityEvaluation,
@@ -52,6 +51,7 @@ import {
   type ConnectorCatalogValidationAuthority,
 } from "./connector-catalog-validator-authority";
 import type { ApiDispatchTimingActionType } from "./api-dispatch-timing.service";
+import { connectorAuthMethodFeatureSwitch } from "./connector-auth-method-feature-switches";
 
 const log = logger("connector-catalog:reader");
 
@@ -175,14 +175,6 @@ function persistedCatalogValidationAuthority(args: {
         backendVersion: args.backendVersion,
         buildCommitSha: args.buildCommitSha,
       };
-}
-
-function isRecognizedFeatureSwitchKey(
-  value: string,
-): value is FeatureSwitchKey {
-  return Object.values(FeatureSwitchKey).some((key) => {
-    return key === value;
-  });
 }
 
 function requiredScopes(method: ConnectorCatalogAuthMethod): readonly string[] {
@@ -535,16 +527,15 @@ export async function loadAcceptedConnectorCatalogSnapshot(
  * ConnectorActionResolver intentionally does not read them.
  */
 function featureSwitchEnabled(
-  method: ConnectorCatalogAuthMethod,
+  connectorSlug: string,
+  authMethodId: string,
   featureStates: ConnectorFeatureStates,
 ): boolean {
-  if (method.featureSwitch === null) {
-    return true;
-  }
-  return (
-    isRecognizedFeatureSwitchKey(method.featureSwitch) &&
-    featureStates?.[method.featureSwitch] === true
+  const featureSwitch = connectorAuthMethodFeatureSwitch(
+    connectorSlug,
+    authMethodId,
   );
+  return featureSwitch === undefined || featureStates?.[featureSwitch] === true;
 }
 
 function effectiveConnectors(args: {
@@ -563,7 +554,9 @@ function effectiveConnectors(args: {
       if (!method.visible) {
         return false;
       }
-      if (!featureSwitchEnabled(method, args.featureStates)) {
+      if (
+        !featureSwitchEnabled(connector.slug, method.id, args.featureStates)
+      ) {
         return false;
       }
       return true;


### PR DESCRIPTION
## Summary

- move connector auth-method feature-switch associations into vm0
- filter connector discovery with vm0-owned `(connector slug, auth method id)` associations
- keep unmapped auth methods ungated and preserve discovery-independent authorization behavior
- cover mapped, shared, graduated, hidden, and manual-grant behavior at API route entry points

## Compatibility and scope

- preserves the external catalog schema and persisted v2 artifact format
- continues to parse legacy `featureSwitch` values but no longer treats producer metadata as rollout policy
- does not change database schemas, public API contracts, connector execution, frontend behavior, or runner protocols
- must deploy before vm0-connectors removes its legacy feature-switch metadata in vm0-connectors#114

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts src/signals/routes/__tests__/zero-connector-catalog.test.ts src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts --maxWorkers=4 --silent=passed-only`
- pre-commit full-workspace `pnpm knip` and `pnpm check-types`
- compared all 40 current vm0-connectors auth-method associations against the vm0 mapping

Closes #25290

Parent: #25287
