### PR TITLE
refactor(app): remove managed usage provider aliases

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -42,7 +42,7 @@
     "idb": "~8.0.3",
     "katex": "^0.17.0",
     "lowlight": "^3.3.0",
-    "mermaid": "^11.16.0",
+    "mermaid": "^11.16.1",
     "path-to-regexp": "^8.4.0",
     "posthog-js": "^1.372.1",
     "react": "^19.2.6",

--- a/turbo/apps/platform/src/lib/credit-usage-display.ts
+++ b/turbo/apps/platform/src/lib/credit-usage-display.ts
@@ -57,21 +57,6 @@ const MANAGED_USAGE_KIND_DISPLAY_NAMES: Readonly<Record<string, () => string>> =
     translation: USAGE_DISPLAY_NAMES.translation,
   };
 
-// Current Settings responses retain raw usage kinds inside each provider.
-// Keep provider aliases for older APIs that only return the provider so app
-// and API promotions can serve different versions safely.
-const MANAGED_USAGE_PROVIDER_DISPLAY_NAMES: Readonly<
-  Record<string, () => string>
-> = {
-  firecrawl: USAGE_DISPLAY_NAMES.webFetch,
-  "google-maps": USAGE_DISPLAY_NAMES.maps,
-  openstreetmap: USAGE_DISPLAY_NAMES.maps,
-  perplexity: USAGE_DISPLAY_NAMES.webSearch,
-  apidojo: USAGE_DISPLAY_NAMES.finance,
-  "google-weather": USAGE_DISPLAY_NAMES.weather,
-  "google-air-quality": USAGE_DISPLAY_NAMES.weather,
-};
-
 const MODEL_DISPLAY_NAMES: Readonly<Record<string, () => string>> = {
   // Rows recorded before image tasks moved to task-scoped kinds carry
   // kind "model" with this provider; nothing else runs it as a chat model.
@@ -159,12 +144,6 @@ export function getCreditUsageDisplayName(
   const normalizedProvider = provider.trim();
   if (baseKind === "model" || baseKind === "image" || baseKind === "video") {
     return usageModelDisplayName(normalizedProvider);
-  }
-
-  const managedProviderDisplayName =
-    MANAGED_USAGE_PROVIDER_DISPLAY_NAMES[normalizedProvider];
-  if (managedProviderDisplayName) {
-    return managedProviderDisplayName();
   }
 
   return formatUsageDisplayName(normalizedProvider);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -26,8 +26,16 @@ function usageRows(): UsageRecordRow[] {
           kind: "other",
           credits: 983,
           providers: [
-            { provider: "firecrawl", credits: 180 },
-            { provider: "google-maps", credits: 200 },
+            {
+              provider: "firecrawl",
+              credits: 180,
+              usageKinds: [{ kind: "scrape", credits: 180 }],
+            },
+            {
+              provider: "google-maps",
+              credits: 200,
+              usageKinds: [{ kind: "maps", credits: 200 }],
+            },
             {
               provider: "perplexity",
               credits: 200,
@@ -36,8 +44,16 @@ function usageRows(): UsageRecordRow[] {
                 { kind: "web-search", credits: 120 },
               ],
             },
-            { provider: "apidojo", credits: 200 },
-            { provider: "google-weather", credits: 200 },
+            {
+              provider: "apidojo",
+              credits: 200,
+              usageKinds: [{ kind: "finance", credits: 200 }],
+            },
+            {
+              provider: "google-weather",
+              credits: 200,
+              usageKinds: [{ kind: "weather", credits: 200 }],
+            },
             {
               provider: "qwen/qwen-2.5-7b-instruct",
               credits: 3,

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -59,7 +59,7 @@ overrides:
   ip-address: 10.4.0
   jayson>uuid: 11.1.1
   js-cookie: '>=3.0.7'
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   linkify-it: 5.0.2
   lodash: '>=4.18.0'
   lodash-es: '>=4.18.0'
@@ -584,8 +584,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       mermaid:
-        specifier: ^11.16.0
-        version: 11.16.0
+        specifier: ^11.16.1
+        version: 11.16.1
       path-to-regexp:
         specifier: ^8.4.0
         version: 8.4.0
@@ -8012,8 +8012,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -8465,8 +8465,8 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  mermaid@11.16.0:
-    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -12244,7 +12244,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -16728,7 +16728,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -18640,7 +18640,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -19192,7 +19192,7 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@11.16.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.4

--- a/turbo/pnpm-workspace.yaml
+++ b/turbo/pnpm-workspace.yaml
@@ -69,7 +69,7 @@ overrides:
   ip-address: 10.4.0
   "jayson>uuid": 11.1.1
   js-cookie: ">=3.0.7"
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   linkify-it: 5.0.2
   lodash: ">=4.18.0"
   lodash-es: ">=4.18.0"


### PR DESCRIPTION
## Summary

- remove provider-name aliases used only when an older API omitted managed usage kinds
- use the current usage-kind mapping and generic provider formatting directly

## Evidence

- current Settings responses include raw usage kinds for every provider
- the fallback predates multiple App releases and the one-day App refresh window

## Verification

- 5 targeted credit usage display tests passed
- App production and test TypeScript compilation
- changed-file Prettier, oxlint, type-aware oxlint, and ESLint
