### PR TITLE
fix(api): seed chat event input context in benchmark

### DIFF
--- a/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
@@ -607,6 +607,7 @@ async function seedTargetThreadRuns(
     chatThreadId: string;
     runId: string;
     eventType: "input.prompt" | "output.message";
+    contextType?: "web";
     content?: string;
     sequenceNumber: number;
     seqId: number;
@@ -647,7 +648,10 @@ async function seedTargetThreadRuns(
         // Input events carry their text in user_message only; chat_events
         // rejects a non-null content projection for them.
         ...(m === 0
-          ? { userMessage: benchUserMessage(content, attachmentId) }
+          ? {
+              contextType: "web",
+              userMessage: benchUserMessage(content, attachmentId),
+            }
           : { content }),
         ...(attachmentId ? { attachFiles: [attachmentId] } : {}),
         createdAt: new Date(now + i * 1000 + m),


### PR DESCRIPTION
## Summary

- set the canonical `contextType: "web"` on only the `input.prompt` rows created by `seedTargetThreadRuns`
- keep the seeded `output.message` rows unchanged

## Root cause

PR #25305 (`8ff0ade1831b4092d2828beb78f18a3c57735229`) added `chat_events_input_context_type_check`, requiring non-null `context_type` for `input.prompt`, `input.automation`, and `input.goal` events.

`zero-chat-threads.bench.ts` directly constructs `eventRows`. The `m === 0` row for every seeded run is an `input.prompt`, but it had no `contextType`, so the insert failed deterministically. The later `no samples` result was downstream of that constraint violation.

- latest failure: https://github.com/vm0-ai/vm0/actions/runs/31014304455
- failing `bench-api` job: https://github.com/vm0-ai/vm0/actions/runs/31014304455/job/92334364645
- repeated failures: runs `31011185174`, `31013008740`, and `31013800944`

The canonical value follows the fixture updated by #25305: `triggerSource: "test"` input prompts use `contextType: "web"`.

## Verification

- `pnpm exec prettier --check apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm --filter @vm0/db db:migrate` against a fresh PostgreSQL 18 cluster
- `pnpm -F api exec vitest bench --run src/signals/routes/__benches__/zero-chat-threads.bench.ts` — passed; all 7 benchmark cases produced samples
- `git diff --check`
