### PR TITLE
refactor(mitm-addon): share threaded http test server

### DIFF
--- a/crates/runner/mitm-addon/tests/auth_endpoint_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_endpoint_helpers.py
@@ -3,10 +3,10 @@
 import contextlib
 import json
 import threading
-from collections import deque
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from tests.threaded_http_test_server import ThreadedHttpTestServer
 
 
 @dataclass(frozen=True)
@@ -21,14 +21,6 @@ class AuthEndpointRequest:
         body = json.loads(self.body)
         assert isinstance(body, dict)
         return body
-
-
-@dataclass(frozen=True)
-class AuthEndpointResponse:
-    status: int
-    body: bytes
-    headers: tuple[tuple[str, str], ...] = ()
-    release_event: threading.Event | None = None
 
 
 def firewall_auth_success_response(
@@ -64,28 +56,24 @@ class FakeAuthEndpoint:
     """
 
     def __init__(self) -> None:
-        self._condition = threading.Condition()
-        self._requests: list[AuthEndpointRequest] = []
-        self._responses: deque[AuthEndpointResponse] = deque()
-        self._release_events: list[threading.Event] = []
-        self._server: ThreadingHTTPServer | None = None
-        self._thread: threading.Thread | None = None
+        self._http = ThreadedHttpTestServer(
+            request_factory=AuthEndpointRequest,
+            default_status=500,
+            default_body=b"unexpected auth request",
+            thread_name="auth-endpoint-test-server",
+        )
 
     @property
     def api_url(self) -> str:
-        assert self._server is not None
-        host, port = self._server.server_address[:2]
-        return f"http://{host}:{port}"
+        return self._http.api_url
 
     @property
     def requests(self) -> tuple[AuthEndpointRequest, ...]:
-        with self._condition:
-            return tuple(self._requests)
+        return self._http.requests
 
     @property
     def request_count(self) -> int:
-        with self._condition:
-            return len(self._requests)
+        return self._http.request_count
 
     def queue_json_response(
         self,
@@ -121,17 +109,12 @@ class FakeAuthEndpoint:
         When no queued response remains, the helper returns its synthetic
         unexpected-request HTTP 500 response.
         """
-        with self._condition:
-            if release_event is not None:
-                self._release_events.append(release_event)
-            self._responses.append(
-                AuthEndpointResponse(
-                    status=status,
-                    body=body,
-                    headers=tuple(headers),
-                    release_event=release_event,
-                )
-            )
+        self._http.queue_response(
+            status,
+            body=body,
+            headers=headers,
+            release_event=release_event,
+        )
 
     def wait_for_request_count(self, count: int, *, timeout: float = 2.0) -> bool:
         """Wait until at least ``count`` auth requests have been recorded.
@@ -139,77 +122,9 @@ class FakeAuthEndpoint:
         Use this instead of sleeps when concurrent tests coordinate with a
         blocked queued response or auth-cache request coalescing.
         """
-        with self._condition:
-            return self._condition.wait_for(lambda: len(self._requests) >= count, timeout)
+        return self._http.wait_for_request_count(count, timeout=timeout)
 
     @contextlib.contextmanager
     def run(self) -> Iterator["FakeAuthEndpoint"]:
-        endpoint = self
-
-        class _Handler(BaseHTTPRequestHandler):
-            def do_GET(self) -> None:
-                endpoint._handle_request(self)
-
-            def do_POST(self) -> None:
-                endpoint._handle_request(self)
-
-            def log_message(self, message_format: str, *args: object) -> None:
-                return None
-
-        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
-        self._server.daemon_threads = True
-        server = self._server
-
-        def serve_forever() -> None:
-            server.serve_forever(poll_interval=0.01)
-
-        self._thread = threading.Thread(
-            target=serve_forever,
-            name="auth-endpoint-test-server",
-            daemon=True,
-        )
-        self._thread.start()
-        try:
+        with self._http.run():
             yield self
-        finally:
-            for release_event in self._release_events:
-                release_event.set()
-            self._server.shutdown()
-            self._thread.join(timeout=2.0)
-            self._server.server_close()
-            self._server = None
-            self._thread = None
-
-    def _record_request_and_reserve_response(
-        self, request: AuthEndpointRequest
-    ) -> AuthEndpointResponse:
-        with self._condition:
-            self._requests.append(request)
-            self._condition.notify_all()
-            if self._responses:
-                return self._responses.popleft()
-            return AuthEndpointResponse(status=500, body=b"unexpected auth request")
-
-    def _handle_request(self, handler: BaseHTTPRequestHandler) -> None:
-        content_length = int(handler.headers.get("content-length", "0"))
-        body = handler.rfile.read(content_length)
-        response = self._record_request_and_reserve_response(
-            AuthEndpointRequest(
-                method=handler.command,
-                path=handler.path,
-                headers={key.lower(): value for key, value in handler.headers.items()},
-                body=body,
-            )
-        )
-
-        if response.release_event is not None:
-            response.release_event.wait()
-
-        handler.send_response(response.status)
-        for name, value in response.headers:
-            handler.send_header(name, value)
-        if response.body:
-            handler.send_header("Content-Length", str(len(response.body)))
-        handler.end_headers()
-        if response.body:
-            handler.wfile.write(response.body)

--- a/crates/runner/mitm-addon/tests/test_http_test_helpers.py
+++ b/crates/runner/mitm-addon/tests/test_http_test_helpers.py
@@ -5,17 +5,26 @@ from __future__ import annotations
 import http.client
 import threading
 import urllib.parse
-from collections.abc import Callable
-from contextlib import AbstractContextManager
+from collections.abc import Mapping
+from dataclasses import dataclass
 from types import TracebackType
 from unittest.mock import patch
 
 from tests.auth_endpoint_helpers import FakeAuthEndpoint
 from tests.thread_helpers import ThreadUnderTest, wait_for_event
+from tests.threaded_http_test_server import ThreadedHttpTestServer
 from tests.usage_helpers import UsageWebhookServer
 
 _THREAD_TIMEOUT_SECONDS = 2.0
 _Response = tuple[int, bytes]
+
+
+@dataclass(frozen=True)
+class _CapturedRequest:
+    method: str
+    path: str
+    headers: dict[str, str]
+    body: bytes
 
 
 class _PauseFirstHandlerReacquire:
@@ -100,7 +109,13 @@ class _PauseFirstHandlerReacquire:
         self.release()
 
 
-def _post(url: str) -> _Response:
+def _request(
+    method: str,
+    url: str,
+    *,
+    body: bytes | None = None,
+    headers: Mapping[str, str] | None = None,
+) -> _Response:
     parsed = urllib.parse.urlsplit(url)
     assert parsed.scheme == "http"
     assert parsed.hostname is not None
@@ -110,11 +125,20 @@ def _post(url: str) -> _Response:
         timeout=_THREAD_TIMEOUT_SECONDS,
     )
     try:
