### PR TITLE
fix(platform): preserve local edits during draft restore

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from "@playwright/test";
+import type { Locator, Page, Response } from "@playwright/test";
 import { expect, test } from "../fixtures";
 import { deriveAppUrl } from "../playwright.config";
 
@@ -18,6 +18,34 @@ interface ConnectorCatalogStatusResponse {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function isSuccessfulAgentDraftClear(response: Response): boolean {
+  const request = response.request();
+  if (
+    !response.ok() ||
+    request.method() !== "PATCH" ||
+    !/^\/api\/zero\/agents\/[^/]+\/draft$/.test(
+      new URL(response.url()).pathname,
+    )
+  ) {
+    return false;
+  }
+  const body: unknown = request.postDataJSON();
+  return (
+    isRecord(body) &&
+    body.draftUserMessage === null &&
+    body.draftAttachments === null
+  );
+}
+
+async function waitForAgentDraftClear(
+  page: Page,
+  clearDraft: () => Promise<void>,
+): Promise<void> {
+  const draftCleared = page.waitForResponse(isSuccessfulAgentDraftClear);
+  await clearDraft();
+  await draftCleared;
 }
 
 function isConnectorCatalogStatusResponse(
@@ -180,6 +208,10 @@ test("chat composer keeps the Send button inside on narrow screens", async ({
     connectorsButton.locator("img:visible, svg:visible"),
   ).toHaveCount(4);
   await expectInside(sendButton, composer);
+
+  await waitForAgentDraftClear(page, async () => {
+    await editor.fill("");
+  });
 });
 
 test("image lightbox centers and pans across the full viewer", async ({
@@ -296,7 +328,9 @@ test("image lightbox centers and pans across the full viewer", async ({
 
   await lightbox.getByRole("button", { name: "Close" }).click();
   await expect(lightbox).toBeHidden();
-  await page.getByRole("button", { name: "Remove lightbox.svg" }).click();
+  await waitForAgentDraftClear(page, async () => {
+    await page.getByRole("button", { name: "Remove lightbox.svg" }).click();
+  });
 });
 
 test("selected avatar and voice cards keep a single border", async ({
@@ -383,4 +417,9 @@ test("selected avatar and voice cards keep a single border", async ({
   const unselectedVoiceEdge = await cardEdgeAppearance(unselectedVoice);
   expect(selectedVoiceEdge.borderWidths).toEqual(["1px", "1px", "1px", "1px"]);
   expect(selectedVoiceEdge).toEqual(unselectedVoiceEdge);
+
+  await page.getByRole("dialog").getByRole("button", { name: "Close" }).click();
+  await waitForAgentDraftClear(page, async () => {
+    await page.getByRole("textbox", { name: "Message" }).fill("");
+  });
 });

--- a/turbo/apps/platform/src/signals/zero-page/agent-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-draft.ts
@@ -221,9 +221,14 @@ export const loadAgentDraft$ = command(
       return;
     }
 
-    const hasLocalDraft =
-      get(draft.input$).trim() !== "" || get(draft.attachments$).length > 0;
-    if (hasLocalDraft) {
+    const hasLocalDraft = (): boolean => {
+      return (
+        get(draft.input$).trim() !== "" ||
+        get(draft.generationTemplate$) !== undefined ||
+        get(draft.attachments$).length > 0
+      );
+    };
+    if (hasLocalDraft()) {
       return;
     }
 
@@ -236,6 +241,13 @@ export const loadAgentDraft$ = command(
       [200],
     );
     signal.throwIfAborted();
+
+    // The composer is interactive while the remote draft loads. Preserve any
+    // input the user added after the request started instead of replacing it
+    // with the older server snapshot.
+    if (hasLocalDraft()) {
+      return;
+    }
 
     const response = zeroAgentDraftResponseSchema.parse(result.body);
     const features = get(featureSwitch$);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -13,10 +13,11 @@ import {
   zeroAgentsByIdContract,
   zeroAgentDraftContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
+import { zeroRunsQueueContract } from "@vm0/api-contracts/contracts/zero-runs";
 import { zeroTeamContract } from "@vm0/api-contracts/contracts/zero-team";
 import { zeroWorkflowsCollectionContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { resetSignal } from "../../../signals/utils.ts";
+import { createDeferredPromise, resetSignal } from "../../../signals/utils.ts";
 import {
   click,
   detachedSetupPage as baseDetachedSetupPage,
@@ -235,6 +236,70 @@ describe("chat drafts", () => {
         screen.getByLabelText("Remove agent-brief.md"),
       ).toBeInTheDocument();
     });
+  });
+
+  it("keeps local edits made while an agent draft is loading", async () => {
+    const agentId = "c0000000-0000-4000-a000-000000000112";
+    const draftResponse = createDeferredPromise<void>(context.signal);
+    let draftRequested = false;
+    mockAgentChatPage(agentId);
+    context.mocks.api(zeroAgentDraftContract.get, async ({ respond }) => {
+      draftRequested = true;
+      await draftResponse.promise;
+      return respond(200, {
+        draftUserMessage: {
+          version: 1,
+          parts: [
+            {
+              type: "file",
+              fileId: "stale-agent-draft-image",
+              filenameSnapshot: "lightbox.svg",
+              contentType: "image/svg+xml",
+            },
+          ],
+        },
+        draftAttachments: [
+          {
+            id: "stale-agent-draft-image",
+            filename: "lightbox.svg",
+            contentType: "image/svg+xml",
+            size: 64,
+            url: "https://cdn.vm7.io/artifacts/test/drafts/lightbox.svg",
+          },
+        ],
+      });
+    });
+    context.mocks.api(zeroRunsQueueContract.getQueue, ({ respond }) => {
+      return respond(200, {
+        concurrency: {
+          tier: "pro",
+          limit: 2,
+          active: 0,
+          available: 2,
+        },
+        queue: [],
+        runningTasks: [],
+        estimatedTimePerRun: null,
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/chat?queue=1`,
+    });
+
+    const editor = await findComposerEditor();
+    await waitFor(() => {
+      expect(draftRequested).toBeTruthy();
+    });
+    await fill(editor, "Local draft created while loading");
+    draftResponse.resolve();
+
+    await screen.findByRole("heading", {
+      name: "Your agent is waiting in line",
+    });
+    expect(editor).toHaveTextContent("Local draft created while loading");
+    expect(screen.queryByLabelText("Remove lightbox.svg")).toBeNull();
   });
 
   it("loads an agent feedback draft from the canonical API", async () => {


### PR DESCRIPTION
## Summary

- preserve composer edits made while an agent draft request is still loading
- add a deterministic regression for a delayed stale attachment draft overwriting local input
- wait for successful server-side draft clearing in Playwright tests that mutate the shared agent draft

## Root cause

[Turbo run 31142272317](https://github.com/vm0-ai/vm0/actions/runs/31142272317) timed out while clicking `Preview template Ada` because the button repeatedly became unstable and detached. The timeout snapshot contained `lightbox.svg`, which came from the preceding image test rather than the avatar test.

The composer becomes interactive before `loadAgentDraft$` finishes. That command checked for local content only before starting the request, then seeded the returned server snapshot unconditionally. A delayed response could therefore replace a template the user had just selected. The preceding Playwright tests also ended immediately after queuing a debounced draft clear, so the shared E2E account could retain the stale attachment snapshot.

The later Clerk `Test ended` message is not causal: the same message appears in successful adjacent runs, including run 31142726661.

## Validation

- deterministic draft-load race regression: 5 consecutive passes; fails without the new post-request guard
- hosted Playwright on final head `52c1429ec9`: [run 31145106845](https://github.com/vm0-ai/vm0/actions/runs/31145106845) attempts 1-5 each passed 11/11 tests
- complete `chat-draft.test.tsx`: 23/23 passed
- Playwright E2E TypeScript check and Clerk fixture integration tests passed
- Playwright target discovery passed
- format, full Turbo lint, Knip, platform/API/remaining workspace type checks, and `git diff --check` passed
