### PR TITLE
feat: clean up inactive browser sessions after seven days

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -49,6 +49,7 @@ const BROWSER_USE_API_URL = "https://api.browser-use.com/api/v3";
 const CRON_SECRET = "test-browser-reconcile-secret";
 const STARTED_AT_MS = Date.parse("2026-07-24T10:00:00.000Z");
 const MINUTE_MS = 60_000;
+const DAY_MS = 24 * 60 * MINUTE_MS;
 
 function commandInput(command: unknown): Record<string, unknown> {
   if (
@@ -1525,6 +1526,247 @@ describe("zero browser route", () => {
       stopped: 0,
       errors: 0,
     });
+  }, 120_000);
+
+  it("deletes inactive browser state and its profile after seven days", async () => {
+    const { routeMocks, runs, chat, actor, agent } =
+      await setupBrowserScenario();
+    const current = await createClaimedChatRun(
+      chat,
+      runs,
+      actor,
+      agent.agentId,
+      "Open a managed browser that will expire",
+    );
+    const profileIds = [randomUUID(), randomUUID()] as const;
+    const providerIds = [randomUUID(), randomUUID()] as const;
+    acceptBrowserUseCdpSessions(providerIds);
+    const providerCreateBodies: unknown[] = [];
+    const deletedProfiles: string[] = [];
+    const savedTabUrl = "https://example.com/retained-tab";
+    let profileCreates = 0;
+    let providerCreates = 0;
+    let providerStops = 0;
+    let currentCdpWebSocketUrl: string | null = null;
+    context.mocks.browserUseCdp.connect.mockImplementation((url) => {
+      currentCdpWebSocketUrl = url;
+    });
+    context.mocks.browserUseCdp.command.mockImplementation((command) => {
+      if (command.method === "Target.getTargets") {
+        return {
+          targetInfos: [
+            currentCdpWebSocketUrl === browserUseCdpWebSocketUrl(providerIds[0])
+              ? {
+                  targetId: "retained-tab",
+                  type: "page",
+                  url: savedTabUrl,
+                }
+              : {
+                  targetId: "default-tab",
+                  type: "page",
+                  url: "about:blank",
+                },
+          ],
+        };
+      }
+      if (command.method === "Target.attachToTarget") {
+        return { sessionId: "foreground-session" };
+      }
+      if (command.method === "Runtime.evaluate") {
+        return { result: { type: "boolean", value: true } };
+      }
+      if (command.method === "Page.getLayoutMetrics") {
+        return {
+          cssVisualViewport: {
+            pageX: 0,
+            pageY: 0,
+            clientWidth: 1440,
+            clientHeight: 900,
+          },
+        };
+      }
+      if (command.method === "Page.captureScreenshot") {
+        return { data: Buffer.from("retained screenshot").toString("base64") };
+      }
+      return undefined;
+    });
+    server.use(
+      http.post(`${BROWSER_USE_API_URL}/profiles`, async ({ request }) => {
+        const body = z
+          .strictObject({ name: z.string() })
+          .parse(await request.json());
+        const profileId = profileIds[profileCreates];
+        profileCreates += 1;
+        if (!profileId) {
+          return HttpResponse.json(
+            { error: "unexpected profile create" },
+            { status: 500 },
+          );
+        }
+        return HttpResponse.json(providerProfile(profileId, body.name), {
+          status: 201,
+        });
+      }),
+      http.delete(`${BROWSER_USE_API_URL}/profiles/:id`, ({ params }) => {
+        const profileId = String(params.id);
+        deletedProfiles.push(profileId);
+        if (profileId === profileIds[0] && deletedProfiles.length === 1) {
+          return HttpResponse.json(
+            { detail: "temporary Browser Use outage" },
+            { status: 503 },
+          );
+        }
+        return new HttpResponse(null, { status: 204 });
+      }),
+      http.post(`${BROWSER_USE_API_URL}/browsers`, async ({ request }) => {
+        providerCreateBodies.push(await request.json());
+        const providerId = providerIds[providerCreates];
+        providerCreates += 1;
+        if (!providerId) {
+          return HttpResponse.json(
+            { error: "unexpected browser create" },
+            { status: 500 },
+          );
+        }
+        return HttpResponse.json(providerBrowser(providerId), { status: 201 });
+      }),
+      http.get(`${BROWSER_USE_API_URL}/browsers/:id`, ({ params }) => {
+        return HttpResponse.json(providerBrowser(String(params.id)));
+      }),
+      http.patch(`${BROWSER_USE_API_URL}/browsers/:id`, ({ params }) => {
+        providerStops += 1;
+        return HttpResponse.json(
+          providerBrowser(String(params.id), { status: "stopped" }),
+        );
+      }),
+    );
+
+    const created = await accept(
+      client().use({ headers: current.claim.browserHeaders, body: {} }),
+      [200],
+    );
+    routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    await accept(
+      client().resizeByThread({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { threadId: current.threadId },
+        body: { aspectRatio: 0.75 },
+      }),
+      [200],
+    );
+
+    mockNow(STARTED_AT_MS + MINUTE_MS);
+    await reconcileBrowsers();
+    await flushWaitUntilForTest();
+    const withScreenshot = await accept(
+      client().get({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { threadId: current.threadId },
+      }),
+      [200],
+    );
+    const screenshotUrl = withScreenshot.body.browser.screenshotUrl;
+    if (!screenshotUrl) {
+      throw new Error("Expected a retained browser screenshot");
+    }
+    const screenshotKey = new URL(screenshotUrl).pathname.slice(1);
+
+    mockNow(STARTED_AT_MS + 11 * MINUTE_MS);
+    const stopped = await reconcileBrowsers();
+    expect(stopped.body).toMatchObject({ stopped: 1, errors: 0 });
+    await flushWaitUntilForTest();
+    expect(providerStops).toBe(1);
+
+    mockNow(STARTED_AT_MS + 11 * MINUTE_MS + 7 * DAY_MS - 1);
+    const retained = await reconcileBrowsers();
+    expect(retained.body.errors).toBe(0);
+    const beforeCutoff = await accept(
+      client().get({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { threadId: current.threadId },
+      }),
+      [200],
+    );
+    expect(beforeCutoff.body.browser).toMatchObject({
+      status: "suspended",
+      screenshotUrl,
+    });
+    expect(deletedProfiles).toStrictEqual([]);
+
+    mockNow(STARTED_AT_MS + 11 * MINUTE_MS + 7 * DAY_MS);
+    const failedCleanup = await reconcileBrowsers();
+    expect(failedCleanup.body.errors).toBe(1);
+    expect(deletedProfiles).toStrictEqual([profileIds[0]]);
+    expect(providerStops).toBe(1);
+    const afterFailedProfileDelete = await accept(
+      client().get({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { threadId: current.threadId },
+      }),
+      [200],
+    );
+    expect(afterFailedProfileDelete.body.browser).toMatchObject({
+      status: "suspended",
+      screenshotUrl: null,
+    });
+    expect(afterFailedProfileDelete.body.browser).not.toHaveProperty("screen");
+    expect(
+      context.mocks.s3.send.mock.calls.some(([command]) => {
+        const input = commandInput(command);
+        return (JSON.stringify(input.Delete) ?? "").includes(screenshotKey);
+      }),
+    ).toBeTruthy();
+
+    const cleaned = await reconcileBrowsers();
+    expect(cleaned.body).toMatchObject({ errors: 0 });
+    expect(deletedProfiles).toStrictEqual([profileIds[0], profileIds[0]]);
+    expect(providerStops).toBe(1);
+    await accept(
+      client().get({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { threadId: current.threadId },
+      }),
+      [404],
+    );
+
+    context.mocks.browserUseCdp.command.mockClear();
+    const reopened = await accept(
+      client().open({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { threadId: current.threadId },
+        body: { eventId: randomUUID() },
+      }),
+      [200],
+    );
+    expect(reopened.body.browser).toMatchObject({
+      threadId: created.body.browser.threadId,
+      status: "active",
+      screenshotUrl: null,
+      screen: { width: 1440, height: 900, resizable: true },
+    });
+    expect(profileCreates).toBe(2);
+    expect(providerCreates).toBe(2);
+    expect(
+      z
+        .strictObject({
+          profileId: z.uuid(),
+          proxyCountryCode: z.null(),
+          timeout: z.literal(240),
+          browserScreenWidth: z.literal(1440),
+          browserScreenHeight: z.literal(900),
+          allowResizing: z.literal(true),
+          enableRecording: z.literal(false),
+        })
+        .parse(providerCreateBodies[1]).profileId,
+    ).toBe(profileIds[1]);
+    expect(
+      context.mocks.browserUseCdp.command.mock.calls.some(([command]) => {
+        return command.method === "Target.createTarget";
+      }),
+    ).toBeFalsy();
+
+    await chat.deleteThread(actor, current.threadId);
+    await flushWaitUntilForTest();
   }, 120_000);
 
   it("deduplicates previous snapshot URLs before restoring browser tabs", async () => {

--- a/turbo/apps/api/src/signals/services/zero-browser.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-browser.service.ts
@@ -82,8 +82,10 @@ const BROWSER_SCREENSHOT_CAPTURE_TIMEOUT_MS = 30_000;
 const BROWSER_SCREENSHOT_CONTENT_TYPE = "image/webp";
 const BROWSER_SCREENSHOT_FILENAME = "browser-screenshot.webp";
 const STRANDED_START_GRACE_MS = 60_000;
+const INACTIVE_BROWSER_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 const MAX_PROVIDER_VALIDATION_ISSUES_TO_LOG = 10;
 const IDLE_LEASE_MS = ZERO_BROWSER_IDLE_LEASE_MINUTES * 60_000;
+const INACTIVE_BROWSER_STATUSES = ["suspended", "error"] as const;
 const OWNED_BROWSER_STATUSES = [
   "creating",
   "active",
@@ -103,6 +105,7 @@ type BrowserSessionRow = typeof browserSessions.$inferSelect;
 type BrowserInstanceRow = typeof browserSessionInstances.$inferSelect;
 type BrowserThreadProfileRow = typeof browserThreadProfiles.$inferSelect;
 type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
+type InactiveBrowserStatus = (typeof INACTIVE_BROWSER_STATUSES)[number];
 
 class BrowserOpenEventIdConflictError extends Error {}
 
@@ -2784,6 +2787,8 @@ async function releaseStrandedBrowserStarts(
     .select({
       chatThreadId: browserSessions.chatThreadId,
       userId: browserSessions.userId,
+      suspendedAt: browserSessions.suspendedAt,
+      suspensionReason: browserSessions.suspensionReason,
     })
     .from(browserSessions)
     .where(
@@ -2798,6 +2803,15 @@ async function releaseStrandedBrowserStarts(
     .limit(limit);
   signal.throwIfAborted();
   for (const browser of stranded) {
+    const retentionCutoff = new Date(
+      nowDate().getTime() - INACTIVE_BROWSER_RETENTION_MS,
+    );
+    const retentionClaimedAt =
+      browser.suspensionReason === "reconcile" &&
+      browser.suspendedAt !== null &&
+      browser.suspendedAt <= retentionCutoff
+        ? browser.suspendedAt
+        : null;
     await db.transaction(async (tx) => {
       await tx
         .update(browserSessionInstances)
@@ -2816,8 +2830,8 @@ async function releaseStrandedBrowserStarts(
         .update(browserSessions)
         .set({
           status: "suspended",
-          suspendedAt: nowDate(),
-          updatedAt: nowDate(),
+          suspendedAt: retentionClaimedAt ?? nowDate(),
+          updatedAt: retentionClaimedAt ?? nowDate(),
         })
         .where(
           and(
@@ -2865,6 +2879,378 @@ async function releaseStrandedBrowserStarts(
     .returning({ chatThreadId: browserSessions.chatThreadId });
   signal.throwIfAborted();
   return stranded.length + abandonedStarts.length;
+}
+
+interface ExpiredInactiveBrowserTarget {
+  readonly chatThreadId: string;
+  readonly userId: string;
+  readonly status: InactiveBrowserStatus;
+  readonly suspendedAt: Date | null;
+  readonly suspensionReason: ZeroBrowserSuspensionReason | null;
+  readonly updatedAt: Date;
+  readonly providerProfileId: string | null;
+}
+
+async function claimExpiredInactiveBrowser(
+  db: Db,
+  target: ExpiredInactiveBrowserTarget,
+  cutoff: Date,
+  screenshotSchemaReady: boolean,
+  signal: AbortSignal,
+): Promise<Date | null> {
+  const claimedAt = nowDate();
+  const claimed = await db.transaction(async (tx) => {
+    await lockBrowserThread(tx, target.chatThreadId);
+    await lockBrowserProfileCreation(tx, target.chatThreadId);
+    const [profile] = await tx
+      .select({
+        providerProfileId: browserThreadProfiles.providerProfileId,
+      })
+      .from(browserThreadProfiles)
+      .where(eq(browserThreadProfiles.chatThreadId, target.chatThreadId))
+      .limit(1);
+    if ((profile?.providerProfileId ?? null) !== target.providerProfileId) {
+      return false;
+    }
+    const [browser] = await tx
+      .update(browserSessions)
+      .set({
+        status: "stopping",
+        suspendedAt: target.updatedAt,
+        suspensionReason: "reconcile",
+        updatedAt: claimedAt,
+      })
+      .where(
+        and(
+          eq(browserSessions.chatThreadId, target.chatThreadId),
+          eq(browserSessions.status, target.status),
+          eq(browserSessions.updatedAt, target.updatedAt),
+          lte(browserSessions.updatedAt, cutoff),
+          notExists(
+            tx
+              .select({
+                providerSessionId: browserSessionInstances.providerSessionId,
+              })
+              .from(browserSessionInstances)
+              .where(
+                and(
+                  eq(
+                    browserSessionInstances.chatThreadId,
+                    browserSessions.chatThreadId,
+                  ),
+                  inArray(browserSessionInstances.status, [
+                    "active",
+                    "stopping",
+                  ]),
+                ),
+              ),
+          ),
+        ),
+      )
+      .returning({ chatThreadId: browserSessions.chatThreadId });
+    if (!browser) {
+      return false;
+    }
+
+    if (screenshotSchemaReady) {
+      const [screenshot] = await tx
+        .select({ objectKey: browserSessionScreenshots.objectKey })
+        .from(browserSessionScreenshots)
+        .where(eq(browserSessionScreenshots.chatThreadId, target.chatThreadId))
+        .limit(1);
+      if (screenshot) {
+        await tx
+          .insert(browserSessionScreenshotDeletions)
+          .values({
+            objectKey: screenshot.objectKey,
+            chatThreadId: target.chatThreadId,
+          })
+          .onConflictDoNothing({
+            target: browserSessionScreenshotDeletions.objectKey,
+          });
+        await tx
+          .delete(browserSessionScreenshots)
+          .where(
+            eq(browserSessionScreenshots.chatThreadId, target.chatThreadId),
+          );
+      }
+    }
+    await tx
+      .delete(browserSessionTabSnapshots)
+      .where(eq(browserSessionTabSnapshots.chatThreadId, target.chatThreadId));
+    await tx
+      .delete(browserSessionInstances)
+      .where(eq(browserSessionInstances.chatThreadId, target.chatThreadId));
+    return true;
+  });
+  signal.throwIfAborted();
+  return claimed ? claimedAt : null;
+}
+
+async function releaseExpiredInactiveBrowserClaim(
+  db: Db,
+  target: ExpiredInactiveBrowserTarget,
+  claimedAt: Date,
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    await lockBrowserThread(tx, target.chatThreadId);
+    await tx
+      .update(browserSessions)
+      .set({
+        status: target.status,
+        suspendedAt: target.suspendedAt,
+        suspensionReason: target.suspensionReason,
+        updatedAt: target.updatedAt,
+      })
+      .where(
+        and(
+          eq(browserSessions.chatThreadId, target.chatThreadId),
+          eq(browserSessions.status, "stopping"),
+          eq(browserSessions.updatedAt, claimedAt),
+        ),
+      );
+  });
+}
+
+async function retireExpiredInactiveBrowser(
+  db: Db,
+  target: ExpiredInactiveBrowserTarget,
+  claimedAt: Date,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const retired = await db.transaction(async (tx) => {
+    await lockBrowserThread(tx, target.chatThreadId);
+    await lockBrowserProfileCreation(tx, target.chatThreadId);
+    const [[browser], [profile]] = await Promise.all([
+      tx
+        .select({
+          status: browserSessions.status,
+          updatedAt: browserSessions.updatedAt,
+        })
+        .from(browserSessions)
+        .where(eq(browserSessions.chatThreadId, target.chatThreadId))
+        .limit(1),
+      tx
+        .select({
+          providerProfileId: browserThreadProfiles.providerProfileId,
+        })
+        .from(browserThreadProfiles)
+        .where(eq(browserThreadProfiles.chatThreadId, target.chatThreadId))
+        .limit(1),
+    ]);
+    if (profile && profile.providerProfileId !== target.providerProfileId) {
+      return false;
+    }
+    if (
+      browser &&
+      (browser.status !== "stopping" ||
+        browser.updatedAt.getTime() !== claimedAt.getTime())
+    ) {
+      return false;
+    }
+    if (browser) {
+      await tx
+        .delete(browserSessions)
+        .where(eq(browserSessions.chatThreadId, target.chatThreadId));
+    }
+    if (target.providerProfileId !== null) {
+      await tx
+        .delete(browserThreadProfiles)
+        .where(
+          and(
+            eq(browserThreadProfiles.chatThreadId, target.chatThreadId),
+            eq(
+              browserThreadProfiles.providerProfileId,
+              target.providerProfileId,
+            ),
+          ),
+        );
+    }
+    return true;
+  });
+  signal.throwIfAborted();
+  if (retired) {
+    await publishBrowserSessionChangedSafely(target.userId, {
+      threadId: target.chatThreadId,
+    });
+  }
+  signal.throwIfAborted();
+  return retired;
+}
+
+async function cleanupExpiredInactiveBrowser(
+  db: Db,
+  target: ExpiredInactiveBrowserTarget,
+  cutoff: Date,
+  screenshotSchemaReady: boolean,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const claimedAt = await claimExpiredInactiveBrowser(
+    db,
+    target,
+    cutoff,
+    screenshotSchemaReady,
+    signal,
+  );
+  if (claimedAt === null) {
+    return false;
+  }
+
+  const cleanup = await settle(
+    (async () => {
+      if (target.providerProfileId !== null) {
+        await deleteBrowserUseProfile(
+          target.providerProfileId,
+          AbortSignal.any([
+            signal,
+            AbortSignal.timeout(PROVIDER_CLEANUP_TIMEOUT_MS),
+          ]),
+        );
+      }
+      const retired = await retireExpiredInactiveBrowser(
+        db,
+        target,
+        claimedAt,
+        signal,
+      );
+      if (!retired) {
+        throw new Error("Expired managed browser cleanup claim changed");
+      }
+    })(),
+  );
+  if (!cleanup.ok) {
+    await releaseExpiredInactiveBrowserClaim(db, target, claimedAt);
+    signal.throwIfAborted();
+    throw cleanup.error;
+  }
+  signal.throwIfAborted();
+  return true;
+}
+
+async function reconcileExpiredInactiveBrowsers(
+  db: Db,
+  limit: number,
+  screenshotSchemaReady: boolean,
+  signal: AbortSignal,
+): Promise<{
+  readonly checked: number;
+  readonly cleaned: number;
+  readonly errors: number;
+}> {
+  const cutoff = new Date(nowDate().getTime() - INACTIVE_BROWSER_RETENTION_MS);
+  const rows = await db
+    .select({
+      chatThreadId: browserSessions.chatThreadId,
+      userId: browserSessions.userId,
+      status: browserSessions.status,
+      suspendedAt: browserSessions.suspendedAt,
+      suspensionReason: browserSessions.suspensionReason,
+      updatedAt: browserSessions.updatedAt,
+      providerProfileId: browserThreadProfiles.providerProfileId,
+    })
+    .from(browserSessions)
+    .leftJoin(
+      browserThreadProfiles,
+      eq(browserThreadProfiles.chatThreadId, browserSessions.chatThreadId),
+    )
+    .where(
+      and(
+        inArray(browserSessions.status, [...INACTIVE_BROWSER_STATUSES]),
+        lte(browserSessions.updatedAt, cutoff),
+        notExists(
+          db
+            .select({
+              providerSessionId: browserSessionInstances.providerSessionId,
+            })
+            .from(browserSessionInstances)
+            .where(
+              and(
+                eq(
+                  browserSessionInstances.chatThreadId,
+                  browserSessions.chatThreadId,
+                ),
+                inArray(browserSessionInstances.status, ["active", "stopping"]),
+              ),
+            ),
+        ),
+      ),
+    )
+    .orderBy(browserSessions.updatedAt)
+    .limit(limit);
+  signal.throwIfAborted();
+
+  let cleaned = 0;
+  let errors = 0;
+  for (const row of rows) {
+    if (row.status !== "suspended" && row.status !== "error") {
+      throw new Error("Expected an inactive managed browser cleanup target");
+    }
+    const result = await settleIncludingAbort(
+      cleanupExpiredInactiveBrowser(
+        db,
+        { ...row, status: row.status },
+        cutoff,
+        screenshotSchemaReady,
+        signal,
+      ),
+    );
+    signal.throwIfAborted();
+    if (result.ok) {
+      cleaned += result.value ? 1 : 0;
+    } else {
+      errors += 1;
+      L.warn("Managed browser retention cleanup failed", {
+        chatThreadId: row.chatThreadId,
+        providerProfileId: row.providerProfileId,
+        error: result.error,
+      });
+    }
+  }
+  return { checked: rows.length, cleaned, errors };
+}
+
+async function purgeExpiredStoppedBrowserInstances(
+  db: Db,
+  limit: number,
+  signal: AbortSignal,
+): Promise<{ readonly checked: number; readonly cleaned: number }> {
+  const cutoff = new Date(nowDate().getTime() - INACTIVE_BROWSER_RETENTION_MS);
+  const rows = await db
+    .select({
+      providerSessionId: browserSessionInstances.providerSessionId,
+    })
+    .from(browserSessionInstances)
+    .where(
+      and(
+        eq(browserSessionInstances.status, "stopped"),
+        lte(browserSessionInstances.finishedAt, cutoff),
+      ),
+    )
+    .orderBy(browserSessionInstances.finishedAt)
+    .limit(limit);
+  signal.throwIfAborted();
+  if (rows.length === 0) {
+    return { checked: 0, cleaned: 0 };
+  }
+  const deleted = await db
+    .delete(browserSessionInstances)
+    .where(
+      and(
+        eq(browserSessionInstances.status, "stopped"),
+        lte(browserSessionInstances.finishedAt, cutoff),
+        inArray(
+          browserSessionInstances.providerSessionId,
+          rows.map((row) => {
+            return row.providerSessionId;
+          }),
+        ),
+      ),
+    )
+    .returning({
+      providerSessionId: browserSessionInstances.providerSessionId,
+    });
+  signal.throwIfAborted();
+  return { checked: rows.length, cleaned: deleted.length };
 }
 
 async function deferBrowserInstanceReconcile(
@@ -3153,13 +3539,24 @@ export const reconcileZeroBrowsers$ = command(
       RECONCILE_BATCH_SIZE,
       signal,
     );
+    const screenshotSchemaReady = await browserScreenshotSchemaAvailable(db);
+    signal.throwIfAborted();
+    const expiredBrowserCleanup = await reconcileExpiredInactiveBrowsers(
+      db,
+      RECONCILE_BATCH_SIZE,
+      screenshotSchemaReady,
+      signal,
+    );
+    const expiredInstanceCleanup = await purgeExpiredStoppedBrowserInstances(
+      db,
+      RECONCILE_BATCH_SIZE,
+      signal,
+    );
     const profileCleanup = await reconcileOrphanedBrowserProfiles(
       db,
       RECONCILE_BATCH_SIZE,
       signal,
     );
-    const screenshotSchemaReady = await browserScreenshotSchemaAvailable(db);
-    signal.throwIfAborted();
     const deleteScreenshotObjects = async (keys: readonly string[]) => {
       await get(deleteS3Objects(env("R2_USER_ARTIFACTS_BUCKET_NAME"), keys));
     };
@@ -3184,16 +3581,21 @@ export const reconcileZeroBrowsers$ = command(
       checked:
         rows.length +
         releasedStarts +
+        expiredBrowserCleanup.checked +
+        expiredInstanceCleanup.checked +
         profileCleanup.checked +
         queuedScreenshotCleanup.checked +
         orphanedScreenshotCleanup.checked,
       stopped:
         stopped +
+        expiredBrowserCleanup.cleaned +
+        expiredInstanceCleanup.cleaned +
         profileCleanup.cleaned +
         queuedScreenshotCleanup.cleaned +
         orphanedScreenshotCleanup.cleaned,
       errors:
         errors +
+        expiredBrowserCleanup.errors +
         profileCleanup.errors +
         queuedScreenshotCleanup.errors +
         orphanedScreenshotCleanup.errors,


### PR DESCRIPTION
## Summary

- retire suspended or errored managed browsers after seven inactive days
- delete the Browser Use thread profile together with local instances, resize state, tab snapshots, and screenshots
- queue screenshot object deletion, purge orphaned stopped instances, and retry transient profile deletion failures without issuing another browser stop

## Test plan

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter="!api" --filter="!@vm0/app"`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-browser.test.ts --maxWorkers=1 --silent=passed-only`