### PR TITLE
refactor(cli): require chat thread agent ID

### DIFF
--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/send.test.ts
@@ -124,29 +124,9 @@ describe("zero chat send command", () => {
       http.get(metadataUrl(OTHER_THREAD_ID), () => {
         return HttpResponse.json({
           id: OTHER_THREAD_ID,
+          agentId: AGENT_ID,
           title: "Busy thread",
           selectedModel: null,
-        });
-      }),
-      http.get("http://localhost:3000/api/zero/chat-threads/snapshot", () => {
-        return HttpResponse.json({
-          chatThreads: [
-            {
-              id: OTHER_THREAD_ID,
-              agentId: AGENT_ID,
-              title: "Busy thread",
-              sortAt: "2026-07-29T10:00:00.000Z",
-              createdAt: "2026-07-29T10:00:00.000Z",
-              updatedAt: "2026-07-29T10:00:00.000Z",
-              pinnedAt: null,
-              renamedAt: null,
-              selectedModel: null,
-              serviceTier: null,
-              computerUseHostId: null,
-            },
-          ],
-          latestEventId: null,
-          latestSeqId: null,
         });
       }),
       http.post(SEND_URL, async ({ request }) => {

--- a/turbo/apps/cli/src/lib/api/domains/zero-chat.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-chat.ts
@@ -173,22 +173,7 @@ export async function getZeroChatThreadAgentId(options: {
   threadId: string;
 }): Promise<string> {
   const thread = await getZeroChatThread(options);
-  if (thread.agentId) {
-    return thread.agentId;
-  }
-
-  // Compatibility fallback for an API version that predates agentId on the
-  // narrow metadata response.
-  const snapshot = await getZeroChatThreadSnapshot();
-  const projection = snapshot.chatThreads.find((candidate) => {
-    return candidate.id === options.threadId;
-  });
-  if (!projection) {
-    throw new Error(
-      `Chat thread "${options.threadId}" was not found in the thread snapshot`,
-    );
-  }
-  return projection.agentId;
+  return thread.agentId;
 }
 
 export async function sendZeroChatEvent(

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -777,9 +777,7 @@ const chatThreadDetailSchema = z.object({
 
 const chatThreadMetadataSchema = z.object({
   id: z.string(),
-  // Optional during API/CLI rollout so a newer CLI can fall back to the
-  // compact thread snapshot when it reaches an older API.
-  agentId: z.string().uuid().optional(),
+  agentId: z.string().uuid(),
   title: z.string().nullable(),
   selectedModel: z.string().nullable(),
 });


### PR DESCRIPTION
## Summary

- require agentId in chat thread metadata responses
- remove the CLI snapshot fallback used with pre-agentId APIs
- update the chat send fixture to use the current metadata response

## Evidence

- current API 1.390.0 always returns agentId from the metadata endpoint
- CLI 9.279.4 was published more than 37 hours before this cleanup, exceeding the two-hour sandbox lifetime

## Verification

- 8 targeted chat send tests passed
- CLI and API contracts TypeScript compilation
- changed-file Prettier, oxlint, type-aware oxlint, and ESLint
