### PR TITLE
test(api): split catalog attestation scenarios

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1481,12 +1481,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     ]);
   });
 
-  it("fully validates legacy catalog attestations before caching them", async () => {
+  it("fully validates a missing catalog authority before caching it", async () => {
     const api = createRunsApi(context);
     // Catalog rows are global by source, so isolate mutations from parallel test files.
     mockEnv(
       "R2_USER_STORAGES_BUCKET_NAME",
-      "test-run-lifecycle-legacy-catalog",
+      "test-run-lifecycle-missing-catalog-authority",
     );
 
     const missingCatalogVersion = `api-test-missing-validation-${randomUUID()}`;
@@ -1532,6 +1532,14 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "test-oauth-secret",
       "fixture-confidential-secret",
     ]);
+  });
+
+  it("fully validates a different catalog authority before caching it", async () => {
+    const api = createRunsApi(context);
+    mockEnv(
+      "R2_USER_STORAGES_BUCKET_NAME",
+      "test-run-lifecycle-different-catalog-authority",
+    );
 
     const differentCatalogVersion = `api-test-different-validation-${randomUUID()}`;
     await installApiTestConnectorCatalog({
@@ -1619,6 +1627,14 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "test-oauth-secret",
       "fixture-confidential-secret",
     ]);
+  });
+
+  it("deduplicates concurrent attested catalog loads", async () => {
+    const api = createRunsApi(context);
+    mockEnv(
+      "R2_USER_STORAGES_BUCKET_NAME",
+      "test-run-lifecycle-concurrent-attested-catalog",
+    );
 
     const concurrentCatalogVersion = `api-test-concurrent-attested-${randomUUID()}`;
     await installApiTestConnectorCatalog({


### PR DESCRIPTION
## Summary

- split the legacy catalog-attestation coverage into missing-authority, different-authority cache reuse, and concurrent-load deduplication scenarios
- give each scenario a distinct catalog source so global catalog state stays isolated
- preserve the existing assertions and default timeout without changing production behavior

## Failure evidence

- Triggering run: https://github.com/vm0-ai/vm0/actions/runs/31076546368
- Event and SHA: `push` to `main` at `8bfeec14caf1a9ea2a74ec782c81cd9c37d9fc57`
- Root-cause classification: flaky test boundary caused by accumulated asynchronous work, not a regression introduced by the triggering Rust-only commit
- First causal event: `test-api (8)` timed out in `fully validates legacy catalog attestations before caching them` at 5,027 ms: https://github.com/vm0-ai/vm0/actions/runs/31076546368/job/92536067257
- The same compound test took 1,046–1,380 ms in the four preceding successful main runs, while the failing file slowed from its usual 40–46 seconds to 86.85 seconds
- The test placed three independent async workflows under one 5-second budget. Under shard contention, their accumulated runtime intermittently crossed that shared budget. In local repetition, one split run took 5.01 seconds in aggregate while all three scenarios passed within their individual budgets

## Validation

- targeted three-scenario run passed 5/5 times
- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- repository type checks, including `api` with a 3,072 MiB heap
- Lefthook pre-commit and commit-msg gates

## Evidence limitation

A direct standalone run of all 146 tests in this file was not a useful local gate: 108 unrelated queue-claim scenarios returned 404 against the local PostgreSQL 18 fixture. The three changed scenarios remained isolated and passed repeatedly; the PR pipeline will run the standard API shard environment.