### PR TITLE
fix(chat): preserve scroll across sharing transitions

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -17,7 +17,7 @@ interface ScrollAfterRenderRequest {
   readonly position: ThreadScrollPosition | null;
 }
 
-interface ChatThreadScrollSignals {
+export interface ChatThreadScrollSignals {
   readonly scrollContainerOnRef$: Command<
     (() => void) | undefined,
     [HTMLElement | null]

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-sharing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-sharing.ts
@@ -3,6 +3,7 @@ import { command, computed, state, type Command, type Computed } from "ccstate";
 
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
+import type { ChatThreadScrollSignals } from "./chat-thread-scroll.ts";
 
 const SHARED_THREAD_SELECTION_TEXT_LIMIT_BYTES = 1.5 * 1024 * 1024;
 
@@ -22,8 +23,8 @@ export interface ChatThreadSharingSignals {
   readonly selectedEventIds$: Computed<ReadonlySet<string>>;
   readonly selectedCount$: Computed<number>;
   readonly createdSharedThreadId$: Computed<string | null>;
-  readonly start$: Command<void, []>;
-  readonly close$: Command<void, []>;
+  readonly start$: Command<Promise<void>, [AbortSignal]>;
+  readonly close$: Command<Promise<void>, [AbortSignal]>;
   readonly toggle$: Command<
     ToggleSharedThreadSelectionResult,
     [readonly ShareableChatEvent[]]
@@ -33,21 +34,35 @@ export interface ChatThreadSharingSignals {
 
 export function createChatThreadSharingSignals(
   threadId: string,
+  scroll: Pick<
+    ChatThreadScrollSignals,
+    "autoScroll$" | "readRenderedThreadScrollPosition$"
+  >,
 ): ChatThreadSharingSignals {
   const internalPhase$ = state<SharedThreadSelectionPhase>("idle");
   const internalSelectedBytes$ = state<ReadonlyMap<string, number>>(new Map());
   const internalCreatedSharedThreadId$ = state<string | null>(null);
 
-  const start$ = command(({ set }) => {
+  const start$ = command(({ set }, signal: AbortSignal) => {
     set(internalSelectedBytes$, new Map());
     set(internalCreatedSharedThreadId$, null);
     set(internalPhase$, "selecting");
+    return set(
+      scroll.autoScroll$,
+      set(scroll.readRenderedThreadScrollPosition$),
+      signal,
+    );
   });
 
-  const close$ = command(({ set }) => {
+  const close$ = command(({ set }, signal: AbortSignal) => {
     set(internalSelectedBytes$, new Map());
     set(internalCreatedSharedThreadId$, null);
     set(internalPhase$, "idle");
+    return set(
+      scroll.autoScroll$,
+      set(scroll.readRenderedThreadScrollPosition$),
+      signal,
+    );
   });
 
   const toggle$ = command(

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -3735,7 +3735,6 @@ function createChatPanelSignalsWithDraft(
     draft,
   );
   const feedback = createChatThreadFeedbackSignals(threadId, composer.feedback);
-  const sharing = createChatThreadSharingSignals(threadId);
   const messages: MessageListSignals = {
     ...createChatThreadMessagePipeline({
       threadId,
@@ -3746,6 +3745,7 @@ function createChatPanelSignalsWithDraft(
     }),
     ...artifact,
   };
+  const sharing = createChatThreadSharingSignals(threadId, messages.scroll);
   const runTracking = createRunTracking({
     threadId,
     setupChatEvents$: messages.setup$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
@@ -6,6 +6,8 @@ import {
   chatThreadEventsContract,
   type ChatEvent,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
 import { mockChatLifecycle, sendMessageInUI } from "./chat-test-helpers.ts";
 import {
   normalizeMockChatEvents,
@@ -372,6 +374,19 @@ function viewportOffsetTop(eventId: string): number {
 function scrollTo(container: HTMLElement, scrollTop: number): void {
   container.scrollTop = scrollTop;
   fireEvent.scroll(container);
+}
+
+function buttonByName(name: string): HTMLElement {
+  const button = queryAllByRoleFast("button").find((candidate) => {
+    return (
+      candidate.getAttribute("aria-label") === name ||
+      candidate.textContent?.replace(/\s+/g, " ").trim() === name
+    );
+  });
+  if (!button) {
+    throw new Error(`Expected a ${name} button`);
+  }
+  return button;
 }
 
 function simpleUserEvents(
@@ -1708,6 +1723,81 @@ describe("chat scroll position", () => {
 
     await waitFor(() => {
       expect(container.scrollTop).toBe(820);
+    });
+  });
+
+  it("restores the visible anchor after entering and exiting sharing", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "scroll-sharing-transition";
+    const events = simpleUserEvents(threadId, "sharing-transition", 8);
+    const sharingActive = () => {
+      return (
+        document.querySelector("[data-chat-share-selectable-group]") !== null
+      );
+    };
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Sharing transition",
+      chatEvents: events,
+    });
+    installChatLayout(
+      new Map([
+        [
+          threadId,
+          {
+            clientHeight: () => {
+              return sharingActive() ? 180 : 300;
+            },
+            scrollHeight: () => {
+              return sharingActive() ? 1060 : 1000;
+            },
+            eventRect: (eventId) => {
+              const index = Number(eventId.split("-").at(-1));
+              if (!Number.isFinite(index)) {
+                return undefined;
+              }
+              return {
+                top: index * 100 + (sharingActive() ? 60 : 0),
+                height: 80,
+              };
+            },
+          },
+        ],
+      ]),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.SharedThreadSharing]: true,
+      },
+    });
+
+    const container = await waitFor(() => {
+      expect(
+        screen.getByText("sharing-transition message 7"),
+      ).toBeInTheDocument();
+      expect(chatScrollContainer().scrollTop).toBe(700);
+      return chatScrollContainer();
+    });
+    scrollTo(container, 420);
+    expect(viewportOffsetTop("sharing-transition-4")).toBe(-20);
+
+    await user.click(buttonByName("Share messages"));
+
+    await waitFor(() => {
+      expect(sharingActive()).toBeTruthy();
+      expect(viewportOffsetTop("sharing-transition-4")).toBe(-20);
+      expect(container.scrollTop).toBe(480);
+    });
+
+    await user.click(buttonByName("Cancel"));
+
+    await waitFor(() => {
+      expect(sharingActive()).toBeFalsy();
+      expect(viewportOffsetTop("sharing-transition-4")).toBe(-20);
+      expect(container.scrollTop).toBe(420);
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -158,6 +158,7 @@ function MobileShareButtonInner({ thread }: { thread: ChatPanelSignals }) {
   const { t } = useTranslation();
   const phase = useGet(thread.sharing.phase$);
   const start = useSet(thread.sharing.start$);
+  const pageSignal = useGet(pageSignal$);
   const enabled =
     useGet(featureSwitch$)[FeatureSwitchKey.SharedThreadSharing] ?? false;
   if (!enabled || phase !== "idle") {
@@ -166,7 +167,13 @@ function MobileShareButtonInner({ thread }: { thread: ChatPanelSignals }) {
   return (
     <button
       type="button"
-      onClick={start}
+      onClick={() => {
+        detach(
+          start(pageSignal),
+          Reason.DomCallback,
+          "start shared thread selection",
+        );
+      }}
       className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
       aria-label={t(($) => {
         return $.chat.sharing.start;
@@ -189,6 +196,7 @@ function MobileSharingOverlayInner({ thread }: { thread: ChatPanelSignals }) {
   const phase = useGet(thread.sharing.phase$);
   const selectedCount = useGet(thread.sharing.selectedCount$);
   const close = useSet(thread.sharing.close$);
+  const pageSignal = useGet(pageSignal$);
   if (phase === "idle") {
     return null;
   }
@@ -202,7 +210,17 @@ function MobileSharingOverlayInner({ thread }: { thread: ChatPanelSignals }) {
           { count: selectedCount },
         )}
       </span>
-      <Button variant="ghost" size="sm" onClick={close}>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => {
+          detach(
+            close(pageSignal),
+            Reason.DomCallback,
+            "close shared thread selection",
+          );
+        }}
+      >
         {t(($) => {
           return $.chat.sharing.cancel;
         })}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -524,6 +524,9 @@ function BrowserMenuButton({ thread }: { thread: ChatPanelSignals }) {
   );
 }
 
+const CHAT_THREAD_HEADER_CLASS =
+  "hidden h-14 shrink-0 items-center justify-between bg-transparent px-6 sm:flex";
+
 function ChatThreadHeader({ thread }: { thread: ChatPanelSignals }) {
   const { t } = useTranslation();
   const threadTitle = useGet(thread.threadTitle$)?.trim() ?? "";
@@ -549,7 +552,7 @@ function ChatThreadHeader({ thread }: { thread: ChatPanelSignals }) {
 
   if (sharingPhase !== "idle") {
     return (
-      <header className="hidden sm:flex shrink-0 bg-transparent px-6 py-3 items-center justify-between">
+      <header className={CHAT_THREAD_HEADER_CLASS}>
         <span className="text-sm font-medium text-foreground">
           {t(
             ($) => {
@@ -558,7 +561,17 @@ function ChatThreadHeader({ thread }: { thread: ChatPanelSignals }) {
             { count: selectedCount },
           )}
         </span>
-        <Button variant="ghost" size="sm" onClick={closeSharing}>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            detach(
+              closeSharing(pageSignal),
+              Reason.DomCallback,
+              "close shared thread selection",
+            );
+          }}
+        >
           {t(($) => {
             return $.chat.sharing.cancel;
           })}
@@ -568,7 +581,7 @@ function ChatThreadHeader({ thread }: { thread: ChatPanelSignals }) {
   }
 
   return (
-    <header className="hidden sm:flex shrink-0 bg-transparent px-6 py-3 items-center justify-between">
+    <header className={CHAT_THREAD_HEADER_CLASS}>
       <div className="flex min-w-0 items-center gap-2">
         <ChatThreadEmojiMenuButton
           threadId={thread.threadId}
@@ -592,7 +605,13 @@ function ChatThreadHeader({ thread }: { thread: ChatPanelSignals }) {
               <TooltipTrigger asChild>
                 <button
                   type="button"
-                  onClick={startSharing}
+                  onClick={() => {
+                    detach(
+                      startSharing(pageSignal),
+                      Reason.DomCallback,
+                      "start shared thread selection",
+                    );
+                  }}
                   className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 transition-colors duration-150 hover:bg-accent hover:text-foreground"
                   aria-label={t(($) => {
                     return $.chat.sharing.start;
@@ -3750,7 +3769,16 @@ function ChatThreadBottomBar({ thread }: { thread: ChatPanelSignals }) {
                   return $.chat.sharing.copyLink;
                 })}
               </Button>
-              <Button variant="outline" onClick={close}>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  detach(
+                    close(pageSignal),
+                    Reason.DomCallback,
+                    "close shared thread selection",
+                  );
+                }}
+              >
                 {t(($) => {
                   return $.chat.sharing.close;
                 })}


### PR DESCRIPTION
## Summary

- update the sharing phase first, then synchronously read the still-rendered chat position and request the existing after-render auto-scroll so the visible anchor is preserved or the tail continues following
- apply the behavior through both desktop and mobile sharing controls with the page lifecycle signal while keeping scroll state scoped to each thread panel
- keep the normal and sharing thread headers at the same fixed 56px height so the bottom composer/share bar is the vertical layout change

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-scroll-position.test.tsx` (21 tests)
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-thread-sharing.test.tsx` (3 tests)

Browser verification was not run because the repository instructions prohibit starting a local dev server unless explicitly requested.
