### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -59,9 +59,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
## Summary

- Update `android_system_properties` from 0.1.5 to 0.1.6 in `crates/Cargo.lock`.
- This is a lockfile-only refresh; no dependency manifests were changed.

## Dependencies not updated

- `generic-array` remains at 0.14.7 (0.14.9 is available) because `crypto-common` 0.1.7 pins it to exactly `=0.14.7`.

## Manual version bumps

- None.

## Tests

- `cargo test --workspace --exclude runner --no-fail-fast`: **3,614 passed, 16 ignored, 2 failed** across 182 targets. The two failures are both in `guest-agent --test command_output_timeout` and reproduce on current `main` in this runtime: `/proc/1` has session ID 0, causing the `rustix` 1.1.4 `Pid` debug assertion while the test helper scans `/proc`. This is unrelated to the Android-specific lockfile update. All other 181 targets completed.
- `MALLOC_ARENA_MAX=1 RAYON_NUM_THREADS=1 cargo test -p runner --no-fail-fast`: **2,999 passed, 20 ignored, 0 failed**. The constrained retry was needed after the GNU linker was SIGKILLed at the 3.8 GiB runtime memory limit.
