### PR TITLE
chore(runner): remove temporary reserved reuse claim instrumentation

### DIFF
--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -187,16 +187,6 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
             "pre-park INFO measurement"
         );
         tracing::info!(
-            target: "runner::reserved_reuse_claim",
-            measurement = "reserved_reuse_claim",
-            outcome = "claimed",
-            run_id = "00000000-0000-0000-0000-000000000001",
-            duration_ms = 42_u64,
-            preference_reason = "none",
-            timezone_state = "absent",
-            "reserved reusable claim observed"
-        );
-        tracing::info!(
             target: "sandbox_fc::balloon_settle",
             measurement = "balloon_settle",
             outcome = "target_reached",
@@ -227,7 +217,6 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
     for message in [
         "info is below threshold, should not be ingested",
         "pre-park INFO measurement",
-        "reserved reusable claim observed",
         "balloon settle completed",
     ] {
         assert!(

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -644,12 +644,6 @@ async fn claim_with_local_admission(
     let observed_candidate =
         is_selected_finalizing_candidate(&candidate, ctx.runner_id, ctx.heartbeat_generation)
             .then(|| candidate.clone());
-    if matches!(
-        &admission.resource,
-        LocalAdmissionResource::Reusable(_) | LocalAdmissionResource::ExactSpeculative(_)
-    ) {
-        candidate.mark_reserved_reuse_claim_started();
-    }
     let LocalAdmission {
         resource,
         cancellation,

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -147,14 +147,6 @@ fn context_with_reuse_key(run_id: RunId, reuse_key: &str) -> crate::types::Execu
     context
 }
 
-fn reserved_reuse_claim_preference(
-    candidate: &crate::provider::JobCandidate,
-) -> Option<&'static str> {
-    candidate
-        .reserved_reuse_claim_observation()
-        .map(crate::provider::ReservedReuseClaimObservation::preference_reason)
-}
-
 /// TOCTOU regression: soft drain can arrive after the main loop has selected
 /// a discovered candidate but before claim. The candidate is still unowned at
 /// that point, so Draining must roll back local admission and skip claim.
@@ -289,17 +281,6 @@ async fn claim_failure_rolls_back_budget() {
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     wait_cancel_token_removed(&env.cancel_tokens, run_id_1, Duration::from_secs(5)).await;
     assert_eq!(budget.allocated().2, 0);
-    let fresh_candidate = env
-        .handle
-        .claim_candidates()
-        .into_iter()
-        .find(|candidate| candidate.run_id() == run_id_1)
-        .expect("fresh candidate should reach the provider claim");
-    assert_eq!(
-        reserved_reuse_claim_preference(&fresh_candidate),
-        None,
-        "fresh admission must stay outside the reserved-reuse claim cohort"
-    );
     // Second job: claim succeeds — budget should have been freed.
     let run_id_2 = RunId::new_v4();
     push_job(
@@ -435,23 +416,6 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
         .await
         .expect("restored idle reservation should serve the next claim");
     assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
-    let claim_candidates = env.handle.claim_candidates();
-    let exact_candidate = claim_candidates
-        .iter()
-        .find(|candidate| candidate.run_id() == conflict_run_id)
-        .expect("exact candidate should reach the provider claim");
-    assert_eq!(
-        reserved_reuse_claim_preference(exact_candidate),
-        Some("exact_history_generation")
-    );
-    let matching_candidate = claim_candidates
-        .iter()
-        .find(|candidate| candidate.run_id() == followup_run_id)
-        .expect("matching candidate should reach the provider claim");
-    assert_eq!(
-        reserved_reuse_claim_preference(matching_candidate),
-        Some("matching_reuse_key")
-    );
     shutdown(&env, run_handle).await;
 }
 
@@ -493,23 +457,6 @@ async fn matching_preference_reservation_is_restored_after_claim_conflict() {
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     wait_cancel_token_removed(&env.cancel_tokens, ordinary_run_id, Duration::from_secs(5)).await;
 
-    let claim_candidates = env.handle.claim_candidates();
-    let matching_candidate = claim_candidates
-        .iter()
-        .find(|candidate| candidate.run_id() == run_id)
-        .expect("matching candidate should reach the provider claim");
-    assert_eq!(
-        reserved_reuse_claim_preference(matching_candidate),
-        Some("matching_reuse_key")
-    );
-    let ordinary_candidate = claim_candidates
-        .iter()
-        .find(|candidate| candidate.run_id() == ordinary_run_id)
-        .expect("ordinary reuse-key candidate should reach the provider claim");
-    assert_eq!(
-        reserved_reuse_claim_preference(ordinary_candidate),
-        Some("none")
-    );
     assert_eq!(
         idle_pool.lock().await.held_reuse_keys(),
         vec![session_id.to_string()],
@@ -810,16 +757,6 @@ async fn selected_finalizing_candidate_records_claim_loss_and_restores_exact_res
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
     assert_candidate_observation(&captured, run_id, history_generation_run_id, "claim_lost");
-    let claimed_candidate = env
-        .handle
-        .claim_candidates()
-        .into_iter()
-        .find(|candidate| candidate.run_id() == run_id)
-        .expect("finalizing candidate should reach the provider claim");
-    assert_eq!(
-        reserved_reuse_claim_preference(&claimed_candidate),
-        Some("finalizing_predecessor")
-    );
     assert_eq!(
         env.idle_pool.lock().await.held_reuse_keys(),
         vec![reuse_key.to_string()],

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -31,7 +31,7 @@ use super::builtin_firewall_catalog::{
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
-    ReservedReuseClaimObservation, parse_runner_preference,
+    parse_runner_preference,
 };
 use crate::active_input::{ActiveInputNotifications, ActiveInputSource};
 use crate::duration::duration_ms;
@@ -46,7 +46,6 @@ use crate::types::{
 use sandbox::SandboxId;
 
 const CHAT_STEER_FEATURE_FLAG: &str = "chatSteer";
-const RESERVED_REUSE_CLAIM_TRACING_TARGET: &str = "runner::reserved_reuse_claim";
 
 fn chat_steer_enabled(
     reuse_key: Option<&str>,
@@ -172,80 +171,6 @@ struct ClaimFailureDecision {
     status: Option<StatusCode>,
     transport_kind: Option<&'static str>,
     response_run_id: Option<RunId>,
-}
-
-enum ReservedReuseClaimOutcome {
-    Claimed { timezone_state: &'static str },
-    Unavailable,
-    ProviderFailure { class: ClaimFailureClass },
-    ResponseRunIdMismatch,
-}
-
-fn record_reserved_reuse_claim_observation(
-    observation: Option<ReservedReuseClaimObservation>,
-    run_id: RunId,
-    runner_id: &str,
-    heartbeat_generation: u64,
-    outcome: ReservedReuseClaimOutcome,
-) {
-    let Some(observation) = observation else {
-        return;
-    };
-    let duration_ms = duration_ms(observation.elapsed());
-    let preference_reason = observation.preference_reason();
-
-    match outcome {
-        ReservedReuseClaimOutcome::Claimed { timezone_state } => tracing::info!(
-            target: RESERVED_REUSE_CLAIM_TRACING_TARGET,
-            measurement = "reserved_reuse_claim",
-            outcome = "claimed",
-            run_id = %run_id,
-            runner_id,
-            heartbeat_generation,
-            runner_version = env!("CARGO_PKG_VERSION"),
-            duration_ms,
-            preference_reason,
-            timezone_state,
-            "reserved reusable claim observed"
-        ),
-        ReservedReuseClaimOutcome::Unavailable => tracing::info!(
-            target: RESERVED_REUSE_CLAIM_TRACING_TARGET,
-            measurement = "reserved_reuse_claim",
-            outcome = "unavailable",
-            run_id = %run_id,
-            runner_id,
-            heartbeat_generation,
-            runner_version = env!("CARGO_PKG_VERSION"),
-            duration_ms,
-            preference_reason,
-            "reserved reusable claim observed"
-        ),
-        ReservedReuseClaimOutcome::ProviderFailure { class } => tracing::info!(
-            target: RESERVED_REUSE_CLAIM_TRACING_TARGET,
-            measurement = "reserved_reuse_claim",
-            outcome = "provider_failure",
-            failure_class = class.as_str(),
-            run_id = %run_id,
-            runner_id,
-            heartbeat_generation,
-            runner_version = env!("CARGO_PKG_VERSION"),
-            duration_ms,
-            preference_reason,
-            "reserved reusable claim observed"
-        ),
-        ReservedReuseClaimOutcome::ResponseRunIdMismatch => tracing::info!(
-            target: RESERVED_REUSE_CLAIM_TRACING_TARGET,
-            measurement = "reserved_reuse_claim",
-            outcome = "response_run_id_mismatch",
-            run_id = %run_id,
-            runner_id,
-            heartbeat_generation,
-            runner_version = env!("CARGO_PKG_VERSION"),
-            duration_ms,
-            preference_reason,
-            "reserved reusable claim observed"
-        ),
-    }
 }
 
 const CLAIM_TELEMETRY_DURATION_MS_MAX: u64 = 9_007_199_254_740_991;
@@ -715,7 +640,6 @@ impl JobProvider for ApiProvider {
 
     async fn claim(&self, candidate: JobCandidate) -> Option<ClaimedJob> {
         let run_id = candidate.run_id();
-        let reserved_reuse_observation = candidate.reserved_reuse_claim_observation();
         match self
             .api
             .claim(&candidate, &self.runner_id, self.heartbeat_generation)
@@ -740,13 +664,6 @@ impl JobProvider for ApiProvider {
                 } {
                     Ok(claimed) => claimed,
                     Err(error) => {
-                        record_reserved_reuse_claim_observation(
-                            reserved_reuse_observation,
-                            run_id,
-                            &self.runner_id,
-                            self.heartbeat_generation,
-                            ReservedReuseClaimOutcome::ResponseRunIdMismatch,
-                        );
                         self.record_claim_failure(
                             run_id,
                             ClaimFailureDecision {
@@ -761,19 +678,6 @@ impl JobProvider for ApiProvider {
                         return None;
                     }
                 };
-                record_reserved_reuse_claim_observation(
-                    reserved_reuse_observation,
-                    run_id,
-                    &self.runner_id,
-                    self.heartbeat_generation,
-                    ReservedReuseClaimOutcome::Claimed {
-                        timezone_state: if claimed.context().user_timezone.is_some() {
-                            "present"
-                        } else {
-                            "absent"
-                        },
-                    },
-                );
                 self.claim_cooldowns.remove(run_id).await;
                 info!(
                     run_id = %run_id,
@@ -784,30 +688,14 @@ impl JobProvider for ApiProvider {
                 Some(claimed)
             }
             Ok(None) => {
-                record_reserved_reuse_claim_observation(
-                    reserved_reuse_observation,
-                    run_id,
-                    &self.runner_id,
-                    self.heartbeat_generation,
-                    ReservedReuseClaimOutcome::Unavailable,
-                );
                 self.claim_cooldowns.remove(run_id).await;
                 info!(run_id = %run_id, "job unavailable, skipping");
                 self.poll_wakeups.request_immediate_poll().await;
                 None
             }
             Err(e) => {
-                let decision = classify_claim_failure(&e);
-                record_reserved_reuse_claim_observation(
-                    reserved_reuse_observation,
-                    run_id,
-                    &self.runner_id,
-                    self.heartbeat_generation,
-                    ReservedReuseClaimOutcome::ProviderFailure {
-                        class: decision.class,
-                    },
-                );
-                self.record_claim_failure(run_id, decision).await;
+                self.record_claim_failure(run_id, classify_claim_failure(&e))
+                    .await;
                 None
             }
         }
@@ -1726,7 +1614,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::http::HttpClientConfig;
-    use crate::provider::{RunnerPreference, RunnerPreferenceReason};
+    use crate::provider::RunnerPreferenceReason;
 
     const RUNNER_CLAIM_RESPONSE_FIXTURE: &str = include_str!(
         "../../../../turbo/packages/api-contracts/src/contracts/__tests__/fixtures/runner-claim-response.json"
@@ -2018,80 +1906,6 @@ mod tests {
             .get(field)
             .map(String::as_str)
             .unwrap_or_else(|| panic!("missing field {field}; event={event:#?}"))
-    }
-
-    fn marked_reusable_candidate(
-        run_id: RunId,
-        preference_reason: Option<RunnerPreferenceReason>,
-    ) -> JobCandidate {
-        let mut candidate = JobCandidate::new(run_id, crate::profile::DEFAULT_PROFILE.to_string())
-            .with_runner_preference(preference_reason.map(|reason| {
-                RunnerPreference::for_test(
-                    TEST_RUNNER_ID.parse().unwrap(),
-                    TEST_HEARTBEAT_GENERATION,
-                    reason,
-                    Instant::now() + Duration::from_secs(30),
-                )
-            }));
-        candidate.mark_reserved_reuse_claim_started();
-        candidate
-    }
-
-    fn reserved_reuse_claim_event(events: &[CapturedEvent]) -> &CapturedEvent {
-        let matching: Vec<_> = events
-            .iter()
-            .filter(|event| {
-                event
-                    .fields
-                    .get("message")
-                    .is_some_and(|message| message == "reserved reusable claim observed")
-            })
-            .collect();
-        assert_eq!(
-            matching.len(),
-            1,
-            "marked claim should emit exactly one observation; events={events:#?}"
-        );
-        matching[0]
-    }
-
-    fn assert_reserved_reuse_claim_event<'a>(
-        events: &'a [CapturedEvent],
-        run_id: RunId,
-        outcome: &str,
-        preference_reason: &str,
-    ) -> &'a CapturedEvent {
-        let event = reserved_reuse_claim_event(events);
-        assert_eq!(event.level, Level::INFO);
-        assert_eq!(event_field(event, "measurement"), "reserved_reuse_claim");
-        assert_eq!(event_field(event, "outcome"), outcome);
-        assert_eq!(event_field(event, "run_id"), run_id.to_string());
-        assert_eq!(event_field(event, "runner_id"), TEST_RUNNER_ID);
-        assert_eq!(
-            event_field(event, "heartbeat_generation"),
-            TEST_HEARTBEAT_GENERATION.to_string()
-        );
-        assert_eq!(
-            event_field(event, "runner_version"),
-            env!("CARGO_PKG_VERSION")
-        );
-        assert_eq!(event_field(event, "preference_reason"), preference_reason);
-        event_field(event, "duration_ms")
-            .parse::<u64>()
-            .expect("claim duration should be an integer number of milliseconds");
-        event
-    }
-
-    fn assert_no_reserved_reuse_claim_event(events: &[CapturedEvent]) {
-        assert!(
-            events.iter().all(|event| {
-                event
-                    .fields
-                    .get("message")
-                    .is_none_or(|message| message != "reserved reusable claim observed")
-            }),
-            "unmarked claim must not emit a reserved-reuse observation; events={events:#?}"
-        );
     }
 
     fn heartbeat_state_for_test() -> HeartbeatState {
@@ -2919,12 +2733,11 @@ mod tests {
         )
         .await;
 
-        let mut direct = tokio::time::timeout(Duration::from_secs(1), provider.discover())
+        let direct = tokio::time::timeout(Duration::from_secs(1), provider.discover())
             .await
             .expect("discover should receive direct candidate")
             .unwrap();
         assert_eq!(direct.discovery_source(), Some(JobDiscoverySource::Ably));
-        direct.mark_reserved_reuse_claim_started();
         let (claim, events) = capture_api_provider_events(provider.claim(direct)).await;
         assert!(claim.is_none());
         let event = captured_event(&events, "claim failed, candidate cooling down");
@@ -2937,17 +2750,6 @@ mod tests {
             !format!("{event:#?}").contains("sensitive-claim-rejection-body"),
             "claim failure event must not contain the response body"
         );
-        let observation =
-            assert_reserved_reuse_claim_event(&events, rejected_run_id, "provider_failure", "none");
-        assert_eq!(
-            event_field(observation, "failure_class"),
-            "http_deterministic"
-        );
-        assert!(
-            !format!("{observation:#?}").contains("sensitive-claim-rejection-body"),
-            "claim observation must not contain the response body"
-        );
-
         let next = tokio::time::timeout(Duration::from_secs(1), provider.discover())
             .await
             .expect("claim failure should poll for another candidate")
@@ -3015,14 +2817,8 @@ mod tests {
         )
         .await;
 
-        let mut unavailable = provider.discover().await.unwrap();
-        unavailable.mark_reserved_reuse_claim_started();
-        let (claim, events) = capture_api_provider_events(provider.claim(unavailable)).await;
-        assert!(claim.is_none());
-        let observation =
-            assert_reserved_reuse_claim_event(&events, unavailable_run_id, "unavailable", "none");
-        assert!(!observation.fields.contains_key("failure_class"));
-        assert!(!observation.fields.contains_key("timezone_state"));
+        let unavailable = provider.discover().await.unwrap();
+        assert!(provider.claim(unavailable).await.is_none());
         let next = tokio::time::timeout(Duration::from_secs(1), provider.discover())
             .await
             .expect("unavailable claim should promptly poll the backlog")
@@ -3896,10 +3692,13 @@ mod tests {
             Arc::new(PollWakeups::new(false)),
         );
 
-        let candidate =
-            marked_reusable_candidate(run_id, Some(RunnerPreferenceReason::ExactHistoryGeneration));
-        let (claimed, events) = capture_api_provider_events(provider.claim(candidate)).await;
-        let claimed = claimed.expect("shared current claim response should decode");
+        let claimed = provider
+            .claim(JobCandidate::new(
+                run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+            ))
+            .await
+            .expect("shared current claim response should decode");
         let context = claimed.context();
 
         assert_eq!(context.run_id, run_id);
@@ -3942,17 +3741,6 @@ mod tests {
         assert_eq!(
             context.codex_runtime_config.as_ref().unwrap().provider_id,
             "fixture_provider"
-        );
-        let event = assert_reserved_reuse_claim_event(
-            &events,
-            run_id,
-            "claimed",
-            "exact_history_generation",
-        );
-        assert_eq!(event_field(event, "timezone_state"), "present");
-        assert!(
-            !format!("{event:#?}").contains("UTC"),
-            "claim observation must not contain the raw timezone"
         );
         claim_mock.assert_calls_async(1).await;
     }
@@ -4053,18 +3841,18 @@ mod tests {
             Arc::new(PollWakeups::new(false)),
         );
 
-        let (claimed, events) = capture_api_provider_events(provider.claim(JobCandidate::new(
-            run_id,
-            crate::profile::DEFAULT_PROFILE.to_string(),
-        )))
-        .await;
-        let claimed = claimed.expect("previous minimal claim response should remain compatible");
+        let claimed = provider
+            .claim(JobCandidate::new(
+                run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+            ))
+            .await
+            .expect("previous minimal claim response should remain compatible");
         let context = claimed.context();
 
         assert_eq!(context.prompt, "previous response");
         assert!(context.append_system_prompt.is_none());
         assert!(context.billable_firewalls.is_empty());
-        assert_no_reserved_reuse_claim_event(&events);
         claim_mock.assert_calls_async(1).await;
     }
 
@@ -4162,7 +3950,7 @@ mod tests {
             Arc::new(PollWakeups::new(false)),
         );
 
-        let candidate = marked_reusable_candidate(run_id, None);
+        let candidate = JobCandidate::new(run_id, crate::profile::DEFAULT_PROFILE.to_string());
         let (claimed, events) = capture_api_provider_events(provider.claim(candidate)).await;
 
         assert!(claimed.is_none());
@@ -4173,10 +3961,6 @@ mod tests {
             context_run_id.to_string()
         );
         assert_eq!(event_field(event, "retry_after_ms"), "30000");
-        let observation =
-            assert_reserved_reuse_claim_event(&events, run_id, "response_run_id_mismatch", "none");
-        assert!(!observation.fields.contains_key("failure_class"));
-        assert!(!observation.fields.contains_key("timezone_state"));
         claim_mock.assert_calls_async(1).await;
     }
 
@@ -4211,7 +3995,7 @@ mod tests {
             Arc::new(PollWakeups::new(false)),
         );
 
-        let candidate = marked_reusable_candidate(run_id, None);
+        let candidate = JobCandidate::new(run_id, crate::profile::DEFAULT_PROFILE.to_string());
         let (claimed, events) = capture_api_provider_events(provider.claim(candidate)).await;
         let claimed = claimed.expect("claim should succeed");
         let event = captured_event(&events, "job claimed");
@@ -4220,8 +4004,6 @@ mod tests {
             "550e8400-e29b-41d4-a716-446655440000"
         );
         assert_eq!(event_field(event, "heartbeat_generation"), "7");
-        let observation = assert_reserved_reuse_claim_event(&events, run_id, "claimed", "none");
-        assert_eq!(event_field(observation, "timezone_state"), "absent");
         let (context, completion_auth, active_input_source) = claimed.into_parts();
         assert_eq!(context.sandbox_token, "claim-sandbox-token");
         assert!(active_input_source.is_none());

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -43,16 +43,6 @@ pub(crate) enum RunnerPreferenceReason {
     FinalizingPredecessor,
 }
 
-impl RunnerPreferenceReason {
-    pub(crate) const fn as_str(self) -> &'static str {
-        match self {
-            Self::ExactHistoryGeneration => "exact_history_generation",
-            Self::MatchingReuseKey => "matching_reuse_key",
-            Self::FinalizingPredecessor => "finalizing_predecessor",
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(crate) struct RunnerProcessIdentity {
@@ -159,23 +149,6 @@ pub(crate) enum JobDiscoverySource {
     Poll,
 }
 
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct ReservedReuseClaimObservation {
-    started_at: Instant,
-    preference_reason: Option<RunnerPreferenceReason>,
-}
-
-impl ReservedReuseClaimObservation {
-    pub(crate) fn elapsed(self) -> Duration {
-        self.started_at.elapsed()
-    }
-
-    pub(crate) fn preference_reason(self) -> &'static str {
-        self.preference_reason
-            .map_or("none", RunnerPreferenceReason::as_str)
-    }
-}
-
 impl JobDiscoverySource {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
@@ -206,7 +179,6 @@ pub struct JobCandidate {
     reuse_key: Option<String>,
     history_generation_run_id: Option<RunId>,
     runner_preference: Option<RunnerPreference>,
-    reserved_reuse_claim_observation: Option<ReservedReuseClaimObservation>,
 }
 
 impl JobCandidate {
@@ -238,7 +210,6 @@ impl JobCandidate {
             reuse_key: None,
             history_generation_run_id: None,
             runner_preference: None,
-            reserved_reuse_claim_observation: None,
         }
     }
 
@@ -334,17 +305,6 @@ impl JobCandidate {
 
     pub(crate) fn runner_preference(&self) -> Option<&RunnerPreference> {
         self.runner_preference.as_ref()
-    }
-
-    pub(crate) fn mark_reserved_reuse_claim_started(&mut self) {
-        self.reserved_reuse_claim_observation = Some(ReservedReuseClaimObservation {
-            started_at: Instant::now(),
-            preference_reason: self.runner_preference().map(RunnerPreference::reason),
-        });
-    }
-
-    pub(crate) fn reserved_reuse_claim_observation(&self) -> Option<ReservedReuseClaimObservation> {
-        self.reserved_reuse_claim_observation
     }
 
     pub(crate) fn without_runner_preference(mut self) -> Self {


### PR DESCRIPTION
## Summary

- remove the temporary local `reserved_reuse_claim` candidate state and claim-outcome logging
- remove observation-only assertions while retaining the surrounding claim, rollback, and reuse integration scenarios
- preserve persisted `sandboxReuseResult`, `sandbox_reuse_hit` / `sandbox_reuse_miss`, and all `runner_exact_reuse_*` telemetry

## Compatibility

This removes process-local state and local INFO output only. It does not change APIs, database schemas, queue or heartbeat payloads, persisted data, claim behavior, or sandbox lifecycle behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features` (2998 passed, 20 ignored)

Closes #25374

Parent context: #24870
