### PR TITLE
refactor(api): route queued chat events by context type alone

### DIFF
--- a/turbo/apps/api/src/scripts/dev-bench-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-bench-seed.ts
@@ -654,6 +654,7 @@ function appendRunEvents(
     chatThreadId: args.threadId,
     runId,
     eventType: "input.prompt",
+    contextType: args.workflowAutomationBrief ? "automation" : "web",
     userMessage: { version: 1, parts: [{ type: "text", text: prompt }] },
     createdAt: baseCreatedAt,
   };
@@ -849,19 +850,23 @@ function appendNullRunControlRows(args: {
       ),
       500,
     );
+    const prompt = userPromptLorem(args.profile, controlIndex);
+    const isInputPrompt = controlIndex % 2 === 0;
     args.eventRows.push({
       id: randomUUID(),
       chatThreadId: args.threadId,
       runId: null,
-      eventType: controlIndex % 2 === 0 ? "input.prompt" : "output.thinking",
-      content:
-        controlIndex % 2 === 0
-          ? userPromptLorem(args.profile, controlIndex)
-          : null,
-      thinking:
-        controlIndex % 2 === 0
-          ? null
-          : `Synthetic background state ${String(controlIndex)}`,
+      eventType: isInputPrompt ? "input.prompt" : "output.thinking",
+      content: null,
+      ...(isInputPrompt
+        ? {
+            contextType: "web",
+            userMessage: {
+              version: 1,
+              parts: [{ type: "text", text: prompt }],
+            },
+          }
+        : { thinking: `Synthetic background state ${String(controlIndex)}` }),
       createdAt,
     });
   }

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
@@ -120,7 +120,7 @@ describe("cron monitor chat event queue", () => {
     expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
   });
 
