### PR TITLE
fix(runner): retry active input after source read failure

### DIFF
--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -9,7 +9,7 @@ use tracing::{debug, warn};
 use crate::active_input::{ActiveInputBatch, ActiveInputPayload, ActiveInputSource};
 use crate::ids::RunId;
 
-const LOCAL_ACTIVE_INPUT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const ACTIVE_INPUT_READ_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 const ACTIVE_INPUT_CONTROL_TIMEOUT: Duration = Duration::from_secs(1);
 const ACTIVE_INPUT_FORWARDER_JOIN_TIMEOUT: Duration = Duration::from_secs(1);
 const FIRST_ACTIVE_INPUT_SEQUENCE: u64 = 1;
@@ -67,7 +67,7 @@ async fn run_forwarder(
             () = job_cancel.cancelled() => return,
             batch = source.read(next_local_sequence) => batch,
         };
-        match batch {
+        let retry_after_read_error = match batch {
             Ok(ActiveInputBatch::Local(entries)) => {
                 for entry in entries {
                     if entry.sequence < next_local_sequence {
@@ -80,23 +80,32 @@ async fn run_forwarder(
                     forward_text(run_id, delivery_sequence, &entry.text, &control).await;
                     next_local_sequence = next_local_sequence.saturating_add(1);
                 }
+                false
             }
             Ok(ActiveInputBatch::Api(prompt)) => {
                 if let Some(prompt) = prompt {
                     delivery_sequence = delivery_sequence.saturating_add(1);
                     forward_text(run_id, delivery_sequence, &prompt, &control).await;
                 }
+                false
             }
             Err(error) => {
                 warn!(run_id = %run_id, error = %error, "active-input source read failed");
+                true
             }
-        }
+        };
 
         tokio::select! {
             biased;
             () = stop.cancelled() => return,
             () = job_cancel.cancelled() => return,
-            () = source.wait(LOCAL_ACTIVE_INPUT_POLL_INTERVAL) => {}
+            () = async {
+                if retry_after_read_error {
+                    tokio::time::sleep(ACTIVE_INPUT_READ_RETRY_INTERVAL).await;
+                } else {
+                    source.wait(ACTIVE_INPUT_READ_RETRY_INTERVAL).await;
+                }
+            } => {}
         }
     }
 }

--- a/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
@@ -1,13 +1,50 @@
 use std::sync::Arc;
 
-use crate::active_input::ActiveInputSource;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+use crate::active_input::{ActiveInputNotifications, ActiveInputSource};
 use crate::executor::agent_run::{RunControls, RunStart, run_in_sandbox};
 use crate::executor::tests::support::{
     RUN_IN_SANDBOX_TEST_TIMEOUT, create_overridden_sandbox, minimal_context, test_executor_config,
     test_telemetry,
 };
+use crate::http::{HttpClient, HttpClientConfig};
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
+use crate::provider::ApiClient;
 use crate::types::SandboxReuseResult;
