### PR TITLE
test(runner): cover retry timer in-flight guard

### DIFF
--- a/crates/runner/src/retry.rs
+++ b/crates/runner/src/retry.rs
@@ -156,14 +156,26 @@ mod tests {
         assert_eq!(rs.consecutive_failures, 0);
     }
 
-    #[test]
-    fn timer_ready_requires_no_handle_and_past_restart() {
-        let mut rs: RetryState<()> =
+    #[tokio::test]
+    async fn timer_ready_requires_no_handle_and_past_restart() {
+        let mut rs: RetryState<tokio::task::JoinHandle<()>> =
             RetryState::new(Duration::from_secs(0), Duration::from_secs(60), None);
         // No restart_at → not ready
         assert!(!rs.timer_ready());
         // Set restart_at to the past so it's immediately ready.
         rs.restart_at = Some(Instant::now() - Duration::from_secs(1));
+        assert!(rs.timer_ready());
+
+        rs.handle = Some(tokio::spawn(std::future::pending::<()>()));
+        let ready_while_in_flight = rs.timer_ready();
+
+        // Reap the task before asserting so a regression cannot detach it.
+        let handle = rs.handle.take().unwrap();
+        handle.abort();
+        let error = handle.await.unwrap_err();
+        assert!(error.is_cancelled());
+
+        assert!(!ready_while_in_flight);
         assert!(rs.timer_ready());
     }
 


### PR DESCRIPTION
## Summary

- exercise an elapsed retry deadline while a real pending task handle remains in flight
- assert the handle guard blocks readiness, then abort and await the task before checking the result
- verify the unchanged elapsed deadline becomes ready after the handle is removed

## Explicit exclusions

- no production retry behavior, caller logic, dependency, API, schema, persisted data, or protocol changes

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner retry::tests::timer_ready_requires_no_handle_and_past_restart -- --exact`
- mutation proof: removing `self.handle.is_none() &&` makes the focused test fail at the in-flight readiness assertion; restoring it makes the test pass
- `cargo test -p runner --bin runner`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`

Closes #25474
