### PR TITLE
fix(platform): render legal consent checkbox check crisply

### DIFF
--- a/turbo/apps/platform/src/lib/static-assets.ts
+++ b/turbo/apps/platform/src/lib/static-assets.ts
@@ -4,9 +4,6 @@ export function platformStaticAssetUrl(path: string) {
   return `${STATIC_ASSETS_BASE_URL}/platform/${path.replace(/^\/+/u, "")}`;
 }
 
-export const platformCheckmarkPrimaryImg = platformStaticAssetUrl(
-  "checkmark-primary-52b8c1164a7c.svg",
-);
 export const platformEmptyPrivateAgentsImg = platformStaticAssetUrl(
   "views/agents-page/assets/empty-private-agents-9a8d7e3750b6.png",
 );

--- a/turbo/apps/platform/src/views/auth/auth-layout.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-layout.tsx
@@ -3,7 +3,6 @@ import { useGet, useSet } from "ccstate-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  platformCheckmarkPrimaryImg,
   platformVm0LogoDarkImg,
   platformVm0LogoImg,
 } from "../../lib/static-assets.ts";
@@ -315,30 +314,49 @@ a[class*="resendCode"] {
   color: hsl(var(--primary)) !important;
 }
 
-/* Legal consent checkbox - clear visual distinction between checked/unchecked states */
+/* Legal consent checkbox - mirrors the platform Checkbox primitive: neutral
+   surface when unchecked, filled primary with a white check when checked. The
+   check is drawn with borders instead of a scaled background image, so it stays
+   crisp at any zoom level or device pixel ratio. */
 .cl-card input[type="checkbox"],
 .cl-formFieldCheckboxInput input[type="checkbox"] {
   -webkit-appearance: none;
   appearance: none;
   outline: none !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
   width: 16px !important;
   height: 16px !important;
   min-width: 16px !important;
-  border: 1.5px solid hsl(var(--foreground) / 0.35) !important;
-  border-radius: 3px !important;
-  background-color: transparent !important;
+  border: 1px solid hsl(var(--border)) !important;
+  border-radius: var(--radius-md) !important;
+  background-color: hsl(var(--input)) !important;
   cursor: pointer !important;
   flex-shrink: 0 !important;
+  transition:
+    background-color 150ms,
+    border-color 150ms !important;
 }
 
 .cl-card input[type="checkbox"]:checked,
 .cl-formFieldCheckboxInput input[type="checkbox"]:checked {
-  background-color: transparent !important;
+  background-color: hsl(var(--primary)) !important;
   border-color: hsl(var(--primary)) !important;
-  background-image: url("${platformCheckmarkPrimaryImg}") !important;
-  background-repeat: no-repeat !important;
-  background-position: center !important;
-  background-size: 70% !important;
+  /* Clerk paints its own checkmark here. Drop it so the two marks cannot
+     double-draw if Clerk changes its asset or its background sizing. */
+  background-image: none !important;
+}
+
+.cl-card input[type="checkbox"]:checked::after,
+.cl-formFieldCheckboxInput input[type="checkbox"]:checked::after {
+  content: "";
+  display: block;
+  width: 5px;
+  height: 9px;
+  border: solid hsl(var(--on-filled));
+  border-width: 0 2px 2px 0;
+  transform: translateY(-1px) rotate(45deg);
 }
 
 .cl-card input[type="checkbox"]:hover,


### PR DESCRIPTION
Closes #25528

## Root cause (reproduced on production)

The checked state overrode Clerk's own checkmark with an orange one painted as a `background-image` on a transparent box:

```css
background-color: transparent !important;
background-image: url("${platformCheckmarkPrimaryImg}") !important;
background-size: 70% !important;
```

Two things combine to break it:

1. `checkmark-primary-52b8c1164a7c.svg` declares only a `viewBox`, no `width`/`height`, so it has no intrinsic size. A one-value `background-size` sets width and leaves height `auto`, so the final raster size is up to the UA.
2. The mark is primary-on-transparent at roughly 11px with a 2.5-unit stroke. Scaled down, the stroke lands on sub-pixel boundaries and antialiases away.

Confirmed on `app.vm0.ai/sign-up` at DPR 1: the checked box renders a barely visible ghost of the mark. Computed style there is `background-size: 70%`, `background-color: rgba(0, 0, 0, 0)`.

Worth noting: **Clerk already ships a white checkmark for this checkbox** (an inline `viewBox="0 0 8 8"` data URI at `background-size: 8px 8px`). The old override replaced a correctly-sized white mark with an undersized orange one.

## Fix

Mirror the platform `Checkbox` primitive (`turbo/packages/ui/src/components/ui/checkbox.tsx`) rather than maintaining a parallel look:

| | before | after |
|---|---|---|
| unchecked | transparent, `--foreground / 0.35` border, 3px radius | `--input` surface, `--border` border, `--radius-md` |
| checked | transparent box, undersized orange background-image | filled `--primary`, white `--on-filled` check |

The check is drawn from two borders on a rotated `::after`, so it is resolution-independent and needs no external asset on the auth critical path. `background-image: none` on `:checked` drops Clerk's own mark so the two cannot double-draw. `platformCheckmarkPrimaryImg` had no other consumer, so that export is removed.

## Verification

![before/after on the live sign-up page](https://cdn.vm0.io/artifacts/n5ifjbaqs6.png)

Captured on `app.vm0.ai/sign-up` at DPR 1 against the real Clerk DOM, by deleting the three existing checkbox rules from the CSSOM and injecting this PR's CSS verbatim. Left column is the rendered row, right column is the 16px checkbox at 8x nearest-neighbour. Also rendered at 1x/3x/5x/8x in light and dark, checked and unchecked, in headless Chromium: the mark stays solid and centred at every size.

Checks run locally: `pnpm format`, `pnpm check-types` (12/12 pass), `pnpm turbo run lint --filter=@vm0/app` (0 errors), `pnpm knip --workspace apps/platform` (clean). Tests left to the PR pipeline.

The e2e helper `accept_legal_consent` targets `input[name="legalAccepted"]` and still drives a real checkbox input, so it is unaffected.

**Preview not yet available:** the Turbo workflow has not run for this PR. Repo-wide, no Turbo run has started since 17:59Z (one PR has been queued since 16:55Z), and `staging-app` / `staging-www.vm6.ai` are both returning 404, so `pr-25530-www.vm6.ai` does not exist yet. Please re-check the preview once CI drains.
