### PR TITLE
test(guest-agent): bound codex entry-point subprocesses

### DIFF
--- a/crates/guest-agent/tests/codex_setup_fail_closed.rs
+++ b/crates/guest-agent/tests/codex_setup_fail_closed.rs
@@ -9,12 +9,16 @@ use guest_contracts::diagnostics::{FailureClass, FailureDiagnostic};
 use serde_json::Value;
 use shell_quote::quote_shell_arg;
 use std::path::Path;
-use std::process::{Command, Output};
+use std::process::Output;
+use std::time::Duration;
+use tokio::process::Command;
+
+const GUEST_AGENT_TIMEOUT: Duration = Duration::from_secs(20);
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
-#[test]
-fn codex_setup_failure_exits_before_cli_spawn() -> TestResult {
+#[tokio::test]
+async fn codex_setup_failure_exits_before_cli_spawn() -> TestResult {
     common::ensure_canonical_workspace_for_test()?;
 
     let tmp = tempfile::tempdir()?;
@@ -38,7 +42,8 @@ fn codex_setup_failure_exits_before_cli_spawn() -> TestResult {
         run_payload_path: &run_payload_path,
         home: tmp.path(),
         run_id: "codex-auth-setup-fail-closed",
-    })?;
+    })
+    .await?;
 
     assert!(
         !output.status.success(),
@@ -84,8 +89,8 @@ fn codex_setup_failure_exits_before_cli_spawn() -> TestResult {
 }
 
 #[cfg(unix)]
-#[test]
-fn codex_setup_rejects_symlinked_home_before_model_catalog_write() -> TestResult {
+#[tokio::test]
+async fn codex_setup_rejects_symlinked_home_before_model_catalog_write() -> TestResult {
     common::ensure_canonical_workspace_for_test()?;
 
     let tmp = tempfile::tempdir()?;
@@ -122,7 +127,8 @@ fn codex_setup_rejects_symlinked_home_before_model_catalog_write() -> TestResult
         run_payload_path: &run_payload_path,
         home: tmp.path(),
         run_id: "codex-auth-setup-symlink-fail-closed",
-    })?;
+    })
+    .await?;
 
     assert!(
         !output.status.success(),
@@ -156,9 +162,10 @@ struct GuestAgentInvocation<'a> {
     run_id: &'a str,
 }
 
-fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::io::Error> {
+async fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::io::Error> {
     let guest_agent = env!("CARGO_BIN_EXE_guest-agent");
-    Command::new(guest_agent)
+    let mut command = Command::new(guest_agent);
+    command
         .env_clear()
         .env("CLI_AGENT_TYPE", "codex")
         .env("USE_MOCK_CODEX", "true")
@@ -176,8 +183,12 @@ fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::io::Er
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
             args.runtime_dir,
         )
-        .env("HOME", args.home)
-        .output()
+        .env("HOME", args.home);
+    let timeout_context = format!(
+        "codex_setup_fail_closed guest-agent scenario '{}' exceeded its completion budget",
+        args.run_id
+    );
+    common::command_output_with_timeout(&mut command, GUEST_AGENT_TIMEOUT, &timeout_context).await
 }
 
 fn write_fake_codex(path: &Path, marker: &Path) -> TestResult {

--- a/crates/guest-agent/tests/codex_startup_telemetry.rs
+++ b/crates/guest-agent/tests/codex_startup_telemetry.rs
@@ -5,14 +5,17 @@ mod common;
 use serde_json::{Value, json};
 use shell_quote::quote_shell_arg;
 use std::path::Path;
-use std::process::{Command, Output};
+use std::process::Output;
+use std::time::Duration;
+use tokio::process::Command;
 
 const CODEX_STARTUP_ACTION: &str = "codex_startup";
+const GUEST_AGENT_TIMEOUT: Duration = Duration::from_secs(20);
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
-#[test]
-fn ordinary_codex_records_startup_success_once_at_turn_started() -> TestResult {
+#[tokio::test]
+async fn ordinary_codex_records_startup_success_once_at_turn_started() -> TestResult {
     common::ensure_canonical_workspace_for_test()?;
 
     let tmp = tempfile::tempdir()?;
@@ -45,7 +48,8 @@ fn ordinary_codex_records_startup_success_once_at_turn_started() -> TestResult {
         run_payload_path: &run_payload_path,
         home: tmp.path(),
         run_id: "codex-startup-success",
-    })?;
+    })
+    .await?;
 
     assert_guest_success(&output);
     let operations = read_sandbox_operations(&runtime_dir)?;
@@ -54,8 +58,8 @@ fn ordinary_codex_records_startup_success_once_at_turn_started() -> TestResult {
     Ok(())
 }
 
