### PR TITLE
test(guest-agent): contain timed-out command descendants

### DIFF
--- a/crates/guest-agent/tests/command_output_timeout.rs
+++ b/crates/guest-agent/tests/command_output_timeout.rs
@@ -3,11 +3,32 @@
 mod common;
 
 use std::io;
+use std::os::fd::OwnedFd;
+use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
-use std::time::Duration;
+use std::process::{Command as StdCommand, Stdio};
+use std::time::{Duration, Instant};
+use tokio::io::unix::AsyncFd;
 use tokio::process::Command;
 
 const MANAGED_TIMEOUT: Duration = Duration::from_secs(20);
+const FIXTURE_READY_TIMEOUT: Duration = Duration::from_secs(5);
+const FIXTURE_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+const DESCENDANT_EXIT_TIMEOUT: Duration = Duration::from_secs(1);
+const DESCENDANT_READY_ENV: &str = "VM0_TEST_DESCENDANT_READY_FILE";
+const DESCENDANT_RELEASE_ENV: &str = "VM0_TEST_DESCENDANT_RELEASE_FILE";
+const DESCENDANT_FIXTURE: &str = "command_output_timeout_descendant_fixture";
+
+struct DescendantCleanup {
+    pidfd: AsyncFd<OwnedFd>,
+}
+
+impl Drop for DescendantCleanup {
+    fn drop(&mut self) {
+        let _ =
+            rustix::process::pidfd_send_signal(self.pidfd.get_ref(), rustix::process::Signal::KILL);
+    }
+}
 
 #[tokio::test]
 async fn command_output_timeout_preserves_completed_output()
@@ -67,4 +88,162 @@ async fn command_output_timeout_reaps_child_before_returning()
         "timed-out child must be reaped before the helper returns"
     );
     Ok(())
