### PR TITLE
test(api): stabilize usage insight source mapping

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
@@ -20,6 +20,7 @@ import {
   ensureUsagePricingRow,
   seedUsagePricingRows,
 } from "../../../test-fixtures/system-config-seeds";
+import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
@@ -111,8 +112,11 @@ async function createSourceRun(
     triggerSource,
   });
   // Free the org's concurrent-run slot; usage attribution only needs the
-  // run row and its trigger source, not a live run.
+  // run row and its trigger source, not a live run. Wait for cancellation's
+  // background settlement before reporting fixture usage so the source query
+  // never races the route's waitUntil work.
   await api.requestCancelRun(actor, run.runId, [200]);
+  await flushWaitUntilForTest();
   return run.runId;
 }
 


### PR DESCRIPTION
## Summary

- wait for cancellation-side `waitUntil` work while building usage-insight source fixtures
- keep the source-bucket assertions and production behavior unchanged

## Failure evidence

- Trigger: [Turbo run 31071972493](https://github.com/vm0-ai/vm0/actions/runs/31071972493), `merge_group`, head `6b7927c4afd93c7989b4eb4faf633bedba1fa7d8`
- First substantive failure: [`test-api (5)` job 92521618760](https://github.com/vm0-ai/vm0/actions/runs/31071972493/job/92521618760)
- Failed test: `GET /api/zero/usage/insight > source mapping — every TriggerSource lands in the correct bucket`
- Symptom: the automation bucket observed 50 instead of the expected minimum 100
- A later merge group for the same PR and exact same tree passed: [run 31072413712](https://github.com/vm0-ai/vm0/actions/runs/31072413712)

## Root cause

Classification: missing explicit test synchronization.

The fixture cancels each run to free the organization's concurrent-run slot. The cancel route returns after committing the run state, then performs usage settlement through `waitUntil`. The helper immediately reported fixture usage and continued to the final settlement/query, so cancellation-side settlement could still interleave with source attribution under parallel API scheduling.

The queued PR did not touch the API test or usage implementation. The first causal event was the fixture proceeding past the cancel response before the route's deferred side effects had finished.

## Fix

Call `flushWaitUntilForTest()` immediately after fixture cancellation, at the route's asynchronous domain boundary. This preserves the production contract and the original assertion strength without retries, delays, or widened tolerances.

## Validation

- target file: 5 consecutive passes, 16/16 each
- target file plus `usage-allowance.test.ts`, 2 workers: 5 consecutive passes, 31/31 each
- after rebasing onto current `main`: target file passed again, 16/16
- `pnpm -F api lint`
- `pnpm -F api check-types`
- Prettier check and `git diff --check`

