### PR TITLE
test(api): isolate export runs from cleanup sweep

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -1,14 +1,7 @@
 import { createHash, createHmac, randomUUID } from "node:crypto";
 import { gzipSync, zstdCompressSync } from "node:zlib";
 import AdmZip from "adm-zip";
-import {
-  afterEach,
-  describe,
-  expect,
-  it,
-  onTestFinished,
-  test as vitestTest,
-} from "vitest";
+import { afterEach, describe, expect, it, onTestFinished } from "vitest";
 import type {
   GenerationTemplateRequest,
   UserMessageDocument,
@@ -69,25 +62,11 @@ interface DeferredS3Put {
 }
 
 const context = testContext();
+const registerExportTest = it;
 const trackDeferredS3Put = createFixtureTracker<DeferredS3Put>((pendingPut) => {
   pendingPut.resolve();
   return Promise.resolve();
 });
-
-// cleanup-sandboxes sweeps threadless runs and export jobs globally. Keep each
-// past-clock export fixture under the same cross-worker ownership boundary as
-// the cron tests for its full create / execute / observe lifecycle.
-function itWithCleanupSandboxesIsolation(
-  name: string,
-  test: () => Promise<void>,
-): void {
-  vitestTest(name, async () => {
-    await withThreadlessRunCleanupTestLockFixture({
-      signal: context.signal,
-      run: test,
-    });
-  });
-}
 
 afterEach(() => {
   clearMockNow();
@@ -1164,6 +1143,15 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
 });
 
 describe("OPS-01: user data export", () => {
+  function it(name: string, test: () => Promise<void>): void {
+    registerExportTest(name, async () => {
+      await withThreadlessRunCleanupTestLockFixture({
+        signal: context.signal,
+        run: test,
+      });
+    });
+  }
+
   it("rejects unauthenticated and org-less export requests", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
@@ -1184,8 +1172,7 @@ describe("OPS-01: user data export", () => {
     expect(orgless.body).toStrictEqual(expectedError);
   });
 
-  // prettier-ignore
-  itWithCleanupSandboxesIsolation("exports user data end to end with active, cooldown, refresh, and latest-job visibility", async () => {
+  it("exports user data end to end with active, cooldown, refresh, and latest-job visibility", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const actor = bdd.user();
@@ -1317,8 +1304,7 @@ describe("OPS-01: user data export", () => {
     });
   });
 
-  // prettier-ignore
-  itWithCleanupSandboxesIsolation("exports the userMessage projection", async () => {
+  it("exports the userMessage projection", async () => {
     const api = createOpsLogsApi(context);
     const chat = createChatFilesBddApi(context);
     const { actor, agentId } = await entitledRunActor();
@@ -1387,8 +1373,7 @@ describe("OPS-01: user data export", () => {
     expect(messages[0]?.content).not.toContain("stale export content");
   });
 
-  // prettier-ignore
-  itWithCleanupSandboxesIsolation("exports only agent instruction files, workflow files, and memory files", async () => {
+  it("exports only agent instruction files, workflow files, and memory files", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1509,8 +1494,7 @@ describe("OPS-01: user data export", () => {
     ).toBeFalsy();
   });
 
-  // prettier-ignore
-  itWithCleanupSandboxesIsolation("exports gzip-backed session history bytes as a jsonl conversation file", async () => {
+  it("exports gzip-backed session history bytes as a jsonl conversation file", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1611,8 +1595,7 @@ describe("OPS-01: user data export", () => {
     expect(manifest.counts.sessionHistories).toBe(1);
   });
 
-  // prettier-ignore
-  itWithCleanupSandboxesIsolation("exports zstd-backed session history bytes as a jsonl conversation file", async () => {
+  it("exports zstd-backed session history bytes as a jsonl conversation file", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1713,8 +1696,7 @@ describe("OPS-01: user data export", () => {
     expect(manifest.counts.sessionHistories).toBe(1);
   });
 
-  // prettier-ignore
-  itWithCleanupSandboxesIsolation("fails user export when gzip-backed session history does not match its hash", async () => {
+  it("fails user export when gzip-backed session history does not match its hash", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1796,8 +1778,7 @@ describe("OPS-01: user data export", () => {
     expect(failedStatus.job.error).toContain("session history hash mismatch");
   });
 
-  // prettier-ignore
-  itWithCleanupSandboxesIsolation("fails user export when zstd-backed session history does not match its hash", async () => {
+  it("fails user export when zstd-backed session history does not match its hash", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1879,8 +1860,7 @@ describe("OPS-01: user data export", () => {
     expect(failedStatus.job.error).toContain("session history hash mismatch");
   });
 
-  // prettier-ignore
-  itWithCleanupSandboxesIsolation("fails user export when gzip-backed session history exceeds its encoded size", async () => {
+  it("fails user export when gzip-backed session history exceeds its encoded size", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1962,8 +1942,7 @@ describe("OPS-01: user data export", () => {
     expect(failedStatus.job.error).toContain("S3 object is too large");
   });
 
-  // prettier-ignore
-  itWithCleanupSandboxesIsolation("surfaces failed exports and allows an immediate retry", async () => {
+  it("surfaces failed exports and allows an immediate retry", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const actor = bdd.user();

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -74,7 +74,10 @@ const trackDeferredS3Put = createFixtureTracker<DeferredS3Put>((pendingPut) => {
   return Promise.resolve();
 });
 
-function itWithThreadlessRunCleanupIsolation(
+// cleanup-sandboxes sweeps threadless runs and export jobs globally. Keep each
+// past-clock export fixture under the same cross-worker ownership boundary as
+// the cron tests for its full create / execute / observe lifecycle.
+function itWithCleanupSandboxesIsolation(
   name: string,
   test: () => Promise<void>,
 ): void {
@@ -1181,7 +1184,8 @@ describe("OPS-01: user data export", () => {
     expect(orgless.body).toStrictEqual(expectedError);
   });
 
-  it("exports user data end to end with active, cooldown, refresh, and latest-job visibility", async () => {
+  // prettier-ignore
+  itWithCleanupSandboxesIsolation("exports user data end to end with active, cooldown, refresh, and latest-job visibility", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const actor = bdd.user();
@@ -1313,7 +1317,8 @@ describe("OPS-01: user data export", () => {
     });
   });
 
-  it("exports the userMessage projection", async () => {
+  // prettier-ignore
+  itWithCleanupSandboxesIsolation("exports the userMessage projection", async () => {
     const api = createOpsLogsApi(context);
     const chat = createChatFilesBddApi(context);
     const { actor, agentId } = await entitledRunActor();
@@ -1382,7 +1387,8 @@ describe("OPS-01: user data export", () => {
     expect(messages[0]?.content).not.toContain("stale export content");
   });
 
-  it("exports only agent instruction files, workflow files, and memory files", async () => {
+  // prettier-ignore
+  itWithCleanupSandboxesIsolation("exports only agent instruction files, workflow files, and memory files", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1504,7 +1510,7 @@ describe("OPS-01: user data export", () => {
   });
 
   // prettier-ignore
-  itWithThreadlessRunCleanupIsolation("exports gzip-backed session history bytes as a jsonl conversation file", async () => {
+  itWithCleanupSandboxesIsolation("exports gzip-backed session history bytes as a jsonl conversation file", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1606,7 +1612,7 @@ describe("OPS-01: user data export", () => {
   });
 
   // prettier-ignore
-  itWithThreadlessRunCleanupIsolation("exports zstd-backed session history bytes as a jsonl conversation file", async () => {
+  itWithCleanupSandboxesIsolation("exports zstd-backed session history bytes as a jsonl conversation file", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1708,7 +1714,7 @@ describe("OPS-01: user data export", () => {
   });
 
   // prettier-ignore
-  itWithThreadlessRunCleanupIsolation("fails user export when gzip-backed session history does not match its hash", async () => {
+  itWithCleanupSandboxesIsolation("fails user export when gzip-backed session history does not match its hash", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1791,7 +1797,7 @@ describe("OPS-01: user data export", () => {
   });
 
   // prettier-ignore
-  itWithThreadlessRunCleanupIsolation("fails user export when zstd-backed session history does not match its hash", async () => {
+  itWithCleanupSandboxesIsolation("fails user export when zstd-backed session history does not match its hash", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1874,7 +1880,7 @@ describe("OPS-01: user data export", () => {
   });
 
   // prettier-ignore
-  itWithThreadlessRunCleanupIsolation("fails user export when gzip-backed session history exceeds its encoded size", async () => {
+  itWithCleanupSandboxesIsolation("fails user export when gzip-backed session history exceeds its encoded size", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1956,7 +1962,8 @@ describe("OPS-01: user data export", () => {
     expect(failedStatus.job.error).toContain("S3 object is too large");
   });
 
-  it("surfaces failed exports and allows an immediate retry", async () => {
+  // prettier-ignore
+  itWithCleanupSandboxesIsolation("surfaces failed exports and allows an immediate retry", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const actor = bdd.user();

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -1,7 +1,14 @@
 import { createHash, createHmac, randomUUID } from "node:crypto";
 import { gzipSync, zstdCompressSync } from "node:zlib";
 import AdmZip from "adm-zip";
-import { afterEach, describe, expect, it, onTestFinished } from "vitest";
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+  test as vitestTest,
+} from "vitest";
 import type {
   GenerationTemplateRequest,
   UserMessageDocument,
@@ -14,6 +21,7 @@ import { env } from "../../../lib/env";
 import { clearMockNow, mockNow } from "../../../lib/time";
 import { testContext, accept } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
+import { withThreadlessRunCleanupTestLockFixture } from "../../../test-fixtures/run-deletion";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { modelStatsRoutes } from "../model-stats";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
@@ -65,6 +73,18 @@ const trackDeferredS3Put = createFixtureTracker<DeferredS3Put>((pendingPut) => {
   pendingPut.resolve();
   return Promise.resolve();
 });
+
+function itWithThreadlessRunCleanupIsolation(
+  name: string,
+  test: () => Promise<void>,
+): void {
+  vitestTest(name, async () => {
+    await withThreadlessRunCleanupTestLockFixture({
+      signal: context.signal,
+      run: test,
+    });
+  });
+}
 
 afterEach(() => {
   clearMockNow();
@@ -1483,7 +1503,8 @@ describe("OPS-01: user data export", () => {
     ).toBeFalsy();
   });
 
-  it("exports gzip-backed session history bytes as a jsonl conversation file", async () => {
+  // prettier-ignore
+  itWithThreadlessRunCleanupIsolation("exports gzip-backed session history bytes as a jsonl conversation file", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1584,7 +1605,8 @@ describe("OPS-01: user data export", () => {
     expect(manifest.counts.sessionHistories).toBe(1);
   });
 
-  it("exports zstd-backed session history bytes as a jsonl conversation file", async () => {
+  // prettier-ignore
+  itWithThreadlessRunCleanupIsolation("exports zstd-backed session history bytes as a jsonl conversation file", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1685,7 +1707,8 @@ describe("OPS-01: user data export", () => {
     expect(manifest.counts.sessionHistories).toBe(1);
   });
 
-  it("fails user export when gzip-backed session history does not match its hash", async () => {
+  // prettier-ignore
+  itWithThreadlessRunCleanupIsolation("fails user export when gzip-backed session history does not match its hash", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1767,7 +1790,8 @@ describe("OPS-01: user data export", () => {
     expect(failedStatus.job.error).toContain("session history hash mismatch");
   });
 
-  it("fails user export when zstd-backed session history does not match its hash", async () => {
+  // prettier-ignore
+  itWithThreadlessRunCleanupIsolation("fails user export when zstd-backed session history does not match its hash", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -1849,7 +1873,8 @@ describe("OPS-01: user data export", () => {
     expect(failedStatus.job.error).toContain("session history hash mismatch");
   });
 
-  it("fails user export when gzip-backed session history exceeds its encoded size", async () => {
+  // prettier-ignore
+  itWithThreadlessRunCleanupIsolation("fails user export when gzip-backed session history exceeds its encoded size", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);


### PR DESCRIPTION
## Summary

- serialize all nine past-clock user-export fixtures against the global cleanup-sandboxes sweep
- reuse the cleanup tests' transaction-scoped PostgreSQL advisory lock for explicit cross-worker ownership
- keep each fixture's create, execute, terminal-status, and latest-job observation inside that ownership boundary
- leave production cleanup behavior, export behavior, timeouts, and business assertions unchanged

## Failures and root cause

This PR covers three failures from the same shared-database race:

- [Turbo run 31089158743](https://github.com/vm0-ai/vm0/actions/runs/31089158743), [test-api (4) job 92575990392](https://github.com/vm0-ai/vm0/actions/runs/31089158743/job/92575990392): a gzip history hash-mismatch export lost its threadless run during claim and returned `Run not found`.
- [Turbo run 31092835709](https://github.com/vm0-ai/vm0/actions/runs/31092835709), [test-api (4) job 92587737672](https://github.com/vm0-ai/vm0/actions/runs/31092835709/job/92587737672): an oversized gzip export logged the expected S3 size error but exposed `Export job timed out`; the immediate retry then exposed the old failed job.
- [Turbo run 31093111509](https://github.com/vm0-ai/vm0/actions/runs/31093111509), [test-api (4) job 92588711845](https://github.com/vm0-ai/vm0/actions/runs/31093111509/job/92588711845): a completed gzip export disappeared from latest-job status, while an upload failure was overwritten by `Export job timed out`.

API integration-test workers share one PostgreSQL database while each worker owns its mocked application clock. The export tests create jobs and threadless web-trigger runs in May 2026. In parallel, `cron-cleanup-sandboxes.test.ts` exercises the production global sweep with an August 2026 clock. The failed shards' file timings overlap that cleanup suite.

At the later cleanup clock, the sweep can:

- delete a completed export job because its 72-hour expiry is already in the past, making status return `job: null` or fall back to the previous failed job;
- mark a pending or running export job older than ten minutes as failed with `Export job timed out`, overwriting the terminal state observed by the export test; and
- delete or cancel a threadless web-trigger run before the session-history fixture claims it.

The retry test advances its second job's `createdAt` by one minute, and latest-job status orders by `createdAt DESC`, so its old-job observation is not a timestamp tie. The later-clock sweep deletes the newly completed retry job, which directly explains that result. The same global sweep therefore accounts for the terminal-state, latest-job visibility, and threadless-run manifestations.

## Fix

The affected export tests now hold `withThreadlessRunCleanupTestLockFixture` across their complete create, execute, and observe lifecycle. Cleanup-sandboxes tests acquire the same transaction-scoped PostgreSQL advisory lock, so workers sharing the database cannot run the global sweep concurrently with these past-clock fixtures.

The original five session-history fixtures remain covered, and the lock now also covers the four non-session-history export fixtures that create and observe past-clock export jobs. Tests that do not create a past-clock job remain unlocked.

## Validation

- completed gzip export visibility target: 5 consecutive runs, 5/5 passed
- oversized gzip terminal-error target: 5 consecutive runs, 5/5 passed
- failed export plus immediate retry target: 5 consecutive runs, 5/5 passed
- gzip history hash-mismatch target: 5 consecutive runs, 5/5 passed
- `ops-logs.bdd.test.ts` + `cron-cleanup-sandboxes.test.ts` with two workers: 2 files, 48/48 tests passed
- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` (12/12 tasks passed)
- `pnpm knip`
- non-API/app type checks (10/10 tasks passed)
- app production and test type checks
- API type check
- `git diff --check origin/main...HEAD`
