### PR TITLE
fix(platform): restore short artifact previews

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -167,7 +167,9 @@ interface ParseBodyBlocksOptions {
 // Constants
 // ---------------------------------------------------------------------------
 
-const PLATFORM_FILE_PATH_PATTERN = /^\/(?:f|artifacts)\/[^/]+\/[^/]+\/[^/]+$/;
+const LEGACY_PLATFORM_FILE_PATH_PATTERN =
+  /^\/(?:f|artifacts)\/[^/]+\/[^/]+\/[^/]+$/;
+const SHORT_ARTIFACT_FILE_PATH_PATTERN = /^\/artifacts\/[0-9a-z]{10}\.[^/]+$/;
 const PLATFORM_FILE_HOST_SUFFIXES = ["vm0.ai", "vm6.ai", "vm7.ai"] as const;
 const PLATFORM_FILE_CDN_HOSTS = ["cdn.vm0.io", "cdn.vm7.io"] as const;
 const HOSTED_SITE_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/u;
@@ -407,7 +409,10 @@ function isPlatformFileUrl(url: string): boolean {
     return false;
   }
   const parsed = new URL(url, baseUrl);
-  if (!PLATFORM_FILE_PATH_PATTERN.test(parsed.pathname)) {
+  if (
+    !LEGACY_PLATFORM_FILE_PATH_PATTERN.test(parsed.pathname) &&
+    !SHORT_ARTIFACT_FILE_PATH_PATTERN.test(parsed.pathname)
+  ) {
     return false;
   }
   if (!hasExplicitUrlOrigin(url)) {
@@ -522,22 +527,23 @@ function renderExtractedPreviewLine(
   const { title, url } = extracted;
   const attachment = previewAttachmentFromUrl(url, title);
   const kind = classifyChatAttachment(attachment);
+  const previewable = isPreviewableChatUrl(url);
 
   if (
     extracted.source === "markdown-link" &&
-    (kind === "image" || kind === "video")
+    (kind === "image" || (kind === "video" && !previewable))
   ) {
     return { renderKind: "markdown", line };
   }
 
-  if (kind === "image" && isPreviewableChatUrl(url)) {
+  if (kind === "image" && previewable) {
     return {
       renderKind: "markdown",
       line: markdownImageLine(url, attachment.filename),
     };
   }
 
-  if (isBodyPreviewKind(kind) && isPreviewableChatUrl(url)) {
+  if (isBodyPreviewKind(kind) && previewable) {
     return {
       renderKind: "preview",
       preview: { filename: attachment.filename, url, kind },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -2526,6 +2526,104 @@ describe("zero attachment chips", () => {
     });
   });
 
+  it("renders short artifact video urls and links as preview cards", async () => {
+    const bareVideoUrl = "https://cdn.vm7.io/artifacts/0123456789.mp4";
+    const linkedVideoUrl = "https://cdn.vm7.io/artifacts/abcdefghij.mp4";
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatEvents: [
+        {
+          id: "msg-short-artifact-video-links",
+          role: "assistant",
+          content: `${bareVideoUrl}\n[Generated clip](${linkedVideoUrl})`,
+          runId: "run-short-artifact-video-links",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    await expect(
+      screen.findByLabelText("Preview 0123456789.mp4"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByLabelText("Preview abcdefghij.mp4")).toBeInTheDocument();
+  });
+
+  it("renders other short artifact urls with their preview ui", async () => {
+    const urls = {
+      audio: "https://cdn.vm7.io/artifacts/0000000001.mp3",
+      markdown: "https://cdn.vm7.io/artifacts/0000000002.md",
+      text: "https://cdn.vm7.io/artifacts/0000000003.txt",
+      json: "https://cdn.vm7.io/artifacts/0000000004.json",
+      csv: "https://cdn.vm7.io/artifacts/0000000005.csv",
+      pdf: "https://cdn.vm7.io/artifacts/0000000006.pdf",
+      html: "https://cdn.vm7.io/artifacts/0000000007.html",
+      file: "https://cdn.vm7.io/artifacts/0000000008.bin",
+      image: "https://cdn.vm7.io/artifacts/0000000009.png",
+    } as const;
+    context.mocks.http.get(urls.markdown, () => {
+      return new Response("# Notes", {
+        headers: { "Content-Type": "text/markdown" },
+      });
+    });
+    context.mocks.http.get(urls.text, () => {
+      return new Response("Transcript", {
+        headers: { "Content-Type": "text/plain" },
+      });
+    });
+    context.mocks.http.get(urls.json, () => {
+      return new Response('{"status":"ready"}', {
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    context.mocks.http.get(urls.csv, () => {
+      return new Response("metric,value\nactivation,87", {
+        headers: { "Content-Type": "text/csv" },
+      });
+    });
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatEvents: [
+        {
+          id: "msg-other-short-artifact-links",
+          role: "assistant",
+          content: `${urls.audio}\n[Notes](${urls.markdown})\n${urls.text}\n[Status](${urls.json})\n${urls.csv}\n[Plan](${urls.pdf})\n[Short site](${urls.html})\n${urls.file}\n${urls.image}`,
+          runId: "run-other-short-artifact-links",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    await expect(
+      screen.findByLabelText("Open audio preview for 0000000001.mp3"),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Open markdown preview for 0000000002.md"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Open text preview for 0000000003.txt"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Open json preview for 0000000004.json"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Open csv preview for 0000000005.csv"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Open pdf preview for 0000000006.pdf"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Open html preview for Short site"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Download 0000000008.bin"),
+    ).toBeInTheDocument();
+    expect(screen.getByAltText("0000000009.png")).toBeInTheDocument();
+  });
+
   it("opens document previews parsed from chat message links", async () => {
     await setupBodyLinkPreviews();
 


### PR DESCRIPTION
## Summary

- recognize flat V2 artifact URLs as trusted vm0 artifact files in chat messages
- render bare and titled vm0 artifact videos with the existing preview card while preserving native video rendering for external media
- cover short URLs for video, audio, Markdown, text, JSON, CSV, PDF, HTML, generic files, and images

## Testing

- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- focused Vitest coverage: 3 tests passed across attachment and Markdown rendering