### PR TITLE
test(python): cover model observation flush bound

### DIFF
--- a/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
@@ -484,6 +484,47 @@ def test_flushes_when_aggregate_bucket_count_reaches_exact_bound(tmp_path):
     assert len(payload["events"]) == usage_buffer.MAX_AGGREGATE_BUCKETS
 
 
+def test_flushes_when_model_observation_bucket_count_reaches_exact_bound(tmp_path):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+
+    usage.buffer_model_usage_observations(
+        "https://api.test/api/webhooks/agent/model-usage-observation",
+        "token-a",
+        "run-1",
+        [
+            observation(source_key=f"source-{index}", model=f"model-{index}")
+            for index in range(usage_buffer.MAX_AGGREGATE_BUCKETS - 1)
+        ],
+        proxy_log_path,
+    )
+    enqueue.assert_not_called()
+
+    final_index = usage_buffer.MAX_AGGREGATE_BUCKETS - 1
+    usage.buffer_model_usage_observations(
+        "https://api.test/api/webhooks/agent/model-usage-observation",
+        "token-a",
+        "run-1",
+        [
+            observation(
+                source_key=f"source-{final_index}",
+                model=f"model-{final_index}",
+            )
+        ],
+        proxy_log_path,
+    )
+
+    enqueue.assert_called_once()
+    payload = enqueue.last_call.payload
+    assert payload["runId"] == "run-1"
+    assert len(payload["events"]) == usage_buffer.MAX_AGGREGATE_BUCKETS
+    assert {flushed_observation["model"] for flushed_observation in payload["events"]} == {
+        f"model-{index}" for index in range(usage_buffer.MAX_AGGREGATE_BUCKETS)
+    }
+    assert enqueue.last_call.log_type == "model_usage_observation"
+
+
 def test_flushes_when_source_event_count_reaches_bound(tmp_path):
     pending_path = tmp_path / "usage-pending"
     enqueue = RecordingEnqueue()


### PR DESCRIPTION
## Summary

- add public-buffer regression coverage for the model-observation aggregate flush bound
- verify 99 distinct model buckets stay buffered and the 100th triggers one enqueue
- verify the emitted batch contains all expected models and uses the model-observation log type

## Scope

This PR changes tests only. It does not modify production behavior, the existing ordinary usage-event threshold test, schemas, persisted data, APIs, or protocols.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_usage_buffer_aggregation.py` (14 passed)
- `uv run --no-sync python -m pytest tests/` (4952 passed)

Closes #25478