-        connection.request("POST", parsed.path, body=b"{}")
+        connection.request(
+            method,
+            parsed.path,
+            body=body,
+            headers={} if headers is None else headers,
+        )
         response = connection.getresponse()
         return response.status, response.read()
     finally:
         connection.close()
+
+
+def _post(url: str) -> _Response:
+    return _request("POST", url, body=b"{}")
 
 
 def _start_post(
@@ -136,21 +160,20 @@ def _start_post(
 
 def _assert_response_alignment(
     *,
+    server: ThreadedHttpTestServer[_CapturedRequest],
     gate: _PauseFirstHandlerReacquire,
-    gate_context: AbstractContextManager[object],
-    url: Callable[[str], str],
-    recorded_paths: Callable[[], list[str]],
-    default_response: _Response,
 ) -> None:
     responses: dict[str, _Response] = {}
     responses_lock = threading.Lock()
     first = None
     second = None
+    with patch.object(threading, "RLock", return_value=gate):
+        condition = threading.Condition()
 
-    with gate_context:
+    with patch.object(server, "_condition", condition), server.run():
         try:
             first = _start_post(
-                url("/first"),
+                f"{server.api_url}/first",
                 key="first",
                 responses=responses,
                 responses_lock=responses_lock,
@@ -161,7 +184,7 @@ def _assert_response_alignment(
                 threads=(first,),
             )
             second = _start_post(
-                url("/second"),
+                f"{server.api_url}/second",
                 key="second",
                 responses=responses,
                 responses_lock=responses_lock,
@@ -175,43 +198,62 @@ def _assert_response_alignment(
             if second is not None:
                 second.join(timeout=_THREAD_TIMEOUT_SECONDS)
 
-    assert recorded_paths()[:2] == ["/first", "/second"]
-    assert responses == {
-        "first": (201, b"first"),
-        "second": (202, b"second"),
-    }
-    assert _post(url("/default")) == default_response
+        assert [request.path for request in server.requests[:2]] == ["/first", "/second"]
+        assert responses == {
+            "first": (201, b"first"),
+            "second": (202, b"second"),
+        }
+        assert _post(f"{server.api_url}/default") == (503, b"default")
 
 
-def test_usage_webhook_server_aligns_responses_with_recorded_order():
-    server = UsageWebhookServer()
+def test_threaded_http_server_aligns_responses_with_recorded_order():
+    server = ThreadedHttpTestServer(
+        request_factory=_CapturedRequest,
+        default_status=503,
+        default_body=b"default",
+        thread_name="shared-http-test-server",
+    )
     server.queue_response(201, body=b"first")
     server.queue_response(202, body=b"second")
-    gate = _PauseFirstHandlerReacquire()
-
-    with server.run():
-        _assert_response_alignment(
-            gate=gate,
-            gate_context=patch.object(server, "_lock", gate),
-            url=server.url,
-            recorded_paths=lambda: [request.path for request in server.requests],
-            default_response=(204, b""),
-        )
+    _assert_response_alignment(server=server, gate=_PauseFirstHandlerReacquire())
 
 
-def test_fake_auth_endpoint_aligns_responses_with_recorded_order():
+def test_fake_auth_endpoint_preserves_capture_and_default_response():
     endpoint = FakeAuthEndpoint()
-    endpoint.queue_response(201, body=b"first")
-    endpoint.queue_response(202, body=b"second")
-    gate = _PauseFirstHandlerReacquire()
-    with patch.object(threading, "RLock", return_value=gate):
-        condition = threading.Condition()
 
     with endpoint.run():
-        _assert_response_alignment(
-            gate=gate,
-            gate_context=patch.object(endpoint, "_condition", condition),
-            url=lambda path: f"{endpoint.api_url}{path}",
-            recorded_paths=lambda: [request.path for request in endpoint.requests],
-            default_response=(500, b"unexpected auth request"),
+        response = _request(
+            "GET",
+            f"{endpoint.api_url}/auth-default",
+            headers={"X-Test-Header": "auth"},
         )
+
+    assert response == (500, b"unexpected auth request")
+    assert endpoint.request_count == 1
+    [request] = endpoint.requests
+    assert request.method == "GET"
+    assert request.path == "/auth-default"
+    assert request.headers["x-test-header"] == "auth"
+    assert "X-Test-Header" not in request.headers
+    assert request.body == b""
+
+
+def test_usage_webhook_server_preserves_capture_and_default_response():
+    server = UsageWebhookServer()
+
+    with server.run():
+        response = _request(
+            "POST",
+            server.url("/usage-default"),
+            body=b"usage-body",
+            headers={"X-Test-Header": "usage"},
+        )
+
+    assert response == (204, b"")
+    assert server.request_count == 1
+    [request] = server.requests
+    assert request.method == "POST"
+    assert request.path == "/usage-default"
+    assert request.headers["x-test-header"] == "usage"
+    assert "X-Test-Header" not in request.headers
+    assert request.body == b"usage-body"

--- a/crates/runner/mitm-addon/tests/test_http_test_helpers.py
+++ b/crates/runner/mitm-addon/tests/test_http_test_helpers.py
@@ -158,17 +158,22 @@ def _start_post(
     return thread
 
 
-def _assert_response_alignment(
-    *,
-    server: ThreadedHttpTestServer[_CapturedRequest],
-    gate: _PauseFirstHandlerReacquire,
-) -> None:
+def test_threaded_http_server_aligns_responses_with_recorded_order():
+    server = ThreadedHttpTestServer(
+        request_factory=_CapturedRequest,
+        default_status=503,
+        default_body=b"default",
+        thread_name="shared-http-test-server",
+    )
+    server.queue_response(201, body=b"first")
+    server.queue_response(202, body=b"second")
     responses: dict[str, _Response] = {}
     responses_lock = threading.Lock()
-    first = None
-    second = None
+    gate = _PauseFirstHandlerReacquire()
     with patch.object(threading, "RLock", return_value=gate):
         condition = threading.Condition()
+    first = None
+    second = None
 
     with patch.object(server, "_condition", condition), server.run():
         try:
@@ -204,18 +209,6 @@ def _assert_response_alignment(
             "second": (202, b"second"),
         }
         assert _post(f"{server.api_url}/default") == (503, b"default")
-
-
-def test_threaded_http_server_aligns_responses_with_recorded_order():
-    server = ThreadedHttpTestServer(
-        request_factory=_CapturedRequest,
-        default_status=503,
-        default_body=b"default",
-        thread_name="shared-http-test-server",
-    )
-    server.queue_response(201, body=b"first")
-    server.queue_response(202, body=b"second")
-    _assert_response_alignment(server=server, gate=_PauseFirstHandlerReacquire())
 
 
 def test_fake_auth_endpoint_preserves_capture_and_default_response():

--- a/crates/runner/mitm-addon/tests/threaded_http_test_server.py
+++ b/crates/runner/mitm-addon/tests/threaded_http_test_server.py
@@ -1,0 +1,156 @@
+"""Shared threaded loopback HTTP server for mitm-addon tests."""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from collections import deque
+from collections.abc import Callable, Iterator, Sequence
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+@dataclass(frozen=True)
+class _QueuedResponse:
+    status: int
+    body: bytes = b""
+    headers: tuple[tuple[str, str], ...] = ()
+    release_event: threading.Event | None = None
+
+
+class ThreadedHttpTestServer[Request]:
+    """Own a FIFO response queue and threaded loopback HTTP lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        request_factory: Callable[[str, str, dict[str, str], bytes], Request],
+        default_status: int,
+        thread_name: str,
+        default_body: bytes = b"",
+    ) -> None:
+        self._request_factory = request_factory
+        self._default_response = _QueuedResponse(
+            status=default_status,
+            body=default_body,
+        )
+        self._thread_name = thread_name
+        self._condition = threading.Condition()
+        self._requests: list[Request] = []
+        self._responses: deque[_QueuedResponse] = deque()
+        self._release_events: list[threading.Event] = []
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def api_url(self) -> str:
+        assert self._server is not None
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}"
+
+    @property
+    def requests(self) -> tuple[Request, ...]:
+        with self._condition:
+            return tuple(self._requests)
+
+    @property
+    def request_count(self) -> int:
+        with self._condition:
+            return len(self._requests)
+
+    def queue_response(
+        self,
+        status: int,
+        *,
+        body: bytes = b"",
+        headers: Sequence[tuple[str, str]] = (),
+        release_event: threading.Event | None = None,
+    ) -> None:
+        with self._condition:
+            if release_event is not None:
+                self._release_events.append(release_event)
+            self._responses.append(
+                _QueuedResponse(
+                    status=status,
+                    body=body,
+                    headers=tuple(headers),
+                    release_event=release_event,
+                )
+            )
+
+    def wait_for_request_count(self, count: int, *, timeout: float = 2.0) -> bool:
+        with self._condition:
+            return self._condition.wait_for(lambda: len(self._requests) >= count, timeout)
+
+    @contextlib.contextmanager
+    def run(self) -> Iterator[ThreadedHttpTestServer[Request]]:
+        server_ref = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                server_ref._handle_request(self)
+
+            def do_POST(self) -> None:
+                server_ref._handle_request(self)
+
+            def log_message(self, message_format: str, *args: object) -> None:
+                return None
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        server = self._server
+
+        def serve_forever() -> None:
+            server.serve_forever(poll_interval=0.01)
+
+        self._thread = threading.Thread(
+            target=serve_forever,
+            name=self._thread_name,
+            daemon=True,
+        )
+        thread = self._thread
+        thread.start()
+        try:
+            yield self
+        finally:
+            with self._condition:
+                release_events = tuple(self._release_events)
+                self._release_events.clear()
+            for release_event in release_events:
+                release_event.set()
+            server.shutdown()
+            thread.join(timeout=2.0)
+            server.server_close()
+            self._server = None
+            self._thread = None
+
+    def _record_request_and_reserve_response(self, request: Request) -> _QueuedResponse:
+        with self._condition:
+            self._requests.append(request)
+            self._condition.notify_all()
+            if self._responses:
+                return self._responses.popleft()
+            return self._default_response
+
+    def _handle_request(self, handler: BaseHTTPRequestHandler) -> None:
+        content_length = int(handler.headers.get("content-length", "0"))
+        body = handler.rfile.read(content_length)
+        response = self._record_request_and_reserve_response(
+            self._request_factory(
+                handler.command,
+                handler.path,
+                {key.lower(): value for key, value in handler.headers.items()},
+                body,
+            )
+        )
+
+        if response.release_event is not None:
+            response.release_event.wait()
+
+        handler.send_response(response.status)
+        for name, value in response.headers:
+            handler.send_header(name, value)
+        if response.body:
+            handler.send_header("Content-Length", str(len(response.body)))
+        handler.end_headers()
+        if response.body:
+            handler.wfile.write(response.body)

--- a/crates/runner/mitm-addon/tests/threaded_http_test_server.py
+++ b/crates/runner/mitm-addon/tests/threaded_http_test_server.py
@@ -40,7 +40,6 @@ class ThreadedHttpTestServer[Request]:
         self._responses: deque[_QueuedResponse] = deque()
         self._release_events: list[threading.Event] = []
         self._server: ThreadingHTTPServer | None = None
-        self._thread: threading.Thread | None = None
 
     @property
     def api_url(self) -> str:
@@ -83,7 +82,7 @@ class ThreadedHttpTestServer[Request]:
             return self._condition.wait_for(lambda: len(self._requests) >= count, timeout)
 
     @contextlib.contextmanager
-    def run(self) -> Iterator[ThreadedHttpTestServer[Request]]:
+    def run(self) -> Iterator[None]:
         server_ref = self
 
         class _Handler(BaseHTTPRequestHandler):
@@ -102,15 +101,14 @@ class ThreadedHttpTestServer[Request]:
         def serve_forever() -> None:
             server.serve_forever(poll_interval=0.01)
 
-        self._thread = threading.Thread(
+        thread = threading.Thread(
             target=serve_forever,
             name=self._thread_name,
             daemon=True,
         )
-        thread = self._thread
         thread.start()
         try:
-            yield self
+            yield
         finally:
             with self._condition:
                 release_events = tuple(self._release_events)
@@ -121,7 +119,6 @@ class ThreadedHttpTestServer[Request]:
             thread.join(timeout=2.0)
             server.server_close()
             self._server = None
-            self._thread = None
 
     def _record_request_and_reserve_response(self, request: Request) -> _QueuedResponse:
         with self._condition:

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import contextlib
 import json
 import threading
-from collections import deque
 from collections.abc import Callable, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Protocol
 
 import usage
+from tests.threaded_http_test_server import ThreadedHttpTestServer
 
 _DeliveryOutcomeCallback = Callable[[usage.webhook.WebhookDeliveryOutcome], None]
 _EnqueueWebhook = Callable[[str, str, dict, str, str, _DeliveryOutcomeCallback], bool]
@@ -124,14 +123,6 @@ def fresh_usage_executor_context() -> Iterator[ThreadPoolExecutor]:
 
 
 @dataclass(frozen=True)
-class WebhookResponse:
-    status: int = 204
-    headers: tuple[tuple[str, str], ...] = ()
-    body: bytes = b""
-    release_event: threading.Event | None = None
-
-
-@dataclass(frozen=True)
 class CapturedWebhookRequest:
     method: str
     path: str
@@ -149,29 +140,23 @@ class CapturedWebhookRequest:
 
 class UsageWebhookServer:
     def __init__(self) -> None:
-        self._lock = threading.Lock()
-        self._request_condition = threading.Condition()
-        self._requests: list[CapturedWebhookRequest] = []
-        self._responses: deque[WebhookResponse] = deque()
-        self._release_events: list[threading.Event] = []
-        self._server: ThreadingHTTPServer | None = None
-        self._thread: threading.Thread | None = None
+        self._http = ThreadedHttpTestServer(
+            request_factory=CapturedWebhookRequest,
+            default_status=204,
+            thread_name="usage-webhook-test-server",
+        )
 
     @property
     def api_url(self) -> str:
-        assert self._server is not None
-        host, port = self._server.server_address[:2]
-        return f"http://{host}:{port}"
+        return self._http.api_url
 
     @property
     def requests(self) -> tuple[CapturedWebhookRequest, ...]:
-        with self._lock:
-            return tuple(self._requests)
+        return self._http.requests
 
     @property
     def request_count(self) -> int:
-        with self._lock:
-            return len(self._requests)
+        return self._http.request_count
 
     def url(self, path: str = "/api/webhooks/agent/usage-event") -> str:
         if not path.startswith("/"):
@@ -187,25 +172,16 @@ class UsageWebhookServer:
         release_event: threading.Event | None = None,
     ) -> None:
         """Queue a response, optionally blocking it until an event is set."""
-        with self._lock:
-            if release_event is not None:
-                self._release_events.append(release_event)
-            self._responses.append(
-                WebhookResponse(
-                    status=status,
-                    headers=tuple(headers),
-                    body=body,
-                    release_event=release_event,
-                )
-            )
+        self._http.queue_response(
+            status,
+            headers=headers,
+            body=body,
+            release_event=release_event,
+        )
 
     def wait_for_request_count(self, count: int, *, timeout: float = 2.0) -> bool:
         """Wait until at least ``count`` requests have been recorded."""
-        with self._request_condition:
-            return self._request_condition.wait_for(
-                lambda: self.request_count >= count,
-                timeout,
-            )
+        return self._http.wait_for_request_count(count, timeout=timeout)
 
     def json_bodies(self) -> list[dict[str, Any]]:
         return [request.json_body() for request in self.requests]
@@ -232,73 +208,5 @@ class UsageWebhookServer:
 
     @contextlib.contextmanager
     def run(self) -> Iterator[UsageWebhookServer]:
-        server_ref = self
-
-        class _Handler(BaseHTTPRequestHandler):
-            def do_GET(self) -> None:
-                server_ref._handle_request(self)
-
-            def do_POST(self) -> None:
-                server_ref._handle_request(self)
-
-            def log_message(self, message_format: str, *args: Any) -> None:
-                return None
-
-        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
-        server = self._server
-
-        def serve_forever() -> None:
-            server.serve_forever(poll_interval=0.01)
-
-        self._thread = threading.Thread(
-            target=serve_forever,
-            name="usage-webhook-test-server",
-            daemon=True,
-        )
-        self._thread.start()
-        try:
+        with self._http.run():
             yield self
-        finally:
-            with self._lock:
-                release_events = tuple(self._release_events)
-                self._release_events.clear()
-            for release_event in release_events:
-                release_event.set()
-            self._server.shutdown()
-            self._thread.join(timeout=2.0)
-            self._server.server_close()
-            self._server = None
-            self._thread = None
-
-    def _record_request_and_reserve_response(
-        self, request: CapturedWebhookRequest
-    ) -> WebhookResponse:
-        with self._lock:
-            self._requests.append(request)
-            response = self._responses.popleft() if self._responses else WebhookResponse()
-        with self._request_condition:
-            self._request_condition.notify_all()
-        return response
-
-    def _handle_request(self, handler: BaseHTTPRequestHandler) -> None:
-        content_length = int(handler.headers.get("content-length", "0"))
-        body = handler.rfile.read(content_length)
-        response = self._record_request_and_reserve_response(
-            CapturedWebhookRequest(
-                method=handler.command,
-                path=handler.path,
-                headers={key.lower(): value for key, value in handler.headers.items()},
-                body=body,
-            )
-        )
-        if response.release_event is not None:
-            response.release_event.wait()
-
-        handler.send_response(response.status)
-        for name, value in response.headers:
-            handler.send_header(name, value)
-        if response.body:
-            handler.send_header("Content-Length", str(len(response.body)))
-        handler.end_headers()
-        if response.body:
-            handler.wfile.write(response.body)


### PR DESCRIPTION
## Summary

- add one generic owner for threaded loopback HTTP request capture, FIFO response reservation, release gates, response emission, and lifecycle
- keep `FakeAuthEndpoint` and `UsageWebhookServer` as protocol-specific facades with their existing APIs and distinct default responses
- move the deterministic response-order regression to the shared owner and retain observable GET/POST capture coverage for both adapters

## Scope

- test infrastructure only
- no production behavior, network protocol, schema, persisted state, migration, deployment compatibility, or unrelated loopback server changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_http_test_helpers.py` (3 passed)
- focused auth and usage helper consumers (282 passed)
- `uv run --no-sync python -m pytest tests/ -q` (4,945 passed)
- `git diff --check`

Closes #25476
