### PR TITLE
fix: open clerk account portal in a new tab

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createApp } from "./app-factory";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed again on 2026-08-06)
+// (no-op API release marker refreshed again on 2026-07-31)
 
 const app = (() => {
   const instanceAbortController = new AbortController();

--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createApp } from "./app-factory";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed again on 2026-07-31)
+// (no-op API release marker refreshed again on 2026-08-06)
 
 const app = (() => {
   const instanceAbortController = new AbortController();

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -353,7 +353,9 @@ export const mockedClerk = {
   // Production-instance behavior: the URL passes through unchanged. Dev
   // instances append the __clerk_db_jwt session handoff parameter.
   buildUrlWithAuth: vi.fn(defaultBuildUrlWithAuthImpl),
-  buildUserProfileUrl: vi.fn(defaultBuildUserProfileUrlImpl),
+  buildUserProfileUrl: vi.fn<typeof defaultBuildUserProfileUrlImpl>(
+    defaultBuildUserProfileUrlImpl,
+  ),
   setActive: vi.fn(defaultSetActiveImpl),
   createOrganization: vi.fn((_params: { name: string; slug: string }) => {
     return Promise.resolve({ id: "new-org-id" });

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -181,6 +181,10 @@ export function clearMockedAuth() {
   });
   mockedClerk.buildUrlWithAuth.mockReset();
   mockedClerk.buildUrlWithAuth.mockImplementation(defaultBuildUrlWithAuthImpl);
+  mockedClerk.buildUserProfileUrl.mockReset();
+  mockedClerk.buildUserProfileUrl.mockImplementation(
+    defaultBuildUserProfileUrlImpl,
+  );
   mockedClerk.buildSignInUrl.mockReset();
   mockedClerk.buildSignInUrl.mockImplementation(defaultBuildSignInUrlImpl);
   mockedClerk.initialize.mockReset();
@@ -214,6 +218,10 @@ const clientSignInCreate = vi.fn(
 );
 const defaultBuildUrlWithAuthImpl = (to: string) => {
   return to;
+};
+
+const defaultBuildUserProfileUrlImpl = () => {
+  return "https://accounts.example.test/user";
 };
 
 interface MockedClerkLoadOptions {
@@ -345,6 +353,7 @@ export const mockedClerk = {
   // Production-instance behavior: the URL passes through unchanged. Dev
   // instances append the __clerk_db_jwt session handoff parameter.
   buildUrlWithAuth: vi.fn(defaultBuildUrlWithAuthImpl),
+  buildUserProfileUrl: vi.fn(defaultBuildUserProfileUrlImpl),
   setActive: vi.fn(defaultSetActiveImpl),
   createOrganization: vi.fn((_params: { name: string; slug: string }) => {
     return Promise.resolve({ id: "new-org-id" });

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -1,11 +1,9 @@
 import { command, computed, state } from "ccstate";
-import type { UserProfileModalProps } from "@clerk/react/types";
-import { clerk$ } from "../../auth.ts";
 import { searchParams$, updateSearchParams$ } from "../../route.ts";
 import { reloadBillingStatus$ } from "../billing.ts";
 import { isOrgAdmin$ } from "../../org.ts";
 import { reloadPersonalModelProviders$ } from "../../external/personal-model-providers.ts";
-import { onRef, resetSignal } from "../../utils.ts";
+import { resetSignal } from "../../utils.ts";
 import {
   clearBillingScrollTarget$,
   clearPendingLogo$,
@@ -48,8 +46,6 @@ const resetSettingsDialogSignal$ = resetSignal();
 const internalSettingsDialogSessionActive$ = state(false);
 const internalSettingsDialogInitialized$ = state(false);
 const internalSettingsDialogHandoffPending$ = state(false);
-const internalSettingsClerkProfilePortalContainer$ =
-  state<HTMLDivElement | null>(null);
 const pendingAccountMenuSettingsSection$ = state<{
   readonly ownerId: string;
   readonly section: SettingsSection;
@@ -60,55 +56,6 @@ export const settingsDialogOpen$ = computed((get) => {
 });
 
 export { internalSettingsDialogSignal$ as settingsDialogSignal$ };
-
-export const settingsClerkProfilePortalContainer$ = computed((get) => {
-  return get(internalSettingsClerkProfilePortalContainer$);
-});
-
-export const setSettingsClerkProfilePortalContainer$ = onRef(
-  command(
-    async ({ get, set }, container: HTMLDivElement, signal: AbortSignal) => {
-      const clerk = await get(clerk$);
-      signal.throwIfAborted();
-      signal.addEventListener(
-        "abort",
-        () => {
-          clerk.closeUserProfile();
-          set(internalSettingsClerkProfilePortalContainer$, null);
-        },
-        { once: true },
-      );
-      set(internalSettingsClerkProfilePortalContainer$, container);
-    },
-  ),
-);
-
-export const openSettingsUserProfile$ = command(
-  async ({ get }, signal: AbortSignal) => {
-    const clerk = await get(clerk$);
-    signal.throwIfAborted();
-    const container = get(internalSettingsClerkProfilePortalContainer$);
-    if (!container) {
-      return;
-    }
-    const props = {
-      apiKeysProps: { hide: true },
-      appearance: {
-        elements: {
-          modalBackdrop: {
-            position: "absolute",
-            width: "100%",
-            height: "100%",
-          },
-        },
-      },
-      getContainer: () => {
-        return container;
-      },
-    } satisfies UserProfileModalProps;
-    clerk.openUserProfile(props);
-  },
-);
 
 export const setPendingAccountMenuSettingsSection$ = command(
   ({ get, set }, ownerId: string, section: SettingsSection | null) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -659,7 +659,7 @@ describe("zero sidebar account menu", () => {
     );
     expect(userProfileLink).toHaveAttribute("target", "_blank");
     expect(userProfileLink).toHaveAttribute("rel", "noreferrer");
-    expect(mockedClerk.buildUserProfileUrl).toHaveBeenCalled();
+    expect(mockedClerk.buildUserProfileUrl).toHaveBeenCalledWith();
     expect(mockedClerk.buildUrlWithAuth).toHaveBeenCalledWith(
       "https://accounts.example.test/user",
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -136,6 +136,16 @@ function buttonByText(text: string): HTMLElement {
   return button;
 }
 
+function linkByText(text: string): HTMLAnchorElement {
+  const link = queryAllByRoleFast("link").find((candidate) => {
+    return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+  });
+  if (!(link instanceof HTMLAnchorElement)) {
+    throw new Error(`${text} link not found`);
+  }
+  return link;
+}
+
 function buttonByLabel(
   label: string,
   container: ParentNode = document.body,
@@ -652,7 +662,7 @@ describe("zero sidebar account menu", () => {
       );
     });
 
-    const userProfileLink = screen.getByRole("link", { name: "Manage" });
+    const userProfileLink = linkByText("Manage");
     expect(userProfileLink).toHaveAttribute(
       "href",
       "https://accounts.example.test/user",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -592,7 +592,7 @@ describe("zero sidebar account menu", () => {
     });
   });
 
-  it("keeps the user profile inside settings and changes debug capture", async () => {
+  it("links to the hosted user profile in a new tab and changes debug capture", async () => {
     prepareDefaultAgent();
     context.mocks.data.userPreferences({
       captureNetworkBodiesRemaining: 0,
@@ -652,49 +652,17 @@ describe("zero sidebar account menu", () => {
       );
     });
 
-    const clerkProfileModals: HTMLDivElement[] = [];
-    mockedClerk.openUserProfile.mockImplementation((options) => {
-      const container = options?.getContainer?.();
-      if (!container) {
-        throw new Error("Clerk profile portal container not found");
-      }
-      const modal = document.createElement("div");
-      modal.dataset.clerkUserProfile = "";
-      container.append(modal);
-      clerkProfileModals.push(modal);
-    });
-
-    click(buttonByText("Manage"));
-
-    await waitFor(() => {
-      expect(clerkProfileModals).toHaveLength(1);
-      expect(mockedClerk.openUserProfile).toHaveBeenCalledWith({
-        apiKeysProps: { hide: true },
-        appearance: {
-          elements: {
-            modalBackdrop: {
-              position: "absolute",
-              width: "100%",
-              height: "100%",
-            },
-          },
-        },
-        getContainer: expect.any(Function),
-      });
-    });
-
-    const clerkProfileModal = clerkProfileModals[0];
-    if (!clerkProfileModal) {
-      throw new Error("Clerk profile modal not found");
-    }
-    expect(openedSettingsDialog).toContainElement(clerkProfileModal);
-    clerkProfileModal.remove();
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole("dialog", { name: "Settings" }),
-      ).toBeInTheDocument();
-    });
+    const userProfileLink = screen.getByRole("link", { name: "Manage" });
+    expect(userProfileLink).toHaveAttribute(
+      "href",
+      "https://accounts.example.test/user",
+    );
+    expect(userProfileLink).toHaveAttribute("target", "_blank");
+    expect(userProfileLink).toHaveAttribute("rel", "noreferrer");
+    expect(mockedClerk.buildUserProfileUrl).toHaveBeenCalled();
+    expect(mockedClerk.buildUrlWithAuth).toHaveBeenCalledWith(
+      "https://accounts.example.test/user",
+    );
 
     click(buttonByText("Debug"));
 
@@ -721,7 +689,6 @@ describe("zero sidebar account menu", () => {
     });
 
     const settingsDialog = screen.getByRole("dialog", { name: "Settings" });
-    mockedClerk.closeUserProfile.mockClear();
     click(buttonByLabel("Close", settingsDialog));
 
     await waitFor(() => {
@@ -730,7 +697,6 @@ describe("zero sidebar account menu", () => {
       ).not.toBeInTheDocument();
       expect(document.querySelector(".zero-dialog-overlay")).toBeNull();
     });
-    expect(mockedClerk.closeUserProfile).toHaveBeenCalledTimes(1);
     expect(document.body.style.pointerEvents).not.toBe("none");
 
     const reopenedMenu = await openAccountMenu();

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/account-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/account-section.tsx
@@ -1,6 +1,6 @@
 import { useGet, useLoadable } from "ccstate-react";
 import { useTranslation } from "react-i18next";
-import { IconUser } from "@tabler/icons-react";
+import { IconExternalLink } from "@tabler/icons-react";
 import { Button } from "@vm0/ui/components/ui/button";
 import {
   clerkInstance$,
@@ -43,7 +43,7 @@ export function AccountSection() {
       </div>
       <Button asChild className="shrink-0">
         <a href={userProfileUrl} target="_blank" rel="noreferrer">
-          <IconUser size={14} />
+          <IconExternalLink size={14} />
           {t(($) => {
             return $.settings.preferences.account.manage;
           })}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/account-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/account-section.tsx
@@ -1,24 +1,18 @@
-import { useGet, useLoadable, useSet } from "ccstate-react";
+import { useGet, useLoadable } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import { IconUser } from "@tabler/icons-react";
 import { Button } from "@vm0/ui/components/ui/button";
-import { currentUserInfo$ } from "../../../../../signals/auth.ts";
 import {
-  openSettingsUserProfile$,
-  settingsClerkProfilePortalContainer$,
-  settingsDialogSignal$,
-} from "../../../../../signals/zero-page/settings/settings-dialog.ts";
-import { detach, Reason } from "../../../../../signals/utils.ts";
+  clerkInstance$,
+  currentUserInfo$,
+} from "../../../../../signals/auth.ts";
 
 export function AccountSection() {
   const { t } = useTranslation();
-  const clerkProfilePortalContainer = useGet(
-    settingsClerkProfilePortalContainer$,
-  );
-  const settingsDialogSignal = useGet(settingsDialogSignal$);
-  const openUserProfile = useSet(openSettingsUserProfile$);
+  const clerk = useGet(clerkInstance$);
   const userLoadable = useLoadable(currentUserInfo$);
   const user = userLoadable.state === "hasData" ? userLoadable.data : undefined;
+  const userProfileUrl = clerk.buildUrlWithAuth(clerk.buildUserProfileUrl());
 
   const displayName = user?.fullName ?? user?.firstName ?? "";
   const email = user?.primaryEmailAddress?.emailAddress ?? "";
@@ -47,19 +41,13 @@ export function AccountSection() {
           <div className="text-sm text-muted-foreground truncate">{email}</div>
         )}
       </div>
-      <Button
-        onClick={() => {
-          if (settingsDialogSignal) {
-            detach(openUserProfile(settingsDialogSignal), Reason.DomCallback);
-          }
-        }}
-        disabled={!clerkProfilePortalContainer || !settingsDialogSignal}
-        className="shrink-0"
-      >
-        <IconUser size={14} />
-        {t(($) => {
-          return $.settings.preferences.account.manage;
-        })}
+      <Button asChild className="shrink-0">
+        <a href={userProfileUrl} target="_blank" rel="noreferrer">
+          <IconUser size={14} />
+          {t(($) => {
+            return $.settings.preferences.account.manage;
+          })}
+        </a>
       </Button>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -30,7 +30,6 @@ import { isOrgAdmin$ } from "../../../../signals/org.ts";
 import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import {
   isAdminOnlySettingsSection,
-  setSettingsClerkProfilePortalContainer$,
   settingsActiveSection$,
   setSettingsActiveSection$,
   type SettingsSection,
@@ -98,9 +97,6 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const { t } = useTranslation();
   const activeSection = useGet(settingsActiveSection$);
   const setActiveSection = useSet(setSettingsActiveSection$);
-  const setClerkProfilePortalContainer = useSet(
-    setSettingsClerkProfilePortalContainer$,
-  );
   const features = useGet(featureSwitch$);
   const isAdminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin =
@@ -269,7 +265,6 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        ref={setClerkProfilePortalContainer}
         closeLabel={t(($) => {
           return $.settings.shared.close;
         })}


### PR DESCRIPTION
## Summary

- open the Clerk-hosted account portal from Settings in a new tab
- preserve Clerk development-session handoff when building the hosted profile URL
- remove the embedded user-profile portal container and lifecycle
- update the account-menu coverage for the hosted profile link

## Testing

- `deploy-app`
- all eight `test-app` shards
- `lint-eslint`
- `lint-types-apps`
- staging browser: Manage opens Clerk Account Portal in a new tab while the original Settings dialog stays open
- staging browser: VM0 logo on the hosted page returns to the app
- staging browser: no page or console errors on either tab