### PR TITLE
test(api): split feishu dm session boundaries

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -909,6 +909,36 @@ describe("Feishu integration", () => {
     );
   }
 
+  async function startFeishuDmSession(fixture: FeishuRunFixture): Promise<{
+    readonly firstMessageId: string;
+    readonly mainSessionId: string;
+  }> {
+    const { actor, runnerGroup, appId, callbackUrl } = fixture;
+    await connectFixtureUser(fixture);
+    const firstMessageId = `om_${randomUUID()}`;
+    await postEvent(
+      callbackUrl,
+      directMessage(appId, "start the Feishu DM session", "ou_feishu_user", {
+        messageId: firstMessageId,
+      }),
+      { encrypted: true },
+    );
+    await flushWaitUntilForTest();
+    const initialRun = await findRun(actor, "start the Feishu DM session");
+    await runsApi.heartbeatRunner(runnerGroup);
+    const initialClaim = await runsApi.claimRunnerJob(initialRun.id);
+    expect(initialClaim.resumeSession).toBeNull();
+    const mainSessionId = randomUUID();
+    await completeRunSession({
+      runId: initialRun.id,
+      sandboxToken: initialClaim.sandboxToken,
+      sessionId: mainSessionId,
+      history: `bdd initial feishu history ${initialRun.id}`,
+      assistantText: "Initial Feishu DM answer",
+    });
+    return { firstMessageId, mainSessionId };
+  }
+
   it("rejects configuration API access when the feature switch is disabled", async () => {
     const actor = authOrgApi.user({
       userId: `user_${randomUUID()}`,
@@ -2740,32 +2770,11 @@ describe("Feishu integration", () => {
     );
   });
 
-  it("resumes and resets Feishu DM sessions at message and agent boundaries", async () => {
+  it("resumes Feishu DM sessions across messages and quoted replies", async () => {
     const fixture = await setupFeishuRunFixture();
-    const { actor, runnerGroup, appId, callbackUrl, alternateAgentId } =
-      fixture;
-    await connectFixtureUser(fixture);
-    const firstMessageId = `om_${randomUUID()}`;
-    await postEvent(
-      callbackUrl,
-      directMessage(appId, "start the Feishu DM session", "ou_feishu_user", {
-        messageId: firstMessageId,
-      }),
-      { encrypted: true },
-    );
-    await flushWaitUntilForTest();
-    const initialRun = await findRun(actor, "start the Feishu DM session");
-    await runsApi.heartbeatRunner(runnerGroup);
-    const initialClaim = await runsApi.claimRunnerJob(initialRun.id);
-    expect(initialClaim.resumeSession).toBeNull();
-    const mainSessionId = randomUUID();
-    await completeRunSession({
-      runId: initialRun.id,
-      sandboxToken: initialClaim.sandboxToken,
-      sessionId: mainSessionId,
-      history: `bdd initial feishu history ${initialRun.id}`,
-      assistantText: "Initial Feishu DM answer",
-    });
+    const { actor, runnerGroup, appId, callbackUrl } = fixture;
+    const { firstMessageId, mainSessionId } =
+      await startFeishuDmSession(fixture);
 
     await postEvent(
       callbackUrl,
@@ -2823,6 +2832,22 @@ describe("Feishu integration", () => {
         );
       });
     expect(completedQuotedReply?.replyInThread).toBeFalsy();
+
+    const client = setupApp({ context })(zeroFeishuConnectContract);
+    await accept(
+      client.removeInstallation({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { installationId: fixture.installationId },
+      }),
+      [200],
+    );
+  });
+
+  it("resets Feishu DM sessions when switching agents", async () => {
+    const fixture = await setupFeishuRunFixture();
+    const { actor, runnerGroup, appId, callbackUrl, alternateAgentId } =
+      fixture;
+    await startFeishuDmSession(fixture);
 
     await postEvent(
       callbackUrl,


### PR DESCRIPTION
## Summary

- extract the shared Feishu DM session bootstrap into a helper that preserves the original claim and completion assertions
- isolate message/quoted-reply resume behavior from agent-switch reset behavior with a fresh fixture for each contract
- keep every explicit `flushWaitUntilForTest`, session assertion, delivery assertion, and installation cleanup without increasing the timeout

## Root cause

[Turbo run 31089948156](https://github.com/vm0-ai/vm0/actions/runs/31089948156) timed out in the combined `resumes and resets Feishu DM sessions at message and agent boundaries` test in [test-api (6)](https://github.com/vm0-ai/vm0/actions/runs/31089948156/job/92578364175).

The failure log shows that the initial DM, normal follow-up, and quoted-reply runs all completed before the 5-second test budget expired. The test timed out before reaching the independent agent-switch/reset subflow; there was no earlier assertion failure, unhandled rejection, or incomplete `waitUntil` ownership signal. The whole file took 24.39 seconds in the failure versus 13.73-15.28 seconds in adjacent successful main runs, where this test completed in 1.57-1.75 seconds. The triggering SHA's PR #25438 changed runner source-read retry behavior and did not touch this API/Feishu path.

The nondeterministic boundary was therefore the cumulative wall-clock budget of four run transitions combined in one test. Under shard contention, the already-completed message-boundary contract could consume enough time to prevent the separate agent-boundary contract from running. This matches the same fixture-isolation pattern previously applied to nearby Feishu session tests in #23333 and #24407.

## Fix

Each independent boundary now runs from a fresh `setupFeishuRunFixture()` while sharing only a deterministic `startFeishuDmSession()` bootstrap. This preserves the product contract and all synchronization while preventing progress in the message-resume scenario from consuming the agent-reset scenario's timeout budget.

No retry, sleep, timeout increase, skip, weakened assertion, swallowed rejection, or detached cleanup was added.

## Verification

- focused split tests passed 5 consecutive runs
  - resume: 1396 ms, 1255 ms, 1468 ms, 1315 ms, 1254 ms
  - reset: 627 ms, 599 ms, 634 ms, 612 ms, 611 ms
- full `zero-feishu-integration.test.ts`: 22/22 passed after the final rebase (resume 739 ms, reset 516 ms)
- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` (12/12 tasks)
- `pnpm knip`
- non-API type checks (10/10 tasks), app production/test type checks, and API type check
- `git diff --check`
