### PR TITLE
refactor(sandbox-fc): retire balloon settle summary

### DIFF
--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -181,15 +181,6 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
         tracing::warn!(foo = "bar", "a warning");
         tracing::error!(code = 42, "a failure");
         tracing::info!("info is below threshold, should not be ingested");
-        tracing::info!(
-            target: "sandbox_fc::balloon_settle",
-            measurement = "balloon_settle",
-            outcome = "target_reached",
-            elapsed_ms = 25_u64,
-            sample_count = 2_u64,
-            admission_action = "reuse",
-            "balloon settle completed"
-        );
     }
 
     guard.shutdown().await;
@@ -209,15 +200,10 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
     assert_eq!(failure["service"], json!("runner"));
     assert_eq!(failure["level"], json!("error"));
     assert_eq!(failure["code"], json!(42));
-    for message in [
-        "info is below threshold, should not be ingested",
-        "balloon settle completed",
-    ] {
-        assert!(
-            !has_event_with_message(&events, message),
-            "INFO event should not be ingested: {events:#?}",
-        );
-    }
+    assert!(
+        !has_event_with_message(&events, "info is below threshold, should not be ingested"),
+        "INFO event should not be ingested: {events:#?}",
+    );
 }
 
 #[tokio::test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3453,60 +3453,6 @@ fn park_admission_action(outcome: SandboxParkOutcome) -> &'static str {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-enum BalloonSettleOutcome {
-    SkippedZeroTarget,
-    TargetReached,
-    WithinTolerance,
-    PressureLimited,
-    Deadline,
-    StatsUnavailable,
-}
-
-impl BalloonSettleOutcome {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::SkippedZeroTarget => "skipped_zero_target",
-            Self::TargetReached => "target_reached",
-            Self::WithinTolerance => "within_tolerance",
-            Self::PressureLimited => "pressure_limited",
-            Self::Deadline => "deadline",
-            Self::StatsUnavailable => "stats_unavailable",
-        }
-    }
-}
-
-fn emit_balloon_settle_summary(
-    settle_outcome: BalloonSettleOutcome,
-    elapsed_ms: u64,
-    sample_count: u32,
-    park_outcome: SandboxParkOutcome,
-) {
-    info!(
-        target: "sandbox_fc::balloon_settle",
-        measurement = "balloon_settle",
-        outcome = settle_outcome.as_str(),
-        elapsed_ms,
-        sample_count,
-        admission_action = park_admission_action(park_outcome),
-        "balloon settle completed"
-    );
-}
-
-fn complete_balloon_settle(
-    summary: &BalloonSettleSummary,
-    settle_outcome: BalloonSettleOutcome,
-    park_outcome: SandboxParkOutcome,
-) -> SandboxParkOutcome {
-    emit_balloon_settle_summary(
-        settle_outcome,
-        summary.elapsed_ms(),
-        summary.sample_count,
-        park_outcome,
-    );
-    park_outcome
-}
-
 /// Wait until the guest balloon driver inflates close enough to `target_mib`.
 ///
 /// The guest needs running vCPUs to inflate, so this must be called
@@ -3542,7 +3488,7 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                     &summary,
                     outcome,
                 );
-                return complete_balloon_settle(&summary, BalloonSettleOutcome::Deadline, outcome);
+                return outcome;
             }
         }
 
@@ -3570,11 +3516,7 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                         reported_total_mib = ?summary.reported_total_mib(),
                         "balloon fully inflated, proceeding to pause"
                     );
-                    return complete_balloon_settle(
-                        &summary,
-                        BalloonSettleOutcome::TargetReached,
-                        SandboxParkOutcome::Reusable,
-                    );
+                    return SandboxParkOutcome::Reusable;
                 }
 
                 if deficit_mib <= tolerance_mib {
@@ -3598,11 +3540,7 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                         reported_total_mib = ?summary.reported_total_mib(),
                         "balloon inflated within tolerance, proceeding to pause"
                     );
