### PR TITLE
fix: use card surface token in avatar template picker

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
@@ -158,7 +158,7 @@ function CatalogFilterField<T extends string>({
       >
         <SelectTrigger
           aria-label={`${label}: ${selectedLabel}`}
-          className="h-9 w-full rounded-lg bg-background text-sm"
+          className="h-9 w-full rounded-lg text-sm"
         >
           <SelectValue />
         </SelectTrigger>
@@ -194,7 +194,7 @@ function CatalogFiltersPopover({
           type="button"
           variant="outline"
           size="sm"
-          className="h-9 gap-2 rounded-full bg-background px-3 shadow-none"
+          className="h-9 gap-2 rounded-full bg-card px-3 shadow-none"
         >
           <IconAdjustmentsHorizontal size={15} stroke={1.7} />
           {t(($) => {
@@ -254,7 +254,7 @@ function AvatarAspectRatioPicker({
         className={cn(
           "flex h-8 items-center gap-2 rounded-lg px-3 text-xs font-semibold transition-all",
           value === "portrait"
-            ? "bg-background text-foreground shadow-sm"
+            ? "bg-card text-foreground shadow-sm"
             : "text-muted-foreground hover:text-foreground",
         )}
         onClick={() => {
@@ -271,7 +271,7 @@ function AvatarAspectRatioPicker({
         className={cn(
           "flex h-8 items-center gap-2 rounded-lg px-3 text-xs font-semibold transition-all",
           value === "landscape"
-            ? "bg-background text-foreground shadow-sm"
+            ? "bg-card text-foreground shadow-sm"
             : "text-muted-foreground hover:text-foreground",
         )}
         onClick={() => {
@@ -501,7 +501,7 @@ function AvatarCatalogFilters({
   return (
     <div
       data-avatar-catalog-toolbar=""
-      className="sticky top-0 z-10 mb-5 flex flex-wrap items-center justify-between gap-3 border-b border-border/70 bg-background pb-4"
+      className="sticky top-0 z-10 mb-5 flex flex-wrap items-center justify-between gap-3 border-b border-border/70 bg-card pb-4"
     >
       <AvatarAspectRatioPicker
         value={filters.aspectRatio}
@@ -738,7 +738,7 @@ function CatalogLoadingSpinner() {
 function AvatarTemplateEmpty({ error }: { readonly error: boolean }) {
   const { t } = useTranslation();
   return (
-    <div className="flex min-h-40 flex-1 items-center justify-center rounded-[22px] border-2 border-dashed border-border bg-background px-6 py-10 text-center">
+    <div className="flex min-h-40 flex-1 items-center justify-center rounded-[22px] border-2 border-dashed border-border bg-card px-6 py-10 text-center">
       <p className="text-sm font-semibold text-muted-foreground">
         {error
           ? t(($) => {


### PR DESCRIPTION
## Problem

Reported in Slack: the Avatar template picker shows an odd grey band across the toolbar row.

Pixel sampling of the report screenshot:

- Dialog surface: `#FFFFFF`
- Toolbar row (and the active `9:16` chip and the `Filters` button): `#FBFBFC`
- The grey block is inset 20px on both sides, i.e. it stops at the content container's `px-5` padding instead of reaching the dialog edges, which is what makes it read as a misaligned band.

## Root cause

`avatar-template-picker.tsx` used `bg-background` for surfaces that sit **inside** the template dialog.

- `packages/ui/src/styles/globals.css:181` — `--background: 214 20% 98.5%` (`#FBFBFC`), the cool-grey **page** background
- `--card` / `--popover` are white, and `PopoverContent` / the dialog surface use `bg-card`

So every `bg-background` in this file paints the page background on top of a white dialog. Other composer surfaces already use `bg-card` (e.g. `zero-chat-composer.tsx:4517`, `:5364`); this file was the outlier.

## Change

Same file, 6 call sites:

| Line | Element | Fix |
| --- | --- | --- |
| 504 | sticky toolbar container (the reported band) | `bg-card` |
| 257 / 274 | active `9:16` / `16:9` chips | `bg-card` |
| 197 | `Filters` button | `bg-card` |
| 741 | empty state panel | `bg-card` |
| 161 | Select inside the filters popover | drop the override, use the default `bg-input` |

`--input` is white in light mode and `gray-200` in dark, which is the intended input surface on a card, so the override on line 161 was both wrong and unnecessary.

This also improves dark mode, where `--background` (`gray-50`) was darker than the dialog's `--card`.