### PR TITLE
feat: roll out mermaid diagrams to all users

### DIFF
--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -351,7 +351,11 @@ describe("assistant markdown", () => {
   it("leaves mermaid blocks as code when the feature switch is off", async () => {
     mockThread("```mermaid\nflowchart TD\n  A --> B\n```");
 
-    detachedSetupPage({ context, path: "/chats/thread-markdown" });
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-markdown",
+      featureSwitches: { [FeatureSwitchKey.MermaidDiagrams]: false },
+    });
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
@@ -817,7 +817,11 @@ describe("chat scroll position", () => {
     });
     const resizeObserver = installResizeObserver();
 
-    detachedSetupPage({ context, path: `/chats/${threadId}` });
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.MermaidDiagrams]: false },
+    });
 
     const container = await waitFor(() => {
       expect(

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -21,6 +21,7 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.PwaChatKeyboardGestures, {})).toBe(
       true,
     );
+    expect(isFeatureEnabled(FeatureSwitchKey.MermaidDiagrams, {})).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -387,8 +387,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "bingjie@vm0.ai",
     description:
       "Render ```mermaid code blocks in assistant markdown as diagrams, and tell the web chat agent that they are rendered.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ArtifactSidebarInlineOpen]: {
     maintainer: "bingjie@vm0.ai",


### PR DESCRIPTION
## What

Turn the `mermaidDiagrams` feature switch on globally: ```` ```mermaid ```` fenced blocks now render as diagrams in web chat for every user, and the web chat agent prompt gets the diagram guidance for every run.

- `feature-switch.ts`: `enabled: true`, drop the staff-org gate (same shape as the `pwaChatKeyboardGestures` rollout in #25229).
- The switch itself stays registered, so a per-user override can still turn it back off.

## Tests

- `feature-switch.test.ts`: assert the switch is globally on.
- Two tests that exercised the switched-off path relied on the old default; they now set the override explicitly:
  - `markdown.test.tsx` — "leaves mermaid blocks as code when the feature switch is off"
  - `chat-scroll-position.test.tsx` — "leaves content growth alone while diagrams are switched off"

Relying on the PR pipeline for lint/type-check/tests.