### PR TITLE
docs(python): clarify jsonl writer input contract

### DIFF
--- a/crates/runner/mitm-addon/src/jsonl_writer.py
+++ b/crates/runner/mitm-addon/src/jsonl_writer.py
@@ -43,7 +43,21 @@ _last_append_failure_warning_at: float | None = None
 
 
 def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> None:
-    """Queue a JSONL line for best-effort append without blocking hook latency."""
+    """Queue caller-framed bytes for best-effort append without blocking hook latency.
+
+    When accepted, ``line`` is passed to the append worker without transformation.
+    The caller owns JSON serialization and the terminating newline; this function
+    validates neither JSON nor record boundaries.
+
+    The call returns no admission or durability result. An empty ``log_path``,
+    writer shutdown, pending-write or pending-byte saturation, or failure to start
+    the worker can leave the entry unaccepted. ``log_name`` supplies warning context,
+    but not every rejection emits one.
+
+    Flush operations wait only for writes that were accepted, so they can succeed
+    even if this call was rejected. Processing an accepted write, including a failed
+    append attempt, does not guarantee persistence.
+    """
     global _pending_bytes, _queued_writes
 
     if not log_path:


### PR DESCRIPTION
## Summary

- document that the asynchronous JSONL writer consumes caller-framed bytes without transforming them
- clarify caller ownership of JSON serialization and terminating newlines, with no record validation
- distinguish rejected admission, accepted-write flush completion, and durable persistence

## Scope

This changes documentation only. It does not change the writer API, queue behavior, warning behavior, callers, tests, persisted data, or deployment compatibility.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_jsonl_writer.py` (12 passed)
- `uv run --no-sync python -m pytest tests/` (4,859 passed)

Closes #25445
