### PR TITLE
fix(python): accept trailing authority-fragment base url variables

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_base_url.py
+++ b/crates/runner/mitm-addon/src/builtin_base_url.py
@@ -302,13 +302,6 @@ def _prefix_is_inside_path(prefix: str) -> bool:
     return "/" in after_scheme
 
 
-def _suffix_authority_prefix(suffix: str) -> str:
-    delimiter = _URL_COMPONENT_DELIMITER_PATTERN.search(suffix)
-    if delimiter is None:
-        return suffix
-    return suffix[: delimiter.start()]
-
-
 def _validate_base_url_template_variable(
     *,
     firewall_name: str,
@@ -354,7 +347,7 @@ def _validate_base_url_template_variable(
             value=value,
         )
         return
-    if _prefix_is_inside_authority(prefix) and _suffix_authority_prefix(suffix) != "":
+    if _prefix_is_inside_authority(prefix):
         _validate_base_url_authority_fragment_variable(
             firewall_name=firewall_name,
             base=base,

--- a/crates/runner/mitm-addon/tests/test_firewall_base_url_validation_contract.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_base_url_validation_contract.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import builtin_base_url
 import matching
 
 _CONTRACT_PATH = (
@@ -18,10 +19,10 @@ _CONTRACT_PATH = (
 )
 
 
-def _load_cases() -> list[dict[str, object]]:
+def _load_cases(key: str) -> list[dict[str, object]]:
     raw_contract = json.loads(_CONTRACT_PATH.read_text(encoding="utf-8"))
     assert isinstance(raw_contract, dict)
-    cases = raw_contract["baseUrlValidationCases"]
+    cases = raw_contract[key]
     assert isinstance(cases, list)
     assert cases
     assert all(isinstance(case, dict) for case in cases)
@@ -36,7 +37,8 @@ def _case_name(case: dict[str, object]) -> str:
     return name
 
 
-_BASE_URL_VALIDATION_CASES = _load_cases()
+_BASE_URL_VALIDATION_CASES = _load_cases("baseUrlValidationCases")
+_BASE_URL_TEMPLATE_RESOLUTION_CASES = _load_cases("baseUrlTemplateResolutionCases")
 
 
 @pytest.mark.parametrize("case", _BASE_URL_VALIDATION_CASES, ids=_case_name)
@@ -49,3 +51,38 @@ def test_firewall_base_url_config_validity_matches_shared_contract(
     assert isinstance(expected_valid, bool)
 
     assert matching.firewall_base_config_is_valid(base) is expected_valid
+
+
+@pytest.mark.parametrize("case", _BASE_URL_TEMPLATE_RESOLUTION_CASES, ids=_case_name)
+def test_firewall_base_url_template_resolution_matches_shared_contract(
+    case: dict[str, object],
+) -> None:
+    base = case["base"]
+    assert isinstance(base, str)
+    raw_vars = case["vars"]
+    assert isinstance(raw_vars, dict)
+    vars_map: dict[str, str] = {}
+    for name, value in raw_vars.items():
+        assert isinstance(name, str)
+        assert isinstance(value, str)
+        vars_map[name] = value
+    expected_resolved_base = case["expectedResolvedBase"]
+    assert expected_resolved_base is None or isinstance(expected_resolved_base, str)
+
+    if expected_resolved_base is None:
+        with pytest.raises(builtin_base_url.BuiltinBaseUrlResolutionError):
+            builtin_base_url.resolve_base_url_template(
+                firewall_name="contract",
+                base=base,
+                vars_map=vars_map,
+            )
+        return
+
+    assert (
+        builtin_base_url.resolve_base_url_template(
+            firewall_name="contract",
+            base=base,
+            vars_map=vars_map,
+        )
+        == expected_resolved_base
+    )

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
@@ -135,6 +135,33 @@ class TestRegistryBuiltinBaseUrlVars:
         assert compiled_firewalls is not None
         assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://acme.zendesk.com"
 
+    def test_builtin_trailing_authority_fragment_resolves_with_provider_policy(self, tmp_path):
+        name = "audit"
+        install_test_builtin_firewall(
+            name=name,
+            base="https://api-${{ vars.HOST }}/v1",
+            host_policy={"kind": "providerOwned", "suffixes": ["example.com"]},
+        )
+        path = tmp_path / "registry.json"
+        write_builtin_firewall_registry(
+            path,
+            run_id=f"run-{name}",
+            name=name,
+            base_url_vars={"HOST": "tenant.example.com"},
+        )
+
+        context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert context is not None
+        vm_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        api = vm_info["firewalls"][0]["apis"][0]
+        assert api["base"] == "https://api-tenant.example.com/v1"
+        assert isinstance(
+            api[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER],
+            builtin_host_policy.CompiledBuiltinHostPolicy,
+        )
+
     def test_builtin_firewall_entry_resolves_ecmascript_whitespace_template(self, tmp_path):
         name = "ecmascript-whitespace"
         install_test_builtin_firewall(

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -1,5 +1,49 @@
 {
   "hostnamePolicy": "vm0-uts46-16.0-v1",
+  "baseUrlTemplateResolutionCases": [
+    {
+      "category": "authority-fragment",
+      "name": "trailing authority fragment before path resolves",
+      "base": "https://api-${{ vars.HOST }}/v1",
+      "vars": { "HOST": "tenant.example.com" },
+      "expectedResolvedBase": "https://api-tenant.example.com/v1"
+    },
+    {
+      "category": "authority-fragment",
+      "name": "trailing authority fragment at end resolves",
+      "base": "https://api-${{ vars.HOST }}",
+      "vars": { "HOST": "tenant.example.com" },
+      "expectedResolvedBase": "https://api-tenant.example.com"
+    },
+    {
+      "category": "query-fragment",
+      "name": "trailing authority fragment before query is invalid",
+      "base": "https://api-${{ vars.HOST }}?page=1",
+      "vars": { "HOST": "tenant.example.com" },
+      "expectedResolvedBase": null
+    },
+    {
+      "category": "query-fragment",
+      "name": "trailing authority fragment before fragment is invalid",
+      "base": "https://api-${{ vars.HOST }}#section",
+      "vars": { "HOST": "tenant.example.com" },
+      "expectedResolvedBase": null
+    },
+    {
+      "category": "authority-fragment",
+      "name": "trailing authority fragment rejects raw structure",
+      "base": "https://api-${{ vars.HOST }}/v1",
+      "vars": { "HOST": "tenant.example.com/capture" },
+      "expectedResolvedBase": null
+    },
+    {
+      "category": "authority-fragment",
+      "name": "trailing authority fragment rejects encoded structure",
+      "base": "https://api-${{ vars.HOST }}/v1",
+      "vars": { "HOST": "tenant.example.com%2fcapture" },
+      "expectedResolvedBase": null
+    }
+  ],
   "baseUrlValidationCases": [
     {
       "category": "valid",

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.test.ts
@@ -6,8 +6,17 @@ import { z } from "zod";
 import { FIREWALL_HOSTNAME_POLICY_VERSION } from "../firewall-hostname-policy";
 import {
   canonicalizeFirewallBaseUrl,
+  resolveFirewallBaseUrlTemplate,
   validateBaseUrl,
 } from "../firewall-types";
+
+const baseUrlTemplateResolutionCaseSchema = z.object({
+  name: z.string(),
+  category: z.string().optional(),
+  base: z.string(),
+  vars: z.record(z.string(), z.string()),
+  expectedResolvedBase: z.string().nullable(),
+});
 
 const baseUrlValidationCaseSchema = z.object({
   name: z.string(),
@@ -21,23 +30,37 @@ const baseUrlValidationCaseSchema = z.object({
 const contractSchema = z
   .object({
     hostnamePolicy: z.literal(FIREWALL_HOSTNAME_POLICY_VERSION),
+    baseUrlTemplateResolutionCases: z
+      .array(baseUrlTemplateResolutionCaseSchema)
+      .min(1),
     baseUrlValidationCases: z.array(baseUrlValidationCaseSchema).min(1),
   })
   .superRefine((contract, ctx) => {
-    const seenNames = new Set<string>();
-    for (const [index, testCase] of contract.baseUrlValidationCases.entries()) {
-      if (seenNames.has(testCase.name)) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["baseUrlValidationCases", index, "name"],
-          message: `duplicate case name "${testCase.name}"`,
-        });
+    for (const [collectionName, testCases] of [
+      [
+        "baseUrlTemplateResolutionCases",
+        contract.baseUrlTemplateResolutionCases,
+      ],
+      ["baseUrlValidationCases", contract.baseUrlValidationCases],
+    ] as const) {
+      const seenNames = new Set<string>();
+      for (const [index, testCase] of testCases.entries()) {
+        if (seenNames.has(testCase.name)) {
+          ctx.addIssue({
+            code: "custom",
+            path: [collectionName, index, "name"],
+            message: `duplicate case name "${testCase.name}"`,
+          });
+        }
+        seenNames.add(testCase.name);
       }
-      seenNames.add(testCase.name);
     }
   });
 
 type BaseUrlValidationCase = z.infer<typeof baseUrlValidationCaseSchema>;
+type BaseUrlTemplateResolutionCase = z.infer<
+  typeof baseUrlTemplateResolutionCaseSchema
+>;
 
 function loadContract(): z.infer<typeof contractSchema> {
   const rawContract: unknown = JSON.parse(
@@ -70,12 +93,39 @@ function assertValidationResult(testCase: BaseUrlValidationCase): void {
   expect(validate).toThrow();
 }
 
+function assertTemplateResolutionResult(
+  testCase: BaseUrlTemplateResolutionCase,
+): void {
+  const resolve = (): string => {
+    return resolveFirewallBaseUrlTemplate({
+      serviceName: "contract",
+      base: testCase.base,
+      vars: testCase.vars,
+    });
+  };
+
+  if (testCase.expectedResolvedBase === null) {
+    expect(resolve).toThrow();
+    return;
+  }
+
+  expect(resolve()).toBe(testCase.expectedResolvedBase);
+}
+
 const contract = loadContract();
 
 describe("firewall base URL validation contract", () => {
   for (const testCase of contract.baseUrlValidationCases) {
     it(testCase.name, () => {
       assertValidationResult(testCase);
+    });
+  }
+});
+
+describe("firewall base URL template resolution contract", () => {
+  for (const testCase of contract.baseUrlTemplateResolutionCases) {
+    it(testCase.name, () => {
+      assertTemplateResolutionResult(testCase);
     });
   }
 });


### PR DESCRIPTION
## Summary

- align the Python built-in base URL resolver with the TypeScript producer for trailing authority-fragment variables
- extend the shared TypeScript/Python base URL contract with success and fail-closed template-resolution cases
- cover the credentialed provider-owned execution-entry and catalog path through runner registry admission

## Compatibility and security

- preserves authority-fragment raw and percent-encoded structure checks, complete-base validation, credentialed HTTPS enforcement, and resolved host-policy enforcement
- does not change the execution payload, API, persisted data, migrations, or TypeScript runtime behavior
- old runners may retain the existing fail-closed rejection during an independent rollout; new runners accept the case only after all existing safety gates pass

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_firewall_base_url_validation_contract.py tests/test_registry_builtin_base_url_vars.py` (161 passed)
- `uv run --no-sync python -m pytest tests/` (4,814 passed)
- `pnpm exec prettier --check packages/connectors/src/__tests__/firewall-base-url-validation-contract.json packages/connectors/src/__tests__/firewall-base-url-validation-contract.test.ts`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-base-url-validation-contract.test.ts` (98 passed)
- `pnpm -F @vm0/connectors test` (902 passed)
- `pnpm knip --workspace @vm0/connectors`
- pre-commit hook: full Turbo `check-types`, full Turbo Knip, Ruff, formatting, file-size, and commit-message checks

Closes #25329
