### PR TITLE
fix(runner): retain openai usage on incomplete sse trailers

### DIFF
--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -235,14 +235,23 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
         if "text/event-stream" in content_type:
             lifecycle_observer: _AnthropicLifecycleObserver | None = None
             anthropic_accounting_events: set[str] = set()
+            openai_recoverable_usage: dict = {}
             if uses_openai_responses_usage_protocol(flow):
                 usage_protocol = "openai_responses_sse"
                 log_parse_error = _make_model_sse_parse_error_logger(
                     flow,
                     usage_protocol=usage_protocol,
                 )
+
+                def record_openai_terminal_usage(terminal_usage: dict) -> None:
+                    usage.merge_openai_responses_usage_result(
+                        openai_recoverable_usage,
+                        terminal_usage,
+                    )
+
                 parser_fn, usage_dict = usage.create_openai_responses_sse_usage_extractor(
-                    on_parse_error=log_parse_error
+                    on_parse_error=log_parse_error,
+                    on_terminal_usage=record_openai_terminal_usage,
                 )
             else:
                 usage_protocol = _ANTHROPIC_MESSAGES_SSE_PROTOCOL
@@ -277,6 +286,15 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
                         anthropic_accounting.report_incomplete(
                             flow,
                             accounting_status,
+                        )
+                    elif (
+                        usage_protocol == "openai_responses_sse"
+                        and decode_error == body_decoding.INCOMPLETE_COMPRESSED_BODY
+                    ):
+                        usage_dict.clear()
+                        usage.merge_openai_responses_usage_result(
+                            usage_dict,
+                            openai_recoverable_usage,
                         )
                     else:
                         usage_dict.clear()

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -179,6 +179,14 @@ class _LiteralState:
     offset: int = 0
 
 
+@dataclass
+class _ScalarConsistency:
+    occurrences: int = 0
+    valid_occurrences: int = 0
+    first_value: object | None = None
+    conflicting: bool = False
+
+
 class JsonSelectiveExtractor:
     """Streaming, bounded JSON extractor for a fixed observation set.
 
@@ -204,6 +212,7 @@ class JsonSelectiveExtractor:
         array_count_paths: set[Path] | None = None,
         wildcard_array_count_paths: set[WildcardPath] | None = None,
         object_presence_paths: set[Path] | None = None,
+        scalar_consistency_paths: set[Path] | None = None,
         max_depth: int = _DEFAULT_MAX_DEPTH,
         max_key_bytes: int = 1024,
         max_number_bytes: int = 128,
@@ -220,6 +229,8 @@ class JsonSelectiveExtractor:
         wildcard keys and fails with ``"max wildcard keys exceeded"``.
         ``max_work_units`` optionally bounds total parser work across all
         chunks and fails with ``"work limit exceeded"``.
+        ``scalar_consistency_paths`` tracks whether every occurrence of a
+        selected scalar path has the expected kind and the same value.
         """
         self.scalar_fields = dict(scalar_fields) if scalar_fields is not None else {}
         self.array_count_paths = set(array_count_paths) if array_count_paths is not None else set()
@@ -228,6 +239,9 @@ class JsonSelectiveExtractor:
         )
         self.object_presence_paths = (
             set(object_presence_paths) if object_presence_paths is not None else set()
+        )
+        self._scalar_consistency_paths = (
+            set(scalar_consistency_paths) if scalar_consistency_paths is not None else set()
         )
         self.max_depth = max_depth
         self.max_key_bytes = max_key_bytes
@@ -239,6 +253,7 @@ class JsonSelectiveExtractor:
             self.array_count_paths,
             self.wildcard_array_count_paths,
             self.object_presence_paths,
+            self._scalar_consistency_paths,
             max_depth=self.max_depth,
             max_key_bytes=self.max_key_bytes,
             max_number_bytes=self.max_number_bytes,
@@ -265,6 +280,7 @@ class JsonSelectiveExtractor:
         self.array_counts: dict[Path, int] = {}
         self.wildcard_array_counts: dict[WildcardPath, dict[str, int]] = {}
         self.object_present: set[Path] = set()
+        self._scalar_consistency: dict[Path, _ScalarConsistency] = {}
 
         self._stack: list[_Frame] = []
         self._root_done = False
@@ -327,6 +343,22 @@ class JsonSelectiveExtractor:
         remains the authoritative complete-document result.
         """
         return self.values.get(path)
+
+    def selected_scalar_values_are_consistent(self, path: Path) -> bool:
+        """Return whether every occurrence is a valid, identical selected scalar.
+
+        An absent field is consistent. Callers must use this only after a
+        complete extraction result; it intentionally considers overwritten
+        duplicate object keys so identity checks can reject conflicting input.
+        """
+        if path not in self._scalar_consistency_paths:
+            raise ValueError("scalar consistency path was not configured")
+        consistency = self._scalar_consistency.get(path)
+        if consistency is None:
+            return True
+        return (
+            consistency.valid_occurrences == consistency.occurrences and not consistency.conflicting
+        )
 
     def finish(self) -> JsonExtractionResult:
         """Finalize the current document and return the extraction result.
@@ -462,6 +494,9 @@ class JsonSelectiveExtractor:
         return i + 1
 
     def _start_value(self, path: Path, chunk: bytes, i: int, *, from_array: bool = False) -> int:
+        if path in self._scalar_consistency_paths:
+            consistency = self._scalar_consistency.setdefault(path, _ScalarConsistency())
+            consistency.occurrences += 1
         b = chunk[i]
         if b == ord("{"):
             self._start_object(path, from_array=from_array)
@@ -782,6 +817,7 @@ class JsonSelectiveExtractor:
         if _contains_surrogate(value):
             self._value_complete()
             return
