### PR TITLE
test(guest-agent): add final telemetry shutdown deadline

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1451,14 +1451,20 @@ mod tests {
                 let telemetry =
                     Telemetry::spawn_for_paths(config.run_id.clone(), &guest_paths, masker, http);
 
-                stop_background_and_flush_final_telemetry(
-                    shutdown,
-                    None,
-                    metrics_handle,
-                    heartbeat_handle,
-                    telemetry,
+                tokio::time::timeout(
+                    Duration::from_secs(5),
+                    stop_background_and_flush_final_telemetry(
+                        shutdown,
+                        None,
+                        metrics_handle,
+                        heartbeat_handle,
+                        telemetry,
+                    ),
                 )
-                .await;
+                .await
+                .expect(
+                    "final telemetry producer shutdown and final upload completion should finish within 5 seconds",
+                );
 
                 telemetry_mock.assert_calls_async(1).await;
                 telemetry_mock.delete_async().await;


### PR DESCRIPTION
## Summary

- bound the complete final telemetry producer shutdown and upload sequence with a five-second test-owned timeout
- report a focused lifecycle diagnostic instead of waiting for the coverage job timeout
- preserve the existing cancellation ordering and exactly-one final upload assertion

## Scope

- test-only change in `crates/guest-agent/src/main.rs`
- no production behavior, API, schema, dependency, or deployment contract changes

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --bin guest-agent tests::final_telemetry_waits_for_background_producers_before_upload -- --exact`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- fault injection without `shutdown.cancel()`: verified the test fails with the new diagnostic in 5.03 seconds, then restored the production code and reran the focused test successfully

Closes #25402
