### PR TITLE
perf(python): bound proxy-log url rendering

### DIFF
--- a/crates/runner/mitm-addon/src/connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/connector_diagnostics.py
@@ -47,10 +47,9 @@ import connector_intent
 import flow_metadata
 import flow_metadata_keys as metadata_keys
 import matching
-import network_log_sanitization
 import request_classification
 import runtime_url_parsing
-from logging_utils import log_proxy_entry
+from logging_utils import log_proxy_entry, project_url_for_proxy_log
 
 _HTTP_STATUS_UNAUTHORIZED = 401
 _HTTP_STATUS_FORBIDDEN = 403
@@ -788,7 +787,7 @@ def _log_proxy_entry(
     candidate = _candidate_from_flow(flow)
     if candidate is None:
         return
-    safe_url = network_log_sanitization.sanitize_url_for_network_log(original_url)
+    url_projection = project_url_for_proxy_log(original_url)
     extra: dict[str, object] = {}
     ownership_reason = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_OWNERSHIP_REASON)
     if isinstance(ownership_reason, str) and ownership_reason:
@@ -801,15 +800,16 @@ def _log_proxy_entry(
     ownership_hint_status = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_OWNERSHIP_HINT_STATUS)
     if isinstance(ownership_hint_status, str) and ownership_hint_status:
         extra["ownership_hint_status"] = ownership_hint_status
+    extra.update(url_projection.truncation_fields())
     log_proxy_entry(
         flow_metadata.proxy_log_path(flow.metadata),
         "warn",
-        f"{candidate.connector_slug} is not configured for this run: {safe_url}",
+        f"{candidate.connector_slug} is not configured for this run: {url_projection.value}",
         type="connector_diagnostic",
         connector=candidate.connector_slug,
         reason=candidate.reason,
         upstream_status=upstream_status,
-        url=original_url,
+        url=url_projection,
         **extra,
     )
     flow.metadata[_CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED] = True

--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -7,6 +7,7 @@ log entries, and extracting firewall metadata.
 import json
 import time
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from mitmproxy import ctx, http
@@ -21,10 +22,25 @@ _PROXY_LOG_RESERVED_FIELDS = {"timestamp", "level", "message"}
 # Network log size fields are consumed as JavaScript numbers downstream.
 NETWORK_LOG_MAX_SAFE_SIZE = 9_007_199_254_740_991
 
-# Keep URL-driven HTTP rows below the runner uploader's 1 MiB payload envelope.
-HTTP_NETWORK_LOG_MAX_URL_CHARACTERS = 1_000_000
+# Network rows limit the complete request URL; proxy diagnostics apply the same
+# number to the query-free value they retain.
+URL_LOG_MAX_CHARACTERS = 1_000_000
 HTTP_NETWORK_LOG_MAX_JSONL_BYTES = 1_000_000
-_HTTP_NETWORK_LOG_TRUNCATED_URL = "[truncated]"
+_TRUNCATED_URL = "[truncated]"
+
+
+@dataclass(frozen=True)
+class _ProxyLogUrlProjection:
+    value: str
+    original_char_count: int | None = None
+
+    def truncation_fields(self) -> dict[str, object]:
+        if self.original_char_count is None:
+            return {}
+        return {
+            "url_truncated": True,
+            "url_original_char_count": self.original_char_count,
+        }
 
 
 def elapsed_ms(start_time: float | None) -> int:
@@ -104,7 +120,7 @@ def log_network_entry(log_path: str, entry: dict) -> None:
 def _http_network_log_omission_entry(entry: dict, original_url_char_count: int) -> dict:
     return {
         **entry,
-        "url": _HTTP_NETWORK_LOG_TRUNCATED_URL,
+        "url": _TRUNCATED_URL,
         "url_truncated": True,
         "url_original_char_count": original_url_char_count,
     }
@@ -117,7 +133,7 @@ def log_http_network_entry(log_path: str, entry: dict, raw_url: str) -> None:
 
     original_url_char_count = len(raw_url)
     log_entry = {**entry, "timestamp": _utc_log_timestamp()}
