### PR TITLE
perf(python): fast-path safe url syntax scans

### DIFF
--- a/crates/runner/mitm-addon/src/url_syntax.py
+++ b/crates/runner/mitm-addon/src/url_syntax.py
@@ -16,6 +16,12 @@ def has_unsafe_url_codepoint(value: str) -> bool:
     excluded; pair this with has_raw_whitespace() when raw whitespace must be
     rejected.
     """
+    # ASCII non-printable code points are exactly C0 controls and DEL.
+    if value.isascii():
+        return not value.isprintable()
+    # Other non-printable code points require the narrower numeric policy below.
+    if value.isprintable():
+        return False
     return any(
         ord(char) < ASCII_CONTROL_MAX
         or ord(char) == ASCII_DELETE
@@ -29,7 +35,7 @@ def has_raw_whitespace(value: str) -> bool:
 
     This covers space, tab, LF, CR, form feed, and vertical tab.
     """
-    return any(char in RAW_WHITESPACE_CHARS for char in value)
+    return any(char in value for char in RAW_WHITESPACE_CHARS)
 
 
 def has_unsafe_runtime_url_syntax(value: str, *, allow_backslash: bool = False) -> bool:

--- a/crates/runner/mitm-addon/src/url_syntax.py
+++ b/crates/runner/mitm-addon/src/url_syntax.py
@@ -1,11 +1,20 @@
 """Shared URL syntax helpers for firewall matching and rewriting."""
 
+import re
+
 # C0 controls are code points below raw space; raw space is handled separately.
 ASCII_CONTROL_MAX = 0x20
 ASCII_DELETE = 0x7F
 RAW_WHITESPACE_CHARS = frozenset(" \t\n\r\f\v")
 _UNICODE_SURROGATE_MIN = 0xD800
 _UNICODE_SURROGATE_MAX = 0xDFFF
+_UNSAFE_URL_CODEPOINT_PATTERN = re.compile(
+    "["
+    f"{chr(0)}-{chr(ASCII_CONTROL_MAX - 1)}"
+    f"{chr(ASCII_DELETE)}"
+    f"{chr(_UNICODE_SURROGATE_MIN)}-{chr(_UNICODE_SURROGATE_MAX)}"
+    "]"
+)
 
 
 def has_unsafe_url_codepoint(value: str) -> bool:
@@ -19,15 +28,10 @@ def has_unsafe_url_codepoint(value: str) -> bool:
     # ASCII non-printable code points are exactly C0 controls and DEL.
     if value.isascii():
         return not value.isprintable()
-    # Other non-printable code points require the narrower numeric policy below.
+    # Other non-printable code points require the narrower policy search below.
     if value.isprintable():
         return False
-    return any(
-        ord(char) < ASCII_CONTROL_MAX
-        or ord(char) == ASCII_DELETE
-        or _UNICODE_SURROGATE_MIN <= ord(char) <= _UNICODE_SURROGATE_MAX
-        for char in value
-    )
+    return _UNSAFE_URL_CODEPOINT_PATTERN.search(value) is not None
 
 
 def has_raw_whitespace(value: str) -> bool:

--- a/crates/runner/mitm-addon/tests/test_url_syntax.py
+++ b/crates/runner/mitm-addon/tests/test_url_syntax.py
@@ -1,6 +1,7 @@
 """Shared runtime URL syntax policy tests."""
 
 from collections.abc import Iterator
+from itertools import product
 
 import pytest
 
@@ -13,6 +14,15 @@ class _NoPythonCharacterAccess(str):
 
     def __getitem__(self, key: int | slice) -> str:
         raise AssertionError("safe URL syntax checks must not index the input in Python")
+
+
+def _numeric_unsafe_url_codepoint_policy(value: str) -> bool:
+    return any(
+        ord(char) < url_syntax.ASCII_CONTROL_MAX
+        or ord(char) == url_syntax.ASCII_DELETE
+        or 0xD800 <= ord(char) <= 0xDFFF
+        for char in value
+    )
 
 
 @pytest.mark.parametrize("codepoint", range(url_syntax.ASCII_CONTROL_MAX))
