### PR TITLE
refactor(runner): centralize firecracker snapshot validation

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -125,7 +125,7 @@ pub async fn run_benchmark(
 
     // Block until memory.bin is in page cache so benchmark numbers are stable.
     {
-        let path = resource_locks.snapshot_paths().memory_bin();
+        let path = resource_locks.snapshot_paths().memory();
         let _ = tokio::task::spawn_blocking(move || prefetch::prefetch_memory(&path)).await;
     }
 

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -188,12 +188,7 @@ mod tests {
     ) {
         let snapshot = rootfs.snapshot(snapshot_hash);
         tokio::fs::create_dir_all(snapshot.dir()).await.unwrap();
-        for path in [
-            snapshot.snapshot_bin(),
-            snapshot.memory_bin(),
-            snapshot.cow_img(),
-            snapshot.cow_bitmap(),
-        ] {
+        for path in snapshot.required_artifacts() {
             tokio::fs::write(path, b"snapshot").await.unwrap();
         }
     }

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -914,12 +914,7 @@ profiles:
 
         let snapshot = rootfs.snapshot(TEST_SNAPSHOT_HASH);
         tokio::fs::create_dir_all(snapshot.dir()).await.unwrap();
-        for path in [
-            snapshot.snapshot_bin(),
-            snapshot.memory_bin(),
-            snapshot.cow_img(),
-            snapshot.cow_bitmap(),
-        ] {
+        for path in snapshot.required_artifacts() {
             tokio::fs::write(path, b"snapshot").await.unwrap();
         }
         tokio::fs::write(

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -465,7 +465,7 @@ async fn run_start_with_home(
     let mut memory_prefetch = prefetch::MemoryPrefetchTasks::spawn(
         resource_locks
             .profile_paths()
-            .map(|(_, profile_paths)| profile_paths.snapshot_paths().memory_bin()),
+            .map(|(_, profile_paths)| profile_paths.snapshot_paths().memory()),
     );
 
     // Compute the smallest profile resources for budget pre-check.

--- a/crates/runner/src/cmd/start/tests/main_loop/startup.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/startup.rs
@@ -512,12 +512,7 @@ async fn local_provider_setup_failure_does_not_create_runtime() {
     let snapshot = rootfs.snapshot(SNAPSHOT_HASH);
     tokio::fs::create_dir_all(snapshot.dir()).await.unwrap();
     tokio::fs::write(rootfs.rootfs(), b"").await.unwrap();
-    for path in [
-        snapshot.snapshot_bin(),
-        snapshot.memory_bin(),
-        snapshot.cow_img(),
-        snapshot.cow_bitmap(),
-    ] {
+    for path in snapshot.required_artifacts() {
         tokio::fs::write(path, b"").await.unwrap();
     }
     tokio::fs::write(

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -336,19 +336,6 @@ async fn check_path_exists(path: &Path, label: &str) -> RunnerResult<()> {
     Ok(())
 }
 
-async fn check_snapshot_complete_marker(path: &Path, label: &str) -> RunnerResult<()> {
-    let content = tokio::fs::read(path)
-        .await
-        .map_err(|e| RunnerError::Config(format!("read {label}: {e}")))?;
-    if content != sandbox_fc::SNAPSHOT_COMPLETE_MARKER_CONTENT {
-        return Err(RunnerError::Config(format!(
-            "{label} is invalid: {}",
-            path.display()
-        )));
-    }
-    Ok(())
-}
-
 // This intentionally does not acquire resource locks. Runtime callers that
 // consume image files must use `lock_and_validate_*_image_artifacts` instead.
 async fn validate_profile_image_artifacts(
@@ -379,15 +366,15 @@ async fn validate_profile_snapshot_artifacts(
     rootfs_paths: &RootfsPaths,
 ) -> RunnerResult<SnapshotPaths> {
     let snapshot_paths = rootfs_paths.snapshot(&profile.snapshot_hash);
-    for path in snapshot_paths.expected_files() {
-        check_path_exists(&path, &format!("profile {name} snapshot")).await?;
+    match sandbox_fc::validate_snapshot_output(&snapshot_paths).await {
+        Ok(sandbox_fc::SnapshotOutputValidation::Complete) => Ok(snapshot_paths),
+        Ok(validation) => Err(RunnerError::Config(format!(
+            "profile {name} snapshot is incomplete: {validation}"
+        ))),
+        Err(error) => Err(RunnerError::Config(format!(
+            "validate profile {name} snapshot: {error}"
+        ))),
     }
-    check_snapshot_complete_marker(
-        &snapshot_paths.complete_marker(),
-        &format!("profile {name} snapshot complete marker"),
-    )
-    .await?;
-    Ok(snapshot_paths)
 }
 
 pub(crate) struct LockedProfileImageArtifacts {

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -127,12 +127,7 @@ async fn test_home_with_artifacts(dir: &std::path::Path, hashes: &[(&str, &str)]
         if !snapshot_hash.is_empty() {
             let snapshot = rootfs.snapshot(snapshot_hash);
             tokio::fs::create_dir_all(snapshot.dir()).await.unwrap();
-            for path in [
-                snapshot.snapshot_bin(),
-                snapshot.memory_bin(),
-                snapshot.cow_img(),
-                snapshot.cow_bitmap(),
-            ] {
+            for path in snapshot.required_artifacts() {
                 tokio::fs::write(&path, b"").await.unwrap();
             }
             tokio::fs::write(
@@ -683,12 +678,7 @@ async fn load_defers_malformed_complete_marker_check() {
     tokio::fs::write(rootfs.rootfs(), b"").await.unwrap();
     let snapshot = rootfs.snapshot(TEST_SNAPSHOT_HASH);
     tokio::fs::create_dir_all(snapshot.dir()).await.unwrap();
-    for path in [
-        snapshot.snapshot_bin(),
-        snapshot.memory_bin(),
-        snapshot.cow_img(),
-        snapshot.cow_bitmap(),
-    ] {
+    for path in snapshot.required_artifacts() {
         tokio::fs::write(&path, b"").await.unwrap();
     }
     tokio::fs::write(snapshot.complete_marker(), b"partial marker")
@@ -720,11 +710,7 @@ async fn validate_profile_image_artifacts_rejects_missing_cow_bitmap() {
     tokio::fs::write(rootfs.rootfs(), b"").await.unwrap();
     let snapshot = rootfs.snapshot(TEST_SNAPSHOT_HASH);
     tokio::fs::create_dir_all(snapshot.dir()).await.unwrap();
-    for path in [
-        snapshot.snapshot_bin(),
-        snapshot.memory_bin(),
-        snapshot.cow_img(),
-    ] {
+    for path in [snapshot.snapshot(), snapshot.memory(), snapshot.cow()] {
         tokio::fs::write(&path, b"").await.unwrap();
     }
     tokio::fs::write(
@@ -749,6 +735,64 @@ async fn validate_profile_image_artifacts_rejects_missing_cow_bitmap() {
         err.to_string().contains("cow.img.bitmap"),
         "expected missing cow bitmap error, got: {err}"
     );
+}
+
+#[tokio::test]
+async fn lock_and_validate_profile_image_artifacts_rejects_directory_snapshot_artifact() {
+    let dir = tempfile::tempdir().unwrap();
+    let home =
+        test_home_with_artifacts(dir.path(), &[(TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH)]).await;
+    let snapshot = RootfsPaths::new(&home, TEST_ROOTFS_HASH).snapshot(TEST_SNAPSHOT_HASH);
+    tokio::fs::remove_file(snapshot.snapshot()).await.unwrap();
+    tokio::fs::create_dir(snapshot.snapshot()).await.unwrap();
+
+    let err = match lock_and_validate_profile_image_artifacts(
+        "vm0/default",
+        &default_profile_config(),
+        &home,
+    )
+    .await
+    {
+        Ok(_) => panic!("expected directory snapshot artifact error"),
+        Err(err) => err,
+    };
+    let message = err.to_string();
+    assert!(
+        message.contains("profile vm0/default snapshot"),
+        "got: {err}"
+    );
+    assert!(message.contains("not a regular file"), "got: {err}");
+    assert!(message.contains("snapshot.bin"), "got: {err}");
+}
+
+#[tokio::test]
+async fn lock_and_validate_profile_image_artifacts_rejects_symlink_snapshot_artifact() {
+    let dir = tempfile::tempdir().unwrap();
+    let home =
+        test_home_with_artifacts(dir.path(), &[(TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH)]).await;
+    let snapshot = RootfsPaths::new(&home, TEST_ROOTFS_HASH).snapshot(TEST_SNAPSHOT_HASH);
+    let target = dir.path().join("snapshot-target.bin");
+    tokio::fs::write(&target, b"snapshot").await.unwrap();
+    tokio::fs::remove_file(snapshot.snapshot()).await.unwrap();
+    std::os::unix::fs::symlink(&target, snapshot.snapshot()).unwrap();
+
+    let err = match lock_and_validate_profile_image_artifacts(
+        "vm0/default",
+        &default_profile_config(),
+        &home,
+    )
+    .await
+    {
+        Ok(_) => panic!("expected symlink snapshot artifact error"),
+        Err(err) => err,
+    };
+    let message = err.to_string();
+    assert!(
+        message.contains("profile vm0/default snapshot"),
+        "got: {err}"
+    );
+    assert!(message.contains("not a regular file"), "got: {err}");
+    assert!(message.contains("snapshot.bin"), "got: {err}");
 }
 
 #[tokio::test]
@@ -902,12 +946,7 @@ async fn load_rejects_snapshot_without_complete_marker() {
     tokio::fs::write(rootfs.rootfs(), b"").await.unwrap();
     let snapshot = rootfs.snapshot(TEST_SNAPSHOT_HASH);
     tokio::fs::create_dir_all(snapshot.dir()).await.unwrap();
-    for path in [
-        snapshot.snapshot_bin(),
-        snapshot.memory_bin(),
-        snapshot.cow_img(),
-        snapshot.cow_bitmap(),
-    ] {
+    for path in snapshot.required_artifacts() {
         tokio::fs::write(&path, b"").await.unwrap();
     }
 
@@ -933,12 +972,7 @@ async fn load_rejects_snapshot_with_malformed_complete_marker() {
     tokio::fs::write(rootfs.rootfs(), b"").await.unwrap();
     let snapshot = rootfs.snapshot(TEST_SNAPSHOT_HASH);
     tokio::fs::create_dir_all(snapshot.dir()).await.unwrap();
-    for path in [
-        snapshot.snapshot_bin(),
-        snapshot.memory_bin(),
-        snapshot.cow_img(),
-        snapshot.cow_bitmap(),
-    ] {
+    for path in snapshot.required_artifacts() {
         tokio::fs::write(&path, b"").await.unwrap();
     }
     tokio::fs::write(snapshot.complete_marker(), b"partial marker")

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -19,6 +19,7 @@
 
 use std::path::{Path, PathBuf};
 
+pub use sandbox_fc::SnapshotOutputPaths as SnapshotPaths;
 use sha2::{Digest, Sha256};
 
 use crate::error::RunnerResult;
@@ -411,61 +412,13 @@ impl RootfsPaths {
 
     /// Derive snapshot paths nested under this rootfs.
     pub fn snapshot(&self, snapshot_hash: &str) -> SnapshotPaths {
-        SnapshotPaths {
-            dir: self.dir.join("snapshots").join(snapshot_hash),
-        }
+        SnapshotPaths::new(self.dir.join("snapshots").join(snapshot_hash))
     }
 
     /// Parent directory for all snapshots under this rootfs.
     #[cfg(test)]
     pub fn snapshots_dir(&self) -> PathBuf {
         self.dir.join("snapshots")
-    }
-}
-
-/// Paths for a snapshot build output, nested under a [`RootfsPaths`].
-///
-/// Layout: `<images_dir>/<rootfs_hash>/snapshots/<snapshot_hash>/{snapshot.bin,memory.bin,cow.img,cow.img.bitmap,.snapshot-complete}`
-///
-/// Constructed via [`RootfsPaths::snapshot`].
-pub struct SnapshotPaths {
-    dir: PathBuf,
-}
-
-impl SnapshotPaths {
-    pub fn dir(&self) -> &Path {
-        &self.dir
-    }
-
-    pub fn snapshot_bin(&self) -> PathBuf {
-        self.dir.join("snapshot.bin")
-    }
-
-    pub fn memory_bin(&self) -> PathBuf {
-        self.dir.join("memory.bin")
-    }
-
-    pub fn cow_img(&self) -> PathBuf {
-        self.dir.join("cow.img")
-    }
-
-    pub fn cow_bitmap(&self) -> PathBuf {
-        self.dir.join("cow.img.bitmap")
-    }
-
-    pub fn complete_marker(&self) -> PathBuf {
-        self.dir.join(".snapshot-complete")
-    }
-
-    /// All files that must exist for the snapshot to be considered complete.
-    pub fn expected_files(&self) -> [PathBuf; 5] {
-        [
-            self.snapshot_bin(),
-            self.memory_bin(),
-            self.cow_img(),
-            self.cow_bitmap(),
-            self.complete_marker(),
-        ]
     }
 }
 
@@ -715,27 +668,6 @@ mod tests {
         let home = HomePaths::with_root(PathBuf::from("/test"));
         let sp = RootfsPaths::new(&home, "aaa").snapshot("bbb");
         assert_eq!(sp.dir(), Path::new("/test/images/aaa/snapshots/bbb"));
-        assert_eq!(
-            sp.snapshot_bin(),
-            PathBuf::from("/test/images/aaa/snapshots/bbb/snapshot.bin")
-        );
-        assert_eq!(
-            sp.memory_bin(),
-            PathBuf::from("/test/images/aaa/snapshots/bbb/memory.bin")
-        );
-        assert_eq!(
-            sp.cow_img(),
-            PathBuf::from("/test/images/aaa/snapshots/bbb/cow.img")
-        );
-        assert_eq!(
-            sp.cow_bitmap(),
-            PathBuf::from("/test/images/aaa/snapshots/bbb/cow.img.bitmap")
-        );
-        assert_eq!(
-            sp.complete_marker(),
-            PathBuf::from("/test/images/aaa/snapshots/bbb/.snapshot-complete")
-        );
-        assert_eq!(sp.expected_files().len(), 5);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -68,5 +68,6 @@ pub use paths::{
 pub use runtime::{FirecrackerRuntime, FirecrackerRuntimeProvider};
 pub use sandbox::FirecrackerSandbox;
 pub use snapshot::{
-    FirecrackerSnapshotProvider, SNAPSHOT_COMPLETE_MARKER_CONTENT, SnapshotError, create_snapshot,
+    FirecrackerSnapshotProvider, SNAPSHOT_COMPLETE_MARKER_CONTENT, SnapshotError,
+    SnapshotOutputValidation, create_snapshot, validate_snapshot_output,
 };

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -232,6 +232,19 @@ impl SnapshotOutputPaths {
         self.output_dir.join("cow.img.bitmap")
     }
 
+    /// Returns the four regular files required for a reusable snapshot.
+    ///
+    /// The completion marker is intentionally separate because it is the
+    /// publication commit signal rather than a snapshot data artifact.
+    pub fn required_artifacts(&self) -> [PathBuf; 4] {
+        [
+            self.snapshot(),
+            self.memory(),
+            self.cow(),
+            self.cow_bitmap(),
+        ]
+    }
+
     /// Commit marker written only after all snapshot artifacts are published.
     pub fn complete_marker(&self) -> PathBuf {
         self.output_dir.join(".snapshot-complete")

--- a/crates/sandbox-fc/src/snapshot/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/mod.rs
@@ -7,7 +7,9 @@ mod publish;
 mod runtime;
 
 pub use error::SnapshotError;
-pub use output::SNAPSHOT_COMPLETE_MARKER_CONTENT;
+pub use output::{
+    SNAPSHOT_COMPLETE_MARKER_CONTENT, SnapshotOutputValidation, validate_snapshot_output,
+};
 pub use provider::FirecrackerSnapshotProvider;
 
 use sandbox::SnapshotCreateConfig;

--- a/crates/sandbox-fc/src/snapshot/output.rs
+++ b/crates/sandbox-fc/src/snapshot/output.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
@@ -20,13 +21,38 @@ use super::SnapshotError;
 /// change for independently deployed readers and writers.
 pub const SNAPSHOT_COMPLETE_MARKER_CONTENT: &[u8] = b"snapshot-complete-v1\n";
 
-pub(super) fn snapshot_artifact_paths(output: &SnapshotOutputPaths) -> [PathBuf; 4] {
-    [
-        output.snapshot(),
-        output.memory(),
-        output.cow(),
-        output.cow_bitmap(),
-    ]
+/// Result of validating a Firecracker snapshot output directory.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SnapshotOutputValidation {
+    /// The exact completion marker and every required artifact are valid.
+    Complete,
+    /// A required artifact or the completion marker is absent.
+    MissingFile(PathBuf),
+    /// A required snapshot artifact exists but is not a regular file.
+    NotRegularFile(PathBuf),
+    /// The completion marker exists but does not contain the exact expected bytes.
+    InvalidCompleteMarker(PathBuf),
+}
+
+impl fmt::Display for SnapshotOutputValidation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Complete => f.write_str("snapshot output is complete"),
+            Self::MissingFile(path) => {
+                write!(f, "required snapshot file not found: {}", path.display())
+            }
+            Self::NotRegularFile(path) => {
+                write!(
+                    f,
+                    "snapshot artifact is not a regular file: {}",
+                    path.display()
+                )
+            }
+            Self::InvalidCompleteMarker(path) => {
+                write!(f, "snapshot complete marker is invalid: {}", path.display())
+            }
+        }
+    }
 }
 
 fn io_error_with_path(action: &str, path: &Path, error: io::Error) -> io::Error {
@@ -66,18 +92,41 @@ pub(super) fn run_snapshot_blocking_fs<T>(f: impl FnOnce() -> T) -> T {
     }
 }
 
-pub(super) async fn snapshot_artifacts_are_regular_files(
+/// Validates the complete Firecracker snapshot artifact contract.
+///
+/// Missing, malformed, and non-regular entries are ordinary incomplete
+/// outcomes. Filesystem failures that prevent validation are returned as I/O
+/// errors with the affected path in their context.
+pub async fn validate_snapshot_output(
     output: &SnapshotOutputPaths,
-) -> Result<bool, sandbox::SnapshotError> {
-    for artifact in snapshot_artifact_paths(output) {
-        match tokio::fs::symlink_metadata(&artifact).await {
-            Ok(metadata) if metadata.file_type().is_file() => {}
-            Ok(_) => return Ok(false),
-            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
-            Err(e) => return Err(io_error_with_path("stat snapshot artifact", &artifact, e).into()),
+) -> io::Result<SnapshotOutputValidation> {
+    let marker = output.complete_marker();
+    match tokio::fs::read(&marker).await {
+        Ok(content) if content == SNAPSHOT_COMPLETE_MARKER_CONTENT => {}
+        Ok(_) => return Ok(SnapshotOutputValidation::InvalidCompleteMarker(marker)),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            return Ok(SnapshotOutputValidation::MissingFile(marker));
+        }
+        Err(e) => {
+            return Err(io_error_with_path(
+                "read snapshot complete marker",
+                &marker,
+                e,
+            ));
         }
     }
-    Ok(true)
+
+    for artifact in output.required_artifacts() {
+        match tokio::fs::symlink_metadata(&artifact).await {
+            Ok(metadata) if metadata.file_type().is_file() => {}
+            Ok(_) => return Ok(SnapshotOutputValidation::NotRegularFile(artifact)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                return Ok(SnapshotOutputValidation::MissingFile(artifact));
+            }
+            Err(e) => return Err(io_error_with_path("stat snapshot artifact", &artifact, e)),
+        }
+    }
+    Ok(SnapshotOutputValidation::Complete)
 }
 
 pub(super) fn remove_file_if_exists_sync(path: &Path) -> std::io::Result<()> {
@@ -156,7 +205,7 @@ fn prepare_snapshot_output_sync(output: &SnapshotOutputPaths) -> Result<PathBuf,
     let work = output.work_dir();
     remove_file_if_exists_sync(&output.complete_marker())?;
     remove_dir_all_if_exists_sync(&work)?;
-    for stale in snapshot_artifact_paths(output) {
+    for stale in output.required_artifacts() {
         remove_file_if_exists_sync(&stale)?;
     }
     std::fs::create_dir_all(&work)?;
@@ -182,7 +231,7 @@ fn publish_snapshot_complete_marker_with_marker_sync(
     let mut marker_created = false;
 
     let result = (|| -> std::io::Result<()> {
-        for artifact in snapshot_artifact_paths(output) {
+        for artifact in output.required_artifacts() {
             require_snapshot_artifact_regular_file_sync(&artifact)?;
         }
 
@@ -210,16 +259,6 @@ fn publish_snapshot_complete_marker_with_marker_sync(
     }
 
     Ok(())
-}
-
-pub(super) async fn snapshot_complete_marker_present(
-    output: &SnapshotOutputPaths,
-) -> Result<bool, sandbox::SnapshotError> {
-    match tokio::fs::read(output.complete_marker()).await {
-        Ok(content) => Ok(content == SNAPSHOT_COMPLETE_MARKER_CONTENT),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
-        Err(e) => Err(e.into()),
-    }
 }
 
 #[cfg(test)]
@@ -256,12 +295,7 @@ mod tests {
         tokio::fs::create_dir_all(output.dir())
             .await
             .expect("create output dir");
-        for artifact in [
-            output.snapshot(),
-            output.memory(),
-            output.cow(),
-            output.cow_bitmap(),
-        ] {
+        for artifact in output.required_artifacts() {
             tokio::fs::write(&artifact, b"snapshot artifact")
                 .await
                 .unwrap_or_else(|e| panic!("write {}: {e}", artifact.display()));
@@ -269,11 +303,11 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_artifact_paths_lists_required_output_artifacts() {
+    fn required_artifacts_lists_snapshot_data_files() {
         let output = SnapshotOutputPaths::new(PathBuf::from("/data/images/test-snapshot"));
 
         assert_eq!(
-            snapshot_artifact_paths(&output),
+            output.required_artifacts(),
             [
                 output.snapshot(),
                 output.memory(),
@@ -404,7 +438,7 @@ mod tests {
             !tokio::fs::try_exists(&marker).await.unwrap(),
             "failed publication must remove its complete marker"
         );
-        for artifact in snapshot_artifact_paths(&output) {
+        for artifact in output.required_artifacts() {
             let content = tokio::fs::read(&artifact)
                 .await
                 .unwrap_or_else(|e| panic!("read {}: {e}", artifact.display()));
@@ -551,48 +585,97 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn snapshot_complete_marker_present_checks_exact_marker_content() {
+    async fn validate_snapshot_output_checks_exact_marker_content() {
         let dir = tempfile::tempdir().expect("tempdir");
         let output = SnapshotOutputPaths::new(dir.path().to_path_buf());
-        tokio::fs::create_dir_all(output.dir())
-            .await
-            .expect("create output dir");
+        write_required_snapshot_artifacts(&output).await;
 
-        assert!(
-            !snapshot_complete_marker_present(&output)
+        assert_eq!(
+            validate_snapshot_output(&output)
                 .await
-                .expect("check missing marker")
+                .expect("validate missing marker"),
+            SnapshotOutputValidation::MissingFile(output.complete_marker())
         );
 
         tokio::fs::write(output.complete_marker(), b"wrong marker")
             .await
             .expect("write malformed marker");
-        assert!(
-            !snapshot_complete_marker_present(&output)
+        assert_eq!(
+            validate_snapshot_output(&output)
                 .await
-                .expect("check malformed marker")
+                .expect("validate malformed marker"),
+            SnapshotOutputValidation::InvalidCompleteMarker(output.complete_marker())
         );
 
         tokio::fs::write(output.complete_marker(), SNAPSHOT_COMPLETE_MARKER_CONTENT)
             .await
             .expect("write valid marker");
-        assert!(
-            snapshot_complete_marker_present(&output)
+        assert_eq!(
+            validate_snapshot_output(&output)
                 .await
-                .expect("check valid marker")
+                .expect("validate complete snapshot"),
+            SnapshotOutputValidation::Complete
         );
     }
 
     #[tokio::test]
-    async fn snapshot_complete_marker_present_propagates_read_errors() {
+    async fn validate_snapshot_output_reports_missing_artifact() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = SnapshotOutputPaths::new(dir.path().to_path_buf());
+        write_required_snapshot_artifacts(&output).await;
+        tokio::fs::write(output.complete_marker(), SNAPSHOT_COMPLETE_MARKER_CONTENT)
+            .await
+            .expect("write valid marker");
+        tokio::fs::remove_file(output.cow_bitmap())
+            .await
+            .expect("remove bitmap");
+
+        assert_eq!(
+            validate_snapshot_output(&output)
+                .await
+                .expect("validate missing artifact"),
+            SnapshotOutputValidation::MissingFile(output.cow_bitmap())
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_snapshot_output_reports_non_regular_artifact() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = SnapshotOutputPaths::new(dir.path().to_path_buf());
+        write_required_snapshot_artifacts(&output).await;
+        tokio::fs::write(output.complete_marker(), SNAPSHOT_COMPLETE_MARKER_CONTENT)
+            .await
+            .expect("write valid marker");
+        tokio::fs::remove_file(output.snapshot())
+            .await
+            .expect("remove snapshot");
+        tokio::fs::create_dir(output.snapshot())
+            .await
+            .expect("replace snapshot with directory");
+
+        assert_eq!(
+            validate_snapshot_output(&output)
+                .await
+                .expect("validate directory artifact"),
+            SnapshotOutputValidation::NotRegularFile(output.snapshot())
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_snapshot_output_propagates_marker_read_errors() {
         let dir = tempfile::tempdir().expect("tempdir");
         let output = SnapshotOutputPaths::new(dir.path().to_path_buf());
         tokio::fs::create_dir_all(output.complete_marker())
             .await
             .expect("create marker directory");
 
-        let _err = snapshot_complete_marker_present(&output)
+        let err = validate_snapshot_output(&output)
             .await
             .expect_err("marker directory should fail to read as marker content");
+        assert!(
+            err.to_string()
+                .contains(&output.complete_marker().display().to_string()),
+            "error should include marker path: {err}"
+        );
     }
 }

--- a/crates/sandbox-fc/src/snapshot/provider.rs
+++ b/crates/sandbox-fc/src/snapshot/provider.rs
@@ -6,7 +6,7 @@ use sandbox::{PendingSnapshotPublish, SnapshotCreateConfig, SnapshotProvider};
 use crate::factory::config_hash;
 use crate::paths::SnapshotOutputPaths;
 
-use super::output::{snapshot_artifacts_are_regular_files, snapshot_complete_marker_present};
+use super::output::{SnapshotOutputValidation, validate_snapshot_output};
 use super::{SnapshotError, create_uncommitted_snapshot};
 
 /// Firecracker-backed snapshot provider.
@@ -32,10 +32,10 @@ impl SnapshotProvider for FirecrackerSnapshotProvider {
 
     async fn is_complete(&self, output_dir: &Path) -> Result<bool, sandbox::SnapshotError> {
         let output = SnapshotOutputPaths::new(output_dir.to_path_buf());
-        if !snapshot_complete_marker_present(&output).await? {
-            return Ok(false);
-        }
-        snapshot_artifacts_are_regular_files(&output).await
+        Ok(matches!(
+            validate_snapshot_output(&output).await?,
+            SnapshotOutputValidation::Complete
+        ))
     }
 }
 
@@ -45,7 +45,7 @@ mod tests {
 
     use crate::paths::SnapshotOutputPaths;
     use crate::snapshot::SNAPSHOT_COMPLETE_MARKER_CONTENT;
-    use crate::snapshot::output::{publish_snapshot_complete_marker, snapshot_artifact_paths};
+    use crate::snapshot::output::publish_snapshot_complete_marker;
 
     use super::*;
 
@@ -65,7 +65,7 @@ mod tests {
         }
 
         async fn write_required_snapshot_artifacts(&self) {
-            for artifact in snapshot_artifact_paths(&self.output) {
+            for artifact in self.output.required_artifacts() {
                 tokio::fs::write(&artifact, b"snapshot artifact")
                     .await
                     .unwrap_or_else(|e| panic!("write {}: {e}", artifact.display()));

--- a/crates/sandbox-fc/src/snapshot/publish.rs
+++ b/crates/sandbox-fc/src/snapshot/publish.rs
@@ -346,13 +346,7 @@ async fn cleanup_kept_cow_paths_after_publish_cancellation(paths: &KeptCowCleanu
 
 fn cleanup_uncommitted_snapshot_output_artifacts(output: &SnapshotOutputPaths) -> bool {
     let mut cleaned = true;
-    for path in [
-        output.complete_marker(),
-        output.snapshot(),
-        output.memory(),
-        output.cow(),
-        output.cow_bitmap(),
-    ] {
+    for path in std::iter::once(output.complete_marker()).chain(output.required_artifacts()) {
         match remove_file_if_exists_sync(&path) {
             Ok(()) => {}
             Err(e) => {


### PR DESCRIPTION
## Summary

- make `sandbox-fc` own canonical firecracker snapshot artifact paths and detailed completeness validation
- route provider and runner lock-time checks through the shared validator while preserving runner profile context and lock ordering
- remove the runner's duplicated snapshot layout and cover directory, symlink, and missing-bitmap regressions

## Scope

- no snapshot format, marker, nesting, schema, API, configuration, protocol, or lock-order changes
- valid existing snapshots remain accepted; malformed non-regular artifacts are now rejected consistently

## Validation

- `cargo test -p sandbox-fc --all-targets --all-features`
- `cargo test -p runner --all-targets --all-features`
- `cargo fmt --all --check`
- `cargo clippy -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox-fc -p runner --all-features --no-deps`

Closes #25452
