### PR TITLE
refactor(mail): remove expired reply follow-up compatibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
@@ -2,16 +2,11 @@ import { Buffer } from "node:buffer";
 
 import { testMailDraftStateContract } from "@vm0/api-contracts/contracts/test-mail-draft-state";
 import { zeroMailContract } from "@vm0/api-contracts/contracts/zero-mail";
-import {
-  zeroWorkflowAutomationsContract,
-  zeroWorkflowsCollectionContract,
-} from "@vm0/api-contracts/contracts/zero-workflows";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
-import { mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { testMailDraftStateRoutes } from "../test-mail-draft-state";
 import { createBddApi } from "./helpers/api-bdd";
@@ -28,8 +23,6 @@ import {
   setConnectorSecretOwner,
 } from "./helpers/connector-credential-storage-state";
 import { zeroMailRoutes } from "../zero-mail";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
-import { zeroWorkflowsRoutes } from "../zero-workflows";
 
 const context = testContext();
 const bdd = createBddApi(context);
@@ -746,210 +739,5 @@ describe("POST /api/zero/mail/drafts/link", () => {
       [200],
     );
     expect(unlinked.body.exists).toBeFalsy();
-  });
-
-  it("supports the previous Platform follow-up request without starting an agent run", async () => {
-    const fixture = await seedGmailMailCardFixture();
-    mockGmailDraftApi();
-
-    const linked = await linkDraft(fixture);
-    await accept(
-      client().sendDraft({
-        headers: authHeaders(),
-        params: { mailDraftId: linked.body.mailDraftId },
-      }),
-      [200],
-    );
-
-    mockOptionalEnv(
-      "GMAIL_PUBSUB_TOPIC_NAME",
-      "projects/test/topics/gmail-replies",
-    );
-    server.use(
-      http.post(`${GMAIL_API_BASE}/watch`, ({ request }) => {
-        expect(request.headers.get("authorization")).toBe(
-          "Bearer gmail-mail-card-token",
-        );
-        return HttpResponse.json({
-          historyId: "101",
-          expiration: "4102444800000",
-        });
-      }),
-    );
-
-    const created = await accept(
-      client().createFollowUp({
-        headers: authHeaders(),
-        params: { mailDraftId: linked.body.mailDraftId },
-        body: {},
-      }),
-      [200],
-    );
-    expect(created.body.mailDraftId).toBe(linked.body.mailDraftId);
-
-    const active = await accept(
-      client().getDraft({
-        headers: authHeaders(),
-        params: { mailDraftId: linked.body.mailDraftId },
-      }),
-      [200],
-    );
-    expect(active.body.mailDraft.followUp).toStrictEqual({
-      status: "active",
-      automationId: created.body.automationId,
-    });
-
-    const automations = await accept(
-      setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
-        zeroWorkflowAutomationsContract,
-      ).listForChatThread({
-        headers: authHeaders(),
-        params: { threadId: fixture.thread.id },
-      }),
-      [200],
-    );
-    expect(automations.body).toHaveLength(1);
-    expect(automations.body[0]).toMatchObject({
-      id: created.body.automationId,
-      kind: "event",
-      enabled: true,
-      eventType: "gmail-new-message",
-      eventConfig: {
-        provider: "gmail",
-        event: "new_message",
-        threadId: GMAIL_THREAD_ID,
-        match: {
-          from: {
-            containsAny: ["recipient@example.com", "copy@example.com"],
-          },
-        },
-      },
-      chatThreadId: fixture.thread.id,
-      workflow: {
-        agentId: fixture.agent.agentId,
-        displayName: "Mail reply follow-ups",
-      },
-    });
-
-    const events = await chat.listThreadEvents(
-      fixture.actor,
-      fixture.thread.id,
-    );
-    expect(events.events).toStrictEqual([
-      expect.objectContaining({
-        eventType: "output.message",
-        content:
-          "Reply tracking is on. When a reply arrives, I’ll let you know in this chat.",
-      }),
-    ]);
-
-    const repeated = await accept(
-      client().createFollowUp({
-        headers: authHeaders(),
-        params: { mailDraftId: linked.body.mailDraftId },
-        body: {},
-      }),
-      [200],
-    );
-    expect(repeated.body).toStrictEqual({
-      mailDraftId: linked.body.mailDraftId,
-      automationId: created.body.automationId,
-    });
-    expect(
-      (await chat.listThreadEvents(fixture.actor, fixture.thread.id)).events,
-    ).toHaveLength(1);
-  });
-
-  it("reuses a matching paused automation attached to the mail chat", async () => {
-    const fixture = await seedGmailMailCardFixture();
-    mockGmailDraftApi();
-    const linked = await linkDraft(fixture);
-    await accept(
-      client().sendDraft({
-        headers: authHeaders(),
-        params: { mailDraftId: linked.body.mailDraftId },
-      }),
-      [200],
-    );
-    mockOptionalEnv(
-      "GMAIL_PUBSUB_TOPIC_NAME",
-      "projects/test/topics/gmail-replies",
-    );
-    server.use(
-      http.post(`${GMAIL_API_BASE}/watch`, () => {
-        return HttpResponse.json({
-          historyId: "102",
-          expiration: "4102444800000",
-        });
-      }),
-    );
-
-    const workflow = await accept(
-      setupApp({ context, routes: zeroWorkflowsRoutes })(
-        zeroWorkflowsCollectionContract,
-      ).create({
-        headers: authHeaders(),
-        body: {
-          agentId: fixture.agent.agentId,
-          chatThreadId: fixture.thread.id,
-          name: "existing-mail-follow-up",
-          visibility: "private",
-        },
-      }),
-      [201],
-    );
-    const automationsClient = setupApp({
-      context,
-      routes: zeroWorkflowAutomationsRoutes,
-    })(zeroWorkflowAutomationsContract);
-    const existing = await accept(
-      automationsClient.create({
-        headers: authHeaders(),
-        params: { workflowId: workflow.body.id },
-        body: {
-          kind: "event",
-          eventType: "gmail-new-message",
-          eventConfig: {
-            provider: "gmail",
-            event: "new_message",
-            threadId: GMAIL_THREAD_ID,
-            match: {
-              from: {
-                containsAny: ["recipient@example.com", "copy@example.com"],
-              },
-            },
-          },
-          enabled: false,
-        },
-      }),
-      [201],
-    );
-    expect(existing.body).toMatchObject({
-      enabled: false,
-      chatThreadId: fixture.thread.id,
-    });
-
-    const followedUp = await accept(
-      client().createFollowUp({
-        headers: authHeaders(),
-        params: { mailDraftId: linked.body.mailDraftId },
-        body: {},
-      }),
-      [200],
-    );
-    expect(followedUp.body.automationId).toBe(existing.body.id);
-
-    const automations = await accept(
-      automationsClient.listForChatThread({
-        headers: authHeaders(),
-        params: { threadId: fixture.thread.id },
-      }),
-      [200],
-    );
-    expect(automations.body).toHaveLength(1);
-    expect(automations.body[0]).toMatchObject({
-      id: existing.body.id,
-      enabled: true,
-    });
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-mail.ts
+++ b/turbo/apps/api/src/signals/routes/zero-mail.ts
@@ -1,15 +1,10 @@
 import { command } from "ccstate";
 import { zeroMailContract } from "@vm0/api-contracts/contracts/zero-mail";
 
-import { badRequestMessage, conflict, notFound } from "../../lib/error";
+import { conflict, notFound } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
-import {
-  publishChatThreadAutomationsChangedSafely,
-  publishChatThreadMessageCreatedSafely,
-  publishThreadListChangedSafely,
-} from "../external/realtime";
 import type { RouteEntry } from "../route-entry";
 import {
   deleteZeroMailDraft$,
@@ -17,18 +12,9 @@ import {
   getZeroMailDraft$,
   linkZeroMailDraft$,
   sendZeroMailDraft$,
-  setupZeroMailFollowUp$,
   type ZeroMailDraftLinkMutationResult,
   type ZeroMailDraftMutationResult,
-  type ZeroMailFollowUpSetupResult,
 } from "../services/zero-mail.service";
-
-function forbidden(message: string) {
-  return {
-    status: 403 as const,
-    body: { error: { message, code: "FORBIDDEN" as const } },
-  };
-}
 
 function mutationResponse(result: ZeroMailDraftMutationResult) {
   switch (result.kind) {
@@ -67,32 +53,6 @@ function linkMutationResponse(result: ZeroMailDraftLinkMutationResult) {
     }
     case "conflict": {
       return conflict(result.message);
-    }
-  }
-}
-
-function followUpSetupResponse(result: ZeroMailFollowUpSetupResult) {
-  switch (result.kind) {
-    case "ok": {
-      return {
-        status: 200 as const,
-        body: {
-          mailDraftId: result.mailDraftId,
-          automationId: result.automationId,
-        },
-      };
-    }
-    case "not_found": {
-      return notFound(result.message);
-    }
-    case "conflict": {
-      return conflict(result.message);
-    }
-    case "forbidden": {
-      return forbidden(result.message);
-    }
-    case "bad_request": {
-      return badRequestMessage(result.message);
     }
   }
 }
@@ -221,50 +181,6 @@ const sendDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   );
 });
 
