### PR TITLE
refactor: reduce fallback slop in internal contracts

### DIFF
--- a/turbo/apps/api/src/signals/services/cli-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/cli-auth.service.ts
@@ -223,7 +223,7 @@ export const ensureTestOrg$ = command(
     if (!cached) {
       await writeDb.insert(orgCache).values({
         orgId: org.id,
-        name: org.name ?? org.slug ?? org.id,
+        name: org.name,
         cachedAt: new Date(nowDate().getTime() + FAR_FUTURE_CACHE_MS),
       });
       signal.throwIfAborted();
@@ -315,13 +315,13 @@ export const resolveTestOrgId$ = command(
         .insert(orgCache)
         .values({
           orgId: org.id,
-          name: org.name ?? org.slug ?? org.id,
+          name: org.name,
           cachedAt,
         })
         .onConflictDoUpdate({
           target: orgCache.orgId,
           set: {
-            name: org.name ?? org.slug ?? org.id,
+            name: org.name,
             cachedAt,
           },
         });

--- a/turbo/apps/api/src/signals/services/zero-workflow-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-data.service.ts
@@ -434,7 +434,7 @@ export async function loadWorkflowOwnerProfile(
 
   if (cachedRow?.name || cachedRow?.email || cachedRow?.imageUrl) {
     return {
-      displayName: cachedRow.name ?? cachedRow.email ?? null,
+      displayName: cachedRow.name ?? cachedRow.email,
       imageUrl: cachedRow.imageUrl ?? null,
     };
   }

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
@@ -89,7 +89,7 @@ export const sidebarChatThreadWindow$ = computed(
       scrollMetrics.clientHeight ||
       scrollViewport?.clientHeight ||
       CHAT_THREAD_VIRTUAL_FALLBACK_VIEWPORT_HEIGHT;
-    const scrollTop = scrollMetrics.scrollTop ?? scrollViewport?.scrollTop ?? 0;
+    const scrollTop = scrollMetrics.scrollTop;
     const { startIndex, endIndex } = getFixedVirtualRange({
       itemCount: chatThreads.length,
       scrollMargin,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -58,7 +58,7 @@ interface SidebarItem {
 }
 
 interface SidebarGroup {
-  label: string | null;
+  label: string;
   items: readonly SidebarItem[];
 }
 
@@ -315,17 +315,13 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
           {/* Desktop: sidebar nav */}
           <nav className="hidden sm:flex sm:flex-col w-52 shrink-0 p-3 pt-3 pb-4 gap-4 overflow-y-auto zero-border-r bg-[hsl(var(--gray-0))]">
             {sidebarGroups.map((group) => {
-              const groupKey =
-                group.label ?? `__personal_${group.items[0]?.id ?? ""}`;
               return (
-                <div key={groupKey} className="shrink-0">
-                  {group.label !== null && (
-                    <div className="h-7 flex items-center pl-2">
-                      <span className="text-[13px] leading-4 text-sidebar-foreground/50 font-medium">
-                        {group.label}
-                      </span>
-                    </div>
-                  )}
+                <div key={group.label} className="shrink-0">
+                  <div className="h-7 flex items-center pl-2">
+                    <span className="text-[13px] leading-4 text-sidebar-foreground/50 font-medium">
+                      {group.label}
+                    </span>
+                  </div>
                   <div className="flex flex-col gap-1">
                     {group.items.map((item) => {
                       const Icon = item.icon;


### PR DESCRIPTION
## Summary

Daily AI-slop fallback cleanup for 2026-08-06 (Asia/Shanghai), based on `603597bc0c1774807f66b5976f1b56d2a468f3e8`.

- scanned 3,944 tracked source files at `2026-08-05T20:02:32.117Z`
- found 4,383 actionable matches overall and 233 high-confidence production-actionable matches
- minimum batch: `ceil(233 * 5%) = 12`
- removed 12 high-confidence scanner candidates across 6 fallback chains
- remaining high-confidence production-actionable matches: 221

## What changed and why it was slop

- Use Clerk's required organization `name` directly in three test-org cache writes. The old `name ?? slug ?? id` chains suggested that a required SDK field could be absent and silently changed the cache identity to unrelated fields.
- Remove an unreachable final `null` from the workflow owner display name. `user_cache.email` is `NOT NULL`, so a cached row can always provide a display name when `name` is absent.
- Use the internal overlay scroll metric directly. `OverlayScrollMetrics.scrollTop` is initialized and updated as a required number, so DOM and zero fallbacks could never run under the internal contract.
- Make settings sidebar group labels explicitly required and use the label as the React key. Every group is constructed with a localized label; the old branch could fabricate a key ending in an empty ID for a state the component never creates.

Each of these chains was reported by both the scanner's same-line nullish-chain and property-fallback-chain detectors, yielding 12 removed high-confidence candidates from 6 code sites.

## Safety evidence

- Type inspection confirmed the removed branches were unreachable under the owning internal contracts.
- Runtime verification showed i18next fields are actually absent before initialization despite their TypeScript declarations, so those locale fallbacks were intentionally retained.
- OAuth/provider field aliases, media messages without text, external DTO compatibility, database null contracts, and presentational defaults were reviewed and intentionally left unchanged.

## Verification

- post-change scanner: 233 -> 221 high-confidence production-actionable matches
- Prettier on all changed files
- package-scoped type-aware Oxlint and ESLint for API and Platform files
- `api` typecheck and Platform production typecheck
- targeted Platform settings navigation test: 1 passed
- Lefthook pre-commit: Prettier, Knip, full serial Turbo typecheck, and file-size check
- commitlint
- targeted CLI-auth BDD could not start because local PostgreSQL was unavailable on `127.0.0.1/::1:5432`; PR CI remains the verification source for that DB-backed test

The remaining scanner candidates are intentionally left for later daily runs so external compatibility and genuinely optional states can be reviewed with their own evidence.
