### PR TITLE
feat: add logto machine-to-machine auth provider

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -130,7 +130,7 @@ const PRIVATE_VALUE = "SECRET_TOKEN";
 const DEFAULT_API_VERSION = apiPackage.version;
 const ZERO_DIGEST = `sha256:${"0".repeat(64)}`;
 const EXPECTED_CAPABILITY_DIGEST =
-  "sha256:343b46bc40d126a2c1174e2019f113576669dd79478d66095175824f2eb0b935";
+  "sha256:a3e06157aba5729831a7be0f4a421e44e0a81b19b739ac54131668e44dd8bd37";
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -84,6 +84,7 @@ import { googleSearchConsoleProvider } from "./connectors/google-search-console/
 import { googleSheetsProvider } from "./connectors/google-sheets/provider";
 import { larkProvider } from "./connectors/lark/provider";
 import { linearProvider } from "./connectors/linear/provider";
+import { logtoProvider } from "./connectors/logto/provider";
 import { mailchimpProvider } from "./connectors/mailchimp/provider";
 import { mercuryProvider } from "./connectors/mercury/provider";
 import { microsoft365Provider } from "./connectors/microsoft-365/provider";
@@ -1006,6 +1007,7 @@ const CONNECTOR_AUTH_METHOD_PROVIDER_ENTRIES = [
   refreshProviderEntry("lark", "api-token", larkProvider),
   authCodeProviderEntry("intervals-icu", "oauth", intervalsIcuProvider),
   authCodeRefreshTokenRevokeProviderEntry("linear", "oauth", linearProvider),
+  refreshProviderEntry("logto", "m2m", logtoProvider),
   authCodeProviderEntry("mailchimp", "oauth", mailchimpProvider),
   authCodeRefreshProviderEntry("mercury", "oauth", mercuryProvider),
   authCodeRefreshProviderEntry("microsoft-365", "oauth", microsoft365Provider),

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/connector-backlog.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/connector-backlog.test.ts
@@ -14,6 +14,7 @@ import {
   exchangeDatadogCode,
   refreshDatadogToken,
 } from "../datadog/oauth";
+import { fetchLogtoAccessToken } from "../logto/m2m";
 import { refreshNetSuiteAccessToken } from "../netsuite/api-token";
 import { fetchPayPalAccessToken } from "../paypal/api-token";
 import { fetchRampAccessToken } from "../ramp/api-token";
@@ -255,6 +256,54 @@ describe("connector backlog auth providers", () => {
     expect(authorization).toBe(
       `Basic ${Buffer.from("client-id:client-secret").toString("base64")}`,
     );
+  });
+
+  it("gets a Logto Management API token for the tenant endpoint", async () => {
+    let grantType: string | null = null;
+    let resource: string | null = null;
+    let scope: string | null = null;
+    let authorization: string | null = null;
+    server.use(
+      http.post("https://acme.logto.app/oidc/token", async ({ request }) => {
+        const body = new URLSearchParams(await request.text());
+        grantType = body.get("grant_type");
+        resource = body.get("resource");
+        scope = body.get("scope");
+        authorization = request.headers.get("authorization");
+        return HttpResponse.json({
+          access_token: "logto-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+          scope: "all",
+        });
+      }),
+    );
+
+    await expect(
+      fetchLogtoAccessToken({
+        tenantId: "acme",
+        appId: "app-id",
+        appSecret: "app-secret",
+        signal,
+      }),
+    ).resolves.toEqual({ accessToken: "logto-token", expiresIn: 3600 });
+    expect(grantType).toBe("client_credentials");
+    expect(resource).toBe("https://acme.logto.app/api");
+    expect(scope).toBe("all");
+    expect(authorization).toBe(
+      `Basic ${Buffer.from("app-id:app-secret").toString("base64")}`,
+    );
+  });
+
+  it("rejects a Logto tenant ID that would redirect the token request", async () => {
+    await expect(
+      fetchLogtoAccessToken({
+        tenantId: "acme.evil.example.com",
+        appId: "app-id",
+        appSecret: "app-secret",
+        signal,
+      }),
+    ).rejects.toThrow("Invalid Logto tenant ID");
   });
 
   it("gets a PayPal client-credentials token", async () => {

--- a/turbo/packages/connectors/src/auth-providers/connectors/logto/m2m.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/logto/m2m.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+import { ProviderHttpError, ProviderResponseError } from "../../provider-error";
+
+const TENANT_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/i;
+
+export async function fetchLogtoAccessToken(args: {
+  readonly tenantId: string;
+  readonly appId: string;
+  readonly appSecret: string;
+  readonly signal: AbortSignal;
+}) {
+  if (!TENANT_ID.test(args.tenantId)) {
+    throw new Error("Invalid Logto tenant ID");
+  }
+  const tenantId = args.tenantId.toLowerCase();
+  // Logto Cloud does not serve the token endpoint on a tenant's custom domain,
+  // so the default tenant endpoint is the only valid host here.
+  const response = await fetch(`https://${tenantId}.logto.app/oidc/token`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${args.appId}:${args.appSecret}`).toString("base64")}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "client_credentials",
+      resource: `https://${tenantId}.logto.app/api`,
+      scope: "all",
+    }),
+    signal: args.signal,
+  });
+  if (!response.ok) {
+    throw new ProviderHttpError(
+      `Logto access token request failed: ${response.status}`,
+      response.status,
+    );
+  }
+  const parsed = z
+    .object({
+      access_token: z.string().min(1),
+      expires_in: z.number().positive(),
+    })
+    .safeParse(await response.json());
+  if (!parsed.success) {
+    throw new ProviderResponseError("Invalid Logto access token response");
+  }
+  return {
+    accessToken: parsed.data.access_token,
+    expiresIn: parsed.data.expires_in,
+  };
+}

