### PR TITLE
refactor(runner): centralize private atomic file publication

### DIFF
--- a/crates/runner/src/host_file.rs
+++ b/crates/runner/src/host_file.rs
@@ -79,6 +79,75 @@ pub(crate) fn validate_private_file_destination(path: &Path, context: &str) -> i
     secure_regular_private_file(&file, path, context)
 }
 
+/// Publish a private file through same-directory atomic replacement on Unix.
+///
+/// The caller remains responsible for parent-directory trust. This operation
+/// does not fsync the file or parent directory, serialize writers, or define
+/// concurrent-writer ordering. Staging-file cleanup after an error is best
+/// effort. Non-Unix builds use a direct platform write instead.
+#[cfg(unix)]
+pub(crate) async fn write_private_atomic(
+    path: &Path,
+    content: &[u8],
+    context: &str,
+) -> io::Result<()> {
+    use std::ffi::OsString;
+    use tokio::io::AsyncWriteExt;
+
+    let file_name = path.file_name().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "{} does not have a file name; refusing to write {context}",
+                path.display()
+            ),
+        )
+    })?;
+    let mut tmp_name = OsString::from(".");
+    tmp_name.push(file_name);
+    tmp_name.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
+    let tmp = path.with_file_name(tmp_name);
+
+    let result = async {
+        let mut options = tokio::fs::OpenOptions::new();
+        options.write(true).create_new(true).mode(PRIVATE_FILE_MODE);
+        let mut file = options
+            .open(&tmp)
+            .await
+            .map_err(|e| wrap_io(e, format!("open {context} tmp {}", tmp.display())))?;
+        chmod_private_file_fd(&file, &tmp, context)?;
+        file.write_all(content)
+            .await
+            .map_err(|e| wrap_io(e, format!("write {context} tmp {}", tmp.display())))?;
+        file.flush()
+            .await
+            .map_err(|e| wrap_io(e, format!("flush {context} tmp {}", tmp.display())))?;
+        drop(file);
+
+        tokio::fs::rename(&tmp, path)
+            .await
+            .map_err(|e| wrap_io(e, format!("rename {context} {}", path.display())))?;
+        Ok(())
+    }
+    .await;
+
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(&tmp).await;
+    }
+    result
+}
+
+#[cfg(not(unix))]
+pub(crate) async fn write_private_atomic(
+    path: &Path,
+    content: &[u8],
+    context: &str,
+) -> io::Result<()> {
+    tokio::fs::write(path, content)
+        .await
+        .map_err(|e| wrap_io(e, format!("write {context} {}", path.display())))
+}
+
 pub(crate) fn secure_regular_private_file<Fd: AsRawFd>(
     file: &Fd,
     path: &Path,
@@ -613,6 +682,62 @@ mod tests {
 
     fn mode(path: &Path) -> u32 {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    #[tokio::test]
+    async fn write_private_atomic_publishes_private_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+
+        write_private_atomic(&path, b"new content", "test file")
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"new content");
+        assert_eq!(mode(&path), PRIVATE_FILE_MODE);
+    }
+
+    #[tokio::test]
+    async fn write_private_atomic_replaces_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        std::fs::write(&path, b"old content").unwrap();
+
+        write_private_atomic(&path, b"new content", "test file")
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"new content");
+    }
+
+    #[tokio::test]
+    async fn write_private_atomic_removes_staging_file_after_rename_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        std::fs::create_dir(&path).unwrap();
+
+        let error = write_private_atomic(&path, b"content", "test file")
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("rename test file"),
+            "unexpected error: {error}"
+        );
+        let leftover_staging_files: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                name.starts_with(".state.json.") && name.ends_with(".tmp")
+            })
+            .collect();
+        assert!(
+            leftover_staging_files.is_empty(),
+            "private file staging sibling should be removed after rename failure"
+        );
+        assert!(path.is_dir());
     }
 
     #[tokio::test]

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -29,9 +29,9 @@ use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::path::{Component, Path, PathBuf};
 
 use crate::error::{RunnerError, RunnerResult};
+use crate::host_file::PRIVATE_FILE_MODE;
 
 const PRIVATE_DIR_MODE: u32 = 0o700;
-const PRIVATE_FILE_MODE: u32 = 0o600;
 const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 const ROOT_UID: u32 = 0;
 const STICKY_BIT: u32 = 0o1000;