+}
+
+#[tokio::test]
+async fn command_output_timeout_terminates_separate_group_descendant()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let readiness_path = tmp.path().join("descendant-ready");
+    let release_path = tmp.path().join("release-parent");
+    let mut command = Command::new(std::env::current_exe()?);
+    command
+        .arg("--ignored")
+        .arg("--exact")
+        .arg(DESCENDANT_FIXTURE)
+        .arg("--nocapture")
+        .env(DESCENDANT_READY_ENV, &readiness_path)
+        .env(DESCENDANT_RELEASE_ENV, &release_path);
+    let execution = tokio::spawn(async move {
+        common::command_output_with_timeout(
+            &mut command,
+            MANAGED_TIMEOUT,
+            "descendant-held output pipes exceeded their budget",
+        )
+        .await
+    });
+
+    common::wait_for_file_contains(&readiness_path, "\n", FIXTURE_READY_TIMEOUT).await?;
+    let (parent_pid, descendant_pid) = read_fixture_pids(&readiness_path)?;
+    let descendant = DescendantCleanup {
+        pidfd: open_pidfd(descendant_pid)?,
+    };
+    let parent_pidfd = open_pidfd(parent_pid)?;
+    let parent_rustix_pid = rustix_pid(parent_pid)?;
+    let descendant_rustix_pid = rustix_pid(descendant_pid)?;
+    assert_eq!(
+        rustix::process::getsid(Some(parent_rustix_pid))?,
+        parent_rustix_pid
+    );
+    assert_eq!(
+        rustix::process::getpgid(Some(parent_rustix_pid))?,
+        parent_rustix_pid
+    );
+    assert_eq!(
+        rustix::process::getsid(Some(descendant_rustix_pid))?,
+        parent_rustix_pid
+    );
+    assert_eq!(
+        rustix::process::getpgid(Some(descendant_rustix_pid))?,
+        descendant_rustix_pid
+    );
+
+    std::fs::write(&release_path, b"release\n")?;
+    assert!(
+        wait_for_pidfd_exit(&parent_pidfd, FIXTURE_EXIT_TIMEOUT).await?,
+        "fixture parent {parent_pid} must exit before the managed deadline advances"
+    );
+
+    tokio::time::pause();
+    tokio::time::advance(MANAGED_TIMEOUT).await;
+    let join_result = execution.await;
+    tokio::time::resume();
+
+    let descendant_exited = wait_for_pidfd_exit(&descendant.pidfd, DESCENDANT_EXIT_TIMEOUT).await?;
+    let error =
+        join_result?.expect_err("descendant-held output pipes should reach the managed timeout");
+
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(
+        error.to_string(),
+        "descendant-held output pipes exceeded their budget"
+    );
+    assert!(
+        descendant_exited,
+        "separate-process-group descendant {descendant_pid} remained live after helper timeout"
+    );
+    Ok(())
+}
+
+#[test]
+#[ignore = "subprocess fixture invoked by the descendant timeout integration test"]
+fn command_output_timeout_descendant_fixture() -> Result<(), Box<dyn std::error::Error>> {
+    let (Some(readiness_path), Some(release_path)) = (
+        std::env::var_os(DESCENDANT_READY_ENV),
+        std::env::var_os(DESCENDANT_RELEASE_ENV),
+    ) else {
+        return Ok(());
+    };
+
+    let mut descendant = StdCommand::new("/bin/sleep")
+        .arg("60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .process_group(0)
+        .spawn()?;
+    let descendant_pid = descendant.id();
+    std::fs::write(
+        &readiness_path,
+        format!("{} {descendant_pid}\n", std::process::id()),
+    )?;
+    let release_path = PathBuf::from(release_path);
+    let release_deadline = Instant::now() + FIXTURE_EXIT_TIMEOUT;
+    while !release_path.exists() {
+        if Instant::now() >= release_deadline {
+            descendant.kill()?;
+            descendant.wait()?;
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "timed out waiting to release descendant fixture parent",
+            )
+            .into());
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+
+    drop(descendant);
+    Ok(())
+}
+
+fn read_fixture_pids(path: &std::path::Path) -> io::Result<(u32, u32)> {
+    let contents = std::fs::read_to_string(path)?;
+    let mut fields = contents.split_whitespace();
+    let parent_pid = fields
+        .next()
+        .ok_or_else(|| io::Error::other("descendant readiness omitted parent PID"))?
+        .parse()
+        .map_err(|error| io::Error::other(format!("parse fixture parent PID: {error}")))?;
+    let descendant_pid = fields
+        .next()
+        .ok_or_else(|| io::Error::other("descendant readiness omitted descendant PID"))?
+        .parse()
+        .map_err(|error| io::Error::other(format!("parse fixture descendant PID: {error}")))?;
+    if fields.next().is_some() {
+        return Err(io::Error::other(
+            "descendant readiness contained unexpected fields",
+        ));
+    }
+    Ok((parent_pid, descendant_pid))
+}
+
+fn rustix_pid(pid: u32) -> io::Result<rustix::process::Pid> {
+    let raw_pid =
+        i32::try_from(pid).map_err(|_| io::Error::other("fixture PID does not fit in pid_t"))?;
+    rustix::process::Pid::from_raw(raw_pid)
+        .ok_or_else(|| io::Error::other("fixture PID cannot identify a process"))
+}
+
+fn open_pidfd(pid: u32) -> io::Result<AsyncFd<OwnedFd>> {
+    let pidfd =
+        rustix::process::pidfd_open(rustix_pid(pid)?, rustix::process::PidfdFlags::empty())?;
+    AsyncFd::new(pidfd)
+}
+
+async fn wait_for_pidfd_exit(pidfd: &AsyncFd<OwnedFd>, timeout: Duration) -> io::Result<bool> {
+    match tokio::time::timeout(timeout, pidfd.readable()).await {
+        Ok(Ok(_)) => Ok(true),
+        Ok(Err(error)) => Err(error),
+        Err(_) => Ok(false),
+    }
 }

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -17,6 +17,7 @@
 
 #![allow(dead_code)] // consumed across multiple test binaries
 
+mod process_session;
 mod system_log;
 
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
@@ -41,9 +42,13 @@ use tokio::net::TcpListener;
 use tokio::process::Command;
 use tokio::sync::{mpsc, oneshot};
 
+use process_session::CommandSession;
+
 pub type SystemLogOverrideGuard = system_log::SystemLogOverrideGuard;
 
 static UNIQUE_TEMP_PATH_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+const COMMAND_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// 128 + SIGTERM(15). Rust / glibc's default signal handler maps a
 /// SIGTERM-terminated process to this exit code.
@@ -97,22 +102,21 @@ pub async fn command_output_with_timeout(
     timeout: Duration,
     timeout_context: &str,
 ) -> io::Result<Output> {
+    CommandSession::configure(command);
     let mut child = command
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true)
         .spawn()?;
+    let session = CommandSession::from_child(&child)?;
     let (Some(mut stdout), Some(mut stderr)) = (child.stdout.take(), child.stderr.take()) else {
-        return match child.kill().await {
-            Ok(()) => Err(io::Error::other(
+        return match terminate_command(&mut child, &session).await {
+            Ok(_) => Err(io::Error::other(
                 "captured child omitted its stdout or stderr pipe",
             )),
-            Err(error) => Err(io::Error::new(
-                error.kind(),
-                format!(
-                    "captured child omitted its stdout or stderr pipe; failed to terminate and reap child: {error}"
-                ),
-            )),
+            Err(error) => Err(io::Error::other(format!(
+                "captured child omitted its stdout or stderr pipe; cleanup failed: {error}"
+            ))),
         };
     };
     let mut stdout_bytes = Vec::new();
@@ -120,12 +124,11 @@ pub async fn command_output_with_timeout(
 
     let output = {
         let wait_with_output = async {
-            let (status, stdout_result, stderr_result) = tokio::join!(
-                child.wait(),
+            let (stdout_result, stderr_result) = tokio::join!(
                 stdout.read_to_end(&mut stdout_bytes),
                 stderr.read_to_end(&mut stderr_bytes),
             );
-            let status = status?;
+            let status = child.wait().await?;
             stdout_result?;
             stderr_result?;
             Ok(Output {
@@ -139,17 +142,79 @@ pub async fn command_output_with_timeout(
 
     match output {
         Ok(output) => output,
-        Err(_) => match child.kill().await {
-            Ok(()) => Err(io::Error::new(
+        Err(_) => match terminate_command(&mut child, &session).await {
+            Ok(_) => Err(io::Error::new(
                 io::ErrorKind::TimedOut,
                 timeout_context.to_string(),
             )),
-            Err(error) => Err(io::Error::new(
-                error.kind(),
-                format!("{timeout_context}; failed to terminate and reap timed-out child: {error}"),
-            )),
+            Err(error) => Err(io::Error::other(format!(
+                "{timeout_context}; timed-out command cleanup failed: {error}"
+            ))),
         },
     }
+}
+
+async fn terminate_command(
+    child: &mut tokio::process::Child,
+    session: &CommandSession,
+) -> Result<std::process::ExitStatus, String> {
+    let direct_kill_error = child.start_kill().err();
+    let deadline = tokio::time::Instant::now() + COMMAND_CLEANUP_TIMEOUT;
+    let session_error = session
+        .kill_members(deadline, COMMAND_CLEANUP_TIMEOUT)
+        .await
+        .err();
+    let wait_result = wait_for_child_until(child, deadline).await;
+
+    match (session_error, wait_result) {
+        (None, Ok(status)) => Ok(status),
+        (Some(session_error), Ok(status)) => Err(command_cleanup_error(
+            direct_kill_error,
+            Some(session_error),
+            format!("killed child status: {status}"),
+        )),
+        (session_error, Err(wait_error)) => Err(command_cleanup_error(
+            direct_kill_error,
+            session_error,
+            wait_error,
+        )),
+    }
+}
+
+async fn wait_for_child_until(
+    child: &mut tokio::process::Child,
+    deadline: tokio::time::Instant,
+) -> Result<std::process::ExitStatus, String> {
+    match child.try_wait() {
+        Ok(Some(status)) => return Ok(status),
+        Ok(None) => {}
+        Err(error) => return Err(format!("wait after kill failed: {error}")),
+    }
+
+    match tokio::time::timeout_at(deadline, child.wait()).await {
+        Ok(Ok(status)) => Ok(status),
+        Ok(Err(error)) => Err(format!("wait after kill failed: {error}")),
+        Err(_) => Err(format!(
+            "wait after kill timed out after {}ms",
+            COMMAND_CLEANUP_TIMEOUT.as_millis()
+        )),
+    }
+}
+
+fn command_cleanup_error(
+    direct_kill_error: Option<io::Error>,
+    session_error: Option<String>,
+    wait_result: String,
+) -> String {
+    let mut errors = Vec::new();
+    if let Some(direct_kill_error) = direct_kill_error {
+        errors.push(format!("start kill failed: {direct_kill_error}"));
+    }
+    if let Some(session_error) = session_error {
+        errors.push(format!("session cleanup failed: {session_error}"));
+    }
+    errors.push(wait_result);
+    errors.join("; ")
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/guest-agent/tests/common/process_session.rs
+++ b/crates/guest-agent/tests/common/process_session.rs
@@ -1,0 +1,304 @@
+use std::io;
+use std::os::fd::OwnedFd;
+use std::time::Duration;
+
+use rustix::process::{Pid, PidfdFlags, Signal};
+use tokio::process::{Child, Command};
+
+const SESSION_SCAN_INTERVAL: Duration = Duration::from_millis(10);
+
+pub(super) struct CommandSession {
+    session_id: Pid,
+}
+
+struct SessionMember {
+    pid: Pid,
+    pidfd: OwnedFd,
+}
+
+struct SessionScan {
+    live_pids: Vec<Pid>,
+    members: Vec<SessionMember>,
+    error: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+struct ProcessStat {
+    state: u8,
+    starttime: u64,
+}
+
+enum ProcessStatRead {
+    Found(ProcessStat),
+    Missing,
+    Unreadable(io::Error),
+    Invalid,
+}
+
+impl CommandSession {
+    pub(super) fn configure(command: &mut Command) {
+        // SAFETY: `setsid` is async-signal-safe and the closure performs no
+        // work beyond that syscall and converting its errno on failure.
+        unsafe {
+            command.pre_exec(|| rustix::process::setsid().map(drop).map_err(io::Error::from));
+        }
+    }
+
+    pub(super) fn from_child(child: &Child) -> io::Result<Self> {
+        let child_pid = child.id().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "spawned command PID is unavailable",
+            )
+        })?;
+        let raw_pid = i32::try_from(child_pid).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "spawned command PID does not fit in pid_t",
+            )
+        })?;
+        let session_id = Pid::from_raw(raw_pid).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "spawned command PID cannot identify a session",
+            )
+        })?;
+        Ok(Self { session_id })
+    }
+
+    pub(super) async fn kill_members(
+        &self,
+        deadline: tokio::time::Instant,
+        cleanup_timeout: Duration,
+    ) -> Result<(), String> {
+        let mut first_error = None;
+
+        loop {
+            let scan = match tokio::time::timeout_at(
+                deadline,
+                scan_session_members(self.session_id),
+            )
+            .await
+            {
+                Ok(Ok(scan)) => scan,
+                Ok(Err(error)) => {
+                    return Err(combine_errors(first_error, error));
+                }
+                Err(_) => {
+                    let timeout = format!(
+                        "session {} scan timed out after {}ms",
+                        self.session_id,
+                        cleanup_timeout.as_millis()
+                    );
+                    return Err(combine_errors(first_error, timeout));
+                }
+            };
+            if first_error.is_none() {
+                first_error = scan.error;
+            }
+            if scan.live_pids.is_empty() {
+                return match first_error {
+                    Some(error) => Err(error),
+                    None => Ok(()),
+                };
+            }
+
+            for member in scan.members {
+                if let Err(error) = rustix::process::pidfd_send_signal(&member.pidfd, Signal::KILL)
+                    && error != rustix::io::Errno::SRCH
+                    && first_error.is_none()
+                {
+                    first_error = Some(format!(
+                        "pidfd signal failed for session {} member {}: {error}",
+                        self.session_id, member.pid
+                    ));
+                }
+            }
+
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                let live_pids = scan
+                    .live_pids
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let timeout = format!(
+                    "session {} remained live after {}ms (pids: {live_pids})",
+                    self.session_id,
+                    cleanup_timeout.as_millis()
+                );
+                return Err(combine_errors(first_error, timeout));
+            }
+            tokio::time::sleep(remaining.min(SESSION_SCAN_INTERVAL)).await;
+        }
+    }
+}
+
+async fn scan_session_members(session_id: Pid) -> Result<SessionScan, String> {
+    let mut entries = tokio::fs::read_dir("/proc")
+        .await
+        .map_err(|error| format!("read /proc for session {session_id}: {error}"))?;
+    let mut live_pids = Vec::new();
+    let mut members = Vec::new();
+    let mut first_error = None;
+
+    loop {
+        let entry = entries
+            .next_entry()
+            .await
+            .map_err(|error| format!("iterate /proc for session {session_id}: {error}"))?;
+        let Some(entry) = entry else {
+            break;
+        };
+        let Some(pid_text) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let Ok(raw_pid) = pid_text.parse::<i32>() else {
+            continue;
+        };
+        let Some(pid) = Pid::from_raw(raw_pid) else {
+            continue;
+        };
+
+        let before = match read_process_stat(pid).await {
+            ProcessStatRead::Found(stat) if process_stat_is_live(stat) => stat,
+            ProcessStatRead::Found(_) | ProcessStatRead::Missing => continue,
+            ProcessStatRead::Unreadable(error) => {
+                record_owned_stat_error(
+                    pid,
+                    session_id,
+                    format!("read /proc/{pid}/stat: {error}"),
+                    &mut live_pids,
+                    &mut first_error,
+                );
+                continue;
+            }
+            ProcessStatRead::Invalid => {
+                record_owned_stat_error(
+                    pid,
+                    session_id,
+                    format!("parse /proc/{pid}/stat"),
+                    &mut live_pids,
+                    &mut first_error,
+                );
+                continue;
+            }
+        };
+        if process_session_id(pid) != Ok(session_id) {
+            continue;
+        }
+
+        let pidfd = match rustix::process::pidfd_open(pid, PidfdFlags::empty()) {
+            Ok(pidfd) => pidfd,
+            Err(rustix::io::Errno::SRCH) => continue,
+            Err(error) => {
+                live_pids.push(pid);
+                if first_error.is_none() {
+                    first_error = Some(format!(
+                        "pidfd_open failed for session {session_id} member {pid}: {error}"
+                    ));
+                }
+                continue;
+            }
+        };
+
+        match read_process_stat(pid).await {
+            ProcessStatRead::Found(stat)
+                if process_stat_is_live(stat) && stat.starttime == before.starttime => {}
+            ProcessStatRead::Found(_) | ProcessStatRead::Missing => continue,
+            ProcessStatRead::Unreadable(error) => {
+                record_owned_stat_error(
+                    pid,
+                    session_id,
+                    format!("re-read /proc/{pid}/stat: {error}"),
+                    &mut live_pids,
+                    &mut first_error,
+                );
+                continue;
+            }
+            ProcessStatRead::Invalid => {
+                record_owned_stat_error(
+                    pid,
+                    session_id,
+                    format!("re-parse /proc/{pid}/stat"),
+                    &mut live_pids,
+                    &mut first_error,
+                );
+                continue;
+            }
+        }
+        if process_session_id(pid) != Ok(session_id) {
+            continue;
+        }
+
+        live_pids.push(pid);
+        members.push(SessionMember { pid, pidfd });
+    }
+
+    Ok(SessionScan {
+        live_pids,
+        members,
+        error: first_error,
+    })
+}
+
+fn record_owned_stat_error(
+    pid: Pid,
+    session_id: Pid,
+    error: String,
+    live_pids: &mut Vec<Pid>,
+    first_error: &mut Option<String>,
+) {
+    if process_session_id(pid) != Ok(session_id) {
+        return;
+    }
+    live_pids.push(pid);
+    if first_error.is_none() {
+        *first_error = Some(format!(
+            "session {session_id} member {pid} process state unavailable: {error}"
+        ));
+    }
+}
+
+fn process_session_id(pid: Pid) -> rustix::io::Result<Pid> {
+    rustix::process::getsid(Some(pid))
+}
+
+async fn read_process_stat(pid: Pid) -> ProcessStatRead {
+    let path = format!("/proc/{pid}/stat");
+    match tokio::fs::read(path).await {
+        Ok(content) => match parse_process_stat(&content) {
+            Some(stat) => ProcessStatRead::Found(stat),
+            None => ProcessStatRead::Invalid,
+        },
+        Err(error) if error.kind() == io::ErrorKind::NotFound => ProcessStatRead::Missing,
+        Err(error) => ProcessStatRead::Unreadable(error),
+    }
+}
+
+fn parse_process_stat(content: &[u8]) -> Option<ProcessStat> {
+    let comm_end = content.iter().rposition(|byte| *byte == b')')?;
+    let fields = content.get(comm_end.checked_add(2)?..)?;
+    let mut fields = fields
+        .split(|byte| byte.is_ascii_whitespace())
+        .filter(|field| !field.is_empty());
+    let state_field = fields.next()?;
+    if state_field.len() != 1 {
+        return None;
+    }
+    let state = *state_field.first()?;
+    let starttime = std::str::from_utf8(fields.nth(18)?).ok()?.parse().ok()?;
+    Some(ProcessStat { state, starttime })
+}
+
+fn process_stat_is_live(stat: ProcessStat) -> bool {
+    !matches!(stat.state, b'Z' | b'X' | b'x')
+}
+
+fn combine_errors(first_error: Option<String>, error: String) -> String {
+    match first_error {
+        Some(first_error) => format!("{first_error}; {error}"),
+        None => error,
+    }
+}


### PR DESCRIPTION
## Summary

- launch commands managed by the guest-agent integration-test helper in a dedicated Linux session
- on timeout, discover every live member of that session across process groups, bind each process identity with a pidfd, terminate it, and reap the direct child before returning
- add an integration regression where the direct child exits while a descendant in a separate process group keeps the captured output pipes open

## Scope

- test infrastructure only; no production runtime, API, schema, persisted data, migration, or dependency changes
- descendants that explicitly create a new session are outside this cleanup boundary; no current helper caller does that

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent --no-deps --all-features --quiet`
- `cargo test -p guest-agent --test command_output_timeout --all-features -- --nocapture`
- descendant regression repeated successfully 20 consecutive times
- `cargo test -p guest-agent --all-targets --all-features --quiet`
- `git diff --check`

Closes #25328
