### PR TITLE
perf(runner): correlate preference reuse outcomes

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -39,7 +39,9 @@ use crate::idle_pool::{
 use crate::ids::RunId;
 use crate::lifecycle::RunnerMode;
 use crate::paths::short_digest;
-use crate::provider::{ClaimedJob, JobCandidate, RunnerPreferenceReason};
+use crate::provider::{
+    ClaimedJob, JobCandidate, RunnerPreferenceReason, RunnerPreferenceRemovalReason,
+};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::run_cancellation::{
     RunCancellationHandle, RunCancellationRegistration, RunCancellationRegistry,
@@ -762,16 +764,22 @@ async fn prepare_preference_candidate(
         return ordinary_preparation(candidate);
     };
     if preference.is_expired() {
-        return ordinary_preparation(candidate.without_runner_preference());
+        return ordinary_preparation(
+            candidate.without_runner_preference(RunnerPreferenceRemovalReason::Expired),
+        );
     }
     let Some(reuse_key) = candidate.reuse_key().map(str::to_owned) else {
-        return ordinary_preparation(candidate.without_runner_preference());
+        return ordinary_preparation(
+            candidate.without_runner_preference(RunnerPreferenceRemovalReason::Cleared),
+        );
     };
 
     match preference.reason() {
         RunnerPreferenceReason::ExactHistoryGeneration => {
             let Some(history_generation_run_id) = candidate.history_generation_run_id() else {
-                return ordinary_preparation(candidate.without_runner_preference());
+                return ordinary_preparation(
+                    candidate.without_runner_preference(RunnerPreferenceRemovalReason::Cleared),
+                );
             };
             if let Some(reservation) = reserve_reusable_idle(
                 &reuse_key,
@@ -817,7 +825,9 @@ async fn prepare_preference_candidate(
         }
         RunnerPreferenceReason::FinalizingPredecessor => {
             let Some(history_generation_run_id) = candidate.history_generation_run_id() else {
-                return ordinary_preparation(candidate.without_runner_preference());
+                return ordinary_preparation(
+                    candidate.without_runner_preference(RunnerPreferenceRemovalReason::Cleared),
+                );
             };
             if let Some(reservation) = reserve_reusable_idle(
                 &reuse_key,
@@ -833,7 +843,9 @@ async fn prepare_preference_candidate(
 
             if preference.targets(ctx.runner_id, ctx.heartbeat_generation) {
                 if !contains_active_reuse_key(&ctx.spawn_ctx.active_reuse_keys, &reuse_key) {
-                    return ordinary_preparation(candidate.without_runner_preference());
+                    return ordinary_preparation(
+                        candidate.without_runner_preference(RunnerPreferenceRemovalReason::Cleared),
+                    );
                 }
                 return defer_preference_candidate(candidate, &preference, &reuse_key, ctx, true)
                     .await;
@@ -881,7 +893,9 @@ async fn defer_preference_candidate(
     retain: bool,
 ) -> PreferencePreparation {
     if preference.is_expired() {
-        return ordinary_preparation(candidate.without_runner_preference());
+        return ordinary_preparation(
+            candidate.without_runner_preference(RunnerPreferenceRemovalReason::Expired),
+        );
     }
     let delay = preference.remaining();
     info!(

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -65,7 +65,7 @@ use crate::paths::{HomePaths, LogPaths, RunnerPaths, touch_mtime};
 use crate::prefetch;
 use crate::provider::{
     ApiProvider, ApiProviderConfig, BuiltinFirewallCatalogCachePaths, JobCandidate, JobProvider,
-    LocalProvider, NetworkPolicyRefreshHandle,
+    LocalProvider, NetworkPolicyRefreshHandle, RunnerPreferenceRemovalReason,
 };
 use crate::proxy;
 use crate::resource_budget::ResourceBudget;
@@ -1854,7 +1854,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 let Some(candidate) = pending_finalizing_candidate.take() else {
                     continue;
                 };
-                let candidate = candidate.without_runner_preference();
+                let candidate = candidate
+                    .without_runner_preference(RunnerPreferenceRemovalReason::Expired);
                 let result = handle_discovered_job(
                     DiscoveredJob { candidate },
                     DiscoveredJobContext {

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -10,7 +10,10 @@ use std::sync::Arc;
 
 use super::super::super::active_reuse_keys::ActiveReuseKeyGuard;
 use crate::paths::RunnerPaths;
-use crate::provider::{RunnerPreference, RunnerPreferenceReason};
+use crate::provider::{
+    RunnerPreference, RunnerPreferenceClaimState, RunnerPreferenceReason,
+    RunnerPreferenceResolution,
+};
 use crate::types::SandboxReuseResult;
 use crate::workspace_image_cache::WorkspaceImageCache;
 
@@ -35,14 +38,28 @@ fn preferred_candidate_until(
     reason: RunnerPreferenceReason,
     deadline: std::time::Instant,
 ) -> crate::provider::JobCandidate {
+    let resolution = match reason {
+        RunnerPreferenceReason::ExactHistoryGeneration => {
+            RunnerPreferenceResolution::ExactHistoryGeneration
+        }
+        RunnerPreferenceReason::MatchingReuseKey => {
+            RunnerPreferenceResolution::MatchingReusableSandbox
+        }
+        RunnerPreferenceReason::FinalizingPredecessor => {
+            RunnerPreferenceResolution::FinalizingPredecessor
+        }
+    };
     crate::provider::JobCandidate::new(run_id, "vm0/default".into())
         .with_reuse_key(reuse_key.map(str::to_owned))
-        .with_runner_preference(Some(RunnerPreference::for_test(
-            uuid::Uuid::from_u128(NON_SELECTED_RUNNER_ID),
-            1,
-            reason,
-            deadline,
-        )))
+        .with_runner_preference_context(
+            Some(RunnerPreference::for_test(
+                uuid::Uuid::from_u128(NON_SELECTED_RUNNER_ID),
+                1,
+                reason,
+                deadline,
+            )),
+            Some(resolution),
+        )
 }
 
 fn matching_preference_candidate(run_id: RunId, session_id: &str) -> crate::provider::JobCandidate {
@@ -94,12 +111,15 @@ fn finalizing_candidate_until(
     crate::provider::JobCandidate::new(run_id, "vm0/default".into())
         .with_reuse_key(Some(reuse_key.to_owned()))
         .with_history_generation_run_id(Some(history_generation_run_id))
-        .with_runner_preference(Some(RunnerPreference::for_test(
-            runner_id.parse().unwrap(),
-            heartbeat_generation,
-            RunnerPreferenceReason::FinalizingPredecessor,
-            deadline,
-        )))
+        .with_runner_preference_context(
+            Some(RunnerPreference::for_test(
+                runner_id.parse().unwrap(),
+                heartbeat_generation,
+                RunnerPreferenceReason::FinalizingPredecessor,
+                deadline,
+            )),
+            Some(RunnerPreferenceResolution::FinalizingPredecessor),
+        )
 }
 
 fn context_with_reuse_key(run_id: RunId, reuse_key: &str) -> crate::types::ExecutionContext {
@@ -624,6 +644,24 @@ async fn selected_finalizing_candidate_keeps_reactor_live_and_claims_after_key_r
         "active-key release without a reusable resource should wake ordinary admission"
     );
     assert_eq!(env.handle.deferred_poll_deadlines().len(), 1);
+    let claimed = env
+        .handle
+        .claim_candidates()
+        .into_iter()
+        .find(|candidate| candidate.run_id() == pending_run_id)
+        .expect("released finalizing candidate should reach claim");
+    let preference_telemetry = claimed
+        .runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION)
+        .expect("finalizing observation should survive retention and clearing");
+    assert_eq!(
+        preference_telemetry.resolution,
+        RunnerPreferenceResolution::FinalizingPredecessor
+    );
+    assert_eq!(
+        preference_telemetry.state,
+        RunnerPreferenceClaimState::Cleared
+    );
+    assert_eq!(preference_telemetry.targeted_self, Some(true));
 
     shutdown(&env, run_handle).await;
 }
@@ -826,6 +864,18 @@ async fn same_run_duplicate_does_not_renew_pending_finalizing_deadline() {
         claimed.runner_preference().is_none(),
         "expiry should clear the advisory preference before ordinary admission"
     );
+    let preference_telemetry = claimed
+        .runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION)
+        .expect("finalizing observation should survive expiry");
+    assert_eq!(
+        preference_telemetry.resolution,
+        RunnerPreferenceResolution::FinalizingPredecessor
+    );
+    assert_eq!(
+        preference_telemetry.state,
+        RunnerPreferenceClaimState::Expired
+    );
+    assert_eq!(preference_telemetry.targeted_self, Some(true));
 
     drop(predecessor_guard);
     shutdown(&env, run_handle).await;
@@ -998,12 +1048,15 @@ async fn selected_finalizing_candidate_without_reuse_key_uses_ordinary_admission
         .send(
             crate::provider::JobCandidate::new(run_id, "vm0/default".into())
                 .with_history_generation_run_id(Some(RunId::new_v4()))
-                .with_runner_preference(Some(RunnerPreference::for_test(
-                    TEST_RUNNER_ID.parse().unwrap(),
-                    TEST_HEARTBEAT_GENERATION,
-                    RunnerPreferenceReason::FinalizingPredecessor,
-                    std::time::Instant::now() + Duration::from_secs(30),
-                ))),
+                .with_runner_preference_context(
+                    Some(RunnerPreference::for_test(
+                        TEST_RUNNER_ID.parse().unwrap(),
+                        TEST_HEARTBEAT_GENERATION,
+                        RunnerPreferenceReason::FinalizingPredecessor,
+                        std::time::Instant::now() + Duration::from_secs(30),
+                    )),
+                    Some(RunnerPreferenceResolution::FinalizingPredecessor),
+                ),
         )
         .unwrap();
 
@@ -1025,6 +1078,18 @@ async fn selected_finalizing_candidate_without_reuse_key_uses_ordinary_admission
         claimed.runner_preference().is_none(),
         "ordinary admission should clear the incomplete advisory preference"
     );
+    let preference_telemetry = claimed
+        .runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION)
+        .expect("incomplete finalizing metadata should preserve its observation");
+    assert_eq!(
+        preference_telemetry.resolution,
+        RunnerPreferenceResolution::FinalizingPredecessor
+    );
+    assert_eq!(
+        preference_telemetry.state,
+        RunnerPreferenceClaimState::Cleared
+    );
+    assert_eq!(preference_telemetry.targeted_self, Some(true));
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -52,7 +52,7 @@ use super::session_restore::{
     MaterializedResumeSession, SessionRestoreDiagnostics, restore_session,
 };
 use super::storage::download_storages;
-use super::telemetry::{RunnerSpawnTiming, record_api_latency};
+use super::telemetry::{RunnerSpawnTiming, record_api_to_spawn};
 use super::workspace_session_history_materializer::{
     WorkspaceSessionHistoryMaterialization, WorkspaceSessionHistoryPhaseTiming,
     WorkspaceSessionHistoryTimings,
@@ -2219,7 +2219,12 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     } = prepared_agent;
 
     // Claude Code process has a PID now — record end-to-end startup latency.
-    record_api_latency("api_to_spawn", context, telemetry);
+    record_api_to_spawn(
+        context,
+        telemetry,
+        start.reuse_result,
+        start.prev_storage.is_some(),
+    );
 
     // Start locally owned input and output work, then release deferred cache
     // fill now that process spawn has succeeded.

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -9,7 +9,7 @@ use guest_contracts::epoch_milliseconds::{
 use tracing::warn;
 
 use crate::guest_timezone::GuestTimezoneAssumption;
-use crate::telemetry::JobTelemetry;
+use crate::telemetry::{JobTelemetry, RunnerStartupPath};
 use crate::types::{ExecutionContext, SandboxReuseResult};
 use crate::workspace_image_cache::WorkspaceCacheCheckoutResult;
 
@@ -318,14 +318,39 @@ pub(super) fn record_api_latency(
     context: &ExecutionContext,
     telemetry: &mut JobTelemetry,
 ) {
+    if let Some(duration) = api_latency_duration(action_type, context) {
+        telemetry.record(action_type, duration, true, None);
+    }
+}
+
+pub(super) fn record_api_to_spawn(
+    context: &ExecutionContext,
+    telemetry: &mut JobTelemetry,
+    sandbox_reuse_result: SandboxReuseResult,
+    reused_workspace: bool,
+) {
+    let runner_startup_path = if sandbox_reuse_result == SandboxReuseResult::Reused {
+        RunnerStartupPath::Sandbox
+    } else if reused_workspace {
+        RunnerStartupPath::Workspace
+    } else {
+        RunnerStartupPath::Cold
+    };
+    if let Some(duration) = api_latency_duration("api_to_spawn", context) {
+        telemetry.record_api_to_spawn(duration, runner_startup_path, sandbox_reuse_result);
+    }
+}
+
+fn api_latency_duration(action_type: &str, context: &ExecutionContext) -> Option<Duration> {
     if let Some(api_start_ms) = context.api_start_time {
         let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
         if let Some(duration) = elapsed_since_api_start_ms(api_start_ms, now_ms) {
-            telemetry.record(action_type, duration, true, None);
+            return Some(duration);
         } else {
             warn_invalid_api_start_time_once(action_type, context, api_start_ms);
         }
     }
+    None
 }
 
 pub(super) fn warn_invalid_api_start_time_once(

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -6,11 +6,33 @@ use sha2::{Digest, Sha256};
 use crate::executor::session_history_cpu::{SessionHistoryCpuPool, SessionHistoryCpuTestGate};
 use crate::executor::tests::support::RUN_IN_SANDBOX_TEST_TIMEOUT;
 use crate::executor::{SessionHistoryRestoreFallback, SessionHistoryRestorePlan};
+use crate::telemetry::{JobTelemetry, RunnerStartupPath};
 use crate::types::{
     ResumeSessionHistory, ResumeSessionHistoryEncoding, ResumeSessionHistoryRef,
     ResumeSessionHistoryRefKind,
 };
 use crate::workspace_image_cache::WorkspaceSessionHistorySidecarRepresentation;
+
+fn enable_api_start_telemetry(context: &mut crate::types::ExecutionContext) {
+    context.api_start_time = Some(chrono::Utc::now().timestamp_millis().max(0) as u64);
+}
+
+fn assert_api_to_spawn_path(
+    telemetry: &JobTelemetry,
+    expected_path: RunnerStartupPath,
+    expected_reuse_result: SandboxReuseResult,
+) {
+    let operations = telemetry.pending_ops_with_runner_startup_snapshot();
+    let startup_operations: Vec<_> = operations
+        .iter()
+        .filter(|operation| operation.action_type == "api_to_spawn")
+        .collect();
+    let [operation] = startup_operations.as_slice() else {
+        panic!("expected one api_to_spawn operation, got {operations:?}");
+    };
+    assert_eq!(operation.runner_startup_path, Some(expected_path));
+    assert_eq!(operation.sandbox_reuse_result, Some(expected_reuse_result));
+}
 
 struct MaterializationObservedFactory {
     inner: MockSandboxFactory,
@@ -76,6 +98,7 @@ async fn workspace_sidecar_materialization_overlaps_sandbox_creation() {
         })
         .await;
     let mut ctx = minimal_context();
+    enable_api_start_telemetry(&mut ctx);
     set_reuse_and_session_history_ref(
         &mut ctx,
         "sess-cache-sidecar-overlap",
@@ -126,6 +149,11 @@ async fn workspace_sidecar_materialization_overlaps_sandbox_creation() {
 
     assert_eq!(outcome.exit_code(), 0);
     assert!(outcome.workspace_image.is_some());
+    assert_api_to_spawn_path(
+        &telemetry,
+        RunnerStartupPath::Workspace,
+        SandboxReuseResult::PoolMiss,
+    );
     assert_eq!(overrides.create_configs().len(), 1);
     let writes = overrides.write_file_calls();
     assert_eq!(writes.len(), 1);
@@ -169,6 +197,7 @@ async fn workspace_retry_cancels_sidecar_materialization_before_cache_invalidati
         })
         .await;
     let mut ctx = minimal_context();
+    enable_api_start_telemetry(&mut ctx);
     set_reuse_and_session_history_ref(
         &mut ctx,
         "sess-cache-sidecar-retry",
@@ -225,6 +254,11 @@ async fn workspace_retry_cancels_sidecar_materialization_before_cache_invalidati
     .expect("cancelled sidecar CPU work should finish");
     assert_eq!(outcome.exit_code(), 0);
     assert!(outcome.workspace_image.is_none());
+    assert_api_to_spawn_path(
+        &telemetry,
+        RunnerStartupPath::Cold,
+        SandboxReuseResult::PoolMiss,
+    );
     assert_eq!(overrides.create_configs().len(), 2);
     assert!(!expected_seed.exists());
     let writes = overrides.write_file_calls();
@@ -1043,14 +1077,20 @@ async fn execute_job_reuse_uses_workspace_cache_when_configured() {
     let (idle_sandbox, _lease) = make_reusable_idle_sandbox(sandbox, source_ip, session_id).await;
 
     let mut ctx = minimal_context();
+    enable_api_start_telemetry(&mut ctx);
     set_reuse_and_session_identity(&mut ctx, session_id, r#"{"type":"init"}"#);
 
     let cancel = tokio_util::sync::CancellationToken::new();
-    let (reuse_outcome, _telemetry) =
+    let (reuse_outcome, telemetry) =
         execute_job_reuse(idle_sandbox, ctx, &config, &params, cancel).await;
 
     assert_eq!(reuse_outcome.exit_code(), 0);
     assert!(reuse_outcome.workspace_image.is_some());
+    assert_api_to_spawn_path(
+        &telemetry,
+        RunnerStartupPath::Sandbox,
+        SandboxReuseResult::Reused,
+    );
 
     let checkout = cache
         .prepare(WorkspaceImagePrepareRequest {

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -12,7 +12,7 @@ use sandbox::{
 use sandbox_mock::MockSandboxFactory;
 
 use super::super::telemetry::{
-    RunnerPreSpawnPhase, elapsed_since_api_start_ms, record_reuse_result,
+    RunnerPreSpawnPhase, elapsed_since_api_start_ms, record_api_to_spawn, record_reuse_result,
 };
 use super::super::{
     ExactReuseSpeculationTiming, ExecutionHooks, NewSandboxDispatch, RunnerPreSpawnOperationTiming,
@@ -26,7 +26,7 @@ use crate::guest_timezone::GuestTimezoneAssumption;
 use crate::http::{HttpClient, HttpClientConfig};
 use crate::ids::RunId;
 use crate::run_cancellation::RunCancellationSignals;
-use crate::telemetry::JobTelemetry;
+use crate::telemetry::{JobTelemetry, RunnerStartupPath};
 use crate::types::SandboxReuseResult;
 
 #[test]
@@ -48,6 +48,52 @@ fn elapsed_since_api_start_ms_rejects_seconds_shaped_start() {
     let duration = elapsed_since_api_start_ms(1_700_000_000, 1_700_000_001_250);
 
     assert_eq!(duration, None);
+}
+
+#[test]
+fn api_to_spawn_records_the_effective_startup_path_and_exact_reuse_result() {
+    for (reuse_result, reused_workspace, expected_path) in [
+        (
+            SandboxReuseResult::Reused,
+            false,
+            RunnerStartupPath::Sandbox,
+        ),
+        (
+            SandboxReuseResult::NoReuseKey,
+            true,
+            RunnerStartupPath::Workspace,
+        ),
+        (SandboxReuseResult::PoolMiss, false, RunnerStartupPath::Cold),
+        (
+            SandboxReuseResult::ProfileMismatch,
+            false,
+            RunnerStartupPath::Cold,
+        ),
+        (
+            SandboxReuseResult::DeviceLimitMismatch,
+            false,
+            RunnerStartupPath::Cold,
+        ),
+        (
+            SandboxReuseResult::UnparkFailed,
+            false,
+            RunnerStartupPath::Cold,
+        ),
+    ] {
+        let mut context = minimal_context();
+        context.api_start_time = Some(chrono::Utc::now().timestamp_millis().max(0) as u64);
+        let mut telemetry = new_telemetry();
+
+        record_api_to_spawn(&context, &mut telemetry, reuse_result, reused_workspace);
+
+        let operations = telemetry.pending_ops_with_runner_startup_snapshot();
+        let [operation] = operations.as_slice() else {
+            panic!("expected one api_to_spawn operation, got {operations:?}");
+        };
+        assert_eq!(operation.action_type, "api_to_spawn");
+        assert_eq!(operation.runner_startup_path, Some(expected_path));
+        assert_eq!(operation.sandbox_reuse_result, Some(reuse_result));
+    }
 }
 
 // -----------------------------------------------------------------------

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -31,7 +31,8 @@ use super::builtin_firewall_catalog::{
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
-    parse_runner_preference,
+    RunnerPreferenceClaimState, RunnerPreferenceResolution, parse_runner_preference,
+    parse_runner_preference_resolution,
 };
 use crate::active_input::{ActiveInputNotifications, ActiveInputSource};
 use crate::duration::duration_ms;
@@ -85,6 +86,12 @@ struct ClaimRequestTelemetry {
     poll_http_request_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     poll_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    runner_preference_resolution: Option<RunnerPreferenceResolution>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    runner_preference_claim_state: Option<RunnerPreferenceClaimState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    runner_preference_targeted_self: Option<bool>,
 }
 
 #[derive(Serialize)]
@@ -586,12 +593,28 @@ impl JobProvider for ApiProvider {
                             None
                         }
                     };
+                    let runner_preference_resolution = match parse_runner_preference_resolution(
+                        job.runner_preference_resolution,
+                    ) {
+                        Ok(resolution) => resolution,
+                        Err(error) => {
+                            warn!(
+                                run_id = %run_id,
+                                error = %error,
+                                "poll: invalid runner preference resolution, omitting telemetry context"
+                            );
+                            None
+                        }
+                    };
                     let profile = job.experimental_profile;
                     info!(run_id = %run_id, %profile, poll_reason = ?reason, "poll: job found");
                     let mut candidate = JobCandidate::new(run_id, profile)
                         .with_reuse_key(reuse_key)
                         .with_history_generation_run_id(history_generation_run_id)
-                        .with_runner_preference(runner_preference)
+                        .with_runner_preference_context(
+                            runner_preference,
+                            runner_preference_resolution,
+                        )
                         .with_discovery_source(JobDiscoverySource::Poll)
                         .with_poll_reason(poll_reason_value(reason))
                         .with_poll_timing(poll_due_started_at.elapsed(), http_request_elapsed);
@@ -1217,6 +1240,8 @@ fn claim_request_body<'a>(
     runner_id: &'a str,
     heartbeat_generation: u64,
 ) -> ClaimRequestBody<'a> {
+    let runner_preference_telemetry =
+        candidate.runner_preference_claim_telemetry(runner_id, heartbeat_generation);
     let is_ably_candidate = candidate.discovery_source() == Some(JobDiscoverySource::Ably);
     let (
         direct_candidate_notification_to_enqueue_ms,
@@ -1266,6 +1291,12 @@ fn claim_request_body<'a>(
                 .poll_http_request_elapsed()
                 .map(claim_telemetry_duration_ms),
             poll_reason: candidate.poll_reason().map(String::from),
+            runner_preference_resolution: runner_preference_telemetry
+                .map(|telemetry| telemetry.resolution),
+            runner_preference_claim_state: runner_preference_telemetry
+                .map(|telemetry| telemetry.state),
+            runner_preference_targeted_self: runner_preference_telemetry
+                .and_then(|telemetry| telemetry.targeted_self),
         },
     }
 }
@@ -1603,7 +1634,9 @@ mod tests {
     use uuid::Uuid;
 
     use crate::http::HttpClientConfig;
-    use crate::provider::RunnerPreferenceReason;
+    use crate::provider::{
+        RunnerPreference, RunnerPreferenceReason, RunnerPreferenceRemovalReason,
+    };
 
     const RUNNER_CLAIM_RESPONSE_FIXTURE: &str = include_str!(
         "../../../../turbo/packages/api-contracts/src/contracts/__tests__/fixtures/runner-claim-response.json"
@@ -2180,6 +2213,21 @@ mod tests {
         assert_eq!(body["telemetry"]["pollDueToJobDiscoveredMs"], 19);
         assert_eq!(body["telemetry"]["pollHttpRequestMs"], 11);
         assert_eq!(body["telemetry"]["pollReason"], "deferred");
+        assert!(
+            body["telemetry"]
+                .get("runnerPreferenceResolution")
+                .is_none()
+        );
+        assert!(
+            body["telemetry"]
+                .get("runnerPreferenceClaimState")
+                .is_none()
+        );
+        assert!(
+            body["telemetry"]
+                .get("runnerPreferenceTargetedSelf")
+                .is_none()
+        );
         assert!(body.get("runnerPreference").is_none());
         assert!(!body.to_string().contains("rawSizeBytes"));
         assert!(!body.to_string().contains("sessionId"));
@@ -2187,6 +2235,86 @@ mod tests {
         assert!(!body.to_string().contains("cacheKey"));
         assert!(!body.to_string().contains("path"));
         assert!(body.get("capabilities").is_none());
+    }
+
+    #[test]
+    fn claim_request_body_serializes_preference_observation_at_claim_time() {
+        let active_preference = RunnerPreference::for_test(
+            TEST_RUNNER_ID.parse().unwrap(),
+            TEST_HEARTBEAT_GENERATION,
+            RunnerPreferenceReason::MatchingReuseKey,
+            Instant::now() + Duration::from_secs(60),
+        );
+        let active = JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
+            .with_runner_preference_context(
+                Some(active_preference),
+                Some(RunnerPreferenceResolution::MatchingWorkspaceCache),
+            );
+        let active_body = serde_json::to_value(claim_request_body_for_test(&active)).unwrap();
+        assert_eq!(
+            active_body["telemetry"]["runnerPreferenceResolution"],
+            "matching_workspace_cache"
+        );
+        assert_eq!(
+            active_body["telemetry"]["runnerPreferenceClaimState"],
+            "active"
+        );
+        assert_eq!(
+            active_body["telemetry"]["runnerPreferenceTargetedSelf"],
+            true
+        );
+
+        let expired_preference = RunnerPreference::for_test(
+            TEST_RUNNER_ID.parse().unwrap(),
+            TEST_HEARTBEAT_GENERATION,
+            RunnerPreferenceReason::ExactHistoryGeneration,
+            Instant::now() - Duration::from_secs(1),
+        );
+        let expired = JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
+            .with_runner_preference_context(
+                Some(expired_preference),
+                Some(RunnerPreferenceResolution::ExactHistoryGeneration),
+            );
+        let expired_body = serde_json::to_value(claim_request_body_for_test(&expired)).unwrap();
+        assert_eq!(
+            expired_body["telemetry"]["runnerPreferenceClaimState"],
+            "expired"
+        );
+
+        let cleared_preference = RunnerPreference::for_test(
+            Uuid::from_u128(8),
+            TEST_HEARTBEAT_GENERATION,
+            RunnerPreferenceReason::FinalizingPredecessor,
+            Instant::now() + Duration::from_secs(60),
+        );
+        let cleared = JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
+            .with_runner_preference_context(
+                Some(cleared_preference),
+                Some(RunnerPreferenceResolution::FinalizingPredecessor),
+            )
+            .without_runner_preference(RunnerPreferenceRemovalReason::Cleared);
+        let cleared_body = serde_json::to_value(claim_request_body_for_test(&cleared)).unwrap();
+        assert_eq!(
+            cleared_body["telemetry"]["runnerPreferenceClaimState"],
+            "cleared"
+        );
+        assert_eq!(
+            cleared_body["telemetry"]["runnerPreferenceTargetedSelf"],
+            false
+        );
+
+        let absent = JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
+            .with_runner_preference_context(None, Some(RunnerPreferenceResolution::NoViableHolder));
+        let absent_body = serde_json::to_value(claim_request_body_for_test(&absent)).unwrap();
+        assert_eq!(
+            absent_body["telemetry"]["runnerPreferenceClaimState"],
+            "absent"
+        );
+        assert!(
+            absent_body["telemetry"]
+                .get("runnerPreferenceTargetedSelf")
+                .is_none()
+        );
     }
 
     #[test]
@@ -2410,6 +2538,7 @@ mod tests {
                         "experimentalProfile": "vm0/large",
                         "cliAgentSessionId": "sess-poll",
                         "historyGenerationRunId": history_generation_run_id,
+                        "runnerPreferenceResolution": "exact_history_generation",
                         "runnerPreference": {
                             "runnerIdentity": {
                                 "runnerId": "00000000-0000-0000-0000-000000000005",
@@ -2449,6 +2578,15 @@ mod tests {
         );
         assert!(preference.targets("00000000-0000-0000-0000-000000000005", 7));
         assert_eq!(
+            discovered
+                .runner_preference_claim_telemetry("00000000-0000-0000-0000-000000000005", 7,),
+            Some(super::super::RunnerPreferenceClaimTelemetry {
+                resolution: RunnerPreferenceResolution::ExactHistoryGeneration,
+                state: RunnerPreferenceClaimState::Active,
+                targeted_self: Some(true),
+            })
+        );
+        assert_eq!(
             discovered.discovery_source(),
             Some(JobDiscoverySource::Poll)
         );
@@ -2469,6 +2607,7 @@ mod tests {
                         "runId": run_id,
                         "experimentalProfile": "vm0/default",
                         "reuseKey": "thread:malformed-preference",
+                        "runnerPreferenceResolution": "matching_workspace_cache",
                         "runnerPreference": {
                             "runnerIdentity": {
                                 "runnerId": TEST_RUNNER_ID,
@@ -2496,6 +2635,51 @@ mod tests {
         assert_eq!(candidate.run_id(), run_id);
         assert_eq!(candidate.reuse_key(), Some("thread:malformed-preference"));
         assert!(candidate.runner_preference().is_none());
+        assert_eq!(
+            candidate.runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION,),
+            Some(super::super::RunnerPreferenceClaimTelemetry {
+                resolution: RunnerPreferenceResolution::MatchingWorkspaceCache,
+                state: RunnerPreferenceClaimState::Cleared,
+                targeted_self: None,
+            })
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn discover_preserves_poll_job_with_future_resolution() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::new_v4();
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(routes::runners::poll::POLL.path);
+                then.status(200).json_body(serde_json::json!({
+                    "job": {
+                        "runId": run_id,
+                        "experimentalProfile": "vm0/default",
+                        "runnerPreferenceResolution": "future_resolution"
+                    }
+                }));
+            })
+            .await;
+        let provider = api_provider_for_test_with_supported_profiles(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+            vec!["vm0/default".to_string()],
+        );
+
+        let candidate = tokio::time::timeout(Duration::from_secs(1), provider.discover())
+            .await
+            .expect("discover should preserve the job")
+            .expect("job candidate");
+
+        assert_eq!(candidate.run_id(), run_id);
+        assert!(
+            candidate
+                .runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION,)
+                .is_none()
+        );
         mock.assert_async().await;
     }
 

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -27,7 +27,10 @@ use super::api_direct_candidates::{
     DirectJobCandidate,
 };
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
-use super::{RunnerPreference, parse_runner_preference};
+use super::{
+    RunnerPreference, RunnerPreferenceResolution, parse_runner_preference,
+    parse_runner_preference_resolution,
+};
 use crate::active_input::ActiveInputNotifications;
 use crate::duration::duration_ms;
 use crate::ids::RunId;
@@ -709,6 +712,7 @@ async fn handle_ably_message_with_network_policy_refresh(
                         notif.reuse_key.map(str::to_owned),
                         notif.runner_preference,
                     )
+                    .with_runner_preference_resolution(notif.runner_preference_resolution)
                     .with_history_generation_run_id(notif.history_generation_run_id),
                 )
             } else {
@@ -751,6 +755,7 @@ struct JobNotification<'a> {
     reuse_key: Option<&'a str>,
     history_generation_run_id: Option<RunId>,
     runner_preference: Option<RunnerPreference>,
+    runner_preference_resolution: Option<RunnerPreferenceResolution>,
 }
 
 struct NetworkPolicyRefreshNotification {
@@ -957,12 +962,26 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
             None
         }
     };
+    let runner_preference_resolution = match parse_runner_preference_resolution(
+        msg.data.get("runnerPreferenceResolution").cloned(),
+    ) {
+        Ok(resolution) => resolution,
+        Err(error) => {
+            warn!(
+                run_id = %run_id,
+                error = %error,
+                "ably: invalid runner preference resolution, omitting telemetry context"
+            );
+            None
+        }
+    };
     Some(JobNotification {
         run_id,
         profile,
         reuse_key,
         history_generation_run_id,
         runner_preference,
+        runner_preference_resolution,
     })
 }
 
@@ -1903,6 +1922,7 @@ mod tests {
                 "profile": "vm0/default",
                 "reuseKey": "thread:chat-thread",
                 "historyGenerationRunId": "00000000-0000-0000-0000-000000000098",
+                "runnerPreferenceResolution": "matching_reusable_sandbox",
                 "runnerPreference": {
                     "runnerIdentity": {
                         "runnerId": "00000000-0000-0000-0000-000000000005",
@@ -1936,6 +1956,14 @@ mod tests {
             RunnerPreferenceReason::MatchingReuseKey
         );
         assert!(preference.targets("00000000-0000-0000-0000-000000000005", 7));
+        assert_eq!(
+            candidate.runner_preference_claim_telemetry("00000000-0000-0000-0000-000000000005", 7,),
+            Some(super::super::RunnerPreferenceClaimTelemetry {
+                resolution: RunnerPreferenceResolution::MatchingReusableSandbox,
+                state: super::super::RunnerPreferenceClaimState::Active,
+                targeted_self: Some(true),
+            })
+        );
         assert_no_direct_candidate(&direct_candidates).await;
         assert!(!wakeups.snapshot().await.poll_now);
     }
@@ -1959,6 +1987,7 @@ mod tests {
                 "runId": "00000000-0000-0000-0000-000000000011",
                 "profile": "vm0/default",
                 "reuseKey": "thread:malformed-preference",
+                "runnerPreferenceResolution": "future_resolution",
                 "runnerPreference": {
                     "runnerIdentity": {
                         "runnerId": "00000000-0000-0000-0000-000000000005",
@@ -1977,6 +2006,11 @@ mod tests {
             .into_job_candidate();
         assert_eq!(candidate.reuse_key(), Some("thread:malformed-preference"));
         assert!(candidate.runner_preference().is_none());
+        assert!(
+            candidate
+                .runner_preference_claim_telemetry("00000000-0000-0000-0000-000000000005", 7,)
+                .is_none()
+        );
         assert_no_direct_candidate(&direct_candidates).await;
     }
 

--- a/crates/runner/src/provider/api_direct_candidates.rs
+++ b/crates/runner/src/provider/api_direct_candidates.rs
@@ -6,7 +6,7 @@ use tokio::sync::{Mutex, Notify};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-use super::{JobCandidate, JobDiscoverySource, RunnerPreference};
+use super::{JobCandidate, JobDiscoverySource, RunnerPreference, RunnerPreferenceResolution};
 use crate::ids::RunId;
 
 pub(super) const DIRECT_CANDIDATE_STALE_AFTER: Duration = Duration::from_secs(60);
@@ -20,6 +20,7 @@ pub(super) struct DirectJobCandidate {
     reuse_key: Option<String>,
     history_generation_run_id: Option<RunId>,
     runner_preference: Option<RunnerPreference>,
+    runner_preference_resolution: Option<RunnerPreferenceResolution>,
 }
 
 impl DirectJobCandidate {
@@ -65,6 +66,7 @@ impl DirectJobCandidate {
             reuse_key,
             history_generation_run_id: None,
             runner_preference,
+            runner_preference_resolution: None,
         }
     }
 
@@ -100,6 +102,14 @@ impl DirectJobCandidate {
         self
     }
 
+    pub(super) fn with_runner_preference_resolution(
+        mut self,
+        runner_preference_resolution: Option<RunnerPreferenceResolution>,
+    ) -> Self {
+        self.runner_preference_resolution = runner_preference_resolution;
+        self
+    }
+
     pub(super) fn into_job_candidate(self) -> JobCandidate {
         let dequeued_at = StdInstant::now();
         let notification_to_enqueue_elapsed = self
@@ -111,7 +121,10 @@ impl DirectJobCandidate {
         JobCandidate::new_with_discovered_at(self.run_id, self.profile_name, self.discovered_at)
             .with_reuse_key(self.reuse_key)
             .with_history_generation_run_id(self.history_generation_run_id)
-            .with_runner_preference(self.runner_preference)
+            .with_runner_preference_context(
+                self.runner_preference,
+                self.runner_preference_resolution,
+            )
             .with_discovery_source(JobDiscoverySource::Ably)
             .with_direct_candidate_timing(notification_to_enqueue_elapsed, inbox_wait_elapsed)
     }
@@ -138,6 +151,7 @@ impl DirectJobCandidate {
         self.reuse_key = candidate.reuse_key;
         self.history_generation_run_id = candidate.history_generation_run_id;
         self.runner_preference = candidate.runner_preference;
+        self.runner_preference_resolution = candidate.runner_preference_resolution;
     }
 }
 
@@ -417,17 +431,22 @@ mod tests {
 
         let first_deadline = StdInstant::now() + Duration::from_secs(5);
         let inserted = inbox
-            .push(DirectJobCandidate::new_with_routing_metadata(
-                run_id,
-                "vm0/default".to_string(),
-                first_discovered_at,
-                Some("session:sess-1".to_string()),
-                Some(runner_preference(
-                    10,
-                    super::super::RunnerPreferenceReason::MatchingReuseKey,
-                    first_deadline,
+            .push(
+                DirectJobCandidate::new_with_routing_metadata(
+                    run_id,
+                    "vm0/default".to_string(),
+                    first_discovered_at,
+                    Some("session:sess-1".to_string()),
+                    Some(runner_preference(
+                        10,
+                        super::super::RunnerPreferenceReason::MatchingReuseKey,
+                        first_deadline,
+                    )),
+                )
+                .with_runner_preference_resolution(Some(
+                    RunnerPreferenceResolution::MatchingReusableSandbox,
                 )),
-            ))
+            )
             .await;
         assert_eq!(
             inserted.snapshot(),
@@ -451,6 +470,9 @@ mod tests {
                         exact_deadline,
                     )),
                 )
+                .with_runner_preference_resolution(Some(
+                    RunnerPreferenceResolution::ExactHistoryGeneration,
+                ))
                 .with_history_generation_run_id(Some(history_generation_run_id)),
             )
             .await;
@@ -466,17 +488,22 @@ mod tests {
         ));
 
         let renewed = inbox
-            .push(DirectJobCandidate::new_with_routing_metadata(
-                run_id,
-                "vm0/default".to_string(),
-                second_discovered_at,
-                Some("session:must-not-renew".to_string()),
-                Some(runner_preference(
-                    30,
-                    super::super::RunnerPreferenceReason::ExactHistoryGeneration,
-                    StdInstant::now() + Duration::from_secs(30),
+            .push(
+                DirectJobCandidate::new_with_routing_metadata(
+                    run_id,
+                    "vm0/default".to_string(),
+                    second_discovered_at,
+                    Some("session:must-not-renew".to_string()),
+                    Some(runner_preference(
+                        30,
+                        super::super::RunnerPreferenceReason::ExactHistoryGeneration,
+                        StdInstant::now() + Duration::from_secs(30),
+                    )),
+                )
+                .with_runner_preference_resolution(Some(
+                    RunnerPreferenceResolution::MatchingWorkspaceCache,
                 )),
-            ))
+            )
             .await;
         assert!(matches!(
             renewed,
@@ -501,6 +528,14 @@ mod tests {
         );
         assert_eq!(preference.deadline(), exact_deadline);
         assert!(preference.targets(&uuid::Uuid::from_u128(20).to_string(), 7));
+        assert_eq!(
+            candidate.runner_preference_claim_telemetry(&uuid::Uuid::from_u128(20).to_string(), 7,),
+            Some(super::super::RunnerPreferenceClaimTelemetry {
+                resolution: RunnerPreferenceResolution::ExactHistoryGeneration,
+                state: super::super::RunnerPreferenceClaimState::Active,
+                targeted_self: Some(true),
+            })
+        );
         assert!(
             candidate
                 .direct_candidate_notification_to_enqueue_elapsed()
@@ -527,18 +562,26 @@ mod tests {
                         StdInstant::now() + Duration::from_secs(5),
                     )),
                 )
+                .with_runner_preference_resolution(Some(
+                    RunnerPreferenceResolution::ExactHistoryGeneration,
+                ))
                 .with_history_generation_run_id(Some(run_id(4))),
             )
             .await;
 
         inbox
-            .push(DirectJobCandidate::new_with_routing_metadata(
-                candidate_run_id,
-                "vm0/default".to_string(),
-                StdInstant::now(),
-                None,
-                None,
-            ))
+            .push(
+                DirectJobCandidate::new_with_routing_metadata(
+                    candidate_run_id,
+                    "vm0/default".to_string(),
+                    StdInstant::now(),
+                    None,
+                    None,
+                )
+                .with_runner_preference_resolution(Some(
+                    RunnerPreferenceResolution::NoViableHolder,
+                )),
+            )
             .await;
 
         let candidate = inbox
@@ -549,6 +592,14 @@ mod tests {
         assert!(candidate.reuse_key().is_none());
         assert!(candidate.history_generation_run_id().is_none());
         assert!(candidate.runner_preference().is_none());
+        assert_eq!(
+            candidate.runner_preference_claim_telemetry(&uuid::Uuid::from_u128(10).to_string(), 7,),
+            Some(super::super::RunnerPreferenceClaimTelemetry {
+                resolution: RunnerPreferenceResolution::NoViableHolder,
+                state: super::super::RunnerPreferenceClaimState::Absent,
+                targeted_self: None,
+            })
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -23,7 +23,7 @@ pub(crate) use network_policy_refresh::{
 
 use chrono::{DateTime, FixedOffset, Utc};
 use sandbox::SandboxId;
-use serde::{Deserialize, Deserializer, de::Error as _};
+use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
@@ -43,12 +43,61 @@ pub(crate) enum RunnerPreferenceReason {
     FinalizingPredecessor,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RunnerPreferenceResolution {
+    ExactHistoryGeneration,
+    FinalizingPredecessor,
+    MatchingReusableSandbox,
+    MatchingWorkspaceCache,
+    NoReuseKey,
+    Expired,
+    NoViableHolder,
+    LookupError,
+}
+
+impl RunnerPreferenceResolution {
+    fn predicts_preference(self) -> bool {
+        matches!(
+            self,
+            Self::ExactHistoryGeneration
+                | Self::FinalizingPredecessor
+                | Self::MatchingReusableSandbox
+                | Self::MatchingWorkspaceCache
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RunnerPreferenceClaimState {
+    Active,
+    Expired,
+    Cleared,
+    Absent,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RunnerPreferenceRemovalReason {
+    Expired,
+    Cleared,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(crate) struct RunnerProcessIdentity {
     runner_id: Uuid,
     #[serde(deserialize_with = "deserialize_heartbeat_generation")]
     heartbeat_generation: u64,
+}
+
+impl RunnerProcessIdentity {
+    fn targets(self, runner_id: &str, heartbeat_generation: u64) -> bool {
+        runner_id
+            .parse::<Uuid>()
+            .is_ok_and(|runner_id| runner_id == self.runner_id)
+            && heartbeat_generation == self.heartbeat_generation
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -84,10 +133,8 @@ impl RunnerPreference {
     }
 
     pub(crate) fn targets(&self, runner_id: &str, heartbeat_generation: u64) -> bool {
-        runner_id
-            .parse::<Uuid>()
-            .is_ok_and(|runner_id| runner_id == self.runner_identity.runner_id)
-            && heartbeat_generation == self.runner_identity.heartbeat_generation
+        self.runner_identity
+            .targets(runner_id, heartbeat_generation)
     }
 
     #[cfg(test)]
@@ -106,6 +153,15 @@ impl RunnerPreference {
             deadline,
         }
     }
+}
+
+pub(crate) fn parse_runner_preference_resolution(
+    value: Option<serde_json::Value>,
+) -> Result<Option<RunnerPreferenceResolution>, serde_json::Error> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    serde_json::from_value(value).map(Some)
 }
 
 pub(crate) fn parse_runner_preference(
@@ -149,6 +205,38 @@ pub(crate) enum JobDiscoverySource {
     Poll,
 }
 
+/// Immutable API decision context used only for claim telemetry.
+///
+/// The live preference may be removed as admission progresses, but this
+/// observation must continue to follow the selected candidate and must never
+/// influence admission itself.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RunnerPreferenceObservation {
+    resolution: RunnerPreferenceResolution,
+    runner_identity: Option<RunnerProcessIdentity>,
+    removal_reason: Option<RunnerPreferenceRemovalReason>,
+}
+
+impl RunnerPreferenceObservation {
+    fn new(
+        resolution: RunnerPreferenceResolution,
+        runner_preference: Option<&RunnerPreference>,
+    ) -> Self {
+        Self {
+            resolution,
+            runner_identity: runner_preference.map(|preference| preference.runner_identity),
+            removal_reason: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct RunnerPreferenceClaimTelemetry {
+    pub(crate) resolution: RunnerPreferenceResolution,
+    pub(crate) state: RunnerPreferenceClaimState,
+    pub(crate) targeted_self: Option<bool>,
+}
+
 impl JobDiscoverySource {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
@@ -179,6 +267,7 @@ pub struct JobCandidate {
     reuse_key: Option<String>,
     history_generation_run_id: Option<RunId>,
     runner_preference: Option<RunnerPreference>,
+    runner_preference_observation: Option<RunnerPreferenceObservation>,
 }
 
 impl JobCandidate {
@@ -210,6 +299,7 @@ impl JobCandidate {
             reuse_key: None,
             history_generation_run_id: None,
             runner_preference: None,
+            runner_preference_observation: None,
         }
     }
 
@@ -307,8 +397,14 @@ impl JobCandidate {
         self.runner_preference.as_ref()
     }
 
-    pub(crate) fn without_runner_preference(mut self) -> Self {
+    pub(crate) fn without_runner_preference(
+        mut self,
+        removal_reason: RunnerPreferenceRemovalReason,
+    ) -> Self {
         self.runner_preference = None;
+        if let Some(observation) = &mut self.runner_preference_observation {
+            observation.removal_reason = Some(removal_reason);
+        }
         self
     }
 
@@ -317,12 +413,51 @@ impl JobCandidate {
         self
     }
 
-    pub(crate) fn with_runner_preference(
+    pub(crate) fn with_runner_preference_context(
         mut self,
         runner_preference: Option<RunnerPreference>,
+        resolution: Option<RunnerPreferenceResolution>,
     ) -> Self {
+        self.runner_preference_observation = resolution.map(|resolution| {
+            RunnerPreferenceObservation::new(resolution, runner_preference.as_ref())
+        });
         self.runner_preference = runner_preference;
         self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_runner_preference(
+        self,
+        runner_preference: Option<RunnerPreference>,
+    ) -> Self {
+        self.with_runner_preference_context(runner_preference, None)
+    }
+
+    pub(crate) fn runner_preference_claim_telemetry(
+        &self,
+        runner_id: &str,
+        heartbeat_generation: u64,
+    ) -> Option<RunnerPreferenceClaimTelemetry> {
+        let observation = self.runner_preference_observation?;
+        let state = match &self.runner_preference {
+            Some(preference) if preference.is_expired() => RunnerPreferenceClaimState::Expired,
+            Some(_) => RunnerPreferenceClaimState::Active,
+            None => match observation.removal_reason {
+                Some(RunnerPreferenceRemovalReason::Expired) => RunnerPreferenceClaimState::Expired,
+                Some(RunnerPreferenceRemovalReason::Cleared) => RunnerPreferenceClaimState::Cleared,
+                None if observation.resolution.predicts_preference() => {
+                    RunnerPreferenceClaimState::Cleared
+                }
+                None => RunnerPreferenceClaimState::Absent,
+            },
+        };
+        Some(RunnerPreferenceClaimTelemetry {
+            resolution: observation.resolution,
+            state,
+            targeted_self: observation
+                .runner_identity
+                .map(|identity| identity.targets(runner_id, heartbeat_generation)),
+        })
     }
 
     pub(crate) fn with_history_generation_run_id(

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -9,6 +9,7 @@ use tracing::warn;
 use crate::duration::duration_ms;
 use crate::http::HttpClient;
 use crate::ids::RunId;
+use crate::types::SandboxReuseResult;
 pub(crate) use session_history::{
     SessionHistoryCacheProbeMetadata, SessionHistoryContentEncodingState,
     SessionHistoryContentLengthState, SessionHistoryResponseTelemetryMetadata,
@@ -23,6 +24,15 @@ const FLUSH_THRESHOLD: Duration = Duration::from_secs(30);
 
 /// Timeout for telemetry HTTP requests (shorter than default API timeout).
 const TELEMETRY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Effective resource path once the guest process has spawned.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RunnerStartupPath {
+    Sandbox,
+    Workspace,
+    Cold,
+}
 
 /// Per-job telemetry collector. Buffers sandbox operations and flushes them
 /// periodically (auto on 30 s threshold) and at job end.
@@ -46,6 +56,10 @@ struct SandboxOp {
     success: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    runner_startup_path: Option<RunnerStartupPath>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sandbox_reuse_result: Option<SandboxReuseResult>,
     #[serde(flatten)]
     session_history: Option<SessionHistoryTelemetryFields>,
 }
@@ -82,6 +96,18 @@ impl JobTelemetry {
         self.record_inner(action_type, duration, success, error, None);
     }
 
+    pub(crate) fn record_api_to_spawn(
+        &mut self,
+        duration: Duration,
+        runner_startup_path: RunnerStartupPath,
+        sandbox_reuse_result: SandboxReuseResult,
+    ) {
+        let mut op = sandbox_op("api_to_spawn", duration, true, None, None);
+        op.runner_startup_path = Some(runner_startup_path);
+        op.sandbox_reuse_result = Some(sandbox_reuse_result);
+        self.push_operation(op);
+    }
+
     /// Record a timed operation with low-cardinality session-history transport
     /// dimensions derived from the hash-backed resume history ref.
     pub fn record_with_session_history_metadata(
@@ -111,8 +137,11 @@ impl JobTelemetry {
         error: Option<&str>,
         metadata: Option<SessionHistoryTelemetryMetadata>,
     ) {
-        self.pending_ops
-            .push(sandbox_op(action_type, duration, success, error, metadata));
+        self.push_operation(sandbox_op(action_type, duration, success, error, metadata));
+    }
+
+    fn push_operation(&mut self, operation: SandboxOp) {
+        self.pending_ops.push(operation);
         if self.oldest_pending.is_none() {
             self.oldest_pending = Some(Instant::now());
         }
@@ -179,6 +208,20 @@ impl JobTelemetry {
                 success: op.success,
                 error: op.error.clone(),
                 session_history: op.session_history,
+            })
+            .collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_ops_with_runner_startup_snapshot(
+        &self,
+    ) -> Vec<RunnerStartupTelemetrySnapshot> {
+        self.pending_ops
+            .iter()
+            .map(|op| RunnerStartupTelemetrySnapshot {
+                action_type: op.action_type.clone(),
+                runner_startup_path: op.runner_startup_path,
+                sandbox_reuse_result: op.sandbox_reuse_result,
             })
             .collect()
     }
@@ -267,6 +310,14 @@ pub(crate) struct SessionHistoryTelemetrySnapshot {
     pub(crate) session_history: Option<SessionHistoryTelemetryFields>,
 }
 
+#[cfg(test)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct RunnerStartupTelemetrySnapshot {
+    pub(crate) action_type: String,
+    pub(crate) runner_startup_path: Option<RunnerStartupPath>,
+    pub(crate) sandbox_reuse_result: Option<SandboxReuseResult>,
+}
+
 fn sandbox_op(
     action_type: &str,
     duration: Duration,
@@ -280,6 +331,8 @@ fn sandbox_op(
         duration_ms: duration_ms(duration),
         success,
         error: error.map(String::from),
+        runner_startup_path: None,
+        sandbox_reuse_result: None,
         session_history: metadata.map(SessionHistoryTelemetryFields::from),
     }
 }
@@ -409,6 +462,8 @@ mod tests {
             duration_ms: 1500,
             success: true,
             error: None,
+            runner_startup_path: None,
+            sandbox_reuse_result: None,
             session_history: None,
         };
         let json = serde_json::to_value(&op).unwrap();
@@ -419,6 +474,28 @@ mod tests {
                 "action_type": "vm_create",
                 "duration_ms": 1500,
                 "success": true,
+            })
+        );
+    }
+
+    #[test]
+    fn api_to_spawn_serializes_bounded_startup_metadata() {
+        let mut telemetry = JobTelemetry::new(http_client(), RunId::nil(), "tok".to_string());
+        telemetry.record_api_to_spawn(
+            Duration::from_millis(125),
+            RunnerStartupPath::Workspace,
+            SandboxReuseResult::PoolMiss,
+        );
+
+        assert_eq!(
+            serde_json::to_value(&telemetry.pending_ops[0]).unwrap(),
+            serde_json::json!({
+                "ts": telemetry.pending_ops[0].ts.clone(),
+                "action_type": "api_to_spawn",
+                "duration_ms": 125,
+                "success": true,
+                "runner_startup_path": "workspace",
+                "sandbox_reuse_result": "poolMiss",
             })
         );
     }
@@ -440,6 +517,8 @@ mod tests {
                 duration_ms: 100,
                 success: true,
                 error: None,
+                runner_startup_path: None,
+                sandbox_reuse_result: None,
                 session_history: Some(metadata.into()),
             }],
         };

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -40,6 +40,8 @@ pub struct Job {
     pub history_generation_run_id: Option<RunId>,
     #[serde(default)]
     pub runner_preference: Option<serde_json::Value>,
+    #[serde(default)]
+    pub runner_preference_resolution: Option<serde_json::Value>,
 }
 
 pub(crate) fn reuse_key_kind(reuse_key: &str) -> &'static str {

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -4,7 +4,10 @@ import type {
   BrowserSessionChangedPayload,
   ConnectorChangedPayload,
 } from "@vm0/api-contracts/contracts/realtime";
-import type { RunnerPreference } from "@vm0/api-contracts/contracts/runners";
+import type {
+  RunnerPreference,
+  RunnerPreferenceResolution,
+} from "@vm0/api-contracts/contracts/runners";
 import type { ZeroBuiltInGenerationRealtimeSubscription } from "@vm0/api-contracts/contracts/zero-built-in-generation";
 
 import { env } from "../../lib/env";
@@ -386,6 +389,7 @@ export async function publishRunnerJobNotification(
     readonly cliAgentSessionId: string | null;
     readonly historyGenerationRunId: string | undefined;
     readonly runnerPreference: RunnerPreference | null;
+    readonly runnerPreferenceResolution: RunnerPreferenceResolution;
   },
 ): Promise<boolean> {
   const published = await tapError(
@@ -403,6 +407,11 @@ export async function publishRunnerJobNotification(
           : {}),
         ...(metadata?.runnerPreference
           ? { runnerPreference: metadata.runnerPreference }
+          : {}),
+        ...(metadata
+          ? {
+              runnerPreferenceResolution: metadata.runnerPreferenceResolution,
+            }
           : {}),
       });
       L.debug(`Published job ${runId} to runner-group:${group} (broadcast)`);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3725,6 +3725,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
     expect(canonicalHeartbeatHolder.job?.reuseKey).toBe(reuseKey);
     expect(runnerPreference(canonicalHeartbeatHolder.job)).toBeUndefined();
+    expect(canonicalHeartbeatHolder.job?.runnerPreferenceResolution).toBe(
+      "no_viable_holder",
+    );
 
     await api.requestHeartbeatRunner(true, [200], {
       runnerId: reuseRunnerId,
@@ -3755,6 +3758,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       reason: "matchingReuseKey",
       expiresAt: expect.any(String),
     });
+    expect(workspaceOnlyHolder.job?.runnerPreferenceResolution).toBe(
+      "matching_workspace_cache",
+    );
     await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
       workspaceCaches: [
@@ -3767,6 +3773,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(runnerPreference(capableWorkspaceHolder.job)).toMatchObject({
       reason: "matchingReuseKey",
     });
+    expect(capableWorkspaceHolder.job?.runnerPreferenceResolution).toBe(
+      "matching_workspace_cache",
+    );
 
     const reusableRunnerId = randomUUID();
     await api.requestHeartbeatRunner(true, [200], {
@@ -3797,11 +3806,15 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(runnerPreference(reusableOverWorkspace.job)).toStrictEqual(
       reusablePreference,
     );
+    expect(reusableOverWorkspace.job?.runnerPreferenceResolution).toBe(
+      "matching_reusable_sandbox",
+    );
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "job",
       expect.objectContaining({
         runId: reusableOverWorkspace.run.runId,
         runnerPreference: reusablePreference,
+        runnerPreferenceResolution: "matching_reusable_sandbox",
       }),
     );
     await api.requestHeartbeatRunner(true, [200], {
@@ -3821,6 +3834,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue with a mismatched capable workspace",
     );
     expect(runnerPreference(mismatchedCapableWorkspace.job)).toBeUndefined();
+    expect(mismatchedCapableWorkspace.job?.runnerPreferenceResolution).toBe(
+      "no_viable_holder",
+    );
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -3840,6 +3856,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       reason: "matchingReuseKey",
       expiresAt: expect.any(String),
     });
+    expect(differentGenerationHolder.job?.runnerPreferenceResolution).toBe(
+      "matching_reusable_sandbox",
+    );
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -3859,6 +3878,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       reason: "exactHistoryGeneration",
       expiresAt: expect.any(String),
     });
+    expect(exactGenerationHolder.job?.runnerPreferenceResolution).toBe(
+      "exact_history_generation",
+    );
 
     for (const { runId, resolution } of [
       {
@@ -3942,6 +3964,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         reuseKey,
         historyGenerationRunId: first.runId,
         runnerPreference: finalizingPreference,
+        runnerPreferenceResolution: "finalizing_predecessor",
       }),
     );
 
@@ -3960,6 +3983,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(sourcePoll.body.job?.runId).toBe(successor.runId);
     expect(runnerPreference(sourcePoll.body.job)).toStrictEqual(
       finalizingPreference,
+    );
+    expect(sourcePoll.body.job?.runnerPreferenceResolution).toBe(
+      "finalizing_predecessor",
     );
     for (const actionType of [
       "runner_notification_affinity_lookup",
@@ -3997,6 +4023,50 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       reason: "matchingReuseKey",
       expiresAt: new Date(successorCreatedAt + 2000).toISOString(),
     });
+    expect(genericPoll.body.job?.runnerPreferenceResolution).toBe(
+      "matching_reusable_sandbox",
+    );
+
+    const claimed = await api.requestClaimRunnerJob(
+      true,
+      successor.runId,
+      [200],
+      {
+        runnerIdentity: sourceRunnerIdentity,
+        telemetry: {
+          discoverySource: "ably",
+          runnerPreferenceResolution: "finalizing_predecessor",
+          runnerPreferenceClaimState: "expired",
+          runnerPreferenceTargetedSelf: true,
+        },
+      },
+    );
+    expect(claimed.status).toBe(200);
+    const successfulClaim = sandboxOperationEventsForRunByAction(
+      successor.runId,
+      "claim_request_to_running",
+    );
+    expect(successfulClaim).toHaveLength(1);
+    expect(successfulClaim[0]).toStrictEqual(
+      expect.objectContaining({
+        runner_preference_resolution: "finalizing_predecessor",
+        runner_preference_claim_state: "expired",
+        runner_preference_targeted_self: "true",
+      }),
+    );
+    for (const event of sandboxOperationEventsForRun(successor.runId)) {
+      if (event.op_type === "claim_request_to_running") {
+        continue;
+      }
+      if (
+        event.op_type === "runner_notification_affinity_lookup" ||
+        event.op_type === "runner_poll_pending_job_lookup"
+      ) {
+        continue;
+      }
+      expect(event).not.toHaveProperty("runner_preference_claim_state");
+      expect(event).not.toHaveProperty("runner_preference_targeted_self");
+    }
 
     await api.requestCancelRun(actor, successor.runId, [200]);
     await flushWaitUntilForTest();
@@ -10751,6 +10821,19 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       expect(serialized).not.toContain(apiKey.token);
     }
     const timingEvents = sandboxOperationEventsForRun(first.runId);
+    const oldRunnerClaimEvent = singleSandboxOperationEvent(
+      timingEvents,
+      "claim_request_to_running",
+    );
+    expect(oldRunnerClaimEvent).not.toHaveProperty(
+      "runner_preference_resolution",
+    );
+    expect(oldRunnerClaimEvent).not.toHaveProperty(
+      "runner_preference_claim_state",
+    );
+    expect(oldRunnerClaimEvent).not.toHaveProperty(
+      "runner_preference_targeted_self",
+    );
     expect(
       timingEvents.find((event) => {
         return event.op_type === "job_discovered_to_claim_request";
@@ -10911,6 +10994,9 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
           directCandidateInboxWaitMs: 34,
           providerDiscoveryToMainLoopMs: 45,
           mainLoopToLocalAdmissionMs: 67,
+          runnerPreferenceResolution: "matching_workspace_cache",
+          runnerPreferenceClaimState: "active",
+          runnerPreferenceTargetedSelf: false,
         },
       },
     );
@@ -10929,6 +11015,19 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         apiKey.token,
       ],
     });
+    const directClaimEvents = sandboxOperationEventsForRun(second.runId);
+    expect(
+      singleSandboxOperationEvent(
+        directClaimEvents,
+        "claim_request_to_running",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        runner_preference_resolution: "matching_workspace_cache",
+        runner_preference_claim_state: "active",
+        runner_preference_targeted_self: "false",
+      }),
+    );
 
     const tokenRequest = {
       keyName: "bdd-key",
@@ -12692,6 +12791,14 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
             session_history_download_source: "configured_public_endpoint",
             session_history_ref_hash: "should-not-forward",
           },
+          {
+            ts: nowDate().toISOString(),
+            action_type: "api_to_spawn",
+            duration_ms: 125,
+            success: true,
+            runner_startup_path: "workspace",
+            sandbox_reuse_result: "poolMiss",
+          },
         ],
       },
       sandboxHeaders,
@@ -12790,6 +12897,20 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
         }),
       ],
     );
+    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
+      "vm0-sandbox-op-log-dev",
+      [
+        expect.objectContaining({
+          op_type: "api_to_spawn",
+          run_id: created.runId,
+          duration_ms: 125,
+          success: true,
+          runner_startup_path: "workspace",
+          sandbox_reuse_result: "poolMiss",
+          source: "sandbox",
+        }),
+      ],
+    );
     const sessionHistoryDownloadEvents = sandboxOperationEventsForRunByAction(
       created.runId,
       "session_history_download",
@@ -12797,6 +12918,12 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
     expect(sessionHistoryDownloadEvents).toHaveLength(1);
     expect(sessionHistoryDownloadEvents[0]).not.toHaveProperty(
       "session_history_ref_hash",
+    );
+    expect(sessionHistoryDownloadEvents[0]).not.toHaveProperty(
+      "runner_startup_path",
+    );
+    expect(sessionHistoryDownloadEvents[0]).not.toHaveProperty(
+      "sandbox_reuse_result",
     );
 
     const observed = await webhooks.requestAgentModelUsageObservationV2(

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -16,6 +16,8 @@ import {
   type ExecutionContext,
   type HeldSandboxState,
   type HeldWorkspaceState,
+  type RunnerPreferenceClaimState,
+  type RunnerPreferenceResolution,
   type SessionHistoryDownloadSource,
   type StoredConnectorPermissionBaseline,
   type StoredExecutionContext,
@@ -111,7 +113,6 @@ import {
   tryNormalizeSessionHistoryBlobEncoding,
 } from "../services/session-history-blobs";
 import {
-  type RunnerPreferenceResolutionOutcome,
   runnerReuseKeyTelemetryKind,
   runnerReusePreferenceLookupError,
   runnerReusePreferencePollPriority,
@@ -545,7 +546,7 @@ function recordPollTimingMetrics(args: {
   readonly profile: string;
   readonly authType: RunnerAuthContext["type"];
   readonly pollReason: string | undefined;
-  readonly runnerPreferenceResolution: RunnerPreferenceResolutionOutcome;
+  readonly runnerPreferenceResolution: RunnerPreferenceResolution;
   readonly reuseKeyKind: "thread" | "session" | "none";
   readonly historyGenerationRunId: string | undefined;
   readonly queueCreatedAtMs: number;
@@ -766,6 +767,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         reuseKey: pendingJob.reuseKey,
         historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
         runnerPreference: reusePreference.runnerPreference ?? undefined,
+        runnerPreferenceResolution: reusePreference.outcome,
       },
     },
   };
@@ -1887,6 +1889,9 @@ interface ClaimTimingTelemetry {
   readonly pollDueToJobDiscoveredMs?: number;
   readonly pollHttpRequestMs?: number;
   readonly pollReason?: string;
+  readonly runnerPreferenceResolution?: RunnerPreferenceResolution;
+  readonly runnerPreferenceClaimState?: RunnerPreferenceClaimState;
+  readonly runnerPreferenceTargetedSelf?: boolean;
 }
 
 function scheduleSuccessfulClaimSideEffects(args: {
@@ -1942,6 +1947,9 @@ function scheduleSuccessfulClaimSideEffects(args: {
     pollDueToJobDiscoveredMs: args.telemetry?.pollDueToJobDiscoveredMs,
     pollHttpRequestMs: args.telemetry?.pollHttpRequestMs,
     pollReason: args.telemetry?.pollReason,
+    runnerPreferenceResolution: args.telemetry?.runnerPreferenceResolution,
+    runnerPreferenceClaimState: args.telemetry?.runnerPreferenceClaimState,
+    runnerPreferenceTargetedSelf: args.telemetry?.runnerPreferenceTargetedSelf,
     historyGenerationRunId: historyGenerationRunIdForStoredExecutionContext(
       args.storedContext,
     ),
@@ -1970,6 +1978,9 @@ function scheduleClaimSucceededSideEffects(args: {
   readonly pollDueToJobDiscoveredMs: number | undefined;
   readonly pollHttpRequestMs: number | undefined;
   readonly pollReason: string | undefined;
+  readonly runnerPreferenceResolution: RunnerPreferenceResolution | undefined;
+  readonly runnerPreferenceClaimState: RunnerPreferenceClaimState | undefined;
+  readonly runnerPreferenceTargetedSelf: boolean | undefined;
   readonly historyGenerationRunId: string | undefined;
   readonly claimRouteTiming: ClaimRouteTimingCollector;
 }): void {
@@ -2006,6 +2017,9 @@ interface ClaimTimingMetricArgs {
   readonly pollDueToJobDiscoveredMs: number | undefined;
   readonly pollHttpRequestMs: number | undefined;
   readonly pollReason: string | undefined;
+  readonly runnerPreferenceResolution: RunnerPreferenceResolution | undefined;
+  readonly runnerPreferenceClaimState: RunnerPreferenceClaimState | undefined;
+  readonly runnerPreferenceTargetedSelf: boolean | undefined;
   readonly historyGenerationRunId: string | undefined;
   readonly claimRouteTiming: ClaimRouteTimingCollector;
 }
@@ -2111,16 +2125,54 @@ function claimTimingOperations(
   args: ClaimTimingMetricArgs,
   dimensions: Record<string, string>,
 ): SandboxOperationAttrs[] {
+  const successfulClaimDimensions = claimSuccessfulPreferenceDimensions(
+    args,
+    dimensions,
+  );
   return CLAIM_TIMING_METRIC_FIELDS.map(({ actionType, valueKey }) => {
     return claimTimingOperation(
       args.runId,
       actionType,
       args[valueKey],
-      dimensions,
+      actionType === "claim_request_to_running"
+        ? successfulClaimDimensions
+        : dimensions,
     );
   }).filter((operation): operation is SandboxOperationAttrs => {
     return operation !== undefined;
   });
+}
+
+function claimSuccessfulPreferenceDimensions(
+  args: ClaimTimingMetricArgs,
+  dimensions: Record<string, string>,
+): Record<string, string> {
+  if (
+    args.runnerPreferenceResolution === undefined &&
+    args.runnerPreferenceClaimState === undefined &&
+    args.runnerPreferenceTargetedSelf === undefined
+  ) {
+    return dimensions;
+  }
+
+  return {
+    ...dimensions,
+    ...(args.runnerPreferenceResolution
+      ? {
+          runner_preference_resolution: args.runnerPreferenceResolution,
+        }
+      : {}),
+    ...(args.runnerPreferenceClaimState
+      ? { runner_preference_claim_state: args.runnerPreferenceClaimState }
+      : {}),
+    ...(args.runnerPreferenceTargetedSelf !== undefined
+      ? {
+          runner_preference_targeted_self: String(
+            args.runnerPreferenceTargetedSelf,
+          ),
+        }
+      : {}),
+  };
 }
 
 function claimTimingOperation(

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -4,6 +4,8 @@ import {
   webhookModelUsageObservationContract,
   webhookTelemetryContract,
   webhookUsageEventContract,
+  type RunnerStartupPath,
+  type SandboxReuseResult,
 } from "@vm0/api-contracts/contracts/webhooks";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { modelUsageObservation } from "@vm0/db/schema/model-usage-observation";
@@ -45,6 +47,8 @@ const L = logger("webhooks:agent");
 
 interface SandboxOperationDimensionInput {
   readonly error?: string;
+  readonly runner_startup_path?: RunnerStartupPath;
+  readonly sandbox_reuse_result?: SandboxReuseResult;
   readonly encoding?: string;
   readonly session_history_raw_size_bucket?: string;
   readonly session_history_encoded_size_bucket?: string;
@@ -63,6 +67,12 @@ function sandboxOperationDimensions(
   return {
     source: "sandbox",
     ...(op.error ? { error: op.error } : {}),
+    ...(op.runner_startup_path
+      ? { runner_startup_path: op.runner_startup_path }
+      : {}),
+    ...(op.sandbox_reuse_result
+      ? { sandbox_reuse_result: op.sandbox_reuse_result }
+      : {}),
     ...(op.encoding ? { encoding: op.encoding } : {}),
     ...(op.session_history_raw_size_bucket
       ? {

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -62,6 +62,7 @@ export async function notifyRunnerJob(
       cliAgentSessionId: args.cliAgentSessionId,
       historyGenerationRunId: args.historyGenerationRunId,
       runnerPreference: reusePreference.runnerPreference,
+      runnerPreferenceResolution: reusePreference.outcome,
     },
   );
   const publishFinishedAt = now();

--- a/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
+++ b/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
@@ -1,4 +1,7 @@
-import type { RunnerPreference } from "@vm0/api-contracts/contracts/runners";
+import type {
+  RunnerPreference,
+  RunnerPreferenceResolution,
+} from "@vm0/api-contracts/contracts/runners";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
@@ -267,19 +270,9 @@ export function runnerReusePreferencePollPriority(args: {
   END`;
 }
 
-export type RunnerPreferenceResolutionOutcome =
-  | "exact_history_generation"
-  | "finalizing_predecessor"
-  | "matching_reusable_sandbox"
-  | "matching_workspace_cache"
-  | "no_reuse_key"
-  | "expired"
-  | "no_viable_holder"
-  | "lookup_error";
-
 interface RunnerReusePreferenceResolution {
   readonly runnerPreference: RunnerPreference | null;
-  readonly outcome: RunnerPreferenceResolutionOutcome;
+  readonly outcome: RunnerPreferenceResolution;
 }
 
 export function runnerReusePreferenceLookupError(): RunnerReusePreferenceResolution {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -506,6 +506,34 @@ describe("runner resume session contract", () => {
       experimentalProfile: "vm0/default",
     });
     expect(job.runnerPreference).toBeUndefined();
+    expect(job.runnerPreferenceResolution).toBeUndefined();
+  });
+
+  it("accepts every optional runner preference resolution beside the strict preference", () => {
+    const jobInput = {
+      runId: "33333333-3333-4333-8333-333333333333",
+      prompt: "continue",
+      appendSystemPrompt: null,
+      agentComposeVersionId: null,
+      vars: null,
+      experimentalProfile: "vm0/default",
+    };
+
+    for (const runnerPreferenceResolution of [
+      "exact_history_generation",
+      "finalizing_predecessor",
+      "matching_reusable_sandbox",
+      "matching_workspace_cache",
+      "no_reuse_key",
+      "expired",
+      "no_viable_holder",
+      "lookup_error",
+    ] as const) {
+      expect(
+        jobSchema.parse({ ...jobInput, runnerPreferenceResolution })
+          .runnerPreferenceResolution,
+      ).toBe(runnerPreferenceResolution);
+    }
   });
 
   it("accepts one strict optional runner preference", () => {
@@ -975,6 +1003,29 @@ describe("runner claim request contract", () => {
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it("accepts optional bounded runner preference claim telemetry", () => {
+    for (const runnerPreferenceClaimState of [
+      "active",
+      "expired",
+      "cleared",
+      "absent",
+    ] as const) {
+      expect(
+        runnersJobClaimContract.claim.body.parse({
+          telemetry: {
+            runnerPreferenceResolution: "matching_workspace_cache",
+            runnerPreferenceClaimState,
+            runnerPreferenceTargetedSelf: false,
+          },
+        }).telemetry,
+      ).toStrictEqual({
+        runnerPreferenceResolution: "matching_workspace_cache",
+        runnerPreferenceClaimState,
+        runnerPreferenceTargetedSelf: false,
+      });
+    }
   });
 
   it("discards malformed diagnostic telemetry", () => {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -60,6 +60,64 @@ describe("storage webhook manifest limits", () => {
 });
 
 describe("webhook telemetry contract", () => {
+  it("accepts bounded startup outcomes and keeps them optional", () => {
+    const startupOutcomes = [
+      ["sandbox", "reused"],
+      ["workspace", "noReuseKey"],
+      ["cold", "poolMiss"],
+      ["cold", "profileMismatch"],
+      ["cold", "deviceLimitMismatch"],
+      ["cold", "unparkFailed"],
+    ] as const;
+    const result = webhookTelemetryContract.send.body.parse({
+      runId: "00000000-0000-4000-8000-000000000000",
+      sandboxOperations: [
+        ...startupOutcomes.map(([runnerStartupPath, sandboxReuseResult]) => {
+          return {
+            ts: "2026-01-15T10:00:00.000Z",
+            action_type: "api_to_spawn",
+            duration_ms: 10,
+            success: true,
+            runner_startup_path: runnerStartupPath,
+            sandbox_reuse_result: sandboxReuseResult,
+          };
+        }),
+        {
+          ts: "2026-01-15T10:00:00.000Z",
+          action_type: "vm_create",
+          duration_ms: 5,
+          success: true,
+        },
+      ],
+    });
+
+    expect(
+      result.sandboxOperations?.slice(0, startupOutcomes.length).map((op) => {
+        return [op.runner_startup_path, op.sandbox_reuse_result];
+      }),
+    ).toStrictEqual(startupOutcomes);
+    expect(result.sandboxOperations?.at(-1)).not.toHaveProperty(
+      "runner_startup_path",
+    );
+  });
+
+  it("rejects unknown startup outcomes", () => {
+    expect(
+      webhookTelemetryContract.send.body.safeParse({
+        runId: "00000000-0000-4000-8000-000000000000",
+        sandboxOperations: [
+          {
+            ts: "2026-01-15T10:00:00.000Z",
+            action_type: "api_to_spawn",
+            duration_ms: 10,
+            success: true,
+            runner_startup_path: "warm",
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+
   it("accepts known session history download sources", () => {
     const result = webhookTelemetryContract.send.body.safeParse({
       runId: "00000000-0000-4000-8000-000000000000",

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -113,6 +113,24 @@ export const runnerPreferenceSchema = z
   })
   .strict();
 
+export const runnerPreferenceResolutionSchema = z.enum([
+  "exact_history_generation",
+  "finalizing_predecessor",
+  "matching_reusable_sandbox",
+  "matching_workspace_cache",
+  "no_reuse_key",
+  "expired",
+  "no_viable_holder",
+  "lookup_error",
+]);
+
+export const runnerPreferenceClaimStateSchema = z.enum([
+  "active",
+  "expired",
+  "cleared",
+  "absent",
+]);
+
 const runnerClaimDiscoverySourceSchema = z.enum(["ably", "poll"]);
 const runnerClaimTelemetrySchema = z
   .object({
@@ -130,6 +148,9 @@ const runnerClaimTelemetrySchema = z
     pollDueToJobDiscoveredMs: z.number().int().nonnegative().optional(),
     pollHttpRequestMs: z.number().int().nonnegative().optional(),
     pollReason: runnerClaimPollReasonSchema.optional(),
+    runnerPreferenceResolution: runnerPreferenceResolutionSchema.optional(),
+    runnerPreferenceClaimState: runnerPreferenceClaimStateSchema.optional(),
+    runnerPreferenceTargetedSelf: z.boolean().optional(),
   })
   .catch({});
 
@@ -296,6 +317,7 @@ export const jobSchema = z.object({
   reuseKey: z.string().nullable().optional(),
   historyGenerationRunId: z.uuid().optional(),
   runnerPreference: runnerPreferenceSchema.optional(),
+  runnerPreferenceResolution: runnerPreferenceResolutionSchema.optional(),
 });
 
 const heldWorkspaceCacheSchema = z.object({
@@ -889,6 +911,12 @@ export type RunnersBuiltinFirewallsResolveContract =
   typeof runnersBuiltinFirewallsResolveContract;
 export type Job = z.infer<typeof jobSchema>;
 export type RunnerPreference = z.infer<typeof runnerPreferenceSchema>;
+export type RunnerPreferenceResolution = z.infer<
+  typeof runnerPreferenceResolutionSchema
+>;
+export type RunnerPreferenceClaimState = z.infer<
+  typeof runnerPreferenceClaimStateSchema
+>;
 export type HeldSandboxState = z.infer<typeof heldSandboxStateSchema>;
 export type HeldWorkspaceState = z.infer<typeof heldWorkspaceStateSchema>;
 export type ExecutionContext = z.infer<typeof executionContextSchema>;

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -722,6 +722,10 @@ const sandboxOperationDownloadSourceSchema = z
   }, sessionHistoryDownloadSourceSchema.optional())
   .optional();
 
+export const runnerStartupPathSchema = z.enum(["sandbox", "workspace", "cold"]);
+
+export type RunnerStartupPath = z.infer<typeof runnerStartupPathSchema>;
+
 /**
  * Sandbox operation schema for internal sandbox operations (init, storage, cli, checkpoint, cleanup)
  */
@@ -731,6 +735,8 @@ const sandboxOperationSchema = z.object({
   duration_ms: z.number(),
   success: z.boolean(),
   error: z.string().optional(),
+  runner_startup_path: runnerStartupPathSchema.optional(),
+  sandbox_reuse_result: sandboxReuseResultSchema.optional(),
   encoding: sessionHistoryEncodingSchema.optional(),
   session_history_raw_size_bucket: sessionHistorySizeBucketSchema.optional(),
   session_history_encoded_size_bucket:


### PR DESCRIPTION
## Summary

- carry the API exact runner-preference resolution with the winning Poll or Ably candidate and emit bounded claim-time state only on the successful post-CAS claim event
- enrich the existing `api_to_spawn` event with the effective sandbox, workspace, or cold startup path and the exact bounded sandbox reuse result
- keep every contract field optional, preserve strict live-preference parsing, and tolerate missing or future telemetry metadata without changing admission or execution

This uses the existing `run_id` join and adds no raw reuse keys, session IDs, runner IDs, cache paths, persistence, or new per-run events. The issue remains open until a mature post-rollout production cohort records coverage and the baseline.

## Validation

- `pnpm -F @vm0/api-contracts exec vitest run` (524 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (146 tests)
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- API contracts and API lint
- `pnpm knip`
- `cargo fmt --all --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-features` (3003 unit tests and 1 integration test passed; 20 ignored)

Refs #25411
Parent #25405
