### PR TITLE
refactor: remove sidebar auto-open compatibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -9,7 +9,6 @@ import { zeroFeatureSwitchesRoutes } from "../zero-feature-switches";
 
 const context = testContext();
 const LEGACY_MAIL_REPLY_FOLLOW_UP_SWITCH = "zeroMailReplyFollowUp";
-const LEGACY_CHAT_THREAD_SIDEBAR_AUTO_OPEN_SWITCH = "chatThreadSidebarAutoOpen";
 
 function client() {
   return setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
@@ -47,39 +46,6 @@ describe("/api/zero/feature-switches", () => {
     expect(
       previousPlatformSwitches[LEGACY_MAIL_REPLY_FOLLOW_UP_SWITCH],
     ).toBeFalsy();
-  });
-
-  it("keeps sidebar auto-open enabled for previous Platform bundles", async () => {
-    createZeroRouteMocks(context).clerk.session(
-      "user_legacy_sidebar_auto_open_test",
-      "org_legacy_sidebar_auto_open_test",
-      "org:member",
-    );
-    const response = await accept(
-      client().get({
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    const previousPlatformSwitches: Record<string, boolean> = {
-      [LEGACY_CHAT_THREAD_SIDEBAR_AUTO_OPEN_SWITCH]: false,
-    };
-    for (const key of Object.keys(previousPlatformSwitches)) {
-      const value = response.body.effectiveSwitches[key];
-      if (value !== undefined) {
-        previousPlatformSwitches[key] = value;
-      }
-    }
-
-    expect(
-      response.body.effectiveSwitches[
-        LEGACY_CHAT_THREAD_SIDEBAR_AUTO_OPEN_SWITCH
-      ],
-    ).toBeTruthy();
-    expect(
-      previousPlatformSwitches[LEGACY_CHAT_THREAD_SIDEBAR_AUTO_OPEN_SWITCH],
-    ).toBeTruthy();
   });
 
   it("persists and activates inline templates for a non-staff org", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
@@ -18,7 +18,6 @@ const featureSwitchesAuthOptions = {
 } as const;
 
 const LEGACY_MAIL_REPLY_FOLLOW_UP_SWITCH = "zeroMailReplyFollowUp";
-const LEGACY_CHAT_THREAD_SIDEBAR_AUTO_OPEN_SWITCH = "chatThreadSidebarAutoOpen";
 function featureSwitchResponseBody(params: {
   readonly orgId: string;
   readonly userId: string;
@@ -36,13 +35,9 @@ function featureSwitchResponseBody(params: {
   // Platform bundles loaded before Mail follow-up removal still carry this
   // key. Force them off until their compatible follow-up endpoint can be
   // removed after the old frontend release drains.
-  // Platform bundles loaded before sidebar auto-open became permanent still
-  // gate that behavior on the removed switch. Keep it enabled until the old
-  // frontend release drains.
   const effectiveSwitches = {
     ...registeredEffectiveSwitches,
     [LEGACY_MAIL_REPLY_FOLLOW_UP_SWITCH]: false,
-    [LEGACY_CHAT_THREAD_SIDEBAR_AUTO_OPEN_SWITCH]: true,
   };
 
   return {


### PR DESCRIPTION
## Summary

- Remove the temporary `chatThreadSidebarAutoOpen: true` entry from the feature-switch API response.
- Delete the old-Platform compatibility test that existed only for that response field.
- Keep the fully rolled-out thread-sidebar auto-open product behavior unchanged.

## Rollout state and history

- Terminal state: `fully-rolled-out`.
- Decision basis: #25495 merged the permanent-on behavior into `main`, and the follow-up request explicitly asks to remove the drained old-version compatibility layer.
- Original feature introduction: `974eacfabe` (`feat: auto-open active chat cards in the thread sidebar`).
- Temporary compatibility introduction: `59b3c2afa4` (`fix: address review findings on pr #25495`).
- Parent comparison: the compatibility response field, comment, constant, and test are absent from the parent of `59b3c2afa4`; this PR removes exactly those additions.

## Behavior comparison

- Preserved: the unconditional Platform implementation in `thread-sidebar-auto-open.ts` and its current consumers.
- Removed: the legacy serialized switch key forced to `true`, its drain-period comments, and the previous-bundle integration test.
- Unrelated legacy responses, including `zeroMailReplyFollowUp`, remain untouched.

## Search and orphan audit

- Zero remaining hits for `chatThreadSidebarAutoOpen`, `ChatThreadSidebarAutoOpen`, kebab/snake variants, the legacy constant, and the legacy test identifiers.
- Semantic matches under `thread-sidebar-auto-open.ts`, `create-chat-thread.ts`, and their symbols are the permanent product implementation and remain intentionally.
- Knip baseline: exit 0 with 44 configuration hints and no unused-code findings.
- Knip after cleanup: identical 44 configuration hints and no new orphan files, exports, types, or dependencies.

## Validation

- `git diff --check`
- Prettier on both changed files
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feature-switches.test.ts` — 2/2 passed after initializing the local PostgreSQL test database and applying migrations
- `pnpm -F api lint` — passed; emitted only existing warnings in unchanged files
- `pnpm -F api check-types` — passed
- Lefthook pre-commit — Prettier, Knip, full workspace type-check 12/12, and file-size checks passed
- Commitlint passed

No full local Vitest suite or dev server was run; the PR pipeline owns the full suite.
