### PR TITLE
fix: neutralize non-allowlisted html tags at the markdown root

### DIFF
--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -87,6 +87,18 @@ describe("assistant markdown", () => {
     expect(container.querySelector(".wmde-markdown span")).toBeNull();
   });
 
+  it("neutralizes non-allowlisted tags written at the top level", () => {
+    const { container } = render(
+      <StoreProvider value={context.store}>
+        <Markdown source={"<style>\n* { margin: 0; padding: 0; }\n</style>"} />
+      </StoreProvider>,
+    );
+
+    // A live <style> element would apply its rules to the whole app document.
+    expect(container.querySelector("style")).toBeNull();
+    expect(container.textContent).toContain("* { margin: 0; padding: 0; }");
+  });
+
   it("keeps blockquotes rendering when html is escaped", () => {
     const { container } = render(
       <StoreProvider value={context.store}>

--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -87,18 +87,6 @@ describe("assistant markdown", () => {
     expect(container.querySelector(".wmde-markdown span")).toBeNull();
   });
 
-  it("neutralizes non-allowlisted tags written at the top level", () => {
-    const { container } = render(
-      <StoreProvider value={context.store}>
-        <Markdown source={"<style>\n* { margin: 0; padding: 0; }\n</style>"} />
-      </StoreProvider>,
-    );
-
-    // A live <style> element would apply its rules to the whole app document.
-    expect(container.querySelector("style")).toBeNull();
-    expect(container.textContent).toContain("* { margin: 0; padding: 0; }");
-  });
-
   it("keeps blockquotes rendering when html is escaped", () => {
     const { container } = render(
       <StoreProvider value={context.store}>
@@ -145,6 +133,34 @@ describe("assistant markdown", () => {
         document.querySelector('[data-color-mode="light"]'),
       ).toBeInTheDocument();
     });
+  });
+
+  it("shows a raw style block as text instead of styling the page", async () => {
+    mockThread("<style>\n.zero-injected { color: red }\n</style>");
+
+    detachedSetupPage({ context, path: "/chats/thread-markdown" });
+
+    await waitFor(() => {
+      expect(document.querySelector(".wmde-markdown")?.textContent).toContain(
+        ".zero-injected { color: red }",
+      );
+    });
+    // A mounted stylesheet would restyle the whole page, not just this message.
+    const injectedSheets = Array.from(
+      document.querySelectorAll("style"),
+    ).filter((sheet) => {
+      return sheet.textContent?.includes(".zero-injected") ?? false;
+    });
+    expect(injectedSheets).toHaveLength(0);
+  });
+
+  it("keeps allowlisted html blocks rendering as elements", async () => {
+    mockThread("<div><strong>kept markup</strong></div>");
+
+    detachedSetupPage({ context, path: "/chats/thread-markdown" });
+
+    const kept = await screen.findByText("kept markup", { selector: "strong" });
+    expect(kept).toBeInTheDocument();
   });
 
   it("renders media links inline", async () => {

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -152,11 +152,15 @@ const rehypeRewriteHandler = (() => {
   return (...args: RewriteArgs) => {
     const [node, , parent] = args;
 
-    // Convert unknown HTML tags to plain text, preserving child content
+    // Convert unknown HTML tags to plain text, preserving child content.
+    // Raw HTML written at the top level of a document lands directly under the
+    // hast root, so root-level nodes must be rewritten too — otherwise tags
+    // like <style> and <script> survive into the app's DOM, where a generated
+    // `* { margin: 0; padding: 0 }` reset unstyles the whole page.
     if (
       node.type === "element" &&
       !validHtmlTags.has(node.tagName) &&
-      parent?.type === "element"
+      (parent?.type === "element" || parent?.type === "root")
     ) {
       const inner = collectText(node);
       const text = inner


### PR DESCRIPTION
## Problem

An activity page unstyles itself the moment its steps finish loading: every element loses its padding and margins (`WebModel`, `StepsContextRunnerNetwork`, the header card and search input collapse onto their own edges) while colors, borders and `gap-*` keep working.

The run in question generated an HTML slide deck whose markup opens with the classic reset:

```css
* { margin: 0; padding: 0; box-sizing: border-box; }
```

That reset is unlayered, so it beats every Tailwind utility in `@layer utilities` — which is exactly the padding/margin-only breakage that shows up on screen.

## Root cause

`rehypeRewriteHandler` in `markdown.tsx` turns every tag outside `validHtmlTags` (no `style`, `script`, `link`, `meta`) into plain text, but only when `parent?.type === "element"`. Raw HTML written at the top level of a markdown document lands **directly under the hast `root`**, so the rewrite never ran for it:

| source | `parent.type` | before this PR |
| --- | --- | --- |
| `<style>…</style>` at top level | `root` | rendered as a live `<style>` element |
| `<div><style>…</style></div>` | `element` | rewritten to text |

`@uiw/react-markdown-preview/common` enables `rehype-raw` and ships no `rehype-sanitize`, so whatever the rewrite misses reaches the DOM verbatim. Activity steps render `<Markdown source={…} />` without `escapeHtml`, so agent output takes that path. The same gap also let a top-level `<script>` through.

## Change

Rewrite root-level nodes as well, so non-allowlisted tags are neutralized regardless of depth. Adds a regression test asserting a top-level `<style>` renders as text and produces no `<style>` element.

Closes #25354
