### PR TITLE
docs(vsock-guest): correct env script cleanup contract

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -387,6 +387,10 @@ jobs:
             cargo test -p vsock-guest --release --no-default-features \
               --test production_identity -- \
               --ignored --exact production_write_file_identity_matches_sudo_policy
+          HOME=/root USER=root LOGNAME=root \
+            cargo test -p vsock-guest --release --no-default-features \
+              --test production_identity -- \
+              --ignored --exact production_env_script_remains_until_operation_cleanup
 
   coverage:
     runs-on: ubuntu-latest-8-cores

--- a/crates/vsock-guest/src/shell_command.rs
+++ b/crates/vsock-guest/src/shell_command.rs
@@ -24,14 +24,22 @@
 //! same-UID sandbox process from replacing the script after its path appears in
 //! argv but before bash opens it.
 //!
-//! Cleanup is intentionally layered. The generated script removes its own file
-//! and directory before exporting env values, stale env-script entries are
-//! cleaned on later launches, and `EnvScriptGuard` removes the script path on
-//! drop. `PreparedShellCommand` and `SpawnedShellCommand` carry that guard so
-//! the script stays available through the prepare-to-spawn handoff and for the
-//! spawned operation. Callers must retain the guard while the shell wrapper may
-//! still need to open the script; dropping it too early can remove the script
-//! before bash reads it.
+//! Cleanup is intentionally layered and mode-dependent. Before exporting env
+//! values, the generated script makes best-effort attempts to remove its own
+//! file and directory. Those attempts succeed when the command identity can
+//! write the per-run directory, including same-user and privileged execution.
+//! In production non-`sudo` execution, the root-owned directory deliberately
+//! denies that access to the sandbox user, so the root-side `EnvScriptGuard`
+//! owns normal cleanup and the restricted script remains until operation
+//! teardown. `PreparedShellCommand` and `SpawnedShellCommand` carry that guard
+//! through the prepare-to-spawn handoff and for the spawned operation. Callers
+//! must retain it while the shell wrapper may still need to open the script;
+//! dropping it too early can remove the script before bash reads it.
+//!
+//! Guard cleanup and later-launch stale cleanup are best effort. If guest
+//! termination bypasses destructors, a script can remain until a later launch
+//! removes it after the stale threshold.
+//!
 //! `SpawnedShellCommand` also returns exec process-containment ownership
 //! only after a successful spawn. Setup failures clean that containment before
 //! returning the original spawn error.
@@ -636,7 +644,7 @@ mod tests {
     }
 
     #[test]
