### PR TITLE
test(api): await cancellation queue drain in chat event test

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -8020,6 +8020,7 @@ describe("CHAT-02: shared user message queue", () => {
     expect(second.body).toMatchObject({ runId: null });
 
     await cancelChatRun(actor, anchor.runId);
+    await flushWaitUntilForTest();
     const messages = await waitForThreadMessages(
       actor,
       anchor.threadId,


### PR DESCRIPTION
## Summary

- wait for cancellation `waitUntil` work to finish before asserting shared-queue message order in CHAT-02
- preserve the existing product behavior and message-order assertion

## Root cause

The cancel route commits the terminal run status before its `waitUntil` side effects drain the shared chat queue. The test waited for the committed status and then polled thread events, so under CI load it could race the claimed queued message becoming visible. This change synchronizes the test at the existing API `waitUntil` boundary instead of changing retries, timeouts, or assertions.

Trigger: https://github.com/vm0-ai/vm0/actions/runs/31104614476

Failed job: https://github.com/vm0-ai/vm0/actions/runs/31104614476/job/92626509286

Evidence:

- exact failing merge-group SHA: `d0f66683126cbaac719a4d479f5daef6d51f195c`
- the only substantive failure was `CHAT-02: shared user message queue > appends a claimed queued message after messages that are still queued`; `ci-gate-turbo` was aggregate noise
- the same shard passed on PR runs 31103883912 and 31103122636, and on adjacent main runs 31103514411 and 31105329028
- the represented PR's changes in this test file affected VM0 key fixtures in another case and did not alter this queue-order scenario

## Verification

- exact target test passed 5 consecutive normal runs
- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `git diff --check`