--- a/turbo/packages/connectors/src/auth-providers/connectors/logto/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/logto/provider.ts
@@ -1,0 +1,20 @@
+import type { RefreshTokenAccessProvider } from "../../types";
+import { fetchLogtoAccessToken } from "./m2m";
+
+export const logtoProvider = {
+  access: {
+    kind: "refresh-token",
+    refresh: async (args) => {
+      const token = await fetchLogtoAccessToken({
+        tenantId: args.inputs.tenantId,
+        appId: args.inputs.appId,
+        appSecret: args.inputs.appSecret,
+        signal: args.signal,
+      });
+      return {
+        outputs: { accessToken: token.accessToken },
+        expiresIn: token.expiresIn,
+      };
+    },
+  } satisfies RefreshTokenAccessProvider<"logto", "m2m">,
+};

--- a/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
@@ -1028,6 +1028,31 @@ export const CONNECTOR_AUTH_PROVIDER_METHOD_REGISTRATIONS = [
     },
   },
   {
+    connectorSlug: "logto",
+    authMethodId: "m2m",
+    contract: {
+      client: {
+        kind: "none",
+      },
+      grant: {
+        kind: "manual",
+        callbackOrigin: null,
+        outputNames: [],
+        startOptionNames: [],
+      },
+      access: {
+        kind: "refresh-token",
+        inputNames: ["appId", "appSecret", "tenantId"],
+        outputNames: ["accessToken"],
+        platformSecrets: [],
+      },
+      revoke: {
+        kind: "none",
+        inputNames: [],
+      },
+    },
+  },
+  {
     connectorSlug: "mailchimp",
     authMethodId: "oauth",
     contract: {


### PR DESCRIPTION
Closes #25570.

Runtime prerequisite for the Logto connector bundle in `vm0-ai/vm0-connectors`.

## Why

Logto's Management API only accepts a short-lived access token minted with the OAuth 2.0 client-credentials grant by a machine-to-machine application. The token response carries `"expires_in": 3600` and Logto issues no long-lived Management API key, so the connector cannot use `manual` + `static` access. It needs `manual` + `refresh-token`, and `vm0` owns that executable half.

Contract, matching the existing `ramp` / `paypal` / `netsuite` / `lark` shape:

| Field | Value |
| --- | --- |
| `client` | `none` |
| `grant` | `manual` |
| `access` | `refresh-token`, inputs `appId`, `appSecret`, `tenantId`, output `accessToken` |
| `revoke` | `none` |

## What this adds

- `connectors/logto/m2m.ts` — posts `grant_type=client_credentials`, `resource=https://<tenant-id>.logto.app/api`, `scope=all` to `https://<tenant-id>.logto.app/oidc/token` with HTTP Basic credentials, and returns the access token with its `expires_in`.
- `connectors/logto/provider.ts` — the `RefreshTokenAccessProvider`.
- `(logto, m2m)` registration in `provider-capabilities.ts` and `connector-auth.ts`.
- Two cases in `connectors/__tests__/connector-backlog.test.ts`.

The tenant ID is validated against `^[a-z0-9]+(?:-[a-z0-9]+)*$` before it is interpolated into the token URL and the resource indicator, so a tenant ID such as `acme.evil.example.com` cannot redirect the credentialed request to another host. A test covers that rejection.

Logto Cloud does not serve the token endpoint on a tenant's custom domain, so the default `<tenant-id>.logto.app` endpoint is the only host used.

## Scope

No new platform secret, feature switch, or billing capability. No change to any existing provider.

## Sources

- <https://docs.logto.io/integrate-logto/interact-with-management-api>
- <https://openapi.logto.io/source.json> — `components.securitySchemes.OAuth2.flows.clientCredentials` declares `tokenUrl: /oidc/token` and the `all` scope.

## Verification

```
pnpm -F @vm0/connectors exec vitest run   40 files, 907 tests passed
pnpm -F @vm0/connectors exec tsc --noEmit clean
pnpm -F @vm0/connectors exec eslint src/auth-providers  clean
pnpm exec prettier --check "packages/connectors/src/auth-providers/**/*.ts"  clean
```

## Follow-up

The `vm0-ai/vm0-connectors` Logto bundle depends on this. It must not merge until this is deployed to development and production, otherwise `connector-catalog-compatibility` filters the connector's only auth method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
