### PR TITLE
refactor(connectors): remove null realtime fallback

### DIFF
--- a/turbo/apps/platform/src/signals/connector-change.test.ts
+++ b/turbo/apps/platform/src/signals/connector-change.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { isConnectorChangedPayloadFor } from "./connector-change";
+
+describe("isConnectorChangedPayloadFor", () => {
+  it("matches a valid payload for the requested connector", () => {
+    expect(
+      isConnectorChangedPayloadFor(
+        { connectorSlug: "google-drive" },
+        "google-drive",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects payloads without a connector identity", () => {
+    expect(isConnectorChangedPayloadFor(null, "google-drive")).toBe(false);
+  });
+});

--- a/turbo/apps/platform/src/signals/connector-change.ts
+++ b/turbo/apps/platform/src/signals/connector-change.ts
@@ -5,10 +5,6 @@ export function isConnectorChangedPayloadFor(
   payload: unknown,
   connectorSlug: ConnectorSlug,
 ): boolean {
-  // Old API deployments publish null during a rolling deployment.
-  if (payload === null) {
-    return true;
-  }
   const parsed = connectorChangedPayloadSchema.safeParse(payload);
   return parsed.success && parsed.data.connectorSlug === connectorSlug;
 }


### PR DESCRIPTION
## Summary

- stop treating a null connector-change payload as a wildcard refresh
- accept only schema-valid payloads for the requested connector
- add focused coverage for valid and null payloads

## Compatibility evidence

- connector-scoped realtime payloads shipped in app v0.642.1 and API v1.332.1 on 2026-07-28
- the old API rolling-deployment window has been closed for more than a week

## Verification

- pnpm --filter @vm0/app exec vitest run src/signals/connector-change.test.ts
- pnpm --filter @vm0/app check-types