### PR TITLE
fix(platform): render markdown emphasis that touches cjk punctuation

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -50,6 +50,8 @@
     "react-i18next": "^17.0.11",
     "react-zoom-pan-pinch": "4.0.3",
     "rehype-katex": "^7.0.1",
+    "remark-cjk-friendly": "^2.3.1",
+    "remark-cjk-friendly-gfm-strikethrough": "^2.3.1",
     "remark-math": "^6.0.0",
     "signal-timers": "^1.0.4",
     "unicode-emoji-json": "^0.9.0"

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -77,6 +77,10 @@ export const artifactSidebarInlineOpenEnabled$ = computed((get): boolean => {
   );
 });
 
+export const cjkFriendlyMarkdownEnabled$ = computed((get): boolean => {
+  return get(featureSwitch$)[FeatureSwitchKey.CjkFriendlyMarkdown] ?? false;
+});
+
 export const chatThreadSidebarAutoOpenEnabled$ = computed((get): boolean => {
   return (
     get(featureSwitch$)[FeatureSwitchKey.ChatThreadSidebarAutoOpen] ?? false

--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -525,4 +525,77 @@ describe("assistant markdown", () => {
       expect(link).toHaveAttribute("rel", "noopener noreferrer");
     });
   });
+
+  // CJK sentences put punctuation directly against the closing delimiter with
+  // no space, which plain CommonMark refuses to close.
+  it("emphasizes text wrapped in delimiters that touch cjk punctuation", async () => {
+    mockThread(
+      [
+        "**加粗（x）**后面",
+        "",
+        "*斜体（x）*后面",
+        "",
+        "***粗斜（x）***后面",
+        "",
+        "他说**「重要」**的事",
+      ].join("\n"),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-markdown" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("加粗（x）", { selector: "strong, b" }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("斜体（x）", { selector: "em, i" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("粗斜（x）", { selector: "em strong, strong em" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("「重要」", { selector: "strong, b" }),
+    ).toBeInTheDocument();
+  });
+
+  // Guards the `pluginsFilter` reorder: the strikethrough companion only wins
+  // over `remark-gfm`'s own `~~` extension when it runs after it.
+  it("strikes through text that touches cjk punctuation", async () => {
+    mockThread("~~删除线（test）~~后面");
+
+    detachedSetupPage({ context, path: "/chats/thread-markdown" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("删除线（test）", { selector: "del, s" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("keeps ascii markdown rendering unchanged", async () => {
+    mockThread(
+      [
+        "**bold**, *em*, ~~del~~",
+        "",
+        "| a | b |",
+        "| --- | --- |",
+        "| 1 | 2 |",
+        "",
+        "- [x] done",
+      ].join("\n"),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-markdown" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("bold", { selector: "strong, b" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("em", { selector: "em, i" })).toBeInTheDocument();
+    expect(screen.getByText("del", { selector: "del, s" })).toBeInTheDocument();
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox")).toBeChecked();
+  });
 });

--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -541,7 +541,11 @@ describe("assistant markdown", () => {
       ].join("\n"),
     );
 
-    detachedSetupPage({ context, path: "/chats/thread-markdown" });
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-markdown",
+      featureSwitches: { [FeatureSwitchKey.CjkFriendlyMarkdown]: true },
+    });
 
     await waitFor(() => {
       expect(
@@ -564,13 +568,37 @@ describe("assistant markdown", () => {
   it("strikes through text that touches cjk punctuation", async () => {
     mockThread("~~删除线（test）~~后面");
 
-    detachedSetupPage({ context, path: "/chats/thread-markdown" });
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-markdown",
+      featureSwitches: { [FeatureSwitchKey.CjkFriendlyMarkdown]: true },
+    });
 
     await waitFor(() => {
       expect(
         screen.getByText("删除线（test）", { selector: "del, s" }),
       ).toBeInTheDocument();
     });
+  });
+
+  it("falls back to stock commonmark when the cjk switch is off", async () => {
+    mockThread("**加粗（x）**后面\n\n~~删除线（test）~~后面");
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-markdown",
+      featureSwitches: { [FeatureSwitchKey.CjkFriendlyMarkdown]: false },
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector(".wmde-markdown")?.textContent).toContain(
+        "**加粗（x）**后面",
+      );
+    });
+    expect(document.querySelector(".wmde-markdown")?.textContent).toContain(
+      "~~删除线（test）~~后面",
+    );
+    expect(document.querySelector(".wmde-markdown del")).toBeNull();
   });
 
   it("keeps ascii markdown rendering unchanged", async () => {

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -11,6 +11,7 @@ import remarkCjkFriendlyStrikethrough from "remark-cjk-friendly-gfm-strikethroug
 import remarkMath from "remark-math";
 import { MermaidDiagram } from "./mermaid-diagram.tsx";
 import { rehypeMermaid } from "../../lib/rehype-mermaid.ts";
+import { cjkFriendlyMarkdownEnabled$ } from "../../signals/external/feature-switch.ts";
 import { pageLifecycleId$ } from "../../signals/page-signal.ts";
 import { theme$ } from "../../signals/theme.ts";
 import {
@@ -433,17 +434,16 @@ const reorderCjkStrikethrough: PluginsFilter = (type, plugins) => {
 
 function buildRemarkPlugins(args: {
   mathEnabled: boolean;
+  cjkFriendlyEnabled: boolean;
   remarkPlugins: MarkdownPreviewProps["remarkPlugins"];
 }): RemarkPlugins {
   const mathPlugins: RemarkPlugins = args.mathEnabled
     ? [[remarkMath, { singleDollarTextMath: false }]]
     : [];
-  return [
-    ...mathPlugins,
-    remarkCjkFriendly,
-    remarkCjkFriendlyStrikethrough,
-    ...(args.remarkPlugins ?? []),
-  ];
+  const cjkPlugins: RemarkPlugins = args.cjkFriendlyEnabled
+    ? [remarkCjkFriendly, remarkCjkFriendlyStrikethrough]
+    : [];
+  return [...mathPlugins, ...cjkPlugins, ...(args.remarkPlugins ?? [])];
 }
 
 // The mermaid plugin has to stay ahead of `rehype-prism-plus`, which
@@ -482,6 +482,7 @@ export function Markdown({
 }) {
   const theme = useGet(theme$);
   const pageLifecycleId = useGet(pageLifecycleId$);
+  const cjkFriendlyEnabled = useGet(cjkFriendlyMarkdownEnabled$);
   const components = mediaPreview
     ? MEDIA_MARKDOWN_COMPONENTS
     : PLAIN_MARKDOWN_COMPONENTS;
@@ -499,8 +500,12 @@ export function Markdown({
       }}
       wrapperElement={{ "data-color-mode": theme }}
       rehypeRewrite={rehypeRewriteHandler}
-      pluginsFilter={reorderCjkStrikethrough}
-      remarkPlugins={buildRemarkPlugins({ mathEnabled, remarkPlugins })}
+      pluginsFilter={cjkFriendlyEnabled ? reorderCjkStrikethrough : undefined}
+      remarkPlugins={buildRemarkPlugins({
+        mathEnabled,
+        cjkFriendlyEnabled,
+        remarkPlugins,
+      })}
       rehypePlugins={buildRehypePlugins({
         mathEnabled,
         mermaidScope: mermaidScope ?? pageLifecycleId,

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -6,6 +6,8 @@ import { useGet, useSet } from "ccstate-react";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { openImageLightbox$ } from "../../signals/zero-page/zero-attachment-chips.ts";
 import rehypeKatex from "rehype-katex";
+import remarkCjkFriendly from "remark-cjk-friendly";
+import remarkCjkFriendlyStrikethrough from "remark-cjk-friendly-gfm-strikethrough";
 import remarkMath from "remark-math";
 import { MermaidDiagram } from "./mermaid-diagram.tsx";
 import { rehypeMermaid } from "../../lib/rehype-mermaid.ts";
@@ -403,6 +405,46 @@ function escapeHtmlTags(source: string): string {
 }
 
 type RehypePlugins = MarkdownPreviewProps["rehypePlugins"];
+type RemarkPlugins = NonNullable<MarkdownPreviewProps["remarkPlugins"]>;
+type PluginsFilter = NonNullable<MarkdownPreviewProps["pluginsFilter"]>;
+
+// CommonMark only closes `**`/`*` when the delimiter is not wedged between a
+// punctuation character and a letter. CJK writes `（）。「」` with no surrounding
+// spaces, so `**加粗（x）**后面` never closes and the asterisks leak as text.
+// These two plugins relax that rule for CJK punctuation only; ASCII output is
+// unchanged.
+//
+// `remark-cjk-friendly` is order-independent, but the strikethrough companion
+// has to replace `remark-gfm`'s own `~~` extension and therefore must run after
+// it. `@uiw/react-markdown-preview` builds `[remarkAlert, ...caller, gfm]`, so
+// caller plugins always land *before* `gfm` — moving the companion to the tail
+// is what puts it behind `gfm`.
+const reorderCjkStrikethrough: PluginsFilter = (type, plugins) => {
+  if (type !== "remark") {
+    return plugins;
+  }
+  return [
+    ...plugins.filter((plugin) => {
+      return plugin !== remarkCjkFriendlyStrikethrough;
+    }),
+    remarkCjkFriendlyStrikethrough,
+  ];
+};
+
+function buildRemarkPlugins(args: {
+  mathEnabled: boolean;
+  remarkPlugins: MarkdownPreviewProps["remarkPlugins"];
+}): RemarkPlugins {
+  const mathPlugins: RemarkPlugins = args.mathEnabled
+    ? [[remarkMath, { singleDollarTextMath: false }]]
+    : [];
+  return [
+    ...mathPlugins,
+    remarkCjkFriendly,
+    remarkCjkFriendlyStrikethrough,
+    ...(args.remarkPlugins ?? []),
+  ];
+}
 
 // The mermaid plugin has to stay ahead of `rehype-prism-plus`, which
 // `@uiw/react-markdown-preview` appends after every caller-provided plugin.
@@ -457,14 +499,8 @@ export function Markdown({
       }}
       wrapperElement={{ "data-color-mode": theme }}
       rehypeRewrite={rehypeRewriteHandler}
-      remarkPlugins={
-        mathEnabled
-          ? [
-              [remarkMath, { singleDollarTextMath: false }],
-              ...(remarkPlugins ?? []),
-            ]
-          : remarkPlugins
-      }
+      pluginsFilter={reorderCjkStrikethrough}
+      remarkPlugins={buildRemarkPlugins({ mathEnabled, remarkPlugins })}
       rehypePlugins={buildRehypePlugins({
         mathEnabled,
         mermaidScope: mermaidScope ?? pageLifecycleId,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -74,4 +74,5 @@ export enum FeatureSwitchKey {
   ChatThreadSidebarAutoOpen = "chatThreadSidebarAutoOpen",
   ArtifactSidebarInlineOpen = "artifactSidebarInlineOpen",
   SharedThreadSharing = "sharedThreadSharing",
+  CjkFriendlyMarkdown = "cjkFriendlyMarkdown",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -395,6 +395,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Open an artifact clicked in a chat thread inside the already-open artifact sidebar instead of stacking the page-global lightbox over it.",
     enabled: true,
   },
+  [FeatureSwitchKey.CjkFriendlyMarkdown]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Close markdown emphasis (`*`, `**`, `***`, `~~`) that sits directly against CJK punctuation, which plain CommonMark leaves as literal asterisks. Turn off to fall back to stock CommonMark parsing.",
+    enabled: true,
+  },
   [FeatureSwitchKey.ThreeColumnNav]: {
     maintainer: "ming@vm0.ai",
     description:

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -607,6 +607,12 @@ importers:
       rehype-katex:
         specifier: ^7.0.1
         version: 7.0.1
+      remark-cjk-friendly:
+        specifier: ^2.3.1
+        version: 2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
+      remark-cjk-friendly-gfm-strikethrough:
+        specifier: ^2.3.1
+        version: 2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1575,7 +1581,7 @@ packages:
     engines: {node: '>=22.12.0'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, integrity: sha512-MXgzlTDEEndJB3TBbvd5uFQO/8gaINo1Hfen8vef5rq/VHVPeB63uuv/uO5+8GFsAJ/rauu6XB79S6K4+aXc+w==, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -8401,6 +8407,24 @@ packages:
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
+  mdast-util-to-markdown-cjk-friendly-gfm-strikethrough@1.0.0:
+    resolution: {integrity: sha512-1ePVfB4P/vz3xSsm6H3D32r6VYGErxclnuLLFK02/2ReF+UdEKm7caulK6Vm0LBIp5gPRtB2Z1OYDznCkX3k2w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/mdast': '*'
+    peerDependenciesMeta:
+      '@types/mdast':
+        optional: true
+
+  mdast-util-to-markdown-cjk-friendly@1.0.0:
+    resolution: {integrity: sha512-BoaAm8mlJ+LAYz0Qs532Y3ciTuQYgBUPZcSFbvC/ZKmEMAKgulw84YvQK1gI34t/vL2euSfuaWlqczkTBgamkw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/mdast': '*'
+    peerDependenciesMeta:
+      '@types/mdast':
+        optional: true
+
   mdast-util-to-markdown@2.1.2:
     resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
 
@@ -8446,6 +8470,35 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-cjk-friendly-gfm-strikethrough@2.0.1:
+    resolution: {integrity: sha512-wVC0zwjJNqQeX+bb07YTPu/CvSAyCTafyYb7sMhX1r62/Lw5M/df3JyYaANyp8g15c1ypJRFSsookTqA1IDsUg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      micromark: ^4.0.0
+      micromark-util-types: ^2.0.0
+    peerDependenciesMeta:
+      micromark-util-types:
+        optional: true
+
+  micromark-extension-cjk-friendly-util@3.0.1:
+    resolution: {integrity: sha512-GcbXqTTHOsiZHyF753oIddP/J2eH8j9zpyQPhkof6B2JNxfEJabnQqxbCgzJNuNes0Y2jTNJ3LiYPSXr6eJA8w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      micromark-util-types: '*'
+    peerDependenciesMeta:
+      micromark-util-types:
+        optional: true
+
+  micromark-extension-cjk-friendly@2.0.1:
+    resolution: {integrity: sha512-OkzoYVTL1ChbvQ8Cc1ayTIz7paFQz8iS9oIYmewncweUSwmWR+hkJF9spJ1lxB90XldJl26A1F4IkPOKS3bDXw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      micromark: ^4.0.0
+      micromark-util-types: ^2.0.0
+    peerDependenciesMeta:
+      micromark-util-types:
+        optional: true
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
@@ -9509,6 +9562,26 @@ packages:
 
   rehype-slug@6.0.0:
     resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
+
+  remark-cjk-friendly-gfm-strikethrough@2.3.1:
+    resolution: {integrity: sha512-JE3TGgouk/sy92SemNMEUhO5mNP4on04cmzOV3s3R5Dbk160ewmpM4tgPiinKKvoJ5UW2fTu7FOYsjVbusSA9w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/mdast': ^4.0.0
+      unified: ^11.0.0
+    peerDependenciesMeta:
+      '@types/mdast':
+        optional: true
+
+  remark-cjk-friendly@2.3.1:
+    resolution: {integrity: sha512-f+pKZRxCRwNEGFBKNRAZAqU91GIK1SAo3ZyFHWRUgC9zcxRR0BXKd6YwqgSsxtW0rNpUDtONj7H5nje2WL3fcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/mdast': ^4.0.0
+      unified: ^11.0.0
+    peerDependenciesMeta:
+      '@types/mdast':
+        optional: true
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -19056,6 +19129,28 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
 
+  mdast-util-to-markdown-cjk-friendly-gfm-strikethrough@1.0.0(@types/mdast@4.0.4)(micromark-util-types@2.0.2):
+    dependencies:
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-cjk-friendly-util: 3.0.1(micromark-util-types@2.0.2)
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
+      '@types/mdast': 4.0.4
+    transitivePeerDependencies:
+      - micromark-util-types
+      - supports-color
+
+  mdast-util-to-markdown-cjk-friendly@1.0.0(@types/mdast@4.0.4)(micromark-util-types@2.0.2):
+    dependencies:
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-cjk-friendly-util: 3.0.1(micromark-util-types@2.0.2)
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
+      '@types/mdast': 4.0.4
+    transitivePeerDependencies:
+      - micromark-util-types
+
   mdast-util-to-markdown@2.1.2:
     dependencies:
       '@types/mdast': 4.0.4
@@ -19138,6 +19233,38 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-cjk-friendly-gfm-strikethrough@2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2):
+    dependencies:
+      devlop: 1.1.0
+      get-east-asian-width: 1.6.0
+      micromark: 4.0.2
+      micromark-extension-cjk-friendly-util: 3.0.1(micromark-util-types@2.0.2)
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-cjk-friendly-util@3.0.1(micromark-util-types@2.0.2):
+    dependencies:
+      get-east-asian-width: 1.6.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-cjk-friendly@2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2):
+    dependencies:
+      devlop: 1.1.0
+      micromark: 4.0.2
+      micromark-extension-cjk-friendly-util: 3.0.1(micromark-util-types@2.0.2)
+      micromark-util-chunked: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
       micromark-util-types: 2.0.2
 
   micromark-extension-gfm-autolink-literal@2.1.0:
@@ -20467,6 +20594,29 @@ snapshots:
       hast-util-heading-rank: 3.0.0
       hast-util-to-string: 3.0.1
       unist-util-visit: 5.1.0
+
+  remark-cjk-friendly-gfm-strikethrough@2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5):
+    dependencies:
+      mdast-util-to-markdown-cjk-friendly-gfm-strikethrough: 1.0.0(@types/mdast@4.0.4)(micromark-util-types@2.0.2)
+      micromark-extension-cjk-friendly-gfm-strikethrough: 2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2)
+      unified: 11.0.5
+    optionalDependencies:
+      '@types/mdast': 4.0.4
+    transitivePeerDependencies:
+      - micromark
+      - micromark-util-types
+      - supports-color
+
+  remark-cjk-friendly@2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5):
+    dependencies:
+      mdast-util-to-markdown-cjk-friendly: 1.0.0(@types/mdast@4.0.4)(micromark-util-types@2.0.2)
+      micromark-extension-cjk-friendly: 2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2)
+      unified: 11.0.5
+    optionalDependencies:
+      '@types/mdast': 4.0.4
+    transitivePeerDependencies:
+      - micromark
+      - micromark-util-types
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
## Problem

Assistant messages written in Chinese/Japanese/Korean regularly render their
emphasis markers as literal text:

| Source | Rendered today |
| --- | --- |
| `**加粗（x）**后面` | `**加粗（x）**后面` |
| `*斜体（x）*后面` | `*斜体（x）*后面` |
| `他说**「重要」**的事` | `他说**「重要」**的事` |
| `~~删除线（test）~~后面` | `~~删除线（test）~~后面` |

This is CommonMark behaving as specified, not a renderer bug. A closing `**`
is only a *right-flanking delimiter run* when it is "either (2a) not preceded
by a Unicode punctuation character, or (2b) preceded by punctuation **and**
followed by whitespace or punctuation" (spec 0.30 §6.2). `（）。，：「」《》！…、`
are all Unicode punctuation, and CJK writes no spaces between a closing bracket
and the next word — so clause (2b) fails and the delimiter never closes.

It is a long-standing spec issue: commonmark/commonmark-spec#650,
[Emphasis and East Asian text](https://talk.commonmark.org/t/emphasis-and-east-asian-text/2491).

## Fix

Add [`remark-cjk-friendly`](https://github.com/tats-u/markdown-cjk-friendly)
and its GFM strikethrough companion to the shared `Markdown` component, so all
markdown surfaces (chat, artifact sidebar, log cards, activity detail) are
covered in one place. The package implements the CommonMark revision candidate
for this problem and only reclassifies CJK punctuation — non-CJK parsing is
untouched. It is the same extension Redmine 6.1.1 enabled in commonmarker
(redmine.org/issues/43234).

`pluginsFilter` is needed because the strikethrough companion has to replace
`remark-gfm`'s own `~~` extension and therefore must run *after* it, while
`@uiw/react-markdown-preview` builds `[remarkAlert, ...caller, gfm]` and always
places caller plugins first. Measured:

```
gfm, cjk, strike  -> ~~ OK        cjk, gfm, strike  -> ~~ OK
gfm, strike, cjk  -> ~~ OK        cjk, strike, gfm  -> ~~ BROKEN  <- @uiw default
```

`remark-cjk-friendly` itself is order-independent.

## Feature switch

Gated behind `cjkFriendlyMarkdown`, **defaulting to enabled**. This changes how
every rendered message is parsed, so the flag exists as a one-click rollback
rather than a staged rollout — the fix is the desired behavior and non-CJK
output is byte-identical. Flipping to a staged launch is a one-line change to
the registry entry (`enabled: false` + `enabledOrgIdHashes: STAFF_ORG_ID_HASHES`).

Turning it off drops the `pluginsFilter` reorder as well, otherwise the filter
would re-append the strikethrough companion that `buildRemarkPlugins` just left
out.

## Scope — what this does not fix

Deliberately out of scope, tracked separately:

- **GFM autolink literals.** `已完成：**https://github.com/vm0-ai/vm0/pull/25430**（draft）`
  still renders wrong, for an unrelated reason: the autolink scanner runs to the
  next ASCII space and only trims the ASCII set `? ! . , : * _ ~`, so it swallows
  `**（draft）` into the href and orphans the opening `**`. The same mechanism
  corrupts plain bare URLs (`链接：https://example.com/a（draft）` → dead link).
  Fixing it correctly means extending GFM's parenthesis-balancing to fullwidth
  brackets; naive tail-trimming breaks legitimate URLs such as
  `https://zh.wikipedia.org/wiki/中文（消歧义）`.
- **`_` / `__` emphasis**, which fails under CommonMark's intraword-underscore
  rule (the one that keeps `snake_case` from italicizing). Unrelated to CJK.
- **Pure-ASCII `**markdown(md)**is`**, which the extension leaves alone by design.
- **Slack / Feishu delivery**, which hand the raw text to the destination's own
  parser and are unreachable from the renderer.

## Verification

- New page-level tests in `markdown.test.tsx` cover `*`, `**`, `***`, the
  opener-side case, `~~` (the `pluginsFilter` regression guard), and the
  switch-off fallback. Each was confirmed to fail without its corresponding
  change and pass with it.
- ASCII regression test asserts `**bold**`, `*em*`, `~~del~~`, GFM tables and
  task lists still render.
- `check-types`, `lint` and `knip` green for both `apps/platform` and
  `packages/core`; `vitest run src/views/components/__tests__/markdown.test.tsx`
  20 passed; `@vm0/core` suite 190 passed.