+        self._record_scalar_consistency(state.path, value)
         self.values[state.path] = value
         self._value_complete()
 
@@ -908,8 +944,19 @@ class JsonSelectiveExtractor:
             self._error = "invalid number"
             return
         if state.selected and isinstance(value, int) and not isinstance(value, bool):
+            self._record_scalar_consistency(state.path, value)
             self.values[state.path] = value
         self._value_complete()
+
+    def _record_scalar_consistency(self, path: Path, value: object) -> None:
+        consistency = self._scalar_consistency.get(path)
+        if consistency is None:
+            return
+        if consistency.valid_occurrences == 0:
+            consistency.first_value = value
+        elif consistency.first_value != value:
+            consistency.conflicting = True
+        consistency.valid_occurrences += 1
 
     def _consume_literal(self, chunk: bytes, i: int) -> int:
         state = self._literal
@@ -1002,6 +1049,7 @@ def _validate_extractor_config(
     array_count_paths: set[Path],
     wildcard_array_count_paths: set[WildcardPath],
     object_presence_paths: set[Path],
+    scalar_consistency_paths: set[Path],
     *,
     max_depth: int,
     max_key_bytes: int,
@@ -1026,6 +1074,9 @@ def _validate_extractor_config(
     _validate_exact_paths("scalar field paths", set(scalar_fields))
     _validate_exact_paths("array count paths", array_count_paths)
     _validate_exact_paths("object presence paths", object_presence_paths)
+    _validate_exact_paths("scalar consistency paths", scalar_consistency_paths)
+    if not scalar_consistency_paths <= set(scalar_fields):
+        raise ValueError("scalar consistency paths must reference scalar fields")
 
     for path in wildcard_array_count_paths:
         _validate_path("wildcard array count paths", path)

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -212,7 +212,15 @@ def _observed_responses_event_type(result: TopLevelStringFieldProbeResult) -> st
 
 
 def _classify_responses_event_type(body: bytes) -> _ResponsesEventTypeClassification:
-    return _classify_responses_event_type_result(_probe_responses_event_type(body))
+    event_type, _event_name = _inspect_responses_event_type(body)
+    return event_type
+
+
+def _inspect_responses_event_type(
+    body: bytes,
+) -> tuple[_ResponsesEventTypeClassification, str | None]:
+    result = _probe_responses_event_type(body)
+    return _classify_responses_event_type_result(result), _observed_responses_event_type(result)
 
 
 def _classify_responses_event_type_result(
@@ -450,6 +458,7 @@ def _store_sse_result_values(
     *,
     event_name: str | None,
     data_event_type: _ResponsesEventTypeClassification | None = None,
+    data_event_name: str | None = None,
 ) -> dict | None:
     data_type = values.get(("type",))
     if (
@@ -474,6 +483,8 @@ def _store_sse_result_values(
 
     if not _has_positive_usage_quantity(source):
         return None
+    if data_event_name is not None and data_type is not None and data_event_name != data_type:
+        return None
     if event_name is None:
         if not _is_known_terminal_usage_event(data_type):
             return None
@@ -483,6 +494,8 @@ def _store_sse_result_values(
     if not _is_known_terminal_usage_event(event_name):
         return None
     if data_event_type not in (None, _RESPONSES_EVENT_TERMINAL):
+        return None
+    if data_event_name is not None and data_event_name != event_name:
         return None
     if data_type is not None and data_type != event_name:
         return None
@@ -544,6 +557,7 @@ class _OpenAIResponsesSseUsageHandler:
         self._eventless_prefix: bytearray | None = None
         self._named_event_prefix: bytearray | None = None
         self._data_event_type: _ResponsesEventTypeClassification | None = None
+        self._data_event_name: str | None = None
         self._discard_eventless_event = False
         self._discard_named_event = False
         self._on_parse_error = on_parse_error
@@ -578,17 +592,26 @@ class _OpenAIResponsesSseUsageHandler:
         if self._eventless_prefix is not None:
             prefix = bytes(self._eventless_prefix)
             self._eventless_prefix = None
-            event_type = _classify_responses_event_type(prefix)
+            event_type, event_name_from_data = _inspect_responses_event_type(prefix)
             if event_type != _RESPONSES_EVENT_KNOWN_NON_USAGE:
-                self._start_full_extractor_from_prefix(prefix, event_type)
+                self._start_full_extractor_from_prefix(
+                    prefix,
+                    event_type,
+                    event_name_from_data,
+                )
         if self._named_event_prefix is not None and self._data_event_type is None:
             prefix = bytes(self._named_event_prefix)
             self._named_event_prefix = None
-            event_type = _classify_responses_event_type(prefix)
+            event_type, event_name_from_data = _inspect_responses_event_type(prefix)
             if event_type != _RESPONSES_EVENT_KNOWN_NON_USAGE:
-                self._start_full_extractor_from_prefix(prefix, event_type)
+                self._start_full_extractor_from_prefix(
+                    prefix,
+                    event_type,
+                    event_name_from_data,
+                )
         extractor = self._extractor
         data_event_type = self._data_event_type
+        data_event_name = self._data_event_name
         self._reset_event_state()
         if extractor is None:
             return
@@ -599,6 +622,7 @@ class _OpenAIResponsesSseUsageHandler:
                 self._usage,
                 event_name=event_name,
                 data_event_type=data_event_type,
+                data_event_name=data_event_name,
             )
             if terminal_usage is not None and self._on_terminal_usage is not None:
                 self._on_terminal_usage(terminal_usage)
@@ -624,6 +648,7 @@ class _OpenAIResponsesSseUsageHandler:
         self._eventless_prefix = None
         self._named_event_prefix = None
         self._data_event_type = None
+        self._data_event_name = None
         self._discard_eventless_event = False
         self._discard_named_event = False
 
@@ -648,8 +673,10 @@ class _OpenAIResponsesSseUsageHandler:
         self,
         prefix: bytes,
         event_type: _ResponsesEventTypeClassification,
+        event_name: str | None,
     ) -> None:
         self._data_event_type = _resolved_data_event_type(event_type)
+        self._data_event_name = event_name
         extractor = self._start_full_extractor(include_type=self._should_include_type_scalar())
         extractor.feed(prefix)
 
@@ -668,12 +695,12 @@ class _OpenAIResponsesSseUsageHandler:
 
         prefix_bytes = bytes(prefix)
         self._eventless_prefix = None
-        event_type = _classify_responses_event_type(prefix_bytes)
+        event_type, event_name = _inspect_responses_event_type(prefix_bytes)
         if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
             self._discard_eventless_event = True
             return
 
-        self._start_full_extractor_from_prefix(prefix_bytes, event_type)
+        self._start_full_extractor_from_prefix(prefix_bytes, event_type, event_name)
         if self._extractor is not None and captured_len < len(chunk):
             self._extractor.feed(chunk[captured_len:])
 
@@ -692,13 +719,13 @@ class _OpenAIResponsesSseUsageHandler:
 
         prefix_bytes = bytes(prefix)
         self._named_event_prefix = None
-        event_type = _classify_responses_event_type(prefix_bytes)
+        event_type, event_name = _inspect_responses_event_type(prefix_bytes)
         if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
             self._extractor = None
             self._discard_named_event = True
             return
 
-        self._start_full_extractor_from_prefix(prefix_bytes, event_type)
+        self._start_full_extractor_from_prefix(prefix_bytes, event_type, event_name)
         if self._extractor is not None and captured_len < len(chunk):
             self._extractor.feed(chunk[captured_len:])
 

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -110,6 +110,7 @@ _RESPONSES_KNOWN_NON_USAGE_EVENTS = frozenset(
     )
 )
 _SseUsageParseErrorCallback = Callable[[str, str], None]
+_SseTerminalUsageCallback = Callable[[dict], None]
 _ResponsesEventTypeClassification = Literal[
     "terminal",
     "known_non_usage",
@@ -449,14 +450,14 @@ def _store_sse_result_values(
     *,
     event_name: str | None,
     data_event_type: _ResponsesEventTypeClassification | None = None,
-) -> None:
+) -> dict | None:
     data_type = values.get(("type",))
     if (
         _is_known_non_usage_event(event_name)
         or data_event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE
         or (data_event_type is None and _is_known_non_usage_event(data_type))
     ):
-        return
+        return None
     event_identity = event_name if event_name is not None else data_type
     is_known_terminal_usage_event = (
         _is_known_terminal_usage_event(event_identity)
@@ -468,12 +469,29 @@ def _store_sse_result_values(
     source: dict = {}
     _store_response_values(values, source, prefix)
     if not is_known_terminal_usage_event and not _has_usage_quantity(source):
-        return
+        return None
     merge_openai_responses_usage_result(target, source)
+
+    if not _has_positive_usage_quantity(source):
+        return None
+    if event_name is None:
+        if not _is_known_terminal_usage_event(data_type):
+            return None
+        if data_event_type not in (None, _RESPONSES_EVENT_TERMINAL):
+            return None
+        return source
+    if not _is_known_terminal_usage_event(event_name):
+        return None
+    if data_event_type not in (None, _RESPONSES_EVENT_TERMINAL):
+        return None
+    if data_type is not None and data_type != event_name:
+        return None
+    return source
 
 
 def create_openai_responses_sse_usage_extractor(
     on_parse_error: _SseUsageParseErrorCallback | None = None,
+    on_terminal_usage: _SseTerminalUsageCallback | None = None,
 ) -> tuple[SseUsageScanner, dict]:
     """Create an incremental usage parser for content-decoded Responses SSE bytes.
 
@@ -491,11 +509,21 @@ def create_openai_responses_sse_usage_extractor(
     malformed non-terminal or unknown events remain silent. HTTP content
     decoding and its errors are outside this parser; callers feed decoded output
     and handle decoder completion separately.
+
+    ``on_terminal_usage(usage)`` is called after a complete, recognized terminal
+    event with compatible SSE/JSON identity contributes positive usage. The
+    callback receives that event's normalized usage snapshot, not the live
+    accumulator. This lets transport finalizers retain only terminal-proven
+    values without changing forward-compatible extraction from unknown events.
     """
 
     usage: dict = {}
     parser = SseUsageScanner(
-        _OpenAIResponsesSseUsageHandler(usage, on_parse_error=on_parse_error),
+        _OpenAIResponsesSseUsageHandler(
+            usage,
+            on_parse_error=on_parse_error,
+            on_terminal_usage=on_terminal_usage,
+        ),
         # Some compatible streams omit SSE event names and carry the terminal
         # response type in the JSON payload.
         capture_data_without_event=True,
@@ -509,6 +537,7 @@ class _OpenAIResponsesSseUsageHandler:
         usage: dict,
         *,
         on_parse_error: _SseUsageParseErrorCallback | None = None,
+        on_terminal_usage: _SseTerminalUsageCallback | None = None,
     ) -> None:
         self._usage = usage
         self._extractor: JsonSelectiveExtractor | None = None
@@ -518,6 +547,7 @@ class _OpenAIResponsesSseUsageHandler:
         self._discard_eventless_event = False
         self._discard_named_event = False
         self._on_parse_error = on_parse_error
+        self._on_terminal_usage = on_terminal_usage
 
     def should_capture_event(self, event_name: str | None) -> bool:
         return event_name is None or not _is_known_non_usage_event(event_name)
@@ -564,12 +594,14 @@ class _OpenAIResponsesSseUsageHandler:
             return
         result = extractor.finish()
         if result.complete:
-            _store_sse_result_values(
+            terminal_usage = _store_sse_result_values(
                 result.values,
                 self._usage,
                 event_name=event_name,
                 data_event_type=data_event_type,
             )
+            if terminal_usage is not None and self._on_terminal_usage is not None:
+                self._on_terminal_usage(terminal_usage)
             return
         event_type = event_name
         if event_type is None:
@@ -606,7 +638,11 @@ class _OpenAIResponsesSseUsageHandler:
         return self._extractor
 
     def _should_include_type_scalar(self) -> bool:
-        return self._data_event_type is None or self._on_parse_error is not None
+        return (
+            self._data_event_type is None
+            or self._on_parse_error is not None
+            or self._on_terminal_usage is not None
+        )
 
     def _start_full_extractor_from_prefix(
         self,

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -212,15 +212,8 @@ def _observed_responses_event_type(result: TopLevelStringFieldProbeResult) -> st
 
 
 def _classify_responses_event_type(body: bytes) -> _ResponsesEventTypeClassification:
-    event_type, _event_name = _inspect_responses_event_type(body)
-    return event_type
-
-
-def _inspect_responses_event_type(
-    body: bytes,
-) -> tuple[_ResponsesEventTypeClassification, str | None]:
     result = _probe_responses_event_type(body)
-    return _classify_responses_event_type_result(result), _observed_responses_event_type(result)
+    return _classify_responses_event_type_result(result)
 
 
 def _classify_responses_event_type_result(
@@ -458,7 +451,7 @@ def _store_sse_result_values(
     *,
     event_name: str | None,
     data_event_type: _ResponsesEventTypeClassification | None = None,
-    data_event_name: str | None = None,
+    data_event_identity_consistent: bool = True,
 ) -> dict | None:
     data_type = values.get(("type",))
     if (
@@ -483,7 +476,7 @@ def _store_sse_result_values(
 
     if not _has_positive_usage_quantity(source):
         return None
-    if data_event_name is not None and data_type is not None and data_event_name != data_type:
+    if not data_event_identity_consistent:
         return None
     if event_name is None:
         if not _is_known_terminal_usage_event(data_type):
@@ -494,8 +487,6 @@ def _store_sse_result_values(
     if not _is_known_terminal_usage_event(event_name):
         return None
     if data_event_type not in (None, _RESPONSES_EVENT_TERMINAL):
-        return None
-    if data_event_name is not None and data_event_name != event_name:
         return None
     if data_type is not None and data_type != event_name:
         return None
@@ -557,7 +548,6 @@ class _OpenAIResponsesSseUsageHandler:
         self._eventless_prefix: bytearray | None = None
         self._named_event_prefix: bytearray | None = None
         self._data_event_type: _ResponsesEventTypeClassification | None = None
-        self._data_event_name: str | None = None
         self._discard_eventless_event = False
         self._discard_named_event = False
         self._on_parse_error = on_parse_error
@@ -592,26 +582,17 @@ class _OpenAIResponsesSseUsageHandler:
         if self._eventless_prefix is not None:
             prefix = bytes(self._eventless_prefix)
             self._eventless_prefix = None
-            event_type, event_name_from_data = _inspect_responses_event_type(prefix)
+            event_type = _classify_responses_event_type(prefix)
             if event_type != _RESPONSES_EVENT_KNOWN_NON_USAGE:
-                self._start_full_extractor_from_prefix(
-                    prefix,
-                    event_type,
-                    event_name_from_data,
-                )
+                self._start_full_extractor_from_prefix(prefix, event_type)
         if self._named_event_prefix is not None and self._data_event_type is None:
             prefix = bytes(self._named_event_prefix)
             self._named_event_prefix = None
-            event_type, event_name_from_data = _inspect_responses_event_type(prefix)
+            event_type = _classify_responses_event_type(prefix)
             if event_type != _RESPONSES_EVENT_KNOWN_NON_USAGE:
-                self._start_full_extractor_from_prefix(
-                    prefix,
-                    event_type,
-                    event_name_from_data,
-                )
+                self._start_full_extractor_from_prefix(prefix, event_type)
         extractor = self._extractor
         data_event_type = self._data_event_type
-        data_event_name = self._data_event_name
         self._reset_event_state()
         if extractor is None:
             return
@@ -622,7 +603,10 @@ class _OpenAIResponsesSseUsageHandler:
                 self._usage,
                 event_name=event_name,
                 data_event_type=data_event_type,
-                data_event_name=data_event_name,
+                data_event_identity_consistent=(
+                    self._on_terminal_usage is None
+                    or extractor.selected_scalar_values_are_consistent(("type",))
+                ),
             )
             if terminal_usage is not None and self._on_terminal_usage is not None:
                 self._on_terminal_usage(terminal_usage)
@@ -648,7 +632,6 @@ class _OpenAIResponsesSseUsageHandler:
         self._eventless_prefix = None
         self._named_event_prefix = None
         self._data_event_type = None
-        self._data_event_name = None
         self._discard_eventless_event = False
         self._discard_named_event = False
 
@@ -658,6 +641,7 @@ class _OpenAIResponsesSseUsageHandler:
         )
         self._extractor = JsonSelectiveExtractor(
             scalar_fields=scalar_fields,
+            scalar_consistency_paths={("type",)} if self._on_terminal_usage is not None else None,
             max_work_units=_RESPONSES_MAX_WORK_UNITS,
         )
         return self._extractor
@@ -673,10 +657,8 @@ class _OpenAIResponsesSseUsageHandler:
         self,
         prefix: bytes,
         event_type: _ResponsesEventTypeClassification,
-        event_name: str | None,
     ) -> None:
         self._data_event_type = _resolved_data_event_type(event_type)
-        self._data_event_name = event_name
         extractor = self._start_full_extractor(include_type=self._should_include_type_scalar())
         extractor.feed(prefix)
 
@@ -695,12 +677,12 @@ class _OpenAIResponsesSseUsageHandler:
 
         prefix_bytes = bytes(prefix)
         self._eventless_prefix = None
-        event_type, event_name = _inspect_responses_event_type(prefix_bytes)
+        event_type = _classify_responses_event_type(prefix_bytes)
         if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
             self._discard_eventless_event = True
             return
 
-        self._start_full_extractor_from_prefix(prefix_bytes, event_type, event_name)
+        self._start_full_extractor_from_prefix(prefix_bytes, event_type)
         if self._extractor is not None and captured_len < len(chunk):
             self._extractor.feed(chunk[captured_len:])
 
@@ -719,13 +701,13 @@ class _OpenAIResponsesSseUsageHandler:
 
         prefix_bytes = bytes(prefix)
         self._named_event_prefix = None
-        event_type, event_name = _inspect_responses_event_type(prefix_bytes)
+        event_type = _classify_responses_event_type(prefix_bytes)
         if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
             self._extractor = None
             self._discard_named_event = True
             return
 
-        self._start_full_extractor_from_prefix(prefix_bytes, event_type, event_name)
+        self._start_full_extractor_from_prefix(prefix_bytes, event_type)
         if self._extractor is not None and captured_len < len(chunk):
             self._extractor.feed(chunk[captured_len:])
 

--- a/crates/runner/mitm-addon/tests/test_json_selective_config.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_config.py
@@ -38,6 +38,20 @@ def test_rejects_invalid_scalar_field_config_value():
         JsonSelectiveExtractor(scalar_fields=json.loads('{"model": "string"}'))
 
 
+def test_rejects_consistency_path_without_scalar_field():
+    with pytest.raises(ValueError, match="must reference scalar fields"):
+        JsonSelectiveExtractor(scalar_consistency_paths={("type",)})
+
+
+def test_consistency_query_requires_configured_path():
+    extractor = JsonSelectiveExtractor()
+    extractor.feed(b"{}")
+    assert extractor.finish().complete is True
+
+    with pytest.raises(ValueError, match="was not configured"):
+        extractor.selected_scalar_values_are_consistent(("type",))
+
+
 @pytest.mark.parametrize(
     ("bound", "value"),
     [

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -37,6 +37,7 @@ from tests.webhook_test_helpers import (
     install_runner_usage_flush_request,
     request_runner_usage_flush,
 )
+from usage import openai_responses
 
 _TELEMETRY_PATH = "/api/webhooks/agent/telemetry"
 
@@ -459,15 +460,38 @@ class TestModelProviderSseUsage:
             event["category"]: event["quantity"] for event in webhook.usage_events()
         } == expected
 
+    @pytest.mark.parametrize(
+        "type_fields",
+        [
+            pytest.param(b'"type":"response.failed",', id="sse-json-conflict"),
+            pytest.param(
+                b'"type":"response.completed","type":"response.failed",'
+                b'"type":"response.completed",',
+                id="middle-conflicts-with-matching-ends",
+            ),
+            pytest.param(
+                b'"padding":"'
+                + b"x" * (openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES + 1)
+                + b'","type":"response.failed","type":"response.completed",',
+                id="conflict-after-prefilter-bound",
+            ),
+            pytest.param(
+                b'"padding":"'
+                + b"x" * (openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES + 1)
+                + b'","type":42,',
+                id="invalid-type-after-prefilter-bound",
+            ),
+        ],
+    )
     def test_full_pipeline_incomplete_compressed_openai_sse_rejects_conflicting_identity(
-        self, tmp_path, real_flow
+        self, tmp_path, real_flow, type_fields
     ):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         assert flow.response is not None
         flow.response.headers["content-encoding"] = "gzip"
         plaintext = (
             b"event: response.completed\n"
-            b'data: {"type":"response.failed","response":{"model":"gpt-5.5",'
+            b"data: {" + type_fields + b'"response":{"model":"gpt-5.5",'
             b'"usage":{"input_tokens":11,"output_tokens":5}}}\n\n'
         )
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -352,33 +352,222 @@ class TestModelProviderSseUsage:
         }
         assert {event["provider"] for event in events} == {"gpt-5.5"}
 
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
     @pytest.mark.parametrize("hook_name", ["response", "error"])
-    def test_full_pipeline_compressed_openai_sse_truncated_trailer_does_not_report_usage(
-        self, tmp_path, real_flow, hook_name
+    def test_full_pipeline_incomplete_compressed_openai_sse_recovers_terminal_usage(
+        self, tmp_path, real_flow, encoding, hook_name
     ):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         assert flow.response is not None
-        flow.response.headers["content-encoding"] = "gzip"
+        flow.response.headers["content-encoding"] = encoding
         plaintext = (
             b"event: response.completed\n"
             b'data: {"response":{"id":"resp_sse_1","model":"gpt-5.5",'
-            b'"usage":{"input_tokens":50,"output_tokens":20}}}\n\n'
+            b'"usage":{"input_tokens":100,"output_tokens":40,'
+            b'"input_tokens_details":{"cached_tokens":20,'
+            b'"cache_write_tokens":30}}}}\n\n'
         )
 
         mitm_addon.responseheaders(flow)
-        response_stream(flow)(gzip.compress(plaintext)[:-1])
+        response_stream(flow)(_compress_zlib_sse(plaintext, encoding)[:-1])
         if hook_name == "error":
             flow.error = Error("connection reset by peer")
             webhook = self._run_error(flow)
         else:
             webhook = self._run_response(flow)
 
+        expected = {
+            "tokens.input": 50,
+            "tokens.output": 40,
+            "tokens.cache_read": 20,
+            "tokens.cache_creation": 30,
+        }
+        assert {
+            event["category"]: event["quantity"] for event in webhook.usage_events()
+        } == expected
+        assert compact_observation_quantities(webhook.model_usage_observation_events()) == expected
+        _assert_single_model_sse_parse_warning(
+            flow,
+            usage_protocol="openai_responses_sse",
+            event="compressed_body",
+            error=body_decoding.INCOMPLETE_COMPRESSED_BODY,
+        )
+
+    @pytest.mark.parametrize(
+        ("event_prefix", "event_type"),
+        [
+            pytest.param(b"event: response.done\n", "response.done", id="done"),
+            pytest.param(
+                b"event: response.incomplete\n",
+                "response.incomplete",
+                id="incomplete",
+            ),
+            pytest.param(b"event: response.failed\n", "response.failed", id="failed"),
+            pytest.param(b"", "response.completed", id="eventless"),
+        ],
+    )
+    def test_full_pipeline_incomplete_compressed_openai_sse_recovers_terminal_vocabulary(
+        self, tmp_path, real_flow, event_prefix, event_type
+    ):
+        flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        assert flow.response is not None
+        flow.response.headers["content-encoding"] = "gzip"
+        plaintext = (
+            event_prefix
+            + b'data: {"type":"'
+            + event_type.encode()
+            + b'","response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":11,"output_tokens":5}}}\n\n'
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(gzip.compress(plaintext)[:-1])
+        webhook = self._run_response(flow)
+
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+            "tokens.input": 11,
+            "tokens.output": 5,
+        }
+
+    @pytest.mark.parametrize("truncate_trailer", [False, True], ids=["complete", "incomplete"])
+    def test_full_pipeline_openai_recovery_excludes_unknown_event_usage(
+        self, tmp_path, real_flow, truncate_trailer
+    ):
+        flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        assert flow.response is not None
+        flow.response.headers["content-encoding"] = "gzip"
+        plaintext = (
+            b"event: response.future_usage\n"
+            b'data: {"type":"response.future_usage","response":{"model":"gpt-5.5",'
+            b'"usage":{"output_tokens":99}}}\n\n'
+            b"event: response.completed\n"
+            b'data: {"type":"response.completed","response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":10}}}\n\n'
+        )
+        encoded = gzip.compress(plaintext)
+        if truncate_trailer:
+            encoded = encoded[:-1]
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(encoded)
+        webhook = self._run_response(flow)
+
+        expected = {"tokens.input": 10}
+        if not truncate_trailer:
+            expected["tokens.output"] = 99
+        assert {
+            event["category"]: event["quantity"] for event in webhook.usage_events()
+        } == expected
+
+    def test_full_pipeline_incomplete_compressed_openai_sse_rejects_conflicting_identity(
+        self, tmp_path, real_flow
+    ):
+        flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        assert flow.response is not None
+        flow.response.headers["content-encoding"] = "gzip"
+        plaintext = (
+            b"event: response.completed\n"
+            b'data: {"type":"response.failed","response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":11,"output_tokens":5}}}\n\n'
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(gzip.compress(plaintext)[:-1])
+        webhook = self._run_response(flow)
+
+        assert webhook.request_count == 0
+
+    def test_full_pipeline_incomplete_compressed_openai_sse_does_not_flush_partial_event(
+        self, tmp_path, real_flow
+    ):
+        flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        assert flow.response is not None
+        flow.response.headers["content-encoding"] = "gzip"
+        plaintext = (
+            b"event: response.completed\n"
+            b'data: {"type":"response.completed","response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":11,"output_tokens":5}'
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(gzip.compress(plaintext)[:-1])
+        webhook = self._run_response(flow)
+
+        assert webhook.request_count == 0
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_full_pipeline_invalid_compressed_openai_sse_remains_fail_closed(
+        self, tmp_path, real_flow, encoding
+    ):
+        flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        assert flow.response is not None
+        flow.response.headers["content-encoding"] = encoding
+        plaintext = (
+            b"event: response.completed\n"
+            b'data: {"type":"response.completed","response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":11,"output_tokens":5}}}\n\n'
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(_compress_zlib_sse(plaintext, encoding) + b"not-compressed")
+        webhook = self._run_response(flow)
+
         assert webhook.request_count == 0
         _assert_single_model_sse_parse_warning(
             flow,
             usage_protocol="openai_responses_sse",
             event="compressed_body",
+            error=body_decoding.INVALID_COMPRESSED_BODY,
         )
+
+    def test_full_pipeline_decoded_limit_openai_sse_remains_fail_closed(self, tmp_path, real_flow):
+        flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        assert flow.response is not None
+        flow.response.headers["content-encoding"] = "gzip"
+        plaintext = (
+            b"event: response.completed\n"
+            b'data: {"type":"response.completed","response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":11,"output_tokens":5}}}\n\n'
+            b"event: response.output_text.delta\n"
+            b"data: " + b"x" * (5 * 1024 * 1024 + 1)
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(gzip.compress(plaintext))
+        webhook = self._run_response(flow)
+
+        assert webhook.request_count == 0
+        _assert_single_model_sse_parse_warning(
+            flow,
+            usage_protocol="openai_responses_sse",
+            event="compressed_body",
+            error=body_decoding.DECODED_BODY_LIMIT_EXCEEDED,
+        )
+
+    def test_full_pipeline_response_then_error_emits_recovered_openai_usage_once(
+        self, tmp_path, real_flow
+    ):
+        flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        assert flow.response is not None
+        flow.response.headers["content-encoding"] = "gzip"
+        plaintext = (
+            b"event: response.completed\n"
+            b'data: {"response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":11,"output_tokens":5}}}\n\n'
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(gzip.compress(plaintext)[:-1])
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.response(flow)
+            flow.error = Error("connection reset after response")
+            mitm_addon.error(flow)
+            usage.flush_usage_events(trigger="test")
+
+        assert [(event["category"], event["quantity"]) for event in webhook.usage_events()] == [
+            ("tokens.input", 11),
+            ("tokens.output", 5),
+        ]
 
     @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
     @pytest.mark.parametrize("hook_name", ["response", "error"])

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -180,14 +180,41 @@ class TestOpenAIResponsesSseUsageExtractor:
             pytest.param(b"", id="eventless"),
         ],
     )
-    def test_conflicting_duplicate_terminal_types_do_not_report_snapshot(self, event_prefix):
+    @pytest.mark.parametrize(
+        "type_fields",
+        [
+            pytest.param(
+                b'"type":"response.failed","type":"response.completed",',
+                id="first-conflicts-with-last",
+            ),
+            pytest.param(
+                b'"type":"response.completed","type":"response.failed",'
+                b'"type":"response.completed",',
+                id="middle-conflicts-with-matching-ends",
+            ),
+            pytest.param(
+                b'"padding":"'
+                + b"x" * (openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES + 1)
+                + b'","type":"response.failed","type":"response.completed",',
+                id="conflict-after-prefilter-bound",
+            ),
+            pytest.param(
+                b'"padding":"'
+                + b"x" * (openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES + 1)
+                + b'","type":42,',
+                id="invalid-type-after-prefilter-bound",
+            ),
+        ],
+    )
+    def test_conflicting_duplicate_terminal_types_do_not_report_snapshot(
+        self, event_prefix, type_fields
+    ):
         terminal_usage: list[dict] = []
         parse, usage = create_openai_responses_sse_usage_extractor(
             on_terminal_usage=terminal_usage.append
         )
         parse(
-            event_prefix + b'data: {"type":"response.failed","type":"response.completed",'
-            b'"response":{"model":"gpt-5.5",'
+            event_prefix + b"data: {" + type_fields + b'"response":{"model":"gpt-5.5",'
             b'"usage":{"input_tokens":9,"output_tokens":4}}}\n\n'
         )
 
@@ -596,17 +623,17 @@ class TestOpenAIResponsesSseUsageExtractor:
         )
         assert len(payload) < openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES
 
-        real_inspect = openai_responses._inspect_responses_event_type
+        real_classify = openai_responses._classify_responses_event_type
         classified_prefixes: list[bytes] = []
 
-        def track_inspection(body: bytes):
+        def track_classification(body: bytes):
             classified_prefixes.append(body)
-            return real_inspect(body)
+            return real_classify(body)
 
         monkeypatch.setattr(
             openai_responses,
-            "_inspect_responses_event_type",
-            track_inspection,
+            "_classify_responses_event_type",
+            track_classification,
         )
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(event_prefix + b"data: ")

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -174,6 +174,31 @@ class TestOpenAIResponsesSseUsageExtractor:
         assert terminal_usage == []
 
     @pytest.mark.parametrize(
+        "event_prefix",
+        [
+            pytest.param(b"event: response.completed\n", id="named"),
+            pytest.param(b"", id="eventless"),
+        ],
+    )
+    def test_conflicting_duplicate_terminal_types_do_not_report_snapshot(self, event_prefix):
+        terminal_usage: list[dict] = []
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_terminal_usage=terminal_usage.append
+        )
+        parse(
+            event_prefix + b'data: {"type":"response.failed","type":"response.completed",'
+            b'"response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":9,"output_tokens":4}}}\n\n'
+        )
+
+        assert usage == {
+            "model": "gpt-5.5",
+            "tokens.input": 9,
+            "tokens.output": 4,
+        }
+        assert terminal_usage == []
+
+    @pytest.mark.parametrize(
         "usage_json",
         [
             pytest.param(b'"usage":{"input_tokens":0,"output_tokens":0}', id="zero-only"),
@@ -571,17 +596,17 @@ class TestOpenAIResponsesSseUsageExtractor:
         )
         assert len(payload) < openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES
 
-        real_classify = openai_responses._classify_responses_event_type
+        real_inspect = openai_responses._inspect_responses_event_type
         classified_prefixes: list[bytes] = []
 
-        def track_classification(body: bytes):
+        def track_inspection(body: bytes):
             classified_prefixes.append(body)
-            return real_classify(body)
+            return real_inspect(body)
 
         monkeypatch.setattr(
             openai_responses,
-            "_classify_responses_event_type",
-            track_classification,
+            "_inspect_responses_event_type",
+            track_inspection,
         )
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(event_prefix + b"data: ")

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -74,6 +74,162 @@ class TestOpenAIResponsesSseUsageExtractor:
             "tokens.output": 0,
         }
 
+    @pytest.mark.parametrize(
+        ("event_type", "event_prefix"),
+        [
+            pytest.param(
+                "response.completed",
+                b"event: response.completed\n",
+                id="completed",
+            ),
+            pytest.param("response.done", b"event: response.done\n", id="done"),
+            pytest.param(
+                "response.incomplete",
+                b"event: response.incomplete\n",
+                id="incomplete",
+            ),
+            pytest.param("response.failed", b"event: response.failed\n", id="failed"),
+            pytest.param("response.completed", b"", id="eventless"),
+        ],
+    )
+    def test_reports_normalized_terminal_usage_snapshot(self, event_type, event_prefix):
+        terminal_usage: list[dict] = []
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_terminal_usage=terminal_usage.append
+        )
+        parse(
+            event_prefix
+            + b'data: {"type":"'
+            + event_type.encode()
+            + b'","response":{"id":"resp_terminal","model":"gpt-5.6-sol",'
+            b'"usage":{"input_tokens":100,"output_tokens":40,'
+            b'"input_tokens_details":{"cached_tokens":25,'
+            b'"cache_write_tokens":30}}}}\n\n'
+        )
+
+        expected = {
+            "message_id": "resp_terminal",
+            "model": "gpt-5.6-sol",
+            "tokens.input": 45,
+            "tokens.output": 40,
+            "tokens.cache_read": 25,
+            "tokens.cache_creation": 30,
+        }
+        assert usage == expected
+        assert terminal_usage == [expected]
+
+    def test_reports_named_terminal_snapshot_without_json_type(self):
+        terminal_usage: list[dict] = []
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_terminal_usage=terminal_usage.append
+        )
+        parse(
+            b"event: response.completed\n"
+            b'data: {"response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":12,"output_tokens":7}}}\n\n'
+        )
+
+        assert usage == {
+            "model": "gpt-5.5",
+            "tokens.input": 12,
+            "tokens.output": 7,
+        }
+        assert terminal_usage == [usage]
+
+    @pytest.mark.parametrize(
+        ("event_name", "data_type"),
+        [
+            pytest.param(
+                "response.completed",
+                "response.failed",
+                id="conflicting-terminal",
+            ),
+            pytest.param(
+                "response.future_usage",
+                "response.future_usage",
+                id="unknown",
+            ),
+        ],
+    )
+    def test_compatibility_usage_does_not_become_terminal_snapshot(self, event_name, data_type):
+        terminal_usage: list[dict] = []
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_terminal_usage=terminal_usage.append
+        )
+        parse(
+            b"event: "
+            + event_name.encode()
+            + b"\n"
+            + b'data: {"type":"'
+            + data_type.encode()
+            + b'","response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":9,"output_tokens":4}}}\n\n'
+        )
+
+        assert usage == {
+            "model": "gpt-5.5",
+            "tokens.input": 9,
+            "tokens.output": 4,
+        }
+        assert terminal_usage == []
+
+    @pytest.mark.parametrize(
+        "usage_json",
+        [
+            pytest.param(b'"usage":{"input_tokens":0,"output_tokens":0}', id="zero-only"),
+            pytest.param(b'"id":"resp_metadata"', id="metadata-only"),
+        ],
+    )
+    def test_terminal_event_without_positive_usage_does_not_report_snapshot(self, usage_json):
+        terminal_usage: list[dict] = []
+        parse, _usage = create_openai_responses_sse_usage_extractor(
+            on_terminal_usage=terminal_usage.append
+        )
+        parse(
+            b"event: response.completed\n"
+            b'data: {"type":"response.completed","response":{"model":"gpt-5.5",'
+            + usage_json
+            + b"}}\n\n"
+        )
+
+        assert terminal_usage == []
+
+    def test_incomplete_terminal_event_does_not_report_snapshot(self):
+        terminal_usage: list[dict] = []
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_terminal_usage=terminal_usage.append
+        )
+        parse(
+            b"event: response.completed\n"
+            b'data: {"type":"response.completed","response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":9,"output_tokens":4}'
+        )
+        parse.finish()
+
+        assert usage == {}
+        assert terminal_usage == []
+
+    def test_terminal_snapshot_excludes_earlier_unknown_usage(self):
+        terminal_usage: list[dict] = []
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_terminal_usage=terminal_usage.append
+        )
+        parse(
+            b"event: response.future_usage\n"
+            b'data: {"type":"response.future_usage","response":{"model":"gpt-5.5",'
+            b'"usage":{"output_tokens":99}}}\n\n'
+            b"event: response.completed\n"
+            b'data: {"type":"response.completed","response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":10}}}\n\n'
+        )
+
+        assert usage == {
+            "model": "gpt-5.5",
+            "tokens.input": 10,
+            "tokens.output": 99,
+        }
+        assert terminal_usage == [{"model": "gpt-5.5", "tokens.input": 10}]
+
     def test_work_limit_discards_partial_event_and_recovers(self):
         parse_errors: list[tuple[str, str]] = []
         parse, usage = create_openai_responses_sse_usage_extractor(


### PR DESCRIPTION
## Summary

- track normalized usage snapshots contributed only by complete, identity-consistent terminal OpenAI Responses SSE events
- recover those strict snapshots when gzip or zlib-wrapped-deflate finalization reports only an incomplete compressed body
- keep unknown-event compatibility on successful streams while leaving conflicting, partial, invalid-compression, and decode-limit paths fail-closed
- require every observed JSON `type` occurrence to be valid and identical before it can establish recoverable terminal identity, including values beyond the prefix probe bound
- cover response/error finalization, terminal event variants, all token categories, provenance isolation, and at-most-once reporting

## Scope exclusions

- no recovery for streams interrupted before a complete terminal Responses event
- no change to direct WebSocket, non-streaming JSON, Anthropic, connector, or provider request behavior
- no API, schema, migration, persisted state, feature switch, telemetry surface, or cleanup work

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_json_selective_config.py tests/test_openai_responses_sse.py tests/test_model_provider_sse_usage.py` (160 passed)
- `uv run --no-sync python -m pytest tests/` (4,856 passed)
- pre-commit Ruff, formatting, file-size, and commit-message checks

Closes #25324