+
+async fn read_http_request(socket: &mut TcpStream) -> String {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 1024];
+    let header_end = loop {
+        let read = socket.read(&mut buffer).await.unwrap();
+        assert!(read > 0, "connection closed before HTTP headers completed");
+        request.extend_from_slice(&buffer[..read]);
+        if let Some(header_end) = request
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|position| position + 4)
+        {
+            break header_end;
+        }
+    };
+    let headers = String::from_utf8_lossy(&request[..header_end]);
+    let body_len = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().unwrap())
+        })
+        .unwrap_or(0);
+    while request.len() < header_end + body_len {
+        let read = socket.read(&mut buffer).await.unwrap();
+        assert!(read > 0, "connection closed before HTTP body completed");
+        request.extend_from_slice(&buffer[..read]);
+    }
+    String::from_utf8(request).unwrap()
+}
 
 #[tokio::test]
 async fn run_in_sandbox_forwards_local_active_inputs_in_order() {
@@ -92,6 +129,119 @@ async fn run_in_sandbox_forwards_local_active_inputs_in_order() {
     assert_eq!(payloads[0]["text"], "first");
     assert_eq!(payloads[1]["text"], "duplicate");
     assert_eq!(payloads[2]["text"], "third");
+}
+
+#[tokio::test]
+async fn run_in_sandbox_retries_api_active_input_after_transient_read_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&wait_gate),
+    ));
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let run_id = ctx.run_id;
+    let active_input_path = format!("/api/runners/runs/{run_id}/active-inputs");
+    let claim_path = format!("{active_input_path}/claim");
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let api_url = format!("http://{}", listener.local_addr().unwrap());
+    let response = |status: &str, body: &str| {
+        format!(
+            "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+    };
+    let responses = [
+        response("200 OK", r#"{"eventIds":[]}"#),
+        response("503 Service Unavailable", r#"{"error":"transient"}"#),
+        response("200 OK", r#"{"eventIds":["event-1"]}"#),
+        response("200 OK", r#"{"prompt":"retry delivered"}"#),
+    ];
+    let (request_tx, mut request_rx) = tokio::sync::mpsc::unbounded_channel();
+    let server = tokio::spawn(async move {
+        for response in responses {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let request = read_http_request(&mut socket).await;
+            socket.write_all(response.as_bytes()).await.unwrap();
+            request_tx.send(request).unwrap();
+        }
+    });
+
+    let notifications = ActiveInputNotifications::new();
+    let source = ActiveInputSource::api(
+        ApiClient::new(
+            HttpClient::new(HttpClientConfig {
+                api_url,
+                vercel_bypass: None,
+                client_session_id: "active-input-retry-test".to_string(),
+            })
+            .unwrap(),
+            "runner-token".to_string(),
+        ),
+        run_id,
+        "sandbox-token".to_string(),
+        notifications.subscribe(run_id),
+    );
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let mut telemetry = test_telemetry(&config, &ctx);
+    let run_task = tokio::spawn(async move {
+        run_in_sandbox(
+            &*sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(cancel, Some(source)),
+        )
+        .await
+    });
+
+    let initial_list = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, request_rx.recv())
+        .await
+        .expect("initial active-input list request should reach the server")
+        .expect("active-input request channel should remain open");
+    assert!(initial_list.starts_with(&format!("GET {active_input_path} ")));
+    notifications.notify(run_id);
+
+    assert!(
+        overrides
+            .wait_for_process_control_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await,
+        "active input should be retried without another notification"
+    );
+    wait_gate.notify_one();
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(result.failure.is_none());
+
+    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, server)
+        .await
+        .expect("active-input server should finish")
+        .unwrap();
+    let mut remaining_requests = Vec::new();
+    while let Some(request) = request_rx.recv().await {
+        remaining_requests.push(request);
+    }
+    assert_eq!(remaining_requests.len(), 3);
+    assert!(remaining_requests[0].starts_with(&format!("GET {active_input_path} ")));
+    assert!(remaining_requests[1].starts_with(&format!("GET {active_input_path} ")));
+    assert!(remaining_requests[2].starts_with(&format!("POST {claim_path} ")));
+
+    let calls = overrides.process_control_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&calls[0].payload).unwrap()["text"],
+        "retry delivered"
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -925,7 +925,7 @@ pub(crate) struct ApiClient {
 }
 
 impl ApiClient {
-    pub(super) fn new(http: HttpClient, token: String) -> Self {
+    pub(crate) fn new(http: HttpClient, token: String) -> Self {
         Self { http, token }
     }
 


### PR DESCRIPTION
## Summary

- retry active-input source reads after a bounded 250 ms delay when the preceding read fails
- keep successful API reads notification-driven while preserving stop and job-cancellation priority
- add an HTTP-to-guest-control regression covering one notification, a transient list failure, and recovery without another notification

## Scope

- no API, database, Ably message, queue, guest-control, or persisted protocol changes
- local active-input polling retains its existing cadence
- claim transaction semantics remain unchanged

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::agent_run_tests::active_input::run_in_sandbox_retries_api_active_input_after_transient_read_failure -- --exact`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`

The regression timed out on the pre-fix control flow after the sole notification was consumed, then passed after the bounded error retry was added.

Closes #25409