-#[test]
-fn ordinary_codex_exit_before_turn_started_records_startup_failure() -> TestResult {
+#[tokio::test]
+async fn ordinary_codex_exit_before_turn_started_records_startup_failure() -> TestResult {
     common::ensure_canonical_workspace_for_test()?;
 
     let tmp = tempfile::tempdir()?;
@@ -80,7 +84,8 @@ fn ordinary_codex_exit_before_turn_started_records_startup_failure() -> TestResu
         run_payload_path: &run_payload_path,
         home: tmp.path(),
         run_id: "codex-startup-before-turn-exit",
-    })?;
+    })
+    .await?;
 
     assert_guest_success(&output);
     let operations = read_sandbox_operations(&runtime_dir)?;
@@ -89,8 +94,8 @@ fn ordinary_codex_exit_before_turn_started_records_startup_failure() -> TestResu
     Ok(())
 }
 
-#[test]
-fn app_server_records_startup_success_at_primary_turn_started() -> TestResult {
+#[tokio::test]
+async fn app_server_records_startup_success_at_primary_turn_started() -> TestResult {
     common::ensure_canonical_workspace_for_test()?;
 
     let mock_codex = common::build_and_locate_mock_codex()?;
@@ -107,7 +112,8 @@ fn app_server_records_startup_success_at_primary_turn_started() -> TestResult {
         run_payload_path: &run_payload_path,
         home: tmp.path(),
         run_id: "codex-app-server-startup-success",
-    })?;
+    })
+    .await?;
 
     assert_guest_success(&output);
     let operations = read_sandbox_operations(&runtime_dir)?;
@@ -116,8 +122,8 @@ fn app_server_records_startup_success_at_primary_turn_started() -> TestResult {
     Ok(())
 }
 
-#[test]
-fn app_server_secondary_turn_started_does_not_complete_startup() -> TestResult {
+#[tokio::test]
+async fn app_server_secondary_turn_started_does_not_complete_startup() -> TestResult {
     common::ensure_canonical_workspace_for_test()?;
 
     let mock_codex = common::build_and_locate_mock_codex()?;
@@ -134,7 +140,8 @@ fn app_server_secondary_turn_started_does_not_complete_startup() -> TestResult {
         run_payload_path: &run_payload_path,
         home: tmp.path(),
         run_id: "codex-app-server-secondary-startup",
-    })?;
+    })
+    .await?;
 
     assert_guest_success(&output);
     let operations = read_sandbox_operations(&runtime_dir)?;
@@ -143,8 +150,8 @@ fn app_server_secondary_turn_started_does_not_complete_startup() -> TestResult {
     Ok(())
 }
 
-#[test]
-fn claude_code_does_not_record_codex_startup() -> TestResult {
+#[tokio::test]
+async fn claude_code_does_not_record_codex_startup() -> TestResult {
     common::ensure_canonical_workspace_for_test()?;
 
     let tmp = tempfile::tempdir()?;
@@ -173,7 +180,8 @@ fn claude_code_does_not_record_codex_startup() -> TestResult {
         run_payload_path: &run_payload_path,
         home: tmp.path(),
         run_id: "claude-startup-control",
-    })?;
+    })
+    .await?;
 
     assert_guest_success(&output);
     let operations = read_sandbox_operations(&runtime_dir)?;
@@ -205,7 +213,7 @@ struct GuestAgentInvocation<'a> {
     run_id: &'a str,
 }
 
-fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::io::Error> {
+async fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::io::Error> {
     let mut command = Command::new(env!("CARGO_BIN_EXE_guest-agent"));
     command
         .env_clear()
@@ -247,7 +255,11 @@ fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::io::Er
         }
     }
 
-    command.output()
+    let timeout_context = format!(
+        "codex_startup_telemetry guest-agent scenario '{}' exceeded its completion budget",
+        args.run_id
+    );
+    common::command_output_with_timeout(&mut command, GUEST_AGENT_TIMEOUT, &timeout_context).await
 }
 
 fn write_run_payload(runtime_dir: &Path, prompt: &str) -> Result<std::path::PathBuf, String> {


### PR DESCRIPTION
## Summary

- bound all seven real guest-agent invocations in the Codex setup and startup telemetry integration suites to a 20-second local completion budget
- reuse the shared session-contained subprocess helper so timeouts terminate descendants and reap the managed child before returning
- preserve the existing exit status, stdout, stderr, filesystem, diagnostic, and telemetry assertions while naming the exact suite and run scenario on timeout

## Scope

This is a test-only caller migration. It does not change production behavior, APIs, protocols, schemas, persistence, migrations, dependencies, or deployment behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent --no-deps --all-features`
- `cargo test -p guest-agent --test codex_setup_fail_closed --test codex_startup_telemetry`
- `cargo test -p guest-agent --all-targets --all-features`
- `git diff --check`

Closes #25333
