### PR TITLE
test(nbd-cow): cover cancellation serialization

### DIFF
--- a/crates/nbd-cow/src/cow_io.rs
+++ b/crates/nbd-cow/src/cow_io.rs
@@ -168,12 +168,40 @@ fn closed_error(operation: &str) -> NbdCowError {
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
     use std::io::Write as _;
+    use std::pin::Pin;
+    use std::task::{Context, Poll, Waker};
+    use std::time::Duration;
 
     use tempfile::NamedTempFile;
 
     use super::*;
     use crate::{BLOCK_SIZE, cow::bitmap_path_for};
+
+    const TEST_TIMEOUT: Duration = Duration::from_secs(1);
+
+    fn create_test_cow_io() -> (NamedTempFile, NamedTempFile, CowIo) {
+        let mut base = NamedTempFile::new().unwrap();
+        base.write_all(&vec![0x11; BLOCK_SIZE]).unwrap();
+        base.flush().unwrap();
+        let cow_file = NamedTempFile::new().unwrap();
+        let cow = CowLayer::new(
+            base.path(),
+            cow_file.path(),
+            BLOCK_SIZE as u64,
+            BLOCK_SIZE,
+            BLOCK_SIZE * 4,
+        )
+        .unwrap();
+        (base, cow_file, CowIo::new(cow))
+    }
+
+    fn poll_once<F: Future>(future: Pin<&mut F>) -> Poll<F::Output> {
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+        future.poll(&mut context)
+    }
 
     #[tokio::test]
     async fn save_bitmap_flushes_buffered_writes() {
@@ -262,5 +290,62 @@ mod tests {
 
         assert!(!source_cow.exists());
         assert_eq!(std::fs::read(target_cow).unwrap(), write_data);
+    }
+
+    #[tokio::test]
+    async fn cancelled_slot_waiter_does_not_submit_write() {
+        let (_base, _cow_file, cow) = create_test_cow_io();
+        let occupied_slot = cow
+            .inner
+            .operation_slot
+            .clone()
+            .try_acquire_owned()
+            .unwrap();
+        let mut cancelled_write = Box::pin(cow.write(0, vec![0x22; BLOCK_SIZE]));
+
+        assert!(poll_once(cancelled_write.as_mut()).is_pending());
+        drop(cancelled_write);
+        drop(occupied_slot);
+
+        let status = tokio::time::timeout(TEST_TIMEOUT, cow.status())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            status,
+            CowIoStatus {
+                dirty_blocks: 0,
+                buffered_blocks: 0,
+                buffer_bytes: 0,
+            }
+        );
+        let data = tokio::time::timeout(TEST_TIMEOUT, cow.read(0, vec![0; BLOCK_SIZE]))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(data, vec![0x11; BLOCK_SIZE]);
+    }
+
+    #[tokio::test]
+    async fn submitted_write_retains_slot_after_awaiter_cancellation() {
+        let (_base, _cow_file, cow) = create_test_cow_io();
+        let cow_gate = cow.inner.cow.try_lock().unwrap();
+        let write_data = vec![0x22; BLOCK_SIZE];
+        let mut cancelled_write = Box::pin(cow.write(0, write_data.clone()));
+
+        assert!(poll_once(cancelled_write.as_mut()).is_pending());
+        drop(cancelled_write);
+        assert_eq!(cow.inner.operation_slot.available_permits(), 0);
+
+        let mut follow_up_read = Box::pin(cow.read(0, vec![0; BLOCK_SIZE]));
+        assert!(poll_once(follow_up_read.as_mut()).is_pending());
+        drop(cow_gate);
+
+        let data = tokio::time::timeout(TEST_TIMEOUT, follow_up_read)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(data, write_data);
+        assert_eq!(cow.inner.operation_slot.available_permits(), 1);
     }
 }


### PR DESCRIPTION
## Summary

- cover cancellation before `CowIo` operation-slot acquisition without submitting or mutating storage
- cover awaiter cancellation after blocking-task submission while the submitted write retains serialization ownership
- verify a follow-up public read waits and observes the completed write using deterministic phase gates and bounded completion

## Scope

This is a test-only change in `nbd-cow`. It does not change production behavior, public APIs, dependencies, schemas, persisted data, protocols, feature switches, or deployment compatibility.

## Validation

- focused `cow_io` tests passed in 20 consecutive runs
- mutation: keeping the permit in the cancelled awaiter failed `submitted_write_retains_slot_after_awaiter_cancellation` as expected
- mutation: bypassing the shared operation semaphore failed `cancelled_slot_waiter_does_not_submit_write` as expected
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p nbd-cow --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow --all-features` (269 passed, 12 existing environment-dependent tests ignored)
- pre-commit workspace Rust formatting, Clippy, documentation, commit message, and file-size checks

Closes #25446
