### PR TITLE
fix: stabilize browser fit resize lifecycle

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
@@ -40,8 +40,13 @@ export interface BrowserSessionSignals extends BrowserSessionDescriptor {
   readonly reloadPanel$: Command<void, []>;
   readonly start$: Command<Promise<void>, [AbortSignal]>;
   readonly close$: Command<Promise<void>, [AbortSignal]>;
-  readonly fitWindow$: Command<Promise<void>, [number, AbortSignal]>;
+  readonly fitViewport$: Command<Promise<void>, [AbortSignal]>;
+  readonly syncFitActionVisibility$: Command<void, []>;
   readonly subscribe$: Command<Promise<void>, [AbortSignal]>;
+  readonly fitViewportRef$: Command<
+    (() => void) | undefined,
+    [HTMLDivElement | null]
+  >;
   // Attach to the visible panel container: the lease heartbeat lives exactly as
   // long as that element is mounted.
   readonly keepAliveRef$: Command<
@@ -89,6 +94,138 @@ function viewerIsVisible(): boolean {
     : document.visibilityState === "visible";
 }
 
+const BROWSER_FIT_GAP_TOLERANCE_PX = 2;
+
+interface ViewportSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+interface BrowserFitDomSignals extends Pick<
+  BrowserSessionSignals,
+  "fitViewportRef$" | "syncFitActionVisibility$"
+> {
+  readonly syncFitActionForScreen$: Command<
+    void,
+    [ZeroBrowserSession["screen"]]
+  >;
+  readonly viewportAspectRatio$: Command<number | null, []>;
+}
+
+function measuredViewport(element: HTMLElement | null): ViewportSize | null {
+  if (!element) {
+    return null;
+  }
+  const { width, height } = element.getBoundingClientRect();
+  if (
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    return null;
+  }
+  return { width, height };
+}
+
+function browserFrameNeedsFit(
+  viewport: ViewportSize | null,
+  browserAspectRatio: number,
+): boolean {
+  if (
+    !viewport ||
+    !Number.isFinite(browserAspectRatio) ||
+    browserAspectRatio <= 0
+  ) {
+    return false;
+  }
+  const fittedWidth = Math.min(
+    viewport.width,
+    viewport.height * browserAspectRatio,
+  );
+  const fittedHeight = Math.min(
+    viewport.height,
+    viewport.width / browserAspectRatio,
+  );
+  return (
+    viewport.width - fittedWidth > BROWSER_FIT_GAP_TOLERANCE_PX ||
+    viewport.height - fittedHeight > BROWSER_FIT_GAP_TOLERANCE_PX
+  );
+}
+
+function createBrowserFitDomSignals(): BrowserFitDomSignals {
+  const runtime: { viewport: HTMLDivElement | null } = { viewport: null };
+  const fitAction = (): HTMLElement | null => {
+    return (
+      runtime.viewport?.querySelector("[data-browser-session-fit-action]") ??
+      null
+    );
+  };
+  const updateFitActionVisibility = (
+    browserAspectRatio: number,
+    canFitWindow: boolean,
+  ): void => {
+    const action = fitAction();
+    if (!action) {
+      return;
+    }
+    action.hidden = !(
+      canFitWindow &&
+      browserFrameNeedsFit(
+        measuredViewport(runtime.viewport),
+        browserAspectRatio,
+      )
+    );
+  };
+  const syncFitActionVisibility$ = command(() => {
+    const viewport = runtime.viewport;
+    const browserAspectRatio = Number(
+      viewport?.dataset.browserAspectRatio ?? "",
+    );
+    const canFitWindow = viewport?.dataset.canFitWindow === "true";
+    updateFitActionVisibility(browserAspectRatio, canFitWindow);
+  });
+  const syncFitActionForScreen$ = command(
+    (_, screen: ZeroBrowserSession["screen"]): void => {
+      updateFitActionVisibility(
+        screen ? screen.width / screen.height : Number.NaN,
+        screen?.resizable === true,
+      );
+    },
+  );
+  const viewportAspectRatio$ = command((): number | null => {
+    const size = measuredViewport(runtime.viewport);
+    return size ? size.width / size.height : null;
+  });
+  const fitViewportRef$ = onRef(
+    command(({ set }, viewport: HTMLDivElement, signal: AbortSignal): void => {
+      runtime.viewport = viewport;
+      const syncFitActionVisibility = () => {
+        set(syncFitActionVisibility$);
+      };
+      const win = viewport.ownerDocument.defaultView;
+      win?.addEventListener("resize", syncFitActionVisibility);
+      signal.addEventListener(
+        "abort",
+        () => {
+          win?.removeEventListener("resize", syncFitActionVisibility);
+          if (runtime.viewport === viewport) {
+            runtime.viewport = null;
+          }
+        },
+        { once: true },
+      );
+      set(syncFitActionVisibility$);
+    }),
+  );
+  return {
+    fitViewportRef$,
+    syncFitActionForScreen$,
+    syncFitActionVisibility$,
+    viewportAspectRatio$,
+  };
+}
+
 async function fetchBrowserSession(
   createClient: ZeroClientFactory,
   threadId: string,
@@ -107,15 +244,16 @@ async function fetchBrowserSession(
 function createFitWindowSignals(
   descriptor: BrowserSessionDescriptor,
   sessionOverride$: State<ZeroBrowserSession | null | undefined>,
-): Pick<BrowserSessionSignals, "fittingWindow$" | "fitWindow$"> {
+  browserFitDom: BrowserFitDomSignals,
+): Pick<BrowserSessionSignals, "fittingWindow$" | "fitViewport$"> {
   const fittingWindowState$ = state(false);
-  const fitWindow$ = command(
-    async (
-      { get, set },
-      aspectRatio: number,
-      signal: AbortSignal,
-    ): Promise<void> => {
+  const fitViewport$ = command(
+    async ({ get, set }, signal: AbortSignal): Promise<void> => {
       if (get(fittingWindowState$)) {
+        return;
+      }
+      const aspectRatio = set(browserFitDom.viewportAspectRatio$);
+      if (aspectRatio === null) {
         return;
       }
       set(fittingWindowState$, true);
@@ -138,6 +276,10 @@ function createFitWindowSignals(
       );
       if (fitted.ok) {
         set(sessionOverride$, fitted.value.body.browser);
+        set(
+          browserFitDom.syncFitActionForScreen$,
+          fitted.value.body.browser.screen,
+        );
       }
     },
   );
@@ -145,7 +287,7 @@ function createFitWindowSignals(
     fittingWindow$: computed((get) => {
       return get(fittingWindowState$);
     }),
-    fitWindow$,
+    fitViewport$,
   };
 }
 
@@ -306,9 +448,11 @@ export function createBrowserSessionSignals(
     });
   });
 
-  const { fittingWindow$, fitWindow$ } = createFitWindowSignals(
+  const browserFitDom = createBrowserFitDomSignals();
+  const { fittingWindow$, fitViewport$ } = createFitWindowSignals(
     descriptor,
     sessionOverride$,
+    browserFitDom,
   );
   const mutationContext: BrowserMutationSignalContext = {
     descriptor,
@@ -376,7 +520,9 @@ export function createBrowserSessionSignals(
     fittingWindow$,
     reload$,
     reloadPanel$: reload$,
-    fitWindow$,
+    fitViewport$,
+    fitViewportRef$: browserFitDom.fitViewportRef$,
+    syncFitActionVisibility$: browserFitDom.syncFitActionVisibility$,
     ...subscriptionSignals,
     keepAliveRef$,
   };

--- a/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
@@ -384,19 +384,28 @@ function createCloseBrowserSignals({
 
 function createBrowserSessionSubscriptionSignals(
   descriptor: BrowserSessionDescriptor,
+  session$: BrowserSessionSignals["session$"],
   reload$: BrowserSessionSignals["reload$"],
+  browserFitDom: BrowserFitDomSignals,
 ): Pick<BrowserSessionSignals, "subscribe$"> {
   const reloadBrowserSession$ = command(
-    ({ set }, _signal: AbortSignal): boolean => {
+    async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
       set(reload$);
+      const session = await get(session$);
+      signal.throwIfAborted();
+      set(browserFitDom.syncFitActionForScreen$, session?.screen);
       return false;
     },
   );
   const onBrowserSessionChanged$ = command(
-    ({ set }, payload: unknown, _signal: AbortSignal): boolean => {
+    (
+      { set },
+      payload: unknown,
+      signal: AbortSignal,
+    ): Promise<boolean> | boolean => {
       const parsed = browserSessionChangedPayloadSchema.safeParse(payload);
       if (parsed.success && parsed.data.threadId === descriptor.threadId) {
-        set(reload$);
+        return set(reloadBrowserSession$, signal);
       }
       return false;
     },
@@ -464,7 +473,9 @@ export function createBrowserSessionSignals(
   const closeSignals = createCloseBrowserSignals(mutationContext);
   const subscriptionSignals = createBrowserSessionSubscriptionSignals(
     descriptor,
+    session$,
     reload$,
+    browserFitDom,
   );
 
   const keepAliveRef$ = onRef(

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-sidebar-layout.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-sidebar-layout.ts
@@ -1,7 +1,9 @@
 import { command, computed, state } from "ccstate";
+import { animationFrame } from "signal-timers";
 
 import { localStorageSignals } from "../external/local-storage.ts";
 import { resetSignal } from "../utils.ts";
+import { syncActiveBrowserFitAction$ } from "./thread-sidebar-coordinator.ts";
 
 // Smallest the sidebar may shrink to before its content stops being usable.
 export const CHAT_THREAD_SIDEBAR_MIN_WIDTH = 400;
@@ -65,9 +67,27 @@ export const startChatThreadSidebarResize$ = command(
     );
     const dragSignal = set(resetChatThreadSidebarResize$, pageSignal);
     const dragMaskEl = get(chatThreadSidebarDragMaskEl$);
+    let fitCheckScheduled = false;
 
     function resetResize(): void {
       set(resetChatThreadSidebarResize$);
+    }
+
+    function scheduleBrowserFitCheck(): void {
+      if (fitCheckScheduled) {
+        return;
+      }
+      fitCheckScheduled = true;
+      // React applies the width subscription after this native pointer event.
+      // Keep the final check alive through pointerup so it measures the
+      // committed sidebar size on the next frame.
+      animationFrame(
+        () => {
+          fitCheckScheduled = false;
+          set(syncActiveBrowserFitAction$);
+        },
+        { signal: pageSignal },
+      );
     }
 
     dragMaskEl.addEventListener(
@@ -78,6 +98,7 @@ export const startChatThreadSidebarResize$ = command(
           maxWidth,
         );
         set(setChatThreadSidebarWidth$, nextWidth);
+        scheduleBrowserFitCheck();
       },
       { signal: dragSignal },
     );

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar-coordinator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar-coordinator.ts
@@ -48,6 +48,14 @@ export const activeThreadSidebar$ = computed(
   },
 );
 
+export const syncActiveBrowserFitAction$ = command(({ get, set }) => {
+  const active = get(activeThreadSidebar$);
+  if (active?.target.type !== "browser") {
+    return;
+  }
+  set(active.thread.browserSessionSignals.syncFitActionVisibility$);
+});
+
 const openOnThread$ = command(
   ({ get, set }, thread: ChatPanelSignals, target: ThreadSidebarTarget) => {
     for (const other of [get(currentLeftThread$), get(currentRightThread$)]) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   artifactCatalogContract,
@@ -810,7 +810,25 @@ describe("thread-owned utility sidebar", () => {
         height: 900,
       }),
     );
-    window.dispatchEvent(new Event("resize"));
+    const resizeHandle = screen.getByRole("separator", {
+      name: "Resize sidebar",
+    });
+    const sidebarLayout = resizeHandle.parentElement;
+    if (!(sidebarLayout instanceof HTMLDivElement)) {
+      throw new Error("Expected the sidebar layout");
+    }
+    vi.spyOn(sidebarLayout, "getBoundingClientRect").mockReturnValue(
+      DOMRect.fromRect({ width: 1600, height: 900 }),
+    );
+    fireEvent.pointerDown(resizeHandle, { clientX: 840 });
+    const resizeMask = document.querySelector(
+      "[data-chat-thread-sidebar-resize-mask]",
+    );
+    if (!(resizeMask instanceof HTMLDivElement)) {
+      throw new Error("Expected the sidebar resize mask");
+    }
+    fireEvent.pointerMove(resizeMask, { clientX: 780 });
+    fireEvent.pointerUp(resizeMask);
     const fitWindow = await waitFor(() => {
       const button = queryAllByRoleFast("button").find((candidate) => {
         return candidate.getAttribute("aria-label") === "Fit browser to window";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -29,6 +29,7 @@ import {
   detachedSetupPage,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { hasSubscription, triggerAblyEvent } from "../../../mocks/ably.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY } from "../../../signals/chat-page/chat-thread-sidebar-layout.ts";
 import {
@@ -737,16 +738,20 @@ describe("thread-owned utility sidebar", () => {
     const liveUrl = "https://live.browser-use.com/?wss=auto-open-browser";
     const requestStarted = context.mocks.deferred<void>();
     const releaseResponse = context.mocks.deferred<void>();
-    const browser = browserSession({
+    let browser = browserSession({
       name: "Auto-open browser",
       liveUrl,
     });
     context.mocks.browser.matchMedia((query) => {
       return query === CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY;
     });
+    let browserRequests = 0;
     context.mocks.api(zeroBrowserContract.get, async ({ respond }) => {
-      requestStarted.resolve();
-      await releaseResponse.promise;
+      browserRequests += 1;
+      if (browserRequests === 1) {
+        requestStarted.resolve();
+        await releaseResponse.promise;
+      }
       return respond(200, { browser });
     });
     let leaseRequests = 0;
@@ -766,12 +771,12 @@ describe("thread-owned utility sidebar", () => {
       zeroBrowserContract.resizeByThread,
       ({ body, respond }) => {
         resizeAspectRatios.push(body.aspectRatio);
-        return respond(200, {
-          browser: {
-            ...browser,
-            screen: { width: 1440, height: 1800, resizable: true },
-          },
-        });
+        browser = {
+          ...browser,
+          screen: { width: 1440, height: 1800, resizable: true },
+          updatedAt: "2026-03-10T00:00:00.500Z",
+        };
+        return respond(200, { browser });
       },
     );
     setupChatThread({
@@ -804,12 +809,10 @@ describe("thread-owned utility sidebar", () => {
     if (!(viewport instanceof HTMLDivElement)) {
       throw new Error("Expected a live browser viewport");
     }
-    vi.spyOn(viewport, "getBoundingClientRect").mockReturnValue(
-      DOMRect.fromRect({
-        width: 720,
-        height: 900,
-      }),
-    );
+    let viewportWidth = 720;
+    vi.spyOn(viewport, "getBoundingClientRect").mockImplementation(() => {
+      return DOMRect.fromRect({ width: viewportWidth, height: 900 });
+    });
     const resizeHandle = screen.getByRole("separator", {
       name: "Resize sidebar",
     });
@@ -852,6 +855,31 @@ describe("thread-owned utility sidebar", () => {
       expect(
         screen.getByTitle("Live browser: Auto-open browser"),
       ).toHaveAttribute("src", liveUrl);
+    });
+
+    viewportWidth = 900;
+    window.dispatchEvent(new Event("resize"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Fit browser to window")).toBeVisible();
+    });
+    viewportWidth = 720;
+    window.dispatchEvent(new Event("resize"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Fit browser to window")).not.toBeVisible();
+    });
+
+    await waitFor(() => {
+      expect(hasSubscription("browserSessionChanged")).toBeTruthy();
+    });
+    browser = {
+      ...browser,
+      screen: { width: 1440, height: 900, resizable: true },
+      updatedAt: "2026-03-10T00:00:01.000Z",
+    };
+    triggerAblyEvent("browserSessionChanged", { threadId: THREAD_ID });
+    await waitFor(() => {
+      expect(viewport).toHaveAttribute("data-browser-aspect-ratio", "1.6");
+      expect(screen.getByLabelText("Fit browser to window")).toBeVisible();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -734,6 +734,39 @@ describe("thread-owned utility sidebar", () => {
     expect(screen.queryByTestId("artifact-sidebar")).not.toBeInTheDocument();
   });
 
+  it("syncs browser fit after the sidebar entry transition", async () => {
+    context.mocks.browser.matchMedia((query) => {
+      return query === CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY;
+    });
+    const browser = browserSession();
+    context.mocks.api(zeroBrowserContract.get, ({ respond }) => {
+      return respond(200, { browser });
+    });
+    context.mocks.api(zeroBrowserContract.leaseByThread, ({ respond }) => {
+      return respond(200, { browser: { ...browser, liveUrl: null } });
+    });
+    setupChatThread();
+
+    click(await screen.findByLabelText("Open browser"));
+    const frame = await screen.findByTitle("Live browser: Thread browser");
+    const viewport = frame.closest("[data-browser-session-viewport]");
+    if (!(viewport instanceof HTMLDivElement)) {
+      throw new Error("Expected a live browser viewport");
+    }
+    vi.spyOn(viewport, "getBoundingClientRect").mockReturnValue(
+      DOMRect.fromRect({ width: 720, height: 900 }),
+    );
+    expect(screen.getByLabelText("Fit browser to window")).not.toBeVisible();
+
+    const transitionEnd = new Event("transitionend", { bubbles: true });
+    Object.defineProperty(transitionEnd, "propertyName", { value: "width" });
+    fireEvent(screen.getByTestId("chat-thread-sidebar-pane"), transitionEnd);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Fit browser to window")).toBeVisible();
+    });
+  });
+
   it("auto-opens the thread browser while its latest lifecycle event is open", async () => {
     const liveUrl = "https://live.browser-use.com/?wss=auto-open-browser";
     const requestStarted = context.mocks.deferred<void>();

--- a/turbo/apps/platform/src/views/zero-page/browser-session-panel.tsx
+++ b/turbo/apps/platform/src/views/zero-page/browser-session-panel.tsx
@@ -27,109 +27,6 @@ interface BrowserSessionPanelProps {
   readonly containLiveFrame?: boolean;
 }
 
-const BROWSER_FIT_GAP_TOLERANCE_PX = 2;
-
-interface ViewportSize {
-  readonly width: number;
-  readonly height: number;
-}
-
-function browserFrameNeedsFit(
-  viewport: ViewportSize | null,
-  browserAspectRatio: number,
-): boolean {
-  if (
-    !viewport ||
-    !Number.isFinite(viewport.width) ||
-    !Number.isFinite(viewport.height) ||
-    viewport.width <= 0 ||
-    viewport.height <= 0 ||
-    !Number.isFinite(browserAspectRatio) ||
-    browserAspectRatio <= 0
-  ) {
-    return false;
-  }
-  const fittedWidth = Math.min(
-    viewport.width,
-    viewport.height * browserAspectRatio,
-  );
-  const fittedHeight = Math.min(
-    viewport.height,
-    viewport.width / browserAspectRatio,
-  );
-  return (
-    viewport.width - fittedWidth > BROWSER_FIT_GAP_TOLERANCE_PX ||
-    viewport.height - fittedHeight > BROWSER_FIT_GAP_TOLERANCE_PX
-  );
-}
-
-function measuredViewport(element: HTMLElement | null): ViewportSize | null {
-  if (!element) {
-    return null;
-  }
-  const { width, height } = element.getBoundingClientRect();
-  if (
-    !Number.isFinite(width) ||
-    !Number.isFinite(height) ||
-    width <= 0 ||
-    height <= 0
-  ) {
-    return null;
-  }
-  return { width, height };
-}
-
-function createBrowserFitController({
-  browserAspectRatio,
-  canFitWindow,
-}: {
-  readonly browserAspectRatio: number;
-  readonly canFitWindow: boolean;
-}): {
-  readonly viewportRef: (element: HTMLDivElement | null) => void;
-  readonly actionRef: (element: HTMLDivElement | null) => void;
-  readonly viewportAspectRatio: () => number | null;
-} {
-  let viewport: HTMLDivElement | null = null;
-  let action: HTMLDivElement | null = null;
-  let observer: ResizeObserver | null = null;
-
-  const syncActionVisibility = () => {
-    if (!action) {
-      return;
-    }
-    action.hidden = !(
-      canFitWindow &&
-      browserFrameNeedsFit(measuredViewport(viewport), browserAspectRatio)
-    );
-  };
-  const viewportRef = (element: HTMLDivElement | null) => {
-    observer?.disconnect();
-    observer = null;
-    window.removeEventListener("resize", syncActionVisibility);
-    viewport = element;
-    if (viewport && canFitWindow) {
-      window.addEventListener("resize", syncActionVisibility);
-      if (typeof ResizeObserver !== "undefined") {
-        observer = new ResizeObserver(syncActionVisibility);
-        observer.observe(viewport);
-      }
-    }
-    syncActionVisibility();
-  };
-  return {
-    viewportRef,
-    actionRef: (element) => {
-      action = element;
-      syncActionVisibility();
-    },
-    viewportAspectRatio: () => {
-      const size = measuredViewport(viewport);
-      return size ? size.width / size.height : null;
-    },
-  };
-}
-
 function PanelFrame({
   children,
   panelRef,
@@ -274,24 +171,23 @@ function ContainedLiveBrowserViewport({
   readonly children: ReactNode;
 }) {
   const { t } = useTranslation();
-  const fitWindow = useSet(signals.fitWindow$);
+  const fitViewport = useSet(signals.fitViewport$);
+  const fitViewportRef = useSet(signals.fitViewportRef$);
   const fittingWindow = useGet(signals.fittingWindow$);
   const pageSignal = useGet(pageSignal$);
-  const fitController = createBrowserFitController({
-    browserAspectRatio,
-    canFitWindow,
-  });
 
   return (
     <div
-      ref={fitController.viewportRef}
+      ref={fitViewportRef}
       data-browser-session-viewport
+      data-browser-aspect-ratio={browserAspectRatio}
+      data-can-fit-window={canFitWindow}
       style={{ containerType: "size" }}
       className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-muted/20"
     >
       {children}
       <div
-        ref={fitController.actionRef}
+        data-browser-session-fit-action
         hidden
         className="pointer-events-none absolute inset-x-0 bottom-3 z-10 flex justify-center px-3"
       >
@@ -302,12 +198,8 @@ function ContainedLiveBrowserViewport({
           data-browser-session-fit
           disabled={fittingWindow}
           onClick={() => {
-            const aspectRatio = fitController.viewportAspectRatio();
-            if (aspectRatio === null) {
-              return;
-            }
             detach(
-              fitWindow(aspectRatio, pageSignal),
+              fitViewport(pageSignal),
               Reason.DomCallback,
               "fit browser to sidebar window",
             );

--- a/turbo/apps/platform/src/views/zero-page/chat-thread-sidebar-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-thread-sidebar-shell.tsx
@@ -2,6 +2,7 @@ import type {
   CSSProperties,
   PointerEvent as ReactPointerEvent,
   ReactNode,
+  TransitionEvent as ReactTransitionEvent,
 } from "react";
 import { useGet, useSet } from "ccstate-react";
 import { cn } from "@vm0/ui";
@@ -15,6 +16,7 @@ import {
   startChatThreadSidebarResize$,
 } from "../../signals/chat-page/chat-thread-sidebar-layout.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import { syncActiveBrowserFitAction$ } from "../../signals/chat-page/thread-sidebar-coordinator.ts";
 
 function chatThreadSidebarLayout(
   width: number | null,
@@ -77,11 +79,24 @@ export function ChatThreadSidebarShell({
   readonly open: boolean;
   readonly sidebar: ReactNode;
 }) {
+  const syncActiveBrowserFitAction = useSet(syncActiveBrowserFitAction$);
   const { style, transition } = chatThreadSidebarLayout(
     useGet(chatThreadSidebarWidth$),
     useGet(chatThreadSidebarResizing$),
     animateEntry,
   );
+
+  function handleSidebarTransitionEnd(
+    event: ReactTransitionEvent<HTMLDivElement>,
+  ): void {
+    if (
+      event.target !== event.currentTarget ||
+      (event.propertyName !== "width" && event.propertyName !== "flex-basis")
+    ) {
+      return;
+    }
+    syncActiveBrowserFitAction();
+  }
 
   return (
     // Keep this structure stable across sidebar open/close so the chat thread
@@ -99,6 +114,7 @@ export function ChatThreadSidebarShell({
       {open && <ChatThreadSidebarResizeHandle />}
       <div
         data-testid="chat-thread-sidebar-pane"
+        onTransitionEnd={handleSidebarTransitionEnd}
         className={cn(
           "flex min-h-0 min-w-0 overflow-hidden",
           transition,


### PR DESCRIPTION
## Summary

- move browser-fit DOM ownership into a thread-scoped ccstate `onRef` so React renders keep a stable callback ref
- recheck the active browser fit action on the frame after the fixed sidebar resize command updates width, while preserving window-resize behavior
- use the actual resized browser screen returned by the API and cover the pointer-driven sidebar resize flow

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/thread-sidebar.test.tsx`
