### PR TITLE
fix(guest-agent): classify credit error envelopes

### DIFF
--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -378,6 +378,26 @@ fn is_insufficient_credits_error(normalized: &str) -> bool {
         || (normalized.contains("api error: 402")
             && normalized.contains("requires more credits")
             && normalized.contains("can only afford"))
+        || has_insufficient_credits_response_envelope(normalized)
+}
+
+fn has_insufficient_credits_response_envelope(normalized: &str) -> bool {
+    const STATUS_MARKER: &str = "402 payment required";
+
+    let Some(status_index) = normalized.find(STATUS_MARKER) else {
+        return false;
+    };
+
+    let mut search_start = status_index + STATUS_MARKER.len();
+    while let Some((value, end_index)) = parse_next_json_object(normalized, search_start) {
+        if value.as_ref().is_some_and(|value| {
+            value.get("error").and_then(Value::as_str) == Some("insufficient_credits")
+        }) {
+            return true;
+        }
+        search_start = end_index;
+    }
+    false
 }
 
 fn is_claude_invalid_credentials_error(normalized: &str) -> bool {

--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -388,16 +388,13 @@ fn has_insufficient_credits_response_envelope(normalized: &str) -> bool {
         return false;
     };
 
-    let mut search_start = status_index + STATUS_MARKER.len();
-    while let Some((value, end_index)) = parse_next_json_object(normalized, search_start) {
-        if value.as_ref().is_some_and(|value| {
-            value.get("error").and_then(Value::as_str) == Some("insufficient_credits")
-        }) {
-            return true;
-        }
-        search_start = end_index;
-    }
-    false
+    let Some((Some(value), _)) =
+        parse_next_json_object(normalized, status_index + STATUS_MARKER.len())
+    else {
+        return false;
+    };
+
+    value.get("error").and_then(Value::as_str) == Some("insufficient_credits")
 }
 
 fn is_claude_invalid_credentials_error(normalized: &str) -> bool {

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -412,6 +412,8 @@ fn cli_failure_reason_ignores_unverified_insufficient_credits_envelopes() {
         r#"unexpected status 402 Payment Required: {"debug":{"error":"insufficient_credits"}}"#,
         r#"provider response: {"error":"insufficient_credits"}"#,
         r#"provider response: {"error":"insufficient_credits"}; later request returned 402 Payment Required"#,
+        r#"unexpected status 402 Payment Required: {"error":"payment_required"}; trailing {"error":"insufficient_credits"}"#,
+        r#"unexpected status 402 Payment Required: {invalid {"error":"insufficient_credits"}"#,
     ] {
         let reason = classify_cli_failure_reason(AgentFramework::Codex, message);
 

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -371,6 +371,31 @@ fn cli_failure_reason_classifies_claude_result_credit_affordability_diagnostic()
 }
 
 #[test]
+fn cli_failure_reason_classifies_deepseek_insufficient_credits_envelope() {
+    let message = r#"unexpected status 402 Payment Required: {"error": "insufficient_credits", "message": "Insufficient credits. Add credits or configure your own API key to continue.", "permission": "model-provider:deepseek", "base": "https://api.deepseek.com/responses"}, url: https://api.deepseek.com/responses"#;
+    let failure_message = selected_failure_message(message, FailureDetailSource::CodexJsonl, None);
+    let diagnostic = FailureDiagnostic::new(
+        FailureClass::CliNonzero,
+        AgentFramework::Codex,
+        PromptMetadata::from_prompt("plain prompt"),
+    )
+    .with_cli_exit_code(1)
+    .with_failure_detail_source(failure_message.source);
+    let diagnostic = with_cli_failure_reason(diagnostic, &failure_message);
+
+    assert_eq!(failure_message.message, message);
+    assert_eq!(diagnostic.failure_class, FailureClass::CliNonzero);
+    assert_eq!(
+        diagnostic.failure_reason,
+        Some(FailureReason::InsufficientCredits)
+    );
+    assert_eq!(
+        diagnostic.failure_detail_source,
+        Some(FailureDetailSource::CodexJsonl)
+    );
+}
+
+#[test]
 fn cli_failure_reason_ignores_generic_402_error() {
     let reason = classify_cli_failure_reason(
         AgentFramework::ClaudeCode,
@@ -378,6 +403,20 @@ fn cli_failure_reason_ignores_generic_402_error() {
     );
 
     assert_eq!(reason, None);
+}
+
+#[test]
+fn cli_failure_reason_ignores_unverified_insufficient_credits_envelopes() {
+    for message in [
+        r#"unexpected status 402 Payment Required: {"error":"payment_required","message":"insufficient_credits"}"#,
+        r#"unexpected status 402 Payment Required: {"debug":{"error":"insufficient_credits"}}"#,
+        r#"provider response: {"error":"insufficient_credits"}"#,
+        r#"provider response: {"error":"insufficient_credits"}; later request returned 402 Payment Required"#,
+    ] {
+        let reason = classify_cli_failure_reason(AgentFramework::Codex, message);
+
+        assert_eq!(reason, None, "message: {message}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- classify DeepSeek `402 Payment Required` response envelopes with top-level `error: "insufficient_credits"` as `InsufficientCredits`
- preserve the existing CLI failure class, detail source, and runner log-level policy
- require the matching JSON envelope to appear after the 402 status marker to avoid unrelated-token false positives

## Scope

This changes only guest-agent failure diagnostics and their tests. It does not change schemas, persisted data, API contracts, MITM responses, provider behavior, or runner policy.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo test --manifest-path crates/Cargo.toml -p runner expected_cli_failure_reasons_log_job_execution_failed_at_info`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- repository pre-commit hooks

Closes #25554
