### PR TITLE
feat: roll out artifact sidebar inline open to all users

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -2387,6 +2387,11 @@ describe("zero attachment chips", () => {
   it("opens only the dialog download menu when the same artifact is in split view", async () => {
     const user = userEvent.setup({ delay: null });
     setupHostedSiteArtifactPreview({
+      // Stacking a dialog over the sidebar for the same artifact only happens
+      // with inline open off; the on path is covered by the next test.
+      featureSwitches: {
+        [FeatureSwitchKey.ArtifactSidebarInlineOpen]: false,
+      },
       filename: "split-dialog-download.html",
       htmlUrl: "https://split-dialog-download.sites.vm7.io",
       label: "Split dialog download",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -399,8 +399,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "bingjie@vm0.ai",
     description:
       "Open an artifact clicked in a chat thread inside the already-open artifact sidebar instead of stacking the page-global lightbox over it.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ImageCanvasDoubleClickZoom]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

Promote the `artifactSidebarInlineOpen` feature switch from staff-only to full rollout.

Clicking an artifact inside a chat thread now opens it in the already-open artifact sidebar instead of stacking the page-global lightbox on top, for every user.

## Change

`turbo/packages/core/src/feature-switch.ts`:

- `enabled: false` → `enabled: true`
- dropped the now-redundant `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` staff gate

No behavior code changed — the switch is read by `artifactSidebarInlineOpenEnabled$` and consumed in `thread-sidebar-coordinator.ts`, both untouched.

`turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx`:

- `opens only the dialog download menu when the same artifact is in split view` relied on the registry default being off, because stacking a dialog over the sidebar for the *same* artifact is exactly what inline open prevents. It now pins the switch to `false` so the off path keeps its coverage. The on path is already covered by the neighbouring cases that pin the switch to `true`.

The switch itself stays in place so the rollout can be reverted with a one-line flip if needed; cleanup can follow once it has been stable in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