-                    return complete_balloon_settle(
-                        &summary,
-                        BalloonSettleOutcome::WithinTolerance,
-                        SandboxParkOutcome::Reusable,
-                    );
+                    return SandboxParkOutcome::Reusable;
                 }
 
                 if summary.is_pressure_limited_partial_reclaim(deficit_mib, tolerance_mib) {
@@ -3627,11 +3565,7 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                         reason = BALLOON_PRESSURE_LIMITED_REASON,
                         "balloon pressure-limited partial reclaim, proceeding to pause"
                     );
-                    return complete_balloon_settle(
-                        &summary,
-                        BalloonSettleOutcome::PressureLimited,
-                        SandboxParkOutcome::Reusable,
-                    );
+                    return SandboxParkOutcome::Reusable;
                 }
 
                 trace!(
@@ -3670,11 +3604,7 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                     %e,
                     "balloon stats unavailable, proceeding to pause"
                 );
-                return complete_balloon_settle(
-                    &summary,
-                    BalloonSettleOutcome::StatsUnavailable,
-                    outcome,
-                );
+                return outcome;
             }
             Err(_) => {
                 let outcome = summary.park_outcome();
@@ -3686,7 +3616,7 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                     &summary,
                     outcome,
                 );
-                return complete_balloon_settle(&summary, BalloonSettleOutcome::Deadline, outcome);
+                return outcome;
             }
         }
 
@@ -3754,12 +3684,6 @@ async fn park_inner(
         // savings.
         wait_for_balloon(&client, target, log_id).await
     } else {
-        emit_balloon_settle_summary(
-            BalloonSettleOutcome::SkippedZeroTarget,
-            0,
-            0,
-            SandboxParkOutcome::Reusable,
-        );
         SandboxParkOutcome::Reusable
     };
 

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -3882,53 +3882,6 @@ fn captured_message_count(events: &[CapturedEvent], message: &str) -> usize {
         .count()
 }
 
-fn assert_balloon_settle_summary(
-    events: &[CapturedEvent],
-    outcome: &str,
-    sample_count: u32,
-    admission_action: &str,
-) {
-    let summaries: Vec<_> = events
-        .iter()
-        .filter(|event| {
-            event
-                .fields
-                .get("message")
-                .is_some_and(|message| message == "balloon settle completed")
-        })
-        .collect();
-    assert_eq!(
-        summaries.len(),
-        1,
-        "expected exactly one balloon settle summary; events={events:#?}"
-    );
-
-    let summary = summaries[0];
-    assert_eq!(summary.level, Level::INFO);
-    assert_eq!(
-        summary
-            .fields
-            .keys()
-            .map(String::as_str)
-            .collect::<Vec<_>>(),
-        [
-            "admission_action",
-            "elapsed_ms",
-            "measurement",
-            "message",
-            "outcome",
-            "sample_count",
-        ],
-        "canonical summary must remain bounded and identifier-free"
-    );
-    assert_event_field(summary, "measurement", "balloon_settle");
-    assert_event_field(summary, "outcome", outcome);
-    assert_event_field(summary, "sample_count", &sample_count.to_string());
-    assert_event_field(summary, "admission_action", admission_action);
-    assert_eq!(summary.field_kinds.get("elapsed_ms"), Some(&"u64"));
-    assert_eq!(summary.field_kinds.get("sample_count"), Some(&"u64"));
-}
-
 #[test]
 fn exec_capture_request_preserves_stable_operation_label() {
     let stdin = [1, 2, 3];
@@ -4186,7 +4139,6 @@ async fn wait_for_balloon_rechecks_after_initial_25_ms_delay() {
             .count(),
         2
     );
-    assert_balloon_settle_summary(&captured.entries(), "target_reached", 2, "reuse");
 }
 
 #[tokio::test]
@@ -4282,7 +4234,6 @@ async fn wait_for_balloon_follows_exact_bounded_poll_schedule() {
             .count(),
         16
     );
-    assert_balloon_settle_summary(&captured.entries(), "deadline", 16, "reject_and_destroy");
 }
 
 #[tokio::test]
@@ -4332,7 +4283,6 @@ async fn wait_for_balloon_extends_deadline_for_recent_safe_progress() {
         &events,
         "balloon inflate incomplete after 5s, pausing anyway"
     ));
-    assert_balloon_settle_summary(&events, "target_reached", 3, "reuse");
 }
 
 #[tokio::test]
