### PR TITLE
fix(ably-subscriber): treat cleanup broken pipe as closed

### DIFF
--- a/crates/ably-subscriber/src/connection/event_loop.rs
+++ b/crates/ably-subscriber/src/connection/event_loop.rs
@@ -19,8 +19,8 @@ use super::message::{decode_data, message_targets_channel};
 use super::session::{SessionState, TokenRenewalFailure};
 use super::state::{ChannelLifecycleState, reconnect_spacing_delay, retry_delay};
 use super::transport::{
-    TransportCloseTracker, WsTransport, connect_pending, websocket_close_frame_reason,
-    websocket_close_reason, websocket_error_reason,
+    TransportCloseTracker, WsTransport, close_websocket_sink, connect_pending,
+    websocket_close_frame_reason, websocket_close_reason, websocket_error_reason,
 };
 use crate::Error;
 use crate::protocol::{
@@ -145,7 +145,7 @@ async fn send_close_message(p: &mut EventLoopState) -> Result<(), Error> {
                     .map_err(Error::from),
                 Err(error) => Err(error),
             };
-            let websocket_result = ws_write.close().await.map_err(Error::from);
+            let websocket_result = close_websocket_sink(&mut ws_write).await;
             match (protocol_result, websocket_result) {
                 (Ok(()), result) | (result, Ok(())) => result,
                 (Err(error), Err(close_error)) => {

--- a/crates/ably-subscriber/src/connection/transport.rs
+++ b/crates/ably-subscriber/src/connection/transport.rs
@@ -129,7 +129,7 @@ impl WsTransport {
             mut ws_write,
         } = self;
         drop(ws_read);
-        tokio::time::timeout(close_timeout, ws_write.close())
+        tokio::time::timeout(close_timeout, close_websocket_sink(&mut ws_write))
             .await
             .map_err(|_| Error::Protocol {
                 code: error_code::TIMEOUT,
@@ -144,6 +144,16 @@ impl WsTransport {
         tracker: &TransportCloseTracker,
     ) {
         tracker.spawn(self, close_timeout);
+    }
+}
+
+pub(super) async fn close_websocket_sink(ws_write: &mut WsWrite) -> Result<(), Error> {
+    match ws_write.close().await {
+        Ok(()) => Ok(()),
+        Err(tungstenite::Error::Io(error)) if error.kind() == std::io::ErrorKind::BrokenPipe => {
+            Ok(())
+        }
+        Err(error) => Err(error.into()),
     }
 }
 

--- a/crates/ably-subscriber/tests/integration/close_drop.rs
+++ b/crates/ably-subscriber/tests/integration/close_drop.rs
@@ -9,6 +9,8 @@ use std::collections::HashMap;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_tungstenite::tungstenite;
+use tracing_subscriber::prelude::*;
+use tracing_test_support::CapturedEvents;
 
 #[tokio::test]
 async fn websocket_close_assertion_preserves_protocol_error() {
@@ -78,6 +80,62 @@ async fn close_subscription() {
     sub.close_and_wait().await.unwrap();
 
     join_server_task(server_task, "mock server").await.unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn peer_reset_during_transport_cleanup_is_idempotent() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (reset_tx, reset_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        reset_rx.await.unwrap();
+        conn.get_ref().set_zero_linger().unwrap();
+        drop(conn);
+    });
+
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let mut timing = TimingConfig::default();
+    timing.min_reconnect_interval = Duration::from_secs(30);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    expect_connected(&mut sub, "Connected event").await.unwrap();
+    reset_tx.send(()).unwrap();
+    let event = expect_event(&mut sub, "peer reset").await.unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    let close_result = sub.close_and_wait().await;
+    join_server_task(server_task, "resetting mock server")
+        .await
+        .unwrap();
+    let events = captured.entries();
+    assert!(
+        close_result.is_ok(),
+        "peer-already-gone transport cleanup failed: {close_result:?}; events={events:#?}"
+    );
+    assert!(
+        !events.iter().any(|event| {
+            event
+                .fields
+                .get("message")
+                .is_some_and(|message| message == "Failed to close websocket transport")
+                && event
+                    .fields
+                    .get("error")
+                    .is_some_and(|error| error.contains("Broken pipe"))
+        }),
+        "peer-already-gone transport cleanup emitted a BrokenPipe warning: {events:#?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- treat an exact `BrokenPipe` returned while closing a discarded WebSocket sink as successful idempotent cleanup
- share the classification between detached transport cleanup and caller-requested WebSocket shutdown
- preserve Ably protocol `CLOSE` send failures, timeouts, and every other WebSocket error
- cover the production interleaving with a synchronized local peer reset that previously emitted the warning

## Scope

This does not broaden accepted peer-disconnect errors, change the public API, or alter runner/API protocols or persisted state.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p ably-subscriber --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p ably-subscriber --all-features --no-deps`
- `cargo test -p ably-subscriber --all-targets --all-features`
- focused peer-reset regression repeated 20 times
- repository pre-commit Rust format, workspace Clippy, workspace documentation, file-size, and commit-message hooks

Closes #25557
