### PR TITLE
fix(runner): prevent drain from missing service restarts

### DIFF
--- a/crates/runner/src/cmd/service/drain_resume.rs
+++ b/crates/runner/src/cmd/service/drain_resume.rs
@@ -11,7 +11,7 @@ use crate::paths::HomePaths;
 use super::drain_override::{remove_drain_restart_override, write_drain_restart_override};
 use super::gate::read_runner_status;
 use super::reload::{SystemdReloadRequirement, coordinate_systemd_reload};
-use super::signal::{ServiceSignalOutcome, signal_service_main};
+use super::signal::{ServiceSignalOutcome, signal_service_main, signal_service_main_bounded};
 use super::systemctl::{
     CleanupUnitActiveState, SystemdUnitEnablement, cleanup_unit_active_state_bounded,
     get_service_restart_policy, is_unit_active_bounded, read_unit_enablement,
@@ -72,6 +72,11 @@ trait ServiceDrainOps {
     fn signal_drain<'a>(
         &'a mut self,
         unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, ServiceSignalOutcome>;
+    fn signal_drain_bounded<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        timeout: Duration,
     ) -> ServiceFuture<'a, ServiceSignalOutcome>;
     fn disable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
     fn restore_enablement<'a>(
@@ -158,6 +163,16 @@ impl ServiceDrainOps for RealServiceDrainOps {
         unit: &'a RunnerServiceUnit,
     ) -> ServiceFuture<'a, ServiceSignalOutcome> {
         Box::pin(async move { signal_service_main(unit, nix::sys::signal::Signal::SIGUSR1).await })
+    }
+
+    fn signal_drain_bounded<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        timeout: Duration,
+    ) -> ServiceFuture<'a, ServiceSignalOutcome> {
+        Box::pin(async move {
+            signal_service_main_bounded(unit, nix::sys::signal::Signal::SIGUSR1, timeout).await
+        })
     }
 
     fn disable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
@@ -502,9 +517,9 @@ async fn wait_for_drain_signal_convergence(
         if now >= deadline {
             continue;
         }
-        let signal_result = tokio::time::timeout(deadline - now, ops.signal_drain(unit))
+        let signal_result = ops
+            .signal_drain_bounded(unit, deadline - now)
             .await
-            .map_err(|_| drain_signal_convergence_timeout_error(unit, &last_active_state))?
             .map_err(|error| {
                 drain_signal_convergence_error(
                     unit,
@@ -952,6 +967,7 @@ mod tests {
         restart_policy_error: bool,
         restart_policy: String,
         signal_results: VecDeque<RunnerResult<ServiceSignalOutcome>>,
+        signal_timeouts: Vec<Duration>,
         disable_error: bool,
         restore_enablement_error: bool,
     }
@@ -986,6 +1002,7 @@ mod tests {
                 restart_policy_error: false,
                 restart_policy: "no".to_string(),
                 signal_results: signal_results(ServiceSignalOutcome::Sent, 1),
+                signal_timeouts: Vec::new(),
                 disable_error: false,
                 restore_enablement_error: false,
             }
@@ -1097,6 +1114,20 @@ mod tests {
                 self.signal_results
                     .pop_front()
                     .expect("missing fake drain signal result"),
+            ))
+        }
+
+        fn signal_drain_bounded<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+            timeout: Duration,
+        ) -> ServiceFuture<'a, ServiceSignalOutcome> {
+            self.events.push("signal_drain_bounded");
+            self.signal_timeouts.push(timeout);
+            Box::pin(std::future::ready(
+                self.signal_results
+                    .pop_front()
+                    .expect("missing fake bounded drain signal result"),
             ))
         }
 
@@ -1723,9 +1754,9 @@ mod tests {
                 "restart_policy",
                 "signal_drain",
                 "lifecycle_state",
-                "signal_drain",
+                "signal_drain_bounded",
                 "lifecycle_state",
-                "signal_drain",
+                "signal_drain_bounded",
             ]
         );
         assert_eq!(
@@ -1736,6 +1767,13 @@ mod tests {
             ops.lifecycle_timeouts,
             [
                 DRAIN_SIGNAL_CONVERGENCE_TIMEOUT,
+                DRAIN_SIGNAL_CONVERGENCE_TIMEOUT,
+                DRAIN_SIGNAL_CONVERGENCE_TIMEOUT - DRAIN_SIGNAL_CONVERGENCE_POLL_INTERVAL,
+            ]
+        );
+        assert_eq!(
+            ops.signal_timeouts,
+            [
                 DRAIN_SIGNAL_CONVERGENCE_TIMEOUT,
                 DRAIN_SIGNAL_CONVERGENCE_TIMEOUT - DRAIN_SIGNAL_CONVERGENCE_POLL_INTERVAL,
             ]

--- a/crates/runner/src/cmd/service/drain_resume.rs
+++ b/crates/runner/src/cmd/service/drain_resume.rs
@@ -13,11 +13,14 @@ use super::gate::read_runner_status;
 use super::reload::{SystemdReloadRequirement, coordinate_systemd_reload};
 use super::signal::{ServiceSignalOutcome, signal_service_main};
 use super::systemctl::{
-    SystemdUnitEnablement, get_service_restart_policy, is_unit_active, is_unit_active_bounded,
-    read_unit_enablement, restore_unit_enablement, run_systemctl,
+    CleanupUnitActiveState, SystemdUnitEnablement, cleanup_unit_active_state_bounded,
+    get_service_restart_policy, is_unit_active_bounded, read_unit_enablement,
+    restore_unit_enablement, run_systemctl,
 };
 use super::{RunnerServiceUnit, ServiceFuture, acquire_service_lock};
 
+const DRAIN_SIGNAL_CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(10);
+const DRAIN_SIGNAL_CONVERGENCE_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const RESUME_ACKNOWLEDGEMENT_TIMEOUT: Duration = Duration::from_secs(10);
 const RESUME_ACKNOWLEDGEMENT_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
@@ -49,7 +52,11 @@ fn ensure_drain_restart_policy_applied(
 }
 
 trait ServiceDrainOps {
-    fn is_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool>;
+    fn lifecycle_state<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        timeout: Duration,
+    ) -> ServiceFuture<'a, CleanupUnitActiveState>;
     fn enablement<'a>(
         &'a mut self,
         unit: &'a RunnerServiceUnit,
@@ -107,8 +114,12 @@ struct RealServiceDrainOps;
 struct RealServiceResumeOps;
 
 impl ServiceDrainOps for RealServiceDrainOps {
-    fn is_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
-        Box::pin(async move { is_unit_active(unit).await })
+    fn lifecycle_state<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        timeout: Duration,
+    ) -> ServiceFuture<'a, CleanupUnitActiveState> {
+        Box::pin(async move { cleanup_unit_active_state_bounded(unit, timeout).await })
     }
 
     fn enablement<'a>(
@@ -419,11 +430,116 @@ async fn resume_enablement_before_transition(
     }
 }
 