@@ -285,60 +285,10 @@ pub async fn read_private_file_to_string_with_max(
 /// a crash-durability guarantee. The function also provides no locking or
 /// concurrent-writer ordering guarantee. After an error, staging-file removal
 /// is attempted as best-effort cleanup.
-#[cfg(unix)]
 pub async fn write_private_file(path: &Path, content: &[u8]) -> RunnerResult<()> {
-    use std::ffi::OsString;
-    use tokio::io::AsyncWriteExt;
-
-    let file_name = path.file_name().ok_or_else(|| {
-        RunnerError::Config(format!(
-            "{} does not have a file name; refusing to write private file",
-            path.display()
-        ))
-    })?;
-    let mut tmp_name = OsString::from(".");
-    tmp_name.push(file_name);
-    tmp_name.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
-    let tmp = path.with_file_name(tmp_name);
-
-    let result = async {
-        let mut options = tokio::fs::OpenOptions::new();
-        options.write(true).create_new(true).mode(PRIVATE_FILE_MODE);
-        let mut file = options.open(&tmp).await.map_err(|e| {
-            RunnerError::Config(format!("open private file tmp {}: {e}", tmp.display()))
-        })?;
-        chmod_private_file_fd(&file, &tmp)?;
-        file.write_all(content).await.map_err(|e| {
-            RunnerError::Config(format!("write private file tmp {}: {e}", tmp.display()))
-        })?;
-        file.flush().await.map_err(|e| {
-            RunnerError::Config(format!("flush private file tmp {}: {e}", tmp.display()))
-        })?;
-        drop(file);
-
-        tokio::fs::rename(&tmp, path).await.map_err(|e| {
-            RunnerError::Config(format!("rename private file {}: {e}", path.display()))
-        })?;
-        Ok(())
-    }
-    .await;
-
-    if result.is_err() {
-        let _ = tokio::fs::remove_file(&tmp).await;
-    }
-    result
-}
-
-/// Write a file directly with the platform filesystem API on non-Unix.
-///
-/// This fallback does not provide the Unix sibling staging, explicit `0600`
-/// mode, or atomic replacement. It uses ordinary path resolution and does not
-/// validate the destination or parent chain.
-#[cfg(not(unix))]
-pub async fn write_private_file(path: &Path, content: &[u8]) -> RunnerResult<()> {
-    tokio::fs::write(path, content)
+    crate::host_file::write_private_atomic(path, content, "private file")
         .await
-        .map_err(|e| RunnerError::Config(format!("write private file {}: {e}", path.display())))
+        .map_err(|e| RunnerError::Config(e.to_string()))
 }
 
 #[cfg(unix)]
@@ -1310,33 +1260,5 @@ mod tests {
             error.to_string().contains("owned by uid"),
             "unexpected error: {error}"
         );
-    }
-
-    #[tokio::test]
-    async fn write_private_file_removes_tmp_after_rename_failure() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("runner.yaml");
-        std::fs::create_dir(&path).unwrap();
-
-        let error = write_private_file(&path, b"secret").await.unwrap_err();
-
-        assert!(
-            error.to_string().contains("rename private file"),
-            "unexpected error: {error}"
-        );
-        let leftover_tmp_files: Vec<_> = std::fs::read_dir(dir.path())
-            .unwrap()
-            .filter_map(Result::ok)
-            .filter(|entry| {
-                let name = entry.file_name();
-                let name = name.to_string_lossy();
-                name.starts_with(".runner.yaml.") && name.ends_with(".tmp")
-            })
-            .collect();
-        assert!(
-            leftover_tmp_files.is_empty(),
-            "private file tmp should be removed after rename failure"
-        );
-        assert!(path.is_dir());
     }
 }

--- a/crates/runner/src/state_file.rs
+++ b/crates/runner/src/state_file.rs
@@ -28,8 +28,6 @@ pub(crate) const BUILTIN_FIREWALL_CATALOG_MAX_BYTES: u64 = 16 * 1024 * 1024;
 pub(crate) const USAGE_PENDING_MAX_BYTES: u64 = 64 * 1024;
 pub(crate) const WORKSPACE_METADATA_MAX_BYTES: u64 = 1024 * 1024;
 
-const PRIVATE_FILE_MODE: u32 = 0o600;
-
 /// Ownership policy for reading a runner state file.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum OwnerCheck {