@@ -45,13 +55,34 @@ def test_unsafe_url_codepoint_contract(value: str, expected: bool):
 
 def test_unsafe_url_codepoint_matches_numeric_policy_for_every_codepoint():
     for codepoint in range(0x110000):
-        expected = (
-            codepoint < url_syntax.ASCII_CONTROL_MAX
-            or codepoint == url_syntax.ASCII_DELETE
-            or 0xD800 <= codepoint <= 0xDFFF
-        )
+        expected = _numeric_unsafe_url_codepoint_policy(chr(codepoint))
         assert url_syntax.has_unsafe_url_codepoint(chr(codepoint)) is expected, (
             f"unexpected URL syntax result for U+{codepoint:04X}"
+        )
+
+
+def test_unsafe_url_codepoint_matches_numeric_policy_for_mixed_strings():
+    boundary_values = (
+        "a",
+        "é",
+        "🙂",
+        " ",
+        "\\",
+        "\x00",
+        "\x1f",
+        "\x7f",
+        "\x80",
+        "\x85",
+        "\u00a0",
+        "\u200b",
+        "\u2028",
+        "\ud800",
+        "\udfff",
+    )
+    for parts in product(boundary_values, repeat=3):
+        value = f"prefix{''.join(parts)}suffix"
+        assert url_syntax.has_unsafe_url_codepoint(value) == _numeric_unsafe_url_codepoint_policy(
+            value
         )
 
 