-  it("does not alert for pointerless web, test, or agent prompts", async () => {
+  it("does not alert for web or agent-run prompts", async () => {
     const fixture = await trackFixture(seedFixture("orphan"));
 
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -21,7 +21,10 @@ import {
   pauseGoalQueueTargetFixture,
   readGoalQueueStateFixture,
 } from "../../../test-fixtures/goal-queue";
-import { admitWorkflowAutomationEventFixture } from "../../../test-fixtures/workflow-queue";
+import {
+  admitWorkflowAutomationEventFixture,
+  readWorkflowRunTriggerSourceFixture,
+} from "../../../test-fixtures/workflow-queue";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import type { ApiTestUser } from "./helpers/api-bdd";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
@@ -608,6 +611,9 @@ describe("workflow queue", () => {
       await postWorkflowWebhook(automation, "run after invalid goal"),
       automation.threadId,
     );
+    await expect(
+      readWorkflowRunTriggerSourceFixture(workflowRunId),
+    ).resolves.toBe("workflow-event");
     const events = await wf.readThreadEvents(automation.threadId);
     expect(events).toContainEqual(
       expect.objectContaining({
@@ -956,6 +962,9 @@ describe("workflow queue", () => {
     await completeRunThroughSandbox(scenario, busyRunId);
     const runIds = await workflowRunIds(webhookAutomation.threadId);
     expect(runIds).toHaveLength(2);
+    await expect(readWorkflowRunTriggerSourceFixture(runIds[1]!)).resolves.toBe(
+      "workflow-schedule",
+    );
     const claimedTick = (
       await wf.readThreadEvents(webhookAutomation.threadId)
     ).find((event) => {

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -2782,7 +2782,6 @@ function pendingActiveInputRows(
       eventType: chatEvents.eventType,
       contextType: chatEvents.contextType,
       contextId: chatEvents.contextId,
-      triggerSource: chatEvents.triggerSource,
       userMessage: chatEvents.userMessage,
       attachFiles: chatEvents.attachFiles,
       generationTemplate: chatEvents.generationTemplate,
@@ -2848,9 +2847,6 @@ async function claimPendingActiveInputEvent(
           userMessage,
           attachFiles: event.attachFiles,
           generationTemplate: event.generationTemplate,
-          ...(event.triggerSource
-            ? { triggerSource: event.triggerSource }
-            : {}),
         });
   if (!replacement) {
     throw new Error("Active input claim lost after locking the thread");
@@ -2871,6 +2867,9 @@ async function materializePendingActiveInputPrompts(
     ) {
       return null;
     }
+    if (event.contextType === null) {
+      throw new Error("Pending active input is missing its context type");
+    }
     prompts.set(
       event.id,
       await materializeActiveInputPrompt(db, {
@@ -2878,7 +2877,7 @@ async function materializePendingActiveInputPrompts(
           id: event.id,
           chatThreadId: event.chatThreadId,
           eventType: event.eventType,
-          triggerSource: event.triggerSource,
+          contextType: event.contextType,
           userMessage: event.userMessage,
           generationTemplate: event.generationTemplate,
         },

--- a/turbo/apps/api/src/signals/services/active-input-prompt.service.ts
+++ b/turbo/apps/api/src/signals/services/active-input-prompt.service.ts
@@ -1,10 +1,10 @@
-import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import { ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES } from "@vm0/api-contracts/contracts/runners";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import type {
   ChatEventGenerationTemplate,
   ChatEventUserMessage,
+  chatEvents,
 } from "@vm0/db/schema/chat-event";
 
 import type { Db } from "../external/db";
@@ -20,7 +20,11 @@ import {
   requiredUserMessageForEvent,
 } from "./zero-chat-user-message.service";
 
-type ContextBackedTriggerSource =
+type ChatEventContextType = NonNullable<
+  (typeof chatEvents.$inferSelect)["contextType"]
+>;
+
+type ContextBackedContextType =
   | "slack"
   | "feishu"
   | "teams"
@@ -31,7 +35,7 @@ interface ActiveInputPromptEvent {
   readonly id: string;
   readonly chatThreadId: string;
   readonly eventType: "input.prompt" | "input.budget";
-  readonly triggerSource: TriggerSource | null;
+  readonly contextType: ChatEventContextType;
   readonly userMessage: ChatEventUserMessage;
   readonly generationTemplate: ChatEventGenerationTemplate | null;
 }
@@ -41,7 +45,7 @@ interface IntegrationPromptMaterial {
   readonly appendSystemPrompt: string;
 }
 
-const CONTEXT_BACKED_TRIGGER_SOURCES: readonly ContextBackedTriggerSource[] = [
+const CONTEXT_BACKED_CONTEXT_TYPES: readonly ContextBackedContextType[] = [
   "slack",
   "feishu",
   "teams",
@@ -57,11 +61,11 @@ export function activeInputPromptFitsControlPayload(prompt: string): boolean {
   );
 }
 
-function isContextBackedTriggerSource(
-  source: TriggerSource | null,
-): source is ContextBackedTriggerSource {
-  return CONTEXT_BACKED_TRIGGER_SOURCES.some((candidate) => {
-    return candidate === source;
+function isContextBackedContextType(
+  contextType: ChatEventContextType,
+): contextType is ContextBackedContextType {
+  return CONTEXT_BACKED_CONTEXT_TYPES.some((candidate) => {
+    return candidate === contextType;
   });
 }
 
@@ -76,7 +80,7 @@ async function loadIntegrationPromptMaterial(
     orgId: args.orgId,
     userId: args.userId,
   };
-  switch (event.triggerSource) {
+  switch (event.contextType) {
     case "slack": {
       return await loadSlackQueuedLaunchMaterial(db, loaderArgs);
     }
@@ -92,10 +96,22 @@ async function loadIntegrationPromptMaterial(
     case "agentphone": {
       return await loadAgentPhoneQueuedLaunchMaterial(db, loaderArgs);
     }
-    default: {
+    case "web":
+    case "github":
+    case "automation":
+    case "goal":
+    case "morning_brief":
+    case "agent_run": {
       return null;
     }
+    default: {
+      return unreachableActiveInputContextType(event.contextType);
+    }
   }
+}
+
+function unreachableActiveInputContextType(contextType: never): never {
+  throw new Error(`Unsupported active input context type: ${contextType}`);
 }
 
 /** Materialize one claimed input prompt into the same text capability as a run prompt. */
@@ -127,9 +143,9 @@ export async function materializeActiveInputPrompt(
     inlineTemplates: inlineTemplatesEnabled,
   });
   const integration = await loadIntegrationPromptMaterial(db, args.event, args);
-  if (isContextBackedTriggerSource(args.event.triggerSource) && !integration) {
+  if (isContextBackedContextType(args.event.contextType) && !integration) {
     throw new Error(
-      `${args.event.triggerSource} active input is missing launch material`,
+      `${args.event.contextType} active input is missing launch material`,
     );
   }
   const generationTemplatePrompt = resolveThreadGenerationTemplatePrompt({

--- a/turbo/apps/api/src/signals/services/agentphone-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/agentphone-queued-launch-context.service.ts
@@ -115,7 +115,6 @@ async function loadAgentPhoneLaunchContext(
         eq(chatEvents.id, args.eventId),
         eq(chatEvents.chatThreadId, args.chatThreadId),
         eq(chatEvents.contextType, "agentphone"),
-        eq(chatEvents.triggerSource, "agentphone"),
       ),
     )
     .limit(1);

--- a/turbo/apps/api/src/signals/services/canonical-slack-thread-status.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-slack-thread-status.service.ts
@@ -145,7 +145,7 @@ async function canonicalSlackThreadHasOutstandingWorkInSnapshot(
       and(
         inArray(chatEvents.chatThreadId, chatThreadIds),
         chatEventTypeIn(["input.prompt"]),
-        eq(chatEvents.triggerSource, "slack"),
+        eq(chatEvents.contextType, "slack"),
         isNull(chatEvents.runId),
         notExists(
           db

--- a/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
@@ -16,17 +16,10 @@ import {
   inArray,
   isNull,
   lt,
-  not,
   notExists,
-  notInArray,
   or,
-  sql,
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
-import {
-  nullableDriverValueDecoder,
-  pgTextDecoder,
-} from "../../lib/db-structured-result";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../../lib/time";
 import { STALE_QUEUE_ITEM_AGE_MS } from "./chat-thread-queue-drain.service";
@@ -192,10 +185,7 @@ async function monitorChatEventQueue(
   eventIds?: readonly string[],
 ) {
   const staleBefore = new Date(nowDate().getTime() - STALE_QUEUE_ITEM_AGE_MS);
-  const orphanedSource =
-    sql`coalesce(${chatEvents.contextType}, ${chatEvents.triggerSource})`.mapWith(
-      nullableDriverValueDecoder(pgTextDecoder),
-    );
+  const orphanedSource = chatEvents.contextType;
   const results = await db
     .select({
       eventType: chatEvents.eventType,
@@ -218,14 +208,6 @@ async function monitorChatEventQueue(
         ),
         lt(chatEvents.createdAt, staleBefore),
         or(
-          and(
-            isNull(chatEvents.contextType),
-            not(chatEventTypeIn(["input.goal"])),
-            or(
-              isNull(chatEvents.triggerSource),
-              notInArray(chatEvents.triggerSource, ["web", "test", "agent"]),
-            ),
-          ),
           missingChatIntegrationContextRowCondition(db),
           missingScheduledContextRowCondition(db),
           missingGoalRowCondition(db),

--- a/turbo/apps/api/src/signals/services/feishu-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-queued-launch-context.service.ts
@@ -141,7 +141,6 @@ async function loadFeishuLaunchContext(
         eq(chatEvents.id, args.eventId),
         eq(chatEvents.chatThreadId, args.chatThreadId),
         eq(chatEvents.contextType, "feishu"),
-        eq(chatEvents.triggerSource, "feishu"),
       ),
     )
     .limit(1);

--- a/turbo/apps/api/src/signals/services/github-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/github-queued-launch-context.service.ts
@@ -105,7 +105,6 @@ async function loadGitHubLaunchContext(
         eq(chatEvents.id, args.eventId),
         eq(chatEvents.chatThreadId, args.chatThreadId),
         eq(chatEvents.contextType, "github"),
-        eq(chatEvents.triggerSource, "github"),
       ),
     )
     .limit(1);

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -130,7 +130,6 @@ import {
 } from "./zero-chat-event-shared.service";
 import { insertChatEvent } from "./zero-chat-event.service";
 import { loadWebChatIncompleteContext } from "./zero-chat-incomplete-context.service";
-import { isWebChatTriggerSource } from "./zero-chat-trigger-source.service";
 import { chatThreadAdmissionBlocked } from "./zero-chat-active-run.service";
 import {
   projectUserMessage,
@@ -143,8 +142,12 @@ import {
 } from "./assistant-event-id";
 import {
   failQueuedUserMessage,
+  isWebChatContextType,
   loadNextUnclaimedQueuedUserMessage,
+  queuedUserMessageTriggerSource,
   resolveAttachFileMetadata$,
+  type QueuedUserMessageContextType,
+  type QueuedUserMessageTriggerSource,
   type QueuedUserMessage,
 } from "./zero-chat-queued-event.service";
 import { handleMorningBriefEmailInternalCallback } from "./internal-morning-brief-run-callback.service";
@@ -283,7 +286,7 @@ export class ChatCallbackPreCreateTimingCollector {
 
   flush(
     runId: string,
-    triggerSource: QueuedUserMessage["triggerSource"] = "web",
+    triggerSource: QueuedUserMessageTriggerSource = "web",
   ): void {
     if (this.flushed) {
       return;
@@ -314,7 +317,7 @@ export class ChatCallbackPreCreateTimingCollector {
 function flushChatCallbackTimingOnRejection(args: {
   readonly timing: ChatCallbackPreCreateTimingCollector;
   readonly getRunId: () => string | null;
-  readonly triggerSource: QueuedUserMessage["triggerSource"];
+  readonly triggerSource: QueuedUserMessageTriggerSource;
 }): (error: unknown) => void {
   return () => {
     const runId = args.getRunId();
@@ -643,7 +646,7 @@ interface CreateQueuedChatRunInput {
     readonly hostId: string;
     readonly displayName: string;
   } | null;
-  readonly triggerSource: QueuedUserMessage["triggerSource"];
+  readonly triggerSource: QueuedUserMessageTriggerSource;
   readonly attachFileMetadata: readonly ChatEventAttachFileMetadata[] | null;
   readonly realAgentInPreview?: boolean;
   readonly slackDelivery?: {
@@ -2284,9 +2287,9 @@ function formatPriorRunEvent(
 }
 
 function priorRunsContextLabel(
-  triggerSource: QueuedUserMessage["triggerSource"],
+  contextType: QueuedUserMessageContextType,
 ): string {
-  switch (triggerSource) {
+  switch (contextType) {
     case "slack": {
       return "Slack";
     }
@@ -2302,18 +2305,27 @@ function priorRunsContextLabel(
     case "github": {
       return "GitHub";
     }
-    case "workflow-schedule": {
+    case "morning_brief": {
       return "Workflow Automation";
     }
-    default: {
+    case "web":
+    case "agent_run":
+    case "agentphone": {
       return "Web Chat";
+    }
+    case "automation":
+    case "goal": {
+      return unreachableQueuedMessageContext(contextType);
+    }
+    default: {
+      return unreachableQueuedContextType(contextType);
     }
   }
 }
 
 function buildChatPriorRunsContext(
   runs: readonly PriorRun[],
-  triggerSource: QueuedUserMessage["triggerSource"],
+  contextType: QueuedUserMessageContextType,
   inlineTemplatesEnabled: boolean,
 ): string {
   if (runs.length === 0) {
@@ -2340,7 +2352,7 @@ function buildChatPriorRunsContext(
     ].join("\n");
   });
   return [
-    `# ${priorRunsContextLabel(triggerSource)} Run Context`,
+    `# ${priorRunsContextLabel(contextType)} Run Context`,
     "The current CLI session is fresh, so recent visible chat rounds are provided here for continuity.",
     "- Treat the newest run below as the most recent prior round.",
     "- Use the LOG_COMMAND for a run if you need more detailed agent log context.",
@@ -2352,9 +2364,10 @@ function buildChatPriorRunsContext(
 async function getLatestRunsByThreadId(
   db: Db,
   threadId: string,
-  triggerSource: QueuedUserMessage["triggerSource"],
+  contextType: QueuedUserMessageContextType,
   limit: number,
 ): Promise<PriorRun[]> {
+  const triggerSource = queuedUserMessageTriggerSource(contextType);
   const runRows = await db
     .select({
       runId: zeroRuns.id,
@@ -2366,7 +2379,7 @@ async function getLatestRunsByThreadId(
     .where(
       and(
         eq(zeroRuns.chatThreadId, threadId),
-        isWebChatTriggerSource(triggerSource)
+        isWebChatContextType(contextType)
           ? inArray(zeroRuns.triggerSource, ["web", "agent"])
           : eq(zeroRuns.triggerSource, triggerSource),
         or(
@@ -2509,7 +2522,7 @@ async function buildQueuedPriorContext(args: {
   readonly threadId: string;
   readonly startNewSession: boolean;
   readonly incompleteContext: string;
-  readonly triggerSource: QueuedUserMessage["triggerSource"];
+  readonly contextType: QueuedUserMessageContextType;
   readonly inlineTemplatesEnabled: boolean;
 }): Promise<string> {
   if (!args.startNewSession || args.incompleteContext.length > 0) {
@@ -2519,10 +2532,10 @@ async function buildQueuedPriorContext(args: {
     await getLatestRunsByThreadId(
       args.db,
       args.threadId,
-      args.triggerSource,
+      args.contextType,
       RECENT_CHAT_RUN_LIMIT,
     ),
-    args.triggerSource,
+    args.contextType,
     args.inlineTemplatesEnabled,
   );
 }
@@ -2627,7 +2640,7 @@ async function resolveQueuedMessageModelRoute(args: {
   readonly threadId: string;
   readonly userId: string;
   readonly orgId: string;
-  readonly triggerSource: QueuedUserMessage["triggerSource"];
+  readonly contextType: QueuedUserMessageContextType;
   readonly timing?: ChatCallbackPreCreateTimingCollector;
 }): Promise<QueuedMessageModelRouteResolution> {
   const modelContext = await measureChatCallbackPreCreateTiming(
@@ -2644,7 +2657,7 @@ async function resolveQueuedMessageModelRoute(args: {
     },
   );
   if ("status" in modelContext) {
-    if (args.triggerSource === "slack") {
+    if (args.contextType === "slack") {
       const unpinnedRoute =
         await resolveUnpinnedSlackQueuedMessageModelRoute(args);
       if (unpinnedRoute) {
@@ -2708,8 +2721,8 @@ function loadQueuedMessageSessionState(
           cliAgentType: modelRoute.cliAgentType,
         },
       });
-      const incompleteContext = isWebChatTriggerSource(
-        args.queuedMessage.triggerSource,
+      const incompleteContext = isWebChatContextType(
+        args.queuedMessage.contextType,
       )
         ? await loadWebChatIncompleteContext(args.db, args.threadId)
         : "";
@@ -2804,11 +2817,11 @@ async function resolveQueuedLaunchMaterial(
     readonly userMessageProjection: ReturnType<typeof projectUserMessage>;
   },
 ): Promise<QueuedLaunchMaterial> {
-  const triggerSource = args.queuedMessage.triggerSource;
+  const contextType = args.queuedMessage.contextType;
   let load: LaunchLoader;
-  switch (triggerSource) {
+  switch (contextType) {
     case "web":
-    case "agent": {
+    case "agent_run": {
       load = loadWebQueuedLaunchMaterial;
       break;
     }
@@ -2848,7 +2861,7 @@ async function resolveQueuedLaunchMaterial(
       });
       break;
     }
-    case "workflow-schedule": {
+    case "morning_brief": {
       load = launchLoader(loadMorningBriefQueuedLaunchMaterial, (material) => {
         return {
           morningBriefDelivery: {
@@ -2861,8 +2874,12 @@ async function resolveQueuedLaunchMaterial(
       });
       break;
     }
+    case "automation":
+    case "goal": {
+      return unreachableQueuedMessageContext(contextType);
+    }
     default: {
-      return unreachableQueuedTriggerSource(triggerSource);
+      return unreachableQueuedContextType(contextType);
     }
   }
   const material = await load(args.db, {
@@ -2878,7 +2895,7 @@ async function resolveQueuedLaunchMaterial(
   if (material) {
     return material;
   }
-  throw new Error(`${triggerSource} queue item is missing launch material`);
+  throw new Error(`${contextType} queue item is missing launch material`);
 }
 
 function queuedIntegrationDeliveries(
@@ -2887,18 +2904,22 @@ function queuedIntegrationDeliveries(
   return launchMaterial.delivery;
 }
 
-function unreachableQueuedTriggerSource(triggerSource: never): never {
-  throw new Error(
-    `Unsupported queued trigger source: ${String(triggerSource)}`,
-  );
+function unreachableQueuedContextType(contextType: never): never {
+  throw new Error(`Unsupported queued context type: ${String(contextType)}`);
+}
+
+function unreachableQueuedMessageContext(
+  contextType: Extract<QueuedUserMessageContextType, "automation" | "goal">,
+): never {
+  throw new Error(`${contextType} context cannot route a queued user message`);
 }
 
 function requiredQueuedDelivery<Delivery>(
   delivery: Delivery | undefined,
-  triggerSource: QueuedUserMessage["triggerSource"],
+  contextType: QueuedUserMessageContextType,
 ): Delivery {
   if (!delivery) {
-    throw new Error(`${triggerSource} queue item is missing delivery material`);
+    throw new Error(`${contextType} queue item is missing delivery material`);
   }
   return delivery;
 }
@@ -2916,10 +2937,10 @@ function queuedMessageAdmissionFailure(
     queuedMessage: args.queuedMessage,
     error,
   };
-  const triggerSource = args.queuedMessage.triggerSource;
-  switch (triggerSource) {
+  const contextType = args.queuedMessage.contextType;
+  switch (contextType) {
     case "web":
-    case "agent": {
+    case "agent_run": {
       return { kind: "web_admission_failure", ...common };
     }
     case "slack": {
@@ -2928,7 +2949,7 @@ function queuedMessageAdmissionFailure(
         ...common,
         slackDelivery: requiredQueuedDelivery(
           launchMaterial.delivery.slackDelivery,
-          triggerSource,
+          contextType,
         ),
       };
     }
@@ -2938,7 +2959,7 @@ function queuedMessageAdmissionFailure(
         ...common,
         feishuDelivery: requiredQueuedDelivery(
           launchMaterial.delivery.feishuDelivery,
-          triggerSource,
+          contextType,
         ),
       };
     }
@@ -2948,7 +2969,7 @@ function queuedMessageAdmissionFailure(
         ...common,
         teamsDelivery: requiredQueuedDelivery(
           launchMaterial.delivery.teamsDelivery,
-          triggerSource,
+          contextType,
         ),
       };
     }
@@ -2958,7 +2979,7 @@ function queuedMessageAdmissionFailure(
         ...common,
         telegramDelivery: requiredQueuedDelivery(
           launchMaterial.delivery.telegramDelivery,
-          triggerSource,
+          contextType,
         ),
       };
     }
@@ -2968,7 +2989,7 @@ function queuedMessageAdmissionFailure(
         ...common,
         agentphoneDelivery: requiredQueuedDelivery(
           launchMaterial.delivery.agentphoneDelivery,
-          triggerSource,
+          contextType,
         ),
       };
     }
@@ -2978,23 +2999,27 @@ function queuedMessageAdmissionFailure(
         ...common,
         githubDelivery: requiredQueuedDelivery(
           launchMaterial.delivery.githubDelivery,
-          triggerSource,
+          contextType,
         ),
       };
     }
-    case "workflow-schedule": {
+    case "morning_brief": {
       return {
         kind: "morning_brief_admission_failure",
         ...common,
         morningBriefDelivery: requiredQueuedDelivery(
           launchMaterial.delivery.morningBriefDelivery,
-          triggerSource,
+          contextType,
         ),
         error,
       };
     }
+    case "automation":
+    case "goal": {
+      return unreachableQueuedMessageContext(contextType);
+    }
     default: {
-      return unreachableQueuedTriggerSource(triggerSource);
+      return unreachableQueuedContextType(contextType);
     }
   }
 }
@@ -3076,7 +3101,7 @@ async function buildCreateQueuedChatRunInput(
       threadId: args.threadId,
       userId: args.userId,
       orgId: args.agent.orgId,
-      triggerSource: args.queuedMessage.triggerSource,
+      contextType: args.queuedMessage.contextType,
       timing: args.timing,
     }),
   ]);
@@ -3132,7 +3157,7 @@ async function buildCreateQueuedChatRunInput(
         threadId: args.threadId,
         startNewSession,
         incompleteContext,
-        triggerSource: args.queuedMessage.triggerSource,
+        contextType: args.queuedMessage.contextType,
         inlineTemplatesEnabled,
       });
     },
@@ -3159,6 +3184,9 @@ async function buildCreateQueuedChatRunInput(
   const prompt = queuedMessagePrompt({
     launchMaterial,
   });
+  const triggerSource = queuedUserMessageTriggerSource(
+    args.queuedMessage.contextType,
+  );
 
   return {
     orgId: args.agent.orgId,
@@ -3181,7 +3209,7 @@ async function buildCreateQueuedChatRunInput(
     cliAgentType: modelRoute.cliAgentType,
     codexServiceTier: modelRoute.codexServiceTier,
     computerUseHostGrant,
-    triggerSource: args.queuedMessage.triggerSource,
+    triggerSource,
     attachFileMetadata,
     realAgentInPreview: isFeatureEnabled(
       FeatureSwitchKey.RealAgentInPreview,
@@ -3286,7 +3314,9 @@ function recordQueuedMessageAdmissionFailure(
   const fields = {
     threadId: failure.threadId,
     userMessageId: failure.queuedMessage.id,
-    triggerSource: failure.queuedMessage.triggerSource,
+    triggerSource: queuedUserMessageTriggerSource(
+      failure.queuedMessage.contextType,
+    ),
     code: failure.error.code,
   };
   if (failure.error.code === "INSUFFICIENT_CREDITS") {

--- a/turbo/apps/api/src/signals/services/morning-brief-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-queued-launch-context.service.ts
@@ -85,7 +85,6 @@ async function loadMorningBriefLaunchContext(
         eq(chatEvents.id, args.eventId),
         eq(chatEvents.chatThreadId, args.chatThreadId),
         eq(chatEvents.contextType, "morning_brief"),
-        eq(chatEvents.triggerSource, "workflow-schedule"),
       ),
     )
     .limit(1);

--- a/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
@@ -485,7 +485,7 @@ async function hasPendingMorningBriefQueueEvent(
     .where(
       and(
         inArray(chatEvents.id, pendingMessageIds),
-        eq(chatEvents.triggerSource, "workflow-schedule"),
+        eq(chatEvents.contextType, "morning_brief"),
       ),
     );
   for (const message of messages) {

--- a/turbo/apps/api/src/signals/services/slack-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/slack-queued-launch-context.service.ts
@@ -141,7 +141,6 @@ async function loadSlackLaunchContext(
         eq(chatEvents.id, args.eventId),
         eq(chatEvents.chatThreadId, args.chatThreadId),
         eq(chatEvents.contextType, "slack"),
-        eq(chatEvents.triggerSource, "slack"),
       ),
     )
     .limit(1);

--- a/turbo/apps/api/src/signals/services/teams-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/teams-queued-launch-context.service.ts
@@ -146,7 +146,6 @@ async function loadTeamsLaunchContext(
         eq(chatEvents.id, args.eventId),
         eq(chatEvents.chatThreadId, args.chatThreadId),
         eq(chatEvents.contextType, "teams"),
-        eq(chatEvents.triggerSource, "teams"),
       ),
     )
     .limit(1);

--- a/turbo/apps/api/src/signals/services/telegram-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/telegram-queued-launch-context.service.ts
@@ -161,7 +161,6 @@ async function loadTelegramLaunchContext(
         eq(chatEvents.id, args.eventId),
         eq(chatEvents.chatThreadId, args.chatThreadId),
         eq(chatEvents.contextType, "telegram"),
-        eq(chatEvents.triggerSource, "telegram"),
       ),
     )
     .limit(1);

--- a/turbo/apps/api/src/signals/services/workflow-automation-trigger-source.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-trigger-source.ts
@@ -1,0 +1,7 @@
+import type { ZeroWorkflowAutomationKind } from "@vm0/db/schema/zero-workflow";
+
+export function manualTriggerSource(automation: {
+  readonly kind: ZeroWorkflowAutomationKind;
+}): "workflow-event" | "workflow-schedule" {
+  return automation.kind === "event" ? "workflow-event" : "workflow-schedule";
+}

--- a/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
@@ -27,6 +27,7 @@ import type {
   WorkflowAutomationEventType,
 } from "./workflow-automation-context.service";
 import type { Tx } from "../../lib/db-types";
+import { manualTriggerSource } from "./workflow-automation-trigger-source";
 
 const automationEventRevoker = alias(chatEvents, "automation_event_revoker");
 
@@ -222,8 +223,8 @@ export async function loadNextWorkflowQueueEvent(
         id: chatEvents.id,
         userId: chatThreads.userId,
         automationId: chatAutomationContext.automationId,
+        automationKind: zeroWorkflowAutomations.kind,
         chatThreadId: chatEvents.chatThreadId,
-        triggerSource: chatEvents.triggerSource,
         triggerBrief: chatAutomationContext.triggerBrief,
         workflowName: chatAutomationContext.workflowName,
         workflowAutomationEventType: chatAutomationContext.eventType,
@@ -238,12 +239,16 @@ export async function loadNextWorkflowQueueEvent(
           eq(chatAutomationContext.id, chatEvents.contextId),
         ),
       )
+      .leftJoin(
+        zeroWorkflowAutomations,
+        eq(zeroWorkflowAutomations.id, chatAutomationContext.automationId),
+      )
       .where(eq(chatEvents.id, head.id))
       .limit(1);
     if (!event) {
       return null;
     }
-    if (!event.automationId || !event.triggerSource) {
+    if (!event.automationId || !event.automationKind) {
       throw new Error(
         `Workflow queue event ${event.id} is missing its typed payload`,
       );
@@ -251,7 +256,7 @@ export async function loadNextWorkflowQueueEvent(
     return {
       ...event,
       automationId: event.automationId,
-      triggerSource: event.triggerSource,
+      triggerSource: manualTriggerSource({ kind: event.automationKind }),
     };
   });
 }
@@ -263,7 +268,7 @@ async function loadAutomationRejectionPayload(
   const [event] = await db
     .select({
       automationId: chatAutomationContext.automationId,
-      triggerSource: chatEvents.triggerSource,
+      automationKind: zeroWorkflowAutomations.kind,
       triggerBrief: chatAutomationContext.triggerBrief,
       userMessage: chatEvents.userMessage,
       workflowId: zeroWorkflows.id,
@@ -321,7 +326,7 @@ export async function rejectWorkflowQueueEvent(
       return false;
     }
     const payload = await loadAutomationRejectionPayload(tx, args.eventId);
-    if (!payload?.automationId || !payload.triggerSource) {
+    if (!payload?.automationId || !payload.automationKind) {
       return false;
     }
     const userMessage =
@@ -351,7 +356,7 @@ export async function rejectWorkflowQueueEvent(
       runId: null,
       error: args.reason,
       automationId: payload.automationId,
-      triggerSource: payload.triggerSource,
+      triggerSource: manualTriggerSource({ kind: payload.automationKind }),
       triggerBrief: payload.triggerBrief,
     });
     return rejected !== null;

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -1584,6 +1584,7 @@ async function appendAssociatedUserMessage(params: {
   readonly userMessage: UserMessageDocument;
   readonly generationTemplate: IncomingGenerationTemplate;
   readonly appendQueueMarker: boolean;
+  readonly triggerSource: "web" | "agent";
   // When false, the thread's in-progress draft is preserved. Automation posts
   // are not user-initiated typing, so they must not clear the user's draft.
   readonly clearDraft: boolean;
@@ -1601,7 +1602,7 @@ async function appendAssociatedUserMessage(params: {
       eventType: "input.prompt",
       userMessage: params.userMessage,
       runId: params.runId,
-      contextType: "web",
+      ...(params.triggerSource === "web" ? { contextType: "web" } : {}),
       attachFiles: fileIds,
       generationTemplate: params.generationTemplate,
     };
@@ -2458,6 +2459,7 @@ function scheduleAssociatedUserMessage(params: {
   readonly appendInitialThinking: boolean;
   readonly touchThreadSort: boolean;
   readonly attachFileMetadata: ChatEventAttachFileMetadata[] | null;
+  readonly triggerSource: "web" | "agent";
 }): void {
   waitUntil(
     (async () => {
@@ -2477,6 +2479,7 @@ function scheduleAssociatedUserMessage(params: {
         userMessage: params.body.userMessage,
         generationTemplate: params.body.generationTemplate,
         appendQueueMarker: params.appendQueueMarker,
+        triggerSource: params.triggerSource,
         clearDraft: true,
       });
       if (inserted) {
@@ -2518,6 +2521,7 @@ function scheduleCreatedChatRunSideEffects(params: {
   readonly initialThinkingEnabled: boolean;
   readonly attachFileMetadata: ChatEventAttachFileMetadata[] | null;
   readonly touchThreadSort: boolean;
+  readonly triggerSource: "web" | "agent";
   readonly queueFirstClaim:
     | {
         readonly createdAt: Date;
@@ -2560,6 +2564,7 @@ function scheduleCreatedChatRunSideEffects(params: {
     appendInitialThinking,
     touchThreadSort: params.touchThreadSort,
     attachFileMetadata: params.attachFileMetadata,
+    triggerSource: params.triggerSource,
   });
 }
 
@@ -3010,6 +3015,7 @@ function scheduleNormalChatRunSideEffects(params: {
       params.args.zeroPreCreateSource,
       params.prepared.thread.isNewThread,
     ),
+    triggerSource: params.prepared.triggerSource,
     queueFirstClaim: {
       createdAt: params.queueFirstClaimedAt,
     },

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -68,6 +68,7 @@ import {
 import type { Tx } from "../../lib/db-types";
 import { withRunModelAnnotation } from "./zero-chat-user-message.service";
 import { manualTriggerSource } from "./workflow-automation-trigger-source";
+import { chatAgentRunContextSchemaAvailable } from "./chat-agent-run-context-schema.service";
 
 type DbTransaction = Tx;
 
@@ -92,8 +93,14 @@ function unreachableQueuedContextType(contextType: never): never {
 
 function requiredQueuedUserMessageContextType(
   contextType: QueuedUserMessageContextType | null,
+  agentRunContextAvailable: boolean,
 ): QueuedUserMessageContextType {
   if (contextType === null) {
+    // Before migration 0830, delegated agent prompts are the only queued input
+    // rows without a context type. Current schemas fail loudly on any NULL.
+    if (!agentRunContextAvailable) {
+      return "agent_run";
+    }
     throw new Error("Queued user message is missing its context type");
   }
   return contextType;
@@ -310,7 +317,10 @@ export async function loadNextUnclaimedQueuedUserMessage(
   if (!head || head.eventType !== "input.prompt") {
     return null;
   }
-  const schemaAvailable = await autonomyBudgetSchemaAvailable(db);
+  const [schemaAvailable, agentRunContextAvailable] = await Promise.all([
+    autonomyBudgetSchemaAvailable(db),
+    chatAgentRunContextSchemaAvailable(db),
+  ]);
   const [event] = await db
     .select({
       id: chatEvents.id,
@@ -352,7 +362,10 @@ export async function loadNextUnclaimedQueuedUserMessage(
   if (!event.userMessage) {
     throw new Error("Queued input event is missing userMessage");
   }
-  const contextType = requiredQueuedUserMessageContextType(event.contextType);
+  const contextType = requiredQueuedUserMessageContextType(
+    event.contextType,
+    agentRunContextAvailable,
+  );
   const autonomyBudget: QueuedUserMessage["autonomyBudget"] =
     !schemaAvailable || event.contextType !== "agent_run"
       ? { kind: "ok", autonomyBudget: INITIAL_AUTONOMY_BUDGET }
@@ -388,6 +401,7 @@ type QueueFirstClaimArgs = QueueFirstRunAssociation & {
 interface QueueFirstClaimSnapshot {
   readonly target: LoadedChatEventReplacementTarget;
   readonly replacement: NewChatEvent;
+  readonly routingContextType: QueuedUserMessageContextType;
 }
 
 function replacementTargetFromQueueHead(
@@ -434,9 +448,13 @@ async function resolveUserQueueFirstClaimSnapshot(
   if (!head.userMessage) {
     throw new Error("Queued input event is missing userMessage");
   }
-  const contextType = requiredQueuedUserMessageContextType(head.contextType);
+  const contextType = requiredQueuedUserMessageContextType(
+    head.contextType,
+    await chatAgentRunContextSchemaAvailable(db),
+  );
   return {
     target: replacementTargetFromQueueHead(head),
+    routingContextType: contextType,
     replacement: {
       chatThreadId: args.threadId,
       eventType: "input.prompt",
@@ -502,6 +520,7 @@ async function resolveWorkflowQueueFirstClaimSnapshot(
   }
   return {
     target: replacementTargetFromQueueHead(head),
+    routingContextType: "automation",
     replacement: {
       chatThreadId: args.threadId,
       eventType: "input.prompt",
@@ -567,6 +586,7 @@ async function resolveGoalQueueFirstClaimSnapshot(
   }
   return {
     target: replacementTargetFromQueueHead(head),
+    routingContextType: "goal",
     replacement: {
       chatThreadId: args.threadId,
       eventType: "input.prompt",
@@ -717,8 +737,7 @@ export async function claimQueueFirstRunAssociation(
       }
       if (
         args.kind === "user_message" &&
-        snapshot.target.contextType !== null &&
-        isWebChatContextType(snapshot.target.contextType) &&
+        isWebChatContextType(snapshot.routingContextType) &&
         args.attachFileMetadata
       ) {
         await attachCanonicalWebInputAssetsToEvent(db, {

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -16,6 +16,7 @@ import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { morningBriefDeliveries } from "@vm0/db/schema/morning-brief";
 import { threadGoals } from "@vm0/db/schema/thread-goal";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
 import {
   and,
   asc,
@@ -27,7 +28,6 @@ import {
   type SQL,
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
-import { z } from "zod";
 
 import {
   pgBooleanDecoder,
@@ -56,7 +56,6 @@ import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
 import { noGoalChangeAfterQueueEvent } from "./chat-goal-queue.service";
 import { resolveArtifactObject$ } from "./artifact-storage.service";
 import { attachCanonicalWebInputAssetsToEvent } from "./canonical-asset.service";
-import { isWebChatTriggerSource } from "./zero-chat-trigger-source.service";
 import {
   childAutonomyBudget,
   type ChildAutonomyBudget,
@@ -68,20 +67,74 @@ import {
 } from "./autonomy-budget-schema.service";
 import type { Tx } from "../../lib/db-types";
 import { withRunModelAnnotation } from "./zero-chat-user-message.service";
+import { manualTriggerSource } from "./workflow-automation-trigger-source";
 
 type DbTransaction = Tx;
 
-const queuedUserMessageTriggerSourceSchema = z.enum([
-  "web",
-  "agent",
-  "slack",
-  "feishu",
-  "teams",
-  "telegram",
-  "agentphone",
-  "github",
-  "workflow-schedule",
-]);
+export type QueuedUserMessageContextType = NonNullable<
+  (typeof chatEvents.$inferSelect)["contextType"]
+>;
+
+export type QueuedUserMessageTriggerSource =
+  | "web"
+  | "agent"
+  | "slack"
+  | "feishu"
+  | "teams"
+  | "telegram"
+  | "agentphone"
+  | "github"
+  | "workflow-schedule";
+
+function unreachableQueuedContextType(contextType: never): never {
+  throw new Error(`Unsupported queued context type: ${String(contextType)}`);
+}
+
+function requiredQueuedUserMessageContextType(
+  contextType: QueuedUserMessageContextType | null,
+): QueuedUserMessageContextType {
+  if (contextType === null) {
+    throw new Error("Queued user message is missing its context type");
+  }
+  return contextType;
+}
+
+export function queuedUserMessageTriggerSource(
+  contextType: QueuedUserMessageContextType,
+): QueuedUserMessageTriggerSource {
+  switch (contextType) {
+    case "web":
+    case "slack":
+    case "feishu":
+    case "teams":
+    case "telegram":
+    case "agentphone":
+    case "github": {
+      return contextType;
+    }
+    case "agent_run": {
+      return "agent";
+    }
+    case "morning_brief": {
+      return "workflow-schedule";
+    }
+    case "automation":
+    case "goal": {
+      throw new Error(
+        `${contextType} context cannot be routed as a queued user message`,
+      );
+    }
+    default: {
+      return unreachableQueuedContextType(contextType);
+    }
+  }
+}
+
+export function isWebChatContextType(
+  contextType: QueuedUserMessageContextType,
+): contextType is Extract<QueuedUserMessageContextType, "web" | "agent_run"> {
+  return contextType === "web" || contextType === "agent_run";
+}
 
 const queuedChatEvent = alias(chatEvents, "queued_chat_event");
 const queuedChatEventRevoker = alias(chatEvents, "queued_chat_event_revoker");
@@ -104,16 +157,7 @@ export interface QueuedUserMessage {
   readonly modelProviderType: string | null;
   readonly modelProviderCredentialScope: ModelProviderCredentialScope | null;
   readonly selectedModel: string | null;
-  readonly triggerSource:
-    | "web"
-    | "agent"
-    | "slack"
-    | "feishu"
-    | "teams"
-    | "telegram"
-    | "agentphone"
-    | "github"
-    | "workflow-schedule";
+  readonly contextType: QueuedUserMessageContextType;
   readonly autonomyBudget:
     | ChildAutonomyBudget
     | { readonly kind: "unavailable"; readonly message: string };
@@ -278,7 +322,6 @@ export async function loadNextUnclaimedQueuedUserMessage(
       modelProviderType: sql`NULL`.mapWith(pgNullDecoder),
       modelProviderCredentialScope: sql`NULL`.mapWith(pgNullDecoder),
       selectedModel: chatThreads.selectedModel,
-      triggerSource: chatEvents.triggerSource,
       contextType: chatEvents.contextType,
       sourceAutonomyBudget: rolloutCompatibleAutonomyBudgetColumn(
         schemaAvailable,
@@ -309,15 +352,7 @@ export async function loadNextUnclaimedQueuedUserMessage(
   if (!event.userMessage) {
     throw new Error("Queued input event is missing userMessage");
   }
-  const triggerSource = queuedUserMessageTriggerSourceSchema.safeParse(
-    event.triggerSource,
-  );
-  // Legacy rows have no typed payload until the cutover migration backfills
-  // them. They remain pending (and keep automation behind them) without making
-  // a code-before-migration deploy fail.
-  if (!triggerSource.success) {
-    return null;
-  }
+  const contextType = requiredQueuedUserMessageContextType(event.contextType);
   const autonomyBudget: QueuedUserMessage["autonomyBudget"] =
     !schemaAvailable || event.contextType !== "agent_run"
       ? { kind: "ok", autonomyBudget: INITIAL_AUTONOMY_BUDGET }
@@ -330,7 +365,7 @@ export async function loadNextUnclaimedQueuedUserMessage(
   return {
     ...event,
     userMessage: event.userMessage,
-    triggerSource: triggerSource.data,
+    contextType,
     autonomyBudget,
   };
 }
@@ -378,7 +413,6 @@ async function resolveUserQueueFirstClaimSnapshot(
       userMessage: chatEvents.userMessage,
       attachFiles: chatEvents.attachFiles,
       generationTemplate: chatEvents.generationTemplate,
-      triggerSource: chatEvents.triggerSource,
     })
     .from(chatEvents)
     .where(
@@ -400,6 +434,7 @@ async function resolveUserQueueFirstClaimSnapshot(
   if (!head.userMessage) {
     throw new Error("Queued input event is missing userMessage");
   }
+  const contextType = requiredQueuedUserMessageContextType(head.contextType);
   return {
     target: replacementTargetFromQueueHead(head),
     replacement: {
@@ -412,7 +447,7 @@ async function resolveUserQueueFirstClaimSnapshot(
       runId: args.runId,
       attachFiles: head.attachFiles ? [...head.attachFiles] : null,
       generationTemplate: head.generationTemplate,
-      ...(head.triggerSource ? { triggerSource: head.triggerSource } : {}),
+      triggerSource: queuedUserMessageTriggerSource(contextType),
     },
   };
 }
@@ -425,7 +460,7 @@ async function resolveWorkflowQueueFirstClaimSnapshot(
     .select({
       ...queueFirstReplacementTargetFields,
       automationId: chatAutomationContext.automationId,
-      triggerSource: chatEvents.triggerSource,
+      automationKind: zeroWorkflowAutomations.kind,
       userMessage: chatEvents.userMessage,
     })
     .from(chatEvents)
@@ -435,6 +470,10 @@ async function resolveWorkflowQueueFirstClaimSnapshot(
         eq(chatEvents.contextType, "automation"),
         eq(chatAutomationContext.id, chatEvents.contextId),
       ),
+    )
+    .leftJoin(
+      zeroWorkflowAutomations,
+      eq(zeroWorkflowAutomations.id, chatAutomationContext.automationId),
     )
     .where(
       and(
@@ -453,7 +492,8 @@ async function resolveWorkflowQueueFirstClaimSnapshot(
     !head ||
     head.eventType !== "input.automation" ||
     head.id !== args.eventId ||
-    head.automationId !== args.automationId
+    head.automationId !== args.automationId ||
+    head.automationKind === null
   ) {
     return null;
   }
@@ -470,7 +510,7 @@ async function resolveWorkflowQueueFirstClaimSnapshot(
           ? head.userMessage
           : withRunModelAnnotation(head.userMessage, args.selectedModel),
       runId: args.runId,
-      ...(head.triggerSource ? { triggerSource: head.triggerSource } : {}),
+      triggerSource: manualTriggerSource({ kind: head.automationKind }),
     },
   };
 }
@@ -677,9 +717,8 @@ export async function claimQueueFirstRunAssociation(
       }
       if (
         args.kind === "user_message" &&
-        "triggerSource" in snapshot.replacement &&
-        snapshot.replacement.triggerSource !== undefined &&
-        isWebChatTriggerSource(snapshot.replacement.triggerSource) &&
+        snapshot.target.contextType !== null &&
+        isWebChatContextType(snapshot.target.contextType) &&
         args.attachFileMetadata
       ) {
         await attachCanonicalWebInputAssetsToEvent(db, {

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
@@ -115,6 +115,7 @@ import {
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import { runWorkflowAutomationNow$ } from "./zero-workflow-automation-run.service";
 import type { RunWorkflowAutomationResult } from "./zero-workflow-automation-launch.service";
+import { manualTriggerSource } from "./workflow-automation-trigger-source";
 import {
   ensureWorkflowUserAutomationThread,
   loadWorkflowUserAutomationThreadId,
@@ -2873,10 +2874,6 @@ interface AutomationActionInput {
   readonly automationId: string;
   readonly sourceRunId?: string;
   readonly autonomyBudgetCeiling?: number;
-}
-
-function manualTriggerSource(automation: AutomationRow) {
-  return automation.kind === "event" ? "workflow-event" : "workflow-schedule";
 }
 
 /**

--- a/turbo/apps/api/src/test-fixtures/workflow-queue.ts
+++ b/turbo/apps/api/src/test-fixtures/workflow-queue.ts
@@ -2,6 +2,7 @@ import {
   zeroWorkflowAutomations,
   zeroWorkflows,
 } from "@vm0/db/schema/zero-workflow";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { eq } from "drizzle-orm";
 
 import { db } from "../lib/db";
@@ -16,6 +17,17 @@ interface WorkflowAutomationEventFixtureArgs {
   readonly automationId: string;
   readonly chatThreadId: string;
   readonly triggerBrief: string;
+}
+
+export async function readWorkflowRunTriggerSourceFixture(
+  runId: string,
+): Promise<string | null> {
+  const [run] = await db()
+    .select({ triggerSource: zeroRuns.triggerSource })
+    .from(zeroRuns)
+    .where(eq(zeroRuns.id, runId))
+    .limit(1);
+  return run?.triggerSource ?? null;
 }
 
 /** Admit a complete generic-webhook context through the production queue path. */


### PR DESCRIPTION
## Summary

- route pending chat events exclusively by `(event_type, context_type)` and remove all production reads of `chat_events.trigger_source`
- derive automation run trigger sources from `zero_workflow_automations.kind` through the existing manual-trigger mapping
- preserve claimed-event context, remove the monitor's unreachable null-context branch, and fix direct seed/input writers found by the constructor audit
- keep existing `chat_events.trigger_source` writes and all `zero_runs.trigger_source`, logging, context-table, schema, and client contracts unchanged

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- Prettier check for every changed file
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts src/scripts/__tests__/dev-bench-seed.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts --maxWorkers=1 --silent=passed-only -t 'lets a running runner claim pending input prompts for steer|keeps immediate and queued runs agent-scoped without retired provenance'`
- production-source grep for `chatEvents.triggerSource`: zero hits
- PR CI: 70 checks passed, including all API shards, deployment compatibility coverage, and Playwright E2E

Closes #25552