### PR TITLE
test(runner): bound deferred storage run completion

### DIFF
--- a/crates/runner/src/executor/tests/agent_run_tests/storage.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/storage.rs
@@ -180,7 +180,10 @@ async fn run_in_sandbox_starts_deferred_cache_fill_after_agent_spawn() {
         );
 
         start_process_gate.release_one();
-        run.await.unwrap();
+        tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, &mut run)
+            .await
+            .expect("deferred storage run should complete after process spawn")
+            .unwrap();
     }
 
     tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, &mut archive_request)


### PR DESCRIPTION
## Summary

- bound deferred-storage `run_in_sandbox` completion after the process-spawn gate with the shared executor-test timeout
- preserve the underlying runner error, archive-request and server deadlines, telemetry assertions, and ordering checks

## Scope

- test-only change in the runner executor storage test
- no production behavior, API, data, dependency, compatibility, migration, or rollout change

## Validation

Passed locally:

- `cd crates && cargo fmt --all`
- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p runner --all-targets --all-features`
- `cd crates && cargo doc -p runner --all-features --no-deps`
- `git diff --check`

Not completed locally:

- `cd crates && cargo test -p runner executor::tests::agent_run_tests::storage::run_in_sandbox_starts_deferred_cache_fill_after_agent_spawn -- --exact`
  - the runner test binary compilation was terminated with `SIGKILL` after `rustc` reached approximately 3.65 GiB in the 4 GiB, no-swap local environment; the PR pipeline will execute the test and full Rust matrix

Closes #25335