@@ -115,16 +146,18 @@ def test_unsafe_runtime_url_syntax_contract(
 
 
 @pytest.mark.parametrize(
-    "value",
+    ("value", "expected_unsafe"),
     [
-        pytest.param("", id="empty"),
-        pytest.param("https://api.example.com/path?query=value", id="printable-ascii"),
-        pytest.param("https://api.example.com/café/東京/🙂", id="printable-unicode"),
+        pytest.param("", False, id="empty"),
+        pytest.param("https://api.example.com/path?query=value", False, id="printable-ascii"),
+        pytest.param("https://api.example.com/café/東京/🙂", False, id="printable-unicode"),
+        pytest.param("https://api.example.com/path\u200b", False, id="accepted-non-printable"),
+        pytest.param("https://api.example.com/café\ud800", True, id="forbidden-surrogate"),
     ],
 )
-def test_safe_url_syntax_bypasses_python_character_access(value: str):
+def test_url_syntax_bypasses_python_character_access(value: str, expected_unsafe: bool):
     guarded_value = _NoPythonCharacterAccess(value)
 
-    assert not url_syntax.has_unsafe_url_codepoint(guarded_value)
+    assert url_syntax.has_unsafe_url_codepoint(guarded_value) is expected_unsafe
     assert not url_syntax.has_raw_whitespace(guarded_value)
-    assert not url_syntax.has_unsafe_runtime_url_syntax(guarded_value)
+    assert url_syntax.has_unsafe_runtime_url_syntax(guarded_value) is expected_unsafe

--- a/crates/runner/mitm-addon/tests/test_url_syntax.py
+++ b/crates/runner/mitm-addon/tests/test_url_syntax.py
@@ -1,0 +1,130 @@
+"""Shared runtime URL syntax policy tests."""
+
+from collections.abc import Iterator
+
+import pytest
+
+import url_syntax
+
+
+class _NoPythonCharacterAccess(str):
+    def __iter__(self) -> Iterator[str]:
+        raise AssertionError("safe URL syntax checks must not iterate the input in Python")
+
+    def __getitem__(self, key: int | slice) -> str:
+        raise AssertionError("safe URL syntax checks must not index the input in Python")
+
+
+@pytest.mark.parametrize("codepoint", range(url_syntax.ASCII_CONTROL_MAX))
+def test_unsafe_url_codepoint_rejects_every_c0_control(codepoint: int):
+    assert url_syntax.has_unsafe_url_codepoint(chr(codepoint))
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("", False, id="empty"),
+        pytest.param(" ", False, id="ascii-space"),
+        pytest.param("\x7f", True, id="ascii-delete"),
+        pytest.param("\ud800", True, id="surrogate-min"),
+        pytest.param("\udfff", True, id="surrogate-max"),
+        pytest.param("ordinary URL text", False, id="printable-ascii"),
+        pytest.param("café/東京/🙂", False, id="printable-unicode"),
+        pytest.param("\x80", False, id="accepted-c1-control"),
+        pytest.param("\x85", False, id="accepted-next-line"),
+        pytest.param("\u00a0", False, id="accepted-no-break-space"),
+        pytest.param("\u200b", False, id="accepted-zero-width-space"),
+        pytest.param("\u2028", False, id="accepted-line-separator"),
+        pytest.param("\u2060", False, id="accepted-word-joiner"),
+        pytest.param("prefix\u200bsuffix\udfff", True, id="fallback-finds-late-surrogate"),
+    ],
+)
+def test_unsafe_url_codepoint_contract(value: str, expected: bool):
+    assert url_syntax.has_unsafe_url_codepoint(value) is expected
+
+
+def test_unsafe_url_codepoint_matches_numeric_policy_for_every_codepoint():
+    for codepoint in range(0x110000):
+        expected = (
+            codepoint < url_syntax.ASCII_CONTROL_MAX
+            or codepoint == url_syntax.ASCII_DELETE
+            or 0xD800 <= codepoint <= 0xDFFF
+        )
+        assert url_syntax.has_unsafe_url_codepoint(chr(codepoint)) is expected, (
+            f"unexpected URL syntax result for U+{codepoint:04X}"
+        )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(" ", id="space"),
+        pytest.param("\t", id="tab"),
+        pytest.param("\n", id="line-feed"),
+        pytest.param("\r", id="carriage-return"),
+        pytest.param("\f", id="form-feed"),
+        pytest.param("\v", id="vertical-tab"),
+    ],
+)
+def test_raw_whitespace_rejects_exact_ascii_set(value: str):
+    assert url_syntax.has_raw_whitespace(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("ordinary-url-text", id="printable-ascii"),
+        pytest.param("café/東京/🙂", id="printable-unicode"),
+        pytest.param("\x85", id="next-line"),
+        pytest.param("\u00a0", id="no-break-space"),
+        pytest.param("\u1680", id="ogham-space-mark"),
+        pytest.param("\u2003", id="em-space"),
+        pytest.param("\u2028", id="line-separator"),
+        pytest.param("\u2029", id="paragraph-separator"),
+        pytest.param("\u3000", id="ideographic-space"),
+    ],
+)
+def test_raw_whitespace_accepts_values_outside_exact_ascii_set(value: str):
+    assert not url_syntax.has_raw_whitespace(value)
+
+
+@pytest.mark.parametrize(
+    ("value", "allow_backslash", "expected"),
+    [
+        pytest.param("", False, False, id="empty"),
+        pytest.param("https://api.example.com/path", False, False, id="safe"),
+        pytest.param("https://api.example.com\\path", False, True, id="backslash-rejected"),
+        pytest.param("https://api.example.com\\path", True, False, id="backslash-allowed"),
+        pytest.param("https://api.example.com\\path ", True, True, id="space-still-rejected"),
+        pytest.param("https://api.example.com\\pa\tth", True, True, id="tab-still-rejected"),
+        pytest.param("https://api.example.com\\pa\x00th", True, True, id="control-still-rejected"),
+        pytest.param(
+            "https://api.example.com\\pa\ud800th", True, True, id="surrogate-still-rejected"
+        ),
+    ],
+)
+def test_unsafe_runtime_url_syntax_contract(
+    value: str,
+    allow_backslash: bool,
+    expected: bool,
+):
+    assert (
+        url_syntax.has_unsafe_runtime_url_syntax(value, allow_backslash=allow_backslash) is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("https://api.example.com/path?query=value", id="printable-ascii"),
+        pytest.param("https://api.example.com/café/東京/🙂", id="printable-unicode"),
+    ],
+)
+def test_safe_url_syntax_bypasses_python_character_access(value: str):
+    guarded_value = _NoPythonCharacterAccess(value)
+
+    assert not url_syntax.has_unsafe_url_codepoint(guarded_value)
+    assert not url_syntax.has_raw_whitespace(guarded_value)
+    assert not url_syntax.has_unsafe_runtime_url_syntax(guarded_value)