@@ -4398,7 +4348,6 @@ async fn wait_for_balloon_progress_grace_remains_bounded() {
     assert_event_field(event, "deficit_mib", "Some(1270)");
     assert_event_field(event, "reason", "severe_deficit");
     assert_event_field(event, "admission_action", "reject_and_destroy");
-    assert_balloon_settle_summary(&events, "deadline", 3, "reject_and_destroy");
 }
 
 #[tokio::test]
@@ -4436,7 +4385,6 @@ async fn wait_for_balloon_near_target_logs_summary_without_timeout() {
     assert_event_field(event, "first_actual_mib", "Some(3545)");
     assert_event_field(event, "max_actual_mib", "Some(3545)");
     assert_event_field(event, "actual_delta_mib", "Some(0)");
-    assert_balloon_settle_summary(&events, "within_tolerance", 1, "reuse");
 }
 
 #[tokio::test]
@@ -4471,7 +4419,6 @@ async fn wait_for_balloon_timeout_logs_actual_stalled_reason() {
     assert_event_field(event, "actual_delta_mib", "Some(0)");
     assert_event_field(event, "reason", "actual_stalled");
     assert_event_field(event, "admission_action", "reuse");
-    assert_balloon_settle_summary(&events, "deadline", 1, "reuse");
 }
 
 #[tokio::test]
@@ -4506,7 +4453,6 @@ async fn wait_for_balloon_accepts_pressure_limited_partial_reclaim() {
     assert_event_field(event, "reported_free_mib", "Some(64)");
     assert_event_field(event, "reported_available_mib", "Some(128)");
     assert_event_field(event, "reason", "pressure_limited_partial_reclaim");
-    assert_balloon_settle_summary(&events, "pressure_limited", 1, "reuse");
 }
 
 #[test]
@@ -4594,7 +4540,6 @@ async fn wait_for_balloon_timeout_logs_target_not_observed_reason() {
     assert_event_field(event, "target_observed", "false");
     assert_event_field(event, "observed_target_mib", "Some(1024)");
     assert_event_field(event, "reason", "target_not_observed");
-    assert_balloon_settle_summary(&events, "deadline", 1, "reuse");
 }
 
 #[tokio::test]
@@ -4641,7 +4586,6 @@ async fn wait_for_balloon_stats_poll_is_bounded_by_settle_timeout() {
     assert_event_field(event, "reason", "stats_unavailable");
     assert_event_field(event, "actual", "None");
     assert_event_field(event, "deficit_mib", "None");
-    assert_balloon_settle_summary(&events, "deadline", 0, "reuse");
 }
 
 #[tokio::test]
@@ -4673,7 +4617,6 @@ async fn wait_for_balloon_timeout_logs_severe_deficit_and_memory_stats() {
     assert_event_field(event, "reported_total_mib", "Some(2048)");
     assert_event_field(event, "reason", "severe_deficit");
     assert_event_field(event, "admission_action", "reject_and_destroy");
-    assert_balloon_settle_summary(&events, "deadline", 1, "reject_and_destroy");
 }
 
 #[tokio::test]
