### PR TITLE
feat(api): adopt connector catalog v3

### DIFF
--- a/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
@@ -127,7 +127,6 @@ function benchCatalogConnector(args: {
         label: "API token",
         description: null,
         visible: true,
-        featureSwitch: null,
         storage: {
           version: 1,
           secrets: [args.secretName],

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -96,7 +96,7 @@ const miscApi = createMiscRoutesApi(context);
 const CRON_SECRET = "connector-catalog-cron-secret";
 const OFFICIAL_RUNNER_AUTHORIZATION =
   "Bearer vm0_official_abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
-const ACTIVE_KEY = "connectors/v2/active.json";
+const ACTIVE_KEY = "connectors/v3/active.json";
 const FIRST_SYNC_TIME = "2026-07-15T08:00:00.000Z";
 const DIAGNOSTICS_USER_ID = `user_${randomUUID()}`;
 const DIAGNOSTICS_ORG_ID = `org_${randomUUID()}`;
@@ -208,7 +208,7 @@ function catalogTemplate(reference: string): string {
 function releaseKeys(version: string): {
   readonly catalog: string;
 } {
-  const prefix = `connectors/v2/releases/${version}`;
+  const prefix = `connectors/v3/releases/${version}`;
   return {
     catalog: `${prefix}/catalog.json`,
   };
@@ -352,7 +352,6 @@ function publicAuthMethod(args: {
     label: `${args.id} auth`,
     description: null,
     visible: true,
-    featureSwitch: null,
     grantKind: args.grantKind,
     manualFields: args.manual
       ? [
@@ -1053,7 +1052,6 @@ function canonicalAuthMethod(
         "label",
         "description",
         "visible",
-        "featureSwitch",
         "grantKind",
         "manualFields",
         "startOptions",
@@ -1067,7 +1065,6 @@ function canonicalAuthMethod(
     label: publicMethod.label,
     description: publicMethod.description,
     visible: publicMethod.visible,
-    featureSwitch: publicMethod.featureSwitch,
     ...(privateMethod.client === undefined
       ? {}
       : { client: privateMethod.client }),
@@ -1096,7 +1093,7 @@ function buildRelease(options: ReleaseFixtureOptions): ReleaseFixture {
     "platform/views/zero-page/components/settings/icons/" +
     `${connectorSlug}-${iconDigest.slice("sha256:".length, 19)}.svg`;
   const catalog: JsonRecord = {
-    artifactSchemaVersion: 2,
+    artifactSchemaVersion: 3,
     catalogVersion: options.version,
     categoryMetadata: {
       categories: [
@@ -1942,7 +1939,7 @@ describe("connector catalog valid lifecycle", () => {
     await replaceApiTestConnectorCatalogStoredBytes({
       catalogVersion: schemaRelease.version,
       rawBytes: jsonBytes({
-        artifactSchemaVersion: 3,
+        artifactSchemaVersion: 4,
         catalogVersion: schemaRelease.version,
       }),
       catalogValidationAuthority: apiTestConnectorCatalogValidationAuthority(),
@@ -1964,7 +1961,7 @@ describe("connector catalog valid lifecycle", () => {
     await replaceApiTestConnectorCatalogStoredBytes({
       catalogVersion: shapeRelease.version,
       rawBytes: jsonBytes({
-        artifactSchemaVersion: 2,
+        artifactSchemaVersion: 3,
       }),
       catalogValidationAuthority: apiTestConnectorCatalogValidationAuthority(),
     });
@@ -2129,13 +2126,6 @@ describe("connector catalog valid lifecycle", () => {
 
     const graduated = buildRelease({
       version: "2026-07-15.external-graduated-switch",
-      mutateCatalog: (artifact) => {
-        const method = firstRecord(
-          firstRecord(artifact.connectors, "connectors").authMethods,
-          "authMethods",
-        );
-        method.featureSwitch = "retiredConnectorSwitch";
-      },
     });
     serveObjects(catalogObjects([release, graduated], graduated));
     await syncCatalog();
@@ -3261,7 +3251,6 @@ describe("connector catalog valid lifecycle", () => {
           id: "api",
           grantKind: "device-auth",
         });
-        method.featureSwitch = "testOauthConnector";
         method.startOptions = [
           {
             id: "environment",
@@ -3439,7 +3428,6 @@ describe("connector catalog valid lifecycle", () => {
           id: "cli",
           grantKind: "external-code",
         });
-        method.featureSwitch = "awsConnector";
         setArtifactAuthMethods(artifact, [method]);
       },
       mutateRuntime: (artifact) => {
@@ -4140,7 +4128,6 @@ describe("connector catalog valid lifecycle", () => {
           id: "oauth",
           grantKind: "auth-code",
         });
-        method.featureSwitch = "datadogConnector";
         setArtifactAuthMethods(artifact, [method]);
       },
       mutateRuntime: (artifact) => {
@@ -4228,7 +4215,6 @@ describe("connector catalog valid lifecycle", () => {
           id: "oauth",
           grantKind: "auth-code",
         });
-        method.featureSwitch = "datadogConnector";
         setArtifactAuthMethods(artifact, [method]);
       },
       mutateRuntime: (artifact) => {
@@ -5286,26 +5272,6 @@ describe("connector catalog executable compatibility", () => {
     });
   });
 
-  it("leaves feature-switch rollout out of executable compatibility", async () => {
-    configureSource();
-    const unknownSwitch = buildRelease({
-      version: "2026-07-15.unknown-feature-switch",
-      mutateCatalog: (artifact) => {
-        const method = firstRecord(
-          firstRecord(artifact.connectors, "connectors").authMethods,
-          "authMethods",
-        );
-        method.featureSwitch = "futureConnectorSwitch";
-      },
-    });
-    serveObjects(catalogObjects([unknownSwitch], unknownSwitch));
-
-    expect((await syncCatalog()).body.filtering).toMatchObject({
-      stale: false,
-      filteredAuthMethods: [],
-    });
-  });
-
   it("accepts inline confidential test clients and applies rollout at request time", async () => {
     mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
     const provider = mockTestOAuthAuthCodeProvider({
@@ -5316,7 +5282,6 @@ describe("connector catalog executable compatibility", () => {
       id: "oauth",
       grantKind: "auth-code",
     });
-    method.featureSwitch = "testOauthConnector";
     const release = buildRelease({
       version: "2026-07-24.inline-confidential-test-client",
       connectorSlug: "test-oauth",
@@ -5984,7 +5949,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
           version: "legacy-pointer-reference",
           mutatePointer: (pointer) => {
             pointer.integrity = {
-              key: "connectors/v2/releases/legacy-pointer-reference/integrity/catalog.json",
+              key: "connectors/v3/releases/legacy-pointer-reference/integrity/catalog.json",
               digest: pointer.catalogDigest,
             };
             delete pointer.catalogDigest;
@@ -6011,7 +5976,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
         return buildRelease({
           version: "unsupported-schema",
           mutateArtifact: (artifact) => {
-            artifact.artifactSchemaVersion = 3;
+            artifact.artifactSchemaVersion = 4;
           },
         });
       },

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
@@ -17,7 +17,6 @@ import {
   connectorAccessSourceSchema,
   connectorAuthClientSourceSchema,
   connectorAuthMethodIdSchema,
-  connectorFeatureSwitchKeySchema,
   connectorRevokeSourceSchema,
   connectorStorageSourceSchema,
   connectorValueRefSchema,
@@ -26,7 +25,7 @@ import {
 } from "./source";
 import { isConnectorCatalogIconKey } from "./icon";
 
-export const SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION = 2;
+export const SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION = 3;
 export const CONNECTOR_CATALOG_ACTIVE_KEY = `connectors/v${SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION}/active.json`;
 
 export const CONNECTOR_CATALOG_MAX_RAW_BYTES = 8 * 1024 * 1024;
@@ -140,7 +139,6 @@ export const connectorCatalogAuthMethodSchema = z
     label: z.string().min(1),
     description: z.string().min(1).nullable(),
     visible: z.boolean(),
-    featureSwitch: connectorFeatureSwitchKeySchema.nullable(),
     client: connectorAuthClientSourceSchema.optional(),
     storage: connectorStorageSourceSchema,
     grant: connectorCatalogGrantSchema,

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-leak.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-leak.ts
@@ -251,7 +251,6 @@ function publicConnector(connector: ConnectorCatalogArtifactConnector) {
         label: method.label,
         description: method.description,
         visible: method.visible,
-        featureSwitch: method.featureSwitch,
         grant: publicGrant(method),
       };
     }),

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
@@ -151,9 +151,6 @@ function validateConnectorSemantics(artifact: ConnectorCatalogArtifact): void {
           label: method.label,
           description: method.description,
           visible: method.visible,
-          ...(method.featureSwitch === null
-            ? {}
-            : { featureSwitch: method.featureSwitch }),
           ...(method.client === undefined ? {} : { client: method.client }),
           storage: method.storage,
           grant: sourceGrant(method),

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/source.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/source.ts
@@ -3,10 +3,6 @@ import { z } from "zod";
 import { connectorCatalogVersionSchema, privateNameSchema } from "./common";
 
 export const publicFieldIdSchema = z.string().regex(/^[a-z][a-zA-Z0-9]*$/u);
-export const connectorFeatureSwitchKeySchema = z
-  .string()
-  .max(128)
-  .regex(/^[a-z][a-zA-Z0-9]*$/u);
 export const internalOptionNameSchema = z
   .string()
   .regex(/^[a-zA-Z][a-zA-Z0-9_]*$/u);
@@ -245,7 +241,6 @@ const connectorAuthMethodSourceSchema = z
     label: z.string().min(1),
     description: z.string().min(1).nullable(),
     visible: z.boolean(),
-    featureSwitch: connectorFeatureSwitchKeySchema.optional(),
     client: connectorAuthClientSourceSchema.optional(),
     storage: connectorStorageSourceSchema,
     grant: connectorGrantSourceSchema,

--- a/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
@@ -157,7 +157,6 @@ interface ProviderMethodArgs {
   readonly label?: string;
   readonly description?: string | null;
   readonly visible?: boolean;
-  readonly featureSwitch?: string | null;
   readonly scopes?: readonly string[];
   readonly fields?: readonly ManualField[];
   readonly startOptions?: readonly DeviceStartOption[];
@@ -304,7 +303,6 @@ function providerMethod(args: ProviderMethodArgs): ConnectorCatalogAuthMethod {
         ? "Test connector authorization."
         : args.description,
     visible: args.visible ?? true,
-    featureSwitch: args.featureSwitch ?? null,
     ...(client === undefined ? {} : { client }),
     storage: storageFromValueRefs(args.values),
     grant: providerGrant({
@@ -332,7 +330,6 @@ interface ManualMethodArgs {
   readonly label?: string;
   readonly description?: string | null;
   readonly visible?: boolean;
-  readonly featureSwitch?: string | null;
   readonly fields: readonly ManualField[];
   readonly envBindings: EnvironmentBindings;
   readonly additionalSecrets?: readonly string[];
@@ -353,7 +350,6 @@ function manualMethod(args: ManualMethodArgs): ConnectorCatalogAuthMethod {
         ? "Enter test connector credentials."
         : args.description,
     visible: args.visible ?? true,
-    featureSwitch: args.featureSwitch ?? null,
     storage: {
       version: 1,
       secrets: [...secrets],
@@ -371,7 +367,6 @@ interface StandardOauthMethodArgs {
   readonly tokenEnvironmentNames: readonly string[];
   readonly additionalValues?: Readonly<Record<string, string>>;
   readonly scopes?: readonly string[];
-  readonly featureSwitch?: string;
   readonly label?: string;
   readonly callbackDescription?: string;
   readonly platformEnvironmentNames?: readonly string[];
@@ -407,7 +402,6 @@ function standardOauthMethod(
     label: args.label ?? "OAuth",
     description:
       args.callbackDescription ?? "Sign in to the test connector provider.",
-    featureSwitch: args.featureSwitch,
     scopes: args.scopes,
     refreshableSecrets: [accessTokenName],
   });
@@ -599,7 +593,6 @@ const connectors = [
         connectorSlug: "aws",
         authMethodId: "cli",
         clientId: "arn:aws:signin:::devtools/cross-device",
-        featureSwitch: "awsConnector",
         scopes: ["openid"],
         values: {
           accessKeyId: secret("AWS_ACCESS_KEY_ID"),
@@ -661,7 +654,6 @@ const connectors = [
     label: "BentoML",
     authMethods: [
       manualMethod({
-        featureSwitch: "bentomlConnector",
         fields: [
           manualField({
             privateName: "BENTO_CLOUD_API_KEY",
@@ -771,7 +763,6 @@ const connectors = [
       providerMethod({
         connectorSlug: "datadog",
         authMethodId: "oauth",
-        featureSwitch: "datadogConnector",
         values: {
           accessToken: secret("DATADOG_ACCESS_TOKEN"),
           domain: variable("DATADOG_DOMAIN"),
@@ -802,7 +793,6 @@ const connectors = [
         connectorSlug: "figma",
         prefix: "FIGMA",
         tokenEnvironmentNames: ["FIGMA_TOKEN"],
-        featureSwitch: "figmaConnector",
       }),
       manualMethod({
         fields: [
@@ -1150,7 +1140,6 @@ const connectors = [
         connectorSlug: "neon",
         prefix: "NEON",
         tokenEnvironmentNames: ["NEON_TOKEN"],
-        featureSwitch: "neonConnector",
       }),
       manualMethod({
         fields: [
@@ -1561,7 +1550,6 @@ const connectors = [
         authMethodId: "oauth",
         clientId: "test-oauth-client",
         clientSecret: "test-oauth-secret",
-        featureSwitch: "testOauthConnector",
         scopes: ["read"],
         values: {
           accessToken: secret("TEST_OAUTH_ACCESS_TOKEN"),
@@ -1579,7 +1567,6 @@ const connectors = [
         authMethodId: "api",
         clientId: "test-oauth-client",
         clientSecret: "test-oauth-secret",
-        featureSwitch: "testOauthConnector",
         scopes: ["read"],
         values: {
           initialAccessToken: secret("TEST_OAUTH_API_ACCESS_TOKEN"),
@@ -1600,7 +1587,6 @@ const connectors = [
       providerMethod({
         connectorSlug: "test-oauth",
         authMethodId: "api-token",
-        featureSwitch: "testOauthConnector",
         values: {
           inputSecret: secret("TEST_OAUTH_TOKEN"),
           inputVariable: variable("TEST_OAUTH_API_TOKEN_INPUT_VAR"),
@@ -1658,7 +1644,6 @@ const connectors = [
         connectorSlug: "test-oauth-device",
         authMethodId: "oauth",
         clientId: "test-oauth-device-client",
-        featureSwitch: "testOauthConnector",
         scopes: ["read"],
         values: {
           accessToken: secret("TEST_OAUTH_DEVICE_ACCESS_TOKEN"),
@@ -1671,7 +1656,6 @@ const connectors = [
         connectorSlug: "test-oauth-device",
         authMethodId: "api",
         clientId: "test-oauth-device-api-client",
-        featureSwitch: "testOauthConnector",
         scopes: ["read"],
         values: {
           accessToken: secret("TEST_OAUTH_DEVICE_API_ACCESS_TOKEN"),
@@ -1767,8 +1751,8 @@ const connectors = [
 ] satisfies readonly ConnectorCatalogArtifactConnector[];
 
 export const API_TEST_CONNECTOR_CATALOG_ARTIFACT = {
-  artifactSchemaVersion: 2,
-  catalogVersion: "api-test-v2",
+  artifactSchemaVersion: 3,
+  catalogVersion: "api-test-v3",
   categoryMetadata: {
     categories: [
       {


### PR DESCRIPTION
## Summary

- switch the strict connector catalog consumer from schema v2 to schema v3 and the `connectors/v3` R2 namespace
- remove producer-owned `featureSwitch` metadata from source, artifact, semantic reconstruction, and leak projections
- update shared fixtures, benchmarks, and existing catalog lifecycle coverage to use field-less v3 while preserving vm0-owned rollout evaluation

## Deployment

Production v3 is already published in R2 as `2026-08-05.27` with digest `sha256:088a853f7332dfff8c420e0a1d1f46d5bcb568441f52392136c1cb71a79d9b3b`.

This PR intentionally supports v3 only. It adds no v2 parser, request fallback, dual-generation query path, migration, or cleanup debt. Older API builds retain their existing v2 state during rollout and explicit rollback. The new build remains fail-closed until the existing minute cron accepts its first v3 snapshot.

There are no public API, runner/frontend protocol, database schema, backfill, environment, or historical-data changes.

## Validation

- `pnpm -F api lint`
- `pnpm -F api check-types`
- 11 affected API integration files: 460 tests passed
- `pnpm knip --workspace api`
- full pre-commit formatting, Knip, and Turbo type checks
- `git diff --check`

Closes #25291
