### PR TITLE
docs(python): document auth base rewrite validation

### DIFF
--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -477,10 +477,10 @@ def build_rewrite_url(
     safe path; userinfo and fragments are not allowed. Backslashes, whitespace
     or unsafe code points, invalid ports, unsafe path syntax, malformed Unicode,
     and unsafe or invalid percent-encoded host syntax are rejected. Accepted
-    hostnames are normalized for forwarding: Unicode and percent-encoded Unicode
-    names use canonical IDNA form, IPv4 literals must already be canonical dotted
-    quads, IPv6 literals are compressed and bracketed, and explicit valid ports
-    are preserved.
+    hosts are normalized for forwarding: Unicode and safely percent-encoded
+    Unicode names use canonical IDNA form, IPv4 literals must be canonical dotted
+    quads after safe percent-decoding, IPv6 literals are compressed and bracketed,
+    and explicit valid ports are preserved.
 
     Unsafe path syntax in ``rel_path`` is rejected as an invariant; firewall
     matching should already have blocked it before auth is applied.

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -471,9 +471,24 @@ def build_rewrite_url(
     path from the firewall match, and query strings from trusted auth data
     and the original request. ``orig_query`` is the raw query string of the
     incoming request (no leading ``?``). Query key precedence is
-    ``resolved_query`` > resolved base query > original request query. Unsafe
-    path syntax in ``rel_path`` is rejected as an invariant; firewall matching
-    should already have blocked it before auth is applied.
+    ``resolved_query`` > resolved base query > original request query.
+
+    ``resolved_base`` must be an absolute HTTPS URL with a valid authority and
+    safe path; userinfo and fragments are not allowed. Backslashes, whitespace
+    or unsafe code points, invalid ports, unsafe path syntax, malformed Unicode,
+    and unsafe or invalid percent-encoded host syntax are rejected. Accepted
+    hostnames are normalized for forwarding: Unicode and percent-encoded Unicode
+    names use canonical IDNA form, IPv4 literals must already be canonical dotted
+    quads, IPv6 literals are compressed and bracketed, and explicit valid ports
+    are preserved.
+
+    Unsafe path syntax in ``rel_path`` is rejected as an invariant; firewall
+    matching should already have blocked it before auth is applied.
+
+    Raises:
+        ValueError: If ``resolved_base`` is not a safe absolute HTTPS URL,
+            ``rel_path`` has unsafe path syntax, or a URL component contains
+            Unicode that cannot be safely encoded.
     """
     if has_unsafe_path(rel_path):
         raise ValueError("Unsafe rewrite path: unsafe path syntax is not allowed")


### PR DESCRIPTION
## Summary

- document the required HTTPS authority and safe-path contract for runtime-resolved `auth.base` URLs
- describe rejected URL categories and accepted hostname normalization behavior
- document the `ValueError` boundary while preserving the existing query-precedence contract

## Scope

- documentation only; URL validation, rewriting behavior, callers, and tests are unchanged
- no API, protocol, persistence, migration, or rollout changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`4807 passed`)

Closes #25325
