### PR TITLE
fix(connectors): preserve firewall without credentials

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -693,12 +693,22 @@ def _parse_firewall_auth_success(
     query = _parse_optional_string_map(decoded_map, "query")
     aws_sigv4 = _parse_optional_aws_sigv4_credentials(decoded_map)
 
-    if set(headers) != set(request.auth_headers):
+    # The API owns required-versus-optional credential semantics. Both builtin
+    # and custom auth may omit entries backed by unavailable optional fields,
+    # but the API must never introduce an entry the matched firewall did not
+    # define.
+    configured_header_names = set(request.auth_headers)
+    resolved_header_names = set(headers)
+    configured_query_names = set(request.auth_query or {})
+    resolved_query_names = set(query or {})
+    if not resolved_header_names.issubset(configured_header_names):
         raise _malformed_firewall_auth_success(
-            "headers must match the configured auth header names"
+            "headers must not contain unconfigured auth header names"
         )
-    if set(query or {}) != set(request.auth_query or {}):
-        raise _malformed_firewall_auth_success("query must match the configured auth query names")
+    if not resolved_query_names.issubset(configured_query_names):
+        raise _malformed_firewall_auth_success(
+            "query must not contain unconfigured auth query names"
+        )
     if (base is not None) != (request.auth_base is not None):
         raise _malformed_firewall_auth_success("base presence must match the configured auth base")
     if (aws_sigv4 is not None) != (request.auth_aws_sigv4 is not None):

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -265,6 +265,35 @@ class TestFetchFirewallHeaders:
         assert result.refreshed_secrets == ["NOTION_TOKEN"]
         assert not hasattr(result, "futureField")
 
+    async def test_response_may_omit_configured_header_and_query_entries(self, mitm_ctx):
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response(
+            firewall_auth_success_response(
+                {"Authorization": "Bearer primary-token"},
+            )
+            | {"query": {}}
+        )
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(platform_api, "VERCEL_BYPASS", ""),
+        ):
+            result = await auth_client.fetch_firewall_headers(
+                firewall_auth_request(
+                    auth_headers={
+                        "Authorization": "Bearer ${{ secrets.PRIMARY_TOKEN }}",
+                        "X-Secondary": "${{ secrets.SECONDARY_TOKEN }}",
+                    },
+                    auth_query={"tenant": "${{ secrets.TENANT }}"},
+                )
+            )
+
+        assert result.payload.headers == {
+            "Authorization": "Bearer primary-token",
+        }
+        assert result.payload.query == {}
+
     @pytest.mark.parametrize(
         "session_token",
         [

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1319,8 +1319,6 @@ pub enum ConnectorRuntimeCustomAbsentReason {
     Connector,
     #[serde(rename = "grant-unavailable")]
     Grant,
-    #[serde(rename = "credentials-unavailable")]
-    Credentials,
     #[serde(rename = "permission-bundle-unavailable")]
     PermissionBundle,
     #[serde(rename = "runtime-configuration-unavailable")]

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9197,7 +9197,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("omits custom connector auth entries backed only by missing optional fields", async () => {
+  it("preserves runtime auth templates while omitting missing optional values", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
     const fw = createFirewallApi(context);
@@ -9279,8 +9279,11 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       customConnectorRuntimeAuthBody(runtime, fw.encryptedSecretsBody({}));
     expect(runtimeApi.auth.headers).toStrictEqual({
       Authorization: `Bearer \${{ secrets.${secretKey} }}`,
+      "X-Secondary": `\${{ secrets.${secondarySecretKey} }}`,
     });
-    expect(runtimeApi.auth.query).toStrictEqual({});
+    expect(runtimeApi.auth.query).toStrictEqual({
+      tenant: `\${{ secrets.${tenantVarKey} }}`,
+    });
     const runtimeResolved = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
       runtimeAuthBody,
@@ -9288,6 +9291,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     );
     expect(runtimeResolved.body).toMatchObject({
       headers: { Authorization: "Bearer optional-primary" },
+      query: {},
     });
 
     const resolved = await fw.requestFirewallAuth(
@@ -9312,7 +9316,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("keeps legacy omission while sync preserves missing optional auth", async () => {
+  it("keeps legacy omission while sync preserves optional-only firewall", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
     const fw = createFirewallApi(context);
@@ -9360,7 +9364,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
 
-    const internalName = `custom_connector_${saved.connector.id.replaceAll("-", "")}`;
+    const idPart = saved.connector.id.replaceAll("-", "");
+    const internalName = `custom_connector_${idPart}`;
+    const secretKey = `CUSTOM_${idPart}_S_SECRET`;
     expect(findFirewallEntry(claim.firewalls, internalName)).toBeUndefined();
     expect(claim.networkPolicies ?? {}).not.toHaveProperty(internalName);
 
@@ -9369,19 +9375,21 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     const runtime = availableCustomConnectorRuntime(runtimeResult);
     expect(runtime.firewall.customConnectorId).toBe(saved.connector.id);
-    const { body: runtimeAuthBody } = customConnectorRuntimeAuthBody(
-      runtime,
-      fw.encryptedSecretsBody({}),
-    );
-    const unavailableAuth = await fw.requestFirewallAuth(
+    const { api: runtimeApi, body: runtimeAuthBody } =
+      customConnectorRuntimeAuthBody(runtime, fw.encryptedSecretsBody({}));
+    expect(runtimeApi.auth.headers).toStrictEqual({
+      Authorization: `Bearer \${{ secrets.${secretKey} }}`,
+    });
+    const resolvedAuth = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
       runtimeAuthBody,
-      [424],
+      [200],
     );
-    if (unavailableAuth.status !== 424) {
-      throw new Error("Expected missing optional custom connector credentials");
+    if (resolvedAuth.status !== 200) {
+      throw new Error("Expected optional-only custom connector auth");
     }
-    expect(unavailableAuth.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
+    expect(resolvedAuth.body.headers).toStrictEqual({});
+    expect(resolvedAuth.body.query).toStrictEqual({});
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8440,6 +8440,38 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       headers: { Authorization: "Bearer restored-custom-secret-value" },
     });
 
+    await connectors.updateCustomConnector(actor, custom.id, {
+      displayName: "BDD Internal API Replaced Auth",
+      prefixTemplates: ["https://*.internal.example.com/v3/"],
+      fields: [
+        {
+          key: "replacement",
+          label: "Replacement token",
+          kind: "secret",
+          required: true,
+        },
+      ],
+      headerInjections: [
+        {
+          name: "X-Replacement",
+          valueTemplate: "Token {{secrets.replacement}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "manual",
+    });
+    const orphanedFieldAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      currentAuthBody,
+      [424],
+    );
+    if (orphanedFieldAuth.status !== 424) {
+      throw new Error("Expected removed custom connector field to be rejected");
+    }
+    expect(orphanedFieldAuth.body.error).toMatchObject({
+      code: "CONNECTOR_NOT_CONFIGURED",
+    });
+
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
     expect(cancelled.status).toBe("cancelled");

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8417,6 +8417,29 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       state: "available",
     });
 
+    await connectors.updateCustomConnector(actor, custom.id, {
+      displayName: "BDD Internal API Updated",
+      prefixTemplates: ["https://*.internal.example.com/v2/"],
+      fields: custom.fields,
+      headerInjections: [
+        {
+          name: "X-Authorization",
+          valueTemplate: "Token {{secrets.secret}}",
+        },
+      ],
+      queryInjections: custom.queryInjections,
+      authMode: custom.authMode,
+    });
+    await connectors.updateAgentCustomConnectors(actor, agentId, [custom.id]);
+    const lastKnownGoodAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      currentAuthBody,
+      [200],
+    );
+    expect(lastKnownGoodAuth.body).toMatchObject({
+      headers: { Authorization: "Bearer restored-custom-secret-value" },
+    });
+
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
     expect(cancelled.status).toBe("cancelled");

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8350,6 +8350,50 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       headers: { Authorization: "Bearer updated-custom-secret-value" },
     });
 
+    await connectors.deleteCustomConnectorSecret(actor, custom.id);
+    const [missingCredentialsRuntime] = await api.syncConnectorRuntime(
+      run.runId,
+      { targets: [target] },
+    );
+    const missingCredentialsAvailable = availableCustomConnectorRuntime(
+      missingCredentialsRuntime,
+    );
+    expect(missingCredentialsAvailable.firewall).toStrictEqual(
+      updatedAvailable.firewall,
+    );
+    expect(missingCredentialsAvailable.networkPolicy).toStrictEqual(
+      updatedAvailable.networkPolicy,
+    );
+    const { body: missingCredentialsAuthBody } = customConnectorRuntimeAuthBody(
+      missingCredentialsAvailable,
+      fw.encryptedSecretsBody({}),
+    );
+    const missingCredentialsAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      missingCredentialsAuthBody,
+      [424],
+    );
+    if (missingCredentialsAuth.status !== 424) {
+      throw new Error("Expected missing custom connector credentials");
+    }
+    expect(missingCredentialsAuth.body.error).toMatchObject({
+      code: "CONNECTOR_NOT_CONFIGURED",
+    });
+
+    await connectors.setCustomConnectorSecret(
+      actor,
+      custom.id,
+      "restored-custom-secret-value",
+    );
+    const restoredCredentialsAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      missingCredentialsAuthBody,
+      [200],
+    );
+    expect(restoredCredentialsAuth.body).toMatchObject({
+      headers: { Authorization: "Bearer restored-custom-secret-value" },
+    });
+
     await connectors.updateAgentCustomConnectors(actor, agentId, []);
     const [absentRuntime] = await api.syncConnectorRuntime(run.runId, {
       targets: [target],
@@ -8765,6 +8809,15 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       connectors: [custom.id],
       failureReason: "reconnect_required",
     });
+    const [reconnectRuntimeResult] = await api.syncConnectorRuntime(
+      firstRun.runId,
+      { targets: [{ kind: "custom", customConnectorId: custom.id }] },
+    );
+    const reconnectRuntime = availableCustomConnectorRuntime(
+      reconnectRuntimeResult,
+    );
+    expect(reconnectRuntime.firewall).toStrictEqual(runtime.firewall);
+    expect(reconnectRuntime.networkPolicy).toStrictEqual(runtime.networkPolicy);
     expect(
       provider.tokenBodies.map((body) => {
         return body.get("grant_type");
@@ -9195,6 +9248,25 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(JSON.stringify(customApis)).not.toContain(secondarySecretKey);
     expect(JSON.stringify(customApis)).not.toContain(tenantVarKey);
 
+    const [runtimeResult] = await api.syncConnectorRuntime(run.runId, {
+      targets: [{ kind: "custom", customConnectorId: saved.connector.id }],
+    });
+    const runtime = availableCustomConnectorRuntime(runtimeResult);
+    const { api: runtimeApi, body: runtimeAuthBody } =
+      customConnectorRuntimeAuthBody(runtime, fw.encryptedSecretsBody({}));
+    expect(runtimeApi.auth.headers).toStrictEqual({
+      Authorization: `Bearer \${{ secrets.${secretKey} }}`,
+    });
+    expect(runtimeApi.auth.query).toStrictEqual({});
+    const runtimeResolved = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      runtimeAuthBody,
+      [200],
+    );
+    expect(runtimeResolved.body).toMatchObject({
+      headers: { Authorization: "Bearer optional-primary" },
+    });
+
     const resolved = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
       {
@@ -9217,9 +9289,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("skips custom connectors when all auth entries require missing optional fields", async () => {
+  it("keeps legacy omission while sync preserves missing optional auth", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
+    const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     const rand = randomUUID().replace(/-/g, "").slice(0, 8);
 
@@ -9267,6 +9340,25 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const internalName = `custom_connector_${saved.connector.id.replaceAll("-", "")}`;
     expect(findFirewallEntry(claim.firewalls, internalName)).toBeUndefined();
     expect(claim.networkPolicies ?? {}).not.toHaveProperty(internalName);
+
+    const [runtimeResult] = await api.syncConnectorRuntime(run.runId, {
+      targets: [{ kind: "custom", customConnectorId: saved.connector.id }],
+    });
+    const runtime = availableCustomConnectorRuntime(runtimeResult);
+    expect(runtime.firewall.customConnectorId).toBe(saved.connector.id);
+    const { body: runtimeAuthBody } = customConnectorRuntimeAuthBody(
+      runtime,
+      fw.encryptedSecretsBody({}),
+    );
+    const unavailableAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      runtimeAuthBody,
+      [424],
+    );
+    if (unavailableAuth.status !== 424) {
+      throw new Error("Expected missing optional custom connector credentials");
+    }
+    expect(unavailableAuth.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -3717,6 +3717,61 @@ function customConnectorRuntimeAuth(args: {
   };
 }
 
+function customConnectorRuntimeAuthForRow(args: {
+  readonly row: CustomConnectorRuntimeDataRows[number];
+  readonly valueMarkers: ReadonlySet<string>;
+  readonly preserveFirewallWithoutCredentials: boolean;
+}): {
+  readonly headers: Record<string, string>;
+  readonly query: Record<string, string>;
+} {
+  const authValueMarkers = new Set(args.valueMarkers);
+  if (args.preserveFirewallWithoutCredentials) {
+    for (const field of args.row.connector.fields) {
+      if (field.required) {
+        authValueMarkers.add(customConnectorValueMarkerKey(field));
+      }
+    }
+    if (args.row.connector.authMode === "oauth") {
+      authValueMarkers.add(
+        customConnectorValueMarkerKey({
+          kind: "secret",
+          key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
+        }),
+      );
+    }
+  }
+  const auth = customConnectorRuntimeAuth({
+    connector: args.row.connector,
+    valueMarkers: authValueMarkers,
+  });
+  if (
+    !args.preserveFirewallWithoutCredentials ||
+    Object.keys(auth.headers).length > 0 ||
+    Object.keys(auth.query).length > 0
+  ) {
+    return auth;
+  }
+
+  const declaredValueMarkers = new Set(
+    args.row.connector.fields.map((field) => {
+      return customConnectorValueMarkerKey(field);
+    }),
+  );
+  if (args.row.connector.authMode === "oauth") {
+    declaredValueMarkers.add(
+      customConnectorValueMarkerKey({
+        kind: "secret",
+        key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
+      }),
+    );
+  }
+  return customConnectorRuntimeAuth({
+    connector: args.row.connector,
+    valueMarkers: declaredValueMarkers,
+  });
+}
+
 async function buildCustomConnectorRuntimeApis(args: {
   readonly row: CustomConnectorRuntimeDataRows[number];
   readonly headers: Record<string, string>;
@@ -3772,6 +3827,7 @@ interface BuildCustomConnectorRuntimeContextArgs {
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   readonly grants: readonly AgentCustomConnectorGrant[] | undefined;
+  readonly preserveFirewallWithoutCredentials: boolean;
   readonly timing?: ApiDispatchTimingCollector;
 }
 
@@ -3846,22 +3902,25 @@ export async function buildCustomConnectorRuntimeContext(
       }),
     );
     const missingRequired =
-      (row.connector.authMode === "oauth" && !oauthConnected) ||
-      row.connector.fields.some((field) => {
-        return (
-          field.required &&
-          !valueMarkers.has(customConnectorValueMarkerKey(field))
-        );
-      });
+      !args.preserveFirewallWithoutCredentials &&
+      ((row.connector.authMode === "oauth" && !oauthConnected) ||
+        row.connector.fields.some((field) => {
+          return (
+            field.required &&
+            !valueMarkers.has(customConnectorValueMarkerKey(field))
+          );
+        }));
     stats.recordPhaseDuration("assembleFirewalls", missingRequiredStartedAt);
     if (missingRequired) {
       stats.recordMissingRequiredConnector();
       continue;
     }
     const authTemplateStartedAt = now();
-    const { headers, query } = customConnectorRuntimeAuth({
-      connector: row.connector,
+    const { headers, query } = customConnectorRuntimeAuthForRow({
+      row,
       valueMarkers,
+      preserveFirewallWithoutCredentials:
+        args.preserveFirewallWithoutCredentials,
     });
     stats.recordPhaseDuration("renderAuthTemplates", authTemplateStartedAt);
     if (Object.keys(headers).length === 0 && Object.keys(query).length === 0) {
@@ -4072,6 +4131,7 @@ async function loadCustomConnectorContext(
         featureSwitchContext: args.featureSwitchContext,
         connectorCatalogSnapshot: args.connectorCatalogSnapshot,
         grants: args.customConnectorGrants,
+        preserveFirewallWithoutCredentials: false,
         timing,
       });
     },

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -3686,7 +3686,7 @@ class CustomConnectorRuntimeBuildStats {
 
 function customConnectorRuntimeAuth(args: {
   readonly connector: CustomConnectorRuntimeDataRows[number]["connector"];
-  readonly valueMarkers: ReadonlySet<string>;
+  readonly valueMarkers: ReadonlySet<string> | undefined;
 }): {
   readonly headers: Record<string, string>;
   readonly query: Record<string, string>;
@@ -3715,61 +3715,6 @@ function customConnectorRuntimeAuth(args: {
       }),
     ),
   };
-}
-
-function customConnectorRuntimeAuthForRow(args: {
-  readonly row: CustomConnectorRuntimeDataRows[number];
-  readonly valueMarkers: ReadonlySet<string>;
-  readonly preserveFirewallWithoutCredentials: boolean;
-}): {
-  readonly headers: Record<string, string>;
-  readonly query: Record<string, string>;
-} {
-  const authValueMarkers = new Set(args.valueMarkers);
-  if (args.preserveFirewallWithoutCredentials) {
-    for (const field of args.row.connector.fields) {
-      if (field.required) {
-        authValueMarkers.add(customConnectorValueMarkerKey(field));
-      }
-    }
-    if (args.row.connector.authMode === "oauth") {
-      authValueMarkers.add(
-        customConnectorValueMarkerKey({
-          kind: "secret",
-          key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
-        }),
-      );
-    }
-  }
-  const auth = customConnectorRuntimeAuth({
-    connector: args.row.connector,
-    valueMarkers: authValueMarkers,
-  });
-  if (
-    !args.preserveFirewallWithoutCredentials ||
-    Object.keys(auth.headers).length > 0 ||
-    Object.keys(auth.query).length > 0
-  ) {
-    return auth;
-  }
-
-  const declaredValueMarkers = new Set(
-    args.row.connector.fields.map((field) => {
-      return customConnectorValueMarkerKey(field);
-    }),
-  );
-  if (args.row.connector.authMode === "oauth") {
-    declaredValueMarkers.add(
-      customConnectorValueMarkerKey({
-        kind: "secret",
-        key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
-      }),
-    );
-  }
-  return customConnectorRuntimeAuth({
-    connector: args.row.connector,
-    valueMarkers: declaredValueMarkers,
-  });
 }
 
 async function buildCustomConnectorRuntimeApis(args: {
@@ -3916,11 +3861,11 @@ export async function buildCustomConnectorRuntimeContext(
       continue;
     }
     const authTemplateStartedAt = now();
-    const { headers, query } = customConnectorRuntimeAuthForRow({
-      row,
-      valueMarkers,
-      preserveFirewallWithoutCredentials:
-        args.preserveFirewallWithoutCredentials,
+    const { headers, query } = customConnectorRuntimeAuth({
+      connector: row.connector,
+      valueMarkers: args.preserveFirewallWithoutCredentials
+        ? undefined
+        : valueMarkers,
     });
     stats.recordPhaseDuration("renderAuthTemplates", authTemplateStartedAt);
     if (Object.keys(headers).length === 0 && Object.keys(query).length === 0) {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -546,7 +546,7 @@ const CUSTOM_CONNECTOR_AUTH_REF_TTL_MS = 5 * 60 * 60 * 1000;
 
 type CustomConnectorAuthRefKind = "secret" | "variable";
 
-export interface CustomConnectorAuthRef {
+interface CustomConnectorAuthRef {
   readonly secretName: string;
   readonly connectorId: string;
   readonly connectorRevision: number;
@@ -4000,7 +4000,6 @@ interface CustomConnectorRuntimeExecutionState {
     };
   };
   readonly networkPolicy: NetworkPolicy;
-  readonly authRefs: readonly CustomConnectorAuthRef[];
 }
 
 export function customConnectorRuntimeExecutionState(args: {
@@ -4047,9 +4046,6 @@ export function customConnectorRuntimeExecutionState(args: {
       },
     },
     networkPolicy,
-    authRefs: args.context.authRefs.filter((ref) => {
-      return ref.connectorId === args.connectorId;
-    }),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -4169,26 +4169,28 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
       return [secretName, field] as const;
     }),
   );
-  const refs = new Map<string, CurrentCustomConnectorAuthRef>(
-    runtime.values.map((value) => {
-      const secretName = customConnectorSecretKey({
-        connectorId: runtime.connector.id,
-        kind: value.kind,
-        key: value.key,
-      });
-      return [
-        secretName,
-        {
-          secretName,
-          connectorId: runtime.connector.id,
-          connectorRevision: runtime.connector.revision,
-          key: value.key,
-          encryptedValue: value.encryptedValue,
-          required: declaredFields.get(secretName)?.required ?? true,
-        } satisfies CurrentCustomConnectorAuthRef,
-      ] as const;
-    }),
-  );
+  const refs = new Map<string, CurrentCustomConnectorAuthRef>();
+  for (const value of runtime.values) {
+    const secretName = customConnectorSecretKey({
+      connectorId: runtime.connector.id,
+      kind: value.kind,
+      key: value.key,
+    });
+    const field = declaredFields.get(secretName);
+    if (!field) {
+      // Stored values survive definition edits, but removed fields are no
+      // longer part of the executable credential contract.
+      continue;
+    }
+    refs.set(secretName, {
+      secretName,
+      connectorId: runtime.connector.id,
+      connectorRevision: runtime.connector.revision,
+      key: value.key,
+      encryptedValue: value.encryptedValue,
+      required: field.required,
+    });
+  }
   for (const [secretName, field] of declaredFields) {
     if (refs.has(secretName)) {
       continue;

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -4141,6 +4141,7 @@ interface CurrentCustomConnectorAuthRef {
   readonly connectorRevision: number;
   readonly key: string;
   readonly encryptedValue: string | null;
+  readonly required: boolean;
 }
 
 async function loadCurrentCustomConnectorAuthRefs(args: {
@@ -4158,39 +4159,72 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
     return undefined;
   }
 
-  const refs: CurrentCustomConnectorAuthRef[] = runtime.values.map((value) => {
-    return {
-      secretName: customConnectorSecretKey({
+  const declaredFields = new Map(
+    runtime.connector.fields.map((field) => {
+      const secretName = customConnectorSecretKey({
+        connectorId: runtime.connector.id,
+        kind: field.kind,
+        key: field.key,
+      });
+      return [secretName, field] as const;
+    }),
+  );
+  const refs = new Map<string, CurrentCustomConnectorAuthRef>(
+    runtime.values.map((value) => {
+      const secretName = customConnectorSecretKey({
         connectorId: runtime.connector.id,
         kind: value.kind,
         key: value.key,
-      }),
+      });
+      return [
+        secretName,
+        {
+          secretName,
+          connectorId: runtime.connector.id,
+          connectorRevision: runtime.connector.revision,
+          key: value.key,
+          encryptedValue: value.encryptedValue,
+          required: declaredFields.get(secretName)?.required ?? true,
+        } satisfies CurrentCustomConnectorAuthRef,
+      ] as const;
+    }),
+  );
+  for (const [secretName, field] of declaredFields) {
+    if (refs.has(secretName)) {
+      continue;
+    }
+    refs.set(secretName, {
+      secretName,
       connectorId: runtime.connector.id,
       connectorRevision: runtime.connector.revision,
-      key: value.key,
-      encryptedValue: value.encryptedValue,
-    } satisfies CurrentCustomConnectorAuthRef;
-  });
+      key: field.key,
+      encryptedValue: null,
+      required: field.required,
+    });
+  }
   if (runtime.connector.authMode === "oauth") {
-    refs.push({
-      secretName: customConnectorSecretKey({
-        connectorId: runtime.connector.id,
-        kind: "secret",
-        key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
-      }),
+    const secretName = customConnectorSecretKey({
+      connectorId: runtime.connector.id,
+      kind: "secret",
+      key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
+    });
+    refs.set(secretName, {
+      secretName,
       connectorId: runtime.connector.id,
       connectorRevision: runtime.connector.revision,
       key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
       encryptedValue: null,
+      required: true,
     });
   }
-  return refs;
+  return [...refs.values()];
 }
 
 type CurrentCustomConnectorSecretsResolution =
   | {
       readonly kind: "available";
       readonly secrets: Record<string, string>;
+      readonly missingOptionalSecrets: readonly string[];
       readonly expiresAt: number | null;
       readonly refreshedConnectors: readonly string[];
       readonly refreshedSecrets: readonly string[];
@@ -4231,6 +4265,7 @@ async function resolveCurrentCustomConnectorSecrets(args: {
     args.auth.userId,
   );
   const currentSecrets: Record<string, string> = {};
+  const missingOptionalSecrets: string[] = [];
   let expiresAt: number | null = null;
   const refreshedConnectors: string[] = [];
   const refreshedSecrets: string[] = [];
@@ -4280,6 +4315,10 @@ async function resolveCurrentCustomConnectorSecrets(args: {
       }
     }
     if (!encryptedValue) {
+      if (!ref.required) {
+        missingOptionalSecrets.push(alias);
+        continue;
+      }
       return { kind: "unavailable" };
     }
     currentSecrets[alias] = await decryptStoredSecretValue(
@@ -4290,9 +4329,62 @@ async function resolveCurrentCustomConnectorSecrets(args: {
   return {
     kind: "available",
     secrets: currentSecrets,
+    missingOptionalSecrets,
     expiresAt,
     refreshedConnectors,
     refreshedSecrets,
+  };
+}
+
+function templateReferencesMissingOptionalSecret(args: {
+  readonly template: string;
+  readonly missingOptionalSecrets: ReadonlySet<string>;
+  readonly kind: "header" | "simple";
+}): boolean {
+  let referencesMissingSecret = false;
+  const collect = (namespace: string, key: string): void => {
+    if (namespace === "secrets" && args.missingOptionalSecrets.has(key)) {
+      referencesMissingSecret = true;
+    }
+  };
+  if (args.kind === "header") {
+    collectHeaderReferencedKeys(args.template, collect);
+  } else {
+    collectSimpleReferencedKeys(args.template, collect);
+  }
+  return referencesMissingSecret;
+}
+
+function omitMissingOptionalCustomAuthEntries(args: {
+  readonly authHeaders: Record<string, string>;
+  readonly authQuery: Record<string, string> | undefined;
+  readonly missingOptionalSecrets: readonly string[];
+}): {
+  readonly authHeaders: Record<string, string>;
+  readonly authQuery: Record<string, string> | undefined;
+} {
+  const missingOptionalSecrets = new Set(args.missingOptionalSecrets);
+  return {
+    authHeaders: Object.fromEntries(
+      Object.entries(args.authHeaders).filter(([, template]) => {
+        return !templateReferencesMissingOptionalSecret({
+          template,
+          missingOptionalSecrets,
+          kind: "header",
+        });
+      }),
+    ),
+    authQuery: args.authQuery
+      ? Object.fromEntries(
+          Object.entries(args.authQuery).filter(([, template]) => {
+            return !templateReferencesMissingOptionalSecret({
+              template,
+              missingOptionalSecrets,
+              kind: "simple",
+            });
+          }),
+        )
+      : undefined,
   };
 }
 
@@ -4343,12 +4435,19 @@ async function resolveCurrentCustomConnectorFirewallAuth(args: {
   if ("status" in billableCacheExpiry) {
     return billableCacheExpiry;
   }
-  const resolved = resolveTemplates({
+  // Runtime sync keeps firewall shape definition-driven. Optional credential
+  // availability affects only the auth entries returned for this request.
+  const availableAuth = omitMissingOptionalCustomAuthEntries({
     authHeaders: args.body.authHeaders,
+    authQuery: args.body.authQuery,
+    missingOptionalSecrets: currentSecrets.missingOptionalSecrets,
+  });
+  const resolved = resolveTemplates({
+    authHeaders: availableAuth.authHeaders,
     secrets: currentSecrets.secrets,
     vars: args.body.vars ?? {},
     authBase: args.body.authBase,
-    authQuery: args.body.authQuery,
+    authQuery: availableAuth.authQuery,
     authAwsSigv4: args.body.authAwsSigv4,
   });
   if (hasEmptyAwsSigv4Credential(resolved.awsSigv4)) {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -1,5 +1,4 @@
 import { Buffer } from "node:buffer";
-import { isDeepStrictEqual } from "node:util";
 
 import {
   getSecretNameForType,
@@ -8,10 +7,7 @@ import {
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import type { ConnectorReconnectReason } from "@vm0/api-contracts/contracts/connector-schemas";
-import type {
-  ConnectorRuntimeSyncResult,
-  SecretConnectorMetadata,
-} from "@vm0/api-contracts/contracts/runners";
+import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
 import type {
   ConnectorAuthMethodId,
   ConnectorSlug,
@@ -55,7 +51,6 @@ import {
 import { isChatgptRefreshError } from "@vm0/connectors/auth-providers/model-providers/codex-oauth/oauth";
 import { agentRunCustomConnectorAuthRefs } from "@vm0/db/schema/agent-run-custom-connector-auth-ref";
 import { agentRuns } from "@vm0/db/schema/agent-run";
-import { agentSessions } from "@vm0/db/schema/agent-session";
 import { connectors } from "@vm0/db/schema/connector";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { secrets as secretsTable } from "@vm0/db/schema/secret";
@@ -111,11 +106,11 @@ import {
   CustomConnectorOAuth2TokenRefreshError,
   resolveLiveCustomConnectorOAuth2AccessToken,
 } from "./custom-connector-oauth2.service";
-import { CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY } from "./zero-custom-connector.service";
 import {
-  resolveConnectorRuntimeTargets,
-  type ConnectorRuntimeResolution,
-} from "./connector-runtime-sync.service";
+  CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
+  customConnectorSecretKey,
+  loadCustomConnectorRuntimeData,
+} from "./zero-custom-connector.service";
 
 type AccessSecretSource = SecretConnectorMetadata["sourceType"];
 type StorageSecretSource = Exclude<AccessSecretSource, "platform-secret">;
@@ -4140,94 +4135,56 @@ function hasEmptyAwsSigv4Credential(
   );
 }
 
-function optionalRecordEquals(
-  left: Readonly<Record<string, string>> | undefined,
-  right: Readonly<Record<string, string>> | undefined,
-): boolean {
-  const normalizedLeft =
-    left && Object.keys(left).length > 0 ? left : undefined;
-  const normalizedRight =
-    right && Object.keys(right).length > 0 ? right : undefined;
-  return isDeepStrictEqual(normalizedLeft, normalizedRight);
+interface CurrentCustomConnectorAuthRef {
+  readonly secretName: string;
+  readonly connectorId: string;
+  readonly connectorRevision: number;
+  readonly key: string;
+  readonly encryptedValue: string | null;
 }
 
-type AvailableCustomConnectorRuntimeResult = Extract<
-  ConnectorRuntimeSyncResult,
-  { readonly state: "available"; readonly target: { readonly kind: "custom" } }
->;
-
-interface AvailableCustomConnectorRuntimeResolution {
-  readonly result: AvailableCustomConnectorRuntimeResult;
-  readonly customAuthRefs: ConnectorRuntimeResolution["customAuthRefs"];
-}
-
-function availableCustomConnectorRuntimeResolution(
-  resolution: ConnectorRuntimeResolution | undefined,
-  customConnectorId: string,
-): AvailableCustomConnectorRuntimeResolution | undefined {
-  if (
-    !resolution ||
-    resolution.result.state !== "available" ||
-    resolution.result.target.kind !== "custom" ||
-    !("firewall" in resolution.result) ||
-    resolution.result.firewall.customConnectorId !== customConnectorId
-  ) {
+async function loadCurrentCustomConnectorAuthRefs(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly customConnectorId: string;
+}): Promise<readonly CurrentCustomConnectorAuthRef[] | undefined> {
+  const [runtime] = await loadCustomConnectorRuntimeData(args.db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    connectorIds: [args.customConnectorId],
+  });
+  if (!runtime) {
     return undefined;
   }
-  return {
-    result: resolution.result,
-    customAuthRefs: resolution.customAuthRefs,
-  };
-}
 
-type CurrentCustomConnectorFirewallApi =
-  AvailableCustomConnectorRuntimeResult["firewall"]["firewall"]["apis"][number];
-
-function matchedCurrentCustomConnectorFirewallApi(args: {
-  readonly body: FirewallAuthBody;
-  readonly resolution: AvailableCustomConnectorRuntimeResolution;
-}): CurrentCustomConnectorFirewallApi | undefined {
-  const matchedFirewall = args.body.matchedFirewall;
-  if (
-    !matchedFirewall ||
-    args.resolution.result.firewall.firewall.name !== matchedFirewall.name
-  ) {
-    return undefined;
+  const refs: CurrentCustomConnectorAuthRef[] = runtime.values.map((value) => {
+    return {
+      secretName: customConnectorSecretKey({
+        connectorId: runtime.connector.id,
+        kind: value.kind,
+        key: value.key,
+      }),
+      connectorId: runtime.connector.id,
+      connectorRevision: runtime.connector.revision,
+      key: value.key,
+      encryptedValue: value.encryptedValue,
+    } satisfies CurrentCustomConnectorAuthRef;
+  });
+  if (runtime.connector.authMode === "oauth") {
+    refs.push({
+      secretName: customConnectorSecretKey({
+        connectorId: runtime.connector.id,
+        kind: "secret",
+        key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
+      }),
+      connectorId: runtime.connector.id,
+      connectorRevision: runtime.connector.revision,
+      key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
+      encryptedValue: null,
+    });
   }
-  const api = args.resolution.result.firewall.firewall.apis.find(
-    (candidate) => {
-      return candidate.id === matchedFirewall.apiId;
-    },
-  );
-  if (
-    !api ||
-    !isDeepStrictEqual(api.auth.headers ?? {}, args.body.authHeaders) ||
-    api.auth.base !== args.body.authBase ||
-    !optionalRecordEquals(api.auth.query, args.body.authQuery) ||
-    !isDeepStrictEqual(api.auth.awsSigv4, args.body.authAwsSigv4)
-  ) {
-    return undefined;
-  }
-  return api;
-}
-
-async function currentCustomConnectorRunScope(
-  db: Db,
-  auth: SandboxAuth,
-): Promise<{ readonly agentId: string } | undefined> {
-  const [run] = await db
-    .select({ agentId: agentSessions.agentComposeId })
-    .from(agentRuns)
-    .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
-    .where(
-      and(
-        eq(agentRuns.id, auth.runId),
-        eq(agentRuns.userId, auth.userId),
-        eq(agentRuns.orgId, auth.orgId),
-      ),
-    )
-    .limit(1);
-  return run;
+  return refs;
 }
 
 type CurrentCustomConnectorSecretsResolution =
@@ -4245,18 +4202,18 @@ type CurrentCustomConnectorSecretsResolution =
 async function resolveCurrentCustomConnectorSecrets(args: {
   readonly db: Db;
   readonly auth: SandboxAuth;
-  readonly api: CurrentCustomConnectorFirewallApi;
-  readonly authRefs: ConnectorRuntimeResolution["customAuthRefs"];
+  readonly body: FirewallAuthBody;
+  readonly authRefs: readonly CurrentCustomConnectorAuthRef[];
   readonly forceRefresh: boolean;
 }): Promise<CurrentCustomConnectorSecretsResolution> {
   const referenced = collectReferencedKeys(
-    args.api.auth.headers ?? {},
-    args.api.auth.base,
-    args.api.auth.query,
-    args.api.auth.awsSigv4,
+    args.body.authHeaders,
+    args.body.authBase,
+    args.body.authQuery,
+    args.body.authAwsSigv4,
   );
   const refsByAlias = new Map(
-    (args.authRefs ?? []).map((ref) => {
+    args.authRefs.map((ref) => {
       return [ref.secretName, ref] as const;
     }),
   );
@@ -4345,46 +4302,27 @@ async function resolveCurrentCustomConnectorFirewallAuth(args: {
   readonly body: FirewallAuthBody;
   readonly customConnectorId: string;
 }): Promise<ResolveFirewallAuthResult> {
-  const run = await currentCustomConnectorRunScope(args.db, args.auth);
-  if (!run) {
+  const orgId = await findRefreshRunOrgId(args.db, args.auth);
+  if (!orgId) {
     return badRequestMessage("Run not found");
   }
-  const [resolution] = await resolveConnectorRuntimeTargets({
+  // The trusted host already matched this request against its effective
+  // firewall. Runtime sync owns firewall changes; auth resolves only the
+  // referenced values from the connector's current credential storage.
+  const authRefs = await loadCurrentCustomConnectorAuthRefs({
     db: args.db,
-    scope: {
-      orgId: args.auth.orgId,
-      userId: args.auth.userId,
-      agentId: run.agentId,
-    },
-    targets: [
-      {
-        kind: "custom",
-        customConnectorId: args.customConnectorId,
-      },
-    ],
+    orgId,
+    userId: args.auth.userId,
+    customConnectorId: args.customConnectorId,
   });
-  if (resolution?.customAuthState === "reconnect-required") {
-    return connectorReconnectRequired([args.customConnectorId]);
-  }
-  const currentResolution = availableCustomConnectorRuntimeResolution(
-    resolution,
-    args.customConnectorId,
-  );
-  if (!currentResolution) {
-    return connectorNotConfigured();
-  }
-  const api = matchedCurrentCustomConnectorFirewallApi({
-    body: args.body,
-    resolution: currentResolution,
-  });
-  if (!api) {
+  if (!authRefs) {
     return connectorNotConfigured();
   }
   const currentSecrets = await resolveCurrentCustomConnectorSecrets({
     db: args.db,
     auth: args.auth,
-    api,
-    authRefs: currentResolution.customAuthRefs,
+    body: args.body,
+    authRefs,
     forceRefresh: args.body.forceRefresh === true,
   });
   if (currentSecrets.kind === "unavailable") {
@@ -4406,12 +4344,12 @@ async function resolveCurrentCustomConnectorFirewallAuth(args: {
     return billableCacheExpiry;
   }
   const resolved = resolveTemplates({
-    authHeaders: api.auth.headers ?? {},
+    authHeaders: args.body.authHeaders,
     secrets: currentSecrets.secrets,
     vars: args.body.vars ?? {},
-    authBase: api.auth.base,
-    authQuery: api.auth.query,
-    authAwsSigv4: api.auth.awsSigv4,
+    authBase: args.body.authBase,
+    authQuery: args.body.authQuery,
+    authAwsSigv4: args.body.authAwsSigv4,
   });
   if (hasEmptyAwsSigv4Credential(resolved.awsSigv4)) {
     return connectorNotConfigured();

--- a/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
@@ -4,8 +4,6 @@ import type {
   ConnectorRuntimeTarget,
 } from "@vm0/api-contracts/contracts/runners";
 import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
-import { connectors } from "@vm0/db/schema/connector";
-import { secrets } from "@vm0/db/schema/secret";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { and, eq, inArray } from "drizzle-orm";
 
@@ -15,18 +13,14 @@ import {
   buildCustomConnectorRuntimeContext,
   customConnectorRuntimeExecutionState,
   loadEffectiveCustomConnectorPermissionBundle,
-  type CustomConnectorAuthRef,
   type CustomConnectorRuntimeDataRows,
 } from "./agent-run-create.service";
 import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { resolveActiveNetworkPolicyRefreshes } from "./zero-user-permission-grants.service";
 import {
-  CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
-  CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_SECRET_NAME,
   CustomConnectorRuntimePrefixError,
   loadCustomConnectorRuntimeData,
-  type StoredValueRow,
 } from "./zero-custom-connector.service";
 
 interface ConnectorRuntimeScope {
@@ -35,24 +29,13 @@ interface ConnectorRuntimeScope {
   readonly agentId: string;
 }
 
-interface CustomConnectionSnapshot {
-  readonly needsReconnect: boolean;
-  readonly secrets: readonly {
-    readonly name: string;
-    readonly encryptedValue: string;
-  }[];
-}
-
 interface CustomTargetSnapshot {
   readonly row: CustomConnectorRuntimeDataRows[number];
   readonly grant: AgentCustomConnectorGrant | undefined;
-  readonly connection: CustomConnectionSnapshot | undefined;
 }
 
-export interface ConnectorRuntimeResolution {
+interface ConnectorRuntimeResolution {
   readonly result: ConnectorRuntimeSyncResult;
-  readonly customAuthRefs?: readonly CustomConnectorAuthRef[];
-  readonly customAuthState?: "reconnect-required";
 }
 
 function customAbsentResult(
@@ -78,73 +61,6 @@ function builtinUnresolvedResult(
       reason: "connector-unavailable",
     },
   };
-}
-
-function connectionSnapshots(
-  rows: readonly {
-    readonly customConnectorId: string;
-    readonly needsReconnect: boolean;
-    readonly secretName: string | null;
-    readonly encryptedValue: string | null;
-  }[],
-): ReadonlyMap<string, CustomConnectionSnapshot> {
-  const grouped = new Map<
-    string,
-    Omit<CustomConnectionSnapshot, "secrets"> & {
-      secrets: { name: string; encryptedValue: string }[];
-    }
-  >();
-  for (const row of rows) {
-    let connection = grouped.get(row.customConnectorId);
-    if (!connection) {
-      connection = {
-        needsReconnect: row.needsReconnect,
-        secrets: [],
-      };
-      grouped.set(row.customConnectorId, connection);
-    }
-    if (row.secretName && row.encryptedValue) {
-      connection.secrets.push({
-        name: row.secretName,
-        encryptedValue: row.encryptedValue,
-      });
-    }
-  }
-  return grouped;
-}
-
-function valuesWithOAuthAccessToken(
-  row: CustomTargetSnapshot,
-): readonly StoredValueRow[] {
-  if (row.row.connector.authMode !== "oauth") {
-    return row.row.values;
-  }
-  const connection = row.connection;
-  const encryptedAccessToken = connection?.secrets.find((secret) => {
-    return secret.name === CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_SECRET_NAME;
-  })?.encryptedValue;
-  if (!connection || connection.needsReconnect || !encryptedAccessToken) {
-    return row.row.values.filter((value) => {
-      return !(
-        value.kind === "secret" &&
-        value.key === CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY
-      );
-    });
-  }
-  return [
-    ...row.row.values.filter((value) => {
-      return !(
-        value.kind === "secret" &&
-        value.key === CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY
-      );
-    }),
-    {
-      connectorId: row.row.connector.id,
-      kind: "secret" as const,
-      key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
-      encryptedValue: encryptedAccessToken,
-    },
-  ];
 }
 
 async function loadCustomSnapshot(args: {
@@ -183,29 +99,6 @@ async function loadCustomSnapshot(args: {
             ),
           ),
         );
-      const connectionRows = await tx
-        .select({
-          customConnectorId: connectors.customConnectorId,
-          needsReconnect: connectors.needsReconnect,
-          secretName: secrets.name,
-          encryptedValue: secrets.encryptedValue,
-        })
-        .from(connectors)
-        .leftJoin(secrets, eq(secrets.connectorId, connectors.id))
-        .where(
-          and(
-            eq(connectors.orgId, args.scope.orgId),
-            eq(connectors.userId, args.scope.userId),
-            inArray(connectors.customConnectorId, args.customConnectorIds),
-          ),
-        );
-      const connections = connectionSnapshots(
-        connectionRows.flatMap((row) => {
-          return row.customConnectorId
-            ? [{ ...row, customConnectorId: row.customConnectorId }]
-            : [];
-        }),
-      );
       const grants = new Map(
         grantRows.map((grant) => {
           return [grant.customConnectorId, grant] as const;
@@ -223,7 +116,6 @@ async function loadCustomSnapshot(args: {
                   permissionNames: [...grant.permissionNames],
                 }
               : undefined,
-          connection: connections.get(row.connector.id),
         });
       }
       return {
@@ -247,8 +139,7 @@ async function resolveCustomTarget(args: {
   if (!custom.grant) {
     return customAbsentResult(args.target, "grant-unavailable");
   }
-  const values = valuesWithOAuthAccessToken(custom);
-  const row = { ...custom.row, values };
+  const row = custom.row;
   const permissionBundle = await loadEffectiveCustomConnectorPermissionBundle({
     row,
     snapshot: args.snapshot.connectorCatalogSnapshot,
@@ -296,11 +187,6 @@ async function resolveCustomTarget(args: {
         customConnectorId: args.target.customConnectorId,
       },
     },
-    customAuthRefs: state.authRefs,
-    ...(custom.row.connector.authMode === "oauth" &&
-    custom.connection?.needsReconnect
-      ? { customAuthState: "reconnect-required" }
-      : {}),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
@@ -24,7 +24,6 @@ import { resolveActiveNetworkPolicyRefreshes } from "./zero-user-permission-gran
 import {
   CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
   CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_SECRET_NAME,
-  customConnectorValueMarkerKey,
   CustomConnectorRuntimePrefixError,
   loadCustomConnectorRuntimeData,
   type StoredValueRow,
@@ -148,31 +147,6 @@ function valuesWithOAuthAccessToken(
   ];
 }
 
-function customCredentialsAvailable(
-  row: CustomTargetSnapshot,
-  values: readonly StoredValueRow[],
-): boolean {
-  const markers = new Set(
-    values.map((value) => {
-      return customConnectorValueMarkerKey(value);
-    }),
-  );
-  if (
-    row.row.connector.authMode === "oauth" &&
-    !markers.has(
-      customConnectorValueMarkerKey({
-        kind: "secret",
-        key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
-      }),
-    )
-  ) {
-    return false;
-  }
-  return row.row.connector.fields.every((field) => {
-    return !field.required || markers.has(customConnectorValueMarkerKey(field));
-  });
-}
-
 async function loadCustomSnapshot(args: {
   readonly db: Db;
   readonly scope: ConnectorRuntimeScope;
@@ -274,15 +248,6 @@ async function resolveCustomTarget(args: {
     return customAbsentResult(args.target, "grant-unavailable");
   }
   const values = valuesWithOAuthAccessToken(custom);
-  if (!customCredentialsAvailable(custom, values)) {
-    const resolution = customAbsentResult(
-      args.target,
-      "credentials-unavailable",
-    );
-    return custom.connection?.needsReconnect
-      ? { ...resolution, customAuthState: "reconnect-required" }
-      : resolution;
-  }
   const row = { ...custom.row, values };
   const permissionBundle = await loadEffectiveCustomConnectorPermissionBundle({
     row,
@@ -298,6 +263,7 @@ async function resolveCustomTarget(args: {
       featureSwitchContext: args.snapshot.featureSwitchContext,
       connectorCatalogSnapshot: args.snapshot.connectorCatalogSnapshot,
       grants: [custom.grant],
+      preserveFirewallWithoutCredentials: true,
     }),
   );
   if (!contextResult.ok) {
@@ -331,6 +297,10 @@ async function resolveCustomTarget(args: {
       },
     },
     customAuthRefs: state.authRefs,
+    ...(custom.row.connector.authMode === "oauth" &&
+    custom.connection?.needsReconnect
+      ? { customAuthState: "reconnect-required" }
+      : {}),
   };
 }
 

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -262,7 +262,6 @@ const connectorRuntimeSyncTargetsSchema = connectorRuntimeTargetsSchema
 export const connectorRuntimeCustomAbsentReasonSchema = z.enum([
   "connector-unavailable",
   "grant-unavailable",
-  "credentials-unavailable",
   "permission-bundle-unavailable",
   "runtime-configuration-unavailable",
 ]);


### PR DESCRIPTION
## Summary

- keep a Custom connector's firewall and network policy available when required credentials are missing or its OAuth connection requires reconnection
- render synchronized Custom firewall auth templates entirely from the connector definition, so partial optional credential availability cannot change firewall shape
- preserve optional fields at the auth boundary by omitting only header/query entries whose optional values are unavailable
- accept optional header/query omissions through one shared runner protocol rule for Builtin and Custom while rejecting names not configured by the matched firewall
- make runtime sync the sole authority for Custom firewall transitions; `/firewall/auth` trusts the firewall matched by the trusted host instead of rebuilding and comparing current firewall, grant, catalog, or permission state
- resolve only the matched firewall's referenced aliases from current credential storage scoped by organization, user, and custom connector identity
- reject preserved credential rows that no longer correspond to a field declared by the current Custom connector definition
- remove the unused `credentials-unavailable` runtime protocol reason

## Compatibility and scope

- no database migration or persisted-state change
- the existing run-start producer behavior is unchanged; the new behavior applies through runtime sync
- this PR does not activate production Custom runtime target emission or change active-run target membership; that remains #25350
- a missing variable required to construct a safe request URL still makes the Custom target unavailable
- the API remains authoritative for required-versus-optional credential semantics: missing required credentials fail auth, while missing optional values may omit only affected auth entries
- preserved storage rows survive definition edits but are never executable after their field leaves the current definition
- runner response validation still fails closed on every header/query name absent from the matched firewall configuration
- no auth-cache lifecycle or refresh-cadence changes

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 -t "RUN-02: custom connectors, grants, and network policies"` (24 tests passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `uv lock --check`
- `uv run --no-sync ruff format --check src/firewall_auth_client.py tests/test_firewall_auth_client.py`
- `uv run --no-sync ruff check src/firewall_auth_client.py tests/test_firewall_auth_client.py`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_firewall_auth_client.py` (83 tests passed)
- `uv run --no-sync python -m pytest tests/` (4,956 tests passed)
- `cargo test -p runner provider::network_policy_refresh::tests:: -- --test-threads=1` (38 tests passed)
- `cargo test -p runner proxy::registry::tests:: -- --test-threads=1` (22 tests passed)

Closes #25553

Parent: #25312
