### PR TITLE
fix(auth): skip sign-in redirects while app is hidden

### DIFF
--- a/turbo/apps/platform/src/signals/auth-retry.ts
+++ b/turbo/apps/platform/src/signals/auth-retry.ts
@@ -107,7 +107,12 @@ export function handleUnauthorizedRedirect(
   clerk: ClerkLike,
   suppressionUntil: number,
 ) {
-  if (isUnauthorizedRedirectSuppressed(suppressionUntil)) {
+  // A hidden PWA can receive 401s before Clerk finishes resuming its session.
+  // Leave navigation to the next visible request's recovery attempt.
+  if (
+    document.visibilityState !== "visible" ||
+    isUnauthorizedRedirectSuppressed(suppressionUntil)
+  ) {
     return;
   }
   // confirmed by ethan@vm0.ai

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -1010,6 +1010,48 @@ describe("zero sidebar account menu", () => {
     expect(screen.queryByText("Unauthorized")).not.toBeInTheDocument();
   });
 
+  it("keeps the app open when auth recovery remains unauthorized in the background", async () => {
+    mockAdminAccountSidebar();
+    context.mocks.data.personalModelProviders([
+      connectedPersonalCodexProvider(),
+    ]);
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+
+    let modelProviderRequests = 0;
+    context.mocks.api(
+      zeroPersonalModelProvidersMainContract.list,
+      ({ respond }) => {
+        modelProviderRequests += 1;
+        return respond(401, {
+          error: {
+            code: "UNAUTHORIZED",
+            message: "Unauthorized",
+          },
+        });
+      },
+    );
+    mockedClerk.sessionGetToken.mockImplementation((options) => {
+      return Promise.resolve(options?.skipCache ? "fresh-token" : "test-token");
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+      },
+      featureSwitches: { [FeatureSwitchKey.SidebarSubscriptionUsage]: true },
+    });
+
+    await waitFor(() => {
+      expect(modelProviderRequests).toBe(2);
+    });
+    expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
+    expect(screen.queryByText("Unauthorized")).not.toBeInTheDocument();
+  });
+
   it("suppresses global sign-in redirects during add-account auth transitions", async () => {
     mockNow(new Date("2026-01-01T00:00:00.000Z"));
     mockAdminAccountSidebar();


### PR DESCRIPTION
## Summary

- skip the final Clerk sign-in redirect when a recovered request remains unauthorized while the document is hidden
- preserve the existing visible-page token refresh, request replay, and confirmed sign-in redirect behavior
- cover the background PWA recovery path with a platform page regression test

## Context

The `app.okou.ai` PWA can receive a 401 while it is backgrounded, before Clerk finishes resuming the satellite session. The shared recovery path force-refreshes the token and replays the request, but previously called `redirectToSignIn()` after the replayed request remained unauthorized even when the document was hidden. This left the user on the VM0 sign-in page when returning to the PWA.

Hidden documents now skip that final navigation. The next request made while the app is visible continues through the existing refresh, replay, and confirmed redirect flow.

## Verification

- `pnpm exec prettier --check apps/platform/src/signals/auth-retry.ts apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx`
- `pnpm --filter @vm0/app run lint`
- `pnpm --filter @vm0/app run check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx` (17 tests passed)
