### PR TITLE
refactor(connectors): remove legacy oauth continuation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
@@ -3,7 +3,6 @@ import { randomUUID } from "node:crypto";
 import { connectorsSlugCallbackContract } from "@vm0/api-contracts/contracts/connectors-slug-callback";
 import {
   zeroConnectorOpenIdStartContract,
-  zeroConnectorOauthContinueContract,
   zeroConnectorsBySlugContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroConnectorCatalogContract } from "@vm0/api-contracts/contracts/zero-connector-catalog";
@@ -311,29 +310,6 @@ function mockSteamPlayerApis(args: { readonly privateOwnedGames?: boolean }) {
 }
 
 describe("Steam OpenID connector", () => {
-  it("rejects a legacy OAuth handoff without an authorization URL", async () => {
-    const actor = testActor();
-    mockSteamRuntimeEnv();
-    const authorizationUrl = await startSteamOpenId(actor);
-
-    const response = await accept(
-      setupApp({ context, routes: zeroConnectorsRoutes })(
-        zeroConnectorOauthContinueContract,
-      ).continue({
-        params: { connectorSlug: "steam" },
-        query: { state: stateFromSteamAuthorizationUrl(authorizationUrl) },
-      }),
-      [404],
-    );
-
-    expect(response.body).toStrictEqual({
-      error: {
-        message: "OAuth handoff not found",
-        code: "NOT_FOUND",
-      },
-    });
-  });
-
   it("exposes Steam in the connector catalog by default", async () => {
     const actor = testActor();
     mockSession(actor);
@@ -341,10 +317,9 @@ describe("Steam OpenID connector", () => {
     const client = setupApp({ context, routes: zeroConnectorCatalogRoutes })(
       zeroConnectorCatalogContract,
     );
-    const visible = await accept(
-      client.status({ headers: authHeaders() }),
-      [200],
-    );
+    const visible = await accept(client.status({ headers: authHeaders() }), [
+      200,
+    ]);
     const steam = visible.body.connectors.find((connector) => {
       return connector.slug === "steam";
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-oauth-state-cleanup.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-oauth-state-cleanup.test.ts
@@ -1,10 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { cronConnectorOauthStateCleanupContract } from "@vm0/api-contracts/contracts/cron";
-import {
-  zeroConnectorOauthContinueContract,
-  zeroConnectorOauthStartContract,
-} from "@vm0/api-contracts/contracts/zero-connectors";
+import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
@@ -74,11 +71,11 @@ describe("connector OAuth state cleanup cron", () => {
     });
   });
 
-  it("deletes expired states while preserving usable handoffs", async () => {
+  it("deletes expired states while preserving unexpired states", async () => {
     mockNow(now() - 20 * 60 * 1000);
     await startGithubOauth();
     clearMockNow();
-    const usableContinuationUrl = await startGithubOauth();
+    await startGithubOauth();
 
     const cleanup = await accept(
       setupApp({ context, routes: cronConnectorOauthStateCleanupRoutes })(
@@ -90,19 +87,5 @@ describe("connector OAuth state cleanup cron", () => {
     );
 
     expect(cleanup.body.deleted).toBeGreaterThanOrEqual(1);
-    const continuation = await accept(
-      setupApp({ context, routes: zeroConnectorsRoutes })(
-        zeroConnectorOauthContinueContract,
-      ).continue({
-        params: { connectorSlug: "github" },
-        query: {
-          state: usableContinuationUrl.searchParams.get("state") ?? "",
-        },
-      }),
-      [307],
-    );
-    expect(continuation.headers.get("location")).toMatch(
-      /^https:\/\/github\.com\/login\/oauth\/authorize\?/u,
-    );
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -134,40 +134,10 @@ async function authorizationUrlFromResponse(response: Response): Promise<URL> {
   return new URL(body.authorizationUrl);
 }
 
-async function providerAuthorizationUrl(continuationUrl: URL): Promise<URL> {
-  const response = await requestOauthContinuation(continuationUrl);
-  expect(response.status).toBe(307);
-  expect(response.headers.get("cache-control")).toBe("no-store");
-  const location = response.headers.get("location");
-  if (!location) {
-    throw new Error("Expected connector OAuth handoff to redirect");
-  }
-  return new URL(location);
-}
-
-async function requestOauthContinuation(
-  continuationUrl: URL,
-): Promise<Response> {
-  const app = createApp({ signal: context.signal, routes: TEST_APP_ROUTES });
-  return await app.request(continuationUrl.toString());
-}
-
 function expectOauthState(authorizationUrl: URL): string {
   const state = authorizationUrl.searchParams.get("state");
   expect(state).toMatch(/^[0-9a-f]{64}$/);
   return state!;
-}
-
-function legacyContinuationUrl(
-  connectorSlug: string,
-  authorizationUrl: URL,
-): URL {
-  const continuationUrl = new URL(
-    `/api/zero/connectors/${connectorSlug}/oauth/continue`,
-    API_ORIGIN,
-  );
-  continuationUrl.searchParams.set("state", expectOauthState(authorizationUrl));
-  return continuationUrl;
 }
 
 async function rejectProviderAuthorization(
@@ -256,106 +226,6 @@ describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
     );
     expectOauthState(authorizationUrl);
     await rejectProviderAuthorization(authorizationUrl);
-  });
-
-  it("continues OAuth handoff URLs issued before deployment", async () => {
-    const response = await requestOauthStart("github", {
-      authenticated: true,
-      origin: API_ORIGIN,
-    });
-    expect(response.status).toBe(200);
-    const authorizationUrl = await authorizationUrlFromResponse(response);
-
-    const redirectedAuthorizationUrl = await providerAuthorizationUrl(
-      legacyContinuationUrl("github", authorizationUrl),
-    );
-
-    expect(redirectedAuthorizationUrl.toString()).toBe(
-      authorizationUrl.toString(),
-    );
-  });
-
-  it("rejects an OAuth handoff whose state does not exist", async () => {
-    const continuationUrl = new URL(
-      "/api/zero/connectors/github/oauth/continue",
-      API_ORIGIN,
-    );
-    continuationUrl.searchParams.set("state", "0".repeat(64));
-
-    const app = createApp({ signal: context.signal, routes: TEST_APP_ROUTES });
-    const response = await app.request(continuationUrl.toString());
-
-    expect(response.status).toBe(404);
-    await expect(response.json()).resolves.toStrictEqual({
-      error: {
-        message: "OAuth handoff not found",
-        code: "NOT_FOUND",
-      },
-    });
-  });
-
-  it("rejects an OAuth handoff for a different connector slug", async () => {
-    const response = await requestOauthStart("github", {
-      authenticated: true,
-      origin: API_ORIGIN,
-    });
-    expect(response.status).toBe(200);
-    const authorizationUrl = await authorizationUrlFromResponse(response);
-    const continuationUrl = legacyContinuationUrl("notion", authorizationUrl);
-
-    const continueResponse = await requestOauthContinuation(continuationUrl);
-
-    expect(continueResponse.status).toBe(404);
-    await expect(continueResponse.json()).resolves.toStrictEqual({
-      error: {
-        message: "OAuth handoff not found",
-        code: "NOT_FOUND",
-      },
-    });
-  });
-
-  it("rejects an expired OAuth handoff", async () => {
-    const startedAt = new Date("2026-07-22T00:00:00.000Z");
-    mockNow(startedAt);
-    const response = await requestOauthStart("github", {
-      authenticated: true,
-      origin: API_ORIGIN,
-    });
-    expect(response.status).toBe(200);
-    const authorizationUrl = await authorizationUrlFromResponse(response);
-    const continuationUrl = legacyContinuationUrl("github", authorizationUrl);
-    mockNow(new Date(startedAt.getTime() + 15 * 60 * 1000));
-
-    const continueResponse = await requestOauthContinuation(continuationUrl);
-
-    expect(continueResponse.status).toBe(404);
-    await expect(continueResponse.json()).resolves.toStrictEqual({
-      error: {
-        message: "OAuth handoff not found",
-        code: "NOT_FOUND",
-      },
-    });
-  });
-
-  it("rejects an OAuth handoff after its callback claims it", async () => {
-    const response = await requestOauthStart("github", {
-      authenticated: true,
-      origin: API_ORIGIN,
-    });
-    expect(response.status).toBe(200);
-    const authorizationUrl = await authorizationUrlFromResponse(response);
-    const continuationUrl = legacyContinuationUrl("github", authorizationUrl);
-    await rejectProviderAuthorization(authorizationUrl);
-
-    const continueResponse = await requestOauthContinuation(continuationUrl);
-
-    expect(continueResponse.status).toBe(404);
-    await expect(continueResponse.json()).resolves.toStrictEqual({
-      error: {
-        message: "OAuth handoff not found",
-        code: "NOT_FOUND",
-      },
-    });
   });
 
   it("uses the configured web origin for local OAuth callback URLs", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -3,7 +3,6 @@ import {
   zeroConnectorManualGrantContract,
   zeroConnectorNoAuthGrantContract,
   zeroConnectorOpenIdStartContract,
-  zeroConnectorOauthContinueContract,
   zeroConnectorOauthStartContract,
   zeroConnectorScopeDiffContract,
   zeroConnectorsBySlugContract,
@@ -45,17 +44,13 @@ import {
   type ConnectorSlugResolution,
 } from "../services/connector-action-resolver.service";
 import { isConnectorCatalogUnavailableError } from "../services/connector-catalog-reader.service";
-import { getConnectorOAuthAuthorizationUrl } from "../services/connector-oauth-state.service";
 import type { RouteEntry } from "../route-entry";
 import { settle } from "../utils";
 import {
   getConnectorOAuthCallbackUrlForMethod,
   getConnectorOpenIdCallbackOriginForMethod,
 } from "./connector-oauth-origin";
-import {
-  connectorOAuthRedirectResponse,
-  CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
-} from "../../lib/connector-oauth-state";
+import { CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS } from "../../lib/connector-oauth-state";
 import {
   buildConnectorAuthCodeAuthUrlWithMethod,
   prepareConnectorAuthCodeStartWithMethod,
@@ -565,33 +560,6 @@ const startConnectorOauthInner$ = command(
   },
 );
 
-// Compatibility for handoff URLs issued before direct provider redirects.
-// Remove after the previous API is no longer rollback-eligible and every state
-// issued with CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS has expired.
-const continueConnectorOauthInner$ = command(
-  async ({ get }, signal: AbortSignal) => {
-    const params = get(
-      pathParamsOf(zeroConnectorOauthContinueContract.continue),
-    );
-    const query = get(queryOf(zeroConnectorOauthContinueContract.continue));
-    const resolution = await getConnectorOAuthAuthorizationUrl(
-      get(db$),
-      { state: query.state, connectorSlug: params.connectorSlug },
-      signal,
-    );
-
-    if (resolution.kind !== "usable") {
-      return notFound("OAuth handoff not found");
-    }
-
-    const response = connectorOAuthRedirectResponse(
-      resolution.authorizationUrl,
-    );
-    response.headers.set("Cache-Control", "no-store");
-    return response;
-  },
-);
-
 const startConnectorOpenIdInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const params = get(pathParamsOf(zeroConnectorOpenIdStartContract.start));
@@ -728,10 +696,6 @@ export const zeroConnectorsRoutes: readonly RouteEntry[] = [
   {
     route: zeroConnectorOauthStartContract.start,
     handler: authRoute(connectorWriteAuth, startConnectorOauthInner$),
-  },
-  {
-    route: zeroConnectorOauthContinueContract.continue,
-    handler: continueConnectorOauthInner$,
   },
   {
     route: zeroConnectorOpenIdStartContract.start,

--- a/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
@@ -43,50 +43,6 @@ type ConnectorOAuthStateStatus =
   | { readonly kind: "invalid" }
   | { readonly kind: "usable" };
 
-type ConnectorOAuthAuthorizationResult =
-  | { readonly kind: "missing" }
-  | { readonly kind: "invalid" }
-  | { readonly kind: "usable"; readonly authorizationUrl: string };
-
-export async function getConnectorOAuthAuthorizationUrl(
-  db: ReadonlyDb,
-  args: {
-    readonly state: string;
-    readonly connectorSlug: ConnectorSlug;
-  },
-  signal: AbortSignal,
-): Promise<ConnectorOAuthAuthorizationResult> {
-  const [storedState] = await db
-    .select({
-      authorizationUrl: connectorOauthStates.authorizationUrl,
-      connectorSlug: connectorOauthStates.connectorSlug,
-      consumedAt: connectorOauthStates.consumedAt,
-      expiresAt: connectorOauthStates.expiresAt,
-    })
-    .from(connectorOauthStates)
-    .where(eq(connectorOauthStates.state, args.state))
-    .limit(1);
-  signal.throwIfAborted();
-
-  if (!storedState) {
-    return { kind: "missing" };
-  }
-
-  if (
-    storedState.connectorSlug !== args.connectorSlug ||
-    storedState.consumedAt ||
-    storedState.expiresAt <= nowDate() ||
-    !storedState.authorizationUrl
-  ) {
-    return { kind: "invalid" };
-  }
-
-  return {
-    kind: "usable",
-    authorizationUrl: storedState.authorizationUrl,
-  };
-}
-
 export async function getConnectorOAuthStateStatus(
   db: Db,
   args: {

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -114,21 +114,6 @@ export const zeroConnectorOauthStartContract = c.router({
   },
 });
 
-export const zeroConnectorOauthContinueContract = c.router({
-  continue: {
-    method: "GET",
-    path: "/api/zero/connectors/:connectorSlug/oauth/continue",
-    pathParams: z.object({ connectorSlug: connectorSlugSchema }),
-    query: z.object({ state: z.string().regex(/^[0-9a-f]{64}$/) }),
-    responses: {
-      307: c.noBody(),
-      400: apiErrorSchema,
-      404: apiErrorSchema,
-    },
-    summary: "Continue connector OAuth in the browser",
-  },
-});
-
 export const zeroConnectorOpenIdStartContract = c.router({
   start: {
     method: "POST",


### PR DESCRIPTION
## Summary

- remove the pre-direct-redirect OAuth continuation contract and route
- remove the authorization URL lookup used only by that route
- remove compatibility-only test coverage while retaining current OAuth start, callback, claim, and cleanup behavior

## Compatibility evidence

- direct provider redirects shipped in app v0.620.1 and API v1.305.1 on 2026-07-23
- OAuth states expire after 15 minutes
- Axiom request logs cover 2026-08-03T11:00:32Z through 2026-08-06T15:44:59Z and show zero requests to the continuation route

## Verification

- pnpm --filter api check-types
- pnpm --filter @vm0/api-contracts check-types
- targeted Vitest suites were attempted but require a local PostgreSQL instance; they stopped during setup with ECONNREFUSED before running assertions