+fn drain_signal_convergence_error(unit: &RunnerServiceUnit, detail: &str) -> RunnerError {
+    RunnerError::Internal(format!(
+        "cannot safely complete drain for {} after the original runner exited: {detail}; \
+         Restart=no remains applied; retry service drain",
+        unit.unit_name()
+    ))
+}
+
+fn drain_signal_convergence_timeout_error(
+    unit: &RunnerServiceUnit,
+    last_active_state: &str,
+) -> RunnerError {
+    drain_signal_convergence_error(
+        unit,
+        &format!(
+            "timed out after {}s waiting to signal a replacement runner \
+             (last ActiveState={last_active_state:?})",
+            DRAIN_SIGNAL_CONVERGENCE_TIMEOUT.as_secs()
+        ),
+    )
+}
+
+async fn wait_for_drain_signal_convergence(
+    unit: &RunnerServiceUnit,
+    ops: &mut impl ServiceDrainOps,
+) -> RunnerResult<()> {
+    let deadline = Instant::now() + DRAIN_SIGNAL_CONVERGENCE_TIMEOUT;
+    let mut last_active_state = "unknown".to_string();
+
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(drain_signal_convergence_timeout_error(
+                unit,
+                &last_active_state,
+            ));
+        }
+
+        let state = ops
+            .lifecycle_state(unit, deadline - now)
+            .await
+            .map_err(|error| {
+                drain_signal_convergence_error(
+                    unit,
+                    &format!("cannot read systemd lifecycle state: {error}"),
+                )
+            })?;
+        last_active_state = state.active_state().to_string();
+
+        if !state.is_active_like() {
+            info!(
+                unit = %unit.unit_name(),
+                active_state = %state.active_state(),
+                "runner exited before drain signal convergence"
+            );
+            return Ok(());
+        }
+        if state.active_state() == "deactivating" {
+            // Restart=no was verified before signal delivery. While systemd is
+            // still deactivating it has not committed an auto-restart timer,
+            // so the loaded policy prevents a replacement from appearing.
+            info!(
+                unit = %unit.unit_name(),
+                "runner is deactivating with Restart=no applied; drain signal not needed"
+            );
+            return Ok(());
+        }
+
+        let now = Instant::now();
+        if now >= deadline {
+            continue;
+        }
+        let signal_result = tokio::time::timeout(deadline - now, ops.signal_drain(unit))
+            .await
+            .map_err(|_| drain_signal_convergence_timeout_error(unit, &last_active_state))?
+            .map_err(|error| {
+                drain_signal_convergence_error(
+                    unit,
+                    &format!("cannot signal replacement runner: {error}"),
+                )
+            })?;
+
+        match signal_result {
+            ServiceSignalOutcome::Sent => {
+                info!(unit = %unit.unit_name(), "sent SIGUSR1 (drain) to replacement runner");
+                return Ok(());
+            }
+            ServiceSignalOutcome::AlreadyGone => {}
+        }
+
+        let now = Instant::now();
+        if now >= deadline {
+            continue;
+        }
+        tokio::time::sleep(std::cmp::min(
+            DRAIN_SIGNAL_CONVERGENCE_POLL_INTERVAL,
+            deadline - now,
+        ))
+        .await;
+    }
+}
+
 async fn drain_with_ops(
     unit: &RunnerServiceUnit,
     ops: &mut impl ServiceDrainOps,
 ) -> RunnerResult<()> {
-    let mut should_signal = ops.is_active(unit).await?;
+    let initial_state = ops
+        .lifecycle_state(unit, DRAIN_SIGNAL_CONVERGENCE_TIMEOUT)
+        .await?;
+    let mut should_signal = initial_state.is_active_like();
     let prior_enablement = drain_enablement_before_transition(unit, ops).await;
     if !should_signal {
         info!(unit = %unit.unit_name(), "no active service found; drain signal not needed");
@@ -478,8 +594,11 @@ async fn drain_with_ops(
                 }
             }
             Err(error) => {
-                match ops.is_active(unit).await {
-                    Ok(true) => {
+                match ops
+                    .lifecycle_state(unit, DRAIN_SIGNAL_CONVERGENCE_TIMEOUT)
+                    .await
+                {
+                    Ok(state) if state.is_active_like() => {
                         return Err(drain_error_after_rollback(
                             unit,
                             restart_override_written,
@@ -490,7 +609,7 @@ async fn drain_with_ops(
                         )
                         .await);
                     }
-                    Ok(false) => {}
+                    Ok(_) => {}
                     Err(active_err) => {
                         return Err(drain_error_after_rollback(
                             unit,
@@ -513,9 +632,10 @@ async fn drain_with_ops(
     }
 
     if should_signal {
-        // `is_unit_active` above can race against the runner exiting on its own.
-        // Both outcomes ("live, signal delivered" and "already gone") retain
-        // the already-applied disabled boot state.
+        // The lifecycle query above can race against the runner exiting or an
+        // already-committed auto-restart timer. Once the main process is gone,
+        // retain fail-closed state and converge instead of rolling protections
+        // back into a potentially restarting service.
         match ops.signal_drain(unit).await {
             Err(error) => {
                 return Err(drain_error_after_rollback(
@@ -532,7 +652,7 @@ async fn drain_with_ops(
                 info!(unit = %unit.unit_name(), "sent SIGUSR1 (drain)");
             }
             Ok(ServiceSignalOutcome::AlreadyGone) => {
-                info!(unit = %unit.unit_name(), "runner already exited; drain signal not needed");
+                wait_for_drain_signal_convergence(unit, ops).await?;
             }
         }
     }
@@ -731,7 +851,7 @@ async fn resume_with_ops(
     resume_after_preflight_with_ops(unit, &base_dir, status.started_at, ops).await
 }
 
-/// `service drain` — send SIGUSR1, disable unit, return immediately.
+/// `service drain` — send SIGUSR1 and disable the unit without waiting for jobs.
 pub(super) async fn run_drain(args: DrainArgs) -> RunnerResult<()> {
     let unit = RunnerServiceUnit::from_suffix(&args.name)?;
     let home = HomePaths::new()?;
@@ -778,6 +898,28 @@ mod tests {
         (0..count).map(|_| Ok(true)).collect()
     }
 
+    fn lifecycle_state(active_state: &str) -> RunnerResult<CleanupUnitActiveState> {
+        let active_like = matches!(
+            active_state,
+            "active" | "activating" | "reloading" | "refreshing" | "deactivating"
+        );
+        Ok(CleanupUnitActiveState::for_test(active_state, active_like))
+    }
+
+    fn lifecycle_states(
+        active_state: &str,
+        count: usize,
+    ) -> VecDeque<RunnerResult<CleanupUnitActiveState>> {
+        (0..count).map(|_| lifecycle_state(active_state)).collect()
+    }
+
+    fn signal_results(
+        outcome: ServiceSignalOutcome,
+        count: usize,
+    ) -> VecDeque<RunnerResult<ServiceSignalOutcome>> {
+        (0..count).map(|_| Ok(outcome)).collect()
+    }
+
     async fn write_test_status(base_dir: &Path, mode: &str, started_at: &str) {
         tokio::fs::create_dir_all(base_dir).await.unwrap();
         tokio::fs::write(
@@ -800,7 +942,8 @@ mod tests {
 
     struct FakeDrainOps {
         events: Vec<&'static str>,
-        active_results: VecDeque<RunnerResult<bool>>,
+        lifecycle_state_results: VecDeque<RunnerResult<CleanupUnitActiveState>>,
+        lifecycle_timeouts: Vec<Duration>,
         enablement_results: VecDeque<RunnerResult<SystemdUnitEnablement>>,
         write_error: bool,
         remove_error: bool,
@@ -808,8 +951,7 @@ mod tests {
         reload_requirements: Vec<SystemdReloadRequirement>,
         restart_policy_error: bool,
         restart_policy: String,
-        signal_error: bool,
-        signal_outcome: ServiceSignalOutcome,
+        signal_results: VecDeque<RunnerResult<ServiceSignalOutcome>>,
         disable_error: bool,
         restore_enablement_error: bool,
     }
@@ -834,7 +976,8 @@ mod tests {
         fn default() -> Self {
             Self {
                 events: Vec::new(),
-                active_results: VecDeque::from([Ok(true)]),
+                lifecycle_state_results: lifecycle_states("active", 1),
+                lifecycle_timeouts: Vec::new(),
                 enablement_results: VecDeque::from([Ok(SystemdUnitEnablement::Enabled)]),
                 write_error: false,
                 remove_error: false,
@@ -842,8 +985,7 @@ mod tests {
                 reload_requirements: Vec::new(),
                 restart_policy_error: false,
                 restart_policy: "no".to_string(),
-                signal_error: false,
-                signal_outcome: ServiceSignalOutcome::Sent,
+                signal_results: signal_results(ServiceSignalOutcome::Sent, 1),
                 disable_error: false,
                 restore_enablement_error: false,
             }
@@ -875,10 +1017,17 @@ mod tests {
     }
 
     impl ServiceDrainOps for FakeDrainOps {
-        fn is_active<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
-            self.events.push("is_active");
+        fn lifecycle_state<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+            timeout: Duration,
+        ) -> ServiceFuture<'a, CleanupUnitActiveState> {
+            self.events.push("lifecycle_state");
+            self.lifecycle_timeouts.push(timeout);
             Box::pin(std::future::ready(
-                self.active_results.pop_front().unwrap_or(Ok(false)),
+                self.lifecycle_state_results
+                    .pop_front()
+                    .expect("missing fake lifecycle state result"),
             ))
         }
 
@@ -944,11 +1093,11 @@ mod tests {
             _unit: &'a RunnerServiceUnit,
         ) -> ServiceFuture<'a, ServiceSignalOutcome> {
             self.events.push("signal_drain");
-            Box::pin(std::future::ready(if self.signal_error {
-                Err(fake_error("signal failed"))
-            } else {
-                Ok(self.signal_outcome)
-            }))
+            Box::pin(std::future::ready(
+                self.signal_results
+                    .pop_front()
+                    .expect("missing fake drain signal result"),
+            ))
         }
 
         fn disable<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
@@ -1096,7 +1245,7 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "is_active",
+                "lifecycle_state",
                 "is_enabled",
                 "write_restart_override",
                 "disable",
@@ -1124,7 +1273,7 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "is_active",
+                "lifecycle_state",
                 "is_enabled",
                 "write_restart_override",
                 "disable",
@@ -1139,7 +1288,7 @@ mod tests {
     async fn drain_inactive_service_skips_restart_override_and_signal() {
         let unit = service_unit();
         let mut ops = FakeDrainOps {
-            active_results: VecDeque::from([Ok(false)]),
+            lifecycle_state_results: VecDeque::from([lifecycle_state("inactive")]),
             ..FakeDrainOps::default()
         };
 
@@ -1147,7 +1296,7 @@ mod tests {
 
         assert_eq!(
             ops.events,
-            ["is_active", "is_enabled", "disable", "daemon_reload"]
+            ["lifecycle_state", "is_enabled", "disable", "daemon_reload"]
         );
         assert_eq!(ops.reload_requirements, [SystemdReloadRequirement::dirty()]);
     }
@@ -1165,7 +1314,7 @@ mod tests {
         assert!(err.to_string().contains("write failed"));
         assert_eq!(
             ops.events,
-            ["is_active", "is_enabled", "write_restart_override"]
+            ["lifecycle_state", "is_enabled", "write_restart_override"]
         );
     }
 
@@ -1183,7 +1332,7 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "is_active",
+                "lifecycle_state",
                 "is_enabled",
                 "write_restart_override",
                 "disable",
@@ -1232,7 +1381,7 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "is_active",
+                "lifecycle_state",
                 "is_enabled",
                 "write_restart_override",
                 "disable",
@@ -1249,7 +1398,7 @@ mod tests {
     async fn drain_restart_policy_error_for_still_active_service_aborts_before_signal() {
         let unit = service_unit();
         let mut ops = FakeDrainOps {
-            active_results: VecDeque::from([Ok(true), Ok(true)]),
+            lifecycle_state_results: lifecycle_states("active", 2),
             restart_policy_error: true,
             ..FakeDrainOps::default()
         };
@@ -1260,13 +1409,42 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "is_active",
+                "lifecycle_state",
                 "is_enabled",
                 "write_restart_override",
                 "disable",
                 "daemon_reload",
                 "restart_policy",
-                "is_active",
+                "lifecycle_state",
+                "remove_restart_override",
+                "restore_enabled",
+                "daemon_reload",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_restart_policy_error_for_deactivating_service_aborts_before_signal() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            lifecycle_state_results: lifecycle_states("deactivating", 2),
+            restart_policy_error: true,
+            ..FakeDrainOps::default()
+        };
+
+        let error = drain_with_ops(&unit, &mut ops).await.unwrap_err();
+
+        assert!(error.to_string().contains("restart policy failed"));
+        assert_eq!(
+            ops.events,
+            [
+                "lifecycle_state",
+                "is_enabled",
+                "write_restart_override",
+                "disable",
+                "daemon_reload",
+                "restart_policy",
+                "lifecycle_state",
                 "remove_restart_override",
                 "restore_enabled",
                 "daemon_reload",
@@ -1278,7 +1456,10 @@ mod tests {
     async fn drain_restart_policy_error_with_failed_active_recheck_rolls_back() {
         let unit = service_unit();
         let mut ops = FakeDrainOps {
-            active_results: VecDeque::from([Ok(true), Err(fake_error("active recheck failed"))]),
+            lifecycle_state_results: VecDeque::from([
+                lifecycle_state("active"),
+                Err(fake_error("active recheck failed")),
+            ]),
             restart_policy_error: true,
             ..FakeDrainOps::default()
         };
@@ -1289,13 +1470,13 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "is_active",
+                "lifecycle_state",
                 "is_enabled",
                 "write_restart_override",
                 "disable",
                 "daemon_reload",
                 "restart_policy",
-                "is_active",
+                "lifecycle_state",
                 "remove_restart_override",
                 "restore_enabled",
                 "daemon_reload",
@@ -1307,7 +1488,10 @@ mod tests {
     async fn drain_restart_policy_error_for_exited_service_still_disables_unit() {
         let unit = service_unit();
         let mut ops = FakeDrainOps {
-            active_results: VecDeque::from([Ok(true), Ok(false)]),
+            lifecycle_state_results: VecDeque::from([
+                lifecycle_state("active"),
+                lifecycle_state("inactive"),
+            ]),
             restart_policy_error: true,
             ..FakeDrainOps::default()
         };
@@ -1317,13 +1501,13 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "is_active",
+                "lifecycle_state",
                 "is_enabled",
                 "write_restart_override",
                 "disable",
                 "daemon_reload",
                 "restart_policy",
-                "is_active",
+                "lifecycle_state",
             ]
         );
     }
@@ -1332,7 +1516,7 @@ mod tests {
     async fn drain_signal_failure_rolls_back_restart_override() {
         let unit = service_unit();
         let mut ops = FakeDrainOps {
-            signal_error: true,
+            signal_results: VecDeque::from([Err(fake_error("signal failed"))]),
             ..FakeDrainOps::default()
         };
 
@@ -1342,7 +1526,7 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "is_active",
+                "lifecycle_state",
                 "is_enabled",
                 "write_restart_override",
                 "disable",
@@ -1362,7 +1546,7 @@ mod tests {
         let mut ops = FakeDrainOps {
             remove_error: true,
             reload_errors: VecDeque::from([false, true]),
-            signal_error: true,
+            signal_results: VecDeque::from([Err(fake_error("signal failed"))]),
             restore_enablement_error: true,
             ..FakeDrainOps::default()
         };
@@ -1386,7 +1570,7 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "is_active",
+                "lifecycle_state",
                 "is_enabled",
                 "write_restart_override",
                 "disable",
@@ -1412,7 +1596,7 @@ mod tests {
         let unit = service_unit();
         let mut ops = FakeDrainOps {
             enablement_results: VecDeque::from([Err(fake_error("enablement read failed"))]),
-            signal_error: true,
+            signal_results: VecDeque::from([Err(fake_error("signal failed"))]),
             ..FakeDrainOps::default()
         };
 
@@ -1431,7 +1615,7 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "is_active",
+                "lifecycle_state",
                 "is_enabled",
                 "write_restart_override",
                 "disable",
@@ -1452,10 +1636,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn drain_already_gone_still_disables_unit() {
+    async fn drain_deactivating_service_applies_override_before_safe_completion() {
         let unit = service_unit();
         let mut ops = FakeDrainOps {
-            signal_outcome: ServiceSignalOutcome::AlreadyGone,
+            lifecycle_state_results: lifecycle_states("deactivating", 2),
+            signal_results: signal_results(ServiceSignalOutcome::AlreadyGone, 1),
             ..FakeDrainOps::default()
         };
 
@@ -1464,14 +1649,168 @@ mod tests {
         assert_eq!(
             ops.events,
             [
-                "is_active",
+                "lifecycle_state",
                 "is_enabled",
                 "write_restart_override",
                 "disable",
                 "daemon_reload",
                 "restart_policy",
                 "signal_drain",
+                "lifecycle_state",
             ]
+        );
+        assert!(!ops.events.contains(&"remove_restart_override"));
+    }
+
+    #[tokio::test]
+    async fn drain_already_gone_inactive_service_still_disables_unit() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            lifecycle_state_results: VecDeque::from([
+                lifecycle_state("active"),
+                lifecycle_state("inactive"),
+            ]),
+            signal_results: signal_results(ServiceSignalOutcome::AlreadyGone, 1),
+            ..FakeDrainOps::default()
+        };
+
+        drain_with_ops(&unit, &mut ops).await.unwrap();
+
+        assert_eq!(
+            ops.events,
+            [
+                "lifecycle_state",
+                "is_enabled",
+                "write_restart_override",
+                "disable",
+                "daemon_reload",
+                "restart_policy",
+                "signal_drain",
+                "lifecycle_state",
+            ]
+        );
+        assert!(!ops.events.contains(&"remove_restart_override"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_signals_replacement_after_deactivating_restart_race() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            lifecycle_state_results: VecDeque::from([
+                lifecycle_state("deactivating"),
+                lifecycle_state("activating"),
+                lifecycle_state("active"),
+            ]),
+            signal_results: VecDeque::from([
+                Ok(ServiceSignalOutcome::AlreadyGone),
+                Ok(ServiceSignalOutcome::AlreadyGone),
+                Ok(ServiceSignalOutcome::Sent),
+            ]),
+            ..FakeDrainOps::default()
+        };
+        let started_at = Instant::now();
+
+        drain_with_ops(&unit, &mut ops).await.unwrap();
+
+        assert_eq!(
+            ops.events,
+            [
+                "lifecycle_state",
+                "is_enabled",
+                "write_restart_override",
+                "disable",
+                "daemon_reload",
+                "restart_policy",
+                "signal_drain",
+                "lifecycle_state",
+                "signal_drain",
+                "lifecycle_state",
+                "signal_drain",
+            ]
+        );
+        assert_eq!(
+            Instant::now() - started_at,
+            DRAIN_SIGNAL_CONVERGENCE_POLL_INTERVAL
+        );
+        assert_eq!(
+            ops.lifecycle_timeouts,
+            [
+                DRAIN_SIGNAL_CONVERGENCE_TIMEOUT,
+                DRAIN_SIGNAL_CONVERGENCE_TIMEOUT,
+                DRAIN_SIGNAL_CONVERGENCE_TIMEOUT - DRAIN_SIGNAL_CONVERGENCE_POLL_INTERVAL,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_convergence_state_failure_retains_restart_override() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            lifecycle_state_results: VecDeque::from([
+                lifecycle_state("active"),
+                Err(fake_error("state recheck failed")),
+            ]),
+            signal_results: signal_results(ServiceSignalOutcome::AlreadyGone, 1),
+            ..FakeDrainOps::default()
+        };
+
+        let error = drain_with_ops(&unit, &mut ops).await.unwrap_err();
+
+        assert!(error.to_string().contains("state recheck failed"));
+        assert!(error.to_string().contains("Restart=no remains applied"));
+        assert!(!ops.events.contains(&"remove_restart_override"));
+        assert!(!ops.events.contains(&"restore_enabled"));
+    }
+
+    #[tokio::test]
+    async fn drain_convergence_signal_failure_retains_restart_override() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            lifecycle_state_results: VecDeque::from([
+                lifecycle_state("active"),
+                lifecycle_state("activating"),
+            ]),
+            signal_results: VecDeque::from([
+                Ok(ServiceSignalOutcome::AlreadyGone),
+                Err(fake_error("replacement signal failed")),
+            ]),
+            ..FakeDrainOps::default()
+        };
+
+        let error = drain_with_ops(&unit, &mut ops).await.unwrap_err();
+
+        assert!(error.to_string().contains("replacement signal failed"));
+        assert!(error.to_string().contains("Restart=no remains applied"));
+        assert!(!ops.events.contains(&"remove_restart_override"));
+        assert!(!ops.events.contains(&"restore_enabled"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_convergence_timeout_is_bounded_and_retains_restart_override() {
+        let unit = service_unit();
+        let attempts = (DRAIN_SIGNAL_CONVERGENCE_TIMEOUT.as_millis()
+            / DRAIN_SIGNAL_CONVERGENCE_POLL_INTERVAL.as_millis()) as usize
+            + 1;
+        let mut ops = FakeDrainOps {
+            lifecycle_state_results: lifecycle_states("activating", attempts),
+            signal_results: signal_results(ServiceSignalOutcome::AlreadyGone, attempts),
+            ..FakeDrainOps::default()
+        };
+        let started_at = Instant::now();
+
+        let error = drain_with_ops(&unit, &mut ops).await.unwrap_err();
+
+        assert_eq!(
+            Instant::now() - started_at,
+            DRAIN_SIGNAL_CONVERGENCE_TIMEOUT
+        );
+        assert!(error.to_string().contains("timed out after 10s"));
+        assert!(error.to_string().contains("Restart=no remains applied"));
+        assert!(!ops.events.contains(&"remove_restart_override"));
+        assert!(!ops.events.contains(&"restore_enabled"));
+        assert_eq!(
+            ops.reload_requirements,
+            [SystemdReloadRequirement::dirty().with_drain_override(true)]
         );
     }
 

--- a/crates/runner/src/cmd/service/drain_resume.rs
+++ b/crates/runner/src/cmd/service/drain_resume.rs
@@ -447,7 +447,7 @@ async fn resume_enablement_before_transition(
 
 fn drain_signal_convergence_error(unit: &RunnerServiceUnit, detail: &str) -> RunnerError {
     RunnerError::Internal(format!(
-        "cannot safely complete drain for {} after the original runner exited: {detail}; \
+        "cannot safely complete drain for {} while converging signal delivery: {detail}; \
          Restart=no remains applied; retry service drain",
         unit.unit_name()
     ))
@@ -460,7 +460,7 @@ fn drain_signal_convergence_timeout_error(
     drain_signal_convergence_error(
         unit,
         &format!(
-            "timed out after {}s waiting to signal a replacement runner \
+            "timed out after {}s waiting to signal an active runner \
              (last ActiveState={last_active_state:?})",
             DRAIN_SIGNAL_CONVERGENCE_TIMEOUT.as_secs()
         ),
@@ -523,13 +523,13 @@ async fn wait_for_drain_signal_convergence(
             .map_err(|error| {
                 drain_signal_convergence_error(
                     unit,
-                    &format!("cannot signal replacement runner: {error}"),
+                    &format!("cannot signal active runner: {error}"),
                 )
             })?;
 
         match signal_result {
             ServiceSignalOutcome::Sent => {
-                info!(unit = %unit.unit_name(), "sent SIGUSR1 (drain) to replacement runner");
+                info!(unit = %unit.unit_name(), "sent SIGUSR1 (drain) during signal convergence");
                 return Ok(());
             }
             ServiceSignalOutcome::AlreadyGone => {}
@@ -653,15 +653,12 @@ async fn drain_with_ops(
         // back into a potentially restarting service.
         match ops.signal_drain(unit).await {
             Err(error) => {
-                return Err(drain_error_after_rollback(
-                    unit,
-                    restart_override_written,
-                    prior_enablement,
-                    ops,
-                    "signal_drain",
-                    error,
-                )
-                .await);
+                warn!(
+                    unit = %unit.unit_name(),
+                    error = %error,
+                    "initial drain signal failed; retaining Restart=no while converging"
+                );
+                wait_for_drain_signal_convergence(unit, ops).await?;
             }
             Ok(ServiceSignalOutcome::Sent) => {
                 info!(unit = %unit.unit_name(), "sent SIGUSR1 (drain)");
@@ -1543,17 +1540,20 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn drain_signal_failure_rolls_back_restart_override() {
+    #[tokio::test(start_paused = true)]
+    async fn drain_signal_failure_converges_without_rollback() {
         let unit = service_unit();
         let mut ops = FakeDrainOps {
-            signal_results: VecDeque::from([Err(fake_error("signal failed"))]),
+            lifecycle_state_results: lifecycle_states("active", 2),
+            signal_results: VecDeque::from([
+                Err(fake_error("initial signal failed")),
+                Ok(ServiceSignalOutcome::Sent),
+            ]),
             ..FakeDrainOps::default()
         };
 
-        let err = drain_with_ops(&unit, &mut ops).await.unwrap_err();
+        drain_with_ops(&unit, &mut ops).await.unwrap();
 
-        assert!(err.to_string().contains("signal failed"));
         assert_eq!(
             ops.events,
             [
@@ -1564,106 +1564,13 @@ mod tests {
                 "daemon_reload",
                 "restart_policy",
                 "signal_drain",
-                "remove_restart_override",
-                "restore_enabled",
-                "daemon_reload",
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn drain_signal_failure_reports_rollback_failures() {
-        let unit = service_unit();
-        let mut ops = FakeDrainOps {
-            remove_error: true,
-            reload_errors: VecDeque::from([false, true]),
-            signal_results: VecDeque::from([Err(fake_error("signal failed"))]),
-            restore_enablement_error: true,
-            ..FakeDrainOps::default()
-        };
-
-        let error = drain_with_ops(&unit, &mut ops).await.unwrap_err();
-        let message = error.to_string();
-
-        assert!(message.contains(
-            "drain failed for vm0-runner-test: internal error: signal failed; additionally rollback failed"
-        ));
-        assert!(
-            message.contains(
-                "failed to roll back drain transition for vm0-runner-test (signal_drain)"
-            )
-        );
-        assert!(message.contains("remove drain restart override: internal error: remove failed"));
-        assert!(
-            message.contains("restore boot enablement: internal error: restore enablement failed")
-        );
-        assert!(message.contains("reload restored systemd state: internal error: reload failed"));
-        assert_eq!(
-            ops.events,
-            [
                 "lifecycle_state",
-                "is_enabled",
-                "write_restart_override",
-                "disable",
-                "daemon_reload",
-                "restart_policy",
-                "signal_drain",
-                "remove_restart_override",
-                "restore_enabled",
-                "daemon_reload",
+                "signal_drain_bounded",
             ]
         );
-        assert_eq!(
-            ops.reload_requirements,
-            [
-                SystemdReloadRequirement::dirty().with_drain_override(true),
-                SystemdReloadRequirement::dirty().with_drain_override(false),
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn drain_signal_failure_reports_unavailable_prior_enablement() {
-        let unit = service_unit();
-        let mut ops = FakeDrainOps {
-            enablement_results: VecDeque::from([Err(fake_error("enablement read failed"))]),
-            signal_results: VecDeque::from([Err(fake_error("signal failed"))]),
-            ..FakeDrainOps::default()
-        };
-
-        let error = drain_with_ops(&unit, &mut ops).await.unwrap_err();
-        let message = error.to_string();
-
-        assert!(message.contains(
-            "drain failed for vm0-runner-test: internal error: signal failed; additionally rollback failed"
-        ));
-        assert!(
-            message.contains(
-                "failed to roll back drain transition for vm0-runner-test (signal_drain)"
-            )
-        );
-        assert!(message.contains("prior boot enablement is unavailable"));
-        assert_eq!(
-            ops.events,
-            [
-                "lifecycle_state",
-                "is_enabled",
-                "write_restart_override",
-                "disable",
-                "daemon_reload",
-                "restart_policy",
-                "signal_drain",
-                "remove_restart_override",
-                "daemon_reload",
-            ]
-        );
-        assert_eq!(
-            ops.reload_requirements,
-            [
-                SystemdReloadRequirement::dirty().with_drain_override(true),
-                SystemdReloadRequirement::dirty().with_drain_override(false),
-            ]
-        );
+        assert_eq!(ops.signal_timeouts, [DRAIN_SIGNAL_CONVERGENCE_TIMEOUT]);
+        assert!(!ops.events.contains(&"remove_restart_override"));
+        assert!(!ops.events.contains(&"restore_enabled"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/service/signal.rs
+++ b/crates/runner/src/cmd/service/signal.rs
@@ -1,9 +1,14 @@
 use std::process::ExitStatus;
+use std::time::Duration;
+
+use tokio::time::Instant;
 
 use crate::error::{RunnerError, RunnerResult};
 
 use super::diagnostic::status_field_preview;
-use super::systemctl::has_service_main_process;
+use super::systemctl::{
+    has_service_main_process, has_service_main_process_bounded, run_command_output_bounded,
+};
 use super::target::RunnerServiceUnit;
 
 /// Outcome of asking systemd to signal a unit's main process.
@@ -54,6 +59,51 @@ pub(super) async fn signal_service_main(
     }
 }
 
+/// Ask systemd to signal the current main process within a cleanup deadline.
+///
+/// Unlike an outer future timeout, the bounded command path kills and reaps a
+/// timed-out `systemctl` child before returning.
+pub(super) async fn signal_service_main_bounded(
+    unit: &RunnerServiceUnit,
+    signal: nix::sys::signal::Signal,
+    duration: Duration,
+) -> RunnerResult<ServiceSignalOutcome> {
+    let deadline = Instant::now() + duration;
+    let signal_arg = format!("--signal={}", signal.as_str());
+    let output = run_command_output_bounded(
+        "systemctl",
+        &[
+            "kill",
+            "--kill-whom=main",
+            signal_arg.as_str(),
+            unit.service_name(),
+        ],
+        duration,
+    )
+    .await
+    .map_err(|error| {
+        RunnerError::Internal(format!(
+            "signal {} with systemctl for {}: {error}",
+            signal.as_str(),
+            unit.service_name()
+        ))
+    })?;
+
+    if output.status.success() {
+        return Ok(ServiceSignalOutcome::Sent);
+    }
+
+    let signal_error = systemctl_kill_error(unit, signal, output.status, &output.stderr);
+    let now = Instant::now();
+    if now >= deadline {
+        return Err(signal_error);
+    }
+    match has_service_main_process_bounded(unit, deadline - now).await {
+        Ok(false) => Ok(ServiceSignalOutcome::AlreadyGone),
+        Ok(true) | Err(_) => Err(signal_error),
+    }
+}
+
 fn systemctl_kill_error(
     unit: &RunnerServiceUnit,
     signal: nix::sys::signal::Signal,
@@ -97,8 +147,9 @@ printf '%s\n' "$*" >> "$VM0_RUN_SERVICE_SIGNAL_INVOCATIONS"
 
 if [ "$1" = "kill" ]; then
   case "$VM0_RUN_SERVICE_SIGNAL_SCENARIO" in
-    success-*) exit 0 ;;
-    absent|live|recheck-failed)
+    success-*|bounded-success) exit 0 ;;
+    bounded-timeout) while :; do :; done ;;
+    absent|bounded-absent|live|recheck-failed)
       printf '%s\n' 'signal delivery failed' >&2
       exit 1
       ;;
@@ -107,7 +158,7 @@ fi
 
 if [ "$1" = "show" ]; then
   case "$VM0_RUN_SERVICE_SIGNAL_SCENARIO" in
-    absent)
+    absent|bounded-absent)
       printf '%s\n' 'LoadState=loaded' 'MainPID=0'
       exit 0
       ;;
@@ -167,6 +218,28 @@ exit 2
 
         assert_eq!(
             invocations,
+            vec![expected_kill_invocation(signal), expected_show_invocation()]
+        );
+    }
+
+    #[tokio::test]
+    async fn signal_service_main_bounded_times_out_systemctl() {
+        let signal = nix::sys::signal::Signal::SIGUSR1;
+        let invocations = run_signal_scenario("bounded-timeout", signal).await;
+
+        assert_eq!(invocations, vec![expected_kill_invocation(signal)]);
+    }
+
+    #[tokio::test]
+    async fn signal_service_main_bounded_preserves_signal_outcomes() {
+        let signal = nix::sys::signal::Signal::SIGUSR1;
+
+        let sent_invocations = run_signal_scenario("bounded-success", signal).await;
+        assert_eq!(sent_invocations, vec![expected_kill_invocation(signal)]);
+
+        let gone_invocations = run_signal_scenario("bounded-absent", signal).await;
+        assert_eq!(
+            gone_invocations,
             vec![expected_kill_invocation(signal), expected_show_invocation()]
         );
     }
@@ -232,13 +305,20 @@ exit 2
             value => panic!("unexpected signal scenario value: {value:?}"),
         };
         let unit = RunnerServiceUnit::from_suffix("test").unwrap();
-        let result = signal_service_main(&unit, signal).await;
+        let result = if scenario.starts_with("bounded-") {
+            signal_service_main_bounded(&unit, signal, Duration::from_millis(100)).await
+        } else {
+            signal_service_main(&unit, signal).await
+        };
 
         match scenario.as_str() {
             "success-sigusr1" | "success-sigusr2" => {
                 assert_eq!(result.unwrap(), ServiceSignalOutcome::Sent);
             }
-            "absent" => {
+            "bounded-success" => {
+                assert_eq!(result.unwrap(), ServiceSignalOutcome::Sent);
+            }
+            "absent" | "bounded-absent" => {
                 assert_eq!(result.unwrap(), ServiceSignalOutcome::AlreadyGone);
             }
             "live" | "recheck-failed" => {
@@ -250,6 +330,13 @@ exit 2
                 assert!(
                     !error.contains("state lookup failed"),
                     "recheck error replaced original failure: {error}"
+                );
+            }
+            "bounded-timeout" => {
+                let error = result.unwrap_err().to_string();
+                assert!(
+                    error.contains("systemctl timed out after 100ms"),
+                    "unexpected error: {error}"
                 );
             }
             unexpected => panic!("unexpected service signal scenario: {unexpected}"),

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -91,7 +91,7 @@ async fn run_command_bounded(
     }
 }
 
-async fn run_command_output_bounded(
+pub(super) async fn run_command_output_bounded(
     program: &str,
     args: &[&str],
     duration: Duration,
@@ -609,10 +609,29 @@ pub(super) async fn has_service_main_process(unit: &RunnerServiceUnit) -> Runner
     let svc = unit.service_name();
     let properties = ["LoadState", "MainPID"];
     let output = run_systemctl_show(svc, &properties).await?;
-    let values = parse_systemctl_show_output(svc, &properties, &output)?;
+    service_main_process_from_output(svc, &properties, &output)
+}
+
+/// Check for a systemd main process while bounding the query and child cleanup.
+pub(super) async fn has_service_main_process_bounded(
+    unit: &RunnerServiceUnit,
+    duration: Duration,
+) -> RunnerResult<bool> {
+    let svc = unit.service_name();
+    let properties = ["LoadState", "MainPID"];
+    let output = run_systemctl_show_bounded(svc, &properties, duration).await?;
+    service_main_process_from_output(svc, &properties, &output)
+}
+
+fn service_main_process_from_output(
+    svc: &str,
+    properties: &[&str],
+    output: &Output,
+) -> RunnerResult<bool> {
+    let values = parse_systemctl_show_output(svc, properties, output)?;
     service_main_process_present_from_systemctl_show(
         svc,
-        &properties,
+        properties,
         &output.status,
         &values,
         &output.stderr,


### PR DESCRIPTION
## Summary

- treat `deactivating` runner services as lifecycle-active so drain installs and verifies runtime `Restart=no` protection before signaling
- converge both `AlreadyGone` races and ambiguous initial signal failures until an active runner is signaled or systemd reaches a safe state
- keep convergence failures fail-closed with `Restart=no` retained and a shared 10-second deadline
- kill and reap bounded `systemctl` children when signal or follow-up state queries time out

## Scope

- changes runner CLI systemd drain and signal orchestration only
- does not change APIs, runner protocols, queue payloads, persisted data, migrations, or normal soft-drain semantics
- preserves rollback for failures before restart protection is verified; signal-delivery uncertainty retains that protection instead

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::service::drain_resume`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `git diff --check`

Closes #25482
