### PR TITLE
test(api): isolate managed model-key fixtures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -65,7 +65,6 @@ import { readAgentRunState$ } from "./helpers/agent-run-callback";
 import { chatEventDisplayText } from "./helpers/chat-event";
 import {
   clearThreadSessionBinding,
-  deleteVm0ManagedDefaultModelKey,
   readRunAutonomyBudgetFixture,
   readThreadSessionBinding,
   seedVm0ManagedModelKey as seedVm0ManagedModelKeyState,
@@ -318,10 +317,8 @@ async function entitledChatActor(
 }
 
 async function seedVm0ManagedModelKey(selectedModel: string): Promise<string> {
-  onTestFinished(async () => {
-    await deleteVm0ManagedDefaultModelKey(context);
-  });
-  return await seedVm0ManagedModelKeyState(context, selectedModel);
+  const fixture = await seedVm0ManagedModelKeyState(context, selectedModel);
+  return fixture.selectedModel;
 }
 
 async function sendChatRun(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -59,10 +59,7 @@ import {
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { chatEventDisplayText } from "./helpers/chat-event";
-import {
-  deleteVm0ManagedDefaultModelKey,
-  seedVm0ManagedDefaultModelKey,
-} from "./helpers/runtime-state";
+import { seedVm0ManagedDefaultModelKey } from "./helpers/runtime-state";
 import {
   generatedStripeCustomerId,
   generatedStripeSubscriptionId,
@@ -2190,12 +2187,9 @@ describe("CHAT-03 run usage events", () => {
   }, 60_000);
 
   it("emits complete allowance-covered usage in one event", async () => {
-    const seededModel = await seedVm0ManagedDefaultModelKey(context);
+    const fixture = await seedVm0ManagedDefaultModelKey(context);
     const selectedModel = DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL;
-    expect(seededModel).toBe(selectedModel);
-    onTestFinished(async () => {
-      await deleteVm0ManagedDefaultModelKey(context);
-    });
+    expect(fixture.selectedModel).toBe(selectedModel);
 
     const { actor, agentId } = await entitledChatActorWithoutRunner(
       "Allowance usage message agent",

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -1,7 +1,10 @@
+import { randomUUID } from "node:crypto";
+
 import type {
   TestRuntimeStateActionBody,
   TestRuntimeStateActionResponse,
 } from "@vm0/api-contracts/contracts/test-runtime-state";
+import { onTestFinished } from "vitest";
 
 import { createAppWithRoutes } from "../../../../app-factory-core";
 import type { TestContext } from "../../../../__tests__/test-context";
@@ -49,36 +52,59 @@ async function postAction(
   return await readJson<TestRuntimeStateActionResponse>(response);
 }
 
+interface Vm0ManagedModelKeyFixture {
+  readonly selectedModel: string;
+  release(): Promise<void>;
+}
+
+function vm0ManagedModelKeyFixture(
+  context: TestContext,
+  fixtureId: string,
+  selectedModel: string,
+): Vm0ManagedModelKeyFixture {
+  let released = false;
+  const release = async (): Promise<void> => {
+    if (released) {
+      return;
+    }
+    await postAction(context, {
+      action: "delete-vm0-managed-model-key",
+      fixture_id: fixtureId,
+    });
+    released = true;
+  };
+  onTestFinished(release);
+  return { selectedModel, release };
+}
+
 export async function seedVm0ManagedDefaultModelKey(
   context: TestContext,
-): Promise<string> {
+): Promise<Vm0ManagedModelKeyFixture> {
+  const fixtureId = randomUUID();
   const response = await postAction(context, {
     action: "seed-vm0-managed-default-model-key",
+    fixture_id: fixtureId,
   });
   if (!response.selected_model) {
     throw new Error("seedVm0ManagedDefaultModelKey missing selected_model");
   }
-  return response.selected_model;
+  return vm0ManagedModelKeyFixture(context, fixtureId, response.selected_model);
 }
 
 export async function seedVm0ManagedModelKey(
   context: TestContext,
   selectedModel: string,
-): Promise<string> {
+): Promise<Vm0ManagedModelKeyFixture> {
+  const fixtureId = randomUUID();
   const response = await postAction(context, {
     action: "seed-vm0-managed-model-key",
+    fixture_id: fixtureId,
     selected_model: selectedModel,
   });
   if (!response.selected_model) {
     throw new Error("seedVm0ManagedModelKey missing selected_model");
   }
-  return response.selected_model;
-}
-
-export async function deleteVm0ManagedDefaultModelKey(
-  context: TestContext,
-): Promise<void> {
-  await postAction(context, { action: "delete-vm0-managed-default-model-key" });
+  return vm0ManagedModelKeyFixture(context, fixtureId, response.selected_model);
 }
 
 export async function enableFakeKms(context: TestContext): Promise<void> {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -89,7 +89,6 @@ import {
 import { setConnectorCredentialStorageState } from "./helpers/connector-credential-storage-state";
 import {
   clearRunApiStart,
-  deleteVm0ManagedDefaultModelKey,
   enableFakeKms,
   holdOrgAdmissionLock,
   mutateRunnerJobConnectorPermissionBaseline,
@@ -488,17 +487,13 @@ function findFirewallEntry(
 }
 
 async function seedVm0ManagedDefaultModelKey(): Promise<string> {
-  onTestFinished(async () => {
-    await deleteVm0ManagedDefaultModelKey(context);
-  });
-  return await seedVm0ManagedDefaultModelKeyState(context);
+  const fixture = await seedVm0ManagedDefaultModelKeyState(context);
+  return fixture.selectedModel;
 }
 
 async function seedVm0ManagedModelKey(selectedModel: string): Promise<string> {
-  onTestFinished(async () => {
-    await deleteVm0ManagedDefaultModelKey(context);
-  });
-  return await seedVm0ManagedModelKeyState(context, selectedModel);
+  const fixture = await seedVm0ManagedModelKeyState(context, selectedModel);
+  return fixture.selectedModel;
 }
 
 function useSecretKmsClientForTests(args: {

--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { testContext } from "../../../__tests__/test-context";
+import { seedVm0ManagedModelKey } from "./helpers/runtime-state";
+
+const context = testContext();
+
+describe("POST /api/test/runtime-state/action", () => {
+  it("keeps overlapping VM0 managed model-key fixtures independently releasable", async () => {
+    const first = await seedVm0ManagedModelKey(context, "gpt-5.6-terra");
+    const second = await seedVm0ManagedModelKey(context, "gpt-5.6-terra");
+
+    expect(first.selectedModel).toBe("gpt-5.6-terra");
+    expect(second.selectedModel).toBe("gpt-5.6-terra");
+
+    await expect(first.release()).resolves.toBeUndefined();
+    await expect(second.release()).resolves.toBeUndefined();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
@@ -18,10 +18,7 @@ import {
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
-import {
-  deleteVm0ManagedDefaultModelKey,
-  seedVm0ManagedDefaultModelKey as seedVm0ManagedDefaultModelKeyState,
-} from "./helpers/runtime-state";
+import { seedVm0ManagedDefaultModelKey as seedVm0ManagedDefaultModelKeyState } from "./helpers/runtime-state";
 import { encryptSecretForTests } from "./helpers/encrypt-secret";
 import {
   generatedStripeCustomerId,
@@ -43,9 +40,6 @@ function addDays(date: Date, days: number): Date {
 }
 
 async function seedVm0ManagedDefaultModelKey(): Promise<void> {
-  onTestFinished(async () => {
-    await deleteVm0ManagedDefaultModelKey(context);
-  });
   await seedVm0ManagedDefaultModelKeyState(context);
 }
 

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -66,8 +66,7 @@ import {
 
 const actionBody$ = bodyResultOf(testRuntimeStateContract.action);
 const fakeKmsDataKey = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
-const RUN_LIFECYCLE_TEST_VM0_MANAGED_API_KEY =
-  "vm0-key-run-lifecycle-bdd-default-model";
+const VM0_MANAGED_MODEL_KEY_FIXTURE_PREFIX = "vm0-key-runtime-fixture-";
 const fakeKmsDecryptCallCount = testOverride<number>(() => {
   return 0;
 });
@@ -216,42 +215,110 @@ function fakeSecretKmsClient(): SecretKmsClient {
 
 async function seedVm0ManagedDefaultModelKey(
   db: Db,
+  fixtureId: string,
   signal: AbortSignal,
 ): Promise<string> {
   const selectedModel = MODEL_PROVIDER_TYPES.vm0.defaultModel;
   if (!selectedModel) {
     throw new Error("Expected vm0 to define a default model");
   }
-  return await seedVm0ManagedModelKey(db, selectedModel, signal);
+  return await seedVm0ManagedModelKey(db, fixtureId, selectedModel, signal);
 }
 
 async function seedVm0ManagedModelKey(
   db: Db,
+  fixtureId: string,
   selectedModel: string,
   signal: AbortSignal,
 ): Promise<string> {
-  await db
-    .delete(vm0ApiKeys)
-    .where(eq(vm0ApiKeys.apiKey, RUN_LIFECYCLE_TEST_VM0_MANAGED_API_KEY));
-  signal.throwIfAborted();
   await db.insert(vm0ApiKeys).values({
     vendor: getVm0Vendor(selectedModel),
     model: getProviderRuntimeModel("vm0", selectedModel),
-    apiKey: RUN_LIFECYCLE_TEST_VM0_MANAGED_API_KEY,
-    label: "run-lifecycle-bdd",
+    apiKey: `${VM0_MANAGED_MODEL_KEY_FIXTURE_PREFIX}${fixtureId}`,
+    label: "runtime-state-fixture",
   });
   signal.throwIfAborted();
   return selectedModel;
 }
 
-async function deleteVm0ManagedDefaultModelKey(
+async function deleteVm0ManagedModelKey(
   db: Db,
+  fixtureId: string,
   signal: AbortSignal,
 ): Promise<void> {
-  await db
+  const deleted = await db
     .delete(vm0ApiKeys)
-    .where(eq(vm0ApiKeys.apiKey, RUN_LIFECYCLE_TEST_VM0_MANAGED_API_KEY));
+    .where(
+      eq(
+        vm0ApiKeys.apiKey,
+        `${VM0_MANAGED_MODEL_KEY_FIXTURE_PREFIX}${fixtureId}`,
+      ),
+    )
+    .returning({ id: vm0ApiKeys.id });
   signal.throwIfAborted();
+  if (deleted.length !== 1) {
+    throw new Error(`Expected one VM0 managed model-key fixture: ${fixtureId}`);
+  }
+}
+
+type Vm0ManagedModelKeyAction = Extract<
+  TestRuntimeStateActionBody,
+  {
+    action:
+      | "seed-vm0-managed-default-model-key"
+      | "seed-vm0-managed-model-key"
+      | "delete-vm0-managed-model-key";
+  }
+>;
+
+function isVm0ManagedModelKeyAction(
+  body: TestRuntimeStateActionBody,
+): body is Vm0ManagedModelKeyAction {
+  return (
+    body.action === "seed-vm0-managed-default-model-key" ||
+    body.action === "seed-vm0-managed-model-key" ||
+    body.action === "delete-vm0-managed-model-key"
+  );
+}
+
+async function vm0ManagedModelKeyActionResponse(
+  db: Db,
+  body: Vm0ManagedModelKeyAction,
+  signal: AbortSignal,
+) {
+  switch (body.action) {
+    case "seed-vm0-managed-default-model-key": {
+      return {
+        status: 200 as const,
+        body: {
+          ok: true as const,
+          selected_model: await seedVm0ManagedDefaultModelKey(
+            db,
+            body.fixture_id,
+            signal,
+          ),
+        },
+      };
+    }
+    case "seed-vm0-managed-model-key": {
+      return {
+        status: 200 as const,
+        body: {
+          ok: true as const,
+          selected_model: await seedVm0ManagedModelKey(
+            db,
+            body.fixture_id,
+            body.selected_model,
+            signal,
+          ),
+        },
+      };
+    }
+    case "delete-vm0-managed-model-key": {
+      await deleteVm0ManagedModelKey(db, body.fixture_id, signal);
+      return { status: 200 as const, body: { ok: true as const } };
+    }
+  }
 }
 
 async function clearRunApiStart(
@@ -1287,33 +1354,10 @@ const postRuntimeStateAction$ = command(
     if (isCompatibilityFixtureAction(body)) {
       return await compatibilityFixtureActionResponse(db, body, signal);
     }
+    if (isVm0ManagedModelKeyAction(body)) {
+      return await vm0ManagedModelKeyActionResponse(db, body, signal);
+    }
     switch (body.action) {
-      case "seed-vm0-managed-default-model-key": {
-        return {
-          status: 200 as const,
-          body: {
-            ok: true as const,
-            selected_model: await seedVm0ManagedDefaultModelKey(db, signal),
-          },
-        };
-      }
-      case "seed-vm0-managed-model-key": {
-        return {
-          status: 200 as const,
-          body: {
-            ok: true as const,
-            selected_model: await seedVm0ManagedModelKey(
-              db,
-              body.selected_model,
-              signal,
-            ),
-          },
-        };
-      }
-      case "delete-vm0-managed-default-model-key": {
-        await deleteVm0ManagedDefaultModelKey(db, signal);
-        return { status: 200 as const, body: { ok: true as const } };
-      }
       case "enable-fake-kms": {
         fakeKmsDecryptCallCount.set(0);
         setSecretKmsClientForTests(fakeSecretKmsClient());

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -11,13 +11,16 @@ export const testRuntimeStateErrorSchema = z.object({
 export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
   z.object({
     action: z.literal("seed-vm0-managed-default-model-key"),
+    fixture_id: z.uuid(),
   }),
   z.object({
     action: z.literal("seed-vm0-managed-model-key"),
+    fixture_id: z.uuid(),
     selected_model: z.string(),
   }),
   z.object({
-    action: z.literal("delete-vm0-managed-default-model-key"),
+    action: z.literal("delete-vm0-managed-model-key"),
+    fixture_id: z.uuid(),
   }),
   z.object({
     action: z.literal("enable-fake-kms"),


### PR DESCRIPTION
## Summary

- give every VM0 managed model-key test fixture a unique owner UUID and database row
- make fixture cleanup delete exactly its owner's row and centralize teardown in an idempotent fixture handle
- migrate all managed-key test consumers and add deterministic overlapping-owner API integration coverage

## Scope

This changes only the production-denied test runtime contract, test fixture implementation, and API integration tests. It does not change production model-provider selection, database schema, external provider behavior, runner protocols, or persisted production state.

## Validation

- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts test` (25 files, 520 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- managed-key overlap integration test (1 test)
- run lifecycle integration tests (146 tests)
- chat events integration tests (72 tests)
- chat threads integration tests (28 tests)
- usage allowance integration tests (15 tests)
- clean-database API suite with four workers (189 files, 2,717 tests)
- `pnpm knip`
- Prettier and `git diff --check`
- repository pre-commit and commit-message hooks

Closes #25417