-const createFollowUpBody$ = bodyResultOf(zeroMailContract.createFollowUp);
-const createFollowUpParams$ = pathParamsOf(zeroMailContract.createFollowUp);
-// Compatibility bridge for Platform bundles loaded before the Mail follow-up
-// action was removed. Delete this route after that frontend release drains.
-const createFollowUpInner$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const auth = get(organizationAuthContext$);
-    const bodyResult = await get(createFollowUpBody$);
-    signal.throwIfAborted();
-    if (!bodyResult.ok) {
-      return bodyResult.response;
-    }
-    const result = await set(
-      setupZeroMailFollowUp$,
-      {
-        orgId: auth.orgId,
-        userId: auth.userId,
-        memberRole: auth.orgRole ?? "member",
-        ...get(createFollowUpParams$),
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-    if (result.kind === "ok") {
-      await publishChatThreadAutomationsChangedSafely(
-        auth.userId,
-        result.chatThreadId,
-      );
-      signal.throwIfAborted();
-      if (result.messageSeqId !== undefined) {
-        await publishChatThreadMessageCreatedSafely(
-          auth.userId,
-          result.chatThreadId,
-          result.messageSeqId,
-        );
-        signal.throwIfAborted();
-        await publishThreadListChangedSafely(auth.userId);
-        signal.throwIfAborted();
-      }
-    }
-    return followUpSetupResponse(result);
-  },
-);
-
 const mailDraftLinkAuth = Object.freeze({
   requireOrganization: true,
   missingOrganizationStatus: 401 as const,
@@ -276,13 +192,6 @@ const mailDraftHumanAuth = Object.freeze({
   requireOrganization: true,
   missingOrganizationStatus: 401 as const,
   requiredCapability: "connector:read" as const,
-  accept: Object.freeze(["session"] as const),
-});
-
-const mailFollowUpHumanAuth = Object.freeze({
-  requireOrganization: true,
-  missingOrganizationStatus: 401 as const,
-  requiredCapability: "agent:write" as const,
   accept: Object.freeze(["session"] as const),
 });
 
@@ -306,9 +215,5 @@ export const zeroMailRoutes: readonly RouteEntry[] = [
   {
     route: zeroMailContract.sendDraft,
     handler: authRoute(mailDraftHumanAuth, sendDraftInner$),
-  },
-  {
-    route: zeroMailContract.createFollowUp,
-    handler: authRoute(mailFollowUpHumanAuth, createFollowUpInner$),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-mail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-mail.service.ts
@@ -10,34 +10,21 @@ import {
   type ZeroMailDraftStatus,
   type ZeroMailInlineImage,
 } from "@vm0/api-contracts/contracts/zero-mail";
-import type { GmailNewMessageEventConfig } from "@vm0/api-contracts/contracts/zero-workflows";
-import { getCustomSkillStorageName } from "@vm0/core/storage-names";
-import { synthesizeWorkflowSkillMd } from "@vm0/core/zero-workflow-skill";
 import { connectorAuthMethodHasRequiredScopes } from "@vm0/connectors/connector-auth-method";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { connectors } from "@vm0/db/schema/connector";
 import { mailDrafts } from "@vm0/db/schema/mail-draft";
 import { userConnectors } from "@vm0/db/schema/user-connector";
-import {
-  workflowUserAutomationThreads,
-  zeroWorkflowAutomations,
-  zeroWorkflows,
-} from "@vm0/db/schema/zero-workflow";
 import { convert } from "html-to-text";
 import { z } from "zod";
 
-import {
-  nullableDriverValueDecoder,
-  pgTextDecoder,
-} from "../../lib/db-structured-result";
+import { pgTextDecoder } from "../../lib/db-structured-result";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../../lib/time";
 import { settle } from "../utils";
-import { insertChatEvent } from "./zero-chat-event.service";
-import { touchChatThreadLastMessageAt } from "./zero-chat-event-shared.service";
 import {
   loadConnectorRuntimeSnapshot,
   type ConnectorRuntimeSnapshot,
@@ -49,12 +36,6 @@ import {
   refreshConnectorCredentialAccess,
   type ConnectorCredentialConnection,
 } from "./connector-credential-runtime.service";
-import { uploadVolumeServerSide$ } from "./storage-volume-upload.service";
-import {
-  createWorkflowAutomation$,
-  enableWorkflowAutomation$,
-  type AutomationResult,
-} from "./zero-workflow-automation.service";
 
 const L = logger("api:zero-mail");
 
@@ -63,17 +44,6 @@ const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_MS = 60 * 60 * 1000;
 const GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1/users/me";
 const GMAIL_ACCESS_TOKEN_ENV = "GMAIL_TOKEN";
 const oauthScopesSchema = z.array(z.string());
-const MAIL_FOLLOW_UP_WORKFLOW_DISPLAY_NAME = "Mail reply follow-ups";
-const MAIL_FOLLOW_UP_WORKFLOW_DESCRIPTION =
-  "Summarize tracked email replies in their originating chat.";
-const MAIL_FOLLOW_UP_WORKFLOW_INSTRUCTION = [
-  "A reply to an email the user asked to track has arrived.",
-  "Read the Gmail thread to understand the new reply, summarize it in this chat, and highlight decisions or next steps.",
-  "If a response is warranted, prepare a linked Gmail draft for the user to review.",
-  "Never send an email automatically.",
-].join(" ");
-const MAIL_FOLLOW_UP_CONFIRMATION =
-  "Reply tracking is on. When a reply arrives, I’ll let you know in this chat.";
 
 interface GmailMessagePart {
   readonly partId: string;
@@ -173,25 +143,6 @@ export type ZeroMailDraftLinkMutationResult =
   | MailDraftLinkResult
   | MailDraftErrorResult;
 
-type MailFollowUpSetupErrorResult = {
-  readonly kind: "not_found" | "conflict" | "forbidden" | "bad_request";
-  readonly message: string;
-};
-
-type MailFollowUpWorkflowResult =
-  | { readonly kind: "ok"; readonly workflowId: string }
-  | MailFollowUpSetupErrorResult;
-
-export type ZeroMailFollowUpSetupResult =
-  | {
-      readonly kind: "ok";
-      readonly mailDraftId: string;
-      readonly automationId: string;
-      readonly chatThreadId: string;
-      readonly messageSeqId: number | undefined;
-    }
-  | MailFollowUpSetupErrorResult;
-
 type ZeroMailDraftAttachmentResult =
   | MailDraftAttachmentResult
   | MailDraftErrorResult;
@@ -199,10 +150,6 @@ type ZeroMailDraftAttachmentResult =
 const reconnectMailError = Object.freeze({
   kind: "conflict" as const,
   message: "Reconnect Gmail before continuing",
-});
-const noMailFollowUpRecipientsError = Object.freeze({
-  kind: "conflict" as const,
-  message: "The sent email has no recipients to track",
 });
 
 interface MailDraftRow {
@@ -214,8 +161,6 @@ interface MailDraftRow {
   readonly gmailThreadId: string;
   readonly gmailMessageId: string;
   readonly sentGmailMessageId: string | null;
-  readonly followUpAutomationId: string | null;
-  readonly followUpAutomationEnabled: boolean | null;
   readonly status: ZeroMailDraftStatus;
   readonly senderName: string | null;
   readonly senderAddress: string;
@@ -224,19 +169,6 @@ interface MailDraftRow {
   readonly updatedAt: Date;
   readonly sentAt: Date | null;
 }
-
-interface MailFollowUpAutomationRow {
-  readonly id: string;
-  readonly enabled: boolean;
-}
-
-type MailFollowUpAutomationResolution =
-  | {
-      readonly kind: "existing";
-      readonly automation: MailFollowUpAutomationRow;
-    }
-  | { readonly kind: "create"; readonly workflowId: string }
-  | MailFollowUpSetupErrorResult;
 
 interface StoredMailDraftRow {
   readonly id: string;
@@ -247,8 +179,6 @@ interface StoredMailDraftRow {
   readonly gmailThreadId: string | null;
   readonly gmailMessageId: string | null;
   readonly sentGmailMessageId: string | null;
-  readonly followUpAutomationId: string | null;
-  readonly followUpAutomationEnabled: boolean | null;
   readonly status: ZeroMailDraftStatus | null;
   readonly senderName: string | null;
   readonly senderAddress: string | null;
@@ -456,10 +386,6 @@ async function loadOwnedMailDraft(args: {
       gmailThreadId: mailDrafts.gmailThreadId,
       gmailMessageId: mailDrafts.gmailMessageId,
       sentGmailMessageId: mailDrafts.sentGmailMessageId,
-      followUpAutomationId: sql`${mailDrafts.followUpAutomationId}`.mapWith(
-        nullableDriverValueDecoder(pgTextDecoder),
-      ),
-      followUpAutomationEnabled: zeroWorkflowAutomations.enabled,
       status: mailDrafts.status,
       senderName: mailDrafts.senderName,
       senderAddress: mailDrafts.senderAddress,
@@ -471,10 +397,6 @@ async function loadOwnedMailDraft(args: {
     .from(mailDrafts)
     .innerJoin(chatThreads, eq(chatThreads.id, mailDrafts.chatThreadId))
     .innerJoin(agentComposes, eq(agentComposes.id, chatThreads.agentComposeId))
-    .leftJoin(
-      zeroWorkflowAutomations,
-      eq(zeroWorkflowAutomations.id, mailDrafts.followUpAutomationId),
-    )
     .where(
       and(
         eq(mailDrafts.id, args.mailDraftId),
@@ -1045,14 +967,6 @@ function responseDraft(args: {
     gmailThreadId: args.row.gmailThreadId,
     gmailMessageId: args.row.gmailMessageId,
     sentGmailMessageId: args.row.sentGmailMessageId ?? undefined,
-    followUp:
-      args.row.followUpAutomationId === null
-        ? undefined
-        : {
-            status:
-              args.row.followUpAutomationEnabled === true ? "active" : "paused",
-            automationId: args.row.followUpAutomationId,
-          },
     createdAt: args.row.createdAt.toISOString(),
     updatedAt: args.row.updatedAt.toISOString(),
     sentAt: args.row.sentAt?.toISOString(),
@@ -1902,552 +1816,6 @@ export const sendZeroMailDraft$ = command(
         details: gmail.current.details,
         detailAvailable: true,
       }),
-    );
-  },
-);
-
-function mailFollowUpWorkflowName(chatThreadId: string): string {
-  return `mail-reply-follow-up-${chatThreadId}`;
-}
-
-function mailFollowUpAutomationFailure(
-  result: Exclude<AutomationResult, { readonly kind: "ok" }>,
-): MailFollowUpSetupErrorResult {
-  switch (result.kind) {
-    case "not-found": {
-      return {
-        kind: "not_found",
-        message: "Mail follow-up workflow not found",
-      };
-    }
-    case "forbidden": {
-      return { kind: "forbidden", message: result.message };
-    }
-    case "conflict": {
-      return { kind: "conflict", message: result.message };
-    }
-    case "team-required":
-    case "bad-request": {
-      return { kind: "bad_request", message: result.message };
-    }
-    case "deleted": {
-      throw new Error("Mail follow-up automation was deleted during setup");
-    }
-  }
-}
-
-const ensureMailFollowUpAutomationEnabled$ = command(
-  async (
-    { set },
-    args: {
-      readonly orgId: string;
-      readonly userId: string;
-      readonly memberRole: string;
-      readonly automationId: string;
-    },
-    signal: AbortSignal,
-  ): Promise<MailFollowUpSetupErrorResult | null> => {
-    const enabled = await set(
-      enableWorkflowAutomation$,
-      {
-        orgId: args.orgId,
-        member: { userId: args.userId, role: args.memberRole },
-        automationId: args.automationId,
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-    return enabled.kind === "ok"
-      ? null
-      : mailFollowUpAutomationFailure(enabled);
-  },
-);
-
-const ensureMailFollowUpWorkflow$ = command(
-  async (
-    { set },
-    args: {
-      readonly orgId: string;
-      readonly userId: string;
-      readonly agentId: string;
-      readonly chatThreadId: string;
-    },
-    signal: AbortSignal,
-  ): Promise<MailFollowUpWorkflowResult> => {
-    const writeDb = set(writeDb$);
-    const name = mailFollowUpWorkflowName(args.chatThreadId);
-    const currentTime = nowDate();
-    const result = await writeDb.transaction(async (tx) => {
-      const [existing] = await tx
-        .select({ id: zeroWorkflows.id })
-        .from(zeroWorkflows)
-        .where(
-          and(
-            eq(zeroWorkflows.orgId, args.orgId),
-            eq(zeroWorkflows.agentId, args.agentId),
-            eq(zeroWorkflows.ownerUserId, args.userId),
-            eq(zeroWorkflows.visibility, "private"),
-            eq(zeroWorkflows.name, name),
-          ),
-        )
-        .limit(1);
-
-      if (existing) {
-        const [binding] = await tx
-          .select({
-            chatThreadId: workflowUserAutomationThreads.chatThreadId,
-          })
-          .from(workflowUserAutomationThreads)
-          .where(
-            and(
-              eq(workflowUserAutomationThreads.orgId, args.orgId),
-              eq(workflowUserAutomationThreads.userId, args.userId),
-              eq(workflowUserAutomationThreads.workflowId, existing.id),
-            ),
-          )
-          .limit(1);
-        if (
-          binding?.chatThreadId &&
-          binding.chatThreadId !== args.chatThreadId
-        ) {
-          return {
-            kind: "conflict" as const,
-            message: "Mail follow-up workflow is bound to another chat",
-          };
-        }
-        await tx
-          .insert(workflowUserAutomationThreads)
-          .values({
-            orgId: args.orgId,
-            userId: args.userId,
-            workflowId: existing.id,
-            chatThreadId: args.chatThreadId,
-            createdAt: currentTime,
-            updatedAt: currentTime,
-          })
-          .onConflictDoUpdate({
-            target: [
-              workflowUserAutomationThreads.orgId,
-              workflowUserAutomationThreads.userId,
-              workflowUserAutomationThreads.workflowId,
-            ],
-            set: {
-              chatThreadId: args.chatThreadId,
-              updatedAt: currentTime,
-            },
-          });
-        return {
-          kind: "ok" as const,
-          workflowId: existing.id,
-        };
-      }
-
-      const workflowId = randomUUID();
-      await tx.insert(zeroWorkflows).values({
-        id: workflowId,
-        orgId: args.orgId,
-        agentId: args.agentId,
-        name,
-        visibility: "private",
-        instruction: MAIL_FOLLOW_UP_WORKFLOW_INSTRUCTION,
-        ownerUserId: args.userId,
-        displayName: MAIL_FOLLOW_UP_WORKFLOW_DISPLAY_NAME,
-        description: MAIL_FOLLOW_UP_WORKFLOW_DESCRIPTION,
-        createdBy: args.userId,
-        updatedBy: args.userId,
-        createdAt: currentTime,
-        updatedAt: currentTime,
-      });
-      await tx.insert(workflowUserAutomationThreads).values({
-        orgId: args.orgId,
-        userId: args.userId,
-        workflowId,
-        chatThreadId: args.chatThreadId,
-        createdAt: currentTime,
-        updatedAt: currentTime,
-      });
-      return { kind: "ok" as const, workflowId };
-    });
-    signal.throwIfAborted();
-    if (result.kind !== "ok") {
-      return result;
-    }
-
-    // Keep the fixed workflow executable and repair a prior partial setup if
-    // storage upload failed after its database row was created.
-    await set(
-      uploadVolumeServerSide$,
-      {
-        orgId: args.orgId,
-        storageName: getCustomSkillStorageName(result.workflowId),
-        files: [
-          {
-            path: "SKILL.md",
-            content: synthesizeWorkflowSkillMd({
-              name,
-              description: MAIL_FOLLOW_UP_WORKFLOW_DESCRIPTION,
-              instruction: MAIL_FOLLOW_UP_WORKFLOW_INSTRUCTION,
-            }),
-          },
-        ],
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-    return { kind: "ok", workflowId: result.workflowId };
-  },
-);
-
-function mailFollowUpEventConfig(
-  draft: ZeroMailDraft,
-): GmailNewMessageEventConfig | null {
-  const recipients = Array.from(
-    new Set([...draft.to, ...draft.cc, ...draft.bcc]),
-  );
-  if (recipients.length === 0) {
-    return null;
-  }
-  return {
-    provider: "gmail",
-    event: "new_message",
-    threadId: draft.gmailThreadId,
-    match: {
-      from: { containsAny: recipients },
-    },
-  };
-}
-
-async function loadMatchingMailFollowUpAutomation(args: {
-  readonly db: ReadonlyDb;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly chatThreadId: string;
-  readonly eventConfig: GmailNewMessageEventConfig;
-}): Promise<MailFollowUpAutomationRow | null> {
-  const [existing] = await args.db
-    .select({
-      id: zeroWorkflowAutomations.id,
-      enabled: zeroWorkflowAutomations.enabled,
-    })
-    .from(zeroWorkflowAutomations)
-    .innerJoin(
-      workflowUserAutomationThreads,
-      and(
-        eq(workflowUserAutomationThreads.orgId, zeroWorkflowAutomations.orgId),
-        eq(
-          workflowUserAutomationThreads.userId,
-          zeroWorkflowAutomations.ownerUserId,
-        ),
-        eq(
-          workflowUserAutomationThreads.workflowId,
-          zeroWorkflowAutomations.workflowId,
-        ),
-      ),
-    )
-    .where(
-      and(
-        eq(zeroWorkflowAutomations.orgId, args.orgId),
-        eq(zeroWorkflowAutomations.ownerUserId, args.userId),
-        eq(zeroWorkflowAutomations.kind, "event"),
-        eq(zeroWorkflowAutomations.eventType, "gmail-new-message"),
-        eq(zeroWorkflowAutomations.eventConfig, args.eventConfig),
-        eq(workflowUserAutomationThreads.chatThreadId, args.chatThreadId),
-      ),
-    )
-    .limit(1);
-  return existing ?? null;
-}
-
-const resolveMailFollowUpAutomation$ = command(
-  async (
-    { set },
-    args: {
-      readonly orgId: string;
-      readonly userId: string;
-      readonly agentId: string;
-      readonly chatThreadId: string;
-      readonly eventConfig: GmailNewMessageEventConfig;
-    },
-    signal: AbortSignal,
-  ): Promise<MailFollowUpAutomationResolution> => {
-    const writeDb = set(writeDb$);
-    const existing = await loadMatchingMailFollowUpAutomation({
-      db: writeDb,
-      orgId: args.orgId,
-      userId: args.userId,
-      chatThreadId: args.chatThreadId,
-      eventConfig: args.eventConfig,
-    });
-    signal.throwIfAborted();
-    if (existing) {
-      return { kind: "existing", automation: existing };
-    }
-
-    const workflow = await set(
-      ensureMailFollowUpWorkflow$,
-      {
-        orgId: args.orgId,
-        userId: args.userId,
-        agentId: args.agentId,
-        chatThreadId: args.chatThreadId,
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-    if (workflow.kind !== "ok") {
-      return workflow;
-    }
-
-    const createdConcurrently = await loadMatchingMailFollowUpAutomation({
-      db: writeDb,
-      orgId: args.orgId,
-      userId: args.userId,
-      chatThreadId: args.chatThreadId,
-      eventConfig: args.eventConfig,
-    });
-    signal.throwIfAborted();
-    return createdConcurrently
-      ? { kind: "existing", automation: createdConcurrently }
-      : { kind: "create", workflowId: workflow.workflowId };
-  },
-);
-
-function existingMailFollowUpResult(
-  row: MailDraftRow,
-): Extract<ZeroMailFollowUpSetupResult, { readonly kind: "ok" }> | null {
-  if (!row.followUpAutomationId) {
-    return null;
-  }
-  return {
-    kind: "ok",
-    mailDraftId: row.id,
-    automationId: row.followUpAutomationId,
-    chatThreadId: row.chatThreadId,
-    messageSeqId: undefined,
-  };
-}
-
-const linkMailFollowUp$ = command(
-  async (
-    { set },
-    args: {
-      readonly orgId: string;
-      readonly userId: string;
-      readonly mailDraftId: string;
-      readonly automationId: string;
-    },
-    signal: AbortSignal,
-  ): Promise<ZeroMailFollowUpSetupResult> => {
-    const result = await set(writeDb$).transaction(async (tx) => {
-      const [source] = await tx
-        .select({
-          mailDraftId: mailDrafts.id,
-          chatThreadId: chatThreads.id,
-          followUpAutomationId: sql`${mailDrafts.followUpAutomationId}`.mapWith(
-            nullableDriverValueDecoder(pgTextDecoder),
-          ),
-        })
-        .from(mailDrafts)
-        .innerJoin(chatThreads, eq(chatThreads.id, mailDrafts.chatThreadId))
-        .innerJoin(
-          agentComposes,
-          eq(agentComposes.id, chatThreads.agentComposeId),
-        )
-        .where(
-          and(
-            eq(mailDrafts.id, args.mailDraftId),
-            eq(chatThreads.userId, args.userId),
-            eq(agentComposes.orgId, args.orgId),
-            eq(mailDrafts.status, "sent"),
-          ),
-        )
-        .limit(1)
-        .for("update");
-      if (!source) {
-        return {
-          kind: "not_found" as const,
-          message: "Sent email not found",
-        };
-      }
-      if (
-        source.followUpAutomationId !== null &&
-        source.followUpAutomationId !== args.automationId
-      ) {
-        return {
-          kind: "conflict" as const,
-          message: "Mail follow-up is already linked to another automation",
-        };
-      }
-      if (source.followUpAutomationId === args.automationId) {
-        return {
-          kind: "ok" as const,
-          mailDraftId: source.mailDraftId,
-          automationId: args.automationId,
-          chatThreadId: source.chatThreadId,
-          messageSeqId: undefined,
-        };
-      }
-
-      await tx
-        .update(mailDrafts)
-        .set({
-          followUpAutomationId: args.automationId,
-          updatedAt: sql`clock_timestamp()`,
-        })
-        .where(eq(mailDrafts.id, source.mailDraftId));
-      const message = await insertChatEvent(tx, {
-        chatThreadId: source.chatThreadId,
-        eventType: "output.message",
-        content: MAIL_FOLLOW_UP_CONFIRMATION,
-      });
-      if (!message) {
-        throw new Error("Failed to append mail follow-up confirmation");
-      }
-      await touchChatThreadLastMessageAt(
-        tx,
-        source.chatThreadId,
-        message.createdAt,
-      );
-      return {
-        kind: "ok" as const,
-        mailDraftId: source.mailDraftId,
-        automationId: args.automationId,
-        chatThreadId: source.chatThreadId,
-        messageSeqId: message.seqId,
-      };
-    });
-    signal.throwIfAborted();
-    return result;
-  },
-);
-
-// Compatibility service for Platform bundles loaded before the Mail follow-up
-// action was removed. Delete with the legacy route after those clients drain.
-export const setupZeroMailFollowUp$ = command(
-  async (
-    { get, set },
-    args: {
-      readonly orgId: string;
-      readonly userId: string;
-      readonly memberRole: string;
-      readonly mailDraftId: string;
-    },
-    signal: AbortSignal,
-  ): Promise<ZeroMailFollowUpSetupResult> => {
-    const row = await loadOwnedMailDraft({
-      db: get(db$),
-      orgId: args.orgId,
-      userId: args.userId,
-      mailDraftId: args.mailDraftId,
-    });
-    signal.throwIfAborted();
-    if (!row || row.status !== "sent") {
-      return { kind: "not_found", message: "Sent email not found" };
-    }
-    const existingFollowUp = existingMailFollowUpResult(row);
-    if (existingFollowUp) {
-      if (row.followUpAutomationEnabled === false) {
-        const error = await set(
-          ensureMailFollowUpAutomationEnabled$,
-          {
-            orgId: args.orgId,
-            userId: args.userId,
-            memberRole: args.memberRole,
-            automationId: existingFollowUp.automationId,
-          },
-          signal,
-        );
-        if (error) {
-          return error;
-        }
-      }
-      return existingFollowUp;
-    }
-
-    const draftResult = await set(
-      getZeroMailDraft$,
-      {
-        orgId: args.orgId,
-        userId: args.userId,
-        mailDraftId: args.mailDraftId,
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-    if (draftResult.kind !== "ok") {
-      return draftResult;
-    }
-    if (draftResult.mailDraft.accessStatus === "reconnect") {
-      return reconnectMailError;
-    }
-    const eventConfig = mailFollowUpEventConfig(draftResult.mailDraft);
-    if (!eventConfig) {
-      return noMailFollowUpRecipientsError;
-    }
-
-    const resolution = await set(
-      resolveMailFollowUpAutomation$,
-      {
-        orgId: args.orgId,
-        userId: args.userId,
-        agentId: row.agentId,
-        chatThreadId: row.chatThreadId,
-        eventConfig,
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-    if (resolution.kind !== "existing" && resolution.kind !== "create") {
-      return resolution;
-    }
-
-    let automationId: string;
-    if (resolution.kind === "existing") {
-      if (!resolution.automation.enabled) {
-        const error = await set(
-          ensureMailFollowUpAutomationEnabled$,
-          {
-            orgId: args.orgId,
-            userId: args.userId,
-            memberRole: args.memberRole,
-            automationId: resolution.automation.id,
-          },
-          signal,
-        );
-        if (error) {
-          return error;
-        }
-      }
-      automationId = resolution.automation.id;
-    } else {
-      const created = await set(
-        createWorkflowAutomation$,
-        {
-          orgId: args.orgId,
-          member: { userId: args.userId, role: args.memberRole },
-          workflowId: resolution.workflowId,
-          eventType: "gmail-new-message",
-          eventConfig,
-          enabled: true,
-        },
-        signal,
-      );
-      signal.throwIfAborted();
-      if (created.kind !== "ok") {
-        return mailFollowUpAutomationFailure(created);
-      }
-      automationId = created.summary.id;
-    }
-
-    return await set(
-      linkMailFollowUp$,
-      {
-        orgId: args.orgId,
-        userId: args.userId,
-        mailDraftId: args.mailDraftId,
-        automationId,
-      },
-      signal,
     );
   },
 );

--- a/turbo/packages/api-contracts/src/contracts/zero-mail.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-mail.ts
@@ -22,17 +22,6 @@ export const zeroMailInlineImageSchema = z.object({
   alt: z.string(),
 });
 
-export const zeroMailFollowUpSchema = z.discriminatedUnion("status", [
-  z.object({
-    status: z.literal("active"),
-    automationId: z.string().uuid(),
-  }),
-  z.object({
-    status: z.literal("paused"),
-    automationId: z.string().uuid(),
-  }),
-]);
-
 const zeroMailDraftBaseSchema = z.object({
   provider: z.literal("gmail"),
   from: z.email(),
@@ -54,7 +43,6 @@ const zeroMailDraftBaseSchema = z.object({
   gmailThreadId: z.string(),
   gmailMessageId: z.string(),
   sentGmailMessageId: z.string().optional(),
-  followUp: zeroMailFollowUpSchema.optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
   sentAt: z.string().optional(),
@@ -166,33 +154,11 @@ export const zeroMailContract = c.router({
     },
     summary: "Send a linked Gmail draft",
   },
-  // Compatibility contract for Platform bundles loaded before the Mail
-  // follow-up action was removed. Delete after that frontend release drains.
-  createFollowUp: {
-    method: "POST",
-    path: "/api/zero/mail/drafts/:mailDraftId/follow-up",
-    headers: authHeadersSchema,
-    pathParams: z.object({ mailDraftId: z.string().uuid() }),
-    body: z.object({}),
-    responses: {
-      200: z.object({
-        mailDraftId: z.string().uuid(),
-        automationId: z.string().uuid(),
-      }),
-      400: apiErrorSchema,
-      401: apiErrorSchema,
-      403: apiErrorSchema,
-      404: apiErrorSchema,
-      409: apiErrorSchema,
-    },
-    summary: "Enable reply tracking for a sent Gmail message",
-  },
 });
 
 export type ZeroMailProvider = z.infer<typeof zeroMailProviderSchema>;
 export type ZeroMailDraftStatus = z.infer<typeof zeroMailDraftStatusSchema>;
 export type ZeroMailAttachment = z.infer<typeof zeroMailAttachmentSchema>;
 export type ZeroMailInlineImage = z.infer<typeof zeroMailInlineImageSchema>;
-export type ZeroMailFollowUp = z.infer<typeof zeroMailFollowUpSchema>;
 export type ZeroMailDraft = z.infer<typeof zeroMailDraftSchema>;
 export type ZeroMailContract = typeof zeroMailContract;

--- a/turbo/packages/db/src/jsonb-contracts/mail-draft.ts
+++ b/turbo/packages/db/src/jsonb-contracts/mail-draft.ts
@@ -1,5 +1,1 @@
-/**
- * Opaque v1 payload retained only while old API pods can overlap the v2
- * Gmail-resource deployment. New application code must not read or write it.
- */
 export type LegacyMailDraftData = Record<string, unknown>;

--- a/turbo/packages/db/src/schema/mail-draft.ts
+++ b/turbo/packages/db/src/schema/mail-draft.ts
@@ -11,7 +11,6 @@ import type { ZeroMailDraftStatus } from "@vm0/api-contracts/contracts/zero-mail
 import type { LegacyMailDraftData } from "@vm0/db/jsonb-contracts/mail-draft";
 import { chatThreads } from "./chat-thread";
 import { connectors } from "./connector";
-import { zeroWorkflowAutomations } from "./zero-workflow";
 
 export const mailDrafts = pgTable(
   "mail_drafts",
@@ -36,15 +35,6 @@ export const mailDrafts = pgTable(
     gmailThreadId: text("gmail_thread_id"),
     gmailMessageId: text("gmail_message_id"),
     sentGmailMessageId: text("sent_gmail_message_id"),
-    // Compatibility declaration for Platform bundles loaded before Mail
-    // follow-up removal. Delete it with the legacy API bridge and physical
-    // column after those clients and the pre-cleanup API release have drained.
-    followUpAutomationId: uuid("follow_up_automation_id").references(
-      () => {
-        return zeroWorkflowAutomations.id;
-      },
-      { onDelete: "set null" },
-    ),
     status: text("status").$type<ZeroMailDraftStatus>(),
     senderName: text("sender_name"),
     senderAddress: text("sender_address"),
@@ -56,9 +46,6 @@ export const mailDrafts = pgTable(
   (table) => {
     return [
       index("idx_mail_drafts_chat_thread").on(table.chatThreadId),
-      index("idx_mail_drafts_follow_up_automation").on(
-        table.followUpAutomationId,
-      ),
       uniqueIndex("mail_drafts_connector_gmail_draft_unique").on(
         table.connectorId,
         table.gmailDraftId,


### PR DESCRIPTION
## Summary

- remove the expired Mail reply follow-up compatibility endpoint
- delete its workflow/automation setup service and response projection
- remove the unused follow-up ORM field and index declaration while leaving the physical database column untouched

## Evidence

- the Platform action was removed on 2026-08-04, more than two App refresh windows before this cleanup
- retained Axiom request logs contain one POST to the compatibility endpoint, last seen on 2026-08-04 at 07:54 UTC
- current App 0.696.0 and API 1.390.0 were both published before this cleanup

## Verification

- API core and test TypeScript compilation
- API contracts TypeScript compilation
- DB TypeScript compilation and JSONB contract lint
- changed-file Prettier, oxlint, type-aware oxlint, and ESLint
- targeted zero-mail Vitest was attempted; all tests were skipped before execution because local PostgreSQL is unavailable on port 5432
