### PR TITLE
refactor(cli): remove legacy billing capability inference

### DIFF
--- a/turbo/apps/cli/src/commands/zero/__tests__/credit.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/credit.test.ts
@@ -27,18 +27,13 @@ function stubBillingStatus(
     readonly tier?: string;
     readonly canBuyCredits?: boolean;
     readonly videoGenerationAllowed?: boolean;
-    readonly omitPlanCapabilities?: boolean;
   } = {},
 ) {
   return http.get("http://localhost:3000/api/zero/billing/status", () => {
     return HttpResponse.json({
       tier: overrides.tier ?? "pro",
-      ...(overrides.omitPlanCapabilities
-        ? {}
-        : {
-            canBuyCredits: overrides.canBuyCredits ?? true,
-            videoGenerationAllowed: overrides.videoGenerationAllowed ?? true,
-          }),
+      canBuyCredits: overrides.canBuyCredits ?? true,
+      videoGenerationAllowed: overrides.videoGenerationAllowed ?? true,
       credits: 12345,
       onboardingPaymentPending: false,
       subscriptionStatus: "active",
@@ -93,36 +88,6 @@ describe("zero credit command", () => {
     expect(output()).toContain("Auto-recharge: enabled");
     expect(output()).toContain("Threshold: 5,000");
     expect(output()).toContain("Amount: 20,000");
-    expect(output()).toContain("Can purchase credits: yes");
-    expect(output()).toContain("Built-in video generation: available");
-  });
-
-  it("preserves legacy limited-free restrictions when capability fields are omitted", async () => {
-    server.use(
-      stubBillingStatus({
-        tier: "limited-free-1",
-        omitPlanCapabilities: true,
-      }),
-    );
-
-    await zeroCreditCommand.parseAsync(["node", "cli"]);
-
-    expect(output()).toContain("Tier: limited-free-1");
-    expect(output()).toContain("Can purchase credits: no");
-    expect(output()).toContain("Built-in video generation: unavailable");
-  });
-
-  it("preserves legacy free access when capability fields are omitted", async () => {
-    server.use(
-      stubBillingStatus({
-        tier: "free",
-        omitPlanCapabilities: true,
-      }),
-    );
-
-    await zeroCreditCommand.parseAsync(["node", "cli"]);
-
-    expect(output()).toContain("Tier: free");
     expect(output()).toContain("Can purchase credits: yes");
     expect(output()).toContain("Built-in video generation: available");
   });

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
@@ -138,18 +138,14 @@ function stubAvailableConnectors(connectorSlugs: string[]) {
 }
 
 function stubBillingStatus(
-  videoGenerationAllowed: boolean | undefined,
+  videoGenerationAllowed: boolean,
   tier = videoGenerationAllowed ? "pro" : "limited-free-1",
 ) {
   return http.get("http://localhost:3000/api/zero/billing/status", () => {
     return HttpResponse.json({
       tier,
-      ...(videoGenerationAllowed === undefined
-        ? {}
-        : {
-            canBuyCredits: videoGenerationAllowed,
-            videoGenerationAllowed,
-          }),
+      canBuyCredits: videoGenerationAllowed,
+      videoGenerationAllowed,
       credits: 0,
       onboardingPaymentPending: false,
       subscriptionStatus: null,
@@ -428,34 +424,6 @@ describe("zero generate lister", () => {
     );
     expect(text).toContain(
       "[Compare plans](http://localhost:3000/?settings=billing&billingView=plans)",
-    );
-  });
-
-  it("uses a restricted legacy tier when billing capability fields are omitted", async () => {
-    server.use(
-      stubConnectorsWithConfiguredSlugs([], ["fal", "luma-ai", "runway"]),
-      stubUserConnectors([]),
-      stubBillingStatus(undefined, "limited-free-1"),
-    );
-
-    await generateCommand.parseAsync(["node", "cli", "video"]);
-
-    expect(output()).toContain(
-      "Availability: Requires a Pro, Team, or Custom workspace plan.",
-    );
-  });
-
-  it("uses an allowed legacy tier when billing capability fields are omitted", async () => {
-    server.use(
-      stubConnectorsWithConfiguredSlugs([], ["fal", "luma-ai", "runway"]),
-      stubUserConnectors([]),
-      stubBillingStatus(undefined, "free"),
-    );
-
-    await generateCommand.parseAsync(["node", "cli", "video"]);
-
-    expect(output()).toContain(
-      "Availability: Available on the current plan without connector setup.",
     );
   });
 

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
@@ -51,18 +51,14 @@ function imageResponse(width: number, height: number) {
 }
 
 function stubBillingStatus(
-  videoGenerationAllowed: boolean | undefined,
+  videoGenerationAllowed: boolean,
   tier = videoGenerationAllowed ? "pro" : "limited-free-1",
 ) {
   return http.get("http://localhost:3000/api/zero/billing/status", () => {
     return HttpResponse.json({
       tier,
-      ...(videoGenerationAllowed === undefined
-        ? {}
-        : {
-            canBuyCredits: videoGenerationAllowed,
-            videoGenerationAllowed,
-          }),
+      canBuyCredits: videoGenerationAllowed,
+      videoGenerationAllowed,
       credits: 0,
       onboardingPaymentPending: false,
       subscriptionStatus: null,
@@ -111,7 +107,7 @@ describe("zero generate video command", () => {
 
   it("should generate a video and print the /f file URL", async () => {
     server.use(
-      stubBillingStatus(undefined, "free"),
+      stubBillingStatus(true),
       http.get(FIRST_FRAME_URL, () => {
         return imageResponse(900, 1600);
       }),
@@ -375,7 +371,7 @@ describe("zero generate video command", () => {
   it("should stop before generation when the workspace plan blocks video", async () => {
     let generationRequests = 0;
     server.use(
-      stubBillingStatus(undefined, "limited-free-1"),
+      stubBillingStatus(false),
       http.post(VIDEO_URL, () => {
         generationRequests += 1;
         return HttpResponse.json(VIDEO_RESULT);

--- a/turbo/apps/cli/src/commands/zero/shared/billing-capabilities.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/billing-capabilities.ts
@@ -1,20 +1,16 @@
 import type { BillingStatusResponse } from "@vm0/api-contracts/contracts/zero-billing";
 import { decodeZeroTokenPayload } from "../../../lib/api/zero-token";
 
-function legacyPaidCapability(tier: string): boolean {
-  return tier !== "limited-free-1" && tier !== "pro-suspend";
-}
-
 export function currentPlanCanBuyCredits(
   billing: BillingStatusResponse,
 ): boolean {
-  return billing.canBuyCredits ?? legacyPaidCapability(billing.tier);
+  return billing.canBuyCredits === true;
 }
 
 export function currentPlanAllowsVideo(
   billing: BillingStatusResponse,
 ): boolean {
-  return billing.videoGenerationAllowed ?? legacyPaidCapability(billing.tier);
+  return billing.videoGenerationAllowed === true;
 }
 
 export function currentTokenCanReadBilling(): boolean {


### PR DESCRIPTION
## Summary

- remove tier-based inference for missing billing capability fields
- consume canBuyCredits and videoGenerationAllowed as explicit API capabilities
- remove legacy-response fixtures and tests

## Evidence

- current API 1.390.0 always emits both capability fields
- CLI 9.279.4 was published more than 37 hours before this cleanup, exceeding the two-hour sandbox lifetime

## Verification

- 46 targeted credit, doctor, video, avatar-video, and generation-list tests passed
- CLI TypeScript compilation
- changed-file Prettier, oxlint, type-aware oxlint, and ESLint
