### PR TITLE
docs(nbd-cow): document pooled snapshot restore

### DIFF
--- a/crates/nbd-cow/src/device/mod.rs
+++ b/crates/nbd-cow/src/device/mod.rs
@@ -120,9 +120,11 @@ impl NbdCowDevice {
 
     /// Destroy the device but keep the COW file for snapshot persistence.
     ///
-    /// Saves the dirty bitmap as a sidecar file (`{cow_file}.bitmap`)
-    /// so that a future `create()` call with the same paths can restore
-    /// the dirty state and serve reads from the COW file correctly.
+    /// Saves the dirty bitmap as a sidecar file (`{cow_file}.bitmap`). To
+    /// restore the device, keep the COW file and sidecar paired, then call
+    /// [`DevicePoolHandle::create_cow_device`](crate::pool::DevicePoolHandle::create_cow_device)
+    /// with a base image containing the original unchanged-block contents, the
+    /// preserved COW path, and the original device size.
     pub async fn destroy_keep_cow(&mut self) -> Result<()> {
         self.shutdown_inner(true).await
     }

--- a/crates/nbd-cow/src/device/pooled.rs
+++ b/crates/nbd-cow/src/device/pooled.rs
@@ -320,6 +320,14 @@ impl PooledNbdCowDevice {
 
     /// Destroy the device while preserving COW data for snapshot persistence.
     ///
+    /// On success, returns [`KeptCow`] with the COW file and its dirty-bitmap
+    /// sidecar. Preserve both files as a pair. To restore the same logical
+    /// device, keep `KeptCow::bitmap_file` at the sidecar path derived from
+    /// `KeptCow::cow_file`, then call
+    /// [`DevicePoolHandle::create_cow_device`](crate::pool::DevicePoolHandle::create_cow_device)
+    /// with a base image containing the original unchanged-block contents,
+    /// `KeptCow::cow_file`, and the original device size.
+    ///
     /// Finalization starts immediately. Dropping the returned future does not
     /// cancel cleanup; it continues in the background and logs its result.
     /// Must be called from a Tokio runtime.


### PR DESCRIPTION
## Summary

- replace the stale `NbdCowDevice::create()` reference with the supported pooled creation API
- document how `KeptCow`'s COW and bitmap files participate in snapshot restoration
- clarify that recreation needs the original unchanged-block base-image contents and device size

## Scope

Documentation only. This does not change runtime behavior, public API signatures, schema, migrations, or the persisted COW/bitmap format.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p nbd-cow --all-targets --all-features`
- `cargo doc -p nbd-cow --all-features --no-deps`
- `cargo test -p nbd-cow --all-targets --all-features`
- repository pre-commit Rust formatting, documentation, and Clippy hooks

Closes #25398
