### PR TITLE
feat: give cross-thread agent runs their source context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -7196,6 +7196,27 @@ describe("CHAT-02: shared user message queue", () => {
     await expect(
       readRunAutonomyBudgetFixture(context, firstTargetRunId),
     ).resolves.toBe(9);
+    const firstTargetRun = await api.readRun(actor, firstTargetRunId);
+    const firstTargetSystemPrompt = firstTargetRun.appendSystemPrompt ?? "";
+    expect(firstTargetSystemPrompt).toContain("# This Run's Trigger");
+    expect(firstTargetSystemPrompt).toContain(`SOURCE_RUN_ID: ${source.runId}`);
+    expect(firstTargetSystemPrompt).toContain(
+      `SOURCE_THREAD_ID: ${source.threadId}`,
+    );
+    expect(firstTargetSystemPrompt).toContain(`SOURCE_AGENT_ID: ${agentId}`);
+    expect(firstTargetSystemPrompt).toContain(
+      "SOURCE_THREAD_TITLE: New thread",
+    );
+    expect(firstTargetSystemPrompt).toContain(
+      `zero chat messages --thread-id ${source.threadId}`,
+    );
+    expect(firstTargetSystemPrompt).toContain(
+      `zero logs ${source.runId} --all`,
+    );
+    const sourceRun = await api.readRun(actor, source.runId);
+    expect(sourceRun.appendSystemPrompt ?? "").not.toContain(
+      "# This Run's Trigger",
+    );
     const firstMessages = await waitForThreadMessages(
       actor,
       firstTargetThread.id,
@@ -7512,6 +7533,11 @@ describe("CHAT-02: shared user message queue", () => {
     );
     expect(rotatedState.zero_run).toMatchObject({ triggerSource: "agent" });
     expect(rotatedSystemPrompt).toContain("# Web Chat Run Context");
+    expect(rotatedSystemPrompt).toContain("# This Run's Trigger");
+    expect(rotatedSystemPrompt).toContain(`SOURCE_RUN_ID: ${source.runId}`);
+    expect(rotatedSystemPrompt).toContain(
+      `SOURCE_THREAD_ID: ${source.threadId}`,
+    );
     expect(rotatedSystemPrompt).toContain(rotatedAnchorPrompt);
     expect(rotatedSystemPrompt).not.toContain("# Incomplete Rounds Context");
     expect(rotatedSystemPrompt).toContain("Web chat files: use");

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -132,9 +132,12 @@ import { insertChatEvent } from "./zero-chat-event.service";
 import { loadWebChatIncompleteContext } from "./zero-chat-incomplete-context.service";
 import { chatThreadAdmissionBlocked } from "./zero-chat-active-run.service";
 import {
+  agentRunSourceAnnotation,
+  type ChatAgentRunSourceAnnotation,
   projectUserMessage,
   requiredUserMessageForEvent,
 } from "./zero-chat-user-message.service";
+import { buildAgentRunSourceContext } from "./zero-web-chat-session-prompt.service";
 import { appendQueuedRunAssistantMarker } from "./zero-chat-queue-marker.service";
 import {
   integrationCompletionFallbackEventIdForRun,
@@ -2757,6 +2760,7 @@ interface QueuedLaunchLoaderArgs {
   readonly chatThreadId: string;
   readonly orgId: string;
   readonly userId: string;
+  readonly agentRunSource: ChatAgentRunSourceAnnotation | null;
   readonly userMessageProjection: ReturnType<typeof projectUserMessage>;
   readonly resolveSignedUrls: (keys: {
     readonly inputKey: string;
@@ -2778,7 +2782,12 @@ type LaunchLoader = (
 const loadWebQueuedLaunchMaterial: LaunchLoader = (_db, args) => {
   return Promise.resolve({
     prompt: args.userMessageProjection.agentPrompt,
-    appendSystemPrompt: buildWebChatPrompt(),
+    appendSystemPrompt: [
+      buildWebChatPrompt(),
+      ...(args.agentRunSource
+        ? [buildAgentRunSourceContext(args.agentRunSource)]
+        : []),
+    ].join("\n\n"),
     delivery: {},
   });
 };
@@ -2888,6 +2897,7 @@ async function resolveQueuedLaunchMaterial(
     orgId: args.agent.orgId,
     userId: args.userId,
     userMessageProjection: args.userMessageProjection,
+    agentRunSource: agentRunSourceAnnotation(args.queuedMessage.userMessage),
     resolveSignedUrls: (keys) => {
       return args.resolveMorningBriefSignedUrls(keys, args.signal);
     },

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -2885,6 +2885,7 @@ function buildCreateZeroRunArgs(params: {
     generationTemplatePrompt: prepared.generationTemplatePrompt,
     computerUseHostDisplayName:
       prepared.computerUseHostGrant?.displayName ?? null,
+    agentRunSource: prepared.agentRunSource,
   };
   return {
     auth: args.auth,

--- a/turbo/apps/api/src/signals/services/zero-chat-user-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-user-message.service.ts
@@ -44,12 +44,31 @@ function chatAgentRunSourceHref(
   return `/chats/${source.threadId}#run-${source.runId}`;
 }
 
+/**
+ * Recover the provenance a send route wrote into the persisted document. The
+ * annotation is the only place a claimed queue item still carries its source
+ * run, because the queue head is read back as a document, not as a send body.
+ */
+export function agentRunSourceAnnotation(
+  document: UserMessageDocument,
+): ChatAgentRunSourceAnnotation | null {
+  for (const part of document.parts) {
+    if (part.type === "source" && part.kind === "agent") {
+      return {
+        runId: part.runId,
+        threadId: part.threadId,
+        agentId: part.agentId,
+        titleSnapshot: part.titleSnapshot,
+      };
+    }
+  }
+  return null;
+}
+
 export function hasAgentRunSourceAnnotation(
   document: UserMessageDocument,
 ): boolean {
-  return document.parts.some((part) => {
-    return part.type === "source" && part.kind === "agent";
-  });
+  return agentRunSourceAnnotation(document) !== null;
 }
 
 /** Project the persisted document for clients that predate agent sources. */

--- a/turbo/apps/api/src/signals/services/zero-web-chat-session-prompt.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-web-chat-session-prompt.service.ts
@@ -26,6 +26,7 @@ import { loadWebChatIncompleteContext } from "./zero-chat-incomplete-context.ser
 import { visibleChatEventCondition } from "./zero-chat-event-shared.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import {
+  type ChatAgentRunSourceAnnotation,
   projectUserMessage,
   requiredUserMessageForEvent,
 } from "./zero-chat-user-message.service";
@@ -52,6 +53,7 @@ export interface WebChatSessionPromptContext {
   readonly inlineTemplatesEnabled: boolean;
   readonly generationTemplatePrompt: string;
   readonly computerUseHostDisplayName: string | null;
+  readonly agentRunSource: ChatAgentRunSourceAnnotation | null;
 }
 
 function buildWebChatPrompt(): string {
@@ -59,6 +61,40 @@ function buildWebChatPrompt(): string {
     "# Current Integration\nYou are currently running inside: Web",
     "You are communicating with the user through the web chat UI.",
   ].join("\n\n");
+}
+
+/**
+ * Provenance for a run whose prompt arrived from an agent run in another chat
+ * thread. The message text is all that crosses the thread boundary, so without
+ * this block the run cannot tell that a person did not write it, and has no
+ * identifier for the conversation it came from.
+ *
+ * These are facts about how the run was created, not instructions about what
+ * to do with them. What the run needs from the source thread depends on the
+ * message, so the commands are listed and the choice is left to the run.
+ */
+export function buildAgentRunSourceContext(
+  source: ChatAgentRunSourceAnnotation,
+): string {
+  return [
+    "# This Run's Trigger",
+    "",
+    "The message this run was created for was sent by an agent run in another chat thread. A person did not type it here.",
+    "",
+    `- SOURCE_RUN_ID: ${source.runId}`,
+    `- SOURCE_THREAD_ID: ${source.threadId}`,
+    `- SOURCE_AGENT_ID: ${source.agentId}`,
+    `- SOURCE_THREAD_TITLE: ${source.titleSnapshot}`,
+    "",
+    "The message text is everything that run chose to carry across the thread boundary. Its own instructions, the conversation it came from, and whatever it already found stayed in the source thread and are not included above.",
+    "",
+    "Reading the source, each through ZERO_TOKEN:",
+    `- \`zero chat messages --thread-id ${source.threadId}\` prints the source thread's user and assistant messages (chat-event:read)`,
+    `- \`zero chat get --thread-id ${source.threadId}\` prints its title, agent, and model (chat-thread:read)`,
+    `- \`zero logs ${source.runId} --all\` prints the full event stream of the run that sent this message (agent-run:read)`,
+    "",
+    `This run's output is appended to this thread, where the user reads it. Nothing carries it back to the source run. \`zero chat send --thread-id ${source.threadId}\` posts a new message into the source thread, which starts a run there.`,
+  ].join("\n");
 }
 
 function buildComputerUseSystemPrompt(displayName: string): string {
@@ -77,6 +113,9 @@ export function buildWebChatAppendSystemPrompt(args: {
 }): string {
   return [
     buildWebChatPrompt(),
+    args.context.agentRunSource
+      ? buildAgentRunSourceContext(args.context.agentRunSource)
+      : "",
     args.priorContext,
     args.incompleteContext,
     args.context.generationTemplatePrompt,

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/get.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/get.test.ts
@@ -16,7 +16,9 @@ import { zeroChatCommand } from "../index";
 
 const THREAD_ID = "00000000-0000-4000-8000-000000000001";
 const AGENT_ID = "00000000-0000-4000-8000-000000000010";
+const OTHER_THREAD_ID = "00000000-0000-4000-8000-000000000002";
 const GET_URL = `http://localhost:3000/api/zero/chat-threads/${THREAD_ID}/metadata`;
+const OTHER_GET_URL = `http://localhost:3000/api/zero/chat-threads/${OTHER_THREAD_ID}/metadata`;
 
 describe("zero chat get command", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -109,7 +111,33 @@ describe("zero chat get command", () => {
     expect(output).toContain("Model:  (default)");
   });
 
-  it("requires ZERO_CHAT_THREAD_ID from the current web chat", async () => {
+  it("loads another chat thread passed with --thread-id", async () => {
+    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+    server.use(
+      http.get(OTHER_GET_URL, () => {
+        return HttpResponse.json({
+          id: OTHER_THREAD_ID,
+          agentId: AGENT_ID,
+          title: "Delegation source",
+          selectedModel: "claude-sonnet-5",
+        });
+      }),
+    );
+
+    await zeroChatCommand.parseAsync([
+      "node",
+      "cli",
+      "get",
+      "--thread-id",
+      OTHER_THREAD_ID,
+    ]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain(`Thread: ${OTHER_THREAD_ID}`);
+    expect(output).toContain("Title:  Delegation source");
+  });
+
+  it("requires a thread ID from the flag or the current web chat", async () => {
     vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
 
     await expect(async () => {
@@ -118,7 +146,7 @@ describe("zero chat get command", () => {
 
     const stderr = mockConsoleError.mock.calls.flat().join("\n");
     expect(stderr).toContain("ZERO_CHAT_THREAD_ID is not set");
-    expect(stderr).toContain("Run this command from a Zero web chat thread.");
+    expect(stderr).toContain("Pass --thread-id <thread-id>");
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/messages.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/messages.test.ts
@@ -121,6 +121,33 @@ function errorEvent(args: { id: string; seqId: number; error: string }) {
   };
 }
 
+function runFailedEvent(args: { id: string; seqId: number; error: string }) {
+  return {
+    id: args.id,
+    threadId: THREAD_ID,
+    eventType: "run.failed" as const,
+    content: args.error,
+    error: args.error,
+    runLifecycleEvent: "failed" as const,
+    runId: RUN_ID,
+    seqId: args.seqId,
+    createdAt: "2026-07-29T08:03:00.000Z",
+  };
+}
+
+function runCancelledEvent(args: { id: string; seqId: number }) {
+  return {
+    id: args.id,
+    threadId: THREAD_ID,
+    eventType: "run.cancelled" as const,
+    content: null,
+    runLifecycleEvent: "cancelled" as const,
+    runId: RUN_ID,
+    seqId: args.seqId,
+    createdAt: "2026-07-29T08:04:00.000Z",
+  };
+}
+
 describe("zero chat messages command", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
   const mockConsoleError = vi
@@ -318,6 +345,54 @@ describe("zero chat messages command", () => {
     expect(output).toContain("[Automation: Gmail label applied]");
     expect(output).toContain("[Goal: Merge PR #1]");
     expect(output).toContain("Session history file not found");
+  });
+
+  it("prints the terminal error of a run that failed without answering", async () => {
+    server.use(
+      http.get(EVENTS_URL, () => {
+        return HttpResponse.json({
+          events: [
+            promptEvent({
+              id: "00000000-0000-4000-8000-000000000025",
+              seqId: 1,
+              text: "delegated prompt",
+              createdAt: "2026-07-29T08:02:30.000Z",
+            }),
+            runFailedEvent({
+              id: "00000000-0000-4000-8000-000000000026",
+              seqId: 2,
+              error: "Agent exited before answering",
+            }),
+          ],
+        });
+      }),
+    );
+
+    await zeroChatCommand.parseAsync(["node", "cli", "messages"]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).not.toContain("No chat messages found");
+    expect(output).toContain("Agent exited before answering");
+  });
+
+  it("skips a terminal run event that carries no error", async () => {
+    server.use(
+      http.get(EVENTS_URL, () => {
+        return HttpResponse.json({
+          events: [
+            runCancelledEvent({
+              id: "00000000-0000-4000-8000-000000000027",
+              seqId: 1,
+            }),
+          ],
+        });
+      }),
+    );
+
+    await zeroChatCommand.parseAsync(["node", "cli", "messages"]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("No chat messages found");
   });
 
   it("renders attachments and mentions instead of reporting empty text", async () => {

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/messages.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/messages.test.ts
@@ -395,6 +395,55 @@ describe("zero chat messages command", () => {
     expect(output).toContain("No chat messages found");
   });
 
+  it("renders a claimed message once instead of alongside the row it revoked", async () => {
+    const pendingId = "00000000-0000-4000-8000-000000000028";
+    server.use(
+      http.get(EVENTS_URL, () => {
+        return HttpResponse.json({
+          events: [
+            promptEvent({
+              id: pendingId,
+              seqId: 1,
+              text: "delegate work to other chat threads",
+              createdAt: "2026-07-29T10:00:00.000Z",
+            }),
+            {
+              ...promptEvent({
+                id: "00000000-0000-4000-8000-000000000029",
+                seqId: 2,
+                text: "delegate work to other chat threads",
+                createdAt: "2026-07-29T10:00:01.000Z",
+              }),
+              revokesEventId: pendingId,
+            },
+            assistantEvent({
+              id: "00000000-0000-4000-8000-00000000002a",
+              seqId: 3,
+              text: "on it",
+              createdAt: "2026-07-29T10:00:02.000Z",
+            }),
+          ],
+        });
+      }),
+    );
+
+    await zeroChatCommand.parseAsync(["node", "cli", "messages", "--json"]);
+
+    const payload = JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0])) as {
+      total: number;
+      messages: readonly { eventId: string; text: string }[];
+    };
+    expect(payload.total).toBe(2);
+    expect(
+      payload.messages.map((message) => {
+        return message.eventId;
+      }),
+    ).toStrictEqual([
+      "00000000-0000-4000-8000-000000000029",
+      "00000000-0000-4000-8000-00000000002a",
+    ]);
+  });
+
   it("renders attachments and mentions instead of reporting empty text", async () => {
     server.use(
       http.get(EVENTS_URL, () => {

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/messages.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/messages.test.ts
@@ -71,6 +71,56 @@ function thinkingEvent(args: { id: string; seqId: number }) {
   };
 }
 
+function automationEvent(args: { id: string; seqId: number; brief: string }) {
+  return {
+    id: args.id,
+    threadId: THREAD_ID,
+    eventType: "input.automation" as const,
+    content: null,
+    userMessage: {
+      version: 1 as const,
+      parts: [
+        {
+          type: "automation" as const,
+          workflowName: "daily-digest",
+          automationBrief: args.brief,
+        },
+      ],
+    },
+    runId: RUN_ID,
+    seqId: args.seqId,
+    createdAt: "2026-07-29T08:00:00.000Z",
+  };
+}
+
+function goalEvent(args: { id: string; seqId: number; brief: string }) {
+  return {
+    id: args.id,
+    threadId: THREAD_ID,
+    eventType: "input.goal" as const,
+    content: null,
+    userMessage: {
+      version: 1 as const,
+      parts: [{ type: "goal" as const, goalBrief: args.brief }],
+    },
+    seqId: args.seqId,
+    createdAt: "2026-07-29T08:01:00.000Z",
+  };
+}
+
+function errorEvent(args: { id: string; seqId: number; error: string }) {
+  return {
+    id: args.id,
+    threadId: THREAD_ID,
+    eventType: "output.error" as const,
+    content: null,
+    error: args.error,
+    runId: RUN_ID,
+    seqId: args.seqId,
+    createdAt: "2026-07-29T08:02:00.000Z",
+  };
+}
+
 describe("zero chat messages command", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
   const mockConsoleError = vi
@@ -234,6 +284,85 @@ describe("zero chat messages command", () => {
     expect(output.indexOf("oldest question")).toBeLessThan(
       output.indexOf("newest answer"),
     );
+  });
+
+  it("prints automation triggers, goal turns, and run errors", async () => {
+    server.use(
+      http.get(EVENTS_URL, () => {
+        return HttpResponse.json({
+          events: [
+            automationEvent({
+              id: "00000000-0000-4000-8000-000000000021",
+              seqId: 1,
+              brief: "Gmail label applied",
+            }),
+            goalEvent({
+              id: "00000000-0000-4000-8000-000000000022",
+              seqId: 2,
+              brief: "Merge PR #1",
+            }),
+            errorEvent({
+              id: "00000000-0000-4000-8000-000000000023",
+              seqId: 3,
+              error: "Session history file not found",
+            }),
+          ],
+        });
+      }),
+    );
+
+    await zeroChatCommand.parseAsync(["node", "cli", "messages"]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).not.toContain("No chat messages found");
+    expect(output).toContain("[Automation: Gmail label applied]");
+    expect(output).toContain("[Goal: Merge PR #1]");
+    expect(output).toContain("Session history file not found");
+  });
+
+  it("renders attachments and mentions instead of reporting empty text", async () => {
+    server.use(
+      http.get(EVENTS_URL, () => {
+        return HttpResponse.json({
+          events: [
+            {
+              id: "00000000-0000-4000-8000-000000000024",
+              threadId: THREAD_ID,
+              eventType: "input.prompt",
+              content: null,
+              userMessage: {
+                version: 1,
+                parts: [
+                  { type: "text", text: "ask " },
+                  {
+                    type: "agent",
+                    agentId: "00000000-0000-4000-8000-000000000030",
+                    nameSnapshot: "Iris",
+                  },
+                  { type: "text", text: " about this" },
+                  {
+                    type: "file",
+                    fileId: "file-1",
+                    filenameSnapshot: "report.pdf",
+                    contentType: "application/pdf",
+                  },
+                ],
+              },
+              runId: RUN_ID,
+              seqId: 1,
+              createdAt: "2026-07-29T10:00:00.000Z",
+            },
+          ],
+        });
+      }),
+    );
+
+    await zeroChatCommand.parseAsync(["node", "cli", "messages"]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("ask [Agent: Iris] about this");
+    expect(output).toContain("[File: report.pdf]");
+    expect(output).not.toContain("(no message text)");
   });
 
   it("guides to send when the thread has no messages", async () => {

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/messages.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/messages.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for zero chat messages command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): backend chat event route via MSW
+ * - Real (internal): CLI argument parsing, pagination, API client, env handling
+ */
+
+import chalk from "chalk";
+import { HttpResponse, http } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { server } from "../../../../mocks/server";
+import { zeroChatCommand } from "../index";
+
+const THREAD_ID = "00000000-0000-4000-8000-000000000001";
+const SOURCE_THREAD_ID = "00000000-0000-4000-8000-000000000002";
+const RUN_ID = "00000000-0000-4000-8000-000000000020";
+const EVENTS_URL = `http://localhost:3000/api/zero/chat-threads/${THREAD_ID}/events`;
+const SOURCE_EVENTS_URL = `http://localhost:3000/api/zero/chat-threads/${SOURCE_THREAD_ID}/events`;
+
+function promptEvent(args: {
+  id: string;
+  seqId: number;
+  text: string;
+  createdAt: string;
+}) {
+  return {
+    id: args.id,
+    threadId: THREAD_ID,
+    eventType: "input.prompt" as const,
+    content: null,
+    userMessage: {
+      version: 1 as const,
+      parts: [{ type: "text" as const, text: args.text }],
+    },
+    runId: RUN_ID,
+    seqId: args.seqId,
+    createdAt: args.createdAt,
+  };
+}
+
+function assistantEvent(args: {
+  id: string;
+  seqId: number;
+  text: string;
+  createdAt: string;
+}) {
+  return {
+    id: args.id,
+    threadId: THREAD_ID,
+    eventType: "output.message" as const,
+    content: args.text,
+    runId: RUN_ID,
+    seqId: args.seqId,
+    createdAt: args.createdAt,
+  };
+}
+
+function thinkingEvent(args: { id: string; seqId: number }) {
+  return {
+    id: args.id,
+    threadId: THREAD_ID,
+    eventType: "output.thinking" as const,
+    content: null,
+    thinking: "internal reasoning",
+    runId: RUN_ID,
+    seqId: args.seqId,
+    createdAt: "2026-07-29T10:00:30.000Z",
+  };
+}
+
+describe("zero chat messages command", () => {
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("ZERO_CHAT_THREAD_ID", THREAD_ID);
+  });
+
+  afterEach(() => {
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    mockExit.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  it("prints user and assistant messages oldest first and drops other events", async () => {
+    server.use(
+      http.get(EVENTS_URL, ({ request }) => {
+        expect(request.headers.get("authorization")).toBe(
+          "Bearer test-zero-token",
+        );
+        return HttpResponse.json({
+          events: [
+            promptEvent({
+              id: "00000000-0000-4000-8000-000000000011",
+              seqId: 1,
+              text: "first delegated prompt",
+              createdAt: "2026-07-29T10:00:00.000Z",
+            }),
+            thinkingEvent({
+              id: "00000000-0000-4000-8000-000000000012",
+              seqId: 2,
+            }),
+            assistantEvent({
+              id: "00000000-0000-4000-8000-000000000013",
+              seqId: 3,
+              text: "done, here is the summary",
+              createdAt: "2026-07-29T10:01:00.000Z",
+            }),
+          ],
+        });
+      }),
+    );
+
+    await zeroChatCommand.parseAsync(["node", "cli", "messages"]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("User");
+    expect(output).toContain("first delegated prompt");
+    expect(output).toContain("Assistant");
+    expect(output).toContain("done, here is the summary");
+    expect(output).not.toContain("internal reasoning");
+    expect(output.indexOf("first delegated prompt")).toBeLessThan(
+      output.indexOf("done, here is the summary"),
+    );
+  });
+
+  it("reads a source thread passed with --thread-id and prints JSON", async () => {
+    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+    server.use(
+      http.get(SOURCE_EVENTS_URL, () => {
+        return HttpResponse.json({
+          events: [
+            promptEvent({
+              id: "00000000-0000-4000-8000-000000000014",
+              seqId: 1,
+              text: "delegate work to other chat threads",
+              createdAt: "2026-07-29T09:00:00.000Z",
+            }),
+          ],
+        });
+      }),
+    );
+
+    await zeroChatCommand.parseAsync([
+      "node",
+      "cli",
+      "messages",
+      "--thread-id",
+      SOURCE_THREAD_ID,
+      "--json",
+    ]);
+
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toStrictEqual(
+      {
+        threadId: SOURCE_THREAD_ID,
+        total: 1,
+        messages: [
+          {
+            eventId: "00000000-0000-4000-8000-000000000014",
+            role: "user",
+            createdAt: "2026-07-29T09:00:00.000Z",
+            runId: RUN_ID,
+            text: "delegate work to other chat threads",
+          },
+        ],
+      },
+    );
+  });
+
+  it("pages backwards until the limit is filled", async () => {
+    const cursors: Array<string | null> = [];
+    server.use(
+      http.get(EVENTS_URL, ({ request }) => {
+        const url = new URL(request.url);
+        const beforeSeqId = url.searchParams.get("beforeSeqId");
+        cursors.push(beforeSeqId);
+        expect(url.searchParams.get("limit")).toBe("50");
+
+        if (beforeSeqId === null) {
+          return HttpResponse.json({
+            events: [
+              thinkingEvent({
+                id: "00000000-0000-4000-8000-000000000015",
+                seqId: 3,
+              }),
+              assistantEvent({
+                id: "00000000-0000-4000-8000-000000000016",
+                seqId: 4,
+                text: "newest answer",
+                createdAt: "2026-07-29T10:02:00.000Z",
+              }),
+            ],
+          });
+        }
+        return HttpResponse.json({
+          events: [
+            promptEvent({
+              id: "00000000-0000-4000-8000-000000000017",
+              seqId: 1,
+              text: "oldest question",
+              createdAt: "2026-07-29T09:59:00.000Z",
+            }),
+            thinkingEvent({
+              id: "00000000-0000-4000-8000-000000000018",
+              seqId: 2,
+            }),
+          ],
+        });
+      }),
+    );
+
+    await zeroChatCommand.parseAsync([
+      "node",
+      "cli",
+      "messages",
+      "--limit",
+      "2",
+    ]);
+
+    expect(cursors).toStrictEqual([null, "3"]);
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output.indexOf("oldest question")).toBeLessThan(
+      output.indexOf("newest answer"),
+    );
+  });
+
+  it("guides to send when the thread has no messages", async () => {
+    server.use(
+      http.get(EVENTS_URL, () => {
+        return HttpResponse.json({ events: [] });
+      }),
+    );
+
+    await zeroChatCommand.parseAsync(["node", "cli", "messages"]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("No chat messages found");
+    expect(output).toContain(`zero chat send --thread-id ${THREAD_ID}`);
+  });
+
+  it("requires a thread ID from the flag or the current web chat", async () => {
+    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+
+    await expect(async () => {
+      await zeroChatCommand.parseAsync(["node", "cli", "messages"]);
+    }).rejects.toThrow("process.exit called");
+
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain("ZERO_CHAT_THREAD_ID is not set");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/chat/get.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/get.ts
@@ -3,45 +3,37 @@ import { Command } from "commander";
 
 import { getZeroChatThread } from "../../../lib/api/domains/zero-chat";
 import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { resolveChatThreadId } from "./shared";
 
 interface GetOptions {
+  readonly threadId?: string;
   readonly json?: boolean;
-}
-
-function getCurrentChatThreadId(): string | undefined {
-  return process.env.ZERO_CHAT_THREAD_ID?.trim() || undefined;
-}
-
-function printUsageError(message: string, hint: string): never {
-  console.error(chalk.red(`✗ ${message}`));
-  console.error(chalk.dim(`  ${hint}`));
-  process.exit(1);
 }
 
 export const getCommand = new Command()
   .name("get")
-  .description("Show the current web chat thread")
+  .description("Show a web chat thread")
+  .option(
+    "--thread-id <id>",
+    "Chat thread ID (defaults to ZERO_CHAT_THREAD_ID)",
+  )
   .option("--json", "Print machine-readable JSON")
   .addHelpText(
     "after",
     `
 Examples:
   Show this chat:    zero chat get
+  Show another chat: zero chat get --thread-id <thread-id>
   Print JSON:        zero chat get --json
 
 Notes:
-  - Uses ZERO_CHAT_THREAD_ID from the current web chat thread
+  - Defaults --thread-id to ZERO_CHAT_THREAD_ID from the current web chat thread
+  - Prints thread metadata; zero chat messages prints the messages
   - Authenticates via ZERO_TOKEN (requires chat-thread:read capability)`,
   )
   .action(
     withErrorHandler(async (options: GetOptions) => {
-      const threadId = getCurrentChatThreadId();
-      if (!threadId) {
-        printUsageError(
-          "ZERO_CHAT_THREAD_ID is not set",
-          "Run this command from a Zero web chat thread.",
-        );
-      }
+      const threadId = resolveChatThreadId(options.threadId);
 
       const thread = await getZeroChatThread({ threadId });
       if (options.json) {

--- a/turbo/apps/cli/src/commands/zero/chat/index.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/index.ts
@@ -4,6 +4,7 @@ import { cancelCommand } from "./cancel";
 import { createCommand } from "./create";
 import { getCommand } from "./get";
 import { listCommand } from "./list";
+import { messagesCommand } from "./messages";
 import { modelCommand } from "./model";
 import { queuedCommand } from "./queued";
 import { renameCommand } from "./rename";
@@ -17,6 +18,7 @@ export const zeroChatCommand = new Command()
   .addCommand(queuedCommand)
   .addCommand(cancelCommand)
   .addCommand(getCommand)
+  .addCommand(messagesCommand)
   .addCommand(listCommand)
   .addCommand(modelCommand)
   .addCommand(renameCommand)
@@ -30,6 +32,8 @@ Examples:
   Cancel a run:      zero chat cancel --thread-id <thread-id> --run-id <run-id>
   List agent chats:  zero chat list
   Show this chat:    zero chat get
+  Show another:      zero chat get --thread-id <thread-id>
+  Read messages:     zero chat messages --thread-id <thread-id>
   Switch model:      zero chat model claude-sonnet-5
   Switch another:    zero chat model --thread <thread-id> claude-sonnet-5
   Rename this chat:  zero chat rename "Launch plan"

--- a/turbo/apps/cli/src/commands/zero/chat/messages.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/messages.ts
@@ -1,0 +1,162 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import type {
+  ChatEvent,
+  UserMessageDocument,
+} from "@vm0/api-contracts/contracts/chat-threads";
+
+import { listZeroChatEvents } from "../../../lib/api/domains/zero-chat";
+import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { formatIsoTimestamp } from "../../../lib/utils/time-format";
+import { parseBoundedLogCount } from "../../../lib/utils/log-pagination";
+import { resolveChatThreadId } from "./shared";
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+const PAGE_LIMIT = 50;
+
+/** Per-thread chat event sequences start at 1, so this marks the oldest event. */
+const FIRST_CHAT_EVENT_SEQ_ID = 1;
+
+interface MessagesOptions {
+  readonly threadId?: string;
+  readonly limit?: string;
+  readonly json?: boolean;
+}
+
+interface ChatMessage {
+  readonly eventId: string;
+  readonly role: "user" | "assistant";
+  readonly createdAt: string;
+  readonly runId: string | null;
+  readonly text: string;
+}
+
+function userMessageText(document: UserMessageDocument): string {
+  return document.parts
+    .map((part) => {
+      return part.type === "text" ? part.text : "";
+    })
+    .join("")
+    .trim();
+}
+
+function toChatMessage(event: ChatEvent): ChatMessage | null {
+  if (event.eventType === "input.prompt") {
+    return {
+      eventId: event.id,
+      role: "user",
+      createdAt: event.createdAt,
+      runId: event.runId ?? null,
+      text: userMessageText(event.userMessage),
+    };
+  }
+  if (event.eventType === "output.message") {
+    return {
+      eventId: event.id,
+      role: "assistant",
+      createdAt: event.createdAt,
+      runId: event.runId ?? null,
+      text: event.content.trim(),
+    };
+  }
+  return null;
+}
+
+/**
+ * A page holds every event type, so a page of 50 can carry a single message.
+ * Walk backwards until the requested message count is filled or the thread's
+ * first event is reached.
+ */
+async function loadRecentMessages(
+  threadId: string,
+  limit: number,
+): Promise<ChatMessage[]> {
+  const messages: ChatMessage[] = [];
+  let beforeSeqId: number | undefined;
+
+  for (;;) {
+    const events = await listZeroChatEvents({
+      threadId,
+      beforeSeqId,
+      limit: PAGE_LIMIT,
+    });
+    const page = events.flatMap((event) => {
+      const message = toChatMessage(event);
+      return message ? [message] : [];
+    });
+    messages.unshift(...page);
+
+    const oldestInPage = events[0];
+    if (
+      messages.length >= limit ||
+      oldestInPage === undefined ||
+      oldestInPage.seqId <= FIRST_CHAT_EVENT_SEQ_ID
+    ) {
+      return messages.slice(-limit);
+    }
+    beforeSeqId = oldestInPage.seqId;
+  }
+}
+
+export const messagesCommand = new Command()
+  .name("messages")
+  .description("Read the messages in a web chat thread")
+  .option(
+    "--thread-id <id>",
+    "Chat thread ID (defaults to ZERO_CHAT_THREAD_ID)",
+  )
+  .option(
+    "--limit <n>",
+    `Maximum number of messages to print (default: ${DEFAULT_LIMIT}, max: ${MAX_LIMIT})`,
+  )
+  .option("--json", "Print machine-readable JSON")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Read this chat:     zero chat messages
+  Read another chat:  zero chat messages --thread-id <thread-id>
+  Read the last 5:    zero chat messages --limit 5
+  Print JSON:         zero chat messages --thread-id <thread-id> --json
+
+Notes:
+  - Prints user and assistant messages oldest first, the order the chat UI shows
+  - Reads a thread the current user owns, including one another agent run wrote into
+  - Authenticates via ZERO_TOKEN (requires chat-event:read capability)`,
+  )
+  .action(
+    withErrorHandler(async (options: MessagesOptions) => {
+      const threadId = resolveChatThreadId(options.threadId);
+      const limit =
+        options.limit === undefined
+          ? DEFAULT_LIMIT
+          : parseBoundedLogCount(options.limit, "--limit", 1, MAX_LIMIT);
+      const messages = await loadRecentMessages(threadId, limit);
+
+      if (options.json) {
+        console.log(
+          JSON.stringify({ threadId, total: messages.length, messages }),
+        );
+        return;
+      }
+
+      if (messages.length === 0) {
+        console.log(chalk.dim("No chat messages found"));
+        console.log(
+          chalk.dim(`  Send one: zero chat send --thread-id ${threadId}`),
+        );
+        return;
+      }
+
+      for (const message of messages) {
+        console.log(
+          `${chalk.dim(formatIsoTimestamp(message.createdAt))} ${chalk.bold(
+            message.role === "user" ? "User" : "Assistant",
+          )}`,
+        );
+        console.log(message.text || chalk.dim("(no message text)"));
+        console.log();
+      }
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/chat/messages.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/messages.ts
@@ -114,8 +114,9 @@ function userMessageText(document: UserMessageDocument): string {
 
 /**
  * Every user-role and assistant-role event that carries message text, matching
- * the roles the chat UI renders. Thinking, followups, run lifecycle, control,
- * browser, and usage events are not messages.
+ * what the chat UI renders. Thinking, followups, control, browser, and usage
+ * events are not messages, and neither are run lifecycle events except the
+ * terminal ones, which carry the failure text the user reads.
  */
 function toChatMessage(event: ChatEvent): ChatMessage | null {
   if (
@@ -158,6 +159,20 @@ function toChatMessage(event: ChatEvent): ChatMessage | null {
       runId: event.runId ?? null,
       text: event.error.trim(),
     };
+  }
+  // A terminal run event carries the failure the user sees only when it has an
+  // error. Without one it is a lifecycle marker, like queued and dequeued.
+  if (event.eventType === "run.failed" || event.eventType === "run.cancelled") {
+    const error = event.error?.trim();
+    return error
+      ? {
+          eventId: event.id,
+          role: "assistant",
+          createdAt: event.createdAt,
+          runId: event.runId,
+          text: error,
+        }
+      : null;
   }
   return null;
 }

--- a/turbo/apps/cli/src/commands/zero/chat/messages.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/messages.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import { Command } from "commander";
+import { revokedChatEventIds } from "@vm0/api-contracts/contracts/chat-events";
 import type {
   ChatEvent,
   UserMessageDocument,
@@ -178,30 +179,45 @@ function toChatMessage(event: ChatEvent): ChatMessage | null {
 }
 
 /**
+ * The thread event stream keeps a revoked event alongside the event that
+ * replaced it, so claiming a queued message leaves two rows carrying the same
+ * text. Reading the stream without folding revocations reports a conversation
+ * that never happened.
+ */
+function foldMessages(events: readonly ChatEvent[]): ChatMessage[] {
+  const revoked = revokedChatEventIds(events);
+  return events.flatMap((event) => {
+    if (revoked.has(event.id)) {
+      return [];
+    }
+    const message = toChatMessage(event);
+    return message ? [message] : [];
+  });
+}
+
+/**
  * A page holds every event type, so a page of 50 can carry a single message.
  * Walk backwards until the requested message count is filled or the thread's
- * first event is reached.
+ * first event is reached. A revoking event is always newer than its target, so
+ * paging from the newest end always holds the revoker once it holds the target.
  */
 async function loadRecentMessages(
   threadId: string,
   limit: number,
 ): Promise<ChatMessage[]> {
-  const messages: ChatMessage[] = [];
+  const events: ChatEvent[] = [];
   let beforeSeqId: number | undefined;
 
   for (;;) {
-    const events = await listZeroChatEvents({
+    const page = await listZeroChatEvents({
       threadId,
       beforeSeqId,
       limit: PAGE_LIMIT,
     });
-    const page = events.flatMap((event) => {
-      const message = toChatMessage(event);
-      return message ? [message] : [];
-    });
-    messages.unshift(...page);
+    events.unshift(...page);
+    const messages = foldMessages(events);
 
-    const oldestInPage = events[0];
+    const oldestInPage = page[0];
     if (
       messages.length >= limit ||
       oldestInPage === undefined ||

--- a/turbo/apps/cli/src/commands/zero/chat/messages.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/messages.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import type {
   ChatEvent,
   UserMessageDocument,
+  UserMessagePart,
 } from "@vm0/api-contracts/contracts/chat-threads";
 
 import { listZeroChatEvents } from "../../../lib/api/domains/zero-chat";
@@ -32,23 +33,112 @@ interface ChatMessage {
   readonly text: string;
 }
 
-function userMessageText(document: UserMessageDocument): string {
-  return document.parts
-    .map((part) => {
-      return part.type === "text" ? part.text : "";
-    })
-    .join("")
-    .trim();
+/**
+ * Parts that read as one sentence with their neighbours, so they concatenate
+ * without a separator the way the chat UI renders them inline.
+ */
+function inlinePartText(part: UserMessagePart): string | null {
+  if (part.type === "text") {
+    return part.text;
+  }
+  if (part.type === "chat_thread") {
+    return `[Chat thread: ${part.titleSnapshot}]`;
+  }
+  if (part.type === "agent") {
+    return `[Agent: ${part.nameSnapshot}]`;
+  }
+  return null;
 }
 
+/**
+ * Parts that stand on their own line. `source` and `model` are provenance and
+ * routing metadata rather than message content, so they render as nothing.
+ */
+function blockPartText(part: UserMessagePart): string | null {
+  if (part.type === "file") {
+    return `[File: ${part.filenameSnapshot}]`;
+  }
+  if (part.type === "template") {
+    return `[Template: ${part.titleSnapshot}]`;
+  }
+  if (part.type === "automation") {
+    return `[Automation: ${part.automationBrief ?? part.workflowName}]`;
+  }
+  if (part.type === "goal") {
+    return `[Goal: ${part.goalBrief}]`;
+  }
+  if (part.type === "morning_brief") {
+    return `[Morning brief: ${part.briefDate}]`;
+  }
+  if (part.type === "feedback") {
+    const note = part.note
+      .map((notePart) => {
+        return inlinePartText(notePart) ?? blockPartText(notePart) ?? "";
+      })
+      .join("")
+      .trim();
+    return `[Feedback on "${part.quote}"] ${note}`.trim();
+  }
+  return null;
+}
+
+/**
+ * A message carries more than text: attachments, templates, automation and goal
+ * triggers, and quoted feedback all appear in the chat UI. Rendering only text
+ * parts would report a non-empty message as empty.
+ */
+function userMessageText(document: UserMessageDocument): string {
+  const blocks: string[] = [];
+  let inline = "";
+  const flushInline = () => {
+    if (inline.length > 0) {
+      blocks.push(inline);
+      inline = "";
+    }
+  };
+  for (const part of document.parts) {
+    const inlineText = inlinePartText(part);
+    if (inlineText !== null) {
+      inline += inlineText;
+      continue;
+    }
+    const blockText = blockPartText(part);
+    if (blockText !== null) {
+      flushInline();
+      blocks.push(blockText);
+    }
+  }
+  flushInline();
+  return blocks.join("\n").trim();
+}
+
+/**
+ * Every user-role and assistant-role event that carries message text, matching
+ * the roles the chat UI renders. Thinking, followups, run lifecycle, control,
+ * browser, and usage events are not messages.
+ */
 function toChatMessage(event: ChatEvent): ChatMessage | null {
-  if (event.eventType === "input.prompt") {
+  if (
+    event.eventType === "input.prompt" ||
+    event.eventType === "input.budget" ||
+    event.eventType === "input.rejected" ||
+    event.eventType === "input.goal"
+  ) {
     return {
       eventId: event.id,
       role: "user",
       createdAt: event.createdAt,
       runId: event.runId ?? null,
       text: userMessageText(event.userMessage),
+    };
+  }
+  if (event.eventType === "input.automation") {
+    return {
+      eventId: event.id,
+      role: "user",
+      createdAt: event.createdAt,
+      runId: event.runId ?? null,
+      text: event.userMessage ? userMessageText(event.userMessage) : "",
     };
   }
   if (event.eventType === "output.message") {
@@ -58,6 +148,15 @@ function toChatMessage(event: ChatEvent): ChatMessage | null {
       createdAt: event.createdAt,
       runId: event.runId ?? null,
       text: event.content.trim(),
+    };
+  }
+  if (event.eventType === "output.error") {
+    return {
+      eventId: event.id,
+      role: "assistant",
+      createdAt: event.createdAt,
+      runId: event.runId ?? null,
+      text: event.error.trim(),
     };
   }
   return null;


### PR DESCRIPTION
## Problem

When agent run A calls `zero chat send --thread-id B`, the run that starts in thread B receives only the message text.

The source run id is already persisted (`chat_events.context_type = 'agent_run'`, `context_id` = source run id, plus a `source` part in `user_message`), and the UI renders it as a link. But `projectUserMessage` deliberately skips `source` parts, so none of it reaches the model. The target run cannot tell that a person did not type the message, and has no identifier for the conversation it came from.

## Change

Append a `# This Run's Trigger` block to the web chat system prompt whenever the launching message carries agent-run provenance. Both launch paths are covered:

- direct send, via `WebChatSessionPromptContext.agentRunSource` (`zero-chat-events.command.ts`)
- queue drain, via the web/agent launch loader, reading the annotation back off the persisted document (`internal-chat-run-callback.service.ts`)

The block follows the "Context, not control" line: it states what happened and what can be read, and leaves the decision to the run.

```
# This Run's Trigger

The message this run was created for was sent by an agent run in another chat thread. A person did not type it here.

- SOURCE_RUN_ID: ...
- SOURCE_THREAD_ID: ...
- SOURCE_AGENT_ID: ...
- SOURCE_THREAD_TITLE: ...

The message text is everything that run chose to carry across the thread boundary. Its own
instructions, the conversation it came from, and whatever it already found stayed in the source
thread and are not included above.

Reading the source, each through ZERO_TOKEN:
- `zero chat messages --thread-id <id>` prints the source thread's user and assistant messages (chat-event:read)
- `zero chat get --thread-id <id>` prints its title, agent, and model (chat-thread:read)
- `zero logs <runId> --all` prints the full event stream of the run that sent this message (agent-run:read)

This run's output is appended to this thread, where the user reads it. Nothing carries it back to
the source run. `zero chat send --thread-id <id>` posts a new message into the source thread, which
starts a run there.
```

## CLI

Two of those three commands did not exist, so the block would have pointed at nothing:

- **`zero chat messages`** (new) prints a thread's user and assistant messages, oldest first, over the existing `chat-threads/:id/events` route, which already serves any thread the caller owns. Pages backwards until `--limit` messages are collected, since a page of events can hold a single message.
- **`zero chat get --thread-id`** now targets another thread instead of only `ZERO_CHAT_THREAD_ID`, matching every other `zero chat` subcommand.

No API contract, schema, or capability changes: both commands ride routes that already exist and already gate on `chat-event:read` / `chat-thread:read`.

## Tests

- `chat-events.bdd.test.ts` asserts the block on the immediate path and on the queue-drain path, and asserts a plain Web run does not get it
- `messages.test.ts` covers ordering, non-message events, `--thread-id`, `--json`, backwards paging, the empty thread, and the missing thread id
- `get.test.ts` covers `--thread-id`

## Compatibility

Prompt text only, no persisted-state or protocol change. Between the API deploy and the next CLI publish, `zero chat messages` will not exist in older sandboxes; `zero logs` and `zero chat get` already work, and `zero chat --help` shows what is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
