### PR TITLE
docs(python): document addon load initialization contract

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -154,7 +154,13 @@ class _BufferedRequestBodyCheck:
 
 
 def load(loader: Loader) -> None:
-    """Register custom options for the addon."""
+    """Initialize compatibility and process-global state before addon options.
+
+    Exact-version mitmproxy and wsproto compatibility is installed first. An
+    unreviewed runtime raises ``RuntimeError`` before the process-global runner
+    usage-flush signal handler or custom options are registered. The signal
+    handler is installed next, followed by custom option registration.
+    """
     mitmproxy_compat.install_runtime_compatibility()
     signal.signal(
         runner_flush_lifecycle.RUNNER_USAGE_FLUSH_SIGNAL,


### PR DESCRIPTION
## Summary

- document that exact-version mitmproxy and wsproto compatibility is installed before later addon initialization
- document the fail-fast `RuntimeError` behavior and process-global usage-flush signal registration order

## Scope

- documentation only; executable statements and their ordering are unchanged
- no new tests because existing configuration-hook tests already cover the documented behavior

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,938 passed)

Closes #25472
