### PR TITLE
test(python): cover codex credential tuple partitioning

### DIFF
--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_lifecycle.py
@@ -59,6 +59,14 @@ async def test_fresh_hit_is_partitioned_and_expiry_never_uses_conditions(real_fl
             catalog_cache.handle_error(flow)
 
 
+async def test_distinct_credential_tuples_with_equal_concatenation_are_partitioned(real_flow):
+    await install_catalog(catalog_flow(real_flow, auth_value="a", account="bc"))
+
+    distinct_tuple = catalog_flow(real_flow, auth_value="ab", account="c")
+    await prepare_miss(distinct_tuple)
+    catalog_cache.handle_error(distinct_tuple)
+
+
 async def test_transport_error_after_expiry_never_serves_old_entry(real_flow):
     with patch.object(catalog_cache.time, "monotonic", return_value=100.0) as monotonic:
         await install_catalog(catalog_flow(real_flow))


### PR DESCRIPTION
## Summary

- add a Codex model catalog cache lifecycle regression for two distinct credential tuples whose naive concatenations are identical
- verify the second tuple remains a cache miss instead of receiving the first tuple's cached catalog
- keep production cache behavior, helpers, dependencies, schemas, and persisted data unchanged

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4818 passed)
- temporary unsafe-concatenation mutation: the new focused test failed at the expected cache-miss assertion

Closes #25389