@@ -4702,8 +4645,6 @@ async fn park_pauses_when_balloon_stats_are_unavailable() {
     assert_event_field(event, "deficit_mib", "None");
     assert_event_field(event, "sample_count", "0");
     assert_event_field(event, "reason", "stats_unavailable");
-    assert_balloon_settle_summary(&events, "stats_unavailable", 0, "reuse");
-
     let reqs = api.drain_requests();
     let ps = patches(&reqs);
     assert_eq!(ps.len(), 2, "expected balloon inflate + vm pause");
@@ -4946,13 +4887,13 @@ async fn park_small_vm_skips_balloon_but_pauses_vcpus() {
     let mut controller = Some(original_controller);
     let mut is_parked = false;
 
-    let (result, events) = capture_async_log_events(park_inner(
+    let result = park_inner(
         &mut is_parked,
         512,
         &mut controller,
         api.socket_path(),
         "test-park-small",
-    ))
+    )
     .await;
     result.unwrap();
 
@@ -4969,7 +4910,6 @@ async fn park_small_vm_skips_balloon_but_pauses_vcpus() {
     assert_eq!(ps.len(), 1, "expected only vm pause, no balloon PATCH");
     assert_eq!(ps[0].path, "/vm");
     assert!(ps[0].body.contains("Paused"));
-    assert_balloon_settle_summary(&events, "skipped_zero_target", 0, "reuse");
 }
 
 #[tokio::test]
@@ -5281,13 +5221,13 @@ async fn park_balloon_failure_leaves_flag_false() {
     let mut controller = Some(test_balloon_controller());
     let mut is_parked = false;
 
-    let (result, events) = capture_async_log_events(park_inner(
+    let result = park_inner(
         &mut is_parked,
         2048,
         &mut controller,
         api.socket_path(),
         "test-park-fail",
-    ))
+    )
     .await;
 
     assert_idle_transition(result, SandboxIdleTransition::Park);
@@ -5298,11 +5238,6 @@ async fn park_balloon_failure_leaves_flag_false() {
     let ps = patches(&reqs);
     assert_eq!(ps.len(), 1, "only balloon inflate should be attempted");
     assert_eq!(ps[0].path, "/balloon");
-    assert!(
-        !has_captured_event(&events, "balloon settle completed"),
-        "PATCH failure occurs before settlement and must not emit a completed summary"
-    );
-
     // A follow-up unpark must be a clean no-op because is_parked is false.
     let (_state_tx, state_rx) = watch::channel(SandboxState::Running);
     unpark_inner(
@@ -5433,13 +5368,13 @@ async fn park_pause_http_400_propagates_as_idle_transition() {
     let mut controller = Some(test_balloon_controller());
     let mut is_parked = false;
 
-    let (result, events) = capture_async_log_events(park_inner(
+    let result = park_inner(
         &mut is_parked,
         2048,
         &mut controller,
         api.socket_path(),
         "pause-fail",
-    ))
+    )
     .await;
 
     assert_idle_transition_message(
@@ -5456,7 +5391,6 @@ async fn park_pause_http_400_propagates_as_idle_transition() {
     assert_eq!(ps.len(), 2);
     assert_eq!(ps[0].path, "/balloon");
     assert_eq!(ps[1].path, "/vm");
-    assert_balloon_settle_summary(&events, "stats_unavailable", 1, "reject_and_destroy");
 }
 
 #[tokio::test]
@@ -5820,13 +5754,13 @@ async fn park_small_vm_pause_failure_preserves_controller() {
     let mut controller = Some(original_controller);
     let mut is_parked = false;
 
-    let (result, events) = capture_async_log_events(park_inner(
+    let result = park_inner(
         &mut is_parked,
         512,
         &mut controller,
         api.socket_path(),
         "small-fail",
-    ))
+    )
     .await;
 
     assert_idle_transition(result, SandboxIdleTransition::Park);
@@ -5839,5 +5773,4 @@ async fn park_small_vm_pause_failure_preserves_controller() {
         original_id,
         "controller must not be replaced or aborted"
     );
-    assert_balloon_settle_summary(&events, "skipped_zero_target", 0, "reuse");
 }


### PR DESCRIPTION
## Summary

- remove the completed `sandbox_fc::balloon_settle` local INFO contract and its observation-only
  outcome wrappers
- return the existing park outcomes directly while preserving polling, deadlines, reclaim
  classification, diagnostics, and balloon-before-pause ordering
- remove only canonical-summary assertions/capture plumbing and the obsolete named Axiom negative
  fixture

## Compatibility

- no API, protocol, queue, guest, schema, database, persisted-data, migration, or deployment-order
  changes
- old and new runner binaries can overlap because every terminal branch returns the same
  `SandboxParkOutcome`; only the retired local INFO record disappears
- retains adaptive polling, progress grace, target/tolerance/pressure handling, severe-retention
  rejection, detailed INFO/WARN diagnostics, pause behavior, and controller ownership

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p sandbox-fc -p runner --all-features --no-deps`
- `cargo test -p sandbox-fc --all-targets --all-features`
- `cargo test -p runner --bin runner --all-features`
- `git diff --check`
- repository-wide exact search confirms no retired target, measurement, message, enum, wrapper, or
  assertion-helper reference remains

Closes #25371
