### PR TITLE
docs: clarify frontend force-upgrade rollout

### DIFF
--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -23,11 +23,40 @@ surfaces are on different versions.
 
 Frontend deployments publish new browser assets, but users who already have an
 app page open keep running the JavaScript that page loaded until the page
-navigates, refreshes, or the app forces a reload.
+navigates or refreshes. The app does not poll for a newer build or automatically
+reload an open page.
+
+The current force-upgrade mechanism is driven by API responses. Standard app
+API clients send `X-Client-Type: App` and a build-time `X-Client-Version`. Before
+route matching, the API compares a parseable advertised version with the floor
+in `turbo/apps/api/src/lib/web-client-compatibility.json`. An older client
+receives `426 Upgrade Required` with `Cache-Control: no-store`. The shared
+contract client and fetch wrapper turn that response into a global UI state
+that displays a non-dismissible update dialog. The dialog's only action calls
+`window.location.reload()`. The app therefore forces the user to choose a
+refresh before continuing; it does not force the reload without user action,
+and an idle page does not discover the requirement until it makes a handled API
+request.
 
 The platform app also registers a service worker. Service-worker code is a
 browser-resident deployable surface, so changes to its behavior must account for
-old controlled clients during rollout.
+old controlled clients during rollout. The current service worker calls
+`skipWaiting()`, but it does not intercept fetches or reload clients on a
+controller change, so it is not the force-upgrade mechanism.
+
+Raise the minimum supported web-client version only after the corresponding app
+build is live. Production promotes API traffic before it promotes the app. If
+one release both introduces the replacement frontend and raises the API floor
+to that new version, the new API can start returning `426` while the frontend
+origin still serves the previous build. A user can then accept the prompt,
+reload the same unsupported build, and receive another `426`.
+
+Treat a floor increase as a later cleanup boundary, not as the initial rollout
+mechanism. First deploy an API that accepts both protocol versions and a
+frontend that starts using the new version. In a later release, after the
+replacement frontend is live, raise the floor and remove the old API contract.
+This ordering also keeps already-open pages working until the API can direct
+them to refresh into a build that is actually available.
 
 The backend must therefore tolerate requests from the previous frontend version
 after a backend deployment. When changing an API used by the frontend, keep the

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -28,15 +28,20 @@ reload an open page.
 
 The current force-upgrade mechanism is driven by API responses. Standard app
 API clients send `X-Client-Type: App` and a build-time `X-Client-Version`. Before
-route matching, the API compares a parseable advertised version with the floor
-in `turbo/apps/api/src/lib/web-client-compatibility.json`. An older client
-receives `426 Upgrade Required` with `Cache-Control: no-store`. The shared
-contract client and fetch wrapper turn that response into a global UI state
-that displays a non-dismissible update dialog. The dialog's only action calls
-`window.location.reload()`. The app therefore forces the user to choose a
-refresh before continuing; it does not force the reload without user action,
-and an idle page does not discover the requirement until it makes a handled API
-request.
+route handlers run, the API rejects an app request whose parseable advertised
+version is below the floor in
+`turbo/apps/api/src/lib/web-client-compatibility.json`. The general floor does
+not reject a missing or unparseable `X-Client-Version`. Endpoint-specific
+protocol gates can produce the same response; Zero Mail currently requires the
+exact `X-Zero-Mail-Client-Version` on `/api/zero/mail/*` requests.
+
+An incompatible request receives `426 Upgrade Required` with `Cache-Control:
+no-store`. The shared contract client and fetch wrapper turn that response into
+a global UI state that displays a non-dismissible update dialog. The dialog's
+only action calls `window.location.reload()`. The app therefore forces the user
+to choose a refresh before continuing; it does not force the reload without
+user action, and an idle page does not discover the requirement until it makes
+a handled API request.
 
 The platform app also registers a service worker. Service-worker code is a
 browser-resident deployable surface, so changes to its behavior must account for


### PR DESCRIPTION
## Summary

- document the API-driven frontend force-upgrade response flow
- clarify that the UI requires user-confirmed reload and that the service worker does not reload clients
- explain why the version floor must be raised in a later release after the replacement frontend is live

## Exclusions

- no runtime behavior or compatibility thresholds changed
- no API, schema, configuration, or persisted-data changes

## Validation

- `git diff --check`
- `cd turbo && pnpm exec prettier --check ../docs/deployment-compatibility.md`
- pre-commit `check-file-size`
- commit message lint
