### PR TITLE
fix(mitm-addon): preserve usage retry fifo

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer/models.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/models.py
@@ -106,6 +106,7 @@ class _FlushBatch:
 @dataclass(frozen=True)
 class _PendingBatch:
     batch: _FlushBatch
+    flush_batch_index: int
     retained_retry_count: int = 0
 
 

--- a/crates/runner/mitm-addon/src/usage/buffer/state.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/state.py
@@ -468,22 +468,20 @@ class _UsageBufferState:
         if retained_batches:
             retained_flush = _pending_flush_from_pending_batches(flush_sequence, retained_batches)
             retained_flush.retry_after_flush_generation = flush_generation
-            self._insert_pending_flush(retained_flush)
+            retained_batch_index = retained_flush.batches[0].flush_batch_index
+            for index, pending_flush in enumerate(self._pending_flushes):
+                if (
+                    pending_flush.flush_sequence == retained_flush.flush_sequence
+                    and pending_flush.batches[0].flush_batch_index > retained_batch_index
+                ):
+                    self._pending_flushes.insert(index, retained_flush)
+                    break
+            else:
+                self._pending_flushes.append(retained_flush)
         return _RetainBatchesResult(
             retained_batches=retained_batches,
             dropped_batches=dropped_batches,
         )
-
-    def _insert_pending_flush(self, retained_flush: _PendingFlush) -> None:
-        retained_batch_index = retained_flush.batches[0].flush_batch_index
-        for index, pending_flush in enumerate(self._pending_flushes):
-            if (
-                pending_flush.flush_sequence == retained_flush.flush_sequence
-                and pending_flush.batches[0].flush_batch_index > retained_batch_index
-            ):
-                self._pending_flushes.insert(index, retained_flush)
-                return
-        self._pending_flushes.append(retained_flush)
 
     def buffered_source_event_count(self) -> int:
         return (

--- a/crates/runner/mitm-addon/src/usage/buffer/state.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/state.py
@@ -461,17 +461,29 @@ class _UsageBufferState:
                 retained_batches.append(
                     _PendingBatch(
                         batch=pending_batch.batch,
+                        flush_batch_index=pending_batch.flush_batch_index,
                         retained_retry_count=pending_batch.retained_retry_count + 1,
                     )
                 )
         if retained_batches:
             retained_flush = _pending_flush_from_pending_batches(flush_sequence, retained_batches)
             retained_flush.retry_after_flush_generation = flush_generation
-            self._pending_flushes.append(retained_flush)
+            self._insert_pending_flush(retained_flush)
         return _RetainBatchesResult(
             retained_batches=retained_batches,
             dropped_batches=dropped_batches,
         )
+
+    def _insert_pending_flush(self, retained_flush: _PendingFlush) -> None:
+        retained_batch_index = retained_flush.batches[0].flush_batch_index
+        for index, pending_flush in enumerate(self._pending_flushes):
+            if (
+                pending_flush.flush_sequence == retained_flush.flush_sequence
+                and pending_flush.batches[0].flush_batch_index > retained_batch_index
+            ):
+                self._pending_flushes.insert(index, retained_flush)
+                return
+        self._pending_flushes.append(retained_flush)
 
     def buffered_source_event_count(self) -> int:
         return (

--- a/crates/runner/mitm-addon/src/usage/buffer/summaries.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/summaries.py
@@ -54,7 +54,10 @@ def _build_flush_summaries(batches: Iterable[_FlushBatch]) -> list[_FlushSummary
 def _pending_flush_from_batches(flush_sequence: int, batches: list[_FlushBatch]) -> _PendingFlush:
     return _pending_flush_from_pending_batches(
         flush_sequence,
-        [_PendingBatch(batch=batch) for batch in batches],
+        [
+            _PendingBatch(batch=batch, flush_batch_index=index)
+            for index, batch in enumerate(batches)
+        ],
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -844,6 +844,73 @@ def test_same_flush_retryable_batches_preserve_batch_order_after_out_of_order_ca
     )
 
 
+def test_late_retryable_batch_precedes_saturated_suffix_from_same_flush(tmp_path):
+    callbacks: list[DeliveryOutcomeCallback] = []
+    first_attempt_runs: list[str] = []
+    retry_runs: list[str] = []
+    pending_path = tmp_path / "usage-pending"
+    retrying = False
+
+    def enqueue_webhook(
+        url: str,
+        sandbox_token: str,
+        payload: dict,
+        path: str,
+        log_type: str,
+        delivery_outcome_callback: DeliveryOutcomeCallback,
+    ) -> bool:
+        del url, sandbox_token, path
+        assert log_type == "usage_event"
+        run_id = payload["runId"]
+        if retrying:
+            retry_runs.append(run_id)
+            delivery_outcome_callback("success")
+            return True
+        first_attempt_runs.append(run_id)
+        if run_id == "run-a":
+            callbacks.append(delivery_outcome_callback)
+            return True
+        return False
+
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue_webhook)
+    usage.set_pending_path(str(pending_path))
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    for run_id, source_key in (("run-a", "source-a"), ("run-b", "source-b")):
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            run_id,
+            [event(source_key=source_key)],
+            str(proxy_log_path),
+        )
+
+    assert usage.flush_usage_events(trigger="test") == 1
+    assert first_attempt_runs == ["run-a", "run-b"]
+    assert len(callbacks) == 1
+
+    callbacks[0]("retryable_failure")
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=2,
+        reports=0,
+        flush_request_id="late-retryable-retained",
+    )
+
+    retrying = True
+    assert usage.flush_usage_events(trigger="test") == 2
+
+    assert retry_runs == ["run-a", "run-b"]
+    assert usage.flush_usage_events(trigger="test") == 0
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="late-retryable-drained",
+    )
+
+
 def test_synchronous_retryable_delivery_before_admission_saturation_is_retained(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary

- preserve each usage batch's original position across retained retry copies
- order retained fragments from the same flush by that stable position
- cover partial saturation followed by a late retryable delivery callback

## Behavior

When a flush admits an earlier batch but retains a later suffix for delivery saturation, a subsequent retryable callback for the admitted batch now places its retained fragment before the suffix. Ordering for unrelated flushes, log-type priority, asynchronous delivery, retry budgets, same-generation retry suppression, payloads, counters, timers, and shutdown behavior are unchanged.

This changes only process-local Python state. It does not change APIs, schemas, migrations, queue or runner protocols, persisted state, configuration, or documentation.

## Validation

- `uv run --no-sync python -m pytest tests/test_usage_buffer_flush_failures.py` (21 passed)
- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,818 passed)

Closes #25388
