### PR TITLE
fix(billing): show portal for any active subscription

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-portal.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-portal.test.ts
@@ -12,6 +12,12 @@ import {
   type InvoicesOrgFixture,
 } from "./helpers/zero-billing-invoices";
 import {
+  createBillingWebhookFixture,
+  generatedStripeCustomerId,
+  generatedStripeSubscriptionId,
+  postUsageAllowanceInvoicePaid,
+} from "./helpers/stripe-billing-webhook";
+import {
   createFixtureTracker,
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
@@ -163,6 +169,45 @@ describe("POST /api/zero/billing/portal", () => {
     ).toHaveBeenCalledWith({
       customer: fixture.stripeCustomerId,
       return_url: returnUrl,
+    });
+  });
+
+  it("returns a portal URL for an allowance-only org", async () => {
+    const fixture = createBillingWebhookFixture();
+    const customerId = generatedStripeCustomerId();
+    await postUsageAllowanceInvoicePaid(context.signal, {
+      ...fixture,
+      customerId,
+      subscriptionId: generatedStripeSubscriptionId(),
+      shortWindowSeconds: 18_000,
+      shortWindowUnits: 5000,
+      weeklyWindowSeconds: 604_800,
+      weeklyWindowUnits: 50_000,
+      effectiveAt: new Date("2026-01-01T00:00:00Z"),
+      expiresAt: new Date("2099-01-01T00:00:00Z"),
+    });
+    mockEnv("APP_URL", APP_ORIGIN);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    context.mocks.stripe.billingPortal.sessions.create.mockResolvedValue({
+      url: "https://billing.stripe.com/session/allowance",
+    });
+
+    const response = await accept(
+      setupApp({ context })(zeroBillingPortalContract).create({
+        body: { returnUrl: `${APP_ORIGIN}/settings/billing` },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      url: "https://billing.stripe.com/session/allowance",
+    });
+    expect(
+      context.mocks.stripe.billingPortal.sessions.create,
+    ).toHaveBeenCalledWith({
+      customer: customerId,
+      return_url: `${APP_ORIGIN}/settings/billing`,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts
@@ -234,6 +234,76 @@ describe("GET /api/zero/billing/status", () => {
     expect(response.body.creditBreakdown).toStrictEqual([]);
   });
 
+  it.each([
+    { status: "active", hasSubscription: true },
+    { status: "canceled", hasSubscription: false },
+  ])(
+    "reports $status usage allowance subscription availability",
+    async ({ status, hasSubscription }) => {
+      const fixture = await track(
+        store.set(
+          seedBillingStatusOrg$,
+          {
+            usageAllowance: {
+              status,
+              shortWindowSeconds: 18_000,
+              shortWindowUnits: 5000,
+              weeklyWindowUnits: 50_000,
+              expiresAt: new Date("2099-04-20T00:00:00Z"),
+            },
+          },
+          context.signal,
+        ),
+      );
+      mocks.clerk.session(fixture.userId, fixture.orgId);
+
+      const response = await accept(
+        setupApp({ context })(zeroBillingStatusContract).get({
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      );
+
+      expect(response.body.hasSubscription).toBe(hasSubscription);
+    },
+  );
+
+  it.each([
+    { status: "active", hasSubscription: true },
+    { status: "canceled", hasSubscription: false },
+  ])(
+    "reports $status concurrency subscription availability",
+    async ({ status, hasSubscription }) => {
+      const fixture = await track(
+        store.set(
+          seedBillingStatusOrg$,
+          {
+            concurrencyEntitlements: [
+              {
+                stripeSubscriptionId: `sub_${randomUUID()}`,
+                slots: 2,
+                startsAt: new Date("2026-01-01T00:00:00Z"),
+                expiresAt: new Date("2099-04-20T00:00:00Z"),
+                subscriptionStatus: status,
+              },
+            ],
+          },
+          context.signal,
+        ),
+      );
+      mocks.clerk.session(fixture.userId, fixture.orgId);
+
+      const response = await accept(
+        setupApp({ context })(zeroBillingStatusContract).get({
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      );
+
+      expect(response.body.hasSubscription).toBe(hasSubscription);
+    },
+  );
+
   it("returns finite concurrency limit when the concurrency cap is disabled", async () => {
     mockEnv("CONCURRENT_RUN_LIMIT_CAP", "0");
     const fixture = await track(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts
@@ -209,6 +209,38 @@ describe("GET /api/zero/billing/status", () => {
     expect(response.body.hasSubscription).toBeTruthy();
   });
 
+  it.each(["canceled", "incomplete_expired"])(
+    "does not report a %s plan as a subscription",
+    async (status) => {
+      const fixture = await track(
+        store.set(
+          seedBillingStatusOrg$,
+          {
+            subscription: {
+              tier: "pro",
+              status,
+              currentPeriodEnd: new Date("2099-04-20T00:00:00Z"),
+              stripeCustomerId: `cus_${randomUUID()}`,
+              stripeSubscriptionId: `sub_${randomUUID()}`,
+            },
+          },
+          context.signal,
+        ),
+      );
+      mocks.clerk.session(fixture.userId, fixture.orgId);
+
+      const response = await accept(
+        setupApp({ context })(zeroBillingStatusContract).get({
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      );
+
+      expect(response.body.subscriptionStatus).toBe(status);
+      expect(response.body.hasSubscription).toBeFalsy();
+    },
+  );
+
   it("returns custom tier status without subscription plan credits", async () => {
     const fixture = await track(
       store.set(seedBillingStatusOrg$, { credits: 0 }, context.signal),
@@ -726,6 +758,7 @@ describe("GET /api/zero/billing/status", () => {
     );
 
     expect(response.body.cancelAtPeriodEnd).toBeTruthy();
+    expect(response.body.hasSubscription).toBeTruthy();
     expect(response.body.scheduledChange).toStrictEqual({
       type: "cancel",
       targetTier: "limited-free-1",

--- a/turbo/apps/api/src/signals/services/billing.service.ts
+++ b/turbo/apps/api/src/signals/services/billing.service.ts
@@ -1,9 +1,10 @@
 import { command, computed, type Computed } from "ccstate";
 import type { AutoRechargeConfig } from "@vm0/api-contracts/contracts/zero-billing";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { orgUsageAllowanceEntitlements } from "@vm0/db/schema/org-usage-allowance";
 import { eq } from "drizzle-orm";
 
-import { db$, writeDb$ } from "../external/db";
+import { db$, writeDb$, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../../lib/time";
 import { getStripeClient } from "../external/stripe-client";
 import { loadOrgPlanCapabilities } from "./org-plan-entitlement-read.service";
@@ -31,12 +32,32 @@ export function autoRechargeConfig(
   });
 }
 
+async function stripeCustomerIdForOrg(
+  db: ReadonlyDb,
+  orgId: string,
+): Promise<string | null> {
+  const [org] = await db
+    .select({ stripeCustomerId: orgMetadata.stripeCustomerId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  if (org?.stripeCustomerId) {
+    return org.stripeCustomerId;
+  }
+
+  const [allowance] = await db
+    .select({
+      stripeCustomerId: orgUsageAllowanceEntitlements.stripeCustomerId,
+    })
+    .from(orgUsageAllowanceEntitlements)
+    .where(eq(orgUsageAllowanceEntitlements.orgId, orgId))
+    .limit(1);
+  return allowance?.stripeCustomerId ?? null;
+}
+
 /**
  * Create a Stripe Billing Portal session for managing subscriptions.
- * Mirrors apps/web's `createBillingPortalSession`. Returns the portal URL.
- *
- * Throws if the org has no Stripe customer yet (defensive — web's
- * tests don't exercise this branch either; framework returns 500).
+ * Returns the portal URL and throws if the org has no Stripe customer yet.
  */
 export const createBillingPortalSession$ = command(
   async (
@@ -45,20 +66,16 @@ export const createBillingPortalSession$ = command(
     signal: AbortSignal,
   ): Promise<string> => {
     const db = get(db$);
-    const [org] = await db
-      .select({ stripeCustomerId: orgMetadata.stripeCustomerId })
-      .from(orgMetadata)
-      .where(eq(orgMetadata.orgId, args.orgId))
-      .limit(1);
+    const stripeCustomerId = await stripeCustomerIdForOrg(db, args.orgId);
     signal.throwIfAborted();
 
-    if (!org?.stripeCustomerId) {
+    if (!stripeCustomerId) {
       throw new Error("Org has no Stripe customer — subscribe first");
     }
 
     const stripe = getStripeClient();
     const session = await stripe.billingPortal.sessions.create({
-      customer: org.stripeCustomerId,
+      customer: stripeCustomerId,
       return_url: args.returnUrl,
     });
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-billing-status.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-status.service.ts
@@ -104,6 +104,11 @@ interface UsageAllowanceStatus {
   windows: UsageAllowanceWindowStatus[];
 }
 
+interface ActiveUsageAllowanceStatus {
+  status: UsageAllowanceStatus;
+  stripeSubscriptionId: string | null;
+}
+
 interface BillingOrgRow {
   tier: string;
   credits: number;
@@ -419,7 +424,7 @@ async function activeUsageAllowanceStatus(
   db: ReadonlyDb,
   orgId: string,
   currentTime: Date,
-): Promise<UsageAllowanceStatus | null> {
+): Promise<ActiveUsageAllowanceStatus | null> {
   const [entitlement] = await db
     .select({
       effectiveAt: orgUsageAllowanceEntitlements.effectiveAt,
@@ -427,6 +432,7 @@ async function activeUsageAllowanceStatus(
       shortWindowUnits: orgUsageAllowanceEntitlements.shortWindowUnits,
       weeklyWindowSeconds: orgUsageAllowanceEntitlements.weeklyWindowSeconds,
       weeklyWindowUnits: orgUsageAllowanceEntitlements.weeklyWindowUnits,
+      stripeSubscriptionId: orgUsageAllowanceEntitlements.stripeSubscriptionId,
     })
     .from(orgUsageAllowanceEntitlements)
     .where(
@@ -489,13 +495,16 @@ async function activeUsageAllowanceStatus(
   }
 
   return {
-    windows: USAGE_ALLOWANCE_WINDOW_KINDS.map((kind) => {
-      return usageAllowanceWindowStatus({
-        entitlement,
-        kind,
-        activeWindow: windowByKind.get(kind),
-      });
-    }),
+    status: {
+      windows: USAGE_ALLOWANCE_WINDOW_KINDS.map((kind) => {
+        return usageAllowanceWindowStatus({
+          entitlement,
+          kind,
+          activeWindow: windowByKind.get(kind),
+        });
+      }),
+    },
+    stripeSubscriptionId: entitlement.stripeSubscriptionId,
   };
 }
 
@@ -555,7 +564,7 @@ function billingStatusResponse(args: {
   unsettledExpired: number;
   activeRecords: readonly ActiveCreditRecord[];
   concurrencySubscriptions: readonly ActiveConcurrencySubscription[];
-  usageAllowance: UsageAllowanceStatus | null;
+  usageAllowance: ActiveUsageAllowanceStatus | null;
   baseConcurrencyLimit: number;
 }): BillingStatusResponse {
   const org = args.org ?? DEFAULT_BILLING_ORG;
@@ -586,7 +595,11 @@ function billingStatusResponse(args: {
     currentPeriodEnd: org.currentPeriodEnd?.toISOString() ?? null,
     cancelAtPeriodEnd: org.cancelAtPeriodEnd,
     scheduledChange: scheduledBillingChange(org),
-    hasSubscription: org.stripeSubscriptionId !== null,
+    hasSubscription:
+      org.stripeSubscriptionId !== null ||
+      args.concurrencySubscriptions.length > 0 ||
+      (args.usageAllowance !== null &&
+        args.usageAllowance.stripeSubscriptionId !== null),
     autoRecharge: {
       enabled: org.autoRechargeEnabled,
       threshold: org.autoRechargeThreshold,
@@ -615,7 +628,7 @@ function billingStatusResponse(args: {
         };
       },
     ),
-    usageAllowance: args.usageAllowance,
+    usageAllowance: args.usageAllowance?.status ?? null,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-billing-status.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-status.service.ts
@@ -551,6 +551,14 @@ function scheduledBillingChange(
   };
 }
 
+function hasManageablePlanSubscription(org: BillingOrgRow): boolean {
+  return (
+    org.stripeSubscriptionId !== null &&
+    org.subscriptionStatus !== "canceled" &&
+    org.subscriptionStatus !== "incomplete_expired"
+  );
+}
+
 function billingStatusResponse(args: {
   orgId: string;
   org: BillingOrgRow | undefined;
@@ -596,7 +604,7 @@ function billingStatusResponse(args: {
     cancelAtPeriodEnd: org.cancelAtPeriodEnd,
     scheduledChange: scheduledBillingChange(org),
     hasSubscription:
-      org.stripeSubscriptionId !== null ||
+      hasManageablePlanSubscription(org) ||
       args.concurrencySubscriptions.length > 0 ||
       (args.usageAllowance !== null &&
         args.usageAllowance.stripeSubscriptionId !== null),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -467,6 +467,48 @@ describe("organization billing settings", () => {
     });
   });
 
+  it("opens the Stripe customer portal for an add-on subscription", async () => {
+    context.mocks.data.org({
+      id: "org_1",
+      name: "Add-on Org",
+      role: "admin",
+    });
+    context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+      return respond(200, {
+        ...noActiveBillingStatus(),
+        hasSubscription: true,
+        concurrencySubscriptions: [
+          {
+            id: "sub_concurrency_12345678",
+            quantity: 2,
+            currentPeriodEnd: "2026-06-01T00:00:00Z",
+            cancelAtPeriodEnd: false,
+          },
+        ],
+      });
+    });
+    context.mocks.api(zeroBillingPortalContract.create, ({ respond }) => {
+      return respond(200, {
+        url: "https://billing.stripe.com/customer-portal/add-on-org",
+      });
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Manage billing")).toBeInTheDocument();
+      expect(screen.getByText("No active plan")).toBeInTheDocument();
+    });
+
+    click(buttonByText("Manage"));
+
+    await waitFor(() => {
+      expect(window.location.href).toBe(
+        "https://billing.stripe.com/customer-portal/add-on-org",
+      );
+    });
+  });
+
   it("shows custom tier access and disables Pro and Team checkout", async () => {
     context.mocks.data.org({
       id: "org_1",

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -1702,7 +1702,7 @@ export function OrgBillingTab() {
   );
   const showBuyCredits = capabilities.canBuyCredits;
   const showConcurrency = capabilities.canBuyConcurrency;
-  const canManageBilling = isPaid && status?.hasSubscription === true;
+  const canManageBilling = status?.hasSubscription === true;
   const openBillingPortal = () => {
     return detach(portal(pageSignal), Reason.DomCallback);
   };


### PR DESCRIPTION
## Summary

- Treat active plan, usage allowance, and concurrency subscriptions as manageable billing subscriptions.
- Show **Manage billing** whenever any current subscription exists, regardless of the base plan tier.
- Resolve the Stripe customer from the allowance entitlement for allowance-only organizations.

## Why

`hasSubscription` only checked the base-plan subscription ID. Organizations such as `vm0` can instead have active Atom usage allowance or concurrency subscriptions, so the billing portal remained hidden even though Stripe had subscriptions to manage.

Canceled or expired historical subscriptions remain excluded. Scheduled end-of-period cancellations remain manageable until the subscription actually ends.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx` (15 tests)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-billing-status.test.ts` (31 tests)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-billing-portal.test.ts` (12 tests)
