### PR TITLE
refactor(github): require install url response field

### DIFF
--- a/turbo/packages/api-contracts/src/contracts/integrations-github.ts
+++ b/turbo/packages/api-contracts/src/contracts/integrations-github.ts
@@ -23,11 +23,8 @@ export type GithubInstallationResponse = z.infer<
   typeof githubInstallationResponseSchema
 >;
 
-// `installUrl` is optional so a new frontend paired with the previous API
-// deployment can still parse this body during a rollout. Make it required once
-// no API version without the field is serving traffic.
 export const githubInstallationNotFoundResponseSchema = apiErrorSchema.extend({
-  installUrl: z.string().nullish(),
+  installUrl: z.string().nullable(),
 });
 
 export type GithubInstallationNotFoundResponse = z.infer<


### PR DESCRIPTION
## Summary

- make installUrl required in the GitHub installation-not-found response
- retain null as the intentional value for non-admin members
- remove the previous-API omission allowance

## Compatibility evidence

- API support for installUrl shipped in API v1.348.0 on 2026-07-30
- every current API response includes the field
- Axiom shows current App traffic successfully consuming this endpoint across subsequent versions

## Verification

- pnpm --filter @vm0/api-contracts check-types