### PR TITLE
refactor(platform): remove image canvas double-click zoom switch

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -11,7 +11,7 @@ import {
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { click, detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -135,23 +135,15 @@ async function uploadFile(file: File): Promise<void> {
   await user.upload(fileInput, file);
 }
 
-async function setupComposer(
-  featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>,
-): Promise<void> {
-  detachedSetupPage({
-    context,
-    path: "/",
-    ...(featureSwitches ? { featureSwitches } : {}),
-  });
+async function setupComposer(): Promise<void> {
+  detachedSetupPage({ context, path: "/" });
 
   await waitFor(() => {
     expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
   });
 }
 
-async function setupUploadedImagePreview(
-  featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>,
-): Promise<void> {
+async function setupUploadedImagePreview(): Promise<void> {
   context.mocks.upload.success({
     id: "upload-photo",
     filename: "photo.png",
@@ -160,7 +152,7 @@ async function setupUploadedImagePreview(
     url: "https://example.com/photo.png",
   });
 
-  await setupComposer(featureSwitches);
+  await setupComposer();
   await uploadFile(new File(["img"], "photo.png", { type: "image/png" }));
 
   await waitFor(() => {
@@ -463,9 +455,7 @@ describe("zero attachment chips", () => {
   });
 
   it("zooms an uploaded image preview with controls and double-click", async () => {
-    await setupUploadedImagePreview({
-      [FeatureSwitchKey.ImageCanvasDoubleClickZoom]: true,
-    });
+    await setupUploadedImagePreview();
 
     click(screen.getByLabelText("Open image preview for photo.png"));
 
@@ -541,9 +531,7 @@ describe("zero attachment chips", () => {
   });
 
   it("resets a transformed uploaded image preview with double-click", async () => {
-    await setupUploadedImagePreview({
-      [FeatureSwitchKey.ImageCanvasDoubleClickZoom]: true,
-    });
+    await setupUploadedImagePreview();
 
     click(screen.getByLabelText("Open image preview for photo.png"));
 
@@ -584,56 +572,6 @@ describe("zero attachment chips", () => {
         "translate(0px, 0px) scale(1)",
       );
     });
-  });
-
-  it("keeps double-click zoom disabled when its feature switch is off", async () => {
-    await setupUploadedImagePreview({
-      [FeatureSwitchKey.ImageCanvasDoubleClickZoom]: false,
-    });
-
-    click(screen.getByLabelText("Open image preview for photo.png"));
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("artifact-dialog-image-zoom-controls"),
-      ).toBeInTheDocument();
-    });
-
-    const zoomStage = screen.getByTestId("artifact-dialog-image-stage");
-    const zoomContent = screen.getByTestId(
-      "artifact-dialog-image-stage-content",
-    );
-    const transformContent = zoomContent.parentElement as HTMLElement;
-    const transformWrapper = transformContent.parentElement as HTMLElement;
-    const lightboxImage = screen.getByTestId("attachment-lightbox-image");
-
-    mockElementBox(zoomStage, { height: 600, width: 800 });
-    mockElementBox(transformWrapper, { height: 600, width: 800 });
-    mockElementBox(transformContent, { height: 600, width: 800 });
-    Object.defineProperty(lightboxImage, "naturalWidth", {
-      configurable: true,
-      value: 1200,
-    });
-    fireEvent.load(lightboxImage);
-
-    await waitFor(() => {
-      expect(lightboxImage).toHaveStyle({ width: "800px" });
-    });
-
-    const requestAnimationFrameSpy = vi.spyOn(window, "requestAnimationFrame");
-    requestAnimationFrameSpy.mockClear();
-
-    try {
-      fireEvent.doubleClick(lightboxImage, { clientX: 200, clientY: 150 });
-
-      expect(requestAnimationFrameSpy).not.toHaveBeenCalled();
-      expect(screen.getByText("100%")).toBeInTheDocument();
-      expect(transformContent.style.transform).toBe(
-        "translate(0px, 0px) scale(1)",
-      );
-    } finally {
-      requestAnimationFrameSpy.mockRestore();
-    }
   });
 
   it("closes the attachment lightbox with Escape before browser shortcuts run", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
@@ -1,9 +1,7 @@
 import type { ReactNode, Ref, SyntheticEvent } from "react";
 import { useGet, useSet } from "ccstate-react";
 import { TransformComponent, TransformWrapper } from "react-zoom-pan-pinch";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { cn } from "@vm0/ui";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   IMAGE_LIGHTBOX_MAX_ZOOM,
   IMAGE_LIGHTBOX_MIN_ZOOM,
@@ -195,7 +193,6 @@ export function ZoomableArtifactImageCanvas({
   src,
   zoomKey = src,
 }: ZoomableArtifactImageCanvasProps) {
-  const featureSwitches = useGet(featureSwitch$);
   const zoomByKey = useGet(zoomableImageCanvasZoomByKey$);
   const fitWidthByKey = useGet(zoomableImageCanvasFitWidthByKey$);
   const setDisplayZoom = useSet(setZoomableImageCanvasZoom$);
@@ -203,8 +200,6 @@ export function ZoomableArtifactImageCanvas({
   const resetDisplayZoom = useSet(resetZoomableImageCanvasZoom$);
   const displayZoom = zoomByKey[zoomKey] ?? 1;
   const fitWidth = fitWidthByKey[zoomKey];
-  const doubleClickZoomEnabled =
-    featureSwitches[FeatureSwitchKey.ImageCanvasDoubleClickZoom] ?? false;
   const imageWidth =
     fitWidth !== undefined ? `${Math.round(fitWidth)}px` : "100%";
   const handleImageLoad = (event: SyntheticEvent<HTMLImageElement>) => {
@@ -221,14 +216,10 @@ export function ZoomableArtifactImageCanvas({
       key={zoomKey}
       centerZoomedOut
       disablePadding
-      doubleClick={
-        doubleClickZoomEnabled
-          ? {
-              mode: displayZoom === 1 ? "zoomIn" : "reset",
-              step: IMAGE_DOUBLE_CLICK_ZOOM_STEP,
-            }
-          : { disabled: true }
-      }
+      doubleClick={{
+        mode: displayZoom === 1 ? "zoomIn" : "reset",
+        step: IMAGE_DOUBLE_CLICK_ZOOM_STEP,
+      }}
       initialScale={1}
       maxScale={IMAGE_LIGHTBOX_MAX_ZOOM}
       minScale={IMAGE_LIGHTBOX_MIN_ZOOM}

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -42,9 +42,6 @@ describe("isFeatureEnabled", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.ChatThreadSidebarAutoOpen, {}),
     ).toBe(false);
-    expect(
-      isFeatureEnabled(FeatureSwitchKey.ImageCanvasDoubleClickZoom, {}),
-    ).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.JoggAiBuiltIn, {})).toBe(false);
   });
 
@@ -125,9 +122,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadSidebarAutoOpen]).toBe(
       true,
     );
-    expect(staffOrgStates[FeatureSwitchKey.ImageCanvasDoubleClickZoom]).toBe(
-      true,
-    );
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(
       true,
@@ -150,9 +144,6 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadSidebarAutoOpen]).toBe(
-      false,
-    );
-    expect(otherOrgStates[FeatureSwitchKey.ImageCanvasDoubleClickZoom]).toBe(
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -74,7 +74,6 @@ export enum FeatureSwitchKey {
   ThreeColumnNav = "threeColumnNav",
   ChatThreadSidebarAutoOpen = "chatThreadSidebarAutoOpen",
   ArtifactSidebarInlineOpen = "artifactSidebarInlineOpen",
-  ImageCanvasDoubleClickZoom = "imageCanvasDoubleClickZoom",
   CustomConnectorCliCreate = "customConnectorCliCreate",
   CustomConnectorOAuth2 = "customConnectorOAuth2",
   MermaidDiagrams = "mermaidDiagrams",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -402,13 +402,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ImageCanvasDoubleClickZoom]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Enable double-click zoom toggling on the shared image canvas.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ThreeColumnNav]: {
     maintainer: "ming@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- make the shared image canvas double-click zoom toggle available to every user
- remove the `ImageCanvasDoubleClickZoom` feature-switch key, registry entry, runtime gate, and switch-only assertions
- keep the positive zoom-in and reset interaction coverage while removing the obsolete disabled-state test

## Rollout decision

- Terminal state: **fully rolled out**
- Evidence: the feature maintainer explicitly requested global rollout and removal of the rollout switch

## History and behavior comparison

- The double-click zoom feature landed in `192e990f78` via #25377.
- The rollout gate was introduced in `bd270f422b`; its parent already contained the intended always-enabled interaction.
- Kept behavior: double-click at 100% uses `zoomIn` with step `1`; double-click after any transform uses `reset`.
- Deleted behavior: the `{ disabled: true }` branch used when the switch was off.
- Comparison conclusion: the cleaned-up canvas matches the pre-gate implementation (`git diff --exit-code bd270f422b^ -- turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx` passes).

## Cleanup evidence

- Second-round repository searches returned no matches for:
  - `ImageCanvasDoubleClickZoom`
  - `imageCanvasDoubleClickZoom`
  - `doubleClickZoomEnabled`
  - `Enable double-click zoom toggling on the shared image canvas`
  - `keeps double-click zoom disabled when its feature switch is off`
- Knip baseline: exit 0 with 44 existing configuration hints.
- Knip after cleanup: exit 0 with the same 44 configuration hints and no new findings.

## Tests and validation

- Preserved the positive image-canvas tests for double-click zoom-in and double-click reset.
- Removed only the obsolete feature-switch-off test and its setup plumbing.
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` — 24 passed
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx` — 42 passed on the final `main` base
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm knip`
- `git diff --check`
- Lefthook pre-commit: Prettier, Knip, and all 12 repository typecheck tasks passed; commitlint passed

PR CI is pending.
