### PR TITLE
docs(ably-subscriber): clarify reconnect timeout scope

### DIFF
--- a/crates/ably-subscriber/src/connection/event_loop.rs
+++ b/crates/ably-subscriber/src/connection/event_loop.rs
@@ -979,8 +979,11 @@ async fn renew_token(p: &mut EventLoopState) -> Result<(), Error> {
 // Reconnection
 // ---------------------------------------------------------------------------
 
-/// Attempt a single reconnect (resume or fresh). Callers are responsible for
-/// applying an outer timeout (e.g. `timing.reconnect_timeout`).
+/// Attempt a single reconnect (resume or fresh).
+///
+/// Reconnect setup through sending the channel `ATTACH` is bounded by
+/// `timing.reconnect_timeout`. Waiting for the attach outcome is then separately
+/// bounded by `timing.realtime_request_timeout`.
 ///
 /// Connection mutations are deferred until the transport is connected and the
 /// channel attach attempt has produced a definitive outcome. If the server

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -189,7 +189,11 @@ pub struct TimingConfig {
     /// Timeout for protocol/WebSocket close operations and the total wait in
     /// [`Subscription::close_and_wait`](crate::Subscription::close_and_wait).
     pub close_timeout: Duration,
-    /// Timeout wrapping each individual reconnect attempt.
+    /// Timeout for reconnect setup through sending the channel `ATTACH`.
+    ///
+    /// Waiting for the attach outcome is separately bounded by
+    /// [`realtime_request_timeout`](Self::realtime_request_timeout), so a
+    /// complete reconnect attempt can approach the sum of both timeouts.
     pub reconnect_timeout: Duration,
     /// Fallback `max_idle_interval` when the server omits connection details.
     /// If connection details are present but `maxIdleInterval` is zero or


### PR DESCRIPTION
## Summary

- clarify that `TimingConfig::reconnect_timeout` bounds reconnect setup through sending channel `ATTACH`
- document the separate `realtime_request_timeout` budget for the following attach-outcome wait
- correct `attempt_reconnect` documentation to match the existing two-phase implementation

## Scope

Documentation only. This PR does not change reconnect behavior, timing defaults, public types, protocol handling, or tests.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p ably-subscriber --all-targets --all-features`
- `cd crates && cargo doc -p ably-subscriber --all-features --no-deps`
- `cd crates && cargo test -p ably-subscriber`
- repository pre-commit hooks (workspace Rust formatting, Clippy, Rustdoc, file-size, and commit-message checks)

Closes #25475
