### PR TITLE
refactor: remove pwa chat keyboard gestures feature switch

### DIFF
--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -91,10 +91,6 @@ export const composerUploadPopoverEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.ComposerUploadPopover] ?? false;
 });
 
-export const pwaChatKeyboardGesturesEnabled$ = computed((get): boolean => {
-  return get(featureSwitch$)[FeatureSwitchKey.PwaChatKeyboardGestures] ?? false;
-});
-
 export const mermaidDiagramsEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.MermaidDiagrams] ?? false;
 });

--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -11,7 +11,6 @@ import { listenForceUpgradeDialog$ } from "../signals/force-upgrade.ts";
 import { setupAuthenticatedDaemons$ } from "../signals/authenticated-daemons.ts";
 import { rootSignal$ } from "../signals/root-signal.ts";
 import { detach, Reason } from "../signals/utils.ts";
-import { pwaChatKeyboardGesturesEnabled$ } from "../signals/external/feature-switch.ts";
 import {
   isStandalonePwa,
   setupKeyboardDismissGesture,
@@ -24,24 +23,12 @@ export const setupRouter = (
   render: (children: React.ReactNode) => void,
 ) => {
   const signal = store.get(rootSignal$);
-  let cleanupKeyboardDismissGesture: (() => void) | undefined;
-  store.watch(
-    (get) => {
-      cleanupKeyboardDismissGesture?.();
-      cleanupKeyboardDismissGesture = undefined;
-      if (get(pwaChatKeyboardGesturesEnabled$) && isStandalonePwa()) {
-        cleanupKeyboardDismissGesture = setupKeyboardDismissGesture();
-      }
-    },
-    { signal, debugLabel: "pwa-chat-keyboard-gestures" },
-  );
-  signal.addEventListener(
-    "abort",
-    () => {
-      cleanupKeyboardDismissGesture?.();
-    },
-    { once: true },
-  );
+  if (isStandalonePwa()) {
+    const cleanupKeyboardDismissGesture = setupKeyboardDismissGesture();
+    signal.addEventListener("abort", cleanupKeyboardDismissGesture, {
+      once: true,
+    });
+  }
   detach(store.set(setupAuthenticatedDaemons$, signal), Reason.Daemon);
   detach(
     store.set(listenForceUpgradeDialog$, signal),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1,6 +1,5 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { describe, expect, it, onTestFinished } from "vitest";
 import { chatThreadEventsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { ZERO_RECOGNITION_MAX_FILE_BYTES } from "@vm0/api-contracts/contracts/zero-recognition";
@@ -75,11 +74,9 @@ function makeVerticallyScrollable(
 }
 
 async function setupKeyboardGestureChat({
-  featureEnabled,
   standalone,
   threadId,
 }: {
-  readonly featureEnabled: boolean;
   readonly standalone: boolean;
   readonly threadId: string;
 }): Promise<{
@@ -103,9 +100,6 @@ async function setupKeyboardGestureChat({
   detachedSetupPage({
     context,
     path: `/chats/${threadId}`,
-    featureSwitches: {
-      [FeatureSwitchKey.PwaChatKeyboardGestures]: featureEnabled,
-    },
   });
 
   return await waitFor(() => {
@@ -393,7 +387,6 @@ describe("chat lifecycle", () => {
   it("contains keyboard gestures on the rendered standalone-PWA chat page", async () => {
     const { composerEditor, composerScrollSurface, history } =
       await setupKeyboardGestureChat({
-        featureEnabled: true,
         standalone: true,
         threadId: "b0000000-0000-4000-a000-000000000991",
       });
@@ -446,30 +439,8 @@ describe("chat lifecycle", () => {
   it("leaves mobile-browser chat gestures unchanged outside standalone mode", async () => {
     const { composerEditor, composerScrollSurface, history } =
       await setupKeyboardGestureChat({
-        featureEnabled: true,
         standalone: false,
         threadId: "b0000000-0000-4000-a000-000000000992",
-      });
-
-    expect(history).not.toHaveClass("overscroll-contain");
-    expect(composerScrollSurface).not.toHaveClass("overscroll-contain");
-    openSoftwareKeyboard();
-    composerEditor.focus();
-    dispatchTouch(composerEditor, "touchstart", { x: 100, y: 500 });
-    const move = dispatchTouch(composerEditor, "touchmove", {
-      x: 100,
-      y: 460,
-    });
-    expect(move.defaultPrevented).toBeFalsy();
-    expect(composerEditor).toHaveFocus();
-  });
-
-  it("leaves standalone-PWA chat gestures unchanged while the switch is disabled", async () => {
-    const { composerEditor, composerScrollSurface, history } =
-      await setupKeyboardGestureChat({
-        featureEnabled: false,
-        standalone: true,
-        threadId: "b0000000-0000-4000-a000-000000000993",
       });
 
     expect(history).not.toHaveClass("overscroll-contain");

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -120,7 +120,6 @@ import { detach, Reason } from "../../signals/utils.ts";
 import {
   featureSwitch$,
   mermaidDiagramsEnabled$,
-  pwaChatKeyboardGesturesEnabled$,
 } from "../../signals/external/feature-switch.ts";
 import { isStandalonePwa } from "../../lib/keyboard-dismiss-gesture.ts";
 import {
@@ -3561,8 +3560,7 @@ function ChatThreadEventsPane({ thread }: { thread: ChatPanelSignals }) {
   const scrollContainerOnRef = useSet(thread.scrollContainerOnRef$);
   const loadMoreRenderedChatGroups = useSet(thread.loadMoreRenderedChatGroups$);
   const pageSignal = useGet(pageSignal$);
-  const pwaChatKeyboardGesturesEnabled =
-    useGet(pwaChatKeyboardGesturesEnabled$) && isStandalonePwa();
+  const standalonePwa = isStandalonePwa();
 
   const handleScroll = (event: ReactUIEvent<HTMLDivElement>) => {
     if (
@@ -3582,7 +3580,7 @@ function ChatThreadEventsPane({ thread }: { thread: ChatPanelSignals }) {
         onScroll={handleScroll}
         className={cn(
           "absolute inset-0 overflow-y-auto focus:outline-none [overflow-anchor:none] [scrollbar-gutter:stable]",
-          pwaChatKeyboardGesturesEnabled && "overscroll-contain",
+          standalonePwa && "overscroll-contain",
         )}
       >
         <ChatThreadEventsMain
@@ -3918,8 +3916,7 @@ function ActiveGoalObjectiveDialog({ threadId }: { threadId: string }) {
 }
 
 function ChatThreadComposer({ thread }: { thread: ChatPanelSignals }) {
-  const pwaChatKeyboardGesturesEnabled =
-    useGet(pwaChatKeyboardGesturesEnabled$) && isStandalonePwa();
+  const standalonePwa = isStandalonePwa();
 
   return (
     <footer
@@ -3930,7 +3927,7 @@ function ChatThreadComposer({ thread }: { thread: ChatPanelSignals }) {
       <div
         className={cn(
           "overflow-y-auto [scrollbar-gutter:stable] pb-2 pl-4 pr-4 pt-3 sm:pl-6 sm:pr-6",
-          pwaChatKeyboardGesturesEnabled && "overscroll-contain",
+          standalonePwa && "overscroll-contain",
         )}
       >
         <div className="mx-auto max-w-[900px]">

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -18,9 +18,6 @@ describe("isFeatureEnabled", () => {
       true,
     );
     expect(isFeatureEnabled(FeatureSwitchKey.TeamsIntegration, {})).toBe(true);
-    expect(isFeatureEnabled(FeatureSwitchKey.PwaChatKeyboardGestures, {})).toBe(
-      true,
-    );
     expect(isFeatureEnabled(FeatureSwitchKey.MermaidDiagrams, {})).toBe(true);
     expect(
       isFeatureEnabled(FeatureSwitchKey.StructuredPromptInlineTemplates, {}),

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -64,7 +64,6 @@ export enum FeatureSwitchKey {
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",
   ChatThreadUnifiedSearch = "chatThreadUnifiedSearch",
   ChatErrorRecovery = "chatErrorRecovery",
-  PwaChatKeyboardGestures = "pwaChatKeyboardGestures",
   SidebarSubscriptionUsage = "sidebarSubscriptionUsage",
   TeamsIntegration = "teamsIntegration",
   FeishuIntegration = "feishuIntegration",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -376,12 +376,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.PwaChatKeyboardGestures]: {
-    maintainer: "bingjie@vm0.ai",
-    description:
-      "Keep the PWA chat composer pinned above the software keyboard and support swipe-to-dismiss gestures.",
-    enabled: true,
-  },
   [FeatureSwitchKey.ChatThreadSidebarAutoOpen]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Terminal state

`fully-rolled-out` — keep the switch-on behavior permanently.

Evidence: the switch was rolled out to everyone in `3ddcfefc` ([#25229](https://github.com/vm0-ai/vm0/pull/25229), 2026-08-05), which changed the registry entry from `enabled: false` + `STAFF_ORG_ID_HASHES` to a plain `enabled: true` with no org gating. `main` has carried the global-on entry since then, so the off-path is dead code.

## Commit archaeology

| Commit | PR | Effect |
| --- | --- | --- |
| `28259bd1` | [#23986](https://github.com/vm0-ai/vm0/pull/23986) | Introduced the switch (staff-gated, `userOverridable: false`), added `keyboard-dismiss-gesture.ts`, the platform signal, both gated call sites, and the test matrix |
| `d428036e` | [#24632](https://github.com/vm0-ai/vm0/pull/24632) | Unrelated repo-wide change that dropped `userOverridable: false` |
| `3ddcfefc` | [#25229](https://github.com/vm0-ai/vm0/pull/25229) | Rolled the switch out to all users |

Each removal was checked against `28259bd1`'s patch and its parent to confirm which side of the branch was pre-existing behavior versus feature code.

## Behavior kept

- `turbo/apps/platform/src/lib/keyboard-dismiss-gesture.ts` is retained in full — it is the shipped feature, not switch scaffolding.
- `isStandalonePwa()` is retained as the permanent gate. It is a runtime display-mode capability check, unrelated to the feature switch; the original condition was `switchEnabled && isStandalonePwa()`, so the switch-on behavior is exactly `isStandalonePwa()`.
- `overscroll-contain` on the chat history and composer scroll surfaces in standalone PWA mode.
- Non-standalone (mobile browser) chat gestures stay unchanged.

## Behavior removed

- Registry entry and `FeatureSwitchKey.PwaChatKeyboardGestures`.
- `pwaChatKeyboardGesturesEnabled$` in `apps/platform/src/signals/external/feature-switch.ts`.
- In `views/main.tsx`, the switch was the `store.watch` callback's only reactive dependency. With it gone the watch had nothing to react to, so it collapses to a direct `if (isStandalonePwa())` setup with the same abort-driven cleanup — no empty wrapper left behind.
- Both `useGet(pwaChatKeyboardGesturesEnabled$) && isStandalonePwa()` call sites in `zero-chat-thread-page.tsx` become a plain `isStandalonePwa()`.

## Tests

- Deleted `leaves standalone-PWA chat gestures unchanged while the switch is disabled` — it only covered the discarded off-behavior.
- Removed the `featureEnabled` parameter and the `featureSwitches` override from `setupKeyboardGestureChat`, plus the now-unused `FeatureSwitchKey` import.
- Kept both remaining behavior tests, which now exercise the permanent behavior directly instead of through the switch: standalone-PWA gestures present, mobile-browser gestures unchanged.
- No negative tests added asserting the key/registry entry no longer exists.

## Second-round keyword sweep

Searched repo-wide for `pwaChatKeyboardGestures`, `PwaChatKeyboardGestures`, `pwa-chat-keyboard-gestures`, `pwa_chat_keyboard_gestures`, `PWA_CHAT_KEYBOARD_GESTURES`, `pwaChatKeyboardGesturesEnabled` — zero hits.

Also swept identifiers introduced by `28259bd1`: `keyboard-dismiss-gesture`, `setupKeyboardDismissGesture`, `isStandalonePwa`, `standaloneDisplayMode`, `keyboardOpen`, `overscroll-contain`, and the `pwa-chat-keyboard-gestures` `debugLabel`. The `debugLabel` is gone; the rest are permanent infrastructure now fully decoupled from the switch (`standaloneDisplayMode` and `overscroll-contain` are also used by unrelated tests and components).

## Knip

`pnpm knip --workspace apps/platform` and `pnpm knip --workspace packages/core` — both clean before and after; this cleanup produced no orphan files, exports, or dependencies. Scoped to the two affected workspaces rather than the full repo.

## Verification run

- `git diff --check` — clean
- Prettier 3.x on all 7 changed files — all already formatted
- `pnpm -F @vm0/core lint` — pass
- `pnpm -F @vm0/app lint` — pass, no findings in changed files (remaining warnings are pre-existing in unrelated files)
- `pnpm -F @vm0/core check-types` — pass
- `pnpm -F @vm0/app check-types` — pass (production + tests projects)
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` — 24 passed
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx` — 29 passed
- `pnpm -F @vm0/app exec vitest run zero-sidebar-mac-shortcut / install-banner / zero-connectors-page / visual-viewport-keyboard` — 96 passed

That last run is deliberate: `setupRouter` is invoked by every page test via `__tests__/page-helper.ts`, and `isStandalonePwa()` is now the sole gate for gesture setup, so the other suites that enable standalone display mode were exercised to confirm no regression.

## Left to the pipeline

Full-repo lint, type-check, Knip, the complete Vitest suite, and cli-e2e. No local dev server and no full local Vitest run, per repo guidance.

## Note

[#24858](https://github.com/vm0-ai/vm0/pull/24858) ("feat: roll out pwa chat keyboard gestures") is still open but was superseded by #25229, which merged the same rollout. It is now a no-op against `main` and conflicts with this PR's removal — it should be closed.
