### PR TITLE
fix(platform): require complete flat artifact urls

### DIFF
--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -50,8 +50,10 @@ Current link-backed card patterns include:
 - `/?settings=billing&billingView=plans`
 - `/mail/drafts/:vm0DraftId`
 - `/browsers/:threadId`
-- platform artifact URLs such as `/f/...` and `/artifacts/...`, plus hosted
-  site URLs that support an inline preview
+- platform artifact URLs such as legacy `/f/...` and `/artifacts/.../.../...`
+  paths, plus hosted site URLs that support an inline preview. Flat V2 artifact
+  paths such as `/artifacts/97ngzkxdyn.mp4` require a complete URL with an
+  allowed VM0 origin.
 
 Recognized billing-plan links render as rich upgrade cards.
 

--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -409,14 +409,15 @@ function isPlatformFileUrl(url: string): boolean {
     return false;
   }
   const parsed = new URL(url, baseUrl);
-  if (
-    !LEGACY_PLATFORM_FILE_PATH_PATTERN.test(parsed.pathname) &&
-    !SHORT_ARTIFACT_FILE_PATH_PATTERN.test(parsed.pathname)
-  ) {
+  const isLegacyPath = LEGACY_PLATFORM_FILE_PATH_PATTERN.test(parsed.pathname);
+  const isShortArtifactPath = SHORT_ARTIFACT_FILE_PATH_PATTERN.test(
+    parsed.pathname,
+  );
+  if (!isLegacyPath && !isShortArtifactPath) {
     return false;
   }
   if (!hasExplicitUrlOrigin(url)) {
-    return true;
+    return isLegacyPath;
   }
   return (
     platformFileHosts().has(parsed.host) ||

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -2618,6 +2618,37 @@ describe("zero attachment chips", () => {
     expect(screen.getByLabelText("Preview abcdefghij.mp4")).toBeInTheDocument();
   });
 
+  it("requires complete urls for flat artifact preview cards", async () => {
+    const incompletePath = "artifacts/97ngzkxdyn.mp4";
+    const rootRelativePath = "/artifacts/97ngzkxdyn.mp4";
+    const completeUrl = "https://cdn.vm7.io/artifacts/97ngzkxdyn.mp4";
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatEvents: [
+        {
+          id: "msg-incomplete-short-artifact-video-links",
+          role: "assistant",
+          content: `${incompletePath}\n${rootRelativePath}\n${completeUrl}`,
+          runId: "run-incomplete-short-artifact-video-links",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    await expect(
+      screen.findByLabelText("Preview 97ngzkxdyn.mp4"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getAllByLabelText("Preview 97ngzkxdyn.mp4")).toHaveLength(1);
+    expect(
+      screen.getByText(incompletePath, { exact: false }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(rootRelativePath, { exact: false }),
+    ).toBeInTheDocument();
+  });
+
   it("renders other short artifact urls with their preview ui", async () => {
     const urls = {
       audio: "https://cdn.vm7.io/artifacts/0000000001.mp3",


### PR DESCRIPTION
## Summary

- require flat V2 artifact preview URLs to include an explicit trusted vm0 origin
- keep incomplete flat paths as ordinary Markdown while preserving legacy relative artifact routes
- add page-level regression coverage and document the URL boundary

## Verification

- pnpm format
- NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- staged workspace, Platform, and API type checks
- focused Platform tests for complete vm0 short URLs, incomplete flat paths, and external native video links