-    if original_url_char_count > HTTP_NETWORK_LOG_MAX_URL_CHARACTERS:
+    if original_url_char_count > URL_LOG_MAX_CHARACTERS:
         _write_jsonl_entry(
             log_path,
             _http_network_log_omission_entry(log_entry, original_url_char_count),
@@ -141,15 +157,31 @@ def log_http_network_entry(log_path: str, entry: dict, raw_url: str) -> None:
     jsonl_writer.write_jsonl_line(log_path, line, "network")
 
 
+def project_url_for_proxy_log(raw_url: str) -> _ProxyLogUrlProjection:
+    """Project a request URL without unbounded retained-path processing."""
+    value = network_log_sanitization.sanitize_url_for_network_log_with_retained_limit(
+        raw_url,
+        URL_LOG_MAX_CHARACTERS,
+    )
+    if value is None:
+        return _ProxyLogUrlProjection(_TRUNCATED_URL, len(raw_url))
+    return _ProxyLogUrlProjection(value)
+
+
 def sanitize_proxy_log_extra_value(key: str, value: object) -> object:
     """Sanitize the narrow set of proxy-log extras owned by this module.
 
-    Only the exact ``url`` field is treated specially, and only when the
-    value is a string.  Every other field is returned unchanged; this helper
-    is not a general secret-redaction boundary for arbitrary proxy-log data.
+    Only the exact ``url`` field is treated specially.  Raw strings are
+    sanitized here; a projection produced by this module is
+    already safe and is unwrapped without repeated URL processing.  Every
+    other field is returned unchanged; this helper is not a general
+    secret-redaction boundary for arbitrary proxy-log data.
     """
-    if key == "url" and isinstance(value, str):
-        return network_log_sanitization.sanitize_url_for_network_log(value)
+    if key == "url":
+        if isinstance(value, _ProxyLogUrlProjection):
+            return value.value
+        if isinstance(value, str):
+            return network_log_sanitization.sanitize_url_for_network_log(value)
     return value
 
 
@@ -164,8 +196,9 @@ def log_proxy_entry(
 
     The logger owns the canonical ``timestamp``, ``level``, and ``message``
     fields; extras with those exact names are ignored and cannot override
-    them.  Among remaining extras, only an exact ``url`` string is sanitized
-    by ``sanitize_proxy_log_extra_value``.  All other extras are written as
+    them.  Among remaining extras, an exact raw string ``url`` is sanitized by
+    ``sanitize_proxy_log_extra_value``; a projection from this module is
+    unwrapped without repeated processing.  All other extras are written as
     provided, so callers must pass only values that are safe to persist and
     JSON-serializable.
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -55,7 +55,6 @@ import http_local_responses
 import http_network_log
 import matching
 import mitmproxy_compat
-import network_log_sanitization
 import platform_api
 import registry
 import request_classification
@@ -97,6 +96,7 @@ from logging_utils import (
     elapsed_ms,
     log_http_network_entry,
     log_proxy_entry,
+    project_url_for_proxy_log,
     shutdown_log_writer,
 )
 from url_utils import AuthorityValidationError, TrustedAuthority, get_trusted_authority
@@ -1819,13 +1819,14 @@ def _finish_response_handling(
 
     # Log errors to per-job proxy log and mitmproxy console
     if flow.response and flow.response.status_code >= _HTTP_STATUS_ERROR_MIN:
-        safe_url = network_log_sanitization.sanitize_url_for_network_log(original_url)
+        url_projection = project_url_for_proxy_log(original_url)
         log_proxy_entry(
             proxy_log_path,
             "warn",
-            f"Response {flow.response.status_code}: {safe_url}",
+            f"Response {flow.response.status_code}: {url_projection.value}",
             type="http_error",
             status=flow.response.status_code,
+            **url_projection.truncation_fields(),
         )
 
 
@@ -1885,13 +1886,14 @@ def _handle_error(flow: http.HTTPFlow) -> None:
     if response_streaming.finalize_interrupted_connector_response_state(flow):
         usage.report_connector_usage(flow, run_id)
 
-    safe_url = network_log_sanitization.sanitize_url_for_network_log(original_url)
+    url_projection = project_url_for_proxy_log(original_url)
     log_proxy_entry(
         proxy_log_path,
         "warn",
-        f"Error: {error_msg}: {safe_url}",
+        f"Error: {error_msg}: {url_projection.value}",
         type="connection_error",
         error=error_msg,
+        **url_projection.truncation_fields(),
     )
 
 

--- a/crates/runner/mitm-addon/src/network_log_sanitization.py
+++ b/crates/runner/mitm-addon/src/network_log_sanitization.py
@@ -69,6 +69,35 @@ def _sanitize_malformed_authority_for_network_log(
     return urllib.parse.urlunsplit((parts.scheme, netloc, path, "", ""))
 
 
+def _sanitize_retained_url_for_network_log(retained_value: str) -> str:
+    normalized_value = _normalize_for_urlsplit(retained_value)
+    try:
+        parts = split_runtime_url(normalized_value)
+    except ValueError:
+        return _sanitize_url_text_fallback_for_network_log(normalized_value)
+
+    malformed_authority_url = _sanitize_malformed_authority_for_network_log(normalized_value, parts)
+    if malformed_authority_url is not None:
+        return malformed_authority_url
+
+    netloc = _sanitize_netloc_for_network_log(parts.netloc)
+    return urllib.parse.urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+
+
+def _bounded_retained_url(value: str, max_characters: int) -> str | None:
+    if len(value) <= max_characters:
+        return strip_url_query_and_fragment(value)
+
+    search_end = max_characters + 1
+    query_start = value.find("?", 0, search_end)
+    fragment_start = value.find("#", 0, query_start if query_start >= 0 else search_end)
+    if fragment_start >= 0:
+        return value[:fragment_start]
+    if query_start >= 0:
+        return value[:query_start]
+    return None
+
+
 def sanitize_url_for_network_log(value: str) -> str:
     """Return a URL string without credentials or query data for diagnostics.
 
@@ -83,18 +112,21 @@ def sanitize_url_for_network_log(value: str) -> str:
     contents.
     """
     retained_value = strip_url_query_and_fragment(value)
-    normalized_value = _normalize_for_urlsplit(retained_value)
-    try:
-        parts = split_runtime_url(normalized_value)
-    except ValueError:
-        return _sanitize_url_text_fallback_for_network_log(normalized_value)
+    return _sanitize_retained_url_for_network_log(retained_value)
 
-    malformed_authority_url = _sanitize_malformed_authority_for_network_log(normalized_value, parts)
-    if malformed_authority_url is not None:
-        return malformed_authority_url
 
-    netloc = _sanitize_netloc_for_network_log(parts.netloc)
-    return urllib.parse.urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+def sanitize_url_for_network_log_with_retained_limit(value: str, max_characters: int) -> str | None:
+    """Sanitize a URL only when its retained query-free value fits the limit.
+
+    Raw inputs above the limit search for query and fragment delimiters only
+    through the first ``max_characters + 1`` characters.  A delimiter within
+    that window proves the retained value is bounded; otherwise no raw prefix
+    is returned or processed.
+    """
+    retained_value = _bounded_retained_url(value, max_characters)
+    if retained_value is None:
+        return None
+    return _sanitize_retained_url_for_network_log(retained_value)
 
 
 def sanitize_request_url_for_network_log(value: str) -> str:

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -726,6 +726,42 @@ class TestErrorHandler:
         assert "api_key=secret" not in entry["message"]
         assert "#frag" not in entry["message"]
 
+    def test_error_proxy_log_omits_retained_url_above_processing_limit(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        secret_userinfo = "proxy-error-user:proxy-error-password"
+        raw_url = f"https://{secret_userinfo}@target.example.com/path/" + ("x" * 1_000_000)
+        network_log_path = tmp_path / "network.jsonl"
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow = real_flow(with_response=False, host="target.example.com")
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(network_log_path)
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
+        flow.metadata[metadata_keys.ORIGINAL_URL] = raw_url
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        http_network_log.set_target(
+            flow,
+            url=raw_url,
+            host="target.example.com",
+            port=443,
+        )
+        flow.error = Error("connection reset by peer")
+
+        with mitm_ctx():
+            mitm_addon.error(flow)
+
+        [network_entry] = read_jsonl_entries_after_flush(network_log_path)
+        assert network_entry["url"] == "[truncated]"
+        [proxy_entry] = read_jsonl_entries_after_flush(proxy_log_path)
+        assert proxy_entry["message"] == "Error: connection reset by peer: [truncated]"
+        assert proxy_entry["type"] == "connection_error"
+        assert proxy_entry["error"] == "connection reset by peer"
+        assert proxy_entry["url_truncated"] is True
+        assert proxy_entry["url_original_char_count"] == len(raw_url)
+        serialized_proxy_entry = json.dumps(proxy_entry)
+        assert secret_userinfo not in serialized_proxy_entry
+        assert len(serialized_proxy_entry.encode()) < 1_000
+
     def test_full_path_error_to_webhook(
         self, tmp_path, real_flow, mitm_ctx, sync_usage_executor, usage_webhook_api
     ):

--- a/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
@@ -87,6 +87,45 @@ async def test_replaces_unauthenticated_connector_401_body(tmp_path, real_flow, 
     assert proxy_entry["type"] == "connector_diagnostic"
     assert proxy_entry["connector"] == "fal"
     assert proxy_entry["upstream_status"] == 401
+    assert proxy_entry["url"] == flow.metadata[metadata_keys.ORIGINAL_URL]
+    assert proxy_entry["message"].endswith(f": {proxy_entry['url']}")
+    assert "url_truncated" not in proxy_entry
+    assert "url_original_char_count" not in proxy_entry
+
+
+async def test_omits_oversized_connector_diagnostic_url_once(tmp_path, real_flow, mitm_ctx):
+    reg_path = write_connector_diagnostic_capture_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="fal.run",
+        path=f"/fal-ai/{'x' * 1_000_000}",
+        method="POST",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        record_connector_diagnostic_requestheaders_context(flow)
+        flow.response = tutils.tresp(
+            status_code=401,
+            headers=header_map({"content-type": "text/plain", "content-length": "8"}),
+            content=b"upstream",
+        )
+        mitm_addon.response(flow)
+
+    raw_url = flow.metadata[metadata_keys.ORIGINAL_URL]
+    proxy_entries = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert [entry["type"] for entry in proxy_entries] == ["connector_diagnostic", "http_error"]
+    connector_entry, http_error_entry = proxy_entries
+    assert connector_entry["message"].endswith(": [truncated]")
+    assert connector_entry["url"] == "[truncated]"
+    assert connector_entry["url_truncated"] is True
+    assert connector_entry["url_original_char_count"] == len(raw_url)
+    assert http_error_entry["message"] == "Response 401: [truncated]"
+    assert http_error_entry["url_truncated"] is True
+    assert http_error_entry["url_original_char_count"] == len(raw_url)
+    serialized_entries = json.dumps(proxy_entries)
+    assert "x" * 100 not in serialized_entries
+    assert len(serialized_entries.encode()) < 2_000
 
 
 async def test_replaces_buffered_head_401_with_bodyless_diagnostic(tmp_path, real_flow, mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
@@ -48,6 +48,9 @@ async def test_replaces_unauthenticated_connector_401_body(tmp_path, real_flow, 
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
         record_connector_diagnostic_requestheaders_context(flow)
+        flow.metadata[metadata_keys.ORIGINAL_URL] = (
+            "https://fal.run/fal-ai/nano-banana-pro?debug=secret#fragment"
+        )
         flow.response = tutils.tresp(
             status_code=401,
             headers=header_map({"content-type": "text/plain", "content-length": "8"}),
@@ -87,8 +90,11 @@ async def test_replaces_unauthenticated_connector_401_body(tmp_path, real_flow, 
     assert proxy_entry["type"] == "connector_diagnostic"
     assert proxy_entry["connector"] == "fal"
     assert proxy_entry["upstream_status"] == 401
-    assert proxy_entry["url"] == flow.metadata[metadata_keys.ORIGINAL_URL]
+    assert proxy_entry["url"] == "https://fal.run/fal-ai/nano-banana-pro"
     assert proxy_entry["message"].endswith(f": {proxy_entry['url']}")
+    serialized_proxy_entry = json.dumps(proxy_entry)
+    assert "debug=secret" not in serialized_proxy_entry
+    assert "#fragment" not in serialized_proxy_entry
     assert "url_truncated" not in proxy_entry
     assert "url_original_char_count" not in proxy_entry
 

--- a/crates/runner/mitm-addon/tests/test_response_handler_logging.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_logging.py
@@ -1124,7 +1124,9 @@ def test_error_status_logs_warning(tmp_path, real_flow, headers):
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
     flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log)
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
-    flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/fail?api_key=secret#frag"
+    flow.metadata[metadata_keys.ORIGINAL_URL] = (
+        "https://user:pass@api.example.com/fail?api_key=secret#frag"
+    )
 
     flow.response = tutils.tresp(status_code=500, headers=http.Headers())
 
@@ -1133,5 +1135,6 @@ def test_error_status_logs_warning(tmp_path, real_flow, headers):
     assert jsonl_exists_after_flush(proxy_log)
     [entry] = read_jsonl_entries_after_flush(proxy_log)
     assert entry["message"] == "Response 500: https://api.example.com/fail"
+    assert "user:pass" not in entry["message"]
     assert "api_key=secret" not in entry["message"]
     assert "#frag" not in entry["message"]

--- a/crates/runner/mitm-addon/tests/test_response_handler_logging.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_logging.py
@@ -31,6 +31,21 @@ from tests.requestheaders_helpers import await_requestheaders_result
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
 
+class _BoundedFindUrl(str):
+    find_calls: list[tuple[str, int, int | None]]
+
+    def __new__(cls, value: str) -> "_BoundedFindUrl":
+        instance = super().__new__(cls, value)
+        instance.find_calls = []
+        return instance
+
+    def find(self, sub: str, start: int = 0, end: int | None = None) -> int:
+        self.find_calls.append((sub, start, end))
+        if end is None:
+            raise AssertionError("oversized retained URLs must not use an unbounded delimiter scan")
+        return super().find(sub, start, end)
+
+
 def test_calculates_latency_and_logs(registry_file, tmp_path, real_flow, mitm_ctx, headers):
     flow = real_flow(with_response=False, host="api.anthropic.com")
     log_path = str(tmp_path / "network.jsonl")
@@ -387,9 +402,12 @@ def test_network_log_does_not_attribute_non_url_oversize_to_url(tmp_path, real_f
     assert "url_original_char_count" not in entry
 
 
-def test_proxy_log_discards_large_query_before_url_processing(tmp_path, real_flow, mitm_ctx):
+@pytest.mark.parametrize("delimiter", ["?", "#"], ids=["query", "fragment"])
+def test_proxy_log_discards_large_suffix_before_url_processing(
+    tmp_path, real_flow, mitm_ctx, delimiter
+):
     retained_url = "https://target.example.com/path"
-    raw_url = f"{retained_url}?payload={'x' * 200_000}"
+    raw_url = f"{retained_url}{delimiter}payload={'x' * 1_000_000}"
     proxy_log_path = tmp_path / "proxy.jsonl"
     flow = real_flow(with_response=False, host="target.example.com")
     flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
@@ -420,6 +438,71 @@ def test_proxy_log_discards_large_query_before_url_processing(tmp_path, real_flo
     assert peak_allocated_bytes < len(raw_url)
     [entry] = read_jsonl_entries_after_flush(proxy_log_path)
     assert entry["message"] == f"Response 500: {retained_url}"
+    assert "url_truncated" not in entry
+    assert "url_original_char_count" not in entry
+
+
+@pytest.mark.parametrize(
+    "discarded_suffix",
+    ["?token=secret#fragment", "#fragment?token=secret"],
+    ids=["query-first", "fragment-first"],
+)
+def test_proxy_log_retains_query_free_url_at_processing_limit(
+    tmp_path, real_flow, mitm_ctx, discarded_suffix
+):
+    prefix = "https://target.example.com/path/"
+    retained_url = prefix + ("x" * (1_000_000 - len(prefix)))
+    raw_url = f"{retained_url}{discarded_suffix}"
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    flow = real_flow(with_response=False, host="target.example.com")
+    flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
+    flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow.metadata[metadata_keys.ORIGINAL_URL] = raw_url
+    flow.response = tutils.tresp(status_code=500, headers=http.Headers())
+
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    [entry] = read_jsonl_entries_after_flush(proxy_log_path)
+    assert entry["message"] == f"Response 500: {retained_url}"
+    assert "secret" not in entry["message"]
+    assert "fragment" not in entry["message"]
+    assert "url_truncated" not in entry
+    assert "url_original_char_count" not in entry
+
+
+def test_proxy_log_omits_retained_url_above_processing_limit(tmp_path, real_flow, mitm_ctx):
+    secret_userinfo = "proxy-log-user:proxy-log-password"
+    raw_url = _BoundedFindUrl(
+        f"https://{secret_userinfo}@target.example.com/path/" + ("x" * 1_000_000)
+    )
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    flow = real_flow(with_response=False, host="target.example.com")
+    flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
+    flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow.metadata[metadata_keys.ORIGINAL_URL] = raw_url
+    flow.response = tutils.tresp(status_code=500, headers=http.Headers())
+
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    serialized = read_jsonl_text_after_flush(proxy_log_path)
+    entry = json.loads(serialized)
+    assert entry["message"] == "Response 500: [truncated]"
+    assert entry["type"] == "http_error"
+    assert entry["status"] == 500
+    assert entry["url_truncated"] is True
+    assert entry["url_original_char_count"] == len(raw_url)
+    assert secret_userinfo not in serialized
+    assert len(serialized.encode()) < 1_000
+    assert raw_url.find_calls == [
+        ("?", 0, 1_000_001),
+        ("#", 0, 1_000_001),
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- bound proxy diagnostic URL projection to the retained query/fragment-free value before normalization, parsing, message construction, or serialization
- emit a fixed marker plus exact truncation metadata for oversized retained paths while preserving short paths followed by large discarded query or fragment data
- reuse one immutable projection for connector diagnostic messages and structured URL fields, without weakening sanitization for ordinary raw URL callers
- cover response errors, connection errors, connector diagnostics, delimiter ordering, and the exact retained-length boundary through real addon entry points

## Scope

- no API, database, queue protocol, persisted relational data, dependency, environment variable, feature switch, or generated contract changes
- the existing top-level network-log policy remains unchanged

## Performance

A seven-iteration real response-hook probe constructed each input before measurement. Multi-megabyte retained paths now produce bounded proxy rows:

| Path payload | Median hook time | Peak traced allocation | JSONL bytes |
| ---: | ---: | ---: | ---: |
| 1 MiB | 0.217 ms | 2,670 bytes | 195 |
| 5 MiB | 0.196 ms | 2,518 bytes | 195 |
| 16 MiB | 0.199 ms | 2,454 bytes | 196 |
| 33 MiB | 0.175 ms | 2,390 bytes | 196 |

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_response_handler_logging.py tests/test_error_handler.py tests/test_response_handler_connector_diagnostics.py tests/test_logging_utils.py` (144 passed)
- `uv run --no-sync python -m pytest tests/` (4,942 passed)
- `lefthook run pre-commit`
- `git diff --check`

Closes #25451
