### PR TITLE
fix: parse pdfs in zero scrape instead of returning base64

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-scrape.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-scrape.test.ts
@@ -442,7 +442,7 @@ describe("zero scrape route", () => {
     expect(requestBody).toStrictEqual({
       url: "https://example.com/page",
       formats: ["markdown"],
-      parsers: [],
+      parsers: [{ type: "pdf", maxPages: 100 }],
       proxy: "basic",
       skipTlsVerification: false,
       maxAge: 0,
@@ -463,6 +463,54 @@ describe("zero scrape route", () => {
       },
     });
     expect(beforeCredits - afterCredits).toBe(4);
+  });
+
+  it("bills a parsed PDF per page and reports truncated page counts", async () => {
+    const actor = createBddApi(context).user();
+    allowExampleDotCom();
+    configureProvider();
+    await seedScrapePricing();
+    await fundActor(actor);
+    const beforeCredits = await credits(actor);
+
+    server.use(
+      http.post(FIRECRAWL_SCRAPE_URL, () => {
+        return HttpResponse.json({
+          success: true,
+          data: {
+            markdown: "# Annual report",
+            metadata: {
+              sourceURL: "https://example.com/report.pdf",
+              numPages: 3,
+              totalPages: 12,
+            },
+          },
+        });
+      }),
+    );
+
+    const response = await accept(
+      client()(zeroScrapeContract).scrape({
+        headers: authenticate(actor),
+        body: {
+          url: "https://example.com/report.pdf",
+          format: "markdown",
+          mode: "standard",
+        },
+      }),
+      [200],
+    );
+    const afterCredits = await credits(actor);
+
+    expect(response.body).toMatchObject({
+      format: "markdown",
+      billingCategory: "standard.markdown",
+      billingQuantity: 3,
+      creditsCharged: 12,
+      metadata: { numPages: 3, totalPages: 12 },
+      result: { markdown: "# Annual report" },
+    });
+    expect(beforeCredits - afterCredits).toBe(12);
   });
 
   it("records usage when the request aborts after Firecrawl succeeds", async () => {
@@ -834,7 +882,7 @@ describe("zero scrape route", () => {
     expect(requestBody).toStrictEqual({
       url: "https://example.com/page",
       formats: ["links"],
-      parsers: [],
+      parsers: [{ type: "pdf", maxPages: 100 }],
       proxy: "enhanced",
       skipTlsVerification: false,
       maxAge: 0,

--- a/turbo/apps/api/src/signals/services/zero-scrape.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-scrape.service.ts
@@ -30,6 +30,9 @@ const MAX_FIRECRAWL_RESPONSE_BYTES = 4 * 1024 * 1024;
 const MAX_FIRECRAWL_ERROR_MESSAGE_CHARS = 4096;
 const MAX_MARKDOWN_CHARS = 1_000_000;
 const MAX_LINKS = 5000;
+// Firecrawl bills PDF parsing per page, so bound the work a single scrape can
+// trigger. Truncation is reported back through metadata.totalPages.
+const MAX_PDF_PAGES = 100;
 
 const SCRAPE_MODE_CONFIG = {
   standard: {
@@ -119,6 +122,7 @@ interface ZeroScrapeSuccessArgs {
   readonly requestedUrl: URL;
   readonly normalized: NormalizedScrape;
   readonly creditsCharged: number;
+  readonly billingQuantity: number;
 }
 
 interface ZeroScrapeSuccessBase {
@@ -139,14 +143,14 @@ interface CompleteScrapeSuccessArgs {
   readonly request: ZeroScrapeRequest;
   readonly requestedUrl: URL;
   readonly firecrawlResult: FirecrawlBodyResult;
-  readonly recordUsage: () => Promise<number>;
+  readonly recordUsage: (quantity: number) => Promise<number>;
 }
 
 interface CompleteScrapeAfterProviderArgs {
   readonly apiKey: string;
   readonly request: ZeroScrapeRequest;
   readonly requestedUrl: URL;
-  readonly recordUsage: () => Promise<number>;
+  readonly recordUsage: (quantity: number) => Promise<number>;
   readonly providerSignal: AbortSignal;
 }
 
@@ -194,6 +198,14 @@ function billingCategory(args: ZeroScrapeRequest): ZeroScrapeBillingCategory {
 
 function firecrawlProxy(mode: ZeroScrapeRequest["mode"]): "basic" | "enhanced" {
   return SCRAPE_MODE_CONFIG[mode].firecrawlProxy;
+}
+
+// Firecrawl reports numPages only for parsed documents and charges one credit
+// per page, so a PDF scrape bills one unit per parsed page and a web page
+// bills a single unit.
+function billingQuantity(metadata: ZeroScrapeResponse["metadata"]): number {
+  const numPages = metadata?.numPages;
+  return numPages !== undefined && numPages > 0 ? numPages : 1;
 }
 
 function targetPolicyMessage(error: ScrapeTargetPolicyError): string {
@@ -290,7 +302,7 @@ async function fetchFirecrawlScrape(
         body: JSON.stringify({
           url: targetUrl.toString(),
           formats: [request.format],
-          parsers: [],
+          parsers: [{ type: "pdf", maxPages: MAX_PDF_PAGES }],
           proxy: firecrawlProxy(request.mode),
           skipTlsVerification: false,
           maxAge: 0,
@@ -392,6 +404,8 @@ function normalizeMetadata(
     language: optionalString(metadata, "language"),
     statusCode: optionalInteger(metadata, "statusCode"),
     publishedTime: optionalString(metadata, "publishedTime"),
+    numPages: optionalInteger(metadata, "numPages"),
+    totalPages: optionalInteger(metadata, "totalPages"),
   };
 
   return Object.values(normalized).some((value) => {
@@ -463,7 +477,7 @@ function successResponseBase(
     ...(args.normalized.finalUrl ? { finalUrl: args.normalized.finalUrl } : {}),
     provider: PROVIDER,
     creditsCharged: args.creditsCharged,
-    billingQuantity: 1,
+    billingQuantity: args.billingQuantity,
     ...(args.normalized.metadata ? { metadata: args.normalized.metadata } : {}),
   };
 }
@@ -575,12 +589,14 @@ async function completeScrapeSuccess(
     return finalUrlError;
   }
 
-  const creditsCharged = await args.recordUsage();
+  const quantity = billingQuantity(normalized.metadata);
+  const creditsCharged = await args.recordUsage(quantity);
   const body = successBody({
     request: args.request,
     requestedUrl: args.requestedUrl,
     normalized,
     creditsCharged,
+    billingQuantity: quantity,
   });
   return { status: 200 as const, body };
 }
@@ -662,7 +678,7 @@ export const zeroScrape$ = command(
       request: args.body,
       requestedUrl: target.url,
       providerSignal: requestSignal,
-      recordUsage: () => {
+      recordUsage: (quantity: number) => {
         // Firecrawl has completed successfully, so a client disconnect must not
         // skip billing. The instance lifecycle still owns the usage commit.
         return set(
@@ -677,6 +693,7 @@ export const zeroScrape$ = command(
               kind: USAGE_KIND,
               provider: PROVIDER,
               category,
+              quantity,
             },
             label: "scrape",
           },

--- a/turbo/apps/cli/src/commands/zero/scrape/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/scrape/__tests__/index.test.ts
@@ -197,6 +197,35 @@ describe("zero scrape command", () => {
     expect(output()).toContain("# Example\n\nContent");
   });
 
+  it("prints parsed page counts and warns when a PDF is truncated", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/zero/scrape", () => {
+        return HttpResponse.json({
+          requestedUrl: "https://example.com/report.pdf",
+          format: "markdown",
+          mode: "standard",
+          provider: "firecrawl",
+          creditsCharged: 400,
+          billingCategory: "standard.markdown",
+          billingQuantity: 100,
+          metadata: { numPages: 100, totalPages: 240 },
+          result: { markdown: "# Annual report" },
+        });
+      }),
+    );
+
+    await zeroScrapeCommand.parseAsync([
+      "node",
+      "cli",
+      "https://example.com/report.pdf",
+    ]);
+
+    expect(output()).toContain("Billing quantity: 100");
+    expect(output()).toContain("Pages parsed: 100");
+    expect(output()).toContain("parsed the first 100 of 240 pages");
+    expect(output()).toContain("# Annual report");
+  });
+
   it("rejects invalid formats before calling the API", async () => {
     let apiRequests = 0;
     server.use(

--- a/turbo/apps/cli/src/commands/zero/scrape/index.ts
+++ b/turbo/apps/cli/src/commands/zero/scrape/index.ts
@@ -40,11 +40,29 @@ function parseMode(value: string): ZeroScrapeMode {
   );
 }
 
+function renderPdfPages(response: ZeroScrapeResponse): void {
+  const numPages = response.metadata?.numPages;
+  if (numPages === undefined) {
+    return;
+  }
+
+  const totalPages = response.metadata?.totalPages;
+  console.log(chalk.dim(`  Pages parsed: ${numPages}`));
+  if (totalPages !== undefined && totalPages > numPages) {
+    console.log(
+      chalk.yellow(
+        `  Truncated: parsed the first ${numPages} of ${totalPages} pages`,
+      ),
+    );
+  }
+}
+
 function renderScrapeMetadata(response: ZeroScrapeResponse): void {
   console.log(chalk.dim(`  Provider: ${response.provider}`));
   console.log(chalk.dim(`  Billing category: ${response.billingCategory}`));
   console.log(chalk.dim(`  Billing quantity: ${response.billingQuantity}`));
   console.log(chalk.dim(`  Credits charged: ${response.creditsCharged}`));
+  renderPdfPages(response);
 }
 
 function renderScrapeResult(response: ZeroScrapeResponse): void {
@@ -100,10 +118,13 @@ export const zeroScrapeCommand = new Command()
 Examples:
   Scrape markdown:  zero scrape https://example.com --format markdown
   Scrape links:     zero scrape https://example.com --format links
+  Scrape a PDF:     zero scrape https://example.com/report.pdf --format markdown
   Enhanced scrape:  zero scrape https://example.com --mode enhanced --json
 
 Notes:
   - Authenticates via ZERO_TOKEN (requires scrape:read capability) or a CLI token
   - Firecrawl calls and credit billing happen on the vm0 API server
-  - Enhanced mode is explicit because it uses a higher billing category`,
+  - Enhanced mode is explicit because it uses a higher billing category
+  - PDF URLs are parsed into markdown, falling back to OCR for scanned pages
+  - PDF scrapes bill one unit per parsed page and stop after 100 pages`,
   );

--- a/turbo/packages/api-contracts/src/contracts/zero-scrape.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-scrape.ts
@@ -26,6 +26,8 @@ export const zeroScrapeMetadataSchema = z.object({
   language: z.string().optional(),
   statusCode: z.number().int().optional(),
   publishedTime: z.string().optional(),
+  numPages: z.number().int().optional(),
+  totalPages: z.number().int().optional(),
 });
 
 const zeroScrapeResponseBaseSchema = z.object({


### PR DESCRIPTION
## Problem

`zero scrape` cannot read PDFs. Pointing it at any PDF URL returns a base64 blob:

```
$ zero scrape https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf --json
.format          = markdown
.result.markdown = JVBERi0xLjQKJcOkw7zDtsOfCjIgMCBvYmoKPDwvTGVuZ3Ro...
```

The cause is `parsers: []` in the Firecrawl request. Firecrawl documents that value as: *"When an empty array is passed, the PDF file is returned in base64 encoding with a flat rate of 1 credit for the entire PDF."* It has been that way since the endpoint was introduced in #20778.

This matters most for text-only models. Claude and GPT can take a PDF as a native document block, so they never hit this path. DeepSeek V4 Flash — the default model — cannot, and the sandbox ships no `pypdf` / `pymupdf` / `pdfminer` / `PIL` / `poppler`, so an agent on the default model has no way to read a PDF at all.

## Change

Send `parsers: [{ type: "pdf", maxPages: 100 }]`. Firecrawl's default `auto` mode extracts the embedded text layer first and falls back to OCR for scanned pages, so no routing logic is needed on our side.

Non-PDF pages are unaffected: `parsers` only applies to document inputs, and Firecrawl still charges a flat credit for an HTML scrape.

### Billing

Firecrawl charges **1 credit per parsed page** rather than a flat credit, so a flat `billingQuantity: 1` would have left vm0 paying per page while charging per request. Usage is now recorded with `quantity` = pages parsed, which `recordManagedUsage$` already supports. A web page still bills 1 unit because Firecrawl only reports `numPages` for parsed documents.

`maxPages: 100` bounds both the per-request cost and the work done inside the 25s provider timeout.

### Truncation is visible

Firecrawl returns `numPages` (parsed) and `totalPages` (true count). Both are now passed through to response metadata, and the CLI prints a warning when they differ, so a truncated 240-page report does not silently look complete:

```
✓ Scrape completed
  Billing quantity: 100
  Credits charged: 400
  Pages parsed: 100
  Truncated: parsed the first 100 of 240 pages
```

## Notes for review

- **No new billing category.** PDFs bill under the existing `standard.markdown` / `enhanced.markdown` categories, so this needs no new `usage_pricing` row and cannot 503 on a missing one.
- **The credit pre-check still runs at quantity 1**, since page count is unknown before the scrape returns. `maxPages` caps the worst-case overshoot at 100 units. Splitting the check into a HEAD request for the page count seemed like more machinery than the exposure justifies — happy to add it if you disagree.
- **This does not cover local files.** `zero scrape` takes a URL, so an uploaded PDF still has no path. Firecrawl's `/v2/parse` accepts `multipart/form-data` uploads and would cover it; that belongs in a separate change.

## Testing

- `pnpm --dir apps/api exec vitest run scrape` — 22 passed, including a new case asserting per-page billing and truncated page counts
- `pnpm --dir apps/cli exec vitest run` — 889 passed
- `pnpm --dir packages/api-contracts exec vitest run` — 529 passed
- `pnpm check-types`, `pnpm turbo run lint` (0 errors), `pnpm format`, `pnpm knip` (output unchanged from baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)