-    fn env_script_content_self_removes_before_exports() {
+    fn env_script_content_attempts_self_removal_before_exports() {
         let dir = Path::new("/run/vm0-exec/vm0-env-test");
         let path = dir.join("run.sh");
         let script =
@@ -788,7 +796,7 @@ mod tests {
     }
 
     #[test]
-    fn env_script_removes_file_and_directory_when_started() {
+    fn env_script_self_removes_when_command_can_write_directory() {
         let (dir, _guard) = temp_dir("self-remove");
         let output = dir.join("output");
         let output_arg = shell_escape_value(output.to_str().unwrap());

--- a/crates/vsock-guest/tests/production_identity.rs
+++ b/crates/vsock-guest/tests/production_identity.rs
@@ -115,6 +115,14 @@ fn production_env_script_remains_until_operation_cleanup() {
     send_supervised_env_exec(&mut stream, 3);
 
     let started = read_message(&mut stream);
+    if started.msg_type == MSG_EXEC_RESULT {
+        let result = vsock_proto::decode_exec_result(&started.payload)
+            .expect("decode exec result received before exec-started");
+        panic!(
+            "exec operation completed before exec-started: termination={:?}, diagnostic={:?}",
+            result.termination, result.diagnostic
+        );
+    }
     assert_eq!(started.msg_type, MSG_EXEC_STARTED);
     assert_eq!(started.seq, 3);
     assert!(
@@ -183,7 +191,9 @@ fn start_guest_connection() -> (JoinHandle<std::io::Result<()>>, UnixStream) {
     host_stream
         .set_read_timeout(Some(GUEST_CONNECTION_TIMEOUT))
         .expect("set host read timeout");
-    let handle = thread::spawn(move || vsock_guest::handle_connection(guest_stream));
+    let handle = thread::spawn(move || {
+        vsock_guest::handle_connection_with_test_process_containment(guest_stream)
+    });
 
     let ready = read_message(&mut host_stream);
     assert_eq!(ready.msg_type, MSG_READY);

--- a/crates/vsock-guest/tests/production_identity.rs
+++ b/crates/vsock-guest/tests/production_identity.rs
@@ -3,19 +3,27 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::{self, Read, Write};
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::os::unix::net::UnixStream;
 use std::panic;
 use std::path::{Path, PathBuf};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
-use vsock_proto::{MSG_ERROR, MSG_READY, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, RawMessage};
+use vsock_proto::{
+    ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream,
+    ExecStartEncodeRequest, ExecTermination, ExecTimeoutPolicy, MSG_ERROR, MSG_EXEC_CANCEL,
+    MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED, MSG_READY, MSG_WRITE_FILE,
+    MSG_WRITE_FILE_RESULT, RawMessage,
+};
 
 const SANDBOX_UID: u32 = 42_420;
 const SANDBOX_GID: u32 = 42_420;
 const SANDBOX_SUPPLEMENTARY_GID: u32 = 42_421;
 const SANDBOX_HOME: &str = "/home/user";
 const PRIVILEGED_REPORT_DIR: &str = "/root";
+const ENV_SCRIPT_ROOT: &str = "/run/vm0-exec";
+const ENV_SCRIPT_PREFIX: &str = "vm0-env-";
 const GUEST_CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
 const GUEST_COMPLETION_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
@@ -96,6 +104,72 @@ fn production_write_file_identity_matches_sudo_policy() {
     join_guest_connection(handle);
 }
 
+#[test]
+#[ignore = "requires root and a production sandbox account; executed explicitly by Rust CI"]
+fn production_env_script_remains_until_operation_cleanup() {
+    require_production_configuration();
+    assert_eq!(current_identity().uid, 0, "test must run as root");
+
+    let entries_before = env_script_entries();
+    let (handle, mut stream) = start_guest_connection();
+    send_supervised_env_exec(&mut stream, 3);
+
+    let started = read_message(&mut stream);
+    assert_eq!(started.msg_type, MSG_EXEC_STARTED);
+    assert_eq!(started.seq, 3);
+    assert!(
+        vsock_proto::decode_exec_started(&started.payload)
+            .expect("decode exec-started response")
+            .pid
+            > 0
+    );
+
+    let output = read_message(&mut stream);
+    assert_eq!(output.msg_type, MSG_EXEC_OUTPUT);
+    assert_eq!(output.seq, 3);
+    let output = vsock_proto::decode_exec_output(&output.payload).expect("decode exec output");
+    assert_eq!(output.stream, ExecOutputStream::Stdout);
+    assert_eq!(output.chunk, b"ready");
+    assert!(!output.truncated);
+
+    let entries_after = env_script_entries();
+    let new_entries: Vec<PathBuf> = entries_after.difference(&entries_before).cloned().collect();
+    assert_eq!(
+        new_entries.len(),
+        1,
+        "expected one active production env-script directory: {new_entries:?}"
+    );
+    let script_dir = &new_entries[0];
+    let script_path = script_dir.join("run.sh");
+    let directory_metadata = fs::symlink_metadata(script_dir)
+        .unwrap_or_else(|error| panic!("read env-script metadata {script_dir:?}: {error}"));
+    assert!(directory_metadata.file_type().is_dir());
+    assert_eq!(directory_metadata.uid(), 0);
+    assert_eq!(directory_metadata.gid(), SANDBOX_GID);
+    assert_eq!(directory_metadata.permissions().mode() & 0o777, 0o710);
+
+    let script_metadata = fs::symlink_metadata(&script_path)
+        .unwrap_or_else(|error| panic!("read env-script metadata {script_path:?}: {error}"));
+    assert!(script_metadata.file_type().is_file());
+    assert_eq!(script_metadata.uid(), 0);
+    assert_eq!(script_metadata.gid(), SANDBOX_GID);
+    assert_eq!(script_metadata.permissions().mode() & 0o777, 0o440);
+    let script = fs::read_to_string(&script_path)
+        .unwrap_or_else(|error| panic!("read active env script {script_path:?}: {error}"));
+    assert!(script.contains("export VM0_ENV_SCRIPT_READY='ready'"));
+
+    send_exec_cancel(&mut stream, 3);
+    let result = read_message(&mut stream);
+    assert_eq!(result.msg_type, MSG_EXEC_RESULT);
+    assert_eq!(result.seq, 3);
+    let result = vsock_proto::decode_exec_result(&result.payload).expect("decode exec result");
+    assert_eq!(result.termination, ExecTermination::Cancelled);
+    wait_for_path_removal(script_dir);
+
+    drop(stream);
+    join_guest_connection(handle);
+}
+
 fn require_production_configuration() {
     #[cfg(debug_assertions)]
     panic!("test requires debug assertions off");
@@ -161,6 +235,66 @@ fn send_write_file(stream: &mut UnixStream, sequence: u32, path: &str, sudo: boo
     let (success, error) =
         vsock_proto::decode_write_file_result(&response.payload).expect("decode write-file result");
     assert!(success, "write-file child failed: {error}");
+}
+
+fn send_supervised_env_exec(stream: &mut UnixStream, sequence: u32) {
+    let payload = vsock_proto::encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
+        lifecycle: ExecLifecyclePolicy::Supervised,
+        timeout: ExecTimeoutPolicy::None,
+        command: "printf '%s' \"$VM0_ENV_SCRIPT_READY\"; sleep 60",
+        env: &[("VM0_ENV_SCRIPT_READY", "ready")],
+        sudo: false,
+        label: "production-env-script-cleanup",
+        stdout: ExecOutputPolicy::Stream {
+            limit_bytes: 64,
+            chunk_limit_bytes: 64,
+        },
+        stderr: ExecOutputPolicy::Capture { limit_bytes: 1024 },
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Disabled,
+        stdin_bytes: None,
+    })
+    .expect("encode exec-start payload");
+    let frame = vsock_proto::encode(MSG_EXEC_START, sequence, &payload).expect("frame exec start");
+    stream.write_all(&frame).expect("send exec-start request");
+}
+
+fn send_exec_cancel(stream: &mut UnixStream, sequence: u32) {
+    let payload = vsock_proto::encode_exec_cancel();
+    let frame =
+        vsock_proto::encode(MSG_EXEC_CANCEL, sequence, &payload).expect("frame exec cancel");
+    stream.write_all(&frame).expect("send exec-cancel request");
+}
+
+fn env_script_entries() -> BTreeSet<PathBuf> {
+    let entries = match fs::read_dir(ENV_SCRIPT_ROOT) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return BTreeSet::new(),
+        Err(error) => panic!("read env-script root {ENV_SCRIPT_ROOT:?}: {error}"),
+    };
+
+    entries
+        .map(|entry| entry.expect("read env-script entry").path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(ENV_SCRIPT_PREFIX))
+        })
+        .collect()
+}
+
+fn wait_for_path_removal(path: &Path) {
+    let deadline = Instant::now()
+        .checked_add(GUEST_CONNECTION_TIMEOUT)
+        .expect("env-script cleanup timeout overflowed");
+    while path.exists() {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "env-script path remained after operation cleanup: {path:?}"
+        );
+        thread::sleep(std::cmp::min(remaining, GUEST_COMPLETION_POLL_INTERVAL));
+    }
 }
 
 fn read_message(stream: &mut UnixStream) -> RawMessage {


### PR DESCRIPTION
## Summary

- correct the `vsock-guest` module contract so env-script cleanup is described as mode-dependent and best effort
- document root-side guard ownership for production non-`sudo` operations and later-launch stale recovery after destructor-bypassing termination
- add a release-mode production integration test that verifies active script residency, exact root:sandbox permissions, and cleanup after cancellation
- isolate the host-side test from the unavailable guest cgroup hierarchy with the existing test-containment connection entry point
- schedule the new ignored production case in the existing Rust CI fixture

## Scope

This PR does not change runtime command construction, ownership, permissions, wrappers, cleanup timing, or deployed process containment. It does not change APIs, persisted data, protocols, or deployment compatibility.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p vsock-guest shell_command` (31 passed)
- `cargo test -p vsock-guest` (223 passed, 2 expected production-fixture tests ignored)
- `cargo test -p vsock-guest --release --no-default-features --test production_identity tests::` (2 passed)
- `cargo clippy --all-targets --all-features`
- `cargo clippy -p vsock-guest --release --no-default-features --all-targets`
- `cargo doc --workspace --all-features --no-deps`
- exact root/release/no-default-features `production_env_script_remains_until_operation_cleanup` fixture (1 passed locally)
- pre-commit: Cargo fmt, Clippy, Rustdoc, file-size check, and commitlint

The exact lifecycle test uses the real root/sandbox identities, `su`, shell wrapper, filesystem ownership, and permissions. It selects only the existing test process-containment backend because a host-side CI container does not own the deployed guest cgroup hierarchy.

Closes #25450
