### PR TITLE
fix(runner): clarify execution time limit log

### DIFF
--- a/crates/runner/src/cmd/start/job_terminal_log.rs
+++ b/crates/runner/src/cmd/start/job_terminal_log.rs
@@ -166,7 +166,10 @@ fn log_job_execution_failed(
 
     match failure.kind {
         ExecutionFailureKind::RunnerJobTimeout { .. } => {
-            emit_job_execution_failed!(tracing::Level::ERROR, "runner job timed out");
+            emit_job_execution_failed!(
+                tracing::Level::ERROR,
+                "runner job reached execution time limit"
+            );
         }
         ExecutionFailureKind::Generic if diagnostic.is_some_and(is_info_level_job_failure) => {
             emit_job_execution_failed!(tracing::Level::INFO, "job execution failed");
@@ -965,7 +968,7 @@ mod tests {
         assert_eq!(event.level, Level::ERROR);
         assert_eq!(
             event.fields.get("message").map(String::as_str),
-            Some("runner job timed out")
+            Some("runner job reached execution time limit")
         );
         assert_field_eq(&event, "exit_code", "124");
         assert_field_eq(&event, "reused", "false");
@@ -1017,7 +1020,7 @@ mod tests {
         );
         assert_eq!(
             timeout_event.fields.get("message").map(String::as_str),
-            Some("runner job timed out")
+            Some("runner job reached execution time limit")
         );
         assert_field_eq(&timeout_event, "timeout_ms", "7200000");
         assert_field_eq(&timeout_event, "elapsed_ms", "7200100");


### PR DESCRIPTION
## Summary

- Rename the runner timeout terminal log to state that the execution time limit was reached.
- Update the terminal-log assertions for the clarified message.

## Exclusions

- No change to the execution time limit, timeout detection, termination behavior, API errors, or sandbox reuse behavior.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner job_terminal_log`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
