### PR TITLE
feat(chat): prefetch unread and active thread events

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1521,7 +1521,7 @@ describe("CHAT-01 chat thread read state", () => {
     });
   }, 120_000);
 
-  it("lists unread agent ids", async () => {
+  it("lists unread agent and thread ids", async () => {
     const {
       actor: owner,
       agentId: agentA,
@@ -1535,6 +1535,9 @@ describe("CHAT-01 chat thread read state", () => {
     ).agentId;
 
     await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([]);
+    await expect(chat.listUnreadChatThreadIds(owner)).resolves.toStrictEqual(
+      [],
+    );
 
     // An active (claimed) run keeps its thread out of the unread aggregate
     // until it completes and leaves a run-finished marker.
@@ -1544,6 +1547,9 @@ describe("CHAT-01 chat thread read state", () => {
     });
     const activeClaim = await claimChatRun(runnerGroup, activeRun.runId);
     await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([]);
+    await expect(chat.listUnreadChatThreadIds(owner)).resolves.toStrictEqual(
+      [],
+    );
 
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(activeRun.runId, activeClaim.sandboxHeaders);
@@ -1555,6 +1561,9 @@ describe("CHAT-01 chat thread read state", () => {
       });
     });
     await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([agentA]);
+    await expect(chat.listUnreadChatThreadIds(owner)).resolves.toStrictEqual([
+      activeRun.threadId,
+    ]);
     context.mocks.ably.publish.mockClear();
     const firstRead = await chat.markThreadRead(owner, activeRun.threadId);
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
@@ -1570,6 +1579,9 @@ describe("CHAT-01 chat thread read state", () => {
     expect(repeatedRead.lastReadAt).toBe(firstRead.lastReadAt);
     expect(context.mocks.ably.publish).not.toHaveBeenCalled();
     await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([]);
+    await expect(chat.listUnreadChatThreadIds(owner)).resolves.toStrictEqual(
+      [],
+    );
 
     // An active goal suppresses the unread flag; a complete goal does not.
     const activeGoalRun = await completeChatRunInThread(owner, runnerGroup, {
@@ -1584,8 +1596,14 @@ describe("CHAT-01 chat thread read state", () => {
     await createThreadGoal(owner, completeGoalRun.runId, "bdd unread goal");
     await completeThreadGoal(owner, completeGoalRun.runId);
     await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([agentB]);
+    await expect(chat.listUnreadChatThreadIds(owner)).resolves.toStrictEqual([
+      completeGoalRun.threadId,
+    ]);
     await chat.markThreadRead(owner, completeGoalRun.threadId);
     await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([]);
+    await expect(chat.listUnreadChatThreadIds(owner)).resolves.toStrictEqual(
+      [],
+    );
 
     const runA = await completeChatRunInThread(owner, runnerGroup, {
       agentId: agentA,
@@ -1598,12 +1616,21 @@ describe("CHAT-01 chat thread read state", () => {
 
     const unreadAgents = await chat.listUnreadAgents(owner);
     expect(new Set(unreadAgents)).toStrictEqual(new Set([agentA, agentB]));
+    expect(new Set(await chat.listUnreadChatThreadIds(owner))).toStrictEqual(
+      new Set([runA.threadId, runB.threadId]),
+    );
 
     await chat.markThreadRead(owner, runA.threadId);
     await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([agentB]);
+    await expect(chat.listUnreadChatThreadIds(owner)).resolves.toStrictEqual([
+      runB.threadId,
+    ]);
 
     await chat.markThreadRead(owner, runB.threadId);
     await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([]);
+    await expect(chat.listUnreadChatThreadIds(owner)).resolves.toStrictEqual(
+      [],
+    );
   }, 120_000);
 
   it("lists active chat thread ids for the current user and org", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1534,10 +1534,56 @@ describe("CHAT-01 chat thread read state", () => {
       })
     ).agentId;
 
+    const unauthenticated = await chat.requestListUnreadChatThreadIds(
+      null,
+      [401],
+    );
+    expectApiError(unauthenticated.body);
+    expect(unauthenticated.body.error.code).toBe("UNAUTHORIZED");
+    const orgless = await chat.requestListUnreadChatThreadIds(
+      bdd.user({ orgId: null }),
+      [401],
+    );
+    expectApiError(orgless.body);
+    expect(orgless.body.error.code).toBe("UNAUTHORIZED");
+
+    const peer = bdd.user({ orgId: owner.orgId });
+    await api.ensureOrgModelProvider(peer);
+    const peerAgent = await bdd.createAgent(peer, {
+      displayName: "Unread peer agent",
+      visibility: "private",
+    });
+    const peerRun = await completeChatRunInThread(peer, runnerGroup, {
+      agentId: peerAgent.agentId,
+      prompt: "peer unread thread stays isolated",
+    });
+
+    const sameUserOtherOrg = bdd.user({ userId: owner.userId });
+    await api.grantProEntitlement(sameUserOtherOrg);
+    await api.ensureOrgModelProvider(sameUserOtherOrg);
+    const otherOrgAgent = await bdd.createAgent(sameUserOtherOrg, {
+      displayName: "Unread other org agent",
+      visibility: "private",
+    });
+    const otherOrgRun = await completeChatRunInThread(
+      sameUserOtherOrg,
+      runnerGroup,
+      {
+        agentId: otherOrgAgent.agentId,
+        prompt: "other org unread thread stays isolated",
+      },
+    );
+
     await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([]);
     await expect(chat.listUnreadChatThreadIds(owner)).resolves.toStrictEqual(
       [],
     );
+    await expect(chat.listUnreadChatThreadIds(peer)).resolves.toStrictEqual([
+      peerRun.threadId,
+    ]);
+    await expect(
+      chat.listUnreadChatThreadIds(sameUserOtherOrg),
+    ).resolves.toStrictEqual([otherOrgRun.threadId]);
 
     // An active (claimed) run keeps its thread out of the unread aggregate
     // until it completes and leaves a run-finished marker.

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -519,6 +519,18 @@ export function createChatFilesBddApi(context: TestContext) {
       return response.body.threadIds;
     },
 
+    async listUnreadChatThreadIds(
+      actor: ApiTestUser,
+    ): Promise<readonly string[]> {
+      const response = await accept(
+        threadsClient().unreadIds({
+          headers: authenticate(context, actor),
+        }),
+        [200],
+      );
+      return response.body.threadIds;
+    },
+
     async requestListUnreadAgents(
       actor: ApiTestUser | null,
       statuses: readonly (200 | 401 | 403)[],

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -531,6 +531,18 @@ export function createChatFilesBddApi(context: TestContext) {
       return response.body.threadIds;
     },
 
+    async requestListUnreadChatThreadIds(
+      actor: ApiTestUser | null,
+      statuses: readonly (200 | 401 | 404)[],
+    ) {
+      return await accept(
+        threadsClient().unreadIds({
+          headers: authenticate(context, actor),
+        }),
+        statuses,
+      );
+    },
+
     async requestListUnreadAgents(
       actor: ApiTestUser | null,
       statuses: readonly (200 | 401 | 403)[],

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -37,6 +37,7 @@ import {
   zeroChatThreadEventsPage,
   zeroChatThreadDraftIds,
   zeroChatThreadUnreadAgentIds,
+  zeroChatThreadUnreadThreadIds,
   zeroChatThreadUnreads,
 } from "../services/zero-chat-thread.service";
 import {
@@ -320,6 +321,18 @@ const listChatThreadUnreadAgentsInner$ = computed(async (get) => {
   return { status: 200 as const, body: { agentIds: [...agentIds] } };
 });
 
+const listChatThreadUnreadIdsInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const threadIds = await get(
+    zeroChatThreadUnreadThreadIds({
+      userId: auth.userId,
+      orgId: auth.orgId,
+    }),
+  );
+
+  return { status: 200 as const, body: { threadIds: [...threadIds] } };
+});
+
 const listChatThreadArtifactsInner$ = computed(async (get) => {
   const auth = get(authContext$);
   const params = get(pathParamsOf(chatThreadArtifactsContract.list));
@@ -398,6 +411,13 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       listChatThreadActiveIdsInner$,
+    ),
+  },
+  {
+    route: chatThreadsContract.unreadIds,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      listChatThreadUnreadIdsInner$,
     ),
   },
   {

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -905,6 +905,37 @@ export function zeroChatThreadUnreadAgentIds(args: {
   });
 }
 
+/** The user's unread thread ids in the current organization. */
+export function zeroChatThreadUnreadThreadIds(args: {
+  readonly userId: string;
+  readonly orgId: string;
+}): Computed<Promise<readonly string[]>> {
+  return computed(async (get) => {
+    const db = get(db$);
+    const lastRunFinish = latestRunFinishEventSubquery(db, chatThreads.id);
+    const rows = await db
+      .select({ threadId: chatThreads.id })
+      .from(chatThreads)
+      .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
+      .crossJoinLateral(lastRunFinish)
+      .where(
+        and(
+          eq(chatThreads.userId, args.userId),
+          eq(zeroAgents.orgId, args.orgId),
+          or(
+            isNull(chatThreads.lastReadAt),
+            gt(lastRunFinish.createdAt, chatThreads.lastReadAt),
+          ),
+          noActiveRunsForCurrentThreadCondition(db),
+          noActiveGoalsForCurrentThreadCondition(db),
+        ),
+      );
+    return rows.map((row) => {
+      return row.threadId;
+    });
+  });
+}
+
 /**
  * Chat threads owned by the user in the current org that currently have at
  * least one non-terminal run. Used by local-first thread lists to hydrate the

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -209,6 +209,11 @@ export const apiAgentsHandlers = [
     return respond(200, { threadIds: [] });
   }),
 
+  // GET /api/zero/chat-threads/unread-ids
+  mockApi(chatThreadsContract.unreadIds, ({ respond }) => {
+    return respond(200, { threadIds: [] });
+  }),
+
   // GET /api/zero/chat-thread-drafts
   mockApi(chatThreadsContract.drafts, ({ respond }) => {
     return respond(200, { draftThreadIds: [] });

--- a/turbo/apps/platform/src/mocks/msw-contract.ts
+++ b/turbo/apps/platform/src/mocks/msw-contract.ts
@@ -121,7 +121,7 @@ function routePattern(route: AppRoute): string | RegExp {
   if (route.path === "/api/zero/chat-threads/:id") {
     // Keep thread detail mocks from swallowing static sibling routes while
     // still accepting the descriptive non-UUID thread ids used by UI tests.
-    return /\/api\/zero\/chat-threads\/(?!snapshot$|events$|active-ids$)([^/]+)$/;
+    return /\/api\/zero\/chat-threads\/(?!snapshot$|events$|active-ids$|unread-ids$)([^/]+)$/;
   }
   return `*${route.path}`;
 }

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-background-sync.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-background-sync.test.ts
@@ -12,6 +12,7 @@ import {
   mockOrganization,
   mockUser,
 } from "../../../__tests__/mock-auth.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { zeroClient$ } from "../../api-client.ts";
 import { CHAT_MESSAGES_STORE } from "../../external/chat-idb-schema.ts";
@@ -93,13 +94,30 @@ function mockSignedInUser(): void {
   });
 }
 
+async function setupAuthenticatedBackgroundSync(): Promise<void> {
+  await setupPage({
+    context,
+    path: "/error",
+    withoutRender: true,
+    user: {
+      id: USER_ID,
+      fullName: "Background Sync User",
+      email: "background-sync@example.com",
+    },
+    session: { token: "test-token" },
+    org: {
+      activeOrg: { id: ORG_ID, name: "Background Sync Org" },
+      memberships: [{ id: ORG_ID }],
+    },
+  });
+}
+
 describe("chat event background sync", () => {
   afterEach(() => {
     clearMockedAuth();
   });
 
   it("subscribes while prefetching unread and active threads once", async () => {
-    mockSignedInUser();
     const initialThreadIdsReady = context.mocks.deferred<void>();
     const requestedThreadIds: string[] = [];
 
@@ -116,34 +134,44 @@ describe("chat event background sync", () => {
       return respond(200, { events: [] });
     });
 
-    await context.store.set(setupRealtime$, context.signal);
-    const subscriberSignal = context.store.set(
-      resetSubscriberSignal$,
-      context.signal,
+    await setupAuthenticatedBackgroundSync();
+
+    await waitFor(() => {
+      expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
+    });
+
+    expect(requestedThreadIds).toStrictEqual([]);
+    initialThreadIdsReady.resolve();
+
+    await waitFor(() => {
+      expect(requestedThreadIds).toHaveLength(3);
+    });
+    expect(new Set(requestedThreadIds)).toStrictEqual(
+      new Set([THREAD_ID, OTHER_THREAD_ID, THIRD_THREAD_ID]),
     );
-    const subscription = context.store.set(
-      setupChatEventBackgroundSync$,
-      subscriberSignal,
-    );
+  });
 
-    try {
-      await waitFor(() => {
-        expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
+  it("continues active prefetch against an API without unread ids", async () => {
+    const requestedThreadIds: string[] = [];
+    context.mocks.api(chatThreadsContract.unreadIds, ({ respond }) => {
+      return respond(404, {
+        error: { message: "Not found", code: "NOT_FOUND" },
       });
+    });
+    context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
+      return respond(200, { threadIds: [THREAD_ID] });
+    });
+    context.mocks.api(chatThreadEventsContract.list, ({ params, respond }) => {
+      requestedThreadIds.push(params.threadId);
+      return respond(200, { events: [] });
+    });
 
-      expect(requestedThreadIds).toStrictEqual([]);
-      initialThreadIdsReady.resolve();
+    await setupAuthenticatedBackgroundSync();
 
-      await waitFor(() => {
-        expect(requestedThreadIds).toHaveLength(3);
-      });
-      expect(new Set(requestedThreadIds)).toStrictEqual(
-        new Set([THREAD_ID, OTHER_THREAD_ID, THIRD_THREAD_ID]),
-      );
-    } finally {
-      context.store.set(resetSubscriberSignal$, context.signal);
-      await expect(subscription).rejects.toMatchObject({ name: "AbortError" });
-    }
+    await waitFor(() => {
+      expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
+      expect(requestedThreadIds).toStrictEqual([THREAD_ID]);
+    });
   });
 
   it("fills only messages after the cached thread end", async () => {

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-background-sync.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-background-sync.test.ts
@@ -2,6 +2,7 @@ import { waitFor } from "@testing-library/react";
 import {
   chatEventResponse,
   chatThreadEventsContract,
+  chatThreadsContract,
   type ChatEvent,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -32,6 +33,7 @@ const USER_ID = "background-sync-user";
 const ORG_ID = "background-sync-org";
 const THREAD_ID = "b0000000-0000-4000-a000-000000000801";
 const OTHER_THREAD_ID = "b0000000-0000-4000-a000-000000000805";
+const THIRD_THREAD_ID = "b0000000-0000-4000-a000-000000000809";
 const FIRST_CACHED_EVENT_ID = "00000000-0000-4000-8000-000000000802";
 const LAST_CACHED_EVENT_ID = "00000000-0000-4000-8000-000000000803";
 const NEW_EVENT_ID = "00000000-0000-4000-8000-000000000804";
@@ -94,6 +96,54 @@ function mockSignedInUser(): void {
 describe("chat event background sync", () => {
   afterEach(() => {
     clearMockedAuth();
+  });
+
+  it("subscribes while prefetching unread and active threads once", async () => {
+    mockSignedInUser();
+    const initialThreadIdsReady = context.mocks.deferred<void>();
+    const requestedThreadIds: string[] = [];
+
+    context.mocks.api(chatThreadsContract.unreadIds, async ({ respond }) => {
+      await initialThreadIdsReady.promise;
+      return respond(200, { threadIds: [THREAD_ID, OTHER_THREAD_ID] });
+    });
+    context.mocks.api(chatThreadsContract.activeIds, async ({ respond }) => {
+      await initialThreadIdsReady.promise;
+      return respond(200, { threadIds: [OTHER_THREAD_ID, THIRD_THREAD_ID] });
+    });
+    context.mocks.api(chatThreadEventsContract.list, ({ params, respond }) => {
+      requestedThreadIds.push(params.threadId);
+      return respond(200, { events: [] });
+    });
+
+    await context.store.set(setupRealtime$, context.signal);
+    const subscriberSignal = context.store.set(
+      resetSubscriberSignal$,
+      context.signal,
+    );
+    const subscription = context.store.set(
+      setupChatEventBackgroundSync$,
+      subscriberSignal,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
+      });
+
+      expect(requestedThreadIds).toStrictEqual([]);
+      initialThreadIdsReady.resolve();
+
+      await waitFor(() => {
+        expect(requestedThreadIds).toHaveLength(3);
+      });
+      expect(new Set(requestedThreadIds)).toStrictEqual(
+        new Set([THREAD_ID, OTHER_THREAD_ID, THIRD_THREAD_ID]),
+      );
+    } finally {
+      context.store.set(resetSubscriberSignal$, context.signal);
+      await expect(subscription).rejects.toMatchObject({ name: "AbortError" });
+    }
   });
 
   it("fills only messages after the cached thread end", async () => {

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-background-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-background-sync.ts
@@ -14,6 +14,8 @@ import {
   activeChatEventThreadIds$,
   receiveActiveChatEvents$,
 } from "./chat-event-signal-registry.ts";
+import { sidebarActiveThreadIds$ } from "./chat-thread-event-sourcing.ts";
+import { allUnreadThreadIds$ } from "./sidebar-unread-threads.ts";
 
 const L = logger("ChatEventBackgroundSync");
 const CHAT_THREAD_MESSAGE_CREATED_PREFIX = "chatThreadMessageCreated:";
@@ -167,8 +169,32 @@ const subscribeChatEventBackgroundSync$ = command(
   },
 );
 
+const syncInitialUnreadAndActiveChatThreadEvents$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const [unreadThreadIds, activeThreadIds] = await Promise.all([
+      get(allUnreadThreadIds$),
+      get(sidebarActiveThreadIds$),
+    ]);
+    signal.throwIfAborted();
+
+    const threadIds = new Set([...unreadThreadIds, ...activeThreadIds]);
+    await Promise.all(
+      Array.from(threadIds, (threadId) => {
+        return set(
+          handleUserChannelMessage$,
+          { name: `${CHAT_THREAD_MESSAGE_CREATED_PREFIX}${threadId}` },
+          signal,
+        );
+      }),
+    );
+  },
+);
+
 export const setupChatEventBackgroundSync$ = command(
   async ({ set }, signal: AbortSignal): Promise<void> => {
-    await set(subscribeChatEventBackgroundSync$, signal);
+    await Promise.all([
+      set(subscribeChatEventBackgroundSync$, signal),
+      set(syncInitialUnreadAndActiveChatThreadEvents$, signal),
+    ]);
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
@@ -91,8 +91,11 @@ export const allUnreadThreadIds$ = computed(
   async (get): Promise<ReadonlySet<string>> => {
     get(reloadChatUnreadStateCounter$);
     const client = get(zeroClient$)(chatThreadsContract);
-    const result = await accept(client.unreadIds(), [200]);
-    return new Set(result.body.threadIds);
+    const result = await accept(client.unreadIds(), [200, 404]);
+    // A newly promoted app can briefly reach an API version from before this
+    // additive route existed. Remove after that API is outside the production
+    // rollback window.
+    return new Set(result.status === 200 ? result.body.threadIds : []);
   },
 );
 

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
@@ -87,6 +87,15 @@ export const unreadAgentIds$ = computed(
   },
 );
 
+export const allUnreadThreadIds$ = computed(
+  async (get): Promise<ReadonlySet<string>> => {
+    get(reloadChatUnreadStateCounter$);
+    const client = get(zeroClient$)(chatThreadsContract);
+    const result = await accept(client.unreadIds(), [200]);
+    return new Set(result.body.threadIds);
+  },
+);
+
 export const markAgentThreadsRead$ = command(
   async ({ get, set }, agentId: string, signal: AbortSignal) => {
     const client = get(zeroClient$)(chatThreadMarkAgentReadContract);

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -979,6 +979,10 @@ export const chatThreadsContract = c.router({
         threadIds: z.array(z.string().uuid()),
       }),
       401: apiErrorSchema,
+      // A newly promoted app can briefly reach an API version from before
+      // this additive route existed. Remove after that API is outside the
+      // production rollback window.
+      404: apiErrorSchema,
     },
     summary:
       "List unread chat thread ids for the caller in the current organization.",

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -970,6 +970,19 @@ export const chatThreadsContract = c.router({
     summary:
       "List chat thread ids that currently have queued, pending, or running runs.",
   },
+  unreadIds: {
+    method: "GET",
+    path: "/api/zero/chat-threads/unread-ids",
+    headers: authHeadersSchema,
+    responses: {
+      200: z.object({
+        threadIds: z.array(z.string().uuid()),
+      }),
+      401: apiErrorSchema,
+    },
+    summary:
+      "List unread chat thread ids for the caller in the current organization.",
+  },
   create: {
     method: "POST",
     path: "/api/zero/chat-threads",


### PR DESCRIPTION
## Summary

- add an organization-scoped API for all unread chat thread IDs
- start initial unread/active thread event hydration concurrently with the Ably background subscription
- deduplicate overlapping thread IDs and reuse the existing new-message sync path
- cover unread lifecycle semantics plus subscription concurrency and deduplication

## Testing

- `pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/chat-event-background-sync.test.ts`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F api lint`

The targeted API BDD test could not start locally because PostgreSQL was unavailable on `localhost:5432`; the PR pipeline will run it with the test database.
