### PR TITLE
test(firewall): cover base specificity decisions

### DIFF
--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -1128,6 +1128,106 @@
       }
     },
     {
+      "name": "plus greedy allowed base wins over star greedy denied base",
+      "firewalls": [
+        {
+          "name": "bentoml",
+          "apis": [
+            {
+              "base": "https://{deployment*}.bentoml.ai",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "deployment.star",
+                  "rules": ["GET /api"]
+                }
+              ]
+            },
+            {
+              "base": "https://{deployment+}.bentoml.ai",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "deployment.plus",
+                  "rules": ["GET /api"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "bentoml": {
+          "allow": ["deployment.plus"],
+          "deny": ["deployment.star"],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://foo.bentoml.ai/api"
+      },
+      "expected": {
+        "kind": "allow",
+        "firewallName": "bentoml",
+        "base": "https://{deployment+}.bentoml.ai",
+        "relativePath": "/api",
+        "permission": "deployment.plus",
+        "rule": "GET /api"
+      }
+    },
+    {
+      "name": "two-code-point allowed base wins over one-code-point emoji denied base",
+      "firewalls": [
+        {
+          "name": "files",
+          "apis": [
+            {
+              "base": "https://api.example.com/files/😀{id}",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "files.emoji",
+                  "rules": ["GET /tail"]
+                }
+              ]
+            },
+            {
+              "base": "https://api.example.com/files/{id}ab",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "files.ascii",
+                  "rules": ["GET /tail"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "files": {
+          "allow": ["files.ascii"],
+          "deny": ["files.emoji"],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/files/😀xab/tail"
+      },
+      "expected": {
+        "kind": "allow",
+        "firewallName": "files",
+        "base": "https://api.example.com/files/{id}ab",
+        "relativePath": "/tail",
+        "permission": "files.ascii",
+        "rule": "GET /tail"
+      }
+    },
+    {
       "name": "unknown endpoint follows deny policy",
       "firewalls": [
         {


### PR DESCRIPTION
## Summary

- add shared final-decision coverage for `+` greedy base precedence over `*` greedy base precedence
- add shared final-decision coverage for mixed-base Unicode code-point literal specificity
- exercise the TypeScript decision matcher and indexed Python production matcher from the same fixtures
- assert the selected allowed base, relative path, permission, and rule through public output

## Exclusions

- no production matcher changes
- no duplicate language-specific fixtures
- no API, protocol, schema, persistence, dependency, migration, or rollout changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,938 passed)
- `pnpm exec prettier --check packages/connectors/src/__tests__/firewall-semantics-contract.json`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors test` (904 passed)
- `pnpm knip`
- `git diff --check`
- `./scripts/check-file-size.sh turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json`
- independent Python and TypeScript mutations confirmed that each new case fails when its intended specificity coordinate is neutralized

Closes #25453