--- a/crates/runner/mitm-addon/tests/test_url_syntax.py
+++ b/crates/runner/mitm-addon/tests/test_url_syntax.py
@@ -13,7 +13,7 @@ class _NoPythonCharacterAccess(str):
         raise AssertionError("safe URL syntax checks must not iterate the input in Python")
 
     def __getitem__(self, key: int | slice) -> str:
-        raise AssertionError("safe URL syntax checks must not index the input in Python")
+        raise IndexError("safe URL syntax checks must not index the input in Python")
 
 
 def _numeric_unsafe_url_codepoint_policy(value: str) -> bool:

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -195,6 +195,7 @@ suites before committing the upgrade.
 | `test_firewall_rewrite_safety.py`                       | Firewall auth URL rewrite fail-closed and safety behavior                                                            |
 | `test_auth_query_injection.py`                          | Firewall auth query injection and query rewrite behavior                                                             |
 | `test_host_normalization.py`                            | Shared hostname identity, ASCII fast-path, IDNA, and label-boundary contracts                                        |
+| `test_url_syntax.py`                                    | Shared raw URL code-point, whitespace, backslash, and safe-input fast-path contracts                                  |
 | `test_url_utils.py`                                     | Rewrite URL, path, query, and auth-base URL utility cases                                                            |
 | `test_url_utils_trusted_authority.py`                   | Trusted request authority success and URL reconstruction                                                             |
 | `test_url_utils_trusted_authority_rejection.py`         | Trusted request authority rejection matrices                                                                         |


### PR DESCRIPTION
## Summary

- classify safe ASCII and printable Unicode URL syntax with C-level string predicates
- search the remaining non-ASCII, non-printable inputs with one precompiled exact policy character class instead of request-controlled Python iteration
- find the six raw ASCII whitespace characters through fixed-needle membership instead of iterating request input in Python
- add exhaustive code-point equivalence, deterministic mixed-string coverage, iteration guards, and the mitm-addon test inventory entry

## Performance

A paired Python 3.14 probe alternated the before/after predicates in the production `_split_base_match_url()` parser for seven runs per input:

| Path payload | Before | After | Reduction | Speedup |
| --- | ---: | ---: | ---: | ---: |
| Printable ASCII, 200,000 chars | 11.732 ms | 0.199 ms | 98.3% | 59.0x |
| Printable Unicode, 200,000 chars | 11.919 ms | 0.200 ms | 98.3% | 59.5x |
| Printable ASCII, 1,000,000 chars | 57.291 ms | 0.967 ms | 98.3% | 59.2x |
| Printable Unicode, 1,000,000 chars | 60.665 ms | 1.005 ms | 98.3% | 60.4x |

The residual predicate path also avoids Python character iteration for long accepted non-printable Unicode and late surrogates:

| Predicate payload, 1,000,000 chars | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| Accepted C1 control at end | 43.318 ms | 2.668 ms | 16.2x |
| Accepted format character at end | 43.707 ms | 2.932 ms | 14.9x |
| Rejected surrogate at end | 43.712 ms | 2.959 ms | 14.8x |

Timing is recorded as implementation evidence only; automated tests use no performance thresholds.

## Semantics and scope

- the optimized predicate matches the previous C0/DEL/surrogate numeric policy across every Python code point on Python 3.12 and 3.14, plus deterministic mixed boundary strings
- empty input, ASCII space, raw whitespace, backslash, `allow_backslash`, accepted non-printable Unicode, and printable Unicode behavior remain unchanged
- the compiled pattern contains only fixed code-point ranges derived from the existing policy constants; it retains no request data and has no backtracking structure
- no request-target limit, mitmproxy request-head buffering change, caller-specific state, or request-derived cache is included
- no API, schema, persisted-data, migration, protocol, queue payload, dependency, environment variable, generated artifact, or feature switch change

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_url_syntax.py` — 77 passed
- focused firewall, path-security, auth-base, built-in policy, and SigV4 suites — 680 passed
- `uv run --no-sync python -m pytest -q tests/` — 4,936 passed, 58 pre-existing mitmproxy logging deprecation warnings
- Python 3.12 and 3.14 full-code-point policy comparisons
- `scripts/check-file-size.sh crates/runner/mitm-addon/src/url_syntax.py crates/runner/mitm-addon/tests/test_url_syntax.py docs/testing/mitm-addon-testing.md`

Closes #25404