@@ -216,75 +214,9 @@ fn validate_open_state_file<Fd: std::os::fd::AsRawFd>(
 /// directory are not fsynced, so this does not provide a crash-durability
 /// guarantee. Non-Unix builds use `tokio::fs::write` as a weaker fallback.
 pub(crate) async fn write_private_atomic(path: &Path, content: &[u8]) -> RunnerResult<()> {
-    #[cfg(unix)]
-    {
-        write_private_atomic_unix(path, content).await
-    }
-
-    #[cfg(not(unix))]
-    {
-        tokio::fs::write(path, content)
-            .await
-            .map_err(|e| RunnerError::Internal(format!("write state file {}: {e}", path.display())))
-    }
-}
-
-#[cfg(unix)]
-async fn write_private_atomic_unix(path: &Path, content: &[u8]) -> RunnerResult<()> {
-    use std::ffi::OsString;
-    use tokio::io::AsyncWriteExt;
-
-    let file_name = path.file_name().ok_or_else(|| {
-        RunnerError::Internal(format!(
-            "{} does not have a file name; refusing to write state file",
-            path.display()
-        ))
-    })?;
-    let mut tmp_name = OsString::from(".");
-    tmp_name.push(file_name);
-    tmp_name.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
-    let tmp = path.with_file_name(tmp_name);
-
-    let result = async {
-        let mut options = tokio::fs::OpenOptions::new();
-        options.write(true).create_new(true).mode(PRIVATE_FILE_MODE);
-        let mut file = options.open(&tmp).await.map_err(|e| {
-            RunnerError::Internal(format!("open state file tmp {}: {e}", tmp.display()))
-        })?;
-        chmod_private_file_fd(&file, &tmp)?;
-        file.write_all(content).await.map_err(|e| {
-            RunnerError::Internal(format!("write state file tmp {}: {e}", tmp.display()))
-        })?;
-        file.flush().await.map_err(|e| {
-            RunnerError::Internal(format!("flush state file tmp {}: {e}", tmp.display()))
-        })?;
-        drop(file);
-        tokio::fs::rename(&tmp, path).await.map_err(|e| {
-            RunnerError::Internal(format!("rename state file {}: {e}", path.display()))
-        })?;
-        Ok(())
-    }
-    .await;
-
-    if result.is_err() {
-        let _ = tokio::fs::remove_file(&tmp).await;
-    }
-    result
-}
-
-#[cfg(unix)]
-fn chmod_private_file_fd<Fd: std::os::fd::AsRawFd>(file: &Fd, path: &Path) -> RunnerResult<()> {
-    // SAFETY: `fchmod` operates on the live fd.
-    let result = unsafe { libc::fchmod(file.as_raw_fd(), PRIVATE_FILE_MODE as libc::mode_t) };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(RunnerError::Internal(format!(
-            "chmod state file {}: {}",
-            path.display(),
-            std::io::Error::last_os_error()
-        )))
-    }
+    crate::host_file::write_private_atomic(path, content, "state file")
+        .await
+        .map_err(|e| RunnerError::Internal(e.to_string()))
 }
 
 #[cfg(test)]
@@ -295,7 +227,7 @@ mod tests {
         ignored_child_test_env_guard_enabled, run_ignored_child_test,
     };
     use std::ffi::CString;
-    use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::os::unix::fs::symlink;
     use std::path::PathBuf;
     use std::time::Duration;
 
@@ -393,20 +325,6 @@ mod tests {
         assert!(
             error.to_string().contains("exceeds 5 bytes"),
             "unexpected error: {error}"
-        );
-    }
-
-    #[tokio::test]
-    async fn write_private_atomic_writes_private_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("state.json");
-
-        write_private_atomic(&path, b"{}").await.unwrap();
-
-        assert_eq!(std::fs::read(&path).unwrap(), b"{}");
-        assert_eq!(
-            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
-            0o600
         );
     }
 }


### PR DESCRIPTION
## Summary

- centralize asynchronous private atomic file publication in the low-level `host_file` boundary
- keep `private_fs` and `state_file` as policy wrappers with their existing error classifications and caller contracts
- make `host_file::PRIVATE_FILE_MODE` the single mode owner and consolidate real-filesystem coverage for publication, replacement, and failure cleanup

## Scope

- preserves the existing staging name, exclusive creation, descriptor chmod, write, flush, close, rename, and best-effort cleanup sequence
- preserves the non-Unix direct-write fallback
- does not add fsync durability, locking, retries, writer ordering, or parent-directory validation
- does not change systemd unit staging

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner host_file::tests::write_private_atomic`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `git diff --check`
- repository pre-commit and commit-message hooks

Closes #25327
