### PR TITLE
test(runner): bound proxy unregister test completion

### DIFF
--- a/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
@@ -213,7 +213,9 @@ async fn execute_inner_proxy_unregister_failure_marks_successful_run_failed() {
     overrides.clear_copy_file_lifecycle_gate();
     copy_gate.release_many(overrides.copy_file_calls().len());
 
-    let outcome = run.await;
+    let outcome = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, &mut run)
+        .await
+        .expect("post-gate proxy cleanup and finalization should complete");
 
     assert_eq!(outcome.exit_code(), 1);
     let error = outcome.error().unwrap();


### PR DESCRIPTION
## Summary

- bound the proxy-unregister regression test's final post-gate run completion with the shared runner test timeout
- report a phase-specific failure when proxy cleanup or finalization stalls
- preserve the existing cleanup error, retained state, and reuse rejection assertions

## Scope

- test-only change in the runner proxy-registry integration test
- no production behavior, timeout value, helper API, protocol, schema, or deployment change

## Validation

- `cargo test -p runner --bin runner executor::tests::sandbox_run_tests::proxy_registry::execute_inner_proxy_unregister_failure_marks_successful_run_failed -- --exact`
- `cargo test -p runner --bin runner executor::tests::sandbox_run_tests::proxy_registry`
- `cargo test -p runner --all-targets --all-features`
- `cargo fmt --all --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`

Closes #25447
