### PR TITLE
test(api): stabilize final goal settlement race

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -23,7 +23,7 @@ import { readGoalQueueStateFixture } from "../../../test-fixtures/goal-queue";
 import {
   holdCheckpointReadsFixture,
   holdChatEventInsertTransactionFixture,
-  holdChatThreadRowLockFixture,
+  holdGoalThreadLockFixture,
   holdModelPolicyReadsFixture,
   insertQueuedSlackMissingContextFixture,
   readChatEventContextFixture,
@@ -2019,58 +2019,49 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
       "revoke the goal invalidated at final settlement",
     );
     await misc.deleteOrgModelProvider(actor, "anthropic-api-key", [204]);
-    const modelPolicyReads = await holdModelPolicyReadsFixture({
+    const goalThreadLock = await holdGoalThreadLockFixture({
+      threadId: first.threadId,
       signal: context.signal,
     });
     onTestFinished(async () => {
-      modelPolicyReads.release();
-      await modelPolicyReads.done;
+      goalThreadLock.release();
+      await goalThreadLock.done;
     });
     chatCallbacks.mockChatOutputEvents([
       assistantEvent(0, "completed before the final goal launch failure"),
     ]);
 
-    await completeChatRunOk(first.runId, sandboxHeaders, {
-      lastEventSequence: 0,
-    });
-    await expect
-      .poll(modelPolicyReads.blockedWaiterCount)
-      .toBeGreaterThanOrEqual(1);
-
     let goalEventId: string | undefined;
-    await expect
-      .poll(async () => {
-        const [eventId] = await goalQueueEventIds(first.threadId);
-        goalEventId = eventId;
-        return eventId;
-      })
-      .toBeDefined();
+    const [paused] = await Promise.all([
+      accept(
+        goalsClient().pause({
+          headers: zeroGoalHeaders(actor, first.runId),
+        }),
+        [200],
+      ),
+      (async () => {
+        await expect.poll(goalThreadLock.waiterCount).toBe(1);
+        await completeChatRunOk(first.runId, sandboxHeaders, {
+          lastEventSequence: 0,
+        });
+        await expect
+          .poll(async () => {
+            const [eventId] = await goalQueueEventIds(first.threadId);
+            goalEventId = eventId;
+            return eventId;
+          })
+          .toBeDefined();
+        await expect.poll(goalThreadLock.waiterCount).toBeGreaterThanOrEqual(2);
+        goalThreadLock.release();
+        await goalThreadLock.done;
+      })(),
+    ]);
+    expect(paused.body.status).toBe("paused");
+    await flushWaitUntilForTest();
+
     if (!goalEventId) {
       throw new Error("Expected the final-boundary goal queue event");
     }
-    const threadLock = await holdChatThreadRowLockFixture({
-      threadId: first.threadId,
-      signal: context.signal,
-    });
-    onTestFinished(async () => {
-      threadLock.release();
-      await threadLock.done;
-    });
-
-    const pauseRequest = goalsClient().pause({
-      headers: zeroGoalHeaders(actor, first.runId),
-    });
-    await expect.poll(threadLock.firstBlockedStatementKind).toBe("update");
-
-    modelPolicyReads.release();
-    await modelPolicyReads.done;
-    await expect.poll(threadLock.blockedWaiterCount).toBeGreaterThanOrEqual(2);
-    threadLock.release();
-
-    const paused = await accept(pauseRequest, [200]);
-    expect(paused.body.status).toBe("paused");
-    await threadLock.done;
-    await flushWaitUntilForTest();
 
     const events = await waitForThreadMessages(
       actor,

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -967,6 +967,71 @@ export async function holdModelPolicyReadsFixture(args: {
 }
 
 /**
+ * Holds the production per-thread goal lifecycle lock so a route test can
+ * order one user lifecycle change ahead of a concurrent queue settlement.
+ * The lock key is scoped to the test's unique thread id, so unrelated API
+ * tests cannot satisfy the waiter barrier.
+ */
+export async function holdGoalThreadLockFixture(args: {
+  readonly threadId: string;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly release: () => void;
+  readonly done: Promise<void>;
+  readonly waiterCount: () => Promise<number>;
+}> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const rows = await executeRawRows(
+      tx,
+      sql`
+        SELECT
+          pg_backend_pid() AS "pid",
+          pg_advisory_xact_lock(hashtext('goal:' || ${args.threadId}))
+      `,
+      databasePidRowSchema,
+    );
+    const holderPid = rows[0]?.pid;
+    if (!holderPid) {
+      throw new Error("Expected the goal thread lock holder pid");
+    }
+    started.resolve(holderPid);
+    await released.promise;
+  });
+  const holderPid = await started.promise;
+
+  return {
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+    done,
+    waiterCount: async () => {
+      const rows = await executeRawRows(
+        db(),
+        sql`
+          SELECT ${count()}::int AS "waiterCount"
+          FROM pg_locks AS waiting
+          WHERE waiting.locktype = 'advisory'
+            AND NOT waiting.granted
+            AND (waiting.classid, waiting.objid, waiting.objsubid) IN (
+              SELECT held.classid, held.objid, held.objsubid
+              FROM pg_locks AS held
+              WHERE held.locktype = 'advisory'
+                AND held.pid = ${holderPid}
+                AND held.granted
+            )
+        `,
+        waiterCountRowSchema,
+      );
+      return rows[0]?.waiterCount ?? 0;
+    },
+  };
+}
+
+/**
  * Reproduces a crash after the canonical chat callback was acknowledged but
  * before its detached terminal processing became durable. Product APIs cannot
  * delete append-only events, so this fixture removes only the exact cancelled


### PR DESCRIPTION
## Summary

- replace the global model-policy waiter barrier with the production per-thread goal lifecycle advisory lock
- order the pause request ahead of failed goal settlement at an explicit deterministic boundary
- own the pause request immediately with `Promise.all` to avoid late rejection handling during teardown

## Root cause

The first substantive failure in the linked API shard expected the pause `UPDATE` to own the final settlement boundary, but observed a concurrent `SELECT ... FOR UPDATE` first. The test treated any waiter on a globally locked `org_model_policies` table as evidence that this thread had reached model resolution. Parallel API tests could satisfy that condition, allowing this test to continue before its own drain reached the intended boundary.

The later `PromiseRejectionHandledWarning`, aborts during teardown, Codecov failure, and aggregate gate failure were downstream cleanup or gate noise rather than the root cause.

## Fix

The test now holds the same advisory lock used by production goal lifecycle operations, keyed by the test's unique thread ID. It confirms the pause request is queued first, triggers failed launch settlement, confirms that settlement is queued behind the pause, and then releases the lock. Business assertions remain unchanged.

## Verification

- target flaky test: 5/5 sequential passes
- three adjacent goal settlement scenarios: 3/3 passes
- Prettier check passed
- `pnpm -F api lint` passed with existing warnings only
- `pnpm -F api check-types` passed

No full-repository Vitest run or local development server was used.

Failure evidence: https://github.com/vm0-ai/vm0/actions/runs/31083758735/job/92558397513
