### PR TITLE
refactor(db): remove legacy chat thread generation template

### DIFF
--- a/turbo/packages/db/src/jsonb-contracts/chat-thread.ts
+++ b/turbo/packages/db/src/jsonb-contracts/chat-thread.ts
@@ -1,9 +1,7 @@
 import type {
   PersistedAttachment,
-  ThreadGenerationTemplates,
   UserMessageInputDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 
 export type ChatThreadDraftAttachments = PersistedAttachment[];
 export type ChatThreadDraftUserMessage = UserMessageInputDocument;
-export type ChatThreadGenerationTemplate = ThreadGenerationTemplates;

--- a/turbo/packages/db/src/schema/chat-thread.ts
+++ b/turbo/packages/db/src/schema/chat-thread.ts
@@ -17,7 +17,6 @@ import { computerUseHosts } from "./computer-use-host";
 import type {
   ChatThreadDraftAttachments,
   ChatThreadDraftUserMessage,
-  ChatThreadGenerationTemplate,
 } from "@vm0/db/jsonb-contracts/chat-thread";
 import { agentRuns, agentSessions } from "./agent-run-session-conversation";
 
@@ -99,14 +98,6 @@ export const chatThreads = pgTable(
     codexServiceTier: varchar("codex_service_tier", {
       length: 20,
     }).$type<CodexServiceTier>(),
-    /**
-     * Legacy generation template column retained for schema compatibility.
-     * Current prompt injection reads the generation template attached to the
-     * current input event only.
-     */
-    generationTemplate: jsonb(
-      "generation_template",
-    ).$type<ChatThreadGenerationTemplate>(),
     computerUseHostId: uuid("computer_use_host_id").references(
       () => {
         return computerUseHosts.id;


### PR DESCRIPTION
## Summary

- remove the unused chat thread generation_template ORM declaration
- remove its unused JSONB TypeScript alias
- leave the physical database column untouched

## Evidence

- current prompt injection reads generation templates from the current input event
- source-wide reference scanning found no read or write through chatThreads.generationTemplate

## Verification

- DB TypeScript compilation
- DB JSONB contract lint
- changed-file Prettier, oxlint, type-aware oxlint, and ESLint
