### PR TITLE
test(python): cover percent-encoded x fallback hints

### DIFF
--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
@@ -312,6 +312,56 @@ def test_billable_counts_fallback_only_when_no_hints(x_usage, tmp_path, real_flo
     assert p["quantity"] == 3
 
 
+@pytest.mark.parametrize(
+    ("path", "query", "rule", "expected_quantity"),
+    [
+        pytest.param(
+            "/2/tweets",
+            "%69ds=1,2",
+            "GET /2/tweets",
+            2,
+            id="encoded-key",
+        ),
+        pytest.param(
+            "/2/tweets",
+            "ids=1%2C2",
+            "GET /2/tweets",
+            2,
+            id="encoded-comma",
+        ),
+        pytest.param(
+            "/2/tweets/search/recent",
+            "query=test&max_results=%35%30",
+            "GET /2/tweets/search/recent",
+            50,
+            id="encoded-decimal",
+        ),
+    ],
+)
+def test_unparseable_response_decodes_percent_encoded_fallback_hints(
+    x_usage,
+    tmp_path,
+    real_flow,
+    path,
+    query,
+    rule,
+    expected_quantity,
+):
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path=path,
+        query=query,
+        body=b"not json",
+        rule=rule,
+    )
+
+    event = x_usage.call_and_get_single_billing(flow)
+
+    assert event["category"] == "posts.read"
+    assert event["quantity"] == expected_quantity
+
+
 def test_parsed_response_ignores_oversized_fallback_query(x_usage, tmp_path, real_flow):
     """Parsed responses bill from the body and do not need query fallback hints."""
     body = json.dumps({"data": [{"id": "1"}, {"id": "2"}]}).encode()


### PR DESCRIPTION
## Summary

- cover percent-decoding of recognized X fallback query keys
- cover encoded comma-separated selector values and encoded decimal `max_results` values
- verify the emitted billing category and quantity through the unparseable-response usage path

## Scope

- test-only change in the mitmproxy addon
- no production parser, limit, API, schema, persisted-state, or compatibility changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/x_connector_usage/test_unparseable.py::test_unparseable_response_decodes_percent_encoded_fallback_hints -q`
- `uv run --no-sync python -m pytest tests/x_connector_usage/`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/ -q` (4954 passed)

Closes #25477
