### PR TITLE
ci: increase lint-types-apps heap limit

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "oxlint && oxlint src --type-aware -c ../../.oxlintrc.typeaware.json --ignore-pattern '**/__tests__/**' && oxlint $(find src -type d -name __tests__) --type-aware -c ../../.oxlintrc.typeaware.json && eslint . --max-warnings 0",
-    "check-types": "NODE_OPTIONS=--max-old-space-size=3072 tsc --noEmit"
+    "check-types": "NODE_OPTIONS=--max-old-space-size=3584 tsc --noEmit"
   },
   "dependencies": {
     "@aws-sdk/client-kms": "^3.1098.0",


### PR DESCRIPTION
## Summary

- increase the API type-check Node.js heap limit from 3072 MiB to 3584 MiB for `lint-types-apps`

## Verification

- Not run (per request)
